### PR TITLE
feat(data-export): Add synchronous in-browser download for small log exports

### DIFF
--- a/src/sentry/data_export/endpoints/data_export.py
+++ b/src/sentry/data_export/endpoints/data_export.py
@@ -21,7 +21,10 @@ from sentry.data_export.processors.explore import (
     SUPPORTED_TRACE_ITEM_DATASETS,
     ExploreProcessor,
 )
-from sentry.data_export.tasks import assemble_download
+from sentry.data_export.tasks import (
+    assemble_download,
+    export_data_to_stored_blobs_sync,
+)
 from sentry.data_export.writers import OutputMode
 from sentry.discover.arithmetic import categorize_columns
 from sentry.exceptions import InvalidParams, InvalidSearchQuery
@@ -47,6 +50,7 @@ SUPPORTED_DATASETS = {
 }
 
 logger = logging.getLogger(__name__)
+MAX_SYNC_LIMIT = 10_000
 
 
 class DataExportQuerySerializer(serializers.Serializer[dict[str, Any]]):
@@ -55,6 +59,7 @@ class DataExportQuerySerializer(serializers.Serializer[dict[str, Any]]):
     format = serializers.ChoiceField(
         choices=OutputMode.supported_values(), required=False, default=OutputMode.CSV.value
     )
+    limit = serializers.IntegerField(required=False, allow_null=True, min_value=1)
 
     def _validate_dataset(self, query_type: str, query_info: dict[str, Any]) -> dict[str, Any]:
         dataset = query_info.get("dataset")
@@ -271,17 +276,21 @@ class DataExportEndpoint(OrganizationEndpoint):
             project_id = query_info["project"]
         return project_id
 
-    def _parse_limit(self, request: Request) -> int | None:
-        limit = None
-        if request.data and hasattr(request.data, "get"):
-            limit = request.data.get("limit")
+    def _parse_limit(self, data: dict[str, Any]) -> tuple[int | None, bool]:
+        limit = data.get("limit")
 
         if limit is not None:
             try:
                 limit = int(limit)
             except (TypeError, ValueError):
                 limit = None
-        return limit
+        run_sync = (
+            limit is not None
+            and limit <= MAX_SYNC_LIMIT
+            and data["query_type"] == ExportQueryType.EXPLORE_STR
+            and data["query_info"].get("dataset") == "logs"
+        )
+        return limit, run_sync
 
     def post(self, request: Request, organization: Organization) -> Response:
         """
@@ -308,8 +317,6 @@ class DataExportEndpoint(OrganizationEndpoint):
         except Environment.DoesNotExist as error:
             return Response(error, status=400)
 
-        limit = self._parse_limit(request)
-
         # Validate the data export payload
         serializer = DataExportQuerySerializer(
             data=request.data,
@@ -327,6 +334,8 @@ class DataExportEndpoint(OrganizationEndpoint):
             return Response(serializer.errors, status=400)
         validated_data = serializer.validated_data
 
+        limit, run_sync = self._parse_limit(validated_data)
+
         try:
             # If this user has sent a request with the same payload and organization,
             # we return them the latest one that is NOT complete (i.e. don't start another)
@@ -341,12 +350,17 @@ class DataExportEndpoint(OrganizationEndpoint):
             )
             status = 200
             if created:
-                self._schedule_export_task(data_export, environment_id, limit, validated_data)
+                self._schedule_export_task(
+                    data_export, environment_id, limit, validated_data, run_sync=run_sync
+                )
                 status = 201
+            data_export.refresh_from_db()
             # This value can be used to find the schedule task in the GCP logs
             extra["data_export_id"] = data_export.id
             if status == 200:
                 extra["status"] = "done"
+            elif run_sync:
+                extra["status"] = "export_data_to_stored_blobs_sync"
             else:
                 extra["status"] = "assemble_download.task_scheduled"
         except ValidationError as e:
@@ -368,22 +382,29 @@ class DataExportEndpoint(OrganizationEndpoint):
         environment_id: int | None,
         limit: int | None,
         validated_data: dict[str, Any],
+        run_sync: bool = False,
     ) -> None:
         qi = validated_data["query_info"]
         export_format = validated_data["format"]
         dataset = qi.get("dataset")
-        metrics.incr(
-            "dataexport.enqueue",
-            tags={
-                "query_type": validated_data["query_type"],
-                "format": export_format,
-                "dataset": str(dataset) if dataset is not None else "none",
-            },
-            sample_rate=1.0,
-        )
-
-        assemble_download.delay(
-            data_export_id=data_export.id,
-            export_limit=limit,
-            environment_id=environment_id,
-        )
+        if run_sync:
+            export_data_to_stored_blobs_sync(
+                data_export=data_export,
+                export_limit=limit or MAX_SYNC_LIMIT,
+                environment_id=environment_id,
+            )
+        else:
+            metrics.incr(
+                "dataexport.enqueue",
+                tags={
+                    "query_type": validated_data["query_type"],
+                    "format": export_format,
+                    "dataset": str(dataset) if dataset is not None else "none",
+                },
+                sample_rate=1.0,
+            )
+            assemble_download.delay(
+                data_export_id=data_export.id,
+                export_limit=limit,
+                environment_id=environment_id,
+            )

--- a/src/sentry/data_export/models.py
+++ b/src/sentry/data_export/models.py
@@ -94,12 +94,15 @@ class ExportedData(Model):
         self.delete_file()
         return super().delete(*args, **kwargs)
 
-    def finalize_upload(self, file: File, expiration: timedelta = DEFAULT_EXPIRATION) -> None:
+    def finalize_upload(
+        self, file: File, expiration: timedelta = DEFAULT_EXPIRATION, email_notif: bool = True
+    ) -> None:
         self.delete_file()  # If a file is present, remove it
         current_time = timezone.now()
         expire_time = current_time + expiration
         self.update(file_id=file.id, date_finished=current_time, date_expired=expire_time)
-        transaction.on_commit(lambda: self.email_success(), router.db_for_write(ExportedData))
+        if email_notif:
+            transaction.on_commit(lambda: self.email_success(), router.db_for_write(ExportedData))
 
     def email_success(self) -> None:
         from sentry.utils.email import MessageBuilder

--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -56,6 +56,10 @@ class AssembleChunkResult(NamedTuple):
     bytes_written_after_chunk: int
 
 
+class ExportDataFileTooBig(Exception):
+    pass
+
+
 def _export_metric_tags(data_export: ExportedData) -> dict[str, str]:
     dataset = data_export.query_info.get("dataset", "None")
     return {
@@ -131,17 +135,17 @@ def _should_stop_fetching_more_fragments(
     return False
 
 
-def _write_exported_chunk_to_blob(
+def export_chunk_to_stored_blobs(
     *,
     data_export: ExportedData,
     export_limit: int,
-    batch_size: int,
-    offset: int,
-    bytes_written: int,
     environment_id: int | None,
-    page_token: str | None,
-    last_emitted_item_id_hex: str | None,
-    first_page: bool,
+    last_emitted_item_id_hex: str | None = None,
+    first_page: bool = True,
+    page_token: str | None = None,
+    offset: int = 0,
+    bytes_written: int = 0,
+    batch_size: int = SNUBA_MAX_RESULTS,
 ) -> AssembleChunkResult:
     """One activation: fill up to MAX_FRAGMENTS_PER_BATCH fragments and persist a blob chunk."""
     output_mode = OutputMode.from_value(data_export.export_format)
@@ -298,7 +302,6 @@ def assemble_download(
     *,
     page_token: str | None = None,
     last_emitted_item_id_hex: str | None = None,
-    run_sync: bool = False,
     **kwargs: Any,
 ) -> None:
     # The API response to export the data contains the ID which you can use
@@ -321,7 +324,7 @@ def assemble_download(
         export_limit = _normalize_export_limit(export_limit)
 
         try:
-            chunk = _write_exported_chunk_to_blob(
+            chunk = export_chunk_to_stored_blobs(
                 data_export=data_export,
                 export_limit=export_limit,
                 batch_size=batch_size,
@@ -383,6 +386,44 @@ def assemble_download(
                 environment_id=environment_id,
                 export_retries=export_retries,
             )
+
+
+def export_data_to_stored_blobs_sync(
+    data_export: ExportedData,
+    export_limit: int,
+    environment_id: int | None,
+) -> None:
+    extra: dict[str, Any] = {
+        "data_export_id": data_export.id,
+        "query": str(data_export.payload),
+        "organization_id": data_export.organization_id,
+        "download_type": "sync",
+    }
+    sentry_sdk.set_tag("download_type", "sync")
+    sentry_sdk.set_context("data_export", extra)
+
+    try:
+        export_chunk_to_stored_blobs(
+            data_export=data_export,
+            export_limit=export_limit,
+            environment_id=environment_id,
+        )
+        merge_export_blobs(data_export_id=data_export.id, email_notif=False)
+    except Exception as error:
+        metrics.incr(
+            "dataexport.error",
+            tags={
+                **_export_metric_tags(data_export),
+                "error": str(error),
+                "download_type": "sync",
+                "error_type": "ExportError"
+                if isinstance(error, ExportError)
+                else type(error).__name__,
+            },
+            sample_rate=1.0,
+        )
+        logger.exception("export_data_sync", extra=extra)
+        raise
 
 
 def get_processor(
@@ -480,10 +521,6 @@ def process_explore(
     return processor.run_query(offset, limit)
 
 
-class ExportDataFileTooBig(Exception):
-    pass
-
-
 def store_export_chunk_as_blob(
     data_export: ExportedData,
     bytes_written: int,
@@ -526,7 +563,7 @@ def store_export_chunk_as_blob(
     namespace=export_tasks,
     silo_mode=SiloMode.CELL,
 )
-def merge_export_blobs(data_export_id: int, **kwargs: Any) -> None:
+def merge_export_blobs(data_export_id: int, *, email_notif: bool = True, **kwargs: Any) -> None:
     extra: dict[str, Any] = {"data_export_id": data_export_id}
     with sentry_sdk.start_span(op="merge"):
         try:
@@ -585,7 +622,7 @@ def merge_export_blobs(data_export_id: int, **kwargs: Any) -> None:
                 # takes longer than the idle timeout, the connection to the primary
                 # database can timeout causing a failure.
                 with atomic_transaction(using=router.db_for_write(ExportedData)):
-                    data_export.finalize_upload(file=file)
+                    data_export.finalize_upload(file=file, email_notif=email_notif)
 
                 time_elapsed = (timezone.now() - data_export.date_added).total_seconds()
                 metrics.timing("dataexport.duration", time_elapsed, sample_rate=1.0)

--- a/tests/sentry/data_export/test_tasks.py
+++ b/tests/sentry/data_export/test_tasks.py
@@ -696,7 +696,6 @@ class AssembleDownloadLargeTest(TestCase, SnubaTestCase):
 
 
 class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogTestCase):
-    # Present on TraceItem / Snuba but not worth pinning (ids, times, nanosecond precision, sampling).
     def setUp(self) -> None:
         super().setUp()
         self.user = self.create_user()
@@ -806,6 +805,7 @@ class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogT
         start = before_now(minutes=15).isoformat()
         end = before_now(seconds=30).isoformat()
 
+        # Present on TraceItem / Snuba but not worth pinning (ids, times, nanosecond precision, sampling).
         variable_keys = frozenset(
             {
                 "timestamp_precise",

--- a/tests/sentry/data_export/test_tasks.py
+++ b/tests/sentry/data_export/test_tasks.py
@@ -1,7 +1,8 @@
-from typing import Any
+from typing import Any, Iterable, cast
 from unittest.mock import MagicMock, patch
 
 from django.db import IntegrityError
+from django.http import StreamingHttpResponse
 from django.urls import reverse
 
 from sentry.data_export.base import ExportQueryType
@@ -924,7 +925,8 @@ class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogT
         )
         dl_response = self.client.get(f"{details_url}?download=1")
         assert dl_response.status_code == 200
-        return b"".join(dl_response.streaming_content).strip()
+        stream = cast(StreamingHttpResponse, dl_response).streaming_content
+        return b"".join(cast(Iterable[bytes], stream)).strip()
 
     @patch("sentry.data_export.models.ExportedData.email_success")
     def test_explore_spans_dataset_called_correctly(self, emailer: MagicMock) -> None:

--- a/tests/sentry/data_export/test_tasks.py
+++ b/tests/sentry/data_export/test_tasks.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from django.db import IntegrityError
@@ -695,6 +696,7 @@ class AssembleDownloadLargeTest(TestCase, SnubaTestCase):
 
 
 class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogTestCase):
+    # Present on TraceItem / Snuba but not worth pinning (ids, times, nanosecond precision, sampling).
     def setUp(self) -> None:
         super().setUp()
         self.user = self.create_user()
@@ -703,6 +705,226 @@ class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogT
         self.team = self.create_team(organization=self.org)
         self.project = self.create_project(organization=self.org, teams=[self.team])
         self.create_member(user=self.user, organization=self.org, teams=[self.team])
+
+    def _store_explore_logs_jsonl_rich_field_fixture(
+        self,
+    ) -> tuple[str, str, dict[str, dict[str, object]], frozenset[str]]:
+        """
+        Two wide logs rows + Snuba ingest. Returns (start_iso, end_iso, expected_rows_by_user_agent, ignore_keys).
+        """
+        shared_attrs = {
+            "environment": "prod",
+            "origin": "auto.log.stdlib",
+            "sdk.name": "sentry.python.django",
+            "sdk.version": "2.47.0",
+            "tags[code.line.number,number]": 148,
+            "tags[process.pid,number]": 6639,
+        }
+        logs = [
+            self.create_ourlog(
+                {
+                    "body": "api.access.alpha",
+                    "severity_text": "info",
+                    "severity_number": 9,
+                },
+                timestamp=before_now(minutes=10),
+                organization=self.org,
+                project=self.project,
+                attributes={
+                    **shared_attrs,
+                    "method": "GET",
+                    "path": "/api/0/projects/acme/issues/",
+                    "user_agent": "python-requests/2.32.5",
+                    "logger.name": "sentry.access.api",
+                    "response": "200",
+                    "rate_limited": "False",
+                    "payload_size": 981,
+                },
+            ),
+            self.create_ourlog(
+                {
+                    "body": "api.access.beta",
+                    "severity_text": "info",
+                    "severity_number": 9,
+                },
+                timestamp=before_now(minutes=8),
+                organization=self.org,
+                project=self.project,
+                attributes={
+                    **shared_attrs,
+                    "method": "POST",
+                    "path": "/api/0/internal/rpc/",
+                    "user_agent": "curl/8.0",
+                    "logger.name": "sentry.access.api",
+                    "response": "201",
+                    "rate_limited": "False",
+                    "payload_size": 2048,
+                },
+            ),
+        ]
+        self.store_eap_items(logs)
+
+        expected_rows: list[dict[str, object]] = [
+            {
+                "sdk.name": "sentry.python.django",
+                "user_agent": "python-requests/2.32.5",
+                "method": "GET",
+                "path": "/api/0/projects/acme/issues/",
+                "sdk.version": "2.47.0",
+                "tags[code.line.number,number]": 148.0,
+                "logger.name": "sentry.access.api",
+                "origin": "auto.log.stdlib",
+                "sentry.body": "api.access.alpha",
+                "rate_limited": "False",
+                "sentry.severity_text": "info",
+                "environment": "prod",
+                "sentry.severity_number": 9.0,
+                "payload_size": 981.0,
+                "tags[process.pid,number]": 6639.0,
+                "response": "200",
+            },
+            {
+                "sdk.name": "sentry.python.django",
+                "user_agent": "curl/8.0",
+                "method": "POST",
+                "path": "/api/0/internal/rpc/",
+                "sdk.version": "2.47.0",
+                "tags[code.line.number,number]": 148.0,
+                "logger.name": "sentry.access.api",
+                "origin": "auto.log.stdlib",
+                "sentry.body": "api.access.beta",
+                "rate_limited": "False",
+                "sentry.severity_text": "info",
+                "environment": "prod",
+                "payload_size": 2048.0,
+                "tags[process.pid,number]": 6639.0,
+                "sentry.severity_number": 9.0,
+                "response": "201",
+            },
+        ]
+        expected_rows_by_agent = {str(row["user_agent"]): row for row in expected_rows}
+        start = before_now(minutes=15).isoformat()
+        end = before_now(seconds=30).isoformat()
+
+        variable_keys = frozenset(
+            {
+                "timestamp_precise",
+                "observed_timestamp",
+                "trace",
+                "id",
+                "item_id",
+                "sentry.timestamp_precise",
+                "sentry.observed_timestamp_nanos",
+                "organization_id",
+                "project_id",
+                "trace_id",
+                "item_type",
+                "timestamp",
+                "sentry._internal.ingested_at",
+                "client_sample_rate",
+                "server_sample_rate",
+                "retention_days",
+                "downsampled_retention_days",
+            }
+        )
+        return start, end, expected_rows_by_agent, variable_keys
+
+    def _assert_explore_logs_jsonl_rows_match_expected(
+        self,
+        rows_by_agent: dict[str, dict[str, object]],
+        expected_rows_by_agent: dict[str, dict[str, object]],
+        ignored_keys: frozenset[str],
+    ) -> None:
+        def assert_row_equals_export(
+            actual: dict[str, object], expected: dict[str, object]
+        ) -> None:
+            for key, exp in expected.items():
+                assert key in actual, f"missing column {key!r}; got {sorted(actual)}"
+                got = actual[key]
+                if isinstance(exp, (int, float)) and isinstance(got, (int, float)):
+                    assert float(got) == float(exp), (key, got, exp)
+                else:
+                    assert got == exp, (key, got, exp)
+            extra = set(actual) - set(expected) - ignored_keys
+            assert not extra, f"unexpected columns: {sorted(extra)}"
+
+        assert set(rows_by_agent.keys()) == set(expected_rows_by_agent.keys())
+        for user_agent in rows_by_agent:
+            assert_row_equals_export(rows_by_agent[user_agent], expected_rows_by_agent[user_agent])
+
+    def _explore_logs_jsonl_rich_field_api_request_body(
+        self, start: str, end: str, *, limit: int | None = None
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "query_type": ExportQueryType.EXPLORE_STR,
+            "format": OutputMode.JSONL.value,
+            "query_info": {
+                "project": [self.project.id],
+                "field": [],
+                "equations": [],
+                "query": "",
+                "dataset": "logs",
+                "start": start,
+                "end": end,
+            },
+        }
+        if limit is not None:
+            body["limit"] = limit
+        return body
+
+    def _post_explore_logs_jsonl_rich_field_export(
+        self, start: str, end: str, *, limit: int | None = None
+    ) -> dict[str, Any]:
+        self.login_as(self.user)
+        url = reverse(
+            "sentry-api-0-organization-data-export",
+            kwargs={"organization_id_or_slug": self.org.slug},
+        )
+        request_body = self._explore_logs_jsonl_rich_field_api_request_body(start, end, limit=limit)
+        with self.feature("organizations:discover-query"):
+            response = self.client.post(
+                url,
+                data=json.dumps(request_body),
+                content_type="application/json",
+            )
+        assert response.status_code == 201, response.content
+        return json.loads(response.content)
+
+    def _assert_explore_logs_jsonl_export_create_payload(
+        self, payload: dict[str, Any]
+    ) -> ExportedData:
+        de = ExportedData.objects.get(id=payload["id"])
+        assert de.user_id == self.user.id
+        assert de.query_type == ExportQueryType.EXPLORE
+        assert de.export_format == OutputMode.JSONL.value
+        assert de.query_info["dataset"] == "logs"
+        return de
+
+    def _assert_rich_field_ndjson_two_rows_match_expected(
+        self,
+        raw_ndjson: bytes,
+        expected_rows_by_agent: dict[str, dict[str, object]],
+        ignored_keys: frozenset[str],
+    ) -> None:
+        lines = [ln for ln in raw_ndjson.split(b"\n") if ln]
+        assert len(lines) == 2
+        rows = [json.loads(ln.decode("utf-8")) for ln in lines]
+        rows_by_agent = {row["user_agent"]: row for row in rows}
+        self._assert_explore_logs_jsonl_rows_match_expected(
+            rows_by_agent, expected_rows_by_agent, ignored_keys
+        )
+
+    def _get_data_export_download_body(self, data_export_id: int) -> bytes:
+        details_url = reverse(
+            "sentry-api-0-organization-data-export-details",
+            kwargs={
+                "organization_id_or_slug": self.org.slug,
+                "data_export_id": data_export_id,
+            },
+        )
+        dl_response = self.client.get(f"{details_url}?download=1")
+        assert dl_response.status_code == 200
+        return b"".join(dl_response.streaming_content).strip()
 
     @patch("sentry.data_export.models.ExportedData.email_success")
     def test_explore_spans_dataset_called_correctly(self, emailer: MagicMock) -> None:
@@ -864,197 +1086,68 @@ class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogT
         assert emailer.called
 
     @patch("sentry.data_export.models.ExportedData.email_success")
-    def test_explore_logs_jsonl_full_dataset_rich_fields(self, emailer: MagicMock) -> None:
+    def test_explore_logs_jsonl_full_dataset_rich_fields_async(self, emailer: MagicMock) -> None:
         """
-        Wide logs JSONL: two rows, export_limit above row count, batch_size 1 or 2.
+        Wide logs JSONL: two rows, export_limit above row count (async assemble_download).
+
         """
-        shared_attrs = {
-            "environment": "prod",
-            "origin": "auto.log.stdlib",
-            "sdk.name": "sentry.python.django",
-            "sdk.version": "2.47.0",
-            "tags[code.line.number,number]": 148,
-            "tags[process.pid,number]": 6639,
-        }
-        logs = [
-            self.create_ourlog(
-                {
-                    "body": "api.access.alpha",
-                    "severity_text": "info",
-                    "severity_number": 9,
-                },
-                timestamp=before_now(minutes=10),
-                organization=self.org,
-                project=self.project,
-                attributes={
-                    **shared_attrs,
-                    "method": "GET",
-                    "path": "/api/0/projects/acme/issues/",
-                    "user_agent": "python-requests/2.32.5",
-                    "logger.name": "sentry.access.api",
-                    "response": "200",
-                    "rate_limited": "False",
-                    "payload_size": 981,
-                },
-            ),
-            self.create_ourlog(
-                {
-                    "body": "api.access.beta",
-                    "severity_text": "info",
-                    "severity_number": 9,
-                },
-                timestamp=before_now(minutes=8),
-                organization=self.org,
-                project=self.project,
-                attributes={
-                    **shared_attrs,
-                    "method": "POST",
-                    "path": "/api/0/internal/rpc/",
-                    "user_agent": "curl/8.0",
-                    "logger.name": "sentry.access.api",
-                    "response": "201",
-                    "rate_limited": "False",
-                    "payload_size": 2048,
-                },
-            ),
-        ]
-        self.store_eap_items(logs)
-
-        expected_rows = [
-            {
-                "sdk.name": "sentry.python.django",
-                "user_agent": "python-requests/2.32.5",
-                "method": "GET",
-                "path": "/api/0/projects/acme/issues/",
-                "sdk.version": "2.47.0",
-                "tags[code.line.number,number]": 148.0,
-                "logger.name": "sentry.access.api",
-                "origin": "auto.log.stdlib",
-                "sentry.body": "api.access.alpha",
-                "rate_limited": "False",
-                "sentry.severity_text": "info",
-                "environment": "prod",
-                "sentry.severity_number": 9.0,
-                "payload_size": 981.0,
-                "tags[process.pid,number]": 6639.0,
-                "response": "200",
-            },
-            {
-                "sdk.name": "sentry.python.django",
-                "user_agent": "curl/8.0",
-                "method": "POST",
-                "path": "/api/0/internal/rpc/",
-                "sdk.version": "2.47.0",
-                "tags[code.line.number,number]": 148.0,
-                "logger.name": "sentry.access.api",
-                "origin": "auto.log.stdlib",
-                "sentry.body": "api.access.beta",
-                "rate_limited": "False",
-                "sentry.severity_text": "info",
-                "environment": "prod",
-                "payload_size": 2048.0,
-                "tags[process.pid,number]": 6639.0,
-                "sentry.severity_number": 9.0,
-                "response": "201",
-            },
-        ]
-        expected_rows_by_agent = {exp_row["user_agent"]: exp_row for exp_row in expected_rows}
-
-        # Present on TraceItem / Snuba but not worth pinning (ids, times, nanosecond precision, sampling).
-        ignored_row_keys = frozenset(
-            {
-                "timestamp_precise",
-                "observed_timestamp",
-                "trace",
-                "id",
-                "item_id",
-                "sentry.timestamp_precise",
-                "sentry.observed_timestamp_nanos",
-                "organization_id",
-                "project_id",
-                "trace_id",
-                "item_type",
-                "timestamp",
-                "sentry._internal.ingested_at",
-                "client_sample_rate",
-                "server_sample_rate",
-                "retention_days",
-                "downsampled_retention_days",
-            }
+        start, end, expected_rows_by_agent, ignored_keys = (
+            self._store_explore_logs_jsonl_rich_field_fixture()
         )
 
-        start = before_now(minutes=15).isoformat()
-        end = before_now(seconds=30).isoformat()
-        request_body = {
-            "query_type": ExportQueryType.EXPLORE_STR,
-            "format": OutputMode.JSONL.value,
-            "query_info": {
-                "project": [self.project.id],
-                "field": [],
-                "equations": [],
-                "query": "",
-                "dataset": "logs",
-                "start": start,
-                "end": end,
-            },
-        }
-        url = reverse(
-            "sentry-api-0-organization-data-export",
-            kwargs={"organization_id_or_slug": self.org.slug},
+        payload = self._post_explore_logs_jsonl_rich_field_export(start, end)
+        de = self._assert_explore_logs_jsonl_export_create_payload(payload)
+
+        with self.tasks():
+            assemble_download(de.id, batch_size=2, export_limit=100)
+
+        de = ExportedData.objects.get(id=de.id)
+        assert de.date_finished is not None
+        file = de._get_file()
+        assert isinstance(file, File)
+        assert file.headers == {"Content-Type": "application/x-ndjson"}
+
+        with file.getfile() as f:
+            content = f.read().strip()
+        self._assert_rich_field_ndjson_two_rows_match_expected(
+            content, expected_rows_by_agent, ignored_keys
         )
-        self.login_as(self.user)
-        for batch_size in (1, 2):
-            with self.subTest(batch_size=batch_size):
-                with self.feature("organizations:discover-query"):
-                    response = self.client.post(
-                        url,
-                        data=json.dumps(request_body),
-                        content_type="application/json",
-                    )
-                assert response.status_code == 201, response.content
-                response_payload = json.loads(response.content)
-                de = ExportedData.objects.get(id=response_payload["id"])
-                assert de.user_id == self.user.id
-                assert de.query_type == ExportQueryType.EXPLORE
-                assert de.export_format == OutputMode.JSONL.value
-                assert de.query_info["dataset"] == "logs"
-
-                with self.tasks():
-                    assemble_download(de.id, batch_size=batch_size, export_limit=100)
-
-                de = ExportedData.objects.get(id=de.id)
-                assert de.date_finished is not None
-                file = de._get_file()
-                assert isinstance(file, File)
-                assert file.headers == {"Content-Type": "application/x-ndjson"}
-
-                with file.getfile() as f:
-                    content = f.read().strip()
-                lines = [ln for ln in content.split(b"\n") if ln]
-                assert len(lines) == 2
-
-                rows = [json.loads(ln.decode("utf-8")) for ln in lines]
-                rows_by_agent = {row["user_agent"]: row for row in rows}
-
-                def assert_row_equals_export(
-                    actual: dict[str, object], expected: dict[str, object]
-                ) -> None:
-                    for key, exp in expected.items():
-                        assert key in actual, f"missing column {key!r}; got {sorted(actual)}"
-                        got = actual[key]
-                        if isinstance(exp, (int, float)) and isinstance(got, (int, float)):
-                            assert float(got) == float(exp), (key, got, exp)
-                        else:
-                            assert got == exp, (key, got, exp)
-                    extra = set(actual) - set(expected) - ignored_row_keys
-                    assert not extra, f"unexpected columns: {sorted(extra)}"
-
-                assert set(rows_by_agent.keys()) == set(expected_rows_by_agent.keys())
-                for user_agent in rows_by_agent.keys():
-                    assert_row_equals_export(
-                        rows_by_agent[user_agent], expected_rows_by_agent[user_agent]
-                    )
         assert emailer.called
+
+    @patch("sentry.data_export.endpoints.data_export.assemble_download.delay")
+    @patch("sentry.data_export.models.ExportedData.email_success")
+    def test_explore_logs_jsonl_full_dataset_rich_fields_sync(
+        self, emailer: MagicMock, assemble_delay: MagicMock
+    ) -> None:
+        """
+        Same dataset as test_explore_logs_jsonl_full_dataset_rich_fields: explore + JSONL + limit
+        runs synchronously; API response includes file metadata; download stream matches rows.
+        """
+        start, end, expected_rows_by_agent, ignored_keys = (
+            self._store_explore_logs_jsonl_rich_field_fixture()
+        )
+
+        payload = self._post_explore_logs_jsonl_rich_field_export(start, end, limit=100)
+        assert not assemble_delay.called
+
+        assert payload["dateFinished"] is not None
+        assert payload["checksum"] is not None
+        assert payload["fileName"] is not None
+        de = self._assert_explore_logs_jsonl_export_create_payload(payload)
+        assert de.date_finished is not None
+        assert de.file_id is not None
+
+        file = de._get_file()
+        assert isinstance(file, File)
+        assert file.checksum == payload["checksum"]
+        assert file.name == payload["fileName"]
+        assert file.headers == {"Content-Type": "application/x-ndjson"}
+
+        raw = self._get_data_export_download_body(de.id)
+        self._assert_rich_field_ndjson_two_rows_match_expected(
+            raw, expected_rows_by_agent, ignored_keys
+        )
+        assert not emailer.called
 
     @patch("sentry.data_export.models.ExportedData.email_success")
     def test_explore_datasets_isolation(self, emailer: MagicMock) -> None:


### PR DESCRIPTION
The data export flow dispatches every request as an async Celery task and emails the user a download link when the job finishes. For small log exports we want to download the log file, within the browser session. 

This adds a sync export path for Explore log exports with a requested limit at or under `MAX_SYNC_LIMIT` (10 000 rows).  The endpoint runs the export inline, stores the blobs, merges them, and returns the finalized `ExportedData` object in the same response. The email notification is suppressed because the download URL is immediately present in the API response.

The async path is unchanged — this is purely additive gating on query type, dataset, and limit size.