### PR TITLE
fix(slack): Include y-axis aggregate in Explore unfurl title

### DIFF
--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping
 from typing import Any, TypedDict
 from urllib.parse import urlparse
 
+import sentry_sdk
 from django.http.request import QueryDict
 
 from sentry import analytics, features
@@ -110,6 +111,10 @@ def _unfurl_explore(
 
         if not org:
             continue
+
+        sentry_sdk.set_tag("organization.slug", org_slug)
+        if user:
+            sentry_sdk.set_tag("user.email", getattr(user, "email", None))
 
         params = link.args["query"]
         chart_type = link.args.get("chart_type")

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -7,7 +7,6 @@ from collections.abc import Mapping
 from typing import Any, TypedDict
 from urllib.parse import urlparse
 
-import sentry_sdk
 from django.http.request import QueryDict
 
 from sentry import analytics, features
@@ -112,10 +111,6 @@ def _unfurl_explore(
         if not org:
             continue
 
-        sentry_sdk.set_tag("organization.slug", org_slug)
-        if user:
-            sentry_sdk.set_tag("user.email", getattr(user, "email", None))
-
         params = link.args["query"]
         chart_type = link.args.get("chart_type")
 
@@ -162,8 +157,10 @@ def _unfurl_explore(
             _logger.warning("Failed to generate chart for explore unfurl")
             continue
 
+        # Only one chart/y-axis is supported at a time in Explore
+        title = f"{defaults['title']} - {y_axes[0]}"
         unfurls[link.url] = SlackDiscoverMessageBuilder(
-            title=defaults["title"],
+            title=title,
             chart_url=url,
         ).build()
 

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -1522,7 +1522,9 @@ class UnfurlTest(TestCase):
 
         assert (
             unfurls[url]
-            == SlackDiscoverMessageBuilder(title="Explore Traces", chart_url="chart-url").build()
+            == SlackDiscoverMessageBuilder(
+                title="Explore Traces - avg(span.duration)", chart_url="chart-url"
+            ).build()
         )
         assert len(mock_generate_chart.mock_calls) == 1
         assert mock_generate_chart.call_args[0][0] == ChartType.SLACK_EXPLORE_LINE
@@ -1695,7 +1697,9 @@ class UnfurlTest(TestCase):
         assert len(unfurls) == 1
         assert (
             unfurls[url]
-            == SlackDiscoverMessageBuilder(title="Explore Traces", chart_url="chart-url").build()
+            == SlackDiscoverMessageBuilder(
+                title="Explore Traces - avg(span.duration)", chart_url="chart-url"
+            ).build()
         )
 
     @patch(
@@ -1806,7 +1810,9 @@ class UnfurlTest(TestCase):
 
         assert (
             unfurls[url]
-            == SlackDiscoverMessageBuilder(title="Explore Logs", chart_url="chart-url").build()
+            == SlackDiscoverMessageBuilder(
+                title="Explore Logs - sum(payload_size)", chart_url="chart-url"
+            ).build()
         )
         assert len(mock_generate_chart.mock_calls) == 1
         chart_data = mock_generate_chart.call_args[0][1]


### PR DESCRIPTION
The Explore unfurl title was a generic "Explore Traces" or "Explore Logs"
which didn't tell the user what was actually being plotted. Now the title
includes the aggregate, e.g. "Explore Traces - avg(span.duration)" or
"Explore Logs - count(message)", matching what the user sees in the Explore
page.

Fixes DAIN-1489