### PR TITLE
fix(incidents): Fix 60x resolution inflation when switching to DYNAMIC detection without explicit time_window

### DIFF
--- a/src/sentry/incidents/logic.py
+++ b/src/sentry/incidents/logic.py
@@ -918,9 +918,11 @@ def update_alert_rule(
             updated_fields["seasonality"] = None
         elif detection_type == AlertRuleDetectionType.DYNAMIC:
             # NOTE: we set seasonality for EA
-            updated_query_fields["resolution"] = timedelta(
-                minutes=time_window if time_window is not None else snuba_query.time_window
-            )
+            if time_window is not None:
+                updated_query_fields["resolution"] = timedelta(minutes=time_window)
+            else:
+                # snuba_query.time_window is already in seconds
+                updated_query_fields["resolution"] = timedelta(seconds=snuba_query.time_window)
             updated_fields["seasonality"] = AlertRuleSeasonality.AUTO
             updated_fields["comparison_delta"] = None
             if (

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -1542,6 +1542,27 @@ class UpdateAlertRuleTest(TestCase, BaseIncidentsTest):
         assert alert_rule.status == AlertRuleStatus.PENDING.value
 
     @with_feature("organizations:anomaly-detection-alerts")
+    @patch("sentry.seer.anomaly_detection.store_data.handle_send_historical_data_to_seer_legacy")
+    def test_update_static_to_dynamic_without_time_window_preserves_resolution(
+        self, mock_handle_seer: MagicMock
+    ) -> None:
+        time_window_minutes = 30
+        alert_rule = self.create_alert_rule(
+            time_window=time_window_minutes, detection_type=AlertRuleDetectionType.STATIC
+        )
+        expected_resolution_seconds = time_window_minutes * 60
+
+        update_alert_rule(
+            alert_rule,
+            sensitivity=AlertRuleSensitivity.HIGH,
+            seasonality=AlertRuleSeasonality.AUTO,
+            detection_type=AlertRuleDetectionType.DYNAMIC,
+        )
+
+        alert_rule.snuba_query.refresh_from_db()
+        assert alert_rule.snuba_query.resolution == expected_resolution_seconds
+
+    @with_feature("organizations:anomaly-detection-alerts")
     @patch(
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
     )


### PR DESCRIPTION
Easy to get mixed up when we're representing a duration as an int and using different resolutions.
This fixes a corner case where we were using seconds as minutes.
