### PR TITLE
fix(explore): Pass sort param for group-by explore Slack unfurls

### DIFF
--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -127,6 +127,10 @@ def _unfurl_explore(
         style = ChartType.SLACK_EXPLORE_LINE
         if group_bys:
             params.setlist("topEvents", [str(TOP_N)])
+            if not params.getlist("sort"):
+                # Default to descending by the first yAxis, matching Explore's
+                # defaultAggregateSortBys behavior
+                params.setlist("sort", [f"-{y_axes[0]}"])
 
         if not params.get("statsPeriod") and not params.get("start"):
             params["statsPeriod"] = DEFAULT_PERIOD
@@ -226,6 +230,12 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
         values = raw_query.getlist(param)
         if values:
             query.setlist(param, values)
+
+    # Explore stores the aggregate sort as "aggregateSort" in the URL;
+    # the events-timeseries endpoint expects it as "sort".
+    aggregate_sort = raw_query.getlist("aggregateSort")
+    if aggregate_sort:
+        query.setlist("sort", aggregate_sort)
 
     return dict(**args, query=query, chart_type=chart_type, dataset=explore_dataset)
 

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -1576,6 +1576,37 @@ class UnfurlTest(TestCase):
         assert len(mock_generate_chart.mock_calls) == 1
         assert mock_generate_chart.call_args[0][0] == ChartType.SLACK_EXPLORE_LINE
 
+        # Verify sort is passed to the timeseries API for correct top events
+        api_params = mock_client_get.call_args[1]["params"]
+        assert api_params.getlist("sort") == ["-avg(span.duration)"]
+
+    @patch(
+        "sentry.integrations.slack.unfurl.explore.client.get",
+    )
+    @patch("sentry.charts.backend.generate_chart", return_value="chart-url")
+    def test_unfurl_explore_with_groupby_explicit_sort(
+        self, mock_generate_chart: MagicMock, mock_client_get: MagicMock
+    ) -> None:
+        mock_client_get.return_value = MagicMock(data=self._build_mock_timeseries_response())
+        url = f"https://sentry.io/organizations/{self.organization.slug}/explore/traces/?aggregateField=%7B%22groupBy%22%3A%22span.op%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22avg(span.duration)%22%5D%7D&aggregateSort=span.op&project={self.project.id}&statsPeriod=24h"
+        link_type, args = match_link(url)
+
+        if not args or not link_type:
+            raise AssertionError("Missing link_type/args")
+
+        links = [
+            UnfurlableUrl(url=url, args=args),
+        ]
+
+        with self.feature(["organizations:data-browsing-widget-unfurl"]):
+            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+
+        assert len(unfurls) == 1
+
+        # Verify explicit aggregateSort from the URL is used instead of the default
+        api_params = mock_client_get.call_args[1]["params"]
+        assert api_params.getlist("sort") == ["span.op"]
+
     @patch(
         "sentry.integrations.slack.unfurl.explore.client.get",
     )


### PR DESCRIPTION
When an Explore link with `groupBy` is unfurled in Slack, the unfurl sets
`topEvents=5` but omits the `sort` parameter. Without it, the timeseries
endpoint returns whichever groups it defaults to rather than the actual top
groups matching what Explore shows (e.g., "mark" and "paint" appearing
instead of the real top groups).

Two changes:
- `map_explore_query_args` now copies the `aggregateSort` URL param
  (Explore's name) as `sort` (the API param name)
- `_unfurl_explore` defaults to `-{yAxis}` (descending by the charted
  aggregate) when no explicit sort is present, matching the frontend's
  `defaultAggregateSortBys` behavior

Fixes DAIN-1490