### PR TITLE
feat(slack): Support unfurling Explore Metrics URLs in Slack

### DIFF
--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -257,7 +257,7 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
                 if field:
                     metric_sort_bys.append(f"-{field}" if kind == "desc" else field)
             metric_query = metric_parsed.get("query") or None
-        except (json.JSONDecodeError, TypeError):
+        except (json.JSONDecodeError, TypeError, AttributeError):
             pass
 
     visualize_fields = raw_query.getlist("visualize") or raw_query.getlist("aggregateField")

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -251,6 +251,8 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
                     y_axes.extend(agg_field["yAxes"])
                 if "groupBy" in agg_field and agg_field["groupBy"]:
                     group_bys.append(agg_field["groupBy"])
+                if chart_type is None and isinstance(agg_field.get("chartType"), int):
+                    chart_type = agg_field["chartType"]
             for sort_by in metric_parsed.get("aggregateSortBys", []):
                 field = sort_by.get("field", "")
                 kind = sort_by.get("kind", "desc")

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -53,6 +53,10 @@ EXPLORE_DATASET_DEFAULTS: dict[SupportedTraceItemType, ExploreDatasetDefaults] =
         "title": "Explore Logs",
         "y_axis": "count(message)",
     },
+    SupportedTraceItemType.TRACEMETRICS: {
+        "title": "Explore Metrics",
+        "y_axis": "sum(value)",
+    },
 }
 
 
@@ -67,6 +71,10 @@ def _get_explore_dataset(url: str) -> SupportedTraceItemType:
     """Returns the dataset based on the explore URL."""
     if explore_logs_link_regex.match(url) or customer_domain_explore_logs_link_regex.match(url):
         return SupportedTraceItemType.LOGS
+    if explore_metrics_link_regex.match(url) or customer_domain_explore_metrics_link_regex.match(
+        url
+    ):
+        return SupportedTraceItemType.TRACEMETRICS
     return SupportedTraceItemType.SPANS
 
 
@@ -214,7 +222,7 @@ def _resolve_display_type(chart_type: int | None, y_axes: list[str]) -> str:
 def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[str, Any]:
     """
     Extracts explore arguments from the explore link's query string.
-    Parses visualize/aggregateField JSON params to extract yAxes, groupBy, and chartType.
+    Parses visualize, aggregateField, or metric JSON params to extract yAxes, groupBy, and chartType.
     """
     # Slack uses HTML escaped ampersands in its Event Links
     url = html.unescape(url)
@@ -223,11 +231,34 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
 
     explore_dataset = _get_explore_dataset(url)
 
-    # Parse visualize (spans explore) or aggregateField (logs explore) JSON params
-    visualize_fields = raw_query.getlist("visualize") or raw_query.getlist("aggregateField")
+    # Parse visualization params from the URL.
+    # Metrics uses a single "metric" JSON param with nested aggregateFields.
+    # Traces uses "visualize" and logs uses "aggregateField".
     y_axes: list[str] = []
     group_bys: list[str] = []
     chart_type: int | None = None
+
+    metric_query: str | None = None
+    metric_sort_bys: list[str] = []
+    metric_json = raw_query.get("metric")
+    if metric_json:
+        try:
+            metric_parsed = json.loads(metric_json)
+            for agg_field in metric_parsed.get("aggregateFields", []):
+                if "yAxes" in agg_field and isinstance(agg_field["yAxes"], list):
+                    y_axes.extend(agg_field["yAxes"])
+                if "groupBy" in agg_field and agg_field["groupBy"]:
+                    group_bys.append(agg_field["groupBy"])
+            for sort_by in metric_parsed.get("aggregateSortBys", []):
+                field = sort_by.get("field", "")
+                kind = sort_by.get("kind", "desc")
+                if field:
+                    metric_sort_bys.append(f"-{field}" if kind == "desc" else field)
+            metric_query = metric_parsed.get("query") or None
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+    visualize_fields = raw_query.getlist("visualize") or raw_query.getlist("aggregateField")
     for field_json in visualize_fields:
         try:
             parsed = json.loads(field_json)
@@ -262,6 +293,12 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
     if aggregate_sort:
         query.setlist("sort", aggregate_sort)
 
+    # Metrics stores query and sort inside the metric JSON param
+    if metric_query:
+        query["query"] = metric_query
+    if metric_sort_bys:
+        query.setlist("sort", metric_sort_bys)
+
     return dict(**args, query=query, chart_type=chart_type, dataset=explore_dataset)
 
 
@@ -281,6 +318,14 @@ customer_domain_explore_logs_link_regex = re.compile(
     r"^https?\://(?P<org_slug>[^.]+?)\.(?#url_prefix)[^/]+/explore/logs/"
 )
 
+explore_metrics_link_regex = re.compile(
+    r"^https?\://(?#url_prefix)[^/]+/organizations/(?P<org_slug>[^/]+)/explore/metrics/"
+)
+
+customer_domain_explore_metrics_link_regex = re.compile(
+    r"^https?\://(?P<org_slug>[^.]+?)\.(?#url_prefix)[^/]+/explore/metrics/"
+)
+
 explore_handler = Handler(
     fn=unfurl_explore,
     matcher=[
@@ -288,6 +333,8 @@ explore_handler = Handler(
         customer_domain_explore_traces_link_regex,
         explore_logs_link_regex,
         customer_domain_explore_logs_link_regex,
+        explore_metrics_link_regex,
+        customer_domain_explore_metrics_link_regex,
     ],
     arg_mapper=map_explore_query_args,
 )

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -232,7 +232,7 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
     explore_dataset = _get_explore_dataset(url)
 
     # Parse visualization params from the URL.
-    # Metrics uses a single "metric" JSON param with nested aggregateFields.
+    # Each metric uses a "metric" JSON param with nested aggregateFields.
     # Traces uses "visualize" and logs uses "aggregateField".
     y_axes: list[str] = []
     group_bys: list[str] = []
@@ -240,8 +240,7 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
 
     metric_query: str | None = None
     metric_sort_bys: list[str] = []
-    metric_json = raw_query.get("metric")
-    if metric_json:
+    for metric_json in raw_query.getlist("metric"):
         try:
             metric_parsed = json.loads(metric_json)
             for agg_field in metric_parsed.get("aggregateFields", []):
@@ -254,9 +253,10 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
                 kind = sort_by.get("kind", "desc")
                 if field:
                     metric_sort_bys.append(f"-{field}" if kind == "desc" else field)
-            metric_query = metric_parsed.get("query") or None
+            if metric_query is None:
+                metric_query = metric_parsed.get("query") or None
         except (json.JSONDecodeError, TypeError):
-            pass
+            continue
 
     visualize_fields = raw_query.getlist("visualize") or raw_query.getlist("aggregateField")
     for field_json in visualize_fields:

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -240,7 +240,10 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
 
     metric_query: str | None = None
     metric_sort_bys: list[str] = []
-    for metric_json in raw_query.getlist("metric"):
+    # Each metric param is a self-contained chart config. We only render one
+    # chart per unfurl, so process only the first metric entry.
+    metric_json = raw_query.getlist("metric")[0] if raw_query.getlist("metric") else None
+    if metric_json:
         try:
             metric_parsed = json.loads(metric_json)
             for agg_field in metric_parsed.get("aggregateFields", []):
@@ -253,10 +256,9 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
                 kind = sort_by.get("kind", "desc")
                 if field:
                     metric_sort_bys.append(f"-{field}" if kind == "desc" else field)
-            if metric_query is None:
-                metric_query = metric_parsed.get("query") or None
+            metric_query = metric_parsed.get("query") or None
         except (json.JSONDecodeError, TypeError):
-            continue
+            pass
 
     visualize_fields = raw_query.getlist("visualize") or raw_query.getlist("aggregateField")
     for field_json in visualize_fields:

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -240,6 +240,30 @@ INTERVALS_PER_DAY = int(60 * 60 * 24 / INTERVAL_COUNT)
                 },
             ),
         ),
+        (
+            "https://sentry.io/organizations/org1/explore/metrics/?metric=%7B%22aggregateFields%22%3A%5B%7B%22yAxes%22%3A%5B%22sum(value)%22%5D%7D%5D%7D&project=1&statsPeriod=7d",
+            (
+                LinkType.EXPLORE,
+                {
+                    "org_slug": "org1",
+                    "query": QueryDict("yAxis=sum(value)&project=1&statsPeriod=7d"),
+                    "chart_type": None,
+                    "dataset": "tracemetrics",
+                },
+            ),
+        ),
+        (
+            "https://org1.sentry.io/explore/metrics/?metric=%7B%22aggregateFields%22%3A%5B%7B%22yAxes%22%3A%5B%22avg(value)%22%5D%7D%5D%7D&statsPeriod=24h",
+            (
+                LinkType.EXPLORE,
+                {
+                    "org_slug": "org1",
+                    "query": QueryDict("yAxis=avg(value)&statsPeriod=24h"),
+                    "chart_type": None,
+                    "dataset": "tracemetrics",
+                },
+            ),
+        ),
     ],
 )
 def test_match_link(url, expected) -> None:
@@ -1910,3 +1934,40 @@ class UnfurlTest(TestCase):
         assert len(unfurls) == 1
         call_kwargs = mock_client_get.call_args[1]
         assert call_kwargs["params"]["dataset"] == "logs"
+
+    @patch(
+        "sentry.integrations.slack.unfurl.explore.client.get",
+    )
+    @patch("sentry.charts.backend.generate_chart", return_value="chart-url")
+    def test_unfurl_explore_metrics(
+        self, mock_generate_chart: MagicMock, mock_client_get: MagicMock
+    ) -> None:
+        mock_client_get.return_value = MagicMock(data=self._build_mock_timeseries_response())
+        url = f"https://sentry.io/organizations/{self.organization.slug}/explore/metrics/?metric=%7B%22aggregateFields%22%3A%5B%7B%22yAxes%22%3A%5B%22sum(value%2Cmy.metric%2Cdistribution%2Cmillisecond)%22%5D%7D%5D%7D&project={self.project.id}&statsPeriod=7d"
+        link_type, args = match_link(url)
+
+        if not args or not link_type:
+            raise AssertionError("Missing link_type/args")
+
+        assert link_type == LinkType.EXPLORE
+        assert args["dataset"] == "tracemetrics"
+
+        links = [
+            UnfurlableUrl(url=url, args=args),
+        ]
+
+        with self.feature(["organizations:data-browsing-widget-unfurl"]):
+            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+
+        assert (
+            unfurls[url]
+            == SlackDiscoverMessageBuilder(
+                title="Explore Metrics - sum(value,my.metric,distribution,millisecond)",
+                chart_url="chart-url",
+            ).build()
+        )
+        assert len(mock_generate_chart.mock_calls) == 1
+        call_kwargs = mock_client_get.call_args[1]
+        api_params = call_kwargs["params"]
+        assert api_params["dataset"] == "tracemetrics"
+        assert api_params["yAxis"] == "sum(value,my.metric,distribution,millisecond)"

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -248,7 +248,7 @@ INTERVALS_PER_DAY = int(60 * 60 * 24 / INTERVAL_COUNT)
                     "org_slug": "org1",
                     "query": QueryDict("yAxis=sum(value)&project=1&statsPeriod=7d"),
                     "chart_type": None,
-                    "dataset": "tracemetrics",
+                    "dataset": SupportedTraceItemType.TRACEMETRICS,
                 },
             ),
         ),
@@ -260,7 +260,7 @@ INTERVALS_PER_DAY = int(60 * 60 * 24 / INTERVAL_COUNT)
                     "org_slug": "org1",
                     "query": QueryDict("yAxis=avg(value)&statsPeriod=24h"),
                     "chart_type": None,
-                    "dataset": "tracemetrics",
+                    "dataset": SupportedTraceItemType.TRACEMETRICS,
                 },
             ),
         ),
@@ -1950,7 +1950,7 @@ class UnfurlTest(TestCase):
             raise AssertionError("Missing link_type/args")
 
         assert link_type == LinkType.EXPLORE
-        assert args["dataset"] == "tracemetrics"
+        assert args["dataset"] == SupportedTraceItemType.TRACEMETRICS
 
         links = [
             UnfurlableUrl(url=url, args=args),


### PR DESCRIPTION
Add Slack unfurl support for Explore Metrics URLs (`/explore/metrics/`),
alongside the existing traces and logs support.

The metrics URL structure differs from traces/logs — it uses a single `metric`
JSON query param with nested `aggregateFields` containing the `yAxes`, rather
than separate `visualize` or `aggregateField` params. The handler parses this
structure and uses the `tracemetrics` dataset for the events-timeseries API call.

Supports both `/organizations/{slug}/explore/metrics/` and customer domain
`{slug}.sentry.io/explore/metrics/` URL formats.

Depends on #112677

Fixes DAIN-1477