### PR TITLE
feat(supergroups): Allow frontend to control RCA source via query param

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -575,7 +575,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable lightweight RCA clustering write path (generate embeddings on new issues)
     manager.add("organizations:supergroups-lightweight-rca-clustering-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable lightweight RCA clustering read path (query lightweight embeddings in supergroup APIs)
-    manager.add("organizations:supergroups-lightweight-rca-clustering-read", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:supergroups-lightweight-rca-clustering-read", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
 
     manager.add("projects:workflow-engine-performance-detectors", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
 

--- a/src/sentry/seer/supergroups/endpoints/organization_supergroup_details.py
+++ b/src/sentry/seer/supergroups/endpoints/organization_supergroup_details.py
@@ -35,13 +35,20 @@ class OrganizationSupergroupDetailsEndpoint(OrganizationEndpoint):
         if not features.has("organizations:top-issues-ui", organization, actor=request.user):
             return Response({"detail": "Feature not available"}, status=403)
 
-        rca_source = (
-            RCASource.LIGHTWEIGHT
-            if features.has(
-                "organizations:supergroups-lightweight-rca-clustering-read", organization
+        rca_source_param = request.GET.get("rca_source")
+        try:
+            rca_source = RCASource(rca_source_param) if rca_source_param else None
+        except ValueError:
+            rca_source = None
+
+        if rca_source is None:
+            rca_source = (
+                RCASource.LIGHTWEIGHT
+                if features.has(
+                    "organizations:supergroups-lightweight-rca-clustering-read", organization
+                )
+                else RCASource.EXPLORER
             )
-            else RCASource.EXPLORER
-        )
 
         response = make_supergroups_get_request(
             {

--- a/src/sentry/seer/supergroups/endpoints/organization_supergroups_by_group.py
+++ b/src/sentry/seer/supergroups/endpoints/organization_supergroups_by_group.py
@@ -78,13 +78,20 @@ class OrganizationSupergroupsByGroupEndpoint(OrganizationEndpoint):
                 status=status_codes.HTTP_404_NOT_FOUND,
             )
 
-        rca_source = (
-            RCASource.LIGHTWEIGHT
-            if features.has(
-                "organizations:supergroups-lightweight-rca-clustering-read", organization
+        rca_source_param = request.GET.get("rca_source")
+        try:
+            rca_source = RCASource(rca_source_param) if rca_source_param else None
+        except ValueError:
+            rca_source = None
+
+        if rca_source is None:
+            rca_source = (
+                RCASource.LIGHTWEIGHT
+                if features.has(
+                    "organizations:supergroups-lightweight-rca-clustering-read", organization
+                )
+                else RCASource.EXPLORER
             )
-            else RCASource.EXPLORER
-        )
 
         response = make_supergroups_get_by_group_ids_request(
             {"organization_id": organization.id, "group_ids": group_ids, "rca_source": rca_source},

--- a/tests/sentry/seer/supergroups/endpoints/test_organization_supergroup_details.py
+++ b/tests/sentry/seer/supergroups/endpoints/test_organization_supergroup_details.py
@@ -65,3 +65,27 @@ class OrganizationSupergroupDetailsEndpointTest(APITestCase):
 
         body = mock_seer.call_args.args[0]
         assert body["rca_source"] == "LIGHTWEIGHT"
+
+    @patch(
+        "sentry.seer.supergroups.endpoints.organization_supergroup_details.make_supergroups_get_request"
+    )
+    def test_rca_source_query_param_overrides_flag(self, mock_seer):
+        mock_seer.return_value = mock_seer_response({"id": 1, "title": "test"})
+
+        with self.feature("organizations:top-issues-ui"):
+            self.get_success_response(self.organization.slug, "1", rca_source="LIGHTWEIGHT")
+
+        body = mock_seer.call_args.args[0]
+        assert body["rca_source"] == "LIGHTWEIGHT"
+
+    @patch(
+        "sentry.seer.supergroups.endpoints.organization_supergroup_details.make_supergroups_get_request"
+    )
+    def test_rca_source_invalid_param_falls_back_to_flag(self, mock_seer):
+        mock_seer.return_value = mock_seer_response({"id": 1, "title": "test"})
+
+        with self.feature("organizations:top-issues-ui"):
+            self.get_success_response(self.organization.slug, "1", rca_source="INVALID")
+
+        body = mock_seer.call_args.args[0]
+        assert body["rca_source"] == "EXPLORER"

--- a/tests/sentry/seer/supergroups/endpoints/test_organization_supergroups_by_group.py
+++ b/tests/sentry/seer/supergroups/endpoints/test_organization_supergroups_by_group.py
@@ -109,3 +109,35 @@ class OrganizationSupergroupsByGroupEndpointTest(APITestCase):
 
         body = mock_seer.call_args.args[0]
         assert body["rca_source"] == "LIGHTWEIGHT"
+
+    @patch(
+        "sentry.seer.supergroups.endpoints.organization_supergroups_by_group.make_supergroups_get_by_group_ids_request"
+    )
+    def test_rca_source_query_param_overrides_flag(self, mock_seer):
+        mock_seer.return_value = mock_seer_response({"data": []})
+
+        with self.feature("organizations:top-issues-ui"):
+            self.get_success_response(
+                self.organization.slug,
+                group_id=[self.unresolved_group.id],
+                rca_source="LIGHTWEIGHT",
+            )
+
+        body = mock_seer.call_args.args[0]
+        assert body["rca_source"] == "LIGHTWEIGHT"
+
+    @patch(
+        "sentry.seer.supergroups.endpoints.organization_supergroups_by_group.make_supergroups_get_by_group_ids_request"
+    )
+    def test_rca_source_invalid_param_falls_back_to_flag(self, mock_seer):
+        mock_seer.return_value = mock_seer_response({"data": []})
+
+        with self.feature("organizations:top-issues-ui"):
+            self.get_success_response(
+                self.organization.slug,
+                group_id=[self.unresolved_group.id],
+                rca_source="INVALID",
+            )
+
+        body = mock_seer.call_args.args[0]
+        assert body["rca_source"] == "EXPLORER"


### PR DESCRIPTION
## Summary
- Accept `rca_source` query param (`LIGHTWEIGHT` or `EXPLORER`) on both supergroup endpoints, falling back to the `-read` feature flag when not provided
- Frontend reads `supergroups-lightweight-rca-clustering-read` feature flag and passes the corresponding `rca_source` param
- Set `-read` flag to `api_expose=True` so it's visible to the frontend and toggleable via the Sentry toolbar

## Test plan
- [x] Backend tests for query param override and invalid param fallback (4 new tests)
- [x] Existing feature flag tests still pass (7 existing tests)
- [ ] Manual: toggle `-read` flag via toolbar → verify supergroups switch between sources