### PR TITLE
fix(claude integration): update to newest claude headers

### DIFF
--- a/src/sentry/integrations/claude_code/integration.py
+++ b/src/sentry/integrations/claude_code/integration.py
@@ -15,7 +15,7 @@ from typing import Any, Literal
 from django import forms
 from django.conf import settings as django_settings
 from django.utils.translation import gettext_lazy as _
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 
 from sentry.integrations.base import (
     FeatureDescription,
@@ -76,7 +76,15 @@ class ClaudeCodeIntegrationMetadata(BaseModel):
     environment_id: str | None = None
     workspace_name: str | None = "default"
     agent_id: str | None = None
-    agent_version: str | None = None
+    agent_version: int | None = None
+
+    @validator("agent_version", pre=True)
+    def coerce_agent_version(cls, v: object) -> int | None:
+        # Old SDK stored version as a timestamp string — drop it so the agent is recreated.
+        # New versions come from the API as integers, so any string value is stale.
+        if isinstance(v, str):
+            return None
+        return v  # type: ignore[return-value]
 
 
 metadata = IntegrationMetadata(

--- a/src/sentry/integrations/claude_code/utils.py
+++ b/src/sentry/integrations/claude_code/utils.py
@@ -9,10 +9,10 @@ from pydantic import BaseModel
 
 
 class ClaudeSessionEventStatus(StrEnum):
-    PENDING = "status_pending"
-    RUNNING = "status_running"
-    IDLE = "status_idle"
-    CLOSED = "status_closed"
+    RESCHEDULING = "session.status_rescheduling"
+    RUNNING = "session.status_running"
+    IDLE = "session.status_idle"
+    TERMINATED = "session.status_terminated"
 
 
 class ClaudeSessionEvent(BaseModel):

--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -690,7 +690,7 @@ def poll_claude_agent(clients, agent_id, org_id, agent_state: CodingAgentState) 
 
     if (
         last_event_type == ClaudeSessionEventStatus.IDLE
-        or last_event_type == ClaudeSessionEventStatus.CLOSED
+        or last_event_type == ClaudeSessionEventStatus.TERMINATED
     ):
         new_status = CodingAgentStatus.COMPLETED
 
@@ -715,7 +715,7 @@ def poll_claude_agent(clients, agent_id, org_id, agent_state: CodingAgentState) 
             },
         )
 
-    elif last_event_type == ClaudeSessionEventStatus.PENDING:
+    elif last_event_type == ClaudeSessionEventStatus.RESCHEDULING:
         if agent_state.status != CodingAgentStatus.PENDING:
             update_coding_agent_state(agent_id=agent_id, status=CodingAgentStatus.PENDING)
 
@@ -780,7 +780,7 @@ def extract_result_from_events(events: list[ClaudeSessionEvent]) -> tuple[str | 
     branch_pattern = re.compile(r"https://github\.com/[^/]+/[^/]+/tree/[-\w./]*[-\w]")
 
     for event in reversed(events):
-        if event.type != "agent":
+        if event.type != "agent.message":
             continue
         for block in getattr(event, "content", []):
             if isinstance(block, dict) and block.get("type") == "text":

--- a/tests/sentry/integrations/claude_code/test_integration.py
+++ b/tests/sentry/integrations/claude_code/test_integration.py
@@ -157,7 +157,7 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
                 environment_id="env-456",
                 workspace_name="my-ws",
                 agent_id="agent-123",
-                agent_version="v1",
+                agent_version=1,
             ),
         )
         installation = integration.get_installation(organization_id=self.organization.id)
@@ -171,7 +171,7 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
             environment_id="env-456",
             workspace_name="my-ws",
             agent_id="agent-123",
-            agent_version="v1",
+            agent_version=1,
         )
 
     def test_get_client_class_not_configured(self) -> None:
@@ -180,6 +180,27 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
         with self.settings(CLAUDE_CODE_CLIENT_CLASS=None):
             with pytest.raises(IntegrationConfigurationError, match="not configured"):
                 installation.get_client()
+
+    # ── agent_version coercion ───────────────────────────────────────
+
+    def test_agent_version_int_is_preserved(self) -> None:
+        installation = self._create_installation(agent_id="agent-123", agent_version=3)
+        metadata = installation._get_metadata()
+        assert metadata.agent_version == 3
+
+    def test_agent_version_old_timestamp_string_is_dropped(self) -> None:
+        # Old SDK stored version as a large timestamp string — should be coerced to None.
+        installation = self._create_installation(
+            agent_id="agent-123", agent_version="1772585501101368014"
+        )
+        metadata = installation._get_metadata()
+        assert metadata.agent_version is None
+        assert metadata.agent_id == "agent-123"
+
+    def test_agent_version_none_stays_none(self) -> None:
+        installation = self._create_installation()
+        metadata = installation._get_metadata()
+        assert metadata.agent_version is None
 
     # ── Property getters ─────────────────────────────────────────────
 
@@ -337,9 +358,9 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
             environment_id="env-same",
             client_environment_id="env-same",
             agent_id="agent-same",
-            agent_version="v-same",
+            agent_version=1,
             client_agent_id="agent-same",
-            client_agent_version="v-same",
+            client_agent_version=1,
         )
 
         with patch(MOCK_GET_CLIENT_CLASS, return_value=mock_cls):
@@ -354,7 +375,7 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
             environment_id="env-existing",
             client_environment_id=None,
             agent_id="agent-existing",
-            agent_version="v-existing",
+            agent_version=1,
             client_agent_id=None,
             client_agent_version=None,
         )
@@ -370,14 +391,14 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
         installation, mock_client, mock_cls, request = self._setup_launch(
             agent_id=None,
             client_agent_id="agent-new-123",
-            client_agent_version="v-new",
+            client_agent_version=2,
         )
 
         with patch(MOCK_GET_CLIENT_CLASS, return_value=mock_cls):
             installation.launch(request=request)
 
         assert installation.model.metadata["agent_id"] == "agent-new-123"
-        assert installation.model.metadata["agent_version"] == "v-new"
+        assert installation.model.metadata["agent_version"] == 2
 
     def test_launch_updates_both_environment_and_agent_when_changed(self) -> None:
         """When both IDs change, both should be persisted in a single update."""
@@ -386,7 +407,7 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
             client_environment_id="env-new",
             agent_id=None,
             client_agent_id="agent-new",
-            client_agent_version="v-new",
+            client_agent_version=2,
         )
 
         with patch(MOCK_GET_CLIENT_CLASS, return_value=mock_cls):
@@ -394,4 +415,4 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
 
         assert installation.model.metadata["environment_id"] == "env-new"
         assert installation.model.metadata["agent_id"] == "agent-new"
-        assert installation.model.metadata["agent_version"] == "v-new"
+        assert installation.model.metadata["agent_version"] == 2

--- a/tests/sentry/seer/autofix/test_coding_agent.py
+++ b/tests/sentry/seer/autofix/test_coding_agent.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from rest_framework.exceptions import PermissionDenied
 
-from sentry.integrations.claude_code.utils import ClaudeSessionEvent
+from sentry.integrations.claude_code.utils import ClaudeSessionEvent, ClaudeSessionEventStatus
 from sentry.integrations.cursor.integration import CursorAgentIntegration
 from sentry.integrations.github_copilot.models import (
     GithubCopilotArtifact,
@@ -703,7 +703,7 @@ MOCK_DJANGO_SETTINGS_PATH = "sentry.seer.autofix.coding_agent.django_settings"
 
 
 def _make_agent_event(text: str) -> ClaudeSessionEvent:
-    return ClaudeSessionEvent(type="agent", content=[{"type": "text", "text": text}])
+    return ClaudeSessionEvent(type="agent.message", content=[{"type": "text", "text": text}])
 
 
 class TestExtractResultFromEvents(TestCase):
@@ -891,7 +891,7 @@ class TestPollClaudeCodeAgents(TestCase):
         mock_client = MagicMock()
         mock_client.list_session_events.return_value = [
             {
-                "type": "agent",
+                "type": "agent.message",
                 "content": [
                     {
                         "type": "text",
@@ -899,7 +899,7 @@ class TestPollClaudeCodeAgents(TestCase):
                     }
                 ],
             },
-            {"type": "status_idle"},
+            {"type": ClaudeSessionEventStatus.IDLE},
         ]
         mock_client.build_result_from_session.return_value = MagicMock(
             pr_url="https://github.com/getsentry/sentry/pull/999"
@@ -925,8 +925,8 @@ class TestPollClaudeCodeAgents(TestCase):
         self._mock_integration(mock_integration_service)
         mock_client = MagicMock()
         mock_client.list_session_events.return_value = [
-            {"type": "agent", "content": [{"type": "text", "text": "Done, no PR."}]},
-            {"type": "status_idle"},
+            {"type": "agent.message", "content": [{"type": "text", "text": "Done, no PR."}]},
+            {"type": ClaudeSessionEventStatus.IDLE},
         ]
         mock_client.build_result_from_session.return_value = MagicMock(pr_url=None)
         mock_import_string.return_value = lambda **kwargs: mock_client
@@ -947,8 +947,8 @@ class TestPollClaudeCodeAgents(TestCase):
     ):
         self._mock_integration(mock_integration_service)
         mock_client = MagicMock()
-        # Last event is status_running — agent is already RUNNING, no update needed
-        mock_client.list_session_events.return_value = [{"type": "status_running"}]
+        # Last event is session.status_running — agent is already RUNNING, no update needed
+        mock_client.list_session_events.return_value = [{"type": ClaudeSessionEventStatus.RUNNING}]
         mock_import_string.return_value = lambda **kwargs: mock_client
 
         agents = {"claude-session-123": self._create_claude_agent()}
@@ -982,7 +982,7 @@ class TestPollClaudeCodeAgents(TestCase):
     ):
         self._mock_integration(mock_integration_service)
         mock_client = MagicMock()
-        mock_client.list_session_events.return_value = [{"type": "agent", "content": []}]
+        mock_client.list_session_events.return_value = [{"type": "agent.message", "content": []}]
         mock_import_string.return_value = lambda **kwargs: mock_client
 
         agents = {"claude-session-123": self._create_claude_agent(status=CodingAgentStatus.PENDING)}
@@ -996,12 +996,14 @@ class TestPollClaudeCodeAgents(TestCase):
     @patch(MOCK_UPDATE_STATE_PATH)
     @patch(MOCK_CLIENT_CLASS_PATH)
     @patch(MOCK_INTEGRATION_SERVICE_PATH)
-    def test_stays_pending_on_status_pending_event(
+    def test_stays_pending_on_status_rescheduling_event(
         self, mock_integration_service, mock_import_string, mock_update_state
     ):
         self._mock_integration(mock_integration_service)
         mock_client = MagicMock()
-        mock_client.list_session_events.return_value = [{"type": "status_pending"}]
+        mock_client.list_session_events.return_value = [
+            {"type": ClaudeSessionEventStatus.RESCHEDULING}
+        ]
         mock_import_string.return_value = lambda **kwargs: mock_client
 
         agents = {"claude-session-123": self._create_claude_agent(status=CodingAgentStatus.PENDING)}
@@ -1047,7 +1049,7 @@ class TestPollClaudeCodeAgents(TestCase):
 
         def make_client(**kwargs):
             client = MagicMock()
-            client.list_session_events.return_value = [{"type": "status_running"}]
+            client.list_session_events.return_value = [{"type": ClaudeSessionEventStatus.RUNNING}]
             clients[kwargs["api_key"]] = client
             return client
 
@@ -1087,7 +1089,7 @@ class TestPollClaudeCodeAgents(TestCase):
     ):
         self._mock_integration(mock_integration_service)
         mock_client = MagicMock()
-        mock_client.list_session_events.return_value = [{"type": "status_running"}]
+        mock_client.list_session_events.return_value = [{"type": ClaudeSessionEventStatus.RUNNING}]
         mock_import_string.return_value = lambda **kwargs: mock_client
 
         agent_a = self._create_claude_agent(agent_id="session-a")


### PR DESCRIPTION
Newest claude headers have changed statuses of claude sessions and event naming. The type of a field stored has also changed so have temporarily added a validator so that field will be cleared if received with the wrong type.