### PR TITLE
fix(explore): Derive default chart type for explore Slack unfurls

### DIFF
--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -153,9 +153,8 @@ def _unfurl_explore(
 
         chart_data: dict[str, Any] = {
             "timeSeries": resp.data.get("timeSeries", []),
+            "type": _resolve_display_type(chart_type, y_axes),
         }
-        if chart_type is not None:
-            chart_data["type"] = chart_type
 
         try:
             url = charts.generate_chart(style, chart_data, size=EXPLORE_CHART_SIZE)
@@ -189,6 +188,28 @@ CHART_TYPE_TO_DISPLAY_TYPE = {
     2: "area",
 }
 
+# Aggregates that default to bar charts in Explore's determineDefaultChartType.
+# All other aggregates default to line.
+_BAR_AGGREGATES = {"count", "count_unique", "sum"}
+
+
+def _resolve_display_type(chart_type: int | None, y_axes: list[str]) -> str:
+    """Return the display type string for the chart.
+
+    Uses the explicit chartType from the URL when present, otherwise
+    mirrors the frontend's ``determineDefaultChartType`` logic which
+    maps count/count_unique/sum aggregates to bar and everything else
+    to line.
+    """
+    if chart_type is not None:
+        return CHART_TYPE_TO_DISPLAY_TYPE.get(chart_type, "line")
+
+    for y_axis in y_axes:
+        func_name = y_axis.split("(")[0] if "(" in y_axis else ""
+        if func_name in _BAR_AGGREGATES:
+            return "bar"
+    return "line"
+
 
 def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[str, Any]:
     """
@@ -206,7 +227,7 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
     visualize_fields = raw_query.getlist("visualize") or raw_query.getlist("aggregateField")
     y_axes: list[str] = []
     group_bys: list[str] = []
-    chart_type: str | None = None
+    chart_type: int | None = None
     for field_json in visualize_fields:
         try:
             parsed = json.loads(field_json)
@@ -215,7 +236,7 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
             if "groupBy" in parsed and parsed["groupBy"]:
                 group_bys.append(parsed["groupBy"])
             if chart_type is None and "chartType" in parsed:
-                chart_type = CHART_TYPE_TO_DISPLAY_TYPE.get(parsed["chartType"])
+                chart_type = parsed["chartType"]
         except (json.JSONDecodeError, TypeError):
             continue
 

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -235,7 +235,7 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
                 y_axes.extend(parsed["yAxes"])
             if "groupBy" in parsed and parsed["groupBy"]:
                 group_bys.append(parsed["groupBy"])
-            if chart_type is None and "chartType" in parsed:
+            if chart_type is None and isinstance(parsed.get("chartType"), int):
                 chart_type = parsed["chartType"]
         except (json.JSONDecodeError, TypeError):
             continue

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -15,6 +15,7 @@ from sentry.integrations.slack.message_builder.issues import SlackIssuesMessageB
 from sentry.integrations.slack.message_builder.metric_alerts import SlackMetricAlertMessageBuilder
 from sentry.integrations.slack.unfurl.handlers import link_handlers, match_link
 from sentry.integrations.slack.unfurl.types import LinkType, UnfurlableUrl
+from sentry.search.eap.types import SupportedTraceItemType
 from sentry.snuba import discover, errors, transactions
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import SnubaQueryEventType
@@ -199,7 +200,7 @@ INTERVALS_PER_DAY = int(60 * 60 * 24 / INTERVAL_COUNT)
                     "org_slug": "org1",
                     "query": QueryDict("yAxis=avg(span.duration)&project=1&statsPeriod=24h"),
                     "chart_type": None,
-                    "dataset": "spans",
+                    "dataset": SupportedTraceItemType.SPANS,
                 },
             ),
         ),
@@ -211,7 +212,7 @@ INTERVALS_PER_DAY = int(60 * 60 * 24 / INTERVAL_COUNT)
                     "org_slug": "org1",
                     "query": QueryDict("yAxis=count(span.duration)&statsPeriod=24h"),
                     "chart_type": None,
-                    "dataset": "spans",
+                    "dataset": SupportedTraceItemType.SPANS,
                 },
             ),
         ),
@@ -223,7 +224,7 @@ INTERVALS_PER_DAY = int(60 * 60 * 24 / INTERVAL_COUNT)
                     "org_slug": "org1",
                     "query": QueryDict("yAxis=sum(payload_size)&project=1&statsPeriod=24h"),
                     "chart_type": None,
-                    "dataset": "logs",
+                    "dataset": SupportedTraceItemType.LOGS,
                 },
             ),
         ),
@@ -235,7 +236,7 @@ INTERVALS_PER_DAY = int(60 * 60 * 24 / INTERVAL_COUNT)
                     "org_slug": "org1",
                     "query": QueryDict("yAxis=count(payload_size)&statsPeriod=24h"),
                     "chart_type": None,
-                    "dataset": "logs",
+                    "dataset": SupportedTraceItemType.LOGS,
                 },
             ),
         ),
@@ -1766,10 +1767,11 @@ class UnfurlTest(TestCase):
         "sentry.integrations.slack.unfurl.explore.client.get",
     )
     @patch("sentry.charts.backend.generate_chart", return_value="chart-url")
-    def test_unfurl_explore_without_chart_type_omits_type(
+    def test_unfurl_explore_without_chart_type_defaults_to_line(
         self, mock_generate_chart: MagicMock, mock_client_get: MagicMock
     ) -> None:
         mock_client_get.return_value = MagicMock(data=self._build_mock_timeseries_response())
+        # avg() is not a bar aggregate, so should default to line
         url = f"https://sentry.io/organizations/{self.organization.slug}/explore/traces/?aggregateField=%7B%22yAxes%22%3A%5B%22avg(span.duration)%22%5D%7D&project={self.project.id}&statsPeriod=24h"
         link_type, args = match_link(url)
 
@@ -1785,7 +1787,35 @@ class UnfurlTest(TestCase):
 
         assert len(unfurls) == 1
         chart_data = mock_generate_chart.call_args[0][1]
-        assert "type" not in chart_data
+        assert chart_data["type"] == "line"
+
+    @patch(
+        "sentry.integrations.slack.unfurl.explore.client.get",
+    )
+    @patch("sentry.charts.backend.generate_chart", return_value="chart-url")
+    def test_unfurl_explore_without_chart_type_count_defaults_to_bar(
+        self, mock_generate_chart: MagicMock, mock_client_get: MagicMock
+    ) -> None:
+        mock_client_get.return_value = MagicMock(
+            data=self._build_mock_timeseries_response(y_axis="count(span.duration)")
+        )
+        # count() should default to bar
+        url = f"https://sentry.io/organizations/{self.organization.slug}/explore/traces/?aggregateField=%7B%22yAxes%22%3A%5B%22count(span.duration)%22%5D%7D&project={self.project.id}&statsPeriod=24h"
+        link_type, args = match_link(url)
+
+        if not args or not link_type:
+            raise AssertionError("Missing link_type/args")
+
+        links = [
+            UnfurlableUrl(url=url, args=args),
+        ]
+
+        with self.feature(["organizations:data-browsing-widget-unfurl"]):
+            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+
+        assert len(unfurls) == 1
+        chart_data = mock_generate_chart.call_args[0][1]
+        assert chart_data["type"] == "bar"
 
     @patch(
         "sentry.integrations.slack.unfurl.explore.client.get",
@@ -1830,7 +1860,7 @@ class UnfurlTest(TestCase):
 
         assert link_type == LinkType.EXPLORE
         assert args["dataset"] == "logs"
-        assert args["chart_type"] == "bar"
+        assert args["chart_type"] == 0
 
         links = [
             UnfurlableUrl(url=url, args=args),


### PR DESCRIPTION
When no explicit `chartType` is in the URL, the Slack unfurl always
rendered a line chart. But Explore defaults `count`/`count_unique`/`sum`
aggregates to bar charts and everything else to line.

Adds `_resolve_display_type(chart_type, y_axes)` which uses the URL's
`chartType` when present and otherwise derives the default from the
aggregate function name, matching the frontend's `determineDefaultChartType`.

Also stores `chart_type` as the raw int from the URL (instead of
pre-converting to a string) so the helper handles the full mapping.

Fixes DAIN-1495