### PR TITLE
feat(settings): Move Repositories sidebar link into the new Integrations section

### DIFF
--- a/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
+++ b/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
@@ -141,12 +141,6 @@ export function getUserOrgNavigationConfiguration(): NavigationSection[] {
           id: 'relay',
         },
         {
-          path: `${organizationSettingsPathPrefix}/repos/`,
-          title: t('Repositories'),
-          description: t('Manage repositories connected to the organization'),
-          id: 'repos',
-        },
-        {
           path: `${organizationSettingsPathPrefix}/early-features/`,
           title: t('Early Features'),
           description: t('Manage early access features'),
@@ -203,6 +197,13 @@ export function getUserOrgNavigationConfiguration(): NavigationSection[] {
             'Manage organization-level integrations, including: Slack, GitHub, Bitbucket, Jira, and Azure DevOps'
           ),
           id: 'integrations',
+          recordAnalytics: true,
+        },
+        {
+          path: `${organizationSettingsPathPrefix}/repos/`,
+          title: t('Repositories'),
+          description: t('Manage repositories connected to the organization'),
+          id: 'repos',
           recordAnalytics: true,
         },
         {


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="197" height="441" alt="Screenshot 2026-04-10 at 12 21 53 PM" src="https://github.com/user-attachments/assets/e810fe9e-2009-40cb-8646-82fcaace2c44" /> | <img width="197" height="441" alt="Screenshot 2026-04-10 at 12 19 48 PM" src="https://github.com/user-attachments/assets/4b39a85e-3445-4f51-9fc3-95fb538e6b60" />
