### PR TITLE
fix(autofix): Check preference repositories instead of tuning for Seer autofix onboarding check

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_onboarding_check.py
+++ b/src/sentry/seer/endpoints/organization_seer_onboarding_check.py
@@ -59,9 +59,7 @@ def is_autofix_enabled(organization: Organization) -> bool:
     """
     if features.has("organizations:seer-project-settings-read-from-sentry", organization):
         return SeerProjectRepository.objects.filter(
-            project__organization_id=organization.id,
-            project__status=ObjectStatus.ACTIVE,
-            repository__status=ObjectStatus.ACTIVE,
+            project__organization_id=organization.id, project__status=ObjectStatus.ACTIVE
         ).exists()
 
     project_ids = list(

--- a/src/sentry/seer/endpoints/organization_seer_onboarding_check.py
+++ b/src/sentry/seer/endpoints/organization_seer_onboarding_check.py
@@ -5,7 +5,7 @@ import logging
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import options
+from sentry import features, options
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -13,11 +13,13 @@ from sentry.api.bases.organization import OrganizationEndpoint
 from sentry.constants import ObjectStatus
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import IntegrationProviderSlug
-from sentry.models.options.project_option import ProjectOption
 from sentry.models.organization import Organization
+from sentry.models.project import Project
 from sentry.models.repositorysettings import RepositorySettings
 from sentry.ratelimits.config import RateLimitConfig
-from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
+from sentry.seer.autofix.utils import get_project_seer_preferences
+from sentry.seer.models.project_repository import SeerProjectRepository
+from sentry.seer.models.seer_api_models import SeerApiError, SeerApiResponseValidationError
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 logger = logging.getLogger(__name__)
@@ -50,21 +52,34 @@ def is_code_review_enabled(organization_id: int) -> bool:
     ).exists()
 
 
-def is_autofix_enabled(organization_id: int) -> bool:
+def is_autofix_enabled(organization: Organization) -> bool:
     """
     Check if autofix/RCA is enabled for any active project in the organization,
-    ie, if any project has sentry:autofix_automation_tuning not set to "off" or None.
+    ie, if any project has repositories configured in Seer preferences.
     """
-    return (
-        ProjectOption.objects.filter(
-            project__organization_id=organization_id,
+    if features.has("organizations:seer-project-settings-read-from-sentry", organization):
+        return SeerProjectRepository.objects.filter(
+            project__organization_id=organization.id,
             project__status=ObjectStatus.ACTIVE,
-            key="sentry:autofix_automation_tuning",
-        )
-        .exclude(value=AutofixAutomationTuningSettings.OFF.value)
-        .exclude(value__isnull=True)
-        .exists()
+            repository__status=ObjectStatus.ACTIVE,
+        ).exists()
+
+    project_ids = list(
+        Project.objects.filter(
+            organization_id=organization.id,
+            status=ObjectStatus.ACTIVE,
+        ).values_list("id", flat=True)
     )
+
+    for project_id in project_ids:
+        try:
+            preference = get_project_seer_preferences(project_id).preference
+            if preference and preference.repositories:
+                return True
+        except (SeerApiError, SeerApiResponseValidationError):
+            pass
+
+    return False
 
 
 @cell_silo_endpoint
@@ -90,7 +105,7 @@ class OrganizationSeerOnboardingCheck(OrganizationEndpoint):
         """Check if the organization has completed Seer onboarding/configuration."""
         has_scm_integration = has_supported_scm_integration(organization.id)
         code_review_enabled = is_code_review_enabled(organization.id)
-        autofix_enabled = is_autofix_enabled(organization.id)
+        autofix_enabled = is_autofix_enabled(organization)
         needs_config_reminder = is_in_seer_config_reminder_list(organization)
         is_seer_configured = has_scm_integration and (code_review_enabled or autofix_enabled)
 

--- a/src/sentry/seer/endpoints/organization_seer_onboarding_check.py
+++ b/src/sentry/seer/endpoints/organization_seer_onboarding_check.py
@@ -17,9 +17,9 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.repositorysettings import RepositorySettings
 from sentry.ratelimits.config import RateLimitConfig
-from sentry.seer.autofix.utils import get_project_seer_preferences
+from sentry.seer.autofix.utils import bulk_get_project_preferences
 from sentry.seer.models.project_repository import SeerProjectRepository
-from sentry.seer.models.seer_api_models import SeerApiError, SeerApiResponseValidationError
+from sentry.seer.models.seer_api_models import SeerApiError
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 
 logger = logging.getLogger(__name__)
@@ -69,15 +69,14 @@ def is_autofix_enabled(organization: Organization) -> bool:
         ).values_list("id", flat=True)
     )
 
-    for project_id in project_ids:
-        try:
-            preference = get_project_seer_preferences(project_id).preference
-            if preference and preference.repositories:
-                return True
-        except (SeerApiError, SeerApiResponseValidationError):
-            pass
+    if not project_ids:
+        return False
 
-    return False
+    try:
+        preferences = bulk_get_project_preferences(organization.id, project_ids)
+        return any(pref and pref.get("repositories") for pref in preferences.values())
+    except SeerApiError:
+        return False
 
 
 @cell_silo_endpoint

--- a/src/sentry/seer/endpoints/organization_seer_onboarding_check.py
+++ b/src/sentry/seer/endpoints/organization_seer_onboarding_check.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 
+from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -72,11 +73,8 @@ def is_autofix_enabled(organization: Organization) -> bool:
     if not project_ids:
         return False
 
-    try:
-        preferences = bulk_get_project_preferences(organization.id, project_ids)
-        return any(pref and pref.get("repositories") for pref in preferences.values())
-    except SeerApiError:
-        return False
+    preferences = bulk_get_project_preferences(organization.id, project_ids)
+    return any(pref and pref.get("repositories") for pref in preferences.values())
 
 
 @cell_silo_endpoint
@@ -102,7 +100,19 @@ class OrganizationSeerOnboardingCheck(OrganizationEndpoint):
         """Check if the organization has completed Seer onboarding/configuration."""
         has_scm_integration = has_supported_scm_integration(organization.id)
         code_review_enabled = is_code_review_enabled(organization.id)
-        autofix_enabled = is_autofix_enabled(organization)
+
+        try:
+            autofix_enabled = is_autofix_enabled(organization)
+        except SeerApiError as e:
+            logger.exception(
+                "seer.onboarding_check.autofix_check_error",
+                extra={"organization_id": organization.id, "status_code": e.status},
+            )
+            return Response(
+                {"detail": "Failed to check autofix status"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
         needs_config_reminder = is_in_seer_config_reminder_list(organization)
         is_seer_configured = has_scm_integration and (code_review_enabled or autofix_enabled)
 

--- a/src/sentry/seer/endpoints/organization_seer_onboarding_check.py
+++ b/src/sentry/seer/endpoints/organization_seer_onboarding_check.py
@@ -98,9 +98,6 @@ class OrganizationSeerOnboardingCheck(OrganizationEndpoint):
 
     def get(self, request: Request, organization: Organization) -> Response:
         """Check if the organization has completed Seer onboarding/configuration."""
-        has_scm_integration = has_supported_scm_integration(organization.id)
-        code_review_enabled = is_code_review_enabled(organization.id)
-
         try:
             autofix_enabled = is_autofix_enabled(organization)
         except SeerApiError as e:
@@ -112,7 +109,8 @@ class OrganizationSeerOnboardingCheck(OrganizationEndpoint):
                 {"detail": "Failed to check autofix status"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
-
+        has_scm_integration = has_supported_scm_integration(organization.id)
+        code_review_enabled = is_code_review_enabled(organization.id)
         needs_config_reminder = is_in_seer_config_reminder_list(organization)
         is_seer_configured = has_scm_integration and (code_review_enabled or autofix_enabled)
 

--- a/tests/sentry/seer/endpoints/test_organization_seer_onboarding_check.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_onboarding_check.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
 from sentry.constants import ObjectStatus
-from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
 from sentry.seer.endpoints.organization_seer_onboarding_check import (
     has_supported_scm_integration,
     is_autofix_enabled,
     is_code_review_enabled,
 )
+from sentry.seer.models.project_repository import SeerProjectRepository
+from sentry.seer.models.seer_api_models import SeerApiError
 from sentry.testutils.cases import APITestCase, TestCase
+from sentry.testutils.helpers import with_feature
 
 
 class TestHasSupportedScmIntegration(TestCase):
@@ -145,89 +149,115 @@ class TestIsCodeReviewEnabled(TestCase):
         assert not is_code_review_enabled(org2.id)
 
 
+@with_feature("organizations:seer-project-settings-read-from-sentry")
 class TestIsAutofixEnabled(TestCase):
     """Unit tests for is_autofix_enabled()"""
 
-    def test_no_option_set(self) -> None:
-        assert not is_autofix_enabled(self.organization.id)
+    def setUp(self) -> None:
+        super().setUp()
+        self.project = self.create_project(organization=self.organization)
 
-    def test_with_autofix_low(self) -> None:
-        self.project.update_option(
-            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.LOW.value
-        )
-        assert is_autofix_enabled(self.organization.id)
+    def test_no_repositories(self) -> None:
+        assert not is_autofix_enabled(self.organization)
 
-    def test_with_autofix_medium(self) -> None:
-        self.project.update_option(
-            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM.value
-        )
-        assert is_autofix_enabled(self.organization.id)
+    def test_with_repository(self) -> None:
+        repo = self.create_repo(project=self.project)
+        SeerProjectRepository.objects.create(project=self.project, repository=repo)
 
-    def test_with_autofix_high(self) -> None:
-        self.project.update_option(
-            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.HIGH.value
-        )
-        assert is_autofix_enabled(self.organization.id)
-
-    def test_with_autofix_off(self) -> None:
-        self.project.update_option(
-            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.OFF.value
-        )
-        assert not is_autofix_enabled(self.organization.id)
-
-    def test_with_autofix_none(self) -> None:
-        self.project.update_option("sentry:autofix_automation_tuning", None)
-        assert not is_autofix_enabled(self.organization.id)
+        assert is_autofix_enabled(self.organization)
 
     def test_no_projects(self) -> None:
+        repo = self.create_repo(project=self.project)
+        SeerProjectRepository.objects.create(project=self.project, repository=repo)
+
         org_without_projects = self.create_organization()
-        assert not is_autofix_enabled(org_without_projects.id)
+
+        assert not is_autofix_enabled(org_without_projects)
 
     def test_inactive_project(self) -> None:
         inactive_project = self.create_project(
             organization=self.organization, status=ObjectStatus.DISABLED
         )
-        inactive_project.update_option(
-            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.HIGH.value
-        )
+        repo = self.create_repo(project=inactive_project)
+        SeerProjectRepository.objects.create(project=inactive_project, repository=repo)
 
-        assert not is_autofix_enabled(self.organization.id)
+        assert not is_autofix_enabled(self.organization)
 
     def test_multiple_projects(self) -> None:
         project1 = self.create_project(organization=self.organization)
-        project2 = self.create_project(organization=self.organization)
-        project3 = self.create_project(organization=self.organization)
+        self.create_project(organization=self.organization)
 
-        project1.update_option(
-            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM.value
-        )
-        project2.update_option(
-            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.OFF.value
-        )
-        project3.update_option(
-            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.OFF.value
-        )
+        repo = self.create_repo(project=project1)
+        SeerProjectRepository.objects.create(project=project1, repository=repo)
 
-        assert is_autofix_enabled(self.organization.id)
+        assert is_autofix_enabled(self.organization)
 
     def test_multiple_organizations(self) -> None:
-        org1 = self.organization
         org2 = self.create_organization()
 
-        project1 = self.create_project(organization=org1)
-        project2 = self.create_project(organization=org2)
+        project1 = self.create_project(organization=self.organization)
+        self.create_project(organization=org2)
 
-        project1.update_option(
-            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.HIGH.value
-        )
-        project2.update_option(
-            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.OFF.value
-        )
+        repo = self.create_repo(project=project1)
+        SeerProjectRepository.objects.create(project=project1, repository=repo)
 
-        assert is_autofix_enabled(org1.id)
-        assert not is_autofix_enabled(org2.id)
+        assert is_autofix_enabled(self.organization)
+        assert not is_autofix_enabled(org2)
 
 
+class TestIsAutofixEnabledSeerApi(TestCase):
+    """Unit tests for is_autofix_enabled() without dual-read flag (calls Seer API)"""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.project = self.create_project(organization=self.organization)
+
+    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.get_project_seer_preferences")
+    def test_no_projects(self, mock_get_prefs: MagicMock) -> None:
+        org_without_projects = self.create_organization()
+        assert not is_autofix_enabled(org_without_projects)
+        mock_get_prefs.assert_not_called()
+
+    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.get_project_seer_preferences")
+    def test_project_with_repositories(self, mock_get_prefs: MagicMock) -> None:
+        mock_get_prefs.return_value = MagicMock(preference=MagicMock(repositories=[MagicMock()]))
+        assert is_autofix_enabled(self.organization)
+
+    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.get_project_seer_preferences")
+    def test_project_with_empty_repositories(self, mock_get_prefs: MagicMock) -> None:
+        mock_get_prefs.return_value = MagicMock(preference=MagicMock(repositories=[]))
+        assert not is_autofix_enabled(self.organization)
+
+    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.get_project_seer_preferences")
+    def test_project_with_no_preference(self, mock_get_prefs: MagicMock) -> None:
+        mock_get_prefs.return_value = MagicMock(preference=None)
+        assert not is_autofix_enabled(self.organization)
+
+    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.get_project_seer_preferences")
+    def test_multiple_projects(self, mock_get_prefs: MagicMock) -> None:
+        project2 = self.create_project(organization=self.organization)
+
+        def side_effect(project_id):
+            if project_id == project2.id:
+                return MagicMock(preference=MagicMock(repositories=[MagicMock()]))
+            return MagicMock(preference=None)
+
+        mock_get_prefs.side_effect = side_effect
+        assert is_autofix_enabled(self.organization)
+
+    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.get_project_seer_preferences")
+    def test_api_error_returns_false(self, mock_get_prefs: MagicMock) -> None:
+        mock_get_prefs.side_effect = SeerApiError("error", 500)
+        assert not is_autofix_enabled(self.organization)
+
+    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.get_project_seer_preferences")
+    def test_inactive_project_excluded(self, mock_get_prefs: MagicMock) -> None:
+        self.project.update(status=ObjectStatus.DISABLED)
+        assert not is_autofix_enabled(self.organization)
+        mock_get_prefs.assert_not_called()
+
+
+@patch("sentry.seer.endpoints.organization_seer_onboarding_check.get_project_seer_preferences")
 class OrganizationSeerOnboardingCheckTest(APITestCase):
     """Integration tests for the GET endpoint"""
 
@@ -236,12 +266,26 @@ class OrganizationSeerOnboardingCheckTest(APITestCase):
     def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
+        self.project = self.create_project(organization=self.organization)
 
     def get_response(self, organization_slug, **kwargs):
         url = f"/api/0/organizations/{organization_slug}/seer/onboarding-check/"
         return self.client.get(url, format="json", **kwargs)
 
-    def test_nothing_configured(self) -> None:
+    def _mock_has_repos(self, mock_get_prefs: MagicMock) -> None:
+        mock_preference = MagicMock()
+        mock_preference.repositories = [MagicMock()]
+        mock_response = MagicMock()
+        mock_response.preference = mock_preference
+        mock_get_prefs.return_value = mock_response
+
+    def _mock_no_repos(self, mock_get_prefs: MagicMock) -> None:
+        mock_response = MagicMock()
+        mock_response.preference = None
+        mock_get_prefs.return_value = mock_response
+
+    def test_nothing_configured(self, mock_get_prefs: MagicMock) -> None:
+        self._mock_no_repos(mock_get_prefs)
         response = self.get_response(self.organization.slug)
 
         assert response.status_code == 200
@@ -253,7 +297,9 @@ class OrganizationSeerOnboardingCheckTest(APITestCase):
             "isSeerConfigured": False,
         }
 
-    def test_all_configured(self) -> None:
+    def test_all_configured(self, mock_get_prefs: MagicMock) -> None:
+        self._mock_has_repos(mock_get_prefs)
+
         self.create_integration(
             organization=self.organization,
             provider="github",
@@ -265,10 +311,6 @@ class OrganizationSeerOnboardingCheckTest(APITestCase):
         self.create_repository_settings(
             repository=repo,
             enabled_code_review=True,
-        )
-
-        self.project.update_option(
-            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.HIGH.value
         )
 
         response = self.get_response(self.organization.slug)
@@ -282,7 +324,9 @@ class OrganizationSeerOnboardingCheckTest(APITestCase):
             "isSeerConfigured": True,
         }
 
-    def test_github_integration_only(self) -> None:
+    def test_github_integration_only(self, mock_get_prefs: MagicMock) -> None:
+        self._mock_no_repos(mock_get_prefs)
+
         self.create_integration(
             organization=self.organization,
             provider="github",
@@ -301,7 +345,9 @@ class OrganizationSeerOnboardingCheckTest(APITestCase):
             "isSeerConfigured": False,
         }
 
-    def test_code_review_enabled_only(self) -> None:
+    def test_code_review_enabled_only(self, mock_get_prefs: MagicMock) -> None:
+        self._mock_no_repos(mock_get_prefs)
+
         repo = self.create_repo(project=self.project)
         self.create_repository_settings(
             repository=repo,
@@ -319,10 +365,8 @@ class OrganizationSeerOnboardingCheckTest(APITestCase):
             "isSeerConfigured": False,
         }
 
-    def test_autofix_enabled_only(self) -> None:
-        self.project.update_option(
-            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.HIGH.value
-        )
+    def test_autofix_enabled_only(self, mock_get_prefs: MagicMock) -> None:
+        self._mock_has_repos(mock_get_prefs)
 
         response = self.get_response(self.organization.slug)
 
@@ -335,7 +379,9 @@ class OrganizationSeerOnboardingCheckTest(APITestCase):
             "isSeerConfigured": False,
         }
 
-    def test_github_and_code_review_enabled(self) -> None:
+    def test_github_and_code_review_enabled(self, mock_get_prefs: MagicMock) -> None:
+        self._mock_no_repos(mock_get_prefs)
+
         self.create_integration(
             organization=self.organization,
             provider="github",
@@ -360,16 +406,14 @@ class OrganizationSeerOnboardingCheckTest(APITestCase):
             "isSeerConfigured": True,
         }
 
-    def test_github_and_autofix_enabled(self) -> None:
+    def test_github_and_autofix_enabled(self, mock_get_prefs: MagicMock) -> None:
+        self._mock_has_repos(mock_get_prefs)
+
         self.create_integration(
             organization=self.organization,
             provider="github",
             name="GitHub Test",
             external_id="123",
-        )
-
-        self.project.update_option(
-            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.HIGH.value
         )
 
         response = self.get_response(self.organization.slug)
@@ -383,15 +427,13 @@ class OrganizationSeerOnboardingCheckTest(APITestCase):
             "isSeerConfigured": True,
         }
 
-    def test_code_review_and_autofix_enabled(self) -> None:
+    def test_code_review_and_autofix_enabled(self, mock_get_prefs: MagicMock) -> None:
+        self._mock_has_repos(mock_get_prefs)
+
         repo = self.create_repo(project=self.project)
         self.create_repository_settings(
             repository=repo,
             enabled_code_review=True,
-        )
-
-        self.project.update_option(
-            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.HIGH.value
         )
 
         response = self.get_response(self.organization.slug)
@@ -405,8 +447,10 @@ class OrganizationSeerOnboardingCheckTest(APITestCase):
             "isSeerConfigured": False,
         }
 
-    def test_needs_config_reminder_forces_configured(self) -> None:
+    def test_needs_config_reminder_forces_configured(self, mock_get_prefs: MagicMock) -> None:
         """When org is in force-config-reminder list, needsConfigReminder is True but isSeerConfigured follows normal logic."""
+        self._mock_no_repos(mock_get_prefs)
+
         with self.options({"seer.organizations.force-config-reminder": [self.organization.slug]}):
             response = self.get_response(self.organization.slug)
 
@@ -419,8 +463,10 @@ class OrganizationSeerOnboardingCheckTest(APITestCase):
                 "isSeerConfigured": False,
             }
 
-    def test_needs_config_reminder_with_scm_integration(self) -> None:
+    def test_needs_config_reminder_with_scm_integration(self, mock_get_prefs: MagicMock) -> None:
         """When org is in config reminder list with SCM integration but no code review/autofix, isSeerConfigured is False."""
+        self._mock_no_repos(mock_get_prefs)
+
         self.create_integration(
             organization=self.organization,
             provider="github",
@@ -440,8 +486,10 @@ class OrganizationSeerOnboardingCheckTest(APITestCase):
                 "isSeerConfigured": False,
             }
 
-    def test_not_in_config_reminder_list(self) -> None:
+    def test_not_in_config_reminder_list(self, mock_get_prefs: MagicMock) -> None:
         """When org is not in config reminder list, isSeerConfigured follows normal logic."""
+        self._mock_no_repos(mock_get_prefs)
+
         with self.options({"seer.organizations.force-config-reminder": ["other-org"]}):
             response = self.get_response(self.organization.slug)
 
@@ -454,9 +502,11 @@ class OrganizationSeerOnboardingCheckTest(APITestCase):
                 "isSeerConfigured": False,
             }
 
-    def test_config_reminder_with_complete_setup(self) -> None:
+    def test_config_reminder_with_complete_setup(self, mock_get_prefs: MagicMock) -> None:
         """Config reminder flag is independent of isSeerConfigured logic."""
         # Set up SCM and code review
+        self._mock_no_repos(mock_get_prefs)
+
         self.create_integration(
             organization=self.organization,
             provider="github",

--- a/tests/sentry/seer/endpoints/test_organization_seer_onboarding_check.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_onboarding_check.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from sentry.constants import ObjectStatus
 from sentry.seer.endpoints.organization_seer_onboarding_check import (
     has_supported_scm_integration,
@@ -243,9 +245,10 @@ class TestIsAutofixEnabledSeerApi(TestCase):
         assert is_autofix_enabled(self.organization)
 
     @patch("sentry.seer.endpoints.organization_seer_onboarding_check.bulk_get_project_preferences")
-    def test_api_error_returns_false(self, mock_bulk_get: MagicMock) -> None:
+    def test_api_error_raises(self, mock_bulk_get: MagicMock) -> None:
         mock_bulk_get.side_effect = SeerApiError("error", 500)
-        assert not is_autofix_enabled(self.organization)
+        with pytest.raises(SeerApiError):
+            is_autofix_enabled(self.organization)
 
     @patch("sentry.seer.endpoints.organization_seer_onboarding_check.bulk_get_project_preferences")
     def test_inactive_project_excluded(self, mock_bulk_get: MagicMock) -> None:
@@ -496,6 +499,14 @@ class OrganizationSeerOnboardingCheckTest(APITestCase):
                 "needsConfigReminder": False,
                 "isSeerConfigured": False,
             }
+
+    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.bulk_get_project_preferences")
+    def test_seer_api_error_returns_500(self, mock_bulk_get: MagicMock) -> None:
+        mock_bulk_get.side_effect = SeerApiError("error", 500)
+        response = self.get_response(self.organization.slug)
+
+        assert response.status_code == 500
+        assert response.data == {"detail": "Failed to check autofix status"}
 
     @patch("sentry.seer.endpoints.organization_seer_onboarding_check.bulk_get_project_preferences")
     def test_config_reminder_with_complete_setup(self, mock_bulk_get: MagicMock) -> None:

--- a/tests/sentry/seer/endpoints/test_organization_seer_onboarding_check.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_onboarding_check.py
@@ -212,52 +212,48 @@ class TestIsAutofixEnabledSeerApi(TestCase):
         super().setUp()
         self.project = self.create_project(organization=self.organization)
 
-    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.get_project_seer_preferences")
-    def test_no_projects(self, mock_get_prefs: MagicMock) -> None:
+    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.bulk_get_project_preferences")
+    def test_no_projects(self, mock_bulk_get: MagicMock) -> None:
         org_without_projects = self.create_organization()
         assert not is_autofix_enabled(org_without_projects)
-        mock_get_prefs.assert_not_called()
+        mock_bulk_get.assert_not_called()
 
-    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.get_project_seer_preferences")
-    def test_project_with_repositories(self, mock_get_prefs: MagicMock) -> None:
-        mock_get_prefs.return_value = MagicMock(preference=MagicMock(repositories=[MagicMock()]))
+    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.bulk_get_project_preferences")
+    def test_project_with_repositories(self, mock_bulk_get: MagicMock) -> None:
+        mock_bulk_get.return_value = {str(self.project.id): {"repositories": [{"name": "repo"}]}}
         assert is_autofix_enabled(self.organization)
 
-    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.get_project_seer_preferences")
-    def test_project_with_empty_repositories(self, mock_get_prefs: MagicMock) -> None:
-        mock_get_prefs.return_value = MagicMock(preference=MagicMock(repositories=[]))
+    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.bulk_get_project_preferences")
+    def test_project_with_empty_repositories(self, mock_bulk_get: MagicMock) -> None:
+        mock_bulk_get.return_value = {str(self.project.id): {"repositories": []}}
         assert not is_autofix_enabled(self.organization)
 
-    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.get_project_seer_preferences")
-    def test_project_with_no_preference(self, mock_get_prefs: MagicMock) -> None:
-        mock_get_prefs.return_value = MagicMock(preference=None)
+    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.bulk_get_project_preferences")
+    def test_project_with_no_preference(self, mock_bulk_get: MagicMock) -> None:
+        mock_bulk_get.return_value = {str(self.project.id): None}
         assert not is_autofix_enabled(self.organization)
 
-    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.get_project_seer_preferences")
-    def test_multiple_projects(self, mock_get_prefs: MagicMock) -> None:
+    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.bulk_get_project_preferences")
+    def test_multiple_projects(self, mock_bulk_get: MagicMock) -> None:
         project2 = self.create_project(organization=self.organization)
-
-        def side_effect(project_id):
-            if project_id == project2.id:
-                return MagicMock(preference=MagicMock(repositories=[MagicMock()]))
-            return MagicMock(preference=None)
-
-        mock_get_prefs.side_effect = side_effect
+        mock_bulk_get.return_value = {
+            str(self.project.id): None,
+            str(project2.id): {"repositories": [{"name": "repo"}]},
+        }
         assert is_autofix_enabled(self.organization)
 
-    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.get_project_seer_preferences")
-    def test_api_error_returns_false(self, mock_get_prefs: MagicMock) -> None:
-        mock_get_prefs.side_effect = SeerApiError("error", 500)
+    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.bulk_get_project_preferences")
+    def test_api_error_returns_false(self, mock_bulk_get: MagicMock) -> None:
+        mock_bulk_get.side_effect = SeerApiError("error", 500)
         assert not is_autofix_enabled(self.organization)
 
-    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.get_project_seer_preferences")
-    def test_inactive_project_excluded(self, mock_get_prefs: MagicMock) -> None:
+    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.bulk_get_project_preferences")
+    def test_inactive_project_excluded(self, mock_bulk_get: MagicMock) -> None:
         self.project.update(status=ObjectStatus.DISABLED)
         assert not is_autofix_enabled(self.organization)
-        mock_get_prefs.assert_not_called()
+        mock_bulk_get.assert_not_called()
 
 
-@patch("sentry.seer.endpoints.organization_seer_onboarding_check.get_project_seer_preferences")
 class OrganizationSeerOnboardingCheckTest(APITestCase):
     """Integration tests for the GET endpoint"""
 
@@ -272,20 +268,9 @@ class OrganizationSeerOnboardingCheckTest(APITestCase):
         url = f"/api/0/organizations/{organization_slug}/seer/onboarding-check/"
         return self.client.get(url, format="json", **kwargs)
 
-    def _mock_has_repos(self, mock_get_prefs: MagicMock) -> None:
-        mock_preference = MagicMock()
-        mock_preference.repositories = [MagicMock()]
-        mock_response = MagicMock()
-        mock_response.preference = mock_preference
-        mock_get_prefs.return_value = mock_response
-
-    def _mock_no_repos(self, mock_get_prefs: MagicMock) -> None:
-        mock_response = MagicMock()
-        mock_response.preference = None
-        mock_get_prefs.return_value = mock_response
-
-    def test_nothing_configured(self, mock_get_prefs: MagicMock) -> None:
-        self._mock_no_repos(mock_get_prefs)
+    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.bulk_get_project_preferences")
+    def test_nothing_configured(self, mock_bulk_get: MagicMock) -> None:
+        mock_bulk_get.return_value = {str(self.project.id): None}
         response = self.get_response(self.organization.slug)
 
         assert response.status_code == 200
@@ -297,8 +282,9 @@ class OrganizationSeerOnboardingCheckTest(APITestCase):
             "isSeerConfigured": False,
         }
 
-    def test_all_configured(self, mock_get_prefs: MagicMock) -> None:
-        self._mock_has_repos(mock_get_prefs)
+    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.bulk_get_project_preferences")
+    def test_all_configured(self, mock_bulk_get: MagicMock) -> None:
+        mock_bulk_get.return_value = {str(self.project.id): {"repositories": [{"name": "repo"}]}}
 
         self.create_integration(
             organization=self.organization,
@@ -324,8 +310,9 @@ class OrganizationSeerOnboardingCheckTest(APITestCase):
             "isSeerConfigured": True,
         }
 
-    def test_github_integration_only(self, mock_get_prefs: MagicMock) -> None:
-        self._mock_no_repos(mock_get_prefs)
+    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.bulk_get_project_preferences")
+    def test_github_integration_only(self, mock_bulk_get: MagicMock) -> None:
+        mock_bulk_get.return_value = {str(self.project.id): None}
 
         self.create_integration(
             organization=self.organization,
@@ -345,8 +332,9 @@ class OrganizationSeerOnboardingCheckTest(APITestCase):
             "isSeerConfigured": False,
         }
 
-    def test_code_review_enabled_only(self, mock_get_prefs: MagicMock) -> None:
-        self._mock_no_repos(mock_get_prefs)
+    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.bulk_get_project_preferences")
+    def test_code_review_enabled_only(self, mock_bulk_get: MagicMock) -> None:
+        mock_bulk_get.return_value = {str(self.project.id): None}
 
         repo = self.create_repo(project=self.project)
         self.create_repository_settings(
@@ -365,8 +353,9 @@ class OrganizationSeerOnboardingCheckTest(APITestCase):
             "isSeerConfigured": False,
         }
 
-    def test_autofix_enabled_only(self, mock_get_prefs: MagicMock) -> None:
-        self._mock_has_repos(mock_get_prefs)
+    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.bulk_get_project_preferences")
+    def test_autofix_enabled_only(self, mock_bulk_get: MagicMock) -> None:
+        mock_bulk_get.return_value = {str(self.project.id): {"repositories": [{"name": "repo"}]}}
 
         response = self.get_response(self.organization.slug)
 
@@ -379,8 +368,9 @@ class OrganizationSeerOnboardingCheckTest(APITestCase):
             "isSeerConfigured": False,
         }
 
-    def test_github_and_code_review_enabled(self, mock_get_prefs: MagicMock) -> None:
-        self._mock_no_repos(mock_get_prefs)
+    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.bulk_get_project_preferences")
+    def test_github_and_code_review_enabled(self, mock_bulk_get: MagicMock) -> None:
+        mock_bulk_get.return_value = {str(self.project.id): None}
 
         self.create_integration(
             organization=self.organization,
@@ -406,8 +396,9 @@ class OrganizationSeerOnboardingCheckTest(APITestCase):
             "isSeerConfigured": True,
         }
 
-    def test_github_and_autofix_enabled(self, mock_get_prefs: MagicMock) -> None:
-        self._mock_has_repos(mock_get_prefs)
+    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.bulk_get_project_preferences")
+    def test_github_and_autofix_enabled(self, mock_bulk_get: MagicMock) -> None:
+        mock_bulk_get.return_value = {str(self.project.id): {"repositories": [{"name": "repo"}]}}
 
         self.create_integration(
             organization=self.organization,
@@ -427,8 +418,9 @@ class OrganizationSeerOnboardingCheckTest(APITestCase):
             "isSeerConfigured": True,
         }
 
-    def test_code_review_and_autofix_enabled(self, mock_get_prefs: MagicMock) -> None:
-        self._mock_has_repos(mock_get_prefs)
+    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.bulk_get_project_preferences")
+    def test_code_review_and_autofix_enabled(self, mock_bulk_get: MagicMock) -> None:
+        mock_bulk_get.return_value = {str(self.project.id): {"repositories": [{"name": "repo"}]}}
 
         repo = self.create_repo(project=self.project)
         self.create_repository_settings(
@@ -447,9 +439,10 @@ class OrganizationSeerOnboardingCheckTest(APITestCase):
             "isSeerConfigured": False,
         }
 
-    def test_needs_config_reminder_forces_configured(self, mock_get_prefs: MagicMock) -> None:
+    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.bulk_get_project_preferences")
+    def test_needs_config_reminder_forces_configured(self, mock_bulk_get: MagicMock) -> None:
         """When org is in force-config-reminder list, needsConfigReminder is True but isSeerConfigured follows normal logic."""
-        self._mock_no_repos(mock_get_prefs)
+        mock_bulk_get.return_value = {str(self.project.id): None}
 
         with self.options({"seer.organizations.force-config-reminder": [self.organization.slug]}):
             response = self.get_response(self.organization.slug)
@@ -463,9 +456,10 @@ class OrganizationSeerOnboardingCheckTest(APITestCase):
                 "isSeerConfigured": False,
             }
 
-    def test_needs_config_reminder_with_scm_integration(self, mock_get_prefs: MagicMock) -> None:
+    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.bulk_get_project_preferences")
+    def test_needs_config_reminder_with_scm_integration(self, mock_bulk_get: MagicMock) -> None:
         """When org is in config reminder list with SCM integration but no code review/autofix, isSeerConfigured is False."""
-        self._mock_no_repos(mock_get_prefs)
+        mock_bulk_get.return_value = {str(self.project.id): None}
 
         self.create_integration(
             organization=self.organization,
@@ -486,9 +480,10 @@ class OrganizationSeerOnboardingCheckTest(APITestCase):
                 "isSeerConfigured": False,
             }
 
-    def test_not_in_config_reminder_list(self, mock_get_prefs: MagicMock) -> None:
+    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.bulk_get_project_preferences")
+    def test_not_in_config_reminder_list(self, mock_bulk_get: MagicMock) -> None:
         """When org is not in config reminder list, isSeerConfigured follows normal logic."""
-        self._mock_no_repos(mock_get_prefs)
+        mock_bulk_get.return_value = {str(self.project.id): None}
 
         with self.options({"seer.organizations.force-config-reminder": ["other-org"]}):
             response = self.get_response(self.organization.slug)
@@ -502,10 +497,11 @@ class OrganizationSeerOnboardingCheckTest(APITestCase):
                 "isSeerConfigured": False,
             }
 
-    def test_config_reminder_with_complete_setup(self, mock_get_prefs: MagicMock) -> None:
+    @patch("sentry.seer.endpoints.organization_seer_onboarding_check.bulk_get_project_preferences")
+    def test_config_reminder_with_complete_setup(self, mock_bulk_get: MagicMock) -> None:
         """Config reminder flag is independent of isSeerConfigured logic."""
         # Set up SCM and code review
-        self._mock_no_repos(mock_get_prefs)
+        mock_bulk_get.return_value = {str(self.project.id): None}
 
         self.create_integration(
             organization=self.organization,


### PR DESCRIPTION
Change is_autofix_enabled to check whether any project in the org has repositories configured in Seer preferences, rather than checking autofix_automation_tuning project options.

Endpoint returns 500 if Seer API errors.