### PR TITLE
ref(snapshots): Track diff algorithm version on comparison results

### DIFF
--- a/src/sentry/preprod/snapshots/image_diff/compare.py
+++ b/src/sentry/preprod/snapshots/image_diff/compare.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 # This is NOT a minimum % changed value, but
 # rather adjusts the sensitivity of pixel change detection.
 ODIFF_SENSITIVITY_DIFF_THRESHOLD = 0.01
+DIFF_ALGORITHM_VERSION = 1
 
 
 def _as_image(source: bytes | Image.Image) -> Image.Image:

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -14,7 +14,7 @@ from taskbroker_client.retry import Retry
 
 from sentry.objectstore import get_preprod_session
 from sentry.preprod.models import PreprodArtifact, PreprodComparisonApproval
-from sentry.preprod.snapshots.image_diff.compare import compare_images_batch
+from sentry.preprod.snapshots.image_diff.compare import DIFF_ALGORITHM_VERSION, compare_images_batch
 from sentry.preprod.snapshots.image_diff.odiff import OdiffServer
 from sentry.preprod.snapshots.manifest import (
     ComparisonManifest,
@@ -668,6 +668,7 @@ def compare_snapshots(
         extras = comparison.extras or {}
         # EME-896: Could become a proper column on PreprodSnapshotComparison
         extras["comparison_key"] = comparison_key
+        extras["diff_algorithm_version"] = DIFF_ALGORITHM_VERSION
         comparison.extras = extras
         comparison.save(
             update_fields=[


### PR DESCRIPTION
## Summary

- Store `diff_algorithm_version` in the comparison's `extras` JSON field so we can track which version of the diffing logic produced each result
- Add `DIFF_ALGORITHM_VERSION = 1` constant in `compare.py` — bump this when diffing logic changes in a way that could affect results
- No DB migration needed since it uses the existing `extras` JSONField

## Test plan

- No behavioral change — just records metadata on comparison rows