### PR TITLE
fix(ci): Use fixed restrict key in migrations drift pg_dumpall

### DIFF
--- a/.github/workflows/migrations-drift.yml
+++ b/.github/workflows/migrations-drift.yml
@@ -51,7 +51,7 @@ jobs:
         run: make apply-migrations
 
       - name: capture database schema before
-        run: docker exec postgres-postgres-1 bash -c 'pg_dumpall -U postgres -s' > schema-before
+        run: docker exec postgres-postgres-1 bash -c 'pg_dumpall -U postgres -s --restrict-key=drift-check' > schema-before
 
       - name: clear db
         run: make drop-db create-db
@@ -65,7 +65,7 @@ jobs:
         run: make drop-db apply-migrations
 
       - name: capture database schema after
-        run: docker exec postgres-postgres-1 bash -c 'pg_dumpall -U postgres -s' > schema-after
+        run: docker exec postgres-postgres-1 bash -c 'pg_dumpall -U postgres -s --restrict-key=drift-check' > schema-after
 
       - name: compare schema
         run: python3 -um tools.migrations.compare --color schema-before schema-after

--- a/.github/workflows/migrations-drift.yml
+++ b/.github/workflows/migrations-drift.yml
@@ -51,7 +51,7 @@ jobs:
         run: make apply-migrations
 
       - name: capture database schema before
-        run: docker exec postgres-postgres-1 bash -c 'pg_dumpall -U postgres -s --restrict-key=drift-check' > schema-before
+        run: docker exec postgres-postgres-1 bash -c 'pg_dumpall -U postgres -s --restrict-key=driftcheck' > schema-before
 
       - name: clear db
         run: make drop-db create-db
@@ -65,7 +65,7 @@ jobs:
         run: make drop-db apply-migrations
 
       - name: capture database schema after
-        run: docker exec postgres-postgres-1 bash -c 'pg_dumpall -U postgres -s --restrict-key=drift-check' > schema-after
+        run: docker exec postgres-postgres-1 bash -c 'pg_dumpall -U postgres -s --restrict-key=driftcheck' > schema-after
 
       - name: compare schema
         run: python3 -um tools.migrations.compare --color schema-before schema-after


### PR DESCRIPTION
Recent PostgreSQL security patches (CVE-2025-8714) added `\restrict`/`\unrestrict` directives with random keys to `pg_dumpall` output. These wrap dump sections to prevent command injection during restore. Since each invocation generates a new random key, the before/after schema dumps in our drift check always differ in these lines, causing false-positive failures.

Using `--restrict-key` with a fixed value makes the output deterministic across both dump invocations. This flag exists specifically for testing and repeatable-output scenarios like ours.