### PR TITLE
fix(prompts-activity): Allow org members to write to prompts-activity

### DIFF
--- a/src/sentry/api/endpoints/prompts_activity.py
+++ b/src/sentry/api/endpoints/prompts_activity.py
@@ -11,6 +11,7 @@ from rest_framework.response import Response
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint
+from sentry.api.bases.organization import OrganizationPermission
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.promptsactivity import PromptsActivity
@@ -34,12 +35,17 @@ class PromptsActivitySerializer(serializers.Serializer):
         return value
 
 
+class PromptsActivityPermission(OrganizationPermission):
+    scope_map = {"GET": ["org:read"], "PUT": ["org:read"]}
+
+
 @cell_silo_endpoint
 class PromptsActivityEndpoint(OrganizationEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.UNKNOWN,
         "PUT": ApiPublishStatus.UNKNOWN,
     }
+    permission_classes = (PromptsActivityPermission,)
 
     def get(self, request: Request, organization: Organization, **kwargs) -> Response:
         """Return feature prompt status if dismissed or in snoozed period"""

--- a/src/sentry/api/endpoints/prompts_activity.py
+++ b/src/sentry/api/endpoints/prompts_activity.py
@@ -36,7 +36,10 @@ class PromptsActivitySerializer(serializers.Serializer):
 
 
 class PromptsActivityPermission(OrganizationPermission):
-    scope_map = {"GET": ["org:read"], "PUT": ["org:read"]}
+    scope_map = {
+        "GET": ["org:read", "org:write", "org:admin"],
+        "PUT": ["org:read", "org:write", "org:admin"],
+    }
 
 
 @cell_silo_endpoint

--- a/tests/sentry/api/endpoints/test_prompts_activity.py
+++ b/tests/sentry/api/endpoints/test_prompts_activity.py
@@ -54,6 +54,21 @@ class GetPromptsActivityTest(PromptsActivityTestBase):
 class PutPromptsActivityTest(PromptsActivityTestBase):
     method = "put"
 
+    def test_regular_org_member_can_dismiss(self) -> None:
+        member_user = self.create_user()
+        self.create_member(user=member_user, organization=self.org, role="member")
+        self.login_as(user=member_user)
+
+        resp = self.client.put(
+            self.path,
+            {
+                "organization_id": self.org.id,
+                "feature": "alert_stream",
+                "status": "dismissed",
+            },
+        )
+        assert resp.status_code == 201
+
     def test_organization_permissions(self) -> None:
         new_org = self.create_organization()
         self.path = reverse("sentry-api-0-organization-prompts-activity", args=[new_org.slug])


### PR DESCRIPTION
This PR back in November fixed a vulnerability in prompts-activity: https://github.com/getsentry/sentry/pull/103753

However, that change also removed the custom permissions which allowed users to use the PUT method. Attempting to dismiss prompts currently results in a 403 unless you have org write access, since it defaults the OrganizationEndpoint permissions.