### PR TITLE
fix(snapshots): Fix staff auth blocking initial size comparison selection

### DIFF
--- a/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
+++ b/src/sentry/preprod/api/endpoints/size_analysis/project_preprod_size_analysis_compare.py
@@ -343,13 +343,39 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(PreprodArtifactEndpoint)
             head_size_analysis__in=head_size_metrics,
             base_size_analysis__in=base_size_metrics,
         )
+        is_rerun = request.query_params.get("rerun") == "true"
+
         if existing_comparisons.exists():
-            if is_active_superuser(request) or is_active_staff(request):
+            if is_rerun:
+                if is_active_superuser(request) or is_active_staff(request):
+                    comparisons_deleted, files_deleted = _delete_existing_comparisons(
+                        existing_comparisons
+                    )
+                    logger.info(
+                        "preprod.size_analysis.compare.api.post.rerun_deleted_existing",
+                        extra={
+                            "head_artifact_id": head_artifact.id,
+                            "base_artifact_id": base_artifact.id,
+                            "comparisons_deleted": comparisons_deleted,
+                            "files_deleted": files_deleted,
+                            "user_id": request.user.id,
+                        },
+                    )
+                elif request.user.is_staff:
+                    raise StaffRequired
+                else:
+                    return Response({"detail": "Only staff can rerun comparisons."}, status=403)
+            elif (
+                existing_comparisons.filter(
+                    state=PreprodArtifactSizeComparison.State.FAILED
+                ).count()
+                == existing_comparisons.count()
+            ):
                 comparisons_deleted, files_deleted = _delete_existing_comparisons(
                     existing_comparisons
                 )
                 logger.info(
-                    "preprod.size_analysis.compare.api.post.rerun_deleted_existing",
+                    "preprod.size_analysis.compare.api.post.retry_deleted_failed",
                     extra={
                         "head_artifact_id": head_artifact.id,
                         "base_artifact_id": base_artifact.id,
@@ -358,8 +384,6 @@ class ProjectPreprodArtifactSizeAnalysisCompareEndpoint(PreprodArtifactEndpoint)
                         "user_id": request.user.id,
                     },
                 )
-            elif request.user.is_staff:
-                raise StaffRequired
             else:
                 comparison_models = []
                 for comparison in existing_comparisons:

--- a/static/app/views/preprod/buildComparison/buildComparison.tsx
+++ b/static/app/views/preprod/buildComparison/buildComparison.tsx
@@ -67,7 +67,7 @@ export default function BuildComparison() {
     RequestError
   >({
     mutationFn: () => {
-      return fetchMutation({url: compareUrl, method: 'POST'});
+      return fetchMutation({url: `${compareUrl}?rerun=true`, method: 'POST'});
     },
     onSuccess: response => {
       if (response?.status === 'exists') {

--- a/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_compare.py
+++ b/tests/sentry/preprod/api/endpoints/size_analysis/test_project_preprod_size_analysis_compare.py
@@ -600,10 +600,12 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         assert data["comparisons"][0]["comparison_id"] == comparison.id
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
-    def test_post_comparison_existing_failed_comparison(self) -> None:
-        """Test POST endpoint returns existing failed comparison when comparison exists and failed"""
-        # Create a failed comparison
-        comparison = self.create_preprod_artifact_size_comparison(
+    @patch("sentry.preprod.size_analysis.tasks.manual_size_analysis_comparison.apply_async")
+    def test_post_comparison_existing_failed_comparison_auto_retries(
+        self, mock_apply_async
+    ) -> None:
+        """Test POST endpoint auto-retries when all existing comparisons are failed"""
+        self.create_preprod_artifact_size_comparison(
             head_size_analysis=self.head_size_metric,
             base_size_analysis=self.base_size_metric,
             organization=self.organization,
@@ -616,12 +618,13 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
 
         assert response.status_code == 200
         data = response.json()
-        assert data["status"] == "exists"
+        assert data["status"] == "created"
         assert len(data["comparisons"]) == 1
         comparison_data = data["comparisons"][0]
-        assert comparison_data["state"] == comparison.state
-        assert comparison_data["error_code"] == str(comparison.error_code)
-        assert comparison_data["error_message"] == comparison.error_message
+        assert comparison_data["state"] == PreprodArtifactSizeComparison.State.PENDING
+        assert comparison_data["comparison_id"] is None
+
+        mock_apply_async.assert_called_once()
 
     @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
     def test_post_comparison_cannot_compare_size_metrics(self) -> None:
@@ -804,3 +807,68 @@ class ProjectPreprodSizeAnalysisCompareTest(APITestCase):
         )
         assert response.status_code == 404
         assert response.data["detail"] == "This build's size data has expired."
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    @patch("sentry.preprod.size_analysis.tasks.manual_size_analysis_comparison.apply_async")
+    def test_post_rerun_as_staff_deletes_and_recreates(self, mock_apply_async):
+        """Test POST with rerun=true as active staff deletes existing and creates new comparisons"""
+        self.create_preprod_artifact_size_comparison(
+            head_size_analysis=self.head_size_metric,
+            base_size_analysis=self.base_size_metric,
+            organization=self.organization,
+            state=PreprodArtifactSizeComparison.State.SUCCESS,
+            file_id=12345,
+        )
+
+        staff_user = self.create_user(is_staff=True)
+        self.organization.member_set.create(user_id=staff_user.id)
+        self.login_as(user=staff_user)
+
+        with patch(
+            "sentry.preprod.api.endpoints.size_analysis.project_preprod_size_analysis_compare.is_active_staff",
+            return_value=True,
+        ):
+            response = self.client.post(f"{self._get_url()}?rerun=true")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "created"
+        assert len(data["comparisons"]) == 1
+        assert data["comparisons"][0]["state"] == PreprodArtifactSizeComparison.State.PENDING
+        mock_apply_async.assert_called_once()
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_post_rerun_as_non_staff_returns_403(self):
+        """Test POST with rerun=true as non-staff returns 403"""
+        self.create_preprod_artifact_size_comparison(
+            head_size_analysis=self.head_size_metric,
+            base_size_analysis=self.base_size_metric,
+            organization=self.organization,
+            state=PreprodArtifactSizeComparison.State.SUCCESS,
+            file_id=12345,
+        )
+
+        response = self.client.post(f"{self._get_url()}?rerun=true")
+
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Only staff can rerun comparisons."
+
+    @override_settings(SENTRY_FEATURES={"organizations:preprod-frontend-routes": True})
+    def test_post_rerun_as_inactive_staff_raises_staff_required(self):
+        """Test POST with rerun=true as is_staff user without active staff session raises StaffRequired"""
+        self.create_preprod_artifact_size_comparison(
+            head_size_analysis=self.head_size_metric,
+            base_size_analysis=self.base_size_metric,
+            organization=self.organization,
+            state=PreprodArtifactSizeComparison.State.SUCCESS,
+            file_id=12345,
+        )
+
+        staff_user = self.create_user(is_staff=True)
+        self.organization.member_set.create(user_id=staff_user.id)
+        self.login_as(user=staff_user)
+
+        response = self.client.post(f"{self._get_url()}?rerun=true")
+
+        assert response.status_code == 403
+        assert response.json()["detail"]["code"] == "staff-required"


### PR DESCRIPTION
## Summary

The size comparison POST endpoint was applying staff re-auth checks whenever existing comparisons were found, regardless of context. This caused staff users to hit a `403 StaffRequired` error on the build selection page when selecting a pair that already had comparison results.

**Fix:** Use a `?rerun=true` query parameter to distinguish the "Rerun Comparison" admin flow from normal comparison triggers.

### Logic paths

| Scenario | `?rerun` | Existing state | Behavior |
|---|---|---|---|
| Build selection page | no | no comparison exists | Creates new comparison |
| Build selection page | no | SUCCESS/PENDING exists | Returns `status: "exists"`, navigates to results |
| Build selection page | no | all FAILED | Deletes failed, re-creates (retry without staff gate) |
| Retry button (failed comparison) | no | all FAILED | Deletes failed, re-creates (retry without staff gate) |
| "Rerun Comparison" admin button | yes | active superuser/staff | Deletes and re-runs |
| "Rerun Comparison" admin button | yes | `is_staff` but not re-authed | `StaffRequired` (triggers re-auth modal) |
| "Rerun Comparison" admin button | yes | non-staff | 403 |

### Files changed
- **Backend**: `project_preprod_size_analysis_compare.py` — branching logic based on `?rerun` query param
- **Frontend**: `buildComparison.tsx` — rerun mutation now sends `?rerun=true`