### PR TITLE
feat(snapshots): Show diff_threshold in snapshot detail header

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -435,6 +435,7 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                 errored_count=len(categorized.errored),
                 comparison_run_info=run_info,
                 approval_info=approval_info,
+                diff_threshold=manifest.diff_threshold,
             ).dict()
         )
 

--- a/src/sentry/preprod/api/models/snapshots/project_preprod_snapshot_models.py
+++ b/src/sentry/preprod/api/models/snapshots/project_preprod_snapshot_models.py
@@ -97,5 +97,7 @@ class SnapshotDetailsApiResponse(BaseModel):
 
     approval_info: SnapshotApprovalInfo | None = None
 
+    diff_threshold: float | None = None
+
 
 # TODO: POST request in the future when we migrate away from current schemas

--- a/static/app/views/preprod/snapshots/header/snapshotHeaderContent.tsx
+++ b/static/app/views/preprod/snapshots/header/snapshotHeaderContent.tsx
@@ -7,7 +7,13 @@ import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
 import * as Layout from 'sentry/components/layouts/thirds';
-import {IconCommit, IconPullRequest, IconShow, IconStack} from 'sentry/icons';
+import {
+  IconCommit,
+  IconPullRequest,
+  IconSliders,
+  IconShow,
+  IconStack,
+} from 'sentry/icons';
 import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
 import type {Theme} from 'sentry/utils/theme';
@@ -66,7 +72,8 @@ export function SnapshotHeaderContent({
     <Layout.HeaderContent>
       <Layout.Title>{t('Snapshot')}</Layout.Title>
 
-      {vcsItems.length > 0 && (
+      {(vcsItems.length > 0 ||
+        (data.diff_threshold !== null && data.diff_threshold !== undefined)) && (
         <Flex align="center" gap="lg" wrap="wrap">
           {vcsItems.map(item => (
             <Flex align="center" gap="xs" key={item.key}>
@@ -82,6 +89,17 @@ export function SnapshotHeaderContent({
               )}
             </Flex>
           ))}
+          {data.diff_threshold !== null && data.diff_threshold !== undefined && (
+            <Flex align="center" gap="xs">
+              <IconSliders size="xs" />
+              <Text size="sm" variant="muted">
+                {t(
+                  'Specified minimum diff: %s%%',
+                  parseFloat((data.diff_threshold * 100).toPrecision(10))
+                )}
+              </Text>
+            </Flex>
+          )}
         </Flex>
       )}
 

--- a/static/app/views/preprod/types/snapshotTypes.ts
+++ b/static/app/views/preprod/types/snapshotTypes.ts
@@ -52,6 +52,8 @@ export interface SnapshotDetailsApiResponse {
 
   approval_info?: SnapshotApprovalInfo | null;
 
+  diff_threshold?: number | null;
+
   // Diff fields
   added: SnapshotImage[];
   added_count: number;


### PR DESCRIPTION
<img width="1426" height="300" alt="CleanShot 2026-04-10 at 14 08 50@2x" src="https://github.com/user-attachments/assets/89acfcf9-9305-4f5b-861a-ae665d01acf9" />


## Summary

Surfaces the optional `diff_threshold` value from the snapshot manifest in the snapshot detail API response and renders it in the header UI next to the branch name when set.

- **Backend**: Added `diff_threshold` field to `SnapshotDetailsApiResponse` model, populated from the manifest
- **Frontend**: Added `diff_threshold` to the TypeScript type, rendered with a settings icon as "Diff threshold: X.X%" in the header

When `diff_threshold` is not set (most snapshots), nothing changes in the UI.

Refs EME-406

## Test plan
- [ ] Load a snapshot that has `diff_threshold` set in its manifest — verify it shows "Diff threshold: X.X%" next to the branch name
- [ ] Load a snapshot without `diff_threshold` — verify no extra element appears in the header