### PR TITLE
ref(repos): Renames and moves some queryOptions calls for `/organization/:orgId/repos/`

### DIFF
--- a/static/app/components/events/autofix/preferences/hooks/useOrganizationRepositories.ts
+++ b/static/app/components/events/autofix/preferences/hooks/useOrganizationRepositories.ts
@@ -64,7 +64,7 @@ export function useOrganizationRepositories({query = {}} = {} as Props) {
   );
 }
 
-export function organizationRepositoriesInfiniteOptions({
+export function organizationRepositoriesWithSettingsInfiniteOptions({
   organization,
   query,
   staleTime,

--- a/static/app/components/events/autofix/preferences/hooks/useOrganizationRepositories.ts
+++ b/static/app/components/events/autofix/preferences/hooks/useOrganizationRepositories.ts
@@ -1,12 +1,8 @@
 import {useCallback, useEffect, useMemo, useRef} from 'react';
 
-import type {Repository, RepositoryWithSettings} from 'sentry/types/integrations';
-import type {Organization} from 'sentry/types/organization';
-import {apiOptions} from 'sentry/utils/api/apiOptions';
+import type {Repository} from 'sentry/types/integrations';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useFetchSequentialPages} from 'sentry/utils/api/useFetchSequentialPages';
-import {encodeSort} from 'sentry/utils/discover/eventView';
-import type {Sort} from 'sentry/utils/discover/fields';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
@@ -61,32 +57,5 @@ export function useOrganizationRepositories({query = {}} = {} as Props) {
       isFetching,
     }),
     [data, isFetching, rest]
-  );
-}
-
-export function organizationRepositoriesWithSettingsInfiniteOptions({
-  organization,
-  query,
-  staleTime,
-}: {
-  organization: Organization;
-  query?: {
-    cursor?: string;
-    integration_id?: string;
-    per_page?: number;
-    query?: string;
-    sort?: Sort;
-    status?: 'active' | 'deleted' | 'unmigratable';
-  };
-  staleTime?: number;
-}) {
-  const sortQuery = query?.sort ? encodeSort(query.sort) : undefined;
-  return apiOptions.asInfinite<RepositoryWithSettings[]>()(
-    '/organizations/$organizationIdOrSlug/repos/',
-    {
-      path: {organizationIdOrSlug: organization.slug},
-      query: {expand: 'settings', per_page: 100, ...query, sort: sortQuery},
-      staleTime: staleTime ?? 0,
-    }
   );
 }

--- a/static/app/components/repositories/scmIntegrationTree/useScmIntegrationTreeData.ts
+++ b/static/app/components/repositories/scmIntegrationTree/useScmIntegrationTreeData.ts
@@ -1,6 +1,6 @@
 import {useEffect, useMemo} from 'react';
 
-import {organizationRepositoriesInfiniteOptions} from 'sentry/components/events/autofix/preferences/hooks/useOrganizationRepositories';
+import {organizationRepositoriesWithSettingsInfiniteOptions} from 'sentry/components/events/autofix/preferences/hooks/useOrganizationRepositories';
 import {organizationConfigIntegrationsQueryOptions} from 'sentry/components/repositories/scmIntegrationTree/organizationConfigIntegrationsQueryOptions';
 import type {
   IntegrationProvider,
@@ -21,7 +21,9 @@ type ScmIntegrationTreeData = {
   refetchIntegrations: () => void;
   reposByIntegrationId: Record<string, IntegrationRepository[]>;
   reposPendingByIntegrationId: Record<string, boolean>;
-  reposQueryOptions: ReturnType<typeof organizationRepositoriesInfiniteOptions>;
+  reposQueryOptions: ReturnType<
+    typeof organizationRepositoriesWithSettingsInfiniteOptions
+  >;
   scmIntegrations: OrganizationIntegration[];
   scmProviders: IntegrationProvider[];
 };
@@ -64,7 +66,7 @@ export function useScmIntegrationTreeData(): ScmIntegrationTreeData {
   );
 
   // 3. Fetch already-connected repos, auto-paginate to get all
-  const reposQueryOptions = organizationRepositoriesInfiniteOptions({
+  const reposQueryOptions = organizationRepositoriesWithSettingsInfiniteOptions({
     organization,
     staleTime: 0,
   });

--- a/static/app/components/repositories/scmIntegrationTree/useScmIntegrationTreeData.ts
+++ b/static/app/components/repositories/scmIntegrationTree/useScmIntegrationTreeData.ts
@@ -1,6 +1,5 @@
 import {useEffect, useMemo} from 'react';
 
-import {organizationRepositoriesWithSettingsInfiniteOptions} from 'sentry/components/events/autofix/preferences/hooks/useOrganizationRepositories';
 import {organizationConfigIntegrationsQueryOptions} from 'sentry/components/repositories/scmIntegrationTree/organizationConfigIntegrationsQueryOptions';
 import type {
   IntegrationProvider,
@@ -10,6 +9,7 @@ import type {
 } from 'sentry/types/integrations';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useInfiniteQuery, useQueries, useQuery} from 'sentry/utils/queryClient';
+import {organizationRepositoriesWithSettingsInfiniteOptions} from 'sentry/utils/repositories/repoQueryOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {organizationIntegrationsQueryOptions} from 'sentry/views/settings/seer/overview/utils/organizationIntegrationsQueryOptions';
 

--- a/static/app/utils/repositories/repoQueryOptions.ts
+++ b/static/app/utils/repositories/repoQueryOptions.ts
@@ -1,0 +1,59 @@
+import type {Repository, RepositoryWithSettings} from 'sentry/types/integrations';
+import type {Organization} from 'sentry/types/organization';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {encodeSort} from 'sentry/utils/discover/eventView';
+import type {Sort} from 'sentry/utils/discover/fields';
+
+export function organizationRepositoriesInfiniteOptions({
+  organization,
+  query,
+  staleTime,
+}: {
+  organization: Organization;
+  query?: {
+    cursor?: string;
+    integration_id?: string;
+    per_page?: number;
+    query?: string;
+    sort?: Sort;
+    status?: 'active' | 'deleted' | 'unmigratable';
+  };
+  staleTime?: number;
+}) {
+  const sortQuery = query?.sort ? encodeSort(query.sort) : undefined;
+  return apiOptions.asInfinite<Repository[]>()(
+    '/organizations/$organizationIdOrSlug/repos/',
+    {
+      path: {organizationIdOrSlug: organization.slug},
+      query: {per_page: 100, ...query, sort: sortQuery},
+      staleTime: staleTime ?? 0,
+    }
+  );
+}
+
+export function organizationRepositoriesWithSettingsInfiniteOptions({
+  organization,
+  query,
+  staleTime,
+}: {
+  organization: Organization;
+  query?: {
+    cursor?: string;
+    integration_id?: string;
+    per_page?: number;
+    query?: string;
+    sort?: Sort;
+    status?: 'active' | 'deleted' | 'unmigratable';
+  };
+  staleTime?: number;
+}) {
+  const sortQuery = query?.sort ? encodeSort(query.sort) : undefined;
+  return apiOptions.asInfinite<RepositoryWithSettings[]>()(
+    '/organizations/$organizationIdOrSlug/repos/',
+    {
+      path: {organizationIdOrSlug: organization.slug},
+      query: {expand: 'settings', per_page: 100, ...query, sort: sortQuery},
+      staleTime: staleTime ?? 0,
+    }
+  );
+}

--- a/static/app/views/settings/organizationIntegrations/integrationCodeMappings.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationCodeMappings.tsx
@@ -17,14 +17,9 @@ import {PanelHeader} from 'sentry/components/panels/panelHeader';
 import {PanelItem} from 'sentry/components/panels/panelItem';
 import {IconAdd} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
-import type {
-  Integration,
-  Repository,
-  RepositoryProjectPathConfig,
-} from 'sentry/types/integrations';
+import type {Integration, RepositoryProjectPathConfig} from 'sentry/types/integrations';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useFetchAllPages} from 'sentry/utils/api/apiFetch';
-import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {getIntegrationIcon} from 'sentry/utils/integrationUtil';
 import {
@@ -34,6 +29,7 @@ import {
   useQueryClient,
   type ApiQueryKey,
 } from 'sentry/utils/queryClient';
+import {organizationRepositoriesInfiniteOptions} from 'sentry/utils/repositories/repoQueryOptions';
 import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {useRouteAnalyticsEventNames} from 'sentry/utils/routeAnalytics/useRouteAnalyticsEventNames';
 import {useRouteAnalyticsParams} from 'sentry/utils/routeAnalytics/useRouteAnalyticsParams';
@@ -163,14 +159,11 @@ export function IntegrationCodeMappings({integration}: {integration: Integration
   );
 
   const repositoriesQuery = useInfiniteQuery({
-    ...apiOptions.asInfinite<Repository[]>()(
-      '/organizations/$organizationIdOrSlug/repos/',
-      {
-        path: {organizationIdOrSlug: organization.slug},
-        query: {status: 'active', per_page: 100},
-        staleTime: 10_000,
-      }
-    ),
+    ...organizationRepositoriesInfiniteOptions({
+      organization,
+      query: {status: 'active', per_page: 100},
+      staleTime: 10_000,
+    }),
     select: data => data.pages.flatMap(page => page.json),
   });
   useFetchAllPages({result: repositoriesQuery});

--- a/static/app/views/settings/seer/overview/codeReviewOverviewSection.tsx
+++ b/static/app/views/settings/seer/overview/codeReviewOverviewSection.tsx
@@ -11,7 +11,6 @@ import {Text} from '@sentry/scraps/text';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {updateOrganization} from 'sentry/actionCreators/organizations';
-import {organizationRepositoriesWithSettingsInfiniteOptions} from 'sentry/components/events/autofix/preferences/hooks/useOrganizationRepositories';
 import {useSeerSupportedProviderIds} from 'sentry/components/events/autofix/utils';
 import {useBulkUpdateRepositorySettings} from 'sentry/components/repositories/useBulkUpdateRepositorySettings';
 import {getRepositoryWithSettingsQueryKey} from 'sentry/components/repositories/useRepositoryWithSettings';
@@ -23,6 +22,7 @@ import {useFetchAllPages} from 'sentry/utils/api/apiFetch';
 import {getSeerOnboardingCheckQueryOptions} from 'sentry/utils/getSeerOnboardingCheckQueryOptions';
 import {useInfiniteQuery, useQueryClient} from 'sentry/utils/queryClient';
 import {fetchMutation} from 'sentry/utils/queryClient';
+import {organizationRepositoriesWithSettingsInfiniteOptions} from 'sentry/utils/repositories/repoQueryOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 export function useCodeReviewOverviewSection() {

--- a/static/app/views/settings/seer/overview/codeReviewOverviewSection.tsx
+++ b/static/app/views/settings/seer/overview/codeReviewOverviewSection.tsx
@@ -11,7 +11,7 @@ import {Text} from '@sentry/scraps/text';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {updateOrganization} from 'sentry/actionCreators/organizations';
-import {organizationRepositoriesInfiniteOptions} from 'sentry/components/events/autofix/preferences/hooks/useOrganizationRepositories';
+import {organizationRepositoriesWithSettingsInfiniteOptions} from 'sentry/components/events/autofix/preferences/hooks/useOrganizationRepositories';
 import {useSeerSupportedProviderIds} from 'sentry/components/events/autofix/utils';
 import {useBulkUpdateRepositorySettings} from 'sentry/components/repositories/useBulkUpdateRepositorySettings';
 import {getRepositoryWithSettingsQueryKey} from 'sentry/components/repositories/useRepositoryWithSettings';
@@ -29,7 +29,7 @@ export function useCodeReviewOverviewSection() {
   const organization = useOrganization();
   const seerSupportedProviderIds = useSeerSupportedProviderIds();
 
-  const queryOptions = organizationRepositoriesInfiniteOptions({
+  const queryOptions = organizationRepositoriesWithSettingsInfiniteOptions({
     organization,
     query: {per_page: 100},
   });

--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
@@ -11,7 +11,6 @@ import {Flex, Grid} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {openModal} from 'sentry/actionCreators/modal';
-import {organizationRepositoriesWithSettingsInfiniteOptions} from 'sentry/components/events/autofix/preferences/hooks/useOrganizationRepositories';
 import {
   isSeerSupportedProvider,
   useSeerSupportedProviderIds,
@@ -32,6 +31,7 @@ import {
   useListItemCheckboxContext,
 } from 'sentry/utils/list/useListItemCheckboxState';
 import {useInfiniteQuery, useQueryClient} from 'sentry/utils/queryClient';
+import {organizationRepositoriesWithSettingsInfiniteOptions} from 'sentry/utils/repositories/repoQueryOptions';
 import {parseAsSort} from 'sentry/utils/url/parseAsSort';
 import {useOrganization} from 'sentry/utils/useOrganization';
 

--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
@@ -11,7 +11,7 @@ import {Flex, Grid} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {openModal} from 'sentry/actionCreators/modal';
-import {organizationRepositoriesInfiniteOptions} from 'sentry/components/events/autofix/preferences/hooks/useOrganizationRepositories';
+import {organizationRepositoriesWithSettingsInfiniteOptions} from 'sentry/components/events/autofix/preferences/hooks/useOrganizationRepositories';
 import {
   isSeerSupportedProvider,
   useSeerSupportedProviderIds,
@@ -60,7 +60,7 @@ export function SeerRepoTable() {
 
   const supportedProviderIds = useSeerSupportedProviderIds();
 
-  const queryOptions = organizationRepositoriesInfiniteOptions({
+  const queryOptions = organizationRepositoriesWithSettingsInfiniteOptions({
     organization,
     query: {per_page: 100, query: searchTerm, sort},
   });

--- a/static/gsApp/views/seerAutomation/onboarding/hooks/seerOnboardingContext.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/hooks/seerOnboardingContext.tsx
@@ -11,7 +11,6 @@ import {
 import * as Sentry from '@sentry/react';
 import uniqBy from 'lodash/uniqBy';
 
-import {organizationRepositoriesWithSettingsInfiniteOptions} from 'sentry/components/events/autofix/preferences/hooks/useOrganizationRepositories';
 import type {
   IntegrationProvider,
   OrganizationIntegration,
@@ -19,6 +18,7 @@ import type {
 } from 'sentry/types/integrations';
 import {useFetchAllPages} from 'sentry/utils/api/apiFetch';
 import {useInfiniteQuery} from 'sentry/utils/queryClient';
+import {organizationRepositoriesWithSettingsInfiniteOptions} from 'sentry/utils/repositories/repoQueryOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 import {useIntegrationInstallation} from './useIntegrationInstallation';

--- a/static/gsApp/views/seerAutomation/onboarding/hooks/seerOnboardingContext.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/hooks/seerOnboardingContext.tsx
@@ -11,7 +11,7 @@ import {
 import * as Sentry from '@sentry/react';
 import uniqBy from 'lodash/uniqBy';
 
-import {organizationRepositoriesInfiniteOptions} from 'sentry/components/events/autofix/preferences/hooks/useOrganizationRepositories';
+import {organizationRepositoriesWithSettingsInfiniteOptions} from 'sentry/components/events/autofix/preferences/hooks/useOrganizationRepositories';
 import type {
   IntegrationProvider,
   OrganizationIntegration,
@@ -91,7 +91,7 @@ export function SeerOnboardingProvider({children}: {children: React.ReactNode}) 
   const hasInitializedCodeReviewMap = useRef(false);
 
   const repositoriesResult = useInfiniteQuery({
-    ...organizationRepositoriesInfiniteOptions({
+    ...organizationRepositoriesWithSettingsInfiniteOptions({
       organization,
       query: {per_page: 100},
     }),


### PR DESCRIPTION
There are some other related fetch and mutation calls to this, i'm going to go around and consolidate. 

**Before**
`organizationRepositoriesInfiniteOptions()` inside `useOrganizationRepositories.tsx`

**After**
`organizationRepositoriesInfiniteOptions()` inside `repoQueryOptions.ts`
`organizationRepositoriesWithSettingsInfiniteOptions()` inside `repoQueryOptions.ts`