### PR TITLE
chore(flags): Remove `projects:alert-filters` feature flag

### DIFF
--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -36,7 +36,6 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
 
         available_ticket_actions = set()
 
-        project_has_filters = features.has("projects:alert-filters", project)
         can_create_tickets = features.has(
             "organizations:integrations-ticket-rules", project.organization
         )
@@ -48,8 +47,8 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
         # TODO: conditions need to be based on actions
         for rule_type, rule_cls in rules:
             node = rule_cls(project=project)
-            # skip over conditions if they are not in the migrated set for a project with alert-filters
-            if project_has_filters and node.id in MIGRATED_CONDITIONS:
+            # skip over conditions if they are not in the migrated set
+            if node.id in MIGRATED_CONDITIONS:
                 continue
 
             if not can_create_tickets and node.id in TICKET_ACTIONS:

--- a/src/sentry/api/serializers/rest_framework/rule.py
+++ b/src/sentry/api/serializers/rest_framework/rule.py
@@ -7,7 +7,6 @@ from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
-from sentry import features
 from sentry.api.fields.actor import OwnerActorField
 from sentry.constants import MIGRATED_CONDITIONS, TICKET_ACTIONS
 from sentry.models.environment import Environment
@@ -107,23 +106,19 @@ class RuleSetSerializer(serializers.Serializer):
                     }
                 )
 
-        # ensure that if a user has alert-filters enabled, they do not use old conditions
-        project = self.context["project"]
+        # ensure that we do not use old conditions
         conditions = attrs.get("conditions", tuple())
-        project_has_filters = features.has("projects:alert-filters", project)
-        if project_has_filters:
-            old_conditions = [
-                condition for condition in conditions if condition["id"] in MIGRATED_CONDITIONS
-            ]
-            if old_conditions:
-                raise serializers.ValidationError(
-                    {
-                        "conditions": "Conditions evaluating an event attribute, tag, or level are outdated please use an appropriate filter instead."
-                    }
-                )
+        old_conditions = [
+            condition for condition in conditions if condition["id"] in MIGRATED_CONDITIONS
+        ]
+        if old_conditions:
+            raise serializers.ValidationError(
+                {
+                    "conditions": "Conditions evaluating an event attribute, tag, or level are outdated please use an appropriate filter instead."
+                }
+            )
 
-        # ensure that if a user has alert-filters enabled, they do not use a 'none' match on conditions
-        if project_has_filters and attrs.get("actionMatch") == "none":
+        if attrs.get("actionMatch") == "none":
             raise serializers.ValidationError(
                 {
                     "conditions": "The 'none' match on conditions is outdated and no longer supported."

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -553,8 +553,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     ###########################
     # Enables quick testing of disabling transaction name clustering for a project.
     manager.add("projects:transaction-name-clustering-disabled", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False, default=False)
-    # Adds additional filters and a new section to issue alert rules.
-    manager.add("projects:alert-filters", ProjectFeature, FeatureHandlerStrategy.INTERNAL, default=True)
     manager.add("projects:discard-transaction", ProjectFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     # Enable error upsampling
     manager.add("projects:error-upsampling", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=True)

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -279,7 +279,7 @@ class Project(Model):
         # This Project has sent transactions
         has_transactions: bool
 
-        # This Project has filters
+        # has_alert_filters is DEPRECATED
         has_alert_filters: bool
 
         # This Project has sessions


### PR DESCRIPTION
This migration has been complete for many years. We've also mostly moved away from the `Rule` table, so just removing this flag.

I'm not cleaning up the related code since I assume we'll fully remove issue alerts at some point.
