### PR TITLE
bug(billing): no longer offering mm2 plans as a destination for changing a user's plan in admin

### DIFF
--- a/static/gsAdmin/components/changePlanAction.spec.tsx
+++ b/static/gsAdmin/components/changePlanAction.spec.tsx
@@ -126,7 +126,7 @@ describe('ChangePlanAction', () => {
     // Verify the tabs are rendered
     expect(screen.getByRole('tab', {name: 'AM3'})).toBeInTheDocument();
     expect(screen.getByRole('tab', {name: 'AM2'})).toBeInTheDocument();
-    expect(screen.getByRole('tab', {name: 'MM2'})).toBeInTheDocument();
+    expect(screen.queryByRole('tab', {name: 'MM2'})).not.toBeInTheDocument();
 
     // Verify at least one plan option is displayed
     expect(screen.getByTestId('change-plan-label-am3_business')).toBeInTheDocument();
@@ -324,16 +324,6 @@ describe('ChangePlanAction', () => {
       const radios = document.querySelectorAll('input[type="radio"]');
       expect(radios.length).toBeGreaterThan(0);
     });
-
-    // Switch to MM2 tier
-    const mm2Tab = screen.getByRole('tab', {name: 'MM2'});
-    await userEvent.click(mm2Tab);
-
-    // Again, verify we have plan options
-    await waitFor(() => {
-      const radios = document.querySelectorAll('input[type="radio"]');
-      expect(radios.length).toBeGreaterThan(0);
-    });
   });
 
   it('shows only test plans when using TEST tier', async () => {
@@ -446,25 +436,6 @@ describe('ChangePlanAction', () => {
       await userEvent.click(screen.getAllByRole('radio')[0] as HTMLElement);
 
       expect(screen.getByText('Seer')).toBeInTheDocument();
-    });
-
-    it('hides Seer budget checkbox for MM2 tier', async () => {
-      openAndLoadModal();
-
-      await waitFor(() => {
-        expect(screen.getByRole('tab', {name: 'AM3'})).toBeInTheDocument();
-      });
-
-      const mm2Tab = screen.getByRole('tab', {name: 'MM2'});
-      await userEvent.click(mm2Tab);
-
-      await userEvent.click(screen.getAllByRole('radio')[0] as HTMLElement);
-
-      expect(
-        screen.queryByRole('checkbox', {
-          name: 'Seer',
-        })
-      ).not.toBeInTheDocument();
     });
 
     it('initializes Seer budget checkbox based on current subscription', async () => {

--- a/static/gsAdmin/components/changePlanAction.tsx
+++ b/static/gsAdmin/components/changePlanAction.tsx
@@ -27,7 +27,7 @@ import {ANNUAL, MONTHLY} from 'getsentry/constants';
 import type {BillingConfig, Plan, Subscription} from 'getsentry/types';
 import {CheckoutType, PlanTier} from 'getsentry/types';
 
-const ALLOWED_TIERS = [PlanTier.MM2, PlanTier.AM1, PlanTier.AM2, PlanTier.AM3];
+const ALLOWED_TIERS = [PlanTier.AM1, PlanTier.AM2, PlanTier.AM3];
 
 type Props = {
   onSuccess: () => void;
@@ -206,20 +206,6 @@ function ChangePlanAction({
       return;
     }
 
-    if (activeTier === PlanTier.MM2) {
-      try {
-        await api.requestPromise(`/customers/${orgId}/`, {
-          method: 'PUT',
-          data,
-        });
-        onSubmitSuccess(data);
-      } catch (error) {
-        onSubmitError(error);
-      }
-      return;
-    }
-
-    // AM plans use a different endpoint to update plans
     try {
       await api.requestPromise(`/customers/${orgId}/subscription/`, {
         method: 'PUT',
@@ -246,10 +232,6 @@ function ChangePlanAction({
     {
       label: 'AM1',
       tier: PlanTier.AM1,
-    },
-    {
-      label: 'MM2',
-      tier: PlanTier.MM2,
     },
     {
       label: 'TEST',
@@ -293,22 +275,6 @@ function ChangePlanAction({
             Monthly
           </a>
         </li>
-        {activeTier === PlanTier.MM2 && (
-          <li
-            className={classNames({
-              active: contractInterval === ANNUAL && billingInterval === MONTHLY,
-            })}
-          >
-            <a
-              onClick={() => {
-                setBillingInterval(MONTHLY);
-                setContractInterval(ANNUAL);
-              }}
-            >
-              Annual (Contract)
-            </a>
-          </li>
-        )}
         <li
           className={classNames({
             active: contractInterval === ANNUAL && billingInterval === ANNUAL,


### PR DESCRIPTION
The Sentry MM2 plans are deprecated, removing them as an option for changing a user's plan on the customer admin page.

## Before

<img width="275"  alt="image" src="https://github.com/user-attachments/assets/b8dd3f8e-065b-4854-aa4d-2df9dbeae2cf" />

## After 
<img width="215" alt="image" src="https://github.com/user-attachments/assets/6e382215-e2bd-45ab-9432-0ddb67c7ec3d" />