### PR TITLE
chore(flags): Remove `organizations:event-unique-user-frequency-condition-with-conditions` feature flag

### DIFF
--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -39,10 +39,6 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
         can_create_tickets = features.has(
             "organizations:integrations-ticket-rules", project.organization
         )
-        has_user_frequency_condition_with_conditions_alert = features.has(
-            "organizations:event-unique-user-frequency-condition-with-conditions",
-            project.organization,
-        )
 
         # TODO: conditions need to be based on actions
         for rule_type, rule_cls in rules:
@@ -80,11 +76,6 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
                 continue
 
             if rule_type.startswith("condition/"):
-                if (
-                    node.id
-                    == "sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyConditionWithConditions"
-                ) and not has_user_frequency_condition_with_conditions_alert:
-                    continue
                 condition_list.append(context)
             elif rule_type.startswith("filter/"):
                 filter_list.append(context)

--- a/src/sentry/api/endpoints/project_rules_configuration.py
+++ b/src/sentry/api/endpoints/project_rules_configuration.py
@@ -40,10 +40,6 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
         can_create_tickets = features.has(
             "organizations:integrations-ticket-rules", project.organization
         )
-        has_user_frequency_condition_with_conditions_alert = features.has(
-            "organizations:event-unique-user-frequency-condition-with-conditions",
-            project.organization,
-        )
 
         # TODO: conditions need to be based on actions
         for rule_type, rule_cls in rules:
@@ -81,11 +77,6 @@ class ProjectRulesConfigurationEndpoint(ProjectEndpoint):
                 continue
 
             if rule_type.startswith("condition/"):
-                if (
-                    node.id
-                    == "sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyConditionWithConditions"
-                ) and not has_user_frequency_condition_with_conditions_alert:
-                    continue
                 condition_list.append(context)
             elif rule_type.startswith("filter/"):
                 filter_list.append(context)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -470,8 +470,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:workflow-engine-orgalertruledetails-delete", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable metric detector limits by plan type
     manager.add("organizations:workflow-engine-metric-detector-limit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable EventUniqueUserFrequencyConditionWithConditions special alert condition
-    manager.add("organizations:event-unique-user-frequency-condition-with-conditions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable our logs product (known internally as ourlogs) in UI and backend
     manager.add("organizations:ourlogs-enabled", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable our logs product to be ingested via Relay.

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -489,8 +489,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Use workflow engine exclusively for OrganizationAlertRuleIndexEndpoint.get results.
     # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
     manager.add("organizations:workflow-engine-orgalertruleindex-get", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable EventUniqueUserFrequencyConditionWithConditions special alert condition
-    manager.add("organizations:event-unique-user-frequency-condition-with-conditions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable our logs product (known internally as ourlogs) in UI and backend
     manager.add("organizations:ourlogs-enabled", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable our logs product to be ingested via Relay.

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -15,11 +15,10 @@ from django.db.models.enums import TextChoices
 from django.utils import timezone
 from snuba_sdk import Op
 
-from sentry import features, release_health, tsdb
+from sentry import release_health, tsdb
 from sentry.issues.constants import get_issue_tsdb_group_model, get_issue_tsdb_user_group_model
 from sentry.issues.grouptype import GroupCategory
 from sentry.models.group import DEFAULT_TYPE_ID, Group
-from sentry.models.project import Project
 from sentry.rules import EventState
 from sentry.rules.conditions.base import EventCondition, GenericCondition
 from sentry.rules.match import MatchType
@@ -602,13 +601,6 @@ class EventUniqueUserFrequencyConditionWithConditions(EventUniqueUserFrequencyCo
         environment_id: int,
     ) -> int:
         assert self.rule
-        if not features.has(
-            "organizations:event-unique-user-frequency-condition-with-conditions",
-            Project.objects.get(id=self.rule.project_id).organization,
-        ):
-            raise NotImplementedError(
-                "EventUniqueUserFrequencyConditionWithConditions is not enabled for this organization"
-            )
         if self.rule.data["filter_match"] == "any":
             raise NotImplementedError(
                 "EventUniqueUserFrequencyConditionWithConditions does not support filter_match == any"
@@ -659,14 +651,6 @@ class EventUniqueUserFrequencyConditionWithConditions(EventUniqueUserFrequencyCo
             },
         )
         assert self.rule
-        if not features.has(
-            "organizations:event-unique-user-frequency-condition-with-conditions",
-            self.rule.project.organization,
-        ):
-            raise NotImplementedError(
-                "EventUniqueUserFrequencyConditionWithConditions is not enabled for this organization"
-            )
-
         if self.rule.data["filter_match"] == "any":
             raise NotImplementedError(
                 "EventUniqueUserFrequencyConditionWithConditions does not support filter_match == any"

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -802,18 +802,6 @@ class IssueRuleEditor extends DeprecatedAsyncComponent<Props, State> {
       return null;
     }
 
-    if (
-      !organization.features.includes(
-        'event-unique-user-frequency-condition-with-conditions'
-      )
-    ) {
-      conditions = conditions?.filter(
-        condition =>
-          condition.id !==
-          'sentry.rules.conditions.event_frequency.EventUniqueUserFrequencyConditionWithConditions'
-      );
-    }
-
     conditions = conditions?.map(condition =>
       CHANGE_ALERT_CONDITION_IDS.includes(condition.id)
         ? {

--- a/tests/sentry/api/endpoints/test_project_rules_configuration.py
+++ b/tests/sentry/api/endpoints/test_project_rules_configuration.py
@@ -8,7 +8,6 @@ from sentry.rules import rules as default_rules
 from sentry.rules.actions.notify_event_service import NotifyEventServiceAction
 from sentry.rules.registry import RuleRegistry
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.features import with_feature
 
 APP_ACTION = "sentry.rules.actions.notify_event_service.NotifyEventServiceAction"
 SENTRY_APP_ALERT_ACTION = "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction"
@@ -176,39 +175,14 @@ class ProjectRuleConfigurationTest(APITestCase):
             "formFields": settings_schema["settings"],
             "sentryAppInstallationUuid": str(install.uuid),
         } in response.data["actions"]
-        assert len(response.data["conditions"]) == 9
+        assert len(response.data["conditions"]) == 10
         assert len(response.data["filters"]) == 10
 
     def test_issue_type_and_category_filter_feature(self) -> None:
         response = self.get_success_response(self.organization.slug, self.project.slug)
         assert len(response.data["actions"]) == 13
-        assert len(response.data["conditions"]) == 9
-        assert len(response.data["filters"]) == 10
-
-        response = self.get_success_response(self.organization.slug, self.project.slug)
-        tagged_event_filter = next(
-            (
-                filter
-                for filter in response.data["filters"]
-                if filter["id"] == "sentry.rules.filters.tagged_event.TaggedEventFilter"
-            ),
-            None,
-        )
-        assert tagged_event_filter
-        filter_list = [
-            choice[0] for choice in tagged_event_filter["formFields"]["match"]["choices"]
-        ]
-        assert MatchType.IS_IN in filter_list
-        assert MatchType.NOT_IN in filter_list
-
-    @with_feature("organizations:event-unique-user-frequency-condition-with-conditions")
-    def test_issue_type_and_category_filter_feature_with_conditions(self) -> None:
-        response = self.get_success_response(self.organization.slug, self.project.slug)
-        assert len(response.data["actions"]) == 13
-
         assert len(response.data["conditions"]) == 10
         assert len(response.data["filters"]) == 10
-        assert len(response.data["conditions"]) == 10
 
         response = self.get_success_response(self.organization.slug, self.project.slug)
         tagged_event_filter = next(

--- a/tests/sentry/api/endpoints/test_project_rules_configuration.py
+++ b/tests/sentry/api/endpoints/test_project_rules_configuration.py
@@ -33,7 +33,7 @@ class ProjectRuleConfigurationTest(APITestCase):
 
         response = self.get_success_response(self.organization.slug, project1.slug)
         assert len(response.data["actions"]) == 13
-        assert len(response.data["conditions"]) == 9
+        assert len(response.data["conditions"]) == 10
         assert len(response.data["filters"]) == 10
 
     @property
@@ -144,7 +144,7 @@ class ProjectRuleConfigurationTest(APITestCase):
                 "service": {"type": "choice", "choices": [[sentry_app.slug, sentry_app.name]]}
             },
         } in response.data["actions"]
-        assert len(response.data["conditions"]) == 9
+        assert len(response.data["conditions"]) == 10
         assert len(response.data["filters"]) == 10
 
     @patch("sentry.sentry_apps.components.SentryAppComponentPreparer.run")

--- a/tests/snuba/rules/conditions/test_event_frequency.py
+++ b/tests/snuba/rules/conditions/test_event_frequency.py
@@ -28,7 +28,6 @@ from sentry.testutils.cases import (
     SnubaTestCase,
 )
 from sentry.testutils.helpers.datetime import before_now, freeze_time
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.skips import requires_snuba
 from sentry.utils.samples import load_data
 
@@ -832,7 +831,6 @@ class EventUniqueUserFrequencyConditionTestCase(StandardIntervalTestBase):
             )
 
 
-@with_feature("organizations:event-unique-user-frequency-condition-with-conditions")
 class EventUniqueUserFrequencyConditionWithConditionsTestCase(StandardIntervalTestBase):
     __test__ = Abstract(__module__, __qualname__)
 


### PR DESCRIPTION
This condition has been created in workflow engine without this flag, so we may as well just release this everywhere.

Since we're defaulting this to true, there's no need to worry about splitting fe/be.
