### PR TITLE
feat(billing): display a customer's managed status in _admin

### DIFF
--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -723,6 +723,7 @@ export function CustomerOverview({customer, onAction, organization}: Props) {
             {customer.owner ? <CustomerContact owner={customer.owner} /> : 'n/a'}{' '}
           </DetailLabel>
           <DetailLabel title="Type">{customer.type || 'n/a'}</DetailLabel>
+          <DetailLabel title="Managed" yesNo={customer.isManaged} />
           <DetailLabel title="Channel">{customer.channel || 'n/a'}</DetailLabel>
           <DetailLabel title="Sponsored Type">
             {customer.sponsoredType || 'n/a'}


### PR DESCRIPTION
feat(billing): display a customer's managed status in _admin. 

<img width="226" height="32" alt="image" src="https://github.com/user-attachments/assets/b48c6fa9-dc89-4840-a04e-e836dfc2d0c5" />

Makes it easier to see the customer's managed status in _admin.
