### PR TITLE
fix(aci): Handle missing resolve condition in serializer

### DIFF
--- a/src/sentry/workflow_engine/migration_helpers/utils.py
+++ b/src/sentry/workflow_engine/migration_helpers/utils.py
@@ -17,13 +17,16 @@ ACTION_TYPE_TO_STRING = {
 }
 
 
-def get_resolve_threshold(condition_group: DataConditionGroup) -> float:
+def get_resolve_threshold(condition_group: DataConditionGroup) -> float | None:
     """
-    Returns the resolution threshold for a static or percent-based metric issue
+    Returns the resolution threshold for a static or percent-based metric issue,
+    or None if no resolve condition exists.
     """
-    resolve_condition = DataCondition.objects.get(
+    resolve_condition = DataCondition.objects.filter(
         condition_result=DetectorPriorityLevel.OK, condition_group=condition_group
-    )
+    ).first()
+    if resolve_condition is None:
+        return None
     return resolve_condition.comparison
 
 

--- a/tests/sentry/incidents/serializers/test_workflow_engine_data_condition.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_data_condition.py
@@ -17,6 +17,7 @@ from sentry.workflow_engine.migration_helpers.alert_rule import (
 )
 from sentry.workflow_engine.models import DataCondition, WorkflowDataConditionGroup
 from sentry.workflow_engine.models.data_condition import Condition
+from sentry.workflow_engine.types import DetectorPriorityLevel
 from tests.sentry.incidents.serializers.test_workflow_engine_base import (
     TestWorkflowEngineSerializer,
 )
@@ -218,3 +219,17 @@ class TestDataConditionSerializer(TestWorkflowEngineSerializer):
         assert serialized_warning_condition["alertRuleId"] == str(alert_rule.id)
         assert len(serialized_warning_condition["actions"]) == 1
         assert serialized_warning_condition["actions"][0]["id"] == str(warning_action.id)
+
+    def test_missing_resolve_condition(self) -> None:
+        # Delete the resolve condition created during setUp
+        DataCondition.objects.filter(
+            condition_group=self.critical_detector_trigger.condition_group,
+            condition_result=DetectorPriorityLevel.OK,
+        ).delete()
+
+        serialized = serialize(
+            self.critical_detector_trigger,
+            self.user,
+            WorkflowEngineDataConditionSerializer(),
+        )
+        assert serialized["resolveThreshold"] is None


### PR DESCRIPTION
This isn't a common case, but can result in practice if a dual written alert is modified via Detector APIs.

Fixes ISWF-2322.
