### PR TITLE
chore(supergroups-backfill): Reduce lightweight backfill batch size and delay

### DIFF
--- a/src/sentry/tasks/seer/backfill_supergroups_lightweight.py
+++ b/src/sentry/tasks/seer/backfill_supergroups_lightweight.py
@@ -25,9 +25,9 @@ from sentry.utils.snuba import bulk_snuba_queries
 
 logger = logging.getLogger(__name__)
 
-BATCH_SIZE = 50
-INTER_BATCH_DELAY_S = 1
-MAX_FAILURES_PER_BATCH = 20
+BATCH_SIZE = 25
+INTER_BATCH_DELAY_S = 10
+MAX_FAILURES_PER_BATCH = 10
 
 
 @instrumented_task(


### PR DESCRIPTION
Seer's lightweight RCA endpoint queues a Celery task and returns in ~20ms, so the bottleneck is Seer processing capacity not request latency. Reduce batch size to 25 and increase delay to 10s to give Seer time to process queued tasks between batches and avoid overloading its worker pool.