### PR TITLE
feat(viewer-context): Add JWT encode/decode for ViewerContext propagation

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -783,6 +783,9 @@ SEER_RPC_SHARED_SECRET: list[str] | None = None
 # Shared secret used to sign cross-region RPC requests to the seer microservice.
 SEER_API_SHARED_SECRET: str = ""
 
+# TTL in seconds for ViewerContext JWT tokens.
+VIEWER_CONTEXT_JWT_TTL: int = 60
+
 # Sign requests to the SCM RPC endpoint
 # First element is used to sign requests; request is accepted if signed with any element in the list.
 SCM_RPC_SHARED_SECRET: list[str] | None = None

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -784,7 +784,7 @@ SEER_RPC_SHARED_SECRET: list[str] | None = None
 SEER_API_SHARED_SECRET: str = ""
 
 # TTL in seconds for ViewerContext JWT tokens.
-VIEWER_CONTEXT_JWT_TTL: int = 300
+VIEWER_CONTEXT_JWT_TTL: int = 900
 
 # Sign requests to the SCM RPC endpoint
 # First element is used to sign requests; request is accepted if signed with any element in the list.

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -784,7 +784,7 @@ SEER_RPC_SHARED_SECRET: list[str] | None = None
 SEER_API_SHARED_SECRET: str = ""
 
 # TTL in seconds for ViewerContext JWT tokens.
-VIEWER_CONTEXT_JWT_TTL: int = 60
+VIEWER_CONTEXT_JWT_TTL: int = 300
 
 # Sign requests to the SCM RPC endpoint
 # First element is used to sign requests; request is accepted if signed with any element in the list.

--- a/src/sentry/viewer_context.py
+++ b/src/sentry/viewer_context.py
@@ -4,6 +4,8 @@ import contextlib
 import contextvars
 import dataclasses
 import enum
+import hashlib
+import time
 from collections.abc import Generator
 from typing import TYPE_CHECKING, Any
 
@@ -93,3 +95,97 @@ def viewer_context_scope(ctx: ViewerContext) -> Generator[None]:
 def get_viewer_context() -> ViewerContext | None:
     """Return the current ``ViewerContext``, or ``None`` if not set."""
     return _viewer_context_var.get()
+
+
+# ---------------------------------------------------------------------------
+# JWT encoding / decoding for cross-service propagation
+# ---------------------------------------------------------------------------
+
+_JWT_STANDARD_CLAIMS = frozenset({"iat", "exp", "iss", "aud", "nbf", "jti", "sub"})
+
+
+def _key_id(key: str) -> str:
+    """Short stable identifier for a key (first 8 hex chars of SHA-256).
+
+    Embedded as ``kid`` in the JWT header so the receiver can look up the
+    correct verification key without trying every key it knows about.
+    """
+    return hashlib.sha256(key.encode("utf-8")).hexdigest()[:8]
+
+
+def _get_jwt_secret(key: str | None = None) -> str:
+    """Return the symmetric key to use for JWT signing/verification.
+
+    Resolution: explicit *key* → ``SEER_API_SHARED_SECRET``.
+
+    TODO: Add a dedicated ``VIEWER_CONTEXT_JWT_SECRET`` setting so that
+    ViewerContext signing is not coupled to the Seer shared secret.
+    """
+    if key is not None:
+        return key
+
+    from django.conf import settings
+
+    secret = getattr(settings, "SEER_API_SHARED_SECRET", "")
+    if secret:
+        return secret
+
+    raise ValueError("No signing key available. Set SEER_API_SHARED_SECRET in settings.")
+
+
+def encode_viewer_context(
+    viewer_context: ViewerContext,
+    *,
+    key: str | None = None,
+    ttl: int | None = None,
+) -> str:
+    """Encode a :class:`ViewerContext` as a signed HS256 JWT."""
+    from django.conf import settings
+
+    from sentry.utils import jwt as jwt_utils
+
+    secret = _get_jwt_secret(key)
+
+    if ttl is None:
+        ttl = getattr(settings, "VIEWER_CONTEXT_JWT_TTL", 60)
+
+    now = time.time()
+    payload: dict[str, Any] = {
+        **viewer_context.serialize(),
+        "iat": now,
+        "exp": now + ttl,
+        "iss": "sentry",
+    }
+
+    return jwt_utils.encode(payload, secret, headers={"kid": _key_id(secret)})
+
+
+def decode_viewer_context(
+    token: str,
+    *,
+    key: str | None = None,
+    leeway: int = 5,
+) -> ViewerContext:
+    """Decode and verify an HS256 JWT into a :class:`ViewerContext`."""
+    import jwt as pyjwt
+
+    secret = _get_jwt_secret(key)
+
+    claims = pyjwt.decode(
+        token,
+        secret,
+        algorithms=["HS256"],
+        options={"require": ["iat", "exp", "iss"]},
+        issuer="sentry",
+        leeway=leeway,
+    )
+    vc_data = {k: v for k, v in claims.items() if k not in _JWT_STANDARD_CLAIMS}
+    return ViewerContext.deserialize(vc_data)
+
+
+def is_jwt_viewer_context(header_value: str) -> bool:
+    """Heuristic to distinguish a JWT from a raw JSON payload.
+
+    JWTs contain dots separating base64url segments; raw JSON starts with ``{``.
+    """
+    return "." in header_value and not header_value.startswith("{")

--- a/src/sentry/viewer_context.py
+++ b/src/sentry/viewer_context.py
@@ -63,8 +63,6 @@ class ViewerContext:
             result["organization_id"] = self.organization_id
         if self.user_id is not None:
             result["user_id"] = self.user_id
-        if self.token is not None:
-            result["token"] = {"kind": self.token.kind, "scopes": list(self.token.get_scopes())}
         return result
 
     @classmethod
@@ -144,7 +142,7 @@ def encode_viewer_context(
     secret = _get_jwt_secret(key)
 
     if ttl is None:
-        ttl = getattr(settings, "VIEWER_CONTEXT_JWT_TTL", 300)
+        ttl = getattr(settings, "VIEWER_CONTEXT_JWT_TTL", 900)
 
     now = time.time()
     payload: dict[str, Any] = {

--- a/src/sentry/viewer_context.py
+++ b/src/sentry/viewer_context.py
@@ -179,8 +179,13 @@ def decode_viewer_context(
 
 
 def is_jwt_viewer_context(header_value: str) -> bool:
-    """Heuristic to distinguish a JWT from a raw JSON payload.
+    """Check whether the header value is a JWT by attempting to read its header.
 
-    JWTs contain dots separating base64url segments; raw JSON starts with ``{``.
+    Uses PyJWT's own parser — raises ``DecodeError`` on anything that
+    isn't a valid JWT structure (raw JSON, empty string, etc.).
     """
-    return "." in header_value and not header_value.startswith("{")
+    try:
+        pyjwt.get_unverified_header(header_value)
+        return True
+    except pyjwt.exceptions.DecodeError:
+        return False

--- a/src/sentry/viewer_context.py
+++ b/src/sentry/viewer_context.py
@@ -144,7 +144,7 @@ def encode_viewer_context(
     secret = _get_jwt_secret(key)
 
     if ttl is None:
-        ttl = getattr(settings, "VIEWER_CONTEXT_JWT_TTL", 60)
+        ttl = getattr(settings, "VIEWER_CONTEXT_JWT_TTL", 300)
 
     now = time.time()
     payload: dict[str, Any] = {

--- a/src/sentry/viewer_context.py
+++ b/src/sentry/viewer_context.py
@@ -12,8 +12,6 @@ from typing import TYPE_CHECKING, Any
 import jwt as pyjwt
 from django.conf import settings
 
-from sentry.utils import jwt as jwt_utils
-
 if TYPE_CHECKING:
     from sentry.auth.services.auth import AuthenticatedToken
 
@@ -156,7 +154,7 @@ def encode_viewer_context(
         "iss": "sentry",
     }
 
-    return jwt_utils.encode(payload, secret, headers={"kid": _key_id(secret)})
+    return pyjwt.encode(payload, secret, algorithm="HS256", headers={"kid": _key_id(secret)})
 
 
 def decode_viewer_context(

--- a/src/sentry/viewer_context.py
+++ b/src/sentry/viewer_context.py
@@ -9,6 +9,11 @@ import time
 from collections.abc import Generator
 from typing import TYPE_CHECKING, Any
 
+import jwt as pyjwt
+from django.conf import settings
+
+from sentry.utils import jwt as jwt_utils
+
 if TYPE_CHECKING:
     from sentry.auth.services.auth import AuthenticatedToken
 
@@ -124,8 +129,6 @@ def _get_jwt_secret(key: str | None = None) -> str:
     if key is not None:
         return key
 
-    from django.conf import settings
-
     secret = getattr(settings, "SEER_API_SHARED_SECRET", "")
     if secret:
         return secret
@@ -140,10 +143,6 @@ def encode_viewer_context(
     ttl: int | None = None,
 ) -> str:
     """Encode a :class:`ViewerContext` as a signed HS256 JWT."""
-    from django.conf import settings
-
-    from sentry.utils import jwt as jwt_utils
-
     secret = _get_jwt_secret(key)
 
     if ttl is None:
@@ -167,8 +166,6 @@ def decode_viewer_context(
     leeway: int = 5,
 ) -> ViewerContext:
     """Decode and verify an HS256 JWT into a :class:`ViewerContext`."""
-    import jwt as pyjwt
-
     secret = _get_jwt_secret(key)
 
     claims = pyjwt.decode(

--- a/tests/sentry/test_viewer_context_jwt.py
+++ b/tests/sentry/test_viewer_context_jwt.py
@@ -58,7 +58,7 @@ class TestEncodeViewerContext(TestCase):
         assert "iat" in claims
         assert "exp" in claims
         assert claims["iss"] == "sentry"
-        assert claims["exp"] - claims["iat"] == 300  # default TTL
+        assert claims["exp"] - claims["iat"] == 900  # default TTL
 
     @override_settings(SEER_API_SHARED_SECRET="test-secret-key")
     def test_custom_ttl(self):
@@ -96,8 +96,7 @@ class TestEncodeViewerContext(TestCase):
         assert result.token is None
 
         claims = pyjwt.decode(jwt_token, options={"verify_signature": False})
-        assert "token" in claims  # serialize() includes it
-        assert claims["token"]["kind"] == "api_token"
+        assert "token" not in claims
 
 
 class TestDecodeViewerContext(TestCase):

--- a/tests/sentry/test_viewer_context_jwt.py
+++ b/tests/sentry/test_viewer_context_jwt.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import time
 
+import jwt as pyjwt
 import pytest
 from django.test import override_settings
 
@@ -50,12 +51,10 @@ class TestEncodeDecodeRoundtrip(TestCase):
 class TestEncodeViewerContext(TestCase):
     @override_settings(SEER_API_SHARED_SECRET="test-secret-key")
     def test_standard_claims_present(self):
-        from sentry.utils import jwt as jwt_utils
-
         vc = ViewerContext(organization_id=1, actor_type=ActorType.USER)
         token = encode_viewer_context(vc)
 
-        claims = jwt_utils.peek_claims(token)
+        claims = pyjwt.decode(token, options={"verify_signature": False})
         assert "iat" in claims
         assert "exp" in claims
         assert claims["iss"] == "sentry"
@@ -63,12 +62,10 @@ class TestEncodeViewerContext(TestCase):
 
     @override_settings(SEER_API_SHARED_SECRET="test-secret-key")
     def test_custom_ttl(self):
-        from sentry.utils import jwt as jwt_utils
-
         vc = ViewerContext(organization_id=1, actor_type=ActorType.USER)
         token = encode_viewer_context(vc, ttl=300)
 
-        claims = jwt_utils.peek_claims(token)
+        claims = pyjwt.decode(token, options={"verify_signature": False})
         assert claims["exp"] - claims["iat"] == 300
 
     def test_custom_key_parameter(self):
@@ -88,8 +85,6 @@ class TestEncodeViewerContext(TestCase):
     def test_token_field_not_in_jwt(self):
         from unittest.mock import MagicMock
 
-        from sentry.utils import jwt as jwt_utils
-
         mock_token = MagicMock()
         mock_token.kind = "api_token"
         mock_token.get_scopes.return_value = ["org:read"]
@@ -100,7 +95,7 @@ class TestEncodeViewerContext(TestCase):
         result = decode_viewer_context(jwt_token)
         assert result.token is None
 
-        claims = jwt_utils.peek_claims(jwt_token)
+        claims = pyjwt.decode(jwt_token, options={"verify_signature": False})
         assert "token" in claims  # serialize() includes it
         assert claims["token"]["kind"] == "api_token"
 
@@ -108,10 +103,6 @@ class TestEncodeViewerContext(TestCase):
 class TestDecodeViewerContext(TestCase):
     @override_settings(SEER_API_SHARED_SECRET="test-secret-key")
     def test_expired_token_rejected(self):
-        import jwt as pyjwt
-
-        from sentry.utils import jwt as jwt_utils
-
         payload = {
             "organization_id": 1,
             "actor_type": "user",
@@ -119,14 +110,12 @@ class TestDecodeViewerContext(TestCase):
             "exp": time.time() - 60,
             "iss": "sentry",
         }
-        expired_token = jwt_utils.encode(payload, "test-secret-key")
+        expired_token = pyjwt.encode(payload, "test-secret-key", algorithm="HS256")
 
         with pytest.raises(pyjwt.exceptions.ExpiredSignatureError):
             decode_viewer_context(expired_token)
 
     def test_wrong_key_rejected(self):
-        import jwt as pyjwt
-
         vc = ViewerContext(organization_id=1, actor_type=ActorType.USER)
         token = encode_viewer_context(vc, key="correct-key")
 
@@ -134,8 +123,6 @@ class TestDecodeViewerContext(TestCase):
             decode_viewer_context(token, key="wrong-key")
 
     def test_leeway_accepts_nearly_expired(self):
-        from sentry.utils import jwt as jwt_utils
-
         payload = {
             "organization_id": 1,
             "actor_type": "user",
@@ -143,7 +130,7 @@ class TestDecodeViewerContext(TestCase):
             "exp": time.time() - 3,  # expired 3 seconds ago
             "iss": "sentry",
         }
-        token = jwt_utils.encode(payload, "test-key")
+        token = pyjwt.encode(payload, "test-key", algorithm="HS256")
 
         # Should succeed with default leeway of 5 seconds
         result = decode_viewer_context(token, key="test-key")

--- a/tests/sentry/test_viewer_context_jwt.py
+++ b/tests/sentry/test_viewer_context_jwt.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import time
+
+import pytest
+from django.test import override_settings
+
+from sentry.testutils.cases import TestCase
+from sentry.viewer_context import (
+    ActorType,
+    ViewerContext,
+    decode_viewer_context,
+    encode_viewer_context,
+    is_jwt_viewer_context,
+)
+
+
+class TestEncodeDecodeRoundtrip(TestCase):
+    @override_settings(SEER_API_SHARED_SECRET="test-secret-key")
+    def test_roundtrip(self):
+        vc = ViewerContext(organization_id=42, user_id=7, actor_type=ActorType.USER)
+        token = encode_viewer_context(vc)
+        result = decode_viewer_context(token)
+
+        assert result.organization_id == 42
+        assert result.user_id == 7
+        assert result.actor_type == ActorType.USER
+        assert result.token is None
+
+    @override_settings(SEER_API_SHARED_SECRET="test-secret-key")
+    def test_roundtrip_minimal(self):
+        vc = ViewerContext(actor_type=ActorType.SYSTEM)
+        token = encode_viewer_context(vc)
+        result = decode_viewer_context(token)
+
+        assert result.organization_id is None
+        assert result.user_id is None
+        assert result.actor_type == ActorType.SYSTEM
+
+    @override_settings(SEER_API_SHARED_SECRET="test-secret-key")
+    def test_roundtrip_integration(self):
+        vc = ViewerContext(organization_id=99, actor_type=ActorType.INTEGRATION)
+        token = encode_viewer_context(vc)
+        result = decode_viewer_context(token)
+
+        assert result.organization_id == 99
+        assert result.actor_type == ActorType.INTEGRATION
+
+
+class TestEncodeViewerContext(TestCase):
+    @override_settings(SEER_API_SHARED_SECRET="test-secret-key")
+    def test_standard_claims_present(self):
+        from sentry.utils import jwt as jwt_utils
+
+        vc = ViewerContext(organization_id=1, actor_type=ActorType.USER)
+        token = encode_viewer_context(vc)
+
+        claims = jwt_utils.peek_claims(token)
+        assert "iat" in claims
+        assert "exp" in claims
+        assert claims["iss"] == "sentry"
+        assert claims["exp"] - claims["iat"] == 60  # default TTL
+
+    @override_settings(SEER_API_SHARED_SECRET="test-secret-key")
+    def test_custom_ttl(self):
+        from sentry.utils import jwt as jwt_utils
+
+        vc = ViewerContext(organization_id=1, actor_type=ActorType.USER)
+        token = encode_viewer_context(vc, ttl=300)
+
+        claims = jwt_utils.peek_claims(token)
+        assert claims["exp"] - claims["iat"] == 300
+
+    def test_custom_key_parameter(self):
+        vc = ViewerContext(organization_id=1, actor_type=ActorType.USER)
+        token = encode_viewer_context(vc, key="my-custom-key")
+        result = decode_viewer_context(token, key="my-custom-key")
+
+        assert result.organization_id == 1
+
+    @override_settings(SEER_API_SHARED_SECRET="")
+    def test_no_key_raises_value_error(self):
+        vc = ViewerContext(organization_id=1, actor_type=ActorType.USER)
+        with pytest.raises(ValueError, match="No signing key available"):
+            encode_viewer_context(vc)
+
+    @override_settings(SEER_API_SHARED_SECRET="test-secret-key")
+    def test_token_field_not_in_jwt(self):
+        from unittest.mock import MagicMock
+
+        from sentry.utils import jwt as jwt_utils
+
+        mock_token = MagicMock()
+        mock_token.kind = "api_token"
+        mock_token.get_scopes.return_value = ["org:read"]
+
+        vc = ViewerContext(organization_id=1, actor_type=ActorType.USER, token=mock_token)
+        jwt_token = encode_viewer_context(vc)
+
+        result = decode_viewer_context(jwt_token)
+        assert result.token is None
+
+        claims = jwt_utils.peek_claims(jwt_token)
+        assert "token" in claims  # serialize() includes it
+        assert claims["token"]["kind"] == "api_token"
+
+
+class TestDecodeViewerContext(TestCase):
+    @override_settings(SEER_API_SHARED_SECRET="test-secret-key")
+    def test_expired_token_rejected(self):
+        import jwt as pyjwt
+
+        from sentry.utils import jwt as jwt_utils
+
+        payload = {
+            "organization_id": 1,
+            "actor_type": "user",
+            "iat": time.time() - 120,
+            "exp": time.time() - 60,
+            "iss": "sentry",
+        }
+        expired_token = jwt_utils.encode(payload, "test-secret-key")
+
+        with pytest.raises(pyjwt.exceptions.ExpiredSignatureError):
+            decode_viewer_context(expired_token)
+
+    def test_wrong_key_rejected(self):
+        import jwt as pyjwt
+
+        vc = ViewerContext(organization_id=1, actor_type=ActorType.USER)
+        token = encode_viewer_context(vc, key="correct-key")
+
+        with pytest.raises(pyjwt.exceptions.InvalidSignatureError):
+            decode_viewer_context(token, key="wrong-key")
+
+    def test_leeway_accepts_nearly_expired(self):
+        from sentry.utils import jwt as jwt_utils
+
+        payload = {
+            "organization_id": 1,
+            "actor_type": "user",
+            "iat": time.time() - 63,
+            "exp": time.time() - 3,  # expired 3 seconds ago
+            "iss": "sentry",
+        }
+        token = jwt_utils.encode(payload, "test-key")
+
+        # Should succeed with default leeway of 5 seconds
+        result = decode_viewer_context(token, key="test-key")
+        assert result.organization_id == 1
+
+    @override_settings(SEER_API_SHARED_SECRET="")
+    def test_no_verification_key_raises(self):
+        vc = ViewerContext(organization_id=1, actor_type=ActorType.USER)
+        token = encode_viewer_context(vc, key="some-key")
+
+        with pytest.raises(ValueError, match="No signing key available"):
+            decode_viewer_context(token)
+
+
+class TestIsJwtViewerContext(TestCase):
+    def test_jwt_string(self):
+        assert is_jwt_viewer_context("eyJhbGciOiJIUzI1NiJ9.eyJmb28iOiJiYXIifQ.sig") is True
+
+    def test_json_string(self):
+        assert is_jwt_viewer_context('{"actor_type": "user", "organization_id": 1}') is False
+
+    def test_empty_string(self):
+        assert is_jwt_viewer_context("") is False

--- a/tests/sentry/test_viewer_context_jwt.py
+++ b/tests/sentry/test_viewer_context_jwt.py
@@ -59,7 +59,7 @@ class TestEncodeViewerContext(TestCase):
         assert "iat" in claims
         assert "exp" in claims
         assert claims["iss"] == "sentry"
-        assert claims["exp"] - claims["iat"] == 60  # default TTL
+        assert claims["exp"] - claims["iat"] == 300  # default TTL
 
     @override_settings(SEER_API_SHARED_SECRET="test-secret-key")
     def test_custom_ttl(self):


### PR DESCRIPTION
Add `encode_viewer_context` and `decode_viewer_context` to `viewer_context.py`
for signing ViewerContext as HS256 JWTs using PyJWT directly. This collapses
the current two-header approach (`X-Viewer-Context` + `X-Viewer-Context-Signature`)
into a single self-contained token with standard claims (`iat`, `exp`, `iss`)
and a `kid` header for key identification.

**Not yet wired into the sending path** — the existing HMAC format in
`signed_seer_api.py` is unchanged. This PR just lands the encode/decode
functions and tests so we can migrate Seer (and future services) incrementally.

Key defaults to `SEER_API_SHARED_SECRET` (already provisioned). Callers can
override via the `key=` parameter for service-specific secrets. A
`VIEWER_CONTEXT_JWT_TTL` setting (default 5 min) controls token lifetime.

Also adds `is_jwt_viewer_context()` heuristic so receivers can distinguish
JWT tokens from legacy raw JSON during the migration period.

Uses PyJWT directly rather than `sentry.utils.jwt` — the wrapper doesn't
expose `issuer`, `leeway`, or `require` which we need for verification.