### PR TITLE
ref(integrations): Refactor the useAddIntegration hook

### DIFF
--- a/static/app/components/repositories/scmIntegrationTree/scmIntegrationTree.tsx
+++ b/static/app/components/repositories/scmIntegrationTree/scmIntegrationTree.tsx
@@ -33,6 +33,7 @@ import type {InfiniteData} from 'sentry/utils/queryClient';
 import {useQueryClient} from 'sentry/utils/queryClient';
 import {useApi} from 'sentry/utils/useApi';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {PostMessageProvider} from 'sentry/utils/window/usePostMessage';
 
 const ROW_HEIGHT = 56;
 const BOTTOM_PADDING = 24;
@@ -299,37 +300,41 @@ export function ScmIntegrationTree({search, repoFilter, providerFilter}: Props) 
   }
 
   return (
-    <TreePanel>
-      <ScrollableBody
-        ref={setScrollBodyRef}
-        style={{
-          maxHeight: scrollBodyHeight ? `calc(100vh - ${scrollBodyHeight}px)` : undefined,
-        }}
-      >
-        <VirtualInner style={{height: virtualizer.getTotalSize()}}>
-          {virtualizer.getVirtualItems().map(virtualItem => {
-            const node = flatNodes[virtualItem.index];
-            if (!node) return null;
+    <PostMessageProvider>
+      <TreePanel>
+        <ScrollableBody
+          ref={setScrollBodyRef}
+          style={{
+            maxHeight: scrollBodyHeight
+              ? `calc(100vh - ${scrollBodyHeight}px)`
+              : undefined,
+          }}
+        >
+          <VirtualInner style={{height: virtualizer.getTotalSize()}}>
+            {virtualizer.getVirtualItems().map(virtualItem => {
+              const node = flatNodes[virtualItem.index];
+              if (!node) return null;
 
-            return (
-              <ScmIntegrationTreeRow
-                key={virtualItem.key}
-                node={node}
-                style={{
-                  transform: `translateY(${virtualItem.start}px)`,
-                  height: virtualItem.size,
-                }}
-                onAddIntegration={handleAddIntegration}
-                onToggleProvider={toggleProvider}
-                onToggleIntegration={toggleIntegration}
-                onToggleRepo={handleToggleRepo}
-                onRemoveDisconnectedRepo={handleRemoveDisconnectedRepo}
-              />
-            );
-          })}
-        </VirtualInner>
-      </ScrollableBody>
-    </TreePanel>
+              return (
+                <ScmIntegrationTreeRow
+                  key={virtualItem.key}
+                  node={node}
+                  style={{
+                    transform: `translateY(${virtualItem.start}px)`,
+                    height: virtualItem.size,
+                  }}
+                  onAddIntegration={handleAddIntegration}
+                  onToggleProvider={toggleProvider}
+                  onToggleIntegration={toggleIntegration}
+                  onToggleRepo={handleToggleRepo}
+                  onRemoveDisconnectedRepo={handleRemoveDisconnectedRepo}
+                />
+              );
+            })}
+          </VirtualInner>
+        </ScrollableBody>
+      </TreePanel>
+    </PostMessageProvider>
   );
 }
 

--- a/static/app/utils/integrations/useAddIntegration.spec.tsx
+++ b/static/app/utils/integrations/useAddIntegration.spec.tsx
@@ -8,7 +8,8 @@ import * as indicators from 'sentry/actionCreators/indicator';
 import * as pipelineModal from 'sentry/components/pipeline/modal';
 import {ConfigStore} from 'sentry/stores/configStore';
 import type {Config} from 'sentry/types/system';
-import {useAddIntegration} from 'sentry/views/settings/organizationIntegrations/addIntegration';
+import {useAddIntegration} from 'sentry/utils/integrations/useAddIntegration';
+import {PostMessageProvider} from 'sentry/utils/window/usePostMessage';
 
 describe('useAddIntegration', () => {
   const provider = GitHubIntegrationProviderFixture();
@@ -54,15 +55,16 @@ describe('useAddIntegration', () => {
     });
 
     it('opens a popup window when startFlow is called', () => {
-      const {result} = renderHookWithProviders(() =>
-        useAddIntegration({
+      const {result} = renderHookWithProviders(useAddIntegration, {
+        additionalWrapper: PostMessageProvider,
+      });
+
+      act(() =>
+        result.current.startFlow({
           provider,
-          organization: OrganizationFixture(),
           onInstall: jest.fn(),
         })
       );
-
-      act(() => result.current.startFlow());
 
       expect(window.open).toHaveBeenCalledTimes(1);
       expect(jest.mocked(window.open).mock.calls[0]![0]).toBe(
@@ -72,17 +74,18 @@ describe('useAddIntegration', () => {
     });
 
     it('includes account and modalParams in the popup URL', () => {
-      const {result} = renderHookWithProviders(() =>
-        useAddIntegration({
+      const {result} = renderHookWithProviders(useAddIntegration, {
+        additionalWrapper: PostMessageProvider,
+      });
+
+      act(() =>
+        result.current.startFlow({
           provider,
-          organization: OrganizationFixture(),
           onInstall: jest.fn(),
           account: 'my-account',
           modalParams: {use_staging: '1'},
         })
       );
-
-      act(() => result.current.startFlow());
 
       const calls = jest.mocked(window.open).mock.calls[0]!;
       const url = calls[0] as string;
@@ -92,15 +95,17 @@ describe('useAddIntegration', () => {
     });
 
     it('includes urlParams passed to startFlow', () => {
-      const {result} = renderHookWithProviders(() =>
-        useAddIntegration({
+      const {result} = renderHookWithProviders(useAddIntegration, {
+        additionalWrapper: PostMessageProvider,
+      });
+
+      act(() =>
+        result.current.startFlow({
           provider,
-          organization: OrganizationFixture(),
           onInstall: jest.fn(),
+          urlParams: {custom_param: 'value'},
         })
       );
-
-      act(() => result.current.startFlow({custom_param: 'value'}));
 
       const url = jest.mocked(window.open).mock.calls[0]![0] as string;
       expect(url).toContain('custom_param=value');
@@ -109,15 +114,16 @@ describe('useAddIntegration', () => {
     it('calls onInstall when a success message is received', async () => {
       const onInstall = jest.fn();
 
-      const {result} = renderHookWithProviders(() =>
-        useAddIntegration({
+      const {result} = renderHookWithProviders(useAddIntegration, {
+        additionalWrapper: PostMessageProvider,
+      });
+
+      act(() =>
+        result.current.startFlow({
           provider,
-          organization: OrganizationFixture(),
           onInstall,
         })
       );
-
-      act(() => result.current.startFlow());
 
       const newIntegration = {
         success: true,
@@ -137,15 +143,16 @@ describe('useAddIntegration', () => {
     it('shows a success indicator on successful installation', async () => {
       const successSpy = jest.spyOn(indicators, 'addSuccessMessage');
 
-      const {result} = renderHookWithProviders(() =>
-        useAddIntegration({
+      const {result} = renderHookWithProviders(useAddIntegration, {
+        additionalWrapper: PostMessageProvider,
+      });
+
+      act(() =>
+        result.current.startFlow({
           provider,
-          organization: OrganizationFixture(),
           onInstall: jest.fn(),
         })
       );
-
-      act(() => result.current.startFlow());
 
       postMessageFromPopup(popup, {success: true, data: integration});
       await waitFor(() => expect(successSpy).toHaveBeenCalledWith('GitHub added'));
@@ -154,15 +161,16 @@ describe('useAddIntegration', () => {
     it('shows an error indicator when the message has success: false', async () => {
       const errorSpy = jest.spyOn(indicators, 'addErrorMessage');
 
-      const {result} = renderHookWithProviders(() =>
-        useAddIntegration({
+      const {result} = renderHookWithProviders(useAddIntegration, {
+        additionalWrapper: PostMessageProvider,
+      });
+
+      act(() =>
+        result.current.startFlow({
           provider,
-          organization: OrganizationFixture(),
           onInstall: jest.fn(),
         })
       );
-
-      act(() => result.current.startFlow());
 
       postMessageFromPopup(popup, {success: false, data: {error: 'OAuth failed'}});
       await waitFor(() => expect(errorSpy).toHaveBeenCalledWith('OAuth failed'));
@@ -171,15 +179,16 @@ describe('useAddIntegration', () => {
     it('shows a generic error when no error message is provided', async () => {
       const errorSpy = jest.spyOn(indicators, 'addErrorMessage');
 
-      const {result} = renderHookWithProviders(() =>
-        useAddIntegration({
+      const {result} = renderHookWithProviders(useAddIntegration, {
+        additionalWrapper: PostMessageProvider,
+      });
+
+      act(() =>
+        result.current.startFlow({
           provider,
-          organization: OrganizationFixture(),
           onInstall: jest.fn(),
         })
       );
-
-      act(() => result.current.startFlow());
 
       postMessageFromPopup(popup, {success: false, data: {}});
       await waitFor(() =>
@@ -190,10 +199,13 @@ describe('useAddIntegration', () => {
     it('ignores messages from invalid origins', async () => {
       const onInstall = jest.fn();
 
-      renderHookWithProviders(() =>
-        useAddIntegration({
+      const {result} = renderHookWithProviders(useAddIntegration, {
+        additionalWrapper: PostMessageProvider,
+      });
+
+      act(() =>
+        result.current.startFlow({
           provider,
-          organization: OrganizationFixture(),
           onInstall,
         })
       );
@@ -210,15 +222,16 @@ describe('useAddIntegration', () => {
     it('does not call onInstall when data is empty on success', async () => {
       const onInstall = jest.fn();
 
-      const {result} = renderHookWithProviders(() =>
-        useAddIntegration({
+      const {result} = renderHookWithProviders(useAddIntegration, {
+        additionalWrapper: PostMessageProvider,
+      });
+
+      act(() =>
+        result.current.startFlow({
           provider,
-          organization: OrganizationFixture(),
           onInstall,
         })
       );
-
-      act(() => result.current.startFlow());
 
       postMessageFromPopup(popup, {success: true, data: null});
 
@@ -228,19 +241,24 @@ describe('useAddIntegration', () => {
       expect(onInstall).not.toHaveBeenCalled();
     });
 
-    it('closes the dialog on unmount', () => {
-      const {result, unmount} = renderHookWithProviders(() =>
-        useAddIntegration({
+    it('unsubscribes from messages on unmount', () => {
+      const onInstall = jest.fn();
+
+      const {result, unmount} = renderHookWithProviders(useAddIntegration, {
+        additionalWrapper: PostMessageProvider,
+      });
+
+      act(() =>
+        result.current.startFlow({
           provider,
-          organization: OrganizationFixture(),
-          onInstall: jest.fn(),
+          onInstall,
         })
       );
 
-      act(() => result.current.startFlow());
       unmount();
 
-      expect(popup.close).toHaveBeenCalledTimes(1);
+      postMessageFromPopup(popup, {success: true, data: integration});
+      expect(onInstall).not.toHaveBeenCalled();
     });
   });
 
@@ -253,15 +271,17 @@ describe('useAddIntegration', () => {
         features: ['integration-api-pipeline-github'],
       });
 
-      const {result} = renderHookWithProviders(() =>
-        useAddIntegration({
+      const {result} = renderHookWithProviders(useAddIntegration, {
+        additionalWrapper: PostMessageProvider,
+        organization,
+      });
+
+      act(() =>
+        result.current.startFlow({
           provider,
-          organization,
           onInstall,
         })
       );
-
-      act(() => result.current.startFlow());
 
       expect(openPipelineModalSpy).toHaveBeenCalledWith({
         type: 'integration',
@@ -278,15 +298,17 @@ describe('useAddIntegration', () => {
         features: ['integration-api-pipeline-github'],
       });
 
-      const {result} = renderHookWithProviders(() =>
-        useAddIntegration({
+      const {result} = renderHookWithProviders(useAddIntegration, {
+        additionalWrapper: PostMessageProvider,
+        organization,
+      });
+
+      act(() =>
+        result.current.startFlow({
           provider,
-          organization,
           onInstall: jest.fn(),
         })
       );
-
-      act(() => result.current.startFlow());
 
       expect(window.open).not.toHaveBeenCalled();
     });
@@ -299,15 +321,17 @@ describe('useAddIntegration', () => {
 
       const organization = OrganizationFixture({features: []});
 
-      const {result} = renderHookWithProviders(() =>
-        useAddIntegration({
+      const {result} = renderHookWithProviders(useAddIntegration, {
+        additionalWrapper: PostMessageProvider,
+        organization,
+      });
+
+      act(() =>
+        result.current.startFlow({
           provider,
-          organization,
           onInstall: jest.fn(),
         })
       );
-
-      act(() => result.current.startFlow());
 
       expect(openPipelineModalSpy).not.toHaveBeenCalled();
       expect(window.open).toHaveBeenCalledTimes(1);

--- a/static/app/utils/integrations/useAddIntegration.tsx
+++ b/static/app/utils/integrations/useAddIntegration.tsx
@@ -9,11 +9,13 @@ import {ConfigStore} from 'sentry/stores/configStore';
 import type {IntegrationProvider, IntegrationWithConfig} from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
 import {trackIntegrationAnalytics} from 'sentry/utils/integrationUtil';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {computeCenteredWindow} from 'sentry/utils/window/computeCenteredWindow';
+import {usePostMessageCallback} from 'sentry/utils/window/usePostMessage';
 import type {MessagingIntegrationAnalyticsView} from 'sentry/views/alerts/rules/issue/setupMessagingIntegrationButton';
 
 export interface AddIntegrationParams {
   onInstall: (data: IntegrationWithConfig) => void;
-  organization: Organization;
   provider: IntegrationProvider;
   account?: string | null;
   analyticsParams?: {
@@ -30,6 +32,7 @@ export interface AddIntegrationParams {
       | 'test_analytics_org_selector';
   };
   modalParams?: Record<string, string>;
+  urlParams?: Record<string, string>;
 }
 
 /**
@@ -65,92 +68,24 @@ function getApiPipelineProvider(
   return key;
 }
 
-function computeCenteredWindow(width: number, height: number) {
-  const screenLeft = window.screenLeft === undefined ? window.screenX : window.screenLeft;
-  const screenTop = window.screenTop === undefined ? window.screenY : window.screenTop;
+// ---------------------------------------------------------------------------
+// Legacy dialog strategy (uses PostMessageContext)
+// ---------------------------------------------------------------------------
 
-  const innerWidth = window.innerWidth
-    ? window.innerWidth
-    : document.documentElement.clientWidth
-      ? document.documentElement.clientWidth
-      : screen.width;
-
-  const innerHeight = window.innerHeight
-    ? window.innerHeight
-    : document.documentElement.clientHeight
-      ? document.documentElement.clientHeight
-      : screen.height;
-
-  const left = innerWidth / 2 - width / 2 + screenLeft;
-  const top = innerHeight / 2 - height / 2 + screenTop;
-
-  return {left, top};
-}
-
-/**
- * Opens the legacy Django-driven integration setup flow in a popup window and
- * listens for a `postMessage` callback on completion.
- *
- * Used  for integrations that have not been migrated to the API pipeline system.
- */
-function useLegacyAddIntegration({
-  provider,
-  organization,
-  onInstall,
-  account,
-  analyticsParams,
-  modalParams,
-}: AddIntegrationParams) {
-  const dialogRef = useRef<Window | null>(null);
-  const onInstallRef = useRef(onInstall);
-  onInstallRef.current = onInstall;
-  const analyticsParamsRef = useRef(analyticsParams);
-  analyticsParamsRef.current = analyticsParams;
-
-  useEffect(() => {
-    function handleMessage(message: MessageEvent) {
-      const validOrigins = [
-        ConfigStore.get('links').sentryUrl,
-        ConfigStore.get('links').organizationUrl,
-        document.location.origin,
-      ];
-      if (!validOrigins.includes(message.origin)) {
-        return;
-      }
-      if (message.source !== dialogRef.current) {
-        return;
-      }
-
-      const {success, data} = message.data;
-      dialogRef.current = null;
-
-      if (!success) {
-        addErrorMessage(data?.error ?? t('An unknown error occurred'));
-        return;
-      }
-      if (!data) {
-        return;
-      }
-
-      trackIntegrationAnalytics('integrations.installation_complete', {
-        integration: provider.key,
-        integration_type: 'first_party',
-        organization,
-        ...analyticsParamsRef.current,
-      });
-      addSuccessMessage(t('%s added', provider.name));
-      onInstallRef.current(data);
-    }
-
-    window.addEventListener('message', handleMessage);
-    return () => {
-      window.removeEventListener('message', handleMessage);
-      dialogRef.current?.close();
-    };
-  }, [provider.key, provider.name, organization]);
+function useLegacyDialogStrategy() {
+  const organization = useOrganization();
+  const subscribe = usePostMessageCallback();
+  const unsubscribeRef = useRef<() => void | null>(null);
 
   const startFlow = useCallback(
-    (urlParams?: Record<string, string>) => {
+    ({
+      provider,
+      onInstall,
+      account,
+      analyticsParams,
+      modalParams,
+      urlParams,
+    }: AddIntegrationParams) => {
       trackIntegrationAnalytics('integrations.installation_start', {
         integration: provider.key,
         integration_type: 'first_party',
@@ -175,31 +110,77 @@ function useLegacyAddIntegration({
       const installUrl = `${url}?${qs.stringify(query)}`;
       const opts = `scrollbars=yes,width=${width},height=${height},top=${top},left=${left}`;
 
-      dialogRef.current = window.open(installUrl, name, opts);
-      dialogRef.current?.focus();
+      let dialog = window.open(installUrl, name, opts);
+      if (!dialog) {
+        // Popup was blocked?
+        return;
+      }
+      dialog?.focus();
+
+      unsubscribeRef.current = subscribe((message: MessageEvent) => {
+        const validOrigins = [
+          ConfigStore.get('links').sentryUrl,
+          ConfigStore.get('links').organizationUrl,
+          document.location.origin,
+        ];
+        if (!validOrigins.includes(message.origin)) {
+          return;
+        }
+        if (message.source !== dialog) {
+          return;
+        }
+
+        const {success, data} = message.data;
+        dialog = null;
+        unsubscribeRef.current?.();
+        unsubscribeRef.current = null;
+
+        if (!success) {
+          addErrorMessage(data?.error ?? t('An unknown error occurred'));
+          return;
+        }
+        if (!data) {
+          return;
+        }
+
+        trackIntegrationAnalytics('integrations.installation_complete', {
+          integration: provider.key,
+          integration_type: 'first_party',
+          organization,
+          ...analyticsParams,
+        });
+        addSuccessMessage(t('%s added', provider.name));
+        onInstall(data);
+      });
     },
-    [provider, organization, account, analyticsParams, modalParams]
+    [subscribe, organization]
   );
+
+  useEffect(() => {
+    return () => {
+      // Unsubscribe if we unmount after having started the flow
+      unsubscribeRef.current?.();
+      unsubscribeRef.current = null;
+    };
+  }, []);
 
   return {startFlow};
 }
+// ---------------------------------------------------------------------------
+// Public hook: selects between pipeline modal and legacy dialog
+// ---------------------------------------------------------------------------
 
-/**
- * Opens the integration setup flow. Automatically selects between the new
- * API-driven pipeline modal and the legacy popup-based flow depending on
- * the organization's feature flags.
- */
-export function useAddIntegration(params: AddIntegrationParams) {
-  const {provider, organization, onInstall} = params;
-  const {startFlow: legacyStartFlow} = useLegacyAddIntegration(params);
-  const pipelineProvider = getApiPipelineProvider(organization, provider.key);
+export function useAddIntegration() {
+  const organization = useOrganization();
+  const {startFlow: legacyStartFlow} = useLegacyDialogStrategy();
 
   const startFlow = useCallback(
-    (urlParams?: Record<string, string>) => {
-      // Fallback to legacy view-based flow when the feature flag for API based
-      // flows is not enabled for the provider.
+    (params: AddIntegrationParams) => {
+      const {provider, onInstall, analyticsParams} = params;
+      const pipelineProvider = getApiPipelineProvider(organization, provider.key);
+
       if (pipelineProvider === null) {
-        legacyStartFlow(urlParams);
+        legacyStartFlow(params);
         return;
       }
 
@@ -207,7 +188,7 @@ export function useAddIntegration(params: AddIntegrationParams) {
         integration: provider.key,
         integration_type: 'first_party',
         organization,
-        ...params.analyticsParams,
+        ...analyticsParams,
       });
       openPipelineModal({
         type: 'integration',
@@ -217,21 +198,14 @@ export function useAddIntegration(params: AddIntegrationParams) {
             integration: provider.key,
             integration_type: 'first_party',
             organization,
-            ...params.analyticsParams,
+            ...analyticsParams,
           });
           addSuccessMessage(t('%s added', provider.name));
           onInstall(data);
         },
       });
     },
-    [
-      pipelineProvider,
-      provider,
-      organization,
-      params.analyticsParams,
-      onInstall,
-      legacyStartFlow,
-    ]
+    [legacyStartFlow, organization]
   );
 
   return {startFlow};

--- a/static/app/utils/window/computeCenteredWindow.tsx
+++ b/static/app/utils/window/computeCenteredWindow.tsx
@@ -1,0 +1,21 @@
+export function computeCenteredWindow(width: number, height: number) {
+  const screenLeft = window.screenLeft === undefined ? window.screenX : window.screenLeft;
+  const screenTop = window.screenTop === undefined ? window.screenY : window.screenTop;
+
+  const innerWidth = window.innerWidth
+    ? window.innerWidth
+    : document.documentElement.clientWidth
+      ? document.documentElement.clientWidth
+      : screen.width;
+
+  const innerHeight = window.innerHeight
+    ? window.innerHeight
+    : document.documentElement.clientHeight
+      ? document.documentElement.clientHeight
+      : screen.height;
+
+  const left = innerWidth / 2 - width / 2 + screenLeft;
+  const top = innerHeight / 2 - height / 2 + screenTop;
+
+  return {left, top};
+}

--- a/static/app/utils/window/usePostMessage.spec.tsx
+++ b/static/app/utils/window/usePostMessage.spec.tsx
@@ -1,0 +1,217 @@
+import React from 'react';
+
+import {act, render, renderHook} from 'sentry-test/reactTestingLibrary';
+
+import {PostMessageProvider, usePostMessageCallback} from './usePostMessage';
+
+function dispatchMessage(data: unknown, origin = document.location.origin) {
+  const event = new MessageEvent('message', {data, origin});
+  window.dispatchEvent(event);
+}
+
+describe('usePostMessage', () => {
+  it('throws when used without PostMessageProvider', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => {
+      renderHook(usePostMessageCallback);
+    }).toThrow('usePostMessageCallback must be used within a PostMessageProvider');
+  });
+
+  it('returns a subscribe function', () => {
+    const {result} = renderHook(usePostMessageCallback, {
+      wrapper: PostMessageProvider,
+    });
+
+    expect(typeof result.current).toBe('function');
+  });
+
+  it('receives window message events after subscribing', () => {
+    const callback = jest.fn();
+
+    const {result} = renderHook(usePostMessageCallback, {
+      wrapper: PostMessageProvider,
+    });
+
+    act(() => {
+      result.current(callback);
+    });
+
+    act(() => dispatchMessage({type: 'test'}));
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback).toHaveBeenCalledWith(
+      expect.objectContaining({data: {type: 'test'}})
+    );
+  });
+
+  it('dispatches to multiple subscribers', () => {
+    const callbackA = jest.fn();
+    const callbackB = jest.fn();
+
+    const {result} = renderHook(usePostMessageCallback, {
+      wrapper: PostMessageProvider,
+    });
+
+    act(() => {
+      result.current(callbackA);
+      result.current(callbackB);
+    });
+
+    act(() => dispatchMessage('hello'));
+
+    expect(callbackA).toHaveBeenCalledTimes(1);
+    expect(callbackB).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops receiving messages after unsubscribing', () => {
+    const callback = jest.fn();
+
+    const {result} = renderHook(usePostMessageCallback, {
+      wrapper: PostMessageProvider,
+    });
+
+    let unsubscribe: () => void;
+    act(() => {
+      unsubscribe = result.current(callback);
+    });
+
+    act(() => {
+      unsubscribe();
+    });
+
+    act(() => dispatchMessage('after-unsubscribe'));
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('stops receiving messages after unmount', () => {
+    const callback = jest.fn();
+
+    const {result, unmount} = renderHook(usePostMessageCallback, {
+      wrapper: PostMessageProvider,
+    });
+
+    act(() => {
+      result.current(callback);
+    });
+
+    unmount();
+
+    act(() => dispatchMessage('after-unmount'));
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('only unsubscribes the targeted callback, not siblings', () => {
+    const stayingCallback = jest.fn();
+    const leavingCallback = jest.fn();
+
+    const {result} = renderHook(usePostMessageCallback, {
+      wrapper: PostMessageProvider,
+    });
+
+    let unsubscribeLeaving: () => void;
+    act(() => {
+      result.current(stayingCallback);
+      unsubscribeLeaving = result.current(leavingCallback);
+    });
+
+    act(() => dispatchMessage('both-present'));
+    expect(stayingCallback).toHaveBeenCalledTimes(1);
+    expect(leavingCallback).toHaveBeenCalledTimes(1);
+
+    stayingCallback.mockClear();
+    leavingCallback.mockClear();
+
+    act(() => {
+      unsubscribeLeaving();
+    });
+
+    act(() => dispatchMessage('one-removed'));
+    expect(stayingCallback).toHaveBeenCalledTimes(1);
+    expect(leavingCallback).not.toHaveBeenCalled();
+  });
+
+  it('only unregisters the unmounted hook, not siblings', () => {
+    const stayingCallback = jest.fn();
+    const leavingCallback = jest.fn();
+
+    function StayingHook() {
+      const subscribe = usePostMessageCallback();
+      const callbackRef = React.useRef(stayingCallback);
+      React.useEffect(() => subscribe(callbackRef.current), [subscribe]);
+      return null;
+    }
+
+    function LeavingHook() {
+      const subscribe = usePostMessageCallback();
+      const callbackRef = React.useRef(leavingCallback);
+      React.useEffect(() => subscribe(callbackRef.current), [subscribe]);
+      return null;
+    }
+
+    function Both({showLeaving}: {showLeaving: boolean}) {
+      return (
+        <PostMessageProvider>
+          <StayingHook />
+          {showLeaving ? <LeavingHook /> : null}
+        </PostMessageProvider>
+      );
+    }
+
+    const {rerender} = render(<Both showLeaving />);
+
+    act(() => dispatchMessage('both-present'));
+    expect(stayingCallback).toHaveBeenCalledTimes(1);
+    expect(leavingCallback).toHaveBeenCalledTimes(1);
+
+    stayingCallback.mockClear();
+    leavingCallback.mockClear();
+
+    rerender(<Both showLeaving={false} />);
+
+    act(() => dispatchMessage('one-removed'));
+    expect(stayingCallback).toHaveBeenCalledTimes(1);
+    expect(leavingCallback).not.toHaveBeenCalled();
+  });
+
+  it('passes the full MessageEvent to callbacks', () => {
+    const callback = jest.fn();
+
+    const {result} = renderHook(usePostMessageCallback, {
+      wrapper: PostMessageProvider,
+    });
+
+    act(() => {
+      result.current(callback);
+    });
+
+    act(() => dispatchMessage({key: 'value'}, 'https://example.com'));
+
+    const event: MessageEvent = callback.mock.calls[0][0];
+    expect(event).toBeInstanceOf(MessageEvent);
+    expect(event.data).toEqual({key: 'value'});
+    expect(event.origin).toBe('https://example.com');
+  });
+});
+
+describe('PostMessageProvider', () => {
+  it('cleans up the window listener when the provider unmounts', () => {
+    const callback = jest.fn();
+
+    const {result, unmount} = renderHook(usePostMessageCallback, {
+      wrapper: PostMessageProvider,
+    });
+
+    act(() => {
+      result.current(callback);
+    });
+
+    unmount();
+
+    act(() => dispatchMessage('after-provider-unmount'));
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+});

--- a/static/app/utils/window/usePostMessage.tsx
+++ b/static/app/utils/window/usePostMessage.tsx
@@ -1,0 +1,40 @@
+import {createContext, useCallback, useContext, useEffect, useRef} from 'react';
+
+type MessageCallback = (event: MessageEvent) => void;
+type Unsubscribe = () => void;
+type Subscribe = (callback: MessageCallback) => Unsubscribe;
+
+const PostMessageContext = createContext<Subscribe | null>(null);
+
+export function PostMessageProvider({children}: {children: React.ReactNode}) {
+  const callbacksRef = useRef(new Set<MessageCallback>());
+
+  useEffect(() => {
+    function handleMessage(event: MessageEvent) {
+      for (const callback of callbacksRef.current.values()) {
+        callback(event);
+      }
+    }
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, []);
+
+  const subscribe = useCallback((callback: MessageCallback) => {
+    callbacksRef.current.add(callback);
+    return () => callbacksRef.current.delete(callback);
+  }, []);
+
+  return (
+    <PostMessageContext.Provider value={subscribe}>
+      {children}
+    </PostMessageContext.Provider>
+  );
+}
+
+export function usePostMessageCallback() {
+  const subscribe = useContext(PostMessageContext);
+  if (!subscribe) {
+    throw new Error('usePostMessageCallback must be used within a PostMessageProvider');
+  }
+  return subscribe;
+}

--- a/static/app/views/integrationOrganizationLink/index.tsx
+++ b/static/app/views/integrationOrganizationLink/index.tsx
@@ -20,6 +20,7 @@ import type {Organization} from 'sentry/types/organization';
 import {generateOrgSlugUrl, urlEncode} from 'sentry/utils';
 import type {IntegrationAnalyticsKey} from 'sentry/utils/analytics/integrations';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {useAddIntegration} from 'sentry/utils/integrations/useAddIntegration';
 import {
   getIntegrationFeatureGate,
   trackIntegrationAnalytics,
@@ -30,8 +31,8 @@ import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useParams} from 'sentry/utils/useParams';
+import {PostMessageProvider} from 'sentry/utils/window/usePostMessage';
 import RouteError from 'sentry/views/routeError';
-import {useAddIntegration} from 'sentry/views/settings/organizationIntegrations/addIntegration';
 import {IntegrationLayout} from 'sentry/views/settings/organizationIntegrations/detailedView/integrationLayout';
 
 interface GitHubIntegrationInstallation {
@@ -231,16 +232,17 @@ export default function IntegrationOrganizationLink() {
     return (
       <IntegrationFeatures organization={organization} features={featuresComponents}>
         {({disabled, disabledReason}) => (
-          <AddIntegrationButton
-            provider={provider}
-            organization={organization}
-            onInstall={onInstallWithInstallationId}
-            installationId={installationId}
-            hasAccess={hasAccess}
-            disabled={disabled}
-            disabledReason={disabledReason}
-            finishInstallation={finishInstallation}
-          />
+          <PostMessageProvider>
+            <AddIntegrationButton
+              provider={provider}
+              onInstall={onInstallWithInstallationId}
+              installationId={installationId}
+              hasAccess={hasAccess}
+              disabled={disabled}
+              disabledReason={disabledReason}
+              finishInstallation={finishInstallation}
+            />
+          </PostMessageProvider>
         )}
       </IntegrationFeatures>
     );
@@ -404,7 +406,6 @@ export default function IntegrationOrganizationLink() {
 
 function AddIntegrationButton({
   provider,
-  organization,
   onInstall,
   installationId,
   hasAccess,
@@ -417,11 +418,10 @@ function AddIntegrationButton({
   finishInstallation: () => void;
   hasAccess: boolean | undefined;
   onInstall: (data: Integration) => void;
-  organization: Organization;
   provider: IntegrationProvider;
   installationId?: string;
 }) {
-  const {startFlow} = useAddIntegration({provider, organization, onInstall});
+  const {startFlow} = useAddIntegration();
 
   return (
     <ButtonWrapper>
@@ -430,7 +430,11 @@ function AddIntegrationButton({
         disabled={!hasAccess || disabled}
         onClick={() =>
           installationId
-            ? startFlow({installation_id: installationId})
+            ? startFlow({
+                provider,
+                onInstall,
+                urlParams: {installation_id: installationId},
+              })
             : finishInstallation()
         }
       >

--- a/static/app/views/settings/organizationIntegrations/addIntegrationButton.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/addIntegrationButton.spec.tsx
@@ -1,9 +1,9 @@
-/* global global */
 import {GitHubIntegrationProviderFixture} from 'sentry-fixture/githubIntegrationProvider';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
+import {PostMessageProvider} from 'sentry/utils/window/usePostMessage';
 import {AddIntegrationButton} from 'sentry/views/settings/organizationIntegrations/addIntegrationButton';
 
 describe('AddIntegrationButton', () => {
@@ -11,22 +11,25 @@ describe('AddIntegrationButton', () => {
 
   it('Opens the setup dialog on click', async () => {
     const focus = jest.fn();
-    const open = jest.fn().mockReturnValue({focus, close: jest.fn()});
-    // any is needed here because getSentry has different types for global
-    (global as any).open = open;
+    const popup = {focus, close: jest.fn()} as unknown as Window;
+    jest.spyOn(window, 'open').mockReturnValue(popup);
 
     render(
-      <AddIntegrationButton
-        provider={provider}
-        onAddIntegration={jest.fn()}
-        organization={OrganizationFixture()}
-      />
+      <PostMessageProvider>
+        <AddIntegrationButton
+          provider={provider}
+          onAddIntegration={jest.fn()}
+          organization={OrganizationFixture()}
+        />
+      </PostMessageProvider>
     );
 
     await userEvent.click(screen.getByLabelText('Add integration'));
-    expect(open.mock.calls).toHaveLength(1);
-    expect(focus.mock.calls).toHaveLength(1);
-    expect(open.mock.calls[0][2]).toBe(
+    expect(window.open).toHaveBeenCalledTimes(1);
+    expect(focus).toHaveBeenCalledTimes(1);
+    expect(window.open).toHaveBeenCalledWith(
+      expect.any(String),
+      'sentryAddIntegration',
       'scrollbars=yes,width=100,height=100,top=334,left=462'
     );
   });

--- a/static/app/views/settings/organizationIntegrations/addIntegrationButton.tsx
+++ b/static/app/views/settings/organizationIntegrations/addIntegrationButton.tsx
@@ -3,20 +3,17 @@ import {Button} from '@sentry/scraps/button';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {t} from 'sentry/locale';
-import type {IntegrationWithConfig} from 'sentry/types/integrations';
+import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
-
-import type {AddIntegrationParams} from './addIntegration';
-import {useAddIntegration} from './addIntegration';
+import type {AddIntegrationParams} from 'sentry/utils/integrations/useAddIntegration';
+import {useAddIntegration} from 'sentry/utils/integrations/useAddIntegration';
 
 interface AddIntegrationButtonProps
   extends
     Omit<ButtonProps, 'children' | 'analyticsParams'>,
-    Pick<
-      AddIntegrationParams,
-      'provider' | 'organization' | 'analyticsParams' | 'modalParams'
-    > {
-  onAddIntegration: (data: IntegrationWithConfig) => void;
+    Pick<AddIntegrationParams, 'provider' | 'analyticsParams' | 'modalParams'> {
+  onAddIntegration: AddIntegrationParams['onInstall'];
+  organization: Organization;
   buttonText?: string;
   installStatus?: string;
   reinstall?: boolean;
@@ -41,13 +38,7 @@ export function AddIntegrationButton({
         ? t('Reinstall')
         : t('Add %s', provider.metadata.noun));
 
-  const {startFlow} = useAddIntegration({
-    provider,
-    organization,
-    onInstall: onAddIntegration,
-    analyticsParams,
-    modalParams,
-  });
+  const {startFlow} = useAddIntegration();
 
   return (
     <Tooltip
@@ -64,7 +55,12 @@ export function AddIntegrationButton({
               provider: provider.metadata.noun,
             });
           }
-          startFlow();
+          startFlow({
+            provider,
+            onInstall: onAddIntegration,
+            analyticsParams,
+            modalParams,
+          });
         }}
         aria-label={t('Add integration')}
       >

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -26,6 +26,7 @@ import type {
 } from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {useAddIntegration} from 'sentry/utils/integrations/useAddIntegration';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import {singleLineRenderer} from 'sentry/utils/marked/marked';
 import {
@@ -47,10 +48,10 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useProjects} from 'sentry/utils/useProjects';
 import {useRoutes} from 'sentry/utils/useRoutes';
+import {PostMessageProvider} from 'sentry/utils/window/usePostMessage';
 import {BreadcrumbTitle} from 'sentry/views/settings/components/settingsBreadcrumb/breadcrumbTitle';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 
-import {useAddIntegration} from './addIntegration';
 import {IntegrationAlertRules} from './integrationAlertRules';
 import {IntegrationCodeMappings} from './integrationCodeMappings';
 import {IntegrationExternalTeamMappings} from './integrationExternalTeamMappings';
@@ -256,12 +257,13 @@ function ConfigureIntegration() {
   const getAction = () => {
     if (provider.key === 'pagerduty') {
       return (
-        <PagerdutyAddServicesButton
-          provider={provider}
-          onInstall={onUpdateIntegration}
-          account={integration.domainName}
-          organization={organization}
-        />
+        <PostMessageProvider>
+          <PagerdutyAddServicesButton
+            provider={provider}
+            onInstall={onUpdateIntegration}
+            account={integration.domainName}
+          />
+        </PostMessageProvider>
       );
     }
 
@@ -557,17 +559,20 @@ function PagerdutyAddServicesButton({
   provider,
   onInstall,
   account,
-  organization,
 }: {
   account: string | null;
   onInstall: () => void;
-  organization: Organization;
   provider: IntegrationProvider;
 }) {
-  const {startFlow} = useAddIntegration({provider, onInstall, account, organization});
+  const {startFlow} = useAddIntegration();
 
   return (
-    <Button priority="primary" size="sm" icon={<IconAdd />} onClick={() => startFlow()}>
+    <Button
+      priority="primary"
+      size="sm"
+      icon={<IconAdd />}
+      onClick={() => startFlow({provider, onInstall, account})}
+    >
       {t('Add Services')}
     </Button>
   );

--- a/static/app/views/settings/organizationIntegrations/directEnableButton.tsx
+++ b/static/app/views/settings/organizationIntegrations/directEnableButton.tsx
@@ -8,8 +8,7 @@ import {t} from 'sentry/locale';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {fetchMutation, useQueryClient} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
-
-import type {AddIntegrationButton} from './addIntegrationButton';
+import type {AddIntegrationButton} from 'sentry/views/settings/organizationIntegrations/addIntegrationButton';
 
 interface DirectEnableButtonProps {
   buttonProps: Pick<

--- a/static/app/views/settings/organizationIntegrations/installedIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/installedIntegration.tsx
@@ -17,6 +17,7 @@ import type {Organization} from 'sentry/types/organization';
 import type {IntegrationAnalyticsKey} from 'sentry/utils/analytics/integrations';
 import {getIntegrationStatus} from 'sentry/utils/integrationUtil';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
+import {PostMessageProvider} from 'sentry/utils/window/usePostMessage';
 
 import {AddIntegrationButton} from './addIntegrationButton';
 import {IntegrationItem} from './integrationItem';
@@ -137,21 +138,23 @@ export class InstalledIntegration extends Component<Props> {
                   )}
                 >
                   {requiresUpgrade && (
-                    <AddIntegrationButton
-                      analyticsParams={{
-                        view: 'integrations_directory_integration_detail',
-                        already_installed: true,
-                      }}
-                      buttonText={t('Update Now')}
-                      data-test-id="integration-upgrade-button"
-                      disabled={disableAction}
-                      icon={<IconWarning />}
-                      onAddIntegration={() => {}}
-                      organization={organization}
-                      provider={provider}
-                      priority="primary"
-                      size="sm"
-                    />
+                    <PostMessageProvider>
+                      <AddIntegrationButton
+                        analyticsParams={{
+                          view: 'integrations_directory_integration_detail',
+                          already_installed: true,
+                        }}
+                        buttonText={t('Update Now')}
+                        data-test-id="integration-upgrade-button"
+                        disabled={disableAction}
+                        icon={<IconWarning />}
+                        onAddIntegration={() => {}}
+                        organization={organization}
+                        provider={provider}
+                        priority="primary"
+                        size="sm"
+                      />
+                    </PostMessageProvider>
                   )}
                   {!provider.metadata.aspects?.directEnable && (
                     <StyledLinkButton

--- a/static/app/views/settings/organizationIntegrations/integrationButton.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationButton.tsx
@@ -5,6 +5,7 @@ import {LinkButton} from '@sentry/scraps/button';
 import {IconOpen} from 'sentry/icons';
 import type {Integration} from 'sentry/types/integrations';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {PostMessageProvider} from 'sentry/utils/window/usePostMessage';
 import {AddIntegrationButton} from 'sentry/views/settings/organizationIntegrations/addIntegrationButton';
 import {DirectEnableButton} from 'sentry/views/settings/organizationIntegrations/directEnableButton';
 import {IntegrationContext} from 'sentry/views/settings/organizationIntegrations/integrationContext';
@@ -56,15 +57,17 @@ export function IntegrationButton({
   }
   if (provider.canAdd) {
     return (
-      <AddIntegrationButton
-        provider={provider}
-        onAddIntegration={onAddIntegration}
-        installStatus={installStatus}
-        analyticsParams={analyticsParams}
-        modalParams={modalParams}
-        {...buttonProps}
-        organization={organization}
-      />
+      <PostMessageProvider>
+        <AddIntegrationButton
+          provider={provider}
+          onAddIntegration={onAddIntegration}
+          installStatus={installStatus}
+          analyticsParams={analyticsParams}
+          modalParams={modalParams}
+          {...buttonProps}
+          organization={organization}
+        />
+      </PostMessageProvider>
     );
   }
   if (metadata.aspects.externalInstall) {


### PR DESCRIPTION
The problem is that previously the `useAddIntegration()` hook had all it's props passed into the hook itself, and therefore we were only able to get things setup for one (or a hard-coded list) provider within a given component. 

ie: `function Foo() { const {startFlow} = useAddIntegration({provider}); return <a onClick={startFlow()} />; `

I want to be able to run that `startFlow()` function from within a dropdown, but i can't do that from the dropdown. The list of things in the dropdown is dynamic, so i'm not going to hard-code `startFlow1 = useAddIntegration(); startFlow2 = useAddIntegration()` either.

See https://github.com/getsentry/sentry/pull/112751

Therefore this PR refactors the hook making two big changes:
- Extract out the window listening part, using a react context provider to maintain the subscription, and the context consumer allows pushing callbacks in. In #112751 this provider will wrap around the dropdown component.
- Pass all the fields as props to `startFlow()`, not as props to the hook itself. The hook now is just a helper that provides a `useCallback` function which triggers the modal/window.open call, and listenes for window messages. All the refs inside that useCallback go away, there are closures instead.