### PR TITLE
feat(cells): Remove legacy non-org-scoped accept invite API route

### DIFF
--- a/src/sentry/api/endpoints/accept_organization_invite.py
+++ b/src/sentry/api/endpoints/accept_organization_invite.py
@@ -71,7 +71,8 @@ def handle_empty_organization_id_or_slug(
 
 def get_invite_state(
     member_id: int,
-    organization_id_or_slug: int | str | None,
+    # TODO(cells): Remove None once AcceptOrganizationInviteRedirectView is deleted
+    organization_id_or_slug: str | None,
     user_id: int | None,
     request: HttpRequest,
 ) -> RpcUserInviteContext | None:
@@ -79,7 +80,7 @@ def get_invite_state(
         return handle_empty_organization_id_or_slug(member_id, user_id, request)
 
     else:
-        if str(organization_id_or_slug).isdecimal():
+        if organization_id_or_slug.isdecimal():
             invite_context = organization_service.get_invite_by_id(
                 organization_id=organization_id_or_slug,
                 organization_member_id=member_id,
@@ -107,9 +108,9 @@ class AcceptOrganizationInvite(Endpoint):
     def convert_args(
         self,
         request: Request,
-        member_id: int,
+        member_id: str,
         token: str,
-        organization_id_or_slug: int | str | None = None,
+        organization_id_or_slug: str,
         *args,
         **kwargs,
     ):
@@ -143,7 +144,7 @@ class AcceptOrganizationInvite(Endpoint):
     def get(
         self,
         request: Request,
-        member_id: int,
+        member_id: str,
         token: str,
         invite_context: RpcUserInviteContext,
         **kwargs,
@@ -267,7 +268,7 @@ class AcceptOrganizationInvite(Endpoint):
             response = Response(
                 status=status.HTTP_400_BAD_REQUEST, data={"details": "member already exists"}
             )
-        elif not request.user.is_authenticated or not helper.valid_request:
+        elif not helper.valid_request:
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
                 data={"details": "unable to accept organization invite"},

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -3783,11 +3783,6 @@ urlpatterns = [
         name="sentry-api-0-data-export-notifications",
     ),
     re_path(
-        r"^accept-invite/(?P<member_id>[^/]+)/(?P<token>[^/]+)/$",
-        AcceptOrganizationInvite.as_view(),
-        name="sentry-api-0-accept-organization-invite",
-    ),
-    re_path(
         r"^notification-defaults/$",
         NotificationDefaultsEndpoints.as_view(),
         name="sentry-api-0-notification-defaults",

--- a/src/sentry/apidocs/api_ownership_allowlist_dont_modify.py
+++ b/src/sentry/apidocs/api_ownership_allowlist_dont_modify.py
@@ -56,7 +56,6 @@ API_OWNERSHIP_ALLOWLIST_DONT_MODIFY = [
     "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/keys/{key_id}/",
     "/api/0/organizations/{organization_id_or_slug}/recent-searches/",
     "/api/0/organizations/{organization_id_or_slug}/projects/",
-    "/api/0/accept-invite/{member_id}/{token}/",
     "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/environments/{environment}/",
     "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/token/",
     "/api/0/organizations/{organization_id_or_slug}/searches/{search_id}/",

--- a/src/sentry/apidocs/api_publish_status_allowlist_dont_modify.py
+++ b/src/sentry/apidocs/api_publish_status_allowlist_dont_modify.py
@@ -809,7 +809,6 @@ API_PUBLISH_STATUS_ALLOWLIST_DONT_MODIFY = {
     "/api/0/authenticators/": {"GET"},
     "/api/0/accept-transfer/": {"GET", "POST"},
     "/api/0/accept-invite/{organization_id_or_slug}/{member_id}/{token}/": {"GET", "POST"},
-    "/api/0/accept-invite/{member_id}/{token}/": {"GET", "POST"},
     "/api/0/profiling/projects/{project_id}/profile/{profile_id}/": {"GET"},
     "/api/0/organizations/{organization_id_or_slug}/{var}/{issue_id}/participants/": {"GET"},
     "/api/0/{var}/{issue_id}/participants/": {"GET"},

--- a/static/app/data/controlsiloUrlPatterns.ts
+++ b/static/app/data/controlsiloUrlPatterns.ts
@@ -154,7 +154,6 @@ export const controlsiloUrlPatterns: RegExp[] = [
   new RegExp('^api/0/authenticators/$'),
   new RegExp('^api/0/accept-invite/[^/]+/[^/]+/[^/]+/$'),
   new RegExp('^api/0/data-export/notifications/google-cloud/$'),
-  new RegExp('^api/0/accept-invite/[^/]+/[^/]+/$'),
   new RegExp('^api/0/notification-defaults/$'),
   new RegExp('^api/0/sentry-apps-stats/$'),
   new RegExp('^api/0/doc-integrations/$'),

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -9,7 +9,6 @@
 
 export type KnownSentryApiUrls =
   | '/'
-  | '/accept-invite/$memberId/$token/'
   | '/accept-invite/$organizationIdOrSlug/$memberId/$token/'
   | '/accept-transfer/'
   | '/api-applications/'

--- a/tests/sentry/api/endpoints/test_accept_organization_invite.py
+++ b/tests/sentry/api/endpoints/test_accept_organization_invite.py
@@ -15,7 +15,6 @@ from sentry.models.organization import Organization
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.organizationmember import InviteStatus, OrganizationMember
 from sentry.models.organizationmembermapping import OrganizationMemberMapping
-from sentry.silo.base import SiloMode
 from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import TestCase
 from sentry.testutils.cell import override_cells
@@ -36,26 +35,20 @@ class AcceptInviteTest(TestCase, HybridCloudTestMixin):
 
     def _get_paths(self, args):
         return (
-            reverse("sentry-api-0-accept-organization-invite", args=args),
             reverse(
                 "sentry-api-0-organization-accept-organization-invite",
                 args=[self.organization.slug] + args,
             ),
             reverse(
                 "sentry-api-0-organization-accept-organization-invite",
-                args=[self.organization.id] + args,
+                args=[str(self.organization.id)] + args,
             ),
         )
 
     def _get_urls(self):
-        return (
-            "sentry-api-0-accept-organization-invite",
-            "sentry-api-0-organization-accept-organization-invite",
-        )
+        return ("sentry-api-0-organization-accept-organization-invite",)
 
     def _get_path(self, url, args):
-        if url == self._get_urls()[0]:
-            return reverse(url, args=args)
         return reverse(url, args=[self.organization.slug] + args)
 
     def _require_2fa_for_organization(self):
@@ -187,27 +180,6 @@ class AcceptInviteTest(TestCase, HybridCloudTestMixin):
 
                 self._assert_pending_invite_details_in_session(om)
                 assert self.client.session["invite_organization_id"] == self.organization.id
-
-    def test_multi_region_organizationmember_id__non_monolith(self) -> None:
-        self._require_2fa_for_organization()
-        assert not self.user.has_2fa()
-
-        self.login_as(self.user)
-
-        with assume_test_silo_mode_of(OrganizationMember), outbox_context(flush=False):
-            om = OrganizationMember.objects.create(
-                email="newuser@example.com", token="abc", organization_id=self.organization.id
-            )
-        with unguarded_write(using=router.db_for_write(OrganizationMemberMapping)):
-            OrganizationMemberMapping.objects.create(
-                organization_id=self.organization.id, organizationmember_id=om.id
-            )
-
-        with override_settings(SILO_MODE=SiloMode.CONTROL, SENTRY_MONOLITH_REGION="something-else"):
-            resp = self.client.get(
-                reverse("sentry-api-0-accept-organization-invite", args=[om.id, om.token])
-            )
-        assert resp.status_code == 400
 
     def test_user_has_2fa(self) -> None:
         self._require_2fa_for_organization()


### PR DESCRIPTION
The `/api/0/accept-invite/{member_id}/{token}/` required no organization context, relying on a cell mapping lookup to determine the org. The org-scoped `/api/0/accept-invite/{organization_id_or_slug}/{member_id}/{token}/` is now the only supported route.

This PR removes the legacy API route and any references to it:
- Remove the URL pattern from api/urls.py
- Remove the legacy pattern from controlsiloUrlPatterns.ts (regenerated)
- Remove the legacy type from knownSentryApiUrls.generated.ts (regenerated)
- Remove entries from the apidocs ownership and publish status allowlists

It also cleans up `AcceptOrganizationInvite` and `get_invite_state` now that `organization_id_or_slug` is always provided:           
  - Fix member_id and organization_id_or_slug type annotations in convert_args and get() to the proper type, django passes kwargs as strings
  - Drop `int | str` from `organization_id_or_slug` since no caller ever passes an integer
  - Remove redundant str() wrapping on .isdecimal() call                                                                      
  - Remove dead not request.user.is_authenticated branch in post()                                                            
  - Add TODO to further narrow type and remove None from get_invite_state once the temporary redirect is cleaned up  

Removing this route is harmless as the web UI has been previously updated to always
use the new url in https://github.com/getsentry/sentry/pull/112634. This is effectively dead code.

This is not a public URL that requires a formal deprecation process.
