### PR TITLE
ref(trends): remove v1 trends endpoint callers and dead code

### DIFF
--- a/static/app/utils/performance/trends/trendsDiscoverQuery.tsx
+++ b/static/app/utils/performance/trends/trendsDiscoverQuery.tsx
@@ -9,7 +9,6 @@ import type {
   TrendChangeType,
   TrendFunctionField,
   TrendsData,
-  TrendsDataEvents,
   TrendsQuery,
   TrendView,
 } from 'sentry/views/performance/trends/types';
@@ -25,7 +24,6 @@ type TrendsRequest = {
   projects: Project[];
   trendChangeType?: TrendChangeType;
   trendFunctionField?: TrendFunctionField;
-  withBreakpoint?: boolean;
 };
 
 type RequestProps = DiscoverQueryProps & TrendsRequest;
@@ -39,14 +37,6 @@ export type TrendDiscoveryChildrenProps = Omit<
 
 type Props = RequestProps & {
   children: (props: TrendDiscoveryChildrenProps) => React.ReactNode;
-};
-
-type EventChildrenProps = Omit<GenericChildrenProps<TrendsDataEvents>, 'tableData'> & {
-  trendsData: TrendsDataEvents | null;
-};
-
-type EventProps = RequestProps & {
-  children: (props: EventChildrenProps) => React.ReactNode;
 };
 
 function getTrendsRequestPayload(props: RequestProps) {
@@ -79,28 +69,11 @@ function getTrendsRequestPayload(props: RequestProps) {
 
 export function TrendsDiscoverQuery(props: Omit<Props, 'projects'>) {
   const {projects} = useProjects();
-  const route = props.withBreakpoint ? 'events-trends-statsv2' : 'events-trends-stats';
   return (
     <GenericDiscoverQuery<TrendsData, TrendsRequest>
       {...props}
       projects={projects}
-      route={route}
-      getRequestPayload={getTrendsRequestPayload}
-    >
-      {({tableData, ...rest}) => {
-        return props.children({trendsData: tableData, ...rest});
-      }}
-    </GenericDiscoverQuery>
-  );
-}
-
-export function TrendsEventsDiscoverQuery(props: Omit<EventProps, 'projects'>) {
-  const {projects} = useProjects();
-  return (
-    <GenericDiscoverQuery<TrendsDataEvents, TrendsRequest>
-      {...props}
-      projects={projects}
-      route="events-trends"
+      route="events-trends-statsv2"
       getRequestPayload={getTrendsRequestPayload}
     >
       {({tableData, ...rest}) => {

--- a/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
+++ b/static/app/views/performance/landing/widgets/components/widgetContainer.spec.tsx
@@ -117,7 +117,7 @@ describe('Performance > Widgets > WidgetContainer', () => {
 
     eventsTrendsStats = MockApiClient.addMockResponse({
       method: 'GET',
-      url: '/organizations/org-slug/events-trends-stats/',
+      url: '/organizations/org-slug/events-trends-statsv2/',
       body: [],
     });
 
@@ -263,12 +263,11 @@ describe('Performance > Widgets > WidgetContainer', () => {
           noPagination: true,
           per_page: QUERY_LIMIT_PARAM,
           project: ['-42'],
-          query:
-            'transaction.op:pageload tpm():>0.01 count_percentage():>0.25 count_percentage():<4 trend_percentage():>0% confidence():>6',
-          sort: 'trend_percentage()',
+          query: 'transaction.op:pageload tpm():>0.1',
+          sort: '-trend_percentage()',
           statsPeriod: '14d',
           trendFunction: 'p95(transaction.duration)',
-          trendType: 'improved',
+          trendType: 'any',
         }),
       })
     );
@@ -720,12 +719,11 @@ describe('Performance > Widgets > WidgetContainer', () => {
           middle: undefined,
           per_page: QUERY_LIMIT_PARAM,
           project: ['-42'],
-          query:
-            'transaction.op:pageload tpm():>0.01 count_percentage():>0.25 count_percentage():<4 trend_percentage():>0% confidence():>6',
-          sort: 'trend_percentage()',
+          query: 'transaction.op:pageload tpm():>0.1',
+          sort: '-trend_percentage()',
           statsPeriod: '7d',
           trendFunction: 'p95(transaction.duration)',
-          trendType: 'improved',
+          trendType: 'any',
         }),
       })
     );
@@ -1008,12 +1006,11 @@ describe('Performance > Widgets > WidgetContainer', () => {
           middle: undefined,
           per_page: QUERY_LIMIT_PARAM,
           project: ['-42'],
-          query:
-            'transaction.op:pageload tpm():>0.01 count_percentage():>0.25 count_percentage():<4 trend_percentage():>0% confidence():>6',
+          query: 'transaction.op:pageload tpm():>0.1',
           sort: '-trend_percentage()',
           statsPeriod: '7d',
           trendFunction: 'p95(transaction.duration)',
-          trendType: 'regression',
+          trendType: 'any',
         }),
       })
     );

--- a/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/trendsWidget.tsx
@@ -31,7 +31,6 @@ import {
   QUERY_LIMIT_PARAM,
   TOTAL_EXPANDABLE_ROWS_HEIGHT,
 } from 'sentry/views/performance/landing/widgets/utils';
-import {PerformanceWidgetSetting} from 'sentry/views/performance/landing/widgets/widgetDefinitions';
 import {
   DisplayModes,
   transactionSummaryRouteWithQuery,
@@ -56,17 +55,11 @@ export function TrendsWidget(props: PerformanceWidgetProps) {
   const navigate = useNavigate();
   const {projects} = useProjects();
 
-  const {isLoading: isCardinalityCheckLoading, outcome} = useMetricsCardinalityContext();
+  const {isLoading: isCardinalityCheckLoading} = useMetricsCardinalityContext();
 
   const {eventView: _eventView, withStaticFilters, InteractiveTitle} = props;
 
-  const withBreakpoint = !isCardinalityCheckLoading && !outcome?.forceTransactionsOnly;
-
-  const trendChangeType =
-    props.chartSetting === PerformanceWidgetSetting.MOST_IMPROVED
-      ? TrendChangeType.IMPROVED
-      : TrendChangeType.REGRESSION;
-  const derivedTrendChangeType = withBreakpoint ? TrendChangeType.ANY : trendChangeType;
+  const derivedTrendChangeType = TrendChangeType.ANY;
   const trendFunctionField = TrendFunctionField.P95;
 
   const [selectedListIndex, setSelectListIndex] = useState<number>(0);
@@ -80,14 +73,7 @@ export function TrendsWidget(props: PerformanceWidgetProps) {
     },
   ];
   const rest = {...props, eventView};
-  if (withBreakpoint) {
-    eventView.additionalConditions.addFilterValues('tpm()', ['>0.1']);
-  } else {
-    eventView.additionalConditions.addFilterValues('tpm()', ['>0.01']);
-    eventView.additionalConditions.addFilterValues('count_percentage()', ['>0.25', '<4']);
-    eventView.additionalConditions.addFilterValues('trend_percentage()', ['>0%']);
-    eventView.additionalConditions.addFilterValues('confidence()', ['>6']);
-  }
+  eventView.additionalConditions.addFilterValues('tpm()', ['>0.1']);
 
   const chart = useMemo<QueryDefinition<DataType, WidgetDataResult>>(
     () => ({
@@ -102,7 +88,6 @@ export function TrendsWidget(props: PerformanceWidgetProps) {
           limit={QUERY_LIMIT_PARAM}
           cursor="0:0:1"
           noPagination
-          withBreakpoint={withBreakpoint}
         />
       ),
       transform: transformTrendsDiscover,

--- a/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/charts.tsx
@@ -236,7 +236,6 @@ export function TransactionSummaryCharts({
             end={eventView.end}
             statsPeriod={eventView.statsPeriod}
             projects={project ? [project] : []}
-            withBreakpoint
           />
         )}
         {display === DisplayModes.VITALS && (

--- a/static/app/views/performance/transactionSummary/transactionOverview/trendChart/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/trendChart/content.tsx
@@ -34,7 +34,6 @@ type Props = {
     start: number;
   };
   transaction?: NormalizedTrendsTransaction;
-  withBreakpoint?: boolean;
 } & Omit<React.ComponentProps<typeof ReleaseSeries>, 'children' | 'queryExtra'> &
   Pick<LineChartProps, 'onLegendSelectChanged' | 'legend'>;
 
@@ -53,7 +52,6 @@ export function Content({
   legend,
   utc,
   queryExtra,
-  withBreakpoint,
   transaction,
   onLegendSelectChanged,
 }: Props) {
@@ -81,9 +79,13 @@ export function Content({
     : [];
 
   const needsLabel = false;
-  const breakpointSeries = withBreakpoint
-    ? getIntervalLine(theme, data || [], 0.5, needsLabel, transaction)
-    : [];
+  const breakpointSeries = getIntervalLine(
+    theme,
+    data || [],
+    0.5,
+    needsLabel,
+    transaction
+  );
 
   const durationUnit = getDurationUnit(series, legend);
 

--- a/static/app/views/performance/transactionSummary/transactionOverview/trendChart/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/trendChart/index.tsx
@@ -40,7 +40,6 @@ type Props = ViewProps & {
   queryExtra: Query;
   trendFunction: TrendFunctionField;
   trendParameter: string;
-  withBreakpoint?: boolean;
 };
 
 export function TrendChart({
@@ -52,7 +51,6 @@ export function TrendChart({
   trendFunction,
   trendParameter,
   queryExtra,
-  withBreakpoint,
   eventView,
   start: propsStart,
   end: propsEnd,
@@ -65,7 +63,7 @@ export function TrendChart({
 
   const {isLoading: isCardinalityCheckLoading, outcome} = useMetricsCardinalityContext();
   const shouldGetBreakpoint =
-    withBreakpoint && !isCardinalityCheckLoading && !outcome?.forceTransactionsOnly;
+    !isCardinalityCheckLoading && !outcome?.forceTransactionsOnly;
 
   function handleLegendSelectChanged(legendChange: {
     name: string;
@@ -172,13 +170,11 @@ export function TrendChart({
     <Fragment>
       {header}
       {shouldGetBreakpoint ? (
-        // queries events-trends-statsv2 for breakpoint data (feature flag only)
         <TrendsDiscoverQuery
           eventView={trendView}
           orgSlug={organization.slug}
           location={location}
           limit={1}
-          withBreakpoint
         >
           {({isLoading, trendsData}) => {
             const events = normalizeTrends(trendsData?.events?.data || []);
@@ -236,7 +232,6 @@ export function TrendChart({
                       loading={loading || isLoading}
                       reloading={reloading}
                       timeFrame={timeframe}
-                      withBreakpoint
                       transaction={selectedTransaction}
                       {...contentCommonProps}
                     />


### PR DESCRIPTION
Complete the v1 trends endpoint deprecation started by PR #111146:

- Always route to v2 (events-trends-statsv2) in TrendsDiscoverQuery, removing the withBreakpoint ternary
- Delete TrendsEventsDiscoverQuery (v1 events-only endpoint caller)
- Remove withBreakpoint prop threading through trendChart components (charts.tsx, trendChart/index.tsx, trendChart/content.tsx)
- Remove 'Trending Regressions' and 'Trending Improvements' dropdown options from releases overview page (sole v1 consumer)
- Remove renderTrendsTable/isTrend from TransactionsList component
- Simplify dead trendsWidget.tsx (always use v2 filters/trendType)
- Update test mocks and assertions for v2 endpoint

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
