### PR TITLE
fix(preprod): Allow branch ref ellipsis in mobile builds table (EME-882)

### DIFF
--- a/static/app/components/preprod/preprodBuildsTableCommon.tsx
+++ b/static/app/components/preprod/preprodBuildsTableCommon.tsx
@@ -118,8 +118,8 @@ export function PreprodBuildsRowCells({
         </SimpleTable.RowCell>
       )}
 
-      <SimpleTable.RowCell justify="start">
-        <Flex direction="column" gap="xs">
+      <SimpleTable.RowCell justify="start" minWidth={0}>
+        <Flex direction="column" gap="xs" minWidth={0} width="100%">
           <Flex align="center" gap="xs">
             {build.app_info?.version !== null && (
               <Text size="lg" bold>
@@ -133,7 +133,7 @@ export function PreprodBuildsRowCells({
             )}
             {build.state === 3 && <IconCheckmark size="sm" variant="success" />}
           </Flex>
-          <Flex align="center" gap="xs">
+          <Flex align="center" gap="xs" minWidth={0}>
             <IconCommit size="xs" />
             <Text size="sm" variant="muted" monospace>
               {(build.vcs_info?.head_sha?.slice(0, 7) || '--').toUpperCase()}
@@ -150,9 +150,17 @@ export function PreprodBuildsRowCells({
                 <Text size="sm" variant="muted">
                   –
                 </Text>
-                <Text size="sm" variant="muted">
-                  {build.vcs_info?.head_ref || '--'}
-                </Text>
+                <Flex flex={1} minWidth={0} overflow="hidden">
+                  <Tooltip
+                    title={build.vcs_info?.head_ref || undefined}
+                    showOnlyOnOverflow
+                    skipWrapper
+                  >
+                    <Text size="sm" variant="muted" ellipsis>
+                      {build.vcs_info?.head_ref || '--'}
+                    </Text>
+                  </Tooltip>
+                </Flex>
               </Fragment>
             )}
           </Flex>


### PR DESCRIPTION
Truncate long Git branch names in the mobile builds table build column.

`Text` with `ellipsis` needs a parent with a definite bounded width. Nested flex rows default to `min-width: auto`, so the VCS line grew with the full branch name and ellipsis never applied. The build column now sets `minWidth={0}` on the row cell and flex wrappers so the grid track can shrink, wraps the head ref in a `flex={1}` `overflow="hidden"` region so only that segment consumes leftover width, and adds a `Tooltip` with `showOnlyOnOverflow` so reviewers can read the full ref when it is clipped.

Column `minmax` templates in the size and distribution tables are unchanged; this is strictly flex/grid shrink behavior inside the build cell.

## Before

<img width="975" height="408" alt="Screenshot 2026-04-13 at 11 02 10" src="https://github.com/user-attachments/assets/937ed8ea-7235-4648-b206-dc2b7fc1a97c" />

## After 

<img width="850" height="472" alt="Screenshot 2026-04-13 at 11 20 52" src="https://github.com/user-attachments/assets/854db4e4-7859-4e94-be6f-a22f3262be93" />

Made with [Cursor](https://cursor.com)