### PR TITLE
fix(migrations): Skip pg_dumpall restrict/unrestrict tokens in drift check

### DIFF
--- a/tools/migrations/compare.py
+++ b/tools/migrations/compare.py
@@ -39,6 +39,10 @@ def norm(s: str) -> dict[str, str]:
             _, db = line.split()
         if line.startswith("--"):
             continue
+        # pg_dumpall (PostgreSQL 16+) emits \restrict / \unrestrict with
+        # random per-session tokens.  These are not part of the schema.
+        if line.startswith(r"\restrict ") or line.startswith(r"\unrestrict "):
+            continue
         if last == "\n" and line == "\n":
             continue
         else:


### PR DESCRIPTION
PostgreSQL 16+ added `\restrict` / `\unrestrict` directives to `pg_dumpall` output. These carry random per-session tokens for password scrambling and are not part of the database schema.

The migration drift CI job runs `pg_dumpall` twice (once after sequential migrations, once after squashed migrations) and compares the output. Since the tokens are regenerated on every dump, the comparison always reports a false-positive diff — causing the `migrations-drift` workflow to fail on every PR that touches migrations, in both sentry and getsentry.

This filters out `\restrict` and `\unrestrict` lines in the `norm()` function, alongside the existing filters for comments and `django_migrations` tables. The `quick_drift_compare.py` script delegates to the same compare module, so both code paths are fixed.

Example of the spurious diff this eliminates:
```
-\restrict chSRsrfaJ6ZjA7ck8dSaajbhnPiwOqTaC6ldxf7bN2kbn4VJZk4ODoz8l0XL2pk
+\restrict dXbwY4tgrWq0glKas9UkhhnydrGduwSqaYnQMvQj53fxjnB36DA9XvXg3TMMG9U
```