### PR TITLE
fix(preprod): Log when PR comment is skipped due to no installable artifacts

### DIFF
--- a/src/sentry/preprod/vcs/pr_comments/tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/tasks.py
@@ -127,6 +127,14 @@ def create_preprod_pr_comment_task(
         siblings = artifact.get_sibling_artifacts_for_commit()
         installable_siblings = [s for s in siblings if is_installable_artifact(s)]
         if not installable_siblings:
+            logger.info(
+                "preprod.pr_comments.create.no_installable_artifacts",
+                extra={
+                    "artifact_id": artifact.id,
+                    "project_id": artifact.project.id,
+                    "sibling_count": len(siblings),
+                },
+            )
             return
 
         existing_comment_id = _find_existing_comment_id(all_for_pr)


### PR DESCRIPTION
## Summary
- The `create_preprod_pr_comment_task` silently returned when no installable sibling artifacts were found for a commit, with no logging
- This made it difficult to diagnose cases where PR comments were expected but never posted during rollout monitoring
- Adds an `info`-level log (`preprod.pr_comments.create.no_installable_artifacts`) with the artifact ID, project ID, and total sibling count