### PR TITLE
feat(conversations): Show [Filtered] in conversation list for scrubbed data

### DIFF
--- a/src/sentry/api/endpoints/organization_ai_conversations.py
+++ b/src/sentry/api/endpoints/organization_ai_conversations.py
@@ -96,6 +96,8 @@ def _extract_content_from_parts(msg: dict) -> str | None:
 
 def _extract_first_user_message(messages: str | list | None) -> str | None:
     """Extract first user message, handling both old (content) and new (parts) formats."""
+    if isinstance(messages, str) and messages == FILTERED:
+        return FILTERED
     parsed = _parse_messages(messages)
     if not parsed:
         return None
@@ -118,8 +120,6 @@ def _get_first_input_message(row: dict) -> str | None:
     # 1. Check new format first (gen_ai.input.messages)
     input_messages = row.get("gen_ai.input.messages")
     if input_messages:
-        if input_messages == FILTERED:
-            return FILTERED
         first_user = _extract_first_user_message(input_messages)
         if first_user:
             return first_user
@@ -127,8 +127,6 @@ def _get_first_input_message(row: dict) -> str | None:
     # 2. Check current format (gen_ai.request.messages)
     request_messages = row.get("gen_ai.request.messages")
     if request_messages:
-        if request_messages == FILTERED:
-            return FILTERED
         return _extract_first_user_message(request_messages)
 
     return None

--- a/src/sentry/api/endpoints/organization_ai_conversations.py
+++ b/src/sentry/api/endpoints/organization_ai_conversations.py
@@ -62,6 +62,9 @@ def _compute_timestamp_ms(finish_ts: float) -> int:
     return int(finish_ts * 1000) if finish_ts else 0
 
 
+FILTERED = "[Filtered]"
+
+
 def _parse_messages(messages: str | list | None) -> list | None:
     if not messages:
         return None
@@ -115,6 +118,8 @@ def _get_first_input_message(row: dict) -> str | None:
     # 1. Check new format first (gen_ai.input.messages)
     input_messages = row.get("gen_ai.input.messages")
     if input_messages:
+        if input_messages == FILTERED:
+            return FILTERED
         first_user = _extract_first_user_message(input_messages)
         if first_user:
             return first_user
@@ -122,6 +127,8 @@ def _get_first_input_message(row: dict) -> str | None:
     # 2. Check current format (gen_ai.request.messages)
     request_messages = row.get("gen_ai.request.messages")
     if request_messages:
+        if request_messages == FILTERED:
+            return FILTERED
         return _extract_first_user_message(request_messages)
 
     return None
@@ -135,6 +142,8 @@ def _get_last_output(row: dict) -> str | None:
     # 1. Check new format first (gen_ai.output.messages)
     output_messages = row.get("gen_ai.output.messages")
     if output_messages:
+        if output_messages == FILTERED:
+            return FILTERED
         # Extract text from the last assistant message
         parsed = _parse_messages(output_messages)
         if parsed:

--- a/static/app/views/insights/pages/conversations/components/conversationsTable.tsx
+++ b/static/app/views/insights/pages/conversations/components/conversationsTable.tsx
@@ -58,7 +58,6 @@ export function ConversationsTable() {
   return <ConversationsTableInner />;
 }
 
-const FILTERED = '[Filtered]';
 const EMPTY_ARRAY: never[] = [];
 
 const defaultColumnOrder: Array<GridColumnOrder<string>> = [
@@ -228,21 +227,17 @@ const BodyCell = memo(function BodyCell({
             <InputOutputLabel variant="muted">{t('Input')}</InputOutputLabel>
             <Flex flex="1" minWidth="0">
               {dataRow.firstInput ? (
-                dataRow.firstInput === FILTERED ? (
-                  <Text variant="muted">{FILTERED}</Text>
-                ) : (
-                  <Tooltip
-                    title={<TooltipContent text={dataRow.firstInput} />}
-                    showOnlyOnOverflow
-                    maxWidth={800}
-                    isHoverable
-                    delay={500}
-                    skipWrapper
-                    position="right"
-                  >
-                    <CellContent text={dataRow.firstInput} />
-                  </Tooltip>
-                )
+                <Tooltip
+                  title={<TooltipContent text={dataRow.firstInput} />}
+                  showOnlyOnOverflow
+                  maxWidth={800}
+                  isHoverable
+                  delay={500}
+                  skipWrapper
+                  position="right"
+                >
+                  <CellContent text={dataRow.firstInput} />
+                </Tooltip>
               ) : (
                 <Text variant="muted">&mdash;</Text>
               )}
@@ -252,21 +247,17 @@ const BodyCell = memo(function BodyCell({
             <InputOutputLabel variant="muted">{t('Output')}</InputOutputLabel>
             <Flex flex="1" minWidth="0">
               {dataRow.lastOutput ? (
-                dataRow.lastOutput === FILTERED ? (
-                  <Text variant="muted">{FILTERED}</Text>
-                ) : (
-                  <Tooltip
-                    title={<TooltipContent text={dataRow.lastOutput} />}
-                    showOnlyOnOverflow
-                    maxWidth={800}
-                    isHoverable
-                    delay={500}
-                    skipWrapper
-                    position="right"
-                  >
-                    <CellContent text={dataRow.lastOutput} />
-                  </Tooltip>
-                )
+                <Tooltip
+                  title={<TooltipContent text={dataRow.lastOutput} />}
+                  showOnlyOnOverflow
+                  maxWidth={800}
+                  isHoverable
+                  delay={500}
+                  skipWrapper
+                  position="right"
+                >
+                  <CellContent text={dataRow.lastOutput} />
+                </Tooltip>
               ) : (
                 <Text variant="muted">&mdash;</Text>
               )}

--- a/static/app/views/insights/pages/conversations/components/conversationsTable.tsx
+++ b/static/app/views/insights/pages/conversations/components/conversationsTable.tsx
@@ -58,6 +58,7 @@ export function ConversationsTable() {
   return <ConversationsTableInner />;
 }
 
+const FILTERED = '[Filtered]';
 const EMPTY_ARRAY: never[] = [];
 
 const defaultColumnOrder: Array<GridColumnOrder<string>> = [
@@ -227,17 +228,21 @@ const BodyCell = memo(function BodyCell({
             <InputOutputLabel variant="muted">{t('Input')}</InputOutputLabel>
             <Flex flex="1" minWidth="0">
               {dataRow.firstInput ? (
-                <Tooltip
-                  title={<TooltipContent text={dataRow.firstInput} />}
-                  showOnlyOnOverflow
-                  maxWidth={800}
-                  isHoverable
-                  delay={500}
-                  skipWrapper
-                  position="right"
-                >
-                  <CellContent text={dataRow.firstInput} />
-                </Tooltip>
+                dataRow.firstInput === FILTERED ? (
+                  <Text variant="muted">{FILTERED}</Text>
+                ) : (
+                  <Tooltip
+                    title={<TooltipContent text={dataRow.firstInput} />}
+                    showOnlyOnOverflow
+                    maxWidth={800}
+                    isHoverable
+                    delay={500}
+                    skipWrapper
+                    position="right"
+                  >
+                    <CellContent text={dataRow.firstInput} />
+                  </Tooltip>
+                )
               ) : (
                 <Text variant="muted">&mdash;</Text>
               )}
@@ -247,17 +252,21 @@ const BodyCell = memo(function BodyCell({
             <InputOutputLabel variant="muted">{t('Output')}</InputOutputLabel>
             <Flex flex="1" minWidth="0">
               {dataRow.lastOutput ? (
-                <Tooltip
-                  title={<TooltipContent text={dataRow.lastOutput} />}
-                  showOnlyOnOverflow
-                  maxWidth={800}
-                  isHoverable
-                  delay={500}
-                  skipWrapper
-                  position="right"
-                >
-                  <CellContent text={dataRow.lastOutput} />
-                </Tooltip>
+                dataRow.lastOutput === FILTERED ? (
+                  <Text variant="muted">{FILTERED}</Text>
+                ) : (
+                  <Tooltip
+                    title={<TooltipContent text={dataRow.lastOutput} />}
+                    showOnlyOnOverflow
+                    maxWidth={800}
+                    isHoverable
+                    delay={500}
+                    skipWrapper
+                    position="right"
+                  >
+                    <CellContent text={dataRow.lastOutput} />
+                  </Tooltip>
+                )
               ) : (
                 <Text variant="muted">&mdash;</Text>
               )}

--- a/tests/sentry/api/endpoints/test_organization_ai_conversations.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations.py
@@ -132,6 +132,14 @@ class TestGetFirstInputMessage:
         }
         assert _get_first_input_message(row) == "Old"
 
+    def test_returns_filtered_for_new_format(self) -> None:
+        row = {"gen_ai.input.messages": "[Filtered]"}
+        assert _get_first_input_message(row) == "[Filtered]"
+
+    def test_returns_filtered_for_old_format(self) -> None:
+        row = {"gen_ai.request.messages": "[Filtered]"}
+        assert _get_first_input_message(row) == "[Filtered]"
+
 
 class TestGetLastOutput:
     """Unit tests for _get_last_output helper function"""
@@ -170,6 +178,10 @@ class TestGetLastOutput:
             "gen_ai.response.text": "Fallback",
         }
         assert _get_last_output(row) == "Fallback"
+
+    def test_returns_filtered(self) -> None:
+        row = {"gen_ai.output.messages": "[Filtered]"}
+        assert _get_last_output(row) == "[Filtered]"
 
 
 class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):

--- a/tests/sentry/api/endpoints/test_organization_ai_conversations.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations.py
@@ -106,6 +106,9 @@ class TestExtractFirstUserMessage:
         messages = "[]"
         assert _extract_first_user_message(messages) is None
 
+    def test_returns_filtered(self) -> None:
+        assert _extract_first_user_message("[Filtered]") == "[Filtered]"
+
 
 class TestGetFirstInputMessage:
     """Unit tests for _get_first_input_message helper function"""


### PR DESCRIPTION
When span attributes contain `[Filtered]` from SDK data scrubbing, the backend extraction functions (`_get_first_input_message`, `_get_last_output`) failed JSON parsing and returned `null`. The conversation list showed `—` instead of indicating the data was filtered.
