### PR TITLE
fix(dashboards): Hide internal error messages from widget error state

### DIFF
--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -351,11 +351,7 @@ function WidgetCard(props: Props) {
     return (
       <Widget
         Title={<Widget.WidgetTitle title={widget.title} />}
-        Visualization={
-          <Widget.WidgetError
-            error={t("Something went wrong with this widget, we're looking into it!")}
-          />
-        }
+        Visualization={<Widget.WidgetError />}
         noVisualizationPadding
       />
     );

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.spec.tsx
@@ -1,7 +1,13 @@
+import * as Sentry from '@sentry/react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+jest.mock('@sentry/react', () => ({
+  ...jest.requireActual('@sentry/react'),
+  captureMessage: jest.fn(),
+}));
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
@@ -74,6 +80,38 @@ beforeEach(() => {
       sampleCount: undefined,
     })
   );
+});
+
+describe('VisualizationWidget error handling', () => {
+  it('captures a Sentry message when errorMessage is returned from the data loader', () => {
+    jest.mocked(WidgetCardDataLoader).mockImplementationOnce(({children}: any) =>
+      children({
+        timeseriesResults: undefined,
+        tableResults: undefined,
+        loading: false,
+        errorMessage: 'Internal server error',
+        confidence: undefined,
+        dataScanned: undefined,
+        isSampled: undefined,
+        sampleCount: undefined,
+      })
+    );
+
+    render(<VisualizationWidget widget={spansBreakdownWidget} selection={selection} />, {
+      organization: OrganizationFixture(),
+    });
+
+    expect(
+      screen.getByText('There was an error loading this widget.')
+    ).toBeInTheDocument();
+    expect(Sentry.captureMessage).toHaveBeenCalledWith('Dashboard widget query error', {
+      level: 'error',
+      extra: {
+        widget_title: spansBreakdownWidget.title,
+        error_message: 'Internal server error',
+      },
+    });
+  });
 });
 
 describe('VisualizationWidget breakdown series labels', () => {

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 import {Link} from 'react-router-dom';
 import {useTheme} from '@emotion/react';
+import * as Sentry from '@sentry/react';
 
 import {Container, Flex, type ContainerProps} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
@@ -132,8 +133,12 @@ export function VisualizationWidget({
         isSampled,
         sampleCount,
       }) => {
-        if (errorMessage && onWidgetError) {
-          onWidgetError(widget, errorMessage);
+        if (errorMessage) {
+          Sentry.captureMessage('Dashboard widget query error', {
+            level: 'error',
+            extra: {widget_title: widget.title, error_message: errorMessage},
+          });
+          onWidgetError?.(widget, errorMessage);
         }
 
         return (

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -31,10 +31,7 @@ import {
 import {getChartType} from 'sentry/views/dashboards/utils/getWidgetExploreUrl';
 import {matchTimeSeriesToTableRowValue} from 'sentry/views/dashboards/widgetCard/matchTimeSeriesToTableRowValue';
 import {transformWidgetSeriesToTimeSeries} from 'sentry/views/dashboards/widgetCard/transformWidgetSeriesToTimeSeries';
-import {
-  MISSING_DATA_MESSAGE,
-  NUMBER_MIN_VALUE,
-} from 'sentry/views/dashboards/widgets/common/settings';
+import {NUMBER_MIN_VALUE} from 'sentry/views/dashboards/widgets/common/settings';
 import type {
   LegendSelection,
   TabularColumn,
@@ -390,7 +387,7 @@ function VisualizationWidgetContent({
   }
 
   if (errorMessage) {
-    return <Widget.WidgetError error={errorMessage} />;
+    return <Widget.WidgetError />;
   }
 
   const timeseriesContainerPadding: ContainerProps = {
@@ -421,7 +418,7 @@ function VisualizationWidgetContent({
   const hasNoPlottableData = plottables.every(plottable => plottable.isEmpty);
 
   if (hasNoPlottableData) {
-    return <Widget.WidgetError error={MISSING_DATA_MESSAGE} />;
+    return <Widget.WidgetError />;
   }
 
   const confidenceFooter = showConfidenceWarning ? (

--- a/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
@@ -163,7 +163,7 @@ export function WidgetCardChartContainer({
             onWidgetError(widget, errorOrEmptyMessage);
           }
 
-          return <Widget.WidgetError error={errorOrEmptyMessage} />;
+          return <Widget.WidgetError />;
         }
 
         return (

--- a/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardChartContainer.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import * as Sentry from '@sentry/react';
 import type {LegendComponentOption} from 'echarts';
 
 import type {Client} from 'sentry/api';
@@ -157,10 +158,13 @@ export function WidgetCardChartContainer({
         if (errorOrEmptyMessage) {
           if (
             typeof errorOrEmptyMessage === 'string' &&
-            errorOrEmptyMessage !== t('No data found') &&
-            onWidgetError
+            errorOrEmptyMessage !== t('No data found')
           ) {
-            onWidgetError(widget, errorOrEmptyMessage);
+            Sentry.captureMessage('Dashboard widget query error', {
+              level: 'error',
+              extra: {widget_title: widget.title, error_message: errorOrEmptyMessage},
+            });
+            onWidgetError?.(widget, errorOrEmptyMessage);
           }
 
           return <Widget.WidgetError />;

--- a/static/app/views/dashboards/widgetCard/widgetFrame.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetFrame.spec.tsx
@@ -1,6 +1,13 @@
+import * as Sentry from '@sentry/react';
+
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {WidgetFrame} from 'sentry/views/dashboards/widgetCard/widgetFrame';
+
+jest.mock('@sentry/react', () => ({
+  ...jest.requireActual('@sentry/react'),
+  captureException: jest.fn(),
+}));
 
 describe('WidgetFrame', () => {
   describe('Layout', () => {
@@ -30,7 +37,18 @@ describe('WidgetFrame', () => {
 
       expect(screen.getByText('Uh Oh')).toBeInTheDocument();
 
-      expect(await screen.findByText(/cannot read properties/i)).toBeInTheDocument();
+      expect(
+        await screen.findByText('There was an error loading this widget.')
+      ).toBeInTheDocument();
+      expect(Sentry.captureException).toHaveBeenCalledWith(expect.any(TypeError));
+    });
+
+    it('Shows a generic error message when error prop is set', () => {
+      render(<WidgetFrame title="EPS" error={new Error('Rate limit exceeded')} />);
+
+      expect(
+        screen.getByText('There was an error loading this widget.')
+      ).toBeInTheDocument();
     });
   });
 

--- a/static/app/views/dashboards/widgetCard/widgetFrame.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetFrame.tsx
@@ -154,7 +154,7 @@ export function WidgetFrame(props: WidgetFrameProps) {
       Visualization={
         props.error ? (
           <Container position="absolute" inset={0}>
-            <Widget.WidgetError error={error} />
+            <Widget.WidgetError />
           </Container>
         ) : (
           props.children

--- a/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.spec.tsx
+++ b/static/app/views/dashboards/widgets/bigNumberWidget/bigNumberWidgetVisualization.spec.tsx
@@ -29,7 +29,9 @@ describe('BigNumberWidgetVisualization', () => {
         />
       );
 
-      expect(screen.getByText('Value is not a finite number.')).toBeInTheDocument();
+      expect(
+        screen.getByText('There was an error loading this widget.')
+      ).toBeInTheDocument();
     });
 
     it('Formats dates', () => {

--- a/static/app/views/dashboards/widgets/common/settings.tsx
+++ b/static/app/views/dashboards/widgets/common/settings.tsx
@@ -20,7 +20,6 @@ export const MIN_HEIGHT = 96;
 
 export const DEFAULT_FIELD = 'unknown'; // Numeric data might, in theory, have a missing field. In this case we need a fallback to provide to the field rendering pipeline. `'unknown'` will results in rendering as a string
 
-export const MISSING_DATA_MESSAGE = t('No Data');
 export const NO_PLOTTABLE_VALUES = t('The data does not contain any plottable values.');
 export const NON_FINITE_NUMBER_MESSAGE = t('Value is not a finite number.');
 

--- a/static/app/views/dashboards/widgets/widget/widget.tsx
+++ b/static/app/views/dashboards/widgets/widget/widget.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
+import * as Sentry from '@sentry/react';
 
 import {Container, Flex} from '@sentry/scraps/layout';
 
@@ -85,11 +86,14 @@ function WidgetLayout(props: Widget) {
       {props.Visualization && (
         <VisualizationWrapper noPadding={props.noVisualizationPadding}>
           <ErrorBoundary
-            customComponent={() => (
-              <Container position="absolute" inset={0}>
-                <WidgetError />
-              </Container>
-            )}
+            customComponent={({error}) => {
+              Sentry.captureException(error);
+              return (
+                <Container position="absolute" inset={0}>
+                  <WidgetError />
+                </Container>
+              );
+            }}
           >
             {props.Visualization}
           </ErrorBoundary>
@@ -98,7 +102,12 @@ function WidgetLayout(props: Widget) {
 
       {props.Footer && (
         <FooterWrapper noPadding={props.noFooterPadding}>
-          <ErrorBoundary customComponent={() => <WidgetError />}>
+          <ErrorBoundary
+            customComponent={({error}) => {
+              Sentry.captureException(error);
+              return <WidgetError />;
+            }}
+          >
             {props.Footer}
           </ErrorBoundary>
         </FooterWrapper>

--- a/static/app/views/dashboards/widgets/widget/widget.tsx
+++ b/static/app/views/dashboards/widgets/widget/widget.tsx
@@ -85,9 +85,9 @@ function WidgetLayout(props: Widget) {
       {props.Visualization && (
         <VisualizationWrapper noPadding={props.noVisualizationPadding}>
           <ErrorBoundary
-            customComponent={({error}) => (
+            customComponent={() => (
               <Container position="absolute" inset={0}>
-                <WidgetError error={error ?? undefined} />
+                <WidgetError />
               </Container>
             )}
           >
@@ -98,9 +98,7 @@ function WidgetLayout(props: Widget) {
 
       {props.Footer && (
         <FooterWrapper noPadding={props.noFooterPadding}>
-          <ErrorBoundary
-            customComponent={({error}) => <WidgetError error={error ?? undefined} />}
-          >
+          <ErrorBoundary customComponent={() => <WidgetError />}>
             {props.Footer}
           </ErrorBoundary>
         </FooterWrapper>

--- a/static/app/views/dashboards/widgets/widget/widgetError.tsx
+++ b/static/app/views/dashboards/widgets/widget/widgetError.tsx
@@ -3,26 +3,12 @@ import styled from '@emotion/styled';
 import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {DEEMPHASIS_VARIANT} from 'sentry/views/dashboards/widgets/bigNumberWidget/settings';
-import type {
-  ErrorPropWithResponseJSON,
-  StateProps,
-} from 'sentry/views/dashboards/widgets/common/types';
 
-interface WidgetErrorProps {
-  error: StateProps['error'];
-}
-
-export function WidgetError({error}: WidgetErrorProps) {
+export function WidgetError() {
   return (
     <Panel>
       <NonShrinkingWarningIcon variant={DEEMPHASIS_VARIANT} size="md" />
-      <ErrorText>
-        {typeof error === 'string'
-          ? error
-          : ((error as ErrorPropWithResponseJSON)?.responseJSON?.detail.toString() ??
-            error?.message ??
-            t('Error loading data.'))}
-      </ErrorText>
+      <ErrorText>{t('There was an error loading this widget.')}</ErrorText>
     </Panel>
   );
 }

--- a/static/app/views/explore/components/chart/chartVisualization.tsx
+++ b/static/app/views/explore/components/chart/chartVisualization.tsx
@@ -98,7 +98,7 @@ export function ChartVisualization({
   if (chartInfo.timeseriesResult.error) {
     return (
       <Container position="absolute" inset={0}>
-        <Widget.WidgetError error={chartInfo.timeseriesResult.error} />
+        <Widget.WidgetError />
       </Container>
     );
   }
@@ -109,7 +109,7 @@ export function ChartVisualization({
     // proxying to RPC. Adding explicit handling with a "better" message
     return (
       <Container position="absolute" inset={0}>
-        <Widget.WidgetError error={t('No data')} />
+        <Widget.WidgetError />
       </Container>
     );
   }

--- a/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
+++ b/static/app/views/insights/common/components/insightsTimeSeriesWidget.tsx
@@ -12,7 +12,6 @@ import type {PageFilters} from 'sentry/types/core';
 import {markDelayedData} from 'sentry/utils/timeSeries/markDelayedData';
 import type {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useReleaseStats} from 'sentry/utils/useReleaseStats';
-import {MISSING_DATA_MESSAGE} from 'sentry/views/dashboards/widgets/common/settings';
 import type {
   LegendSelection,
   TimeSeries,
@@ -189,7 +188,7 @@ export function InsightsTimeSeriesWidget(props: InsightsTimeSeriesWidgetProps) {
           Title={Title}
           Visualization={
             <Container position="absolute" inset={0}>
-              <Widget.WidgetError error={props.error} />
+              <Widget.WidgetError />
             </Container>
           }
         />
@@ -206,7 +205,7 @@ export function InsightsTimeSeriesWidget(props: InsightsTimeSeriesWidgetProps) {
           Title={Title}
           Visualization={
             <Container position="absolute" inset={0}>
-              <Widget.WidgetError error={MISSING_DATA_MESSAGE} />
+              <Widget.WidgetError />
             </Container>
           }
         />

--- a/static/app/views/insights/mobile/appStarts/components/charts/deviceClassBreakdownBarChart.tsx
+++ b/static/app/views/insights/mobile/appStarts/components/charts/deviceClassBreakdownBarChart.tsx
@@ -136,7 +136,7 @@ export function DeviceClassBreakdownBarChart({
           Title={Title}
           Visualization={
             <Container position="absolute" inset={0}>
-              <Widget.WidgetError error={error} />
+              <Widget.WidgetError />
             </Container>
           }
         />

--- a/static/app/views/insights/mobile/screenload/components/charts/screenBarChart.tsx
+++ b/static/app/views/insights/mobile/screenload/components/charts/screenBarChart.tsx
@@ -101,7 +101,7 @@ export function ScreensBarChart({
           Title={Title}
           Visualization={
             <Container position="absolute" inset={0}>
-              <Widget.WidgetError error={error} />
+              <Widget.WidgetError />
             </Container>
           }
         />

--- a/static/app/views/insights/pages/platform/laravel/widgetVisualizationStates.tsx
+++ b/static/app/views/insights/pages/platform/laravel/widgetVisualizationStates.tsx
@@ -30,7 +30,7 @@ export function WidgetVisualizationStates<T extends WidgetVisualization>({
   if (error) {
     return (
       <Container position="absolute" inset={0}>
-        <Widget.WidgetError error={error} />
+        <Widget.WidgetError />
       </Container>
     );
   }

--- a/static/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectApdexScoreCard.tsx
@@ -158,7 +158,7 @@ export function ProjectApdexScoreCard(props: Props) {
         }
         Visualization={
           <Container position="absolute" inset={0}>
-            <Widget.WidgetError error={error} />
+            <Widget.WidgetError />
           </Container>
         }
       />

--- a/static/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectStabilityScoreCard.tsx
@@ -185,7 +185,7 @@ export function ProjectStabilityScoreCard(props: Props) {
         }
         Visualization={
           <Container position="absolute" inset={0}>
-            <Widget.WidgetError error={error} />
+            <Widget.WidgetError />
           </Container>
         }
       />

--- a/static/app/views/projectDetail/projectScoreCards/projectVelocityScoreCard.tsx
+++ b/static/app/views/projectDetail/projectScoreCards/projectVelocityScoreCard.tsx
@@ -198,7 +198,7 @@ export function ProjectVelocityScoreCard(props: Props) {
         }
         Visualization={
           <Container position="absolute" inset={0}>
-            <Widget.WidgetError error={error} />
+            <Widget.WidgetError />
           </Container>
         }
       />


### PR DESCRIPTION
Widget error states previously displayed raw internal error messages to users — API response details, JS error messages, or `responseJSON.detail` strings from failed requests. These strings are technical, often unhelpful, and can leak implementation details.

This replaces the dynamic error text with a fixed generic message ("There was an error loading this widget.") across all widget types and all callers of `Widget.WidgetError`. The `error` prop is removed entirely from `WidgetError` since it is no longer rendered.

Alongside the UX fix, widget errors that were previously swallowed silently are now reported to Sentry:
- `Sentry.captureMessage` is called with `widget_title` and `error_message` context when an API error surfaces in the timeseries or non-timeseries widget data loaders
- `Sentry.captureException` is called in the `ErrorBoundary` fallback inside the base `Widget` component for JS errors

Previously, only the Seer-generated dashboard flow reported widget errors to Sentry. Regular dashboards had no visibility into widget failures.

Before:

<img width="642" height="287" alt="image" src="https://github.com/user-attachments/assets/611f4d48-f7e8-48c5-bbd1-5601eb804d0e" />

After:
<img width="642" height="287" alt="image" src="https://github.com/user-attachments/assets/2c18d8d7-77aa-40e3-8c76-dd8b244c3694" />
