### PR TITLE
fix(preprod): Always show platform header in PR comments

### DIFF
--- a/src/sentry/preprod/vcs/pr_comments/templates.py
+++ b/src/sentry/preprod/vcs/pr_comments/templates.py
@@ -36,16 +36,10 @@ def format_pr_comment(artifacts: list[PreprodArtifact], project: Project) -> str
     separator = "|----------|--------|---------|---------------|--------------|"
 
     if ios_rows:
-        if android_rows:
-            sections.append(f"### iOS\n\n{header}\n{separator}\n" + "\n".join(ios_rows))
-        else:
-            sections.append(f"{header}\n{separator}\n" + "\n".join(ios_rows))
+        sections.append(f"### iOS\n\n{header}\n{separator}\n" + "\n".join(ios_rows))
 
     if android_rows:
-        if ios_rows:
-            sections.append(f"### Android\n\n{header}\n{separator}\n" + "\n".join(android_rows))
-        else:
-            sections.append(f"{header}\n{separator}\n" + "\n".join(android_rows))
+        sections.append(f"### Android\n\n{header}\n{separator}\n" + "\n".join(android_rows))
 
     settings_url = project.organization.absolute_url(
         f"/settings/projects/{project.slug}/mobile-builds/", query="tab=distribution"

--- a/tests/sentry/preprod/vcs/pr_comments/test_templates.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_templates.py
@@ -65,8 +65,7 @@ class FormatPrCommentTest(TestCase):
         assert "1.2.3 (456)" in result
         assert "Release" in result
         assert "[Install Build](" in result
-        # Single platform — no subheader
-        assert "### iOS" not in result
+        assert "### iOS" in result
 
     def test_single_android_artifact(self) -> None:
         artifact = self._create_artifact(
@@ -77,7 +76,7 @@ class FormatPrCommentTest(TestCase):
         result = format_pr_comment([artifact], project=self.project)
 
         assert "AndroidApp" in result
-        assert "### Android" not in result
+        assert "### Android" in result
 
     def test_multiple_platforms_shows_subheaders(self) -> None:
         ios_artifact = self._create_artifact(app_name="iOSApp")


### PR DESCRIPTION
## Summary
- Always display the `### iOS` / `### Android` section header in build distribution PR comments, even when only one platform is present
- Previously the header was omitted for single-platform comments, making it ambiguous which platform the builds were for
- Simplifies the conditional logic in `format_pr_comment()` by removing unnecessary nesting