### PR TITLE
fix(autofix): Remove autofixEnabled check from project setup guard

### DIFF
--- a/static/app/components/events/autofix/useAutofixSetup.tsx
+++ b/static/app/components/events/autofix/useAutofixSetup.tsx
@@ -13,7 +13,6 @@ interface AutofixSetupRepoDefinition extends AutofixRepoDefinition {
 }
 
 export interface AutofixSetupResponse {
-  autofixEnabled: boolean;
   billing: {
     hasAutofixQuota: boolean;
   } | null;
@@ -61,7 +60,6 @@ export function useAutofixSetup(
 
   return {
     ...queryData,
-    autofixEnabled: Boolean(queryData.data?.autofixEnabled),
     canStartAutofix: Boolean(queryData.data?.integration.ok),
     canCreatePullRequests: Boolean(queryData.data?.githubWriteIntegration?.ok),
     hasAutofixQuota: Boolean(queryData.data?.billing?.hasAutofixQuota),

--- a/static/app/views/issueDetails/streamline/hooks/useAiConfig.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useAiConfig.tsx
@@ -7,7 +7,6 @@ import {useIsSampleEvent} from 'sentry/views/issueDetails/utils';
 
 interface AiConfigResult {
   areAiFeaturesAllowed: boolean;
-  autofixEnabled: boolean;
   hasAutofix: boolean;
   hasAutofixQuota: boolean;
   hasGithubIntegration: boolean;
@@ -27,7 +26,6 @@ export const useAiConfig = (group: Group, project: Project): AiConfigResult => {
     hasAutofixQuota,
     refetch: refetchAutofixSetup,
     seerReposLinked,
-    autofixEnabled,
   } = useAutofixSetup({
     groupId: group.id,
   });
@@ -58,6 +56,5 @@ export const useAiConfig = (group: Group, project: Project): AiConfigResult => {
     hasAutofixQuota,
     refetchAutofixSetup,
     seerReposLinked,
-    autofixEnabled,
   };
 };

--- a/static/app/views/issueDetails/streamline/sidebar/autofixSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/autofixSection.spec.tsx
@@ -43,7 +43,6 @@ describe('AutofixSection', () => {
         integration: {ok: true, reason: null},
         githubWriteIntegration: {ok: true, repos: []},
         seerReposLinked: true,
-        autofixEnabled: true,
       }),
     });
 
@@ -528,7 +527,6 @@ describe('AutofixSection', () => {
         integration: {ok: true, reason: null},
         githubWriteIntegration: {ok: true, repos: []},
         seerReposLinked: false,
-        autofixEnabled: true,
       }),
     });
 

--- a/static/app/views/issueDetails/streamline/sidebar/autofixSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/autofixSection.spec.tsx
@@ -551,36 +551,6 @@ describe('AutofixSection', () => {
     );
   });
 
-  it('shows project setup UI when autofix is not enabled', async () => {
-    MockApiClient.addMockResponse({
-      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/setup/`,
-      body: AutofixSetupFixture({
-        integration: {ok: true, reason: null},
-        githubWriteIntegration: {ok: true, repos: []},
-        seerReposLinked: true,
-        autofixEnabled: false,
-      }),
-    });
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,
-      body: {autofix: null},
-    });
-
-    render(<AutofixSection event={mockEvent} group={mockGroup} project={mockProject} />, {
-      organization,
-    });
-
-    expect(await screen.findByText('Finish Configuring Seer')).toBeInTheDocument();
-    const link = screen.getByRole('button', {
-      name: 'Set Up Seer for This Project',
-    });
-    expect(link).toHaveAttribute(
-      'href',
-      `/settings/${organization.slug}/projects/${mockProject.slug}/seer/`
-    );
-  });
-
   it('shows empty state when there are no artifacts', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${mockProject.organization.slug}/issues/${mockGroup.id}/autofix/`,

--- a/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
@@ -153,9 +153,7 @@ export function AutofixContent({aiConfig, group, project, event}: AutofixContent
 
   const needProjSetup =
     // scm integration not linked to project
-    !aiConfig.seerReposLinked ||
-    // autofix setting not enabled
-    !aiConfig.autofixEnabled;
+    !aiConfig.seerReposLinked;
 
   if (needOrgSetup || needProjSetup) {
     return (

--- a/static/gsApp/components/ai/aiConfigureSeerQuotaSidebar.spec.tsx
+++ b/static/gsApp/components/ai/aiConfigureSeerQuotaSidebar.spec.tsx
@@ -17,7 +17,6 @@ function makeAiConfig(
 ): ReturnType<typeof useAiConfig> {
   return {
     areAiFeaturesAllowed: true,
-    autofixEnabled: true,
     hasAutofix: true,
     hasAutofixQuota: true,
     hasGithubIntegration: true,

--- a/tests/js/fixtures/autofixSetupFixture.ts
+++ b/tests/js/fixtures/autofixSetupFixture.ts
@@ -4,7 +4,6 @@ export function AutofixSetupFixture(
   params: Partial<AutofixSetupResponse>
 ): AutofixSetupResponse {
   return {
-    autofixEnabled: true,
     integration: {
       ok: true,
       reason: null,


### PR DESCRIPTION
`autofixEnabled` currently reflects whether `autofix` *automation* is enabled, not whether `autofix` as a whole is available. Checking it in the project setup guard (`needProjSetup`) incorrectly showed the "Finish Configuring Seer" prompt to users who have autofix available but don't have automation enabled.

Agent transcript: https://claudescope.sentry.dev/share/GAJtanmZw0fDWjdqTdOp8MATJkvlYIJb3kyhCaDIBUE