### PR TITLE
ref(chartcuterie): Use plottable classes for Explore chart series

### DIFF
--- a/static/app/chartcuterie/explore.tsx
+++ b/static/app/chartcuterie/explore.tsx
@@ -1,18 +1,15 @@
 import type {Theme} from '@emotion/react';
-import type {BarSeriesOption, LineSeriesOption} from 'echarts';
 
 import {Grid} from 'sentry/components/charts/components/grid';
 import {Legend} from 'sentry/components/charts/components/legend';
 import {XAxis} from 'sentry/components/charts/components/xAxis';
 import {YAxis} from 'sentry/components/charts/components/yAxis';
-import {AreaSeries} from 'sentry/components/charts/series/areaSeries';
-import {BarSeries} from 'sentry/components/charts/series/barSeries';
-import {LineSeries} from 'sentry/components/charts/series/lineSeries';
-import {timeSeriesItemToEChartsDataPoint} from 'sentry/utils/timeSeries/timeSeriesItemToEChartsDataPoint';
 import {DisplayType} from 'sentry/views/dashboards/types';
 import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
 import {formatTimeSeriesLabel} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesLabel';
 import {formatYAxisValue} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatYAxisValue';
+import type {ContinuousTimeSeriesPlottingOptions} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/continuousTimeSeries';
+import {createPlottableFromTimeSeries} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/createPlottableFromTimeSeries';
 
 import {DEFAULT_FONT_FAMILY} from './slack';
 import type {RenderDescriptor} from './types';
@@ -39,29 +36,6 @@ type ExploreChartData = {
   timeSeries: TimeSeries[];
   type?: DisplayType;
 };
-
-/**
- * Creates an ECharts series based on the display type.
- *
- * NOTE: We intentionally avoid importing the plottable classes (Line, Area,
- * Bars) here because they pull in `@sentry/react` which requires browser
- * globals that are unavailable in chartcuterie's Node.js VM sandbox. Using
- * the series constructors directly keeps this bundle compatible.
- */
-function createSeries(
-  displayType: DisplayType,
-  props: LineSeriesOption & BarSeriesOption
-) {
-  switch (displayType) {
-    case DisplayType.BAR:
-      return BarSeries(props);
-    case DisplayType.AREA:
-      return AreaSeries({...props, areaStyle: {opacity: 0.4}});
-    case DisplayType.LINE:
-    default:
-      return LineSeries(props);
-  }
-}
 
 export const makeExploreCharts = (theme: Theme): Array<RenderDescriptor<ChartType>> => {
   const exploreXAxis = XAxis({
@@ -123,12 +97,13 @@ export const makeExploreCharts = (theme: Theme): Array<RenderDescriptor<ChartTyp
       if (!hasGroups) {
         const ts = timeSeries[0]!;
         const color = theme.chart.getColorPalette(0);
-        const singleSeries = createSeries(displayType, {
-          name: ts.yAxis,
-          data: ts.values.map(timeSeriesItemToEChartsDataPoint),
-          lineStyle: {color: color?.[0], opacity: 1},
-          itemStyle: {color: color?.[0]},
-        });
+        const plottingOptions: ContinuousTimeSeriesPlottingOptions = {
+          color: color?.[0] ?? '',
+          unit: ts.meta?.valueUnit ?? null,
+          yAxisPosition: 'left',
+        };
+        const plottable = createPlottableFromTimeSeries(displayType, ts);
+        const series = plottable?.toSeries(plottingOptions) ?? [];
 
         return {
           ...exploreDefaults,
@@ -136,7 +111,7 @@ export const makeExploreCharts = (theme: Theme): Array<RenderDescriptor<ChartTyp
           xAxis: exploreXAxis,
           useUTC: true,
           color,
-          series: [singleSeries],
+          series,
         };
       }
 
@@ -151,13 +126,17 @@ export const makeExploreCharts = (theme: Theme): Array<RenderDescriptor<ChartTyp
         color.push(theme.tokens.content.secondary);
       }
 
-      const series = sorted.map((ts, i) => {
-        return createSeries(displayType, {
+      const series = sorted.flatMap((ts, i) => {
+        const plottingOptions: ContinuousTimeSeriesPlottingOptions = {
+          color: color?.[i] ?? '',
+          unit: ts.meta?.valueUnit ?? null,
+          yAxisPosition: 'left',
+        };
+        const plottable = createPlottableFromTimeSeries(displayType, ts, {
           name: formatTimeSeriesLabel(ts),
-          data: ts.values.map(timeSeriesItemToEChartsDataPoint),
-          lineStyle: {color: color?.[i], opacity: 1},
-          itemStyle: {color: color?.[i]},
+          color: color?.[i],
         });
+        return plottable?.toSeries(plottingOptions) ?? [];
       });
 
       return {

--- a/static/app/utils/timeSeries/scaleTimeSeriesData.tsx
+++ b/static/app/utils/timeSeries/scaleTimeSeriesData.tsx
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/react';
 import partialRight from 'lodash/partialRight';
 
 import type {AggregationOutputType, DataUnit} from 'sentry/utils/discover/fields';
@@ -43,10 +42,6 @@ export function scaleTimeSeriesData(
     (sourceType === 'size' && !isASizeUnit(destinationUnit)) ||
     (sourceType === 'rate' && !isARateUnit(destinationUnit))
   ) {
-    Sentry.captureMessage(
-      `Attempted invalid timeseries conversion from ${sourceType} in ${sourceUnit} to ${destinationUnit}`
-    );
-
     return timeSeries;
   }
 

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/area.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/area.tsx
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/react';
 import type {LineSeriesOption} from 'echarts';
 
 import {LineSeries} from 'sentry/components/charts/series/lineSeries';
@@ -13,8 +12,6 @@ import {
   type ContinuousTimeSeriesPlottingOptions,
 } from './continuousTimeSeries';
 import type {Plottable} from './plottable';
-
-const {error} = Sentry.logger;
 
 export class Area extends ContinuousTimeSeries implements Plottable {
   #timeSeriesAndIsIncomplete: Array<[TimeSeries, boolean]>;
@@ -38,9 +35,6 @@ export class Area extends ContinuousTimeSeries implements Plottable {
     const datum = mergedData.at(dataIndex);
 
     if (!datum) {
-      error('`Area` plottable `onHighlight` out-of-range error', {
-        seriesDataIndex: dataIndex,
-      });
       return;
     }
 

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/bars.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/bars.tsx
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/react';
 // eslint-disable-next-line no-restricted-imports
 import color from 'color';
 import type {BarSeriesOption, LineSeriesOption} from 'echarts';
@@ -13,8 +12,6 @@ import {
 } from './continuousTimeSeries';
 import type {Plottable} from './plottable';
 
-const {error} = Sentry.logger;
-
 interface BarsConfig extends ContinuousTimeSeriesConfig {
   /**
    * Stack name. If provided, bar plottables with the same stack will be stacked visually.
@@ -28,9 +25,6 @@ export class Bars extends ContinuousTimeSeries<BarsConfig> implements Plottable 
     const datum = this.timeSeries.values.at(dataIndex);
 
     if (!datum) {
-      error('`Bars` plottable `onHighlight` out-of-range error', {
-        seriesDataIndex: dataIndex,
-      });
       return;
     }
 

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/createPlottableFromTimeSeries.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/createPlottableFromTimeSeries.tsx
@@ -13,7 +13,7 @@ type PlottableConfig = {
   stack?: string;
 };
 
-function createPlottableFromTimeSeries(
+export function createPlottableFromTimeSeries(
   displayType: DisplayType,
   timeSeries: TimeSeries,
   config?: PlottableConfig

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/line.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/line.tsx
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/react';
 import type {LineSeriesOption} from 'echarts';
 
 import {LineSeries} from 'sentry/components/charts/series/lineSeries';
@@ -13,8 +12,6 @@ import {
   type ContinuousTimeSeriesPlottingOptions,
 } from './continuousTimeSeries';
 import type {Plottable} from './plottable';
-
-const {error} = Sentry.logger;
 
 export class Line extends ContinuousTimeSeries implements Plottable {
   #timeSeriesAndIsIncomplete: Array<[TimeSeries, boolean]>;
@@ -38,9 +35,6 @@ export class Line extends ContinuousTimeSeries implements Plottable {
     const datum = mergedData.at(seriesDataIndex);
 
     if (!datum) {
-      error('`Line` plottable `onHighlight` out-of-range error', {
-        seriesDataIndex,
-      });
       return;
     }
 

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/samples.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/plottables/samples.tsx
@@ -1,5 +1,4 @@
 import type {Theme} from '@emotion/react';
-import * as Sentry from '@sentry/react';
 import type {EChartsType, ScatterSeriesOption, SeriesOption} from 'echarts';
 
 import {t} from 'sentry/locale';
@@ -21,8 +20,6 @@ import {crossIconPath} from 'sentry/views/insights/common/views/spanSummaryPage/
 
 import {BaselineMarkLine} from './baselineMarkline';
 import type {Plottable, PlottableTimeSeriesValueType} from './plottable';
-
-const {error, warn} = Sentry.logger;
 
 type ScatterPlotDatum = [timestamp: string, value: number, id: string];
 
@@ -104,10 +101,7 @@ export class Samples implements Plottable {
 
     try {
       chart = this.chartRef?.getEchartsInstance();
-    } catch (e) {
-      warn(
-        '`Samples` could not dispatch action because the chart was removed from the DOM'
-      );
+    } catch {
       return undefined;
     }
 
@@ -206,17 +200,7 @@ export class Samples implements Plottable {
   #getSampleByIndex(dataIndex: number): ValidSampleRow | undefined {
     const sample = this.sampleTableData.data.at(dataIndex);
 
-    if (!sample) {
-      error('`Samples` plottable data out-of-range error', {
-        dataIndex,
-      });
-      return undefined;
-    }
-
-    if (!isValidSampleRow(sample)) {
-      warn('`Samples` plottable `onHighlight` almost received an invalid row', {
-        dataIndex,
-      });
+    if (!sample || !isValidSampleRow(sample)) {
       return undefined;
     }
 


### PR DESCRIPTION
Removes `@sentry/react` imports from the plottable classes (`Line`, `Area`,
`Bars`, `Samples`) and `scaleTimeSeriesData`. These were only used for
`Sentry.logger` error/warn calls in `onHighlight` handlers and a
`captureMessage` for invalid unit conversions — none of which are critical
for chart rendering.

This unblocks the chartcuterie explore config from using the plottable
classes directly, replacing the duplicated `createSeries` function that
manually called `LineSeries`/`BarSeries`/`AreaSeries`. Benefits:

- **Incomplete data handling**: Charts now render incomplete segments with
  dotted lines, matching the browser Explore page
- **Unit scaling**: Data is properly scaled through `scaleTimeSeriesData`
- **Less duplication**: Series construction logic lives in one place

The chartcuterie build (`pnpm build-chartcuterie-config`) succeeds with no
`@sentry/react` in the output bundle.

Fixes DAIN-1497