### PR TITLE
ref(preprod): Update PR comment template styling

### DIFF
--- a/src/sentry/preprod/vcs/pr_comments/templates.py
+++ b/src/sentry/preprod/vcs/pr_comments/templates.py
@@ -21,35 +21,29 @@ def format_pr_comment(artifacts: list[PreprodArtifact], project: Project) -> str
         config = artifact.build_configuration.name if artifact.build_configuration else "--"
         artifact_url = get_preprod_artifact_url(artifact, view_type="install")
 
-        install_cell = f"[Install Build]({artifact_url})"
+        app_name_cell = f"[{app_name}]({artifact_url})"
 
-        row = f"| {app_name} | {app_id} | {version_string} | {config} | {install_cell} |"
+        row = f"| {app_name_cell} | {app_id} | {version_string} | {config} |"
 
         if artifact.is_android():
             android_rows.append(row)
         else:
             ios_rows.append(row)
 
-    sections: list[str] = ["## Sentry Build Distribution"]
+    sections: list[str] = ["## 📲 Install Builds"]
 
-    header = "| App Name | App ID | Version | Configuration | Install Page |"
-    separator = "|----------|--------|---------|---------------|--------------|"
+    header = "| 🔗 App Name | App ID | Version | Configuration |"
+    separator = "|-------------|--------|---------|---------------|"
 
     if ios_rows:
-        if android_rows:
-            sections.append(f"### iOS\n\n{header}\n{separator}\n" + "\n".join(ios_rows))
-        else:
-            sections.append(f"{header}\n{separator}\n" + "\n".join(ios_rows))
+        sections.append(f"### iOS\n\n{header}\n{separator}\n" + "\n".join(ios_rows))
 
     if android_rows:
-        if ios_rows:
-            sections.append(f"### Android\n\n{header}\n{separator}\n" + "\n".join(android_rows))
-        else:
-            sections.append(f"{header}\n{separator}\n" + "\n".join(android_rows))
+        sections.append(f"### Android\n\n{header}\n{separator}\n" + "\n".join(android_rows))
 
     settings_url = project.organization.absolute_url(
         f"/settings/projects/{project.slug}/mobile-builds/", query="tab=distribution"
     )
-    sections.append(f"[Configure {project.name} build distribution settings]({settings_url})")
+    sections.append(f"[⚙️ {project.name} Build Distribution Settings]({settings_url})")
 
     return "\n\n".join(sections)

--- a/tests/sentry/preprod/vcs/pr_comments/test_templates.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_templates.py
@@ -58,15 +58,13 @@ class FormatPrCommentTest(TestCase):
 
         result = format_pr_comment([artifact], project=self.project)
 
-        assert "## Sentry Build Distribution" in result
-        assert "| App Name | App ID | Version | Configuration | Install Page |" in result
-        assert "MyApp" in result
+        assert "## 📲 Install Builds" in result
+        assert "| 🔗 App Name | App ID | Version | Configuration |" in result
+        assert "[MyApp](" in result
         assert "com.example.app" in result
         assert "1.2.3 (456)" in result
         assert "Release" in result
-        assert "[Install Build](" in result
-        # Single platform — no subheader
-        assert "### iOS" not in result
+        assert "### iOS" in result
 
     def test_single_android_artifact(self) -> None:
         artifact = self._create_artifact(
@@ -77,7 +75,7 @@ class FormatPrCommentTest(TestCase):
         result = format_pr_comment([artifact], project=self.project)
 
         assert "AndroidApp" in result
-        assert "### Android" not in result
+        assert "### Android" in result
 
     def test_multiple_platforms_shows_subheaders(self) -> None:
         ios_artifact = self._create_artifact(app_name="iOSApp")
@@ -99,7 +97,7 @@ class FormatPrCommentTest(TestCase):
 
         result = format_pr_comment([artifact], project=self.project)
 
-        assert f"[Configure {self.project.name} build distribution settings](" in result
+        assert f"[⚙️ {self.project.name} Build Distribution Settings](" in result
         assert f"/settings/projects/{self.project.slug}/mobile-builds/?tab=distribution" in result
 
     def test_empty_list_raises(self) -> None:


### PR DESCRIPTION
Cleans up the build distribution PR comment template:

- Always show iOS/Android platform headers even when only one platform has artifacts, so the section is always clearly labeled
- Make app name a hyperlink to the install page and drop the separate Install Page column to reduce table width
- Rename header from "Sentry Build Distribution" to "📲 Install Builds" so it's immediately obvious what the comment is for
- Update settings link text to "⚙️ {project} Build Distribution Settings"

sample below 👇

---
## 📲 Install Builds

  ### iOS

  | 🔗 App Name | App ID | Version | Configuration |
  |-------------|--------|---------|---------------|
  | [MyApp](https://sentry.io/organizations/my-org/preprod/artifacts/1/install/) | com.example.ios | 1.2.3 (456) | Release |

  ### Android

  | 🔗 App Name | App ID | Version | Configuration |
  |-------------|--------|---------|---------------|
  | [MyAndroidApp](https://sentry.io/organizations/my-org/preprod/artifacts/2/install/) | com.example.android | 2.0.0 (100) | Debug |

  [⚙️ test_project Build Distribution Settings](https://sentry.io/settings/projects/test-project/mobile-builds/?tab=distribution)