### PR TITLE
fix(dashboards): Surface lastVisited field in API response

### DIFF
--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -592,6 +592,8 @@ class DashboardListSerializer(Serializer, DashboardFiltersMixin):
                     member__organization=organization,
                 ).first()
                 result[dashboard]["last_visited"] = visit.last_visited if visit else None
+            else:
+                result[dashboard]["last_visited"] = dashboard.last_visited
 
             result[dashboard]["created_by"] = serialized_users.get(str(dashboard.created_by_id))
             result[dashboard]["is_favorited"] = dashboard.id in favorited_dashboard_ids

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
@@ -878,6 +878,41 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         assert response.data[0].get("environment") == ["alpha"]
         assert response.data[0].get("filters") == {"release": ["v1"]}
 
+    def test_get_last_visited_field_without_reordering_flag(self) -> None:
+        # Clean up existing dashboards setup for this test.
+        Dashboard.objects.all().delete()
+
+        one_hour_ago = before_now(hours=1)
+        Dashboard.objects.create(
+            title="Dashboard visited oldest",
+            organization=self.organization,
+            created_by_id=self.user.id,
+            last_visited=one_hour_ago,
+        )
+
+        now = before_now(minutes=0)
+        Dashboard.objects.create(
+            title="Dashboard visited most recently",
+            organization=self.organization,
+            created_by_id=self.user.id,
+            last_visited=now,
+        )
+
+        response = self.client.get(self.url, data={"sort": "recentlyViewed"})
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 3
+
+        titles = [row["title"] for row in response.data]
+        assert titles == [
+            "General",
+            "Dashboard visited most recently",
+            "Dashboard visited oldest",
+        ]
+
+        # Only "Dashboard with last visited" has a last visited timestamp.
+        visited_at = [row.get("lastVisited") for row in response.data]
+        assert visited_at == [None, now, one_hour_ago]
+
     def test_get_with_last_visited(self) -> None:
         # Clean up existing dashboards setup for this test.
         Dashboard.objects.all().delete()


### PR DESCRIPTION
The API response wasn't returning the `lastVisited` field for the dashboard. This exposes the `lastVisited` field stored on a dashboard that accounts for the last time _any_ user visited the dashboard.

There's a feature flag that exposes the last time the current user visited the dashboard, but that code path is not in use at the moment, hence why this field is populated in the `else` in the serializer code.