### PR TITLE
fix(testutils): Add reset_trace_context() helper to clear active span

### DIFF
--- a/src/sentry/testutils/helpers/sdk.py
+++ b/src/sentry/testutils/helpers/sdk.py
@@ -1,0 +1,30 @@
+"""
+Helpers for manipulating the Sentry SDK state in tests.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from contextlib import contextmanager
+
+import sentry_sdk
+
+
+@contextmanager
+def reset_trace_context() -> Generator[None]:
+    """
+    Context manager that isolates the SDK scope AND clears any inherited span.
+
+    ``sentry_sdk.isolation_scope()`` forks (shallow-copies) the current scope,
+    which means any active span is carried over.  This wrapper also sets
+    ``scope.span = None`` so that ``get_trace_id()`` returns ``None`` inside
+    the block — which is the expected state when no span is active.
+
+    Usage::
+
+        with reset_trace_context():
+            handler.emit(record, logger=logger)
+    """
+    with sentry_sdk.isolation_scope():
+        sentry_sdk.get_current_scope().span = None
+        yield


### PR DESCRIPTION
## Problem

`sentry_sdk.isolation_scope()` shallow-copies the active span into the new scope. Tests that assert `get_trace_id() is None` (e.g. when testing code paths that run outside a trace) still see a live trace ID inside an `isolation_scope()` block because the copied span is non-None.

## Change

New file `src/sentry/testutils/helpers/sdk.py` — exports `reset_trace_context()`, a context manager that:

1. Enters `sentry_sdk.isolation_scope()` to isolate from the outer scope.
2. Sets `scope.span = None` to clear the inherited span reference.

Usage:
```python
from sentry.testutils.helpers.sdk import reset_trace_context

with reset_trace_context():
    assert get_trace_id() is None
```

## Test plan

Used by `tests/sentry/logging/test_handler.py` which asserts that log records emitted outside an active span carry no trace ID.