### PR TITLE
fix(organizations): Fix negative lookahead in absolute_url for org slug 'new'

### DIFF
--- a/src/sentry/organizations/absolute_url.py
+++ b/src/sentry/organizations/absolute_url.py
@@ -9,7 +9,7 @@ from sentry.utils.http import absolute_uri, is_using_customer_domain
 
 _path_patterns: list[tuple[re.Pattern[str], str]] = [
     # /organizations/slug/section, but not /organizations/new
-    (re.compile(r"\/?organizations\/(?!new)[^/]+\/(.*)"), r"/\1"),
+    (re.compile(r"\/?organizations\/(?!new\/)[^/]+\/(.*)"), r"/\1"),
     # For /settings/:orgId/ -> /settings/organization/
     (
         re.compile(r"\/settings\/(?!account\/|!billing\/|projects\/|seer\/|teams)[^/]+\/?$"),

--- a/tests/sentry/organizations/test_absolute_url.py
+++ b/tests/sentry/organizations/test_absolute_url.py
@@ -42,6 +42,7 @@ from sentry.organizations.absolute_url import customer_domain_path
         ("/checkout/acme/", "/checkout/"),
         ("/checkout/acme/?query=value", "/checkout/?query=value"),
         ("/organizations/new/", "/organizations/new/"),
+        ("/organizations/newt-corp/issues/", "/issues/"),
         ("/organizations/albertos-apples/issues/", "/issues/"),
         ("/organizations/albertos-apples/issues/?_q=all#hash", "/issues/?_q=all#hash"),
         ("/acme/project-slug/getting-started/", "/getting-started/project-slug/"),


### PR DESCRIPTION
## Problem

`absolute_url.py` strips `/organizations/<slug>/` from URL paths using:
```python
r"\/?organizations\/(?!new)[^/]+\/(.*)"
```

The lookahead `(?!new)` matches any slug that doesn't *start with* the string "new". This incorrectly excludes slugs like `"newco"` or `"newly"` — valid org slugs that happen to begin with "new".

## Fix

```diff
-r"\/?organizations\/(?!new)[^/]+\/(.*)"
+r"\/?organizations\/(?!new\/)[^/]+\/(.*)"
```

Adding the trailing slash to the lookahead means only the exact path segment `new/` (i.e. an org literally named `"new"`) triggers the exclusion. Slugs starting with "new" followed by any other character are now handled correctly.

## Test plan

Added a test case in `tests/sentry/organizations/test_absolute_url.py` covering slugs that start with "new" but are not exactly "new".