### PR TITLE
fix(releases): Support environment filter in the query param

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -26,6 +26,7 @@ from sentry.api.paginator import (
     OffsetPaginator,
 )
 from sentry.api.release_search import (
+    ENVIRONMENT_KEY,
     FINALIZED_KEY,
     RELEASE_CREATED_KEY,
     RELEASE_FREE_TEXT_KEY,
@@ -179,6 +180,33 @@ def _filter_releases_by_query(queryset, organization, query, filter_params):
                     f"date_added__{OPERATOR_TO_DJANGO[search_filter.operator]}": search_filter.value.raw_value
                 }
             )
+
+        if search_filter.key.name == ENVIRONMENT_KEY:
+            negated = search_filter.operator in ("!=", "NOT IN")
+            kind, value_o = search_filter.value.classify_and_format_wildcard()
+            project_ids = filter_params["project_id"]
+            if kind == "infix":
+                env_q = Q(
+                    releaseprojectenvironment__environment__name__icontains=value_o,
+                    releaseprojectenvironment__project_id__in=project_ids,
+                )
+            elif kind == "prefix":
+                env_q = Q(
+                    releaseprojectenvironment__environment__name__istartswith=value_o,
+                    releaseprojectenvironment__project_id__in=project_ids,
+                )
+            elif kind == "suffix":
+                env_q = Q(
+                    releaseprojectenvironment__environment__name__iendswith=value_o,
+                    releaseprojectenvironment__project_id__in=project_ids,
+                )
+            else:
+                env_names = value_o if isinstance(value_o, list) else [value_o]
+                env_q = Q(
+                    releaseprojectenvironment__environment__name__in=env_names,
+                    releaseprojectenvironment__project_id__in=project_ids,
+                )
+            queryset = queryset.exclude(env_q) if negated else queryset.filter(env_q)
 
     return queryset
 

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -184,29 +184,13 @@ def _filter_releases_by_query(queryset, organization, query, filter_params):
         if search_filter.key.name == ENVIRONMENT_KEY:
             negated = search_filter.operator in ("!=", "NOT IN")
             kind, value_o = search_filter.value.classify_and_format_wildcard()
-            project_ids = filter_params["project_id"]
-            if kind == "infix":
-                env_q = Q(
-                    releaseprojectenvironment__environment__name__icontains=value_o,
-                    releaseprojectenvironment__project_id__in=project_ids,
-                )
-            elif kind == "prefix":
-                env_q = Q(
-                    releaseprojectenvironment__environment__name__istartswith=value_o,
-                    releaseprojectenvironment__project_id__in=project_ids,
-                )
-            elif kind == "suffix":
-                env_q = Q(
-                    releaseprojectenvironment__environment__name__iendswith=value_o,
-                    releaseprojectenvironment__project_id__in=project_ids,
-                )
-            else:
-                env_names = value_o if isinstance(value_o, list) else [value_o]
-                env_q = Q(
-                    releaseprojectenvironment__environment__name__in=env_names,
-                    releaseprojectenvironment__project_id__in=project_ids,
-                )
-            queryset = queryset.exclude(env_q) if negated else queryset.filter(env_q)
+            lookup_map = {"infix": "icontains", "prefix": "istartswith", "suffix": "iendswith"}
+            queryset = queryset.filter_by_environment(
+                value_o,
+                filter_params["project_id"],
+                lookup=lookup_map.get(kind, "in"),
+                negated=negated,
+            )
 
     return queryset
 
@@ -418,7 +402,6 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, ReleaseAnal
                     status=400,
                 )
 
-        queryset = queryset.distinct()
         queryset = filter_releases_by_projects(queryset, filter_params["project_id"])
 
         if sort == "date":

--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -418,6 +418,7 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, ReleaseAnal
                     status=400,
                 )
 
+        queryset = queryset.distinct()
         queryset = filter_releases_by_projects(queryset, filter_params["project_id"])
 
         if sort == "date":

--- a/src/sentry/api/release_search.py
+++ b/src/sentry/api/release_search.py
@@ -10,6 +10,7 @@ from sentry.search.events.constants import (
     SEMVER_PACKAGE_ALIAS,
 )
 
+ENVIRONMENT_KEY = "environment"
 RELEASE_FREE_TEXT_KEY = "release_free_text"
 FINALIZED_KEY = "finalized"
 RELEASE_CREATED_KEY = "release.created"
@@ -27,6 +28,7 @@ release_search_config = SearchConfig.create_from(
         SEMVER_PACKAGE_ALIAS,
         FINALIZED_KEY,
         RELEASE_CREATED_KEY,
+        ENVIRONMENT_KEY,
     },
     date_keys={RELEASE_CREATED_KEY},
     allow_boolean=False,

--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -143,6 +143,18 @@ class ReleaseModelManager(BaseManager["Release"]):
             organization_id, operator, value, project_ids, environments
         )
 
+    def filter_by_environment(
+        self,
+        value: str | Sequence[str],
+        project_ids: Sequence[int],
+        *,
+        lookup: str = "in",
+        negated: bool = False,
+    ) -> ReleaseQuerySet:
+        return self.get_queryset().filter_by_environment(
+            value, project_ids, lookup=lookup, negated=negated
+        )
+
     def order_by_recent(self):
         return self.get_queryset().order_by_recent()
 

--- a/src/sentry/models/releases/util.py
+++ b/src/sentry/models/releases/util.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Self
 
 from django.db import models
-from django.db.models import Case, F, Func, Q, Subquery, Value, When
+from django.db.models import Case, Exists, F, Func, OuterRef, Q, Subquery, Value, When
 from django.db.models.signals import pre_save
 from sentry_relay.exceptions import RelayError
 from sentry_relay.processing import parse_release
@@ -200,6 +200,40 @@ class ReleaseQuerySet(BaseQuerySet["Release"]):
 
         qs = self.filter(id__in=Subquery(rpes.filter(query).values_list("release_id", flat=True)))
         return qs
+
+    def filter_by_environment(
+        self,
+        value: str | Sequence[str],
+        project_ids: Sequence[int],
+        *,
+        lookup: str = "in",
+        negated: bool = False,
+    ) -> Self:
+        """
+        Filter releases by environment name using an EXISTS subquery, avoiding
+        duplicate rows when a release appears in the same environment across
+        multiple projects.
+
+        ``lookup`` controls the match type: ``"in"`` for exact, or one of
+        ``"icontains"`` / ``"istartswith"`` / ``"iendswith"`` for wildcards.
+        """
+        from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
+
+        if lookup == "in":
+            env_filter: dict[str, object] = {
+                "environment__name__in": value if isinstance(value, list) else [value]
+            }
+        else:
+            env_filter = {f"environment__name__{lookup}": value}
+
+        exists_subquery = Exists(
+            ReleaseProjectEnvironment.objects.filter(
+                release=OuterRef("pk"),
+                project_id__in=project_ids,
+                **env_filter,
+            )
+        )
+        return self.filter(~exists_subquery if negated else exists_subquery)
 
     def order_by_recent(self) -> Self:
         return self.order_by("-date_added", "-id")

--- a/src/sentry/models/releases/util.py
+++ b/src/sentry/models/releases/util.py
@@ -221,7 +221,7 @@ class ReleaseQuerySet(BaseQuerySet["Release"]):
 
         if lookup == "in":
             env_filter: dict[str, object] = {
-                "environment__name__in": value if isinstance(value, list) else [value]
+                "environment__name__in": [value] if isinstance(value, str) else list(value)
             }
         else:
             env_filter = {f"environment__name__{lookup}": value}

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -2593,6 +2593,21 @@ class OrganizationReleaseListEnvironmentsTest(APITestCase):
         )
         self.assert_releases(response, [self.release2, self.release3, self.release5])
 
+    def test_environment_query_param_and_environment_filter_are_anded(self) -> None:
+        """Both ?environment= and environment: in query are applied as AND conditions."""
+        url = reverse(
+            "sentry-api-0-organization-releases", kwargs={"organization_id_or_slug": self.org.slug}
+        )
+        # ?environment=prod alone → release1, release5
+        # query=environment:staging alone → release2, release3, release5
+        # Both together → only release5 (in both prod and staging)
+        response = self.client.get(
+            url,
+            format="json",
+            data={"environment": self.env1.name, "query": f"environment:{self.env2.name}"},
+        )
+        self.assert_releases(response, [self.release5])
+
     def test_environment_wildcard_in_query_param(self) -> None:
         """environment: with wildcard patterns in the query string should use substring matching"""
         url = reverse(

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -2461,6 +2461,8 @@ class OrganizationReleaseCommitRangesTest(SetRefsTestCase):
 
 
 class OrganizationReleaseListEnvironmentsTest(APITestCase):
+    endpoint = "sentry-api-0-organization-releases"
+
     def setUp(self) -> None:
         self.login_as(user=self.user)
         org = self.create_organization(owner=self.user)
@@ -2534,7 +2536,6 @@ class OrganizationReleaseListEnvironmentsTest(APITestCase):
         return env
 
     def assert_releases(self, response, releases):
-        assert response.status_code == 200, response.content
         assert len(response.data) == len(releases)
 
         response_versions = sorted(r["version"] for r in response.data)
@@ -2542,122 +2543,85 @@ class OrganizationReleaseListEnvironmentsTest(APITestCase):
         assert response_versions == releases_versions
 
     def test_environments_filter(self) -> None:
-        url = reverse(
-            "sentry-api-0-organization-releases", kwargs={"organization_id_or_slug": self.org.slug}
-        )
-        response = self.client.get(url + "?environment=" + self.env1.name, format="json")
+        response = self.get_success_response(self.org.slug, environment=self.env1.name)
         self.assert_releases(response, [self.release1, self.release5])
 
-        response = self.client.get(url + "?environment=" + self.env2.name, format="json")
+        response = self.get_success_response(self.org.slug, environment=self.env2.name)
         self.assert_releases(response, [self.release2, self.release3, self.release5])
 
     def test_empty_environment(self) -> None:
-        url = reverse(
-            "sentry-api-0-organization-releases", kwargs={"organization_id_or_slug": self.org.slug}
-        )
         env = self.make_environment("", self.project2)
         ReleaseProjectEnvironment.objects.create(
             project_id=self.project2.id, release_id=self.release4.id, environment_id=env.id
         )
-        response = self.client.get(url + "?environment=", format="json")
+        response = self.get_success_response(self.org.slug, environment="")
         self.assert_releases(response, [self.release4])
 
     def test_all_environments(self) -> None:
-        url = reverse(
-            "sentry-api-0-organization-releases", kwargs={"organization_id_or_slug": self.org.slug}
-        )
-        response = self.client.get(url, format="json")
+        response = self.get_success_response(self.org.slug)
         self.assert_releases(
             response, [self.release1, self.release2, self.release3, self.release4, self.release5]
         )
 
     def test_invalid_environment(self) -> None:
-        url = reverse(
-            "sentry-api-0-organization-releases", kwargs={"organization_id_or_slug": self.org.slug}
-        )
-        response = self.client.get(url + "?environment=" + "invalid_environment", format="json")
-        assert response.status_code == 404
+        self.get_error_response(self.org.slug, environment="invalid_environment", status_code=404)
 
     def test_environment_in_query_param(self) -> None:
         """environment: in the query string should filter the same as ?environment="""
-        url = reverse(
-            "sentry-api-0-organization-releases", kwargs={"organization_id_or_slug": self.org.slug}
-        )
-        response = self.client.get(
-            url, format="json", data={"query": f"environment:{self.env1.name}"}
-        )
+        response = self.get_success_response(self.org.slug, query=f"environment:{self.env1.name}")
         self.assert_releases(response, [self.release1, self.release5])
 
-        response = self.client.get(
-            url, format="json", data={"query": f"environment:{self.env2.name}"}
-        )
+        response = self.get_success_response(self.org.slug, query=f"environment:{self.env2.name}")
         self.assert_releases(response, [self.release2, self.release3, self.release5])
 
     def test_environment_query_param_and_environment_filter_are_anded(self) -> None:
         """Both ?environment= and environment: in query are applied as AND conditions."""
-        url = reverse(
-            "sentry-api-0-organization-releases", kwargs={"organization_id_or_slug": self.org.slug}
-        )
         # ?environment=prod alone → release1, release5
         # query=environment:staging alone → release2, release3, release5
         # Both together → only release5 (in both prod and staging)
-        response = self.client.get(
-            url,
-            format="json",
-            data={"environment": self.env1.name, "query": f"environment:{self.env2.name}"},
+        response = self.get_success_response(
+            self.org.slug,
+            environment=self.env1.name,
+            query=f"environment:{self.env2.name}",
         )
         self.assert_releases(response, [self.release5])
 
     def test_environment_wildcard_in_query_param(self) -> None:
         """environment: with wildcard patterns in the query string should use substring matching"""
-        url = reverse(
-            "sentry-api-0-organization-releases", kwargs={"organization_id_or_slug": self.org.slug}
-        )
         # env1="prod" contains "rod"; env2="staging" does not
-        response = self.client.get(url, format="json", data={"query": "environment:*rod*"})
+        response = self.get_success_response(self.org.slug, query="environment:*rod*")
         self.assert_releases(response, [self.release1, self.release5])
 
         # The frontend sends Contains via private-use unicode delimiters — same semantics
-        response = self.client.get(
-            url, format="json", data={"query": "!environment:\uf00dContains\uf00dprod"}
+        response = self.get_success_response(
+            self.org.slug, query="!environment:\uf00dContains\uf00dprod"
         )
         self.assert_releases(response, [self.release2, self.release3, self.release4])
 
     def test_specify_project_ids(self) -> None:
-        url = reverse(
-            "sentry-api-0-organization-releases", kwargs={"organization_id_or_slug": self.org.slug}
-        )
-        response = self.client.get(url, format="json", data={"project": self.project1.id})
+        response = self.get_success_response(self.org.slug, project=self.project1.id)
         self.assert_releases(response, [self.release1, self.release3, self.release5])
-        response = self.client.get(url, format="json", data={"project": self.project2.id})
+
+        response = self.get_success_response(self.org.slug, project=self.project2.id)
         self.assert_releases(response, [self.release2, self.release4, self.release5])
-        response = self.client.get(
-            url, format="json", data={"project": [self.project1.id, self.project2.id]}
+
+        response = self.get_success_response(
+            self.org.slug, project=[self.project1.id, self.project2.id]
         )
         self.assert_releases(
             response, [self.release1, self.release2, self.release3, self.release4, self.release5]
         )
 
     def test_date_range(self) -> None:
-        url = reverse(
-            "sentry-api-0-organization-releases", kwargs={"organization_id_or_slug": self.org.slug}
-        )
-        response = self.client.get(
-            url,
-            format="json",
-            data={
-                "start": (datetime.now() - timedelta(days=1)).isoformat() + "Z",
-                "end": datetime.now().isoformat() + "Z",
-            },
+        response = self.get_success_response(
+            self.org.slug,
+            start=(datetime.now() - timedelta(days=1)).isoformat() + "Z",
+            end=datetime.now().isoformat() + "Z",
         )
         self.assert_releases(response, [self.release4, self.release5])
 
     def test_invalid_date_range(self) -> None:
-        url = reverse(
-            "sentry-api-0-organization-releases", kwargs={"organization_id_or_slug": self.org.slug}
-        )
-        response = self.client.get(url, format="json", data={"start": "null", "end": "null"})
-        assert response.status_code == 400
+        self.get_error_response(self.org.slug, start="null", end="null", status_code=400)
 
 
 class OrganizationReleaseCreateCommitPatch(ReleaseCommitPatchTest):

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -2566,6 +2566,22 @@ class OrganizationReleaseListEnvironmentsTest(APITestCase):
     def test_invalid_environment(self) -> None:
         self.get_error_response(self.org.slug, environment="invalid_environment", status_code=404)
 
+    def test_environment_in_query_param_no_duplicates(self) -> None:
+        """A release in the same environment across multiple projects must appear only once."""
+        # Give project2 the prod environment and associate release5 with it,
+        # so release5 has two RPE rows both matching environment:prod.
+        self.env1.add_project(self.project2)
+        ReleaseProjectEnvironment.objects.create(
+            project_id=self.project2.id, release_id=self.release5.id, environment_id=self.env1.id
+        )
+        # Use the header that enables __get_new, which lacks the .distinct() that __get_old has.
+        response = self.get_success_response(
+            self.org.slug,
+            query=f"environment:{self.env1.name}",
+            extra_headers={"HTTP_X_PERFORMANCE_OPTIMIZATIONS": "enabled"},
+        )
+        self.assert_releases(response, [self.release1, self.release5])
+
     def test_environment_in_query_param(self) -> None:
         """environment: in the query string should filter the same as ?environment="""
         response = self.get_success_response(self.org.slug, query=f"environment:{self.env1.name}")

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -1350,6 +1350,22 @@ class OrganizationReleasesStatsTest(APITestCase):
         response = self.get_success_response(self.organization.slug, query="release:*baz*")
         assert [r["version"] for r in response.data] == []
 
+    def test_environment_in_query_param(self) -> None:
+        """environment: in the query string filters the stats endpoint's ValuesQuerySet correctly."""
+        env = self.create_environment(name="prod", project=self.project1)
+
+        release_in_env = self.create_release(project=self.project1, version="release-in-env")
+        ReleaseProjectEnvironment.objects.create(
+            project_id=self.project1.id,
+            release_id=release_in_env.id,
+            environment_id=env.id,
+        )
+
+        self.create_release(project=self.project2, version="release-not-in-env")
+
+        response = self.get_success_response(self.organization.slug, query="environment:prod")
+        assert [r["version"] for r in response.data] == [release_in_env.version]
+
 
 class OrganizationReleaseCreateTest(APITestCase):
     def test_empty_release_version(self) -> None:

--- a/tests/sentry/api/endpoints/test_organization_releases.py
+++ b/tests/sentry/api/endpoints/test_organization_releases.py
@@ -2578,6 +2578,36 @@ class OrganizationReleaseListEnvironmentsTest(APITestCase):
         response = self.client.get(url + "?environment=" + "invalid_environment", format="json")
         assert response.status_code == 404
 
+    def test_environment_in_query_param(self) -> None:
+        """environment: in the query string should filter the same as ?environment="""
+        url = reverse(
+            "sentry-api-0-organization-releases", kwargs={"organization_id_or_slug": self.org.slug}
+        )
+        response = self.client.get(
+            url, format="json", data={"query": f"environment:{self.env1.name}"}
+        )
+        self.assert_releases(response, [self.release1, self.release5])
+
+        response = self.client.get(
+            url, format="json", data={"query": f"environment:{self.env2.name}"}
+        )
+        self.assert_releases(response, [self.release2, self.release3, self.release5])
+
+    def test_environment_wildcard_in_query_param(self) -> None:
+        """environment: with wildcard patterns in the query string should use substring matching"""
+        url = reverse(
+            "sentry-api-0-organization-releases", kwargs={"organization_id_or_slug": self.org.slug}
+        )
+        # env1="prod" contains "rod"; env2="staging" does not
+        response = self.client.get(url, format="json", data={"query": "environment:*rod*"})
+        self.assert_releases(response, [self.release1, self.release5])
+
+        # The frontend sends Contains via private-use unicode delimiters — same semantics
+        response = self.client.get(
+            url, format="json", data={"query": "!environment:\uf00dContains\uf00dprod"}
+        )
+        self.assert_releases(response, [self.release2, self.release3, self.release4])
+
     def test_specify_project_ids(self) -> None:
         url = reverse(
             "sentry-api-0-organization-releases", kwargs={"organization_id_or_slug": self.org.slug}


### PR DESCRIPTION
The `/releases` endpoint returns 400 when the `query` param contains an `environment:` token (e.g. `?query=environment:production`). Other endpoints accept environment either as a dedicated `?environment=` param or inline in the query string; this brings releases in line with that behaviour.

The frontend already sends `environment:` in the query string for some widgets (e.g. crashes by release), so the 400 is a real user-facing breakage.

## What changed

**`src/sentry/api/release_search.py`** — added `ENVIRONMENT_KEY = "environment"` alongside the other local key constants, and included it in the `release_search_config` allowed-key set so the parser accepts it instead of raising `InvalidSearchQuery`.

**`src/sentry/api/endpoints/organization_releases.py`** — added a handler for `ENVIRONMENT_KEY` in `_filter_releases_by_query`. It calls `classify_and_format_wildcard()` (the same helper used by `RELEASE_ALIAS`) to map wildcard patterns to the right ORM lookups:
- `environment:*foo*` → `__icontains`
- `environment:foo*` → `__istartswith`
- `environment:*foo` → `__iendswith`
- `environment:prod` → exact `__in`
- `!environment:*foo*` → `exclude(...)` variant for each

This handles the exact frontend format (`!environment:\uF00DContains\uF00Dfoo`) that was previously breaking.

## Notes

When `environment` is supplied both as `?environment=prod` and as `environment:staging` in the query string, the two filters are AND-ed — both `.filter()` calls are applied independently. This is consistent with how other chained filters work and is covered by a test.

`release.stage` uses `filter_params.get("environment")` for its environment scoping, which is only populated from the dedicated `?environment=` param. This pre-existing inconsistency is out of scope here.

Refs DAIN-1281