### PR TITLE
fix: Don't skip cache reload for project options

### DIFF
--- a/src/sentry/ingest/transaction_clusterer/meta.py
+++ b/src/sentry/ingest/transaction_clusterer/meta.py
@@ -28,6 +28,4 @@ def track_clusterer_run(namespace: ClustererNamespace, project: Project) -> None
     meta["last_run"] = now = int(datetime.now(timezone.utc).timestamp())
     if meta["first_run"] == 0:
         meta["first_run"] = now
-    # This option is updated very often, but only keeps track of transaction clusterer internal metadata.
-    # To minimize the recomputations the system does, we can skip reloading (project) caches.
-    project.update_option(namespace.value.meta_store, meta, reload_cache=False)
+    project.update_option(namespace.value.meta_store, meta)

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -129,16 +129,9 @@ class ProjectOptionManager(OptionManager["ProjectOption"]):
         self.filter(project=project, key=key).delete()
         self.reload_cache(project.id, "projectoption.unset_value", key)
 
-    def set_value(
-        self, project: int | Project, key: str, value: Any, reload_cache: bool = True
-    ) -> bool:
+    def set_value(self, project: int | Project, key: str, value: Any) -> bool:
         """
         Sets a project option for the given project.
-        :param reload_cache: Invalidate the project config and reload the
-        cache only if the value has changed and `reload_cache` is `True`.
-
-        Do not call this with `False` unless you know for sure that it's fine
-        to keep the cached project config.
         """
 
         if isinstance(project, models.Model):
@@ -160,7 +153,7 @@ class ProjectOptionManager(OptionManager["ProjectOption"]):
                 self.filter(id=obj.id).update(value=value)
                 is_value_changed = True
 
-        if reload_cache and is_value_changed:
+        if is_value_changed:
             # invalidate the cached project config only if the value has changed,
             # and reload_cache is set to True
             self.reload_cache(project_id, "projectoption.set_value", key)

--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -444,14 +444,11 @@ class Project(Model):
     ) -> Any:
         return self.option_manager.get_value(self, key, default, validate)
 
-    def update_option(self, key: str, value: Any, reload_cache: bool = True) -> bool:
+    def update_option(self, key: str, value: Any) -> bool:
         """
         Updates a project option for this project.
-        :param reload_cache: Invalidate the project config and reload the
-        cache. Do not call this with `False` unless you know for sure that
-        it's fine to keep the cached project config.
         """
-        return self.option_manager.set_value(self, key, value, reload_cache=reload_cache)
+        return self.option_manager.set_value(self, key, value)
 
     def delete_option(self, key: str) -> None:
         self.option_manager.unset_value(self, key)

--- a/src/sentry/tasks/auto_resolve_issues.py
+++ b/src/sentry/tasks/auto_resolve_issues.py
@@ -77,7 +77,7 @@ def auto_resolve_project_issues(project_id, cutoff=None, chunk_size=1000, **kwar
     if not age:
         return
 
-    project.update_option("sentry:_last_auto_resolve", int(time()), reload_cache=False)
+    project.update_option("sentry:_last_auto_resolve", int(time()))
 
     if cutoff:
         cutoff = datetime.fromtimestamp(cutoff, timezone.utc)

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -309,7 +309,15 @@ def schedule_invalidate_project_config(
 
     from sentry.models.project import Project
 
-    if trigger_details in NON_INVALIDATING_PROJECT_OPTIONS:
+    if (
+        trigger
+        in [
+            "projectoption.post_deleteprojectoption.post_save",
+            "projectoption.set_value",
+            "projectoption.unset_value",
+        ]
+        and trigger_details in NON_INVALIDATING_PROJECT_OPTIONS
+    ):
         return
 
     if transaction_db is None:

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -312,7 +312,8 @@ def schedule_invalidate_project_config(
     if (
         trigger
         in [
-            "projectoption.post_deleteprojectoption.post_save",
+            "projectoption.post_delete",
+            "projectoption.post_save",
             "projectoption.set_value",
             "projectoption.unset_value",
         ]

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -16,6 +16,13 @@ from sentry.utils.sdk import set_current_event_project
 
 logger = logging.getLogger(__name__)
 
+# Project options that don't trigger a project config invalidation.
+NON_INVALIDATING_PROJECT_OPTIONS = [
+    "sentry:_last_auto_resolve",
+    # This option is updated very often, but only keeps track of transaction clusterer internal metadata.
+    "sentry:transaction_name_cluster_meta",
+]
+
 
 # The time_limit here should match the `debounce_ttl` of the projectconfig_debounce_cache
 # service.
@@ -304,6 +311,9 @@ def schedule_invalidate_project_config(
 
     if transaction_db is None:
         transaction_db = router.db_for_write(Project)
+
+    if trigger_details in NON_INVALIDATING_PROJECT_OPTIONS:
+        return
 
     def _do_schedule():
         _schedule_invalidate_project_config(

--- a/src/sentry/tasks/relay.py
+++ b/src/sentry/tasks/relay.py
@@ -309,11 +309,11 @@ def schedule_invalidate_project_config(
 
     from sentry.models.project import Project
 
-    if transaction_db is None:
-        transaction_db = router.db_for_write(Project)
-
     if trigger_details in NON_INVALIDATING_PROJECT_OPTIONS:
         return
+
+    if transaction_db is None:
+        transaction_db = router.db_for_write(Project)
 
     def _do_schedule():
         _schedule_invalidate_project_config(


### PR DESCRIPTION
In order to cut down on pointless project config invalidations, we introduced a `reload_cache` flag to `ProjectOptionManager.set_value`, cf. https://github.com/getsentry/sentry/pull/95521, https://github.com/getsentry/sentry/pull/95524, and INGEST-444. However, this also skips setting the cache in addition to the project config invalidation.

In this PR, we take a different tack: the flag is removed, the `reload_cache` method is once again called unconditionally, and it's now up to `schedule_invalidate_project_config` to decide whether an option requires a project config invalidation. The options for which this can be skipped are now simply listed in `NON_INVALIDATING_PROJECT_OPTIONS`.