### PR TITLE
style(explore): Use landscape chart size and scale fonts for explore unfurls

### DIFF
--- a/static/app/chartcuterie/explore.tsx
+++ b/static/app/chartcuterie/explore.tsx
@@ -19,10 +19,10 @@ import type {RenderDescriptor} from './types';
 import {ChartType} from './types';
 
 /**
- * Font size and spacing scaled for the larger explore chart canvas (1600x1200).
+ * Font size and spacing scaled for the larger explore chart canvas (1200x400).
  */
-const EXPLORE_FONT_SIZE = 32;
-const EXPLORE_CHART_SIZE = {width: 1600, height: 1200};
+const EXPLORE_FONT_SIZE = 28;
+const EXPLORE_CHART_SIZE = {width: 1200, height: 400};
 
 /**
  * Builds a y-axis axisLabel formatter from the first timeseries metadata.


### PR DESCRIPTION
Update the explore Chartcuterie config from 1600x1200 to 1200x400
(3:1 landscape) to match the Explore chart proportions. Scale font
size from 32 to 28 to remain readable at the new canvas dimensions.

This pairs with the backend PR that passes the same size override
to Chartcuterie.

Refs DAIN-1491