### PR TITLE
fix(seer): Dont show the Seer subscription banner to orgs with managed subscriptions

### DIFF
--- a/static/gsApp/views/seerAutomation/components/seerSettingsPageContent.tsx
+++ b/static/gsApp/views/seerAutomation/components/seerSettingsPageContent.tsx
@@ -4,6 +4,7 @@ import {Stack} from '@sentry/scraps/layout';
 import {t} from 'sentry/locale';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
+import {useSubscription} from 'getsentry/hooks/useSubscription';
 import {NoActiveSeerSubscriptionBanner} from 'getsentry/views/seerAutomation/components/noActiveSeerSubscriptionBanner';
 import {SeerWizardSetupBanner} from 'getsentry/views/seerAutomation/components/seerWizardSetupBanner';
 import {SettingsPageTabs} from 'getsentry/views/seerAutomation/components/settingsPageTabs';
@@ -14,13 +15,14 @@ interface Props {
 }
 
 export function SeerSettingsPageContent({children}: Props) {
+  const subscription = useSubscription();
   const organization = useOrganization();
   const canWrite = useCanWriteSettings();
   const hasSeatBasedSeer = organization.features.includes('seat-based-seer-enabled');
   const hasLegacySeer = organization.features.includes('seer-added');
   const hasCodeReviewBeta = organization.features.includes('code-review-beta');
   const showNoActiveSeerSubscriptionBanner =
-    !hasSeatBasedSeer && (hasLegacySeer || hasCodeReviewBeta);
+    !hasSeatBasedSeer && (hasLegacySeer || hasCodeReviewBeta) && !subscription?.isManaged;
 
   return (
     <Stack gap="lg">

--- a/static/gsApp/views/seerAutomation/components/seerSettingsPageContent.tsx
+++ b/static/gsApp/views/seerAutomation/components/seerSettingsPageContent.tsx
@@ -24,7 +24,7 @@ export function SeerSettingsPageContent({children}: Props) {
   const showNoActiveSeerSubscriptionBanner =
     !hasSeatBasedSeer &&
     (hasLegacySeer || hasCodeReviewBeta) &&
-    !subscription?.canSelfServe;
+    subscription?.canSelfServe;
 
   return (
     <Stack gap="lg">

--- a/static/gsApp/views/seerAutomation/components/seerSettingsPageContent.tsx
+++ b/static/gsApp/views/seerAutomation/components/seerSettingsPageContent.tsx
@@ -22,7 +22,9 @@ export function SeerSettingsPageContent({children}: Props) {
   const hasLegacySeer = organization.features.includes('seer-added');
   const hasCodeReviewBeta = organization.features.includes('code-review-beta');
   const showNoActiveSeerSubscriptionBanner =
-    !hasSeatBasedSeer && (hasLegacySeer || hasCodeReviewBeta) && !subscription?.isManaged;
+    !hasSeatBasedSeer &&
+    (hasLegacySeer || hasCodeReviewBeta) &&
+    !subscription?.canSelfServe;
 
   return (
     <Stack gap="lg">

--- a/static/gsApp/views/seerAutomation/seerAutomation.spec.tsx
+++ b/static/gsApp/views/seerAutomation/seerAutomation.spec.tsx
@@ -38,29 +38,6 @@ describe('SeerAutomation', () => {
     });
   });
 
-  it('shows no-active-subscription banner inline for legacy Seer cohorts', () => {
-    const organization = OrganizationFixture({
-      features: ['code-review-beta'],
-    });
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/seer/onboarding-check/`,
-      method: 'GET',
-      body: {
-        hasSupportedScmIntegration: true,
-        isAutofixEnabled: true,
-        isCodeReviewEnabled: true,
-        isSeerConfigured: true,
-      },
-    });
-
-    render(<SeerAutomation />, {organization});
-
-    expect(
-      screen.getByText('You are using an older Seer experience.')
-    ).toBeInTheDocument();
-  });
-
   it('does not show legacy banner for orgs without legacy or beta Seer features', () => {
     const organization = OrganizationFixture({
       features: [],

--- a/static/gsApp/views/seerAutomation/seerAutomation.tsx
+++ b/static/gsApp/views/seerAutomation/seerAutomation.tsx
@@ -9,6 +9,7 @@ import {showNewSeer} from 'sentry/utils/seer/showNewSeer';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 
+import {useSubscription} from 'getsentry/hooks/useSubscription';
 import {NoActiveSeerSubscriptionBanner} from 'getsentry/views/seerAutomation/components/noActiveSeerSubscriptionBanner';
 import {SeerAutomationDefault} from 'getsentry/views/seerAutomation/components/seerAutomationDefault';
 import {SeerAutomationProjectList} from 'getsentry/views/seerAutomation/components/seerAutomationProjectList';
@@ -17,12 +18,13 @@ import {SettingsPageTabs} from 'getsentry/views/seerAutomation/components/settin
 import {SeerAutomationSettings} from 'getsentry/views/seerAutomation/settings';
 
 export default function SeerAutomation() {
+  const subscription = useSubscription();
   const organization = useOrganization();
   const hasSeatBasedSeer = organization.features.includes('seat-based-seer-enabled');
   const hasLegacySeer = organization.features.includes('seer-added');
   const hasCodeReviewBeta = organization.features.includes('code-review-beta');
   const showNoActiveSeerSubscriptionBanner =
-    !hasSeatBasedSeer && (hasLegacySeer || hasCodeReviewBeta);
+    !hasSeatBasedSeer && (hasLegacySeer || hasCodeReviewBeta) && !subscription?.isManaged;
 
   if (showNewSeer(organization)) {
     return <SeerAutomationSettings />;

--- a/static/gsApp/views/seerAutomation/seerAutomation.tsx
+++ b/static/gsApp/views/seerAutomation/seerAutomation.tsx
@@ -24,7 +24,9 @@ export default function SeerAutomation() {
   const hasLegacySeer = organization.features.includes('seer-added');
   const hasCodeReviewBeta = organization.features.includes('code-review-beta');
   const showNoActiveSeerSubscriptionBanner =
-    !hasSeatBasedSeer && (hasLegacySeer || hasCodeReviewBeta) && !subscription?.isManaged;
+    !hasSeatBasedSeer &&
+    (hasLegacySeer || hasCodeReviewBeta) &&
+    !subscription?.canSelfServe;
 
   if (showNewSeer(organization)) {
     return <SeerAutomationSettings />;

--- a/static/gsApp/views/seerAutomation/seerAutomation.tsx
+++ b/static/gsApp/views/seerAutomation/seerAutomation.tsx
@@ -26,7 +26,7 @@ export default function SeerAutomation() {
   const showNoActiveSeerSubscriptionBanner =
     !hasSeatBasedSeer &&
     (hasLegacySeer || hasCodeReviewBeta) &&
-    !subscription?.canSelfServe;
+    subscription?.canSelfServe;
 
   if (showNewSeer(organization)) {
     return <SeerAutomationSettings />;


### PR DESCRIPTION
Orgs that are on our legacy seer pricing model see a banner to help them get ready to change over to the new pricing. But we shouldn't show this to orgs that have a managed plan, because they're not going to be able to change anything!

We might need to further dig in and do things differently for managed+sponsored vs. managed+salesled. That's TBD though.

For reference this is what the banner looks like:
<img width="1116" height="395" alt="SCR-20260413-jaty" src="https://github.com/user-attachments/assets/8f9495fb-efef-4b23-98a3-8a3819eed680" />
