### PR TITLE
feat(data-export): Add exponential back off in case of rate limit errors from snuba

### DIFF
--- a/src/sentry/data_export/base.py
+++ b/src/sentry/data_export/base.py
@@ -7,6 +7,10 @@ EXPORTED_ROWS_LIMIT = 10000000
 SNUBA_MAX_RESULTS = 10000
 DEFAULT_EXPIRATION = timedelta(weeks=4)
 
+DEFAULT_EXPORT_RETRIES = 3
+RECOVERABLE_RETRY_BASE_SECONDS = 30
+RECOVERABLE_RETRY_MAX_SECONDS = 300
+
 
 class ExportError(Exception):
     def __init__(self, message: str, recoverable: bool = False) -> None:

--- a/src/sentry/data_export/base.py
+++ b/src/sentry/data_export/base.py
@@ -13,9 +13,10 @@ RECOVERABLE_RETRY_MAX_SECONDS = 300
 
 
 class ExportError(Exception):
-    def __init__(self, message: str, recoverable: bool = False) -> None:
+    def __init__(self, message: str, recoverable: bool = False, delay_retry: bool = False) -> None:
         super().__init__(message)
         self.recoverable = recoverable
+        self.delay_retry = delay_retry
 
 
 class ExportStatus(str, Enum):

--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -11,6 +11,17 @@ from django.db import IntegrityError, router
 from django.utils import timezone
 from taskbroker_client.retry import NoRetriesRemainingError, Retry, retry_task
 
+from sentry.data_export.base import (
+    DEFAULT_EXPORT_RETRIES,
+    EXPORTED_ROWS_LIMIT,
+    MAX_BATCH_SIZE,
+    MAX_FRAGMENTS_PER_BATCH,
+    RECOVERABLE_RETRY_BASE_SECONDS,
+    RECOVERABLE_RETRY_MAX_SECONDS,
+    SNUBA_MAX_RESULTS,
+    ExportError,
+    ExportQueryType,
+)
 from sentry.data_export.models import ExportedData, ExportedDataBlob
 from sentry.data_export.processors.discover import DiscoverProcessor
 from sentry.data_export.processors.explore import ExploreProcessor, TraceItemFullExportProcessor
@@ -31,15 +42,6 @@ from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import export_tasks
 from sentry.utils import metrics
 from sentry.utils.db import atomic_transaction
-
-from .base import (
-    EXPORTED_ROWS_LIMIT,
-    MAX_BATCH_SIZE,
-    MAX_FRAGMENTS_PER_BATCH,
-    SNUBA_MAX_RESULTS,
-    ExportError,
-    ExportQueryType,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -200,6 +202,15 @@ def export_chunk_to_stored_blobs(
     )
 
 
+def recoverable_retry_countdown(remaining_export_retries: int) -> int:
+    """Delay before re-running assemble_download after a recoverable Snuba error."""
+    attempt_count = max(0, DEFAULT_EXPORT_RETRIES - remaining_export_retries)
+    return min(
+        RECOVERABLE_RETRY_MAX_SECONDS,
+        RECOVERABLE_RETRY_BASE_SECONDS * (2**attempt_count),
+    )
+
+
 def _schedule_retry(
     *,
     data_export_id: int,
@@ -224,6 +235,7 @@ def _schedule_retry(
             "page_token": page_token,
             "last_emitted_item_id_hex": last_emitted_item_id_hex,
         },
+        countdown=recoverable_retry_countdown(export_retries),
     )
 
 
@@ -298,7 +310,7 @@ def assemble_download(
     offset: int = 0,
     bytes_written: int = 0,
     environment_id: int | None = None,
-    export_retries: int = 3,
+    export_retries: int = DEFAULT_EXPORT_RETRIES,
     *,
     page_token: str | None = None,
     last_emitted_item_id_hex: str | None = None,

--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -222,6 +222,7 @@ def _schedule_retry(
     export_retries: int,
     page_token: str | None,
     last_emitted_item_id_hex: str | None,
+    delay_retry: bool = False,
 ) -> None:
     assemble_download.apply_async(
         args=[data_export_id],
@@ -235,7 +236,7 @@ def _schedule_retry(
             "page_token": page_token,
             "last_emitted_item_id_hex": last_emitted_item_id_hex,
         },
-        countdown=recoverable_retry_countdown(export_retries),
+        countdown=recoverable_retry_countdown(export_retries) if delay_retry else None,
     )
 
 
@@ -359,6 +360,7 @@ def assemble_download(
                     export_retries=export_retries,
                     page_token=page_token,
                     last_emitted_item_id_hex=last_emitted_item_id_hex,
+                    delay_retry=error.delay_retry,
                 )
             else:
                 metrics.incr(

--- a/src/sentry/data_export/utils.py
+++ b/src/sentry/data_export/utils.py
@@ -48,6 +48,7 @@ def handle_snuba_errors(
                 capture_exception(error)
                 message = "Internal error. Please try again."
                 recoverable = False
+                delay_retry = False
                 if isinstance(
                     error,
                     (
@@ -60,6 +61,16 @@ def handle_snuba_errors(
                 ):
                     message = TIMEOUT_ERROR_MESSAGE
                     recoverable = True
+
+                if isinstance(
+                    error,
+                    (
+                        snuba.RateLimitExceeded,
+                        snuba.QueryTooManySimultaneous,
+                        SnubaRPCRateLimitExceeded,
+                    ),
+                ):
+                    delay_retry = True
                 elif isinstance(
                     error,
                     (
@@ -72,7 +83,7 @@ def handle_snuba_errors(
                     ),
                 ):
                     message = "Internal error. Your query failed to run."
-                raise ExportError(message, recoverable=recoverable)
+                raise ExportError(message, recoverable=recoverable, delay_retry=delay_retry)
 
         return wrapped
 

--- a/src/sentry/data_export/utils.py
+++ b/src/sentry/data_export/utils.py
@@ -62,15 +62,15 @@ def handle_snuba_errors(
                     message = TIMEOUT_ERROR_MESSAGE
                     recoverable = True
 
-                if isinstance(
-                    error,
-                    (
-                        snuba.RateLimitExceeded,
-                        snuba.QueryTooManySimultaneous,
-                        SnubaRPCRateLimitExceeded,
-                    ),
-                ):
-                    delay_retry = True
+                    if isinstance(
+                        error,
+                        (
+                            snuba.RateLimitExceeded,
+                            snuba.QueryTooManySimultaneous,
+                            SnubaRPCRateLimitExceeded,
+                        ),
+                    ):
+                        delay_retry = True
                 elif isinstance(
                     error,
                     (

--- a/src/sentry/data_export/utils.py
+++ b/src/sentry/data_export/utils.py
@@ -10,12 +10,12 @@ from sentry_protos.snuba.v1.endpoint_trace_items_pb2 import ExportTraceItemsResp
 from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 from sentry_protos.snuba.v1.trace_item_pb2 import AnyValue, TraceItem
 
+from sentry.data_export.base import ExportError
 from sentry.search.events.constants import TIMEOUT_ERROR_MESSAGE
 from sentry.snuba import discover
 from sentry.utils import metrics, snuba
 from sentry.utils.sdk import capture_exception
-
-from .base import ExportError
+from sentry.utils.snuba_rpc import SnubaRPCRateLimitExceeded
 
 
 # Adapted into decorator from 'src/sentry/api/endpoints/organization_events.py'
@@ -55,6 +55,7 @@ def handle_snuba_errors(
                         snuba.QueryMemoryLimitExceeded,
                         snuba.QueryExecutionTimeMaximum,
                         snuba.QueryTooManySimultaneous,
+                        SnubaRPCRateLimitExceeded,
                     ),
                 ):
                     message = TIMEOUT_ERROR_MESSAGE

--- a/tests/sentry/data_export/test_tasks.py
+++ b/tests/sentry/data_export/test_tasks.py
@@ -1,6 +1,4 @@
-
 from typing import Any, Iterable, cast
-
 from unittest.mock import MagicMock, patch
 
 from django.db import IntegrityError
@@ -939,7 +937,6 @@ class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogT
         assert dl_response.status_code == 200
         stream = cast(StreamingHttpResponse, dl_response).streaming_content
         return b"".join(cast(Iterable[bytes], stream)).strip()
-
 
     @patch("sentry.data_export.models.ExportedData.email_success")
     def test_explore_spans_dataset_called_correctly(self, emailer: MagicMock) -> None:

--- a/tests/sentry/data_export/test_tasks.py
+++ b/tests/sentry/data_export/test_tasks.py
@@ -699,7 +699,6 @@ class AssembleDownloadLargeTest(TestCase, SnubaTestCase):
 
 
 class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogTestCase):
-    # Present on TraceItem / Snuba but not worth pinning (ids, times, nanosecond precision, sampling).
     def setUp(self) -> None:
         super().setUp()
         self.user = self.create_user()
@@ -809,6 +808,7 @@ class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogT
         start = before_now(minutes=15).isoformat()
         end = before_now(seconds=30).isoformat()
 
+        # Present on TraceItem / Snuba but not worth pinning (ids, times, nanosecond precision, sampling).
         variable_keys = frozenset(
             {
                 "timestamp_precise",

--- a/tests/sentry/data_export/test_tasks.py
+++ b/tests/sentry/data_export/test_tasks.py
@@ -9,7 +9,11 @@ from django.urls import reverse
 
 from sentry.data_export.base import ExportQueryType
 from sentry.data_export.models import ExportedData
-from sentry.data_export.tasks import assemble_download, merge_export_blobs
+from sentry.data_export.tasks import (
+    assemble_download,
+    merge_export_blobs,
+    recoverable_retry_countdown,
+)
 from sentry.data_export.writers import OutputMode
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models.files.file import File
@@ -71,6 +75,12 @@ class AssembleDownloadTest(TestCase, SnubaTestCase):
 
     def test_task_persistent_name(self) -> None:
         assert assemble_download.name == "sentry.data_export.tasks.assemble_download"
+
+    def test_recoverable_retry_countdown_exponential_backoff(self) -> None:
+        assert recoverable_retry_countdown(3) == 30
+        assert recoverable_retry_countdown(2) == 60
+        assert recoverable_retry_countdown(1) == 120
+        assert recoverable_retry_countdown(0) == 240
 
     @patch("sentry.data_export.models.ExportedData.email_success")
     def test_issue_by_tag_batched(self, emailer: MagicMock) -> None:

--- a/tests/sentry/data_export/test_tasks.py
+++ b/tests/sentry/data_export/test_tasks.py
@@ -1,4 +1,6 @@
+
 from typing import Any, Iterable, cast
+
 from unittest.mock import MagicMock, patch
 
 from django.db import IntegrityError
@@ -697,6 +699,7 @@ class AssembleDownloadLargeTest(TestCase, SnubaTestCase):
 
 
 class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogTestCase):
+    # Present on TraceItem / Snuba but not worth pinning (ids, times, nanosecond precision, sampling).
     def setUp(self) -> None:
         super().setUp()
         self.user = self.create_user()
@@ -806,7 +809,6 @@ class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogT
         start = before_now(minutes=15).isoformat()
         end = before_now(seconds=30).isoformat()
 
-        # Present on TraceItem / Snuba but not worth pinning (ids, times, nanosecond precision, sampling).
         variable_keys = frozenset(
             {
                 "timestamp_precise",
@@ -927,6 +929,7 @@ class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogT
         assert dl_response.status_code == 200
         stream = cast(StreamingHttpResponse, dl_response).streaming_content
         return b"".join(cast(Iterable[bytes], stream)).strip()
+
 
     @patch("sentry.data_export.models.ExportedData.email_success")
     def test_explore_spans_dataset_called_correctly(self, emailer: MagicMock) -> None:


### PR DESCRIPTION
Snuba requests in data export job can fail due to 429 (rate limits). Main reason for these 429 are exhausting concurrent request thresholds. 
We can mark  these RPC rate limit exceeded errors from snuba as recoverable and reschedule the export task/sub-task with appropriate delay. 