### PR TITLE
fix(seer): Set a min height for the virtual scrolling Code Review settings table

### DIFF
--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTable.tsx
@@ -41,7 +41,7 @@ import {SeerRepoTableRow} from 'getsentry/views/seerAutomation/components/repoTa
 const GRID_COLUMNS = '40px 1fr 118px 150px';
 const SELECTED_ROW_HEIGHT = 44;
 const BOTTOM_PADDING = 24; // px gap between table bottom and viewport edge
-const estimateSize = () => 60;
+const estimateSize = () => 68;
 
 export function SeerRepoTable() {
   const queryClient = useQueryClient();
@@ -280,7 +280,7 @@ function VirtualizedRepoTable({
     <ScrollableBody
       ref={setScrollBodyRef}
       style={{
-        minHeight: 0,
+        minHeight: Math.min(10, repositories.length) * estimateSize(),
         maxHeight: maxHeight ? `calc(100vh - ${Math.round(maxHeight)}px)` : undefined,
       }}
     >


### PR DESCRIPTION
Before the table had a min-height of 0, which means that the table could fully collapse and hide all the rows. This started happening because there are a bunch of banners on top, and when they're all visible, and the window is small, there's no room left for the table!

<img width="1178" height="527" alt="SCR-20260413-jeob" src="https://github.com/user-attachments/assets/da4d49fe-95b7-4a57-8f93-990c3dd35147" />

So I'm setting a new minimum: set the height to match the number of rows you have, up to 10. After 10 rows you'll either get scrolling (because the window is too short) or you could still see everything.

This introduces the problem that there could be 2x scrollbars on the page, which i don't love. But the data fetching story is such that we need the virtual table to prevent re-render issues and stuff. It's something that could/would be fixed with a new api iteration which is coming soon™
