### PR TITLE
fix(issues): Remove unsed group prop from ContextCard

### DIFF
--- a/static/app/components/events/contexts/contextCard.spec.tsx
+++ b/static/app/components/events/contexts/contextCard.spec.tsx
@@ -1,5 +1,4 @@
 import {EventFixture} from 'sentry-fixture/event';
-import {GroupFixture} from 'sentry-fixture/group';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -8,7 +7,6 @@ import {ContextCard} from 'sentry/components/events/contexts/contextCard';
 import * as iconTools from 'sentry/components/events/contexts/contextIcon';
 
 describe('ContextCard', () => {
-  const group = GroupFixture();
   const project = ProjectFixture();
   it('renders the card with formatted context data', () => {
     const event = EventFixture();
@@ -37,7 +35,6 @@ describe('ContextCard', () => {
         alias={alias}
         value={customContext}
         event={event}
-        group={group}
         project={project}
       />
     );
@@ -72,7 +69,6 @@ describe('ContextCard', () => {
         alias="browser"
         value={browserContext}
         event={event}
-        group={group}
         project={project}
       />
     );
@@ -93,7 +89,6 @@ describe('ContextCard', () => {
         alias="organization"
         value={unknownContext}
         event={event}
-        group={group}
         project={project}
       />
     );
@@ -150,7 +145,6 @@ describe('ContextCard', () => {
         alias={alias}
         value={errorContext}
         event={event}
-        group={group}
         project={project}
       />
     );

--- a/static/app/components/events/contexts/contextCard.tsx
+++ b/static/app/components/events/contexts/contextCard.tsx
@@ -17,7 +17,7 @@ import {
   type KeyValueDataContentProps,
 } from 'sentry/components/keyValueData';
 import type {Event} from 'sentry/types/event';
-import type {Group, KeyValueListDataItem} from 'sentry/types/group';
+import type {KeyValueListDataItem} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {isEmptyObject} from 'sentry/utils/object/isEmptyObject';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -27,7 +27,6 @@ interface ContextCardProps {
   alias: string;
   event: Event;
   type: string;
-  group?: Group;
   project?: Project;
   value?: ContextValue;
 }

--- a/static/app/components/events/contexts/contextDataSection.tsx
+++ b/static/app/components/events/contexts/contextDataSection.tsx
@@ -7,7 +7,6 @@ import {CONTEXT_DOCS_LINK} from 'sentry/components/events/contexts/utils';
 import {KeyValueData} from 'sentry/components/keyValueData';
 import {t, tct} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
-import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
@@ -15,13 +14,11 @@ import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSectio
 interface ContextDataSectionProps {
   event: Event;
   disableCollapsePersistence?: boolean;
-  group?: Group;
   project?: Project;
 }
 
 export function ContextDataSection({
   event,
-  group,
   project,
   disableCollapsePersistence,
 }: ContextDataSectionProps) {
@@ -33,7 +30,6 @@ export function ContextDataSection({
         alias={alias}
         value={contextValue}
         event={event}
-        group={group}
         project={project}
       />
     )

--- a/static/app/components/events/contexts/index.tsx
+++ b/static/app/components/events/contexts/index.tsx
@@ -3,13 +3,11 @@ import * as Sentry from '@sentry/react';
 
 import {ContextDataSection} from 'sentry/components/events/contexts/contextDataSection';
 import type {Event, EventContexts as EventContextValues} from 'sentry/types/event';
-import type {Group} from 'sentry/types/group';
 import {useProjects} from 'sentry/utils/useProjects';
 
 type Props = {
   event: Event;
   disableCollapsePersistence?: boolean;
-  group?: Group;
 };
 
 interface UnknownContextValue {
@@ -82,7 +80,7 @@ export function getOrderedContextItems(event: Event): ContextItem[] {
   return items;
 }
 
-export function EventContexts({event, group, disableCollapsePersistence}: Props) {
+export function EventContexts({event, disableCollapsePersistence}: Props) {
   const {projects} = useProjects();
   const project = projects.find(p => p.id === event.projectID);
   const {contexts, sdk} = event;
@@ -102,7 +100,6 @@ export function EventContexts({event, group, disableCollapsePersistence}: Props)
   return (
     <ContextDataSection
       event={event}
-      group={group}
       project={project}
       disableCollapsePersistence={disableCollapsePersistence}
     />

--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -119,7 +119,6 @@ export function FeedbackItem({feedbackItem, eventData, onBackToList}: Props) {
               title={t('Context')}
             >
               <FeedbackItemContexts
-                feedbackItem={feedbackItem}
                 eventData={eventData}
                 project={feedbackItem.project}
               />
@@ -154,11 +153,9 @@ export function FeedbackItem({feedbackItem, eventData, onBackToList}: Props) {
 
 function FeedbackItemContexts({
   eventData,
-  feedbackItem,
   project,
 }: {
   eventData: Event;
-  feedbackItem: FeedbackIssue;
   project: undefined | Project;
 }) {
   const evidenceObject = Object.fromEntries(
@@ -182,7 +179,6 @@ function FeedbackItemContexts({
         alias={alias}
         value={contextValue}
         event={eventData}
-        group={feedbackItem as unknown as Group}
         project={project}
       />
     )

--- a/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
+++ b/static/app/views/issueDetails/groupEventDetails/groupEventDetailsContent.tsx
@@ -362,7 +362,7 @@ export function EventDetailsContent({
           <EventTagsDataSection event={event} projectSlug={project.slug} ref={tagsRef} />
         </Fragment>
       ) : null}
-      <EventContexts group={group} event={event} />
+      <EventContexts event={event} />
       <ErrorBoundary mini message={t('There was a problem loading feature flags.')}>
         <EventFeatureFlagSection group={group} project={project} event={event} />
       </ErrorBoundary>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/contexts.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/contexts.tsx
@@ -62,7 +62,6 @@ export function Contexts({
       alias={alias}
       value={value}
       event={event}
-      group={undefined}
       project={project}
     />
   ));


### PR DESCRIPTION
was not being used in `ContextCard`, was passed down in a number of ways
