### PR TITLE
feat(snapshots): Add snapshots list table to Releases page

### DIFF
--- a/src/sentry/preprod/api/endpoints/builds.py
+++ b/src/sentry/preprod/api/endpoints/builds.py
@@ -77,8 +77,16 @@ class BuildsEndpoint(OrganizationEndpoint):
         try:
             queryset = queryset_for_query(query, organization)
             queryset = queryset.select_related(
-                "project", "build_configuration", "commit_comparison", "mobile_app_info"
-            ).prefetch_related("preprodartifactsizemetrics_set")
+                "project",
+                "build_configuration",
+                "commit_comparison",
+                "mobile_app_info",
+                "preprodsnapshotmetrics",
+            ).prefetch_related(
+                "preprodartifactsizemetrics_set",
+                "preprodsnapshotmetrics__snapshot_comparisons_head_metrics",
+                "preprodcomparisonapproval_set",
+            )
             queryset = queryset.filter(date_added__gte=cutoff)
             if start:
                 queryset = queryset.filter(date_added__gte=start)

--- a/src/sentry/preprod/api/models/project_preprod_build_details_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_build_details_models.py
@@ -9,7 +9,13 @@ from sentry.preprod.build_distribution_utils import (
     get_download_count_for_artifact,
     is_installable_artifact,
 )
-from sentry.preprod.models import Platform, PreprodArtifact, PreprodArtifactSizeMetrics
+from sentry.preprod.models import (
+    Platform,
+    PreprodArtifact,
+    PreprodArtifactSizeMetrics,
+    PreprodComparisonApproval,
+)
+from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
 from sentry.preprod.vcs.status_checks.size.tasks import StatusCheckErrorType
 
 logger = logging.getLogger(__name__)
@@ -83,6 +89,17 @@ class PostedStatusChecks(BaseModel):
     size: StatusCheckResult | None = None
 
 
+class SnapshotInfo(BaseModel):
+    image_count: int
+    comparison_state: Literal["pending", "processing", "success", "failed"] | None = None
+    comparison_error_message: str | None = None
+    images_added: int = 0
+    images_removed: int = 0
+    images_changed: int = 0
+    images_unchanged: int = 0
+    approval_status: Literal["approved", "requires_approval"] | None = None
+
+
 class SizeInfoSizeMetric(BaseModel):
     metrics_artifact_type: PreprodArtifactSizeMetrics.MetricsArtifactType
     install_size_bytes: int
@@ -147,6 +164,7 @@ class BuildDetailsApiResponse(BaseModel):
     posted_status_checks: PostedStatusChecks | None = None
     base_artifact_id: str | None = None
     base_build_info: BuildDetailsAppInfo | None = None
+    snapshot_info: SnapshotInfo | None = None
 
 
 def create_build_details_app_info(artifact: PreprodArtifact) -> BuildDetailsAppInfo:
@@ -262,6 +280,61 @@ def to_size_info(
             raise ValueError(f"Unknown SizeAnalysisState {main_metric.state}")
 
 
+def to_snapshot_info(artifact: PreprodArtifact) -> SnapshotInfo | None:
+    try:
+        snapshot_metrics = artifact.preprodsnapshotmetrics
+    except PreprodSnapshotMetrics.DoesNotExist:
+        return None
+
+    comparison_state = None
+    comparison_error_message = None
+    images_added = 0
+    images_removed = 0
+    images_changed = 0
+    images_unchanged = 0
+
+    comparisons = sorted(
+        snapshot_metrics.snapshot_comparisons_head_metrics.all(),
+        key=lambda c: c.id,
+        reverse=True,
+    )
+    comparison = comparisons[0] if comparisons else None
+    if comparison:
+        comparison_state = PreprodSnapshotComparison.State(comparison.state).name.lower()
+        if comparison.state == PreprodSnapshotComparison.State.SUCCESS:
+            images_added = comparison.images_added
+            images_removed = comparison.images_removed
+            images_changed = comparison.images_changed
+            images_unchanged = comparison.images_unchanged
+        elif comparison.state == PreprodSnapshotComparison.State.FAILED:
+            comparison_error_message = comparison.error_message
+
+    approval_status = None
+    # REJECTED is no longer used; all non-APPROVED statuses are treated as requires_approval
+    approvals = [
+        a
+        for a in artifact.preprodcomparisonapproval_set.all()
+        if a.preprod_feature_type == PreprodComparisonApproval.FeatureType.SNAPSHOTS
+    ]
+    approvals.sort(key=lambda a: a.id, reverse=True)
+    if approvals:
+        if approvals[0].approval_status == PreprodComparisonApproval.ApprovalStatus.APPROVED:
+            approval_status = "approved"
+        else:
+            approval_status = "requires_approval"
+
+    return SnapshotInfo(
+        image_count=snapshot_metrics.image_count,
+        comparison_state=comparison_state,
+        comparison_error_message=comparison_error_message,
+        images_added=images_added,
+        images_removed=images_removed,
+        images_changed=images_changed,
+        images_unchanged=images_unchanged,
+        approval_status=approval_status,
+    )
+
+
 def transform_preprod_artifact_to_build_details(
     artifact: PreprodArtifact,
 ) -> BuildDetailsApiResponse:
@@ -315,6 +388,8 @@ def transform_preprod_artifact_to_build_details(
 
     posted_status_checks = _parse_posted_status_checks(artifact)
 
+    snapshot_info = to_snapshot_info(artifact)
+
     return BuildDetailsApiResponse(
         id=artifact.id,
         state=artifact.state,
@@ -327,6 +402,7 @@ def transform_preprod_artifact_to_build_details(
         posted_status_checks=posted_status_checks,
         base_artifact_id=base_artifact.id if base_artifact else None,
         base_build_info=base_build_info,
+        snapshot_info=snapshot_info,
     )
 
 

--- a/src/sentry/preprod/api/models/project_preprod_build_details_models.py
+++ b/src/sentry/preprod/api/models/project_preprod_build_details_models.py
@@ -89,7 +89,7 @@ class PostedStatusChecks(BaseModel):
     size: StatusCheckResult | None = None
 
 
-class SnapshotInfo(BaseModel):
+class SnapshotComparisonInfo(BaseModel):
     image_count: int
     comparison_state: Literal["pending", "processing", "success", "failed"] | None = None
     comparison_error_message: str | None = None
@@ -164,7 +164,7 @@ class BuildDetailsApiResponse(BaseModel):
     posted_status_checks: PostedStatusChecks | None = None
     base_artifact_id: str | None = None
     base_build_info: BuildDetailsAppInfo | None = None
-    snapshot_info: SnapshotInfo | None = None
+    snapshot_comparison_info: SnapshotComparisonInfo | None = None
 
 
 def create_build_details_app_info(artifact: PreprodArtifact) -> BuildDetailsAppInfo:
@@ -280,9 +280,9 @@ def to_size_info(
             raise ValueError(f"Unknown SizeAnalysisState {main_metric.state}")
 
 
-def to_snapshot_info(artifact: PreprodArtifact) -> SnapshotInfo | None:
+def to_snapshot_comparison_info(head_artifact: PreprodArtifact) -> SnapshotComparisonInfo | None:
     try:
-        snapshot_metrics = artifact.preprodsnapshotmetrics
+        snapshot_metrics = head_artifact.preprodsnapshotmetrics
     except PreprodSnapshotMetrics.DoesNotExist:
         return None
 
@@ -313,7 +313,7 @@ def to_snapshot_info(artifact: PreprodArtifact) -> SnapshotInfo | None:
     # REJECTED is no longer used; all non-APPROVED statuses are treated as requires_approval
     approvals = [
         a
-        for a in artifact.preprodcomparisonapproval_set.all()
+        for a in head_artifact.preprodcomparisonapproval_set.all()
         if a.preprod_feature_type == PreprodComparisonApproval.FeatureType.SNAPSHOTS
     ]
     approvals.sort(key=lambda a: a.id, reverse=True)
@@ -323,7 +323,7 @@ def to_snapshot_info(artifact: PreprodArtifact) -> SnapshotInfo | None:
         else:
             approval_status = "requires_approval"
 
-    return SnapshotInfo(
+    return SnapshotComparisonInfo(
         image_count=snapshot_metrics.image_count,
         comparison_state=comparison_state,
         comparison_error_message=comparison_error_message,
@@ -388,7 +388,7 @@ def transform_preprod_artifact_to_build_details(
 
     posted_status_checks = _parse_posted_status_checks(artifact)
 
-    snapshot_info = to_snapshot_info(artifact)
+    snapshot_comparison_info = to_snapshot_comparison_info(artifact)
 
     return BuildDetailsApiResponse(
         id=artifact.id,
@@ -402,7 +402,7 @@ def transform_preprod_artifact_to_build_details(
         posted_status_checks=posted_status_checks,
         base_artifact_id=base_artifact.id if base_artifact else None,
         base_build_info=base_build_info,
-        snapshot_info=snapshot_info,
+        snapshot_comparison_info=snapshot_comparison_info,
     )
 
 

--- a/static/app/components/preprod/preprodBuildsDisplay.ts
+++ b/static/app/components/preprod/preprodBuildsDisplay.ts
@@ -1,6 +1,7 @@
 export enum PreprodBuildsDisplay {
   SIZE = 'size',
   DISTRIBUTION = 'distribution',
+  SNAPSHOT = 'snapshot',
 }
 
 export function getPreprodBuildsDisplay(
@@ -13,6 +14,8 @@ export function getPreprodBuildsDisplay(
   switch (display) {
     case PreprodBuildsDisplay.DISTRIBUTION:
       return PreprodBuildsDisplay.DISTRIBUTION;
+    case PreprodBuildsDisplay.SNAPSHOT:
+      return PreprodBuildsDisplay.SNAPSHOT;
     case PreprodBuildsDisplay.SIZE:
     default:
       return PreprodBuildsDisplay.SIZE;

--- a/static/app/components/preprod/preprodBuildsSearchControls.tsx
+++ b/static/app/components/preprod/preprodBuildsSearchControls.tsx
@@ -36,6 +36,10 @@ interface PreprodBuildsSearchControlsProps {
    */
   allowedKeys?: string[];
   /**
+   * Hide the display mode toggle
+   */
+  hideDisplayToggle?: boolean;
+  /**
    * Called on every keystroke (for controlled input with debounce)
    */
   onChange?: (query: string, state: {queryIsValid: boolean}) => void;
@@ -54,6 +58,7 @@ export function PreprodBuildsSearchControls({
   display,
   projects,
   allowedKeys = MOBILE_BUILDS_ALLOWED_KEYS,
+  hideDisplayToggle,
   onChange,
   onSearch,
   onDisplayChange,
@@ -74,20 +79,22 @@ export function PreprodBuildsSearchControls({
           projects={projects}
         />
       </Container>
-      <Container maxWidth="200px">
-        <CompactSelect
-          options={displaySelectOptions}
-          value={display}
-          onChange={option => onDisplayChange(option.value)}
-          trigger={triggerProps => (
-            <OverlayTrigger.Button
-              {...triggerProps}
-              prefix={t('Display')}
-              style={{width: '100%', zIndex: 1}}
-            />
-          )}
-        />
-      </Container>
+      {!hideDisplayToggle && (
+        <Container maxWidth="200px">
+          <CompactSelect
+            options={displaySelectOptions}
+            value={display}
+            onChange={option => onDisplayChange(option.value)}
+            trigger={triggerProps => (
+              <OverlayTrigger.Button
+                {...triggerProps}
+                prefix={t('Display')}
+                style={{width: '100%', zIndex: 1}}
+              />
+            )}
+          />
+        </Container>
+      )}
     </Flex>
   );
 }

--- a/static/app/components/preprod/preprodBuildsSnapshotTable.tsx
+++ b/static/app/components/preprod/preprodBuildsSnapshotTable.tsx
@@ -126,7 +126,7 @@ export function PreprodBuildsSnapshotTable({
       organizationSlug,
       snapshotId: build.id,
     });
-    const info = build.snapshot_info;
+    const info = build.snapshot_comparison_info;
     const appId = build.app_info?.app_id;
     return (
       <SimpleTable.Row key={build.id}>
@@ -173,7 +173,7 @@ export function PreprodBuildsSnapshotTable({
                 <Flex align="center" gap="xs">
                   <IconCommit size="xs" />
                   <Text size="sm" variant="muted" monospace>
-                    {(build.vcs_info?.head_sha?.slice(0, 7) || '--').toUpperCase()}
+                    {(build.vcs_info?.head_sha?.slice(0, 7) || '–').toUpperCase()}
                   </Text>
                 </Flex>
               </Flex>

--- a/static/app/components/preprod/preprodBuildsSnapshotTable.tsx
+++ b/static/app/components/preprod/preprodBuildsSnapshotTable.tsx
@@ -64,26 +64,26 @@ function ChangeCounts({
   unchanged: number;
 }) {
   if (!comparisonState) {
-    return <Tag>{t('Base')}</Tag>;
+    return <Tag variant="info">{t('Base')}</Tag>;
   }
   if (comparisonState === 'pending') {
     return (
       <Tooltip title={t('Waiting to start comparison')}>
-        <Tag>{t('Pending')}</Tag>
+        <Tag variant="muted">{t('Pending')}</Tag>
       </Tooltip>
     );
   }
   if (comparisonState === 'processing') {
     return (
       <Tooltip title={t('Comparing against base snapshot')}>
-        <Tag>{t('Processing')}</Tag>
+        <Tag variant="muted">{t('Processing')}</Tag>
       </Tooltip>
     );
   }
   if (comparisonState === 'failed') {
     return (
       <Tooltip title={errorMessage || t('Comparison failed')}>
-        <Tag variant="error">{t('Failed')}</Tag>
+        <Tag variant="danger">{t('Failed')}</Tag>
       </Tooltip>
     );
   }

--- a/static/app/components/preprod/preprodBuildsSnapshotTable.tsx
+++ b/static/app/components/preprod/preprodBuildsSnapshotTable.tsx
@@ -1,0 +1,224 @@
+import type {ReactNode} from 'react';
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import {Tag} from '@sentry/scraps/badge';
+import InteractionStateLayer from '@sentry/scraps/interactionStateLayer';
+import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {SimpleTable} from 'sentry/components/tables/simpleTable';
+import {TimeSince} from 'sentry/components/timeSince';
+import {IconCommit} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import type {
+  BuildDetailsApiResponse,
+  SnapshotApprovalStatus,
+  SnapshotComparisonState,
+} from 'sentry/views/preprod/types/buildDetailsTypes';
+import {getSnapshotPath} from 'sentry/views/preprod/utils/buildLinkUtils';
+
+import {FullRowLink} from './preprodBuildsTableCommon';
+
+interface PreprodBuildsSnapshotTableProps {
+  builds: BuildDetailsApiResponse[];
+  organizationSlug: string;
+  showProjectColumn: boolean;
+  content?: ReactNode;
+  onRowClick?: (build: BuildDetailsApiResponse) => void;
+}
+
+function ApprovalBadge({
+  comparisonState,
+  approvalStatus,
+}: {
+  approvalStatus: SnapshotApprovalStatus | null | undefined;
+  comparisonState: SnapshotComparisonState | null | undefined;
+}) {
+  if (!comparisonState || comparisonState !== 'success') {
+    return <Text variant="muted">{'–'}</Text>;
+  }
+  if (approvalStatus === 'approved') {
+    return <Tag variant="success">{t('Approved')}</Tag>;
+  }
+  if (approvalStatus === 'requires_approval') {
+    return <Tag variant="warning">{t('Needs Approval')}</Tag>;
+  }
+  return <Text variant="muted">{'–'}</Text>;
+}
+
+function ChangeCounts({
+  added,
+  removed,
+  changed,
+  unchanged,
+  comparisonState,
+  errorMessage,
+}: {
+  added: number;
+  changed: number;
+  comparisonState: SnapshotComparisonState | null | undefined;
+  errorMessage: string | null | undefined;
+  removed: number;
+  unchanged: number;
+}) {
+  if (!comparisonState) {
+    return <Tag>{t('Base')}</Tag>;
+  }
+  if (comparisonState === 'pending') {
+    return (
+      <Tooltip title={t('Waiting to start comparison')}>
+        <Tag>{t('Pending')}</Tag>
+      </Tooltip>
+    );
+  }
+  if (comparisonState === 'processing') {
+    return (
+      <Tooltip title={t('Comparing against base snapshot')}>
+        <Tag>{t('Processing')}</Tag>
+      </Tooltip>
+    );
+  }
+  if (comparisonState === 'failed') {
+    return (
+      <Tooltip title={errorMessage || t('Comparison failed')}>
+        <Tag variant="error">{t('Failed')}</Tag>
+      </Tooltip>
+    );
+  }
+  const parts: string[] = [];
+  if (added > 0) {
+    parts.push(t('%s added', added));
+  }
+  if (removed > 0) {
+    parts.push(t('%s removed', removed));
+  }
+  if (changed > 0) {
+    parts.push(t('%s modified', changed));
+  }
+  if (unchanged > 0) {
+    parts.push(t('%s unchanged', unchanged));
+  }
+  return (
+    <Text size="sm" variant="muted">
+      {parts.join(', ')}
+    </Text>
+  );
+}
+
+export function PreprodBuildsSnapshotTable({
+  builds,
+  content,
+  onRowClick,
+  organizationSlug,
+  showProjectColumn,
+}: PreprodBuildsSnapshotTableProps) {
+  const rows = builds.map(build => {
+    const linkUrl = getSnapshotPath({
+      organizationSlug,
+      snapshotId: build.id,
+    });
+    const info = build.snapshot_info;
+    const appId = build.app_info?.app_id;
+    return (
+      <SimpleTable.Row key={build.id}>
+        <FullRowLink to={linkUrl} onClick={() => onRowClick?.(build)}>
+          <Fragment>
+            <InteractionStateLayer />
+            <SimpleTable.RowCell justify="start">
+              <Flex direction="column" gap="2xs">
+                <Text bold>{appId || t('Snapshot')}</Text>
+                <Text size="sm" variant="muted">
+                  {t('%s images', info?.image_count ?? 0)}
+                </Text>
+              </Flex>
+            </SimpleTable.RowCell>
+            {showProjectColumn && (
+              <SimpleTable.RowCell justify="start">
+                <Text>{build.project_slug}</Text>
+              </SimpleTable.RowCell>
+            )}
+            <SimpleTable.RowCell>
+              <ChangeCounts
+                added={info?.images_added ?? 0}
+                removed={info?.images_removed ?? 0}
+                changed={info?.images_changed ?? 0}
+                unchanged={info?.images_unchanged ?? 0}
+                comparisonState={info?.comparison_state}
+                errorMessage={info?.comparison_error_message}
+              />
+            </SimpleTable.RowCell>
+            <SimpleTable.RowCell justify="start">
+              <Flex direction="column" gap="2xs">
+                {build.vcs_info?.head_ref && (
+                  <Flex align="center" gap="xs">
+                    <Text size="sm" bold>
+                      {build.vcs_info.head_ref}
+                    </Text>
+                    {build.vcs_info?.pr_number && (
+                      <Text size="sm" variant="muted">
+                        #{build.vcs_info.pr_number}
+                      </Text>
+                    )}
+                  </Flex>
+                )}
+                <Flex align="center" gap="xs">
+                  <IconCommit size="xs" />
+                  <Text size="sm" variant="muted" monospace>
+                    {(build.vcs_info?.head_sha?.slice(0, 7) || '--').toUpperCase()}
+                  </Text>
+                </Flex>
+              </Flex>
+            </SimpleTable.RowCell>
+            <SimpleTable.RowCell>
+              <ApprovalBadge
+                comparisonState={info?.comparison_state}
+                approvalStatus={info?.approval_status}
+              />
+            </SimpleTable.RowCell>
+            <SimpleTable.RowCell>
+              {build.app_info?.date_added ? (
+                <TimeSince date={build.app_info.date_added} unitStyle="short" />
+              ) : (
+                '–'
+              )}
+            </SimpleTable.RowCell>
+          </Fragment>
+        </FullRowLink>
+      </SimpleTable.Row>
+    );
+  });
+
+  return (
+    <BuildsSnapshotTable showProjectColumn={showProjectColumn}>
+      <SimpleTable.Header>
+        <SimpleTable.HeaderCell>{t('Snapshot')}</SimpleTable.HeaderCell>
+        {showProjectColumn && (
+          <SimpleTable.HeaderCell>{t('Project')}</SimpleTable.HeaderCell>
+        )}
+        <SimpleTable.HeaderCell>{t('Changes')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell>{t('Branch')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell>{t('Approval')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell>{t('Created')}</SimpleTable.HeaderCell>
+      </SimpleTable.Header>
+      {content ?? rows}
+    </BuildsSnapshotTable>
+  );
+}
+
+const snapshotTableColumns = {
+  withProject: `minmax(200px, 2fr) minmax(100px, 1fr) minmax(100px, 140px)
+    minmax(180px, 2fr) minmax(100px, 1fr) minmax(80px, 120px)`,
+  withoutProject: `minmax(200px, 2fr) minmax(100px, 140px)
+    minmax(180px, 2fr) minmax(100px, 1fr) minmax(80px, 120px)`,
+};
+
+const BuildsSnapshotTable = styled(SimpleTable)<{showProjectColumn?: boolean}>`
+  overflow-x: auto;
+  overflow-y: auto;
+  grid-template-columns: ${p =>
+    p.showProjectColumn
+      ? snapshotTableColumns.withProject
+      : snapshotTableColumns.withoutProject};
+`;

--- a/static/app/components/preprod/preprodBuildsSnapshotTable.tsx
+++ b/static/app/components/preprod/preprodBuildsSnapshotTable.tsx
@@ -87,6 +87,13 @@ function ChangeCounts({
       </Tooltip>
     );
   }
+  if (added === 0 && removed === 0 && changed === 0) {
+    return (
+      <Text size="sm" variant="muted">
+        {t('No changes')}
+      </Text>
+    );
+  }
   const parts: string[] = [];
   if (added > 0) {
     parts.push(t('%s added', added));

--- a/static/app/components/preprod/preprodBuildsTable.tsx
+++ b/static/app/components/preprod/preprodBuildsTable.tsx
@@ -56,7 +56,7 @@ export function PreprodBuildsTable({
     display === PreprodBuildsDisplay.DISTRIBUTION
       ? 'https://docs.sentry.io/product/build-distribution/'
       : display === PreprodBuildsDisplay.SNAPSHOT
-        ? 'https://docs.sentry.io/product/visual-snapshots/'
+        ? 'https://docs.sentry.io/product/snapshot-testing/'
         : 'https://docs.sentry.io/product/size-analysis/';
 
   const hasMultiplePlatforms = useMemo(() => {

--- a/static/app/components/preprod/preprodBuildsTable.tsx
+++ b/static/app/components/preprod/preprodBuildsTable.tsx
@@ -55,7 +55,9 @@ export function PreprodBuildsTable({
   const emptyStateDocUrl =
     display === PreprodBuildsDisplay.DISTRIBUTION
       ? 'https://docs.sentry.io/product/build-distribution/'
-      : 'https://docs.sentry.io/product/size-analysis/';
+      : display === PreprodBuildsDisplay.SNAPSHOT
+        ? 'https://docs.sentry.io/product/visual-snapshots/'
+        : 'https://docs.sentry.io/product/size-analysis/';
 
   const hasMultiplePlatforms = useMemo(() => {
     const platforms = new Set(builds.map(b => b.app_info?.platform).filter(Boolean));
@@ -80,12 +82,25 @@ export function PreprodBuildsTable({
       <SimpleTable.Empty>
         <Text as="p">
           {hasSearchQuery
-            ? t('No mobile builds found for your search')
-            : tct('No mobile builds found, see our [link:documentation] for more info.', {
-                link: (
-                  <ExternalLink href={emptyStateDocUrl}>{t('Learn more')}</ExternalLink>
-                ),
-              })}
+            ? display === PreprodBuildsDisplay.SNAPSHOT
+              ? t('No snapshots found for your search')
+              : t('No mobile builds found for your search')
+            : display === PreprodBuildsDisplay.SNAPSHOT
+              ? tct('No snapshots found, see our [link:documentation] for more info.', {
+                  link: (
+                    <ExternalLink href={emptyStateDocUrl}>{t('Learn more')}</ExternalLink>
+                  ),
+                })
+              : tct(
+                  'No mobile builds found, see our [link:documentation] for more info.',
+                  {
+                    link: (
+                      <ExternalLink href={emptyStateDocUrl}>
+                        {t('Learn more')}
+                      </ExternalLink>
+                    ),
+                  }
+                )}
         </Text>
       </SimpleTable.Empty>
     );

--- a/static/app/components/preprod/preprodBuildsTable.tsx
+++ b/static/app/components/preprod/preprodBuildsTable.tsx
@@ -14,6 +14,7 @@ import {getLabels} from 'sentry/views/preprod/utils/labelUtils';
 import {PreprodBuildsDisplay} from './preprodBuildsDisplay';
 import {PreprodBuildsDistributionTable} from './preprodBuildsDistributionTable';
 import {PreprodBuildsSizeTable} from './preprodBuildsSizeTable';
+import {PreprodBuildsSnapshotTable} from './preprodBuildsSnapshotTable';
 
 interface PreprodBuildsTableProps {
   builds: BuildDetailsApiResponse[];
@@ -51,10 +52,10 @@ export function PreprodBuildsTable({
   hasSearchQuery,
   showProjectColumn = false,
 }: PreprodBuildsTableProps) {
-  const isDistributionDisplay = display === PreprodBuildsDisplay.DISTRIBUTION;
-  const emptyStateDocUrl = isDistributionDisplay
-    ? 'https://docs.sentry.io/product/build-distribution/'
-    : 'https://docs.sentry.io/product/size-analysis/';
+  const emptyStateDocUrl =
+    display === PreprodBuildsDisplay.DISTRIBUTION
+      ? 'https://docs.sentry.io/product/build-distribution/'
+      : 'https://docs.sentry.io/product/size-analysis/';
 
   const hasMultiplePlatforms = useMemo(() => {
     const platforms = new Set(builds.map(b => b.app_info?.platform).filter(Boolean));
@@ -92,7 +93,15 @@ export function PreprodBuildsTable({
 
   return (
     <Fragment>
-      {isDistributionDisplay ? (
+      {display === PreprodBuildsDisplay.SNAPSHOT ? (
+        <PreprodBuildsSnapshotTable
+          builds={builds}
+          content={tableContent}
+          onRowClick={onRowClick}
+          organizationSlug={organizationSlug}
+          showProjectColumn={showProjectColumn}
+        />
+      ) : display === PreprodBuildsDisplay.DISTRIBUTION ? (
         <PreprodBuildsDistributionTable
           builds={builds}
           content={tableContent}

--- a/static/app/utils/analytics/preprodBuildAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/preprodBuildAnalyticsEvents.tsx
@@ -18,6 +18,7 @@ type PreprodSettingsEvent = {
 export type BuildListPageSource =
   | 'preprod_builds_list'
   | 'releases_mobile_builds_tab'
+  | 'releases_snapshots_tab'
   | 'releases_details_preprod_builds';
 
 export type PreprodBuildEventParameters = {

--- a/static/app/views/preprod/types/buildDetailsTypes.ts
+++ b/static/app/views/preprod/types/buildDetailsTypes.ts
@@ -15,6 +15,7 @@ export interface BuildDetailsApiResponse {
   posted_status_checks?: PostedStatusChecks | null;
   base_artifact_id?: string | null;
   base_build_info?: BuildDetailsAppInfo | null;
+  snapshot_info?: SnapshotInfo | null;
 }
 
 interface BuildDetailsDistributionInfo {
@@ -191,4 +192,18 @@ export function isStatusCheckFailure(
   result: StatusCheckResult | undefined | null
 ): result is StatusCheckResultFailure {
   return result?.success === false;
+}
+
+export type SnapshotComparisonState = 'pending' | 'processing' | 'success' | 'failed';
+export type SnapshotApprovalStatus = 'approved' | 'requires_approval';
+
+export interface SnapshotInfo {
+  image_count: number;
+  approval_status: SnapshotApprovalStatus | null;
+  comparison_error_message: string | null;
+  comparison_state: SnapshotComparisonState | null;
+  images_added: number;
+  images_changed: number;
+  images_removed: number;
+  images_unchanged: number;
 }

--- a/static/app/views/preprod/types/buildDetailsTypes.ts
+++ b/static/app/views/preprod/types/buildDetailsTypes.ts
@@ -15,7 +15,7 @@ export interface BuildDetailsApiResponse {
   posted_status_checks?: PostedStatusChecks | null;
   base_artifact_id?: string | null;
   base_build_info?: BuildDetailsAppInfo | null;
-  snapshot_info?: SnapshotInfo | null;
+  snapshot_comparison_info?: SnapshotComparisonInfo | null;
 }
 
 interface BuildDetailsDistributionInfo {
@@ -197,7 +197,7 @@ export function isStatusCheckFailure(
 export type SnapshotComparisonState = 'pending' | 'processing' | 'success' | 'failed';
 export type SnapshotApprovalStatus = 'approved' | 'requires_approval';
 
-export interface SnapshotInfo {
+export interface SnapshotComparisonInfo {
   image_count: number;
   approval_status: SnapshotApprovalStatus | null;
   comparison_error_message: string | null;

--- a/static/app/views/preprod/utils/buildLinkUtils.ts
+++ b/static/app/views/preprod/utils/buildLinkUtils.ts
@@ -73,3 +73,11 @@ export function formatBuildName(
 
   return `v${version} (${buildNumber})`;
 }
+
+export function getSnapshotPath(params: {
+  organizationSlug: string;
+  snapshotId: string;
+}): string {
+  const {organizationSlug, snapshotId} = params;
+  return `/organizations/${organizationSlug}/preprod/snapshots/${snapshotId}/`;
+}

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -21,6 +21,7 @@ import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {ProjectPageFilter} from 'sentry/components/pageFilters/project/projectPageFilter';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
+import {PreprodBuildsDisplay} from 'sentry/components/preprod/preprodBuildsDisplay';
 import {SearchQueryBuilder} from 'sentry/components/searchQueryBuilder';
 import type {GetTagValues} from 'sentry/components/searchQueryBuilder';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
@@ -56,7 +57,7 @@ import {ReleasesSortOptions} from './releasesSortOptions';
 import {ReleasesStatusOption, ReleasesStatusOptions} from './releasesStatusOptions';
 import {validateSummaryStatsPeriod} from './utils';
 
-type ReleaseTab = 'releases' | 'mobile-builds';
+type ReleaseTab = 'releases' | 'mobile-builds' | 'snapshots';
 
 const RELEASE_FILTER_KEYS = [
   ...Object.values(SEMVER_TAGS),
@@ -244,6 +245,7 @@ export default function ReleasesList() {
   }, [selection.projects]);
 
   const hasPreprodFeature = organization.features?.includes('preprod-frontend-routes');
+  const hasSnapshotsFeature = organization.features?.includes('preprod-snapshots');
 
   const {statsPeriod, start, end, utc} = normalizeDateTimeParams(location.query);
   const buildsProbeQuery = useQuery({
@@ -285,13 +287,27 @@ export default function ReleasesList() {
 
   const shouldShowMobileBuildsTab =
     hasPreprodFeature && (hasBuildsData || hasAnyStrictlyMobileProject);
+  const shouldShowSnapshotsTab = !!hasSnapshotsFeature;
+  const shouldShowTabs = shouldShowMobileBuildsTab || shouldShowSnapshotsTab;
 
   const selectedTab = useMemo(() => {
-    if (!shouldShowMobileBuildsTab) {
+    if (!shouldShowTabs) {
       return 'releases';
     }
-    return (decodeScalar(location.query.tab) as ReleaseTab | undefined) || 'releases';
-  }, [shouldShowMobileBuildsTab, location.query.tab]);
+    const tab = decodeScalar(location.query.tab) as ReleaseTab | undefined;
+    if (tab === 'snapshots' && !shouldShowSnapshotsTab) {
+      return 'releases';
+    }
+    if (tab === 'mobile-builds' && !shouldShowMobileBuildsTab) {
+      return 'releases';
+    }
+    return tab || 'releases';
+  }, [
+    shouldShowTabs,
+    shouldShowMobileBuildsTab,
+    shouldShowSnapshotsTab,
+    location.query.tab,
+  ]);
 
   const handleSearch = useCallback(
     (query: string) => {
@@ -473,7 +489,11 @@ export default function ReleasesList() {
                 shouldShowMobileBuildsTab={shouldShowMobileBuildsTab}
               >
                 <ProjectPageFilter />
-                <EnvironmentPageFilter disabled={selectedTab === 'mobile-builds'} />
+                <EnvironmentPageFilter
+                  disabled={
+                    selectedTab === 'mobile-builds' || selectedTab === 'snapshots'
+                  }
+                />
                 <DatePageFilter
                   disallowArbitraryRelativeRanges
                   menuFooterMessage={t(
@@ -482,7 +502,7 @@ export default function ReleasesList() {
                 />
               </ReleasesPageFilterBar>
 
-              {shouldShowMobileBuildsTab && (
+              {shouldShowTabs && (
                 <Layout.HeaderTabs value={selectedTab} onChange={handleTabChange}>
                   <TabList aria-label={t('Releases tab selector')}>
                     <TabList.Item
@@ -495,23 +515,44 @@ export default function ReleasesList() {
                     >
                       {t('Releases')}
                     </TabList.Item>
-                    <TabList.Item
-                      key="mobile-builds"
-                      to={{
-                        pathname: location.pathname,
-                        query: {
-                          ...location.query,
-                          query: undefined,
-                          tab: 'mobile-builds',
-                        },
-                      }}
-                      textValue={t('Mobile Builds')}
-                    >
-                      <Flex align="center" gap="sm">
-                        {t('Mobile Builds')}
-                        <FeatureBadge type="new" />
-                      </Flex>
-                    </TabList.Item>
+                    {shouldShowMobileBuildsTab && (
+                      <TabList.Item
+                        key="mobile-builds"
+                        to={{
+                          pathname: location.pathname,
+                          query: {
+                            ...location.query,
+                            query: undefined,
+                            tab: 'mobile-builds',
+                          },
+                        }}
+                        textValue={t('Mobile Builds')}
+                      >
+                        <Flex align="center" gap="sm">
+                          {t('Mobile Builds')}
+                          <FeatureBadge type="new" />
+                        </Flex>
+                      </TabList.Item>
+                    )}
+                    {shouldShowSnapshotsTab && (
+                      <TabList.Item
+                        key="snapshots"
+                        to={{
+                          pathname: location.pathname,
+                          query: {
+                            ...location.query,
+                            query: undefined,
+                            tab: 'snapshots',
+                          },
+                        }}
+                        textValue={t('Snapshots')}
+                      >
+                        <Flex align="center" gap="sm">
+                          {t('Snapshots')}
+                          <FeatureBadge type="alpha" />
+                        </Flex>
+                      </TabList.Item>
+                    )}
                   </TabList>
                 </Layout.HeaderTabs>
               )}
@@ -524,6 +565,15 @@ export default function ReleasesList() {
                   <MobileBuilds
                     organization={organization}
                     selectedProjectIds={selectedProjectIds}
+                  />
+                )}
+
+                {selectedTab === 'snapshots' && shouldShowSnapshotsTab && (
+                  <MobileBuilds
+                    organization={organization}
+                    selectedProjectIds={selectedProjectIds}
+                    defaultDisplay={PreprodBuildsDisplay.SNAPSHOT}
+                    hideDisplayToggle
                   />
                 )}
 

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -288,10 +288,10 @@ export default function ReleasesList() {
   const shouldShowMobileBuildsTab =
     hasPreprodFeature && (hasBuildsData || hasAnyStrictlyMobileProject);
   const shouldShowSnapshotsTab = !!hasSnapshotsFeature;
-  const shouldShowTabs = shouldShowMobileBuildsTab || shouldShowSnapshotsTab;
+  const shouldShowPreprodTabs = shouldShowMobileBuildsTab || shouldShowSnapshotsTab;
 
   const selectedTab = useMemo(() => {
-    if (!shouldShowTabs) {
+    if (!shouldShowPreprodTabs) {
       return 'releases';
     }
     const tab = decodeScalar(location.query.tab) as ReleaseTab | undefined;
@@ -303,7 +303,7 @@ export default function ReleasesList() {
     }
     return tab || 'releases';
   }, [
-    shouldShowTabs,
+    shouldShowPreprodTabs,
     shouldShowMobileBuildsTab,
     shouldShowSnapshotsTab,
     location.query.tab,
@@ -502,7 +502,7 @@ export default function ReleasesList() {
                 />
               </ReleasesPageFilterBar>
 
-              {shouldShowTabs && (
+              {shouldShowPreprodTabs && (
                 <Layout.HeaderTabs value={selectedTab} onChange={handleTabChange}>
                   <TabList aria-label={t('Releases tab selector')}>
                     <TabList.Item

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -515,44 +515,42 @@ export default function ReleasesList() {
                     >
                       {t('Releases')}
                     </TabList.Item>
-                    {shouldShowMobileBuildsTab && (
-                      <TabList.Item
-                        key="mobile-builds"
-                        to={{
-                          pathname: location.pathname,
-                          query: {
-                            ...location.query,
-                            query: undefined,
-                            tab: 'mobile-builds',
-                          },
-                        }}
-                        textValue={t('Mobile Builds')}
-                      >
-                        <Flex align="center" gap="sm">
-                          {t('Mobile Builds')}
-                          <FeatureBadge type="new" />
-                        </Flex>
-                      </TabList.Item>
-                    )}
-                    {shouldShowSnapshotsTab && (
-                      <TabList.Item
-                        key="snapshots"
-                        to={{
-                          pathname: location.pathname,
-                          query: {
-                            ...location.query,
-                            query: undefined,
-                            tab: 'snapshots',
-                          },
-                        }}
-                        textValue={t('Snapshots')}
-                      >
-                        <Flex align="center" gap="sm">
-                          {t('Snapshots')}
-                          <FeatureBadge type="alpha" />
-                        </Flex>
-                      </TabList.Item>
-                    )}
+                    <TabList.Item
+                      key="mobile-builds"
+                      hidden={!shouldShowMobileBuildsTab}
+                      to={{
+                        pathname: location.pathname,
+                        query: {
+                          ...location.query,
+                          query: undefined,
+                          tab: 'mobile-builds',
+                        },
+                      }}
+                      textValue={t('Mobile Builds')}
+                    >
+                      <Flex align="center" gap="sm">
+                        {t('Mobile Builds')}
+                        <FeatureBadge type="new" />
+                      </Flex>
+                    </TabList.Item>
+                    <TabList.Item
+                      key="snapshots"
+                      hidden={!shouldShowSnapshotsTab}
+                      to={{
+                        pathname: location.pathname,
+                        query: {
+                          ...location.query,
+                          query: undefined,
+                          tab: 'snapshots',
+                        },
+                      }}
+                      textValue={t('Snapshots')}
+                    >
+                      <Flex align="center" gap="sm">
+                        {t('Snapshots')}
+                        <FeatureBadge type="alpha" />
+                      </Flex>
+                    </TabList.Item>
                   </TabList>
                 </Layout.HeaderTabs>
               )}

--- a/static/app/views/releases/list/index.tsx
+++ b/static/app/views/releases/list/index.tsx
@@ -486,7 +486,7 @@ export default function ReleasesList() {
 
               <ReleasesPageFilterBar
                 condensed
-                shouldShowMobileBuildsTab={shouldShowMobileBuildsTab}
+                shouldShowPreprodTabs={shouldShowPreprodTabs}
               >
                 <ProjectPageFilter />
                 <EnvironmentPageFilter
@@ -654,8 +654,8 @@ export default function ReleasesList() {
   );
 }
 
-const ReleasesPageFilterBar = styled(PageFilterBar)<{shouldShowMobileBuildsTab: boolean}>`
-  ${p => !p.shouldShowMobileBuildsTab && `margin-bottom: ${p.theme.space.xl};`}
+const ReleasesPageFilterBar = styled(PageFilterBar)<{shouldShowPreprodTabs: boolean}>`
+  ${p => !p.shouldShowPreprodTabs && `margin-bottom: ${p.theme.space.xl};`}
 `;
 
 const SortAndFilterWrapper = styled('div')`

--- a/static/app/views/releases/list/mobileBuilds.tsx
+++ b/static/app/views/releases/list/mobileBuilds.tsx
@@ -118,6 +118,7 @@ export function MobileBuilds({
       selectedProjectIds[0] === `${ALL_ACCESS_PROJECTS}`);
   const projectId = selectedProjectIds[0];
   const shouldShowOnboarding =
+    activeDisplay !== PreprodBuildsDisplay.SNAPSHOT &&
     builds.length === 0 &&
     !isLoadingBuilds &&
     !buildsError &&
@@ -134,7 +135,10 @@ export function MobileBuilds({
     enabled: selectedProjectIds.length > 0,
     error: !!buildsError,
     isLoading: isLoadingBuilds,
-    pageSource: 'releases_mobile_builds_tab',
+    pageSource:
+      activeDisplay === PreprodBuildsDisplay.SNAPSHOT
+        ? 'releases_snapshots_tab'
+        : 'releases_mobile_builds_tab',
     projectCount: selectedProjectIds.length,
     searchQuery,
   });

--- a/static/app/views/releases/list/mobileBuilds.tsx
+++ b/static/app/views/releases/list/mobileBuilds.tsx
@@ -6,6 +6,7 @@ import {Stack} from '@sentry/scraps/layout';
 
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {ALL_ACCESS_PROJECTS} from 'sentry/components/pageFilters/constants';
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {
   getPreprodBuildsDisplay,
@@ -28,17 +29,24 @@ import {MobileBuildsChart} from './mobileBuildsChart';
 type Props = {
   organization: Organization;
   selectedProjectIds: string[];
+  defaultDisplay?: PreprodBuildsDisplay;
+  hideDisplayToggle?: boolean;
 };
 
-export function MobileBuilds({organization, selectedProjectIds}: Props) {
+export function MobileBuilds({
+  organization,
+  selectedProjectIds,
+  defaultDisplay,
+  hideDisplayToggle,
+}: Props) {
   const location = useLocation();
   const navigate = useNavigate();
 
   const [searchQuery] = useQueryState('query', parseAsString);
   const [cursor] = useQueryState('cursor', parseAsString);
   const activeDisplay = useMemo(
-    () => getPreprodBuildsDisplay(location.query.display),
-    [location.query.display]
+    () => defaultDisplay ?? getPreprodBuildsDisplay(location.query.display),
+    [defaultDisplay, location.query.display]
   );
 
   const buildsQueryParams = useMemo(() => {
@@ -104,7 +112,10 @@ export function MobileBuilds({organization, selectedProjectIds}: Props) {
   const builds = buildsResponse?.json ?? [];
   const pageLinks = buildsResponse?.headers.Link ?? undefined;
   const hasSearchQuery = !!searchQuery?.trim();
-  const showProjectColumn = selectedProjectIds.length > 1;
+  const showProjectColumn =
+    selectedProjectIds.length > 1 ||
+    (selectedProjectIds.length === 1 &&
+      selectedProjectIds[0] === `${ALL_ACCESS_PROJECTS}`);
   const projectId = selectedProjectIds[0];
   const shouldShowOnboarding =
     builds.length === 0 &&
@@ -159,6 +170,7 @@ export function MobileBuilds({organization, selectedProjectIds}: Props) {
         initialQuery={searchQuery ?? ''}
         display={activeDisplay}
         projects={selectedProjectIds.map(Number)}
+        hideDisplayToggle={hideDisplayToggle}
         onSearch={handleSearch}
         onDisplayChange={handleDisplayChange}
       />

--- a/tests/sentry/preprod/api/endpoints/test_builds.py
+++ b/tests/sentry/preprod/api/endpoints/test_builds.py
@@ -113,6 +113,7 @@ class BuildsEndpointTest(APITestCase):
                 "posted_status_checks": None,
                 "project_slug": "bar",
                 "size_info": None,
+                "snapshot_info": None,
             }
         ]
 

--- a/tests/sentry/preprod/api/endpoints/test_builds.py
+++ b/tests/sentry/preprod/api/endpoints/test_builds.py
@@ -113,7 +113,7 @@ class BuildsEndpointTest(APITestCase):
                 "posted_status_checks": None,
                 "project_slug": "bar",
                 "size_info": None,
-                "snapshot_info": None,
+                "snapshot_comparison_info": None,
             }
         ]
 


### PR DESCRIPTION
<img width="3862" height="3064" alt="CleanShot 2026-04-13 at 10 24 38@2x" src="https://github.com/user-attachments/assets/83079ec4-a370-4673-baea-88a78d9cd057" />


Adds a new Snapshots tab to the Releases page for browsing visual snapshot builds. The tab is gated behind the `organizations:preprod-snapshots` feature flag, independently from the existing Mobile Builds tab (`preprod-frontend-routes`).

**What this adds:**

- `PreprodBuildsSnapshotTable` component with a consolidated column layout inspired by the old Emerge Tools UI:
  - **Snapshot**: app name + image count subtitle
  - **Changes**: shows lifecycle state tags (Base/Pending/Processing/Failed) when comparison isn't complete, or full diff summary text (e.g., "10 modified, 1 unchanged") when it is
  - **Branch**: git ref + commit SHA
  - **Approval**: only shows Approved/Needs Approval badges for successful comparisons
  - **Created**: relative timestamp

- Backend additions to `SnapshotInfo` API response:
  - `comparison_error_message` field for rich Failed state tooltips
  - Literal types for `comparison_state` and `approval_status` for type safety on both sides

- Fixed N+1 query issue in `to_snapshot_info()` by adding `select_related`/`prefetch_related` for snapshot metrics, comparisons, and approvals in the builds endpoint queryset

- Snapshots tab visibility independently gated from Mobile Builds tab, with proper fallback if a user navigates to a tab whose feature flag is off