### PR TITLE
ref(profiling): Remove unused props and dead code from flamegraph toolbars

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionProfiles/content.tsx
+++ b/static/app/views/performance/transactionSummary/transactionProfiles/content.tsx
@@ -45,8 +45,6 @@ const DEFAULT_FLAMEGRAPH_PREFERENCES: DeepPartial<FlamegraphState> = {
   },
 };
 
-const noop = () => void 0;
-
 function isEmpty(resp: Profiling.Schema) {
   const profile = resp.profiles[0];
   if (!profile) {
@@ -73,7 +71,6 @@ function isEmpty(resp: Profiling.Schema) {
 
 interface TransactionProfilesContentProps {
   query: string;
-  transaction: string;
 }
 
 export function TransactionProfilesContent(props: TransactionProfilesContentProps) {
@@ -172,8 +169,6 @@ export function TransactionProfilesContent(props: TransactionProfilesContentProp
                   onVisualizationChange={onVisualizationChange}
                   frameFilter={frameFilter}
                   onFrameFilterChange={onFrameFilterChange}
-                  hideSystemFrames={false}
-                  setHideSystemFrames={noop}
                   expanded={showSidePanel}
                   setExpanded={setShowSidePanel}
                 />
@@ -227,12 +222,10 @@ interface AggregateFlamegraphToolbarProps {
   canvasPoolManager: CanvasPoolManager;
   expanded: boolean;
   frameFilter: 'system' | 'application' | 'all';
-  hideSystemFrames: boolean;
   onFrameFilterChange: (value: 'system' | 'application' | 'all') => void;
   onVisualizationChange: (value: 'flamegraph' | 'call tree') => void;
   scheduler: CanvasScheduler;
   setExpanded: (expanded: boolean) => void;
-  setHideSystemFrames: (value: boolean) => void;
   visualization: 'flamegraph' | 'call tree';
 }
 

--- a/static/app/views/performance/transactionSummary/transactionProfiles/index.tsx
+++ b/static/app/views/performance/transactionSummary/transactionProfiles/index.tsx
@@ -125,7 +125,7 @@ function Profiles({transaction}: ProfilesProps) {
           />
         )}
       </FilterActions>
-      <TransactionProfilesContent query={query} transaction={transaction} />
+      <TransactionProfilesContent query={query} />
     </StyledMain>
   );
 }

--- a/static/app/views/profiling/landingAggregateFlamegraph.tsx
+++ b/static/app/views/profiling/landingAggregateFlamegraph.tsx
@@ -44,8 +44,6 @@ const DEFAULT_FLAMEGRAPH_PREFERENCES: DeepPartial<FlamegraphState> = {
   },
 };
 
-const noop = () => void 0;
-
 function decodeViewOrDefault(
   value: string | string[] | null | undefined,
   defaultValue: 'flamegraph' | 'profiles'
@@ -63,13 +61,10 @@ interface AggregateFlamegraphToolbarProps {
   canvasPoolManager: CanvasPoolManager;
   expanded: boolean;
   frameFilter: 'system' | 'application' | 'all';
-  hideSystemFrames: boolean;
   onFrameFilterChange: (value: 'system' | 'application' | 'all') => void;
-  onHideRegressionsClick: () => void;
   onVisualizationChange: (value: 'flamegraph' | 'call tree') => void;
   scheduler: CanvasScheduler;
   setExpanded: (expanded: boolean) => void;
-  setHideSystemFrames: (value: boolean) => void;
   visualization: 'flamegraph' | 'call tree';
 }
 
@@ -211,10 +206,6 @@ export function LandingAggregateFlamegraph({
     [setVisualization]
   );
 
-  const [hideRegressions, setHideRegressions] = useLocalStorageState<boolean>(
-    'flamegraph-hide-regressions',
-    false
-  );
   const [frameFilter, setFrameFilter] = useLocalStorageState<
     'system' | 'application' | 'all'
   >('flamegraph-frame-filter', 'application');
@@ -254,10 +245,6 @@ export function LandingAggregateFlamegraph({
     }
   }, [location.query.view, view]);
 
-  const onHideRegressionsClick = useCallback(() => {
-    return setHideRegressions(!hideRegressions);
-  }, [hideRegressions, setHideRegressions]);
-
   const [showSidePanel, setShowSidePanel] = useState(true);
 
   const initial = useRef(true);
@@ -293,9 +280,6 @@ export function LandingAggregateFlamegraph({
                   onVisualizationChange={onVisualizationChange}
                   frameFilter={frameFilter}
                   onFrameFilterChange={onFrameFilterChange}
-                  hideSystemFrames={false}
-                  setHideSystemFrames={noop}
-                  onHideRegressionsClick={onHideRegressionsClick}
                   expanded={showSidePanel}
                   setExpanded={setShowSidePanel}
                 />


### PR DESCRIPTION
`hideSystemFrames`, `setHideSystemFrames`, and `onHideRegressionsClick` were being passed as noop/false placeholders and never actually used