### PR TITLE
feat(seer): Add Seer admin page with night shift trigger

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -527,6 +527,7 @@ from sentry.rules.history.endpoints.project_rule_group_history import (
 )
 from sentry.rules.history.endpoints.project_rule_stats import ProjectRuleStatsIndexEndpoint
 from sentry.scm.endpoints.scm_rpc import ScmRpcServiceEndpoint
+from sentry.seer.endpoints.admin_night_shift_trigger import SeerAdminNightShiftTriggerEndpoint
 from sentry.seer.endpoints.group_ai_autofix import GroupAutofixEndpoint
 from sentry.seer.endpoints.group_ai_summary import GroupAiSummaryEndpoint
 from sentry.seer.endpoints.group_autofix_setup_check import GroupAutofixSetupCheck
@@ -3653,6 +3654,11 @@ INTERNAL_URLS = [
     ),
     *preprod_urls.preprod_internal_urlpatterns,
     *notification_platform_urls.internal_urlpatterns,
+    re_path(
+        r"^seer/night-shift/trigger/$",
+        SeerAdminNightShiftTriggerEndpoint.as_view(),
+        name="sentry-admin-seer-night-shift-trigger",
+    ),
 ]
 
 urlpatterns = [

--- a/src/sentry/seer/endpoints/admin_night_shift_trigger.py
+++ b/src/sentry/seer/endpoints/admin_night_shift_trigger.py
@@ -1,0 +1,36 @@
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import Endpoint, internal_cell_silo_endpoint
+from sentry.api.permissions import StaffPermission
+from sentry.tasks.seer.night_shift.cron import run_night_shift_for_org
+
+
+@internal_cell_silo_endpoint
+class SeerAdminNightShiftTriggerEndpoint(Endpoint):
+    owner = ApiOwner.ML_AI
+    permission_classes = (StaffPermission,)
+    publish_status = {
+        "POST": ApiPublishStatus.PRIVATE,
+    }
+
+    def post(self, request: Request) -> Response:
+        organization_id = request.data.get("organization_id")
+        if organization_id is None:
+            return Response({"detail": "organization_id is required"}, status=400)
+
+        try:
+            organization_id = int(organization_id)
+        except (ValueError, TypeError):
+            return Response({"detail": "organization_id must be a valid integer"}, status=400)
+
+        run_night_shift_for_org.apply_async(args=[organization_id])
+
+        return Response(
+            {
+                "success": True,
+                "organization_id": organization_id,
+            }
+        )

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -121,6 +121,7 @@ export type KnownSentryApiUrls =
   | '/internal/rpc/$serviceName/$methodName/'
   | '/internal/scm-rpc/$methodName/'
   | '/internal/seer-rpc/$methodName/'
+  | '/internal/seer/night-shift/trigger/'
   | '/internal/warnings/'
   | '/issues/$issueId/'
   | '/issues/$issueId/activities/'

--- a/static/gsAdmin/routes.tsx
+++ b/static/gsAdmin/routes.tsx
@@ -35,6 +35,7 @@ import {RelocationArtifactDetails} from 'admin/views/relocationArtifactDetails';
 import {RelocationCreate} from 'admin/views/relocationCreate';
 import {RelocationDetails} from 'admin/views/relocationDetails';
 import {Relocations} from 'admin/views/relocations';
+import {SeerAdminPage} from 'admin/views/seerAdminPage';
 import {SentryAppDetails} from 'admin/views/sentryAppDetails';
 import {SentryApps} from 'admin/views/sentryApps';
 import {SentryEmployees} from 'admin/views/sentryEmployees';
@@ -290,6 +291,15 @@ function buildRoutes() {
           {
             index: true,
             component: LaunchpadAdminPage,
+          },
+        ],
+      },
+      {
+        path: 'seer/',
+        children: [
+          {
+            index: true,
+            component: SeerAdminPage,
           },
         ],
       },

--- a/static/gsAdmin/views/layout.tsx
+++ b/static/gsAdmin/views/layout.tsx
@@ -80,6 +80,7 @@ export function Layout() {
                 Spike Projection Generation
               </NavLink>
               <NavLink to="/_admin/launchpad/">Launchpad (Emerge) Related</NavLink>
+              <NavLink to="/_admin/seer/">Seer</NavLink>
             </Navigation>
             <div>
               <ThemeToggle

--- a/static/gsAdmin/views/seerAdminPage.tsx
+++ b/static/gsAdmin/views/seerAdminPage.tsx
@@ -80,7 +80,7 @@ export function SeerAdminPage() {
         <Grid columns={{xs: '1fr', md: '1fr 1fr'}} gap="xl">
           <form onSubmit={handleNightShiftSubmit}>
             <Container background="secondary" border="primary" radius="md" padding="lg">
-              <Flex direction="column" gap="md" alignItems="start">
+              <Flex direction="column" gap="md" align="start">
                 <Heading as="h3">Trigger Night Shift Run</Heading>
                 <Text as="p" variant="muted">
                   Dispatch a night shift run for a specific organization. This will select

--- a/static/gsAdmin/views/seerAdminPage.tsx
+++ b/static/gsAdmin/views/seerAdminPage.tsx
@@ -1,5 +1,4 @@
 import {useState} from 'react';
-import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
@@ -81,7 +80,7 @@ export function SeerAdminPage() {
         <Grid columns={{xs: '1fr', md: '1fr 1fr'}} gap="xl">
           <form onSubmit={handleNightShiftSubmit}>
             <Container background="secondary" border="primary" radius="md" padding="lg">
-              <Flex direction="column" gap="md">
+              <Flex direction="column" gap="md" alignItems="start">
                 <Heading as="h3">Trigger Night Shift Run</Heading>
                 <Text as="p" variant="muted">
                   Dispatch a night shift run for a specific organization. This will select
@@ -90,7 +89,7 @@ export function SeerAdminPage() {
                 <label htmlFor="organizationId">
                   <Text bold>Organization ID:</Text>
                 </label>
-                <StyledInput
+                <Input
                   type="text"
                   name="organizationId"
                   value={organizationId}
@@ -101,7 +100,6 @@ export function SeerAdminPage() {
                   priority="primary"
                   type="submit"
                   disabled={!organizationId.trim() || !region || isNightShiftPending}
-                  style={{width: 'fit-content'}}
                 >
                   Trigger Night Shift
                 </Button>
@@ -113,8 +111,3 @@ export function SeerAdminPage() {
     </div>
   );
 }
-
-const StyledInput = styled(Input)`
-  width: 100%;
-  max-width: 300px;
-`;

--- a/static/gsAdmin/views/seerAdminPage.tsx
+++ b/static/gsAdmin/views/seerAdminPage.tsx
@@ -1,0 +1,129 @@
+import {useState} from 'react';
+import {css} from '@emotion/react';
+
+import {Button} from '@sentry/scraps/button';
+import {CompactSelect} from '@sentry/scraps/compactSelect';
+import {Input} from '@sentry/scraps/input';
+import {Container, Flex, Grid} from '@sentry/scraps/layout';
+import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
+import {Heading, Text} from '@sentry/scraps/text';
+
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {ConfigStore} from 'sentry/stores/configStore';
+import type {Region} from 'sentry/types/system';
+import {fetchMutation, useMutation} from 'sentry/utils/queryClient';
+
+import {PageHeader} from 'admin/components/pageHeader';
+
+export function SeerAdminPage() {
+  const [organizationId, setOrganizationId] = useState<string>('');
+  const regions = ConfigStore.get('regions');
+  const [region, setRegion] = useState<Region | null>(regions[0] ?? null);
+
+  const {mutate: triggerNightShift, isPending: isNightShiftPending} = useMutation({
+    mutationFn: () => {
+      return fetchMutation({
+        url: '/internal/seer/night-shift/trigger/',
+        method: 'POST',
+        data: {organization_id: parseInt(organizationId, 10)},
+        options: {host: region?.url},
+      });
+    },
+    onSuccess: () => {
+      addSuccessMessage(`Night shift run triggered for organization ${organizationId}`);
+      setOrganizationId('');
+    },
+    onError: () => {
+      addErrorMessage('Failed to trigger night shift run');
+    },
+  });
+
+  const handleNightShiftSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!region) {
+      addErrorMessage('Please select a region first');
+      return;
+    }
+    if (!organizationId.trim()) {
+      addErrorMessage('Organization ID is required');
+      return;
+    }
+    triggerNightShift();
+  };
+
+  return (
+    <div>
+      <PageHeader title="Seer Admin Page" />
+      <Flex direction="column" gap="lg">
+        <Text as="p">
+          Admin tools for managing Seer features. Select a region before performing
+          actions.
+        </Text>
+
+        <CompactSelect
+          trigger={triggerProps => (
+            <OverlayTrigger.Button {...triggerProps} prefix="Region" />
+          )}
+          value={region ? region.url : undefined}
+          options={regions.map((r: Region) => ({
+            label: r.name,
+            value: r.url,
+          }))}
+          onChange={opt => {
+            const regionOption = regions.find((r: Region) => r.url === opt.value);
+            if (regionOption === undefined) {
+              return;
+            }
+            setRegion(regionOption);
+          }}
+        />
+
+        <Grid
+          columns="1fr 1fr"
+          gap="xl"
+          css={css`
+            @media (max-width: 768px) {
+              grid-template-columns: 1fr;
+            }
+          `}
+        >
+          <form onSubmit={handleNightShiftSubmit}>
+            <Container background="secondary" border="primary" radius="md" padding="lg">
+              <Flex direction="column" gap="md">
+                <Heading as="h3">Trigger Night Shift Run</Heading>
+                <Text as="p" variant="muted">
+                  Dispatch a night shift run for a specific organization. This will select
+                  candidate issues and run agentic triage on them.
+                </Text>
+                <label htmlFor="organizationId">
+                  <Text bold>Organization ID:</Text>
+                </label>
+                <Input
+                  type="text"
+                  name="organizationId"
+                  value={organizationId}
+                  onChange={e => setOrganizationId(e.target.value)}
+                  placeholder="Enter organization ID"
+                  css={css`
+                    width: 100%;
+                    max-width: 300px;
+                  `}
+                />
+                <Button
+                  priority="primary"
+                  type="submit"
+                  disabled={!organizationId.trim() || !region || isNightShiftPending}
+                  css={css`
+                    width: fit-content;
+                  `}
+                >
+                  Trigger Night Shift
+                </Button>
+              </Flex>
+            </Container>
+          </form>
+        </Grid>
+      </Flex>
+    </div>
+  );
+}

--- a/static/gsAdmin/views/seerAdminPage.tsx
+++ b/static/gsAdmin/views/seerAdminPage.tsx
@@ -1,5 +1,5 @@
 import {useState} from 'react';
-import {css} from '@emotion/react';
+import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
@@ -78,15 +78,7 @@ export function SeerAdminPage() {
           }}
         />
 
-        <Grid
-          columns="1fr 1fr"
-          gap="xl"
-          css={css`
-            @media (max-width: 768px) {
-              grid-template-columns: 1fr;
-            }
-          `}
-        >
+        <Grid columns={{xs: '1fr', md: '1fr 1fr'}} gap="xl">
           <form onSubmit={handleNightShiftSubmit}>
             <Container background="secondary" border="primary" radius="md" padding="lg">
               <Flex direction="column" gap="md">
@@ -98,24 +90,18 @@ export function SeerAdminPage() {
                 <label htmlFor="organizationId">
                   <Text bold>Organization ID:</Text>
                 </label>
-                <Input
+                <StyledInput
                   type="text"
                   name="organizationId"
                   value={organizationId}
                   onChange={e => setOrganizationId(e.target.value)}
                   placeholder="Enter organization ID"
-                  css={css`
-                    width: 100%;
-                    max-width: 300px;
-                  `}
                 />
                 <Button
                   priority="primary"
                   type="submit"
                   disabled={!organizationId.trim() || !region || isNightShiftPending}
-                  css={css`
-                    width: fit-content;
-                  `}
+                  style={{width: 'fit-content'}}
                 >
                   Trigger Night Shift
                 </Button>
@@ -127,3 +113,8 @@ export function SeerAdminPage() {
     </div>
   );
 }
+
+const StyledInput = styled(Input)`
+  width: 100%;
+  max-width: 300px;
+`;

--- a/tests/sentry/seer/endpoints/test_admin_night_shift_trigger.py
+++ b/tests/sentry/seer/endpoints/test_admin_night_shift_trigger.py
@@ -1,0 +1,47 @@
+from unittest.mock import patch
+
+from sentry.testutils.cases import APITestCase
+
+
+class SeerAdminNightShiftTriggerTest(APITestCase):
+    endpoint = "sentry-admin-seer-night-shift-trigger"
+    method = "post"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.user = self.create_user(is_staff=True)
+        self.organization = self.create_organization(owner=self.user)
+        self.login_as(user=self.user)
+
+    def get_response(self, *args, **params):
+        with patch("sentry.api.permissions.is_active_staff", return_value=True):
+            return super().get_response(*args, **params)
+
+    def test_trigger_night_shift(self) -> None:
+        with patch(
+            "sentry.seer.endpoints.admin_night_shift_trigger.run_night_shift_for_org"
+        ) as mock_task:
+            response = self.get_success_response(
+                organization_id=self.organization.id,
+                status_code=200,
+            )
+
+        assert response.data["success"] is True
+        assert response.data["organization_id"] == self.organization.id
+        mock_task.apply_async.assert_called_once_with(args=[self.organization.id])
+
+    def test_missing_organization_id(self) -> None:
+        response = self.get_response()
+        assert response.status_code == 400
+        assert response.data["detail"] == "organization_id is required"
+
+    def test_invalid_organization_id(self) -> None:
+        response = self.get_response(organization_id="not-a-number")
+        assert response.status_code == 400
+        assert response.data["detail"] == "organization_id must be a valid integer"
+
+    def test_requires_staff(self) -> None:
+        non_staff_user = self.create_user(is_staff=False)
+        self.login_as(user=non_staff_user)
+        response = super().get_response(organization_id=self.organization.id)
+        assert response.status_code == 403


### PR DESCRIPTION
Add a Seer section to the `_admin` panel with an action to trigger a night shift run for a specific organization. This dispatches the `run_night_shift_for_org` celery task via a new staff-only internal API endpoint.

The endpoint (`POST /internal/seer/night-shift/trigger/`) is protected by `StaffPermission`, restricting access to Sentry employees. The frontend page follows the same pattern as the existing Launchpad admin page — region selector + org ID input.

This is the first Seer admin action; the page is structured to accommodate future actions (e.g. rebuilding the explorer index).