### PR TITLE
fix(seer): Prevent horizontal scrollbar flash on block entry animation

### DIFF
--- a/static/app/views/seerExplorer/panelContainers.tsx
+++ b/static/app/views/seerExplorer/panelContainers.tsx
@@ -211,6 +211,7 @@ const PanelContent = styled('div')`
 export const BlocksContainer = styled(Stack)`
   flex: 1;
   overflow-y: auto;
+  overflow-x: hidden;
   overscroll-behavior: contain;
 `;
 


### PR DESCRIPTION
## Changes

The Seer Explorer panel showed a brief horizontal scrollbar flash each time a new response block loaded.

**Root cause:** The block entry animation in `blockComponents.tsx` uses `initial={{opacity: 0, x: 10}}`, starting each new block 10px to the right of its natural position. `BlocksContainer` has `overflow-y: auto` but no explicit `overflow-x` — CSS coerces `overflow-x` to `auto` when `overflow-y` is `auto`, so those first few animation frames (while the block is at `translateX(10px)`) triggered a visible horizontal scrollbar before the animation resolved to `x: 0`.

**Fix:** Add `overflow-x: hidden` to `BlocksContainer` in `panelContainers.tsx`. This clips the animation without affecting vertical scrolling.

[bug report slack thread](https://sentry.slack.com/archives/C089L9UUJDV/p1776093113957399)