### PR TITLE
chore(integrations): Split github webhook sync flag out from our general auto sync flags.

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -144,6 +144,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:integrations-github-platform-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:github-repo-auto-sync", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:github-repo-auto-sync-apply", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:github-repo-auto-sync-webhook", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:github_enterprise-repo-auto-sync", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:github_enterprise-repo-auto-sync-apply", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:gitlab-repo-auto-sync", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)

--- a/src/sentry/integrations/github/tasks/sync_repos_on_install_change.py
+++ b/src/sentry/integrations/github/tasks/sync_repos_on_install_change.py
@@ -79,7 +79,7 @@ def sync_repos_on_install_change(
             )
             continue
 
-        if not features.has("organizations:github-repo-auto-sync", rpc_org):
+        if not features.has("organizations:github-repo-auto-sync-webhook", rpc_org):
             continue
 
         with SCMIntegrationInteractionEvent(

--- a/tests/sentry/integrations/github/tasks/test_sync_repos_on_install_change.py
+++ b/tests/sentry/integrations/github/tasks/test_sync_repos_on_install_change.py
@@ -12,7 +12,7 @@ from sentry.silo.base import SiloMode
 from sentry.testutils.cases import IntegrationTestCase
 from sentry.testutils.silo import assume_test_silo_mode, assume_test_silo_mode_of, control_silo_test
 
-FEATURE_FLAG = "organizations:github-repo-auto-sync"
+FEATURE_FLAG = "organizations:github-repo-auto-sync-webhook"
 
 
 @control_silo_test

--- a/tests/sentry/integrations/github/test_webhook.py
+++ b/tests/sentry/integrations/github/test_webhook.py
@@ -435,7 +435,7 @@ class InstallationRepositoriesEventWebhookTest(APITestCase):
         )
         sha1, sha256 = self._compute_signatures(body)
 
-        with self.feature("organizations:github-repo-auto-sync"), self.tasks():
+        with self.feature("organizations:github-repo-auto-sync-webhook"), self.tasks():
             response = self.client.post(
                 path=self.url,
                 data=body,
@@ -483,7 +483,7 @@ class InstallationRepositoriesEventWebhookTest(APITestCase):
         )
         sha1, sha256 = self._compute_signatures(body)
 
-        with self.feature("organizations:github-repo-auto-sync"), self.tasks():
+        with self.feature("organizations:github-repo-auto-sync-webhook"), self.tasks():
             response = self.client.post(
                 path=self.url,
                 data=body,


### PR DESCRIPTION
For testing, it's safer to have this separate to the repo auto sync work so we can test things in isolation

<!-- Describe your PR here. -->