### PR TITLE
fix(autofix): Filter out autofix code mappings with bad repos (inactive, no integration, etc.)

### DIFF
--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -918,9 +918,12 @@ def get_autofix_repos_from_project_code_mappings(
         repo_name_sections = repo.name.split("/")
 
         if (
-            # We expect a repository name to be in the format of "owner/name" for now.
+            # Repository name must be in "owner/name" format.
             len(repo_name_sections) > 1
-            # Filter out code mappings with unsupported providers.
+            # Only include active repos with a supported provider, active integration, and external ID.
+            and repo.status == ObjectStatus.ACTIVE
+            and repo.integration_id is not None
+            and repo.external_id
             and repo.provider
             and repo.provider in SEER_SUPPORTED_SCM_PROVIDERS
         ):

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -930,9 +930,7 @@ def get_autofix_repos_from_project_code_mappings(
             repo_dict = {
                 "repository_id": repo.id,
                 "organization_id": repo.organization_id,
-                "integration_id": (
-                    str(repo.integration_id) if repo.integration_id is not None else None
-                ),
+                "integration_id": str(repo.integration_id),
                 "provider": repo.provider,
                 "owner": repo_name_sections[0],
                 "name": "/".join(repo_name_sections[1:]),

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -918,7 +918,7 @@ def get_autofix_repos_from_project_code_mappings(
         repo_name_sections = repo.name.split("/")
 
         if (
-            # Repository name must be in "owner/name" format.
+            # We expect a repository name to be in the format of "owner/name" for now.
             len(repo_name_sections) > 1
             # Only include active repos with a supported provider, active integration, and external ID.
             and repo.status == ObjectStatus.ACTIVE

--- a/tests/sentry/autofix/test_utils.py
+++ b/tests/sentry/autofix/test_utils.py
@@ -5,6 +5,7 @@ import orjson
 import pytest
 
 from sentry import ratelimits
+from sentry.constants import ObjectStatus
 from sentry.seer.autofix.constants import AutofixStatus
 from sentry.seer.autofix.utils import (
     AUTOFIX_AUTOTRIGGED_RATE_LIMIT_OPTION_MULTIPLIERS,
@@ -72,6 +73,88 @@ class TestGetRepoFromCodeMappings(TestCase):
         repos = get_autofix_repos_from_project_code_mappings(project)
         assert len(repos) == 1
         assert repos[0]["provider"] == "integrations:github"
+
+    def test_filters_out_disabled_repos(self) -> None:
+        project = self.create_project()
+        active_repo = self.create_repo(
+            name="getsentry/sentry",
+            provider="integrations:github",
+            external_id="123",
+            integration_id=234,
+        )
+        self.create_code_mapping(project=project, repo=active_repo)
+
+        disabled_repo = self.create_repo(
+            name="getsentry/disabled-repo",
+            provider="integrations:github",
+            external_id="456",
+            integration_id=234,
+            status=ObjectStatus.DISABLED,
+        )
+        self.create_code_mapping(
+            project=project,
+            repo=disabled_repo,
+            stack_root="disabled/",
+            source_root="src/disabled/",
+        )
+
+        repos = get_autofix_repos_from_project_code_mappings(project)
+        assert len(repos) == 1
+        assert repos[0]["repository_id"] == active_repo.id
+
+    def test_filters_out_repos_without_integration(self) -> None:
+        project = self.create_project()
+        repo_with_integration = self.create_repo(
+            name="getsentry/sentry",
+            provider="integrations:github",
+            external_id="123",
+            integration_id=234,
+        )
+        self.create_code_mapping(project=project, repo=repo_with_integration)
+
+        repo_without_integration = self.create_repo(
+            name="getsentry/no-integration",
+            provider="integrations:github",
+            external_id="456",
+            integration_id=None,
+        )
+        self.create_code_mapping(
+            project=project,
+            repo=repo_without_integration,
+            stack_root="no-int/",
+            source_root="src/no-int/",
+        )
+
+        repos = get_autofix_repos_from_project_code_mappings(project)
+        assert len(repos) == 1
+        assert repos[0]["repository_id"] == repo_with_integration.id
+
+    def test_filters_out_repos_without_external_id(self) -> None:
+        project = self.create_project()
+        repo_with_external_id = self.create_repo(
+            name="getsentry/sentry",
+            provider="integrations:github",
+            external_id="123",
+            integration_id=234,
+        )
+        self.create_code_mapping(project=project, repo=repo_with_external_id)
+
+        repo_without_external_id = self.create_repo(
+            name="getsentry/no-external",
+            provider="integrations:github",
+            external_id=None,
+            integration_id=234,
+        )
+        self.create_code_mapping(
+            project=project,
+            repo=repo_without_external_id,
+            stack_root="no-ext/",
+            source_root="src/no-ext/",
+        )
+
+        repos = get_autofix_repos_from_project_code_mappings(project)
+        assert len(repos) == 1
+        assert repos[0]["repository_id"] == repo_with_external_id.id
 
 
 class TestGetAutofixStateFromPrId(TestCase):

--- a/tests/sentry/autofix/test_utils.py
+++ b/tests/sentry/autofix/test_utils.py
@@ -89,8 +89,8 @@ class TestGetRepoFromCodeMappings(TestCase):
             provider="integrations:github",
             external_id="456",
             integration_id=234,
-            status=ObjectStatus.DISABLED,
         )
+        disabled_repo.update(status=ObjectStatus.DISABLED)
         self.create_code_mapping(
             project=project,
             repo=disabled_repo,

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -336,6 +336,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
             name="getsentry/sentry",
             provider="integrations:github",
             external_id="123",
+            integration_id=234,
         )
         self.create_code_mapping(project=self.project, repo=repo)
 
@@ -495,6 +496,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
             name="getsentry/sentry",
             provider="integrations:github",
             external_id="123",
+            integration_id=234,
         )
         self.create_code_mapping(project=self.project, repo=repo)
 
@@ -581,6 +583,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
             name="getsentry/sentry",
             provider="integrations:github",
             external_id="123",
+            integration_id=234,
         )
         self.create_code_mapping(project=self.project, repo=repo)
 
@@ -653,6 +656,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
             name="getsentry/sentry",
             provider="integrations:github",
             external_id="123",
+            integration_id=234,
         )
         self.create_code_mapping(project=self.project, repo=repo)
 


### PR DESCRIPTION
`get_autofix_repos_from_project_code_mappings` was returning repos from code mappings regardless of repo status, integration, or external ID. This caused disabled/hidden repos to be written into `SeerProjectRepository` when autofix bootstrapped preferences from code mappings (whereas in Seer DB, Seer has a cleanup cron that removes these after they're created).

Added filters to match the criteria used by `check_repository_integrations_status` (the RPC that Seer's cleanup cron validates against): active status, non-null integration ID, non-null external ID, and supported SCM provider.