### PR TITLE
fix(pageFilters): Reset modifier key state on window blur in project selector

### DIFF
--- a/static/app/components/pageFilters/useStagedCompactSelect.tsx
+++ b/static/app/components/pageFilters/useStagedCompactSelect.tsx
@@ -414,11 +414,19 @@ export function useStagedCompactSelect<Value extends SelectKey>({
           : null;
       setModifierActive(!!keyRef.current);
     };
+    // Reset modifier state when the window loses focus so that held keys
+    // released outside the browser don't leave the state stuck.
+    const onBlur = () => {
+      keyRef.current = null;
+      setModifierActive(false);
+    };
     window.addEventListener('keydown', onKeyChange);
     window.addEventListener('keyup', onKeyChange);
+    window.addEventListener('blur', onBlur);
     return () => {
       window.removeEventListener('keydown', onKeyChange);
       window.removeEventListener('keyup', onKeyChange);
+      window.removeEventListener('blur', onBlur);
     };
   }, []);
 


### PR DESCRIPTION
The project/environment selector tracks cmd/ctrl/shift via window keydown/keyup listeners for multi-select behavior. If you cmd-tab away while holding a modifier, the keyup never fires and the state gets stuck - single clicks keep behaving like multi-select until you press and release the key again.

Adds a window blur listener that resets the modifier state so it can't persist across focus changes.

I think i was doing like cmd+tab and then the next time i used the project selector it was in multi select mode?