### PR TITLE
fix(releases): Validate project access in release details endpoint

### DIFF
--- a/src/sentry/releases/endpoints/organization_release_details.py
+++ b/src/sentry/releases/endpoints/organization_release_details.py
@@ -35,7 +35,6 @@ from sentry.apidocs.parameters import GlobalParams, ReleaseParams, VisibilityPar
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.activity import Activity
 from sentry.models.organization import Organization
-from sentry.models.project import Project
 from sentry.models.release import Release, ReleaseStatus
 from sentry.models.releases.exceptions import ReleaseCommitError, UnsafeReleaseDeletion
 from sentry.snuba.sessions import STATS_PERIODS
@@ -356,20 +355,30 @@ class OrganizationReleaseDetailsEndpoint(
         if not self.has_release_permission(request, organization, release):
             raise ResourceDoesNotExist
 
-        if with_health and project_id:
+        # Validate project access when project_id is provided
+        project = None
+        if project_id:
             try:
-                project = Project.objects.get_from_cache(id=int(project_id))
-            except (ValueError, Project.DoesNotExist):
+                project_id_int = int(project_id)
+            except ValueError:
                 raise ParseError(detail="Invalid project")
+            validated_projects = self.get_projects(
+                request, organization, project_ids={project_id_int}
+            )
+            if not validated_projects:
+                raise ResourceDoesNotExist
+            project = validated_projects[0]
+
+        if with_health and project:
             release._for_project_id = project.id
 
-        if project_id:
+        if project:
             # Add sessions time bound to current project meta data
             environments = set(request.GET.getlist("environment")) or None
             current_project_meta.update(
                 {
                     **release_health.backend.get_release_sessions_time_bounds(
-                        project_id=int(project_id),
+                        project_id=project.id,
                         release=release.version,
                         org_id=organization.id,
                         environments=environments,
@@ -394,7 +403,7 @@ class OrganizationReleaseDetailsEndpoint(
                         **self.get_first_and_last_releases(
                             org=organization,
                             environment=filter_params.get("environment"),
-                            project_id=[project_id],
+                            project_id=[project.id],
                             sort=sort,
                         ),
                     }

--- a/tests/sentry/releases/endpoints/test_organization_release_details.py
+++ b/tests/sentry/releases/endpoints/test_organization_release_details.py
@@ -130,6 +130,47 @@ class ReleaseDetailsTest(APITestCase):
         response = self.client.get(url, {"project": self.project1.id})
         assert response.status_code == 200
 
+    def test_project_from_another_org_is_rejected(self) -> None:
+        """Supplying a project_id belonging to a different organization must not
+        leak session health data (IDOR check)."""
+        other_org = self.create_organization(owner=self.create_user())
+        other_project = self.create_project(organization=other_org)
+
+        release = Release.objects.create(organization_id=self.organization.id, version="abcabcabc")
+        release.add_project(self.project1)
+
+        self.create_member(teams=[self.team1], user=self.user1, organization=self.organization)
+        self.login_as(user=self.user1)
+
+        url = reverse(
+            "sentry-api-0-organization-release-details",
+            kwargs={"organization_id_or_slug": self.organization.slug, "version": release.version},
+        )
+
+        response = self.client.get(url, {"project": other_project.id})
+        assert response.status_code in (403, 404)
+
+    def test_project_user_has_no_access_to_is_rejected(self) -> None:
+        """Supplying a project_id the user does not have access to within the
+        same org must be rejected."""
+        team2 = self.create_team(organization=self.organization)
+        no_access_project = self.create_project(teams=[team2], organization=self.organization)
+
+        release = Release.objects.create(organization_id=self.organization.id, version="abcabcabc")
+        release.add_project(self.project1)
+        release.add_project(no_access_project)
+
+        self.create_member(teams=[self.team1], user=self.user1, organization=self.organization)
+        self.login_as(user=self.user1)
+
+        url = reverse(
+            "sentry-api-0-organization-release-details",
+            kwargs={"organization_id_or_slug": self.organization.slug, "version": release.version},
+        )
+
+        response = self.client.get(url, {"project": no_access_project.id})
+        assert response.status_code in (403, 404)
+
     def test_correct_project_contains_current_project_meta(self) -> None:
         """
         Test that shows when correct project id is passed to the request, `sessionsLowerBound`,


### PR DESCRIPTION
The project_id query parameter was taken directly from user input and used to fetch health data without verifying the user has access to that project or that it belongs to the organization. Replace the unscoped Project.objects.get_from_cache() call with self.get_projects(), which validates both org membership and user permissions.

Fixes IDOR found in Semgrep: https://semgrep.dev/orgs/sentry/findings/750426332
