### PR TITLE
fix(dashboards): Disable Open in Explore for multi-query logs widgets

### DIFF
--- a/static/app/components/modals/dataWidgetViewerModal.tsx
+++ b/static/app/components/modals/dataWidgetViewerModal.tsx
@@ -91,6 +91,7 @@ import {checkUserHasEditAccess} from 'sentry/views/dashboards/utils/checkUserHas
 import {
   getWidgetExploreUrl,
   getWidgetTableRowExploreUrlFunction,
+  widgetTypeSupportsExploreMultiQuery,
 } from 'sentry/views/dashboards/utils/getWidgetExploreUrl';
 import {getWidgetMetricsUrl} from 'sentry/views/dashboards/utils/getWidgetMetricsUrl';
 import {widgetCanUseTimeSeriesVisualization} from 'sentry/views/dashboards/utils/widgetCanUseTimeSeriesVisualization';
@@ -916,16 +917,21 @@ function OpenButton({
     case WidgetType.SPANS:
     case WidgetType.LOGS: {
       openLabel = t('Open in Explore');
-      const exploreUrl = getWidgetExploreUrl(
-        widget,
-        dashboardFilters,
-        selection,
-        organization
-      );
-      if (!exploreUrl) {
-        return null;
+      const multiQueryUnsupported =
+        widget.queries.length > 1 &&
+        !widgetTypeSupportsExploreMultiQuery(widget.widgetType);
+      if (multiQueryUnsupported) {
+        return (
+          <Tooltip
+            title={t('Explore does not support multiple queries for this dataset')}
+          >
+            <Button priority="primary" disabled>
+              {openLabel}
+            </Button>
+          </Tooltip>
+        );
       }
-      path = exploreUrl;
+      path = getWidgetExploreUrl(widget, dashboardFilters, selection, organization)!;
       break;
     }
     case WidgetType.TRACEMETRICS:

--- a/static/app/components/modals/dataWidgetViewerModal.tsx
+++ b/static/app/components/modals/dataWidgetViewerModal.tsx
@@ -914,13 +914,20 @@ function OpenButton({
       path = getWidgetReleasesUrl(widget, dashboardFilters, selection, organization);
       break;
     case WidgetType.SPANS:
+    case WidgetType.LOGS: {
       openLabel = t('Open in Explore');
-      path = getWidgetExploreUrl(widget, dashboardFilters, selection, organization);
+      const exploreUrl = getWidgetExploreUrl(
+        widget,
+        dashboardFilters,
+        selection,
+        organization
+      );
+      if (!exploreUrl) {
+        return null;
+      }
+      path = exploreUrl;
       break;
-    case WidgetType.LOGS:
-      openLabel = t('Open in Explore');
-      path = getWidgetExploreUrl(widget, dashboardFilters, selection, organization);
-      break;
+    }
     case WidgetType.TRACEMETRICS:
       openLabel = t('Open in Explore');
       path = getWidgetMetricsUrl(widget, dashboardFilters, selection, organization);

--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.spec.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.spec.tsx
@@ -340,6 +340,30 @@ describe('getWidgetExploreUrl', () => {
     expect(query2.query).toBe('is_transaction:false');
   });
 
+  it('returns null for log widgets with multiple queries', () => {
+    const widget = WidgetFixture({
+      displayType: DisplayType.LINE,
+      widgetType: WidgetType.LOGS,
+      queries: [
+        WidgetQueryFixture({
+          aggregates: ['count()'],
+          columns: [],
+          conditions: 'level:error',
+          orderby: '',
+        }),
+        WidgetQueryFixture({
+          aggregates: ['count()'],
+          columns: [],
+          conditions: 'level:warning',
+          orderby: '',
+        }),
+      ],
+    });
+
+    const url = getWidgetExploreUrl(widget, undefined, selection, organization);
+    expect(url).toBeNull();
+  });
+
   it('adds referrer query parameter if provided', () => {
     const widget = WidgetFixture({
       displayType: DisplayType.LINE,

--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.spec.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.spec.tsx
@@ -316,9 +316,10 @@ describe('getWidgetExploreUrl', () => {
     });
 
     const url = getWidgetExploreUrl(widget, undefined, selection, organization);
+    expect(url).not.toBeNull();
 
     // Provide a fake base URL to allow parsing the relative URL
-    const urlObject = new URL(url, 'https://www.example.com');
+    const urlObject = new URL(url!, 'https://www.example.com');
     expect(urlObject.pathname).toBe('/organizations/org-slug/explore/traces/compare/');
 
     expect(urlObject.searchParams.get('interval')).toBe('30m');
@@ -455,11 +456,12 @@ describe('getWidgetTableRowExploreUrlFunction', () => {
   });
 });
 
-function expectUrl(url: string) {
+function expectUrl(url: string | null) {
   return {
     toMatch({path, params}: {params: Array<[string, string]>; path: string}) {
+      expect(url).not.toBeNull();
       expect(url).toMatch(new RegExp(`^${path}\\?`));
-      const urlParams = new URLSearchParams(url.substring(path.length));
+      const urlParams = new URLSearchParams(url!.substring(path.length));
       function compareFn(a: [string, string], b: [string, string]) {
         if (a[0] < b[0]) {
           return -1;

--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/react';
 import trimStart from 'lodash/trimStart';
 
 import type {PageFilters} from 'sentry/types/core';
@@ -92,6 +91,17 @@ const WIDGET_TRACE_ITEM_TO_URL_FUNCTION: Record<
   [TraceItemDataset.ERRORS]: undefined,
 };
 
+/**
+ * Returns whether the given widget type supports multiple queries in the Explore view.
+ * Currently only spans supports multi-query explore.
+ */
+export function widgetTypeSupportsExploreMultiQuery(
+  widgetType: WidgetType | undefined
+): boolean {
+  const traceItemDataset = getTraceItemDatasetFromWidgetType(widgetType);
+  return traceItemDataset === TraceItemDataset.SPANS;
+}
+
 export function getWidgetExploreUrl(
   widget: Widget,
   dashboardFilters: DashboardFilters | undefined,
@@ -99,17 +109,10 @@ export function getWidgetExploreUrl(
   organization: Organization,
   preferMode?: Mode,
   referrer?: string
-) {
+): string | null {
   const traceItemDataset = getTraceItemDatasetFromWidgetType(widget.widgetType);
 
   if (widget.queries.length > 1) {
-    if (traceItemDataset === TraceItemDataset.LOGS) {
-      Sentry.captureException(
-        new Error(
-          `getWidgetExploreUrl: multiple queries for logs is unsupported, widget_id: ${widget.id}, organization_id: ${organization.id}, dashboard_id: ${widget.dashboardId}`
-        )
-      );
-    }
     return _getWidgetExploreUrlForMultipleQueries(
       widget,
       dashboardFilters,
@@ -374,9 +377,12 @@ function _getWidgetExploreUrlForMultipleQueries(
   dashboardFilters: DashboardFilters | undefined,
   selection: PageFilters,
   organization: Organization,
-  _traceItemDataset: TraceItemDataset,
+  traceItemDataset: TraceItemDataset,
   referrer?: string
-): string {
+): string | null {
+  if (traceItemDataset !== TraceItemDataset.SPANS) {
+    return null;
+  }
   const eventView = eventViewFromWidget(widget.title, widget.queries[0]!, selection);
   const locationQueryParams = eventView.generateQueryStringObject();
   const datetime = {

--- a/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetExploreUrl.tsx
@@ -93,13 +93,15 @@ const WIDGET_TRACE_ITEM_TO_URL_FUNCTION: Record<
 
 /**
  * Returns whether the given widget type supports multiple queries in the Explore view.
- * Currently only spans supports multi-query explore.
  */
 export function widgetTypeSupportsExploreMultiQuery(
   widgetType: WidgetType | undefined
 ): boolean {
   const traceItemDataset = getTraceItemDatasetFromWidgetType(widgetType);
-  return traceItemDataset === TraceItemDataset.SPANS;
+  return (
+    traceItemDataset === TraceItemDataset.SPANS ||
+    traceItemDataset === TraceItemDataset.TRACEMETRICS
+  );
 }
 
 export function getWidgetExploreUrl(
@@ -377,10 +379,10 @@ function _getWidgetExploreUrlForMultipleQueries(
   dashboardFilters: DashboardFilters | undefined,
   selection: PageFilters,
   organization: Organization,
-  traceItemDataset: TraceItemDataset,
+  _traceItemDataset: TraceItemDataset,
   referrer?: string
 ): string | null {
-  if (traceItemDataset !== TraceItemDataset.SPANS) {
+  if (!widgetTypeSupportsExploreMultiQuery(widget.widgetType)) {
     return null;
   }
   const eventView = eventViewFromWidget(widget.title, widget.queries[0]!, selection);

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -34,7 +34,10 @@ import {
   performanceScoreTooltip,
   usesTimeSeriesData,
 } from 'sentry/views/dashboards/utils';
-import {getWidgetExploreUrl} from 'sentry/views/dashboards/utils/getWidgetExploreUrl';
+import {
+  getWidgetExploreUrl,
+  widgetTypeSupportsExploreMultiQuery,
+} from 'sentry/views/dashboards/utils/getWidgetExploreUrl';
 import {getWidgetMetricsUrl} from 'sentry/views/dashboards/utils/getWidgetMetricsUrl';
 import {getReferrer} from 'sentry/views/dashboards/widgetCard/genericWidgetQueries';
 import {transformWidgetSeriesToTimeSeries} from 'sentry/views/dashboards/widgetCard/transformWidgetSeriesToTimeSeries';
@@ -238,17 +241,29 @@ export function getMenuOptions(
     organization.features.includes('visibility-explore-view') &&
     (widget.widgetType === WidgetType.SPANS || widget.widgetType === WidgetType.LOGS)
   ) {
+    const multiQueryUnsupported =
+      widget.queries.length > 1 &&
+      !widgetTypeSupportsExploreMultiQuery(widget.widgetType);
+
     menuOptions.push({
       key: 'open-in-explore',
       label: t('Open in Explore'),
-      to: getWidgetExploreUrl(
-        widget,
-        dashboardFilters,
-        selection,
-        organization,
-        widget.queries.some(q => q.aggregates.length > 0) ? Mode.AGGREGATE : Mode.SAMPLES,
-        getReferrer(widget.displayType)
-      ),
+      disabled: multiQueryUnsupported,
+      tooltip: multiQueryUnsupported
+        ? t('Explore does not support multiple queries for this dataset')
+        : undefined,
+      to: multiQueryUnsupported
+        ? undefined
+        : getWidgetExploreUrl(
+            widget,
+            dashboardFilters,
+            selection,
+            organization,
+            widget.queries.some(q => q.aggregates.length > 0)
+              ? Mode.AGGREGATE
+              : Mode.SAMPLES,
+            getReferrer(widget.displayType)
+          ),
     });
   }
 

--- a/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetCardContextMenu.tsx
@@ -254,7 +254,7 @@ export function getMenuOptions(
         : undefined,
       to: multiQueryUnsupported
         ? undefined
-        : getWidgetExploreUrl(
+        : (getWidgetExploreUrl(
             widget,
             dashboardFilters,
             selection,
@@ -263,7 +263,7 @@ export function getMenuOptions(
               ? Mode.AGGREGATE
               : Mode.SAMPLES,
             getReferrer(widget.displayType)
-          ),
+          ) ?? undefined),
     });
   }
 


### PR DESCRIPTION
Logs Explore does not support multiple queries, but the "Open in Explore" button was routing multi-query logs widgets to the spans explorer instead. This fixes the issue by disabling the option and showing a tooltip when the dataset doesn't support multi-query explore.

<img width="485" height="298" alt="image" src="https://github.com/user-attachments/assets/d9458719-2379-45dc-9c14-6a1ea7953467" />
 
<img width="593" height="300" alt="image" src="https://github.com/user-attachments/assets/3c5724d4-d3ee-43fc-9cb4-a7e34594974a" />



Changes:
- `getWidgetExploreUrl` now returns `null` when the dataset doesn't support multiple queries (instead of generating a wrong spans URL)
- Added `widgetTypeSupportsExploreMultiQuery` utility for callers to check support
- Context menu disables "Open in Explore" with a tooltip for unsupported multi-query datasets
- Widget viewer modal hides the Open button entirely when the URL is null
- Removed the `Sentry.captureException` workaround that logged the issue without preventing it

Fixes DAIN-1473