### PR TITLE
fix(metrics): Debounce metric selector attribute queries

### DIFF
--- a/static/app/views/explore/contexts/traceItemAttributeContext.tsx
+++ b/static/app/views/explore/contexts/traceItemAttributeContext.tsx
@@ -54,6 +54,7 @@ export type TraceItemAttributeConfig = {
   projects?: Project[] | Array<string | number>;
   query?: string;
   search?: string;
+  staleTime?: number;
 };
 
 type TraceItemAttributeOptions = Partial<Omit<TraceItemAttributeConfig, 'traceItemType'>>;
@@ -70,6 +71,7 @@ function useTraceItemAttributeConfig({
   projects: rawProjects,
   search,
   query,
+  staleTime,
 }: TraceItemAttributeConfig): TypedTraceItemAttributesResult {
   const projects = rawProjects && isProjectArray(rawProjects) ? rawProjects : undefined;
   const projectIds =
@@ -84,6 +86,7 @@ function useTraceItemAttributeConfig({
       projects,
       search,
       query,
+      staleTime,
     });
 
   const {attributes: stringAttributes, isLoading: stringAttributesLoading} =
@@ -95,6 +98,7 @@ function useTraceItemAttributeConfig({
       projects,
       search,
       query,
+      staleTime,
     });
 
   const {attributes: booleanAttributes, isLoading: booleanAttributesLoading} =
@@ -106,6 +110,7 @@ function useTraceItemAttributeConfig({
       projects,
       search,
       query,
+      staleTime,
     });
 
   const booleanBaseKeys = useMemo(() => {

--- a/static/app/views/explore/hooks/useTraceItemAttributeKeys.tsx
+++ b/static/app/views/explore/hooks/useTraceItemAttributeKeys.tsx
@@ -16,6 +16,7 @@ interface UseTraceItemAttributeKeysProps extends UseTraceItemAttributeBaseProps 
   projectIds?: Array<string | number>;
   query?: string;
   search?: string;
+  staleTime?: number;
 }
 
 export function useTraceItemAttributeKeys({
@@ -26,6 +27,7 @@ export function useTraceItemAttributeKeys({
   projectIds: explicitProjectIds,
   query,
   search,
+  staleTime,
 }: UseTraceItemAttributeKeysProps) {
   const {selection} = usePageFilters();
 
@@ -60,6 +62,7 @@ export function useTraceItemAttributeKeys({
     enabled,
     queryKey: [...queryKey, search],
     queryFn: () => getTraceItemAttributeKeys(search),
+    staleTime,
   });
 
   const previous = usePrevious(data, isFetching);

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -42,6 +42,7 @@ import {
 import {createTraceMetricFilter} from 'sentry/views/explore/metrics/utils';
 
 export const NONE_UNIT = 'none';
+const METRIC_ATTRIBUTES_DEBOUNCE_DURATION = 200;
 
 function nextFrameCallback(cb: () => void) {
   if ('requestAnimationFrame' in window) {
@@ -689,21 +690,24 @@ function MetricAttributesSection({
     type: metricType,
   });
 
+  const debouncedTraceMetricFilter = useDebouncedValue(
+    traceMetricFilter,
+    METRIC_ATTRIBUTES_DEBOUNCE_DURATION
+  );
+
+  const isDebouncingAttributes = debouncedTraceMetricFilter !== traceMetricFilter;
+  const metricAttributeQuery = {
+    enabled: Boolean(debouncedTraceMetricFilter),
+    query: debouncedTraceMetricFilter,
+    staleTime: Infinity,
+  };
+
   const {attributes: stringAttrs, isLoading: stringLoading} =
-    useTraceMetricItemAttributes(
-      {enabled: Boolean(traceMetricFilter), query: traceMetricFilter},
-      'string'
-    );
+    useTraceMetricItemAttributes(metricAttributeQuery, 'string');
   const {attributes: numberAttrs, isLoading: numberLoading} =
-    useTraceMetricItemAttributes(
-      {enabled: Boolean(traceMetricFilter), query: traceMetricFilter},
-      'number'
-    );
+    useTraceMetricItemAttributes(metricAttributeQuery, 'number');
   const {attributes: booleanAttrs, isLoading: booleanLoading} =
-    useTraceMetricItemAttributes(
-      {enabled: Boolean(traceMetricFilter), query: traceMetricFilter},
-      'boolean'
-    );
+    useTraceMetricItemAttributes(metricAttributeQuery, 'boolean');
 
   const attributeKeys = useMemo(() => {
     const keys = new Set([
@@ -716,7 +720,7 @@ function MetricAttributesSection({
       .sort((a, b) => prettifyTagKey(a).localeCompare(prettifyTagKey(b)));
   }, [stringAttrs, numberAttrs, booleanAttrs]);
 
-  if (stringLoading || numberLoading || booleanLoading) {
+  if (isDebouncingAttributes || stringLoading || numberLoading || booleanLoading) {
     return (
       <Stack gap="xs">
         <Text size="md">{t('Attributes')}:</Text>


### PR DESCRIPTION
Adds in debouncing and setting infinity stale time for the attributes side panel to save on network requests.