### PR TITLE
feat(seer): Add run ID to Seer Explorer Slack footer

### DIFF
--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -114,6 +114,8 @@ def register_permanent_features(manager: FeatureManager) -> None:
         "organizations:sentry-pride-logo-footer": False,
         # Enable priority calculations using Seer's severity endpoint
         "organizations:seer-based-priority": False,
+        # Show Seer run ID in Slack notification footers
+        "organizations:seer-run-id-in-slack": False,
         # Enable Vercel integration - there is a custom handler in getsentry
         "organizations:integrations-vercel": True,
         # Enable GitHub multi-org for users to connect many Sentry orgs to a single GitHub org.

--- a/src/sentry/notifications/platform/slack/renderers/seer.py
+++ b/src/sentry/notifications/platform/slack/renderers/seer.py
@@ -210,8 +210,11 @@ class SeerSlackRenderer(NotificationRenderer[SlackRenderable]):
         from sentry.models.organization import Organization
 
         blocks: list[Block] = [MarkdownBlock(text=data.summary)]
-        organization = Organization.objects.get_from_cache(id=data.organization_id)
-        if features.has("organizations:seer-run-id-in-slack", organization):
+        try:
+            organization = Organization.objects.get_from_cache(id=data.organization_id)
+        except Organization.DoesNotExist:
+            organization = None
+        if organization and features.has("organizations:seer-run-id-in-slack", organization):
             blocks.append(ContextBlock(elements=[PlainTextObject(text=f"Run ID: {data.run_id}")]))
 
         return SlackRenderable(blocks=blocks, text="Seer Explorer has finished")

--- a/src/sentry/notifications/platform/slack/renderers/seer.py
+++ b/src/sentry/notifications/platform/slack/renderers/seer.py
@@ -206,8 +206,13 @@ class SeerSlackRenderer(NotificationRenderer[SlackRenderable]):
 
     @classmethod
     def _render_explorer_response(cls, data: SeerExplorerResponse) -> SlackRenderable:
+        from sentry import features
+        from sentry.models.organization import Organization
+
         blocks: list[Block] = [MarkdownBlock(text=data.summary)]
-        blocks.append(ContextBlock(elements=[PlainTextObject(text=f"Run ID: {data.run_id}")]))
+        organization = Organization.objects.get_from_cache(id=data.organization_id)
+        if features.has("organizations:seer-run-id-in-slack", organization):
+            blocks.append(ContextBlock(elements=[PlainTextObject(text=f"Run ID: {data.run_id}")]))
 
         return SlackRenderable(blocks=blocks, text="Seer Explorer has finished")
 

--- a/src/sentry/notifications/platform/slack/renderers/seer.py
+++ b/src/sentry/notifications/platform/slack/renderers/seer.py
@@ -207,6 +207,7 @@ class SeerSlackRenderer(NotificationRenderer[SlackRenderable]):
     @classmethod
     def _render_explorer_response(cls, data: SeerExplorerResponse) -> SlackRenderable:
         blocks: list[Block] = [MarkdownBlock(text=data.summary)]
+        blocks.append(ContextBlock(elements=[PlainTextObject(text=f"Run ID: {data.run_id}")]))
 
         return SlackRenderable(blocks=blocks, text="Seer Explorer has finished")
 

--- a/tests/sentry/notifications/platform/slack/renderers/test_seer.py
+++ b/tests/sentry/notifications/platform/slack/renderers/test_seer.py
@@ -246,10 +246,14 @@ class SeerSlackRendererExplorerTest(TestCase):
 
         assert renderable["text"] == "Seer Explorer has finished"
         blocks = renderable["blocks"]
-        assert len(blocks) == 1
+        assert len(blocks) == 2
 
         assert isinstance(blocks[0], MarkdownBlock)
         assert "Found a spike in 500 errors from the auth service." in blocks[0].text
+
+        assert isinstance(blocks[1], ContextBlock)
+        assert isinstance(blocks[1].elements[0], PlainTextObject)
+        assert f"Run ID: {MOCK_RUN_ID}" in blocks[1].elements[0].text
 
     def test_render_dispatches_to_explorer_response(self) -> None:
         data = self._create_explorer_response(summary="Test")

--- a/tests/sentry/notifications/platform/slack/renderers/test_seer.py
+++ b/tests/sentry/notifications/platform/slack/renderers/test_seer.py
@@ -242,7 +242,8 @@ class SeerSlackRendererExplorerTest(TestCase):
         data = self._create_explorer_response(
             summary="Found a spike in 500 errors from the auth service."
         )
-        renderable = SeerSlackRenderer._render_explorer_response(data)
+        with self.feature("organizations:seer-run-id-in-slack"):
+            renderable = SeerSlackRenderer._render_explorer_response(data)
 
         assert renderable["text"] == "Seer Explorer has finished"
         blocks = renderable["blocks"]
@@ -254,6 +255,19 @@ class SeerSlackRendererExplorerTest(TestCase):
         assert isinstance(blocks[1], ContextBlock)
         assert isinstance(blocks[1].elements[0], PlainTextObject)
         assert f"Run ID: {MOCK_RUN_ID}" in blocks[1].elements[0].text
+
+    def test_render_explorer_response_without_run_id_flag(self) -> None:
+        data = self._create_explorer_response(
+            summary="Found a spike in 500 errors from the auth service."
+        )
+        renderable = SeerSlackRenderer._render_explorer_response(data)
+
+        assert renderable["text"] == "Seer Explorer has finished"
+        blocks = renderable["blocks"]
+        assert len(blocks) == 1
+
+        assert isinstance(blocks[0], MarkdownBlock)
+        assert "Found a spike in 500 errors from the auth service." in blocks[0].text
 
     def test_render_dispatches_to_explorer_response(self) -> None:
         data = self._create_explorer_response(summary="Test")


### PR DESCRIPTION
We would like the run id to show up in our replies so we can debug Seer Explorer queries quickly.

Currently it looks like this:

<img width="538" height="161" alt="image" src="https://github.com/user-attachments/assets/43aadf6d-cd4b-477d-afcd-9256a2bbc11d" />

Fixes ISWF-2432