### PR TITLE
feat(eslint): Add no-flag-comments rule to disallow section separator comments

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -459,6 +459,7 @@ export default typescript.config([
     rules: {
       '@sentry/no-digits-in-tn': 'error',
       '@sentry/no-dynamic-translations': 'error',
+      '@sentry/no-flag-comments': 'error',
       '@sentry/no-static-translations': 'error',
       '@sentry/no-styled-shortcut': 'error',
     },

--- a/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeRow.tsx
+++ b/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeRow.tsx
@@ -27,10 +27,6 @@ import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {AddIntegrationButton} from 'sentry/views/settings/organizationIntegrations/addIntegrationButton';
 
-// ---------------------------------------------------------------------------
-// Row component
-// ---------------------------------------------------------------------------
-
 type Props = {
   node: TreeNode;
   onAddIntegration: () => void;

--- a/static/app/utils/theme/types.tsx
+++ b/static/app/utils/theme/types.tsx
@@ -33,9 +33,7 @@ export type MotionEasing = 'smooth' | 'snap' | 'enter' | 'exit' | 'spring';
  */
 export type MotionDuration = 'fast' | 'moderate' | 'slow';
 
-// -----------------------------------------------------------------------------
 // Theme Variants
-// -----------------------------------------------------------------------------
 
 /**
  * Background surface level for layered UI elements.
@@ -75,9 +73,7 @@ export type BorderVariant =
   | 'secondary'
   | 'muted';
 
-// -----------------------------------------------------------------------------
 // Component Variants (should be moved locally, aligned to SemanticVariant)
-// -----------------------------------------------------------------------------
 
 /**
  * Icon size constraint.
@@ -109,9 +105,7 @@ export type TagVariant =
  */
 export type AlertVariant = 'muted' | 'info' | 'warning' | 'success' | 'danger';
 
-// -----------------------------------------------------------------------------
 // Internal types
-// -----------------------------------------------------------------------------
 
 type SizeKeys = readonly ['0', '2xs', 'xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl'];
 type Size = SizeKeys[number];

--- a/static/app/views/seerExplorer/contexts/llmContext.spec.tsx
+++ b/static/app/views/seerExplorer/contexts/llmContext.spec.tsx
@@ -6,15 +6,14 @@ import {LLMContextProvider, useLLMContext} from './llmContext';
 import type {LLMContextSnapshot} from './llmContextTypes';
 import {registerLLMContext} from './registerLLMContext';
 
-// ---------------------------------------------------------------------------
-// Test helper: ContextCapture
-//
-// Renders nothing but stores a reference to the getSnapshot function.
-// Since the context value is memoized (stable), this component only renders
-// once. However, getSnapshot() always reads stateRef.current (fresh), so
-// calling capturedRef.current() in waitFor gives live data.
-// ---------------------------------------------------------------------------
-
+/**
+ * Test helper: ContextCapture
+ *
+ * Renders nothing but stores a reference to the getSnapshot function.
+ * Since the context value is memoized (stable), this component only renders
+ * once. However, getSnapshot() always reads stateRef.current (fresh), so
+ * calling capturedRef.current() in waitFor gives live data.
+ */
 function makeContextCapture() {
   const ref: {current: ((componentOnly?: boolean) => LLMContextSnapshot) | null} = {
     current: null,
@@ -34,9 +33,7 @@ function makeContextCapture() {
   return {ContextCapture, getSnapshot};
 }
 
-// ---------------------------------------------------------------------------
 // Test fixtures
-// ---------------------------------------------------------------------------
 
 function DummyChart({label}: {label?: string}) {
   useLLMContext({label: label ?? 'chart'});
@@ -66,10 +63,6 @@ function DummyDashboard({name, children}: {children?: ReactNode; name?: string})
 const ContextChart = registerLLMContext('chart', DummyChart);
 const ContextWidget = registerLLMContext('widget', DummyWidget);
 const ContextDashboard = registerLLMContext('dashboard', DummyDashboard);
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 describe('LLMContextProvider — empty state', () => {
   it('returns an empty snapshot when no nodes are registered', async () => {

--- a/static/app/views/seerExplorer/contexts/llmContext.tsx
+++ b/static/app/views/seerExplorer/contexts/llmContext.tsx
@@ -18,9 +18,7 @@ import type {
   LLMContextState,
 } from './llmContextTypes';
 
-// ---------------------------------------------------------------------------
 // Internal context — holds the registry operations (registerNode, etc.)
-// ---------------------------------------------------------------------------
 
 const [_LLMContextProvider, _useLLMContextValue] =
   createDefinedContext<LLMContextInternalValue>({
@@ -35,21 +33,18 @@ const [_LLMContextProvider, _useLLMContextValue] =
  */
 export const useLLMContextRegistry = _useLLMContextValue;
 
-// ---------------------------------------------------------------------------
-// LLMNodeContext — carries the current component's nodeId down the tree
-// so child registerLLMContext wrappers can declare their parentId immediately
-// during render (before any effects have fired).
-// Default undefined = no parent (root level).
-// ---------------------------------------------------------------------------
-
+/**
+ * LLMNodeContext — carries the current component's nodeId down the tree
+ * so child registerLLMContext wrappers can declare their parentId immediately
+ * during render (before any effects have fired).
+ * Default undefined = no parent (root level).
+ */
 export const LLMNodeContext = createContext<string | undefined>(undefined);
 
-// ---------------------------------------------------------------------------
 // Tree assembly helpers — convert the flat node map to a nested snapshot.
 // Data is read from nodeData (imperative ref) rather than the reducer state
 // so that writes from useLLMContext(data) are visible immediately even
 // before the HOC's registerNode effect has fired.
-// ---------------------------------------------------------------------------
 
 function collectDescendantIds(
   nodes: Map<string, LLMContextNode>,
@@ -110,9 +105,7 @@ function serializeState(
   };
 }
 
-// ---------------------------------------------------------------------------
 // LLMContextProvider — root of the entire context tree
-// ---------------------------------------------------------------------------
 
 interface LLMContextProviderProps {
   children: ReactNode;
@@ -172,30 +165,28 @@ export function LLMContextProvider({children}: LLMContextProviderProps) {
   return <_LLMContextProvider value={value}>{children}</_LLMContextProvider>;
 }
 
-// ---------------------------------------------------------------------------
-// useLLMContext — write overload
-//
-// Call inside a registerLLMContext-wrapped component (or any descendant)
-// to push structured data into the nearest registered context node.
-// Accepts any value type — objects, arrays, strings, numbers, etc.
-//
-//   useLLMContext({ title: 'Error Rate', threshold: 5 });
-//   useLLMContext(someComputedValue);
-// ---------------------------------------------------------------------------
-
+/**
+ * useLLMContext — write overload
+ *
+ * Call inside a registerLLMContext-wrapped component (or any descendant)
+ * to push structured data into the nearest registered context node.
+ * Accepts any value type — objects, arrays, strings, numbers, etc.
+ *
+ *   useLLMContext({ title: 'Error Rate', threshold: 5 });
+ *   useLLMContext(someComputedValue);
+ */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type -- {} here means "any non-undefined value" to distinguish from the no-arg read overload
 export function useLLMContext(data: {} | null): void;
 
-// ---------------------------------------------------------------------------
-// useLLMContext — read overload
-//
-// Call with no arguments to get getLLMContext.
-//
-//   const { getLLMContext } = useLLMContext();
-//   getLLMContext()      // full tree from root
-//   getLLMContext(true)  // current component's subtree only
-// ---------------------------------------------------------------------------
-
+/**
+ * useLLMContext — read overload
+ *
+ * Call with no arguments to get getLLMContext.
+ *
+ *   const { getLLMContext } = useLLMContext();
+ *   getLLMContext()      // full tree from root
+ *   getLLMContext(true)  // current component's subtree only
+ */
 export function useLLMContext(): {
   getLLMContext: (componentOnly?: boolean) => LLMContextSnapshot;
 };

--- a/static/eslint/eslintPluginSentry/index.ts
+++ b/static/eslint/eslintPluginSentry/index.ts
@@ -1,6 +1,7 @@
 import {noDefaultExports} from './no-default-exports';
 import {noDigitsInTn} from './no-digits-in-tn';
 import {noDynamicTranslations} from './no-dynamic-translations';
+import {noFlagComments} from './no-flag-comments';
 import {noStaticTranslations} from './no-static-translations';
 import {noStyledShortcut} from './no-styled-shortcut';
 import {noUnnecessaryTypeAnnotation} from './no-unnecessary-type-annotation';
@@ -9,6 +10,7 @@ export const rules = {
   'no-default-exports': noDefaultExports,
   'no-digits-in-tn': noDigitsInTn,
   'no-dynamic-translations': noDynamicTranslations,
+  'no-flag-comments': noFlagComments,
   'no-static-translations': noStaticTranslations,
   'no-styled-shortcut': noStyledShortcut,
   'no-unnecessary-type-annotation': noUnnecessaryTypeAnnotation,

--- a/static/eslint/eslintPluginSentry/no-flag-comments.spec.ts
+++ b/static/eslint/eslintPluginSentry/no-flag-comments.spec.ts
@@ -1,0 +1,37 @@
+import {RuleTester} from '@typescript-eslint/rule-tester';
+
+import {noFlagComments} from './no-flag-comments';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-flag-comments', noFlagComments, {
+  valid: [
+    {code: '// This is a normal comment'},
+    {code: '// TODO: fix this'},
+    {code: '/** JSDoc comment */'},
+    {code: '// a - b - c'},
+    {code: '// --strict flag enables strict mode'},
+  ],
+  invalid: [
+    {
+      code: '// ---------------------------------------------------------------------------',
+      errors: [{messageId: 'noFlagComment'}],
+    },
+    {
+      code: '// ---',
+      errors: [{messageId: 'noFlagComment'}],
+    },
+    {
+      code: '// ----------',
+      errors: [{messageId: 'noFlagComment'}],
+    },
+    {
+      code: [
+        '// ---------------------------------------------------------------------------',
+        '// Test implementations',
+        '// ---------------------------------------------------------------------------',
+      ].join('\n'),
+      errors: [{messageId: 'noFlagComment'}, {messageId: 'noFlagComment'}],
+    },
+  ],
+});

--- a/static/eslint/eslintPluginSentry/no-flag-comments.ts
+++ b/static/eslint/eslintPluginSentry/no-flag-comments.ts
@@ -1,0 +1,29 @@
+import {ESLintUtils} from '@typescript-eslint/utils';
+
+export const noFlagComments = ESLintUtils.RuleCreator.withoutDocs({
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Disallow flag-style section separator comments (e.g. // ----------)',
+    },
+    schema: [],
+    messages: {
+      noFlagComment:
+        'Avoid flag-style section separator comments. If you need to section your module, consider splitting it into multiple modules. To document a function, use a JSDoc comment instead. If you truly want to add a comment explaining a section of code, simply do not add the dashes.',
+    },
+  },
+  create(context) {
+    return {
+      Program() {
+        for (const comment of context.sourceCode.getAllComments()) {
+          if (comment.type === 'Line' && /^-{3,}\s*$/.test(comment.value.trim())) {
+            context.report({
+              loc: comment.loc,
+              messageId: 'noFlagComment',
+            });
+          }
+        }
+      },
+    };
+  },
+});


### PR DESCRIPTION
Adds a custom ESLint rule that disallows comments consisting only of
dashes (e.g. // -----------). Fixes existing violations across 4 files.