### PR TITLE
ref(cmdk) add see more functionality

### DIFF
--- a/static/app/components/commandPalette/ui/commandPalette.spec.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.spec.tsx
@@ -480,7 +480,7 @@ describe('CommandPalette', () => {
       expect(actionOptions).toHaveLength(5);
       expect(screen.queryByRole('option', {name: 'Action 5'})).not.toBeInTheDocument();
       expect(screen.queryByRole('option', {name: 'Action 6'})).not.toBeInTheDocument();
-      expect(screen.getByRole('option', {name: 'See more'})).toBeInTheDocument();
+      expect(screen.getByRole('option', {name: 'See all'})).toBeInTheDocument();
     });
 
     it('limits static children when limit prop is set', async () => {
@@ -502,7 +502,7 @@ describe('CommandPalette', () => {
       expect(actionOptions).toHaveLength(3);
       expect(screen.queryByRole('option', {name: 'Item 3'})).not.toBeInTheDocument();
       expect(screen.queryByRole('option', {name: 'Item 4'})).not.toBeInTheDocument();
-      expect(screen.getByRole('option', {name: 'See more'})).toBeInTheDocument();
+      expect(screen.getByRole('option', {name: 'See all'})).toBeInTheDocument();
     });
 
     it('does not limit static children when limit prop is not set', async () => {
@@ -570,7 +570,7 @@ describe('CommandPalette', () => {
       expect(screen.getByRole('option', {name: 'Item 2'})).toBeInTheDocument();
       expect(screen.queryByRole('option', {name: 'Item 3'})).not.toBeInTheDocument();
       expect(screen.queryByRole('option', {name: 'Item 4'})).not.toBeInTheDocument();
-      expect(screen.getByRole('option', {name: 'See more'})).toBeInTheDocument();
+      expect(screen.getByRole('option', {name: 'See all'})).toBeInTheDocument();
     });
 
     it('grandchildren do not resurface individually when their parent nested group matches the search query', async () => {
@@ -651,7 +651,7 @@ describe('CommandPalette', () => {
       expect(await screen.findByRole('option', {name: 'Action 1'})).toBeInTheDocument();
       expect(screen.getByRole('option', {name: 'Action 2'})).toBeInTheDocument();
       expect(screen.queryByRole('option', {name: 'Action 3'})).not.toBeInTheDocument();
-      expect(screen.getByRole('option', {name: 'See more'})).toBeInTheDocument();
+      expect(screen.getByRole('option', {name: 'See all'})).toBeInTheDocument();
     });
 
     it('respects a custom limit prop', async () => {
@@ -689,7 +689,7 @@ describe('CommandPalette', () => {
         .getAllByRole('option')
         .filter(el => !el.hasAttribute('aria-disabled'));
       expect(actionOptions).toHaveLength(3);
-      expect(screen.getByRole('option', {name: 'See more'})).toBeInTheDocument();
+      expect(screen.getByRole('option', {name: 'See all'})).toBeInTheDocument();
     });
 
     it('clicking see more drills into the full limited group in browse mode', async () => {
@@ -704,11 +704,11 @@ describe('CommandPalette', () => {
         </GlobalActionsComponent>
       );
 
-      await userEvent.click(await screen.findByRole('option', {name: 'See more'}));
+      await userEvent.click(await screen.findByRole('option', {name: 'See all'}));
 
       expect(await screen.findByRole('option', {name: 'Item 3'})).toBeInTheDocument();
       expect(screen.getByRole('option', {name: 'Item 4'})).toBeInTheDocument();
-      expect(screen.queryByRole('option', {name: 'See more'})).not.toBeInTheDocument();
+      expect(screen.queryByRole('option', {name: 'See all'})).not.toBeInTheDocument();
     });
 
     it('clicking see more drills into the full limited group in search mode', async () => {
@@ -725,11 +725,11 @@ describe('CommandPalette', () => {
 
       const input = await screen.findByRole('textbox', {name: 'Search commands'});
       await userEvent.type(input, 'Item');
-      await userEvent.click(await screen.findByRole('option', {name: 'See more'}));
+      await userEvent.click(await screen.findByRole('option', {name: 'See all'}));
 
       expect(await screen.findByRole('option', {name: 'Item 3'})).toBeInTheDocument();
       expect(screen.getByRole('option', {name: 'Item 4'})).toBeInTheDocument();
-      expect(screen.queryByRole('option', {name: 'See more'})).not.toBeInTheDocument();
+      expect(screen.queryByRole('option', {name: 'See all'})).not.toBeInTheDocument();
     });
 
     it('clicking see more preserves the active query in the expanded group', async () => {
@@ -746,11 +746,49 @@ describe('CommandPalette', () => {
 
       const input = await screen.findByRole('textbox', {name: 'Search commands'});
       await userEvent.type(input, 'Item');
-      await userEvent.click(await screen.findByRole('option', {name: 'See more'}));
+      await userEvent.click(await screen.findByRole('option', {name: 'See all'}));
 
       await waitFor(() => expect(input).toHaveValue('Item'));
       expect(await screen.findByRole('option', {name: 'Item 3'})).toBeInTheDocument();
       expect(screen.getByRole('option', {name: 'Item 4'})).toBeInTheDocument();
+    });
+
+    it('keeps expanded search results sorted by match quality after clicking see more', async () => {
+      render(
+        <GlobalActionsComponent>
+          <CMDKAction display={{label: 'SDKs'}} limit={2}>
+            <CMDKAction display={{label: 'gkojavascript-nextjs'}} onAction={jest.fn()} />
+            <CMDKAction display={{label: 'gkojavascript-astro'}} onAction={jest.fn()} />
+            <CMDKAction display={{label: 'java-spring-boot'}} onAction={jest.fn()} />
+            <CMDKAction display={{label: 'java-spring-boot-test'}} onAction={jest.fn()} />
+          </CMDKAction>
+        </GlobalActionsComponent>
+      );
+
+      const input = await screen.findByRole('textbox', {name: 'Search commands'});
+      await userEvent.type(input, 'java');
+
+      const previewOptions = screen
+        .getAllByRole('option')
+        .filter(el => !el.hasAttribute('aria-disabled'));
+      expect(previewOptions.map(option => option.textContent)).toEqual([
+        'java-spring-boot',
+        'java-spring-boot-test',
+        'See all',
+      ]);
+
+      await userEvent.click(screen.getByRole('option', {name: 'See all'}));
+
+      const expandedOptions = (await screen.findAllByRole('option'))
+        .filter(el => !el.hasAttribute('aria-disabled'))
+        .map(option => option.textContent);
+
+      expect(expandedOptions.slice(0, 4)).toEqual([
+        'java-spring-boot',
+        'java-spring-boot-test',
+        'gkojavascript-nextjs',
+        'gkojavascript-astro',
+      ]);
     });
   });
 

--- a/static/app/components/commandPalette/ui/commandPalette.spec.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.spec.tsx
@@ -753,6 +753,46 @@ describe('CommandPalette', () => {
       expect(screen.getByRole('option', {name: 'Item 4'})).toBeInTheDocument();
     });
 
+    it('clicking see more does not inherit the parent callback', async () => {
+      const parentCallback = jest.fn();
+
+      render(
+        <GlobalActionsComponent>
+          <CMDKAction
+            display={{label: 'Static Group'}}
+            limit={2}
+            onAction={parentCallback}
+          >
+            <CMDKAction display={{label: 'Item 1'}} onAction={jest.fn()} />
+            <CMDKAction display={{label: 'Item 2'}} onAction={jest.fn()} />
+            <CMDKAction display={{label: 'Item 3'}} onAction={jest.fn()} />
+          </CMDKAction>
+        </GlobalActionsComponent>
+      );
+
+      await userEvent.click(await screen.findByRole('option', {name: 'See all'}));
+
+      expect(parentCallback).not.toHaveBeenCalled();
+      expect(await screen.findByRole('option', {name: 'Item 3'})).toBeInTheDocument();
+    });
+
+    it('clicking see more does not inherit the parent link indicator', async () => {
+      render(
+        <GlobalActionsComponent>
+          <CMDKAction display={{label: 'Static Group'}} limit={2} to="/group/">
+            <CMDKAction display={{label: 'Item 1'}} onAction={jest.fn()} />
+            <CMDKAction display={{label: 'Item 2'}} onAction={jest.fn()} />
+            <CMDKAction display={{label: 'Item 3'}} onAction={jest.fn()} />
+          </CMDKAction>
+        </GlobalActionsComponent>
+      );
+
+      const seeMore = await screen.findByRole('option', {name: 'See all'});
+      expect(
+        seeMore.querySelector('[data-test-id="command-palette-link-indicator"]')
+      ).not.toBeInTheDocument();
+    });
+
     it('keeps expanded search results sorted by match quality after clicking see more', async () => {
       render(
         <GlobalActionsComponent>

--- a/static/app/components/commandPalette/ui/commandPalette.spec.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.spec.tsx
@@ -477,9 +477,10 @@ describe('CommandPalette', () => {
       const actionOptions = screen
         .getAllByRole('option')
         .filter(el => !el.hasAttribute('aria-disabled'));
-      expect(actionOptions).toHaveLength(4);
+      expect(actionOptions).toHaveLength(5);
       expect(screen.queryByRole('option', {name: 'Action 5'})).not.toBeInTheDocument();
       expect(screen.queryByRole('option', {name: 'Action 6'})).not.toBeInTheDocument();
+      expect(screen.getByRole('option', {name: 'See more'})).toBeInTheDocument();
     });
 
     it('limits static children when limit prop is set', async () => {
@@ -498,9 +499,10 @@ describe('CommandPalette', () => {
       const actionOptions = screen
         .getAllByRole('option')
         .filter(el => !el.hasAttribute('aria-disabled'));
-      expect(actionOptions).toHaveLength(2);
+      expect(actionOptions).toHaveLength(3);
       expect(screen.queryByRole('option', {name: 'Item 3'})).not.toBeInTheDocument();
       expect(screen.queryByRole('option', {name: 'Item 4'})).not.toBeInTheDocument();
+      expect(screen.getByRole('option', {name: 'See more'})).toBeInTheDocument();
     });
 
     it('does not limit static children when limit prop is not set', async () => {
@@ -568,6 +570,7 @@ describe('CommandPalette', () => {
       expect(screen.getByRole('option', {name: 'Item 2'})).toBeInTheDocument();
       expect(screen.queryByRole('option', {name: 'Item 3'})).not.toBeInTheDocument();
       expect(screen.queryByRole('option', {name: 'Item 4'})).not.toBeInTheDocument();
+      expect(screen.getByRole('option', {name: 'See more'})).toBeInTheDocument();
     });
 
     it('grandchildren do not resurface individually when their parent nested group matches the search query', async () => {
@@ -648,6 +651,7 @@ describe('CommandPalette', () => {
       expect(await screen.findByRole('option', {name: 'Action 1'})).toBeInTheDocument();
       expect(screen.getByRole('option', {name: 'Action 2'})).toBeInTheDocument();
       expect(screen.queryByRole('option', {name: 'Action 3'})).not.toBeInTheDocument();
+      expect(screen.getByRole('option', {name: 'See more'})).toBeInTheDocument();
     });
 
     it('respects a custom limit prop', async () => {
@@ -684,7 +688,69 @@ describe('CommandPalette', () => {
       const actionOptions = screen
         .getAllByRole('option')
         .filter(el => !el.hasAttribute('aria-disabled'));
-      expect(actionOptions).toHaveLength(2);
+      expect(actionOptions).toHaveLength(3);
+      expect(screen.getByRole('option', {name: 'See more'})).toBeInTheDocument();
+    });
+
+    it('clicking see more drills into the full limited group in browse mode', async () => {
+      render(
+        <GlobalActionsComponent>
+          <CMDKAction display={{label: 'Static Group'}} limit={2}>
+            <CMDKAction display={{label: 'Item 1'}} onAction={jest.fn()} />
+            <CMDKAction display={{label: 'Item 2'}} onAction={jest.fn()} />
+            <CMDKAction display={{label: 'Item 3'}} onAction={jest.fn()} />
+            <CMDKAction display={{label: 'Item 4'}} onAction={jest.fn()} />
+          </CMDKAction>
+        </GlobalActionsComponent>
+      );
+
+      await userEvent.click(await screen.findByRole('option', {name: 'See more'}));
+
+      expect(await screen.findByRole('option', {name: 'Item 3'})).toBeInTheDocument();
+      expect(screen.getByRole('option', {name: 'Item 4'})).toBeInTheDocument();
+      expect(screen.queryByRole('option', {name: 'See more'})).not.toBeInTheDocument();
+    });
+
+    it('clicking see more drills into the full limited group in search mode', async () => {
+      render(
+        <GlobalActionsComponent>
+          <CMDKAction display={{label: 'Static Group'}} limit={2}>
+            <CMDKAction display={{label: 'Item 1'}} onAction={jest.fn()} />
+            <CMDKAction display={{label: 'Item 2'}} onAction={jest.fn()} />
+            <CMDKAction display={{label: 'Item 3'}} onAction={jest.fn()} />
+            <CMDKAction display={{label: 'Item 4'}} onAction={jest.fn()} />
+          </CMDKAction>
+        </GlobalActionsComponent>
+      );
+
+      const input = await screen.findByRole('textbox', {name: 'Search commands'});
+      await userEvent.type(input, 'Item');
+      await userEvent.click(await screen.findByRole('option', {name: 'See more'}));
+
+      expect(await screen.findByRole('option', {name: 'Item 3'})).toBeInTheDocument();
+      expect(screen.getByRole('option', {name: 'Item 4'})).toBeInTheDocument();
+      expect(screen.queryByRole('option', {name: 'See more'})).not.toBeInTheDocument();
+    });
+
+    it('clicking see more preserves the active query in the expanded group', async () => {
+      render(
+        <GlobalActionsComponent>
+          <CMDKAction display={{label: 'Static Group'}} limit={2}>
+            <CMDKAction display={{label: 'Item 1'}} onAction={jest.fn()} />
+            <CMDKAction display={{label: 'Item 2'}} onAction={jest.fn()} />
+            <CMDKAction display={{label: 'Item 3'}} onAction={jest.fn()} />
+            <CMDKAction display={{label: 'Item 4'}} onAction={jest.fn()} />
+          </CMDKAction>
+        </GlobalActionsComponent>
+      );
+
+      const input = await screen.findByRole('textbox', {name: 'Search commands'});
+      await userEvent.type(input, 'Item');
+      await userEvent.click(await screen.findByRole('option', {name: 'See more'}));
+
+      await waitFor(() => expect(input).toHaveValue('Item'));
+      expect(await screen.findByRole('option', {name: 'Item 3'})).toBeInTheDocument();
+      expect(screen.getByRole('option', {name: 'Item 4'})).toBeInTheDocument();
     });
   });
 

--- a/static/app/components/commandPalette/ui/commandPalette.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.tsx
@@ -104,8 +104,8 @@ export function CommandPalette(props: CommandPaletteProps) {
       {node: CollectionTreeNode<CMDKActionData>; score: {matched: boolean; score: number}}
     >();
     scoreTree(currentNodes, scores, state.query.toLowerCase());
-    return flattenActions(currentNodes, scores);
-  }, [currentNodes, state.query]);
+    return flattenActions(currentNodes, scores, state.action !== null);
+  }, [currentNodes, state.action, state.query]);
 
   const analytics = useCommandPaletteAnalytics(actions.length);
 
@@ -537,7 +537,8 @@ function flattenActions(
   scores: Map<
     string,
     {node: CollectionTreeNode<CMDKActionData>; score: {matched: boolean; score: number}}
-  > | null
+  > | null,
+  sortLeafResults = false
 ): CMDKFlatItem[] {
   // Browse mode: show each top-level node and its direct children.
   if (!scores) {
@@ -593,13 +594,17 @@ function flattenActions(
     dfs(node);
   }
 
-  // Sort top-level groups to the front by their max-scoring child.
+  // Keep the existing top-level search ordering by default, but when we are
+  // inside an expanded group we also sort leaf actions by their own score so
+  // the full result list matches the limited preview ordering.
   collected.sort((a, b) => {
-    const maxScore = (n: CMDKFlatItem) =>
-      n.children.length > 0
-        ? Math.max(0, ...n.children.map(c => scores.get(c.key)?.score.score ?? 0))
-        : 0;
-    return maxScore(b) - maxScore(a);
+    const sortScore = (n: CMDKFlatItem) => {
+      if (n.children.length > 0) {
+        return Math.max(0, ...n.children.map(c => scores.get(c.key)?.score.score ?? 0));
+      }
+      return sortLeafResults ? (scores.get(n.key)?.score.score ?? 0) : 0;
+    };
+    return sortScore(b) - sortScore(a);
   });
 
   // Track processed keys so children beyond a group's limit cannot resurface as
@@ -660,7 +665,7 @@ function makeSeeMoreAction(node: CollectionTreeNode<CMDKActionData>): CMDKFlatIt
     key: `${node.key}:see-more`,
     listItemType: 'action',
     display: {
-      label: 'See more',
+      label: 'See all',
       icon: <IconArrow direction="right" />,
     },
   };

--- a/static/app/components/commandPalette/ui/commandPalette.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.tsx
@@ -661,11 +661,16 @@ function shouldShowSeeMore(childCount: number, limit?: number): boolean {
 
 function makeSeeMoreAction(node: CollectionTreeNode<CMDKActionData>): CMDKFlatItem {
   return {
-    ...node,
+    children: node.children,
     key: `${node.key}:see-more`,
+    parent: node.parent,
     listItemType: 'action',
+    limit: node.limit,
+    ref: node.ref,
+    keywords: node.keywords,
     display: {
-      label: 'See all',
+      details: node.display.details,
+      label: t('See all'),
       icon: <IconArrow direction="right" />,
     },
   };

--- a/static/app/components/commandPalette/ui/commandPalette.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.tsx
@@ -221,15 +221,23 @@ export function CommandPalette(props: CommandPaletteProps) {
       }
 
       const resultIndex = actions.indexOf(action);
+      const sourceAction = getSourceAction(action, actions);
+      const carriedQuery = isSeeMoreAction(action.key) ? state.query : undefined;
 
       if (action.children.length > 0) {
-        analytics.recordGroupAction(action, resultIndex);
+        analytics.recordGroupAction(sourceAction, resultIndex);
         if ('onAction' in action) {
           // Run the primary callback before drilling into the secondary actions.
           // Modifier keys are irrelevant here — this is not a link navigation.
           action.onAction();
         }
-        dispatch({type: 'push action', key: action.key, label: action.display.label});
+        dispatch({
+          type: 'push action',
+          key: getSourceActionKey(action.key),
+          label: sourceAction.display.label,
+          prompt: 'prompt' in sourceAction ? sourceAction.prompt : undefined,
+          query: carriedQuery,
+        });
         return;
       }
 
@@ -259,7 +267,7 @@ export function CommandPalette(props: CommandPaletteProps) {
 
       closeModal?.();
     },
-    [actions, analytics, closeModal, dispatch, navigate]
+    [actions, analytics, closeModal, dispatch, navigate, state.query]
   );
 
   const resultsListRef = useRef<HTMLDivElement>(null);
@@ -555,10 +563,12 @@ function flattenActions(
         if (!children.length) {
           continue;
         }
-        results.push({...node, listItemType: 'section'});
-        const visibleChildren =
-          node.limit === undefined ? children : children.slice(0, node.limit);
+        results.push(makeSectionAction(node));
+        const visibleChildren = getLimitedChildren(children, node.limit);
         results.push(...visibleChildren);
+        if (shouldShowSeeMore(children.length, node.limit)) {
+          results.push(makeSeeMoreAction(node));
+        }
       } else {
         results.push({...node, listItemType: 'action'});
       }
@@ -609,8 +619,7 @@ function flattenActions(
         (a, b) =>
           (scores.get(b.key)?.score.score ?? 0) - (scores.get(a.key)?.score.score ?? 0)
       );
-      const limitedMatches =
-        item.limit === undefined ? sortedMatches : sortedMatches.slice(0, item.limit);
+      const limitedMatches = getLimitedChildren(sortedMatches, item.limit);
       // Mark every child and their entire subtrees as seen — including those
       // beyond the limit — so neither over-limit children nor any of their
       // nested descendants can resurface as independent flat items later.
@@ -618,10 +627,11 @@ function flattenActions(
         markSubtreeSeen(child, seen);
       }
       return [
-        // Suffix the header key so a group used as both a section header and
-        // an action item inside its parent doesn't produce duplicate React keys.
-        {...item, key: `${item.key}:header`, listItemType: 'section'},
+        makeSectionAction(item),
         ...limitedMatches.map(c => ({...c, listItemType: 'action' as const})),
+        ...(shouldShowSeeMore(matched.length, item.limit)
+          ? [makeSeeMoreAction(item)]
+          : []),
       ];
     }
 
@@ -634,6 +644,53 @@ function flattenActions(
   });
 
   return flattened;
+}
+
+function getLimitedChildren<T>(children: T[], limit?: number): T[] {
+  return limit === undefined ? children : children.slice(0, limit);
+}
+
+function shouldShowSeeMore(childCount: number, limit?: number): boolean {
+  return typeof limit === 'number' && childCount > limit;
+}
+
+function makeSeeMoreAction(node: CollectionTreeNode<CMDKActionData>): CMDKFlatItem {
+  return {
+    ...node,
+    key: `${node.key}:see-more`,
+    listItemType: 'action',
+    display: {
+      label: 'See more',
+      icon: <IconArrow direction="right" />,
+    },
+  };
+}
+
+function makeSectionAction(node: CollectionTreeNode<CMDKActionData>): CMDKFlatItem {
+  return {
+    ...node,
+    key: `${node.key}:header`,
+    listItemType: 'section',
+  };
+}
+
+function getSourceAction(action: CMDKFlatItem, actions: CMDKFlatItem[]): CMDKFlatItem {
+  if (!isSeeMoreAction(action.key)) {
+    return action;
+  }
+
+  const sourceActionKey = getSourceActionKey(action.key);
+  return (
+    actions.find(candidate => candidate.key === `${sourceActionKey}:header`) ?? action
+  );
+}
+
+function isSeeMoreAction(key: string): boolean {
+  return key.endsWith(':see-more');
+}
+
+function getSourceActionKey(key: string): string {
+  return isSeeMoreAction(key) ? key.replace(/:see-more$/, '') : key;
 }
 
 function isEmptyResourceNode(node: CollectionTreeNode<CMDKActionData>): boolean {

--- a/static/app/components/commandPalette/ui/commandPaletteStateContext.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteStateContext.tsx
@@ -32,7 +32,13 @@ export type CommandPaletteAction =
   | {type: 'toggle modal'}
   | {type: 'reset'}
   | {query: string; type: 'set query'}
-  | {key: string; label: string; type: 'push action'; prompt?: string}
+  | {
+      key: string;
+      label: string;
+      type: 'push action';
+      prompt?: string;
+      query?: string;
+    }
   | {type: 'trigger action'}
   | {type: 'pop action'};
 
@@ -71,7 +77,7 @@ function commandPaletteReducer(
           },
           previous: state.action,
         },
-        query: '',
+        query: action.query ?? '',
       };
     case 'pop action':
       return {


### PR DESCRIPTION
When the count of children of an action exceed its limit prop, inject a "see all" action.

<img width="1254" height="490" alt="CleanShot 2026-04-13 at 21 21 44@2x" src="https://github.com/user-attachments/assets/aaf85779-b03e-4df6-8e51-4b81aa057153" />

When users click this action, they are taken to a dedicated view for that action (with the current query carried over, so that they don't need to re-type it). We achieve this essentially for free by cloning the parent action, removing the limit and using a "see all" label.
