### PR TITLE
feat(integrations): Send SLO lifecycle metrics to Sentry via SDK

### DIFF
--- a/src/sentry/integrations/utils/metrics.py
+++ b/src/sentry/integrations/utils/metrics.py
@@ -8,6 +8,7 @@ from types import TracebackType
 from typing import Any, Self
 
 import sentry_sdk
+from django.conf import settings
 
 from sentry import options
 from sentry.exceptions import RestrictedIPAddress
@@ -167,6 +168,7 @@ class EventLifecycle:
 
         sample_rate = 1.0
         metrics.incr(key, tags=tags, sample_rate=sample_rate)
+        sentry_sdk.metrics.count(f"{settings.SENTRY_METRICS_PREFIX}{key}", 1, attributes=dict(tags))
 
         sentry_sdk.set_tags(tags)
 


### PR DESCRIPTION
## Summary
- Adds a direct `sentry_sdk.metrics.count()` call in `EventLifecycle.record_event()` so SLO metrics (`started`, `success`, `halted`, `failure`) are sent to Sentry's metrics product at 100% with `integration_id` included as a tag.
- The existing `metrics.incr()` call (Datadog) is untouched.
- This bypasses the `DualWriteMetricsBackend` experimental backend which only samples at 5%, giving us full-fidelity SLO data in Sentry without the cardinality cost on Datadog.

Companion PR in seer: https://github.com/getsentry/seer/pull/new/telkins/slo-sentry-metrics

## Test plan
- [ ] Verify metric appears in Sentry Metrics explorer as `sentry.integrations.slo.started` with `integration_id` tag
- [ ] Confirm existing Datadog metrics are unaffected