### PR TITLE
fix(slack): Update explore unfurl chart size to 1200x400

### DIFF
--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -36,7 +36,7 @@ _logger = logging.getLogger(__name__)
 DEFAULT_PERIOD = "14d"
 TOP_N = 5
 
-EXPLORE_CHART_SIZE: ChartSize = {"width": 1600, "height": 1200}
+EXPLORE_CHART_SIZE: ChartSize = {"width": 1200, "height": 400}
 
 
 class ExploreDatasetDefaults(TypedDict):


### PR DESCRIPTION
Update the backend `EXPLORE_CHART_SIZE` from 1600x1200 to 1200x400 to match the frontend chartcuterie config. The backend override means we can adjust chart dimensions without redeploying chartcuterie.