### PR TITLE
feat(seer): Add ViewerContext authentication for Seer callbacks

### DIFF
--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -774,3 +774,59 @@ class HmacSignatureAuthentication(StandardAuthentication):
         sentry_sdk.get_isolation_scope().set_tag(self.sdk_tag_name, True)
 
         return (AnonymousUser(), token)
+
+
+class ViewerContextAuthentication(BaseAuthentication):
+    """Authenticate requests using signed X-Viewer-Context headers.
+
+    Used by trusted services (e.g., Seer) that echo back the viewer context
+    originally signed by Sentry. The signature is verified against
+    SEER_API_SHARED_SECRET. The user is resolved via user_service.get_user()
+    which works cross-silo (RPC-backed, cached).
+
+    Sets request.auth = None so that determine_access derives permissions
+    from the user's OrganizationMember role — identical to session auth.
+    """
+
+    def authenticate(self, request: Request) -> tuple[Any, Any] | None:
+        viewer_context = request.META.get("HTTP_X_VIEWER_CONTEXT")
+        viewer_signature = request.META.get("HTTP_X_VIEWER_CONTEXT_SIGNATURE")
+
+        if not viewer_context or not viewer_signature:
+            return None
+
+        secret = getattr(settings, "SEER_API_SHARED_SECRET", "")
+        if not secret:
+            return None
+
+        # Verify HMAC signature
+        context_bytes = viewer_context.encode("utf-8")
+        computed = hmac.new(
+            secret.encode("utf-8"),
+            context_bytes,
+            hashlib.sha256,
+        ).hexdigest()
+        if not constant_time_compare(computed, viewer_signature):
+            return None
+
+        # Parse viewer context and resolve user
+        try:
+            import orjson
+
+            data = orjson.loads(context_bytes)
+        except (ValueError, TypeError):
+            return None
+
+        user_id = data.get("user_id")
+        if not user_id:
+            return None
+
+        user = user_service.get_user(user_id=user_id)
+        if user is None:
+            return None
+
+        sentry_sdk.get_isolation_scope().set_tag("viewer_context_auth", True)
+
+        # Return None for auth to match session behavior —
+        # determine_access will derive scopes from org membership role.
+        return (user, None)

--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -6,7 +6,6 @@ import logging
 from collections.abc import Callable, Iterable
 from typing import Any, ClassVar
 
-import orjson
 import sentry_sdk
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
@@ -778,49 +777,30 @@ class HmacSignatureAuthentication(StandardAuthentication):
 
 
 class ViewerContextAuthentication(BaseAuthentication):
-    """Authenticate requests using signed X-Viewer-Context headers.
+    """Authenticate requests using X-Viewer-Context headers.
 
+    Accepts both JWT (HS256) and legacy JSON + HMAC signature formats.
     Used by trusted services (e.g., Seer) that echo back the viewer context
-    originally signed by Sentry. The signature is verified against
-    SEER_API_SHARED_SECRET. The user is resolved via user_service.get_user()
-    which works cross-silo (RPC-backed, cached).
+    originally signed by Sentry.
 
+    The user is resolved via user_service.get_user() (RPC-backed, cached).
     Sets request.auth = None so that determine_access derives permissions
     from the user's OrganizationMember role — identical to session auth.
     """
 
     def authenticate(self, request: Request) -> tuple[Any, Any] | None:
-        viewer_context = request.META.get("HTTP_X_VIEWER_CONTEXT")
-        viewer_signature = request.META.get("HTTP_X_VIEWER_CONTEXT_SIGNATURE")
+        from sentry.viewer_context import viewer_context_from_header
 
-        if not viewer_context or not viewer_signature:
+        header = request.META.get("HTTP_X_VIEWER_CONTEXT")
+        if not header:
             return None
 
-        secret = getattr(settings, "SEER_API_SHARED_SECRET", "")
-        if not secret:
+        signature = request.META.get("HTTP_X_VIEWER_CONTEXT_SIGNATURE")
+        vc = viewer_context_from_header(header, signature)
+        if vc is None or vc.user_id is None:
             return None
 
-        # Verify HMAC signature
-        context_bytes = viewer_context.encode("utf-8")
-        computed = hmac.new(
-            secret.encode("utf-8"),
-            context_bytes,
-            hashlib.sha256,
-        ).hexdigest()
-        if not constant_time_compare(computed, viewer_signature):
-            return None
-
-        # Parse viewer context and resolve user
-        try:
-            data = orjson.loads(context_bytes)
-        except (orjson.JSONDecodeError, ValueError, TypeError):
-            return None
-
-        user_id = data.get("user_id")
-        if not user_id:
-            return None
-
-        user = user_service.get_user(user_id=user_id)
+        user = user_service.get_user(user_id=vc.user_id)
         if user is None:
             return None
 

--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -801,7 +801,7 @@ class ViewerContextAuthentication(BaseAuthentication):
             return None
 
         user = user_service.get_user(user_id=vc.user_id)
-        if user is None:
+        if user is None or not user.is_active:
             return None
 
         sentry_sdk.get_isolation_scope().set_tag("viewer_context_auth", True)

--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -6,6 +6,7 @@ import logging
 from collections.abc import Callable, Iterable
 from typing import Any, ClassVar
 
+import orjson
 import sentry_sdk
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
@@ -811,10 +812,8 @@ class ViewerContextAuthentication(BaseAuthentication):
 
         # Parse viewer context and resolve user
         try:
-            import orjson
-
             data = orjson.loads(context_bytes)
-        except (ValueError, TypeError):
+        except (orjson.JSONDecodeError, ValueError, TypeError):
             return None
 
         user_id = data.get("user_id")

--- a/src/sentry/middleware/auth.py
+++ b/src/sentry/middleware/auth.py
@@ -13,6 +13,7 @@ from sentry.api.authentication import (
     ApiKeyAuthentication,
     OrgAuthTokenAuthentication,
     UserAuthTokenAuthentication,
+    ViewerContextAuthentication,
 )
 from sentry.users.models.userip import UserIP
 from sentry.utils.auth import AuthUserPasswordExpired, logger
@@ -78,6 +79,15 @@ class AuthenticationMiddleware(MiddlewareMixin):
                     # default to anonymous user and use IP ratelimit
                     request.user, request.auth = SimpleLazyObject(lambda: get_user(request)), None
                 return
+
+        # Try viewer context authentication (signed headers from trusted services)
+        try:
+            result = ViewerContextAuthentication().authenticate(request)
+        except AuthenticationFailed:
+            result = None
+        if result:
+            request.user, request.auth = result
+            return
 
         # default to anonymous user and use IP ratelimit
         request.user, request.auth = SimpleLazyObject(lambda: get_user(request)), None

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -20,8 +20,8 @@ from sentry.seer.explorer.client_utils import (
     ExplorerRunsRequest,
     ExplorerUpdateRequest,
     collect_user_org_context,
-    create_explorer_api_token,
     fetch_run_status,
+    get_proxy_headers,
     make_explorer_chat_request,
     make_explorer_runs_request,
     make_explorer_update_request,
@@ -272,13 +272,6 @@ class SeerExplorerClient:
             raise ValueError("artifact_key and artifact_schema must be provided together")
 
         user_org_context = collect_user_org_context(self.user, self.organization, request=request)
-        user_auth_token = (
-            create_explorer_api_token(self.user, self.organization)
-            if self.enable_code_mode_tools
-            and self.user
-            and not isinstance(self.user, AnonymousUser)
-            else None
-        )
 
         chat_body: ExplorerChatRequest = ExplorerChatRequest(
             organization_id=self.organization.id,
@@ -292,7 +285,7 @@ class SeerExplorerClient:
             is_interactive=self.is_interactive,
             enable_coding=self.enable_coding,
             enable_code_mode_tools=self.enable_code_mode_tools,
-            user_auth_token=user_auth_token,
+            proxy_headers=get_proxy_headers() if self.enable_code_mode_tools else None,
         )
 
         if self.reasoning_effort is not None:
@@ -384,14 +377,6 @@ class SeerExplorerClient:
         if bool(artifact_schema) != bool(artifact_key):
             raise ValueError("artifact_key and artifact_schema must be provided together")
 
-        user_auth_token = (
-            create_explorer_api_token(self.user, self.organization)
-            if self.enable_code_mode_tools
-            and self.user
-            and not isinstance(self.user, AnonymousUser)
-            else None
-        )
-
         chat_body: ExplorerChatRequest = ExplorerChatRequest(
             organization_id=self.organization.id,
             query=prompt,
@@ -402,7 +387,7 @@ class SeerExplorerClient:
             is_interactive=self.is_interactive,
             enable_coding=self.enable_coding,
             enable_code_mode_tools=self.enable_code_mode_tools,
-            user_auth_token=user_auth_token,
+            proxy_headers=get_proxy_headers() if self.enable_code_mode_tools else None,
         )
 
         if prompt_metadata:

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -315,8 +315,6 @@ def get_proxy_headers() -> dict[str, str] | None:
     if not settings.SEER_API_SHARED_SECRET:
         return None
 
-    import orjson
-
     context_bytes = orjson.dumps(ctx.serialize())
     signature = sign_viewer_context(context_bytes)
     return {

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -9,13 +9,12 @@ from __future__ import annotations
 
 import logging
 import time
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Any, NotRequired, TypedDict
 
 import orjson
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
-from django.utils import timezone
 from rest_framework.request import Request
 from urllib3 import BaseHTTPResponse, HTTPConnectionPool
 
@@ -71,7 +70,7 @@ class ExplorerChatRequest(TypedDict):
     metadata: NotRequired[dict[str, Any]]
     is_context_engine_enabled: NotRequired[bool]
     max_iterations: NotRequired[int]
-    user_auth_token: NotRequired[str | None]
+    proxy_headers: NotRequired[dict[str, str] | None]
 
 
 class ExplorerRunsRequest(TypedDict):
@@ -301,32 +300,29 @@ def collect_user_org_context(
     }
 
 
-def create_explorer_api_token(user: SentryUser | RpcUser, organization: Organization) -> str | None:
-    """Create a short-lived read-only API token for Seer to call back into Sentry."""
-    try:
-        from sentry.models.apitoken import ApiToken
-        from sentry.types.token import AuthTokenType
-        from sentry.users.models.user import User as UserModel
+def get_proxy_headers() -> dict[str, str] | None:
+    """Build auth headers for Seer to echo back to Sentry on callbacks.
 
-        real_user = UserModel.objects.get(id=user.id)
-        token = ApiToken.objects.create(
-            user=real_user,
-            token_type=AuthTokenType.USER,
-            scoping_organization_id=organization.id,
-            scope_list=[
-                "org:read",
-                "project:read",
-                "event:read",
-                "alerts:read",
-                "member:read",
-                "team:read",
-            ],
-            expires_at=timezone.now() + timedelta(hours=1),
-        )
-        return token.plaintext_token
-    except Exception:
-        logger.exception("Failed to create short-lived API token for Seer Explorer")
+    Returns a dict of headers (X-Viewer-Context + signature) or None.
+    """
+    from sentry.seer.signed_seer_api import sign_viewer_context
+    from sentry.viewer_context import get_viewer_context
+
+    ctx = get_viewer_context()
+    if ctx is None or ctx.user_id is None:
         return None
+
+    if not settings.SEER_API_SHARED_SECRET:
+        return None
+
+    import orjson
+
+    context_bytes = orjson.dumps(ctx.serialize())
+    signature = sign_viewer_context(context_bytes)
+    return {
+        "X-Viewer-Context": context_bytes.decode("utf-8"),
+        "X-Viewer-Context-Signature": signature,
+    }
 
 
 def fetch_run_status(run_id: int, organization: Organization) -> SeerRunState:

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -1,6 +1,7 @@
 import uuid
 from datetime import UTC, datetime, timedelta
 
+import orjson
 import pytest
 from django.test import RequestFactory, override_settings
 from django.urls import resolve
@@ -1013,8 +1014,6 @@ class TestViewerContextAuthentication(TestCase):
 
     @override_settings(SEER_API_SHARED_SECRET=SHARED_SECRET)
     def test_valid_viewer_context_authenticates(self) -> None:
-        import orjson
-
         context = orjson.dumps({"user_id": self.user.id, "actor_type": "user"}).decode()
         signature = self._sign_context(context)
 
@@ -1028,8 +1027,6 @@ class TestViewerContextAuthentication(TestCase):
 
     @override_settings(SEER_API_SHARED_SECRET=SHARED_SECRET)
     def test_invalid_signature_returns_none(self) -> None:
-        import orjson
-
         context = orjson.dumps({"user_id": self.user.id, "actor_type": "user"}).decode()
 
         request = self._make_request(viewer_context=context, viewer_signature="bad-signature")
@@ -1039,8 +1036,6 @@ class TestViewerContextAuthentication(TestCase):
 
     @override_settings(SEER_API_SHARED_SECRET=SHARED_SECRET)
     def test_missing_signature_returns_none(self) -> None:
-        import orjson
-
         context = orjson.dumps({"user_id": self.user.id, "actor_type": "user"}).decode()
 
         request = self._make_request(viewer_context=context)
@@ -1056,8 +1051,6 @@ class TestViewerContextAuthentication(TestCase):
 
     @override_settings(SEER_API_SHARED_SECRET=SHARED_SECRET)
     def test_unknown_user_id_returns_none(self) -> None:
-        import orjson
-
         context = orjson.dumps({"user_id": 999999999, "actor_type": "user"}).decode()
         signature = self._sign_context(context)
 
@@ -1068,8 +1061,6 @@ class TestViewerContextAuthentication(TestCase):
 
     @override_settings(SEER_API_SHARED_SECRET=SHARED_SECRET)
     def test_missing_user_id_returns_none(self) -> None:
-        import orjson
-
         context = orjson.dumps({"actor_type": "system"}).decode()
         signature = self._sign_context(context)
 
@@ -1080,8 +1071,6 @@ class TestViewerContextAuthentication(TestCase):
 
     @override_settings(SEER_API_SHARED_SECRET="")
     def test_empty_secret_returns_none(self) -> None:
-        import orjson
-
         context = orjson.dumps({"user_id": self.user.id, "actor_type": "user"}).decode()
 
         request = self._make_request(viewer_context=context, viewer_signature="anything")

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -17,6 +17,7 @@ from sentry.api.authentication import (
     RelayAuthentication,
     RpcSignatureAuthentication,
     UserAuthTokenAuthentication,
+    ViewerContextAuthentication,
     compare_service_signature,
 )
 from sentry.auth.services.auth import AuthenticatedToken
@@ -982,3 +983,113 @@ class TestAuthenticateHeader:
     def test_dsn_authentication_returns_dsn_with_realm(self) -> None:
         auth = DSNAuthentication()
         assert auth.authenticate_header(_drf_request()) == 'Dsn realm="api"'
+
+
+@no_silo_test
+class TestViewerContextAuthentication(TestCase):
+    SHARED_SECRET = "test-seer-api-shared-secret"
+
+    def _sign_context(self, context_json: str) -> str:
+        import hashlib
+        import hmac as hmac_mod
+
+        return hmac_mod.new(
+            self.SHARED_SECRET.encode("utf-8"),
+            context_json.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+
+    def _make_request(
+        self,
+        viewer_context: str | None = None,
+        viewer_signature: str | None = None,
+        authorization: str | None = None,
+    ) -> Request:
+        headers: dict[str, str] = {}
+        if viewer_context is not None:
+            headers["HTTP_X_VIEWER_CONTEXT"] = viewer_context
+        if viewer_signature is not None:
+            headers["HTTP_X_VIEWER_CONTEXT_SIGNATURE"] = viewer_signature
+        if authorization is not None:
+            headers["HTTP_AUTHORIZATION"] = authorization
+
+        req = RequestFactory().get("/api/0/organizations/", **headers)
+        return drf_request_from_request(req)
+
+    @override_settings(SEER_API_SHARED_SECRET=SHARED_SECRET)
+    def test_valid_viewer_context_authenticates(self) -> None:
+        import orjson
+
+        context = orjson.dumps({"user_id": self.user.id, "actor_type": "user"}).decode()
+        signature = self._sign_context(context)
+
+        request = self._make_request(viewer_context=context, viewer_signature=signature)
+        result = ViewerContextAuthentication().authenticate(request)
+
+        assert result is not None
+        user, auth = result
+        assert user.id == self.user.id
+        assert auth is None
+
+    @override_settings(SEER_API_SHARED_SECRET=SHARED_SECRET)
+    def test_invalid_signature_returns_none(self) -> None:
+        import orjson
+
+        context = orjson.dumps({"user_id": self.user.id, "actor_type": "user"}).decode()
+
+        request = self._make_request(viewer_context=context, viewer_signature="bad-signature")
+        result = ViewerContextAuthentication().authenticate(request)
+
+        assert result is None
+
+    @override_settings(SEER_API_SHARED_SECRET=SHARED_SECRET)
+    def test_missing_signature_returns_none(self) -> None:
+        import orjson
+
+        context = orjson.dumps({"user_id": self.user.id, "actor_type": "user"}).decode()
+
+        request = self._make_request(viewer_context=context)
+        result = ViewerContextAuthentication().authenticate(request)
+
+        assert result is None
+
+    def test_missing_headers_returns_none(self) -> None:
+        request = self._make_request()
+        result = ViewerContextAuthentication().authenticate(request)
+
+        assert result is None
+
+    @override_settings(SEER_API_SHARED_SECRET=SHARED_SECRET)
+    def test_unknown_user_id_returns_none(self) -> None:
+        import orjson
+
+        context = orjson.dumps({"user_id": 999999999, "actor_type": "user"}).decode()
+        signature = self._sign_context(context)
+
+        request = self._make_request(viewer_context=context, viewer_signature=signature)
+        result = ViewerContextAuthentication().authenticate(request)
+
+        assert result is None
+
+    @override_settings(SEER_API_SHARED_SECRET=SHARED_SECRET)
+    def test_missing_user_id_returns_none(self) -> None:
+        import orjson
+
+        context = orjson.dumps({"actor_type": "system"}).decode()
+        signature = self._sign_context(context)
+
+        request = self._make_request(viewer_context=context, viewer_signature=signature)
+        result = ViewerContextAuthentication().authenticate(request)
+
+        assert result is None
+
+    @override_settings(SEER_API_SHARED_SECRET="")
+    def test_empty_secret_returns_none(self) -> None:
+        import orjson
+
+        context = orjson.dumps({"user_id": self.user.id, "actor_type": "user"}).decode()
+
+        request = self._make_request(viewer_context=context, viewer_signature="anything")
+        result = ViewerContextAuthentication().authenticate(request)
+
+        assert result is None

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -1088,3 +1088,30 @@ class TestViewerContextAuthentication(TestCase):
         result = ViewerContextAuthentication().authenticate(request)
 
         assert result is None
+
+    @override_settings(SEER_API_SHARED_SECRET=SHARED_SECRET)
+    def test_jwt_viewer_context_authenticates(self) -> None:
+        from sentry.viewer_context import ActorType, ViewerContext, encode_viewer_context
+
+        vc = ViewerContext(user_id=self.user.id, actor_type=ActorType.USER)
+        token = encode_viewer_context(vc)
+
+        request = self._make_request(viewer_context=token)
+        result = ViewerContextAuthentication().authenticate(request)
+
+        assert result is not None
+        user, auth = result
+        assert user.id == self.user.id
+        assert auth is None
+
+    @override_settings(SEER_API_SHARED_SECRET=SHARED_SECRET)
+    def test_jwt_wrong_key_returns_none(self) -> None:
+        from sentry.viewer_context import ActorType, ViewerContext, encode_viewer_context
+
+        vc = ViewerContext(user_id=self.user.id, actor_type=ActorType.USER)
+        token = encode_viewer_context(vc, key="wrong-key")
+
+        request = self._make_request(viewer_context=token)
+        result = ViewerContextAuthentication().authenticate(request)
+
+        assert result is None

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -1003,17 +1003,12 @@ class TestViewerContextAuthentication(TestCase):
         self,
         viewer_context: str | None = None,
         viewer_signature: str | None = None,
-        authorization: str | None = None,
     ) -> Request:
-        headers: dict[str, str] = {}
+        req = RequestFactory().get("/api/0/organizations/")
         if viewer_context is not None:
-            headers["HTTP_X_VIEWER_CONTEXT"] = viewer_context
+            req.META["HTTP_X_VIEWER_CONTEXT"] = viewer_context
         if viewer_signature is not None:
-            headers["HTTP_X_VIEWER_CONTEXT_SIGNATURE"] = viewer_signature
-        if authorization is not None:
-            headers["HTTP_AUTHORIZATION"] = authorization
-
-        req = RequestFactory().get("/api/0/organizations/", **headers)
+            req.META["HTTP_X_VIEWER_CONTEXT_SIGNATURE"] = viewer_signature
         return drf_request_from_request(req)
 
     @override_settings(SEER_API_SHARED_SECRET=SHARED_SECRET)


### PR DESCRIPTION
## Summary
- Adds `ViewerContextAuthentication` class that validates signed `X-Viewer-Context` headers from trusted services (Seer), resolving user identity via `user_service.get_user()` (RPC-safe, works in cell mode)
- Replaces short-lived API token creation (`create_explorer_api_token`) which required control silo access and caused `SiloLimit.AvailabilityError` in production cell-mode endpoints
- Explorer client builds a `proxy_headers` dict with signed viewer context and passes it to Seer, which echoes all headers back on callbacks

## Context
Sentry already signs `X-Viewer-Context` headers with `SEER_API_SHARED_SECRET` on every call to Seer. The new authenticator verifies the signature and resolves permissions from org membership — identical to session auth. No new secrets, no cross-silo RPC, no token lifecycle management.

The `proxy_headers` approach supports both viewer context (internal/session users) and bearer tokens (future external MCP consumers) without separate code paths.

Companion PR: getsentry/seer#5750

## Test plan
- [x] 7 new tests for `ViewerContextAuthentication` (valid sig, invalid sig, missing headers, unknown user, etc.)
- [ ] Manual test with Explorer code mode tools enabled
- [ ] Verify no regression for session auth and bearer token auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)