### PR TITLE
fix(cmdk): tie-break equal search scores by length

### DIFF
--- a/static/app/components/commandPalette/ui/commandPalette.spec.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.spec.tsx
@@ -826,9 +826,31 @@ describe('CommandPalette', () => {
       expect(expandedOptions.slice(0, 4)).toEqual([
         'java-spring-boot',
         'java-spring-boot-test',
-        'gkojavascript-nextjs',
         'gkojavascript-astro',
+        'gkojavascript-nextjs',
       ]);
+    });
+
+    it('breaks equal search scores by shorter label length', async () => {
+      render(
+        <GlobalActionsComponent>
+          <CMDKAction display={{label: 'Paths'}} limit={2}>
+            <CMDKAction display={{label: 'path-cccccc'}} onAction={jest.fn()} />
+            <CMDKAction display={{label: 'path-aaa'}} onAction={jest.fn()} />
+            <CMDKAction display={{label: 'path-b'}} onAction={jest.fn()} />
+          </CMDKAction>
+        </GlobalActionsComponent>
+      );
+
+      const input = await screen.findByRole('textbox', {name: 'Search commands'});
+      await userEvent.type(input, 'path');
+
+      const options = screen
+        .getAllByRole('option')
+        .filter(el => !el.hasAttribute('aria-disabled'))
+        .map(option => option.textContent);
+
+      expect(options).toEqual(['path-b', 'path-aaa', 'See all']);
     });
   });
 

--- a/static/app/components/commandPalette/ui/commandPalette.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.tsx
@@ -76,11 +76,6 @@ interface CommandPaletteScore {
   score: number;
 }
 
-interface CommandPaletteScoredNode {
-  node: CollectionTreeNode<CMDKActionData>;
-  score: CommandPaletteScore;
-}
-
 interface CommandPaletteProps {
   closeModal?: () => void;
 }
@@ -110,7 +105,7 @@ export function CommandPalette(props: CommandPaletteProps) {
       return flattenActions(currentNodes, null);
     }
 
-    const scores = new Map<string, CommandPaletteScoredNode>();
+    const scores = new Map<string, CommandPaletteScore>();
     scoreTree(currentNodes, scores, state.query.toLowerCase());
     return flattenActions(currentNodes, scores, state.action !== null);
   }, [currentNodes, state.action, state.query]);
@@ -517,22 +512,29 @@ function compareCommandPaletteScores(
   a: CommandPaletteScore | undefined,
   b: CommandPaletteScore | undefined
 ): number {
-  const scoreDiff = (b?.score ?? 0) - (a?.score ?? 0);
-  if (scoreDiff !== 0) {
-    return scoreDiff;
+  return (
+    (b?.score ?? 0) - (a?.score ?? 0) || (a?.length ?? Infinity) - (b?.length ?? Infinity)
+  );
+}
+
+function getBestItemScore(
+  item: CMDKFlatItem,
+  scores: Map<string, CommandPaletteScore>,
+  sortLeafResults: boolean
+): CommandPaletteScore | undefined {
+  if (item.children.length > 0) {
+    return item.children
+      .map(child => scores.get(child.key))
+      .filter(score => score !== undefined)
+      .sort(compareCommandPaletteScores)[0];
   }
 
-  const lengthDiff = (a?.length ?? Infinity) - (b?.length ?? Infinity);
-  if (lengthDiff !== 0) {
-    return lengthDiff;
-  }
-
-  return 0;
+  return sortLeafResults ? scores.get(item.key) : undefined;
 }
 
 function scoreTree(
   nodes: Array<CollectionTreeNode<CMDKActionData>>,
-  scores: Map<string, CommandPaletteScoredNode>,
+  scores: Map<string, CommandPaletteScore>,
   query: string
 ): void {
   function dfs(node: CollectionTreeNode<CMDKActionData>) {
@@ -541,7 +543,7 @@ function scoreTree(
     }
     const s = scoreNode(query, node);
     if (s.matched) {
-      scores.set(node.key, {node, score: s});
+      scores.set(node.key, s);
     }
   }
   for (const node of nodes) {
@@ -561,7 +563,7 @@ function markSubtreeSeen(
 
 function flattenActions(
   nodes: Array<CollectionTreeNode<CMDKActionData>>,
-  scores: Map<string, CommandPaletteScoredNode> | null,
+  scores: Map<string, CommandPaletteScore> | null,
   sortLeafResults = false
 ): CMDKFlatItem[] {
   // Browse mode: show each top-level node and its direct children.
@@ -621,24 +623,12 @@ function flattenActions(
   // Keep the existing top-level search ordering by default, but when we are
   // inside an expanded group we also sort leaf actions by their own score so
   // the full result list matches the limited preview ordering.
-  collected.sort((a, b) => {
-    const sortScore = (n: CMDKFlatItem): CommandPaletteScore | undefined => {
-      if (n.children.length > 0) {
-        return n.children
-          .map(c => scores.get(c.key)?.score)
-          .reduce<CommandPaletteScore | undefined>((best, current) => {
-            if (!current) {
-              return best;
-            }
-            return !best || compareCommandPaletteScores(current, best) < 0
-              ? current
-              : best;
-          }, undefined);
-      }
-      return sortLeafResults ? scores.get(n.key)?.score : undefined;
-    };
-    return compareCommandPaletteScores(sortScore(a), sortScore(b));
-  });
+  collected.sort((a, b) =>
+    compareCommandPaletteScores(
+      getBestItemScore(a, scores, sortLeafResults),
+      getBestItemScore(b, scores, sortLeafResults)
+    )
+  );
 
   // Track processed keys so children beyond a group's limit cannot resurface as
   // standalone flat items later in the traversal.
@@ -650,11 +640,11 @@ function flattenActions(
 
     if (item.children.length > 0) {
       const matched = item.children.filter(
-        c => scores.get(c.key)?.score.matched && !isEmptyResourceNode(c)
+        c => scores.get(c.key)?.matched && !isEmptyResourceNode(c)
       );
       if (!matched.length) return [];
       const sortedMatches = matched.sort((a, b) =>
-        compareCommandPaletteScores(scores.get(a.key)?.score, scores.get(b.key)?.score)
+        compareCommandPaletteScores(scores.get(a.key), scores.get(b.key))
       );
       const limitedMatches = getLimitedChildren(sortedMatches, item.limit);
       // Mark every child and their entire subtrees as seen — including those
@@ -677,7 +667,7 @@ function flattenActions(
     if (isEmptyResourceNode(item)) {
       return [];
     }
-    return scores.get(item.key)?.score.matched ? [{...item, listItemType: 'action'}] : [];
+    return scores.get(item.key)?.matched ? [{...item, listItemType: 'action'}] : [];
   });
 
   return flattened;

--- a/static/app/components/commandPalette/ui/commandPalette.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.tsx
@@ -70,6 +70,17 @@ type CMDKFlatItem = CollectionTreeNode<CMDKActionData> & {
   listItemType: 'action' | 'section';
 };
 
+interface CommandPaletteScore {
+  length: number;
+  matched: boolean;
+  score: number;
+}
+
+interface CommandPaletteScoredNode {
+  node: CollectionTreeNode<CMDKActionData>;
+  score: CommandPaletteScore;
+}
+
 interface CommandPaletteProps {
   closeModal?: () => void;
 }
@@ -99,10 +110,7 @@ export function CommandPalette(props: CommandPaletteProps) {
       return flattenActions(currentNodes, null);
     }
 
-    const scores = new Map<
-      string,
-      {node: CollectionTreeNode<CMDKActionData>; score: {matched: boolean; score: number}}
-    >();
+    const scores = new Map<string, CommandPaletteScoredNode>();
     scoreTree(currentNodes, scores, state.query.toLowerCase());
     return flattenActions(currentNodes, scores, state.action !== null);
   }, [currentNodes, state.action, state.query]);
@@ -479,7 +487,7 @@ function presortBySlotRef(
 function scoreNode(
   query: string,
   node: CollectionTreeNode<CMDKActionData>
-): {matched: boolean; score: number} {
+): CommandPaletteScore {
   const label = node.display.label;
   const details = node.display.details ?? '';
   const keywords = node.keywords ?? [];
@@ -488,24 +496,43 @@ function scoreNode(
   // fzf's built-in exact-match bonus fire naturally (e.g. query === label)
   // and avoids false cross-field subsequence matches from string concatenation.
   let best = -Infinity;
+  let bestLength = Infinity;
   let matched = false;
   for (const candidate of [label, details, ...keywords]) {
     if (!candidate) continue;
     const result = fzf(candidate, query, false);
     if (result.end !== -1 && result.score > best) {
       best = result.score;
+      bestLength = candidate.length;
+      matched = true;
+    } else if (result.end !== -1 && result.score === best) {
+      bestLength = Math.min(bestLength, candidate.length);
       matched = true;
     }
   }
-  return {matched, score: matched ? best : 0};
+  return {length: matched ? bestLength : Infinity, matched, score: matched ? best : 0};
+}
+
+function compareCommandPaletteScores(
+  a: CommandPaletteScore | undefined,
+  b: CommandPaletteScore | undefined
+): number {
+  const scoreDiff = (b?.score ?? 0) - (a?.score ?? 0);
+  if (scoreDiff !== 0) {
+    return scoreDiff;
+  }
+
+  const lengthDiff = (a?.length ?? Infinity) - (b?.length ?? Infinity);
+  if (lengthDiff !== 0) {
+    return lengthDiff;
+  }
+
+  return 0;
 }
 
 function scoreTree(
   nodes: Array<CollectionTreeNode<CMDKActionData>>,
-  scores: Map<
-    string,
-    {node: CollectionTreeNode<CMDKActionData>; score: {matched: boolean; score: number}}
-  >,
+  scores: Map<string, CommandPaletteScoredNode>,
   query: string
 ): void {
   function dfs(node: CollectionTreeNode<CMDKActionData>) {
@@ -534,10 +561,7 @@ function markSubtreeSeen(
 
 function flattenActions(
   nodes: Array<CollectionTreeNode<CMDKActionData>>,
-  scores: Map<
-    string,
-    {node: CollectionTreeNode<CMDKActionData>; score: {matched: boolean; score: number}}
-  > | null,
+  scores: Map<string, CommandPaletteScoredNode> | null,
   sortLeafResults = false
 ): CMDKFlatItem[] {
   // Browse mode: show each top-level node and its direct children.
@@ -598,13 +622,22 @@ function flattenActions(
   // inside an expanded group we also sort leaf actions by their own score so
   // the full result list matches the limited preview ordering.
   collected.sort((a, b) => {
-    const sortScore = (n: CMDKFlatItem) => {
+    const sortScore = (n: CMDKFlatItem): CommandPaletteScore | undefined => {
       if (n.children.length > 0) {
-        return Math.max(0, ...n.children.map(c => scores.get(c.key)?.score.score ?? 0));
+        return n.children
+          .map(c => scores.get(c.key)?.score)
+          .reduce<CommandPaletteScore | undefined>((best, current) => {
+            if (!current) {
+              return best;
+            }
+            return !best || compareCommandPaletteScores(current, best) < 0
+              ? current
+              : best;
+          }, undefined);
       }
-      return sortLeafResults ? (scores.get(n.key)?.score.score ?? 0) : 0;
+      return sortLeafResults ? scores.get(n.key)?.score : undefined;
     };
-    return sortScore(b) - sortScore(a);
+    return compareCommandPaletteScores(sortScore(a), sortScore(b));
   });
 
   // Track processed keys so children beyond a group's limit cannot resurface as
@@ -620,9 +653,8 @@ function flattenActions(
         c => scores.get(c.key)?.score.matched && !isEmptyResourceNode(c)
       );
       if (!matched.length) return [];
-      const sortedMatches = matched.sort(
-        (a, b) =>
-          (scores.get(b.key)?.score.score ?? 0) - (scores.get(a.key)?.score.score ?? 0)
+      const sortedMatches = matched.sort((a, b) =>
+        compareCommandPaletteScores(scores.get(a.key)?.score, scores.get(b.key)?.score)
       );
       const limitedMatches = getLimitedChildren(sortedMatches, item.limit);
       // Mark every child and their entire subtrees as seen — including those


### PR DESCRIPTION
Tie break equal search scores by preferring shorter matches or instances where the query likely has a larger overlap with the searched string