### PR TITLE
chore(slack-seer): Tweak suggested prompts for DMs

### DIFF
--- a/src/sentry/integrations/slack/webhooks/event.py
+++ b/src/sentry/integrations/slack/webhooks/event.py
@@ -48,20 +48,20 @@ _logger = logging.getLogger(__name__)
 
 _SEER_STARTING_PROMPTS = [
     {
-        "title": "Summarize recent issues",
-        "message": "What are the most important unresolved issues in my projects right now?",
+        "title": "👾  What's breaking right now?",
+        "message": "What are the most critical unresolved errors happening in my projects right now?",
     },
     {
-        "title": "Investigate an error",
-        "message": "Help me investigate what's causing errors in my project.",
+        "title": "⚡️  Locate the bottlenecks",
+        "message": "Find the slowest endpoints and biggest performance bottlenecks in the last 24 hours.",
     },
     {
-        "title": "Explain a stack trace",
-        "message": "Can you explain the root cause of this stack trace?",
+        "title": "🛰  Run a diagnostics scan",
+        "message": "Give me a full health summary of my projects — top errors, performance trends, and anything that needs attention.",
     },
     {
-        "title": "Find performance bottlenecks",
-        "message": "What are the slowest endpoints or pages in my projects?",
+        "title": "🪐  Weekly mission debrief",
+        "message": "Summarize what's broken, improved and any notable changes across my projects over the last 7 days.",
     },
 ]
 _SEER_LOADING_MESSAGES = [


### PR DESCRIPTION
Workshopped these with with Seer to get something more interesting across, the prompts are direct, the titles are more spacey and playful. Open to suggestions though.

Meaningful changes are that all of these prompts will provide good responses. Previous ones like "summarize a stack trace" will always get the response "what stack trace, I don't see one attached" which is useless