### PR TITLE
feat(autofix): Upgrade explorer-based autofix to use Sonnet

### DIFF
--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -205,7 +205,7 @@ def get_step_webhook_action_type(step: AutofixStep, is_completed: bool) -> SeerA
 
 def get_autofix_explorer_client(
     group: Group,
-    intelligence_level: Literal["low", "medium", "high"] = "low",
+    intelligence_level: Literal["low", "medium", "high"] = "medium",
     enable_coding: bool = False,
 ) -> SeerExplorerClient:
     from sentry.seer.autofix.on_completion_hook import (
@@ -230,7 +230,7 @@ def trigger_autofix_explorer(
     referrer: AutofixReferrer,
     run_id: int | None = None,
     stopping_point: AutofixStoppingPoint | None = None,
-    intelligence_level: Literal["low", "medium", "high"] = "low",
+    intelligence_level: Literal["low", "medium", "high"] = "medium",
     user_context: str | None = None,
     insert_index: int | None = None,
 ) -> int:

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -207,6 +207,8 @@ def get_autofix_explorer_client(
     group: Group,
     intelligence_level: Literal["low", "medium", "high"] = "low",
     enable_coding: bool = False,
+    model: str | None = None,
+    reasoning_effort: str | None = None,
 ) -> SeerExplorerClient:
     from sentry.seer.autofix.on_completion_hook import (
         AutofixOnCompletionHook,  # nested to avoid circular import
@@ -221,6 +223,8 @@ def get_autofix_explorer_client(
         intelligence_level=intelligence_level,
         on_completion_hook=AutofixOnCompletionHook,
         enable_coding=enable_coding,
+        model=model,
+        reasoning_effort=reasoning_effort,
     )
 
 
@@ -233,6 +237,8 @@ def trigger_autofix_explorer(
     intelligence_level: Literal["low", "medium", "high"] = "low",
     user_context: str | None = None,
     insert_index: int | None = None,
+    model: str | None = None,
+    reasoning_effort: str | None = None,
 ) -> int:
     """
     Start or continue an Explorer-based autofix run.
@@ -242,6 +248,8 @@ def trigger_autofix_explorer(
         step: Which autofix step to run
         run_id: Existing run ID to continue, or None for new run
         stopping_point: Where to stop the automated pipeline (only used for new runs)
+        model: Optional model override (e.g. "claude-sonnet-4-6")
+        reasoning_effort: Optional reasoning effort override (e.g. "medium")
 
     Returns:
         The run ID
@@ -262,6 +270,8 @@ def trigger_autofix_explorer(
         group,
         intelligence_level=intelligence_level,
         enable_coding=config.enable_coding,
+        model=model,
+        reasoning_effort=reasoning_effort,
     )
 
     prompt = build_step_prompt(step, group, user_context)

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -205,7 +205,7 @@ def get_step_webhook_action_type(step: AutofixStep, is_completed: bool) -> SeerA
 
 def get_autofix_explorer_client(
     group: Group,
-    intelligence_level: Literal["low", "medium", "high"] = "medium",
+    intelligence_level: Literal["low", "medium", "high"] = "low",
     enable_coding: bool = False,
 ) -> SeerExplorerClient:
     from sentry.seer.autofix.on_completion_hook import (
@@ -230,7 +230,7 @@ def trigger_autofix_explorer(
     referrer: AutofixReferrer,
     run_id: int | None = None,
     stopping_point: AutofixStoppingPoint | None = None,
-    intelligence_level: Literal["low", "medium", "high"] = "medium",
+    intelligence_level: Literal["low", "medium", "high"] = "low",
     user_context: str | None = None,
     insert_index: int | None = None,
 ) -> int:

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -199,6 +199,8 @@ class SeerExplorerClient:
         enable_coding: bool = False,
         enable_code_mode_tools: bool = False,
         max_iterations: int | None = None,
+        model: str | None = None,
+        reasoning_effort: str | None = None,
     ):
         self.organization = organization
         self.user = user
@@ -211,6 +213,8 @@ class SeerExplorerClient:
         self.is_interactive = is_interactive
         self.enable_code_mode_tools = enable_code_mode_tools
         self.max_iterations = max_iterations
+        self.model = model
+        self.reasoning_effort = reasoning_effort
 
         if enable_coding and not organization.get_option("sentry:enable_seer_coding", True):
             raise SeerPermissionError("Seer coding is not enabled for this organization")
@@ -295,6 +299,12 @@ class SeerExplorerClient:
 
         if self.max_iterations is not None:
             chat_body["max_iterations"] = self.max_iterations
+
+        if self.model is not None:
+            chat_body["model"] = self.model
+
+        if self.reasoning_effort is not None:
+            chat_body["reasoning_effort"] = self.reasoning_effort
 
         if self.project:
             chat_body["project_id"] = self.project.id

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -71,6 +71,8 @@ class ExplorerChatRequest(TypedDict):
     is_context_engine_enabled: NotRequired[bool]
     max_iterations: NotRequired[int]
     user_auth_token: NotRequired[str | None]
+    model: NotRequired[str]
+    reasoning_effort: NotRequired[str]
 
 
 class ExplorerRunsRequest(TypedDict):


### PR DESCRIPTION
## Summary
- Adds `model` and `reasoning_effort` parameters to `SeerExplorerClient`, `ExplorerChatRequest`, `get_autofix_explorer_client`, and `trigger_autofix_explorer`.
- These allow callers to override the model and reasoning effort used by the Seer explorer agent, without changing the default `intelligence_level` mapping.
- Companion to getsentry/seer#5752 which reads and applies these fields on the Seer side.

**Important:** If `intelligence_level` is set, `model` and `reasoning_effort` should NOT be set — they are mutually exclusive approaches. `intelligence_level` will eventually be deprecated in favor of explicit `model`/`reasoning_effort`.

## Test plan
- [ ] Verify existing explorer-based autofix behavior unchanged (new params default to `None`)
- [ ] Verify Seer-side reads `model` and `reasoning_effort` from the request when present
- [ ] Test with explicit model/reasoning_effort overrides (e.g. `model="claude-sonnet-4-6"`, `reasoning_effort="medium"`)