### PR TITLE
feat(integrations): Pass initialData through to initialize

### DIFF
--- a/static/app/components/pipeline/modal.tsx
+++ b/static/app/components/pipeline/modal.tsx
@@ -26,19 +26,31 @@ interface PipelineModalProps<
 > extends ModalRenderProps {
   provider: P;
   type: T;
+  initialData?: Record<string, string>;
   onComplete?: (data: CompletionDataFor<T, P>) => void;
 }
 
 function PipelineModal<
   T extends RegisteredPipelineType,
   P extends ProvidersByType[T] = ProvidersByType[T],
->({Header, Body, closeModal, type, provider, onComplete}: PipelineModalProps<T, P>) {
+>({
+  Header,
+  Body,
+  closeModal,
+  type,
+  provider,
+  initialData,
+  onComplete,
+}: PipelineModalProps<T, P>) {
   const handleComplete = (data: CompletionDataFor<T, P>) => {
     onComplete?.(data);
     closeModal();
   };
 
-  const pipeline = usePipeline(type, provider, {onComplete: handleComplete});
+  const pipeline = usePipeline(type, provider, {
+    onComplete: handleComplete,
+    initialData,
+  });
   const {stepDefinition} = pipeline;
 
   const stepText = (
@@ -130,6 +142,7 @@ interface OpenPipelineModalOptions<
 > {
   provider: P;
   type: T;
+  initialData?: Record<string, string>;
   onClose?: () => void;
   onComplete?: (data: CompletionDataFor<T, P>) => void;
 }
@@ -137,10 +150,16 @@ interface OpenPipelineModalOptions<
 export function openPipelineModal<
   T extends RegisteredPipelineType,
   P extends ProvidersByType[T] = ProvidersByType[T],
->({type, provider, onComplete, onClose}: OpenPipelineModalOptions<T, P>) {
+>({type, provider, initialData, onComplete, onClose}: OpenPipelineModalOptions<T, P>) {
   openModal(
     deps => (
-      <PipelineModal {...deps} type={type} provider={provider} onComplete={onComplete} />
+      <PipelineModal
+        {...deps}
+        type={type}
+        provider={provider}
+        initialData={initialData}
+        onComplete={onComplete}
+      />
     ),
     {onClose, closeEvents: 'none'}
   );

--- a/static/app/components/pipeline/usePipeline.spec.tsx
+++ b/static/app/components/pipeline/usePipeline.spec.tsx
@@ -333,4 +333,42 @@ describe('usePipeline', () => {
     expect(await screen.findByText('none')).toBeInTheDocument();
     expect(initRequest).not.toHaveBeenCalled();
   });
+
+  it('includes initialData in the initialize request', async () => {
+    const initRequest = MockApiClient.addMockResponse({
+      url: API_URL,
+      method: 'POST',
+      body: {
+        step: 'step_one',
+        stepIndex: 0,
+        totalSteps: 2,
+        provider: 'dummy',
+        data: {message: 'Hello!'},
+      },
+      match: [
+        MockApiClient.matchData({
+          action: 'initialize',
+          provider: 'dummy',
+          initialData: {installation_id: '12345'},
+        }),
+      ],
+    });
+
+    function InitialDataHarness() {
+      const pipeline = usePipeline('integration', 'dummy', {
+        initialData: {installation_id: '12345'},
+      });
+      return (
+        <div>
+          <div data-test-id="step">{pipeline.stepDefinition?.stepId ?? 'none'}</div>
+          <div data-test-id="view">{pipeline.view}</div>
+        </div>
+      );
+    }
+
+    render(<InitialDataHarness />, {organization});
+
+    expect(await screen.findByText('Hello!')).toBeInTheDocument();
+    expect(initRequest).toHaveBeenCalledTimes(1);
+  });
 });

--- a/static/app/components/pipeline/usePipeline.tsx
+++ b/static/app/components/pipeline/usePipeline.tsx
@@ -36,6 +36,7 @@ interface UsePipelineOptions<
   P extends ProvidersByType[T],
 > {
   enabled?: boolean;
+  initialData?: Record<string, string>;
   onComplete?: (data: CompletionDataFor<T, P>) => void;
 }
 
@@ -97,7 +98,7 @@ export function usePipeline<
   onCompleteRef.current = options.onComplete;
   const generationRef = useRef(0);
 
-  const {enabled = true} = options;
+  const {enabled = true, initialData} = options;
 
   const pipelineName = getBackendPipelineType(type);
   const apiUrl = `/organizations/${organization.slug}/pipeline/${pipelineName}/`;
@@ -117,7 +118,7 @@ export function usePipeline<
       fetchMutation<PipelineStepResponse>({
         method: 'POST',
         url: apiUrl,
-        data: {action: 'initialize', provider},
+        data: {action: 'initialize', provider, initialData},
       }),
     onMutate: () => ({generation: generationRef.current}),
     onSuccess: (data: PipelineStepResponse, _variables, context) => {

--- a/static/app/views/settings/organizationIntegrations/addIntegration.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/addIntegration.spec.tsx
@@ -266,8 +266,33 @@ describe('useAddIntegration', () => {
       expect(openPipelineModalSpy).toHaveBeenCalledWith({
         type: 'integration',
         provider: 'github',
+        initialData: undefined,
         onComplete: expect.any(Function),
       });
+    });
+
+    it('passes urlParams as initialData to the pipeline modal', () => {
+      const openPipelineModalSpy = jest.spyOn(pipelineModal, 'openPipelineModal');
+
+      const organization = OrganizationFixture({
+        features: ['integration-api-pipeline-github'],
+      });
+
+      const {result} = renderHookWithProviders(() =>
+        useAddIntegration({
+          provider,
+          organization,
+          onInstall: jest.fn(),
+        })
+      );
+
+      act(() => result.current.startFlow({installation_id: '12345'}));
+
+      expect(openPipelineModalSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          initialData: {installation_id: '12345'},
+        })
+      );
     });
 
     it('does not open a popup window when the pipeline modal is used', () => {

--- a/static/app/views/settings/organizationIntegrations/addIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/addIntegration.tsx
@@ -213,6 +213,7 @@ export function useAddIntegration(params: AddIntegrationParams) {
       openPipelineModal({
         type: 'integration',
         provider: pipelineProvider,
+        initialData: urlParams,
         onComplete: (data: IntegrationWithConfig) => {
           trackIntegrationAnalytics('integrations.installation_complete', {
             integration: provider.key,


### PR DESCRIPTION
Needed for pipelines that bind some initial state via a setup-flow that
starts _outside_ of the normal app flow

Requires https://github.com/getsentry/sentry/pull/112849