### PR TITLE
ref(seer): Move seer-run-id-in-slack flag to flagpole

### DIFF
--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -114,8 +114,6 @@ def register_permanent_features(manager: FeatureManager) -> None:
         "organizations:sentry-pride-logo-footer": False,
         # Enable priority calculations using Seer's severity endpoint
         "organizations:seer-based-priority": False,
-        # Show Seer run ID in Slack notification footers
-        "organizations:seer-run-id-in-slack": False,
         # Enable Vercel integration - there is a custom handler in getsentry
         "organizations:integrations-vercel": True,
         # Enable GitHub multi-org for users to connect many Sentry orgs to a single GitHub org.

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -393,6 +393,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-project-settings-read-from-sentry", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable public RPC endpoint for local seer development
     manager.add("organizations:seer-public-rpc", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Show Seer run ID in Slack notification footers
+    manager.add("organizations:seer-run-id-in-slack", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Organizations on the old usage-based (v0) Seer plan
     manager.add("organizations:seer-added", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Organizations on the new seat-based Seer plan


### PR DESCRIPTION
Move the `organizations:seer-run-id-in-slack` feature flag from `permanent.py`
(INTERNAL strategy) to `temporary.py` (FLAGPOLE strategy) so it can be
configured per-org via sentry-options-automator instead of being plan-gated
through getsentry.