### PR TITLE
fix(coding integrations): allow model specification based on api key

### DIFF
--- a/src/sentry/integrations/claude_code/integration.py
+++ b/src/sentry/integrations/claude_code/integration.py
@@ -200,7 +200,7 @@ class ClaudeCodeAgentIntegrationProvider(CodingAgentIntegrationProvider):
             api_key=api_key,
             environment_id=environment_id,
             workspace_name=workspace_name,
-            model=client.model,
+            model=getattr(client, "model", None),
         )
 
         return {

--- a/src/sentry/integrations/claude_code/integration.py
+++ b/src/sentry/integrations/claude_code/integration.py
@@ -77,6 +77,7 @@ class ClaudeCodeIntegrationMetadata(BaseModel):
     workspace_name: str | None = "default"
     agent_id: str | None = None
     agent_version: int | None = None
+    model: str | None = None
 
     @validator("agent_version", pre=True)
     def coerce_agent_version(cls, v: object) -> int | None:
@@ -199,6 +200,7 @@ class ClaudeCodeAgentIntegrationProvider(CodingAgentIntegrationProvider):
             api_key=api_key,
             environment_id=environment_id,
             workspace_name=workspace_name,
+            model=client.model,
         )
 
         return {
@@ -297,6 +299,7 @@ class ClaudeCodeAgentIntegration(CodingAgentIntegration):
             workspace_name=metadata.workspace_name,
             agent_id=metadata.agent_id,
             agent_version=metadata.agent_version,
+            model=metadata.model,
         )
 
     def launch(self, request: CodingAgentLaunchRequest) -> CodingAgentState:

--- a/src/sentry/integrations/claude_code/integration.py
+++ b/src/sentry/integrations/claude_code/integration.py
@@ -182,15 +182,20 @@ class ClaudeCodeAgentIntegrationProvider(CodingAgentIntegrationProvider):
                 raise IntegrationConfigurationError(
                     "Invalid Anthropic API key. Please check your credentials."
                 )
+        except IntegrationConfigurationError:
+            raise
+        except ValueError as e:
+            # e.g. valid key but GET /v1/models lists no model we support (getsentry client).
+            self.get_logger().warning(
+                "claude_code.build_integration.no_supported_model",
+                extra={"error": str(e)},
+            )
+            raise IntegrationConfigurationError(str(e)) from e
         except Exception as e:
-            if isinstance(e, IntegrationConfigurationError):
-                raise
             self.get_logger().exception(
                 "claude_code.build_integration.validation_failed",
             )
-            raise IntegrationConfigurationError(
-                "Unable to validate Anthropic API key. Please check your credentials."
-            ) from e
+            raise IntegrationConfigurationError("Unable to validate Anthropic API key.") from e
 
         environment_id = None
         workspace_name = "default"

--- a/tests/sentry/integrations/claude_code/test_integration.py
+++ b/tests/sentry/integrations/claude_code/test_integration.py
@@ -101,6 +101,17 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
 
         assert result["metadata"]["model"] == "claude-sonnet-4-6"
 
+    def test_build_integration_omits_model_when_client_has_no_model_attr(self) -> None:
+        mock_client = MagicMock(spec=["validate_api_key"])
+        mock_client.validate_api_key.return_value = True
+        mock_cls = MagicMock(return_value=mock_client)
+        state: Mapping[str, Any] = {"api_key": "sk-ant-test-api-key-123"}
+
+        with patch(MOCK_GET_CLIENT_CLASS, return_value=mock_cls):
+            result = self.provider().build_integration(state)
+
+        assert result["metadata"]["model"] is None
+
     def test_build_integration_no_supported_model_raises(self) -> None:
         mock_cls, _ = _mock_client_class(
             validate_side_effect=ValueError(

--- a/tests/sentry/integrations/claude_code/test_integration.py
+++ b/tests/sentry/integrations/claude_code/test_integration.py
@@ -25,6 +25,7 @@ MOCK_GET_CLIENT_CLASS = "sentry.integrations.claude_code.integration._get_client
 def _mock_client_class(validate_return=True, validate_side_effect=None, **client_attrs):
     """Create a mock client class whose instances have validate_api_key and optional attributes."""
     mock_client = MagicMock()
+    mock_client.model = "claude-opus-4-6"
     if validate_side_effect:
         mock_client.validate_api_key.side_effect = validate_side_effect
     else:
@@ -88,6 +89,31 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
         assert metadata["workspace_name"] == "default"
         assert metadata["agent_id"] is None
         assert metadata["agent_version"] is None
+        assert metadata["model"] == "claude-opus-4-6"
+
+    def test_build_integration_persists_selected_model(self) -> None:
+        mock_cls, mock_client = _mock_client_class()
+        mock_client.model = "claude-sonnet-4-6"
+        state: Mapping[str, Any] = {"api_key": "sk-ant-test-api-key-123"}
+
+        with patch(MOCK_GET_CLIENT_CLASS, return_value=mock_cls):
+            result = self.provider().build_integration(state)
+
+        assert result["metadata"]["model"] == "claude-sonnet-4-6"
+
+    def test_build_integration_no_supported_model_raises(self) -> None:
+        mock_cls, _ = _mock_client_class(
+            validate_side_effect=ValueError(
+                "This API key does not have access to any supported Claude models"
+            )
+        )
+
+        with patch(MOCK_GET_CLIENT_CLASS, return_value=mock_cls):
+            with pytest.raises(
+                IntegrationConfigurationError,
+                match="Unable to validate Anthropic API key",
+            ):
+                self.provider().build_integration({"api_key": "sk-ant-key"})
 
     def test_build_integration_creates_unique_external_ids(self) -> None:
         mock_cls, _ = _mock_client_class()
@@ -145,6 +171,7 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
             workspace_name="default",
             agent_id=None,
             agent_version=None,
+            model=None,
         )
 
     def test_get_client_with_environment_and_workspace(self) -> None:
@@ -172,6 +199,51 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
             workspace_name="my-ws",
             agent_id="agent-123",
             agent_version=1,
+            model=None,
+        )
+
+    def test_get_client_passes_model_from_metadata(self) -> None:
+        mock_cls, mock_client = _mock_client_class()
+        integration = self.create_provider_integration(
+            provider="claude_code",
+            name="Claude Code Agent",
+            external_id="claude-code-ext-123",
+            metadata=self._make_metadata(model="claude-sonnet-4-6"),
+        )
+        installation = integration.get_installation(organization_id=self.organization.id)
+
+        with patch(MOCK_GET_CLIENT_CLASS, return_value=mock_cls):
+            installation.get_client()
+
+        mock_cls.assert_called_once_with(
+            api_key="sk-ant-test-api-key-123",
+            environment_id=None,
+            workspace_name="default",
+            agent_id=None,
+            agent_version=None,
+            model="claude-sonnet-4-6",
+        )
+
+    def test_get_client_passes_none_model_when_metadata_has_none(self) -> None:
+        mock_cls, _ = _mock_client_class()
+        integration = self.create_provider_integration(
+            provider="claude_code",
+            name="Claude Code Agent",
+            external_id="claude-code-ext-123",
+            metadata=self._make_metadata(),
+        )
+        installation = integration.get_installation(organization_id=self.organization.id)
+
+        with patch(MOCK_GET_CLIENT_CLASS, return_value=mock_cls):
+            installation.get_client()
+
+        mock_cls.assert_called_once_with(
+            api_key="sk-ant-test-api-key-123",
+            environment_id=None,
+            workspace_name="default",
+            agent_id=None,
+            agent_version=None,
+            model=None,
         )
 
     def test_get_client_class_not_configured(self) -> None:

--- a/tests/sentry/integrations/claude_code/test_integration.py
+++ b/tests/sentry/integrations/claude_code/test_integration.py
@@ -113,17 +113,11 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
         assert result["metadata"]["model"] is None
 
     def test_build_integration_no_supported_model_raises(self) -> None:
-        mock_cls, _ = _mock_client_class(
-            validate_side_effect=ValueError(
-                "This API key does not have access to any supported Claude models"
-            )
-        )
+        msg = "This API key does not have access to any supported Claude models"
+        mock_cls, _ = _mock_client_class(validate_side_effect=ValueError(msg))
 
         with patch(MOCK_GET_CLIENT_CLASS, return_value=mock_cls):
-            with pytest.raises(
-                IntegrationConfigurationError,
-                match="Unable to validate Anthropic API key",
-            ):
+            with pytest.raises(IntegrationConfigurationError, match=msg):
                 self.provider().build_integration({"api_key": "sk-ant-key"})
 
     def test_build_integration_creates_unique_external_ids(self) -> None:


### PR DESCRIPTION
Not all enterprise customer api keys allow access to opus 4.6. This PR and its matching one in getsentry use the api key to see allowed models and picks the smartest one for handoff.

The changes in the sentry repo include taking in a new model variable and saving it in the metadata.

Unit tests were written and I tested locally but couldn't fully reproduce the enterprise key behaviour so will watch for new errors. 