### PR TITLE
feat(workflow-engine): Add pagination captions to list views

### DIFF
--- a/static/app/components/pagination.tsx
+++ b/static/app/components/pagination.tsx
@@ -6,8 +6,9 @@ import {Button, ButtonBar} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 
 import {IconChevron} from 'sentry/icons';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {defined} from 'sentry/utils';
+import {parseCursor} from 'sentry/utils/cursor';
 import {parseLinkHeader} from 'sentry/utils/parseLinkHeader';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -99,6 +100,36 @@ export function Pagination({
       </ButtonBar>
     </Flex>
   );
+}
+
+/**
+ * Returns a formatted pagination caption like "1-25 of 100"
+ */
+export function getPaginationCaption({
+  cursor,
+  limit,
+  pageLength,
+  total,
+}: {
+  cursor: string | string[] | undefined | null;
+  limit: number;
+  pageLength: number;
+  total: number;
+}): React.ReactNode {
+  if (pageLength === 0) {
+    return '';
+  }
+
+  const currentCursor = parseCursor(cursor);
+  const offset = currentCursor?.offset ?? 0;
+  const start = offset * limit + 1;
+  const end = start + pageLength - 1;
+
+  return tct('[start]-[end] of [total]', {
+    start: start.toLocaleString(),
+    end: end.toLocaleString(),
+    total: total.toLocaleString(),
+  });
 }
 
 const PaginationCaption = styled('span')`

--- a/static/app/views/automations/components/automationHistoryList.tsx
+++ b/static/app/views/automations/components/automationHistoryList.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo} from 'react';
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
 import {PlatformIcon} from 'platformicons';
@@ -8,12 +8,11 @@ import {Link} from '@sentry/scraps/link';
 
 import {DateTime} from 'sentry/components/dateTime';
 import {LoadingError} from 'sentry/components/loadingError';
-import {Pagination} from 'sentry/components/pagination';
+import {getPaginationCaption, Pagination} from 'sentry/components/pagination';
 import {Placeholder} from 'sentry/components/placeholder';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import {selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
-import {parseCursor} from 'sentry/utils/cursor';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -80,22 +79,15 @@ export function AutomationHistoryList({
   const pageLinks = data?.headers.Link;
   const totalCountInt = data?.headers['X-Hits'] ?? 0;
 
-  const paginationCaption = useMemo(() => {
-    if (isLoading || !data?.json || data.json.length === 0 || limit === null) {
-      return undefined;
-    }
-
-    const currentCursor = parseCursor(cursor);
-    const offset = currentCursor?.offset ?? 0;
-    const startCount = offset * limit + 1;
-    const endCount = startCount + data.json.length - 1;
-
-    return tct('[start]-[end] of [total]', {
-      start: startCount.toLocaleString(),
-      end: endCount.toLocaleString(),
-      total: totalCountInt.toLocaleString(),
-    });
-  }, [data?.json, isLoading, cursor, limit, totalCountInt]);
+  const paginationCaption =
+    isLoading || !data?.json
+      ? undefined
+      : getPaginationCaption({
+          cursor,
+          limit,
+          pageLength: data.json.length,
+          total: totalCountInt,
+        });
 
   return (
     <Fragment>
@@ -155,7 +147,7 @@ export function AutomationHistoryList({
           });
         }}
         pageLinks={pageLinks}
-        caption={totalCountInt > limit ? paginationCaption : null}
+        caption={paginationCaption}
       />
     </Fragment>
   );

--- a/static/app/views/automations/components/connectedMonitorsList.tsx
+++ b/static/app/views/automations/components/connectedMonitorsList.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo} from 'react';
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
 
@@ -6,15 +6,14 @@ import {Button} from '@sentry/scraps/button';
 
 import {LoadingError} from 'sentry/components/loadingError';
 import type {CursorHandler} from 'sentry/components/pagination';
-import {Pagination} from 'sentry/components/pagination';
+import {getPaginationCaption, Pagination} from 'sentry/components/pagination';
 import {Placeholder} from 'sentry/components/placeholder';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {IssueCell} from 'sentry/components/workflowEngine/gridCell/issueCell';
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
 import {selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
-import {parseCursor} from 'sentry/utils/cursor';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {DetectorLink} from 'sentry/views/detectors/components/detectorLink';
 import {DetectorAssigneeCell} from 'sentry/views/detectors/components/detectorListTable/detectorAssigneeCell';
@@ -103,22 +102,15 @@ export function ConnectedMonitorsList({
   const pageLinks = data?.headers.Link;
   const totalCountInt = data?.headers['X-Hits'] ?? 0;
 
-  const paginationCaption = useMemo(() => {
-    if (isLoading || !detectors || detectors?.length === 0 || limit === null) {
-      return undefined;
-    }
-
-    const currentCursor = parseCursor(cursor);
-    const offset = currentCursor?.offset ?? 0;
-    const startCount = offset * limit + 1;
-    const endCount = startCount + detectors.length - 1;
-
-    return tct('[start]-[end] of [total]', {
-      start: startCount.toLocaleString(),
-      end: endCount.toLocaleString(),
-      total: totalCountInt.toLocaleString(),
-    });
-  }, [detectors, isLoading, cursor, limit, totalCountInt]);
+  const paginationCaption =
+    isLoading || !detectors || limit === null
+      ? undefined
+      : getPaginationCaption({
+          cursor,
+          limit,
+          pageLength: detectors.length,
+          total: totalCountInt,
+        });
 
   return (
     <Container {...props}>
@@ -183,7 +175,7 @@ export function ConnectedMonitorsList({
         <Pagination
           onCursor={onCursor}
           pageLinks={pageLinks}
-          caption={totalCountInt > limit ? paginationCaption : null}
+          caption={paginationCaption}
         />
       )}
     </Container>

--- a/static/app/views/automations/list.tsx
+++ b/static/app/views/automations/list.tsx
@@ -6,7 +6,7 @@ import {Flex} from '@sentry/scraps/layout';
 
 import {ProjectPageFilter} from 'sentry/components/pageFilters/project/projectPageFilter';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import {Pagination} from 'sentry/components/pagination';
+import {getPaginationCaption, Pagination} from 'sentry/components/pagination';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {AlertsMonitorsShowcaseButton} from 'sentry/components/workflowEngine/alertsMonitorsShowcaseButton';
 import {WorkflowEngineListLayout as ListLayout} from 'sentry/components/workflowEngine/layout/list';
@@ -72,6 +72,16 @@ export default function AutomationsList() {
     return links && !links.previous!.results && !links.next!.results;
   }, [pageLinks]);
 
+  const paginationCaption =
+    isLoading || !automations
+      ? undefined
+      : getPaginationCaption({
+          cursor,
+          limit: AUTOMATION_LIST_PAGE_LIMIT,
+          pageLength: automations.length,
+          total: hits,
+        });
+
   return (
     <SentryDocumentTitle title={t('Alerts')}>
       <ListLayout
@@ -101,6 +111,7 @@ export default function AutomationsList() {
           </VisuallyCompleteWithData>
           <Pagination
             pageLinks={pageLinks}
+            caption={paginationCaption}
             onCursor={newCursor => {
               navigate({
                 pathname: location.pathname,

--- a/static/app/views/detectors/components/connectedAutomationList.tsx
+++ b/static/app/views/detectors/components/connectedAutomationList.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo} from 'react';
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
 
@@ -6,17 +6,16 @@ import {Button} from '@sentry/scraps/button';
 
 import {LoadingError} from 'sentry/components/loadingError';
 import type {CursorHandler} from 'sentry/components/pagination';
-import {Pagination} from 'sentry/components/pagination';
+import {getPaginationCaption, Pagination} from 'sentry/components/pagination';
 import {Placeholder} from 'sentry/components/placeholder';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {ActionCell} from 'sentry/components/workflowEngine/gridCell/actionCell';
 import {AutomationTitleCell} from 'sentry/components/workflowEngine/gridCell/automationTitleCell';
 import {TimeAgoCell} from 'sentry/components/workflowEngine/gridCell/timeAgoCell';
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import type {Automation} from 'sentry/types/workflowEngine/automations';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
 import {selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
-import {parseCursor} from 'sentry/utils/cursor';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {automationsApiOptions} from 'sentry/views/automations/hooks';
 import {getAutomationActions} from 'sentry/views/automations/hooks/utils';
@@ -95,22 +94,15 @@ export function ConnectedAutomationsList({
   const pageLinks = data?.headers.Link;
   const totalCountInt = data?.headers['X-Hits'] ?? 0;
 
-  const paginationCaption = useMemo(() => {
-    if (!automations || automations.length === 0 || isLoading || limit === null) {
-      return undefined;
-    }
-
-    const currentCursor = parseCursor(cursor);
-    const offset = currentCursor?.offset ?? 0;
-    const startCount = offset * limit + 1;
-    const endCount = startCount + automations.length - 1;
-
-    return tct('[start]-[end] of [total]', {
-      start: startCount.toLocaleString(),
-      end: endCount.toLocaleString(),
-      total: totalCountInt.toLocaleString(),
-    });
-  }, [automations, isLoading, cursor, limit, totalCountInt]);
+  const paginationCaption =
+    isLoading || !automations || limit === null
+      ? undefined
+      : getPaginationCaption({
+          cursor,
+          limit,
+          pageLength: automations.length,
+          total: totalCountInt,
+        });
 
   return (
     <Container {...props}>
@@ -174,7 +166,7 @@ export function ConnectedAutomationsList({
         <Pagination
           onCursor={onCursor}
           pageLinks={pageLinks}
-          caption={totalCountInt > limit ? paginationCaption : null}
+          caption={paginationCaption}
         />
       )}
     </Container>

--- a/static/app/views/detectors/components/details/common/automations.tsx
+++ b/static/app/views/detectors/components/details/common/automations.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useMemo, useState} from 'react';
+import {Fragment, useCallback, useState} from 'react';
 import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
 
@@ -11,7 +11,7 @@ import {addLoadingMessage, addSuccessMessage} from 'sentry/actionCreators/indica
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import {useDrawer} from 'sentry/components/globalDrawer';
 import {LoadingError} from 'sentry/components/loadingError';
-import {Pagination} from 'sentry/components/pagination';
+import {getPaginationCaption, Pagination} from 'sentry/components/pagination';
 import {Placeholder} from 'sentry/components/placeholder';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {ActionCell} from 'sentry/components/workflowEngine/gridCell/actionCell';
@@ -22,7 +22,6 @@ import {t, tct} from 'sentry/locale';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
 import {defined} from 'sentry/utils';
 import {selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
-import {parseCursor} from 'sentry/utils/cursor';
 import {useQueryClient} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjectFromId} from 'sentry/utils/useProjectFromId';
@@ -116,22 +115,15 @@ function DetectorAutomationsTable({
   const pageLinks = data?.headers.Link;
   const totalCountInt = data?.headers['X-Hits'] ?? 0;
 
-  const paginationCaption = useMemo(() => {
-    if (!automations || automations.length === 0 || isPending) {
-      return undefined;
-    }
-
-    const currentCursor = parseCursor(cursor);
-    const offset = currentCursor?.offset ?? 0;
-    const startCount = offset * AUTOMATIONS_PER_PAGE + 1;
-    const endCount = startCount + automations.length - 1;
-
-    return tct('[start]-[end] of [total]', {
-      start: startCount.toLocaleString(),
-      end: endCount.toLocaleString(),
-      total: totalCountInt.toLocaleString(),
-    });
-  }, [automations, isPending, cursor, totalCountInt]);
+  const paginationCaption =
+    isPending || !automations
+      ? undefined
+      : getPaginationCaption({
+          cursor,
+          limit: AUTOMATIONS_PER_PAGE,
+          pageLength: automations.length,
+          total: totalCountInt,
+        });
 
   return (
     <Container>
@@ -209,7 +201,7 @@ function DetectorAutomationsTable({
       <Pagination
         onCursor={setCursor}
         pageLinks={pageLinks}
-        caption={totalCountInt > AUTOMATIONS_PER_PAGE ? paginationCaption : null}
+        caption={paginationCaption}
       />
     </Container>
   );

--- a/static/app/views/detectors/components/detectorListTable/index.tsx
+++ b/static/app/views/detectors/components/detectorListTable/index.tsx
@@ -452,7 +452,6 @@ const DetectorListSimpleTable = styled(SimpleTable)<{
   isVisualizationExpanded: boolean;
 }>`
   grid-template-columns: 1fr;
-  margin-bottom: ${p => p.theme.space.xl};
 
   [data-column-name='type'],
   [data-column-name='last-issue'],

--- a/static/app/views/detectors/list/common/detectorListContent.tsx
+++ b/static/app/views/detectors/list/common/detectorListContent.tsx
@@ -1,13 +1,15 @@
 import {useCallback, type ReactNode} from 'react';
 
-import {Pagination} from 'sentry/components/pagination';
+import {getPaginationCaption, Pagination} from 'sentry/components/pagination';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
 import type {ApiResponse} from 'sentry/utils/api/apiFetch';
 import {parseLinkHeader} from 'sentry/utils/parseLinkHeader';
 import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
+import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {DetectorListTable} from 'sentry/views/detectors/components/detectorListTable';
+import {DETECTOR_LIST_PAGE_LIMIT} from 'sentry/views/detectors/list/common/constants';
 
 interface DetectorListContentProps {
   data: ApiResponse<Detector[]> | undefined;
@@ -32,6 +34,8 @@ export function DetectorListContent({
   const maxHits = data?.headers['X-Max-Hits'] ?? Infinity;
   const pageLinks = data?.headers.Link;
 
+  const cursor = decodeScalar(location.query.cursor);
+
   const allResultsVisible = useCallback(() => {
     if (!pageLinks) {
       return false;
@@ -39,6 +43,16 @@ export function DetectorListContent({
     const links = parseLinkHeader(pageLinks);
     return links && !links.previous!.results && !links.next!.results;
   }, [pageLinks]);
+
+  const paginationCaption =
+    isLoading || !data?.json
+      ? undefined
+      : getPaginationCaption({
+          cursor,
+          limit: DETECTOR_LIST_PAGE_LIMIT,
+          pageLength: data.json.length,
+          total: hits,
+        });
 
   return (
     <div>
@@ -62,6 +76,7 @@ export function DetectorListContent({
       </VisuallyCompleteWithData>
       <Pagination
         pageLinks={pageLinks}
+        caption={paginationCaption}
         onCursor={newCursor => {
           navigate({
             pathname: location.pathname,


### PR DESCRIPTION
Closes ID-1464
Closes ID-1463

Ensures that all alerts/monitors pages are using pagination captions.

Since there is a lot of repeated logic, added a util to the Pagination component that we can use to generate the caption.

<img width="446" height="124" alt="CleanShot 2026-04-13 at 13 50 59@2x" src="https://github.com/user-attachments/assets/e3dc8dc1-9420-43e4-bf3c-438295820326" />
