### PR TITLE
feat(aci): Modify test action endpoint to accept a project slug

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_test_fire_action.py
+++ b/src/sentry/workflow_engine/endpoints/organization_test_fire_action.py
@@ -86,24 +86,19 @@ class OrganizationTestFireActionsEndpoint(OrganizationEndpoint):
         if not request.user.is_authenticated:
             return Response(status=HTTP_401_UNAUTHORIZED)
 
+        qs = Project.objects.filter(
+            organization=organization,
+            teams__organizationmember__user_id=request.user.id,
+            status=ObjectStatus.ACTIVE,
+        )
+
         project_slug = data.get("project_slug")
         if project_slug:
-            project = Project.objects.filter(
-                organization=organization,
-                slug=project_slug,
-                teams__organizationmember__user_id=request.user.id,
-                status=ObjectStatus.ACTIVE,
-            ).first()
+            qs = qs.filter(slug=project_slug)
         else:
-            project = (
-                Project.objects.filter(
-                    organization=organization,
-                    teams__organizationmember__user_id=request.user.id,
-                    status=ObjectStatus.ACTIVE,
-                )
-                .order_by("name")
-                .first()
-            )
+            qs = qs.order_by("name")
+
+        project = qs.first()
 
         if not project:
             return Response(

--- a/src/sentry/workflow_engine/endpoints/organization_test_fire_action.py
+++ b/src/sentry/workflow_engine/endpoints/organization_test_fire_action.py
@@ -90,13 +90,11 @@ class OrganizationTestFireActionsEndpoint(OrganizationEndpoint):
             organization=organization,
             teams__organizationmember__user_id=request.user.id,
             status=ObjectStatus.ACTIVE,
-        )
+        ).order_by("slug")
 
         project_slug = data.get("project_slug")
         if project_slug:
             qs = qs.filter(slug=project_slug)
-        else:
-            qs = qs.order_by("name")
 
         project = qs.first()
 

--- a/src/sentry/workflow_engine/endpoints/organization_test_fire_action.py
+++ b/src/sentry/workflow_engine/endpoints/organization_test_fire_action.py
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 
 class TestActionsValidator(CamelSnakeSerializer[Any]):
     actions = serializers.ListField(required=True)
+    project_slug = serializers.CharField(required=False)
 
     def validate_actions(self, value: Any) -> Any:
         validated_actions = []
@@ -85,17 +86,24 @@ class OrganizationTestFireActionsEndpoint(OrganizationEndpoint):
         if not request.user.is_authenticated:
             return Response(status=HTTP_401_UNAUTHORIZED)
 
-        # Get the alphabetically first project associated with the organization
-        # This is because we don't have a project when test firing actions
-        project = (
-            Project.objects.filter(
+        project_slug = data.get("project_slug")
+        if project_slug:
+            project = Project.objects.filter(
                 organization=organization,
+                slug=project_slug,
                 teams__organizationmember__user_id=request.user.id,
                 status=ObjectStatus.ACTIVE,
+            ).first()
+        else:
+            project = (
+                Project.objects.filter(
+                    organization=organization,
+                    teams__organizationmember__user_id=request.user.id,
+                    status=ObjectStatus.ACTIVE,
+                )
+                .order_by("name")
+                .first()
             )
-            .order_by("name")
-            .first()
-        )
 
         if not project:
             return Response(

--- a/tests/sentry/workflow_engine/endpoints/test_organization_test_fire_action.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_test_fire_action.py
@@ -223,20 +223,18 @@ class TestFireActionsEndpointTest(APITestCase, BaseWorkflowTest):
             "detail": "No projects found for this organization that the user has access to"
         }
 
-    @mock.patch(
-        "sentry.workflow_engine.endpoints.organization_test_fire_action.get_test_notification_event_data"
-    )
+    @mock.patch("sentry.workflow_engine.endpoints.organization_test_fire_action.test_fire_actions")
     def test_uses_specified_project_slug(
         self,
-        mock_get_test_event: mock.MagicMock,
+        mock_test_fire_actions: mock.MagicMock,
     ) -> None:
         """Test that providing project_slug uses the specified project"""
+        mock_test_fire_actions.return_value = (None, None)
+
         team = self.create_team(organization=self.organization, members=[self.user])
         target_project = self.create_project(
             organization=self.organization, name="zzz-target-project", teams=[team]
         )
-
-        mock_get_test_event.return_value = None
 
         action_data = [
             {
@@ -246,17 +244,20 @@ class TestFireActionsEndpointTest(APITestCase, BaseWorkflowTest):
             }
         ]
 
-        self.get_error_response(
+        response = self.get_success_response(
             self.organization.slug,
             actions=action_data,
             project_slug=target_project.slug,
         )
+        assert response.status_code == 200
 
-        # Verify get_test_notification_event_data was called with the specified project
-        mock_get_test_event.assert_called_once_with(target_project)
+        # Verify test_fire_actions was called with the specified project
+        mock_test_fire_actions.assert_called_once()
+        _, project_arg = mock_test_fire_actions.call_args[0]
+        assert project_arg == target_project
 
-    def test_invalid_project_slug_falls_through(self) -> None:
-        """Test that an invalid project_slug returns an error"""
+    def test_invalid_project_slug(self) -> None:
+        """Test that an invalid project_slug returns with a 400 error"""
         action_data = [
             {
                 "type": Action.Type.PLUGIN.value,

--- a/tests/sentry/workflow_engine/endpoints/test_organization_test_fire_action.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_test_fire_action.py
@@ -224,6 +224,55 @@ class TestFireActionsEndpointTest(APITestCase, BaseWorkflowTest):
         }
 
     @mock.patch(
+        "sentry.workflow_engine.endpoints.organization_test_fire_action.get_test_notification_event_data"
+    )
+    def test_uses_specified_project_slug(
+        self,
+        mock_get_test_event: mock.MagicMock,
+    ) -> None:
+        """Test that providing project_slug uses the specified project"""
+        team = self.create_team(organization=self.organization, members=[self.user])
+        target_project = self.create_project(
+            organization=self.organization, name="zzz-target-project", teams=[team]
+        )
+
+        mock_get_test_event.return_value = None
+
+        action_data = [
+            {
+                "type": Action.Type.PLUGIN.value,
+                "data": {},
+                "config": {},
+            }
+        ]
+
+        self.get_error_response(
+            self.organization.slug,
+            actions=action_data,
+            project_slug=target_project.slug,
+        )
+
+        # Verify get_test_notification_event_data was called with the specified project
+        mock_get_test_event.assert_called_once_with(target_project)
+
+    def test_invalid_project_slug_falls_through(self) -> None:
+        """Test that an invalid project_slug returns an error"""
+        action_data = [
+            {
+                "type": Action.Type.PLUGIN.value,
+                "data": {},
+                "config": {},
+            }
+        ]
+
+        response = self.get_error_response(
+            self.organization.slug,
+            actions=action_data,
+            project_slug="nonexistent-project",
+        )
+        assert response.status_code == 400
+
+    @mock.patch(
         "sentry.notifications.notification_action.types.BaseIssueAlertHandler.send_test_notification"
     )
     @mock.patch("sentry.integrations.slack.actions.form.get_channel_id")


### PR DESCRIPTION
Ref ISWF-2436

The legacy alerts UI sends a test action which displays the selected project. The new endpoint selects the first one alphabetically, which can be a bit confusing for the user.

This PR adds support for passing `project_slug` to decide which project is shown in the test notification. This way the frontend can choose one of the selected projects.