### PR TITLE
ref: Prefer `renderHookWithProviders()` over `renderHook()` and manually creating a wrapper.

### DIFF
--- a/static/AGENTS.md
+++ b/static/AGENTS.md
@@ -564,6 +564,14 @@ jest.mocked(usePageFilters)
 PageFiltersStore.onInitializeUrlState(
     PageFiltersFixture({ projects: [1]}),
 )
+
+// ❌ Don't recreate the basic context providers
+renderHook(useNavigate, {
+  wrapper: (children) => (<AllTheProviders>{children}</AllTheProviders>),
+})
+
+// ✅ Use the provided helpers that mock everything
+renderHookWithProviders(useNavigate)
 ```
 
 #### Use fixtures

--- a/static/app/bootstrap/boostrapRequests.spec.tsx
+++ b/static/app/bootstrap/boostrapRequests.spec.tsx
@@ -4,7 +4,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {TeamFixture} from 'sentry-fixture/team';
 
-import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import type {ApiResult} from 'sentry/api';
 import {ORGANIZATION_FETCH_ERROR_TYPES} from 'sentry/constants';
@@ -14,22 +14,12 @@ import {TeamStore} from 'sentry/stores/teamStore';
 import type {Organization} from 'sentry/types/organization';
 import {FeatureFlagOverrides} from 'sentry/utils/featureFlagOverrides';
 import {localStorageWrapper} from 'sentry/utils/localStorage';
-import {
-  DEFAULT_QUERY_CLIENT_CONFIG,
-  QueryClient,
-  QueryClientProvider,
-} from 'sentry/utils/queryClient';
 
 import {
   useBootstrapOrganizationQuery,
   useBootstrapProjectsQuery,
   useBootstrapTeamsQuery,
 } from './bootstrapRequests';
-
-const queryClient = new QueryClient(DEFAULT_QUERY_CLIENT_CONFIG);
-const wrapper = ({children}: {children?: React.ReactNode}) => (
-  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-);
 
 describe('useBootstrapOrganizationQuery', () => {
   const org = OrganizationFixture();
@@ -38,7 +28,6 @@ describe('useBootstrapOrganizationQuery', () => {
   beforeEach(() => {
     MockApiClient.clearMockResponses();
     OrganizationStore.reset();
-    queryClient.clear();
     localStorageWrapper.clear();
   });
 
@@ -49,7 +38,9 @@ describe('useBootstrapOrganizationQuery', () => {
       query: {detailed: 0, include_feature_flags: 1},
     });
 
-    const {result} = renderHook(() => useBootstrapOrganizationQuery(orgSlug), {wrapper});
+    const {result} = renderHookWithProviders(() =>
+      useBootstrapOrganizationQuery(orgSlug)
+    );
 
     await waitFor(() => expect(result.current.data).toBeDefined());
     expect(JSON.stringify(OrganizationStore.get().organization)).toEqual(
@@ -64,7 +55,9 @@ describe('useBootstrapOrganizationQuery', () => {
       body: {},
     });
 
-    const {result} = renderHook(() => useBootstrapOrganizationQuery(orgSlug), {wrapper});
+    const {result} = renderHookWithProviders(() =>
+      useBootstrapOrganizationQuery(orgSlug)
+    );
 
     await waitFor(() => expect(result.current.error).toBeDefined());
     expect(OrganizationStore.get().organization).toBeNull();
@@ -75,7 +68,7 @@ describe('useBootstrapOrganizationQuery', () => {
   });
 
   it('does not fetch when orgSlug is null', () => {
-    const {result} = renderHook(() => useBootstrapOrganizationQuery(null), {wrapper});
+    const {result} = renderHookWithProviders(() => useBootstrapOrganizationQuery(null));
     expect(result.current.data).toBeUndefined();
   });
 
@@ -84,7 +77,9 @@ describe('useBootstrapOrganizationQuery', () => {
       orgSlug: org.slug,
       organization: Promise.resolve<ApiResult<Organization>>([org, undefined, undefined]),
     };
-    const {result} = renderHook(() => useBootstrapOrganizationQuery(orgSlug), {wrapper});
+    const {result} = renderHookWithProviders(() =>
+      useBootstrapOrganizationQuery(orgSlug)
+    );
     await waitFor(() => expect(result.current.data).toBeDefined());
     expect(window.__sentry_preload?.organization).toBeUndefined();
   });
@@ -105,7 +100,9 @@ describe('useBootstrapOrganizationQuery', () => {
       query: {detailed: 0, include_feature_flags: 1},
     });
 
-    const {result} = renderHook(() => useBootstrapOrganizationQuery(orgSlug), {wrapper});
+    const {result} = renderHookWithProviders(() =>
+      useBootstrapOrganizationQuery(orgSlug)
+    );
     await waitFor(() => expect(result.current.data).toBeDefined());
     expect(JSON.stringify(OrganizationStore.get().organization?.features)).toEqual(
       JSON.stringify(['enable-issues'])
@@ -129,7 +126,6 @@ describe('useBootstrapTeamsQuery', () => {
   beforeEach(() => {
     MockApiClient.clearMockResponses();
     TeamStore.reset();
-    queryClient.clear();
   });
 
   it('updates team store with fetched data', async () => {
@@ -141,7 +137,7 @@ describe('useBootstrapTeamsQuery', () => {
       },
     });
 
-    const {result} = renderHook(() => useBootstrapTeamsQuery(orgSlug), {wrapper});
+    const {result} = renderHookWithProviders(() => useBootstrapTeamsQuery(orgSlug));
 
     await waitFor(() => expect(result.current.data).toBeDefined());
     expect(TeamStore.getState().teams).toEqual(mockTeams);
@@ -154,14 +150,14 @@ describe('useBootstrapTeamsQuery', () => {
       statusCode: 500,
     });
 
-    const {result} = renderHook(() => useBootstrapTeamsQuery(orgSlug), {wrapper});
+    const {result} = renderHookWithProviders(() => useBootstrapTeamsQuery(orgSlug));
 
     await waitFor(() => expect(result.current.error).toBeDefined());
     expect(TeamStore.getState().teams).toEqual([]);
   });
 
   it('does not fetch when orgSlug is null', () => {
-    const {result} = renderHook(() => useBootstrapTeamsQuery(null), {wrapper});
+    const {result} = renderHookWithProviders(() => useBootstrapTeamsQuery(null));
     expect(result.current.data).toBeUndefined();
   });
 });
@@ -173,7 +169,6 @@ describe('useBootstrapProjectsQuery', () => {
   beforeEach(() => {
     MockApiClient.clearMockResponses();
     ProjectsStore.reset();
-    queryClient.clear();
   });
 
   it('updates projects store with fetched data', async () => {
@@ -186,7 +181,7 @@ describe('useBootstrapProjectsQuery', () => {
       },
     });
 
-    const {result} = renderHook(() => useBootstrapProjectsQuery(orgSlug), {wrapper});
+    const {result} = renderHookWithProviders(() => useBootstrapProjectsQuery(orgSlug));
 
     await waitFor(() => expect(result.current.data).toBeDefined());
     expect(ProjectsStore.getState().projects).toEqual(mockProjects);
@@ -198,14 +193,14 @@ describe('useBootstrapProjectsQuery', () => {
       statusCode: 500,
     });
 
-    const {result} = renderHook(() => useBootstrapProjectsQuery(orgSlug), {wrapper});
+    const {result} = renderHookWithProviders(() => useBootstrapProjectsQuery(orgSlug));
 
     await waitFor(() => expect(result.current.error).toBeDefined());
     expect(ProjectsStore.getState().projects).toEqual([]);
   });
 
   it('does not fetch when orgSlug is null', () => {
-    const {result} = renderHook(() => useBootstrapProjectsQuery(null), {wrapper});
+    const {result} = renderHookWithProviders(() => useBootstrapProjectsQuery(null));
     expect(result.current.data).toBeUndefined();
   });
 });

--- a/static/app/components/core/layout/styles.spec.tsx
+++ b/static/app/components/core/layout/styles.spec.tsx
@@ -1,7 +1,7 @@
-import {css, ThemeProvider} from '@emotion/react';
+import {css} from '@emotion/react';
 import {ThemeFixture} from 'sentry-fixture/theme';
 
-import {act, renderHook} from 'sentry-test/reactTestingLibrary';
+import {act, renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
 import type {BreakpointSize} from 'sentry/utils/theme';
 
@@ -21,13 +21,6 @@ const mockMatchMedia = (matches: boolean) => ({
   removeEventListener: jest.fn(),
   dispatchEvent: jest.fn(),
 });
-
-// Helper function to create a wrapper with theme
-const createWrapper = () => {
-  return function Wrapper({children}: {children: React.ReactNode}) {
-    return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
-  };
-};
 
 // Helper to set up media query mocks for specific breakpoints
 const setupMediaQueries = (
@@ -110,9 +103,7 @@ describe('rc', () => {
 
 describe('useResponsivePropValue', () => {
   it('returns identity for non-responsive values', () => {
-    const {result} = renderHook(() => useResponsivePropValue('hello'), {
-      wrapper: createWrapper(),
-    });
+    const {result} = renderHookWithProviders(() => useResponsivePropValue('hello'));
 
     expect(result.current).toBe('hello');
   });
@@ -131,9 +122,9 @@ describe('useResponsivePropValue', () => {
       md: 'medium',
     };
 
-    const {result} = renderHook(() => useResponsivePropValue(responsiveValue), {
-      wrapper: createWrapper(),
-    });
+    const {result} = renderHookWithProviders(() =>
+      useResponsivePropValue(responsiveValue)
+    );
 
     expect(result.current).toBe('medium');
     cleanup();
@@ -151,9 +142,9 @@ describe('useResponsivePropValue', () => {
       md: 'medium',
     };
 
-    const {result} = renderHook(() => useResponsivePropValue(responsiveValue), {
-      wrapper: createWrapper(),
-    });
+    const {result} = renderHookWithProviders(() =>
+      useResponsivePropValue(responsiveValue)
+    );
 
     expect(result.current).toBe('medium');
     cleanup();
@@ -169,9 +160,9 @@ describe('useResponsivePropValue', () => {
       sm: 'small',
     };
 
-    const {result} = renderHook(() => useResponsivePropValue(responsiveValue), {
-      wrapper: createWrapper(),
-    });
+    const {result} = renderHookWithProviders(() =>
+      useResponsivePropValue(responsiveValue)
+    );
 
     expect(result.current).toBe('small');
     cleanup();
@@ -190,9 +181,9 @@ describe('useResponsivePropValue', () => {
       lg: 'large',
     };
 
-    const {result} = renderHook(() => useResponsivePropValue(responsiveValue), {
-      wrapper: createWrapper(),
-    });
+    const {result} = renderHookWithProviders(() =>
+      useResponsivePropValue(responsiveValue)
+    );
 
     expect(result.current).toBe('small');
     cleanup();
@@ -211,20 +202,18 @@ describe('useResponsivePropValue', () => {
       lg: undefined,
     };
 
-    const {result} = renderHook(() => useResponsivePropValue(responsiveValue), {
-      wrapper: createWrapper(),
-    });
+    const {result} = renderHookWithProviders(() =>
+      useResponsivePropValue(responsiveValue)
+    );
 
     expect(result.current).toBe('medium');
     cleanup();
   });
 
   it('throws an error when no breakpoints are defined in responsive prop', () => {
-    expect(() =>
-      renderHook(() => useResponsivePropValue({}), {
-        wrapper: createWrapper(),
-      })
-    ).toThrow('Responsive prop must contain at least one breakpoint');
+    expect(() => renderHookWithProviders(() => useResponsivePropValue({}))).toThrow(
+      'Responsive prop must contain at least one breakpoint'
+    );
   });
 });
 
@@ -241,9 +230,7 @@ describe('useActiveBreakpoint', () => {
       xl: false,
     });
 
-    const {result} = renderHook(() => useActiveBreakpoint(), {
-      wrapper: createWrapper(),
-    });
+    const {result} = renderHookWithProviders(() => useActiveBreakpoint());
 
     expect(result.current).toBe('2xs');
     cleanup();
@@ -258,9 +245,7 @@ describe('useActiveBreakpoint', () => {
       xl: false,
     });
 
-    const {result} = renderHook(() => useActiveBreakpoint(), {
-      wrapper: createWrapper(),
-    });
+    const {result} = renderHookWithProviders(() => useActiveBreakpoint());
 
     expect(result.current).toBe('md');
     cleanup();
@@ -270,9 +255,7 @@ describe('useActiveBreakpoint', () => {
     const matchMediaSpy = jest.fn(() => mockMatchMedia(false));
     window.matchMedia = matchMediaSpy;
 
-    renderHook(() => useActiveBreakpoint(), {
-      wrapper: createWrapper(),
-    });
+    renderHookWithProviders(() => useActiveBreakpoint());
 
     // Should create media queries for all breakpoints (in reverse order)
     expect(matchMediaSpy).toHaveBeenCalledTimes(Object.keys(theme.breakpoints).length);
@@ -295,9 +278,7 @@ describe('useActiveBreakpoint', () => {
       xl: true,
     });
 
-    const {result} = renderHook(() => useActiveBreakpoint(), {
-      wrapper: createWrapper(),
-    });
+    const {result} = renderHookWithProviders(() => useActiveBreakpoint());
 
     // Should return xl (largest) when all are active
     expect(result.current).toBe('xl');
@@ -336,11 +317,8 @@ describe('useActiveBreakpoint', () => {
       return mockQuery;
     });
 
-    const {result} = renderHook(
-      () => useResponsivePropValue({xs: 'small', md: 'medium', lg: 'large'}),
-      {
-        wrapper: createWrapper(),
-      }
+    const {result} = renderHookWithProviders(() =>
+      useResponsivePropValue({xs: 'small', md: 'medium', lg: 'large'})
     );
 
     // Initially query matches 'medium'
@@ -387,11 +365,8 @@ describe('useActiveBreakpoint', () => {
       dispatchEvent: jest.fn(),
     }));
 
-    const {unmount} = renderHook(
-      () => useResponsivePropValue({xs: 'small', md: 'medium'}),
-      {
-        wrapper: createWrapper(),
-      }
+    const {unmount} = renderHookWithProviders(() =>
+      useResponsivePropValue({xs: 'small', md: 'medium'})
     );
 
     // Sets up listeners for all breakpoints

--- a/static/app/components/core/renderToString.spec.tsx
+++ b/static/app/components/core/renderToString.spec.tsx
@@ -1,13 +1,8 @@
-import {ThemeProvider} from '@emotion/react';
-import {ThemeFixture} from 'sentry-fixture/theme';
-
-import {act, renderHook} from 'sentry-test/reactTestingLibrary';
+import {act, renderHook, renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
 import {Tag} from '@sentry/scraps/badge';
 
 import {useRenderToString} from './renderToString';
-
-const theme = ThemeFixture();
 
 describe('renderToString', () => {
   it('should render a simple component to string', async () => {
@@ -15,7 +10,7 @@ describe('renderToString', () => {
       return <div>Hello, World!</div>;
     }
 
-    const {result} = renderHook(() => useRenderToString());
+    const {result} = renderHook(useRenderToString);
 
     const string = await act(() => result.current(<SimpleComponent />));
 
@@ -26,9 +21,7 @@ describe('renderToString', () => {
       return <Tag variant="success">SuccessTag</Tag>;
     }
 
-    const {result} = renderHook(() => useRenderToString(), {
-      wrapper: ({children}) => <ThemeProvider theme={theme}>{children}</ThemeProvider>,
-    });
+    const {result} = renderHookWithProviders(useRenderToString);
 
     const string = await act(() => result.current(<ScrapsComponent />));
 

--- a/static/app/utils/api/useFetchParallelPages.spec.tsx
+++ b/static/app/utils/api/useFetchParallelPages.spec.tsx
@@ -1,17 +1,6 @@
-import type {ReactNode} from 'react';
-
-import {makeTestQueryClient} from 'sentry-test/queryClient';
-import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {useFetchParallelPages} from 'sentry/utils/api/useFetchParallelPages';
-import type {QueryClient} from 'sentry/utils/queryClient';
-import {QueryClientProvider} from 'sentry/utils/queryClient';
-
-function makeWrapper(queryClient: QueryClient) {
-  return function wrapper({children}: {children?: ReactNode}) {
-    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
-  };
-}
 
 const MOCK_API_ENDPOINT = '/api/test/';
 function queryKeyFactory() {
@@ -26,8 +15,7 @@ describe('useFetchParallelPages', () => {
     });
     const getQueryKey = queryKeyFactory();
 
-    const {result} = renderHook(useFetchParallelPages, {
-      wrapper: makeWrapper(makeTestQueryClient()),
+    const {result} = renderHookWithProviders(useFetchParallelPages, {
       initialProps: {
         enabled: false,
         getQueryKey,
@@ -48,8 +36,7 @@ describe('useFetchParallelPages', () => {
     });
     const getQueryKey = queryKeyFactory();
 
-    const {result, rerender} = renderHook(useFetchParallelPages, {
-      wrapper: makeWrapper(makeTestQueryClient()),
+    const {result, rerender} = renderHookWithProviders(useFetchParallelPages, {
       initialProps: {
         enabled: false,
         getQueryKey,
@@ -76,8 +63,7 @@ describe('useFetchParallelPages', () => {
   it('should call the queryFn zero times, when hits is 0', () => {
     const getQueryKey = queryKeyFactory();
 
-    const {result} = renderHook(useFetchParallelPages, {
-      wrapper: makeWrapper(makeTestQueryClient()),
+    const {result} = renderHookWithProviders(useFetchParallelPages, {
       initialProps: {
         enabled: true,
         getQueryKey,
@@ -94,8 +80,7 @@ describe('useFetchParallelPages', () => {
   it('should call the queryFn zero times, and flip to state=success when hits is 0', () => {
     const getQueryKey = queryKeyFactory();
 
-    const {result, rerender} = renderHook(useFetchParallelPages, {
-      wrapper: makeWrapper(makeTestQueryClient()),
+    const {result, rerender} = renderHookWithProviders(useFetchParallelPages, {
       initialProps: {
         enabled: false,
         getQueryKey,
@@ -122,8 +107,7 @@ describe('useFetchParallelPages', () => {
     });
     const getQueryKey = queryKeyFactory();
 
-    const {result} = renderHook(useFetchParallelPages, {
-      wrapper: makeWrapper(makeTestQueryClient()),
+    const {result} = renderHookWithProviders(useFetchParallelPages, {
       initialProps: {
         enabled: true,
         getQueryKey,
@@ -148,8 +132,7 @@ describe('useFetchParallelPages', () => {
     });
     const getQueryKey = queryKeyFactory();
 
-    const {result} = renderHook(useFetchParallelPages, {
-      wrapper: makeWrapper(makeTestQueryClient()),
+    const {result} = renderHookWithProviders(useFetchParallelPages, {
       initialProps: {
         enabled: true,
         getQueryKey,
@@ -180,8 +163,7 @@ describe('useFetchParallelPages', () => {
     });
     const getQueryKey = queryKeyFactory();
 
-    const {result} = renderHook(useFetchParallelPages, {
-      wrapper: makeWrapper(makeTestQueryClient()),
+    const {result} = renderHookWithProviders(useFetchParallelPages, {
       initialProps: {
         enabled: true,
         getQueryKey,
@@ -207,8 +189,7 @@ describe('useFetchParallelPages', () => {
     });
     const getQueryKey = queryKeyFactory();
 
-    const {result} = renderHook(useFetchParallelPages, {
-      wrapper: makeWrapper(makeTestQueryClient()),
+    const {result} = renderHookWithProviders(useFetchParallelPages, {
       initialProps: {
         enabled: true,
         getQueryKey,
@@ -238,8 +219,7 @@ describe('useFetchParallelPages', () => {
     });
     const getQueryKey = queryKeyFactory();
 
-    const {result} = renderHook(useFetchParallelPages, {
-      wrapper: makeWrapper(makeTestQueryClient()),
+    const {result} = renderHookWithProviders(useFetchParallelPages, {
       initialProps: {
         enabled: true,
         getQueryKey,
@@ -271,8 +251,7 @@ describe('useFetchParallelPages', () => {
 
     const getQueryKey = queryKeyFactory();
 
-    const {result} = renderHook(useFetchParallelPages, {
-      wrapper: makeWrapper(makeTestQueryClient()),
+    const {result} = renderHookWithProviders(useFetchParallelPages, {
       initialProps: {
         enabled: true,
         getQueryKey,

--- a/static/app/utils/useProjects.spec.tsx
+++ b/static/app/utils/useProjects.spec.tsx
@@ -1,17 +1,12 @@
-import type {ReactNode} from 'react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {act, renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {useProjects} from 'sentry/utils/useProjects';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 const org = OrganizationFixture();
-function TestContext({children}: {children?: ReactNode}) {
-  return <OrganizationContext value={org}>{children}</OrganizationContext>;
-}
 
 describe('useProjects', () => {
   const mockProjects = [ProjectFixture()];
@@ -19,7 +14,7 @@ describe('useProjects', () => {
   it('provides projects from the team store', () => {
     act(() => ProjectsStore.loadInitialData(mockProjects));
 
-    const {result} = renderHook(useProjects, {wrapper: TestContext});
+    const {result} = renderHookWithProviders(useProjects, {organization: org});
     const {projects} = result.current;
 
     expect(projects).toEqual(mockProjects);
@@ -37,9 +32,7 @@ describe('useProjects', () => {
       body: [newProject3, newProject4],
     });
 
-    const {result} = renderHook(useProjects, {
-      wrapper: TestContext,
-    });
+    const {result} = renderHookWithProviders(useProjects, {organization: org});
     const {onSearch} = result.current;
 
     // Works with append
@@ -72,9 +65,9 @@ describe('useProjects', () => {
       body: [projectFoo],
     });
 
-    const {result} = renderHook(useProjects, {
+    const {result} = renderHookWithProviders(useProjects, {
+      organization: org,
       initialProps: {slugs: ['foo']},
-      wrapper: TestContext,
     });
 
     expect(result.current.initiallyLoaded).toBe(false);
@@ -89,9 +82,9 @@ describe('useProjects', () => {
   it('only loads slugs when needed', () => {
     act(() => ProjectsStore.loadInitialData(mockProjects));
 
-    const {result} = renderHook(useProjects, {
+    const {result} = renderHookWithProviders(useProjects, {
+      organization: org,
       initialProps: {slugs: [mockProjects[0]!.slug]},
-      wrapper: TestContext,
     });
 
     const {projects, initiallyLoaded} = result.current;

--- a/static/app/utils/useUpdateOrganization.spec.tsx
+++ b/static/app/utils/useUpdateOrganization.spec.tsx
@@ -1,19 +1,14 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {makeTestQueryClient} from 'sentry-test/queryClient';
-import {act, renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {OrganizationStore} from 'sentry/stores/organizationStore';
-import {QueryClient, QueryClientProvider} from 'sentry/utils/queryClient';
 
 import {useUpdateOrganization} from './useUpdateOrganization';
 
 describe('useUpdateOrganization', () => {
-  let queryClient: QueryClient;
-
   beforeEach(() => {
     MockApiClient.clearMockResponses();
-    queryClient = makeTestQueryClient();
     OrganizationStore.reset();
   });
 
@@ -37,11 +32,7 @@ describe('useUpdateOrganization', () => {
       body: updatedOrganization,
     });
 
-    const {result} = renderHook(() => useUpdateOrganization(organization), {
-      wrapper: ({children}) => (
-        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-      ),
-    });
+    const {result} = renderHookWithProviders(() => useUpdateOrganization(organization));
 
     // Verify initial state
     expect(OrganizationStore.get().organization?.name).toBe('Original Name');
@@ -81,11 +72,7 @@ describe('useUpdateOrganization', () => {
       body: {detail: 'Internal Server Error'},
     });
 
-    const {result} = renderHook(() => useUpdateOrganization(organization), {
-      wrapper: ({children}) => (
-        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-      ),
-    });
+    const {result} = renderHookWithProviders(() => useUpdateOrganization(organization));
 
     // Verify initial state
     expect(OrganizationStore.get().organization?.name).toBe('Original Name');

--- a/static/app/views/dashboards/widgetCard/hooks/useErrorsWidgetQuery.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useErrorsWidgetQuery.spec.tsx
@@ -2,11 +2,10 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 import {WidgetFixture} from 'sentry-fixture/widget';
 
-import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {QueryClient, QueryClientProvider} from 'sentry/utils/queryClient';
 import {DisplayType} from 'sentry/views/dashboards/types';
 
 import {useErrorsSeriesQuery, useErrorsTableQuery} from './useErrorsWidgetQuery';
@@ -14,20 +13,6 @@ import {useErrorsSeriesQuery, useErrorsTableQuery} from './useErrorsWidgetQuery'
 jest.mock('sentry/views/dashboards/utils/widgetQueryQueue', () => ({
   useWidgetQueryQueue: () => ({queue: null}),
 }));
-
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-      },
-    },
-  });
-
-  return function Wrapper({children}: {children: React.ReactNode}) {
-    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
-  };
-}
 
 describe('useErrorsSeriesQuery', () => {
   const organization = OrganizationFixture();
@@ -64,15 +49,13 @@ describe('useErrorsSeriesQuery', () => {
       },
     });
 
-    renderHook(
-      () =>
-        useErrorsSeriesQuery({
-          widget,
-          organization,
-          pageFilters,
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useErrorsSeriesQuery({
+        widget,
+        organization,
+        pageFilters,
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -126,15 +109,13 @@ describe('useErrorsSeriesQuery', () => {
       },
     });
 
-    renderHook(
-      () =>
-        useErrorsSeriesQuery({
-          widget,
-          organization,
-          pageFilters: pageFiltersWithDates,
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useErrorsSeriesQuery({
+        widget,
+        organization,
+        pageFilters: pageFiltersWithDates,
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -172,18 +153,16 @@ describe('useErrorsSeriesQuery', () => {
       },
     });
 
-    renderHook(
-      () =>
-        useErrorsSeriesQuery({
-          widget,
-          organization,
-          pageFilters,
-          dashboardFilters: {
-            release: ['1.0.0'],
-          },
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useErrorsSeriesQuery({
+        widget,
+        organization,
+        pageFilters,
+        dashboardFilters: {
+          release: ['1.0.0'],
+        },
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -251,15 +230,13 @@ describe('useErrorsSeriesQuery', () => {
       ],
     });
 
-    renderHook(
-      () =>
-        useErrorsSeriesQuery({
-          widget,
-          organization,
-          pageFilters,
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useErrorsSeriesQuery({
+        widget,
+        organization,
+        pageFilters,
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -301,15 +278,13 @@ describe('useErrorsTableQuery', () => {
       },
     });
 
-    renderHook(
-      () =>
-        useErrorsTableQuery({
-          widget,
-          organization,
-          pageFilters,
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useErrorsTableQuery({
+        widget,
+        organization,
+        pageFilters,
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -346,15 +321,13 @@ describe('useErrorsTableQuery', () => {
       },
     });
 
-    renderHook(
-      () =>
-        useErrorsTableQuery({
-          widget,
-          organization,
-          pageFilters,
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useErrorsTableQuery({
+        widget,
+        organization,
+        pageFilters,
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -391,18 +364,16 @@ describe('useErrorsTableQuery', () => {
       },
     });
 
-    renderHook(
-      () =>
-        useErrorsTableQuery({
-          widget,
-          organization,
-          pageFilters,
-          dashboardFilters: {
-            release: ['1.0.0'],
-          },
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useErrorsTableQuery({
+        widget,
+        organization,
+        pageFilters,
+        dashboardFilters: {
+          release: ['1.0.0'],
+        },
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -439,17 +410,15 @@ describe('useErrorsTableQuery', () => {
       },
     });
 
-    renderHook(
-      () =>
-        useErrorsTableQuery({
-          widget,
-          organization,
-          pageFilters,
-          enabled: true,
-          cursor: '0:10:0',
-          limit: 50,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useErrorsTableQuery({
+        widget,
+        organization,
+        pageFilters,
+        enabled: true,
+        cursor: '0:10:0',
+        limit: 50,
+      })
     );
 
     await waitFor(() => {

--- a/static/app/views/dashboards/widgetCard/hooks/useIssuesWidgetQuery.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useIssuesWidgetQuery.spec.tsx
@@ -2,10 +2,9 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 import {WidgetFixture} from 'sentry-fixture/widget';
 
-import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
-import {QueryClient, QueryClientProvider} from 'sentry/utils/queryClient';
 import {DisplayType} from 'sentry/views/dashboards/types';
 import {IssueSortOptions} from 'sentry/views/issueList/utils';
 
@@ -14,20 +13,6 @@ import {useIssuesSeriesQuery, useIssuesTableQuery} from './useIssuesWidgetQuery'
 jest.mock('sentry/views/dashboards/utils/widgetQueryQueue', () => ({
   useWidgetQueryQueue: () => ({queue: null}),
 }));
-
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-      },
-    },
-  });
-
-  return function Wrapper({children}: {children: React.ReactNode}) {
-    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
-  };
-}
 
 describe('useIssuesSeriesQuery', () => {
   const organization = OrganizationFixture();
@@ -66,15 +51,13 @@ describe('useIssuesSeriesQuery', () => {
       },
     });
 
-    renderHook(
-      () =>
-        useIssuesSeriesQuery({
-          widget,
-          organization,
-          pageFilters,
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useIssuesSeriesQuery({
+        widget,
+        organization,
+        pageFilters,
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -117,18 +100,16 @@ describe('useIssuesSeriesQuery', () => {
       },
     });
 
-    renderHook(
-      () =>
-        useIssuesSeriesQuery({
-          widget,
-          organization,
-          pageFilters,
-          dashboardFilters: {
-            release: ['1.0.0'],
-          },
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useIssuesSeriesQuery({
+        widget,
+        organization,
+        pageFilters,
+        dashboardFilters: {
+          release: ['1.0.0'],
+        },
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -183,15 +164,13 @@ describe('useIssuesTableQuery', () => {
       ],
     });
 
-    renderHook(
-      () =>
-        useIssuesTableQuery({
-          widget,
-          organization,
-          pageFilters,
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useIssuesTableQuery({
+        widget,
+        organization,
+        pageFilters,
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -236,17 +215,15 @@ describe('useIssuesTableQuery', () => {
       ],
     });
 
-    renderHook(
-      () =>
-        useIssuesTableQuery({
-          widget,
-          organization,
-          pageFilters,
-          limit: 50,
-          cursor: 'test-cursor',
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useIssuesTableQuery({
+        widget,
+        organization,
+        pageFilters,
+        limit: 50,
+        cursor: 'test-cursor',
+        enabled: true,
+      })
     );
 
     await waitFor(() => {

--- a/static/app/views/dashboards/widgetCard/hooks/useLogsWidgetQuery.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useLogsWidgetQuery.spec.tsx
@@ -2,10 +2,9 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 import {WidgetFixture} from 'sentry-fixture/widget';
 
-import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
-import {QueryClient, QueryClientProvider} from 'sentry/utils/queryClient';
 import {DisplayType} from 'sentry/views/dashboards/types';
 
 import {useLogsSeriesQuery, useLogsTableQuery} from './useLogsWidgetQuery';
@@ -13,20 +12,6 @@ import {useLogsSeriesQuery, useLogsTableQuery} from './useLogsWidgetQuery';
 jest.mock('sentry/views/dashboards/utils/widgetQueryQueue', () => ({
   useWidgetQueryQueue: () => ({queue: null}),
 }));
-
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-      },
-    },
-  });
-
-  return function Wrapper({children}: {children: React.ReactNode}) {
-    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
-  };
-}
 
 describe('useLogsSeriesQuery', () => {
   const organization = OrganizationFixture();
@@ -60,15 +45,13 @@ describe('useLogsSeriesQuery', () => {
       },
     });
 
-    renderHook(
-      () =>
-        useLogsSeriesQuery({
-          widget,
-          organization,
-          pageFilters,
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useLogsSeriesQuery({
+        widget,
+        organization,
+        pageFilters,
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -106,18 +89,16 @@ describe('useLogsSeriesQuery', () => {
       },
     });
 
-    renderHook(
-      () =>
-        useLogsSeriesQuery({
-          widget,
-          organization,
-          pageFilters,
-          dashboardFilters: {
-            release: ['1.0.0'],
-          },
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useLogsSeriesQuery({
+        widget,
+        organization,
+        pageFilters,
+        dashboardFilters: {
+          release: ['1.0.0'],
+        },
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -165,15 +146,13 @@ describe('useLogsTableQuery', () => {
       },
     });
 
-    renderHook(
-      () =>
-        useLogsTableQuery({
-          widget,
-          organization,
-          pageFilters,
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useLogsTableQuery({
+        widget,
+        organization,
+        pageFilters,
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -210,17 +189,15 @@ describe('useLogsTableQuery', () => {
       },
     });
 
-    renderHook(
-      () =>
-        useLogsTableQuery({
-          widget,
-          organization,
-          pageFilters,
-          limit: 50,
-          cursor: 'test-cursor',
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useLogsTableQuery({
+        widget,
+        organization,
+        pageFilters,
+        limit: 50,
+        cursor: 'test-cursor',
+        enabled: true,
+      })
     );
 
     await waitFor(() => {

--- a/static/app/views/dashboards/widgetCard/hooks/useReleasesWidgetQuery.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useReleasesWidgetQuery.spec.tsx
@@ -3,11 +3,10 @@ import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 import {SessionsFieldFixture} from 'sentry-fixture/sessions';
 import {WidgetFixture} from 'sentry-fixture/widget';
 
-import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {SessionField} from 'sentry/types/sessions';
-import {QueryClient, QueryClientProvider} from 'sentry/utils/queryClient';
 import {DisplayType} from 'sentry/views/dashboards/types';
 
 import {useReleasesSeriesQuery, useReleasesTableQuery} from './useReleasesWidgetQuery';
@@ -15,20 +14,6 @@ import {useReleasesSeriesQuery, useReleasesTableQuery} from './useReleasesWidget
 jest.mock('sentry/views/dashboards/utils/widgetQueryQueue', () => ({
   useWidgetQueryQueue: () => ({queue: null}),
 }));
-
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-      },
-    },
-  });
-
-  return function Wrapper({children}: {children: React.ReactNode}) {
-    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
-  };
-}
 
 describe('useReleasesSeriesQuery', () => {
   const organization = OrganizationFixture();
@@ -60,15 +45,13 @@ describe('useReleasesSeriesQuery', () => {
       body: SessionsFieldFixture(`crash_free_rate(${SessionField.SESSION})`),
     });
 
-    renderHook(
-      () =>
-        useReleasesSeriesQuery({
-          widget,
-          organization,
-          pageFilters,
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useReleasesSeriesQuery({
+        widget,
+        organization,
+        pageFilters,
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -104,18 +87,16 @@ describe('useReleasesSeriesQuery', () => {
       body: SessionsFieldFixture(`crash_free_rate(${SessionField.SESSION})`),
     });
 
-    renderHook(
-      () =>
-        useReleasesSeriesQuery({
-          widget,
-          organization,
-          pageFilters,
-          dashboardFilters: {
-            release: ['2.0.0'],
-          },
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useReleasesSeriesQuery({
+        widget,
+        organization,
+        pageFilters,
+        dashboardFilters: {
+          release: ['2.0.0'],
+        },
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -150,15 +131,13 @@ describe('useReleasesSeriesQuery', () => {
       body: SessionsFieldFixture(`sum(${SessionField.SESSION})`),
     });
 
-    renderHook(
-      () =>
-        useReleasesSeriesQuery({
-          widget,
-          organization,
-          pageFilters,
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useReleasesSeriesQuery({
+        widget,
+        organization,
+        pageFilters,
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -194,15 +173,13 @@ describe('useReleasesSeriesQuery', () => {
       body: SessionsFieldFixture(`crash_free_rate(${SessionField.SESSION})`),
     });
 
-    renderHook(
-      () =>
-        useReleasesSeriesQuery({
-          widget,
-          organization,
-          pageFilters,
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useReleasesSeriesQuery({
+        widget,
+        organization,
+        pageFilters,
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -249,15 +226,13 @@ describe('useReleasesTableQuery', () => {
       body: SessionsFieldFixture(`crash_free_rate(${SessionField.SESSION})`),
     });
 
-    renderHook(
-      () =>
-        useReleasesTableQuery({
-          widget,
-          organization,
-          pageFilters,
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useReleasesTableQuery({
+        widget,
+        organization,
+        pageFilters,
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -294,17 +269,15 @@ describe('useReleasesTableQuery', () => {
       body: SessionsFieldFixture(`crash_free_rate(${SessionField.SESSION})`),
     });
 
-    renderHook(
-      () =>
-        useReleasesTableQuery({
-          widget,
-          organization,
-          pageFilters,
-          limit: 50,
-          cursor: 'test-cursor',
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useReleasesTableQuery({
+        widget,
+        organization,
+        pageFilters,
+        limit: 50,
+        cursor: 'test-cursor',
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -340,18 +313,16 @@ describe('useReleasesTableQuery', () => {
       body: SessionsFieldFixture(`crash_free_rate(${SessionField.SESSION})`),
     });
 
-    renderHook(
-      () =>
-        useReleasesTableQuery({
-          widget,
-          organization,
-          pageFilters,
-          dashboardFilters: {
-            release: ['1.0.0'],
-          },
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useReleasesTableQuery({
+        widget,
+        organization,
+        pageFilters,
+        dashboardFilters: {
+          release: ['1.0.0'],
+        },
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -386,15 +357,13 @@ describe('useReleasesTableQuery', () => {
       body: SessionsFieldFixture(`sum(${SessionField.SESSION})`),
     });
 
-    renderHook(
-      () =>
-        useReleasesTableQuery({
-          widget,
-          organization,
-          pageFilters,
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useReleasesTableQuery({
+        widget,
+        organization,
+        pageFilters,
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -431,15 +400,13 @@ describe('useReleasesTableQuery', () => {
       body: SessionsFieldFixture(`crash_free_rate(${SessionField.SESSION})`),
     });
 
-    renderHook(
-      () =>
-        useReleasesTableQuery({
-          widget,
-          organization,
-          pageFilters,
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useReleasesTableQuery({
+        widget,
+        organization,
+        pageFilters,
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -475,15 +442,13 @@ describe('useReleasesTableQuery', () => {
       body: SessionsFieldFixture(`sum(${SessionField.SESSION})`),
     });
 
-    renderHook(
-      () =>
-        useReleasesTableQuery({
-          widget,
-          organization,
-          pageFilters,
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useReleasesTableQuery({
+        widget,
+        organization,
+        pageFilters,
+        enabled: true,
+      })
     );
 
     await waitFor(() => {

--- a/static/app/views/dashboards/widgetCard/hooks/useSpansWidgetQuery.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useSpansWidgetQuery.spec.tsx
@@ -2,10 +2,9 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 import {WidgetFixture} from 'sentry-fixture/widget';
 
-import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
-import {QueryClient, QueryClientProvider} from 'sentry/utils/queryClient';
 import {DisplayType} from 'sentry/views/dashboards/types';
 
 import {useSpansSeriesQuery, useSpansTableQuery} from './useSpansWidgetQuery';
@@ -13,20 +12,6 @@ import {useSpansSeriesQuery, useSpansTableQuery} from './useSpansWidgetQuery';
 jest.mock('sentry/views/dashboards/utils/widgetQueryQueue', () => ({
   useWidgetQueryQueue: () => ({queue: null}),
 }));
-
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-      },
-    },
-  });
-
-  return function Wrapper({children}: {children: React.ReactNode}) {
-    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
-  };
-}
 
 describe('useSpansSeriesQuery', () => {
   const organization = OrganizationFixture();
@@ -77,15 +62,13 @@ describe('useSpansSeriesQuery', () => {
       },
     });
 
-    renderHook(
-      () =>
-        useSpansSeriesQuery({
-          widget,
-          organization,
-          pageFilters: pageFiltersWithDates,
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useSpansSeriesQuery({
+        widget,
+        organization,
+        pageFilters: pageFiltersWithDates,
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -123,18 +106,16 @@ describe('useSpansSeriesQuery', () => {
       },
     });
 
-    renderHook(
-      () =>
-        useSpansSeriesQuery({
-          widget,
-          organization,
-          pageFilters,
-          dashboardFilters: {
-            release: ['1.0.0'],
-          },
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useSpansSeriesQuery({
+        widget,
+        organization,
+        pageFilters,
+        dashboardFilters: {
+          release: ['1.0.0'],
+        },
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -202,15 +183,13 @@ describe('useSpansSeriesQuery', () => {
       ],
     });
 
-    renderHook(
-      () =>
-        useSpansSeriesQuery({
-          widget,
-          organization,
-          pageFilters,
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useSpansSeriesQuery({
+        widget,
+        organization,
+        pageFilters,
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -241,15 +220,13 @@ describe('useSpansSeriesQuery', () => {
       },
     });
 
-    const {result} = renderHook(
-      () =>
-        useSpansSeriesQuery({
-          widget,
-          organization,
-          pageFilters,
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    const {result} = renderHookWithProviders(() =>
+      useSpansSeriesQuery({
+        widget,
+        organization,
+        pageFilters,
+        enabled: true,
+      })
     );
 
     expect(result.current.loading).toBe(true);
@@ -278,15 +255,13 @@ describe('useSpansSeriesQuery', () => {
       statusCode: 500,
     });
 
-    const {result} = renderHook(
-      () =>
-        useSpansSeriesQuery({
-          widget,
-          organization,
-          pageFilters,
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    const {result} = renderHookWithProviders(() =>
+      useSpansSeriesQuery({
+        widget,
+        organization,
+        pageFilters,
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -342,15 +317,13 @@ describe('useSpansTableQuery', () => {
       },
     });
 
-    renderHook(
-      () =>
-        useSpansTableQuery({
-          widget,
-          organization,
-          pageFilters: pageFiltersWithDates,
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useSpansTableQuery({
+        widget,
+        organization,
+        pageFilters: pageFiltersWithDates,
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -388,15 +361,13 @@ describe('useSpansTableQuery', () => {
       },
     });
 
-    const {result} = renderHook(
-      () =>
-        useSpansTableQuery({
-          widget,
-          organization,
-          pageFilters,
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    const {result} = renderHookWithProviders(() =>
+      useSpansTableQuery({
+        widget,
+        organization,
+        pageFilters,
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -426,18 +397,16 @@ describe('useSpansTableQuery', () => {
       },
     });
 
-    renderHook(
-      () =>
-        useSpansTableQuery({
-          widget,
-          organization,
-          pageFilters,
-          dashboardFilters: {
-            release: ['1.0.0'],
-          },
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useSpansTableQuery({
+        widget,
+        organization,
+        pageFilters,
+        dashboardFilters: {
+          release: ['1.0.0'],
+        },
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -474,17 +443,15 @@ describe('useSpansTableQuery', () => {
       },
     });
 
-    renderHook(
-      () =>
-        useSpansTableQuery({
-          widget,
-          organization,
-          pageFilters,
-          limit: 50,
-          cursor: 'test-cursor',
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useSpansTableQuery({
+        widget,
+        organization,
+        pageFilters,
+        limit: 50,
+        cursor: 'test-cursor',
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -522,15 +489,13 @@ describe('useSpansTableQuery', () => {
       },
     });
 
-    const {result} = renderHook(
-      () =>
-        useSpansTableQuery({
-          widget,
-          organization,
-          pageFilters,
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    const {result} = renderHookWithProviders(() =>
+      useSpansTableQuery({
+        widget,
+        organization,
+        pageFilters,
+        enabled: true,
+      })
     );
 
     expect(result.current.loading).toBe(true);
@@ -559,15 +524,13 @@ describe('useSpansTableQuery', () => {
       statusCode: 500,
     });
 
-    const {result} = renderHook(
-      () =>
-        useSpansTableQuery({
-          widget,
-          organization,
-          pageFilters,
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    const {result} = renderHookWithProviders(() =>
+      useSpansTableQuery({
+        widget,
+        organization,
+        pageFilters,
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -601,15 +564,13 @@ describe('useSpansTableQuery', () => {
       },
     });
 
-    renderHook(
-      () =>
-        useSpansTableQuery({
-          widget,
-          organization,
-          pageFilters,
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useSpansTableQuery({
+        widget,
+        organization,
+        pageFilters,
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -644,15 +605,13 @@ describe('useSpansTableQuery', () => {
         data: [{transaction: '/api/test', 'count()': 100}],
       },
     });
-    renderHook(
-      () =>
-        useSpansTableQuery({
-          widget,
-          organization,
-          pageFilters,
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useSpansTableQuery({
+        widget,
+        organization,
+        pageFilters,
+        enabled: true,
+      })
     );
     await waitFor(() => {
       expect(mockRequest).toHaveBeenCalledWith(
@@ -688,15 +647,13 @@ describe('useSpansTableQuery', () => {
       },
     });
 
-    renderHook(
-      () =>
-        useSpansTableQuery({
-          widget,
-          organization,
-          pageFilters,
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useSpansTableQuery({
+        widget,
+        organization,
+        pageFilters,
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -734,16 +691,14 @@ describe('useSpansTableQuery', () => {
       },
     });
 
-    renderHook(
-      () =>
-        useSpansTableQuery({
-          widget,
-          organization,
-          pageFilters,
-          limit: 15,
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useSpansTableQuery({
+        widget,
+        organization,
+        pageFilters,
+        limit: 15,
+        enabled: true,
+      })
     );
 
     await waitFor(() => {

--- a/static/app/views/dashboards/widgetCard/hooks/useTraceMetricsWidgetQuery.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useTraceMetricsWidgetQuery.spec.tsx
@@ -2,10 +2,9 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 import {WidgetFixture} from 'sentry-fixture/widget';
 
-import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
-import {QueryClient, QueryClientProvider} from 'sentry/utils/queryClient';
 import {DisplayType} from 'sentry/views/dashboards/types';
 
 import {
@@ -16,20 +15,6 @@ import {
 jest.mock('sentry/views/dashboards/utils/widgetQueryQueue', () => ({
   useWidgetQueryQueue: () => ({queue: null}),
 }));
-
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-      },
-    },
-  });
-
-  return function Wrapper({children}: {children: React.ReactNode}) {
-    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
-  };
-}
 
 describe('useTraceMetricsSeriesQuery', () => {
   const organization = OrganizationFixture();
@@ -74,15 +59,13 @@ describe('useTraceMetricsSeriesQuery', () => {
       },
     });
 
-    renderHook(
-      () =>
-        useTraceMetricsSeriesQuery({
-          widget,
-          organization,
-          pageFilters,
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useTraceMetricsSeriesQuery({
+        widget,
+        organization,
+        pageFilters,
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -130,18 +113,16 @@ describe('useTraceMetricsSeriesQuery', () => {
       },
     });
 
-    renderHook(
-      () =>
-        useTraceMetricsSeriesQuery({
-          widget,
-          organization,
-          pageFilters,
-          dashboardFilters: {
-            release: ['1.0.0'],
-          },
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useTraceMetricsSeriesQuery({
+        widget,
+        organization,
+        pageFilters,
+        dashboardFilters: {
+          release: ['1.0.0'],
+        },
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -178,15 +159,13 @@ describe('useTraceMetricsSeriesQuery', () => {
       },
     });
 
-    renderHook(
-      () =>
-        useTraceMetricsSeriesQuery({
-          widget,
-          organization,
-          pageFilters,
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useTraceMetricsSeriesQuery({
+        widget,
+        organization,
+        pageFilters,
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -239,15 +218,13 @@ describe('useTraceMetricsTableQuery', () => {
       },
     });
 
-    renderHook(
-      () =>
-        useTraceMetricsTableQuery({
-          widget,
-          organization,
-          pageFilters,
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useTraceMetricsTableQuery({
+        widget,
+        organization,
+        pageFilters,
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -289,17 +266,15 @@ describe('useTraceMetricsTableQuery', () => {
       },
     });
 
-    renderHook(
-      () =>
-        useTraceMetricsTableQuery({
-          widget,
-          organization,
-          pageFilters,
-          limit: 25,
-          cursor: 'test-cursor',
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useTraceMetricsTableQuery({
+        widget,
+        organization,
+        pageFilters,
+        limit: 25,
+        cursor: 'test-cursor',
+        enabled: true,
+      })
     );
 
     await waitFor(() => {

--- a/static/app/views/dashboards/widgetCard/hooks/useTransactionsWidgetQuery.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/hooks/useTransactionsWidgetQuery.spec.tsx
@@ -2,12 +2,11 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 import {WidgetFixture} from 'sentry-fixture/widget';
 
-import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {MEPState} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
-import {QueryClient, QueryClientProvider} from 'sentry/utils/queryClient';
 import {DisplayType} from 'sentry/views/dashboards/types';
 
 import {
@@ -18,20 +17,6 @@ import {
 jest.mock('sentry/views/dashboards/utils/widgetQueryQueue', () => ({
   useWidgetQueryQueue: () => ({queue: null}),
 }));
-
-function createWrapper() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-      },
-    },
-  });
-
-  return function Wrapper({children}: {children: React.ReactNode}) {
-    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
-  };
-}
 
 describe('useTransactionsSeriesQuery', () => {
   const organization = OrganizationFixture({
@@ -67,15 +52,13 @@ describe('useTransactionsSeriesQuery', () => {
       },
     });
 
-    renderHook(
-      () =>
-        useTransactionsSeriesQuery({
-          widget,
-          organization,
-          pageFilters,
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useTransactionsSeriesQuery({
+        widget,
+        organization,
+        pageFilters,
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -113,16 +96,14 @@ describe('useTransactionsSeriesQuery', () => {
       },
     });
 
-    renderHook(
-      () =>
-        useTransactionsSeriesQuery({
-          widget,
-          organization,
-          pageFilters,
-          enabled: true,
-          mepSetting: MEPState.AUTO,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useTransactionsSeriesQuery({
+        widget,
+        organization,
+        pageFilters,
+        enabled: true,
+        mepSetting: MEPState.AUTO,
+      })
     );
 
     await waitFor(() => {
@@ -172,15 +153,13 @@ describe('useTransactionsTableQuery', () => {
       },
     });
 
-    renderHook(
-      () =>
-        useTransactionsTableQuery({
-          widget,
-          organization,
-          pageFilters,
-          enabled: true,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useTransactionsTableQuery({
+        widget,
+        organization,
+        pageFilters,
+        enabled: true,
+      })
     );
 
     await waitFor(() => {
@@ -217,16 +196,14 @@ describe('useTransactionsTableQuery', () => {
       },
     });
 
-    renderHook(
-      () =>
-        useTransactionsTableQuery({
-          widget,
-          organization,
-          pageFilters,
-          enabled: true,
-          mepSetting: MEPState.AUTO,
-        }),
-      {wrapper: createWrapper()}
+    renderHookWithProviders(() =>
+      useTransactionsTableQuery({
+        widget,
+        organization,
+        pageFilters,
+        enabled: true,
+        mepSetting: MEPState.AUTO,
+      })
     );
 
     await waitFor(() => {

--- a/static/app/views/explore/hooks/useSortByFields.spec.tsx
+++ b/static/app/views/explore/hooks/useSortByFields.spec.tsx
@@ -1,17 +1,13 @@
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {makeTestQueryClient} from 'sentry-test/queryClient';
-import {renderHook} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
-import type {Organization} from 'sentry/types/organization';
-import {QueryClientProvider} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import type {TraceItemAttributeConfig} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {useSortByFields} from 'sentry/views/explore/hooks/useSortByFields';
 import {TraceItemDataset} from 'sentry/views/explore/types';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 jest.mock('sentry/utils/useLocation');
 const mockedUsedLocation = jest.mocked(useLocation);
@@ -19,16 +15,6 @@ const spansConfig: TraceItemAttributeConfig = {
   traceItemType: TraceItemDataset.SPANS,
   enabled: true,
 };
-
-function createWrapper(organization: Organization) {
-  return function ({children}: {children?: React.ReactNode}) {
-    return (
-      <QueryClientProvider client={makeTestQueryClient()}>
-        <OrganizationContext value={organization}>{children}</OrganizationContext>
-      </QueryClientProvider>
-    );
-  };
-}
 
 describe('useSortByFields', () => {
   const organization = OrganizationFixture();
@@ -45,7 +31,7 @@ describe('useSortByFields', () => {
   });
 
   it('returns a valid list of field options in samples mode', () => {
-    const {result} = renderHook(
+    const {result} = renderHookWithProviders(
       () =>
         useSortByFields({
           config: spansConfig,
@@ -61,9 +47,7 @@ describe('useSortByFields', () => {
           yAxes: ['avg(span.duration)'],
           mode: Mode.SAMPLES,
         }),
-      {
-        wrapper: createWrapper(organization),
-      }
+      {organization}
     );
 
     expect(result.current.map(field => field.value)).toEqual([
@@ -77,7 +61,7 @@ describe('useSortByFields', () => {
   });
 
   it('returns a valid list of field options in aggregate mode', () => {
-    const {result} = renderHook(
+    const {result} = renderHookWithProviders(
       () =>
         useSortByFields({
           config: spansConfig,
@@ -86,9 +70,7 @@ describe('useSortByFields', () => {
           yAxes: ['avg(span.duration)'],
           mode: Mode.AGGREGATE,
         }),
-      {
-        wrapper: createWrapper(organization),
-      }
+      {organization}
     );
 
     expect(result.current.map(field => field.value)).toEqual([

--- a/static/app/views/explore/hooks/useVisualizeFields.spec.tsx
+++ b/static/app/views/explore/hooks/useVisualizeFields.spec.tsx
@@ -1,30 +1,16 @@
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {makeTestQueryClient} from 'sentry-test/queryClient';
-import {renderHook} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
-import type {Organization} from 'sentry/types/organization';
 import {parseFunction} from 'sentry/utils/discover/fields';
-import {QueryClientProvider} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useSpanItemAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {useVisualizeFields} from 'sentry/views/explore/hooks/useVisualizeFields';
 import {TraceItemDataset} from 'sentry/views/explore/types';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 jest.mock('sentry/utils/useLocation');
 const mockedUsedLocation = jest.mocked(useLocation);
-
-function createWrapper(organization: Organization) {
-  return function ({children}: {children?: React.ReactNode}) {
-    return (
-      <QueryClientProvider client={makeTestQueryClient()}>
-        <OrganizationContext value={organization}>{children}</OrganizationContext>
-      </QueryClientProvider>
-    );
-  };
-}
 
 function useWrapper(yAxis: string) {
   const {attributes: stringTags} = useSpanItemAttributes({}, 'string');
@@ -54,8 +40,8 @@ describe('useVisualizeFields', () => {
   });
 
   it('returns numeric fields', () => {
-    const {result} = renderHook(() => useWrapper('avg(score.ttfb)'), {
-      wrapper: createWrapper(organization),
+    const {result} = renderHookWithProviders(() => useWrapper('avg(score.ttfb)'), {
+      organization,
     });
 
     expect(result.current.map(field => field.value)).toEqual([
@@ -66,16 +52,16 @@ describe('useVisualizeFields', () => {
   });
 
   it('returns numeric fields for count', () => {
-    const {result} = renderHook(() => useWrapper('count(span.duration)'), {
-      wrapper: createWrapper(organization),
+    const {result} = renderHookWithProviders(() => useWrapper('count(span.duration)'), {
+      organization,
     });
 
     expect(result.current.map(field => field.value)).toEqual(['span.duration']);
   });
 
   it('returns string fields for count_unique', () => {
-    const {result} = renderHook(() => useWrapper('count_unique(foobar)'), {
-      wrapper: createWrapper(organization),
+    const {result} = renderHookWithProviders(() => useWrapper('count_unique(foobar)'), {
+      organization,
     });
 
     expect(result.current.map(field => field.value)).toEqual(

--- a/static/app/views/insights/common/queries/useDiscover.spec.tsx
+++ b/static/app/views/insights/common/queries/useDiscover.spec.tsx
@@ -1,31 +1,19 @@
-import type {ReactNode} from 'react';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 
-import {makeTestQueryClient} from 'sentry-test/queryClient';
-import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import {QueryClientProvider} from 'sentry/utils/queryClient';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import type {SpanProperty} from 'sentry/views/insights/types';
 import {SpanFields} from 'sentry/views/insights/types';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 jest.mock('sentry/utils/useLocation');
 jest.mock('sentry/components/pageFilters/usePageFilters');
-
-function Wrapper({children}: {children?: ReactNode}) {
-  return (
-    <QueryClientProvider client={makeTestQueryClient()}>
-      <OrganizationContext value={OrganizationFixture()}>{children}</OrganizationContext>
-    </QueryClientProvider>
-  );
-}
 
 describe('useDiscover', () => {
   describe('useSpans', () => {
@@ -46,10 +34,9 @@ describe('useDiscover', () => {
         body: {data: []},
       });
 
-      const {result} = renderHook(
+      const {result} = renderHookWithProviders(
         ({fields, enabled}) => useSpans({fields, enabled}, 'span-metrics-series'),
         {
-          wrapper: Wrapper,
           initialProps: {
             fields: ['epm()'] as SpanProperty[],
             enabled: false,
@@ -76,7 +63,7 @@ describe('useDiscover', () => {
         },
       });
 
-      const {result} = renderHook(
+      const {result} = renderHookWithProviders(
         ({filters, fields, sorts, limit, cursor, referrer}) =>
           useSpans(
             {
@@ -89,7 +76,6 @@ describe('useDiscover', () => {
             referrer
           ),
         {
-          wrapper: Wrapper,
           initialProps: {
             filters: {
               'span.group': '221aa7ebd216',
@@ -173,10 +159,9 @@ describe('useDiscover', () => {
         body: {data: []},
       });
 
-      const {result} = renderHook(
+      const {result} = renderHookWithProviders(
         ({fields, enabled}) => useSpans({fields, enabled}, 'referrer'),
         {
-          wrapper: Wrapper,
           initialProps: {
             fields: [SpanFields.SPAN_DESCRIPTION] as SpanProperty[],
             enabled: false,
@@ -210,7 +195,7 @@ describe('useDiscover', () => {
         },
       });
 
-      const {result} = renderHook(
+      const {result} = renderHookWithProviders(
         ({filters, fields, sorts, limit, cursor, referrer}) =>
           useSpans(
             {
@@ -223,7 +208,6 @@ describe('useDiscover', () => {
             referrer
           ),
         {
-          wrapper: Wrapper,
           initialProps: {
             filters: {
               'span.group': '221aa7ebd216',

--- a/static/app/views/replays/detail/header/replayDetailsUserBadge.spec.tsx
+++ b/static/app/views/replays/detail/header/replayDetailsUserBadge.spec.tsx
@@ -1,4 +1,4 @@
-import {act, type ReactNode} from 'react';
+import {act} from 'react';
 import {duration} from 'moment-timezone';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ReplayNavigateEventFixture} from 'sentry-fixture/replay/helpers';
@@ -6,27 +6,20 @@ import {RRWebInitFrameEventsFixture} from 'sentry-fixture/replay/rrweb';
 import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
-import {makeTestQueryClient} from 'sentry-test/queryClient';
-import {render, renderHook, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  renderHookWithProviders,
+  screen,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
 
-import {QueryClientProvider} from 'sentry/utils/queryClient';
 import {useLoadReplayReader} from 'sentry/utils/replays/hooks/useLoadReplayReader';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 import {ReplayDetailsUserBadge} from 'sentry/views/replays/detail/header/replayDetailsUserBadge';
 import type {HydratedReplayRecord} from 'sentry/views/replays/types';
 
 const {organization, project} = initializeOrg({
   organization: OrganizationFixture({}),
 });
-
-function wrapper({children}: {children?: ReactNode}) {
-  const queryClient = makeTestQueryClient();
-  return (
-    <QueryClientProvider client={queryClient}>
-      <OrganizationContext value={organization}>{children}</OrganizationContext>
-    </QueryClientProvider>
-  );
-}
 
 function replayRecordFixture(replayRecord?: Partial<HydratedReplayRecord>) {
   return ReplayRecordFixture({
@@ -80,8 +73,8 @@ describe('replayDetailsUserBadge', () => {
       match: [(_url, options) => options.query?.cursor === '0:0:0'],
     });
 
-    const {result} = renderHook(useLoadReplayReader, {
-      wrapper,
+    const {result} = renderHookWithProviders(useLoadReplayReader, {
+      organization,
       initialProps: {
         orgSlug: organization.slug,
         replaySlug: `${project.slug}:${replayRecord.id}`,
@@ -142,8 +135,8 @@ describe('replayDetailsUserBadge', () => {
       match: [(_url, options) => options.query?.cursor === '0:0:0'],
     });
 
-    const {result} = renderHook(useLoadReplayReader, {
-      wrapper,
+    const {result} = renderHookWithProviders(useLoadReplayReader, {
+      organization,
       initialProps: {
         orgSlug: organization.slug,
         replaySlug: `${project.slug}:${replayRecord.id}`,

--- a/static/gsApp/hooks/genAiAccess.spec.tsx
+++ b/static/gsApp/hooks/genAiAccess.spec.tsx
@@ -2,12 +2,10 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {UserFixture} from 'sentry-fixture/user';
 
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
-import {renderHook} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
-import type {Organization} from 'sentry/types/organization';
 import {getRegionDataFromOrganization} from 'sentry/utils/regions';
 import {useUser} from 'sentry/utils/useUser';
-import {OrganizationContext} from 'sentry/views/organizationContext';
 
 import {BillingType} from 'getsentry/types';
 
@@ -21,12 +19,6 @@ jest.mock('sentry/utils/regions', () => ({
 
 const mockUseUser = jest.mocked(useUser);
 const mockGetRegionData = jest.mocked(getRegionDataFromOrganization);
-
-const contextWrapper = (organization: Organization) => {
-  return function ({children}: {children: React.ReactNode}) {
-    return <OrganizationContext value={organization}>{children}</OrganizationContext>;
-  };
-};
 
 describe('useGenAiConsentButtonAccess', () => {
   beforeEach(() => {
@@ -52,9 +44,10 @@ describe('useGenAiConsentButtonAccess', () => {
       });
       mockUseUser.mockReturnValue(UserFixture({isSuperuser: false}));
 
-      const {result} = renderHook(() => useGenAiConsentButtonAccess({subscription}), {
-        wrapper: contextWrapper(organization),
-      });
+      const {result} = renderHookWithProviders(
+        () => useGenAiConsentButtonAccess({subscription}),
+        {organization}
+      );
 
       expect(result.current).toEqual(
         expect.objectContaining({
@@ -83,9 +76,10 @@ describe('useGenAiConsentButtonAccess', () => {
       });
       mockUseUser.mockReturnValue(UserFixture({isSuperuser: false}));
 
-      const {result} = renderHook(() => useGenAiConsentButtonAccess({subscription}), {
-        wrapper: contextWrapper(organization),
-      });
+      const {result} = renderHookWithProviders(
+        () => useGenAiConsentButtonAccess({subscription}),
+        {organization}
+      );
 
       expect(result.current).toEqual(
         expect.objectContaining({
@@ -114,9 +108,10 @@ describe('useGenAiConsentButtonAccess', () => {
       });
       mockUseUser.mockReturnValue(UserFixture({isSuperuser: true}));
 
-      const {result} = renderHook(() => useGenAiConsentButtonAccess({subscription}), {
-        wrapper: contextWrapper(organization),
-      });
+      const {result} = renderHookWithProviders(
+        () => useGenAiConsentButtonAccess({subscription}),
+        {organization}
+      );
 
       expect(result.current).toEqual(
         expect.objectContaining({
@@ -145,9 +140,10 @@ describe('useGenAiConsentButtonAccess', () => {
       });
       mockUseUser.mockReturnValue(UserFixture({isSuperuser: false}));
 
-      const {result} = renderHook(() => useGenAiConsentButtonAccess({subscription}), {
-        wrapper: contextWrapper(organization),
-      });
+      const {result} = renderHookWithProviders(
+        () => useGenAiConsentButtonAccess({subscription}),
+        {organization}
+      );
 
       expect(result.current).toEqual(
         expect.objectContaining({
@@ -179,9 +175,10 @@ describe('useGenAiConsentButtonAccess', () => {
       });
       mockUseUser.mockReturnValue(UserFixture({isSuperuser: false}));
 
-      const {result} = renderHook(() => useGenAiConsentButtonAccess({subscription}), {
-        wrapper: contextWrapper(organization),
-      });
+      const {result} = renderHookWithProviders(
+        () => useGenAiConsentButtonAccess({subscription}),
+        {organization}
+      );
 
       expect(result.current).toEqual(
         expect.objectContaining({
@@ -210,9 +207,10 @@ describe('useGenAiConsentButtonAccess', () => {
       });
       mockUseUser.mockReturnValue(UserFixture({isSuperuser: false}));
 
-      const {result} = renderHook(() => useGenAiConsentButtonAccess({subscription}), {
-        wrapper: contextWrapper(organization),
-      });
+      const {result} = renderHookWithProviders(
+        () => useGenAiConsentButtonAccess({subscription}),
+        {organization}
+      );
 
       expect(result.current).toEqual(
         expect.objectContaining({


### PR DESCRIPTION
Related to https://github.com/getsentry/frontend-tsc/issues/96