### PR TITLE
fix(seer): Feature flag Seer RPC preference reads

### DIFF
--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -89,7 +89,7 @@ from sentry.seer.autofix.utils import (
     write_preference_to_sentry_db,
 )
 from sentry.seer.autofix.utils import (
-    bulk_get_project_preferences as bulk_get_preferences_from_seer_api,
+    bulk_get_project_preferences as bulk_get_project_seer_preferences,
 )
 from sentry.seer.constants import SEER_SUPPORTED_SCM_PROVIDERS, SeerSCMProvider
 from sentry.seer.entrypoints.operator import SeerAutofixOperator, process_autofix_updates
@@ -910,7 +910,7 @@ def bulk_get_project_preferences(*, organization_id: int, project_ids: list[int]
             for project_id, preference in preferences.items()
         }
     else:
-        return bulk_get_preferences_from_seer_api(organization_id, project_ids)
+        return bulk_get_project_seer_preferences(organization_id, project_ids)
 
 
 seer_method_registry: dict[str, Callable] = {  # return type must be serialized

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -900,8 +900,7 @@ def bulk_get_project_preferences(*, organization_id: int, project_ids: list[int]
     """Bulk get Seer project preferences.
 
     Returns a dict keyed by stringified project ID. Values are preference dicts or None
-    for projects with no configured preferences. Projects that don't belong to the
-    given organization are silently excluded from the result.
+    for projects with no configured preferences.
     """
     organization = Organization.objects.get_from_cache(id=organization_id)
     if features.has("organizations:seer-project-settings-read-from-sentry", organization):

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -88,6 +88,9 @@ from sentry.seer.autofix.utils import (
     resolve_repository_ids,
     write_preference_to_sentry_db,
 )
+from sentry.seer.autofix.utils import (
+    bulk_get_project_preferences as bulk_get_preferences_from_seer_api,
+)
 from sentry.seer.constants import SEER_SUPPORTED_SCM_PROVIDERS, SeerSCMProvider
 from sentry.seer.entrypoints.operator import SeerAutofixOperator, process_autofix_updates
 from sentry.seer.explorer.custom_tool_utils import call_custom_tool
@@ -873,7 +876,7 @@ def check_repository_integrations_status(*, repository_integrations: list[dict[s
 
 
 def get_project_preferences(*, organization_id: int, project_id: int) -> dict | None:
-    """Get Seer project preferences for a single project from Sentry DB.
+    """Get Seer project preferences for a single project.
 
     Raises Project.DoesNotExist if the project is not found or doesn't belong to the org.
     Returns None if the project has no configured preferences.
@@ -882,24 +885,33 @@ def get_project_preferences(*, organization_id: int, project_id: int) -> dict | 
     if project.organization_id != organization_id:
         raise Project.DoesNotExist
 
-    preference = read_preference_from_sentry_db(project)
+    organization = Organization.objects.get_from_cache(id=organization_id)
+    if features.has("organizations:seer-project-settings-read-from-sentry", organization):
+        preference = read_preference_from_sentry_db(project)
+    else:
+        preference = get_project_seer_preferences(project_id).preference
+
     if preference is None:
         return None
     return preference.dict()
 
 
 def bulk_get_project_preferences(*, organization_id: int, project_ids: list[int]) -> dict:
-    """Bulk get Seer project preferences from Sentry DB.
+    """Bulk get Seer project preferences.
 
     Returns a dict keyed by stringified project ID. Values are preference dicts or None
     for projects with no configured preferences. Projects that don't belong to the
     given organization are silently excluded from the result.
     """
-    preferences = bulk_read_preferences_from_sentry_db(organization_id, project_ids)
-    return {
-        str(project_id): preference.dict() if preference else None
-        for project_id, preference in preferences.items()
-    }
+    organization = Organization.objects.get_from_cache(id=organization_id)
+    if features.has("organizations:seer-project-settings-read-from-sentry", organization):
+        preferences = bulk_read_preferences_from_sentry_db(organization_id, project_ids)
+        return {
+            str(project_id): preference.dict() if preference else None
+            for project_id, preference in preferences.items()
+        }
+    else:
+        return bulk_get_preferences_from_seer_api(organization_id, project_ids)
 
 
 seer_method_registry: dict[str, Callable] = {  # return type must be serialized

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -1631,7 +1631,7 @@ class TestSeerRpcMethods(APITestCase):
         )
         assert result == {}
 
-    @patch("sentry.seer.endpoints.seer_rpc.bulk_get_preferences_from_seer_api")
+    @patch("sentry.seer.endpoints.seer_rpc.bulk_get_project_seer_preferences")
     def test_bulk_get_project_preferences_seer_api(self, mock_seer: Any) -> None:
         project1 = self.create_project(organization=self.organization)
         project2 = self.create_project(organization=self.organization)

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -31,6 +31,7 @@ from sentry.seer.endpoints.seer_rpc import (
 from sentry.seer.explorer.tools import get_trace_item_attributes
 from sentry.sentry_apps.metrics import SentryAppEventType
 from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode_of
 from sentry.utils.snuba_rpc import SnubaRPCRateLimitExceeded
 
@@ -1531,6 +1532,7 @@ class TestSeerRpcMethods(APITestCase):
 
         assert result == {"error": "integration_not_found"}
 
+    @with_feature("organizations:seer-project-settings-read-from-sentry")
     @patch("sentry.seer.endpoints.seer_rpc.read_preference_from_sentry_db")
     def test_get_project_preferences_returns_preference(self, mock_read: Any) -> None:
         project = self.create_project(organization=self.organization)
@@ -1544,6 +1546,7 @@ class TestSeerRpcMethods(APITestCase):
         assert result == {"project_id": project.id, "repositories": []}
         mock_read.assert_called_once()
 
+    @with_feature("organizations:seer-project-settings-read-from-sentry")
     @patch("sentry.seer.endpoints.seer_rpc.read_preference_from_sentry_db")
     def test_get_project_preferences_returns_none_when_no_preference(self, mock_read: Any) -> None:
         project = self.create_project(organization=self.organization)
@@ -1570,6 +1573,32 @@ class TestSeerRpcMethods(APITestCase):
                 project_id=project.id,
             )
 
+    @patch("sentry.seer.endpoints.seer_rpc.get_project_seer_preferences")
+    def test_get_project_preferences_seer_api(self, mock_seer: Any) -> None:
+        project = self.create_project(organization=self.organization)
+        mock_seer.return_value = MagicMock(
+            preference=MagicMock(
+                dict=MagicMock(return_value={"project_id": project.id, "repositories": []})
+            )
+        )
+        result = get_project_preferences(
+            organization_id=self.organization.id,
+            project_id=project.id,
+        )
+        assert result == {"project_id": project.id, "repositories": []}
+        mock_seer.assert_called_once_with(project.id)
+
+    @patch("sentry.seer.endpoints.seer_rpc.get_project_seer_preferences")
+    def test_get_project_preferences_seer_api_returns_none(self, mock_seer: Any) -> None:
+        project = self.create_project(organization=self.organization)
+        mock_seer.return_value = MagicMock(preference=None)
+        result = get_project_preferences(
+            organization_id=self.organization.id,
+            project_id=project.id,
+        )
+        assert result is None
+
+    @with_feature("organizations:seer-project-settings-read-from-sentry")
     @patch("sentry.seer.endpoints.seer_rpc.bulk_read_preferences_from_sentry_db")
     def test_bulk_get_project_preferences_returns_preferences(self, mock_bulk_read: Any) -> None:
         project1 = self.create_project(organization=self.organization)
@@ -1590,6 +1619,7 @@ class TestSeerRpcMethods(APITestCase):
         }
         mock_bulk_read.assert_called_once_with(self.organization.id, [project1.id, project2.id])
 
+    @with_feature("organizations:seer-project-settings-read-from-sentry")
     @patch("sentry.seer.endpoints.seer_rpc.bulk_read_preferences_from_sentry_db")
     def test_bulk_get_project_preferences_returns_empty_for_no_projects(
         self, mock_bulk_read: Any
@@ -1600,6 +1630,24 @@ class TestSeerRpcMethods(APITestCase):
             project_ids=[],
         )
         assert result == {}
+
+    @patch("sentry.seer.endpoints.seer_rpc.bulk_get_preferences_from_seer_api")
+    def test_bulk_get_project_preferences_seer_api(self, mock_seer: Any) -> None:
+        project1 = self.create_project(organization=self.organization)
+        project2 = self.create_project(organization=self.organization)
+        mock_seer.return_value = {
+            str(project1.id): {"project_id": project1.id, "repositories": []},
+            str(project2.id): None,
+        }
+        result = bulk_get_project_preferences(
+            organization_id=self.organization.id,
+            project_ids=[project1.id, project2.id],
+        )
+        assert result == {
+            str(project1.id): {"project_id": project1.id, "repositories": []},
+            str(project2.id): None,
+        }
+        mock_seer.assert_called_once_with(self.organization.id, [project1.id, project2.id])
 
 
 class TestTriggerCodingAgentLaunch:


### PR DESCRIPTION
The Seer RPC functions to get project preferences should be feature-flagged under `organizations:seer-project-settings-read-from-sentry`. 