### PR TITLE
ref(integrations): Log specific external IDs in repo sync diff

### DIFF
--- a/src/sentry/integrations/source_code_management/sync_repos.py
+++ b/src/sentry/integrations/source_code_management/sync_repos.py
@@ -189,6 +189,9 @@ def sync_repos_for_org(organization_integration_id: int) -> None:
                     "new": len(new_ids),
                     "removed": len(removed_ids),
                     "restored": len(restored_ids),
+                    "new_ids": list(new_ids),
+                    "removed_ids": list(removed_ids),
+                    "restored_ids": list(restored_ids),
                 },
             )
 


### PR DESCRIPTION
Log the actual new/removed/restored external IDs instead of just counts, so we can verify exactly which repos the sync would affect during the dry run.