### PR TITLE
ref(ci): add cancel-in-progress to pull_request prs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,10 @@ on:
   schedule:
     - cron: '44 12 * * 1'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/enforce-license-compliance.yml
+++ b/.github/workflows/enforce-license-compliance.yml
@@ -3,6 +3,10 @@ name: Enforce License Compliance
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   enforce-license-compliance:
     runs-on: ubuntu-latest

--- a/.github/workflows/sentry-pull-request-bot.yml
+++ b/.github/workflows/sentry-pull-request-bot.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     types: [opened, edited]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   # TODO(billy): Move this into an external action as we add more functionality
   test-getsentry:


### PR DESCRIPTION
we already do this for all most pull_request workflows here - giving it a fresh pass

---

this adds concurrency cancellation to pull_request workflows so that pushing a new commit to a PR automatically cancels any still-running workflow from the previous commit

99% of the time if you push a new commit you don't care about the previous workflow if its still running

we (devinfra) can't measure this yet but this would greatly help decrease org-wide runner queue pressure!
