### PR TITLE
ref(useApiQueries): Refactor the two callers of useApiQueries to remove that abstraction

### DIFF
--- a/static/app/utils/queryClient.tsx
+++ b/static/app/utils/queryClient.tsx
@@ -7,7 +7,7 @@ import type {
   UseQueryOptions,
   UseQueryResult,
 } from '@tanstack/react-query';
-import {useInfiniteQuery, useQueries, useQuery} from '@tanstack/react-query';
+import {useInfiniteQuery, useQuery} from '@tanstack/react-query';
 
 import type {ApiResult, ResponseMeta} from 'sentry/api';
 import {Client} from 'sentry/api';
@@ -118,34 +118,6 @@ export function useApiQuery<TResponseData, TError = RequestError>(
   //      useQuery above. The react-query library's UseQueryResult is a union type and
   //      too complex to recreate here so casting the entire object is more appropriate.
   return queryResult as UseApiQueryResult<TResponseData, TError>;
-}
-
-export function useApiQueries<TResponseData, TError = RequestError>(
-  queryKeys: ApiQueryKey[],
-  options: UseApiQueryOptions<TResponseData, TError>
-): Array<UseApiQueryResult<TResponseData, TError>> {
-  const results = useQueries({
-    queries: queryKeys.map(queryKey => {
-      return {
-        queryKey,
-        queryFn: fetchDataQuery<TResponseData>,
-        ...options,
-      };
-    }),
-  });
-
-  return results.map(({data, ...rest}) => {
-    const queryResult = {
-      data: data?.[0],
-      getResponseHeader: data?.[2]?.getResponseHeader,
-      ...rest,
-    };
-
-    // XXX: We need to cast here because unwrapping `data` breaks the type returned by
-    //      useQuery above. The react-query library's UseQueryResult is a union type and
-    //      too complex to recreate here so casting the entire object is more appropriate.
-    return queryResult as UseApiQueryResult<TResponseData, TError>;
-  });
 }
 
 /**

--- a/static/app/utils/replays/hooks/useFeedbackEvents.tsx
+++ b/static/app/utils/replays/hooks/useFeedbackEvents.tsx
@@ -1,6 +1,7 @@
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {skipToken, useQueries} from '@tanstack/react-query';
+
+import {apiOptions} from 'sentry/utils/api/apiOptions';
 import type {FeedbackEvent} from 'sentry/utils/feedback/types';
-import {useApiQueries} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 export function useFeedbackEvents({
@@ -12,31 +13,26 @@ export function useFeedbackEvents({
 }) {
   const organization = useOrganization();
 
-  const feedbackEventQuery = useApiQueries<FeedbackEvent>(
-    feedbackEventIds.map((feedbackEventId: string) => [
-      getApiUrl('/projects/$organizationIdOrSlug/$projectIdOrSlug/events/$eventId/', {
-        path: {
-          organizationIdOrSlug: organization.slug,
-          projectIdOrSlug: projectId!,
-          eventId: feedbackEventId,
-        },
-      }),
-    ]),
-    {
-      staleTime: Infinity,
-      enabled: Boolean(feedbackEventIds.length > 0 && projectId),
-    }
-  );
-
-  const feedbackEvents = feedbackEventQuery
-    .map(query => query.data)
-    .filter(e => e !== undefined);
-  const isPending = feedbackEventQuery.some(query => query.isPending);
-  const isError = feedbackEventQuery.some(query => query.isError);
-
-  return {
-    feedbackEvents,
-    isPending,
-    isError,
-  };
+  return useQueries({
+    queries: feedbackEventIds.map((feedbackEventId: string) =>
+      apiOptions.as<FeedbackEvent>()(
+        '/projects/$organizationIdOrSlug/$projectIdOrSlug/events/$eventId/',
+        {
+          path: projectId
+            ? {
+                organizationIdOrSlug: organization.slug,
+                projectIdOrSlug: projectId,
+                eventId: feedbackEventId,
+              }
+            : skipToken,
+          staleTime: Infinity,
+        }
+      )
+    ),
+    combine: results => ({
+      feedbackEvents: results.map(r => r.data).filter(e => e !== undefined),
+      isPending: results.some(r => r.isPending),
+      isError: results.some(r => r.isError),
+    }),
+  });
 }

--- a/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.tsx
+++ b/static/app/views/alerts/rules/issue/setupMessagingIntegrationButton.tsx
@@ -1,3 +1,5 @@
+import {useQueries, useQuery} from '@tanstack/react-query';
+
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 
@@ -8,9 +10,8 @@ import type {
   IntegrationProvider,
   OrganizationIntegration,
 } from 'sentry/types/integrations';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {getIntegrationFeatureGate} from 'sentry/utils/integrationUtil';
-import {useApiQueries, useApiQuery} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {MessagingIntegrationModal} from 'sentry/views/alerts/rules/issue/messagingIntegrationModal';
 
@@ -40,25 +41,36 @@ export function SetupMessagingIntegrationButton({
     }
   };
 
-  const messagingIntegrationsQuery = useApiQuery<OrganizationIntegration[]>(
-    [
-      getApiUrl('/organizations/$organizationIdOrSlug/integrations/', {
+  const messagingIntegrationsQuery = useQuery(
+    apiOptions.as<OrganizationIntegration[]>()(
+      '/organizations/$organizationIdOrSlug/integrations/',
+      {
         path: {organizationIdOrSlug: organization.slug},
-      }),
-      {query: {integrationType: 'messaging'}},
-    ],
-    {staleTime: Infinity}
+        query: {integrationType: 'messaging'},
+        staleTime: Infinity,
+      }
+    )
   );
 
-  const integrationProvidersQuery = useApiQueries<{providers: IntegrationProvider[]}>(
-    providerKeys.map((providerKey: string) => [
-      getApiUrl('/organizations/$organizationIdOrSlug/config/integrations/', {
-        path: {organizationIdOrSlug: organization.slug},
-      }),
-      {query: {provider_key: providerKey}},
-    ]),
-    {staleTime: Infinity}
-  );
+  const integrationProvidersQuery = useQueries({
+    queries: providerKeys.map((providerKey: string) =>
+      apiOptions.as<{providers: IntegrationProvider[]}>()(
+        '/organizations/$organizationIdOrSlug/config/integrations/',
+        {
+          path: {organizationIdOrSlug: organization.slug},
+          query: {provider_key: providerKey},
+          staleTime: Infinity,
+        }
+      )
+    ),
+    combine: results => ({
+      providers: results
+        .map(r => r.data?.providers[0])
+        .filter((p): p is IntegrationProvider => p !== undefined),
+      isPending: results.some(r => r.isPending),
+      isError: results.some(r => r.isError),
+    }),
+  });
 
   const {IntegrationFeatures} = getIntegrationFeatureGate();
 
@@ -69,9 +81,9 @@ export function SetupMessagingIntegrationButton({
   if (
     messagingIntegrationsQuery.isPending ||
     messagingIntegrationsQuery.isError ||
-    integrationProvidersQuery.some(({isPending}) => isPending) ||
-    integrationProvidersQuery.some(({isError}) => isError) ||
-    integrationProvidersQuery[0]!.data === undefined
+    integrationProvidersQuery.isPending ||
+    integrationProvidersQuery.isError ||
+    integrationProvidersQuery.providers.length === 0
   ) {
     return null;
   }
@@ -83,7 +95,7 @@ export function SetupMessagingIntegrationButton({
   return (
     <IntegrationFeatures
       organization={organization}
-      features={integrationProvidersQuery[0]!.data.providers[0]?.metadata?.features!}
+      features={integrationProvidersQuery.providers[0]!.metadata?.features}
     >
       {({disabled, disabledReason}) => (
         <div>
@@ -111,12 +123,7 @@ export function SetupMessagingIntegrationButton({
                     {...deps}
                     headerContent={t('Connect with a messaging tool')}
                     bodyContent={t('Receive alerts and digests right where you work.')}
-                    providers={integrationProvidersQuery
-                      .map(result => result.data?.providers[0])
-                      .filter(
-                        (provider): provider is IntegrationProvider =>
-                          provider !== undefined
-                      )}
+                    providers={integrationProvidersQuery.providers}
                     onAddIntegration={onAddIntegration}
                     {...(projectId && {modalParams: {projectId}})}
                     analyticsView={analyticsView}


### PR DESCRIPTION
These queries are used in other places, so the caches have the potential to be messy. Lets take a look:
- /projects/$organizationIdOrSlug/$projectIdOrSlug/events/$eventId/ is read-only, so we should be filling up the cache with v2 types, but only where the eventId is a feedback
- /organizations/$organizationIdOrSlug/integrations/ is already using a mix of v1 and v2 cache shapes :(
- /organizations/$organizationIdOrSlug/config/integrations/ is static, it doesnt change, so we can have a mix of cache shapes
