### PR TITLE
ref(workflows): Don't export metrics_incr from workflow_engine.utils

### DIFF
--- a/src/sentry/workflow_engine/utils/__init__.py
+++ b/src/sentry/workflow_engine/utils/__init__.py
@@ -1,6 +1,0 @@
-__all__ = [
-    "metrics_incr",
-    "MetricTags",
-]
-
-from .metrics import MetricTags, metrics_incr


### PR DESCRIPTION
Not a big deal either way, but nobody is using it, and removing it simplifies the module interface slightly.