### PR TITLE
ref(aci): Onboarding design tweaks

### DIFF
--- a/static/app/components/featureShowcase.tsx
+++ b/static/app/components/featureShowcase.tsx
@@ -44,7 +44,7 @@ function Step({children}: {children: ReactNode}) {
 }
 
 function StepImage(props: ImageProps) {
-  return <Image height="200px" objectFit="contain" {...props} />;
+  return <Image objectFit="contain" {...props} />;
 }
 
 function StepTitle({children}: {children: ReactNode}) {

--- a/static/app/components/workflowEngine/ui/alertsMonitorsOnboardingBanner.tsx
+++ b/static/app/components/workflowEngine/ui/alertsMonitorsOnboardingBanner.tsx
@@ -6,7 +6,7 @@ import {Text} from '@sentry/scraps/text';
 
 import {usePrompt} from 'sentry/actionCreators/prompts';
 import {openAlertsMonitorsShowcase} from 'sentry/components/workflowEngine/ui/alertsMonitorsShowcase';
-import {IconClose} from 'sentry/icons';
+import {IconClose, IconInfo} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
@@ -54,6 +54,7 @@ export function OnboardingBanner() {
         <Flex gap="md" align="center">
           <Button
             size="xs"
+            icon={<IconInfo />}
             onClick={() => openAlertsMonitorsShowcase({organization})}
             aria-label={t('Take a tour')}
           >

--- a/static/app/components/workflowEngine/ui/alertsMonitorsShowcase.tsx
+++ b/static/app/components/workflowEngine/ui/alertsMonitorsShowcase.tsx
@@ -23,7 +23,7 @@ export function openAlertsMonitorsShowcase({organization}: {organization: Organi
   trackAnalytics('monitors.onboarding_modal_viewed', {organization, step: 0});
   openModal(deps => <AlertsMonitorsShowcase {...deps} />, {
     modalCss: (theme: Theme) => css`
-      width: 490px;
+      width: 560px;
 
       [role='document'] {
         padding: ${theme.space['2xl']};


### PR DESCRIPTION
Closes ID-1461
Closes ID-1460

Small UI tweaks to the monitors onboarding experience:

- Widened the showcase modal from 490px to 560px so the content has a bit more breathing room
- Added an info icon to the "Take a tour" button in the onboarding banner

<img width="656" height="270" alt="CleanShot 2026-04-13 at 15 24 03@2x" src="https://github.com/user-attachments/assets/604a9b74-abca-4e97-88c0-e74cbec31181" />
<img width="1184" height="968" alt="CleanShot 2026-04-13 at 15 24 07@2x" src="https://github.com/user-attachments/assets/95172d80-3e11-409f-9b17-18df1493e68a" />
