### PR TITLE
feat(aci): Add created_by search filter to workflow index endpoint

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -49,6 +49,7 @@ from sentry.deletions.models.scheduleddeletion import CellScheduledDeletion
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models.organization import Organization
 from sentry.models.project import Project
+from sentry.search.utils import parse_user_value
 from sentry.utils.audit import create_audit_entry
 from sentry.utils.dates import ensure_aware
 from sentry.workflow_engine.endpoints.serializers.workflow_serializer import (
@@ -80,7 +81,7 @@ SORT_COL_MAP = {
 workflow_search_config = SearchConfig.create_from(
     default_config,
     text_operator_keys={"name", "action"},
-    allowed_keys={"name", "action"},
+    allowed_keys={"name", "action", "created_by"},
     allow_boolean=False,
     free_text_key="query",
 )
@@ -175,6 +176,21 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
                             "workflowdataconditiongroup__condition_group__dataconditiongroupaction__action__type",
                             distinct=True,
                         )
+                    case SearchFilter(
+                        key=SearchKey("created_by"),
+                        operator=("=" | "IN" | "!=" | "NOT IN"),
+                    ):
+                        values = (
+                            filter.value.value
+                            if isinstance(filter.value.value, list)
+                            else [filter.value.value]
+                        )
+                        user_ids = [parse_user_value(v, request.user).id for v in values]
+                        created_by_q = Q(created_by_id__in=user_ids)
+                        if filter.operator in ("!=", "NOT IN"):
+                            queryset = queryset.exclude(created_by_q)
+                        else:
+                            queryset = queryset.filter(created_by_q)
                     case SearchFilter(key=SearchKey("query"), operator="="):
                         # 'query' is our free text key; all free text gets returned here
                         # as '=', and we search any relevant fields for it.

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
@@ -498,6 +498,76 @@ class OrganizationWorkflowIndexBaseTest(OrganizationWorkflowAPITestCase):
         )
         assert len(response.data) == 1
 
+    def test_query_by_created_by_me(self) -> None:
+        self.workflow.update(created_by_id=self.user.id)
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"query": "created_by:me"}
+        )
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(self.workflow.id)
+
+    def test_query_by_created_by_email(self) -> None:
+        other_user = self.create_user(email="other@example.com")
+        self.workflow.update(created_by_id=self.user.id)
+        self.workflow_two.update(created_by_id=other_user.id)
+
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"query": f"created_by:{self.user.email}"}
+        )
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(self.workflow.id)
+
+        response2 = self.get_success_response(
+            self.organization.slug, qs_params={"query": f"created_by:{other_user.email}"}
+        )
+        assert len(response2.data) == 1
+        assert response2.data[0]["id"] == str(self.workflow_two.id)
+
+    def test_query_by_created_by_negation(self) -> None:
+        self.workflow.update(created_by_id=self.user.id)
+        self.workflow_two.update(created_by_id=self.user.id)
+
+        response = self.get_success_response(
+            self.organization.slug, qs_params={"query": f"!created_by:{self.user.email}"}
+        )
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(self.workflow_three.id)
+
+    def test_query_by_created_by_multiple(self) -> None:
+        other_user = self.create_user(email="other@example.com")
+        self.workflow.update(created_by_id=self.user.id)
+        self.workflow_two.update(created_by_id=other_user.id)
+
+        response = self.get_success_response(
+            self.organization.slug,
+            qs_params={"query": f"created_by:[{self.user.email},{other_user.email}]"},
+        )
+        assert len(response.data) == 2
+        assert {w["id"] for w in response.data} == {
+            str(self.workflow.id),
+            str(self.workflow_two.id),
+        }
+
+    def test_query_by_created_by_negated_list(self) -> None:
+        other_user = self.create_user(email="other@example.com")
+        self.workflow.update(created_by_id=self.user.id)
+        self.workflow_two.update(created_by_id=other_user.id)
+
+        response = self.get_success_response(
+            self.organization.slug,
+            qs_params={"query": f"!created_by:[{self.user.email},{other_user.email}]"},
+        )
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(self.workflow_three.id)
+
+    def test_query_by_created_by_invalid_user(self) -> None:
+        self.workflow.update(created_by_id=self.user.id)
+        response = self.get_success_response(
+            self.organization.slug,
+            qs_params={"query": "created_by:nonexistent@example.com"},
+        )
+        assert len(response.data) == 0
+
 
 @cell_silo_test
 class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase, BaseWorkflowTest):


### PR DESCRIPTION
Ref ISWF-2448

The workflow index endpoint already supports filtering by `name` and `action` in the query parameter, but there's no way to filter by who created the workflow. This logic works similarly to the assignee filter in the detector_index endpoint

This uses `parse_user_value` from the existing search utils to resolve values like `me` (current user) or an email/username to a user ID, then filters on `created_by_id`. Supports `=`, `!=`, and `IN` operators (e.g. `created_by:me`, `!created_by:user@example.com`, `created_by:[user1,user2]`).