### PR TITLE
fix(dynamic-grouping): Adjust supergroup drawer header

### DIFF
--- a/static/app/views/issueList/supergroups/supergroupDrawer.tsx
+++ b/static/app/views/issueList/supergroups/supergroupDrawer.tsx
@@ -32,7 +32,7 @@ import {
   LoadingStreamGroup,
   StreamGroup,
 } from 'sentry/components/stream/group';
-import {IconChevron, IconFilter, IconFocus} from 'sentry/icons';
+import {IconChevron, IconFilter} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {GroupStore} from 'sentry/stores/groupStore';
 import type {Group} from 'sentry/types/group';
@@ -103,7 +103,13 @@ export function SupergroupDetailDrawer({
               <StyledMarkedText text={supergroup.title} inline as="span" />
             </Heading>
 
-            <Flex wrap="wrap" gap="lg">
+            {supergroup.summary && (
+              <Text size="md">
+                <StyledMarkedText text={supergroup.summary} inline as="span" />
+              </Text>
+            )}
+
+            <Stack gap="sm">
               {supergroup.error_type && (
                 <Flex gap="xs">
                   <Text size="sm" variant="muted">
@@ -120,23 +126,7 @@ export function SupergroupDetailDrawer({
                   <Text size="sm">{supergroup.code_area}</Text>
                 </Flex>
               )}
-            </Flex>
-
-            {supergroup.summary && (
-              <Container background="secondary" border="primary" radius="md">
-                <Flex direction="column" padding="md lg" gap="sm">
-                  <Flex align="center" gap="xs">
-                    <IconFocus size="xs" variant="promotion" />
-                    <Text size="sm" bold>
-                      {t('Root Cause')}
-                    </Text>
-                  </Flex>
-                  <Text size="sm">
-                    <StyledMarkedText text={supergroup.summary} inline as="span" />
-                  </Text>
-                </Flex>
-              </Container>
-            )}
+            </Stack>
           </Stack>
         </Container>
 


### PR DESCRIPTION
reformat the information at the top of the drawer making the root cause a bit larger

before

<img width="987" height="195" alt="image" src="https://github.com/user-attachments/assets/8974b550-3f95-49de-a000-375abfce9a75" />

after

<img width="991" height="177" alt="image" src="https://github.com/user-attachments/assets/7b3411b8-0609-4d77-b7f4-f2c8e1642cdb" />
