### PR TITLE
feat(viewer-context): Restore ViewerContext from JWT in middleware

### DIFF
--- a/src/sentry/middleware/viewer_context.py
+++ b/src/sentry/middleware/viewer_context.py
@@ -22,18 +22,13 @@ logger = logging.getLogger(__name__)
 def ViewerContextMiddleware(
     get_response: Callable[[HttpRequest], HttpResponseBase],
 ) -> Callable[[HttpRequest], HttpResponseBase]:
-    """Set :class:`ViewerContext` for every request after authentication.
+    """Set :class:`ViewerContext` for every request.
 
-    Must be placed **after** ``AuthenticationMiddleware`` so that
-    ``request.user`` and ``request.auth`` are already populated.
+    Placed after ``AuthenticationMiddleware``. Authenticated user always
+    takes precedence; ``X-Viewer-Context`` JWT is only used for
+    unauthenticated service-to-service calls (e.g. Seer → Sentry).
 
-    If the request carries a valid ``X-Viewer-Context`` JWT header,
-    the context is restored from the token instead of the Django auth
-    user.  This is the path used by service-to-service calls (e.g.
-    Seer calling back into Sentry).
-
-    Gated by the ``viewer-context.enabled`` option (FLAG_NOSTORE).
-    Set via deploy config; requires restart to change.
+    Gated by ``viewer-context.enabled`` (FLAG_NOSTORE).
     """
     enabled = options.get("viewer-context.enabled")
 
@@ -57,7 +52,7 @@ def ViewerContextMiddleware(
                 and request_ctx.organization_id is not None
                 and jwt_ctx.organization_id != request_ctx.organization_id
             ):
-                logger.warning(
+                logger.error(
                     "viewer_context.jwt_request_mismatch",
                     extra={
                         "jwt_org_id": jwt_ctx.organization_id,

--- a/src/sentry/middleware/viewer_context.py
+++ b/src/sentry/middleware/viewer_context.py
@@ -24,8 +24,10 @@ def ViewerContextMiddleware(
     """Set :class:`ViewerContext` for every request.
 
     Placed after ``AuthenticationMiddleware``. Authenticated user always
-    takes precedence; ``X-Viewer-Context`` JWT is only used for
-    unauthenticated service-to-service calls (e.g. Seer → Sentry).
+    takes precedence; ``X-Viewer-Context`` is only used when there is
+    no authenticated user (service-to-service calls, e.g. Seer → Sentry).
+
+    Accepts both JWT and legacy JSON + HMAC signature formats.
 
     Gated by ``viewer-context.enabled`` (FLAG_NOSTORE).
     """
@@ -74,7 +76,8 @@ def _viewer_context_from_jwt_header(request: HttpRequest) -> ViewerContext | Non
     header_value = request.META.get("HTTP_X_VIEWER_CONTEXT")
     if not header_value:
         return None
-    return viewer_context_from_header(header_value)
+    signature = request.META.get("HTTP_X_VIEWER_CONTEXT_SIGNATURE")
+    return viewer_context_from_header(header_value, signature)
 
 
 def _viewer_context_from_request(request: HttpRequest) -> ViewerContext:

--- a/src/sentry/middleware/viewer_context.py
+++ b/src/sentry/middleware/viewer_context.py
@@ -11,8 +11,7 @@ from sentry import options
 from sentry.viewer_context import (
     ActorType,
     ViewerContext,
-    decode_viewer_context,
-    is_jwt_viewer_context,
+    viewer_context_from_header,
     viewer_context_scope,
 )
 
@@ -43,10 +42,10 @@ def ViewerContextMiddleware(
             return get_response(request)
 
         request_ctx = _viewer_context_from_request(request)
-        jwt_ctx = _viewer_context_from_jwt(request)
+        jwt_ctx = _viewer_context_from_jwt_header(request)
 
         if jwt_ctx is not None and request_ctx.user_id is not None:
-            # Authenticated user takes precedence. Log if the JWT disagrees.
+            # Authenticated user takes precedence.
             if (
                 jwt_ctx.organization_id is not None
                 and request_ctx.organization_id is not None
@@ -71,24 +70,11 @@ def ViewerContextMiddleware(
     return ViewerContextMiddleware_impl
 
 
-def _viewer_context_from_jwt(request: HttpRequest) -> ViewerContext | None:
-    """Try to extract a ViewerContext from the X-Viewer-Context JWT header.
-
-    Returns ``None`` if the header is absent, not a JWT, or fails
-    verification.
-    """
+def _viewer_context_from_jwt_header(request: HttpRequest) -> ViewerContext | None:
     header_value = request.META.get("HTTP_X_VIEWER_CONTEXT")
     if not header_value:
         return None
-
-    if not is_jwt_viewer_context(header_value):
-        return None
-
-    try:
-        return decode_viewer_context(header_value)
-    except Exception:
-        logger.warning("viewer_context.jwt_decode_failed", exc_info=True)
-        return None
+    return viewer_context_from_header(header_value)
 
 
 def _viewer_context_from_request(request: HttpRequest) -> ViewerContext:

--- a/src/sentry/middleware/viewer_context.py
+++ b/src/sentry/middleware/viewer_context.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 
 from django.conf import settings
@@ -7,7 +8,15 @@ from django.http.request import HttpRequest
 from django.http.response import HttpResponseBase
 
 from sentry import options
-from sentry.viewer_context import ActorType, ViewerContext, viewer_context_scope
+from sentry.viewer_context import (
+    ActorType,
+    ViewerContext,
+    decode_viewer_context,
+    is_jwt_viewer_context,
+    viewer_context_scope,
+)
+
+logger = logging.getLogger(__name__)
 
 
 def ViewerContextMiddleware(
@@ -17,6 +26,11 @@ def ViewerContextMiddleware(
 
     Must be placed **after** ``AuthenticationMiddleware`` so that
     ``request.user`` and ``request.auth`` are already populated.
+
+    If the request carries a valid ``X-Viewer-Context`` JWT header,
+    the context is restored from the token instead of the Django auth
+    user.  This is the path used by service-to-service calls (e.g.
+    Seer calling back into Sentry).
 
     Gated by the ``viewer-context.enabled`` option (FLAG_NOSTORE).
     Set via deploy config; requires restart to change.
@@ -33,11 +47,53 @@ def ViewerContextMiddleware(
         if request.path_info.startswith(settings.ANONYMOUS_STATIC_PREFIXES):
             return get_response(request)
 
-        ctx = _viewer_context_from_request(request)
+        request_ctx = _viewer_context_from_request(request)
+        jwt_ctx = _viewer_context_from_jwt(request)
+
+        if jwt_ctx is not None and request_ctx.user_id is not None:
+            # Authenticated user takes precedence. Log if the JWT disagrees.
+            if (
+                jwt_ctx.organization_id is not None
+                and request_ctx.organization_id is not None
+                and jwt_ctx.organization_id != request_ctx.organization_id
+            ):
+                logger.warning(
+                    "viewer_context.jwt_request_mismatch",
+                    extra={
+                        "jwt_org_id": jwt_ctx.organization_id,
+                        "request_org_id": request_ctx.organization_id,
+                    },
+                )
+            ctx = request_ctx
+        elif jwt_ctx is not None:
+            ctx = jwt_ctx
+        else:
+            ctx = request_ctx
+
         with viewer_context_scope(ctx):
             return get_response(request)
 
     return ViewerContextMiddleware_impl
+
+
+def _viewer_context_from_jwt(request: HttpRequest) -> ViewerContext | None:
+    """Try to extract a ViewerContext from the X-Viewer-Context JWT header.
+
+    Returns ``None`` if the header is absent, not a JWT, or fails
+    verification.
+    """
+    header_value = request.META.get("HTTP_X_VIEWER_CONTEXT")
+    if not header_value:
+        return None
+
+    if not is_jwt_viewer_context(header_value):
+        return None
+
+    try:
+        return decode_viewer_context(header_value)
+    except Exception:
+        logger.warning("viewer_context.jwt_decode_failed", exc_info=True)
+        return None
 
 
 def _viewer_context_from_request(request: HttpRequest) -> ViewerContext:

--- a/src/sentry/middleware/viewer_context.py
+++ b/src/sentry/middleware/viewer_context.py
@@ -24,8 +24,9 @@ def ViewerContextMiddleware(
     """Set :class:`ViewerContext` for every request.
 
     Placed after ``AuthenticationMiddleware``. Authenticated user always
-    takes precedence; ``X-Viewer-Context`` is only used when there is
-    no authenticated user (service-to-service calls, e.g. Seer → Sentry).
+    takes precedence; ``X-Viewer-Context`` header is only used when
+    there is no authenticated *user* (service-to-service calls that
+    authenticate via HMAC but have no user session, e.g. Seer → Sentry).
 
     Accepts both JWT and legacy JSON + HMAC signature formats.
 

--- a/src/sentry/viewer_context.py
+++ b/src/sentry/viewer_context.py
@@ -108,6 +108,8 @@ def get_viewer_context() -> ViewerContext | None:
 # ---------------------------------------------------------------------------
 
 _JWT_STANDARD_CLAIMS = frozenset({"iat", "exp", "iss", "aud", "nbf", "jti", "sub"})
+# JWT header field identifying which key was used for signing (RFC 7515 §4.1.4).
+_JWT_KEY_ID_HEADER = "kid"
 
 
 def _key_id(key: str) -> str:
@@ -171,7 +173,9 @@ def encode_viewer_context(
         "iss": "sentry",
     }
 
-    return pyjwt.encode(payload, secret, algorithm="HS256", headers={"kid": _key_id(secret)})
+    return pyjwt.encode(
+        payload, secret, algorithm="HS256", headers={_JWT_KEY_ID_HEADER: _key_id(secret)}
+    )
 
 
 def decode_viewer_context(
@@ -192,7 +196,7 @@ def decode_viewer_context(
         if not keys_by_kid:
             raise ValueError("No verification keys available.")
 
-        kid = pyjwt.get_unverified_header(token).get("kid")
+        kid = pyjwt.get_unverified_header(token).get(_JWT_KEY_ID_HEADER)
         secret = keys_by_kid.get(kid, "") if kid else ""
         if not secret:
             raise pyjwt.exceptions.InvalidKeyError(f"No verification key matches kid={kid!r}")

--- a/src/sentry/viewer_context.py
+++ b/src/sentry/viewer_context.py
@@ -5,12 +5,15 @@ import contextvars
 import dataclasses
 import enum
 import hashlib
+import logging
 import time
 from collections.abc import Generator
 from typing import TYPE_CHECKING, Any
 
 import jwt as pyjwt
 from django.conf import settings
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from sentry.auth.services.auth import AuthenticatedToken
@@ -114,8 +117,8 @@ def _key_id(key: str) -> str:
     return hashlib.sha256(key.encode("utf-8")).hexdigest()[:8]
 
 
-def _get_jwt_secret(key: str | None = None) -> str:
-    """Return the symmetric key to use for JWT signing/verification.
+def _get_signing_key(key: str | None = None) -> str:
+    """Return the key to use for JWT signing.
 
     Resolution: explicit *key* → ``SEER_API_SHARED_SECRET``.
 
@@ -132,6 +135,21 @@ def _get_jwt_secret(key: str | None = None) -> str:
     raise ValueError("No signing key available. Set SEER_API_SHARED_SECRET in settings.")
 
 
+def _get_verification_keys() -> list[str]:
+    """Return all keys that may have been used to sign a ViewerContext JWT.
+
+    The receiver tries each key (kid-matched first) when verifying.
+    Add new service keys here as more services propagate ViewerContext.
+    """
+    keys: list[str] = []
+
+    seer_secret = getattr(settings, "SEER_API_SHARED_SECRET", "")
+    if seer_secret:
+        keys.append(seer_secret)
+
+    return keys
+
+
 def encode_viewer_context(
     viewer_context: ViewerContext,
     *,
@@ -139,7 +157,7 @@ def encode_viewer_context(
     ttl: int | None = None,
 ) -> str:
     """Encode a :class:`ViewerContext` as a signed HS256 JWT."""
-    secret = _get_jwt_secret(key)
+    secret = _get_signing_key(key)
 
     if ttl is None:
         ttl = getattr(settings, "VIEWER_CONTEXT_JWT_TTL", 900)
@@ -161,19 +179,56 @@ def decode_viewer_context(
     key: str | None = None,
     leeway: int = 5,
 ) -> ViewerContext:
-    """Decode and verify an HS256 JWT into a :class:`ViewerContext`."""
-    secret = _get_jwt_secret(key)
+    """Decode and verify an HS256 JWT into a :class:`ViewerContext`.
 
-    claims = pyjwt.decode(
-        token,
-        secret,
-        algorithms=["HS256"],
-        options={"require": ["iat", "exp", "iss"]},
-        issuer="sentry",
-        leeway=leeway,
-    )
-    vc_data = {k: v for k, v in claims.items() if k not in _JWT_STANDARD_CLAIMS}
-    return ViewerContext.deserialize(vc_data)
+    When *key* is provided it is used directly.  Otherwise all keys
+    from ``_get_verification_keys()`` are tried, kid-matched key first.
+    """
+    if key is not None:
+        keys = [key]
+    else:
+        keys = _get_verification_keys()
+
+    if not keys:
+        raise ValueError("No verification keys available.")
+
+    # Use kid to try the matching key first.
+    kid = pyjwt.get_unverified_header(token).get("kid")
+    if kid:
+        keys = sorted(keys, key=lambda k: _key_id(k) != kid)
+
+    last_exc: Exception | None = None
+    for k in keys:
+        try:
+            claims = pyjwt.decode(
+                token,
+                k,
+                algorithms=["HS256"],
+                options={"require": ["iat", "exp", "iss"]},
+                issuer="sentry",
+                leeway=leeway,
+            )
+            vc_data = {ck: cv for ck, cv in claims.items() if ck not in _JWT_STANDARD_CLAIMS}
+            return ViewerContext.deserialize(vc_data)
+        except pyjwt.exceptions.PyJWTError as exc:
+            last_exc = exc
+
+    raise last_exc  # type: ignore[misc]
+
+
+def viewer_context_from_header(header_value: str) -> ViewerContext | None:
+    """Try to decode a ViewerContext from an X-Viewer-Context header value.
+
+    Returns ``None`` if the value is not a JWT or fails verification.
+    """
+    if not is_jwt_viewer_context(header_value):
+        return None
+
+    try:
+        return decode_viewer_context(header_value)
+    except Exception:
+        logger.warning("viewer_context.jwt_decode_failed", exc_info=True)
+        return None
 
 
 def is_jwt_viewer_context(header_value: str) -> bool:

--- a/src/sentry/viewer_context.py
+++ b/src/sentry/viewer_context.py
@@ -5,12 +5,14 @@ import contextvars
 import dataclasses
 import enum
 import hashlib
+import hmac
 import logging
 import time
 from collections.abc import Generator
 from typing import TYPE_CHECKING, Any
 
 import jwt as pyjwt
+import orjson
 from django.conf import settings
 
 logger = logging.getLogger(__name__)
@@ -232,11 +234,6 @@ def viewer_context_from_header(
 
 def _verify_legacy_viewer_context(context_json: str, signature: str) -> ViewerContext | None:
     """Verify and decode a legacy JSON + HMAC-signed viewer context."""
-    import hashlib
-    import hmac
-
-    import orjson
-
     keys_by_kid = _get_verification_keys()
     context_bytes = context_json.encode("utf-8")
 

--- a/src/sentry/viewer_context.py
+++ b/src/sentry/viewer_context.py
@@ -216,19 +216,51 @@ def decode_viewer_context(
     raise last_exc  # type: ignore[misc]
 
 
-def viewer_context_from_header(header_value: str) -> ViewerContext | None:
-    """Try to decode a ViewerContext from an X-Viewer-Context header value.
+def viewer_context_from_header(
+    header_value: str, signature: str | None = None
+) -> ViewerContext | None:
+    """Decode a ViewerContext from ``X-Viewer-Context`` header(s).
 
-    Returns ``None`` if the value is not a JWT or fails verification.
+    Dual-mode for migration:
+    - JWT (HS256) — new format, self-contained
+    - Raw JSON + ``X-Viewer-Context-Signature`` HMAC — legacy format
     """
-    if not is_jwt_viewer_context(header_value):
-        return None
+    if is_jwt_viewer_context(header_value):
+        try:
+            return decode_viewer_context(header_value)
+        except Exception:
+            logger.warning("viewer_context.jwt_decode_failed", exc_info=True)
+            return None
 
-    try:
-        return decode_viewer_context(header_value)
-    except Exception:
-        logger.warning("viewer_context.jwt_decode_failed", exc_info=True)
-        return None
+    # Legacy: raw JSON + HMAC signature
+    if signature is not None:
+        return _verify_legacy_viewer_context(header_value, signature)
+
+    return None
+
+
+def _verify_legacy_viewer_context(context_json: str, signature: str) -> ViewerContext | None:
+    """Verify and decode a legacy JSON + HMAC-signed viewer context."""
+    import hashlib
+    import hmac
+
+    import orjson
+
+    keys = _get_verification_keys()
+    context_bytes = context_json.encode("utf-8")
+
+    for key in keys:
+        computed = hmac.new(key.encode("utf-8"), context_bytes, hashlib.sha256).hexdigest()
+        if hmac.compare_digest(computed, signature):
+            try:
+                data = orjson.loads(context_bytes)
+                return ViewerContext.deserialize(data)
+            except Exception:
+                logger.warning("viewer_context.legacy_decode_failed", exc_info=True)
+                return None
+
+    logger.warning("viewer_context.legacy_signature_mismatch")
+    return None
 
 
 def is_jwt_viewer_context(header_value: str) -> bool:

--- a/src/sentry/viewer_context.py
+++ b/src/sentry/viewer_context.py
@@ -135,17 +135,16 @@ def _get_signing_key(key: str | None = None) -> str:
     raise ValueError("No signing key available. Set SEER_API_SHARED_SECRET in settings.")
 
 
-def _get_verification_keys() -> list[str]:
-    """Return all keys that may have been used to sign a ViewerContext JWT.
+def _get_verification_keys() -> dict[str, str]:
+    """Return a ``{kid: key}`` mapping of all known verification keys.
 
-    The receiver tries each key (kid-matched first) when verifying.
     Add new service keys here as more services propagate ViewerContext.
     """
-    keys: list[str] = []
+    keys: dict[str, str] = {}
 
     seer_secret = getattr(settings, "SEER_API_SHARED_SECRET", "")
     if seer_secret:
-        keys.append(seer_secret)
+        keys[_key_id(seer_secret)] = seer_secret
 
     return keys
 
@@ -185,35 +184,27 @@ def decode_viewer_context(
     from ``_get_verification_keys()`` are tried, kid-matched key first.
     """
     if key is not None:
-        keys = [key]
+        secret = key
     else:
-        keys = _get_verification_keys()
+        keys_by_kid = _get_verification_keys()
+        if not keys_by_kid:
+            raise ValueError("No verification keys available.")
 
-    if not keys:
-        raise ValueError("No verification keys available.")
+        kid = pyjwt.get_unverified_header(token).get("kid")
+        secret = keys_by_kid.get(kid, "") if kid else ""
+        if not secret:
+            raise pyjwt.exceptions.InvalidKeyError(f"No verification key matches kid={kid!r}")
 
-    # Use kid to try the matching key first.
-    kid = pyjwt.get_unverified_header(token).get("kid")
-    if kid:
-        keys = sorted(keys, key=lambda k: _key_id(k) != kid)
-
-    last_exc: Exception | None = None
-    for k in keys:
-        try:
-            claims = pyjwt.decode(
-                token,
-                k,
-                algorithms=["HS256"],
-                options={"require": ["iat", "exp", "iss"]},
-                issuer="sentry",
-                leeway=leeway,
-            )
-            vc_data = {ck: cv for ck, cv in claims.items() if ck not in _JWT_STANDARD_CLAIMS}
-            return ViewerContext.deserialize(vc_data)
-        except pyjwt.exceptions.PyJWTError as exc:
-            last_exc = exc
-
-    raise last_exc  # type: ignore[misc]
+    claims = pyjwt.decode(
+        token,
+        secret,
+        algorithms=["HS256"],
+        options={"require": ["iat", "exp", "iss"]},
+        issuer="sentry",
+        leeway=leeway,
+    )
+    vc_data = {ck: cv for ck, cv in claims.items() if ck not in _JWT_STANDARD_CLAIMS}
+    return ViewerContext.deserialize(vc_data)
 
 
 def viewer_context_from_header(
@@ -246,10 +237,10 @@ def _verify_legacy_viewer_context(context_json: str, signature: str) -> ViewerCo
 
     import orjson
 
-    keys = _get_verification_keys()
+    keys_by_kid = _get_verification_keys()
     context_bytes = context_json.encode("utf-8")
 
-    for key in keys:
+    for key in keys_by_kid.values():
         computed = hmac.new(key.encode("utf-8"), context_bytes, hashlib.sha256).hexdigest()
         if hmac.compare_digest(computed, signature):
             try:

--- a/tests/sentry/middleware/test_viewer_context.py
+++ b/tests/sentry/middleware/test_viewer_context.py
@@ -300,7 +300,7 @@ class ViewerContextMiddlewareTest(TestCase):
 
         middleware(request)
 
-        mock_logger.warning.assert_called_once_with(
+        mock_logger.error.assert_called_once_with(
             "viewer_context.jwt_request_mismatch",
             extra={
                 "jwt_org_id": 99,

--- a/tests/sentry/middleware/test_viewer_context.py
+++ b/tests/sentry/middleware/test_viewer_context.py
@@ -1,15 +1,20 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from django.contrib.auth.models import AnonymousUser
-from django.test import RequestFactory
+from django.test import RequestFactory, override_settings
 
 from sentry.auth.services.auth import AuthenticatedToken
 from sentry.middleware.viewer_context import ViewerContextMiddleware, _viewer_context_from_request
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
-from sentry.viewer_context import ActorType, get_viewer_context
+from sentry.viewer_context import (
+    ActorType,
+    ViewerContext,
+    encode_viewer_context,
+    get_viewer_context,
+)
 
 
 class ViewerContextFromRequestTest(TestCase):
@@ -194,3 +199,157 @@ class ViewerContextMiddlewareTest(TestCase):
         assert ctx.user_id is None
         assert ctx.organization_id is None
         assert ctx.token is None
+
+    @override_options({"viewer-context.enabled": True})
+    @override_settings(SEER_API_SHARED_SECRET="test-secret")
+    def test_jwt_header_sets_viewer_context(self):
+        vc = ViewerContext(organization_id=42, user_id=7, actor_type=ActorType.INTEGRATION)
+        token = encode_viewer_context(vc)
+
+        captured: list = []
+
+        def get_response(request):
+            captured.append(get_viewer_context())
+            return MagicMock(status_code=200)
+
+        middleware = ViewerContextMiddleware(get_response)
+
+        request = self.factory.get("/", HTTP_X_VIEWER_CONTEXT=token)
+        request.user = AnonymousUser()
+        request.auth = None
+
+        middleware(request)
+
+        assert len(captured) == 1
+        ctx = captured[0]
+        assert ctx is not None
+        assert ctx.organization_id == 42
+        assert ctx.user_id == 7
+        assert ctx.actor_type == ActorType.INTEGRATION
+
+    @override_options({"viewer-context.enabled": True})
+    @override_settings(SEER_API_SHARED_SECRET="test-secret")
+    def test_authenticated_user_takes_precedence_over_jwt(self):
+        vc = ViewerContext(organization_id=99, actor_type=ActorType.INTEGRATION)
+        token = encode_viewer_context(vc)
+
+        captured: list = []
+
+        def get_response(request):
+            captured.append(get_viewer_context())
+            return MagicMock(status_code=200)
+
+        middleware = ViewerContextMiddleware(get_response)
+
+        request = self.factory.get("/", HTTP_X_VIEWER_CONTEXT=token)
+        request.user = self.user
+        request.auth = None
+
+        middleware(request)
+
+        assert len(captured) == 1
+        ctx = captured[0]
+        assert ctx.user_id == self.user.id
+        assert ctx.actor_type == ActorType.USER
+
+    @override_options({"viewer-context.enabled": True})
+    @override_settings(SEER_API_SHARED_SECRET="test-secret")
+    def test_jwt_used_when_no_authenticated_user(self):
+        vc = ViewerContext(organization_id=99, actor_type=ActorType.INTEGRATION)
+        token = encode_viewer_context(vc)
+
+        captured: list = []
+
+        def get_response(request):
+            captured.append(get_viewer_context())
+            return MagicMock(status_code=200)
+
+        middleware = ViewerContextMiddleware(get_response)
+
+        request = self.factory.get("/", HTTP_X_VIEWER_CONTEXT=token)
+        request.user = AnonymousUser()
+        request.auth = None
+
+        middleware(request)
+
+        assert len(captured) == 1
+        ctx = captured[0]
+        assert ctx.organization_id == 99
+        assert ctx.actor_type == ActorType.INTEGRATION
+        assert ctx.user_id is None
+
+    @override_options({"viewer-context.enabled": True})
+    @override_settings(SEER_API_SHARED_SECRET="test-secret")
+    @patch("sentry.middleware.viewer_context.logger")
+    def test_logs_warning_on_jwt_request_mismatch(self, mock_logger):
+        vc = ViewerContext(organization_id=99, actor_type=ActorType.INTEGRATION)
+        token = encode_viewer_context(vc)
+
+        middleware = ViewerContextMiddleware(lambda r: MagicMock(status_code=200))
+
+        token_auth = AuthenticatedToken(
+            allowed_origins=[],
+            scopes=["org:read"],
+            entity_id=1,
+            kind="org_auth_token",
+            organization_id=self.organization.id,
+        )
+        request = self.factory.get("/", HTTP_X_VIEWER_CONTEXT=token)
+        request.user = self.user
+        request.auth = token_auth
+
+        middleware(request)
+
+        mock_logger.warning.assert_called_once_with(
+            "viewer_context.jwt_request_mismatch",
+            extra={
+                "jwt_org_id": 99,
+                "request_org_id": self.organization.id,
+            },
+        )
+
+    @override_options({"viewer-context.enabled": True})
+    @override_settings(SEER_API_SHARED_SECRET="test-secret")
+    def test_invalid_jwt_falls_back_to_request_user(self):
+        captured: list = []
+
+        def get_response(request):
+            captured.append(get_viewer_context())
+            return MagicMock(status_code=200)
+
+        middleware = ViewerContextMiddleware(get_response)
+
+        request = self.factory.get("/", HTTP_X_VIEWER_CONTEXT="invalid.jwt.token")
+        request.user = self.user
+        request.auth = None
+
+        middleware(request)
+
+        assert len(captured) == 1
+        ctx = captured[0]
+        assert ctx.user_id == self.user.id
+        assert ctx.actor_type == ActorType.USER
+
+    @override_options({"viewer-context.enabled": True})
+    def test_raw_json_header_falls_back_to_request_user(self):
+        captured: list = []
+
+        def get_response(request):
+            captured.append(get_viewer_context())
+            return MagicMock(status_code=200)
+
+        middleware = ViewerContextMiddleware(get_response)
+
+        request = self.factory.get(
+            "/",
+            HTTP_X_VIEWER_CONTEXT='{"actor_type": "integration", "organization_id": 42}',
+        )
+        request.user = self.user
+        request.auth = None
+
+        middleware(request)
+
+        assert len(captured) == 1
+        ctx = captured[0]
+        assert ctx.user_id == self.user.id
+        assert ctx.actor_type == ActorType.USER

--- a/tests/sentry/middleware/test_viewer_context.py
+++ b/tests/sentry/middleware/test_viewer_context.py
@@ -331,7 +331,7 @@ class ViewerContextMiddlewareTest(TestCase):
         assert ctx.actor_type == ActorType.USER
 
     @override_options({"viewer-context.enabled": True})
-    def test_raw_json_header_falls_back_to_request_user(self):
+    def test_raw_json_without_signature_falls_back(self):
         captured: list = []
 
         def get_response(request):
@@ -353,3 +353,64 @@ class ViewerContextMiddlewareTest(TestCase):
         ctx = captured[0]
         assert ctx.user_id == self.user.id
         assert ctx.actor_type == ActorType.USER
+
+    @override_options({"viewer-context.enabled": True})
+    @override_settings(SEER_API_SHARED_SECRET="test-secret")
+    def test_legacy_hmac_header_sets_viewer_context(self):
+        import hashlib
+        import hmac
+
+        import orjson
+
+        context_data = {"actor_type": "integration", "organization_id": 42}
+        context_bytes = orjson.dumps(context_data)
+        signature = hmac.new(b"test-secret", context_bytes, hashlib.sha256).hexdigest()
+
+        captured: list = []
+
+        def get_response(request):
+            captured.append(get_viewer_context())
+            return MagicMock(status_code=200)
+
+        middleware = ViewerContextMiddleware(get_response)
+
+        request = self.factory.get(
+            "/",
+            HTTP_X_VIEWER_CONTEXT=context_bytes.decode("utf-8"),
+            HTTP_X_VIEWER_CONTEXT_SIGNATURE=signature,
+        )
+        request.user = AnonymousUser()
+        request.auth = None
+
+        middleware(request)
+
+        assert len(captured) == 1
+        ctx = captured[0]
+        assert ctx.organization_id == 42
+        assert ctx.actor_type == ActorType.INTEGRATION
+
+    @override_options({"viewer-context.enabled": True})
+    @override_settings(SEER_API_SHARED_SECRET="test-secret")
+    def test_legacy_hmac_bad_signature_ignored(self):
+        captured: list = []
+
+        def get_response(request):
+            captured.append(get_viewer_context())
+            return MagicMock(status_code=200)
+
+        middleware = ViewerContextMiddleware(get_response)
+
+        request = self.factory.get(
+            "/",
+            HTTP_X_VIEWER_CONTEXT='{"actor_type": "integration", "organization_id": 42}',
+            HTTP_X_VIEWER_CONTEXT_SIGNATURE="bad-signature",
+        )
+        request.user = AnonymousUser()
+        request.auth = None
+
+        middleware(request)
+
+        assert len(captured) == 1
+        ctx = captured[0]
+        assert ctx.user_id is None
+        assert ctx.organization_id is None

--- a/tests/sentry/test_viewer_context_jwt.py
+++ b/tests/sentry/test_viewer_context_jwt.py
@@ -109,7 +109,14 @@ class TestDecodeViewerContext(TestCase):
             "exp": time.time() - 60,
             "iss": "sentry",
         }
-        expired_token = pyjwt.encode(payload, "test-secret-key", algorithm="HS256")
+        from sentry.viewer_context import _key_id
+
+        expired_token = pyjwt.encode(
+            payload,
+            "test-secret-key",
+            algorithm="HS256",
+            headers={"kid": _key_id("test-secret-key")},
+        )
 
         with pytest.raises(pyjwt.exceptions.ExpiredSignatureError):
             decode_viewer_context(expired_token)

--- a/tests/sentry/test_viewer_context_jwt.py
+++ b/tests/sentry/test_viewer_context_jwt.py
@@ -140,7 +140,7 @@ class TestDecodeViewerContext(TestCase):
         vc = ViewerContext(organization_id=1, actor_type=ActorType.USER)
         token = encode_viewer_context(vc, key="some-key")
 
-        with pytest.raises(ValueError, match="No signing key available"):
+        with pytest.raises(ValueError, match="No verification keys available"):
             decode_viewer_context(token)
 
 


### PR DESCRIPTION
Middleware decodes `X-Viewer-Context` on incoming requests.

- Auth user always wins; header only used when no user is authenticated
- Dual-mode: accepts both JWT (new) and JSON + HMAC signature (legacy)
- Org ID mismatch between header and auth user logged as error
- Parsing logic lives in `viewer_context.py` as `viewer_context_from_header()`
- Verification keys in `_get_verification_keys()` — currently just `SEER_API_SHARED_SECRET`

Depends on #112765.