### PR TITLE
ref(integrations): Refactor useAddIntegration to accept params at call time

### DIFF
--- a/static/app/utils/integrations/useAddIntegration.spec.tsx
+++ b/static/app/utils/integrations/useAddIntegration.spec.tsx
@@ -8,7 +8,7 @@ import * as indicators from 'sentry/actionCreators/indicator';
 import * as pipelineModal from 'sentry/components/pipeline/modal';
 import {ConfigStore} from 'sentry/stores/configStore';
 import type {Config} from 'sentry/types/system';
-import {useAddIntegration} from 'sentry/views/settings/organizationIntegrations/addIntegration';
+import {useAddIntegration} from 'sentry/utils/integrations/useAddIntegration';
 
 describe('useAddIntegration', () => {
   const provider = GitHubIntegrationProviderFixture();
@@ -54,15 +54,15 @@ describe('useAddIntegration', () => {
     });
 
     it('opens a popup window when startFlow is called', () => {
-      const {result} = renderHookWithProviders(() =>
-        useAddIntegration({
+      const {result} = renderHookWithProviders(() => useAddIntegration());
+
+      act(() =>
+        result.current.startFlow({
           provider,
           organization: OrganizationFixture(),
           onInstall: jest.fn(),
         })
       );
-
-      act(() => result.current.startFlow());
 
       expect(window.open).toHaveBeenCalledTimes(1);
       expect(jest.mocked(window.open).mock.calls[0]![0]).toBe(
@@ -72,8 +72,10 @@ describe('useAddIntegration', () => {
     });
 
     it('includes account and modalParams in the popup URL', () => {
-      const {result} = renderHookWithProviders(() =>
-        useAddIntegration({
+      const {result} = renderHookWithProviders(() => useAddIntegration());
+
+      act(() =>
+        result.current.startFlow({
           provider,
           organization: OrganizationFixture(),
           onInstall: jest.fn(),
@@ -81,8 +83,6 @@ describe('useAddIntegration', () => {
           modalParams: {use_staging: '1'},
         })
       );
-
-      act(() => result.current.startFlow());
 
       const calls = jest.mocked(window.open).mock.calls[0]!;
       const url = calls[0] as string;
@@ -92,15 +92,16 @@ describe('useAddIntegration', () => {
     });
 
     it('includes urlParams passed to startFlow', () => {
-      const {result} = renderHookWithProviders(() =>
-        useAddIntegration({
+      const {result} = renderHookWithProviders(() => useAddIntegration());
+
+      act(() =>
+        result.current.startFlow({
           provider,
           organization: OrganizationFixture(),
           onInstall: jest.fn(),
+          urlParams: {custom_param: 'value'},
         })
       );
-
-      act(() => result.current.startFlow({custom_param: 'value'}));
 
       const url = jest.mocked(window.open).mock.calls[0]![0] as string;
       expect(url).toContain('custom_param=value');
@@ -109,15 +110,15 @@ describe('useAddIntegration', () => {
     it('calls onInstall when a success message is received', async () => {
       const onInstall = jest.fn();
 
-      const {result} = renderHookWithProviders(() =>
-        useAddIntegration({
+      const {result} = renderHookWithProviders(() => useAddIntegration());
+
+      act(() =>
+        result.current.startFlow({
           provider,
           organization: OrganizationFixture(),
           onInstall,
         })
       );
-
-      act(() => result.current.startFlow());
 
       const newIntegration = {
         success: true,
@@ -137,15 +138,15 @@ describe('useAddIntegration', () => {
     it('shows a success indicator on successful installation', async () => {
       const successSpy = jest.spyOn(indicators, 'addSuccessMessage');
 
-      const {result} = renderHookWithProviders(() =>
-        useAddIntegration({
+      const {result} = renderHookWithProviders(() => useAddIntegration());
+
+      act(() =>
+        result.current.startFlow({
           provider,
           organization: OrganizationFixture(),
           onInstall: jest.fn(),
         })
       );
-
-      act(() => result.current.startFlow());
 
       postMessageFromPopup(popup, {success: true, data: integration});
       await waitFor(() => expect(successSpy).toHaveBeenCalledWith('GitHub added'));
@@ -154,15 +155,15 @@ describe('useAddIntegration', () => {
     it('shows an error indicator when the message has success: false', async () => {
       const errorSpy = jest.spyOn(indicators, 'addErrorMessage');
 
-      const {result} = renderHookWithProviders(() =>
-        useAddIntegration({
+      const {result} = renderHookWithProviders(() => useAddIntegration());
+
+      act(() =>
+        result.current.startFlow({
           provider,
           organization: OrganizationFixture(),
           onInstall: jest.fn(),
         })
       );
-
-      act(() => result.current.startFlow());
 
       postMessageFromPopup(popup, {success: false, data: {error: 'OAuth failed'}});
       await waitFor(() => expect(errorSpy).toHaveBeenCalledWith('OAuth failed'));
@@ -171,15 +172,15 @@ describe('useAddIntegration', () => {
     it('shows a generic error when no error message is provided', async () => {
       const errorSpy = jest.spyOn(indicators, 'addErrorMessage');
 
-      const {result} = renderHookWithProviders(() =>
-        useAddIntegration({
+      const {result} = renderHookWithProviders(() => useAddIntegration());
+
+      act(() =>
+        result.current.startFlow({
           provider,
           organization: OrganizationFixture(),
           onInstall: jest.fn(),
         })
       );
-
-      act(() => result.current.startFlow());
 
       postMessageFromPopup(popup, {success: false, data: {}});
       await waitFor(() =>
@@ -190,13 +191,7 @@ describe('useAddIntegration', () => {
     it('ignores messages from invalid origins', async () => {
       const onInstall = jest.fn();
 
-      renderHookWithProviders(() =>
-        useAddIntegration({
-          provider,
-          organization: OrganizationFixture(),
-          onInstall,
-        })
-      );
+      renderHookWithProviders(() => useAddIntegration());
 
       // jsdom's postMessage uses origin '' which won't match any valid origin
       window.postMessage({success: true, data: integration}, '*');
@@ -210,15 +205,15 @@ describe('useAddIntegration', () => {
     it('does not call onInstall when data is empty on success', async () => {
       const onInstall = jest.fn();
 
-      const {result} = renderHookWithProviders(() =>
-        useAddIntegration({
+      const {result} = renderHookWithProviders(() => useAddIntegration());
+
+      act(() =>
+        result.current.startFlow({
           provider,
           organization: OrganizationFixture(),
           onInstall,
         })
       );
-
-      act(() => result.current.startFlow());
 
       postMessageFromPopup(popup, {success: true, data: null});
 
@@ -229,15 +224,15 @@ describe('useAddIntegration', () => {
     });
 
     it('closes the dialog on unmount', () => {
-      const {result, unmount} = renderHookWithProviders(() =>
-        useAddIntegration({
+      const {result, unmount} = renderHookWithProviders(() => useAddIntegration());
+
+      act(() =>
+        result.current.startFlow({
           provider,
           organization: OrganizationFixture(),
           onInstall: jest.fn(),
         })
       );
-
-      act(() => result.current.startFlow());
       unmount();
 
       expect(popup.close).toHaveBeenCalledTimes(1);
@@ -253,15 +248,15 @@ describe('useAddIntegration', () => {
         features: ['integration-api-pipeline-github'],
       });
 
-      const {result} = renderHookWithProviders(() =>
-        useAddIntegration({
+      const {result} = renderHookWithProviders(() => useAddIntegration());
+
+      act(() =>
+        result.current.startFlow({
           provider,
           organization,
           onInstall,
         })
       );
-
-      act(() => result.current.startFlow());
 
       expect(openPipelineModalSpy).toHaveBeenCalledWith({
         type: 'integration',
@@ -278,15 +273,15 @@ describe('useAddIntegration', () => {
         features: ['integration-api-pipeline-github'],
       });
 
-      const {result} = renderHookWithProviders(() =>
-        useAddIntegration({
+      const {result} = renderHookWithProviders(() => useAddIntegration());
+
+      act(() =>
+        result.current.startFlow({
           provider,
           organization,
           onInstall: jest.fn(),
         })
       );
-
-      act(() => result.current.startFlow());
 
       expect(window.open).not.toHaveBeenCalled();
     });
@@ -299,15 +294,15 @@ describe('useAddIntegration', () => {
 
       const organization = OrganizationFixture({features: []});
 
-      const {result} = renderHookWithProviders(() =>
-        useAddIntegration({
+      const {result} = renderHookWithProviders(() => useAddIntegration());
+
+      act(() =>
+        result.current.startFlow({
           provider,
           organization,
           onInstall: jest.fn(),
         })
       );
-
-      act(() => result.current.startFlow());
 
       expect(openPipelineModalSpy).not.toHaveBeenCalled();
       expect(window.open).toHaveBeenCalledTimes(1);

--- a/static/app/utils/integrations/useAddIntegration.tsx
+++ b/static/app/utils/integrations/useAddIntegration.tsx
@@ -9,6 +9,7 @@ import {ConfigStore} from 'sentry/stores/configStore';
 import type {IntegrationProvider, IntegrationWithConfig} from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
 import {trackIntegrationAnalytics} from 'sentry/utils/integrationUtil';
+import {computeCenteredWindow} from 'sentry/utils/window/computeCenteredWindow';
 import type {MessagingIntegrationAnalyticsView} from 'sentry/views/alerts/rules/issue/setupMessagingIntegrationButton';
 
 export interface AddIntegrationParams {
@@ -30,6 +31,7 @@ export interface AddIntegrationParams {
       | 'test_analytics_org_selector';
   };
   modalParams?: Record<string, string>;
+  urlParams?: Record<string, string>;
 }
 
 /**
@@ -66,47 +68,21 @@ function getApiPipelineProvider(
   return key;
 }
 
-function computeCenteredWindow(width: number, height: number) {
-  const screenLeft = window.screenLeft === undefined ? window.screenX : window.screenLeft;
-  const screenTop = window.screenTop === undefined ? window.screenY : window.screenTop;
-
-  const innerWidth = window.innerWidth
-    ? window.innerWidth
-    : document.documentElement.clientWidth
-      ? document.documentElement.clientWidth
-      : screen.width;
-
-  const innerHeight = window.innerHeight
-    ? window.innerHeight
-    : document.documentElement.clientHeight
-      ? document.documentElement.clientHeight
-      : screen.height;
-
-  const left = innerWidth / 2 - width / 2 + screenLeft;
-  const top = innerHeight / 2 - height / 2 + screenTop;
-
-  return {left, top};
-}
-
 /**
- * Opens the legacy Django-driven integration setup flow in a popup window and
- * listens for a `postMessage` callback on completion.
+ * Opens the integration setup flow. Accepts all parameters at call time via
+ * `startFlow(params)`, so a single hook instance can launch flows for any
+ * provider. Automatically selects between the API-driven pipeline modal and
+ * the legacy popup-based flow depending on the organization's feature flags.
  *
- * Used  for integrations that have not been migrated to the API pipeline system.
+ * The hook manages its own `message` event listener for the legacy popup flow.
+ * No context provider is needed.
  */
-function useLegacyAddIntegration({
-  provider,
-  organization,
-  onInstall,
-  account,
-  analyticsParams,
-  modalParams,
-}: AddIntegrationParams) {
+export function useAddIntegration() {
   const dialogRef = useRef<Window | null>(null);
-  const onInstallRef = useRef(onInstall);
-  onInstallRef.current = onInstall;
-  const analyticsParamsRef = useRef(analyticsParams);
-  analyticsParamsRef.current = analyticsParams;
+  const activeProviderRef = useRef<IntegrationProvider | null>(null);
+  const organizationRef = useRef<Organization | null>(null);
+  const onInstallRef = useRef<((data: IntegrationWithConfig) => void) | null>(null);
+  const analyticsParamsRef = useRef<AddIntegrationParams['analyticsParams']>(undefined);
 
   useEffect(() => {
     function handleMessage(message: MessageEvent) {
@@ -133,14 +109,16 @@ function useLegacyAddIntegration({
         return;
       }
 
-      trackIntegrationAnalytics('integrations.installation_complete', {
-        integration: provider.key,
-        integration_type: 'first_party',
-        organization,
-        ...analyticsParamsRef.current,
-      });
-      addSuccessMessage(t('%s added', provider.name));
-      onInstallRef.current(data);
+      if (activeProviderRef.current && organizationRef.current) {
+        trackIntegrationAnalytics('integrations.installation_complete', {
+          integration: activeProviderRef.current.key,
+          integration_type: 'first_party',
+          organization: organizationRef.current,
+          ...analyticsParamsRef.current,
+        });
+        addSuccessMessage(t('%s added', activeProviderRef.current.name));
+      }
+      onInstallRef.current?.(data);
     }
 
     window.addEventListener('message', handleMessage);
@@ -148,67 +126,26 @@ function useLegacyAddIntegration({
       window.removeEventListener('message', handleMessage);
       dialogRef.current?.close();
     };
-  }, [provider.key, provider.name, organization]);
+  }, []);
 
-  const startFlow = useCallback(
-    (urlParams?: Record<string, string>) => {
+  const startFlow = useCallback((params: AddIntegrationParams) => {
+    const {organization, provider, onInstall, account, analyticsParams, modalParams} =
+      params;
+
+    // Store in refs for the message handler
+    activeProviderRef.current = provider;
+    organizationRef.current = organization;
+    onInstallRef.current = onInstall;
+    analyticsParamsRef.current = analyticsParams;
+
+    const pipelineProvider = getApiPipelineProvider(organization, provider.key);
+
+    if (pipelineProvider !== null) {
       trackIntegrationAnalytics('integrations.installation_start', {
         integration: provider.key,
         integration_type: 'first_party',
         organization,
         ...analyticsParams,
-      });
-
-      const name = modalParams?.use_staging
-        ? 'sentryAddStagingIntegration'
-        : 'sentryAddIntegration';
-      const {url, width, height} = provider.setupDialog;
-      const {left, top} = computeCenteredWindow(width, height);
-
-      let query: Record<string, string> = {...urlParams};
-      if (account) {
-        query.account = account;
-      }
-      if (modalParams) {
-        query = {...query, ...modalParams};
-      }
-
-      const installUrl = `${url}?${qs.stringify(query)}`;
-      const opts = `scrollbars=yes,width=${width},height=${height},top=${top},left=${left}`;
-
-      dialogRef.current = window.open(installUrl, name, opts);
-      dialogRef.current?.focus();
-    },
-    [provider, organization, account, analyticsParams, modalParams]
-  );
-
-  return {startFlow};
-}
-
-/**
- * Opens the integration setup flow. Automatically selects between the new
- * API-driven pipeline modal and the legacy popup-based flow depending on
- * the organization's feature flags.
- */
-export function useAddIntegration(params: AddIntegrationParams) {
-  const {provider, organization, onInstall} = params;
-  const {startFlow: legacyStartFlow} = useLegacyAddIntegration(params);
-  const pipelineProvider = getApiPipelineProvider(organization, provider.key);
-
-  const startFlow = useCallback(
-    (urlParams?: Record<string, string>) => {
-      // Fallback to legacy view-based flow when the feature flag for API based
-      // flows is not enabled for the provider.
-      if (pipelineProvider === null) {
-        legacyStartFlow(urlParams);
-        return;
-      }
-
-      trackIntegrationAnalytics('integrations.installation_start', {
-        integration: provider.key,
-        integration_type: 'first_party',
-        organization,
-        ...params.analyticsParams,
       });
       openPipelineModal({
         type: 'integration',
@@ -218,22 +155,43 @@ export function useAddIntegration(params: AddIntegrationParams) {
             integration: provider.key,
             integration_type: 'first_party',
             organization,
-            ...params.analyticsParams,
+            ...analyticsParams,
           });
           addSuccessMessage(t('%s added', provider.name));
           onInstall(data);
         },
       });
-    },
-    [
-      pipelineProvider,
-      provider,
+      return;
+    }
+
+    // Legacy popup flow
+    trackIntegrationAnalytics('integrations.installation_start', {
+      integration: provider.key,
+      integration_type: 'first_party',
       organization,
-      params.analyticsParams,
-      onInstall,
-      legacyStartFlow,
-    ]
-  );
+      ...analyticsParams,
+    });
+
+    const name = modalParams?.use_staging
+      ? 'sentryAddStagingIntegration'
+      : 'sentryAddIntegration';
+    const {url, width, height} = provider.setupDialog;
+    const {left, top} = computeCenteredWindow(width, height);
+
+    let query: Record<string, string> = {...params.urlParams};
+    if (account) {
+      query.account = account;
+    }
+    if (modalParams) {
+      query = {...query, ...modalParams};
+    }
+
+    const installUrl = `${url}?${qs.stringify(query)}`;
+    const opts = `scrollbars=yes,width=${width},height=${height},top=${top},left=${left}`;
+
+    dialogRef.current = window.open(installUrl, name, opts);
+    dialogRef.current?.focus();
+  }, []);
 
   return {startFlow};
 }

--- a/static/app/utils/window/computeCenteredWindow.tsx
+++ b/static/app/utils/window/computeCenteredWindow.tsx
@@ -1,0 +1,21 @@
+export function computeCenteredWindow(width: number, height: number) {
+  const screenLeft = window.screenLeft === undefined ? window.screenX : window.screenLeft;
+  const screenTop = window.screenTop === undefined ? window.screenY : window.screenTop;
+
+  const innerWidth = window.innerWidth
+    ? window.innerWidth
+    : document.documentElement.clientWidth
+      ? document.documentElement.clientWidth
+      : screen.width;
+
+  const innerHeight = window.innerHeight
+    ? window.innerHeight
+    : document.documentElement.clientHeight
+      ? document.documentElement.clientHeight
+      : screen.height;
+
+  const left = innerWidth / 2 - width / 2 + screenLeft;
+  const top = innerHeight / 2 - height / 2 + screenTop;
+
+  return {left, top};
+}

--- a/static/app/views/integrationOrganizationLink/index.tsx
+++ b/static/app/views/integrationOrganizationLink/index.tsx
@@ -20,6 +20,7 @@ import type {Organization} from 'sentry/types/organization';
 import {generateOrgSlugUrl, urlEncode} from 'sentry/utils';
 import type {IntegrationAnalyticsKey} from 'sentry/utils/analytics/integrations';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {useAddIntegration} from 'sentry/utils/integrations/useAddIntegration';
 import {
   getIntegrationFeatureGate,
   trackIntegrationAnalytics,
@@ -31,7 +32,6 @@ import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useParams} from 'sentry/utils/useParams';
 import RouteError from 'sentry/views/routeError';
-import {useAddIntegration} from 'sentry/views/settings/organizationIntegrations/addIntegration';
 import {IntegrationLayout} from 'sentry/views/settings/organizationIntegrations/detailedView/integrationLayout';
 
 interface GitHubIntegrationInstallation {
@@ -421,7 +421,7 @@ function AddIntegrationButton({
   provider: IntegrationProvider;
   installationId?: string;
 }) {
-  const {startFlow} = useAddIntegration({provider, organization, onInstall});
+  const {startFlow} = useAddIntegration();
 
   return (
     <ButtonWrapper>
@@ -430,7 +430,12 @@ function AddIntegrationButton({
         disabled={!hasAccess || disabled}
         onClick={() =>
           installationId
-            ? startFlow({installation_id: installationId})
+            ? startFlow({
+                provider,
+                organization,
+                onInstall,
+                urlParams: {installation_id: installationId},
+              })
             : finishInstallation()
         }
       >

--- a/static/app/views/settings/organizationIntegrations/addIntegrationButton.tsx
+++ b/static/app/views/settings/organizationIntegrations/addIntegrationButton.tsx
@@ -5,9 +5,8 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 import {t} from 'sentry/locale';
 import type {IntegrationWithConfig} from 'sentry/types/integrations';
 import {trackAnalytics} from 'sentry/utils/analytics';
-
-import type {AddIntegrationParams} from './addIntegration';
-import {useAddIntegration} from './addIntegration';
+import type {AddIntegrationParams} from 'sentry/utils/integrations/useAddIntegration';
+import {useAddIntegration} from 'sentry/utils/integrations/useAddIntegration';
 
 interface AddIntegrationButtonProps
   extends
@@ -41,13 +40,7 @@ export function AddIntegrationButton({
         ? t('Reinstall')
         : t('Add %s', provider.metadata.noun));
 
-  const {startFlow} = useAddIntegration({
-    provider,
-    organization,
-    onInstall: onAddIntegration,
-    analyticsParams,
-    modalParams,
-  });
+  const {startFlow} = useAddIntegration();
 
   return (
     <Tooltip
@@ -64,7 +57,13 @@ export function AddIntegrationButton({
               provider: provider.metadata.noun,
             });
           }
-          startFlow();
+          startFlow({
+            provider,
+            organization,
+            onInstall: onAddIntegration,
+            analyticsParams,
+            modalParams,
+          });
         }}
         aria-label={t('Add integration')}
       >

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -26,6 +26,7 @@ import type {
 } from 'sentry/types/integrations';
 import type {Organization} from 'sentry/types/organization';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {useAddIntegration} from 'sentry/utils/integrations/useAddIntegration';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import {singleLineRenderer} from 'sentry/utils/marked/marked';
 import {
@@ -50,7 +51,6 @@ import {useRoutes} from 'sentry/utils/useRoutes';
 import {BreadcrumbTitle} from 'sentry/views/settings/components/settingsBreadcrumb/breadcrumbTitle';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 
-import {useAddIntegration} from './addIntegration';
 import {IntegrationAlertRules} from './integrationAlertRules';
 import {IntegrationCodeMappings} from './integrationCodeMappings';
 import {IntegrationExternalTeamMappings} from './integrationExternalTeamMappings';
@@ -564,10 +564,15 @@ function PagerdutyAddServicesButton({
   organization: Organization;
   provider: IntegrationProvider;
 }) {
-  const {startFlow} = useAddIntegration({provider, onInstall, account, organization});
+  const {startFlow} = useAddIntegration();
 
   return (
-    <Button priority="primary" size="sm" icon={<IconAdd />} onClick={() => startFlow()}>
+    <Button
+      priority="primary"
+      size="sm"
+      icon={<IconAdd />}
+      onClick={() => startFlow({provider, onInstall, account, organization})}
+    >
       {t('Add Services')}
     </Button>
   );


### PR DESCRIPTION
Refactors `useAddIntegration` so that `startFlow()` accepts all params (provider, organization, onInstall, etc.) at call time instead of at hook initialization. This lets a single hook instance launch flows for any provider, which is needed for multi-provider UIs like dropdowns where the provider isn't known until the user clicks.

The hook now manages its own `message` event listener via refs, eliminating the need for a context provider (`PostMessageProvider`) at call sites.

Other changes:
- Moved hook from `views/settings/organizationIntegrations/` to `utils/integrations/`
- Extracted `computeCenteredWindow` to `utils/window/`
- Added `urlParams` to `AddIntegrationParams` (used by `IntegrationOrganizationLink` for `installation_id`)

All existing call sites updated: `AddIntegrationButton`, `PagerdutyAddServicesButton`, and `IntegrationOrganizationLink`.

Refs VDY-69