### PR TITLE
feat(explorer): Add Code Mode toggle to Explorer UI

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -323,7 +323,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable code editing tools in Seer Explorer chat
     manager.add("organizations:seer-explorer-chat-coding", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable code mode tools (sentry_api_search/execute) in Seer Explorer
-    manager.add("organizations:seer-explorer-code-mode-tools", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:seer-explorer-code-mode-tools", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable structured LLM context (JSON snapshot) instead of ASCII DOM snapshot
     manager.add("organizations:context-engine-structured-page-context", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the Seer Overview sections for Seat-Based users

--- a/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
@@ -55,6 +55,12 @@ class SeerExplorerChatSerializer(serializers.Serializer):
         default=True,
         help_text="Override context engine rollout flag (applies to reasoning platform only).",
     )
+    override_code_mode_enable = serializers.BooleanField(
+        required=False,
+        default=None,
+        allow_null=True,
+        help_text="Override code mode tools flag from the frontend toggle.",
+    )
 
 
 class OrganizationSeerExplorerChatPermission(OrganizationPermission):
@@ -156,6 +162,7 @@ class OrganizationSeerExplorerChatEndpoint(OrganizationEndpoint):
         on_page_context = validated_data.get("on_page_context")
         page_name = validated_data.get("page_name")
         override_ce_enable = validated_data["override_ce_enable"]
+        override_code_mode_enable = validated_data.get("override_code_mode_enable")
 
         # If the frontend sent a structured LLMContext JSON snapshot, convert to markdown.
         if on_page_context:
@@ -175,6 +182,8 @@ class OrganizationSeerExplorerChatEndpoint(OrganizationEndpoint):
             enable_code_mode_tools = features.has(
                 "organizations:seer-explorer-code-mode-tools", organization, actor=request.user
             )
+            if override_code_mode_enable is not None and enable_code_mode_tools:
+                enable_code_mode_tools = override_code_mode_enable
             client = SeerExplorerClient(
                 organization,
                 request.user,

--- a/static/app/views/seerExplorer/explorerPanel.spec.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.spec.tsx
@@ -215,7 +215,7 @@ describe('ExplorerPanel', () => {
           createPR: jest.fn(),
           overrideCtxEngEnable: true,
           setOverrideCtxEngEnable: jest.fn(),
-          overrideCodeModeEnable: false,
+          overrideCodeModeEnable: true,
           setOverrideCodeModeEnable: jest.fn(),
         });
 

--- a/static/app/views/seerExplorer/explorerPanel.spec.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.spec.tsx
@@ -215,6 +215,8 @@ describe('ExplorerPanel', () => {
           createPR: jest.fn(),
           overrideCtxEngEnable: true,
           setOverrideCtxEngEnable: jest.fn(),
+          overrideCodeModeEnable: false,
+          setOverrideCodeModeEnable: jest.fn(),
         });
 
       renderWithPanelContext(<ExplorerPanel />, true, {organization});
@@ -277,6 +279,8 @@ describe('ExplorerPanel', () => {
         createPR: jest.fn(),
         overrideCtxEngEnable: true,
         setOverrideCtxEngEnable: jest.fn(),
+        overrideCodeModeEnable: false,
+        setOverrideCodeModeEnable: jest.fn(),
       });
 
       renderWithPanelContext(<ExplorerPanel />, true, {organization});

--- a/static/app/views/seerExplorer/explorerPanel.tsx
+++ b/static/app/views/seerExplorer/explorerPanel.tsx
@@ -117,6 +117,8 @@ export function ExplorerPanel() {
     wasJustInterrupted,
     overrideCtxEngEnable,
     setOverrideCtxEngEnable,
+    overrideCodeModeEnable,
+    setOverrideCodeModeEnable,
   } = useSeerExplorer();
 
   const copySessionEnabled = Boolean(runId && organization?.slug);
@@ -624,6 +626,11 @@ export function ExplorerPanel() {
           !!organization?.features.includes(
             'seer-explorer-context-engine-fe-override-ui-flag'
           )
+        }
+        overrideCodeModeEnable={overrideCodeModeEnable}
+        onOverrideCodeModeEnableToggle={() => setOverrideCodeModeEnable(v => !v)}
+        showCodeModeToggle={
+          !!organization?.features.includes('seer-explorer-code-mode-tools')
         }
       />
       {menu}

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -117,6 +117,7 @@ export const useSeerExplorer = () => {
   const captureAsciiSnapshot = useAsciiSnapshot();
   const {getLLMContext} = useLLMContext();
   const [overrideCtxEngEnable, setOverrideCtxEngEnable] = useState<boolean>(true);
+  const [overrideCodeModeEnable, setOverrideCodeModeEnable] = useState<boolean>(true);
 
   const [runId, setRunId] = useSessionStorage<number | null>(
     'seer-explorer-run-id',
@@ -295,6 +296,7 @@ export const useSeerExplorer = () => {
             on_page_context: screenshot,
             page_name: getPageReferrer(),
             override_ce_enable: overrideCtxEngEnable,
+            override_code_mode_enable: overrideCodeModeEnable,
           },
         })) as SeerExplorerChatResponse;
 
@@ -336,6 +338,7 @@ export const useSeerExplorer = () => {
       getPageReferrer,
       organization,
       overrideCtxEngEnable,
+      overrideCodeModeEnable,
     ]
   );
 
@@ -598,5 +601,7 @@ export const useSeerExplorer = () => {
     createPR,
     overrideCtxEngEnable,
     setOverrideCtxEngEnable,
+    overrideCodeModeEnable,
+    setOverrideCodeModeEnable,
   };
 };

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -117,7 +117,7 @@ export const useSeerExplorer = () => {
   const captureAsciiSnapshot = useAsciiSnapshot();
   const {getLLMContext} = useLLMContext();
   const [overrideCtxEngEnable, setOverrideCtxEngEnable] = useState<boolean>(true);
-  const [overrideCodeModeEnable, setOverrideCodeModeEnable] = useState<boolean>(true);
+  const [overrideCodeModeEnable, setOverrideCodeModeEnable] = useState<boolean>(false);
 
   const [runId, setRunId] = useSessionStorage<number | null>(
     'seer-explorer-run-id',

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -117,7 +117,7 @@ export const useSeerExplorer = () => {
   const captureAsciiSnapshot = useAsciiSnapshot();
   const {getLLMContext} = useLLMContext();
   const [overrideCtxEngEnable, setOverrideCtxEngEnable] = useState<boolean>(true);
-  const [overrideCodeModeEnable, setOverrideCodeModeEnable] = useState<boolean>(false);
+  const [overrideCodeModeEnable, setOverrideCodeModeEnable] = useState<boolean>(true);
 
   const [runId, setRunId] = useSessionStorage<number | null>(
     'seer-explorer-run-id',

--- a/static/app/views/seerExplorer/topBar.tsx
+++ b/static/app/views/seerExplorer/topBar.tsx
@@ -33,12 +33,15 @@ interface TopBarProps {
   onCopySessionClick: () => void;
   onFeedbackClick: () => void;
   onNewChatClick: () => void;
+  onOverrideCodeModeEnableToggle: () => void;
   onOverrideCtxEngEnableToggle: () => void;
   onSessionHistoryClick: (buttonRef: React.RefObject<HTMLElement | null>) => void;
   onSizeToggleClick: () => void;
+  overrideCodeModeEnable: boolean;
   overrideCtxEngEnable: boolean;
   panelSize: 'max' | 'med';
   sessionHistoryButtonRef: React.RefObject<HTMLButtonElement | null>;
+  showCodeModeToggle: boolean;
   showContextEngineToggle: boolean;
 }
 
@@ -55,8 +58,11 @@ export function TopBar({
   onCopyLinkClick,
   onSizeToggleClick,
   onOverrideCtxEngEnableToggle,
+  onOverrideCodeModeEnableToggle,
   overrideCtxEngEnable,
+  overrideCodeModeEnable,
   showContextEngineToggle,
+  showCodeModeToggle,
   panelSize,
   isCopySessionEnabled,
   isCopyLinkEnabled,
@@ -112,6 +118,27 @@ export function TopBar({
           tooltipProps={{title: t('Copy link to current chat and web page')}}
           disabled={!isCopyLinkEnabled}
         />
+        {showCodeModeToggle && (
+          <Tooltip
+            title={
+              overrideCodeModeEnable
+                ? t('Code mode enabled (click to disable)')
+                : t('Code mode disabled (click to enable)')
+            }
+          >
+            <Flex align="center" gap="xs" padding="xs sm" height="100%">
+              <Switch
+                size="sm"
+                checked={overrideCodeModeEnable}
+                onChange={onOverrideCodeModeEnableToggle}
+                aria-label={t('Toggle code mode')}
+              />
+              <Text size="sm" variant="muted">
+                {t('CM')}
+              </Text>
+            </Flex>
+          </Tooltip>
+        )}
         {showContextEngineToggle && (
           <Tooltip
             title={


### PR DESCRIPTION
## Summary
- Adds a CM (Code Mode) toggle to the Explorer top bar, next to the existing CE toggle
- Only visible when user has `seer-explorer-code-mode-tools` feature flag
- Frontend sends `override_code_mode_enable` in POST body
- Backend uses it to enable/disable code mode tools (only overrides if flag is already enabled — can't bypass the flag)

## Test plan
- [ ] Verify toggle appears only when feature-flagged
- [ ] Verify toggling CM off suppresses code mode tools in Explorer responses
- [ ] Verify CE toggle still works independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)