### PR TITLE
ref(cells): Safe Python symbol renames in relocation module

### DIFF
--- a/src/sentry/relocation/models/relocationtransfer.py
+++ b/src/sentry/relocation/models/relocationtransfer.py
@@ -24,10 +24,10 @@ class RelocationTransferState(models.TextChoices):
 
 class BaseRelocationTransfer(DefaultFieldsModel):
     """
-    Base class for control + region relocation transfer models
+    Base class for control + cell relocation transfer models
 
     Relocation transfers are used to record a retriable
-    state of a regional transfer for relocation data.
+    state of a cell transfer for relocation data.
     These models replace outbox based transfers.
     """
 
@@ -50,7 +50,7 @@ class BaseRelocationTransfer(DefaultFieldsModel):
 class ControlRelocationTransfer(BaseRelocationTransfer):
     __relocation_scope__ = RelocationScope.Excluded
 
-    # The public key of the region that is requesting
+    # The public key of the cell that is requesting
     # the relocation.
     public_key = models.BinaryField(null=True)
 

--- a/src/sentry/relocation/services/relocation_export/impl.py
+++ b/src/sentry/relocation/services/relocation_export/impl.py
@@ -22,8 +22,8 @@ from sentry.relocation.models.relocationtransfer import (
     RelocationTransferState,
 )
 from sentry.relocation.services.relocation_export.service import (
+    CellRelocationExportService,
     ControlRelocationExportService,
-    RegionRelocationExportService,
 )
 from sentry.relocation.tasks.process import fulfill_cross_region_export_request, uploading_complete
 from sentry.relocation.tasks.transfer import process_relocation_transfer_control
@@ -33,7 +33,7 @@ from sentry.utils.db import atomic_transaction
 logger = logging.getLogger("sentry.relocation")
 
 
-class DBBackedRelocationExportService(RegionRelocationExportService):
+class DBBackedRelocationExportService(CellRelocationExportService):
     def request_new_export(
         self,
         *,
@@ -52,11 +52,11 @@ class DBBackedRelocationExportService(RegionRelocationExportService):
         }
         logger.info("SaaS -> SaaS request received in exporting region", extra=logger_data)
 
-        # This task will do the actual work of performing the export and saving it to this regions
+        # This task will do the actual work of performing the export and saving it to this cell's
         # "relocation" GCS bucket. It is annotated with the appropriate retry, back-off etc logic
         # for robustness' sake. The last action performed by this task is to call an instance of
         # `ControlRelocationExportService.reply_with_export` via a manually-scheduled
-        # `RegionOutbox`, which will handle the task of asynchronously delivering the encrypted,
+        # `CellOutbox`, which will handle the task of asynchronously delivering the encrypted,
         # newly-exported bytes.
         fulfill_cross_region_export_request.apply_async(
             args=[
@@ -184,7 +184,7 @@ class ProxyingRelocationExportService(ControlRelocationExportService):
         logger.info("SaaS -> SaaS reply received on proxy", extra=logger_data)
 
         # Save the payload into the control silo's "relocation" GCS bucket. This bucket is only used
-        # for temporary storage of `encrypted_bytes` being shuffled between regions like this.
+        # for temporary storage of `encrypted_bytes` being shuffled between cells like this.
         path = f"runs/{relocation_uuid}/saas_to_saas_export/{org_slug}.tar"
         relocation_storage = get_relocation_storage()
         # TODO(azaslavsky): finish transfer from `encrypted_contents` -> `encrypted_bytes`.
@@ -192,7 +192,7 @@ class ProxyingRelocationExportService(ControlRelocationExportService):
         relocation_storage.save(path, fp)
         logger.info("SaaS -> SaaS export contents retrieved", extra=logger_data)
 
-        # Save transfer record so we can push state to the requesting region
+        # Save transfer record so we can push state to the requesting cell
         transfer = ControlRelocationTransfer.objects.create(
             relocation_uuid=relocation_uuid,
             org_slug=org_slug,

--- a/src/sentry/relocation/services/relocation_export/service.py
+++ b/src/sentry/relocation/services/relocation_export/service.py
@@ -12,21 +12,21 @@ from sentry.silo.base import SiloMode
 
 
 @dataclass(frozen=True)
-class ByRequestingRegionName(ByCellName):
+class ByRequestingCellName(ByCellName):
     parameter_name: str = "requesting_region_name"
 
 
 @dataclass(frozen=True)
-class ByReplyingRegionName(ByCellName):
+class ByReplyingCellName(ByCellName):
     parameter_name: str = "replying_region_name"
 
 
 # See the comment on /src/sentry/relocation/tasks/process.py::uploading_start for a detailed description of
 # how this service fits into the entire SAAS->SAAS relocation workflow.
-class RegionRelocationExportService(RpcService):
+class CellRelocationExportService(RpcService):
     """
     Service that implements asynchronous relocation export request and reply methods. The request
-    method is sent by the requesting region to the exporting region, with
+    method is sent by the requesting cell to the exporting cell, with
     `ControlRelocationExportService` acting as a middleman proxy.
     """
 
@@ -41,7 +41,7 @@ class RegionRelocationExportService(RpcService):
 
         return DBBackedRelocationExportService()
 
-    @cell_rpc_method(resolve=ByReplyingRegionName())
+    @cell_rpc_method(resolve=ByReplyingCellName())
     @abstractmethod
     def request_new_export(
         self,
@@ -54,9 +54,9 @@ class RegionRelocationExportService(RpcService):
     ) -> None:
         """
         This helper method exists to facilitate calling `export_in_organization_scope` from one
-        region to another. It performs the `export_in_organization_scope` call in the target region,
+        cell to another. It performs the `export_in_organization_scope` call in the target cell,
         but instead of merely writing the output to a file locally, it takes the bytes of the
-        resulting tarball and (asynchronously, via a `RegionOutbox` handler that calls
+        resulting tarball and (asynchronously, via a `CellOutbox` handler that calls
         `reply_with_export`) sends them back over the wire using the `reply_with_export` method.
 
         This method always produces encrypted exports, so the caller must supply the correct public
@@ -64,7 +64,7 @@ class RegionRelocationExportService(RpcService):
         """
         pass
 
-    @cell_rpc_method(resolve=ByRequestingRegionName())
+    @cell_rpc_method(resolve=ByRequestingCellName())
     @abstractmethod
     def reply_with_export(
         self,
@@ -79,7 +79,7 @@ class RegionRelocationExportService(RpcService):
     ) -> None:
         """
         This method is responsible for asynchronously sending an already generated and locally-saved
-        export tarball back from the exporting region to the region that requested the export.
+        export tarball back from the exporting cell to the cell that requested the export.
         """
         pass
 
@@ -89,8 +89,8 @@ class RegionRelocationExportService(RpcService):
 class ControlRelocationExportService(RpcService):
     """
     Service that proxies asynchronous relocation export request and reply methods. The requesting
-    and exporting region use this service as a middleman to enable inter-region communication. The
-    actual export logic is contained in the `RegionRelocationExportService` that this proxy serves
+    and exporting cell use this service as a middleman to enable inter-cell communication. The
+    actual export logic is contained in the `CellRelocationExportService` that this proxy serves
     to connect.
     """
 
@@ -118,7 +118,7 @@ class ControlRelocationExportService(RpcService):
     ) -> None:
         """
         This helper method is a proxy handler for the `request_new_export` method, durably
-        forwarding it from the requesting region to the exporting region by writing a retryable
+        forwarding it from the requesting cell to the exporting cell by writing a retryable
         `ControlOutbox` entry.
         """
         pass
@@ -138,11 +138,11 @@ class ControlRelocationExportService(RpcService):
     ) -> None:
         """
         This helper method is a proxy handler for the `reply_with_export` method, durably forwarding
-        it from the requesting region to the exporting region by writing a retryable `ControlOutbox`
+        it from the requesting cell to the exporting cell by writing a retryable `ControlOutbox`
         entry.
         """
         pass
 
 
-region_relocation_export_service = RegionRelocationExportService.create_delegation()
+cell_relocation_export_service = CellRelocationExportService.create_delegation()
 control_relocation_export_service = ControlRelocationExportService.create_delegation()

--- a/src/sentry/relocation/tasks/process.py
+++ b/src/sentry/relocation/tasks/process.py
@@ -338,8 +338,8 @@ def fulfill_cross_region_export_request(
     logger_data = {
         "uuid": uuid_str,
         "task": "fulfill_cross_region_export_request",
-        "requesting_region_name": requesting_cell_name,
-        "replying_region_name": replying_cell_name,
+        "requesting_cell_name": requesting_cell_name,
+        "replying_cell_name": replying_cell_name,
         "org_slug": org_slug,
         "encrypted_public_key_size": len(encrypt_with_public_key_bytes),
         "scheduled_at": scheduled_at,

--- a/src/sentry/relocation/tasks/process.py
+++ b/src/sentry/relocation/tasks/process.py
@@ -121,7 +121,7 @@ RELOCATION_FILES_TO_BE_VALIDATED = [
 # Various error strings that we want to surface to users, grouped by step.
 ERR_UPLOADING_FAILED = "Internal error during file upload."
 ERR_UPLOADING_NO_SAAS_TO_SAAS_ORG_SLUG = "SAAS->SAAS relocations must specify an org slug."
-ERR_UPLOADING_CROSS_REGION_TIMEOUT = Template(
+ERR_UPLOADING_CROSS_CELL_TIMEOUT = Template(
     "Cross-region relocation export request timed out after $delta."
 )
 
@@ -164,16 +164,16 @@ ERR_COMPLETED_INTERNAL = "Internal error during relocation wrap-up."
     processing_deadline_duration=FAST_TIME_LIMIT,
     retry=Retry(times=MAX_FAST_TASK_RETRIES, on=(Exception,), times_exceeded=LastAction.Discard),
 )
-def uploading_start(uuid: str, replying_region_name: str | None, org_slug: str | None) -> None:
+def uploading_start(uuid: str, replying_cell_name: str | None, org_slug: str | None) -> None:
     """
     The very first action in the relocation pipeline. In the case of a `SAAS_TO_SAAS` relocation, it
-    will trigger the export of the requested organization from the region it currently live in. If
+    will trigger the export of the requested organization from the cell it currently lives in. If
     this is a `SELF_HOSTED` relocation, this task is a no-op that merely auto-triggers the next step
     in the chain, `upload_complete`.
 
     In the case of a `SAAS_TO_SAAS` relocation, we'll need to export an organization from the
-    exporting region (ER) back to the requesting region (RR - where this method is running). Because
-    region-to-region messaging is forbidden, all of this messaging will need to be proxied via the
+    exporting cell (EC) back to the requesting cell (RC - where this method is running). Because
+    cell-to-cell messaging is forbidden, all of this messaging will need to be proxied via the
     control silo (CS). Thus, to accomplish this export-and-copy operation, we'll need to use
     sequenced RPC calls to fault-tolerantly execute code in these three siloed locations.
 
@@ -184,7 +184,7 @@ def uploading_start(uuid: str, replying_region_name: str | None, org_slug: str |
 
 
         | Requesting |            |   Control  |            | Exporting  |
-        |    (RR)    |            |    (CS)    |            |    (ER)    |
+        |    (RC)    |            |    (CS)    |            |    (EC)    |
         |============|            |============|            |============|
         |            |            |            |            |            |
         |     01     |            |            |            |            |
@@ -203,46 +203,46 @@ def uploading_start(uuid: str, replying_region_name: str | None, org_slug: str |
         |            |            |            |            |            |
 
 
-    01. (RR) ./tasks/process.py::uploading_start: This first function grabs this (aka the
-        "requesting" region) region's public key, then sends an RPC call to the control silo,
-        requesting an export of some `org_slug` from the `replying_region_name` in which is lives.
+    01. (RC) ./tasks/process.py::uploading_start: This first function grabs this (aka the
+        "requesting" cell) cell's public key, then sends an RPC call to the control silo,
+        requesting an export of some `org_slug` from the `replying_cell_name` in which is lives.
     02. The `ProxyingRelocationExportService::request_new_export` call is sent over the wire from
-        the requesting region to the control silo.
+        the requesting cell to the control silo.
     03. (CS) .../relocation_export/impl.py::ProxyingRelocationExportService::request_new_export: The
         request RPC call is received, and is immediately packaged into a `ControlRelocationTransfer`,
-        so that we may robustly forward it to the exporting region. This task successfully completing causes
+        so that we may robustly forward it to the exporting cell. This task successfully completing causes
         the RPC to successfully return to the sender, allowing the calling `uploading_start`
         task to finish successfully as well.
     04. (CS) ./tasks/transfer.py::process_relocation_transfer_control: Whenever an outbox draining attempt
-        occurs, this code will be called to forward the proxied call into the exporting region.
+        occurs, this code will be called to forward the proxied call into the exporting cell.
     05. The `DBBackedExportService::request_new_export` call is sent over the wire from the control
-        silo to the exporting region.
-    06. (ER) .../relocation_export/impl.py::DBBackedRelocationExportService::request_new_export: The
+        silo to the exporting cell.
+    06. (EC) .../relocation_export/impl.py::DBBackedRelocationExportService::request_new_export: The
         request RPC call is received, and immediately schedules the
         `fulfill_cross_region_export_request` task, which uses an exponential backoff
         algorithm to try and create an encrypted tarball containing an export of the requested org
         slug.
-    07. (ER) ./tasks/process.py::fulfill_cross_region_export_request: This task performs
-        the actual export operation locally in the exporting region. This data is written as a file
-        to this region's relocation-specific GCS bucket, and the response is immediately packaged
+    07. (EC) ./tasks/process.py::fulfill_cross_region_export_request: This task performs
+        the actual export operation locally in the exporting cell. This data is written as a file
+        to this cell's relocation-specific GCS bucket, and the response is immediately packaged
         into a `RegionRelocationTransfer`, so that we may robustly attempt to send it to control silo
-        and the requesting region.
-    08. (ER) ./tasks/transfer.py::process_relocation_transfer_region: This code will be called to read
+        and the requesting cell.
+    08. (EC) ./tasks/transfer.py::process_relocation_transfer_region: This code will be called to read
         the saved export data from the local GCS bucket, package it into an RPC call, and send
         it back to the proxy (control silo).
     09. The `ProxyingRelocationExportService::reply_with_export` call is sent over the wire from the
-        exporting region back to the control silo.
+        exporting cell back to the control silo.
     10. (CS) .../relocation_export/impl.py::ProxyingRelocationExportService::reply_with_export: The
         request RPC call is received, and is immediately packaged into a `ControlRelocationTransfer`,
-        so that we may robustly forward it back to the requesting region. To ensure robustness,
+        so that we may robustly forward it back to the requesting cell. To ensure robustness,
         the export data is saved to a local file, so that transfer attempts can read it locally
         without needing to make their own nested RPC calls.
     11. (CS) ../tasks/transfer.py::process_relocation_transfer_control: This code will be called to read
         the export data from the local relocation-specific GCS bucket, then forward it into
-        the requesting region.
+        the requesting cell.
     12. The `DBBackedExportService::reply_with_export` call is sent over the wire from the control
-        silo back to the requesting region.
-    13. (RR) .../relocation_export/impl.py::DBBackedRelocationExportService::reply_with_export:
+        silo back to the requesting cell.
+    13. (RC) .../relocation_export/impl.py::DBBackedRelocationExportService::reply_with_export:
         We've made it all the way back! The export data gets saved to a `RelocationFile` associated
         with the `Relocation` that originally triggered `uploading_start`, and the next task in the
         sequence (`uploading_complete`) is scheduled.
@@ -266,11 +266,11 @@ def uploading_start(uuid: str, replying_region_name: str | None, org_slug: str |
         attempts_left,
         ERR_UPLOADING_FAILED,
     ):
-        # If SAAS->SAAS, kick off an export on the source region. In this case, we will not schedule
-        # an `uploading_complete` task - this region's `RelocationExportService.reply_with_export`
+        # If SAAS->SAAS, kick off an export on the source cell. In this case, we will not schedule
+        # an `uploading_complete` task - this cell's `RelocationExportService.reply_with_export`
         # method will wait for a reply from the work we've scheduled here, which will be in charge
         # of writing the `RelocationFile` from the exported data and kicking off
-        # `uploading_complete` with the export data from the source region.
+        # `uploading_complete` with the export data from the source cell.
         if relocation.provenance == Relocation.Provenance.SAAS_TO_SAAS:
             if not org_slug:
                 return fail_relocation(
@@ -279,22 +279,22 @@ def uploading_start(uuid: str, replying_region_name: str | None, org_slug: str |
                     ERR_UPLOADING_NO_SAAS_TO_SAAS_ORG_SLUG,
                 )
 
-            # We want to encrypt this organization from the other region using this region's public
+            # We want to encrypt this organization from the other cell using this cell's public
             # key.
             public_key_pem = GCPKMSEncryptor.from_crypto_key_version(
                 get_default_crypto_key_version()
             ).get_public_key_pem()
 
-            # Send out the cross-region request.
+            # Send out the cross-cell request.
             control_relocation_export_service.request_new_export(
                 relocation_uuid=str(uuid),
                 requesting_region_name=get_local_cell().name,
-                replying_region_name=replying_region_name,
+                replying_region_name=replying_cell_name,
                 org_slug=org_slug,
                 encrypt_with_public_key=public_key_pem,
             )
 
-            # Make sure we're not waiting forever for our cross-region check to come back. After a
+            # Make sure we're not waiting forever for our cross-cell check to come back. After a
             # reasonable amount of time, go ahead and fail the relocation.
             cross_region_export_timeout_check.apply_async(
                 args=[uuid],
@@ -317,8 +317,8 @@ def uploading_start(uuid: str, replying_region_name: str | None, org_slug: str |
 )
 def fulfill_cross_region_export_request(
     uuid_str: str,
-    requesting_region_name: str,
-    replying_region_name: str,
+    requesting_cell_name: str,
+    replying_cell_name: str,
     org_slug: str,
     encrypt_with_public_key: str,
     # Unix timestamp, in seconds.
@@ -327,9 +327,9 @@ def fulfill_cross_region_export_request(
     """
     Unlike most other tasks in this file, this one is not an `OrderedTask` intended to be
     sequentially executed as part of the relocation pipeline. Instead, its job is to export an
-    already existing organization from an adjacent region. That means it is triggered (via RPC - the
-    `relocation_export` service for more) on that region from the `uploading_start` task, which then
-    waits for the exporting region to issue an RPC call back with the data. Once that replying RPC
+    already existing organization from an adjacent cell. That means it is triggered (via RPC - the
+    `relocation_export` service for more) on that cell from the `uploading_start` task, which then
+    waits for the exporting cell to issue an RPC call back with the data. Once that replying RPC
     call is received with the encrypted export in tow, it will trigger the next step in the
     `SAAS_TO_SAAS` relocation's pipeline, namely `uploading_complete`.
     """
@@ -338,8 +338,8 @@ def fulfill_cross_region_export_request(
     logger_data = {
         "uuid": uuid_str,
         "task": "fulfill_cross_region_export_request",
-        "requesting_region_name": requesting_region_name,
-        "replying_region_name": replying_region_name,
+        "requesting_region_name": requesting_cell_name,
+        "replying_region_name": replying_cell_name,
         "org_slug": org_slug,
         "encrypted_public_key_size": len(encrypt_with_public_key_bytes),
         "scheduled_at": scheduled_at,
@@ -403,8 +403,8 @@ def fulfill_cross_region_export_request(
     # Save a transfer record to move the export to control silo
     transfer = RegionRelocationTransfer.objects.create(
         relocation_uuid=uuid_str,
-        requesting_region=requesting_region_name,
-        exporting_region=replying_region_name,
+        requesting_region=requesting_cell_name,
+        exporting_region=replying_cell_name,
         org_slug=org_slug,
         state=RelocationTransferState.Reply,
         # Set next runtime in the future to reduce races with scheduled tasks
@@ -426,7 +426,7 @@ def fulfill_cross_region_export_request(
 )
 def cross_region_export_timeout_check(uuid: str) -> None:
     """
-    Not part of the primary `OrderedTask` queue. This task is only used to ensure that cross-region
+    Not part of the primary `OrderedTask` queue. This task is only used to ensure that cross-cell
     export requests don't hang indefinitely.
     """
     uuid = str(uuid)
@@ -443,7 +443,7 @@ def cross_region_export_timeout_check(uuid: str) -> None:
         extra=logger_data,
     )
 
-    # We've moved past the `UPLOADING_START` step, so the cross-region response was received, one
+    # We've moved past the `UPLOADING_START` step, so the cross-cell response was received, one
     # way or another.
     if relocation.latest_task != OrderedTask.UPLOADING_START.name:
         logger.info(
@@ -461,7 +461,7 @@ def cross_region_export_timeout_check(uuid: str) -> None:
         )
         return
 
-    reason = ERR_UPLOADING_CROSS_REGION_TIMEOUT.substitute(delta=CROSS_REGION_EXPORT_TIMEOUT)
+    reason = ERR_UPLOADING_CROSS_CELL_TIMEOUT.substitute(delta=CROSS_REGION_EXPORT_TIMEOUT)
     logger_data["reason"] = reason
     logger.error(
         "cross_region_export_timeout_check: timeout detected",

--- a/src/sentry/relocation/tasks/transfer.py
+++ b/src/sentry/relocation/tasks/transfer.py
@@ -15,8 +15,8 @@ from sentry.relocation.models.relocationtransfer import (
     RelocationTransferState,
 )
 from sentry.relocation.services.relocation_export.service import (
+    cell_relocation_export_service,
     control_relocation_export_service,
-    region_relocation_export_service,
 )
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
@@ -108,9 +108,9 @@ def process_relocation_transfer_control(transfer_id: int) -> None:
         if public_key:
             public_key = bytes(public_key)
 
-        # Forward the export request to the exporting region.
+        # Forward the export request to the exporting cell.
         try:
-            region_relocation_export_service.request_new_export(
+            cell_relocation_export_service.request_new_export(
                 relocation_uuid=str(transfer.relocation_uuid),
                 requesting_region_name=transfer.requesting_region,
                 replying_region_name=transfer.exporting_region,
@@ -131,7 +131,7 @@ def process_relocation_transfer_control(transfer_id: int) -> None:
     elif transfer.state == RelocationTransferState.Reply:
         # We expect the `ProxyRelocationExportService::reply_with_export` implementation to have
         # written the export data to the control silo's local relocation-specific GCS bucket. Here,
-        # we just read it into memory and attempt the RPC back to the requesting region.
+        # we just read it into memory and attempt the RPC back to the requesting cell.
         uuid = transfer.relocation_uuid
         slug = transfer.org_slug
 
@@ -152,8 +152,8 @@ def process_relocation_transfer_control(transfer_id: int) -> None:
 
         try:
             with encrypted_bytes:
-                # Move encrypted bytes to the requesting region.
-                region_relocation_export_service.reply_with_export(
+                # Move encrypted bytes to the requesting cell.
+                cell_relocation_export_service.reply_with_export(
                     relocation_uuid=str(transfer.relocation_uuid),
                     requesting_region_name=transfer.requesting_region,
                     replying_region_name=transfer.exporting_region,

--- a/tests/sentry/relocation/tasks/test_process.py
+++ b/tests/sentry/relocation/tasks/test_process.py
@@ -56,7 +56,7 @@ from sentry.relocation.tasks.process import (
     ERR_PREPROCESSING_NO_USERS,
     ERR_PREPROCESSING_TOO_MANY_ORGS,
     ERR_PREPROCESSING_TOO_MANY_USERS,
-    ERR_UPLOADING_CROSS_REGION_TIMEOUT,
+    ERR_UPLOADING_CROSS_CELL_TIMEOUT,
     ERR_UPLOADING_FAILED,
     ERR_UPLOADING_NO_SAAS_TO_SAAS_ORG_SLUG,
     ERR_VALIDATING_INTERNAL,
@@ -263,7 +263,7 @@ class UploadingStartTest(RelocationTaskTestCase):
     @patch("sentry.relocation.tasks.process.cross_region_export_timeout_check.apply_async")
     def test_success_saas_to_saas(
         self,
-        cross_region_export_timeout_check_mock: Mock,
+        cross_cell_export_timeout_check_mock: Mock,
         uploading_complete_mock: Mock,
         fake_message_builder: Mock,
         fake_kms_client: Mock,
@@ -281,7 +281,7 @@ class UploadingStartTest(RelocationTaskTestCase):
         # Ensure that the import/export process was driven to completion.
         # self.tasks() is doing a lot of work here.
         assert uploading_complete_mock.call_count == 1
-        assert cross_region_export_timeout_check_mock.call_count == 1
+        assert cross_cell_export_timeout_check_mock.call_count == 1
         assert fake_message_builder.call_count == 0
         assert fake_kms_client.return_value.get_public_key.call_count > 0
         assert fake_kms_client.return_value.asymmetric_decrypt.call_count == 0
@@ -294,7 +294,7 @@ class UploadingStartTest(RelocationTaskTestCase):
     @patch("sentry.relocation.tasks.process.cross_region_export_timeout_check.apply_async")
     def test_success_self_hosted(
         self,
-        cross_region_export_timeout_check_mock: Mock,
+        cross_cell_export_timeout_check_mock: Mock,
         uploading_complete_mock: Mock,
         fake_message_builder: Mock,
         fake_kms_client: Mock,
@@ -313,7 +313,7 @@ class UploadingStartTest(RelocationTaskTestCase):
             uploading_start(self.uuid, None, None)
 
         assert uploading_complete_mock.call_count == 1
-        assert cross_region_export_timeout_check_mock.call_count == 0
+        assert cross_cell_export_timeout_check_mock.call_count == 0
         assert fake_message_builder.call_count == 0
         assert fake_kms_client.return_value.get_public_key.call_count == 0
         assert fake_kms_client.return_value.asymmetric_decrypt.call_count == 0
@@ -323,7 +323,7 @@ class UploadingStartTest(RelocationTaskTestCase):
     @patch("sentry.relocation.tasks.process.cross_region_export_timeout_check.apply_async")
     def test_retry_if_attempts_left(
         self,
-        cross_region_export_timeout_check_mock: Mock,
+        cross_cell_export_timeout_check_mock: Mock,
         uploading_complete_mock: Mock,
         fake_message_builder: Mock,
         fake_kms_client: Mock,
@@ -341,7 +341,7 @@ class UploadingStartTest(RelocationTaskTestCase):
                 uploading_start(self.uuid, EXPORTING_TEST_REGION, self.requested_org_slug)
 
         assert uploading_complete_mock.call_count == 0
-        assert cross_region_export_timeout_check_mock.call_count == 0
+        assert cross_cell_export_timeout_check_mock.call_count == 0
         assert fake_message_builder.call_count == 0
         assert fake_kms_client.return_value.get_public_key.call_count == 1
         assert fake_kms_client.return_value.asymmetric_decrypt.call_count == 0
@@ -353,7 +353,7 @@ class UploadingStartTest(RelocationTaskTestCase):
     @patch("sentry.relocation.tasks.process.cross_region_export_timeout_check.apply_async")
     def test_fail_if_no_attempts_left(
         self,
-        cross_region_export_timeout_check_mock: Mock,
+        cross_cell_export_timeout_check_mock: Mock,
         uploading_complete_mock: Mock,
         fake_message_builder: Mock,
         fake_kms_client: Mock,
@@ -379,7 +379,7 @@ class UploadingStartTest(RelocationTaskTestCase):
         )
 
         assert uploading_complete_mock.call_count == 0
-        assert cross_region_export_timeout_check_mock.call_count == 0
+        assert cross_cell_export_timeout_check_mock.call_count == 0
         assert fake_kms_client.return_value.get_public_key.call_count == 1
         assert fake_kms_client.return_value.asymmetric_decrypt.call_count == 0
 
@@ -390,7 +390,7 @@ class UploadingStartTest(RelocationTaskTestCase):
     @patch("sentry.relocation.tasks.process.cross_region_export_timeout_check.apply_async")
     def test_fail_no_org_slug_when_saas_to_saas(
         self,
-        cross_region_export_timeout_check_mock: Mock,
+        cross_cell_export_timeout_check_mock: Mock,
         uploading_complete_mock: Mock,
         fake_message_builder: Mock,
         fake_kms_client: Mock,
@@ -408,7 +408,7 @@ class UploadingStartTest(RelocationTaskTestCase):
             uploading_start(self.uuid, EXPORTING_TEST_REGION, None)
 
         assert uploading_complete_mock.call_count == 0
-        assert cross_region_export_timeout_check_mock.call_count == 0
+        assert cross_cell_export_timeout_check_mock.call_count == 0
         assert fake_message_builder.call_count == 1
         assert fake_kms_client.return_value.get_public_key.call_count == 0
         assert fake_kms_client.return_value.asymmetric_decrypt.call_count == 0
@@ -444,7 +444,7 @@ class UploadingStartTest(RelocationTaskTestCase):
             relocation = Relocation.objects.get(uuid=self.uuid)
             assert relocation.status == Relocation.Status.FAILURE.value
             assert relocation.latest_notified == Relocation.EmailKind.FAILED.value
-            assert relocation.failure_reason == ERR_UPLOADING_CROSS_REGION_TIMEOUT.substitute(
+            assert relocation.failure_reason == ERR_UPLOADING_CROSS_CELL_TIMEOUT.substitute(
                 delta=timedelta(minutes=-1)
             )
             assert fake_message_builder.call_count == 1

--- a/tests/sentry/relocation/tasks/test_transfer.py
+++ b/tests/sentry/relocation/tasks/test_transfer.py
@@ -42,7 +42,7 @@ def create_control_relocation_transfer(organization: Organization, **kwargs):
     )
 
 
-def create_region_relocation_transfer(organization: Organization, **kwargs):
+def create_cell_relocation_transfer(organization: Organization, **kwargs):
     if "relocation_uuid" not in kwargs:
         kwargs["relocation_uuid"] = uuid4()
     if "state" not in kwargs:
@@ -100,7 +100,7 @@ class FindRelocationTransferRegionTest(TestCase):
 
     @patch("sentry.relocation.tasks.transfer.process_relocation_transfer_region")
     def test_no_due_records(self, mock_process: MagicMock) -> None:
-        create_region_relocation_transfer(
+        create_cell_relocation_transfer(
             organization=self.organization, scheduled_for=timezone.now() + timedelta(minutes=2)
         )
         find_relocation_transfer_region()
@@ -108,7 +108,7 @@ class FindRelocationTransferRegionTest(TestCase):
 
     @patch("sentry.relocation.tasks.transfer.process_relocation_transfer_region")
     def test_due_records(self, mock_process: MagicMock) -> None:
-        transfer = create_region_relocation_transfer(
+        transfer = create_cell_relocation_transfer(
             organization=self.organization, scheduled_for=timezone.now() - timedelta(minutes=2)
         )
         find_relocation_transfer_region()
@@ -118,7 +118,7 @@ class FindRelocationTransferRegionTest(TestCase):
 
     @patch("sentry.relocation.tasks.transfer.process_relocation_transfer_region")
     def test_purge_expired(self, mock_process: MagicMock) -> None:
-        transfer = create_region_relocation_transfer(
+        transfer = create_cell_relocation_transfer(
             organization=self.organization,
             scheduled_for=timezone.now() - timedelta(minutes=2),
         )
@@ -176,7 +176,7 @@ class ProcessRelocationTransferControlTest(TestCase):
         assert mock_uploading_complete.apply_async.called, "task should be spawned"
         # Should be removed on completion.
         assert not ControlRelocationTransfer.objects.filter(id=transfer.id).exists()
-        # the relocation RPC call should create a file on the region
+        # the relocation RPC call should create a file on the cell
         with assume_test_silo_mode(SiloMode.CELL):
             assert RelocationFile.objects.filter(relocation=relocation).exists()
 
@@ -188,7 +188,7 @@ class ProcessRelocationTransferRegionTest(TestCase):
         assert res is None
 
     def test_transfer_request_state(self) -> None:
-        transfer = create_region_relocation_transfer(
+        transfer = create_cell_relocation_transfer(
             organization=self.organization,
             state=RelocationTransferState.Request,
         )
@@ -204,7 +204,7 @@ class ProcessRelocationTransferRegionTest(TestCase):
             want_org_slugs=["acme-org"],
             step=Relocation.Step.UPLOADING.value,
         )
-        transfer = create_region_relocation_transfer(
+        transfer = create_cell_relocation_transfer(
             organization=organization,
             relocation_uuid=relocation.uuid,
             state=RelocationTransferState.Reply,


### PR DESCRIPTION
Rename Python-level symbols (class names, variable names, parameters, comments, docstrings) from "region" to "cell" terminology in the relocation export service, transfer tasks, and related tests.

Wire format strings, DB column names, Celery task name= strings and Django model names are intentionally left unchanged for a later migration.
