### PR TITLE
fix(issues): Hide line numbers on non-in-app stack trace frames

### DIFF
--- a/static/app/components/stackTrace/frame/frameHeader.tsx
+++ b/static/app/components/stackTrace/frame/frameHeader.tsx
@@ -126,7 +126,9 @@ function FrameLocation({
 }) {
   const {event} = useStackTraceFrameContext();
   const frameDisplayPath = getFrameDisplayPath(frame, platform, event);
-  const frameLocationSuffix = formatFrameLocation('', frame.lineNo, frame.colNo);
+  const frameLocationSuffix = frame.inApp
+    ? formatFrameLocation('', frame.lineNo, frame.colNo)
+    : '';
 
   return (
     <LocationWrapper>

--- a/static/app/components/stackTrace/stackTrace.spec.tsx
+++ b/static/app/components/stackTrace/stackTrace.spec.tsx
@@ -740,6 +740,34 @@ describe('Core StackTrace', () => {
     expect(screen.queryByText(':0:0')).not.toBeInTheDocument();
   });
 
+  it('does not render line number for non-in-app frames', async () => {
+    const {event, stacktrace} = makeStackTraceData();
+    const frame = stacktrace.frames[stacktrace.frames.length - 1]!;
+
+    render(
+      <TestStackTraceProvider
+        event={event}
+        stacktrace={{
+          ...stacktrace,
+          frames: [
+            {
+              ...frame,
+              filename: 'library_internal.py',
+              lineNo: 42,
+              inApp: false,
+            },
+          ],
+        }}
+      >
+        <StackTraceFrames frameContextComponent={FrameContent} />
+      </TestStackTraceProvider>
+    );
+
+    expect(await screen.findByText('library_internal.py')).toBeInTheDocument();
+    // Line number not shown for non-in-app frames
+    expect(screen.queryByText(/42/)).not.toBeInTheDocument();
+  });
+
   it('falls back to raw function and renders trimmed package in title metadata', async () => {
     const {event, stacktrace} = makeStackTraceData();
     const frame = stacktrace.frames[stacktrace.frames.length - 1]!;


### PR DESCRIPTION
the line number doesn't really matter when it isn't your code, just show the filename. This matches the old stack trace.

before

<img width="618" height="235" alt="image" src="https://github.com/user-attachments/assets/3e3e622b-8926-4b74-a51a-a9a9f28445ac" />

after

<img width="632" height="240" alt="image" src="https://github.com/user-attachments/assets/fd7ce674-95dc-4caa-82f3-2879a6022fc3" />
