### PR TITLE
fix(aci): Add Slack Staging action type to new alert builder

### DIFF
--- a/static/app/components/workflowEngine/ui/actionMetadata.tsx
+++ b/static/app/components/workflowEngine/ui/actionMetadata.tsx
@@ -68,6 +68,10 @@ export const ActionMetadata: Partial<
     name: t('Slack'),
     icon: <StyledPluginIcon pluginId="slack" size={ICON_SIZE} />,
   },
+  [ActionType.SLACK_STAGING]: {
+    name: t('Slack (Staging)'),
+    icon: <StyledPluginIcon pluginId="slack" size={ICON_SIZE} />,
+  },
   [ActionType.WEBHOOK]: {
     name: t('Webhook'),
     icon: <StyledPluginIcon pluginId="webhooks" size={ICON_SIZE} />,

--- a/static/app/types/workflowEngine/actions.tsx
+++ b/static/app/types/workflowEngine/actions.tsx
@@ -35,6 +35,7 @@ export enum ActionTarget {
 
 export enum ActionType {
   SLACK = 'slack',
+  SLACK_STAGING = 'slack_staging',
   MSTEAMS = 'msteams',
   DISCORD = 'discord',
   PAGERDUTY = 'pagerduty',

--- a/static/app/views/automations/components/actionNodes.tsx
+++ b/static/app/views/automations/components/actionNodes.tsx
@@ -218,6 +218,15 @@ export const actionNodesMap = new Map<ActionType, ActionNode>([
     },
   ],
   [
+    ActionType.SLACK_STAGING,
+    {
+      label: t('Slack (Staging)'),
+      action: SlackNode,
+      details: SlackDetails,
+      validate: validateSlackAction,
+    },
+  ],
+  [
     ActionType.WEBHOOK,
     {
       label: t('Send a notification via an integration'),

--- a/static/app/views/automations/new.spec.tsx
+++ b/static/app/views/automations/new.spec.tsx
@@ -128,6 +128,11 @@ describe('AutomationNewSettings', () => {
           handlerGroup: ActionGroup.OTHER,
           integrations: undefined,
         }),
+        ActionHandlerFixture({
+          type: ActionType.SLACK_STAGING,
+          handlerGroup: ActionGroup.NOTIFICATION,
+          integrations: [{id: 'slack-staging-1', name: 'My Slack Staging Workspace'}],
+        }),
       ],
     });
 
@@ -332,6 +337,16 @@ describe('AutomationNewSettings', () => {
       delay: null,
     });
 
+    await addAction('Slack (Staging)');
+    {
+      const stagingTargets = screen.getAllByRole('textbox', {name: 'Target'});
+      const stagingTarget = stagingTargets.at(-1);
+      expect(stagingTarget).toBeDefined();
+      await userEvent.type(stagingTarget as HTMLElement, '#staging-alerts', {
+        delay: null,
+      });
+    }
+
     await addAction('Discord');
     await userEvent.type(screen.getByPlaceholderText('channel ID or URL'), '123', {
       delay: null,
@@ -492,10 +507,11 @@ describe('AutomationNewSettings', () => {
       },
       slack_staging: {
         type: 'slack_staging',
+        integrationId: 'slack-staging-1',
         config: {
           targetType: 'specific',
           targetIdentifier: '',
-          targetDisplay: '',
+          targetDisplay: '#staging-alerts',
         },
       },
     };

--- a/static/app/views/automations/new.spec.tsx
+++ b/static/app/views/automations/new.spec.tsx
@@ -490,6 +490,14 @@ describe('AutomationNewSettings', () => {
           targetDisplay: null,
         },
       },
+      slack_staging: {
+        type: 'slack_staging',
+        config: {
+          targetType: 'specific',
+          targetIdentifier: '',
+          targetDisplay: '',
+        },
+      },
     };
 
     await waitFor(() => expect(saveWorkflow).toHaveBeenCalled());

--- a/static/app/views/automations/utils/getIncompatibleActionWarning.tsx
+++ b/static/app/views/automations/utils/getIncompatibleActionWarning.tsx
@@ -5,6 +5,7 @@ import type {Detector} from 'sentry/types/workflowEngine/detectors';
 const METRIC_DETECTOR_SUPPORTED_ACTIONS = new Set<ActionType>([
   ActionType.EMAIL,
   ActionType.SLACK,
+  ActionType.SLACK_STAGING,
   ActionType.MSTEAMS,
   ActionType.PAGERDUTY,
   ActionType.OPSGENIE,


### PR DESCRIPTION
This new action type wasn't in the frontend config, so it doesn't know what to render for the label or action UI.