### PR TITLE
fix(iswf): Updates the display label for alerts to use Workflow by default, when available

### DIFF
--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -35,7 +35,7 @@ from sentry.shared_integrations.exceptions import (
 )
 from sentry.types.activity import ActivityType
 from sentry.types.rules import RuleFuture
-from sentry.workflow_engine.models import Action, AlertRuleWorkflow, Detector
+from sentry.workflow_engine.models import Action, AlertRuleWorkflow, Detector, Workflow
 from sentry.workflow_engine.types import ActionInvocation, DetectorPriorityLevel, WorkflowEventData
 from sentry.workflow_engine.typings.notification_action import (
     ACTION_FIELD_MAPPINGS,
@@ -201,7 +201,18 @@ class BaseIssueAlertHandler(ABC):
         workflow_id = getattr(action, "workflow_id", None)
         rule_id = None
 
-        label = detector.name
+        label = None
+        if workflow_id is not None:
+            try:
+                workflow = Workflow.objects.get(id=workflow_id)
+                label = workflow.name
+            except Workflow.DoesNotExist:
+                # If the workflow no longer exists, bail and use detector name
+                # as a fallback.
+                pass
+
+        if label is None:
+            label = detector.name
         # Build link to the rule if it exists, otherwise build link to the workflow.
         # FE will handle redirection if necessary from rule -> workflow
 

--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -202,7 +202,8 @@ class BaseIssueAlertHandler(ABC):
         rule_id = None
 
         label = None
-        if workflow_id is not None:
+        # Attempt to query the workflow name for non-test notifications.
+        if workflow_id is not None and workflow_id != TEST_NOTIFICATION_ID:
             try:
                 workflow = Workflow.objects.get(id=workflow_id)
                 label = workflow.name

--- a/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
@@ -168,7 +168,7 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
         assert rule.environment_id is not None
         assert self.workflow.environment is not None
         assert rule.environment_id == self.workflow.environment.id
-        assert rule.label == self.detector.name
+        assert rule.label == self.workflow.name
         assert rule.data == {
             "actions": [
                 {
@@ -182,6 +182,30 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
         }
         assert rule.status == ObjectStatus.ACTIVE
         assert rule.source == RuleSource.ISSUE
+
+    def test_create_rule_instance_from_action_deleted_workflow_falls_back_to_detector_name(
+        self,
+    ) -> None:
+        """Test that label falls back to detector.name when the workflow no longer exists"""
+        workflow_id = self.workflow.id
+        self.workflow.delete()
+        rule = self.handler.create_rule_instance_from_action(
+            self.action, self.detector, self.event_data
+        )
+
+        assert isinstance(rule, Rule)
+        assert rule.label == self.detector.name
+        assert rule.data == {
+            "actions": [
+                {
+                    "id": "sentry.integrations.discord.notify_action.DiscordNotifyServiceAction",
+                    "server": "1234567890",
+                    "channel_id": "channel456",
+                    "tags": "environment,user,my_tag",
+                    "workflow_id": workflow_id,
+                }
+            ]
+        }
 
     def test_create_rule_instance_from_action_no_environment(self) -> None:
         """Test that create_rule_instance_from_action creates a Rule with correct attributes"""

--- a/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_issue_alert_registry_handlers.py
@@ -25,7 +25,7 @@ from sentry.notifications.notification_action.types import (
     BaseIssueAlertHandler,
     TicketingIssueAlertHandler,
 )
-from sentry.notifications.types import ActionTargetType, FallthroughChoiceType
+from sentry.notifications.types import TEST_NOTIFICATION_ID, ActionTargetType, FallthroughChoiceType
 from sentry.testutils.helpers.data_blobs import (
     AZURE_DEVOPS_ACTION_DATA_BLOBS,
     EMAIL_ACTION_DATA_BLOBS,
@@ -205,6 +205,27 @@ class TestBaseIssueAlertHandler(BaseWorkflowTest):
                     "workflow_id": workflow_id,
                 }
             ]
+        }
+
+    def test_create_rule_instance_from_action_with_test_notification_id(self) -> None:
+        """Test that Workflow lookup is skipped for test notifications, falling back to detector name"""
+        self.action.workflow_id = TEST_NOTIFICATION_ID
+        rule = self.handler.create_rule_instance_from_action(
+            self.action, self.detector, self.event_data
+        )
+
+        assert isinstance(rule, Rule)
+        assert rule.label == self.detector.name
+        assert rule.data == {
+            "actions": [
+                {
+                    "id": "sentry.integrations.discord.notify_action.DiscordNotifyServiceAction",
+                    "server": "1234567890",
+                    "channel_id": "channel456",
+                    "tags": "environment,user,my_tag",
+                    "legacy_rule_id": TEST_NOTIFICATION_ID,
+                }
+            ],
         }
 
     def test_create_rule_instance_from_action_no_environment(self) -> None:

--- a/tests/sentry/notifications/platform/slack/renderers/test_issue.py
+++ b/tests/sentry/notifications/platform/slack/renderers/test_issue.py
@@ -47,7 +47,7 @@ class IssueAlertInvocationMixin(TestCase):
             name="Test Detector",
             type=ErrorGroupType.slug,
         )
-        workflow = self.create_workflow(organization=self.organization)
+        workflow = self.create_workflow(organization=self.organization, name="Test Workflow")
         action = self.create_action(
             type=Action.Type.SLACK,
             data={"tags": ", ".join(tags) if tags else "", "notes": notes},
@@ -99,7 +99,7 @@ class IssueNotificationDataTest(IssueAlertInvocationMixin):
         assert result.notification_uuid == "test-uuid-123"
         assert isinstance(result.rule, SerializableRuleProxy)
         assert result.rule.id == invocation.action.id
-        assert result.rule.label == invocation.detector.name
+        assert result.rule.label == "Test Workflow"
         assert result.tags == ["environment", "level"]
         assert result.notes == "test note"
         assert len(result.rule.data["actions"]) == 1
@@ -164,6 +164,7 @@ class IssueSlackRendererTest(IssueAlertInvocationMixin):
         workflow_id: int,
         event_id: str,
         title: str = "test event",
+        rule_label: str = "Test Workflow",
         notes: str | None = None,
         tags: list[str] | None = None,
     ) -> SlackRenderable:
@@ -256,7 +257,7 @@ class IssueSlackRendererTest(IssueAlertInvocationMixin):
                         "type": "mrkdwn",
                         "text": (
                             f"Project: <{project_url}|{project_slug}>"
-                            f"    Alert: <{alert_url}|Test Detector>"
+                            f"    Alert: <{alert_url}|{rule_label}>"
                             f"    Short ID: {group.qualified_short_id}"
                         ),
                     }

--- a/tests/sentry/rules/actions/test_notify_event_service.py
+++ b/tests/sentry/rules/actions/test_notify_event_service.py
@@ -136,7 +136,7 @@ class NotifyEventServiceWebhookActionTest(NotifyEventServiceActionTest):
         assert payload["message"] == "こんにちは"
         assert payload["event"]["id"] == self.event.event_id
         assert payload["event"]["event_id"] == self.event.event_id
-        assert payload["triggering_rules"] == ["error_detector"]
+        assert payload["triggering_rules"] == ["error_workflow"]
 
     @responses.activate
     def test_legacy_webhooks_uneven_dual_write_aci(self) -> None:


### PR DESCRIPTION
Currently, we display a mixture of Detector name and alert rule link in issue alert footers. This is confusing from a user perspective, so this PR attempts to use the workflow name when available.
