### PR TITLE
feat(viewer-context): Switch Seer API to JWT X-Viewer-Context header

### DIFF
--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -12,7 +12,7 @@ from urllib3 import BaseHTTPResponse, HTTPConnectionPool, Retry
 
 from sentry.net.http import connection_from_url
 from sentry.utils import metrics
-from sentry.viewer_context import ViewerContext, get_viewer_context
+from sentry.viewer_context import ViewerContext, encode_viewer_context, get_viewer_context
 
 
 class SeerViewerContext(TypedDict, total=False):
@@ -138,18 +138,15 @@ def make_signed_seer_api_request(
 
     resolved = _resolve_viewer_context(viewer_context)
     if resolved:
-        if settings.SEER_API_SHARED_SECRET:
-            try:
-                context_bytes = orjson.dumps(resolved.serialize())
-                context_signature = sign_viewer_context(context_bytes)
-                headers["X-Viewer-Context"] = context_bytes.decode("utf-8")
-                headers["X-Viewer-Context-Signature"] = context_signature
-            except Exception:
-                logger.exception("Failed to serialize viewer context for call to Seer.")
-        else:
+        try:
+            headers["X-Viewer-Context"] = encode_viewer_context(resolved)
+        except ValueError:
             logger.warning(
-                "settings.SEER_API_SHARED_SECRET is not set. Unable to sign viewer context for call to Seer."
+                "viewer_context_jwt.no_signing_key",
+                extra={"msg": "No key available to sign viewer context JWT."},
             )
+        except Exception:
+            logger.exception("Failed to encode viewer context JWT for call to Seer.")
 
     options: dict[str, Any] = {}
     if timeout:

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -705,3 +705,12 @@ def sign_with_seer_secret(body: bytes) -> dict[str, str]:
         )
         metrics.incr("seer.unsigned_request", sample_rate=1.0)
     return auth_headers
+
+
+def sign_viewer_context(context_bytes: bytes) -> str:
+    """Sign the viewer context payload with the shared secret."""
+    return hmac.new(
+        settings.SEER_API_SHARED_SECRET.encode("utf-8"),
+        context_bytes,
+        hashlib.sha256,
+    ).hexdigest()

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -705,12 +705,3 @@ def sign_with_seer_secret(body: bytes) -> dict[str, str]:
         )
         metrics.incr("seer.unsigned_request", sample_rate=1.0)
     return auth_headers
-
-
-def sign_viewer_context(context_bytes: bytes) -> str:
-    """Sign the viewer context payload with the shared secret."""
-    return hmac.new(
-        settings.SEER_API_SHARED_SECRET.encode("utf-8"),
-        context_bytes,
-        hashlib.sha256,
-    ).hexdigest()

--- a/tests/sentry/event_manager/test_severity.py
+++ b/tests/sentry/event_manager/test_severity.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import hashlib
-import hmac
 import uuid
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -88,23 +86,19 @@ class TestGetEventSeverity(TestCase):
             override_settings(SEER_API_SHARED_SECRET="some-secret"),
         ):
             _get_severity_score(event)
-            viewer_context_bytes = orjson.dumps(
-                {"actor_type": "unknown", "organization_id": self.project.organization_id}
-            )
-            mock_urlopen.assert_called_with(
-                "POST",
-                "/v0/issues/severity-score",
-                body=orjson.dumps(payload),
-                headers={
-                    "content-type": "application/json;charset=utf-8",
-                    "Authorization": f"Rpcsignature rpc0:{hmac.new(b'some-secret', orjson.dumps(payload), hashlib.sha256).hexdigest()}",
-                    "X-Viewer-Context": viewer_context_bytes.decode("utf-8"),
-                    "X-Viewer-Context-Signature": hmac.new(
-                        b"some-secret", viewer_context_bytes, hashlib.sha256
-                    ).hexdigest(),
-                },
-                timeout=options.get("issues.severity.seer-timeout", settings.SEER_SEVERITY_TIMEOUT),
-            )
+            call_kwargs = mock_urlopen.call_args
+            assert call_kwargs[0] == ("POST", "/v0/issues/severity-score")
+            assert call_kwargs[1]["body"] == orjson.dumps(payload)
+            headers = call_kwargs[1]["headers"]
+            assert headers["content-type"] == "application/json;charset=utf-8"
+            assert "Authorization" in headers
+            assert "X-Viewer-Context-Signature" not in headers
+            # ViewerContext is now a JWT
+            from sentry.viewer_context import decode_viewer_context
+
+            vc = decode_viewer_context(headers["X-Viewer-Context"], key="some-secret")
+            assert vc.organization_id == self.project.organization_id
+            assert vc.actor_type.value == "unknown"
 
     @patch(
         "sentry.event_manager.severity_connection_pool.urlopen",


### PR DESCRIPTION
Replace the legacy two-header format (`X-Viewer-Context` JSON +
`X-Viewer-Context-Signature` HMAC) with a single `X-Viewer-Context`
JWT header in `make_signed_seer_api_request()`.

Seer already accepts JWT via `is_jwt_viewer_context` / `decode_jwt_viewer_context`
(getsentry/seer@b22dcb62).

**Do not merge** until Seer's JWT acceptance is deployed.

Depends on #112765, #112875.