### PR TITLE
fix(drawer): Align drawer header with page frame header

### DIFF
--- a/static/app/components/events/eventDrawer.tsx
+++ b/static/app/components/events/eventDrawer.tsx
@@ -39,8 +39,8 @@ export const EventDrawerContainer = styled('div')`
 
 export const EventDrawerHeader = styled(DrawerHeader)`
   position: unset;
-  max-height: ${MIN_NAV_HEIGHT}px;
-  min-height: ${MIN_NAV_HEIGHT}px;
+  max-height: var(--drawer-header-height, ${MIN_NAV_HEIGHT}px);
+  min-height: var(--drawer-header-height, ${MIN_NAV_HEIGHT}px);
   align-items: center;
   box-shadow: none;
   border-bottom: 1px solid ${p => p.theme.tokens.border.primary};

--- a/static/app/components/globalDrawer/components.tsx
+++ b/static/app/components/globalDrawer/components.tsx
@@ -9,6 +9,8 @@ import {SlideOverPanel} from '@sentry/scraps/slideOverPanel';
 import type {DrawerOptions} from 'sentry/components/globalDrawer';
 import {IconClose} from 'sentry/icons/iconClose';
 import {t} from 'sentry/locale';
+import {PRIMARY_HEADER_HEIGHT} from 'sentry/views/navigation/constants';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 import {
   DEFAULT_WIDTH_PERCENT,
@@ -126,6 +128,7 @@ export function DrawerHeader({
   hideCloseButton = false,
 }: DrawerHeaderProps) {
   const {onClose} = useDrawerContentContext();
+  const hasPageFrameFeature = useHasPageFrameFeature();
 
   return (
     <Header
@@ -133,6 +136,7 @@ export function DrawerHeader({
       className={className}
       hideCloseButton={hideCloseButton}
       hideBar={hideBar}
+      height={hasPageFrameFeature ? `${PRIMARY_HEADER_HEIGHT}px` : undefined}
     >
       {!hideCloseButton && (
         <Fragment>
@@ -160,7 +164,11 @@ const HeaderBar = styled('div')`
   border-right: 1px solid ${p => p.theme.tokens.border.primary};
 `;
 
-const Header = styled('header')<{hideBar?: boolean; hideCloseButton?: boolean}>`
+const Header = styled('header')<{
+  height?: string;
+  hideBar?: boolean;
+  hideCloseButton?: boolean;
+}>`
   position: sticky;
   top: 0;
   z-index: ${p => p.theme.zIndex.drawer + 1};
@@ -175,6 +183,16 @@ const Header = styled('header')<{hideBar?: boolean; hideCloseButton?: boolean}>`
   padding-left: ${p => (p.hideCloseButton ? '24px' : p.theme.space.xl)};
   padding-top: ${p => (p.hideCloseButton ? p.theme.space.lg : p.theme.space.sm)};
   padding-bottom: ${p => (p.hideCloseButton ? p.theme.space.lg : p.theme.space.sm)};
+  ${p =>
+    p.height &&
+    `
+    --drawer-header-height: ${p.height};
+    height: var(--drawer-header-height);
+    box-sizing: border-box;
+    align-items: center;
+    box-shadow: none;
+    border-bottom: 1px solid ${p.theme.tokens.border.primary};
+  `}
 `;
 
 export const DrawerBody = styled('aside')`


### PR DESCRIPTION
When the page-frame feature is active, the TopBar is 53px tall but
drawer headers were shorter — 44px for EventDrawerHeader, ~36px for
the base DrawerHeader. This caused a visible border misalignment
between the page header and the drawer header.

Sets the drawer header height to match `PRIMARY_HEADER_HEIGHT` when
page-frame is enabled, using a CSS custom property
(`--drawer-header-height`) so both `EventDrawerHeader` and any
`styled(DrawerHeader)` extensions pick up the correct value
automatically. When page-frame is inactive, all styles remain
unchanged — the variable isn't set, and `EventDrawerHeader` falls
back to its original 44px via `var(--drawer-header-height, 44px)`.


**Before**

<img width="2553" height="1065" alt="image" src="https://github.com/user-attachments/assets/be665a30-6f62-4a3d-b5b7-bac90a4cab4e" />




**After**


<img width="2554" height="882" alt="image" src="https://github.com/user-attachments/assets/a1207ad5-fe3c-40c3-ba8f-adb55f615d96" />


closes https://linear.app/getsentry/issue/DE-1098/sidesheet-header-not-aligned-with-topbar-component
