### PR TITLE
fix(ci): Select taskworker config test when task files change

### DIFF
--- a/.github/workflows/scripts/compute-sentry-selected-tests.py
+++ b/.github/workflows/scripts/compute-sentry-selected-tests.py
@@ -82,6 +82,12 @@ EXTRA_FILE_TO_TEST_MAPPING: dict[str, list[str]] = {
     ".github/CODEOWNERS": ["tests/sentry/api/test_api_owners.py"],
 }
 
+EXTRA_PATTERN_TO_TEST_MAPPING: list[tuple[re.Pattern[str], list[str]]] = [
+    # Filesystem-scanning tests can't be discovered via coverage.
+    # Any new task module must be registered in TASKWORKER_IMPORTS.
+    (re.compile(r"^src/sentry/.*tasks.*\.py$"), ["tests/sentry/taskworker/test_config.py"]),
+]
+
 EXCLUDED_TEST_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"^tests/(acceptance|apidocs|js|tools)/"),
 ]
@@ -211,6 +217,12 @@ def main() -> int:
             # Extra mapped files
             for f in changed:
                 affected_test_files.update(EXTRA_FILE_TO_TEST_MAPPING.get(f, []))
+
+            # Pattern-based extra mappings (e.g. new task files -> config tests)
+            for f in changed:
+                for pattern, extra_tests in EXTRA_PATTERN_TO_TEST_MAPPING:
+                    if pattern.search(f):
+                        affected_test_files.update(extra_tests)
 
             # Directly changed test files
             changed_tests = {


### PR DESCRIPTION
## Summary

- `test_all_instrumented_tasks_registered` uses filesystem scanning (`Path.rglob`) to verify all `@instrumented_task` modules are registered in `TASKWORKER_IMPORTS`. Because it never imports task source files, coverage-based selective testing never links those files to this test — so it's skipped when a PR adds a new task module.
- Adds `EXTRA_PATTERN_TO_TEST_MAPPING` to `compute-sentry-selected-tests.py`: any changed Python file matching `src/sentry/.*tasks.*\.py` now automatically includes `tests/sentry/taskworker/test_config.py` in the selected test set.
- This prevents PRs that add an `@instrumented_task` without updating `TASKWORKER_IMPORTS` from slipping through selective testing.

https://claude.ai/code/session_01DLEj1p1FBkRPRhYrGrr97H