### PR TITLE
feat(conversations): Make conversation detail panels resizable

### DIFF
--- a/static/app/views/insights/pages/conversations/components/conversationView.tsx
+++ b/static/app/views/insights/pages/conversations/components/conversationView.tsx
@@ -1,4 +1,3 @@
-import type React from 'react';
 import {memo, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
@@ -165,7 +164,7 @@ function ConversationView({
   );
 
   const leftPanelContent = (
-    <LeftPanel>
+    <Flex direction="column" minHeight="0" height="100%" overflow="hidden">
       <StyledTabs
         value={activeTab}
         onChange={key => handleTabChange(key as ConversationTab)}
@@ -198,11 +197,11 @@ function ConversationView({
           </FullWidthTabPanels>
         </Flex>
       </StyledTabs>
-    </LeftPanel>
+    </Flex>
   );
 
   const rightPanelContent = (
-    <DetailsPanel>
+    <Container minHeight="0" height="100%" background="primary" overflowY="auto" overflowX="hidden">
       {selectedNode?.renderDetails({
         node: selectedNode,
         manager: null,
@@ -214,11 +213,11 @@ function ConversationView({
         hideNodeActions: true,
         initiallyCollapseAiIO: true,
       })}
-    </DetailsPanel>
+    </Container>
   );
 
   return (
-    <SplitPanelWrapper ref={containerRef}>
+    <Flex ref={containerRef} flex="1" minHeight="0" overflow="hidden">
       {containerWidth > 0 ? (
         <SplitPanel
           availableSize={containerWidth}
@@ -232,14 +231,14 @@ function ConversationView({
           sizeStorageKey={SPLIT_PANEL_STORAGE_KEY}
         />
       ) : null}
-    </SplitPanelWrapper>
+    </Flex>
   );
 }
 
 function ConversationViewSkeleton() {
   return (
     <Flex flex="1" minHeight="0" height="100%">
-      <LeftPanel>
+      <Flex direction="column" minHeight="0" height="100%" overflow="hidden">
         <Container borderBottom="primary" padding="md lg">
           <Flex gap="lg">
             <Placeholder height="14px" width="40px" />
@@ -280,8 +279,8 @@ function ConversationViewSkeleton() {
             </Flex>
           </Container>
         </Flex>
-      </LeftPanel>
-      <DetailsPanel>
+      </Flex>
+      <Container minHeight="0" height="100%" background="primary" overflowY="auto" overflowX="hidden">
         <Flex direction="column" gap="lg" padding="lg">
           <Flex direction="column" gap="sm">
             <Placeholder height="14px" width="180px" />
@@ -304,22 +303,7 @@ function ConversationViewSkeleton() {
             <Placeholder height="120px" width="100%" />
           </Flex>
         </Flex>
-      </DetailsPanel>
-    </Flex>
-  );
-}
-
-const SplitPanelWrapper = styled('div')`
-  display: flex;
-  flex: 1;
-  min-height: 0;
-  overflow: hidden;
-`;
-
-function LeftPanel({children}: {children: React.ReactNode}) {
-  return (
-    <Flex direction="column" minHeight="0" height="100%" overflow="hidden">
-      {children}
+      </Container>
     </Flex>
   );
 }
@@ -339,17 +323,3 @@ const FullWidthTabPanels = styled(TabPanels)`
     width: 100%;
   }
 `;
-
-function DetailsPanel({children}: {children: React.ReactNode}) {
-  return (
-    <Container
-      minHeight="0"
-      height="100%"
-      background="primary"
-      overflowY="auto"
-      overflowX="hidden"
-    >
-      {children}
-    </Container>
-  );
-}

--- a/static/app/views/insights/pages/conversations/components/conversationView.tsx
+++ b/static/app/views/insights/pages/conversations/components/conversationView.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import {memo, useCallback, useEffect, useMemo, useState} from 'react';
+import {memo, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Container, Flex} from '@sentry/scraps/layout';
@@ -7,8 +7,10 @@ import {TabList, TabPanels, Tabs} from '@sentry/scraps/tabs';
 
 import {EmptyMessage} from 'sentry/components/emptyMessage';
 import {Placeholder} from 'sentry/components/placeholder';
+import {SplitPanel} from 'sentry/components/splitPanel';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {useDimensions} from 'sentry/utils/useDimensions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {AISpanList} from 'sentry/views/insights/pages/agents/components/aiSpanList';
 import {getDefaultSelectedNode} from 'sentry/views/insights/pages/agents/utils/getDefaultSelectedNode';
@@ -106,6 +108,11 @@ export const ConversationViewContent = memo(function ConversationViewContent({
   );
 });
 
+const LEFT_PANEL_MIN_WIDTH = 400;
+const RIGHT_PANEL_MIN_WIDTH = 350;
+const DIVIDER_WIDTH = 16;
+const SPLIT_PANEL_STORAGE_KEY = 'conversation-detail-split-panel-size';
+
 function ConversationView({
   nodes,
   nodeTraceMap,
@@ -123,6 +130,8 @@ function ConversationView({
 }) {
   const organization = useOrganization();
   const [activeTab, setActiveTab] = useState<ConversationTab>('messages');
+  const containerRef = useRef<HTMLDivElement>(null);
+  const {width: containerWidth} = useDimensions({elementRef: containerRef});
 
   const handleTabChange = useCallback(
     (newTab: ConversationTab) => {
@@ -150,56 +159,80 @@ function ConversationView({
     return <EmptyMessage>{t('No AI spans found in this conversation')}</EmptyMessage>;
   }
 
-  return (
-    <Flex flex="1" minHeight="0" overflow="hidden">
-      <LeftPanel>
-        <StyledTabs
-          value={activeTab}
-          onChange={key => handleTabChange(key as ConversationTab)}
-        >
-          <Container borderBottom="primary">
-            <TabList>
-              <TabList.Item key="messages">{t('Chat')}</TabList.Item>
-              <TabList.Item key="trace">{t('Spans')}</TabList.Item>
-            </TabList>
-          </Container>
-          <Flex flex="1" minHeight="0" width="100%" overflowX="hidden" overflowY="auto">
-            <FullWidthTabPanels>
-              <TabPanels.Item key="messages">
-                <MessagesPanel
+  const defaultLeftWidth = Math.max(
+    LEFT_PANEL_MIN_WIDTH,
+    (containerWidth - DIVIDER_WIDTH) * 0.6
+  );
+
+  const leftPanelContent = (
+    <LeftPanel>
+      <StyledTabs
+        value={activeTab}
+        onChange={key => handleTabChange(key as ConversationTab)}
+      >
+        <Container borderBottom="primary">
+          <TabList>
+            <TabList.Item key="messages">{t('Chat')}</TabList.Item>
+            <TabList.Item key="trace">{t('Spans')}</TabList.Item>
+          </TabList>
+        </Container>
+        <Flex flex="1" minHeight="0" width="100%" overflowX="hidden" overflowY="auto">
+          <FullWidthTabPanels>
+            <TabPanels.Item key="messages">
+              <MessagesPanel
+                nodes={nodes}
+                selectedNodeId={selectedNode?.id ?? null}
+                onSelectNode={onSelectNode}
+              />
+            </TabPanels.Item>
+            <TabPanels.Item key="trace">
+              <Container padding="md lg md lg">
+                <AISpanList
                   nodes={nodes}
-                  selectedNodeId={selectedNode?.id ?? null}
+                  selectedNodeKey={selectedNode?.id ?? nodes[0]?.id ?? ''}
                   onSelectNode={onSelectNode}
+                  compressGaps
                 />
-              </TabPanels.Item>
-              <TabPanels.Item key="trace">
-                <Container padding="md lg md lg">
-                  <AISpanList
-                    nodes={nodes}
-                    selectedNodeKey={selectedNode?.id ?? nodes[0]?.id ?? ''}
-                    onSelectNode={onSelectNode}
-                    compressGaps
-                  />
-                </Container>
-              </TabPanels.Item>
-            </FullWidthTabPanels>
-          </Flex>
-        </StyledTabs>
-      </LeftPanel>
-      <DetailsPanel>
-        {selectedNode?.renderDetails({
-          node: selectedNode,
-          manager: null,
-          onParentClick: () => {},
-          onTabScrollToNode: () => {},
-          organization,
-          replay: null,
-          traceId: nodeTraceMap.get(selectedNode.id) ?? '',
-          hideNodeActions: true,
-          initiallyCollapseAiIO: true,
-        })}
-      </DetailsPanel>
-    </Flex>
+              </Container>
+            </TabPanels.Item>
+          </FullWidthTabPanels>
+        </Flex>
+      </StyledTabs>
+    </LeftPanel>
+  );
+
+  const rightPanelContent = (
+    <DetailsPanel>
+      {selectedNode?.renderDetails({
+        node: selectedNode,
+        manager: null,
+        onParentClick: () => {},
+        onTabScrollToNode: () => {},
+        organization,
+        replay: null,
+        traceId: nodeTraceMap.get(selectedNode.id) ?? '',
+        hideNodeActions: true,
+        initiallyCollapseAiIO: true,
+      })}
+    </DetailsPanel>
+  );
+
+  return (
+    <SplitPanelWrapper ref={containerRef}>
+      {containerWidth > 0 ? (
+        <SplitPanel
+          availableSize={containerWidth}
+          left={{
+            content: leftPanelContent,
+            default: defaultLeftWidth,
+            min: LEFT_PANEL_MIN_WIDTH,
+            max: containerWidth - RIGHT_PANEL_MIN_WIDTH - DIVIDER_WIDTH,
+          }}
+          right={rightPanelContent}
+          sizeStorageKey={SPLIT_PANEL_STORAGE_KEY}
+        />
+      ) : null}
+    </SplitPanelWrapper>
   );
 }
 
@@ -214,12 +247,10 @@ function ConversationViewSkeleton() {
           </Flex>
         </Container>
         <Flex direction="column" flex="1" gap="md" padding="lg" background="secondary">
-          {/* User message skeleton */}
           <Flex direction="column" gap="sm" padding="sm md">
             <Placeholder height="12px" width="120px" />
             <Placeholder height="12px" width="80%" />
           </Flex>
-          {/* Assistant message skeleton */}
           <Container background="primary" radius="md" border="primary" padding="sm md">
             <Flex direction="column" gap="sm">
               <Flex align="center" gap="sm">
@@ -234,12 +265,10 @@ function ConversationViewSkeleton() {
               <Placeholder height="12px" width="60%" />
             </Flex>
           </Container>
-          {/* Another user message */}
           <Flex direction="column" gap="sm" padding="sm md">
             <Placeholder height="12px" width="120px" />
             <Placeholder height="12px" width="60%" />
           </Flex>
-          {/* Another assistant message */}
           <Container background="primary" radius="md" border="primary" padding="sm md">
             <Flex direction="column" gap="sm">
               <Flex align="center" gap="sm">
@@ -280,16 +309,16 @@ function ConversationViewSkeleton() {
   );
 }
 
+const SplitPanelWrapper = styled('div')`
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+`;
+
 function LeftPanel({children}: {children: React.ReactNode}) {
   return (
-    <Flex
-      direction="column"
-      flex={1}
-      minWidth="400px"
-      minHeight="0"
-      borderRight="primary"
-      overflow="hidden"
-    >
+    <Flex direction="column" minHeight="0" height="100%" overflow="hidden">
       {children}
     </Flex>
   );
@@ -314,9 +343,8 @@ const FullWidthTabPanels = styled(TabPanels)`
 function DetailsPanel({children}: {children: React.ReactNode}) {
   return (
     <Container
-      width="500px"
-      minWidth="500px"
       minHeight="0"
+      height="100%"
       background="primary"
       overflowY="auto"
       overflowX="hidden"

--- a/static/app/views/insights/pages/conversations/components/conversationView.tsx
+++ b/static/app/views/insights/pages/conversations/components/conversationView.tsx
@@ -373,9 +373,9 @@ function ConversationViewSkeleton() {
 type PanelDividerProps = {
   'data-is-held': boolean;
   'data-slide-direction': 'leftright' | 'updown';
-  icon?: React.ReactNode;
   onDoubleClick: React.MouseEventHandler<HTMLElement>;
   onMouseDown: React.MouseEventHandler<HTMLElement>;
+  icon?: React.ReactNode;
 } & React.DOMAttributes<HTMLDivElement>;
 
 const PanelBorderDivider = styled(

--- a/static/app/views/insights/pages/conversations/components/conversationView.tsx
+++ b/static/app/views/insights/pages/conversations/components/conversationView.tsx
@@ -1,3 +1,4 @@
+import type React from 'react';
 import {memo, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
@@ -109,7 +110,7 @@ export const ConversationViewContent = memo(function ConversationViewContent({
 
 const LEFT_PANEL_MIN_WIDTH = 400;
 const RIGHT_PANEL_MIN_WIDTH = 350;
-const DIVIDER_WIDTH = 16;
+const DIVIDER_WIDTH = 5;
 const SPLIT_PANEL_STORAGE_KEY = 'conversation-detail-split-panel-size';
 
 function ConversationView({
@@ -155,7 +156,11 @@ function ConversationView({
   }
 
   if (nodes.length === 0) {
-    return <EmptyMessage>{t('No AI spans found in this conversation')}</EmptyMessage>;
+    return (
+      <EmptyMessage>
+        {t('No AI spans found in this conversation')}
+      </EmptyMessage>
+    );
   }
 
   const defaultLeftWidth = Math.max(
@@ -164,7 +169,12 @@ function ConversationView({
   );
 
   const leftPanelContent = (
-    <Flex direction="column" minHeight="0" height="100%" overflow="hidden">
+    <Flex
+      direction="column"
+      minHeight="0"
+      height="100%"
+      overflow="hidden"
+    >
       <StyledTabs
         value={activeTab}
         onChange={key => handleTabChange(key as ConversationTab)}
@@ -175,7 +185,13 @@ function ConversationView({
             <TabList.Item key="trace">{t('Spans')}</TabList.Item>
           </TabList>
         </Container>
-        <Flex flex="1" minHeight="0" width="100%" overflowX="hidden" overflowY="auto">
+        <Flex
+          flex="1"
+          minHeight="0"
+          width="100%"
+          overflowX="hidden"
+          overflowY="auto"
+        >
           <FullWidthTabPanels>
             <TabPanels.Item key="messages">
               <MessagesPanel
@@ -188,7 +204,9 @@ function ConversationView({
               <Container padding="md lg md lg">
                 <AISpanList
                   nodes={nodes}
-                  selectedNodeKey={selectedNode?.id ?? nodes[0]?.id ?? ''}
+                  selectedNodeKey={
+                    selectedNode?.id ?? nodes[0]?.id ?? ''
+                  }
                   onSelectNode={onSelectNode}
                   compressGaps
                 />
@@ -201,7 +219,13 @@ function ConversationView({
   );
 
   const rightPanelContent = (
-    <Container minHeight="0" height="100%" background="primary" overflowY="auto" overflowX="hidden">
+    <Container
+      minHeight="0"
+      height="100%"
+      background="primary"
+      overflowY="auto"
+      overflowX="hidden"
+    >
       {selectedNode?.renderDetails({
         node: selectedNode,
         manager: null,
@@ -225,10 +249,14 @@ function ConversationView({
             content: leftPanelContent,
             default: defaultLeftWidth,
             min: LEFT_PANEL_MIN_WIDTH,
-            max: containerWidth - RIGHT_PANEL_MIN_WIDTH - DIVIDER_WIDTH,
+            max:
+              containerWidth -
+              RIGHT_PANEL_MIN_WIDTH -
+              DIVIDER_WIDTH,
           }}
           right={rightPanelContent}
           sizeStorageKey={SPLIT_PANEL_STORAGE_KEY}
+          SplitDivider={PanelBorderDivider}
         />
       ) : null}
     </Flex>
@@ -238,25 +266,46 @@ function ConversationView({
 function ConversationViewSkeleton() {
   return (
     <Flex flex="1" minHeight="0" height="100%">
-      <Flex direction="column" minHeight="0" height="100%" overflow="hidden">
+      <Flex
+        direction="column"
+        minHeight="0"
+        height="100%"
+        overflow="hidden"
+        flex="3"
+      >
         <Container borderBottom="primary" padding="md lg">
           <Flex gap="lg">
             <Placeholder height="14px" width="40px" />
             <Placeholder height="14px" width="40px" />
           </Flex>
         </Container>
-        <Flex direction="column" flex="1" gap="md" padding="lg" background="secondary">
+        <Flex
+          direction="column"
+          flex="1"
+          gap="md"
+          padding="lg"
+          background="secondary"
+        >
           <Flex direction="column" gap="sm" padding="sm md">
             <Placeholder height="12px" width="120px" />
             <Placeholder height="12px" width="80%" />
           </Flex>
-          <Container background="primary" radius="md" border="primary" padding="sm md">
+          <Container
+            background="primary"
+            radius="md"
+            border="primary"
+            padding="sm md"
+          >
             <Flex direction="column" gap="sm">
               <Flex align="center" gap="sm">
                 <Placeholder height="12px" width="100px" />
                 <Placeholder height="12px" width="40px" />
               </Flex>
-              <Container background="tertiary" radius="sm" padding="xs sm">
+              <Container
+                background="tertiary"
+                radius="sm"
+                padding="xs sm"
+              >
                 <Placeholder height="12px" width="150px" />
               </Container>
               <Placeholder height="12px" width="90%" />
@@ -268,7 +317,12 @@ function ConversationViewSkeleton() {
             <Placeholder height="12px" width="120px" />
             <Placeholder height="12px" width="60%" />
           </Flex>
-          <Container background="primary" radius="md" border="primary" padding="sm md">
+          <Container
+            background="primary"
+            radius="md"
+            border="primary"
+            padding="sm md"
+          >
             <Flex direction="column" gap="sm">
               <Flex align="center" gap="sm">
                 <Placeholder height="12px" width="80px" />
@@ -280,7 +334,15 @@ function ConversationViewSkeleton() {
           </Container>
         </Flex>
       </Flex>
-      <Container minHeight="0" height="100%" background="primary" overflowY="auto" overflowX="hidden">
+      <Container borderLeft="primary" />
+      <Container
+        minHeight="0"
+        height="100%"
+        background="primary"
+        overflowY="auto"
+        overflowX="hidden"
+        flex="2"
+      >
         <Flex direction="column" gap="lg" padding="lg">
           <Flex direction="column" gap="sm">
             <Placeholder height="14px" width="180px" />
@@ -307,6 +369,42 @@ function ConversationViewSkeleton() {
     </Flex>
   );
 }
+
+const PanelBorderDivider = styled(
+  ({icon: _icon, ...props}: {icon?: React.ReactNode} & Record<string, unknown>) => (
+    <div {...props} />
+  )
+)`
+  width: 5px;
+  height: 100%;
+  cursor: ew-resize;
+  position: relative;
+  flex-shrink: 0;
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 2px;
+    width: 1px;
+    background: ${p => p.theme.tokens.border.primary};
+  }
+
+  &:hover::after {
+    left: 1px;
+    width: 3px;
+    background: ${p => p.theme.tokens.border.focus};
+    border-radius: 2px;
+  }
+
+  &[data-is-held='true']::after {
+    left: 1px;
+    width: 3px;
+    background: ${p => p.theme.tokens.border.focus};
+    border-radius: 2px;
+  }
+`;
 
 const StyledTabs = styled(Tabs)`
   min-height: 0;

--- a/static/app/views/insights/pages/conversations/components/conversationView.tsx
+++ b/static/app/views/insights/pages/conversations/components/conversationView.tsx
@@ -370,11 +370,17 @@ function ConversationViewSkeleton() {
   );
 }
 
+type PanelDividerProps = {
+  'data-is-held': boolean;
+  'data-slide-direction': 'leftright' | 'updown';
+  icon?: React.ReactNode;
+  onDoubleClick: React.MouseEventHandler<HTMLElement>;
+  onMouseDown: React.MouseEventHandler<HTMLElement>;
+} & React.DOMAttributes<HTMLDivElement>;
+
 const PanelBorderDivider = styled(
-  ({icon: _icon, ...props}: {icon?: React.ReactNode} & Record<string, unknown>) => (
-    <div {...props} />
-  )
-)`
+  ({icon: _icon, ...props}: PanelDividerProps) => <div {...props} />
+)<PanelDividerProps>`
   width: 5px;
   height: 100%;
   cursor: ew-resize;
@@ -394,14 +400,14 @@ const PanelBorderDivider = styled(
   &:hover::after {
     left: 1px;
     width: 3px;
-    background: ${p => p.theme.tokens.border.focus};
+    background: ${p => p.theme.tokens.focus.default};
     border-radius: 2px;
   }
 
   &[data-is-held='true']::after {
     left: 1px;
     width: 3px;
-    background: ${p => p.theme.tokens.border.focus};
+    background: ${p => p.theme.tokens.focus.default};
     border-radius: 2px;
   }
 `;


### PR DESCRIPTION
## Summary
- Replace the fixed-width left/right panel layout in conversation details with the existing `SplitPanel` component
- Users can now drag the divider between the chat/spans panel and the details panel to resize them
- Panel size is persisted to localStorage so the preference is remembered across sessions
- Left panel min width: 400px, right panel min width: 350px, default split: 60/40

## Test plan
- [ ] Open a conversation detail page
- [ ] Verify the draggable divider appears between the left (Chat/Spans) and right (Details) panels
- [ ] Drag the divider left and right to resize panels
- [ ] Verify min widths are enforced (left: 400px, right: 350px)
- [ ] Refresh the page and verify the panel size is persisted
- [ ] Double-click the divider to reset to default size
- [ ] Verify the loading skeleton still renders correctly
- [ ] Verify tab switching (Chat/Spans) still works

https://claude.ai/code/session_01EV6y7A1Yc1UT6J53wfjYf2