### PR TITLE
ref(db): Migrate create_or_update to update_or_create in five modules

### DIFF
--- a/src/sentry/api/endpoints/organization_onboarding_tasks.py
+++ b/src/sentry/api/endpoints/organization_onboarding_tasks.py
@@ -57,7 +57,7 @@ class OrganizationOnboardingTaskEndpoint(OrganizationEndpoint):
         if completion_seen:
             values["completion_seen"] = timezone.now()
 
-        rows_affected, created = onboarding_tasks.create_or_update_onboarding_task(
+        _, created = onboarding_tasks.create_or_update_onboarding_task(
             organization=organization,
             task=task_id,
             user=request.user,
@@ -72,8 +72,7 @@ class OrganizationOnboardingTaskEndpoint(OrganizationEndpoint):
                 level="warning",
             )
 
-        if rows_affected or created:
-            onboarding_tasks.try_mark_onboarding_complete(organization.id)
+        onboarding_tasks.try_mark_onboarding_complete(organization.id)
 
         return Response(status=204)
 

--- a/src/sentry/models/featureadoption.py
+++ b/src/sentry/models/featureadoption.py
@@ -179,8 +179,10 @@ class FeatureAdoptionManager(BaseManager["FeatureAdoption"]):
             return False
 
         if not self.in_cache(organization_id, feature_id):
-            row, created = self.create_or_update(
-                organization_id=organization_id, feature_id=feature_id, complete=True
+            _, created = self.update_or_create(
+                organization_id=organization_id,
+                feature_id=feature_id,
+                defaults={"complete": True},
             )
             self.set_cache(organization_id, feature_id)
             return created

--- a/src/sentry/models/options/organization_option.py
+++ b/src/sentry/models/options/organization_option.py
@@ -53,11 +53,9 @@ class OrganizationOptionManager(OptionManager["OrganizationOption"]):
         self.reload_cache(organization.id, "organizationoption.unset_value")
 
     def set_value(self, organization: Organization, key: str, value: Any) -> bool:
-        inst, created = self.create_or_update(
-            organization=organization, key=key, values={"value": value}
-        )
+        self.update_or_create(organization=organization, key=key, defaults={"value": value})
         self.reload_cache(organization.id, "organizationoption.set_value")
-        return bool(created) or inst > 0
+        return True
 
     def get_all_values(self, organization: Organization | int) -> Mapping[str, Any]:
         if isinstance(organization, models.Model):

--- a/src/sentry/onboarding_tasks/backends/organization_onboarding_task.py
+++ b/src/sentry/onboarding_tasks/backends/organization_onboarding_task.py
@@ -32,11 +32,11 @@ class OrganizationOnboardingTaskBackend(OnboardingTaskBackend[OrganizationOnboar
         )
 
     def create_or_update_onboarding_task(self, organization, user, task, values):
-        return self.Model.objects.create_or_update(
+        return self.Model.objects.update_or_create(
             organization=organization,
             task=task,
-            values=values,
-            defaults={"user_id": user.id},
+            defaults=values,
+            create_defaults={"user_id": user.id, **values},
         )
 
     def complete_onboarding_task(

--- a/src/sentry/utils/mockdata/core.py
+++ b/src/sentry/utils/mockdata/core.py
@@ -391,7 +391,7 @@ def create_member(
 
 
 def create_access_request(member: OrganizationMember, team: Team) -> None:
-    OrganizationAccessRequest.objects.create_or_update(member=member, team=team)
+    OrganizationAccessRequest.objects.get_or_create(member=member, team=team)
 
 
 def generate_projects(organization: Organization) -> Mapping[str, Any]:
@@ -586,11 +586,11 @@ def populate_release(
             authors=[str(a.id) for a in authors],
         )
 
-    ReleaseProjectEnvironment.objects.create_or_update(
+    ReleaseProjectEnvironment.objects.update_or_create(
         project=project,
         environment=environment,
         release=release,
-        defaults={"last_deploy_id": deploy.id},
+        create_defaults={"last_deploy_id": deploy.id},
     )
 
     Activity.objects.create(

--- a/tests/sentry/test_no_create_or_update_usage.py
+++ b/tests/sentry/test_no_create_or_update_usage.py
@@ -13,10 +13,6 @@ ALLOWLIST_FILES: set[str] = {
     "src/sentry/buffer/base.py",
     "src/sentry/db/models/manager/base.py",
     "src/sentry/nodestore/django/backend.py",
-    "src/sentry/onboarding_tasks/backends/organization_onboarding_task.py",
-    "src/sentry/models/featureadoption.py",
-    "src/sentry/models/options/organization_option.py",
-    "src/sentry/utils/mockdata/core.py",
     "src/sentry/tasks/assemble.py",
     "src/sentry/services/nodestore/django/backend.py",
 }


### PR DESCRIPTION
Replace the legacy Sentry `create_or_update` helper with Django's `update_or_create` across five call sites, removing them from the usage allowlist.

`create_or_update` predates Django's `update_or_create` and is being deprecated. A CI test enforces an allowlist of remaining usages; this PR removes four files from that list.

**FeatureAdoption** — `complete=True` was in the filter but is not part of the `unique_together` constraint on `(organization, feature_id)`. With `update_or_create`, that would cause an `IntegrityError` if a row existed with `complete=False`. Fixed by moving `complete=True` into `defaults` so the filter aligns with the unique constraint.

**OrganizationOption.set_value** — `values=` → `defaults=`. The old return value `bool(created) or inst > 0` guarded against 0 rows affected, which cannot happen with `update_or_create` — always returns `True` now.

**OrganizationOnboardingTask** — `values=` maps to `defaults=` (applied on create and update); the create-only `user_id` moves to `create_defaults` merged with `values`, since Django uses `create_defaults` exclusively for the insert path.

**Onboarding tasks endpoint** — `rows_affected` is no longer meaningful since `update_or_create` always returns an instance. `try_mark_onboarding_complete` is called unconditionally; it is idempotent (early-exits if `onboarding:complete` option already exists, and deduplicates the analytics event via a unique constraint).

**mockdata** — `create_or_update(member, team)` with no values becomes `get_or_create`; `defaults=` (which was create-only in the legacy API) becomes `create_defaults=`.

Supersedes #111784 (rebased fresh on master to avoid stale CI failures).

Requires https://github.com/getsentry/getsentry/pull/19890