### PR TITLE
feat(explore): Add 1 day interval option for durations >= 14 days

### DIFF
--- a/static/app/utils/useChartInterval.spec.tsx
+++ b/static/app/utils/useChartInterval.spec.tsx
@@ -27,6 +27,7 @@ describe('useChartInterval', () => {
       {value: '1h', label: '1 hour'},
       {value: '3h', label: '3 hours'},
       {value: '6h', label: '6 hours'},
+      {value: '1d', label: '1 day'},
     ]);
     expect(chartInterval).toBe('1h'); // default
 

--- a/static/app/utils/useChartInterval.tsx
+++ b/static/app/utils/useChartInterval.tsx
@@ -65,26 +65,32 @@ function useChartIntervalImpl({
   intervalOptions: Array<{label: string; value: string}>,
 ] {
   const {datetime} = pagefilters.selection;
-  const intervalOptions = useMemo(
-    () => getIntervalOptionsForPageFilter(datetime),
-    [datetime]
-  );
+
+  const {intervalOptions, defaultInterval} = useMemo(() => {
+    const diffInMinutes = getDiffInMinutes(datetime);
+    const options = getIntervalOptionsForPageFilter(datetime);
+
+    // Compute the default from the ladder-derived options, before appending extras
+    const fallback =
+      unspecifiedStrategy === ChartIntervalUnspecifiedStrategy.USE_SMALLEST
+        ? options[0]!.value
+        : (options[options.length - 2]?.value ?? options[options.length - 1]!.value);
+
+    if (diffInMinutes >= MINIMUM_DURATION_FOR_ONE_DAY_INTERVAL) {
+      options.push(ONE_DAY_OPTION);
+    }
+
+    return {intervalOptions: options, defaultInterval: fallback};
+  }, [datetime, unspecifiedStrategy]);
 
   const interval = useMemo(() => {
     const decodedInterval = decodeScalar(location.query.interval);
 
-    // Default to the second largest option or largest option
-    const fallbackInterval =
-      unspecifiedStrategy === ChartIntervalUnspecifiedStrategy.USE_SMALLEST
-        ? intervalOptions[0]!.value
-        : (intervalOptions[intervalOptions.length - 2]?.value ??
-          intervalOptions[intervalOptions.length - 1]!.value);
-
     return decodedInterval &&
       intervalOptions.some(option => option.value === decodedInterval)
       ? decodedInterval
-      : fallbackInterval;
-  }, [location.query.interval, unspecifiedStrategy, intervalOptions]);
+      : defaultInterval;
+  }, [location.query.interval, intervalOptions, defaultInterval]);
 
   const setInterval = useCallback(
     (newInterval: string) => {
@@ -138,6 +144,9 @@ const MAXIMUM_INTERVAL = new GranularityLadder([
   [FIVE_MINUTES, '5m'],
   [0, '1m'],
 ]);
+
+const ONE_DAY_OPTION = {value: '1d', label: t('1 day')};
+const MINIMUM_DURATION_FOR_ONE_DAY_INTERVAL = TWO_WEEKS;
 
 export function getIntervalOptionsForPageFilter(datetime: PageFilters['datetime']) {
   const diffInMinutes = getDiffInMinutes(datetime);


### PR DESCRIPTION
Add a "1 day" bucket option to the interval dropdown in Explore and Dashboards for time ranges of 14 days or more.

The interval rebalancing in #112562 removed the `1d` option. This was flagged by user feedback — for longer time ranges, daily bucketing is a natural and useful granularity. Rather than re-tuning the interval ladders, this appends `1d` as an extra option outside the ladder system. The default interval for each strategy (smallest for Explore, second-biggest for Dashboards) is computed before the extra is appended, so defaults are unchanged.

Refs DAIN-1511