### PR TITLE
feat(autofix): Change default intelligence level from low to medium

### DIFF
--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -205,7 +205,7 @@ def get_step_webhook_action_type(step: AutofixStep, is_completed: bool) -> SeerA
 
 def get_autofix_explorer_client(
     group: Group,
-    intelligence_level: Literal["low", "medium", "high"] = "low",
+    intelligence_level: Literal["low", "medium", "high"] = "medium",
     enable_coding: bool = False,
 ) -> SeerExplorerClient:
     from sentry.seer.autofix.on_completion_hook import (
@@ -230,7 +230,7 @@ def trigger_autofix_explorer(
     referrer: AutofixReferrer,
     run_id: int | None = None,
     stopping_point: AutofixStoppingPoint | None = None,
-    intelligence_level: Literal["low", "medium", "high"] = "low",
+    intelligence_level: Literal["low", "medium", "high"] = "medium",
     user_context: str | None = None,
     insert_index: int | None = None,
 ) -> int:

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -116,7 +116,7 @@ class ExplorerAutofixRequestSerializer(CamelSnakeSerializer):
     intelligence_level = serializers.ChoiceField(
         required=False,
         choices=["low", "medium", "high"],
-        default="low",
+        default="medium",
         help_text="The intelligence level to use.",
     )
     user_context = serializers.CharField(

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -942,7 +942,7 @@ class GroupAutofixEndpointExplorerRoutingTest(APITestCase, SnubaTestCase):
                 referrer=AutofixReferrer.GROUP_AUTOFIX_ENDPOINT,
                 stopping_point=AutofixStoppingPoint.CODE_CHANGES,
                 run_id=None,
-                intelligence_level="low",
+                intelligence_level="medium",
                 user_context=None,
                 insert_index=None,
             )
@@ -970,7 +970,7 @@ class GroupAutofixEndpointExplorerRoutingTest(APITestCase, SnubaTestCase):
                 referrer=AutofixReferrer.GROUP_AUTOFIX_ENDPOINT,
                 stopping_point=None,
                 run_id=42,
-                intelligence_level="low",
+                intelligence_level="medium",
                 user_context=None,
                 insert_index=3,
             )


### PR DESCRIPTION
## Summary

Changes the default `intelligence_level` for Seer Explorer autofix from `"low"` to `"medium"`.

### Intelligence Levels (from `seer/automation/explorer/chat_component.py`)

All levels use `reasoning_effort = "low"`. The difference is the model:

| Level | Primary Model | Fallbacks |
|-------|--------------|-----------|
| **low** | `claude-haiku-4-5@20251001` | `claude-sonnet-4-5@20250929`, `claude-sonnet-4@20250514` |
| **medium** | `claude-sonnet-4-6@default` | `claude-sonnet-4-5@20250929`, `claude-haiku-4-5@20251001` |
| **high** | `claude-opus-4-6@default` | `claude-opus-4-5@20251101`, `claude-haiku-4-5@20251001` |

Note: `reasoning_effort` is hardcoded to `"low"` on the Seer side and is not configurable from Sentry. We'll look to address this in a future PR.

### Changes

- Updated default in `get_autofix_explorer_client()` from `"low"` → `"medium"`
- Updated default in `trigger_autofix_explorer()` from `"low"` → `"medium"`
- Updated serializer default in `GroupAiAutofixEndpoint` from `"low"` → `"medium"`
- Updated corresponding tests