### PR TITLE
ref(dashboards): Move insights-to-dashboards checks to own feature flag

### DIFF
--- a/static/app/views/navigation/secondary/sections/insights/insightsSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/insights/insightsSecondaryNavigation.tsx
@@ -35,7 +35,10 @@ export function InsightsSecondaryNavigation() {
   const baseUrl = `/organizations/${organization.slug}/${DOMAIN_VIEW_BASE_URL}`;
 
   const shouldRedirectToMonitors =
-    organization.features.includes('insights-to-dashboards-ui-rollout') && !user?.isStaff;
+    organization.features.includes('workflow-engine-ui') && !user?.isStaff;
+  const hasInsightsToDashboards = organization.features.includes(
+    'insights-to-dashboards-ui-rollout'
+  );
 
   return (
     <Fragment>
@@ -121,7 +124,7 @@ export function InsightsSecondaryNavigation() {
             </Feature>
           </SecondaryNavigation.List>
         </SecondaryNavigation.Section>
-        {!organization.features.includes('insights-to-dashboards-ui-rollout') && (
+        {!hasInsightsToDashboards && (
           <Fragment>
             <SecondaryNavigation.Separator />
             <ProjectsNavigationItems

--- a/static/app/views/navigation/secondary/sections/insights/insightsSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/insights/insightsSecondaryNavigation.tsx
@@ -35,7 +35,7 @@ export function InsightsSecondaryNavigation() {
   const baseUrl = `/organizations/${organization.slug}/${DOMAIN_VIEW_BASE_URL}`;
 
   const shouldRedirectToMonitors =
-    organization.features.includes('workflow-engine-ui') && !user?.isStaff;
+    organization.features.includes('insights-to-dashboards-ui-rollout') && !user?.isStaff;
 
   return (
     <Fragment>
@@ -121,7 +121,7 @@ export function InsightsSecondaryNavigation() {
             </Feature>
           </SecondaryNavigation.List>
         </SecondaryNavigation.Section>
-        {!organization.features.includes('workflow-engine-ui') && (
+        {!organization.features.includes('insights-to-dashboards-ui-rollout') && (
           <Fragment>
             <SecondaryNavigation.Separator />
             <ProjectsNavigationItems

--- a/static/app/views/projects/index.tsx
+++ b/static/app/views/projects/index.tsx
@@ -18,7 +18,7 @@ export default function Projects() {
     newPathPrefix: '/projects/',
   });
 
-  const redirectPath = organization.features.includes('workflow-engine-ui')
+  const redirectPath = organization.features.includes('insights-to-dashboards-ui-rollout')
     ? reverseRedirect
     : forwardRedirect;
 

--- a/static/app/views/projects/pathname.tsx
+++ b/static/app/views/projects/pathname.tsx
@@ -8,7 +8,7 @@ export function makeProjectsPathname({
   organization: Organization;
   path: '/' | `/${string}/`;
 }) {
-  const base = organization.features.includes('workflow-engine-ui')
+  const base = organization.features.includes('insights-to-dashboards-ui-rollout')
     ? 'projects'
     : 'insights/projects';
   return normalizeUrl(`/organizations/${organization.slug}/${base}${path}`);


### PR DESCRIPTION
Move migration checks from `workflow-engine-ui` to the new `insights-to-dashboards-ui-rollout` feature flag so we can coordinate the rollout independently from the Monitor team's `workflow-engine-ui` rollout

Closes [DAIN-1509](https://linear.app/getsentry/issue/DAIN-1509/move-insights-dashboards-rollout-to-our-own-flag)