### PR TITLE
ref(slack): Remove reactions:write scope before Slack app submission

### DIFF
--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -373,7 +373,6 @@ class SlackIntegrationProvider(IntegrationProvider):
     # Used by SlackStagingIntegrationProvider
     extended_oauth_scopes = frozenset(
         [
-            SlackScope.REACTIONS_WRITE,
             SlackScope.CHANNELS_HISTORY,
             SlackScope.GROUPS_HISTORY,
             SlackScope.APP_MENTIONS_READ,

--- a/src/sentry/integrations/slack/utils/constants.py
+++ b/src/sentry/integrations/slack/utils/constants.py
@@ -6,8 +6,6 @@ SLACK_RATE_LIMITED_MESSAGE = "Requests to Slack exceeded the rate limit. Please 
 class SlackScope(StrEnum):
     """OAuth scopes for the Slack integration."""
 
-    REACTIONS_WRITE = "reactions:write"
-    """Allows the bot to add and remove reactions to messages."""
     CHANNELS_HISTORY = "channels:history"
     """Allows the bot to read message history in channels."""
     GROUPS_HISTORY = "groups:history"


### PR DESCRIPTION
When we submit the slack app for review, we want to be able to demonstrate that every new permission is required for the app to function. According to Slack's [documentation](https://docs.slack.dev/slack-marketplace/slack-marketplace-review-guide/#scopes):

> _Please do not submit your app with scopes for a feature that you plan to build at some point in future_

completes ISWF-2454