### PR TITLE
feat(autofix): Pass reasoning_effort=medium for explorer autofix RCA

### DIFF
--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -100,12 +100,14 @@ class StepConfig:
         artifact_schema: type[BaseModel] | None,
         prompt_fn: Callable[..., str],
         enable_coding: bool = False,
+        reasoning_effort: Literal["low", "medium", "high"] | None = None,
         started_event: type[AiAutofixPhaseEvent] | None = None,
         completed_event: type[AiAutofixPhaseEvent] | None = None,
     ):
         self.artifact_schema = artifact_schema
         self.prompt_fn = prompt_fn
         self.enable_coding = enable_coding
+        self.reasoning_effort = reasoning_effort
         self.started_event = started_event
         self.completed_event = completed_event
 
@@ -115,6 +117,7 @@ STEP_CONFIGS: dict[AutofixStep, StepConfig] = {
     AutofixStep.ROOT_CAUSE: StepConfig(
         artifact_schema=RootCauseArtifact,
         prompt_fn=root_cause_prompt,
+        reasoning_effort="medium",
         started_event=AiAutofixRootCauseStartedEvent,
         completed_event=AiAutofixRootCauseCompletedEvent,
     ),
@@ -206,6 +209,7 @@ def get_step_webhook_action_type(step: AutofixStep, is_completed: bool) -> SeerA
 def get_autofix_explorer_client(
     group: Group,
     intelligence_level: Literal["low", "medium", "high"] = "medium",
+    reasoning_effort: Literal["low", "medium", "high"] | None = None,
     enable_coding: bool = False,
 ) -> SeerExplorerClient:
     from sentry.seer.autofix.on_completion_hook import (
@@ -219,6 +223,7 @@ def get_autofix_explorer_client(
         category_key="autofix",
         category_value=str(group.id),
         intelligence_level=intelligence_level,
+        reasoning_effort=reasoning_effort,
         on_completion_hook=AutofixOnCompletionHook,
         enable_coding=enable_coding,
     )
@@ -261,6 +266,7 @@ def trigger_autofix_explorer(
     client = get_autofix_explorer_client(
         group,
         intelligence_level=intelligence_level,
+        reasoning_effort=config.reasoning_effort,
         enable_coding=config.enable_coding,
     )
 

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -195,6 +195,7 @@ class SeerExplorerClient:
         custom_tools: list[type[ExplorerTool[Any]]] | None = None,
         on_completion_hook: type[ExplorerOnCompletionHook] | None = None,
         intelligence_level: Literal["low", "medium", "high"] = "medium",
+        reasoning_effort: Literal["low", "medium", "high"] | None = None,
         is_interactive: bool = False,
         enable_coding: bool = False,
         enable_code_mode_tools: bool = False,
@@ -206,6 +207,7 @@ class SeerExplorerClient:
         self.custom_tools = custom_tools or []
         self.on_completion_hook = on_completion_hook
         self.intelligence_level = intelligence_level
+        self.reasoning_effort = reasoning_effort
         self.category_key = category_key
         self.category_value = category_value
         self.is_interactive = is_interactive
@@ -292,6 +294,9 @@ class SeerExplorerClient:
             enable_code_mode_tools=self.enable_code_mode_tools,
             user_auth_token=user_auth_token,
         )
+
+        if self.reasoning_effort is not None:
+            chat_body["reasoning_effort"] = self.reasoning_effort
 
         if self.max_iterations is not None:
             chat_body["max_iterations"] = self.max_iterations

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -56,6 +56,7 @@ class ExplorerChatRequest(TypedDict):
     page_name: NotRequired[str | None]
     user_org_context: NotRequired[dict[str, Any] | None]
     intelligence_level: NotRequired[str]
+    reasoning_effort: NotRequired[str]
     is_interactive: NotRequired[bool]
     enable_coding: NotRequired[bool]
     enable_code_mode_tools: NotRequired[bool]


### PR DESCRIPTION
## Summary
- Threads `reasoning_effort` parameter through `SeerExplorerClient` and `StepConfig`
- Sets `reasoning_effort="medium"` for the ROOT_CAUSE autofix step to improve RCA quality
- Adds `reasoning_effort` to the `ExplorerChatRequest` TypedDict sent to seer

## Companion PR
- Seer side: accepts and applies the `reasoning_effort` override in the explorer client

## Test plan
- [ ] Verify autofix RCA triggers with reasoning_effort="medium" in the seer request
- [ ] Verify other autofix steps (solution, code_changes, etc.) are unaffected (reasoning_effort=None)


Agent transcript: https://claudescope.sentry.dev/share/sXuMsW3OyylrytGHpQcX5qlA9OkX-aT4a8xWPugUiJU