### PR TITLE
ref(chartcuterie): Update explore chart legend styling

### DIFF
--- a/static/app/chartcuterie/explore.tsx
+++ b/static/app/chartcuterie/explore.tsx
@@ -46,18 +46,27 @@ export const makeExploreCharts = (theme: Theme): Array<RenderDescriptor<ChartTyp
   });
 
   const exploreDefaults = {
-    grid: Grid({left: 5, right: 5, bottom: 5, top: 60}),
+    grid: Grid({left: 10, right: 10, bottom: 10, top: 60}),
     backgroundColor: theme.tokens.background.primary,
     legend: Legend({
       theme,
+      icon: 'roundRect',
       itemHeight: 16,
-      top: 2,
-      right: 10,
+      itemWidth: 16,
+      itemGap: 16,
+      top: 6,
+      left: 10,
+      truncate: 40,
       textStyle: {
         fontSize: EXPLORE_FONT_SIZE,
         lineHeight: EXPLORE_FONT_SIZE * 1.4,
         fontFamily: DEFAULT_FONT_FAMILY,
       },
+      pageTextStyle: {
+        fontSize: EXPLORE_FONT_SIZE,
+        fontFamily: DEFAULT_FONT_FAMILY,
+      },
+      pageIconSize: EXPLORE_FONT_SIZE * 0.6,
     }),
     yAxis: YAxis({
       theme,


### PR DESCRIPTION
Update the Slack explore chart legend to more closely match the dashboard UI styling.

Changes:
- Use `roundRect` icon instead of `circle` to match the square `LegendCheckbox` indicators in the dashboard
- Left-align the legend instead of right-aligned
- Increase padding around the chart perimeter (5px → 10px)
- Increase `itemGap` to prevent legend items from overlapping
- Add label truncation at 40 characters for long series names
- Scale `pageTextStyle` and `pageIconSize` to match the larger 1200x400 canvas so scroll pagination is visible

Rendered in chrome, it looks like this. Although not a 1:1 comparsion as it's not through chartcuterie and into slack
<img width="1231" height="433" alt="image" src="https://github.com/user-attachments/assets/8377ed1c-5911-4b5f-8421-bddaf300aa48" />


Refs DAIN-1513