### PR TITLE
fix(pipeline): Handle pipeline error responses in usePipeline hook

### DIFF
--- a/static/app/components/pipeline/usePipeline.spec.tsx
+++ b/static/app/components/pipeline/usePipeline.spec.tsx
@@ -172,6 +172,7 @@ describe('usePipeline', () => {
     MockApiClient.addMockResponse({
       url: API_URL,
       method: 'POST',
+      statusCode: 400,
       body: {
         status: 'error',
         data: {detail: 'Something went wrong'},
@@ -184,12 +185,103 @@ describe('usePipeline', () => {
 
     expect(await screen.findByText('Something went wrong')).toBeInTheDocument();
 
+    // Pipeline stays active — step view is still visible
+    expect(screen.getByTestId('step')).toHaveTextContent('step_one');
+    expect(screen.getByRole('textbox', {name: 'Your name'})).toBeInTheDocument();
+
     // Restart should recover from the error and re-initialize
     await userEvent.click(screen.getByTestId('restart'));
 
     expect(await screen.findByText('Hello!')).toBeInTheDocument();
     expect(screen.getByTestId('error')).toHaveTextContent('none');
     expect(screen.getByTestId('step')).toHaveTextContent('step_one');
+  });
+
+  it('handles expired session (404) as unrecoverable', async () => {
+    MockApiClient.addMockResponse({
+      url: API_URL,
+      method: 'POST',
+      body: {
+        step: 'step_one',
+        stepIndex: 0,
+        totalSteps: 2,
+        provider: 'dummy',
+        data: {message: 'Hello!'},
+      },
+      match: [MockApiClient.matchData({action: 'initialize', provider: 'dummy'})],
+    });
+
+    render(<TestHarness />, {organization});
+    expect(await screen.findByText('Hello!')).toBeInTheDocument();
+
+    MockApiClient.addMockResponse({
+      url: API_URL,
+      method: 'POST',
+      statusCode: 404,
+      body: {detail: 'No active pipeline session.'},
+      match: [MockApiClient.matchData({name: 'Test'})],
+    });
+
+    await userEvent.type(screen.getByRole('textbox', {name: 'Your name'}), 'Test');
+    await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+    expect(
+      await screen.findByText('This flow has expired. Please start over.')
+    ).toBeInTheDocument();
+
+    // Step view is gone — pipeline is in unrecoverable error state
+    expect(screen.getByTestId('step')).toHaveTextContent('none');
+  });
+
+  it('handles server error (5xx) as unrecoverable', async () => {
+    MockApiClient.addMockResponse({
+      url: API_URL,
+      method: 'POST',
+      body: {
+        step: 'step_one',
+        stepIndex: 0,
+        totalSteps: 2,
+        provider: 'dummy',
+        data: {message: 'Hello!'},
+      },
+      match: [MockApiClient.matchData({action: 'initialize', provider: 'dummy'})],
+    });
+
+    render(<TestHarness />, {organization});
+    expect(await screen.findByText('Hello!')).toBeInTheDocument();
+
+    MockApiClient.addMockResponse({
+      url: API_URL,
+      method: 'POST',
+      statusCode: 500,
+      body: {detail: 'Internal server error'},
+      match: [MockApiClient.matchData({name: 'Test'})],
+    });
+
+    await userEvent.type(screen.getByRole('textbox', {name: 'Your name'}), 'Test');
+    await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+    expect(await screen.findByText('Internal server error')).toBeInTheDocument();
+
+    // Step view is gone — pipeline is in unrecoverable error state
+    expect(screen.getByTestId('step')).toHaveTextContent('none');
+  });
+
+  it('handles initialization failure', async () => {
+    MockApiClient.addMockResponse({
+      url: API_URL,
+      method: 'POST',
+      statusCode: 400,
+      body: {detail: 'provider is required.'},
+      match: [MockApiClient.matchData({action: 'initialize', provider: 'dummy'})],
+    });
+
+    render(<TestHarness />, {organization});
+
+    expect(await screen.findByText('provider is required.')).toBeInTheDocument();
+
+    // Step view is gone — pipeline is in unrecoverable error state
+    expect(screen.getByTestId('step')).toHaveTextContent('none');
   });
 
   it('restarts the pipeline from the beginning', async () => {

--- a/static/app/components/pipeline/usePipeline.tsx
+++ b/static/app/components/pipeline/usePipeline.tsx
@@ -21,22 +21,57 @@ import type {
 import {getBackendPipelineType} from './types';
 
 type PipelineState<T extends RegisteredPipelineType, P extends ProvidersByType[T]> =
-  | {status: 'idle'}
-  | {status: 'initializing'}
   | {
+      /**
+       * Pipeline has not yet started
+       */
+      status: 'idle';
+    }
+  | {
+      /**
+       * Pipeline is making it's initialization call. This is essentially a
+       * loading state, but the first view will be available.
+       */
+      status: 'initializing';
+    }
+  | {
+      /**
+       * Pipeline is currently stepping through each step of the pipeline
+       */
       status: 'active';
       stepData: Record<string, unknown>;
       stepInfo: PipelineStepResponse;
     }
-  | {data: CompletionDataFor<T, P>; status: 'complete'}
-  | {error: Error; status: 'error'};
+  | {
+      data: CompletionDataFor<T, P>;
+      /**
+       * Pipeline has been completed and no longer needs to be advanced.
+       */
+      status: 'complete';
+    }
+  | {
+      error: Error;
+      /**
+       * When the pipeline is in the error state, this indicates an
+       * unrecoverable error. Advance responses with status error will NOT put
+       * the pipeline into an unrecoverable state. This is reserved for a
+       * pipeline expiring or a 500 error.
+       */
+      status: 'error';
+    };
 
 interface UsePipelineOptions<
   T extends RegisteredPipelineType,
   P extends ProvidersByType[T],
 > {
   enabled?: boolean;
+  /**
+   * Data that will be passed through to the initialization call.
+   */
   initialData?: Record<string, string>;
+  /**
+   * Called when the piepline has finished
+   */
   onComplete?: (data: CompletionDataFor<T, P>) => void;
 }
 
@@ -108,12 +143,11 @@ export function usePipeline<
     [type, provider]
   );
 
-  const {mutate: initializeMutate, ...initializeRest} = useMutation<
-    PipelineStepResponse,
-    Error,
-    void,
-    {generation: number}
-  >({
+  const {
+    mutate: initializeMutate,
+    error: initializeError,
+    isPending: isInitializePending,
+  } = useMutation<PipelineStepResponse, RequestError, void, {generation: number}>({
     mutationFn: () =>
       fetchMutation<PipelineStepResponse>({
         method: 'POST',
@@ -121,13 +155,13 @@ export function usePipeline<
         data: {action: 'initialize', provider, initialData},
       }),
     onMutate: () => ({generation: generationRef.current}),
-    onSuccess: (data: PipelineStepResponse, _variables, context) => {
+    onSuccess: (data, _variables, context) => {
       if (context?.generation !== generationRef.current) {
         return;
       }
       setState({status: 'active', stepInfo: data, stepData: data.data});
     },
-    onError: (error: Error, _variables, context) => {
+    onError: (error, _variables, context) => {
       if (context?.generation !== generationRef.current) {
         return;
       }
@@ -153,7 +187,7 @@ export function usePipeline<
         data,
       }),
     onMutate: () => ({generation: generationRef.current}),
-    onSuccess: (response: PipelineAdvanceResponse, _variables, context) => {
+    onSuccess: (response, _variables, context) => {
       if (context?.generation !== generationRef.current) {
         return;
       }
@@ -201,14 +235,12 @@ export function usePipeline<
           break;
         }
         case 'error':
-          setState({
-            status: 'error',
-            error: new Error((response.data?.detail as string) ?? 'Pipeline error'),
-          });
+          // The backend returns HTTP 400 for error results, so this case
+          // is handled by onError below, not here.
           break;
       }
     },
-    onError: (error: RequestError, _variables, context) => {
+    onError: (error, _variables, context) => {
       if (context?.generation !== generationRef.current) {
         return;
       }
@@ -272,11 +304,9 @@ export function usePipeline<
       return <CompletionView data={state.data} finish={finish} />;
     }
 
-    if (!stepDefinition) {
+    if (!stepDefinition || state.status !== 'active') {
       return null;
     }
-
-    const isActive = state.status === 'active';
 
     // Widen from the specific union of component types to the general
     // PipelineStepDefinition component type
@@ -285,9 +315,9 @@ export function usePipeline<
 
     return (
       <Component
-        stepIndex={isActive ? state.stepInfo.stepIndex : 0}
-        totalSteps={isActive ? state.stepInfo.totalSteps : definition.steps.length}
-        stepData={isActive ? state.stepData : {}}
+        stepIndex={state.stepInfo.stepIndex}
+        totalSteps={state.stepInfo.totalSteps}
+        stepData={state.stepData}
         advance={advanceMutate}
         isAdvancing={isAdvancePending}
         advanceError={advanceError}
@@ -308,26 +338,7 @@ export function usePipeline<
       ? {stepIndex: state.stepInfo.stepIndex, totalSteps: state.stepInfo.totalSteps}
       : {stepIndex: 0, totalSteps: definition.steps.length};
 
-  // Pipeline-level error displayed by the modal as a full-width alert with a
-  // "Start over" button. When state.status is 'error', the pipeline has hit an
-  // unrecoverable failure (backend PipelineStepResult.error() response, expired
-  // session, or 5xx). Otherwise falls back to initialization errors or
-  // advanceError — but only when it carries a `detail` message (a non-field
-  // error). Field-level validation errors from advanceError are handled by step
-  // components via setFieldErrors() and don't surface here.
-  const advanceDetailError =
-    advanceError && typeof (advanceError.responseJSON as any)?.detail === 'string'
-      ? ((advanceError.responseJSON as any).detail as string)
-      : null;
-
-  const rawError =
-    state.status === 'error' ? state.error : (initializeRest.error ?? null);
-
-  const error = rawError
-    ? ((rawError instanceof RequestError
-        ? ((rawError.responseJSON as any)?.detail as string | undefined)
-        : undefined) ?? rawError.message)
-    : advanceDetailError;
+  const error = getPipelineError(state, initializeError, advanceError);
 
   const completionData = state.status === 'complete' ? state.data : null;
 
@@ -338,10 +349,57 @@ export function usePipeline<
     stepDefinition,
     stepIndex,
     totalSteps,
-    isInitializing: state.status === 'initializing' || initializeRest.isPending,
+    isInitializing: state.status === 'initializing' || isInitializePending,
     isAdvancing: isAdvancePending,
     isComplete: state.status === 'complete',
     error,
     completionData,
   };
+}
+
+/**
+ * Extract a human-readable message from an error. Prefers the `detail` field
+ * from a DRF error response, falls back to the JS error message.
+ */
+function getErrorMessage(err: Error): string {
+  if (err instanceof RequestError) {
+    const detail = (err.responseJSON as Record<string, unknown> | undefined)?.detail;
+    if (typeof detail === 'string') {
+      return detail;
+    }
+  }
+  return err.message;
+}
+
+/**
+ * Derive the pipeline-level error string. Three sources, in priority:
+ *
+ * 1. Unrecoverable state error — expired session (404) or server error (5xx)
+ * 2. Initialization failure — bad provider, missing params, etc.
+ * 3. Step error — PipelineStepResult.error() returned as 400 with
+ *    {status: "error", data: {detail: "..."}}. Field-level validation
+ *    errors are NOT surfaced here; those go to step components via
+ *    advanceError / setFieldErrors().
+ */
+function getPipelineError(
+  state: {status: string; error?: Error},
+  initializeError: RequestError | null,
+  advanceError: RequestError | null
+): string | null {
+  if (state.status === 'error' && state.error) {
+    return getErrorMessage(state.error);
+  }
+  if (initializeError) {
+    return getErrorMessage(initializeError);
+  }
+  if (advanceError) {
+    const json = advanceError.responseJSON as Record<string, unknown> | undefined;
+    if (json?.status === 'error') {
+      const data = json.data as Record<string, unknown> | undefined;
+      if (typeof data?.detail === 'string') {
+        return data.detail;
+      }
+    }
+  }
+  return null;
 }


### PR DESCRIPTION
The backend returns HTTP 400 with {status: "error", data: {detail}} for PipelineStepResult.error() responses, but the frontend was only extracting detail from the top-level responseJSON. This meant pipeline-level errors were silently swallowed.

Extract error detail from the correct nested response shape and keep the pipeline active so the step view remains visible. Reorganize error derivation into a named function with clear priority: state errors (expired/5xx), then init failures, then step errors. Add tests for all error paths.