### PR TITLE
ref(chartcuterie): Rename SLACK_EXPLORE_LINE to SLACK_TIMESERIES (backend)

### DIFF
--- a/src/sentry/charts/types.py
+++ b/src/sentry/charts/types.py
@@ -24,7 +24,7 @@ class ChartType(Enum):
     SLACK_PERFORMANCE_FUNCTION_REGRESSION = "slack:performance.functionRegression"
     SLACK_METRIC_DETECTOR_EVENTS = "slack:metricDetector.events"
     SLACK_METRIC_DETECTOR_SESSIONS = "slack:metricDetector.sessions"
-    SLACK_EXPLORE_LINE = "slack:explore.line"
+    SLACK_TIMESERIES = "slack:timeseries"
 
 
 class ChartSize(TypedDict):

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -134,7 +134,7 @@ def _unfurl_explore(
 
         group_bys = params.getlist("groupBy")
 
-        style = ChartType.SLACK_EXPLORE_LINE
+        style = ChartType.SLACK_TIMESERIES
         if group_bys:
             params.setlist("topEvents", [str(TOP_N)])
             if not params.getlist("sort"):

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -1552,7 +1552,7 @@ class UnfurlTest(TestCase):
             ).build()
         )
         assert len(mock_generate_chart.mock_calls) == 1
-        assert mock_generate_chart.call_args[0][0] == ChartType.SLACK_EXPLORE_LINE
+        assert mock_generate_chart.call_args[0][0] == ChartType.SLACK_TIMESERIES
         chart_data = mock_generate_chart.call_args[0][1]
         assert "timeSeries" in chart_data
 
@@ -1601,7 +1601,7 @@ class UnfurlTest(TestCase):
 
         assert len(unfurls) == 1
         assert len(mock_generate_chart.mock_calls) == 1
-        assert mock_generate_chart.call_args[0][0] == ChartType.SLACK_EXPLORE_LINE
+        assert mock_generate_chart.call_args[0][0] == ChartType.SLACK_TIMESERIES
 
         # Verify sort is passed to the timeseries API for correct top events
         api_params = mock_client_get.call_args[1]["params"]
@@ -1736,7 +1736,7 @@ class UnfurlTest(TestCase):
         chart_type = mock_generate_chart.call_args[0][0]
         chart_data = mock_generate_chart.call_args[0][1]
 
-        assert chart_type == ChartType.SLACK_EXPLORE_LINE
+        assert chart_type == ChartType.SLACK_TIMESERIES
         # timeSeries should be passed through directly from the API response
         time_series = chart_data["timeSeries"]
         assert isinstance(time_series, list)


### PR DESCRIPTION
## Summary
- Renames the `ChartType.SLACK_EXPLORE_LINE` enum member to `ChartType.SLACK_TIMESERIES` and its string value from `slack:explore.line` to `slack:timeseries` in the backend Python code
- Updates the Slack explore unfurl handler and tests to use the new name

Work for https://linear.app/getsentry/issue/DAIN-1521/update-unfurl-handler-name

## Test plan
- [x] Pre-commit passes
- [ ] Existing `test_unfurl` tests pass with updated enum references