### PR TITLE
ref(chartcuterie): Rename SLACK_EXPLORE_LINE to SLACK_TIMESERIES (frontend)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -356,6 +356,7 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /static/app/components/arithmeticBuilder/                                 @getsentry/data-browsing
 
 /static/app/components/charts/                                            @getsentry/data-browsing
+/static/app/chartcuterie/timeseries.tsx                                   @getsentry/data-browsing
 
 /static/app/views/insights/                                               @getsentry/dashboards
 

--- a/static/app/chartcuterie/config.tsx
+++ b/static/app/chartcuterie/config.tsx
@@ -12,10 +12,10 @@
 import {lightTheme} from 'sentry/utils/theme/theme';
 
 import {makeDiscoverCharts} from './discover';
-import {makeExploreCharts} from './explore';
 import {makeMetricAlertCharts} from './metricAlert';
 import {makeMetricDetectorCharts} from './metricDetector';
 import {makePerformanceCharts} from './performance';
+import {makeTimeseriesCharts} from './timeseries';
 import type {
   ChartcuterieConfig,
   ChartType,
@@ -43,7 +43,7 @@ const register = (renderDescriptor: RenderDescriptor<ChartType>) =>
   renderConfig.set(renderDescriptor.key, renderDescriptor);
 
 makeDiscoverCharts(lightTheme).forEach(register);
-makeExploreCharts(lightTheme).forEach(register);
+makeTimeseriesCharts(lightTheme).forEach(register);
 makeMetricAlertCharts(lightTheme).forEach(register);
 makeMetricDetectorCharts(lightTheme).forEach(register);
 makePerformanceCharts(lightTheme).forEach(register);

--- a/static/app/chartcuterie/timeseries.tsx
+++ b/static/app/chartcuterie/timeseries.tsx
@@ -37,7 +37,9 @@ type ExploreChartData = {
   type?: DisplayType;
 };
 
-export const makeExploreCharts = (theme: Theme): Array<RenderDescriptor<ChartType>> => {
+export const makeTimeseriesCharts = (
+  theme: Theme
+): Array<RenderDescriptor<ChartType>> => {
   const exploreXAxis = XAxis({
     theme,
     splitNumber: 3,
@@ -78,7 +80,7 @@ export const makeExploreCharts = (theme: Theme): Array<RenderDescriptor<ChartTyp
   const exploreCharts: Array<RenderDescriptor<ChartType>> = [];
 
   exploreCharts.push({
-    key: ChartType.SLACK_EXPLORE_LINE,
+    key: ChartType.SLACK_TIMESERIES,
     getOption: (data: ExploreChartData) => {
       const {timeSeries, type: displayType = DisplayType.LINE} = data;
 

--- a/static/app/chartcuterie/timeseries.tsx
+++ b/static/app/chartcuterie/timeseries.tsx
@@ -16,10 +16,10 @@ import type {RenderDescriptor} from './types';
 import {ChartType} from './types';
 
 /**
- * Font size and spacing scaled for the larger explore chart canvas (1200x400).
+ * Font size and spacing scaled for the larger timeseries chart canvas (1200x400).
  */
-const EXPLORE_FONT_SIZE = 28;
-const EXPLORE_CHART_SIZE = {width: 1200, height: 400};
+const FONT_SIZE = 28;
+const CHART_SIZE = {width: 1200, height: 400};
 
 /**
  * Builds a y-axis axisLabel formatter from the first timeseries metadata.
@@ -32,7 +32,7 @@ function makeYAxisFormatter(timeSeries: TimeSeries[]) {
   return (value: number) => formatYAxisValue(value, valueType, valueUnit ?? undefined);
 }
 
-type ExploreChartData = {
+type ChartData = {
   timeSeries: TimeSeries[];
   type?: DisplayType;
 };
@@ -40,14 +40,14 @@ type ExploreChartData = {
 export const makeTimeseriesCharts = (
   theme: Theme
 ): Array<RenderDescriptor<ChartType>> => {
-  const exploreXAxis = XAxis({
+  const xAxis = XAxis({
     theme,
     splitNumber: 3,
     isGroupedByDate: true,
-    axisLabel: {fontSize: EXPLORE_FONT_SIZE, fontFamily: DEFAULT_FONT_FAMILY},
+    axisLabel: {fontSize: FONT_SIZE, fontFamily: DEFAULT_FONT_FAMILY},
   });
 
-  const exploreDefaults = {
+  const defaults = {
     grid: Grid({left: 10, right: 10, bottom: 10, top: 60}),
     backgroundColor: theme.tokens.background.primary,
     legend: Legend({
@@ -60,44 +60,44 @@ export const makeTimeseriesCharts = (
       left: 10,
       truncate: 40,
       textStyle: {
-        fontSize: EXPLORE_FONT_SIZE,
-        lineHeight: EXPLORE_FONT_SIZE * 1.4,
+        fontSize: FONT_SIZE,
+        lineHeight: FONT_SIZE * 1.4,
         fontFamily: DEFAULT_FONT_FAMILY,
       },
       pageTextStyle: {
-        fontSize: EXPLORE_FONT_SIZE,
+        fontSize: FONT_SIZE,
         fontFamily: DEFAULT_FONT_FAMILY,
       },
-      pageIconSize: EXPLORE_FONT_SIZE * 0.6,
+      pageIconSize: FONT_SIZE * 0.6,
     }),
     yAxis: YAxis({
       theme,
       splitNumber: 3,
-      axisLabel: {fontSize: EXPLORE_FONT_SIZE, fontFamily: DEFAULT_FONT_FAMILY},
+      axisLabel: {fontSize: FONT_SIZE, fontFamily: DEFAULT_FONT_FAMILY},
     }),
   };
 
-  const exploreCharts: Array<RenderDescriptor<ChartType>> = [];
+  const charts: Array<RenderDescriptor<ChartType>> = [];
 
-  exploreCharts.push({
+  charts.push({
     key: ChartType.SLACK_TIMESERIES,
-    getOption: (data: ExploreChartData) => {
+    getOption: (data: ChartData) => {
       const {timeSeries, type: displayType = DisplayType.LINE} = data;
 
       if (timeSeries.length === 0) {
         return {
-          ...exploreDefaults,
-          xAxis: exploreXAxis,
+          ...defaults,
+          xAxis,
           useUTC: true,
           series: [],
         };
       }
 
-      const exploreYAxis = YAxis({
+      const yAxis = YAxis({
         theme,
         splitNumber: 3,
         axisLabel: {
-          fontSize: EXPLORE_FONT_SIZE,
+          fontSize: FONT_SIZE,
           fontFamily: DEFAULT_FONT_FAMILY,
           formatter: makeYAxisFormatter(timeSeries),
         },
@@ -117,9 +117,9 @@ export const makeTimeseriesCharts = (
         const series = plottable?.toSeries(plottingOptions) ?? [];
 
         return {
-          ...exploreDefaults,
-          yAxis: exploreYAxis,
-          xAxis: exploreXAxis,
+          ...defaults,
+          yAxis,
+          xAxis,
           useUTC: true,
           color,
           series,
@@ -151,16 +151,16 @@ export const makeTimeseriesCharts = (
       });
 
       return {
-        ...exploreDefaults,
-        yAxis: exploreYAxis,
-        xAxis: exploreXAxis,
+        ...defaults,
+        yAxis,
+        xAxis,
         useUTC: true,
         color,
         series,
       };
     },
-    ...EXPLORE_CHART_SIZE,
+    ...CHART_SIZE,
   });
 
-  return exploreCharts;
+  return charts;
 };

--- a/static/app/chartcuterie/types.tsx
+++ b/static/app/chartcuterie/types.tsx
@@ -20,7 +20,7 @@ export enum ChartType {
   SLACK_METRIC_DETECTOR_SESSIONS = 'slack:metricDetector.sessions',
   SLACK_PERFORMANCE_ENDPOINT_REGRESSION = 'slack:performance.endpointRegression',
   SLACK_PERFORMANCE_FUNCTION_REGRESSION = 'slack:performance.functionRegression',
-  SLACK_EXPLORE_LINE = 'slack:explore.line',
+  SLACK_TIMESERIES = 'slack:timeseries',
 }
 
 /**


### PR DESCRIPTION
## Summary
- Renames the `ChartType.SLACK_EXPLORE_LINE` enum member to `ChartType.SLACK_TIMESERIES` and its string value from `slack:explore.line` to `slack:timeseries` in the frontend TypeScript code
- Renames `explore.tsx` to `timeseries.tsx` and `makeExploreCharts` to `makeTimeseriesCharts`
- Updates `config.tsx` import accordingly

This is because the handler covers all timeseries chart types, and it's not specific to explore line charts

Depends on getsentry/sentry#112933

Work for https://linear.app/getsentry/issue/DAIN-1521/update-unfurl-handler-name

## Test plan
- [x] Pre-commit passes
- [ ] Chartcuterie config still registers the timeseries chart type correctly