### PR TITLE
feat(integrations): Add metrics to pipeline advancer and pipeline API endpoints

### DIFF
--- a/src/sentry/api/endpoints/organization_pipeline.py
+++ b/src/sentry/api/endpoints/organization_pipeline.py
@@ -22,6 +22,7 @@ from sentry.integrations.pipeline import (
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.pipeline.base import Pipeline
 from sentry.pipeline.types import PipelineStepAction
+from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +87,12 @@ class OrganizationPipelineEndpoint(ControlSiloOrganizationEndpoint):
             return result
         pipeline = result
 
+        metrics.incr(
+            "integrations.pipeline_api.advance",
+            tags={"provider": pipeline.provider.key, "pipeline": pipeline_name},
+            sample_rate=1.0,
+        )
+
         step_result = pipeline.api_advance(request._request, request.data)
 
         response_data = step_result.serialize()
@@ -120,6 +127,12 @@ class OrganizationPipelineEndpoint(ControlSiloOrganizationEndpoint):
             return Response({"detail": "Pipeline does not support API mode."}, status=400)
 
         pipeline.set_api_mode()
+
+        metrics.incr(
+            "integrations.pipeline_api.initialize",
+            tags={"provider": provider_id, "pipeline": pipeline_name},
+            sample_rate=1.0,
+        )
 
         # If the provider defines an initial data serializer, validate the
         # initialData dict from the request and bind it to pipeline state.

--- a/src/sentry/web/frontend/pipeline_advancer.py
+++ b/src/sentry/web/frontend/pipeline_advancer.py
@@ -11,6 +11,7 @@ from sentry.identity.pipeline import IdentityPipeline
 from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.organizations.absolute_url import generate_organization_url
+from sentry.utils import metrics
 from sentry.utils.http import absolute_uri, create_redirect_url
 from sentry.utils.json import dumps_htmlsafe
 from sentry.web.frontend.base import BaseView, all_silo_view
@@ -120,7 +121,18 @@ class PipelineAdvancerView(BaseView):
         # that relays the callback params back to the opener window via
         # postMessage instead of processing the callback server-side.
         if pipeline.is_api_mode:
+            metrics.incr(
+                "integrations.pipeline_advancer.trampoline",
+                tags={"provider": provider_id},
+                sample_rate=1.0,
+            )
             return _render_trampoline(request, pipeline)
+
+        metrics.incr(
+            "integrations.pipeline_advancer.legacy",
+            tags={"provider": provider_id},
+            sample_rate=1.0,
+        )
 
         subdomain = pipeline.fetch_state("subdomain")
         if subdomain is not None and request.subdomain != subdomain:


### PR DESCRIPTION
Track provider-tagged metrics on the pipeline advancer to distinguish legacy server-side callbacks from API-driven trampoline redirects, and on the pipeline API endpoint to track initialize and advance calls.