### PR TITLE
feat(usageStats): Add new `no_parent_span` client discard reason

### DIFF
--- a/static/app/views/organizationStats/getReasonGroupName.spec.ts
+++ b/static/app/views/organizationStats/getReasonGroupName.spec.ts
@@ -100,6 +100,10 @@ describe('getReasonGroupName', () => {
     expect(getReasonGroupName(Outcome.CLIENT_DISCARD, 'ignored')).toBe(
       ClientDiscardReason.IGNORED
     );
+
+    expect(getReasonGroupName(Outcome.CLIENT_DISCARD, 'no_parent_span')).toBe(
+      ClientDiscardReason.NO_PARENT_SPAN
+    );
   });
 
   it('handles abuse limit reason types', () => {

--- a/static/app/views/organizationStats/getReasonGroupName.ts
+++ b/static/app/views/organizationStats/getReasonGroupName.ts
@@ -84,6 +84,7 @@ export enum ClientDiscardReason {
   INSUFFICIENT_DATA = 'insufficient_data',
   BACKPRESSURE = 'backpressure',
   IGNORED = 'ignored',
+  NO_PARENT_SPAN = 'no_parent_span',
 }
 
 enum RateLimitedReason {
@@ -238,6 +239,7 @@ function getClientDiscardReasonGroupName(reason: ClientDiscardReason): string {
     case ClientDiscardReason.INSUFFICIENT_DATA:
     case ClientDiscardReason.BACKPRESSURE:
     case ClientDiscardReason.IGNORED:
+    case ClientDiscardReason.NO_PARENT_SPAN:
       return reason;
     default:
       return 'other';


### PR DESCRIPTION
Adds the newly added `no_parent_span` client discard reason so that we can show it in usage stats. This is primarily intended to track how many spans our SDKs currently drop because of our decision to require an active parent span for the span to be recorded. (done analogously to https://github.com/getsentry/sentry/pull/106251). 

snuba: https://github.com/getsentry/snuba/pull/7866
ref: https://linear.app/getsentry/issue/SDK-1123/add-client-report-outcome-for-dropped-spans-because-of-missing-parent