### PR TITLE
fix(integrations): Hide Fix with Seer button on Slack unfurls

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -710,7 +710,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
                     )
                 )
 
-        if self._has_autofix:
+        if self._has_autofix and not self.is_unfurl:
             autofix_button = SeerSlackRenderer.render_autofix_button(group=self.group)
             # We have to coerce this since we're not using the proper SlackSDK client to emit this
             # notification yet, it just takes JSON.

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -1139,6 +1139,19 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         blocks = SlackIssuesMessageBuilder(group).build()
         assert not self._has_autofix_button(blocks)
 
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
+    @with_feature(
+        {
+            "organizations:gen-ai-features": True,
+            "organizations:seer-slack-workflows": True,
+        }
+    )
+    def test_autofix_button_hidden_on_unfurl(self, mock_quota: MagicMock) -> None:
+        self.organization.update_option("sentry:enable_seer_enhanced_alerts", True)
+        group = self.create_group(project=self.project)
+        blocks = SlackIssuesMessageBuilder(group, is_unfurl=True).build()
+        assert not self._has_autofix_button(blocks)
+
 
 class BuildGroupAttachmentReplaysTest(TestCase):
     @patch("sentry.models.group.Group.has_replays")


### PR DESCRIPTION
omit the fix w/ seer button for unfurls. it requires updating the message which is not possible for unfurl attachments. We'll just reserve it for issue alerts instead.

Fixes ISWF-2439