### PR TITLE
fix(aci): Link to issue page instead of specific event in automation history

### DIFF
--- a/static/app/views/automations/components/automationHistoryList.tsx
+++ b/static/app/views/automations/components/automationHistoryList.tsx
@@ -120,7 +120,7 @@ export function AutomationHistoryList({
             <SimpleTable.RowCell>
               <StyledLink
                 to={{
-                  pathname: `/organizations/${org.slug}/issues/${row.group.id}/events/${row.eventId}/`,
+                  pathname: `/organizations/${org.slug}/issues/${row.group.id}/`,
                   query: {project: row.group.project.id},
                 }}
               >


### PR DESCRIPTION
Closes ISWF-2451

The issue column in the automation history list was linking to `/issues/{groupId}/events/{eventId}/`, but the `eventId` stored in `WorkflowFireHistory` is not always the actual issue event ID. When `create_workflow_fire_histories` records a fire triggered via an `Activity`, it stores `activity.id` as the event ID

https://github.com/getsentry/sentry/blob/17128fb98fd87d13c2a4c81a309421693a9158e6/src/sentry/workflow_engine/processors/workflow_fire_history.py#L48-L52

IMO this is something that we may want to tighten up in the future, but for now I'm just going to link to the issue rather than the specific event. 