### PR TITLE
fix(metrics): Update selected metric on project change

### DIFF
--- a/static/app/views/explore/metrics/metricToolbar/index.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/index.tsx
@@ -51,6 +51,9 @@ export function MetricToolbar({
     setVisualize(visualize.replace({visible: !visualize.visible}));
   }, [setVisualize, visualize]);
   const setTraceMetric = useSetTraceMetric();
+  const aggregateMetricQueryCount = metricQueries.filter(q =>
+    isVisualizeFunction(q.queryParams.visualizes[0]!)
+  ).length;
 
   // We need at least one metric visualized, but equations should always
   // be removable.
@@ -98,7 +101,11 @@ export function MetricToolbar({
           {isVisualizeFunction(visualize) ? (
             <Fragment>
               <Flex minWidth={0}>
-                <MetricSelector traceMetric={traceMetric} onChange={setTraceMetric} />
+                <MetricSelector
+                  traceMetric={traceMetric}
+                  onChange={setTraceMetric}
+                  fallbackOnProjectChange={aggregateMetricQueryCount === 1}
+                />
               </Flex>
               <Flex gap="md" minWidth={0}>
                 <Flex flex="2 1 0" minWidth={0}>
@@ -153,7 +160,11 @@ export function MetricToolbar({
       {isVisualizeFunction(visualize) ? (
         <Fragment>
           <Flex minWidth={0}>
-            <MetricSelector traceMetric={traceMetric} onChange={setTraceMetric} />
+            <MetricSelector
+              traceMetric={traceMetric}
+              onChange={setTraceMetric}
+              fallbackOnProjectChange={aggregateMetricQueryCount === 1}
+            />
           </Flex>
           <Flex gap="md" minWidth={0}>
             <Flex flex="2 1 0" minWidth={0}>

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -20,10 +20,12 @@ import {Text} from '@sentry/scraps/text';
 import {DateTime} from 'sentry/components/dateTime';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Overlay, PositionWrapper} from 'sentry/components/overlay';
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {DEFAULT_DEBOUNCE_DURATION} from 'sentry/constants';
 import {IconCheckmark, IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {prettifyTagKey} from 'sentry/utils/fields';
+import {valueIsEqual} from 'sentry/utils/object/valueIsEqual';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useOverlay} from 'sentry/utils/useOverlay';
@@ -96,14 +98,20 @@ interface MetricSelectOption {
 export function MetricSelector({
   traceMetric,
   onChange,
+  fallbackOnProjectChange = false,
 }: {
   onChange: (traceMetric: TraceMetric) => void;
   traceMetric: TraceMetric;
+  fallbackOnProjectChange?: boolean;
 }) {
   const triggerId = useId();
 
   const organization = useOrganization();
+  const {selection} = usePageFilters();
   const hasMetricUnitsUI = useHasMetricUnitsUI();
+  const previousProjectsRef = useRef(selection.projects);
+  const pendingProjectValidationRef = useRef(false);
+  const sawFetchForPendingProjectRef = useRef(false);
 
   const searchRef = useRef<HTMLInputElement>(null);
   const listElementRef = useRef<HTMLUListElement>(null);
@@ -151,16 +159,8 @@ export function MetricSelector({
   // Always show the selected metric at the top of the list so it's easy to
   // find when the dropdown is reopened. Filter it out of the API results to
   // avoid duplication.
-  const metricOptions = useMemo((): MetricSelectOption[] => {
-    const selectedMetricValue = traceMetric.name
-      ? makeMetricSelectValue(
-          hasMetricUnitsUI
-            ? traceMetric
-            : {name: traceMetric.name, type: traceMetric.type}
-        )
-      : null;
-
-    const apiOptions =
+  const apiMetricOptions = useMemo(
+    (): MetricSelectOption[] =>
       metricOptionsData?.data?.map(option => ({
         label: option[TraceMetricKnownFieldKey.METRIC_NAME],
         value: makeMetricSelectValue({
@@ -188,20 +188,33 @@ export function MetricSelector({
             metricUnit={option[TraceMetricKnownFieldKey.METRIC_UNIT] ?? NONE_UNIT}
           />
         ),
-      })) ?? [];
+      })) ?? [],
+    [metricOptionsData?.data, hasMetricUnitsUI]
+  );
+  const previousApiMetricOptionsRef = useRef(apiMetricOptions);
+
+  const metricOptions = useMemo((): MetricSelectOption[] => {
+    const selectedMetricValue = traceMetric.name
+      ? makeMetricSelectValue(
+          hasMetricUnitsUI
+            ? traceMetric
+            : {name: traceMetric.name, type: traceMetric.type}
+        )
+      : null;
 
     // Prefer the API version of the selected metric (it has count/lastSeen),
     // falling back to the bare optionFromTraceMetric when the API hasn't
     // returned it (e.g. filtered by search or still loading).
     const selectedOption = selectedMetricValue
-      ? (apiOptions.find(o => o.value === selectedMetricValue) ?? optionFromTraceMetric)
+      ? (apiMetricOptions.find(o => o.value === selectedMetricValue) ??
+        optionFromTraceMetric)
       : null;
 
     return [
       ...(selectedOption ? [selectedOption] : []),
-      ...apiOptions.filter(o => o.value !== selectedMetricValue),
+      ...apiMetricOptions.filter(o => o.value !== selectedMetricValue),
     ];
-  }, [metricOptionsData, optionFromTraceMetric, traceMetric, hasMetricUnitsUI]);
+  }, [apiMetricOptions, optionFromTraceMetric, traceMetric, hasMetricUnitsUI]);
 
   // Auto-select the first metric when no metric is currently selected.
   // This handles the initial load case where the URL has no metric param.
@@ -214,6 +227,69 @@ export function MetricSelector({
       });
     }
   }, [metricOptions, onChange, traceMetric.name, hasMetricUnitsUI]);
+
+  useEffect(() => {
+    const projectsChanged = !valueIsEqual(
+      previousProjectsRef.current,
+      selection.projects
+    );
+
+    if (projectsChanged) {
+      previousProjectsRef.current = selection.projects;
+      pendingProjectValidationRef.current = fallbackOnProjectChange;
+      sawFetchForPendingProjectRef.current = false;
+    }
+
+    if (!pendingProjectValidationRef.current) {
+      previousApiMetricOptionsRef.current = apiMetricOptions;
+      return;
+    }
+
+    if (isFetching) {
+      sawFetchForPendingProjectRef.current = true;
+      previousApiMetricOptionsRef.current = apiMetricOptions;
+      return;
+    }
+
+    const apiMetricOptionsChanged =
+      previousApiMetricOptionsRef.current !== apiMetricOptions;
+
+    if (!sawFetchForPendingProjectRef.current && !apiMetricOptionsChanged) {
+      previousApiMetricOptionsRef.current = apiMetricOptions;
+      return;
+    }
+
+    pendingProjectValidationRef.current = false;
+    previousApiMetricOptionsRef.current = apiMetricOptions;
+
+    if (!traceMetric.name) {
+      return;
+    }
+
+    const metricExists = apiMetricOptions.some(
+      option =>
+        option.metricName === traceMetric.name && option.metricType === traceMetric.type
+    );
+
+    if (metricExists || !apiMetricOptions[0]) {
+      return;
+    }
+
+    onChange({
+      name: apiMetricOptions[0].metricName,
+      type: apiMetricOptions[0].metricType,
+      unit: hasMetricUnitsUI ? apiMetricOptions[0].metricUnit : undefined,
+    });
+  }, [
+    apiMetricOptions,
+    fallbackOnProjectChange,
+    hasMetricUnitsUI,
+    isFetching,
+    onChange,
+    selection.projects,
+    traceMetric.name,
+    traceMetric.type,
+  ]);
 
   const traceMetricSelectValue = makeMetricSelectValue(
     hasMetricUnitsUI ? traceMetric : {name: traceMetric.name, type: traceMetric.type}

--- a/static/app/views/explore/metrics/metricsTab.spec.tsx
+++ b/static/app/views/explore/metrics/metricsTab.spec.tsx
@@ -1,4 +1,5 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
 import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
 import {
   createTraceMetricFixtures,
@@ -6,6 +7,7 @@ import {
 } from 'sentry-fixture/tracemetrics';
 
 import {
+  act,
   render,
   screen,
   userEvent,
@@ -14,10 +16,12 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import type {DatePageFilterProps} from 'sentry/components/pageFilters/date/datePageFilter';
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {EQUATION_PREFIX} from 'sentry/utils/discover/fields';
 import {MetricsTabContent} from 'sentry/views/explore/metrics/metricsTab';
 import {MultiMetricsQueryParamsProvider} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
+import {TraceMetricKnownFieldKey} from 'sentry/views/explore/metrics/types';
 import {
   VisualizeEquation,
   VisualizeFunction,
@@ -64,34 +68,36 @@ describe('MetricsTabContent', () => {
     route: '/organizations/:orgId/explore/metrics/',
   };
 
-  beforeEach(() => {
-    MockApiClient.clearMockResponses();
-    trackAnalyticsMock.mockClear();
-    setupPageFilters();
-
-    const metricFixtures = createTraceMetricFixtures(organization, project, new Date());
-    setupTraceItemsMock(metricFixtures.detailedFixtures);
-    setupEventsMock(metricFixtures.detailedFixtures, [
+  function setupMetricQueryMocks(
+    metricFixtures: ReturnType<typeof createTraceMetricFixtures>['detailedFixtures'],
+    projectId: string
+  ) {
+    setupEventsMock(metricFixtures, [
       MockApiClient.matchQuery({
         dataset: 'tracemetrics',
         referrer: 'api.explore.metric-options',
+        project: [projectId],
       }),
     ]);
 
-    setupEventsMock(metricFixtures.detailedFixtures, [
+    setupEventsMock(metricFixtures, [
       MockApiClient.matchQuery({
         dataset: 'tracemetrics',
         referrer: 'api.explore.metric-aggregates-table',
+        project: [projectId],
       }),
     ]);
 
-    setupEventsMock(metricFixtures.detailedFixtures, [
+    setupEventsMock(metricFixtures, [
       MockApiClient.matchQuery({
         dataset: 'tracemetrics',
         referrer: 'api.explore.metric-samples-table',
+        project: [projectId],
       }),
     ]);
+  }
 
+  function setupSharedMocks() {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events-timeseries/`,
       method: 'GET',
@@ -147,6 +153,17 @@ describe('MetricsTabContent', () => {
       method: 'GET',
       body: {},
     });
+  }
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    trackAnalyticsMock.mockClear();
+    setupPageFilters();
+
+    const metricFixtures = createTraceMetricFixtures(organization, project, new Date());
+    setupTraceItemsMock(metricFixtures.detailedFixtures);
+    setupMetricQueryMocks(metricFixtures.detailedFixtures, project.id);
+    setupSharedMocks();
   });
 
   it('should add a metric when Add Metric button is clicked', async () => {
@@ -197,6 +214,120 @@ describe('MetricsTabContent', () => {
     // copies the last metric as a starting point
     expect(within(toolbars[2]!).getByRole('button', {name: 'foo'})).toBeInTheDocument();
     expect(screen.getAllByTestId('metric-panel')).toHaveLength(3);
+  });
+
+  it('keeps the selected metric when the new project still has it', async () => {
+    const otherProject = ProjectFixture({
+      id: '2',
+      slug: 'other-project',
+      hasTraceMetrics: true,
+    });
+
+    MockApiClient.clearMockResponses();
+    trackAnalyticsMock.mockClear();
+    setupPageFilters();
+
+    const initialFixtures = createTraceMetricFixtures(organization, project, new Date());
+    setupTraceItemsMock(initialFixtures.detailedFixtures);
+    setupMetricQueryMocks(initialFixtures.detailedFixtures, project.id);
+    setupSharedMocks();
+
+    render(
+      <ProviderWrapper>
+        <MetricsTabContent datePageFilterProps={datePageFilterProps} />
+      </ProviderWrapper>,
+      {
+        initialRouterConfig,
+        organization,
+      }
+    );
+
+    const toolbars = screen.getAllByTestId('metric-toolbar');
+    await waitFor(() => {
+      expect(within(toolbars[0]!).getByRole('button', {name: 'bar'})).toBeInTheDocument();
+    });
+
+    const otherProjectFixtures = createTraceMetricFixtures(
+      organization,
+      otherProject,
+      new Date()
+    ).detailedFixtures;
+
+    MockApiClient.clearMockResponses();
+    setupMetricQueryMocks(otherProjectFixtures, otherProject.id);
+    setupSharedMocks();
+
+    act(() => PageFiltersStore.updateProjects([Number(otherProject.id)], []));
+
+    await waitFor(() => {
+      expect(
+        within(screen.getAllByTestId('metric-toolbar')[0]!).getByRole('button', {
+          name: 'bar',
+        })
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('does not auto-rewrite metrics when multiple metric queries are selected', async () => {
+    const otherProject = ProjectFixture({
+      id: '2',
+      slug: 'other-project',
+      hasTraceMetrics: true,
+    });
+
+    MockApiClient.clearMockResponses();
+    trackAnalyticsMock.mockClear();
+    setupPageFilters();
+
+    const initialFixtures = createTraceMetricFixtures(organization, project, new Date());
+    setupTraceItemsMock(initialFixtures.detailedFixtures);
+    setupMetricQueryMocks(initialFixtures.detailedFixtures, project.id);
+    setupSharedMocks();
+
+    render(
+      <ProviderWrapper>
+        <MetricsTabContent datePageFilterProps={datePageFilterProps} />
+      </ProviderWrapper>,
+      {
+        initialRouterConfig,
+        organization,
+      }
+    );
+
+    let toolbars = screen.getAllByTestId('metric-toolbar');
+    await waitFor(() => {
+      expect(within(toolbars[0]!).getByRole('button', {name: 'bar'})).toBeInTheDocument();
+    });
+
+    const otherProjectFixtures = createTraceMetricFixtures(
+      organization,
+      otherProject,
+      new Date()
+    ).detailedFixtures.filter(
+      fixture => fixture[TraceMetricKnownFieldKey.METRIC_NAME] !== 'bar'
+    );
+
+    MockApiClient.clearMockResponses();
+    setupMetricQueryMocks(otherProjectFixtures, otherProject.id);
+    setupSharedMocks();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Add Metric'}));
+
+    toolbars = screen.getAllByTestId('metric-toolbar');
+    await userEvent.click(within(toolbars[1]!).getByRole('button', {name: 'bar'}));
+    await userEvent.click(within(toolbars[1]!).getByRole('option', {name: 'foo'}));
+
+    act(() => PageFiltersStore.updateProjects([Number(otherProject.id)], []));
+
+    await waitFor(() => {
+      const updatedToolbars = screen.getAllByTestId('metric-toolbar');
+      expect(
+        within(updatedToolbars[0]!).getByRole('button', {name: 'bar'})
+      ).toBeInTheDocument();
+      expect(
+        within(updatedToolbars[1]!).getByRole('button', {name: 'foo'})
+      ).toBeInTheDocument();
+    });
   });
 
   it('should fire analytics for metadata', async () => {


### PR DESCRIPTION
Update metrics explore to reconcile the selected metric when the project filter changes.

The selector now falls back to the first available metric when a single-metric view switches to a project that does not contain the current metric. It also leaves multi-metric selections alone and adds regression coverage around both behaviors.

This moved the reconciliation into the selector itself because that component owns the live, project-scoped metric options used by the toolbar.