### PR TITLE
[wip] perf(tests): Gate selenium screenshot/log collection on failure only

### DIFF
--- a/src/sentry/testutils/pytest/selenium.py
+++ b/src/sentry/testutils/pytest/selenium.py
@@ -456,11 +456,12 @@ def browser(request, live_server):
 
     yield driver
 
-    # dump console log to stdout, will be shown when test fails
-    for entry in driver.get_log("browser"):
-        sys.stderr.write("[browser console] ")
-        sys.stderr.write(repr(entry))
-        sys.stderr.write("\n")
+    rep_call = getattr(request.node, "rep_call", None)
+    if rep_call is not None and rep_call.failed:
+        for entry in driver.get_log("browser"):
+            sys.stderr.write("[browser console] ")
+            sys.stderr.write(repr(entry))
+            sys.stderr.write("\n")
     # Teardown Selenium.
     try:
         driver.quit()
@@ -472,10 +473,11 @@ def browser(request, live_server):
 def pytest_runtest_makereport(item, call):
     outcome = yield
     report = outcome.get_result()
+    setattr(item, f"rep_{report.when}", report)
     summary: MutableSequence[str] = []
     extra = getattr(report, "extra", [])
     driver = getattr(item, "_driver", None)
-    if driver is not None:
+    if driver is not None and report.failed and report.when == "call":
         _gather_url(item, report, driver, summary, extra)
         _gather_screenshot(item, report, driver, summary, extra)
         _gather_html(item, report, driver, summary, extra)

--- a/src/sentry/testutils/pytest/selenium.py
+++ b/src/sentry/testutils/pytest/selenium.py
@@ -456,6 +456,7 @@ def browser(request, live_server):
 
     yield driver
 
+    # dump console log to stdout, will be shown when test fails
     rep_call = getattr(request.node, "rep_call", None)
     if rep_call is not None and rep_call.failed:
         for entry in driver.get_log("browser"):


### PR DESCRIPTION
Gate acceptance test screenshot, HTML, browser log, and URL collection
in `pytest_runtest_makereport` to only run when the test actually fails
during the call phase. Previously this ran unconditionally for every
test phase (setup, call, teardown) — 624 collection rounds for 208
tests, most of which are wasted on passing tests.

Also gates the browser console log stderr dump in the `browser` fixture
teardown on failure, matching the original comment's intent ("will be
shown when test fails"). Uses the standard pytest `rep_call` pattern
to make the call phase report available in the fixture.

**Estimated savings:** Each collection round takes a screenshot, captures
full page HTML, and pulls browser logs — per test, per phase. With ~208
acceptance tests across 10 shards (~21 tests/shard), that's ~63
unnecessary collection rounds per shard eliminated (3 phases × 21 tests,
minus the handful that fail). At ~50-100ms per collection round
(screenshot is the expensive one), this saves roughly 1-3 seconds per
shard, or 10-30 seconds of total CI compute across all shards.

Changes:
- Add `setattr(item, f"rep_{report.when}", report)` in the hook to
  store phase results on the test node (standard pytest pattern)
- Gate `_gather_*` calls on `report.failed and report.when == "call"`
- Gate console log dump on `rep_call.failed`