### PR TITLE
fix(aci): Negative margin was too large

### DIFF
--- a/static/app/views/detectors/components/forms/automateSection.tsx
+++ b/static/app/views/detectors/components/forms/automateSection.tsx
@@ -133,5 +133,5 @@ export function AutomateSection({step}: {step?: number}) {
 const ButtonWrapper = styled(Flex)`
   border-top: 1px solid ${p => p.theme.tokens.border.primary};
   padding: ${p => p.theme.space.xl};
-  margin: -${p => p.theme.space.xl};
+  margin: -${p => p.theme.space.lg};
 `;


### PR DESCRIPTION
# Description
The negative margins here are not meant to match the padding of this element, but the padding of the parent element. This makes it consistent with the top level component.

### Before
the bar above "create new alert" is too long by a few pixels
<img width="1480" height="263" alt="Screenshot 2026-04-13 at 4 31 48 PM" src="https://github.com/user-attachments/assets/6539d95e-0689-4bad-ad3a-59caa3448493" />

### After
The negative margin lines up with the padding.
<img width="1487" height="282" alt="Screenshot 2026-04-14 at 10 20 24 AM" src="https://github.com/user-attachments/assets/c87e6628-f370-4bfe-8662-d67707950436" />