### PR TITLE
ref(dashboards): Set reasoning_effort to medium for dashboard generation

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
@@ -116,6 +116,7 @@ class OrganizationDashboardGenerateEndpoint(OrganizationEndpoint):
                 on_completion_hook=DashboardOnCompletionHook,
                 category_key="dashboard_generate",
                 category_value=str(organization.id),
+                reasoning_effort="medium",
             )
             run_id = client.start_run(
                 prompt=prompt,

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_generate.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_generate.py
@@ -47,6 +47,7 @@ class OrganizationDashboardGenerateEndpointTest(APITestCase):
             on_completion_hook=DashboardOnCompletionHook,
             category_key="dashboard_generate",
             category_value=str(self.organization.id),
+            reasoning_effort="medium",
         )
         mock_client.start_run.assert_called_once_with(
             prompt="Show me error rates by project",
@@ -148,6 +149,7 @@ class OrganizationDashboardGenerateEndpointTest(APITestCase):
             on_completion_hook=DashboardOnCompletionHook,
             category_key="dashboard_generate",
             category_value=str(self.organization.id),
+            reasoning_effort="medium",
         )
 
         # Verify on_page_context includes the current dashboard JSON


### PR DESCRIPTION
## Summary
- Sets `reasoning_effort="medium"` on the `SeerExplorerClient` used for agentic dashboard generation
- Seer's Explorer module defaults reasoning_effort to `"low"` for all intelligence levels — this bumps dashboard generation to `"medium"` for better output quality

## Test plan
- Updated existing tests to assert the new `reasoning_effort` kwarg is passed through