### PR TITLE
ref(explorer): Set reasoning_effort to medium for explorer chat

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
@@ -181,6 +181,7 @@ class OrganizationSeerExplorerChatEndpoint(OrganizationEndpoint):
                 is_interactive=True,
                 enable_coding=enable_coding,
                 enable_code_mode_tools=enable_code_mode_tools,
+                reasoning_effort="medium",
             )
             if run_id:
                 # Continue existing conversation

--- a/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
@@ -74,6 +74,7 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
             is_interactive=True,
             enable_coding=False,
             enable_code_mode_tools=False,
+            reasoning_effort="medium",
         )
         mock_client.start_run.assert_called_once_with(
             prompt="What is this error about?",
@@ -110,6 +111,7 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
                 is_interactive=True,
                 enable_coding=feature_enabled and option_enabled,
                 enable_code_mode_tools=False,
+                reasoning_effort="medium",
             )
 
     @patch("sentry.seer.endpoints.organization_seer_explorer_chat.SeerExplorerClient")
@@ -132,6 +134,7 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
             is_interactive=True,
             enable_coding=False,
             enable_code_mode_tools=False,
+            reasoning_effort="medium",
         )
         mock_client.continue_run.assert_called_once_with(
             run_id=789,
@@ -164,6 +167,7 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
                 is_interactive=True,
                 enable_coding=feature_enabled and option_enabled,
                 enable_code_mode_tools=False,
+                reasoning_effort="medium",
             )
 
     @patch("sentry.seer.endpoints.organization_seer_explorer_chat.SeerExplorerClient")


### PR DESCRIPTION
## Summary
- Sets `reasoning_effort="medium"` on the interactive explorer chat `SeerExplorerClient`, up from the seer-side default of `"low"`
- Paired with getsentry/seer#5775 which adds `reasoning_effort` as a dimension in satisfaction metrics so we can measure the impact

**Note on bugbot comment:** `reasoning_effort` is only sent on `start_run`, not `continue_run`. This is fine because seer persists `reasoning_effort` in the `ExplorerState` at `start_run` time and reads it from the stored state on subsequent requests — `continue_run` does not read `reasoning_effort` from the request payload.

## Test plan
- [ ] Monitor satisfaction metrics after deploy, faceting by `reasoning_effort` to compare medium vs low