### PR TITLE
fix(dashboards): Hide legend alias option for details widget type

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.spec.tsx
@@ -114,6 +114,35 @@ describe('QueryFilterBuilder', () => {
     expect(await screen.findByPlaceholderText('Legend Alias')).toBeInTheDocument();
   });
 
+  it('does not render a legend alias input for the details widget', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <WidgetBuilderQueryFilterBuilder
+          onQueryConditionChange={() => {}}
+          validatedWidgetResponse={{} as any}
+        />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: '/mock-pathname/',
+            query: {
+              query: [],
+              dataset: WidgetType.SPANS,
+              displayType: DisplayType.DETAILS,
+            },
+          },
+        },
+      }
+    );
+
+    expect(
+      await screen.findByPlaceholderText('Search for spans, users, tags, and more')
+    ).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('Legend Alias')).not.toBeInTheDocument();
+  });
+
   it('limits number of filter queries to 3', async () => {
     render(
       <WidgetBuilderProvider>

--- a/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.spec.tsx
@@ -143,6 +143,35 @@ describe('QueryFilterBuilder', () => {
     expect(screen.queryByPlaceholderText('Legend Alias')).not.toBeInTheDocument();
   });
 
+  it('does not allow adding multiple filters for the details widget', async () => {
+    render(
+      <WidgetBuilderProvider>
+        <WidgetBuilderQueryFilterBuilder
+          onQueryConditionChange={() => {}}
+          validatedWidgetResponse={{} as any}
+        />
+      </WidgetBuilderProvider>,
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: '/mock-pathname/',
+            query: {
+              query: [],
+              dataset: WidgetType.SPANS,
+              displayType: DisplayType.DETAILS,
+            },
+          },
+        },
+      }
+    );
+
+    expect(
+      await screen.findByPlaceholderText('Search for spans, users, tags, and more')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('+ Add Filter')).not.toBeInTheDocument();
+  });
+
   it('limits number of filter queries to 3', async () => {
     render(
       <WidgetBuilderProvider>

--- a/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
@@ -76,10 +76,12 @@ export function WidgetBuilderQueryFilterBuilder({
   // - Tables: no legend (data shown in rows)
   // - Big Numbers: no legend (single value)
   // - Bar (Categorical): no aliases (only one filter allowed, no point aliasing it)
+  // - Details: no legend (single query, data shown in key-value pairs)
   const canHaveAlias =
     state.displayType !== DisplayType.TABLE &&
     state.displayType !== DisplayType.BIG_NUMBER &&
-    state.displayType !== DisplayType.CATEGORICAL_BAR;
+    state.displayType !== DisplayType.CATEGORICAL_BAR &&
+    state.displayType !== DisplayType.DETAILS;
 
   const onAddSearchConditions = () => {
     // TODO: after hook gets updated with different dispatch types, change this part

--- a/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/queryFilterBuilder.tsx
@@ -63,10 +63,12 @@ export function WidgetBuilderQueryFilterBuilder({
   // - Tables: only one filter (no overlay concept)
   // - Big Numbers: only one filter (single value display)
   // - Bar (Categorical): only one filter allowed, to simplify product for now
+  // - Details: only one filter (single query, key-value display)
   const canAddSearchConditions =
     state.displayType !== DisplayType.TABLE &&
     state.displayType !== DisplayType.BIG_NUMBER &&
     state.displayType !== DisplayType.CATEGORICAL_BAR &&
+    state.displayType !== DisplayType.DETAILS &&
     state.query &&
     state.query.length < 3;
 


### PR DESCRIPTION
Hide the legend alias input in the query filter builder when the details
widget type is selected. The details widget displays data as key-value
pairs with a single query, so a legend alias serves no purpose — similar
to tables and big numbers which are already excluded.

Adds a test confirming the alias input is not rendered for details widgets.