### PR TITLE
feat(tracemetrics): Disable the samples panel for equations

### DIFF
--- a/static/app/views/explore/metrics/metricInfoTabs/index.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/index.tsx
@@ -19,6 +19,7 @@ import {
   useSetQueryParamsMode,
 } from 'sentry/views/explore/queryParams/context';
 import {Mode} from 'sentry/views/explore/queryParams/mode';
+import {isVisualizeEquation} from 'sentry/views/explore/queryParams/visualize';
 
 interface MetricInfoTabsProps {
   orientation: TableOrientation;
@@ -52,7 +53,24 @@ export function MetricInfoTabs({
     >
       {orientation === 'right' || visualize.visible ? (
         <Flex direction="row" justify="between" align="center" paddingRight="xl">
-          <MetricInfoTabList orientation={orientation} contentsHidden={contentsHidden} />
+          <TabListWrapper orientation={orientation}>
+            <TabList variant="floating">
+              <TabList.Item
+                key={Mode.SAMPLES}
+                disabled={contentsHidden || isVisualizeEquation(visualize)}
+                tooltip={{
+                  title: isVisualizeEquation(visualize)
+                    ? t('Samples are not available for equations')
+                    : undefined,
+                }}
+              >
+                {t('Samples')}
+              </TabList.Item>
+              <TabList.Item key={Mode.AGGREGATE} disabled={contentsHidden}>
+                {t('Aggregates')}
+              </TabList.Item>
+            </TabList>
+          </TabListWrapper>
           {additionalActions}
         </Flex>
       ) : null}
@@ -75,26 +93,5 @@ export function MetricInfoTabs({
         </BodyContainer>
       ) : null}
     </TabStateProvider>
-  );
-}
-
-function MetricInfoTabList({
-  orientation,
-  contentsHidden,
-}: {
-  orientation: TableOrientation;
-  contentsHidden?: boolean;
-}) {
-  return (
-    <TabListWrapper orientation={orientation}>
-      <TabList variant="floating">
-        <TabList.Item key={Mode.SAMPLES} disabled={contentsHidden}>
-          {t('Samples')}
-        </TabList.Item>
-        <TabList.Item key={Mode.AGGREGATE} disabled={contentsHidden}>
-          {t('Aggregates')}
-        </TabList.Item>
-      </TabList>
-    </TabListWrapper>
   );
 }

--- a/static/app/views/explore/metrics/metricQuery.spec.tsx
+++ b/static/app/views/explore/metrics/metricQuery.spec.tsx
@@ -211,7 +211,7 @@ describe('defaultMetricQuery', () => {
       metric: {name: '', type: ''},
       queryParams: new ReadableQueryParams({
         extrapolate: true,
-        mode: Mode.SAMPLES,
+        mode: Mode.AGGREGATE,
         query: '',
         cursor: '',
         fields: ['id', 'timestamp'],

--- a/static/app/views/explore/metrics/metricQuery.tsx
+++ b/static/app/views/explore/metrics/metricQuery.tsx
@@ -118,7 +118,7 @@ export function defaultMetricQuery({
     metric: {name: '', type: ''},
     queryParams: new ReadableQueryParams({
       extrapolate: true,
-      mode: Mode.SAMPLES,
+      mode: type === 'equation' ? Mode.AGGREGATE : Mode.SAMPLES,
       query: defaultQuery(),
 
       cursor: '',


### PR DESCRIPTION
Samples with equations doesn't really make sense, we're disabling it with a tooltip to explain that.