### PR TITLE
fix(dashoards): Fix table widget column widths snapping after user resize

### DIFF
--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -658,11 +658,6 @@ function TableComponent({
           tableData={tableData}
           frameless
           scrollable
-          fit={
-            widget?.tableWidths?.length && widget?.tableWidths?.length > 0
-              ? undefined
-              : 'max-content'
-          }
           aliases={aliases}
           onChangeSort={onWidgetTableSort}
           sort={sort}


### PR DESCRIPTION
Fixes an issue where table column widths "snap" to fit the container the first time a user resizes a column. This was due to the `fit` prop. Initially widgets do not have a `widget?.tableWidths` until manually resized by the user, which causes the `fit` prop to change. Use `undefined` instead of `max-content` since `max-content` introduces horizontal scroll by default