### PR TITLE
feat(integrations): Log integration_id and endpoint in integrations.http_response

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -94,6 +94,12 @@ class GitHubReaction(StrEnum):
     EYES = "eyes"
 
 
+class GitHubApiEndpoint(StrEnum):
+    COMPARE_COMMITS = "compare_commits"
+    LIST_COMMITS = "list_commits"
+    GET_COMMIT = "get_commit"
+
+
 class GithubSetupApiClient(IntegrationProxyClient):
     """
     API Client that doesn't require an installation.
@@ -342,7 +348,11 @@ class GitHubBaseClient(
         see https://docs.github.com/en/rest/commits/commits#list-commits-on-a-repository
         using end_sha as parameter.
         """
-        return self.get_cached(f"/repos/{repo}/commits", params={"sha": end_sha})
+        return self.get_cached(
+            f"/repos/{repo}/commits",
+            params={"sha": end_sha},
+            endpoint=GitHubApiEndpoint.LIST_COMMITS,
+        )
 
     def compare_commits(self, repo: str, start_sha: str, end_sha: str) -> list[Any]:
         """
@@ -352,6 +362,7 @@ class GitHubBaseClient(
         return self._get_with_pagination(
             f"/repos/{repo}/compare/{start_sha}...{end_sha}",
             response_key="commits",
+            endpoint=GitHubApiEndpoint.COMPARE_COMMITS,
         )
 
     def repo_hooks(self, repo: str) -> Sequence[Any]:
@@ -364,13 +375,15 @@ class GitHubBaseClient(
         """
         https://docs.github.com/en/rest/commits/commits#list-commits
         """
-        return self.get(f"/repos/{repo}/commits")
+        return self.get(f"/repos/{repo}/commits", endpoint=GitHubApiEndpoint.LIST_COMMITS)
 
     def get_commit(self, repo: str, sha: str) -> Any:
         """
         https://docs.github.com/en/rest/commits/commits#get-a-commit
         """
-        return self.get_cached(f"/repos/{repo}/commits/{sha}")
+        return self.get_cached(
+            f"/repos/{repo}/commits/{sha}", endpoint=GitHubApiEndpoint.GET_COMMIT
+        )
 
     def get_installation_info(self, installation_id: int | str) -> Any:
         """
@@ -601,7 +614,11 @@ class GitHubBaseClient(
         return self._get_with_pagination(f"/repos/{repo}/assignees")
 
     def _get_with_pagination(
-        self, path: str, response_key: str | None = None, page_number_limit: int | None = None
+        self,
+        path: str,
+        response_key: str | None = None,
+        page_number_limit: int | None = None,
+        endpoint: GitHubApiEndpoint | None = None,
     ) -> list[Any]:
         """
         Github uses the Link header to provide pagination links. Github
@@ -622,7 +639,7 @@ class GitHubBaseClient(
             output: list[dict[str, Any]] = []
 
             page_number = 1
-            resp = self.get(path, params={"per_page": self.page_size})
+            resp = self.get(path, params={"per_page": self.page_size}, endpoint=endpoint)
             output.extend(resp) if not response_key else output.extend(resp[response_key])
             next_link = get_next_link(resp)
 
@@ -631,7 +648,7 @@ class GitHubBaseClient(
             while next_link and page_number < page_number_limit:
                 # If a per_page is specified, GitHub preserves the per_page value
                 # in the response headers.
-                resp = self.get(next_link)
+                resp = self.get(next_link, endpoint=endpoint)
                 output.extend(resp) if not response_key else output.extend(resp[response_key])
 
                 next_link = get_next_link(resp)

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -96,8 +96,9 @@ class GitHubReaction(StrEnum):
 
 class GitHubApiEndpoint(StrEnum):
     COMPARE_COMMITS = "compare_commits"
-    LIST_COMMITS = "list_commits"
+    GET_COMMITS = "get_commits"
     GET_COMMIT = "get_commit"
+    CHECK_FILE = "check_file"
 
 
 class GithubSetupApiClient(IntegrationProxyClient):
@@ -351,7 +352,7 @@ class GitHubBaseClient(
         return self.get_cached(
             f"/repos/{repo}/commits",
             params={"sha": end_sha},
-            endpoint=GitHubApiEndpoint.LIST_COMMITS,
+            endpoint=GitHubApiEndpoint.GET_COMMITS,
         )
 
     def compare_commits(self, repo: str, start_sha: str, end_sha: str) -> list[Any]:
@@ -375,7 +376,7 @@ class GitHubBaseClient(
         """
         https://docs.github.com/en/rest/commits/commits#list-commits
         """
-        return self.get(f"/repos/{repo}/commits", endpoint=GitHubApiEndpoint.LIST_COMMITS)
+        return self.get(f"/repos/{repo}/commits", endpoint=GitHubApiEndpoint.GET_COMMITS)
 
     def get_commit(self, repo: str, sha: str) -> Any:
         """
@@ -778,7 +779,11 @@ class GitHubBaseClient(
         return self._get_with_pagination(f"/repos/{owner}/{repo}/labels")
 
     def check_file(self, repo: Repository, path: str, version: str | None) -> object | None:
-        return self.head_cached(path=f"/repos/{repo.name}/contents/{path}", params={"ref": version})
+        return self.head_cached(
+            path=f"/repos/{repo.name}/contents/{path}",
+            params={"ref": version},
+            endpoint=GitHubApiEndpoint.CHECK_FILE,
+        )
 
     def get_file(
         self, repo: Repository, path: str, ref: str | None, codeowners: bool = False

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -91,8 +91,6 @@ class BaseApiClient:
         extra: Mapping[str, str] | None = None,
     ) -> None:
         tags: dict[str, str | int] = {self.integration_type: self.name, "status": code}
-        if extra is not None and (endpoint := extra.get("endpoint")) is not None:
-            tags["endpoint"] = endpoint
         metrics.incr(
             f"{self.metrics_prefix}.http_response",
             sample_rate=1.0,
@@ -229,8 +227,6 @@ class BaseApiClient:
         full_url = self.build_url(path)
 
         request_tags: dict[str, str] = {self.integration_type: self.name}
-        if endpoint is not None:
-            request_tags["endpoint"] = endpoint
         metrics.incr(
             f"{self.metrics_prefix}.http_request",
             sample_rate=1.0,

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -90,10 +90,13 @@ class BaseApiClient:
         resp: Response | None = None,
         extra: Mapping[str, str] | None = None,
     ) -> None:
+        tags: dict[str, str | int] = {self.integration_type: self.name, "status": code}
+        if extra is not None and (endpoint := extra.get("endpoint")) is not None:
+            tags["endpoint"] = endpoint
         metrics.incr(
             f"{self.metrics_prefix}.http_response",
             sample_rate=1.0,
-            tags={self.integration_type: self.name, "status": code},
+            tags=tags,
         )
 
         log_params = {
@@ -175,6 +178,7 @@ class BaseApiClient:
         ignore_webhook_errors: bool = False,
         prepared_request: PreparedRequest | None = None,
         raw_response: Literal[True] = ...,
+        endpoint: str | None = None,
     ) -> Response: ...
 
     @overload
@@ -193,6 +197,7 @@ class BaseApiClient:
         ignore_webhook_errors: bool = False,
         prepared_request: PreparedRequest | None = None,
         raw_response: bool = ...,
+        endpoint: str | None = None,
     ) -> Any: ...
 
     def _request(
@@ -210,6 +215,7 @@ class BaseApiClient:
         ignore_webhook_errors: bool = False,
         prepared_request: PreparedRequest | None = None,
         raw_response: bool = False,
+        endpoint: str | None = None,
     ) -> Any | Response:
         if allow_redirects is None:
             allow_redirects = self.allow_redirects
@@ -222,10 +228,13 @@ class BaseApiClient:
 
         full_url = self.build_url(path)
 
+        request_tags: dict[str, str] = {self.integration_type: self.name}
+        if endpoint is not None:
+            request_tags["endpoint"] = endpoint
         metrics.incr(
             f"{self.metrics_prefix}.http_request",
             sample_rate=1.0,
-            tags={self.integration_type: self.name},
+            tags=request_tags,
         )
 
         if self.integration_type:
@@ -248,6 +257,8 @@ class BaseApiClient:
             extra[self.integration_type] = self.name
         if self.integration_id is not None:
             extra["integration_id"] = str(self.integration_id)
+        if endpoint is not None:
+            extra["endpoint"] = endpoint
 
         try:
             with self.build_session() as session:

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -246,6 +246,8 @@ class BaseApiClient:
         # It shouldn't be possible for integration_type to be null.
         if self.integration_type:
             extra[self.integration_type] = self.name
+        if self.integration_id is not None:
+            extra["integration_id"] = str(self.integration_id)
 
         try:
             with self.build_session() as session:

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -251,8 +251,9 @@ class BaseApiClient:
         # It shouldn't be possible for integration_type to be null.
         if self.integration_type:
             extra[self.integration_type] = self.name
-        if self.integration_id is not None:
-            extra["integration_id"] = str(self.integration_id)
+        integration_id = getattr(self, "integration_id", None)
+        if integration_id is not None:
+            extra["integration_id"] = str(integration_id)
         if endpoint is not None:
             extra["endpoint"] = endpoint
 

--- a/src/sentry_plugins/client.py
+++ b/src/sentry_plugins/client.py
@@ -52,7 +52,7 @@ class AuthApiClient(ApiClient):
         headers: Mapping[str, str] | None = None,
         data: Mapping[str, str] | None = None,
         params: Mapping[str, str] | None = None,
-        auth: tuple[str, str] | str | None = None,
+        auth: tuple[str, str] | None = None,
         json: bool = True,
         allow_text: bool = False,
         allow_redirects: bool | None = None,
@@ -60,6 +60,7 @@ class AuthApiClient(ApiClient):
         ignore_webhook_errors: bool = False,
         prepared_request: PreparedRequest | None = None,
         raw_response: Literal[True] = ...,
+        endpoint: str | None = None,
     ) -> Response: ...
 
     @overload
@@ -78,6 +79,7 @@ class AuthApiClient(ApiClient):
         ignore_webhook_errors: bool = False,
         prepared_request: PreparedRequest | None = None,
         raw_response: bool = ...,
+        endpoint: str | None = None,
     ) -> Any: ...
 
     def _request(self, method, path, **kwargs):

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -167,6 +167,43 @@ class GitHubApiClientTest(TestCase):
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
+    def test_compare_commits_tracks_compare_endpoint(self, get_jwt) -> None:
+        with mock.patch.object(
+            self.github_client, "_get_with_pagination"
+        ) as mock_get_with_pagination:
+            self.github_client.compare_commits(self.repo.name, "abc", "xyz")
+
+        mock_get_with_pagination.assert_called_once_with(
+            f"/repos/{self.repo.name}/compare/abc...xyz",
+            response_key="commits",
+            endpoint="compare_commits",
+        )
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_get_last_commits_tracks_list_commits_endpoint(self, get_jwt) -> None:
+        with mock.patch.object(self.github_client, "get_cached") as mock_get_cached:
+            self.github_client.get_last_commits(self.repo.name, "abc")
+
+        mock_get_cached.assert_called_once_with(
+            f"/repos/{self.repo.name}/commits",
+            params={"sha": "abc"},
+            endpoint="list_commits",
+        )
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_get_commit_tracks_get_commit_endpoint(self, get_jwt) -> None:
+        with mock.patch.object(self.github_client, "get_cached") as mock_get_cached:
+            self.github_client.get_commit(self.repo.name, "abc")
+
+        mock_get_cached.assert_called_once_with(
+            f"/repos/{self.repo.name}/commits/abc",
+            endpoint="get_commit",
+        )
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
     def test_get_with_pagination(self, get_jwt) -> None:
         url = f"https://api.github.com/repos/{self.repo.name}/assignees?per_page={self.github_client.page_size}"
 

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -13,7 +13,7 @@ from responses import matchers
 
 from sentry.constants import ObjectStatus
 from sentry.integrations.github.blame import create_blame_query, generate_file_path_mapping
-from sentry.integrations.github.client import GitHubApiClient, GitHubReaction
+from sentry.integrations.github.client import GitHubApiClient, GitHubApiEndpoint, GitHubReaction
 from sentry.integrations.github.constants import GITHUB_API_ACCEPT_HEADER
 from sentry.integrations.github.integration import GitHubIntegration
 from sentry.integrations.source_code_management.commit_context import (
@@ -124,6 +124,18 @@ class GitHubApiClientTest(TestCase):
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
+    def test_check_file_tracks_check_file_endpoint(self, get_jwt) -> None:
+        with mock.patch.object(self.github_client, "head_cached") as mock_head_cached:
+            self.github_client.check_file(self.repo, "README.md", "master")
+
+        mock_head_cached.assert_called_once_with(
+            path=f"/repos/{self.repo.name}/contents/README.md",
+            params={"ref": "master"},
+            endpoint=GitHubApiEndpoint.CHECK_FILE,
+        )
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
     def test_check_no_file(self, get_jwt) -> None:
         path = "src/santry/integrations/github/client.py"
         version = "master"
@@ -181,14 +193,14 @@ class GitHubApiClientTest(TestCase):
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
-    def test_get_last_commits_tracks_list_commits_endpoint(self, get_jwt) -> None:
+    def test_get_last_commits_tracks_get_commits_endpoint(self, get_jwt) -> None:
         with mock.patch.object(self.github_client, "get_cached") as mock_get_cached:
             self.github_client.get_last_commits(self.repo.name, "abc")
 
         mock_get_cached.assert_called_once_with(
             f"/repos/{self.repo.name}/commits",
             params={"sha": "abc"},
-            endpoint="list_commits",
+            endpoint=GitHubApiEndpoint.GET_COMMITS,
         )
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")

--- a/tests/sentry/shared_integrations/client/test_base.py
+++ b/tests/sentry/shared_integrations/client/test_base.py
@@ -100,4 +100,26 @@ class BaseApiClientTest(TestCase):
         api_client.get("https://example.com/get")
 
         assert mock_track_response_data.call_count == 1
-        assert mock_track_response_data.mock_calls[0].kwargs["extra"]["integration_id"] == 123
+        assert mock_track_response_data.mock_calls[0].kwargs["extra"]["integration_id"] == "123"
+
+    @patch("sentry.shared_integrations.client.base.metrics.incr")
+    @patch.object(Session, "send")
+    def test_request_and_response_metrics_include_endpoint(
+        self, mock_session_send, mock_metrics_incr
+    ) -> None:
+        response = MagicMock()
+        response.status_code = 204
+        mock_session_send.return_value = response
+
+        self.api_client.get("https://example.com/get", endpoint="compare_commits")
+
+        mock_metrics_incr.assert_any_call(
+            "None.http_request",
+            sample_rate=1.0,
+            tags={"integration": "base", "endpoint": "compare_commits"},
+        )
+        mock_metrics_incr.assert_any_call(
+            "None.http_response",
+            sample_rate=1.0,
+            tags={"integration": "base", "status": 204, "endpoint": "compare_commits"},
+        )

--- a/tests/sentry/shared_integrations/client/test_base.py
+++ b/tests/sentry/shared_integrations/client/test_base.py
@@ -104,7 +104,7 @@ class BaseApiClientTest(TestCase):
 
     @patch("sentry.shared_integrations.client.base.metrics.incr")
     @patch.object(Session, "send")
-    def test_request_and_response_metrics_include_endpoint(
+    def test_request_and_response_metrics_do_not_include_endpoint(
         self, mock_session_send, mock_metrics_incr
     ) -> None:
         response = MagicMock()
@@ -116,10 +116,10 @@ class BaseApiClientTest(TestCase):
         mock_metrics_incr.assert_any_call(
             "None.http_request",
             sample_rate=1.0,
-            tags={"integration": "base", "endpoint": "compare_commits"},
+            tags={"integration": "base"},
         )
         mock_metrics_incr.assert_any_call(
             "None.http_response",
             sample_rate=1.0,
-            tags={"integration": "base", "status": 204, "endpoint": "compare_commits"},
+            tags={"integration": "base", "status": 204},
         )

--- a/tests/sentry/shared_integrations/client/test_base.py
+++ b/tests/sentry/shared_integrations/client/test_base.py
@@ -82,3 +82,22 @@ class BaseApiClientTest(TestCase):
         self.api_client.get("https://172.31.255.255")
         assert mock_session_send.call_count == 1
         assert mock_session_send.mock_calls[0].kwargs["timeout"] == 30
+
+    @patch.object(BaseApiClient, "track_response_data")
+    @patch.object(Session, "send")
+    def test_track_response_data_includes_integration_id(
+        self, mock_session_send, mock_track_response_data
+    ) -> None:
+        response = MagicMock()
+        response.status_code = 204
+        mock_session_send.return_value = response
+
+        class Client(BaseApiClient):
+            integration_type = "integration"
+            integration_name = "base"
+
+        api_client = Client(integration_id=123)
+        api_client.get("https://example.com/get")
+
+        assert mock_track_response_data.call_count == 1
+        assert mock_track_response_data.mock_calls[0].kwargs["extra"]["integration_id"] == 123


### PR DESCRIPTION
This will help us see how often an API is being hit for a specific integration.

It adds `integration_id` and `endpoint` to `%s.http_response` logs [[1](https://github.com/getsentry/sentry/blob/286eb4433c70cab9a5eab823db2f64512c8f2941/src/sentry/shared_integrations/client/base.py#L120-L121)]

This can be used to evaluate what endpoints a specific integration is calling, thus, help troubleshoot a customer's usage.