### PR TITLE
fix(arithmetic): Handle quoted search args in arithmetic

### DIFF
--- a/src/sentry/discover/arithmetic.py
+++ b/src/sentry/discover/arithmetic.py
@@ -122,15 +122,19 @@ divide               = ~r"[/÷]"
 
 function_value         = function_name open_paren spaces function_args? spaces closed_paren
 function_args          = aggregate_param (spaces comma spaces aggregate_param)*
-aggregate_param        = quoted_aggregate_param / raw_aggregate_param
+aggregate_param        = backtick_search_param / quoted_aggregate_param / raw_aggregate_param
 raw_aggregate_param    = ~r"[^()\t\n, \"]+"
 quoted_aggregate_param = '"' ('\\"' / ~r'[^\t\n\"]')* '"'
+backtick_search_param  = backtick search_value backtick
 # Different from a field value, since a function arg may not be a valid field
 function_name          = ~r"[a-zA-Z_0-9]+"
 numeric_value          = ~r"[+-]?[0-9]+\.?[0-9]*"
 field_value            = ~r"[a-zA-Z_\.]+"
+# Search value is any text except a backtick which will exit back to normal parsing
+search_value           = ~r"[^`]*"
 
 comma                = ","
+backtick             = "`"
 open_paren           = "("
 closed_paren         = ")"
 spaces               = " "*

--- a/tests/sentry/discover/test_arithmetic.py
+++ b/tests/sentry/discover/test_arithmetic.py
@@ -263,6 +263,9 @@ def test_field_values(a, op, b) -> None:
             "opportunity_score(measurements.score.fcp)",
         ),
         (100, "*", "opportunity_score(measurements.score.cls)"),
+        ("count_if(`test:foo`)", "+", "ttfd_contribution_rate()"),
+        ('count_if(`test:"blah blah"`)', "+", "ttfd_contribution_rate()"),
+        ('count_if(`test:"blah blah"`,test, test)', "+", "sum_if(`test:\"blah'blah'blah\"`)"),
     ],
 )
 def test_function_values(lhs, op, rhs) -> None:

--- a/tests/snuba/api/endpoints/test_organization_events_trace_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_trace_metrics.py
@@ -781,6 +781,40 @@ class OrganizationEventsTraceMetricsEndpointTest(OrganizationEventsEndpointTestB
         assert len(data) == 1
         assert data[0]["count_if(`release:abcdef`,value,request_duration,distribution,none)"] == 1
 
+    def test_count_if_with_quotes(self):
+        trace_metrics = [
+            self.create_trace_metric("request_duration", 200.0, "distribution", metric_unit="none"),
+            self.create_trace_metric(
+                "request_duration",
+                200.0,
+                "distribution",
+                metric_unit="none",
+                attributes={"agent_name": "Agent Run"},
+            ),
+        ]
+        self.store_eap_items(trace_metrics)
+
+        response = self.do_request(
+            {
+                "field": [
+                    'equation|count_if(`agent_name:"Agent Run"`,value,request_duration,distribution,none)'
+                ],
+                "project": self.project.id,
+                "dataset": self.dataset,
+                "statsPeriod": "10m",
+            }
+        )
+        assert response.status_code == 200, response.content
+        data = response.data["data"]
+
+        assert len(data) == 1
+        assert (
+            data[0][
+                'equation|count_if(`agent_name:"Agent Run"`,value,request_duration,distribution,none)'
+            ]
+            == 1
+        )
+
     def test_count_if_in_equation(self):
         trace_metrics = [
             self.create_trace_metric("request_duration", 200.0, "distribution", metric_unit="none"),


### PR DESCRIPTION
- Because the search args in arithmetic wasn't aware of these backticks it couldn't handle the case where they would have `"` in them. This updates the grammar so this is handled and adds corresponding test cases