### PR TITLE
feat(navigation): Hide Insights sidebar behind feature flag

### DIFF
--- a/static/app/views/navigation/index.desktop.spec.tsx
+++ b/static/app/views/navigation/index.desktop.spec.tsx
@@ -211,6 +211,27 @@ describe('desktop navigation', () => {
       expect(links[5]).toHaveAttribute('href', '/settings/org-slug/');
     });
 
+    it('hides Insights nav item when insights-to-dashboards-ui-rollout is enabled', () => {
+      render(
+        <PrimaryNavigationContextProvider>
+          <Navigation />
+        </PrimaryNavigationContextProvider>,
+        navigationContext({
+          organization: {
+            features: [...ALL_AVAILABLE_FEATURES, 'insights-to-dashboards-ui-rollout'],
+          },
+        })
+      );
+
+      const primaryNav = screen.getByRole('navigation', {name: 'Primary Navigation'});
+      const links = within(primaryNav).getAllByRole('link');
+      const linkNames = links.map(
+        link => link.getAttribute('aria-label') ?? link.textContent
+      );
+
+      expect(linkNames).not.toContain('Insights');
+    });
+
     it('primary navigation marks exactly one link as active for the current route', () => {
       render(
         <PrimaryNavigationContextProvider>

--- a/static/app/views/navigation/navigation.tsx
+++ b/static/app/views/navigation/navigation.tsx
@@ -226,33 +226,35 @@ export function PrimaryNavigationItems({listRef}: PrimaryNavigationItemsProps) {
         </NavigationTourElement>
       </Feature>
 
-      <Feature features={['performance-view']}>
-        <NavigationTourElement
-          id={NavigationTour.INSIGHTS}
-          title={null}
-          description={null}
-        >
-          {tourProps => (
-            <PrimaryNavigation.ListItem>
-              <PrimaryNavigation.Link
-                to={`/${prefix}/insights/`}
-                analyticsKey="insights"
-                label={t('Insights')}
-                {...mergeProps(
-                  makeNavigationItemProps(
-                    'insights',
-                    `/${prefix}/insights/`,
-                    `/${prefix}/insights`
-                  ),
-                  tourProps
-                )}
-              >
-                <IconGraph type="area" />
-              </PrimaryNavigation.Link>
-            </PrimaryNavigation.ListItem>
-          )}
-        </NavigationTourElement>
-      </Feature>
+      {!organization.features.includes('insights-to-dashboards-ui-rollout') && (
+        <Feature features={['performance-view']}>
+          <NavigationTourElement
+            id={NavigationTour.INSIGHTS}
+            title={null}
+            description={null}
+          >
+            {tourProps => (
+              <PrimaryNavigation.ListItem>
+                <PrimaryNavigation.Link
+                  to={`/${prefix}/insights/`}
+                  analyticsKey="insights"
+                  label={t('Insights')}
+                  {...mergeProps(
+                    makeNavigationItemProps(
+                      'insights',
+                      `/${prefix}/insights/`,
+                      `/${prefix}/insights`
+                    ),
+                    tourProps
+                  )}
+                >
+                  <IconGraph type="area" />
+                </PrimaryNavigation.Link>
+              </PrimaryNavigation.ListItem>
+            )}
+          </NavigationTourElement>
+        </Feature>
+      )}
 
       {hasPageFrame ? null : (
         <PrimaryNavigation.ListItem padding="0 md">

--- a/static/app/views/navigation/secondary/content.tsx
+++ b/static/app/views/navigation/secondary/content.tsx
@@ -1,6 +1,7 @@
 import type {ReactNode} from 'react';
 
 import {unreachable} from 'sentry/utils/unreachable';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {usePrimaryNavigation} from 'sentry/views/navigation/primaryNavigationContext';
 import {AdminSecondaryNavigation} from 'sentry/views/navigation/secondary/sections/admin/adminSecondaryNavigation';
 import {DashboardsSecondaryNavigation} from 'sentry/views/navigation/secondary/sections/dashboards/dashboardsSecondaryNavigation';
@@ -13,10 +14,14 @@ import {SettingsSecondaryNavigation} from 'sentry/views/navigation/secondary/sec
 
 export function SecondaryNavigationContent(): ReactNode {
   const {activeGroup} = usePrimaryNavigation();
+  const organization = useOrganization();
   switch (activeGroup) {
     case 'issues':
       return <IssuesSecondaryNavigation />;
     case 'insights':
+      if (organization.features.includes('insights-to-dashboards-ui-rollout')) {
+        return null;
+      }
       return <InsightsSecondaryNavigation />;
     case 'dashboards':
       return <DashboardsSecondaryNavigation />;


### PR DESCRIPTION
Hide the "Insights" entry from the primary sidebar and secondary navigation menu, gated behind the `insights-to-dashboards-ui-rollout` feature flag. Part of the Insights → Dashboards UI migration.

When the flag is enabled, the Insights primary nav link is not rendered and the secondary navigation returns `null` (matching the existing `prevent` pattern). It's a _touch_ janky because landing on a `/insights/` URL shows a blank secondary menu, but we're about to add redirects anyway, so the `/insights/` URLs won't even exist

Closes DAIN-1213