### PR TITLE
feat(seer): Add Sentry metrics to night shift pipeline

### DIFF
--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -350,6 +350,7 @@ def make_llm_generate_request(
         "/v1/llm/generate",
         body=orjson.dumps(body),
         timeout=timeout,
+        metric_tags={"referrer": body["referrer"]},
         viewer_context=viewer_context,
     )
 

--- a/src/sentry/tasks/seer/night_shift/agentic_triage.py
+++ b/src/sentry/tasks/seer/night_shift/agentic_triage.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 
 import orjson
 import pydantic
+import sentry_sdk
 
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -72,7 +73,13 @@ def _triage_candidates(
 
     try:
         response = make_llm_generate_request(body, timeout=60)
+
         if response.status >= 400:
+            sentry_sdk.metrics.count(
+                "night_shift.triage_error",
+                1,
+                attributes={"error_type": "request_failed"},
+            )
             logger.error(
                 "night_shift.triage_request_failed",
                 extra={
@@ -85,6 +92,11 @@ def _triage_candidates(
         data = orjson.loads(response.data)
         content = data.get("content")
         if not content:
+            sentry_sdk.metrics.count(
+                "night_shift.triage_error",
+                1,
+                attributes={"error_type": "empty_response"},
+            )
             logger.error(
                 "night_shift.triage_empty_response",
                 extra={"organization_id": organization.id},
@@ -93,6 +105,11 @@ def _triage_candidates(
 
         triage_response = _TriageResponse.parse_raw(content)
     except Exception:
+        sentry_sdk.metrics.count(
+            "night_shift.triage_error",
+            1,
+            attributes={"error_type": "request_error"},
+        )
         logger.exception(
             "night_shift.triage_request_error",
             extra={"organization_id": organization.id},

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from collections.abc import Sequence
 from datetime import timedelta
 
@@ -62,6 +63,8 @@ def schedule_night_shift() -> None:
             )
             batch_index += 1
 
+    sentry_sdk.metrics.count("night_shift.orgs_dispatched", batch_index)
+
     logger.info(
         "night_shift.schedule_complete",
         extra={"orgs_dispatched": batch_index},
@@ -88,6 +91,8 @@ def run_night_shift_for_org(organization_id: int) -> None:
         }
     )
 
+    start_time = time.monotonic()
+
     eligible_projects = _get_eligible_projects(organization)
     if not eligible_projects:
         logger.info(
@@ -98,6 +103,8 @@ def run_night_shift_for_org(organization_id: int) -> None:
             },
         )
         return
+
+    sentry_sdk.metrics.distribution("night_shift.eligible_projects", len(eligible_projects))
 
     triage_strategy = "agentic_triage"
     run = SeerNightShiftRun.objects.create(
@@ -120,6 +127,7 @@ def run_night_shift_for_org(organization_id: int) -> None:
                 ]
             )
     except Exception:
+        sentry_sdk.metrics.count("night_shift.run_error", 1)
         logger.exception(
             "night_shift.run_failed",
             extra={
@@ -129,6 +137,11 @@ def run_night_shift_for_org(organization_id: int) -> None:
         )
         run.update(error_message="Night shift run failed")
         return
+
+    sentry_sdk.metrics.distribution("night_shift.candidates_selected", len(candidates))
+    for c in candidates:
+        sentry_sdk.metrics.count("night_shift.triage_action", 1, attributes={"action": c.action})
+    sentry_sdk.metrics.distribution("night_shift.org_run_duration", time.monotonic() - start_time)
 
     logger.info(
         "night_shift.candidates_selected",

--- a/src/sentry/tasks/seer/night_shift/simple_triage.py
+++ b/src/sentry/tasks/seer/night_shift/simple_triage.py
@@ -4,6 +4,8 @@ import logging
 from collections.abc import Sequence
 from dataclasses import dataclass
 
+import sentry_sdk
+
 from sentry import search
 from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
 from sentry.models.group import GroupStatus
@@ -86,7 +88,12 @@ def fixability_score_strategy(
         )
 
     candidates.sort(reverse=True)
-    return candidates[:NIGHT_SHIFT_MAX_CANDIDATES]
+    selected = candidates[:NIGHT_SHIFT_MAX_CANDIDATES]
+
+    for c in selected:
+        sentry_sdk.metrics.distribution("night_shift.fixability_score", c.fixability)
+
+    return selected
 
 
 def priority_label(priority: int | None) -> str | None:


### PR DESCRIPTION
Add `sentry_sdk.metrics` instrumentation to the night shift pipeline so we can build a Sentry dashboard for monitoring throughput, error rates, and candidate selection.

**Counters:**
- `night_shift.orgs_dispatched` — total orgs scheduled per cron run
- `night_shift.triage_action` — one per verdict, tagged by `action` (autofix/root_cause_only)
- `night_shift.run_error` — org run failures
- `night_shift.triage_error` — LLM triage errors, tagged by `error_type`

**Distributions:**
- `night_shift.eligible_projects` — projects per org
- `night_shift.candidates_selected` — candidates per org
- `night_shift.org_run_duration` — wall time per org run
- `night_shift.fixability_score` — score distribution of selected candidates

Also forwards `referrer` as a `metric_tag` on `make_llm_generate_request` so `seer.request_to_seer` can be filtered by caller — this benefits all LLM proxy callers, not just night shift.