### PR TITLE
fix(supergroups): Improve backfill task resilience and observability

### DIFF
--- a/src/sentry/tasks/seer/backfill_supergroups_lightweight.py
+++ b/src/sentry/tasks/seer/backfill_supergroups_lightweight.py
@@ -103,6 +103,18 @@ def backfill_supergroups_lightweight_for_org(
         )
         return
 
+    logger.info(
+        "supergroups_backfill_lightweight.batch_starting",
+        extra={
+            "organization_id": organization_id,
+            "project_id": project.id,
+            "last_group_id": last_group_id,
+            "batch_size": len(groups),
+            "first_group_id": groups[0].id,
+            "last_group_id_in_batch": groups[-1].id,
+        },
+    )
+
     # Phase 1: Batch fetch event data
     group_event_pairs = _batch_fetch_events(groups, organization_id)
 
@@ -169,6 +181,17 @@ def backfill_supergroups_lightweight_for_org(
     metrics.incr(
         "seer.supergroups_backfill_lightweight.groups_failed",
         amount=failure_count,
+    )
+
+    logger.info(
+        "supergroups_backfill_lightweight.batch_complete",
+        extra={
+            "organization_id": organization_id,
+            "project_id": project.id,
+            "success_count": success_count,
+            "failure_count": failure_count,
+            "last_group_id_in_batch": groups[-1].id,
+        },
     )
 
     if failure_count >= MAX_FAILURES_PER_BATCH:

--- a/src/sentry/tasks/seer/backfill_supergroups_lightweight.py
+++ b/src/sentry/tasks/seer/backfill_supergroups_lightweight.py
@@ -57,6 +57,26 @@ def backfill_supergroups_lightweight_for_org(
         )
         return
 
+    try:
+        _backfill_org(organization, organization_id, last_project_id, last_group_id)
+    except Exception:
+        logger.exception(
+            "supergroups_backfill_lightweight.task_failed",
+            extra={
+                "organization_id": organization_id,
+                "last_project_id": last_project_id,
+                "last_group_id": last_group_id,
+            },
+        )
+        raise
+
+
+def _backfill_org(
+    organization: Organization,
+    organization_id: int,
+    last_project_id: int,
+    last_group_id: int,
+) -> None:
     # Get the next project to process, starting from where we left off
     project = (
         Project.objects.filter(
@@ -270,11 +290,22 @@ def _batch_fetch_events(groups: Sequence[Group], organization_id: int) -> list[t
     # Batch fetch all event data from nodestore in one multi-get
     eventstore.bind_nodes(events)
 
+    # Filter out events with empty data
+    valid_groups: list[Group] = []
+    valid_events: list[Event] = []
+    for group, event in zip(matched_groups, events):
+        if event.data:
+            valid_groups.append(group)
+            valid_events.append(event)
+
+    if not valid_events:
+        return []
+
     # Bulk serialize all events
-    serialized_events = serialize(events, None, EventSerializer())
+    serialized_events = serialize(valid_events, None, EventSerializer())
 
     return [
         (group, serialized_event)
-        for group, serialized_event in zip(matched_groups, serialized_events)
+        for group, serialized_event in zip(valid_groups, serialized_events)
         if serialized_event
     ]


### PR DESCRIPTION
Fix backfill task crashing on events with empty nodestore data (SENTRY-5NA8) and add logging for better observability.

**Fixes:**
- Filter out events with empty/missing data after `bind_nodes` before serialization, preventing `KeyError: 'timestamp'` crashes that kill the entire backfill chain
- Wrap task body in try/except that logs cursor state (org, project, group) on failure so we know where to resume

**Logging:**
- Add batch start log (project, group range, batch size)
- Add batch complete log (success/failure counts)
- Add task failure log with cursor position

Previously, a task crash produced no `supergroups_backfill_lightweight.*` logs, making it hard to tell if the backfill stopped or how far it got.

Fixes SENTRY-5NA8