### PR TITLE
fix(billing): Guard localStorage access in navBillingStatus and trialStarter

### DIFF
--- a/static/app/utils/createStorage.spec.tsx
+++ b/static/app/utils/createStorage.spec.tsx
@@ -1,0 +1,38 @@
+import {createStorage} from 'sentry/utils/createStorage';
+
+describe('createStorage', () => {
+  it('returns noopStorage when underlying storage is null', () => {
+    const storage = createStorage(() => null as unknown as Storage);
+
+    expect(storage.getItem('any-key')).toBeNull();
+    expect(() => storage.setItem('key', 'value')).not.toThrow();
+    expect(() => storage.removeItem('key')).not.toThrow();
+    expect(() => storage.clear()).not.toThrow();
+    expect(storage).toHaveLength(0);
+    expect(storage.key(0)).toBeNull();
+  });
+
+  it('returns noopStorage when storage.setItem throws', () => {
+    const brokenStorage = {
+      ...window.localStorage,
+      setItem() {
+        throw new DOMException('The quota has been exceeded.');
+      },
+    } as Storage;
+
+    const storage = createStorage(() => brokenStorage);
+
+    expect(storage.getItem('any-key')).toBeNull();
+    expect(() => storage.setItem('key', 'value')).not.toThrow();
+    expect(storage).toHaveLength(0);
+  });
+
+  it('returns real storage when it works correctly', () => {
+    const storage = createStorage(() => window.localStorage);
+
+    storage.setItem('test-key', 'test-value');
+    expect(storage.getItem('test-key')).toBe('test-value');
+    storage.removeItem('test-key');
+    expect(storage.getItem('test-key')).toBeNull();
+  });
+});

--- a/static/gsApp/components/navBillingStatus.spec.tsx
+++ b/static/gsApp/components/navBillingStatus.spec.tsx
@@ -13,16 +13,22 @@ jest.mock('sentry/utils/localStorage', () => {
   const actual = jest.requireActual<typeof import('sentry/utils/localStorage')>(
     'sentry/utils/localStorage'
   );
+  const wrapper = actual.localStorageWrapper;
   return {
     ...actual,
     localStorageWrapper: {
-      ...actual.localStorageWrapper,
       getItem: jest.fn((...args: Parameters<Storage['getItem']>) =>
-        actual.localStorageWrapper.getItem(...args)
+        wrapper.getItem(...args)
       ),
       setItem: jest.fn((...args: Parameters<Storage['setItem']>) =>
-        actual.localStorageWrapper.setItem(...args)
+        wrapper.setItem(...args)
       ),
+      removeItem: jest.fn((...args: Parameters<Storage['removeItem']>) =>
+        wrapper.removeItem(...args)
+      ),
+      clear: jest.fn(() => wrapper.clear()),
+      key: jest.fn((index: number) => wrapper.key(index)),
+      length: wrapper.length,
     },
   };
 });

--- a/static/gsApp/components/navBillingStatus.spec.tsx
+++ b/static/gsApp/components/navBillingStatus.spec.tsx
@@ -8,7 +8,6 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {resetMockDate, setMockDate} from 'sentry-test/utils';
 
 import {DataCategory} from 'sentry/types/core';
-import {createStorage} from 'sentry/utils/createStorage';
 
 jest.mock('sentry/utils/localStorage', () => {
   const actual = jest.requireActual<typeof import('sentry/utils/localStorage')>(
@@ -683,118 +682,38 @@ describe('PrimaryNavigationQuotaExceeded', () => {
 
   describe('localStorage unavailable', () => {
     beforeEach(() => {
-      // Simulate noopStorage fallback: getItem returns null, setItem is a no-op
       jest.mocked(localStorageWrapper.getItem).mockReturnValue(null);
       jest.mocked(localStorageWrapper.setItem).mockImplementation(() => undefined);
     });
 
-    it('should render without crashing when localStorage is unavailable', async () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should render and auto-open without crashing when localStorage is unavailable', async () => {
       render(<PrimaryNavigationQuotaExceeded organization={organization} />);
 
       expect(
         await screen.findByRole('button', {name: 'Billing Status'})
       ).toBeInTheDocument();
-    });
-
-    it('should auto-open the alert when localStorage is unavailable', async () => {
-      render(<PrimaryNavigationQuotaExceeded organization={organization} />);
-
-      // With getItem returning null, the component should auto-open
-      // because currentCategories !== lastShownCategories (null)
+      // Auto-opens because currentCategories !== lastShownCategories (null)
       expect(await screen.findByText('Quotas Exceeded')).toBeInTheDocument();
-    });
-
-    it('should handle setItem gracefully when localStorage is unavailable', async () => {
-      render(<PrimaryNavigationQuotaExceeded organization={organization} />);
-
-      // The component auto-opens and calls setItem to persist state.
-      // With noopStorage, setItem is a no-op — verify it was called without throwing.
-      expect(await screen.findByText('Quotas Exceeded')).toBeInTheDocument();
+      // setItem is a no-op but should not throw
       expect(localStorageWrapper.setItem).toHaveBeenCalled();
     });
-  });
 
-  describe('localStorage unavailable (integration)', () => {
-    // Integration tests that verify the full createStorage → noopStorage → component
-    // pipeline, covering the production crash on Sony BRAVIA 4K TV (Chrome Mobile
-    // WebView 90, Android 10) where window.localStorage is null.
-
-    it('createStorage returns a safe noopStorage when window.localStorage is null', () => {
-      const originalLocalStorage = window.localStorage;
-      Object.defineProperty(window, 'localStorage', {
-        value: null,
-        configurable: true,
-      });
-      try {
-        const storage = createStorage(() => window.localStorage);
-
-        // noopStorage should be safe to call without throwing
-        expect(storage.getItem('any-key')).toBeNull();
-        expect(() => storage.setItem('key', 'value')).not.toThrow();
-        expect(() => storage.removeItem('key')).not.toThrow();
-        expect(() => storage.clear()).not.toThrow();
-        expect(storage).toHaveLength(0);
-        expect(storage.key(0)).toBeNull();
-      } finally {
-        Object.defineProperty(window, 'localStorage', {
-          value: originalLocalStorage,
-          configurable: true,
-        });
-      }
-    });
-
-    it('createStorage returns a safe noopStorage when storage.setItem throws', () => {
-      // Simulates environments where localStorage exists but is disabled (e.g. quota exceeded, private browsing)
-      const brokenStorage = {
-        ...window.localStorage,
-        setItem() {
-          throw new DOMException('The quota has been exceeded.');
-        },
-      } as Storage;
-
-      const storage = createStorage(() => brokenStorage);
-
-      expect(storage.getItem('any-key')).toBeNull();
-      expect(() => storage.setItem('key', 'value')).not.toThrow();
-      expect(storage).toHaveLength(0);
-    });
-
-    it('component allows dismiss interaction when localStorage is unavailable', async () => {
-      // Simulate noopStorage: getItem returns null, setItem is a no-op
-      jest.mocked(localStorageWrapper.getItem).mockReturnValue(null);
-      jest.mocked(localStorageWrapper.setItem).mockImplementation(() => undefined);
-
+    it('should allow dismiss interaction when localStorage is unavailable', async () => {
       render(<PrimaryNavigationQuotaExceeded organization={organization} />);
 
-      // Component auto-opens since getItem returns null (categories mismatch)
       expect(await screen.findByText('Quotas Exceeded')).toBeInTheDocument();
 
-      // User should be able to dismiss the alert without crashing
       await userEvent.click(
         screen.getByRole('button', {
           name: 'Dismiss alert for the rest of the billing cycle',
         })
       );
 
-      // Verify dismiss triggers prompt snooze API calls (one per exceeded category)
       expect(promptMock).toHaveBeenCalledTimes(4);
-    });
-
-    it('component reads and writes correct localStorage keys when storage is available', async () => {
-      // Verify the component uses localStorageWrapper (not raw localStorage) for reads/writes
-      render(<PrimaryNavigationQuotaExceeded organization={organization} />);
-
-      expect(
-        await screen.findByRole('button', {name: 'Billing Status'})
-      ).toBeInTheDocument();
-
-      // Verify localStorageWrapper.getItem was called with expected keys
-      expect(localStorageWrapper.getItem).toHaveBeenCalledWith(
-        `billing-status-last-shown-categories-${organization.id}`
-      );
-      expect(localStorageWrapper.getItem).toHaveBeenCalledWith(
-        `billing-status-last-shown-date-${organization.id}`
-      );
     });
   });
 });

--- a/static/gsApp/components/navBillingStatus.spec.tsx
+++ b/static/gsApp/components/navBillingStatus.spec.tsx
@@ -8,6 +8,29 @@ import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {resetMockDate, setMockDate} from 'sentry-test/utils';
 
 import {DataCategory} from 'sentry/types/core';
+import {createStorage} from 'sentry/utils/createStorage';
+
+jest.mock('sentry/utils/localStorage', () => {
+  const actual = jest.requireActual<typeof import('sentry/utils/localStorage')>(
+    'sentry/utils/localStorage'
+  );
+  return {
+    ...actual,
+    localStorageWrapper: {
+      ...actual.localStorageWrapper,
+      getItem: jest.fn((...args: Parameters<Storage['getItem']>) =>
+        actual.localStorageWrapper.getItem(...args)
+      ),
+      setItem: jest.fn((...args: Parameters<Storage['setItem']>) =>
+        actual.localStorageWrapper.setItem(...args)
+      ),
+    },
+  };
+});
+
+const {localStorageWrapper} = jest.requireMock<
+  typeof import('sentry/utils/localStorage')
+>('sentry/utils/localStorage');
 
 import {PrimaryNavigationQuotaExceeded} from 'getsentry/components/navBillingStatus';
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
@@ -655,6 +678,123 @@ describe('PrimaryNavigationQuotaExceeded', () => {
           /You have used up your quota for errors. Monitoring and new data are paused until your quota resets./
         )
       ).toBeInTheDocument();
+    });
+  });
+
+  describe('localStorage unavailable', () => {
+    beforeEach(() => {
+      // Simulate noopStorage fallback: getItem returns null, setItem is a no-op
+      jest.mocked(localStorageWrapper.getItem).mockReturnValue(null);
+      jest.mocked(localStorageWrapper.setItem).mockImplementation(() => undefined);
+    });
+
+    it('should render without crashing when localStorage is unavailable', async () => {
+      render(<PrimaryNavigationQuotaExceeded organization={organization} />);
+
+      expect(
+        await screen.findByRole('button', {name: 'Billing Status'})
+      ).toBeInTheDocument();
+    });
+
+    it('should auto-open the alert when localStorage is unavailable', async () => {
+      render(<PrimaryNavigationQuotaExceeded organization={organization} />);
+
+      // With getItem returning null, the component should auto-open
+      // because currentCategories !== lastShownCategories (null)
+      expect(await screen.findByText('Quotas Exceeded')).toBeInTheDocument();
+    });
+
+    it('should handle setItem gracefully when localStorage is unavailable', async () => {
+      render(<PrimaryNavigationQuotaExceeded organization={organization} />);
+
+      // The component auto-opens and calls setItem to persist state.
+      // With noopStorage, setItem is a no-op — verify it was called without throwing.
+      expect(await screen.findByText('Quotas Exceeded')).toBeInTheDocument();
+      expect(localStorageWrapper.setItem).toHaveBeenCalled();
+    });
+  });
+
+  describe('localStorage unavailable (integration)', () => {
+    // Integration tests that verify the full createStorage → noopStorage → component
+    // pipeline, covering the production crash on Sony BRAVIA 4K TV (Chrome Mobile
+    // WebView 90, Android 10) where window.localStorage is null.
+
+    it('createStorage returns a safe noopStorage when window.localStorage is null', () => {
+      const originalLocalStorage = window.localStorage;
+      Object.defineProperty(window, 'localStorage', {
+        value: null,
+        configurable: true,
+      });
+      try {
+        const storage = createStorage(() => window.localStorage);
+
+        // noopStorage should be safe to call without throwing
+        expect(storage.getItem('any-key')).toBeNull();
+        expect(() => storage.setItem('key', 'value')).not.toThrow();
+        expect(() => storage.removeItem('key')).not.toThrow();
+        expect(() => storage.clear()).not.toThrow();
+        expect(storage).toHaveLength(0);
+        expect(storage.key(0)).toBeNull();
+      } finally {
+        Object.defineProperty(window, 'localStorage', {
+          value: originalLocalStorage,
+          configurable: true,
+        });
+      }
+    });
+
+    it('createStorage returns a safe noopStorage when storage.setItem throws', () => {
+      // Simulates environments where localStorage exists but is disabled (e.g. quota exceeded, private browsing)
+      const brokenStorage = {
+        ...window.localStorage,
+        setItem() {
+          throw new DOMException('The quota has been exceeded.');
+        },
+      } as Storage;
+
+      const storage = createStorage(() => brokenStorage);
+
+      expect(storage.getItem('any-key')).toBeNull();
+      expect(() => storage.setItem('key', 'value')).not.toThrow();
+      expect(storage).toHaveLength(0);
+    });
+
+    it('component allows dismiss interaction when localStorage is unavailable', async () => {
+      // Simulate noopStorage: getItem returns null, setItem is a no-op
+      jest.mocked(localStorageWrapper.getItem).mockReturnValue(null);
+      jest.mocked(localStorageWrapper.setItem).mockImplementation(() => undefined);
+
+      render(<PrimaryNavigationQuotaExceeded organization={organization} />);
+
+      // Component auto-opens since getItem returns null (categories mismatch)
+      expect(await screen.findByText('Quotas Exceeded')).toBeInTheDocument();
+
+      // User should be able to dismiss the alert without crashing
+      await userEvent.click(
+        screen.getByRole('button', {
+          name: 'Dismiss alert for the rest of the billing cycle',
+        })
+      );
+
+      // Verify dismiss triggers prompt snooze API calls (one per exceeded category)
+      expect(promptMock).toHaveBeenCalledTimes(4);
+    });
+
+    it('component reads and writes correct localStorage keys when storage is available', async () => {
+      // Verify the component uses localStorageWrapper (not raw localStorage) for reads/writes
+      render(<PrimaryNavigationQuotaExceeded organization={organization} />);
+
+      expect(
+        await screen.findByRole('button', {name: 'Billing Status'})
+      ).toBeInTheDocument();
+
+      // Verify localStorageWrapper.getItem was called with expected keys
+      expect(localStorageWrapper.getItem).toHaveBeenCalledWith(
+        `billing-status-last-shown-categories-${organization.id}`
+      );
+      expect(localStorageWrapper.getItem).toHaveBeenCalledWith(
+        `billing-status-last-shown-date-${organization.id}`
+      );
     });
   });
 });

--- a/static/gsApp/components/navBillingStatus.tsx
+++ b/static/gsApp/components/navBillingStatus.tsx
@@ -14,6 +14,7 @@ import {t, tct} from 'sentry/locale';
 import {DataCategory} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import {getDaysSinceDate} from 'sentry/utils/getDaysSinceDate';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 import {
   PrimaryNavigation,
   usePrimaryNavigationButtonOverlay,
@@ -443,10 +444,10 @@ export function PrimaryNavigationQuotaExceeded({
     // either it has been more than a day since the last shown date,
     // the categories have changed, or
     // the last time it was shown was before the current usage cycle started
-    const lastShownCategories = localStorage.getItem(
+    const lastShownCategories = localStorageWrapper.getItem(
       `billing-status-last-shown-categories-${organization.id}`
     );
-    const lastShownDate = localStorage.getItem(
+    const lastShownDate = localStorageWrapper.getItem(
       `billing-status-last-shown-date-${organization.id}`
     );
     const daysSinceLastShown = lastShownDate ? getDaysSinceDate(lastShownDate) : 0;
@@ -463,11 +464,11 @@ export function PrimaryNavigationQuotaExceeded({
     ) {
       hasAutoOpenedAlertRef.current = true;
       overlayState.open();
-      localStorage.setItem(
+      localStorageWrapper.setItem(
         `billing-status-last-shown-categories-${organization.id}`,
         currentCategories
       );
-      localStorage.setItem(
+      localStorageWrapper.setItem(
         `billing-status-last-shown-date-${organization.id}`,
         moment().utc().toISOString()
       );

--- a/static/gsApp/components/trialStarter.spec.tsx
+++ b/static/gsApp/components/trialStarter.spec.tsx
@@ -6,6 +6,25 @@ import {TeamFixture} from 'sentry-fixture/team';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
 import {act, render, screen} from 'sentry-test/reactTestingLibrary';
 
+jest.mock('sentry/utils/localStorage', () => {
+  const actual = jest.requireActual<typeof import('sentry/utils/localStorage')>(
+    'sentry/utils/localStorage'
+  );
+  return {
+    ...actual,
+    localStorageWrapper: {
+      ...actual.localStorageWrapper,
+      removeItem: jest.fn((...args: Parameters<Storage['removeItem']>) =>
+        actual.localStorageWrapper.removeItem(...args)
+      ),
+    },
+  };
+});
+
+const {localStorageWrapper} = jest.requireMock<
+  typeof import('sentry/utils/localStorage')
+>('sentry/utils/localStorage');
+
 import TrialStarter from 'getsentry/components/trialStarter';
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
 
@@ -105,5 +124,57 @@ describe('TrialStarter', () => {
     expect(startedCall.trialStarting).toBe(false);
     expect(startedCall.trialStarted).toBe(false);
     expect(startedCall.trialFailed).toBe(true);
+  });
+
+  it('starts a trial successfully when localStorage is unavailable', async () => {
+    // Simulate noopStorage: removeItem is a no-op (e.g., Android WebView without DOM Storage)
+    jest.mocked(localStorageWrapper.removeItem).mockImplementation(() => null);
+
+    const handleTrialStarted = jest.fn();
+    // eslint-disable-next-line no-empty-pattern
+    const renderer = jest.fn(({}: RendererProps) => <div>render text</div>);
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/`,
+      body: org,
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/projects/`,
+      body: [ProjectFixture()],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/teams/`,
+      body: [TeamFixture()],
+    });
+
+    render(
+      <TrialStarter
+        organization={org}
+        source="test-abc"
+        onTrialStarted={handleTrialStarted}
+      >
+        {renderer}
+      </TrialStarter>
+    );
+
+    MockApiClient.addMockResponse({
+      url: `/customers/${org.slug}/`,
+      method: 'PUT',
+    });
+    MockApiClient.addMockResponse({
+      url: `/customers/${org.slug}/`,
+      method: 'GET',
+      body: sub,
+    });
+
+    await act(() => renderer.mock.calls.at(-1)![0].startTrial());
+
+    expect(handleTrialStarted).toHaveBeenCalled();
+    expect(localStorageWrapper.removeItem).toHaveBeenCalledWith(
+      'sidebar-new-seen:customizable-dashboards'
+    );
+
+    const startedCall = renderer.mock.calls.at(-1)![0];
+    expect(startedCall.trialStarted).toBe(true);
+    expect(startedCall.trialFailed).toBe(false);
   });
 });

--- a/static/gsApp/components/trialStarter.tsx
+++ b/static/gsApp/components/trialStarter.tsx
@@ -2,6 +2,7 @@ import {useState} from 'react';
 
 import {fetchOrganizationDetails} from 'sentry/actionCreators/organization';
 import type {Organization} from 'sentry/types/organization';
+import {localStorageWrapper} from 'sentry/utils/localStorage';
 import {useApi} from 'sentry/utils/useApi';
 
 import {withSubscription} from 'getsentry/components/withSubscription';
@@ -69,7 +70,7 @@ function TrialStarter(props: Props) {
 
     // we showed the "new" icon for the upsell that wasn't the actual dashboard
     // we should clear this so folks can see "new" for the actual dashboard
-    localStorage.removeItem('sidebar-new-seen:customizable-dashboards');
+    localStorageWrapper.removeItem('sidebar-new-seen:customizable-dashboards');
   };
 
   const {subscription, children} = props;


### PR DESCRIPTION
Closes JAVASCRIPT-38TV

## The Bug

On devices where `window.localStorage` is `null` — notably Android WebView
without DOM Storage enabled (e.g. Sony BRAVIA smart TVs) — two gsApp
components crash with:

```
TypeError: Cannot read property 'getItem' of null
```

**Root cause chain:**
1. Android WebView has DOM Storage **disabled by default**
2. The embedding app must call `WebSettings.setDomStorageEnabled(true)` to enable it
3. When disabled, `window.localStorage` evaluates to `null` (not undefined — literally null)
4. `navBillingStatus.tsx` and `trialStarter.tsx` call `localStorage.getItem()` / `.setItem()` / `.removeItem()` directly on this null value

The crash in `navBillingStatus.tsx` is caught by an `ErrorBoundary` with
`customComponent={null}`, so the billing status icon silently disappears.
User impact is minimal but the fix is trivial.

## The Fix

Sentry already has a safe localStorage wrapper:

```
createStorage() → localStorageWrapper → useLocalStorageState
```

`createStorage()` tests actual read/write capability at module load. If
`localStorage` is null or throws, it returns a `noopStorage` object that
returns `null` for reads and no-ops for writes. Both components just
weren't using it.

**Changes:**
- `navBillingStatus.tsx` — replace 4 raw `localStorage.getItem/setItem` calls with `localStorageWrapper`
- `trialStarter.tsx` — replace 1 raw `localStorage.removeItem` call with `localStorageWrapper`

## Tests

- `navBillingStatus.spec.tsx` — 2 tests: component renders/auto-opens and allows dismiss when localStorage is unavailable
- `trialStarter.spec.tsx` — 1 test: trial starts successfully when localStorage is unavailable
- `createStorage.spec.tsx` (**new file**) — 3 tests: noopStorage fallback when storage is null, when setItem throws, and happy path