### PR TITLE
fix(preprod): Hide approve button on status check when snapshots already approved

### DIFF
--- a/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
@@ -242,7 +242,11 @@ def create_preprod_snapshot_status_check_task(
             changes_map,
             approvals_map=approvals_map,
         )
-        if any(changes_map.values()):
+        has_unapproved_changes = any(
+            has_changes and artifact_id not in approvals_map
+            for artifact_id, has_changes in changes_map.items()
+        )
+        if has_unapproved_changes:
             approve_action_identifier = APPROVE_SNAPSHOT_ACTION_IDENTIFIER
 
     completed_at: datetime | None = None


### PR DESCRIPTION
Hide the GitHub check run "Approve" button when all snapshot changes
have already been approved.

Previously, `approve_action_identifier` was set whenever `changes_map`
had any truthy entries — regardless of whether those changes were
already approved. This meant the Approve button persisted on the check
run even after a user approved all snapshots (either via the Sentry UI
or the GitHub button itself).

Now the condition cross-references `approvals_map` to only include the
button when at least one changed artifact remains unapproved. This is
consistent with how `_compute_snapshot_status` already determines
pass/fail status.