### PR TITLE
Restrict allowed values in sentry.conf.py for feature-flags

### DIFF
--- a/src/sentry/api/endpoints/internal/feature_flags.py
+++ b/src/sentry/api/endpoints/internal/feature_flags.py
@@ -1,3 +1,5 @@
+from collections.abc import Mapping
+
 from django.conf import settings
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -8,6 +10,30 @@ from sentry.api.base import Endpoint, all_silo_endpoint
 from sentry.api.permissions import SuperuserPermission
 from sentry.conf.server import SENTRY_EARLY_FEATURES
 from sentry.runner.settings import configure, discover_configs
+
+
+def _coerce_early_feature_flag_value(value: object) -> bool | None:
+    """
+    Map API input to a bool for SENTRY_FEATURES. Accepts JSON booleans, 0/1
+    (common in scripts), and the strings "true"/"false" (case-insensitive).
+    Returns None if the value cannot be interpreted safely.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        if value == 1:
+            return True
+        if value == 0:
+            return False
+        return None
+    if isinstance(value, str):
+        lowered = value.lower()
+        if lowered == "true":
+            return True
+        if lowered == "false":
+            return False
+        return None
+    return None
 
 
 @all_silo_endpoint
@@ -36,8 +62,29 @@ class InternalFeatureFlagsEndpoint(Endpoint):
         if not settings.SENTRY_SELF_HOSTED:
             return Response("You are not self-hosting Sentry.", status=403)
 
-        data = request.data.keys()
-        valid_feature_flags = [flag for flag in data if SENTRY_EARLY_FEATURES.get(flag, False)]
+        payload: object = request.data
+        if not isinstance(payload, Mapping):
+            return Response(
+                {"detail": "Feature flag updates must be a JSON object."},
+                status=400,
+            )
+
+        valid_feature_flags = [flag for flag in payload if flag in SENTRY_EARLY_FEATURES]
+        coerced_values: dict[str, bool] = {}
+        for valid_flag in valid_feature_flags:
+            coerced = _coerce_early_feature_flag_value(payload.get(valid_flag))
+            if coerced is None:
+                return Response(
+                    {
+                        "detail": (
+                            f'Feature flag "{valid_flag}" must be true or false '
+                            f"(boolean, 0 or 1, or the string true or false)."
+                        )
+                    },
+                    status=400,
+                )
+            coerced_values[valid_flag] = coerced
+
         _, py, yml = discover_configs()
         # Open the file for reading and writing
         with open(py, "r+") as file:
@@ -45,9 +92,8 @@ class InternalFeatureFlagsEndpoint(Endpoint):
             # print(lines)
             for valid_flag in valid_feature_flags:
                 match_found = False
-                new_string = (
-                    f'\nSENTRY_FEATURES["{valid_flag}"]={request.data.get(valid_flag, False)}\n'
-                )
+                python_bool = "True" if coerced_values[valid_flag] else "False"
+                new_string = f'\nSENTRY_FEATURES["{valid_flag}"]={python_bool}\n'
                 # Search for the string match and update lines
                 for i, line in enumerate(lines):
                     if valid_flag in line:

--- a/tests/sentry/api/endpoints/test_internal_feature_flags.py
+++ b/tests/sentry/api/endpoints/test_internal_feature_flags.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+from django.test import override_settings
+from django.urls import reverse
+
+from sentry.conf.server import SENTRY_EARLY_FEATURES
+from sentry.testutils.cases import APITestCase
+
+EARLY_FEATURE_FLAG = next(iter(SENTRY_EARLY_FEATURES))
+
+
+class TestInternalFeatureFlagsEndpoint(APITestCase):
+    url = reverse("sentry-api-0-internal-feature-flags")
+
+    @override_settings(SENTRY_SELF_HOSTED=False)
+    def test_get_not_self_hosted(self) -> None:
+        user = self.create_user(is_superuser=True)
+        self.login_as(user=user, superuser=True)
+        response = self.client.get(self.url)
+        assert response.status_code == 403
+
+    @override_settings(SENTRY_SELF_HOSTED=False)
+    def test_put_not_self_hosted(self) -> None:
+        user = self.create_user(is_superuser=True)
+        self.login_as(user=user, superuser=True)
+        response = self.client.put(self.url, {EARLY_FEATURE_FLAG: True}, format="json")
+        assert response.status_code == 403
+
+    @override_settings(SENTRY_SELF_HOSTED=True)
+    def test_put_not_superuser(self) -> None:
+        self.login_as(user=self.user, superuser=False)
+        response = self.client.put(self.url, {EARLY_FEATURE_FLAG: True}, format="json")
+        assert response.status_code == 403
+
+    @override_settings(SENTRY_SELF_HOSTED=True)
+    def test_put_string_value_returns_400(self) -> None:
+        user = self.create_user(is_superuser=True)
+        self.login_as(user=user, superuser=True)
+        initial = "# sentry config placeholder\n"
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix="sentry.conf.py", delete=False, encoding="utf-8"
+        ) as tmp:
+            tmp.write(initial)
+            py_path = tmp.name
+        py_file = Path(py_path)
+        try:
+            with mock.patch(
+                "sentry.api.endpoints.internal.feature_flags.discover_configs",
+                return_value=(str(py_file.parent), str(py_file), None),
+            ) as discover_mock:
+                response = self.client.put(
+                    self.url,
+                    {EARLY_FEATURE_FLAG: "__import__('os').popen('id').read()"},
+                    format="json",
+                )
+
+            assert response.status_code == 400
+            assert "true or false" in response.data["detail"]
+            discover_mock.assert_not_called()
+            assert py_file.read_text() == initial
+        finally:
+            py_file.unlink(missing_ok=True)
+
+    @override_settings(SENTRY_SELF_HOSTED=True)
+    def test_put_int_other_than_zero_or_one_returns_400(self) -> None:
+        user = self.create_user(is_superuser=True)
+        self.login_as(user=user, superuser=True)
+        initial = "# sentry config placeholder\n"
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix="sentry.conf.py", delete=False, encoding="utf-8"
+        ) as tmp:
+            tmp.write(initial)
+            py_path = tmp.name
+        py_file = Path(py_path)
+        try:
+            with mock.patch(
+                "sentry.api.endpoints.internal.feature_flags.discover_configs",
+                return_value=(str(py_file.parent), str(py_file), None),
+            ) as discover_mock:
+                response = self.client.put(self.url, {EARLY_FEATURE_FLAG: 2}, format="json")
+
+            assert response.status_code == 400
+            discover_mock.assert_not_called()
+            assert py_file.read_text() == initial
+        finally:
+            py_file.unlink(missing_ok=True)
+
+    @override_settings(SENTRY_SELF_HOSTED=True)
+    def test_put_int_one_writes_true_literal(self) -> None:
+        user = self.create_user(is_superuser=True)
+        self.login_as(user=user, superuser=True)
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix="sentry.conf.py", delete=False, encoding="utf-8"
+        ) as tmp:
+            tmp.write("# empty\n")
+            py_path = tmp.name
+        py_file = Path(py_path)
+        try:
+            with (
+                mock.patch(
+                    "sentry.api.endpoints.internal.feature_flags.discover_configs",
+                    return_value=(str(py_file.parent), str(py_file), None),
+                ),
+                mock.patch("sentry.api.endpoints.internal.feature_flags.configure"),
+            ):
+                response = self.client.put(self.url, {EARLY_FEATURE_FLAG: 1}, format="json")
+
+            assert response.status_code == 200
+            written = py_file.read_text().replace(" ", "")
+            assert f'SENTRY_FEATURES["{EARLY_FEATURE_FLAG}"]=True' in written
+        finally:
+            py_file.unlink(missing_ok=True)
+
+    @override_settings(SENTRY_SELF_HOSTED=True)
+    def test_put_int_zero_writes_false_literal(self) -> None:
+        user = self.create_user(is_superuser=True)
+        self.login_as(user=user, superuser=True)
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix="sentry.conf.py", delete=False, encoding="utf-8"
+        ) as tmp:
+            tmp.write("# empty\n")
+            py_path = tmp.name
+        py_file = Path(py_path)
+        try:
+            with (
+                mock.patch(
+                    "sentry.api.endpoints.internal.feature_flags.discover_configs",
+                    return_value=(str(py_file.parent), str(py_file), None),
+                ),
+                mock.patch("sentry.api.endpoints.internal.feature_flags.configure"),
+            ):
+                response = self.client.put(self.url, {EARLY_FEATURE_FLAG: 0}, format="json")
+
+            assert response.status_code == 200
+            written = py_file.read_text().replace(" ", "")
+            assert f'SENTRY_FEATURES["{EARLY_FEATURE_FLAG}"]=False' in written
+        finally:
+            py_file.unlink(missing_ok=True)
+
+    @override_settings(SENTRY_SELF_HOSTED=True)
+    def test_put_string_true_writes_true_literal(self) -> None:
+        user = self.create_user(is_superuser=True)
+        self.login_as(user=user, superuser=True)
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix="sentry.conf.py", delete=False, encoding="utf-8"
+        ) as tmp:
+            tmp.write("# empty\n")
+            py_path = tmp.name
+        py_file = Path(py_path)
+        try:
+            with (
+                mock.patch(
+                    "sentry.api.endpoints.internal.feature_flags.discover_configs",
+                    return_value=(str(py_file.parent), str(py_file), None),
+                ),
+                mock.patch("sentry.api.endpoints.internal.feature_flags.configure"),
+            ):
+                response = self.client.put(self.url, {EARLY_FEATURE_FLAG: "true"}, format="json")
+
+            assert response.status_code == 200
+            written = py_file.read_text().replace(" ", "")
+            assert f'SENTRY_FEATURES["{EARLY_FEATURE_FLAG}"]=True' in written
+        finally:
+            py_file.unlink(missing_ok=True)
+
+    @override_settings(SENTRY_SELF_HOSTED=True)
+    def test_put_string_false_writes_false_literal(self) -> None:
+        user = self.create_user(is_superuser=True)
+        self.login_as(user=user, superuser=True)
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix="sentry.conf.py", delete=False, encoding="utf-8"
+        ) as tmp:
+            tmp.write("# empty\n")
+            py_path = tmp.name
+        py_file = Path(py_path)
+        try:
+            with (
+                mock.patch(
+                    "sentry.api.endpoints.internal.feature_flags.discover_configs",
+                    return_value=(str(py_file.parent), str(py_file), None),
+                ),
+                mock.patch("sentry.api.endpoints.internal.feature_flags.configure"),
+            ):
+                response = self.client.put(self.url, {EARLY_FEATURE_FLAG: "FALSE"}, format="json")
+
+            assert response.status_code == 200
+            written = py_file.read_text().replace(" ", "")
+            assert f'SENTRY_FEATURES["{EARLY_FEATURE_FLAG}"]=False' in written
+        finally:
+            py_file.unlink(missing_ok=True)
+
+    @override_settings(SENTRY_SELF_HOSTED=True)
+    def test_put_string_other_than_true_false_returns_400(self) -> None:
+        user = self.create_user(is_superuser=True)
+        self.login_as(user=user, superuser=True)
+        initial = "# sentry config placeholder\n"
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix="sentry.conf.py", delete=False, encoding="utf-8"
+        ) as tmp:
+            tmp.write(initial)
+            py_path = tmp.name
+        py_file = Path(py_path)
+        try:
+            with mock.patch(
+                "sentry.api.endpoints.internal.feature_flags.discover_configs",
+                return_value=(str(py_file.parent), str(py_file), None),
+            ) as discover_mock:
+                response = self.client.put(self.url, {EARLY_FEATURE_FLAG: "yes"}, format="json")
+
+            assert response.status_code == 400
+            discover_mock.assert_not_called()
+            assert py_file.read_text() == initial
+        finally:
+            py_file.unlink(missing_ok=True)
+
+    @override_settings(SENTRY_SELF_HOSTED=True)
+    def test_put_boolean_writes_safe_literal(self) -> None:
+        user = self.create_user(is_superuser=True)
+        self.login_as(user=user, superuser=True)
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix="sentry.conf.py", delete=False, encoding="utf-8"
+        ) as tmp:
+            tmp.write("# empty\n")
+            py_path = tmp.name
+        py_file = Path(py_path)
+        try:
+            with (
+                mock.patch(
+                    "sentry.api.endpoints.internal.feature_flags.discover_configs",
+                    return_value=(str(py_file.parent), str(py_file), None),
+                ),
+                mock.patch("sentry.api.endpoints.internal.feature_flags.configure"),
+            ):
+                response = self.client.put(self.url, {EARLY_FEATURE_FLAG: True}, format="json")
+
+            assert response.status_code == 200
+            written = py_file.read_text()
+            assert f'SENTRY_FEATURES["{EARLY_FEATURE_FLAG}"]=True' in written.replace(" ", "")
+            assert "__import__" not in written
+        finally:
+            py_file.unlink(missing_ok=True)
+
+    @override_settings(SENTRY_SELF_HOSTED=True)
+    def test_put_non_object_payload_returns_400(self) -> None:
+        user = self.create_user(is_superuser=True)
+        self.login_as(user=user, superuser=True)
+        response = self.client.put(self.url, [EARLY_FEATURE_FLAG], format="json")
+        assert response.status_code == 400


### PR DESCRIPTION
Restricts the allowed values that the feature-flags endpoint accepts to mitigate a remote code execution vulnerability accessible by Superusers. Allowing full JSON and trusting that user input was a flaw.

I had considered making this strict boolean, but I can't be certain of existing use cases that might accept a variety of intended values so ensuring some potential backwards compatibility with 0/1, "true"/"false", and the bool. 

Thanks to @grumpinout1. @JorianWoltjer, @reindaelman of @Aikido-Security for the find. 