### PR TITLE
ref(onboarding): Rename SCM integration analytics view to onboarding_scm

### DIFF
--- a/static/app/utils/analytics/integrations/index.ts
+++ b/static/app/utils/analytics/integrations/index.ts
@@ -16,6 +16,7 @@ export type IntegrationView = {
     | 'stacktrace_issue_details'
     | 'integration_configuration_detail'
     | 'onboarding'
+    | 'onboarding_scm'
     | 'project_creation'
     | 'developer_settings'
     | 'new_integration_modal'

--- a/static/app/utils/integrations/useAddIntegration.tsx
+++ b/static/app/utils/integrations/useAddIntegration.tsx
@@ -24,6 +24,7 @@ export interface AddIntegrationParams {
       | 'integrations_directory_integration_detail'
       | 'integrations_directory'
       | 'onboarding'
+      | 'onboarding_scm'
       | 'project_creation'
       | 'seer_onboarding_github'
       | 'seer_onboarding_code_review'

--- a/static/app/views/onboarding/components/scmProviderPills.tsx
+++ b/static/app/views/onboarding/components/scmProviderPills.tsx
@@ -21,7 +21,7 @@ export function ScmProviderPills({providers, onInstall}: ScmProviderPillsProps) 
             type: 'first_party',
             installStatus: 'Not Installed',
             analyticsParams: {
-              view: 'onboarding',
+              view: 'onboarding_scm',
               already_installed: false,
             },
           }}

--- a/static/app/views/settings/organizationIntegrations/integrationContext.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationContext.tsx
@@ -11,6 +11,7 @@ type IntegrationContextProps = {
       | 'integrations_directory_integration_detail'
       | 'integrations_directory'
       | 'onboarding'
+      | 'onboarding_scm'
       | 'project_creation'
       | 'seer_onboarding_github'
       | 'seer_onboarding_code_review'


### PR DESCRIPTION
The SCM onboarding flow was using the generic and preexisting `view: 'onboarding'` value when tracking `integrations.installation_complete` analytics. This is ambiguous since `'onboarding'` could be reused by other integration surfaces, which would pollute experiment data for the SCM onboarding experiment.

Adds a new `'onboarding_scm'` view value and uses it in `scmProviderPills.tsx`. The existing `'onboarding'` value is preserved for other callers.

Refs VDY-81