### PR TITLE
feat(seer): Replace LLM triage with Explorer agent in night shift

### DIFF
--- a/src/sentry/seer/explorer/client_models.py
+++ b/src/sentry/seer/explorer/client_models.py
@@ -145,6 +145,39 @@ class ExplorerCodingAgentState(BaseModel):
         extra = "allow"
 
 
+class Usage(BaseModel):
+    """Token usage and cost for a single model."""
+
+    completion_tokens: int = 0
+    prompt_tokens: int = 0
+    total_tokens: int = 0
+    prompt_cache_read_tokens: int = 0
+    prompt_cache_write_tokens: int = 0
+    thinking_tokens: int = 0
+    dollar_cost: float = 0.0
+    model: str = ""
+
+    class Config:
+        extra = "allow"
+
+
+class UsageAccumulator(BaseModel):
+    """Aggregated usage across multiple LLM calls."""
+
+    usages: list[Usage] = Field(default_factory=list)
+
+    class Config:
+        extra = "allow"
+
+    @property
+    def total_dollar_cost(self) -> float:
+        return sum(u.dollar_cost for u in self.usages)
+
+    @property
+    def total_tokens(self) -> int:
+        return sum(u.total_tokens for u in self.usages)
+
+
 class SeerRunState(BaseModel):
     """State of a Seer Explorer session."""
 
@@ -156,6 +189,7 @@ class SeerRunState(BaseModel):
     repo_pr_states: dict[str, RepoPRState] = Field(default_factory=dict)
     metadata: dict[str, Any] | None = None
     coding_agents: dict[str, ExplorerCodingAgentState] = Field(default_factory=dict)
+    usage: UsageAccumulator = Field(default_factory=UsageAccumulator)
 
     class Config:
         extra = "allow"

--- a/src/sentry/tasks/seer/night_shift/agentic_triage.py
+++ b/src/sentry/tasks/seer/night_shift/agentic_triage.py
@@ -2,15 +2,16 @@ from __future__ import annotations
 
 import logging
 import textwrap
+import time
 from collections.abc import Sequence
 
-import orjson
 import pydantic
 import sentry_sdk
 
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.seer.signed_seer_api import LlmGenerateRequest, make_llm_generate_request
+from sentry.seer.explorer.client import SeerExplorerClient
+from sentry.seer.explorer.client_models import SeerRunState
 from sentry.tasks.seer.night_shift.models import TriageAction, TriageResult
 from sentry.tasks.seer.night_shift.simple_triage import (
     ScoredCandidate,
@@ -30,19 +31,16 @@ class _TriageVerdict(pydantic.BaseModel):
 class _TriageResponse(pydantic.BaseModel):
     verdicts: list[_TriageVerdict]
 
-    @pydantic.validator("verdicts")
-    def filter_skips(cls, v: list[_TriageVerdict]) -> list[_TriageVerdict]:
-        return [verdict for verdict in v if verdict.action != TriageAction.SKIP]
-
 
 def agentic_triage_strategy(
     projects: Sequence[Project],
     organization: Organization,
 ) -> list[TriageResult]:
     """
-    Select candidates via fixability scoring, then filter through an LLM
-    triage call that decides the action for each candidate.
+    Select candidates via fixability scoring, then use the Seer Explorer agent
+    to investigate each candidate and decide the appropriate action.
     """
+    # TODO: try a new way to get scored issues
     scored = fixability_score_strategy(projects)
     if not scored:
         return []
@@ -55,82 +53,150 @@ def _triage_candidates(
     organization: Organization,
 ) -> list[TriageResult]:
     """
-    Call Seer LLM proxy to triage the candidate batch via a single LLM call.
-    Returns candidates the LLM didn't skip, with their assigned action.
+    Start a Seer Explorer run to investigate candidate issues and return
+    triage verdicts. The agent can browse the repo, inspect stacktraces,
+    and use its tools to make informed decisions.
     """
     groups_by_id = {c.group.id: c.group for c in candidates}
 
-    body = LlmGenerateRequest(
-        provider="gemini",
-        model="pro-preview",
-        referrer="night_shift.triage",
-        prompt=_build_triage_prompt(candidates),
-        system_prompt="",
-        temperature=0.0,
-        max_tokens=4096,
-        response_schema=_TriageResponse.schema(),
+    client = SeerExplorerClient(
+        organization,
+        user=None,
+        category_key="night_shift",
+        category_value=f"org-{organization.id}",
+        intelligence_level="high",
+        reasoning_effort="high",
     )
 
     try:
-        response = make_llm_generate_request(body, timeout=60)
+        run_id = client.start_run(
+            prompt=_build_triage_prompt(candidates),
+            artifact_key="triage_verdicts",
+            artifact_schema=_TriageResponse,
+        )
 
-        if response.status >= 400:
-            sentry_sdk.metrics.count(
-                "night_shift.triage_error",
-                1,
-                attributes={"error_type": "request_failed"},
-            )
+        logger.info(
+            "night_shift.explorer_run_started",
+            extra={
+                "organization_id": organization.id,
+                "run_id": run_id,
+                "num_candidates": len(candidates),
+            },
+        )
+
+        state = _poll_with_logging(client, run_id, organization.id)
+
+        triage_response = state.get_artifact("triage_verdicts", _TriageResponse)
+        if not triage_response:
             logger.error(
-                "night_shift.triage_request_failed",
+                "night_shift.triage_no_artifact",
                 extra={
                     "organization_id": organization.id,
-                    "status": response.status,
+                    "run_id": run_id,
+                    "status": state.status,
                 },
             )
-            return []
-
-        data = orjson.loads(response.data)
-        content = data.get("content")
-        if not content:
             sentry_sdk.metrics.count(
                 "night_shift.triage_error",
                 1,
-                attributes={"error_type": "empty_response"},
-            )
-            logger.error(
-                "night_shift.triage_empty_response",
-                extra={"organization_id": organization.id},
+                attributes={"error_type": "no_artifact"},
             )
             return []
-
-        triage_response = _TriageResponse.parse_raw(content)
     except Exception:
         sentry_sdk.metrics.count(
             "night_shift.triage_error",
             1,
-            attributes={"error_type": "request_error"},
+            attributes={"error_type": "explorer_error"},
         )
         logger.exception(
-            "night_shift.triage_request_error",
+            "night_shift.triage_explorer_error",
             extra={"organization_id": organization.id},
         )
         return []
-
-    results = [
-        TriageResult(group=groups_by_id[v.group_id], action=v.action)
-        for v in triage_response.verdicts
-        if v.group_id in groups_by_id
-    ]
 
     logger.info(
         "night_shift.triage_verdicts",
         extra={
             "organization_id": organization.id,
+            "run_id": run_id,
             "verdicts": {v.group_id: v.action for v in triage_response.verdicts},
         },
     )
 
-    return results
+    return [
+        TriageResult(group=groups_by_id[v.group_id], action=v.action)
+        for v in triage_response.verdicts
+        if v.group_id in groups_by_id and v.action != TriageAction.SKIP
+    ]
+
+
+POLL_INTERVAL = 2.0
+POLL_TIMEOUT = 120.0
+
+
+def _poll_with_logging(
+    client: SeerExplorerClient,
+    run_id: int,
+    organization_id: int,
+) -> SeerRunState:
+    """Poll an Explorer run, logging new non-loading blocks as they appear."""
+    start_time = time.monotonic()
+    seen_block_ids: set[str] = set()
+
+    while True:
+        state = client.get_run(run_id)
+
+        for block in state.blocks:
+            if block.id in seen_block_ids or block.loading:
+                continue
+            seen_block_ids.add(block.id)
+
+            msg = block.message
+            tool_names = [tc.function for tc in msg.tool_calls] if msg.tool_calls else None
+            logger.info(
+                "night_shift.explorer_block",
+                extra={
+                    "organization_id": organization_id,
+                    "run_id": run_id,
+                    "block_id": block.id,
+                    "role": msg.role,
+                    "tool_calls": tool_names,
+                    "has_artifacts": bool(block.artifacts),
+                },
+            )
+
+        if state.status in ("completed", "error", "awaiting_user_input"):
+            usage = state.usage
+            logger.info(
+                "night_shift.explorer_run_completed",
+                extra={
+                    "organization_id": organization_id,
+                    "run_id": run_id,
+                    "status": state.status,
+                    "num_blocks": len(state.blocks),
+                    "duration": round(time.monotonic() - start_time, 1),
+                    "dollar_cost": usage.total_dollar_cost,
+                    "usage": [
+                        {
+                            "model": u.model,
+                            "prompt_tokens": u.prompt_tokens,
+                            "completion_tokens": u.completion_tokens,
+                            "cache_read_tokens": u.prompt_cache_read_tokens,
+                            "cache_write_tokens": u.prompt_cache_write_tokens,
+                            "thinking_tokens": u.thinking_tokens,
+                            "total_tokens": u.total_tokens,
+                        }
+                        for u in usage.usages
+                    ],
+                },
+            )
+            return state
+
+        elapsed = time.monotonic() - start_time
+        if elapsed >= POLL_TIMEOUT:
+            raise TimeoutError(f"Explorer run {run_id} timed out after {POLL_TIMEOUT}s")
+
+        time.sleep(POLL_INTERVAL)
 
 
 def _build_triage_prompt(
@@ -150,16 +216,33 @@ def _build_triage_prompt(
         a batch of candidate issues and decide which ones are worth running automated
         root-cause analysis and code fixes on.
 
-        For each candidate, choose one action:
-        - "autofix": Run the full automated pipeline (root cause → solution → code changes).
-          Choose this for issues that look clearly fixable from their title/culprit and have
-          a high fixability score.
-        - "root_cause_only": Only run root-cause analysis, don't attempt a fix.
-          Choose this for issues that are worth investigating but may be too complex or
-          ambiguous to auto-fix confidently.
-        - "skip": Don't process this issue.
-          Choose this for issues that are vague, likely duplicates of each other in this
-          batch, or not worth spending compute on.
+        Use your tools to investigate each issue — look at all relevant telemetry: the stacktraces,
+        event logs, event details, breadcrumbs, metrics, and the relevant code in the repository.
+
+        When evaluating each issue, consider whether an AI coding agent with full
+        codebase access could fix the ROOT CAUSE of the issue — not just add try/except or defensive
+        checks around it. Use these criteria:
+
+        Clearly fixable in code (-> autofix):
+        - The bug is a clear mistake in application logic (wrong key, off-by-one,
+          missing None check on app data)
+        - Root cause is visible in application code within a connected repository
+        - Straightforward change to business logic
+
+        Worth investigating but not auto-fixable (-> root_cause_only):
+        - Likely fixable but requires non-trivial investigation or cross-cutting changes
+        - Error originates in third-party libraries, vendor code, or framework internals
+        - Root cause is outside the code (filesystem, external services, environment)
+
+        Not worth processing (-> skip):
+        - The issue is vague with no actionable stacktrace
+        - Duplicate of another issue in this batch
+        - The code is correct but the environment is broken (infra down, DNS failure,
+          config not provisioned, data corruption)
+
+        The "fixability" score in the candidate data is a prior estimate of how likely
+        the issue is to be fixable (0.0 = not fixable, 1.0 = very fixable). Use it as
+        a signal but verify with your own investigation.
 
         Provide a brief reason for each decision.
 

--- a/src/sentry/tasks/seer/night_shift/agentic_triage.py
+++ b/src/sentry/tasks/seer/night_shift/agentic_triage.py
@@ -59,16 +59,16 @@ def _triage_candidates(
     """
     groups_by_id = {c.group.id: c.group for c in candidates}
 
-    client = SeerExplorerClient(
-        organization,
-        user=None,
-        category_key="night_shift",
-        category_value=f"org-{organization.id}",
-        intelligence_level="high",
-        reasoning_effort="high",
-    )
-
     try:
+        client = SeerExplorerClient(
+            organization,
+            user=None,
+            category_key="night_shift",
+            category_value=f"org-{organization.id}",
+            intelligence_level="high",
+            reasoning_effort="high",
+        )
+
         run_id = client.start_run(
             prompt=_build_triage_prompt(candidates),
             artifact_key="triage_verdicts",

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -4,6 +4,7 @@ from django.utils import timezone
 
 from sentry.models.group import Group
 from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
+from sentry.seer.explorer.client_models import Artifact, MemoryBlock, Message, SeerRunState
 from sentry.seer.models.night_shift import SeerNightShiftRun, SeerNightShiftRunIssue
 from sentry.seer.models.project_repository import SeerProjectRepository
 from sentry.tasks.seer.night_shift.cron import (
@@ -15,16 +16,31 @@ from sentry.tasks.seer.night_shift.simple_triage import fixability_score_strateg
 from sentry.testutils.cases import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.pytest.fixtures import django_db_all
-from sentry.utils import json
 
 
-def _mock_llm_response(group_ids: list[int], action: str = "autofix") -> MagicMock:
+def _mock_explorer_client(group_ids: list[int], action: str = "autofix") -> MagicMock:
+    """Create a mock SeerExplorerClient that returns triage verdicts."""
     verdicts = [{"group_id": gid, "action": action, "reason": "test"} for gid in group_ids]
-    content = json.dumps({"verdicts": verdicts})
-    response = MagicMock()
-    response.status = 200
-    response.data = json.dumps({"content": content}).encode()
-    return response
+    artifact = Artifact(key="triage_verdicts", data={"verdicts": verdicts}, reason="test")
+
+    state = SeerRunState(
+        run_id=1,
+        blocks=[
+            MemoryBlock(
+                id="test-block",
+                message=Message(role="assistant"),
+                timestamp="2025-01-01T00:00:00",
+                artifacts=[artifact],
+            ),
+        ],
+        status="completed",
+        updated_at="2025-01-01T00:00:00",
+    )
+
+    client = MagicMock()
+    client.start_run.return_value = 1
+    client.get_run.return_value = state
+    return client
 
 
 @django_db_all
@@ -165,10 +181,11 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
             seer_autofix_last_triggered=timezone.now(),
         )
 
+        mock_client = _mock_explorer_client([high_fix.id, low_fix.id])
         with (
             patch(
-                "sentry.tasks.seer.night_shift.agentic_triage.make_llm_generate_request",
-                return_value=_mock_llm_response([high_fix.id, low_fix.id]),
+                "sentry.tasks.seer.night_shift.agentic_triage.SeerExplorerClient",
+                return_value=mock_client,
             ),
             patch("sentry.tasks.seer.night_shift.cron.logger") as mock_logger,
         ):
@@ -203,10 +220,11 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
             project_b, "high-group", seer_fixability_score=0.95
         )
 
+        mock_client = _mock_explorer_client([high_group.id, low_group.id])
         with (
             patch(
-                "sentry.tasks.seer.night_shift.agentic_triage.make_llm_generate_request",
-                return_value=_mock_llm_response([high_group.id, low_group.id]),
+                "sentry.tasks.seer.night_shift.agentic_triage.SeerExplorerClient",
+                return_value=mock_client,
             ),
             patch("sentry.tasks.seer.night_shift.cron.logger") as mock_logger,
         ):

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from django.utils import timezone
 
@@ -18,29 +18,31 @@ from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.pytest.fixtures import django_db_all
 
 
-def _mock_explorer_client(group_ids: list[int], action: str = "autofix") -> MagicMock:
-    """Create a mock SeerExplorerClient that returns triage verdicts."""
-    verdicts = [{"group_id": gid, "action": action, "reason": "test"} for gid in group_ids]
-    artifact = Artifact(key="triage_verdicts", data={"verdicts": verdicts}, reason="test")
+class FakeExplorerClient:
+    """Stub SeerExplorerClient that returns canned triage verdicts."""
 
-    state = SeerRunState(
-        run_id=1,
-        blocks=[
-            MemoryBlock(
-                id="test-block",
-                message=Message(role="assistant"),
-                timestamp="2025-01-01T00:00:00",
-                artifacts=[artifact],
-            ),
-        ],
-        status="completed",
-        updated_at="2025-01-01T00:00:00",
-    )
+    def __init__(self, group_ids: list[int], action: str = "autofix"):
+        verdicts = [{"group_id": gid, "action": action, "reason": "test"} for gid in group_ids]
+        artifact = Artifact(key="triage_verdicts", data={"verdicts": verdicts}, reason="test")
+        self._state = SeerRunState(
+            run_id=1,
+            blocks=[
+                MemoryBlock(
+                    id="test-block",
+                    message=Message(role="assistant"),
+                    timestamp="2025-01-01T00:00:00",
+                    artifacts=[artifact],
+                ),
+            ],
+            status="completed",
+            updated_at="2025-01-01T00:00:00",
+        )
 
-    client = MagicMock()
-    client.start_run.return_value = 1
-    client.get_run.return_value = state
-    return client
+    def start_run(self, **kwargs):
+        return 1
+
+    def get_run(self, run_id, **kwargs):
+        return self._state
 
 
 @django_db_all
@@ -181,11 +183,11 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
             seer_autofix_last_triggered=timezone.now(),
         )
 
-        mock_client = _mock_explorer_client([high_fix.id, low_fix.id])
+        fake_client = FakeExplorerClient([high_fix.id, low_fix.id])
         with (
             patch(
                 "sentry.tasks.seer.night_shift.agentic_triage.SeerExplorerClient",
-                return_value=mock_client,
+                return_value=fake_client,
             ),
             patch("sentry.tasks.seer.night_shift.cron.logger") as mock_logger,
         ):
@@ -220,11 +222,11 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
             project_b, "high-group", seer_fixability_score=0.95
         )
 
-        mock_client = _mock_explorer_client([high_group.id, low_group.id])
+        fake_client = FakeExplorerClient([high_group.id, low_group.id])
         with (
             patch(
                 "sentry.tasks.seer.night_shift.agentic_triage.SeerExplorerClient",
-                return_value=mock_client,
+                return_value=fake_client,
             ),
             patch("sentry.tasks.seer.night_shift.cron.logger") as mock_logger,
         ):


### PR DESCRIPTION
Replace the single-shot LLM call in night shift triage with a Seer Explorer agent run that can investigate issues using tools before making triage decisions.

Previously, night shift made one LLM call with candidate metadata and asked for verdicts. Now it starts an Explorer session that can use `get_issue_details`, `get_event_details`, `code_search`, and other tools to investigate each issue before deciding whether to autofix, root-cause-only, or skip.

**Changes:**
- `agentic_triage.py`: Use `SeerExplorerClient` with artifact schema for structured verdicts, poll with logging to show tool calls in real-time, improved prompt with concrete fixability criteria from our fixability score rubric
- `client_models.py`: Add `Usage`/`UsageAccumulator` models so we can track token counts and dollar cost per Explorer run

Depends on getsentry/seer#5780 (merged) for the usage data in the Explorer state response.