### PR TITLE
fix(iswf): Validate that detectors are selected when saving alerts

### DIFF
--- a/static/app/views/automations/components/editConnectedMonitors.tsx
+++ b/static/app/views/automations/components/editConnectedMonitors.tsx
@@ -1,6 +1,7 @@
 import {Fragment, useCallback, useContext, useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
+import {Alert} from '@sentry/scraps/alert';
 import {Button, LinkButton} from '@sentry/scraps/button';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 
@@ -22,6 +23,7 @@ import type {Detector} from 'sentry/types/workflowEngine/detectors';
 import {useQueryClient} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
+import {AutomationBuilderErrorContext} from 'sentry/views/automations/components/automationBuilderErrorContext';
 import {ConnectedMonitorsList} from 'sentry/views/automations/components/connectedMonitorsList';
 import {useConnectedDetectors} from 'sentry/views/automations/hooks/useConnectedDetectors';
 import {DetectorSearch} from 'sentry/views/detectors/components/detectorSearch';
@@ -284,6 +286,8 @@ function SpecificMonitorsSection({
   );
 }
 
+export const CONNECTED_MONITORS_ERROR_ID = 'connectedMonitors';
+
 function EditConnectedMonitorsContent({
   initialMode,
   connectedIds,
@@ -291,6 +295,7 @@ function EditConnectedMonitorsContent({
 }: ContentProps) {
   const [monitorMode, setMonitorMode] = useState<MonitorMode>(initialMode);
   const {form} = useContext(FormContext);
+  const errorContext = useContext(AutomationBuilderErrorContext);
 
   const handleModeChange = useCallback(
     (newMode: MonitorMode) => {
@@ -302,11 +307,23 @@ function EditConnectedMonitorsContent({
   );
   const handleProjectChange = useCallback(
     (projectIds: string[]) => {
-      if (!projectIds.length) {
+      if (projectIds.length) {
+        errorContext?.removeError(CONNECTED_MONITORS_ERROR_ID);
+      } else {
         setConnectedIds([]);
       }
     },
-    [setConnectedIds]
+    [setConnectedIds, errorContext]
+  );
+
+  const handleSetConnectedIds = useCallback(
+    (ids: Automation['detectorIds']) => {
+      setConnectedIds(ids);
+      if (ids.length) {
+        errorContext?.removeError(CONNECTED_MONITORS_ERROR_ID);
+      }
+    },
+    [setConnectedIds, errorContext]
   );
 
   return (
@@ -332,8 +349,13 @@ function EditConnectedMonitorsContent({
           ) : (
             <SpecificMonitorsSection
               connectedIds={connectedIds}
-              setConnectedIds={setConnectedIds}
+              setConnectedIds={handleSetConnectedIds}
             />
+          )}
+          {errorContext?.errors[CONNECTED_MONITORS_ERROR_ID] && (
+            <Alert variant="danger">
+              {errorContext.errors[CONNECTED_MONITORS_ERROR_ID]}
+            </Alert>
           )}
         </Stack>
       </FormSection>

--- a/static/app/views/automations/edit.tsx
+++ b/static/app/views/automations/edit.tsx
@@ -42,6 +42,7 @@ import {
 } from 'sentry/views/automations/components/automationFormData';
 import {EditableAutomationName} from 'sentry/views/automations/components/editableAutomationName';
 import {EditAutomationActions} from 'sentry/views/automations/components/editAutomationActions';
+import {CONNECTED_MONITORS_ERROR_ID} from 'sentry/views/automations/components/editConnectedMonitors';
 import {getAutomationAnalyticsPayload} from 'sentry/views/automations/components/forms/common/getAutomationAnalyticsPayload';
 import {AutomationFormProvider} from 'sentry/views/automations/components/forms/context';
 import {useAutomationQuery, useUpdateAutomation} from 'sentry/views/automations/hooks';
@@ -143,6 +144,11 @@ function AutomationEditForm({automation}: {automation: Automation}) {
   const handleFormSubmit = useCallback<OnSubmitCallback>(
     async (data, onSubmitSuccess, onSubmitError, _event, formModel) => {
       const errors = validateAutomationBuilderState(state);
+      if (!data.detectorIds?.length && !data.projectIds?.length) {
+        errors[CONNECTED_MONITORS_ERROR_ID] = t(
+          'Select at least one project or monitor to create an alert.'
+        );
+      }
       setAutomationBuilderErrors(errors);
 
       if (Object.keys(errors).length > 0) {

--- a/static/app/views/automations/new.spec.tsx
+++ b/static/app/views/automations/new.spec.tsx
@@ -201,7 +201,12 @@ describe('AutomationNewSettings', () => {
       body: created,
     });
 
-    const {router} = render(<AutomationNewSettings />, {organization});
+    const {router} = render(<AutomationNewSettings />, {
+      organization,
+      initialRouterConfig: {
+        location: {pathname: '/', query: {connectedIds: '123'}},
+      },
+    });
 
     // Add an action filter (tagged event)
     await selectEvent.select(
@@ -283,7 +288,7 @@ describe('AutomationNewSettings', () => {
               },
             ],
             config: {frequency: 0},
-            detectorIds: [],
+            detectorIds: ['123'],
             enabled: true,
           },
         })
@@ -321,7 +326,12 @@ describe('AutomationNewSettings', () => {
       body: created,
     });
 
-    render(<AutomationNewSettings />, {organization});
+    render(<AutomationNewSettings />, {
+      organization,
+      initialRouterConfig: {
+        location: {pathname: '/', query: {connectedIds: '123'}},
+      },
+    });
 
     const addAction = async (label: string) => {
       await selectEvent.select(screen.getByRole('textbox', {name: 'Add action'}), label);
@@ -503,6 +513,33 @@ describe('AutomationNewSettings', () => {
       expect(action).toEqual(expect.objectContaining(expectedAction));
     });
   }, 10000);
+
+  it('shows validation error when submitting with no projects or monitors selected', async () => {
+    const post = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/workflows/`,
+      method: 'POST',
+      body: AutomationFixture(),
+    });
+
+    render(<AutomationNewSettings />, {organization});
+
+    // Add an action so the builder validation passes
+    await selectEvent.select(screen.getByRole('textbox', {name: 'Add action'}), 'Slack');
+    await userEvent.type(screen.getByRole('textbox', {name: 'Target'}), '#alerts');
+
+    // Submit with no projects or monitors selected
+    await userEvent.click(screen.getByRole('button', {name: 'Create Alert'}));
+
+    // Should show validation error
+    expect(
+      await screen.findByText(
+        'Select at least one project or monitor to create an alert.'
+      )
+    ).toBeInTheDocument();
+
+    // Should not have submitted
+    expect(post).not.toHaveBeenCalled();
+  });
 
   it('surfaces error details when test notification fails', async () => {
     jest.spyOn(indicators, 'addErrorMessage');

--- a/static/app/views/automations/new.tsx
+++ b/static/app/views/automations/new.tsx
@@ -35,6 +35,7 @@ import {
   validateAutomationBuilderState,
 } from 'sentry/views/automations/components/automationFormData';
 import {EditableAutomationName} from 'sentry/views/automations/components/editableAutomationName';
+import {CONNECTED_MONITORS_ERROR_ID} from 'sentry/views/automations/components/editConnectedMonitors';
 import {getAutomationAnalyticsPayload} from 'sentry/views/automations/components/forms/common/getAutomationAnalyticsPayload';
 import {AutomationFormProvider} from 'sentry/views/automations/components/forms/context';
 import {useCreateAutomation} from 'sentry/views/automations/hooks';
@@ -111,6 +112,11 @@ export default function AutomationNewSettings() {
   const handleSubmit = useCallback<OnSubmitCallback>(
     async (data, onSubmitSuccess, onSubmitError, _event, formModel) => {
       const errors = validateAutomationBuilderState(state);
+      if (!data.detectorIds?.length && !data.projectIds?.length) {
+        errors[CONNECTED_MONITORS_ERROR_ID] = t(
+          'Select at least one project or monitor to create an alert.'
+        );
+      }
       setAutomationBuilderErrors(errors);
 
       if (Object.keys(errors).length > 0) {


### PR DESCRIPTION
When creating or editing an alert with "Alert on all issues in selected projects" but no projects chosen, the form submits and creates a workflow with no connected detectors — the alert will never fire. Same for "Alert on specific monitors" with none connected.

Adds submit-time validation that checks both `projectIds` and `detectorIds` are not empty, showing an inline error in the Source section. The error clears when the user selects a project or connects a monitor.

Refs ISWF-2235