### PR TITLE
fix(ACI): Serialize activities correctly

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_incident.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_incident.py
@@ -96,7 +96,7 @@ class WorkflowEngineIncidentSerializer(Serializer):
         if "activities" in self.expand:
             gopas = list(
                 GroupOpenPeriodActivity.objects.filter(group_open_period__in=item_list).order_by(
-                    "date_added"
+                    "date_added", "id"
                 )[:1000]
             )
             open_period_activities: defaultdict[int, list[dict[str, Any]]] = defaultdict(list)

--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_incident.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_incident.py
@@ -11,18 +11,20 @@ from sentry.incidents.endpoints.serializers.incident import (
     IncidentSerializerResponse,
 )
 from sentry.incidents.endpoints.serializers.utils import get_fake_id_from_object_id
-from sentry.incidents.models.incident import IncidentStatus, IncidentStatusMethod, IncidentType
+from sentry.incidents.models.incident import (
+    IncidentActivityType,
+    IncidentStatus,
+    IncidentStatusMethod,
+    IncidentType,
+)
 from sentry.models.group import Group
 from sentry.models.groupopenperiod import GroupOpenPeriod
-from sentry.models.groupopenperiodactivity import GroupOpenPeriodActivity
+from sentry.models.groupopenperiodactivity import GroupOpenPeriodActivity, OpenPeriodActivityType
 from sentry.snuba.entity_subscription import apply_dataset_query_conditions
 from sentry.snuba.models import QuerySubscription, SnubaQuery
 from sentry.types.group import PriorityLevel
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
-from sentry.workflow_engine.endpoints.serializers.group_open_period_serializer import (
-    GroupOpenPeriodActivitySerializer,
-)
 from sentry.workflow_engine.models import (
     AlertRuleDetector,
     DataSourceDetector,
@@ -93,17 +95,37 @@ class WorkflowEngineIncidentSerializer(Serializer):
 
         if "activities" in self.expand:
             gopas = list(
-                GroupOpenPeriodActivity.objects.filter(group_open_period__in=item_list)[:1000]
+                GroupOpenPeriodActivity.objects.filter(group_open_period__in=item_list).order_by(
+                    "date_added"
+                )[:1000]
             )
-            open_period_activities = defaultdict(list)
-            # XXX: the incident endpoint is undocumented, so we aren' on the hook for supporting
-            # any specific payloads. Since this isn't used on the Sentry side for notification charts,
-            # I've opted to just use the GroupOpenPeriodActivity serializer.
-            for gopa, serialized_activity in zip(
-                gopas,
-                serialize(gopas, user=user, serializer=GroupOpenPeriodActivitySerializer()),
-            ):
-                open_period_activities[gopa.group_open_period_id].append(serialized_activity)
+            open_period_activities: defaultdict[int, list[dict[str, Any]]] = defaultdict(list)
+            for gopa in gopas:
+                existing = open_period_activities[gopa.group_open_period_id]
+                # Derive previousValue from the last activity's value in this open period
+                previous_value = existing[-1]["value"] if existing else None
+
+                # Map PriorityLevel → IncidentStatus numeric string. CLOSED activities always
+                # have value=None since closure has no associated priority, so we map those
+                # explicitly. Non-closed activities with a null value are malformed and skipped.
+                if gopa.value is not None:
+                    value: str = str(
+                        self.priority_to_incident_status.get(gopa.value, IncidentStatus.OPEN.value)
+                    )
+                elif gopa.type == OpenPeriodActivityType.CLOSED:
+                    value = str(IncidentStatus.CLOSED.value)
+                else:
+                    continue
+
+                existing.append(
+                    {
+                        "id": str(gopa.id),
+                        "type": IncidentActivityType.STATUS_CHANGE.value,
+                        "value": value,
+                        "previousValue": previous_value,
+                        "dateCreated": gopa.date_added,
+                    }
+                )
             for open_period in item_list:
                 if open_period in results:
                     results[open_period]["activities"] = open_period_activities[open_period.id]

--- a/tests/sentry/incidents/endpoints/serializers/test_incident.py
+++ b/tests/sentry/incidents/endpoints/serializers/test_incident.py
@@ -4,7 +4,11 @@ from django.utils import timezone
 
 from sentry.api.serializers import serialize
 from sentry.incidents.endpoints.serializers.alert_rule import DetailedAlertRuleSerializer
-from sentry.incidents.endpoints.serializers.incident import DetailedIncidentSerializer
+from sentry.incidents.endpoints.serializers.incident import (
+    DetailedIncidentSerializer,
+    IncidentSerializer,
+)
+from sentry.incidents.models.incident import IncidentActivityType, IncidentStatus
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
@@ -28,6 +32,30 @@ class IncidentSerializerTest(TestCase):
         assert result["dateDetected"] == incident.date_detected
         assert result["dateCreated"] == incident.date_added
         assert result["dateClosed"] == incident.date_closed
+
+    def test_with_activities(self) -> None:
+        incident = self.create_incident()
+        activity = self.create_incident_activity(
+            incident=incident,
+            type=IncidentActivityType.STATUS_CHANGE.value,
+            value=str(IncidentStatus.CRITICAL.value),
+            previous_value=str(IncidentStatus.WARNING.value),
+        )
+
+        result = serialize(incident, serializer=IncidentSerializer(expand=["activities"]))
+
+        assert result["activities"] is not None
+        assert len(result["activities"]) == 1
+        assert result["activities"][0] == {
+            "id": str(activity.id),
+            "incidentIdentifier": str(incident.identifier),
+            "user": None,
+            "type": IncidentActivityType.STATUS_CHANGE.value,
+            "value": str(IncidentStatus.CRITICAL.value),
+            "previousValue": str(IncidentStatus.WARNING.value),
+            "comment": None,
+            "dateCreated": activity.date_added,
+        }
 
 
 class DetailedIncidentSerializerTest(TestCase):

--- a/tests/sentry/incidents/endpoints/serializers/test_incident.py
+++ b/tests/sentry/incidents/endpoints/serializers/test_incident.py
@@ -49,9 +49,11 @@ class IncidentSerializerTest(TestCase):
         assert result["activities"][0] == {
             "id": str(activity.id),
             "incidentIdentifier": str(incident.identifier),
+            "user": None,
             "type": IncidentActivityType.STATUS_CHANGE.value,
             "value": str(IncidentStatus.CRITICAL.value),
             "previousValue": str(IncidentStatus.WARNING.value),
+            "comment": None,
             "dateCreated": activity.date_added,
         }
 

--- a/tests/sentry/incidents/endpoints/serializers/test_incident.py
+++ b/tests/sentry/incidents/endpoints/serializers/test_incident.py
@@ -49,11 +49,9 @@ class IncidentSerializerTest(TestCase):
         assert result["activities"][0] == {
             "id": str(activity.id),
             "incidentIdentifier": str(incident.identifier),
-            "user": None,
             "type": IncidentActivityType.STATUS_CHANGE.value,
             "value": str(IncidentStatus.CRITICAL.value),
             "previousValue": str(IncidentStatus.WARNING.value),
-            "comment": None,
             "dateCreated": activity.date_added,
         }
 

--- a/tests/sentry/incidents/serializers/test_workflow_engine_incident.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_incident.py
@@ -6,7 +6,12 @@ from sentry.incidents.endpoints.serializers.workflow_engine_incident import (
     WorkflowEngineDetailedIncidentSerializer,
     WorkflowEngineIncidentSerializer,
 )
-from sentry.incidents.models.incident import IncidentStatus, IncidentStatusMethod, IncidentType
+from sentry.incidents.models.incident import (
+    IncidentActivityType,
+    IncidentStatus,
+    IncidentStatusMethod,
+    IncidentType,
+)
 from sentry.models.groupopenperiodactivity import GroupOpenPeriodActivity, OpenPeriodActivityType
 from sentry.snuba.models import SnubaQueryEventType
 from sentry.types.group import PriorityLevel
@@ -140,11 +145,75 @@ class TestIncidentSerializer(TestWorkflowEngineSerializer):
             WorkflowEngineIncidentSerializer(expand=["activities"]),
         )
         assert len(serialized_incident["activities"]) == 1
-        serialized_activity = serialized_incident["activities"][0]
-        assert serialized_activity == {
+        assert serialized_incident["activities"][0] == {
             "id": str(gopa.id),
-            "type": OpenPeriodActivityType.OPENED.to_str(),
-            "value": PriorityLevel(self.group.priority).to_str(),
+            "type": IncidentActivityType.STATUS_CHANGE.value,
+            "value": str(IncidentStatus.CRITICAL.value),
+            "previousValue": None,
             "dateCreated": gopa.date_added,
-            "eventId": "a" * 32,
         }
+
+    def test_with_activities_tracks_previous_value(self) -> None:
+        GroupOpenPeriodActivity.objects.create(
+            date_added=self.group_open_period.date_added,
+            group_open_period=self.group_open_period,
+            type=OpenPeriodActivityType.OPENED,
+            value=self.group.priority,
+        )
+        gopa_status_change = GroupOpenPeriodActivity.objects.create(
+            date_added=self.group_open_period.date_added,
+            group_open_period=self.group_open_period,
+            type=OpenPeriodActivityType.STATUS_CHANGE,
+            value=PriorityLevel.MEDIUM,
+        )
+        serialized_incident = serialize(
+            self.group_open_period,
+            self.user,
+            WorkflowEngineIncidentSerializer(expand=["activities"]),
+        )
+        activities = serialized_incident["activities"]
+        assert len(activities) == 2
+        assert activities[0]["value"] == str(IncidentStatus.CRITICAL.value)
+        assert activities[0]["previousValue"] is None
+        assert activities[1]["value"] == str(IncidentStatus.WARNING.value)
+        assert activities[1]["previousValue"] == str(IncidentStatus.CRITICAL.value)
+        assert activities[1]["id"] == str(gopa_status_change.id)
+
+    def test_with_activities_closed_maps_to_closed_status(self) -> None:
+        GroupOpenPeriodActivity.objects.create(
+            date_added=self.group_open_period.date_added,
+            group_open_period=self.group_open_period,
+            type=OpenPeriodActivityType.OPENED,
+            value=self.group.priority,
+        )
+        gopa_closed = GroupOpenPeriodActivity.objects.create(
+            date_added=self.group_open_period.date_added,
+            group_open_period=self.group_open_period,
+            type=OpenPeriodActivityType.CLOSED,
+            value=None,
+        )
+        serialized_incident = serialize(
+            self.group_open_period,
+            self.user,
+            WorkflowEngineIncidentSerializer(expand=["activities"]),
+        )
+        activities = serialized_incident["activities"]
+        assert len(activities) == 2
+        assert activities[1]["id"] == str(gopa_closed.id)
+        assert activities[1]["value"] == str(IncidentStatus.CLOSED.value)
+        assert activities[1]["previousValue"] == str(IncidentStatus.CRITICAL.value)
+
+    def test_with_activities_skips_null_value_non_closed(self) -> None:
+        gopa_malformed = GroupOpenPeriodActivity.objects.create(
+            date_added=self.group_open_period.date_added,
+            group_open_period=self.group_open_period,
+            type=OpenPeriodActivityType.STATUS_CHANGE,
+            value=None,
+        )
+        serialized_incident = serialize(
+            self.group_open_period,
+            self.user,
+            WorkflowEngineIncidentSerializer(expand=["activities"]),
+        )
+        activity_ids = [a["id"] for a in serialized_incident["activities"]]
+        assert str(gopa_malformed.id) not in activity_ids


### PR DESCRIPTION
When attempting to load a monitor on the old UI that had any activity we were unable to render the page because the incident activity value was sometimes `null`. This PR updates how we serialize `GroupOpenPeriodActivity` objects into the legacy `Activity` format expected by the front end. 

Fixes https://sentry.sentry.io/issues/7411677694/