### PR TITLE
feat(snapshots): Show skipped count in status checks and PR comments

### DIFF
--- a/src/sentry/preprod/vcs/pr_comments/snapshot_templates.py
+++ b/src/sentry/preprod/vcs/pr_comments/snapshot_templates.py
@@ -10,8 +10,8 @@ from sentry.preprod.url_utils import get_preprod_artifact_comparison_url, get_pr
 _HEADER = "## Sentry Snapshot Testing"
 PROCESSING_STATUS = "⏳ Processing"
 COMPARISON_TABLE_HEADER = (
-    "| Name | Added | Removed | Modified | Renamed | Unchanged | Status |\n"
-    "| :--- | :---: | :---: | :---: | :---: | :---: | :---: |\n"
+    "| Name | Added | Removed | Modified | Renamed | Unchanged | Skipped | Status |\n"
+    "| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |\n"
 )
 
 
@@ -36,7 +36,7 @@ def format_snapshot_pr_comment(
         metrics = snapshot_metrics_map.get(artifact.id)
 
         if not metrics:
-            table_rows.append(f"| {name_cell} | - | - | - | - | - | {PROCESSING_STATUS} |")
+            table_rows.append(f"| {name_cell} | - | - | - | - | - | - | {PROCESSING_STATUS} |")
             continue
 
         comparison = comparisons_map.get(metrics.id)
@@ -45,21 +45,21 @@ def format_snapshot_pr_comment(
         if not comparison and not has_base:
             # No base to compare against — show snapshot count only
             table_rows.append(
-                f"| {name_cell} | - | - | - | - | - | ✅ {metrics.image_count} uploaded |"
+                f"| {name_cell} | - | - | - | - | - | - | ✅ {metrics.image_count} uploaded |"
             )
             continue
 
         if not comparison:
-            table_rows.append(f"| {name_cell} | - | - | - | - | - | {PROCESSING_STATUS} |")
+            table_rows.append(f"| {name_cell} | - | - | - | - | - | - | {PROCESSING_STATUS} |")
             continue
 
         if comparison.state in (
             PreprodSnapshotComparison.State.PENDING,
             PreprodSnapshotComparison.State.PROCESSING,
         ):
-            table_rows.append(f"| {name_cell} | - | - | - | - | - | {PROCESSING_STATUS} |")
+            table_rows.append(f"| {name_cell} | - | - | - | - | - | - | {PROCESSING_STATUS} |")
         elif comparison.state == PreprodSnapshotComparison.State.FAILED:
-            table_rows.append(f"| {name_cell} | - | - | - | - | - | ❌ Comparison failed |")
+            table_rows.append(f"| {name_cell} | - | - | - | - | - | - | ❌ Comparison failed |")
         else:
             base_artifact = base_artifact_map.get(artifact.id)
             artifact_url = (
@@ -86,6 +86,7 @@ def format_snapshot_pr_comment(
                 f" | {_section_cell(comparison.images_changed, 'changed', artifact_url)}"
                 f" | {_section_cell(comparison.images_renamed, 'renamed', artifact_url)}"
                 f" | {_section_cell(comparison.images_unchanged, 'unchanged', artifact_url)}"
+                f" | {_section_cell(comparison.images_skipped, 'skipped', artifact_url)}"
                 f" | {status} |"
             )
 

--- a/src/sentry/preprod/vcs/status_checks/snapshots/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/templates.py
@@ -38,6 +38,7 @@ def format_snapshot_status_check_messages(
     total_removed = 0
     total_renamed = 0
     total_unchanged = 0
+    total_skipped = 0
 
     for artifact in artifacts:
         metrics = snapshot_metrics_map.get(artifact.id)
@@ -58,6 +59,7 @@ def format_snapshot_status_check_messages(
             total_removed += comparison.images_removed
             total_renamed += comparison.images_renamed
             total_unchanged += comparison.images_unchanged
+            total_skipped += comparison.images_skipped
 
     if overall_status == StatusCheckStatus.IN_PROGRESS:
         subtitle = str(_("Comparing snapshots..."))
@@ -111,6 +113,17 @@ def format_snapshot_status_check_messages(
                 % {"count": total_unchanged}
             )
         subtitle = ", ".join(str(p) for p in parts)
+
+    if total_skipped > 0 and overall_status != StatusCheckStatus.IN_PROGRESS:
+        skipped_text = str(
+            ngettext(
+                "%(count)d skipped",
+                "%(count)d skipped",
+                total_skipped,
+            )
+            % {"count": total_skipped}
+        )
+        subtitle = f"{subtitle}, {skipped_text}"
 
     summary = _format_snapshot_summary(
         artifacts,
@@ -231,19 +244,19 @@ def _format_snapshot_summary(
 
         metrics = snapshot_metrics_map.get(artifact.id)
         if not metrics:
-            table_rows.append(f"| {name} | - | - | - | - | - | {PROCESSING_STATUS} |")
+            table_rows.append(f"| {name} | - | - | - | - | - | - | {PROCESSING_STATUS} |")
             continue
 
         comparison = comparisons_map.get(metrics.id)
         if not comparison:
-            table_rows.append(f"| {name} | - | - | - | - | - | {PROCESSING_STATUS} |")
+            table_rows.append(f"| {name} | - | - | - | - | - | - | {PROCESSING_STATUS} |")
             continue
 
         if comparison.state in (
             PreprodSnapshotComparison.State.PENDING,
             PreprodSnapshotComparison.State.PROCESSING,
         ):
-            table_rows.append(f"| {name} | - | - | - | - | - | {PROCESSING_STATUS} |")
+            table_rows.append(f"| {name} | - | - | - | - | - | - | {PROCESSING_STATUS} |")
         else:
             base_artifact = base_artifact_map.get(artifact.id)
             artifact_url = (
@@ -270,6 +283,7 @@ def _format_snapshot_summary(
                 f" | {_section_cell(comparison.images_changed, 'changed', artifact_url)}"
                 f" | {_section_cell(comparison.images_renamed, 'renamed', artifact_url)}"
                 f" | {_section_cell(comparison.images_unchanged, 'unchanged', artifact_url)}"
+                f" | {_section_cell(comparison.images_skipped, 'skipped', artifact_url)}"
                 f" | {status} |"
             )
 

--- a/tests/sentry/preprod/snapshots/test_auto_approve.py
+++ b/tests/sentry/preprod/snapshots/test_auto_approve.py
@@ -533,3 +533,55 @@ class TryAutoApproveSnapshotTest(TestCase):
             preprod_artifact=head_artifact,
             approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
         ).exists()
+
+    def test_auto_approves_selective_build_against_full_build(self):
+        sibling_images = {
+            "screen1.png": ComparisonImageResult(
+                status="changed", head_hash="abc", base_hash="old1"
+            ),
+            "screen2.png": ComparisonImageResult(
+                status="unchanged", head_hash="same", base_hash="same"
+            ),
+            "screen3.png": ComparisonImageResult(
+                status="unchanged", head_hash="same2", base_hash="same2"
+            ),
+        }
+        sibling, comp_key, comp_json = self._create_approved_sibling(
+            pr_number=42,
+            comparison_images=sibling_images,
+        )
+
+        cc = self.create_commit_comparison(
+            organization=self.organization,
+            pr_number=42,
+            head_repo_name="owner/repo",
+        )
+        head_artifact = self.create_preprod_artifact(
+            project=self.project,
+            commit_comparison=cc,
+            app_id="com.example.app",
+        )
+
+        head_manifest = self._create_head_manifest(
+            {
+                "screen1.png": ComparisonImageResult(
+                    status="changed", head_hash="abc", base_hash="old1"
+                ),
+                "screen2.png": ComparisonImageResult(
+                    status="unchanged", head_hash="same", base_hash="same"
+                ),
+                "screen3.png": ComparisonImageResult(status="skipped", base_hash="same2"),
+            }
+        )
+
+        session = _mock_session_with_manifests({comp_key: comp_json})
+        _try_auto_approve_snapshot(head_artifact, head_manifest, session)
+
+        approval = PreprodComparisonApproval.objects.get(
+            preprod_artifact=head_artifact,
+            preprod_feature_type=PreprodComparisonApproval.FeatureType.SNAPSHOTS,
+            approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
+        )
+        assert approval.extras is not None
+        assert approval.extras["auto_approval"] is True
+        assert approval.extras["prev_approved_artifact_id"] == sibling.id

--- a/tests/sentry/preprod/vcs/pr_comments/test_snapshot_templates.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_snapshot_templates.py
@@ -202,6 +202,7 @@ class FormatSnapshotPrCommentSuccessTest(SnapshotPrCommentTestBase):
         assert "`com.example.app`" in result
         # Zero counts are plain text, non-zero unchanged is linked
         assert "| 0 | 0 | 0 | 0 |" in result
+        assert "| 0 | ✅ Unchanged |" in result
         assert "?section=unchanged" in result
 
     def test_changes_show_needs_approval(self) -> None:
@@ -352,7 +353,10 @@ class FormatSnapshotPrCommentSuccessTest(SnapshotPrCommentTestBase):
             project=self.project,
         )
 
-        assert "| Name | Added | Removed | Modified | Renamed | Unchanged | Status |" in result
+        assert (
+            "| Name | Added | Removed | Modified | Renamed | Unchanged | Skipped | Status |"
+            in result
+        )
 
     def test_settings_link_included(self) -> None:
         artifact, metrics = self._create_artifact_with_metrics()
@@ -387,7 +391,10 @@ class FormatSnapshotPrCommentNoBaseTest(SnapshotPrCommentTestBase):
             [artifact], {artifact.id: metrics}, {}, {}, {}, project=self.project
         )
 
-        assert "| Name | Added | Removed | Modified | Renamed | Unchanged | Status |" in result
+        assert (
+            "| Name | Added | Removed | Modified | Renamed | Unchanged | Skipped | Status |"
+            in result
+        )
 
     def test_no_base_multiple_artifacts(self) -> None:
         artifacts = []

--- a/tests/sentry/preprod/vcs/status_checks/snapshots/test_tasks.py
+++ b/tests/sentry/preprod/vcs/status_checks/snapshots/test_tasks.py
@@ -6,6 +6,9 @@ from sentry.preprod.snapshots.utils import build_changes_map
 from sentry.preprod.vcs.status_checks.snapshots.tasks import (
     _compute_snapshot_status,
 )
+from sentry.preprod.vcs.status_checks.snapshots.templates import (
+    format_snapshot_status_check_messages,
+)
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import cell_silo_test
 
@@ -140,6 +143,74 @@ class BuildChangesMapTest(SnapshotTasksTestBase):
             [artifact], {artifact.id: metrics}, {metrics.id: _get_comparison(metrics)}
         )
         assert changes_map[artifact.id] is True
+
+
+@cell_silo_test
+class SnapshotStatusCheckWithSkippedTest(SnapshotTasksTestBase):
+    def _make_comparison_and_format(self, images_changed=0, images_skipped=0, images_unchanged=0):
+        artifact = self.create_preprod_artifact(
+            project=self.project, commit_comparison=self.commit_comparison
+        )
+        head_metrics = PreprodSnapshotMetrics.objects.create(
+            preprod_artifact=artifact, image_count=10
+        )
+        base_artifact = self.create_preprod_artifact(
+            project=self.project, commit_comparison=self.commit_comparison
+        )
+        PreprodSnapshotMetrics.objects.create(preprod_artifact=base_artifact, image_count=10)
+        comparison = PreprodSnapshotComparison.objects.create(
+            head_snapshot_metrics=head_metrics,
+            base_snapshot_metrics=PreprodSnapshotMetrics.objects.get(
+                preprod_artifact=base_artifact
+            ),
+            state=PreprodSnapshotComparison.State.SUCCESS,
+            images_changed=images_changed,
+            images_skipped=images_skipped,
+            images_unchanged=images_unchanged,
+        )
+        has_changes = images_changed > 0
+        status = StatusCheckStatus.FAILURE if has_changes else StatusCheckStatus.SUCCESS
+        _, subtitle, summary = format_snapshot_status_check_messages(
+            artifacts=[artifact],
+            snapshot_metrics_map={artifact.id: head_metrics},
+            comparisons_map={head_metrics.id: comparison},
+            overall_status=status,
+            base_artifact_map={artifact.id: base_artifact},
+            changes_map={artifact.id: has_changes},
+        )
+        return subtitle, summary
+
+    def test_changes_with_skipped_in_subtitle_and_summary(self):
+        subtitle, summary = self._make_comparison_and_format(
+            images_changed=2, images_skipped=50, images_unchanged=3
+        )
+
+        assert "2 modified" in subtitle
+        assert "50 skipped" in subtitle
+        assert "3 unchanged" in subtitle
+        assert "Skipped" in summary
+        assert "50" in summary
+
+    def test_no_changes_with_skipped(self):
+        subtitle, _ = self._make_comparison_and_format(images_skipped=300, images_unchanged=5)
+
+        assert subtitle == "No changes detected, 300 skipped"
+
+    def test_skipped_does_not_require_approval(self):
+        artifact, metrics, _ = self._make_artifact_with_comparison()
+        comparison = _get_comparison(metrics)
+        comparison.images_skipped = 100
+        comparison.save(update_fields=["images_skipped"])
+
+        changes_map = build_changes_map(
+            [artifact], {artifact.id: metrics}, {metrics.id: comparison}
+        )
+        assert changes_map[artifact.id] is False
+
+        status = _compute_snapshot_status(
+            [artifact], {artifact.id: metrics}, {metrics.id: comparison}, {}, changes_map
+        )
+        assert status == StatusCheckStatus.SUCCESS
 
 
 def _get_comparison(metrics: PreprodSnapshotMetrics) -> PreprodSnapshotComparison:

--- a/tests/sentry/preprod/vcs/status_checks/snapshots/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/snapshots/test_templates.py
@@ -531,8 +531,11 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
             {},
         )
 
-        assert "| Name | Added | Removed | Modified | Renamed | Unchanged | Status |" in summary
-        assert "| :--- | :---: | :---: | :---: | :---: | :---: | :---: |" in summary
+        assert (
+            "| Name | Added | Removed | Modified | Renamed | Unchanged | Skipped | Status |"
+            in summary
+        )
+        assert "| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |" in summary
 
     def test_summary_has_no_settings_link(self) -> None:
         head_artifact, head_metrics = self._create_artifact_with_metrics()
@@ -640,11 +643,12 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
         assert subtitle == "No changes detected"
 
         expected = (
-            "| Name | Added | Removed | Modified | Renamed | Unchanged | Status |\n"
-            "| :--- | :---: | :---: | :---: | :---: | :---: | :---: |\n"
+            "| Name | Added | Removed | Modified | Renamed | Unchanged | Skipped | Status |\n"
+            "| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |\n"
             f"| [My App]({artifact_url})<br>`com.example.app`"
             f" | 0 | 0 | 0 | 0"
             f" | [{15}]({artifact_url}?section=unchanged)"
+            f" | 0"
             f" | ✅ Unchanged |"
         )
         assert summary == expected
@@ -682,14 +686,15 @@ class SnapshotSummaryFormattingTest(SnapshotStatusCheckTestBase):
         assert subtitle == "3 modified, 1 added, 2 removed, 1 renamed, 4 unchanged"
 
         expected = (
-            "| Name | Added | Removed | Modified | Renamed | Unchanged | Status |\n"
-            "| :--- | :---: | :---: | :---: | :---: | :---: | :---: |\n"
+            "| Name | Added | Removed | Modified | Renamed | Unchanged | Skipped | Status |\n"
+            "| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |\n"
             f"| [My App]({artifact_url})<br>`com.example.app`"
             f" | [{1}]({artifact_url}?section=added)"
             f" | [{2}]({artifact_url}?section=removed)"
             f" | [{3}]({artifact_url}?section=changed)"
             f" | [{1}]({artifact_url}?section=renamed)"
             f" | [{4}]({artifact_url}?section=unchanged)"
+            f" | 0"
             f" | ⏳ Needs approval |"
         )
         assert summary == expected
@@ -1035,14 +1040,15 @@ class SnapshotApprovalFormattingTest(SnapshotStatusCheckTestBase):
         assert subtitle == "3 modified, 1 added, 2 removed, 1 renamed, 4 unchanged"
 
         expected = (
-            "| Name | Added | Removed | Modified | Renamed | Unchanged | Status |\n"
-            "| :--- | :---: | :---: | :---: | :---: | :---: | :---: |\n"
+            "| Name | Added | Removed | Modified | Renamed | Unchanged | Skipped | Status |\n"
+            "| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |\n"
             f"| [My App]({artifact_url})<br>`com.example.app`"
             f" | [{1}]({artifact_url}?section=added)"
             f" | [{2}]({artifact_url}?section=removed)"
             f" | [{3}]({artifact_url}?section=changed)"
             f" | [{1}]({artifact_url}?section=renamed)"
             f" | [{4}]({artifact_url}?section=unchanged)"
+            f" | 0"
             f" | ✅ Approved |"
         )
         assert summary == expected


### PR DESCRIPTION
Surface skipped image counts from selective testing in VCS integrations:

- Status check subtitle always appends skipped count when non-zero
  (e.g. "No changes detected, 300 skipped" or "2 modified, 300 skipped")
- Skipped column added to PR comment and status check summary tables
- Skipped images do not affect the "No changes detected" signal or
  trigger approval requirements

**Stack:** [1/3 Schema](https://github.com/getsentry/sentry/pull/113005) | [2/3 Core logic](https://github.com/getsentry/sentry/pull/113006) | 3/3 VCS presentation