### PR TITLE
feat(detectors): Add connected line graph to mobile build visualization

### DIFF
--- a/static/app/views/detectors/components/detectorTypeForm.tsx
+++ b/static/app/views/detectors/components/detectorTypeForm.tsx
@@ -707,7 +707,7 @@ function MobileBuildVisualization() {
   const danger = theme.colors.red400;
   const accent =
     theme.chart.getColorPalette(0)[0] ?? theme.tokens.graphics.accent.vibrant;
-  const bg = theme.tokens.background.secondary;
+  const bg = theme.tokens.background.primary;
 
   return (
     <svg fill="none" viewBox="0 0 480 56">

--- a/static/app/views/detectors/components/detectorTypeForm.tsx
+++ b/static/app/views/detectors/components/detectorTypeForm.tsx
@@ -95,6 +95,13 @@ function MonitorTypeField() {
       disabled: !canCreateMetricDetector,
     },
     {
+      id: 'preprod_size_analysis',
+      name: getDetectorTypeLabel('preprod_size_analysis'),
+      description: t('Monitor mobile app build sizes and detect regressions.'),
+      visualization: <MobileBuildVisualization />,
+      show: !!organization?.features?.includes('preprod-size-monitors-frontend'),
+    },
+    {
       id: 'monitor_check_in_failure',
       name: getDetectorTypeLabel('monitor_check_in_failure'),
       description: t(
@@ -115,13 +122,6 @@ function MonitorTypeField() {
           ),
         }
       ),
-    },
-    {
-      id: 'preprod_size_analysis',
-      name: getDetectorTypeLabel('preprod_size_analysis'),
-      description: t('Monitor mobile app build sizes and detect regressions.'),
-      visualization: null,
-      show: !!organization?.features?.includes('preprod-size-monitors-frontend'),
     },
   ];
 
@@ -698,6 +698,82 @@ function UptimeVisualization() {
       <rect width="4" height="14" x="444.254" y="20.991" fill={danger} rx="2" />
       <rect width="4" height="14" x="456.254" y="20.991" fill={danger} rx="2" />
       <rect width="4" height="14" x="468.254" y="20.991" fill={danger} rx="2" />
+    </svg>
+  );
+}
+
+function MobileBuildVisualization() {
+  const theme = useTheme();
+  const danger = theme.colors.red400;
+  const accent =
+    theme.chart.getColorPalette(0)[0] ?? theme.tokens.graphics.accent.vibrant;
+  const bg = theme.tokens.background.secondary;
+
+  return (
+    <svg fill="none" viewBox="0 0 480 56">
+      <rect x="0" y="0" width="480" height="27.6" fill={danger} fillOpacity="0.1" />
+      <line
+        x1="0"
+        y1="27.6"
+        x2="480"
+        y2="27.6"
+        stroke={danger}
+        strokeWidth="0.5"
+        strokeDasharray="2.4 2.4"
+      />
+      <polyline
+        fill="none"
+        stroke={accent}
+        strokeWidth="1.0"
+        points="7.9,38.5 18.1,40.1 28.3,42.4 38.5,39.4 48.7,49.2 58.9,38.7 69.1,22.6 79.3,41.0 89.5,41.9 99.7,33.6 109.9,40.3 120.0,43.2 130.2,38.3 140.4,44.8 150.6,38.8 160.8,42.3 171.0,39.9 181.2,15.9 191.4,42.6 201.6,39.6 211.8,40.6 222.0,38.1 232.2,42.8 242.4,40.5 252.5,39.0 262.7,41.5 272.9,40.1 283.1,39.4 293.3,8.5 303.5,41.0 313.7,42.1 323.9,38.7 334.1,49.2 344.3,39.2 354.5,42.4 364.7,39.7 374.9,38.5 385.1,43.0 395.2,16.6 405.4,38.8 415.6,40.8 425.8,41.7 436.0,38.3 446.2,41.2 456.4,39.6 466.6,42.3 476.8,40.3"
+      />
+      <circle cx="7.9" cy="38.5" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="18.1" cy="40.1" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="28.3" cy="42.4" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="38.5" cy="39.4" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="48.7" cy="49.2" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="58.9" cy="38.7" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="69.1" cy="22.6" r="2" fill={bg} strokeWidth="1.5" stroke={danger} />
+      <circle cx="79.3" cy="41.0" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="89.5" cy="41.9" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="99.7" cy="33.6" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="109.9" cy="40.3" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="120.0" cy="43.2" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="130.2" cy="38.3" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="140.4" cy="44.8" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="150.6" cy="38.8" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="160.8" cy="42.3" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="171.0" cy="39.9" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="181.2" cy="15.9" r="2" fill={bg} strokeWidth="1.5" stroke={danger} />
+      <circle cx="191.4" cy="42.6" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="201.6" cy="39.6" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="211.8" cy="40.6" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="222.0" cy="38.1" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="232.2" cy="42.8" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="242.4" cy="40.5" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="252.5" cy="39.0" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="262.7" cy="41.5" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="272.9" cy="40.1" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="283.1" cy="39.4" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="293.3" cy="8.5" r="2" fill={bg} strokeWidth="1.5" stroke={danger} />
+      <circle cx="303.5" cy="41.0" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="313.7" cy="42.1" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="323.9" cy="38.7" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="334.1" cy="49.2" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="344.3" cy="39.2" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="354.5" cy="42.4" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="364.7" cy="39.7" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="374.9" cy="38.5" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="385.1" cy="43.0" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="395.2" cy="16.6" r="2" fill={bg} strokeWidth="1.5" stroke={danger} />
+      <circle cx="405.4" cy="38.8" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="415.6" cy="40.8" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="425.8" cy="41.7" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="436.0" cy="38.3" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="446.2" cy="41.2" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="456.4" cy="39.6" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="466.6" cy="42.3" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
+      <circle cx="476.8" cy="40.3" r="2" fill={bg} strokeWidth="1.5" stroke={accent} />
     </svg>
   );
 }


### PR DESCRIPTION
Add a line-graph polyline connecting all data points in the `MobileBuildVisualization` SVG, giving the chart a connected appearance instead of isolated dots.

Circles are filled with the parent container's background color so the polyline appears cleanly interrupted at each data point rather than showing through underneath.

Also moves the `preprod_size_analysis` detector type entry higher in the list and wires it up to the new visualization (previously `visualization: null`).