### PR TITLE
fix(auth): Add diagnostic logging to ViewerContextAuthentication

### DIFF
--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -801,31 +801,29 @@ class ViewerContextAuthentication(BaseAuthentication):
         verification_keys = _get_verification_keys()
         vc = viewer_context_from_header(header, signature)
 
-        logger.info(
-            "viewer_context_auth.attempt",
-            extra={
-                "header_length": len(header),
-                "header_is_jwt": "." in header and header.count(".") == 2,
-                "signature_present": signature is not None,
-                "signature_length": len(signature) if signature else 0,
-                "verification_key_count": len(verification_keys),
-                "vc_resolved": vc is not None,
-                "vc_user_id": vc.user_id if vc else None,
-                "path": request.path,
-            },
-        )
-
         if vc is None or vc.user_id is None:
+            logger.warning(
+                "viewer_context_auth.failed",
+                extra={
+                    "reason": "vc_not_resolved" if vc is None else "no_user_id",
+                    "header_length": len(header),
+                    "header_is_jwt": "." in header and header.count(".") == 2,
+                    "signature_present": signature is not None,
+                    "signature_length": len(signature) if signature else 0,
+                    "verification_key_count": len(verification_keys),
+                    "path": request.path,
+                },
+            )
             return None
 
         user = user_service.get_user(user_id=vc.user_id)
         if user is None or not user.is_active:
-            logger.info(
-                "viewer_context_auth.user_lookup_failed",
+            logger.warning(
+                "viewer_context_auth.failed",
                 extra={
+                    "reason": "user_not_found" if user is None else "user_inactive",
                     "vc_user_id": vc.user_id,
-                    "user_found": user is not None,
-                    "user_active": user.is_active if user else None,
+                    "path": request.path,
                 },
             )
             return None

--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -789,19 +789,45 @@ class ViewerContextAuthentication(BaseAuthentication):
     """
 
     def authenticate(self, request: Request) -> tuple[Any, Any] | None:
-        from sentry.viewer_context import viewer_context_from_header
+        from sentry.viewer_context import _get_verification_keys, viewer_context_from_header
 
         header = request.META.get("HTTP_X_VIEWER_CONTEXT")
         if not header:
             return None
 
+        # TODO(jstanley): Temporary diagnostics for debugging prod 401s.
+        # Remove once the auth issue is resolved.
         signature = request.META.get("HTTP_X_VIEWER_CONTEXT_SIGNATURE")
+        verification_keys = _get_verification_keys()
         vc = viewer_context_from_header(header, signature)
+
+        logger.info(
+            "viewer_context_auth.attempt",
+            extra={
+                "header_length": len(header),
+                "header_is_jwt": "." in header and header.count(".") == 2,
+                "signature_present": signature is not None,
+                "signature_length": len(signature) if signature else 0,
+                "verification_key_count": len(verification_keys),
+                "vc_resolved": vc is not None,
+                "vc_user_id": vc.user_id if vc else None,
+                "path": request.path,
+            },
+        )
+
         if vc is None or vc.user_id is None:
             return None
 
         user = user_service.get_user(user_id=vc.user_id)
         if user is None or not user.is_active:
+            logger.info(
+                "viewer_context_auth.user_lookup_failed",
+                extra={
+                    "vc_user_id": vc.user_id,
+                    "user_found": user is not None,
+                    "user_active": user.is_active if user else None,
+                },
+            )
             return None
 
         sentry_sdk.get_isolation_scope().set_tag("viewer_context_auth", True)

--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -795,13 +795,14 @@ class ViewerContextAuthentication(BaseAuthentication):
         if not header:
             return None
 
-        # TODO(jstanley): Temporary diagnostics for debugging prod 401s.
-        # Remove once the auth issue is resolved.
         signature = request.META.get("HTTP_X_VIEWER_CONTEXT_SIGNATURE")
         verification_keys = _get_verification_keys()
         vc = viewer_context_from_header(header, signature)
 
         if vc is None or vc.user_id is None:
+            # TODO(jstanley): Temporary logging for debugging non-public prod 401s
+            # during X-Viewer-Context propagation (Seer code mode callbacks).
+            # Remove once the auth issue is resolved.
             logger.warning(
                 "viewer_context_auth.failed",
                 extra={
@@ -818,6 +819,9 @@ class ViewerContextAuthentication(BaseAuthentication):
 
         user = user_service.get_user(user_id=vc.user_id)
         if user is None or not user.is_active:
+            # TODO(jstanley): Temporary logging for debugging non-public prod 401s
+            # during X-Viewer-Context propagation (Seer code mode callbacks).
+            # Remove once the auth issue is resolved.
             logger.warning(
                 "viewer_context_auth.failed",
                 extra={


### PR DESCRIPTION
## Summary
- Adds temporary diagnostic logging inside `ViewerContextAuthentication.authenticate()` to debug 401s in production
- Logs only metadata: header length, JWT detection, signature presence/length, verification key count, resolution result
- No header values, signatures, or user content logged
- Only fires when `X-Viewer-Context` header is present (code mode callbacks only)

## Context
Code mode callbacks to Sentry are returning 401 in production. Seer-side instrumentation confirms headers are sent correctly. We need to see what Django receives and which step in the authenticator returns `None`.

## Test plan
- [ ] Deploy and trigger code mode query
- [ ] Check for `viewer_context_auth.attempt` log in Sentry
- [ ] Identify which field indicates the failure point

🤖 Generated with [Claude Code](https://claude.com/claude-code)