### PR TITLE
ref(ci): Update sentry-cli to 3.3.5 and simplify snapshot upload

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -3,6 +3,9 @@
 sentry_frontend_workflow_file: &sentry_frontend_workflow_file
   - added|modified: '.github/workflows/frontend.yml'
 
+sentry_frontend_snapshots_workflow_file: &sentry_frontend_snapshots_workflow_file
+  - added|modified: '.github/workflows/frontend-snapshots.yml'
+
 # Provides list of changed files to test (jest)
 # getsentry/sentry does not use the list directly, instead we shard tests inside jest.config.js
 testable_modified: &testable_modified
@@ -30,6 +33,7 @@ typecheckable_rules_changed: &typecheckable_rules_changed
 # Trigger to apply the 'Scope: Frontend' label to PRs
 frontend_all: &frontend_all
   - *sentry_frontend_workflow_file
+  - *sentry_frontend_snapshots_workflow_file
   - added|modified: '**/*.{ts,tsx,js,jsx,mjs}'
   - added|modified: 'static/**/*.{less,json,yml,md,mdx}'
   - added|modified: '{vercel,tsconfig,biome,package}.json'

--- a/.github/workflows/frontend-snapshots.yml
+++ b/.github/workflows/frontend-snapshots.yml
@@ -69,37 +69,19 @@ jobs:
 
       - name: Install sentry-cli
         if: ${{ !cancelled() }}
-        run: curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=3.3.4 sh
+        run: curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=3.3.5 sh
 
       - name: Upload snapshots
         id: upload
         if: ${{ !cancelled() }}
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_SNAPSHOTS_AUTH_TOKEN }}
-        run: |
-          ARGS=(
-            --log-level=debug
-            --auth-token "${{ secrets.SENTRY_SNAPSHOTS_AUTH_TOKEN }}"
-            build snapshots "${{ env.SNAPSHOT_OUTPUT_DIR }}"
-            --app-id sentry-frontend
-            --project sentry-frontend
-            --head-sha "${{ github.event.pull_request.head.sha || github.sha }}"
-            --vcs-provider github
-            --head-repo-name "${{ github.repository }}"
-          )
-
-          # PR-only flags: base-sha, base-ref, base-repo-name, head-ref, pr-number
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            ARGS+=(
-              --base-sha "${{ github.event.pull_request.base.sha }}"
-              --base-repo-name "${{ github.repository }}"
-              --head-ref "${{ github.head_ref }}"
-              --base-ref "${{ github.base_ref }}"
-              --pr-number "${{ github.event.number }}"
-            )
-          fi
-
-          sentry-cli "${ARGS[@]}"
+        run: >
+          sentry-cli
+          --log-level=debug
+          build snapshots "${{ env.SNAPSHOT_OUTPUT_DIR }}"
+          --app-id sentry-frontend
+          --project sentry-frontend
 
       - name: Report upload failure to Sentry
         if: ${{ failure() && steps.upload.outcome == 'failure' }}


### PR DESCRIPTION
## Summary

- Update sentry-cli from 3.3.4 to 3.3.5 in the frontend-snapshots workflow
- Remove manually specified git metadata flags that sentry-cli automatically detects from the GitHub Actions environment (`--head-sha`, `--base-sha`, `--vcs-provider`, `--head-repo-name`, `--base-repo-name`, `--head-ref`, `--base-ref`, `--pr-number`, `--auth-token`)