### PR TITLE
ref(monitors): Portal disable/edit actions to TopBar when page frame is enabled

### DIFF
--- a/static/app/views/detectors/components/details/common/header.tsx
+++ b/static/app/views/detectors/components/details/common/header.tsx
@@ -1,3 +1,5 @@
+import {Fragment} from 'react';
+
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import {DetailLayout} from 'sentry/components/workflowEngine/layout/detail';
 import {t} from 'sentry/locale';
@@ -49,24 +51,35 @@ export function DetectorDetailsDefaultHeaderContent({
   project: Project;
 }) {
   const hasPageFrameFeature = useHasPageFrameFeature();
+
+  if (hasPageFrameFeature) {
+    return (
+      <TopBar.Slot name="title">
+        <DetectorDetailsBreadcrumbs detector={detector} />
+      </TopBar.Slot>
+    );
+  }
+
   return (
     <DetailLayout.HeaderContent>
-      {hasPageFrameFeature ? (
-        <TopBar.Slot name="title">
-          <DetectorDetailsBreadcrumbs detector={detector} />
-        </TopBar.Slot>
-      ) : (
-        <DetectorDetailsBreadcrumbs detector={detector} />
-      )}
-      {!hasPageFrameFeature && (
-        <DetailLayout.Title title={detector.name} project={project} />
-      )}
+      <DetectorDetailsBreadcrumbs detector={detector} />
+      <DetailLayout.Title title={detector.name} project={project} />
     </DetailLayout.HeaderContent>
   );
 }
 
 function DetectorDetailsDefaultActions({detector}: {detector: Detector}) {
-  return (
+  const hasPageFrameFeature = useHasPageFrameFeature();
+
+  return hasPageFrameFeature ? (
+    <Fragment>
+      <TopBar.Slot name="actions">
+        <DisableDetectorAction detector={detector} />
+        <EditDetectorAction detector={detector} />
+      </TopBar.Slot>
+      <MonitorFeedbackButton />
+    </Fragment>
+  ) : (
     <DetailLayout.Actions>
       <MonitorFeedbackButton />
       <DisableDetectorAction detector={detector} />
@@ -76,6 +89,17 @@ function DetectorDetailsDefaultActions({detector}: {detector: Detector}) {
 }
 
 export function DetectorDetailsHeader({detector, project}: DetectorDetailsHeaderProps) {
+  const hasPageFrameFeature = useHasPageFrameFeature();
+
+  if (hasPageFrameFeature) {
+    return (
+      <Fragment>
+        <DetectorDetailsDefaultHeaderContent detector={detector} project={project} />
+        <DetectorDetailsDefaultActions detector={detector} />
+      </Fragment>
+    );
+  }
+
   return (
     <DetailLayout.Header>
       <DetectorDetailsDefaultHeaderContent detector={detector} project={project} />

--- a/static/app/views/detectors/components/details/error/index.tsx
+++ b/static/app/views/detectors/components/details/error/index.tsx
@@ -1,3 +1,5 @@
+import {Fragment} from 'react';
+
 import {ExternalLink, Link} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
@@ -19,6 +21,8 @@ import {DetectorDetailsDefaultHeaderContent} from 'sentry/views/detectors/compon
 import {DetectorDetailsOngoingIssues} from 'sentry/views/detectors/components/details/common/ongoingIssues';
 import {MonitorFeedbackButton} from 'sentry/views/detectors/components/monitorFeedbackButton';
 import {useCanEditDetectorWorkflowConnections} from 'sentry/views/detectors/utils/useCanEditDetector';
+import {TopBar} from 'sentry/views/navigation/topBar';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 type ErrorDetectorDetailsProps = {
   detector: Detector;
@@ -72,16 +76,27 @@ export function ErrorDetectorDetails({detector, project}: ErrorDetectorDetailsPr
   const organization = useOrganization();
   const canEdit = useCanEditDetectorWorkflowConnections({projectId: project.id});
   const {selection} = usePageFilters();
+  const hasPageFrameFeature = useHasPageFrameFeature();
 
   return (
     <DetailLayout>
-      <DetailLayout.Header>
-        <DetectorDetailsDefaultHeaderContent detector={detector} project={project} />
-        <DetailLayout.Actions>
+      {hasPageFrameFeature ? (
+        <Fragment>
+          <DetectorDetailsDefaultHeaderContent detector={detector} project={project} />
+          <TopBar.Slot name="actions">
+            <EditDetectorAction detector={detector} canEdit={canEdit} />
+          </TopBar.Slot>
           <MonitorFeedbackButton />
-          <EditDetectorAction detector={detector} canEdit={canEdit} />
-        </DetailLayout.Actions>
-      </DetailLayout.Header>
+        </Fragment>
+      ) : (
+        <DetailLayout.Header>
+          <DetectorDetailsDefaultHeaderContent detector={detector} project={project} />
+          <DetailLayout.Actions>
+            <MonitorFeedbackButton />
+            <EditDetectorAction detector={detector} canEdit={canEdit} />
+          </DetailLayout.Actions>
+        </DetailLayout.Header>
+      )}
       <DetailLayout.Body>
         <DetailLayout.Main>
           <DisabledAlert


### PR DESCRIPTION
Updated uptime monitor layout by portaling the actions into the topbar slot