### PR TITLE
ref(preprod): Disable snapshot PR comments by default

### DIFF
--- a/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
@@ -76,7 +76,7 @@ def create_preprod_snapshot_pr_comment_task(
         )
         return
 
-    if not artifact.project.get_option(ENABLED_OPTION_KEY, default=True):
+    if not artifact.project.get_option(ENABLED_OPTION_KEY):
         logger.info(
             "preprod.snapshot_pr_comments.create.project_disabled",
             extra={"artifact_id": artifact.id, "project_id": artifact.project.id},

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -220,7 +220,7 @@ register(key="sentry:preprod_distribution_enabled_query", default="")
 register(key="sentry:preprod_distribution_pr_comments_enabled_by_customer", default=True)
 
 # Boolean to enable/disable snapshot PR comments for this project.
-register(key="sentry:preprod_snapshot_pr_comments_enabled", default=True)
+register(key="sentry:preprod_snapshot_pr_comments_enabled", default=False)
 
 # Whether to enable on-demand source context fetching from SCM integrations
 register(key="sentry:scm_source_context_enabled", default=False)

--- a/tests/sentry/preprod/vcs/pr_comments/test_snapshot_tasks.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_snapshot_tasks.py
@@ -27,6 +27,7 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
             teams=[self.team], organization=self.organization, name="test_project"
         )
         self._feature = "organizations:preprod-snapshot-pr-comments"
+        self.project.update_option("sentry:preprod_snapshot_pr_comments_enabled", True)
 
     def _create_artifact_with_metrics(
         self,


### PR DESCRIPTION
Change the default for `sentry:preprod_snapshot_pr_comments_enabled` from `True` to `False` so snapshot PR comments are opt-in rather than opt-out. Users can still enable them per-project via the toggle in project settings.