### PR TITLE
ref(cmdk): Guard GlobalCommandPaletteActions behind cmd-k-supercharged at the mount site

### DIFF
--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -79,7 +79,6 @@ function renderAsyncResult(item: CommandPaletteAction, index: number) {
 export function GlobalCommandPaletteActions() {
   const organization = useOrganization();
   const user = useUser();
-  const hasDsnLookup = organization.features.includes('cmd-k-dsn-lookup');
   const {projects} = useProjects();
   const {mutateAsync: mutateUserOptions} = useMutateUserOptions();
   const {starredViews} = useStarredIssueViews();
@@ -90,6 +89,11 @@ export function GlobalCommandPaletteActions() {
     onSuccess: () => window.location.reload(),
   });
 
+  if (!organization.features.includes('cmd-k-supercharged')) {
+    return null;
+  }
+
+  const hasDsnLookup = organization.features.includes('cmd-k-dsn-lookup');
   const prefix = `/organizations/${organization.slug}`;
 
   return (

--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -89,10 +89,6 @@ export function GlobalCommandPaletteActions() {
     onSuccess: () => window.location.reload(),
   });
 
-  if (!organization.features.includes('cmd-k-supercharged')) {
-    return null;
-  }
-
   const hasDsnLookup = organization.features.includes('cmd-k-dsn-lookup');
   const prefix = `/organizations/${organization.slug}`;
 

--- a/static/app/views/navigation/index.tsx
+++ b/static/app/views/navigation/index.tsx
@@ -55,6 +55,7 @@ function CommandPaletteSlotOutlets() {
 }
 
 function UserAndOrganizationNavigation() {
+  const organization = useOrganization();
   const {layout} = usePrimaryNavigation();
   const {visible} = useGlobalModal();
   const {view, setView} = useSecondaryNavigation();
@@ -76,7 +77,9 @@ function UserAndOrganizationNavigation() {
     <NavigationLayout>
       <CommandPaletteHotkeys />
       <CommandPaletteSlotOutlets />
-      <GlobalCommandPaletteActions />
+      {organization.features.includes('cmd-k-supercharged') && (
+        <GlobalCommandPaletteActions />
+      )}
       {layout === 'mobile' ? (
         <MobileSecondaryNavigationContextProvider>
           {hasPageFrame ? <MobilePageFrameNavigation /> : <MobileNavigation />}


### PR DESCRIPTION
## Changes

Moves the \`cmd-k-supercharged\` feature flag check from inside \`GlobalCommandPaletteActions\` to its call site in \`navigation/index.tsx\`.

When the flag is disabled the component is never mounted, so hooks like \`useStarredIssueViews\`, \`useGetStarredDashboards\`, and \`useProjects\` never run and no unnecessary API calls are made on every page load for orgs without the flag.