### PR TITLE
fix(ui): Fix the logs page divider

### DIFF
--- a/static/app/components/layouts/thirds.tsx
+++ b/static/app/components/layouts/thirds.tsx
@@ -1,4 +1,4 @@
-import {useContext, type HTMLAttributes} from 'react';
+import {type HTMLAttributes} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -10,8 +10,6 @@ import {
 } from '@sentry/scraps/layout';
 import {Tabs} from '@sentry/scraps/tabs';
 
-import {usePrimaryNavigation} from 'sentry/views/navigation/primaryNavigationContext';
-import {SecondaryNavigationContext} from 'sentry/views/navigation/secondaryNavigationContext';
 import {TopBar} from 'sentry/views/navigation/topBar';
 import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
@@ -20,27 +18,11 @@ import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFea
  */
 export function Page(props: FlexProps<'main'> & {withPadding?: boolean}) {
   const hasPageFrame = useHasPageFrameFeature();
-  const primaryNavigation = usePrimaryNavigation();
-  const secondaryNavigation = useContext(SecondaryNavigationContext);
 
   const {withPadding, ...rest} = props;
 
   if (hasPageFrame) {
-    return (
-      <Stack
-        as="main"
-        flex="1"
-        borderLeft={
-          secondaryNavigation?.view === 'expanded'
-            ? primaryNavigation.layout === 'sidebar'
-              ? 'primary'
-              : undefined
-            : undefined
-        }
-        background="primary"
-        {...rest}
-      />
-    );
+    return <Stack as="main" flex="1" background="primary" {...rest} />;
   }
 
   return (

--- a/static/app/views/navigation/secondary/components.tsx
+++ b/static/app/views/navigation/secondary/components.tsx
@@ -181,18 +181,11 @@ function SecondarySidebar({children}: SecondarySidebarProps) {
 
 function SecondarySidebarWrapper(props: NavigationTourElementProps) {
   const theme = useTheme();
-  const secondaryNavigation = useSecondaryNavigation();
-  const hasPageFrame = useHasPageFrameFeature();
-  const {layout} = usePrimaryNavigation();
 
   return (
     <Container
       background="secondary"
-      borderRight={
-        hasPageFrame && secondaryNavigation.view === 'expanded' && layout !== 'mobile'
-          ? undefined
-          : 'primary'
-      }
+      borderRight="primary"
       position="relative"
       height="100%"
     >


### PR DESCRIPTION
Fix the doubled left divider on the Logs page frame.

The page-frame boundary was split between the page shell and the secondary sidebar, which made the Logs view read as if it had two left borders.

This keeps the divider on the secondary sidebar and removes the extra page-shell border so the boundary renders as a single line again.

closes https://linear.app/getsentry/issue/DE-1117/logs-has-a-double-left-border