### PR TITLE
feat(source-map-config-issues): Filtering out config issues from default issues stream

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -147,6 +147,7 @@ def group_categories_from_search_filters(
         # Hide certain categories from the default issue stream
         group_categories.discard(GroupCategory.FEEDBACK.value)
         group_categories.discard(GroupCategory.INSTRUMENTATION.value)
+        group_categories.discard(GroupCategory.CONFIGURATION.value)
 
     if not features.has("organizations:performance-issues-search", organization):
         group_categories.discard(GroupCategory.PERFORMANCE.value)


### PR DESCRIPTION
- Similar to instrumentation and feedback issues, discoverability is enabled through the sidebar nav item or searching for specifc fields like `issue.category`