### PR TITLE
feat(preprod): Add artifact_type field to Explore UI (EME-874)

### DIFF
--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -5,6 +5,7 @@ import type {TagCollection} from 'sentry/types/group';
 import {CONDITIONS_ARGUMENTS, WEB_VITALS_QUALITY} from 'sentry/utils/discover/types';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 import {SpanFields} from 'sentry/views/insights/types';
+import {METRICS_ARTIFACT_TYPES} from 'sentry/views/settings/project/preprod/types';
 
 // Don't forget to update https://docs.sentry.io/product/sentry-basics/search/searchable-properties/ for any changes made here
 
@@ -394,7 +395,6 @@ export enum AggregationKey {
   FAILURE_RATE = 'failure_rate',
   LAST_SEEN = 'last_seen',
   PERFORMANCE_SCORE = 'performance_score',
-  OPPORTUNITY_SCORE = 'opportunity_score',
 }
 
 export enum IsFieldValues {
@@ -1024,35 +1024,7 @@ export const AGGREGATION_FIELDS: Record<AggregationKey, FieldDefinition> = {
       {
         name: 'value',
         kind: 'column',
-        columnTypes: validateAllowedColumns([
-          'measurements.score.total',
-          'measurements.score.lcp',
-          'measurements.score.fcp',
-          'measurements.score.inp',
-          'measurements.score.cls',
-          'measurements.score.ttfb',
-        ]),
-        defaultValue: 'measurements.score.total',
-        required: true,
-      },
-    ],
-  },
-  [AggregationKey.OPPORTUNITY_SCORE]: {
-    desc: t('Returns the opportunity score for a given web vital'),
-    kind: FieldKind.FUNCTION,
-    valueType: FieldValueType.SCORE,
-    parameters: [
-      {
-        name: 'value',
-        kind: 'column',
-        columnTypes: validateAllowedColumns([
-          'measurements.score.total',
-          'measurements.score.lcp',
-          'measurements.score.fcp',
-          'measurements.score.inp',
-          'measurements.score.cls',
-          'measurements.score.ttfb',
-        ]),
+        columnTypes: [FieldValueType.NUMBER],
         defaultValue: 'measurements.score.total',
         required: true,
       },
@@ -1083,8 +1055,6 @@ export const ALLOWED_EXPLORE_VISUALIZE_AGGREGATES: AggregationKey[] = [
   AggregationKey.EPS,
   AggregationKey.FAILURE_RATE,
   AggregationKey.FAILURE_COUNT,
-  AggregationKey.PERFORMANCE_SCORE,
-  AggregationKey.OPPORTUNITY_SCORE,
 ];
 
 export const ALLOWED_EXPLORE_EQUATION_AGGREGATES: AggregationKey[] = [
@@ -2548,6 +2518,12 @@ const PREPROD_FIELD_DEFINITIONS: Record<string, FieldDefinition> = {
     desc: t('The display name of the application'),
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
+  },
+  artifact_type: {
+    desc: t('The type of artifact component (e.g., main app, watch app, app clip)'),
+    kind: FieldKind.FIELD,
+    valueType: FieldValueType.STRING,
+    values: [...METRICS_ARTIFACT_TYPES],
   },
   build_configuration_name: {
     desc: t('The name of the build configuration (e.g., Debug, Release)'),

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -395,6 +395,7 @@ export enum AggregationKey {
   FAILURE_RATE = 'failure_rate',
   LAST_SEEN = 'last_seen',
   PERFORMANCE_SCORE = 'performance_score',
+  OPPORTUNITY_SCORE = 'opportunity_score',
 }
 
 export enum IsFieldValues {
@@ -1024,7 +1025,35 @@ export const AGGREGATION_FIELDS: Record<AggregationKey, FieldDefinition> = {
       {
         name: 'value',
         kind: 'column',
-        columnTypes: [FieldValueType.NUMBER],
+        columnTypes: validateAllowedColumns([
+          'measurements.score.total',
+          'measurements.score.lcp',
+          'measurements.score.fcp',
+          'measurements.score.inp',
+          'measurements.score.cls',
+          'measurements.score.ttfb',
+        ]),
+        defaultValue: 'measurements.score.total',
+        required: true,
+      },
+    ],
+  },
+  [AggregationKey.OPPORTUNITY_SCORE]: {
+    desc: t('Returns the opportunity score for a given web vital'),
+    kind: FieldKind.FUNCTION,
+    valueType: FieldValueType.SCORE,
+    parameters: [
+      {
+        name: 'value',
+        kind: 'column',
+        columnTypes: validateAllowedColumns([
+          'measurements.score.total',
+          'measurements.score.lcp',
+          'measurements.score.fcp',
+          'measurements.score.inp',
+          'measurements.score.cls',
+          'measurements.score.ttfb',
+        ]),
         defaultValue: 'measurements.score.total',
         required: true,
       },
@@ -1055,6 +1084,8 @@ export const ALLOWED_EXPLORE_VISUALIZE_AGGREGATES: AggregationKey[] = [
   AggregationKey.EPS,
   AggregationKey.FAILURE_RATE,
   AggregationKey.FAILURE_COUNT,
+  AggregationKey.PERFORMANCE_SCORE,
+  AggregationKey.OPPORTUNITY_SCORE,
 ];
 
 export const ALLOWED_EXPLORE_EQUATION_AGGREGATES: AggregationKey[] = [

--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -96,6 +96,7 @@ export const SENTRY_LOG_NUMBER_TAGS: string[] = [OurLogKnownFieldKey.SEVERITY_NU
 export const SENTRY_PREPROD_STRING_TAGS: string[] = [
   'app_id',
   'app_name',
+  'artifact_type',
   'build_configuration_name',
   'build_number',
   'build_version',
@@ -126,6 +127,9 @@ export const HIDDEN_PREPROD_ATTRIBUTES = [
   'tags[artifact_state,number]',
   'tags[artifact_date_built,number]',
   'tags[build_number,number]',
+  'metrics_artifact_type',
+  'tags[metrics_artifact_type,number]',
+  'tags[artifact_type,number]',
 ];
 
 export const SENTRY_TRACEMETRIC_STRING_TAGS: string[] = [

--- a/static/app/views/settings/project/preprod/types.ts
+++ b/static/app/views/settings/project/preprod/types.ts
@@ -10,13 +10,19 @@ const ALL_MEASUREMENTS = ['absolute', 'absolute_diff', 'relative_diff'] as const
 
 export type MeasurementType = (typeof ALL_MEASUREMENTS)[number];
 
-export const ALL_ARTIFACT_TYPES = [
-  'all_artifacts',
+/**
+ * Canonical list of metrics artifact types.
+ * Keep in sync with PreprodArtifactSizeMetrics.MetricsArtifactType.as_choices() in
+ * src/sentry/preprod/models.py
+ */
+export const METRICS_ARTIFACT_TYPES = [
   'main_artifact',
   'watch_artifact',
   'android_dynamic_feature_artifact',
   'app_clip_artifact',
 ] as const;
+
+export const ALL_ARTIFACT_TYPES = ['all_artifacts', ...METRICS_ARTIFACT_TYPES] as const;
 
 export type ArtifactType = (typeof ALL_ARTIFACT_TYPES)[number];
 


### PR DESCRIPTION
## Summary
- Extract canonical `METRICS_ARTIFACT_TYPES` constant and compose `ALL_ARTIFACT_TYPES` on top
- Add `artifact_type` to `PREPROD_FIELD_DEFINITIONS` with predefined dropdown values
- Expose `artifact_type` as a string tag in Explore
- Hide old integer-backed `metrics_artifact_type` fields from UI

## Dependencies
Depends on #112905 (backend) landing first. The backend PR writes `metrics_artifact_type` as a string label into EAP and exposes it as the public `artifact_type` field in the search resolver.

## Screenshots

<img width="484" height="318" alt="Screenshot 2026-04-14 at 09 20 55" src="https://github.com/user-attachments/assets/7cd09862-c75f-48e9-bafa-ea5949b6c1a9" />

## Test plan
- [ ] Pre-commit passes
- [ ] CI green
- [ ] After backend lands: verify `artifact_type` appears in Explore search with dropdown values
- [ ] Verify old `metrics_artifact_type` integer fields are hidden

Closes EME-874