### PR TITLE
fix(conversations): Move detail breadcrumbs to page frame top bar

### DIFF
--- a/static/app/views/insights/pages/conversations/conversationsPageHeader.tsx
+++ b/static/app/views/insights/pages/conversations/conversationsPageHeader.tsx
@@ -2,10 +2,7 @@ import {Fragment} from 'react';
 
 import {FeatureBadge} from '@sentry/scraps/badge';
 
-import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
-import {useOrganization} from 'sentry/utils/useOrganization';
 import {
-  CONVERSATIONS_LANDING_SUB_PATH,
   CONVERSATIONS_LANDING_TITLE,
   CONVERSATIONS_SIDEBAR_LABEL,
 } from 'sentry/views/insights/pages/conversations/settings';
@@ -15,6 +12,7 @@ import {
 } from 'sentry/views/insights/pages/domainViewHeader';
 
 type Props = {
+  domainBaseUrl: string;
   breadcrumbs?: HeaderProps['additionalBreadCrumbs'];
   headerActions?: HeaderProps['additonalHeaderActions'];
   headerTitle?: HeaderProps['headerTitle'];
@@ -26,16 +24,11 @@ export function ConversationsPageHeader({
   headerTitle,
   breadcrumbs,
   hideDefaultTabs,
+  domainBaseUrl,
 }: Props) {
-  const organization = useOrganization();
-
-  const conversationsBaseUrl = normalizeUrl(
-    `/organizations/${organization.slug}/explore/${CONVERSATIONS_LANDING_SUB_PATH}/`
-  );
-
   return (
     <DomainViewHeader
-      domainBaseUrl={conversationsBaseUrl}
+      domainBaseUrl={domainBaseUrl}
       domainTitle={CONVERSATIONS_SIDEBAR_LABEL}
       headerTitle={
         headerTitle ?? (

--- a/static/app/views/insights/pages/conversations/layout.spec.tsx
+++ b/static/app/views/insights/pages/conversations/layout.spec.tsx
@@ -1,0 +1,46 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, within} from 'sentry-test/reactTestingLibrary';
+
+import {TopBar} from 'sentry/views/navigation/topBar';
+
+import ConversationsLayout from './layout';
+
+describe('ConversationsLayout', () => {
+  it('renders detail breadcrumbs in the top bar when page frame is enabled', () => {
+    const organization = OrganizationFixture({
+      features: ['page-frame'],
+    });
+
+    render(
+      <TopBar.Slot.Provider>
+        <div data-test-id="top-bar-container">
+          <TopBar />
+        </div>
+        <ConversationsLayout />
+      </TopBar.Slot.Provider>,
+      {
+        organization,
+        initialRouterConfig: {
+          route: '/organizations/:orgId/explore/conversations/:conversationId/',
+          location: {
+            pathname: `/organizations/${organization.slug}/explore/conversations/6c5b72fc/`,
+            query: {
+              environment: ['prod'],
+              project: ['1'],
+              statsPeriod: '7d',
+            },
+          },
+        },
+      }
+    );
+
+    const topBar = screen.getByTestId('top-bar-container');
+    expect(within(topBar).getByTestId('breadcrumb-list')).toBeInTheDocument();
+    expect(within(topBar).getByText('6c5b72fc')).toBeInTheDocument();
+    expect(within(topBar).getByRole('link', {name: 'Conversations'})).toHaveAttribute(
+      'href',
+      `/organizations/${organization.slug}/explore/conversations/?environment=prod&project=1&statsPeriod=7d`
+    );
+  });
+});

--- a/static/app/views/insights/pages/conversations/layout.tsx
+++ b/static/app/views/insights/pages/conversations/layout.tsx
@@ -4,24 +4,53 @@ import styled from '@emotion/styled';
 
 import {Stack} from '@sentry/scraps/layout';
 
+import {Breadcrumbs} from 'sentry/components/breadcrumbs';
+import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {ConversationsPageHeader} from 'sentry/views/insights/pages/conversations/conversationsPageHeader';
+import {
+  CONVERSATIONS_LANDING_SUB_PATH,
+  CONVERSATIONS_SIDEBAR_LABEL,
+} from 'sentry/views/insights/pages/conversations/settings';
+import {TopBar} from 'sentry/views/navigation/topBar';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 function ConversationsLayout() {
+  const organization = useOrganization();
+  const hasPageFrameFeature = useHasPageFrameFeature();
   const {conversationId} = useParams<{conversationId?: string}>();
 
   const isDetailPage = !!conversationId;
+  const conversationsBaseUrl = normalizeUrl(
+    `/organizations/${organization.slug}/explore/${CONVERSATIONS_LANDING_SUB_PATH}/`
+  );
 
   return (
     <Stack flex={1}>
       {isDetailPage ? (
-        <DetailHeaderWrapper>
-          <ConversationsPageHeader
-            hideDefaultTabs
-            headerTitle={<Fragment />}
-            breadcrumbs={[{label: conversationId.slice(0, 8)}]}
-          />
-        </DetailHeaderWrapper>
+        hasPageFrameFeature ? (
+          <TopBar.Slot name="title">
+            <TopBarBreadcrumbs
+              crumbs={[
+                {
+                  label: CONVERSATIONS_SIDEBAR_LABEL,
+                  to: conversationsBaseUrl,
+                  preservePageFilters: true,
+                },
+                {label: conversationId.slice(0, 8)},
+              ]}
+            />
+          </TopBar.Slot>
+        ) : (
+          <DetailHeaderWrapper>
+            <ConversationsPageHeader
+              hideDefaultTabs
+              headerTitle={<Fragment />}
+              breadcrumbs={[{label: conversationId.slice(0, 8)}]}
+            />
+          </DetailHeaderWrapper>
+        )
       ) : (
         <ConversationsPageHeader />
       )}
@@ -35,6 +64,10 @@ const DetailHeaderWrapper = styled('div')`
     padding-left: ${p => p.theme.space['2xl']};
     padding-right: ${p => p.theme.space['2xl']};
   }
+`;
+
+const TopBarBreadcrumbs = styled(Breadcrumbs)`
+  padding: 0;
 `;
 
 export default ConversationsLayout;

--- a/static/app/views/insights/pages/conversations/layout.tsx
+++ b/static/app/views/insights/pages/conversations/layout.tsx
@@ -45,6 +45,7 @@ function ConversationsLayout() {
         ) : (
           <DetailHeaderWrapper>
             <ConversationsPageHeader
+              domainBaseUrl={conversationsBaseUrl}
               hideDefaultTabs
               headerTitle={<Fragment />}
               breadcrumbs={[{label: conversationId.slice(0, 8)}]}
@@ -52,7 +53,7 @@ function ConversationsLayout() {
           </DetailHeaderWrapper>
         )
       ) : (
-        <ConversationsPageHeader />
+        <ConversationsPageHeader domainBaseUrl={conversationsBaseUrl} />
       )}
       <Outlet />
     </Stack>

--- a/static/app/views/insights/pages/conversations/layout.tsx
+++ b/static/app/views/insights/pages/conversations/layout.tsx
@@ -31,7 +31,7 @@ function ConversationsLayout() {
       {isDetailPage ? (
         hasPageFrameFeature ? (
           <TopBar.Slot name="title">
-            <TopBarBreadcrumbs
+            <Breadcrumbs
               crumbs={[
                 {
                   label: CONVERSATIONS_SIDEBAR_LABEL,
@@ -64,10 +64,6 @@ const DetailHeaderWrapper = styled('div')`
     padding-left: ${p => p.theme.space['2xl']};
     padding-right: ${p => p.theme.space['2xl']};
   }
-`;
-
-const TopBarBreadcrumbs = styled(Breadcrumbs)`
-  padding: 0;
 `;
 
 export default ConversationsLayout;


### PR DESCRIPTION
Move the Conversations detail breadcrumb trail into the page-frame top bar.

In page-frame mode the detail layout was still routing breadcrumbs through the shared page header. Because the detail view renders its actual title and summary in the body, that left the breadcrumb row inside the page content instead of the sticky top bar.

This updates the page-frame detail layout to register the `Conversations / <id>` trail in `TopBar.Slot name="title"` and keeps the existing non-page-frame header path unchanged. It also adds a regression test that mounts the top bar slot provider and verifies the breadcrumb is rendered there with preserved page filters.

Refs DE-1082

closes https://linear.app/getsentry/issue/DE-1129/conversations-renders-breadcrumbs-into-the-page-layout