### PR TITLE
ref(ui): Remove integrations-cursor feature flag from frontend

### DIFF
--- a/static/app/components/events/autofix/codingAgentIntegrationCta.tsx
+++ b/static/app/components/events/autofix/codingAgentIntegrationCta.tsx
@@ -24,10 +24,10 @@ interface CodingAgentIntegrationCtaProps {
 interface AgentConfig {
   displayName: string;
   docsUrl: string;
-  featureFlag: string;
   pluginId: string;
   provider: string;
   target: SeerAutomationHandoffConfiguration['target'];
+  featureFlag?: string;
   headingName?: string;
 }
 
@@ -51,7 +51,9 @@ export function makeCodingAgentIntegrationCta(config: AgentConfig) {
       i => i.provider === config.provider
     );
 
-    const hasFeatureFlag = organization.features.includes(config.featureFlag);
+    const hasFeatureFlag = config.featureFlag
+      ? organization.features.includes(config.featureFlag)
+      : true;
     const hasIntegration = Boolean(integration);
     const isAutomationEnabled =
       project.seerScannerAutomation !== false &&

--- a/static/app/components/events/autofix/cursorIntegrationCta.spec.tsx
+++ b/static/app/components/events/autofix/cursorIntegrationCta.spec.tsx
@@ -9,9 +9,7 @@ import {ProjectsStore} from 'sentry/stores/projectsStore';
 
 describe('CursorIntegrationCta', () => {
   const project = ProjectFixture();
-  const organization = OrganizationFixture({
-    features: ['integrations-cursor'],
-  });
+  const organization = OrganizationFixture();
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
@@ -32,28 +30,6 @@ describe('CursorIntegrationCta', () => {
       body: {
         integrations: [],
       },
-    });
-  });
-
-  describe('Feature Flag', () => {
-    it('does not render without integrations-cursor feature flag', () => {
-      const orgWithoutFlag = OrganizationFixture({
-        features: [],
-      });
-
-      const {container} = render(<CursorIntegrationCta project={project} />, {
-        organization: orgWithoutFlag,
-      });
-
-      expect(container).toBeEmptyDOMElement();
-    });
-
-    it('renders with integrations-cursor feature flag', async () => {
-      render(<CursorIntegrationCta project={project} />, {
-        organization,
-      });
-
-      expect(await screen.findByText('Cursor Agent Integration')).toBeInTheDocument();
     });
   });
 

--- a/static/app/components/events/autofix/cursorIntegrationCta.tsx
+++ b/static/app/components/events/autofix/cursorIntegrationCta.tsx
@@ -3,7 +3,6 @@ import {CodingAgentProvider} from 'sentry/components/events/autofix/types';
 
 export const CursorIntegrationCta = makeCodingAgentIntegrationCta({
   provider: 'cursor',
-  featureFlag: 'integrations-cursor',
   target: CodingAgentProvider.CURSOR_BACKGROUND_AGENT,
   pluginId: 'cursor',
   displayName: 'Cursor',

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.spec.tsx
@@ -647,7 +647,7 @@ describe('SeerDrawer', () => {
 
     render(<SeerDrawer event={mockEvent} group={mockGroup} project={mockProject} />, {
       organization: OrganizationFixture({
-        features: ['gen-ai-features', 'integrations-cursor', 'issue-views'],
+        features: ['gen-ai-features', 'issue-views'],
       }),
     });
 
@@ -728,7 +728,7 @@ describe('SeerDrawer', () => {
 
     render(<SeerDrawer event={mockEvent} group={mockGroup} project={mockProject} />, {
       organization: OrganizationFixture({
-        features: ['gen-ai-features', 'integrations-cursor', 'issue-views'],
+        features: ['gen-ai-features', 'issue-views'],
       }),
     });
 

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.spec.tsx
@@ -149,7 +149,7 @@ describe('SeerNotices', () => {
     render(<SeerNotices groupId="123" hasGithubIntegration project={project} />, {
       organization: {
         ...organization,
-        features: ['integrations-cursor'],
+        features: [],
       },
     });
     await waitFor(() => {
@@ -193,7 +193,7 @@ describe('SeerNotices', () => {
     render(<SeerNotices groupId="123" hasGithubIntegration project={project} />, {
       organization: {
         ...organization,
-        features: ['integrations-cursor'],
+        features: [],
       },
     });
 
@@ -252,7 +252,7 @@ describe('SeerNotices', () => {
     render(<SeerNotices groupId="123" hasGithubIntegration project={project} />, {
       organization: {
         ...organization,
-        features: ['integrations-cursor'],
+        features: [],
       },
     });
 

--- a/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerNotices.tsx
@@ -115,9 +115,6 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
   const cursorIntegration = codingAgentIntegrations?.integrations.find(
     integration => integration.provider === 'cursor'
   );
-  const hasCursorFeatureFlagEnabled = Boolean(
-    organization.features.includes('integrations-cursor')
-  );
   const isCursorHandoffConfigured = Boolean(preference?.automation_handoff);
 
   const unreadableRepos = repos.filter(repo => repo.is_readable === false);
@@ -155,9 +152,7 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
   );
 
   const needsCursorIntegration =
-    hasCursorFeatureFlagEnabled &&
-    (!isCursorHandoffConfigured || !cursorIntegration) &&
-    !cursorStepSkipped;
+    (!isCursorHandoffConfigured || !cursorIntegration) && !cursorStepSkipped;
 
   // Calculate incomplete steps
   const stepConditions = [
@@ -425,7 +420,7 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
               )}
 
               {/* Step 5: Cursor Integration */}
-              {hasCursorFeatureFlagEnabled && (
+              {
                 <GuidedSteps.Step
                   key="cursor-integration"
                   stepKey="cursor-integration"
@@ -523,7 +518,7 @@ export function SeerNotices({groupId, hasGithubIntegration, project}: SeerNotice
                     )}
                   </CustomStepButtons>
                 </GuidedSteps.Step>
-              )}
+              }
             </StyledGuidedSteps>
             <StepsDivider />
           </motion.div>

--- a/static/app/views/settings/projectSeer/index.spec.tsx
+++ b/static/app/views/settings/projectSeer/index.spec.tsx
@@ -449,9 +449,7 @@ describe('ProjectSeer', () => {
   });
 
   it('can enable automation handoff to Cursor when Cursor integration is available', async () => {
-    const orgWithCursorFeature = OrganizationFixture({
-      features: ['integrations-cursor'],
-    });
+    const orgWithCursorFeature = OrganizationFixture();
 
     const initialProject: Project = {
       ...project,
@@ -707,9 +705,7 @@ describe('ProjectSeer', () => {
     it('renders and loads initial value when cursor_handoff is selected', async () => {
       MockApiClient.clearMockResponses();
 
-      const orgWithCursorFeature = OrganizationFixture({
-        features: ['integrations-cursor'],
-      });
+      const orgWithCursorFeature = OrganizationFixture();
 
       const initialProject: Project = {
         ...project,
@@ -786,9 +782,7 @@ describe('ProjectSeer', () => {
     it('calls update mutation when toggled', async () => {
       MockApiClient.clearMockResponses();
 
-      const orgWithCursorFeature = OrganizationFixture({
-        features: ['integrations-cursor'],
-      });
+      const orgWithCursorFeature = OrganizationFixture();
 
       const initialProject: Project = {
         ...project,
@@ -894,9 +888,7 @@ describe('ProjectSeer', () => {
     it('shows integration selector when multiple cursor integrations exist', async () => {
       MockApiClient.clearMockResponses();
 
-      const orgWithCursorFeature = OrganizationFixture({
-        features: ['integrations-cursor'],
-      });
+      const orgWithCursorFeature = OrganizationFixture();
 
       const initialProject: Project = {
         ...project,
@@ -984,9 +976,7 @@ describe('ProjectSeer', () => {
     it('calls update mutation when switching integration', async () => {
       MockApiClient.clearMockResponses();
 
-      const orgWithCursorFeature = OrganizationFixture({
-        features: ['integrations-cursor'],
-      });
+      const orgWithCursorFeature = OrganizationFixture();
 
       const initialProject: Project = {
         ...project,
@@ -1108,7 +1098,7 @@ describe('ProjectSeer', () => {
       MockApiClient.clearMockResponses();
 
       const orgWithBothFeatures = OrganizationFixture({
-        features: ['integrations-cursor', 'integrations-claude-code'],
+        features: ['integrations-claude-code'],
       });
 
       const initialProject: Project = {
@@ -1189,9 +1179,7 @@ describe('ProjectSeer', () => {
     it('does not show integration selector with single cursor integration', async () => {
       MockApiClient.clearMockResponses();
 
-      const orgWithCursorFeature = OrganizationFixture({
-        features: ['integrations-cursor'],
-      });
+      const orgWithCursorFeature = OrganizationFixture();
 
       const initialProject: Project = {
         ...project,

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -224,9 +224,7 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
     [project.slug, queryClient, organization.slug]
   );
 
-  const hasCursorIntegration = Boolean(
-    organization.features.includes('integrations-cursor') && cursorIntegration
-  );
+  const hasCursorIntegration = Boolean(cursorIntegration);
 
   const hasClaudeIntegration = Boolean(
     organization.features.includes('integrations-claude-code') && claudeIntegration


### PR DESCRIPTION
Remove all frontend checks for the `integrations-cursor` feature flag, which is 100% rolled out. The cursor integration UI now renders unconditionally. The flag registration in `temporary.py` is intentionally kept until this frontend change is deployed, after which it can be removed in a follow-up.

- Made `featureFlag` optional in `AgentConfig` interface (other agents like claude-code still use it)
- Removed flag gating in `seerNotices.tsx`, `projectSeer/index.tsx`, and `cursorIntegrationCta.tsx`
- Cleaned up test files to not rely on the feature flag

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.


Agent transcript: https://claudescope.sentry.dev/share/JFuyMDjmG06x4diRyNV0yvhSsC3t6UulboexLcecwQc