### PR TITLE
fix(rules): Handle MultipleObjectsReturned in get_rule_workflow_ids

### DIFF
--- a/src/sentry/rules/history/backends/postgres.py
+++ b/src/sentry/rules/history/backends/postgres.py
@@ -57,9 +57,17 @@ def get_rule_workflow_ids(target: Workflow | Rule) -> IdPair:
     if isinstance(target, Workflow):
         workflow_id = target.id
         try:
-            alert_rule_workflow = AlertRuleWorkflow.objects.get(workflow=target)
+            alert_rule_workflow = AlertRuleWorkflow.objects.get(
+                workflow=target, rule_id__isnull=False
+            )
             rule_id = alert_rule_workflow.rule_id
         except AlertRuleWorkflow.DoesNotExist:
+            rule_id = None
+        except AlertRuleWorkflow.MultipleObjectsReturned:
+            logger.warning(
+                "Multiple AlertRuleWorkflow entries for workflow",
+                extra={"workflow_id": target.id},
+            )
             rule_id = None
     else:
         rule_id = target.id
@@ -67,6 +75,12 @@ def get_rule_workflow_ids(target: Workflow | Rule) -> IdPair:
             alert_rule_workflow = AlertRuleWorkflow.objects.get(rule_id=target.id)
             workflow_id = alert_rule_workflow.workflow_id
         except AlertRuleWorkflow.DoesNotExist:
+            workflow_id = None
+        except AlertRuleWorkflow.MultipleObjectsReturned:
+            logger.warning(
+                "Multiple AlertRuleWorkflow entries for rule",
+                extra={"rule_id": target.id},
+            )
             workflow_id = None
     return IdPair(workflow_id=workflow_id, rule_id=rule_id)
 

--- a/tests/sentry/rules/history/backends/test_postgres.py
+++ b/tests/sentry/rules/history/backends/test_postgres.py
@@ -1,7 +1,11 @@
 from datetime import timedelta
 
 from sentry.models.rulefirehistory import RuleFireHistory
-from sentry.rules.history.backends.postgres import PostgresRuleHistoryBackend
+from sentry.rules.history.backends.postgres import (
+    IdPair,
+    PostgresRuleHistoryBackend,
+    get_rule_workflow_ids,
+)
 from sentry.rules.history.base import RuleGroupHistory
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import with_feature
@@ -510,3 +514,70 @@ class FetchRuleHourlyStatsPaginatedTest(BasePostgresRuleHistoryBackendTest):
         # Hour 1: 1 (workflow)
         # Hour 0: 0
         assert [r.count for r in results[-5:]] == [2, 2, 1, 1, 0]
+
+
+class GetRuleWorkflowIdsTest(BaseWorkflowTest):
+    def test_workflow_with_single_alert_rule_workflow(self) -> None:
+        rule = self.create_project_rule(project=self.project)
+        workflow_triggers = self.create_data_condition_group()
+        workflow = self.create_workflow(
+            when_condition_group=workflow_triggers,
+            organization=self.organization,
+        )
+        AlertRuleWorkflow.objects.create(rule_id=rule.id, workflow=workflow)
+
+        result = get_rule_workflow_ids(workflow)
+        assert result == IdPair(workflow_id=workflow.id, rule_id=rule.id)
+
+    def test_workflow_with_no_alert_rule_workflow(self) -> None:
+        workflow_triggers = self.create_data_condition_group()
+        workflow = self.create_workflow(
+            when_condition_group=workflow_triggers,
+            organization=self.organization,
+        )
+
+        result = get_rule_workflow_ids(workflow)
+        assert result == IdPair(workflow_id=workflow.id, rule_id=None)
+
+    def test_workflow_with_multiple_alert_rule_workflows(self) -> None:
+        """A workflow linked to both a rule_id and an alert_rule_id should resolve the rule_id."""
+        rule = self.create_project_rule(project=self.project)
+        workflow_triggers = self.create_data_condition_group()
+        workflow = self.create_workflow(
+            when_condition_group=workflow_triggers,
+            organization=self.organization,
+        )
+        AlertRuleWorkflow.objects.create(rule_id=rule.id, workflow=workflow)
+        AlertRuleWorkflow.objects.create(alert_rule_id=1, workflow=workflow)
+
+        result = get_rule_workflow_ids(workflow)
+        assert result == IdPair(workflow_id=workflow.id, rule_id=rule.id)
+
+    def test_workflow_with_multiple_rule_id_entries(self) -> None:
+        """Multiple AlertRuleWorkflow rows with rule_id for the same workflow should not crash."""
+        rule_1 = self.create_project_rule(project=self.project)
+        rule_2 = self.create_project_rule(project=self.project)
+        workflow_triggers = self.create_data_condition_group()
+        workflow = self.create_workflow(
+            when_condition_group=workflow_triggers,
+            organization=self.organization,
+        )
+        AlertRuleWorkflow.objects.create(rule_id=rule_1.id, workflow=workflow)
+        AlertRuleWorkflow.objects.create(rule_id=rule_2.id, workflow=workflow)
+
+        result = get_rule_workflow_ids(workflow)
+        assert result == IdPair(workflow_id=workflow.id, rule_id=None)
+
+    def test_rule_with_single_alert_rule_workflow(self) -> None:
+        rule = self.create_project_rule(project=self.project)
+        arw = AlertRuleWorkflow.objects.get(rule_id=rule.id)
+
+        result = get_rule_workflow_ids(rule)
+        assert result == IdPair(workflow_id=arw.workflow_id, rule_id=rule.id)
+
+    def test_rule_with_no_alert_rule_workflow(self) -> None:
+        rule = self.create_project_rule(project=self.project)
+        AlertRuleWorkflow.objects.filter(rule_id=rule.id).delete()
+
+        result = get_rule_workflow_ids(rule)
+        assert result == IdPair(workflow_id=None, rule_id=rule.id)


### PR DESCRIPTION
AlertRuleWorkflow has no unique constraint on the workflow field alone, so a workflow can have multiple entries (e.g. one with rule_id and one with alert_rule_id). Filter for rule_id entries specifically and handle MultipleObjectsReturned gracefully instead of crashing with a 500.

Fixes SENTRY-5N7J
