### PR TITLE
fix(dashboards): Show breadcrumb separator in page frame

### DIFF
--- a/static/app/views/dashboards/detail.spec.tsx
+++ b/static/app/views/dashboards/detail.spec.tsx
@@ -26,7 +26,10 @@ import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {TeamStore} from 'sentry/stores/teamStore';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import CreateDashboard from 'sentry/views/dashboards/create';
-import {DashboardDetailWithInjectedProps as DashboardDetail} from 'sentry/views/dashboards/detail';
+import {
+  DashboardDetailWithInjectedProps as DashboardDetail,
+  DashboardPageFrameTitle,
+} from 'sentry/views/dashboards/detail';
 import {EditAccessSelector} from 'sentry/views/dashboards/editAccessSelector';
 import * as types from 'sentry/views/dashboards/types';
 import {DashboardState} from 'sentry/views/dashboards/types';
@@ -623,6 +626,21 @@ describe('Dashboards > Detail', () => {
       );
       expect(await screen.findByText('All Releases')).toBeInTheDocument();
       expect(mockReleases).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows a separator between the dashboard breadcrumb and title in page frame mode', () => {
+      render(
+        <DashboardPageFrameTitle
+          dashboard={DashboardFixture([], {id: '1', title: 'Custom Errors'})}
+          isEditingDashboard={false}
+          onUpdate={jest.fn()}
+        />
+      );
+
+      expect(
+        screen.getByTestId('dashboard-breadcrumb-title-separator')
+      ).toBeInTheDocument();
+      expect(screen.getByText('Custom Errors')).toBeInTheDocument();
     });
 
     it('hides add widget option', async () => {

--- a/static/app/views/dashboards/detail.spec.tsx
+++ b/static/app/views/dashboards/detail.spec.tsx
@@ -26,16 +26,14 @@ import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {TeamStore} from 'sentry/stores/teamStore';
 import {browserHistory} from 'sentry/utils/browserHistory';
 import CreateDashboard from 'sentry/views/dashboards/create';
-import {
-  DashboardDetailWithInjectedProps as DashboardDetail,
-  DashboardPageFrameTitle,
-} from 'sentry/views/dashboards/detail';
+import {DashboardDetailWithInjectedProps as DashboardDetail} from 'sentry/views/dashboards/detail';
 import {EditAccessSelector} from 'sentry/views/dashboards/editAccessSelector';
 import * as types from 'sentry/views/dashboards/types';
 import {DashboardState} from 'sentry/views/dashboards/types';
 import {PrebuiltDashboardId} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import ViewEditDashboard from 'sentry/views/dashboards/view';
 import {useWidgetBuilderState} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
+import {TopBar} from 'sentry/views/navigation/topBar';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 
 jest.mock('sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState');
@@ -628,19 +626,37 @@ describe('Dashboards > Detail', () => {
       expect(mockReleases).toHaveBeenCalledTimes(1);
     });
 
-    it('shows a separator between the dashboard breadcrumb and title in page frame mode', () => {
+    it('renders the linked dashboard breadcrumb in the top bar when page frame is enabled', async () => {
+      const pageFrameOrganization = OrganizationFixture({
+        slug: 'org-slug',
+        features: [...organization.features, 'page-frame'],
+      });
+
       render(
-        <DashboardPageFrameTitle
-          dashboard={DashboardFixture([], {id: '1', title: 'Custom Errors'})}
-          isEditingDashboard={false}
-          onUpdate={jest.fn()}
-        />
+        <TopBar.Slot.Provider>
+          <TopBar />
+          <DashboardDetail
+            initialState={DashboardState.VIEW}
+            dashboard={DashboardFixture([], {id: '1', title: 'Custom Errors'})}
+            dashboards={[]}
+            onDashboardUpdate={jest.fn()}
+          />
+        </TopBar.Slot.Provider>,
+        {
+          organization: pageFrameOrganization,
+        }
       );
 
+      const breadcrumbs = await screen.findByTestId('breadcrumb-list');
+      expect(within(breadcrumbs).getByRole('link', {name: 'Dashboards'})).toHaveAttribute(
+        'href',
+        '/organizations/org-slug/dashboards/'
+      );
+      expect(within(breadcrumbs).getByText('Custom Errors')).toBeInTheDocument();
+      expect(within(breadcrumbs).getAllByRole('img')).toHaveLength(1);
       expect(
-        screen.getByTestId('dashboard-breadcrumb-title-separator')
-      ).toBeInTheDocument();
-      expect(screen.getByText('Custom Errors')).toBeInTheDocument();
+        screen.queryByRole('heading', {name: 'Custom Errors'})
+      ).not.toBeInTheDocument();
     });
 
     it('hides add widget option', async () => {

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -9,7 +9,7 @@ import isEqualWith from 'lodash/isEqualWith';
 import omit from 'lodash/omit';
 import pick from 'lodash/pick';
 
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 
 import {
   createDashboard,
@@ -35,7 +35,6 @@ import {NoProjectMessage} from 'sentry/components/noProjectMessage';
 import {PageFiltersContainer} from 'sentry/components/pageFilters/container';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {USING_CUSTOMER_DOMAIN} from 'sentry/constants';
-import {IconSlashForward} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
@@ -1183,15 +1182,8 @@ class DashboardDetail extends Component<Props, State> {
                 <Layout.Header unified={this.props.hasPageFrameFeature}>
                   {this.props.hasPageFrameFeature ? (
                     <TopBar.Slot name="title">
-                      <Breadcrumbs
-                        crumbs={[
-                          {
-                            label: t('Dashboards'),
-                            to: `/organizations/${organization.slug}/dashboards/`,
-                          },
-                        ]}
-                      />
-                      <DashboardPageFrameTitle
+                      <DashboardPageFrameBreadcrumbs
+                        organizationSlug={organization.slug}
                         dashboard={modifiedDashboard ?? dashboard}
                         onUpdate={this.setModifiedDashboard}
                         isEditingDashboard={this.isEditingDashboard}
@@ -1500,33 +1492,42 @@ class DashboardDetail extends Component<Props, State> {
   }
 }
 
-export function DashboardPageFrameTitle({
+function DashboardPageFrameBreadcrumbs({
   dashboard,
+  organizationSlug,
   isEditingDashboard,
   onUpdate,
 }: {
   dashboard: DashboardDetails | null;
   isEditingDashboard: boolean;
   onUpdate: (dashboard: DashboardDetails) => void;
+  organizationSlug: string;
 }) {
   return (
-    <Flex align="center" gap="xs" minWidth={0}>
-      <Flex
-        align="center"
-        justify="center"
-        flexShrink={0}
-        data-test-id="dashboard-breadcrumb-title-separator"
-      >
-        <IconSlashForward size="xs" variant="muted" />
-      </Flex>
-      <DashboardTitle
-        dashboard={dashboard}
-        onUpdate={onUpdate}
-        isEditingDashboard={isEditingDashboard}
-      />
-    </Flex>
+    <StyledDashboardPageFrameBreadcrumbs
+      crumbs={[
+        {
+          label: t('Dashboards'),
+          to: `/organizations/${organizationSlug}/dashboards/`,
+        },
+        {
+          label: (
+            <DashboardTitle
+              dashboard={dashboard}
+              onUpdate={onUpdate}
+              isEditingDashboard={isEditingDashboard}
+            />
+          ),
+        },
+      ]}
+    />
   );
 }
+
+const StyledDashboardPageFrameBreadcrumbs = styled(Breadcrumbs)`
+  padding: 0;
+  height: 34px;
+`;
 
 const StyledPageHeader = styled('div')`
   display: grid;

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -9,7 +9,7 @@ import isEqualWith from 'lodash/isEqualWith';
 import omit from 'lodash/omit';
 import pick from 'lodash/pick';
 
-import {Stack} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 
 import {
   createDashboard,
@@ -35,6 +35,7 @@ import {NoProjectMessage} from 'sentry/components/noProjectMessage';
 import {PageFiltersContainer} from 'sentry/components/pageFilters/container';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {USING_CUSTOMER_DOMAIN} from 'sentry/constants';
+import {IconSlashForward} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {InjectedRouter} from 'sentry/types/legacyReactRouter';
 import type {Organization} from 'sentry/types/organization';
@@ -1190,7 +1191,7 @@ class DashboardDetail extends Component<Props, State> {
                           },
                         ]}
                       />
-                      <DashboardTitle
+                      <DashboardPageFrameTitle
                         dashboard={modifiedDashboard ?? dashboard}
                         onUpdate={this.setModifiedDashboard}
                         isEditingDashboard={this.isEditingDashboard}
@@ -1497,6 +1498,34 @@ class DashboardDetail extends Component<Props, State> {
 
     return this.renderDefaultDashboardDetail();
   }
+}
+
+export function DashboardPageFrameTitle({
+  dashboard,
+  isEditingDashboard,
+  onUpdate,
+}: {
+  dashboard: DashboardDetails | null;
+  isEditingDashboard: boolean;
+  onUpdate: (dashboard: DashboardDetails) => void;
+}) {
+  return (
+    <Flex align="center" gap="xs" minWidth={0}>
+      <Flex
+        align="center"
+        justify="center"
+        flexShrink={0}
+        data-test-id="dashboard-breadcrumb-title-separator"
+      >
+        <IconSlashForward size="xs" variant="muted" />
+      </Flex>
+      <DashboardTitle
+        dashboard={dashboard}
+        onUpdate={onUpdate}
+        isEditingDashboard={isEditingDashboard}
+      />
+    </Flex>
+  );
 }
 
 const StyledPageHeader = styled('div')`

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -1182,11 +1182,22 @@ class DashboardDetail extends Component<Props, State> {
                 <Layout.Header unified={this.props.hasPageFrameFeature}>
                   {this.props.hasPageFrameFeature ? (
                     <TopBar.Slot name="title">
-                      <DashboardPageFrameBreadcrumbs
-                        organizationSlug={organization.slug}
-                        dashboard={modifiedDashboard ?? dashboard}
-                        onUpdate={this.setModifiedDashboard}
-                        isEditingDashboard={this.isEditingDashboard}
+                      <Breadcrumbs
+                        crumbs={[
+                          {
+                            label: t('Dashboards'),
+                            to: `/organizations/${organization.slug}/dashboards/`,
+                          },
+                          {
+                            label: (
+                              <DashboardTitle
+                                dashboard={modifiedDashboard ?? dashboard}
+                                onUpdate={this.setModifiedDashboard}
+                                isEditingDashboard={this.isEditingDashboard}
+                              />
+                            ),
+                          },
+                        ]}
                       />
                     </TopBar.Slot>
                   ) : (
@@ -1491,43 +1502,6 @@ class DashboardDetail extends Component<Props, State> {
     return this.renderDefaultDashboardDetail();
   }
 }
-
-function DashboardPageFrameBreadcrumbs({
-  dashboard,
-  organizationSlug,
-  isEditingDashboard,
-  onUpdate,
-}: {
-  dashboard: DashboardDetails | null;
-  isEditingDashboard: boolean;
-  onUpdate: (dashboard: DashboardDetails) => void;
-  organizationSlug: string;
-}) {
-  return (
-    <StyledDashboardPageFrameBreadcrumbs
-      crumbs={[
-        {
-          label: t('Dashboards'),
-          to: `/organizations/${organizationSlug}/dashboards/`,
-        },
-        {
-          label: (
-            <DashboardTitle
-              dashboard={dashboard}
-              onUpdate={onUpdate}
-              isEditingDashboard={isEditingDashboard}
-            />
-          ),
-        },
-      ]}
-    />
-  );
-}
-
-const StyledDashboardPageFrameBreadcrumbs = styled(Breadcrumbs)`
-  padding: 0;
-  height: 34px;
-`;
 
 const StyledPageHeader = styled('div')`
   display: grid;


### PR DESCRIPTION
Render the dashboard title as the second crumb in the page-frame top bar breadcrumbs.

In page-frame mode, the dashboard header previously rendered the `Dashboards`
breadcrumb and the editable title as separate siblings, so the shared
`Breadcrumbs` component never received a second crumb and could not render the
separator between them.

Move the dashboard title into the shared `Breadcrumbs` component as the second
crumb and add a regression test that covers the page-frame branch in the top
bar. This keeps the unified dashboard header aligned with other breadcrumb-based
headers without introducing dashboard-specific separator logic.


closes https://linear.app/getsentry/issue/DE-1139/dashboards-breadcrumbs-separator-is-not-visible
