### PR TITLE
fix(releases): Move page-frame breadcrumbs into the top bar

### DIFF
--- a/static/app/views/releases/detail/header/releaseHeader.spec.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.spec.tsx
@@ -30,14 +30,13 @@ describe('ReleaseHeader', () => {
   });
 
   function renderHeader(organization = OrganizationFixture()) {
-    const location = LocationFixture({
-      pathname: `/organizations/${organization.slug}/releases/${release.version}/`,
-      query: {
-        project: String(project.id),
-      },
-    });
+    const pathname = `/organizations/${organization.slug}/releases/${release.version}/`;
+    const query = {
+      project: String(project.id),
+    };
+    const location = LocationFixture({pathname, query});
 
-    const initialRouterConfig: RouterConfig = {location};
+    const initialRouterConfig: RouterConfig = {location: {pathname, query}};
 
     return render(
       <TopBar.Slot.Provider>

--- a/static/app/views/releases/detail/header/releaseHeader.spec.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.spec.tsx
@@ -39,11 +39,9 @@ describe('ReleaseHeader', () => {
 
     return render(
       <TopBar.Slot.Provider>
-        <div data-test-id="topbar-title">
-          <TopBar.Slot.Outlet name="title">
-            {props => <div {...props} data-test-id="topbar-title-slot" />}
-          </TopBar.Slot.Outlet>
-        </div>
+        <TopBar.Slot.Outlet name="title">
+          {props => <div {...props} data-test-id="topbar-title-slot" />}
+        </TopBar.Slot.Outlet>
         <ReleaseHeader
           location={location}
           organization={org}

--- a/static/app/views/releases/detail/header/releaseHeader.spec.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.spec.tsx
@@ -61,29 +61,19 @@ describe('ReleaseHeader', () => {
     );
   }
 
-  it('renders breadcrumbs inside the page header without page frame', () => {
+  it('renders breadcrumbs and title inside the header without page frame', () => {
     renderHeader();
 
-    const header = screen.getByRole('tablist').closest('header');
-    expect(header).not.toBeNull();
-
-    expect(within(header!).getByTestId('breadcrumb-list')).toBeInTheDocument();
-    expect(
-      within(screen.getByTestId('topbar-title')).queryByTestId('breadcrumb-list')
-    ).not.toBeInTheDocument();
+    const header = screen.getByRole('tablist').closest('header')!;
+    expect(within(header).getByTestId('breadcrumb-list')).toBeInTheDocument();
+    expect(within(header).getByText(release.version)).toBeInTheDocument();
   });
 
-  it('moves breadcrumbs into the top bar when page frame is enabled', () => {
-    const organization = OrganizationFixture({features: ['page-frame']});
-    renderHeader(organization);
+  it('moves breadcrumbs and title into the top bar when page frame is enabled', () => {
+    renderHeader(OrganizationFixture({features: ['page-frame']}));
 
-    const header = screen.getByRole('tablist').closest('header');
-    expect(header).not.toBeNull();
-
-    expect(within(header!).queryByTestId('breadcrumb-list')).not.toBeInTheDocument();
-    expect(
-      within(screen.getByTestId('topbar-title-slot')).getByTestId('breadcrumb-list')
-    ).toBeInTheDocument();
-    expect(within(header!).getByText(release.version)).toBeInTheDocument();
+    const topbarSlot = screen.getByTestId('topbar-title-slot');
+    expect(within(topbarSlot).getByTestId('breadcrumb-list')).toBeInTheDocument();
+    expect(within(topbarSlot).getByText(release.version)).toBeInTheDocument();
   });
 });

--- a/static/app/views/releases/detail/header/releaseHeader.spec.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.spec.tsx
@@ -1,0 +1,90 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ReleaseFixture} from 'sentry-fixture/release';
+import {ReleaseMetaFixture} from 'sentry-fixture/releaseMeta';
+import {ReleaseProjectFixture} from 'sentry-fixture/releaseProject';
+
+import {render, screen, within} from 'sentry-test/reactTestingLibrary';
+import type {RouterConfig} from 'sentry-test/reactTestingLibrary';
+
+import type {ReleaseProject} from 'sentry/types/release';
+import {TopBar} from 'sentry/views/navigation/topBar';
+
+import {ReleaseHeader} from './releaseHeader';
+
+describe('ReleaseHeader', () => {
+  const project = ReleaseProjectFixture({
+    id: 1,
+    slug: 'sentry-android-shop',
+    platform: 'android',
+  }) as Required<ReleaseProject>;
+
+  const release = ReleaseFixture({
+    version: '0c7d1730b1b1',
+    projects: [project],
+  });
+
+  const releaseMeta = ReleaseMetaFixture({
+    version: release.version,
+    projects: [project],
+  });
+
+  function renderHeader(organization = OrganizationFixture()) {
+    const location = LocationFixture({
+      pathname: `/organizations/${organization.slug}/releases/${release.version}/`,
+      query: {
+        project: String(project.id),
+      },
+    });
+
+    const initialRouterConfig: RouterConfig = {location};
+
+    return render(
+      <TopBar.Slot.Provider>
+        <div data-test-id="topbar-title">
+          <TopBar.Slot.Outlet name="title">
+            {props => <div {...props} data-test-id="topbar-title-slot" />}
+          </TopBar.Slot.Outlet>
+        </div>
+        <ReleaseHeader
+          location={location}
+          organization={organization}
+          project={project}
+          refetchData={jest.fn()}
+          release={release}
+          releaseMeta={releaseMeta}
+        />
+      </TopBar.Slot.Provider>,
+      {
+        organization,
+        initialRouterConfig,
+      }
+    );
+  }
+
+  it('renders breadcrumbs inside the page header without page frame', () => {
+    renderHeader();
+
+    const header = screen.getByRole('tablist').closest('header');
+    expect(header).not.toBeNull();
+
+    expect(within(header!).getByTestId('breadcrumb-list')).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('topbar-title')).queryByTestId('breadcrumb-list')
+    ).not.toBeInTheDocument();
+  });
+
+  it('moves breadcrumbs into the top bar when page frame is enabled', () => {
+    const organization = OrganizationFixture({features: ['page-frame']});
+    renderHeader(organization);
+
+    const header = screen.getByRole('tablist').closest('header');
+    expect(header).not.toBeNull();
+
+    expect(within(header!).queryByTestId('breadcrumb-list')).not.toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('topbar-title-slot')).getByTestId('breadcrumb-list')
+    ).toBeInTheDocument();
+    expect(within(header!).getByText(release.version)).toBeInTheDocument();
+  });
+});

--- a/static/app/views/releases/detail/header/releaseHeader.spec.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.spec.tsx
@@ -13,6 +13,8 @@ import {TopBar} from 'sentry/views/navigation/topBar';
 import {ReleaseHeader} from './releaseHeader';
 
 describe('ReleaseHeader', () => {
+  const organization = OrganizationFixture();
+
   const project = ReleaseProjectFixture({
     id: 1,
     slug: 'sentry-android-shop',
@@ -29,13 +31,10 @@ describe('ReleaseHeader', () => {
     projects: [project],
   });
 
-  function renderHeader(organization = OrganizationFixture()) {
-    const pathname = `/organizations/${organization.slug}/releases/${release.version}/`;
-    const query = {
-      project: String(project.id),
-    };
+  function renderHeader(org = organization) {
+    const pathname = `/organizations/${org.slug}/releases/${release.version}/`;
+    const query = {project: String(project.id)};
     const location = LocationFixture({pathname, query});
-
     const initialRouterConfig: RouterConfig = {location: {pathname, query}};
 
     return render(
@@ -47,33 +46,39 @@ describe('ReleaseHeader', () => {
         </div>
         <ReleaseHeader
           location={location}
-          organization={organization}
+          organization={org}
           project={project}
           refetchData={jest.fn()}
           release={release}
           releaseMeta={releaseMeta}
         />
       </TopBar.Slot.Provider>,
-      {
-        organization,
-        initialRouterConfig,
-      }
+      {organization: org, initialRouterConfig}
     );
   }
 
-  it('renders breadcrumbs and title inside the header without page frame', () => {
+  it('renders breadcrumbs with a link to releases and the release version', () => {
     renderHeader();
 
-    const header = screen.getByRole('tablist').closest('header')!;
-    expect(within(header).getByTestId('breadcrumb-list')).toBeInTheDocument();
-    expect(within(header).getByText(release.version)).toBeInTheDocument();
+    const breadcrumbs = screen.getByTestId('breadcrumb-list');
+    expect(within(breadcrumbs).getByRole('link', {name: 'Releases'})).toHaveAttribute(
+      'href',
+      `/organizations/${organization.slug}/explore/releases/?project=${project.id}`
+    );
+    expect(screen.getByText(release.version)).toBeInTheDocument();
   });
 
-  it('moves breadcrumbs and title into the top bar when page frame is enabled', () => {
-    renderHeader(OrganizationFixture({features: ['page-frame']}));
+  it('renders breadcrumbs with release version in the top bar when page frame is enabled', () => {
+    const pageFrameOrg = OrganizationFixture({features: ['page-frame']});
+    renderHeader(pageFrameOrg);
 
     const topbarSlot = screen.getByTestId('topbar-title-slot');
-    expect(within(topbarSlot).getByTestId('breadcrumb-list')).toBeInTheDocument();
+    const breadcrumbs = within(topbarSlot).getByTestId('breadcrumb-list');
+
+    expect(within(breadcrumbs).getByRole('link', {name: 'Releases'})).toHaveAttribute(
+      'href',
+      `/organizations/${pageFrameOrg.slug}/explore/releases/?project=${project.id}`
+    );
     expect(within(topbarSlot).getByText(release.version)).toBeInTheDocument();
   });
 });

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -49,14 +49,9 @@ export function ReleaseHeader({
   const hasPageFrameFeature = useHasPageFrameFeature();
   const {version, url} = release;
   const {commitCount, commitFilesChanged} = releaseMeta;
-  const titleContent = (avatarSize: number) => (
-    <Flex
-      align="center"
-      gap="md"
-      minWidth={0}
-      css={hasPageFrameFeature ? titleWrapperStyles : undefined}
-    >
-      <IdBadge project={project} avatarSize={avatarSize} hideName />
+  const titleChildren = (
+    <Fragment>
+      <IdBadge project={project} avatarSize={hasPageFrameFeature ? 16 : 28} hideName />
       <Version version={version} anchor={false} />
       <CopyToClipboardButton
         className="release-copy-button"
@@ -75,7 +70,7 @@ export function ReleaseHeader({
           </Tooltip>
         </IconWrapper>
       )}
-    </Flex>
+    </Fragment>
   );
 
   const breadcrumbs = [
@@ -88,7 +83,15 @@ export function ReleaseHeader({
       preservePageFilters: true,
     },
     ...(hasPageFrameFeature
-      ? [{label: titleContent(16)}]
+      ? [
+          {
+            label: (
+              <Flex align="center" gap="md" minWidth={0} css={titleWrapperStyles}>
+                {titleChildren}
+              </Flex>
+            ),
+          },
+        ]
       : [{label: t('Release Details')}]),
   ];
 
@@ -179,7 +182,7 @@ export function ReleaseHeader({
         ) : (
           <Fragment>
             <Breadcrumbs crumbs={breadcrumbs} />
-            <Layout.Title>{titleContent(28)}</Layout.Title>
+            <Layout.Title>{titleChildren}</Layout.Title>
           </Fragment>
         )}
       </Layout.HeaderContent>

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -147,30 +147,31 @@ export function ReleaseHeader({
           <Breadcrumbs crumbs={breadcrumbs} />
         )}
         <Layout.Title>
-          <IdBadge
-            project={project}
-            avatarSize={hasPageFrameFeature ? 16 : 28}
-            hideName
-          />
-          <Version version={version} anchor={false} truncate />
-          <IconWrapper>
+          <TitleWrapper>
+            <IdBadge
+              project={project}
+              avatarSize={hasPageFrameFeature ? 16 : 28}
+              hideName
+            />
+            <Version version={version} anchor={false} truncate />
             <CopyToClipboardButton
+              className="release-copy-button"
               priority="transparent"
               size="zero"
               text={version}
               tooltipProps={{title: version}}
               aria-label={t('Copy release version to clipboard')}
             />
-          </IconWrapper>
-          {!!url && (
-            <IconWrapper>
-              <Tooltip title={url}>
-                <ExternalLink href={url}>
-                  <IconOpen />
-                </ExternalLink>
-              </Tooltip>
-            </IconWrapper>
-          )}
+            {!!url && (
+              <IconWrapper>
+                <Tooltip title={url}>
+                  <ExternalLink href={url}>
+                    <IconOpen />
+                  </ExternalLink>
+                </Tooltip>
+              </IconWrapper>
+            )}
+          </TitleWrapper>
         </Layout.Title>
       </Layout.HeaderContent>
 
@@ -206,6 +207,21 @@ export function ReleaseHeader({
     </Layout.Header>
   );
 }
+
+const TitleWrapper = styled('span')`
+  display: flex;
+  align-items: center;
+  gap: ${p => p.theme.space.md};
+  min-width: 0;
+
+  .release-copy-button {
+    display: none;
+  }
+
+  &:hover .release-copy-button {
+    display: block;
+  }
+`;
 
 const IconWrapper = styled('span')`
   transition: color 0.3s ease-in-out;

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -210,6 +210,8 @@ export function ReleaseHeader({
 }
 
 const TitleWrapper = styled(Flex)`
+  line-height: 1;
+
   .release-copy-button {
     display: none;
   }

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -154,7 +154,7 @@ export function ReleaseHeader({
               avatarSize={hasPageFrameFeature ? 16 : 28}
               hideName
             />
-            <Version version={version} anchor={false} truncate />
+            <Version version={version} anchor={false} />
             <CopyToClipboardButton
               className="release-copy-button"
               priority="transparent"

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -4,6 +4,7 @@ import type {Location} from 'history';
 import pick from 'lodash/pick';
 
 import {Badge, FeatureBadge} from '@sentry/scraps/badge';
+import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {TabList} from '@sentry/scraps/tabs';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -147,7 +148,7 @@ export function ReleaseHeader({
           <Breadcrumbs crumbs={breadcrumbs} />
         )}
         <Layout.Title>
-          <TitleWrapper>
+          <TitleWrapper align="center" gap="md" minWidth={0}>
             <IdBadge
               project={project}
               avatarSize={hasPageFrameFeature ? 16 : 28}
@@ -208,12 +209,7 @@ export function ReleaseHeader({
   );
 }
 
-const TitleWrapper = styled('span')`
-  display: flex;
-  align-items: center;
-  gap: ${p => p.theme.space.md};
-  min-width: 0;
-
+const TitleWrapper = styled(Flex)`
   .release-copy-button {
     display: none;
   }

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 import pick from 'lodash/pick';
@@ -101,14 +101,14 @@ export function ReleaseHeader({
             <FeatureBadge type="new" />
           </BadgeWrapper>
         ) : (
-          <React.Fragment>
+          <Fragment>
             <NavTabsBadge variant="muted">
               {formatAbbreviatedNumber(numberOfMobileBuilds)}
             </NavTabsBadge>
             <BadgeWrapper>
               <FeatureBadge type="new" />
             </BadgeWrapper>
-          </React.Fragment>
+          </Fragment>
         ),
     }),
     textValue: t('Mobile Builds %s', numberOfMobileBuilds),
@@ -138,7 +138,7 @@ export function ReleaseHeader({
   };
 
   const title = (
-    <React.Fragment>
+    <Fragment>
       <IdBadge project={project} avatarSize={28} hideName />
       <Version version={version} anchor={false} truncate />
       <IconWrapper>
@@ -159,24 +159,24 @@ export function ReleaseHeader({
           </Tooltip>
         </IconWrapper>
       )}
-    </React.Fragment>
+    </Fragment>
   );
 
   return (
     <Layout.Header>
       <Layout.HeaderContent>
         {hasPageFrameFeature ? (
-          <React.Fragment>
+          <Fragment>
             <TopBar.Slot name="title">
               <Breadcrumbs crumbs={breadcrumbs} />
             </TopBar.Slot>
             <PageFrameTitle as="h1">{title}</PageFrameTitle>
-          </React.Fragment>
+          </Fragment>
         ) : (
-          <React.Fragment>
+          <Fragment>
             <Breadcrumbs crumbs={breadcrumbs} />
             <Layout.Title>{title}</Layout.Title>
-          </React.Fragment>
+          </Fragment>
         )}
       </Layout.HeaderContent>
 

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 import pick from 'lodash/pick';
@@ -49,7 +50,7 @@ export function ReleaseHeader({
   const {version, url} = release;
   const {commitCount, commitFilesChanged} = releaseMeta;
   const titleContent = (avatarSize: number) => (
-    <TitleWrapper align="center" gap="md" minWidth={0}>
+    <Flex align="center" gap="md" minWidth={0} css={titleWrapperStyles}>
       <IdBadge project={project} avatarSize={avatarSize} hideName />
       <Version version={version} anchor={false} />
       <CopyToClipboardButton
@@ -69,7 +70,7 @@ export function ReleaseHeader({
           </Tooltip>
         </IconWrapper>
       )}
-    </TitleWrapper>
+    </Flex>
   );
 
   const breadcrumbs = [
@@ -211,7 +212,7 @@ export function ReleaseHeader({
   );
 }
 
-const TitleWrapper = styled(Flex)`
+const titleWrapperStyles = css`
   line-height: 1;
 
   .release-copy-button {

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -148,7 +148,7 @@ export function ReleaseHeader({
           <Breadcrumbs crumbs={breadcrumbs} />
         )}
         <Layout.Title>
-          <TitleWrapper align="center" gap="sm" minWidth={0}>
+          <TitleWrapper align="center" gap="md" minWidth={0}>
             <IdBadge
               project={project}
               avatarSize={hasPageFrameFeature ? 16 : 28}

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -185,7 +185,7 @@ export function ReleaseHeader({
                 {label: t('Release Details')},
               ]}
             />
-            <Layout.Title>{renderTitleContent(28)}</Layout.Title>
+            <Layout.Title>{renderTitleContent(16)}</Layout.Title>
           </React.Fragment>
         )}
       </Layout.HeaderContent>

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -231,7 +231,7 @@ const titleWrapperStyles = css`
   }
 
   &:hover .release-copy-button {
-    display: block;
+    display: inline-flex;
   }
 `;
 

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -49,6 +49,31 @@ export function ReleaseHeader({
   const hasPageFrameFeature = useHasPageFrameFeature();
   const {version, url} = release;
   const {commitCount, commitFilesChanged} = releaseMeta;
+
+  const renderTitleContent = (avatarSize: number) => (
+    <React.Fragment>
+      <IdBadge project={project} avatarSize={avatarSize} hideName />
+      <Version version={version} anchor={false} truncate />
+      <CopyToClipboardButton
+        className="release-copy-button"
+        priority="transparent"
+        size="zero"
+        text={version}
+        tooltipProps={{title: version}}
+        aria-label={t('Copy release version to clipboard')}
+      />
+      {!!url && (
+        <IconWrapper>
+          <Tooltip title={url}>
+            <ExternalLink href={url}>
+              <IconOpen />
+            </ExternalLink>
+          </Tooltip>
+        </IconWrapper>
+      )}
+    </React.Fragment>
+  );
+
   const releasePath = makeReleasesPathname({
     organization,
     path: `/${encodeURIComponent(version)}/`,
@@ -141,25 +166,7 @@ export function ReleaseHeader({
                 {
                   label: (
                     <Flex align="center" gap="md" minWidth={0} css={titleWrapperStyles}>
-                      <IdBadge project={project} avatarSize={16} hideName />
-                      <Version version={version} anchor={false} truncate />
-                      <CopyToClipboardButton
-                        className="release-copy-button"
-                        priority="transparent"
-                        size="zero"
-                        text={version}
-                        tooltipProps={{title: version}}
-                        aria-label={t('Copy release version to clipboard')}
-                      />
-                      {!!url && (
-                        <IconWrapper>
-                          <Tooltip title={url}>
-                            <ExternalLink href={url}>
-                              <IconOpen />
-                            </ExternalLink>
-                          </Tooltip>
-                        </IconWrapper>
-                      )}
+                      {renderTitleContent(16)}
                     </Flex>
                   ),
                 },
@@ -178,27 +185,7 @@ export function ReleaseHeader({
                 {label: t('Release Details')},
               ]}
             />
-            <Layout.Title>
-              <IdBadge project={project} avatarSize={28} hideName />
-              <Version version={version} anchor={false} truncate />
-              <CopyToClipboardButton
-                className="release-copy-button"
-                priority="transparent"
-                size="zero"
-                text={version}
-                tooltipProps={{title: version}}
-                aria-label={t('Copy release version to clipboard')}
-              />
-              {!!url && (
-                <IconWrapper>
-                  <Tooltip title={url}>
-                    <ExternalLink href={url}>
-                      <IconOpen />
-                    </ExternalLink>
-                  </Tooltip>
-                </IconWrapper>
-              )}
-            </Layout.Title>
+            <Layout.Title>{renderTitleContent(28)}</Layout.Title>
           </React.Fragment>
         )}
       </Layout.HeaderContent>

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -6,7 +6,6 @@ import pick from 'lodash/pick';
 import {Badge, FeatureBadge} from '@sentry/scraps/badge';
 import {ExternalLink} from '@sentry/scraps/link';
 import {TabList} from '@sentry/scraps/tabs';
-import {Heading} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
@@ -166,18 +165,13 @@ export function ReleaseHeader({
     <Layout.Header>
       <Layout.HeaderContent>
         {hasPageFrameFeature ? (
-          <Fragment>
-            <TopBar.Slot name="title">
-              <Breadcrumbs crumbs={breadcrumbs} />
-            </TopBar.Slot>
-            <PageFrameTitle as="h1">{title}</PageFrameTitle>
-          </Fragment>
-        ) : (
-          <Fragment>
+          <TopBar.Slot name="title">
             <Breadcrumbs crumbs={breadcrumbs} />
-            <Layout.Title>{title}</Layout.Title>
-          </Fragment>
+          </TopBar.Slot>
+        ) : (
+          <Breadcrumbs crumbs={breadcrumbs} />
         )}
+        <Layout.Title>{title}</Layout.Title>
       </Layout.HeaderContent>
 
       {hasPageFrameFeature ? (
@@ -225,16 +219,6 @@ const IconWrapper = styled('span')`
       color: ${p => p.theme.tokens.content.primary};
     }
   }
-`;
-
-const PageFrameTitle = styled(Heading)`
-  display: flex;
-  align-items: center;
-  gap: ${p => p.theme.space.md};
-  margin: 0;
-  min-width: 0;
-  overflow: hidden;
-  width: 100%;
 `;
 
 const NavTabsBadge = styled(Badge)`

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -57,7 +57,7 @@ export function ReleaseHeader({
       label: t('Releases'),
       preservePageFilters: true,
     },
-    {label: t('Release Details')},
+    ...(hasPageFrameFeature ? [] : [{label: t('Release Details')}]),
   ];
 
   const releasePath = makeReleasesPathname({

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -147,7 +147,7 @@ export function ReleaseHeader({
           <Breadcrumbs crumbs={breadcrumbs} />
         )}
         <Layout.Title>
-          <IdBadge project={project} avatarSize={28} hideName />
+          <IdBadge project={project} avatarSize={16} hideName />
           <Version version={version} anchor={false} truncate />
           <IconWrapper>
             <CopyToClipboardButton

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -6,6 +6,7 @@ import pick from 'lodash/pick';
 import {Badge, FeatureBadge} from '@sentry/scraps/badge';
 import {ExternalLink} from '@sentry/scraps/link';
 import {TabList} from '@sentry/scraps/tabs';
+import {Heading} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
@@ -47,6 +48,17 @@ export function ReleaseHeader({
   const hasPageFrameFeature = useHasPageFrameFeature();
   const {version, url} = release;
   const {commitCount, commitFilesChanged} = releaseMeta;
+  const breadcrumbs = [
+    {
+      to: makeReleasesPathname({
+        organization,
+        path: '/',
+      }),
+      label: t('Releases'),
+      preservePageFilters: true,
+    },
+    {label: t('Release Details')},
+  ];
 
   const releasePath = makeReleasesPathname({
     organization,
@@ -125,44 +137,46 @@ export function ReleaseHeader({
     return tabs[0]!.to; // default to 'Overview'
   };
 
+  const title = (
+    <React.Fragment>
+      <IdBadge project={project} avatarSize={28} hideName />
+      <Version version={version} anchor={false} truncate />
+      <IconWrapper>
+        <CopyToClipboardButton
+          priority="transparent"
+          size="zero"
+          text={version}
+          tooltipProps={{title: version}}
+          aria-label={t('Copy release version to clipboard')}
+        />
+      </IconWrapper>
+      {!!url && (
+        <IconWrapper>
+          <Tooltip title={url}>
+            <ExternalLink href={url}>
+              <IconOpen />
+            </ExternalLink>
+          </Tooltip>
+        </IconWrapper>
+      )}
+    </React.Fragment>
+  );
+
   return (
     <Layout.Header>
       <Layout.HeaderContent>
-        <Breadcrumbs
-          crumbs={[
-            {
-              to: makeReleasesPathname({
-                organization,
-                path: '/',
-              }),
-              label: t('Releases'),
-              preservePageFilters: true,
-            },
-            {label: t('Release Details')},
-          ]}
-        />
-        <Layout.Title>
-          <IdBadge project={project} avatarSize={28} hideName />
-          <Version version={version} anchor={false} truncate />
-          <IconWrapper>
-            <CopyToClipboardButton
-              priority="transparent"
-              size="zero"
-              text={version}
-              tooltipProps={{title: version}}
-              aria-label={t('Copy release version to clipboard')}
-            />
-          </IconWrapper>
-          {!!url && (
-            <IconWrapper>
-              <Tooltip title={url}>
-                <ExternalLink href={url}>
-                  <IconOpen />
-                </ExternalLink>
-              </Tooltip>
-            </IconWrapper>
-          )}
-        </Layout.Title>
+        {hasPageFrameFeature ? (
+          <TopBar.Slot name="title">
+            <Breadcrumbs crumbs={breadcrumbs} />
+          </TopBar.Slot>
+        ) : (
+          <Breadcrumbs crumbs={breadcrumbs} />
+        )}
+        {hasPageFrameFeature ? (
+          <PageFrameTitle as="h1">{title}</PageFrameTitle>
+        ) : (
+          <Layout.Title>{title}</Layout.Title>
+        )}
       </Layout.HeaderContent>
 
       {hasPageFrameFeature ? (
@@ -210,6 +224,16 @@ const IconWrapper = styled('span')`
       color: ${p => p.theme.tokens.content.primary};
     }
   }
+`;
+
+const PageFrameTitle = styled(Heading)`
+  display: flex;
+  align-items: center;
+  gap: ${p => p.theme.space.md};
+  margin: 0;
+  min-width: 0;
+  overflow: hidden;
+  width: 100%;
 `;
 
 const NavTabsBadge = styled(Badge)`

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -147,7 +147,11 @@ export function ReleaseHeader({
           <Breadcrumbs crumbs={breadcrumbs} />
         )}
         <Layout.Title>
-          <IdBadge project={project} avatarSize={16} hideName />
+          <IdBadge
+            project={project}
+            avatarSize={hasPageFrameFeature ? 16 : 28}
+            hideName
+          />
           <Version version={version} anchor={false} truncate />
           <IconWrapper>
             <CopyToClipboardButton

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -50,9 +50,9 @@ export function ReleaseHeader({
   const {version, url} = release;
   const {commitCount, commitFilesChanged} = releaseMeta;
 
-  const renderTitleContent = (avatarSize: number) => (
+  const renderTitleContent = () => (
     <React.Fragment>
-      <IdBadge project={project} avatarSize={avatarSize} hideName />
+      <IdBadge project={project} avatarSize={16} hideName />
       <Version version={version} anchor={false} truncate />
       <CopyToClipboardButton
         className="release-copy-button"
@@ -166,7 +166,7 @@ export function ReleaseHeader({
                 {
                   label: (
                     <Flex align="center" gap="md" minWidth={0} css={titleWrapperStyles}>
-                      {renderTitleContent(16)}
+                      {renderTitleContent()}
                     </Flex>
                   ),
                 },
@@ -185,7 +185,7 @@ export function ReleaseHeader({
                 {label: t('Release Details')},
               ]}
             />
-            <Layout.Title>{renderTitleContent(28)}</Layout.Title>
+            <Layout.Title>{renderTitleContent()}</Layout.Title>
           </React.Fragment>
         )}
       </Layout.HeaderContent>

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -49,52 +49,6 @@ export function ReleaseHeader({
   const hasPageFrameFeature = useHasPageFrameFeature();
   const {version, url} = release;
   const {commitCount, commitFilesChanged} = releaseMeta;
-  const titleChildren = (
-    <React.Fragment>
-      <IdBadge project={project} avatarSize={hasPageFrameFeature ? 16 : 28} hideName />
-      <Version version={version} anchor={false} />
-      <CopyToClipboardButton
-        className="release-copy-button"
-        priority="transparent"
-        size="zero"
-        text={version}
-        tooltipProps={{title: version}}
-        aria-label={t('Copy release version to clipboard')}
-      />
-      {!!url && (
-        <IconWrapper>
-          <Tooltip title={url}>
-            <ExternalLink href={url}>
-              <IconOpen />
-            </ExternalLink>
-          </Tooltip>
-        </IconWrapper>
-      )}
-    </React.Fragment>
-  );
-
-  const breadcrumbs = [
-    {
-      to: makeReleasesPathname({
-        organization,
-        path: '/',
-      }),
-      label: t('Releases'),
-      preservePageFilters: true,
-    },
-    ...(hasPageFrameFeature
-      ? [
-          {
-            label: (
-              <Flex align="center" gap="md" minWidth={0} css={titleWrapperStyles}>
-                {titleChildren}
-              </Flex>
-            ),
-          },
-        ]
-      : [{label: t('Release Details')}]),
-  ];
-
   const releasePath = makeReleasesPathname({
     organization,
     path: `/${encodeURIComponent(version)}/`,
@@ -177,12 +131,74 @@ export function ReleaseHeader({
       <Layout.HeaderContent>
         {hasPageFrameFeature ? (
           <TopBar.Slot name="title">
-            <Breadcrumbs crumbs={breadcrumbs} />
+            <Breadcrumbs
+              crumbs={[
+                {
+                  to: makeReleasesPathname({organization, path: '/'}),
+                  label: t('Releases'),
+                  preservePageFilters: true,
+                },
+                {
+                  label: (
+                    <Flex align="center" gap="md" minWidth={0} css={titleWrapperStyles}>
+                      <IdBadge project={project} avatarSize={16} hideName />
+                      <Version version={version} anchor={false} truncate />
+                      <CopyToClipboardButton
+                        className="release-copy-button"
+                        priority="transparent"
+                        size="zero"
+                        text={version}
+                        tooltipProps={{title: version}}
+                        aria-label={t('Copy release version to clipboard')}
+                      />
+                      {!!url && (
+                        <IconWrapper>
+                          <Tooltip title={url}>
+                            <ExternalLink href={url}>
+                              <IconOpen />
+                            </ExternalLink>
+                          </Tooltip>
+                        </IconWrapper>
+                      )}
+                    </Flex>
+                  ),
+                },
+              ]}
+            />
           </TopBar.Slot>
         ) : (
           <React.Fragment>
-            <Breadcrumbs crumbs={breadcrumbs} />
-            <Layout.Title>{titleChildren}</Layout.Title>
+            <Breadcrumbs
+              crumbs={[
+                {
+                  to: makeReleasesPathname({organization, path: '/'}),
+                  label: t('Releases'),
+                  preservePageFilters: true,
+                },
+                {label: t('Release Details')},
+              ]}
+            />
+            <Layout.Title>
+              <IdBadge project={project} avatarSize={28} hideName />
+              <Version version={version} anchor={false} truncate />
+              <CopyToClipboardButton
+                className="release-copy-button"
+                priority="transparent"
+                size="zero"
+                text={version}
+                tooltipProps={{title: version}}
+                aria-label={t('Copy release version to clipboard')}
+              />
+              {!!url && (
+                <IconWrapper>
+                  <Tooltip title={url}>
+                    <ExternalLink href={url}>
+                      <IconOpen />
+                    </ExternalLink>
+                  </Tooltip>
+                </IconWrapper>
+              )}
+            </Layout.Title>
           </React.Fragment>
         )}
       </Layout.HeaderContent>

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -136,31 +136,6 @@ export function ReleaseHeader({
     return tabs[0]!.to; // default to 'Overview'
   };
 
-  const title = (
-    <Fragment>
-      <IdBadge project={project} avatarSize={28} hideName />
-      <Version version={version} anchor={false} truncate />
-      <IconWrapper>
-        <CopyToClipboardButton
-          priority="transparent"
-          size="zero"
-          text={version}
-          tooltipProps={{title: version}}
-          aria-label={t('Copy release version to clipboard')}
-        />
-      </IconWrapper>
-      {!!url && (
-        <IconWrapper>
-          <Tooltip title={url}>
-            <ExternalLink href={url}>
-              <IconOpen />
-            </ExternalLink>
-          </Tooltip>
-        </IconWrapper>
-      )}
-    </Fragment>
-  );
-
   return (
     <Layout.Header>
       <Layout.HeaderContent>
@@ -171,7 +146,28 @@ export function ReleaseHeader({
         ) : (
           <Breadcrumbs crumbs={breadcrumbs} />
         )}
-        <Layout.Title>{title}</Layout.Title>
+        <Layout.Title>
+          <IdBadge project={project} avatarSize={28} hideName />
+          <Version version={version} anchor={false} truncate />
+          <IconWrapper>
+            <CopyToClipboardButton
+              priority="transparent"
+              size="zero"
+              text={version}
+              tooltipProps={{title: version}}
+              aria-label={t('Copy release version to clipboard')}
+            />
+          </IconWrapper>
+          {!!url && (
+            <IconWrapper>
+              <Tooltip title={url}>
+                <ExternalLink href={url}>
+                  <IconOpen />
+                </ExternalLink>
+              </Tooltip>
+            </IconWrapper>
+          )}
+        </Layout.Title>
       </Layout.HeaderContent>
 
       {hasPageFrameFeature ? (

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import React from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
@@ -50,7 +50,7 @@ export function ReleaseHeader({
   const {version, url} = release;
   const {commitCount, commitFilesChanged} = releaseMeta;
   const titleChildren = (
-    <Fragment>
+    <React.Fragment>
       <IdBadge project={project} avatarSize={hasPageFrameFeature ? 16 : 28} hideName />
       <Version version={version} anchor={false} />
       <CopyToClipboardButton
@@ -70,7 +70,7 @@ export function ReleaseHeader({
           </Tooltip>
         </IconWrapper>
       )}
-    </Fragment>
+    </React.Fragment>
   );
 
   const breadcrumbs = [
@@ -136,14 +136,14 @@ export function ReleaseHeader({
             <FeatureBadge type="new" />
           </BadgeWrapper>
         ) : (
-          <Fragment>
+          <React.Fragment>
             <NavTabsBadge variant="muted">
               {formatAbbreviatedNumber(numberOfMobileBuilds)}
             </NavTabsBadge>
             <BadgeWrapper>
               <FeatureBadge type="new" />
             </BadgeWrapper>
-          </Fragment>
+          </React.Fragment>
         ),
     }),
     textValue: t('Mobile Builds %s', numberOfMobileBuilds),
@@ -180,10 +180,10 @@ export function ReleaseHeader({
             <Breadcrumbs crumbs={breadcrumbs} />
           </TopBar.Slot>
         ) : (
-          <Fragment>
+          <React.Fragment>
             <Breadcrumbs crumbs={breadcrumbs} />
             <Layout.Title>{titleChildren}</Layout.Title>
-          </Fragment>
+          </React.Fragment>
         )}
       </Layout.HeaderContent>
 

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -50,7 +50,7 @@ export function ReleaseHeader({
   const {version, url} = release;
   const {commitCount, commitFilesChanged} = releaseMeta;
 
-  const renderTitleContent = () => (
+  const titleContent = (
     <React.Fragment>
       <IdBadge project={project} avatarSize={16} hideName />
       <Version version={version} anchor={false} truncate />
@@ -166,7 +166,7 @@ export function ReleaseHeader({
                 {
                   label: (
                     <Flex align="center" gap="md" minWidth={0} css={titleWrapperStyles}>
-                      {renderTitleContent()}
+                      {titleContent}
                     </Flex>
                   ),
                 },
@@ -185,7 +185,7 @@ export function ReleaseHeader({
                 {label: t('Release Details')},
               ]}
             />
-            <Layout.Title>{renderTitleContent()}</Layout.Title>
+            <Layout.Title>{titleContent}</Layout.Title>
           </React.Fragment>
         )}
       </Layout.HeaderContent>

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -57,7 +57,35 @@ export function ReleaseHeader({
       label: t('Releases'),
       preservePageFilters: true,
     },
-    ...(hasPageFrameFeature ? [] : [{label: t('Release Details')}]),
+    ...(hasPageFrameFeature
+      ? [
+          {
+            label: (
+              <TitleWrapper align="center" gap="md" minWidth={0}>
+                <IdBadge project={project} avatarSize={16} hideName />
+                <Version version={version} anchor={false} />
+                <CopyToClipboardButton
+                  className="release-copy-button"
+                  priority="transparent"
+                  size="zero"
+                  text={version}
+                  tooltipProps={{title: version}}
+                  aria-label={t('Copy release version to clipboard')}
+                />
+                {!!url && (
+                  <IconWrapper>
+                    <Tooltip title={url}>
+                      <ExternalLink href={url}>
+                        <IconOpen />
+                      </ExternalLink>
+                    </Tooltip>
+                  </IconWrapper>
+                )}
+              </TitleWrapper>
+            ),
+          },
+        ]
+      : [{label: t('Release Details')}]),
   ];
 
   const releasePath = makeReleasesPathname({
@@ -145,35 +173,33 @@ export function ReleaseHeader({
             <Breadcrumbs crumbs={breadcrumbs} />
           </TopBar.Slot>
         ) : (
-          <Breadcrumbs crumbs={breadcrumbs} />
+          <Fragment>
+            <Breadcrumbs crumbs={breadcrumbs} />
+            <Layout.Title>
+              <TitleWrapper align="center" gap="md" minWidth={0}>
+                <IdBadge project={project} avatarSize={28} hideName />
+                <Version version={version} anchor={false} />
+                <CopyToClipboardButton
+                  className="release-copy-button"
+                  priority="transparent"
+                  size="zero"
+                  text={version}
+                  tooltipProps={{title: version}}
+                  aria-label={t('Copy release version to clipboard')}
+                />
+                {!!url && (
+                  <IconWrapper>
+                    <Tooltip title={url}>
+                      <ExternalLink href={url}>
+                        <IconOpen />
+                      </ExternalLink>
+                    </Tooltip>
+                  </IconWrapper>
+                )}
+              </TitleWrapper>
+            </Layout.Title>
+          </Fragment>
         )}
-        <Layout.Title>
-          <TitleWrapper align="center" gap="md" minWidth={0}>
-            <IdBadge
-              project={project}
-              avatarSize={hasPageFrameFeature ? 16 : 28}
-              hideName
-            />
-            <Version version={version} anchor={false} />
-            <CopyToClipboardButton
-              className="release-copy-button"
-              priority="transparent"
-              size="zero"
-              text={version}
-              tooltipProps={{title: version}}
-              aria-label={t('Copy release version to clipboard')}
-            />
-            {!!url && (
-              <IconWrapper>
-                <Tooltip title={url}>
-                  <ExternalLink href={url}>
-                    <IconOpen />
-                  </ExternalLink>
-                </Tooltip>
-              </IconWrapper>
-            )}
-          </TitleWrapper>
-        </Layout.Title>
       </Layout.HeaderContent>
 
       {hasPageFrameFeature ? (

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -50,7 +50,12 @@ export function ReleaseHeader({
   const {version, url} = release;
   const {commitCount, commitFilesChanged} = releaseMeta;
   const titleContent = (avatarSize: number) => (
-    <Flex align="center" gap="md" minWidth={0} css={titleWrapperStyles}>
+    <Flex
+      align="center"
+      gap="md"
+      minWidth={0}
+      css={hasPageFrameFeature ? titleWrapperStyles : undefined}
+    >
       <IdBadge project={project} avatarSize={avatarSize} hideName />
       <Version version={version} anchor={false} />
       <CopyToClipboardButton

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -166,16 +166,17 @@ export function ReleaseHeader({
     <Layout.Header>
       <Layout.HeaderContent>
         {hasPageFrameFeature ? (
-          <TopBar.Slot name="title">
+          <React.Fragment>
+            <TopBar.Slot name="title">
+              <Breadcrumbs crumbs={breadcrumbs} />
+            </TopBar.Slot>
+            <PageFrameTitle as="h1">{title}</PageFrameTitle>
+          </React.Fragment>
+        ) : (
+          <React.Fragment>
             <Breadcrumbs crumbs={breadcrumbs} />
-          </TopBar.Slot>
-        ) : (
-          <Breadcrumbs crumbs={breadcrumbs} />
-        )}
-        {hasPageFrameFeature ? (
-          <PageFrameTitle as="h1">{title}</PageFrameTitle>
-        ) : (
-          <Layout.Title>{title}</Layout.Title>
+            <Layout.Title>{title}</Layout.Title>
+          </React.Fragment>
         )}
       </Layout.HeaderContent>
 

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -148,7 +148,7 @@ export function ReleaseHeader({
           <Breadcrumbs crumbs={breadcrumbs} />
         )}
         <Layout.Title>
-          <TitleWrapper align="center" gap="md" minWidth={0}>
+          <TitleWrapper align="center" gap="sm" minWidth={0}>
             <IdBadge
               project={project}
               avatarSize={hasPageFrameFeature ? 16 : 28}

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -48,6 +48,30 @@ export function ReleaseHeader({
   const hasPageFrameFeature = useHasPageFrameFeature();
   const {version, url} = release;
   const {commitCount, commitFilesChanged} = releaseMeta;
+  const titleContent = (avatarSize: number) => (
+    <TitleWrapper align="center" gap="md" minWidth={0}>
+      <IdBadge project={project} avatarSize={avatarSize} hideName />
+      <Version version={version} anchor={false} />
+      <CopyToClipboardButton
+        className="release-copy-button"
+        priority="transparent"
+        size="zero"
+        text={version}
+        tooltipProps={{title: version}}
+        aria-label={t('Copy release version to clipboard')}
+      />
+      {!!url && (
+        <IconWrapper>
+          <Tooltip title={url}>
+            <ExternalLink href={url}>
+              <IconOpen />
+            </ExternalLink>
+          </Tooltip>
+        </IconWrapper>
+      )}
+    </TitleWrapper>
+  );
+
   const breadcrumbs = [
     {
       to: makeReleasesPathname({
@@ -58,33 +82,7 @@ export function ReleaseHeader({
       preservePageFilters: true,
     },
     ...(hasPageFrameFeature
-      ? [
-          {
-            label: (
-              <TitleWrapper align="center" gap="md" minWidth={0}>
-                <IdBadge project={project} avatarSize={16} hideName />
-                <Version version={version} anchor={false} />
-                <CopyToClipboardButton
-                  className="release-copy-button"
-                  priority="transparent"
-                  size="zero"
-                  text={version}
-                  tooltipProps={{title: version}}
-                  aria-label={t('Copy release version to clipboard')}
-                />
-                {!!url && (
-                  <IconWrapper>
-                    <Tooltip title={url}>
-                      <ExternalLink href={url}>
-                        <IconOpen />
-                      </ExternalLink>
-                    </Tooltip>
-                  </IconWrapper>
-                )}
-              </TitleWrapper>
-            ),
-          },
-        ]
+      ? [{label: titleContent(16)}]
       : [{label: t('Release Details')}]),
   ];
 
@@ -175,29 +173,7 @@ export function ReleaseHeader({
         ) : (
           <Fragment>
             <Breadcrumbs crumbs={breadcrumbs} />
-            <Layout.Title>
-              <TitleWrapper align="center" gap="md" minWidth={0}>
-                <IdBadge project={project} avatarSize={28} hideName />
-                <Version version={version} anchor={false} />
-                <CopyToClipboardButton
-                  className="release-copy-button"
-                  priority="transparent"
-                  size="zero"
-                  text={version}
-                  tooltipProps={{title: version}}
-                  aria-label={t('Copy release version to clipboard')}
-                />
-                {!!url && (
-                  <IconWrapper>
-                    <Tooltip title={url}>
-                      <ExternalLink href={url}>
-                        <IconOpen />
-                      </ExternalLink>
-                    </Tooltip>
-                  </IconWrapper>
-                )}
-              </TitleWrapper>
-            </Layout.Title>
+            <Layout.Title>{titleContent(28)}</Layout.Title>
           </Fragment>
         )}
       </Layout.HeaderContent>

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -185,7 +185,7 @@ export function ReleaseHeader({
                 {label: t('Release Details')},
               ]}
             />
-            <Layout.Title>{renderTitleContent(16)}</Layout.Title>
+            <Layout.Title>{renderTitleContent(28)}</Layout.Title>
           </React.Fragment>
         )}
       </Layout.HeaderContent>


### PR DESCRIPTION
Move the Releases detail breadcrumb trail into the top bar when page-frame is enabled and keep the release version block in the page header.

This fixes the toolbar inconsistency where Releases showed the large project badge in the page-frame top bar while leaving the breadcrumb trail inside the page content. After this change, Releases matches the surrounding detail views by using the top bar for navigation context and the page header for the release title.

Add a focused regression spec that covers both page-frame and non-page-frame rendering so the breadcrumb/title split stays stable.


**Before**

<img width="475" height="104" alt="image" src="https://github.com/user-attachments/assets/f0c4ff3c-39b6-4362-abe7-b5e328d1a6de" />



**After**


https://github.com/user-attachments/assets/3b587be3-6220-4173-8880-d0d06ef0be1f




**Note:** The copy button now appears when hovering, matching the behavior in logs and issues.



closes https://linear.app/getsentry/issue/DE-1127/releases-uses-large-icon-and-renders-breadcrumbs-into-the-page


closes https://linear.app/getsentry/issue/DE-1128/releases-shows-copy-button-all-the-time-not-just-on-hover-like-in