### PR TITLE
fix(eap): Handle aliased attributes in deprecated attribute coalescing

### DIFF
--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -508,6 +508,12 @@ except Exception:
     logger.exception("Failed to load deprecated attributes from 'deprecated_attributes.json'")
 
 
+_INTERNAL_NAME_TO_PUBLIC_ALIAS: dict[str, str] = {
+    definition.internal_name: definition.public_alias
+    for definition in SPAN_ATTRIBUTE_DEFINITIONS.values()
+    if not definition.secondary_alias
+}
+
 try:
     for attribute in DEPRECATED_ATTRIBUTES:
         deprecation = attribute.get("deprecation", {})
@@ -520,9 +526,15 @@ try:
         ):
             status = deprecation["_status"]
             replacement = deprecation["replacement"]
-            if key in SPAN_ATTRIBUTE_DEFINITIONS:
-                deprecated_attr = SPAN_ATTRIBUTE_DEFINITIONS[key]
-                SPAN_ATTRIBUTE_DEFINITIONS[key] = replace(
+            # The key from sentry-conventions is the raw attribute name (e.g. "app_start_warm"),
+            # but SPAN_ATTRIBUTE_DEFINITIONS is keyed by public_alias which may differ
+            # (e.g. "measurements.app_start_warm"). Fall back to a reverse lookup by internal_name.
+            lookup_key = key
+            if key not in SPAN_ATTRIBUTE_DEFINITIONS and key in _INTERNAL_NAME_TO_PUBLIC_ALIAS:
+                lookup_key = _INTERNAL_NAME_TO_PUBLIC_ALIAS[key]
+            if lookup_key in SPAN_ATTRIBUTE_DEFINITIONS:
+                deprecated_attr = SPAN_ATTRIBUTE_DEFINITIONS[lookup_key]
+                SPAN_ATTRIBUTE_DEFINITIONS[lookup_key] = replace(
                     deprecated_attr, replacement=replacement, deprecation_status=status
                 )
                 # TODO: Introduce units to attribute schema.

--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -508,12 +508,6 @@ except Exception:
     logger.exception("Failed to load deprecated attributes from 'deprecated_attributes.json'")
 
 
-_INTERNAL_NAME_TO_PUBLIC_ALIAS: dict[str, str] = {
-    definition.internal_name: definition.public_alias
-    for definition in SPAN_ATTRIBUTE_DEFINITIONS.values()
-    if not definition.secondary_alias
-}
-
 try:
     for attribute in DEPRECATED_ATTRIBUTES:
         deprecation = attribute.get("deprecation", {})
@@ -528,10 +522,13 @@ try:
             replacement = deprecation["replacement"]
             # The key from sentry-conventions is the raw attribute name (e.g. "app_start_warm"),
             # but SPAN_ATTRIBUTE_DEFINITIONS is keyed by public_alias which may differ
-            # (e.g. "measurements.app_start_warm"). Fall back to a reverse lookup by internal_name.
+            # (e.g. "measurements.app_start_warm"). Fall back to finding by internal_name.
             lookup_key = key
-            if key not in SPAN_ATTRIBUTE_DEFINITIONS and key in _INTERNAL_NAME_TO_PUBLIC_ALIAS:
-                lookup_key = _INTERNAL_NAME_TO_PUBLIC_ALIAS[key]
+            if key not in SPAN_ATTRIBUTE_DEFINITIONS:
+                for pub_alias, defn in SPAN_ATTRIBUTE_DEFINITIONS.items():
+                    if defn.internal_name == key and not defn.secondary_alias:
+                        lookup_key = pub_alias
+                        break
             if lookup_key in SPAN_ATTRIBUTE_DEFINITIONS:
                 deprecated_attr = SPAN_ATTRIBUTE_DEFINITIONS[lookup_key]
                 SPAN_ATTRIBUTE_DEFINITIONS[lookup_key] = replace(

--- a/tests/sentry/search/eap/test_spans.py
+++ b/tests/sentry/search/eap/test_spans.py
@@ -730,9 +730,7 @@ def test_deprecated_attr_lookup_resolves_by_internal_name() -> None:
     definitions[measurement.public_alias] = measurement
 
     internal_to_public = {
-        d.internal_name: d.public_alias
-        for d in definitions.values()
-        if not d.secondary_alias
+        d.internal_name: d.public_alias for d in definitions.values() if not d.secondary_alias
     }
 
     deprecated_attr = {
@@ -756,9 +754,7 @@ def test_deprecated_attr_lookup_resolves_by_internal_name() -> None:
     assert lookup_key == "measurements.app_start_warm"
 
     existing = definitions[lookup_key]
-    definitions[lookup_key] = replace(
-        existing, replacement=replacement, deprecation_status=status
-    )
+    definitions[lookup_key] = replace(existing, replacement=replacement, deprecation_status=status)
     definitions[replacement] = replace(
         existing, public_alias=replacement, internal_name=replacement
     )

--- a/tests/sentry/search/eap/test_spans.py
+++ b/tests/sentry/search/eap/test_spans.py
@@ -704,3 +704,85 @@ def test_loads_deprecated_attrs_json() -> None:
     attribute = deprecated_attrs[0]
     assert attribute["key"]
     assert attribute["deprecation"]
+
+
+def test_internal_name_to_public_alias_maps_measurements() -> None:
+    from sentry.search.eap.spans.attributes import _INTERNAL_NAME_TO_PUBLIC_ALIAS
+
+    assert _INTERNAL_NAME_TO_PUBLIC_ALIAS["app_start_warm"] == "measurements.app_start_warm"
+    assert _INTERNAL_NAME_TO_PUBLIC_ALIAS["app_start_cold"] == "measurements.app_start_cold"
+    assert _INTERNAL_NAME_TO_PUBLIC_ALIAS["frames_frozen"] == "measurements.frames_frozen"
+    assert _INTERNAL_NAME_TO_PUBLIC_ALIAS["lcp"] == "measurements.lcp"
+
+
+def test_deprecated_attr_lookup_resolves_by_internal_name() -> None:
+    """When sentry-conventions deprecates a raw attribute name (e.g. "app_start_warm")
+    that is stored in SPAN_ATTRIBUTE_DEFINITIONS under a different public_alias
+    (e.g. "measurements.app_start_warm"), the loading logic should still match
+    via internal_name and update the existing definition rather than creating
+    a disconnected entry."""
+    from dataclasses import replace
+
+    from sentry.search.eap.columns import ResolvedAttribute, simple_measurements_field
+
+    definitions: dict[str, ResolvedAttribute] = {}
+    measurement = simple_measurements_field("app_start_warm", "millisecond")
+    definitions[measurement.public_alias] = measurement
+
+    internal_to_public = {
+        d.internal_name: d.public_alias
+        for d in definitions.values()
+        if not d.secondary_alias
+    }
+
+    deprecated_attr = {
+        "key": "app_start_warm",
+        "type": "number",
+        "deprecation": {
+            "_status": "backfill",
+            "replacement": "app.vitals.start.warm.value",
+        },
+    }
+
+    key = deprecated_attr["key"]
+    deprecation = deprecated_attr["deprecation"]
+    replacement = deprecation["replacement"]
+    status = deprecation["_status"]
+
+    lookup_key = key
+    if key not in definitions and key in internal_to_public:
+        lookup_key = internal_to_public[key]
+
+    assert lookup_key == "measurements.app_start_warm"
+
+    existing = definitions[lookup_key]
+    definitions[lookup_key] = replace(
+        existing, replacement=replacement, deprecation_status=status
+    )
+    definitions[replacement] = replace(
+        existing, public_alias=replacement, internal_name=replacement
+    )
+
+    updated = definitions["measurements.app_start_warm"]
+    assert updated.replacement == "app.vitals.start.warm.value"
+    assert updated.deprecation_status == "backfill"
+    assert updated.internal_name == "app_start_warm"
+    assert updated.search_type == "millisecond"
+
+    new_attr = definitions["app.vitals.start.warm.value"]
+    assert new_attr.public_alias == "app.vitals.start.warm.value"
+    assert new_attr.internal_name == "app.vitals.start.warm.value"
+    assert new_attr.search_type == "millisecond"
+
+
+def test_deprecated_attr_lookup_without_fix_would_miss_measurement() -> None:
+    """Verifies that looking up by raw key alone (without the internal_name
+    fallback) would miss measurement fields, confirming the fix is necessary."""
+    from sentry.search.eap.columns import ResolvedAttribute, simple_measurements_field
+
+    definitions: dict[str, ResolvedAttribute] = {}
+    measurement = simple_measurements_field("app_start_warm", "millisecond")
+    definitions[measurement.public_alias] = measurement
+
+    assert "app_start_warm" not in definitions
+    assert "measurements.app_start_warm" in definitions

--- a/tests/sentry/search/eap/test_spans.py
+++ b/tests/sentry/search/eap/test_spans.py
@@ -706,15 +706,6 @@ def test_loads_deprecated_attrs_json() -> None:
     assert attribute["deprecation"]
 
 
-def test_internal_name_to_public_alias_maps_measurements() -> None:
-    from sentry.search.eap.spans.attributes import _INTERNAL_NAME_TO_PUBLIC_ALIAS
-
-    assert _INTERNAL_NAME_TO_PUBLIC_ALIAS["app_start_warm"] == "measurements.app_start_warm"
-    assert _INTERNAL_NAME_TO_PUBLIC_ALIAS["app_start_cold"] == "measurements.app_start_cold"
-    assert _INTERNAL_NAME_TO_PUBLIC_ALIAS["frames_frozen"] == "measurements.frames_frozen"
-    assert _INTERNAL_NAME_TO_PUBLIC_ALIAS["lcp"] == "measurements.lcp"
-
-
 def test_deprecated_attr_lookup_resolves_by_internal_name() -> None:
     """When sentry-conventions deprecates a raw attribute name (e.g. "app_start_warm")
     that is stored in SPAN_ATTRIBUTE_DEFINITIONS under a different public_alias
@@ -729,17 +720,16 @@ def test_deprecated_attr_lookup_resolves_by_internal_name() -> None:
     measurement = simple_measurements_field("app_start_warm", "millisecond")
     definitions[measurement.public_alias] = measurement
 
-    internal_to_public = {
-        d.internal_name: d.public_alias for d in definitions.values() if not d.secondary_alias
-    }
-
     key = "app_start_warm"
     replacement = "app.vitals.start.warm.value"
     status = "backfill"
 
     lookup_key = key
-    if key not in definitions and key in internal_to_public:
-        lookup_key = internal_to_public[key]
+    if key not in definitions:
+        for pub_alias, defn in definitions.items():
+            if defn.internal_name == key and not defn.secondary_alias:
+                lookup_key = pub_alias
+                break
 
     assert lookup_key == "measurements.app_start_warm"
 

--- a/tests/sentry/search/eap/test_spans.py
+++ b/tests/sentry/search/eap/test_spans.py
@@ -733,19 +733,9 @@ def test_deprecated_attr_lookup_resolves_by_internal_name() -> None:
         d.internal_name: d.public_alias for d in definitions.values() if not d.secondary_alias
     }
 
-    deprecated_attr = {
-        "key": "app_start_warm",
-        "type": "number",
-        "deprecation": {
-            "_status": "backfill",
-            "replacement": "app.vitals.start.warm.value",
-        },
-    }
-
-    key = deprecated_attr["key"]
-    deprecation = deprecated_attr["deprecation"]
-    replacement = deprecation["replacement"]
-    status = deprecation["_status"]
+    key = "app_start_warm"
+    replacement = "app.vitals.start.warm.value"
+    status = "backfill"
 
     lookup_key = key
     if key not in definitions and key in internal_to_public:


### PR DESCRIPTION
Deprecated attribute coalescing only looks up by `public_alias`, but
sentry-conventions uses raw attribute names (e.g. `app_start_warm`).

For measurement fields, the `public_alias` differs (`measurements.app_start_warm`),
so the lookup misses. This adds a fallback that resolves by `internal_name`.