### PR TITLE
Fix/monitors UI copy

### DIFF
--- a/static/app/components/workflowEngine/layout/list.tsx
+++ b/static/app/components/workflowEngine/layout/list.tsx
@@ -12,7 +12,7 @@ interface WorkflowEngineListLayoutProps {
   actions: React.ReactNode;
   /** The main content for this page */
   children: React.ReactNode;
-  description: string;
+  description: React.ReactNode;
   docsUrl: string;
   title: string;
 }

--- a/static/app/views/detectors/components/detectorTypeForm.tsx
+++ b/static/app/views/detectors/components/detectorTypeForm.tsx
@@ -86,7 +86,7 @@ function MonitorTypeField() {
       id: 'metric_issue',
       name: getDetectorTypeLabel('metric_issue'),
       description: t(
-        'Monitor error counts, logs, custom metrics, span duration, crash rates, and more. '
+        'Monitor error counts, logs, application metrics, span duration, crash rates, and more.'
       ),
       visualization: <MetricVisualization />,
       infoBanner: canCreateMetricDetector ? undefined : (

--- a/static/app/views/detectors/components/forms/metric/metricTemplateOptions.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricTemplateOptions.tsx
@@ -62,7 +62,7 @@ export const METRIC_TEMPLATE_OPTIONS: TemplateOption[] = [
   },
   {
     key: 'trace_item_metrics',
-    label: t('Custom Metrics'),
+    label: t('Application Metrics'),
     detectorDataset: DetectorDataset.METRICS,
     aggregate: 'sum(value,,,-)',
   },

--- a/static/app/views/detectors/components/forms/metric/templateSection.tsx
+++ b/static/app/views/detectors/components/forms/metric/templateSection.tsx
@@ -25,7 +25,7 @@ const DATASET_LABELS: Record<DetectorDataset, string> = {
   [DetectorDataset.LOGS]: t('Logs'),
   [DetectorDataset.RELEASES]: t('Releases'),
   [DetectorDataset.TRANSACTIONS]: t('Transactions'),
-  [DetectorDataset.METRICS]: t('Metrics'),
+  [DetectorDataset.METRICS]: t('Application Metrics'),
 };
 
 /**

--- a/static/app/views/detectors/components/forms/metric/useDatasetChoices.tsx
+++ b/static/app/views/detectors/components/forms/metric/useDatasetChoices.tsx
@@ -58,7 +58,7 @@ export function useDatasetChoices(): Array<SelectValue<DetectorDataset>> {
         ? [
             {
               value: DetectorDataset.METRICS,
-              label: t('Metrics'),
+              label: t('Application Metrics'),
               trailingItems: <FeatureBadge type="beta" />,
             },
           ]

--- a/static/app/views/detectors/list/metric.tsx
+++ b/static/app/views/detectors/list/metric.tsx
@@ -1,29 +1,37 @@
+import {Link} from '@sentry/scraps/link';
+
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {WorkflowEngineListLayout} from 'sentry/components/workflowEngine/layout/list';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {DetectorListActions} from 'sentry/views/detectors/list/common/detectorListActions';
 import {DetectorListContent} from 'sentry/views/detectors/list/common/detectorListContent';
 import {DetectorListHeader} from 'sentry/views/detectors/list/common/detectorListHeader';
 import {useDetectorListQuery} from 'sentry/views/detectors/list/common/useDetectorListQuery';
 
 const TITLE = t('Metric Monitors');
-const DESCRIPTION = t(
-  'Metric monitors track errors based on span attributes and custom metrics.'
-);
 const DOCS_URL =
   'https://docs.sentry.io/product/new-monitors-and-alerts/monitors/#metric-monitor-settings';
 
 export default function MetricDetectorsList() {
+  const organization = useOrganization();
   const detectorListQuery = useDetectorListQuery({
     detectorFilter: 'metric_issue',
   });
+
+  const description = tct(
+    'Metric Monitors automatically create [issuesLink:Issues] when queries meet defined thresholds.',
+    {
+      issuesLink: <Link to={`/organizations/${organization.slug}/issues/`} />,
+    }
+  );
 
   return (
     <SentryDocumentTitle title={TITLE}>
       <WorkflowEngineListLayout
         actions={<DetectorListActions detectorType="metric_issue" />}
         title={TITLE}
-        description={DESCRIPTION}
+        description={description}
         docsUrl={DOCS_URL}
       >
         <DetectorListHeader showTypeFilter={false} />

--- a/static/app/views/detectors/utils/useDetectorFilterKeys.tsx
+++ b/static/app/views/detectors/utils/useDetectorFilterKeys.tsx
@@ -23,7 +23,7 @@ const DETECTOR_FILTER_KEYS: Record<
   type: {
     predefined: true,
     fieldDefinition: {
-      desc: 'Type of the detector',
+      desc: 'Type of the monitor',
       kind: FieldKind.FIELD,
       valueType: FieldValueType.STRING,
       allowWildcard: false,

--- a/static/app/views/discover/savedQuery/index.spec.tsx
+++ b/static/app/views/discover/savedQuery/index.spec.tsx
@@ -497,5 +497,29 @@ describe('Discover > SaveQueryButtonGroup', () => {
       expect(queryParameters.get('dataset')).toBe('events');
       expect(queryParameters.get('eventTypes')).toBe('error');
     });
+    it('renders "Create Alert" button without workflow-engine-ui flag', () => {
+      const metricAlertOrg = {
+        ...organization,
+        features: ['incidents'],
+      };
+      mount(location, metricAlertOrg, errorsViewModified, savedQuery, yAxis);
+
+      expect(screen.getByRole('button', {name: 'Create Alert'})).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', {name: 'Create Monitor'})
+      ).not.toBeInTheDocument();
+    });
+    it('renders "Create Monitor" button with workflow-engine-ui flag', () => {
+      const metricAlertOrg = {
+        ...organization,
+        features: ['incidents', 'workflow-engine-ui'],
+      };
+      mount(location, metricAlertOrg, errorsViewModified, savedQuery, yAxis);
+
+      expect(screen.getByRole('button', {name: 'Create Monitor'})).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', {name: 'Create Alert'})
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/static/app/views/discover/savedQuery/index.tsx
+++ b/static/app/views/discover/savedQuery/index.tsx
@@ -497,7 +497,6 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
           onClick={this.handleCreateAlertSuccess}
           referrer="discover"
           size="sm"
-          aria-label={t('Create Alert')}
           data-test-id="discover2-create-from-discover"
           alertType={alertType}
         />

--- a/static/app/views/navigation/secondary/sections/monitors/monitorsSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/monitors/monitorsSecondaryNavigation.tsx
@@ -35,7 +35,10 @@ export function MonitorsSecondaryNavigation() {
           </SecondaryNavigation.List>
         </SecondaryNavigation.Section>
         <SecondaryNavigation.Separator />
-        <SecondaryNavigation.Section id="monitors-data-types" title={t('By Data Type')}>
+        <SecondaryNavigation.Section
+          id="monitors-data-types"
+          title={t('By Monitor Type')}
+        >
           <SecondaryNavigation.List>
             <SecondaryNavigation.ListItem>
               <SecondaryNavigation.Link


### PR DESCRIPTION
<!-- Describe your PR here. -->

Fixes a number of copy inconsistencies noticed during bug bash and due to the upcoming launch of recently renamed application metrics.

Specifically:
- render "Create Monitor" behind workflow-ui-engine flag on Discover pages
- fixes references to custom metrics/metrics and replaces with Application Metrics
- clarifies references to monitors (data type, detector etc.) in the app