### PR TITLE
feat(tracemetrics): Add group by selector to equations

### DIFF
--- a/static/app/views/explore/metrics/metricToolbar/groupBySelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/groupBySelector.tsx
@@ -1,7 +1,7 @@
 import {useCallback, useMemo} from 'react';
 
-import {CompactSelect} from '@sentry/scraps/compactSelect';
 import type {SelectOption} from '@sentry/scraps/compactSelect';
+import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
 import {t} from 'sentry/locale';
@@ -22,6 +22,10 @@ interface GroupBySelectorProps {
    * The metric to filter attributes by
    */
   traceMetric: TraceMetric;
+  /**
+   * Whether to skip the trace metric filter. For equations.
+   */
+  skipTraceMetricFilter?: boolean;
 }
 
 /**
@@ -29,7 +33,10 @@ interface GroupBySelectorProps {
  * Fetches available attribute keys from the trace-items API endpoint
  * and displays them as options in a compact select dropdown.
  */
-export function GroupBySelector({traceMetric}: GroupBySelectorProps) {
+export function GroupBySelector({
+  traceMetric,
+  skipTraceMetricFilter,
+}: GroupBySelectorProps) {
   const groupBys = useQueryParamsGroupBys();
   const setGroupBys = useSetQueryParamsGroupBys();
 
@@ -39,22 +46,22 @@ export function GroupBySelector({traceMetric}: GroupBySelectorProps) {
     useTraceItemAttributeKeys({
       traceItemType: TraceItemDataset.TRACEMETRICS,
       type: 'number',
-      enabled: Boolean(traceMetricFilter),
-      query: traceMetricFilter,
+      enabled: skipTraceMetricFilter || Boolean(traceMetricFilter),
+      query: skipTraceMetricFilter ? undefined : traceMetricFilter,
     });
   const {attributes: stringTags, isLoading: stringTagsLoading} =
     useTraceItemAttributeKeys({
       traceItemType: TraceItemDataset.TRACEMETRICS,
       type: 'string',
-      enabled: Boolean(traceMetricFilter),
-      query: traceMetricFilter,
+      enabled: skipTraceMetricFilter || Boolean(traceMetricFilter),
+      query: skipTraceMetricFilter ? undefined : traceMetricFilter,
     });
   const {attributes: booleanTags, isLoading: booleanTagsLoading} =
     useTraceItemAttributeKeys({
       traceItemType: TraceItemDataset.TRACEMETRICS,
       type: 'boolean',
-      enabled: Boolean(traceMetricFilter),
-      query: traceMetricFilter,
+      enabled: skipTraceMetricFilter || Boolean(traceMetricFilter),
+      query: skipTraceMetricFilter ? undefined : traceMetricFilter,
     });
 
   const visibleNumberTags = useMemo(() => {
@@ -122,7 +129,7 @@ export function GroupBySelector({traceMetric}: GroupBySelectorProps) {
       options={enabledOptions}
       value={[...groupBys]}
       loading={isLoading}
-      disabled={!traceMetricFilter}
+      disabled={!skipTraceMetricFilter && !traceMetricFilter}
       onChange={handleChange}
       style={{width: '100%'}}
     />

--- a/static/app/views/explore/metrics/metricToolbar/groupBySelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/groupBySelector.tsx
@@ -23,7 +23,10 @@ interface GroupBySelectorProps {
    */
   traceMetric: TraceMetric;
   /**
-   * Whether to skip the trace metric filter. For equations.
+   * Whether to skip the trace metric filter.
+   *
+   * For equations, because at the moment there isn't an easy way to filter
+   * the attributes to the relevant attributes.
    */
   skipTraceMetricFilter?: boolean;
 }

--- a/static/app/views/explore/metrics/metricToolbar/index.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/index.spec.tsx
@@ -36,8 +36,10 @@ function Wrapper({
 }
 
 describe('MetricToolbar', () => {
+  let mockAttributesRequest: jest.Mock;
+
   beforeEach(() => {
-    MockApiClient.addMockResponse({
+    mockAttributesRequest = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/trace-items/attributes/',
       body: [],
     });
@@ -87,6 +89,21 @@ describe('MetricToolbar', () => {
     );
 
     expect(await screen.findByRole('button', {name: /Group by/})).toBeInTheDocument();
+
+    // The query is left undefined for the attributes request because
+    // we currently don't filter the attributes for equations
+    ['string', 'number', 'boolean'].forEach(attributeType => {
+      expect(mockAttributesRequest).toHaveBeenCalledWith(
+        '/organizations/org-slug/trace-items/attributes/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            itemType: 'tracemetrics',
+            attributeType,
+            query: undefined,
+          }),
+        })
+      );
+    });
   });
 
   it('renders group by selector for function visualizations', async () => {

--- a/static/app/views/explore/metrics/metricToolbar/index.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/index.spec.tsx
@@ -1,0 +1,124 @@
+import {type ReactNode} from 'react';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {MetricsQueryParamsProvider} from 'sentry/views/explore/metrics/metricsQueryParams';
+import {MetricToolbar} from 'sentry/views/explore/metrics/metricToolbar';
+import {MultiMetricsQueryParamsProvider} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
+import {Mode} from 'sentry/views/explore/queryParams/mode';
+import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
+import {
+  VisualizeEquation,
+  VisualizeFunction,
+} from 'sentry/views/explore/queryParams/visualize';
+
+function Wrapper({
+  children,
+  queryParams,
+}: {
+  children: ReactNode;
+  queryParams: ReadableQueryParams;
+}) {
+  return (
+    <MultiMetricsQueryParamsProvider>
+      <MetricsQueryParamsProvider
+        traceMetric={{name: 'test_metric', type: 'distribution'}}
+        queryParams={queryParams}
+        setQueryParams={() => {}}
+        removeMetric={() => {}}
+        setTraceMetric={() => {}}
+      >
+        {children}
+      </MetricsQueryParamsProvider>
+    </MultiMetricsQueryParamsProvider>
+  );
+}
+
+describe('MetricToolbar', () => {
+  beforeEach(() => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/trace-items/attributes/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/recent-searches/',
+      body: [],
+    });
+  });
+
+  it('renders group by selector for equation visualizations', async () => {
+    const organization = OrganizationFixture({
+      features: [
+        'tracemetrics-enabled',
+        'tracemetrics-ui-refresh',
+        'tracemetrics-equations-in-explore',
+      ],
+    });
+
+    const queryParams = new ReadableQueryParams({
+      extrapolate: true,
+      mode: Mode.AGGREGATE,
+      query: '',
+      cursor: '',
+      fields: ['id', 'timestamp'],
+      sortBys: [{field: 'timestamp', kind: 'desc'}],
+      aggregateCursor: '',
+      aggregateFields: [new VisualizeEquation('equation|A + B')],
+      aggregateSortBys: [{field: 'equation|A + B', kind: 'desc'}],
+    });
+
+    render(
+      <MetricToolbar
+        traceMetric={{name: 'test_metric', type: 'distribution'}}
+        queryLabel="ƒ1"
+        referenceMap={{A: 'sum(value)', B: 'avg(value)'}}
+      />,
+      {
+        organization,
+        additionalWrapper: ({children}: {children: ReactNode}) => (
+          <Wrapper queryParams={queryParams}>{children}</Wrapper>
+        ),
+      }
+    );
+
+    expect(await screen.findByRole('button', {name: /Group by/})).toBeInTheDocument();
+  });
+
+  it('renders group by selector for function visualizations', async () => {
+    const organization = OrganizationFixture({
+      features: ['tracemetrics-enabled', 'tracemetrics-ui-refresh'],
+    });
+
+    const queryParams = new ReadableQueryParams({
+      extrapolate: true,
+      mode: Mode.SAMPLES,
+      query: '',
+      cursor: '',
+      fields: ['id', 'timestamp'],
+      sortBys: [{field: 'timestamp', kind: 'desc'}],
+      aggregateCursor: '',
+      aggregateFields: [new VisualizeFunction('sum(value,test_metric,distribution,-)')],
+      aggregateSortBys: [{field: 'sum(value,test_metric,distribution,-)', kind: 'desc'}],
+    });
+
+    render(
+      <MetricToolbar
+        traceMetric={{name: 'test_metric', type: 'distribution'}}
+        queryLabel="A"
+      />,
+      {
+        organization,
+        additionalWrapper: ({children}: {children: ReactNode}) => (
+          <Wrapper queryParams={queryParams}>{children}</Wrapper>
+        ),
+      }
+    );
+
+    expect(await screen.findByRole('button', {name: /Group by/})).toBeInTheDocument();
+  });
+});

--- a/static/app/views/explore/metrics/metricToolbar/index.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/index.tsx
@@ -129,12 +129,19 @@ export function MetricToolbar({
               )}
             </Fragment>
           ) : isVisualizeEquation(visualize) ? (
-            <EquationBuilder
-              expression={visualize.expression.text}
-              referenceMap={referenceMap}
-              handleExpressionChange={handleExpressionChange}
-              onReferenceLabelsChange={handleReferenceLabelsChange}
-            />
+            <Flex minWidth={0} gap="md">
+              <Flex flex="4 1 0" minWidth={0}>
+                <EquationBuilder
+                  expression={visualize.expression.text}
+                  referenceMap={referenceMap}
+                  handleExpressionChange={handleExpressionChange}
+                  onReferenceLabelsChange={handleReferenceLabelsChange}
+                />
+              </Flex>
+              <Flex flex="1 1 0" minWidth={0}>
+                <GroupBySelector traceMetric={traceMetric} skipTraceMetricFilter />
+              </Flex>
+            </Flex>
           ) : null}
           {canRemoveMetric && <DeleteMetricButton disabled={isReferencedByEquation} />}
         </Grid>


### PR DESCRIPTION
Adds a group by selector to equations. At the moment, we weren't able to get the attributes for all of the metrics in the equations easily, so we'll start with showing them all.

I didn't pay too much attention to styling the toolbar just yet, I still need to add filtering so I expected to do some touch ups after that.

<img width="1420" height="431" alt="Screenshot 2026-04-15 at 12 36 23 AM" src="https://github.com/user-attachments/assets/65c29d1c-eae6-4867-9add-ba6db94db670" />
