### PR TITLE
Enforce basic sanitization in email tempaltes for org display names

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -170,6 +170,13 @@ class BaseOrganizationSerializer(serializers.Serializer):
         max_length=DEFAULT_SLUG_MAX_LENGTH,
     )
 
+    def validate_name(self, value: str) -> str:
+        if "://" in value:
+            raise serializers.ValidationError(
+                "Organization name cannot contain URL schemes (e.g. http:// or https://)."
+            )
+        return value
+
     def validate_slug(self, value: str) -> str:
         # Historically, the only check just made sure there was more than 1
         # character for the slug, but since then, there are many slugs that

--- a/src/sentry/models/organizationmember.py
+++ b/src/sentry/models/organizationmember.py
@@ -348,6 +348,7 @@ class OrganizationMember(ReplicatedCellModel):
 
     def send_invite_email(self, referrer: str | None = None):
         from sentry.utils.email import MessageBuilder
+        from sentry.utils.email.sanitize import sanitize_outbound_name
 
         context = {
             "email": self.email,
@@ -356,7 +357,7 @@ class OrganizationMember(ReplicatedCellModel):
         }
 
         msg = MessageBuilder(
-            subject="Join %s in using Sentry" % self.organization.name,
+            subject="Join %s in using Sentry" % sanitize_outbound_name(self.organization.name),
             template="sentry/emails/member-invite.txt",
             html_template="sentry/emails/member-invite.html",
             type="organization.invite",
@@ -371,6 +372,7 @@ class OrganizationMember(ReplicatedCellModel):
 
     def send_sso_link_email(self, sending_user_email: str, provider):
         from sentry.utils.email import MessageBuilder
+        from sentry.utils.email.sanitize import sanitize_outbound_name
 
         link_args = {"organization_slug": self.organization.slug}
         context = {
@@ -381,7 +383,7 @@ class OrganizationMember(ReplicatedCellModel):
         }
 
         msg = MessageBuilder(
-            subject=f"Action Required for {self.organization.name}",
+            subject=f"Action Required for {sanitize_outbound_name(self.organization.name)}",
             template="sentry/emails/auth-link-identity.txt",
             html_template="sentry/emails/auth-link-identity.html",
             type="organization.auth_link",
@@ -392,6 +394,7 @@ class OrganizationMember(ReplicatedCellModel):
     def send_sso_unlink_email(self, disabling_user: RpcUser | str, provider):
         from sentry.users.services.lost_password_hash import lost_password_hash_service
         from sentry.utils.email import MessageBuilder
+        from sentry.utils.email.sanitize import sanitize_outbound_name
 
         # Nothing to send if this member isn't associated to a user
         if not self.user_id:
@@ -424,7 +427,7 @@ class OrganizationMember(ReplicatedCellModel):
             context["set_password_url"] = password_hash.get_absolute_url(mode="set_password")
 
         msg = MessageBuilder(
-            subject=f"Action Required for {self.organization.name}",
+            subject=f"Action Required for {sanitize_outbound_name(self.organization.name)}",
             template="sentry/emails/auth-sso-disabled.txt",
             html_template="sentry/emails/auth-sso-disabled.html",
             type="organization.auth_sso_disabled",

--- a/src/sentry/notifications/notifications/organization_request/abstract_invite_request.py
+++ b/src/sentry/notifications/notifications/organization_request/abstract_invite_request.py
@@ -16,6 +16,7 @@ from sentry.notifications.notifications.strategies.member_write_role_recipient_s
 from sentry.notifications.utils.actions import MessageAction
 from sentry.types.actor import Actor
 from sentry.users.services.user.service import user_service
+from sentry.utils.email.sanitize import sanitize_outbound_name
 
 if TYPE_CHECKING:
     from sentry.users.models.user import User
@@ -40,7 +41,7 @@ class AbstractInviteRequestNotification(OrganizationRequestNotification, abc.ABC
         )
 
     def get_subject(self, context: Mapping[str, Any] | None = None) -> str:
-        return f"Access request to {self.organization.name}"
+        return f"Access request to {sanitize_outbound_name(self.organization.name)}"
 
     def get_recipient_context(
         self, recipient: Actor, extra_context: Mapping[str, Any]

--- a/src/sentry/notifications/notifications/organization_request/integration_request.py
+++ b/src/sentry/notifications/notifications/organization_request/integration_request.py
@@ -83,7 +83,7 @@ class IntegrationRequestNotification(OrganizationRequestNotification):
         return "Request to Install"
 
     def get_message_description(self, recipient: Actor, provider: ExternalProviders) -> str:
-        requester_name = self.requester.get_display_name()
+        requester_name = sanitize_outbound_name(self.requester.get_display_name())
         optional_message = (
             f" They've included this message `{self.message}`" if self.message else ""
         )

--- a/src/sentry/notifications/notifications/organization_request/integration_request.py
+++ b/src/sentry/notifications/notifications/organization_request/integration_request.py
@@ -72,7 +72,7 @@ class IntegrationRequestNotification(OrganizationRequestNotification):
         }
 
     def get_subject(self, context: Mapping[str, Any] | None = None) -> str:
-        return f"Your team member requested the {self.provider_name} integration on Sentry"
+        return f"Your team member requested the {sanitize_outbound_name(self.provider_name)} integration on Sentry"
 
     def get_notification_title(
         self, provider: ExternalProviders, context: Mapping[str, Any] | None = None
@@ -89,7 +89,7 @@ class IntegrationRequestNotification(OrganizationRequestNotification):
             if self.message
             else ""
         )
-        return f"{requester_name} is requesting to install the {self.provider_name} integration into {sanitize_outbound_name(self.organization.name)}.{optional_message}"
+        return f"{requester_name} is requesting to install the {sanitize_outbound_name(self.provider_name)} integration into {sanitize_outbound_name(self.organization.name)}.{optional_message}"
 
     def get_message_actions(
         self, recipient: Actor, provider: ExternalProviders

--- a/src/sentry/notifications/notifications/organization_request/integration_request.py
+++ b/src/sentry/notifications/notifications/organization_request/integration_request.py
@@ -85,7 +85,9 @@ class IntegrationRequestNotification(OrganizationRequestNotification):
     def get_message_description(self, recipient: Actor, provider: ExternalProviders) -> str:
         requester_name = sanitize_outbound_name(self.requester.get_display_name())
         optional_message = (
-            f" They've included this message `{self.message}`" if self.message else ""
+            f" They've included this message `{sanitize_outbound_name(self.message)}`"
+            if self.message
+            else ""
         )
         return f"{requester_name} is requesting to install the {self.provider_name} integration into {sanitize_outbound_name(self.organization.name)}.{optional_message}"
 

--- a/src/sentry/notifications/notifications/organization_request/integration_request.py
+++ b/src/sentry/notifications/notifications/organization_request/integration_request.py
@@ -11,6 +11,7 @@ from sentry.notifications.notifications.strategies.owner_recipient_strategy impo
 )
 from sentry.notifications.utils.actions import MessageAction
 from sentry.types.actor import Actor
+from sentry.utils.email.sanitize import sanitize_outbound_name
 
 if TYPE_CHECKING:
     from sentry.models.organization import Organization
@@ -86,7 +87,7 @@ class IntegrationRequestNotification(OrganizationRequestNotification):
         optional_message = (
             f" They've included this message `{self.message}`" if self.message else ""
         )
-        return f"{requester_name} is requesting to install the {self.provider_name} integration into {self.organization.name}.{optional_message}"
+        return f"{requester_name} is requesting to install the {self.provider_name} integration into {sanitize_outbound_name(self.organization.name)}.{optional_message}"
 
     def get_message_actions(
         self, recipient: Actor, provider: ExternalProviders

--- a/src/sentry/notifications/notifications/organization_request/invite_request.py
+++ b/src/sentry/notifications/notifications/organization_request/invite_request.py
@@ -32,5 +32,5 @@ class InviteRequestNotification(AbstractInviteRequestNotification):
         return "Request to Invite"
 
     def get_message_description(self, recipient: Actor, provider: ExternalProviders) -> str:
-        requester_name = self.requester.get_display_name()
+        requester_name = sanitize_outbound_name(self.requester.get_display_name())
         return f"{requester_name} is requesting to invite {self.pending_member.email} into {sanitize_outbound_name(self.organization.name)}"

--- a/src/sentry/notifications/notifications/organization_request/invite_request.py
+++ b/src/sentry/notifications/notifications/organization_request/invite_request.py
@@ -5,6 +5,7 @@ from sentry.analytics.events.inapp_request import InviteRequestSentEvent
 from sentry.integrations.types import ExternalProviders
 from sentry.notifications.class_manager import register
 from sentry.types.actor import Actor
+from sentry.utils.email.sanitize import sanitize_outbound_name
 
 from .abstract_invite_request import AbstractInviteRequestNotification
 
@@ -32,4 +33,4 @@ class InviteRequestNotification(AbstractInviteRequestNotification):
 
     def get_message_description(self, recipient: Actor, provider: ExternalProviders) -> str:
         requester_name = self.requester.get_display_name()
-        return f"{requester_name} is requesting to invite {self.pending_member.email} into {self.organization.name}"
+        return f"{requester_name} is requesting to invite {self.pending_member.email} into {sanitize_outbound_name(self.organization.name)}"

--- a/src/sentry/notifications/notifications/organization_request/join_request.py
+++ b/src/sentry/notifications/notifications/organization_request/join_request.py
@@ -5,6 +5,7 @@ from sentry.analytics.events.inapp_request import JoinRequestSentEvent
 from sentry.integrations.types import ExternalProviders
 from sentry.notifications.class_manager import register
 from sentry.types.actor import Actor
+from sentry.utils.email.sanitize import sanitize_outbound_name
 
 from .abstract_invite_request import AbstractInviteRequestNotification
 
@@ -31,4 +32,4 @@ class JoinRequestNotification(AbstractInviteRequestNotification):
         return "Request to Join"
 
     def get_message_description(self, recipient: Actor, provider: ExternalProviders) -> str:
-        return f"{self.pending_member.email} is requesting to join {self.organization.name}"
+        return f"{self.pending_member.email} is requesting to join {sanitize_outbound_name(self.organization.name)}"

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -44,6 +44,7 @@ from sentry.users.services.user_option.service import get_option_from_list
 from sentry.utils import json, redis
 from sentry.utils.dates import floor_to_utc_day, to_datetime
 from sentry.utils.email import MessageBuilder
+from sentry.utils.email.sanitize import sanitize_outbound_name
 from sentry.utils.query import RangeQuerySetWrapper
 
 date_format = partial(dateformat.format, format_string="F jS, Y")
@@ -295,7 +296,7 @@ class OrganizationReportBatch:
         local_start, local_end = get_local_dates(self.ctx, user_id)
 
         message = MessageBuilder(
-            subject=f"Weekly Report for {self.ctx.organization.name}: {date_format(local_start)} - {date_format(local_end)}",
+            subject=f"Weekly Report for {sanitize_outbound_name(self.ctx.organization.name)}: {date_format(local_start)} - {date_format(local_end)}",
             template="sentry/emails/reports/body.txt",
             html_template="sentry/emails/reports/body.html",
             type="report.organization",

--- a/src/sentry/templates/sentry/emails/auth-link-identity.txt
+++ b/src/sentry/templates/sentry/emails/auth-link-identity.txt
@@ -1,4 +1,4 @@
-{{ provider.name }} Single Sign-On has been configured for the {{ organization.name }} organization.
+{% load sentry_helpers %}{{ provider.name }} Single Sign-On has been configured for the {{ organization.name|sanitize_periods }} organization.
 
 Link your Sentry account to enable signing on with your {{ provider.name }} account by visiting the following url:
 

--- a/src/sentry/templates/sentry/emails/auth-sso-disabled.txt
+++ b/src/sentry/templates/sentry/emails/auth-sso-disabled.txt
@@ -1,4 +1,4 @@
-{{ provider.name }} Single Sign-On has been disabled for the {{ organization.name }} organization.
+{% load sentry_helpers %}{{ provider.name }} Single Sign-On has been disabled for the {{ organization.name|sanitize_periods }} organization.
 
 {% if has_password %}
 You can now login using your email {{ email }}, and password. If you forgot your password you can always reset it by visiting the following url:

--- a/src/sentry/templates/sentry/emails/member-invite.html
+++ b/src/sentry/templates/sentry/emails/member-invite.html
@@ -5,7 +5,7 @@
 
 {% block main %}
     <p>Hey there,</p>
-    <p>Your teammates at <strong>{{ organization.name }}</strong> are using Sentry to catch errors, improve latency issues, and keep their (and maybe your) code from catching fire. 🔥</p>
+    <p>Your teammates at <strong>{{ organization.name|sanitize_periods }}</strong> are using Sentry to catch errors, improve latency issues, and keep their (and maybe your) code from catching fire. 🔥</p>
 
     <p>Looks like they need your help. You've been invited to join them:</p>
 

--- a/src/sentry/templates/sentry/emails/member-invite.txt
+++ b/src/sentry/templates/sentry/emails/member-invite.txt
@@ -1,6 +1,6 @@
-Hey there,
+{% load sentry_helpers %}Hey there,
 
-Your teammates at {{ organization.name }} are using Sentry to catch errors, crush latency issues, and keep their (and maybe your) code from catching fire.
+Your teammates at {{ organization.name|sanitize_periods }} are using Sentry to catch errors, crush latency issues, and keep their (and maybe your) code from catching fire.
 
 Looks like they need your help. You've been invited to join them:
 

--- a/src/sentry/templates/sentry/emails/onboarding-continuation.html
+++ b/src/sentry/templates/sentry/emails/onboarding-continuation.html
@@ -11,7 +11,7 @@
   Before you get started fixing all your broken and slow code, we need a few more details
   about your {{ platforms }} project{{num_platforms|pluralize}}. Click the button below
   when you're back at your computer to complete the set up for
-  <strong>{{ organization_name }}</strong>.
+  <strong>{{ organization_name|sanitize_periods }}</strong>.
 </p>
 
 <p>

--- a/src/sentry/templates/sentry/emails/onboarding-continuation.txt
+++ b/src/sentry/templates/sentry/emails/onboarding-continuation.txt
@@ -1,9 +1,9 @@
-Finish Onboarding
+{% load sentry_helpers %}Finish Onboarding
 
 Hey {{ recipient_name }}
 
 Before you get started fixing all your broken and slow code, we need a few more details
 about your {{ platforms }} project{{num_platforms|pluralize}}. Click the button below when you're back at
-your computer to complete the set up for {{ organization_name }}.
+your computer to complete the set up for {{ organization_name|sanitize_periods }}.
 
 {{ onboarding_link }}

--- a/src/sentry/templates/sentry/emails/org-auth-token-created.txt
+++ b/src/sentry/templates/sentry/emails/org-auth-token-created.txt
@@ -3,7 +3,7 @@
 {% autoescape off %}
 Security Notice
 ---------------
-User {{ actor.email }} has created a new Organization Auth Token "{{ token_name }}" for your Sentry organization {{ organization.name }}.
+User {{ actor.email }} has created a new Organization Auth Token "{{ token_name }}" for your Sentry organization {{ organization.name|sanitize_periods }}.
 
 Details
 -------

--- a/src/sentry/templates/sentry/emails/org_delete_confirm.txt
+++ b/src/sentry/templates/sentry/emails/org_delete_confirm.txt
@@ -1,4 +1,4 @@
-The {{ organization.name }} organization has been scheduled for deletion by:
+{% load sentry_helpers %}The {{ organization.name|sanitize_periods }} organization has been scheduled for deletion by:
 
 User: {{ username }}
 IP: {{ user_ip_address }}

--- a/src/sentry/templates/sentry/emails/organization-invite-request.html
+++ b/src/sentry/templates/sentry/emails/organization-invite-request.html
@@ -6,7 +6,7 @@
 {% block main %}
   <h3>Request for Access</h3>
 
-  <p><strong>{{ inviter_name|sanitize_periods }}</strong> has requested to invite <strong>{{ email }}</strong> to the {{ organization_name }} organization.</p>
+  <p><strong>{{ inviter_name|sanitize_periods }}</strong> has requested to invite <strong>{{ email }}</strong> to the {{ organization_name|sanitize_periods }} organization.</p>
 
   <a href="{{ pending_requests_link }}" class="btn">View access requests</a>
 

--- a/src/sentry/templates/sentry/emails/organization-invite-request.txt
+++ b/src/sentry/templates/sentry/emails/organization-invite-request.txt
@@ -1,7 +1,7 @@
 {% load sentry_helpers %}
 Request for Access
 
-{{ inviter_name|sanitize_periods }} has requested to invite {{ email }} to the {{ organization_name }} organization.
+{{ inviter_name|sanitize_periods }} has requested to invite {{ email }} to the {{ organization_name|sanitize_periods }} organization.
 
 View access requests by clicking the link below:
 

--- a/src/sentry/templates/sentry/emails/organization-join-request.html
+++ b/src/sentry/templates/sentry/emails/organization-join-request.html
@@ -1,11 +1,12 @@
 {% extends "sentry/emails/base.html" %}
 
 {% load i18n %}
+{% load sentry_helpers %}
 
 {% block main %}
   <h3>Request for Access</h3>
 
-  <p><strong>{{ email }}</strong> is requesting to join the {{ organization_name }} organization.</p>
+  <p><strong>{{ email }}</strong> is requesting to join the {{ organization_name|sanitize_periods }} organization.</p>
 
   <a href="{{ pending_requests_link }}" class="btn">View access requests</a>
 

--- a/src/sentry/templates/sentry/emails/organization-join-request.txt
+++ b/src/sentry/templates/sentry/emails/organization-join-request.txt
@@ -1,6 +1,6 @@
-Request for Access
+{% load sentry_helpers %}Request for Access
 
-{{ email }} is requesting to join the {{ organization_name }} organization.
+{{ email }} is requesting to join the {{ organization_name|sanitize_periods }} organization.
 
 View access requests by clicking the link below:
 

--- a/src/sentry/templates/sentry/emails/requests/organization-integration.html
+++ b/src/sentry/templates/sentry/emails/requests/organization-integration.html
@@ -6,7 +6,7 @@
 {% block main %}
   <p>
     Seems like your team could use some new tools. {{ requester_name|sanitize_periods }} from
-    {{ organization_name }} requested the installation of {{ integration_name }}.
+    {{ organization_name|sanitize_periods }} requested the installation of {{ integration_name }}.
     {% if message %}
         They've included some additional context:
         <pre>{{ message }}</pre>

--- a/src/sentry/templates/sentry/emails/requests/organization-integration.html
+++ b/src/sentry/templates/sentry/emails/requests/organization-integration.html
@@ -9,7 +9,7 @@
     {{ organization_name|sanitize_periods }} requested the installation of {{ integration_name }}.
     {% if message %}
         They've included some additional context:
-        <pre>{{ message }}</pre>
+        <pre>{{ message|sanitize_periods }}</pre>
     {% endif %}
   </p>
   <p>

--- a/src/sentry/templates/sentry/emails/requests/organization-integration.html
+++ b/src/sentry/templates/sentry/emails/requests/organization-integration.html
@@ -6,14 +6,14 @@
 {% block main %}
   <p>
     Seems like your team could use some new tools. {{ requester_name|sanitize_periods }} from
-    {{ organization_name|sanitize_periods }} requested the installation of {{ integration_name }}.
+    {{ organization_name|sanitize_periods }} requested the installation of {{ integration_name|sanitize_periods }}.
     {% if message %}
         They've included some additional context:
         <pre>{{ message|sanitize_periods }}</pre>
     {% endif %}
   </p>
   <p>
-    <a href="{{ integration_link }}" class="btn">Install {{ integration_name }}</a>
+    <a href="{{ integration_link }}" class="btn">Install {{ integration_name|sanitize_periods }}</a>
   </p>
   <p>
     If you're not up for installation, you can

--- a/src/sentry/templates/sentry/emails/requests/organization-integration.txt
+++ b/src/sentry/templates/sentry/emails/requests/organization-integration.txt
@@ -1,10 +1,10 @@
 {% load sentry_helpers %}
-Seems like your team could use some new tools. {{ requester_name|sanitize_periods }} from {{ organization_name|sanitize_periods }} requested the installation of {{ integration_name }}.
+Seems like your team could use some new tools. {{ requester_name|sanitize_periods }} from {{ organization_name|sanitize_periods }} requested the installation of {{ integration_name|sanitize_periods }}.
 {% if message %}
 They’ve included some additional context:
     {{ message|sanitize_periods }}
 {% endif %}
-Install {{ provider_name }} by clicking the link below:
+Install {{ provider_name|sanitize_periods }} by clicking the link below:
 
     {{ provider_link }}
 

--- a/src/sentry/templates/sentry/emails/requests/organization-integration.txt
+++ b/src/sentry/templates/sentry/emails/requests/organization-integration.txt
@@ -2,7 +2,7 @@
 Seems like your team could use some new tools. {{ requester_name|sanitize_periods }} from {{ organization_name|sanitize_periods }} requested the installation of {{ integration_name }}.
 {% if message %}
 They’ve included some additional context:
-    {{ message }}
+    {{ message|sanitize_periods }}
 {% endif %}
 Install {{ provider_name }} by clicking the link below:
 

--- a/src/sentry/templates/sentry/emails/requests/organization-integration.txt
+++ b/src/sentry/templates/sentry/emails/requests/organization-integration.txt
@@ -1,5 +1,5 @@
 {% load sentry_helpers %}
-Seems like your team could use some new tools. {{ requester_name|sanitize_periods }} from {{ organization_name }} requested the installation of {{ integration_name }}.
+Seems like your team could use some new tools. {{ requester_name|sanitize_periods }} from {{ organization_name|sanitize_periods }} requested the installation of {{ integration_name }}.
 {% if message %}
 They’ve included some additional context:
     {{ message }}

--- a/src/sentry/templates/sentry/emails/setup_2fa.txt
+++ b/src/sentry/templates/sentry/emails/setup_2fa.txt
@@ -1,6 +1,6 @@
-Setup Two-Factor Authentication
+{% load sentry_helpers %}Setup Two-Factor Authentication
 
-The {{ organization.name|title }} organization now requires all members to enable
+The {{ organization.name|sanitize_periods|title }} organization now requires all members to enable
 two-factor authentication. Effective immediately, you will be unable to access
 this organization or receive its notifications until you enable at least
 one form of 2FA.

--- a/src/sentry/templates/sentry/emails/slack-migration.txt
+++ b/src/sentry/templates/sentry/emails/slack-migration.txt
@@ -1,7 +1,7 @@
-Slack Upgrade
+{% load sentry_helpers %}Slack Upgrade
 --------------
 
-Your Sentry Slack Integration for workspace {{integration.name}} has been updated on behalf of organization {{organization.name}}. For more information, check out the documentation: {{ doc_link }}.
+Your Sentry Slack Integration for workspace {{integration.name}} has been updated on behalf of organization {{organization.name|sanitize_periods}}. For more information, check out the documentation: {{ doc_link }}.
 
 {% if good_channels %}
     Sentry was able to send messages to the following private channels with instructions on how to add Sentry to the channel:

--- a/src/sentry/templatetags/sentry_helpers.py
+++ b/src/sentry/templatetags/sentry_helpers.py
@@ -314,8 +314,6 @@ def sanitize_periods(value):
     Primarily used in email templates when a field may contain a domain name to prevent
     email clients from creating a clickable link to the domain.
     """
-    word_joiner = "\u2060"
+    from sentry.utils.email.sanitize import sanitize_outbound_name
 
-    # Adding the Unicode character before every period
-    output_string = value.replace(".", word_joiner + ".")
-    return output_string
+    return sanitize_outbound_name(value)

--- a/src/sentry/utils/email/sanitize.py
+++ b/src/sentry/utils/email/sanitize.py
@@ -1,0 +1,14 @@
+WORD_JOINER = "\u2060"
+
+_CONTROL_CHAR_TABLE = str.maketrans(
+    "", "", "".join(chr(c) for c in [*range(0x00, 0x09), 0x0B, 0x0C, *range(0x0E, 0x20), 0x7F])
+)
+
+
+def sanitize_outbound_name(value: str) -> str:
+    """Prevent mail-client auto-linking of user-controlled display names
+    by breaking periods, URL schemes, and stripping control characters."""
+    value = value.translate(_CONTROL_CHAR_TABLE)
+    value = value.replace("://", ":" + WORD_JOINER + "//")
+    value = value.replace(".", WORD_JOINER + ".")
+    return value

--- a/tests/sentry/core/endpoints/test_organization_index.py
+++ b/tests/sentry/core/endpoints/test_organization_index.py
@@ -265,6 +265,18 @@ class OrganizationsCreateTest(OrganizationIndexTest, HybridCloudTestMixin):
             self.get_error_response(name="name", slug="1234", status_code=400)
             self.get_error_response(name="name", slug="I-contain-UPPERCASE", status_code=400)
 
+    def test_name_with_url_scheme_rejected(self) -> None:
+        with self.options({"api.rate-limit.org-create": 9001}):
+            self.get_error_response(
+                name="https://evil.com Click Here", slug="legit-slug", status_code=400
+            )
+            self.get_error_response(name="http://evil.com", slug="legit-slug-2", status_code=400)
+
+    def test_name_with_periods_allowed(self) -> None:
+        response = self.get_success_response(name="Acme Inc.", slug="acme-inc")
+        org = Organization.objects.get(id=response.data["id"])
+        assert org.name == "Acme Inc."
+
     def test_without_slug(self) -> None:
         response = self.get_success_response(name="hello world")
 

--- a/tests/sentry/models/test_organizationmember.py
+++ b/tests/sentry/models/test_organizationmember.py
@@ -103,6 +103,16 @@ class OrganizationMemberTest(TestCase, HybridCloudTestMixin):
         assert len(mail.outbox) == 1
         assert self.organization.absolute_url("/accept/") in mail.outbox[0].body
 
+    def test_send_invite_email_sanitizes_org_name(self) -> None:
+        org = self.create_organization(name="https://evil.com org")
+        member = OrganizationMember(id=1, organization=org, email="user@example.com")
+        with self.options({"system.url-prefix": "http://example.com"}), self.tasks():
+            member.send_invite_email()
+
+        assert len(mail.outbox) == 1
+        msg = mail.outbox[0]
+        assert "://" not in msg.subject
+
     def test_send_sso_link_email(self) -> None:
         organization = self.create_organization()
         member = OrganizationMember(id=1, organization=organization, email="foo@example.com")

--- a/tests/sentry/templatetags/test_sentry_helpers.py
+++ b/tests/sentry/templatetags/test_sentry_helpers.py
@@ -170,3 +170,10 @@ def test_sanitize_periods() -> None:
     input = '{% load sentry_helpers %} {{ "example.com"|sanitize_periods}}'
     result = engines["django"].from_string(input).render().strip()
     assert result == "example\u2060.com"
+
+
+def test_sanitize_periods_breaks_url_scheme() -> None:
+    input = '{% load sentry_helpers %} {{ "https://evil.com"|sanitize_periods}}'
+    result = engines["django"].from_string(input).render().strip()
+    assert "://" not in result
+    assert "\u2060." in result

--- a/tests/sentry/utils/email/test_sanitize.py
+++ b/tests/sentry/utils/email/test_sanitize.py
@@ -1,0 +1,52 @@
+from sentry.utils.email.sanitize import WORD_JOINER, sanitize_outbound_name
+
+
+class TestSanitizeOutboundName:
+    def test_plain_name_unchanged(self):
+        assert sanitize_outbound_name("My Company") == "My Company"
+
+    def test_periods_get_word_joiner(self):
+        result = sanitize_outbound_name("evil.com")
+        assert result == f"evil{WORD_JOINER}.com"
+
+    def test_multiple_periods(self):
+        result = sanitize_outbound_name("sub.evil.com")
+        assert result == f"sub{WORD_JOINER}.evil{WORD_JOINER}.com"
+
+    def test_url_scheme_broken(self):
+        result = sanitize_outbound_name("https://evil.com")
+        assert "://" not in result
+        assert f":{WORD_JOINER}//" in result
+
+    def test_url_scheme_and_periods(self):
+        result = sanitize_outbound_name("https://evil.com/path")
+        assert "://" not in result
+        assert f"{WORD_JOINER}." in result
+
+    def test_control_chars_stripped(self):
+        result = sanitize_outbound_name("evil\x00name\x07here")
+        assert "\x00" not in result
+        assert "\x07" not in result
+        assert "evilnamehere" in result
+
+    def test_newlines_preserved(self):
+        """Regular newlines and tabs are NOT stripped (only true control chars)."""
+        result = sanitize_outbound_name("line1\nline2\ttab")
+        assert "\n" in result
+        assert "\t" in result
+
+    def test_empty_string(self):
+        assert sanitize_outbound_name("") == ""
+
+    def test_emoji_preserved(self):
+        result = sanitize_outbound_name("My Org 🚀")
+        assert "🚀" in result
+
+    def test_unicode_name_preserved(self):
+        result = sanitize_outbound_name("Ünïcödé Org")
+        assert result == "Ünïcödé Org"
+
+    def test_scam_style_payload(self):
+        name = "Free Offer: 2g.tel/promo 👈Click Here."
+        result = sanitize_outbound_name(name)
+        assert "." not in result.replace(WORD_JOINER + ".", "")

--- a/tests/sentry/utils/email/test_sanitize.py
+++ b/tests/sentry/utils/email/test_sanitize.py
@@ -2,51 +2,51 @@ from sentry.utils.email.sanitize import WORD_JOINER, sanitize_outbound_name
 
 
 class TestSanitizeOutboundName:
-    def test_plain_name_unchanged(self):
+    def test_plain_name_unchanged(self) -> None:
         assert sanitize_outbound_name("My Company") == "My Company"
 
-    def test_periods_get_word_joiner(self):
+    def test_periods_get_word_joiner(self) -> None:
         result = sanitize_outbound_name("evil.com")
         assert result == f"evil{WORD_JOINER}.com"
 
-    def test_multiple_periods(self):
+    def test_multiple_periods(self) -> None:
         result = sanitize_outbound_name("sub.evil.com")
         assert result == f"sub{WORD_JOINER}.evil{WORD_JOINER}.com"
 
-    def test_url_scheme_broken(self):
+    def test_url_scheme_broken(self) -> None:
         result = sanitize_outbound_name("https://evil.com")
         assert "://" not in result
         assert f":{WORD_JOINER}//" in result
 
-    def test_url_scheme_and_periods(self):
+    def test_url_scheme_and_periods(self) -> None:
         result = sanitize_outbound_name("https://evil.com/path")
         assert "://" not in result
         assert f"{WORD_JOINER}." in result
 
-    def test_control_chars_stripped(self):
+    def test_control_chars_stripped(self) -> None:
         result = sanitize_outbound_name("evil\x00name\x07here")
         assert "\x00" not in result
         assert "\x07" not in result
         assert "evilnamehere" in result
 
-    def test_newlines_preserved(self):
+    def test_newlines_preserved(self) -> None:
         """Regular newlines and tabs are NOT stripped (only true control chars)."""
         result = sanitize_outbound_name("line1\nline2\ttab")
         assert "\n" in result
         assert "\t" in result
 
-    def test_empty_string(self):
+    def test_empty_string(self) -> None:
         assert sanitize_outbound_name("") == ""
 
-    def test_emoji_preserved(self):
+    def test_emoji_preserved(self) -> None:
         result = sanitize_outbound_name("My Org 🚀")
         assert "🚀" in result
 
-    def test_unicode_name_preserved(self):
+    def test_unicode_name_preserved(self) -> None:
         result = sanitize_outbound_name("Ünïcödé Org")
         assert result == "Ünïcödé Org"
 
-    def test_scam_style_payload(self):
+    def test_scam_style_payload(self) -> None:
         name = "Free Offer: 2g.tel/promo 👈Click Here."
         result = sanitize_outbound_name(name)
         assert "." not in result.replace(WORD_JOINER + ".", "")


### PR DESCRIPTION
Will prevent URLs added to org display names from being rendered in our email templates