### PR TITLE
feat(night-shift): Trigger autofix for fixable candidates and add dry run mode

### DIFF
--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -62,12 +62,14 @@ auto_run_source_map = {
     SeerAutomationSource.ISSUE_DETAILS: "issue_summary_fixability",
     SeerAutomationSource.ALERT: "issue_summary_on_alert_fixability",
     SeerAutomationSource.POST_PROCESS: "issue_summary_on_post_process_fixability",
+    SeerAutomationSource.NIGHT_SHIFT: "night_shift",
 }
 
 referrer_map = {
     SeerAutomationSource.ISSUE_DETAILS: AutofixReferrer.ISSUE_SUMMARY_FIXABILITY,
     SeerAutomationSource.ALERT: AutofixReferrer.ISSUE_SUMMARY_ALERT_FIXABILITY,
     SeerAutomationSource.POST_PROCESS: AutofixReferrer.ISSUE_SUMMARY_POST_PROCESS_FIXABILITY,
+    SeerAutomationSource.NIGHT_SHIFT: AutofixReferrer.NIGHT_SHIFT,
 }
 
 STOPPING_POINT_HIERARCHY = {

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -512,17 +512,6 @@ def get_automation_stopping_point(group: Group) -> AutofixStoppingPoint:
     return _apply_user_preference_upper_bound(fixability_stopping_point, user_preference)
 
 
-def get_user_stopping_point(group: Group) -> AutofixStoppingPoint | None:
-    """
-    Get the user's configured stopping point without a fixability assessment.
-    Returns None if the user has no preference configured.
-    """
-    user_preference = _get_user_stopping_point_preference(group)
-    if user_preference is not None:
-        return AutofixStoppingPoint(user_preference)
-    return None
-
-
 def _get_user_stopping_point_preference(group: Group) -> str | None:
     if features.has("organizations:seer-project-settings-read-from-sentry", group.organization):
         preference = read_preference_from_sentry_db(group.project)

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -507,13 +507,27 @@ def get_automation_stopping_point(group: Group) -> AutofixStoppingPoint:
     fixability_score = get_and_update_group_fixability_score(group)
     fixability_stopping_point = _get_stopping_point_from_fixability(fixability_score)
 
-    if features.has("organizations:seer-project-settings-read-from-sentry", group.organization):
-        preference = read_preference_from_sentry_db(group.project)
-        user_preference = preference.automated_run_stopping_point if preference else None
-    else:
-        user_preference = _fetch_user_preference(group.project.id)
+    user_preference = _get_user_stopping_point_preference(group)
 
     return _apply_user_preference_upper_bound(fixability_stopping_point, user_preference)
+
+
+def get_user_stopping_point(group: Group) -> AutofixStoppingPoint | None:
+    """
+    Get the user's configured stopping point without a fixability assessment.
+    Returns None if the user has no preference configured.
+    """
+    user_preference = _get_user_stopping_point_preference(group)
+    if user_preference is not None:
+        return AutofixStoppingPoint(user_preference)
+    return None
+
+
+def _get_user_stopping_point_preference(group: Group) -> str | None:
+    if features.has("organizations:seer-project-settings-read-from-sentry", group.organization):
+        preference = read_preference_from_sentry_db(group.project)
+        return preference.automated_run_stopping_point if preference else None
+    return _fetch_user_preference(group.project.id)
 
 
 def _generate_summary(

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -507,16 +507,13 @@ def get_automation_stopping_point(group: Group) -> AutofixStoppingPoint:
     fixability_score = get_and_update_group_fixability_score(group)
     fixability_stopping_point = _get_stopping_point_from_fixability(fixability_score)
 
-    user_preference = _get_user_stopping_point_preference(group)
-
-    return _apply_user_preference_upper_bound(fixability_stopping_point, user_preference)
-
-
-def _get_user_stopping_point_preference(group: Group) -> str | None:
     if features.has("organizations:seer-project-settings-read-from-sentry", group.organization):
         preference = read_preference_from_sentry_db(group.project)
-        return preference.automated_run_stopping_point if preference else None
-    return _fetch_user_preference(group.project.id)
+        user_preference = preference.automated_run_stopping_point if preference else None
+    else:
+        user_preference = _fetch_user_preference(group.project.id)
+
+    return _apply_user_preference_upper_bound(fixability_stopping_point, user_preference)
 
 
 def _generate_summary(

--- a/src/sentry/seer/endpoints/admin_night_shift_trigger.py
+++ b/src/sentry/seer/endpoints/admin_night_shift_trigger.py
@@ -26,11 +26,14 @@ class SeerAdminNightShiftTriggerEndpoint(Endpoint):
         except (ValueError, TypeError):
             return Response({"detail": "organization_id must be a valid integer"}, status=400)
 
-        run_night_shift_for_org.apply_async(args=[organization_id])
+        dry_run = bool(request.data.get("dry_run", False))
+
+        run_night_shift_for_org.apply_async(args=[organization_id], kwargs={"dry_run": dry_run})
 
         return Response(
             {
                 "success": True,
                 "organization_id": organization_id,
+                "dry_run": dry_run,
             }
         )

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -14,7 +14,7 @@ from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.project import Project
 from sentry.seer.autofix.constants import AutofixAutomationTuningSettings, AutofixReferrer
 from sentry.seer.autofix.issue_summary import _trigger_autofix_task
-from sentry.seer.autofix.utils import bulk_read_preferences, get_autofix_state
+from sentry.seer.autofix.utils import bulk_read_preferences
 from sentry.seer.models.night_shift import SeerNightShiftRun, SeerNightShiftRunIssue
 from sentry.seer.models.seer_api_models import SeerProjectPreference
 from sentry.tasks.base import instrumented_task
@@ -216,9 +216,6 @@ def _trigger_autofix_for_candidate(
     Returns True if the autofix task was dispatched.
     """
     try:
-        if get_autofix_state(group_id=group.id, organization_id=organization.id):
-            return False
-
         event = group.get_latest_event()
         if not event:
             logger.warning(

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -12,8 +12,15 @@ from sentry.constants import ObjectStatus
 from sentry.models.group import Group
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.project import Project
-from sentry.seer.autofix.constants import AutofixAutomationTuningSettings, AutofixReferrer
-from sentry.seer.autofix.issue_summary import _trigger_autofix_task
+from sentry.seer.autofix.constants import (
+    AutofixAutomationTuningSettings,
+    SeerAutomationSource,
+)
+from sentry.seer.autofix.issue_summary import (
+    _trigger_autofix_task,
+    auto_run_source_map,
+    referrer_map,
+)
 from sentry.seer.autofix.utils import bulk_read_preferences
 from sentry.seer.models.night_shift import SeerNightShiftRun, SeerNightShiftRunIssue
 from sentry.seer.models.seer_api_models import SeerProjectPreference
@@ -228,8 +235,8 @@ def _trigger_autofix_for_candidate(
             group_id=group.id,
             event_id=event.event_id,
             user_id=None,
-            auto_run_source="night_shift",
-            referrer=AutofixReferrer.NIGHT_SHIFT,
+            auto_run_source=auto_run_source_map[SeerAutomationSource.NIGHT_SHIFT],
+            referrer=referrer_map[SeerAutomationSource.NIGHT_SHIFT],
             stopping_point=stopping_point,
         )
         return True

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -13,9 +13,10 @@ from sentry.models.group import Group
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.project import Project
 from sentry.seer.autofix.constants import AutofixAutomationTuningSettings, AutofixReferrer
-from sentry.seer.autofix.issue_summary import _trigger_autofix_task, get_user_stopping_point
+from sentry.seer.autofix.issue_summary import _trigger_autofix_task
 from sentry.seer.autofix.utils import bulk_read_preferences, get_autofix_state
 from sentry.seer.models.night_shift import SeerNightShiftRun, SeerNightShiftRunIssue
+from sentry.seer.models.seer_api_models import SeerProjectPreference
 from sentry.tasks.base import instrumented_task
 from sentry.tasks.seer.night_shift.agentic_triage import agentic_triage_strategy
 from sentry.tasks.seer.night_shift.models import TriageAction
@@ -97,7 +98,7 @@ def run_night_shift_for_org(organization_id: int, dry_run: bool = False) -> None
     start_time = time.monotonic()
 
     try:
-        eligible_projects = _get_eligible_projects(organization)
+        eligible_projects, preferences = _get_eligible_projects(organization)
         if not eligible_projects:
             logger.info(
                 "night_shift.no_eligible_projects",
@@ -155,14 +156,6 @@ def run_night_shift_for_org(organization_id: int, dry_run: bool = False) -> None
         sentry_sdk.metrics.count("night_shift.triage_action", 1, attributes={"action": c.action})
     sentry_sdk.metrics.distribution("night_shift.org_run_duration", time.monotonic() - start_time)
 
-    autofix_triggered = 0
-    if not dry_run:
-        for c in candidates:
-            if c.action == TriageAction.AUTOFIX:
-                if _trigger_autofix_for_candidate(c.group, organization):
-                    autofix_triggered += 1
-    sentry_sdk.metrics.count("night_shift.autofix_triggered", autofix_triggered)
-
     logger.info(
         "night_shift.candidates_selected",
         extra={
@@ -172,7 +165,6 @@ def run_night_shift_for_org(organization_id: int, dry_run: bool = False) -> None
             "num_eligible_projects": len(eligible_projects),
             "num_candidates": len(candidates),
             "dry_run": dry_run,
-            "num_autofix_triggered": autofix_triggered,
             "candidates": [
                 {
                     "group_id": c.group.id,
@@ -182,6 +174,16 @@ def run_night_shift_for_org(organization_id: int, dry_run: bool = False) -> None
             ],
         },
     )
+
+    autofix_triggered = 0
+    if not dry_run:
+        for c in candidates:
+            if c.action == TriageAction.AUTOFIX:
+                pref = preferences.get(c.group.project_id)
+                stopping_point = pref.automated_run_stopping_point if pref else None
+                if _trigger_autofix_for_candidate(c.group, organization, stopping_point):
+                    autofix_triggered += 1
+    sentry_sdk.metrics.count("night_shift.autofix_triggered", autofix_triggered)
 
 
 def _get_eligible_orgs_from_batch(
@@ -206,7 +208,9 @@ def _get_eligible_orgs_from_batch(
     return eligible
 
 
-def _trigger_autofix_for_candidate(group: Group, organization: Organization) -> bool:
+def _trigger_autofix_for_candidate(
+    group: Group, organization: Organization, stopping_point: str | None
+) -> bool:
     """Trigger autofix for a single candidate identified as fixable by night shift triage.
 
     Returns True if the autofix task was dispatched.
@@ -222,8 +226,6 @@ def _trigger_autofix_for_candidate(group: Group, organization: Organization) -> 
                 extra={"group_id": group.id, "organization_id": organization.id},
             )
             return False
-
-        stopping_point = get_user_stopping_point(group)
 
         _trigger_autofix_task.delay(
             group_id=group.id,
@@ -242,21 +244,24 @@ def _trigger_autofix_for_candidate(group: Group, organization: Organization) -> 
         return False
 
 
-def _get_eligible_projects(organization: Organization) -> list[Project]:
+def _get_eligible_projects(
+    organization: Organization,
+) -> tuple[list[Project], dict[int, SeerProjectPreference | None]]:
     """Return active projects that have automation enabled and connected repos."""
     project_map = {
         p.id: p
         for p in Project.objects.filter(organization=organization, status=ObjectStatus.ACTIVE)
     }
     if not project_map:
-        return []
+        return [], {}
 
     preferences = bulk_read_preferences(organization, list(project_map))
 
-    return [
+    projects = [
         project_map[pid]
         for pid, pref in preferences.items()
         if pref is not None
         and pref.repositories
         and pref.autofix_automation_tuning != AutofixAutomationTuningSettings.OFF
     ]
+    return projects, preferences

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -13,7 +13,7 @@ from sentry.models.group import Group
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.project import Project
 from sentry.seer.autofix.constants import AutofixAutomationTuningSettings, AutofixReferrer
-from sentry.seer.autofix.issue_summary import _trigger_autofix_task, get_automation_stopping_point
+from sentry.seer.autofix.issue_summary import _trigger_autofix_task, get_user_stopping_point
 from sentry.seer.autofix.utils import bulk_read_preferences, get_autofix_state
 from sentry.seer.models.night_shift import SeerNightShiftRun, SeerNightShiftRunIssue
 from sentry.tasks.base import instrumented_task
@@ -223,7 +223,7 @@ def _trigger_autofix_for_candidate(group: Group, organization: Organization) -> 
             )
             return False
 
-        stopping_point = get_automation_stopping_point(group)
+        stopping_point = get_user_stopping_point(group)
 
         _trigger_autofix_task.delay(
             group_id=group.id,

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -9,13 +9,16 @@ import sentry_sdk
 
 from sentry import features, options
 from sentry.constants import ObjectStatus
+from sentry.models.group import Group
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.project import Project
-from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
-from sentry.seer.autofix.utils import bulk_read_preferences
+from sentry.seer.autofix.constants import AutofixAutomationTuningSettings, AutofixReferrer
+from sentry.seer.autofix.issue_summary import _trigger_autofix_task, get_automation_stopping_point
+from sentry.seer.autofix.utils import bulk_read_preferences, get_autofix_state
 from sentry.seer.models.night_shift import SeerNightShiftRun, SeerNightShiftRunIssue
 from sentry.tasks.base import instrumented_task
 from sentry.tasks.seer.night_shift.agentic_triage import agentic_triage_strategy
+from sentry.tasks.seer.night_shift.models import TriageAction
 from sentry.taskworker.namespaces import seer_tasks
 from sentry.utils.iterators import chunked
 from sentry.utils.query import RangeQuerySetWrapper
@@ -76,7 +79,7 @@ def schedule_night_shift() -> None:
     namespace=seer_tasks,
     processing_deadline_duration=5 * 60,
 )
-def run_night_shift_for_org(organization_id: int) -> None:
+def run_night_shift_for_org(organization_id: int, dry_run: bool = False) -> None:
     try:
         organization = Organization.objects.get(
             id=organization_id, status=OrganizationStatus.ACTIVE
@@ -152,6 +155,14 @@ def run_night_shift_for_org(organization_id: int) -> None:
         sentry_sdk.metrics.count("night_shift.triage_action", 1, attributes={"action": c.action})
     sentry_sdk.metrics.distribution("night_shift.org_run_duration", time.monotonic() - start_time)
 
+    autofix_triggered = 0
+    if not dry_run:
+        for c in candidates:
+            if c.action == TriageAction.AUTOFIX:
+                if _trigger_autofix_for_candidate(c.group, organization):
+                    autofix_triggered += 1
+    sentry_sdk.metrics.count("night_shift.autofix_triggered", autofix_triggered)
+
     logger.info(
         "night_shift.candidates_selected",
         extra={
@@ -160,6 +171,8 @@ def run_night_shift_for_org(organization_id: int) -> None:
             "run_id": run.id,
             "num_eligible_projects": len(eligible_projects),
             "num_candidates": len(candidates),
+            "dry_run": dry_run,
+            "num_autofix_triggered": autofix_triggered,
             "candidates": [
                 {
                     "group_id": c.group.id,
@@ -191,6 +204,42 @@ def _get_eligible_orgs_from_batch(
             return []
 
     return eligible
+
+
+def _trigger_autofix_for_candidate(group: Group, organization: Organization) -> bool:
+    """Trigger autofix for a single candidate identified as fixable by night shift triage.
+
+    Returns True if the autofix task was dispatched.
+    """
+    try:
+        if get_autofix_state(group_id=group.id, organization_id=organization.id):
+            return False
+
+        event = group.get_latest_event()
+        if not event:
+            logger.warning(
+                "night_shift.no_event_for_autofix",
+                extra={"group_id": group.id, "organization_id": organization.id},
+            )
+            return False
+
+        stopping_point = get_automation_stopping_point(group)
+
+        _trigger_autofix_task.delay(
+            group_id=group.id,
+            event_id=event.event_id,
+            user_id=None,
+            auto_run_source="night_shift",
+            referrer=AutofixReferrer.NIGHT_SHIFT,
+            stopping_point=stopping_point,
+        )
+        return True
+    except Exception:
+        logger.exception(
+            "night_shift.autofix_trigger_failed",
+            extra={"group_id": group.id, "organization_id": organization.id},
+        )
+        return False
 
 
 def _get_eligible_projects(organization: Organization) -> list[Project]:

--- a/static/gsAdmin/views/seerAdminPage.tsx
+++ b/static/gsAdmin/views/seerAdminPage.tsx
@@ -16,6 +16,7 @@ import {PageHeader} from 'admin/components/pageHeader';
 
 export function SeerAdminPage() {
   const [organizationId, setOrganizationId] = useState<string>('');
+  const [dryRun, setDryRun] = useState<boolean>(false);
   const regions = ConfigStore.get('regions');
   const [region, setRegion] = useState<Region | null>(regions[0] ?? null);
 
@@ -24,12 +25,15 @@ export function SeerAdminPage() {
       return fetchMutation({
         url: '/internal/seer/night-shift/trigger/',
         method: 'POST',
-        data: {organization_id: parseInt(organizationId, 10)},
+        data: {organization_id: parseInt(organizationId, 10), dry_run: dryRun},
         options: {host: region?.url},
       });
     },
     onSuccess: () => {
-      addSuccessMessage(`Night shift run triggered for organization ${organizationId}`);
+      const mode = dryRun ? ' (dry run)' : '';
+      addSuccessMessage(
+        `Night shift run triggered for organization ${organizationId}${mode}`
+      );
       setOrganizationId('');
     },
     onError: () => {
@@ -96,6 +100,14 @@ export function SeerAdminPage() {
                   onChange={e => setOrganizationId(e.target.value)}
                   placeholder="Enter organization ID"
                 />
+                <Flex as="label" gap="sm" align="center">
+                  <input
+                    type="checkbox"
+                    checked={dryRun}
+                    onChange={e => setDryRun(e.target.checked)}
+                  />
+                  <Text>Dry run (triage only, no autofix triggered)</Text>
+                </Flex>
                 <Button
                   priority="primary"
                   type="submit"

--- a/tests/sentry/seer/endpoints/test_admin_night_shift_trigger.py
+++ b/tests/sentry/seer/endpoints/test_admin_night_shift_trigger.py
@@ -28,7 +28,9 @@ class SeerAdminNightShiftTriggerTest(APITestCase):
 
         assert response.data["success"] is True
         assert response.data["organization_id"] == self.organization.id
-        mock_task.apply_async.assert_called_once_with(args=[self.organization.id])
+        mock_task.apply_async.assert_called_once_with(
+            args=[self.organization.id], kwargs={"dry_run": False}
+        )
 
     def test_missing_organization_id(self) -> None:
         response = self.get_response()

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -123,7 +123,9 @@ class TestGetEligibleProjects(TestCase):
         self.create_project(organization=org)
 
         with self.feature("organizations:seer-project-settings-read-from-sentry"):
-            assert _get_eligible_projects(org) == [eligible]
+            projects, preferences = _get_eligible_projects(org)
+            assert projects == [eligible]
+            assert eligible.id in preferences
 
 
 @django_db_all
@@ -263,6 +265,80 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
         run = SeerNightShiftRun.objects.get(organization=org)
         assert run.error_message == "Night shift run failed"
         assert not SeerNightShiftRunIssue.objects.filter(run=run).exists()
+
+    def test_triggers_autofix_for_fixable_candidates(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        self._make_eligible(project)
+
+        group = self._store_event_and_update_group(
+            project, "fixable", seer_fixability_score=0.9, times_seen=5
+        )
+
+        fake_client = FakeExplorerClient([group.id], action="autofix")
+        with (
+            self.feature("organizations:seer-project-settings-read-from-sentry"),
+            patch(
+                "sentry.tasks.seer.night_shift.agentic_triage.SeerExplorerClient",
+                return_value=fake_client,
+            ),
+            patch("sentry.tasks.seer.night_shift.cron._trigger_autofix_task") as mock_autofix_task,
+        ):
+            run_night_shift_for_org(org.id)
+
+            mock_autofix_task.delay.assert_called_once()
+            call_kwargs = mock_autofix_task.delay.call_args.kwargs
+            assert call_kwargs["group_id"] == group.id
+            assert call_kwargs["user_id"] is None
+            assert call_kwargs["auto_run_source"] == "night_shift"
+
+    def test_dry_run_skips_autofix(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        self._make_eligible(project)
+
+        group = self._store_event_and_update_group(
+            project, "fixable", seer_fixability_score=0.9, times_seen=5
+        )
+
+        fake_client = FakeExplorerClient([group.id], action="autofix")
+        with (
+            self.feature("organizations:seer-project-settings-read-from-sentry"),
+            patch(
+                "sentry.tasks.seer.night_shift.agentic_triage.SeerExplorerClient",
+                return_value=fake_client,
+            ),
+            patch("sentry.tasks.seer.night_shift.cron._trigger_autofix_task") as mock_autofix_task,
+        ):
+            run_night_shift_for_org(org.id, dry_run=True)
+
+            mock_autofix_task.delay.assert_not_called()
+
+        # Candidates should still be saved to DB
+        run = SeerNightShiftRun.objects.get(organization=org)
+        assert SeerNightShiftRunIssue.objects.filter(run=run).count() == 1
+
+    def test_skips_autofix_for_non_autofix_candidates(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        self._make_eligible(project)
+
+        group = self._store_event_and_update_group(
+            project, "skip-me", seer_fixability_score=0.9, times_seen=5
+        )
+
+        fake_client = FakeExplorerClient([group.id], action="root_cause_only")
+        with (
+            self.feature("organizations:seer-project-settings-read-from-sentry"),
+            patch(
+                "sentry.tasks.seer.night_shift.agentic_triage.SeerExplorerClient",
+                return_value=fake_client,
+            ),
+            patch("sentry.tasks.seer.night_shift.cron._trigger_autofix_task") as mock_autofix_task,
+        ):
+            run_night_shift_for_org(org.id)
+
+            mock_autofix_task.delay.assert_not_called()
 
     def test_empty_candidates_creates_run_with_no_issues(self) -> None:
         org = self.create_organization()


### PR DESCRIPTION
Night shift triage now triggers autofix automation for candidates identified as fixable by the agentic triage strategy. Each autofix run carries a dedicated `NIGHT_SHIFT` referrer (`AutofixReferrer.NIGHT_SHIFT` + `auto_run_source="night_shift"`) so this cohort can be tracked and evaluated separately from the regular post-process/alert automation flow.

Per candidate, we check for an existing autofix run and resolve the user's configured stopping point before dispatching `_trigger_autofix_task`. Unlike the regular automation flow, we skip the fixability-score-based stopping point since night shift already performed its own agentic assessment — only the user's project preference is honored as an upper bound. Quota and feature flag checks are handled downstream by `trigger_autofix`/`trigger_autofix_explorer`.

Also adds a **dry run** toggle to the Seer admin page (`/_admin/seer/`). When enabled, night shift runs triage and logs candidates as usual but skips autofix triggering — useful for evaluating triage quality without side effects like autofix run timestamps that prevent re-runs.

### Changes

- `issue_summary.py`: Wire `NIGHT_SHIFT` into `auto_run_source_map` and `referrer_map`. Extract `_get_user_stopping_point_preference` helper and add `get_user_stopping_point` for callers that need just the user preference without fixability scoring.
- `cron.py`: Add `_trigger_autofix_for_candidate()` helper, loop in `run_night_shift_for_org`, accept `dry_run` kwarg, use `get_user_stopping_point` for stopping point.
- `admin_night_shift_trigger.py`: Pass `dry_run` flag through to the task.
- `seerAdminPage.tsx`: Add dry run checkbox to the night shift trigger form.