### PR TITLE
feat(tracemetrics): Add filter bar to equation

### DIFF
--- a/static/app/views/explore/metrics/metricToolbar/filter.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/filter.tsx
@@ -33,6 +33,7 @@ const EMPTY_ALIASES: TagCollection = {};
 
 interface FilterProps {
   traceMetric: TraceMetric;
+  skipTraceMetricFilter?: boolean;
 }
 
 interface MetricsSearchBarProps {
@@ -53,7 +54,7 @@ function MetricsSearchBar({
   return <TraceItemSearchQueryBuilder {...tracesItemSearchQueryBuilderProps} />;
 }
 
-export function Filter({traceMetric}: FilterProps) {
+export function Filter({traceMetric, skipTraceMetricFilter}: FilterProps) {
   const query = useQueryParamsQuery();
   const setQuery = useSetQueryParamsQuery();
   const organization = useOrganization();
@@ -70,20 +71,20 @@ export function Filter({traceMetric}: FilterProps) {
   const {attributes: numberTags} = useTraceItemAttributeKeys({
     traceItemType: TraceItemDataset.TRACEMETRICS,
     type: 'number',
-    enabled: Boolean(traceMetricFilter),
-    query: traceMetricFilter,
+    enabled: skipTraceMetricFilter || Boolean(traceMetricFilter),
+    query: skipTraceMetricFilter ? undefined : traceMetricFilter,
   });
   const {attributes: stringTags} = useTraceItemAttributeKeys({
     traceItemType: TraceItemDataset.TRACEMETRICS,
     type: 'string',
-    enabled: Boolean(traceMetricFilter),
-    query: traceMetricFilter,
+    enabled: skipTraceMetricFilter || Boolean(traceMetricFilter),
+    query: skipTraceMetricFilter ? undefined : traceMetricFilter,
   });
   const {attributes: booleanTags} = useTraceItemAttributeKeys({
     traceItemType: TraceItemDataset.TRACEMETRICS,
     type: 'boolean',
-    enabled: Boolean(traceMetricFilter),
-    query: traceMetricFilter,
+    enabled: skipTraceMetricFilter || Boolean(traceMetricFilter),
+    query: skipTraceMetricFilter ? undefined : traceMetricFilter,
   });
 
   const visibleNumberTags = useMemo(() => {
@@ -154,6 +155,10 @@ export function Filter({traceMetric}: FilterProps) {
         onSearch: setQuery,
         searchSource: 'tracemetrics',
         namespace: traceMetric.name,
+
+        // Disable the recent searches when not using a trace metric filter because
+        // the recent searches for metrics need to be namespaced on the trace metric filter.
+        disableRecentSearches: skipTraceMetricFilter,
       };
     }, [
       query,
@@ -162,6 +167,7 @@ export function Filter({traceMetric}: FilterProps) {
       visibleNumberTags,
       visibleStringTags,
       traceMetric.name,
+      skipTraceMetricFilter,
     ]);
 
   const searchQueryBuilderProviderProps = useTraceItemSearchQueryBuilderProps(

--- a/static/app/views/explore/metrics/metricToolbar/index.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/index.tsx
@@ -157,8 +157,11 @@ export function MetricToolbar({
           ) : null}
           {canRemoveMetric && <DeleteMetricButton disabled={isReferencedByEquation} />}
         </Grid>
-        {isNarrow && isVisualizeFunction(visualize) && (
-          <Filter traceMetric={traceMetric} />
+        {isNarrow && (
+          <Filter
+            traceMetric={traceMetric}
+            skipTraceMetricFilter={isVisualizeEquation(visualize)}
+          />
         )}
       </Flex>
     );

--- a/static/app/views/explore/metrics/metricToolbar/index.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/index.tsx
@@ -134,8 +134,10 @@ export function MetricToolbar({
               )}
             </Fragment>
           ) : isVisualizeEquation(visualize) ? (
+            // The flex definitions are more complex for this case to mirror the styling for the
+            // visualizeFunction case.
             <Flex minWidth={0} gap="md">
-              <Flex flex="4 1 0" minWidth={0}>
+              <Flex flex="16 1 0" minWidth={0}>
                 <EquationBuilder
                   expression={visualize.expression.text}
                   referenceMap={referenceMap}
@@ -143,9 +145,14 @@ export function MetricToolbar({
                   onReferenceLabelsChange={handleReferenceLabelsChange}
                 />
               </Flex>
-              <Flex flex="1 1 0" minWidth={0}>
+              <Flex flex="9 1 0" minWidth={0}>
                 <GroupBySelector traceMetric={traceMetric} skipTraceMetricFilter />
               </Flex>
+              {!isNarrow && (
+                <Flex flex="30 1 0" minWidth={0}>
+                  <Filter traceMetric={traceMetric} skipTraceMetricFilter />
+                </Flex>
+              )}
             </Flex>
           ) : null}
           {canRemoveMetric && <DeleteMetricButton disabled={isReferencedByEquation} />}


### PR DESCRIPTION
Adds a filter bar. Similarly to group by, we can't show the relevant attributes at this time so we're skipping the `query` filter in the request for tags. Also disables `recentSearches` because we have this hack for metrics where the metrics recent searches is namespaced by the metric you've selected, but this doesn't work or make sense for equations.


https://github.com/user-attachments/assets/cc0f7d31-05b1-413c-a2b1-f5a0e3cb3f88

