### PR TITLE
fix(autofix): Ignore default-valued options when checking if preference is configured

### DIFF
--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -750,7 +750,8 @@ def read_preference_from_sentry_db(project: Project) -> SeerProjectPreference | 
     ]
 
     has_configured_options = any(
-        ProjectOption.objects.isset(project, key) for key in SEER_PROJECT_PREFERENCE_OPTION_KEYS
+        project.get_option(key) != projectoptions.get_well_known_default(key, project=project)
+        for key in SEER_PROJECT_PREFERENCE_OPTION_KEYS
     )
     if not repo_definitions and not has_configured_options:
         return None
@@ -797,6 +798,8 @@ def bulk_read_preferences_from_sentry_db(
     for project in projects:
         has_configured_options = any(
             project_options[key][project.id] is not None
+            and project_options[key][project.id]
+            != projectoptions.get_well_known_default(key, project=project)
             for key in SEER_PROJECT_PREFERENCE_OPTION_KEYS
         )
         if project.id not in repo_definitions_by_project and not has_configured_options:

--- a/tests/sentry/seer/autofix/test_autofix_utils.py
+++ b/tests/sentry/seer/autofix/test_autofix_utils.py
@@ -1342,6 +1342,15 @@ class TestReadPreferenceFromSentryDb(TestCase):
         assert result.autofix_automation_tuning == AutofixAutomationTuningSettings.HIGH
         assert result.repositories == []
 
+    def test_autofix_automation_tuning_default_alone_returns_none(self):
+        """Setting autofix_automation_tuning to its default (OFF) should not count as configured."""
+        self.project.update_option(
+            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.OFF
+        )
+
+        result = read_preference_from_sentry_db(self.project)
+        assert result is None
+
     def test_project_with_stopping_point_only(self):
         self.project.update_option("sentry:seer_automated_run_stopping_point", "open_pr")
 
@@ -1538,6 +1547,15 @@ class TestBulkReadPreferencesFromSentryDb(TestCase):
         pref = result[self.project1.id]
         assert pref is not None
         assert pref.autofix_automation_tuning == AutofixAutomationTuningSettings.OFF
+
+    def test_autofix_automation_tuning_default_alone_returns_none(self):
+        """Setting autofix_automation_tuning to its default (OFF) should not count as configured."""
+        self.project1.update_option(
+            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.OFF
+        )
+
+        result = bulk_read_preferences_from_sentry_db(self.organization.id, [self.project1.id])
+        assert result[self.project1.id] is None
 
     def test_wrong_organization_excluded(self):
         other_org = self.create_organization()


### PR DESCRIPTION
Projects with `autofix_automation_tuning` explicitly set to its default ("OFF") — e.g. by `set_default_project_autofix_automation_tuning` at project creation — were being treated as having configured preferences. This caused `read_preference_from_sentry_db` to return a `SeerProjectPreference` with empty repositories instead of `None`, skipping the fallback path that populates repos from code mappings in `trigger_autofix`.

Compare option values against their registered defaults so only meaningfully configured options count.