### PR TITLE
feat(onboarding): Gate SCM_PROJECT_DETAILS step with feature flag

### DIFF
--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -630,7 +630,7 @@ describe('Onboarding', () => {
 
   describe('SCM onboarding flow', () => {
     const scmOrganization = OrganizationFixture({
-      features: ['onboarding-scm-experiment'],
+      features: ['onboarding-scm-experiment', 'onboarding-scm-project-details'],
     });
 
     const githubProvider = GitHubIntegrationProviderFixture({

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -170,7 +170,15 @@ export function OnboardingWithoutContext() {
     feature: 'onboarding-scm-experiment',
   });
 
-  const onboardingSteps = hasScmOnboarding ? scmOnboardingSteps : legacyOnboardingSteps;
+  const hasProjectDetailsStep = organization.features.includes(
+    'onboarding-scm-project-details'
+  );
+
+  const scmSteps = hasProjectDetailsStep
+    ? scmOnboardingSteps
+    : scmOnboardingSteps.filter(s => s.id !== OnboardingStepId.SCM_PROJECT_DETAILS);
+
+  const onboardingSteps = hasScmOnboarding ? scmSteps : legacyOnboardingSteps;
 
   const stepObj = onboardingSteps.find(({id}) => stepId === id);
   const stepIndex = onboardingSteps.findIndex(({id}) => stepId === id);

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -27,6 +27,7 @@ import type {PlatformIntegration, PlatformKey} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {isDisabledGamingPlatform} from 'sentry/utils/platform';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {useProjects} from 'sentry/utils/useProjects';
 import {useTeams} from 'sentry/utils/useTeams';
 import {ScmFeatureSelectionCards} from 'sentry/views/onboarding/components/scmFeatureSelectionCards';
 import {ScmPlatformCard} from 'sentry/views/onboarding/components/scmPlatformCard';
@@ -93,6 +94,7 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
   } = useOnboardingContext();
 
   const {teams} = useTeams();
+  const {projects} = useProjects();
   const createProject = useCreateProject();
   const hasProjectDetailsStep = organization.features.includes(
     'onboarding-scm-project-details'
@@ -335,6 +337,16 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
           ? toSelectedSdk(getPlatformInfo(currentPlatformKey)!)
           : undefined);
       if (!platform) {
+        return;
+      }
+
+      // If a project for this platform already exists (e.g. the user went
+      // back after the project had already received its first event), skip
+      // creation and reuse it — mirrors useConfigureSdk logic.
+      const existingProject = projects.find(p => p.slug === platform.key);
+      if (existingProject) {
+        setCreatedProjectSlug(existingProject.slug);
+        onComplete(undefined, {product: currentFeatures});
         return;
       }
 

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -1,4 +1,5 @@
 import {useCallback, useEffect, useMemo, useState} from 'react';
+import * as Sentry from '@sentry/react';
 import {LayoutGroup, motion} from 'framer-motion';
 import {PlatformIcon} from 'platformicons';
 
@@ -7,6 +8,7 @@ import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Select} from '@sentry/scraps/select';
 import {Heading} from '@sentry/scraps/text';
 
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {closeModal, openConsoleModal, openModal} from 'sentry/actionCreators/modal';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {SupportedLanguages} from 'sentry/components/onboarding/frameworkSuggestionModal';
@@ -16,13 +18,16 @@ import {
   getDisabledProducts,
   platformProductAvailability,
 } from 'sentry/components/onboarding/productSelection';
+import {useCreateProject} from 'sentry/components/onboarding/useCreateProject';
 import {platforms} from 'sentry/data/platforms';
 import {t} from 'sentry/locale';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
+import type {Team} from 'sentry/types/organization';
 import type {PlatformIntegration, PlatformKey} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {isDisabledGamingPlatform} from 'sentry/utils/platform';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {useTeams} from 'sentry/utils/useTeams';
 import {ScmFeatureSelectionCards} from 'sentry/views/onboarding/components/scmFeatureSelectionCards';
 import {ScmPlatformCard} from 'sentry/views/onboarding/components/scmPlatformCard';
 
@@ -84,7 +89,14 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
     setSelectedPlatform,
     selectedFeatures,
     setSelectedFeatures,
+    setCreatedProjectSlug,
   } = useOnboardingContext();
+
+  const {teams} = useTeams();
+  const createProject = useCreateProject();
+  const hasProjectDetailsStep = organization.features.includes(
+    'onboarding-scm-project-details'
+  );
 
   const [showManualPicker, setShowManualPicker] = useState(false);
 
@@ -306,7 +318,7 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
     }
   }
 
-  function handleContinue() {
+  async function handleContinue() {
     // Persist derived defaults to context if user accepted them
     if (currentPlatformKey && !selectedPlatform?.key) {
       setPlatform(currentPlatformKey);
@@ -314,6 +326,38 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
     if (!selectedFeatures) {
       setSelectedFeatures(currentFeatures);
     }
+
+    if (!hasProjectDetailsStep) {
+      // Auto-create project with defaults when SCM_PROJECT_DETAILS step is skipped
+      const platform =
+        selectedPlatform ??
+        (currentPlatformKey
+          ? toSelectedSdk(getPlatformInfo(currentPlatformKey)!)
+          : undefined);
+      if (!platform) {
+        return;
+      }
+
+      const firstAdminTeam = teams.find((team: Team) =>
+        team.access.includes('team:admin')
+      );
+
+      try {
+        const project = await createProject.mutateAsync({
+          name: platform.key,
+          platform,
+          default_rules: true,
+          firstTeamSlug: firstAdminTeam?.slug,
+        });
+        setCreatedProjectSlug(project.slug);
+        onComplete(undefined, {product: currentFeatures});
+      } catch (error) {
+        addErrorMessage(t('Failed to create project'));
+        Sentry.captureException(error);
+      }
+      return;
+    }
+
     onComplete();
   }
 
@@ -459,7 +503,8 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
                 features: currentFeatures,
               }}
               onClick={handleContinue}
-              disabled={!currentPlatformKey}
+              disabled={!currentPlatformKey || createProject.isPending}
+              busy={createProject.isPending}
             >
               {t('Continue')}
             </Button>

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -16,6 +16,7 @@ import type {Team} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {slugify} from 'sentry/utils/slugify';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {useProjects} from 'sentry/utils/useProjects';
 import {useTeams} from 'sentry/utils/useTeams';
 import {
   DEFAULT_ISSUE_ALERT_OPTIONS_VALUES,
@@ -36,6 +37,7 @@ export function ScmProjectDetails({onComplete}: StepProps) {
   const {selectedPlatform, selectedFeatures, setCreatedProjectSlug} =
     useOnboardingContext();
   const {teams} = useTeams();
+  const {projects} = useProjects();
   const createProjectAndRules = useCreateProjectAndRules();
   useEffect(() => {
     trackAnalytics('onboarding.scm_project_details_step_viewed', {organization});
@@ -98,6 +100,16 @@ export function ScmProjectDetails({onComplete}: StepProps) {
 
   async function handleCreateProject() {
     if (!selectedPlatform || !canSubmit) {
+      return;
+    }
+
+    // If a project for this name already exists (e.g. the user went back
+    // after the project had already received its first event), skip
+    // creation and reuse it — mirrors useConfigureSdk logic.
+    const existingProject = projects.find(p => p.slug === projectNameResolved);
+    if (existingProject) {
+      setCreatedProjectSlug(existingProject.slug);
+      onComplete(undefined, selectedFeatures ? {product: selectedFeatures} : undefined);
       return;
     }
 

--- a/static/app/views/onboarding/useBackActions.tsx
+++ b/static/app/views/onboarding/useBackActions.tsx
@@ -118,7 +118,9 @@ export function useBackActions({
         // store data and skip project creation.
         // In the SCM flow, preserve context so the user keeps their SCM
         // connection, repo selection, and feature choices.
-        await deleteRecentCreatedProject(prevStep.id === 'scm-project-details');
+        await deleteRecentCreatedProject(
+          organization.features.includes('onboarding-scm-experiment')
+        );
       }
 
       if (!browserBackButton) {

--- a/static/app/views/onboarding/useBackActions.tsx
+++ b/static/app/views/onboarding/useBackActions.tsx
@@ -10,6 +10,7 @@ import {handleXhrErrorResponse} from 'sentry/utils/handleXhrErrorResponse';
 import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useApi} from 'sentry/utils/useApi';
+import {useExperiment} from 'sentry/utils/useExperiment';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import type {StepDescriptor} from 'sentry/views/onboarding/types';
 
@@ -33,6 +34,9 @@ export function useBackActions({
   const api = useApi();
   const organization = useOrganization();
   const onboardingContext = useOnboardingContext();
+  const {inExperiment: hasScmOnboarding} = useExperiment({
+    feature: 'onboarding-scm-experiment',
+  });
   const currentStep = onboardingSteps[stepIndex];
 
   const deleteRecentCreatedProject = useCallback(
@@ -118,9 +122,7 @@ export function useBackActions({
         // store data and skip project creation.
         // In the SCM flow, preserve context so the user keeps their SCM
         // connection, repo selection, and feature choices.
-        await deleteRecentCreatedProject(
-          organization.features.includes('onboarding-scm-experiment')
-        );
+        await deleteRecentCreatedProject(hasScmOnboarding);
       }
 
       if (!browserBackButton) {
@@ -128,13 +130,14 @@ export function useBackActions({
       }
     },
     [
-      goToStep,
+      currentStep,
       organization,
-      onboardingContext,
       isRecentCreatedProjectActive,
       recentCreatedProject,
-      currentStep,
+      onboardingContext,
+      goToStep,
       deleteRecentCreatedProject,
+      hasScmOnboarding,
     ]
   );
 


### PR DESCRIPTION
Gate the `SCM_PROJECT_DETAILS` step behind the `onboarding-scm-project-details` feature flag to experiment with a shorter SCM onboarding flow.

When the flag is **present**, the flow is unchanged:
`SCM_CONNECT -> SCM_PLATFORM_FEATURES -> SCM_PROJECT_DETAILS -> SETUP_DOCS`

When the flag is **absent**, the project details step is skipped:
`SCM_CONNECT -> SCM_PLATFORM_FEATURES -> SETUP_DOCS`

In the skipped case, clicking Continue on the platform features step auto-creates the project with defaults (platform key as name, first admin team, default alert rules), sets `createdProjectSlug` in context so `SETUP_DOCS` can find it, and passes selected features as query products. The Continue button shows a loading state during creation and surfaces an error toast if it fails.

The flag is not yet registered in `temporary.py` -- this is the client-side wiring only. What is lost when the step is skipped: custom project name, team selection, alert frequency configuration (all fall back to defaults matching the legacy onboarding flow).

Refs VDY-82