### PR TITLE
chore(integrations): Gate disabling repositories behind a separate flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -149,6 +149,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:github-repo-auto-sync", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:github-repo-auto-sync-apply", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:github-repo-auto-sync-webhook", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("organizations:scm-repo-auto-sync-removal", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:github_enterprise-repo-auto-sync", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:github_enterprise-repo-auto-sync-apply", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:gitlab-repo-auto-sync", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)

--- a/src/sentry/integrations/github/tasks/sync_repos_on_install_change.py
+++ b/src/sentry/integrations/github/tasks/sync_repos_on_install_change.py
@@ -140,7 +140,7 @@ def _sync_repos_for_org(
                     provider=integration.provider,
                 )
 
-    if repos_removed:
+    if repos_removed and features.has("organizations:scm-repo-auto-sync-removal", rpc_org):
         # Look up repos before disabling to get their IDs and names
         external_ids = [str(repo["id"]) for repo in repos_removed]
         existing_repos = repository_service.get_repositories(

--- a/src/sentry/integrations/source_code_management/sync_repos.py
+++ b/src/sentry/integrations/source_code_management/sync_repos.py
@@ -247,7 +247,7 @@ def sync_repos_for_org(organization_integration_id: int) -> None:
                         provider=provider_key,
                     )
 
-        if removed_ids:
+        if removed_ids and _has_feature("organizations:scm-repo-auto-sync-removal", rpc_org):
             repository_service.disable_repositories_by_external_ids(
                 organization_id=organization_id,
                 integration_id=integration.id,

--- a/tests/sentry/integrations/github/tasks/test_sync_repos_on_install_change.py
+++ b/tests/sentry/integrations/github/tasks/test_sync_repos_on_install_change.py
@@ -13,6 +13,7 @@ from sentry.testutils.cases import IntegrationTestCase
 from sentry.testutils.silo import assume_test_silo_mode, assume_test_silo_mode_of, control_silo_test
 
 FEATURE_FLAG = "organizations:github-repo-auto-sync-webhook"
+REMOVAL_FLAG = "organizations:scm-repo-auto-sync-removal"
 
 
 @control_silo_test
@@ -70,7 +71,7 @@ class SyncReposOnInstallChangeTestCase(IntegrationTestCase):
                 status=ObjectStatus.ACTIVE,
             )
 
-        with self.feature(FEATURE_FLAG):
+        with self.feature([FEATURE_FLAG, REMOVAL_FLAG]):
             sync_repos_on_install_change(
                 integration_id=self.integration.id,
                 action="removed",
@@ -100,7 +101,7 @@ class SyncReposOnInstallChangeTestCase(IntegrationTestCase):
                 status=ObjectStatus.ACTIVE,
             )
 
-        with self.feature(FEATURE_FLAG):
+        with self.feature([FEATURE_FLAG, REMOVAL_FLAG]):
             sync_repos_on_install_change(
                 integration_id=self.integration.id,
                 action="added",

--- a/tests/sentry/integrations/github/test_webhook.py
+++ b/tests/sentry/integrations/github/test_webhook.py
@@ -435,7 +435,15 @@ class InstallationRepositoriesEventWebhookTest(APITestCase):
         )
         sha1, sha256 = self._compute_signatures(body)
 
-        with self.feature("organizations:github-repo-auto-sync-webhook"), self.tasks():
+        with (
+            self.feature(
+                [
+                    "organizations:github-repo-auto-sync-webhook",
+                    "organizations:scm-repo-auto-sync-removal",
+                ]
+            ),
+            self.tasks(),
+        ):
             response = self.client.post(
                 path=self.url,
                 data=body,
@@ -483,7 +491,15 @@ class InstallationRepositoriesEventWebhookTest(APITestCase):
         )
         sha1, sha256 = self._compute_signatures(body)
 
-        with self.feature("organizations:github-repo-auto-sync-webhook"), self.tasks():
+        with (
+            self.feature(
+                [
+                    "organizations:github-repo-auto-sync-webhook",
+                    "organizations:scm-repo-auto-sync-removal",
+                ]
+            ),
+            self.tasks(),
+        ):
             response = self.client.post(
                 path=self.url,
                 data=body,

--- a/tests/sentry/integrations/source_code_management/test_sync_repos.py
+++ b/tests/sentry/integrations/source_code_management/test_sync_repos.py
@@ -85,7 +85,11 @@ class SyncReposForOrgTestCase(IntegrationTestCase):
         self._add_repos_response([{"id": 1, "full_name": "getsentry/sentry", "name": "sentry"}])
 
         with self.feature(
-            ["organizations:github-repo-auto-sync", "organizations:github-repo-auto-sync-apply"]
+            [
+                "organizations:github-repo-auto-sync",
+                "organizations:github-repo-auto-sync-apply",
+                "organizations:scm-repo-auto-sync-removal",
+            ]
         ):
             sync_repos_for_org(self.oi.id)
 


### PR DESCRIPTION
Being cautious with this auto sync work and gating a potentially destructive operation behind a deletion flag.
