### PR TITLE
fix(eco): Re-adds the Complete Installation button to integration config pages"

### DIFF
--- a/static/app/components/backendJsonFormAdapter/backendJsonAutoSaveForm.tsx
+++ b/static/app/components/backendJsonFormAdapter/backendJsonAutoSaveForm.tsx
@@ -8,7 +8,11 @@ import {Stack} from '@sentry/scraps/layout';
 import {unreachable} from 'sentry/utils/unreachable';
 
 import {ChoiceMapperDropdown, ChoiceMapperTable} from './choiceMapperAdapter';
-import {ProjectMapperAddRow, ProjectMapperTable} from './projectMapperAdapter';
+import {
+  ProjectMapperAddRow,
+  ProjectMapperNextButton,
+  ProjectMapperTable,
+} from './projectMapperAdapter';
 import {TableBody, TableHeaderRow} from './tableAdapter';
 import type {FieldValue, JsonFormAdapterFieldConfig} from './types';
 import {getDefaultForField, getZodType, transformChoices} from './utils';
@@ -110,6 +114,7 @@ export function BackendJsonAutoSaveForm<
                     indicator={indicator}
                     disabled={field.disabled || baseProps.disabled}
                   />
+                  <ProjectMapperNextButton config={field} value={fieldApi.state.value} />
                 </Stack>
               );
             }}

--- a/static/app/components/backendJsonFormAdapter/projectMapperAdapter.spec.tsx
+++ b/static/app/components/backendJsonFormAdapter/projectMapperAdapter.spec.tsx
@@ -241,6 +241,51 @@ describe('ProjectMapperAdapter', () => {
     expect(addButton).toBeEnabled();
   });
 
+  it('controls disabled during in-flight mutation', async () => {
+    let resolveMutation!: () => void;
+    const pendingMutationOptions = {
+      mutationFn: jest.fn(
+        () => new Promise<void>(resolve => (resolveMutation = resolve))
+      ),
+    };
+
+    render(
+      <BackendJsonAutoSaveForm
+        field={makeConfig()}
+        initialValue={[
+          [101, 'proj-1'],
+          [102, 'proj-2'],
+        ]}
+        mutationOptions={pendingMutationOptions}
+      />,
+      {organization: org}
+    );
+
+    // Delete buttons should be enabled initially
+    const deleteButtons = screen.getAllByRole('button', {name: 'Delete'});
+    expect(deleteButtons[0]).toBeEnabled();
+
+    // Delete to trigger mutation
+    await userEvent.click(deleteButtons[0]!);
+
+    await waitFor(() => {
+      expect(pendingMutationOptions.mutationFn).toHaveBeenCalled();
+    });
+
+    // Delete buttons should be disabled during mutation
+    const disabledButtons = screen.getAllByRole('button', {name: 'Delete'});
+    expect(disabledButtons.every(btn => btn.hasAttribute('disabled'))).toBe(true);
+
+    // Resolve the mutation
+    resolveMutation();
+
+    // Controls should be re-enabled after mutation resolves
+    await waitFor(() => {
+      const enabledButtons = screen.getAllByRole('button', {name: 'Delete'});
+      expect(enabledButtons.some(btn => !btn.hasAttribute('disabled'))).toBe(true);
+    });
+  });
+
   describe('next button', () => {
     const nextButtonConfig = {
       nextButton: {
@@ -319,51 +364,6 @@ describe('ProjectMapperAdapter', () => {
       );
 
       expect(screen.queryByText('Complete on Vercel')).not.toBeInTheDocument();
-    });
-  });
-
-  it('controls disabled during in-flight mutation', async () => {
-    let resolveMutation!: () => void;
-    const pendingMutationOptions = {
-      mutationFn: jest.fn(
-        () => new Promise<void>(resolve => (resolveMutation = resolve))
-      ),
-    };
-
-    render(
-      <BackendJsonAutoSaveForm
-        field={makeConfig()}
-        initialValue={[
-          [101, 'proj-1'],
-          [102, 'proj-2'],
-        ]}
-        mutationOptions={pendingMutationOptions}
-      />,
-      {organization: org}
-    );
-
-    // Delete buttons should be enabled initially
-    const deleteButtons = screen.getAllByRole('button', {name: 'Delete'});
-    expect(deleteButtons[0]).toBeEnabled();
-
-    // Delete to trigger mutation
-    await userEvent.click(deleteButtons[0]!);
-
-    await waitFor(() => {
-      expect(pendingMutationOptions.mutationFn).toHaveBeenCalled();
-    });
-
-    // Delete buttons should be disabled during mutation
-    const disabledButtons = screen.getAllByRole('button', {name: 'Delete'});
-    expect(disabledButtons.every(btn => btn.hasAttribute('disabled'))).toBe(true);
-
-    // Resolve the mutation
-    resolveMutation();
-
-    // Controls should be re-enabled after mutation resolves
-    await waitFor(() => {
-      const enabledButtons = screen.getAllByRole('button', {name: 'Delete'});
-      expect(enabledButtons.some(btn => !btn.hasAttribute('disabled'))).toBe(true);
     });
   });
 });

--- a/static/app/components/backendJsonFormAdapter/projectMapperAdapter.spec.tsx
+++ b/static/app/components/backendJsonFormAdapter/projectMapperAdapter.spec.tsx
@@ -241,6 +241,87 @@ describe('ProjectMapperAdapter', () => {
     expect(addButton).toBeEnabled();
   });
 
+  describe('next button', () => {
+    const nextButtonConfig = {
+      nextButton: {
+        allowedDomain: 'https://vercel.com',
+        description: 'Link your Sentry projects to complete your installation on Vercel',
+        text: 'Complete on Vercel',
+      },
+    };
+
+    afterEach(() => {
+      window.history.replaceState({}, '', '/');
+    });
+
+    it('renders disabled next button when no mappings exist', () => {
+      window.history.replaceState({}, '', '?next=https://vercel.com/install/complete');
+
+      render(
+        <BackendJsonAutoSaveForm
+          field={makeConfig(nextButtonConfig)}
+          initialValue={[]}
+          mutationOptions={mutationOptions}
+        />,
+        {organization: org}
+      );
+
+      expect(
+        screen.getByText(
+          'Link your Sentry projects to complete your installation on Vercel'
+        )
+      ).toBeInTheDocument();
+
+      const button = screen.getByRole('button', {name: 'Complete on Vercel'});
+      expect(button).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('renders enabled next button when mappings exist', () => {
+      window.history.replaceState({}, '', '?next=https://vercel.com/install/complete');
+
+      render(
+        <BackendJsonAutoSaveForm
+          field={makeConfig(nextButtonConfig)}
+          initialValue={[[101, 'proj-1']]}
+          mutationOptions={mutationOptions}
+        />,
+        {organization: org}
+      );
+
+      const button = screen.getByRole('button', {name: 'Complete on Vercel'});
+      expect(button).toHaveAttribute('href', 'https://vercel.com/install/complete');
+      expect(button).toHaveAttribute('aria-disabled', 'false');
+    });
+
+    it('does not render next button when next param is missing', () => {
+      render(
+        <BackendJsonAutoSaveForm
+          field={makeConfig(nextButtonConfig)}
+          initialValue={[]}
+          mutationOptions={mutationOptions}
+        />,
+        {organization: org}
+      );
+
+      expect(screen.queryByText('Complete on Vercel')).not.toBeInTheDocument();
+    });
+
+    it('does not render next button when next param domain does not match', () => {
+      window.history.replaceState({}, '', '?next=https://evil.com/steal');
+
+      render(
+        <BackendJsonAutoSaveForm
+          field={makeConfig(nextButtonConfig)}
+          initialValue={[]}
+          mutationOptions={mutationOptions}
+        />,
+        {organization: org}
+      );
+
+      expect(screen.queryByText('Complete on Vercel')).not.toBeInTheDocument();
+    });
+  });
+
   it('controls disabled during in-flight mutation', async () => {
     let resolveMutation!: () => void;
     const pendingMutationOptions = {

--- a/static/app/components/backendJsonFormAdapter/projectMapperAdapter.spec.tsx
+++ b/static/app/components/backendJsonFormAdapter/projectMapperAdapter.spec.tsx
@@ -295,20 +295,22 @@ describe('ProjectMapperAdapter', () => {
       },
     };
 
-    afterEach(() => {
-      window.history.replaceState({}, '', '/');
-    });
-
     it('renders disabled next button when no mappings exist', () => {
-      window.history.replaceState({}, '', '?next=https://vercel.com/install/complete');
-
       render(
         <BackendJsonAutoSaveForm
           field={makeConfig(nextButtonConfig)}
           initialValue={[]}
           mutationOptions={mutationOptions}
         />,
-        {organization: org}
+        {
+          organization: org,
+          initialRouterConfig: {
+            location: {
+              pathname: '/',
+              query: {next: 'https://vercel.com/install/complete'},
+            },
+          },
+        }
       );
 
       expect(
@@ -322,15 +324,21 @@ describe('ProjectMapperAdapter', () => {
     });
 
     it('renders enabled next button when mappings exist', () => {
-      window.history.replaceState({}, '', '?next=https://vercel.com/install/complete');
-
       render(
         <BackendJsonAutoSaveForm
           field={makeConfig(nextButtonConfig)}
           initialValue={[[101, 'proj-1']]}
           mutationOptions={mutationOptions}
         />,
-        {organization: org}
+        {
+          organization: org,
+          initialRouterConfig: {
+            location: {
+              pathname: '/',
+              query: {next: 'https://vercel.com/install/complete'},
+            },
+          },
+        }
       );
 
       const button = screen.getByRole('button', {name: 'Complete on Vercel'});
@@ -352,15 +360,18 @@ describe('ProjectMapperAdapter', () => {
     });
 
     it('does not render next button when next param domain does not match', () => {
-      window.history.replaceState({}, '', '?next=https://evil.com/steal');
-
       render(
         <BackendJsonAutoSaveForm
           field={makeConfig(nextButtonConfig)}
           initialValue={[]}
           mutationOptions={mutationOptions}
         />,
-        {organization: org}
+        {
+          organization: org,
+          initialRouterConfig: {
+            location: {pathname: '/', query: {next: 'https://evil.com/steal'}},
+          },
+        }
       );
 
       expect(screen.queryByText('Complete on Vercel')).not.toBeInTheDocument();

--- a/static/app/components/backendJsonFormAdapter/projectMapperAdapter.tsx
+++ b/static/app/components/backendJsonFormAdapter/projectMapperAdapter.tsx
@@ -1,6 +1,6 @@
 import {useState} from 'react';
 
-import {Button} from '@sentry/scraps/button';
+import {Button, LinkButton} from '@sentry/scraps/button';
 import {Container, Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Select} from '@sentry/scraps/select';
@@ -17,6 +17,7 @@ import {
   IconVercel,
 } from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {safeGetQsParam} from 'sentry/utils/integrationUtil';
 
 import type {JsonFormAdapterFieldConfig} from './types';
 
@@ -226,5 +227,51 @@ export function ProjectMapperTable({
         );
       })}
     </div>
+  );
+}
+
+interface ProjectMapperNextButtonProps {
+  config: ProjectMapperConfig;
+  value: MappedValue[];
+}
+
+export function ProjectMapperNextButton({config, value}: ProjectMapperNextButtonProps) {
+  const {nextButton} = config;
+  if (!nextButton) {
+    return null;
+  }
+
+  const nextUrlOrArray = safeGetQsParam('next');
+  let nextUrl = Array.isArray(nextUrlOrArray) ? nextUrlOrArray[0] : nextUrlOrArray;
+
+  if (nextUrl && !nextUrl.startsWith(nextButton.allowedDomain)) {
+    // eslint-disable-next-line no-console
+    console.warn(`Got unexpected next url: ${nextUrl}`);
+    nextUrl = undefined;
+  }
+
+  if (!nextUrl) {
+    return null;
+  }
+
+  const hasLinkedProjects = value.length > 0;
+
+  return (
+    <Flex align="center" justify="between" gap="md">
+      <Text>{nextButton.description}</Text>
+      <LinkButton
+        size="sm"
+        priority="primary"
+        icon={<IconOpen />}
+        disabled={!hasLinkedProjects}
+        href={nextUrl}
+        tooltipProps={{
+          title: t('Please link at least one project to continue.'),
+          disabled: hasLinkedProjects,
+        }}
+      >
+        {nextButton.text}
+      </LinkButton>
+    </Flex>
   );
 }

--- a/static/app/components/backendJsonFormAdapter/projectMapperAdapter.tsx
+++ b/static/app/components/backendJsonFormAdapter/projectMapperAdapter.tsx
@@ -1,4 +1,6 @@
 import {useState} from 'react';
+import * as Sentry from '@sentry/react';
+import {parseAsString, useQueryState} from 'nuqs';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
 import {Container, Flex} from '@sentry/scraps/layout';
@@ -17,7 +19,6 @@ import {
   IconVercel,
 } from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {safeGetQsParam} from 'sentry/utils/integrationUtil';
 
 import type {JsonFormAdapterFieldConfig} from './types';
 
@@ -237,20 +238,14 @@ interface ProjectMapperNextButtonProps {
 
 export function ProjectMapperNextButton({config, value}: ProjectMapperNextButtonProps) {
   const {nextButton} = config;
-  if (!nextButton) {
+  const [nextUrl] = useQueryState('next', parseAsString);
+
+  if (!nextButton || !nextUrl) {
     return null;
   }
 
-  const nextUrlOrArray = safeGetQsParam('next');
-  let nextUrl = Array.isArray(nextUrlOrArray) ? nextUrlOrArray[0] : nextUrlOrArray;
-
-  if (nextUrl && !nextUrl.startsWith(nextButton.allowedDomain)) {
-    // eslint-disable-next-line no-console
-    console.warn(`Got unexpected next url: ${nextUrl}`);
-    nextUrl = undefined;
-  }
-
-  if (!nextUrl) {
+  if (!nextUrl.startsWith(nextButton.allowedDomain)) {
+    Sentry.captureMessage(`Got invalid next url: ${nextUrl}`);
     return null;
   }
 


### PR DESCRIPTION
Adds a missing "Next" button to our integration configuration pages, which appears to have been accidentally omitted in the ProjectMapper refactor in #110666


I've tested this using the Dev UI to ensure it completes installation as expected, and requires a single project mapping to be defined prior to allowing install.

## Screenshot during testing
<img width="1419" height="317" alt="Screenshot 2026-04-14 at 5 13 16 PM" src="https://github.com/user-attachments/assets/9b1f9306-1317-46fe-bc5d-758fcf5942a3" />


### Mobile Screenshot:
<img width="616" height="738" alt="image" src="https://github.com/user-attachments/assets/b88d6fa0-2476-4e1c-88a5-430b21ea7293" />

Resolves ISWF-2405
Resolves #112345
