### PR TITLE
feat(tracemetrics): Add PII scrubbing UI

### DIFF
--- a/static/app/views/explore/metrics/metricsFlags.tsx
+++ b/static/app/views/explore/metrics/metricsFlags.tsx
@@ -41,3 +41,10 @@ export const canUseMetricsEquations = (organization: Organization) => {
     organization.features.includes('tracemetrics-equations-in-explore')
   );
 };
+
+export const canUseMetricsPiiScrubbingUI = (organization: Organization) => {
+  return (
+    canUseMetricsUI(organization) &&
+    organization.features.includes('tracemetrics-pii-scrubbing-ui')
+  );
+};

--- a/static/app/views/settings/components/dataScrubbing/modals/dataScrubFormModal.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/dataScrubFormModal.tsx
@@ -23,6 +23,7 @@ import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {canUseMetricsPiiScrubbingUI} from 'sentry/views/explore/metrics/metricsFlags';
 import {submitRules} from 'sentry/views/settings/components/dataScrubbing/submitRules';
 import type {
   EditableRule,
@@ -97,6 +98,13 @@ export function DataScrubFormModal({
 }: DataScrubFormModalProps) {
   const organization = useOrganization();
   const traceItemDatasetsEnabled = areScrubbingDatasetsEnabled(organization);
+  const enabledDatasets = [AllowedDataScrubbingDatasets.DEFAULT];
+  if (organization.features.includes('ourlogs-enabled')) {
+    enabledDatasets.push(AllowedDataScrubbingDatasets.LOGS);
+  }
+  if (canUseMetricsPiiScrubbingUI(organization)) {
+    enabledDatasets.push(AllowedDataScrubbingDatasets.METRICS);
+  }
   const {sourceGroupData} = useSourceGroupData();
 
   // Compute initial dataset from initialState
@@ -250,7 +258,7 @@ export function DataScrubFormModal({
                     variant="compact"
                   >
                     <Flex gap="lg">
-                      {sortBy(Object.values(AllowedDataScrubbingDatasets)).map(value => (
+                      {sortBy(enabledDatasets).map(value => (
                         <field.Radio.Item key={value} value={value}>
                           {getDatasetLabelLong(value)}
                         </field.Radio.Item>

--- a/static/app/views/settings/components/dataScrubbing/modals/form/attributeField.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/attributeField.tsx
@@ -21,6 +21,20 @@ import {
 } from 'sentry/views/settings/components/dataScrubbing/types';
 import {TraceItemFieldSelector} from 'sentry/views/settings/components/dataScrubbing/utils';
 
+const datasetToTraceItemType: Record<
+  Exclude<AllowedDataScrubbingDatasets, AllowedDataScrubbingDatasets.DEFAULT>,
+  TraceItemDataset
+> = {
+  [AllowedDataScrubbingDatasets.LOGS]: TraceItemDataset.LOGS,
+  [AllowedDataScrubbingDatasets.METRICS]: TraceItemDataset.TRACEMETRICS,
+};
+
+const HIDDEN_SCRUBBING_ATTRIBUTES: Partial<
+  Record<AllowedDataScrubbingDatasets, Set<string>>
+> = {
+  [AllowedDataScrubbingDatasets.METRICS]: new Set(['metric.name']),
+};
+
 type FieldProps = {
   'aria-describedby': string;
   'aria-invalid': boolean;
@@ -52,10 +66,14 @@ export function AttributeField({
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [activeSuggestion, setActiveSuggestion] = useState(0);
 
+  const traceItemType =
+    dataset === AllowedDataScrubbingDatasets.DEFAULT
+      ? TraceItemDataset.LOGS
+      : datasetToTraceItemType[dataset];
   const traceItemAttributeStringsResult = useTraceItemAttributeKeys({
     enabled: true,
     type: 'string',
-    traceItemType: TraceItemDataset.LOGS,
+    traceItemType,
     projects: project ? [project] : undefined,
   });
   const [suggestedAttributeValues, setSuggestedAttributeValues] = useLocalStorageState(
@@ -100,16 +118,21 @@ export function AttributeField({
       return [];
     }
 
+    const hidden = HIDDEN_SCRUBBING_ATTRIBUTES[dataset];
+
     return [
       ...TraceItemFieldSelector.getAllStaticFields(dataset).map(staticField => ({
         value: staticField.fieldName,
         label: staticField.fieldName,
       })),
-      ...traceItemFields.map(field => ({
-        value: field.label,
-        label:
-          TraceItemFieldSelector.fromField(dataset, field.key)?.toLabel() ?? field.label,
-      })),
+      ...traceItemFields
+        .filter(field => !hidden?.has(field.key))
+        .map(field => ({
+          value: field.label,
+          label:
+            TraceItemFieldSelector.fromField(dataset, field.key)?.toLabel() ??
+            field.label,
+        })),
     ];
   }, [dataset, suggestedAttributeValues]);
 

--- a/static/app/views/settings/components/dataScrubbing/types.tsx
+++ b/static/app/views/settings/components/dataScrubbing/types.tsx
@@ -132,6 +132,8 @@ export enum AllowedDataScrubbingDatasets {
   DEFAULT = 'default',
   // This is the dataset that is used for data scrubbing. When this is selected, the user will be shown a trace item attribute picker.
   LOGS = 'logs',
+  // Trace metrics dataset. When selected, the user will be shown a trace item attribute picker for metrics.
+  METRICS = 'metrics',
 }
 
 export type PiiConfig =

--- a/static/app/views/settings/components/dataScrubbing/utils.tsx
+++ b/static/app/views/settings/components/dataScrubbing/utils.tsx
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/react';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {useTraceItemAttributeKeys} from 'sentry/views/explore/hooks/useTraceItemAttributeKeys';
+import {canUseMetricsPiiScrubbingUI} from 'sentry/views/explore/metrics/metricsFlags';
 
 import {
   AllowedDataScrubbingDatasets,
@@ -82,6 +83,7 @@ function getDatasetLabel(dataset: AllowedDataScrubbingDatasets) {
   const labelMap: Record<AllowedDataScrubbingDatasets, string> = {
     [AllowedDataScrubbingDatasets.DEFAULT]: t('Events'),
     [AllowedDataScrubbingDatasets.LOGS]: t('Logs'),
+    [AllowedDataScrubbingDatasets.METRICS]: t('Metrics'),
   };
   return labelMap[dataset];
 }
@@ -93,6 +95,7 @@ export function getDatasetLabelLong(dataset: AllowedDataScrubbingDatasets) {
   const labelMap: Record<AllowedDataScrubbingDatasets, string> = {
     [AllowedDataScrubbingDatasets.DEFAULT]: t('Errors, Transactions, Attachments'),
     [AllowedDataScrubbingDatasets.LOGS]: t('Logs'),
+    [AllowedDataScrubbingDatasets.METRICS]: t('Metrics'),
   };
   return labelMap[dataset];
 }
@@ -244,8 +247,10 @@ export function getRuleDescription(rule: Rule) {
  * This indicates whether the data scrubbing modal shows "dataset" selector, which can be used to select new datasets that only allow for TraceItem attribute scrubbing.
  */
 export function areScrubbingDatasetsEnabled(organization: Organization) {
-  // Currently only logs supports scrubbing datasets.
-  return organization.features.includes('ourlogs-enabled');
+  return (
+    organization.features.includes('ourlogs-enabled') ||
+    canUseMetricsPiiScrubbingUI(organization)
+  );
 }
 
 function getSourceLabel(rule: Rule) {
@@ -283,6 +288,11 @@ export class TraceItemFieldSelector {
         fieldName: 'message',
       },
     ],
+    [AllowedDataScrubbingDatasets.METRICS]: [
+      {
+        regex: /^\$metric\.attributes\.'([^']+)'\.value$/,
+      },
+    ],
     [AllowedDataScrubbingDatasets.DEFAULT]: [],
   };
 
@@ -291,6 +301,7 @@ export class TraceItemFieldSelector {
     string | null
   > = {
     [AllowedDataScrubbingDatasets.LOGS]: '$log',
+    [AllowedDataScrubbingDatasets.METRICS]: '$metric',
     [AllowedDataScrubbingDatasets.DEFAULT]: null,
   };
 
@@ -303,6 +314,9 @@ export class TraceItemFieldSelector {
         return '$log.body';
       }
       return `$log.attributes.'${alias}'.value`;
+    },
+    [AllowedDataScrubbingDatasets.METRICS]: (alias: string) => {
+      return `$metric.attributes.'${alias}'.value`;
     },
     [AllowedDataScrubbingDatasets.DEFAULT]: () => null,
   };
@@ -498,15 +512,15 @@ export class TraceItemFieldSelector {
           label: t('body'),
         },
       ],
+      [AllowedDataScrubbingDatasets.METRICS]: null,
       [AllowedDataScrubbingDatasets.DEFAULT]: null,
     };
-    if (
-      dataset === AllowedDataScrubbingDatasets.DEFAULT ||
-      !nonAttributeFields[dataset]
-    ) {
-      Sentry.captureException(
-        new Error('Non-attribute fields should not be used for event selectors')
-      );
+    if (!nonAttributeFields[dataset]) {
+      if (dataset === AllowedDataScrubbingDatasets.DEFAULT) {
+        Sentry.captureException(
+          new Error('Non-attribute fields should not be used for event selectors')
+        );
+      }
       return null;
     }
     return nonAttributeFields[dataset];

--- a/tests/js/fixtures/log.ts
+++ b/tests/js/fixtures/log.ts
@@ -424,11 +424,13 @@ export function createMockAttributeResults(empty = false): AttributeResults {
     return {
       [AllowedDataScrubbingDatasets.DEFAULT]: null,
       [AllowedDataScrubbingDatasets.LOGS]: mockTraceItemAttributeKeysEmptyResult,
+      [AllowedDataScrubbingDatasets.METRICS]: mockTraceItemAttributeKeysEmptyResult,
     };
   }
 
   return {
     [AllowedDataScrubbingDatasets.DEFAULT]: null,
     [AllowedDataScrubbingDatasets.LOGS]: mockTraceItemAttributeKeysResult,
+    [AllowedDataScrubbingDatasets.METRICS]: mockTraceItemAttributeKeysResult,
   };
 }


### PR DESCRIPTION
### Summary
Adds another dataset to the advanced pii scrubbing modal, also intreprets $metric rules as relating to the metric dataset. Similar restrictions as with logs apply. This is behind the `tracemetrics-pii-scrubbing-ui` flag.