### PR TITLE
perf(issues): Consolidate duplicate issue tags requests into one

### DIFF
--- a/static/app/views/issueDetails/groupTags/useGroupTags.tsx
+++ b/static/app/views/issueDetails/groupTags/useGroupTags.tsx
@@ -21,11 +21,6 @@ export interface GroupTag {
      * Example: user -> `'user.id:\"1\"'`
      */
     query?: string;
-    /**
-     * Available if `readable` query param is true
-     * @deprecated - Use the frontend to get readable device names
-     */
-    readable?: string;
   }>;
   totalValues: number;
 }
@@ -38,11 +33,6 @@ interface FetchIssueTagsParameters {
   groupId: string | undefined;
   orgSlug: string;
   limit?: number;
-  /**
-   * Readable formats mobile device names
-   * TODO(scott): Can we do this in the frontend instead
-   */
-  readable?: boolean;
 }
 
 type GroupTagUseQueryOptions = Partial<UseApiQueryOptions<GroupTag[]>>;
@@ -51,13 +41,12 @@ const makeGroupTagsQueryKey = ({
   groupId,
   orgSlug,
   environment,
-  readable,
   limit,
 }: FetchIssueTagsParameters): ApiQueryKey => [
   getApiUrl('/organizations/$organizationIdOrSlug/issues/$issueId/tags/', {
     path: {organizationIdOrSlug: orgSlug, issueId: groupId!},
   }),
-  {query: {environment, readable, limit}},
+  {query: {environment, limit}},
 ];
 
 export function useGroupTags(
@@ -76,21 +65,5 @@ export function useGroupTags(
       enabled: defined(parameters.groupId) && enabled,
       ...options,
     }
-  );
-}
-
-/**
- * Primarily used for tag facets
- */
-export function useGroupTagsReadable(
-  parameters: Omit<FetchIssueTagsParameters, 'orgSlug' | 'readable'>,
-  options: GroupTagUseQueryOptions = {}
-) {
-  return useGroupTags(
-    {
-      readable: true,
-      ...parameters,
-    },
-    options
   );
 }

--- a/static/app/views/issueDetails/streamline/issueTagsPreview.tsx
+++ b/static/app/views/issueDetails/streamline/issueTagsPreview.tsx
@@ -30,7 +30,7 @@ import {useMedia} from 'sentry/utils/useMedia';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {formatVersion} from 'sentry/utils/versions/formatVersion';
 import type {GroupTag} from 'sentry/views/issueDetails/groupTags/useGroupTags';
-import {useGroupTagsReadable} from 'sentry/views/issueDetails/groupTags/useGroupTags';
+import {useGroupTags} from 'sentry/views/issueDetails/groupTags/useGroupTags';
 import {useEventQuery} from 'sentry/views/issueDetails/streamline/hooks/useEventQuery';
 import {Tab, TabPaths} from 'sentry/views/issueDetails/types';
 import {useGroupDetailsRoute} from 'sentry/views/issueDetails/useGroupDetailsRoute';
@@ -253,7 +253,7 @@ export function IssueTagsPreview({
     isError,
     isPending,
     data: tags,
-  } = useGroupTagsReadable({
+  } = useGroupTags({
     groupId,
     environment: environments,
   });

--- a/static/app/views/issueDetails/utils.tsx
+++ b/static/app/views/issueDetails/utils.tsx
@@ -20,7 +20,7 @@ import type {ApiQueryKey} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
-import {useGroupTagsReadable} from 'sentry/views/issueDetails/groupTags/useGroupTags';
+import {useGroupTags} from 'sentry/views/issueDetails/groupTags/useGroupTags';
 
 export function markEventSeen(
   api: Client,
@@ -284,7 +284,7 @@ export function useIsSampleEvent(): boolean {
 
   const group = GroupStore.get(groupId);
 
-  const {data} = useGroupTagsReadable(
+  const {data} = useGroupTags(
     {
       groupId,
       environment: environments,


### PR DESCRIPTION
The issue details page was making two requests to the same `/issues/{id}/tags/` endpoint - one with `readable=true` (used by the tag facets preview and sample event check) and one without (used by the tag drawer and event search).

Neither caller actually used the `readable` field from the response.