### PR TITLE
feat(dashboards): Add endpoint to list dashboard revisions

### DIFF
--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -10,7 +10,7 @@ from django.db.models import prefetch_related_objects
 from sentry import features
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.discover.arithmetic import get_equation_alias_index, is_equation, is_equation_alias
-from sentry.models.dashboard import Dashboard, DashboardFavoriteUser
+from sentry.models.dashboard import Dashboard, DashboardFavoriteUser, DashboardRevision
 from sentry.models.dashboard_permissions import DashboardPermissions
 from sentry.models.dashboard_widget import (
     DashboardWidget,
@@ -694,3 +694,34 @@ class DashboardDetailsModelSerializer(Serializer, DashboardFiltersMixin):
         }
 
         return data
+
+
+class DashboardRevisionResponse(TypedDict):
+    id: str
+    title: str
+    dateCreated: datetime
+    createdBy: dict[str, Any] | None
+    source: str
+
+
+@register(DashboardRevision)
+class DashboardRevisionSerializer(Serializer):
+    def get_attrs(self, item_list, user, **kwargs):
+        user_ids = [r.created_by_id for r in item_list if r.created_by_id is not None]
+        users_by_id = {
+            u["id"]: {"id": u["id"], "name": u["name"], "email": u["email"]}
+            for u in user_service.serialize_many(filter={"user_ids": user_ids})
+        }
+        return {
+            revision: {"created_by": users_by_id.get(str(revision.created_by_id))}
+            for revision in item_list
+        }
+
+    def serialize(self, obj, attrs, user, **kwargs) -> DashboardRevisionResponse:
+        return {
+            "id": str(obj.id),
+            "title": obj.title,
+            "dateCreated": obj.date_added,
+            "createdBy": attrs.get("created_by"),
+            "source": obj.source,
+        }

--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -160,6 +160,9 @@ from sentry.dashboards.endpoints.organization_dashboard_details import (
 from sentry.dashboards.endpoints.organization_dashboard_generate import (
     OrganizationDashboardGenerateEndpoint,
 )
+from sentry.dashboards.endpoints.organization_dashboard_revisions import (
+    OrganizationDashboardRevisionsEndpoint,
+)
 from sentry.dashboards.endpoints.organization_dashboard_widget_details import (
     OrganizationDashboardWidgetDetailsEndpoint,
 )
@@ -1608,6 +1611,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/dashboards/(?P<dashboard_id>[^/]+)/favorite/$",
         OrganizationDashboardFavoriteEndpoint.as_view(),
         name="sentry-api-0-organization-dashboard-favorite",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/dashboards/(?P<dashboard_id>[^/]+)/revisions/$",
+        OrganizationDashboardRevisionsEndpoint.as_view(),
+        name="sentry-api-0-organization-dashboard-revisions",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/shortids/(?P<issue_id>[^/]+)/$",

--- a/src/sentry/dashboards/endpoints/organization_dashboard_revisions.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_revisions.py
@@ -10,12 +10,13 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.paginator import OffsetPaginator
-from sentry.dashboards.endpoints.organization_dashboard_details import OrganizationDashboardBase
+from sentry.dashboards.endpoints.organization_dashboard_details import (
+    REVISIONS_FEATURE,
+    OrganizationDashboardBase,
+)
 from sentry.models.dashboard import Dashboard, DashboardRevision
 from sentry.models.organization import Organization
 from sentry.users.services.user.service import user_service
-
-REVISIONS_FEATURE = "organizations:dashboards-revisions"
 
 
 def _serialize_revisions(revisions: list[DashboardRevision], user: Any) -> list[dict[str, Any]]:

--- a/src/sentry/dashboards/endpoints/organization_dashboard_revisions.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_revisions.py
@@ -19,11 +19,11 @@ from sentry.models.organization import Organization
 from sentry.users.services.user.service import user_service
 
 
-def _serialize_revisions(revisions: list[DashboardRevision], user: Any) -> list[dict[str, Any]]:
+def _serialize_revisions(revisions: list[DashboardRevision]) -> list[dict[str, Any]]:
     user_ids = [r.created_by_id for r in revisions if r.created_by_id is not None]
     users_by_id = {
         u["id"]: {"id": u["id"], "name": u["name"], "email": u["email"]}
-        for u in user_service.serialize_many(filter={"user_ids": user_ids}, as_user=user)
+        for u in user_service.serialize_many(filter={"user_ids": user_ids})
     }
     return [
         {
@@ -66,5 +66,5 @@ class OrganizationDashboardRevisionsEndpoint(OrganizationDashboardBase):
             queryset=queryset,
             order_by="-date_added",
             paginator_cls=OffsetPaginator,
-            on_results=lambda results: _serialize_revisions(results, request.user),
+            on_results=_serialize_revisions,
         )

--- a/src/sentry/dashboards/endpoints/organization_dashboard_revisions.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_revisions.py
@@ -26,7 +26,7 @@ class DashboardRevisionSerializer(Serializer):
         self, item_list: Sequence[DashboardRevision], user: Any, **kwargs: Any
     ) -> dict[DashboardRevision, dict[str, Any]]:
         serialized_users = {
-            u["id"]: u
+            u["id"]: {"id": u["id"], "name": u["name"], "email": u["email"]}
             for u in user_service.serialize_many(
                 filter={
                     "user_ids": [

--- a/src/sentry/dashboards/endpoints/organization_dashboard_revisions.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_revisions.py
@@ -9,7 +9,6 @@ from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
-from sentry.api.bases.organization import OrganizationPermission
 from sentry.api.paginator import OffsetPaginator
 from sentry.dashboards.endpoints.organization_dashboard_details import OrganizationDashboardBase
 from sentry.models.dashboard import Dashboard, DashboardRevision
@@ -43,7 +42,6 @@ class OrganizationDashboardRevisionsEndpoint(OrganizationDashboardBase):
         "GET": ApiPublishStatus.PRIVATE,
     }
     owner = ApiOwner.DASHBOARDS
-    permission_classes = (OrganizationPermission,)
 
     def get(
         self,

--- a/src/sentry/dashboards/endpoints/organization_dashboard_revisions.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_revisions.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import cell_silo_endpoint
+from sentry.api.bases.organization import OrganizationPermission
+from sentry.api.paginator import OffsetPaginator
+from sentry.api.serializers import Serializer, serialize
+from sentry.dashboards.endpoints.organization_dashboard_details import OrganizationDashboardBase
+from sentry.models.dashboard import Dashboard, DashboardRevision
+from sentry.models.organization import Organization
+from sentry.users.services.user.service import user_service
+
+REVISIONS_FEATURE = "organizations:dashboards-revisions"
+
+
+class DashboardRevisionSerializer(Serializer):
+    def get_attrs(
+        self, item_list: Sequence[DashboardRevision], user: Any, **kwargs: Any
+    ) -> dict[DashboardRevision, dict[str, Any]]:
+        serialized_users = {
+            u["id"]: u
+            for u in user_service.serialize_many(
+                filter={
+                    "user_ids": [
+                        rev.created_by_id for rev in item_list if rev.created_by_id is not None
+                    ]
+                },
+                as_user=user,
+            )
+        }
+        return {
+            rev: {"created_by": serialized_users.get(str(rev.created_by_id))} for rev in item_list
+        }
+
+    def serialize(
+        self, obj: DashboardRevision, attrs: dict[str, Any], user: Any, **kwargs: Any
+    ) -> dict[str, Any]:
+        return {
+            "id": str(obj.id),
+            "title": obj.title,
+            "dateCreated": obj.date_added,
+            "createdBy": attrs.get("created_by"),
+            "source": obj.source,
+        }
+
+
+@cell_silo_endpoint
+class OrganizationDashboardRevisionsEndpoint(OrganizationDashboardBase):
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+    }
+    owner = ApiOwner.DASHBOARDS
+    permission_classes = (OrganizationPermission,)
+
+    def get(
+        self,
+        request: Request,
+        organization: Organization,
+        dashboard: Dashboard | dict[str, Any],
+    ) -> Response:
+        """
+        Return the revision history for an organization's custom dashboard.
+        """
+        if not features.has(REVISIONS_FEATURE, organization, actor=request.user):
+            return Response(status=404)
+
+        if not isinstance(dashboard, Dashboard):
+            return Response(status=404)
+
+        queryset = DashboardRevision.objects.filter(dashboard=dashboard).order_by("-date_added")
+
+        return self.paginate(
+            request=request,
+            queryset=queryset,
+            order_by="-date_added",
+            paginator_cls=OffsetPaginator,
+            on_results=lambda results: serialize(
+                results, request.user, serializer=DashboardRevisionSerializer()
+            ),
+        )

--- a/src/sentry/dashboards/endpoints/organization_dashboard_revisions.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_revisions.py
@@ -10,31 +10,13 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.paginator import OffsetPaginator
+from sentry.api.serializers import serialize
 from sentry.dashboards.endpoints.organization_dashboard_details import (
     REVISIONS_FEATURE,
     OrganizationDashboardBase,
 )
 from sentry.models.dashboard import Dashboard, DashboardRevision
 from sentry.models.organization import Organization
-from sentry.users.services.user.service import user_service
-
-
-def _serialize_revisions(revisions: list[DashboardRevision]) -> list[dict[str, Any]]:
-    user_ids = [r.created_by_id for r in revisions if r.created_by_id is not None]
-    users_by_id = {
-        u["id"]: {"id": u["id"], "name": u["name"], "email": u["email"]}
-        for u in user_service.serialize_many(filter={"user_ids": user_ids})
-    }
-    return [
-        {
-            "id": str(r.id),
-            "title": r.title,
-            "dateCreated": r.date_added,
-            "createdBy": users_by_id.get(str(r.created_by_id)),
-            "source": r.source,
-        }
-        for r in revisions
-    ]
 
 
 @cell_silo_endpoint
@@ -66,5 +48,5 @@ class OrganizationDashboardRevisionsEndpoint(OrganizationDashboardBase):
             queryset=queryset,
             order_by="-date_added",
             paginator_cls=OffsetPaginator,
-            on_results=_serialize_revisions,
+            on_results=lambda x: serialize(x, request.user),
         )

--- a/src/sentry/dashboards/endpoints/organization_dashboard_revisions.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_revisions.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
 from typing import Any
 
 from rest_framework.request import Request
@@ -12,7 +11,6 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationPermission
 from sentry.api.paginator import OffsetPaginator
-from sentry.api.serializers import Serializer, serialize
 from sentry.dashboards.endpoints.organization_dashboard_details import OrganizationDashboardBase
 from sentry.models.dashboard import Dashboard, DashboardRevision
 from sentry.models.organization import Organization
@@ -21,35 +19,22 @@ from sentry.users.services.user.service import user_service
 REVISIONS_FEATURE = "organizations:dashboards-revisions"
 
 
-class DashboardRevisionSerializer(Serializer):
-    def get_attrs(
-        self, item_list: Sequence[DashboardRevision], user: Any, **kwargs: Any
-    ) -> dict[DashboardRevision, dict[str, Any]]:
-        serialized_users = {
-            u["id"]: {"id": u["id"], "name": u["name"], "email": u["email"]}
-            for u in user_service.serialize_many(
-                filter={
-                    "user_ids": [
-                        rev.created_by_id for rev in item_list if rev.created_by_id is not None
-                    ]
-                },
-                as_user=user,
-            )
+def _serialize_revisions(revisions: list[DashboardRevision], user: Any) -> list[dict[str, Any]]:
+    user_ids = [r.created_by_id for r in revisions if r.created_by_id is not None]
+    users_by_id = {
+        u["id"]: {"id": u["id"], "name": u["name"], "email": u["email"]}
+        for u in user_service.serialize_many(filter={"user_ids": user_ids}, as_user=user)
+    }
+    return [
+        {
+            "id": str(r.id),
+            "title": r.title,
+            "dateCreated": r.date_added,
+            "createdBy": users_by_id.get(str(r.created_by_id)),
+            "source": r.source,
         }
-        return {
-            rev: {"created_by": serialized_users.get(str(rev.created_by_id))} for rev in item_list
-        }
-
-    def serialize(
-        self, obj: DashboardRevision, attrs: dict[str, Any], user: Any, **kwargs: Any
-    ) -> dict[str, Any]:
-        return {
-            "id": str(obj.id),
-            "title": obj.title,
-            "dateCreated": obj.date_added,
-            "createdBy": attrs.get("created_by"),
-            "source": obj.source,
-        }
+        for r in revisions
+    ]
 
 
 @cell_silo_endpoint
@@ -82,7 +67,5 @@ class OrganizationDashboardRevisionsEndpoint(OrganizationDashboardBase):
             queryset=queryset,
             order_by="-date_added",
             paginator_cls=OffsetPaginator,
-            on_results=lambda results: serialize(
-                results, request.user, serializer=DashboardRevisionSerializer()
-            ),
+            on_results=lambda results: _serialize_revisions(results, request.user),
         )

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -218,6 +218,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/dashboards/'
   | '/organizations/$organizationIdOrSlug/dashboards/$dashboardId/'
   | '/organizations/$organizationIdOrSlug/dashboards/$dashboardId/favorite/'
+  | '/organizations/$organizationIdOrSlug/dashboards/$dashboardId/revisions/'
   | '/organizations/$organizationIdOrSlug/dashboards/$dashboardId/visit/'
   | '/organizations/$organizationIdOrSlug/dashboards/generate/'
   | '/organizations/$organizationIdOrSlug/dashboards/starred/'

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -4014,21 +4014,12 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
             assert response.data["widgets"][1]["queries"][0] == "Text widgets don't have queries"
 
     def test_put_creates_dashboard_revision_when_feature_enabled(self) -> None:
-        original_title = self.dashboard.title
         with self.feature("organizations:dashboards-revisions"):
             response = self.do_request(
                 "put", self.url(self.dashboard.id), data={"title": "Updated Title"}
             )
         assert response.status_code == 200, response.data
-
-        revisions = DashboardRevision.objects.filter(dashboard=self.dashboard)
-        assert revisions.count() == 1
-        revision = revisions.first()
-        assert revision is not None
-        assert revision.title == original_title
-        assert revision.snapshot["title"] == original_title
-        assert revision.snapshot_schema_version == 1
-        assert revision.created_by_id == self.user.id
+        assert DashboardRevision.objects.filter(dashboard=self.dashboard).count() == 1
 
     def test_put_does_not_create_revision_when_feature_disabled(self) -> None:
         response = self.do_request(
@@ -4048,28 +4039,6 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         # The dashboard itself was updated
         self.dashboard.refresh_from_db()
         assert self.dashboard.title == "New Title"
-
-    def test_put_deletes_revisions_beyond_retention_limit(self) -> None:
-        # Create 10 existing revisions
-        for i in range(10):
-            DashboardRevision.objects.create(
-                dashboard=self.dashboard,
-                created_by_id=self.user.id,
-                title=f"Revision {i}",
-                snapshot={},
-                snapshot_schema_version=1,
-            )
-
-        assert DashboardRevision.objects.filter(dashboard=self.dashboard).count() == 10
-
-        with self.feature("organizations:dashboards-revisions"):
-            response = self.do_request(
-                "put", self.url(self.dashboard.id), data={"title": "Updated Title"}
-            )
-        assert response.status_code == 200, response.data
-
-        # After creating the 11th revision, the oldest should be deleted to maintain 10
-        assert DashboardRevision.objects.filter(dashboard=self.dashboard).count() == 10
 
     def test_put_snapshot_includes_widgets_and_queries(self) -> None:
         with self.feature("organizations:dashboards-revisions"):

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -4014,12 +4014,21 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
             assert response.data["widgets"][1]["queries"][0] == "Text widgets don't have queries"
 
     def test_put_creates_dashboard_revision_when_feature_enabled(self) -> None:
+        original_title = self.dashboard.title
         with self.feature("organizations:dashboards-revisions"):
             response = self.do_request(
                 "put", self.url(self.dashboard.id), data={"title": "Updated Title"}
             )
         assert response.status_code == 200, response.data
-        assert DashboardRevision.objects.filter(dashboard=self.dashboard).count() == 1
+
+        revisions = DashboardRevision.objects.filter(dashboard=self.dashboard)
+        assert revisions.count() == 1
+        revision = revisions.first()
+        assert revision is not None
+        assert revision.title == original_title
+        assert revision.snapshot["title"] == original_title
+        assert revision.snapshot_schema_version == 1
+        assert revision.created_by_id == self.user.id
 
     def test_put_does_not_create_revision_when_feature_disabled(self) -> None:
         response = self.do_request(
@@ -4039,6 +4048,28 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         # The dashboard itself was updated
         self.dashboard.refresh_from_db()
         assert self.dashboard.title == "New Title"
+
+    def test_put_deletes_revisions_beyond_retention_limit(self) -> None:
+        # Create 10 existing revisions
+        for i in range(10):
+            DashboardRevision.objects.create(
+                dashboard=self.dashboard,
+                created_by_id=self.user.id,
+                title=f"Revision {i}",
+                snapshot={},
+                snapshot_schema_version=1,
+            )
+
+        assert DashboardRevision.objects.filter(dashboard=self.dashboard).count() == 10
+
+        with self.feature("organizations:dashboards-revisions"):
+            response = self.do_request(
+                "put", self.url(self.dashboard.id), data={"title": "Updated Title"}
+            )
+        assert response.status_code == 200, response.data
+
+        # After creating the 11th revision, the oldest should be deleted to maintain 10
+        assert DashboardRevision.objects.filter(dashboard=self.dashboard).count() == 10
 
     def test_put_snapshot_includes_widgets_and_queries(self) -> None:
         with self.feature("organizations:dashboards-revisions"):

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_revisions.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_revisions.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from django.urls import reverse
+
+from sentry.models.dashboard import Dashboard, DashboardRevision
+from sentry.testutils.cases import APITestCase
+
+
+class OrganizationDashboardRevisionsTestCase(APITestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(self.user)
+        self.dashboard = Dashboard.objects.create(
+            title="Dashboard 1",
+            created_by_id=self.user.id,
+            organization=self.organization,
+        )
+        self.url = reverse(
+            "sentry-api-0-organization-dashboard-revisions",
+            kwargs={
+                "organization_id_or_slug": self.organization.slug,
+                "dashboard_id": self.dashboard.id,
+            },
+        )
+
+    def _create_revision(self, title: str = "Dashboard 1") -> DashboardRevision:
+        return DashboardRevision.objects.create(
+            dashboard=self.dashboard,
+            created_by_id=self.user.id,
+            title=title,
+            source="edit",
+            snapshot={},
+            snapshot_schema_version=DashboardRevision.SNAPSHOT_SCHEMA_VERSION,
+        )
+
+
+class GetOrganizationDashboardRevisionsTest(OrganizationDashboardRevisionsTestCase):
+    def test_returns_404_without_feature_flag(self) -> None:
+        self._create_revision()
+        response = self.client.get(self.url)
+        assert response.status_code == 404
+
+    def test_returns_empty_list_when_no_revisions(self) -> None:
+        with self.feature("organizations:dashboards-revisions"):
+            response = self.client.get(self.url)
+
+        assert response.status_code == 200
+        assert response.data == []
+
+    def test_returns_revisions_with_expected_fields(self) -> None:
+        revision = self._create_revision()
+        with self.feature("organizations:dashboards-revisions"):
+            response = self.client.get(self.url)
+
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        data = response.data[0]
+        assert data["id"] == str(revision.id)
+        assert data["title"] == "Dashboard 1"
+        assert data["source"] == "edit"
+        assert data["createdBy"] is not None
+        assert data["createdBy"]["id"] == str(self.user.id)
+        assert "dateCreated" in data
+
+    def test_returns_revisions_newest_first(self) -> None:
+        first = self._create_revision(title="First")
+        second = self._create_revision(title="Second")
+
+        with self.feature("organizations:dashboards-revisions"):
+            response = self.client.get(self.url)
+
+        assert response.status_code == 200
+        assert len(response.data) == 2
+        assert response.data[0]["id"] == str(second.id)
+        assert response.data[1]["id"] == str(first.id)
+
+    def test_returns_404_for_prebuilt_dashboard(self) -> None:
+        prebuilt_url = reverse(
+            "sentry-api-0-organization-dashboard-revisions",
+            kwargs={
+                "organization_id_or_slug": self.organization.slug,
+                "dashboard_id": "default-overview",
+            },
+        )
+        with self.feature("organizations:dashboards-revisions"):
+            response = self.client.get(prebuilt_url)
+
+        assert response.status_code == 404
+
+    def test_returns_revisions_scoped_to_dashboard(self) -> None:
+        other_dashboard = Dashboard.objects.create(
+            title="Other Dashboard",
+            created_by_id=self.user.id,
+            organization=self.organization,
+        )
+        DashboardRevision.objects.create(
+            dashboard=other_dashboard,
+            created_by_id=self.user.id,
+            title="Other Dashboard",
+            source="edit",
+            snapshot={},
+            snapshot_schema_version=DashboardRevision.SNAPSHOT_SCHEMA_VERSION,
+        )
+        revision = self._create_revision()
+
+        with self.feature("organizations:dashboards-revisions"):
+            response = self.client.get(self.url)
+
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(revision.id)
+
+    def test_null_created_by_when_user_deleted(self) -> None:
+        DashboardRevision.objects.create(
+            dashboard=self.dashboard,
+            created_by_id=None,
+            title="Dashboard 1",
+            source="edit",
+            snapshot={},
+            snapshot_schema_version=DashboardRevision.SNAPSHOT_SCHEMA_VERSION,
+        )
+
+        with self.feature("organizations:dashboards-revisions"):
+            response = self.client.get(self.url)
+
+        assert response.status_code == 200
+        assert len(response.data) == 1
+        assert response.data[0]["createdBy"] is None

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_revisions.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_revisions.py
@@ -58,8 +58,11 @@ class GetOrganizationDashboardRevisionsTest(OrganizationDashboardRevisionsTestCa
         assert data["id"] == str(revision.id)
         assert data["title"] == "Dashboard 1"
         assert data["source"] == "edit"
-        assert data["createdBy"] is not None
-        assert data["createdBy"]["id"] == str(self.user.id)
+        assert data["createdBy"] == {
+            "id": str(self.user.id),
+            "name": self.user.get_display_name(),
+            "email": self.user.email,
+        }
         assert "dateCreated" in data
 
     def test_returns_revisions_newest_first(self) -> None:


### PR DESCRIPTION
Add a new endpoint for listing the revision history of a dashboard.

**Endpoint**: `GET /api/0/organizations/<org>/dashboards/<dashboard_id>/revisions/`

Each revision entry includes:
- `id` — revision ID
- `title` — dashboard title at the time of save
- `dateCreated` — when the revision was saved
- `createdBy` — slim user object (`id`, `name`, `email`)
- `source` — what triggered the save (e.g. `"edit"`)

The endpoint is gated behind the `organizations:dashboards-revisions` feature flag and returns 404 for prebuilt dashboards. Results are ordered newest-first and paginated. Up to 10 revisions are retained per dashboard (enforced at write time by the base branch).

This PR stacks on top of `skaasten/feat/dashboard-revision-snapshot-on-save`, which adds the `DashboardRevision` model and the snapshot-on-save logic.

Refs DAIN-1517