### PR TITLE
fix(issues): Skip duplicate issue attachments query when possible

### DIFF
--- a/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.spec.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.spec.tsx
@@ -84,7 +84,6 @@ describe('GroupEventAttachments', () => {
         query: {
           screenshot: '1',
           environment: [],
-          statsPeriod: '14d',
         },
       })
     );

--- a/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/groupEventAttachments.tsx
@@ -74,6 +74,9 @@ export function GroupEventAttachments({project, group}: GroupEventAttachmentsPro
 
   const {mutate: deleteAttachment} = useDeleteGroupEventAttachment();
 
+  const hasSetStatsPeriod =
+    location.query.statsPeriod || location.query.start || location.query.end;
+
   const handleDelete = (attachment: IssueAttachment) => {
     deleteAttachment({
       attachment,
@@ -83,10 +86,12 @@ export function GroupEventAttachments({project, group}: GroupEventAttachmentsPro
       orgSlug: organization.slug,
       cursor: location.query.cursor as string | undefined,
       environment: eventView.environment as string[],
-      start: eventView.start,
-      end: eventView.end,
-      statsPeriod: eventView.statsPeriod,
       eventQuery,
+      ...(hasSetStatsPeriod && {
+        start: eventView.start,
+        end: eventView.end,
+        statsPeriod: eventView.statsPeriod,
+      }),
     });
   };
 

--- a/static/app/views/issueDetails/groupEventAttachments/useGroupEventAttachments.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/useGroupEventAttachments.tsx
@@ -14,8 +14,9 @@ interface UseGroupEventAttachmentsOptions {
   group: Group;
   options?: {
     /**
-     * If true, the query will fetch all available attachments for the group, ignoring the
-     * current filters (for environment, date, query, etc).
+     * If true, fetches all attachments for the group without applying any
+     * filters (environment, date range, query). Used by the header badge to
+     * determine whether the issue has any attachments at all.
      */
     fetchAllAvailable?: boolean;
     placeholderData?: typeof keepPreviousData;
@@ -116,7 +117,18 @@ export function useGroupEventAttachments({
 
   const hasSetStatsPeriod =
     location.query.statsPeriod || location.query.start || location.query.end;
-  const fetchAllAvailable = options?.fetchAllAvailable;
+
+  const filterParams = options?.fetchAllAvailable
+    ? {}
+    : {
+        environment: eventView.environment as string[],
+        eventQuery,
+        ...(hasSetStatsPeriod && {
+          start: eventView.start,
+          end: eventView.end,
+          statsPeriod: eventView.statsPeriod,
+        }),
+      };
 
   const {data, isPending, isError, refetch} = useQuery({
     ...fetchGroupEventAttachmentsApiOptions({
@@ -124,13 +136,7 @@ export function useGroupEventAttachments({
       group,
       orgSlug: organization.slug,
       cursor: location.query.cursor as string | undefined,
-      // We only want to filter by date/query/environment if we're using the Streamlined UI
-      environment: fetchAllAvailable ? undefined : (eventView.environment as string[]),
-      start: fetchAllAvailable && !hasSetStatsPeriod ? undefined : eventView.start,
-      end: fetchAllAvailable && !hasSetStatsPeriod ? undefined : eventView.end,
-      statsPeriod:
-        fetchAllAvailable && !hasSetStatsPeriod ? undefined : eventView.statsPeriod,
-      eventQuery: fetchAllAvailable ? undefined : eventQuery,
+      ...filterParams,
     }),
     placeholderData: options?.placeholderData,
     select: selectJsonWithHeaders,


### PR DESCRIPTION
The attachments hook was always forwarding `eventView.statsPeriod` to the API even when no time filter was set by the user. Now the attachments badge (in the issue header) can use the same request when no query is required.