### PR TITLE
feat(tracemetrics): Disable filter actions on equations/results

### DIFF
--- a/static/app/views/discover/table/cellAction.tsx
+++ b/static/app/views/discover/table/cellAction.tsx
@@ -12,6 +12,7 @@ import {defined} from 'sentry/utils';
 import type {TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import {
   fieldAlignment,
+  isEquation,
   isEquationAlias,
   isRelativeSpanOperationBreakdownField,
 } from 'sentry/utils/discover/fields';
@@ -193,7 +194,7 @@ function makeCellActions({
   }
 
   // Do not render context menu buttons for the equation fields until we can query on them
-  if (isEquationAlias(column.name)) {
+  if (isEquationAlias(column.name) || isEquation(column.key as string)) {
     return null;
   }
 


### PR DESCRIPTION
We disable cell actions on equation aliases, this intent was also supposed to apply to equations because we've started moving away from the equation alias format. Disabling this prevents users trying to filter results in the filter bar because we don't have a way to represent them there either.