### PR TITLE
fix(tracemetrics): Allow sorting on all aggregate tab columns

### DIFF
--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
@@ -250,6 +250,7 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
           }
 
           const direction = sorts.find(s => s.field === field)?.kind;
+          const canSort = field !== TraceMetricKnownFieldKey.METRIC_NAME;
 
           function updateSort() {
             const kind = direction === 'desc' ? 'asc' : 'desc';
@@ -266,7 +267,7 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
               }
               isSticky={isLastColumn(i)}
               sort={direction}
-              handleSortClick={updateSort}
+              handleSortClick={canSort ? updateSort : undefined}
             >
               <Tooltip showOnlyOnOverflow title={label}>
                 {label}

--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
@@ -250,8 +250,6 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
           }
 
           const direction = sorts.find(s => s.field === field)?.kind;
-          const canSort =
-            displayColumns.find(column => column.key === field)?.isSortable !== false;
 
           function updateSort() {
             const kind = direction === 'desc' ? 'asc' : 'desc';
@@ -268,7 +266,7 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
               }
               isSticky={isLastColumn(i)}
               sort={direction}
-              handleSortClick={canSort ? updateSort : undefined}
+              handleSortClick={updateSort}
             >
               <Tooltip showOnlyOnOverflow title={label}>
                 {label}


### PR DESCRIPTION
There isn't anything in the aggregates tab columns that isn't sortable. I need to look into why these aren't automatically defined as sortable but for now this is a patch.