### PR TITLE
fix(tracemetrics): Disable recent searches until ready

### DIFF
--- a/static/app/views/explore/metrics/metricToolbar/filter.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/filter.tsx
@@ -156,9 +156,9 @@ export function Filter({traceMetric, skipTraceMetricFilter}: FilterProps) {
         searchSource: 'tracemetrics',
         namespace: traceMetric.name,
 
-        // Disable the recent searches when not using a trace metric filter because
-        // the recent searches for metrics need to be namespaced on the trace metric filter.
-        disableRecentSearches: skipTraceMetricFilter,
+        // Disable the recent searches when not using a trace metric filter or when the metric name
+        // is not set because the recent searches for metrics need to be namespaced on the trace metric filter.
+        disableRecentSearches: skipTraceMetricFilter || !traceMetric.name,
       };
     }, [
       query,


### PR DESCRIPTION
Fixes a bug where clicking into the search bar too early was showing all these weird namespaced tracemetrics results.