### PR TITLE
feat(vercel): Add API-driven pipeline backend for Vercel integration setup

### DIFF
--- a/src/sentry/api/endpoints/organization_pipeline.py
+++ b/src/sentry/api/endpoints/organization_pipeline.py
@@ -127,6 +127,7 @@ class OrganizationPipelineEndpoint(ControlSiloOrganizationEndpoint):
             return Response({"detail": "Pipeline does not support API mode."}, status=400)
 
         pipeline.set_api_mode()
+        pipeline.bind_state("user_id", request.user.id)
 
         metrics.incr(
             "integrations.pipeline_api.initialize",

--- a/src/sentry/identity/oauth2.py
+++ b/src/sentry/identity/oauth2.py
@@ -301,17 +301,27 @@ class OAuth2ApiStep:
     def get_serializer_cls(self) -> type:
         return OAuth2ApiSerializer
 
+    def extract_code(self, validated_data: dict[str, str], pipeline: Pipeline[Any, Any]) -> str:
+        """The authorization code to exchange for a token.
+
+        Defaults to the `code` relayed in the callback POST. Subclasses may
+        override to source it elsewhere -- e.g. preauthorized marketplace
+        installs that bind the code to pipeline state up front.
+        """
+        return validated_data["code"]
+
     def handle_post(
         self,
         validated_data: dict[str, str],
         pipeline: Pipeline[Any, Any],
         request: HttpRequest,
     ) -> PipelineStepResult:
-        code = validated_data["code"]
         state = validated_data["state"]
 
         if state != pipeline.signature:
             return PipelineStepResult.error(ERR_INVALID_STATE)
+
+        code = self.extract_code(validated_data, pipeline)
 
         try:
             data = self._exchange_token(code)

--- a/src/sentry/identity/vercel/provider.py
+++ b/src/sentry/identity/vercel/provider.py
@@ -8,6 +8,7 @@ class VercelIdentityProvider(OAuth2Provider):
     key = "vercel"
     name = "Vercel"
 
+    oauth_authorize_url = "https://vercel.com/oauth/authorize"
     # https://vercel.com/docs/integrations/reference#using-the-vercel-api/exchange-code-for-access-token
     oauth_access_token_url = "https://api.vercel.com/v2/oauth/access_token"
 

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -12,6 +12,7 @@ from rest_framework.serializers import ValidationError
 from sentry import options
 from sentry.constants import ObjectStatus
 from sentry.identity.pipeline import IdentityPipeline
+from sentry.identity.vercel.provider import VercelIdentityProvider
 from sentry.integrations.base import (
     FeatureDescription,
     IntegrationData,
@@ -24,7 +25,7 @@ from sentry.integrations.models.integration import Integration
 from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.services.integration import integration_service
 from sentry.organizations.services.organization.model import RpcOrganization
-from sentry.pipeline.views.base import PipelineView
+from sentry.pipeline.views.base import ApiPipelineSteps, PipelineView
 from sentry.pipeline.views.nested import NestedPipelineView
 from sentry.projects.services.project.model import RpcProject
 from sentry.projects.services.project_key import project_key_service
@@ -435,8 +436,22 @@ class VercelIntegrationProvider(IntegrationProvider):
     def get_pipeline_views(self) -> Sequence[PipelineView[IntegrationPipeline]]:
         return [self._identity_pipeline_view()]
 
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps[IntegrationPipeline]:
+        provider = VercelIdentityProvider(
+            redirect_url=absolute_uri(self.oauth_redirect_url),
+        )
+        return [
+            provider.make_oauth_api_step(bind_key="oauth_data"),
+        ]
+
     def build_integration(self, state: Mapping[str, Any]) -> IntegrationData:
-        data = state["identity"]["data"]
+        # TODO: legacy views write token data to state["identity"]["data"] via
+        # NestedPipelineView. API steps write directly to state["oauth_data"].
+        # Remove the legacy path once the old views are retired.
+        if "oauth_data" in state:
+            data = state["oauth_data"]
+        else:
+            data = state["identity"]["data"]
         access_token = data["access_token"]
         team_id = data.get("team_id")
         client = VercelClient(access_token, team_id)

--- a/src/sentry/integrations/vercel/integration.py
+++ b/src/sentry/integrations/vercel/integration.py
@@ -2,16 +2,21 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping, Sequence
-from typing import Any, Self, TypedDict
+from typing import Any, Self, TypedDict, cast
 from urllib.parse import urlencode
 
 import sentry_sdk
+from django.http.request import HttpRequest
 from django.utils.translation import gettext_lazy as _
+from rest_framework.fields import CharField
 from rest_framework.serializers import ValidationError
 
 from sentry import options
+from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
 from sentry.constants import ObjectStatus
+from sentry.identity.oauth2 import OAuth2ApiStep
 from sentry.identity.pipeline import IdentityPipeline
+from sentry.identity.vercel.provider import VercelIdentityProvider
 from sentry.integrations.base import (
     FeatureDescription,
     IntegrationData,
@@ -24,7 +29,8 @@ from sentry.integrations.models.integration import Integration
 from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.services.integration import integration_service
 from sentry.organizations.services.organization.model import RpcOrganization
-from sentry.pipeline.views.base import PipelineView
+from sentry.pipeline.base import Pipeline
+from sentry.pipeline.views.base import ApiPipelineSteps, PipelineView
 from sentry.pipeline.views.nested import NestedPipelineView
 from sentry.projects.services.project.model import RpcProject
 from sentry.projects.services.project_key import project_key_service
@@ -427,15 +433,51 @@ class VercelIntegration(IntegrationInstallation):
                 raise
 
 
+class VercelInitialDataSerializer(CamelSnakeSerializer):
+    """Initial pipeline data for marketplace-originated Vercel installs.
+
+    Vercel performs the OAuth grant on its side and redirects back to Sentry
+    with an authorization `code`. The frontend forwards it here so the pipeline
+    can exchange it for an access token without a second authorize round-trip.
+    """
+
+    code = CharField(required=True)
+
+
+class VercelAdvanceSerializer(CamelSnakeSerializer):
+    state = CharField(required=True)
+
+
+class VercelOAuthApiStep(OAuth2ApiStep):
+    """API-mode install step for Vercel.
+
+    Vercel installs are always initiated from the Vercel marketplace, which
+    performs the OAuth grant and forwards the authorization `code` as initialData
+    (bound to pipeline state). There is no authorize popup: the step signals the
+    frontend to auto-advance and reads the code back out of pipeline state to
+    exchange it, rather than opening an authorize URL and reading it from the
+    callback POST.
+    """
+
+    def get_step_data(self, pipeline: Pipeline[Any, Any], request: HttpRequest) -> dict[str, str]:
+        return {"state": pipeline.signature}
+
+    def get_serializer_cls(self) -> type:
+        return VercelAdvanceSerializer
+
+    def extract_code(self, validated_data: dict[str, str], pipeline: Pipeline[Any, Any]) -> str:
+        return cast(str, pipeline.fetch_state("code"))
+
+
 class VercelIntegrationProvider(IntegrationProvider):
     key = "vercel"
     name = "Vercel"
     can_add = False
+    can_add_externally = True
     can_disable = False
     metadata = metadata
     integration_cls = VercelIntegration
     features = frozenset([IntegrationFeatures.DEPLOYMENT])
-    oauth_redirect_url = "/extensions/vercel/configure/"
     # feature flag handler is in getsentry
     requires_feature_flag = True
 
@@ -444,14 +486,40 @@ class VercelIntegrationProvider(IntegrationProvider):
             bind_key="identity",
             provider_key=self.key,
             pipeline_cls=IdentityPipeline,
-            config={"redirect_url": absolute_uri(self.oauth_redirect_url)},
+            config={"redirect_url": absolute_uri("/extensions/vercel/configure/")},
         )
 
     def get_pipeline_views(self) -> Sequence[PipelineView[IntegrationPipeline]]:
         return [self._identity_pipeline_view()]
 
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps[IntegrationPipeline]:
+        provider = VercelIdentityProvider()
+        return [
+            VercelOAuthApiStep(
+                # No authorize popup: the marketplace already granted the code.
+                authorize_url="",
+                client_id=str(provider.get_oauth_client_id()),
+                client_secret=provider.get_oauth_client_secret(),
+                access_token_url=provider.get_oauth_access_token_url(),
+                scope="",
+                # The code is issued against the marketplace redirect URI, so the
+                # token exchange must send the same value back to Vercel.
+                redirect_url="/extensions/vercel/configure/",
+                bind_key="oauth_data",
+            ),
+        ]
+
+    def get_initial_data_serializer_cls(self) -> type[VercelInitialDataSerializer]:
+        return VercelInitialDataSerializer
+
     def build_integration(self, state: Mapping[str, Any]) -> IntegrationData:
-        data = state["identity"]["data"]
+        # TODO: legacy views write token data to state["identity"]["data"] via
+        # NestedPipelineView. API steps write directly to state["oauth_data"].
+        # Remove the legacy path once the old views are retired.
+        if "oauth_data" in state:
+            data = state["oauth_data"]
+        else:
+            data = state["identity"]["data"]
         access_token = data["access_token"]
         team_id = data.get("team_id")
         client = VercelClient(access_token, team_id)

--- a/src/sentry/pipeline/base.py
+++ b/src/sentry/pipeline/base.py
@@ -245,6 +245,14 @@ class Pipeline[M: Model, S: PipelineSessionStore](abc.ABC):
         return data if key is None else data.get(key)
 
     def fetch_state(self, key: str | None = None) -> Any | None:
+        # In API mode the pipeline drives its own steps and never runs the
+        # legacy nested views, so state always lives at the top level. Providers
+        # mid-migration may still expose a NestedPipelineView via
+        # get_pipeline_views() for the legacy flow; don't surface nested state
+        # for them here.
+        if self.is_api_mode:
+            return self._fetch_state(key)
+
         step_index = self.step_index
         if step_index >= len(self.pipeline_views):
             return self._fetch_state(key)

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest import mock
 from urllib.parse import parse_qs
 
 import orjson
 import pytest
 import responses
+from django.urls import reverse
 from rest_framework.serializers import ValidationError
 
 from sentry.constants import ObjectStatus
@@ -10,6 +15,7 @@ from sentry.deletions.models.scheduleddeletion import ScheduledDeletion
 from sentry.identity.vercel.provider import VercelIdentityProvider
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.vercel import VercelClient, VercelIntegrationProvider, metadata
 from sentry.models.project import Project
 from sentry.models.projectkey import ProjectKey, ProjectKeyStatus
@@ -20,7 +26,8 @@ from sentry.sentry_apps.models.sentry_app_installation_for_provider import (
 )
 from sentry.sentry_apps.models.sentry_app_installation_token import SentryAppInstallationToken
 from sentry.silo.base import SiloMode
-from sentry.testutils.cases import IntegrationTestCase, TestCase
+from sentry.testutils.cases import APITestCase, IntegrationTestCase, TestCase
+from sentry.testutils.helpers import with_feature
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 
@@ -516,6 +523,147 @@ class VercelIntegrationTest(IntegrationTestCase):
             VercelIntegrationProvider().post_install(
                 integration=integration, organization=org, extra={"user_id": None}
             )
+
+
+@control_silo_test
+@mock.patch.object(VercelIntegrationProvider, "can_add", True)
+class VercelApiPipelineTest(APITestCase):
+    endpoint = "sentry-api-0-organization-pipeline"
+    method = "post"
+
+    config_id = "my_config_id"
+    team_id = "my_team_id"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(self.user)
+
+    def tearDown(self) -> None:
+        responses.reset()
+        super().tearDown()
+
+    def _get_pipeline_url(self) -> str:
+        return reverse(
+            self.endpoint,
+            args=[self.organization.slug, IntegrationPipeline.pipeline_name],
+        )
+
+    def _initialize_pipeline(self) -> Any:
+        return self.client.post(
+            self._get_pipeline_url(),
+            data={"action": "initialize", "provider": "vercel"},
+            format="json",
+        )
+
+    def _advance_step(self, data: dict[str, Any]) -> Any:
+        return self.client.post(self._get_pipeline_url(), data=data, format="json")
+
+    def _get_pipeline_signature(self, resp: Any) -> str:
+        return resp.data["data"]["oauthUrl"].split("state=")[1].split("&")[0]
+
+    @responses.activate
+    @with_feature("organizations:integrations-vercel")
+    def test_initialize_pipeline(self) -> None:
+        resp = self._initialize_pipeline()
+        assert resp.status_code == 200
+        assert resp.data["step"] == "oauth_login"
+        assert resp.data["stepIndex"] == 0
+        assert resp.data["totalSteps"] == 1
+        assert resp.data["provider"] == "vercel"
+        oauth_url = resp.data["data"]["oauthUrl"]
+        assert "vercel.com/oauth/authorize" in oauth_url
+
+    @responses.activate
+    @with_feature("organizations:integrations-vercel")
+    def test_oauth_step_missing_code(self) -> None:
+        self._initialize_pipeline()
+        resp = self._advance_step({})
+        assert resp.status_code == 400
+
+    @responses.activate
+    @with_feature("organizations:integrations-vercel")
+    def test_full_pipeline_team_flow(self) -> None:
+        responses.add(
+            responses.POST,
+            VercelIdentityProvider.oauth_access_token_url,
+            json={
+                "access_token": "my_access_token",
+                "user_id": "my_user_id",
+                "installation_id": self.config_id,
+                "team_id": self.team_id,
+            },
+        )
+        responses.add(
+            responses.GET,
+            f"{VercelClient.base_url}{VercelClient.GET_TEAM_URL % self.team_id}?teamId={self.team_id}",
+            json={"name": "My Team Name", "slug": "my_team_slug"},
+        )
+        responses.add(
+            responses.GET,
+            f"{VercelClient.base_url}{VercelClient.GET_PROJECTS_URL}?limit={VercelClient.pagination_limit}&teamId={self.team_id}",
+            json={"projects": [], "pagination": {"count": 0, "next": None}},
+        )
+
+        resp = self._initialize_pipeline()
+        assert resp.data["step"] == "oauth_login"
+        pipeline_signature = self._get_pipeline_signature(resp)
+
+        resp = self._advance_step({"code": "oauth-code", "state": pipeline_signature})
+        assert resp.status_code == 200
+        assert resp.data["status"] == "complete"
+
+        integration = Integration.objects.get(provider="vercel")
+        assert integration.external_id == self.team_id
+        assert integration.name == "My Team Name"
+        assert integration.metadata["access_token"] == "my_access_token"
+        assert integration.metadata["installation_id"] == self.config_id
+        assert integration.metadata["installation_type"] == "team"
+        assert OrganizationIntegration.objects.filter(
+            organization_id=self.organization.id,
+            integration=integration,
+        ).exists()
+
+    @responses.activate
+    @with_feature("organizations:integrations-vercel")
+    def test_full_pipeline_user_flow(self) -> None:
+        responses.add(
+            responses.POST,
+            VercelIdentityProvider.oauth_access_token_url,
+            json={
+                "access_token": "my_access_token",
+                "user_id": "my_user_id",
+                "installation_id": self.config_id,
+            },
+        )
+        responses.add(
+            responses.GET,
+            f"{VercelClient.base_url}{VercelClient.GET_USER_URL}",
+            json={"user": {"name": "My Name", "username": "my_user_name"}},
+        )
+        responses.add(
+            responses.GET,
+            f"{VercelClient.base_url}{VercelClient.GET_PROJECTS_URL}?limit={VercelClient.pagination_limit}&",
+            json={"projects": [], "pagination": {"count": 0, "next": None}},
+        )
+
+        resp = self._initialize_pipeline()
+        assert resp.data["step"] == "oauth_login"
+        pipeline_signature = self._get_pipeline_signature(resp)
+
+        resp = self._advance_step({"code": "oauth-code", "state": pipeline_signature})
+        assert resp.status_code == 200
+        assert resp.data["status"] == "complete"
+
+        integration = Integration.objects.get(provider="vercel")
+        assert integration.external_id == "my_user_id"
+        assert integration.name == "My Name"
+        assert integration.metadata["access_token"] == "my_access_token"
+        assert integration.metadata["installation_id"] == self.config_id
+        assert integration.metadata["installation_type"] == "user"
+        assert OrganizationIntegration.objects.filter(
+            organization_id=self.organization.id,
+            integration=integration,
+        ).exists()
 
 
 class VercelIntegrationMetadataTest(TestCase):

--- a/tests/sentry/integrations/vercel/test_integration.py
+++ b/tests/sentry/integrations/vercel/test_integration.py
@@ -1,9 +1,13 @@
+from __future__ import annotations
+
+from typing import Any
 from unittest import mock
 from urllib.parse import parse_qs
 
 import orjson
 import pytest
 import responses
+from django.urls import reverse
 from rest_framework.serializers import ValidationError
 
 from sentry.constants import ObjectStatus
@@ -11,6 +15,7 @@ from sentry.deletions.models.scheduleddeletion import ScheduledDeletion
 from sentry.identity.vercel.provider import VercelIdentityProvider
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.vercel import VercelClient, VercelIntegrationProvider, metadata
 from sentry.models.project import Project
 from sentry.models.projectkey import ProjectKey, ProjectKeyStatus
@@ -21,7 +26,8 @@ from sentry.sentry_apps.models.sentry_app_installation_for_provider import (
 )
 from sentry.sentry_apps.models.sentry_app_installation_token import SentryAppInstallationToken
 from sentry.silo.base import SiloMode
-from sentry.testutils.cases import IntegrationTestCase, TestCase
+from sentry.testutils.cases import APITestCase, IntegrationTestCase, TestCase
+from sentry.testutils.helpers import with_feature
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
 
@@ -551,6 +557,156 @@ class VercelIntegrationTest(IntegrationTestCase):
             VercelIntegrationProvider().post_install(
                 integration=integration, organization=org, extra={"user_id": None}
             )
+
+
+@control_silo_test
+class VercelApiPipelineTest(APITestCase):
+    endpoint = "sentry-api-0-organization-pipeline"
+    method = "post"
+
+    config_id = "my_config_id"
+    team_id = "my_team_id"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(self.user)
+
+    def tearDown(self) -> None:
+        responses.reset()
+        super().tearDown()
+
+    def _get_pipeline_url(self) -> str:
+        return reverse(
+            self.endpoint,
+            args=[self.organization.slug, IntegrationPipeline.pipeline_name],
+        )
+
+    def _initialize_pipeline(self, code: str = "oauth-code") -> Any:
+        return self.client.post(
+            self._get_pipeline_url(),
+            data={
+                "action": "initialize",
+                "provider": "vercel",
+                "initialData": {"code": code},
+            },
+            format="json",
+        )
+
+    def _advance_step(self, data: dict[str, Any]) -> Any:
+        return self.client.post(self._get_pipeline_url(), data=data, format="json")
+
+    def _get_pipeline_signature(self, resp: Any) -> str:
+        return resp.data["data"]["state"]
+
+    @responses.activate
+    @with_feature("organizations:integrations-vercel")
+    def test_initialize_pipeline(self) -> None:
+        resp = self._initialize_pipeline()
+        assert resp.status_code == 200
+        assert resp.data["step"] == "oauth_login"
+        assert resp.data["stepIndex"] == 0
+        assert resp.data["totalSteps"] == 1
+        assert resp.data["provider"] == "vercel"
+        # The marketplace already granted the code, so the step signals the
+        # frontend to auto-advance -- no authorize popup, no code echoed out.
+        assert resp.data["data"]["state"]
+        assert "oauthUrl" not in resp.data["data"]
+        assert "code" not in resp.data["data"]
+
+    @responses.activate
+    @with_feature("organizations:integrations-vercel")
+    def test_initialize_requires_code(self) -> None:
+        resp = self.client.post(
+            self._get_pipeline_url(),
+            data={"action": "initialize", "provider": "vercel"},
+            format="json",
+        )
+        assert resp.status_code == 400
+
+    @responses.activate
+    @with_feature("organizations:integrations-vercel")
+    def test_full_pipeline_team_flow(self) -> None:
+        responses.add(
+            responses.POST,
+            VercelIdentityProvider.oauth_access_token_url,
+            json={
+                "access_token": "my_access_token",
+                "user_id": "my_user_id",
+                "installation_id": self.config_id,
+                "team_id": self.team_id,
+            },
+        )
+        responses.add(
+            responses.GET,
+            f"{VercelClient.base_url}{VercelClient.GET_TEAM_URL % self.team_id}?teamId={self.team_id}",
+            json={"name": "My Team Name", "slug": "my_team_slug"},
+        )
+        responses.add(
+            responses.GET,
+            f"{VercelClient.base_url}{VercelClient.GET_PROJECTS_URL}?limit={VercelClient.pagination_limit}&teamId={self.team_id}",
+            json={"projects": [], "pagination": {"count": 0, "next": None}},
+        )
+
+        resp = self._initialize_pipeline()
+        assert resp.data["step"] == "oauth_login"
+        pipeline_signature = self._get_pipeline_signature(resp)
+
+        resp = self._advance_step({"code": "oauth-code", "state": pipeline_signature})
+        assert resp.status_code == 200
+        assert resp.data["status"] == "complete"
+
+        integration = Integration.objects.get(provider="vercel")
+        assert integration.external_id == self.team_id
+        assert integration.name == "My Team Name"
+        assert integration.metadata["access_token"] == "my_access_token"
+        assert integration.metadata["installation_id"] == self.config_id
+        assert integration.metadata["installation_type"] == "team"
+        assert OrganizationIntegration.objects.filter(
+            organization_id=self.organization.id,
+            integration=integration,
+        ).exists()
+
+    @responses.activate
+    @with_feature("organizations:integrations-vercel")
+    def test_full_pipeline_user_flow(self) -> None:
+        responses.add(
+            responses.POST,
+            VercelIdentityProvider.oauth_access_token_url,
+            json={
+                "access_token": "my_access_token",
+                "user_id": "my_user_id",
+                "installation_id": self.config_id,
+            },
+        )
+        responses.add(
+            responses.GET,
+            f"{VercelClient.base_url}{VercelClient.GET_USER_URL}",
+            json={"user": {"name": "My Name", "username": "my_user_name"}},
+        )
+        responses.add(
+            responses.GET,
+            f"{VercelClient.base_url}{VercelClient.GET_PROJECTS_URL}?limit={VercelClient.pagination_limit}&",
+            json={"projects": [], "pagination": {"count": 0, "next": None}},
+        )
+
+        resp = self._initialize_pipeline()
+        assert resp.data["step"] == "oauth_login"
+        pipeline_signature = self._get_pipeline_signature(resp)
+
+        resp = self._advance_step({"code": "oauth-code", "state": pipeline_signature})
+        assert resp.status_code == 200
+        assert resp.data["status"] == "complete"
+
+        integration = Integration.objects.get(provider="vercel")
+        assert integration.external_id == "my_user_id"
+        assert integration.name == "My Name"
+        assert integration.metadata["access_token"] == "my_access_token"
+        assert integration.metadata["installation_id"] == self.config_id
+        assert integration.metadata["installation_type"] == "user"
+        assert OrganizationIntegration.objects.filter(
+            organization_id=self.organization.id,
+            integration=integration,
+        ).exists()
 
 
 class VercelIntegrationMetadataTest(TestCase):


### PR DESCRIPTION
Adds the API-driven install pipeline backend for Vercel, part of the integration pipeline migration ([VDY-32](https://linear.app/getsentry/issue/VDY-32)).

## Approach

Vercel installs are **always** initiated from the Vercel marketplace, which performs the OAuth grant on its side and redirects to Sentry with an authorization `code` (the legacy flow's identity provider only ever ran an `OAuth2CallbackView` — there's no authorize step). So this models Vercel on the **marketplace install pattern** (MS Teams, Discord App Directory), not the in-app OAuth popup pattern (Slack, GitHub): the frontend forwards the `code` as `initialData`, the step auto-advances, and exchanges it — no second authorize round-trip.

## What

- `OAuth2ApiStep` gains a small overridable `extract_code()` seam (default: read the `code` from the callback POST), so providers can reuse the generic token exchange while sourcing the code differently.
- `VercelOAuthApiStep` overrides `extract_code()` to read the code from pipeline state, returns only `state` from `get_step_data` (signals the frontend to auto-advance — no popup), and exchanges against the marketplace `redirect_uri` (`/extensions/vercel/configure/`), which is what the code was issued against.
- `VercelInitialDataSerializer` validates the forwarded `code`; the endpoint binds it to pipeline state on initialize.
- `build_integration()` reads the new `state["oauth_data"]`, falling back to the legacy `state["identity"]["data"]`; the legacy path is removed in the follow-up cleanup.
- Vercel keeps `can_add = False` and sets `can_add_externally = True` so the pipeline endpoint accepts the externally-initiated install. The endpoint binds `user_id` so `build_integration`/`post_install` can resolve the installing user.
- `Pipeline.fetch_state` reads top-level state directly in API mode. Vercel still exposes its legacy `NestedPipelineView` during the migration, but the nested views never run in API mode, so their state-surfacing shouldn't apply.

## Deploy note

Backend half; the frontend activation ships separately in #116625 (frontend and backend are not atomically deployed). The configure→`/link/` redirect that fully turns this on lands last, after the frontend is deployed, to avoid a redirect loop.

Ref [VDY-44](https://linear.app/getsentry/issue/VDY-44/vercel-api-driven-integration-setup)
