### PR TITLE
fix(insights): Fix empty txn summary when transaction.op is default

### DIFF
--- a/static/app/views/dashboards/datasetConfig/spans.tsx
+++ b/static/app/views/dashboards/datasetConfig/spans.tsx
@@ -474,12 +474,14 @@ function renderTransactionAsLinkable(data: EventData, baggage: RenderFunctionBag
 
   const filters = new MutableSearch('');
 
-  // Filters on the transaction summary page won't match the dashboard because transaction summary isn't on eap yet.
+  const isEap = organization.features.includes('performance-transaction-summary-eap');
   if (data[SpanFields.SPAN_OP]) {
-    filters.addFilterValue('transaction.op', data[SpanFields.SPAN_OP]);
+    filters.addFilterValue(
+      isEap ? SpanFields.SPAN_OP : SpanFields.TRANSACTION_OP,
+      data[SpanFields.SPAN_OP]
+    );
   }
   if (data[SpanFields.REQUEST_METHOD]) {
-    const isEap = organization.features.includes('performance-transaction-summary-eap');
     filters.addFilterValue(
       isEap ? 'request.method' : 'http.method',
       data[SpanFields.REQUEST_METHOD]

--- a/static/app/views/insights/pages/transactionCell.tsx
+++ b/static/app/views/insights/pages/transactionCell.tsx
@@ -8,6 +8,8 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
 import {OverflowEllipsisTextContainer} from 'sentry/views/insights/common/components/textAlign';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
+import {SpanFields} from 'sentry/views/insights/types';
+import {useTransactionSummaryEAP} from 'sentry/views/performance/eap/useTransactionSummaryEAP';
 import {generateTransactionSummaryRoute} from 'sentry/views/performance/transactionSummary/utils';
 
 interface Props {
@@ -21,12 +23,16 @@ export function TransactionCell({project, transaction, transactionMethod}: Props
   const organization = useOrganization();
   const location = useLocation();
   const {view} = useDomainViewFilters();
+  const isEAP = useTransactionSummaryEAP();
 
   const projectId = projects.projects.find(p => p.slug === project)?.id;
 
   const searchQuery = new MutableSearch('');
   if (transactionMethod) {
-    searchQuery.addFilterValue('transaction.op', transactionMethod);
+    searchQuery.addFilterValue(
+      isEAP ? SpanFields.SPAN_OP : SpanFields.TRANSACTION_OP,
+      transactionMethod
+    );
   }
 
   if (!transaction || !projectId) {


### PR DESCRIPTION
Relay [doesn't extract transaction ops when they have the default value of `default`](https://github.com/getsentry/relay/blob/ae5a27cb9c7571c821099e778ce921d3b908df77/relay-event-normalization/src/normalize/utils.rs#L158-L165). Since links into the transaction summary from insights include the transaction op as a filter, `transaction.op:default` was returning an empty screen.

Instead, use `span.op` when linking into transaction summary:
- `default` is populated here correctly, so the page works
- it's span first/span streaming compatible

This fixes both the Insights and Prebuilt Dashboard versions of the transaction link rendering (and removes an old comment calling out the `span.op`/`transaction.op` name discrepancy).