### PR TITLE
fix(stack-trace): Show <unknown> for frames with no filename

### DIFF
--- a/static/app/components/stackTrace/frame/frameHeader.tsx
+++ b/static/app/components/stackTrace/frame/frameHeader.tsx
@@ -141,8 +141,16 @@ function FrameLocation({
       <FrameLocationTooltip frame={frame} frameDisplayPath={frameDisplayPath}>
         <Path>
           <span>
-            <span>{frameDisplayPath}</span>
-            {frameLocationSuffix ? <span>{frameLocationSuffix}</span> : null}
+            {frameDisplayPath ? (
+              <span>{frameDisplayPath}</span>
+            ) : (
+              <Text as="span" variant="muted">
+                {t('<unknown>')}
+              </Text>
+            )}
+            {frameDisplayPath && frameLocationSuffix ? (
+              <span>{frameLocationSuffix}</span>
+            ) : null}
           </span>
         </Path>
       </FrameLocationTooltip>

--- a/static/app/components/stackTrace/stackTrace.spec.tsx
+++ b/static/app/components/stackTrace/stackTrace.spec.tsx
@@ -724,6 +724,37 @@ describe('Core StackTrace', () => {
     expect(screen.queryByText('MainActivity.java')).not.toBeInTheDocument();
   });
 
+  it('renders <unknown> with line number when frame has no filename or module', async () => {
+    const {event, stacktrace} = makeStackTraceData();
+    const frame = stacktrace.frames[stacktrace.frames.length - 1]!;
+
+    render(
+      <TestStackTraceProvider
+        event={event}
+        stacktrace={{
+          ...stacktrace,
+          frames: [
+            {
+              ...frame,
+              filename: null,
+              module: null,
+              absPath: null,
+              function: 'eval',
+              lineNo: 5,
+              colNo: 20,
+              inApp: true,
+            },
+          ],
+        }}
+      >
+        <StackTraceFrames frameContextComponent={FrameContent} />
+      </TestStackTraceProvider>
+    );
+
+    expect(await screen.findByText('<unknown>')).toBeInTheDocument();
+    expect(screen.queryByText(':5:20')).not.toBeInTheDocument();
+  });
+
   it('does not render line number when lineNo is zero', async () => {
     const {event, stacktrace} = makeStackTraceData();
     const frame = stacktrace.frames[stacktrace.frames.length - 1]!;

--- a/static/app/components/stackTrace/stackTrace.stories.tsx
+++ b/static/app/components/stackTrace/stackTrace.stories.tsx
@@ -1002,6 +1002,41 @@ export default Storybook.story('StackTrace', story => {
     );
   });
 
+  story('StackTraceProvider - No Filename', () => {
+    const event = makeEvent({platform: 'javascript', projectID: '1'});
+    const stacktrace: StacktraceWithFrames = {
+      framesOmitted: null,
+      hasSystemFrames: false,
+      registers: {},
+      frames: [
+        makeFrame({
+          filename: null,
+          module: null,
+          absPath: null,
+          function: 'eval',
+          lineNo: 5,
+          colNo: 20,
+          inApp: true,
+        }),
+      ],
+    };
+
+    return (
+      <Fragment>
+        <p>
+          Frames with no filename or module (e.g. browser <code>eval</code>) show a muted{' '}
+          <code>{'<unknown>'}</code> in the path slot.
+        </p>
+        <StoryStackTraceProvider event={event} stacktrace={stacktrace}>
+          <StackTraceFrames
+            frameContextComponent={FrameContent}
+            frameActionsComponent={StoryFrameActions}
+          />
+        </StoryStackTraceProvider>
+      </Fragment>
+    );
+  });
+
   story('StackTraceProvider - Raw Function and Package', () => {
     const {event, stacktrace} = makeRawFunctionAndPackageStackTraceData();
 


### PR DESCRIPTION
Tweaks a rare case where we have no filename in the new stack trace. Adds a story.

The old stack trace

<img width="452" height="143" alt="image" src="https://github.com/user-attachments/assets/301db57d-2073-43fd-93fc-7ca37dbb778a" />


before

<img width="358" height="104" alt="image" src="https://github.com/user-attachments/assets/081b4192-d3a5-43b5-ab1e-4a050b69f3b4" />


after

<img width="325" height="95" alt="image" src="https://github.com/user-attachments/assets/59e293e1-68b7-4197-94ed-d534c7de99fb" />
