### PR TITLE
fix(aci): Improve legacy model tracking

### DIFF
--- a/src/sentry/incidents/endpoints/bases.py
+++ b/src/sentry/incidents/endpoints/bases.py
@@ -14,6 +14,7 @@ from sentry.models.organization import Organization
 from sentry.workflow_engine.endpoints.utils.ids import to_valid_int_id
 from sentry.workflow_engine.models.alertrule_detector import AlertRuleDetector
 from sentry.workflow_engine.models.detector import Detector
+from sentry.workflow_engine.utils.legacy_metric_tracking import report_used_legacy_models
 
 
 class OrganizationAlertRuleBaseEndpoint(OrganizationEndpoint):
@@ -150,6 +151,7 @@ class WorkflowEngineProjectAlertRuleEndpoint(ProjectAlertRuleEndpoint):
 
             return args, kwargs
 
+        report_used_legacy_models()
         try:
             kwargs["alert_rule"] = AlertRule.objects.get(
                 projects=project, id=validated_alert_rule_id
@@ -203,6 +205,7 @@ class WorkflowEngineOrganizationAlertRuleEndpoint(OrganizationAlertRuleEndpoint)
 
             return args, kwargs
 
+        report_used_legacy_models()
         try:
             kwargs["alert_rule"] = AlertRule.objects.get(
                 organization=organization, id=validated_alert_rule_id

--- a/src/sentry/rules/history/endpoints/project_rule_group_history.py
+++ b/src/sentry/rules/history/endpoints/project_rule_group_history.py
@@ -23,6 +23,7 @@ from sentry.models.rule import Rule
 from sentry.rules.history import fetch_rule_groups_paginated
 from sentry.rules.history.base import RuleGroupHistory
 from sentry.workflow_engine.models.workflow import Workflow
+from sentry.workflow_engine.utils.legacy_metric_tracking import track_alert_endpoint_execution
 
 
 class RuleGroupHistoryResponse(TypedDict):
@@ -78,6 +79,7 @@ class ProjectRuleGroupHistoryIndexEndpoint(WorkflowEngineRuleEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
+    @track_alert_endpoint_execution("GET", "sentry-api-0-project-rule-group-history-index")
     def get(self, request: Request, project: Project, rule: Rule | Workflow) -> Response:
         per_page = self.get_per_page(request)
         cursor = self.get_cursor_from_request(request)

--- a/src/sentry/rules/history/endpoints/project_rule_stats.py
+++ b/src/sentry/rules/history/endpoints/project_rule_stats.py
@@ -20,6 +20,7 @@ from sentry.models.rule import Rule
 from sentry.rules.history import fetch_rule_hourly_stats
 from sentry.rules.history.base import TimeSeriesValue
 from sentry.workflow_engine.models.workflow import Workflow
+from sentry.workflow_engine.utils.legacy_metric_tracking import track_alert_endpoint_execution
 
 
 class TimeSeriesValueResponse(TypedDict):
@@ -61,6 +62,7 @@ class ProjectRuleStatsIndexEndpoint(WorkflowEngineRuleEndpoint):
             404: RESPONSE_NOT_FOUND,
         },
     )
+    @track_alert_endpoint_execution("GET", "sentry-api-0-project-rule-stats-index")
     def get(self, request: Request, project: Project, rule: Rule | Workflow) -> Response:
         """
         Note that results are returned in hourly buckets.


### PR DESCRIPTION
Our metric for tracking legacy model API use have a few holes, but I think this should close the biggest ones.
