### PR TITLE
fix(onboarding): scm onboarding reuse project on back-nav when nothing changed

### DIFF
--- a/static/app/views/onboarding/scmProjectDetails.spec.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.spec.tsx
@@ -375,6 +375,178 @@ describe('ScmProjectDetails', () => {
     expect(stored.projectDetailsForm.alertRuleConfig).toBeDefined();
   });
 
+  it('reuses existing project when nothing changed on back-nav', async () => {
+    const existingProject = ProjectFixture({
+      slug: 'javascript-nextjs',
+      name: 'javascript-nextjs',
+    });
+    ProjectsStore.loadInitialData([existingProject]);
+
+    const createRequest = MockApiClient.addMockResponse({
+      url: `/teams/${organization.slug}/${teamWithAccess.slug}/projects/`,
+      method: 'POST',
+      body: existingProject,
+    });
+
+    const onComplete = jest.fn();
+
+    render(
+      <ScmProjectDetails
+        onComplete={onComplete}
+        stepIndex={3}
+        genSkipOnboardingLink={() => null}
+      />,
+      {
+        organization,
+        additionalWrapper: makeOnboardingWrapper({
+          selectedPlatform: mockPlatform,
+          createdProjectSlug: existingProject.slug,
+          projectDetailsForm: {
+            projectName: 'javascript-nextjs',
+            teamSlug: teamWithAccess.slug,
+            alertRuleConfig: {
+              alertSetting: 0,
+              interval: '1m',
+              metric: 0,
+              threshold: '10',
+            },
+          },
+        }),
+      }
+    );
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Create project'}));
+
+    await waitFor(() => {
+      expect(onComplete).toHaveBeenCalled();
+    });
+    expect(createRequest).not.toHaveBeenCalled();
+  });
+
+  it('creates a new project when the user edits after restoring form state', async () => {
+    const existingProject = ProjectFixture({
+      slug: 'javascript-nextjs',
+      name: 'javascript-nextjs',
+    });
+    ProjectsStore.loadInitialData([existingProject]);
+
+    const createRequest = MockApiClient.addMockResponse({
+      url: `/teams/${organization.slug}/${teamWithAccess.slug}/projects/`,
+      method: 'POST',
+      body: ProjectFixture({slug: 'renamed-project', name: 'renamed-project'}),
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/`,
+      body: organization,
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/teams/`,
+      body: [teamWithAccess],
+    });
+
+    const onComplete = jest.fn();
+
+    render(
+      <ScmProjectDetails
+        onComplete={onComplete}
+        stepIndex={3}
+        genSkipOnboardingLink={() => null}
+      />,
+      {
+        organization,
+        additionalWrapper: makeOnboardingWrapper({
+          selectedPlatform: mockPlatform,
+          createdProjectSlug: existingProject.slug,
+          projectDetailsForm: {
+            projectName: 'javascript-nextjs',
+            teamSlug: teamWithAccess.slug,
+            alertRuleConfig: {
+              alertSetting: 0,
+              interval: '1m',
+              metric: 0,
+              threshold: '10',
+            },
+          },
+        }),
+      }
+    );
+
+    const input = await screen.findByPlaceholderText('project-name');
+    await userEvent.clear(input);
+    await userEvent.type(input, 'renamed-project');
+
+    await userEvent.click(screen.getByRole('button', {name: 'Create project'}));
+
+    await waitFor(() => {
+      expect(createRequest).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(onComplete).toHaveBeenCalled();
+    });
+  });
+
+  it('creates a new project when the stored project is missing from the store', async () => {
+    // ProjectsStore is empty (initialized in beforeEach), so a stale
+    // createdProjectSlug can't match and reuse is skipped.
+    const createRequest = MockApiClient.addMockResponse({
+      url: `/teams/${organization.slug}/${teamWithAccess.slug}/projects/`,
+      method: 'POST',
+      body: ProjectFixture({slug: 'javascript-nextjs', name: 'javascript-nextjs'}),
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/`,
+      body: organization,
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/teams/`,
+      body: [teamWithAccess],
+    });
+
+    const onComplete = jest.fn();
+
+    render(
+      <ScmProjectDetails
+        onComplete={onComplete}
+        stepIndex={3}
+        genSkipOnboardingLink={() => null}
+      />,
+      {
+        organization,
+        additionalWrapper: makeOnboardingWrapper({
+          selectedPlatform: mockPlatform,
+          createdProjectSlug: 'javascript-nextjs',
+          projectDetailsForm: {
+            projectName: 'javascript-nextjs',
+            teamSlug: teamWithAccess.slug,
+            alertRuleConfig: {
+              alertSetting: 0,
+              interval: '1m',
+              metric: 0,
+              threshold: '10',
+            },
+          },
+        }),
+      }
+    );
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Create project'}));
+
+    await waitFor(() => {
+      expect(createRequest).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(onComplete).toHaveBeenCalled();
+    });
+  });
+
   it('shows error message on project creation failure', async () => {
     const onComplete = jest.fn();
 

--- a/static/app/views/onboarding/scmProjectDetails.spec.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.spec.tsx
@@ -9,6 +9,7 @@ import {
   OnboardingContextProvider,
   type OnboardingSessionState,
 } from 'sentry/components/onboarding/onboardingContext';
+import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {TeamStore} from 'sentry/stores/teamStore';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import * as analytics from 'sentry/utils/analytics';
@@ -44,6 +45,7 @@ describe('ScmProjectDetails', () => {
   beforeEach(() => {
     sessionStorageWrapper.clear();
     TeamStore.loadInitialData([teamWithAccess]);
+    ProjectsStore.loadInitialData([]);
 
     // useCreateNotificationAction queries messaging integrations on mount
     MockApiClient.addMockResponse({

--- a/static/app/views/onboarding/scmProjectDetails.spec.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.spec.tsx
@@ -14,6 +14,7 @@ import {TeamStore} from 'sentry/stores/teamStore';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import * as analytics from 'sentry/utils/analytics';
 import {sessionStorageWrapper} from 'sentry/utils/sessionStorage';
+import {MetricValues, RuleAction} from 'sentry/views/projectInstall/issueAlertOptions';
 
 import {ScmProjectDetails} from './scmProjectDetails';
 
@@ -376,6 +377,7 @@ describe('ScmProjectDetails', () => {
   });
 
   it('reuses existing project when nothing changed on back-nav', async () => {
+    const trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
     const existingProject = ProjectFixture({
       slug: 'javascript-nextjs',
       name: 'javascript-nextjs',
@@ -405,9 +407,9 @@ describe('ScmProjectDetails', () => {
             projectName: 'javascript-nextjs',
             teamSlug: teamWithAccess.slug,
             alertRuleConfig: {
-              alertSetting: 0,
+              alertSetting: RuleAction.DEFAULT_ALERT,
               interval: '1m',
-              metric: 0,
+              metric: MetricValues.ERRORS,
               threshold: '10',
             },
           },
@@ -421,6 +423,10 @@ describe('ScmProjectDetails', () => {
       expect(onComplete).toHaveBeenCalled();
     });
     expect(createRequest).not.toHaveBeenCalled();
+    expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+      'onboarding.scm_project_details_create_succeeded',
+      expect.objectContaining({project_slug: existingProject.slug})
+    );
   });
 
   it('creates a new project when the user edits after restoring form state', async () => {
@@ -465,9 +471,9 @@ describe('ScmProjectDetails', () => {
             projectName: 'javascript-nextjs',
             teamSlug: teamWithAccess.slug,
             alertRuleConfig: {
-              alertSetting: 0,
+              alertSetting: RuleAction.DEFAULT_ALERT,
               interval: '1m',
-              metric: 0,
+              metric: MetricValues.ERRORS,
               threshold: '10',
             },
           },
@@ -527,9 +533,9 @@ describe('ScmProjectDetails', () => {
             projectName: 'javascript-nextjs',
             teamSlug: teamWithAccess.slug,
             alertRuleConfig: {
-              alertSetting: 0,
+              alertSetting: RuleAction.DEFAULT_ALERT,
               interval: '1m',
-              metric: 0,
+              metric: MetricValues.ERRORS,
               threshold: '10',
             },
           },

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -136,7 +136,11 @@ export function ScmProjectDetails({onComplete}: StepProps) {
     // User navigated back and clicked Create without changing anything; skip
     // to setup-docs without creating a duplicate. Any actual change abandons
     // the previous project and creates a new one, matching legacy onboarding.
-    if (projectStillExists && nothingChanged) {
+    if (projectStillExists && createdProjectSlug && nothingChanged) {
+      trackAnalytics('onboarding.scm_project_details_create_succeeded', {
+        organization,
+        project_slug: createdProjectSlug,
+      });
       onComplete(undefined, selectedFeatures ? {product: selectedFeatures} : undefined);
       return;
     }

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -16,6 +16,7 @@ import type {Team} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {slugify} from 'sentry/utils/slugify';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {useProjects} from 'sentry/utils/useProjects';
 import {useTeams} from 'sentry/utils/useTeams';
 import {
   DEFAULT_ISSUE_ALERT_OPTIONS_VALUES,
@@ -36,11 +37,13 @@ export function ScmProjectDetails({onComplete}: StepProps) {
   const {
     selectedPlatform,
     selectedFeatures,
+    createdProjectSlug,
     setCreatedProjectSlug,
     projectDetailsForm,
     setProjectDetailsForm,
   } = useOnboardingContext();
-  const {teams} = useTeams();
+  const {teams, fetching: isLoadingTeams} = useTeams();
+  const {projects, initiallyLoaded: projectsLoaded} = useProjects();
   const createProjectAndRules = useCreateProjectAndRules();
   useEffect(() => {
     trackAnalytics('onboarding.scm_project_details_step_viewed', {organization});
@@ -100,11 +103,28 @@ export function ScmProjectDetails({onComplete}: StepProps) {
     });
   }
 
+  // Block submission until teams and the projects store have loaded so the
+  // reuse check below can't be bypassed by a race.
   const canSubmit =
     projectNameResolved.length > 0 &&
     teamSlugResolved.length > 0 &&
     !!selectedPlatform &&
-    !createProjectAndRules.isPending;
+    !createProjectAndRules.isPending &&
+    !isLoadingTeams &&
+    projectsLoaded;
+
+  const projectStillExists =
+    !!createdProjectSlug && projects.some(p => p.slug === createdProjectSlug);
+
+  const savedAlert = projectDetailsForm?.alertRuleConfig;
+  const nothingChanged =
+    !!projectDetailsForm &&
+    projectNameResolved === projectDetailsForm.projectName &&
+    teamSlugResolved === projectDetailsForm.teamSlug &&
+    alertRuleConfig.alertSetting === savedAlert?.alertSetting &&
+    alertRuleConfig.interval === savedAlert?.interval &&
+    alertRuleConfig.metric === savedAlert?.metric &&
+    alertRuleConfig.threshold === savedAlert?.threshold;
 
   async function handleCreateProject() {
     if (!selectedPlatform || !canSubmit) {
@@ -112,6 +132,14 @@ export function ScmProjectDetails({onComplete}: StepProps) {
     }
 
     trackAnalytics('onboarding.scm_project_details_create_clicked', {organization});
+
+    // User navigated back and clicked Create without changing anything; skip
+    // to setup-docs without creating a duplicate. Any actual change abandons
+    // the previous project and creates a new one, matching legacy onboarding.
+    if (projectStillExists && nothingChanged) {
+      onComplete(undefined, selectedFeatures ? {product: selectedFeatures} : undefined);
+      return;
+    }
 
     try {
       const {project} = await createProjectAndRules.mutateAsync({

--- a/static/app/views/projectInstall/issueAlertOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertOptions.tsx
@@ -13,7 +13,7 @@ import {
   type IssueAlertNotificationProps,
 } from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 
-enum MetricValues {
+export enum MetricValues {
   ERRORS = 0,
   USERS = 1,
 }

--- a/tests/acceptance/test_scm_onboarding.py
+++ b/tests/acceptance/test_scm_onboarding.py
@@ -491,7 +491,10 @@ class ScmOnboardingTest(AcceptanceTestCase):
 
             # Switch alerts from "High priority issues" to "create later".
             self.browser.click(
-                xpath='//div[@role="radio"][contains(., "create my own alerts later")]'
+                xpath='//button[@role="radio"][contains(., "create my own alerts later")]'
+            )
+            self.browser.wait_until(
+                xpath='//button[@role="radio"][@aria-checked="true"][contains(., "create my own alerts later")]'
             )
             self.browser.wait_until_clickable(xpath='//button[contains(., "Create project")]')
             self.browser.click(xpath='//button[contains(., "Create project")]')

--- a/tests/acceptance/test_scm_onboarding.py
+++ b/tests/acceptance/test_scm_onboarding.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from unittest import mock
 
 import pytest
@@ -42,6 +43,29 @@ class ScmOnboardingTest(AcceptanceTestCase):
         self.browser.wait_until('[data-test-id="onboarding-step-welcome"]')
         self.browser.click('[data-test-id="onboarding-welcome-start"]')
         self.browser.wait_until('[data-test-id="onboarding-step-scm-connect"]')
+
+    @contextmanager
+    def projects_born_active(self):
+        """Mark newly-created Projects as active so useRecentCreatedProject sees
+        isProjectActive=true on the first render of setup-docs.
+
+        Without this, tests must write first_event after setup-docs mounts, then
+        wait for the hook's 1s poll to observe it — racing the test's click on
+        Back. Mutating the returned instance lets ProjectSummarySerializer
+        surface firstEvent in the create response, so the frontend never sees
+        the inactive state.
+        """
+        original_create = Project.objects.create
+
+        def create_active(*args, **kwargs):
+            project = original_create(*args, **kwargs)
+            now = timezone.now()
+            Project.objects.filter(id=project.id).update(first_event=now)
+            project.first_event = now
+            return project
+
+        with mock.patch.object(Project.objects, "create", side_effect=create_active):
+            yield
 
     def skip_to_setup_docs(self, platform_search: str, platform_label: str) -> None:
         """Drive through the skip flow to setup-docs: skip connect → pick platform → create project."""
@@ -448,7 +472,10 @@ class ScmOnboardingTest(AcceptanceTestCase):
 
     def test_scm_back_from_setup_docs_active_project_no_changes(self) -> None:
         """Active project survives back-nav; clicking Create again reuses it (no duplicate)."""
-        with self.feature({"organizations:onboarding-scm-experiment": True}):
+        with (
+            self.feature({"organizations:onboarding-scm-experiment": True}),
+            self.projects_born_active(),
+        ):
             self.start_onboarding()
             self.skip_to_setup_docs("React", "React")
 
@@ -456,10 +483,7 @@ class ScmOnboardingTest(AcceptanceTestCase):
             project = Project.objects.get(organization=self.org)
             assert Rule.objects.filter(project=project).count() == 1
 
-            # Mark the project as active (received a first event).
-            Project.objects.filter(id=project.id).update(first_event=timezone.now())
-
-            # Navigate back — project is active, so useBackActions does NOT delete it.
+            # Project is active, so useBackActions does NOT delete it on back-nav.
             self.browser.click('[aria-label="Back"]')
             self.browser.wait_until('[data-test-id="onboarding-step-scm-project-details"]')
             self.browser.wait_until_clickable(xpath='//button[contains(., "Create project")]')
@@ -475,16 +499,16 @@ class ScmOnboardingTest(AcceptanceTestCase):
 
     def test_scm_back_from_setup_docs_active_project_alert_changed(self) -> None:
         """Changing the alert setting abandons the active project and creates a new one."""
-        with self.feature({"organizations:onboarding-scm-experiment": True}):
+        with (
+            self.feature({"organizations:onboarding-scm-experiment": True}),
+            self.projects_born_active(),
+        ):
             self.start_onboarding()
             self.skip_to_setup_docs("React", "React")
 
             self.browser.wait_until(xpath='//h2[text()="Configure React SDK"]')
             project1 = Project.objects.get(organization=self.org)
             assert Rule.objects.filter(project=project1).count() == 1
-
-            # Mark active so useBackActions preserves it on back-nav.
-            Project.objects.filter(id=project1.id).update(first_event=timezone.now())
 
             self.browser.click('[aria-label="Back"]')
             self.browser.wait_until('[data-test-id="onboarding-step-scm-project-details"]')
@@ -512,14 +536,15 @@ class ScmOnboardingTest(AcceptanceTestCase):
 
     def test_scm_back_from_setup_docs_active_project_platform_changed(self) -> None:
         """Active project survives back-nav; changing platform creates a new project."""
-        with self.feature({"organizations:onboarding-scm-experiment": True}):
+        with (
+            self.feature({"organizations:onboarding-scm-experiment": True}),
+            self.projects_born_active(),
+        ):
             self.start_onboarding()
             self.skip_to_setup_docs("React", "React")
 
             self.browser.wait_until(xpath='//h2[text()="Configure React SDK"]')
             project1 = Project.objects.get(organization=self.org)
-
-            Project.objects.filter(id=project1.id).update(first_event=timezone.now())
 
             # Navigate all the way back to platform selection and pick a different one.
             self.browser.click('[aria-label="Back"]')

--- a/tests/acceptance/test_scm_onboarding.py
+++ b/tests/acceptance/test_scm_onboarding.py
@@ -1,10 +1,12 @@
 from unittest import mock
 
 import pytest
+from django.utils import timezone
 
 from sentry.integrations.github.integration import GitHubOAuthLoginResult
 from sentry.integrations.models.integration import Integration
 from sentry.models.project import Project
+from sentry.models.rule import Rule
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.testutils.asserts import assert_existing_projects_status
 from sentry.testutils.cases import AcceptanceTestCase
@@ -40,6 +42,26 @@ class ScmOnboardingTest(AcceptanceTestCase):
         self.browser.wait_until('[data-test-id="onboarding-step-welcome"]')
         self.browser.click('[data-test-id="onboarding-welcome-start"]')
         self.browser.wait_until('[data-test-id="onboarding-step-scm-connect"]')
+
+    def skip_to_setup_docs(self, platform_search: str, platform_label: str) -> None:
+        """Drive through the skip flow to setup-docs: skip connect → pick platform → create project."""
+        self.browser.click(xpath='//button[contains(., "Skip for now")]')
+
+        self.browser.wait_until('[data-test-id="onboarding-step-scm-platform-features"]')
+        self.browser.wait_until(xpath='//h3[text()="Select a platform"]')
+        input_el = self.browser.element('input[aria-autocomplete="list"]')
+        input_el.send_keys(platform_search)
+        self.browser.wait_until(
+            xpath=f'//p[@data-test-id="menu-list-item-label"][text()="{platform_label}"]'
+        )
+        self.browser.click(
+            xpath=f'//p[@data-test-id="menu-list-item-label"][text()="{platform_label}"]'
+        )
+        self.browser.click(xpath='//button[contains(., "Continue")]')
+
+        self.browser.wait_until('[data-test-id="onboarding-step-scm-project-details"]')
+        self.browser.wait_until_clickable(xpath='//button[contains(., "Create project")]')
+        self.browser.click(xpath='//button[contains(., "Create project")]')
 
     def test_scm_onboarding_happy_path(self) -> None:
         """Full flow: welcome → connect repo → detected platform → create project."""
@@ -398,3 +420,126 @@ class ScmOnboardingTest(AcceptanceTestCase):
             input_el = self.browser.element('input[aria-autocomplete="list"]')
             input_el.send_keys("nonexistent-repo")
             self.browser.wait_until(xpath='//*[contains(text(), "No repositories found")]')
+
+    def test_scm_back_from_setup_docs_non_active_project(self) -> None:
+        """Non-active project is deleted on back-nav; re-creating produces a fresh project."""
+        with self.feature({"organizations:onboarding-scm-experiment": True}):
+            self.start_onboarding()
+            self.skip_to_setup_docs("React", "React")
+
+            self.browser.wait_until(xpath='//h2[text()="Configure React SDK"]')
+            project1 = Project.objects.get(organization=self.org)
+            assert project1.platform == "javascript-react"
+
+            # Navigate back — project has no events, so useBackActions deletes it.
+            self.browser.click('[aria-label="Back"]')
+            self.browser.wait_until('[data-test-id="onboarding-step-scm-project-details"]')
+            self.browser.wait_until_clickable(xpath='//button[contains(., "Create project")]')
+            self.browser.click(xpath='//button[contains(., "Create project")]')
+
+            self.browser.wait_until(xpath='//h2[text()="Configure React SDK"]')
+            project2 = Project.objects.get(organization=self.org, slug="javascript-react", status=0)
+            assert project2.id != project1.id
+            assert_existing_projects_status(
+                self.org,
+                active_project_ids=[project2.id],
+                deleted_project_ids=[project1.id],
+            )
+
+    def test_scm_back_from_setup_docs_active_project_no_changes(self) -> None:
+        """Active project survives back-nav; clicking Create again reuses it (no duplicate)."""
+        with self.feature({"organizations:onboarding-scm-experiment": True}):
+            self.start_onboarding()
+            self.skip_to_setup_docs("React", "React")
+
+            self.browser.wait_until(xpath='//h2[text()="Configure React SDK"]')
+            project = Project.objects.get(organization=self.org)
+            assert Rule.objects.filter(project=project).count() == 1
+
+            # Mark the project as active (received a first event).
+            Project.objects.filter(id=project.id).update(first_event=timezone.now())
+
+            # Navigate back — project is active, so useBackActions does NOT delete it.
+            self.browser.click('[aria-label="Back"]')
+            self.browser.wait_until('[data-test-id="onboarding-step-scm-project-details"]')
+            self.browser.wait_until_clickable(xpath='//button[contains(., "Create project")]')
+            self.browser.click(xpath='//button[contains(., "Create project")]')
+
+            # Reuse fast-path: same project, same rule.
+            self.browser.wait_until(xpath='//h2[text()="Configure React SDK"]')
+            assert Project.objects.filter(organization=self.org, status=0).count() == 1
+            assert_existing_projects_status(
+                self.org, active_project_ids=[project.id], deleted_project_ids=[]
+            )
+            assert Rule.objects.filter(project=project).count() == 1
+
+    def test_scm_back_from_setup_docs_active_project_alert_changed(self) -> None:
+        """Changing the alert setting abandons the active project and creates a new one."""
+        with self.feature({"organizations:onboarding-scm-experiment": True}):
+            self.start_onboarding()
+            self.skip_to_setup_docs("React", "React")
+
+            self.browser.wait_until(xpath='//h2[text()="Configure React SDK"]')
+            project1 = Project.objects.get(organization=self.org)
+            assert Rule.objects.filter(project=project1).count() == 1
+
+            # Mark active so useBackActions preserves it on back-nav.
+            Project.objects.filter(id=project1.id).update(first_event=timezone.now())
+
+            self.browser.click('[aria-label="Back"]')
+            self.browser.wait_until('[data-test-id="onboarding-step-scm-project-details"]')
+
+            # Switch alerts from "High priority issues" to "create later".
+            self.browser.click(
+                xpath='//div[@role="radio"][contains(., "create my own alerts later")]'
+            )
+            self.browser.wait_until_clickable(xpath='//button[contains(., "Create project")]')
+            self.browser.click(xpath='//button[contains(., "Create project")]')
+
+            # New project is created with a suffixed slug; the old project is kept.
+            self.browser.wait_until(xpath='//h2[text()="Configure React SDK"]')
+            active = Project.objects.filter(organization=self.org, status=0).order_by("id")
+            assert active.count() == 2
+            project2 = active.last()
+            assert project2.id != project1.id
+            assert project2.platform == "javascript-react"
+            # "create later" → no alert rule on the new project; old rule survives.
+            assert Rule.objects.filter(project=project2).count() == 0
+            assert Rule.objects.filter(project=project1).count() == 1
+
+    def test_scm_back_from_setup_docs_active_project_platform_changed(self) -> None:
+        """Active project survives back-nav; changing platform creates a new project."""
+        with self.feature({"organizations:onboarding-scm-experiment": True}):
+            self.start_onboarding()
+            self.skip_to_setup_docs("React", "React")
+
+            self.browser.wait_until(xpath='//h2[text()="Configure React SDK"]')
+            project1 = Project.objects.get(organization=self.org)
+
+            Project.objects.filter(id=project1.id).update(first_event=timezone.now())
+
+            # Navigate all the way back to platform selection and pick a different one.
+            self.browser.click('[aria-label="Back"]')
+            self.browser.wait_until('[data-test-id="onboarding-step-scm-project-details"]')
+            self.browser.click('[aria-label="Back"]')
+            self.browser.wait_until('[data-test-id="onboarding-step-scm-platform-features"]')
+            self.browser.wait_until(xpath='//h3[text()="Select a platform"]')
+            input_el = self.browser.element('input[aria-autocomplete="list"]')
+            input_el.send_keys("Vue")
+            self.browser.wait_until(xpath='//p[@data-test-id="menu-list-item-label"][text()="Vue"]')
+            self.browser.click(xpath='//p[@data-test-id="menu-list-item-label"][text()="Vue"]')
+            self.browser.click(xpath='//button[contains(., "Continue")]')
+
+            self.browser.wait_until('[data-test-id="onboarding-step-scm-project-details"]')
+            self.browser.wait_until_clickable(xpath='//button[contains(., "Create project")]')
+            self.browser.click(xpath='//button[contains(., "Create project")]')
+
+            self.browser.wait_until(xpath='//h2[text()="Configure Vue SDK"]')
+            project2 = Project.objects.get(organization=self.org, platform="javascript-vue")
+            assert project2.id != project1.id
+            assert_existing_projects_status(
+                self.org,
+                active_project_ids=[project1.id, project2.id],
+                deleted_project_ids=[],
+            )
+            assert Rule.objects.filter(project=project2).count() == 1


### PR DESCRIPTION
When a user reaches setup-docs, navigates back to project details, and clicks Create without editing anything, skip straight to setup-docs instead of creating a duplicate. Any actual change (name, team, alert config, or platform) abandons the previous project and creates a new one, matching legacy onboarding. Server-side slug generation appends a random suffix on collision, so repeated names don't block creation.

The abandoned-project outcome is expected to be rare: `useBackActions` deletes any project that has not yet received an event when the user navigates back from setup-docs. A project only survives to be abandoned if the user has already triggered an event on it and then returns to change settings.

Also guard the Create button against teams and projects still loading so the reuse check cannot be bypassed by a race.

**PR stack:**
- [PR 1](https://github.com/getsentry/sentry/pull/113128): Context refactor -- persist form state (merged)
- **PR 2 (this):** Reuse project on no-change back-nav
- [PR 3](https://github.com/getsentry/sentry/pull/113112): VDY-82 feature flag gating