### PR TITLE
feat(onboarding): Gate SCM_PROJECT_DETAILS step with feature flag

### DIFF
--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -630,7 +630,10 @@ describe('Onboarding', () => {
 
   describe('SCM onboarding flow', () => {
     const scmOrganization = OrganizationFixture({
-      features: ['onboarding-scm-experiment'],
+      features: [
+        'onboarding-scm-experiment',
+        'onboarding-scm-project-details-experiment',
+      ],
     });
 
     const githubProvider = GitHubIntegrationProviderFixture({

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -780,6 +780,102 @@ describe('Onboarding', () => {
       });
     });
 
+    it('skips scm-project-details and auto-creates the project when experiment is off', async () => {
+      ProjectsStore.loadInitialData([]);
+      const controlOrganization = OrganizationFixture({
+        features: ['onboarding-scm-experiment'],
+      });
+      const createdProject = ProjectFixture({
+        platform: 'javascript-nextjs',
+        slug: 'javascript-nextjs',
+      });
+      jest
+        .spyOn(useRecentCreatedProjectHook, 'useRecentCreatedProject')
+        .mockImplementation(() => ({
+          project: createdProject,
+          isProjectActive: false,
+        }));
+      MockApiClient.addMockResponse({
+        url: `/organizations/${controlOrganization.slug}/`,
+        body: controlOrganization,
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${controlOrganization.slug}/config/integrations/`,
+        body: {providers: [githubProvider]},
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${controlOrganization.slug}/integrations/`,
+        body: [],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${controlOrganization.slug}/repos/`,
+        body: [],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${controlOrganization.slug}/teams/`,
+        body: [],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${controlOrganization.slug}/projects/`,
+        body: [],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${controlOrganization.slug}/sdks/`,
+        body: {},
+      });
+      MockApiClient.addMockResponse({
+        url: `/projects/${controlOrganization.slug}/${createdProject.slug}/keys/`,
+        body: [],
+      });
+      MockApiClient.addMockResponse({
+        url: `/projects/${controlOrganization.slug}/${createdProject.slug}/issues/`,
+        body: [],
+      });
+      MockApiClient.addMockResponse({
+        url: `/projects/${controlOrganization.slug}/${createdProject.slug}/overview/`,
+        body: createdProject,
+      });
+      const createRequest = MockApiClient.addMockResponse({
+        url: `/organizations/${controlOrganization.slug}/experimental/projects/`,
+        method: 'POST',
+        body: createdProject,
+      });
+
+      const {router} = render(
+        <OnboardingContextProvider
+          initialValue={{
+            selectedPlatform: nextJsPlatform,
+            selectedFeatures: [ProductSolution.ERROR_MONITORING],
+          }}
+        >
+          <OnboardingWithoutContext />
+        </OnboardingContextProvider>,
+        {
+          organization: controlOrganization,
+          initialRouterConfig: {
+            location: {
+              pathname: `/onboarding/${controlOrganization.slug}/scm-platform-features/`,
+            },
+            route: '/onboarding/:orgId/:step/',
+          },
+        }
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', {name: 'Continue'})).toBeEnabled();
+      });
+      await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+      await waitFor(() => {
+        expect(createRequest).toHaveBeenCalled();
+      });
+      await waitFor(() => {
+        expect(router.location.pathname).toBe(
+          `/onboarding/${controlOrganization.slug}/setup-docs/`
+        );
+      });
+    });
+
     it('renders scm-project-details step with project details form', () => {
       render(
         <OnboardingContextProvider initialValue={{selectedPlatform: nextJsPlatform}}>

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -808,6 +808,102 @@ describe('Onboarding', () => {
       });
     });
 
+    it('skips scm-project-details and auto-creates the project when experiment is off', async () => {
+      ProjectsStore.loadInitialData([]);
+      const controlOrganization = OrganizationFixture({
+        features: ['onboarding-scm-experiment'],
+      });
+      const createdProject = ProjectFixture({
+        platform: 'javascript-nextjs',
+        slug: 'javascript-nextjs',
+      });
+      jest
+        .spyOn(useRecentCreatedProjectHook, 'useRecentCreatedProject')
+        .mockImplementation(() => ({
+          project: createdProject,
+          isProjectActive: false,
+        }));
+      MockApiClient.addMockResponse({
+        url: `/organizations/${controlOrganization.slug}/`,
+        body: controlOrganization,
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${controlOrganization.slug}/config/integrations/`,
+        body: {providers: [githubProvider]},
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${controlOrganization.slug}/integrations/`,
+        body: [],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${controlOrganization.slug}/repos/`,
+        body: [],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${controlOrganization.slug}/teams/`,
+        body: [],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${controlOrganization.slug}/projects/`,
+        body: [],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${controlOrganization.slug}/sdks/`,
+        body: {},
+      });
+      MockApiClient.addMockResponse({
+        url: `/projects/${controlOrganization.slug}/${createdProject.slug}/keys/`,
+        body: [],
+      });
+      MockApiClient.addMockResponse({
+        url: `/projects/${controlOrganization.slug}/${createdProject.slug}/issues/`,
+        body: [],
+      });
+      MockApiClient.addMockResponse({
+        url: `/projects/${controlOrganization.slug}/${createdProject.slug}/overview/`,
+        body: createdProject,
+      });
+      const createRequest = MockApiClient.addMockResponse({
+        url: `/organizations/${controlOrganization.slug}/experimental/projects/`,
+        method: 'POST',
+        body: createdProject,
+      });
+
+      const {router} = render(
+        <OnboardingContextProvider
+          initialValue={{
+            selectedPlatform: nextJsPlatform,
+            selectedFeatures: [ProductSolution.ERROR_MONITORING],
+          }}
+        >
+          <OnboardingWithoutContext />
+        </OnboardingContextProvider>,
+        {
+          organization: controlOrganization,
+          initialRouterConfig: {
+            location: {
+              pathname: `/onboarding/${controlOrganization.slug}/scm-platform-features/`,
+            },
+            route: '/onboarding/:orgId/:step/',
+          },
+        }
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', {name: 'Continue'})).toBeEnabled();
+      });
+      await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+      await waitFor(() => {
+        expect(createRequest).toHaveBeenCalled();
+      });
+      await waitFor(() => {
+        expect(router.location.pathname).toBe(
+          `/onboarding/${controlOrganization.slug}/setup-docs/`
+        );
+      });
+    });
+
     it('renders scm-project-details step with project details form', () => {
       render(
         <OnboardingContextProvider initialValue={{selectedPlatform: nextJsPlatform}}>

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -170,7 +170,18 @@ export function OnboardingWithoutContext() {
     feature: 'onboarding-scm-experiment',
   });
 
-  const onboardingSteps = hasScmOnboarding ? scmOnboardingSteps : legacyOnboardingSteps;
+  // Only report exposure for users who are actually in SCM onboarding —
+  // the assignment is irrelevant for legacy onboarding.
+  const {inExperiment: hasProjectDetailsStep} = useExperiment({
+    feature: 'onboarding-scm-project-details-experiment',
+    reportExposure: hasScmOnboarding,
+  });
+
+  const scmSteps = hasProjectDetailsStep
+    ? scmOnboardingSteps
+    : scmOnboardingSteps.filter(s => s.id !== OnboardingStepId.SCM_PROJECT_DETAILS);
+
+  const onboardingSteps = hasScmOnboarding ? scmSteps : legacyOnboardingSteps;
 
   const stepObj = onboardingSteps.find(({id}) => stepId === id);
   const stepIndex = onboardingSteps.findIndex(({id}) => stepId === id);

--- a/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
@@ -1,6 +1,8 @@
 import {DetectedPlatformFixture} from 'sentry-fixture/detectedPlatform';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
 import {RepositoryFixture} from 'sentry-fixture/repository';
+import {TeamFixture} from 'sentry-fixture/team';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -602,6 +604,225 @@ describe('ScmPlatformFeatures', () => {
         'onboarding.scm_platform_change_platform_clicked',
         expect.objectContaining({organization})
       );
+    });
+  });
+
+  describe('project-details step skipped (control group)', () => {
+    const adminTeam = TeamFixture({slug: 'admin-team', access: ['team:admin']});
+    const nextJsPlatform = {
+      key: 'javascript-nextjs' as const,
+      name: 'Next.js',
+      language: 'javascript' as const,
+      link: 'https://docs.sentry.io/platforms/javascript/guides/nextjs/',
+      type: 'framework' as const,
+      category: 'browser' as const,
+    };
+
+    beforeEach(() => {
+      TeamStore.loadInitialData([adminTeam]);
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/`,
+        body: organization,
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/projects/`,
+        body: [],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/teams/`,
+        body: [adminTeam],
+      });
+    });
+
+    it('auto-creates the project on Continue and forwards selected features', async () => {
+      const onComplete = jest.fn();
+      const createdProject = ProjectFixture({
+        slug: 'javascript-nextjs',
+        platform: 'javascript-nextjs',
+      });
+      const createRequest = MockApiClient.addMockResponse({
+        url: `/teams/${organization.slug}/${adminTeam.slug}/projects/`,
+        method: 'POST',
+        body: createdProject,
+      });
+
+      render(
+        <ScmPlatformFeatures
+          onComplete={onComplete}
+          stepIndex={2}
+          genSkipOnboardingLink={() => null}
+        />,
+        {
+          organization,
+          additionalWrapper: makeOnboardingWrapper({
+            selectedPlatform: nextJsPlatform,
+            selectedFeatures: [ProductSolution.ERROR_MONITORING],
+          }),
+        }
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', {name: 'Continue'})).toBeEnabled();
+      });
+      await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+      await waitFor(() => {
+        expect(createRequest).toHaveBeenCalledWith(
+          `/teams/${organization.slug}/${adminTeam.slug}/projects/`,
+          expect.objectContaining({
+            method: 'POST',
+            data: expect.objectContaining({
+              platform: 'javascript-nextjs',
+              name: 'javascript-nextjs',
+              default_rules: true,
+            }),
+          })
+        );
+      });
+      expect(onComplete).toHaveBeenCalledWith(undefined, {
+        product: [ProductSolution.ERROR_MONITORING],
+      });
+    });
+
+    it('reuses the existing project when the platform is unchanged', async () => {
+      const onComplete = jest.fn();
+      const existingProject = ProjectFixture({
+        slug: 'javascript-nextjs',
+        platform: 'javascript-nextjs',
+      });
+      ProjectsStore.loadInitialData([existingProject]);
+      const createRequest = MockApiClient.addMockResponse({
+        url: `/teams/${organization.slug}/${adminTeam.slug}/projects/`,
+        method: 'POST',
+        body: existingProject,
+      });
+
+      render(
+        <ScmPlatformFeatures
+          onComplete={onComplete}
+          stepIndex={2}
+          genSkipOnboardingLink={() => null}
+        />,
+        {
+          organization,
+          additionalWrapper: makeOnboardingWrapper({
+            selectedPlatform: nextJsPlatform,
+            selectedFeatures: [ProductSolution.ERROR_MONITORING],
+            createdProjectSlug: existingProject.slug,
+          }),
+        }
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', {name: 'Continue'})).toBeEnabled();
+      });
+      await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+      await waitFor(() => {
+        expect(onComplete).toHaveBeenCalledWith(undefined, {
+          product: [ProductSolution.ERROR_MONITORING],
+        });
+      });
+      expect(createRequest).not.toHaveBeenCalled();
+    });
+
+    it('creates a new project when the platform changed from the existing one', async () => {
+      const onComplete = jest.fn();
+      const stalePythonProject = ProjectFixture({
+        slug: 'python',
+        platform: 'python',
+      });
+      ProjectsStore.loadInitialData([stalePythonProject]);
+      const newProject = ProjectFixture({
+        slug: 'javascript-nextjs',
+        platform: 'javascript-nextjs',
+      });
+      const createRequest = MockApiClient.addMockResponse({
+        url: `/teams/${organization.slug}/${adminTeam.slug}/projects/`,
+        method: 'POST',
+        body: newProject,
+      });
+
+      render(
+        <ScmPlatformFeatures
+          onComplete={onComplete}
+          stepIndex={2}
+          genSkipOnboardingLink={() => null}
+        />,
+        {
+          organization,
+          additionalWrapper: makeOnboardingWrapper({
+            selectedPlatform: nextJsPlatform,
+            selectedFeatures: [ProductSolution.ERROR_MONITORING],
+            createdProjectSlug: stalePythonProject.slug,
+          }),
+        }
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', {name: 'Continue'})).toBeEnabled();
+      });
+      await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+      await waitFor(() => {
+        expect(createRequest).toHaveBeenCalled();
+      });
+      expect(onComplete).toHaveBeenCalledWith(undefined, {
+        product: [ProductSolution.ERROR_MONITORING],
+      });
+    });
+  });
+
+  describe('project-details step enabled (experiment group)', () => {
+    const experimentOrganization = OrganizationFixture({
+      features: [
+        'performance-view',
+        'session-replay',
+        'profiling-view',
+        'onboarding-scm-project-details-experiment',
+      ],
+    });
+    const nextJsPlatform = {
+      key: 'javascript-nextjs' as const,
+      name: 'Next.js',
+      language: 'javascript' as const,
+      link: 'https://docs.sentry.io/platforms/javascript/guides/nextjs/',
+      type: 'framework' as const,
+      category: 'browser' as const,
+    };
+
+    it('advances without creating a project on Continue', async () => {
+      const onComplete = jest.fn();
+      const createRequest = MockApiClient.addMockResponse({
+        url: `/teams/${experimentOrganization.slug}/team-slug/projects/`,
+        method: 'POST',
+        body: ProjectFixture(),
+      });
+
+      render(
+        <ScmPlatformFeatures
+          onComplete={onComplete}
+          stepIndex={2}
+          genSkipOnboardingLink={() => null}
+        />,
+        {
+          organization: experimentOrganization,
+          additionalWrapper: makeOnboardingWrapper({
+            selectedPlatform: nextJsPlatform,
+            selectedFeatures: [ProductSolution.ERROR_MONITORING],
+          }),
+        }
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', {name: 'Continue'})).toBeEnabled();
+      });
+      await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+      await waitFor(() => {
+        expect(onComplete).toHaveBeenCalledWith();
+      });
+      expect(createRequest).not.toHaveBeenCalled();
     });
   });
 });

--- a/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
@@ -10,6 +10,8 @@ import {
   OnboardingContextProvider,
   type OnboardingSessionState,
 } from 'sentry/components/onboarding/onboardingContext';
+import {ProjectsStore} from 'sentry/stores/projectsStore';
+import {TeamStore} from 'sentry/stores/teamStore';
 import * as analytics from 'sentry/utils/analytics';
 import {sessionStorageWrapper} from 'sentry/utils/sessionStorage';
 
@@ -72,6 +74,8 @@ describe('ScmPlatformFeatures', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     sessionStorageWrapper.clear();
+    ProjectsStore.loadInitialData([]);
+    TeamStore.loadInitialData([]);
   });
 
   afterEach(() => {

--- a/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
@@ -679,7 +679,7 @@ describe('ScmPlatformFeatures', () => {
           })
         );
       });
-      expect(onComplete).toHaveBeenCalledWith(undefined, {
+      expect(onComplete).toHaveBeenCalledWith(nextJsPlatform, {
         product: [ProductSolution.ERROR_MONITORING],
       });
     });
@@ -719,7 +719,7 @@ describe('ScmPlatformFeatures', () => {
       await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
 
       await waitFor(() => {
-        expect(onComplete).toHaveBeenCalledWith(undefined, {
+        expect(onComplete).toHaveBeenCalledWith(nextJsPlatform, {
           product: [ProductSolution.ERROR_MONITORING],
         });
       });
@@ -767,8 +767,64 @@ describe('ScmPlatformFeatures', () => {
       await waitFor(() => {
         expect(createRequest).toHaveBeenCalled();
       });
-      expect(onComplete).toHaveBeenCalledWith(undefined, {
+      expect(onComplete).toHaveBeenCalledWith(nextJsPlatform, {
         product: [ProductSolution.ERROR_MONITORING],
+      });
+    });
+
+    it('forwards the detected platform to onComplete when the user did not click a card', async () => {
+      // Regression: if the user hits Continue without explicitly selecting a
+      // detected platform, selectedPlatform stays undefined in context while
+      // currentPlatformKey falls back to the detected key. Passing undefined
+      // to onComplete here would trip goNextStep's SETUP_DOCS guard because
+      // the captured closure still sees selectedPlatform as undefined.
+      const onComplete = jest.fn();
+      const createdProject = ProjectFixture({
+        slug: 'javascript-nextjs',
+        platform: 'javascript-nextjs',
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/repos/42/platforms/`,
+        body: {
+          platforms: [
+            DetectedPlatformFixture({
+              platform: 'javascript-nextjs',
+              language: 'javascript',
+            }),
+          ],
+        },
+      });
+      MockApiClient.addMockResponse({
+        url: `/teams/${organization.slug}/${adminTeam.slug}/projects/`,
+        method: 'POST',
+        body: createdProject,
+      });
+
+      render(
+        <ScmPlatformFeatures
+          onComplete={onComplete}
+          stepIndex={2}
+          genSkipOnboardingLink={() => null}
+        />,
+        {
+          organization,
+          additionalWrapper: makeOnboardingWrapper({
+            selectedRepository: mockRepository,
+          }),
+        }
+      );
+
+      await screen.findByRole('radio', {name: /Next.js/});
+      await waitFor(() => {
+        expect(screen.getByRole('button', {name: 'Continue'})).toBeEnabled();
+      });
+      await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+      await waitFor(() => {
+        expect(onComplete).toHaveBeenCalledWith(
+          expect.objectContaining({key: 'javascript-nextjs'}),
+          {product: [ProductSolution.ERROR_MONITORING]}
+        );
       });
     });
   });

--- a/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
@@ -719,7 +719,7 @@ describe('ScmPlatformFeatures', () => {
           })
         );
       });
-      expect(onComplete).toHaveBeenCalledWith(undefined, {
+      expect(onComplete).toHaveBeenCalledWith(nextJsPlatform, {
         product: [ProductSolution.ERROR_MONITORING],
       });
     });
@@ -759,7 +759,7 @@ describe('ScmPlatformFeatures', () => {
       await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
 
       await waitFor(() => {
-        expect(onComplete).toHaveBeenCalledWith(undefined, {
+        expect(onComplete).toHaveBeenCalledWith(nextJsPlatform, {
           product: [ProductSolution.ERROR_MONITORING],
         });
       });
@@ -807,8 +807,64 @@ describe('ScmPlatformFeatures', () => {
       await waitFor(() => {
         expect(createRequest).toHaveBeenCalled();
       });
-      expect(onComplete).toHaveBeenCalledWith(undefined, {
+      expect(onComplete).toHaveBeenCalledWith(nextJsPlatform, {
         product: [ProductSolution.ERROR_MONITORING],
+      });
+    });
+
+    it('forwards the detected platform to onComplete when the user did not click a card', async () => {
+      // Regression: if the user hits Continue without explicitly selecting a
+      // detected platform, selectedPlatform stays undefined in context while
+      // currentPlatformKey falls back to the detected key. Passing undefined
+      // to onComplete here would trip goNextStep's SETUP_DOCS guard because
+      // the captured closure still sees selectedPlatform as undefined.
+      const onComplete = jest.fn();
+      const createdProject = ProjectFixture({
+        slug: 'javascript-nextjs',
+        platform: 'javascript-nextjs',
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/repos/42/platforms/`,
+        body: {
+          platforms: [
+            DetectedPlatformFixture({
+              platform: 'javascript-nextjs',
+              language: 'javascript',
+            }),
+          ],
+        },
+      });
+      MockApiClient.addMockResponse({
+        url: `/teams/${organization.slug}/${adminTeam.slug}/projects/`,
+        method: 'POST',
+        body: createdProject,
+      });
+
+      render(
+        <ScmPlatformFeatures
+          onComplete={onComplete}
+          stepIndex={2}
+          genSkipOnboardingLink={() => null}
+        />,
+        {
+          organization,
+          additionalWrapper: makeOnboardingWrapper({
+            selectedRepository: mockRepository,
+          }),
+        }
+      );
+
+      await screen.findByRole('radio', {name: /Next.js/});
+      await waitFor(() => {
+        expect(screen.getByRole('button', {name: 'Continue'})).toBeEnabled();
+      });
+      await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+      await waitFor(() => {
+        expect(onComplete).toHaveBeenCalledWith(
+          expect.objectContaining({key: 'javascript-nextjs'}),
+          {product: [ProductSolution.ERROR_MONITORING]}
+        );
       });
     });
   });

--- a/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
@@ -1,6 +1,8 @@
 import {DetectedPlatformFixture} from 'sentry-fixture/detectedPlatform';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
 import {RepositoryFixture} from 'sentry-fixture/repository';
+import {TeamFixture} from 'sentry-fixture/team';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -642,6 +644,225 @@ describe('ScmPlatformFeatures', () => {
         'onboarding.scm_platform_change_platform_clicked',
         expect.objectContaining({organization})
       );
+    });
+  });
+
+  describe('project-details step skipped (control group)', () => {
+    const adminTeam = TeamFixture({slug: 'admin-team', access: ['team:admin']});
+    const nextJsPlatform = {
+      key: 'javascript-nextjs' as const,
+      name: 'Next.js',
+      language: 'javascript' as const,
+      link: 'https://docs.sentry.io/platforms/javascript/guides/nextjs/',
+      type: 'framework' as const,
+      category: 'browser' as const,
+    };
+
+    beforeEach(() => {
+      TeamStore.loadInitialData([adminTeam]);
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/`,
+        body: organization,
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/projects/`,
+        body: [],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/teams/`,
+        body: [adminTeam],
+      });
+    });
+
+    it('auto-creates the project on Continue and forwards selected features', async () => {
+      const onComplete = jest.fn();
+      const createdProject = ProjectFixture({
+        slug: 'javascript-nextjs',
+        platform: 'javascript-nextjs',
+      });
+      const createRequest = MockApiClient.addMockResponse({
+        url: `/teams/${organization.slug}/${adminTeam.slug}/projects/`,
+        method: 'POST',
+        body: createdProject,
+      });
+
+      render(
+        <ScmPlatformFeatures
+          onComplete={onComplete}
+          stepIndex={2}
+          genSkipOnboardingLink={() => null}
+        />,
+        {
+          organization,
+          additionalWrapper: makeOnboardingWrapper({
+            selectedPlatform: nextJsPlatform,
+            selectedFeatures: [ProductSolution.ERROR_MONITORING],
+          }),
+        }
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', {name: 'Continue'})).toBeEnabled();
+      });
+      await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+      await waitFor(() => {
+        expect(createRequest).toHaveBeenCalledWith(
+          `/teams/${organization.slug}/${adminTeam.slug}/projects/`,
+          expect.objectContaining({
+            method: 'POST',
+            data: expect.objectContaining({
+              platform: 'javascript-nextjs',
+              name: 'javascript-nextjs',
+              default_rules: true,
+            }),
+          })
+        );
+      });
+      expect(onComplete).toHaveBeenCalledWith(undefined, {
+        product: [ProductSolution.ERROR_MONITORING],
+      });
+    });
+
+    it('reuses the existing project when the platform is unchanged', async () => {
+      const onComplete = jest.fn();
+      const existingProject = ProjectFixture({
+        slug: 'javascript-nextjs',
+        platform: 'javascript-nextjs',
+      });
+      ProjectsStore.loadInitialData([existingProject]);
+      const createRequest = MockApiClient.addMockResponse({
+        url: `/teams/${organization.slug}/${adminTeam.slug}/projects/`,
+        method: 'POST',
+        body: existingProject,
+      });
+
+      render(
+        <ScmPlatformFeatures
+          onComplete={onComplete}
+          stepIndex={2}
+          genSkipOnboardingLink={() => null}
+        />,
+        {
+          organization,
+          additionalWrapper: makeOnboardingWrapper({
+            selectedPlatform: nextJsPlatform,
+            selectedFeatures: [ProductSolution.ERROR_MONITORING],
+            createdProjectSlug: existingProject.slug,
+          }),
+        }
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', {name: 'Continue'})).toBeEnabled();
+      });
+      await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+      await waitFor(() => {
+        expect(onComplete).toHaveBeenCalledWith(undefined, {
+          product: [ProductSolution.ERROR_MONITORING],
+        });
+      });
+      expect(createRequest).not.toHaveBeenCalled();
+    });
+
+    it('creates a new project when the platform changed from the existing one', async () => {
+      const onComplete = jest.fn();
+      const stalePythonProject = ProjectFixture({
+        slug: 'python',
+        platform: 'python',
+      });
+      ProjectsStore.loadInitialData([stalePythonProject]);
+      const newProject = ProjectFixture({
+        slug: 'javascript-nextjs',
+        platform: 'javascript-nextjs',
+      });
+      const createRequest = MockApiClient.addMockResponse({
+        url: `/teams/${organization.slug}/${adminTeam.slug}/projects/`,
+        method: 'POST',
+        body: newProject,
+      });
+
+      render(
+        <ScmPlatformFeatures
+          onComplete={onComplete}
+          stepIndex={2}
+          genSkipOnboardingLink={() => null}
+        />,
+        {
+          organization,
+          additionalWrapper: makeOnboardingWrapper({
+            selectedPlatform: nextJsPlatform,
+            selectedFeatures: [ProductSolution.ERROR_MONITORING],
+            createdProjectSlug: stalePythonProject.slug,
+          }),
+        }
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', {name: 'Continue'})).toBeEnabled();
+      });
+      await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+      await waitFor(() => {
+        expect(createRequest).toHaveBeenCalled();
+      });
+      expect(onComplete).toHaveBeenCalledWith(undefined, {
+        product: [ProductSolution.ERROR_MONITORING],
+      });
+    });
+  });
+
+  describe('project-details step enabled (experiment group)', () => {
+    const experimentOrganization = OrganizationFixture({
+      features: [
+        'performance-view',
+        'session-replay',
+        'profiling-view',
+        'onboarding-scm-project-details-experiment',
+      ],
+    });
+    const nextJsPlatform = {
+      key: 'javascript-nextjs' as const,
+      name: 'Next.js',
+      language: 'javascript' as const,
+      link: 'https://docs.sentry.io/platforms/javascript/guides/nextjs/',
+      type: 'framework' as const,
+      category: 'browser' as const,
+    };
+
+    it('advances without creating a project on Continue', async () => {
+      const onComplete = jest.fn();
+      const createRequest = MockApiClient.addMockResponse({
+        url: `/teams/${experimentOrganization.slug}/team-slug/projects/`,
+        method: 'POST',
+        body: ProjectFixture(),
+      });
+
+      render(
+        <ScmPlatformFeatures
+          onComplete={onComplete}
+          stepIndex={2}
+          genSkipOnboardingLink={() => null}
+        />,
+        {
+          organization: experimentOrganization,
+          additionalWrapper: makeOnboardingWrapper({
+            selectedPlatform: nextJsPlatform,
+            selectedFeatures: [ProductSolution.ERROR_MONITORING],
+          }),
+        }
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', {name: 'Continue'})).toBeEnabled();
+      });
+      await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+      await waitFor(() => {
+        expect(onComplete).toHaveBeenCalledWith();
+      });
+      expect(createRequest).not.toHaveBeenCalled();
     });
   });
 });

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -334,6 +334,11 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
     ? projects.find(p => p.slug === createdProjectSlug)
     : undefined;
 
+  // When the project-details step is skipped, Continue auto-creates the
+  // project, which needs the teams and projects stores loaded.
+  const autoCreateDataPending =
+    !hasProjectDetailsStep && (isLoadingTeams || !projectsLoaded);
+
   async function handleContinue() {
     // Persist derived defaults to context if user accepted them
     if (currentPlatformKey && !selectedPlatform?.key) {
@@ -345,14 +350,14 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
 
     if (!hasProjectDetailsStep) {
       // Auto-create project with defaults when SCM_PROJECT_DETAILS step is skipped
-      const platform =
-        selectedPlatform ??
-        (currentPlatformKey
-          ? toSelectedSdk(getPlatformInfo(currentPlatformKey)!)
-          : undefined);
-      if (!platform) {
+      if (!currentPlatformKey) {
         return;
       }
+      const info = getPlatformInfo(currentPlatformKey);
+      if (!info) {
+        return;
+      }
+      const platform = selectedPlatform ?? toSelectedSdk(info);
 
       // If a project was already created for this platform (e.g. the user
       // went back after the project received its first event), reuse it.
@@ -529,9 +534,7 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
               }}
               onClick={handleContinue}
               disabled={
-                !currentPlatformKey ||
-                createProject.isPending ||
-                (!hasProjectDetailsStep && (isLoadingTeams || !projectsLoaded))
+                !currentPlatformKey || createProject.isPending || autoCreateDataPending
               }
               busy={createProject.isPending}
             >

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -363,8 +363,11 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
       // went back after the project received its first event), reuse it.
       // If the platform changed, abandon the old project and create a new
       // one — matching legacy onboarding behavior.
+      // `platform` is forwarded because setPlatform's context update has not
+      // propagated to the captured onComplete closure yet, and goNextStep's
+      // SETUP_DOCS guard would otherwise block navigation.
       if (existingProject?.platform === platform.key) {
-        onComplete(undefined, {product: currentFeatures});
+        onComplete(platform, {product: currentFeatures});
         return;
       }
 
@@ -380,7 +383,7 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
           firstTeamSlug: firstAdminTeam?.slug,
         });
         setCreatedProjectSlug(project.slug);
-        onComplete(undefined, {product: currentFeatures});
+        onComplete(platform, {product: currentFeatures});
       } catch (error) {
         addErrorMessage(t('Failed to create project'));
         Sentry.captureException(error);

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -1,4 +1,5 @@
 import {useCallback, useEffect, useMemo, useState} from 'react';
+import * as Sentry from '@sentry/react';
 import {LayoutGroup, motion} from 'framer-motion';
 import {PlatformIcon} from 'platformicons';
 
@@ -7,6 +8,7 @@ import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Select} from '@sentry/scraps/select';
 import {Heading} from '@sentry/scraps/text';
 
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {closeModal, openConsoleModal, openModal} from 'sentry/actionCreators/modal';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {SupportedLanguages} from 'sentry/components/onboarding/frameworkSuggestionModal';
@@ -16,13 +18,18 @@ import {
   getDisabledProducts,
   platformProductAvailability,
 } from 'sentry/components/onboarding/productSelection';
+import {useCreateProject} from 'sentry/components/onboarding/useCreateProject';
 import {platforms} from 'sentry/data/platforms';
 import {t} from 'sentry/locale';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
+import type {Team} from 'sentry/types/organization';
 import type {PlatformIntegration, PlatformKey} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {isDisabledGamingPlatform} from 'sentry/utils/platform';
+import {useExperiment} from 'sentry/utils/useExperiment';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {useProjects} from 'sentry/utils/useProjects';
+import {useTeams} from 'sentry/utils/useTeams';
 import {ScmFeatureSelectionCards} from 'sentry/views/onboarding/components/scmFeatureSelectionCards';
 import {ScmPlatformCard} from 'sentry/views/onboarding/components/scmPlatformCard';
 
@@ -85,7 +92,19 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
     selectedFeatures,
     setSelectedFeatures,
     setProjectDetailsForm,
+    createdProjectSlug,
+    setCreatedProjectSlug,
   } = useOnboardingContext();
+
+  const {teams, fetching: isLoadingTeams} = useTeams();
+  const {projects, initiallyLoaded: projectsLoaded} = useProjects();
+  const createProject = useCreateProject();
+  // Exposure is reported upstream in onboarding.tsx when the user enters SCM
+  // onboarding; skip it here to avoid double-counting on step mount.
+  const {inExperiment: hasProjectDetailsStep} = useExperiment({
+    feature: 'onboarding-scm-project-details-experiment',
+    reportExposure: false,
+  });
 
   const [showManualPicker, setShowManualPicker] = useState(false);
 
@@ -311,7 +330,11 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
     }
   }
 
-  function handleContinue() {
+  const existingProject = createdProjectSlug
+    ? projects.find(p => p.slug === createdProjectSlug)
+    : undefined;
+
+  async function handleContinue() {
     // Persist derived defaults to context if user accepted them
     if (currentPlatformKey && !selectedPlatform?.key) {
       setPlatform(currentPlatformKey);
@@ -319,6 +342,47 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
     if (!selectedFeatures) {
       setSelectedFeatures(currentFeatures);
     }
+
+    if (!hasProjectDetailsStep) {
+      // Auto-create project with defaults when SCM_PROJECT_DETAILS step is skipped
+      const platform =
+        selectedPlatform ??
+        (currentPlatformKey
+          ? toSelectedSdk(getPlatformInfo(currentPlatformKey)!)
+          : undefined);
+      if (!platform) {
+        return;
+      }
+
+      // If a project was already created for this platform (e.g. the user
+      // went back after the project received its first event), reuse it.
+      // If the platform changed, abandon the old project and create a new
+      // one — matching legacy onboarding behavior.
+      if (existingProject?.platform === platform.key) {
+        onComplete(undefined, {product: currentFeatures});
+        return;
+      }
+
+      const firstAdminTeam = teams.find((team: Team) =>
+        team.access.includes('team:admin')
+      );
+
+      try {
+        const project = await createProject.mutateAsync({
+          name: platform.key,
+          platform,
+          default_rules: true,
+          firstTeamSlug: firstAdminTeam?.slug,
+        });
+        setCreatedProjectSlug(project.slug);
+        onComplete(undefined, {product: currentFeatures});
+      } catch (error) {
+        addErrorMessage(t('Failed to create project'));
+        Sentry.captureException(error);
+      }
+      return;
+    }
+
     onComplete();
   }
 
@@ -464,7 +528,12 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
                 features: currentFeatures,
               }}
               onClick={handleContinue}
-              disabled={!currentPlatformKey}
+              disabled={
+                !currentPlatformKey ||
+                createProject.isPending ||
+                (!hasProjectDetailsStep && (isLoadingTeams || !projectsLoaded))
+              }
+              busy={createProject.isPending}
             >
               {t('Continue')}
             </Button>

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -1,4 +1,5 @@
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import * as Sentry from '@sentry/react';
 import {LayoutGroup, motion} from 'framer-motion';
 import {PlatformIcon} from 'platformicons';
 
@@ -7,6 +8,7 @@ import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Select} from '@sentry/scraps/select';
 import {Heading} from '@sentry/scraps/text';
 
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {closeModal, openConsoleModal, openModal} from 'sentry/actionCreators/modal';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {SupportedLanguages} from 'sentry/components/onboarding/frameworkSuggestionModal';
@@ -16,13 +18,18 @@ import {
   getDisabledProducts,
   platformProductAvailability,
 } from 'sentry/components/onboarding/productSelection';
+import {useCreateProject} from 'sentry/components/onboarding/useCreateProject';
 import {platforms} from 'sentry/data/platforms';
 import {t} from 'sentry/locale';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
+import type {Team} from 'sentry/types/organization';
 import type {PlatformIntegration, PlatformKey} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {isDisabledGamingPlatform} from 'sentry/utils/platform';
+import {useExperiment} from 'sentry/utils/useExperiment';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {useProjects} from 'sentry/utils/useProjects';
+import {useTeams} from 'sentry/utils/useTeams';
 import {ScmFeatureSelectionCards} from 'sentry/views/onboarding/components/scmFeatureSelectionCards';
 import {ScmPlatformCard} from 'sentry/views/onboarding/components/scmPlatformCard';
 
@@ -85,7 +92,19 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
     selectedFeatures,
     setSelectedFeatures,
     setProjectDetailsForm,
+    createdProjectSlug,
+    setCreatedProjectSlug,
   } = useOnboardingContext();
+
+  const {teams, fetching: isLoadingTeams} = useTeams();
+  const {projects, initiallyLoaded: projectsLoaded} = useProjects();
+  const createProject = useCreateProject();
+  // Exposure is reported upstream in onboarding.tsx when the user enters SCM
+  // onboarding; skip it here to avoid double-counting on step mount.
+  const {inExperiment: hasProjectDetailsStep} = useExperiment({
+    feature: 'onboarding-scm-project-details-experiment',
+    reportExposure: false,
+  });
 
   const [showManualPicker, setShowManualPicker] = useState(false);
 
@@ -332,7 +351,11 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
     }
   }
 
-  function handleContinue() {
+  const existingProject = createdProjectSlug
+    ? projects.find(p => p.slug === createdProjectSlug)
+    : undefined;
+
+  async function handleContinue() {
     // Persist derived defaults to context if user accepted them
     if (currentPlatformKey && !selectedPlatform?.key) {
       setPlatform(currentPlatformKey);
@@ -340,6 +363,47 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
     if (!selectedFeatures) {
       setSelectedFeatures(currentFeatures);
     }
+
+    if (!hasProjectDetailsStep) {
+      // Auto-create project with defaults when SCM_PROJECT_DETAILS step is skipped
+      const platform =
+        selectedPlatform ??
+        (currentPlatformKey
+          ? toSelectedSdk(getPlatformInfo(currentPlatformKey)!)
+          : undefined);
+      if (!platform) {
+        return;
+      }
+
+      // If a project was already created for this platform (e.g. the user
+      // went back after the project received its first event), reuse it.
+      // If the platform changed, abandon the old project and create a new
+      // one — matching legacy onboarding behavior.
+      if (existingProject?.platform === platform.key) {
+        onComplete(undefined, {product: currentFeatures});
+        return;
+      }
+
+      const firstAdminTeam = teams.find((team: Team) =>
+        team.access.includes('team:admin')
+      );
+
+      try {
+        const project = await createProject.mutateAsync({
+          name: platform.key,
+          platform,
+          default_rules: true,
+          firstTeamSlug: firstAdminTeam?.slug,
+        });
+        setCreatedProjectSlug(project.slug);
+        onComplete(undefined, {product: currentFeatures});
+      } catch (error) {
+        addErrorMessage(t('Failed to create project'));
+        Sentry.captureException(error);
+      }
+      return;
+    }
+
     onComplete();
   }
 
@@ -485,7 +549,12 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
                 features: currentFeatures,
               }}
               onClick={handleContinue}
-              disabled={!currentPlatformKey}
+              disabled={
+                !currentPlatformKey ||
+                createProject.isPending ||
+                (!hasProjectDetailsStep && (isLoadingTeams || !projectsLoaded))
+              }
+              busy={createProject.isPending}
             >
               {t('Continue')}
             </Button>

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -384,8 +384,11 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
       // went back after the project received its first event), reuse it.
       // If the platform changed, abandon the old project and create a new
       // one — matching legacy onboarding behavior.
+      // `platform` is forwarded because setPlatform's context update has not
+      // propagated to the captured onComplete closure yet, and goNextStep's
+      // SETUP_DOCS guard would otherwise block navigation.
       if (existingProject?.platform === platform.key) {
-        onComplete(undefined, {product: currentFeatures});
+        onComplete(platform, {product: currentFeatures});
         return;
       }
 
@@ -401,7 +404,7 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
           firstTeamSlug: firstAdminTeam?.slug,
         });
         setCreatedProjectSlug(project.slug);
-        onComplete(undefined, {product: currentFeatures});
+        onComplete(platform, {product: currentFeatures});
       } catch (error) {
         addErrorMessage(t('Failed to create project'));
         Sentry.captureException(error);

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -355,6 +355,11 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
     ? projects.find(p => p.slug === createdProjectSlug)
     : undefined;
 
+  // When the project-details step is skipped, Continue auto-creates the
+  // project, which needs the teams and projects stores loaded.
+  const autoCreateDataPending =
+    !hasProjectDetailsStep && (isLoadingTeams || !projectsLoaded);
+
   async function handleContinue() {
     // Persist derived defaults to context if user accepted them
     if (currentPlatformKey && !selectedPlatform?.key) {
@@ -366,14 +371,14 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
 
     if (!hasProjectDetailsStep) {
       // Auto-create project with defaults when SCM_PROJECT_DETAILS step is skipped
-      const platform =
-        selectedPlatform ??
-        (currentPlatformKey
-          ? toSelectedSdk(getPlatformInfo(currentPlatformKey)!)
-          : undefined);
-      if (!platform) {
+      if (!currentPlatformKey) {
         return;
       }
+      const info = getPlatformInfo(currentPlatformKey);
+      if (!info) {
+        return;
+      }
+      const platform = selectedPlatform ?? toSelectedSdk(info);
 
       // If a project was already created for this platform (e.g. the user
       // went back after the project received its first event), reuse it.
@@ -550,9 +555,7 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
               }}
               onClick={handleContinue}
               disabled={
-                !currentPlatformKey ||
-                createProject.isPending ||
-                (!hasProjectDetailsStep && (isLoadingTeams || !projectsLoaded))
+                !currentPlatformKey || createProject.isPending || autoCreateDataPending
               }
               busy={createProject.isPending}
             >

--- a/static/app/views/onboarding/scmProjectDetails.spec.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.spec.tsx
@@ -381,6 +381,7 @@ describe('ScmProjectDetails', () => {
     const existingProject = ProjectFixture({
       slug: 'javascript-nextjs',
       name: 'javascript-nextjs',
+      platform: 'javascript-nextjs',
     });
     ProjectsStore.loadInitialData([existingProject]);
 
@@ -486,6 +487,73 @@ describe('ScmProjectDetails', () => {
     await userEvent.type(input, 'renamed-project');
 
     await userEvent.click(screen.getByRole('button', {name: 'Create project'}));
+
+    await waitFor(() => {
+      expect(createRequest).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(onComplete).toHaveBeenCalled();
+    });
+  });
+
+  it('creates a new project when the stored project has a different platform', async () => {
+    const stalePythonProject = ProjectFixture({
+      slug: 'javascript-nextjs',
+      name: 'javascript-nextjs',
+      platform: 'python',
+    });
+    ProjectsStore.loadInitialData([stalePythonProject]);
+
+    const createRequest = MockApiClient.addMockResponse({
+      url: `/teams/${organization.slug}/${teamWithAccess.slug}/projects/`,
+      method: 'POST',
+      body: ProjectFixture({
+        slug: 'javascript-nextjs',
+        name: 'javascript-nextjs',
+        platform: 'javascript-nextjs',
+      }),
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/`,
+      body: organization,
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/teams/`,
+      body: [teamWithAccess],
+    });
+
+    const onComplete = jest.fn();
+
+    render(
+      <ScmProjectDetails
+        onComplete={onComplete}
+        stepIndex={3}
+        genSkipOnboardingLink={() => null}
+      />,
+      {
+        organization,
+        additionalWrapper: makeOnboardingWrapper({
+          selectedPlatform: mockPlatform,
+          createdProjectSlug: stalePythonProject.slug,
+          projectDetailsForm: {
+            projectName: 'javascript-nextjs',
+            teamSlug: teamWithAccess.slug,
+            alertRuleConfig: {
+              alertSetting: RuleAction.DEFAULT_ALERT,
+              interval: '1m',
+              metric: MetricValues.ERRORS,
+              threshold: '10',
+            },
+          },
+        }),
+      }
+    );
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Create project'}));
 
     await waitFor(() => {
       expect(createRequest).toHaveBeenCalled();

--- a/static/app/views/onboarding/scmProjectDetails.tsx
+++ b/static/app/views/onboarding/scmProjectDetails.tsx
@@ -113,11 +113,17 @@ export function ScmProjectDetails({onComplete}: StepProps) {
     !isLoadingTeams &&
     projectsLoaded;
 
-  const projectStillExists =
-    !!createdProjectSlug && projects.some(p => p.slug === createdProjectSlug);
+  const existingProject = createdProjectSlug
+    ? projects.find(p => p.slug === createdProjectSlug)
+    : undefined;
 
+  // Platform is compared against the project record rather than a form-state
+  // snapshot because the Project model tracks it; alert fields are not on the
+  // Project record so we compare those against the context snapshot.
+  const samePlatform = existingProject?.platform === selectedPlatform?.key;
   const savedAlert = projectDetailsForm?.alertRuleConfig;
   const nothingChanged =
+    samePlatform &&
     !!projectDetailsForm &&
     projectNameResolved === projectDetailsForm.projectName &&
     teamSlugResolved === projectDetailsForm.teamSlug &&
@@ -136,10 +142,10 @@ export function ScmProjectDetails({onComplete}: StepProps) {
     // User navigated back and clicked Create without changing anything; skip
     // to setup-docs without creating a duplicate. Any actual change abandons
     // the previous project and creates a new one, matching legacy onboarding.
-    if (projectStillExists && createdProjectSlug && nothingChanged) {
+    if (existingProject && nothingChanged) {
       trackAnalytics('onboarding.scm_project_details_create_succeeded', {
         organization,
-        project_slug: createdProjectSlug,
+        project_slug: existingProject.slug,
       });
       onComplete(undefined, selectedFeatures ? {product: selectedFeatures} : undefined);
       return;

--- a/static/app/views/onboarding/useBackActions.tsx
+++ b/static/app/views/onboarding/useBackActions.tsx
@@ -10,6 +10,7 @@ import {handleXhrErrorResponse} from 'sentry/utils/handleXhrErrorResponse';
 import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useApi} from 'sentry/utils/useApi';
+import {useExperiment} from 'sentry/utils/useExperiment';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import type {StepDescriptor} from 'sentry/views/onboarding/types';
 
@@ -33,6 +34,9 @@ export function useBackActions({
   const api = useApi();
   const organization = useOrganization();
   const onboardingContext = useOnboardingContext();
+  const {inExperiment: hasScmOnboarding} = useExperiment({
+    feature: 'onboarding-scm-experiment',
+  });
   const currentStep = onboardingSteps[stepIndex];
 
   const deleteRecentCreatedProject = useCallback(
@@ -118,7 +122,7 @@ export function useBackActions({
         // store data and skip project creation.
         // In the SCM flow, preserve context so the user keeps their SCM
         // connection, repo selection, and feature choices.
-        await deleteRecentCreatedProject(prevStep.id === 'scm-project-details');
+        await deleteRecentCreatedProject(hasScmOnboarding);
       }
 
       if (!browserBackButton) {
@@ -126,13 +130,14 @@ export function useBackActions({
       }
     },
     [
-      goToStep,
+      currentStep,
       organization,
-      onboardingContext,
       isRecentCreatedProjectActive,
       recentCreatedProject,
-      currentStep,
+      onboardingContext,
+      goToStep,
       deleteRecentCreatedProject,
+      hasScmOnboarding,
     ]
   );
 

--- a/static/app/views/onboarding/useBackActions.tsx
+++ b/static/app/views/onboarding/useBackActions.tsx
@@ -36,6 +36,7 @@ export function useBackActions({
   const onboardingContext = useOnboardingContext();
   const {inExperiment: hasScmOnboarding} = useExperiment({
     feature: 'onboarding-scm-experiment',
+    reportExposure: false,
   });
   const currentStep = onboardingSteps[stepIndex];
 

--- a/tests/acceptance/test_scm_onboarding.py
+++ b/tests/acceptance/test_scm_onboarding.py
@@ -87,6 +87,23 @@ class ScmOnboardingTest(AcceptanceTestCase):
         self.browser.wait_until_clickable(xpath='//button[contains(., "Create project")]')
         self.browser.click(xpath='//button[contains(., "Create project")]')
 
+    def skip_to_setup_docs_control(self, platform_search: str, platform_label: str) -> None:
+        """Control-path variant: Continue on platform features auto-creates the project."""
+        self.browser.click(xpath='//button[contains(., "Skip for now")]')
+
+        self.browser.wait_until('[data-test-id="onboarding-step-scm-platform-features"]')
+        self.browser.wait_until(xpath='//h3[text()="Select a platform"]')
+        input_el = self.browser.element('input[aria-autocomplete="list"]')
+        input_el.send_keys(platform_search)
+        self.browser.wait_until(
+            xpath=f'//p[@data-test-id="menu-list-item-label"][text()="{platform_label}"]'
+        )
+        self.browser.click(
+            xpath=f'//p[@data-test-id="menu-list-item-label"][text()="{platform_label}"]'
+        )
+        self.browser.wait_until_clickable(xpath='//button[contains(., "Continue")]')
+        self.browser.click(xpath='//button[contains(., "Continue")]')
+
     def test_scm_onboarding_happy_path(self) -> None:
         """Full flow: welcome → connect repo → detected platform → create project."""
         self.create_github_integration()
@@ -600,8 +617,8 @@ class ScmOnboardingTest(AcceptanceTestCase):
             )
             assert Rule.objects.filter(project=project2).count() == 1
 
-    def test_scm_onboarding_skips_project_details_when_experiment_off(self) -> None:
-        """Control path: Continue on platform features auto-creates project and lands on setup-docs."""
+    def test_scm_onboarding_control_skip_integration(self) -> None:
+        """Control path skip flow: skip connect → manual platform → Continue auto-creates project."""
         with self.feature(
             {
                 "organizations:onboarding-scm-experiment": True,
@@ -609,19 +626,7 @@ class ScmOnboardingTest(AcceptanceTestCase):
             }
         ):
             self.start_onboarding()
-
-            self.browser.click(xpath='//button[contains(., "Skip for now")]')
-
-            self.browser.wait_until('[data-test-id="onboarding-step-scm-platform-features"]')
-            self.browser.wait_until(xpath='//h3[text()="Select a platform"]')
-            input_el = self.browser.element('input[aria-autocomplete="list"]')
-            input_el.send_keys("React")
-            self.browser.wait_until(
-                xpath='//p[@data-test-id="menu-list-item-label"][text()="React"]'
-            )
-            self.browser.click(xpath='//p[@data-test-id="menu-list-item-label"][text()="React"]')
-            self.browser.wait_until_clickable(xpath='//button[contains(., "Continue")]')
-            self.browser.click(xpath='//button[contains(., "Continue")]')
+            self.skip_to_setup_docs_control("React", "React")
 
             # Skips scm-project-details entirely and lands on setup-docs.
             self.browser.wait_until(xpath='//h2[text()="Configure React SDK"]')
@@ -635,4 +640,169 @@ class ScmOnboardingTest(AcceptanceTestCase):
             assert Rule.objects.filter(project=project).count() == 1
             assert_existing_projects_status(
                 self.org, active_project_ids=[project.id], deleted_project_ids=[]
+            )
+
+    def test_scm_onboarding_control_happy_path(self) -> None:
+        """Control path full flow: connect repo → detected platform → Continue auto-creates project."""
+        self.create_github_integration()
+
+        mock_repos = [
+            {
+                "name": "sentry",
+                "identifier": "getsentry/sentry",
+                "default_branch": "master",
+                "external_id": "12345",
+            },
+        ]
+        mock_platforms = [
+            {
+                "platform": "python-django",
+                "language": "Python",
+                "bytes": 50000,
+                "confidence": "high",
+                "priority": 1,
+            }
+        ]
+
+        with (
+            self.feature(
+                {
+                    "organizations:onboarding-scm-experiment": True,
+                    "organizations:onboarding-scm-project-details-experiment": False,
+                    "organizations:integrations-github-platform-detection": True,
+                }
+            ),
+            mock.patch(
+                "sentry.integrations.github.integration.GitHubIntegration.get_repositories",
+                return_value=mock_repos,
+            ),
+            mock.patch(
+                "sentry.integrations.github.repository.GitHubRepositoryProvider._validate_repo",
+                return_value={"id": "12345"},
+            ),
+            mock.patch(
+                "sentry.integrations.api.endpoints.organization_repository_platforms.detect_platforms",
+                return_value=mock_platforms,
+            ),
+        ):
+            self.start_onboarding()
+
+            self.browser.wait_until(xpath='//*[contains(text(), "Connected to")]')
+            input_el = self.browser.element('input[aria-autocomplete="list"]')
+            input_el.send_keys("sentry")
+            self.browser.wait_until('[data-test-id="menu-list-item-label"]')
+            self.browser.click('[data-test-id="menu-list-item-label"]')
+            self.browser.wait_until_clickable(xpath='//button[contains(., "Continue")]')
+            self.browser.click(xpath='//button[contains(., "Continue")]')
+
+            self.browser.wait_until('[data-test-id="onboarding-step-scm-platform-features"]')
+            self.browser.wait_until('[role="radio"]')
+            self.browser.click('[role="radio"]')
+            self.browser.wait_until_clickable(xpath='//button[contains(., "Continue")]')
+            self.browser.click(xpath='//button[contains(., "Continue")]')
+
+            self.browser.wait_until(xpath='//h2[text()="Configure Django SDK"]')
+            assert not self.browser.element_exists(
+                '[data-test-id="onboarding-step-scm-project-details"]'
+            )
+
+            project = Project.objects.get(organization=self.org)
+            assert project.platform == "python-django"
+            assert project.name == "python-django"
+            assert project.slug == "python-django"
+            assert_existing_projects_status(
+                self.org, active_project_ids=[project.id], deleted_project_ids=[]
+            )
+
+    def test_scm_back_from_setup_docs_control_non_active_project(self) -> None:
+        """Control path: non-active project is deleted on back-nav; Continue creates a fresh one."""
+        with self.feature(
+            {
+                "organizations:onboarding-scm-experiment": True,
+                "organizations:onboarding-scm-project-details-experiment": False,
+            }
+        ):
+            self.start_onboarding()
+            self.skip_to_setup_docs_control("React", "React")
+
+            self.browser.wait_until(xpath='//h2[text()="Configure React SDK"]')
+            project1 = Project.objects.get(organization=self.org)
+            assert project1.platform == "javascript-react"
+
+            # Back from setup-docs lands on scm-platform-features; project has no
+            # events, so useBackActions deletes it.
+            self.browser.click('[aria-label="Back"]')
+            self.browser.wait_until('[data-test-id="onboarding-step-scm-platform-features"]')
+            self.browser.wait_until_clickable(xpath='//button[contains(., "Continue")]')
+            self.browser.click(xpath='//button[contains(., "Continue")]')
+
+            self.browser.wait_until(xpath='//h2[text()="Configure React SDK"]')
+            project2 = Project.objects.get(organization=self.org, slug="javascript-react", status=0)
+            assert project2.id != project1.id
+            assert_existing_projects_status(
+                self.org,
+                active_project_ids=[project2.id],
+                deleted_project_ids=[project1.id],
+            )
+
+    def test_scm_back_from_setup_docs_control_active_project_no_changes(self) -> None:
+        """Control path: active project survives back-nav; Continue reuses it (no duplicate)."""
+        with self.feature(
+            {
+                "organizations:onboarding-scm-experiment": True,
+                "organizations:onboarding-scm-project-details-experiment": False,
+            }
+        ):
+            self.start_onboarding()
+            self.skip_to_setup_docs_control("React", "React")
+
+            self.browser.wait_until(xpath='//h2[text()="Configure React SDK"]')
+            project = Project.objects.get(organization=self.org)
+
+            Project.objects.filter(id=project.id).update(first_event=timezone.now())
+
+            self.browser.click('[aria-label="Back"]')
+            self.browser.wait_until('[data-test-id="onboarding-step-scm-platform-features"]')
+            self.browser.wait_until_clickable(xpath='//button[contains(., "Continue")]')
+            self.browser.click(xpath='//button[contains(., "Continue")]')
+
+            self.browser.wait_until(xpath='//h2[text()="Configure React SDK"]')
+            assert Project.objects.filter(organization=self.org, status=0).count() == 1
+            assert_existing_projects_status(
+                self.org, active_project_ids=[project.id], deleted_project_ids=[]
+            )
+
+    def test_scm_back_from_setup_docs_control_active_project_platform_changed(self) -> None:
+        """Control path: active project survives back-nav; changing platform creates a new project."""
+        with self.feature(
+            {
+                "organizations:onboarding-scm-experiment": True,
+                "organizations:onboarding-scm-project-details-experiment": False,
+            }
+        ):
+            self.start_onboarding()
+            self.skip_to_setup_docs_control("React", "React")
+
+            self.browser.wait_until(xpath='//h2[text()="Configure React SDK"]')
+            project1 = Project.objects.get(organization=self.org)
+
+            Project.objects.filter(id=project1.id).update(first_event=timezone.now())
+
+            self.browser.click('[aria-label="Back"]')
+            self.browser.wait_until('[data-test-id="onboarding-step-scm-platform-features"]')
+            self.browser.wait_until(xpath='//h3[text()="Select a platform"]')
+            input_el = self.browser.element('input[aria-autocomplete="list"]')
+            input_el.send_keys("Vue")
+            self.browser.wait_until(xpath='//p[@data-test-id="menu-list-item-label"][text()="Vue"]')
+            self.browser.click(xpath='//p[@data-test-id="menu-list-item-label"][text()="Vue"]')
+            self.browser.wait_until_clickable(xpath='//button[contains(., "Continue")]')
+            self.browser.click(xpath='//button[contains(., "Continue")]')
+
+            self.browser.wait_until(xpath='//h2[text()="Configure Vue SDK"]')
+            project2 = Project.objects.get(organization=self.org, platform="javascript-vue")
+            assert project2.id != project1.id
+            assert_existing_projects_status(
+                self.org,
+                active_project_ids=[project1.id, project2.id],
+                deleted_project_ids=[],
             )

--- a/tests/acceptance/test_scm_onboarding.py
+++ b/tests/acceptance/test_scm_onboarding.py
@@ -114,6 +114,7 @@ class ScmOnboardingTest(AcceptanceTestCase):
             self.feature(
                 {
                     "organizations:onboarding-scm-experiment": True,
+                    "organizations:onboarding-scm-project-details-experiment": True,
                     "organizations:integrations-github-platform-detection": True,
                 }
             ),
@@ -167,7 +168,12 @@ class ScmOnboardingTest(AcceptanceTestCase):
 
     def test_scm_onboarding_skip_integration(self) -> None:
         """Skip flow: welcome → skip connect → manual platform → create project."""
-        with self.feature({"organizations:onboarding-scm-experiment": True}):
+        with self.feature(
+            {
+                "organizations:onboarding-scm-experiment": True,
+                "organizations:onboarding-scm-project-details-experiment": True,
+            }
+        ):
             self.start_onboarding()
 
             # SCM Connect: skip
@@ -237,6 +243,7 @@ class ScmOnboardingTest(AcceptanceTestCase):
             self.feature(
                 {
                     "organizations:onboarding-scm-experiment": True,
+                    "organizations:onboarding-scm-project-details-experiment": True,
                     "organizations:integrations-github-platform-detection": True,
                 }
             ),
@@ -372,6 +379,7 @@ class ScmOnboardingTest(AcceptanceTestCase):
             self.feature(
                 {
                     "organizations:onboarding-scm-experiment": True,
+                    "organizations:onboarding-scm-project-details-experiment": True,
                     "organizations:integrations-github-platform-detection": True,
                 }
             ),
@@ -447,7 +455,12 @@ class ScmOnboardingTest(AcceptanceTestCase):
 
     def test_scm_back_from_setup_docs_non_active_project(self) -> None:
         """Non-active project is deleted on back-nav; re-creating produces a fresh project."""
-        with self.feature({"organizations:onboarding-scm-experiment": True}):
+        with self.feature(
+            {
+                "organizations:onboarding-scm-experiment": True,
+                "organizations:onboarding-scm-project-details-experiment": True,
+            }
+        ):
             self.start_onboarding()
             self.skip_to_setup_docs("React", "React")
 
@@ -473,7 +486,12 @@ class ScmOnboardingTest(AcceptanceTestCase):
     def test_scm_back_from_setup_docs_active_project_no_changes(self) -> None:
         """Active project survives back-nav; clicking Create again reuses it (no duplicate)."""
         with (
-            self.feature({"organizations:onboarding-scm-experiment": True}),
+            self.feature(
+                {
+                    "organizations:onboarding-scm-experiment": True,
+                    "organizations:onboarding-scm-project-details-experiment": True,
+                }
+            ),
             self.projects_born_active(),
         ):
             self.start_onboarding()
@@ -500,7 +518,12 @@ class ScmOnboardingTest(AcceptanceTestCase):
     def test_scm_back_from_setup_docs_active_project_alert_changed(self) -> None:
         """Changing the alert setting abandons the active project and creates a new one."""
         with (
-            self.feature({"organizations:onboarding-scm-experiment": True}),
+            self.feature(
+                {
+                    "organizations:onboarding-scm-experiment": True,
+                    "organizations:onboarding-scm-project-details-experiment": True,
+                }
+            ),
             self.projects_born_active(),
         ):
             self.start_onboarding()
@@ -537,7 +560,12 @@ class ScmOnboardingTest(AcceptanceTestCase):
     def test_scm_back_from_setup_docs_active_project_platform_changed(self) -> None:
         """Active project survives back-nav; changing platform creates a new project."""
         with (
-            self.feature({"organizations:onboarding-scm-experiment": True}),
+            self.feature(
+                {
+                    "organizations:onboarding-scm-experiment": True,
+                    "organizations:onboarding-scm-project-details-experiment": True,
+                }
+            ),
             self.projects_born_active(),
         ):
             self.start_onboarding()
@@ -571,3 +599,40 @@ class ScmOnboardingTest(AcceptanceTestCase):
                 deleted_project_ids=[],
             )
             assert Rule.objects.filter(project=project2).count() == 1
+
+    def test_scm_onboarding_skips_project_details_when_experiment_off(self) -> None:
+        """Control path: Continue on platform features auto-creates project and lands on setup-docs."""
+        with self.feature(
+            {
+                "organizations:onboarding-scm-experiment": True,
+                "organizations:onboarding-scm-project-details-experiment": False,
+            }
+        ):
+            self.start_onboarding()
+
+            self.browser.click(xpath='//button[contains(., "Skip for now")]')
+
+            self.browser.wait_until('[data-test-id="onboarding-step-scm-platform-features"]')
+            self.browser.wait_until(xpath='//h3[text()="Select a platform"]')
+            input_el = self.browser.element('input[aria-autocomplete="list"]')
+            input_el.send_keys("React")
+            self.browser.wait_until(
+                xpath='//p[@data-test-id="menu-list-item-label"][text()="React"]'
+            )
+            self.browser.click(xpath='//p[@data-test-id="menu-list-item-label"][text()="React"]')
+            self.browser.wait_until_clickable(xpath='//button[contains(., "Continue")]')
+            self.browser.click(xpath='//button[contains(., "Continue")]')
+
+            # Skips scm-project-details entirely and lands on setup-docs.
+            self.browser.wait_until(xpath='//h2[text()="Configure React SDK"]')
+            assert not self.browser.element_exists(
+                '[data-test-id="onboarding-step-scm-project-details"]'
+            )
+
+            project = Project.objects.get(organization=self.org)
+            assert project.platform == "javascript-react"
+            assert project.slug == "javascript-react"
+            assert Rule.objects.filter(project=project).count() == 1
+            assert_existing_projects_status(
+                self.org, active_project_ids=[project.id], deleted_project_ids=[]
+            )

--- a/tests/acceptance/test_scm_onboarding.py
+++ b/tests/acceptance/test_scm_onboarding.py
@@ -747,19 +747,20 @@ class ScmOnboardingTest(AcceptanceTestCase):
 
     def test_scm_back_from_setup_docs_control_active_project_no_changes(self) -> None:
         """Control path: active project survives back-nav; Continue reuses it (no duplicate)."""
-        with self.feature(
-            {
-                "organizations:onboarding-scm-experiment": True,
-                "organizations:onboarding-scm-project-details-experiment": False,
-            }
+        with (
+            self.feature(
+                {
+                    "organizations:onboarding-scm-experiment": True,
+                    "organizations:onboarding-scm-project-details-experiment": False,
+                }
+            ),
+            self.projects_born_active(),
         ):
             self.start_onboarding()
             self.skip_to_setup_docs_control("React", "React")
 
             self.browser.wait_until(xpath='//h2[text()="Configure React SDK"]')
             project = Project.objects.get(organization=self.org)
-
-            Project.objects.filter(id=project.id).update(first_event=timezone.now())
 
             self.browser.click('[aria-label="Back"]')
             self.browser.wait_until('[data-test-id="onboarding-step-scm-platform-features"]')
@@ -774,19 +775,20 @@ class ScmOnboardingTest(AcceptanceTestCase):
 
     def test_scm_back_from_setup_docs_control_active_project_platform_changed(self) -> None:
         """Control path: active project survives back-nav; changing platform creates a new project."""
-        with self.feature(
-            {
-                "organizations:onboarding-scm-experiment": True,
-                "organizations:onboarding-scm-project-details-experiment": False,
-            }
+        with (
+            self.feature(
+                {
+                    "organizations:onboarding-scm-experiment": True,
+                    "organizations:onboarding-scm-project-details-experiment": False,
+                }
+            ),
+            self.projects_born_active(),
         ):
             self.start_onboarding()
             self.skip_to_setup_docs_control("React", "React")
 
             self.browser.wait_until(xpath='//h2[text()="Configure React SDK"]')
             project1 = Project.objects.get(organization=self.org)
-
-            Project.objects.filter(id=project1.id).update(first_event=timezone.now())
 
             self.browser.click('[aria-label="Back"]')
             self.browser.wait_until('[data-test-id="onboarding-step-scm-platform-features"]')


### PR DESCRIPTION
Gate the `SCM_PROJECT_DETAILS` step behind the `onboarding-scm-project-details-experiment` assignment to experiment with a shorter SCM onboarding flow.

When the user is in the experiment, the flow is unchanged: `SCM_CONNECT -> SCM_PLATFORM_FEATURES -> SCM_PROJECT_DETAILS -> SETUP_DOCS`

When the user is in the control group, the project details step is skipped: `SCM_CONNECT -> SCM_PLATFORM_FEATURES -> SETUP_DOCS`

In the skipped case, clicking Continue on the platform features step auto-creates the project with defaults (platform key as name, first admin team, default alert rules), sets `createdProjectSlug` in context so `SETUP_DOCS` can find it, and passes selected features as query products. Also updates `useBackActions` to use `useExperiment` since the hardcoded step ID no longer works when the step is removed.

Tests cover both paths: the experiment-on flow (unchanged) and the control flow (auto-create on Continue, back-nav with inactive/active/platform-changed projects).

Also aligns the reuse check in `scmProjectDetails.tsx` with the new one in `scmPlatformFeatures.tsx`. Both now cross-check `existingProject.platform` against the current selection so the guard does not rely on `projectDetailsForm` being cleared whenever platform changes. That refactor is arguably a #113111 concern but lives here because the divergence only appears once this PR introduces the second callsite.

**PR stack:**
- [PR 1](https://github.com/getsentry/sentry/pull/113128): Context refactor, persist form state (merged)
- [PR 2](https://github.com/getsentry/sentry/pull/113111): Gap fixes for SCM project creation (merged)
- **PR 3 (this):** VDY-82 feature flag gating

Refs VDY-82
