### PR TITLE
fix(settings): Add spacing above notification alert on emails page

### DIFF
--- a/static/app/views/settings/account/accountEmails.tsx
+++ b/static/app/views/settings/account/accountEmails.tsx
@@ -7,7 +7,7 @@ import {AlertLink} from '@sentry/scraps/alert';
 import {Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {defaultFormOptions, FormSearch, useScrapsForm} from '@sentry/scraps/form';
-import {Flex, Grid} from '@sentry/scraps/layout';
+import {Container, Flex, Grid} from '@sentry/scraps/layout';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import type {RequestOptions} from 'sentry/api';
@@ -107,15 +107,17 @@ function AccountEmails() {
         </form.AppForm>
       </FormSearch>
 
-      <AlertLink.Container>
-        <AlertLink
-          to="/settings/account/notifications"
-          trailingItems={<IconStack />}
-          variant="info"
-        >
-          {t('Want to change how many emails you get? Use the notifications panel.')}
-        </AlertLink>
-      </AlertLink.Container>
+      <Container paddingTop="xl">
+        <AlertLink.Container>
+          <AlertLink
+            to="/settings/account/notifications/"
+            trailingItems={<IconStack />}
+            variant="info"
+          >
+            {t('Want to change how many emails you get? Use the notifications panel.')}
+          </AlertLink>
+        </AlertLink.Container>
+      </Container>
     </Fragment>
   );
 }


### PR DESCRIPTION
The alert was sitting right up against the "Add email" submit button. I think alerts use to have margin or something crazy.

before

<img width="1066" height="273" alt="image" src="https://github.com/user-attachments/assets/d61d6f9f-343b-49af-93b9-c034bb03475e" />
