### PR TITLE
feat(aci): Send project slug with test fire action request

### DIFF
--- a/static/app/views/automations/components/actionFilterBlock.tsx
+++ b/static/app/views/automations/components/actionFilterBlock.tsx
@@ -1,0 +1,215 @@
+import styled from '@emotion/styled';
+
+import {Button} from '@sentry/scraps/button';
+import {Container, Flex} from '@sentry/scraps/layout';
+import {Select} from '@sentry/scraps/select';
+
+import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
+import {ConditionBadge} from 'sentry/components/workflowEngine/ui/conditionBadge';
+import {IconDelete, IconMail} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
+import type {SelectValue} from 'sentry/types/core';
+import type {Action} from 'sentry/types/workflowEngine/actions';
+import {
+  DataConditionGroupLogicType,
+  DataConditionHandlerGroupType,
+  type DataConditionGroup,
+} from 'sentry/types/workflowEngine/dataConditions';
+import type {RequestError} from 'sentry/utils/requestError/requestError';
+import {useProjects} from 'sentry/utils/useProjects';
+import {FILTER_MATCH_OPTIONS} from 'sentry/views/automations/components/actionFilters/constants';
+import {ActionNodeList} from 'sentry/views/automations/components/actionNodeList';
+import {useAutomationBuilderContext} from 'sentry/views/automations/components/automationBuilderContext';
+import {useAutomationBuilderErrorContext} from 'sentry/views/automations/components/automationBuilderErrorContext';
+import {
+  stripActionFields,
+  validateActions,
+} from 'sentry/views/automations/components/automationFormData';
+import {DataConditionNodeList} from 'sentry/views/automations/components/dataConditionNodeList';
+import {useSendTestNotification as useSendTestNotificationMutation} from 'sentry/views/automations/hooks';
+import {useConnectedDetectors} from 'sentry/views/automations/hooks/useConnectedDetectors';
+
+// We want the test notification to use a project that makes sense for alert config,
+// so this selects the first project that is connected, and that the user has access to.
+// If no project meets these criteria, we send nothing and the endpoint will default to a random project.
+function useTestNotificationProjectSlug(): string | undefined {
+  const formProjectIds = useFormField<string[]>('projectIds');
+  const {connectedDetectors} = useConnectedDetectors();
+  const {projects} = useProjects();
+
+  const selectedProjectIds = new Set([
+    ...(formProjectIds ?? []),
+    ...connectedDetectors.map(d => d.projectId),
+  ]);
+
+  return projects.find(p => selectedProjectIds.has(p.id))?.slug;
+}
+
+function useSendTestNotification(actionFilterActions: Action[]) {
+  const {setErrors} = useAutomationBuilderErrorContext();
+  const projectSlug = useTestNotificationProjectSlug();
+
+  const {mutate, isPending} = useSendTestNotificationMutation({
+    onError: (error: RequestError) => {
+      setErrors(prev => ({
+        ...prev,
+        ...error?.responseJSON,
+      }));
+    },
+  });
+
+  const sendTestNotification = () => {
+    const actionErrors = validateActions({actions: actionFilterActions});
+    setErrors(prev => ({...prev, ...actionErrors}));
+
+    if (Object.keys(actionErrors).length === 0) {
+      mutate({
+        actions: actionFilterActions.map(action => stripActionFields(action)),
+        projectSlug,
+      });
+    }
+  };
+
+  return {sendTestNotification, isPending};
+}
+
+interface ActionFilterBlockProps {
+  actionFilter: DataConditionGroup;
+}
+
+export function ActionFilterBlock({actionFilter}: ActionFilterBlockProps) {
+  const {state, actions} = useAutomationBuilderContext();
+  const actionFilterActions = actionFilter.actions || [];
+  const {sendTestNotification, isPending} = useSendTestNotification(actionFilterActions);
+  const numActionFilters = state.actionFilters.length;
+
+  return (
+    <IfThenWrapper>
+      <Step>
+        <Flex direction="column" gap="md">
+          <StepLead data-test-id="action-filter-logic-type">
+            {tct('[if: If] [selector] of these filters match', {
+              if: <ConditionBadge />,
+              selector: (
+                <Container width="80px">
+                  <EmbeddedSelectField
+                    styles={{
+                      control: (provided: any) => ({
+                        ...provided,
+                        minHeight: '21px',
+                        height: '21px',
+                      }),
+                    }}
+                    isSearchable={false}
+                    isClearable={false}
+                    name={`actionFilters.${actionFilter.id}.logicType`}
+                    options={FILTER_MATCH_OPTIONS}
+                    size="xs"
+                    value={
+                      FILTER_MATCH_OPTIONS.find(
+                        choice =>
+                          choice.value === actionFilter.logicType ||
+                          choice.alias === actionFilter.logicType
+                      )?.value || actionFilter.logicType
+                    }
+                    onChange={(option: SelectValue<DataConditionGroupLogicType>) =>
+                      actions.updateIfLogicType(actionFilter.id, option.value)
+                    }
+                  />
+                </Container>
+              ),
+            })}
+          </StepLead>
+          {numActionFilters > 1 && (
+            <DeleteButton
+              aria-label={t('Delete If/Then Block')}
+              size="sm"
+              icon={<IconDelete />}
+              priority="transparent"
+              onClick={() => actions.removeIf(actionFilter.id)}
+              className="delete-condition-group"
+            />
+          )}
+          <DataConditionNodeList
+            handlerGroup={DataConditionHandlerGroupType.ACTION_FILTER}
+            label={t('Add filter')}
+            placeholder={t('Any event')}
+            groupId={actionFilter.id}
+            conditions={actionFilter?.conditions || []}
+            onAddRow={type => actions.addIfCondition(actionFilter.id, type)}
+            onDeleteRow={id => actions.removeIfCondition(actionFilter.id, id)}
+            updateCondition={(id, params) =>
+              actions.updateIfCondition(actionFilter.id, id, params)
+            }
+          />
+        </Flex>
+      </Step>
+      <Step>
+        <StepLead>
+          {tct('[then:Then] perform these actions', {
+            then: <ConditionBadge />,
+          })}
+        </StepLead>
+        <ActionNodeList
+          placeholder={t('Select an action')}
+          conditionGroupId={actionFilter.id}
+          actions={actionFilter?.actions || []}
+          onAddRow={handler => actions.addIfAction(actionFilter.id, handler)}
+          onDeleteRow={id => actions.removeIfAction(actionFilter.id, id)}
+          updateAction={(id, data) => actions.updateIfAction(actionFilter.id, id, data)}
+        />
+      </Step>
+      <span>
+        <Button
+          icon={<IconMail />}
+          onClick={sendTestNotification}
+          disabled={!actionFilter.actions?.length || isPending}
+        >
+          {t('Send Test Notification')}
+        </Button>
+      </span>
+    </IfThenWrapper>
+  );
+}
+
+const Step = styled(Flex)`
+  flex-direction: column;
+  gap: ${p => p.theme.space.sm};
+`;
+
+const StepLead = styled(Flex)`
+  align-items: center;
+  gap: ${p => p.theme.space.xs};
+  margin-bottom: ${p => p.theme.space.xs};
+`;
+
+const EmbeddedSelectField = styled(Select)`
+  padding: 0;
+  font-weight: ${p => p.theme.font.weight.sans.regular};
+  text-transform: none;
+`;
+
+const IfThenWrapper = styled(Flex)`
+  position: relative;
+  flex-direction: column;
+  gap: ${p => p.theme.space.md};
+  border: 1px solid ${p => p.theme.tokens.border.primary};
+  border-radius: ${p => p.theme.radius.md};
+  padding: ${p => p.theme.space.lg};
+  margin-top: ${p => p.theme.space.md};
+
+  /* Only hide delete button when hover is supported */
+  @media (hover: hover) {
+    &:not(:hover):not(:focus-within) {
+      .delete-condition-group {
+        ${p => p.theme.visuallyHidden}
+      }
+    }
+  }
+`;
+
+const DeleteButton = styled(Button)`
+  position: absolute;
+  top: ${p => p.theme.space.sm};
+  right: ${p => p.theme.space.sm};
+`;

--- a/static/app/views/automations/components/actionFilterBlock.tsx
+++ b/static/app/views/automations/components/actionFilterBlock.tsx
@@ -2,7 +2,6 @@ import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 import {Container, Flex} from '@sentry/scraps/layout';
-import {Select} from '@sentry/scraps/select';
 
 import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
 import {ConditionBadge} from 'sentry/components/workflowEngine/ui/conditionBadge';
@@ -26,6 +25,11 @@ import {
   validateActions,
 } from 'sentry/views/automations/components/automationFormData';
 import {DataConditionNodeList} from 'sentry/views/automations/components/dataConditionNodeList';
+import {
+  EmbeddedSelectField,
+  Step,
+  StepLead,
+} from 'sentry/views/automations/components/stepComponents';
 import {useSendTestNotification as useSendTestNotificationMutation} from 'sentry/views/automations/hooks';
 import {useConnectedDetectors} from 'sentry/views/automations/hooks/useConnectedDetectors';
 
@@ -171,23 +175,6 @@ export function ActionFilterBlock({actionFilter}: ActionFilterBlockProps) {
     </IfThenWrapper>
   );
 }
-
-const Step = styled(Flex)`
-  flex-direction: column;
-  gap: ${p => p.theme.space.sm};
-`;
-
-const StepLead = styled(Flex)`
-  align-items: center;
-  gap: ${p => p.theme.space.xs};
-  margin-bottom: ${p => p.theme.space.xs};
-`;
-
-const EmbeddedSelectField = styled(Select)`
-  padding: 0;
-  font-weight: ${p => p.theme.font.weight.sans.regular};
-  text-transform: none;
-`;
 
 const IfThenWrapper = styled(Flex)`
   position: relative;

--- a/static/app/views/automations/components/automationBuilder.tsx
+++ b/static/app/views/automations/components/automationBuilder.tsx
@@ -3,7 +3,6 @@ import styled from '@emotion/styled';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Container, Flex} from '@sentry/scraps/layout';
-import {Select} from '@sentry/scraps/select';
 
 import {fetchOrgMembers} from 'sentry/actionCreators/members';
 import {ConditionBadge} from 'sentry/components/workflowEngine/ui/conditionBadge';
@@ -22,6 +21,11 @@ import {AutomationBuilderConflictContext} from 'sentry/views/automations/compone
 import {useAutomationBuilderContext} from 'sentry/views/automations/components/automationBuilderContext';
 import {useAutomationBuilderErrorContext} from 'sentry/views/automations/components/automationBuilderErrorContext';
 import {DataConditionNodeList} from 'sentry/views/automations/components/dataConditionNodeList';
+import {
+  EmbeddedSelectField,
+  Step,
+  StepLead,
+} from 'sentry/views/automations/components/stepComponents';
 import {TRIGGER_MATCH_OPTIONS} from 'sentry/views/automations/components/triggers/constants';
 import {findConflictingConditions} from 'sentry/views/automations/hooks/utils';
 
@@ -119,23 +123,6 @@ export function AutomationBuilder() {
     </AutomationBuilderConflictContext.Provider>
   );
 }
-
-const Step = styled(Flex)`
-  flex-direction: column;
-  gap: ${p => p.theme.space.sm};
-`;
-
-const StepLead = styled(Flex)`
-  align-items: center;
-  gap: ${p => p.theme.space.xs};
-  margin-bottom: ${p => p.theme.space.xs};
-`;
-
-const EmbeddedSelectField = styled(Select)`
-  padding: 0;
-  font-weight: ${p => p.theme.font.weight.sans.regular};
-  text-transform: none;
-`;
 
 const StyledAlert = styled(Alert)`
   margin-top: ${p => p.theme.space.md};

--- a/static/app/views/automations/components/automationBuilder.tsx
+++ b/static/app/views/automations/components/automationBuilder.tsx
@@ -2,36 +2,27 @@ import {useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {Alert} from '@sentry/scraps/alert';
-import {Button} from '@sentry/scraps/button';
 import {Container, Flex} from '@sentry/scraps/layout';
 import {Select} from '@sentry/scraps/select';
 
 import {fetchOrgMembers} from 'sentry/actionCreators/members';
 import {ConditionBadge} from 'sentry/components/workflowEngine/ui/conditionBadge';
 import {PurpleTextButton} from 'sentry/components/workflowEngine/ui/purpleTextButton';
-import {IconAdd, IconDelete, IconMail} from 'sentry/icons';
+import {IconAdd} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {SelectValue} from 'sentry/types/core';
 import {
-  type DataConditionGroup,
   DataConditionGroupLogicType,
   DataConditionHandlerGroupType,
 } from 'sentry/types/workflowEngine/dataConditions';
-import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {useApi} from 'sentry/utils/useApi';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {FILTER_MATCH_OPTIONS} from 'sentry/views/automations/components/actionFilters/constants';
-import {ActionNodeList} from 'sentry/views/automations/components/actionNodeList';
+import {ActionFilterBlock} from 'sentry/views/automations/components/actionFilterBlock';
 import {AutomationBuilderConflictContext} from 'sentry/views/automations/components/automationBuilderConflictContext';
 import {useAutomationBuilderContext} from 'sentry/views/automations/components/automationBuilderContext';
 import {useAutomationBuilderErrorContext} from 'sentry/views/automations/components/automationBuilderErrorContext';
-import {
-  stripActionFields,
-  validateActions,
-} from 'sentry/views/automations/components/automationFormData';
 import {DataConditionNodeList} from 'sentry/views/automations/components/dataConditionNodeList';
 import {TRIGGER_MATCH_OPTIONS} from 'sentry/views/automations/components/triggers/constants';
-import {useSendTestNotification} from 'sentry/views/automations/hooks';
 import {findConflictingConditions} from 'sentry/views/automations/hooks/utils';
 
 export function AutomationBuilder() {
@@ -129,131 +120,6 @@ export function AutomationBuilder() {
   );
 }
 
-interface ActionFilterBlockProps {
-  actionFilter: DataConditionGroup;
-}
-
-function ActionFilterBlock({actionFilter}: ActionFilterBlockProps) {
-  const {state, actions} = useAutomationBuilderContext();
-  const {setErrors} = useAutomationBuilderErrorContext();
-  const {mutate: sendTestNotification, isPending} = useSendTestNotification({
-    onError: (error: RequestError) => {
-      // Store test notification error in error context
-      setErrors(prev => ({
-        ...prev,
-        ...error?.responseJSON,
-      }));
-    },
-  });
-
-  const numActionFilters = state.actionFilters.length;
-
-  const handleSendTestNotification = () => {
-    const actionFilterActions = actionFilter.actions || [];
-
-    // Validate actions before sending test notification
-    const actionErrors = validateActions({actions: actionFilterActions});
-    setErrors(prev => ({...prev, ...actionErrors}));
-
-    // Only send test notification if there are no validation errors
-    if (Object.keys(actionErrors).length === 0) {
-      sendTestNotification(
-        actionFilterActions.map(action => {
-          return stripActionFields(action);
-        })
-      );
-    }
-  };
-
-  return (
-    <IfThenWrapper>
-      <Step>
-        <Flex direction="column" gap="md">
-          <StepLead data-test-id="action-filter-logic-type">
-            {tct('[if: If] [selector] of these filters match', {
-              if: <ConditionBadge />,
-              selector: (
-                <Container width="80px">
-                  <EmbeddedSelectField
-                    styles={{
-                      control: (provided: any) => ({
-                        ...provided,
-                        minHeight: '21px',
-                        height: '21px',
-                      }),
-                    }}
-                    isSearchable={false}
-                    isClearable={false}
-                    name={`actionFilters.${actionFilter.id}.logicType`}
-                    options={FILTER_MATCH_OPTIONS}
-                    size="xs"
-                    value={
-                      FILTER_MATCH_OPTIONS.find(
-                        choice =>
-                          choice.value === actionFilter.logicType ||
-                          choice.alias === actionFilter.logicType
-                      )?.value || actionFilter.logicType
-                    }
-                    onChange={(option: SelectValue<DataConditionGroupLogicType>) =>
-                      actions.updateIfLogicType(actionFilter.id, option.value)
-                    }
-                  />
-                </Container>
-              ),
-            })}
-          </StepLead>
-          {numActionFilters > 1 && (
-            <DeleteButton
-              aria-label={t('Delete If/Then Block')}
-              size="sm"
-              icon={<IconDelete />}
-              priority="transparent"
-              onClick={() => actions.removeIf(actionFilter.id)}
-              className="delete-condition-group"
-            />
-          )}
-          <DataConditionNodeList
-            handlerGroup={DataConditionHandlerGroupType.ACTION_FILTER}
-            label={t('Add filter')}
-            placeholder={t('Any event')}
-            groupId={actionFilter.id}
-            conditions={actionFilter?.conditions || []}
-            onAddRow={type => actions.addIfCondition(actionFilter.id, type)}
-            onDeleteRow={id => actions.removeIfCondition(actionFilter.id, id)}
-            updateCondition={(id, params) =>
-              actions.updateIfCondition(actionFilter.id, id, params)
-            }
-          />
-        </Flex>
-      </Step>
-      <Step>
-        <StepLead>
-          {tct('[then:Then] perform these actions', {
-            then: <ConditionBadge />,
-          })}
-        </StepLead>
-        <ActionNodeList
-          placeholder={t('Select an action')}
-          conditionGroupId={actionFilter.id}
-          actions={actionFilter?.actions || []}
-          onAddRow={handler => actions.addIfAction(actionFilter.id, handler)}
-          onDeleteRow={id => actions.removeIfAction(actionFilter.id, id)}
-          updateAction={(id, data) => actions.updateIfAction(actionFilter.id, id, data)}
-        />
-      </Step>
-      <span>
-        <Button
-          icon={<IconMail />}
-          onClick={handleSendTestNotification}
-          disabled={!actionFilter.actions?.length || isPending}
-        >
-          {t('Send Test Notification')}
-        </Button>
-      </span>
-    </IfThenWrapper>
-  );
-}
-
 const Step = styled(Flex)`
   flex-direction: column;
   gap: ${p => p.theme.space.sm};
@@ -269,31 +135,6 @@ const EmbeddedSelectField = styled(Select)`
   padding: 0;
   font-weight: ${p => p.theme.font.weight.sans.regular};
   text-transform: none;
-`;
-
-const IfThenWrapper = styled(Flex)`
-  position: relative;
-  flex-direction: column;
-  gap: ${p => p.theme.space.md};
-  border: 1px solid ${p => p.theme.tokens.border.primary};
-  border-radius: ${p => p.theme.radius.md};
-  padding: ${p => p.theme.space.lg};
-  margin-top: ${p => p.theme.space.md};
-
-  /* Only hide delete button when hover is supported */
-  @media (hover: hover) {
-    &:not(:hover):not(:focus-within) {
-      .delete-condition-group {
-        ${p => p.theme.visuallyHidden}
-      }
-    }
-  }
-`;
-
-const DeleteButton = styled(Button)`
-  position: absolute;
-  top: ${p => p.theme.space.sm};
-  right: ${p => p.theme.space.sm};
 `;
 
 const StyledAlert = styled(Alert)`

--- a/static/app/views/automations/components/stepComponents.tsx
+++ b/static/app/views/automations/components/stepComponents.tsx
@@ -1,0 +1,21 @@
+import styled from '@emotion/styled';
+
+import {Flex} from '@sentry/scraps/layout';
+import {Select} from '@sentry/scraps/select';
+
+export const Step = styled(Flex)`
+  flex-direction: column;
+  gap: ${p => p.theme.space.sm};
+`;
+
+export const StepLead = styled(Flex)`
+  align-items: center;
+  gap: ${p => p.theme.space.xs};
+  margin-bottom: ${p => p.theme.space.xs};
+`;
+
+export const EmbeddedSelectField = styled(Select)`
+  padding: 0;
+  font-weight: ${p => p.theme.font.weight.sans.regular};
+  text-transform: none;
+`;

--- a/static/app/views/automations/hooks/index.tsx
+++ b/static/app/views/automations/hooks/index.tsx
@@ -319,22 +319,27 @@ export function useUpdateAutomationsMutation() {
   });
 }
 
+interface SendTestNotificationVariables {
+  actions: Array<Omit<Action, 'id'>>;
+  projectSlug?: string;
+}
+
 export function useSendTestNotification(
-  options?: UseMutationOptions<void, RequestError, Array<Omit<Action, 'id'>>>
+  options?: UseMutationOptions<void, RequestError, SendTestNotificationVariables>
 ) {
   const org = useOrganization();
   const api = useApi({persistInFlight: true});
   const queryClient = useQueryClient();
 
-  return useMutation<void, RequestError, Array<Omit<Action, 'id'>>>({
-    mutationFn: data =>
+  return useMutation<void, RequestError, SendTestNotificationVariables>({
+    mutationFn: ({actions, projectSlug}) =>
       api.requestPromise(
         getApiUrl('/organizations/$organizationIdOrSlug/test-fire-actions/', {
           path: {organizationIdOrSlug: org.slug},
         }),
         {
           method: 'POST',
-          data: {actions: data},
+          data: {actions, projectSlug},
         }
       ),
     ...options,
@@ -343,14 +348,14 @@ export function useSendTestNotification(
         queryKey: automationsApiOptions(org).queryKey,
       });
       addSuccessMessage(
-        tn('Notification fired!', 'Notifications sent!', variables.length)
+        tn('Notification fired!', 'Notifications sent!', variables.actions.length)
       );
       options?.onSuccess?.(data, variables, onMutateResult, context);
     },
     onError: (error, variables, onMutateResult, context) => {
       addErrorMessage(
         getWorkflowEngineResponseErrorMessage(error.responseJSON) ||
-          tn('Notification failed', 'Notifications failed', variables.length)
+          tn('Notification failed', 'Notifications failed', variables.actions.length)
       );
       options?.onError?.(error, variables, onMutateResult, context);
     },

--- a/static/app/views/automations/new.spec.tsx
+++ b/static/app/views/automations/new.spec.tsx
@@ -529,7 +529,7 @@ describe('AutomationNewSettings', () => {
       expect(expectedAction).toBeDefined();
       expect(action).toEqual(expect.objectContaining(expectedAction));
     });
-  }, 10000);
+  }, 30000);
 
   it('sends test notification with project slug from connected monitor', async () => {
     jest.spyOn(indicators, 'addSuccessMessage');

--- a/static/app/views/automations/new.spec.tsx
+++ b/static/app/views/automations/new.spec.tsx
@@ -1,6 +1,8 @@
 import {AutomationFixture} from 'sentry-fixture/automations';
+import {IssueStreamDetectorFixture} from 'sentry-fixture/detectors';
 import {MemberFixture} from 'sentry-fixture/member';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
 import {UserFixture} from 'sentry-fixture/user';
 import {
   ActionHandlerFixture,
@@ -11,6 +13,7 @@ import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrar
 import {selectEvent} from 'sentry-test/selectEvent';
 
 import * as indicators from 'sentry/actionCreators/indicator';
+import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {Action} from 'sentry/types/workflowEngine/actions';
 import {ActionGroup, ActionType} from 'sentry/types/workflowEngine/actions';
 import {
@@ -527,6 +530,68 @@ describe('AutomationNewSettings', () => {
       expect(action).toEqual(expect.objectContaining(expectedAction));
     });
   }, 10000);
+
+  it('sends test notification with project slug from connected monitor', async () => {
+    jest.spyOn(indicators, 'addSuccessMessage');
+
+    const project = ProjectFixture({id: '1', slug: 'my-project'});
+    ProjectsStore.loadInitialData([project]);
+
+    const detectorId = '10';
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/detectors/`,
+      method: 'GET',
+      body: [IssueStreamDetectorFixture({id: detectorId, projectId: project.id})],
+    });
+
+    const testFireAction = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/test-fire-actions/`,
+      method: 'POST',
+      body: {},
+    });
+
+    render(<AutomationNewSettings />, {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: `/organizations/${organization.slug}/alerts/new/`,
+          query: {connectedIds: detectorId},
+        },
+      },
+    });
+
+    await selectEvent.select(screen.getByRole('textbox', {name: 'Add action'}), 'Slack');
+    await userEvent.type(screen.getByRole('textbox', {name: 'Target'}), '#alerts');
+    await userEvent.click(screen.getByRole('button', {name: 'Send Test Notification'}));
+
+    await waitFor(() => {
+      expect(testFireAction).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          data: {
+            actions: [
+              {
+                type: ActionType.SLACK,
+                integrationId: 'slack-1',
+                config: {
+                  targetType: 'specific',
+                  targetIdentifier: '',
+                  targetDisplay: '#alerts',
+                },
+                data: {},
+                status: 'active',
+              },
+            ],
+            projectSlug: 'my-project',
+          },
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(indicators.addSuccessMessage).toHaveBeenCalledWith('Notification fired!');
+    });
+  });
 
   it('surfaces error details when test notification fails', async () => {
     jest.spyOn(indicators, 'addErrorMessage');


### PR DESCRIPTION
Closes ISWF-2436

This is the frontend follow-up to #112859, which added `projectSlug` support to the test fire action endpoint. This PR selects a connected project to pass for that value by adding `useTestNotificationProjectSlug()` and a test. While doing so, I extracted ActionFilterBlock into its own file since it was getting kinda big.

Tested it out and it works as expected. Before it selected the alphabetical first project, now it selects the one that's connected:

<img width="1210" height="702" alt="CleanShot 2026-04-15 at 15 03 34@2x" src="https://github.com/user-attachments/assets/ff3a00fb-45c7-455f-a043-48e636e1c334" />
