### PR TITLE
fix(workflows): Don't reuse existing workflow in create_priority_workflow

### DIFF
--- a/src/sentry/workflow_engine/defaults/workflows.py
+++ b/src/sentry/workflow_engine/defaults/workflows.py
@@ -43,10 +43,6 @@ def connect_workflows_to_issue_stream(
 
 
 def create_priority_workflow(org: Organization) -> Workflow:
-    existing = Workflow.objects.filter(organization=org, name=DEFAULT_WORKFLOW_LABEL).first()
-    if existing:
-        return existing
-
     with transaction.atomic(router.db_for_write(Workflow)):
         when_condition_group = DataConditionGroup.objects.create(
             logic_type=DataConditionGroup.Type.ANY_SHORT_CIRCUIT,

--- a/tests/sentry/workflow_engine/defaults/test_workflows.py
+++ b/tests/sentry/workflow_engine/defaults/test_workflows.py
@@ -150,19 +150,19 @@ class TestCreatePriorityWorkflow(TestCase):
         # Verify action filter has correct logic type
         assert action_filter.logic_type == DataConditionGroup.Type.ANY_SHORT_CIRCUIT
 
-    def test_idempotent_returns_existing_workflow(self) -> None:
+    def test_creates_separate_workflow_per_call(self) -> None:
+        """Each call creates a new Workflow so that each project gets its own."""
         org = self.create_organization()
 
         workflow1 = create_priority_workflow(org)
         workflow2 = create_priority_workflow(org)
 
-        assert workflow1.id == workflow2.id
-        # Should only have one workflow
+        assert workflow1.id != workflow2.id
         assert (
             Workflow.objects.filter(
                 organization=org, name="Send a notification for high priority issues"
             ).count()
-            == 1
+            == 2
         )
 
 


### PR DESCRIPTION
Workflows are organization scoped, so there shouldn't be any need to create a new priority error workflow for every project; one should be enough.

However, we're still supporting the APIs/UI for Rule, and Rules were each dual written to Workflows and will soon be represented as Workflows. We can't represent per-project Rules as a single Workflow, and in the cases where we currently do, any modification to the Rule (including delete) results in inconsistency and brokenness.

So, we need to ensure that newly created "rules" aren't deduplicated for now, and in another change we'll process existing shared workflows to unshare them, at least until we're no longer offering a Rule interface.

Part of ISWF-2470.