### PR TITLE
fix(repos): Fix vsts sync error

### DIFF
--- a/fixtures/vsts.py
+++ b/fixtures/vsts.py
@@ -137,11 +137,7 @@ class VstsIntegrationTestCase(IntegrationTestCase):
                         "id": self.repo_id,
                         "name": self.repo_name,
                         "project": {"name": self.project_a["name"]},
-                        "_links": {
-                            "web": {
-                                "href": f"https://{self.vsts_account_name.lower()}.visualstudio.com/_git/{self.repo_name}"
-                            }
-                        },
+                        "webUrl": f"https://{self.vsts_account_name.lower()}.visualstudio.com/_git/{self.repo_name}",
                     }
                 ]
             },

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -357,7 +357,7 @@ class VstsIntegration(RepositoryIntegration[VstsApiClient], VstsIssuesSpec):
                     "repo_name": repo["name"],
                     "identifier": str(repo["id"]),
                     "external_id": self.get_repo_external_id(repo),
-                    "url": repo["_links"]["web"]["href"],
+                    "url": repo.get("webUrl"),
                     "instance": self.instance,
                     "project": repo["project"]["name"],
                 }

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -357,7 +357,7 @@ class VstsIntegration(RepositoryIntegration[VstsApiClient], VstsIssuesSpec):
                     "repo_name": repo["name"],
                     "identifier": str(repo["id"]),
                     "external_id": self.get_repo_external_id(repo),
-                    "url": repo.get("webUrl"),
+                    "url": repo.get("webUrl", ""),
                     "instance": self.instance,
                     "project": repo["project"]["name"],
                 }

--- a/tests/sentry/integrations/source_code_management/test_sync_repos.py
+++ b/tests/sentry/integrations/source_code_management/test_sync_repos.py
@@ -455,17 +455,13 @@ class SyncReposForOrgVstsTestCase(TestCase):
                     "id": "repo-uuid-1",
                     "name": "cool-service",
                     "project": {"name": "ProjectA"},
-                    "_links": {
-                        "web": {"href": "https://myvstsaccount.visualstudio.com/_git/cool-service"}
-                    },
+                    "webUrl": "https://myvstsaccount.visualstudio.com/_git/cool-service",
                 },
                 {
                     "id": "repo-uuid-2",
                     "name": "other-service",
                     "project": {"name": "ProjectA"},
-                    "_links": {
-                        "web": {"href": "https://myvstsaccount.visualstudio.com/_git/other-service"}
-                    },
+                    "webUrl": "https://myvstsaccount.visualstudio.com/_git/other-service",
                 },
             ]
         }


### PR DESCRIPTION
The links field isn't always present. Use `webUrl` instead, and fall back to an empty url as needed

Fixes SENTRY-5NAH
