### PR TITLE
fix(night-shift): Remove poll timeout that aborted Explorer runs

### DIFF
--- a/src/sentry/tasks/seer/night_shift/agentic_triage.py
+++ b/src/sentry/tasks/seer/night_shift/agentic_triage.py
@@ -131,7 +131,6 @@ def _triage_candidates(
 
 
 POLL_INTERVAL = 2.0
-POLL_TIMEOUT = 120.0
 
 
 def _poll_with_logging(
@@ -191,10 +190,6 @@ def _poll_with_logging(
                 },
             )
             return state
-
-        elapsed = time.monotonic() - start_time
-        if elapsed >= POLL_TIMEOUT:
-            raise TimeoutError(f"Explorer run {run_id} timed out after {POLL_TIMEOUT}s")
 
         time.sleep(POLL_INTERVAL)
 


### PR DESCRIPTION
The polling loop in `_poll_with_logging` raised a `TimeoutError` after 120s, which caused the entire night shift run to be abandoned for an org — even though the Explorer was still actively working on the Seer side. For large orgs like Sentry (70 eligible projects, 10 candidates), the Explorer can legitimately need more than 120s to investigate all candidates.

In the observed incident (SENTRY-5NFV), the Explorer had finished analyzing all issues and was writing its final verdicts when the timeout killed the run at 121.3s.

This removes the client-side poll timeout entirely. The task's own `processing_deadline_duration` (5 minutes) serves as the backstop. There's no cancel API on the Explorer client, so a client-side timeout only wastes the Seer-side work that continues running regardless.

Fixes SENTRY-5NFV