### PR TITLE
fix(workflows): Handle duplicated AlertRuleWorkflow entries for a Workflow more gracefully

### DIFF
--- a/src/sentry/rules/history/backends/postgres.py
+++ b/src/sentry/rules/history/backends/postgres.py
@@ -53,11 +53,17 @@ def convert_hourly_stats(
     return results
 
 
-def get_rule_workflow_ids(target: Workflow | Rule) -> IdPair:
+def get_rule_workflow_ids(target: Workflow | Rule, project_id: int | None = None) -> IdPair:
     if isinstance(target, Workflow):
         workflow_id = target.id
         try:
-            alert_rule_workflow = AlertRuleWorkflow.objects.get(workflow=target)
+            qs = AlertRuleWorkflow.objects.filter(workflow=target)
+            if project_id is not None:
+                # rule_id is not a Django FK, so we use an __in subquery to
+                # scope to the project.  Django evaluates this as a single SQL
+                # statement (subquery), not a separate round-trip.
+                qs = qs.filter(rule_id__in=Rule.objects.filter(project_id=project_id).values("id"))
+            alert_rule_workflow = qs.get()
             rule_id = alert_rule_workflow.rule_id
         except AlertRuleWorkflow.DoesNotExist:
             rule_id = None
@@ -186,8 +192,9 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
         end: datetime,
         cursor: Cursor | None = None,
         per_page: int = 25,
+        project_id: int | None = None,
     ) -> CursorResult[RuleGroupHistory]:
-        workflow_id, rule_id = get_rule_workflow_ids(target)
+        workflow_id, rule_id = get_rule_workflow_ids(target, project_id=project_id)
 
         if not workflow_id and isinstance(target, Rule):
             logger.warning("No workflow associated with rule", extra={"rule_id": rule_id})
@@ -257,12 +264,13 @@ class PostgresRuleHistoryBackend(RuleHistoryBackend):
         target: Rule | Workflow,
         start: datetime,
         end: datetime,
+        project_id: int | None = None,
     ) -> Sequence[TimeSeriesValue]:
         start = start.replace(tzinfo=timezone.utc)
         end = end.replace(tzinfo=timezone.utc)
         existing_data: dict[datetime, TimeSeriesValue] = {}
 
-        workflow_id, rule_id = get_rule_workflow_ids(target)
+        workflow_id, rule_id = get_rule_workflow_ids(target, project_id=project_id)
         if not workflow_id and isinstance(target, Rule):
             logger.warning("No workflow associated with rule", extra={"rule_id": target.id})
             existing_data = self._fetch_rule_fire_history_hourly_stats(target, start, end)

--- a/src/sentry/rules/history/base.py
+++ b/src/sentry/rules/history/base.py
@@ -50,7 +50,13 @@ class RuleHistoryBackend(Service):
         raise NotImplementedError
 
     def fetch_rule_groups_paginated(
-        self, target: Rule | Workflow, start: datetime, end: datetime, cursor: Cursor, per_page: int
+        self,
+        target: Rule | Workflow,
+        start: datetime,
+        end: datetime,
+        cursor: Cursor,
+        per_page: int,
+        project_id: int | None = None,
     ) -> CursorResult[RuleGroupHistory]:
         """
         Fetches groups that triggered a rule or workflow within a given timeframe, ordered by number of
@@ -59,7 +65,7 @@ class RuleHistoryBackend(Service):
         raise NotImplementedError
 
     def fetch_rule_hourly_stats(
-        self, target: Rule | Workflow, start: datetime, end: datetime
+        self, target: Rule | Workflow, start: datetime, end: datetime, project_id: int | None = None
     ) -> Sequence[TimeSeriesValue]:
         """
         Fetches counts of how often a rule has fired withing a given datetime range, bucketed by

--- a/src/sentry/rules/history/endpoints/project_rule_group_history.py
+++ b/src/sentry/rules/history/endpoints/project_rule_group_history.py
@@ -86,7 +86,9 @@ class ProjectRuleGroupHistoryIndexEndpoint(WorkflowEngineRuleEndpoint):
         except InvalidParams:
             raise ParseError(detail="Invalid start and end dates")
 
-        results = fetch_rule_groups_paginated(rule, start, end, cursor, per_page)
+        results = fetch_rule_groups_paginated(
+            rule, start, end, cursor, per_page, project_id=project.id
+        )
 
         response = Response(serialize(results.results, request.user, RuleGroupHistorySerializer()))
         self.add_cursor_headers(request, response, results)

--- a/src/sentry/rules/history/endpoints/project_rule_stats.py
+++ b/src/sentry/rules/history/endpoints/project_rule_stats.py
@@ -66,5 +66,5 @@ class ProjectRuleStatsIndexEndpoint(WorkflowEngineRuleEndpoint):
         Note that results are returned in hourly buckets.
         """
         start, end = get_date_range_from_params(request.GET)
-        results = fetch_rule_hourly_stats(rule, start, end)
+        results = fetch_rule_hourly_stats(rule, start, end, project_id=project.id)
         return Response(serialize(results, request.user, TimeSeriesValueSerializer()))

--- a/tests/sentry/rules/history/endpoints/test_project_rule_group_history.py
+++ b/tests/sentry/rules/history/endpoints/test_project_rule_group_history.py
@@ -7,6 +7,7 @@ from sentry.rules.history.endpoints.project_rule_group_history import RuleGroupH
 from sentry.testutils.cases import APITestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.skips import requires_snuba
+from sentry.workflow_engine.models import AlertRuleWorkflow
 
 pytestmark = [requires_snuba]
 
@@ -93,6 +94,29 @@ class ProjectRuleGroupHistoryIndexEndpointTest(APITestCase):
             [RuleGroupHistory(group_2, 1, base_triggered_date)],
             self.user,
             RuleGroupHistorySerializer(),
+        )
+
+    def test_shared_workflow_across_projects(self) -> None:
+        project_a = self.project
+        project_b = self.create_project(organization=self.organization)
+        rule_a = self.create_project_rule(project=project_a)
+        rule_b = self.create_project_rule(project=project_b)
+
+        # Simulate the bug: point both rules at the same Workflow
+        arw_a = AlertRuleWorkflow.objects.get(rule_id=rule_a.id)
+        shared_workflow = arw_a.workflow
+        arw_b = AlertRuleWorkflow.objects.get(rule_id=rule_b.id)
+        arw_b.workflow = shared_workflow
+        arw_b.save()
+
+        self.login_as(self.user)
+        # This would crash with MultipleObjectsReturned without the project_id fix
+        self.get_success_response(
+            self.organization.slug,
+            project_a.slug,
+            rule_a.id,
+            start=before_now(days=1),
+            end=before_now(days=0),
         )
 
     def test_invalid_dates(self) -> None:

--- a/tests/sentry/rules/history/endpoints/test_project_rule_stats.py
+++ b/tests/sentry/rules/history/endpoints/test_project_rule_stats.py
@@ -10,6 +10,7 @@ from sentry.testutils.cases import APITestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.silo import control_silo_test
 from sentry.testutils.skips import requires_snuba
+from sentry.workflow_engine.models import AlertRuleWorkflow
 
 pytestmark = [requires_snuba]
 
@@ -74,6 +75,29 @@ class ProjectRuleStatsIndexEndpointTest(APITestCase):
             {"date": now - timedelta(hours=1), "count": 1},
             {"date": now, "count": 0},
         ]
+
+    def test_shared_workflow_across_projects(self) -> None:
+        project_a = self.project
+        project_b = self.create_project(organization=self.organization)
+        rule_a = self.create_project_rule(project=project_a)
+        rule_b = self.create_project_rule(project=project_b)
+
+        # Simulate the bug: point both rules at the same Workflow
+        arw_a = AlertRuleWorkflow.objects.get(rule_id=rule_a.id)
+        shared_workflow = arw_a.workflow
+        arw_b = AlertRuleWorkflow.objects.get(rule_id=rule_b.id)
+        arw_b.workflow = shared_workflow
+        arw_b.save()
+
+        self.login_as(self.user)
+        # This would crash with MultipleObjectsReturned without the project_id fix
+        self.get_success_response(
+            self.organization.slug,
+            project_a.slug,
+            rule_a.id,
+            start=before_now(days=1),
+            end=before_now(days=0),
+        )
 
     def test_invalid_date_range(self) -> None:
         rule = self.create_project_rule(project=self.event.project)


### PR DESCRIPTION
We've got a few fixes for this situation in the works, but if we can avoid crashing in the meantime that seems ideal.

Part of ISWF-2470.
