### PR TITLE
perf(api): Add collapse=organization to project details endpoint

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -75,6 +75,7 @@ _PROJECT_SCOPE_PREFIX = "projects:"
 
 LATEST_DEPLOYS_KEY: Final = "latestDeploys"
 UNUSED_ON_FRONTEND_FEATURES: Final = "unusedFeatures"
+ORGANIZATION_KEY: Final = "organization"
 
 
 # These features are not used on the frontend,
@@ -979,7 +980,16 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
         for option in queryset.iterator():
             options_by_project[option.project_id][option.key] = option.value
 
-        orgs = {d["id"]: d for d in serialize(list({i.organization for i in item_list}), user)}
+        if self._collapse(ORGANIZATION_KEY):
+            orgs = {
+                str(i.organization_id): {
+                    "id": str(i.organization_id),
+                    "slug": i.organization.slug,
+                }
+                for i in item_list
+            }
+        else:
+            orgs = {d["id"]: d for d in serialize(list({i.organization for i in item_list}), user)}
 
         # Only fetch the latest release version key for each project to cut down on response size
         latest_release_versions = _get_project_to_release_version_mapping(item_list)

--- a/src/sentry/core/endpoints/project_details.py
+++ b/src/sentry/core/endpoints/project_details.py
@@ -549,7 +549,8 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
         """
         Return details on an individual project.
         """
-        data = serialize(project, request.user, DetailedProjectSerializer())
+        collapse = request.GET.getlist("collapse", [])
+        data = serialize(project, request.user, DetailedProjectSerializer(collapse=collapse))
 
         # TODO: should switch to expand and move logic into the serializer
         include = set(filter(bool, request.GET.get("include", "").split(",")))

--- a/tests/sentry/core/endpoints/test_project_details.py
+++ b/tests/sentry/core/endpoints/test_project_details.py
@@ -115,6 +115,17 @@ class ProjectDetailsTest(APITestCase):
         )
         assert not response.data["hasAlertIntegrationInstalled"]
 
+    def test_collapse_organization(self) -> None:
+        response = self.get_success_response(
+            self.project.organization.slug,
+            self.project.slug,
+            qs_params={"collapse": ["organization"]},
+        )
+        assert response.data["organization"] == {
+            "id": str(self.project.organization.id),
+            "slug": self.project.organization.slug,
+        }
+
     def test_filters_disabled_plugins(self) -> None:
         from sentry.plugins.base import plugins
 


### PR DESCRIPTION
The project details endpoint serializes the full organization through OrganizationSummarySerializer which fetches avatars, auth provider config, and computes feature flags. When the caller only needs the org id and slug, `?collapse=organization` skips all of that and returns a minimal object.

Could shave off 400ms of the current project details 500ms request time.