### PR TITLE
fix(billing): Account for gifted quantities in productIsEnabled check

### DIFF
--- a/static/gsApp/utils/billing.spec.tsx
+++ b/static/gsApp/utils/billing.spec.tsx
@@ -1407,6 +1407,27 @@ describe('productIsEnabled', () => {
     };
     expect(productIsEnabled(subscription, DataCategory.MONITOR_SEATS)).toBe(true);
   });
+
+  it('returns true for subscriptions with hasSoftCap=true even when softCapType is null and no prepaid quota', () => {
+    subscription.hasSoftCap = true;
+    subscription.categories.monitorSeats = {
+      ...subscription.categories.monitorSeats!,
+      reserved: 0,
+      free: 0,
+      prepaid: 0,
+      softCapType: null,
+    };
+    expect(productIsEnabled(subscription, DataCategory.MONITOR_SEATS)).toBe(true);
+
+    subscription.categories.uptime = {
+      ...subscription.categories.uptime!,
+      reserved: 0,
+      free: 0,
+      prepaid: 0,
+      softCapType: null,
+    };
+    expect(productIsEnabled(subscription, DataCategory.UPTIME)).toBe(true);
+  });
 });
 
 describe('getSeerTrialCategory', () => {

--- a/static/gsApp/utils/billing.spec.tsx
+++ b/static/gsApp/utils/billing.spec.tsx
@@ -1348,6 +1348,43 @@ describe('productIsEnabled', () => {
     };
     expect(productIsEnabled(subscription, DataCategory.PROFILE_DURATION)).toBe(true);
   });
+  it('returns true for gifted-only data categories (reserved=0, free>0)', () => {
+    subscription.categories.monitorSeats = {
+      ...subscription.categories.monitorSeats!,
+      reserved: 0,
+      free: 1,
+      prepaid: 1,
+    };
+    expect(productIsEnabled(subscription, DataCategory.MONITOR_SEATS)).toBe(true);
+
+    subscription.categories.uptime = {
+      ...subscription.categories.uptime!,
+      reserved: 0,
+      free: 1,
+      prepaid: 1,
+    };
+    expect(productIsEnabled(subscription, DataCategory.UPTIME)).toBe(true);
+  });
+
+  it('returns false for categories with no quota at all', () => {
+    subscription.categories.monitorSeats = {
+      ...subscription.categories.monitorSeats!,
+      reserved: 0,
+      free: 0,
+      prepaid: 0,
+    };
+    expect(productIsEnabled(subscription, DataCategory.MONITOR_SEATS)).toBe(false);
+  });
+
+  it('returns true for categories with both reserved and gifted quota', () => {
+    subscription.categories.monitorSeats = {
+      ...subscription.categories.monitorSeats!,
+      reserved: 1,
+      free: 1,
+      prepaid: 2,
+    };
+    expect(productIsEnabled(subscription, DataCategory.MONITOR_SEATS)).toBe(true);
+  });
 });
 
 describe('getSeerTrialCategory', () => {

--- a/static/gsApp/utils/billing.spec.tsx
+++ b/static/gsApp/utils/billing.spec.tsx
@@ -1386,6 +1386,16 @@ describe('productIsEnabled', () => {
     expect(productIsEnabled(subscription, DataCategory.MONITOR_SEATS)).toBe(true);
   });
 
+  it('returns true for categories with unlimited prepaid (UNLIMITED_RESERVED sentinel)', () => {
+    subscription.categories.monitorSeats = {
+      ...subscription.categories.monitorSeats!,
+      reserved: UNLIMITED_RESERVED,
+      free: 0,
+      prepaid: UNLIMITED_RESERVED,
+    };
+    expect(productIsEnabled(subscription, DataCategory.MONITOR_SEATS)).toBe(true);
+  });
+
   it('returns true for categories with softCapType TRUE_FORWARD even with no prepaid quota', () => {
     subscription.categories.monitorSeats = {
       ...subscription.categories.monitorSeats!,

--- a/static/gsApp/utils/billing.spec.tsx
+++ b/static/gsApp/utils/billing.spec.tsx
@@ -1385,6 +1385,28 @@ describe('productIsEnabled', () => {
     };
     expect(productIsEnabled(subscription, DataCategory.MONITOR_SEATS)).toBe(true);
   });
+
+  it('returns true for categories with softCapType TRUE_FORWARD even with no prepaid quota', () => {
+    subscription.categories.monitorSeats = {
+      ...subscription.categories.monitorSeats!,
+      reserved: 0,
+      free: 0,
+      prepaid: 0,
+      softCapType: 'TRUE_FORWARD',
+    };
+    expect(productIsEnabled(subscription, DataCategory.MONITOR_SEATS)).toBe(true);
+  });
+
+  it('returns true for categories with softCapType ON_DEMAND even with no prepaid quota', () => {
+    subscription.categories.monitorSeats = {
+      ...subscription.categories.monitorSeats!,
+      reserved: 0,
+      free: 0,
+      prepaid: 0,
+      softCapType: 'ON_DEMAND',
+    };
+    expect(productIsEnabled(subscription, DataCategory.MONITOR_SEATS)).toBe(true);
+  });
 });
 
 describe('getSeerTrialCategory', () => {

--- a/static/gsApp/utils/billing.tsx
+++ b/static/gsApp/utils/billing.tsx
@@ -1040,7 +1040,7 @@ export function productIsEnabled(
   if (!metricHistory) {
     return false;
   }
-  const isPaygOnly = (metricHistory.prepaid ?? 0) === 0;
+  const isPaygOnly = (metricHistory.prepaid ?? 0) === 0 && !metricHistory.softCapType;
   return (
     !isPaygOnly ||
     metricHistory.onDemandBudget > 0 ||

--- a/static/gsApp/utils/billing.tsx
+++ b/static/gsApp/utils/billing.tsx
@@ -1040,7 +1040,10 @@ export function productIsEnabled(
   if (!metricHistory) {
     return false;
   }
-  const isPaygOnly = (metricHistory.prepaid ?? 0) === 0 && !metricHistory.softCapType;
+  const isPaygOnly =
+    (metricHistory.prepaid ?? 0) === 0 &&
+    !metricHistory.softCapType &&
+    !subscription.hasSoftCap;
   return (
     !isPaygOnly ||
     metricHistory.onDemandBudget > 0 ||

--- a/static/gsApp/utils/billing.tsx
+++ b/static/gsApp/utils/billing.tsx
@@ -1040,16 +1040,15 @@ export function productIsEnabled(
   if (!metricHistory) {
     return false;
   }
-  const isPaygOnly =
-    (metricHistory.prepaid ?? 0) === 0 &&
-    !metricHistory.softCapType &&
-    !subscription.hasSoftCap;
-  return (
-    !isPaygOnly ||
+  const hasNonPaygAccess =
+    (metricHistory.prepaid ?? 0) !== 0 ||
+    !!metricHistory.softCapType ||
+    !!subscription.hasSoftCap;
+  const hasPaygBudget =
     metricHistory.onDemandBudget > 0 ||
     (subscription.onDemandBudgets?.budgetMode === OnDemandBudgetMode.SHARED &&
-      subscription.onDemandBudgets.sharedMaxBudget > 0)
-  );
+      subscription.onDemandBudgets.sharedMaxBudget > 0);
+  return hasNonPaygAccess || hasPaygBudget;
 }
 
 /**

--- a/static/gsApp/utils/billing.tsx
+++ b/static/gsApp/utils/billing.tsx
@@ -1040,7 +1040,7 @@ export function productIsEnabled(
   if (!metricHistory) {
     return false;
   }
-  const isPaygOnly = metricHistory.reserved === 0;
+  const isPaygOnly = (metricHistory.prepaid ?? 0) === 0;
   return (
     !isPaygOnly ||
     metricHistory.onDemandBudget > 0 ||

--- a/static/gsApp/views/subscriptionPage/usageOverview/components/panel.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/components/panel.spec.tsx
@@ -709,6 +709,29 @@ describe('ProductBreakdownPanel', () => {
     expect(screen.queryByText('Upgrade required')).not.toBeInTheDocument();
   });
 
+  it('does not show Upgrade required for soft cap monitors with no prepaid quota', async () => {
+    subscription.categories.monitorSeats = {
+      ...subscription.categories.monitorSeats!,
+      reserved: 0,
+      free: 0,
+      prepaid: 0,
+      softCapType: 'TRUE_FORWARD',
+    };
+    subscription.hasSoftCap = true;
+    SubscriptionStore.set(organization.slug, subscription);
+    render(
+      <ProductBreakdownPanel
+        subscription={subscription}
+        organization={organization}
+        usageData={usageData}
+        selectedProduct={DataCategory.MONITOR_SEATS}
+      />
+    );
+
+    await screen.findByRole('heading', {name: 'Cron Monitors'});
+    expect(screen.queryByText('Upgrade required')).not.toBeInTheDocument();
+  });
+
   it('renders for data category with missing metric history', async () => {
     // NOTE(isabella): currently, we would never have this case IRL
     // since we would not allow a data category without a metric history to be

--- a/static/gsApp/views/subscriptionPage/usageOverview/components/panel.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/components/panel.spec.tsx
@@ -732,6 +732,33 @@ describe('ProductBreakdownPanel', () => {
     expect(screen.queryByText('Upgrade required')).not.toBeInTheDocument();
   });
 
+  it('does not show Upgrade required when hasSoftCap=true but category softCapType is null', async () => {
+    // Legacy soft cap orgs can have hasSoftCap=true on the subscription but
+    // softCapType=null on newer categories (e.g. MONITOR_SEAT, UPTIME)
+    // because create_new_category_histories does not inherit soft_cap_type
+    // from siblings or from the subscription-level soft_cap flag.
+    subscription.hasSoftCap = true;
+    subscription.categories.monitorSeats = {
+      ...subscription.categories.monitorSeats!,
+      reserved: 0,
+      free: 0,
+      prepaid: 0,
+      softCapType: null,
+    };
+    SubscriptionStore.set(organization.slug, subscription);
+    render(
+      <ProductBreakdownPanel
+        subscription={subscription}
+        organization={organization}
+        usageData={usageData}
+        selectedProduct={DataCategory.MONITOR_SEATS}
+      />
+    );
+
+    await screen.findByRole('heading', {name: 'Cron Monitors'});
+    expect(screen.queryByText('Upgrade required')).not.toBeInTheDocument();
+  });
+
   it('renders for data category with missing metric history', async () => {
     // NOTE(isabella): currently, we would never have this case IRL
     // since we would not allow a data category without a metric history to be

--- a/static/gsApp/views/subscriptionPage/usageOverview/components/panel.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/components/panel.spec.tsx
@@ -669,6 +669,46 @@ describe('ProductBreakdownPanel', () => {
     await screen.findByText('Active Contributors (0)'); // wait for billed seats to be loaded
   });
 
+  it('does not show Upgrade required for gifted-only monitors', async () => {
+    subscription.categories.monitorSeats = {
+      ...subscription.categories.monitorSeats!,
+      reserved: 0,
+      free: 1,
+      prepaid: 1,
+    };
+    render(
+      <ProductBreakdownPanel
+        subscription={subscription}
+        organization={organization}
+        usageData={usageData}
+        selectedProduct={DataCategory.MONITOR_SEATS}
+      />
+    );
+
+    await screen.findByRole('heading', {name: 'Cron Monitors'});
+    expect(screen.queryByText('Upgrade required')).not.toBeInTheDocument();
+  });
+
+  it('does not show Upgrade required for gifted-only uptime monitors', async () => {
+    subscription.categories.uptime = {
+      ...subscription.categories.uptime!,
+      reserved: 0,
+      free: 1,
+      prepaid: 1,
+    };
+    render(
+      <ProductBreakdownPanel
+        subscription={subscription}
+        organization={organization}
+        usageData={usageData}
+        selectedProduct={DataCategory.UPTIME}
+      />
+    );
+
+    await screen.findByRole('heading', {name: 'Uptime Monitors'});
+    expect(screen.queryByText('Upgrade required')).not.toBeInTheDocument();
+  });
+
   it('renders for data category with missing metric history', async () => {
     // NOTE(isabella): currently, we would never have this case IRL
     // since we would not allow a data category without a metric history to be

--- a/static/gsApp/views/subscriptionPage/usageOverview/components/table.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/components/table.spec.tsx
@@ -507,6 +507,50 @@ describe('UsageOverviewTable', () => {
     expect(screen.queryByTestId('product-row-disabled-uptime')).not.toBeInTheDocument();
   });
 
+  it('renders hasSoftCap monitors as enabled even when category softCapType is null', async () => {
+    // Legacy soft cap orgs can have hasSoftCap=true on the subscription but
+    // softCapType=null on newer categories (e.g. MONITOR_SEAT, UPTIME)
+    // because create_new_category_histories does not inherit soft_cap_type
+    // from siblings or from the subscription-level soft_cap flag.
+    const sub = SubscriptionFixture({organization, plan: 'am3_business'});
+    sub.hasSoftCap = true;
+    sub.categories.monitorSeats = {
+      ...sub.categories.monitorSeats!,
+      reserved: 0,
+      free: 0,
+      prepaid: 0,
+      softCapType: null,
+    };
+    sub.categories.uptime = {
+      ...sub.categories.uptime!,
+      reserved: 0,
+      free: 0,
+      prepaid: 0,
+      softCapType: null,
+    };
+    SubscriptionStore.set(organization.slug, sub);
+
+    render(
+      <UsageOverviewTable
+        subscription={sub}
+        organization={organization}
+        usageData={usageData}
+        onRowClick={jest.fn()}
+        selectedProduct={DataCategory.ERRORS}
+      />
+    );
+
+    await screen.findByRole('columnheader', {name: 'Feature'});
+
+    expect(screen.getByTestId('product-row-monitorSeats')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('product-row-disabled-monitorSeats')
+    ).not.toBeInTheDocument();
+
+    expect(screen.getByTestId('product-row-uptime')).toBeInTheDocument();
+    expect(screen.queryByTestId('product-row-disabled-uptime')).not.toBeInTheDocument();
+  });
+
   it('renders disabled product rows', async () => {
     // both profiling categories are disabled because there is no PAYG
     subscription.onDemandBudgets = {

--- a/static/gsApp/views/subscriptionPage/usageOverview/components/table.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/components/table.spec.tsx
@@ -466,6 +466,47 @@ describe('UsageOverviewTable', () => {
     expect(screen.queryByTestId('product-row-disabled-uptime')).not.toBeInTheDocument();
   });
 
+  it('renders soft cap monitors as enabled, not disabled', async () => {
+    const sub = SubscriptionFixture({organization, plan: 'am3_business'});
+    sub.categories.monitorSeats = {
+      ...sub.categories.monitorSeats!,
+      reserved: 0,
+      free: 0,
+      prepaid: 0,
+      softCapType: 'TRUE_FORWARD',
+    };
+    sub.categories.uptime = {
+      ...sub.categories.uptime!,
+      reserved: 0,
+      free: 0,
+      prepaid: 0,
+      softCapType: 'TRUE_FORWARD',
+    };
+    sub.hasSoftCap = true;
+    SubscriptionStore.set(organization.slug, sub);
+
+    render(
+      <UsageOverviewTable
+        subscription={sub}
+        organization={organization}
+        usageData={usageData}
+        onRowClick={jest.fn()}
+        selectedProduct={DataCategory.ERRORS}
+      />
+    );
+
+    await screen.findByRole('columnheader', {name: 'Feature'});
+
+    // Soft cap monitors should appear as enabled rows
+    expect(screen.getByTestId('product-row-monitorSeats')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('product-row-disabled-monitorSeats')
+    ).not.toBeInTheDocument();
+
+    expect(screen.getByTestId('product-row-uptime')).toBeInTheDocument();
+    expect(screen.queryByTestId('product-row-disabled-uptime')).not.toBeInTheDocument();
+  });
+
   it('renders disabled product rows', async () => {
     // both profiling categories are disabled because there is no PAYG
     subscription.onDemandBudgets = {

--- a/static/gsApp/views/subscriptionPage/usageOverview/components/table.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/components/table.spec.tsx
@@ -428,6 +428,44 @@ describe('UsageOverviewTable', () => {
     expect(screen.queryByRole('cell', {name: 'Errors'})).not.toBeInTheDocument();
   });
 
+  it('renders gifted-only monitors as enabled, not disabled', async () => {
+    const sub = SubscriptionFixture({organization, plan: 'am3_business'});
+    sub.categories.monitorSeats = {
+      ...sub.categories.monitorSeats!,
+      reserved: 0,
+      free: 1,
+      prepaid: 1,
+    };
+    sub.categories.uptime = {
+      ...sub.categories.uptime!,
+      reserved: 0,
+      free: 1,
+      prepaid: 1,
+    };
+    SubscriptionStore.set(organization.slug, sub);
+
+    render(
+      <UsageOverviewTable
+        subscription={sub}
+        organization={organization}
+        usageData={usageData}
+        onRowClick={jest.fn()}
+        selectedProduct={DataCategory.ERRORS}
+      />
+    );
+
+    await screen.findByRole('columnheader', {name: 'Feature'});
+
+    // Gifted-only monitors should appear as enabled rows
+    expect(screen.getByTestId('product-row-monitorSeats')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('product-row-disabled-monitorSeats')
+    ).not.toBeInTheDocument();
+
+    expect(screen.getByTestId('product-row-uptime')).toBeInTheDocument();
+    expect(screen.queryByTestId('product-row-disabled-uptime')).not.toBeInTheDocument();
+  });
+
   it('renders disabled product rows', async () => {
     // both profiling categories are disabled because there is no PAYG
     subscription.onDemandBudgets = {

--- a/static/gsApp/views/subscriptionPage/usageOverview/index.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/index.spec.tsx
@@ -9,6 +9,7 @@ import {DataCategory} from 'sentry/types/core';
 import * as useMedia from 'sentry/utils/useMedia';
 import {SecondaryNavigationContextProvider} from 'sentry/views/navigation/secondaryNavigationContext';
 
+import {UNLIMITED_RESERVED} from 'getsentry/constants';
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
 import {UsageOverview} from 'getsentry/views/subscriptionPage/usageOverview';
 
@@ -275,6 +276,40 @@ describe('UsageOverview', () => {
     expect(screen.queryByRole('heading', {name: 'Errors'})).not.toBeInTheDocument();
     subscription.categories.monitorSeats = originalMonitorSeats;
     subscription.hasSoftCap = originalHasSoftCap;
+  });
+
+  it('selects product from URL when category has unlimited prepaid (UNLIMITED_RESERVED sentinel)', async () => {
+    jest
+      .spyOn(useMedia, 'useMedia')
+      .mockImplementation(query => query.includes('min-width'));
+    const originalMonitorSeats = subscription.categories.monitorSeats;
+    subscription.categories.monitorSeats = {
+      ...subscription.categories.monitorSeats!,
+      reserved: UNLIMITED_RESERVED,
+      free: 0,
+      prepaid: UNLIMITED_RESERVED,
+      softCapType: null,
+    };
+    render(
+      <UsageOverview
+        subscription={subscription}
+        organization={organization}
+        usageData={usageData}
+      />,
+      {
+        additionalWrapper: SecondaryNavigationContextProvider,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/subscription/usage-overview',
+            query: {product: DataCategory.MONITOR_SEATS},
+          },
+        },
+      }
+    );
+
+    await screen.findByRole('heading', {name: 'Cron Monitors'});
+    expect(screen.queryByRole('heading', {name: 'Errors'})).not.toBeInTheDocument();
+    subscription.categories.monitorSeats = originalMonitorSeats;
   });
 
   it('can switch panel by clicking table rows', async () => {

--- a/static/gsApp/views/subscriptionPage/usageOverview/index.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/index.spec.tsx
@@ -203,6 +203,43 @@ describe('UsageOverview', () => {
     subscription.categories.monitorSeats = originalMonitorSeats;
   });
 
+  it('selects product with softCapType from URL query parameter', async () => {
+    jest
+      .spyOn(useMedia, 'useMedia')
+      .mockImplementation(query => query.includes('min-width'));
+    const originalMonitorSeats = subscription.categories.monitorSeats;
+    const originalHasSoftCap = subscription.hasSoftCap;
+    subscription.categories.monitorSeats = {
+      ...subscription.categories.monitorSeats!,
+      reserved: 0,
+      free: 0,
+      prepaid: 0,
+      softCapType: 'TRUE_FORWARD',
+    };
+    subscription.hasSoftCap = true;
+    render(
+      <UsageOverview
+        subscription={subscription}
+        organization={organization}
+        usageData={usageData}
+      />,
+      {
+        additionalWrapper: SecondaryNavigationContextProvider,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/subscription/usage-overview',
+            query: {product: DataCategory.MONITOR_SEATS},
+          },
+        },
+      }
+    );
+
+    await screen.findByRole('heading', {name: 'Cron Monitors'});
+    expect(screen.queryByRole('heading', {name: 'Errors'})).not.toBeInTheDocument();
+    subscription.categories.monitorSeats = originalMonitorSeats;
+    subscription.hasSoftCap = originalHasSoftCap;
+  });
+
   it('can switch panel by clicking table rows', async () => {
     jest
       .spyOn(useMedia, 'useMedia')

--- a/static/gsApp/views/subscriptionPage/usageOverview/index.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/index.spec.tsx
@@ -135,6 +135,74 @@ describe('UsageOverview', () => {
     expect(screen.queryByRole('heading', {name: 'Transactions'})).not.toBeInTheDocument();
   });
 
+  it('selects gifted-only product from URL query parameter', async () => {
+    jest
+      .spyOn(useMedia, 'useMedia')
+      .mockImplementation(query => query.includes('min-width'));
+    const originalMonitorSeats = subscription.categories.monitorSeats;
+    subscription.categories.monitorSeats = {
+      ...subscription.categories.monitorSeats!,
+      reserved: 0,
+      free: 1,
+      prepaid: 1,
+    };
+    render(
+      <UsageOverview
+        subscription={subscription}
+        organization={organization}
+        usageData={usageData}
+      />,
+      {
+        additionalWrapper: SecondaryNavigationContextProvider,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/subscription/usage-overview',
+            query: {product: DataCategory.MONITOR_SEATS},
+          },
+        },
+      }
+    );
+
+    await screen.findByRole('heading', {name: 'Cron Monitors'});
+    expect(screen.queryByRole('heading', {name: 'Errors'})).not.toBeInTheDocument();
+    subscription.categories.monitorSeats = originalMonitorSeats;
+  });
+
+  it('does not select product from URL when no quota at all', async () => {
+    jest
+      .spyOn(useMedia, 'useMedia')
+      .mockImplementation(query => query.includes('min-width'));
+    const originalMonitorSeats = subscription.categories.monitorSeats;
+    subscription.categories.monitorSeats = {
+      ...subscription.categories.monitorSeats!,
+      reserved: 0,
+      free: 0,
+      prepaid: 0,
+    };
+    render(
+      <UsageOverview
+        subscription={subscription}
+        organization={organization}
+        usageData={usageData}
+      />,
+      {
+        additionalWrapper: SecondaryNavigationContextProvider,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/subscription/usage-overview',
+            query: {product: DataCategory.MONITOR_SEATS},
+          },
+        },
+      }
+    );
+
+    await screen.findByRole('heading', {name: 'Errors'});
+    expect(
+      screen.queryByRole('heading', {name: 'Cron Monitors'})
+    ).not.toBeInTheDocument();
+    subscription.categories.monitorSeats = originalMonitorSeats;
+  });
+
   it('can switch panel by clicking table rows', async () => {
     jest
       .spyOn(useMedia, 'useMedia')

--- a/static/gsApp/views/subscriptionPage/usageOverview/index.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/index.spec.tsx
@@ -240,6 +240,43 @@ describe('UsageOverview', () => {
     subscription.hasSoftCap = originalHasSoftCap;
   });
 
+  it('selects product from URL when subscription has hasSoftCap=true and category has null softCapType', async () => {
+    jest
+      .spyOn(useMedia, 'useMedia')
+      .mockImplementation(query => query.includes('min-width'));
+    const originalMonitorSeats = subscription.categories.monitorSeats;
+    const originalHasSoftCap = subscription.hasSoftCap;
+    subscription.hasSoftCap = true;
+    subscription.categories.monitorSeats = {
+      ...subscription.categories.monitorSeats!,
+      reserved: 0,
+      free: 0,
+      prepaid: 0,
+      softCapType: null,
+    };
+    render(
+      <UsageOverview
+        subscription={subscription}
+        organization={organization}
+        usageData={usageData}
+      />,
+      {
+        additionalWrapper: SecondaryNavigationContextProvider,
+        initialRouterConfig: {
+          location: {
+            pathname: '/organizations/org-slug/subscription/usage-overview',
+            query: {product: DataCategory.MONITOR_SEATS},
+          },
+        },
+      }
+    );
+
+    await screen.findByRole('heading', {name: 'Cron Monitors'});
+    expect(screen.queryByRole('heading', {name: 'Errors'})).not.toBeInTheDocument();
+    subscription.categories.monitorSeats = originalMonitorSeats;
+    subscription.hasSoftCap = originalHasSoftCap;
+  });
+
   it('can switch panel by clicking table rows', async () => {
     jest
       .spyOn(useMedia, 'useMedia')

--- a/static/gsApp/views/subscriptionPage/usageOverview/index.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/index.tsx
@@ -51,6 +51,8 @@ export function UsageOverview({
     if (productFromQuery) {
       const isAddOn = checkIsAddOn(productFromQuery);
       if (selectedProduct !== productFromQuery) {
+        const dataCategory = productFromQuery as DataCategory;
+        const metricHistory = subscription.categories[dataCategory];
         const isSelectable = isAddOn
           ? (subscription.addOns?.[productFromQuery as AddOnCategory]?.enabled ??
               false) &&
@@ -59,20 +61,13 @@ export function UsageOverview({
             ]?.dataCategories.every(category =>
               checkIsAddOnChildCategory(subscription, category, true)
             )
-          : (subscription.categories[productFromQuery as DataCategory]?.prepaid ?? 0) >
-              0 ||
-            !!subscription.categories[productFromQuery as DataCategory]?.softCapType ||
-            (!!subscription.categories[productFromQuery as DataCategory] &&
-              subscription.hasSoftCap) ||
-            !!getActiveProductTrial(
-              subscription.productTrials ?? null,
-              productFromQuery as DataCategory
-            ) ||
+          : (metricHistory?.prepaid ?? 0) > 0 ||
+            !!metricHistory?.softCapType ||
+            (!!metricHistory && subscription.hasSoftCap) ||
+            !!getActiveProductTrial(subscription.productTrials ?? null, dataCategory) ||
             (subscription.onDemandBudgets?.budgetMode === OnDemandBudgetMode.SHARED
               ? subscription.onDemandBudgets.sharedMaxBudget
-              : (subscription.onDemandBudgets?.budgets?.[
-                  productFromQuery as DataCategory
-                ] ?? 0)) > 0;
+              : (subscription.onDemandBudgets?.budgets?.[dataCategory] ?? 0)) > 0;
         if (isSelectable) {
           setSelectedProduct(
             isAddOn

--- a/static/gsApp/views/subscriptionPage/usageOverview/index.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/index.tsx
@@ -62,6 +62,8 @@ export function UsageOverview({
           : (subscription.categories[productFromQuery as DataCategory]?.prepaid ?? 0) >
               0 ||
             !!subscription.categories[productFromQuery as DataCategory]?.softCapType ||
+            (!!subscription.categories[productFromQuery as DataCategory] &&
+              subscription.hasSoftCap) ||
             !!getActiveProductTrial(
               subscription.productTrials ?? null,
               productFromQuery as DataCategory

--- a/static/gsApp/views/subscriptionPage/usageOverview/index.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/index.tsx
@@ -59,7 +59,7 @@ export function UsageOverview({
             ]?.dataCategories.every(category =>
               checkIsAddOnChildCategory(subscription, category, true)
             )
-          : (subscription.categories[productFromQuery as DataCategory]?.reserved ?? 0) >
+          : (subscription.categories[productFromQuery as DataCategory]?.prepaid ?? 0) >
               0 ||
             !!getActiveProductTrial(
               subscription.productTrials ?? null,

--- a/static/gsApp/views/subscriptionPage/usageOverview/index.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/index.tsx
@@ -61,7 +61,7 @@ export function UsageOverview({
             ]?.dataCategories.every(category =>
               checkIsAddOnChildCategory(subscription, category, true)
             )
-          : (metricHistory?.prepaid ?? 0) > 0 ||
+          : (metricHistory?.prepaid ?? 0) !== 0 ||
             !!metricHistory?.softCapType ||
             (!!metricHistory && subscription.hasSoftCap) ||
             !!getActiveProductTrial(subscription.productTrials ?? null, dataCategory) ||

--- a/static/gsApp/views/subscriptionPage/usageOverview/index.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/index.tsx
@@ -61,6 +61,7 @@ export function UsageOverview({
             )
           : (subscription.categories[productFromQuery as DataCategory]?.prepaid ?? 0) >
               0 ||
+            !!subscription.categories[productFromQuery as DataCategory]?.softCapType ||
             !!getActiveProductTrial(
               subscription.productTrials ?? null,
               productFromQuery as DataCategory


### PR DESCRIPTION
## Problem

On the subscription page, orgs on `am3_t_ent` with **legacy soft cap** see **"Upgrade required — You currently do not have access to this feature"** for Cron Monitors and Uptime Monitors, even when those monitors are gifted.

## Root Cause

`productIsEnabled()` (frontend) decides whether a billing category is active or locked. Three bugs compounded:

### Bug 1: Gifted quantities ignored

```typescript
// billing.tsx:1043 (before)
const isPaygOnly = metricHistory.reserved === 0;
```

Only checks `reserved` (plan-included quota), ignoring `free` (gifted quota).

### Bug 2: Per-category soft cap type ignored

A category with `softCapType = 'TRUE_FORWARD'` or `'ON_DEMAND'` represents soft cap billing — the org can use the product via forward/ondemand billing. But the function didn't check `softCapType`.

### Bug 3: Subscription-level legacy soft cap flag ignored (the main miss)

`subscription.soft_cap` (legacy boolean, serialized as `hasSoftCap`) and `metric_history.soft_cap_type` (per-category enum) are **orthogonal** fields in getsentry that are **not kept in sync**. Verified across the getsentry codebase:

- `change_soft_cap()` (`getsentry/billing/soft_cap.py:17-54`) toggles `subscription.soft_cap` but does NOT touch any metric history's `soft_cap_type`.
- Salesforce provisioning sets `subscription.soft_cap = "enable soft-cap" in deal_terms` independently from per-category `soft_cap_type_*` fields.
- `create_new_category_histories` (`getsentry/models/billingmetrichistory.py:301`) creates rows for backfilled categories (like MONITOR_SEAT, UPTIME) with `soft_cap_type = None` — it does NOT inherit from siblings or from the subscription-level `soft_cap` flag.

So legacy soft cap orgs whose Cron/Uptime categories were backfilled after original provisioning have `hasSoftCap = true` but `softCapType = null` on those categories. **This is exactly the am3_t_ent scenario reported.**

### Data for the affected orgs

| Field | Value | Meaning |
|-------|-------|---------|
| `hasSoftCap` | `true` | Subscription-level legacy soft cap flag |
| `reserved` | `0` | Plan tier includes 0 monitors by default |
| `free` | `0` | No gifted monitors |
| `prepaid` | `0` | reserved + free |
| `softCapType` | `null` | Not set on backfilled category |
| `onDemandBudget` | `0` | Legacy soft cap orgs have no PAYG budget |

## Fix

### `billing.tsx:1043`

```typescript
// Before:
const isPaygOnly = metricHistory.reserved === 0;

// After:
const isPaygOnly =
  (metricHistory.prepaid ?? 0) === 0 &&
  !metricHistory.softCapType &&
  !subscription.hasSoftCap;
```

- `prepaid` = `reserved + free` — accounts for gifted quantities
- `!softCapType` — treats soft cap categories as enabled
- `!subscription.hasSoftCap` — treats legacy soft cap subscriptions as enabled

This matches the backend-wide pattern: `subscription.soft_cap OR metric_history.soft_cap_type is not None` used in:
- `getsentry/quotas.py`
- `getsentry/billing/seat_policy/monitor.py`
- `getsentry/billing/tally_usage.py`
- `getsentry/models/billingseatassignment.py`

### `index.tsx` (URL product selection)

Parallel changes to the selectability check: use `prepaid`, add `softCapType` check, add `hasSoftCap` check (guarded on the category existing on the subscription).

## Tests Added (16 new across 4 files)

**`billing.spec.tsx`** (6 new in `productIsEnabled` describe):
- Gifted-only category (reserved=0, free>0) → enabled
- No quota at all → disabled
- Mixed reserved + gifted → enabled
- softCapType TRUE_FORWARD with no prepaid → enabled
- softCapType ON_DEMAND with no prepaid → enabled
- hasSoftCap=true with null softCapType and no prepaid → enabled (the am3_t_ent bug)

**`index.spec.tsx`** (4 new):
- URL selects gifted-only product
- URL does not select zero-quota product
- URL selects product with softCapType
- URL selects product with hasSoftCap=true and null softCapType (the am3_t_ent bug)

**`panel.spec.tsx`** (4 new):
- Gifted monitors don't show "Upgrade required"
- Gifted uptime doesn't show "Upgrade required"
- Soft cap monitors don't show "Upgrade required"
- hasSoftCap=true with null softCapType doesn't show "Upgrade required" (the am3_t_ent bug)

**`table.spec.tsx`** (2 new):
- Gifted monitors render as enabled rows
- hasSoftCap=true with null softCapType renders as enabled (the am3_t_ent bug)

## Why this matches the backend

The backend serializer (`getsentry/api/serializers/customer.py:499`) sends `hasSoftCap: sub.soft_cap` directly. Every quota/seat check in the backend uses the `OR` pattern. The frontend now matches that invariant.