### PR TITLE
fix(tracemetrics): Metric panel title should use equation with label

### DIFF
--- a/static/app/views/explore/metrics/equationBuilder/index.spec.tsx
+++ b/static/app/views/explore/metrics/equationBuilder/index.spec.tsx
@@ -55,7 +55,8 @@ describe('EquationBuilder', () => {
     expect(handleExpressionChange).toHaveBeenCalledWith(
       expect.objectContaining({
         text: 'count(value,metricA,distribution,none) * 2',
-      })
+      }),
+      'A * 2'
     );
   });
 });

--- a/static/app/views/explore/metrics/equationBuilder/index.tsx
+++ b/static/app/views/explore/metrics/equationBuilder/index.tsx
@@ -23,7 +23,7 @@ export function EquationBuilder({
   onReferenceLabelsChange,
 }: {
   expression: string;
-  handleExpressionChange: (expression: Expression) => void;
+  handleExpressionChange: (resolved: Expression, internalText: string) => void;
   onReferenceLabelsChange?: (labels: string[]) => void;
   referenceMap?: Record<string, string>;
 }) {
@@ -49,7 +49,10 @@ export function EquationBuilder({
     (newExpression: Expression) => {
       startTransition(() => {
         if (newExpression.isValid) {
-          handleExpressionChange(resolveExpression(newExpression, referenceMap));
+          handleExpressionChange(
+            resolveExpression(newExpression, referenceMap),
+            newExpression.text
+          );
         }
       });
     },

--- a/static/app/views/explore/metrics/metricGraph/index.tsx
+++ b/static/app/views/explore/metrics/metricGraph/index.tsx
@@ -57,6 +57,7 @@ interface MetricsGraphProps {
   additionalActions?: React.ReactNode;
   infoContentHidden?: boolean;
   isMetricOptionsEmpty?: boolean;
+  title?: string;
 }
 
 export function MetricsGraph({
@@ -65,6 +66,7 @@ export function MetricsGraph({
   additionalActions,
   infoContentHidden,
   isMetricOptionsEmpty,
+  title,
 }: MetricsGraphProps) {
   const metricQueries = useMultiMetricsQueryParams();
   const visualize = useMetricVisualize();
@@ -91,6 +93,7 @@ export function MetricsGraph({
       additionalActions={additionalActions}
       infoContentHidden={infoContentHidden}
       isMetricOptionsEmpty={isMetricOptionsEmpty}
+      title={title}
     />
   );
 }
@@ -110,6 +113,7 @@ function Graph({
   infoContentHidden,
   additionalActions,
   isMetricOptionsEmpty,
+  title,
 }: GraphProps) {
   const organization = useOrganization();
   const aggregate = visualize.yAxis;
@@ -178,8 +182,8 @@ function Graph({
     if (visualizes.length > 1) {
       return metricName;
     }
-    return metricLabel ?? prettifyAggregation(aggregate) ?? aggregate;
-  }, [aggregate, metricLabel, metricName, visualizes.length]);
+    return title ?? metricLabel ?? prettifyAggregation(aggregate) ?? aggregate;
+  }, [aggregate, metricLabel, metricName, visualizes.length, title]);
 
   const Title = <Widget.WidgetTitle title={chartTitle} />;
 

--- a/static/app/views/explore/metrics/metricPanel/index.spec.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.spec.tsx
@@ -14,7 +14,10 @@ import {MetricsQueryParamsProvider} from 'sentry/views/explore/metrics/metricsQu
 import {MultiMetricsQueryParamsProvider} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
 import {Mode} from 'sentry/views/explore/queryParams/mode';
 import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
-import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
+import {
+  VisualizeEquation,
+  VisualizeFunction,
+} from 'sentry/views/explore/queryParams/visualize';
 
 function createWrapper({
   queryParams,
@@ -268,6 +271,46 @@ describe('MetricPanel', () => {
         screen.queryByRole('button', {name: 'Table bottom'})
       ).not.toBeInTheDocument();
       expect(screen.queryByRole('button', {name: 'Table right'})).not.toBeInTheDocument();
+    });
+
+    it('uses the internal expression as the chart title for equations', async () => {
+      const equationQueryParams = new ReadableQueryParams({
+        extrapolate: true,
+        mode: Mode.AGGREGATE,
+        query: '',
+        cursor: '',
+        fields: ['id', 'timestamp'],
+        sortBys: [{field: 'timestamp', kind: 'desc'}],
+        aggregateCursor: '',
+        aggregateFields: [new VisualizeEquation('equation|sum(value) + avg(value)')],
+        aggregateSortBys: [{field: 'equation|sum(value) + avg(value)', kind: 'desc'}],
+      });
+
+      const equationOrg = {
+        ...organization,
+        features: [...organization.features, 'tracemetrics-equations-in-explore'],
+      };
+
+      render(
+        <MetricPanel
+          traceMetric={traceMetric}
+          queryIndex={0}
+          queryLabel="ƒ1"
+          referenceMap={{A: 'sum(value)', B: 'avg(value)'}}
+        />,
+        {
+          organization: equationOrg,
+          additionalWrapper: createWrapper({
+            queryParams: equationQueryParams,
+            traceMetric,
+          }),
+        }
+      );
+
+      // The chart title should display the unresolved/internal expression (A + B),
+      // not the resolved form (sum(value) + avg(value))
+      expect(await screen.findByText('A + B')).toBeInTheDocument();
+      expect(screen.queryByText('sum(value) + avg(value)')).not.toBeInTheDocument();
     });
   });
 });

--- a/static/app/views/explore/metrics/metricPanel/index.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.tsx
@@ -18,6 +18,7 @@ import {
   getTraceSamplesTableFields,
   TraceSamplesTableColumns,
 } from 'sentry/views/explore/metrics/constants';
+import {unresolveExpression} from 'sentry/views/explore/metrics/equationBuilder/utils';
 import {useMetricAggregatesTable} from 'sentry/views/explore/metrics/hooks/useMetricAggregatesTable';
 import {useMetricSamplesTable} from 'sentry/views/explore/metrics/hooks/useMetricSamplesTable';
 import {useMetricTimeseries} from 'sentry/views/explore/metrics/hooks/useMetricTimeseries';
@@ -89,6 +90,13 @@ export function MetricPanel({
   const topEvents = useTopEvents();
   const visualize = useMetricVisualize();
 
+  const [title, setTitle] = useState<string | undefined>(() => {
+    if (isVisualizeEquation(visualize)) {
+      return unresolveExpression(visualize.expression.text, referenceMap);
+    }
+    return undefined;
+  });
+
   const areQueriesEnabled = isVisualizeFunction(visualize)
     ? Boolean(traceMetric.name) && !isMetricOptionsEmpty
     : isVisualizeEquation(visualize) && Boolean(visualize.expression.text);
@@ -143,6 +151,7 @@ export function MetricPanel({
                 dragAttributes={dragAttributes}
                 referencedMetricLabels={referencedMetricLabels}
                 onEquationLabelsChange={onEquationLabelsChange}
+                onTitleChange={setTitle}
               />
             </Container>
             {visualize.visible ? (
@@ -169,6 +178,7 @@ export function MetricPanel({
                       infoContentHidden={infoContentHidden}
                       setInfoContentHidden={setInfoContentHidden}
                       isMetricOptionsEmpty={isMetricOptionsEmpty}
+                      title={title}
                     />
                   </Container>
                 </Activity>
@@ -192,6 +202,7 @@ export function MetricPanel({
             infoContentHidden={infoContentHidden}
             setInfoContentHidden={setInfoContentHidden}
             isMetricOptionsEmpty={isMetricOptionsEmpty}
+            title={title}
           />
         ) : (
           <StackedOrientation
@@ -203,6 +214,7 @@ export function MetricPanel({
             infoContentHidden={infoContentHidden}
             setInfoContentHidden={setInfoContentHidden}
             isMetricOptionsEmpty={isMetricOptionsEmpty}
+            title={title}
           />
         )}
       </PanelBody>

--- a/static/app/views/explore/metrics/metricPanel/sideBySideOrientation.tsx
+++ b/static/app/views/explore/metrics/metricPanel/sideBySideOrientation.tsx
@@ -30,6 +30,7 @@ export function SideBySideOrientation({
   infoContentHidden,
   setInfoContentHidden,
   isMetricOptionsEmpty,
+  title,
 }: {
   infoContentHidden: boolean;
   isMetricOptionsEmpty: boolean;
@@ -38,6 +39,7 @@ export function SideBySideOrientation({
   setOrientation: (orientation: TableOrientation) => void;
   timeseriesResult: ReturnType<typeof useMetricTimeseries>['result'];
   traceMetric: TraceMetric;
+  title?: string;
 }) {
   const organization = useOrganization();
   const hasMetricsUIRefresh = canUseMetricsUIRefresh(organization);
@@ -52,6 +54,7 @@ export function SideBySideOrientation({
             timeseriesResult={timeseriesResult}
             orientation={orientation}
             isMetricOptionsEmpty={isMetricOptionsEmpty}
+            title={title}
           />
         </Container>
         <Container minWidth="0">
@@ -98,6 +101,7 @@ export function SideBySideOrientation({
           additionalActions={additionalActions}
           infoContentHidden={infoContentHidden}
           isMetricOptionsEmpty={isMetricOptionsEmpty}
+          title={title}
         />
       </div>
     );
@@ -114,6 +118,7 @@ export function SideBySideOrientation({
                 timeseriesResult={timeseriesResult}
                 orientation={orientation}
                 isMetricOptionsEmpty={isMetricOptionsEmpty}
+                title={title}
               />
             ),
             default: defaultSplit,

--- a/static/app/views/explore/metrics/metricPanel/stackedOrientation.tsx
+++ b/static/app/views/explore/metrics/metricPanel/stackedOrientation.tsx
@@ -19,6 +19,7 @@ export function StackedOrientation({
   infoContentHidden,
   setInfoContentHidden,
   isMetricOptionsEmpty,
+  title,
 }: {
   canChangeOrientation: boolean;
   infoContentHidden: boolean;
@@ -28,6 +29,7 @@ export function StackedOrientation({
   setOrientation: (orientation: TableOrientation) => void;
   timeseriesResult: ReturnType<typeof useMetricTimeseries>['result'];
   traceMetric: TraceMetric;
+  title?: string;
 }) {
   const additionalInfoTabActions = (
     <Flex direction="row">
@@ -50,6 +52,7 @@ export function StackedOrientation({
           timeseriesResult={timeseriesResult}
           orientation={orientation}
           isMetricOptionsEmpty={isMetricOptionsEmpty}
+          title={title}
         />
       </StackedGraphWrapper>
       <div>

--- a/static/app/views/explore/metrics/metricToolbar/index.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/index.tsx
@@ -35,6 +35,7 @@ interface MetricToolbarProps {
   dragAttributes?: DraggableAttributes;
   dragListeners?: SyntheticListenerMap;
   onEquationLabelsChange?: (equationLabel: string, labels: string[]) => void;
+  onTitleChange?: (title: string) => void;
   referenceMap?: Record<string, string>;
   referencedMetricLabels?: Set<string>;
 }
@@ -47,6 +48,7 @@ export function MetricToolbar({
   dragAttributes,
   referencedMetricLabels,
   onEquationLabelsChange,
+  onTitleChange,
 }: MetricToolbarProps) {
   const organization = useOrganization();
   const breakpoints = useBreakpoints();
@@ -80,10 +82,11 @@ export function MetricToolbar({
   );
 
   const handleExpressionChange = useCallback(
-    (newExpression: Expression) => {
+    (newExpression: Expression, internalText: string) => {
       setVisualize(visualize.replace({yAxis: `${EQUATION_PREFIX}${newExpression.text}`}));
+      onTitleChange?.(internalText);
     },
-    [setVisualize, visualize]
+    [setVisualize, visualize, onTitleChange]
   );
 
   const dndGrid = dragListeners ? 'auto ' : '';

--- a/static/app/views/explore/metrics/metricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/metricsQueryParams.tsx
@@ -160,7 +160,6 @@ export function useMetricLabel(): string {
   const {metric} = useTraceMetricContext();
 
   if (isVisualizeEquation(visualize)) {
-    // TODO: This should show the unresolved expression from the equation builder
     return visualize.expression.text;
   }
   if (isVisualizeFunction(visualize) && visualize.parsedFunction) {


### PR DESCRIPTION
Primarily, the equation builder was supposed to avoid leaking the internal representation out of itself, but because we want to display it in another component (i.e. the chart title), we need to expose a way to hook into the internal value when a change is reported.

In this case, call the `handleExpressionChange` callback with both the resolved version, and the internal version so we can read it and store it in local state for the metric panel to use for the title. This only applies to equations right now but I've made the terminology more general (i.e. `title`, etc)

Ideally, `useMetricLabel` would have been able to provide this but I didn't really want to store more metadata higher than the metric panel, where it's relevant

<img width="624" height="434" alt="Screenshot 2026-04-15 at 11 35 01 PM" src="https://github.com/user-attachments/assets/aec70c43-3a09-4684-8394-8dc979f2f087" />
