### PR TITLE
fix(dashboards): Use scientific notation for small numbers in breakdown table

### DIFF
--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -31,10 +31,7 @@ import {
 import {getChartType} from 'sentry/views/dashboards/utils/getWidgetExploreUrl';
 import {matchTimeSeriesToTableRowValue} from 'sentry/views/dashboards/widgetCard/matchTimeSeriesToTableRowValue';
 import {transformWidgetSeriesToTimeSeries} from 'sentry/views/dashboards/widgetCard/transformWidgetSeriesToTimeSeries';
-import {
-  MISSING_DATA_MESSAGE,
-  NUMBER_MIN_VALUE,
-} from 'sentry/views/dashboards/widgets/common/settings';
+import {MISSING_DATA_MESSAGE} from 'sentry/views/dashboards/widgets/common/settings';
 import type {
   LegendSelection,
   TabularColumn,
@@ -368,13 +365,6 @@ function VisualizationWidgetContent({
                 <NegativeCostWarning>
                   {formatBreakdownLegendValue(value, dataType, dataUnit)}
                 </NegativeCostWarning>
-              ) : dataType === 'number' &&
-                value !== null &&
-                value > 0 &&
-                value < NUMBER_MIN_VALUE ? (
-                <Tooltip title={value.toLocaleString()}>
-                  <span>{formatBreakdownLegendValue(value, dataType, dataUnit)}</span>
-                </Tooltip>
               ) : (
                 formatBreakdownLegendValue(value, dataType, dataUnit)
               )}

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatBreakdownLegendValue.spec.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatBreakdownLegendValue.spec.tsx
@@ -1,0 +1,30 @@
+import {formatBreakdownLegendValue} from './formatBreakdownLegendValue';
+
+describe('formatBreakdownLegendValue', () => {
+  it('returns em dash for null', () => {
+    expect(formatBreakdownLegendValue(null, 'number')).toBe('—');
+  });
+
+  it.each([
+    [0.000033452, '3.35E-5'],
+    [0.00003, '3E-5'],
+    [0.00000001, '1E-8'],
+    [5e-35, '5E-35'],
+  ])('formats small number %s as scientific notation %s', (value, expected) => {
+    expect(formatBreakdownLegendValue(value, 'number')).toBe(expected);
+  });
+
+  it('does not use scientific notation for numbers >= 0.0001', () => {
+    expect(formatBreakdownLegendValue(0.001234, 'number')).toBe('0.0012');
+    expect(formatBreakdownLegendValue(17.1238, 'number')).toBe('17.1238');
+    expect(formatBreakdownLegendValue(170, 'number')).toBe('170');
+  });
+
+  it('does not use scientific notation for 0', () => {
+    expect(formatBreakdownLegendValue(0, 'number')).toBe('0');
+  });
+
+  it('delegates non-number types to formatTooltipValue', () => {
+    expect(formatBreakdownLegendValue(1000, 'integer')).toBe('1,000');
+  });
+});

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatBreakdownLegendValue.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/formatters/formatBreakdownLegendValue.tsx
@@ -26,7 +26,10 @@ export function formatBreakdownLegendValue(
     value > 0 &&
     value < NUMBER_MIN_VALUE
   ) {
-    return `<${NUMBER_MIN_VALUE}`;
+    return value.toLocaleString(undefined, {
+      notation: 'scientific' as const,
+      maximumSignificantDigits: 3,
+    });
   }
 
   return formatTooltipValue(value, type, unit);


### PR DESCRIPTION
Small number values in the breakdown table below charts showed `<0.0001` with a tooltip that displayed `0` for very small values (because `toLocaleString()` without options rounds aggressively).

This replaces the threshold indicator with scientific notation (e.g., `3.35E-5`), which shows the actual value precisely and eliminates the need for a tooltip. This aligns with the number formatting guidelines proposed in #112410 (though, those are in discussion)

Changes:
- `formatBreakdownLegendValue` now returns scientific notation (3 significant digits) for small `number`-type values instead of `<0.0001`
- Removed the `<Tooltip>` wrapper for small numbers in `VisualizationWidget` since the value is no longer obfuscated
- Added tests for `formatBreakdownLegendValue`

I didn't bother changing anything else for this PR, though in the future as we solidify the guidelines we'll implement them more rigorously.

Closes DAIN-1430