### PR TITLE
ref: fix 'occured' -> 'occurred' typos across sentry_apps, UI, and loader templates

### DIFF
--- a/src/sentry/sentry_apps/external_requests/issue_link_requester.py
+++ b/src/sentry/sentry_apps/external_requests/issue_link_requester.py
@@ -122,7 +122,7 @@ class IssueLinkRequester:
                 )
 
                 raise SentryAppIntegratorError(
-                    message=f"Issue occured while trying to contact {self.sentry_app.slug} to link issue",
+                    message=f"Issue occurred while trying to contact {self.sentry_app.slug} to link issue",
                     webhook_context={"error_type": BAD_RESPONSE_HALT_REASON, **extras},
                     status_code=500,
                 )

--- a/src/sentry/sentry_apps/utils/errors.py
+++ b/src/sentry/sentry_apps/utils/errors.py
@@ -51,7 +51,7 @@ class SentryAppBaseError(Exception):
         return f"{type(self).__name__}: message={self.message} status_code={self.status_code} error_type={self.error_type}"
 
 
-# Represents a user/client error that occured during a Sentry App process
+# Represents a user/client error that occurred during a Sentry App process
 class SentryAppError(SentryAppBaseError):
     error_type = SentryAppErrorType.CLIENT
     status_code = 400
@@ -71,7 +71,7 @@ class SentryAppSentryError(SentryAppBaseError):
     def to_public_dict(self) -> SentryAppPublicErrorBody:
         error_id = sentry_sdk.capture_exception(self, level="info")
         return {
-            "detail": f"An issue occured during the integration platform process. Sentry error ID: {error_id}"
+            "detail": f"An issue occurred during the integration platform process. Sentry error ID: {error_id}"
         }
 
     def response_from_exception(self) -> Response:

--- a/src/sentry/templates/sentry/js-sdk-loader.js.tmpl
+++ b/src/sentry/templates/sentry/js-sdk-loader.js.tmpl
@@ -30,7 +30,7 @@
                 (queueIsFunction(item) && item.f.indexOf('capture') > -1) ||
                 (queueIsFunction(item) && item.f.indexOf('showReportDialog') > -1))) {
             // We only want to lazy inject/load the sdk bundle if
-            // an error or promise rejection occured
+            // an error or promise rejection occurred
             // OR someone called `capture...` on the SDK
             injectCDNScriptTag();
         }

--- a/src/sentry/templates/sentry/js-sdk-loader.ts
+++ b/src/sentry/templates/sentry/js-sdk-loader.ts
@@ -78,7 +78,7 @@ declare const __LOADER__IS_LAZY__: any;
         (queueIsFunction(item) && item.f.indexOf('showReportDialog') > -1))
     ) {
       // We only want to lazy inject/load the sdk bundle if
-      // an error or promise rejection occured
+      // an error or promise rejection occurred
       // OR someone called `capture...` on the SDK
       injectCDNScriptTag();
     }

--- a/static/app/views/insights/crons/types.tsx
+++ b/static/app/views/insights/crons/types.tsx
@@ -167,7 +167,7 @@ export interface CheckIn {
    */
   environment: string;
   /**
-   * What was the monitors nextCheckIn value when this check-in occured, this
+   * What was the monitors nextCheckIn value when this check-in occurred, this
    * is when we expected the check-in to happen. May be null for the very first check-in.
    */
   expectedTime: string | null;

--- a/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarStatusCheck.tsx
+++ b/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarStatusCheck.tsx
@@ -102,7 +102,7 @@ function getErrorMessage(
   switch (errorType) {
     case StatusCheckErrorType.INTEGRATION_ERROR:
       return t(
-        'An error occured with the %s integration. Please ensure the Sentry app is installed, has the required permissions, and that the organization has accepted any updated permissions.',
+        'An error occurred with the %s integration. Please ensure the Sentry app is installed, has the required permissions, and that the organization has accepted any updated permissions.',
         providerName
       );
     case StatusCheckErrorType.API_ERROR:

--- a/static/gsApp/components/upgradeNowModal/modalSamePrice.tsx
+++ b/static/gsApp/components/upgradeNowModal/modalSamePrice.tsx
@@ -89,7 +89,7 @@ function UpgradeNowModal({
       <Header>{t('Get to the root cause of an error faster')}</Header>
       <p>
         {t(
-          'Enable video-like reproduction of your user sessions so you can see what happened before, during and after an error or performance issue occured.'
+          'Enable video-like reproduction of your user sessions so you can see what happened before, during and after an error or performance issue occurred.'
         )}
       </p>
       <CTAPanel>

--- a/tests/sentry/sentry_apps/api/bases/test_sentryapps.py
+++ b/tests/sentry/sentry_apps/api/bases/test_sentryapps.py
@@ -264,5 +264,5 @@ class IntegrationPlatformEndpointTest(TestCase):
 
         assert response.status_code == 500
         assert response.data == {
-            "detail": f"An issue occured during the integration platform process. Sentry error ID: {None}"
+            "detail": f"An issue occurred during the integration platform process. Sentry error ID: {None}"
         }

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_installation_external_issue_actions.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_installation_external_issue_actions.py
@@ -82,7 +82,7 @@ class SentryAppInstallationExternalIssuesEndpointTest(APITestCase):
         assert response.status_code == 500
         assert (
             response.content
-            == b'{"detail":"Issue occured while trying to contact testin to link issue"}'
+            == b'{"detail":"Issue occurred while trying to contact testin to link issue"}'
         )
         with assume_test_silo_mode_of(PlatformExternalIssue):
             assert not PlatformExternalIssue.objects.all()

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_installation_external_issues.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_app_installation_external_issues.py
@@ -123,6 +123,6 @@ class SentryAppInstallationExternalIssuesEndpointTest(APITestCase):
 
         assert response.status_code == 500
         assert response.data == {
-            "detail": f"An issue occured during the integration platform process. Sentry error ID: {None}"
+            "detail": f"An issue occurred during the integration platform process. Sentry error ID: {None}"
         }
         mock_update_or_create.assert_called_once()


### PR DESCRIPTION
## Summary

Fix `occured` → `occurred` typos across Sentry. Multiple are user-visible — surfaced in API error responses, the JS SDK loader template (served to every site using the loader), and UI components.

## Changes

### Source fixes

| File | Kind | User-visible? |
|------|------|---------------|
| `src/sentry/sentry_apps/utils/errors.py` | API error detail + comment | ✅ yes |
| `src/sentry/sentry_apps/external_requests/issue_link_requester.py` | API error `message` | ✅ yes |
| `src/sentry/templates/sentry/js-sdk-loader.js.tmpl` | Loader template comment | served in loader output |
| `src/sentry/templates/sentry/js-sdk-loader.ts` | TS source for loader | served in loader output |
| `static/app/views/insights/crons/types.tsx` | JSDoc comment | no |
| `static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarStatusCheck.tsx` | User-visible error message | ✅ yes |
| `static/gsApp/components/upgradeNowModal/modalSamePrice.tsx` | Modal body text | ✅ yes |

### Test updates (following the string changes)

- `tests/sentry/sentry_apps/api/bases/test_sentryapps.py`
- `tests/sentry/sentry_apps/api/endpoints/test_sentry_app_installation_external_issue_actions.py`
- `tests/sentry/sentry_apps/api/endpoints/test_sentry_app_installation_external_issues.py`

All assertions against the old string updated to match. Tests stay green.

## Testing

String-replacement change. Existing test suite (updated assertions) verifies the new strings.