### PR TITLE
fix(preprod): Handle 404 gracefully in install details (EME-883)

### DIFF
--- a/static/app/components/preprod/preprodBuildsTableCommon.tsx
+++ b/static/app/components/preprod/preprodBuildsTableCommon.tsx
@@ -14,6 +14,7 @@ import {TimeSince} from 'sentry/components/timeSince';
 import {IconCheckmark, IconCommit, IconNot} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {InstallAppButton} from 'sentry/views/preprod/components/installAppButton';
+import {getDistributionErrorTooltip} from 'sentry/views/preprod/components/installDetailsContent';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
 
 export function PreprodBuildsHeaderCells({
@@ -76,7 +77,13 @@ export function PreprodBuildsRowCells({
                       variant="icon"
                     />
                   ) : (
-                    <Tooltip title={t('Not installable')} skipWrapper>
+                    <Tooltip
+                      title={getDistributionErrorTooltip(
+                        build.distribution_info?.error_code,
+                        build.distribution_info?.error_message
+                      )}
+                      skipWrapper
+                    >
                       <span>
                         <Button
                           aria-label={t('Not installable')}

--- a/static/app/views/preprod/components/installAppButton.tsx
+++ b/static/app/views/preprod/components/installAppButton.tsx
@@ -35,7 +35,7 @@ export function InstallAppButton({
       project_slug: projectId,
       source,
     });
-    openInstallModal(artifactId);
+    openInstallModal(artifactId, projectId);
   };
 
   if (variant === 'icon') {

--- a/static/app/views/preprod/components/installDetailsContent.spec.tsx
+++ b/static/app/views/preprod/components/installDetailsContent.spec.tsx
@@ -8,30 +8,30 @@ import {
 } from 'sentry/views/preprod/components/installDetailsContent';
 
 describe('getDistributionErrorTooltip', () => {
-  it('returns quota message for NO_QUOTA', () => {
-    expect(getDistributionErrorTooltip('NO_QUOTA')).toBe('Distribution quota exceeded');
+  it('returns quota message for no_quota', () => {
+    expect(getDistributionErrorTooltip('no_quota')).toBe('Distribution quota exceeded');
   });
 
-  it('returns signature message for SKIPPED with invalid_signature', () => {
-    expect(getDistributionErrorTooltip('SKIPPED', 'invalid_signature')).toBe(
+  it('returns signature message for skipped with invalid_signature', () => {
+    expect(getDistributionErrorTooltip('skipped', 'invalid_signature')).toBe(
       'Code signature is invalid'
     );
   });
 
-  it('returns simulator message for SKIPPED with simulator', () => {
-    expect(getDistributionErrorTooltip('SKIPPED', 'simulator')).toBe(
+  it('returns simulator message for skipped with simulator', () => {
+    expect(getDistributionErrorTooltip('skipped', 'simulator')).toBe(
       'Simulator builds cannot be distributed'
     );
   });
 
-  it('returns generic skipped message for SKIPPED with unknown message', () => {
-    expect(getDistributionErrorTooltip('SKIPPED', 'something_else')).toBe(
+  it('returns generic skipped message for skipped with unknown message', () => {
+    expect(getDistributionErrorTooltip('skipped', 'something_else')).toBe(
       'Distribution was skipped'
     );
   });
 
-  it('returns processing error message for PROCESSING_ERROR', () => {
-    expect(getDistributionErrorTooltip('PROCESSING_ERROR')).toBe(
+  it('returns processing error message for processing_error', () => {
+    expect(getDistributionErrorTooltip('processing_error')).toBe(
       'Distribution failed due to a processing error'
     );
   });
@@ -100,7 +100,7 @@ describe('InstallDetailsContent', () => {
       <InstallDetailsContent
         artifactId="artifact-1"
         projectSlug="my-project"
-        distributionErrorCode="SKIPPED"
+        distributionErrorCode="skipped"
         distributionErrorMessage="simulator"
       />,
       {organization}

--- a/static/app/views/preprod/components/installDetailsContent.spec.tsx
+++ b/static/app/views/preprod/components/installDetailsContent.spec.tsx
@@ -1,0 +1,102 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {InstallDetailsContent} from 'sentry/views/preprod/components/installDetailsContent';
+
+describe('InstallDetailsContent', () => {
+  const organization = OrganizationFixture();
+  const INSTALL_DETAILS_URL = `/organizations/${organization.slug}/preprodartifacts/artifact-1/private-install-details/`;
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('shows friendly error when API returns 404', async () => {
+    MockApiClient.addMockResponse({
+      url: INSTALL_DETAILS_URL,
+      statusCode: 404,
+      body: {error: 'Installable file not available'},
+    });
+
+    render(<InstallDetailsContent artifactId="artifact-1" />, {organization});
+
+    expect(
+      await screen.findByText('Build distribution is not enabled')
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Retry'})).not.toBeInTheDocument();
+  });
+
+  it('shows settings link when projectSlug is provided and API returns 404', async () => {
+    MockApiClient.addMockResponse({
+      url: INSTALL_DETAILS_URL,
+      statusCode: 404,
+      body: {error: 'Installable file not available'},
+    });
+
+    render(<InstallDetailsContent artifactId="artifact-1" projectSlug="my-project" />, {
+      organization,
+    });
+
+    expect(
+      await screen.findByText('Build distribution is not enabled')
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'project settings'})).toHaveAttribute(
+      'href',
+      `/settings/${organization.slug}/projects/my-project/mobile-builds/?tab=distribution`
+    );
+  });
+
+  it('shows message without link when projectSlug is not provided and API returns 404', async () => {
+    MockApiClient.addMockResponse({
+      url: INSTALL_DETAILS_URL,
+      statusCode: 404,
+      body: {error: 'Installable file not available'},
+    });
+
+    render(<InstallDetailsContent artifactId="artifact-1" />, {organization});
+
+    expect(
+      await screen.findByText('Build distribution is not enabled')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'The installable file is not available for this build. Enable build distribution in your project settings.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('shows generic error with retry for non-404 errors', async () => {
+    MockApiClient.addMockResponse({
+      url: INSTALL_DETAILS_URL,
+      statusCode: 500,
+      body: {detail: 'Internal error'},
+    });
+
+    render(<InstallDetailsContent artifactId="artifact-1" />, {organization});
+
+    expect(
+      await screen.findByRole('button', {name: 'Retry'}, {timeout: 10_000})
+    ).toBeInTheDocument();
+  });
+
+  it('renders install details on success', async () => {
+    MockApiClient.addMockResponse({
+      url: INSTALL_DETAILS_URL,
+      body: {
+        platform: 'apple',
+        install_url: 'https://example.com/install',
+        is_code_signature_valid: true,
+        profile_name: 'Dev Profile',
+        codesigning_type: 'development',
+        download_count: 5,
+      },
+    });
+
+    render(<InstallDetailsContent artifactId="artifact-1" />, {organization});
+
+    expect(await screen.findByText('5 downloads')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Download'})).toBeInTheDocument();
+  });
+});

--- a/static/app/views/preprod/components/installDetailsContent.spec.tsx
+++ b/static/app/views/preprod/components/installDetailsContent.spec.tsx
@@ -2,7 +2,45 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
-import {InstallDetailsContent} from 'sentry/views/preprod/components/installDetailsContent';
+import {
+  getDistributionErrorTooltip,
+  InstallDetailsContent,
+} from 'sentry/views/preprod/components/installDetailsContent';
+
+describe('getDistributionErrorTooltip', () => {
+  it('returns quota message for NO_QUOTA', () => {
+    expect(getDistributionErrorTooltip('NO_QUOTA')).toBe('Distribution quota exceeded');
+  });
+
+  it('returns signature message for SKIPPED with invalid_signature', () => {
+    expect(getDistributionErrorTooltip('SKIPPED', 'invalid_signature')).toBe(
+      'Code signature is invalid'
+    );
+  });
+
+  it('returns simulator message for SKIPPED with simulator', () => {
+    expect(getDistributionErrorTooltip('SKIPPED', 'simulator')).toBe(
+      'Simulator builds cannot be distributed'
+    );
+  });
+
+  it('returns generic skipped message for SKIPPED with unknown message', () => {
+    expect(getDistributionErrorTooltip('SKIPPED', 'something_else')).toBe(
+      'Distribution was skipped'
+    );
+  });
+
+  it('returns processing error message for PROCESSING_ERROR', () => {
+    expect(getDistributionErrorTooltip('PROCESSING_ERROR')).toBe(
+      'Distribution failed due to a processing error'
+    );
+  });
+
+  it('returns fallback for no error code', () => {
+    expect(getDistributionErrorTooltip(null, null)).toBe('Not installable');
+    expect(getDistributionErrorTooltip(undefined, undefined)).toBe('Not installable');
+  });
+});
 
 describe('InstallDetailsContent', () => {
   const organization = OrganizationFixture();
@@ -78,6 +116,45 @@ describe('InstallDetailsContent', () => {
 
     expect(
       await screen.findByRole('button', {name: 'Retry'}, {timeout: 10_000})
+    ).toBeInTheDocument();
+  });
+
+  it('shows distribution error reason when no install URL and error code is provided', async () => {
+    MockApiClient.addMockResponse({
+      url: INSTALL_DETAILS_URL,
+      body: {
+        platform: 'apple',
+        is_code_signature_valid: true,
+      },
+    });
+
+    render(
+      <InstallDetailsContent
+        artifactId="artifact-1"
+        distributionErrorCode="SKIPPED"
+        distributionErrorMessage="simulator"
+      />,
+      {organization}
+    );
+
+    expect(
+      await screen.findByText('Simulator builds cannot be distributed')
+    ).toBeInTheDocument();
+  });
+
+  it('shows generic fallback when no install URL and no error code', async () => {
+    MockApiClient.addMockResponse({
+      url: INSTALL_DETAILS_URL,
+      body: {
+        platform: 'apple',
+        is_code_signature_valid: true,
+      },
+    });
+
+    render(<InstallDetailsContent artifactId="artifact-1" />, {organization});
+
+    expect(
+      await screen.findByText('No install download link available')
     ).toBeInTheDocument();
   });
 

--- a/static/app/views/preprod/components/installDetailsContent.spec.tsx
+++ b/static/app/views/preprod/components/installDetailsContent.spec.tsx
@@ -50,22 +50,7 @@ describe('InstallDetailsContent', () => {
     MockApiClient.clearMockResponses();
   });
 
-  it('shows friendly error when API returns 404', async () => {
-    MockApiClient.addMockResponse({
-      url: INSTALL_DETAILS_URL,
-      statusCode: 404,
-      body: {error: 'Installable file not available'},
-    });
-
-    render(<InstallDetailsContent artifactId="artifact-1" />, {organization});
-
-    expect(
-      await screen.findByText('Build distribution is not enabled')
-    ).toBeInTheDocument();
-    expect(screen.queryByRole('button', {name: 'Retry'})).not.toBeInTheDocument();
-  });
-
-  it('shows settings link when projectSlug is provided and API returns 404', async () => {
+  it('shows friendly error with settings link when API returns 404', async () => {
     MockApiClient.addMockResponse({
       url: INSTALL_DETAILS_URL,
       statusCode: 404,
@@ -79,30 +64,11 @@ describe('InstallDetailsContent', () => {
     expect(
       await screen.findByText('Build distribution is not enabled')
     ).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Retry'})).not.toBeInTheDocument();
     expect(screen.getByRole('link', {name: 'project settings'})).toHaveAttribute(
       'href',
       `/settings/${organization.slug}/projects/my-project/mobile-builds/?tab=distribution`
     );
-  });
-
-  it('shows message without link when projectSlug is not provided and API returns 404', async () => {
-    MockApiClient.addMockResponse({
-      url: INSTALL_DETAILS_URL,
-      statusCode: 404,
-      body: {error: 'Installable file not available'},
-    });
-
-    render(<InstallDetailsContent artifactId="artifact-1" />, {organization});
-
-    expect(
-      await screen.findByText('Build distribution is not enabled')
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        'The installable file is not available for this build. Enable build distribution in your project settings.'
-      )
-    ).toBeInTheDocument();
-    expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 
   it('shows generic error with retry for non-404 errors', async () => {
@@ -112,7 +78,9 @@ describe('InstallDetailsContent', () => {
       body: {detail: 'Internal error'},
     });
 
-    render(<InstallDetailsContent artifactId="artifact-1" />, {organization});
+    render(<InstallDetailsContent artifactId="artifact-1" projectSlug="my-project" />, {
+      organization,
+    });
 
     expect(
       await screen.findByRole('button', {name: 'Retry'}, {timeout: 10_000})
@@ -131,6 +99,7 @@ describe('InstallDetailsContent', () => {
     render(
       <InstallDetailsContent
         artifactId="artifact-1"
+        projectSlug="my-project"
         distributionErrorCode="SKIPPED"
         distributionErrorMessage="simulator"
       />,
@@ -151,7 +120,9 @@ describe('InstallDetailsContent', () => {
       },
     });
 
-    render(<InstallDetailsContent artifactId="artifact-1" />, {organization});
+    render(<InstallDetailsContent artifactId="artifact-1" projectSlug="my-project" />, {
+      organization,
+    });
 
     expect(
       await screen.findByText('No install download link available')
@@ -171,7 +142,9 @@ describe('InstallDetailsContent', () => {
       },
     });
 
-    render(<InstallDetailsContent artifactId="artifact-1" />, {organization});
+    render(<InstallDetailsContent artifactId="artifact-1" projectSlug="my-project" />, {
+      organization,
+    });
 
     expect(await screen.findByText('5 downloads')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Download'})).toBeInTheDocument();

--- a/static/app/views/preprod/components/installDetailsContent.spec.tsx
+++ b/static/app/views/preprod/components/installDetailsContent.spec.tsx
@@ -44,7 +44,58 @@ describe('InstallDetailsContent', () => {
     MockApiClient.clearMockResponses();
   });
 
-  it('shows friendly error with settings link when API returns 404', async () => {
+  it('shows settings link on 404 when distribution is disabled', async () => {
+    MockApiClient.addMockResponse({
+      url: INSTALL_DETAILS_URL,
+      statusCode: 404,
+      body: {error: 'Installable file not available'},
+    });
+
+    render(
+      <InstallDetailsContent
+        artifactId="artifact-1"
+        projectSlug="my-project"
+        distributionErrorCode="distribution_disabled"
+        distributionErrorMessage="Distribution disabled for this project"
+      />,
+      {organization}
+    );
+
+    expect(
+      await screen.findByText('Build distribution is not enabled')
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Retry'})).not.toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'project settings'})).toHaveAttribute(
+      'href',
+      `/settings/${organization.slug}/projects/my-project/mobile-builds/?tab=distribution`
+    );
+  });
+
+  it('shows backend error message on 404 for non-disabled distribution errors', async () => {
+    MockApiClient.addMockResponse({
+      url: INSTALL_DETAILS_URL,
+      statusCode: 404,
+      body: {error: 'Installable file not available'},
+    });
+
+    render(
+      <InstallDetailsContent
+        artifactId="artifact-1"
+        projectSlug="my-project"
+        distributionErrorCode="no_quota"
+        distributionErrorMessage="Distribution quota exceeded"
+      />,
+      {organization}
+    );
+
+    expect(await screen.findByText('Distribution quota exceeded')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', {name: 'project settings'})
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Retry'})).not.toBeInTheDocument();
+  });
+
+  it('shows generic fallback on 404 when no error code is provided', async () => {
     MockApiClient.addMockResponse({
       url: INSTALL_DETAILS_URL,
       statusCode: 404,
@@ -56,13 +107,11 @@ describe('InstallDetailsContent', () => {
     });
 
     expect(
-      await screen.findByText('Build distribution is not enabled')
+      await screen.findByText('No install download link available')
     ).toBeInTheDocument();
-    expect(screen.queryByRole('button', {name: 'Retry'})).not.toBeInTheDocument();
-    expect(screen.getByRole('link', {name: 'project settings'})).toHaveAttribute(
-      'href',
-      `/settings/${organization.slug}/projects/my-project/mobile-builds/?tab=distribution`
-    );
+    expect(
+      screen.queryByRole('link', {name: 'project settings'})
+    ).not.toBeInTheDocument();
   });
 
   it('shows generic error with retry for non-404 errors', async () => {

--- a/static/app/views/preprod/components/installDetailsContent.spec.tsx
+++ b/static/app/views/preprod/components/installDetailsContent.spec.tsx
@@ -8,35 +8,29 @@ import {
 } from 'sentry/views/preprod/components/installDetailsContent';
 
 describe('getDistributionErrorTooltip', () => {
-  it('returns quota message for no_quota', () => {
-    expect(getDistributionErrorTooltip('no_quota')).toBe('Distribution quota exceeded');
+  it('returns the backend-provided message verbatim when present', () => {
+    expect(
+      getDistributionErrorTooltip(
+        'simulator_build',
+        'Simulator builds cannot be distributed.'
+      )
+    ).toBe('Simulator builds cannot be distributed.');
   });
 
-  it('returns signature message for skipped with invalid_signature', () => {
+  it('translates legacy skipped + invalid_signature message', () => {
     expect(getDistributionErrorTooltip('skipped', 'invalid_signature')).toBe(
       'Code signature is invalid'
     );
   });
 
-  it('returns simulator message for skipped with simulator', () => {
+  it('translates legacy skipped + simulator message', () => {
     expect(getDistributionErrorTooltip('skipped', 'simulator')).toBe(
       'Simulator builds cannot be distributed'
     );
   });
 
-  it('returns generic skipped message for skipped with unknown message', () => {
-    expect(getDistributionErrorTooltip('skipped', 'something_else')).toBe(
-      'Distribution was skipped'
-    );
-  });
-
-  it('returns processing error message for processing_error', () => {
-    expect(getDistributionErrorTooltip('processing_error')).toBe(
-      'Distribution failed due to a processing error'
-    );
-  });
-
-  it('returns fallback for no error code', () => {
+  it('falls back to a generic label when no message is provided', () => {
+    expect(getDistributionErrorTooltip('no_quota')).toBe('Not installable');
     expect(getDistributionErrorTooltip(null, null)).toBe('Not installable');
     expect(getDistributionErrorTooltip(undefined, undefined)).toBe('Not installable');
   });
@@ -100,15 +94,42 @@ describe('InstallDetailsContent', () => {
       <InstallDetailsContent
         artifactId="artifact-1"
         projectSlug="my-project"
-        distributionErrorCode="skipped"
-        distributionErrorMessage="simulator"
+        distributionErrorCode="simulator_build"
+        distributionErrorMessage="Simulator builds cannot be distributed."
       />,
       {organization}
     );
 
     expect(
-      await screen.findByText('Simulator builds cannot be distributed')
+      await screen.findByText('Simulator builds cannot be distributed.')
     ).toBeInTheDocument();
+  });
+
+  it('shows settings link when error code is distribution_disabled', async () => {
+    MockApiClient.addMockResponse({
+      url: INSTALL_DETAILS_URL,
+      body: {
+        platform: 'apple',
+        is_code_signature_valid: true,
+      },
+    });
+
+    render(
+      <InstallDetailsContent
+        artifactId="artifact-1"
+        projectSlug="my-project"
+        distributionErrorCode="distribution_disabled"
+      />,
+      {organization}
+    );
+
+    expect(
+      await screen.findByText('Build distribution is not enabled')
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'project settings'})).toHaveAttribute(
+      'href',
+      `/settings/${organization.slug}/projects/my-project/mobile-builds/?tab=distribution`
+    );
   });
 
   it('shows generic fallback when no install URL and no error code', async () => {

--- a/static/app/views/preprod/components/installDetailsContent.tsx
+++ b/static/app/views/preprod/components/installDetailsContent.tsx
@@ -24,10 +24,10 @@ export function getDistributionErrorTooltip(
   errorCode?: string | null,
   errorMessage?: string | null
 ): string {
-  if (errorCode === 'NO_QUOTA') {
+  if (errorCode === 'no_quota') {
     return t('Distribution quota exceeded');
   }
-  if (errorCode === 'SKIPPED') {
+  if (errorCode === 'skipped') {
     if (errorMessage === 'invalid_signature') {
       return t('Code signature is invalid');
     }
@@ -36,7 +36,7 @@ export function getDistributionErrorTooltip(
     }
     return t('Distribution was skipped');
   }
-  if (errorCode === 'PROCESSING_ERROR') {
+  if (errorCode === 'processing_error') {
     return t('Distribution failed due to a processing error');
   }
   return t('Not installable');

--- a/static/app/views/preprod/components/installDetailsContent.tsx
+++ b/static/app/views/preprod/components/installDetailsContent.tsx
@@ -20,8 +20,32 @@ import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import type {InstallDetailsApiResponse} from 'sentry/views/preprod/types/installDetailsTypes';
 
+export function getDistributionErrorTooltip(
+  errorCode?: string | null,
+  errorMessage?: string | null
+): string {
+  if (errorCode === 'NO_QUOTA') {
+    return t('Distribution quota exceeded');
+  }
+  if (errorCode === 'SKIPPED') {
+    if (errorMessage === 'invalid_signature') {
+      return t('Code signature is invalid');
+    }
+    if (errorMessage === 'simulator') {
+      return t('Simulator builds cannot be distributed');
+    }
+    return t('Distribution was skipped');
+  }
+  if (errorCode === 'PROCESSING_ERROR') {
+    return t('Distribution failed due to a processing error');
+  }
+  return t('Not installable');
+}
+
 interface InstallDetailsContentProps {
   artifactId: string;
+  distributionErrorCode?: string | null;
+  distributionErrorMessage?: string | null;
   projectSlug?: string;
   size?: 'sm' | 'lg';
 }
@@ -30,6 +54,8 @@ export function InstallDetailsContent({
   artifactId,
   projectSlug,
   size = 'sm',
+  distributionErrorCode,
+  distributionErrorMessage,
 }: InstallDetailsContentProps) {
   const theme = useTheme();
   const organization = useOrganization();
@@ -267,13 +293,7 @@ export function InstallDetailsContent({
       </Flex>
     );
   } else {
-    if (installDetails.is_code_signature_valid) {
-      body = (
-        <Flex direction="column" align="center" gap={outerGap}>
-          <Text>{t('No install download link available')}</Text>
-        </Flex>
-      );
-    } else {
+    if (installDetails.is_code_signature_valid === false) {
       let errors = null;
       if (
         installDetails.code_signature_errors &&
@@ -293,6 +313,15 @@ export function InstallDetailsContent({
         <Flex direction="column" align="center" gap={outerGap}>
           <Text>{'Code signature is invalid'}</Text>
           {errors}
+        </Flex>
+      );
+    } else {
+      const message = distributionErrorCode
+        ? getDistributionErrorTooltip(distributionErrorCode, distributionErrorMessage)
+        : t('No install download link available');
+      body = (
+        <Flex direction="column" align="center" gap={outerGap}>
+          <Text>{message}</Text>
         </Flex>
       );
     }

--- a/static/app/views/preprod/components/installDetailsContent.tsx
+++ b/static/app/views/preprod/components/installDetailsContent.tsx
@@ -3,6 +3,7 @@ import {useTheme} from '@emotion/react';
 
 import {Button} from '@sentry/scraps/button';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Link} from '@sentry/scraps/link';
 import {Separator} from '@sentry/scraps/separator';
 import {Heading, Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -14,17 +15,20 @@ import {t, tct, tn} from 'sentry/locale';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {MarkedText} from 'sentry/utils/marked/markedText';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import type {InstallDetailsApiResponse} from 'sentry/views/preprod/types/installDetailsTypes';
 
 interface InstallDetailsContentProps {
   artifactId: string;
+  projectSlug?: string;
   size?: 'sm' | 'lg';
 }
 
 export function InstallDetailsContent({
   artifactId,
+  projectSlug,
   size = 'sm',
 }: InstallDetailsContentProps) {
   const theme = useTheme();
@@ -54,6 +58,12 @@ export function InstallDetailsContent({
     ],
     {
       staleTime: 0,
+      retry: (failureCount, apiError) => {
+        if ((apiError as RequestError)?.status === 404) {
+          return false;
+        }
+        return failureCount < 2;
+      },
     }
   );
 
@@ -66,12 +76,38 @@ export function InstallDetailsContent({
       </Flex>
     );
   } else if (isError || !installDetails) {
-    body = (
-      <Flex direction="column" align="center" gap={outerGap}>
-        <Text>{t('Error: %s', error?.message || 'Failed to fetch install details')}</Text>
-        <Button onClick={() => refetch()}>{t('Retry')}</Button>
-      </Flex>
-    );
+    if (error?.status === 404) {
+      body = (
+        <Flex direction="column" align="center" gap={outerGap}>
+          <Text>{t('Build distribution is not enabled')}</Text>
+          <Text size="sm" variant="muted" align="center">
+            {projectSlug
+              ? tct(
+                  'The installable file is not available for this build. Enable build distribution in your [link:project settings].',
+                  {
+                    link: (
+                      <Link
+                        to={`/settings/${organization.slug}/projects/${projectSlug}/mobile-builds/?tab=distribution`}
+                      />
+                    ),
+                  }
+                )
+              : t(
+                  'The installable file is not available for this build. Enable build distribution in your project settings.'
+                )}
+          </Text>
+        </Flex>
+      );
+    } else {
+      body = (
+        <Flex direction="column" align="center" gap={outerGap}>
+          <Text>
+            {t('Error: %s', error?.message || 'Failed to fetch install details')}
+          </Text>
+          <Button onClick={() => refetch()}>{t('Retry')}</Button>
+        </Flex>
+      );
+    }
   } else if (installDetails.codesigning_type === 'appstore') {
     body = (
       <Flex direction="column" align="center" gap={outerGap}>

--- a/static/app/views/preprod/components/installDetailsContent.tsx
+++ b/static/app/views/preprod/components/installDetailsContent.tsx
@@ -58,7 +58,7 @@ export function InstallDetailsContent({
     ],
     {
       staleTime: 0,
-      retry: (failureCount, apiError) => {
+      retry: (failureCount, apiError: RequestError) => {
         if (apiError?.status === 404) {
           return false;
         }

--- a/static/app/views/preprod/components/installDetailsContent.tsx
+++ b/static/app/views/preprod/components/installDetailsContent.tsx
@@ -59,7 +59,7 @@ export function InstallDetailsContent({
     {
       staleTime: 0,
       retry: (failureCount, apiError) => {
-        if ((apiError as RequestError)?.status === 404) {
+        if (apiError?.status === 404) {
           return false;
         }
         return failureCount < 2;

--- a/static/app/views/preprod/components/installDetailsContent.tsx
+++ b/static/app/views/preprod/components/installDetailsContent.tsx
@@ -44,9 +44,9 @@ export function getDistributionErrorTooltip(
 
 interface InstallDetailsContentProps {
   artifactId: string;
+  projectSlug: string;
   distributionErrorCode?: string | null;
   distributionErrorMessage?: string | null;
-  projectSlug?: string;
   size?: 'sm' | 'lg';
 }
 
@@ -107,20 +107,16 @@ export function InstallDetailsContent({
         <Flex direction="column" align="center" gap={outerGap}>
           <Text>{t('Build distribution is not enabled')}</Text>
           <Text size="sm" variant="muted" align="center">
-            {projectSlug
-              ? tct(
-                  'The installable file is not available for this build. Enable build distribution in your [link:project settings].',
-                  {
-                    link: (
-                      <Link
-                        to={`/settings/${organization.slug}/projects/${projectSlug}/mobile-builds/?tab=distribution`}
-                      />
-                    ),
-                  }
-                )
-              : t(
-                  'The installable file is not available for this build. Enable build distribution in your project settings.'
-                )}
+            {tct(
+              'The installable file is not available for this build. Enable build distribution in your [link:project settings].',
+              {
+                link: (
+                  <Link
+                    to={`/settings/${organization.slug}/projects/${projectSlug}/mobile-builds/?tab=distribution`}
+                  />
+                ),
+              }
+            )}
           </Text>
         </Flex>
       );
@@ -293,38 +289,33 @@ export function InstallDetailsContent({
       </Flex>
     );
   } else {
-    if (installDetails.is_code_signature_valid === false) {
-      let errors = null;
-      if (
-        installDetails.code_signature_errors &&
-        installDetails.code_signature_errors.length > 0
-      ) {
-        errors = (
-          <CodeSignatureInfo>
-            <Stack gap="sm">
-              {installDetails.code_signature_errors.map((e, index) => (
-                <Text key={index}>{e}</Text>
-              ))}
-            </Stack>
-          </CodeSignatureInfo>
-        );
-      }
-      body = (
-        <Flex direction="column" align="center" gap={outerGap}>
-          <Text>{'Code signature is invalid'}</Text>
-          {errors}
-        </Flex>
+    let message: string;
+    if (distributionErrorCode) {
+      message = getDistributionErrorTooltip(
+        distributionErrorCode,
+        distributionErrorMessage
       );
+    } else if (installDetails.is_code_signature_valid === false) {
+      message = t('Code signature is invalid');
     } else {
-      const message = distributionErrorCode
-        ? getDistributionErrorTooltip(distributionErrorCode, distributionErrorMessage)
-        : t('No install download link available');
-      body = (
-        <Flex direction="column" align="center" gap={outerGap}>
-          <Text>{message}</Text>
-        </Flex>
-      );
+      message = t('No install download link available');
     }
+
+    body = (
+      <Flex direction="column" align="center" gap={outerGap}>
+        <Text>{message}</Text>
+        {installDetails.code_signature_errors &&
+          installDetails.code_signature_errors.length > 0 && (
+            <CodeSignatureInfo>
+              <Stack gap="sm">
+                {installDetails.code_signature_errors.map((e, index) => (
+                  <Text key={index}>{e}</Text>
+                ))}
+              </Stack>
+            </CodeSignatureInfo>
+          )}
+      </Flex>
+    );
   }
 
   return body;

--- a/static/app/views/preprod/components/installDetailsContent.tsx
+++ b/static/app/views/preprod/components/installDetailsContent.tsx
@@ -119,7 +119,21 @@ export function InstallDetailsContent({
     );
   } else if (isError || !installDetails) {
     if (error?.status === 404) {
-      body = distributionDisabledBody;
+      // 404 means there's no installable file. Use the error_code/message the
+      // parent passes from build-details to explain why — only show the
+      // settings link when distribution is actually disabled for the project.
+      if (distributionErrorCode === 'distribution_disabled') {
+        body = distributionDisabledBody;
+      } else {
+        const message = distributionErrorCode
+          ? getDistributionErrorTooltip(distributionErrorCode, distributionErrorMessage)
+          : t('No install download link available');
+        body = (
+          <Flex direction="column" align="center" gap={outerGap}>
+            <Text>{message}</Text>
+          </Flex>
+        );
+      }
     } else {
       body = (
         <Flex direction="column" align="center" gap={outerGap}>

--- a/static/app/views/preprod/components/installDetailsContent.tsx
+++ b/static/app/views/preprod/components/installDetailsContent.tsx
@@ -18,7 +18,6 @@ import {useApiQuery} from 'sentry/utils/queryClient';
 import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {InstallableAppErrorCode} from 'sentry/views/preprod/types/buildDetailsTypes';
 import type {InstallDetailsApiResponse} from 'sentry/views/preprod/types/installDetailsTypes';
 
 export function getDistributionErrorTooltip(
@@ -29,7 +28,7 @@ export function getDistributionErrorTooltip(
   // error_message as a short-code string. Translate those to real sentences.
   // Drop once launchpad has been emitting the new codes long enough that old
   // rows have aged out.
-  if (errorCode === InstallableAppErrorCode.SKIPPED) {
+  if (errorCode === 'skipped') {
     if (errorMessage === 'invalid_signature') {
       return t('Code signature is invalid');
     }
@@ -44,7 +43,7 @@ export function getDistributionErrorTooltip(
 interface InstallDetailsContentProps {
   artifactId: string;
   projectSlug: string;
-  distributionErrorCode?: InstallableAppErrorCode | string | null;
+  distributionErrorCode?: string | null;
   distributionErrorMessage?: string | null;
   size?: 'sm' | 'lg';
 }
@@ -289,7 +288,7 @@ export function InstallDetailsContent({
         </Fragment>
       </Flex>
     );
-  } else if (distributionErrorCode === InstallableAppErrorCode.DISTRIBUTION_DISABLED) {
+  } else if (distributionErrorCode === 'distribution_disabled') {
     body = distributionDisabledBody;
   } else {
     let message: string;

--- a/static/app/views/preprod/components/installDetailsContent.tsx
+++ b/static/app/views/preprod/components/installDetailsContent.tsx
@@ -18,34 +18,33 @@ import {useApiQuery} from 'sentry/utils/queryClient';
 import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {InstallableAppErrorCode} from 'sentry/views/preprod/types/buildDetailsTypes';
 import type {InstallDetailsApiResponse} from 'sentry/views/preprod/types/installDetailsTypes';
 
 export function getDistributionErrorTooltip(
   errorCode?: string | null,
   errorMessage?: string | null
 ): string {
-  if (errorCode === 'no_quota') {
-    return t('Distribution quota exceeded');
-  }
-  if (errorCode === 'skipped') {
+  // Legacy rows: before the granular codes existed, the reason was stuffed into
+  // error_message as a short-code string. Translate those to real sentences.
+  // Drop once launchpad has been emitting the new codes long enough that old
+  // rows have aged out.
+  if (errorCode === InstallableAppErrorCode.SKIPPED) {
     if (errorMessage === 'invalid_signature') {
       return t('Code signature is invalid');
     }
     if (errorMessage === 'simulator') {
       return t('Simulator builds cannot be distributed');
     }
-    return t('Distribution was skipped');
   }
-  if (errorCode === 'processing_error') {
-    return t('Distribution failed due to a processing error');
-  }
-  return t('Not installable');
+
+  return errorMessage || t('Not installable');
 }
 
 interface InstallDetailsContentProps {
   artifactId: string;
   projectSlug: string;
-  distributionErrorCode?: string | null;
+  distributionErrorCode?: InstallableAppErrorCode | string | null;
   distributionErrorMessage?: string | null;
   size?: 'sm' | 'lg';
 }
@@ -93,6 +92,24 @@ export function InstallDetailsContent({
     }
   );
 
+  const distributionDisabledBody = (
+    <Flex direction="column" align="center" gap={outerGap}>
+      <Text>{t('Build distribution is not enabled')}</Text>
+      <Text size="sm" variant="muted" align="center">
+        {tct(
+          'The installable file is not available for this build. Enable build distribution in your [link:project settings].',
+          {
+            link: (
+              <Link
+                to={`/settings/${organization.slug}/projects/${projectSlug}/mobile-builds/?tab=distribution`}
+              />
+            ),
+          }
+        )}
+      </Text>
+    </Flex>
+  );
+
   let body: ReactNode;
   if (isPending) {
     body = (
@@ -103,23 +120,7 @@ export function InstallDetailsContent({
     );
   } else if (isError || !installDetails) {
     if (error?.status === 404) {
-      body = (
-        <Flex direction="column" align="center" gap={outerGap}>
-          <Text>{t('Build distribution is not enabled')}</Text>
-          <Text size="sm" variant="muted" align="center">
-            {tct(
-              'The installable file is not available for this build. Enable build distribution in your [link:project settings].',
-              {
-                link: (
-                  <Link
-                    to={`/settings/${organization.slug}/projects/${projectSlug}/mobile-builds/?tab=distribution`}
-                  />
-                ),
-              }
-            )}
-          </Text>
-        </Flex>
-      );
+      body = distributionDisabledBody;
     } else {
       body = (
         <Flex direction="column" align="center" gap={outerGap}>
@@ -288,6 +289,8 @@ export function InstallDetailsContent({
         </Fragment>
       </Flex>
     );
+  } else if (distributionErrorCode === InstallableAppErrorCode.DISTRIBUTION_DISABLED) {
+    body = distributionDisabledBody;
   } else {
     let message: string;
     if (distributionErrorCode) {

--- a/static/app/views/preprod/components/installModal.tsx
+++ b/static/app/views/preprod/components/installModal.tsx
@@ -12,7 +12,7 @@ import {InstallDetailsContent} from 'sentry/views/preprod/components/installDeta
 interface InstallModalProps {
   artifactId: string;
   closeModal: () => void;
-  projectSlug?: string;
+  projectSlug: string;
 }
 
 function InstallModal({artifactId, closeModal, projectSlug}: InstallModalProps) {
@@ -44,7 +44,7 @@ function InstallModal({artifactId, closeModal, projectSlug}: InstallModalProps) 
   );
 }
 
-export function openInstallModal(artifactId: string, projectSlug?: string) {
+export function openInstallModal(artifactId: string, projectSlug: string) {
   openModal(
     ({closeModal}) => (
       <InstallModal

--- a/static/app/views/preprod/components/installModal.tsx
+++ b/static/app/views/preprod/components/installModal.tsx
@@ -12,9 +12,10 @@ import {InstallDetailsContent} from 'sentry/views/preprod/components/installDeta
 interface InstallModalProps {
   artifactId: string;
   closeModal: () => void;
+  projectSlug?: string;
 }
 
-function InstallModal({artifactId, closeModal}: InstallModalProps) {
+function InstallModal({artifactId, closeModal, projectSlug}: InstallModalProps) {
   return (
     <Flex direction="column">
       <Grid display="grid" columns="1fr auto 1fr" align="center">
@@ -33,15 +34,25 @@ function InstallModal({artifactId, closeModal}: InstallModalProps) {
         </Container>
       </Grid>
       <Container padding="xl">
-        <InstallDetailsContent artifactId={artifactId} size="sm" />
+        <InstallDetailsContent
+          artifactId={artifactId}
+          size="sm"
+          projectSlug={projectSlug}
+        />
       </Container>
     </Flex>
   );
 }
 
-export function openInstallModal(artifactId: string) {
+export function openInstallModal(artifactId: string, projectSlug?: string) {
   openModal(
-    ({closeModal}) => <InstallModal artifactId={artifactId} closeModal={closeModal} />,
+    ({closeModal}) => (
+      <InstallModal
+        artifactId={artifactId}
+        closeModal={closeModal}
+        projectSlug={projectSlug}
+      />
+    ),
     {
       modalCss: css`
         max-width: 500px;

--- a/static/app/views/preprod/install/installPage.tsx
+++ b/static/app/views/preprod/install/installPage.tsx
@@ -56,17 +56,19 @@ export default function InstallPage() {
                     </Flex>
                   </Container>
                   <Container padding="2xl">
-                    <InstallDetailsContent
-                      artifactId={artifactId}
-                      size="lg"
-                      projectSlug={buildDetailsQuery.data?.project_slug}
-                      distributionErrorCode={
-                        buildDetailsQuery.data?.distribution_info?.error_code
-                      }
-                      distributionErrorMessage={
-                        buildDetailsQuery.data?.distribution_info?.error_message
-                      }
-                    />
+                    {buildDetailsQuery.data && (
+                      <InstallDetailsContent
+                        artifactId={artifactId}
+                        size="lg"
+                        projectSlug={buildDetailsQuery.data.project_slug}
+                        distributionErrorCode={
+                          buildDetailsQuery.data.distribution_info?.error_code
+                        }
+                        distributionErrorMessage={
+                          buildDetailsQuery.data.distribution_info?.error_message
+                        }
+                      />
+                    )}
                   </Container>
                 </Container>
                 {buildDetailsQuery.data && (

--- a/static/app/views/preprod/install/installPage.tsx
+++ b/static/app/views/preprod/install/installPage.tsx
@@ -1,7 +1,9 @@
+import {Button} from '@sentry/scraps/button';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
-import {Heading} from '@sentry/scraps/text';
+import {Heading, Text} from '@sentry/scraps/text';
 
 import * as Layout from 'sentry/components/layouts/thirds';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
@@ -56,7 +58,25 @@ export default function InstallPage() {
                     </Flex>
                   </Container>
                   <Container padding="2xl">
-                    {buildDetailsQuery.data && (
+                    {buildDetailsQuery.isPending ? (
+                      <Flex direction="column" align="center" gap="lg">
+                        <LoadingIndicator />
+                        <Text>{t('Loading build details...')}</Text>
+                      </Flex>
+                    ) : buildDetailsQuery.isError || !buildDetailsQuery.data ? (
+                      <Flex direction="column" align="center" gap="lg">
+                        <Text>
+                          {t(
+                            'Error: %s',
+                            buildDetailsQuery.error?.message ||
+                              'Failed to fetch build details'
+                          )}
+                        </Text>
+                        <Button onClick={() => buildDetailsQuery.refetch()}>
+                          {t('Retry')}
+                        </Button>
+                      </Flex>
+                    ) : (
                       <InstallDetailsContent
                         artifactId={artifactId}
                         size="lg"

--- a/static/app/views/preprod/install/installPage.tsx
+++ b/static/app/views/preprod/install/installPage.tsx
@@ -56,7 +56,11 @@ export default function InstallPage() {
                     </Flex>
                   </Container>
                   <Container padding="2xl">
-                    <InstallDetailsContent artifactId={artifactId} size="lg" />
+                    <InstallDetailsContent
+                      artifactId={artifactId}
+                      size="lg"
+                      projectSlug={buildDetailsQuery.data?.project_slug}
+                    />
                   </Container>
                 </Container>
                 {buildDetailsQuery.data && (

--- a/static/app/views/preprod/install/installPage.tsx
+++ b/static/app/views/preprod/install/installPage.tsx
@@ -60,6 +60,12 @@ export default function InstallPage() {
                       artifactId={artifactId}
                       size="lg"
                       projectSlug={buildDetailsQuery.data?.project_slug}
+                      distributionErrorCode={
+                        buildDetailsQuery.data?.distribution_info?.error_code
+                      }
+                      distributionErrorMessage={
+                        buildDetailsQuery.data?.distribution_info?.error_message
+                      }
                     />
                   </Container>
                 </Container>

--- a/static/app/views/preprod/types/buildDetailsTypes.ts
+++ b/static/app/views/preprod/types/buildDetailsTypes.ts
@@ -22,19 +22,8 @@ interface BuildDetailsDistributionInfo {
   is_installable: boolean;
   download_count: number;
   release_notes: string | null;
-  error_code?: InstallableAppErrorCode | null;
+  error_code?: string | null;
   error_message?: string | null;
-}
-
-export enum InstallableAppErrorCode {
-  NO_QUOTA = 'no_quota',
-  SKIPPED = 'skipped',
-  PROCESSING_ERROR = 'processing_error',
-  DISTRIBUTION_DISABLED = 'distribution_disabled',
-  DISTRIBUTION_FILTERED = 'distribution_filtered',
-  INVALID_CODE_SIGNATURE = 'invalid_code_signature',
-  SIMULATOR_BUILD = 'simulator_build',
-  UNSUPPORTED_ARTIFACT_TYPE = 'unsupported_artifact_type',
 }
 
 export interface BuildDetailsAppInfo {

--- a/static/app/views/preprod/types/buildDetailsTypes.ts
+++ b/static/app/views/preprod/types/buildDetailsTypes.ts
@@ -22,8 +22,19 @@ interface BuildDetailsDistributionInfo {
   is_installable: boolean;
   download_count: number;
   release_notes: string | null;
-  error_code?: string | null;
+  error_code?: InstallableAppErrorCode | null;
   error_message?: string | null;
+}
+
+export enum InstallableAppErrorCode {
+  NO_QUOTA = 'no_quota',
+  SKIPPED = 'skipped',
+  PROCESSING_ERROR = 'processing_error',
+  DISTRIBUTION_DISABLED = 'distribution_disabled',
+  DISTRIBUTION_FILTERED = 'distribution_filtered',
+  INVALID_CODE_SIGNATURE = 'invalid_code_signature',
+  SIMULATOR_BUILD = 'simulator_build',
+  UNSUPPORTED_ARTIFACT_TYPE = 'unsupported_artifact_type',
 }
 
 export interface BuildDetailsAppInfo {


### PR DESCRIPTION
## What

When the `private-install-details` endpoint returns a 404 (because distribution is disabled), the Download Build modal and install page now show a friendly error message with a link to the project's distribution settings, instead of a raw error like `"Error: (404) https://..."`.

## Why

Users who have distribution disabled see a confusing raw error when they try to install a build. This makes the error actionable by explaining what's wrong and where to fix it.

Here's a screenshot of what this will look like:
<img width="535" height="249" alt="Screenshot 2026-04-16 at 09 01 45" src="https://github.com/user-attachments/assets/529e986e-70e3-4900-ab86-b984efdc1bd3" />


Fixes EME-883