### PR TITLE
chore(metrics): Update Android and Java onboarding to require SDK 8.34.0

### DIFF
--- a/static/app/gettingStartedDocs/android/metrics.tsx
+++ b/static/app/gettingStartedDocs/android/metrics.tsx
@@ -34,7 +34,7 @@ export const metrics: OnboardingConfig<BasePlatformOptions> = {
         {
           type: 'text',
           text: tct(
-            "To start using metrics, make sure your Sentry Android SDK version is [version:8.30.0] or higher. If you're on an older version of the SDK, follow our [link:migration guide] to upgrade.",
+            "To start using metrics, make sure your Sentry Android SDK version is [version:8.34.0] or higher. If you're on an older version of the SDK, follow our [link:migration guide] to upgrade.",
             {
               version: <code />,
               link: (

--- a/static/app/gettingStartedDocs/java/metrics.tsx
+++ b/static/app/gettingStartedDocs/java/metrics.tsx
@@ -78,7 +78,7 @@ export const metrics: OnboardingConfig<BasePlatformOptions> = {
           {
             type: 'text',
             text: tct(
-              "To start using metrics, make sure your Sentry Java SDK version is [version:8.30.0] or higher. If you're on an older version of the SDK, follow our [link:migration guide] to upgrade.",
+              "To start using metrics, make sure your Sentry Java SDK version is [version:8.34.0] or higher. If you're on an older version of the SDK, follow our [link:migration guide] to upgrade.",
               {
                 version: <code />,
                 link: (


### PR DESCRIPTION
Update the minimum SDK version for metrics onboarding from 8.30.0 to 8.34.0 for both Android and Java platforms.

SDK 8.34.0 provides stable support for metrics, as part of preparing metrics for GA.

Related docs PR: https://github.com/getsentry/sentry-docs/pull/17359