### PR TITLE
ref(cmdk) improve nesting structure

### DIFF
--- a/static/app/components/commandPalette/ui/cmdk.tsx
+++ b/static/app/components/commandPalette/ui/cmdk.tsx
@@ -95,9 +95,10 @@ export function CMDKAction({
 }: CMDKActionProps) {
   const ref = CommandPaletteSlot.useSlotOutletRef();
 
-  // For async resources, default to 4 when no explicit limit is given.
-  // For static children, undefined means no limit.
-  const effectiveLimit = limit ?? (resource ? 4 : undefined);
+  // For async-only resource nodes (function children), default limit to 4.
+  // For nodes with static children alongside a resource, no default limit applies.
+  const effectiveLimit =
+    limit ?? (resource && typeof children === 'function' ? 4 : undefined);
 
   const nodeData: CMDKActionData =
     to === undefined
@@ -118,16 +119,30 @@ export function CMDKAction({
     enabled: !!resource && (resourceOptions.enabled ?? true),
   });
 
-  if (!children) {
+  if (!children && !resource) {
     return null;
   }
 
+  // Render-prop: call function with async data (existing behavior).
+  // Static children: render as-is. Resource results are auto-rendered alongside
+  // static children so they register in the collection as depth-1 nodes
+  // (no prefix injection in search results).
   const resolvedChildren =
-    typeof children === 'function' ? (data ? children(data) : null) : children;
+    typeof children === 'function' ? (data ? children(data) : null) : (children ?? null);
+
+  const resolvedResourceNodes =
+    typeof children !== 'function' && data
+      ? (data as CommandPaletteAction[]).map((item, i) => {
+          if ('to' in item) return <CMDKAction key={i} {...item} />;
+          if ('onAction' in item) return <CMDKAction key={i} {...item} />;
+          return null;
+        })
+      : null;
 
   return (
     <CMDKCollection.Context.Provider value={key}>
       {resolvedChildren}
+      {resolvedResourceNodes}
     </CMDKCollection.Context.Provider>
   );
 }

--- a/static/app/components/commandPalette/ui/cmdk.tsx
+++ b/static/app/components/commandPalette/ui/cmdk.tsx
@@ -133,9 +133,10 @@ export function CMDKAction({
   const resolvedResourceNodes =
     typeof children !== 'function' && data
       ? (data as CommandPaletteAction[]).map((item, i) => {
-          if ('to' in item) return <CMDKAction key={i} {...item} />;
-          if ('onAction' in item) return <CMDKAction key={i} {...item} />;
-          return null;
+          // CommandPaletteActionGroup has an `actions` prop that CMDKAction doesn't
+          // accept, so we skip groups here — they can't be auto-rendered as leaf nodes.
+          if ('actions' in item) return null;
+          return <CMDKAction key={i} {...item} />;
         })
       : null;
 

--- a/static/app/components/commandPalette/ui/commandPalette.spec.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.spec.tsx
@@ -283,8 +283,9 @@ describe('CommandPalette', () => {
       const input = await screen.findByRole('textbox', {name: 'Search commands'});
       await userEvent.type(input, 'child');
 
+      // The item now renders with its parent group as a prefix, so match by regex
       expect(
-        await screen.findByRole('option', {name: 'Child Action'})
+        await screen.findByRole('option', {name: /Child Action/})
       ).toBeInTheDocument();
     });
 

--- a/static/app/components/commandPalette/ui/commandPalette.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.tsx
@@ -100,7 +100,7 @@ export function CommandPalette(props: CommandPaletteProps) {
     return nodes;
   }, [store, state.action]);
 
-  const actions = useMemo<CMDKFlatItem[]>(() => {
+  const [actions, prefixMap] = useMemo<[CMDKFlatItem[], Map<string, string[]>]>(() => {
     if (!state.query) {
       return flattenActions(currentNodes, null);
     }
@@ -123,7 +123,7 @@ export function CommandPalette(props: CommandPaletteProps) {
   const treeState = useTreeState({
     disabledKeys: sectionKeys,
     children: actions.map(action => {
-      const menuItem = makeMenuItemFromAction(action);
+      const menuItem = makeMenuItemFromAction(action, prefixMap);
 
       if (action.listItemType === 'section') {
         return (
@@ -159,11 +159,16 @@ export function CommandPalette(props: CommandPaletteProps) {
         );
       }
 
+      const prefix = prefixMap.get(action.key);
       return (
         <Item<CommandPaletteActionMenuItem>
           {...menuItem}
           key={action.key}
-          textValue={action.display.label}
+          textValue={
+            prefix?.length
+              ? `${prefix.join(' ')} ${action.display.label}`
+              : action.display.label
+          }
         >
           {menuItem.label}
         </Item>
@@ -226,7 +231,7 @@ export function CommandPalette(props: CommandPaletteProps) {
       }
 
       const resultIndex = actions.indexOf(action);
-      const sourceAction = getSourceAction(action, actions);
+      const sourceAction = getSourceAction(action, actions, prefixMap);
       const carriedQuery = isSeeMoreAction(action.key) ? state.query : undefined;
 
       if (action.children.length > 0) {
@@ -272,7 +277,7 @@ export function CommandPalette(props: CommandPaletteProps) {
 
       closeModal?.();
     },
-    [actions, analytics, closeModal, dispatch, navigate, state.query]
+    [actions, analytics, closeModal, dispatch, navigate, prefixMap, state.query]
   );
 
   const resultsListRef = useRef<HTMLDivElement>(null);
@@ -567,7 +572,7 @@ function flattenActions(
   nodes: Array<CollectionTreeNode<CMDKActionData>>,
   scores: Map<string, CommandPaletteScore> | null,
   sortLeafResults = false
-): CMDKFlatItem[] {
+): [CMDKFlatItem[], Map<string, string[]>] {
   // Browse mode: show each top-level node and its direct children.
   if (!scores) {
     const results: CMDKFlatItem[] = [];
@@ -602,7 +607,7 @@ function flattenActions(
         results.push({...node, listItemType: 'action'});
       }
     }
-    return results;
+    return [results, new Map()];
   }
 
   // Search mode: DFS all nodes, collect as flat list, sort groups by max child
@@ -622,6 +627,11 @@ function flattenActions(
     dfs(node);
   }
 
+  const nodeMap = new Map<string, CollectionTreeNode<CMDKActionData>>();
+  for (const item of collected) {
+    nodeMap.set(item.key, item);
+  }
+
   // Keep the existing top-level search ordering by default, but when we are
   // inside an expanded group we also sort leaf actions by their own score so
   // the full result list matches the limited preview ordering.
@@ -635,6 +645,8 @@ function flattenActions(
   // Track processed keys so children beyond a group's limit cannot resurface as
   // standalone flat items later in the traversal.
   const seen = new Set<string>();
+  const prefixMap = new Map<string, string[]>();
+  const usedSectionHeaders = new Set<string>();
 
   const flattened = collected.flatMap((item): CMDKFlatItem[] => {
     if (seen.has(item.key)) return [];
@@ -642,7 +654,7 @@ function flattenActions(
 
     if (item.children.length > 0) {
       const matched = item.children.filter(
-        c => scores.get(c.key)?.matched && !isEmptyResourceNode(c)
+        c => scores.get(c.key)?.matched && !isEmptyResourceNode(c) && !seen.has(c.key)
       );
       if (!matched.length) return [];
       const sortedMatches = matched.sort((a, b) =>
@@ -655,12 +667,50 @@ function flattenActions(
       for (const child of item.children) {
         markSubtreeSeen(child, seen);
       }
+      // Walk the ancestor chain inline to find the root section for this group.
+      let root: CollectionTreeNode<CMDKActionData> = item;
+      const intermediatePath: string[] = [];
+      while (root.parent !== null) {
+        const parent = nodeMap.get(root.parent);
+        if (!parent) break;
+        intermediatePath.unshift(root.display.label);
+        root = parent;
+      }
+      const isNested = root.key !== item.key;
+      const seeMore = shouldShowSeeMore(matched.length, item.limit);
+
+      if (isNested) {
+        for (const child of limitedMatches) {
+          prefixMap.set(child.key, intermediatePath);
+        }
+        if (seeMore) {
+          // Store the group label so getSourceAction can recover it for the
+          // "See all" item even though the original section header is not emitted.
+          // Use a distinct `:source-label` suffix so this entry is never mistaken
+          // for a render-time prefix by makeMenuItemFromAction.
+          prefixMap.set(`${item.key}:see-more:source-label`, [item.display.label]);
+        }
+        const sectionHeader = usedSectionHeaders.has(root.key)
+          ? []
+          : [makeSectionAction(root)];
+        usedSectionHeaders.add(root.key);
+        return [
+          ...sectionHeader,
+          ...limitedMatches.map(c => ({...c, listItemType: 'action' as const})),
+          ...(seeMore ? [makeSeeMoreAction(item)] : []),
+        ];
+      }
+
+      // A nested descendant processed earlier may have already emitted this item's
+      // section header via the root-bubbling path — skip it to avoid a duplicate key.
+      const sectionHeader = usedSectionHeaders.has(item.key)
+        ? []
+        : [makeSectionAction(item)];
+      usedSectionHeaders.add(item.key);
       return [
-        makeSectionAction(item),
+        ...sectionHeader,
         ...limitedMatches.map(c => ({...c, listItemType: 'action' as const})),
-        ...(shouldShowSeeMore(matched.length, item.limit)
-          ? [makeSeeMoreAction(item)]
-          : []),
+        ...(seeMore ? [makeSeeMoreAction(item)] : []),
       ];
     }
 
@@ -672,7 +722,7 @@ function flattenActions(
     return scores.get(item.key)?.matched ? [{...item, listItemType: 'action'}] : [];
   });
 
-  return flattened;
+  return [flattened, prefixMap];
 }
 
 function getLimitedChildren<T>(children: T[], limit?: number): T[] {
@@ -708,15 +758,29 @@ function makeSectionAction(node: CollectionTreeNode<CMDKActionData>): CMDKFlatIt
   };
 }
 
-function getSourceAction(action: CMDKFlatItem, actions: CMDKFlatItem[]): CMDKFlatItem {
+function getSourceAction(
+  action: CMDKFlatItem,
+  actions: CMDKFlatItem[],
+  prefixMap: Map<string, string[]>
+): CMDKFlatItem {
   if (!isSeeMoreAction(action.key)) {
     return action;
   }
 
   const sourceActionKey = getSourceActionKey(action.key);
-  return (
-    actions.find(candidate => candidate.key === `${sourceActionKey}:header`) ?? action
+  const headerMatch = actions.find(
+    candidate => candidate.key === `${sourceActionKey}:header`
   );
+  if (headerMatch) return headerMatch;
+
+  // For nested groups the original header was replaced by the root ancestor header.
+  // The prefix map stores the group label under a distinct `:source-label` key.
+  const groupLabel = prefixMap.get(`${action.key}:source-label`)?.[0];
+  if (groupLabel) {
+    return {...action, display: {...action.display, label: groupLabel}};
+  }
+
+  return action;
 }
 
 function isSeeMoreAction(key: string): boolean {
@@ -737,7 +801,11 @@ function isEmptyResourceNode(node: CollectionTreeNode<CMDKActionData>): boolean 
   );
 }
 
-function makeMenuItemFromAction(action: CMDKFlatItem): CommandPaletteActionMenuItem {
+function makeMenuItemFromAction(
+  action: CMDKFlatItem,
+  prefixMap: Map<string, string[]>
+): CommandPaletteActionMenuItem {
+  const prefix = prefixMap.get(action.key);
   const isExternal = 'to' in action ? isExternalLocation(action.to) : false;
   const trailingItems =
     'to' in action ? (
@@ -754,7 +822,23 @@ function makeMenuItemFromAction(action: CMDKFlatItem): CommandPaletteActionMenuI
 
   return {
     key: action.key,
-    label: action.display.label,
+    label: prefix?.length ? (
+      <Flex align="center" gap="xs">
+        {prefix.map((segment, i) => (
+          <Fragment key={i}>
+            <Text size="sm" variant="muted">
+              {segment}
+            </Text>
+            <IconDefaultsProvider size="xs" variant="muted">
+              <IconArrow direction="right" />
+            </IconDefaultsProvider>
+          </Fragment>
+        ))}
+        <Text size="sm">{action.display.label}</Text>
+      </Flex>
+    ) : (
+      action.display.label
+    ),
     details: action.display.details,
     leadingItems: (
       <Flex

--- a/static/app/components/commandPalette/ui/commandPalette.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.tsx
@@ -882,7 +882,7 @@ function makeMenuItemFromAction(
       action.display.label
     ),
     details: action.display.details,
-    leadingItems: (
+    leadingItems: isSeeMoreAction(action.key) ? null : (
       <Flex
         height="100%"
         align="start"

--- a/static/app/components/commandPalette/ui/commandPalette.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.tsx
@@ -826,15 +826,13 @@ function makeMenuItemFromAction(
       <Flex align="center" gap="xs">
         {prefix.map((segment, i) => (
           <Fragment key={i}>
-            <Text size="sm" variant="muted">
-              {segment}
-            </Text>
+            <Text variant="muted">{segment}</Text>
             <IconDefaultsProvider size="xs" variant="muted">
               <IconArrow direction="right" />
             </IconDefaultsProvider>
           </Fragment>
         ))}
-        <Text size="sm">{action.display.label}</Text>
+        <Text>{action.display.label}</Text>
       </Flex>
     ) : (
       action.display.label

--- a/static/app/components/commandPalette/ui/commandPalette.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.tsx
@@ -655,7 +655,7 @@ function flattenActions(
   const rootBestScore = new Map<string, CommandPaletteScore>();
   for (const [key, score] of scores) {
     const node = nodeMap.get(key);
-    if (node && node.parent === null && node.children.length === 0) continue;
+    if (node?.parent === null && node.children.length === 0) continue;
     const rootKey = nodeRootKey.get(key);
     if (rootKey === undefined) continue;
     const current = rootBestScore.get(rootKey);

--- a/static/app/components/commandPalette/ui/commandPalette.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.tsx
@@ -726,10 +726,12 @@ function flattenActions(
           prefixMap.set(child.key, intermediatePath);
         }
         if (seeMore) {
-          // Store the group label so getSourceAction can recover it for the
-          // "See all" item even though the original section header is not emitted.
-          // Use a distinct `:source-label` suffix so this entry is never mistaken
-          // for a render-time prefix by makeMenuItemFromAction.
+          // Render-time prefix for the "See all" item — same path as its siblings.
+          prefixMap.set(`${item.key}:see-more`, intermediatePath);
+          // Source-label hint so getSourceAction can recover the group label for
+          // analytics/navigation even though the original section header is not
+          // emitted. The distinct `:source-label` suffix avoids collision with the
+          // render-time prefix entry above.
           prefixMap.set(`${item.key}:see-more:source-label`, [item.display.label]);
         }
         const sectionHeader = usedSectionHeaders.has(root.key)

--- a/static/app/components/commandPalette/ui/commandPalette.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.tsx
@@ -632,15 +632,57 @@ function flattenActions(
     nodeMap.set(item.key, item);
   }
 
-  // Keep the existing top-level search ordering by default, but when we are
-  // inside an expanded group we also sort leaf actions by their own score so
-  // the full result list matches the limited preview ordering.
-  collected.sort((a, b) =>
-    compareCommandPaletteScores(
+  // Pre-compute the root ancestor key for every node. The sort below uses this
+  // as the primary key so all results from the same top-level section stay
+  // grouped together, regardless of how individual sub-groups score.
+  const nodeRootKey = new Map<string, string>();
+  for (const item of collected) {
+    let root: CollectionTreeNode<CMDKActionData> = item;
+    while (root.parent !== null) {
+      const parent = nodeMap.get(root.parent);
+      if (!parent) break;
+      root = parent;
+    }
+    nodeRootKey.set(item.key, root.key);
+  }
+
+  // Best score among all matched descendants for each root section. Used as
+  // the primary sort key so sections are ordered by their top relevance signal.
+  // Root-level leaf nodes (parent === null, no children) are excluded: they are
+  // their own root and inherit the old behaviour of sorting by DFS order rather
+  // than match quality, consistent with getBestItemScore returning undefined for
+  // leaves when sortLeafResults is false.
+  const rootBestScore = new Map<string, CommandPaletteScore>();
+  for (const [key, score] of scores) {
+    const node = nodeMap.get(key);
+    if (node && node.parent === null && node.children.length === 0) continue;
+    const rootKey = nodeRootKey.get(key);
+    if (rootKey === undefined) continue;
+    const current = rootBestScore.get(rootKey);
+    if (current === undefined || compareCommandPaletteScores(score, current) < 0) {
+      rootBestScore.set(rootKey, score);
+    }
+  }
+
+  // Sort with root section as the primary key so every node from the same
+  // top-level section stays together in the output. Within each root, order
+  // groups by their best child score so the most relevant sub-section surfaces
+  // first. When we are inside an expanded group we also sort leaf actions by
+  // their own score so the full result list matches the limited preview ordering.
+  collected.sort((a, b) => {
+    const aRootKey = nodeRootKey.get(a.key)!;
+    const bRootKey = nodeRootKey.get(b.key)!;
+    if (aRootKey !== bRootKey) {
+      return compareCommandPaletteScores(
+        rootBestScore.get(aRootKey),
+        rootBestScore.get(bRootKey)
+      );
+    }
+    return compareCommandPaletteScores(
       getBestItemScore(a, scores, sortLeafResults),
       getBestItemScore(b, scores, sortLeafResults)
-    )
-  );
+    );
+  });
 
   // Track processed keys so children beyond a group's limit cannot resurface as
   // standalone flat items later in the traversal.

--- a/static/app/components/commandPalette/ui/commandPalette.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.tsx
@@ -789,7 +789,6 @@ function makeSeeMoreAction(node: CollectionTreeNode<CMDKActionData>): CMDKFlatIt
     display: {
       details: node.display.details,
       label: t('See all'),
-      icon: <IconArrow direction="right" />,
     },
   };
 }
@@ -882,7 +881,7 @@ function makeMenuItemFromAction(
       action.display.label
     ),
     details: action.display.details,
-    leadingItems: isSeeMoreAction(action.key) ? null : (
+    leadingItems: (
       <Flex
         height="100%"
         align="start"

--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -266,7 +266,7 @@ export function GlobalCommandPaletteActions() {
             <CMDKAction
               key={project.id}
               display={{
-                label: project.name,
+                label: project.slug,
                 icon: <ProjectAvatar project={project} size={16} />,
               }}
               to={`/settings/${organization.slug}/projects/${project.slug}/`}

--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -393,7 +393,42 @@ export function GlobalCommandPaletteActions() {
         )}
       </CMDKAction>
 
-      <CMDKAction display={{label: t('Help')}}>
+      <CMDKAction
+        display={{label: t('Help')}}
+        resource={(query: string): CMDKQueryOptions => {
+          return cmdkQueryOptions({
+            queryKey: ['command-palette-help-search', query, helpSearch],
+            queryFn: () =>
+              helpSearch.query(
+                query,
+                {searchAllIndexes: true},
+                {analyticsTags: ['source:command-palette']}
+              ),
+            select: data => {
+              const results = [];
+              for (const index of data) {
+                for (const hit of index.hits.slice(0, 3)) {
+                  results.push({
+                    display: {
+                      label: DOMPurify.sanitize(hit.title ?? '', {ALLOWED_TAGS: []}),
+                      details: DOMPurify.sanitize(
+                        hit.context?.context1 ?? hit.context?.context2 ?? '',
+                        {ALLOWED_TAGS: []}
+                      ),
+                      icon: <IconDocs />,
+                    },
+                    keywords: [hit.context?.context1, hit.context?.context2].filter(
+                      (v): v is string => typeof v === 'string'
+                    ),
+                    to: hit.url,
+                  });
+                }
+              }
+              return results;
+            },
+          });
+        }}
+      >
         <CMDKAction
           display={{label: t('Open Documentation'), icon: <IconDocs />}}
           to="https://docs.sentry.io"
@@ -410,44 +445,6 @@ export function GlobalCommandPaletteActions() {
           display={{label: t('View Changelog'), icon: <IconOpen />}}
           to="https://sentry.io/changelog/"
         />
-        <CMDKAction
-          display={{label: t('Search Results')}}
-          resource={(query: string): CMDKQueryOptions => {
-            return cmdkQueryOptions({
-              queryKey: ['command-palette-help-search', query, helpSearch],
-              queryFn: () =>
-                helpSearch.query(
-                  query,
-                  {searchAllIndexes: true},
-                  {analyticsTags: ['source:command-palette']}
-                ),
-              select: data => {
-                const results = [];
-                for (const index of data) {
-                  for (const hit of index.hits.slice(0, 3)) {
-                    results.push({
-                      display: {
-                        label: DOMPurify.sanitize(hit.title ?? '', {ALLOWED_TAGS: []}),
-                        details: DOMPurify.sanitize(
-                          hit.context?.context1 ?? hit.context?.context2 ?? '',
-                          {ALLOWED_TAGS: []}
-                        ),
-                        icon: <IconDocs />,
-                      },
-                      keywords: [hit.context?.context1, hit.context?.context2].filter(
-                        (v): v is string => typeof v === 'string'
-                      ),
-                      to: hit.url,
-                    });
-                  }
-                }
-                return results;
-              },
-            });
-          }}
-        >
-          {data => data.map((item, i) => renderAsyncResult(item, i))}
-        </CMDKAction>
       </CMDKAction>
 
       <CMDKAction display={{label: t('Interface')}}>


### PR DESCRIPTION
Updates the grouping traversal so that it groups all actions under its top level nodes (previously each child group would end up as a top level match) and flattens the list of links to those nodes (mimics what we had initially).

I initially removed similar behavior because the CMDK interaction model wasn't clear to me, but I've now brought it back with what I believe is a good set of improvements. With this change, the top level groups persist, and the flattened list of actions is a small detail that helps educate the user on where the sub-sections live. I've modified the UI to use the muted color for the parent sections so that the visual anchoring and the area where the user's focus will be on is the sub section titles. I believe this achieves the best of both world, but I'm open to feedback.

<img width="1272" height="930" alt="CleanShot 2026-04-16 at 11 17 28@2x" src="https://github.com/user-attachments/assets/73b6b2e2-dfea-4cd7-9d14-6a4d8d516689" />
<img width="1312" height="944" alt="CleanShot 2026-04-16 at 11 17 18@2x" src="https://github.com/user-attachments/assets/0b48a973-ffde-48d7-b0bc-097a5bdb05b5" />

