### PR TITLE
ref(sdk): allow to disable threading integration

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2295,6 +2295,8 @@ if SENTRY_DEV_DSN:
     # This is used in case you want to report traces of your development set up to a project of your choice
     SENTRY_SDK_CONFIG["dsn"] = SENTRY_DEV_DSN
 
+SENTRY_SDK_THREADING_INTEGRATION = os.environ.get("SENTRY_SDK_DISABLE_THREADING") != "1"
+
 # The sample rate to use for profiles. This is conditional on the usage of
 # traces_sample_rate. So that means the true sample rate will be approximately
 # traces_sample_rate * profiles_sample_rate

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -523,28 +523,36 @@ def configure_sdk():
     from sentry_sdk.integrations.redis import RedisIntegration
     from sentry_sdk.integrations.threading import ThreadingIntegration
 
+    integrations = [
+        DjangoAtomicIntegration(),
+        DjangoIntegration(
+            signals_spans=False,
+            cache_spans=True,
+            middleware_spans=False,
+            db_transaction_spans=True,
+        ),
+        # This makes it so all levels of logging are recorded as breadcrumbs,
+        # but none are captured as events (that's handled by the `internal`
+        # logger defined in `server.py`, which ignores the levels set
+        # in the integration and goes straight to the underlying handler class).
+        LoggingIntegration(event_level=None, sentry_logs_level=logging.INFO),
+        RustInfoIntegration(),
+        RedisIntegration(),
+    ]
+    disabled_integrations = []
+
+    if settings.SENTRY_SDK_THREADING_INTEGRATION:
+        integrations.append(ThreadingIntegration())
+    else:
+        disabled_integrations.append(ThreadingIntegration())
+
     sentry_sdk.init(
         # set back the sentry4sentry_dsn popped above since we need a default dsn on the client
         # for dynamic sampling context public_key population
         dsn=dsns.sentry4sentry,
         transport=MultiplexingTransport,
-        integrations=[
-            DjangoAtomicIntegration(),
-            DjangoIntegration(
-                signals_spans=False,
-                cache_spans=True,
-                middleware_spans=False,
-                db_transaction_spans=True,
-            ),
-            # This makes it so all levels of logging are recorded as breadcrumbs,
-            # but none are captured as events (that's handled by the `internal`
-            # logger defined in `server.py`, which ignores the levels set
-            # in the integration and goes straight to the underlying handler class).
-            LoggingIntegration(event_level=None, sentry_logs_level=logging.INFO),
-            RustInfoIntegration(),
-            RedisIntegration(),
-            ThreadingIntegration(),
-        ],
+        integrations=integrations,
+        disabled_integrations=disabled_integrations,
         **sdk_options,
     )
 


### PR DESCRIPTION
SSIA

With ASGI experimentation, we suffer from a memory leak, which might be caused by https://github.com/getsentry/sentry-python/issues/5928, given the usage of `sync_to_async`.

This setting allow us to verify the assumption.