### PR TITLE
ref(discover): Remove dead saved query delete code

### DIFF
--- a/static/app/views/discover/savedQuery/index.tsx
+++ b/static/app/views/discover/savedQuery/index.tsx
@@ -21,7 +21,7 @@ import type {MenuItemProps} from 'sentry/components/dropdownMenu';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {Hovercard} from 'sentry/components/hovercard';
 import {Overlay, PositionWrapper} from 'sentry/components/overlay';
-import {IconBookmark, IconDelete, IconEllipsis, IconStar} from 'sentry/icons';
+import {IconBookmark, IconEllipsis, IconStar} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Organization, SavedQuery} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
@@ -431,25 +431,6 @@ class SavedQueryButtonGroup extends PureComponent<Props, State> {
 
     // Is a new query enable saveas
     return this.renderButtonSaveAs(disabled);
-  }
-
-  renderButtonDelete(disabled: boolean) {
-    const {isNewQuery} = this.state;
-
-    if (isNewQuery) {
-      return null;
-    }
-
-    return (
-      <Button
-        data-test-id="discover2-savedquery-button-delete"
-        onClick={this.handleDeleteQuery}
-        disabled={disabled}
-        size="sm"
-        icon={<IconDelete />}
-        aria-label={t('Delete')}
-      />
-    );
   }
 
   renderButtonCreateAlert() {


### PR DESCRIPTION
Remove an unused delete-button helper from the discover saved query button group.

Delete is already exposed through the context menu, and `renderButtonDelete` is never rendered anywhere in the component. Keeping the unused method around also kept `IconDelete` imported with no live call site.

This keeps the component smaller without changing saved query behavior. The existing saved query component spec still passes after the cleanup.