### PR TITLE
feat(seer): Add command palette action to resume night shift explorer chats

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_explorer_runs.py
+++ b/src/sentry/seer/endpoints/organization_seer_explorer_runs.py
@@ -37,11 +37,16 @@ class OrganizationSeerExplorerRunsEndpoint(OrganizationEndpoint):
 
     def get(self, request: Request, organization: Organization) -> Response:
         """
-        Get a list of explorer runs triggered by the requesting user.
+        Get a list of explorer runs for the organization.
+
+        By default, results are scoped to the requesting user. Pass ``owner=false``
+        to return runs from all users (e.g. system-created night-shift runs).
 
         Query Parameters:
-            category_key: Optional category key to filter by (e.g., "bug-fixer", "researcher")
-            category_value: Optional category value to filter by (e.g., "issue-123", "a5b32")
+            owner: If "true" (default), only return runs owned by the requesting
+                user. If "false", return runs regardless of owner.
+            category_key: Optional category key to filter by (e.g., "night_shift", "autofix")
+            category_value: Optional category value to filter by (e.g., "org-123")
         """
         has_access, error = has_seer_explorer_access_with_detail(organization, request.user)
         if not has_access:
@@ -49,6 +54,7 @@ class OrganizationSeerExplorerRunsEndpoint(OrganizationEndpoint):
 
         category_key = request.GET.get("category_key")
         category_value = request.GET.get("category_value")
+        only_current_user = request.GET.get("owner", "true").lower() != "false"
 
         def _make_seer_runs_request(offset: int, limit: int) -> dict[str, Any]:
             try:
@@ -58,7 +64,7 @@ class OrganizationSeerExplorerRunsEndpoint(OrganizationEndpoint):
                     category_value=category_value,
                     offset=offset,
                     limit=limit,
-                    only_current_user=category_key is None,
+                    only_current_user=only_current_user,
                 )
             except SeerPermissionError as e:
                 raise PermissionDenied(e.message) from e

--- a/src/sentry/seer/endpoints/organization_seer_explorer_runs.py
+++ b/src/sentry/seer/endpoints/organization_seer_explorer_runs.py
@@ -58,6 +58,7 @@ class OrganizationSeerExplorerRunsEndpoint(OrganizationEndpoint):
                     category_value=category_value,
                     offset=offset,
                     limit=limit,
+                    only_current_user=category_key is None,
                 )
             except SeerPermissionError as e:
                 raise PermissionDenied(e.message) from e

--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -330,7 +330,7 @@ export function GlobalCommandPaletteActions() {
                 '/organizations/$organizationIdOrSlug/seer/explorer-runs/',
                 {path: {organizationIdOrSlug: organization.slug}}
               );
-              const query = {per_page: 10, category_key: 'night_shift'};
+              const query = {per_page: 10, category_key: 'night_shift', owner: 'false'};
               return cmdkQueryOptions({
                 queryKey: [url, {query}],
                 queryFn: () => QUERY_API_CLIENT.requestPromise(url, {query}),

--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -314,8 +314,16 @@ export function GlobalCommandPaletteActions() {
             />
           )}
           <CMDKAction
-            display={{label: t('Resume recent chat'), icon: <IconSeer />}}
-            keywords={[t('seer'), t('ai'), t('chat'), t('agent'), t('explorer')]}
+            display={{label: t('Night Shift Chats'), icon: <IconSeer />}}
+            keywords={[
+              t('seer'),
+              t('ai'),
+              t('chat'),
+              t('agent'),
+              t('explorer'),
+              t('nightshift'),
+              t('autofix'),
+            ]}
             limit={10}
             resource={(): CMDKQueryOptions => {
               const url = getApiUrl(

--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -29,6 +29,7 @@ import {
   IconLock,
   IconOpen,
   IconSearch,
+  IconSeer,
   IconSettings,
   IconSiren,
   IconStar,
@@ -36,6 +37,7 @@ import {
 } from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import {QUERY_API_CLIENT, useMutation} from 'sentry/utils/queryClient';
 import {useMutateUserOptions} from 'sentry/utils/useMutateUserOptions';
@@ -50,6 +52,7 @@ import {MCP_LANDING_SUB_PATH} from 'sentry/views/insights/pages/mcp/settings';
 import {MOBILE_LANDING_SUB_PATH} from 'sentry/views/insights/pages/mobile/settings';
 import {ISSUE_TAXONOMY_CONFIG} from 'sentry/views/issueList/taxonomies';
 import {useStarredIssueViews} from 'sentry/views/navigation/secondary/sections/issues/issueViews/useStarredIssueViews';
+import {openSeerExplorer} from 'sentry/views/seerExplorer/openSeerExplorer';
 import {getUserOrgNavigationConfiguration} from 'sentry/views/settings/organization/userOrgNavigationConfiguration';
 
 import {CMDKAction} from './cmdk';
@@ -310,6 +313,30 @@ export function GlobalCommandPaletteActions() {
               onAction={() => exitSuperuser()}
             />
           )}
+          <CMDKAction
+            display={{label: t('Resume recent chat'), icon: <IconSeer />}}
+            keywords={[t('seer'), t('ai'), t('chat'), t('agent'), t('explorer')]}
+            limit={10}
+            resource={(): CMDKQueryOptions => {
+              const url = getApiUrl(
+                '/organizations/$organizationIdOrSlug/seer/explorer-runs/',
+                {path: {organizationIdOrSlug: organization.slug}}
+              );
+              const query = {per_page: 10, category_key: 'night_shift'};
+              return cmdkQueryOptions({
+                queryKey: [url, {query}],
+                queryFn: () => QUERY_API_CLIENT.requestPromise(url, {query}),
+                select: (data: {data: Array<{run_id: number; title: string}>}) =>
+                  data.data.map(session => ({
+                    display: {label: session.title, icon: <IconSeer />},
+                    onAction: () => openSeerExplorer({runId: session.run_id}),
+                  })),
+                staleTime: 30_000,
+              });
+            }}
+          >
+            {data => data.map((item, i) => renderAsyncResult(item, i))}
+          </CMDKAction>
         </CMDKAction>
       )}
 

--- a/tests/sentry/seer/endpoints/test_organization_seer_explorer_runs.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_explorer_runs.py
@@ -63,6 +63,7 @@ class TestOrganizationSeerExplorerRunsEndpoint(APITestCase):
             category_value=None,
             offset=0,
             limit=101,  # Default per_page of 100 + 1 for has_more
+            only_current_user=True,
         )
 
     def test_get_cursor_pagination(self) -> None:
@@ -97,7 +98,7 @@ class TestOrganizationSeerExplorerRunsEndpoint(APITestCase):
         assert 'rel="next"; results="true"' in response.headers["Link"]
 
         self.mock_client.get_runs.assert_called_once_with(
-            category_key=None, category_value=None, offset=0, limit=3
+            category_key=None, category_value=None, offset=0, limit=3, only_current_user=True
         )
 
         # Second page - mock seer response for offset 2, limit 3.


### PR DESCRIPTION
Adds a "Night Shift Chats" item under the Admin section of the command
palette (Cmd+K) that lists recent night shift Seer Explorer sessions.
Selecting a session opens it in the Seer Explorer panel via
`openSeerExplorer({runId})`.

Night shift explorer runs are created with `user=None` by the agentic
triage task, so they were previously invisible to the explorer-runs
endpoint which filters by the requesting user. The endpoint now accepts
an explicit `owner` query param (default `true`). Passing `owner=false`
disables the user filter, making system-created runs (night shift, etc.)
visible.

**Backend**: `organization_seer_explorer_runs.py` — added `owner` query
param to control user scoping, updated docstring.

**Frontend**: `commandPaletteGlobalActions.tsx` — new `CMDKAction` under
Admin that fetches night shift runs with `category_key=night_shift&owner=false`.