### PR TITLE
ref(tsc): profile events endpoint to apiOptions

### DIFF
--- a/static/app/utils/profiling/hooks/useProfileEvents.tsx
+++ b/static/app/utils/profiling/hooks/useProfileEvents.tsx
@@ -1,8 +1,9 @@
+import {useQuery} from '@tanstack/react-query';
+
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import type {PageFilters} from 'sentry/types/core';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import {useApiQuery} from 'sentry/utils/queryClient';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 import type {EventsResults, Sort} from './types';
@@ -20,53 +21,57 @@ interface UseProfileEventsOptions<F extends string = ProfilingFieldType> {
   refetchOnMount?: boolean;
 }
 
-export function useProfileEvents<F extends string>({
+export function useProfileEventsApiOptions<F extends string>({
   fields,
   limit,
   referrer,
   query,
   sort,
-  cursor,
-  enabled = true,
-  refetchOnMount = true,
   datetime,
   projects,
-}: UseProfileEventsOptions<F>) {
+  cursor,
+}: Pick<
+  UseProfileEventsOptions<F>,
+  'fields' | 'limit' | 'referrer' | 'query' | 'sort' | 'datetime' | 'projects' | 'cursor'
+>) {
   const organization = useOrganization();
   const {selection} = usePageFilters();
 
-  query = `is_transaction:true (has:profile.id OR (has:profiler.id has:thread.id)) ${query ? `(${query})` : ''}`;
+  const fullQuery = `is_transaction:true (has:profile.id OR (has:profiler.id has:thread.id)) ${query ? `(${query})` : ''}`;
 
-  const endpointOptions = {
-    query: {
-      dataset: 'spans',
-      referrer,
-      project: projects || selection.projects,
-      environment: selection.environments,
-      ...normalizeDateTimeParams(datetime ?? selection.datetime),
-      field: fields,
-      per_page: limit,
-      query,
-      sort: sort.order === 'asc' ? sort.key : `-${sort.key}`,
-      cursor,
-    },
-  };
-
-  return useApiQuery<EventsResults<F>>(
-    [
-      getApiUrl('/organizations/$organizationIdOrSlug/events/', {
-        path: {organizationIdOrSlug: organization.slug},
-      }),
-      endpointOptions,
-    ],
+  return apiOptions.as<EventsResults<F>>()(
+    '/organizations/$organizationIdOrSlug/events/',
     {
+      path: {organizationIdOrSlug: organization.slug},
+      query: {
+        dataset: 'spans',
+        referrer,
+        project: projects || selection.projects,
+        environment: selection.environments,
+        ...normalizeDateTimeParams(datetime ?? selection.datetime),
+        field: fields,
+        per_page: limit,
+        query: fullQuery,
+        sort: sort.order === 'asc' ? sort.key : `-${sort.key}`,
+        cursor,
+      },
       staleTime: 0,
-      refetchOnWindowFocus: false,
-      refetchOnMount,
-      retry: false,
-      enabled,
     }
   );
+}
+
+export function useProfileEvents<F extends string>({
+  enabled = true,
+  refetchOnMount = true,
+  ...rest
+}: UseProfileEventsOptions<F>) {
+  return useQuery({
+    ...useProfileEventsApiOptions(rest),
+    refetchOnWindowFocus: false,
+    refetchOnMount,
+    retry: false,
+    enabled,
+  });
 }
 
 type ProfilingFieldType =

--- a/static/app/utils/profiling/hooks/useProfileFunctions.tsx
+++ b/static/app/utils/profiling/hooks/useProfileFunctions.tsx
@@ -1,8 +1,9 @@
+import {useQuery} from '@tanstack/react-query';
+
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import type {PageFilters} from 'sentry/types/core';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import {useApiQuery} from 'sentry/utils/queryClient';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 import type {EventsResults, Sort} from './types';
@@ -20,49 +21,55 @@ interface UseProfileFunctionsOptions<F extends string> {
   refetchOnMount?: boolean;
 }
 
-export function useProfileFunctions<F extends string>({
+export function useProfileFunctionsOptions<F extends string>({
   fields,
   referrer,
   sort,
   cursor,
   datetime,
-  enabled,
   limit,
   projects,
   query,
-  refetchOnMount,
-}: UseProfileFunctionsOptions<F>) {
+}: Pick<
+  UseProfileFunctionsOptions<F>,
+  'fields' | 'referrer' | 'sort' | 'cursor' | 'datetime' | 'limit' | 'projects' | 'query'
+>) {
   const organization = useOrganization();
   const {selection} = usePageFilters();
 
-  const endpointOptions = {
-    query: {
-      dataset: 'profileFunctions',
-      referrer,
-      project: projects || selection.projects,
-      environment: selection.environments,
-      ...normalizeDateTimeParams(datetime ?? selection.datetime),
-      field: fields,
-      per_page: limit,
-      query,
-      sort: sort.order === 'asc' ? sort.key : `-${sort.key}`,
-      cursor,
-    },
-  };
-
-  return useApiQuery<EventsResults<F>>(
-    [
-      getApiUrl('/organizations/$organizationIdOrSlug/events/', {
-        path: {organizationIdOrSlug: organization.slug},
-      }),
-      endpointOptions,
-    ],
+  return apiOptions.as<EventsResults<F>>()(
+    '/organizations/$organizationIdOrSlug/events/',
     {
+      path: {organizationIdOrSlug: organization.slug},
+      query: {
+        dataset: 'profileFunctions',
+        referrer,
+        project: projects || selection.projects,
+        environment: selection.environments,
+        ...normalizeDateTimeParams(datetime ?? selection.datetime),
+        field: fields,
+        per_page: limit,
+        query,
+        sort: sort.order === 'asc' ? sort.key : `-${sort.key}`,
+        cursor,
+      },
       staleTime: 0,
-      refetchOnWindowFocus: false,
-      refetchOnMount,
-      retry: false,
-      enabled,
     }
   );
+}
+
+export function useProfileFunctions<F extends string>({
+  enabled,
+  refetchOnMount,
+  ...rest
+}: UseProfileFunctionsOptions<F>) {
+  const options = useProfileFunctionsOptions(rest);
+
+  return useQuery({
+    ...options,
+    refetchOnWindowFocus: false,
+    refetchOnMount,
+    retry: false,
+    enabled,
+  });
 }

--- a/static/app/views/explore/logs/useLogsAggregatesTable.tsx
+++ b/static/app/views/explore/logs/useLogsAggregatesTable.tsx
@@ -1,11 +1,11 @@
 import {useCallback} from 'react';
+import {useQuery} from '@tanstack/react-query';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {useCaseInsensitivity} from 'sentry/components/searchQueryBuilder/hooks';
 import {defined} from 'sentry/utils';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {apiOptions, selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {useApiQuery, type ApiQueryKey} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {
@@ -41,14 +41,17 @@ export function useLogsAggregatesTable({
 }: UseLogsAggregatesTableOptions) {
   const canTriggerHighAccuracy = useCallback(
     (results: ReturnType<typeof useLogsAggregatesTableImpl>['result']) => {
-      const canGoToHigherAccuracyTier = results.data?.meta?.dataScanned === 'partial';
-      const hasData = defined(results.data?.data) && results.data.data.length > 0;
+      const json = results.data?.json;
+      const canGoToHigherAccuracyTier = json?.meta?.dataScanned === 'partial';
+      const hasData = defined(json?.data) && json.data.length > 0;
       return !hasData && canGoToHigherAccuracyTier;
     },
     []
   );
 
-  const aggregateTableResult = useProgressiveQuery<typeof useLogsAggregatesTableImpl>({
+  const {result, pageLinks, eventView} = useProgressiveQuery<
+    typeof useLogsAggregatesTableImpl
+  >({
     queryHookImplementation: useLogsAggregatesTableImpl,
     queryHookArgs: {
       enabled,
@@ -61,9 +64,13 @@ export function useLogsAggregatesTable({
   });
 
   return {
-    ...aggregateTableResult.result,
-    pageLinks: aggregateTableResult.pageLinks,
-    eventView: aggregateTableResult.eventView,
+    data: result.data?.json,
+    isLoading: result.isLoading,
+    isPending: result.isPending,
+    isError: result.isError,
+    error: result.error,
+    pageLinks,
+    eventView,
   };
 }
 
@@ -74,27 +81,28 @@ function useLogsAggregatesTableImpl({
   queryExtras,
 }: UseLogsAggregatesTableOptions) {
   referrer = referrer ?? 'api.explore.logs-table-aggregates';
-  const {queryKey, other} = useLogsAggregatesQueryKey({
+  const {queryOptions, eventView} = useLogsAggregatesApiOptions({
     limit,
     queryExtras,
     referrer,
   });
 
-  const queryResult = useApiQuery<LogsAggregatesResult>(queryKey, {
+  const result = useQuery({
+    ...queryOptions,
+    select: selectJsonWithHeaders,
     enabled,
-    staleTime: getStaleTimeForEventView(other.eventView),
     refetchOnWindowFocus: false,
     retry: false,
   });
 
   return {
-    result: queryResult,
-    pageLinks: queryResult?.getResponseHeader?.('Link') ?? undefined,
-    eventView: other.eventView,
+    result,
+    pageLinks: result.data?.headers.Link,
+    eventView,
   };
 }
 
-function useLogsAggregatesQueryKey({
+function useLogsAggregatesApiOptions({
   limit,
   referrer,
   queryExtras,
@@ -106,7 +114,7 @@ function useLogsAggregatesQueryKey({
   const organization = useOrganization();
   const _search = useQueryParamsSearch();
   const baseSearch = useLogsFrozenSearch();
-  const {selection, isReady: pageFiltersReady} = usePageFilters();
+  const {selection} = usePageFilters();
   const location = useLocation();
   const projectIds = useLogsFrozenProjectIds();
   const groupBys = useQueryParamsGroupBys();
@@ -133,31 +141,24 @@ function useLogsAggregatesQueryKey({
     dataset,
     projectIds ?? pageFilters.projects
   );
-  const params = {
-    query: {
-      ...eventView.getEventsAPIPayload(location),
-      per_page: limit ? limit : undefined,
-      cursor: aggregateCursor,
-      referrer,
-      caseInsensitive,
-      sampling: queryExtras?.samplingMode,
-    },
-    pageFiltersReady,
-    eventView,
-  };
-
-  const queryKey: ApiQueryKey = [
-    getApiUrl('/organizations/$organizationIdOrSlug/events/', {
+  const options = apiOptions.as<LogsAggregatesResult>()(
+    '/organizations/$organizationIdOrSlug/events/',
+    {
       path: {organizationIdOrSlug: organization.slug},
-    }),
-    params,
-  ];
+      query: {
+        ...eventView.getEventsAPIPayload(location),
+        per_page: limit ? limit : undefined,
+        cursor: aggregateCursor,
+        referrer,
+        caseInsensitive,
+        sampling: queryExtras?.samplingMode,
+      },
+      staleTime: getStaleTimeForEventView(eventView),
+    }
+  );
 
   return {
-    queryKey,
-    other: {
-      eventView,
-      pageFiltersReady,
-    },
+    queryOptions: options,
+    eventView,
   };
 }

--- a/static/app/views/profiling/content.tsx
+++ b/static/app/views/profiling/content.tsx
@@ -1,5 +1,6 @@
 import {Fragment, useCallback, useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
+import {useQuery} from '@tanstack/react-query';
 import type {Location} from 'history';
 
 import {Alert} from '@sentry/scraps/alert';
@@ -32,7 +33,8 @@ import {DataCategory} from 'sentry/types/core';
 import type {PageFilters} from 'sentry/types/core';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {useProfileEvents} from 'sentry/utils/profiling/hooks/useProfileEvents';
+import {selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
+import {useProfileEventsApiOptions} from 'sentry/utils/profiling/hooks/useProfileEvents';
 import {formatError, formatSort} from 'sentry/utils/profiling/hooks/utils';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useDatePageFilterProps} from 'sentry/utils/useDatePageFilterProps';
@@ -284,7 +286,7 @@ function TransactionsTab({onDataState, location, selection}: TabbedContentProps)
 
   const cursor = decodeScalar(location.query.cursor);
 
-  const transactions = useProfileEvents<FieldType>({
+  const transactionsOptions = useProfileEventsApiOptions<FieldType>({
     cursor,
     fields,
     query,
@@ -292,11 +294,17 @@ function TransactionsTab({onDataState, location, selection}: TabbedContentProps)
     limit: 50,
     referrer: 'api.profiling.landing-table',
   });
+  const transactions = useQuery({
+    ...transactionsOptions,
+    select: selectJsonWithHeaders,
+    refetchOnWindowFocus: false,
+    retry: false,
+  });
 
   const transactionsError =
     transactions.status === 'error' ? formatError(transactions.error) : '';
 
-  const hasData = (transactions.data?.data?.length || 0) > 0;
+  const hasData = (transactions.data?.json?.data?.length || 0) > 0;
   const isLoading = transactions.isPending;
   const isError = transactions.isError;
 
@@ -332,7 +340,7 @@ function TransactionsTab({onDataState, location, selection}: TabbedContentProps)
       )}
       <ProfileEventsTable
         columns={fields.slice()}
-        data={transactions.status === 'success' ? transactions.data : null}
+        data={transactions.status === 'success' ? transactions.data.json : null}
         error={transactions.status === 'error' ? t('Unable to load profiles') : null}
         isLoading={transactions.status === 'pending'}
         sort={sort}
@@ -340,9 +348,7 @@ function TransactionsTab({onDataState, location, selection}: TabbedContentProps)
       />
       <StyledPagination
         pageLinks={
-          transactions.status === 'success'
-            ? (transactions.getResponseHeader?.('Link') ?? null)
-            : null
+          transactions.status === 'success' ? transactions.data.headers.Link : null
         }
       />
     </Fragment>

--- a/static/app/views/profiling/landing/slowestFunctionsWidget.tsx
+++ b/static/app/views/profiling/landing/slowestFunctionsWidget.tsx
@@ -2,6 +2,7 @@ import type {ReactNode} from 'react';
 import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
+import {useQuery} from '@tanstack/react-query';
 import omit from 'lodash/omit';
 
 import {Button} from '@sentry/scraps/button';
@@ -33,11 +34,15 @@ import type {Series} from 'sentry/types/echarts';
 import type {EventsStatsSeries} from 'sentry/types/organization';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
 import {axisLabelFormatter, tooltipFormatter} from 'sentry/utils/discover/charts';
 import {getShortEventId} from 'sentry/utils/events';
 import {Frame} from 'sentry/utils/profiling/frame';
 import type {EventsResultsDataRow} from 'sentry/utils/profiling/hooks/types';
-import {useProfileFunctions} from 'sentry/utils/profiling/hooks/useProfileFunctions';
+import {
+  useProfileFunctions,
+  useProfileFunctionsOptions,
+} from 'sentry/utils/profiling/hooks/useProfileFunctions';
 import {useProfileTopEventsStats} from 'sentry/utils/profiling/hooks/useProfileTopEventsStats';
 import {generateProfileRouteFromProfileReference} from 'sentry/utils/profiling/routes';
 import type {UseApiQueryResult} from 'sentry/utils/queryClient';
@@ -134,7 +139,7 @@ export function SlowestFunctionsWidget<F extends BreakdownFunction>({
     [organization, analyticsSource]
   );
 
-  const functionsQuery = useProfileFunctions<FunctionsField>({
+  const functionsQueryOptions = useProfileFunctionsOptions<FunctionsField>({
     fields: functionsFields.includes(sortFunction as any)
       ? functionsFields
       : [...functionsFields, sortFunction],
@@ -147,8 +152,14 @@ export function SlowestFunctionsWidget<F extends BreakdownFunction>({
     limit: MAX_FUNCTIONS,
     cursor: slowFnCursor,
   });
+  const functionsQuery = useQuery({
+    ...functionsQueryOptions,
+    select: selectJsonWithHeaders,
+    refetchOnWindowFocus: false,
+    retry: false,
+  });
 
-  const functionsData = functionsQuery.data?.data || [];
+  const functionsData = functionsQuery.data?.json?.data || [];
 
   const hasFunctions = (functionsData.length || 0) > 0;
 
@@ -156,7 +167,9 @@ export function SlowestFunctionsWidget<F extends BreakdownFunction>({
   const projects = functionsQuery.isFetched
     ? [
         ...new Set(
-          (functionsQuery.data?.data ?? []).map(func => func['project.id'] as number)
+          (functionsQuery.data?.json?.data ?? []).map(
+            func => func['project.id'] as number
+          )
         ),
       ]
     : [];
@@ -240,7 +253,7 @@ export function SlowestFunctionsWidget<F extends BreakdownFunction>({
           </Flex>
         </Subtitle>
         <StyledPagination
-          pageLinks={functionsQuery.getResponseHeader?.('Link') ?? null}
+          pageLinks={functionsQuery.data?.headers.Link ?? null}
           size="xs"
           onCursor={handleCursor}
           paginationAnalyticsEvent={paginationAnalyticsEvent}


### PR DESCRIPTION
only focussing on the ones that need to extract response headers - we already have a mixture of both formats for this endpoint.