### PR TITLE
feat(integrations): Include endpoint and URL for slo.halted

### DIFF
--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -12,6 +12,7 @@ from taskbroker_client.retry import Retry
 from sentry import features
 from sentry.constants import ObjectStatus
 from sentry.exceptions import InvalidIdentity, PluginError
+from sentry.integrations.github.client import GitHubApiEndpoint
 from sentry.integrations.source_code_management.metrics import (
     SCMIntegrationInteractionEvent,
     SCMIntegrationInteractionType,
@@ -242,6 +243,14 @@ def fetch_commits(
                 pass
 
         end_sha = ref["commit"]
+        provider_name = repo.provider
+        endpoint = (
+            GitHubApiEndpoint.GET_COMMITS
+            if isinstance(provider_name, str)
+            and provider_name in GITHUB_CACHEABLE_REPOSITORY_PROVIDERS
+            and start_sha is None
+            else GitHubApiEndpoint.COMPARE_COMMITS
+        )
 
         with SCMIntegrationInteractionEvent(
             SCMIntegrationInteractionType.COMPARE_COMMITS,
@@ -254,13 +263,14 @@ def fetch_commits(
                     "organization_id": repo.organization_id,
                     "user_id": user_id,
                     "repository": repo.name,
+                    "url": repo.url,
                     "provider": provider.id,
                     "end_sha": end_sha,
                     "start_sha": start_sha,
+                    "endpoint": endpoint,
                 }
             )
             try:
-                provider_name = repo.provider
                 compare_commits_cache_enabled = (
                     github_compare_commits_cache_feature_enabled
                     and isinstance(provider_name, str)

--- a/tests/sentry/tasks/test_commits.py
+++ b/tests/sentry/tasks/test_commits.py
@@ -515,3 +515,79 @@ class HandleInvalidIdentityTest(TestCase):
         msg = mail.outbox[-1]
         assert msg.subject == "Unable to Fetch Commits"
         assert msg.to == [self.user.email]
+
+
+class FetchCommitsLifecycleExtrasTest(TestCase):
+    @patch("sentry.integrations.utils.metrics.logger.info")
+    @patch("sentry.plugins.providers.dummy.repository.DummyRepositoryProvider.compare_commits")
+    def test_halted_log_includes_repository_url(
+        self, mock_compare_commits: MagicMock, mock_logger_info: MagicMock
+    ) -> None:
+        self.login_as(user=self.user)
+        org = self.create_organization(owner=self.user, name="baz")
+        repo = Repository.objects.create(
+            name="example",
+            url="https://github.com/example/example",
+            provider="dummy",
+            organization_id=org.id,
+        )
+        release = Release.objects.create(organization_id=org.id, version="abcabcabc")
+        commit = Commit.objects.create(organization_id=org.id, repository_id=repo.id, key="a" * 40)
+        ReleaseHeadCommit.objects.create(
+            organization_id=org.id, repository_id=repo.id, release=release, commit=commit
+        )
+        release2 = Release.objects.create(organization_id=org.id, version="12345678")
+        refs = [{"repository": repo.name, "commit": "b" * 40}]
+
+        mock_compare_commits.side_effect = PluginError("You can read me")
+
+        with self.tasks():
+            fetch_commits(
+                release_id=release2.id,
+                user_id=self.user.id,
+                refs=refs,
+                prev_release_id=release.id,
+            )
+
+        assert any(
+            call.args
+            and call.args[0] == "integrations.slo.halted"
+            and call.kwargs.get("extra", {}).get("url") == repo.url
+            and call.kwargs.get("extra", {}).get("endpoint") == "compare_commits"
+            for call in mock_logger_info.call_args_list
+        )
+
+    @patch("sentry.integrations.utils.metrics.logger.info")
+    @patch("sentry.integrations.github.repository.GitHubRepositoryProvider.compare_commits")
+    def test_halted_log_includes_fallback_endpoint_when_start_sha_missing(
+        self, mock_compare_commits: MagicMock, mock_logger_info: MagicMock
+    ) -> None:
+        self.login_as(user=self.user)
+        org = self.create_organization(owner=self.user, name="baz")
+        repo = Repository.objects.create(
+            name="example",
+            url="https://github.com/example/example",
+            provider="integrations:github",
+            organization_id=org.id,
+        )
+        previous_release = Release.objects.create(organization_id=org.id, version="old-release")
+        release = Release.objects.create(organization_id=org.id, version="new-release")
+        refs = [{"repository": repo.name, "commit": "b" * 40}]
+
+        mock_compare_commits.side_effect = PluginError("You can read me")
+
+        with self.tasks():
+            fetch_commits(
+                release_id=release.id,
+                user_id=self.user.id,
+                refs=refs,
+                prev_release_id=previous_release.id,
+            )
+
+        assert any(
+            call.args
+            and call.args[0] == "integrations.slo.halted"
+            and call.kwargs.get("extra", {}).get("url") == repo.url
+            and call.kwargs.get("extra", {}).get("endpoint") == "get_commits"
+            for call in mock_logger_info.call_args_list
+        )


### PR DESCRIPTION
This will help distinguish what API usage by endpoint. The URL is also useful when looking at logs.