### PR TITLE
Add logger warnings for display name filter action

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -171,13 +171,28 @@ class BaseOrganizationSerializer(serializers.Serializer):
         max_length=DEFAULT_SLUG_MAX_LENGTH,
     )
 
+    def _log_name_blocked(self, name: str, reason: str) -> None:
+        extra: dict[str, object] = {"attempted_name": name, "reason": reason}
+        request = self.context.get("request")
+        if request is not None:
+            extra["user_id"] = getattr(request.user, "id", None)
+            extra["user_ip"] = request.META.get("REMOTE_ADDR")
+            extra["user_agent"] = request.META.get("HTTP_USER_AGENT")
+        org = self.context.get("organization")
+        if org is not None:
+            extra["org_id"] = org.id
+            extra["org_slug"] = org.slug
+        logging.getLogger("sentry.security").warning("spam.display-name-blocked", extra=extra)
+
     def validate_name(self, value: str) -> str:
         if "://" in value:
+            self._log_name_blocked(value, "url_scheme")
             raise serializers.ValidationError(
                 "Organization name cannot contain URL schemes (e.g. http:// or https://)."
             )
 
         if is_spam_display_name(value):
+            self._log_name_blocked(value, "spam_filter")
             raise serializers.ValidationError(
                 "This name contains disallowed content. Please choose a different name."
             )

--- a/src/sentry/core/endpoints/organization_index.py
+++ b/src/sentry/core/endpoints/organization_index.py
@@ -383,7 +383,7 @@ class OrganizationIndexEndpoint(Endpoint):
                 status=429,
             )
 
-        serializer = OrganizationPostSerializer(data=request.data)
+        serializer = OrganizationPostSerializer(data=request.data, context={"request": request})
 
         if not serializer.is_valid():
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_details.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_details.py
@@ -142,6 +142,7 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
             partial=True,
             access=request.access,
             active_staff=is_active_staff(request),
+            context={"request": request},
         )
 
         if serializer.is_valid():

--- a/src/sentry/sentry_apps/api/endpoints/sentry_apps.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_apps.py
@@ -108,7 +108,7 @@ class SentryAppsEndpoint(SentryAppsBaseEndpoint):
                 status=403,
             )
 
-        serializer = SentryAppParser(data=data, access=request.access)
+        serializer = SentryAppParser(data=data, access=request.access, context={"request": request})
 
         if serializer.is_valid():
             if data.get("isInternal"):

--- a/src/sentry/sentry_apps/api/parsers/sentry_app.py
+++ b/src/sentry/sentry_apps/api/parsers/sentry_app.py
@@ -169,7 +169,12 @@ class SentryAppParser(Serializer):
             raise ValidationError("Cannot exceed %d characters" % max_length)
 
         if is_spam_display_name(value):
-            extra: dict[str, object] = {"attempted_name": value}
+            extra: dict[str, object] = {"attempted_name": value, "reason": "spam_filter"}
+            request = self.context.get("request")
+            if request is not None:
+                extra["user_id"] = getattr(request.user, "id", None)
+                extra["user_ip"] = request.META.get("REMOTE_ADDR")
+                extra["user_agent"] = request.META.get("HTTP_USER_AGENT")
             if self.instance:
                 extra["sentry_app_id"] = self.instance.id
                 extra["sentry_app_slug"] = self.instance.slug

--- a/src/sentry/sentry_apps/api/parsers/sentry_app.py
+++ b/src/sentry/sentry_apps/api/parsers/sentry_app.py
@@ -1,3 +1,5 @@
+import logging
+
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field, extend_schema_serializer
 from jsonschema.exceptions import ValidationError as SchemaValidationError
@@ -167,6 +169,11 @@ class SentryAppParser(Serializer):
             raise ValidationError("Cannot exceed %d characters" % max_length)
 
         if is_spam_display_name(value):
+            extra: dict[str, object] = {"attempted_name": value}
+            if self.instance:
+                extra["sentry_app_id"] = self.instance.id
+                extra["sentry_app_slug"] = self.instance.slug
+            logging.getLogger("sentry.security").warning("spam.display-name-blocked", extra=extra)
             raise ValidationError(
                 "This name contains disallowed content. Please choose a different name."
             )


### PR DESCRIPTION
After https://github.com/getsentry/sentry/pull/113106, adding some logger warning for when the filter comes into action. `sentry.security` and `spam.display-name-blocked`.

Also now passing request context in organization_index and passes some from sentry_app and sentry_app_details so we can capture so additional metadata during failed attempts. 