### PR TITLE
fix(monitors): Update tour carousel copy to clarify issue creation

### DIFF
--- a/static/app/components/workflowEngine/ui/alertsMonitorsShowcase.tsx
+++ b/static/app/components/workflowEngine/ui/alertsMonitorsShowcase.tsx
@@ -132,20 +132,20 @@ function AlertsMonitorsShowcase(props: ModalRenderProps) {
       <FeatureShowcase.Step>
         <FeatureShowcase.Image
           src={monitorsTourAlertsImage}
-          alt={t('Alerts notify your team')}
+          alt={t('Alerts notify your team of issues')}
         />
         <FeatureShowcase.StepTitle>
-          {t('Alerts notify your team')}
+          {t('Alerts notify your team of issues')}
         </FeatureShowcase.StepTitle>
         <FeatureShowcase.StepContent>
           <Text>
             {t(
-              'Alerts notify your team. Define who gets paged, when, and how — via Slack, email, PagerDuty, and more.'
+              'Issues created by Monitors trigger Alerts. Alerts define who gets paged, when, and how — via Slack, email, PagerDuty, and more.'
             )}
           </Text>
           <Text>
             {t(
-              'Scale and connect to many monitors, projects, and issue types. Configure your routing so the right people get notified when it matters.'
+              'One alert can connect to many monitors, projects, and issue types. Configure your routing once and the right people get notified everywhere it matters.'
             )}
           </Text>
         </FeatureShowcase.StepContent>
@@ -162,12 +162,12 @@ function AlertsMonitorsShowcase(props: ModalRenderProps) {
         <FeatureShowcase.StepContent>
           <Text>
             {t(
-              'When creating a Monitor you have the option of setting up a new Alert or connecting to an existing Alert at the same time.'
+              "When creating a Monitor you have the option of creating a new Alert or connecting an existing Alert. This ensures your team is notified about issues created by the monitor, when and how you'd like."
             )}
           </Text>
           <Text>
             {t(
-              'When creating or editing Alerts you can connect to existing routing without ever touching your Monitor logic.'
+              'To change notification routing, edit Alerts without needing to touch Monitor logic.'
             )}
           </Text>
           <Text>


### PR DESCRIPTION
Rewrites steps 3 and 4 of the monitors onboarding carousel to more clearly explain that Monitors create Issues, and that Alerts notify teams about those Issues. Previous copy was vague about the role of issue creation in the monitor-to-alert flow.

- Step 3 title: 'Alerts notify your team' → 'Alerts notify your team of issues'
- Step 3 body: clarifies that issues created by Monitors trigger Alerts
- Step 4 body: reframes connecting Alerts around issue notification routing

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
