### PR TITLE
ref(nightshift): Log agent_run_id in night shift logs

### DIFF
--- a/src/sentry/tasks/seer/night_shift/agentic_triage.py
+++ b/src/sentry/tasks/seer/night_shift/agentic_triage.py
@@ -35,15 +35,17 @@ class _TriageResponse(pydantic.BaseModel):
 def agentic_triage_strategy(
     projects: Sequence[Project],
     organization: Organization,
-) -> list[TriageResult]:
+) -> tuple[list[TriageResult], int | None]:
     """
     Select candidates via fixability scoring, then use the Seer Explorer agent
     to investigate each candidate and decide the appropriate action.
+
+    Returns a tuple of (triage_results, agent_run_id).
     """
     # TODO: try a new way to get scored issues
     scored = fixability_score_strategy(projects)
     if not scored:
-        return []
+        return [], None
 
     return _triage_candidates(scored, organization)
 
@@ -51,11 +53,13 @@ def agentic_triage_strategy(
 def _triage_candidates(
     candidates: list[ScoredCandidate],
     organization: Organization,
-) -> list[TriageResult]:
+) -> tuple[list[TriageResult], int | None]:
     """
     Start a Seer Explorer run to investigate candidate issues and return
     triage verdicts. The agent can browse the repo, inspect stacktraces,
     and use its tools to make informed decisions.
+
+    Returns a tuple of (triage_results, agent_run_id).
     """
     groups_by_id = {c.group.id: c.group for c in candidates}
 
@@ -69,7 +73,7 @@ def _triage_candidates(
             reasoning_effort="high",
         )
 
-        run_id = client.start_run(
+        agent_run_id = client.start_run(
             prompt=_build_triage_prompt(candidates),
             artifact_key="triage_verdicts",
             artifact_schema=_TriageResponse,
@@ -79,12 +83,12 @@ def _triage_candidates(
             "night_shift.explorer_run_started",
             extra={
                 "organization_id": organization.id,
-                "run_id": run_id,
+                "agent_run_id": agent_run_id,
                 "num_candidates": len(candidates),
             },
         )
 
-        state = _poll_with_logging(client, run_id, organization.id)
+        state = _poll_with_logging(client, agent_run_id, organization.id)
 
         triage_response = state.get_artifact("triage_verdicts", _TriageResponse)
         if not triage_response:
@@ -92,7 +96,7 @@ def _triage_candidates(
                 "night_shift.triage_no_artifact",
                 extra={
                     "organization_id": organization.id,
-                    "run_id": run_id,
+                    "agent_run_id": agent_run_id,
                     "status": state.status,
                 },
             )
@@ -101,7 +105,7 @@ def _triage_candidates(
                 1,
                 attributes={"error_type": "no_artifact"},
             )
-            return []
+            return [], agent_run_id
     except Exception:
         sentry_sdk.metrics.count(
             "night_shift.triage_error",
@@ -112,13 +116,13 @@ def _triage_candidates(
             "night_shift.triage_explorer_error",
             extra={"organization_id": organization.id},
         )
-        return []
+        return [], None
 
     logger.info(
         "night_shift.triage_verdicts",
         extra={
             "organization_id": organization.id,
-            "run_id": run_id,
+            "agent_run_id": agent_run_id,
             "verdicts": {v.group_id: v.action for v in triage_response.verdicts},
         },
     )
@@ -127,7 +131,7 @@ def _triage_candidates(
         TriageResult(group=groups_by_id[v.group_id], action=v.action)
         for v in triage_response.verdicts
         if v.group_id in groups_by_id and v.action != TriageAction.SKIP
-    ]
+    ], agent_run_id
 
 
 POLL_INTERVAL = 2.0
@@ -135,7 +139,7 @@ POLL_INTERVAL = 2.0
 
 def _poll_with_logging(
     client: SeerExplorerClient,
-    run_id: int,
+    agent_run_id: int,
     organization_id: int,
 ) -> SeerRunState:
     """Poll an Explorer run, logging new non-loading blocks as they appear."""
@@ -143,7 +147,7 @@ def _poll_with_logging(
     seen_block_ids: set[str] = set()
 
     while True:
-        state = client.get_run(run_id)
+        state = client.get_run(agent_run_id)
 
         for block in state.blocks:
             if block.id in seen_block_ids or block.loading:
@@ -156,7 +160,7 @@ def _poll_with_logging(
                 "night_shift.explorer_block",
                 extra={
                     "organization_id": organization_id,
-                    "run_id": run_id,
+                    "agent_run_id": agent_run_id,
                     "block_id": block.id,
                     "role": msg.role,
                     "tool_calls": tool_names,
@@ -170,7 +174,7 @@ def _poll_with_logging(
                 "night_shift.explorer_run_completed",
                 extra={
                     "organization_id": organization_id,
-                    "run_id": run_id,
+                    "agent_run_id": agent_run_id,
                     "status": state.status,
                     "num_blocks": len(state.blocks),
                     "duration": round(time.monotonic() - start_time, 1),

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -132,8 +132,9 @@ def run_night_shift_for_org(organization_id: int, dry_run: bool = False) -> None
         triage_strategy=triage_strategy,
     )
 
+    agent_run_id = None
     try:
-        candidates = agentic_triage_strategy(eligible_projects, organization)
+        candidates, agent_run_id = agentic_triage_strategy(eligible_projects, organization)
 
         if candidates:
             SeerNightShiftRunIssue.objects.bulk_create(
@@ -153,6 +154,7 @@ def run_night_shift_for_org(organization_id: int, dry_run: bool = False) -> None
             extra={
                 "organization_id": organization_id,
                 "run_id": run.id,
+                "agent_run_id": agent_run_id,
             },
         )
         run.update(error_message="Night shift run failed")
@@ -169,6 +171,7 @@ def run_night_shift_for_org(organization_id: int, dry_run: bool = False) -> None
             "organization_id": organization_id,
             "organization_slug": organization.slug,
             "run_id": run.id,
+            "agent_run_id": agent_run_id,
             "num_eligible_projects": len(eligible_projects),
             "num_candidates": len(candidates),
             "dry_run": dry_run,

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -353,7 +353,7 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
             self.feature("organizations:seer-project-settings-read-from-sentry"),
             patch(
                 "sentry.tasks.seer.night_shift.cron.agentic_triage_strategy",
-                return_value=[],
+                return_value=([], None),
             ),
         ):
             run_night_shift_for_org(org.id)


### PR DESCRIPTION
Disambiguate the explorer/agent run ID from the nightshift run ID in
logs. Previously both were logged as `run_id` in different log messages
but referred to different things — `SeerNightShiftRun.id` in `cron.py`
vs the SeerExplorer run ID in `agentic_triage.py`.

Now the explorer run is consistently logged as `agent_run_id` across
both files, and the cron orchestrator logs both `run_id` (nightshift)
and `agent_run_id` (explorer) so they can be correlated.


Agent transcript: https://claudescope.sentry.dev/share/PEGyG663VI6j17aOrIFTIZ-tlQFiVlZ3VxjZ4PEZwD4