### PR TITLE
feat(pagerduty): Add frontend pipeline step for PagerDuty integration setup

### DIFF
--- a/static/app/components/pipeline/pipelineIntegrationPagerDuty.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationPagerDuty.spec.tsx
@@ -1,0 +1,110 @@
+import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {pagerDutyIntegrationPipeline} from './pipelineIntegrationPagerDuty';
+import type {PipelineStepProps} from './types';
+
+const PagerDutyInstallStep = pagerDutyIntegrationPipeline.steps[0].component;
+
+function makeStepProps<D, A>(
+  overrides: Partial<PipelineStepProps<D, A>> & {stepData: D}
+): PipelineStepProps<D, A> {
+  return {
+    advance: jest.fn(),
+    advanceError: null,
+    isAdvancing: false,
+    stepIndex: 0,
+    totalSteps: 1,
+    ...overrides,
+  };
+}
+
+let mockPopup: Window;
+
+function dispatchPipelineMessage({
+  data,
+  origin = document.location.origin,
+  source = mockPopup,
+}: {
+  data: Record<string, string>;
+  origin?: string;
+  source?: Window | MessageEventSource | null;
+}) {
+  act(() => {
+    const event = new MessageEvent('message', {data, origin});
+    Object.defineProperty(event, 'source', {value: source});
+    window.dispatchEvent(event);
+  });
+}
+
+beforeEach(() => {
+  mockPopup = {
+    closed: false,
+    close: jest.fn(),
+    focus: jest.fn(),
+  } as unknown as Window;
+  jest.spyOn(window, 'open').mockReturnValue(mockPopup);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('PagerDutyInstallStep', () => {
+  it('renders the install step for PagerDuty', () => {
+    render(
+      <PagerDutyInstallStep
+        {...makeStepProps({
+          stepData: {installUrl: 'https://app.pagerduty.com/install/integration'},
+        })}
+      />
+    );
+
+    expect(
+      screen.getByRole('button', {name: 'Install PagerDuty App'})
+    ).toBeInTheDocument();
+  });
+
+  it('calls advance with config on callback', async () => {
+    const advance = jest.fn();
+    render(
+      <PagerDutyInstallStep
+        {...makeStepProps({
+          stepData: {installUrl: 'https://app.pagerduty.com/install/integration'},
+          advance,
+        })}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Install PagerDuty App'}));
+
+    dispatchPipelineMessage({
+      data: {
+        _pipeline_source: 'sentry-pipeline',
+        config: '{"account":{"name":"Test","subdomain":"test"}}',
+      },
+    });
+
+    expect(advance).toHaveBeenCalledWith({
+      config: '{"account":{"name":"Test","subdomain":"test"}}',
+    });
+  });
+
+  it('shows loading state when isAdvancing is true', () => {
+    render(
+      <PagerDutyInstallStep
+        {...makeStepProps({
+          stepData: {installUrl: 'https://app.pagerduty.com/install/integration'},
+          isAdvancing: true,
+        })}
+      />
+    );
+
+    expect(screen.getByRole('button', {name: 'Installing...'})).toBeDisabled();
+  });
+
+  it('disables install button when installUrl is not provided', () => {
+    render(<PagerDutyInstallStep {...makeStepProps({stepData: {}})} />);
+
+    expect(screen.getByRole('button', {name: 'Install PagerDuty App'})).toBeDisabled();
+  });
+});

--- a/static/app/components/pipeline/pipelineIntegrationPagerDuty.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationPagerDuty.tsx
@@ -1,0 +1,88 @@
+import {useCallback} from 'react';
+
+import {Button} from '@sentry/scraps/button';
+import {Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {t} from 'sentry/locale';
+import type {IntegrationWithConfig} from 'sentry/types/integrations';
+
+import {useRedirectPopupStep} from './shared/useRedirectPopupStep';
+import type {PipelineDefinition, PipelineStepProps} from './types';
+import {pipelineComplete} from './types';
+
+function PagerDutyInstallStep({
+  stepData,
+  advance,
+  isAdvancing,
+}: PipelineStepProps<{installUrl?: string}, {config: string}>) {
+  const handleCallback = useCallback(
+    (data: Record<string, string>) => {
+      advance({config: data.config ?? ''});
+    },
+    [advance]
+  );
+
+  const {openPopup, popupStatus} = useRedirectPopupStep({
+    redirectUrl: stepData.installUrl,
+    onCallback: handleCallback,
+    popup: {height: 900},
+  });
+
+  return (
+    <Stack gap="lg" align="start">
+      <Stack gap="sm">
+        <Text>
+          {t(
+            'Install the Sentry app on your PagerDuty account to complete the integration setup.'
+          )}
+        </Text>
+        {popupStatus === 'popup-open' && (
+          <Text variant="muted" size="sm">
+            {t('A popup should have opened to install the PagerDuty app.')}
+          </Text>
+        )}
+        {popupStatus === 'failed-to-open' && (
+          <Text variant="danger" size="sm">
+            {t(
+              'The installation popup was blocked by your browser. Please ensure popups are allowed and try again.'
+            )}
+          </Text>
+        )}
+      </Stack>
+      {isAdvancing ? (
+        <Button size="sm" disabled>
+          {t('Installing...')}
+        </Button>
+      ) : popupStatus === 'popup-open' ? (
+        <Button size="sm" onClick={openPopup}>
+          {t('Reopen installation window')}
+        </Button>
+      ) : (
+        <Button
+          size="sm"
+          priority="primary"
+          onClick={openPopup}
+          disabled={!stepData.installUrl}
+        >
+          {t('Install PagerDuty App')}
+        </Button>
+      )}
+    </Stack>
+  );
+}
+
+export const pagerDutyIntegrationPipeline = {
+  type: 'integration',
+  provider: 'pagerduty',
+  actionTitle: t('Installing PagerDuty Integration'),
+  getCompletionData: pipelineComplete<IntegrationWithConfig>,
+  completionView: null,
+  steps: [
+    {
+      stepId: 'installation_redirect',
+      shortDescription: t('Installing PagerDuty app'),
+      component: PagerDutyInstallStep,
+    },
+  ],
+} as const satisfies PipelineDefinition;

--- a/static/app/components/pipeline/registry.tsx
+++ b/static/app/components/pipeline/registry.tsx
@@ -4,6 +4,7 @@ import {bitbucketIntegrationPipeline} from './pipelineIntegrationBitbucket';
 import {discordIntegrationPipeline} from './pipelineIntegrationDiscord';
 import {githubIntegrationPipeline} from './pipelineIntegrationGitHub';
 import {gitlabIntegrationPipeline} from './pipelineIntegrationGitLab';
+import {pagerDutyIntegrationPipeline} from './pipelineIntegrationPagerDuty';
 import {slackIntegrationPipeline} from './pipelineIntegrationSlack';
 import {vstsIntegrationPipeline} from './pipelineIntegrationVsts';
 
@@ -17,6 +18,7 @@ export const PIPELINE_REGISTRY = [
   dummyIntegrationPipeline,
   githubIntegrationPipeline,
   gitlabIntegrationPipeline,
+  pagerDutyIntegrationPipeline,
   slackIntegrationPipeline,
   vstsIntegrationPipeline,
 ] as const;


### PR DESCRIPTION
Register the PagerDuty integration in the pipeline registry with a
single installation redirect step. Uses useRedirectPopupStep directly
since PagerDuty uses an app install flow rather than standard OAuth.
The callback forwards the config JSON param from PagerDuty.

Refs [VDY-84: PagerDuty: API-driven integration setup](https://linear.app/getsentry/issue/VDY-84/pagerduty-api-driven-integration-setup)