### PR TITLE
feat(opsgenie): Add API-driven pipeline backend for Opsgenie integration setup

### DIFF
--- a/src/sentry/integrations/opsgenie/integration.py
+++ b/src/sentry/integrations/opsgenie/integration.py
@@ -8,8 +8,10 @@ from django import forms
 from django.http.request import HttpRequest
 from django.http.response import HttpResponseBase
 from django.utils.translation import gettext_lazy as _
+from rest_framework.fields import CharField, ChoiceField
 from rest_framework.serializers import ValidationError
 
+from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
 from sentry.constants import ObjectStatus
 from sentry.integrations.base import (
     FeatureDescription,
@@ -32,7 +34,8 @@ from sentry.integrations.utils.metrics import (
     IntegrationPipelineViewType,
 )
 from sentry.organizations.services.organization.model import RpcOrganization
-from sentry.pipeline.views.base import PipelineView
+from sentry.pipeline.types import PipelineStepResult
+from sentry.pipeline.views.base import ApiPipelineSteps, PipelineView
 from sentry.shared_integrations.exceptions import (
     ApiError,
     ApiRateLimitedError,
@@ -248,6 +251,40 @@ class OpsgenieIntegration(IntegrationInstallation):
         )
 
 
+BASE_URL_CHOICES = [
+    ("https://api.opsgenie.com/", "api.opsgenie.com"),
+    ("https://api.eu.opsgenie.com/", "api.eu.opsgenie.com"),
+    ("https://api.atlassian.com/jsm/ops/integration/", "api.atlassian.com (JSM)"),
+]
+
+
+class OpsgenieInstallationApiSerializer(CamelSnakeSerializer):
+    base_url = ChoiceField(choices=BASE_URL_CHOICES, required=True)
+    provider = CharField(required=True)
+    api_key = CharField(required=False, allow_blank=True, default="")
+
+
+class OpsgenieInstallationApiStep:
+    step_name = "installation_config"
+
+    def get_step_data(self, pipeline: IntegrationPipeline, request: HttpRequest) -> dict[str, Any]:
+        return {
+            "baseUrlChoices": [{"value": url, "label": label} for url, label in BASE_URL_CHOICES],
+        }
+
+    def get_serializer_cls(self) -> type:
+        return OpsgenieInstallationApiSerializer
+
+    def handle_post(
+        self,
+        validated_data: dict[str, str],
+        pipeline: IntegrationPipeline,
+        request: HttpRequest,
+    ) -> PipelineStepResult:
+        pipeline.bind_state("installation_data", validated_data)
+        return PipelineStepResult.advance()
+
+
 class OpsgenieIntegrationProvider(IntegrationProvider):
     key = IntegrationProviderSlug.OPSGENIE.value
     name = "Opsgenie"
@@ -262,6 +299,9 @@ class OpsgenieIntegrationProvider(IntegrationProvider):
 
     def get_pipeline_views(self) -> Sequence[PipelineView[IntegrationPipeline]]:
         return [InstallationConfigView()]
+
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps[IntegrationPipeline]:
+        return [OpsgenieInstallationApiStep()]
 
     def build_integration(self, state: Mapping[str, Any]) -> IntegrationData:
         api_key = state["installation_data"]["api_key"]

--- a/tests/sentry/integrations/opsgenie/test_integration.py
+++ b/tests/sentry/integrations/opsgenie/test_integration.py
@@ -1,8 +1,12 @@
+from __future__ import annotations
+
 from functools import cached_property
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 import responses
+from django.urls import reverse
 from rest_framework.serializers import ValidationError
 
 from sentry.integrations.models.integration import Integration
@@ -12,6 +16,7 @@ from sentry.integrations.opsgenie.tasks import (
     ALERT_LEGACY_INTEGRATIONS,
     ALERT_LEGACY_INTEGRATIONS_WITH_NAME,
 )
+from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.types import EventLifecycleOutcome
 from sentry.models.rule import Rule
 from sentry.shared_integrations.exceptions import ApiRateLimitedError, ApiUnauthorized
@@ -240,6 +245,114 @@ class OpsgenieIntegrationTest(IntegrationTestCase):
             b"At least one feature from this list has to be enabled in order to setup the integration"
             in resp.content
         )
+
+
+@control_silo_test
+class OpsgenieApiPipelineTest(APITestCase):
+    endpoint = "sentry-api-0-organization-pipeline"
+    method = "post"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(self.user)
+
+    def _get_pipeline_url(self) -> str:
+        return reverse(
+            self.endpoint,
+            args=[self.organization.slug, IntegrationPipeline.pipeline_name],
+        )
+
+    def _initialize_pipeline(self) -> Any:
+        return self.client.post(
+            self._get_pipeline_url(),
+            data={"action": "initialize", "provider": "opsgenie"},
+            format="json",
+        )
+
+    def _advance_step(self, data: dict[str, Any]) -> Any:
+        return self.client.post(self._get_pipeline_url(), data=data, format="json")
+
+    @with_feature(
+        {
+            "organizations:integrations-enterprise-alert-rule": True,
+            "organizations:integrations-enterprise-incident-management": True,
+        }
+    )
+    def test_initialize_pipeline(self) -> None:
+        resp = self._initialize_pipeline()
+        assert resp.status_code == 200
+        assert resp.data["step"] == "installation_config"
+        assert resp.data["stepIndex"] == 0
+        assert resp.data["totalSteps"] == 1
+        assert resp.data["provider"] == "opsgenie"
+        assert "baseUrlChoices" in resp.data["data"]
+
+    @with_feature(
+        {
+            "organizations:integrations-enterprise-alert-rule": True,
+            "organizations:integrations-enterprise-incident-management": True,
+        }
+    )
+    def test_invalid_base_url(self) -> None:
+        self._initialize_pipeline()
+        resp = self._advance_step(
+            {
+                "baseUrl": "https://evil.example.com/",
+                "provider": "test-app",
+            }
+        )
+        assert resp.status_code == 400
+
+    @with_feature(
+        {
+            "organizations:integrations-enterprise-alert-rule": True,
+            "organizations:integrations-enterprise-incident-management": True,
+        }
+    )
+    def test_full_pipeline_flow(self) -> None:
+        resp = self._initialize_pipeline()
+        assert resp.data["step"] == "installation_config"
+
+        resp = self._advance_step(
+            {
+                "baseUrl": "https://api.opsgenie.com/",
+                "provider": "cool-name",
+                "apiKey": "123-key",
+            }
+        )
+        assert resp.status_code == 200
+        assert resp.data["status"] == "complete"
+
+        integration = Integration.objects.get(provider="opsgenie")
+        assert integration.external_id == "cool-name"
+        assert integration.name == "cool-name"
+        assert integration.metadata["domain_name"] == "cool-name.app.opsgenie.com"
+
+        assert OrganizationIntegration.objects.filter(
+            organization_id=self.organization.id,
+            integration=integration,
+        ).exists()
+
+    @with_feature(
+        {
+            "organizations:integrations-enterprise-alert-rule": True,
+            "organizations:integrations-enterprise-incident-management": True,
+        }
+    )
+    def test_full_pipeline_flow_no_key(self) -> None:
+        self._initialize_pipeline()
+        resp = self._advance_step(
+            {
+                "baseUrl": "https://api.opsgenie.com/",
+                "provider": "cool-name",
+            }
+        )
+        assert resp.status_code == 200
+        assert resp.data["status"] == "complete"
+
+        integration = Integration.objects.get(provider="opsgenie")
+        assert integration.external_id == "cool-name"
+        assert integration.metadata["api_key"] == ""
 
 
 class OpsgenieMigrationIntegrationTest(APITestCase):


### PR DESCRIPTION
Implement get_pipeline_api_steps() on OpsgenieIntegrationProvider with
a single installation config step. The step collects base URL (validated
against allowed choices), account name, and an optional integration key.
Binds to installation_data so build_integration() works unchanged.

Refs [VDY-89: OpsGenie: API-Driven integration setup](https://linear.app/getsentry/issue/VDY-89/opsgenie-api-driven-integration-setup)