### PR TITLE
fix(chartcuterie): Stack grouped bar charts in unfurls

### DIFF
--- a/static/app/chartcuterie/timeseries.tsx
+++ b/static/app/chartcuterie/timeseries.tsx
@@ -146,6 +146,7 @@ export const makeTimeseriesCharts = (
         const plottable = createPlottableFromTimeSeries(displayType, ts, {
           name: formatTimeSeriesLabel(ts),
           color: color?.[i],
+          stack: 'all',
         });
         return plottable?.toSeries(plottingOptions) ?? [];
       });


### PR DESCRIPTION
Grouped bar charts rendered by chartcuterie for Slack Explore/Dashboards unfurls were not stacking, so each group rendered as its own side-by-side bar instead of accumulating into one column per x-tick. This didn't match how the equivalent charts render in Explore or Dashboards.

Pass a shared `stack` key to the plottable when rendering grouped series, matching Explore's `chartVisualization.tsx` which also passes `stack: 'all'`. ECharts stacks every series that shares the same `stack` string, so all series in a given chart accumulate into a single stack per x-tick.

Only the grouped branch needs the change — the single-series branch renders one series and has nothing to stack.

Refs DAIN-1536