### PR TITLE
fix(chartcuterie): Reduce legend font size and truncation length

### DIFF
--- a/static/app/chartcuterie/timeseries.tsx
+++ b/static/app/chartcuterie/timeseries.tsx
@@ -58,10 +58,10 @@ export const makeTimeseriesCharts = (
       itemGap: 16,
       top: 6,
       left: 10,
-      truncate: 40,
+      truncate: 20,
       textStyle: {
-        fontSize: FONT_SIZE,
-        lineHeight: FONT_SIZE * 1.4,
+        fontSize: FONT_SIZE * 0.8,
+        lineHeight: FONT_SIZE * 1.1,
         fontFamily: DEFAULT_FONT_FAMILY,
       },
       pageTextStyle: {


### PR DESCRIPTION
Reduce legend text size and truncation threshold in chartcuterie timeseries
charts (used for Slack unfurls) to prevent legend items from overlapping
when there are many groups or long group names.

- Font size: 28px -> 22.4px (`FONT_SIZE * 0.8`)
- Line height: 39.2px -> 30.8px (`FONT_SIZE * 1.1`)
- Truncation: 40 chars -> 20 chars

Follow-up to #112931.