### PR TITLE
feat(seer): Add thinking blocks toggle to explorer chat

### DIFF
--- a/static/app/views/seerExplorer/components/blockComponents.tsx
+++ b/static/app/views/seerExplorer/components/blockComponents.tsx
@@ -6,6 +6,7 @@ import type {LocationDescriptor} from 'history';
 
 import {Button} from '@sentry/scraps/button';
 import {inlineCodeStyles} from '@sentry/scraps/code';
+import {Disclosure} from '@sentry/scraps/disclosure';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -56,6 +57,7 @@ interface BlockProps {
   readOnly?: boolean;
   ref?: React.Ref<HTMLDivElement>;
   runId?: number;
+  showThinking?: boolean;
 }
 
 function hasValidContent(content: string): boolean {
@@ -151,6 +153,7 @@ export function BlockComponent({
   onNavigate,
   onRegisterEnterHandler,
   ref,
+  showThinking = false,
 }: BlockProps) {
   const {copy} = useCopyToClipboard();
   const organization = useOrganization();
@@ -160,9 +163,18 @@ export function BlockComponent({
   const toolsUsed = getToolsStringFromBlock(block);
   const hasTools = toolsUsed.length > 0;
   const hasContent = hasValidContent(block.message.content);
+  const hasThinkingContentToShow =
+    showThinking && hasValidContent(block.message.thinking_content ?? '');
   const processedContent = useMemo(
     () => postProcessLLMMarkdown(block.message.content),
     [block.message.content]
+  );
+  const processedThinkingContent = useMemo(
+    () =>
+      hasThinkingContentToShow
+        ? postProcessLLMMarkdown(block.message.thinking_content ?? '')
+        : '',
+    [block.message.thinking_content, hasThinkingContentToShow]
   );
 
   // State to track selected tool link (for navigation)
@@ -392,7 +404,21 @@ export function BlockComponent({
           </Flex>
         ) : (
           <Flex align="start" width="100%">
-            <BlockContentWrapper hasOnlyTools={!hasContent && hasTools}>
+            <BlockContentWrapper
+              hasOnlyTools={!hasContent && !hasThinkingContentToShow && hasTools}
+            >
+              {hasThinkingContentToShow && (
+                <Disclosure>
+                  <Disclosure.Title>
+                    <Text size="xs" variant="muted" monospace>
+                      {t('Thinking')}
+                    </Text>
+                  </Disclosure.Title>
+                  <Disclosure.Content>
+                    <MarkedText text={processedThinkingContent} />
+                  </Disclosure.Content>
+                </Disclosure>
+              )}
               {hasContent && (
                 <BlockContent
                   text={processedContent}

--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
@@ -43,6 +43,7 @@ export function ExplorerDrawerContent({
 
   const [inputValue, setInputValue] = useState('');
   const [hoveredBlockIndex, setHoveredBlockIndex] = useState(-1);
+  const [showThinking, setShowThinking] = useState(false);
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -352,6 +353,11 @@ export function ExplorerDrawerContent({
         showCodeModeToggle={
           !!organization?.features.includes('seer-explorer-code-mode-tools')
         }
+        showThinking={showThinking}
+        onShowThinkingToggle={() => setShowThinking(v => !v)}
+        showThinkingToggle={
+          !!organization?.features.includes('seer-explorer-thinking-blocks')
+        }
       />
       {menu}
       <BlocksContainer ref={scrollContainerRef} onClick={handleBlocksClick}>
@@ -379,6 +385,7 @@ export function ExplorerDrawerContent({
                 isAwaitingQuestion={isQuestionPending}
                 isLatestTodoBlock={index === latestTodoBlockIndex}
                 readOnly={readOnly}
+                showThinking={showThinking}
                 onNavigate={undefined} // TODO: close drawer on link navigate? useDrawerContentContext
                 onRegisterEnterHandler={handler => {
                   blockEnterHandlers.current.set(index, handler);

--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerHeader.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerHeader.tsx
@@ -25,10 +25,13 @@ interface ExplorerDrawerHeaderProps {
   onNewChatClick: () => void;
   onOverrideCodeModeEnableToggle: () => void;
   onOverrideCtxEngEnableToggle: () => void;
+  onShowThinkingToggle: () => void;
   overrideCodeModeEnable: boolean;
   overrideCtxEngEnable: boolean;
   showCodeModeToggle: boolean;
   showContextEngineToggle: boolean;
+  showThinking: boolean;
+  showThinkingToggle: boolean;
 }
 
 export function ExplorerDrawerHeader({
@@ -43,6 +46,9 @@ export function ExplorerDrawerHeader({
   showCodeModeToggle,
   overrideCodeModeEnable,
   onOverrideCodeModeEnableToggle,
+  showThinking,
+  showThinkingToggle,
+  onShowThinkingToggle,
 }: ExplorerDrawerHeaderProps) {
   // Session history query
   const {
@@ -146,6 +152,27 @@ export function ExplorerDrawerHeader({
               />
               <Text size="sm" variant="muted">
                 {t('CM')}
+              </Text>
+            </Flex>
+          </Tooltip>
+        )}
+        {showThinkingToggle && (
+          <Tooltip
+            title={
+              showThinking
+                ? t('Hide thinking blocks (click to hide)')
+                : t('Show thinking blocks (click to show)')
+            }
+          >
+            <Flex align="center" gap="xs" padding="xs sm" height="100%">
+              <Switch
+                size="sm"
+                checked={showThinking}
+                onChange={onShowThinkingToggle}
+                aria-label={t('Toggle thinking blocks')}
+              />
+              <Text size="sm" variant="muted">
+                {t('Show thinking')}
               </Text>
             </Flex>
           </Tooltip>


### PR DESCRIPTION
Add a toggle in the explorer top bar that shows/hides LLM thinking content in chat blocks. When enabled, assistant messages that include `thinking_content` display a collapsible Disclosure section above the main response.

The toggle follows existing patterns:
- Rendered as a `Switch` in the top bar, matching the context engine (CE) toggle style
- Gated behind `organizations:seer-explorer-thinking-blocks`, registered in #113437 (land first)
- Off by default — users opt in to see thinking blocks


Agent transcript: https://claudescope.sentry.dev/share/gf6WzWexFIp3HMzlPjgCIHrG8w552yCWcLNT3zuyNqY

https://github.com/user-attachments/assets/142f8865-472a-4d7a-a04c-00194c633ac5