### PR TITLE
fix(performance): Support continuous profiling in sampled events table

### DIFF
--- a/static/app/views/insights/types.tsx
+++ b/static/app/views/insights/types.tsx
@@ -52,6 +52,7 @@ export enum SpanFields {
   SPAN_SYSTEM = 'span.system',
   SPAN_CATEGORY = 'span.category',
   TRANSACTION_SPAN_ID = 'transaction.span_id',
+  TRANSACTION_EVENT_ID = 'transaction.event_id',
   SPAN_SELF_TIME = 'span.self_time',
   TRACE = 'trace',
   PROFILE_ID = 'profile_id',
@@ -304,6 +305,7 @@ export type NonNullableStringFields =
   | SpanFields.CLS_SOURCE
   | SpanFields.LCP_ELEMENT
   | SpanFields.TRANSACTION_SPAN_ID
+  | SpanFields.TRANSACTION_EVENT_ID
   | SpanFields.DB_SYSTEM
   | SpanFields.CODE_FILEPATH
   | SpanFields.CODE_FUNCTION

--- a/static/app/views/performance/transactionSummary/transactionEvents/eapSampledEventsTable.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eapSampledEventsTable.spec.tsx
@@ -16,6 +16,59 @@ describe('EAP SampledEventsTable', () => {
     features: ['performance-view'],
   });
 
+  const META_FIELDS = {
+    span_id: 'string',
+    'user.id': 'string',
+    'user.email': 'string',
+    'user.username': 'string',
+    'user.ip': 'string',
+    'span.duration': 'duration',
+    trace: 'string',
+    timestamp: 'date',
+    'profile.id': 'string',
+    'profiler.id': 'string',
+    'thread.id': 'number',
+    'precise.start_ts': 'number',
+    'precise.finish_ts': 'number',
+    'spans.browser': 'number',
+    'spans.db': 'number',
+    'spans.http': 'number',
+    'spans.resource': 'number',
+    'spans.ui': 'number',
+    'transaction.event_id': 'string',
+    'transaction.span_id': 'string',
+    project: 'string',
+  };
+
+  function addDataMock(row: Record<string, unknown>) {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: {
+        meta: {fields: META_FIELDS},
+        data: [row],
+      },
+      match: [
+        (_url, options) =>
+          options.query?.field?.includes('span_id') &&
+          options.query?.query?.includes('transaction:/api/test') &&
+          options.query?.query?.includes('is_transaction:true'),
+      ],
+    });
+  }
+
+  const eventView = EventView.fromNewQueryWithLocation(
+    {
+      id: undefined,
+      version: 2,
+      name: 'test',
+      fields: ['span_id', 'span.duration', 'trace', 'timestamp'],
+      query: '',
+      projects: [Number(project.id)],
+      orderby: '-timestamp',
+    },
+    LocationFixture({pathname: '/'})
+  );
+
   beforeEach(() => {
     ProjectsStore.loadInitialData([project]);
     PageFiltersStore.onInitializeUrlState(
@@ -31,55 +84,6 @@ describe('EAP SampledEventsTable', () => {
       },
       match: [(_url, options) => options.query?.field?.includes('count()')],
     });
-
-    // Main data query
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/events/`,
-      body: {
-        meta: {
-          fields: {
-            span_id: 'string',
-            'user.id': 'string',
-            'user.email': 'string',
-            'user.username': 'string',
-            'user.ip': 'string',
-            'span.duration': 'duration',
-            trace: 'string',
-            timestamp: 'date',
-            'profile.id': 'string',
-            'spans.browser': 'number',
-            'spans.db': 'number',
-            'spans.http': 'number',
-            'spans.resource': 'number',
-            'spans.ui': 'number',
-          },
-        },
-        data: [
-          {
-            span_id: 'abc123',
-            'user.id': '',
-            'user.email': 'user@example.com',
-            'user.username': '',
-            'user.ip': '',
-            'span.duration': 350,
-            trace: 'trace123',
-            timestamp: '2025-01-01T12:00:00+00:00',
-            'profile.id': 'prof1',
-            'spans.browser': 50,
-            'spans.db': 100,
-            'spans.http': 150,
-            'spans.resource': 50,
-            'spans.ui': 0,
-          },
-        ],
-      },
-      match: [
-        (_url, options) =>
-          options.query?.field?.includes('span_id') &&
-          options.query?.query?.includes('transaction:/api/test') &&
-          options.query?.query?.includes('is_transaction:true'),
-      ],
-    });
   });
 
   afterEach(() => {
@@ -88,18 +92,29 @@ describe('EAP SampledEventsTable', () => {
   });
 
   it('renders the table with data', async () => {
-    const eventView = EventView.fromNewQueryWithLocation(
-      {
-        id: undefined,
-        version: 2,
-        name: 'test',
-        fields: ['span_id', 'span.duration', 'trace', 'timestamp'],
-        query: '',
-        projects: [Number(project.id)],
-        orderby: '-timestamp',
-      },
-      LocationFixture({pathname: '/'})
-    );
+    addDataMock({
+      span_id: 'abc123',
+      'user.id': '',
+      'user.email': 'user@example.com',
+      'user.username': '',
+      'user.ip': '',
+      'span.duration': 350,
+      trace: 'trace123',
+      timestamp: '2025-01-01T12:00:00+00:00',
+      'profile.id': 'prof1',
+      'profiler.id': '',
+      'thread.id': 0,
+      'precise.start_ts': 123,
+      'precise.finish_ts': 124,
+      'spans.browser': 50,
+      'spans.db': 100,
+      'spans.http': 150,
+      'spans.resource': 50,
+      'spans.ui': 0,
+      'transaction.event_id': 'event_id_123',
+      'transaction.span_id': 'span_id_123',
+      project: project.slug,
+    });
 
     render(
       <SampledEventsTable
@@ -125,5 +140,65 @@ describe('EAP SampledEventsTable', () => {
 
     // Verify ops breakdown renders
     expect(screen.getByTestId('relative-ops-breakdown')).toBeInTheDocument();
+
+    // Verify V1 (transaction) profile link
+    const profileLink = screen.getByRole('button', {name: 'View Profile'});
+    expect(profileLink).toHaveAttribute(
+      'href',
+      `/organizations/${organization.slug}/explore/profiling/profile/${project.slug}/prof1/flamegraph/?referrer=performance`
+    );
+  });
+
+  it('links to the continuous profile when a profiler id is present', async () => {
+    // thread.id === 0 is a valid main-thread identifier and must not disable
+    // the profile link.
+    addDataMock({
+      span_id: 'abc123',
+      'user.id': '',
+      'user.email': 'user@example.com',
+      'user.username': '',
+      'user.ip': '',
+      'span.duration': 350,
+      trace: 'trace123',
+      timestamp: '2025-01-01T12:00:00+00:00',
+      'profile.id': '',
+      'profiler.id': 'profiler_xyz',
+      'thread.id': 0,
+      'precise.start_ts': 1735732800,
+      'precise.finish_ts': 1735732801,
+      'spans.browser': 50,
+      'spans.db': 100,
+      'spans.http': 150,
+      'spans.resource': 50,
+      'spans.ui': 0,
+      'transaction.event_id': 'event_id_123',
+      'transaction.span_id': 'span_id_123',
+      project: project.slug,
+    });
+
+    render(
+      <SampledEventsTable
+        eventView={eventView}
+        transactionName="/api/test"
+        maxDuration={5000}
+        isMaxDurationLoading={false}
+        cursor={undefined}
+        onCursor={() => {}}
+      />,
+      {organization}
+    );
+
+    // Verify V2 (continuous) profile link
+    const profileLink = await screen.findByRole('button', {name: 'View Profile'});
+    const href = profileLink.getAttribute('href') ?? '';
+    expect(href).toContain(
+      `/organizations/${organization.slug}/explore/profiling/profile/${project.slug}/flamegraph/`
+    );
+    expect(href).toContain('profilerId=profiler_xyz');
+    expect(href).toContain('tid=0');
+    expect(href).toContain('eventId=event_id_123');
+    expect(href).toContain('traceId=trace123');
+    expect(href).toContain('transactionId=span_id_123');
+    expect(href).toContain('referrer=performance');
   });
 });

--- a/static/app/views/performance/transactionSummary/transactionEvents/eapSampledEventsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eapSampledEventsTable.tsx
@@ -23,6 +23,7 @@ import {
 import {IconPlay, IconProfiling} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
+import type {TableDataRow} from 'sentry/utils/discover/discoverQuery';
 import type {EventsMetaType, EventView} from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {
@@ -30,6 +31,7 @@ import {
   SPAN_OP_BREAKDOWN_FIELDS,
 } from 'sentry/utils/discover/fields';
 import {toPercent} from 'sentry/utils/number/toPercent';
+import {isEmptyObject} from 'sentry/utils/object/isEmptyObject';
 import {decodeScalar, decodeSorts} from 'sentry/utils/queryString';
 import {projectSupportsReplay} from 'sentry/utils/replays/projectSupportsReplay';
 import type {Theme} from 'sentry/utils/theme';
@@ -45,6 +47,7 @@ import {QueryParameterNames} from 'sentry/views/insights/common/views/queryParam
 import {ModuleName, type SpanProperty} from 'sentry/views/insights/types';
 import {TraceViewSources} from 'sentry/views/performance/newTraceDetails/traceHeader/breadcrumbs';
 import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
+import {generateProfileLink} from 'sentry/views/performance/transactionSummary/utils';
 import {
   platformToPerformanceType,
   ProjectPerformanceType,
@@ -73,6 +76,9 @@ const BASE_FIELDS = [
   'spans.http',
   'spans.resource',
   'spans.ui',
+  'transaction.event_id',
+  'transaction.span_id',
+  'project',
 ];
 
 type SampledEventsColumn = GridColumnHeader<
@@ -127,7 +133,6 @@ export function SampledEventsTable({
   const organization = useOrganization();
 
   const project = projects.find(p => p.id === String(eventView.project[0]));
-  const projectSlug = project?.slug;
 
   const isBackend =
     platformToPerformanceType(projects, eventView.project) ===
@@ -244,7 +249,7 @@ export function SampledEventsTable({
             });
           },
           renderBodyCell: (column, row) =>
-            renderBodyCell(column, row, meta, projectSlug, location, organization, theme),
+            renderBodyCell(column, row, meta, location, organization, theme),
         }}
       />
       <Pagination
@@ -261,7 +266,6 @@ function renderBodyCell(
   column: SampledEventsColumn,
   row: Record<string, any>,
   meta: EventsMetaType | undefined,
-  projectSlug: string | undefined,
   location: Location,
   organization: Organization,
   theme: Theme
@@ -309,21 +313,23 @@ function renderBodyCell(
   }
 
   if (column.key === 'profile.id') {
+    // generateProfileLink reads tableRow.id as the transaction event id
+    // (discover-style rows); EAP spans expose it as `transaction.event_id`,
+    // so alias it here.
+    const tableRow: TableDataRow = {
+      ...row,
+      id: String(row['transaction.event_id'] ?? ''),
+    };
+    const to = normalizeUrl(generateProfileLink()(organization, tableRow, undefined));
+
     return (
       <div>
         <LinkButton
           size="xs"
           icon={<IconProfiling size="xs" />}
-          to={{
-            pathname: normalizeUrl(
-              `/organizations/${organization.slug}/profiling/profile/${projectSlug}/${row['profile.id']}/flamegraph/`
-            ),
-            query: {
-              referrer: 'performance',
-            },
-          }}
+          to={to}
           aria-label={t('View Profile')}
-          disabled={!row['profile.id']}
+          disabled={isEmptyObject(to)}
         />
       </div>
     );

--- a/static/app/views/performance/transactionSummary/utils.tsx
+++ b/static/app/views/performance/transactionSummary/utils.tsx
@@ -9,7 +9,7 @@ import {generateLinkToEventInTraceView} from 'sentry/utils/discover/urls';
 import {getRouteStringFromRoutes} from 'sentry/utils/getRouteStringFromRoutes';
 import {
   generateContinuousProfileFlamechartRouteWithQuery,
-  generateProfileFlamechartRoute,
+  generateProfileFlamechartRouteWithQuery,
 } from 'sentry/utils/profiling/routes';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
@@ -181,14 +181,17 @@ export function generateProfileLink() {
     tableRow: TableDataRow,
     _location: Location | undefined
   ) => {
-    const projectSlug = tableRow['project.name'];
+    // The preferred attribute for EAP spans is `project`, but the old discover
+    // dataset rows use `project.name`.
+    const projectSlug = tableRow.project ?? tableRow['project.name'];
 
     const profileId = tableRow['profile.id'];
     if (projectSlug && profileId) {
-      return generateProfileFlamechartRoute({
+      return generateProfileFlamechartRouteWithQuery({
         organization,
-        projectSlug: String(tableRow['project.name']),
+        projectSlug: String(projectSlug),
         profileId: String(profileId),
+        query: {referrer: 'performance'},
       });
     }
 
@@ -202,11 +205,20 @@ export function generateProfileLink() {
       typeof tableRow['precise.finish_ts'] === 'number'
         ? getDateFromTimestamp(tableRow['precise.finish_ts'] * 1000)
         : null;
-    if (projectSlug && profilerId && threadId && start && finish) {
-      const query: Record<string, string> = {tid: String(threadId)};
+    const hasThreadId =
+      typeof threadId === 'number' ||
+      (typeof threadId === 'string' && threadId.length > 0);
+    if (projectSlug && profilerId && hasThreadId && start && finish) {
+      const query: Record<string, string> = {
+        tid: String(threadId),
+        referrer: 'performance',
+      };
       if (tableRow.id && tableRow.trace) {
         query.eventId = String(tableRow.id);
         query.traceId = String(tableRow.trace);
+      }
+      if (tableRow['transaction.span_id']) {
+        query.transactionId = String(tableRow['transaction.span_id']);
       }
 
       return generateContinuousProfileFlamechartRouteWithQuery({


### PR DESCRIPTION
The sampled events table's profile column only considered V1 (transaction) profiles. Update it to also link to V2 (continuous) profiles, and use the existing helper method to do so.

A couple other tweaks along the way:
- Also update the helper method to include the span-based transaction ID in the continuous flamegraph page's query string as well - this is unused right now but will let us break that page's dependency on transaction events in the near future.
- Fixed an issue where a `thread.id` of `0` (typical for browser profiling) could prevent a profile link from showing (since `0` is falsey).

Fixes DAIN-1538.