### PR TITLE
feat(dashboards): Use org option for widget query queue concurrency

### DIFF
--- a/static/app/views/dashboards/utils/widgetQueryQueue.tsx
+++ b/static/app/views/dashboards/utils/widgetQueryQueue.tsx
@@ -34,18 +34,22 @@ export function useWidgetQueryQueue() {
   return hasQueueFeature && queueContext ? queueContext : {queue: undefined};
 }
 
-// Lowest known safe values for customers
-const MAX_CONCURRENCY = 5;
+// Lowest known safe value for customers — used when the org option is unset so we
+// never accidentally assume a high limit.
+const FALLBACK_CONCURRENCY = 5;
 const MAX_RETRIES = 5;
 
 export function WidgetQueryQueueProvider({children}: {children: React.ReactNode}) {
   const startTimeRef = useRef<number | undefined>(undefined);
   const location = useLocation();
+  const organization = useOrganization();
+  const concurrency =
+    organization.dashboardsAsyncQueueParallelLimit ?? FALLBACK_CONCURRENCY;
 
   const queueOptions = useMemo(
     () =>
       asyncQueuerOptions({
-        concurrency: MAX_CONCURRENCY,
+        concurrency,
         wait: 5,
         started: true,
         key: 'widget-query-queue',
@@ -75,7 +79,7 @@ export function WidgetQueryQueueProvider({children}: {children: React.ReactNode}
           }
         },
       }),
-    [location.pathname]
+    [location.pathname, concurrency]
   );
 
   const queue = useAsyncQueuer(fetchWidgetItem, queueOptions);


### PR DESCRIPTION
Wire the `sentry:dashboards-async-queue-parallel-limit` org option into the dashboards widget query async queuer so the concurrency can be tuned per-org.

Previously `WidgetQueryQueueProvider` hardcoded `concurrency: 5`. The backend already surfaces the option on the org payload as `organization.dashboardsAsyncQueueParallelLimit`, so the provider now reads that value and passes it through to `asyncQueuerOptions`. When the option isn't present (e.g. older payloads) we fall back to 5 rather than assuming a high limit.

The queuer is still gated by the `visibility-dashboards-async-queue` feature flag via `useWidgetQueryQueue`, so consumers off the flag are unaffected.

Refs BROWSE-480