### PR TITLE
perf(projects): Use collapse=organization on project details fetches

### DIFF
--- a/static/app/components/events/autofix/preferences/hooks/useBulkAutofixAutomationSettings.ts
+++ b/static/app/components/events/autofix/preferences/hooks/useBulkAutofixAutomationSettings.ts
@@ -4,6 +4,7 @@ import type {ProjectSeerPreferences} from 'sentry/components/events/autofix/type
 import type {Organization} from 'sentry/types/organization';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {makeDetailedProjectQueryKey} from 'sentry/utils/project/useDetailedProject';
 import {
   fetchMutation,
   useMutation,
@@ -140,14 +141,10 @@ export function useUpdateBulkAutofixAutomationSettings(
         }
         // Invalidate the query for ProjectOptions to Settings>Project>Seer details page
         queryClient.invalidateQueries({
-          queryKey: [
-            getApiUrl('/projects/$organizationIdOrSlug/$projectIdOrSlug/', {
-              path: {
-                organizationIdOrSlug: organization.slug,
-                projectIdOrSlug: project.slug,
-              },
-            }),
-          ],
+          queryKey: makeDetailedProjectQueryKey({
+            orgSlug: organization.slug,
+            projectSlug: project.slug,
+          }),
         });
         // Invalidate the query for SeerPreferences to Settings>Project>Seer details page
         queryClient.invalidateQueries({

--- a/static/app/components/events/highlights/highlightsSettingsForm.tsx
+++ b/static/app/components/events/highlights/highlightsSettingsForm.tsx
@@ -9,11 +9,12 @@ import {t, tct} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
 import {convertMultilineFieldValue, extractMultilineFields} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import type {ApiResponse} from 'sentry/utils/api/apiFetch';
 import {
   makeDetailedProjectQueryKey,
   useDetailedProject,
 } from 'sentry/utils/project/useDetailedProject';
-import {setApiQueryData, useQueryClient} from 'sentry/utils/queryClient';
+import {useQueryClient} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
 
@@ -42,13 +43,13 @@ export function HighlightsSettingsForm({projectSlug}: HighlightsSettingsFormProp
     apiMethod: 'PUT',
     apiEndpoint: `/projects/${organization.slug}/${projectSlug}/`,
     onSubmitSuccess: (updatedProject: Project) => {
-      setApiQueryData<Project>(
-        queryClient,
+      queryClient.setQueryData<ApiResponse<Project>>(
         makeDetailedProjectQueryKey({
           orgSlug: organization.slug,
           projectSlug: project.slug,
         }),
-        data => (updatedProject ? updatedProject : data)
+        prev =>
+          updatedProject ? {headers: prev?.headers ?? {}, json: updatedProject} : prev
       );
       trackAnalytics('highlights.project_settings.updated_manually', {organization});
       addSuccessMessage(`Successfully updated highlights for '${project.name}'`);

--- a/static/app/components/events/meta/annotatedText/filteredAnnotatedTextValue.tsx
+++ b/static/app/components/events/meta/annotatedText/filteredAnnotatedTextValue.tsx
@@ -2,9 +2,7 @@ import {useMemo} from 'react';
 
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import type {Project} from 'sentry/types/project';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import {useApiQuery} from 'sentry/utils/queryClient';
+import {useDetailedProject} from 'sentry/utils/project/useDetailedProject';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
@@ -26,17 +24,9 @@ export function FilteredAnnotatedTextValue({value, meta}: Props) {
 
   // Fetch full project details including `project.relayPiiConfig`
   // That property is not normally available in the store
-  const {data: projectDetails} = useApiQuery<Project>(
-    [
-      getApiUrl('/projects/$organizationIdOrSlug/$projectIdOrSlug/', {
-        path: {
-          organizationIdOrSlug: organization.slug,
-          projectIdOrSlug: currentProject?.slug!,
-        },
-      }),
-    ],
+  const {data: projectDetails} = useDetailedProject(
+    {orgSlug: organization.slug, projectSlug: currentProject?.slug ?? ''},
     {
-      staleTime: Infinity,
       retry: false,
       enabled: !!currentProject?.slug,
       notifyOnChangeProps: ['data'],

--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -51,7 +51,7 @@ export type Project = {
   isInternal: boolean;
   isMember: boolean;
   name: string;
-  organization: Organization;
+  organization: Pick<Organization, 'id' | 'slug'>;
   plugins: Plugin[];
   processingIssues: number;
   relayCustomMetricCardinalityLimit: number | null;

--- a/static/app/utils/project/useDetailedProject.tsx
+++ b/static/app/utils/project/useDetailedProject.tsx
@@ -1,32 +1,43 @@
+import type {UseQueryOptions} from '@tanstack/react-query';
+import {useQuery} from '@tanstack/react-query';
+
 import type {Project} from 'sentry/types/project';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import {
-  useApiQuery,
-  type ApiQueryKey,
-  type UseApiQueryOptions,
-} from 'sentry/utils/queryClient';
+import type {ApiResponse} from 'sentry/utils/api/apiFetch';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import type {ApiQueryKey} from 'sentry/utils/api/apiQueryKey';
 
 interface DetailedProjectParameters {
   orgSlug: string;
   projectSlug: string;
 }
 
-export const makeDetailedProjectQueryKey = ({
+type DetailedProjectOptions = Omit<
+  UseQueryOptions<ApiResponse<Project>, Error, Project, ApiQueryKey>,
+  'queryKey' | 'queryFn' | 'select'
+>;
+
+export const makeDetailedProjectApiOptions = ({
   orgSlug,
   projectSlug,
-}: DetailedProjectParameters): ApiQueryKey => [
-  getApiUrl('/projects/$organizationIdOrSlug/$projectIdOrSlug/', {
+}: DetailedProjectParameters) =>
+  apiOptions.as<Project>()('/projects/$organizationIdOrSlug/$projectIdOrSlug/', {
     path: {organizationIdOrSlug: orgSlug, projectIdOrSlug: projectSlug},
-  }),
-];
+    query: {
+      // Skips expensive properties of organization details
+      collapse: 'organization',
+    },
+    staleTime: Infinity,
+  });
+
+export const makeDetailedProjectQueryKey = (params: DetailedProjectParameters) =>
+  makeDetailedProjectApiOptions(params).queryKey;
 
 export function useDetailedProject(
   params: DetailedProjectParameters,
-  options: Partial<UseApiQueryOptions<Project>> = {}
+  options: DetailedProjectOptions = {}
 ) {
-  return useApiQuery<Project>(makeDetailedProjectQueryKey(params), {
-    staleTime: Infinity,
-    retry: false,
+  return useQuery({
+    ...makeDetailedProjectApiOptions(params),
     ...options,
   });
 }

--- a/static/app/utils/project/useDetailedProject.tsx
+++ b/static/app/utils/project/useDetailedProject.tsx
@@ -38,6 +38,7 @@ export function useDetailedProject(
 ) {
   return useQuery({
     ...makeDetailedProjectApiOptions(params),
+    retry: false,
     ...options,
   });
 }

--- a/static/app/utils/project/useUpdateProject.tsx
+++ b/static/app/utils/project/useUpdateProject.tsx
@@ -1,12 +1,8 @@
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {Project} from 'sentry/types/project';
+import type {ApiResponse} from 'sentry/utils/api/apiFetch';
 import {makeDetailedProjectQueryKey} from 'sentry/utils/project/useDetailedProject';
-import {
-  fetchMutation,
-  setApiQueryData,
-  useMutation,
-  useQueryClient,
-} from 'sentry/utils/queryClient';
+import {fetchMutation, useMutation, useQueryClient} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 interface Variables extends Partial<Project> {}
@@ -32,7 +28,7 @@ export function useUpdateProject(project: Project) {
 
   return useMutation<Project, Error, Variables, Context>({
     onMutate: (data: Variables) => {
-      const fromCache = queryClient.getQueryData<Project>(queryKey);
+      const fromCache = queryClient.getQueryData<ApiResponse<Project>>(queryKey)?.json;
       const fromStore = ProjectsStore.getById(project.id);
       const fromProp = project;
 
@@ -64,7 +60,10 @@ export function useUpdateProject(project: Project) {
 
       // Update caches optimistically
       ProjectsStore.onUpdateSuccess(updatedProject);
-      setApiQueryData<Project>(queryClient, queryKey, updatedProject);
+      queryClient.setQueryData<ApiResponse<Project>>(queryKey, prev => ({
+        headers: prev?.headers ?? {},
+        json: updatedProject,
+      }));
 
       return {previousProject};
     },
@@ -78,7 +77,10 @@ export function useUpdateProject(project: Project) {
     onError: (_error, _variables, context) => {
       if (context?.previousProject) {
         ProjectsStore.onUpdateSuccess(context.previousProject);
-        queryClient.setQueryData(queryKey, context.previousProject);
+        queryClient.setQueryData<ApiResponse<Project>>(queryKey, prev => ({
+          headers: prev?.headers ?? {},
+          json: context.previousProject,
+        }));
       }
     },
     onSettled: () => {

--- a/static/app/utils/useEventWaiter.tsx
+++ b/static/app/utils/useEventWaiter.tsx
@@ -1,10 +1,12 @@
 import {useEffect} from 'react';
 import * as Sentry from '@sentry/react';
+import {useQuery} from '@tanstack/react-query';
 
 import type {Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {makeDetailedProjectApiOptions} from 'sentry/utils/project/useDetailedProject';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {RequestError} from 'sentry/utils/requestError/requestError';
 
@@ -60,13 +62,6 @@ export function useEventWaiter({
 }: UseEventWaiterOptions): FirstEvent {
   const shouldPoll = !disabled && !!organization && !!project;
 
-  const projectUrl = getApiUrl('/projects/$organizationIdOrSlug/$projectIdOrSlug/', {
-    path: {
-      organizationIdOrSlug: organization.slug,
-      projectIdOrSlug: project.slug,
-    },
-  });
-
   const issuesUrl = getApiUrl(
     '/projects/$organizationIdOrSlug/$projectIdOrSlug/issues/',
     {
@@ -78,17 +73,19 @@ export function useEventWaiter({
   );
 
   // Poll the project endpoint to detect when the first event arrives
-  const projectQuery = useApiQuery<Project>([projectUrl], {
+  const projectQuery = useQuery({
+    ...makeDetailedProjectApiOptions({
+      orgSlug: organization.slug,
+      projectSlug: project.slug,
+    }),
     refetchInterval: query => {
       if (!shouldPoll) {
         return false;
       }
       // Stop polling once the first event has been detected
-      if (query.state.data) {
-        const [projectData] = query.state.data;
-        if (getFirstEvent(eventType, projectData)) {
-          return false;
-        }
+      const projectData = query.state.data?.json;
+      if (projectData && getFirstEvent(eventType, projectData)) {
+        return false;
       }
       return pollInterval;
     },

--- a/static/app/views/explore/components/annotatedAttributeTooltip.tsx
+++ b/static/app/views/explore/components/annotatedAttributeTooltip.tsx
@@ -2,9 +2,7 @@ import React from 'react';
 
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import type {Project} from 'sentry/types/project';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import {useApiQuery} from 'sentry/utils/queryClient';
+import {useDetailedProject} from 'sentry/utils/project/useDetailedProject';
 import type {RendererExtra} from 'sentry/views/explore/logs/fieldRenderers';
 import {TraceItemMetaInfo} from 'sentry/views/explore/utils';
 
@@ -20,17 +18,9 @@ export function AnnotatedAttributeTooltip({
   // Fetch full project details including `project.relayPiiConfig`
   // That property is not normally available in the store.
   // Taken from FilteredAnnotatedTextValue.tsx
-  const {data: projectDetails} = useApiQuery<Project>(
-    [
-      getApiUrl('/projects/$organizationIdOrSlug/$projectIdOrSlug/', {
-        path: {
-          organizationIdOrSlug: extra.organization.slug,
-          projectIdOrSlug: extra.project?.slug!,
-        },
-      }),
-    ],
+  const {data: projectDetails} = useDetailedProject(
+    {orgSlug: extra.organization.slug, projectSlug: extra.project?.slug ?? ''},
     {
-      staleTime: Infinity,
       retry: false,
       enabled: !!extra.project?.slug && !!fieldKey && !!extra.traceItemMeta,
       notifyOnChangeProps: ['data'],

--- a/static/app/views/projects/projectContext.tsx
+++ b/static/app/views/projects/projectContext.tsx
@@ -168,8 +168,12 @@ class ProjectContextProvider extends Component<Props, State> {
     }));
 
     if (activeProject && hasAccess) {
+      // TODO: Convert this class component to a functional one and use
+      // `useDetailedProject` so this request shares the same cache and the
+      // `collapse=organization` query option is applied automatically.
       const projectRequest = this.props.api.requestPromise(
-        `/projects/${organization.slug}/${projectSlug}/`
+        `/projects/${organization.slug}/${projectSlug}/`,
+        {query: {collapse: 'organization'}}
       );
 
       try {

--- a/static/app/views/projects/redirectDeprecatedProjectRoute.tsx
+++ b/static/app/views/projects/redirectDeprecatedProjectRoute.tsx
@@ -54,8 +54,12 @@ class ProjectDetailsInner extends Component<DetailsProps, DetailsState> {
     const {orgId, projectSlug} = this.props;
 
     try {
+      // TODO: Convert this class component to a functional one and use
+      // `useDetailedProject` so this request shares the same cache and the
+      // `collapse=organization` query option is applied automatically.
       const project = await this.props.api.requestPromise(
-        `/projects/${orgId}/${projectSlug}/`
+        `/projects/${orgId}/${projectSlug}/`,
+        {query: {collapse: 'organization'}}
       );
 
       this.setState({

--- a/static/app/views/releases/list/releaseHealthCTA.tsx
+++ b/static/app/views/releases/list/releaseHealthCTA.tsx
@@ -10,8 +10,7 @@ import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import type {Release} from 'sentry/types/release';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import {useApiQuery} from 'sentry/utils/queryClient';
+import {useDetailedProject} from 'sentry/utils/project/useDetailedProject';
 
 interface Props {
   organization: Organization;
@@ -30,15 +29,8 @@ export function ReleaseHealthCTA({
     data: project,
     isPending,
     isError,
-  } = useApiQuery<Project>(
-    [
-      getApiUrl('/projects/$organizationIdOrSlug/$projectIdOrSlug/', {
-        path: {
-          organizationIdOrSlug: organization.slug,
-          projectIdOrSlug: selectedProject?.slug!,
-        },
-      }),
-    ],
+  } = useDetailedProject(
+    {orgSlug: organization.slug, projectSlug: selectedProject?.slug ?? ''},
     {
       enabled: Boolean(selectedProject) && releases.length > 0,
       staleTime: 1_000, // 1 second

--- a/static/app/views/settings/account/accountNotificationFineTuning.tsx
+++ b/static/app/views/settings/account/accountNotificationFineTuning.tsx
@@ -49,8 +49,8 @@ function AccountNotificationsByProject({
 
   return (
     <Fragment>
-      {Object.values(projectsByOrg).map(org =>
-        org.projects.map((project, i) => {
+      {Object.values(projectsByOrg).map(orgProjects =>
+        orgProjects.map((project, i) => {
           const schema = z.object({[project.id]: z.string()});
           return (
             <Fragment key={project.id}>

--- a/static/app/views/settings/account/notifications/utils.tsx
+++ b/static/app/views/settings/account/notifications/utils.tsx
@@ -1,5 +1,4 @@
 import {DataCategoryExact} from 'sentry/types/core';
-import type {OrganizationSummary} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {NOTIFICATION_SETTINGS_PATHNAMES} from 'sentry/views/settings/account/notifications/constants';
 
@@ -11,20 +10,13 @@ const notificationsByProject = ['alerts', 'email', 'workflow', 'spikeProtection'
 export const isGroupedByProject = (notificationType: string): boolean =>
   notificationsByProject.includes(notificationType);
 
-export const groupByOrganization = (
-  projects: Project[]
-): Record<string, {organization: OrganizationSummary; projects: Project[]}> => {
-  return projects.reduce<
-    Record<string, {organization: OrganizationSummary; projects: Project[]}>
-  >((acc, project) => {
+export const groupByOrganization = (projects: Project[]): Record<string, Project[]> => {
+  return projects.reduce<Record<string, Project[]>>((acc, project) => {
     const orgSlug = project.organization.slug;
     if (acc.hasOwnProperty(orgSlug)) {
-      acc[orgSlug]!.projects.push(project);
+      acc[orgSlug]!.push(project);
     } else {
-      acc[orgSlug] = {
-        organization: project.organization,
-        projects: [project],
-      };
+      acc[orgSlug] = [project];
     }
     return acc;
   }, {});

--- a/static/app/views/settings/projectGeneralSettings/index.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.tsx
@@ -34,10 +34,10 @@ import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import type {Organization} from 'sentry/types/organization';
 import type {PlatformKey, Project} from 'sentry/types/project';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import type {ApiResponse} from 'sentry/utils/api/apiFetch';
 import {handleXhrErrorResponse} from 'sentry/utils/handleXhrErrorResponse';
-import type {ApiQueryKey} from 'sentry/utils/queryClient';
-import {setApiQueryData, useQueryClient} from 'sentry/utils/queryClient';
+import {makeDetailedProjectQueryKey} from 'sentry/utils/project/useDetailedProject';
+import {useQueryClient} from 'sentry/utils/queryClient';
 import {recreateRoute} from 'sentry/utils/recreateRoute';
 import {useApi} from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -79,11 +79,10 @@ export function ProjectGeneralSettings({project, onChangeSlug}: Props) {
   const organization = useOrganization();
   const api = useApi({persistInFlight: true});
 
-  const makeProjectSettingsQueryKey: ApiQueryKey = [
-    getApiUrl('/projects/$organizationIdOrSlug/$projectIdOrSlug/', {
-      path: {organizationIdOrSlug: organization.slug, projectIdOrSlug: project.slug},
-    }),
-  ];
+  const projectSettingsQueryKey = makeDetailedProjectQueryKey({
+    orgSlug: organization.slug,
+    projectSlug: project.slug,
+  });
 
   const handleTransferFieldChange = (id: string, value: FieldValue) => {
     form[id] = value;
@@ -293,7 +292,10 @@ export function ProjectGeneralSettings({project, onChangeSlug}: Props) {
     apiMethod: 'PUT' as const,
     apiEndpoint: endpoint,
     onSubmitSuccess: resp => {
-      setApiQueryData(queryClient, makeProjectSettingsQueryKey, resp);
+      queryClient.setQueryData<ApiResponse<Project>>(projectSettingsQueryKey, prev => ({
+        headers: prev?.headers ?? {},
+        json: resp,
+      }));
       if (project.slug !== resp.slug) {
         changeProjectSlug(project.slug, resp.slug);
         // Container will redirect after stores get updated with new slug

--- a/static/app/views/settings/projectSecurityHeaders/csp.tsx
+++ b/static/app/views/settings/projectSecurityHeaders/csp.tsx
@@ -14,15 +14,13 @@ import {PanelHeader} from 'sentry/components/panels/panelHeader';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
 import type {Project, ProjectKey} from 'sentry/types/project';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import {projectKeysApiOptions} from 'sentry/utils/projectKeys';
+import type {ApiResponse} from 'sentry/utils/api/apiFetch';
 import {
-  fetchMutation,
-  setApiQueryData,
-  useApiQuery,
-  useQueryClient,
-  type ApiQueryKey,
-} from 'sentry/utils/queryClient';
+  makeDetailedProjectQueryKey,
+  useDetailedProject,
+} from 'sentry/utils/project/useDetailedProject';
+import {projectKeysApiOptions} from 'sentry/utils/projectKeys';
+import {fetchMutation, useQueryClient} from 'sentry/utils/queryClient';
 import {routeTitleGen} from 'sentry/utils/routeTitle';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
@@ -82,15 +80,9 @@ export default function ProjectCspReports() {
     isPending: isLoadingProject,
     isError: isProjectError,
     refetch: refetchProject,
-  } = useApiQuery<Project>(
-    [
-      getApiUrl('/projects/$organizationIdOrSlug/$projectIdOrSlug/', {
-        path: {organizationIdOrSlug: organization.slug, projectIdOrSlug: projectId},
-      }),
-    ],
-    {
-      staleTime: 0,
-    }
+  } = useDetailedProject(
+    {orgSlug: organization.slug, projectSlug: projectId},
+    {staleTime: 0}
   );
 
   if (isLoadingKeyList || isLoadingProject) {
@@ -109,11 +101,10 @@ export default function ProjectCspReports() {
   }
 
   const projectEndpoint = `/projects/${organization.slug}/${projectId}/`;
-  const projectQueryKey: ApiQueryKey = [
-    getApiUrl('/projects/$organizationIdOrSlug/$projectIdOrSlug/', {
-      path: {organizationIdOrSlug: organization.slug, projectIdOrSlug: projectId},
-    }),
-  ];
+  const projectQueryKey = makeDetailedProjectQueryKey({
+    orgSlug: organization.slug,
+    projectSlug: projectId,
+  });
 
   const cspMutationOptions = mutationOptions({
     mutationFn: (data: Partial<CspSchema>) =>
@@ -123,15 +114,16 @@ export default function ProjectCspReports() {
         data: {options: data},
       }),
     onSuccess: (updatedProject: Project) => {
-      setApiQueryData<Project>(queryClient, projectQueryKey, previousData => {
-        if (!previousData) {
-          return updatedProject;
-        }
-        return {
-          ...previousData,
-          ...updatedProject,
-          options: {...previousData.options, ...updatedProject.options},
-        };
+      queryClient.setQueryData<ApiResponse<Project>>(projectQueryKey, prev => {
+        const previous = prev?.json;
+        const merged = previous
+          ? {
+              ...previous,
+              ...updatedProject,
+              options: {...previous.options, ...updatedProject.options},
+            }
+          : updatedProject;
+        return {headers: prev?.headers ?? {}, json: merged};
       });
     },
   });

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -35,9 +35,9 @@ import {DataCategoryExact} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import type {ApiQueryKey} from 'sentry/utils/queryClient';
-import {setApiQueryData, useQuery} from 'sentry/utils/queryClient';
+import type {ApiResponse} from 'sentry/utils/api/apiFetch';
+import {makeDetailedProjectQueryKey} from 'sentry/utils/project/useDetailedProject';
+import {useQuery} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
 import {getPricingDocsLinkForEventType} from 'sentry/views/settings/account/notifications/utils';
@@ -213,12 +213,14 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
 
   const handleSubmitSuccess = useCallback(
     (resp: Project) => {
-      const projectSettingsQueryKey: ApiQueryKey = [
-        getApiUrl('/projects/$organizationIdOrSlug/$projectIdOrSlug/', {
-          path: {organizationIdOrSlug: organization.slug, projectIdOrSlug: project.slug},
-        }),
-      ];
-      setApiQueryData(queryClient, projectSettingsQueryKey, resp);
+      const projectSettingsQueryKey = makeDetailedProjectQueryKey({
+        orgSlug: organization.slug,
+        projectSlug: project.slug,
+      });
+      queryClient.setQueryData<ApiResponse<Project>>(projectSettingsQueryKey, prev => ({
+        headers: prev?.headers ?? {},
+        json: resp,
+      }));
       ProjectsStore.onUpdateSuccess(resp);
     },
     [project.slug, queryClient, organization.slug]

--- a/static/gsAdmin/views/projectDetails.tsx
+++ b/static/gsAdmin/views/projectDetails.tsx
@@ -9,6 +9,7 @@ import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {DataCategoryExact} from 'sentry/types/core';
+import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useApiQuery} from 'sentry/utils/queryClient';
@@ -33,7 +34,12 @@ export function ProjectDetails() {
     orgId: string;
     projectId: string;
   }>();
-  const {data, isPending, isError} = useApiQuery<Project>(
+  // This admin view fetches project details without `collapse=organization`,
+  // so the backend returns a full Organization rather than the minimal
+  // {id, slug} shape used elsewhere.
+  const {data, isPending, isError} = useApiQuery<
+    Omit<Project, 'organization'> & {organization: Organization}
+  >(
     [
       getApiUrl('/projects/$organizationIdOrSlug/$projectIdOrSlug/', {
         path: {organizationIdOrSlug: orgId, projectIdOrSlug: projectId},

--- a/tests/js/fixtures/project.ts
+++ b/tests/js/fixtures/project.ts
@@ -1,4 +1,3 @@
-import {OrganizationFixture} from 'sentry-fixture/organization';
 import {TeamFixture} from 'sentry-fixture/team';
 
 import type {Project} from 'sentry/types/project';
@@ -47,7 +46,7 @@ export function ProjectFixture(params: Partial<Project> = {}): Project {
     hasInsightsAgentMonitoring: false,
     hasInsightsMCP: false,
     isInternal: false,
-    organization: OrganizationFixture(),
+    organization: {id: '3', slug: 'org-slug'},
     plugins: [],
     processingIssues: 0,
     relayPiiConfig: '',


### PR DESCRIPTION
Fetch the project details endpoint with `collapse=organization`. Could save ~400ms on the request and consolidates a dozen `useApiQuery<Project>` call sites onto a single typed hook with one shared cache.

`Project.organization` is now the minimal `{id, slug}` shape that the collapsed response returns - and that most list endpoints were already returning anyway.

Switch all project details call sites away from setApiQueryData and the old format.

Follow-up to #113140 on the backend.