### PR TITLE
fix(tracemetrics): Make metric option search case insensitive

### DIFF
--- a/static/app/views/explore/hooks/useMetricOptions.spec.tsx
+++ b/static/app/views/explore/hooks/useMetricOptions.spec.tsx
@@ -56,7 +56,7 @@ describe('useMetricOptions', () => {
       ],
     };
 
-    const mockRequest = MockApiClient.addMockResponse({
+    MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
       method: 'GET',
       body: mockData,
@@ -78,9 +78,6 @@ describe('useMetricOptions', () => {
       ...context,
     });
 
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
-
-    expect(mockRequest).toHaveBeenCalledTimes(1);
     await waitFor(() =>
       expect(result.current.data?.data).toEqual([
         {['metric.name']: 'metric.a', ['metric.type']: 'distribution'},
@@ -109,26 +106,24 @@ describe('useMetricOptions', () => {
       ...context,
     });
 
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
-
-    expect(mockRequest).toHaveBeenCalledTimes(1);
-    expect(mockRequest).toHaveBeenCalledWith(
-      `/organizations/${organization.slug}/events/`,
-      expect.objectContaining({
-        query: expect.objectContaining({
-          dataset: 'tracemetrics',
-          field: [
-            'metric.name',
-            'metric.type',
-            'count(metric.name)',
-            'max(timestamp_precise)',
-          ],
-          referrer: 'api.explore.metric-options',
-          statsPeriod: '3d',
-        }),
-      })
+    await waitFor(() =>
+      expect(mockRequest).toHaveBeenCalledWith(
+        `/organizations/${organization.slug}/events/`,
+        expect.objectContaining({
+          query: expect.objectContaining({
+            dataset: 'tracemetrics',
+            field: [
+              'metric.name',
+              'metric.type',
+              'count(metric.name)',
+              'max(timestamp_precise)',
+            ],
+            referrer: 'api.explore.metric-options',
+            statsPeriod: '3d',
+          }),
+        })
+      )
     );
-
     await waitFor(() =>
       expect(result.current.data?.data).toEqual([
         {['metric.name']: 'metric.a', ['metric.type']: 'distribution'},
@@ -149,9 +144,8 @@ describe('useMetricOptions', () => {
       ...context,
     });
 
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
-
-    expect(result.current.data).toEqual({data: []});
+    await waitFor(() => expect(result.current.data?.data).toEqual([]));
+    expect(result.current.isMetricOptionsEmpty).toBe(true);
   });
 
   it('can be disabled', () => {
@@ -176,7 +170,7 @@ describe('useMetricOptions', () => {
       body: {data: []},
     });
 
-    const {result} = renderHookWithProviders(useMetricOptions, {
+    renderHookWithProviders(useMetricOptions, {
       ...context,
       initialRouterConfig: {
         location: {
@@ -186,16 +180,15 @@ describe('useMetricOptions', () => {
       },
     });
 
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
-
-    expect(mockRequest).toHaveBeenCalledTimes(1);
-    expect(mockRequest).toHaveBeenCalledWith(
-      `/organizations/${organization.slug}/events/`,
-      expect.objectContaining({
-        query: expect.objectContaining({
-          environment: ['production'],
-        }),
-      })
+    await waitFor(() =>
+      expect(mockRequest).toHaveBeenCalledWith(
+        `/organizations/${organization.slug}/events/`,
+        expect.objectContaining({
+          query: expect.objectContaining({
+            environment: ['production'],
+          }),
+        })
+      )
     );
   });
 });

--- a/static/app/views/explore/hooks/useMetricOptions.tsx
+++ b/static/app/views/explore/hooks/useMetricOptions.tsx
@@ -9,7 +9,6 @@ import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useQuery} from 'sentry/utils/queryClient';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {TRACE_ITEM_ATTRIBUTE_STALE_TIME} from 'sentry/views/explore/constants';
 import {useHasMetricUnitsUI} from 'sentry/views/explore/metrics/hooks/useHasMetricUnitsUI';
 import {
   TraceMetricKnownFieldKey,
@@ -73,7 +72,7 @@ function metricOptionsQueryKey({
     {
       path: {organizationIdOrSlug: orgSlug!},
       query,
-      staleTime: TRACE_ITEM_ATTRIBUTE_STALE_TIME,
+      staleTime: 5 * 60 * 1000,
     }
   );
 }

--- a/static/app/views/explore/hooks/useMetricOptions.tsx
+++ b/static/app/views/explore/hooks/useMetricOptions.tsx
@@ -3,11 +3,13 @@ import {useMemo} from 'react';
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import type {PageFilters} from 'sentry/types/core';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {defined} from 'sentry/utils';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
-import {useApiQuery, type ApiQueryKey} from 'sentry/utils/queryClient';
+import {useQuery} from 'sentry/utils/queryClient';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {TRACE_ITEM_ATTRIBUTE_STALE_TIME} from 'sentry/views/explore/constants';
 import {useHasMetricUnitsUI} from 'sentry/views/explore/metrics/hooks/useHasMetricUnitsUI';
 import {
   TraceMetricKnownFieldKey,
@@ -30,37 +32,33 @@ function metricOptionsQueryKey({
   search,
   environments,
   hasMetricUnitsUI,
-}: UseMetricOptionsProps & {hasMetricUnitsUI?: boolean} = {}): ApiQueryKey {
-  const searchValue = new MutableSearch('');
-  if (search) {
-    searchValue.addStringContainsFilter(
-      `${TraceMetricKnownFieldKey.METRIC_NAME}:${search}`
-    );
-  }
+}: UseMetricOptionsProps & {hasMetricUnitsUI?: boolean} = {}) {
   const queryFields = [
     TraceMetricKnownFieldKey.METRIC_NAME,
     TraceMetricKnownFieldKey.METRIC_TYPE,
     `count(${TraceMetricKnownFieldKey.METRIC_NAME})`,
     `max(${TraceMetricKnownFieldKey.TIMESTAMP_PRECISE})`,
   ];
+
   if (hasMetricUnitsUI) {
     queryFields.push(TraceMetricKnownFieldKey.METRIC_UNIT);
   }
 
-  const query: Record<string, string | string[] | number[]> = {
+  let searchValue: MutableSearch | undefined = undefined;
+  if (search) {
+    searchValue = new MutableSearch('');
+    searchValue.addContainsFilterValue(TraceMetricKnownFieldKey.METRIC_NAME, search);
+  }
+
+  const query: Record<string, string | string[] | number[] | undefined> = {
     dataset: DiscoverDatasets.TRACEMETRICS,
     field: queryFields,
-    query: searchValue.formatString(),
     referrer: 'api.explore.metric-options',
+    query: defined(searchValue) ? searchValue.formatString() : undefined,
+    caseInsensitive: defined(searchValue) ? '1' : undefined,
+    project: projectIds?.length ? projectIds?.map(String) : undefined,
+    environment: environments?.length ? environments : undefined,
   };
-
-  if (projectIds?.length) {
-    query.project = projectIds.map(String);
-  }
-
-  if (environments?.length) {
-    query.environment = environments;
-  }
 
   if (datetime) {
     Object.entries(normalizeDateTimeParams(datetime)).forEach(([key, value]) => {
@@ -70,12 +68,14 @@ function metricOptionsQueryKey({
     });
   }
 
-  return [
-    getApiUrl('/organizations/$organizationIdOrSlug/events/', {
+  return apiOptions.as<TraceMetricEventsResult>()(
+    '/organizations/$organizationIdOrSlug/events/',
+    {
       path: {organizationIdOrSlug: orgSlug!},
-    }),
-    {query},
-  ];
+      query,
+      staleTime: TRACE_ITEM_ATTRIBUTE_STALE_TIME,
+    }
+  );
 }
 
 /**
@@ -93,31 +93,20 @@ export function useMetricOptions({
   const {selection} = usePageFilters();
   const hasMetricUnitsUI = useHasMetricUnitsUI();
 
-  const queryKey = useMemo(
-    () =>
-      metricOptionsQueryKey({
-        search,
-        orgSlug: organization.slug,
-        projectIds: projectIds ?? selection.projects,
-        datetime: datetime ?? selection.datetime,
-        environments: environments ?? selection.environments,
-        hasMetricUnitsUI,
-      }),
-    [
-      organization.slug,
-      projectIds,
+  const {
+    data: result,
+    isFetching,
+    isLoading,
+  } = useQuery({
+    ...metricOptionsQueryKey({
       search,
-      selection.projects,
-      selection.datetime,
-      datetime,
-      environments,
-      selection.environments,
+      orgSlug: organization.slug,
+      projectIds: projectIds ?? selection.projects,
+      datetime: datetime ?? selection.datetime,
+      environments: environments ?? selection.environments,
       hasMetricUnitsUI,
-    ]
-  );
+    }),
 
-  const result = useApiQuery<TraceMetricEventsResult>(queryKey, {
-    staleTime: 5 * 60 * 1000, // Cache for 5 minutes
     refetchOnWindowFocus: false,
     refetchOnMount: false,
     retry: false,
@@ -125,27 +114,25 @@ export function useMetricOptions({
   });
 
   const filteredData = useMemo(() => {
-    if (!result.data?.data) {
+    if (!result?.data) {
       return undefined;
     }
     // Filter out empty string metric names which cause infinite update loops
-    return result.data.data
+    return result.data
       .filter(item => item[TraceMetricKnownFieldKey.METRIC_NAME]?.length > 0)
       .sort((a, b) =>
         a[TraceMetricKnownFieldKey.METRIC_NAME].localeCompare(
           b[TraceMetricKnownFieldKey.METRIC_NAME]
         )
       );
-  }, [result.data?.data]);
+  }, [result?.data]);
 
   const isMetricOptionsEmpty =
-    !result.isFetching &&
-    !result.isLoading &&
-    (!filteredData || filteredData.length === 0);
+    !isFetching && !isLoading && (!filteredData || filteredData.length === 0);
 
   return {
-    ...result,
-    data: filteredData ? {...result.data, data: filteredData} : result.data,
+    data: filteredData ? {...result, data: filteredData} : result,
     isMetricOptionsEmpty,
+    isFetching,
   };
 }


### PR DESCRIPTION
This PR modifies the the underlying fetching of metrics to be case insensitive while searching, to make it a bit easier for users to find things quickly.

As well, I took the time to update this data fetching hook to be built on top of the new `apiOptions`.