### PR TITLE
fix(api): Tighten alert mutation write scopes

### DIFF
--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from datetime import datetime
-from typing import Any, Literal, NotRequired, TypedDict, overload
+from typing import Any, Literal, NotRequired, TypeAlias, TypedDict, overload
 
 import sentry_sdk
 from django.core.cache import cache
@@ -228,6 +228,14 @@ def _has_any_team_scope(request: Request, scope: str) -> bool:
 ALERT_MUTATION_SCOPES = frozenset({"org:write", "alerts:write"})
 
 
+class _AlertMutationLookupMiss:
+    pass
+
+
+ALERT_MUTATION_LOOKUP_MISS = _AlertMutationLookupMiss()
+AlertMutationProjectLookup: TypeAlias = Sequence[Project] | None | _AlertMutationLookupMiss
+
+
 def _has_project_alert_write_access(request: Request, projects: Sequence[Project]) -> bool:
     return bool(projects) and all(
         request.access.has_any_project_scope(project, ALERT_MUTATION_SCOPES) for project in projects
@@ -238,12 +246,14 @@ def _has_view_project_scoped_alert_write(
     request: Request,
     view: APIView,
     organization: Organization | RpcOrganization | RpcUserOrganizationContext,
-) -> bool | None:
+) -> bool | None | _AlertMutationLookupMiss:
     get_projects = getattr(view, "get_alert_mutation_projects", None)
     if not callable(get_projects):
         return None
 
     projects = get_projects(request, organization)
+    if projects is ALERT_MUTATION_LOOKUP_MISS:
+        return ALERT_MUTATION_LOOKUP_MISS
     if projects is None:
         return None
 
@@ -271,6 +281,10 @@ class OrganizationAlertRulePermission(OrganizationPermission):
             return False
 
         project_scoped_access = _has_view_project_scoped_alert_write(request, view, organization)
+        if project_scoped_access is ALERT_MUTATION_LOOKUP_MISS:
+            if _has_any_team_scope(request, "alerts:write"):
+                raise ResourceDoesNotExist
+            return False
         if project_scoped_access is not None:
             return project_scoped_access
 
@@ -300,6 +314,10 @@ class OrganizationDetectorPermission(OrganizationPermission):
             return False
 
         project_scoped_access = _has_view_project_scoped_alert_write(request, view, organization)
+        if project_scoped_access is ALERT_MUTATION_LOOKUP_MISS:
+            if _has_any_team_scope(request, "alerts:write"):
+                raise ResourceDoesNotExist
+            return False
         if project_scoped_access is not None:
             return project_scoped_access
 

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -29,6 +29,7 @@ from sentry.models.orgauthtoken import is_org_auth_token_auth
 from sentry.models.project import Project
 from sentry.models.release import Release
 from sentry.models.releases.release_project import ReleaseProject
+from sentry.models.team import Team
 from sentry.organizations.services.organization import (
     RpcOrganization,
     RpcUserOrganizationContext,
@@ -212,30 +213,99 @@ class OrganizationSearchPermission(OrganizationPermission):
 class OrganizationDataExportPermission(OrganizationPermission):
     scope_map = {
         "GET": ["event:read", "event:write", "event:admin"],
-        "POST": ["event:read", "event:write", "event:admin"],
+        "POST": ["event:write", "event:admin"],
     }
+
+
+def _has_any_team_scope(request: Request, scope: str) -> bool:
+    if not request.access.team_ids_with_membership:
+        return False
+
+    teams = Team.objects.filter(id__in=request.access.team_ids_with_membership)
+    return any(request.access.has_team_scope(team, scope) for team in teams)
+
+
+ALERT_MUTATION_SCOPES = frozenset({"org:write", "alerts:write"})
+
+
+def _has_project_alert_write_access(request: Request, projects: Sequence[Project]) -> bool:
+    return bool(projects) and all(
+        request.access.has_any_project_scope(project, ALERT_MUTATION_SCOPES) for project in projects
+    )
+
+
+def _has_view_project_scoped_alert_write(
+    request: Request,
+    view: APIView,
+    organization: Organization | RpcOrganization | RpcUserOrganizationContext,
+) -> bool | None:
+    get_projects = getattr(view, "get_alert_mutation_projects", None)
+    if not callable(get_projects):
+        return None
+
+    projects = get_projects(request, organization)
+    if projects is None:
+        return None
+
+    return _has_project_alert_write_access(request, projects)
 
 
 class OrganizationAlertRulePermission(OrganizationPermission):
     scope_map = {
         "GET": ["org:read", "org:write", "org:admin", "alerts:read"],
-        # grant org:read permission, but raise permission denied if the members aren't allowed
-        # to create alerts and the user isn't a team admin
-        "POST": ["org:read", "org:write", "org:admin", "alerts:write"],
+        "POST": ["org:write", "org:admin", "alerts:write"],
         "PUT": ["org:write", "org:admin", "alerts:write"],
         "DELETE": ["org:write", "org:admin", "alerts:write"],
     }
+
+    def has_object_permission(
+        self,
+        request: Request,
+        view: APIView,
+        organization: Organization | RpcOrganization | RpcUserOrganizationContext,
+    ) -> bool:
+        if super().has_object_permission(request, view, organization):
+            return True
+
+        if request.method not in {"POST", "PUT", "DELETE"}:
+            return False
+
+        project_scoped_access = _has_view_project_scoped_alert_write(request, view, organization)
+        if project_scoped_access is not None:
+            return project_scoped_access
+
+        return bool(getattr(view, "allow_any_team_alert_write_fallback", False)) and (
+            _has_any_team_scope(request, "alerts:write")
+        )
 
 
 class OrganizationDetectorPermission(OrganizationPermission):
     scope_map = {
         "GET": ["org:read", "org:write", "org:admin", "alerts:read"],
-        # grant org:read permission, but raise permission denied if the members aren't allowed
-        # to create alerts and the user isn't a team admin
-        "POST": ["org:read", "org:write", "org:admin", "alerts:write"],
-        "PUT": ["org:read", "org:write", "org:admin", "alerts:write"],
-        "DELETE": ["org:read", "org:write", "org:admin", "alerts:write"],
+        "POST": ["org:write", "org:admin", "alerts:write"],
+        "PUT": ["org:write", "org:admin", "alerts:write"],
+        "DELETE": ["org:write", "org:admin", "alerts:write"],
     }
+
+    def has_object_permission(
+        self,
+        request: Request,
+        view: APIView,
+        organization: Organization | RpcOrganization | RpcUserOrganizationContext,
+    ) -> bool:
+        if super().has_object_permission(request, view, organization):
+            return True
+
+        if request.method not in {"POST", "PUT", "DELETE"}:
+            return False
+
+        project_scoped_access = _has_view_project_scoped_alert_write(request, view, organization)
+        if project_scoped_access is not None:
+            return project_scoped_access
+
+        return bool(getattr(view, "allow_any_team_alert_write_fallback", False)) and (
+            _has_any_team_scope(request, "alerts:write")
+        )
 
 
 class OrgAuthTokenPermission(OrganizationPermission):

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -46,6 +46,15 @@ class NoProjects(Exception):
     pass
 
 
+def _get_organization_id(
+    organization: Organization | RpcOrganization | RpcUserOrganizationContext,
+) -> int:
+    if isinstance(organization, RpcUserOrganizationContext):
+        return organization.organization.id
+
+    return organization.id
+
+
 class OrganizationPermission(DemoSafePermission):
     scope_map = {
         "GET": ["org:read", "org:write", "org:admin"],
@@ -293,37 +302,8 @@ class OrganizationAlertRulePermission(OrganizationPermission):
         )
 
 
-class OrganizationDetectorPermission(OrganizationPermission):
-    scope_map = {
-        "GET": ["org:read", "org:write", "org:admin", "alerts:read"],
-        "POST": ["org:write", "org:admin", "alerts:write"],
-        "PUT": ["org:write", "org:admin", "alerts:write"],
-        "DELETE": ["org:write", "org:admin", "alerts:write"],
-    }
-
-    def has_object_permission(
-        self,
-        request: Request,
-        view: APIView,
-        organization: Organization | RpcOrganization | RpcUserOrganizationContext,
-    ) -> bool:
-        if super().has_object_permission(request, view, organization):
-            return True
-
-        if request.method not in {"POST", "PUT", "DELETE"}:
-            return False
-
-        project_scoped_access = _has_view_project_scoped_alert_write(request, view, organization)
-        if project_scoped_access is ALERT_MUTATION_LOOKUP_MISS:
-            if _has_any_team_scope(request, "alerts:write"):
-                raise ResourceDoesNotExist
-            return False
-        if project_scoped_access is not None:
-            return project_scoped_access
-
-        return bool(getattr(view, "allow_any_team_alert_write_fallback", False)) and (
-            _has_any_team_scope(request, "alerts:write")
-        )
+class OrganizationDetectorPermission(OrganizationAlertRulePermission):
+    pass
 
 
 class OrgAuthTokenPermission(OrganizationPermission):

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -294,7 +294,7 @@ class OrganizationAlertRulePermission(OrganizationPermission):
             if _has_any_team_scope(request, "alerts:write"):
                 raise ResourceDoesNotExist
             return False
-        if project_scoped_access is not None:
+        if isinstance(project_scoped_access, bool):
             return project_scoped_access
 
         return bool(getattr(view, "allow_any_team_alert_write_fallback", False)) and (

--- a/src/sentry/incidents/endpoints/bases.py
+++ b/src/sentry/incidents/endpoints/bases.py
@@ -1,4 +1,3 @@
-from collections.abc import Sequence
 from typing import Any
 
 from rest_framework.exceptions import PermissionDenied
@@ -7,7 +6,12 @@ from rest_framework.request import Request
 
 from sentry import features
 from sentry.api.api_owners import ApiOwner
-from sentry.api.bases.organization import OrganizationAlertRulePermission, OrganizationEndpoint
+from sentry.api.bases.organization import (
+    ALERT_MUTATION_LOOKUP_MISS,
+    AlertMutationProjectLookup,
+    OrganizationAlertRulePermission,
+    OrganizationEndpoint,
+)
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.incidents.endpoints.serializers.utils import get_object_id_from_fake_id
@@ -102,7 +106,7 @@ class OrganizationAlertRuleEndpoint(OrganizationEndpoint):
         self,
         request: Request,
         organization: Organization | RpcOrganization | RpcUserOrganizationContext,
-    ) -> Sequence[Project] | None:
+    ) -> AlertMutationProjectLookup:
         if request.method not in {"PUT", "DELETE"}:
             return None
 
@@ -113,7 +117,7 @@ class OrganizationAlertRuleEndpoint(OrganizationEndpoint):
         try:
             validated_alert_rule_id = to_valid_int_id("alert_rule_id", raw_alert_rule_id)
         except RestFrameworkValidationError:
-            return None
+            return ALERT_MUTATION_LOOKUP_MISS
 
         try:
             organization_id = _get_organization_id(organization)
@@ -127,7 +131,7 @@ class OrganizationAlertRuleEndpoint(OrganizationEndpoint):
             Project.DoesNotExist,
             Project.MultipleObjectsReturned,
         ):
-            return None
+            return ALERT_MUTATION_LOOKUP_MISS
 
     def convert_args(
         self, request: Request, alert_rule_id: int, *args: Any, **kwargs: Any
@@ -215,7 +219,7 @@ class WorkflowEngineOrganizationAlertRuleEndpoint(OrganizationAlertRuleEndpoint)
         self,
         request: Request,
         organization: Organization | RpcOrganization | RpcUserOrganizationContext,
-    ) -> Sequence[Project] | None:
+    ) -> AlertMutationProjectLookup:
         projects = super().get_alert_mutation_projects(request, organization)
         if projects is not None:
             return projects
@@ -230,7 +234,7 @@ class WorkflowEngineOrganizationAlertRuleEndpoint(OrganizationAlertRuleEndpoint)
         try:
             validated_alert_rule_id = to_valid_int_id("alert_rule_id", raw_alert_rule_id)
         except RestFrameworkValidationError:
-            return None
+            return ALERT_MUTATION_LOOKUP_MISS
 
         organization_id = _get_organization_id(organization)
         ard = (
@@ -247,7 +251,7 @@ class WorkflowEngineOrganizationAlertRuleEndpoint(OrganizationAlertRuleEndpoint)
         try:
             detector_id = get_object_id_from_fake_id(validated_alert_rule_id)
         except ValueError:
-            return None
+            return ALERT_MUTATION_LOOKUP_MISS
 
         detector = (
             Detector.objects.select_related("project")
@@ -258,7 +262,7 @@ class WorkflowEngineOrganizationAlertRuleEndpoint(OrganizationAlertRuleEndpoint)
             .first()
         )
         if detector is None:
-            return None
+            return ALERT_MUTATION_LOOKUP_MISS
 
         return [detector.project]
 

--- a/src/sentry/incidents/endpoints/bases.py
+++ b/src/sentry/incidents/endpoints/bases.py
@@ -1,6 +1,8 @@
+from collections.abc import Sequence
 from typing import Any
 
 from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import ValidationError as RestFrameworkValidationError
 from rest_framework.request import Request
 
 from sentry import features
@@ -11,9 +13,20 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.incidents.endpoints.serializers.utils import get_object_id_from_fake_id
 from sentry.incidents.models.alert_rule import AlertRule
 from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.organizations.services.organization import RpcOrganization, RpcUserOrganizationContext
 from sentry.workflow_engine.endpoints.utils.ids import to_valid_int_id
 from sentry.workflow_engine.models.alertrule_detector import AlertRuleDetector
 from sentry.workflow_engine.models.detector import Detector
+
+
+def _get_organization_id(
+    organization: Organization | RpcOrganization | RpcUserOrganizationContext,
+) -> int:
+    if isinstance(organization, RpcUserOrganizationContext):
+        return organization.organization.id
+
+    return organization.id
 
 
 class OrganizationAlertRuleBaseEndpoint(OrganizationEndpoint):
@@ -23,6 +36,8 @@ class OrganizationAlertRuleBaseEndpoint(OrganizationEndpoint):
     Provides permission checking for alert creation that handles both
     org-level permissions and team admin project-scoped permissions.
     """
+
+    allow_any_team_alert_write_fallback = True
 
     def check_can_create_alert(self, request: Request, organization: Organization) -> None:
         """
@@ -82,6 +97,37 @@ class ProjectAlertRuleEndpoint(ProjectEndpoint):
 
 class OrganizationAlertRuleEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationAlertRulePermission,)
+
+    def get_alert_mutation_projects(
+        self,
+        request: Request,
+        organization: Organization | RpcOrganization | RpcUserOrganizationContext,
+    ) -> Sequence[Project] | None:
+        if request.method not in {"PUT", "DELETE"}:
+            return None
+
+        raw_alert_rule_id = self.kwargs.get("alert_rule_id")
+        if raw_alert_rule_id is None:
+            return None
+
+        try:
+            validated_alert_rule_id = to_valid_int_id("alert_rule_id", raw_alert_rule_id)
+        except RestFrameworkValidationError:
+            return None
+
+        try:
+            organization_id = _get_organization_id(organization)
+            alert_rule = AlertRule.objects.prefetch_related("projects").get(
+                organization_id=organization_id, id=validated_alert_rule_id
+            )
+            return [alert_rule.projects.get()]
+        except (
+            AlertRule.DoesNotExist,
+            AlertRule.MultipleObjectsReturned,
+            Project.DoesNotExist,
+            Project.MultipleObjectsReturned,
+        ):
+            return None
 
     def convert_args(
         self, request: Request, alert_rule_id: int, *args: Any, **kwargs: Any
@@ -164,6 +210,57 @@ class WorkflowEngineOrganizationAlertRuleEndpoint(OrganizationAlertRuleEndpoint)
     # Subclasses may set a per-method granular flag (e.g. for GET) that is OR'd
     # with the broad workflow-engine-rule-serializers flag.
     workflow_engine_method_flags: dict[str, str] = {}
+
+    def get_alert_mutation_projects(
+        self,
+        request: Request,
+        organization: Organization | RpcOrganization | RpcUserOrganizationContext,
+    ) -> Sequence[Project] | None:
+        projects = super().get_alert_mutation_projects(request, organization)
+        if projects is not None:
+            return projects
+
+        if request.method not in {"PUT", "DELETE"}:
+            return None
+
+        raw_alert_rule_id = self.kwargs.get("alert_rule_id")
+        if raw_alert_rule_id is None:
+            return None
+
+        try:
+            validated_alert_rule_id = to_valid_int_id("alert_rule_id", raw_alert_rule_id)
+        except RestFrameworkValidationError:
+            return None
+
+        organization_id = _get_organization_id(organization)
+        ard = (
+            AlertRuleDetector.objects.select_related("detector__project")
+            .filter(
+                alert_rule_id=validated_alert_rule_id,
+                detector__project__organization_id=organization_id,
+            )
+            .first()
+        )
+        if ard is not None:
+            return [ard.detector.project]
+
+        try:
+            detector_id = get_object_id_from_fake_id(validated_alert_rule_id)
+        except ValueError:
+            return None
+
+        detector = (
+            Detector.objects.select_related("project")
+            .filter(
+                id=detector_id,
+                project__organization_id=organization_id,
+            )
+            .first()
+        )
+        if detector is None:
+            return None
+
+        return [detector.project]
 
     def convert_args(
         self, request: Request, alert_rule_id: int, *args: Any, **kwargs: Any

--- a/src/sentry/incidents/endpoints/bases.py
+++ b/src/sentry/incidents/endpoints/bases.py
@@ -11,6 +11,7 @@ from sentry.api.bases.organization import (
     AlertMutationProjectLookup,
     OrganizationAlertRulePermission,
     OrganizationEndpoint,
+    _get_organization_id,
 )
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -22,15 +23,6 @@ from sentry.organizations.services.organization import RpcOrganization, RpcUserO
 from sentry.workflow_engine.endpoints.utils.ids import to_valid_int_id
 from sentry.workflow_engine.models.alertrule_detector import AlertRuleDetector
 from sentry.workflow_engine.models.detector import Detector
-
-
-def _get_organization_id(
-    organization: Organization | RpcOrganization | RpcUserOrganizationContext,
-) -> int:
-    if isinstance(organization, RpcUserOrganizationContext):
-        return organization.organization.id
-
-    return organization.id
 
 
 class OrganizationAlertRuleBaseEndpoint(OrganizationEndpoint):
@@ -221,7 +213,7 @@ class WorkflowEngineOrganizationAlertRuleEndpoint(OrganizationAlertRuleEndpoint)
         organization: Organization | RpcOrganization | RpcUserOrganizationContext,
     ) -> AlertMutationProjectLookup:
         projects = super().get_alert_mutation_projects(request, organization)
-        if projects is not None:
+        if projects is not None and projects is not ALERT_MUTATION_LOOKUP_MISS:
             return projects
 
         if request.method not in {"PUT", "DELETE"}:

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -13,6 +13,7 @@ from rest_framework.response import Response
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
+from sentry.api.bases.organization import ALERT_MUTATION_SCOPES
 from sentry.api.fields.actor import OwnerActorField
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework.project import ProjectField
@@ -321,6 +322,11 @@ def _check_project_access[T](
             return Response(status=status.HTTP_404_NOT_FOUND)
 
         if not request.access.has_project_access(project):
+            return Response(status=status.HTTP_403_FORBIDDEN)
+
+        if request.method in {"PUT", "DELETE"} and not request.access.has_any_project_scope(
+            project, ALERT_MUTATION_SCOPES
+        ):
             return Response(status=status.HTTP_403_FORBIDDEN)
 
         return func(self, request, organization, alert_rule)

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -51,6 +51,8 @@ from .alert_rule_trigger import AlertRuleTriggerSerializer
 
 logger = logging.getLogger(__name__)
 
+ALERT_RULE_PROJECT_SCOPES = ("project:read", "org:write", "org:admin", "alerts:write")
+
 
 class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRule]):
     """
@@ -62,7 +64,7 @@ class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRu
 
     environment = serializers.CharField(required=False, allow_null=True)
     projects = serializers.ListField(
-        child=ProjectField(scope="project:read"),
+        child=ProjectField(scope=ALERT_RULE_PROJECT_SCOPES),
         required=False,
         max_length=1,
     )

--- a/src/sentry/issues/endpoints/project_user_issue.py
+++ b/src/sentry/issues/endpoints/project_user_issue.py
@@ -180,7 +180,7 @@ class WebVitalsIssueDataSerializer(ProjectUserIssueRequestSerializer):
 class ProjectUserIssuePermission(ProjectPermission):
     scope_map = {
         "GET": [],
-        "POST": ["event:read", "event:write", "event:admin"],
+        "POST": ["event:write", "event:admin"],
         "PUT": [],
         "DELETE": [],
     }

--- a/src/sentry/monitors/endpoints/organization_monitor_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index.py
@@ -18,7 +18,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import NoProjects
-from sentry.api.bases.organization import OrganizationAlertRulePermission
+from sentry.api.bases.organization import ALERT_MUTATION_SCOPES, OrganizationAlertRulePermission
 from sentry.api.helpers.teams import get_teams
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
@@ -40,6 +40,7 @@ from sentry.db.models.query import in_iexact
 from sentry.incidents.endpoints.bases import OrganizationAlertRuleBaseEndpoint
 from sentry.models.environment import Environment
 from sentry.models.organization import Organization
+from sentry.models.project import Project
 from sentry.monitors.models import (
     DEFAULT_STATUS_ORDER,
     MONITOR_ENVIRONMENT_ORDERING,
@@ -326,11 +327,23 @@ class OrganizationMonitorIndexEndpoint(OrganizationAlertRuleBaseEndpoint):
 
         result = dict(validator.validated_data)
 
-        projects = self.get_projects(request, organization, include_all_accessible=True)
-        project_ids = [project.id for project in projects]
-
         monitor_guids = result.pop("ids", [])
-        monitors = list(Monitor.objects.filter(guid__in=monitor_guids, project_id__in=project_ids))
+        monitors = list(
+            Monitor.objects.filter(guid__in=monitor_guids, organization_id=organization.id)
+        )
+        projects_by_id = {
+            project.id: project
+            for project in Project.objects.filter(
+                id__in={monitor.project_id for monitor in monitors},
+                organization_id=organization.id,
+            )
+        }
+        if not all(
+            (project := projects_by_id.get(monitor.project_id))
+            and request.access.has_any_project_scope(project, ALERT_MUTATION_SCOPES)
+            for monitor in monitors
+        ):
+            return self.respond(status=403)
 
         status = result.get("status")
         # If enabling monitors, ensure we can assign all before moving forward

--- a/src/sentry/monitors/validators.py
+++ b/src/sentry/monitors/validators.py
@@ -74,6 +74,7 @@ IntervalNames = Literal["year", "month", "week", "day", "hour", "minute"]
 INTERVAL_NAMES = ("year", "month", "week", "day", "hour", "minute")
 
 CRONTAB_WHITESPACE = re.compile(r"\s+")
+MONITOR_PROJECT_SCOPES = ("project:read", "org:write", "org:admin", "alerts:write")
 
 # XXX(dcramer): @reboot is not supported (as it cannot be)
 NONSTANDARD_CRONTAB_SCHEDULES = {
@@ -312,7 +313,7 @@ class ConfigValidator(serializers.Serializer):
 @extend_schema_serializer(exclude_fields=["alert_rule"])
 class MonitorValidator(CamelSnakeSerializer):
     project = ProjectField(
-        scope="project:read",
+        scope=MONITOR_PROJECT_SCOPES,
         required=True,
         help_text="The project slug to associate the monitor to.",
     )

--- a/src/sentry/replays/endpoints/project_replay_details.py
+++ b/src/sentry/replays/endpoints/project_replay_details.py
@@ -23,7 +23,7 @@ class ReplayDetailsPermission(ProjectPermission):
         "GET": ["project:read", "project:write", "project:admin"],
         "POST": ["project:write", "project:admin"],
         "PUT": ["project:write", "project:admin"],
-        "DELETE": ["project:read", "project:write", "project:admin"],
+        "DELETE": ["event:admin"],
     }
 
 

--- a/src/sentry/replays/endpoints/project_replay_summary.py
+++ b/src/sentry/replays/endpoints/project_replay_summary.py
@@ -52,6 +52,13 @@ class ProjectReplaySummaryEndpoint(ProjectReplayEndpoint):
         "GET": ApiPublishStatus.EXPERIMENTAL,
         "POST": ApiPublishStatus.EXPERIMENTAL,
     }
+    readonly_mutation_scope_exceptions = {
+        "POST": (
+            "POST starts replay-summary generation but only derives summary data from existing "
+            "replay/event data. It intentionally follows replay read access instead of requiring "
+            "a separate write capability."
+        )
+    }
     permission_classes = (ReplaySummaryPermission,)
 
     def __init__(self, **kw) -> None:

--- a/src/sentry/seer/endpoints/organization_events_anomalies.py
+++ b/src/sentry/seer/endpoints/organization_events_anomalies.py
@@ -6,7 +6,7 @@ from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
-from sentry.api.bases.organization import OrganizationAlertRulePermission
+from sentry.api.bases.organization import ALERT_MUTATION_SCOPES, OrganizationAlertRulePermission
 from sentry.api.bases.organization_events import OrganizationEventsEndpointBase
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers.base import serialize
@@ -20,6 +20,7 @@ from sentry.apidocs.examples.organization_examples import OrganizationExamples
 from sentry.apidocs.parameters import GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.organization import Organization
+from sentry.models.project import Project
 from sentry.seer.anomaly_detection.get_historical_anomalies import (
     get_historical_anomaly_data_from_seer_preview,
 )
@@ -33,7 +34,21 @@ class OrganizationEventsAnomaliesEndpoint(OrganizationEventsEndpointBase):
     publish_status = {
         "POST": ApiPublishStatus.EXPERIMENTAL,
     }
+    allow_any_team_alert_write_fallback = True
+    # This POST previews anomaly-detection config used while authoring metric
+    # alerts/detectors, so it intentionally follows alert-write permissions.
     permission_classes = (OrganizationAlertRulePermission,)
+
+    def get_alert_mutation_projects(self, request: Request, organization: Organization):
+        raw_project_id = request.data.get("project_id")
+        if raw_project_id is None:
+            return None
+
+        try:
+            project_id = to_valid_int_id("project_id", raw_project_id)
+            return list(Project.objects.filter(id=project_id, organization_id=organization.id))
+        except Exception:
+            return None
 
     @extend_schema(
         operation_id="Identify anomalies in historical data",
@@ -89,9 +104,17 @@ class OrganizationEventsAnomaliesEndpoint(OrganizationEventsEndpointBase):
             )
 
         project_id = to_valid_int_id("project_id", raw_project_id)
-        projects = self.get_projects(request, organization, project_ids={project_id})
+        projects = list(Project.objects.filter(id=project_id, organization_id=organization.id))
         if not projects:
-            return Response({"detail": "Invalid project"}, status=400)
+            return Response(
+                {"detail": "You do not have permission to perform this action."},
+                status=403,
+            )
+        if not all(
+            request.access.has_any_project_scope(project, ALERT_MUTATION_SCOPES)
+            for project in projects
+        ):
+            return Response(status=403)
 
         anomalies = get_historical_anomaly_data_from_seer_preview(
             current_data=current_data,

--- a/src/sentry/seer/endpoints/organization_events_anomalies.py
+++ b/src/sentry/seer/endpoints/organization_events_anomalies.py
@@ -6,7 +6,11 @@ from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
-from sentry.api.bases.organization import ALERT_MUTATION_SCOPES, OrganizationAlertRulePermission
+from sentry.api.bases.organization import (
+    ALERT_MUTATION_SCOPES,
+    OrganizationAlertRulePermission,
+    _get_organization_id,
+)
 from sentry.api.bases.organization_events import OrganizationEventsEndpointBase
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers.base import serialize
@@ -21,6 +25,7 @@ from sentry.apidocs.parameters import GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.organization import Organization
 from sentry.models.project import Project
+from sentry.organizations.services.organization import RpcOrganization, RpcUserOrganizationContext
 from sentry.seer.anomaly_detection.get_historical_anomalies import (
     get_historical_anomaly_data_from_seer_preview,
 )
@@ -39,14 +44,22 @@ class OrganizationEventsAnomaliesEndpoint(OrganizationEventsEndpointBase):
     # alerts/detectors, so it intentionally follows alert-write permissions.
     permission_classes = (OrganizationAlertRulePermission,)
 
-    def get_alert_mutation_projects(self, request: Request, organization: Organization):
+    def get_alert_mutation_projects(
+        self,
+        request: Request,
+        organization: Organization | RpcOrganization | RpcUserOrganizationContext,
+    ):
         raw_project_id = request.data.get("project_id")
         if raw_project_id is None:
             return None
 
         try:
             project_id = to_valid_int_id("project_id", raw_project_id)
-            return list(Project.objects.filter(id=project_id, organization_id=organization.id))
+            return list(
+                Project.objects.filter(
+                    id=project_id, organization_id=_get_organization_id(organization)
+                )
+            )
         except Exception:
             return None
 

--- a/src/sentry/seer/endpoints/organization_events_anomalies.py
+++ b/src/sentry/seer/endpoints/organization_events_anomalies.py
@@ -1,4 +1,5 @@
 from drf_spectacular.utils import extend_schema
+from rest_framework.exceptions import ValidationError as RestFrameworkValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -7,7 +8,9 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import (
+    ALERT_MUTATION_LOOKUP_MISS,
     ALERT_MUTATION_SCOPES,
+    AlertMutationProjectLookup,
     OrganizationAlertRulePermission,
     _get_organization_id,
 )
@@ -48,20 +51,25 @@ class OrganizationEventsAnomaliesEndpoint(OrganizationEventsEndpointBase):
         self,
         request: Request,
         organization: Organization | RpcOrganization | RpcUserOrganizationContext,
-    ):
+    ) -> AlertMutationProjectLookup:
         raw_project_id = request.data.get("project_id")
         if raw_project_id is None:
             return None
 
         try:
             project_id = to_valid_int_id("project_id", raw_project_id)
-            return list(
-                Project.objects.filter(
-                    id=project_id, organization_id=_get_organization_id(organization)
-                )
+        except RestFrameworkValidationError:
+            return ALERT_MUTATION_LOOKUP_MISS
+
+        projects = list(
+            Project.objects.filter(
+                id=project_id, organization_id=_get_organization_id(organization)
             )
-        except Exception:
-            return None
+        )
+        if not projects:
+            return ALERT_MUTATION_LOOKUP_MISS
+
+        return projects
 
     @extend_schema(
         operation_id="Identify anomalies in historical data",

--- a/src/sentry/uptime/endpoints/organization_uptime_alert_preview_check.py
+++ b/src/sentry/uptime/endpoints/organization_uptime_alert_preview_check.py
@@ -30,6 +30,9 @@ logger = logging.getLogger(__name__)
 @cell_silo_endpoint
 class OrganizationUptimeAlertPreviewCheckEndpoint(OrganizationEndpoint):
     owner = ApiOwner.CRONS
+    allow_any_team_alert_write_fallback = True
+    # This POST previews monitor creation and validation, so it intentionally
+    # uses the same permission surface as creating the alert itself.
     permission_classes = (OrganizationAlertRulePermission,)
 
     publish_status = {

--- a/src/sentry/uptime/endpoints/organization_uptime_assertion_suggestions.py
+++ b/src/sentry/uptime/endpoints/organization_uptime_assertion_suggestions.py
@@ -50,6 +50,9 @@ class OrganizationUptimeAssertionSuggestionsEndpoint(OrganizationEndpoint):
     """
 
     owner = ApiOwner.CRONS
+    allow_any_team_alert_write_fallback = True
+    # This POST is part of the uptime monitor authoring flow, so it should
+    # track the same alert-write permission as the monitor it helps create.
     permission_classes = (OrganizationAlertRulePermission,)
 
     publish_status = {

--- a/src/sentry/workflow_engine/endpoints/organization_detector_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_details.py
@@ -27,6 +27,7 @@ from sentry.incidents.metric_issue_detector import schedule_update_project_confi
 from sentry.issues import grouptype
 from sentry.models.organization import Organization
 from sentry.models.project import Project
+from sentry.organizations.services.organization import RpcOrganization, RpcUserOrganizationContext
 from sentry.utils.audit import create_audit_entry
 from sentry.workflow_engine.endpoints.serializers.detector_serializer import DetectorSerializer
 from sentry.workflow_engine.endpoints.utils.ids import to_valid_int_id
@@ -37,6 +38,15 @@ from sentry.workflow_engine.endpoints.validators.utils import (
     get_unknown_detector_type_error,
 )
 from sentry.workflow_engine.models import Detector
+
+
+def _get_organization_id(
+    organization: Organization | RpcOrganization | RpcUserOrganizationContext,
+) -> int:
+    if isinstance(organization, RpcUserOrganizationContext):
+        return organization.organization.id
+
+    return organization.id
 
 
 def remove_detector(request: Request, organization: Organization, detector: Detector) -> Response:
@@ -95,6 +105,37 @@ def get_detector_validator(
 @cell_silo_endpoint
 @extend_schema(tags=["Monitors"])
 class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
+    def get_alert_mutation_projects(
+        self,
+        request: Request,
+        organization: Organization | RpcOrganization | RpcUserOrganizationContext,
+    ) -> list[Project] | None:
+        if request.method not in {"PUT", "DELETE"}:
+            return None
+
+        raw_detector_id = self.kwargs.get("detector_id")
+        if raw_detector_id is None:
+            return None
+
+        try:
+            validated_detector_id = to_valid_int_id("detector_id", raw_detector_id)
+        except ValidationError:
+            return None
+
+        organization_id = _get_organization_id(organization)
+        detector = (
+            Detector.objects.select_related("project")
+            .filter(
+                id=validated_detector_id,
+                project__organization_id=organization_id,
+            )
+            .first()
+        )
+        if detector is None:
+            return None
+
+        return [detector.project]
+
     def convert_args(
         self, request: Request, detector_id: str, *args: Any, **kwargs: Any
     ) -> tuple[tuple[Any, ...], dict[str, Organization | Detector]]:

--- a/src/sentry/workflow_engine/endpoints/organization_detector_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_details.py
@@ -11,6 +11,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import OrganizationDetectorPermission, OrganizationEndpoint
+from sentry.api.bases.organization import ALERT_MUTATION_LOOKUP_MISS, AlertMutationProjectLookup
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.apidocs.constants import (
@@ -109,7 +110,7 @@ class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
         self,
         request: Request,
         organization: Organization | RpcOrganization | RpcUserOrganizationContext,
-    ) -> list[Project] | None:
+    ) -> AlertMutationProjectLookup:
         if request.method not in {"PUT", "DELETE"}:
             return None
 
@@ -120,7 +121,7 @@ class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
         try:
             validated_detector_id = to_valid_int_id("detector_id", raw_detector_id)
         except ValidationError:
-            return None
+            return ALERT_MUTATION_LOOKUP_MISS
 
         organization_id = _get_organization_id(organization)
         detector = (
@@ -132,7 +133,7 @@ class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
             .first()
         )
         if detector is None:
-            return None
+            return ALERT_MUTATION_LOOKUP_MISS
 
         return [detector.project]
 

--- a/src/sentry/workflow_engine/endpoints/organization_detector_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_details.py
@@ -11,7 +11,11 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import OrganizationDetectorPermission, OrganizationEndpoint
-from sentry.api.bases.organization import ALERT_MUTATION_LOOKUP_MISS, AlertMutationProjectLookup
+from sentry.api.bases.organization import (
+    ALERT_MUTATION_LOOKUP_MISS,
+    AlertMutationProjectLookup,
+    _get_organization_id,
+)
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.apidocs.constants import (
@@ -39,15 +43,6 @@ from sentry.workflow_engine.endpoints.validators.utils import (
     get_unknown_detector_type_error,
 )
 from sentry.workflow_engine.models import Detector
-
-
-def _get_organization_id(
-    organization: Organization | RpcOrganization | RpcUserOrganizationContext,
-) -> int:
-    if isinstance(organization, RpcUserOrganizationContext):
-        return organization.organization.id
-
-    return organization.id
 
 
 def remove_detector(request: Request, organization: Organization, detector: Detector) -> Response:

--- a/src/sentry/workflow_engine/endpoints/organization_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_index.py
@@ -150,6 +150,7 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
         "DELETE": ApiPublishStatus.PUBLIC,
     }
     owner = ApiOwner.ISSUES
+    allow_any_team_alert_write_fallback = True
 
     permission_classes = (OrganizationDetectorPermission,)
 

--- a/tests/sentry/data_export/endpoints/test_data_export.py
+++ b/tests/sentry/data_export/endpoints/test_data_export.py
@@ -2,12 +2,17 @@ from __future__ import annotations
 
 from typing import Any
 
+from django.urls import reverse
+
 from sentry.data_export.base import ExportQueryType, ExportStatus
 from sentry.data_export.models import ExportedData
 from sentry.data_export.writers import OutputMode
+from sentry.models.apitoken import ApiToken
 from sentry.search.utils import parse_datetime_string
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.silo import assume_test_silo_mode
 from sentry.utils.snuba import MAX_FIELDS
 
 
@@ -24,6 +29,7 @@ class DataExportTest(APITestCase):
         )
         self.create_member(user=self.user, organization=self.org, teams=[self.team])
         self.login_as(user=self.user)
+        self.url = reverse(self.endpoint, args=[self.org.slug])
 
     def make_payload(
         self, payload_type: str, extras: dict[str, Any] | None = None, overwrite: bool = False
@@ -56,6 +62,10 @@ class DataExportTest(APITestCase):
                 payload["query_info"].update(extras)
         return payload
 
+    def _create_token(self, scope: str) -> ApiToken:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            return ApiToken.objects.create(user=self.user, scope_list=[scope])
+
     def test_authorization(self) -> None:
         payload = self.make_payload("issue")
 
@@ -77,6 +87,34 @@ class DataExportTest(APITestCase):
         # Without project permissions, the endpoint should 403
         with self.feature("organizations:discover-query"):
             self.get_error_response(self.org.slug, status_code=403, **modified_payload)
+
+    def test_post_requires_event_write_scope_for_tokens(self) -> None:
+        payload = self.make_payload("issue")
+        token = self._create_token("event:read")
+
+        with self.feature("organizations:discover-query"):
+            response = self.client.post(
+                self.url,
+                data=payload,
+                format="json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 403
+
+    def test_post_allows_event_write_scope_for_tokens(self) -> None:
+        payload = self.make_payload("issue")
+        token = self._create_token("event:write")
+
+        with self.feature("organizations:discover-query"):
+            response = self.client.post(
+                self.url,
+                data=payload,
+                format="json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 201
 
     def test_new_export(self) -> None:
         """

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -1144,6 +1144,26 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
 
         assert response.status_code == 403
 
+    def test_update_missing_target_preserves_404_for_project_scoped_alerts_write(self) -> None:
+        team_admin_user = self.create_user()
+        self.create_member(
+            user=team_admin_user,
+            organization=self.organization,
+            role="member",
+            team_roles=[(self.team, "admin")],
+        )
+        self.organization.update_option("sentry:alerts_member_write", False)
+        self.login_as(team_admin_user)
+
+        with self.feature("organizations:incidents"):
+            response = self.client.put(
+                reverse(self.endpoint, args=[self.organization.slug, 999999999]),
+                data=self.valid_params,
+                format="json",
+            )
+
+        assert response.status_code == 404
+
     def test_simple(self) -> None:
         self.create_member(
             user=self.user, organization=self.organization, role="owner", teams=[self.team]
@@ -2822,6 +2842,24 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase):
             )
 
         assert response.status_code == 403
+
+    def test_delete_missing_target_preserves_404_for_project_scoped_alerts_write(self) -> None:
+        team_admin_user = self.create_user()
+        self.create_member(
+            user=team_admin_user,
+            organization=self.organization,
+            role="member",
+            team_roles=[(self.team, "admin")],
+        )
+        self.organization.update_option("sentry:alerts_member_write", False)
+        self.login_as(team_admin_user)
+
+        with self.feature("organizations:incidents"):
+            response = self.client.delete(
+                reverse(self.endpoint, args=[self.organization.slug, 999999999]),
+            )
+
+        assert response.status_code == 404
 
     def test_simple(self) -> None:
         self.create_member(

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -11,6 +11,7 @@ import responses
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.test import override_settings
+from django.urls import reverse
 from httpx import HTTPError
 from rest_framework.exceptions import ErrorDetail
 from rest_framework.response import Response
@@ -45,6 +46,7 @@ from sentry.integrations.slack.tasks.find_channel_id_for_alert_rule import (
     find_channel_id_for_alert_rule,
 )
 from sentry.integrations.slack.utils.channel import SlackChannelIdData
+from sentry.models.apitoken import ApiToken
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.project import Project
@@ -85,6 +87,10 @@ class AlertRuleDetailsBase(AlertRuleBase):
     __test__ = Abstract(__module__, __qualname__)
 
     endpoint = "sentry-api-0-organization-alert-rule-details"
+
+    def _create_token(self, scope: str, user=None) -> ApiToken:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            return ApiToken.objects.create(user=user or self.user, scope_list=[scope])
 
     @patch(
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
@@ -1045,6 +1051,98 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
 
 class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
     method = "put"
+
+    def test_team_admin_can_update_with_project_scoped_alerts_write(self) -> None:
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+        team_admin_user = self.create_user()
+        self.create_member(
+            user=team_admin_user,
+            organization=self.organization,
+            role="member",
+            team_roles=[(self.team, "admin")],
+        )
+        self.organization.update_option("sentry:alerts_member_write", False)
+        self.login_as(team_admin_user)
+
+        with self.feature("organizations:incidents"):
+            response = self.client.put(
+                reverse(self.endpoint, args=[self.organization.slug, self.alert_rule.id]),
+                data=self.valid_params,
+                format="json",
+            )
+
+        assert response.status_code == 200
+        self.alert_rule.refresh_from_db()
+        assert self.alert_rule.name == self.valid_params["name"]
+
+    def test_update_requires_alerts_write_scope_for_tokens(self) -> None:
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+        token = self._create_token("org:read")
+
+        with self.feature("organizations:incidents"):
+            response = self.client.put(
+                reverse(self.endpoint, args=[self.organization.slug, self.alert_rule.id]),
+                data=self.valid_params,
+                format="json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 403
+
+    def test_update_allows_alerts_write_scope_for_tokens(self) -> None:
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+        token = self._create_token("alerts:write")
+
+        with self.feature("organizations:incidents"):
+            response = self.client.put(
+                reverse(self.endpoint, args=[self.organization.slug, self.alert_rule.id]),
+                data=self.valid_params,
+                format="json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 200
+        self.alert_rule.refresh_from_db()
+        assert self.alert_rule.name == self.valid_params["name"]
+
+    def test_update_denies_alerts_write_scope_for_other_team_projects(self) -> None:
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+        team_admin_user = self.create_user()
+        self.create_member(
+            user=team_admin_user,
+            organization=self.organization,
+            role="member",
+            team_roles=[(self.team, "admin")],
+        )
+        self.organization.update_option("sentry:alerts_member_write", False)
+
+        other_team = self.create_team(organization=self.organization, name="other-team")
+        other_project = self.create_project(
+            organization=self.organization, teams=[other_team], name="other-project"
+        )
+        other_alert_rule = self.new_alert_rule(
+            data={**deepcopy(self.alert_rule_dict), "projects": [other_project.slug]}
+        )
+
+        token = self._create_token("alerts:write", user=team_admin_user)
+
+        with self.feature("organizations:incidents"):
+            response = self.client.put(
+                reverse(self.endpoint, args=[self.organization.slug, other_alert_rule.id]),
+                data={**self.valid_params, "projects": [other_project.slug]},
+                format="json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 403
 
     def test_simple(self) -> None:
         self.create_member(
@@ -2672,6 +2770,58 @@ class AlertRuleDetailsSentryAppPutEndpointTest(AlertRuleDetailsBase):
 
 class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase):
     method = "delete"
+
+    def test_team_admin_can_delete_workflow_engine_detector_with_project_scoped_alerts_write(
+        self,
+    ) -> None:
+        team_admin_user = self.create_user()
+        self.create_member(
+            user=team_admin_user,
+            organization=self.organization,
+            role="member",
+            team_roles=[(self.team, "admin")],
+        )
+        self.organization.update_option("sentry:alerts_member_write", False)
+        self.login_as(team_admin_user)
+
+        detector = self.create_detector(project=self.project, type=MetricIssue.slug)
+        data_source = self.create_data_source()
+        self.create_data_source_detector(data_source, detector)
+        fake_detector_id = get_fake_id_from_object_id(detector.id)
+
+        with self.feature({"organizations:workflow-engine-rule-serializers": True}):
+            self.get_success_response(self.organization.slug, fake_detector_id, status_code=204)
+
+    def test_delete_denies_alerts_write_scope_for_other_team_projects(self) -> None:
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+        team_admin_user = self.create_user()
+        self.create_member(
+            user=team_admin_user,
+            organization=self.organization,
+            role="member",
+            team_roles=[(self.team, "admin")],
+        )
+        self.organization.update_option("sentry:alerts_member_write", False)
+
+        other_team = self.create_team(organization=self.organization, name="other-team")
+        other_project = self.create_project(
+            organization=self.organization, teams=[other_team], name="other-project"
+        )
+        other_alert_rule = self.new_alert_rule(
+            data={**deepcopy(self.alert_rule_dict), "projects": [other_project.slug]}
+        )
+
+        token = self._create_token("alerts:write", user=team_admin_user)
+
+        with self.feature("organizations:incidents"):
+            response = self.client.delete(
+                reverse(self.endpoint, args=[self.organization.slug, other_alert_rule.id]),
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 403
 
     def test_simple(self) -> None:
         self.create_member(

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -1077,6 +1077,36 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         self.alert_rule.refresh_from_db()
         assert self.alert_rule.name == self.valid_params["name"]
 
+    @with_feature("organizations:workflow-engine-rule-serializers")
+    def test_team_admin_can_reach_workflow_engine_detector_update_with_project_scoped_alerts_write(
+        self,
+    ) -> None:
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+        team_admin_user = self.create_user()
+        self.create_member(
+            user=team_admin_user,
+            organization=self.organization,
+            role="member",
+            team_roles=[(self.team, "admin")],
+        )
+        self.organization.update_option("sentry:alerts_member_write", False)
+        self.login_as(team_admin_user)
+
+        ard = AlertRuleDetector.objects.get(alert_rule_id=self.alert_rule.id)
+        detector = Detector.objects.get(id=ard.detector_id)
+        fake_detector_id = get_fake_id_from_object_id(detector.id)
+
+        with self.feature("organizations:incidents"), outbox_runner():
+            response = self.client.put(
+                reverse(self.endpoint, args=[self.organization.slug, fake_detector_id]),
+                data=self.valid_params,
+                format="json",
+            )
+
+        assert response.status_code == 400
+
     def test_update_requires_alerts_write_scope_for_tokens(self) -> None:
         self.create_member(
             user=self.user, organization=self.organization, role="owner", teams=[self.team]

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -40,6 +40,7 @@ from sentry.integrations.slack.tasks.find_channel_id_for_alert_rule import (
     find_channel_id_for_alert_rule,
 )
 from sentry.integrations.slack.utils.channel import SlackChannelIdData
+from sentry.models.apitoken import ApiToken
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.projectteam import ProjectTeam
@@ -417,6 +418,10 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         )
         self.login_as(self.user)
 
+    def _create_token(self, scope: str) -> ApiToken:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            return ApiToken.objects.create(user=self.user, scope_list=[scope])
+
     def test_simple(self) -> None:
         with (
             outbox_runner(),
@@ -440,6 +445,39 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             resp.renderer_context["request"].META["REMOTE_ADDR"]
             == list(audit_log_entry)[0].ip_address
         )
+
+    def test_create_requires_alerts_write_scope_for_tokens(self) -> None:
+        team = self.create_team(organization=self.organization, members=[self.user])
+        ProjectTeam.objects.create(project=self.project, team=team)
+        token = self._create_token("org:read")
+
+        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+            response = self.client.post(
+                f"/api/0/organizations/{self.organization.slug}/alert-rules/",
+                data=self.alert_rule_dict,
+                format="json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 403
+
+    def test_create_allows_alerts_write_scope_for_tokens(self) -> None:
+        team = self.create_team(organization=self.organization, members=[self.user])
+        ProjectTeam.objects.create(project=self.project, team=team)
+        token = self._create_token("alerts:write")
+
+        with (
+            outbox_runner(),
+            self.feature(["organizations:incidents", "organizations:performance-view"]),
+        ):
+            response = self.client.post(
+                f"/api/0/organizations/{self.organization.slug}/alert-rules/",
+                data=self.alert_rule_dict,
+                format="json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 201
 
     @patch("sentry.incidents.serializers.alert_rule.are_any_projects_error_upsampled")
     def test_count_automatically_converted_to_upsampled_count_for_upsampled_projects(

--- a/tests/sentry/issues/endpoints/test_project_user_issue.py
+++ b/tests/sentry/issues/endpoints/test_project_user_issue.py
@@ -6,9 +6,11 @@ from django.urls import reverse
 
 from sentry.issues.grouptype import WebVitalsGroup
 from sentry.issues.producer import PayloadType
+from sentry.models.apitoken import ApiToken
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
-from sentry.testutils.silo import cell_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, cell_silo_test
 
 
 @cell_silo_test
@@ -30,6 +32,10 @@ class ProjectUserIssueEndpointTest(APITestCase):
                 "project_id_or_slug": self.project.slug,
             },
         )
+
+    def _create_token(self, scope: str) -> ApiToken:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            return ApiToken.objects.create(user=self.user, scope_list=[scope])
 
     @with_feature("organizations:performance-web-vitals-seer-suggestions")
     def test_create_web_vitals_issue_success(self) -> None:
@@ -109,6 +115,48 @@ class ProjectUserIssueEndpointTest(APITestCase):
         )
 
         assert response.status_code == 404
+
+    @with_feature("organizations:performance-web-vitals-seer-suggestions")
+    def test_create_web_vitals_issue_requires_event_write_scope(self) -> None:
+        token = self._create_token("event:read")
+
+        response = self.client.post(
+            self.url,
+            data={
+                "transaction": "/test-transaction",
+                "issueType": WebVitalsGroup.slug,
+                "score": 75,
+                "value": 1000,
+                "vital": "lcp",
+            },
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {token.token}",
+        )
+
+        assert response.status_code == 403
+
+    @with_feature("organizations:performance-web-vitals-seer-suggestions")
+    def test_create_web_vitals_issue_allows_event_write_scope(self) -> None:
+        token = self._create_token("event:write")
+
+        with patch(
+            "sentry.issues.endpoints.project_user_issue.produce_occurrence_to_kafka"
+        ) as mock_produce:
+            response = self.client.post(
+                self.url,
+                data={
+                    "transaction": "/test-transaction",
+                    "issueType": WebVitalsGroup.slug,
+                    "score": 75,
+                    "value": 1000,
+                    "vital": "lcp",
+                },
+                format="json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 200
+        assert response.data == {"event_id": mock_produce.call_args[1]["occurrence"].event_id}
 
     @with_feature("organizations:performance-web-vitals-seer-suggestions")
     def test_missing_required_fields(self) -> None:

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
@@ -6,20 +6,24 @@ from unittest.mock import MagicMock, patch
 
 from django.conf import settings
 from django.test.utils import override_settings
+from django.urls import reverse
 from rest_framework.exceptions import ErrorDetail
 
 from sentry import audit_log
 from sentry.analytics.events.cron_monitor_created import CronMonitorCreated, FirstCronMonitorCreated
 from sentry.constants import ObjectStatus
+from sentry.models.apitoken import ApiToken
 from sentry.models.projectteam import ProjectTeam
 from sentry.models.rule import Rule, RuleSource
 from sentry.monitors.models import Monitor, MonitorStatus, ScheduleType, is_monitor_muted
 from sentry.monitors.utils import get_detector_for_monitor
 from sentry.quotas.base import SeatAssignmentResult
+from sentry.silo.base import SiloMode
 from sentry.testutils.asserts import assert_org_audit_log_exists
 from sentry.testutils.cases import MonitorTestCase
 from sentry.testutils.helpers.analytics import assert_any_analytics_event
 from sentry.testutils.outbox import outbox_runner
+from sentry.testutils.silo import assume_test_silo_mode
 from sentry.utils.outcomes import Outcome
 from sentry.utils.slug import DEFAULT_SLUG_ERROR_MESSAGE
 
@@ -438,6 +442,49 @@ class CreateOrganizationMonitorTest(MonitorTestCase):
         super().setUp()
         self.login_as(self.user)
 
+    def _create_token(self, scope: str) -> ApiToken:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            return ApiToken.objects.create(user=self.user, scope_list=[scope])
+
+    def test_create_requires_alerts_write_scope_for_tokens(self) -> None:
+        token = self._create_token("org:read")
+        data = {
+            "project": self.project.slug,
+            "name": "My Monitor",
+            "type": "cron_job",
+            "owner": f"user:{self.user.id}",
+            "config": {"schedule_type": "crontab", "schedule": "@daily"},
+        }
+
+        response = self.client.post(
+            reverse(self.endpoint, args=[self.organization.slug]),
+            data=data,
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {token.token}",
+        )
+
+        assert response.status_code == 403
+
+    def test_create_allows_alerts_write_scope_for_tokens(self) -> None:
+        token = self._create_token("alerts:write")
+        data = {
+            "project": self.project.slug,
+            "name": "My Monitor",
+            "type": "cron_job",
+            "owner": f"user:{self.user.id}",
+            "config": {"schedule_type": "crontab", "schedule": "@daily"},
+        }
+
+        with outbox_runner():
+            response = self.client.post(
+                reverse(self.endpoint, args=[self.organization.slug]),
+                data=data,
+                format="json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 201
+
     @patch("sentry.analytics.record")
     def test_simple(self, mock_record: MagicMock) -> None:
         data = {
@@ -841,6 +888,10 @@ class BulkEditOrganizationMonitorTest(MonitorTestCase):
         super().setUp()
         self.login_as(self.user)
 
+    def _create_token(self, scope: str, user=None) -> ApiToken:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            return ApiToken.objects.create(user=user or self.user, scope_list=[scope])
+
     def test_valid_ids(self) -> None:
         monitor_one = self._create_monitor(slug="monitor_one")
         self._create_monitor(slug="monitor_two")
@@ -934,6 +985,35 @@ class BulkEditOrganizationMonitorTest(MonitorTestCase):
         assert monitor_one.status == ObjectStatus.ACTIVE
         assert monitor_two.status == ObjectStatus.ACTIVE
 
+    def test_bulk_edit_denies_alerts_write_scope_for_other_team_projects(self) -> None:
+        team_admin_user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=team_admin_user,
+            organization=self.organization,
+            role="member",
+            team_roles=[(self.team, "admin")],
+        )
+        self.organization.update_option("sentry:alerts_member_write", False)
+
+        other_team = self.create_team(organization=self.organization, name="other-team")
+        other_project = self.create_project(
+            organization=self.organization, teams=[other_team], name="other-project"
+        )
+        other_monitor = self._create_monitor(slug="other-monitor")
+        other_monitor.update(project_id=other_project.id)
+        token = self._create_token("alerts:write", user=team_admin_user)
+
+        response = self.client.put(
+            reverse(self.endpoint, args=[self.organization.slug]),
+            data={"ids": [other_monitor.guid], "status": "disabled"},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {token.token}",
+        )
+
+        assert response.status_code == 403
+        other_monitor.refresh_from_db()
+        assert other_monitor.status == ObjectStatus.ACTIVE
+
     @patch("sentry.quotas.backend.check_assign_seats")
     def test_enable_no_quota(self, check_assign_seats: MagicMock) -> None:
         monitor_one = self._create_monitor(slug="monitor_one", status=ObjectStatus.DISABLED)
@@ -977,9 +1057,7 @@ class BulkEditOrganizationMonitorTest(MonitorTestCase):
             "ids": [monitor.guid],
             "isMuted": True,
         }
-        response = self.get_success_response(self.organization.slug, **data)
-        assert response.status_code == 200
-        assert response.data == {"updated": [], "errored": []}
+        self.get_error_response(self.organization.slug, status_code=403, **data)
 
         monitor.refresh_from_db()
         env.refresh_from_db()

--- a/tests/sentry/replays/endpoints/test_project_replay_details.py
+++ b/tests/sentry/replays/endpoints/test_project_replay_details.py
@@ -5,13 +5,16 @@ from uuid import uuid4
 
 from django.urls import reverse
 
+from sentry.models.apitoken import ApiToken
 from sentry.models.files.file import File
 from sentry.replays.lib import kafka
 from sentry.replays.lib.storage import RecordingSegmentStorageMeta, storage
 from sentry.replays.models import ReplayRecordingSegment
 from sentry.replays.testutils import assert_expected_response, mock_expected_response, mock_replay
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase, ReplaysSnubaTestCase
 from sentry.testutils.helpers import TaskRunner
+from sentry.testutils.silo import assume_test_silo_mode
 from sentry.utils import kafka_config
 
 REPLAYS_FEATURES = {"organizations:session-replay": True}
@@ -191,6 +194,66 @@ class ProjectReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
             assert False, "File was not deleted."
         except File.DoesNotExist:
             pass
+
+    def test_delete_requires_event_admin_scope_for_api_tokens(self) -> None:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            token = ApiToken.objects.create(user=self.user, scope_list=["event:read"])
+
+        with self.feature(REPLAYS_FEATURES):
+            response = self.client.delete(
+                self.url, HTTP_AUTHORIZATION=f"Bearer {token.token}", format="json"
+            )
+
+        assert response.status_code == 403
+
+    def test_delete_denies_project_write_scope_for_api_tokens(self) -> None:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            token = ApiToken.objects.create(user=self.user, scope_list=["project:write"])
+
+        with self.feature(REPLAYS_FEATURES):
+            response = self.client.delete(
+                self.url, HTTP_AUTHORIZATION=f"Bearer {token.token}", format="json"
+            )
+
+        assert response.status_code == 403
+
+    def test_delete_denies_event_write_scope_for_api_tokens(self) -> None:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            token = ApiToken.objects.create(user=self.user, scope_list=["event:write"])
+
+        with self.feature(REPLAYS_FEATURES):
+            with patch("sentry.replays.endpoints.project_replay_details.delete_replay.delay"):
+                response = self.client.delete(
+                    self.url, HTTP_AUTHORIZATION=f"Bearer {token.token}", format="json"
+                )
+
+        assert response.status_code == 403
+
+    def test_delete_allows_event_admin_scope_for_api_tokens(self) -> None:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            token = ApiToken.objects.create(user=self.user, scope_list=["event:admin"])
+
+        with self.feature(REPLAYS_FEATURES):
+            with patch("sentry.replays.endpoints.project_replay_details.delete_replay.delay"):
+                response = self.client.delete(
+                    self.url, HTTP_AUTHORIZATION=f"Bearer {token.token}", format="json"
+                )
+
+        assert response.status_code == 204
+
+    def test_delete_requires_event_admin_scope_for_members_without_event_admin(self) -> None:
+        self.organization.update_option("sentry:events_member_admin", False)
+
+        member_user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=member_user, organization=self.organization, role="member", teams=[]
+        )
+        self.login_as(user=member_user)
+
+        with self.feature(REPLAYS_FEATURES):
+            response = self.client.delete(self.url)
+
+        assert response.status_code == 403
 
     def test_delete_replay_from_clickhouse_data(self) -> None:
         """Test deleting files uploaded through the direct storage interface."""

--- a/tests/sentry/replays/endpoints/test_project_replay_summary.py
+++ b/tests/sentry/replays/endpoints/test_project_replay_summary.py
@@ -7,8 +7,11 @@ import requests
 from django.conf import settings
 from django.urls import reverse
 
+from sentry.models.apitoken import ApiToken
 from sentry.replays.testutils import mock_replay
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import SnubaTestCase, TransactionTestCase
+from sentry.testutils.silo import assume_test_silo_mode
 from sentry.utils import json
 
 
@@ -139,6 +142,41 @@ class ProjectReplaySummaryTestCase(
         assert body["organization_id"] == self.organization.id
         assert body["project_id"] == self.project.id
         assert body.get("temperature") is None
+
+    @patch("sentry.replays.endpoints.project_replay_summary.make_replay_summary_start_request")
+    def test_post_allows_event_read_scope_for_api_tokens(self, mock_seer_request: Mock) -> None:
+        mock_seer_request.return_value = MockSeerResponse(200, json_data={"hello": "world"})
+        self.store_replay()
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            token = ApiToken.objects.create(user=self.user, scope_list=["event:read"])
+
+        with self.feature(self.features):
+            response = self.client.post(
+                self.url,
+                data={"num_segments": 1},
+                content_type="application/json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 200
+        assert response.json() == {"hello": "world"}
+
+    def test_post_requires_replay_read_scope_for_api_tokens(self) -> None:
+        self.store_replay()
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            token = ApiToken.objects.create(user=self.user, scope_list=["org:read"])
+
+        with self.feature(self.features):
+            response = self.client.post(
+                self.url,
+                data={"num_segments": 1},
+                content_type="application/json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 403
 
     def test_post_replay_not_found(self) -> None:
         with self.feature(self.features):

--- a/tests/sentry/seer/endpoints/test_organization_events_anomalies.py
+++ b/tests/sentry/seer/endpoints/test_organization_events_anomalies.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import orjson
@@ -12,6 +13,7 @@ from sentry.incidents.models.alert_rule import (
     AlertRuleThresholdType,
 )
 from sentry.models.apitoken import ApiToken
+from sentry.organizations.services.organization import RpcOrganization, RpcUserOrganizationContext
 from sentry.seer.anomaly_detection.types import (
     Anomaly,
     AnomalyDetectionConfig,
@@ -20,6 +22,7 @@ from sentry.seer.anomaly_detection.types import (
     TimeSeriesPoint,
 )
 from sentry.seer.anomaly_detection.utils import translate_direction
+from sentry.seer.endpoints.organization_events_anomalies import OrganizationEventsAnomaliesEndpoint
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
@@ -89,6 +92,15 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
                 ),
             ],
         )
+
+    def test_get_alert_mutation_projects_accepts_rpc_org_context(self) -> None:
+        endpoint = OrganizationEventsAnomaliesEndpoint()
+        request = SimpleNamespace(data={"project_id": str(self.project.id)})
+        organization = RpcUserOrganizationContext(
+            organization=RpcOrganization(id=self.organization.id)
+        )
+
+        assert endpoint.get_alert_mutation_projects(request, organization) == [self.project]
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:incidents")

--- a/tests/sentry/seer/endpoints/test_organization_events_anomalies.py
+++ b/tests/sentry/seer/endpoints/test_organization_events_anomalies.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import orjson
+from django.urls import reverse
 from urllib3 import HTTPResponse
 from urllib3.exceptions import TimeoutError
 
@@ -10,6 +11,7 @@ from sentry.incidents.models.alert_rule import (
     AlertRuleSensitivity,
     AlertRuleThresholdType,
 )
+from sentry.models.apitoken import ApiToken
 from sentry.seer.anomaly_detection.types import (
     Anomaly,
     AnomalyDetectionConfig,
@@ -18,10 +20,12 @@ from sentry.seer.anomaly_detection.types import (
     TimeSeriesPoint,
 )
 from sentry.seer.anomaly_detection.utils import translate_direction
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.outbox import outbox_runner
+from sentry.testutils.silo import assume_test_silo_mode
 
 
 @freeze_time()
@@ -43,6 +47,10 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
     historical_timestamp_2 = (four_weeks_ago + timedelta(days=10)).timestamp()
     current_timestamp_1 = one_week_ago.timestamp()
     current_timestamp_2 = (one_week_ago + timedelta(minutes=10)).timestamp()
+
+    def _create_token(self, scope: str, user=None) -> ApiToken:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            return ApiToken.objects.create(user=user or self.user, scope_list=[scope])
 
     def get_test_data(self, project_id: int) -> dict:
         return {
@@ -156,6 +164,94 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
 
         assert mock_seer_request.call_count == 1
         assert resp.data == seer_return_value["timeseries"]
+
+    @with_feature("organizations:anomaly-detection-alerts")
+    @with_feature("organizations:incidents")
+    @patch(
+        "sentry.seer.anomaly_detection.get_historical_anomalies.seer_anomaly_detection_connection_pool.urlopen"
+    )
+    def test_alerts_write_scope_allows_post(self, mock_seer_request: MagicMock) -> None:
+        mock_seer_request.return_value = HTTPResponse(
+            orjson.dumps(
+                DetectAnomaliesResponse(
+                    success=True,
+                    message="",
+                    timeseries=[
+                        TimeSeriesPoint(
+                            timestamp=self.current_timestamp_1,
+                            value=2,
+                            anomaly=Anomaly(anomaly_score=-0.1, anomaly_type="none"),
+                        ),
+                        TimeSeriesPoint(
+                            timestamp=self.current_timestamp_2,
+                            value=3,
+                            anomaly=Anomaly(anomaly_score=-0.2, anomaly_type="none"),
+                        ),
+                    ],
+                )
+            ),
+            status=200,
+        )
+        token = self._create_token("alerts:write")
+        data = self.get_test_data(self.project.id)
+        url = reverse(self.endpoint, args=[self.organization.slug])
+
+        with outbox_runner():
+            response = self.client.post(
+                url,
+                data=orjson.dumps(data),
+                content_type="application/json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 200
+
+    @with_feature("organizations:anomaly-detection-alerts")
+    @with_feature("organizations:incidents")
+    def test_org_read_scope_cannot_post(self) -> None:
+        token = self._create_token("org:read")
+        data = self.get_test_data(self.project.id)
+        url = reverse(self.endpoint, args=[self.organization.slug])
+
+        with outbox_runner():
+            response = self.client.post(
+                url,
+                data=orjson.dumps(data),
+                content_type="application/json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 403
+
+    @with_feature("organizations:anomaly-detection-alerts")
+    @with_feature("organizations:incidents")
+    def test_alerts_write_scope_denies_other_team_projects(self) -> None:
+        team_admin_user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=team_admin_user,
+            organization=self.organization,
+            role="member",
+            team_roles=[(self.team, "admin")],
+        )
+        self.organization.update_option("sentry:alerts_member_write", False)
+
+        other_team = self.create_team(organization=self.organization, name="other-team")
+        other_project = self.create_project(
+            organization=self.organization, teams=[other_team], name="other-project"
+        )
+        token = self._create_token("alerts:write", user=team_admin_user)
+        data = self.get_test_data(other_project.id)
+        url = reverse(self.endpoint, args=[self.organization.slug])
+
+        with outbox_runner():
+            response = self.client.post(
+                url,
+                data=orjson.dumps(data),
+                content_type="application/json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 403
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:incidents")

--- a/tests/sentry/seer/endpoints/test_organization_events_anomalies.py
+++ b/tests/sentry/seer/endpoints/test_organization_events_anomalies.py
@@ -1,12 +1,15 @@
 from datetime import timedelta
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import MagicMock, patch
 
 import orjson
 from django.urls import reverse
+from rest_framework.request import Request
 from urllib3 import HTTPResponse
 from urllib3.exceptions import TimeoutError
 
+from sentry.api.bases.organization import ALERT_MUTATION_LOOKUP_MISS
 from sentry.incidents.models.alert_rule import (
     AlertRuleSeasonality,
     AlertRuleSensitivity,
@@ -29,6 +32,7 @@ from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
+from sentry.users.models.user import User
 
 
 @freeze_time()
@@ -51,7 +55,7 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
     current_timestamp_1 = one_week_ago.timestamp()
     current_timestamp_2 = (one_week_ago + timedelta(minutes=10)).timestamp()
 
-    def _create_token(self, scope: str, user=None) -> ApiToken:
+    def _create_token(self, scope: str, user: User | None = None) -> ApiToken:
         with assume_test_silo_mode(SiloMode.CONTROL):
             return ApiToken.objects.create(user=user or self.user, scope_list=[scope])
 
@@ -95,12 +99,36 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
 
     def test_get_alert_mutation_projects_accepts_rpc_org_context(self) -> None:
         endpoint = OrganizationEventsAnomaliesEndpoint()
-        request = SimpleNamespace(data={"project_id": str(self.project.id)})
+        request = cast(Request, SimpleNamespace(data={"project_id": str(self.project.id)}))
         organization = RpcUserOrganizationContext(
             organization=RpcOrganization(id=self.organization.id)
         )
 
         assert endpoint.get_alert_mutation_projects(request, organization) == [self.project]
+
+    def test_get_alert_mutation_projects_returns_lookup_miss_for_invalid_project_id(self) -> None:
+        endpoint = OrganizationEventsAnomaliesEndpoint()
+        request = cast(Request, SimpleNamespace(data={"project_id": "not-a-project"}))
+        organization = RpcUserOrganizationContext(
+            organization=RpcOrganization(id=self.organization.id)
+        )
+
+        assert (
+            endpoint.get_alert_mutation_projects(request, organization)
+            is ALERT_MUTATION_LOOKUP_MISS
+        )
+
+    def test_get_alert_mutation_projects_returns_lookup_miss_for_missing_project(self) -> None:
+        endpoint = OrganizationEventsAnomaliesEndpoint()
+        request = cast(Request, SimpleNamespace(data={"project_id": "999999999"}))
+        organization = RpcUserOrganizationContext(
+            organization=RpcOrganization(id=self.organization.id)
+        )
+
+        assert (
+            endpoint.get_alert_mutation_projects(request, organization)
+            is ALERT_MUTATION_LOOKUP_MISS
+        )
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:incidents")

--- a/tests/sentry/uptime/endpoints/test_organization_uptime_alert_preview.py
+++ b/tests/sentry/uptime/endpoints/test_organization_uptime_alert_preview.py
@@ -134,3 +134,27 @@ class OrganizationUptimeAlertPreview(UptimeAlertBaseEndpointTest):
         )
 
         assert response.status_code == 200, response.content
+
+    def test_org_read_scope_cannot_run_preview_check(self) -> None:
+        api_key = self.create_api_key(organization=self.organization, scope_list=["org:read"])
+
+        url = reverse(
+            "sentry-api-0-organization-uptime-alert-preview-check",
+            kwargs={"organization_id_or_slug": self.organization.slug},
+        )
+        response = self.client.post(
+            url,
+            data={
+                "name": "test",
+                "environment": "uptime-prod",
+                "owner": f"user:{self.user.id}",
+                "url": "http://sentry.io",
+                "timeoutMs": 1500,
+                "body": None,
+                "region": "default",
+            },
+            format="json",
+            HTTP_AUTHORIZATION=self.create_basic_auth_header(api_key.key),
+        )
+
+        assert response.status_code == 403

--- a/tests/sentry/uptime/endpoints/test_organization_uptime_assertion_suggestions.py
+++ b/tests/sentry/uptime/endpoints/test_organization_uptime_assertion_suggestions.py
@@ -1,0 +1,85 @@
+from unittest import mock
+
+from django.test import override_settings
+from django.urls import reverse
+
+from sentry.conf.types.uptime import UptimeRegionConfig
+from tests.sentry.uptime.endpoints import UptimeAlertBaseEndpointTest
+
+
+@override_settings(
+    UPTIME_REGIONS=[
+        UptimeRegionConfig(
+            slug="default",
+            name="Default Region",
+            config_redis_key_prefix="default",
+            api_endpoint="pop-st-1.uptime-checker.s4s.sentry.internal:80",
+        )
+    ]
+)
+class OrganizationUptimeAssertionSuggestionsTest(UptimeAlertBaseEndpointTest):
+    endpoint = "sentry-api-0-organization-uptime-assertion-suggestions"
+    method = "post"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.url = reverse(self.endpoint, args=[self.organization.slug])
+        self.payload = {
+            "name": "test",
+            "environment": "uptime-prod",
+            "owner": f"user:{self.user.id}",
+            "url": "http://sentry.io",
+            "timeoutMs": 1500,
+            "body": None,
+            "region": "default",
+        }
+
+    @mock.patch(
+        "sentry.uptime.endpoints.organization_uptime_assertion_suggestions.generate_assertion_suggestions"
+    )
+    @mock.patch(
+        "sentry.uptime.endpoints.organization_uptime_assertion_suggestions.checker_api.invoke_checker_preview"
+    )
+    @mock.patch(
+        "sentry.uptime.endpoints.organization_uptime_assertion_suggestions.UptimeCheckPreviewValidator"
+    )
+    @mock.patch("sentry.uptime.endpoints.organization_uptime_assertion_suggestions.has_seer_access")
+    def test_alerts_write_scope_can_generate_suggestions(
+        self,
+        mock_has_seer_access: mock.MagicMock,
+        mock_validator_cls: mock.MagicMock,
+        mock_preview: mock.MagicMock,
+        mock_generate: mock.MagicMock,
+    ) -> None:
+        api_key = self.create_api_key(organization=self.organization, scope_list=["alerts:write"])
+        mock_has_seer_access.return_value = True
+        mock_validator = mock_validator_cls.return_value
+        mock_validator.is_valid.return_value = True
+        mock_validator.save.return_value = {"active_regions": ["default"]}
+        mock_preview.return_value = mock.Mock(
+            status_code=200,
+            json=mock.Mock(return_value={"status": 200}),
+            raise_for_status=mock.Mock(),
+        )
+        mock_generate.return_value = (None, None)
+
+        response = self.client.post(
+            self.url,
+            data=self.payload,
+            format="json",
+            HTTP_AUTHORIZATION=self.create_basic_auth_header(api_key.key),
+        )
+
+        assert response.status_code == 200
+
+    def test_org_read_scope_cannot_generate_suggestions(self) -> None:
+        api_key = self.create_api_key(organization=self.organization, scope_list=["org:read"])
+
+        response = self.client.post(
+            self.url,
+            data=self.payload,
+            format="json",
+            HTTP_AUTHORIZATION=self.create_basic_auth_header(api_key.key),
+        )
+
+        assert response.status_code == 403

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
@@ -25,6 +25,7 @@ from sentry.testutils.helpers import with_feature
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode, cell_silo_test
 from sentry.testutils.skips import requires_kafka, requires_snuba
+from sentry.users.models.user import User
 from sentry.workflow_engine.models import (
     AlertRuleDetector,
     DataCondition,
@@ -96,7 +97,7 @@ class OrganizationDetectorDetailsBaseTest(APITestCase):
         )
         assert self.detector.data_sources is not None
 
-    def _create_token(self, scope: str, user=None) -> ApiToken:
+    def _create_token(self, scope: str, user: User | None = None) -> ApiToken:
         with assume_test_silo_mode(SiloMode.CONTROL):
             return ApiToken.objects.create(user=user or self.user, scope_list=[scope])
 

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 from unittest import mock
 
 import pytest
+from django.urls import reverse
 from django.utils import timezone
 
 from sentry import audit_log
@@ -12,6 +13,7 @@ from sentry.grouping.grouptype import ErrorGroupType
 from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.models.alert_rule import AlertRuleDetectionType
 from sentry.incidents.utils.constants import INCIDENTS_SNUBA_SUBSCRIPTION_TYPE
+from sentry.models.apitoken import ApiToken
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset
@@ -93,6 +95,10 @@ class OrganizationDetectorDetailsBaseTest(APITestCase):
             data_source=self.data_source, detector=self.detector
         )
         assert self.detector.data_sources is not None
+
+    def _create_token(self, scope: str, user=None) -> ApiToken:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            return ApiToken.objects.create(user=user or self.user, scope_list=[scope])
 
 
 @cell_silo_test
@@ -526,6 +532,84 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
         detector = Detector.objects.get(id=response.data["id"])
         assert detector.enabled is False
         assert detector.status == ObjectStatus.DISABLED
+
+    def test_update_requires_alerts_write_scope_for_tokens(self) -> None:
+        token = self._create_token("org:read")
+
+        response = self.client.put(
+            reverse(self.endpoint, args=[self.organization.slug, self.detector.id]),
+            data={"enabled": False},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {token.token}",
+        )
+
+        assert response.status_code == 403
+
+    def test_team_admin_can_update_with_project_scoped_alerts_write(self) -> None:
+        team_admin_user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=team_admin_user,
+            organization=self.organization,
+            role="member",
+            team_roles=[(self.team, "admin")],
+        )
+        self.organization.update_option("sentry:alerts_member_write", False)
+        self.login_as(team_admin_user)
+
+        with self.tasks():
+            response = self.client.put(
+                reverse(self.endpoint, args=[self.organization.slug, self.detector.id]),
+                data={"enabled": False},
+                format="json",
+            )
+
+        assert response.status_code == 200
+        self.detector.refresh_from_db()
+        assert self.detector.enabled is False
+
+    def test_update_allows_alerts_write_scope_for_tokens(self) -> None:
+        token = self._create_token("alerts:write")
+
+        with self.tasks():
+            response = self.client.put(
+                reverse(self.endpoint, args=[self.organization.slug, self.detector.id]),
+                data={"enabled": False},
+                format="json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 200
+        self.detector.refresh_from_db()
+        assert self.detector.enabled is False
+
+    def test_update_denies_alerts_write_scope_for_other_team_projects(self) -> None:
+        team_admin_user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=team_admin_user,
+            organization=self.organization,
+            role="member",
+            team_roles=[(self.team, "admin")],
+        )
+        self.organization.update_option("sentry:alerts_member_write", False)
+
+        other_team = self.create_team(organization=self.organization, name="other-team")
+        other_project = self.create_project(
+            organization=self.organization, teams=[other_team], name="other-project"
+        )
+        other_detector = self.create_detector(
+            project=other_project, type=MetricIssue.slug, name="Other Detector"
+        )
+
+        token = self._create_token("alerts:write", user=team_admin_user)
+
+        response = self.client.put(
+            reverse(self.endpoint, args=[self.organization.slug, other_detector.id]),
+            data={"enabled": False},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {token.token}",
+        )
+
+        assert response.status_code == 403
 
     def test_enable_detector(self) -> None:
         self.detector.update(enabled=False)
@@ -1054,6 +1138,51 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
 @cell_silo_test
 class OrganizationDetectorDetailsDeleteTest(OrganizationDetectorDetailsBaseTest):
     method = "DELETE"
+
+    def test_team_admin_can_delete_with_project_scoped_alerts_write(self) -> None:
+        team_admin_user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=team_admin_user,
+            organization=self.organization,
+            role="member",
+            team_roles=[(self.team, "admin")],
+        )
+        self.organization.update_option("sentry:alerts_member_write", False)
+        self.login_as(team_admin_user)
+
+        with outbox_runner():
+            response = self.client.delete(
+                reverse(self.endpoint, args=[self.organization.slug, self.detector.id])
+            )
+
+        assert response.status_code == 204
+
+    def test_delete_denies_alerts_write_scope_for_other_team_projects(self) -> None:
+        team_admin_user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=team_admin_user,
+            organization=self.organization,
+            role="member",
+            team_roles=[(self.team, "admin")],
+        )
+        self.organization.update_option("sentry:alerts_member_write", False)
+
+        other_team = self.create_team(organization=self.organization, name="other-team")
+        other_project = self.create_project(
+            organization=self.organization, teams=[other_team], name="other-project"
+        )
+        other_detector = self.create_detector(
+            project=other_project, type=MetricIssue.slug, name="Other Detector"
+        )
+
+        token = self._create_token("alerts:write", user=team_admin_user)
+
+        response = self.client.delete(
+            reverse(self.endpoint, args=[self.organization.slug, other_detector.id]),
+            HTTP_AUTHORIZATION=f"Bearer {token.token}",
+        )
+
+        assert response.status_code == 403
 
     @mock.patch(
         "sentry.workflow_engine.endpoints.organization_detector_details.schedule_update_project_config"

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
@@ -611,6 +611,25 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
 
         assert response.status_code == 403
 
+    def test_update_missing_target_preserves_404_for_project_scoped_alerts_write(self) -> None:
+        team_admin_user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=team_admin_user,
+            organization=self.organization,
+            role="member",
+            team_roles=[(self.team, "admin")],
+        )
+        self.organization.update_option("sentry:alerts_member_write", False)
+        self.login_as(team_admin_user)
+
+        response = self.client.put(
+            reverse(self.endpoint, args=[self.organization.slug, 999999999]),
+            data={"enabled": False},
+            format="json",
+        )
+
+        assert response.status_code == 404
+
     def test_enable_detector(self) -> None:
         self.detector.update(enabled=False)
         self.detector.update(status=ObjectStatus.DISABLED)
@@ -1183,6 +1202,23 @@ class OrganizationDetectorDetailsDeleteTest(OrganizationDetectorDetailsBaseTest)
         )
 
         assert response.status_code == 403
+
+    def test_delete_missing_target_preserves_404_for_project_scoped_alerts_write(self) -> None:
+        team_admin_user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=team_admin_user,
+            organization=self.organization,
+            role="member",
+            team_roles=[(self.team, "admin")],
+        )
+        self.organization.update_option("sentry:alerts_member_write", False)
+        self.login_as(team_admin_user)
+
+        response = self.client.delete(
+            reverse(self.endpoint, args=[self.organization.slug, 999999999]),
+        )
+
+        assert response.status_code == 404
 
     @mock.patch(
         "sentry.workflow_engine.endpoints.organization_detector_details.schedule_update_project_config"


### PR DESCRIPTION
Tighten project-scoped write checks for alert-style mutation endpoints that target a specific project.

This rebuilds the intended scope-tightening work from #113120 directly on `master` so it can land without the unrelated readonly-mutation-notes changes that were stacked into the old branch.

The main change is to honor project-scoped `alerts:write` access consistently across alert-rule and detector mutations, monitor creation, uptime previews and suggestions, replay deletes, data export authorization, user issue mutation, and Seer anomaly preview requests. While tightening those checks, this keeps the established missing-target behavior for alert-rule and detector detail flows instead of turning stale or nonexistent targets into generic permission failures. The Seer anomaly preview follow-up also preserves lookup-miss handling when the permission layer receives an `RpcUserOrganizationContext`.

This also updates regression coverage around project-scoped writers, missing targets, cross-project access, and the anomaly-preview permission path so the permission logic and endpoint behavior stay aligned.

The optional OpenAPI schema-diff check is expected on this PR because these permission changes intentionally update the documented security requirements for the affected endpoints.

Supersedes #113120.