### PR TITLE
Revert "ref(seer): Filter private fields from explorer chat API response"

### DIFF
--- a/src/sentry/seer/explorer/client_models.py
+++ b/src/sentry/seer/explorer/client_models.py
@@ -15,12 +15,11 @@ T = TypeVar("T", bound=BaseModel)
 class ToolCall(BaseModel):
     """A tool call in a message."""
 
-    id: str | None = None
     function: str
     args: str
 
     class Config:
-        extra = "ignore"
+        extra = "allow"
 
 
 class Message(BaseModel):
@@ -28,12 +27,11 @@ class Message(BaseModel):
 
     role: Literal["user", "assistant", "tool_use"]
     content: str | None = None
-    thinking_content: str | None = None
     tool_calls: list[ToolCall] | None = None
     metadata: dict[str, str] | None = None
 
     class Config:
-        extra = "ignore"
+        extra = "allow"
 
 
 class Artifact(BaseModel):
@@ -44,7 +42,7 @@ class Artifact(BaseModel):
     reason: str
 
     class Config:
-        extra = "ignore"
+        extra = "allow"
 
 
 class FilePatch(BaseModel):
@@ -67,7 +65,7 @@ class ExplorerFilePatch(BaseModel):
     diff: str = ""
 
     class Config:
-        extra = "ignore"
+        extra = "allow"
 
 
 class RepoPRState(BaseModel):
@@ -85,38 +83,7 @@ class RepoPRState(BaseModel):
     description: str | None = None
 
     class Config:
-        extra = "ignore"
-
-
-class TodoItem(BaseModel):
-    """A todo item tracked by the agent."""
-
-    content: str
-    status: Literal["pending", "in_progress", "completed"]
-
-    class Config:
-        extra = "ignore"
-
-
-class ToolLink(BaseModel):
-    """A link to a Sentry resource referenced by a tool call."""
-
-    kind: str
-    params: dict[str, Any]
-
-    class Config:
-        extra = "ignore"
-
-
-class ToolResult(BaseModel):
-    """The result of a tool call execution."""
-
-    tool_call_id: str
-    tool_call_function: str
-    content: str
-
-    class Config:
-        extra = "ignore"
+        extra = "allow"
 
 
 class MemoryBlock(BaseModel):
@@ -134,12 +101,9 @@ class MemoryBlock(BaseModel):
     pr_commit_shas: dict[str, str] | None = (
         None  # repository name -> commit SHA. Used to track which commit was associated with each repo's PR at the time this block was created.
     )
-    todos: list[TodoItem] | None = None
-    tool_links: list[ToolLink | None] | None = None
-    tool_results: list[ToolResult | None] | None = None
 
     class Config:
-        extra = "ignore"
+        extra = "allow"
 
 
 class PendingUserInput(BaseModel):
@@ -150,7 +114,7 @@ class PendingUserInput(BaseModel):
     data: dict[str, Any]
 
     class Config:
-        extra = "ignore"
+        extra = "allow"
 
 
 class CodingAgentResult(BaseModel):
@@ -162,7 +126,7 @@ class CodingAgentResult(BaseModel):
     pr_url: str | None = None
 
     class Config:
-        extra = "ignore"
+        extra = "allow"
 
 
 class ExplorerCodingAgentState(BaseModel):
@@ -178,7 +142,7 @@ class ExplorerCodingAgentState(BaseModel):
     integration_id: int | None = None
 
     class Config:
-        extra = "ignore"
+        extra = "allow"
 
 
 class Usage(BaseModel):
@@ -194,7 +158,7 @@ class Usage(BaseModel):
     model: str = ""
 
     class Config:
-        extra = "ignore"
+        extra = "allow"
 
 
 class UsageAccumulator(BaseModel):
@@ -203,7 +167,7 @@ class UsageAccumulator(BaseModel):
     usages: list[Usage] = Field(default_factory=list)
 
     class Config:
-        extra = "ignore"
+        extra = "allow"
 
     @property
     def total_dollar_cost(self) -> float:
@@ -221,15 +185,14 @@ class SeerRunState(BaseModel):
     blocks: list[MemoryBlock]
     status: Literal["processing", "completed", "error", "awaiting_user_input"]
     updated_at: str
-    owner_user_id: int | None = None
     pending_user_input: PendingUserInput | None = None
     repo_pr_states: dict[str, RepoPRState] = Field(default_factory=dict)
-    metadata: dict[str, Any] | None = Field(default=None, exclude=True)
-    coding_agents: dict[str, ExplorerCodingAgentState] = Field(default_factory=dict, exclude=True)
-    usage: UsageAccumulator = Field(default_factory=UsageAccumulator, exclude=True)
+    metadata: dict[str, Any] | None = None
+    coding_agents: dict[str, ExplorerCodingAgentState] = Field(default_factory=dict)
+    usage: UsageAccumulator = Field(default_factory=UsageAccumulator)
 
     class Config:
-        extra = "ignore"
+        extra = "allow"
 
     def get_artifacts(self) -> dict[str, Artifact]:
         """

--- a/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
@@ -45,46 +45,6 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
         assert response.data["session"]["status"] == "completed"
         mock_client.get_run.assert_called_once_with(run_id=123)
 
-    @patch("sentry.seer.endpoints.organization_seer_explorer_chat.SeerExplorerClient")
-    def test_get_excludes_private_fields(self, mock_client_class: MagicMock) -> None:
-        from sentry.seer.explorer.client_models import (
-            MemoryBlock,
-            Message,
-            SeerRunState,
-            Usage,
-            UsageAccumulator,
-        )
-
-        mock_state = SeerRunState(
-            run_id=123,
-            blocks=[
-                MemoryBlock(
-                    id="b1",
-                    message=Message(role="assistant", content="hello"),
-                    timestamp="2024-01-01T00:00:00Z",
-                ),
-            ],
-            status="completed",
-            updated_at="2024-01-01T00:00:00Z",
-            usage=UsageAccumulator(
-                usages=[Usage(dollar_cost=0.42, model="claude", total_tokens=1000)]
-            ),
-            metadata={"internal": "data"},
-        )
-        mock_client = MagicMock()
-        mock_client.get_run.return_value = mock_state
-        mock_client_class.return_value = mock_client
-
-        response = self.client.get(f"{self.url}123/")
-
-        assert response.status_code == 200
-        session = response.data["session"]
-        assert "usage" not in session
-        assert "metadata" not in session
-        assert "coding_agents" not in session
-        assert session["blocks"][0]["id"] == "b1"
-        assert session["blocks"][0]["message"]["content"] == "hello"
-
     def test_post_without_query_returns_400(self) -> None:
         data: dict[str, Any] = {}
         response = self.client.post(self.url, data, format="json")


### PR DESCRIPTION
Reverts #113125 (commit a2b45849600).

## Why
Adding `Field(exclude=True)` to `SeerRunState.metadata` (and `coding_agents`, `usage`) breaks the `open_pr` autofix path. `trigger_push_changes` in `src/sentry/seer/autofix/autofix_agent.py` calls `client.get_run(run_id)`, which round-trips the state through `SeerRunState.dict()`. With `exclude=True`, `metadata` is dropped, so the subsequent `state.metadata.get("group_id") != group.id` check raises `SeerPermissionError`, which the endpoint converts to a 404.

Breaks these tests in `GroupAutofixEndpointExplorerRoutingTest`:
- `test_open_pr`
- `test_open_pr_with_repo_name`
- `test_open_pr_without_repo_name`

The original PR's goal (not leaking private fields from the chat GET endpoint) is still worth doing — but it needs to avoid mutating `.dict()` on fields that internal callers (autofix, night shift) rely on. Recommended follow-up: filter at the chat endpoint's serialization layer instead of at the model level.

## Test plan
- [x] All 13 tests in `GroupAutofixEndpointExplorerRoutingTest` pass locally


Agent transcript: https://claudescope.sentry.dev/share/UNpzUgEqDq3qylO2yWNXUNup8rl7E67hslWFRdN21Mo