### PR TITLE
fix(api): Serialize defaultCodingAgentIntegrationId as a string  

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -608,7 +608,7 @@ class OrganizationSerializerResponse(_OrganizationSerializerResponseOptional):
     enableSeerEnhancedAlerts: bool
     enableSeerCoding: bool
     defaultCodingAgent: str
-    defaultCodingAgentIntegrationId: int | None
+    defaultCodingAgentIntegrationId: str | None
     defaultAutomatedRunStoppingPoint: str
     autoEnableCodeReview: bool
     autoOpenPrs: bool
@@ -696,6 +696,10 @@ class OrganizationSerializer(OrganizationSummarySerializer):
         elif has_dynamic_sampling(obj):
             sample_rate = quotas.backend.get_blended_sample_rate(organization_id=obj.id)
             is_dynamically_sampled = sample_rate is not None and sample_rate < 1.0
+
+        coding_agent_integration_id = obj.get_option(
+            "sentry:seer_default_coding_agent_integration_id", None
+        )
 
         context: OrganizationSerializerResponse = {
             **base,
@@ -795,8 +799,8 @@ class OrganizationSerializer(OrganizationSummarySerializer):
             "defaultCodingAgent": obj.get_option(
                 "sentry:seer_default_coding_agent", SEER_DEFAULT_CODING_AGENT_DEFAULT
             ),
-            "defaultCodingAgentIntegrationId": obj.get_option(
-                "sentry:seer_default_coding_agent_integration_id", None
+            "defaultCodingAgentIntegrationId": (
+                str(coding_agent_integration_id) if coding_agent_integration_id else None
             ),
             "defaultAutomatedRunStoppingPoint": self._get_default_automated_run_stopping_point(obj),
             "autoOpenPrs": bool(

--- a/tests/sentry/core/endpoints/test_organization_details.py
+++ b/tests/sentry/core/endpoints/test_organization_details.py
@@ -1641,7 +1641,7 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
             self.organization.get_option("sentry:seer_default_coding_agent_integration_id")
             == integration.id
         )
-        assert response.data["defaultCodingAgentIntegrationId"] == integration.id
+        assert response.data["defaultCodingAgentIntegrationId"] == str(integration.id)
 
     def test_default_coding_agent_integration_id_rejects_foreign_org(self) -> None:
         other_org = self.create_organization()
@@ -1665,7 +1665,7 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
             self.organization.get_option("sentry:seer_default_coding_agent_integration_id")
             == integration.id
         )
-        assert response.data["defaultCodingAgentIntegrationId"] == integration.id
+        assert response.data["defaultCodingAgentIntegrationId"] == str(integration.id)
 
     def test_default_coding_agent_integration_id_null_on_first_write_create_path(self) -> None:
         # Tests the create path (no OrganizationOption row exists yet): sending null


### PR DESCRIPTION
Fixes AIML-2706

Returns `defaultCodingAgentIntegrationId` as a string in the org serializer to adhere to convention of returning numeric IDs as strings (avoids JS precision loss for large  IDs).                                                          
                                                                 
Frontend already wraps reads with str ([1](https://github.com/getsentry/sentry/blob/9a2d6599cc0c3572a272b12eb06cf965484c49c9/static/app/views/settings/seer/overview/utils/seerPreferredAgent.ts#L32), [2](https://github.com/getsentry/sentry/blob/9a2d6599cc0c3572a272b12eb06cf965484c49c9/static/app/views/settings/seer/overview/autofixOverviewSection.tsx#L57)) and sends a str on PUT (PUT [here](https://github.com/getsentry/sentry/blob/9a2d6599cc0c3572a272b12eb06cf965484c49c9/static/app/views/settings/seer/overview/utils/seerPreferredAgent.ts#L96), typed as str [here](https://github.com/getsentry/sentry/blob/9a2d6599cc0c3572a272b12eb06cf965484c49c9/static/app/components/events/autofix/useAutofix.tsx#L326)), so no frontend changes required.