### PR TITLE
ref(seer): Filter private fields from explorer chat API response

### DIFF
--- a/src/sentry/seer/explorer/client_models.py
+++ b/src/sentry/seer/explorer/client_models.py
@@ -15,11 +15,12 @@ T = TypeVar("T", bound=BaseModel)
 class ToolCall(BaseModel):
     """A tool call in a message."""
 
+    id: str | None = None
     function: str
     args: str
 
     class Config:
-        extra = "allow"
+        extra = "ignore"
 
 
 class Message(BaseModel):
@@ -27,11 +28,12 @@ class Message(BaseModel):
 
     role: Literal["user", "assistant", "tool_use"]
     content: str | None = None
+    thinking_content: str | None = None
     tool_calls: list[ToolCall] | None = None
     metadata: dict[str, str] | None = None
 
     class Config:
-        extra = "allow"
+        extra = "ignore"
 
 
 class Artifact(BaseModel):
@@ -42,7 +44,7 @@ class Artifact(BaseModel):
     reason: str
 
     class Config:
-        extra = "allow"
+        extra = "ignore"
 
 
 class FilePatch(BaseModel):
@@ -65,7 +67,7 @@ class ExplorerFilePatch(BaseModel):
     diff: str = ""
 
     class Config:
-        extra = "allow"
+        extra = "ignore"
 
 
 class RepoPRState(BaseModel):
@@ -83,7 +85,38 @@ class RepoPRState(BaseModel):
     description: str | None = None
 
     class Config:
-        extra = "allow"
+        extra = "ignore"
+
+
+class TodoItem(BaseModel):
+    """A todo item tracked by the agent."""
+
+    content: str
+    status: Literal["pending", "in_progress", "completed"]
+
+    class Config:
+        extra = "ignore"
+
+
+class ToolLink(BaseModel):
+    """A link to a Sentry resource referenced by a tool call."""
+
+    kind: str
+    params: dict[str, Any]
+
+    class Config:
+        extra = "ignore"
+
+
+class ToolResult(BaseModel):
+    """The result of a tool call execution."""
+
+    tool_call_id: str
+    tool_call_function: str
+    content: str
+
+    class Config:
+        extra = "ignore"
 
 
 class MemoryBlock(BaseModel):
@@ -101,9 +134,12 @@ class MemoryBlock(BaseModel):
     pr_commit_shas: dict[str, str] | None = (
         None  # repository name -> commit SHA. Used to track which commit was associated with each repo's PR at the time this block was created.
     )
+    todos: list[TodoItem] | None = None
+    tool_links: list[ToolLink | None] | None = None
+    tool_results: list[ToolResult | None] | None = None
 
     class Config:
-        extra = "allow"
+        extra = "ignore"
 
 
 class PendingUserInput(BaseModel):
@@ -114,7 +150,7 @@ class PendingUserInput(BaseModel):
     data: dict[str, Any]
 
     class Config:
-        extra = "allow"
+        extra = "ignore"
 
 
 class CodingAgentResult(BaseModel):
@@ -126,7 +162,7 @@ class CodingAgentResult(BaseModel):
     pr_url: str | None = None
 
     class Config:
-        extra = "allow"
+        extra = "ignore"
 
 
 class ExplorerCodingAgentState(BaseModel):
@@ -142,7 +178,7 @@ class ExplorerCodingAgentState(BaseModel):
     integration_id: int | None = None
 
     class Config:
-        extra = "allow"
+        extra = "ignore"
 
 
 class Usage(BaseModel):
@@ -158,7 +194,7 @@ class Usage(BaseModel):
     model: str = ""
 
     class Config:
-        extra = "allow"
+        extra = "ignore"
 
 
 class UsageAccumulator(BaseModel):
@@ -167,7 +203,7 @@ class UsageAccumulator(BaseModel):
     usages: list[Usage] = Field(default_factory=list)
 
     class Config:
-        extra = "allow"
+        extra = "ignore"
 
     @property
     def total_dollar_cost(self) -> float:
@@ -185,14 +221,15 @@ class SeerRunState(BaseModel):
     blocks: list[MemoryBlock]
     status: Literal["processing", "completed", "error", "awaiting_user_input"]
     updated_at: str
+    owner_user_id: int | None = None
     pending_user_input: PendingUserInput | None = None
     repo_pr_states: dict[str, RepoPRState] = Field(default_factory=dict)
-    metadata: dict[str, Any] | None = None
-    coding_agents: dict[str, ExplorerCodingAgentState] = Field(default_factory=dict)
-    usage: UsageAccumulator = Field(default_factory=UsageAccumulator)
+    metadata: dict[str, Any] | None = Field(default=None, exclude=True)
+    coding_agents: dict[str, ExplorerCodingAgentState] = Field(default_factory=dict, exclude=True)
+    usage: UsageAccumulator = Field(default_factory=UsageAccumulator, exclude=True)
 
     class Config:
-        extra = "allow"
+        extra = "ignore"
 
     def get_artifacts(self) -> dict[str, Artifact]:
         """

--- a/src/sentry/seer/explorer/client_models.py
+++ b/src/sentry/seer/explorer/client_models.py
@@ -47,6 +47,33 @@ class Artifact(BaseModel):
         extra = "ignore"
 
 
+class DiffLine(BaseModel):
+    """A single line in a diff hunk."""
+
+    diff_line_no: int | None = None
+    source_line_no: int | None = None
+    target_line_no: int | None = None
+    line_type: Literal["+", "-", " "]
+    value: str
+
+    class Config:
+        extra = "ignore"
+
+
+class Hunk(BaseModel):
+    """A hunk in a file patch."""
+
+    source_start: int
+    source_length: int
+    target_start: int
+    target_length: int
+    section_header: str
+    lines: list[DiffLine]
+
+    class Config:
+        extra = "ignore"
+
+
 class FilePatch(BaseModel):
     """A file patch from code editing."""
 
@@ -54,9 +81,12 @@ class FilePatch(BaseModel):
     type: Literal["A", "M", "D"]  # A=add, M=modify, D=delete
     added: int
     removed: int
+    source_file: str = ""
+    target_file: str = ""
+    hunks: list[Hunk] = []
 
     class Config:
-        extra = "allow"
+        extra = "ignore"
 
 
 class ExplorerFilePatch(BaseModel):
@@ -224,6 +254,8 @@ class SeerRunState(BaseModel):
     owner_user_id: int | None = None
     pending_user_input: PendingUserInput | None = None
     repo_pr_states: dict[str, RepoPRState] = Field(default_factory=dict)
+    # exclude=True omits these from .dict() so they're not exposed via the public
+    # chat API. Internal callers (autofix, night shift) still access them directly.
     metadata: dict[str, Any] | None = Field(default=None, exclude=True)
     coding_agents: dict[str, ExplorerCodingAgentState] = Field(default_factory=dict, exclude=True)
     usage: UsageAccumulator = Field(default_factory=UsageAccumulator, exclude=True)

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -1062,13 +1062,15 @@ class GroupAutofixEndpointExplorerRoutingTest(APITestCase, SnubaTestCase):
         mock_explorer_state_response.status = 200
         mock_explorer_state_response.json = Mock(
             return_value={
-                "session": SeerRunState(
-                    run_id=123,
-                    blocks=[],
-                    status="completed",
-                    updated_at="2023-07-18T12:00:00Z",
-                    metadata={"group_id": group.id},
-                ).dict()
+                "session": {
+                    **SeerRunState(
+                        run_id=123,
+                        blocks=[],
+                        status="completed",
+                        updated_at="2023-07-18T12:00:00Z",
+                    ).dict(),
+                    "metadata": {"group_id": group.id},
+                }
             }
         )
         mock_explorer_state_request.return_value = mock_explorer_state_response
@@ -1103,13 +1105,15 @@ class GroupAutofixEndpointExplorerRoutingTest(APITestCase, SnubaTestCase):
         mock_explorer_state_response.status = 200
         mock_explorer_state_response.json = Mock(
             return_value={
-                "session": SeerRunState(
-                    run_id=123,
-                    blocks=[],
-                    status="completed",
-                    updated_at="2023-07-18T12:00:00Z",
-                    metadata={"group_id": group.id},
-                ).dict()
+                "session": {
+                    **SeerRunState(
+                        run_id=123,
+                        blocks=[],
+                        status="completed",
+                        updated_at="2023-07-18T12:00:00Z",
+                    ).dict(),
+                    "metadata": {"group_id": group.id},
+                }
             }
         )
         mock_explorer_state_request.return_value = mock_explorer_state_response
@@ -1147,13 +1151,15 @@ class GroupAutofixEndpointExplorerRoutingTest(APITestCase, SnubaTestCase):
         mock_explorer_state_response.status = 200
         mock_explorer_state_response.json = Mock(
             return_value={
-                "session": SeerRunState(
-                    run_id=123,
-                    blocks=[],
-                    status="completed",
-                    updated_at="2023-07-18T12:00:00Z",
-                    metadata={"group_id": group.id},
-                ).dict()
+                "session": {
+                    **SeerRunState(
+                        run_id=123,
+                        blocks=[],
+                        status="completed",
+                        updated_at="2023-07-18T12:00:00Z",
+                    ).dict(),
+                    "metadata": {"group_id": group.id},
+                }
             }
         )
         mock_explorer_state_request.return_value = mock_explorer_state_response

--- a/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
@@ -45,6 +45,46 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
         assert response.data["session"]["status"] == "completed"
         mock_client.get_run.assert_called_once_with(run_id=123)
 
+    @patch("sentry.seer.endpoints.organization_seer_explorer_chat.SeerExplorerClient")
+    def test_get_excludes_private_fields(self, mock_client_class: MagicMock) -> None:
+        from sentry.seer.explorer.client_models import (
+            MemoryBlock,
+            Message,
+            SeerRunState,
+            Usage,
+            UsageAccumulator,
+        )
+
+        mock_state = SeerRunState(
+            run_id=123,
+            blocks=[
+                MemoryBlock(
+                    id="b1",
+                    message=Message(role="assistant", content="hello"),
+                    timestamp="2024-01-01T00:00:00Z",
+                ),
+            ],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            usage=UsageAccumulator(
+                usages=[Usage(dollar_cost=0.42, model="claude", total_tokens=1000)]
+            ),
+            metadata={"internal": "data"},
+        )
+        mock_client = MagicMock()
+        mock_client.get_run.return_value = mock_state
+        mock_client_class.return_value = mock_client
+
+        response = self.client.get(f"{self.url}123/")
+
+        assert response.status_code == 200
+        session = response.data["session"]
+        assert "usage" not in session
+        assert "metadata" not in session
+        assert "coding_agents" not in session
+        assert session["blocks"][0]["id"] == "b1"
+        assert session["blocks"][0]["message"]["content"] == "hello"
+
     def test_post_without_query_returns_400(self) -> None:
         data: dict[str, Any] = {}
         response = self.client.post(self.url, data, format="json")


### PR DESCRIPTION
The explorer chat GET endpoint was forwarding the full `SeerRunState` from Seer to users via `state.dict()`, exposing internal fields and metadata. All models also used `extra = "allow"` which let any undeclared fields from Seer leak through to the response.

Two changes:
- **`extra = "ignore"`** on models used in the chat response, so undeclared fields from Seer are dropped at parse time rather than leaking through `.dict()`
- **`Field(exclude=True)`** on some fields so they're omitted from `.dict()` but still accessible as attributes for internal callers (autofix, night shift, etc.)

Also declares fields the frontend consumes that were previously only passing through as Pydantic extras: `owner_user_id`, `todos`, `tool_links`, `tool_results`, `thinking_content`, and `ToolCall.id`.

Related: https://github.com/getsentry/seer/pull/5803 — this change on the Sentry side makes the Seer-side stripping of fields unnecessary for the chat endpoint.