### PR TITLE
perf(pagination): Reduce unnecessary overquerying in CombinedQuerysetPaginator

### DIFF
--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -707,7 +707,10 @@ class CombinedQuerysetPaginator:
         offset = page * cursor_value
         stop = offset + (int(cursor_value) or limit) + 1
 
-        combined_querysets = self._build_combined_querysets(cursor.is_prev, max_rows=stop)
+        # is_prev reverses the SQL sort direction, so applying max_rows would
+        # keep items from the wrong end of each queryset.
+        max_rows = stop if not cursor.is_prev else None
+        combined_querysets = self._build_combined_querysets(cursor.is_prev, max_rows=max_rows)
 
         if offset < 0:
             raise BadPaginationError("Pagination offset cannot be negative")

--- a/src/sentry/api/paginator.py
+++ b/src/sentry/api/paginator.py
@@ -10,6 +10,7 @@ from urllib.parse import quote
 
 from django.core.exceptions import EmptyResultSet, ObjectDoesNotExist
 from django.db import connections
+from django.db.models import QuerySet
 from django.db.models.functions import Lower
 from sentry_protos.snuba.v1.request_common_pb2 import PageToken
 
@@ -554,9 +555,11 @@ class GenericOffsetPaginator:
 
 
 class CombinedQuerysetIntermediary:
-    is_empty = False
+    is_empty: bool = False
+    instance_type: type
+    order_by_type: type
 
-    def __init__(self, queryset, order_by):
+    def __init__(self, queryset: QuerySet[Any], order_by: list[str]) -> None:
         assert isinstance(order_by, list), "order_by must be a list of keys/field names"
         self.queryset = queryset
         self.order_by = order_by
@@ -569,7 +572,7 @@ class CombinedQuerysetIntermediary:
         except ObjectDoesNotExist:
             self.is_empty = True
 
-    def _assert_has_field(self, instance, field):
+    def _assert_has_field(self, instance: object, field: str) -> None:
         assert hasattr(instance, field), (
             f"Model of type {self.instance_type} does not have field {field}"
         )
@@ -591,15 +594,21 @@ class CombinedQuerysetPaginator:
     There is an assertion in the constructor to help prevent this from manifesting.
     """
 
-    multiplier = 1000000  # Use microseconds for date keys.
-    using_dates = False
+    multiplier: int = 1000000  # Use microseconds for date keys.
+    using_dates: bool = False
 
-    def __init__(self, intermediaries, desc=False, on_results=None, case_insensitive=False):
+    def __init__(
+        self,
+        intermediaries: list[CombinedQuerysetIntermediary],
+        desc: bool = False,
+        on_results: Callable[[list[Any]], list[Any]] | None = None,
+        case_insensitive: bool = False,
+    ) -> None:
         self.desc = desc
         self.intermediaries = intermediaries
         self.on_results = on_results
         self.case_insensitive = case_insensitive
-        self.model_key_map = {}
+        self.model_key_map: dict[type, list[str]] = {}
         for intermediary in list(self.intermediaries):
             if intermediary.is_empty:
                 self.intermediaries.remove(intermediary)
@@ -620,10 +629,10 @@ class CombinedQuerysetPaginator:
                 "When sorting by a date, it must be the key used on all intermediaries"
             )
 
-    def key_from_item(self, item):
+    def key_from_item(self, item: object) -> str:
         return self.model_key_map[type(item)][0]
 
-    def _prep_value(self, item, key, for_prev):
+    def _prep_value(self, item: object, key: str, for_prev: bool) -> object:
         """
         Formats values for use in the cursor
         """
@@ -635,7 +644,7 @@ class CombinedQuerysetPaginator:
             return quote(value.lower())
         return value
 
-    def get_item_key(self, item, for_prev=False):
+    def get_item_key(self, item: object, for_prev: bool = False) -> object:
         if self.using_dates:
             return int(
                 self.multiplier * float(getattr(item, self.key_from_item(item)).strftime("%s.%f"))
@@ -643,10 +652,10 @@ class CombinedQuerysetPaginator:
         else:
             return self._prep_value(item, self.key_from_item(item), for_prev)
 
-    def _is_asc(self, is_prev):
+    def _is_asc(self, is_prev: bool) -> bool:
         return (self.desc and is_prev) or not (self.desc or is_prev)
 
-    def _build_combined_querysets(self, is_prev):
+    def _build_combined_querysets(self, is_prev: bool, max_rows: int | None = None) -> list[object]:
         asc = self._is_asc(is_prev)
         combined_querysets = list()
         for intermediary in self.intermediaries:
@@ -664,6 +673,8 @@ class CombinedQuerysetPaginator:
                     queryset = queryset.order_by(key)
                 else:
                     queryset = queryset.order_by(f"-{key}")
+            if max_rows is not None:
+                queryset = queryset[:max_rows]
             combined_querysets += list(queryset)
 
         def _sort_combined_querysets(item):
@@ -683,7 +694,7 @@ class CombinedQuerysetPaginator:
 
         return combined_querysets
 
-    def get_result(self, cursor=None, limit=100):
+    def get_result(self, cursor: Cursor | None = None, limit: int = 100) -> CursorResult[Any]:
         # offset is page #
         # value is page limit
         if cursor is None:
@@ -691,12 +702,12 @@ class CombinedQuerysetPaginator:
 
         limit = min(limit, MAX_LIMIT)
 
-        combined_querysets = self._build_combined_querysets(cursor.is_prev)
-
         page = int(cursor.offset)
         cursor_value = int(cursor.value)
         offset = page * cursor_value
         stop = offset + (int(cursor_value) or limit) + 1
+
+        combined_querysets = self._build_combined_querysets(cursor.is_prev, max_rows=stop)
 
         if offset < 0:
             raise BadPaginationError("Pagination offset cannot be negative")

--- a/tests/sentry/api/test_paginator.py
+++ b/tests/sentry/api/test_paginator.py
@@ -638,18 +638,20 @@ class CombinedQuerysetPaginatorTest(APITestCase):
         assert list(result) == page1_results
 
     def test_order_by_invalid_key(self) -> None:
+        self.create_project_rule(name="rule1")
         with pytest.raises(AssertionError):
-            rule_intermediary = CombinedQuerysetIntermediary(Rule.objects.all(), "dontexist")
-            CombinedQuerysetPaginator(
-                intermediaries=[rule_intermediary],
-            )
+            CombinedQuerysetIntermediary(Rule.objects.all(), ["dontexist"])
 
     def test_mix_date_and_not_date(self) -> None:
+        self.create_project_rule(name="rule1")
+        self.create_alert_rule(name="alertrule1")
         with pytest.raises(AssertionError):
-            rule_intermediary = CombinedQuerysetIntermediary(Rule.objects.all(), "date_added")
-            rule_intermediary2 = CombinedQuerysetIntermediary(Rule.objects.all(), "label")
+            rule_intermediary = CombinedQuerysetIntermediary(Rule.objects.all(), ["date_added"])
+            alert_rule_intermediary = CombinedQuerysetIntermediary(
+                AlertRule.objects.all(), ["name"]
+            )
             CombinedQuerysetPaginator(
-                intermediaries=[rule_intermediary, rule_intermediary2],
+                intermediaries=[rule_intermediary, alert_rule_intermediary],
             )
 
     def test_only_issue_alert_rules(self) -> None:
@@ -690,9 +692,9 @@ class CombinedQuerysetPaginatorTest(APITestCase):
         assert page2_results[-1].id == rule_ids[-1]
 
         prev_cursor = result.prev
-        result = list(paginator.get_result(limit=5, cursor=prev_cursor))
-        assert len(result) == 5
-        assert result == page1_results
+        prev_results = list(paginator.get_result(limit=5, cursor=prev_cursor))
+        assert len(prev_results) == 5
+        assert prev_results == page1_results
 
     def test_only_metric_alert_rules(self) -> None:
         project = self.project
@@ -751,9 +753,9 @@ class CombinedQuerysetPaginatorTest(APITestCase):
         assert page2_results[-1].id == alert_rule_ids[-1]
 
         prev_cursor = result.prev
-        result = list(paginator.get_result(limit=5, cursor=prev_cursor))
-        assert len(result) == 5
-        assert result == page1_results
+        prev_results = list(paginator.get_result(limit=5, cursor=prev_cursor))
+        assert len(prev_results) == 5
+        assert prev_results == page1_results
 
     def test_issue_and_metric_alert_rules(self) -> None:
         AlertRule.objects.all().delete()
@@ -819,9 +821,35 @@ class CombinedQuerysetPaginatorTest(APITestCase):
         assert page2_results[0].id == rule_ids[2]
 
         prev_cursor = result.prev
-        result = list(paginator.get_result(limit=5, cursor=prev_cursor))
-        assert len(result) == 5
-        assert result == page1_results
+        prev_results = list(paginator.get_result(limit=5, cursor=prev_cursor))
+        assert len(prev_results) == 5
+        assert prev_results == page1_results
+
+    def test_individual_querysets_are_limited(self) -> None:
+        Rule.objects.all().delete()
+
+        for i in range(10):
+            self.create_alert_rule(name=f"alertrule{i}")
+            self.create_project_rule(name=f"rule{i}")
+
+        alert_rule_intermediary = CombinedQuerysetIntermediary(
+            AlertRule.objects.all(), ["date_added"]
+        )
+        rule_intermediary = CombinedQuerysetIntermediary(Rule.objects.all(), ["date_added"])
+        paginator = CombinedQuerysetPaginator(
+            intermediaries=[alert_rule_intermediary, rule_intermediary],
+            desc=True,
+        )
+
+        limit = 3
+        result = paginator.get_result(limit=limit, cursor=None)
+        assert len(result) == limit
+
+        # Each queryset has 10 rows but max_rows=4 (stop = offset + limit + 1)
+        # should limit each to 4, giving 8 total instead of 20.
+        stop = limit + 1
+        built = paginator._build_combined_querysets(is_prev=False, max_rows=stop)
+        assert len(built) == stop * 2
 
 
 class TestChainPaginator(SimpleTestCase):

--- a/tests/sentry/api/test_paginator.py
+++ b/tests/sentry/api/test_paginator.py
@@ -825,6 +825,29 @@ class CombinedQuerysetPaginatorTest(APITestCase):
         assert len(prev_results) == 5
         assert prev_results == page1_results
 
+    def test_prev_page_not_limited(self) -> None:
+        Rule.objects.all().delete()
+
+        rules = []
+        for i in range(10):
+            rules.append(self.create_project_rule(name=f"rule{i}"))
+
+        rule_intermediary = CombinedQuerysetIntermediary(Rule.objects.all(), ["date_added"])
+        paginator = CombinedQuerysetPaginator(
+            intermediaries=[rule_intermediary],
+            desc=True,
+        )
+
+        # Page forward twice with limit=3 so we're on page 3.
+        page1 = paginator.get_result(limit=3, cursor=None)
+        page2 = paginator.get_result(limit=3, cursor=page1.next)
+        page3 = paginator.get_result(limit=3, cursor=page2.next)
+        assert len(page3) == 3
+
+        # Navigate back to page 2 via prev cursor.
+        prev_result = paginator.get_result(limit=3, cursor=page3.prev)
+        assert list(prev_result) == list(page2)
+
     def test_individual_querysets_are_limited(self) -> None:
         Rule.objects.all().delete()
 


### PR DESCRIPTION
CombinedQuerysetPaginator combines multiple querysets, but did so by querying the full results of all source queries, then merging.
For resultsets larger than the current pagination limit, that's just wasted resources.
By limiting the source queries to the max of what might be necessary if they're the only result, in some orgs we go from 100s of rows queried and processed to less than 100.
This isn't as efficient as doing something smarter with offsets, but it should be quite helpful for first page performance (the most common case), and no worse for subsequent pages.

While in the neighborhood, we type annotate the involved classes and fix the broken test cases.