### PR TITLE
feat(dashboards): Redirect Insights pages to corresponding dashboards

### DIFF
--- a/static/app/utils/analytics/dashboardsAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/dashboardsAnalyticsEvents.tsx
@@ -110,6 +110,10 @@ export type DashboardsEventParameters = {
     show_templates: boolean;
   };
   'dashboards_manage.toggle_favorite': {dashboard_id: string; favorited: boolean};
+  'dashboards_views.insights_redirect': {
+    dashboard_id: string;
+    prebuilt_id: number;
+  };
   'dashboards_views.open_in_discover.opened': {
     widget_type: string;
   };
@@ -219,5 +223,6 @@ export const dashboardsEventMap: Record<DashboardsEventKey, string | null> = {
   'dashboards2.edit_access.save': 'Dashboards2: Edit Access Dropdown Selection Saved',
   'dashboards2.span_migration.results_check':
     'Dashboards2: Check Widget Results From Span Migration',
+  'dashboards_views.insights_redirect': 'Insights: Redirected to Dashboard',
   ...dashboardsEventMapWidgetBuilder,
 };

--- a/static/app/views/dashboards/prebuiltDashboardRenderer.spec.tsx
+++ b/static/app/views/dashboards/prebuiltDashboardRenderer.spec.tsx
@@ -1,6 +1,6 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {PrebuiltDashboardRenderer} from 'sentry/views/dashboards/prebuiltDashboardRenderer';
 import {PrebuiltDashboardId} from 'sentry/views/dashboards/utils/prebuiltConfigs';
@@ -17,39 +17,52 @@ jest.mock('sentry/views/dashboards/utils/usePopulateLinkedDashboards', () => ({
 }));
 
 describe('PrebuiltDashboardRenderer', () => {
-  const organization = OrganizationFixture();
+  const initialRouterConfig = {
+    location: {
+      pathname: '/insights/backend/',
+      query: {
+        project: '1',
+        environment: 'production',
+        statsPeriod: '7d',
+      },
+    },
+  };
 
-  it('renders dashboard link with page filter query params from the URL', async () => {
-    render(
-      <PrebuiltDashboardRenderer prebuiltId={PrebuiltDashboardId.BACKEND_OVERVIEW} />,
-      {
-        organization,
-        initialRouterConfig: {
-          location: {
-            pathname: '/insights/backend/',
-            query: {
-              project: '1',
-              environment: 'production',
-              statsPeriod: '7d',
-            },
-          },
-        },
-      }
-    );
-
-    const link = await screen.findByRole('link', {
-      name: 'View this page on Dashboards',
+  it('redirects to the corresponding dashboard with page filter query params when flag is enabled', async () => {
+    const organization = OrganizationFixture({
+      features: ['insights-to-dashboards-ui-rollout'],
     });
 
-    expect(link).toHaveAttribute(
-      'href',
-      expect.stringContaining(`/organizations/${organization.slug}/dashboard/42/`)
+    const {router} = render(
+      <PrebuiltDashboardRenderer prebuiltId={PrebuiltDashboardId.BACKEND_OVERVIEW} />,
+      {organization, initialRouterConfig}
     );
-    expect(link).toHaveAttribute('href', expect.stringContaining('project=1'));
-    expect(link).toHaveAttribute(
-      'href',
-      expect.stringContaining('environment=production')
+
+    await waitFor(() => {
+      expect(router.location.pathname).toBe(
+        `/organizations/${organization.slug}/dashboard/42/`
+      );
+    });
+    expect(router.location.query).toEqual(
+      expect.objectContaining({
+        project: '1',
+        environment: 'production',
+        statsPeriod: '7d',
+      })
     );
-    expect(link).toHaveAttribute('href', expect.stringContaining('statsPeriod=7d'));
+  });
+
+  it('does not redirect when flag is disabled', async () => {
+    const organization = OrganizationFixture({features: []});
+
+    const {router} = render(
+      <PrebuiltDashboardRenderer prebuiltId={PrebuiltDashboardId.BACKEND_OVERVIEW} />,
+      {organization, initialRouterConfig}
+    );
+
+    // Wait for any potential async redirect to settle
+    await waitFor(() => {
+      expect(router.location.pathname).toBe('/insights/backend/');
+    });
   });
 });

--- a/static/app/views/dashboards/prebuiltDashboardRenderer.tsx
+++ b/static/app/views/dashboards/prebuiltDashboardRenderer.tsx
@@ -12,6 +12,7 @@ import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {IconClose} from 'sentry/icons';
 import {tct} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useIsSentryEmployee} from 'sentry/utils/useIsSentryEmployee';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -61,10 +62,10 @@ export function PrebuiltDashboardRenderer({
       prebuilt_id: prebuiltId,
     });
     navigate(
-      {
+      normalizeUrl({
         pathname: `/organizations/${organization.slug}/dashboard/${dashboardId}/`,
         query: extractSelectionParameters(location.query),
-      },
+      }),
       {replace: true}
     );
   }, [

--- a/static/app/views/dashboards/prebuiltDashboardRenderer.tsx
+++ b/static/app/views/dashboards/prebuiltDashboardRenderer.tsx
@@ -1,3 +1,5 @@
+import {useLayoutEffect} from 'react';
+
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
 import {Container} from '@sentry/scraps/layout';
@@ -9,8 +11,10 @@ import {extractSelectionParameters} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {IconClose} from 'sentry/icons';
 import {tct} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {useIsSentryEmployee} from 'sentry/utils/useIsSentryEmployee';
 import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {DashboardDetailWithInjectedProps as DashboardDetail} from 'sentry/views/dashboards/detail';
 import {
@@ -36,9 +40,41 @@ export function PrebuiltDashboardRenderer({
 }: PrebuiltDashboardRendererProps) {
   const organization = useOrganization();
   const location = useLocation();
+  const navigate = useNavigate();
   const prebuiltDashboard = PREBUILT_DASHBOARDS[prebuiltId];
   const {dashboard: populatedPrebuiltDashboard, isLoading} =
     useGetPrebuiltDashboard(prebuiltId);
+
+  const dashboardId = populatedPrebuiltDashboard?.id;
+
+  const insightsToDashboardsEnabled = organization.features.includes(
+    'insights-to-dashboards-ui-rollout'
+  );
+
+  useLayoutEffect(() => {
+    if (!dashboardId || !insightsToDashboardsEnabled) {
+      return;
+    }
+    trackAnalytics('dashboards_views.insights_redirect', {
+      organization,
+      dashboard_id: dashboardId,
+      prebuilt_id: prebuiltId,
+    });
+    navigate(
+      {
+        pathname: `/organizations/${organization.slug}/dashboard/${dashboardId}/`,
+        query: extractSelectionParameters(location.query),
+      },
+      {replace: true}
+    );
+  }, [
+    dashboardId,
+    insightsToDashboardsEnabled,
+    organization,
+    prebuiltId,
+    navigate,
+    location.query,
+  ]);
 
   const {title, filters} = prebuiltDashboard;
   const widgets = populatedPrebuiltDashboard?.widgets ?? prebuiltDashboard.widgets;
@@ -80,8 +116,6 @@ export function PrebuiltDashboardRenderer({
     filters: mergedFilters,
     projects: undefined,
   };
-
-  const dashboardId = populatedPrebuiltDashboard?.id;
 
   const pageFilters = usePageFilters();
   const isSentryEmployee = useIsSentryEmployee();


### PR DESCRIPTION
Adds an automatic redirect in `PrebuiltDashboardRenderer` so that users who land on any Insights URL (via bookmark, external link, etc.) are immediately sent to the corresponding prebuilt Dashboard.

The component already fetches the corresponding dashboard ID on every render, making it the right single place to centralize this redirect across all 25 Insights pages.

**What changed:**
- `PrebuiltDashboardRenderer` now uses `useLayoutEffect` to redirect to the corresponding dashboard once the dashboard ID resolves. `useLayoutEffect` is used (rather than `useEffect`) to fire before the browser paints, avoiding a flash of Insights page content on redirect.
- Page filter query params (`project`, `environment`, `statsPeriod`, etc.) are preserved in the redirect.
- The redirect uses `replace: true` so the Insights URL is replaced in browser history rather than pushed — the back button will work correctly.
- A `dashboards_views.insights_redirect` analytics event is fired on each redirect with `dashboard_id` and `prebuilt_id`.
- The entire behaviour is gated behind the `insights-to-dashboards-ui-rollout` feature flag.

**Tests:** The existing test was replaced with two tests — one asserting the redirect fires with the correct URL and query params when the flag is enabled, and one asserting no redirect occurs when the flag is disabled. Tests use `router.location` assertions rather than mocking `useNavigate`.

Refs DAIN-1531