### PR TITLE
feat(cursor): Add API-driven pipeline backend for Cursor integration setup

### DIFF
--- a/src/sentry/integrations/cursor/integration.py
+++ b/src/sentry/integrations/cursor/integration.py
@@ -5,10 +5,13 @@ from collections.abc import Mapping, MutableMapping
 from typing import Any, Literal
 
 from django import forms
+from django.http.request import HttpRequest
 from django.utils.translation import gettext_lazy as _
 from pydantic import BaseModel
 from requests import HTTPError
+from rest_framework.fields import CharField
 
+from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
 from sentry.integrations.base import (
     FeatureDescription,
     IntegrationData,
@@ -22,8 +25,11 @@ from sentry.integrations.coding_agent.integration import (
 )
 from sentry.integrations.cursor.client import CursorAgentClient
 from sentry.integrations.models.integration import Integration
+from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.models.apitoken import generate_token
+from sentry.pipeline.types import PipelineStepResult
+from sentry.pipeline.views.base import ApiPipelineSteps
 from sentry.shared_integrations.exceptions import ApiError, IntegrationConfigurationError
 
 DESCRIPTION = "Connect your Sentry organization with Cursor Cloud Agents."
@@ -72,6 +78,29 @@ class CursorPipelineView(CodingAgentPipelineView):
         return "sentry/integrations/cursor-config.html"
 
 
+class CursorApiKeySerializer(CamelSnakeSerializer):
+    api_key = CharField(required=True, max_length=255)
+
+
+class CursorApiKeyApiStep:
+    step_name = "api_key_config"
+
+    def get_step_data(self, pipeline: IntegrationPipeline, request: HttpRequest) -> dict[str, Any]:
+        return {}
+
+    def get_serializer_cls(self) -> type:
+        return CursorApiKeySerializer
+
+    def handle_post(
+        self,
+        validated_data: dict[str, str],
+        pipeline: IntegrationPipeline,
+        request: HttpRequest,
+    ) -> PipelineStepResult:
+        pipeline.bind_state("config", {"api_key": validated_data["api_key"]})
+        return PipelineStepResult.advance()
+
+
 class CursorAgentIntegrationProvider(CodingAgentIntegrationProvider):
     key = "cursor"
     name = "Cursor Agent"
@@ -79,6 +108,9 @@ class CursorAgentIntegrationProvider(CodingAgentIntegrationProvider):
 
     def get_pipeline_views(self):
         return [CursorPipelineView()]
+
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps[IntegrationPipeline]:
+        return [CursorApiKeyApiStep()]
 
     def build_integration(self, state: Mapping[str, Any]) -> IntegrationData:
         config = state.get("config", {})

--- a/tests/sentry/integrations/cursor/test_integration.py
+++ b/tests/sentry/integrations/cursor/test_integration.py
@@ -6,15 +6,20 @@ from unittest.mock import MagicMock, patch
 from uuid import UUID
 
 import pytest
+from django.urls import reverse
 
 from sentry.integrations.cursor.integration import (
     CursorAgentIntegration,
     CursorAgentIntegrationProvider,
 )
 from sentry.integrations.cursor.models import CursorApiKeyMetadata
+from sentry.integrations.models.integration import Integration
+from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.shared_integrations.exceptions import ApiError, IntegrationConfigurationError
-from sentry.testutils.cases import IntegrationTestCase
-from sentry.testutils.silo import assume_test_silo_mode_of
+from sentry.testutils.cases import APITestCase, IntegrationTestCase
+from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.silo import assume_test_silo_mode_of, control_silo_test
 
 
 @pytest.fixture
@@ -471,3 +476,66 @@ class CursorIntegrationTest(IntegrationTestCase):
         display_info = installation.get_dynamic_display_information()
 
         assert display_info is None
+
+
+@control_silo_test
+class CursorApiPipelineTest(APITestCase):
+    endpoint = "sentry-api-0-organization-pipeline"
+    method = "post"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(self.user)
+
+    def _get_pipeline_url(self) -> str:
+        return reverse(
+            self.endpoint,
+            args=[self.organization.slug, IntegrationPipeline.pipeline_name],
+        )
+
+    def _initialize_pipeline(self) -> Any:
+        return self.client.post(
+            self._get_pipeline_url(),
+            data={"action": "initialize", "provider": "cursor"},
+            format="json",
+        )
+
+    def _advance_step(self, data: dict[str, Any]) -> Any:
+        return self.client.post(self._get_pipeline_url(), data=data, format="json")
+
+    @with_feature("organizations:integrations-cursor")
+    def test_initialize_pipeline(self) -> None:
+        resp = self._initialize_pipeline()
+        assert resp.status_code == 200
+        assert resp.data["step"] == "api_key_config"
+        assert resp.data["stepIndex"] == 0
+        assert resp.data["totalSteps"] == 1
+        assert resp.data["provider"] == "cursor"
+
+    @with_feature("organizations:integrations-cursor")
+    def test_missing_api_key(self) -> None:
+        self._initialize_pipeline()
+        resp = self._advance_step({})
+        assert resp.status_code == 400
+
+    @with_feature("organizations:integrations-cursor")
+    @patch(
+        "sentry.integrations.cursor.client.CursorAgentClient.verify_api_key",
+        return_value=None,
+    )
+    def test_full_pipeline_flow(self, mock_verify: MagicMock) -> None:
+        resp = self._initialize_pipeline()
+        assert resp.data["step"] == "api_key_config"
+
+        resp = self._advance_step({"apiKey": "cursor-api-key-123"})
+        assert resp.status_code == 200
+        assert resp.data["status"] == "complete"
+
+        integration = Integration.objects.get(provider="cursor")
+        assert integration.metadata["api_key"] == "cursor-api-key-123"
+        assert integration.metadata["domain_name"] == "cursor.sh"
+
+        assert OrganizationIntegration.objects.filter(
+            organization_id=self.organization.id,
+            integration=integration,
+        ).exists()


### PR DESCRIPTION
Implement get_pipeline_api_steps() on CursorAgentIntegrationProvider
with a single API key config step. The step collects the Cursor API key
and binds it to state["config"]["api_key"] so build_integration() works
unchanged for both legacy and API paths.

Refs [VDY-92: Cursor: API-driven integration setup](https://linear.app/getsentry/issue/VDY-92/cursor-api-driven-integration-setup)