### PR TITLE
fix(tracemetric): Change metric selector syntax

### DIFF
--- a/static/app/views/settings/components/dataScrubbing/modals/form/attributeField.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/attributeField.tsx
@@ -76,7 +76,7 @@ export function AttributeField({
     dataset === AllowedDataScrubbingDatasets.DEFAULT
       ? TraceItemDataset.LOGS
       : datasetToTraceItemType[dataset];
-  const traceItemAttributeStringsResult = useQuery({
+  const traceItemAttributeResult = useQuery({
     ...traceItemAttributeKeysOptions({
       organization,
       selection,
@@ -87,7 +87,7 @@ export function AttributeField({
     select: selectTraceItemTagCollection('string'),
   });
   const [suggestedAttributeValues, setSuggestedAttributeValues] = useLocalStorageState(
-    `advanced-data-scrubbing.suggested-attribute-values:v2:${projectId ? projectId : 'all'}`,
+    `advanced-data-scrubbing.suggested-attribute-values:v3:${projectId ? projectId : 'all'}`,
     {} as TagCollection
   );
 
@@ -96,25 +96,23 @@ export function AttributeField({
 
   useEffect(() => {
     if (
-      traceItemAttributeStringsResult.data &&
-      !traceItemAttributeStringsResult.isLoading &&
-      !traceItemAttributeStringsResult.error
+      traceItemAttributeResult.data &&
+      !traceItemAttributeResult.isLoading &&
+      !traceItemAttributeResult.error
     ) {
       // This limits the attributes you can see when selecting for pii scrubbing, but we have to currently as tags[] syntax is strictly invalid.
       // We should address this ultimately via fixing the trace item keys endpoint to emit the stored/relay-esque syntax at some point, instead of frontend hacks.
-      setSuggestedAttributeValues(
-        elideTagBasedAttributes(traceItemAttributeStringsResult.data)
-      );
+      setSuggestedAttributeValues(elideTagBasedAttributes(traceItemAttributeResult.data));
     }
   }, [
     onChange,
-    traceItemAttributeStringsResult.data,
-    traceItemAttributeStringsResult.isLoading,
-    traceItemAttributeStringsResult.error,
+    traceItemAttributeResult.data,
+    traceItemAttributeResult.isLoading,
+    traceItemAttributeResult.error,
     setSuggestedAttributeValues,
   ]);
 
-  const suggestions = useMemo(() => {
+  const suggestions = useMemo((): AttributeSuggestion[] => {
     if (!suggestedAttributeValues) {
       return [];
     }
@@ -221,7 +219,7 @@ export function AttributeField({
 
   return (
     <Wrapper>
-      {traceItemAttributeStringsResult.isLoading &&
+      {traceItemAttributeResult.isLoading &&
       !Object.keys(suggestedAttributeValues).length ? (
         <LoadingIndicator style={{margin: '0 auto'}} size={20} />
       ) : (

--- a/static/app/views/settings/components/dataScrubbing/utils.tsx
+++ b/static/app/views/settings/components/dataScrubbing/utils.tsx
@@ -290,7 +290,7 @@ export class TraceItemFieldSelector {
     ],
     [AllowedDataScrubbingDatasets.METRICS]: [
       {
-        regex: /^\$metric\.attributes\.'([^']+)'\.value$/,
+        regex: /^\$trace_metric\.attributes\.'([^']+)'\.value$/,
       },
     ],
     [AllowedDataScrubbingDatasets.DEFAULT]: [],
@@ -301,7 +301,7 @@ export class TraceItemFieldSelector {
     string | null
   > = {
     [AllowedDataScrubbingDatasets.LOGS]: '$log',
-    [AllowedDataScrubbingDatasets.METRICS]: '$metric',
+    [AllowedDataScrubbingDatasets.METRICS]: '$trace_metric',
     [AllowedDataScrubbingDatasets.DEFAULT]: null,
   };
 
@@ -316,7 +316,7 @@ export class TraceItemFieldSelector {
       return `$log.attributes.'${alias}'.value`;
     },
     [AllowedDataScrubbingDatasets.METRICS]: (alias: string) => {
-      return `$metric.attributes.'${alias}'.value`;
+      return `$trace_metric.attributes.'${alias}'.value`;
     },
     [AllowedDataScrubbingDatasets.DEFAULT]: () => null,
   };


### PR DESCRIPTION
### Summary
This swaps the selector syntax to 'trace_metric'


