### PR TITLE
fix(dashboards): Remove "Insights" from breadcrumbs

### DIFF
--- a/static/app/views/performance/breadcrumb.tsx
+++ b/static/app/views/performance/breadcrumb.tsx
@@ -27,9 +27,11 @@ export function getCrumbs(props: Props) {
   const crumbs: Crumb[] = [];
   const {organization, location, transaction, spanSlug, eventSlug, traceSlug} = props;
 
-  crumbs.push({
-    label: DOMAIN_VIEW_BASE_TITLE,
-  });
+  if (!organization.features.includes('insights-to-dashboards-ui-rollout')) {
+    crumbs.push({
+      label: DOMAIN_VIEW_BASE_TITLE,
+    });
+  }
 
   crumbs.push(
     ...getTabCrumbs({

--- a/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
@@ -253,9 +253,11 @@ function getInsightsModuleBreadcrumbs(
       ),
     });
   } else {
-    crumbs.push({
-      label: t('Insights'),
-    });
+    if (!organization.features.includes('insights-to-dashboards-ui-rollout')) {
+      crumbs.push({
+        label: DOMAIN_VIEW_BASE_TITLE,
+      });
+    }
   }
 
   let moduleName: RoutableModuleNames | undefined = undefined;

--- a/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
@@ -112,10 +112,12 @@ function getPerformanceBreadCrumbs(
       ),
     });
   } else {
-    crumbs.push({
-      label: DOMAIN_VIEW_BASE_TITLE,
-      to: undefined,
-    });
+    if (!organization.features.includes('insights-to-dashboards-ui-rollout')) {
+      crumbs.push({
+        label: DOMAIN_VIEW_BASE_TITLE,
+        to: undefined,
+      });
+    }
   }
 
   switch (location.query.tab) {


### PR DESCRIPTION
Since Insights are going away, let's remove mentions of "Insights" from the breadcrumbs. The URLs still have "insights" in them, but that's not as critical.

**e.g.,**
<img width="391" height="91" alt="Screenshot 2026-04-16 at 2 42 06 PM" src="https://github.com/user-attachments/assets/f9018779-34d4-4a2f-be8c-2669888e0d74" />
