### PR TITLE
fix(dashboards): Use dashboards as fallback secondary nav content for Insights pages

### DIFF
--- a/static/app/views/navigation/secondary/content.tsx
+++ b/static/app/views/navigation/secondary/content.tsx
@@ -20,7 +20,7 @@ export function SecondaryNavigationContent(): ReactNode {
       return <IssuesSecondaryNavigation />;
     case 'insights':
       if (organization.features.includes('insights-to-dashboards-ui-rollout')) {
-        return null;
+        return <DashboardsSecondaryNavigation />;
       }
       return <InsightsSecondaryNavigation />;
     case 'dashboards':


### PR DESCRIPTION
Insights are going away, so the _sidebar_ navigation for Insights is gone, but there are still some URLs that have `/insights/` in them, and they activate the secondary navigation. Right now it shows up as an empty grey block, which is awkward. I think using the Dashboards secondary is a safer fallback in this case, while we migrate those URLs away.

**e.g.,**
<img width="514" height="623" alt="Screenshot 2026-04-16 at 2 46 05 PM" src="https://github.com/user-attachments/assets/9ca38fca-9ca9-4a5e-8f29-847068773554" />
