### PR TITLE
feat(cursor): Add frontend pipeline step for Cursor integration setup

### DIFF
--- a/static/app/components/pipeline/pipelineIntegrationCursor.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationCursor.spec.tsx
@@ -1,0 +1,46 @@
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {cursorIntegrationPipeline} from './pipelineIntegrationCursor';
+import type {PipelineStepProps} from './types';
+
+const CursorApiKeyStep = cursorIntegrationPipeline.steps[0].component;
+
+function makeStepProps<D, A>(
+  overrides: Partial<PipelineStepProps<D, A>> & {stepData: D}
+): PipelineStepProps<D, A> {
+  return {
+    advance: jest.fn(),
+    advanceError: null,
+    isAdvancing: false,
+    stepIndex: 0,
+    totalSteps: 1,
+    ...overrides,
+  };
+}
+
+describe('CursorApiKeyStep', () => {
+  it('renders the API key form', () => {
+    render(<CursorApiKeyStep {...makeStepProps({stepData: {}})} />);
+
+    expect(screen.getByRole('button', {name: 'Continue'})).toBeInTheDocument();
+    expect(screen.getByLabelText('Cursor API Key')).toBeInTheDocument();
+  });
+
+  it('calls advance with API key on submit', async () => {
+    const advance = jest.fn();
+    render(<CursorApiKeyStep {...makeStepProps({stepData: {}, advance})} />);
+
+    await userEvent.type(screen.getByLabelText('Cursor API Key'), 'cursor-api-key-123');
+    await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+    await waitFor(() => {
+      expect(advance).toHaveBeenCalledWith({apiKey: 'cursor-api-key-123'});
+    });
+  });
+
+  it('shows loading state when isAdvancing', () => {
+    render(<CursorApiKeyStep {...makeStepProps({stepData: {}, isAdvancing: true})} />);
+
+    expect(screen.getByRole('button', {name: 'Submitting...'})).toBeDisabled();
+  });
+});

--- a/static/app/components/pipeline/pipelineIntegrationCursor.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationCursor.tsx
@@ -1,0 +1,79 @@
+import {useEffect} from 'react';
+import {z} from 'zod';
+
+import {defaultFormOptions, setFieldErrors, useScrapsForm} from '@sentry/scraps/form';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {t} from 'sentry/locale';
+import type {IntegrationWithConfig} from 'sentry/types/integrations';
+
+import type {PipelineDefinition, PipelineStepProps} from './types';
+import {pipelineComplete} from './types';
+
+const apiKeySchema = z.object({
+  apiKey: z.string().min(1, t('API key is required')),
+});
+
+function CursorApiKeyStep({
+  advance,
+  advanceError,
+  isAdvancing,
+}: PipelineStepProps<Record<string, never>, {apiKey: string}>) {
+  const form = useScrapsForm({
+    ...defaultFormOptions,
+    defaultValues: {apiKey: ''},
+    validators: {onDynamic: apiKeySchema},
+    onSubmit: ({value}) => {
+      advance({apiKey: value.apiKey});
+    },
+  });
+
+  useEffect(() => {
+    if (advanceError) {
+      setFieldErrors(form, advanceError);
+    }
+  }, [advanceError, form]);
+
+  return (
+    <form.AppForm form={form}>
+      <Stack gap="lg">
+        <Text>
+          {t('Enter your Cursor API key to connect Cursor Agents with Sentry.')}
+        </Text>
+        <form.AppField name="apiKey">
+          {field => (
+            <field.Layout.Stack label={t('Cursor API Key')} required>
+              <field.Input
+                type="password"
+                value={field.state.value}
+                onChange={field.handleChange}
+                placeholder="crsr_..."
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+        <Flex>
+          <form.SubmitButton disabled={isAdvancing}>
+            {isAdvancing ? t('Submitting...') : t('Continue')}
+          </form.SubmitButton>
+        </Flex>
+      </Stack>
+    </form.AppForm>
+  );
+}
+
+export const cursorIntegrationPipeline = {
+  type: 'integration',
+  provider: 'cursor',
+  actionTitle: t('Installing Cursor Agent'),
+  getCompletionData: pipelineComplete<IntegrationWithConfig>,
+  completionView: null,
+  steps: [
+    {
+      stepId: 'api_key_config',
+      shortDescription: t('Configuring API key'),
+      component: CursorApiKeyStep,
+    },
+  ],
+} as const satisfies PipelineDefinition;

--- a/static/app/components/pipeline/registry.tsx
+++ b/static/app/components/pipeline/registry.tsx
@@ -1,6 +1,7 @@
 import {dummyIntegrationPipeline} from './pipelineDummyProvider';
 import {awsLambdaIntegrationPipeline} from './pipelineIntegrationAwsLambda';
 import {bitbucketIntegrationPipeline} from './pipelineIntegrationBitbucket';
+import {cursorIntegrationPipeline} from './pipelineIntegrationCursor';
 import {discordIntegrationPipeline} from './pipelineIntegrationDiscord';
 import {githubIntegrationPipeline} from './pipelineIntegrationGitHub';
 import {gitlabIntegrationPipeline} from './pipelineIntegrationGitLab';
@@ -13,6 +14,7 @@ import {vstsIntegrationPipeline} from './pipelineIntegrationVsts';
 export const PIPELINE_REGISTRY = [
   awsLambdaIntegrationPipeline,
   bitbucketIntegrationPipeline,
+  cursorIntegrationPipeline,
   discordIntegrationPipeline,
   dummyIntegrationPipeline,
   githubIntegrationPipeline,


### PR DESCRIPTION
Adds the API key configuration step for the Cursor integration
pipeline, including form validation and tests.

Refs [VDY-92](https://linear.app/getsentry/issue/VDY-92/cursor-api-driven-integration-setup)