### PR TITLE
feat(claude-code): Add frontend pipeline step for Claude Code integration setup

### DIFF
--- a/static/app/components/pipeline/pipelineIntegrationClaudeCode.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationClaudeCode.spec.tsx
@@ -1,0 +1,48 @@
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {claudeCodeIntegrationPipeline} from './pipelineIntegrationClaudeCode';
+import type {PipelineStepProps} from './types';
+
+const ClaudeCodeApiKeyStep = claudeCodeIntegrationPipeline.steps[0].component;
+
+function makeStepProps<D, A>(
+  overrides: Partial<PipelineStepProps<D, A>> & {stepData: D}
+): PipelineStepProps<D, A> {
+  return {
+    advance: jest.fn(),
+    advanceError: null,
+    isAdvancing: false,
+    stepIndex: 0,
+    totalSteps: 1,
+    ...overrides,
+  };
+}
+
+describe('ClaudeCodeApiKeyStep', () => {
+  it('renders the API key form', () => {
+    render(<ClaudeCodeApiKeyStep {...makeStepProps({stepData: {}})} />);
+
+    expect(screen.getByRole('button', {name: 'Continue'})).toBeInTheDocument();
+    expect(screen.getByLabelText('Anthropic API Key')).toBeInTheDocument();
+  });
+
+  it('calls advance with API key on submit', async () => {
+    const advance = jest.fn();
+    render(<ClaudeCodeApiKeyStep {...makeStepProps({stepData: {}, advance})} />);
+
+    await userEvent.type(screen.getByLabelText('Anthropic API Key'), 'sk-ant-test-key');
+    await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+    await waitFor(() => {
+      expect(advance).toHaveBeenCalledWith({apiKey: 'sk-ant-test-key'});
+    });
+  });
+
+  it('shows loading state when isAdvancing', () => {
+    render(
+      <ClaudeCodeApiKeyStep {...makeStepProps({stepData: {}, isAdvancing: true})} />
+    );
+
+    expect(screen.getByRole('button', {name: 'Submitting...'})).toBeDisabled();
+  });
+});

--- a/static/app/components/pipeline/pipelineIntegrationClaudeCode.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationClaudeCode.tsx
@@ -1,0 +1,79 @@
+import {useEffect} from 'react';
+import {z} from 'zod';
+
+import {defaultFormOptions, setFieldErrors, useScrapsForm} from '@sentry/scraps/form';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {t} from 'sentry/locale';
+import type {IntegrationWithConfig} from 'sentry/types/integrations';
+
+import type {PipelineDefinition, PipelineStepProps} from './types';
+import {pipelineComplete} from './types';
+
+const apiKeySchema = z.object({
+  apiKey: z.string().min(1, t('API key is required')),
+});
+
+function ClaudeCodeApiKeyStep({
+  advance,
+  advanceError,
+  isAdvancing,
+}: PipelineStepProps<Record<string, never>, {apiKey: string}>) {
+  const form = useScrapsForm({
+    ...defaultFormOptions,
+    defaultValues: {apiKey: ''},
+    validators: {onDynamic: apiKeySchema},
+    onSubmit: ({value}) => {
+      advance({apiKey: value.apiKey});
+    },
+  });
+
+  useEffect(() => {
+    if (advanceError) {
+      setFieldErrors(form, advanceError);
+    }
+  }, [advanceError, form]);
+
+  return (
+    <form.AppForm form={form}>
+      <Stack gap="lg">
+        <Text>
+          {t('Enter your Anthropic API key to connect Claude Agent with Sentry.')}
+        </Text>
+        <form.AppField name="apiKey">
+          {field => (
+            <field.Layout.Stack label={t('Anthropic API Key')} required>
+              <field.Input
+                type="password"
+                value={field.state.value}
+                onChange={field.handleChange}
+                placeholder="sk-ant-..."
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+        <Flex>
+          <form.SubmitButton disabled={isAdvancing}>
+            {isAdvancing ? t('Submitting...') : t('Continue')}
+          </form.SubmitButton>
+        </Flex>
+      </Stack>
+    </form.AppForm>
+  );
+}
+
+export const claudeCodeIntegrationPipeline = {
+  type: 'integration',
+  provider: 'claude_code',
+  actionTitle: t('Installing Claude Agent'),
+  getCompletionData: pipelineComplete<IntegrationWithConfig>,
+  completionView: null,
+  steps: [
+    {
+      stepId: 'api_key_config',
+      shortDescription: t('Configuring API key'),
+      component: ClaudeCodeApiKeyStep,
+    },
+  ],
+} as const satisfies PipelineDefinition;

--- a/static/app/components/pipeline/registry.tsx
+++ b/static/app/components/pipeline/registry.tsx
@@ -1,6 +1,7 @@
 import {dummyIntegrationPipeline} from './pipelineDummyProvider';
 import {awsLambdaIntegrationPipeline} from './pipelineIntegrationAwsLambda';
 import {bitbucketIntegrationPipeline} from './pipelineIntegrationBitbucket';
+import {claudeCodeIntegrationPipeline} from './pipelineIntegrationClaudeCode';
 import {cursorIntegrationPipeline} from './pipelineIntegrationCursor';
 import {discordIntegrationPipeline} from './pipelineIntegrationDiscord';
 import {githubIntegrationPipeline} from './pipelineIntegrationGitHub';
@@ -15,6 +16,7 @@ import {vstsIntegrationPipeline} from './pipelineIntegrationVsts';
 export const PIPELINE_REGISTRY = [
   awsLambdaIntegrationPipeline,
   bitbucketIntegrationPipeline,
+  claudeCodeIntegrationPipeline,
   cursorIntegrationPipeline,
   discordIntegrationPipeline,
   dummyIntegrationPipeline,


### PR DESCRIPTION
Adds the API key configuration step for the Claude Code integration
pipeline, including form validation and tests.

Refs [VDY-91](https://linear.app/getsentry/issue/VDY-91/claude-code-api-driven-integration-setup)