### PR TITLE
feat(opsgenie): Add frontend pipeline step for Opsgenie integration setup

### DIFF
--- a/static/app/components/pipeline/pipelineIntegrationOpsgenie.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationOpsgenie.spec.tsx
@@ -1,0 +1,92 @@
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {opsgenieIntegrationPipeline} from './pipelineIntegrationOpsgenie';
+import type {PipelineStepProps} from './types';
+
+const OpsgenieInstallationConfigStep = opsgenieIntegrationPipeline.steps[0].component;
+
+function makeStepProps<D, A>(
+  overrides: Partial<PipelineStepProps<D, A>> & {stepData: D}
+): PipelineStepProps<D, A> {
+  return {
+    advance: jest.fn(),
+    advanceError: null,
+    isAdvancing: false,
+    stepIndex: 0,
+    totalSteps: 1,
+    ...overrides,
+  };
+}
+
+const baseUrlChoices = [
+  {value: 'https://api.opsgenie.com/', label: 'api.opsgenie.com'},
+  {value: 'https://api.eu.opsgenie.com/', label: 'api.eu.opsgenie.com'},
+];
+
+describe('OpsgenieInstallationConfigStep', () => {
+  it('renders the config form', () => {
+    render(
+      <OpsgenieInstallationConfigStep {...makeStepProps({stepData: {baseUrlChoices}})} />
+    );
+
+    expect(screen.getByRole('button', {name: 'Continue'})).toBeInTheDocument();
+    expect(screen.getByRole('textbox', {name: 'Account Name'})).toBeInTheDocument();
+  });
+
+  it('calls advance with form data on submit', async () => {
+    const advance = jest.fn();
+    render(
+      <OpsgenieInstallationConfigStep
+        {...makeStepProps({stepData: {baseUrlChoices}, advance})}
+      />
+    );
+
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'Account Name'}),
+      'cool-name'
+    );
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'Opsgenie Integration Key'}),
+      '123-key'
+    );
+    await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+    await waitFor(() => {
+      expect(advance).toHaveBeenCalledWith({
+        baseUrl: 'https://api.opsgenie.com/',
+        provider: 'cool-name',
+        apiKey: '123-key',
+      });
+    });
+  });
+
+  it('submits without api key when left empty', async () => {
+    const advance = jest.fn();
+    render(
+      <OpsgenieInstallationConfigStep
+        {...makeStepProps({stepData: {baseUrlChoices}, advance})}
+      />
+    );
+
+    await userEvent.type(screen.getByRole('textbox', {name: 'Account Name'}), 'my-app');
+    await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+    await waitFor(() => {
+      expect(advance).toHaveBeenCalledWith({
+        baseUrl: 'https://api.opsgenie.com/',
+        provider: 'my-app',
+        apiKey: undefined,
+      });
+    });
+  });
+
+  it('shows loading state when isAdvancing', () => {
+    render(
+      <OpsgenieInstallationConfigStep
+        {...makeStepProps({stepData: {baseUrlChoices}, isAdvancing: true})}
+      />
+    );
+
+    expect(screen.getByRole('button', {name: 'Submitting...'})).toBeDisabled();
+  });
+});

--- a/static/app/components/pipeline/pipelineIntegrationOpsgenie.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationOpsgenie.tsx
@@ -1,0 +1,139 @@
+import {useEffect} from 'react';
+import {z} from 'zod';
+
+import {defaultFormOptions, setFieldErrors, useScrapsForm} from '@sentry/scraps/form';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {t} from 'sentry/locale';
+import type {IntegrationWithConfig} from 'sentry/types/integrations';
+
+import type {PipelineDefinition, PipelineStepProps} from './types';
+import {pipelineComplete} from './types';
+
+interface BaseUrlChoice {
+  label: string;
+  value: string;
+}
+
+interface InstallationConfigStepData {
+  baseUrlChoices?: BaseUrlChoice[];
+}
+
+interface InstallationConfigAdvanceData {
+  baseUrl: string;
+  provider: string;
+  apiKey?: string;
+}
+
+const installationConfigSchema = z.object({
+  baseUrl: z.string().min(1, t('Base URL is required')),
+  provider: z.string().min(1, t('Account name is required')),
+  apiKey: z.string(),
+});
+
+function OpsgenieInstallationConfigStep({
+  stepData,
+  advance,
+  advanceError,
+  isAdvancing,
+}: PipelineStepProps<InstallationConfigStepData, InstallationConfigAdvanceData>) {
+  const choices = stepData.baseUrlChoices ?? [];
+
+  const form = useScrapsForm({
+    ...defaultFormOptions,
+    defaultValues: {
+      baseUrl: choices[0]?.value ?? '',
+      provider: '',
+      apiKey: '',
+    },
+    validators: {onDynamic: installationConfigSchema},
+    onSubmit: ({value}) => {
+      advance({
+        baseUrl: value.baseUrl,
+        provider: value.provider,
+        apiKey: value.apiKey || undefined,
+      });
+    },
+  });
+
+  useEffect(() => {
+    if (advanceError) {
+      setFieldErrors(form, advanceError);
+    }
+  }, [advanceError, form]);
+
+  return (
+    <form.AppForm form={form}>
+      <Stack gap="lg">
+        <Text>
+          {t(
+            'Configure your Opsgenie integration to start receiving Sentry alerts in Opsgenie.'
+          )}
+        </Text>
+        <form.AppField name="baseUrl">
+          {field => (
+            <field.Layout.Stack label={t('Base URL')} required>
+              <field.Select
+                value={field.state.value}
+                onChange={field.handleChange}
+                options={choices.map(c => ({value: c.value, label: c.label}))}
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+        <form.AppField name="provider">
+          {field => (
+            <field.Layout.Stack
+              label={t('Account Name')}
+              hintText={t("Example: 'acme' for https://acme.app.opsgenie.com/")}
+              required
+            >
+              <field.Input
+                value={field.state.value}
+                onChange={field.handleChange}
+                placeholder={t('your-account-name')}
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+        <form.AppField name="apiKey">
+          {field => (
+            <field.Layout.Stack
+              label={t('Opsgenie Integration Key')}
+              hintText={t(
+                'Optionally, add your first integration key for sending alerts. You can rename this key later.'
+              )}
+            >
+              <field.Input
+                value={field.state.value}
+                onChange={field.handleChange}
+                placeholder={t('Integration key (optional)')}
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+        <Flex>
+          <form.SubmitButton disabled={isAdvancing}>
+            {isAdvancing ? t('Submitting...') : t('Continue')}
+          </form.SubmitButton>
+        </Flex>
+      </Stack>
+    </form.AppForm>
+  );
+}
+
+export const opsgenieIntegrationPipeline = {
+  type: 'integration',
+  provider: 'opsgenie',
+  actionTitle: t('Installing Opsgenie Integration'),
+  getCompletionData: pipelineComplete<IntegrationWithConfig>,
+  completionView: null,
+  steps: [
+    {
+      stepId: 'installation_config',
+      shortDescription: t('Configuring Opsgenie connection'),
+      component: OpsgenieInstallationConfigStep,
+    },
+  ],
+} as const satisfies PipelineDefinition;

--- a/static/app/components/pipeline/registry.tsx
+++ b/static/app/components/pipeline/registry.tsx
@@ -5,6 +5,7 @@ import {cursorIntegrationPipeline} from './pipelineIntegrationCursor';
 import {discordIntegrationPipeline} from './pipelineIntegrationDiscord';
 import {githubIntegrationPipeline} from './pipelineIntegrationGitHub';
 import {gitlabIntegrationPipeline} from './pipelineIntegrationGitLab';
+import {opsgenieIntegrationPipeline} from './pipelineIntegrationOpsgenie';
 import {pagerDutyIntegrationPipeline} from './pipelineIntegrationPagerDuty';
 import {slackIntegrationPipeline} from './pipelineIntegrationSlack';
 import {vstsIntegrationPipeline} from './pipelineIntegrationVsts';
@@ -20,6 +21,7 @@ export const PIPELINE_REGISTRY = [
   dummyIntegrationPipeline,
   githubIntegrationPipeline,
   gitlabIntegrationPipeline,
+  opsgenieIntegrationPipeline,
   pagerDutyIntegrationPipeline,
   slackIntegrationPipeline,
   vstsIntegrationPipeline,


### PR DESCRIPTION
Register the Opsgenie integration in the pipeline registry with a single
installation config form step. Collects base URL (select from allowed
choices), account name, and an optional integration key using the shared
scraps form primitives.

Refs [VDY-89: OpsGenie: API-Driven integration setup](https://linear.app/getsentry/issue/VDY-89/opsgenie-api-driven-integration-setup)