### PR TITLE
ref(integrations): Request recent GitHub commits with explicit page size

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -343,15 +343,15 @@ class GitHubBaseClient(
     # Github gives us links to navigate, however, let's be safe in case we're fed garbage
     page_number_limit = 50  # With a default of 100 per page -> 5,000 items
 
-    def get_last_commits(self, repo: str, end_sha: str) -> Sequence[Any]:
+    def get_last_commits(self, repo: str, end_sha: str, per_page: int = 20) -> Sequence[Any]:
         """
-        Return API request that fetches last ~30 commits
+        Return API request that fetches the last N commits.
         see https://docs.github.com/en/rest/commits/commits#list-commits-on-a-repository
         using end_sha as parameter.
         """
         return self.get_cached(
             f"/repos/{repo}/commits",
-            params={"sha": end_sha},
+            params={"sha": end_sha, "per_page": per_page},
             endpoint=GitHubApiEndpoint.GET_COMMITS,
         )
 

--- a/src/sentry/integrations/github/repository.py
+++ b/src/sentry/integrations/github/repository.py
@@ -86,8 +86,8 @@ class GitHubRepositoryProvider(IntegrationRepositoryProvider["GitHubIntegration"
         name = repo.config["name"]
 
         try:
-            commits = client.get_last_commits(name, end_sha)
-            return self._format_commits(client, name, commits[:20])
+            commits = client.get_last_commits(name, end_sha, per_page=20)
+            return self._format_commits(client, name, commits)
         except Exception as e:
             installation.raise_error(e)
 

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -199,7 +199,7 @@ class GitHubApiClientTest(TestCase):
 
         mock_get_cached.assert_called_once_with(
             f"/repos/{self.repo.name}/commits",
-            params={"sha": "abc"},
+            params={"sha": "abc", "per_page": 20},
             endpoint=GitHubApiEndpoint.GET_COMMITS,
         )
 

--- a/tests/sentry/integrations/github/test_repository.py
+++ b/tests/sentry/integrations/github/test_repository.py
@@ -81,7 +81,7 @@ class GitHubAppsProviderTest(TestCase):
     def test_compare_commits_no_start(self, get_jwt: mock.MagicMock) -> None:
         responses.add(
             responses.GET,
-            "https://api.github.com/repos/getsentry/example-repo/commits?sha=abcdef",
+            "https://api.github.com/repos/getsentry/example-repo/commits?sha=abcdef&per_page=20",
             json=orjson.loads(GET_LAST_COMMITS_EXAMPLE),
         )
         responses.add(
@@ -97,7 +97,7 @@ class GitHubAppsProviderTest(TestCase):
     def test_compare_commits_no_start_failure(self) -> None:
         responses.add(
             responses.GET,
-            "https://api.github.com/repos/getsentry/example-repo/commits?sha=abcdef",
+            "https://api.github.com/repos/getsentry/example-repo/commits?sha=abcdef&per_page=20",
             status=502,
         )
         with pytest.raises(IntegrationError):


### PR DESCRIPTION
## Summary
- request recent GitHub commits with an explicit `per_page=20` parameter in `get_last_commits`
- stop trimming commit lists in the GitHub repository provider by relying on the client-requested page size
- update GitHub client and repository tests to assert the new request query parameters

## Test plan
- [x] `.venv/bin/pytest -svv --reuse-db tests/sentry/integrations/github/test_client.py tests/sentry/integrations/github/test_repository.py`
- [x] `.venv/bin/pre-commit run --files src/sentry/integrations/github/client.py src/sentry/integrations/github/repository.py tests/sentry/integrations/github/test_client.py tests/sentry/integrations/github/test_repository.py`

Made with [Cursor](https://cursor.com)