### PR TITLE
fix(slack): Restrict trace unfurling to /traces links

### DIFF
--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -307,11 +307,11 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
 
 
 explore_traces_link_regex = re.compile(
-    r"^https?\://(?#url_prefix)[^/]+/organizations/(?P<org_slug>[^/]+)/explore/traces/"
+    r"^https?\://(?#url_prefix)[^/]+/organizations/(?P<org_slug>[^/]+)/explore/traces/(?!trace/)"
 )
 
 customer_domain_explore_traces_link_regex = re.compile(
-    r"^https?\://(?P<org_slug>[^.]+?)\.(?#url_prefix)[^/]+/explore/traces/"
+    r"^https?\://(?P<org_slug>[^.]+?)\.(?#url_prefix)[^/]+/explore/traces/(?!trace/)"
 )
 
 explore_logs_link_regex = re.compile(

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -307,11 +307,11 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
 
 
 explore_traces_link_regex = re.compile(
-    r"^https?\://(?#url_prefix)[^/]+/organizations/(?P<org_slug>[^/]+)/explore/traces/(?!trace/)"
+    r"^https?\://(?#url_prefix)[^/]+/organizations/(?P<org_slug>[^/]+)/explore/traces/(?=[?#]|$)"
 )
 
 customer_domain_explore_traces_link_regex = re.compile(
-    r"^https?\://(?P<org_slug>[^.]+?)\.(?#url_prefix)[^/]+/explore/traces/(?!trace/)"
+    r"^https?\://(?P<org_slug>[^.]+?)\.(?#url_prefix)[^/]+/explore/traces/(?=[?#]|$)"
 )
 
 explore_logs_link_regex = re.compile(

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -315,19 +315,19 @@ customer_domain_explore_traces_link_regex = re.compile(
 )
 
 explore_logs_link_regex = re.compile(
-    r"^https?\://(?#url_prefix)[^/]+/organizations/(?P<org_slug>[^/]+)/explore/logs/"
+    r"^https?\://(?#url_prefix)[^/]+/organizations/(?P<org_slug>[^/]+)/explore/logs/(?=[?#]|$)"
 )
 
 customer_domain_explore_logs_link_regex = re.compile(
-    r"^https?\://(?P<org_slug>[^.]+?)\.(?#url_prefix)[^/]+/explore/logs/"
+    r"^https?\://(?P<org_slug>[^.]+?)\.(?#url_prefix)[^/]+/explore/logs/(?=[?#]|$)"
 )
 
 explore_metrics_link_regex = re.compile(
-    r"^https?\://(?#url_prefix)[^/]+/organizations/(?P<org_slug>[^/]+)/explore/metrics/"
+    r"^https?\://(?#url_prefix)[^/]+/organizations/(?P<org_slug>[^/]+)/explore/metrics/(?=[?#]|$)"
 )
 
 customer_domain_explore_metrics_link_regex = re.compile(
-    r"^https?\://(?P<org_slug>[^.]+?)\.(?#url_prefix)[^/]+/explore/metrics/"
+    r"^https?\://(?P<org_slug>[^.]+?)\.(?#url_prefix)[^/]+/explore/metrics/(?=[?#]|$)"
 )
 
 explore_handler = Handler(

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -272,6 +272,14 @@ INTERVALS_PER_DAY = int(60 * 60 * 24 / INTERVAL_COUNT)
             "https://org1.sentry.io/explore/traces/trace/trace_id_123/?project=1&statsPeriod=24h",
             (None, None),
         ),
+        (
+            "https://sentry.io/organizations/org1/explore/traces/other/?project=1",
+            (None, None),
+        ),
+        (
+            "https://org1.sentry.io/explore/traces/other/?project=1",
+            (None, None),
+        ),
     ],
 )
 def test_match_link(url, expected) -> None:

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -280,6 +280,22 @@ INTERVALS_PER_DAY = int(60 * 60 * 24 / INTERVAL_COUNT)
             "https://org1.sentry.io/explore/traces/other/?project=1",
             (None, None),
         ),
+        (
+            "https://sentry.io/organizations/org1/explore/logs/trace/trace_id_123/?project=1",
+            (None, None),
+        ),
+        (
+            "https://org1.sentry.io/explore/logs/trace/trace_id_123/?project=1",
+            (None, None),
+        ),
+        (
+            "https://sentry.io/organizations/org1/explore/metrics/trace/trace_id_123/?project=1",
+            (None, None),
+        ),
+        (
+            "https://org1.sentry.io/explore/metrics/trace/trace_id_123/?project=1",
+            (None, None),
+        ),
     ],
 )
 def test_match_link(url, expected) -> None:

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -264,6 +264,14 @@ INTERVALS_PER_DAY = int(60 * 60 * 24 / INTERVAL_COUNT)
                 },
             ),
         ),
+        (
+            "https://sentry.io/organizations/org1/explore/traces/trace/trace_id_123/?project=1&statsPeriod=24h",
+            (None, None),
+        ),
+        (
+            "https://org1.sentry.io/explore/traces/trace/trace_id_123/?project=1&statsPeriod=24h",
+            (None, None),
+        ),
     ],
 )
 def test_match_link(url, expected) -> None:


### PR DESCRIPTION
Restrict the Slack explore-trace unfurler so it only matches the top-level
`/explore/traces/` search page and skips `/explore/traces/trace/<id>/`
trace detail links.

The existing `explore_traces_link_regex` and its customer-domain variant
matched any URL starting with `/explore/traces/`, so sharing a link like
`/explore/traces/trace/<trace_id>/?…` triggered the events-timeseries
unfurl path, which isn't meaningful for a single trace detail page.
A negative lookahead for `trace/` after `/explore/traces/` keeps the
traces search page unfurling while excluding the trace detail view.

Fixes DAIN-1541