### PR TITLE
feat(vercel): Add frontend pipeline step for Vercel integration setup

### DIFF
--- a/static/app/components/pipeline/pipelineIntegrationVercel.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationVercel.spec.tsx
@@ -1,0 +1,108 @@
+import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {vercelIntegrationPipeline} from './pipelineIntegrationVercel';
+import type {PipelineStepProps} from './types';
+
+const VercelOAuthLoginStep = vercelIntegrationPipeline.steps[0].component;
+
+function makeStepProps<D, A>(
+  overrides: Partial<PipelineStepProps<D, A>> & {stepData: D}
+): PipelineStepProps<D, A> {
+  return {
+    advance: jest.fn(),
+    advanceError: null,
+    isAdvancing: false,
+    stepIndex: 0,
+    totalSteps: 1,
+    ...overrides,
+  };
+}
+
+let mockPopup: Window;
+
+function dispatchPipelineMessage({
+  data,
+  origin = document.location.origin,
+  source = mockPopup,
+}: {
+  data: Record<string, string>;
+  origin?: string;
+  source?: Window | MessageEventSource | null;
+}) {
+  act(() => {
+    const event = new MessageEvent('message', {data, origin});
+    Object.defineProperty(event, 'source', {value: source});
+    window.dispatchEvent(event);
+  });
+}
+
+beforeEach(() => {
+  mockPopup = {
+    closed: false,
+    close: jest.fn(),
+    focus: jest.fn(),
+  } as unknown as Window;
+  jest.spyOn(window, 'open').mockReturnValue(mockPopup);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('VercelOAuthLoginStep', () => {
+  it('renders the OAuth login step for Vercel', () => {
+    render(
+      <VercelOAuthLoginStep
+        {...makeStepProps({stepData: {oauthUrl: 'https://vercel.com/oauth/authorize'}})}
+      />
+    );
+
+    expect(screen.getByRole('button', {name: 'Authorize Vercel'})).toBeInTheDocument();
+  });
+
+  it('calls advance with code and state on OAuth callback', async () => {
+    const advance = jest.fn();
+    render(
+      <VercelOAuthLoginStep
+        {...makeStepProps({
+          stepData: {oauthUrl: 'https://vercel.com/oauth/authorize'},
+          advance,
+        })}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Authorize Vercel'}));
+
+    dispatchPipelineMessage({
+      data: {
+        _pipeline_source: 'sentry-pipeline',
+        code: 'auth-code-123',
+        state: 'state-xyz',
+      },
+    });
+
+    expect(advance).toHaveBeenCalledWith({
+      code: 'auth-code-123',
+      state: 'state-xyz',
+    });
+  });
+
+  it('shows loading state when isAdvancing is true', () => {
+    render(
+      <VercelOAuthLoginStep
+        {...makeStepProps({
+          stepData: {oauthUrl: 'https://vercel.com/oauth/authorize'},
+          isAdvancing: true,
+        })}
+      />
+    );
+
+    expect(screen.getByRole('button', {name: 'Authorizing...'})).toBeDisabled();
+  });
+
+  it('disables authorize button when oauthUrl is not provided', () => {
+    render(<VercelOAuthLoginStep {...makeStepProps({stepData: {}})} />);
+
+    expect(screen.getByRole('button', {name: 'Authorize Vercel'})).toBeDisabled();
+  });
+});

--- a/static/app/components/pipeline/pipelineIntegrationVercel.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationVercel.tsx
@@ -1,0 +1,46 @@
+import {useCallback} from 'react';
+
+import {t} from 'sentry/locale';
+import type {IntegrationWithConfig} from 'sentry/types/integrations';
+
+import type {OAuthCallbackData} from './shared/oauthLoginStep';
+import {OAuthLoginStep} from './shared/oauthLoginStep';
+import type {PipelineDefinition, PipelineStepProps} from './types';
+import {pipelineComplete} from './types';
+
+function VercelOAuthLoginStep({
+  stepData,
+  advance,
+  isAdvancing,
+}: PipelineStepProps<{oauthUrl?: string}, {code: string; state: string}>) {
+  const handleOAuthCallback = useCallback(
+    (data: OAuthCallbackData) => {
+      advance({code: data.code, state: data.state});
+    },
+    [advance]
+  );
+
+  return (
+    <OAuthLoginStep
+      oauthUrl={stepData.oauthUrl}
+      isLoading={isAdvancing}
+      serviceName="Vercel"
+      onOAuthCallback={handleOAuthCallback}
+    />
+  );
+}
+
+export const vercelIntegrationPipeline = {
+  type: 'integration',
+  provider: 'vercel',
+  actionTitle: t('Installing Vercel Integration'),
+  getCompletionData: pipelineComplete<IntegrationWithConfig>,
+  completionView: null,
+  steps: [
+    {
+      stepId: 'oauth_login',
+      shortDescription: t('Authorizing via Vercel OAuth'),
+      component: VercelOAuthLoginStep,
+    },
+  ],
+} as const satisfies PipelineDefinition;

--- a/static/app/components/pipeline/registry.tsx
+++ b/static/app/components/pipeline/registry.tsx
@@ -9,6 +9,7 @@ import {gitlabIntegrationPipeline} from './pipelineIntegrationGitLab';
 import {opsgenieIntegrationPipeline} from './pipelineIntegrationOpsgenie';
 import {pagerDutyIntegrationPipeline} from './pipelineIntegrationPagerDuty';
 import {slackIntegrationPipeline} from './pipelineIntegrationSlack';
+import {vercelIntegrationPipeline} from './pipelineIntegrationVercel';
 import {vstsIntegrationPipeline} from './pipelineIntegrationVsts';
 
 /**
@@ -27,6 +28,7 @@ export const PIPELINE_REGISTRY = [
   pagerDutyIntegrationPipeline,
   slackIntegrationPipeline,
   vstsIntegrationPipeline,
+  vercelIntegrationPipeline,
 ] as const;
 
 type AllPipelines = (typeof PIPELINE_REGISTRY)[number];


### PR DESCRIPTION
Register the Vercel integration in the pipeline registry with a single
OAuthLoginStep component, mirroring the Slack pattern. Includes spec
file with tests for the OAuth login step.

Ref [VDY-44](https://linear.app/getsentry/issue/VDY-44/vercel-api-driven-integration-setup)