### PR TITLE
feat(viewer-context): Tag isolation scope with viewer identity

### DIFF
--- a/src/sentry/viewer_context.py
+++ b/src/sentry/viewer_context.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 
 import jwt as pyjwt
 import orjson
+import sentry_sdk
 from django.conf import settings
 
 logger = logging.getLogger(__name__)
@@ -92,6 +93,15 @@ def viewer_context_scope(ctx: ViewerContext) -> Generator[None]:
     it guarantees cleanup via ``reset(token)`` even on exceptions.
     """
     tok = _viewer_context_var.set(ctx)
+    # Tag the isolation scope so the current transaction and all spans carry
+    # viewer identity. Enables post-hoc detection of misattribution by alerting
+    # on traces that contain conflicting viewer identities (RFC Appendix B).
+    scope = sentry_sdk.get_isolation_scope()
+    if ctx.user_id is not None:
+        scope.set_tag("viewer.user_id", ctx.user_id)
+    if ctx.organization_id is not None:
+        scope.set_tag("viewer.org_id", ctx.organization_id)
+    scope.set_tag("viewer.actor_type", ctx.actor_type.value)
     try:
         yield
     finally:


### PR DESCRIPTION
Tag the current `sentry_sdk` isolation scope inside `viewer_context_scope`
so every transaction and span emitted within the scope carries
`viewer.user_id`, `viewer.org_id`, and `viewer.actor_type`.

This is the prerequisite for the post-hoc misattribution detector
described in the Unified ViewerContext RFC (Appendix B): alert on
traces that contain conflicting viewer identities. Tagging at the
scope manager (rather than per-entrypoint) means every caller —
API middleware, RPC `applied_to_request`, taskworker `ViewerContextHook`,
webhook handlers — picks it up without per-site changes.

Reviewer notes:
- Tags are set on the isolation scope, so they stick to the current
  transaction rather than leaking to other concurrent ones.
- Because `set_tag` overwrites rather than stacks, nested scopes with
  different viewers leave the outer scope showing the inner value after
  exit. Acceptable for the detection use case — the RFC's intent is
  "was there ever a conflicting viewer in this trace." A follow-up
  could emit a breadcrumb on each scope entry if we want a full trail.
- Still gated by `viewer-context.enabled` via the middleware; tags
  only flow once that option is on for the caller.

Refs [RFC: Unified ViewerContext via ContextVar](https://www.notion.so/sentry/RFC-Unified-ViewerContext-via-ContextVar-32f8b10e4b5d81988625cb5787035e02)