### PR TITLE
ref(pipeline): Extract shared test helpers from pipeline integration specs

### DIFF
--- a/static/app/components/pipeline/pipelineIntegrationAwsLambda.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationAwsLambda.spec.tsx
@@ -10,24 +10,13 @@ Object.defineProperty(globalThis.crypto, 'randomUUID', {
 });
 
 import {awsLambdaIntegrationPipeline} from './pipelineIntegrationAwsLambda';
-import type {PipelineStepProps} from './types';
+import {createMakeStepProps} from './testUtils';
 
 const ProjectSelectStep = awsLambdaIntegrationPipeline.steps[0].component;
 const CloudFormationStep = awsLambdaIntegrationPipeline.steps[1].component;
 const InstrumentationStep = awsLambdaIntegrationPipeline.steps[2].component;
 
-function makeStepProps<D, A>(
-  overrides: Partial<PipelineStepProps<D, A>> & {stepData: D}
-): PipelineStepProps<D, A> {
-  return {
-    advance: jest.fn(),
-    advanceError: null,
-    isAdvancing: false,
-    stepIndex: 0,
-    totalSteps: 3,
-    ...overrides,
-  };
-}
+const makeStepProps = createMakeStepProps({totalSteps: 3});
 
 describe('ProjectSelectStep', () => {
   it('renders project selector', () => {

--- a/static/app/components/pipeline/pipelineIntegrationBitbucket.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationBitbucket.spec.tsx
@@ -1,48 +1,16 @@
-import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {bitbucketIntegrationPipeline} from './pipelineIntegrationBitbucket';
-import type {PipelineStepProps} from './types';
+import {createMakeStepProps, dispatchPipelineMessage, setupMockPopup} from './testUtils';
 
 const BitbucketAuthorizeStep = bitbucketIntegrationPipeline.steps[0].component;
 
-function makeStepProps<D, A>(
-  overrides: Partial<PipelineStepProps<D, A>> & {stepData: D}
-): PipelineStepProps<D, A> {
-  return {
-    advance: jest.fn(),
-    advanceError: null,
-    isAdvancing: false,
-    stepIndex: 0,
-    totalSteps: 1,
-    ...overrides,
-  };
-}
+const makeStepProps = createMakeStepProps({totalSteps: 1});
 
 let mockPopup: Window;
 
-function dispatchPipelineMessage({
-  data,
-  origin = document.location.origin,
-  source = mockPopup,
-}: {
-  data: Record<string, string>;
-  origin?: string;
-  source?: Window | MessageEventSource | null;
-}) {
-  act(() => {
-    const event = new MessageEvent('message', {data, origin});
-    Object.defineProperty(event, 'source', {value: source});
-    window.dispatchEvent(event);
-  });
-}
-
 beforeEach(() => {
-  mockPopup = {
-    closed: false,
-    close: jest.fn(),
-    focus: jest.fn(),
-  } as unknown as Window;
-  jest.spyOn(window, 'open').mockReturnValue(mockPopup);
+  mockPopup = setupMockPopup();
 });
 
 afterEach(() => {
@@ -82,6 +50,7 @@ describe('BitbucketAuthorizeStep', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Authorize Bitbucket'}));
 
     dispatchPipelineMessage({
+      source: mockPopup,
       data: {
         _pipeline_source: 'sentry-pipeline',
         jwt: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test',

--- a/static/app/components/pipeline/pipelineIntegrationClaudeCode.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationClaudeCode.spec.tsx
@@ -1,22 +1,11 @@
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {claudeCodeIntegrationPipeline} from './pipelineIntegrationClaudeCode';
-import type {PipelineStepProps} from './types';
+import {createMakeStepProps} from './testUtils';
 
 const ClaudeCodeApiKeyStep = claudeCodeIntegrationPipeline.steps[0].component;
 
-function makeStepProps<D, A>(
-  overrides: Partial<PipelineStepProps<D, A>> & {stepData: D}
-): PipelineStepProps<D, A> {
-  return {
-    advance: jest.fn(),
-    advanceError: null,
-    isAdvancing: false,
-    stepIndex: 0,
-    totalSteps: 1,
-    ...overrides,
-  };
-}
+const makeStepProps = createMakeStepProps({totalSteps: 1});
 
 describe('ClaudeCodeApiKeyStep', () => {
   it('renders the API key form', () => {

--- a/static/app/components/pipeline/pipelineIntegrationCursor.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationCursor.spec.tsx
@@ -1,22 +1,11 @@
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {cursorIntegrationPipeline} from './pipelineIntegrationCursor';
-import type {PipelineStepProps} from './types';
+import {createMakeStepProps} from './testUtils';
 
 const CursorApiKeyStep = cursorIntegrationPipeline.steps[0].component;
 
-function makeStepProps<D, A>(
-  overrides: Partial<PipelineStepProps<D, A>> & {stepData: D}
-): PipelineStepProps<D, A> {
-  return {
-    advance: jest.fn(),
-    advanceError: null,
-    isAdvancing: false,
-    stepIndex: 0,
-    totalSteps: 1,
-    ...overrides,
-  };
-}
+const makeStepProps = createMakeStepProps({totalSteps: 1});
 
 describe('CursorApiKeyStep', () => {
   it('renders the API key form', () => {

--- a/static/app/components/pipeline/pipelineIntegrationDiscord.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationDiscord.spec.tsx
@@ -1,48 +1,16 @@
-import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {discordIntegrationPipeline} from './pipelineIntegrationDiscord';
-import type {PipelineStepProps} from './types';
+import {createMakeStepProps, dispatchPipelineMessage, setupMockPopup} from './testUtils';
 
 const DiscordOAuthLoginStep = discordIntegrationPipeline.steps[0].component;
 
-function makeStepProps<D, A>(
-  overrides: Partial<PipelineStepProps<D, A>> & {stepData: D}
-): PipelineStepProps<D, A> {
-  return {
-    advance: jest.fn(),
-    advanceError: null,
-    isAdvancing: false,
-    stepIndex: 0,
-    totalSteps: 1,
-    ...overrides,
-  };
-}
+const makeStepProps = createMakeStepProps({totalSteps: 1});
 
 let mockPopup: Window;
 
-function dispatchPipelineMessage({
-  data,
-  origin = document.location.origin,
-  source = mockPopup,
-}: {
-  data: Record<string, string>;
-  origin?: string;
-  source?: Window | MessageEventSource | null;
-}) {
-  act(() => {
-    const event = new MessageEvent('message', {data, origin});
-    Object.defineProperty(event, 'source', {value: source});
-    window.dispatchEvent(event);
-  });
-}
-
 beforeEach(() => {
-  mockPopup = {
-    closed: false,
-    close: jest.fn(),
-    focus: jest.fn(),
-  } as unknown as Window;
-  jest.spyOn(window, 'open').mockReturnValue(mockPopup);
+  mockPopup = setupMockPopup();
 });
 
 afterEach(() => {
@@ -76,6 +44,7 @@ describe('DiscordOAuthLoginStep', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Authorize Discord'}));
 
     dispatchPipelineMessage({
+      source: mockPopup,
       data: {
         _pipeline_source: 'sentry-pipeline',
         code: 'auth-code-123',

--- a/static/app/components/pipeline/pipelineIntegrationGitHub.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationGitHub.spec.tsx
@@ -1,49 +1,17 @@
-import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {githubIntegrationPipeline} from './pipelineIntegrationGitHub';
-import type {PipelineStepProps} from './types';
+import {createMakeStepProps, dispatchPipelineMessage, setupMockPopup} from './testUtils';
 
 const GitHubOAuthLoginStep = githubIntegrationPipeline.steps[0].component;
 const OrgSelectionStep = githubIntegrationPipeline.steps[1].component;
 
-function makeStepProps<D, A>(
-  overrides: Partial<PipelineStepProps<D, A>> & {stepData: D}
-): PipelineStepProps<D, A> {
-  return {
-    advance: jest.fn(),
-    advanceError: null,
-    isAdvancing: false,
-    stepIndex: 0,
-    totalSteps: 2,
-    ...overrides,
-  };
-}
+const makeStepProps = createMakeStepProps({totalSteps: 2});
 
 let mockPopup: Window;
 
-function dispatchPipelineMessage({
-  data,
-  origin = document.location.origin,
-  source = mockPopup,
-}: {
-  data: Record<string, string>;
-  origin?: string;
-  source?: Window | MessageEventSource | null;
-}) {
-  act(() => {
-    const event = new MessageEvent('message', {data, origin});
-    Object.defineProperty(event, 'source', {value: source});
-    window.dispatchEvent(event);
-  });
-}
-
 beforeEach(() => {
-  mockPopup = {
-    closed: false,
-    close: jest.fn(),
-    focus: jest.fn(),
-  } as unknown as Window;
-  jest.spyOn(window, 'open').mockReturnValue(mockPopup);
+  mockPopup = setupMockPopup();
 });
 
 afterEach(() => {
@@ -54,7 +22,9 @@ describe('GitHubOAuthLoginStep', () => {
   it('renders the OAuth login step for GitHub', () => {
     render(
       <GitHubOAuthLoginStep
-        {...makeStepProps({stepData: {oauthUrl: 'https://github.com/login/oauth'}})}
+        {...makeStepProps({
+          stepData: {oauthUrl: 'https://github.com/login/oauth'},
+        })}
       />
     );
 
@@ -75,6 +45,7 @@ describe('GitHubOAuthLoginStep', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Authorize GitHub'}));
 
     dispatchPipelineMessage({
+      source: mockPopup,
       data: {
         _pipeline_source: 'sentry-pipeline',
         code: 'abc123',
@@ -234,6 +205,7 @@ describe('OrgSelectionStep', () => {
     );
 
     dispatchPipelineMessage({
+      source: mockPopup,
       data: {
         _pipeline_source: 'sentry-pipeline',
         installation_id: 'new-inst-99',
@@ -268,13 +240,7 @@ describe('OrgSelectionStep', () => {
   });
 
   it('disables install button when installAppUrl is not provided', () => {
-    render(
-      <OrgSelectionStep
-        {...makeStepProps({
-          stepData: {installationInfo: []},
-        })}
-      />
-    );
+    render(<OrgSelectionStep {...makeStepProps({stepData: {installationInfo: []}})} />);
 
     expect(screen.getByRole('button', {name: 'Install GitHub App'})).toBeDisabled();
   });

--- a/static/app/components/pipeline/pipelineIntegrationGitLab.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationGitLab.spec.tsx
@@ -1,49 +1,17 @@
-import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {gitlabIntegrationPipeline} from './pipelineIntegrationGitLab';
-import type {PipelineStepProps} from './types';
+import {createMakeStepProps, dispatchPipelineMessage, setupMockPopup} from './testUtils';
 
 const InstallationConfigStep = gitlabIntegrationPipeline.steps[0].component;
 const GitLabOAuthLoginStep = gitlabIntegrationPipeline.steps[1].component;
 
-function makeStepProps<D, A>(
-  overrides: Partial<PipelineStepProps<D, A>> & {stepData: D}
-): PipelineStepProps<D, A> {
-  return {
-    advance: jest.fn(),
-    advanceError: null,
-    isAdvancing: false,
-    stepIndex: 0,
-    totalSteps: 2,
-    ...overrides,
-  };
-}
+const makeStepProps = createMakeStepProps({totalSteps: 2});
 
 let mockPopup: Window;
 
-function dispatchPipelineMessage({
-  data,
-  origin = document.location.origin,
-  source = mockPopup,
-}: {
-  data: Record<string, string>;
-  origin?: string;
-  source?: Window | MessageEventSource | null;
-}) {
-  act(() => {
-    const event = new MessageEvent('message', {data, origin});
-    Object.defineProperty(event, 'source', {value: source});
-    window.dispatchEvent(event);
-  });
-}
-
 beforeEach(() => {
-  mockPopup = {
-    closed: false,
-    close: jest.fn(),
-    focus: jest.fn(),
-  } as unknown as Window;
-  jest.spyOn(window, 'open').mockReturnValue(mockPopup);
+  mockPopup = setupMockPopup();
 });
 
 afterEach(() => {
@@ -110,10 +78,7 @@ describe('InstallationConfigStep', () => {
     const advance = jest.fn();
     render(
       <InstallationConfigStep
-        {...makeStepProps({
-          stepData: {setupValues: []},
-          advance,
-        })}
+        {...makeStepProps({stepData: {setupValues: []}, advance})}
       />
     );
 
@@ -145,10 +110,7 @@ describe('InstallationConfigStep', () => {
     const advance = jest.fn();
     render(
       <InstallationConfigStep
-        {...makeStepProps({
-          stepData: {setupValues: []},
-          advance,
-        })}
+        {...makeStepProps({stepData: {setupValues: []}, advance})}
       />
     );
 
@@ -212,10 +174,7 @@ describe('InstallationConfigStep', () => {
     const advance = jest.fn();
     render(
       <InstallationConfigStep
-        {...makeStepProps({
-          stepData: {setupValues: []},
-          advance,
-        })}
+        {...makeStepProps({stepData: {setupValues: []}, advance})}
       />
     );
 
@@ -256,10 +215,7 @@ describe('InstallationConfigStep', () => {
     const advance = jest.fn();
     render(
       <InstallationConfigStep
-        {...makeStepProps({
-          stepData: {setupValues: []},
-          advance,
-        })}
+        {...makeStepProps({stepData: {setupValues: []}, advance})}
       />
     );
 
@@ -311,7 +267,9 @@ describe('GitLabOAuthLoginStep', () => {
   it('renders the OAuth login step for GitLab', () => {
     render(
       <GitLabOAuthLoginStep
-        {...makeStepProps({stepData: {oauthUrl: 'https://gitlab.com/oauth/authorize'}})}
+        {...makeStepProps({
+          stepData: {oauthUrl: 'https://gitlab.com/oauth/authorize'},
+        })}
       />
     );
 
@@ -332,6 +290,7 @@ describe('GitLabOAuthLoginStep', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Authorize GitLab'}));
 
     dispatchPipelineMessage({
+      source: mockPopup,
       data: {
         _pipeline_source: 'sentry-pipeline',
         code: 'auth-code-123',

--- a/static/app/components/pipeline/pipelineIntegrationOpsgenie.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationOpsgenie.spec.tsx
@@ -1,22 +1,11 @@
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {opsgenieIntegrationPipeline} from './pipelineIntegrationOpsgenie';
-import type {PipelineStepProps} from './types';
+import {createMakeStepProps} from './testUtils';
 
 const OpsgenieInstallationConfigStep = opsgenieIntegrationPipeline.steps[0].component;
 
-function makeStepProps<D, A>(
-  overrides: Partial<PipelineStepProps<D, A>> & {stepData: D}
-): PipelineStepProps<D, A> {
-  return {
-    advance: jest.fn(),
-    advanceError: null,
-    isAdvancing: false,
-    stepIndex: 0,
-    totalSteps: 1,
-    ...overrides,
-  };
-}
+const makeStepProps = createMakeStepProps({totalSteps: 1});
 
 const baseUrlChoices = [
   {value: 'https://api.opsgenie.com/', label: 'api.opsgenie.com'},

--- a/static/app/components/pipeline/pipelineIntegrationPagerDuty.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationPagerDuty.spec.tsx
@@ -1,48 +1,16 @@
-import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {pagerDutyIntegrationPipeline} from './pipelineIntegrationPagerDuty';
-import type {PipelineStepProps} from './types';
+import {createMakeStepProps, dispatchPipelineMessage, setupMockPopup} from './testUtils';
 
 const PagerDutyInstallStep = pagerDutyIntegrationPipeline.steps[0].component;
 
-function makeStepProps<D, A>(
-  overrides: Partial<PipelineStepProps<D, A>> & {stepData: D}
-): PipelineStepProps<D, A> {
-  return {
-    advance: jest.fn(),
-    advanceError: null,
-    isAdvancing: false,
-    stepIndex: 0,
-    totalSteps: 1,
-    ...overrides,
-  };
-}
+const makeStepProps = createMakeStepProps({totalSteps: 1});
 
 let mockPopup: Window;
 
-function dispatchPipelineMessage({
-  data,
-  origin = document.location.origin,
-  source = mockPopup,
-}: {
-  data: Record<string, string>;
-  origin?: string;
-  source?: Window | MessageEventSource | null;
-}) {
-  act(() => {
-    const event = new MessageEvent('message', {data, origin});
-    Object.defineProperty(event, 'source', {value: source});
-    window.dispatchEvent(event);
-  });
-}
-
 beforeEach(() => {
-  mockPopup = {
-    closed: false,
-    close: jest.fn(),
-    focus: jest.fn(),
-  } as unknown as Window;
-  jest.spyOn(window, 'open').mockReturnValue(mockPopup);
+  mockPopup = setupMockPopup();
 });
 
 afterEach(() => {
@@ -78,6 +46,7 @@ describe('PagerDutyInstallStep', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Install PagerDuty App'}));
 
     dispatchPipelineMessage({
+      source: mockPopup,
       data: {
         _pipeline_source: 'sentry-pipeline',
         config: '{"account":{"name":"Test","subdomain":"test"}}',

--- a/static/app/components/pipeline/pipelineIntegrationSlack.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationSlack.spec.tsx
@@ -1,48 +1,16 @@
-import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {slackIntegrationPipeline} from './pipelineIntegrationSlack';
-import type {PipelineStepProps} from './types';
+import {createMakeStepProps, dispatchPipelineMessage, setupMockPopup} from './testUtils';
 
 const SlackOAuthLoginStep = slackIntegrationPipeline.steps[0].component;
 
-function makeStepProps<D, A>(
-  overrides: Partial<PipelineStepProps<D, A>> & {stepData: D}
-): PipelineStepProps<D, A> {
-  return {
-    advance: jest.fn(),
-    advanceError: null,
-    isAdvancing: false,
-    stepIndex: 0,
-    totalSteps: 1,
-    ...overrides,
-  };
-}
+const makeStepProps = createMakeStepProps({totalSteps: 1});
 
 let mockPopup: Window;
 
-function dispatchPipelineMessage({
-  data,
-  origin = document.location.origin,
-  source = mockPopup,
-}: {
-  data: Record<string, string>;
-  origin?: string;
-  source?: Window | MessageEventSource | null;
-}) {
-  act(() => {
-    const event = new MessageEvent('message', {data, origin});
-    Object.defineProperty(event, 'source', {value: source});
-    window.dispatchEvent(event);
-  });
-}
-
 beforeEach(() => {
-  mockPopup = {
-    closed: false,
-    close: jest.fn(),
-    focus: jest.fn(),
-  } as unknown as Window;
-  jest.spyOn(window, 'open').mockReturnValue(mockPopup);
+  mockPopup = setupMockPopup();
 });
 
 afterEach(() => {
@@ -53,7 +21,9 @@ describe('SlackOAuthLoginStep', () => {
   it('renders the OAuth login step for Slack', () => {
     render(
       <SlackOAuthLoginStep
-        {...makeStepProps({stepData: {oauthUrl: 'https://slack.com/oauth/authorize'}})}
+        {...makeStepProps({
+          stepData: {oauthUrl: 'https://slack.com/oauth/authorize'},
+        })}
       />
     );
 
@@ -74,6 +44,7 @@ describe('SlackOAuthLoginStep', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Authorize Slack'}));
 
     dispatchPipelineMessage({
+      source: mockPopup,
       data: {
         _pipeline_source: 'sentry-pipeline',
         code: 'auth-code-123',

--- a/static/app/components/pipeline/pipelineIntegrationVercel.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationVercel.spec.tsx
@@ -1,48 +1,16 @@
-import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {vercelIntegrationPipeline} from './pipelineIntegrationVercel';
-import type {PipelineStepProps} from './types';
+import {createMakeStepProps, dispatchPipelineMessage, setupMockPopup} from './testUtils';
 
 const VercelOAuthLoginStep = vercelIntegrationPipeline.steps[0].component;
 
-function makeStepProps<D, A>(
-  overrides: Partial<PipelineStepProps<D, A>> & {stepData: D}
-): PipelineStepProps<D, A> {
-  return {
-    advance: jest.fn(),
-    advanceError: null,
-    isAdvancing: false,
-    stepIndex: 0,
-    totalSteps: 1,
-    ...overrides,
-  };
-}
+const makeStepProps = createMakeStepProps({totalSteps: 1});
 
 let mockPopup: Window;
 
-function dispatchPipelineMessage({
-  data,
-  origin = document.location.origin,
-  source = mockPopup,
-}: {
-  data: Record<string, string>;
-  origin?: string;
-  source?: Window | MessageEventSource | null;
-}) {
-  act(() => {
-    const event = new MessageEvent('message', {data, origin});
-    Object.defineProperty(event, 'source', {value: source});
-    window.dispatchEvent(event);
-  });
-}
-
 beforeEach(() => {
-  mockPopup = {
-    closed: false,
-    close: jest.fn(),
-    focus: jest.fn(),
-  } as unknown as Window;
-  jest.spyOn(window, 'open').mockReturnValue(mockPopup);
+  mockPopup = setupMockPopup();
 });
 
 afterEach(() => {
@@ -53,7 +21,9 @@ describe('VercelOAuthLoginStep', () => {
   it('renders the OAuth login step for Vercel', () => {
     render(
       <VercelOAuthLoginStep
-        {...makeStepProps({stepData: {oauthUrl: 'https://vercel.com/oauth/authorize'}})}
+        {...makeStepProps({
+          stepData: {oauthUrl: 'https://vercel.com/oauth/authorize'},
+        })}
       />
     );
 
@@ -74,6 +44,7 @@ describe('VercelOAuthLoginStep', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Authorize Vercel'}));
 
     dispatchPipelineMessage({
+      source: mockPopup,
       data: {
         _pipeline_source: 'sentry-pipeline',
         code: 'auth-code-123',

--- a/static/app/components/pipeline/pipelineIntegrationVsts.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationVsts.spec.tsx
@@ -1,49 +1,17 @@
-import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {vstsIntegrationPipeline} from './pipelineIntegrationVsts';
-import type {PipelineStepProps} from './types';
+import {createMakeStepProps, dispatchPipelineMessage, setupMockPopup} from './testUtils';
 
 const VstsOAuthLoginStep = vstsIntegrationPipeline.steps[0].component;
 const VstsAccountSelectionStep = vstsIntegrationPipeline.steps[1].component;
 
-function makeStepProps<D, A>(
-  overrides: Partial<PipelineStepProps<D, A>> & {stepData: D}
-): PipelineStepProps<D, A> {
-  return {
-    advance: jest.fn(),
-    advanceError: null,
-    isAdvancing: false,
-    stepIndex: 0,
-    totalSteps: 2,
-    ...overrides,
-  };
-}
+const makeStepProps = createMakeStepProps({totalSteps: 2});
 
 let mockPopup: Window;
 
-function dispatchPipelineMessage({
-  data,
-  origin = document.location.origin,
-  source = mockPopup,
-}: {
-  data: Record<string, string>;
-  origin?: string;
-  source?: Window | MessageEventSource | null;
-}) {
-  act(() => {
-    const event = new MessageEvent('message', {data, origin});
-    Object.defineProperty(event, 'source', {value: source});
-    window.dispatchEvent(event);
-  });
-}
-
 beforeEach(() => {
-  mockPopup = {
-    closed: false,
-    close: jest.fn(),
-    focus: jest.fn(),
-  } as unknown as Window;
-  jest.spyOn(window, 'open').mockReturnValue(mockPopup);
+  mockPopup = setupMockPopup();
 });
 
 afterEach(() => {
@@ -83,6 +51,7 @@ describe('VstsOAuthLoginStep', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Authorize Azure DevOps'}));
 
     dispatchPipelineMessage({
+      source: mockPopup,
       data: {
         _pipeline_source: 'sentry-pipeline',
         code: 'auth-code-123',

--- a/static/app/components/pipeline/shared/oauthLoginStep.spec.tsx
+++ b/static/app/components/pipeline/shared/oauthLoginStep.spec.tsx
@@ -1,4 +1,9 @@
-import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {
+  dispatchPipelineMessage,
+  setupMockPopup,
+} from 'sentry/components/pipeline/testUtils';
 
 import {OAuthLoginStep} from './oauthLoginStep';
 
@@ -8,33 +13,12 @@ describe('OAuthLoginStep', () => {
 
   beforeEach(() => {
     mockOnOAuthCallback.mockClear();
-    mockPopup = {
-      closed: false,
-      close: jest.fn(),
-      focus: jest.fn(),
-    } as unknown as Window;
-    jest.spyOn(window, 'open').mockReturnValue(mockPopup);
+    mockPopup = setupMockPopup();
   });
 
   afterEach(() => {
     jest.restoreAllMocks();
   });
-
-  function dispatchPipelineMessage({
-    data,
-    origin = document.location.origin,
-    source = mockPopup,
-  }: {
-    data: Record<string, string>;
-    origin?: string;
-    source?: Window | MessageEventSource | null;
-  }) {
-    act(() => {
-      window.dispatchEvent(
-        new MessageEvent('message', {data, origin, source: source as Window})
-      );
-    });
-  }
 
   it('renders the authorize button with the service name', () => {
     render(
@@ -108,6 +92,7 @@ describe('OAuthLoginStep', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Authorize GitLab'}));
 
     dispatchPipelineMessage({
+      source: mockPopup,
       data: {
         _pipeline_source: 'sentry-pipeline',
         code: 'auth-code-123',
@@ -135,6 +120,7 @@ describe('OAuthLoginStep', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Authorize GitLab'}));
 
     dispatchPipelineMessage({
+      source: mockPopup,
       data: {source: 'some-extension', code: 'nope'},
     });
 
@@ -153,6 +139,7 @@ describe('OAuthLoginStep', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Authorize GitLab'}));
 
     dispatchPipelineMessage({
+      source: mockPopup,
       data: {
         _pipeline_source: 'sentry-pipeline',
         code: 'auth-code-123',

--- a/static/app/components/pipeline/testUtils.tsx
+++ b/static/app/components/pipeline/testUtils.tsx
@@ -1,0 +1,64 @@
+import {act} from 'react';
+
+import type {PipelineStepProps} from './types';
+
+/**
+ * Creates a makeStepProps helper pre-filled with pipeline-specific defaults.
+ *
+ * Call once at the top of a describe block:
+ *
+ *   const makeStepProps = createMakeStepProps({totalSteps: 2});
+ *
+ * Then use in each test:
+ *
+ *   makeStepProps({stepData: {...}})
+ */
+export function createMakeStepProps(
+  defaults: Partial<PipelineStepProps<any, any>> & {totalSteps: number}
+) {
+  return function makeStepProps<D, A>(
+    overrides: Partial<PipelineStepProps<D, A>> & {stepData: D}
+  ): PipelineStepProps<D, A> {
+    return {
+      advance: jest.fn(),
+      advanceError: null,
+      isAdvancing: false,
+      stepIndex: 0,
+      ...defaults,
+      ...overrides,
+    };
+  };
+}
+
+/**
+ * Sets up a mock popup window and spies on window.open to return it.
+ * Call in beforeEach. Remember to call jest.restoreAllMocks() in afterEach.
+ */
+export function setupMockPopup(): Window {
+  const popup = {
+    closed: false,
+    close: jest.fn(),
+    focus: jest.fn(),
+  } as unknown as Window;
+  jest.spyOn(window, 'open').mockReturnValue(popup);
+  return popup;
+}
+
+/**
+ * Dispatches a MessageEvent simulating a pipeline popup callback.
+ */
+export function dispatchPipelineMessage({
+  data,
+  origin = document.location.origin,
+  source,
+}: {
+  data: Record<string, string>;
+  source: Window | MessageEventSource | null;
+  origin?: string;
+}) {
+  act(() => {
+    const event = new MessageEvent('message', {data, origin});
+    Object.defineProperty(event, 'source', {value: source});
+    window.dispatchEvent(event);
+  });
+}


### PR DESCRIPTION
Move duplicated makeStepProps factory, mock popup setup, and
dispatchPipelineMessage helper into a shared testUtils module.
createMakeStepProps captures pipeline-specific defaults (like
totalSteps) once per file, keeping individual test calls clean.