### PR TITLE
fix(assisted-query): Apply Seer visualizations and sort to metrics page

### DIFF
--- a/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox.tsx
@@ -105,6 +105,11 @@ interface AskSeerPollingComboBoxProps<T extends QueryTokensProps> extends Omit<
    */
   fallbackMutationOptions?: UseMutationOptions<any, Error, string>;
   /**
+   * Optional key-value options to pass to the search agent start endpoint.
+   * Used for strategy-specific context (e.g., metric name/type/unit for Metrics).
+   */
+  options?: Record<string, unknown>;
+  /**
    * Transform the final response from the polling API to the expected format.
    * This allows customization of how the response is converted to query items.
    */
@@ -118,6 +123,7 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
   strategy,
   transformResponse,
   fallbackMutationOptions,
+  options: extraOptions,
   ...props
 }: AskSeerPollingComboBoxProps<T>) {
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -159,6 +165,7 @@ export function AskSeerPollingComboBox<T extends QueryTokensProps>({
   } = useAskSeerPolling<T>({
     projectIds,
     strategy,
+    options: extraOptions,
     onError: error => {
       addErrorMessage(t('Failed to process AI query: %(error)s', {error: error.message}));
       trackAnalytics('ai_query.error', {

--- a/static/app/components/searchQueryBuilder/askSeerCombobox/useAskSeerPolling.tsx
+++ b/static/app/components/searchQueryBuilder/askSeerCombobox/useAskSeerPolling.tsx
@@ -60,6 +60,7 @@ interface UseAskSeerPollingOptions<T extends QueryTokensProps> {
   strategy: string;
   onError?: (error: Error) => void;
   onSuccess?: (result: T) => void;
+  options?: Record<string, unknown>;
 }
 
 /**
@@ -117,6 +118,7 @@ export function useAskSeerPolling<T extends QueryTokensProps>(
               natural_language_query: query,
               project_ids: options.projectIds,
               strategy: options.strategy,
+              ...(options.options ? {options: options.options} : {}),
             },
           }
         )) as AskSeerStartResponse;

--- a/static/app/utils/analytics/metricsAnalyticsEvent.tsx
+++ b/static/app/utils/analytics/metricsAnalyticsEvent.tsx
@@ -2,21 +2,6 @@ import type {Organization} from 'sentry/types/organization';
 import type {PlatformKey} from 'sentry/types/project';
 
 export type MetricsAnalyticsEventParameters = {
-  'metrics.ai_query_applied': {
-    group_by_count: number;
-    query: string;
-    visualize_count: number;
-  };
-  'metrics.ai_query_interface': {
-    action: 'opened' | 'closed' | 'consent_accepted';
-  };
-  'metrics.ai_query_rejected': {
-    natural_language_query: string;
-    num_queries_returned: number;
-  };
-  'metrics.ai_query_submitted': {
-    natural_language_query: string;
-  };
   'metrics.explorer.metadata': {
     datetime_selection: string;
     environment_count: number;
@@ -87,10 +72,6 @@ export type MetricsAnalyticsEventParameters = {
 type MetricsAnalyticsEventKey = keyof MetricsAnalyticsEventParameters;
 
 export const metricsAnalyticsEventMap: Record<MetricsAnalyticsEventKey, string | null> = {
-  'metrics.ai_query_applied': 'Metrics AI Query Applied',
-  'metrics.ai_query_interface': 'Metrics AI Query Interface',
-  'metrics.ai_query_rejected': 'Metrics AI Query Rejected',
-  'metrics.ai_query_submitted': 'Metrics AI Query Submitted',
   'metrics.explorer.metadata': 'Metric Explorer Pageload Metadata',
   'metrics.explorer.panel.metadata': 'Metric Explorer Panel Metadata',
   'metrics.issue_details.drawer_opened': 'Metrics Issue Details Drawer Opened',

--- a/static/app/utils/analytics/metricsAnalyticsEvent.tsx
+++ b/static/app/utils/analytics/metricsAnalyticsEvent.tsx
@@ -2,6 +2,21 @@ import type {Organization} from 'sentry/types/organization';
 import type {PlatformKey} from 'sentry/types/project';
 
 export type MetricsAnalyticsEventParameters = {
+  'metrics.ai_query_applied': {
+    group_by_count: number;
+    query: string;
+    visualize_count: number;
+  };
+  'metrics.ai_query_interface': {
+    action: 'opened' | 'closed' | 'consent_accepted';
+  };
+  'metrics.ai_query_rejected': {
+    natural_language_query: string;
+    num_queries_returned: number;
+  };
+  'metrics.ai_query_submitted': {
+    natural_language_query: string;
+  };
   'metrics.explorer.metadata': {
     datetime_selection: string;
     environment_count: number;
@@ -72,6 +87,10 @@ export type MetricsAnalyticsEventParameters = {
 type MetricsAnalyticsEventKey = keyof MetricsAnalyticsEventParameters;
 
 export const metricsAnalyticsEventMap: Record<MetricsAnalyticsEventKey, string | null> = {
+  'metrics.ai_query_applied': 'Metrics AI Query Applied',
+  'metrics.ai_query_interface': 'Metrics AI Query Interface',
+  'metrics.ai_query_rejected': 'Metrics AI Query Rejected',
+  'metrics.ai_query_submitted': 'Metrics AI Query Submitted',
   'metrics.explorer.metadata': 'Metric Explorer Pageload Metadata',
   'metrics.explorer.panel.metadata': 'Metric Explorer Panel Metadata',
   'metrics.issue_details.drawer_opened': 'Metrics Issue Details Drawer Opened',

--- a/static/app/views/explore/metrics/metricToolbar/filter.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/filter.tsx
@@ -58,9 +58,9 @@ export function Filter({traceMetric}: FilterProps) {
   const setQuery = useSetQueryParamsQuery();
   const organization = useOrganization();
 
-  const hasTranslateEndpoint = organization.features.includes(
-    'gen-ai-explore-metrics-search'
-  );
+  const hasTranslateEndpoint =
+    organization.features.includes('gen-ai-search-agent-translate') &&
+    organization.features.includes('gen-ai-explore-metrics-search');
 
   const traceMetricFilter = createTraceMetricFilter(traceMetric);
 

--- a/static/app/views/explore/metrics/metricToolbar/filter.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/filter.tsx
@@ -1,8 +1,12 @@
 import {useMemo} from 'react';
 
-import {SearchQueryBuilderProvider} from 'sentry/components/searchQueryBuilder/context';
+import {
+  SearchQueryBuilderProvider,
+  useSearchQueryBuilder,
+} from 'sentry/components/searchQueryBuilder/context';
 import type {TagCollection} from 'sentry/types/group';
 import {FieldKind} from 'sentry/utils/fields';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   TraceItemSearchQueryBuilder,
   useTraceItemSearchQueryBuilderProps,
@@ -16,6 +20,7 @@ import {
 import {useTraceItemAttributeKeys} from 'sentry/views/explore/hooks/useTraceItemAttributeKeys';
 import {HiddenTraceMetricSearchFields} from 'sentry/views/explore/metrics/constants';
 import {type TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
+import {MetricsTabSeerComboBox} from 'sentry/views/explore/metrics/metricsTabSeerComboBox';
 import {createTraceMetricFilter} from 'sentry/views/explore/metrics/utils';
 import {
   useQueryParamsQuery,
@@ -30,9 +35,28 @@ interface FilterProps {
   traceMetric: TraceMetric;
 }
 
+interface MetricsSearchBarProps {
+  tracesItemSearchQueryBuilderProps: TraceItemSearchQueryBuilderProps;
+}
+
+function MetricsSearchBar({tracesItemSearchQueryBuilderProps}: MetricsSearchBarProps) {
+  const {displayAskSeer} = useSearchQueryBuilder();
+
+  if (displayAskSeer) {
+    return <MetricsTabSeerComboBox />;
+  }
+
+  return <TraceItemSearchQueryBuilder {...tracesItemSearchQueryBuilderProps} />;
+}
+
 export function Filter({traceMetric}: FilterProps) {
   const query = useQueryParamsQuery();
   const setQuery = useSetQueryParamsQuery();
+  const organization = useOrganization();
+
+  const hasTranslateEndpoint = organization.features.includes(
+    'gen-ai-search-agent-translate'
+  );
 
   const traceMetricFilter = createTraceMetricFilter(traceMetric);
 
@@ -142,9 +166,13 @@ export function Filter({traceMetric}: FilterProps) {
       // Use the metric name as a key to force remount when it changes
       // This prevents race conditions when navigating between different metrics
       key={traceMetric.name}
+      enableAISearch={hasTranslateEndpoint}
+      aiSearchBadgeType="alpha"
       {...searchQueryBuilderProviderProps}
     >
-      <TraceItemSearchQueryBuilder {...tracesItemSearchQueryBuilderProps} />
+      <MetricsSearchBar
+        tracesItemSearchQueryBuilderProps={tracesItemSearchQueryBuilderProps}
+      />
     </SearchQueryBuilderProvider>
   );
 }

--- a/static/app/views/explore/metrics/metricToolbar/filter.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/filter.tsx
@@ -166,9 +166,9 @@ export function Filter({traceMetric}: FilterProps) {
       // Use the metric name as a key to force remount when it changes
       // This prevents race conditions when navigating between different metrics
       key={traceMetric.name}
+      {...searchQueryBuilderProviderProps}
       enableAISearch={hasTranslateEndpoint}
       aiSearchBadgeType="alpha"
-      {...searchQueryBuilderProviderProps}
     >
       <MetricsSearchBar
         tracesItemSearchQueryBuilderProps={tracesItemSearchQueryBuilderProps}

--- a/static/app/views/explore/metrics/metricToolbar/filter.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/filter.tsx
@@ -36,14 +36,18 @@ interface FilterProps {
 }
 
 interface MetricsSearchBarProps {
+  traceMetric: TraceMetric;
   tracesItemSearchQueryBuilderProps: TraceItemSearchQueryBuilderProps;
 }
 
-function MetricsSearchBar({tracesItemSearchQueryBuilderProps}: MetricsSearchBarProps) {
+function MetricsSearchBar({
+  tracesItemSearchQueryBuilderProps,
+  traceMetric,
+}: MetricsSearchBarProps) {
   const {displayAskSeer} = useSearchQueryBuilder();
 
   if (displayAskSeer) {
-    return <MetricsTabSeerComboBox />;
+    return <MetricsTabSeerComboBox traceMetric={traceMetric} />;
   }
 
   return <TraceItemSearchQueryBuilder {...tracesItemSearchQueryBuilderProps} />;
@@ -55,7 +59,7 @@ export function Filter({traceMetric}: FilterProps) {
   const organization = useOrganization();
 
   const hasTranslateEndpoint = organization.features.includes(
-    'gen-ai-search-agent-translate'
+    'gen-ai-explore-metrics-search'
   );
 
   const traceMetricFilter = createTraceMetricFilter(traceMetric);
@@ -172,6 +176,7 @@ export function Filter({traceMetric}: FilterProps) {
     >
       <MetricsSearchBar
         tracesItemSearchQueryBuilderProps={tracesItemSearchQueryBuilderProps}
+        traceMetric={traceMetric}
       />
     </SearchQueryBuilderProvider>
   );

--- a/static/app/views/explore/metrics/metricToolbar/filter.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/filter.tsx
@@ -58,9 +58,12 @@ export function Filter({traceMetric}: FilterProps) {
   const setQuery = useSetQueryParamsQuery();
   const organization = useOrganization();
 
-  const hasTranslateEndpoint =
-    organization.features.includes('gen-ai-search-agent-translate') &&
-    organization.features.includes('gen-ai-explore-metrics-search');
+  const hasTranslateEndpoint = organization.features.includes(
+    'gen-ai-search-agent-translate'
+  );
+  const hasMetricsAISearch = organization.features.includes(
+    'gen-ai-explore-metrics-search'
+  );
 
   const traceMetricFilter = createTraceMetricFilter(traceMetric);
 
@@ -171,7 +174,7 @@ export function Filter({traceMetric}: FilterProps) {
       // This prevents race conditions when navigating between different metrics
       key={traceMetric.name}
       {...searchQueryBuilderProviderProps}
-      enableAISearch={hasTranslateEndpoint}
+      enableAISearch={hasTranslateEndpoint && hasMetricsAISearch}
       aiSearchBadgeType="alpha"
     >
       <MetricsSearchBar

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -11,6 +11,7 @@ import {stringifyToken} from 'sentry/components/searchSyntax/utils';
 import {ConfigStore} from 'sentry/stores/configStore';
 import type {DateString} from 'sentry/types/core';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import type {Sort} from 'sentry/utils/discover/fields';
 import {getFieldDefinition} from 'sentry/utils/fields';
 import {fetchMutation, mutationOptions} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -18,6 +19,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
 import {
+  defaultAggregateSortBys,
   encodeMetricQueryParams,
   type BaseMetricQuery,
   type TraceMetric,
@@ -25,9 +27,8 @@ import {
 import {useMultiMetricsQueryParams} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
 import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateField';
 import {useQueryParams} from 'sentry/views/explore/queryParams/context';
-import {isGroupBy} from 'sentry/views/explore/queryParams/groupBy';
 import {Mode} from 'sentry/views/explore/queryParams/mode';
-import {isVisualize} from 'sentry/views/explore/queryParams/visualize';
+import {isVisualize, VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 import type {ChartType} from 'sentry/views/insights/common/components/chart';
 
 interface MetricsTabSeerComboBoxProps {
@@ -201,49 +202,53 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
             ? Mode.AGGREGATE
             : Mode.SAMPLES;
 
-      // Build aggregateFields array (same merge logic as LogsTabSeerComboBox)
-      // This combines groupBys with existing visualizations
-      let seenVisualizes = false;
-      let groupByAfterVisualizes = false;
+      // Convert Seer visualizations to VisualizeFunction objects
+      const seerVisualizes = visualizations.flatMap(viz =>
+        viz.yAxes.map(yAxis => new VisualizeFunction(yAxis, {chartType: viz.chartType}))
+      );
 
-      for (const aggregateField of queryParams.aggregateFields) {
-        if (isGroupBy(aggregateField) && seenVisualizes) {
-          groupByAfterVisualizes = true;
-          break;
-        } else if (isVisualize(aggregateField)) {
-          seenVisualizes = true;
-        }
-      }
-
+      // Build aggregateFields: groupBys first, then visualizes
       const aggregateFields: AggregateField[] = [];
-      const iter = groupBys[Symbol.iterator]();
 
-      for (const aggregateField of queryParams.aggregateFields) {
-        if (isVisualize(aggregateField)) {
-          if (!groupByAfterVisualizes) {
-            // Insert group bys before visualizes
-            for (const groupBy of iter) {
-              aggregateFields.push({groupBy});
-            }
-          }
-          aggregateFields.push(aggregateField);
-        } else if (isGroupBy(aggregateField)) {
-          const {value: groupBy, done} = iter.next();
-          if (!done) {
-            aggregateFields.push({groupBy});
-          }
-        }
-      }
-
-      // Add any remaining group bys
-      for (const groupBy of iter) {
+      for (const groupBy of groupBys) {
         aggregateFields.push({groupBy});
       }
+
+      // Use Seer visualizes if provided, otherwise preserve existing
+      if (seerVisualizes.length > 0) {
+        for (const viz of seerVisualizes) {
+          aggregateFields.push(viz);
+        }
+      } else {
+        for (const field of queryParams.aggregateFields) {
+          if (isVisualize(field)) {
+            aggregateFields.push(field);
+          }
+        }
+      }
+
+      // Parse and apply sort from Seer response
+      const parseSeerSort = (sortStr: string): Sort => {
+        if (sortStr.startsWith('-')) {
+          return {field: sortStr.slice(1), kind: 'desc'};
+        }
+        return {field: sortStr, kind: 'asc'};
+      };
+
+      const seerSort = result.sort ? parseSeerSort(result.sort) : undefined;
+      const aggregateSortBys =
+        mode === Mode.AGGREGATE && seerSort
+          ? [seerSort]
+          : defaultAggregateSortBys(aggregateFields);
+      const sortBys =
+        mode === Mode.SAMPLES && seerSort ? [seerSort] : queryParams.sortBys;
 
       // Build updated ReadableQueryParams for this metric
       const newQueryParams = queryParams.replace({
         query: queryToUse,
         aggregateFields,
+        aggregateSortBys,
+        sortBys,
         mode,
       });
 

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -1,0 +1,368 @@
+import {useCallback, useMemo} from 'react';
+
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {AskSeerComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox';
+import {AskSeerPollingComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox';
+import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
+import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils';
+import {Token} from 'sentry/components/searchSyntax/parser';
+import {stringifyToken} from 'sentry/components/searchSyntax/utils';
+import {ConfigStore} from 'sentry/stores/configStore';
+import type {DateString} from 'sentry/types/core';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {getFieldDefinition} from 'sentry/utils/fields';
+import {fetchMutation, mutationOptions} from 'sentry/utils/queryClient';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {useProjects} from 'sentry/utils/useProjects';
+import type {WritableAggregateField} from 'sentry/views/explore/queryParams/aggregateField';
+import {
+  useQueryParams,
+  useSetQueryParams,
+} from 'sentry/views/explore/queryParams/context';
+import {isGroupBy} from 'sentry/views/explore/queryParams/groupBy';
+import {Mode} from 'sentry/views/explore/queryParams/mode';
+import {isVisualize} from 'sentry/views/explore/queryParams/visualize';
+import type {ChartType} from 'sentry/views/insights/common/components/chart';
+
+interface Visualization {
+  chartType: ChartType;
+  yAxes: string[];
+}
+
+interface AskSeerSearchQuery {
+  end: string | null;
+  groupBys: string[];
+  mode: string;
+  query: string;
+  sort: string;
+  start: string | null;
+  statsPeriod: string;
+  visualizations: Visualization[];
+}
+
+interface MetricsAskSeerTranslateResponse {
+  responses: Array<{
+    end: string | null;
+    group_by: string[];
+    mode: string;
+    query: string;
+    sort: string;
+    start: string | null;
+    stats_period: string;
+    visualization: Array<{
+      chart_type: number;
+      y_axes: string[];
+    }>;
+  }>;
+  unsupported_reason: string | null;
+}
+
+export function MetricsTabSeerComboBox() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const {projects} = useProjects();
+  const pageFilters = usePageFilters();
+  const organization = useOrganization();
+  const queryParams = useQueryParams();
+  const setQueryParams = useSetQueryParams();
+  const {
+    currentInputValueRef,
+    query,
+    committedQuery,
+    askSeerSuggestedQueryRef,
+    enableAISearch,
+  } = useSearchQueryBuilder();
+
+  let initialSeerQuery = '';
+  const queryDetails = useMemo(() => {
+    const queryToUse = committedQuery.length > 0 ? committedQuery : query;
+    const parsedQuery = parseQueryBuilderValue(queryToUse, getFieldDefinition);
+    return {parsedQuery, queryToUse};
+  }, [committedQuery, query]);
+
+  const inputValue = currentInputValueRef.current.trim();
+
+  // Only filter out FREE_TEXT tokens if there's actual input value to filter by
+  const filteredCommittedQuery = queryDetails?.parsedQuery
+    ?.filter(
+      token =>
+        !(token.type === Token.FREE_TEXT && inputValue && token.text.includes(inputValue))
+    )
+    ?.map(token => stringifyToken(token))
+    ?.join(' ')
+    ?.trim();
+
+  // Use filteredCommittedQuery if it exists and has content, otherwise fall back to queryToUse
+  if (filteredCommittedQuery && filteredCommittedQuery.length > 0) {
+    initialSeerQuery = filteredCommittedQuery;
+  } else if (queryDetails?.queryToUse) {
+    initialSeerQuery = queryDetails.queryToUse;
+  }
+
+  if (inputValue) {
+    initialSeerQuery =
+      initialSeerQuery === '' ? inputValue : `${initialSeerQuery} ${inputValue}`;
+  }
+
+  const metricsTabAskSeerMutationOptions = mutationOptions({
+    mutationFn: async (queryToSubmit: string) => {
+      const selectedProjects =
+        pageFilters.selection.projects?.length > 0 &&
+        pageFilters.selection.projects?.[0] !== -1
+          ? pageFilters.selection.projects
+          : projects.filter(p => p.isMember).map(p => p.id);
+
+      const user = ConfigStore.get('user');
+      const data = await fetchMutation<MetricsAskSeerTranslateResponse>({
+        url: `/organizations/${organization.slug}/search-agent/translate/`,
+        method: 'POST',
+        data: {
+          org_id: organization.id,
+          org_slug: organization.slug,
+          natural_language_query: queryToSubmit,
+          project_ids: selectedProjects,
+          strategy: 'Metrics',
+          user_email: user?.email,
+        },
+      });
+
+      return {
+        status: 'ok',
+        unsupported_reason: data.unsupported_reason,
+        queries: data.responses.map(r => ({
+          visualizations:
+            r?.visualization?.map(v => ({
+              chartType: v?.chart_type,
+              yAxes: v?.y_axes ?? [],
+            })) ?? [],
+          query: r?.query ?? '',
+          sort: r?.sort ?? '',
+          groupBys: r?.group_by ?? [],
+          statsPeriod: r?.stats_period ?? '',
+          start: r?.start ?? null,
+          end: r?.end ?? null,
+          mode: r?.mode ?? 'metrics',
+        })),
+      };
+    },
+  });
+
+  const applySeerSearchQuery = useCallback(
+    (result: AskSeerSearchQuery) => {
+      if (!result) return;
+      const {
+        query: queryToUse,
+        groupBys,
+        statsPeriod,
+        start: resultStart,
+        end: resultEnd,
+        visualizations,
+      } = result;
+
+      let start: DateString = null;
+      let end: DateString = null;
+
+      if (resultStart && resultEnd) {
+        // Strip 'Z' suffix to treat UTC dates as local time
+        const startLocal = resultStart.endsWith('Z')
+          ? resultStart.slice(0, -1)
+          : resultStart;
+        const endLocal = resultEnd.endsWith('Z') ? resultEnd.slice(0, -1) : resultEnd;
+        start = new Date(startLocal).toISOString();
+        end = new Date(endLocal).toISOString();
+      } else {
+        start = pageFilters.selection.datetime.start;
+        end = pageFilters.selection.datetime.end;
+      }
+
+      // Update mode based on groupBys or response mode
+      const mode =
+        groupBys.length > 0
+          ? Mode.AGGREGATE
+          : result.mode === 'aggregates'
+            ? Mode.AGGREGATE
+            : Mode.SAMPLES;
+
+      // Build aggregateFields array (same merge logic as LogsTabSeerComboBox)
+      // This combines groupBys with existing visualizations
+      let seenVisualizes = false;
+      let groupByAfterVisualizes = false;
+
+      for (const aggregateField of queryParams.aggregateFields) {
+        if (isGroupBy(aggregateField) && seenVisualizes) {
+          groupByAfterVisualizes = true;
+          break;
+        } else if (isVisualize(aggregateField)) {
+          seenVisualizes = true;
+        }
+      }
+
+      const aggregateFields: WritableAggregateField[] = [];
+      const iter = groupBys[Symbol.iterator]();
+
+      for (const aggregateField of queryParams.aggregateFields) {
+        if (isVisualize(aggregateField)) {
+          if (!groupByAfterVisualizes) {
+            // Insert group bys before visualizes
+            for (const groupBy of iter) {
+              aggregateFields.push({groupBy});
+            }
+          }
+          aggregateFields.push(aggregateField.serialize());
+        } else if (isGroupBy(aggregateField)) {
+          const {value: groupBy, done} = iter.next();
+          if (!done) {
+            aggregateFields.push({groupBy});
+          }
+        }
+      }
+
+      // Add any remaining group bys
+      for (const groupBy of iter) {
+        aggregateFields.push({groupBy});
+      }
+
+      // Update per-query state atomically (query, aggregateFields, mode)
+      setQueryParams({query: queryToUse, aggregateFields, mode});
+
+      // Update global time range via navigation
+      const selection = {
+        ...pageFilters.selection,
+        datetime: {
+          start,
+          end,
+          utc: pageFilters.selection.datetime.utc,
+          period:
+            resultStart && resultEnd
+              ? null
+              : statsPeriod || pageFilters.selection.datetime.period,
+        },
+      };
+
+      askSeerSuggestedQueryRef.current = JSON.stringify({
+        selection,
+        query: queryToUse,
+        groupBys,
+        mode,
+      });
+
+      trackAnalytics('metrics.ai_query_applied', {
+        organization,
+        query: queryToUse,
+        group_by_count: groupBys.length,
+        visualize_count: visualizations?.length ?? 0,
+      });
+
+      // Navigate to update global time range params
+      navigate(
+        {
+          ...location,
+          query: {
+            ...location.query,
+            start: selection.datetime.start,
+            end: selection.datetime.end,
+            statsPeriod: selection.datetime.period,
+            utc: selection.datetime.utc,
+          },
+        },
+        {replace: true, preventScrollReset: true}
+      );
+    },
+    [
+      askSeerSuggestedQueryRef,
+      location,
+      navigate,
+      organization,
+      pageFilters.selection,
+      queryParams.aggregateFields,
+      setQueryParams,
+    ]
+  );
+
+  const usePollingEndpoint = organization.features.includes(
+    'gen-ai-search-agent-translate'
+  );
+
+  // Get selected project IDs for the polling variant
+  const selectedProjectIds = useMemo(() => {
+    if (
+      pageFilters.selection.projects?.length > 0 &&
+      pageFilters.selection.projects?.[0] !== -1
+    ) {
+      return pageFilters.selection.projects;
+    }
+    return projects.filter(p => p.isMember).map(p => parseInt(p.id, 10));
+  }, [pageFilters.selection.projects, projects]);
+
+  // Transform the final_response from Seer to match the expected format
+  const transformResponse = useCallback(
+    (response: AskSeerSearchQuery): AskSeerSearchQuery[] => {
+      const seerResponse = response as unknown as {
+        responses?: Array<{
+          end: string | null;
+          group_by: string[];
+          mode: string;
+          query: string;
+          sort: string;
+          start: string | null;
+          stats_period: string;
+          visualization: Array<{
+            chart_type: number;
+            y_axes: string[];
+          }>;
+        }>;
+      };
+
+      if (seerResponse.responses && Array.isArray(seerResponse.responses)) {
+        return seerResponse.responses.map(r => ({
+          visualizations:
+            r?.visualization?.map(v => ({
+              chartType: v?.chart_type,
+              yAxes: v?.y_axes ?? [],
+            })) ?? [],
+          query: r?.query ?? '',
+          sort: r?.sort ?? '',
+          groupBys: r?.group_by ?? [],
+          statsPeriod: r?.stats_period ?? '',
+          start: r?.start ?? null,
+          end: r?.end ?? null,
+          mode: r?.mode ?? 'metrics',
+        }));
+      }
+
+      return [response];
+    },
+    []
+  );
+
+  if (!enableAISearch) {
+    return null;
+  }
+
+  if (usePollingEndpoint) {
+    return (
+      <AskSeerPollingComboBox<AskSeerSearchQuery>
+        initialQuery={initialSeerQuery}
+        projectIds={selectedProjectIds}
+        strategy="Metrics"
+        applySeerSearchQuery={applySeerSearchQuery}
+        transformResponse={transformResponse}
+        analyticsSource="metrics"
+        feedbackSource="metrics_ai_query"
+        fallbackMutationOptions={metricsTabAskSeerMutationOptions}
+      />
+    );
+  }
+
+  return (
+    <AskSeerComboBox
+      initialQuery={initialSeerQuery}
+      askSeerMutationOptions={metricsTabAskSeerMutationOptions}
+      applySeerSearchQuery={applySeerSearchQuery}
+      analyticsSource="metrics"
+      feedbackSource="metrics_ai_query"
+    />
+  );
+}

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -85,19 +85,19 @@ export function MetricsTabSeerComboBox() {
   const inputValue = currentInputValueRef.current.trim();
 
   // Only filter out FREE_TEXT tokens if there's actual input value to filter by
-  const filteredCommittedQuery = queryDetails?.parsedQuery
+  const filteredCommittedQuery = queryDetails.parsedQuery
     ?.filter(
       token =>
         !(token.type === Token.FREE_TEXT && inputValue && token.text.includes(inputValue))
     )
-    ?.map(token => stringifyToken(token))
-    ?.join(' ')
-    ?.trim();
+    .map(token => stringifyToken(token))
+    .join(' ')
+    .trim();
 
   // Use filteredCommittedQuery if it exists and has content, otherwise fall back to queryToUse
   if (filteredCommittedQuery && filteredCommittedQuery.length > 0) {
     initialSeerQuery = filteredCommittedQuery;
-  } else if (queryDetails?.queryToUse) {
+  } else if (queryDetails.queryToUse) {
     initialSeerQuery = queryDetails.queryToUse;
   }
 
@@ -132,18 +132,17 @@ export function MetricsTabSeerComboBox() {
         status: 'ok',
         unsupported_reason: data.unsupported_reason,
         queries: data.responses.map(r => ({
-          visualizations:
-            r?.visualization?.map(v => ({
-              chartType: v?.chart_type,
-              yAxes: v?.y_axes ?? [],
-            })) ?? [],
-          query: r?.query ?? '',
-          sort: r?.sort ?? '',
-          groupBys: r?.group_by ?? [],
-          statsPeriod: r?.stats_period ?? '',
-          start: r?.start ?? null,
-          end: r?.end ?? null,
-          mode: r?.mode ?? 'metrics',
+          visualizations: r.visualization.map(v => ({
+            chartType: v.chart_type,
+            yAxes: v.y_axes,
+          })),
+          query: r.query,
+          sort: r.sort,
+          groupBys: r.group_by,
+          statsPeriod: r.stats_period,
+          start: r.start,
+          end: r.end,
+          mode: r.mode,
         })),
       };
     },
@@ -317,18 +316,17 @@ export function MetricsTabSeerComboBox() {
 
       if (seerResponse.responses && Array.isArray(seerResponse.responses)) {
         return seerResponse.responses.map(r => ({
-          visualizations:
-            r?.visualization?.map(v => ({
-              chartType: v?.chart_type,
-              yAxes: v?.y_axes ?? [],
-            })) ?? [],
-          query: r?.query ?? '',
-          sort: r?.sort ?? '',
-          groupBys: r?.group_by ?? [],
-          statsPeriod: r?.stats_period ?? '',
-          start: r?.start ?? null,
-          end: r?.end ?? null,
-          mode: r?.mode ?? 'metrics',
+          visualizations: r.visualization.map(v => ({
+            chartType: v.chart_type,
+            yAxes: v.y_axes,
+          })),
+          query: r.query,
+          sort: r.sort,
+          groupBys: r.group_by,
+          statsPeriod: r.stats_period,
+          start: r.start,
+          end: r.end,
+          mode: r.mode,
         }));
       }
 

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -16,12 +16,14 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
-import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
-import type {WritableAggregateField} from 'sentry/views/explore/queryParams/aggregateField';
 import {
-  useQueryParams,
-  useSetQueryParams,
-} from 'sentry/views/explore/queryParams/context';
+  encodeMetricQueryParams,
+  type BaseMetricQuery,
+  type TraceMetric,
+} from 'sentry/views/explore/metrics/metricQuery';
+import {useMultiMetricsQueryParams} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
+import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateField';
+import {useQueryParams} from 'sentry/views/explore/queryParams/context';
 import {isGroupBy} from 'sentry/views/explore/queryParams/groupBy';
 import {Mode} from 'sentry/views/explore/queryParams/mode';
 import {isVisualize} from 'sentry/views/explore/queryParams/visualize';
@@ -71,7 +73,7 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
   const pageFilters = usePageFilters();
   const organization = useOrganization();
   const queryParams = useQueryParams();
-  const setQueryParams = useSetQueryParams();
+  const metricQueries = useMultiMetricsQueryParams();
   const {
     currentInputValueRef,
     query,
@@ -210,7 +212,7 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
         }
       }
 
-      const aggregateFields: WritableAggregateField[] = [];
+      const aggregateFields: AggregateField[] = [];
       const iter = groupBys[Symbol.iterator]();
 
       for (const aggregateField of queryParams.aggregateFields) {
@@ -221,7 +223,7 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
               aggregateFields.push({groupBy});
             }
           }
-          aggregateFields.push(aggregateField.serialize());
+          aggregateFields.push(aggregateField);
         } else if (isGroupBy(aggregateField)) {
           const {value: groupBy, done} = iter.next();
           if (!done) {
@@ -235,10 +237,23 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
         aggregateFields.push({groupBy});
       }
 
-      // Update per-query state atomically (query, aggregateFields, mode)
-      setQueryParams({query: queryToUse, aggregateFields, mode});
+      // Build updated ReadableQueryParams for this metric
+      const newQueryParams = queryParams.replace({
+        query: queryToUse,
+        aggregateFields,
+        mode,
+      });
 
-      // Update global time range via navigation
+      // Build encoded metric queries, updating the current metric's query params
+      const newEncodedMetrics = metricQueries
+        .map((mq: BaseMetricQuery) => {
+          if (mq.queryParams === queryParams) {
+            return encodeMetricQueryParams({...mq, queryParams: newQueryParams});
+          }
+          return encodeMetricQueryParams(mq);
+        })
+        .filter(Boolean);
+
       const selection = {
         ...pageFilters.selection,
         datetime: {
@@ -266,12 +281,15 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
         visualize_count: visualizations?.length ?? 0,
       });
 
-      // Navigate to update global time range params
+      // Single navigate with both metric params and datetime
+      // (Previously, setQueryParams and navigate were called separately,
+      // causing the second navigate to overwrite the first with stale location)
       navigate(
         {
           ...location,
           query: {
             ...location.query,
+            metric: newEncodedMetrics,
             start: selection.datetime.start,
             end: selection.datetime.end,
             statsPeriod: selection.datetime.period,
@@ -284,11 +302,11 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
     [
       askSeerSuggestedQueryRef,
       location,
+      metricQueries,
       navigate,
       organization,
       pageFilters.selection,
-      queryParams.aggregateFields,
-      setQueryParams,
+      queryParams,
     ]
   );
 

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -16,6 +16,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
+import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import type {WritableAggregateField} from 'sentry/views/explore/queryParams/aggregateField';
 import {
   useQueryParams,
@@ -25,6 +26,10 @@ import {isGroupBy} from 'sentry/views/explore/queryParams/groupBy';
 import {Mode} from 'sentry/views/explore/queryParams/mode';
 import {isVisualize} from 'sentry/views/explore/queryParams/visualize';
 import type {ChartType} from 'sentry/views/insights/common/components/chart';
+
+interface MetricsTabSeerComboBoxProps {
+  traceMetric: TraceMetric;
+}
 
 interface Visualization {
   chartType: ChartType;
@@ -59,7 +64,7 @@ interface MetricsAskSeerTranslateResponse {
   unsupported_reason: string | null;
 }
 
-export function MetricsTabSeerComboBox() {
+export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProps) {
   const navigate = useNavigate();
   const location = useLocation();
   const {projects} = useProjects();
@@ -125,6 +130,13 @@ export function MetricsTabSeerComboBox() {
           project_ids: selectedProjects,
           strategy: 'Metrics',
           user_email: user?.email,
+          options: {
+            metric_context: {
+              metric_name: traceMetric.name,
+              metric_type: traceMetric.type,
+              metric_unit: traceMetric.unit ?? 'none',
+            },
+          },
         },
       });
 
@@ -281,7 +293,7 @@ export function MetricsTabSeerComboBox() {
   );
 
   const usePollingEndpoint = organization.features.includes(
-    'gen-ai-search-agent-translate'
+    'gen-ai-explore-metrics-search'
   );
 
   // Get selected project IDs for the polling variant
@@ -345,6 +357,13 @@ export function MetricsTabSeerComboBox() {
         initialQuery={initialSeerQuery}
         projectIds={selectedProjectIds}
         strategy="Metrics"
+        options={{
+          metric_context: {
+            metric_name: traceMetric.name,
+            metric_type: traceMetric.type,
+            metric_unit: traceMetric.unit ?? 'none',
+          },
+        }}
         applySeerSearchQuery={applySeerSearchQuery}
         transformResponse={transformResponse}
         analyticsSource="metrics"

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -292,9 +292,9 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
     ]
   );
 
-  const usePollingEndpoint = organization.features.includes(
-    'gen-ai-explore-metrics-search'
-  );
+  const usePollingEndpoint =
+    organization.features.includes('gen-ai-search-agent-translate') &&
+    organization.features.includes('gen-ai-explore-metrics-search');
 
   // Get selected project IDs for the polling variant
   const selectedProjectIds = useMemo(() => {

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -367,7 +367,6 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
         applySeerSearchQuery={applySeerSearchQuery}
         transformResponse={transformResponse}
         analyticsSource="metrics"
-        feedbackSource="metrics_ai_query"
         fallbackMutationOptions={metricsTabAskSeerMutationOptions}
       />
     );
@@ -379,7 +378,6 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
       askSeerMutationOptions={metricsTabAskSeerMutationOptions}
       applySeerSearchQuery={applySeerSearchQuery}
       analyticsSource="metrics"
-      feedbackSource="metrics_ai_query"
     />
   );
 }

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -148,13 +148,14 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
         status: 'ok',
         unsupported_reason: data.unsupported_reason,
         queries: data.responses.map(r => ({
-          visualizations: r.visualization.map(v => ({
-            chartType: v.chart_type,
-            yAxes: v.y_axes,
-          })),
+          visualizations:
+            r.visualization?.map(v => ({
+              chartType: v.chart_type,
+              yAxes: v.y_axes,
+            })) ?? [],
           query: r.query,
           sort: r.sort,
-          groupBys: r.group_by,
+          groupBys: r.group_by ?? [],
           statsPeriod: r.stats_period,
           start: r.start,
           end: r.end,
@@ -350,13 +351,14 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
 
       if (seerResponse.responses && Array.isArray(seerResponse.responses)) {
         return seerResponse.responses.map(r => ({
-          visualizations: r.visualization.map(v => ({
-            chartType: v.chart_type,
-            yAxes: v.y_axes,
-          })),
+          visualizations:
+            r.visualization?.map(v => ({
+              chartType: v.chart_type,
+              yAxes: v.y_axes,
+            })) ?? [],
           query: r.query,
           sort: r.sort,
-          groupBys: r.group_by,
+          groupBys: r.group_by ?? [],
           statsPeriod: r.stats_period,
           start: r.start,
           end: r.end,

--- a/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
+++ b/static/app/views/explore/metrics/metricsTabSeerComboBox.tsx
@@ -1,5 +1,6 @@
 import {useCallback, useMemo} from 'react';
 
+import {useAnalyticsArea} from 'sentry/components/analyticsArea';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {AskSeerComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerComboBox';
 import {AskSeerPollingComboBox} from 'sentry/components/searchQueryBuilder/askSeerCombobox/askSeerPollingComboBox';
@@ -74,6 +75,7 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
   const organization = useOrganization();
   const queryParams = useQueryParams();
   const metricQueries = useMultiMetricsQueryParams();
+  const analyticsArea = useAnalyticsArea();
   const {
     currentInputValueRef,
     query,
@@ -274,8 +276,9 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
         mode,
       });
 
-      trackAnalytics('metrics.ai_query_applied', {
+      trackAnalytics('ai_query.applied', {
         organization,
+        area: analyticsArea,
         query: queryToUse,
         group_by_count: groupBys.length,
         visualize_count: visualizations?.length ?? 0,
@@ -300,6 +303,7 @@ export function MetricsTabSeerComboBox({traceMetric}: MetricsTabSeerComboBoxProp
       );
     },
     [
+      analyticsArea,
       askSeerSuggestedQueryRef,
       location,
       metricQueries,


### PR DESCRIPTION
Apply visualization and sort data from the Seer AI search response to the metrics page state.

Previously, `applySeerSearchQuery` in `metricsTabSeerComboBox.tsx` extracted but ignored both the `visualization` and `sort` fields from the Seer response. It only applied `query`, `groupBys`, and `mode` — leaving the aggregate function and sort unchanged. This meant Seer could return `avg(value)` for a distribution metric, but the page would keep whatever aggregate and sort were previously selected.

### What changed

- Convert Seer visualizations (`{chartType, yAxes}`) to `VisualizeFunction` objects with proper `chartType` mapping (0=BAR, 1=LINE, 2=AREA)
- Replace the old merge logic that preserved existing visualize fields with simpler logic that uses Seer visualizes when provided
- Parse Seer sort string (e.g., `"-avg(value)"`) into `Sort` objects (`{field, kind}`)
- Apply `aggregateSortBys` for aggregate mode and `sortBys` for samples mode
- Pass all three (`aggregateFields`, `aggregateSortBys`, `sortBys`) to `queryParams.replace()` so old state does not leak through

### Companion PR

This depends on the Seer backend PR getsentry/seer#5804 which adds full aggregation support and type-aware default aggregations to the metrics AI search strategy.