### PR TITLE
feat(tracemetrics): Add parser for resolved expressions

### DIFF
--- a/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
@@ -1,0 +1,89 @@
+import {Tag} from '@sentry/scraps/badge';
+import {Container, Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {t} from 'sentry/locale';
+import {
+  METRIC_DETECTOR_FORM_FIELDS,
+  useMetricDetectorFormField,
+} from 'sentry/views/detectors/components/forms/metric/metricFormData';
+import {parseAggregateExpression} from 'sentry/views/explore/metrics/parseAggregateExpression';
+import {parseMetricAggregate} from 'sentry/views/explore/metrics/parseMetricsAggregate';
+import {isVisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
+
+/**
+ * Read-only skeleton preview of the equations editor for trace-metric
+ * detectors. Parses the current aggregate string and renders the metric rows
+ * and compact equation it would yield. Will be replaced by the interactive
+ * editor in a follow-up.
+ */
+export function MetricsEquationVisualize() {
+  const aggregateFunction = useMetricDetectorFormField(
+    METRIC_DETECTOR_FORM_FIELDS.aggregateFunction
+  );
+  const parsed = parseAggregateExpression(aggregateFunction ?? '');
+
+  return (
+    <Container padding="md" border="primary" radius="md">
+      <Flex direction="column" gap="md">
+        <Text variant="muted" size="sm">
+          {t('Equations editor preview — not yet interactive.')}
+        </Text>
+
+        {parsed.metricQueries.length === 0 ? (
+          <Text variant="muted" size="sm">
+            {t('No metrics detected in the saved aggregate.')}
+          </Text>
+        ) : (
+          <Flex direction="column" gap="sm">
+            {parsed.metricQueries.map(query => {
+              const visualize = query.queryParams.visualizes[0];
+              const aggregateText =
+                visualize && isVisualizeFunction(visualize) ? visualize.yAxis : '';
+              const {aggregation} = parseMetricAggregate(aggregateText);
+              return (
+                <Flex key={query.label} align="center" gap="sm">
+                  <Tag variant="info">{query.label}</Tag>
+                  <Text as="span" size="sm" bold>
+                    {aggregation}
+                  </Text>
+                  <Text as="span" size="sm">
+                    {query.queryParams.query || t('(no query)')}
+                  </Text>
+                  <Text as="span" size="sm">
+                    {query.metric.name || t('(no metric)')}
+                  </Text>
+                  {query.metric.type ? (
+                    <Text as="span" variant="muted" size="sm">
+                      {query.metric.type}
+                    </Text>
+                  ) : null}
+                </Flex>
+              );
+            })}
+          </Flex>
+        )}
+
+        {parsed.compactExpression ? (
+          <Flex align="center" gap="sm">
+            <Text variant="muted" size="sm">
+              {t('Parsed Equation:')}
+            </Text>
+            <Text monospace size="sm">
+              {parsed.compactExpression}
+            </Text>
+          </Flex>
+        ) : null}
+
+        <Flex align="center" gap="sm">
+          <Text variant="muted" size="sm">
+            {t('Raw Equation:')}
+          </Text>
+          <Text monospace size="sm">
+            {aggregateFunction}
+          </Text>
+        </Flex>
+      </Flex>
+    </Container>
+  );
+}

--- a/static/app/views/detectors/components/forms/metric/visualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/visualize.tsx
@@ -12,7 +12,7 @@ import {FormContext} from 'sentry/components/forms/formContext';
 import {t} from 'sentry/locale';
 import type {SelectValue} from 'sentry/types/core';
 import type {AggregateParameter} from 'sentry/utils/discover/fields';
-import {parseFunction} from 'sentry/utils/discover/fields';
+import {isEquation, parseFunction} from 'sentry/utils/discover/fields';
 import {
   AggregationKey,
   ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
@@ -27,6 +27,7 @@ import {
   METRIC_DETECTOR_FORM_FIELDS,
   useMetricDetectorFormField,
 } from 'sentry/views/detectors/components/forms/metric/metricFormData';
+import {MetricsEquationVisualize} from 'sentry/views/detectors/components/forms/metric/metricsEquationVisualize';
 import {MetricsVisualize} from 'sentry/views/detectors/components/forms/metric/metricsVisualize';
 import {SectionLabel} from 'sentry/views/detectors/components/forms/sectionLabel';
 import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetConfig';
@@ -36,6 +37,7 @@ import type {FieldValue} from 'sentry/views/discover/table/types';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
 import {DEFAULT_VISUALIZATION_FIELD} from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
 import {useTraceItemDatasetAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
+import {canUseMetricsEquationsInAlerts} from 'sentry/views/explore/metrics/metricsFlags';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
 /**
@@ -219,9 +221,16 @@ function buildAggregateFunction(aggregate: string, parameters: string[]): string
 }
 
 export function Visualize() {
+  const organization = useOrganization();
   const dataset = useMetricDetectorFormField(METRIC_DETECTOR_FORM_FIELDS.dataset);
 
+  const aggregateFunction = useMetricDetectorFormField(
+    METRIC_DETECTOR_FORM_FIELDS.aggregateFunction
+  );
   if (dataset === DetectorDataset.METRICS) {
+    if (canUseMetricsEquationsInAlerts(organization) && isEquation(aggregateFunction)) {
+      return <MetricsEquationVisualize />;
+    }
     return <MetricsVisualize />;
   }
 

--- a/static/app/views/explore/metrics/metricsFlags.tsx
+++ b/static/app/views/explore/metrics/metricsFlags.tsx
@@ -45,6 +45,13 @@ export const canUseMetricsEquations = (organization: Organization) => {
   );
 };
 
+export const canUseMetricsEquationsInAlerts = (organization: Organization) => {
+  return (
+    canUseMetricsAlertsUI(organization) &&
+    organization.features.includes('tracemetrics-equations-in-alerts')
+  );
+};
+
 export const canUseMetricsPiiScrubbingUI = (organization: Organization) => {
   return (
     canUseMetricsUI(organization) &&

--- a/static/app/views/explore/metrics/parseAggregateExpression.spec.tsx
+++ b/static/app/views/explore/metrics/parseAggregateExpression.spec.tsx
@@ -1,0 +1,152 @@
+import {parseAggregateExpression} from 'sentry/views/explore/metrics/parseAggregateExpression';
+import {
+  VisualizeEquation,
+  VisualizeFunction,
+} from 'sentry/views/explore/queryParams/visualize';
+
+describe('parseAggregateExpression', () => {
+  it('parses a single aggregate into one row with label A', () => {
+    const result = parseAggregateExpression('sum(value,foo,counter,-)');
+
+    expect(result.compactExpression).toBeNull();
+    expect(result.equationRow).toBeNull();
+    expect(result.metricQueries).toHaveLength(1);
+    expect(result.metricQueries[0]).toEqual(
+      expect.objectContaining({
+        label: 'A',
+        metric: {name: 'foo', type: 'counter', unit: undefined},
+      })
+    );
+    expect(result.metricQueries[0]!.queryParams.aggregateFields).toEqual([
+      new VisualizeFunction('sum(value,foo,counter,-)'),
+    ]);
+  });
+
+  it('parses an equation with two distinct metrics into two labeled rows', () => {
+    const result = parseAggregateExpression(
+      'equation|sum(value,metricA,counter,-) + avg(value,metricB,gauge,-)'
+    );
+
+    expect(result.metricQueries).toHaveLength(2);
+    expect(result.metricQueries[0]).toEqual(
+      expect.objectContaining({
+        label: 'A',
+        metric: {name: 'metricA', type: 'counter', unit: undefined},
+      })
+    );
+    expect(result.metricQueries[1]).toEqual(
+      expect.objectContaining({
+        label: 'B',
+        metric: {name: 'metricB', type: 'gauge', unit: undefined},
+      })
+    );
+    expect(result.compactExpression).toBe('A + B');
+    expect(result.equationRow?.queryParams.aggregateFields).toEqual([
+      new VisualizeEquation(
+        'equation|sum(value,metricA,counter,-) + avg(value,metricB,gauge,-)'
+      ),
+    ]);
+  });
+
+  it('dedupes identical function calls into a single row', () => {
+    const result = parseAggregateExpression(
+      'equation|sum(value,metricA,counter,-) + sum(value,metricA,counter,-)'
+    );
+
+    expect(result.metricQueries).toHaveLength(1);
+    expect(result.metricQueries[0]).toEqual(
+      expect.objectContaining({
+        label: 'A',
+        metric: {name: 'metricA', type: 'counter', unit: undefined},
+      })
+    );
+    expect(result.compactExpression).toBe('A + A');
+  });
+
+  it('preserves numeric literals alongside references', () => {
+    const result = parseAggregateExpression('equation|sum(value,metricA,counter,-) / 2');
+
+    expect(result.metricQueries).toHaveLength(1);
+    expect(result.compactExpression).toBe('A / 2');
+  });
+
+  it('assigns labels in order of first appearance within nested parens', () => {
+    const result = parseAggregateExpression(
+      'equation|(sum(value,metricB,counter,-) + sum(value,metricA,counter,-)) / sum(value,metricC,counter,-)'
+    );
+
+    expect(result.metricQueries).toHaveLength(3);
+    expect(result.metricQueries.map(q => q.metric.name)).toEqual([
+      'metricB',
+      'metricA',
+      'metricC',
+    ]);
+    expect(result.metricQueries.map(q => q.label)).toEqual(['A', 'B', 'C']);
+  });
+
+  it('returns empty rows for an equation with no function calls', () => {
+    const result = parseAggregateExpression('equation|1 + 2');
+
+    expect(result.metricQueries).toHaveLength(0);
+    expect(result.compactExpression).toBe('1 + 2');
+    expect(result.equationRow).not.toBeNull();
+  });
+
+  it('parses units when present', () => {
+    const result = parseAggregateExpression(
+      'avg(value,latency,distribution,millisecond)'
+    );
+
+    expect(result.metricQueries[0]).toEqual(
+      expect.objectContaining({
+        metric: {name: 'latency', type: 'distribution', unit: 'millisecond'},
+      })
+    );
+  });
+
+  it('normalizes _if function into plain aggregate + query', () => {
+    const result = parseAggregateExpression(
+      'sum_if(`status:ok`,value,requests,counter,none)'
+    );
+
+    expect(result.metricQueries[0]).toEqual(
+      expect.objectContaining({
+        label: 'A',
+        metric: {name: 'requests', type: 'counter', unit: 'none'},
+      })
+    );
+    expect(result.metricQueries[0]!.queryParams.query).toBe('status:ok');
+    expect(result.metricQueries[0]!.queryParams.aggregateFields).toEqual([
+      new VisualizeFunction('sum(value,requests,counter,none)'),
+    ]);
+  });
+
+  it('preserves complex _if filter query', () => {
+    const result = parseAggregateExpression(
+      'equation|sum_if(`agent_name:["Agent Run","Assisted Query"] AND environment:prod`,value,errors,counter,none) / sum(value,total,counter,none)'
+    );
+
+    expect(result.metricQueries).toHaveLength(2);
+    expect(result.metricQueries[0]!.queryParams.query).toBe(
+      'agent_name:["Agent Run","Assisted Query"] AND environment:prod'
+    );
+    expect(result.metricQueries[0]!.queryParams.aggregateFields).toEqual([
+      new VisualizeFunction('sum(value,errors,counter,none)'),
+    ]);
+    expect(result.metricQueries[1]!.queryParams.aggregateFields).toEqual([
+      new VisualizeFunction('sum(value,total,counter,none)'),
+    ]);
+    expect(result.metricQueries[1]!.queryParams.query).toBe('');
+  });
+
+  it('dedupes identical _if calls and distinguishes different filters', () => {
+    const result = parseAggregateExpression(
+      'equation|sum_if(`env:prod`,value,metricA,counter,-) + sum_if(`env:dev`,value,metricA,counter,-) + sum_if(`env:prod`,value,metricA,counter,-)'
+    );
+
+    expect(result.metricQueries).toHaveLength(2);
+    expect(result.metricQueries[0]!.queryParams.query).toBe('env:prod');
+    expect(result.metricQueries[1]!.queryParams.query).toBe('env:dev');
+    expect(result.compactExpression).toBe('A + B + A');
+  });
+});

--- a/static/app/views/explore/metrics/parseAggregateExpression.tsx
+++ b/static/app/views/explore/metrics/parseAggregateExpression.tsx
@@ -1,0 +1,155 @@
+import {
+  isTokenFunction,
+  type TokenFunction,
+} from 'sentry/components/arithmeticBuilder/token';
+import {tokenizeExpression} from 'sentry/components/arithmeticBuilder/tokenizer';
+import {EQUATION_PREFIX, isEquation} from 'sentry/utils/discover/fields';
+import {
+  defaultMetricQuery,
+  type BaseMetricQuery,
+} from 'sentry/views/explore/metrics/metricQuery';
+import {parseMetricAggregate} from 'sentry/views/explore/metrics/parseMetricsAggregate';
+import {
+  VisualizeEquation,
+  VisualizeFunction,
+} from 'sentry/views/explore/queryParams/visualize';
+import {getFunctionLabel} from 'sentry/views/explore/toolbar/toolbarVisualize';
+
+interface ParsedAggregateExpression {
+  /**
+   * Equation in compact form using reference labels (e.g. "A + B / 2").
+   * `null` when the input is a single aggregate rather than an equation.
+   */
+  compactExpression: string | null;
+  /**
+   * The equation row itself (a `BaseMetricQuery` whose visualize is an
+   * equation). `null` when the input is a single aggregate.
+   */
+  equationRow: BaseMetricQuery | null;
+  metricQueries: BaseMetricQuery[];
+}
+
+const IF_SUFFIX = '_if';
+
+interface ParsedEquationComponent {
+  /**
+   * The filter query from the conditional aggregation if applicable.
+   */
+  filterQuery: string;
+  /**
+   * Function call in its plain `op(value,metric,type,unit)` form with the
+   * conditional argument removed.
+   */
+  plainAggregate: string;
+}
+
+/**
+ * Parses function tokens into the format to be represented as individual metric queries.
+ *
+ * The main normalization that's occurring here is the removal of the `_if` combinator if
+ * applicable and extraction of the query from that combinator.
+ */
+function normalizeFunctionToken(token: TokenFunction): ParsedEquationComponent {
+  if (!token.function.endsWith(IF_SUFFIX) || token.attributes.length === 0) {
+    return {plainAggregate: token.text, filterQuery: ''};
+  }
+
+  const plainName = token.function.slice(0, -IF_SUFFIX.length);
+  const [filterAttr, ...restAttrs] = token.attributes;
+  const filterText = filterAttr?.text ?? '';
+
+  // Extract the query from the first argument, checking if it's wrapped in backticks.
+  const filterQuery =
+    filterText.startsWith('`') && filterText.endsWith('`')
+      ? filterText.slice(1, -1)
+      : filterText;
+
+  const plainAggregate = `${plainName}(${restAttrs.map(a => a.text).join(',')})`;
+  return {plainAggregate, filterQuery};
+}
+
+function makeMetricQuery(token: TokenFunction, label: string): BaseMetricQuery {
+  const {plainAggregate, filterQuery} = normalizeFunctionToken(token);
+  const {traceMetric} = parseMetricAggregate(plainAggregate);
+  const base = defaultMetricQuery();
+  return {
+    metric: traceMetric,
+    label,
+    queryParams: base.queryParams.replace({
+      aggregateFields: [new VisualizeFunction(plainAggregate)],
+      query: filterQuery,
+    }),
+  };
+}
+
+function makeEquationRow(prefixedEquation: string): BaseMetricQuery {
+  const base = defaultMetricQuery({type: 'equation'});
+  return {
+    metric: {name: '', type: ''},
+    queryParams: base.queryParams.replace({
+      aggregateFields: [new VisualizeEquation(prefixedEquation)],
+    }),
+  };
+}
+
+function defaultRow(label: string): BaseMetricQuery {
+  return {...defaultMetricQuery(), label};
+}
+
+/**
+ * Parses a saved aggregate string (either a single `op(value,metric,type,unit)`
+ * call, or an `equation|<expression>` composed of such calls) into metric queries.
+ *
+ * `_if(<filter>, value, metric, type, unit)` forms are normalized so `_if` is
+ * removed and the filter is extracted.
+ *
+ * Duplicate function calls collapse to a single row so the resulting compact
+ * expression may repeat a label (e.g. `A + A` when the user summed a metric
+ * with an equivalent version of itself).
+ */
+export function parseAggregateExpression(aggregate: string): ParsedAggregateExpression {
+  if (!isEquation(aggregate)) {
+    const tokens = tokenizeExpression(aggregate);
+    const functionToken = tokens.find(isTokenFunction);
+    const label = getFunctionLabel(0);
+    return {
+      metricQueries: [
+        functionToken ? makeMetricQuery(functionToken, label) : defaultRow(label),
+      ],
+      compactExpression: null,
+      equationRow: null,
+    };
+  }
+
+  const expressionText = aggregate.slice(EQUATION_PREFIX.length);
+  const tokens = tokenizeExpression(expressionText);
+
+  // Tracks a label for each unique function call in the equation. To be used
+  // to generate the compact expression after parsing its subcomponents.
+  const labelByAggregateString = new Map<string, string>();
+  const metricQueries: BaseMetricQuery[] = [];
+
+  // Iterate over the tokens and create a metric query for each unique function call.
+  for (const token of tokens) {
+    if (!isTokenFunction(token)) {
+      continue;
+    }
+    if (labelByAggregateString.has(token.text)) {
+      continue;
+    }
+    const label = getFunctionLabel(labelByAggregateString.size);
+    labelByAggregateString.set(token.text, label);
+    metricQueries.push(makeMetricQuery(token, label));
+  }
+
+  const compactExpression = tokens
+    .map(token => labelByAggregateString.get(token.text) ?? token.text)
+    .filter(text => text.length > 0)
+    .join(' ');
+
+  return {
+    metricQueries,
+    compactExpression,
+    equationRow: makeEquationRow(aggregate),
+  };
+}


### PR DESCRIPTION
Adds a parser helper that will take a resolved equation, and break out the smaller sub-components needed to compose the original equation.

This gets around the issue of alerts only storing the single aggregate it's alerting on. In the equation case it'll be the full equation, so for the UI to continue using references we need to parse the equation and get the subcomponents to initialize some local state.

You don't really need to review the `MetricsEquationVisualize`, I just wanted to add it to mock out a spot where I think the new UI we're building for equations will live. It mostly just validates the idea of parsing an equation from something I've saved here: https://sentry.dev.getsentry.net:7999/monitors/7037172/edit/ . It also prevents knip from complaining without having to add a line to ignore knip for this helper

<img width="1468" height="375" alt="Screenshot 2026-04-16 at 4 37 54 PM" src="https://github.com/user-attachments/assets/bbb5f89c-d8f9-4f26-a2ad-d52a6d451e69" />

You can also test it here: https://sentry-gx0w9jqhi.sentry.dev/monitors/7037172/edit/
and enable the `tracemetrics-equations-in-alerts` flag
