### PR TITLE
fix(issues): Include event property fields in has: suggestions

### DIFF
--- a/static/app/views/issueList/searchBar.spec.tsx
+++ b/static/app/views/issueList/searchBar.spec.tsx
@@ -87,6 +87,8 @@ describe('IssueListSearchBar', () => {
       );
 
       expect(await screen.findByRole('option', {name: 'someTag'})).toBeInTheDocument();
+      // Event property fields like stack.filename should also be suggested
+      expect(screen.getByRole('option', {name: 'stack.filename'})).toBeInTheDocument();
     });
 
     it('displays conflicting tags', async () => {

--- a/static/app/views/issueList/utils/useFetchIssueTags.tsx
+++ b/static/app/views/issueList/utils/useFetchIssueTags.tsx
@@ -253,10 +253,13 @@ function builtInIssuesFields({
     },
     {}
   );
-  const hasFieldValues = [
-    ...Object.values(currentTags).map(tag => tag.key),
-    ...Object.values(SEMVER_TAGS).map(tag => tag.key),
-  ].sort();
+  const hasFieldValues = Array.from(
+    new Set([
+      ...Object.values(currentTags).map(tag => tag.key),
+      ...Object.values(SEMVER_TAGS).map(tag => tag.key),
+      ...ISSUE_EVENT_PROPERTY_FIELDS,
+    ])
+  ).sort();
 
   const tagCollection: TagCollection = {
     [FieldKey.IS]: {


### PR DESCRIPTION
The `has:` filter in the issue search only suggested custom tags (like `has:browser.name`) and semver fields. Structured event fields like `stack.filename`, `stack.function`, `device.arch`, `error.handled`, etc. never showed up even though they're valid search keys and already defined in `ISSUE_EVENT_PROPERTY_FIELDS`.

fixes https://linear.app/getsentry/issue/ID-1021/surface-event-symbolicated-vs-not-symbolicated-in-issue-search