### PR TITLE
fix(issues): Apply issue search conditions to next/prev event buttons on issue details page

### DIFF
--- a/src/sentry/issues/endpoints/group_event_details.py
+++ b/src/sentry/issues/endpoints/group_event_details.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
+from typing import Any
 
 from django.contrib.auth.models import AnonymousUser
 from drf_spectacular.utils import extend_schema
@@ -54,7 +55,7 @@ from sentry.utils import metrics
 
 def issue_search_query_to_conditions(
     query: str, group: Group, user: User | AnonymousUser, environments: Sequence[Environment]
-) -> list[Condition]:
+) -> tuple[list[Condition], list[Any]]:
     from sentry.utils.snuba import resolve_column, resolve_conditions
 
     dataset = (
@@ -67,7 +68,7 @@ def issue_search_query_to_conditions(
     )
 
     # transform search filters -> the legacy condition format
-    legacy_conditions = []
+    legacy_conditions: list[Any] = []
     if search_filters:
         for search_filter in search_filters:
             from sentry.api.serializers import GroupSerializerSnuba
@@ -97,11 +98,13 @@ def issue_search_query_to_conditions(
 
     # the transformed conditions is generic and isn't 'dataset aware', we need to map the generic columns
     # being queried to the appropriate dataset column
-    resolved_legacy_conditions = resolve_conditions(legacy_conditions, resolve_column(dataset))
+    resolved_legacy_conditions = (
+        resolve_conditions(legacy_conditions, resolve_column(dataset)) or []
+    )
 
     # convert the legacy condition format into the SnQL condition format
-    snql_conditions = []
-    for cond in resolved_legacy_conditions or ():
+    snql_conditions: list[Condition] = []
+    for cond in resolved_legacy_conditions:
         if not is_condition(cond):
             # this shouldn't be possible since issue search only allows ands
             or_conditions = []
@@ -115,7 +118,7 @@ def issue_search_query_to_conditions(
         else:
             snql_conditions.append(parse_condition(cond))
 
-    return snql_conditions
+    return snql_conditions, resolved_legacy_conditions
 
 
 @extend_schema(tags=["Events"])
@@ -170,23 +173,24 @@ class GroupEventDetailsEndpoint(GroupEndpoint):
             raise ParseError(detail="Invalid date range")
 
         query = request.GET.get("query")
-        try:
-            conditions: list[Condition] = (
-                issue_search_query_to_conditions(query, group, request.user, environments)
-                if query
-                else []
-            )
-        except ValidationError:
-            raise ParseError(detail="Invalid event query")
-        except InvalidSearchQuery as error:
-            message = str(error)
-            raise ParseError(detail=message)
-        except Exception:
-            logging.exception(
-                "group_event_details.parse_query",
-                extra={"query": query, "group": group.id, "organization": organization.id},
-            )
-            raise ParseError(detail="Unable to parse query")
+        conditions: list[Condition] = []
+        legacy_conditions: list[Any] = []
+        if query:
+            try:
+                conditions, legacy_conditions = issue_search_query_to_conditions(
+                    query, group, request.user, environments
+                )
+            except ValidationError:
+                raise ParseError(detail="Invalid event query")
+            except InvalidSearchQuery as error:
+                message = str(error)
+                raise ParseError(detail=message)
+            except Exception:
+                logging.exception(
+                    "group_event_details.parse_query",
+                    extra={"query": query, "group": group.id, "organization": organization.id},
+                )
+                raise ParseError(detail="Unable to parse query")
 
         if environments:
             conditions.append(Condition(Column("environment"), Op.IN, environment_names))
@@ -243,6 +247,7 @@ class GroupEventDetailsEndpoint(GroupEndpoint):
             environments=environment_names,
             include_full_release_data="fullRelease" not in collapse,
             conditions=conditions,
+            legacy_conditions=legacy_conditions,
             start=start,
             end=end,
         )

--- a/src/sentry/issues/endpoints/project_event_details.py
+++ b/src/sentry/issues/endpoints/project_event_details.py
@@ -34,6 +34,7 @@ def wrap_event_response(
     environments: list[str],
     include_full_release_data: bool = False,
     conditions: list[Condition] | None = None,
+    legacy_conditions: list[Any] | None = None,
     start: datetime | None = None,
     end: datetime | None = None,
 ) -> GroupEventDetailsResponse | None:
@@ -54,6 +55,8 @@ def wrap_event_response(
 
     if conditions is None:
         conditions = []
+    if legacy_conditions is None:
+        legacy_conditions = []
 
     if event.group_id:
         if options.get("eventstore.adjacent_event_ids_use_snql"):
@@ -68,12 +71,19 @@ def wrap_event_response(
                 end=end,
             )
         else:
-            legacy_conditions = []
+            filter_conditions: list[Any] = []
             if environments:
-                legacy_conditions.append(["environment", "IN", environments])
+                filter_conditions.append(["environment", "IN", environments])
+
+            if legacy_conditions:
+                apply_query_conditions_org_ids = options.get(
+                    "eventstore.adjacent_event_ids_apply_query_conditions.organization_ids"
+                )
+                if event.project.organization_id in apply_query_conditions_org_ids:
+                    filter_conditions.extend(legacy_conditions)
 
             _filter = eventstore.Filter(
-                conditions=legacy_conditions,
+                conditions=filter_conditions,
                 project_ids=[event.project_id],
                 group_ids=[event.group_id],
                 start=start,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3692,6 +3692,12 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "eventstore.adjacent_event_ids_apply_query_conditions.organization_ids",
+    type=Sequence,
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Demo mode
 register(

--- a/tests/sentry/issues/endpoints/test_group_event_details.py
+++ b/tests/sentry/issues/endpoints/test_group_event_details.py
@@ -164,6 +164,137 @@ class GroupEventDetailsEndpointTest(GroupEventDetailsEndpointTestBase, APITestCa
         assert response.data["previousEventID"] == str(self.event_a.event_id)
         assert response.data["nextEventID"] is None
 
+    def _build_interleaved_tag_group(self) -> tuple:
+        m1 = self.store_event(
+            data={
+                "event_id": "1" * 32,
+                "timestamp": before_now(minutes=10).isoformat(),
+                "fingerprint": ["walk-group"],
+                "tags": {"attachmentsAdded": "true"},
+            },
+            project_id=self.project_1.id,
+        )
+        n1 = self.store_event(
+            data={
+                "event_id": "2" * 32,
+                "timestamp": before_now(minutes=8).isoformat(),
+                "fingerprint": ["walk-group"],
+            },
+            project_id=self.project_1.id,
+        )
+        m2 = self.store_event(
+            data={
+                "event_id": "3" * 32,
+                "timestamp": before_now(minutes=6).isoformat(),
+                "fingerprint": ["walk-group"],
+                "tags": {"attachmentsAdded": "true"},
+            },
+            project_id=self.project_1.id,
+        )
+        n2 = self.store_event(
+            data={
+                "event_id": "4" * 32,
+                "timestamp": before_now(minutes=4).isoformat(),
+                "fingerprint": ["walk-group"],
+            },
+            project_id=self.project_1.id,
+        )
+        m3 = self.store_event(
+            data={
+                "event_id": "5" * 32,
+                "timestamp": before_now(minutes=2).isoformat(),
+                "fingerprint": ["walk-group"],
+                "tags": {"attachmentsAdded": "true"},
+            },
+            project_id=self.project_1.id,
+        )
+        return m1, n1, m2, n2, m3
+
+    def test_walk_next_prev_respects_query_filter_for_allowlisted_org(self) -> None:
+        m1, n1, m2, _n2, m3 = self._build_interleaved_tag_group()
+        group_id = m1.group.id
+        query = "attachmentsAdded:true"
+
+        def fetch(event_id: str):
+            url = f"/api/0/organizations/{self.organization.slug}/issues/{group_id}/events/{event_id}/"
+            return self.client.get(url, {"query": query}, format="json")
+
+        allowlist = {
+            "eventstore.adjacent_event_ids_apply_query_conditions.organization_ids": [
+                self.organization.id
+            ]
+        }
+        with self.options(allowlist):
+            # Middle matching event: prev/next hop past the non-matching
+            # neighbors on both sides.
+            middle = fetch(m2.event_id)
+            assert middle.status_code == 200, middle.content
+            assert middle.data["previousEventID"] == str(m1.event_id)
+            assert middle.data["nextEventID"] == str(m3.event_id)
+
+            # Oldest matching event: boundary on the prev side.
+            oldest = fetch(m1.event_id)
+            assert oldest.status_code == 200, oldest.content
+            assert oldest.data["previousEventID"] is None
+            assert oldest.data["nextEventID"] == str(m2.event_id)
+
+            # Newest matching event: boundary on the next side.
+            newest = fetch(m3.event_id)
+            assert newest.status_code == 200, newest.content
+            assert newest.data["previousEventID"] == str(m2.event_id)
+            assert newest.data["nextEventID"] is None
+
+            # Landing on a non-matching event directly (e.g. via a stale
+            # URL) still returns it, but its adjacent IDs are filtered
+            # so the user can walk back into the matching set.
+            between = fetch(n1.event_id)
+            assert between.status_code == 200, between.content
+            assert between.data["previousEventID"] == str(m1.event_id)
+            assert between.data["nextEventID"] == str(m2.event_id)
+
+    def test_next_prev_respects_or_query_filter_for_allowlisted_org(self) -> None:
+        red = self.store_event(
+            data={
+                "event_id": "6" * 32,
+                "timestamp": before_now(minutes=10).isoformat(),
+                "fingerprint": ["or-group"],
+                "tags": {"color": "red"},
+            },
+            project_id=self.project_1.id,
+        )
+        self.store_event(
+            data={
+                "event_id": "7" * 32,
+                "timestamp": before_now(minutes=8).isoformat(),
+                "fingerprint": ["or-group"],
+                "tags": {"color": "green"},
+            },
+            project_id=self.project_1.id,
+        )
+        blue = self.store_event(
+            data={
+                "event_id": "8" * 32,
+                "timestamp": before_now(minutes=6).isoformat(),
+                "fingerprint": ["or-group"],
+                "tags": {"color": "blue"},
+            },
+            project_id=self.project_1.id,
+        )
+
+        url = f"/api/0/organizations/{self.organization.slug}/issues/{blue.group.id}/events/{blue.event_id}/"
+        with self.options(
+            {
+                "eventstore.adjacent_event_ids_apply_query_conditions.organization_ids": [
+                    self.organization.id
+                ]
+            }
+        ):
+            response = self.client.get(url, {"query": "color:[red, blue]"}, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data["previousEventID"] == str(red.event_id)
+        assert response.data["nextEventID"] is None
+
 
 class GroupEventDetailsHelpfulEndpointTest(
     GroupEventDetailsEndpointTestBase, APITestCase, SnubaTestCase, OccurrenceTestMixin

--- a/tests/sentry/issues/endpoints/test_group_event_details.py
+++ b/tests/sentry/issues/endpoints/test_group_event_details.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import Any
 from uuid import uuid4
 
 from sentry.models.group import GroupStatus
@@ -164,7 +165,7 @@ class GroupEventDetailsEndpointTest(GroupEventDetailsEndpointTestBase, APITestCa
         assert response.data["previousEventID"] == str(self.event_a.event_id)
         assert response.data["nextEventID"] is None
 
-    def _build_interleaved_tag_group(self) -> tuple:
+    def _build_interleaved_tag_group(self) -> tuple[Any, Any, Any, Any, Any]:
         m1 = self.store_event(
             data={
                 "event_id": "1" * 32,
@@ -215,7 +216,7 @@ class GroupEventDetailsEndpointTest(GroupEventDetailsEndpointTestBase, APITestCa
         group_id = m1.group.id
         query = "attachmentsAdded:true"
 
-        def fetch(event_id: str):
+        def fetch(event_id: str) -> Any:
             url = f"/api/0/organizations/{self.organization.slug}/issues/{group_id}/events/{event_id}/"
             return self.client.get(url, {"query": query}, format="json")
 


### PR DESCRIPTION
Fixes [ID-1257](https://linear.app/getsentry/issue/ID-1257/nextprev-event-buttons-dont-reflect-filters).

The Next/Prev event buttons on the issue details page currently ignore the search query applied on the issue feed, so users walking events end up on ones that don't match their filter. First, latest, and initial-load event all already work.

This PR updates the query path used by next/prev event navigation to ensure that the user's filters/conditions are applied. This new behavior is behind an organization allowlist so I can test in the Sentry org before rolling out fully.