### PR TITLE
feat(viewer-context): Add S018 lint rule banning raw _viewer_context_var.set()

### DIFF
--- a/tests/tools/test_flake8_plugin.py
+++ b/tests/tools/test_flake8_plugin.py
@@ -345,3 +345,83 @@ def test_S015_current_or_future_year() -> None:
         )
         == []
     )
+
+
+def test_S018_raw_set_outside_module() -> None:
+    src = "_viewer_context_var.set(ctx)\n"
+    errors = _run(src, filename="src/sentry/some/other/module.py")
+    assert errors == [
+        "t.py:1:0: S018 Use `viewer_context_scope(...)` instead of `_viewer_context_var.set(...)`."
+        " The scope manager guarantees `reset(token)` cleanup; raw `.set()` leaves the"
+        " ContextVar unbalanced and can leak viewer identity across requests."
+    ]
+
+
+def test_S018_kwargs_form_flagged() -> None:
+    src = "_viewer_context_var.set(value=ctx)\n"
+    errors = _run(src, filename="src/sentry/foo.py")
+    assert len(errors) == 1
+    assert "S018" in errors[0]
+
+
+def test_S018_allowlisted_module() -> None:
+    # The contextvar's own module legitimately calls .set() inside the scope manager
+    # and inside set_viewer_context_organization.
+    src = "_viewer_context_var.set(ctx)\n"
+    assert _run(src, filename="src/sentry/viewer_context.py") == []
+    # Match works for any path ending at sentry/viewer_context.py
+    assert _run(src, filename="/abs/path/src/sentry/viewer_context.py") == []
+
+
+def test_S018_middleware_module_not_allowlisted() -> None:
+    # The middleware lives at sentry/middleware/viewer_context.py and is NOT the
+    # allowlisted module — it is expected to use viewer_context_scope.
+    src = "_viewer_context_var.set(ctx)\n"
+    errors = _run(src, filename="src/sentry/middleware/viewer_context.py")
+    assert len(errors) == 1
+    assert "S018" in errors[0]
+
+
+def test_S018_get_method_not_flagged() -> None:
+    src = "x = _viewer_context_var.get()\n"
+    assert _run(src, filename="src/sentry/foo.py") == []
+
+
+def test_S018_reset_method_not_flagged() -> None:
+    src = "_viewer_context_var.reset(tok)\n"
+    assert _run(src, filename="src/sentry/foo.py") == []
+
+
+def test_S018_other_set_calls_not_flagged() -> None:
+    # .set() on anything other than the exact name `_viewer_context_var` is fine
+    assert _run("my_set.set(x)\n", filename="src/sentry/foo.py") == []
+    assert _run("ctx_var.set(x)\n", filename="src/sentry/foo.py") == []
+    assert _run("_other_var.set(x)\n", filename="src/sentry/foo.py") == []
+    # Common ContextVar names shouldn't accidentally trigger
+    assert _run("_request_var.set(req)\n", filename="src/sentry/foo.py") == []
+
+
+def test_S018_attribute_chain_receiver_not_flagged() -> None:
+    # `obj._viewer_context_var.set(x)` — receiver is Attribute, not Name —
+    # so the check (which requires isinstance Name) does not fire.
+    src = "obj._viewer_context_var.set(x)\n"
+    assert _run(src, filename="src/sentry/foo.py") == []
+
+
+def test_S018_string_literal_not_flagged() -> None:
+    # mock.patch passing the dotted path as a string is not a `.set(` call;
+    # the AST is `mock.patch(Constant("..."))`, not `_viewer_context_var.set(...)`.
+    src = 'from unittest import mock\nmock.patch("sentry.viewer_context._viewer_context_var.set")\n'
+    assert _run(src, filename="tests/sentry/test_foo.py") == []
+
+
+def test_S018_dict_set_not_flagged() -> None:
+    # `set` as a dict key, set comprehension, etc. — no false positive
+    src = "data = {'set': 1}\nresult = {x.set for x in items}\n"
+    assert _run(src, filename="src/sentry/foo.py") == []
+
+
+def test_S018_method_named_set_not_flagged() -> None:
+    # A class with its own .set() method should not trip the rule
+    src = "class Foo:\n    def set(self, x): pass\n\nFoo().set(1)\n"
+    assert _run(src, filename="src/sentry/foo.py") == []

--- a/tools/flake8_plugin.py
+++ b/tools/flake8_plugin.py
@@ -48,6 +48,25 @@ S017_msg = (
     "billing/platform/. Use only getsentry.billing.platform.* imports."
 )
 
+S018_msg = (
+    "S018 Use `viewer_context_scope(...)` instead of `_viewer_context_var.set(...)`. "
+    "The scope manager guarantees `reset(token)` cleanup; raw `.set()` leaves the "
+    "ContextVar unbalanced and can leak viewer identity across requests."
+)
+
+
+def _is_viewer_context_module(filename: str) -> bool:
+    """The single file allowed to call `_viewer_context_var.set()` directly.
+
+    Matches `src/sentry/viewer_context.py` exactly; the middleware at
+    `src/sentry/middleware/viewer_context.py` goes through the scope manager
+    and is not allowlisted.
+    """
+    normalized = filename.replace("\\", "/")
+    return normalized == "sentry/viewer_context.py" or normalized.endswith(
+        "/sentry/viewer_context.py"
+    )
+
 
 # --- S015: do not hardcode current or future UTC year as test "now" ---
 # Flag year >= current UTC year at lint time. Module/class scope + freeze_time(datetime(...)).
@@ -257,6 +276,16 @@ class SentryVisitor(ast.NodeVisitor):
         self.generic_visit(node)
 
     def visit_Call(self, node: ast.Call) -> None:
+        # S018: raw `_viewer_context_var.set(...)` outside the viewer_context module
+        if (
+            isinstance(node.func, ast.Attribute)
+            and node.func.attr == "set"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "_viewer_context_var"
+            and not _is_viewer_context_module(self.filename)
+        ):
+            self.errors.append((node.lineno, node.col_offset, S018_msg))
+
         if _is_tests_path(self.filename):
             if (
                 isinstance(node.func, ast.Name)


### PR DESCRIPTION
The Unified ViewerContext RFC says raw `.set()` on the viewer ContextVar is off-limits — only `viewer_context_scope()` (which uses `reset(token)`) is safe. Without a lint rule, a stray `_viewer_context_var.set(...)` leaves the ContextVar unbalanced and can leak viewer identity into the next unit of work running on the same thread (the exact failure mode the RFC's Appendix B threat model worries about).

S018 lives in the existing custom flake8 plugin (`tools/flake8_plugin.py`). It fires on `Call(Attribute(Name('_viewer_context_var'), 'set'))` and allowlists exactly one file — `src/sentry/viewer_context.py` — which is where the scope manager and `set_viewer_context_organization` legitimately call `.set()`. The middleware at `src/sentry/middleware/viewer_context.py` is **not** allowlisted; it goes through `viewer_context_scope` already.

False-positive coverage in `tests/tools/test_flake8_plugin.py`:
- `.get()` / `.reset()` on the same name — not flagged
- `.set()` on different names (`my_set`, `ctx_var`, `_other_var`, `_request_var`) — not flagged
- `obj._viewer_context_var.set(x)` (Attribute receiver, not Name) — not flagged
- `mock.patch("sentry.viewer_context._viewer_context_var.set")` (string literal) — not flagged
- `{'set': 1}` dict key, set comprehensions — not flagged
- A user-defined class with its own `.set()` method — not flagged

Live codebase sweep: zero hits. Only legitimate caller (the contextvar's own module) is allowlisted.

Refs [RFC: Unified ViewerContext via ContextVar](https://www.notion.so/sentry/RFC-Unified-ViewerContext-via-ContextVar-32f8b10e4b5d81988625cb5787035e02)