### PR TITLE
feat(viewer-context): Add observe() helper and instrument 3 chokepoints

### DIFF
--- a/src/sentry/api/endpoints/internal/rpc.py
+++ b/src/sentry/api/endpoints/internal/rpc.py
@@ -17,7 +17,11 @@ from sentry.hybridcloud.rpc.service import (
 )
 from sentry.hybridcloud.rpc.sig import SerializableFunctionValueException
 from sentry.utils.env import in_test_environment
-from sentry.viewer_context import ViewerContext, viewer_context_scope
+from sentry.viewer_context import (
+    ViewerContext,
+    observe_viewer_context_propagation,
+    viewer_context_scope,
+)
 
 
 @internal_all_silo_endpoint
@@ -71,6 +75,15 @@ class InternalRpcServiceEndpoint(Endpoint):
             except Exception as e:
                 sentry_sdk.capture_exception()
                 raise ParseError from e
+
+        # Observe what the caller actually sent, not the empty default we fall back to.
+        # `vc` is always non-None (defaulted to ViewerContext()), so observing inside
+        # the scope below would always see actor_type=unknown and never trigger the
+        # missing-VC signal.
+        observe_viewer_context_propagation(
+            "rpc_inbound",
+            ctx=vc if vc_data else None,
+        )
 
         try:
             with viewer_context_scope(vc), auth_context.applied_to_request(request):

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -12,7 +12,12 @@ from urllib3 import BaseHTTPResponse, HTTPConnectionPool, Retry
 
 from sentry.net.http import connection_from_url
 from sentry.utils import metrics
-from sentry.viewer_context import ViewerContext, encode_viewer_context, get_viewer_context
+from sentry.viewer_context import (
+    ViewerContext,
+    encode_viewer_context,
+    get_viewer_context,
+    observe_viewer_context_propagation,
+)
 
 
 class SeerViewerContext(TypedDict, total=False):
@@ -137,6 +142,7 @@ def make_signed_seer_api_request(
     }
 
     resolved = _resolve_viewer_context(viewer_context)
+    observe_viewer_context_propagation("seer_rpc_out", ctx=resolved)
     if resolved:
         try:
             headers["X-Viewer-Context"] = encode_viewer_context(resolved)

--- a/src/sentry/taskworker/adapters.py
+++ b/src/sentry/taskworker/adapters.py
@@ -30,7 +30,12 @@ from sentry.utils import json
 from sentry.utils import metrics as sentry_metrics
 from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
 from sentry.utils.memory import track_memory_usage as sentry_track_memory_usage
-from sentry.viewer_context import ViewerContext, get_viewer_context, viewer_context_scope
+from sentry.viewer_context import (
+    ViewerContext,
+    get_viewer_context,
+    observe_viewer_context_propagation,
+    viewer_context_scope,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -170,12 +175,21 @@ class ViewerContextHook:
 
     def on_execute(self, headers: dict[str, str]) -> contextlib.AbstractContextManager[None]:
         raw = headers.get(self.HEADER)
-        if not raw:
-            return contextlib.nullcontext()
-        try:
-            ctx = ViewerContext.deserialize(orjson.loads(raw))
-        except (orjson.JSONDecodeError, TypeError, KeyError, AttributeError):
-            logger.exception("Failed to deserialize viewer context header")
+        ctx: ViewerContext | None = None
+        if raw:
+            try:
+                ctx = ViewerContext.deserialize(orjson.loads(raw))
+            except (orjson.JSONDecodeError, TypeError, KeyError, AttributeError):
+                logger.exception("Failed to deserialize viewer context header")
+        # Only `expected=True` when dispatch actually sent the header. That distinguishes
+        # the noise case (system task with no VC, header genuinely absent) from the bug
+        # case (header sent but deserialization failed → ctx is None).
+        observe_viewer_context_propagation(
+            "task_execute",
+            ctx=ctx,
+            expected=bool(raw),
+        )
+        if ctx is None:
             return contextlib.nullcontext()
         return viewer_context_scope(ctx)
 

--- a/src/sentry/viewer_context.py
+++ b/src/sentry/viewer_context.py
@@ -15,10 +15,16 @@ import jwt as pyjwt
 import orjson
 from django.conf import settings
 
+from sentry.utils import metrics
+
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from sentry.auth.services.auth import AuthenticatedToken
+
+# Sentinel for `observe_viewer_context_propagation(ctx=...)`: distinguishes
+# "caller passed None" from "caller didn't pass ctx".
+_OBSERVE_USE_CONTEXTVAR: Any = object()
 
 _viewer_context_var: contextvars.ContextVar[ViewerContext | None] = contextvars.ContextVar(
     "viewer_context", default=None
@@ -101,6 +107,52 @@ def viewer_context_scope(ctx: ViewerContext) -> Generator[None]:
 def get_viewer_context() -> ViewerContext | None:
     """Return the current ``ViewerContext``, or ``None`` if not set."""
     return _viewer_context_var.get()
+
+
+def observe_viewer_context_propagation(
+    point: str,
+    *,
+    ctx: ViewerContext | None | Any = _OBSERVE_USE_CONTEXTVAR,
+    expected: bool = True,
+) -> None:
+    """Emit a ``viewer_context.observation`` counter for the current ViewerContext at *point*.
+
+    Tags: ``point``, ``actor_type``, ``has_user_id``, ``has_org_id``, ``expected``.
+    Cardinality stays bounded: never tag user/org ids themselves, only their presence.
+
+    By default reads the current ContextVar. Pass *ctx* explicitly when the value
+    being observed is a just-resolved override that hasn't entered a scope yet
+    (e.g. the merged result inside ``make_signed_seer_api_request``).
+
+    When ``expected`` is True (the default — most chokepoints expect a viewer)
+    and no ViewerContext is present, also emits a warning log so the offending
+    call site can be identified.
+    """
+    if ctx is _OBSERVE_USE_CONTEXTVAR:
+        ctx = _viewer_context_var.get()
+
+    if ctx is None:
+        actor_type = "none"
+        has_user = False
+        has_org = False
+    else:
+        actor_type = ctx.actor_type.value
+        has_user = ctx.user_id is not None
+        has_org = ctx.organization_id is not None
+
+    metrics.incr(
+        "viewer_context.observation",
+        tags={
+            "point": point,
+            "actor_type": actor_type,
+            "has_user_id": str(has_user).lower(),
+            "has_org_id": str(has_org).lower(),
+            "expected": str(expected).lower(),
+        },
+    )
+
+    if expected and ctx is None:
+        logger.warning("viewer_context.missing", extra={"point": point})
 
 
 def set_viewer_context_organization(organization_id: int) -> None:

--- a/tests/sentry/test_viewer_context.py
+++ b/tests/sentry/test_viewer_context.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextvars
 import dataclasses
 import threading
+from unittest import mock
 
 import pytest
 
@@ -10,6 +11,7 @@ from sentry.viewer_context import (
     ActorType,
     ViewerContext,
     get_viewer_context,
+    observe_viewer_context_propagation,
     set_viewer_context_organization,
     viewer_context_scope,
 )
@@ -145,3 +147,81 @@ class TestViewerContextScope:
         set_viewer_context_organization(42)
 
         assert get_viewer_context() is None
+
+
+class TestObserve:
+    @pytest.fixture(autouse=True)
+    def patch_metrics(self):
+        with mock.patch("sentry.viewer_context.metrics") as m:
+            yield m
+
+    def _tags(self, m):
+        assert m.incr.call_count == 1
+        args, kwargs = m.incr.call_args
+        assert args == ("viewer_context.observation",)
+        return kwargs["tags"]
+
+    def test_no_context_tags_actor_none(self, patch_metrics):
+        observe_viewer_context_propagation("seer_rpc_out")
+        tags = self._tags(patch_metrics)
+        assert tags == {
+            "point": "seer_rpc_out",
+            "actor_type": "none",
+            "has_user_id": "false",
+            "has_org_id": "false",
+            "expected": "true",
+        }
+
+    def test_with_context_tags_actor_and_presence_flags(self, patch_metrics):
+        ctx = ViewerContext(user_id=42, organization_id=7, actor_type=ActorType.USER)
+        with viewer_context_scope(ctx):
+            observe_viewer_context_propagation("seer_rpc_out")
+        tags = self._tags(patch_metrics)
+        assert tags["actor_type"] == "user"
+        assert tags["has_user_id"] == "true"
+        assert tags["has_org_id"] == "true"
+
+    def test_partial_context_tags_individual_flags(self, patch_metrics):
+        # User without org (e.g. cross-org admin lookup before org is resolved)
+        ctx = ViewerContext(user_id=42, actor_type=ActorType.USER)
+        with viewer_context_scope(ctx):
+            observe_viewer_context_propagation("rpc_inbound")
+        tags = self._tags(patch_metrics)
+        assert tags["has_user_id"] == "true"
+        assert tags["has_org_id"] == "false"
+
+    def test_explicit_ctx_overrides_contextvar(self, patch_metrics):
+        # Caller passes a resolved value that's distinct from the contextvar
+        with viewer_context_scope(ViewerContext(actor_type=ActorType.SYSTEM)):
+            observe_viewer_context_propagation(
+                "seer_rpc_out", ctx=ViewerContext(actor_type=ActorType.INTEGRATION)
+            )
+        tags = self._tags(patch_metrics)
+        assert tags["actor_type"] == "integration"
+
+    def test_explicit_ctx_none_treated_as_missing(self, patch_metrics):
+        # Distinguishes "ctx wasn't passed" (sentinel) from "ctx is explicitly None"
+        with viewer_context_scope(ViewerContext(actor_type=ActorType.USER)):
+            observe_viewer_context_propagation("seer_rpc_out", ctx=None)
+        tags = self._tags(patch_metrics)
+        assert tags["actor_type"] == "none"
+
+    def test_expected_false_does_not_log_when_missing(self, patch_metrics, caplog):
+        observe_viewer_context_propagation("optional_point", expected=False)
+        tags = self._tags(patch_metrics)
+        assert tags["expected"] == "false"
+        # No warning log for expected=False misses
+        assert all(r.levelname != "WARNING" for r in caplog.records)
+
+    def test_expected_true_logs_when_missing(self, patch_metrics, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="sentry.viewer_context"):
+            observe_viewer_context_propagation("rpc_inbound")
+        assert any(r.message == "viewer_context.missing" for r in caplog.records)
+
+    def test_expected_true_does_not_log_when_present(self, patch_metrics, caplog):
+        ctx = ViewerContext(user_id=1, actor_type=ActorType.USER)
+        with viewer_context_scope(ctx):
+            observe_viewer_context_propagation("rpc_inbound")
+        assert all(r.message != "viewer_context.missing" for r in caplog.records)


### PR DESCRIPTION
Companion to seer-side PR with matching `seer_rpc_in` + `sentry_rpc_out` instrumentation.

## What

A single helper `observe(point)` in `src/sentry/viewer_context.py` that emits a `viewer_context.observation` counter with bounded-cardinality tags:

- `point` — fixed enum of named chokepoints (e.g. `seer_rpc_out`, `task_execute`, `rpc_inbound`)
- `actor_type` — `user` / `system` / `integration` / `unknown` / `none` (`none` = ctx is `None`)
- `has_user_id` — bool
- `has_org_id` — bool
- `expected` — bool, marks "we expect VC at this point" so misses can be surfaced

Total cardinality: ~5 points × 5 actor types × 2 × 2 × 2 ≈ 200 series. No raw user/org ids ever tagged — only their presence.

When `expected=True` (default) and no VC is present, also emits a warning log so the offending call site can be identified for investigation.

## Chokepoints wired in this PR

1. **`seer_rpc_out`** — `make_signed_seer_api_request` after `_resolve_viewer_context`. Observes the resolved (post-merge) value that actually gets sent in `X-Viewer-Context`.
2. **`task_execute`** — `ViewerContextHook.on_execute`. Observes the deserialized header value (or `None` if header was missing/unparseable). Small refactor to reorganize the early-return path so the observe call has the deserialized `ctx` in scope.
3. **`rpc_inbound`** — cross-silo RPC dispatcher. Called inside `viewer_context_scope(vc)` so we see what propagated.

## Dashboard usage

Per chokepoint, the `actor_type=none AND expected=true` rate gives the "context lost" rate:

```
rate(viewer_context.observation{actor_type="none", expected="true"}) by (point)
```

Cross-cut by `has_user_id`/`has_org_id` to find partial-context cases (e.g. user known but org missing).

## Why a sentinel for `ctx=`

`observe(point, ctx=...)` lets callers pass an explicit value (e.g. the just-resolved param override at `seer_rpc_out`) instead of always reading the ContextVar. The default sentinel distinguishes "caller didn't pass ctx" (read ContextVar) from "caller explicitly passed `None`" (treat as missing).

## Tests

`TestObserve` in `tests/sentry/test_viewer_context.py` covers: default reads ContextVar, explicit ctx overrides, `ctx=None` is treated as missing, presence flags reflect partial contexts, `expected=False` suppresses the warning log, `expected=True` logs only when missing.

Refs [RFC: Unified ViewerContext via ContextVar](https://www.notion.so/sentry/RFC-Unified-ViewerContext-via-ContextVar-32f8b10e4b5d81988625cb5787035e02)