### PR TITLE
feat(utils): Add PK caching and validate_item to CursoredScheduler

### DIFF
--- a/src/sentry/utils/cursored_scheduler.py
+++ b/src/sentry/utils/cursored_scheduler.py
@@ -5,9 +5,12 @@ spread over time via a scheduled task.
 The framework takes a queryset, a task, a cycle duration, and a schedule key.
 It reads the tick interval from the schedule config, then automatically
 calculates the batch size needed to complete one full cycle within the target
-duration. Each invocation, it fetches the next batch of PKs and dispatches
-the task for each one. The cursor is stored in cache (Redis) so progress
-persists across invocations. A distributed lock prevents overlapping ticks.
+duration. At cycle start, all matching PKs are snapshotted into cache so that
+batch sizes remain stable even if the queryset grows or shrinks mid-cycle.
+Each invocation, it fetches the next batch of PKs from the cached snapshot
+and dispatches the task for each one. The cursor is stored in cache (Redis)
+so progress persists across invocations. A distributed lock prevents
+overlapping ticks.
 
 Usage:
 
@@ -35,6 +38,20 @@ Usage:
 
 The task will be called with the PK as a positional argument:
     process_item.delay(item_pk)
+
+Optional validate_item callback:
+
+    def is_eligible(pk: int) -> bool:
+        org = Organization.objects.get_from_cache(id=pk)
+        return features.has("organizations:my-feature", org)
+
+    scheduler = CursoredScheduler(
+        ...
+        validate_item=is_eligible,
+    )
+
+When provided, validate_item is called for each PK before dispatching.
+Items that fail validation are skipped without dispatching the task.
 """
 
 from __future__ import annotations
@@ -42,6 +59,7 @@ from __future__ import annotations
 import logging
 import math
 import time
+from collections.abc import Callable
 from datetime import timedelta
 
 from django.conf import settings
@@ -58,6 +76,7 @@ logger = logging.getLogger(__name__)
 CURSOR_CACHE_KEY_PREFIX = "cursored_scheduler"
 BATCH_SIZE_CACHE_KEY_PREFIX = "cursored_scheduler_batch_size"
 CYCLE_START_CACHE_KEY_PREFIX = "cursored_scheduler_cycle_start"
+PK_LIST_CACHE_KEY_PREFIX = "cursored_scheduler_pks"
 LOCK_PREFIX = "cursored_scheduler_lock"
 # How long to hold the lock during a tick
 DEFAULT_LOCK_DURATION_SECONDS = 120
@@ -97,6 +116,10 @@ class CursoredScheduler[M: Model]:
     When all rows have been processed, the cursor resets and a new cycle
     begins on the next tick().
 
+    At cycle start, all matching PKs are snapshotted into cache. Subsequent
+    ticks read from this snapshot, ensuring stable batch sizes even if the
+    underlying queryset changes mid-cycle.
+
     Batch size is auto-calculated at the start of each cycle based on the total
     row count, cycle_duration, and the tick interval from the schedule config,
     so that one full pass through the queryset completes within approximately
@@ -111,18 +134,21 @@ class CursoredScheduler[M: Model]:
         task: Task[[int], None],
         cycle_duration: timedelta,
         lock_duration: int = DEFAULT_LOCK_DURATION_SECONDS,
+        validate_item: Callable[[int], bool] | None = None,
     ):
         self.name = name
         self.schedule_key = schedule_key
         self.cache_key = f"{CURSOR_CACHE_KEY_PREFIX}:{name}"
         self.batch_size_cache_key = f"{BATCH_SIZE_CACHE_KEY_PREFIX}:{name}"
         self.cycle_start_cache_key = f"{CYCLE_START_CACHE_KEY_PREFIX}:{name}"
+        self.pk_list_cache_key = f"{PK_LIST_CACHE_KEY_PREFIX}:{name}"
         self.lock_key = f"{LOCK_PREFIX}:{name}"
         self.queryset = queryset
         self.task = task
         self.cycle_duration = cycle_duration
         self.cache_ttl = int(cycle_duration.total_seconds() * 2)
         self.lock_duration = lock_duration
+        self.validate_item = validate_item
         self._metric_tags = {"scheduler": name}
 
     @property
@@ -134,8 +160,8 @@ class CursoredScheduler[M: Model]:
         Process the next batch. Call this from your beat task.
 
         Acquires a lock to prevent overlapping ticks, fetches the next batch
-        of PKs from the queryset, dispatches the task for each one, and
-        advances the cursor.
+        of PKs from the cached snapshot, dispatches the task for each one,
+        and advances the cursor.
 
         Returns True if there are more items to process, False if the cycle
         is complete. Returns False without processing if the lock cannot be
@@ -162,28 +188,36 @@ class CursoredScheduler[M: Model]:
         tick_start = time.time()
 
         cursor = self._get_cursor()
-        queryset = self.queryset
 
         if cursor == 0:
-            batch_size = self._initialize_batch(queryset)
+            batch_size = self._initialize_cycle()
         else:
             batch_size = self._get_batch_size()
 
-        items = list(
-            queryset.filter(pk__gt=cursor).order_by("pk").values_list("pk", flat=True)[:batch_size]
-        )
-
-        if not items:
-            self._finalize_batch()
+        cached_pks = self._get_cached_pks()
+        if not cached_pks:
+            self._finalize_cycle()
             metrics.timing(
                 "cursored_scheduler.tick_duration", time.time() - tick_start, tags=self._metric_tags
             )
             return False
 
-        for pk in items:
-            self.task.delay(pk)
+        items = [pk for pk in cached_pks if pk > cursor][:batch_size]
 
-        dispatched = len(items)
+        if not items:
+            self._finalize_cycle()
+            metrics.timing(
+                "cursored_scheduler.tick_duration", time.time() - tick_start, tags=self._metric_tags
+            )
+            return False
+
+        dispatched = 0
+        for pk in items:
+            if self.validate_item is not None and not self.validate_item(pk):
+                continue
+            self.task.delay(pk)
+            dispatched += 1
+
         metrics.gauge("cursored_scheduler.batch_size", dispatched, tags=self._metric_tags)
 
         self._set_cursor(items[-1])
@@ -192,33 +226,36 @@ class CursoredScheduler[M: Model]:
             "cursored_scheduler.tick_duration", time.time() - tick_start, tags=self._metric_tags
         )
 
-        if dispatched < batch_size:
-            self._finalize_batch()
+        if len(items) < batch_size:
+            self._finalize_cycle()
             return False
 
         return True
 
-    def _initialize_batch(self, queryset: QuerySet[M]) -> int:
-        batch_size = self._calculate_batch_size(queryset)
+    def _initialize_cycle(self) -> int:
+        all_pks = list(self.queryset.order_by("pk").values_list("pk", flat=True))
+        self._set_cached_pks(all_pks)
+
+        batch_size = self._calculate_batch_size(len(all_pks))
         cache.set(self.batch_size_cache_key, batch_size, self.cache_ttl)
         cache.set(self.cycle_start_cache_key, time.time(), self.cache_ttl)
         return batch_size
 
-    def _finalize_batch(self):
-        """Reset cursor and batch size to 0, starting a new cycle on the next tick."""
+    def _finalize_cycle(self):
+        """Reset cursor, batch size, and PK cache, starting a new cycle on the next tick."""
         self._emit_cycle_duration()
         cache.set(self.cache_key, 0, self.cache_ttl)
         cache.set(self.batch_size_cache_key, 0, self.cache_ttl)
+        cache.delete(self.pk_list_cache_key)
         cache.delete(self.cycle_start_cache_key)
         metrics.incr("cursored_scheduler.cycle_complete", tags=self._metric_tags)
 
-    def _calculate_batch_size(self, queryset: QuerySet[M]) -> int:
+    def _calculate_batch_size(self, total_rows: int) -> int:
         """
         Calculate batch size based on total rows, cycle duration, and tick interval.
 
         batch_size = ceil(total_rows / ticks_per_cycle)
         """
-        total_rows = queryset.count()
         ticks_per_cycle = self.cycle_duration / self.tick_interval
         batch_size = math.ceil(total_rows / ticks_per_cycle)
         return max(batch_size, MIN_BATCH_SIZE)
@@ -250,3 +287,12 @@ class CursoredScheduler[M: Model]:
         if value is None:
             return 0
         return int(value)
+
+    def _get_cached_pks(self) -> list[int]:
+        value = cache.get(self.pk_list_cache_key)
+        if value is None:
+            return []
+        return value
+
+    def _set_cached_pks(self, pks: list[int]) -> None:
+        cache.set(self.pk_list_cache_key, pks, self.cache_ttl)

--- a/src/sentry/utils/cursored_scheduler.py
+++ b/src/sentry/utils/cursored_scheduler.py
@@ -69,22 +69,19 @@ from taskbroker_client.task import Task
 
 from sentry.locks import locks
 from sentry.utils import metrics, redis
+from sentry.utils.iterators import chunked
 from sentry.utils.locking import UnableToAcquireLock
 
 logger = logging.getLogger(__name__)
 
-CURSOR_CACHE_KEY_PREFIX = "cursored_scheduler"
+CURSOR_CACHE_KEY_PREFIX = "cursored_scheduler_offset"
 BATCH_SIZE_CACHE_KEY_PREFIX = "cursored_scheduler_batch_size"
 CYCLE_START_CACHE_KEY_PREFIX = "cursored_scheduler_cycle_start"
 PK_LIST_CACHE_KEY_PREFIX = "cursored_scheduler_pks"
 LOCK_PREFIX = "cursored_scheduler_lock"
-# How long to hold the lock during a tick
 DEFAULT_LOCK_DURATION_SECONDS = 120
-# Minimum batch size
 MIN_BATCH_SIZE = 1
-# Max PKs per RPUSH command during cycle init. Keeps each command small so
-# Redis's single-threaded event loop isn't blocked for long.
-RPUSH_CHUNK_SIZE = 1000
+RPUSH_CHUNK_SIZE = 10_000
 
 
 def _get_tick_interval(schedule_key: str) -> timedelta:
@@ -228,21 +225,32 @@ class CursoredScheduler[M: Model]:
         return True
 
     def _initialize_cycle(self) -> int:
+        init_start = time.time()
+
         all_pks = list(self.queryset.order_by("pk").values_list("pk", flat=True))
 
         client = self._get_redis_client()
-        # Clear any stale list from a crashed prior init; the distributed lock
-        # ensures no other tick can race with us here.
+
+        existing_len = client.llen(self.pk_list_cache_key)
+        if existing_len > 0:
+            logger.warning(
+                "cursored_scheduler.pk_list_not_empty",
+                extra={"scheduler": self.name, "existing_len": existing_len},
+            )
         client.delete(self.pk_list_cache_key)
-        with client.pipeline(transaction=False) as pipe:
-            for i in range(0, len(all_pks), RPUSH_CHUNK_SIZE):
-                pipe.rpush(self.pk_list_cache_key, *all_pks[i : i + RPUSH_CHUNK_SIZE])
-            pipe.expire(self.pk_list_cache_key, self.cache_ttl)
-            pipe.execute()
+
+        for chunk in chunked(all_pks, RPUSH_CHUNK_SIZE):
+            client.rpush(self.pk_list_cache_key, *chunk)
+        client.expire(self.pk_list_cache_key, self.cache_ttl)
 
         batch_size = self._calculate_batch_size(len(all_pks))
         cache.set(self.batch_size_cache_key, batch_size, self.cache_ttl)
         cache.set(self.cycle_start_cache_key, time.time(), self.cache_ttl)
+
+        metrics.timing(
+            "cursored_scheduler.init_duration", time.time() - init_start, tags=self._metric_tags
+        )
+
         return batch_size
 
     def _finalize_cycle(self):

--- a/src/sentry/utils/cursored_scheduler.py
+++ b/src/sentry/utils/cursored_scheduler.py
@@ -56,6 +56,7 @@ Items that fail validation are skipped without dispatching the task.
 
 from __future__ import annotations
 
+import bisect
 import logging
 import math
 import time
@@ -202,7 +203,8 @@ class CursoredScheduler[M: Model]:
             )
             return False
 
-        items = [pk for pk in cached_pks if pk > cursor][:batch_size]
+        start = bisect.bisect_right(cached_pks, cursor)
+        items = cached_pks[start : start + batch_size]
 
         if not items:
             self._finalize_cycle()

--- a/src/sentry/utils/cursored_scheduler.py
+++ b/src/sentry/utils/cursored_scheduler.py
@@ -5,12 +5,12 @@ spread over time via a scheduled task.
 The framework takes a queryset, a task, a cycle duration, and a schedule key.
 It reads the tick interval from the schedule config, then automatically
 calculates the batch size needed to complete one full cycle within the target
-duration. At cycle start, all matching PKs are snapshotted into cache so that
-batch sizes remain stable even if the queryset grows or shrinks mid-cycle.
-Each invocation, it fetches the next batch of PKs from the cached snapshot
-and dispatches the task for each one. The cursor is stored in cache (Redis)
-so progress persists across invocations. A distributed lock prevents
-overlapping ticks.
+duration. At cycle start, all matching PKs are snapshotted into a Redis list
+so that batch sizes remain stable even if the queryset grows or shrinks
+mid-cycle. Each invocation, it fetches the next page of PKs from the Redis
+list via LRANGE and dispatches the task for each one. The cursor (an integer
+offset into the snapshotted list) is stored in Django's cache so progress
+persists across invocations. A distributed lock prevents overlapping ticks.
 
 Usage:
 
@@ -56,7 +56,6 @@ Items that fail validation are skipped without dispatching the task.
 
 from __future__ import annotations
 
-import bisect
 import logging
 import math
 import time
@@ -69,7 +68,7 @@ from django.db.models import Model, QuerySet
 from taskbroker_client.task import Task
 
 from sentry.locks import locks
-from sentry.utils import metrics
+from sentry.utils import metrics, redis
 from sentry.utils.locking import UnableToAcquireLock
 
 logger = logging.getLogger(__name__)
@@ -83,6 +82,9 @@ LOCK_PREFIX = "cursored_scheduler_lock"
 DEFAULT_LOCK_DURATION_SECONDS = 120
 # Minimum batch size
 MIN_BATCH_SIZE = 1
+# Max PKs per RPUSH command during cycle init. Keeps each command small so
+# Redis's single-threaded event loop isn't blocked for long.
+RPUSH_CHUNK_SIZE = 1000
 
 
 def _get_tick_interval(schedule_key: str) -> timedelta:
@@ -117,9 +119,9 @@ class CursoredScheduler[M: Model]:
     When all rows have been processed, the cursor resets and a new cycle
     begins on the next tick().
 
-    At cycle start, all matching PKs are snapshotted into cache. Subsequent
-    ticks read from this snapshot, ensuring stable batch sizes even if the
-    underlying queryset changes mid-cycle.
+    At cycle start, all matching PKs are snapshotted into a Redis list.
+    Subsequent ticks read pages from this snapshot via LRANGE, ensuring
+    stable batch sizes even if the underlying queryset changes mid-cycle.
 
     Batch size is auto-calculated at the start of each cycle based on the total
     row count, cycle_duration, and the tick interval from the schedule config,
@@ -195,16 +197,7 @@ class CursoredScheduler[M: Model]:
         else:
             batch_size = self._get_batch_size()
 
-        cached_pks = self._get_cached_pks()
-        if not cached_pks:
-            self._finalize_cycle()
-            metrics.timing(
-                "cursored_scheduler.tick_duration", time.time() - tick_start, tags=self._metric_tags
-            )
-            return False
-
-        start = bisect.bisect_right(cached_pks, cursor)
-        items = cached_pks[start : start + batch_size]
+        items = self._get_cached_pks_page(cursor, batch_size)
 
         if not items:
             self._finalize_cycle()
@@ -222,7 +215,7 @@ class CursoredScheduler[M: Model]:
 
         metrics.gauge("cursored_scheduler.batch_size", dispatched, tags=self._metric_tags)
 
-        self._set_cursor(items[-1])
+        self._set_cursor(cursor + len(items))
 
         metrics.timing(
             "cursored_scheduler.tick_duration", time.time() - tick_start, tags=self._metric_tags
@@ -236,7 +229,16 @@ class CursoredScheduler[M: Model]:
 
     def _initialize_cycle(self) -> int:
         all_pks = list(self.queryset.order_by("pk").values_list("pk", flat=True))
-        self._set_cached_pks(all_pks)
+
+        client = self._get_redis_client()
+        # Clear any stale list from a crashed prior init; the distributed lock
+        # ensures no other tick can race with us here.
+        client.delete(self.pk_list_cache_key)
+        with client.pipeline(transaction=False) as pipe:
+            for i in range(0, len(all_pks), RPUSH_CHUNK_SIZE):
+                pipe.rpush(self.pk_list_cache_key, *all_pks[i : i + RPUSH_CHUNK_SIZE])
+            pipe.expire(self.pk_list_cache_key, self.cache_ttl)
+            pipe.execute()
 
         batch_size = self._calculate_batch_size(len(all_pks))
         cache.set(self.batch_size_cache_key, batch_size, self.cache_ttl)
@@ -244,11 +246,11 @@ class CursoredScheduler[M: Model]:
         return batch_size
 
     def _finalize_cycle(self):
-        """Reset cursor, batch size, and PK cache, starting a new cycle on the next tick."""
+        """Reset cursor, batch size, and PK list, starting a new cycle on the next tick."""
         self._emit_cycle_duration()
         cache.set(self.cache_key, 0, self.cache_ttl)
         cache.set(self.batch_size_cache_key, 0, self.cache_ttl)
-        cache.delete(self.pk_list_cache_key)
+        self._get_redis_client().delete(self.pk_list_cache_key)
         cache.delete(self.cycle_start_cache_key)
         metrics.incr("cursored_scheduler.cycle_complete", tags=self._metric_tags)
 
@@ -290,11 +292,10 @@ class CursoredScheduler[M: Model]:
             return 0
         return int(value)
 
-    def _get_cached_pks(self) -> list[int]:
-        value = cache.get(self.pk_list_cache_key)
-        if value is None:
-            return []
-        return value
+    def _get_cached_pks_page(self, offset: int, count: int) -> list[int]:
+        client = self._get_redis_client()
+        raw = client.lrange(self.pk_list_cache_key, offset, offset + count - 1)
+        return [int(v) for v in raw]
 
-    def _set_cached_pks(self, pks: list[int]) -> None:
-        cache.set(self.pk_list_cache_key, pks, self.cache_ttl)
+    def _get_redis_client(self):
+        return redis.redis_clusters.get("default")

--- a/src/sentry/utils/cursored_scheduler.py
+++ b/src/sentry/utils/cursored_scheduler.py
@@ -237,7 +237,7 @@ class CursoredScheduler[M: Model]:
                 "cursored_scheduler.pk_list_not_empty",
                 extra={"scheduler": self.name, "existing_len": existing_len},
             )
-        client.delete(self.pk_list_cache_key)
+            client.delete(self.pk_list_cache_key)
 
         for chunk in chunked(all_pks, RPUSH_CHUNK_SIZE):
             client.rpush(self.pk_list_cache_key, *chunk)

--- a/tests/sentry/utils/test_cursored_scheduler.py
+++ b/tests/sentry/utils/test_cursored_scheduler.py
@@ -16,6 +16,7 @@ from sentry.utils.cursored_scheduler import (
     CursoredScheduler,
     _get_tick_interval,
 )
+from sentry.utils.redis import redis_clusters
 
 TEST_SCHEDULES = {
     "test-scheduler-beat": {
@@ -40,8 +41,11 @@ class CursoredSchedulerTest(TestCase):
         self.mock_task = MagicMock()
         self.cache_key = f"{CURSOR_CACHE_KEY_PREFIX}:test_scheduler"
         self.batch_size_key = f"{BATCH_SIZE_CACHE_KEY_PREFIX}:test_scheduler"
+        self.pk_list_key = f"{PK_LIST_CACHE_KEY_PREFIX}:test_scheduler"
+        self.redis_client = redis_clusters.get("default")
         cache.delete(self.cache_key)
         cache.delete(self.batch_size_key)
+        self.redis_client.delete(self.pk_list_key)
 
     _oi_counter = 0
 
@@ -308,15 +312,13 @@ class CursoredSchedulerTest(TestCase):
         assert self.mock_task.delay.call_count == 3
 
     def test_pks_cached_at_cycle_start(self):
-        """PKs are snapshotted into cache at the start of each cycle."""
+        """PKs are snapshotted into the Redis list at the start of each cycle."""
         self._create_org_integrations(30)
         scheduler = self._make_scheduler()
 
         scheduler.tick()
 
-        cached_pks = cache.get(f"{PK_LIST_CACHE_KEY_PREFIX}:test_scheduler")
-        assert cached_pks is not None
-        assert len(cached_pks) == 30
+        assert self.redis_client.llen(self.pk_list_key) == 30
 
     def test_cached_pks_stable_mid_cycle(self):
         """Adding items mid-cycle doesn't affect the current cycle's batch size."""
@@ -337,7 +339,7 @@ class CursoredSchedulerTest(TestCase):
         assert len(second_batch) == 10
 
     def test_cached_pks_cleared_after_cycle(self):
-        """PK cache is cleared when cycle completes."""
+        """PK list is cleared when cycle completes."""
         self._create_org_integrations(30)
         scheduler = self._make_scheduler()
 
@@ -346,8 +348,7 @@ class CursoredSchedulerTest(TestCase):
         scheduler.tick()
         scheduler.tick()  # cycle done
 
-        cached_pks = cache.get(f"{PK_LIST_CACHE_KEY_PREFIX}:test_scheduler")
-        assert cached_pks is None
+        assert self.redis_client.exists(self.pk_list_key) == 0
 
     def test_validate_item_filters_dispatches(self):
         """When validate_item is provided, only items passing validation are dispatched."""
@@ -384,7 +385,7 @@ class CursoredSchedulerTest(TestCase):
 
     def test_validate_item_cursor_advances_past_skipped(self):
         """Cursor advances based on all items in batch, not just dispatched ones."""
-        ois = self._create_org_integrations(30)
+        self._create_org_integrations(30)
 
         scheduler = CursoredScheduler(
             name="test_scheduler",
@@ -404,7 +405,7 @@ class CursoredSchedulerTest(TestCase):
         assert self.mock_task.delay.call_count == 0
         cursor = cache.get(f"{CURSOR_CACHE_KEY_PREFIX}:test_scheduler")
         assert cursor is not None
-        assert int(cursor) == ois[9].pk
+        assert int(cursor) == 10
 
 
 @override_settings(TASKWORKER_SCHEDULES=TEST_SCHEDULES)

--- a/tests/sentry/utils/test_cursored_scheduler.py
+++ b/tests/sentry/utils/test_cursored_scheduler.py
@@ -12,6 +12,7 @@ from sentry.testutils.silo import control_silo_test
 from sentry.utils.cursored_scheduler import (
     BATCH_SIZE_CACHE_KEY_PREFIX,
     CURSOR_CACHE_KEY_PREFIX,
+    PK_LIST_CACHE_KEY_PREFIX,
     CursoredScheduler,
     _get_tick_interval,
 )
@@ -305,6 +306,105 @@ class CursoredSchedulerTest(TestCase):
         scheduler.tick()
         scheduler.tick()
         assert self.mock_task.delay.call_count == 3
+
+    def test_pks_cached_at_cycle_start(self):
+        """PKs are snapshotted into cache at the start of each cycle."""
+        self._create_org_integrations(30)
+        scheduler = self._make_scheduler()
+
+        scheduler.tick()
+
+        cached_pks = cache.get(f"{PK_LIST_CACHE_KEY_PREFIX}:test_scheduler")
+        assert cached_pks is not None
+        assert len(cached_pks) == 30
+
+    def test_cached_pks_stable_mid_cycle(self):
+        """Adding items mid-cycle doesn't affect the current cycle's batch size."""
+        self._create_org_integrations(30)
+        scheduler = self._make_scheduler()
+
+        scheduler.tick()
+        first_batch = [c.args[0] for c in self.mock_task.delay.call_args_list]
+        assert len(first_batch) == 10
+
+        # Add more items mid-cycle
+        self._create_org_integrations(30)
+
+        self.mock_task.reset_mock()
+        scheduler.tick()
+        second_batch = [c.args[0] for c in self.mock_task.delay.call_args_list]
+        # Still 10, not recalculated to 20
+        assert len(second_batch) == 10
+
+    def test_cached_pks_cleared_after_cycle(self):
+        """PK cache is cleared when cycle completes."""
+        self._create_org_integrations(30)
+        scheduler = self._make_scheduler()
+
+        scheduler.tick()
+        scheduler.tick()
+        scheduler.tick()
+        scheduler.tick()  # cycle done
+
+        cached_pks = cache.get(f"{PK_LIST_CACHE_KEY_PREFIX}:test_scheduler")
+        assert cached_pks is None
+
+    def test_validate_item_filters_dispatches(self):
+        """When validate_item is provided, only items passing validation are dispatched."""
+        ois = self._create_org_integrations(30)
+        # Only dispatch even-indexed PKs
+        even_pks = {oi.pk for oi in ois[::2]}
+
+        scheduler = CursoredScheduler(
+            name="test_scheduler",
+            schedule_key="test-scheduler-beat",
+            queryset=OrganizationIntegration.objects.filter(
+                integration__provider="github",
+                status=ObjectStatus.ACTIVE,
+            ),
+            task=self.mock_task,
+            cycle_duration=timedelta(minutes=3),
+            validate_item=lambda pk: pk in even_pks,
+        )
+
+        scheduler.tick()
+
+        dispatched_pks = [c.args[0] for c in self.mock_task.delay.call_args_list]
+        for pk in dispatched_pks:
+            assert pk in even_pks
+
+    def test_validate_item_none_dispatches_all(self):
+        """When validate_item is None (default), all items are dispatched."""
+        self._create_org_integrations(30)
+        scheduler = self._make_scheduler()
+
+        scheduler.tick()
+
+        assert self.mock_task.delay.call_count == 10
+
+    def test_validate_item_cursor_advances_past_skipped(self):
+        """Cursor advances based on all items in batch, not just dispatched ones."""
+        ois = self._create_org_integrations(30)
+
+        scheduler = CursoredScheduler(
+            name="test_scheduler",
+            schedule_key="test-scheduler-beat",
+            queryset=OrganizationIntegration.objects.filter(
+                integration__provider="github",
+                status=ObjectStatus.ACTIVE,
+            ),
+            task=self.mock_task,
+            cycle_duration=timedelta(minutes=3),
+            validate_item=lambda pk: False,  # reject all
+        )
+
+        scheduler.tick()
+
+        # No dispatches, but cursor should still advance
+        assert self.mock_task.delay.call_count == 0
+        cursor = cache.get(f"{CURSOR_CACHE_KEY_PREFIX}:test_scheduler")
+        assert cursor is not None
+        assert int(cursor) == ois[9].pk
 
 
 @override_settings(TASKWORKER_SCHEDULES=TEST_SCHEDULES)


### PR DESCRIPTION
Cache all matching PKs at cycle start so batch sizes remain stable for the entire run. Add optional validate_item callback to filter items before dispatching, allowing callers to apply eligibility checks (e.g., feature flags) without dispatching no-op tasks.
