### PR TITLE
feat(seer): Print Explorer URL after night shift trigger script runs

### DIFF
--- a/bin/seer/trigger-night-shift
+++ b/bin/seer/trigger-night-shift
@@ -7,6 +7,8 @@ configure()
 import argparse
 import sys
 
+from sentry import options
+from sentry.models.organization import Organization
 from sentry.tasks.seer.night_shift.cron import run_night_shift_for_org
 
 
@@ -17,10 +19,30 @@ def _positive_int(value: str) -> int:
     return parsed
 
 
+def _get_explorer_url(org_id: int, run_id: int) -> str | None:
+    url_prefix = options.get("system.url-prefix")
+    if not url_prefix:
+        return None
+
+    try:
+        slug = Organization.objects.values_list("slug", flat=True).get(id=org_id)
+    except Organization.DoesNotExist:
+        return None
+
+    return f"{url_prefix}/organizations/{slug}/issues/?explorerRunId={run_id}"
+
+
 def main(org_id: int, max_candidates: int | None) -> None:
     sys.stdout.write(f"> Running night shift for organization {org_id}...\n")
-    run_night_shift_for_org(org_id, max_candidates=max_candidates)
+    agent_run_id = run_night_shift_for_org(org_id, max_candidates=max_candidates)
     sys.stdout.write("> Done.\n")
+
+    if agent_run_id is not None:
+        explorer_url = _get_explorer_url(org_id, agent_run_id)
+        if explorer_url:
+            sys.stdout.write(f"> Explorer run: {explorer_url}\n")
+        else:
+            sys.stdout.write(f"> Explorer run ID: {agent_run_id}\n")
 
 
 if __name__ == "__main__":

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -91,7 +91,7 @@ def run_night_shift_for_org(
     organization_id: int,
     dry_run: bool = False,
     max_candidates: int | None = None,
-) -> None:
+) -> int | None:
     try:
         organization = Organization.objects.get(
             id=organization_id, status=OrganizationStatus.ACTIVE
@@ -204,6 +204,8 @@ def run_night_shift_for_org(
                 if _trigger_autofix_for_candidate(c.group, organization, stopping_point):
                     autofix_triggered += 1
     sentry_sdk.metrics.count("night_shift.autofix_triggered", autofix_triggered)
+
+    return agent_run_id
 
 
 def _get_eligible_orgs_from_batch(

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -97,7 +97,7 @@ def run_night_shift_for_org(
             id=organization_id, status=OrganizationStatus.ACTIVE
         )
     except Organization.DoesNotExist:
-        return
+        return None
 
     sentry_sdk.set_tags(
         {
@@ -118,7 +118,7 @@ def run_night_shift_for_org(
                     "organization_slug": organization.slug,
                 },
             )
-            return
+            return None
     except Exception:
         logger.exception(
             "night_shift.failed_to_get_eligible_projects",
@@ -126,7 +126,7 @@ def run_night_shift_for_org(
                 "organization_id": organization_id,
             },
         )
-        return
+        return None
 
     sentry_sdk.metrics.distribution("night_shift.eligible_projects", len(eligible_projects))
 
@@ -168,7 +168,7 @@ def run_night_shift_for_org(
             },
         )
         run.update(error_message="Night shift run failed")
-        return
+        return None
 
     sentry_sdk.metrics.distribution("night_shift.candidates_selected", len(candidates))
     for c in candidates:


### PR DESCRIPTION
After a night shift run completes, the `bin/seer/trigger-night-shift` script now prints a clickable Explorer URL so you can jump straight to the triage session for debugging instead of digging through logs for the run ID.

```
> Running night shift for organization 1...
> Done.
> Explorer run: https://sentry.io/organizations/sentry/issues/?explorerRunId=12345
```

To support this, `run_night_shift_for_org` now returns the `agent_run_id` (`int | None`). The return value is discarded when the task runs via Celery — only the direct script invocation uses it.