### PR TITLE
fix(pipeline): Fix GitHub setup_action=install breaking API pipeline popup flow

### DIFF
--- a/src/sentry/web/frontend/pipeline_advancer.py
+++ b/src/sentry/web/frontend/pipeline_advancer.py
@@ -34,6 +34,11 @@ TRAMPOLINE_HTML = """\
   if (window.opener) {{
     window.opener.postMessage(data, {origin});
     window.close();
+  }} else if ({fallback_url}) {{
+    // GitHub apps installed directly from GitHub won't have an opener window.
+    // Redirect to the integration install org picker instead of showing a
+    // dead-end page.
+    window.location.assign({fallback_url});
   }} else {{
     document.getElementById("fallback").style.display = "flex";
   }}
@@ -45,7 +50,7 @@ TRAMPOLINE_HTML = """\
 </html>"""
 
 
-def _render_trampoline(request: HttpRequest, pipeline: object) -> HttpResponse:
+def _render_trampoline(request: HttpRequest, pipeline: object, provider_id: str) -> HttpResponse:
     """Render a minimal page that posts callback params back to the opener."""
     params: dict[str, str] = {"_pipeline_source": "sentry-pipeline"}
     for key, values in parse_qs(request.META.get("QUERY_STRING", "")).items():
@@ -53,6 +58,17 @@ def _render_trampoline(request: HttpRequest, pipeline: object) -> HttpResponse:
             params[key] = values[0]
 
     data_json = str(dumps_htmlsafe(params))
+
+    # When the callback looks like a GitHub direct install (setup_action=install
+    # with an installation_id), pre-compute the fallback redirect URL so the
+    # trampoline can navigate there if there's no opener window.
+    installation_id = request.GET.get("installation_id")
+    if request.GET.get("setup_action") == "install" and installation_id:
+        fallback_url = str(
+            dumps_htmlsafe(reverse("integration-installation", args=[provider_id, installation_id]))
+        )
+    else:
+        fallback_url = "null"
 
     # In multi-region the opener may be on a different origin (e.g.
     # org-slug.sentry.io) than the trampoline (sentry.io/extensions/...),
@@ -66,7 +82,12 @@ def _render_trampoline(request: HttpRequest, pipeline: object) -> HttpResponse:
     nonce = getattr(request, "csp_nonce", "")
 
     return HttpResponse(
-        TRAMPOLINE_HTML.format(data_json=data_json, origin=origin, nonce=nonce),
+        TRAMPOLINE_HTML.format(
+            data_json=data_json,
+            origin=origin,
+            nonce=nonce,
+            fallback_url=fallback_url,
+        ),
         content_type="text/html",
     )
 
@@ -106,10 +127,7 @@ class PipelineAdvancerView(BaseView):
         if (
             provider_id == IntegrationProviderSlug.GITHUB.value
             and request.GET.get("setup_action") == "install"
-            # There should be no pipeline. If there IS an active API pipeline
-            # we also redirect, since the trampoline would render with no
-            # opener window and leave the user stuck.
-            and (pipeline is None or pipeline.is_api_mode)
+            and pipeline is None
         ):
             installation_id = request.GET.get("installation_id")
             return self.redirect(
@@ -129,7 +147,7 @@ class PipelineAdvancerView(BaseView):
                 tags={"provider": provider_id, "pipeline": pipeline.pipeline_name},
                 sample_rate=1.0,
             )
-            return _render_trampoline(request, pipeline)
+            return _render_trampoline(request, pipeline, provider_id)
 
         metrics.incr(
             "integrations.pipeline_advancer.legacy",

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -2399,16 +2399,17 @@ class GitHubPipelineAdvancerTest(IntegrationTestCase):
         assert resp["Location"] == self._get_expected_redirect()
 
     @responses.activate
-    def test_api_pipeline_redirects_to_org_picker(self) -> None:
-        """When an API pipeline is active, redirect to the org picker instead
-        of rendering the trampoline (which would leave the user stuck since
-        there is no opener window)."""
+    def test_api_pipeline_renders_trampoline(self) -> None:
+        """When an API pipeline is active, render the trampoline page. If the
+        popup has an opener it will postMessage back; if not (e.g. GitHub
+        direct install) the trampoline JS will redirect to the org picker."""
         self.pipeline.set_api_mode()
         self.save_session()
 
         resp = self.client.get(self._get_setup_install_url())
-        assert resp.status_code == 302
-        assert resp["Location"] == self._get_expected_redirect()
+        assert resp.status_code == 200
+        assert b"window.opener" in resp.content
+        assert b"extensions/external-install" in resp.content
 
     @responses.activate
     def test_legacy_pipeline_does_not_redirect(self) -> None:


### PR DESCRIPTION
During normal GitHub integration setup via the API pipeline, GitHub's
callback redirect includes setup_action=install. The pipeline advancer
was matching this and redirecting to the org picker instead of rendering
the trampoline, which meant the popup never posted back to the opener.

Remove the `or pipeline.is_api_mode` condition so the server-side
redirect only fires when there truly is no pipeline. Add fallback logic
to the trampoline so if there's no opener window and the callback is a
GitHub install, it redirects to the org picker client-side.