### PR TITLE
fix(issues): Prevent descender cutoff in GroupMetaRow annotations

### DIFF
--- a/static/app/components/groupMetaRow.tsx
+++ b/static/app/components/groupMetaRow.tsx
@@ -213,6 +213,7 @@ const LoggerAnnotation = styled(Annotation)`
   min-width: 10px;
   display: block;
   width: 100%;
+  line-height: 1.4;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -222,7 +223,7 @@ const Location = styled('div')`
   font-size: ${p => p.theme.font.size.sm};
   color: ${p => p.theme.tokens.content.secondary};
   min-width: 10px;
-  line-height: 1.1;
+  line-height: 1.4;
   display: block;
   width: 100%;
   white-space: nowrap;


### PR DESCRIPTION
The `logger` annotation in `GroupMetaRow` was getting its descenders clipped

Bumps `line-height` to 1.4 on both. `align-items: center` on the parent grid keeps vertical alignment intact.

before
<img width="541" height="76" alt="image" src="https://github.com/user-attachments/assets/d21f4226-60a1-4e22-93ed-a2fae2451903" />

after
<img width="537" height="73" alt="image" src="https://github.com/user-attachments/assets/5911a124-3b8a-4828-b6d2-341c65417d4d" />
