### PR TITLE
ref(drawer): add `shouldLockScroll` option

### DIFF
--- a/static/app/components/globalDrawer/index.tsx
+++ b/static/app/components/globalDrawer/index.tsx
@@ -72,6 +72,10 @@ export interface DrawerOptions {
    * If true (default), closes the drawer when the location changes
    */
   shouldCloseOnLocationChange?: (nextLocation: Location) => boolean;
+  /**
+   * If true (default), locks the page scroll when the drawer is open
+   */
+  shouldLockScroll?: boolean;
   //
   // Custom framer motion transition for the drawer
   //
@@ -123,7 +127,9 @@ export function GlobalDrawer({children}: any) {
   const scrollLock = useScrollLock(document.body);
   const openDrawer = useCallback<DrawerContextType['openDrawer']>(
     (renderer, options) => {
-      scrollLock.acquire();
+      if (options.scrollLock ?? true) {
+        scrollLock.acquire();
+      }
       overwriteDrawerConfig({renderer, options});
       options.onOpen?.();
     },

--- a/static/app/components/globalDrawer/index.tsx
+++ b/static/app/components/globalDrawer/index.tsx
@@ -127,7 +127,7 @@ export function GlobalDrawer({children}: any) {
   const scrollLock = useScrollLock(document.body);
   const openDrawer = useCallback<DrawerContextType['openDrawer']>(
     (renderer, options) => {
-      if (options.scrollLock ?? true) {
+      if (options.shouldLockScroll ?? true) {
         scrollLock.acquire();
       }
       overwriteDrawerConfig({renderer, options});

--- a/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerDrawer.tsx
@@ -60,9 +60,8 @@ export const useOpenSeerDrawer = ({
         max-height: 100%;
       `,
       resizable: true,
-      shouldCloseOnInteractOutside: () => {
-        return false;
-      },
+      closeOnOutsideClick: false,
+      shouldLockScroll: false,
       onClose: () => {
         navigate(
           {


### PR DESCRIPTION
Adds a `shouldLockScroll` option to the `useDrawer` hook to unblock Seer