### PR TITLE
feat(aci): Require at least one connected monitor in the alert builder

### DIFF
--- a/static/app/views/automations/components/automationBuilderDrawerForm.tsx
+++ b/static/app/views/automations/components/automationBuilderDrawerForm.tsx
@@ -118,7 +118,9 @@ export function AutomationBuilderDrawerForm({
 
   const handleSubmit = useCallback<OnSubmitCallback>(
     async (data, onSubmitSuccess, onSubmitError, _event, formModel) => {
-      const errors = validateAutomationBuilderState(state);
+      const errors = validateAutomationBuilderState(state, data as AutomationFormData, {
+        validateConnectedMonitors: false,
+      });
       setAutomationBuilderErrors(errors);
 
       if (Object.keys(errors).length > 0) {

--- a/static/app/views/automations/components/automationFormData.tsx
+++ b/static/app/views/automations/components/automationFormData.tsx
@@ -12,6 +12,7 @@ import type {
 import {actionNodesMap} from 'sentry/views/automations/components/actionNodes';
 import type {AutomationBuilderState} from 'sentry/views/automations/components/automationBuilderContext';
 import {dataConditionNodesMap} from 'sentry/views/automations/components/dataConditionNodes';
+import {CONNECTED_MONITORS_ERROR_ID} from 'sentry/views/automations/components/editConnectedMonitors';
 
 export interface AutomationFormData {
   detectorIds: string[];
@@ -106,8 +107,23 @@ export interface ValidateDataConditionProps {
   condition: DataCondition;
 }
 
-export function validateAutomationBuilderState(state: AutomationBuilderState) {
+export function validateAutomationBuilderState(
+  state: AutomationBuilderState,
+  data: AutomationFormData,
+  {validateConnectedMonitors = true}: {validateConnectedMonitors?: boolean} = {}
+) {
   const errors: Record<string, string> = {};
+
+  if (
+    validateConnectedMonitors &&
+    !data.detectorIds?.length &&
+    !data.projectIds?.length
+  ) {
+    errors[CONNECTED_MONITORS_ERROR_ID] = t(
+      'Select at least one project or monitor to create an alert.'
+    );
+  }
+
   // validate trigger conditions
   for (const condition of state.triggers.conditions || []) {
     const validationResult = dataConditionNodesMap

--- a/static/app/views/automations/components/editConnectedMonitors.tsx
+++ b/static/app/views/automations/components/editConnectedMonitors.tsx
@@ -1,6 +1,7 @@
 import {Fragment, useCallback, useContext, useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
+import {Alert} from '@sentry/scraps/alert';
 import {Button, LinkButton} from '@sentry/scraps/button';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 
@@ -22,6 +23,7 @@ import type {Detector} from 'sentry/types/workflowEngine/detectors';
 import {useQueryClient} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
+import {AutomationBuilderErrorContext} from 'sentry/views/automations/components/automationBuilderErrorContext';
 import {ConnectedMonitorsList} from 'sentry/views/automations/components/connectedMonitorsList';
 import {useConnectedDetectors} from 'sentry/views/automations/hooks/useConnectedDetectors';
 import {DetectorSearch} from 'sentry/views/detectors/components/detectorSearch';
@@ -284,6 +286,8 @@ function SpecificMonitorsSection({
   );
 }
 
+export const CONNECTED_MONITORS_ERROR_ID = 'connectedMonitors';
+
 function EditConnectedMonitorsContent({
   initialMode,
   connectedIds,
@@ -291,6 +295,7 @@ function EditConnectedMonitorsContent({
 }: ContentProps) {
   const [monitorMode, setMonitorMode] = useState<MonitorMode>(initialMode);
   const {form} = useContext(FormContext);
+  const errorContext = useContext(AutomationBuilderErrorContext);
 
   const handleModeChange = useCallback(
     (newMode: MonitorMode) => {
@@ -302,11 +307,23 @@ function EditConnectedMonitorsContent({
   );
   const handleProjectChange = useCallback(
     (projectIds: string[]) => {
-      if (!projectIds.length) {
+      if (projectIds.length) {
+        errorContext?.removeError(CONNECTED_MONITORS_ERROR_ID);
+      } else {
         setConnectedIds([]);
       }
     },
-    [setConnectedIds]
+    [setConnectedIds, errorContext]
+  );
+
+  const handleSetConnectedIds = useCallback(
+    (ids: Automation['detectorIds']) => {
+      setConnectedIds(ids);
+      if (ids.length) {
+        errorContext?.removeError(CONNECTED_MONITORS_ERROR_ID);
+      }
+    },
+    [setConnectedIds, errorContext]
   );
 
   return (
@@ -332,8 +349,13 @@ function EditConnectedMonitorsContent({
           ) : (
             <SpecificMonitorsSection
               connectedIds={connectedIds}
-              setConnectedIds={setConnectedIds}
+              setConnectedIds={handleSetConnectedIds}
             />
+          )}
+          {errorContext?.errors[CONNECTED_MONITORS_ERROR_ID] && (
+            <Alert variant="danger">
+              {errorContext.errors[CONNECTED_MONITORS_ERROR_ID]}
+            </Alert>
           )}
         </Stack>
       </FormSection>

--- a/static/app/views/automations/edit.tsx
+++ b/static/app/views/automations/edit.tsx
@@ -142,13 +142,14 @@ function AutomationEditForm({automation}: {automation: Automation}) {
 
   const handleFormSubmit = useCallback<OnSubmitCallback>(
     async (data, onSubmitSuccess, onSubmitError, _event, formModel) => {
-      const errors = validateAutomationBuilderState(state);
+      const automationFormData = data as AutomationFormData;
+      const errors = validateAutomationBuilderState(state, automationFormData);
       setAutomationBuilderErrors(errors);
 
       if (Object.keys(errors).length > 0) {
         const analyticsPayload = getAutomationAnalyticsPayload(
           getNewAutomationData({
-            data: data as AutomationFormData,
+            data: automationFormData,
             state,
           })
         );
@@ -167,7 +168,7 @@ function AutomationEditForm({automation}: {automation: Automation}) {
       formModel.setFormSaving();
 
       const formData = await resolveDetectorIdsForProjects({
-        formData: data as AutomationFormData,
+        formData: automationFormData,
         onSubmitError,
         organization,
         projectIds: data.projectIds,

--- a/static/app/views/automations/new.spec.tsx
+++ b/static/app/views/automations/new.spec.tsx
@@ -2,6 +2,7 @@ import {AutomationFixture} from 'sentry-fixture/automations';
 import {IssueStreamDetectorFixture} from 'sentry-fixture/detectors';
 import {MemberFixture} from 'sentry-fixture/member';
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {UserFixture} from 'sentry-fixture/user';
 import {
@@ -13,6 +14,7 @@ import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrar
 import {selectEvent} from 'sentry-test/selectEvent';
 
 import * as indicators from 'sentry/actionCreators/indicator';
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {Action} from 'sentry/types/workflowEngine/actions';
 import {ActionGroup, ActionType} from 'sentry/types/workflowEngine/actions';
@@ -209,7 +211,12 @@ describe('AutomationNewSettings', () => {
       body: created,
     });
 
-    const {router} = render(<AutomationNewSettings />, {organization});
+    const {router} = render(<AutomationNewSettings />, {
+      organization,
+      initialRouterConfig: {
+        location: {pathname: '/', query: {connectedIds: '123'}},
+      },
+    });
 
     // Add an action filter (tagged event)
     await selectEvent.select(
@@ -291,7 +298,7 @@ describe('AutomationNewSettings', () => {
               },
             ],
             config: {frequency: 0},
-            detectorIds: [],
+            detectorIds: ['123'],
             enabled: true,
           },
         })
@@ -329,7 +336,12 @@ describe('AutomationNewSettings', () => {
       body: created,
     });
 
-    render(<AutomationNewSettings />, {organization});
+    render(<AutomationNewSettings />, {
+      organization,
+      initialRouterConfig: {
+        location: {pathname: '/', query: {connectedIds: '123'}},
+      },
+    });
 
     const addAction = async (label: string) => {
       await selectEvent.select(screen.getByRole('textbox', {name: 'Add action'}), label);
@@ -591,6 +603,68 @@ describe('AutomationNewSettings', () => {
     await waitFor(() => {
       expect(indicators.addSuccessMessage).toHaveBeenCalledWith('Notification fired!');
     });
+  });
+
+  it('shows validation error when submitting with no projects or monitors selected', async () => {
+    ProjectsStore.loadInitialData([]);
+
+    const post = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/workflows/`,
+      method: 'POST',
+      body: AutomationFixture(),
+    });
+
+    render(<AutomationNewSettings />, {organization});
+
+    // Add an action so the builder validation passes
+    await selectEvent.select(screen.getByRole('textbox', {name: 'Add action'}), 'Slack');
+    await userEvent.type(screen.getByRole('textbox', {name: 'Target'}), '#alerts');
+
+    // Submit with no projects or monitors selected
+    await userEvent.click(screen.getByRole('button', {name: 'Create Alert'}));
+
+    // Should show validation error
+    expect(
+      await screen.findByText(
+        'Select at least one project or monitor to create an alert.'
+      )
+    ).toBeInTheDocument();
+
+    // Should not have submitted
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it('pre-selects a project from page filters on first load', async () => {
+    const project = ProjectFixture({id: '2', slug: 'my-project', isMember: true});
+    ProjectsStore.loadInitialData([project]);
+    PageFiltersStore.onInitializeUrlState(
+      PageFiltersFixture({projects: [Number(project.id)]})
+    );
+
+    render(<AutomationNewSettings />, {organization});
+
+    // The project selector should show the pre-selected project
+    expect(await screen.findByText('my-project')).toBeInTheDocument();
+  });
+
+  it('pre-selects the first member project when "my projects" is selected', async () => {
+    const memberProject = ProjectFixture({
+      id: '3',
+      slug: 'member-project',
+      isMember: true,
+    });
+    const otherProject = ProjectFixture({
+      id: '4',
+      slug: 'other-project',
+      isMember: false,
+    });
+    ProjectsStore.loadInitialData([otherProject, memberProject]);
+    PageFiltersStore.onInitializeUrlState(PageFiltersFixture({projects: []}));
+
+    render(<AutomationNewSettings />, {organization});
+
+    // Should pre-select the member project
+    expect(await screen.findByText('member-project')).toBeInTheDocument();
   });
 
   it('surfaces error details when test notification fails', async () => {

--- a/static/app/views/automations/new.tsx
+++ b/static/app/views/automations/new.tsx
@@ -2,7 +2,9 @@ import {useCallback, useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
+import orderBy from 'lodash/orderBy';
 import {Observer} from 'mobx-react-lite';
+import {parseAsNativeArrayOf, parseAsString, useQueryState} from 'nuqs';
 
 import {Button} from '@sentry/scraps/button';
 import {Flex, Stack} from '@sentry/scraps/layout';
@@ -12,6 +14,7 @@ import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import {FormModel} from 'sentry/components/forms/model';
 import type {OnSubmitCallback} from 'sentry/components/forms/types';
 import * as Layout from 'sentry/components/layouts/thirds';
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {FullHeightForm} from 'sentry/components/workflowEngine/form/fullHeightForm';
 import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
@@ -19,9 +22,9 @@ import {StickyFooter} from 'sentry/components/workflowEngine/ui/footer';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useQueryClient} from 'sentry/utils/queryClient';
-import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {useProjects} from 'sentry/utils/useProjects';
 import {
   AutomationBuilderContext,
   useAutomationBuilderReducer,
@@ -68,23 +71,69 @@ function AutomationBreadcrumbs() {
   );
 }
 
-const initialData = {
+const INITIAL_FORM_DATA_DEFAULTS = {
   name: '',
   environment: null,
   frequency: 0,
   enabled: true,
   projectIds: [],
+  detectorIds: [],
 };
+
+function useInitialFormData() {
+  const {selection} = usePageFilters();
+  const [connectedIds] = useQueryState(
+    'connectedIds',
+    parseAsNativeArrayOf(parseAsString)
+  );
+  const [projectId] = useQueryState('project', parseAsString);
+  const {projects} = useProjects();
+
+  // If URL params are passed, use them
+  if (connectedIds.length > 0) {
+    return {
+      ...INITIAL_FORM_DATA_DEFAULTS,
+      detectorIds: connectedIds,
+    };
+  }
+  if (projectId) {
+    return {
+      ...INITIAL_FORM_DATA_DEFAULTS,
+      projectIds: [projectId],
+    };
+  }
+
+  // If any specific projects are selected, use the first one
+  const intitialSelectedProject = selection.projects.find(p => p > 0);
+  if (intitialSelectedProject) {
+    return {
+      ...INITIAL_FORM_DATA_DEFAULTS,
+      projectIds: [String(intitialSelectedProject)],
+    };
+  }
+
+  // Otherwise use the first project that the user has access to
+  const sortedUserProjects = orderBy(
+    projects,
+    ['isMember', 'isBookmarked'],
+    ['desc', 'desc']
+  );
+  const firstUserProject = sortedUserProjects[0];
+  return {
+    ...INITIAL_FORM_DATA_DEFAULTS,
+    projectIds: firstUserProject ? [firstUserProject.id] : [],
+  };
+}
 
 export default function AutomationNewSettings() {
   const navigate = useNavigate();
-  const location = useLocation();
   const queryClient = useQueryClient();
   const organization = useOrganization();
   const model = useMemo(() => new FormModel(), []);
   const {state, actions} = useAutomationBuilderReducer();
   const theme = useTheme();
   const maxWidth = theme.breakpoints.lg;
+  const initialData = useInitialFormData();
 
   const {
     errors: automationBuilderErrors,
@@ -92,31 +141,18 @@ export default function AutomationNewSettings() {
     removeError,
   } = useAutomationBuilderErrors();
 
-  const initialConnectedIds = useMemo(() => {
-    const connectedIdsQuery = location.query.connectedIds as
-      | string
-      | string[]
-      | undefined;
-    if (!connectedIdsQuery) {
-      return [];
-    }
-    const connectedIds = Array.isArray(connectedIdsQuery)
-      ? connectedIdsQuery
-      : [connectedIdsQuery];
-    return connectedIds;
-  }, [location.query.connectedIds]);
-
   const {mutateAsync: createAutomation, error} = useCreateAutomation();
 
   const handleSubmit = useCallback<OnSubmitCallback>(
     async (data, onSubmitSuccess, onSubmitError, _event, formModel) => {
-      const errors = validateAutomationBuilderState(state);
+      const automationFormData = data as AutomationFormData;
+      const errors = validateAutomationBuilderState(state, automationFormData);
       setAutomationBuilderErrors(errors);
 
       if (Object.keys(errors).length > 0) {
         const analyticsPayload = getAutomationAnalyticsPayload(
           getNewAutomationData({
-            data: data as AutomationFormData,
+            data: automationFormData,
             state,
           })
         );
@@ -136,7 +172,7 @@ export default function AutomationNewSettings() {
       formModel.setFormSaving();
 
       const formData = await resolveDetectorIdsForProjects({
-        formData: data as AutomationFormData,
+        formData: automationFormData,
         onSubmitError,
         organization,
         projectIds: data.projectIds,
@@ -189,7 +225,7 @@ export default function AutomationNewSettings() {
   return (
     <FullHeightForm
       hideFooter
-      initialData={{...initialData, detectorIds: initialConnectedIds}}
+      initialData={initialData}
       onSubmit={handleSubmit}
       model={model}
     >


### PR DESCRIPTION
Closes ISWF-2235

- Adds validation to prevent saving alerts without a connected project/monitor
- When creating a new alert, automatically selects a project from your page filters (or if "my projects" is selected, chooses one of the projects you belong to) 

https://github.com/user-attachments/assets/713fda2a-e1e1-4dff-b2b0-ac8c5f08967a

