### PR TITLE
chore(billing): Renamed metrics to application metric counts(BIL-2237)

### DIFF
--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -633,10 +633,10 @@ export const DATA_CATEGORY_INFO = {
   [DataCategoryExact.TRACE_METRIC]: {
     name: DataCategoryExact.TRACE_METRIC,
     plural: DataCategory.TRACE_METRICS,
-    singular: 'metric',
-    displayName: 'metric',
-    titleName: t('Metrics'),
-    productName: t('Metrics'),
+    singular: 'applicationMetric',
+    displayName: 'application metric',
+    titleName: t('Application Metrics Counts'), // only visible internally
+    productName: t('Application Metrics'),
     uid: 33,
     isBilledCategory: false,
     statsInfo: {
@@ -648,7 +648,7 @@ export const DATA_CATEGORY_INFO = {
   [DataCategoryExact.TRACE_METRIC_BYTE]: {
     name: DataCategoryExact.TRACE_METRIC_BYTE,
     plural: DataCategory.TRACE_METRIC_BYTE,
-    singular: 'traceMetricByte',
+    singular: 'applicationMetricByte',
     displayName: 'application metric byte',
     titleName: t('Application Metrics'),
     productName: t('Application Metrics'),


### PR DESCRIPTION
https://linear.app/getsentry/issue/BIL-2237/rename-metrics-to-application-metric-counts

This PR renames metrics to application metric counts, to reflect the shift in naming to application metrics, and to clarify that this represents raw counts, instead of the volume based application metric bytes. This also reflects the logs pattern. 