### PR TITLE
feat(llm-detection): Add Seer budget pre-check before dispatching traces

### DIFF
--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -331,7 +331,7 @@ def detect_llm_issues_for_project(project_id: int) -> None:
 
     budget_response = make_signed_seer_api_request(
         seer_issue_detection_connection_pool,
-        f"{SEER_CHECK_BUDGET_ENDPOINT_PATH}?organization_id={organization_id}",
+        f"{SEER_CHECK_BUDGET_ENDPOINT_PATH}/{organization_id}",
         body=b"",
         method="GET",
         timeout=SEER_TIMEOUT_S,

--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -31,11 +31,13 @@ from sentry.seer.explorer.utils import normalize_description
 from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_request
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import issues_tasks
+from sentry.utils import json
 from sentry.utils.redis import redis_clusters
 
 logger = logging.getLogger("sentry.tasks.llm_issue_detection")
 
 SEER_ANALYZE_ISSUE_ENDPOINT_PATH = "/v1/automation/issue-detection/analyze"
+SEER_CHECK_BUDGET_ENDPOINT_PATH = "/v1/automation/issue-detection/check-budget"
 SEER_TIMEOUT_S = 10
 START_TIME_DELTA_MINUTES = 60
 TRANSACTION_BATCH_SIZE = 50
@@ -326,6 +328,26 @@ def detect_llm_issues_for_project(project_id: int) -> None:
     perf_settings = project.get_option("sentry:performance_issue_settings", default={})
     if not perf_settings.get("ai_issue_detection_enabled", True):
         return
+
+    budget_response = make_signed_seer_api_request(
+        seer_issue_detection_connection_pool,
+        f"{SEER_CHECK_BUDGET_ENDPOINT_PATH}?organization_id={organization_id}",
+        body=b"",
+        method="GET",
+        timeout=SEER_TIMEOUT_S,
+    )
+    if budget_response.status == 200:
+        # fail-open since there is an additional budget check on the seer side
+        try:
+            body = json.loads(budget_response.data)
+            if not body.get("has_budget", True):
+                logger.info(
+                    "llm_issue_detection.budget_exceeded",
+                    extra={"organization_id": organization_id},
+                )
+                return
+        except json.JSONDecodeError:
+            pass
 
     evidence_traces = get_project_top_transaction_traces_for_llm_detection(
         project_id, limit=TRANSACTION_BATCH_SIZE, start_time_delta_minutes=START_TIME_DELTA_MINUTES

--- a/tests/sentry/tasks/test_llm_issue_detection.py
+++ b/tests/sentry/tasks/test_llm_issue_detection.py
@@ -27,6 +27,13 @@ from sentry.testutils.helpers.features import with_feature
 
 
 class LLMIssueDetectionTest(TestCase):
+    @staticmethod
+    def _budget_ok_response() -> Mock:
+        response = Mock()
+        response.status = 200
+        response.data = b'{"has_budget": true}'
+        return response
+
     @patch("sentry.tasks.llm_issue_detection.detection.detect_llm_issues_for_project.apply_async")
     def test_run_detection_dispatches_sub_tasks(self, mock_apply_async):
         project = self.create_project()
@@ -44,11 +51,16 @@ class LLMIssueDetectionTest(TestCase):
         )
 
     @with_feature("organizations:gen-ai-features")
+    @patch("sentry.tasks.llm_issue_detection.detection.make_signed_seer_api_request")
     @patch("sentry.tasks.llm_issue_detection.detection.make_issue_detection_request")
     @patch(
         "sentry.tasks.llm_issue_detection.trace_data.get_project_top_transaction_traces_for_llm_detection"
     )
-    def test_detect_llm_issues_no_transactions(self, mock_get_transactions, mock_seer_request):
+    def test_detect_llm_issues_no_transactions(
+        self, mock_get_transactions, mock_seer_request, mock_budget_request
+    ):
+        mock_budget_request.return_value = self._budget_ok_response()
+
         mock_get_transactions.return_value = []
 
         detect_llm_issues_for_project(self.project.id)
@@ -61,9 +73,14 @@ class LLMIssueDetectionTest(TestCase):
         mock_seer_request.assert_not_called()
 
     @with_feature("organizations:gen-ai-features")
+    @patch("sentry.tasks.llm_issue_detection.detection.make_signed_seer_api_request")
     @patch("sentry.tasks.llm_issue_detection.trace_data.Spans.run_table_query")
     @patch("sentry.tasks.llm_issue_detection.detection.make_issue_detection_request")
-    def test_detect_llm_issues_no_traces(self, mock_seer_request, mock_spans_query):
+    def test_detect_llm_issues_no_traces(
+        self, mock_seer_request, mock_spans_query, mock_budget_request
+    ):
+        mock_budget_request.return_value = self._budget_ok_response()
+
         mock_spans_query.side_effect = [
             # First call: Return a transaction
             {
@@ -164,6 +181,7 @@ class LLMIssueDetectionTest(TestCase):
         assert occurrence.type == AIDetectedDBGroupType
 
     @with_feature("organizations:gen-ai-features")
+    @patch("sentry.tasks.llm_issue_detection.detection.make_signed_seer_api_request")
     @patch("sentry.tasks.llm_issue_detection.detection.mark_traces_as_processed")
     @patch("sentry.tasks.llm_issue_detection.detection._get_unprocessed_traces")
     @patch("sentry.tasks.llm_issue_detection.detection.make_issue_detection_request")
@@ -176,7 +194,10 @@ class LLMIssueDetectionTest(TestCase):
         mock_seer_request,
         mock_get_unprocessed,
         mock_mark_processed,
+        mock_budget_request,
     ):
+        mock_budget_request.return_value = self._budget_ok_response()
+
         mock_shuffle.return_value = None  # shuffles in-place, mock to prevent reordering
         mock_get_unprocessed.return_value = {"trace_id_1", "trace_id_2"}  # All unprocessed
 
@@ -234,6 +255,7 @@ class LLMIssueDetectionTest(TestCase):
         mock_mark_processed.assert_called_once_with(["trace_id_1", "trace_id_2"])
 
     @with_feature("organizations:gen-ai-features")
+    @patch("sentry.tasks.llm_issue_detection.detection.make_signed_seer_api_request")
     @patch("sentry.tasks.llm_issue_detection.detection.mark_traces_as_processed")
     @patch("sentry.tasks.llm_issue_detection.detection._get_unprocessed_traces")
     @patch("sentry.tasks.llm_issue_detection.detection.make_issue_detection_request")
@@ -248,7 +270,10 @@ class LLMIssueDetectionTest(TestCase):
         mock_seer_request,
         mock_get_unprocessed,
         mock_mark_processed,
+        mock_budget_request,
     ):
+        mock_budget_request.return_value = self._budget_ok_response()
+
         mock_shuffle.return_value = None
         mock_get_unprocessed.return_value = {"trace_id_1"}
 
@@ -274,6 +299,43 @@ class LLMIssueDetectionTest(TestCase):
         assert mock_logger_error.call_count == 1
         # Traces NOT marked as processed on error - will be retried next run
         assert mock_mark_processed.call_count == 0
+
+    @with_feature("organizations:gen-ai-features")
+    @patch("sentry.tasks.llm_issue_detection.detection.make_issue_detection_request")
+    @patch(
+        "sentry.tasks.llm_issue_detection.trace_data.get_project_top_transaction_traces_for_llm_detection"
+    )
+    @patch("sentry.tasks.llm_issue_detection.detection.make_signed_seer_api_request")
+    def test_check_budget_fail_open(self, mock_budget_request, mock_get_transactions, _):
+        mock_budget_response = Mock()
+        mock_budget_response.status = 500
+        mock_budget_response.data = b"Internal Server Error"
+        mock_budget_request.return_value = mock_budget_response
+
+        mock_get_transactions.return_value = []
+
+        detect_llm_issues_for_project(self.project.id)
+
+        mock_get_transactions.assert_called_once()
+
+    @with_feature("organizations:gen-ai-features")
+    @patch("sentry.tasks.llm_issue_detection.detection.make_issue_detection_request")
+    @patch(
+        "sentry.tasks.llm_issue_detection.trace_data.get_project_top_transaction_traces_for_llm_detection"
+    )
+    @patch("sentry.tasks.llm_issue_detection.detection.make_signed_seer_api_request")
+    def test_check_budget_over_budget(
+        self, mock_budget_request, mock_get_transactions, mock_seer_request
+    ):
+        mock_budget_response = Mock()
+        mock_budget_response.status = 200
+        mock_budget_response.data = b'{"has_budget": false}'
+        mock_budget_request.return_value = mock_budget_response
+
+        detect_llm_issues_for_project(self.project.id)
+
+        mock_get_transactions.assert_not_called()
+        mock_seer_request.assert_not_called()
 
 
 class TestTraceProcessingFunctions:


### PR DESCRIPTION
Call [my new `check-budget` endpoint](https://github.com/getsentry/seer/pull/5828) before fetching and dispatching traces for LLM analysis. If the org is over its weekly budget, skip the entire detection flow early.

Fail-open: if the budget endpoint returns a non-200, is unreachable, or returns bad JSON, detection proceeds normally. Seer has its own fail-closed guard in the task as a backstop.