### PR TITLE
fix(billing): Treat UNLIMITED_RESERVED as active quota in profiling

### DIFF
--- a/static/gsApp/components/profiling/alerts.spec.tsx
+++ b/static/gsApp/components/profiling/alerts.spec.tsx
@@ -1,0 +1,135 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {MetricHistoryFixture} from 'getsentry-test/fixtures/metricHistory';
+import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {DataCategory} from 'sentry/types/core';
+
+import {ContinuousProfilingBillingRequirementBanner} from 'getsentry/components/profiling/alerts';
+import {UNLIMITED_RESERVED} from 'getsentry/constants';
+import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
+import {PlanTier} from 'getsentry/types';
+
+describe('ContinuousProfilingBillingRequirementBanner', () => {
+  beforeEach(() => {
+    SubscriptionStore.init();
+  });
+
+  it('renders null when profileDuration has unlimited reserved quota', () => {
+    const organization = OrganizationFixture();
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am3_t_ent',
+      planTier: PlanTier.AM3,
+    });
+    subscription.categories.profileDuration = MetricHistoryFixture({
+      category: DataCategory.PROFILE_DURATION,
+      reserved: UNLIMITED_RESERVED,
+      prepaid: UNLIMITED_RESERVED,
+    });
+    subscription.onDemandMaxSpend = 0;
+    SubscriptionStore.set(organization.slug, subscription);
+
+    const project = ProjectFixture({platform: 'python'});
+    render(<ContinuousProfilingBillingRequirementBanner project={project} />, {
+      organization,
+    });
+
+    expect(
+      screen.queryByRole('heading', {name: 'Try Sentry Business for Free'})
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', {name: /Pay-As-You-Go/i})
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', {name: /On-Demand/i})).not.toBeInTheDocument();
+  });
+
+  it('renders null on non-AM2/AM3 plans', () => {
+    const organization = OrganizationFixture();
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am1_f',
+      planTier: PlanTier.AM1,
+    });
+    SubscriptionStore.set(organization.slug, subscription);
+
+    const project = ProjectFixture({platform: 'python'});
+    render(<ContinuousProfilingBillingRequirementBanner project={project} />, {
+      organization,
+    });
+
+    expect(
+      screen.queryByRole('heading', {name: 'Try Sentry Business for Free'})
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders null when project platform is not profile-duration-compatible', () => {
+    const organization = OrganizationFixture();
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am3_t_ent',
+      planTier: PlanTier.AM3,
+    });
+    SubscriptionStore.set(organization.slug, subscription);
+
+    const project = ProjectFixture({platform: 'other'});
+    render(<ContinuousProfilingBillingRequirementBanner project={project} />, {
+      organization,
+    });
+
+    expect(
+      screen.queryByRole('heading', {name: 'Try Sentry Business for Free'})
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the business-trial banner when profileDuration budget is unavailable', () => {
+    const organization = OrganizationFixture();
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am3_t_ent',
+      planTier: PlanTier.AM3,
+    });
+    // Default planCategories.profileDuration.events is 0 for am3_t_ent, so
+    // reserved/prepaid are already 0. SubscriptionFixture defaults set
+    // onDemandMaxSpend=0 and canTrial=true, so BusinessTrialBanner should
+    // render.
+    SubscriptionStore.set(organization.slug, subscription);
+
+    const project = ProjectFixture({platform: 'python'});
+    render(<ContinuousProfilingBillingRequirementBanner project={project} />, {
+      organization,
+    });
+
+    expect(
+      screen.getByRole('heading', {name: 'Try Sentry Business for Free'})
+    ).toBeInTheDocument();
+  });
+
+  it('renders null when budget is exceeded (EXCEEDED path)', () => {
+    const organization = OrganizationFixture();
+    const subscription = SubscriptionFixture({
+      organization,
+      plan: 'am3_t_ent',
+      planTier: PlanTier.AM3,
+    });
+    subscription.categories.profileDuration = MetricHistoryFixture({
+      category: DataCategory.PROFILE_DURATION,
+      reserved: 1_000_000,
+      prepaid: 1_000_000,
+      usageExceeded: true,
+    });
+    SubscriptionStore.set(organization.slug, subscription);
+
+    const project = ProjectFixture({platform: 'python'});
+    render(<ContinuousProfilingBillingRequirementBanner project={project} />, {
+      organization,
+    });
+
+    expect(
+      screen.queryByRole('heading', {name: 'Try Sentry Business for Free'})
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', {name: /On-Demand/i})).not.toBeInTheDocument();
+  });
+});

--- a/static/gsApp/utils/profiling.spec.ts
+++ b/static/gsApp/utils/profiling.spec.ts
@@ -1,0 +1,165 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {MetricHistoryFixture} from 'getsentry-test/fixtures/metricHistory';
+import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+
+import {DataCategory} from 'sentry/types/core';
+
+import {UNLIMITED_RESERVED} from 'getsentry/constants';
+import type {Subscription} from 'getsentry/types';
+import {PlanTier} from 'getsentry/types';
+import {BudgetUsage, checkBudgetUsageFor} from 'getsentry/utils/profiling';
+
+describe('checkBudgetUsageFor', () => {
+  const organization = OrganizationFixture();
+  let subscription: Subscription;
+
+  beforeEach(() => {
+    subscription = SubscriptionFixture({
+      organization,
+      plan: 'am3_t_ent',
+      planTier: PlanTier.AM3,
+    });
+    subscription.onDemandMaxSpend = 0;
+  });
+
+  it('returns UNKNOWN when the category is missing from subscription.categories', () => {
+    delete subscription.categories.profileDuration;
+    expect(checkBudgetUsageFor(subscription, DataCategory.PROFILE_DURATION)).toBe(
+      BudgetUsage.UNKNOWN
+    );
+  });
+
+  it('returns AVAILABLE when reserved > 0 and not exceeded', () => {
+    subscription.categories.profileDuration = MetricHistoryFixture({
+      category: DataCategory.PROFILE_DURATION,
+      reserved: 1000,
+      prepaid: 1000,
+    });
+    expect(checkBudgetUsageFor(subscription, DataCategory.PROFILE_DURATION)).toBe(
+      BudgetUsage.AVAILABLE
+    );
+  });
+
+  it('returns AVAILABLE when reserved === UNLIMITED_RESERVED', () => {
+    subscription.categories.profileDuration = MetricHistoryFixture({
+      category: DataCategory.PROFILE_DURATION,
+      reserved: UNLIMITED_RESERVED,
+      prepaid: UNLIMITED_RESERVED,
+      free: 0,
+      onDemandBudget: 0,
+      onDemandQuantity: 0,
+    });
+    expect(checkBudgetUsageFor(subscription, DataCategory.PROFILE_DURATION)).toBe(
+      BudgetUsage.AVAILABLE
+    );
+  });
+
+  it('returns EXCEEDED when reserved > 0 and usageExceeded=true', () => {
+    subscription.categories.profileDuration = MetricHistoryFixture({
+      category: DataCategory.PROFILE_DURATION,
+      reserved: 1000,
+      prepaid: 1000,
+      usageExceeded: true,
+    });
+    expect(checkBudgetUsageFor(subscription, DataCategory.PROFILE_DURATION)).toBe(
+      BudgetUsage.EXCEEDED
+    );
+  });
+
+  it('returns EXCEEDED when reserved === UNLIMITED_RESERVED and usageExceeded=true', () => {
+    subscription.categories.profileDuration = MetricHistoryFixture({
+      category: DataCategory.PROFILE_DURATION,
+      reserved: UNLIMITED_RESERVED,
+      prepaid: UNLIMITED_RESERVED,
+      usageExceeded: true,
+    });
+    expect(checkBudgetUsageFor(subscription, DataCategory.PROFILE_DURATION)).toBe(
+      BudgetUsage.EXCEEDED
+    );
+  });
+
+  it('returns AVAILABLE when reserved=0 but free > 0', () => {
+    subscription.categories.profileDuration = MetricHistoryFixture({
+      category: DataCategory.PROFILE_DURATION,
+      reserved: 0,
+      prepaid: 0,
+      free: 500,
+    });
+    expect(checkBudgetUsageFor(subscription, DataCategory.PROFILE_DURATION)).toBe(
+      BudgetUsage.AVAILABLE
+    );
+  });
+
+  it('returns AVAILABLE when reserved=0 but onDemandBudget > 0', () => {
+    subscription.categories.profileDuration = MetricHistoryFixture({
+      category: DataCategory.PROFILE_DURATION,
+      reserved: 0,
+      prepaid: 0,
+      onDemandBudget: 1000,
+    });
+    expect(checkBudgetUsageFor(subscription, DataCategory.PROFILE_DURATION)).toBe(
+      BudgetUsage.AVAILABLE
+    );
+  });
+
+  it('returns AVAILABLE when reserved=0 but onDemandQuantity > 0', () => {
+    subscription.categories.profileDuration = MetricHistoryFixture({
+      category: DataCategory.PROFILE_DURATION,
+      reserved: 0,
+      prepaid: 0,
+      onDemandQuantity: 100,
+    });
+    expect(checkBudgetUsageFor(subscription, DataCategory.PROFILE_DURATION)).toBe(
+      BudgetUsage.AVAILABLE
+    );
+  });
+
+  it('returns AVAILABLE when category has no quota but subscription.onDemandMaxSpend > 0', () => {
+    subscription.categories.profileDuration = MetricHistoryFixture({
+      category: DataCategory.PROFILE_DURATION,
+      reserved: 0,
+      prepaid: 0,
+    });
+    subscription.onDemandMaxSpend = 5000;
+    expect(checkBudgetUsageFor(subscription, DataCategory.PROFILE_DURATION)).toBe(
+      BudgetUsage.AVAILABLE
+    );
+  });
+
+  it('returns EXCEEDED when category has no quota, onDemandMaxSpend > 0, and usageExceeded', () => {
+    subscription.categories.profileDuration = MetricHistoryFixture({
+      category: DataCategory.PROFILE_DURATION,
+      reserved: 0,
+      prepaid: 0,
+      usageExceeded: true,
+    });
+    subscription.onDemandMaxSpend = 5000;
+    expect(checkBudgetUsageFor(subscription, DataCategory.PROFILE_DURATION)).toBe(
+      BudgetUsage.EXCEEDED
+    );
+  });
+
+  it('returns UNAVAILABLE when reserved=0 and no free/onDemandBudget/onDemandQuantity and no onDemandMaxSpend', () => {
+    subscription.categories.profileDuration = MetricHistoryFixture({
+      category: DataCategory.PROFILE_DURATION,
+      reserved: 0,
+      prepaid: 0,
+    });
+    expect(checkBudgetUsageFor(subscription, DataCategory.PROFILE_DURATION)).toBe(
+      BudgetUsage.UNAVAILABLE
+    );
+  });
+
+  it.each([DataCategory.PROFILE_DURATION, DataCategory.PROFILE_DURATION_UI] as const)(
+    'returns AVAILABLE for UNLIMITED_RESERVED on %s',
+    dataCategory => {
+      subscription.categories[dataCategory] = MetricHistoryFixture({
+        category: dataCategory,
+        reserved: UNLIMITED_RESERVED,
+        prepaid: UNLIMITED_RESERVED,
+      });
+      expect(checkBudgetUsageFor(subscription, dataCategory)).toBe(BudgetUsage.AVAILABLE);
+    }
+  );
+});

--- a/static/gsApp/utils/profiling.ts
+++ b/static/gsApp/utils/profiling.ts
@@ -19,7 +19,7 @@ export function checkBudgetUsageFor(
   }
 
   if (
-    (category.reserved && category.reserved > 0) ||
+    (category.reserved ?? 0) !== 0 ||
     (category.free && category.free > 0) ||
     (category.onDemandBudget && category.onDemandBudget > 0) ||
     (category.onDemandQuantity && category.onDemandQuantity > 0)


### PR DESCRIPTION
Customers with unlimited profile-duration quota (`am3_t_ent` trials, and any enterprise org promoted to unlimited by `correct_enterprise_reserved()`) see a misleading "profiling unavailable" banner on the profiling onboarding page, even though their quota is unlimited.

## The bug

`checkBudgetUsageFor` in `static/gsApp/utils/profiling.ts` decides whether a category has active quota. The first clause guards on `reserved > 0`:

```ts
if (
  (category.reserved && category.reserved > 0) ||  // -1 fails this
  (category.free && category.free > 0) ||
  (category.onDemandBudget && category.onDemandBudget > 0) ||
  (category.onDemandQuantity && category.onDemandQuantity > 0)
) { ... }
```

For `UNLIMITED_RESERVED = -1`, `-1 > 0` is `false`. Sales-led enterprise orgs typically have everything else at `0` and `onDemandMaxSpend = 0`, so the function falls through and returns `BudgetUsage.UNAVAILABLE`. `ContinuousProfilingBillingRequirementBanner` then renders the upsell — the opposite of the truth.

## The fix

```diff
-  (category.reserved && category.reserved > 0) ||
+  (category.reserved ?? 0) !== 0 ||
```

Same `(… ?? 0) !== 0` pattern PR #113142 landed in two sibling files. All three "does this category count as having active quota?" checks now agree on the `UNLIMITED_RESERVED` sentinel:

| File | Function | Source |
|------|----------|--------|
| `static/gsApp/utils/billing.tsx:1044` | `productIsEnabled` | #113142 |
| `static/gsApp/views/subscriptionPage/usageOverview/index.tsx:64` | URL-query product selection | #113142 |
| `static/gsApp/utils/profiling.ts:22` | `checkBudgetUsageFor` | this PR |

## Who is affected

- `am3_t_ent` (Enterprise Trial) and `am3_t` (Basic Trial) populations — both plans set `profile_duration.reserved_tiers` to unlimited for the trial tier.
- Paying enterprise orgs that `correct_enterprise_reserved()` (`getsentry/billing/plans/__init__.py:103`) promotes to unlimited reserved — the same cohort that motivated #113142 on `am3_business_ent_auf`.

## Tests

- `static/gsApp/utils/profiling.spec.ts` covers every branch of `checkBudgetUsageFor`, with explicit `UNLIMITED_RESERVED` cases on both `PROFILE_DURATION` and `PROFILE_DURATION_UI`.
- `static/gsApp/components/profiling/alerts.spec.tsx` pins the user-visible behavior of `ContinuousProfilingBillingRequirementBanner`, including the regression: an unlimited-reserved org does not see the banner.

## Out of scope

A second finding from the same audit (`usagePercentage` in `views/subscriptionPage/usageHistory.tsx` reporting `>100%` for historical unlimited `prepaid`) lives in a different file and rendering path. Splitting it into a separate PR keeps this change focused on `checkBudgetUsageFor`.

Refs #113142