### PR TITLE
fix(claude-code): convert workspace option to default-checkbox

### DIFF
--- a/src/sentry/integrations/claude_code/integration.py
+++ b/src/sentry/integrations/claude_code/integration.py
@@ -259,16 +259,15 @@ class ClaudeCodeAgentIntegration(CodingAgentIntegration):
                 "choices": choices,
             },
             {
-                "name": "workspace_name",
-                "type": "text",
-                "label": _("Workspace Name"),
+                "name": "workspace_is_default",
+                "type": "boolean",
+                "label": _("I am using the default workspace"),
                 "help": _(
-                    "Your Anthropic workspace name (from platform.claude.com URL), used to link to session details. "
-                    "Defaults to 'default' — override this if your workspace has a different name."
+                    "Check this if your Anthropic workspace is named 'default'. "
+                    "When checked, an 'Open in Claude' link to the session is shown. "
+                    "Uncheck if you use a custom workspace name — the link will be hidden."
                 ),
                 "required": False,
-                "placeholder": "default",
-                "formatMessageValue": False,
             },
         ]
 
@@ -282,8 +281,8 @@ class ClaudeCodeAgentIntegration(CodingAgentIntegration):
         if "environment_id" in data:
             metadata.environment_id = data["environment_id"] or None
 
-        if "workspace_name" in data:
-            metadata.workspace_name = data["workspace_name"] or None
+        if "workspace_is_default" in data:
+            metadata.workspace_name = "default" if data["workspace_is_default"] else None
 
         self._persist_metadata(metadata)
         super().update_organization_config({})
@@ -292,7 +291,7 @@ class ClaudeCodeAgentIntegration(CodingAgentIntegration):
         metadata = self._get_metadata()
         return {
             "environment_id": metadata.environment_id or "",
-            "workspace_name": metadata.workspace_name or "",
+            "workspace_is_default": metadata.workspace_name == "default",
         }
 
     def get_client(self) -> Any:

--- a/tests/sentry/integrations/claude_code/test_integration.py
+++ b/tests/sentry/integrations/claude_code/test_integration.py
@@ -308,36 +308,53 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
 
         assert installation.model.metadata["environment_id"] is None
 
-    def test_update_organization_config_sets_workspace_name(self) -> None:
-        installation = self._create_installation()
-        installation.update_organization_config({"workspace_name": "my-workspace"})
+    def test_update_organization_config_workspace_is_default_true(self) -> None:
+        installation = self._create_installation(workspace_name=None)
+        installation.update_organization_config({"workspace_is_default": True})
 
-        assert installation.model.metadata["workspace_name"] == "my-workspace"
+        assert installation.model.metadata["workspace_name"] == "default"
 
-    def test_update_organization_config_clears_workspace_name(self) -> None:
-        installation = self._create_installation(workspace_name="old-ws")
-        installation.update_organization_config({"workspace_name": ""})
+    def test_update_organization_config_workspace_is_default_false(self) -> None:
+        installation = self._create_installation(workspace_name="default")
+        installation.update_organization_config({"workspace_is_default": False})
 
         assert installation.model.metadata["workspace_name"] is None
 
     # ── get_config_data ──────────────────────────────────────────────
 
-    def test_get_config_data(self) -> None:
+    def test_get_config_data_workspace_is_default_true_when_default(self) -> None:
         installation = self._create_installation(
             environment_id="env-cfg",
-            workspace_name="ws-cfg",
+            workspace_name="default",
         )
         data = installation.get_config_data()
 
         assert data["environment_id"] == "env-cfg"
-        assert data["workspace_name"] == "ws-cfg"
+        assert data["workspace_is_default"] is True
 
-    def test_get_config_data_defaults_to_empty_strings_except_workspace(self) -> None:
-        installation = self._create_installation()
+    def test_get_config_data_workspace_is_default_false_when_custom(self) -> None:
+        installation = self._create_installation(workspace_name="my-custom-ws")
         data = installation.get_config_data()
 
-        assert data["environment_id"] == ""
-        assert data["workspace_name"] == "default"
+        assert data["workspace_is_default"] is False
+
+    def test_get_config_data_workspace_is_default_false_when_none(self) -> None:
+        installation = self._create_installation(workspace_name=None)
+        data = installation.get_config_data()
+
+        assert data["workspace_is_default"] is False
+
+    def test_get_organization_config_workspace_is_boolean_field(self) -> None:
+        installation = self._create_installation()
+        mock_cls, mock_client = _mock_client_class()
+        mock_client.list_environments.return_value = []
+
+        with patch(MOCK_GET_CLIENT_CLASS, return_value=mock_cls):
+            fields = {f["name"]: f for f in installation.get_organization_config()}
+
+        assert "workspace_is_default" in fields
+        assert fields["workspace_is_default"]["type"] == "boolean"
+        assert "workspace_name" not in fields
 
     # ── launch ───────────────────────────────────────────────────────
 


### PR DESCRIPTION
Replace the free-text "Workspace Name" field with a boolean "I am using the default workspace" checkbox. Checked stores workspace_name="default" (the common case); unchecked stores None so client.get_session_link returns None and the "Open in Claude" link is hidden in the Seer drawer.

Existing installs with workspace_name=="default" appear checked; installs with a custom workspace_name appear unchecked and will be cleared on next save (no migration needed).

This change is because Anthropic is not using workspace name in the url like with default and instead is using a workspace id which they don't expose anywhere. Luckily an overwhelming majority of users use the default workspace so this shouldn't affect most people.