### PR TITLE
fix(seer): surface coding agent launch errors inline in drawer

### DIFF
--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -54,6 +54,7 @@ from sentry.seer.autofix.utils import (
     CodingAgentState,
     CodingAgentStatus,
     StoreCodingAgentStatesRequest,
+    extract_api_error_message,
     get_autofix_state,
     get_coding_agent_prompt,
     get_project_seer_preferences,
@@ -393,7 +394,10 @@ def _launch_agents_for_repos(
                 if status_code == 401:
                     error_message = "Authentication failed. Please check that your API credentials are correct and have access to the required API endpoints."
                 else:
-                    error_message = f"Failed to launch coding agent: {status_code} Error: {e}"
+                    error_message = (
+                        extract_api_error_message(e.response)
+                        or f"Failed to launch coding agent ({status_code})"
+                    )
 
             failure: dict = {
                 "repo_name": repo_name,

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -70,6 +70,28 @@ class AutofixStoppingPoint(StrEnum):
     OPEN_PR = "open_pr"
 
 
+def extract_api_error_message(response: Any) -> str | None:
+    # Anthropic returns {"error": {"type": "...", "message": "..."}}; others
+    # (OpenAI, GitHub, Stripe) use one of "error.message" or top-level "message".
+    if response is None:
+        return None
+    try:
+        body = response.json()
+    except (ValueError, AttributeError):
+        return None
+    if not isinstance(body, dict):
+        return None
+    error = body.get("error")
+    if isinstance(error, dict):
+        message = error.get("message")
+        if isinstance(message, str) and message:
+            return message
+    message = body.get("message")
+    if isinstance(message, str) and message:
+        return message
+    return None
+
+
 def get_valid_automated_run_stopping_points(
     organization: Organization,
 ) -> set[AutofixStoppingPoint]:

--- a/src/sentry/seer/explorer/coding_agent_handoff.py
+++ b/src/sentry/seer/explorer/coding_agent_handoff.py
@@ -27,7 +27,7 @@ from sentry.seer.autofix.coding_agent import (
     sanitize_branch_name,
     store_coding_agent_states_to_seer,
 )
-from sentry.seer.autofix.utils import CodingAgentState
+from sentry.seer.autofix.utils import CodingAgentState, extract_api_error_message
 from sentry.seer.models import SeerApiError, SeerRepoDefinition
 from sentry.shared_integrations.exceptions import ApiError
 
@@ -141,7 +141,11 @@ def launch_coding_agents(
             failure_type = "generic"
             error_message = "Failed to launch coding agent"
             github_installation_id: str | None = None
-            if isinstance(e, ApiError):
+            if isinstance(e, HTTPError) and e.response is not None:
+                api_message = extract_api_error_message(e.response)
+                if api_message:
+                    error_message = api_message
+            elif isinstance(e, ApiError):
                 if e.code == 403 and is_github_copilot:
                     if e.text and "not licensed" in e.text.lower():
                         failure_type = "github_copilot_not_licensed"

--- a/static/app/components/events/autofix/useExplorerAutofix.spec.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.spec.tsx
@@ -463,3 +463,100 @@ describe('useExplorerAutofix - createPR', () => {
     });
   });
 });
+
+describe('useExplorerAutofix - codingAgentErrors', () => {
+  const GROUP_ID = '123';
+  const AUTOFIX_URL = `/organizations/org-slug/issues/${GROUP_ID}/autofix/`;
+  const integration = {id: '42', name: 'Claude Agent', provider: 'claude_code'};
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: AUTOFIX_URL,
+      method: 'GET',
+      body: {autofix: null},
+    });
+  });
+
+  it('accumulates generic failures across multiple launch attempts', async () => {
+    MockApiClient.addMockResponse({
+      url: AUTOFIX_URL,
+      method: 'POST',
+      body: {
+        successes: [],
+        failures: [{error_message: 'first error', repo_name: 'org/repo'}],
+      },
+    });
+
+    const {result} = renderHookWithProviders(() => useExplorerAutofix(GROUP_ID));
+
+    await act(() => result.current.triggerCodingAgentHandoff(1, integration));
+    await waitFor(() => {
+      expect(result.current.codingAgentErrors).toEqual(['first error']);
+    });
+
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: AUTOFIX_URL,
+      method: 'GET',
+      body: {autofix: null},
+    });
+    MockApiClient.addMockResponse({
+      url: AUTOFIX_URL,
+      method: 'POST',
+      body: {
+        successes: [],
+        failures: [{error_message: 'second error', repo_name: 'org/repo'}],
+      },
+    });
+
+    await act(() => result.current.triggerCodingAgentHandoff(1, integration));
+    await waitFor(() => {
+      expect(result.current.codingAgentErrors).toEqual(['first error', 'second error']);
+    });
+  });
+
+  it('appends API-level errors (rejected request) to the list', async () => {
+    MockApiClient.addMockResponse({
+      url: AUTOFIX_URL,
+      method: 'POST',
+      statusCode: 500,
+      body: {detail: 'boom'},
+    });
+
+    const {result} = renderHookWithProviders(() => useExplorerAutofix(GROUP_ID));
+
+    await expect(
+      act(() => result.current.triggerCodingAgentHandoff(1, integration))
+    ).rejects.toBeDefined();
+
+    await waitFor(() => {
+      expect(result.current.codingAgentErrors).toEqual(['boom']);
+    });
+  });
+
+  it('dismissCodingAgentError removes the error at the given index', async () => {
+    MockApiClient.addMockResponse({
+      url: AUTOFIX_URL,
+      method: 'POST',
+      body: {
+        successes: [],
+        failures: [
+          {error_message: 'a', repo_name: 'org/repo'},
+          {error_message: 'b', repo_name: 'org/repo'},
+          {error_message: 'c', repo_name: 'org/repo'},
+        ],
+      },
+    });
+
+    const {result} = renderHookWithProviders(() => useExplorerAutofix(GROUP_ID));
+
+    await act(() => result.current.triggerCodingAgentHandoff(1, integration));
+    await waitFor(() => {
+      expect(result.current.codingAgentErrors).toEqual(['a', 'b', 'c']);
+    });
+
+    act(() => result.current.dismissCodingAgentError(1));
+    expect(result.current.codingAgentErrors).toEqual(['a', 'c']);
+  });
+});

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -521,6 +521,8 @@ export function useExplorerAutofix(
    */
   const [waitingForCodingAgent, setWaitingForCodingAgent] = useState(false);
 
+  const [codingAgentErrors, setCodingAgentErrors] = useState<string[]>([]);
+
   const {data: apiData, isPending} = useApiQuery<ExplorerAutofixResponse>(
     makeExplorerAutofixQueryKey(orgSlug, groupId),
     {
@@ -731,9 +733,14 @@ export function useExplorerAutofix(
             openModal(deps => <AutofixCursorGithubAccessModal {...deps} />);
           }
 
-          otherFailures.forEach(failure => {
-            addErrorMessage(failure.error_message ?? 'Failed to launch coding agent');
-          });
+          if (otherFailures.length > 0) {
+            setCodingAgentErrors(prev => [
+              ...prev,
+              ...otherFailures.map(
+                f => f.error_message ?? 'Failed to launch coding agent'
+              ),
+            ]);
+          }
         }
 
         // Invalidate to fetch fresh data
@@ -746,7 +753,10 @@ export function useExplorerAutofix(
           window.location.href = `/remote/github-copilot/oauth/?next=${encodeURIComponent(currentUrl)}`;
           return;
         }
-        addErrorMessage(e?.responseJSON?.detail ?? 'Failed to launch coding agent');
+        setCodingAgentErrors(prev => [
+          ...prev,
+          e?.responseJSON?.detail ?? 'Failed to launch coding agent',
+        ]);
         throw e;
       } finally {
         setWaitingForCodingAgent(false);
@@ -793,6 +803,16 @@ export function useExplorerAutofix(
      * Trigger coding agent handoff for an existing run.
      */
     triggerCodingAgentHandoff,
+    /**
+     * Errors from coding agent launch attempts, accumulated across launches and
+     * persisted for the lifetime of the hook mount. Displayed inline in the panel.
+     */
+    codingAgentErrors,
+    /**
+     * Dismiss a single coding agent error by its index in `codingAgentErrors`.
+     */
+    dismissCodingAgentError: (index: number) =>
+      setCodingAgentErrors(prev => prev.filter((_, i) => i !== index)),
   };
 }
 

--- a/static/app/components/events/autofix/v3/content.tsx
+++ b/static/app/components/events/autofix/v3/content.tsx
@@ -1,5 +1,7 @@
 import {Fragment, useMemo} from 'react';
 
+import {Alert} from '@sentry/scraps/alert';
+import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 
 import {
@@ -21,6 +23,8 @@ import {
 } from 'sentry/components/events/autofix/v3/autofixCards';
 import {SeerDrawerNextStep} from 'sentry/components/events/autofix/v3/nextStep';
 import {Placeholder} from 'sentry/components/placeholder';
+import {IconClose} from 'sentry/icons';
+import {t} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
 import type {useAiConfig} from 'sentry/views/issueDetails/streamline/hooks/useAiConfig';
 
@@ -59,6 +63,23 @@ export function SeerDrawerContent({aiConfig, autofix, group}: SeerDrawerContentP
       {autofix.runState?.status === 'completed' && (
         <SeerDrawerNextStep group={group} autofix={autofix} sections={sections} />
       )}
+      {autofix.codingAgentErrors.map((error, i) => (
+        <Alert
+          key={i}
+          variant="danger"
+          trailingItems={
+            <Button
+              size="zero"
+              priority="transparent"
+              icon={<IconClose size="sm" />}
+              aria-label={t('Dismiss error')}
+              onClick={() => autofix.dismissCodingAgentError(i)}
+            />
+          }
+        >
+          {error}
+        </Alert>
+      ))}
     </Flex>
   );
 }


### PR DESCRIPTION
Previously, failures during coding agent launch appeared as global toast notifications. Move them into the Seer drawer as dismissable alerts at the bottom of the panel, accumulated across launch attempts for the lifetime of the mount. Also extract the clean message from HTTPError response bodies (e.g. Anthropic's {error: {message: ...}}) so users see the real API error instead of a generic status-code string.

example view: 
 
<img width="888" height="751" alt="Screenshot 2026-04-16 at 2 57 22 PM" src="https://github.com/user-attachments/assets/228218f7-ef4e-486b-9d78-364557d4da60" />
