### PR TITLE
fix(billing): Render unlimited reserved as ∞ in usage history

### DIFF
--- a/static/gsApp/views/subscriptionPage/usageHistory.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageHistory.spec.tsx
@@ -8,7 +8,7 @@ import {
   Am3DsEnterpriseSubscriptionFixture,
   SubscriptionFixture,
 } from 'getsentry-test/fixtures/subscription';
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
 
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {DataCategory} from 'sentry/types/core';
@@ -191,8 +191,6 @@ describe('Subscription > UsageHistory', () => {
               prepaid: 1,
             }),
           },
-          reserved: {errors: UNLIMITED_RESERVED, transactions: 1000, attachments: 1},
-          usage: {errors: 12345, transactions: 0, attachments: 0},
         }),
       ],
     });
@@ -206,8 +204,8 @@ describe('Subscription > UsageHistory', () => {
 
     render(<UsageHistory />, {organization});
 
-    // Errors row renders ∞ in both the Reserved and Used (%) cells.
-    expect(await screen.findAllByRole('cell', {name: UNLIMITED})).toHaveLength(2);
+    const errorsRow = await screen.findByRole('row', {name: /^Errors/});
+    expect(within(errorsRow).getAllByRole('cell', {name: UNLIMITED})).toHaveLength(2);
     expect(screen.queryByText('>100%')).not.toBeInTheDocument();
   });
 
@@ -234,8 +232,6 @@ describe('Subscription > UsageHistory', () => {
               prepaid: 1,
             }),
           },
-          reserved: {errors: 1000, transactions: 1000, attachments: 1},
-          usage: {errors: 9999, transactions: 0, attachments: 0},
         }),
       ],
     });
@@ -249,8 +245,8 @@ describe('Subscription > UsageHistory', () => {
 
     render(<UsageHistory />, {organization});
 
-    // Only the Used (%) cell for Errors renders ∞ — Reserved renders the positive number.
-    expect(await screen.findByRole('cell', {name: UNLIMITED})).toBeInTheDocument();
+    const errorsRow = await screen.findByRole('row', {name: /^Errors/});
+    expect(within(errorsRow).getByRole('cell', {name: UNLIMITED})).toBeInTheDocument();
     expect(screen.queryByText('>100%')).not.toBeInTheDocument();
   });
 

--- a/static/gsApp/views/subscriptionPage/usageHistory.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/usageHistory.spec.tsx
@@ -23,7 +23,9 @@ import {
 } from 'getsentry/constants';
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
 import {OnDemandBudgetMode, PlanTier} from 'getsentry/types';
-import UsageHistory from 'getsentry/views/subscriptionPage/usageHistory';
+import UsageHistory, {
+  usagePercentage,
+} from 'getsentry/views/subscriptionPage/usageHistory';
 
 describe('Subscription > UsageHistory', () => {
   const organization = OrganizationFixture({access: ['org:billing']});
@@ -164,6 +166,92 @@ describe('Subscription > UsageHistory', () => {
 
     expect(screen.queryByText('On-Demand Spend')).not.toBeInTheDocument();
     expect(mockCall).toHaveBeenCalled();
+  });
+
+  it('renders ∞ when reserved and prepaid are UNLIMITED_RESERVED', async () => {
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/history/`,
+      method: 'GET',
+      body: [
+        BillingHistoryFixture({
+          categories: {
+            errors: MetricHistoryFixture({
+              usage: 12345,
+              reserved: UNLIMITED_RESERVED,
+              prepaid: UNLIMITED_RESERVED,
+            }),
+            transactions: MetricHistoryFixture({
+              category: DataCategory.TRANSACTIONS,
+              reserved: 1000,
+              prepaid: 1000,
+            }),
+            attachments: MetricHistoryFixture({
+              category: DataCategory.ATTACHMENTS,
+              reserved: 1,
+              prepaid: 1,
+            }),
+          },
+          reserved: {errors: UNLIMITED_RESERVED, transactions: 1000, attachments: 1},
+          usage: {errors: 12345, transactions: 0, attachments: 0},
+        }),
+      ],
+    });
+
+    const subscription = SubscriptionFixture({
+      plan: 'am1_f',
+      planTier: PlanTier.AM1,
+      organization,
+    });
+    SubscriptionStore.set(organization.slug, subscription);
+
+    render(<UsageHistory />, {organization});
+
+    // Errors row renders ∞ in both the Reserved and Used (%) cells.
+    expect(await screen.findAllByRole('cell', {name: UNLIMITED})).toHaveLength(2);
+    expect(screen.queryByText('>100%')).not.toBeInTheDocument();
+  });
+
+  it('renders ∞ when prepaid is UNLIMITED_RESERVED but reserved is positive', async () => {
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/history/`,
+      method: 'GET',
+      body: [
+        BillingHistoryFixture({
+          categories: {
+            errors: MetricHistoryFixture({
+              usage: 9999,
+              reserved: 1000,
+              prepaid: UNLIMITED_RESERVED,
+            }),
+            transactions: MetricHistoryFixture({
+              category: DataCategory.TRANSACTIONS,
+              reserved: 1000,
+              prepaid: 1000,
+            }),
+            attachments: MetricHistoryFixture({
+              category: DataCategory.ATTACHMENTS,
+              reserved: 1,
+              prepaid: 1,
+            }),
+          },
+          reserved: {errors: 1000, transactions: 1000, attachments: 1},
+          usage: {errors: 9999, transactions: 0, attachments: 0},
+        }),
+      ],
+    });
+
+    const subscription = SubscriptionFixture({
+      plan: 'am1_f',
+      planTier: PlanTier.AM1,
+      organization,
+    });
+    SubscriptionStore.set(organization.slug, subscription);
+
+    render(<UsageHistory />, {organization});
+
+    // Only the Used (%) cell for Errors renders ∞ — Reserved renders the positive number.
+    expect(await screen.findByRole('cell', {name: UNLIMITED})).toBeInTheDocument();
+    expect(screen.queryByText('>100%')).not.toBeInTheDocument();
   });
 
   it('overage is shown as >100%', async () => {
@@ -911,5 +999,38 @@ describe('Subscription > UsageHistory', () => {
     // Should show >100% when usage exceeds prepaid limit
     expect(await screen.findByText(/UI Profile Hours/i)).toBeInTheDocument();
     expect(await screen.findByText('>100%')).toBeInTheDocument();
+  });
+});
+
+describe('usagePercentage', () => {
+  it('returns 0% when prepaid is null', () => {
+    expect(usagePercentage(0, null)).toBe('0%');
+    expect(usagePercentage(100, null)).toBe('0%');
+  });
+
+  it('returns 0% when prepaid is 0', () => {
+    expect(usagePercentage(0, 0)).toBe('0%');
+    expect(usagePercentage(50, 0)).toBe('0%');
+  });
+
+  it('returns UNLIMITED when prepaid equals UNLIMITED_RESERVED', () => {
+    expect(usagePercentage(0, UNLIMITED_RESERVED)).toBe(UNLIMITED);
+    expect(usagePercentage(1_000_000, UNLIMITED_RESERVED)).toBe(UNLIMITED);
+  });
+
+  it('returns >100% when usage exceeds prepaid', () => {
+    expect(usagePercentage(1001, 1000)).toBe('>100%');
+  });
+
+  it('returns formatted percentage when usage is below prepaid', () => {
+    expect(usagePercentage(500, 1000)).toBe('50%');
+  });
+
+  it('returns 0% when usage is 0 and prepaid is positive', () => {
+    expect(usagePercentage(0, 1000)).toBe('0%');
+  });
+
+  it('returns 100% when usage equals prepaid', () => {
+    expect(usagePercentage(1000, 1000)).toBe('100%');
   });
 });

--- a/static/gsApp/views/subscriptionPage/usageHistory.tsx
+++ b/static/gsApp/views/subscriptionPage/usageHistory.tsx
@@ -40,6 +40,7 @@ import {
   formatReservedWithUnits,
   formatUsageWithUnits,
   getSoftCapType,
+  isUnlimitedReserved,
 } from 'getsentry/utils/billing';
 import {getPlanCategoryName, sortCategories} from 'getsentry/utils/dataCategory';
 import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
@@ -53,7 +54,10 @@ interface Props {
   subscription: Subscription;
 }
 
-function usagePercentage(usage: number, prepaid: number | null): string {
+export function usagePercentage(usage: number, prepaid: number | null): string {
+  if (isUnlimitedReserved(prepaid)) {
+    return UNLIMITED;
+  }
   if (prepaid === null || prepaid === 0) {
     return t('0%');
   }
@@ -345,13 +349,15 @@ function UsageHistoryRow({history}: RowProps) {
                     <td>
                       {metricHistory.reserved === RESERVED_BUDGET_QUOTA
                         ? 'N/A'
-                        : usagePercentage(
-                            convertUsageToReservedUnit(
-                              metricHistory.usage,
-                              metricHistory.category
-                            ),
-                            metricHistory.prepaid
-                          )}
+                        : isUnlimitedReserved(metricHistory.reserved)
+                          ? UNLIMITED
+                          : usagePercentage(
+                              convertUsageToReservedUnit(
+                                metricHistory.usage,
+                                metricHistory.category
+                              ),
+                              metricHistory.prepaid
+                            )}
                     </td>
                   </tr>
                 ))}


### PR DESCRIPTION
Billing admins reviewing past periods in the usage history table see `>100%` in the "Used (%)" column for any category that had unlimited reserved quota — exactly the row in the UI designed to surface overages.

## The bug

`usageHistory.tsx` renders the per-category "Used (%)" cell with a nested ternary that special-cases `RESERVED_BUDGET_QUOTA` (-2) but not `UNLIMITED_RESERVED` (-1):

```tsx
<td>
  {metricHistory.reserved === RESERVED_BUDGET_QUOTA
    ? 'N/A'
    : usagePercentage(
        convertUsageToReservedUnit(metricHistory.usage, metricHistory.category),
        metricHistory.prepaid
      )}
</td>
```

Inside `usagePercentage`:

```ts
function usagePercentage(usage: number, prepaid: number | null): string {
  if (prepaid === null || prepaid === 0) { return t('0%'); }
  if (usage > prepaid) { return '>100%'; }   // usage > -1 is always true
  return formatPercentage(usage / prepaid, 0);
}
```

For `prepaid = UNLIMITED_RESERVED = -1`, `usage > -1` is always true for any non-negative usage, so the function returns `'>100%'`. Opposite of the truth.

## The fix

Both layers, defense in depth:

**1. Helper (`usagePercentage`)** — early-return the `UNLIMITED` (∞) constant for unlimited prepaid, and export the helper so the unit-test layer can pin the contract:

```diff
-function usagePercentage(usage: number, prepaid: number | null): string {
+export function usagePercentage(usage: number, prepaid: number | null): string {
+  if (isUnlimitedReserved(prepaid)) {
+    return UNLIMITED;
+  }
   if (prepaid === null || prepaid === 0) {
     return t('0%');
   }
```

**2. Call site** — add a parallel `isUnlimitedReserved(reserved) → UNLIMITED` branch next to the existing `RESERVED_BUDGET_QUOTA → 'N/A'` guard:

```diff
 <td>
   {metricHistory.reserved === RESERVED_BUDGET_QUOTA
     ? 'N/A'
+    : isUnlimitedReserved(metricHistory.reserved)
+      ? UNLIMITED
     : usagePercentage(...)}
 </td>
```

**Why both layers**: the call-site guard reads the canonical `metricHistory.reserved` field and mirrors the neighboring `RESERVED_BUDGET_QUOTA` pattern. The helper guard protects against any caller — now or future — passing `prepaid = -1`, and enables pure unit tests of the helper contract.

## Who is affected

- Enterprise orgs promoted to unlimited via `correct_enterprise_reserved()` (`getsentry/billing/plans/__init__.py:103`) — the same cohort as #113142 and #113254.
- Historical `am3_t` / `am3_t_ent` trial periods. `create_metric_histories_from_updates` (`getsentry/models/billingmetrichistory.py:189`) preserves the `prepaid = UNLIMITED_RESERVED` state on monthly rotation, so these rows persist in the usage history table indefinitely.

## Tests

- `describe('usagePercentage', ...)` — 7 new pure-function unit tests of the exported helper (null, 0, unlimited, overage, under-quota, zero usage, exact match).
- Inside the existing component describe — two new render-level cases pin the regression: the fully-unlimited row (`reserved = prepaid = -1`) and the defense-in-depth divergent case (`reserved > 0, prepaid = -1`). The existing "overage is shown as >100%" test remains green, confirming non-unlimited rows still surface overages correctly.

## Relationship to #113142 / #113254

Third and final PR in a set addressing the `UNLIMITED_RESERVED = -1` sentinel:

| PR | Surface |
|----|---------|
| #113142 | `productIsEnabled` + usage-overview URL selector |
| #113254 | `checkBudgetUsageFor` + profiling billing banner |
| this PR | `usagePercentage` + usage history table |

All three now follow the same "treat `-1` as active/unlimited, not as a small negative number" convention.

Refs #113142
Refs #113254