### PR TITLE
ref(viewer-context): Switch observe helper to sentry_sdk.metrics.count

### DIFF
--- a/src/sentry/viewer_context.py
+++ b/src/sentry/viewer_context.py
@@ -13,9 +13,8 @@ from typing import TYPE_CHECKING, Any
 
 import jwt as pyjwt
 import orjson
+import sentry_sdk
 from django.conf import settings
-
-from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
 
@@ -140,9 +139,10 @@ def observe_viewer_context_propagation(
         has_user = ctx.user_id is not None
         has_org = ctx.organization_id is not None
 
-    metrics.incr(
+    sentry_sdk.metrics.count(
         "viewer_context.observation",
-        tags={
+        1,
+        attributes={
             "point": point,
             "actor_type": actor_type,
             "has_user_id": str(has_user).lower(),

--- a/tests/sentry/test_viewer_context.py
+++ b/tests/sentry/test_viewer_context.py
@@ -152,14 +152,14 @@ class TestViewerContextScope:
 class TestObserve:
     @pytest.fixture(autouse=True)
     def patch_metrics(self):
-        with mock.patch("sentry.viewer_context.metrics") as m:
+        with mock.patch("sentry.viewer_context.sentry_sdk.metrics.count") as m:
             yield m
 
     def _tags(self, m):
-        assert m.incr.call_count == 1
-        args, kwargs = m.incr.call_args
-        assert args == ("viewer_context.observation",)
-        return kwargs["tags"]
+        assert m.call_count == 1
+        args, kwargs = m.call_args
+        assert args == ("viewer_context.observation", 1)
+        return kwargs["attributes"]
 
     def test_no_context_tags_actor_none(self, patch_metrics):
         observe_viewer_context_propagation("seer_rpc_out")


### PR DESCRIPTION
The helper added in #113237 used `sentry.utils.metrics.incr`, which routes through `SENTRY_METRICS_BACKEND` (Datadog in production) and isn't visible in Sentry's product UI.

Swap to `sentry_sdk.metrics.count` (same pattern used in `src/sentry/tasks/seer/night_shift/agentic_triage.py:104`) so the `viewer_context.observation` series is queryable in Sentry's own Insights/Dashboards alongside the rest of the trace data.

- Same metric name (`viewer_context.observation`).
- Same tag schema, just `tags={...}` becomes `attributes={...}`.
- No double-emit: dropped the prior Datadog call. Nothing depended on it yet.
- Tests updated to mock `sentry_sdk.metrics.count`.
- Companion seer-side PR swaps `statsd.increment` for the same call.

Refs [RFC: Unified ViewerContext via ContextVar](https://www.notion.so/sentry/RFC-Unified-ViewerContext-via-ContextVar-32f8b10e4b5d81988625cb5787035e02)