### PR TITLE
fix(api): tighten published mutation scopes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -439,6 +439,7 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /static/app/components/analyticsArea.spec.tsx  @getsentry/app-frontend
 /static/app/components/analyticsArea.tsx       @getsentry/app-frontend
 /static/app/components/loading/                @getsentry/app-frontend
+/static/app/components/markdownTextArea.tsx    @getsentry/app-frontend
 /static/app/components/events/interfaces/      @getsentry/app-frontend
 /static/app/components/forms/                  @getsentry/app-frontend
 /static/app/components/featureShowcase.mdx     @getsentry/app-frontend

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -439,7 +439,6 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /static/app/components/analyticsArea.spec.tsx  @getsentry/app-frontend
 /static/app/components/analyticsArea.tsx       @getsentry/app-frontend
 /static/app/components/loading/                @getsentry/app-frontend
-/static/app/components/markdownTextArea.tsx    @getsentry/app-frontend
 /static/app/components/events/interfaces/      @getsentry/app-frontend
 /static/app/components/forms/                  @getsentry/app-frontend
 /static/app/components/featureShowcase.mdx     @getsentry/app-frontend

--- a/src/sentry/api/bases/incident.py
+++ b/src/sentry/api/bases/incident.py
@@ -24,6 +24,9 @@ class IncidentPermission(OrganizationPermission):
         "PUT": ["org:write", "org:admin", "project:read", "project:write", "project:admin"],
         "DELETE": ["org:write", "org:admin", "project:read", "project:write", "project:admin"],
     }
+    readonly_mutation_scope_exceptions = {
+        "PUT": "Incident updates still allow project-scoped members with access to the incident's projects.",
+    }
 
 
 class IncidentEndpoint(OrganizationEndpoint):

--- a/src/sentry/api/bases/incident.py
+++ b/src/sentry/api/bases/incident.py
@@ -20,9 +20,9 @@ class IncidentPermission(OrganizationPermission):
             "project:write",
             "project:admin",
         ],
-        "POST": ["org:write", "org:admin", "project:write", "project:admin"],
-        "PUT": ["org:write", "org:admin", "project:write", "project:admin"],
-        "DELETE": ["org:write", "org:admin", "project:write", "project:admin"],
+        "POST": ["org:write", "org:admin", "project:read", "project:write", "project:admin"],
+        "PUT": ["org:write", "org:admin", "project:read", "project:write", "project:admin"],
+        "DELETE": ["org:write", "org:admin", "project:read", "project:write", "project:admin"],
     }
 
 

--- a/src/sentry/api/bases/incident.py
+++ b/src/sentry/api/bases/incident.py
@@ -20,9 +20,9 @@ class IncidentPermission(OrganizationPermission):
             "project:write",
             "project:admin",
         ],
-        "POST": ["org:write", "org:admin", "project:read", "project:write", "project:admin"],
-        "PUT": ["org:write", "org:admin", "project:read", "project:write", "project:admin"],
-        "DELETE": ["org:write", "org:admin", "project:read", "project:write", "project:admin"],
+        "POST": ["org:write", "org:admin", "project:write", "project:admin"],
+        "PUT": ["org:write", "org:admin", "project:write", "project:admin"],
+        "DELETE": ["org:write", "org:admin", "project:write", "project:admin"],
     }
 
 

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -233,6 +233,15 @@ class OrganizationDataExportPermission(OrganizationPermission):
     }
 
 
+def get_organization_id(
+    organization: Organization | RpcOrganization | RpcUserOrganizationContext,
+) -> int:
+    if isinstance(organization, RpcUserOrganizationContext):
+        return organization.organization.id
+
+    return organization.id
+
+
 def _has_any_team_scope(request: Request, scope: str) -> bool:
     if not request.access.team_ids_with_membership:
         return False

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -163,12 +163,19 @@ class OrganizationIntegrationsLoosePermission(OrganizationPermission):
         "PUT": ["org:read", "org:write", "org:admin", "org:integrations"],
         "DELETE": ["org:admin", "org:integrations"],
     }
+    readonly_mutation_scope_exceptions = {
+        "POST": "Legacy integration setup helpers still allow org:read and enforce narrower checks in the view.",
+        "PUT": "Legacy integration edit helpers still allow org:read and enforce narrower checks in the view.",
+    }
 
 
 class OrganizationCodeMappingsBulkPermission(OrganizationPermission):
     scope_map = {
         "GET": ["org:read", "org:write", "org:admin", "org:integrations", "org:ci"],
         "POST": ["org:read", "org:write", "org:admin", "org:integrations", "org:ci"],
+    }
+    readonly_mutation_scope_exceptions = {
+        "POST": "Bulk code mapping suggestions remain available to org members with repository access.",
     }
 
 
@@ -199,6 +206,10 @@ class OrganizationPinnedSearchPermission(OrganizationPermission):
         "PUT": ["org:read", "org:write", "org:admin"],
         "DELETE": ["org:read", "org:write", "org:admin"],
     }
+    readonly_mutation_scope_exceptions = {
+        "PUT": "Pinned search changes only update the requesting member's personal pinned state.",
+        "DELETE": "Pinned search removal only updates the requesting member's personal pinned state.",
+    }
 
 
 class OrganizationSearchPermission(OrganizationPermission):
@@ -207,6 +218,11 @@ class OrganizationSearchPermission(OrganizationPermission):
         "POST": ["org:read", "org:write", "org:admin"],
         "PUT": ["org:read", "org:write", "org:admin"],
         "DELETE": ["org:read", "org:write", "org:admin"],
+    }
+    readonly_mutation_scope_exceptions = {
+        "POST": "Members may manage personal saved searches without org:write.",
+        "PUT": "Members may edit personal saved searches without org:write.",
+        "DELETE": "Members may delete personal saved searches without org:write.",
     }
 
 
@@ -225,7 +241,8 @@ def _has_any_team_scope(request: Request, scope: str) -> bool:
     return any(request.access.has_team_scope(team, scope) for team in teams)
 
 
-ALERT_MUTATION_SCOPES = frozenset({"org:write", "alerts:write"})
+# Project-scoped alert authoring should rely on the alert-specific write scope.
+ALERT_MUTATION_SCOPES = frozenset({"alerts:write"})
 
 
 def _has_project_alert_write_access(request: Request, projects: Sequence[Project]) -> bool:
@@ -250,13 +267,38 @@ def _has_view_project_scoped_alert_write(
     return _has_project_alert_write_access(request, projects)
 
 
+def get_legacy_alert_mutation_scopes(view: APIView, method: str | None) -> tuple[str, ...]:
+    if method is None:
+        return ()
+
+    legacy_scope_map = getattr(view, "legacy_alert_mutation_scope_map", None)
+    if legacy_scope_map is None:
+        return ()
+
+    scopes = legacy_scope_map.get(method, ())
+    return tuple(scopes)
+
+
 class OrganizationAlertRulePermission(OrganizationPermission):
     scope_map = {
         "GET": ["org:read", "org:write", "org:admin", "alerts:read"],
-        "POST": ["org:write", "org:admin", "alerts:write"],
-        "PUT": ["org:write", "org:admin", "alerts:write"],
-        "DELETE": ["org:write", "org:admin", "alerts:write"],
+        "POST": ["alerts:write"],
+        "PUT": ["alerts:write"],
+        "DELETE": ["alerts:write"],
     }
+
+    def has_permission(self, request: Request, view: APIView) -> bool:
+        if super().has_permission(request, view):
+            return True
+
+        if not request.auth:
+            return False
+
+        current_scopes = request.auth.get_scopes()
+        return any(
+            scope in current_scopes
+            for scope in get_legacy_alert_mutation_scopes(view, request.method)
+        )
 
     def has_object_permission(
         self,
@@ -270,6 +312,12 @@ class OrganizationAlertRulePermission(OrganizationPermission):
         if request.method not in {"POST", "PUT", "DELETE"}:
             return False
 
+        if any(
+            request.access.has_scope(scope)
+            for scope in get_legacy_alert_mutation_scopes(view, request.method)
+        ):
+            return True
+
         project_scoped_access = _has_view_project_scoped_alert_write(request, view, organization)
         if project_scoped_access is not None:
             return project_scoped_access
@@ -282,9 +330,9 @@ class OrganizationAlertRulePermission(OrganizationPermission):
 class OrganizationDetectorPermission(OrganizationPermission):
     scope_map = {
         "GET": ["org:read", "org:write", "org:admin", "alerts:read"],
-        "POST": ["org:write", "org:admin", "alerts:write"],
-        "PUT": ["org:write", "org:admin", "alerts:write"],
-        "DELETE": ["org:write", "org:admin", "alerts:write"],
+        "POST": ["alerts:write"],
+        "PUT": ["alerts:write"],
+        "DELETE": ["alerts:write"],
     }
 
     def has_object_permission(
@@ -315,6 +363,10 @@ class OrgAuthTokenPermission(OrganizationPermission):
         "PUT": ["org:read", "org:write", "org:admin"],
         "DELETE": ["org:write", "org:admin"],
     }
+    readonly_mutation_scope_exceptions = {
+        "POST": "Organization auth token creation is a legacy org:read mutation.",
+        "PUT": "Organization auth token updates are a legacy org:read mutation.",
+    }
 
 
 class OrganizationFlagWebHookSigningSecretPermission(OrganizationPermission):
@@ -322,6 +374,9 @@ class OrganizationFlagWebHookSigningSecretPermission(OrganizationPermission):
         "GET": ["org:read", "org:write", "org:admin"],
         "POST": ["org:read", "org:write", "org:admin"],
         "DELETE": ["org:write", "org:admin"],
+    }
+    readonly_mutation_scope_exceptions = {
+        "POST": "Webhook signing secret writes allow org:read but the view restricts updates to creators or org writers.",
     }
 
 

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -345,6 +345,19 @@ class OrganizationDetectorPermission(OrganizationPermission):
         "DELETE": ["alerts:write"],
     }
 
+    def has_permission(self, request: Request, view: APIView) -> bool:
+        if super().has_permission(request, view):
+            return True
+
+        if not request.auth:
+            return False
+
+        current_scopes = request.auth.get_scopes()
+        return any(
+            scope in current_scopes
+            for scope in get_legacy_alert_mutation_scopes(view, request.method)
+        )
+
     def has_object_permission(
         self,
         request: Request,
@@ -356,6 +369,12 @@ class OrganizationDetectorPermission(OrganizationPermission):
 
         if request.method not in {"POST", "PUT", "DELETE"}:
             return False
+
+        if any(
+            request.access.has_scope(scope)
+            for scope in get_legacy_alert_mutation_scopes(view, request.method)
+        ):
+            return True
 
         project_scoped_access = _has_view_project_scoped_alert_write(request, view, organization)
         if project_scoped_access is not None:

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -225,6 +225,31 @@ def _has_any_team_scope(request: Request, scope: str) -> bool:
     return any(request.access.has_team_scope(team, scope) for team in teams)
 
 
+ALERT_MUTATION_SCOPES = frozenset({"org:write", "alerts:write"})
+
+
+def _has_project_alert_write_access(request: Request, projects: Sequence[Project]) -> bool:
+    return bool(projects) and all(
+        request.access.has_any_project_scope(project, ALERT_MUTATION_SCOPES) for project in projects
+    )
+
+
+def _has_view_project_scoped_alert_write(
+    request: Request,
+    view: APIView,
+    organization: Organization | RpcOrganization | RpcUserOrganizationContext,
+) -> bool | None:
+    get_projects = getattr(view, "get_alert_mutation_projects", None)
+    if not callable(get_projects):
+        return None
+
+    projects = get_projects(request, organization)
+    if projects is None:
+        return None
+
+    return _has_project_alert_write_access(request, projects)
+
+
 class OrganizationAlertRulePermission(OrganizationPermission):
     scope_map = {
         "GET": ["org:read", "org:write", "org:admin", "alerts:read"],
@@ -242,8 +267,15 @@ class OrganizationAlertRulePermission(OrganizationPermission):
         if super().has_object_permission(request, view, organization):
             return True
 
-        return request.method in {"POST", "PUT", "DELETE"} and _has_any_team_scope(
-            request, "alerts:write"
+        if request.method not in {"POST", "PUT", "DELETE"}:
+            return False
+
+        project_scoped_access = _has_view_project_scoped_alert_write(request, view, organization)
+        if project_scoped_access is not None:
+            return project_scoped_access
+
+        return bool(getattr(view, "allow_any_team_alert_write_fallback", False)) and (
+            _has_any_team_scope(request, "alerts:write")
         )
 
 
@@ -264,8 +296,15 @@ class OrganizationDetectorPermission(OrganizationPermission):
         if super().has_object_permission(request, view, organization):
             return True
 
-        return request.method in {"POST", "PUT", "DELETE"} and _has_any_team_scope(
-            request, "alerts:write"
+        if request.method not in {"POST", "PUT", "DELETE"}:
+            return False
+
+        project_scoped_access = _has_view_project_scoped_alert_write(request, view, organization)
+        if project_scoped_access is not None:
+            return project_scoped_access
+
+        return bool(getattr(view, "allow_any_team_alert_write_fallback", False)) and (
+            _has_any_team_scope(request, "alerts:write")
         )
 
 

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -289,7 +289,7 @@ def get_legacy_alert_mutation_scopes(view: APIView, method: str | None) -> tuple
     return tuple(scopes)
 
 
-class OrganizationAlertRulePermission(OrganizationPermission):
+class OrganizationAlertMutationPermission(OrganizationPermission):
     scope_map = {
         "GET": ["org:read", "org:write", "org:admin", "alerts:read"],
         "POST": ["alerts:write"],
@@ -337,52 +337,12 @@ class OrganizationAlertRulePermission(OrganizationPermission):
         )
 
 
-class OrganizationDetectorPermission(OrganizationPermission):
-    scope_map = {
-        "GET": ["org:read", "org:write", "org:admin", "alerts:read"],
-        "POST": ["alerts:write"],
-        "PUT": ["alerts:write"],
-        "DELETE": ["alerts:write"],
-    }
+class OrganizationAlertRulePermission(OrganizationAlertMutationPermission):
+    pass
 
-    def has_permission(self, request: Request, view: APIView) -> bool:
-        if super().has_permission(request, view):
-            return True
 
-        if not request.auth:
-            return False
-
-        current_scopes = request.auth.get_scopes()
-        return any(
-            scope in current_scopes
-            for scope in get_legacy_alert_mutation_scopes(view, request.method)
-        )
-
-    def has_object_permission(
-        self,
-        request: Request,
-        view: APIView,
-        organization: Organization | RpcOrganization | RpcUserOrganizationContext,
-    ) -> bool:
-        if super().has_object_permission(request, view, organization):
-            return True
-
-        if request.method not in {"POST", "PUT", "DELETE"}:
-            return False
-
-        if any(
-            request.access.has_scope(scope)
-            for scope in get_legacy_alert_mutation_scopes(view, request.method)
-        ):
-            return True
-
-        project_scoped_access = _has_view_project_scoped_alert_write(request, view, organization)
-        if project_scoped_access is not None:
-            return project_scoped_access
-
-        return bool(getattr(view, "allow_any_team_alert_write_fallback", False)) and (
-            _has_any_team_scope(request, "alerts:write")
-        )
+class OrganizationDetectorPermission(OrganizationAlertMutationPermission):
+    pass
 
 
 class OrgAuthTokenPermission(OrganizationPermission):

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -159,8 +159,8 @@ class OrganizationIntegrationsPermission(OrganizationPermission):
 class OrganizationIntegrationsLoosePermission(OrganizationPermission):
     scope_map = {
         "GET": ["org:read", "org:write", "org:admin", "org:integrations", "org:ci"],
-        "POST": ["org:write", "org:admin", "org:integrations"],
-        "PUT": ["org:write", "org:admin", "org:integrations"],
+        "POST": ["org:read", "org:write", "org:admin", "org:integrations"],
+        "PUT": ["org:read", "org:write", "org:admin", "org:integrations"],
         "DELETE": ["org:admin", "org:integrations"],
     }
 
@@ -168,7 +168,7 @@ class OrganizationIntegrationsLoosePermission(OrganizationPermission):
 class OrganizationCodeMappingsBulkPermission(OrganizationPermission):
     scope_map = {
         "GET": ["org:read", "org:write", "org:admin", "org:integrations", "org:ci"],
-        "POST": ["org:write", "org:admin", "org:integrations", "org:ci"],
+        "POST": ["org:read", "org:write", "org:admin", "org:integrations", "org:ci"],
     }
 
 
@@ -272,8 +272,8 @@ class OrganizationDetectorPermission(OrganizationPermission):
 class OrgAuthTokenPermission(OrganizationPermission):
     scope_map = {
         "GET": ["org:read", "org:write", "org:admin"],
-        "POST": ["org:write", "org:admin"],
-        "PUT": ["org:write", "org:admin"],
+        "POST": ["org:read", "org:write", "org:admin"],
+        "PUT": ["org:read", "org:write", "org:admin"],
         "DELETE": ["org:write", "org:admin"],
     }
 

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -29,6 +29,7 @@ from sentry.models.orgauthtoken import is_org_auth_token_auth
 from sentry.models.project import Project
 from sentry.models.release import Release
 from sentry.models.releases.release_project import ReleaseProject
+from sentry.models.team import Team
 from sentry.organizations.services.organization import (
     RpcOrganization,
     RpcUserOrganizationContext,
@@ -158,8 +159,8 @@ class OrganizationIntegrationsPermission(OrganizationPermission):
 class OrganizationIntegrationsLoosePermission(OrganizationPermission):
     scope_map = {
         "GET": ["org:read", "org:write", "org:admin", "org:integrations", "org:ci"],
-        "POST": ["org:read", "org:write", "org:admin", "org:integrations"],
-        "PUT": ["org:read", "org:write", "org:admin", "org:integrations"],
+        "POST": ["org:write", "org:admin", "org:integrations"],
+        "PUT": ["org:write", "org:admin", "org:integrations"],
         "DELETE": ["org:admin", "org:integrations"],
     }
 
@@ -167,7 +168,7 @@ class OrganizationIntegrationsLoosePermission(OrganizationPermission):
 class OrganizationCodeMappingsBulkPermission(OrganizationPermission):
     scope_map = {
         "GET": ["org:read", "org:write", "org:admin", "org:integrations", "org:ci"],
-        "POST": ["org:read", "org:write", "org:admin", "org:integrations", "org:ci"],
+        "POST": ["org:write", "org:admin", "org:integrations", "org:ci"],
     }
 
 
@@ -212,37 +213,67 @@ class OrganizationSearchPermission(OrganizationPermission):
 class OrganizationDataExportPermission(OrganizationPermission):
     scope_map = {
         "GET": ["event:read", "event:write", "event:admin"],
-        "POST": ["event:read", "event:write", "event:admin"],
+        "POST": ["event:write", "event:admin"],
     }
+
+
+def _has_any_team_scope(request: Request, scope: str) -> bool:
+    if not request.access.team_ids_with_membership:
+        return False
+
+    teams = Team.objects.filter(id__in=request.access.team_ids_with_membership)
+    return any(request.access.has_team_scope(team, scope) for team in teams)
 
 
 class OrganizationAlertRulePermission(OrganizationPermission):
     scope_map = {
         "GET": ["org:read", "org:write", "org:admin", "alerts:read"],
-        # grant org:read permission, but raise permission denied if the members aren't allowed
-        # to create alerts and the user isn't a team admin
-        "POST": ["org:read", "org:write", "org:admin", "alerts:write"],
+        "POST": ["org:write", "org:admin", "alerts:write"],
         "PUT": ["org:write", "org:admin", "alerts:write"],
         "DELETE": ["org:write", "org:admin", "alerts:write"],
     }
+
+    def has_object_permission(
+        self,
+        request: Request,
+        view: APIView,
+        organization: Organization | RpcOrganization | RpcUserOrganizationContext,
+    ) -> bool:
+        if super().has_object_permission(request, view, organization):
+            return True
+
+        return request.method in {"POST", "PUT", "DELETE"} and _has_any_team_scope(
+            request, "alerts:write"
+        )
 
 
 class OrganizationDetectorPermission(OrganizationPermission):
     scope_map = {
         "GET": ["org:read", "org:write", "org:admin", "alerts:read"],
-        # grant org:read permission, but raise permission denied if the members aren't allowed
-        # to create alerts and the user isn't a team admin
-        "POST": ["org:read", "org:write", "org:admin", "alerts:write"],
-        "PUT": ["org:read", "org:write", "org:admin", "alerts:write"],
-        "DELETE": ["org:read", "org:write", "org:admin", "alerts:write"],
+        "POST": ["org:write", "org:admin", "alerts:write"],
+        "PUT": ["org:write", "org:admin", "alerts:write"],
+        "DELETE": ["org:write", "org:admin", "alerts:write"],
     }
+
+    def has_object_permission(
+        self,
+        request: Request,
+        view: APIView,
+        organization: Organization | RpcOrganization | RpcUserOrganizationContext,
+    ) -> bool:
+        if super().has_object_permission(request, view, organization):
+            return True
+
+        return request.method in {"POST", "PUT", "DELETE"} and _has_any_team_scope(
+            request, "alerts:write"
+        )
 
 
 class OrgAuthTokenPermission(OrganizationPermission):
     scope_map = {
         "GET": ["org:read", "org:write", "org:admin"],
-        "POST": ["org:read", "org:write", "org:admin"],
-        "PUT": ["org:read", "org:write", "org:admin"],
+        "POST": ["org:write", "org:admin"],
+        "PUT": ["org:write", "org:admin"],
         "DELETE": ["org:write", "org:admin"],
     }
 

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -289,7 +289,7 @@ def get_legacy_alert_mutation_scopes(view: APIView, method: str | None) -> tuple
     return tuple(scopes)
 
 
-class OrganizationAlertMutationPermission(OrganizationPermission):
+class OrganizationAlertingMutationPermission(OrganizationPermission):
     scope_map = {
         "GET": ["org:read", "org:write", "org:admin", "alerts:read"],
         "POST": ["alerts:write"],
@@ -337,11 +337,11 @@ class OrganizationAlertMutationPermission(OrganizationPermission):
         )
 
 
-class OrganizationAlertRulePermission(OrganizationAlertMutationPermission):
+class OrganizationAlertRulePermission(OrganizationAlertingMutationPermission):
     pass
 
 
-class OrganizationDetectorPermission(OrganizationAlertMutationPermission):
+class OrganizationDetectorPermission(OrganizationAlertingMutationPermission):
     pass
 
 

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -252,6 +252,7 @@ def _has_any_team_scope(request: Request, scope: str) -> bool:
 
 # Project-scoped alert authoring should rely on the alert-specific write scope.
 ALERT_MUTATION_SCOPES = frozenset({"alerts:write"})
+LEGACY_ALERT_MUTATION_PROJECT_SCOPES = ("project:read", "org:write", "alerts:write")
 
 
 def _has_project_alert_write_access(request: Request, projects: Sequence[Project]) -> bool:

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -252,7 +252,7 @@ def _has_any_team_scope(request: Request, scope: str) -> bool:
 
 # Project-scoped alert authoring should rely on the alert-specific write scope.
 ALERT_MUTATION_SCOPES = frozenset({"alerts:write"})
-LEGACY_ALERT_MUTATION_PROJECT_SCOPES = ("project:read", "org:write", "alerts:write")
+LEGACY_ALERT_MUTATION_PROJECT_SCOPES = ("org:write", "alerts:write")
 
 
 def _has_project_alert_write_access(request: Request, projects: Sequence[Project]) -> bool:
@@ -291,7 +291,7 @@ def get_legacy_alert_mutation_scopes(view: APIView, method: str | None) -> tuple
 
 class OrganizationAlertingMutationPermission(OrganizationPermission):
     scope_map = {
-        "GET": ["org:read", "org:write", "org:admin", "alerts:read"],
+        "GET": ["org:read", "org:write", "org:admin", "alerts:read", "alerts:write"],
         "POST": ["alerts:write"],
         "PUT": ["alerts:write"],
         "DELETE": ["alerts:write"],

--- a/src/sentry/api/bases/organization.py
+++ b/src/sentry/api/bases/organization.py
@@ -206,6 +206,8 @@ class OrganizationPinnedSearchPermission(OrganizationPermission):
         "PUT": ["org:read", "org:write", "org:admin"],
         "DELETE": ["org:read", "org:write", "org:admin"],
     }
+    # TODO(api-scope-personalization): Move personal saved/pinned search writes off
+    # readonly org scopes once we add a narrow member/personal preference write scope.
     readonly_mutation_scope_exceptions = {
         "PUT": "Pinned search changes only update the requesting member's personal pinned state.",
         "DELETE": "Pinned search removal only updates the requesting member's personal pinned state.",
@@ -219,6 +221,8 @@ class OrganizationSearchPermission(OrganizationPermission):
         "PUT": ["org:read", "org:write", "org:admin"],
         "DELETE": ["org:read", "org:write", "org:admin"],
     }
+    # TODO(api-scope-personalization): Move personal saved-search writes off readonly
+    # org scopes once we add a narrow member/personal preference write scope.
     readonly_mutation_scope_exceptions = {
         "POST": "Members may manage personal saved searches without org:write.",
         "PUT": "Members may edit personal saved searches without org:write.",

--- a/src/sentry/api/bases/organization_request_change.py
+++ b/src/sentry/api/bases/organization_request_change.py
@@ -7,6 +7,9 @@ from sentry.api.bases.organization import OrganizationEndpoint
 
 
 class OrganizationRequestChangeEndpointPermission(OrganizationPermission):
+    readonly_mutation_scope_exceptions = {
+        "POST": "This endpoint only files a request for an organization change; members use it without organization write access.",
+    }
     # just requesting so read permission is enough
     scope_map = {
         "POST": ["org:read"],

--- a/src/sentry/api/bases/project.py
+++ b/src/sentry/api/bases/project.py
@@ -133,6 +133,9 @@ class ProjectOwnershipPermission(ProjectPermission):
         "PUT": ["project:read", "project:write", "project:admin"],
         "DELETE": ["project:admin"],
     }
+    readonly_mutation_scope_exceptions = {
+        "PUT": "Project ownership rules allow project:read for legacy ownership config edits.",
+    }
 
 
 class ProjectEndpoint(Endpoint):

--- a/src/sentry/api/endpoints/organization_onboarding_continuation_email.py
+++ b/src/sentry/api/endpoints/organization_onboarding_continuation_email.py
@@ -43,6 +43,9 @@ def get_request_builder_args(user: User, organization: Organization, platforms: 
 
 class OnboardingContinuationPermission(OrganizationPermission):
     scope_map = {"POST": ["org:read", "org:write", "org:admin"]}
+    readonly_mutation_scope_exceptions = {
+        "POST": "Members may trigger their own onboarding continuation email.",
+    }
 
 
 @cell_silo_endpoint

--- a/src/sentry/api/endpoints/organization_onboarding_tasks.py
+++ b/src/sentry/api/endpoints/organization_onboarding_tasks.py
@@ -15,6 +15,9 @@ from sentry.models.organizationonboardingtask import OnboardingTask, OnboardingT
 
 class OnboardingTaskPermission(OrganizationPermission):
     scope_map = {"POST": ["org:read"], "GET": ["org:read"]}
+    readonly_mutation_scope_exceptions = {
+        "POST": "Members may update their own onboarding task state.",
+    }
 
 
 @cell_silo_endpoint

--- a/src/sentry/api/endpoints/organization_recent_searches.py
+++ b/src/sentry/api/endpoints/organization_recent_searches.py
@@ -22,6 +22,9 @@ class OrganizationRecentSearchPermission(OrganizationPermission):
         "GET": ["org:read", "org:write", "org:admin"],
         "POST": ["org:read", "org:write", "org:admin"],
     }
+    readonly_mutation_scope_exceptions = {
+        "POST": "Recent search writes only affect the requesting member's history.",
+    }
 
 
 @cell_silo_endpoint

--- a/src/sentry/api/endpoints/organization_recent_searches.py
+++ b/src/sentry/api/endpoints/organization_recent_searches.py
@@ -22,6 +22,8 @@ class OrganizationRecentSearchPermission(OrganizationPermission):
         "GET": ["org:read", "org:write", "org:admin"],
         "POST": ["org:read", "org:write", "org:admin"],
     }
+    # TODO(api-scope-personalization): Move recent-search writes off readonly org
+    # scopes once we add a narrow member/personal preference write scope.
     readonly_mutation_scope_exceptions = {
         "POST": "Recent search writes only affect the requesting member's history.",
     }

--- a/src/sentry/api/endpoints/project_repo_path_parsing.py
+++ b/src/sentry/api/endpoints/project_repo_path_parsing.py
@@ -96,7 +96,7 @@ class ProjectRepoPathParsingEndpointLoosePermission(ProjectPermission):
     """
 
     scope_map = {
-        "POST": ["project:write"],
+        "POST": ["org:read", "project:write", "project:admin"],
     }
 
 

--- a/src/sentry/api/endpoints/project_repo_path_parsing.py
+++ b/src/sentry/api/endpoints/project_repo_path_parsing.py
@@ -96,7 +96,7 @@ class ProjectRepoPathParsingEndpointLoosePermission(ProjectPermission):
     """
 
     scope_map = {
-        "POST": ["org:read", "project:write", "project:admin"],
+        "POST": ["project:write"],
     }
 
 

--- a/src/sentry/api/endpoints/project_repo_path_parsing.py
+++ b/src/sentry/api/endpoints/project_repo_path_parsing.py
@@ -98,6 +98,9 @@ class ProjectRepoPathParsingEndpointLoosePermission(ProjectPermission):
     scope_map = {
         "POST": ["org:read", "project:write", "project:admin"],
     }
+    readonly_mutation_scope_exceptions = {
+        "POST": "Repo path parsing validates a suggested mapping and does not persist project state.",
+    }
 
 
 @cell_silo_endpoint

--- a/src/sentry/api/endpoints/prompts_activity.py
+++ b/src/sentry/api/endpoints/prompts_activity.py
@@ -40,6 +40,9 @@ class PromptsActivityPermission(OrganizationPermission):
         "GET": ["org:read", "org:write", "org:admin"],
         "PUT": ["org:read", "org:write", "org:admin"],
     }
+    readonly_mutation_scope_exceptions = {
+        "PUT": "Prompt activity updates only change the requesting member's prompt state.",
+    }
 
 
 @cell_silo_endpoint

--- a/src/sentry/api/endpoints/prompts_activity.py
+++ b/src/sentry/api/endpoints/prompts_activity.py
@@ -40,6 +40,8 @@ class PromptsActivityPermission(OrganizationPermission):
         "GET": ["org:read", "org:write", "org:admin"],
         "PUT": ["org:read", "org:write", "org:admin"],
     }
+    # TODO(api-scope-personalization): Move prompt preference writes off readonly
+    # org scopes once we add a narrow member/personal preference write scope.
     readonly_mutation_scope_exceptions = {
         "PUT": "Prompt activity updates only change the requesting member's prompt state.",
     }

--- a/src/sentry/codecov/endpoints/repository_token_regenerate/repository_token_regenerate.py
+++ b/src/sentry/codecov/endpoints/repository_token_regenerate/repository_token_regenerate.py
@@ -18,6 +18,9 @@ from sentry.integrations.services.integration.model import RpcIntegration
 
 
 class RepositoryTokenRegeneratePermission(OrganizationPermission):
+    readonly_mutation_scope_exceptions = {
+        "POST": "Codecov token regeneration preserves read-only token access for now.",
+    }
     scope_map = {
         "GET": ["org:read", "org:write", "org:admin"],
         "POST": ["org:read", "org:write", "org:admin"],

--- a/src/sentry/codecov/endpoints/sync_repos/sync_repos.py
+++ b/src/sentry/codecov/endpoints/sync_repos/sync_repos.py
@@ -18,6 +18,9 @@ from sentry.integrations.services.integration.model import RpcIntegration
 
 
 class SyncReposPermission(OrganizationPermission):
+    readonly_mutation_scope_exceptions = {
+        "POST": "Codecov sync preserves read-only token access pending integration-scope cleanup.",
+    }
     scope_map = {
         "GET": ["org:read", "org:write", "org:admin"],
         "POST": ["org:read", "org:write", "org:admin"],

--- a/src/sentry/conduit/endpoints/organization_conduit_demo.py
+++ b/src/sentry/conduit/endpoints/organization_conduit_demo.py
@@ -31,6 +31,9 @@ class OrganizationConduitDemoPermission(OrganizationPermission):
     This is a demo-only feature and doesn't modify organization state.
     """
 
+    readonly_mutation_scope_exceptions = {
+        "POST": "Demo credential generation preserves read-only token access for now.",
+    }
     scope_map = {
         "POST": ["org:read", "org:write", "org:admin"],
     }

--- a/src/sentry/core/endpoints/organization_member_invite/index.py
+++ b/src/sentry/core/endpoints/organization_member_invite/index.py
@@ -38,6 +38,9 @@ from sentry.utils.audit import create_audit_entry
 
 
 class MemberInvitePermission(OrganizationPermission):
+    readonly_mutation_scope_exceptions = {
+        "POST": "Members can create invite requests on this endpoint even when they cannot send invites directly.",
+    }
     scope_map = {
         "GET": ["member:read", "member:write", "member:admin"],
         # We will do an additional check to see if a user can invite members. If

--- a/src/sentry/core/endpoints/organization_member_invite/utils.py
+++ b/src/sentry/core/endpoints/organization_member_invite/utils.py
@@ -6,6 +6,9 @@ ERR_RATE_LIMITED = "You are being rate limited for too many invitations."
 
 
 class MemberInviteDetailsPermission(OrganizationPermission):
+    readonly_mutation_scope_exceptions = {
+        "DELETE": "Invite deletion keeps current member-read token semantics for now.",
+    }
     scope_map = {
         "GET": ["member:read", "member:write", "member:admin"],
         "PUT": ["member:write", "member:admin"],

--- a/src/sentry/core/endpoints/organization_member_requests_invite_index.py
+++ b/src/sentry/core/endpoints/organization_member_requests_invite_index.py
@@ -20,6 +20,9 @@ from sentry.notifications.utils.tasks import async_send_notification
 
 
 class InviteRequestPermissions(OrganizationPermission):
+    readonly_mutation_scope_exceptions = {
+        "POST": "Invite request creation keeps member-read token access for now.",
+    }
     scope_map = {
         "GET": ["member:read", "member:write", "member:admin"],
         "POST": ["member:read", "member:write", "member:admin"],

--- a/src/sentry/core/endpoints/organization_member_team_details.py
+++ b/src/sentry/core/endpoints/organization_member_team_details.py
@@ -72,6 +72,11 @@ class OrganizationMemberTeamDetailsSerializer(Serializer):
 
 
 class OrganizationTeamMemberPermission(OrganizationPermission):
+    readonly_mutation_scope_exceptions = {
+        "POST": "Team membership writes keep current mixed org/member/team token semantics for now.",
+        "PUT": "Team membership writes keep current mixed org/member/team token semantics for now.",
+        "DELETE": "Team membership writes keep current mixed org/member/team token semantics for now.",
+    }
     scope_map = {
         "GET": [
             "org:read",

--- a/src/sentry/core/endpoints/organization_member_utils.py
+++ b/src/sentry/core/endpoints/organization_member_utils.py
@@ -61,6 +61,9 @@ class MemberConflictValidationError(serializers.ValidationError):
 
 
 class RelaxedMemberPermission(OrganizationPermission):
+    readonly_mutation_scope_exceptions = {
+        "DELETE": "Member deletion keeps self-service and role-comparison semantics for now.",
+    }
     scope_map = {
         "GET": ["member:read", "member:write", "member:admin"],
         "POST": ["member:write", "member:admin"],

--- a/src/sentry/core/endpoints/organization_projects_experiment.py
+++ b/src/sentry/core/endpoints/organization_projects_experiment.py
@@ -55,6 +55,9 @@ class OrgProjectPermission(OrganizationPermission):
     scope_map = {
         "POST": ["project:read", "project:write", "project:admin"],
     }
+    readonly_mutation_scope_exceptions = {
+        "POST": "Experimental team-plus-project creation remains available to members when org settings allow it.",
+    }
 
 
 class AuditData(TypedDict):

--- a/src/sentry/core/endpoints/project_details.py
+++ b/src/sentry/core/endpoints/project_details.py
@@ -507,6 +507,9 @@ class RelaxedProjectPermission(ProjectPermission):
         "PUT": ["project:read", "project:write", "project:admin"],
         "DELETE": ["project:admin"],
     }
+    readonly_mutation_scope_exceptions = {
+        "PUT": "Project detail updates still allow project:read for legacy field-level permission checks.",
+    }
 
 
 class RelaxedProjectAndStaffPermission(StaffPermissionMixin, RelaxedProjectPermission):

--- a/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_generate.py
@@ -49,6 +49,9 @@ class DashboardGenerateSerializer(serializers.Serializer[dict[str, Any]]):
 
 
 class OrganizationDashboardGeneratePermission(OrganizationPermission):
+    readonly_mutation_scope_exceptions = {
+        "POST": "Dashboard generation is a POST helper/action and needs separate contract cleanup.",
+    }
     scope_map = {
         "POST": ["org:read"],
     }

--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -303,9 +303,9 @@ def sync_prebuilt_dashboards(organization: Organization) -> None:
 class OrganizationDashboardsPermission(OrganizationPermission):
     scope_map = {
         "GET": ["org:read", "org:write", "org:admin"],
-        "POST": ["org:write", "org:admin"],
-        "PUT": ["org:write", "org:admin"],
-        "DELETE": ["org:write", "org:admin"],
+        "POST": ["org:read", "org:write", "org:admin"],
+        "PUT": ["org:read", "org:write", "org:admin"],
+        "DELETE": ["org:read", "org:write", "org:admin"],
     }
 
     def has_object_permission(

--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -307,6 +307,11 @@ class OrganizationDashboardsPermission(OrganizationPermission):
         "PUT": ["org:read", "org:write", "org:admin"],
         "DELETE": ["org:read", "org:write", "org:admin"],
     }
+    readonly_mutation_scope_exceptions = {
+        "POST": "Dashboard creation remains available to org members.",
+        "PUT": "Dashboard edits remain available to org members with object-level edit access.",
+        "DELETE": "Dashboard deletion remains available to org members with object-level edit access.",
+    }
 
     def has_object_permission(
         self,

--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -303,9 +303,9 @@ def sync_prebuilt_dashboards(organization: Organization) -> None:
 class OrganizationDashboardsPermission(OrganizationPermission):
     scope_map = {
         "GET": ["org:read", "org:write", "org:admin"],
-        "POST": ["org:read", "org:write", "org:admin"],
-        "PUT": ["org:read", "org:write", "org:admin"],
-        "DELETE": ["org:read", "org:write", "org:admin"],
+        "POST": ["org:write", "org:admin"],
+        "PUT": ["org:write", "org:admin"],
+        "DELETE": ["org:write", "org:admin"],
     }
 
     def has_object_permission(

--- a/src/sentry/dashboards/endpoints/organization_dashboards_starred.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards_starred.py
@@ -23,6 +23,9 @@ class MemberPermission(OrganizationPermission):
         "GET": ["member:read", "member:write"],
         "PUT": ["member:read", "member:write"],
     }
+    readonly_mutation_scope_exceptions = {
+        "PUT": "Starred dashboard ordering only updates the requesting member's preferences.",
+    }
 
 
 @cell_silo_endpoint

--- a/src/sentry/dashboards/endpoints/organization_dashboards_starred.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards_starred.py
@@ -23,6 +23,8 @@ class MemberPermission(OrganizationPermission):
         "GET": ["member:read", "member:write"],
         "PUT": ["member:read", "member:write"],
     }
+    # TODO(api-scope-personalization): Move dashboard favorite ordering off
+    # readonly member scopes once we add a narrow personal preference write scope.
     readonly_mutation_scope_exceptions = {
         "PUT": "Starred dashboard ordering only updates the requesting member's preferences.",
     }

--- a/src/sentry/discover/endpoints/bases.py
+++ b/src/sentry/discover/endpoints/bases.py
@@ -11,6 +11,11 @@ class DiscoverSavedQueryPermission(OrganizationPermission):
         "PUT": ["org:read", "org:write", "org:admin"],
         "DELETE": ["org:read", "org:write", "org:admin"],
     }
+    readonly_mutation_scope_exceptions = {
+        "POST": "Discover saved query mutations remain available for personal or otherwise permitted queries.",
+        "PUT": "Discover saved query mutations remain available for personal or otherwise permitted queries.",
+        "DELETE": "Discover saved query mutations remain available for personal or otherwise permitted queries.",
+    }
 
     def has_object_permission(self, request, view, obj):
         if isinstance(obj, Organization):

--- a/src/sentry/discover/endpoints/bases.py
+++ b/src/sentry/discover/endpoints/bases.py
@@ -11,6 +11,8 @@ class DiscoverSavedQueryPermission(OrganizationPermission):
         "PUT": ["org:read", "org:write", "org:admin"],
         "DELETE": ["org:read", "org:write", "org:admin"],
     }
+    # TODO(api-scope-personalization): Move saved-query writes off readonly org
+    # scopes once we add a narrow member/personal query write scope.
     readonly_mutation_scope_exceptions = {
         "POST": "Discover saved query mutations remain available for personal or otherwise permitted queries.",
         "PUT": "Discover saved query mutations remain available for personal or otherwise permitted queries.",

--- a/src/sentry/discover/endpoints/discover_key_transactions.py
+++ b/src/sentry/discover/endpoints/discover_key_transactions.py
@@ -23,13 +23,30 @@ from sentry.models.projectteam import ProjectTeam
 from sentry.models.team import Team
 
 
+def _has_any_team_scope(request: Request, scopes: list[str]) -> bool:
+    if not request.access.team_ids_with_membership:
+        return False
+
+    teams = Team.objects.filter(id__in=request.access.team_ids_with_membership)
+    return any(
+        any(request.access.has_team_scope(team, scope) for scope in scopes) for team in teams
+    )
+
+
 class KeyTransactionPermission(OrganizationPermission):
     scope_map = {
-        "GET": ["org:read"],
-        "POST": ["org:read"],
-        "PUT": ["org:read"],
-        "DELETE": ["org:read"],
+        "GET": ["project:read"],
+        "POST": ["project:write"],
+        "PUT": ["project:write"],
+        "DELETE": ["project:write"],
     }
+
+    def has_object_permission(self, request: Request, view, obj: object) -> bool:
+        if super().has_object_permission(request, view, obj):
+            return True
+
+        allowed_scopes = self.scope_map.get(request.method or "", [])
+        return _has_any_team_scope(request, allowed_scopes)
 
 
 @cell_silo_endpoint

--- a/src/sentry/discover/endpoints/discover_key_transactions.py
+++ b/src/sentry/discover/endpoints/discover_key_transactions.py
@@ -30,6 +30,10 @@ class KeyTransactionPermission(OrganizationPermission):
         "PUT": ["org:read"],
         "DELETE": ["org:read"],
     }
+    readonly_mutation_scope_exceptions = {
+        "POST": "Key transaction writes are additionally constrained by project and team membership checks.",
+        "DELETE": "Key transaction deletes are additionally constrained by project and team membership checks.",
+    }
 
 
 @cell_silo_endpoint

--- a/src/sentry/discover/endpoints/discover_key_transactions.py
+++ b/src/sentry/discover/endpoints/discover_key_transactions.py
@@ -23,30 +23,13 @@ from sentry.models.projectteam import ProjectTeam
 from sentry.models.team import Team
 
 
-def _has_any_team_scope(request: Request, scopes: list[str]) -> bool:
-    if not request.access.team_ids_with_membership:
-        return False
-
-    teams = Team.objects.filter(id__in=request.access.team_ids_with_membership)
-    return any(
-        any(request.access.has_team_scope(team, scope) for scope in scopes) for team in teams
-    )
-
-
 class KeyTransactionPermission(OrganizationPermission):
     scope_map = {
-        "GET": ["project:read"],
-        "POST": ["project:write"],
-        "PUT": ["project:write"],
-        "DELETE": ["project:write"],
+        "GET": ["org:read"],
+        "POST": ["org:read"],
+        "PUT": ["org:read"],
+        "DELETE": ["org:read"],
     }
-
-    def has_object_permission(self, request: Request, view, obj: object) -> bool:
-        if super().has_object_permission(request, view, obj):
-            return True
-
-        allowed_scopes = self.scope_map.get(request.method or "", [])
-        return _has_any_team_scope(request, allowed_scopes)
 
 
 @cell_silo_endpoint

--- a/src/sentry/explore/endpoints/bases.py
+++ b/src/sentry/explore/endpoints/bases.py
@@ -11,6 +11,11 @@ class ExploreSavedQueryPermission(OrganizationPermission):
         "PUT": ["org:read", "org:write", "org:admin"],
         "DELETE": ["org:read", "org:write", "org:admin"],
     }
+    readonly_mutation_scope_exceptions = {
+        "POST": "Explore saved query mutations remain available for personal or otherwise permitted queries.",
+        "PUT": "Explore saved query mutations remain available for personal or otherwise permitted queries.",
+        "DELETE": "Explore saved query mutations remain available for personal or otherwise permitted queries.",
+    }
 
     def has_object_permission(self, request, view, obj):
         if isinstance(obj, Organization):

--- a/src/sentry/explore/endpoints/bases.py
+++ b/src/sentry/explore/endpoints/bases.py
@@ -11,6 +11,8 @@ class ExploreSavedQueryPermission(OrganizationPermission):
         "PUT": ["org:read", "org:write", "org:admin"],
         "DELETE": ["org:read", "org:write", "org:admin"],
     }
+    # TODO(api-scope-personalization): Move saved-query writes off readonly org
+    # scopes once we add a narrow member/personal query write scope.
     readonly_mutation_scope_exceptions = {
         "POST": "Explore saved query mutations remain available for personal or otherwise permitted queries.",
         "PUT": "Explore saved query mutations remain available for personal or otherwise permitted queries.",

--- a/src/sentry/explore/endpoints/explore_saved_query_starred.py
+++ b/src/sentry/explore/endpoints/explore_saved_query_starred.py
@@ -25,6 +25,9 @@ class MemberPermission(OrganizationPermission):
     scope_map = {
         "POST": ["member:read", "member:write"],
     }
+    readonly_mutation_scope_exceptions = {
+        "POST": "Starring an Explore query only changes the requesting member's preferences.",
+    }
 
 
 @cell_silo_endpoint

--- a/src/sentry/explore/endpoints/explore_saved_query_starred.py
+++ b/src/sentry/explore/endpoints/explore_saved_query_starred.py
@@ -25,6 +25,8 @@ class MemberPermission(OrganizationPermission):
     scope_map = {
         "POST": ["member:read", "member:write"],
     }
+    # TODO(api-scope-personalization): Move saved-query starring off readonly
+    # member scopes once we add a narrow personal preference write scope.
     readonly_mutation_scope_exceptions = {
         "POST": "Starring an Explore query only changes the requesting member's preferences.",
     }

--- a/src/sentry/explore/endpoints/explore_saved_query_starred_order.py
+++ b/src/sentry/explore/endpoints/explore_saved_query_starred_order.py
@@ -17,6 +17,9 @@ class MemberPermission(OrganizationPermission):
     scope_map = {
         "PUT": ["member:read", "member:write"],
     }
+    readonly_mutation_scope_exceptions = {
+        "PUT": "Explore starred query ordering only changes the requesting member's preferences.",
+    }
 
 
 class ExploreSavedQueryStarredOrderSerializer(serializers.Serializer):

--- a/src/sentry/explore/endpoints/explore_saved_query_starred_order.py
+++ b/src/sentry/explore/endpoints/explore_saved_query_starred_order.py
@@ -17,6 +17,8 @@ class MemberPermission(OrganizationPermission):
     scope_map = {
         "PUT": ["member:read", "member:write"],
     }
+    # TODO(api-scope-personalization): Move saved-query starring order off
+    # readonly member scopes once we add a narrow personal preference write scope.
     readonly_mutation_scope_exceptions = {
         "PUT": "Explore starred query ordering only changes the requesting member's preferences.",
     }

--- a/src/sentry/incidents/endpoints/bases.py
+++ b/src/sentry/incidents/endpoints/bases.py
@@ -51,12 +51,12 @@ class OrganizationAlertRuleBaseEndpoint(OrganizationEndpoint):
         # team admins should be able to create alerts for the projects they have access to
         projects = self.get_projects(request, organization)
         # team admins will have alerts:write scoped to their projects, members will not
-        team_admin_has_access = all(
-            [request.access.has_project_scope(project, "alerts:write") for project in projects]
-        )
-        # all() returns True for empty list, so include a check for it
-        if not team_admin_has_access or not projects:
-            raise PermissionDenied
+        if projects and all(
+            request.access.has_project_scope(project, "alerts:write") for project in projects
+        ):
+            return
+
+        raise PermissionDenied
 
 
 class ProjectAlertRuleEndpoint(ProjectEndpoint):

--- a/src/sentry/incidents/endpoints/bases.py
+++ b/src/sentry/incidents/endpoints/bases.py
@@ -14,9 +14,19 @@ from sentry.incidents.endpoints.serializers.utils import get_object_id_from_fake
 from sentry.incidents.models.alert_rule import AlertRule
 from sentry.models.organization import Organization
 from sentry.models.project import Project
+from sentry.organizations.services.organization import RpcOrganization, RpcUserOrganizationContext
 from sentry.workflow_engine.endpoints.utils.ids import to_valid_int_id
 from sentry.workflow_engine.models.alertrule_detector import AlertRuleDetector
 from sentry.workflow_engine.models.detector import Detector
+
+
+def _get_organization_id(
+    organization: Organization | RpcOrganization | RpcUserOrganizationContext,
+) -> int:
+    if isinstance(organization, RpcUserOrganizationContext):
+        return organization.organization.id
+
+    return organization.id
 
 
 class OrganizationAlertRuleBaseEndpoint(OrganizationEndpoint):
@@ -89,7 +99,9 @@ class OrganizationAlertRuleEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationAlertRulePermission,)
 
     def get_alert_mutation_projects(
-        self, request: Request, organization: Organization
+        self,
+        request: Request,
+        organization: Organization | RpcOrganization | RpcUserOrganizationContext,
     ) -> Sequence[Project] | None:
         if request.method not in {"PUT", "DELETE"}:
             return None
@@ -104,8 +116,9 @@ class OrganizationAlertRuleEndpoint(OrganizationEndpoint):
             return None
 
         try:
+            organization_id = _get_organization_id(organization)
             alert_rule = AlertRule.objects.prefetch_related("projects").get(
-                organization=organization, id=validated_alert_rule_id
+                organization_id=organization_id, id=validated_alert_rule_id
             )
             return [alert_rule.projects.get()]
         except (
@@ -199,7 +212,9 @@ class WorkflowEngineOrganizationAlertRuleEndpoint(OrganizationAlertRuleEndpoint)
     workflow_engine_method_flags: dict[str, str] = {}
 
     def get_alert_mutation_projects(
-        self, request: Request, organization: Organization
+        self,
+        request: Request,
+        organization: Organization | RpcOrganization | RpcUserOrganizationContext,
     ) -> Sequence[Project] | None:
         projects = super().get_alert_mutation_projects(request, organization)
         if projects is not None:
@@ -217,11 +232,12 @@ class WorkflowEngineOrganizationAlertRuleEndpoint(OrganizationAlertRuleEndpoint)
         except RestFrameworkValidationError:
             return None
 
+        organization_id = _get_organization_id(organization)
         ard = (
             AlertRuleDetector.objects.select_related("detector__project")
             .filter(
                 alert_rule_id=validated_alert_rule_id,
-                detector__project__organization=organization,
+                detector__project__organization_id=organization_id,
             )
             .first()
         )
@@ -237,7 +253,7 @@ class WorkflowEngineOrganizationAlertRuleEndpoint(OrganizationAlertRuleEndpoint)
             Detector.objects.select_related("project")
             .filter(
                 id=detector_id,
-                project__organization=organization,
+                project__organization_id=organization_id,
             )
             .first()
         )

--- a/src/sentry/incidents/endpoints/bases.py
+++ b/src/sentry/incidents/endpoints/bases.py
@@ -1,6 +1,8 @@
+from collections.abc import Sequence
 from typing import Any
 
 from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import ValidationError as RestFrameworkValidationError
 from rest_framework.request import Request
 
 from sentry import features
@@ -11,6 +13,7 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.incidents.endpoints.serializers.utils import get_object_id_from_fake_id
 from sentry.incidents.models.alert_rule import AlertRule
 from sentry.models.organization import Organization
+from sentry.models.project import Project
 from sentry.workflow_engine.endpoints.utils.ids import to_valid_int_id
 from sentry.workflow_engine.models.alertrule_detector import AlertRuleDetector
 from sentry.workflow_engine.models.detector import Detector
@@ -23,6 +26,8 @@ class OrganizationAlertRuleBaseEndpoint(OrganizationEndpoint):
     Provides permission checking for alert creation that handles both
     org-level permissions and team admin project-scoped permissions.
     """
+
+    allow_any_team_alert_write_fallback = True
 
     def check_can_create_alert(self, request: Request, organization: Organization) -> None:
         """
@@ -82,6 +87,34 @@ class ProjectAlertRuleEndpoint(ProjectEndpoint):
 
 class OrganizationAlertRuleEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationAlertRulePermission,)
+
+    def get_alert_mutation_projects(
+        self, request: Request, organization: Organization
+    ) -> Sequence[Project] | None:
+        if request.method not in {"PUT", "DELETE"}:
+            return None
+
+        raw_alert_rule_id = self.kwargs.get("alert_rule_id")
+        if raw_alert_rule_id is None:
+            return None
+
+        try:
+            validated_alert_rule_id = to_valid_int_id("alert_rule_id", raw_alert_rule_id)
+        except RestFrameworkValidationError:
+            return None
+
+        try:
+            alert_rule = AlertRule.objects.prefetch_related("projects").get(
+                organization=organization, id=validated_alert_rule_id
+            )
+            return [alert_rule.projects.get()]
+        except (
+            AlertRule.DoesNotExist,
+            AlertRule.MultipleObjectsReturned,
+            Project.DoesNotExist,
+            Project.MultipleObjectsReturned,
+        ):
+            return None
 
     def convert_args(
         self, request: Request, alert_rule_id: int, *args: Any, **kwargs: Any
@@ -164,6 +197,54 @@ class WorkflowEngineOrganizationAlertRuleEndpoint(OrganizationAlertRuleEndpoint)
     # Subclasses may set a per-method granular flag (e.g. for GET) that is OR'd
     # with the broad workflow-engine-rule-serializers flag.
     workflow_engine_method_flags: dict[str, str] = {}
+
+    def get_alert_mutation_projects(
+        self, request: Request, organization: Organization
+    ) -> Sequence[Project] | None:
+        projects = super().get_alert_mutation_projects(request, organization)
+        if projects is not None:
+            return projects
+
+        if request.method not in {"PUT", "DELETE"}:
+            return None
+
+        raw_alert_rule_id = self.kwargs.get("alert_rule_id")
+        if raw_alert_rule_id is None:
+            return None
+
+        try:
+            validated_alert_rule_id = to_valid_int_id("alert_rule_id", raw_alert_rule_id)
+        except RestFrameworkValidationError:
+            return None
+
+        ard = (
+            AlertRuleDetector.objects.select_related("detector__project")
+            .filter(
+                alert_rule_id=validated_alert_rule_id,
+                detector__project__organization=organization,
+            )
+            .first()
+        )
+        if ard is not None:
+            return [ard.detector.project]
+
+        try:
+            detector_id = get_object_id_from_fake_id(validated_alert_rule_id)
+        except ValueError:
+            return None
+
+        detector = (
+            Detector.objects.select_related("project")
+            .filter(
+                id=detector_id,
+                project__organization=organization,
+            )
+            .first()
+        )
+        if detector is None:
+            return None
+
+        return [detector.project]
 
     def convert_args(
         self, request: Request, alert_rule_id: int, *args: Any, **kwargs: Any

--- a/src/sentry/incidents/endpoints/bases.py
+++ b/src/sentry/incidents/endpoints/bases.py
@@ -7,7 +7,11 @@ from rest_framework.request import Request
 
 from sentry import features
 from sentry.api.api_owners import ApiOwner
-from sentry.api.bases.organization import OrganizationAlertRulePermission, OrganizationEndpoint
+from sentry.api.bases.organization import (
+    OrganizationAlertRulePermission,
+    OrganizationEndpoint,
+    get_legacy_alert_mutation_scopes,
+)
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.incidents.endpoints.serializers.utils import get_object_id_from_fake_id
@@ -46,11 +50,9 @@ class OrganizationAlertRuleBaseEndpoint(OrganizationEndpoint):
         in their request.
         """
 
-        # if the requesting user has any of these org-level permissions, then they can create an alert
-        if (
-            request.access.has_scope("alerts:write")
-            or request.access.has_scope("org:admin")
-            or request.access.has_scope("org:write")
+        if request.access.has_scope("alerts:write") or any(
+            request.access.has_scope(scope)
+            for scope in get_legacy_alert_mutation_scopes(self, request.method)
         ):
             return
 

--- a/src/sentry/incidents/endpoints/bases.py
+++ b/src/sentry/incidents/endpoints/bases.py
@@ -11,6 +11,7 @@ from sentry.api.bases.organization import (
     OrganizationAlertRulePermission,
     OrganizationEndpoint,
     get_legacy_alert_mutation_scopes,
+    get_organization_id,
 )
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -22,15 +23,6 @@ from sentry.organizations.services.organization import RpcOrganization, RpcUserO
 from sentry.workflow_engine.endpoints.utils.ids import to_valid_int_id
 from sentry.workflow_engine.models.alertrule_detector import AlertRuleDetector
 from sentry.workflow_engine.models.detector import Detector
-
-
-def _get_organization_id(
-    organization: Organization | RpcOrganization | RpcUserOrganizationContext,
-) -> int:
-    if isinstance(organization, RpcUserOrganizationContext):
-        return organization.organization.id
-
-    return organization.id
 
 
 class OrganizationAlertRuleBaseEndpoint(OrganizationEndpoint):
@@ -118,7 +110,7 @@ class OrganizationAlertRuleEndpoint(OrganizationEndpoint):
             return None
 
         try:
-            organization_id = _get_organization_id(organization)
+            organization_id = get_organization_id(organization)
             alert_rule = AlertRule.objects.prefetch_related("projects").get(
                 organization_id=organization_id, id=validated_alert_rule_id
             )
@@ -234,7 +226,7 @@ class WorkflowEngineOrganizationAlertRuleEndpoint(OrganizationAlertRuleEndpoint)
         except RestFrameworkValidationError:
             return None
 
-        organization_id = _get_organization_id(organization)
+        organization_id = get_organization_id(organization)
         ard = (
             AlertRuleDetector.objects.select_related("detector__project")
             .filter(

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -13,10 +13,6 @@ from rest_framework.response import Response
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
-from sentry.api.bases.organization import (
-    ALERT_MUTATION_SCOPES,
-    get_legacy_alert_mutation_scopes,
-)
 from sentry.api.fields.actor import OwnerActorField
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework.project import ProjectField
@@ -331,17 +327,6 @@ def _check_project_access[T](
 
         if not request.access.has_project_access(project):
             return Response(status=status.HTTP_403_FORBIDDEN)
-
-        if request.method in {"PUT", "DELETE"}:
-            has_project_alert_write = request.access.has_any_project_scope(
-                project, ALERT_MUTATION_SCOPES
-            )
-            has_legacy_org_write = any(
-                request.access.has_scope(scope)
-                for scope in get_legacy_alert_mutation_scopes(self, request.method)
-            )
-            if not has_project_alert_write and not has_legacy_org_write:
-                return Response(status=status.HTTP_403_FORBIDDEN)
 
         return func(self, request, organization, alert_rule)
 

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -13,7 +13,10 @@ from rest_framework.response import Response
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
-from sentry.api.bases.organization import ALERT_MUTATION_SCOPES
+from sentry.api.bases.organization import (
+    ALERT_MUTATION_SCOPES,
+    get_legacy_alert_mutation_scopes,
+)
 from sentry.api.fields.actor import OwnerActorField
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework.project import ProjectField
@@ -329,10 +332,16 @@ def _check_project_access[T](
         if not request.access.has_project_access(project):
             return Response(status=status.HTTP_403_FORBIDDEN)
 
-        if request.method in {"PUT", "DELETE"} and not request.access.has_any_project_scope(
-            project, ALERT_MUTATION_SCOPES
-        ):
-            return Response(status=status.HTTP_403_FORBIDDEN)
+        if request.method in {"PUT", "DELETE"}:
+            has_project_alert_write = request.access.has_any_project_scope(
+                project, ALERT_MUTATION_SCOPES
+            )
+            has_legacy_org_write = any(
+                request.access.has_scope(scope)
+                for scope in get_legacy_alert_mutation_scopes(self, request.method)
+            )
+            if not has_project_alert_write and not has_legacy_org_write:
+                return Response(status=status.HTTP_403_FORBIDDEN)
 
         return func(self, request, organization, alert_rule)
 
@@ -351,6 +360,12 @@ class OrganizationAlertRuleDetailsEndpoint(WorkflowEngineOrganizationAlertRuleEn
         "DELETE": ApiPublishStatus.PUBLIC,
         "GET": ApiPublishStatus.PUBLIC,
         "PUT": ApiPublishStatus.PUBLIC,
+    }
+    # TODO(api-write-scope-compat): Remove legacy org:write support once public
+    # metric alert clients have migrated to alerts:write.
+    legacy_alert_mutation_scope_map = {
+        "DELETE": ("org:write",),
+        "PUT": ("org:write",),
     }
 
     @extend_schema(

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -13,6 +13,7 @@ from rest_framework.response import Response
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
+from sentry.api.bases.organization import ALERT_MUTATION_SCOPES
 from sentry.api.fields.actor import OwnerActorField
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework.project import ProjectField
@@ -326,6 +327,11 @@ def _check_project_access[T](
             return Response(status=status.HTTP_404_NOT_FOUND)
 
         if not request.access.has_project_access(project):
+            return Response(status=status.HTTP_403_FORBIDDEN)
+
+        if request.method in {"PUT", "DELETE"} and not request.access.has_any_project_scope(
+            project, ALERT_MUTATION_SCOPES
+        ):
             return Response(status=status.HTTP_403_FORBIDDEN)
 
         return func(self, request, organization, alert_rule)

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -221,7 +221,7 @@ class OrganizationAlertRuleDetailsPutSerializer(serializers.Serializer):
         help_text="The time period to aggregate over.",
     )
     projects = serializers.ListField(
-        child=ProjectField(scope="project:read"),
+        child=ProjectField(scope="alerts:write"),
         help_text="The names of the projects to filter by.",
     )
     query = serializers.CharField(

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -914,6 +914,9 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationAlertRuleBaseEndpoint, Aler
         "GET": ApiPublishStatus.PUBLIC,
         "POST": ApiPublishStatus.PUBLIC,
     }
+    # TODO(api-write-scope-compat): Remove legacy org:write support once public
+    # metric alert clients have migrated to alerts:write.
+    legacy_alert_mutation_scope_map = {"POST": ("org:write",)}
     permission_classes = (OrganizationAlertRulePermission,)
     workflow_engine_method_flags = {
         "GET": "organizations:workflow-engine-orgalertruleindex-get",

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -824,7 +824,7 @@ class OrganizationAlertRuleIndexPostSerializer(serializers.Serializer):
     )
     # projects is not required in the serializer, however, the UI requires a project is chosen
     projects = serializers.ListField(
-        child=ProjectField(scope="project:read"),
+        child=ProjectField(scope="alerts:write"),
         help_text="Metric alerts are currently limited to one project. The array should contain a single slug, representing the project to filter by.",
     )
     query = serializers.CharField(

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -51,6 +51,8 @@ from .alert_rule_trigger import AlertRuleTriggerSerializer
 
 logger = logging.getLogger(__name__)
 
+ALERT_RULE_PROJECT_SCOPES = ("project:read", "org:write", "org:admin", "alerts:write")
+
 
 class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRule]):
     """
@@ -62,7 +64,7 @@ class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRu
 
     environment = serializers.CharField(required=False, allow_null=True)
     projects = serializers.ListField(
-        child=ProjectField(scope="project:read"),
+        child=ProjectField(scope=ALERT_RULE_PROJECT_SCOPES),
         required=False,
         max_length=1,
     )

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -51,7 +51,9 @@ from .alert_rule_trigger import AlertRuleTriggerSerializer
 
 logger = logging.getLogger(__name__)
 
-ALERT_RULE_PROJECT_SCOPES = ("project:read", "org:write", "org:admin", "alerts:write")
+# TODO(api-write-scope-compat): Remove legacy org:write support once public
+# metric alert clients have migrated to alerts:write.
+ALERT_RULE_PROJECT_SCOPES = ("project:read", "org:write", "alerts:write")
 
 
 class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRule]):

--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -16,6 +16,7 @@ from rest_framework import serializers
 from urllib3.exceptions import MaxRetryError, TimeoutError
 
 from sentry import features
+from sentry.api.bases.organization import LEGACY_ALERT_MUTATION_PROJECT_SCOPES
 from sentry.api.exceptions import BadRequest, RequestTimeout
 from sentry.api.fields.actor import OwnerActorField
 from sentry.api.helpers.error_upsampling import are_any_projects_error_upsampled
@@ -51,10 +52,6 @@ from .alert_rule_trigger import AlertRuleTriggerSerializer
 
 logger = logging.getLogger(__name__)
 
-# TODO(api-write-scope-compat): Remove legacy org:write support once public
-# metric alert clients have migrated to alerts:write.
-ALERT_RULE_PROJECT_SCOPES = ("project:read", "org:write", "alerts:write")
-
 
 class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRule]):
     """
@@ -66,7 +63,7 @@ class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRu
 
     environment = serializers.CharField(required=False, allow_null=True)
     projects = serializers.ListField(
-        child=ProjectField(scope=ALERT_RULE_PROJECT_SCOPES),
+        child=ProjectField(scope=LEGACY_ALERT_MUTATION_PROJECT_SCOPES),
         required=False,
         max_length=1,
     )

--- a/src/sentry/insights/endpoints/starred_segments.py
+++ b/src/sentry/insights/endpoints/starred_segments.py
@@ -23,6 +23,10 @@ class MemberPermission(OrganizationPermission):
         "POST": ["member:read", "member:write"],
         "DELETE": ["member:read", "member:write"],
     }
+    readonly_mutation_scope_exceptions = {
+        "POST": "Starring an insights segment only changes the requesting member's preferences.",
+        "DELETE": "Unstarring an insights segment only changes the requesting member's preferences.",
+    }
 
 
 @cell_silo_endpoint

--- a/src/sentry/insights/endpoints/starred_segments.py
+++ b/src/sentry/insights/endpoints/starred_segments.py
@@ -23,6 +23,8 @@ class MemberPermission(OrganizationPermission):
         "POST": ["member:read", "member:write"],
         "DELETE": ["member:read", "member:write"],
     }
+    # TODO(api-scope-personalization): Move insights segment starring off
+    # readonly member scopes once we add a narrow personal preference write scope.
     readonly_mutation_scope_exceptions = {
         "POST": "Starring an insights segment only changes the requesting member's preferences.",
         "DELETE": "Unstarring an insights segment only changes the requesting member's preferences.",

--- a/src/sentry/issues/endpoints/bases/group_search_view.py
+++ b/src/sentry/issues/endpoints/bases/group_search_view.py
@@ -14,6 +14,10 @@ class GroupSearchViewPermission(OrganizationPermission):
         "PUT": ["org:read", "org:write", "org:admin"],
         "DELETE": ["org:read", "org:write", "org:admin"],
     }
+    readonly_mutation_scope_exceptions = {
+        "PUT": "Group search view edits remain available to creators and org managers without requiring org:write in the scope map.",
+        "DELETE": "Group search view deletes remain available to creators and org managers without requiring org:write in the scope map.",
+    }
 
     def has_object_permission(self, request: Request, view: APIView, obj: object) -> bool:
         if isinstance(obj, Organization):

--- a/src/sentry/issues/endpoints/bases/group_search_view.py
+++ b/src/sentry/issues/endpoints/bases/group_search_view.py
@@ -14,6 +14,8 @@ class GroupSearchViewPermission(OrganizationPermission):
         "PUT": ["org:read", "org:write", "org:admin"],
         "DELETE": ["org:read", "org:write", "org:admin"],
     }
+    # TODO(api-scope-personalization): Move custom issue-view writes off
+    # readonly org scopes once we add a narrow member/personal view write scope.
     readonly_mutation_scope_exceptions = {
         "PUT": "Group search view edits remain available to creators and org managers without requiring org:write in the scope map.",
         "DELETE": "Group search view deletes remain available to creators and org managers without requiring org:write in the scope map.",

--- a/src/sentry/issues/endpoints/organization_group_search_view_details_starred.py
+++ b/src/sentry/issues/endpoints/organization_group_search_view_details_starred.py
@@ -25,6 +25,9 @@ class MemberPermission(OrganizationPermission):
     scope_map = {
         "POST": ["member:read", "member:write"],
     }
+    readonly_mutation_scope_exceptions = {
+        "POST": "Starring a group search view only changes the requesting member's preferences.",
+    }
 
 
 @cell_silo_endpoint

--- a/src/sentry/issues/endpoints/organization_group_search_view_details_starred.py
+++ b/src/sentry/issues/endpoints/organization_group_search_view_details_starred.py
@@ -25,6 +25,8 @@ class MemberPermission(OrganizationPermission):
     scope_map = {
         "POST": ["member:read", "member:write"],
     }
+    # TODO(api-scope-personalization): Move issue-view starring off readonly
+    # member scopes once we add a narrow personal preference write scope.
     readonly_mutation_scope_exceptions = {
         "POST": "Starring a group search view only changes the requesting member's preferences.",
     }

--- a/src/sentry/issues/endpoints/organization_group_search_view_starred_order.py
+++ b/src/sentry/issues/endpoints/organization_group_search_view_starred_order.py
@@ -15,6 +15,9 @@ class MemberPermission(OrganizationPermission):
     scope_map = {
         "PUT": ["member:read", "member:write"],
     }
+    readonly_mutation_scope_exceptions = {
+        "PUT": "Group search view starred ordering only changes the requesting member's preferences.",
+    }
 
 
 class GroupSearchViewStarredOrderSerializer(serializers.Serializer):

--- a/src/sentry/issues/endpoints/organization_group_search_view_starred_order.py
+++ b/src/sentry/issues/endpoints/organization_group_search_view_starred_order.py
@@ -15,6 +15,8 @@ class MemberPermission(OrganizationPermission):
     scope_map = {
         "PUT": ["member:read", "member:write"],
     }
+    # TODO(api-scope-personalization): Move issue-view starring order off
+    # readonly member scopes once we add a narrow personal preference write scope.
     readonly_mutation_scope_exceptions = {
         "PUT": "Group search view starred ordering only changes the requesting member's preferences.",
     }

--- a/src/sentry/issues/endpoints/organization_group_search_view_visit.py
+++ b/src/sentry/issues/endpoints/organization_group_search_view_visit.py
@@ -16,6 +16,9 @@ class MemberPermission(OrganizationPermission):
     scope_map = {
         "POST": ["member:read"],
     }
+    readonly_mutation_scope_exceptions = {
+        "POST": "View visit timestamps only update the requesting member's last-visited state.",
+    }
 
 
 @cell_silo_endpoint

--- a/src/sentry/issues/endpoints/organization_group_search_view_visit.py
+++ b/src/sentry/issues/endpoints/organization_group_search_view_visit.py
@@ -16,6 +16,8 @@ class MemberPermission(OrganizationPermission):
     scope_map = {
         "POST": ["member:read"],
     }
+    # TODO(api-scope-personalization): Move last-visited writes off readonly
+    # member scopes once we add a narrow personal preference write scope.
     readonly_mutation_scope_exceptions = {
         "POST": "View visit timestamps only update the requesting member's last-visited state.",
     }

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -28,6 +28,9 @@ class MemberPermission(OrganizationPermission):
         "GET": ["member:read", "member:write"],
         "POST": ["member:read", "member:write"],
     }
+    readonly_mutation_scope_exceptions = {
+        "POST": "Creating a custom group search view is allowed for organization members.",
+    }
 
     def has_object_permission(self, request: Request, view: APIView, obj: Any) -> bool:
         if isinstance(obj, Organization):

--- a/src/sentry/issues/endpoints/organization_group_search_views.py
+++ b/src/sentry/issues/endpoints/organization_group_search_views.py
@@ -28,6 +28,8 @@ class MemberPermission(OrganizationPermission):
         "GET": ["member:read", "member:write"],
         "POST": ["member:read", "member:write"],
     }
+    # TODO(api-scope-personalization): Move custom issue-view creation off
+    # readonly member scopes once we add a narrow member/personal view write scope.
     readonly_mutation_scope_exceptions = {
         "POST": "Creating a custom group search view is allowed for organization members.",
     }

--- a/src/sentry/issues/endpoints/project_user_issue.py
+++ b/src/sentry/issues/endpoints/project_user_issue.py
@@ -184,6 +184,12 @@ class ProjectUserIssuePermission(ProjectPermission):
         "PUT": [],
         "DELETE": [],
     }
+    readonly_mutation_scope_exceptions = {
+        "POST": (
+            "User-defined issue creation derives a new issue from event data the caller can "
+            "already inspect, so it intentionally follows event read access."
+        ),
+    }
 
 
 class ProjectUserIssueResponseSerializer(serializers.Serializer):

--- a/src/sentry/issues/endpoints/project_user_issue.py
+++ b/src/sentry/issues/endpoints/project_user_issue.py
@@ -180,7 +180,7 @@ class WebVitalsIssueDataSerializer(ProjectUserIssueRequestSerializer):
 class ProjectUserIssuePermission(ProjectPermission):
     scope_map = {
         "GET": [],
-        "POST": ["event:read", "event:write", "event:admin"],
+        "POST": ["event:write", "event:admin"],
         "PUT": [],
         "DELETE": [],
     }

--- a/src/sentry/issues/endpoints/project_user_issue.py
+++ b/src/sentry/issues/endpoints/project_user_issue.py
@@ -180,7 +180,7 @@ class WebVitalsIssueDataSerializer(ProjectUserIssueRequestSerializer):
 class ProjectUserIssuePermission(ProjectPermission):
     scope_map = {
         "GET": [],
-        "POST": ["event:write", "event:admin"],
+        "POST": ["event:read", "event:write", "event:admin"],
         "PUT": [],
         "DELETE": [],
     }

--- a/src/sentry/issues/endpoints/project_user_issue.py
+++ b/src/sentry/issues/endpoints/project_user_issue.py
@@ -10,7 +10,7 @@ from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
-from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
+from sentry.api.bases.project import ProjectEndpoint, ProjectEventPermission
 from sentry.apidocs.parameters import GlobalParams
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.issues.grouptype import GroupType, WebVitalsGroup
@@ -177,18 +177,12 @@ class WebVitalsIssueDataSerializer(ProjectUserIssueRequestSerializer):
     value = serializers.IntegerField(required=True)
 
 
-class ProjectUserIssuePermission(ProjectPermission):
+class ProjectUserIssuePermission(ProjectEventPermission):
     scope_map = {
         "GET": [],
-        "POST": ["event:read", "event:write", "event:admin"],
+        "POST": ["event:write", "event:admin"],
         "PUT": [],
         "DELETE": [],
-    }
-    readonly_mutation_scope_exceptions = {
-        "POST": (
-            "User-defined issue creation derives a new issue from event data the caller can "
-            "already inspect, so it intentionally follows event read access."
-        ),
     }
 
 

--- a/src/sentry/monitors/endpoints/organization_monitor_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index.py
@@ -40,6 +40,7 @@ from sentry.db.models.query import in_iexact
 from sentry.incidents.endpoints.bases import OrganizationAlertRuleBaseEndpoint
 from sentry.models.environment import Environment
 from sentry.models.organization import Organization
+from sentry.models.project import Project
 from sentry.monitors.models import (
     DEFAULT_STATUS_ORDER,
     MONITOR_ENVIRONMENT_ORDERING,
@@ -86,6 +87,9 @@ class OrganizationMonitorIndexEndpoint(OrganizationAlertRuleBaseEndpoint):
         "PUT": ApiPublishStatus.EXPERIMENTAL,
     }
     owner = ApiOwner.CRONS
+    # TODO(api-write-scope-compat): Remove legacy org:write support once public
+    # cron monitor clients have migrated to alerts:write.
+    legacy_alert_mutation_scope_map = {"POST": ("org:write",)}
     permission_classes = (OrganizationAlertRulePermission,)
 
     @extend_schema(
@@ -331,9 +335,11 @@ class OrganizationMonitorIndexEndpoint(OrganizationAlertRuleBaseEndpoint):
 
         monitor_guids = result.pop("ids", [])
         monitors = list(Monitor.objects.filter(guid__in=monitor_guids, project_id__in=project_ids))
+        projects_by_id = Project.objects.in_bulk({monitor.project_id for monitor in monitors})
         if not all(
-            request.access.has_any_project_scope(monitor.project, ALERT_MUTATION_SCOPES)
-            for monitor in monitors
+            project is not None
+            and request.access.has_any_project_scope(project, ALERT_MUTATION_SCOPES)
+            for project in (projects_by_id.get(monitor.project_id) for monitor in monitors)
         ):
             return self.respond(status=403)
 

--- a/src/sentry/monitors/endpoints/organization_monitor_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index.py
@@ -18,7 +18,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import NoProjects
-from sentry.api.bases.organization import OrganizationAlertRulePermission
+from sentry.api.bases.organization import ALERT_MUTATION_SCOPES, OrganizationAlertRulePermission
 from sentry.api.helpers.teams import get_teams
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
@@ -331,6 +331,11 @@ class OrganizationMonitorIndexEndpoint(OrganizationAlertRuleBaseEndpoint):
 
         monitor_guids = result.pop("ids", [])
         monitors = list(Monitor.objects.filter(guid__in=monitor_guids, project_id__in=project_ids))
+        if not all(
+            request.access.has_any_project_scope(monitor.project, ALERT_MUTATION_SCOPES)
+            for monitor in monitors
+        ):
+            return self.respond(status=403)
 
         status = result.get("status")
         # If enabling monitors, ensure we can assign all before moving forward

--- a/src/sentry/monitors/endpoints/organization_monitor_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index.py
@@ -18,7 +18,11 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import NoProjects
-from sentry.api.bases.organization import ALERT_MUTATION_SCOPES, OrganizationAlertRulePermission
+from sentry.api.bases.organization import (
+    ALERT_MUTATION_SCOPES,
+    OrganizationAlertRulePermission,
+    get_legacy_alert_mutation_scopes,
+)
 from sentry.api.helpers.teams import get_teams
 from sentry.api.paginator import OffsetPaginator
 from sentry.api.serializers import serialize
@@ -89,7 +93,10 @@ class OrganizationMonitorIndexEndpoint(OrganizationAlertRuleBaseEndpoint):
     owner = ApiOwner.CRONS
     # TODO(api-write-scope-compat): Remove legacy org:write support once public
     # cron monitor clients have migrated to alerts:write.
-    legacy_alert_mutation_scope_map = {"POST": ("org:write",)}
+    legacy_alert_mutation_scope_map = {
+        "POST": ("org:write", "org:admin"),
+        "PUT": ("org:write", "org:admin"),
+    }
     permission_classes = (OrganizationAlertRulePermission,)
 
     @extend_schema(
@@ -329,6 +336,9 @@ class OrganizationMonitorIndexEndpoint(OrganizationAlertRuleBaseEndpoint):
             return self.respond(validator.errors, status=400)
 
         result = dict(validator.validated_data)
+        monitor_edit_scopes = ALERT_MUTATION_SCOPES | frozenset(
+            get_legacy_alert_mutation_scopes(self, request.method)
+        )
 
         projects = self.get_projects(request, organization, include_all_accessible=True)
         project_ids = [project.id for project in projects]
@@ -338,7 +348,7 @@ class OrganizationMonitorIndexEndpoint(OrganizationAlertRuleBaseEndpoint):
         projects_by_id = Project.objects.in_bulk({monitor.project_id for monitor in monitors})
         if not all(
             project is not None
-            and request.access.has_any_project_scope(project, ALERT_MUTATION_SCOPES)
+            and request.access.has_any_project_scope(project, monitor_edit_scopes)
             for project in (projects_by_id.get(monitor.project_id) for monitor in monitors)
         ):
             return self.respond(status=403)

--- a/src/sentry/monitors/endpoints/organization_monitor_index.py
+++ b/src/sentry/monitors/endpoints/organization_monitor_index.py
@@ -94,8 +94,8 @@ class OrganizationMonitorIndexEndpoint(OrganizationAlertRuleBaseEndpoint):
     # TODO(api-write-scope-compat): Remove legacy org:write support once public
     # cron monitor clients have migrated to alerts:write.
     legacy_alert_mutation_scope_map = {
-        "POST": ("org:write", "org:admin"),
-        "PUT": ("org:write", "org:admin"),
+        "POST": ("org:write", "alerts:write"),
+        "PUT": ("org:write", "alerts:write"),
     }
     permission_classes = (OrganizationAlertRulePermission,)
 

--- a/src/sentry/monitors/validators.py
+++ b/src/sentry/monitors/validators.py
@@ -74,7 +74,9 @@ IntervalNames = Literal["year", "month", "week", "day", "hour", "minute"]
 INTERVAL_NAMES = ("year", "month", "week", "day", "hour", "minute")
 
 CRONTAB_WHITESPACE = re.compile(r"\s+")
-MONITOR_PROJECT_SCOPES = ("project:read", "org:write", "org:admin", "alerts:write")
+# TODO(api-write-scope-compat): Remove legacy org:write support once public
+# cron monitor clients have migrated to alerts:write.
+MONITOR_PROJECT_SCOPES = ("project:read", "org:write", "alerts:write")
 
 # XXX(dcramer): @reboot is not supported (as it cannot be)
 NONSTANDARD_CRONTAB_SCHEDULES = {

--- a/src/sentry/monitors/validators.py
+++ b/src/sentry/monitors/validators.py
@@ -14,6 +14,7 @@ from rest_framework import serializers
 from rest_framework.fields import empty
 
 from sentry import audit_log, quotas
+from sentry.api.bases.organization import LEGACY_ALERT_MUTATION_PROJECT_SCOPES
 from sentry.api.fields.actor import OwnerActorField
 from sentry.api.fields.empty_integer import EmptyIntegerField
 from sentry.api.fields.sentry_slug import SentrySerializerSlugField
@@ -74,9 +75,6 @@ IntervalNames = Literal["year", "month", "week", "day", "hour", "minute"]
 INTERVAL_NAMES = ("year", "month", "week", "day", "hour", "minute")
 
 CRONTAB_WHITESPACE = re.compile(r"\s+")
-# TODO(api-write-scope-compat): Remove legacy org:write support once public
-# cron monitor clients have migrated to alerts:write.
-MONITOR_PROJECT_SCOPES = ("project:read", "org:write", "alerts:write")
 
 # XXX(dcramer): @reboot is not supported (as it cannot be)
 NONSTANDARD_CRONTAB_SCHEDULES = {
@@ -315,7 +313,7 @@ class ConfigValidator(serializers.Serializer):
 @extend_schema_serializer(exclude_fields=["alert_rule"])
 class MonitorValidator(CamelSnakeSerializer):
     project = ProjectField(
-        scope=MONITOR_PROJECT_SCOPES,
+        scope=LEGACY_ALERT_MUTATION_PROJECT_SCOPES,
         required=True,
         help_text="The project slug to associate the monitor to.",
     )

--- a/src/sentry/monitors/validators.py
+++ b/src/sentry/monitors/validators.py
@@ -74,6 +74,7 @@ IntervalNames = Literal["year", "month", "week", "day", "hour", "minute"]
 INTERVAL_NAMES = ("year", "month", "week", "day", "hour", "minute")
 
 CRONTAB_WHITESPACE = re.compile(r"\s+")
+MONITOR_PROJECT_SCOPES = ("project:read", "org:write", "org:admin", "alerts:write")
 
 # XXX(dcramer): @reboot is not supported (as it cannot be)
 NONSTANDARD_CRONTAB_SCHEDULES = {
@@ -312,7 +313,7 @@ class ConfigValidator(serializers.Serializer):
 @extend_schema_serializer(exclude_fields=["alert_rule"])
 class MonitorValidator(CamelSnakeSerializer):
     project = ProjectField(
-        scope="project:read",
+        scope=MONITOR_PROJECT_SCOPES,
         required=True,
         help_text="The project slug to associate the monitor to.",
     )

--- a/src/sentry/notifications/api/endpoints/notification_actions_index.py
+++ b/src/sentry/notifications/api/endpoints/notification_actions_index.py
@@ -30,6 +30,11 @@ logger = logging.getLogger(__name__)
 
 
 class NotificationActionsPermission(OrganizationPermission):
+    readonly_mutation_scope_exceptions = {
+        "POST": "Notification action writes also rely on project-scoped checks; cleanup is deferred.",
+        "PUT": "Notification action writes also rely on project-scoped checks; cleanup is deferred.",
+        "DELETE": "Notification action writes also rely on project-scoped checks; cleanup is deferred.",
+    }
     scope_map = {
         "GET": ["org:read", "org:write", "org:admin"],
         "POST": ["org:read", "org:write", "org:admin"],

--- a/src/sentry/preprod/api/bases/preprod_artifact_endpoint.py
+++ b/src/sentry/preprod/api/bases/preprod_artifact_endpoint.py
@@ -33,6 +33,10 @@ class BasePreprodArtifactResourceDoesNotExist(APIException):
 
 # This is not a general permission. It specifically for triggering comparisons.
 class ProjectPreprodArtifactPermission(OrganizationEventPermission):
+    readonly_mutation_scope_exceptions = {
+        "POST": "Preprod comparison triggers preserve read-only token access for now.",
+        "PUT": "Preprod comparison triggers preserve read-only token access for now.",
+    }
     scope_map = {
         "GET": ["event:read", "event:write", "event:admin"],
         # Some simple actions, like triggering comparisons, should be allowed

--- a/src/sentry/replays/endpoints/project_replay_details.py
+++ b/src/sentry/replays/endpoints/project_replay_details.py
@@ -23,7 +23,7 @@ class ReplayDetailsPermission(ProjectPermission):
         "GET": ["project:read"],
         "POST": ["project:write"],
         "PUT": ["project:write"],
-        "DELETE": ["event:write"],
+        "DELETE": ["project:write"],
     }
 
 

--- a/src/sentry/replays/endpoints/project_replay_details.py
+++ b/src/sentry/replays/endpoints/project_replay_details.py
@@ -20,10 +20,10 @@ from sentry.replays.usecases.reader import has_archived_segment
 
 class ReplayDetailsPermission(ProjectPermission):
     scope_map = {
-        "GET": ["project:read", "project:write", "project:admin"],
-        "POST": ["project:write", "project:admin"],
-        "PUT": ["project:write", "project:admin"],
-        "DELETE": ["project:read", "project:write", "project:admin"],
+        "GET": ["project:read"],
+        "POST": ["project:write"],
+        "PUT": ["project:write"],
+        "DELETE": ["event:write"],
     }
 
 

--- a/src/sentry/replays/endpoints/project_replay_details.py
+++ b/src/sentry/replays/endpoints/project_replay_details.py
@@ -23,7 +23,7 @@ class ReplayDetailsPermission(ProjectPermission):
         "GET": ["project:read", "project:write", "project:admin"],
         "POST": ["project:write", "project:admin"],
         "PUT": ["project:write", "project:admin"],
-        "DELETE": ["project:write", "project:admin"],
+        "DELETE": ["event:write", "event:admin"],
     }
 
 

--- a/src/sentry/replays/endpoints/project_replay_details.py
+++ b/src/sentry/replays/endpoints/project_replay_details.py
@@ -23,7 +23,7 @@ class ReplayDetailsPermission(ProjectPermission):
         "GET": ["project:read", "project:write", "project:admin"],
         "POST": ["project:write", "project:admin"],
         "PUT": ["project:write", "project:admin"],
-        "DELETE": ["event:admin"],
+        "DELETE": ["project:read", "project:write", "project:admin"],
     }
 
 

--- a/src/sentry/replays/endpoints/project_replay_details.py
+++ b/src/sentry/replays/endpoints/project_replay_details.py
@@ -23,7 +23,7 @@ class ReplayDetailsPermission(ProjectPermission):
         "GET": ["project:read", "project:write", "project:admin"],
         "POST": ["project:write", "project:admin"],
         "PUT": ["project:write", "project:admin"],
-        "DELETE": ["event:write", "event:admin"],
+        "DELETE": ["event:admin"],
     }
 
 

--- a/src/sentry/replays/endpoints/project_replay_details.py
+++ b/src/sentry/replays/endpoints/project_replay_details.py
@@ -20,10 +20,10 @@ from sentry.replays.usecases.reader import has_archived_segment
 
 class ReplayDetailsPermission(ProjectPermission):
     scope_map = {
-        "GET": ["project:read"],
-        "POST": ["project:write"],
-        "PUT": ["project:write"],
-        "DELETE": ["project:write"],
+        "GET": ["project:read", "project:write", "project:admin"],
+        "POST": ["project:write", "project:admin"],
+        "PUT": ["project:write", "project:admin"],
+        "DELETE": ["project:write", "project:admin"],
     }
 
 

--- a/src/sentry/replays/endpoints/project_replay_details.py
+++ b/src/sentry/replays/endpoints/project_replay_details.py
@@ -25,6 +25,12 @@ class ReplayDetailsPermission(ProjectPermission):
         "PUT": ["project:write", "project:admin"],
         "DELETE": ["project:read", "project:write", "project:admin"],
     }
+    readonly_mutation_scope_exceptions = {
+        "DELETE": (
+            "Replay deletion is a public API and has historically allowed project:read for "
+            "compatible replay-managing clients, so tightening it would be user-impacting."
+        ),
+    }
 
 
 @cell_silo_endpoint

--- a/src/sentry/replays/endpoints/project_replay_details.py
+++ b/src/sentry/replays/endpoints/project_replay_details.py
@@ -23,13 +23,7 @@ class ReplayDetailsPermission(ProjectPermission):
         "GET": ["project:read", "project:write", "project:admin"],
         "POST": ["project:write", "project:admin"],
         "PUT": ["project:write", "project:admin"],
-        "DELETE": ["project:read", "project:write", "project:admin"],
-    }
-    readonly_mutation_scope_exceptions = {
-        "DELETE": (
-            "Replay deletion is a public API and has historically allowed project:read for "
-            "compatible replay-managing clients, so tightening it would be user-impacting."
-        ),
+        "DELETE": ["event:admin"],
     }
 
 

--- a/src/sentry/replays/endpoints/project_replay_summary.py
+++ b/src/sentry/replays/endpoints/project_replay_summary.py
@@ -38,8 +38,8 @@ SEER_POLL_STATE_ENDPOINT_PATH = "/v1/automation/summarize/replay/breadcrumbs/sta
 
 class ReplaySummaryPermission(ProjectPermission):
     scope_map = {
-        "GET": ["event:read", "event:write", "event:admin"],
-        "POST": ["event:read", "event:write", "event:admin"],
+        "GET": ["event:read"],
+        "POST": ["event:write"],
         "PUT": [],
         "DELETE": [],
     }

--- a/src/sentry/replays/endpoints/project_replay_summary.py
+++ b/src/sentry/replays/endpoints/project_replay_summary.py
@@ -39,7 +39,7 @@ SEER_POLL_STATE_ENDPOINT_PATH = "/v1/automation/summarize/replay/breadcrumbs/sta
 class ReplaySummaryPermission(ProjectPermission):
     scope_map = {
         "GET": ["event:read", "event:write", "event:admin"],
-        "POST": ["event:write", "event:admin"],
+        "POST": ["event:read", "event:write", "event:admin"],
         "PUT": [],
         "DELETE": [],
     }
@@ -51,6 +51,13 @@ class ProjectReplaySummaryEndpoint(ProjectReplayEndpoint):
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
         "POST": ApiPublishStatus.EXPERIMENTAL,
+    }
+    readonly_mutation_scope_exceptions = {
+        "POST": (
+            "POST starts replay-summary generation but only derives summary data from existing "
+            "replay/event data. It intentionally follows replay read access instead of requiring "
+            "a separate write capability."
+        )
     }
     permission_classes = (ReplaySummaryPermission,)
 

--- a/src/sentry/replays/endpoints/project_replay_summary.py
+++ b/src/sentry/replays/endpoints/project_replay_summary.py
@@ -38,8 +38,8 @@ SEER_POLL_STATE_ENDPOINT_PATH = "/v1/automation/summarize/replay/breadcrumbs/sta
 
 class ReplaySummaryPermission(ProjectPermission):
     scope_map = {
-        "GET": ["event:read"],
-        "POST": ["event:write"],
+        "GET": ["event:read", "event:write", "event:admin"],
+        "POST": ["event:write", "event:admin"],
         "PUT": [],
         "DELETE": [],
     }

--- a/src/sentry/seer/endpoints/issue_view_title_generate.py
+++ b/src/sentry/seer/endpoints/issue_view_title_generate.py
@@ -29,6 +29,9 @@ MAX_QUERY_LENGTH = 500
 
 
 class IssueViewTitleGeneratePermission(OrganizationPermission):
+    readonly_mutation_scope_exceptions = {
+        "POST": "Issue title generation is a read-like POST helper and needs separate cleanup.",
+    }
     scope_map = {
         "POST": ["org:read"],
     }

--- a/src/sentry/seer/endpoints/organization_events_anomalies.py
+++ b/src/sentry/seer/endpoints/organization_events_anomalies.py
@@ -36,6 +36,11 @@ class OrganizationEventsAnomaliesEndpoint(OrganizationEventsEndpointBase):
         "POST": ApiPublishStatus.EXPERIMENTAL,
     }
     allow_any_team_alert_write_fallback = True
+    # TODO(api-write-scope-compat): Remove legacy org:* support once alert
+    # authoring preview clients have migrated to alerts:write.
+    legacy_alert_mutation_scope_map = {
+        "POST": ("org:read", "org:write", "org:admin"),
+    }
     # This POST previews anomaly-detection config used while authoring metric
     # alerts/detectors, so it intentionally follows alert-write permissions.
     permission_classes = (OrganizationAlertRulePermission,)

--- a/src/sentry/seer/endpoints/organization_events_anomalies.py
+++ b/src/sentry/seer/endpoints/organization_events_anomalies.py
@@ -103,9 +103,8 @@ class OrganizationEventsAnomaliesEndpoint(OrganizationEventsEndpointBase):
             )
 
         project_id = to_valid_int_id("project_id", raw_project_id)
+
         projects = self.get_projects(request, organization, project_ids={project_id})
-        if not projects:
-            return Response({"detail": "Invalid project"}, status=400)
         if not all(
             request.access.has_any_project_scope(project, ALERT_MUTATION_SCOPES)
             for project in projects

--- a/src/sentry/seer/endpoints/organization_events_anomalies.py
+++ b/src/sentry/seer/endpoints/organization_events_anomalies.py
@@ -7,7 +7,7 @@ from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
-from sentry.api.bases.organization import ALERT_MUTATION_SCOPES, OrganizationAlertRulePermission
+from sentry.api.bases.organization import OrganizationAlertRulePermission
 from sentry.api.bases.organization_events import OrganizationEventsEndpointBase
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers.base import serialize
@@ -115,13 +115,7 @@ class OrganizationEventsAnomaliesEndpoint(OrganizationEventsEndpointBase):
             )
 
         project_id = to_valid_int_id("project_id", raw_project_id)
-
-        projects = self.get_projects(request, organization, project_ids={project_id})
-        if not all(
-            request.access.has_any_project_scope(project, ALERT_MUTATION_SCOPES)
-            for project in projects
-        ):
-            return Response(status=403)
+        self.get_projects(request, organization, project_ids={project_id})
 
         anomalies = get_historical_anomaly_data_from_seer_preview(
             current_data=current_data,

--- a/src/sentry/seer/endpoints/organization_events_anomalies.py
+++ b/src/sentry/seer/endpoints/organization_events_anomalies.py
@@ -1,4 +1,5 @@
 from drf_spectacular.utils import extend_schema
+from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -20,6 +21,7 @@ from sentry.apidocs.examples.organization_examples import OrganizationExamples
 from sentry.apidocs.parameters import GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.organization import Organization
+from sentry.organizations.services.organization import RpcOrganization, RpcUserOrganizationContext
 from sentry.seer.anomaly_detection.get_historical_anomalies import (
     get_historical_anomaly_data_from_seer_preview,
 )
@@ -38,16 +40,26 @@ class OrganizationEventsAnomaliesEndpoint(OrganizationEventsEndpointBase):
     # alerts/detectors, so it intentionally follows alert-write permissions.
     permission_classes = (OrganizationAlertRulePermission,)
 
-    def get_alert_mutation_projects(self, request: Request, organization: Organization):
+    def get_alert_mutation_projects(
+        self,
+        request: Request,
+        organization: Organization | RpcOrganization | RpcUserOrganizationContext,
+    ):
         raw_project_id = request.data.get("project_id")
         if raw_project_id is None:
             return None
 
         try:
             project_id = to_valid_int_id("project_id", raw_project_id)
-            return self.get_projects(request, organization, project_ids={project_id})
-        except Exception:
+        except ValidationError:
             return None
+
+        lookup_organization = (
+            organization.organization
+            if isinstance(organization, RpcUserOrganizationContext)
+            else organization
+        )
+        return self.get_projects(request, lookup_organization, project_ids={project_id})
 
     @extend_schema(
         operation_id="Identify anomalies in historical data",

--- a/src/sentry/seer/endpoints/organization_events_anomalies.py
+++ b/src/sentry/seer/endpoints/organization_events_anomalies.py
@@ -33,6 +33,8 @@ class OrganizationEventsAnomaliesEndpoint(OrganizationEventsEndpointBase):
     publish_status = {
         "POST": ApiPublishStatus.EXPERIMENTAL,
     }
+    # This POST previews anomaly-detection config used while authoring metric
+    # alerts/detectors, so it intentionally follows alert-write permissions.
     permission_classes = (OrganizationAlertRulePermission,)
 
     @extend_schema(

--- a/src/sentry/seer/endpoints/organization_events_anomalies.py
+++ b/src/sentry/seer/endpoints/organization_events_anomalies.py
@@ -6,7 +6,7 @@ from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
-from sentry.api.bases.organization import OrganizationAlertRulePermission
+from sentry.api.bases.organization import ALERT_MUTATION_SCOPES, OrganizationAlertRulePermission
 from sentry.api.bases.organization_events import OrganizationEventsEndpointBase
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers.base import serialize
@@ -33,9 +33,21 @@ class OrganizationEventsAnomaliesEndpoint(OrganizationEventsEndpointBase):
     publish_status = {
         "POST": ApiPublishStatus.EXPERIMENTAL,
     }
+    allow_any_team_alert_write_fallback = True
     # This POST previews anomaly-detection config used while authoring metric
     # alerts/detectors, so it intentionally follows alert-write permissions.
     permission_classes = (OrganizationAlertRulePermission,)
+
+    def get_alert_mutation_projects(self, request: Request, organization: Organization):
+        raw_project_id = request.data.get("project_id")
+        if raw_project_id is None:
+            return None
+
+        try:
+            project_id = to_valid_int_id("project_id", raw_project_id)
+            return self.get_projects(request, organization, project_ids={project_id})
+        except Exception:
+            return None
 
     @extend_schema(
         operation_id="Identify anomalies in historical data",
@@ -94,6 +106,11 @@ class OrganizationEventsAnomaliesEndpoint(OrganizationEventsEndpointBase):
         projects = self.get_projects(request, organization, project_ids={project_id})
         if not projects:
             return Response({"detail": "Invalid project"}, status=400)
+        if not all(
+            request.access.has_any_project_scope(project, ALERT_MUTATION_SCOPES)
+            for project in projects
+        ):
+            return Response(status=403)
 
         anomalies = get_historical_anomaly_data_from_seer_preview(
             current_data=current_data,

--- a/src/sentry/seer/endpoints/organization_events_anomalies.py
+++ b/src/sentry/seer/endpoints/organization_events_anomalies.py
@@ -36,10 +36,10 @@ class OrganizationEventsAnomaliesEndpoint(OrganizationEventsEndpointBase):
         "POST": ApiPublishStatus.EXPERIMENTAL,
     }
     allow_any_team_alert_write_fallback = True
-    # TODO(api-write-scope-compat): Remove legacy org:* support once alert
+    # TODO(api-write-scope-compat): Remove legacy org:write support once alert
     # authoring preview clients have migrated to alerts:write.
     legacy_alert_mutation_scope_map = {
-        "POST": ("org:read", "org:write", "org:admin"),
+        "POST": ("org:write", "alerts:write"),
     }
     # This POST previews anomaly-detection config used while authoring metric
     # alerts/detectors, so it intentionally follows alert-write permissions.

--- a/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
@@ -64,6 +64,9 @@ class SeerExplorerChatSerializer(serializers.Serializer):
 
 
 class OrganizationSeerExplorerChatPermission(OrganizationPermission):
+    readonly_mutation_scope_exceptions = {
+        "POST": "Seer explorer chat is a read-like POST helper and needs separate cleanup.",
+    }
     scope_map = {
         "GET": ["org:read"],
         "POST": ["org:read"],

--- a/src/sentry/seer/endpoints/organization_seer_explorer_update.py
+++ b/src/sentry/seer/endpoints/organization_seer_explorer_update.py
@@ -24,6 +24,9 @@ logger = logging.getLogger(__name__)
 
 
 class OrganizationSeerExplorerUpdatePermission(OrganizationPermission):
+    readonly_mutation_scope_exceptions = {
+        "POST": "Seer explorer updates are POST helpers and need separate contract cleanup.",
+    }
     scope_map = {
         "POST": ["org:read"],
     }

--- a/src/sentry/seer/endpoints/organization_seer_rpc.py
+++ b/src/sentry/seer/endpoints/organization_seer_rpc.py
@@ -151,6 +151,9 @@ public_project_seer_method_registry: dict[str, Callable] = {
 class SeerRpcPermission(OrganizationPermission):
     # Seer RPCs uses POST requests but is actually read only
     # So relax the permissions here.
+    readonly_mutation_scope_exceptions = {
+        "POST": "Seer RPC POST is intentionally read-only and tracked separately.",
+    }
     scope_map = {
         "POST": ["org:read", "org:write", "org:admin"],
     }

--- a/src/sentry/seer/endpoints/organization_trace_summary.py
+++ b/src/sentry/seer/endpoints/organization_trace_summary.py
@@ -21,6 +21,9 @@ logger = logging.getLogger(__name__)
 
 
 class OrganizationTraceSummaryPermission(OrganizationPermission):
+    readonly_mutation_scope_exceptions = {
+        "POST": "Trace summary is a read-like POST helper and needs separate contract cleanup.",
+    }
     scope_map = {
         "POST": ["org:read"],
     }

--- a/src/sentry/seer/endpoints/trace_explorer_ai_setup.py
+++ b/src/sentry/seer/endpoints/trace_explorer_ai_setup.py
@@ -27,6 +27,9 @@ from rest_framework.request import Request
 
 
 class OrganizationTraceExplorerAIPermission(OrganizationPermission):
+    readonly_mutation_scope_exceptions = {
+        "POST": "Trace explorer POST helpers are read-like actions and need separate cleanup.",
+    }
     scope_map = {
         "GET": ["org:read"],
         "POST": ["org:read"],

--- a/src/sentry/sentry_apps/api/bases/sentryapps.py
+++ b/src/sentry/sentry_apps/api/bases/sentryapps.py
@@ -432,6 +432,9 @@ class SentryAppInstallationBaseEndpoint(IntegrationPlatformEndpoint):
 
 
 class SentryAppInstallationExternalIssuePermission(SentryAppInstallationPermission):
+    readonly_mutation_scope_exceptions = {
+        "POST": "This endpoint creates an external issue link for an issue the caller can already read.",
+    }
     scope_map = {
         "POST": ("event:read", "event:write", "event:admin"),
         "DELETE": ("event:admin",),

--- a/src/sentry/uptime/endpoints/organization_uptime_alert_preview_check.py
+++ b/src/sentry/uptime/endpoints/organization_uptime_alert_preview_check.py
@@ -31,6 +31,11 @@ logger = logging.getLogger(__name__)
 class OrganizationUptimeAlertPreviewCheckEndpoint(OrganizationEndpoint):
     owner = ApiOwner.CRONS
     allow_any_team_alert_write_fallback = True
+    # TODO(api-write-scope-compat): Remove legacy org:* support once uptime
+    # preview clients have migrated to alerts:write.
+    legacy_alert_mutation_scope_map = {
+        "POST": ("org:read", "org:write", "org:admin"),
+    }
     # This POST previews monitor creation and validation, so it intentionally
     # uses the same permission surface as creating the alert itself.
     permission_classes = (OrganizationAlertRulePermission,)

--- a/src/sentry/uptime/endpoints/organization_uptime_alert_preview_check.py
+++ b/src/sentry/uptime/endpoints/organization_uptime_alert_preview_check.py
@@ -30,6 +30,7 @@ logger = logging.getLogger(__name__)
 @cell_silo_endpoint
 class OrganizationUptimeAlertPreviewCheckEndpoint(OrganizationEndpoint):
     owner = ApiOwner.CRONS
+    allow_any_team_alert_write_fallback = True
     # This POST previews monitor creation and validation, so it intentionally
     # uses the same permission surface as creating the alert itself.
     permission_classes = (OrganizationAlertRulePermission,)

--- a/src/sentry/uptime/endpoints/organization_uptime_alert_preview_check.py
+++ b/src/sentry/uptime/endpoints/organization_uptime_alert_preview_check.py
@@ -30,6 +30,8 @@ logger = logging.getLogger(__name__)
 @cell_silo_endpoint
 class OrganizationUptimeAlertPreviewCheckEndpoint(OrganizationEndpoint):
     owner = ApiOwner.CRONS
+    # This POST previews monitor creation and validation, so it intentionally
+    # uses the same permission surface as creating the alert itself.
     permission_classes = (OrganizationAlertRulePermission,)
 
     publish_status = {

--- a/src/sentry/uptime/endpoints/organization_uptime_alert_preview_check.py
+++ b/src/sentry/uptime/endpoints/organization_uptime_alert_preview_check.py
@@ -31,10 +31,10 @@ logger = logging.getLogger(__name__)
 class OrganizationUptimeAlertPreviewCheckEndpoint(OrganizationEndpoint):
     owner = ApiOwner.CRONS
     allow_any_team_alert_write_fallback = True
-    # TODO(api-write-scope-compat): Remove legacy org:* support once uptime
+    # TODO(api-write-scope-compat): Remove legacy org:write support once uptime
     # preview clients have migrated to alerts:write.
     legacy_alert_mutation_scope_map = {
-        "POST": ("org:read", "org:write", "org:admin"),
+        "POST": ("org:write", "alerts:write"),
     }
     # This POST previews monitor creation and validation, so it intentionally
     # uses the same permission surface as creating the alert itself.

--- a/src/sentry/uptime/endpoints/organization_uptime_assertion_suggestions.py
+++ b/src/sentry/uptime/endpoints/organization_uptime_assertion_suggestions.py
@@ -51,6 +51,11 @@ class OrganizationUptimeAssertionSuggestionsEndpoint(OrganizationEndpoint):
 
     owner = ApiOwner.CRONS
     allow_any_team_alert_write_fallback = True
+    # TODO(api-write-scope-compat): Remove legacy org:* support once uptime
+    # assertion-suggestion clients have migrated to alerts:write.
+    legacy_alert_mutation_scope_map = {
+        "POST": ("org:read", "org:write", "org:admin"),
+    }
     # This POST is part of the uptime monitor authoring flow, so it should
     # track the same alert-write permission as the monitor it helps create.
     permission_classes = (OrganizationAlertRulePermission,)

--- a/src/sentry/uptime/endpoints/organization_uptime_assertion_suggestions.py
+++ b/src/sentry/uptime/endpoints/organization_uptime_assertion_suggestions.py
@@ -50,6 +50,7 @@ class OrganizationUptimeAssertionSuggestionsEndpoint(OrganizationEndpoint):
     """
 
     owner = ApiOwner.CRONS
+    allow_any_team_alert_write_fallback = True
     # This POST is part of the uptime monitor authoring flow, so it should
     # track the same alert-write permission as the monitor it helps create.
     permission_classes = (OrganizationAlertRulePermission,)

--- a/src/sentry/uptime/endpoints/organization_uptime_assertion_suggestions.py
+++ b/src/sentry/uptime/endpoints/organization_uptime_assertion_suggestions.py
@@ -50,6 +50,8 @@ class OrganizationUptimeAssertionSuggestionsEndpoint(OrganizationEndpoint):
     """
 
     owner = ApiOwner.CRONS
+    # This POST is part of the uptime monitor authoring flow, so it should
+    # track the same alert-write permission as the monitor it helps create.
     permission_classes = (OrganizationAlertRulePermission,)
 
     publish_status = {

--- a/src/sentry/uptime/endpoints/organization_uptime_assertion_suggestions.py
+++ b/src/sentry/uptime/endpoints/organization_uptime_assertion_suggestions.py
@@ -51,10 +51,10 @@ class OrganizationUptimeAssertionSuggestionsEndpoint(OrganizationEndpoint):
 
     owner = ApiOwner.CRONS
     allow_any_team_alert_write_fallback = True
-    # TODO(api-write-scope-compat): Remove legacy org:* support once uptime
+    # TODO(api-write-scope-compat): Remove legacy org:write support once uptime
     # assertion-suggestion clients have migrated to alerts:write.
     legacy_alert_mutation_scope_map = {
-        "POST": ("org:read", "org:write", "org:admin"),
+        "POST": ("org:write", "alerts:write"),
     }
     # This POST is part of the uptime monitor authoring flow, so it should
     # track the same alert-write permission as the monitor it helps create.

--- a/src/sentry/workflow_engine/endpoints/organization_detector_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_details.py
@@ -123,6 +123,34 @@ def get_detector_validator(
 @cell_silo_endpoint
 @extend_schema(tags=["Monitors"])
 class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
+    def get_alert_mutation_projects(
+        self, request: Request, organization: Organization
+    ) -> list[Project] | None:
+        if request.method not in {"PUT", "DELETE"}:
+            return None
+
+        raw_detector_id = self.kwargs.get("detector_id")
+        if raw_detector_id is None:
+            return None
+
+        try:
+            validated_detector_id = to_valid_int_id("detector_id", raw_detector_id)
+        except ValidationError:
+            return None
+
+        detector = (
+            Detector.objects.select_related("project")
+            .filter(
+                id=validated_detector_id,
+                project__organization_id=organization.id,
+            )
+            .first()
+        )
+        if detector is None:
+            return None
+
+        return [detector.project]
+
     def convert_args(
         self, request: Request, detector_id: str, *args: Any, **kwargs: Any
     ) -> tuple[tuple[Any, ...], dict[str, Organization | Detector]]:

--- a/src/sentry/workflow_engine/endpoints/organization_detector_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_details.py
@@ -13,6 +13,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import OrganizationDetectorPermission, OrganizationEndpoint
+from sentry.api.bases.organization import get_organization_id
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
 from sentry.apidocs.constants import (
@@ -67,15 +68,6 @@ def _check_metric_detector_allowed(detector: Detector, organization: Organizatio
         return
     if not is_metric_subscription_allowed(dataset, organization):
         raise ResourceDoesNotExist
-
-
-def _get_organization_id(
-    organization: Organization | RpcOrganization | RpcUserOrganizationContext,
-) -> int:
-    if isinstance(organization, RpcUserOrganizationContext):
-        return organization.organization.id
-
-    return organization.id
 
 
 def remove_detector(request: Request, organization: Organization, detector: Detector) -> Response:
@@ -134,6 +126,8 @@ def get_detector_validator(
 @cell_silo_endpoint
 @extend_schema(tags=["Monitors"])
 class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
+    allow_any_team_alert_write_fallback = True
+
     def get_alert_mutation_projects(
         self,
         request: Request,
@@ -151,7 +145,7 @@ class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
         except ValidationError:
             return None
 
-        organization_id = _get_organization_id(organization)
+        organization_id = get_organization_id(organization)
         detector = (
             Detector.objects.select_related("project")
             .filter(

--- a/src/sentry/workflow_engine/endpoints/organization_detector_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_details.py
@@ -127,6 +127,12 @@ def get_detector_validator(
 @extend_schema(tags=["Monitors"])
 class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
     allow_any_team_alert_write_fallback = True
+    # TODO(api-write-scope-compat): Remove legacy org:* support once public
+    # detector clients have migrated to alerts:write.
+    legacy_alert_mutation_scope_map = {
+        "PUT": ("org:read", "org:write", "org:admin"),
+        "DELETE": ("org:read", "org:write", "org:admin"),
+    }
 
     def get_alert_mutation_projects(
         self,

--- a/src/sentry/workflow_engine/endpoints/organization_detector_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_details.py
@@ -32,7 +32,6 @@ from sentry.incidents.utils.types import DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
 from sentry.issues import grouptype
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.snuba.models import SnubaQuery
 from sentry.organizations.services.organization import RpcOrganization, RpcUserOrganizationContext
 from sentry.snuba.models import SnubaQuery
 from sentry.utils.audit import create_audit_entry

--- a/src/sentry/workflow_engine/endpoints/organization_detector_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_details.py
@@ -32,6 +32,8 @@ from sentry.issues import grouptype
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.snuba.models import SnubaQuery
+from sentry.organizations.services.organization import RpcOrganization, RpcUserOrganizationContext
+from sentry.snuba.models import SnubaQuery
 from sentry.utils.audit import create_audit_entry
 from sentry.workflow_engine.endpoints.serializers.detector_serializer import DetectorSerializer
 from sentry.workflow_engine.endpoints.utils.ids import to_valid_int_id
@@ -65,6 +67,15 @@ def _check_metric_detector_allowed(detector: Detector, organization: Organizatio
         return
     if not is_metric_subscription_allowed(dataset, organization):
         raise ResourceDoesNotExist
+
+
+def _get_organization_id(
+    organization: Organization | RpcOrganization | RpcUserOrganizationContext,
+) -> int:
+    if isinstance(organization, RpcUserOrganizationContext):
+        return organization.organization.id
+
+    return organization.id
 
 
 def remove_detector(request: Request, organization: Organization, detector: Detector) -> Response:
@@ -124,7 +135,9 @@ def get_detector_validator(
 @extend_schema(tags=["Monitors"])
 class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
     def get_alert_mutation_projects(
-        self, request: Request, organization: Organization
+        self,
+        request: Request,
+        organization: Organization | RpcOrganization | RpcUserOrganizationContext,
     ) -> list[Project] | None:
         if request.method not in {"PUT", "DELETE"}:
             return None
@@ -138,11 +151,12 @@ class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
         except ValidationError:
             return None
 
+        organization_id = _get_organization_id(organization)
         detector = (
             Detector.objects.select_related("project")
             .filter(
                 id=validated_detector_id,
-                project__organization_id=organization.id,
+                project__organization_id=organization_id,
             )
             .first()
         )

--- a/src/sentry/workflow_engine/endpoints/organization_detector_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_details.py
@@ -129,8 +129,8 @@ class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
     # TODO(api-write-scope-compat): Remove legacy org:* support once public
     # detector clients have migrated to alerts:write.
     legacy_alert_mutation_scope_map = {
-        "PUT": ("org:read", "org:write", "org:admin"),
-        "DELETE": ("org:read", "org:write", "org:admin"),
+        "PUT": ("org:write", "org:admin", "alerts:write"),
+        "DELETE": ("org:write", "org:admin", "alerts:write"),
     }
 
     def get_alert_mutation_projects(

--- a/src/sentry/workflow_engine/endpoints/organization_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_index.py
@@ -153,6 +153,7 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
         "DELETE": ApiPublishStatus.PUBLIC,
     }
     owner = ApiOwner.ISSUES
+    allow_any_team_alert_write_fallback = True
 
     permission_classes = (OrganizationDetectorPermission,)
 

--- a/src/sentry/workflow_engine/endpoints/organization_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_index.py
@@ -154,6 +154,12 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
     }
     owner = ApiOwner.ISSUES
     allow_any_team_alert_write_fallback = True
+    # TODO(api-write-scope-compat): Remove legacy org:* support once public
+    # detector clients have migrated to alerts:write.
+    legacy_alert_mutation_scope_map = {
+        "PUT": ("org:read", "org:write", "org:admin"),
+        "DELETE": ("org:read", "org:write", "org:admin"),
+    }
 
     permission_classes = (OrganizationDetectorPermission,)
 

--- a/src/sentry/workflow_engine/endpoints/organization_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_index.py
@@ -157,8 +157,8 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
     # TODO(api-write-scope-compat): Remove legacy org:* support once public
     # detector clients have migrated to alerts:write.
     legacy_alert_mutation_scope_map = {
-        "PUT": ("org:read", "org:write", "org:admin"),
-        "DELETE": ("org:read", "org:write", "org:admin"),
+        "PUT": ("org:write", "org:admin", "alerts:write"),
+        "DELETE": ("org:write", "org:admin", "alerts:write"),
     }
 
     permission_classes = (OrganizationDetectorPermission,)

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -27,7 +27,10 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint
-from sentry.api.bases.organization import OrganizationPermission
+from sentry.api.bases.organization import (
+    OrganizationPermission,
+    get_legacy_alert_mutation_scopes,
+)
 from sentry.api.event_search import SearchConfig, SearchFilter, SearchKey, default_config
 from sentry.api.event_search import parse_search_query as base_parse_search_query
 from sentry.api.exceptions import ResourceDoesNotExist
@@ -96,6 +99,31 @@ class OrganizationWorkflowPermission(OrganizationPermission):
         "DELETE": ["alerts:write"],
     }
 
+    def has_permission(self, request: Request, view) -> bool:
+        if super().has_permission(request, view):
+            return True
+
+        if not request.auth:
+            return False
+
+        current_scopes = request.auth.get_scopes()
+        return any(
+            scope in current_scopes
+            for scope in get_legacy_alert_mutation_scopes(view, request.method)
+        )
+
+    def has_object_permission(self, request: Request, view, organization) -> bool:
+        if super().has_object_permission(request, view, organization):
+            return True
+
+        if request.method not in {"POST", "PUT", "DELETE"}:
+            return False
+
+        return any(
+            request.access.has_scope(scope)
+            for scope in get_legacy_alert_mutation_scopes(view, request.method)
+        )
+
 
 class OrganizationWorkflowEndpoint(OrganizationEndpoint):
     permission_classes = (OrganizationWorkflowPermission,)
@@ -141,6 +169,13 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
         "DELETE": ApiPublishStatus.PUBLIC,
     }
     owner = ApiOwner.ISSUES
+    # TODO(api-write-scope-compat): Remove legacy org:* support once public
+    # workflow clients have migrated to alerts:write.
+    legacy_alert_mutation_scope_map = {
+        "POST": ("org:write", "org:admin"),
+        "PUT": ("org:write", "org:admin"),
+        "DELETE": ("org:write", "org:admin"),
+    }
     permission_classes = (OrganizationWorkflowPermission,)
 
     def filter_workflows(self, request: Request, organization: Organization) -> QuerySet[Workflow]:

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -91,9 +91,9 @@ parse_workflow_query = partial(base_parse_search_query, config=workflow_search_c
 class OrganizationWorkflowPermission(OrganizationPermission):
     scope_map = {
         "GET": ["org:read", "org:write", "org:admin", "alerts:read"],
-        "POST": ["org:write", "org:admin", "alerts:write"],
-        "PUT": ["org:write", "org:admin", "alerts:write"],
-        "DELETE": ["org:write", "org:admin", "alerts:write"],
+        "POST": ["alerts:write"],
+        "PUT": ["alerts:write"],
+        "DELETE": ["alerts:write"],
     }
 
 

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -21,6 +21,7 @@ from rest_framework import serializers, status
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from sentry import audit_log
 from sentry.api.api_owners import ApiOwner
@@ -52,6 +53,7 @@ from sentry.deletions.models.scheduleddeletion import CellScheduledDeletion
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models.organization import Organization
 from sentry.models.project import Project
+from sentry.organizations.services.organization import RpcOrganization, RpcUserOrganizationContext
 from sentry.search.utils import parse_user_value
 from sentry.utils.audit import create_audit_entry
 from sentry.utils.dates import ensure_aware
@@ -99,7 +101,7 @@ class OrganizationWorkflowPermission(OrganizationPermission):
         "DELETE": ["alerts:write"],
     }
 
-    def has_permission(self, request: Request, view) -> bool:
+    def has_permission(self, request: Request, view: APIView) -> bool:
         if super().has_permission(request, view):
             return True
 
@@ -112,7 +114,12 @@ class OrganizationWorkflowPermission(OrganizationPermission):
             for scope in get_legacy_alert_mutation_scopes(view, request.method)
         )
 
-    def has_object_permission(self, request: Request, view, organization) -> bool:
+    def has_object_permission(
+        self,
+        request: Request,
+        view: APIView,
+        organization: Organization | RpcOrganization | RpcUserOrganizationContext,
+    ) -> bool:
         if super().has_object_permission(request, view, organization):
             return True
 

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -21,7 +21,6 @@ from rest_framework import serializers, status
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.views import APIView
 
 from sentry import audit_log
 from sentry.api.api_owners import ApiOwner
@@ -29,8 +28,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import OrganizationEndpoint
 from sentry.api.bases.organization import (
-    OrganizationPermission,
-    get_legacy_alert_mutation_scopes,
+    OrganizationAlertingMutationPermission,
 )
 from sentry.api.event_search import SearchConfig, SearchFilter, SearchKey, default_config
 from sentry.api.event_search import parse_search_query as base_parse_search_query
@@ -53,7 +51,6 @@ from sentry.deletions.models.scheduleddeletion import CellScheduledDeletion
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.organizations.services.organization import RpcOrganization, RpcUserOrganizationContext
 from sentry.search.utils import parse_user_value
 from sentry.utils.audit import create_audit_entry
 from sentry.utils.dates import ensure_aware
@@ -93,43 +90,8 @@ workflow_search_config = SearchConfig.create_from(
 parse_workflow_query = partial(base_parse_search_query, config=workflow_search_config)
 
 
-class OrganizationWorkflowPermission(OrganizationPermission):
-    scope_map = {
-        "GET": ["org:read", "org:write", "org:admin", "alerts:read"],
-        "POST": ["alerts:write"],
-        "PUT": ["alerts:write"],
-        "DELETE": ["alerts:write"],
-    }
-
-    def has_permission(self, request: Request, view: APIView) -> bool:
-        if super().has_permission(request, view):
-            return True
-
-        if not request.auth:
-            return False
-
-        current_scopes = request.auth.get_scopes()
-        return any(
-            scope in current_scopes
-            for scope in get_legacy_alert_mutation_scopes(view, request.method)
-        )
-
-    def has_object_permission(
-        self,
-        request: Request,
-        view: APIView,
-        organization: Organization | RpcOrganization | RpcUserOrganizationContext,
-    ) -> bool:
-        if super().has_object_permission(request, view, organization):
-            return True
-
-        if request.method not in {"POST", "PUT", "DELETE"}:
-            return False
-
-        return any(
-            request.access.has_scope(scope)
-            for scope in get_legacy_alert_mutation_scopes(view, request.method)
-        )
+class OrganizationWorkflowPermission(OrganizationAlertingMutationPermission):
+    pass
 
 
 class OrganizationWorkflowEndpoint(OrganizationEndpoint):

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -95,6 +95,12 @@ class OrganizationWorkflowPermission(OrganizationAlertingMutationPermission):
 
 
 class OrganizationWorkflowEndpoint(OrganizationEndpoint):
+    # TODO(api-write-scope-compat): Remove legacy org:* support once public
+    # workflow clients have migrated to alerts:write.
+    legacy_alert_mutation_scope_map = {
+        "PUT": ("org:write", "org:admin"),
+        "DELETE": ("org:write", "org:admin"),
+    }
     permission_classes = (OrganizationWorkflowPermission,)
 
     def convert_args(

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -98,8 +98,8 @@ class OrganizationWorkflowEndpoint(OrganizationEndpoint):
     # TODO(api-write-scope-compat): Remove legacy org:* support once public
     # workflow clients have migrated to alerts:write.
     legacy_alert_mutation_scope_map = {
-        "PUT": ("org:write", "org:admin"),
-        "DELETE": ("org:write", "org:admin"),
+        "PUT": ("org:write", "org:admin", "alerts:write"),
+        "DELETE": ("org:write", "org:admin", "alerts:write"),
     }
     permission_classes = (OrganizationWorkflowPermission,)
 
@@ -147,9 +147,9 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
     # TODO(api-write-scope-compat): Remove legacy org:* support once public
     # workflow clients have migrated to alerts:write.
     legacy_alert_mutation_scope_map = {
-        "POST": ("org:write", "org:admin"),
-        "PUT": ("org:write", "org:admin"),
-        "DELETE": ("org:write", "org:admin"),
+        "POST": ("org:write", "org:admin", "alerts:write"),
+        "PUT": ("org:write", "org:admin", "alerts:write"),
+        "DELETE": ("org:write", "org:admin", "alerts:write"),
     }
     permission_classes = (OrganizationWorkflowPermission,)
 

--- a/src/sentry/workflow_engine/endpoints/validators/utils.py
+++ b/src/sentry/workflow_engine/endpoints/validators/utils.py
@@ -26,10 +26,8 @@ from sentry.workflow_engine.models.workflow import Workflow
 
 logger = logging.getLogger(__name__)
 
-# Detector edits should use the alert-specific write scope regardless of how the
-# detector was created.
-SYSTEM_CREATED_DETECTOR_REQUIRED_SCOPES = {"alerts:write"}
-USER_CREATED_DETECTOR_REQUIRED_SCOPES = {"alerts:write"}
+SYSTEM_CREATED_DETECTOR_EDIT_SCOPES = frozenset({"org:write"})
+USER_CREATED_DETECTOR_EDIT_SCOPES = frozenset({"alerts:write"})
 
 
 def is_system_created_detector(detector: Detector) -> bool:
@@ -45,12 +43,15 @@ def is_system_created_detector(detector: Detector) -> bool:
     )
 
 
-def can_edit_system_created_detectors(request: Request, project: Project) -> bool:
-    return request.access.has_any_project_scope(project, SYSTEM_CREATED_DETECTOR_REQUIRED_SCOPES)
+def _can_edit_project_detectors(request: Request, project: Project, scopes: frozenset[str]) -> bool:
+    return request.access.has_any_project_scope(project, scopes)
 
 
-def can_edit_user_created_detectors(request: Request, project: Project) -> bool:
-    return request.access.has_any_project_scope(project, USER_CREATED_DETECTOR_REQUIRED_SCOPES)
+def _get_detector_edit_scopes(detector: Detector) -> frozenset[str]:
+    if is_system_created_detector(detector):
+        return SYSTEM_CREATED_DETECTOR_EDIT_SCOPES
+
+    return USER_CREATED_DETECTOR_EDIT_SCOPES
 
 
 def can_edit_detectors(detectors: QuerySet[Detector], request: Request) -> bool:
@@ -58,17 +59,16 @@ def can_edit_detectors(detectors: QuerySet[Detector], request: Request) -> bool:
     Determine if the requesting user has access to edit the given detectors.
     """
     required_scopes = (
-        SYSTEM_CREATED_DETECTOR_REQUIRED_SCOPES
+        SYSTEM_CREATED_DETECTOR_EDIT_SCOPES
         if any(is_system_created_detector(detector) for detector in detectors)
-        else USER_CREATED_DETECTOR_REQUIRED_SCOPES
+        else USER_CREATED_DETECTOR_EDIT_SCOPES
     )
-
     projects = Project.objects.filter(
         id__in=detectors.values_list("project_id", flat=True).distinct()
     )
 
     return all(
-        request.access.has_any_project_scope(project, required_scopes) for project in projects
+        _can_edit_project_detectors(request, project, required_scopes) for project in projects
     )
 
 
@@ -76,12 +76,9 @@ def can_edit_detector(detector: Detector, request: Request) -> bool:
     """
     Determine if the requesting user has alert-write access to edit the detector.
     """
-    if is_system_created_detector(detector) and not can_edit_system_created_detectors(
-        request, detector.project
-    ):
-        return False
-
-    return can_edit_user_created_detectors(request, detector.project)
+    return _can_edit_project_detectors(
+        request, detector.project, _get_detector_edit_scopes(detector)
+    )
 
 
 def can_delete_detectors(detectors: QuerySet[Detector], request: Request) -> bool:
@@ -95,7 +92,10 @@ def can_delete_detectors(detectors: QuerySet[Detector], request: Request) -> boo
     projects = Project.objects.filter(
         id__in=detectors.values_list("project_id", flat=True).distinct()
     )
-    return all(can_edit_user_created_detectors(request, project) for project in projects)
+    return all(
+        _can_edit_project_detectors(request, project, USER_CREATED_DETECTOR_EDIT_SCOPES)
+        for project in projects
+    )
 
 
 def can_delete_detector(detector: Detector, request: Request) -> bool:
@@ -106,7 +106,7 @@ def can_delete_detector(detector: Detector, request: Request) -> bool:
     if is_system_created_detector(detector):
         return False
 
-    return can_edit_user_created_detectors(request, detector.project)
+    return _can_edit_project_detectors(request, detector.project, USER_CREATED_DETECTOR_EDIT_SCOPES)
 
 
 def can_edit_detector_workflow_connections(detector: Detector, request: Request) -> bool:
@@ -114,9 +114,7 @@ def can_edit_detector_workflow_connections(detector: Detector, request: Request)
     Anyone with alert write access to the project can connect/disconnect detectors of any type,
     which is slightly different from full edit access which differs by detector type.
     """
-    return request.access.has_any_project_scope(
-        detector.project, USER_CREATED_DETECTOR_REQUIRED_SCOPES
-    )
+    return _can_edit_project_detectors(request, detector.project, USER_CREATED_DETECTOR_EDIT_SCOPES)
 
 
 def validate_detectors_exist_and_have_permissions(

--- a/src/sentry/workflow_engine/endpoints/validators/utils.py
+++ b/src/sentry/workflow_engine/endpoints/validators/utils.py
@@ -26,9 +26,10 @@ from sentry.workflow_engine.models.workflow import Workflow
 
 logger = logging.getLogger(__name__)
 
-# Only those with organization write permissions can edit system-created detectors (e.g. error detectors).
-SYSTEM_CREATED_DETECTOR_REQUIRED_SCOPES = {"org:write"}
-USER_CREATED_DETECTOR_REQUIRED_SCOPES = {"org:write", "alerts:write"}
+# Detector edits should use the alert-specific write scope regardless of how the
+# detector was created.
+SYSTEM_CREATED_DETECTOR_REQUIRED_SCOPES = {"alerts:write"}
+USER_CREATED_DETECTOR_REQUIRED_SCOPES = {"alerts:write"}
 
 
 def is_system_created_detector(detector: Detector) -> bool:
@@ -55,8 +56,6 @@ def can_edit_user_created_detectors(request: Request, project: Project) -> bool:
 def can_edit_detectors(detectors: QuerySet[Detector], request: Request) -> bool:
     """
     Determine if the requesting user has access to edit the given detectors.
-    System created detectors lock edit access to org:write, while user created detectors
-    are more permissive.
     """
     required_scopes = (
         SYSTEM_CREATED_DETECTOR_REQUIRED_SCOPES
@@ -75,9 +74,7 @@ def can_edit_detectors(detectors: QuerySet[Detector], request: Request) -> bool:
 
 def can_edit_detector(detector: Detector, request: Request) -> bool:
     """
-    Determine if the requesting user has access to detector edit. If the request does not have the "alerts:write"
-    permission, then we must verify that the user is a team admin with "alerts:write" access to the project(s)
-    in their request.
+    Determine if the requesting user has alert-write access to edit the detector.
     """
     if is_system_created_detector(detector) and not can_edit_system_created_detectors(
         request, detector.project

--- a/src/sentry/workflow_engine/endpoints/validators/utils.py
+++ b/src/sentry/workflow_engine/endpoints/validators/utils.py
@@ -27,7 +27,10 @@ from sentry.workflow_engine.models.workflow import Workflow
 logger = logging.getLogger(__name__)
 
 SYSTEM_CREATED_DETECTOR_EDIT_SCOPES = frozenset({"org:write"})
-USER_CREATED_DETECTOR_EDIT_SCOPES = frozenset({"alerts:write"})
+# TODO(api-write-scope-compat): Remove legacy org:write support for
+# user-created detector edits once public detector clients have migrated to
+# alerts:write.
+USER_CREATED_DETECTOR_EDIT_SCOPES = frozenset({"org:write", "alerts:write"})
 
 
 def is_system_created_detector(detector: Detector) -> bool:

--- a/src/sentry/workflow_engine/endpoints/validators/utils.py
+++ b/src/sentry/workflow_engine/endpoints/validators/utils.py
@@ -26,10 +26,9 @@ from sentry.workflow_engine.models.workflow import Workflow
 
 logger = logging.getLogger(__name__)
 
-SYSTEM_CREATED_DETECTOR_EDIT_SCOPES = frozenset({"org:write"})
 # TODO(api-write-scope-compat): Remove legacy org:write support for
-# user-created detector edits once public detector clients have migrated to
-# alerts:write.
+# detector edits once public detector clients have migrated to alerts:write.
+SYSTEM_CREATED_DETECTOR_EDIT_SCOPES = frozenset({"org:write", "alerts:write"})
 USER_CREATED_DETECTOR_EDIT_SCOPES = frozenset({"org:write", "alerts:write"})
 
 

--- a/tests/sentry/api/test_permissions.py
+++ b/tests/sentry/api/test_permissions.py
@@ -1,5 +1,11 @@
+from collections.abc import Generator
+
+from django.test import SimpleTestCase
+from django.urls import URLPattern, URLResolver
+from django.urls.resolvers import get_resolver
 from rest_framework.views import APIView
 
+from sentry.api.base import Endpoint
 from sentry.api.permissions import (
     DemoSafePermission,
     DisallowImpersonatedTokenCreation,
@@ -8,10 +14,34 @@ from sentry.api.permissions import (
     SuperuserOrStaffFeatureFlaggedPermission,
     SuperuserPermission,
 )
+from sentry.conf.server import SENTRY_READONLY_SCOPES
 from sentry.demo_mode.utils import READONLY_SCOPES
 from sentry.organizations.services.organization import organization_service
 from sentry.testutils.cases import DRFPermissionTestCase
 from sentry.testutils.helpers.options import override_options
+from sentry.testutils.silo import no_silo_test
+
+MUTATION_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+
+
+def _iter_endpoint_view_classes(urlpatterns, base: str = "") -> Generator[type[Endpoint]]:
+    for pattern in urlpatterns:
+        if isinstance(pattern, URLResolver):
+            yield from _iter_endpoint_view_classes(
+                pattern.url_patterns, base + str(pattern.pattern)
+            )
+        elif isinstance(pattern, URLPattern):
+            callback = pattern.callback
+            if hasattr(callback, "view_class") and issubclass(callback.view_class, Endpoint):
+                yield callback.view_class
+
+
+def _get_class_path(cls: type[object]) -> str:
+    return f"{cls.__module__}.{cls.__name__}"
+
+
+def _get_readonly_mutation_scope_exceptions(cls: type[object]) -> dict[str, str]:
+    return getattr(cls, "readonly_mutation_scope_exceptions", {}) or {}
 
 
 class PermissionsTest(DRFPermissionTestCase):
@@ -223,3 +253,62 @@ class DemoSafePermissionsTest(DRFPermissionTestCase):
             )
 
             assert readonly_rpc_context.member.scopes == list(self.org_member_scopes)
+
+
+@no_silo_test
+class PublishedMutationScopeTest(SimpleTestCase):
+    def test_readonly_mutation_scope_exceptions_are_notes(self) -> None:
+        for view_cls in sorted(
+            set(_iter_endpoint_view_classes(get_resolver().url_patterns)), key=_get_class_path
+        ):
+            for cls in (view_cls, *getattr(view_cls, "permission_classes", ())):
+                exceptions = getattr(cls, "readonly_mutation_scope_exceptions", None)
+                if exceptions is None:
+                    continue
+
+                assert isinstance(exceptions, dict), (
+                    f"{_get_class_path(cls)} readonly_mutation_scope_exceptions must be a dict"
+                )
+
+                for method, note in exceptions.items():
+                    assert method in MUTATION_METHODS, (
+                        f"{_get_class_path(cls)} readonly_mutation_scope_exceptions[{method!r}] "
+                        "must target a mutation method"
+                    )
+                    assert isinstance(note, str) and note.strip(), (
+                        f"{_get_class_path(cls)} readonly_mutation_scope_exceptions[{method!r}] "
+                        "must be a non-empty note"
+                    )
+
+    def test_published_mutation_endpoints_require_readonly_scope_notes(self) -> None:
+        missing_notes = []
+
+        for view_cls in sorted(
+            set(_iter_endpoint_view_classes(get_resolver().url_patterns)), key=_get_class_path
+        ):
+            publish_status = getattr(view_cls, "publish_status", {}) or {}
+            permission_classes = getattr(view_cls, "permission_classes", ()) or ()
+            view_exceptions = _get_readonly_mutation_scope_exceptions(view_cls)
+
+            for method in MUTATION_METHODS & set(publish_status):
+                for permission_cls in permission_classes:
+                    readonly_scopes = (
+                        set(getattr(permission_cls, "scope_map", {}).get(method, ()))
+                        & SENTRY_READONLY_SCOPES
+                    )
+                    if not readonly_scopes:
+                        continue
+
+                    if view_exceptions.get(method) or _get_readonly_mutation_scope_exceptions(
+                        permission_cls
+                    ).get(method):
+                        continue
+
+                    missing_notes.append(
+                        f"{_get_class_path(view_cls)} {method} accepts readonly scopes "
+                        f"{sorted(readonly_scopes)} via {_get_class_path(permission_cls)}. "
+                        "Remove the readonly scopes or add "
+                        "readonly_mutation_scope_exceptions[method] with a justification note."
+                    )
+
+        assert not missing_notes, "\n".join(missing_notes)

--- a/tests/sentry/api/test_permissions.py
+++ b/tests/sentry/api/test_permissions.py
@@ -24,12 +24,10 @@ from sentry.testutils.silo import no_silo_test
 MUTATION_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
 
 
-def _iter_endpoint_view_classes(urlpatterns, base: str = "") -> Generator[type[Endpoint]]:
+def _iter_endpoint_view_classes(urlpatterns) -> Generator[type[Endpoint]]:
     for pattern in urlpatterns:
         if isinstance(pattern, URLResolver):
-            yield from _iter_endpoint_view_classes(
-                pattern.url_patterns, base + str(pattern.pattern)
-            )
+            yield from _iter_endpoint_view_classes(pattern.url_patterns)
         elif isinstance(pattern, URLPattern):
             callback = pattern.callback
             if hasattr(callback, "view_class") and issubclass(callback.view_class, Endpoint):

--- a/tests/sentry/api/test_permissions.py
+++ b/tests/sentry/api/test_permissions.py
@@ -6,6 +6,11 @@ from django.urls.resolvers import get_resolver
 from rest_framework.views import APIView
 
 from sentry.api.base import Endpoint
+from sentry.api.bases.organization import (
+    ALERT_MUTATION_SCOPES,
+    LEGACY_ALERT_MUTATION_PROJECT_SCOPES,
+    OrganizationAlertingMutationPermission,
+)
 from sentry.api.permissions import (
     DemoSafePermission,
     DisallowImpersonatedTokenCreation,
@@ -255,6 +260,29 @@ class DemoSafePermissionsTest(DRFPermissionTestCase):
 
 @no_silo_test
 class PublishedMutationScopeTest(SimpleTestCase):
+    def test_alert_mutation_scope_constants_are_alert_specific(self) -> None:
+        assert ALERT_MUTATION_SCOPES == {"alerts:write"}
+        assert set(LEGACY_ALERT_MUTATION_PROJECT_SCOPES) & SENTRY_READONLY_SCOPES == set()
+        assert "alerts:write" in OrganizationAlertingMutationPermission.scope_map["GET"]
+
+    def test_legacy_alert_mutation_scope_maps_do_not_accept_readonly_scopes(self) -> None:
+        invalid_scopes = []
+
+        for view_cls in sorted(
+            set(_iter_endpoint_view_classes(get_resolver().url_patterns)), key=_get_class_path
+        ):
+            legacy_scope_map = getattr(view_cls, "legacy_alert_mutation_scope_map", {}) or {}
+
+            for method, scopes in legacy_scope_map.items():
+                readonly_scopes = set(scopes) & SENTRY_READONLY_SCOPES
+                if readonly_scopes:
+                    invalid_scopes.append(
+                        f"{_get_class_path(view_cls)} {method} legacy alert mutation "
+                        f"compat accepts readonly scopes {sorted(readonly_scopes)}."
+                    )
+
+        assert not invalid_scopes, "\n".join(invalid_scopes)
+
     def test_readonly_mutation_scope_exceptions_are_notes(self) -> None:
         for view_cls in sorted(
             set(_iter_endpoint_view_classes(get_resolver().url_patterns)), key=_get_class_path

--- a/tests/sentry/data_export/endpoints/test_data_export.py
+++ b/tests/sentry/data_export/endpoints/test_data_export.py
@@ -7,9 +7,12 @@ from django.urls import reverse
 from sentry.data_export.base import ExportQueryType, ExportStatus
 from sentry.data_export.models import ExportedData
 from sentry.data_export.writers import OutputMode
+from sentry.models.apitoken import ApiToken
 from sentry.search.utils import parse_datetime_string
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.silo import assume_test_silo_mode
 from sentry.utils.snuba import MAX_FIELDS
 
 
@@ -59,6 +62,10 @@ class DataExportTest(APITestCase):
                 payload["query_info"].update(extras)
         return payload
 
+    def _create_token(self, scope: str) -> ApiToken:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            return ApiToken.objects.create(user=self.user, scope_list=[scope])
+
     def test_authorization(self) -> None:
         payload = self.make_payload("issue")
 
@@ -81,30 +88,30 @@ class DataExportTest(APITestCase):
         with self.feature("organizations:discover-query"):
             self.get_error_response(self.org.slug, status_code=403, **modified_payload)
 
-    def test_post_requires_event_write_scope_for_api_keys(self) -> None:
+    def test_post_requires_event_write_scope_for_tokens(self) -> None:
         payload = self.make_payload("issue")
-        api_key = self.create_api_key(organization=self.org, scope_list=["event:read"])
+        token = self._create_token("event:read")
 
         with self.feature("organizations:discover-query"):
             response = self.client.post(
                 self.url,
                 data=payload,
                 format="json",
-                HTTP_AUTHORIZATION=self.create_basic_auth_header(api_key.key),
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
             )
 
         assert response.status_code == 403
 
-    def test_post_allows_event_write_scope_for_api_keys(self) -> None:
+    def test_post_allows_event_write_scope_for_tokens(self) -> None:
         payload = self.make_payload("issue")
-        api_key = self.create_api_key(organization=self.org, scope_list=["event:write"])
+        token = self._create_token("event:write")
 
         with self.feature("organizations:discover-query"):
             response = self.client.post(
                 self.url,
                 data=payload,
                 format="json",
-                HTTP_AUTHORIZATION=self.create_basic_auth_header(api_key.key),
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
             )
 
         assert response.status_code == 201

--- a/tests/sentry/data_export/endpoints/test_data_export.py
+++ b/tests/sentry/data_export/endpoints/test_data_export.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from django.urls import reverse
+
 from sentry.data_export.base import ExportQueryType, ExportStatus
 from sentry.data_export.models import ExportedData
 from sentry.data_export.writers import OutputMode
@@ -24,6 +26,7 @@ class DataExportTest(APITestCase):
         )
         self.create_member(user=self.user, organization=self.org, teams=[self.team])
         self.login_as(user=self.user)
+        self.url = reverse(self.endpoint, args=[self.org.slug])
 
     def make_payload(
         self, payload_type: str, extras: dict[str, Any] | None = None, overwrite: bool = False
@@ -77,6 +80,34 @@ class DataExportTest(APITestCase):
         # Without project permissions, the endpoint should 403
         with self.feature("organizations:discover-query"):
             self.get_error_response(self.org.slug, status_code=403, **modified_payload)
+
+    def test_post_requires_event_write_scope_for_api_keys(self) -> None:
+        payload = self.make_payload("issue")
+        api_key = self.create_api_key(organization=self.org, scope_list=["event:read"])
+
+        with self.feature("organizations:discover-query"):
+            response = self.client.post(
+                self.url,
+                data=payload,
+                format="json",
+                HTTP_AUTHORIZATION=self.create_basic_auth_header(api_key.key),
+            )
+
+        assert response.status_code == 403
+
+    def test_post_allows_event_write_scope_for_api_keys(self) -> None:
+        payload = self.make_payload("issue")
+        api_key = self.create_api_key(organization=self.org, scope_list=["event:write"])
+
+        with self.feature("organizations:discover-query"):
+            response = self.client.post(
+                self.url,
+                data=payload,
+                format="json",
+                HTTP_AUTHORIZATION=self.create_basic_auth_header(api_key.key),
+            )
+
+        assert response.status_code == 201
 
     def test_new_export(self) -> None:
         """

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -88,9 +88,9 @@ class AlertRuleDetailsBase(AlertRuleBase):
 
     endpoint = "sentry-api-0-organization-alert-rule-details"
 
-    def _create_token(self, scope: str) -> ApiToken:
+    def _create_token(self, scope: str, user=None) -> ApiToken:
         with assume_test_silo_mode(SiloMode.CONTROL):
-            return ApiToken.objects.create(user=self.user, scope_list=[scope])
+            return ApiToken.objects.create(user=user or self.user, scope_list=[scope])
 
     @patch(
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
@@ -1085,6 +1085,35 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         assert response.status_code == 200
         self.alert_rule.refresh_from_db()
         assert self.alert_rule.name == self.valid_params["name"]
+
+    def test_update_denies_alerts_write_scope_for_other_team_projects(self) -> None:
+        team_admin_user = self.create_user()
+        self.create_member(
+            user=team_admin_user,
+            organization=self.organization,
+            role="member",
+            team_roles=[(self.team, "admin")],
+        )
+
+        other_team = self.create_team(organization=self.organization, name="other-team")
+        other_project = self.create_project(
+            organization=self.organization, teams=[other_team], name="other-project"
+        )
+        other_alert_rule = self.new_alert_rule(
+            data={**deepcopy(self.alert_rule_dict), "projects": [other_project.slug]}
+        )
+
+        token = self._create_token("alerts:write", user=team_admin_user)
+
+        with self.feature("organizations:incidents"):
+            response = self.client.put(
+                reverse(self.endpoint, args=[self.organization.slug, other_alert_rule.id]),
+                data={**self.valid_params, "projects": [other_project.slug]},
+                format="json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 403
 
     def test_simple(self) -> None:
         self.create_member(
@@ -2712,6 +2741,33 @@ class AlertRuleDetailsSentryAppPutEndpointTest(AlertRuleDetailsBase):
 
 class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase):
     method = "delete"
+
+    def test_delete_denies_alerts_write_scope_for_other_team_projects(self) -> None:
+        team_admin_user = self.create_user()
+        self.create_member(
+            user=team_admin_user,
+            organization=self.organization,
+            role="member",
+            team_roles=[(self.team, "admin")],
+        )
+
+        other_team = self.create_team(organization=self.organization, name="other-team")
+        other_project = self.create_project(
+            organization=self.organization, teams=[other_team], name="other-project"
+        )
+        other_alert_rule = self.new_alert_rule(
+            data={**deepcopy(self.alert_rule_dict), "projects": [other_project.slug]}
+        )
+
+        token = self._create_token("alerts:write", user=team_admin_user)
+
+        with self.feature("organizations:incidents"):
+            response = self.client.delete(
+                reverse(self.endpoint, args=[self.organization.slug, other_alert_rule.id]),
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 403
 
     def test_simple(self) -> None:
         self.create_member(

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -1053,6 +1053,9 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
     method = "put"
 
     def test_team_admin_can_update_with_project_scoped_alerts_write(self) -> None:
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
         team_admin_user = self.create_user()
         self.create_member(
             user=team_admin_user,
@@ -1090,6 +1093,26 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
 
         assert response.status_code == 403
 
+    # TODO(api-write-scope-compat): Remove this legacy org:write coverage once
+    # public metric alert clients have migrated to alerts:write.
+    def test_update_allows_legacy_org_write_scope_for_tokens(self) -> None:
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+        token = self._create_token("org:write")
+
+        with self.feature("organizations:incidents"):
+            response = self.client.put(
+                reverse(self.endpoint, args=[self.organization.slug, self.alert_rule.id]),
+                data=self.valid_params,
+                format="json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 200
+        self.alert_rule.refresh_from_db()
+        assert self.alert_rule.name == self.valid_params["name"]
+
     def test_update_allows_alerts_write_scope_for_tokens(self) -> None:
         self.create_member(
             user=self.user, organization=self.organization, role="owner", teams=[self.team]
@@ -1109,6 +1132,9 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         assert self.alert_rule.name == self.valid_params["name"]
 
     def test_update_denies_alerts_write_scope_for_other_team_projects(self) -> None:
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
         team_admin_user = self.create_user()
         self.create_member(
             user=team_admin_user,
@@ -1116,6 +1142,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
             role="member",
             team_roles=[(self.team, "admin")],
         )
+        self.organization.update_option("sentry:alerts_member_write", False)
 
         other_team = self.create_team(organization=self.organization, name="other-team")
         other_project = self.create_project(
@@ -2786,6 +2813,9 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase):
             self.get_success_response(self.organization.slug, fake_detector_id, status_code=204)
 
     def test_delete_denies_alerts_write_scope_for_other_team_projects(self) -> None:
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
         team_admin_user = self.create_user()
         self.create_member(
             user=team_admin_user,
@@ -2793,6 +2823,7 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase):
             role="member",
             team_roles=[(self.team, "admin")],
         )
+        self.organization.update_option("sentry:alerts_member_write", False)
 
         other_team = self.create_team(organization=self.organization, name="other-team")
         other_project = self.create_project(
@@ -2811,6 +2842,22 @@ class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase):
             )
 
         assert response.status_code == 403
+
+    # TODO(api-write-scope-compat): Remove this legacy org:write coverage once
+    # public metric alert clients have migrated to alerts:write.
+    def test_delete_allows_legacy_org_write_scope_for_tokens(self) -> None:
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+        token = self._create_token("org:write")
+
+        with self.feature("organizations:incidents"), outbox_runner():
+            response = self.client.delete(
+                reverse(self.endpoint, args=[self.organization.slug, self.alert_rule.id]),
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 204
 
     def test_simple(self) -> None:
         self.create_member(

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -1052,6 +1052,28 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
 class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
     method = "put"
 
+    def test_team_admin_can_update_with_project_scoped_alerts_write(self) -> None:
+        team_admin_user = self.create_user()
+        self.create_member(
+            user=team_admin_user,
+            organization=self.organization,
+            role="member",
+            team_roles=[(self.team, "admin")],
+        )
+        self.organization.update_option("sentry:alerts_member_write", False)
+        self.login_as(team_admin_user)
+
+        with self.feature("organizations:incidents"):
+            response = self.client.put(
+                reverse(self.endpoint, args=[self.organization.slug, self.alert_rule.id]),
+                data=self.valid_params,
+                format="json",
+            )
+
+        assert response.status_code == 200
+        self.alert_rule.refresh_from_db()
+        assert self.alert_rule.name == self.valid_params["name"]
+
     def test_update_requires_alerts_write_scope_for_tokens(self) -> None:
         self.create_member(
             user=self.user, organization=self.organization, role="owner", teams=[self.team]
@@ -2741,6 +2763,27 @@ class AlertRuleDetailsSentryAppPutEndpointTest(AlertRuleDetailsBase):
 
 class AlertRuleDetailsDeleteEndpointTest(AlertRuleDetailsBase):
     method = "delete"
+
+    def test_team_admin_can_delete_workflow_engine_detector_with_project_scoped_alerts_write(
+        self,
+    ) -> None:
+        team_admin_user = self.create_user()
+        self.create_member(
+            user=team_admin_user,
+            organization=self.organization,
+            role="member",
+            team_roles=[(self.team, "admin")],
+        )
+        self.organization.update_option("sentry:alerts_member_write", False)
+        self.login_as(team_admin_user)
+
+        detector = self.create_detector(project=self.project, type=MetricIssue.slug)
+        data_source = self.create_data_source()
+        self.create_data_source_detector(data_source, detector)
+        fake_detector_id = get_fake_id_from_object_id(detector.id)
+
+        with self.feature({"organizations:workflow-engine-rule-serializers": True}):
+            self.get_success_response(self.organization.slug, fake_detector_id, status_code=204)
 
     def test_delete_denies_alerts_write_scope_for_other_team_projects(self) -> None:
         team_admin_user = self.create_user()

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -11,6 +11,7 @@ import responses
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.test import override_settings
+from django.urls import reverse
 from httpx import HTTPError
 from rest_framework.exceptions import ErrorDetail
 from rest_framework.response import Response
@@ -45,6 +46,7 @@ from sentry.integrations.slack.tasks.find_channel_id_for_alert_rule import (
     find_channel_id_for_alert_rule,
 )
 from sentry.integrations.slack.utils.channel import SlackChannelIdData
+from sentry.models.apitoken import ApiToken
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.project import Project
@@ -85,6 +87,10 @@ class AlertRuleDetailsBase(AlertRuleBase):
     __test__ = Abstract(__module__, __qualname__)
 
     endpoint = "sentry-api-0-organization-alert-rule-details"
+
+    def _create_token(self, scope: str) -> ApiToken:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            return ApiToken.objects.create(user=self.user, scope_list=[scope])
 
     @patch(
         "sentry.seer.anomaly_detection.store_data.seer_anomaly_detection_connection_pool.urlopen"
@@ -1045,6 +1051,40 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
 
 class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
     method = "put"
+
+    def test_update_requires_alerts_write_scope_for_tokens(self) -> None:
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+        token = self._create_token("org:read")
+
+        with self.feature("organizations:incidents"):
+            response = self.client.put(
+                reverse(self.endpoint, args=[self.organization.slug, self.alert_rule.id]),
+                data=self.valid_params,
+                format="json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 403
+
+    def test_update_allows_alerts_write_scope_for_tokens(self) -> None:
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+        token = self._create_token("alerts:write")
+
+        with self.feature("organizations:incidents"):
+            response = self.client.put(
+                reverse(self.endpoint, args=[self.organization.slug, self.alert_rule.id]),
+                data=self.valid_params,
+                format="json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 200
+        self.alert_rule.refresh_from_db()
+        assert self.alert_rule.name == self.valid_params["name"]
 
     def test_simple(self) -> None:
         self.create_member(

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -447,6 +447,8 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         )
 
     def test_create_requires_alerts_write_scope_for_tokens(self) -> None:
+        team = self.create_team(organization=self.organization, members=[self.user])
+        ProjectTeam.objects.create(project=self.project, team=team)
         token = self._create_token("org:read")
 
         with self.feature(["organizations:incidents", "organizations:performance-view"]):
@@ -460,6 +462,8 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         assert response.status_code == 403
 
     def test_create_allows_alerts_write_scope_for_tokens(self) -> None:
+        team = self.create_team(organization=self.organization, members=[self.user])
+        ProjectTeam.objects.create(project=self.project, team=team)
         token = self._create_token("alerts:write")
 
         with (

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -40,6 +40,7 @@ from sentry.integrations.slack.tasks.find_channel_id_for_alert_rule import (
     find_channel_id_for_alert_rule,
 )
 from sentry.integrations.slack.utils.channel import SlackChannelIdData
+from sentry.models.apitoken import ApiToken
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.projectteam import ProjectTeam
@@ -417,6 +418,10 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         )
         self.login_as(self.user)
 
+    def _create_token(self, scope: str) -> ApiToken:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            return ApiToken.objects.create(user=self.user, scope_list=[scope])
+
     def test_simple(self) -> None:
         with (
             outbox_runner(),
@@ -440,6 +445,35 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             resp.renderer_context["request"].META["REMOTE_ADDR"]
             == list(audit_log_entry)[0].ip_address
         )
+
+    def test_create_requires_alerts_write_scope_for_tokens(self) -> None:
+        token = self._create_token("org:read")
+
+        with self.feature(["organizations:incidents", "organizations:performance-view"]):
+            response = self.client.post(
+                f"/api/0/organizations/{self.organization.slug}/alert-rules/",
+                data=self.alert_rule_dict,
+                format="json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 403
+
+    def test_create_allows_alerts_write_scope_for_tokens(self) -> None:
+        token = self._create_token("alerts:write")
+
+        with (
+            outbox_runner(),
+            self.feature(["organizations:incidents", "organizations:performance-view"]),
+        ):
+            response = self.client.post(
+                f"/api/0/organizations/{self.organization.slug}/alert-rules/",
+                data=self.alert_rule_dict,
+                format="json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 201
 
     @patch("sentry.incidents.serializers.alert_rule.are_any_projects_error_upsampled")
     def test_count_automatically_converted_to_upsampled_count_for_upsampled_projects(

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -461,6 +461,26 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
 
         assert response.status_code == 403
 
+    # TODO(api-write-scope-compat): Remove this legacy org:write coverage once
+    # public metric alert clients have migrated to alerts:write.
+    def test_create_allows_legacy_org_write_scope_for_tokens(self) -> None:
+        team = self.create_team(organization=self.organization, members=[self.user])
+        ProjectTeam.objects.create(project=self.project, team=team)
+        token = self._create_token("org:write")
+
+        with (
+            outbox_runner(),
+            self.feature(["organizations:incidents", "organizations:performance-view"]),
+        ):
+            response = self.client.post(
+                f"/api/0/organizations/{self.organization.slug}/alert-rules/",
+                data=self.alert_rule_dict,
+                format="json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 201
+
     def test_create_allows_alerts_write_scope_for_tokens(self) -> None:
         team = self.create_team(organization=self.organization, members=[self.user])
         ProjectTeam.objects.create(project=self.project, team=team)

--- a/tests/sentry/issues/endpoints/test_project_user_issue.py
+++ b/tests/sentry/issues/endpoints/test_project_user_issue.py
@@ -117,23 +117,27 @@ class ProjectUserIssueEndpointTest(APITestCase):
         assert response.status_code == 404
 
     @with_feature("organizations:performance-web-vitals-seer-suggestions")
-    def test_create_web_vitals_issue_requires_event_write_scope(self) -> None:
+    def test_create_web_vitals_issue_allows_event_read_scope(self) -> None:
         token = self._create_token("event:read")
 
-        response = self.client.post(
-            self.url,
-            data={
-                "transaction": "/test-transaction",
-                "issueType": WebVitalsGroup.slug,
-                "score": 75,
-                "value": 1000,
-                "vital": "lcp",
-            },
-            format="json",
-            HTTP_AUTHORIZATION=f"Bearer {token.token}",
-        )
+        with patch(
+            "sentry.issues.endpoints.project_user_issue.produce_occurrence_to_kafka"
+        ) as mock_produce:
+            response = self.client.post(
+                self.url,
+                data={
+                    "transaction": "/test-transaction",
+                    "issueType": WebVitalsGroup.slug,
+                    "score": 75,
+                    "value": 1000,
+                    "vital": "lcp",
+                },
+                format="json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
 
-        assert response.status_code == 403
+        assert response.status_code == 200
+        assert response.data == {"event_id": mock_produce.call_args[1]["occurrence"].event_id}
 
     @with_feature("organizations:performance-web-vitals-seer-suggestions")
     def test_create_web_vitals_issue_allows_event_write_scope(self) -> None:

--- a/tests/sentry/issues/endpoints/test_project_user_issue.py
+++ b/tests/sentry/issues/endpoints/test_project_user_issue.py
@@ -6,9 +6,11 @@ from django.urls import reverse
 
 from sentry.issues.grouptype import WebVitalsGroup
 from sentry.issues.producer import PayloadType
+from sentry.models.apitoken import ApiToken
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
-from sentry.testutils.silo import cell_silo_test
+from sentry.testutils.silo import assume_test_silo_mode, cell_silo_test
 
 
 @cell_silo_test
@@ -30,6 +32,10 @@ class ProjectUserIssueEndpointTest(APITestCase):
                 "project_id_or_slug": self.project.slug,
             },
         )
+
+    def _create_token(self, scope: str) -> ApiToken:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            return ApiToken.objects.create(user=self.user, scope_list=[scope])
 
     @with_feature("organizations:performance-web-vitals-seer-suggestions")
     def test_create_web_vitals_issue_success(self) -> None:
@@ -109,6 +115,48 @@ class ProjectUserIssueEndpointTest(APITestCase):
         )
 
         assert response.status_code == 404
+
+    @with_feature("organizations:performance-web-vitals-seer-suggestions")
+    def test_create_web_vitals_issue_requires_event_write_scope(self) -> None:
+        token = self._create_token("event:read")
+
+        response = self.client.post(
+            self.url,
+            data={
+                "transaction": "/test-transaction",
+                "issueType": WebVitalsGroup.slug,
+                "score": 75,
+                "value": 1000,
+                "vital": "lcp",
+            },
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {token.token}",
+        )
+
+        assert response.status_code == 403
+
+    @with_feature("organizations:performance-web-vitals-seer-suggestions")
+    def test_create_web_vitals_issue_allows_event_write_scope(self) -> None:
+        token = self._create_token("event:write")
+
+        with patch(
+            "sentry.issues.endpoints.project_user_issue.produce_occurrence_to_kafka"
+        ) as mock_produce:
+            response = self.client.post(
+                self.url,
+                data={
+                    "transaction": "/test-transaction",
+                    "issueType": WebVitalsGroup.slug,
+                    "score": 75,
+                    "value": 1000,
+                    "vital": "lcp",
+                },
+                format="json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 200
+        assert response.data == {"event_id": mock_produce.call_args[1]["occurrence"].event_id}
 
     @with_feature("organizations:performance-web-vitals-seer-suggestions")
     def test_missing_required_fields(self) -> None:

--- a/tests/sentry/issues/endpoints/test_project_user_issue.py
+++ b/tests/sentry/issues/endpoints/test_project_user_issue.py
@@ -117,27 +117,23 @@ class ProjectUserIssueEndpointTest(APITestCase):
         assert response.status_code == 404
 
     @with_feature("organizations:performance-web-vitals-seer-suggestions")
-    def test_create_web_vitals_issue_allows_event_read_scope(self) -> None:
+    def test_create_web_vitals_issue_denies_event_read_scope(self) -> None:
         token = self._create_token("event:read")
 
-        with patch(
-            "sentry.issues.endpoints.project_user_issue.produce_occurrence_to_kafka"
-        ) as mock_produce:
-            response = self.client.post(
-                self.url,
-                data={
-                    "transaction": "/test-transaction",
-                    "issueType": WebVitalsGroup.slug,
-                    "score": 75,
-                    "value": 1000,
-                    "vital": "lcp",
-                },
-                format="json",
-                HTTP_AUTHORIZATION=f"Bearer {token.token}",
-            )
+        response = self.client.post(
+            self.url,
+            data={
+                "transaction": "/test-transaction",
+                "issueType": WebVitalsGroup.slug,
+                "score": 75,
+                "value": 1000,
+                "vital": "lcp",
+            },
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {token.token}",
+        )
 
-        assert response.status_code == 200
-        assert response.data == {"event_id": mock_produce.call_args[1]["occurrence"].event_id}
+        assert response.status_code == 403
 
     @with_feature("organizations:performance-web-vitals-seer-suggestions")
     def test_create_web_vitals_issue_allows_event_write_scope(self) -> None:

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
@@ -1047,6 +1047,46 @@ class BulkEditOrganizationMonitorTest(MonitorTestCase):
         other_monitor.refresh_from_db()
         assert other_monitor.status == ObjectStatus.ACTIVE
 
+    # TODO(api-write-scope-compat): Remove this legacy org:write coverage once
+    # public cron monitor clients have migrated to alerts:write.
+    def test_bulk_edit_allows_org_write_scope_for_tokens(self) -> None:
+        monitor_one = self._create_monitor(slug="monitor-one")
+        token = self._create_token("org:write")
+
+        response = self.client.put(
+            reverse(self.endpoint, args=[self.organization.slug]),
+            data={"ids": [monitor_one.guid], "status": "disabled"},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {token.token}",
+        )
+
+        assert response.status_code == 200
+        monitor_one.refresh_from_db()
+        assert monitor_one.status == ObjectStatus.DISABLED
+
+    def test_team_admin_can_bulk_edit_with_project_scoped_alerts_write(self) -> None:
+        team_admin_user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=team_admin_user,
+            organization=self.organization,
+            role="member",
+            team_roles=[(self.team, "admin")],
+        )
+        self.organization.update_option("sentry:alerts_member_write", False)
+        self.login_as(team_admin_user)
+
+        monitor_one = self._create_monitor(slug="monitor-one")
+
+        response = self.get_success_response(
+            self.organization.slug,
+            ids=[monitor_one.guid],
+            status="disabled",
+        )
+
+        assert response.status_code == 200
+        monitor_one.refresh_from_db()
+        assert monitor_one.status == ObjectStatus.DISABLED
+
     @patch("sentry.quotas.backend.check_assign_seats")
     def test_enable_no_quota(self, check_assign_seats: MagicMock) -> None:
         monitor_one = self._create_monitor(slug="monitor_one", status=ObjectStatus.DISABLED)

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
@@ -888,6 +888,10 @@ class BulkEditOrganizationMonitorTest(MonitorTestCase):
         super().setUp()
         self.login_as(self.user)
 
+    def _create_token(self, scope: str, user=None) -> ApiToken:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            return ApiToken.objects.create(user=user or self.user, scope_list=[scope])
+
     def test_valid_ids(self) -> None:
         monitor_one = self._create_monitor(slug="monitor_one")
         self._create_monitor(slug="monitor_two")
@@ -980,6 +984,33 @@ class BulkEditOrganizationMonitorTest(MonitorTestCase):
         monitor_two.refresh_from_db()
         assert monitor_one.status == ObjectStatus.ACTIVE
         assert monitor_two.status == ObjectStatus.ACTIVE
+
+    def test_bulk_edit_denies_alerts_write_scope_for_other_team_projects(self) -> None:
+        team_admin_user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=team_admin_user,
+            organization=self.organization,
+            role="member",
+            team_roles=[(self.team, "admin")],
+        )
+
+        other_team = self.create_team(organization=self.organization, name="other-team")
+        other_project = self.create_project(
+            organization=self.organization, teams=[other_team], name="other-project"
+        )
+        other_monitor = self._create_monitor(project=other_project, slug="other-monitor")
+        token = self._create_token("alerts:write", user=team_admin_user)
+
+        response = self.client.put(
+            reverse(self.endpoint, args=[self.organization.slug]),
+            data={"ids": [other_monitor.guid], "status": "disabled"},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {token.token}",
+        )
+
+        assert response.status_code == 403
+        other_monitor.refresh_from_db()
+        assert other_monitor.status == ObjectStatus.ACTIVE
 
     @patch("sentry.quotas.backend.check_assign_seats")
     def test_enable_no_quota(self, check_assign_seats: MagicMock) -> None:

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
@@ -6,20 +6,24 @@ from unittest.mock import MagicMock, patch
 
 from django.conf import settings
 from django.test.utils import override_settings
+from django.urls import reverse
 from rest_framework.exceptions import ErrorDetail
 
 from sentry import audit_log
 from sentry.analytics.events.cron_monitor_created import CronMonitorCreated, FirstCronMonitorCreated
 from sentry.constants import ObjectStatus
+from sentry.models.apitoken import ApiToken
 from sentry.models.projectteam import ProjectTeam
 from sentry.models.rule import Rule, RuleSource
 from sentry.monitors.models import Monitor, MonitorStatus, ScheduleType, is_monitor_muted
 from sentry.monitors.utils import get_detector_for_monitor
 from sentry.quotas.base import SeatAssignmentResult
+from sentry.silo.base import SiloMode
 from sentry.testutils.asserts import assert_org_audit_log_exists
 from sentry.testutils.cases import MonitorTestCase
 from sentry.testutils.helpers.analytics import assert_any_analytics_event
 from sentry.testutils.outbox import outbox_runner
+from sentry.testutils.silo import assume_test_silo_mode
 from sentry.utils.outcomes import Outcome
 from sentry.utils.slug import DEFAULT_SLUG_ERROR_MESSAGE
 
@@ -437,6 +441,49 @@ class CreateOrganizationMonitorTest(MonitorTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.login_as(self.user)
+
+    def _create_token(self, scope: str) -> ApiToken:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            return ApiToken.objects.create(user=self.user, scope_list=[scope])
+
+    def test_create_requires_alerts_write_scope_for_tokens(self) -> None:
+        token = self._create_token("org:read")
+        data = {
+            "project": self.project.slug,
+            "name": "My Monitor",
+            "type": "cron_job",
+            "owner": f"user:{self.user.id}",
+            "config": {"schedule_type": "crontab", "schedule": "@daily"},
+        }
+
+        response = self.client.post(
+            reverse(self.endpoint, args=[self.organization.slug]),
+            data=data,
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {token.token}",
+        )
+
+        assert response.status_code == 403
+
+    def test_create_allows_alerts_write_scope_for_tokens(self) -> None:
+        token = self._create_token("alerts:write")
+        data = {
+            "project": self.project.slug,
+            "name": "My Monitor",
+            "type": "cron_job",
+            "owner": f"user:{self.user.id}",
+            "config": {"schedule_type": "crontab", "schedule": "@daily"},
+        }
+
+        with outbox_runner():
+            response = self.client.post(
+                reverse(self.endpoint, args=[self.organization.slug]),
+                data=data,
+                format="json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 201
 
     @patch("sentry.analytics.record")
     def test_simple(self, mock_record: MagicMock) -> None:

--- a/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
+++ b/tests/sentry/monitors/endpoints/test_organization_monitor_index.py
@@ -465,6 +465,28 @@ class CreateOrganizationMonitorTest(MonitorTestCase):
 
         assert response.status_code == 403
 
+    # TODO(api-write-scope-compat): Remove this legacy org:write coverage once
+    # public cron monitor clients have migrated to alerts:write.
+    def test_create_allows_legacy_org_write_scope_for_tokens(self) -> None:
+        token = self._create_token("org:write")
+        data = {
+            "project": self.project.slug,
+            "name": "My Monitor",
+            "type": "cron_job",
+            "owner": f"user:{self.user.id}",
+            "config": {"schedule_type": "crontab", "schedule": "@daily"},
+        }
+
+        with outbox_runner():
+            response = self.client.post(
+                reverse(self.endpoint, args=[self.organization.slug]),
+                data=data,
+                format="json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 201
+
     def test_create_allows_alerts_write_scope_for_tokens(self) -> None:
         token = self._create_token("alerts:write")
         data = {
@@ -993,12 +1015,25 @@ class BulkEditOrganizationMonitorTest(MonitorTestCase):
             role="member",
             team_roles=[(self.team, "admin")],
         )
+        self.organization.update_option("sentry:alerts_member_write", False)
 
         other_team = self.create_team(organization=self.organization, name="other-team")
         other_project = self.create_project(
             organization=self.organization, teams=[other_team], name="other-project"
         )
-        other_monitor = self._create_monitor(project=other_project, slug="other-monitor")
+        other_monitor = Monitor.objects.create(
+            organization_id=self.organization.id,
+            project_id=other_project.id,
+            config={
+                "schedule": "* * * * *",
+                "schedule_type": ScheduleType.CRONTAB,
+                "checkin_margin": None,
+                "max_runtime": None,
+            },
+            owner_user_id=self.user.id,
+            slug="other-monitor",
+            name="other-monitor",
+        )
         token = self._create_token("alerts:write", user=team_admin_user)
 
         response = self.client.put(

--- a/tests/sentry/replays/endpoints/test_project_replay_details.py
+++ b/tests/sentry/replays/endpoints/test_project_replay_details.py
@@ -195,7 +195,7 @@ class ProjectReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
         except File.DoesNotExist:
             pass
 
-    def test_delete_requires_event_write_scope_for_api_tokens(self) -> None:
+    def test_delete_requires_event_admin_scope_for_api_tokens(self) -> None:
         with assume_test_silo_mode(SiloMode.CONTROL):
             token = ApiToken.objects.create(user=self.user, scope_list=["event:read"])
 
@@ -217,7 +217,7 @@ class ProjectReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
 
         assert response.status_code == 403
 
-    def test_delete_allows_event_write_scope_for_api_tokens(self) -> None:
+    def test_delete_denies_event_write_scope_for_api_tokens(self) -> None:
         with assume_test_silo_mode(SiloMode.CONTROL):
             token = ApiToken.objects.create(user=self.user, scope_list=["event:write"])
 
@@ -227,7 +227,33 @@ class ProjectReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
                     self.url, HTTP_AUTHORIZATION=f"Bearer {token.token}", format="json"
                 )
 
+        assert response.status_code == 403
+
+    def test_delete_allows_event_admin_scope_for_api_tokens(self) -> None:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            token = ApiToken.objects.create(user=self.user, scope_list=["event:admin"])
+
+        with self.feature(REPLAYS_FEATURES):
+            with patch("sentry.replays.endpoints.project_replay_details.delete_replay.delay"):
+                response = self.client.delete(
+                    self.url, HTTP_AUTHORIZATION=f"Bearer {token.token}", format="json"
+                )
+
         assert response.status_code == 204
+
+    def test_delete_requires_event_admin_scope_for_members_without_event_admin(self) -> None:
+        self.organization.update_option("sentry:events_member_admin", False)
+
+        member_user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=member_user, organization=self.organization, role="member", teams=[]
+        )
+        self.login_as(user=member_user)
+
+        with self.feature(REPLAYS_FEATURES):
+            response = self.client.delete(self.url)
+
+        assert response.status_code == 403
 
     def test_delete_replay_from_clickhouse_data(self) -> None:
         """Test deleting files uploaded through the direct storage interface."""

--- a/tests/sentry/replays/endpoints/test_project_replay_details.py
+++ b/tests/sentry/replays/endpoints/test_project_replay_details.py
@@ -195,7 +195,7 @@ class ProjectReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
         except File.DoesNotExist:
             pass
 
-    def test_delete_requires_event_admin_scope_for_api_tokens(self) -> None:
+    def test_delete_denies_event_read_scope_for_api_tokens(self) -> None:
         with assume_test_silo_mode(SiloMode.CONTROL):
             token = ApiToken.objects.create(user=self.user, scope_list=["event:read"])
 
@@ -206,16 +206,29 @@ class ProjectReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
 
         assert response.status_code == 403
 
-    def test_delete_denies_project_write_scope_for_api_tokens(self) -> None:
+    def test_delete_allows_project_read_scope_for_api_tokens(self) -> None:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            token = ApiToken.objects.create(user=self.user, scope_list=["project:read"])
+
+        with self.feature(REPLAYS_FEATURES):
+            with patch("sentry.replays.endpoints.project_replay_details.delete_replay.delay"):
+                response = self.client.delete(
+                    self.url, HTTP_AUTHORIZATION=f"Bearer {token.token}", format="json"
+                )
+
+        assert response.status_code == 204
+
+    def test_delete_allows_project_write_scope_for_api_tokens(self) -> None:
         with assume_test_silo_mode(SiloMode.CONTROL):
             token = ApiToken.objects.create(user=self.user, scope_list=["project:write"])
 
         with self.feature(REPLAYS_FEATURES):
-            response = self.client.delete(
-                self.url, HTTP_AUTHORIZATION=f"Bearer {token.token}", format="json"
-            )
+            with patch("sentry.replays.endpoints.project_replay_details.delete_replay.delay"):
+                response = self.client.delete(
+                    self.url, HTTP_AUTHORIZATION=f"Bearer {token.token}", format="json"
+                )
 
-        assert response.status_code == 403
+        assert response.status_code == 204
 
     def test_delete_denies_event_write_scope_for_api_tokens(self) -> None:
         with assume_test_silo_mode(SiloMode.CONTROL):
@@ -229,19 +242,18 @@ class ProjectReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
 
         assert response.status_code == 403
 
-    def test_delete_allows_event_admin_scope_for_api_tokens(self) -> None:
+    def test_delete_denies_event_admin_scope_for_api_tokens(self) -> None:
         with assume_test_silo_mode(SiloMode.CONTROL):
             token = ApiToken.objects.create(user=self.user, scope_list=["event:admin"])
 
         with self.feature(REPLAYS_FEATURES):
-            with patch("sentry.replays.endpoints.project_replay_details.delete_replay.delay"):
-                response = self.client.delete(
-                    self.url, HTTP_AUTHORIZATION=f"Bearer {token.token}", format="json"
-                )
+            response = self.client.delete(
+                self.url, HTTP_AUTHORIZATION=f"Bearer {token.token}", format="json"
+            )
 
-        assert response.status_code == 204
+        assert response.status_code == 403
 
-    def test_delete_requires_event_admin_scope_for_members_without_event_admin(self) -> None:
+    def test_delete_members_do_not_require_event_admin(self) -> None:
         self.organization.update_option("sentry:events_member_admin", False)
 
         member_user = self.create_user(is_superuser=False)
@@ -251,9 +263,10 @@ class ProjectReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
         self.login_as(user=member_user)
 
         with self.feature(REPLAYS_FEATURES):
-            response = self.client.delete(self.url)
+            with patch("sentry.replays.endpoints.project_replay_details.delete_replay.delay"):
+                response = self.client.delete(self.url)
 
-        assert response.status_code == 403
+        assert response.status_code == 204
 
     def test_delete_replay_from_clickhouse_data(self) -> None:
         """Test deleting files uploaded through the direct storage interface."""

--- a/tests/sentry/replays/endpoints/test_project_replay_details.py
+++ b/tests/sentry/replays/endpoints/test_project_replay_details.py
@@ -5,13 +5,16 @@ from uuid import uuid4
 
 from django.urls import reverse
 
+from sentry.models.apitoken import ApiToken
 from sentry.models.files.file import File
 from sentry.replays.lib import kafka
 from sentry.replays.lib.storage import RecordingSegmentStorageMeta, storage
 from sentry.replays.models import ReplayRecordingSegment
 from sentry.replays.testutils import assert_expected_response, mock_expected_response, mock_replay
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase, ReplaysSnubaTestCase
 from sentry.testutils.helpers import TaskRunner
+from sentry.testutils.silo import assume_test_silo_mode
 from sentry.utils import kafka_config
 
 REPLAYS_FEATURES = {"organizations:session-replay": True}
@@ -191,6 +194,29 @@ class ProjectReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
             assert False, "File was not deleted."
         except File.DoesNotExist:
             pass
+
+    def test_delete_requires_event_write_scope_for_api_tokens(self) -> None:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            token = ApiToken.objects.create(user=self.user, scope_list=["event:read"])
+
+        with self.feature(REPLAYS_FEATURES):
+            response = self.client.delete(
+                self.url, HTTP_AUTHORIZATION=f"Bearer {token.token}", format="json"
+            )
+
+        assert response.status_code == 403
+
+    def test_delete_allows_event_write_scope_for_api_tokens(self) -> None:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            token = ApiToken.objects.create(user=self.user, scope_list=["event:write"])
+
+        with self.feature(REPLAYS_FEATURES):
+            with patch("sentry.replays.endpoints.project_replay_details.delete_replay.delay"):
+                response = self.client.delete(
+                    self.url, HTTP_AUTHORIZATION=f"Bearer {token.token}", format="json"
+                )
+
+        assert response.status_code == 204
 
     def test_delete_replay_from_clickhouse_data(self) -> None:
         """Test deleting files uploaded through the direct storage interface."""

--- a/tests/sentry/replays/endpoints/test_project_replay_details.py
+++ b/tests/sentry/replays/endpoints/test_project_replay_details.py
@@ -206,6 +206,17 @@ class ProjectReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
 
         assert response.status_code == 403
 
+    def test_delete_denies_project_write_scope_for_api_tokens(self) -> None:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            token = ApiToken.objects.create(user=self.user, scope_list=["project:write"])
+
+        with self.feature(REPLAYS_FEATURES):
+            response = self.client.delete(
+                self.url, HTTP_AUTHORIZATION=f"Bearer {token.token}", format="json"
+            )
+
+        assert response.status_code == 403
+
     def test_delete_allows_event_write_scope_for_api_tokens(self) -> None:
         with assume_test_silo_mode(SiloMode.CONTROL):
             token = ApiToken.objects.create(user=self.user, scope_list=["event:write"])

--- a/tests/sentry/replays/endpoints/test_project_replay_details.py
+++ b/tests/sentry/replays/endpoints/test_project_replay_details.py
@@ -206,29 +206,27 @@ class ProjectReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
 
         assert response.status_code == 403
 
-    def test_delete_allows_project_read_scope_for_api_tokens(self) -> None:
+    def test_delete_denies_project_read_scope_for_api_tokens(self) -> None:
         with assume_test_silo_mode(SiloMode.CONTROL):
             token = ApiToken.objects.create(user=self.user, scope_list=["project:read"])
 
         with self.feature(REPLAYS_FEATURES):
-            with patch("sentry.replays.endpoints.project_replay_details.delete_replay.delay"):
-                response = self.client.delete(
-                    self.url, HTTP_AUTHORIZATION=f"Bearer {token.token}", format="json"
-                )
+            response = self.client.delete(
+                self.url, HTTP_AUTHORIZATION=f"Bearer {token.token}", format="json"
+            )
 
-        assert response.status_code == 204
+        assert response.status_code == 403
 
-    def test_delete_allows_project_write_scope_for_api_tokens(self) -> None:
+    def test_delete_denies_project_write_scope_for_api_tokens(self) -> None:
         with assume_test_silo_mode(SiloMode.CONTROL):
             token = ApiToken.objects.create(user=self.user, scope_list=["project:write"])
 
         with self.feature(REPLAYS_FEATURES):
-            with patch("sentry.replays.endpoints.project_replay_details.delete_replay.delay"):
-                response = self.client.delete(
-                    self.url, HTTP_AUTHORIZATION=f"Bearer {token.token}", format="json"
-                )
+            response = self.client.delete(
+                self.url, HTTP_AUTHORIZATION=f"Bearer {token.token}", format="json"
+            )
 
-        assert response.status_code == 204
+        assert response.status_code == 403
 
     def test_delete_denies_event_write_scope_for_api_tokens(self) -> None:
         with assume_test_silo_mode(SiloMode.CONTROL):
@@ -242,18 +240,19 @@ class ProjectReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
 
         assert response.status_code == 403
 
-    def test_delete_denies_event_admin_scope_for_api_tokens(self) -> None:
+    def test_delete_allows_event_admin_scope_for_api_tokens(self) -> None:
         with assume_test_silo_mode(SiloMode.CONTROL):
             token = ApiToken.objects.create(user=self.user, scope_list=["event:admin"])
 
         with self.feature(REPLAYS_FEATURES):
-            response = self.client.delete(
-                self.url, HTTP_AUTHORIZATION=f"Bearer {token.token}", format="json"
-            )
+            with patch("sentry.replays.endpoints.project_replay_details.delete_replay.delay"):
+                response = self.client.delete(
+                    self.url, HTTP_AUTHORIZATION=f"Bearer {token.token}", format="json"
+                )
 
-        assert response.status_code == 403
+        assert response.status_code == 204
 
-    def test_delete_members_do_not_require_event_admin(self) -> None:
+    def test_delete_denies_members_without_event_admin(self) -> None:
         self.organization.update_option("sentry:events_member_admin", False)
 
         member_user = self.create_user(is_superuser=False)
@@ -263,10 +262,9 @@ class ProjectReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
         self.login_as(user=member_user)
 
         with self.feature(REPLAYS_FEATURES):
-            with patch("sentry.replays.endpoints.project_replay_details.delete_replay.delay"):
-                response = self.client.delete(self.url)
+            response = self.client.delete(self.url)
 
-        assert response.status_code == 204
+        assert response.status_code == 403
 
     def test_delete_replay_from_clickhouse_data(self) -> None:
         """Test deleting files uploaded through the direct storage interface."""

--- a/tests/sentry/replays/endpoints/test_project_replay_summary.py
+++ b/tests/sentry/replays/endpoints/test_project_replay_summary.py
@@ -7,8 +7,11 @@ import requests
 from django.conf import settings
 from django.urls import reverse
 
+from sentry.models.apitoken import ApiToken
 from sentry.replays.testutils import mock_replay
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import SnubaTestCase, TransactionTestCase
+from sentry.testutils.silo import assume_test_silo_mode
 from sentry.utils import json
 
 
@@ -139,6 +142,41 @@ class ProjectReplaySummaryTestCase(
         assert body["organization_id"] == self.organization.id
         assert body["project_id"] == self.project.id
         assert body.get("temperature") is None
+
+    @patch("sentry.replays.endpoints.project_replay_summary.make_replay_summary_start_request")
+    def test_post_allows_event_read_scope_for_api_tokens(self, mock_seer_request: Mock) -> None:
+        mock_seer_request.return_value = MockSeerResponse(200, json_data={"hello": "world"})
+        self.store_replay()
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            token = ApiToken.objects.create(user=self.user, scope_list=["event:read"])
+
+        with self.feature(self.features):
+            response = self.client.post(
+                self.url,
+                data={"num_segments": 1},
+                content_type="application/json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 200
+        assert response.json() == {"hello": "world"}
+
+    def test_post_requires_replay_read_scope_for_api_tokens(self) -> None:
+        self.store_replay()
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            token = ApiToken.objects.create(user=self.user, scope_list=["org:read"])
+
+        with self.feature(self.features):
+            response = self.client.post(
+                self.url,
+                data={"num_segments": 1},
+                content_type="application/json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 403
 
     def test_post_replay_not_found(self) -> None:
         with self.feature(self.features):

--- a/tests/sentry/seer/endpoints/test_organization_events_anomalies.py
+++ b/tests/sentry/seer/endpoints/test_organization_events_anomalies.py
@@ -48,9 +48,9 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
     current_timestamp_1 = one_week_ago.timestamp()
     current_timestamp_2 = (one_week_ago + timedelta(minutes=10)).timestamp()
 
-    def _create_token(self, scope: str) -> ApiToken:
+    def _create_token(self, scope: str, user=None) -> ApiToken:
         with assume_test_silo_mode(SiloMode.CONTROL):
-            return ApiToken.objects.create(user=self.user, scope_list=[scope])
+            return ApiToken.objects.create(user=user or self.user, scope_list=[scope])
 
     def get_test_data(self, project_id: int) -> dict:
         return {
@@ -211,6 +211,35 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
     def test_org_read_scope_cannot_post(self) -> None:
         token = self._create_token("org:read")
         data = self.get_test_data(self.project.id)
+        url = reverse(self.endpoint, args=[self.organization.slug])
+
+        with outbox_runner():
+            response = self.client.post(
+                url,
+                data=orjson.dumps(data),
+                content_type="application/json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 403
+
+    @with_feature("organizations:anomaly-detection-alerts")
+    @with_feature("organizations:incidents")
+    def test_alerts_write_scope_denies_other_team_projects(self) -> None:
+        team_admin_user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=team_admin_user,
+            organization=self.organization,
+            role="member",
+            team_roles=[(self.team, "admin")],
+        )
+
+        other_team = self.create_team(organization=self.organization, name="other-team")
+        other_project = self.create_project(
+            organization=self.organization, teams=[other_team], name="other-project"
+        )
+        token = self._create_token("alerts:write", user=team_admin_user)
+        data = self.get_test_data(other_project.id)
         url = reverse(self.endpoint, args=[self.organization.slug])
 
         with outbox_runner():

--- a/tests/sentry/seer/endpoints/test_organization_events_anomalies.py
+++ b/tests/sentry/seer/endpoints/test_organization_events_anomalies.py
@@ -2,7 +2,9 @@ from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import orjson
+import pytest
 from django.urls import reverse
+from rest_framework.exceptions import PermissionDenied
 from urllib3 import HTTPResponse
 from urllib3.exceptions import TimeoutError
 
@@ -12,6 +14,7 @@ from sentry.incidents.models.alert_rule import (
     AlertRuleThresholdType,
 )
 from sentry.models.apitoken import ApiToken
+from sentry.organizations.services.organization import organization_service
 from sentry.seer.anomaly_detection.types import (
     Anomaly,
     AnomalyDetectionConfig,
@@ -20,6 +23,7 @@ from sentry.seer.anomaly_detection.types import (
     TimeSeriesPoint,
 )
 from sentry.seer.anomaly_detection.utils import translate_direction
+from sentry.seer.endpoints.organization_events_anomalies import OrganizationEventsAnomaliesEndpoint
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
@@ -89,6 +93,35 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
                 ),
             ],
         )
+
+    def test_get_alert_mutation_projects_unwraps_rpc_user_org_context(self) -> None:
+        endpoint = OrganizationEventsAnomaliesEndpoint()
+        request = MagicMock()
+        request.data = {"project_id": str(self.project.id)}
+
+        rpc_org_context = organization_service.get_organization_by_id(
+            id=self.organization.id, user_id=self.user.id
+        )
+        assert rpc_org_context is not None
+
+        with patch.object(endpoint, "get_projects", return_value=[self.project]) as get_projects:
+            projects = endpoint.get_alert_mutation_projects(request, rpc_org_context)
+
+        assert projects == [self.project]
+        get_projects.assert_called_once_with(
+            request, rpc_org_context.organization, project_ids={self.project.id}
+        )
+
+    def test_get_alert_mutation_projects_does_not_swallow_permission_denied(self) -> None:
+        endpoint = OrganizationEventsAnomaliesEndpoint()
+        request = MagicMock()
+        request.data = {"project_id": str(self.project.id)}
+
+        with (
+            patch.object(endpoint, "get_projects", side_effect=PermissionDenied),
+            pytest.raises(PermissionDenied),
+        ):
+            endpoint.get_alert_mutation_projects(request, self.organization)
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:incidents")

--- a/tests/sentry/seer/endpoints/test_organization_events_anomalies.py
+++ b/tests/sentry/seer/endpoints/test_organization_events_anomalies.py
@@ -225,6 +225,23 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:incidents")
+    def test_org_write_scope_cannot_post(self) -> None:
+        token = self._create_token("org:write")
+        data = self.get_test_data(self.project.id)
+        url = reverse(self.endpoint, args=[self.organization.slug])
+
+        with outbox_runner():
+            response = self.client.post(
+                url,
+                data=orjson.dumps(data),
+                content_type="application/json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 403
+
+    @with_feature("organizations:anomaly-detection-alerts")
+    @with_feature("organizations:incidents")
     def test_alerts_write_scope_denies_other_team_projects(self) -> None:
         team_admin_user = self.create_user(is_superuser=False)
         self.create_member(
@@ -233,6 +250,7 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
             role="member",
             team_roles=[(self.team, "admin")],
         )
+        self.organization.update_option("sentry:alerts_member_write", False)
 
         other_team = self.create_team(organization=self.organization, name="other-team")
         other_project = self.create_project(

--- a/tests/sentry/seer/endpoints/test_organization_events_anomalies.py
+++ b/tests/sentry/seer/endpoints/test_organization_events_anomalies.py
@@ -172,7 +172,24 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
     )
     def test_alerts_write_scope_allows_post(self, mock_seer_request: MagicMock) -> None:
         mock_seer_request.return_value = HTTPResponse(
-            orjson.dumps(DetectAnomaliesResponse(success=True, message="", timeseries=[])),
+            orjson.dumps(
+                DetectAnomaliesResponse(
+                    success=True,
+                    message="",
+                    timeseries=[
+                        TimeSeriesPoint(
+                            timestamp=self.current_timestamp_1,
+                            value=2,
+                            anomaly=Anomaly(anomaly_score=-0.1, anomaly_type="none"),
+                        ),
+                        TimeSeriesPoint(
+                            timestamp=self.current_timestamp_2,
+                            value=3,
+                            anomaly=Anomaly(anomaly_score=-0.2, anomaly_type="none"),
+                        ),
+                    ],
+                )
+            ),
             status=200,
         )
         token = self._create_token("alerts:write")

--- a/tests/sentry/seer/endpoints/test_organization_events_anomalies.py
+++ b/tests/sentry/seer/endpoints/test_organization_events_anomalies.py
@@ -241,7 +241,28 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:incidents")
-    def test_org_read_scope_cannot_post(self) -> None:
+    # TODO(api-write-scope-compat): Remove this legacy org:* coverage once
+    # alert authoring preview clients have migrated to alerts:write.
+    @patch(
+        "sentry.seer.anomaly_detection.get_historical_anomalies.seer_anomaly_detection_connection_pool.urlopen"
+    )
+    def test_org_read_scope_can_post(self, mock_seer_request: MagicMock) -> None:
+        mock_seer_request.return_value = HTTPResponse(
+            orjson.dumps(
+                DetectAnomaliesResponse(
+                    success=True,
+                    message="",
+                    timeseries=[
+                        TimeSeriesPoint(
+                            timestamp=self.current_timestamp_1,
+                            value=2,
+                            anomaly=Anomaly(anomaly_score=-0.1, anomaly_type="none"),
+                        )
+                    ],
+                )
+            ),
+            status=200,
+        )
         token = self._create_token("org:read")
         data = self.get_test_data(self.project.id)
         url = reverse(self.endpoint, args=[self.organization.slug])
@@ -254,11 +275,32 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token.token}",
             )
 
-        assert response.status_code == 403
+        assert response.status_code == 200
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:incidents")
-    def test_org_write_scope_cannot_post(self) -> None:
+    # TODO(api-write-scope-compat): Remove this legacy org:* coverage once
+    # alert authoring preview clients have migrated to alerts:write.
+    @patch(
+        "sentry.seer.anomaly_detection.get_historical_anomalies.seer_anomaly_detection_connection_pool.urlopen"
+    )
+    def test_org_write_scope_can_post(self, mock_seer_request: MagicMock) -> None:
+        mock_seer_request.return_value = HTTPResponse(
+            orjson.dumps(
+                DetectAnomaliesResponse(
+                    success=True,
+                    message="",
+                    timeseries=[
+                        TimeSeriesPoint(
+                            timestamp=self.current_timestamp_1,
+                            value=2,
+                            anomaly=Anomaly(anomaly_score=-0.1, anomaly_type="none"),
+                        )
+                    ],
+                )
+            ),
+            status=200,
+        )
         token = self._create_token("org:write")
         data = self.get_test_data(self.project.id)
         url = reverse(self.endpoint, args=[self.organization.slug])
@@ -271,7 +313,7 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token.token}",
             )
 
-        assert response.status_code == 403
+        assert response.status_code == 200
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:incidents")
@@ -302,6 +344,45 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
             )
 
         assert response.status_code == 403
+
+    @with_feature("organizations:anomaly-detection-alerts")
+    @with_feature("organizations:incidents")
+    @patch(
+        "sentry.seer.anomaly_detection.get_historical_anomalies.seer_anomaly_detection_connection_pool.urlopen"
+    )
+    def test_team_admin_can_post_when_member_alert_write_disabled(
+        self, mock_seer_request: MagicMock
+    ) -> None:
+        team_admin_user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=team_admin_user,
+            organization=self.organization,
+            role="member",
+            team_roles=[(self.team, "admin")],
+        )
+        self.organization.update_option("sentry:alerts_member_write", False)
+        self.login_as(team_admin_user)
+
+        seer_return_value = DetectAnomaliesResponse(
+            success=True,
+            message="",
+            timeseries=[
+                TimeSeriesPoint(
+                    timestamp=self.current_timestamp_1,
+                    value=2,
+                    anomaly=Anomaly(anomaly_score=-0.1, anomaly_type="none"),
+                )
+            ],
+        )
+        mock_seer_request.return_value = HTTPResponse(orjson.dumps(seer_return_value), status=200)
+
+        data = self.get_test_data(self.project.id)
+        with outbox_runner():
+            response = self.get_success_response(
+                self.organization.slug, status_code=200, raw_data=orjson.dumps(data)
+            )
+
+        assert response.status_code == 200
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:incidents")

--- a/tests/sentry/seer/endpoints/test_organization_events_anomalies.py
+++ b/tests/sentry/seer/endpoints/test_organization_events_anomalies.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 import orjson
+from django.urls import reverse
 from urllib3 import HTTPResponse
 from urllib3.exceptions import TimeoutError
 
@@ -10,6 +11,7 @@ from sentry.incidents.models.alert_rule import (
     AlertRuleSensitivity,
     AlertRuleThresholdType,
 )
+from sentry.models.apitoken import ApiToken
 from sentry.seer.anomaly_detection.types import (
     Anomaly,
     AnomalyDetectionConfig,
@@ -18,10 +20,12 @@ from sentry.seer.anomaly_detection.types import (
     TimeSeriesPoint,
 )
 from sentry.seer.anomaly_detection.utils import translate_direction
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.outbox import outbox_runner
+from sentry.testutils.silo import assume_test_silo_mode
 
 
 @freeze_time()
@@ -43,6 +47,10 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
     historical_timestamp_2 = (four_weeks_ago + timedelta(days=10)).timestamp()
     current_timestamp_1 = one_week_ago.timestamp()
     current_timestamp_2 = (one_week_ago + timedelta(minutes=10)).timestamp()
+
+    def _create_token(self, scope: str) -> ApiToken:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            return ApiToken.objects.create(user=self.user, scope_list=[scope])
 
     def get_test_data(self, project_id: int) -> dict:
         return {
@@ -156,6 +164,47 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
 
         assert mock_seer_request.call_count == 1
         assert resp.data == seer_return_value["timeseries"]
+
+    @with_feature("organizations:anomaly-detection-alerts")
+    @with_feature("organizations:incidents")
+    @patch(
+        "sentry.seer.anomaly_detection.get_historical_anomalies.seer_anomaly_detection_connection_pool.urlopen"
+    )
+    def test_alerts_write_scope_allows_post(self, mock_seer_request: MagicMock) -> None:
+        mock_seer_request.return_value = HTTPResponse(
+            orjson.dumps(DetectAnomaliesResponse(success=True, message="", timeseries=[])),
+            status=200,
+        )
+        token = self._create_token("alerts:write")
+        data = self.get_test_data(self.project.id)
+        url = reverse(self.endpoint, args=[self.organization.slug])
+
+        with outbox_runner():
+            response = self.client.post(
+                url,
+                data=orjson.dumps(data),
+                content_type="application/json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 200
+
+    @with_feature("organizations:anomaly-detection-alerts")
+    @with_feature("organizations:incidents")
+    def test_org_read_scope_cannot_post(self) -> None:
+        token = self._create_token("org:read")
+        data = self.get_test_data(self.project.id)
+        url = reverse(self.endpoint, args=[self.organization.slug])
+
+        with outbox_runner():
+            response = self.client.post(
+                url,
+                data=orjson.dumps(data),
+                content_type="application/json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 403
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:incidents")

--- a/tests/sentry/seer/endpoints/test_organization_events_anomalies.py
+++ b/tests/sentry/seer/endpoints/test_organization_events_anomalies.py
@@ -241,12 +241,10 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:incidents")
-    # TODO(api-write-scope-compat): Remove this legacy org:* coverage once
-    # alert authoring preview clients have migrated to alerts:write.
     @patch(
         "sentry.seer.anomaly_detection.get_historical_anomalies.seer_anomaly_detection_connection_pool.urlopen"
     )
-    def test_org_read_scope_can_post(self, mock_seer_request: MagicMock) -> None:
+    def test_org_read_scope_cannot_post(self, mock_seer_request: MagicMock) -> None:
         mock_seer_request.return_value = HTTPResponse(
             orjson.dumps(
                 DetectAnomaliesResponse(
@@ -275,11 +273,11 @@ class OrganizationEventsAnomaliesEndpointTest(APITestCase):
                 HTTP_AUTHORIZATION=f"Bearer {token.token}",
             )
 
-        assert response.status_code == 200
+        assert response.status_code == 403
 
     @with_feature("organizations:anomaly-detection-alerts")
     @with_feature("organizations:incidents")
-    # TODO(api-write-scope-compat): Remove this legacy org:* coverage once
+    # TODO(api-write-scope-compat): Remove this legacy org:write coverage once
     # alert authoring preview clients have migrated to alerts:write.
     @patch(
         "sentry.seer.anomaly_detection.get_historical_anomalies.seer_anomaly_detection_connection_pool.urlopen"

--- a/tests/sentry/uptime/endpoints/test_organization_uptime_alert_preview.py
+++ b/tests/sentry/uptime/endpoints/test_organization_uptime_alert_preview.py
@@ -135,9 +135,25 @@ class OrganizationUptimeAlertPreview(UptimeAlertBaseEndpointTest):
 
         assert response.status_code == 200, response.content
 
-    def test_org_read_scope_cannot_run_preview_check(self) -> None:
+    # TODO(api-write-scope-compat): Remove this legacy org:* coverage once
+    # uptime preview clients have migrated to alerts:write.
+    @responses.activate
+    def test_org_read_scope_can_run_preview_check(self) -> None:
         api_key = self.create_api_key(organization=self.organization, scope_list=["org:read"])
 
+        responses.add(
+            responses.POST,
+            "http://pop-st-1.uptime-checker.s4s.sentry.internal:80/validate_check",
+            status=200,
+            json={"succeeded": True},
+        )
+        responses.add(
+            responses.POST,
+            "http://pop-st-1.uptime-checker.s4s.sentry.internal:80/execute_config",
+            status=200,
+            json={"succeeded": True},
+        )
+
         url = reverse(
             "sentry-api-0-organization-uptime-alert-preview-check",
             kwargs={"organization_id_or_slug": self.organization.slug},
@@ -157,11 +173,27 @@ class OrganizationUptimeAlertPreview(UptimeAlertBaseEndpointTest):
             HTTP_AUTHORIZATION=self.create_basic_auth_header(api_key.key),
         )
 
-        assert response.status_code == 403
+        assert response.status_code == 200
 
-    def test_org_write_scope_cannot_run_preview_check(self) -> None:
+    # TODO(api-write-scope-compat): Remove this legacy org:* coverage once
+    # uptime preview clients have migrated to alerts:write.
+    @responses.activate
+    def test_org_write_scope_can_run_preview_check(self) -> None:
         api_key = self.create_api_key(organization=self.organization, scope_list=["org:write"])
 
+        responses.add(
+            responses.POST,
+            "http://pop-st-1.uptime-checker.s4s.sentry.internal:80/validate_check",
+            status=200,
+            json={"succeeded": True},
+        )
+        responses.add(
+            responses.POST,
+            "http://pop-st-1.uptime-checker.s4s.sentry.internal:80/execute_config",
+            status=200,
+            json={"succeeded": True},
+        )
+
         url = reverse(
             "sentry-api-0-organization-uptime-alert-preview-check",
             kwargs={"organization_id_or_slug": self.organization.slug},
@@ -181,4 +213,42 @@ class OrganizationUptimeAlertPreview(UptimeAlertBaseEndpointTest):
             HTTP_AUTHORIZATION=self.create_basic_auth_header(api_key.key),
         )
 
-        assert response.status_code == 403
+        assert response.status_code == 200
+
+    @responses.activate
+    def test_team_admin_can_run_preview_check_when_member_alert_write_disabled(self) -> None:
+        team_admin_user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=team_admin_user,
+            organization=self.organization,
+            role="member",
+            team_roles=[(self.team, "admin")],
+        )
+        self.organization.update_option("sentry:alerts_member_write", False)
+        self.login_as(team_admin_user)
+
+        responses.add(
+            responses.POST,
+            "http://pop-st-1.uptime-checker.s4s.sentry.internal:80/validate_check",
+            status=200,
+            json={"succeeded": True},
+        )
+        responses.add(
+            responses.POST,
+            "http://pop-st-1.uptime-checker.s4s.sentry.internal:80/execute_config",
+            status=200,
+            json={"succeeded": True},
+        )
+
+        response = self.get_success_response(
+            self.organization.slug,
+            name="test",
+            environment="uptime-prod",
+            owner=f"user:{team_admin_user.id}",
+            url="http://sentry.io",
+            timeout_ms=1500,
+            body=None,
+            region="default",
+        )
+
+        assert response.status_code == 200

--- a/tests/sentry/uptime/endpoints/test_organization_uptime_alert_preview.py
+++ b/tests/sentry/uptime/endpoints/test_organization_uptime_alert_preview.py
@@ -134,3 +134,27 @@ class OrganizationUptimeAlertPreview(UptimeAlertBaseEndpointTest):
         )
 
         assert response.status_code == 200, response.content
+
+    def test_org_read_scope_cannot_run_preview_check(self) -> None:
+        api_key = self.create_api_key(organization=self.organization, scope_list=["org:read"])
+
+        url = reverse(
+            "sentry-api-0-organization-uptime-alert-preview-check",
+            kwargs={"organization_id_or_slug": self.organization.slug},
+        )
+        response = self.client.post(
+            url,
+            data={
+                "name": "test",
+                "environment": "uptime-prod",
+                "owner": f"user:{self.user.id}",
+                "url": "http://sentry.io",
+                "timeoutMs": 1500,
+                "body": None,
+                "region": "default",
+            },
+            format="json",
+            HTTP_AUTHORIZATION=self.create_basic_auth_header(api_key.key),
+        )
+
+        assert response.status_code == 403

--- a/tests/sentry/uptime/endpoints/test_organization_uptime_alert_preview.py
+++ b/tests/sentry/uptime/endpoints/test_organization_uptime_alert_preview.py
@@ -158,3 +158,27 @@ class OrganizationUptimeAlertPreview(UptimeAlertBaseEndpointTest):
         )
 
         assert response.status_code == 403
+
+    def test_org_write_scope_cannot_run_preview_check(self) -> None:
+        api_key = self.create_api_key(organization=self.organization, scope_list=["org:write"])
+
+        url = reverse(
+            "sentry-api-0-organization-uptime-alert-preview-check",
+            kwargs={"organization_id_or_slug": self.organization.slug},
+        )
+        response = self.client.post(
+            url,
+            data={
+                "name": "test",
+                "environment": "uptime-prod",
+                "owner": f"user:{self.user.id}",
+                "url": "http://sentry.io",
+                "timeoutMs": 1500,
+                "body": None,
+                "region": "default",
+            },
+            format="json",
+            HTTP_AUTHORIZATION=self.create_basic_auth_header(api_key.key),
+        )
+
+        assert response.status_code == 403

--- a/tests/sentry/uptime/endpoints/test_organization_uptime_alert_preview.py
+++ b/tests/sentry/uptime/endpoints/test_organization_uptime_alert_preview.py
@@ -135,10 +135,8 @@ class OrganizationUptimeAlertPreview(UptimeAlertBaseEndpointTest):
 
         assert response.status_code == 200, response.content
 
-    # TODO(api-write-scope-compat): Remove this legacy org:* coverage once
-    # uptime preview clients have migrated to alerts:write.
     @responses.activate
-    def test_org_read_scope_can_run_preview_check(self) -> None:
+    def test_org_read_scope_cannot_run_preview_check(self) -> None:
         api_key = self.create_api_key(organization=self.organization, scope_list=["org:read"])
 
         responses.add(
@@ -173,9 +171,9 @@ class OrganizationUptimeAlertPreview(UptimeAlertBaseEndpointTest):
             HTTP_AUTHORIZATION=self.create_basic_auth_header(api_key.key),
         )
 
-        assert response.status_code == 200
+        assert response.status_code == 403
 
-    # TODO(api-write-scope-compat): Remove this legacy org:* coverage once
+    # TODO(api-write-scope-compat): Remove this legacy org:write coverage once
     # uptime preview clients have migrated to alerts:write.
     @responses.activate
     def test_org_write_scope_can_run_preview_check(self) -> None:

--- a/tests/sentry/uptime/endpoints/test_organization_uptime_assertion_suggestions.py
+++ b/tests/sentry/uptime/endpoints/test_organization_uptime_assertion_suggestions.py
@@ -34,6 +34,8 @@ class OrganizationUptimeAssertionSuggestionsTest(UptimeAlertBaseEndpointTest):
             "region": "default",
         }
 
+    # TODO(api-write-scope-compat): Remove this legacy org:* coverage once
+    # uptime assertion-suggestion clients have migrated to alerts:write.
     @mock.patch(
         "sentry.uptime.endpoints.organization_uptime_assertion_suggestions.generate_assertion_suggestions"
     )
@@ -72,8 +74,36 @@ class OrganizationUptimeAssertionSuggestionsTest(UptimeAlertBaseEndpointTest):
 
         assert response.status_code == 200
 
-    def test_org_read_scope_cannot_generate_suggestions(self) -> None:
+    # TODO(api-write-scope-compat): Remove this legacy org:* coverage once
+    # uptime assertion-suggestion clients have migrated to alerts:write.
+    @mock.patch(
+        "sentry.uptime.endpoints.organization_uptime_assertion_suggestions.generate_assertion_suggestions"
+    )
+    @mock.patch(
+        "sentry.uptime.endpoints.organization_uptime_assertion_suggestions.checker_api.invoke_checker_preview"
+    )
+    @mock.patch(
+        "sentry.uptime.endpoints.organization_uptime_assertion_suggestions.UptimeCheckPreviewValidator"
+    )
+    @mock.patch("sentry.uptime.endpoints.organization_uptime_assertion_suggestions.has_seer_access")
+    def test_org_read_scope_can_generate_suggestions(
+        self,
+        mock_has_seer_access: mock.MagicMock,
+        mock_validator_cls: mock.MagicMock,
+        mock_preview: mock.MagicMock,
+        mock_generate: mock.MagicMock,
+    ) -> None:
         api_key = self.create_api_key(organization=self.organization, scope_list=["org:read"])
+        mock_has_seer_access.return_value = True
+        mock_validator = mock_validator_cls.return_value
+        mock_validator.is_valid.return_value = True
+        mock_validator.save.return_value = {"active_regions": ["default"]}
+        mock_preview.return_value = mock.Mock(
+            status_code=200,
+            json=mock.Mock(return_value={"status": 200}),
+            raise_for_status=mock.Mock(),
+        )
+        mock_generate.return_value = (None, None)
 
         response = self.client.post(
             self.url,
@@ -82,10 +112,36 @@ class OrganizationUptimeAssertionSuggestionsTest(UptimeAlertBaseEndpointTest):
             HTTP_AUTHORIZATION=self.create_basic_auth_header(api_key.key),
         )
 
-        assert response.status_code == 403
+        assert response.status_code == 200
 
-    def test_org_write_scope_cannot_generate_suggestions(self) -> None:
+    @mock.patch(
+        "sentry.uptime.endpoints.organization_uptime_assertion_suggestions.generate_assertion_suggestions"
+    )
+    @mock.patch(
+        "sentry.uptime.endpoints.organization_uptime_assertion_suggestions.checker_api.invoke_checker_preview"
+    )
+    @mock.patch(
+        "sentry.uptime.endpoints.organization_uptime_assertion_suggestions.UptimeCheckPreviewValidator"
+    )
+    @mock.patch("sentry.uptime.endpoints.organization_uptime_assertion_suggestions.has_seer_access")
+    def test_org_write_scope_can_generate_suggestions(
+        self,
+        mock_has_seer_access: mock.MagicMock,
+        mock_validator_cls: mock.MagicMock,
+        mock_preview: mock.MagicMock,
+        mock_generate: mock.MagicMock,
+    ) -> None:
         api_key = self.create_api_key(organization=self.organization, scope_list=["org:write"])
+        mock_has_seer_access.return_value = True
+        mock_validator = mock_validator_cls.return_value
+        mock_validator.is_valid.return_value = True
+        mock_validator.save.return_value = {"active_regions": ["default"]}
+        mock_preview.return_value = mock.Mock(
+            status_code=200,
+            json=mock.Mock(return_value={"status": 200}),
+            raise_for_status=mock.Mock(),
+        )
+        mock_generate.return_value = (None, None)
 
         response = self.client.post(
             self.url,
@@ -94,4 +150,46 @@ class OrganizationUptimeAssertionSuggestionsTest(UptimeAlertBaseEndpointTest):
             HTTP_AUTHORIZATION=self.create_basic_auth_header(api_key.key),
         )
 
-        assert response.status_code == 403
+        assert response.status_code == 200
+
+    @mock.patch(
+        "sentry.uptime.endpoints.organization_uptime_assertion_suggestions.generate_assertion_suggestions"
+    )
+    @mock.patch(
+        "sentry.uptime.endpoints.organization_uptime_assertion_suggestions.checker_api.invoke_checker_preview"
+    )
+    @mock.patch(
+        "sentry.uptime.endpoints.organization_uptime_assertion_suggestions.UptimeCheckPreviewValidator"
+    )
+    @mock.patch("sentry.uptime.endpoints.organization_uptime_assertion_suggestions.has_seer_access")
+    def test_team_admin_can_generate_suggestions_when_member_alert_write_disabled(
+        self,
+        mock_has_seer_access: mock.MagicMock,
+        mock_validator_cls: mock.MagicMock,
+        mock_preview: mock.MagicMock,
+        mock_generate: mock.MagicMock,
+    ) -> None:
+        team_admin_user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=team_admin_user,
+            organization=self.organization,
+            role="member",
+            team_roles=[(self.team, "admin")],
+        )
+        self.organization.update_option("sentry:alerts_member_write", False)
+        self.login_as(team_admin_user)
+
+        mock_has_seer_access.return_value = True
+        mock_validator = mock_validator_cls.return_value
+        mock_validator.is_valid.return_value = True
+        mock_validator.save.return_value = {"active_regions": ["default"]}
+        mock_preview.return_value = mock.Mock(
+            status_code=200,
+            json=mock.Mock(return_value={"status": 200}),
+            raise_for_status=mock.Mock(),
+        )
+        mock_generate.return_value = (None, None)
+
+        response = self.client.post(self.url, data=self.payload, format="json")
+
+        assert response.status_code == 200

--- a/tests/sentry/uptime/endpoints/test_organization_uptime_assertion_suggestions.py
+++ b/tests/sentry/uptime/endpoints/test_organization_uptime_assertion_suggestions.py
@@ -83,3 +83,15 @@ class OrganizationUptimeAssertionSuggestionsTest(UptimeAlertBaseEndpointTest):
         )
 
         assert response.status_code == 403
+
+    def test_org_write_scope_cannot_generate_suggestions(self) -> None:
+        api_key = self.create_api_key(organization=self.organization, scope_list=["org:write"])
+
+        response = self.client.post(
+            self.url,
+            data=self.payload,
+            format="json",
+            HTTP_AUTHORIZATION=self.create_basic_auth_header(api_key.key),
+        )
+
+        assert response.status_code == 403

--- a/tests/sentry/uptime/endpoints/test_organization_uptime_assertion_suggestions.py
+++ b/tests/sentry/uptime/endpoints/test_organization_uptime_assertion_suggestions.py
@@ -1,0 +1,85 @@
+from unittest import mock
+
+from django.test import override_settings
+from django.urls import reverse
+
+from sentry.conf.types.uptime import UptimeRegionConfig
+from tests.sentry.uptime.endpoints import UptimeAlertBaseEndpointTest
+
+
+@override_settings(
+    UPTIME_REGIONS=[
+        UptimeRegionConfig(
+            slug="default",
+            name="Default Region",
+            config_redis_key_prefix="default",
+            api_endpoint="pop-st-1.uptime-checker.s4s.sentry.internal:80",
+        )
+    ]
+)
+class OrganizationUptimeAssertionSuggestionsTest(UptimeAlertBaseEndpointTest):
+    endpoint = "sentry-api-0-organization-uptime-assertion-suggestions"
+    method = "post"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.url = reverse(self.endpoint, args=[self.organization.slug])
+        self.payload = {
+            "name": "test",
+            "environment": "uptime-prod",
+            "owner": f"user:{self.user.id}",
+            "url": "http://sentry.io",
+            "timeoutMs": 1500,
+            "body": None,
+            "region": "default",
+        }
+
+    @mock.patch(
+        "sentry.uptime.endpoints.organization_uptime_assertion_suggestions.generate_assertion_suggestions"
+    )
+    @mock.patch(
+        "sentry.uptime.endpoints.organization_uptime_assertion_suggestions.checker_api.invoke_checker_preview"
+    )
+    @mock.patch(
+        "sentry.uptime.endpoints.organization_uptime_assertion_suggestions.UptimeCheckPreviewValidator"
+    )
+    @mock.patch("sentry.uptime.endpoints.organization_uptime_assertion_suggestions.has_seer_access")
+    def test_alerts_write_scope_can_generate_suggestions(
+        self,
+        mock_has_seer_access: mock.MagicMock,
+        mock_validator_cls: mock.MagicMock,
+        mock_preview: mock.MagicMock,
+        mock_generate: mock.MagicMock,
+    ) -> None:
+        api_key = self.create_api_key(organization=self.organization, scope_list=["alerts:write"])
+        mock_has_seer_access.return_value = True
+        mock_validator = mock_validator_cls.return_value
+        mock_validator.is_valid.return_value = True
+        mock_validator.save.return_value = {"active_regions": ["default"]}
+        mock_preview.return_value = mock.Mock(
+            status_code=200,
+            json=mock.Mock(return_value={"status": 200}),
+            raise_for_status=mock.Mock(),
+        )
+        mock_generate.return_value = (None, None)
+
+        response = self.client.post(
+            self.url,
+            data=self.payload,
+            format="json",
+            HTTP_AUTHORIZATION=self.create_basic_auth_header(api_key.key),
+        )
+
+        assert response.status_code == 200
+
+    def test_org_read_scope_cannot_generate_suggestions(self) -> None:
+        api_key = self.create_api_key(organization=self.organization, scope_list=["org:read"])
+
+        response = self.client.post(
+            self.url,
+            data=self.payload,
+            format="json",
+            HTTP_AUTHORIZATION=self.create_basic_auth_header(api_key.key),
+        )
+
+        assert response.status_code == 403

--- a/tests/sentry/uptime/endpoints/test_organization_uptime_assertion_suggestions.py
+++ b/tests/sentry/uptime/endpoints/test_organization_uptime_assertion_suggestions.py
@@ -34,8 +34,6 @@ class OrganizationUptimeAssertionSuggestionsTest(UptimeAlertBaseEndpointTest):
             "region": "default",
         }
 
-    # TODO(api-write-scope-compat): Remove this legacy org:* coverage once
-    # uptime assertion-suggestion clients have migrated to alerts:write.
     @mock.patch(
         "sentry.uptime.endpoints.organization_uptime_assertion_suggestions.generate_assertion_suggestions"
     )
@@ -74,8 +72,6 @@ class OrganizationUptimeAssertionSuggestionsTest(UptimeAlertBaseEndpointTest):
 
         assert response.status_code == 200
 
-    # TODO(api-write-scope-compat): Remove this legacy org:* coverage once
-    # uptime assertion-suggestion clients have migrated to alerts:write.
     @mock.patch(
         "sentry.uptime.endpoints.organization_uptime_assertion_suggestions.generate_assertion_suggestions"
     )
@@ -86,7 +82,7 @@ class OrganizationUptimeAssertionSuggestionsTest(UptimeAlertBaseEndpointTest):
         "sentry.uptime.endpoints.organization_uptime_assertion_suggestions.UptimeCheckPreviewValidator"
     )
     @mock.patch("sentry.uptime.endpoints.organization_uptime_assertion_suggestions.has_seer_access")
-    def test_org_read_scope_can_generate_suggestions(
+    def test_org_read_scope_cannot_generate_suggestions(
         self,
         mock_has_seer_access: mock.MagicMock,
         mock_validator_cls: mock.MagicMock,
@@ -112,7 +108,7 @@ class OrganizationUptimeAssertionSuggestionsTest(UptimeAlertBaseEndpointTest):
             HTTP_AUTHORIZATION=self.create_basic_auth_header(api_key.key),
         )
 
-        assert response.status_code == 200
+        assert response.status_code == 403
 
     @mock.patch(
         "sentry.uptime.endpoints.organization_uptime_assertion_suggestions.generate_assertion_suggestions"

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
@@ -646,6 +646,25 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
 
         assert response.status_code == 403
 
+    def test_team_admin_update_missing_detector_returns_404(self) -> None:
+        team_admin_user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=team_admin_user,
+            organization=self.organization,
+            role="member",
+            team_roles=[(self.team, "admin")],
+        )
+        self.organization.update_option("sentry:alerts_member_write", False)
+        self.login_as(team_admin_user)
+
+        response = self.client.put(
+            reverse(self.endpoint, args=[self.organization.slug, 999999999]),
+            data={"enabled": False},
+            format="json",
+        )
+
+        assert response.status_code == 404
+
     def test_enable_detector(self) -> None:
         self.detector.update(enabled=False)
         self.detector.update(status=ObjectStatus.DISABLED)
@@ -1218,6 +1237,23 @@ class OrganizationDetectorDetailsDeleteTest(OrganizationDetectorDetailsBaseTest)
         )
 
         assert response.status_code == 403
+
+    def test_team_admin_delete_missing_detector_returns_404(self) -> None:
+        team_admin_user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=team_admin_user,
+            organization=self.organization,
+            role="member",
+            team_roles=[(self.team, "admin")],
+        )
+        self.organization.update_option("sentry:alerts_member_write", False)
+        self.login_as(team_admin_user)
+
+        response = self.client.delete(
+            reverse(self.endpoint, args=[self.organization.slug, 999999999])
+        )
+
+        assert response.status_code == 404
 
     @mock.patch(
         "sentry.workflow_engine.endpoints.organization_detector_details.schedule_update_project_config"

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 from unittest import mock
 
 import pytest
+from django.urls import reverse
 from django.utils import timezone
 
 from sentry import audit_log
@@ -13,6 +14,7 @@ from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.models.alert_rule import AlertRuleDetectionType
 from sentry.incidents.utils.constants import INCIDENTS_SNUBA_SUBSCRIPTION_TYPE
 from sentry.incidents.utils.subscription_limits import METRIC_SUBSCRIPTION_FEATURE_FLAGS
+from sentry.models.apitoken import ApiToken
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset
@@ -267,6 +269,10 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
             "config": self.detector.config,
         }
         assert SnubaQuery.objects.get(id=self.snuba_query.id)
+
+    def _create_token(self, scope: str) -> ApiToken:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            return ApiToken.objects.create(user=self.user, scope_list=[scope])
 
     def assert_detector_updated(self, detector: Detector) -> None:
         assert detector.name == "Updated Detector"
@@ -549,6 +555,33 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
         detector = Detector.objects.get(id=response.data["id"])
         assert detector.enabled is False
         assert detector.status == ObjectStatus.DISABLED
+
+    def test_update_requires_alerts_write_scope_for_tokens(self) -> None:
+        token = self._create_token("org:read")
+
+        response = self.client.put(
+            reverse(self.endpoint, args=[self.organization.slug, self.detector.id]),
+            data={"enabled": False},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {token.token}",
+        )
+
+        assert response.status_code == 403
+
+    def test_update_allows_alerts_write_scope_for_tokens(self) -> None:
+        token = self._create_token("alerts:write")
+
+        with self.tasks():
+            response = self.client.put(
+                reverse(self.endpoint, args=[self.organization.slug, self.detector.id]),
+                data={"enabled": False},
+                format="json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 200
+        self.detector.refresh_from_db()
+        assert self.detector.enabled is False
 
     def test_enable_detector(self) -> None:
         self.detector.update(enabled=False)

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
@@ -568,17 +568,22 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
 
         assert response.status_code == 403
 
-    def test_update_rejects_org_write_scope_for_tokens(self) -> None:
+    # TODO(api-write-scope-compat): Remove this legacy org:* coverage once
+    # public detector clients have migrated to alerts:write.
+    def test_update_allows_org_write_scope_for_tokens(self) -> None:
         token = self._create_token("org:write")
 
-        response = self.client.put(
-            reverse(self.endpoint, args=[self.organization.slug, self.detector.id]),
-            data={"enabled": False},
-            format="json",
-            HTTP_AUTHORIZATION=f"Bearer {token.token}",
-        )
+        with self.tasks():
+            response = self.client.put(
+                reverse(self.endpoint, args=[self.organization.slug, self.detector.id]),
+                data={"enabled": False},
+                format="json",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
 
-        assert response.status_code == 403
+        assert response.status_code == 200
+        self.detector.refresh_from_db()
+        assert self.detector.enabled is False
 
     def test_team_admin_can_update_with_project_scoped_alerts_write(self) -> None:
         team_admin_user = self.create_user(is_superuser=False)
@@ -1192,6 +1197,30 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
 @cell_silo_test
 class OrganizationDetectorDetailsDeleteTest(OrganizationDetectorDetailsBaseTest):
     method = "DELETE"
+
+    # TODO(api-write-scope-compat): Remove this legacy org:* coverage once
+    # public detector clients have migrated to alerts:write.
+    def test_delete_allows_org_write_scope_for_tokens(self) -> None:
+        token = self._create_token("org:write")
+
+        with outbox_runner():
+            response = self.client.delete(
+                reverse(self.endpoint, args=[self.organization.slug, self.detector.id]),
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 204
+
+    def test_delete_allows_alerts_write_scope_for_tokens(self) -> None:
+        token = self._create_token("alerts:write")
+
+        with outbox_runner():
+            response = self.client.delete(
+                reverse(self.endpoint, args=[self.organization.slug, self.detector.id]),
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 204
 
     def test_team_admin_can_delete_with_project_scoped_alerts_write(self) -> None:
         team_admin_user = self.create_user(is_superuser=False)

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
@@ -270,9 +270,9 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
         }
         assert SnubaQuery.objects.get(id=self.snuba_query.id)
 
-    def _create_token(self, scope: str) -> ApiToken:
+    def _create_token(self, scope: str, user=None) -> ApiToken:
         with assume_test_silo_mode(SiloMode.CONTROL):
-            return ApiToken.objects.create(user=self.user, scope_list=[scope])
+            return ApiToken.objects.create(user=user or self.user, scope_list=[scope])
 
     def assert_detector_updated(self, detector: Detector) -> None:
         assert detector.name == "Updated Detector"
@@ -582,6 +582,32 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
         assert response.status_code == 200
         self.detector.refresh_from_db()
         assert self.detector.enabled is False
+
+    def test_update_denies_alerts_write_scope_for_other_team_projects(self) -> None:
+        team_admin_user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=team_admin_user,
+            organization=self.organization,
+            role="member",
+            team_roles=[(self.team, "admin")],
+        )
+
+        other_team = self.create_team(organization=self.organization, name="other-team")
+        other_project = self.create_project(
+            organization=self.organization, teams=[other_team], name="other-project"
+        )
+        other_detector = self.create_detector(project=other_project, name="Other Detector")
+
+        token = self._create_token("alerts:write", user=team_admin_user)
+
+        response = self.client.put(
+            reverse(self.endpoint, args=[self.organization.slug, other_detector.id]),
+            data={"enabled": False},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {token.token}",
+        )
+
+        assert response.status_code == 403
 
     def test_enable_detector(self) -> None:
         self.detector.update(enabled=False)
@@ -1110,6 +1136,30 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
 @cell_silo_test
 class OrganizationDetectorDetailsDeleteTest(OrganizationDetectorDetailsBaseTest):
     method = "DELETE"
+
+    def test_delete_denies_alerts_write_scope_for_other_team_projects(self) -> None:
+        team_admin_user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=team_admin_user,
+            organization=self.organization,
+            role="member",
+            team_roles=[(self.team, "admin")],
+        )
+
+        other_team = self.create_team(organization=self.organization, name="other-team")
+        other_project = self.create_project(
+            organization=self.organization, teams=[other_team], name="other-project"
+        )
+        other_detector = self.create_detector(project=other_project, name="Other Detector")
+
+        token = self._create_token("alerts:write", user=team_admin_user)
+
+        response = self.client.delete(
+            reverse(self.endpoint, args=[self.organization.slug, other_detector.id]),
+            HTTP_AUTHORIZATION=f"Bearer {token.token}",
+        )
+
+        assert response.status_code == 403
 
     @mock.patch(
         "sentry.workflow_engine.endpoints.organization_detector_details.schedule_update_project_config"

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
@@ -568,6 +568,28 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
 
         assert response.status_code == 403
 
+    def test_team_admin_can_update_with_project_scoped_alerts_write(self) -> None:
+        team_admin_user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=team_admin_user,
+            organization=self.organization,
+            role="member",
+            team_roles=[(self.team, "admin")],
+        )
+        self.organization.update_option("sentry:alerts_member_write", False)
+        self.login_as(team_admin_user)
+
+        with self.tasks():
+            response = self.client.put(
+                reverse(self.endpoint, args=[self.organization.slug, self.detector.id]),
+                data={"enabled": False},
+                format="json",
+            )
+
+        assert response.status_code == 200
+        self.detector.refresh_from_db()
+        assert self.detector.enabled is False
+
     def test_update_allows_alerts_write_scope_for_tokens(self) -> None:
         token = self._create_token("alerts:write")
 
@@ -1136,6 +1158,24 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
 @cell_silo_test
 class OrganizationDetectorDetailsDeleteTest(OrganizationDetectorDetailsBaseTest):
     method = "DELETE"
+
+    def test_team_admin_can_delete_with_project_scoped_alerts_write(self) -> None:
+        team_admin_user = self.create_user(is_superuser=False)
+        self.create_member(
+            user=team_admin_user,
+            organization=self.organization,
+            role="member",
+            team_roles=[(self.team, "admin")],
+        )
+        self.organization.update_option("sentry:alerts_member_write", False)
+        self.login_as(team_admin_user)
+
+        with outbox_runner():
+            response = self.client.delete(
+                reverse(self.endpoint, args=[self.organization.slug, self.detector.id])
+            )
+
+        assert response.status_code == 204
 
     def test_delete_denies_alerts_write_scope_for_other_team_projects(self) -> None:
         team_admin_user = self.create_user(is_superuser=False)

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
@@ -98,6 +98,10 @@ class OrganizationDetectorDetailsBaseTest(APITestCase):
         )
         assert self.detector.data_sources is not None
 
+    def _create_token(self, scope: str, user=None) -> ApiToken:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            return ApiToken.objects.create(user=user or self.user, scope_list=[scope])
+
 
 @cell_silo_test
 class OrganizationDetectorDetailsGetTest(OrganizationDetectorDetailsBaseTest):
@@ -269,10 +273,6 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
             "config": self.detector.config,
         }
         assert SnubaQuery.objects.get(id=self.snuba_query.id)
-
-    def _create_token(self, scope: str, user=None) -> ApiToken:
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            return ApiToken.objects.create(user=user or self.user, scope_list=[scope])
 
     def assert_detector_updated(self, detector: Detector) -> None:
         assert detector.name == "Updated Detector"
@@ -568,6 +568,18 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
 
         assert response.status_code == 403
 
+    def test_update_rejects_org_write_scope_for_tokens(self) -> None:
+        token = self._create_token("org:write")
+
+        response = self.client.put(
+            reverse(self.endpoint, args=[self.organization.slug, self.detector.id]),
+            data={"enabled": False},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {token.token}",
+        )
+
+        assert response.status_code == 403
+
     def test_team_admin_can_update_with_project_scoped_alerts_write(self) -> None:
         team_admin_user = self.create_user(is_superuser=False)
         self.create_member(
@@ -613,12 +625,15 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
             role="member",
             team_roles=[(self.team, "admin")],
         )
+        self.organization.update_option("sentry:alerts_member_write", False)
 
         other_team = self.create_team(organization=self.organization, name="other-team")
         other_project = self.create_project(
             organization=self.organization, teams=[other_team], name="other-project"
         )
-        other_detector = self.create_detector(project=other_project, name="Other Detector")
+        other_detector = self.create_detector(
+            project=other_project, type=MetricIssue.slug, name="Other Detector"
+        )
 
         token = self._create_token("alerts:write", user=team_admin_user)
 
@@ -1185,12 +1200,15 @@ class OrganizationDetectorDetailsDeleteTest(OrganizationDetectorDetailsBaseTest)
             role="member",
             team_roles=[(self.team, "admin")],
         )
+        self.organization.update_option("sentry:alerts_member_write", False)
 
         other_team = self.create_team(organization=self.organization, name="other-team")
         other_project = self.create_project(
             organization=self.organization, teams=[other_team], name="other-project"
         )
-        other_detector = self.create_detector(project=other_project, name="Other Detector")
+        other_detector = self.create_detector(
+            project=other_project, type=MetricIssue.slug, name="Other Detector"
+        )
 
         token = self._create_token("alerts:write", user=team_admin_user)
 

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from typing import Any
 from unittest import mock
 
 import pytest
@@ -98,7 +99,7 @@ class OrganizationDetectorDetailsBaseTest(APITestCase):
         )
         assert self.detector.data_sources is not None
 
-    def _create_token(self, scope: str, user=None) -> ApiToken:
+    def _create_token(self, scope: str, user: Any | None = None) -> ApiToken:
         with assume_test_silo_mode(SiloMode.CONTROL):
             return ApiToken.objects.create(user=user or self.user, scope_list=[scope])
 

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -1515,6 +1515,27 @@ class OrganizationDetectorDeleteTest(OrganizationDetectorIndexBaseTest):
             actor=self.user,
         )
 
+    def test_delete_detectors_permission_allowed_for_team_admin(self) -> None:
+        team_admin_user = self.create_user()
+        self.create_member(
+            team_roles=[(self.team, "admin")],
+            user=team_admin_user,
+            role="member",
+            organization=self.organization,
+        )
+        self.organization.update_option("sentry:alerts_member_write", False)
+        self.login_as(user=team_admin_user)
+
+        with outbox_runner():
+            self.get_success_response(
+                self.organization.slug,
+                qs_params={"id": str(self.detector.id)},
+                status_code=204,
+            )
+
+        self.detector.refresh_from_db()
+        assert self.detector.status == ObjectStatus.PENDING_DELETION
+
     def test_delete_detectors_permission_denied(self) -> None:
         # Members can not delete detectors for projects they are not part of
         other_detector = self.create_detector(

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 
 import pytest
 from django.db.models import Q
+from django.urls import reverse
 
 from sentry import audit_log
 from sentry.api.serializers import serialize
@@ -13,9 +14,11 @@ from sentry.grouping.grouptype import ErrorGroupType
 from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.models.alert_rule import AlertRule
 from sentry.incidents.utils.constants import INCIDENTS_SNUBA_SUBSCRIPTION_TYPE
+from sentry.models.apitoken import ApiToken
 from sentry.models.environment import Environment
 from sentry.monitors.grouptype import MonitorIncidentType
 from sentry.search.utils import _HACKY_INVALID_USER
+from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
 from sentry.snuba.subscriptions import create_snuba_query, create_snuba_subscription
@@ -24,7 +27,8 @@ from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.outbox import outbox_runner
-from sentry.testutils.silo import cell_silo_test
+from sentry.testutils.skips import requires_kafka, requires_snuba
+from sentry.testutils.silo import assume_test_silo_mode, cell_silo_test
 from sentry.testutils.skips import requires_kafka, requires_snuba
 from sentry.uptime.grouptype import UptimeDomainCheckFailure
 from sentry.uptime.types import (
@@ -62,6 +66,10 @@ class OrganizationDetectorIndexBaseTest(APITestCase):
         self.issue_stream_detector = self.create_detector(
             type=IssueStreamGroupType.slug, project=self.project, name="Issue Stream"
         )
+
+    def _create_token(self, scope: str, user=None) -> ApiToken:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            return ApiToken.objects.create(user=user or self.user, scope_list=[scope])
 
 
 @cell_silo_test
@@ -1022,6 +1030,36 @@ class OrganizationDetectorIndexPutTest(OrganizationDetectorIndexBaseTest):
             organization=self.organization,
         )
 
+    # TODO(api-write-scope-compat): Remove this legacy org:* coverage once
+    # public detector clients have migrated to alerts:write.
+    def test_update_detectors_allows_org_write_scope_for_tokens(self) -> None:
+        token = self._create_token("org:write")
+
+        response = self.client.put(
+            f"{reverse(self.endpoint, args=[self.organization.slug])}?id={self.user_detector.id}",
+            data={"enabled": False},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {token.token}",
+        )
+
+        assert response.status_code == 200
+        self.user_detector.refresh_from_db()
+        assert self.user_detector.enabled is False
+
+    def test_update_detectors_allows_alerts_write_scope_for_tokens(self) -> None:
+        token = self._create_token("alerts:write")
+
+        response = self.client.put(
+            f"{reverse(self.endpoint, args=[self.organization.slug])}?id={self.user_detector.id}",
+            data={"enabled": False},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {token.token}",
+        )
+
+        assert response.status_code == 200
+        self.user_detector.refresh_from_db()
+        assert self.user_detector.enabled is False
+
     def test_update_detectors_by_ids_success(self) -> None:
         response = self.get_success_response(
             self.organization.slug,
@@ -1342,6 +1380,30 @@ class OrganizationDetectorDeleteTest(OrganizationDetectorIndexBaseTest):
         self.detector_three = self.create_detector(
             project=self.project, name="Third Detector", type=MetricIssue.slug
         )
+
+    # TODO(api-write-scope-compat): Remove this legacy org:* coverage once
+    # public detector clients have migrated to alerts:write.
+    def test_delete_detectors_allows_org_write_scope_for_tokens(self) -> None:
+        token = self._create_token("org:write")
+
+        with outbox_runner():
+            response = self.client.delete(
+                f"{reverse(self.endpoint, args=[self.organization.slug])}?id={self.detector.id}",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 204
+
+    def test_delete_detectors_allows_alerts_write_scope_for_tokens(self) -> None:
+        token = self._create_token("alerts:write")
+
+        with outbox_runner():
+            response = self.client.delete(
+                f"{reverse(self.endpoint, args=[self.organization.slug])}?id={self.detector.id}",
+                HTTP_AUTHORIZATION=f"Bearer {token.token}",
+            )
+
+        assert response.status_code == 204
 
     def test_delete_detectors_by_ids_success(self) -> None:
         """Test successful deletion of detectors by specific IDs"""

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -1,5 +1,6 @@
 from collections.abc import Sequence
 from datetime import timedelta
+from typing import Any
 
 import pytest
 from django.db.models import Q
@@ -27,7 +28,6 @@ from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.outbox import outbox_runner
-from sentry.testutils.skips import requires_kafka, requires_snuba
 from sentry.testutils.silo import assume_test_silo_mode, cell_silo_test
 from sentry.testutils.skips import requires_kafka, requires_snuba
 from sentry.uptime.grouptype import UptimeDomainCheckFailure
@@ -67,7 +67,7 @@ class OrganizationDetectorIndexBaseTest(APITestCase):
             type=IssueStreamGroupType.slug, project=self.project, name="Issue Stream"
         )
 
-    def _create_token(self, scope: str, user=None) -> ApiToken:
+    def _create_token(self, scope: str, user: Any | None = None) -> ApiToken:
         with assume_test_silo_mode(SiloMode.CONTROL):
             return ApiToken.objects.create(user=user or self.user, scope_list=[scope])
 

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
@@ -1,6 +1,7 @@
 from contextlib import AbstractContextManager
 
 import responses
+from django.urls import reverse
 
 from sentry import audit_log
 from sentry.api.serializers import serialize
@@ -34,6 +35,10 @@ class OrganizationWorkflowDetailsBaseTest(APITestCase):
     def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
+
+    def _auth_header(self, *scopes: str) -> bytes:
+        api_key = self.create_api_key(organization=self.organization, scope_list=list(scopes))
+        return self.create_basic_auth_header(api_key.key)
 
 
 @cell_silo_test
@@ -81,6 +86,32 @@ class OrganizationUpdateWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWo
             {"name": "teamId", "value": "1"},
             {"name": "assigneeId", "value": "3"},
         ]
+
+    # TODO(api-write-scope-compat): Remove this legacy org:* coverage once
+    # public workflow clients have migrated to alerts:write.
+    def test_update_allows_legacy_org_write_scope_for_api_keys(self) -> None:
+        updated_workflow = {**self.valid_workflow, "name": "Updated Workflow"}
+
+        response = self.client.put(
+            reverse(self.endpoint, args=[self.organization.slug, self.workflow.id]),
+            data=updated_workflow,
+            format="json",
+            HTTP_AUTHORIZATION=self._auth_header("org:write"),
+        )
+
+        assert response.status_code == 200
+
+    def test_update_allows_alerts_write_scope_for_api_keys(self) -> None:
+        updated_workflow = {**self.valid_workflow, "name": "Updated Workflow"}
+
+        response = self.client.put(
+            reverse(self.endpoint, args=[self.organization.slug, self.workflow.id]),
+            data=updated_workflow,
+            format="json",
+            HTTP_AUTHORIZATION=self._auth_header("alerts:write"),
+        )
+
+        assert response.status_code == 200
 
     def test_simple(self) -> None:
         self.valid_workflow["name"] = "Updated Workflow"
@@ -794,6 +825,26 @@ class OrganizationDeleteWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWo
     def setUp(self) -> None:
         super().setUp()
         self.workflow = self.create_workflow(organization_id=self.organization.id)
+
+    # TODO(api-write-scope-compat): Remove this legacy org:* coverage once
+    # public workflow clients have migrated to alerts:write.
+    def test_delete_allows_legacy_org_write_scope_for_api_keys(self) -> None:
+        with outbox_runner():
+            response = self.client.delete(
+                reverse(self.endpoint, args=[self.organization.slug, self.workflow.id]),
+                HTTP_AUTHORIZATION=self._auth_header("org:write"),
+            )
+
+        assert response.status_code == 204
+
+    def test_delete_allows_alerts_write_scope_for_api_keys(self) -> None:
+        with outbox_runner():
+            response = self.client.delete(
+                reverse(self.endpoint, args=[self.organization.slug, self.workflow.id]),
+                HTTP_AUTHORIZATION=self._auth_header("alerts:write"),
+            )
+
+        assert response.status_code == 204
 
     def test_simple(self) -> None:
         with outbox_runner():

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
@@ -3,6 +3,7 @@ from typing import Any
 from unittest import mock
 
 import responses
+from django.urls import reverse
 
 from sentry import audit_log
 from sentry.api.serializers import serialize
@@ -37,6 +38,10 @@ class OrganizationWorkflowAPITestCase(APITestCase):
     def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
+
+    def _auth_headers(self, *scopes: str) -> dict[str, str]:
+        api_key = self.create_api_key(organization=self.organization, scope_list=list(scopes))
+        return {"HTTP_AUTHORIZATION": self.create_basic_auth_header(api_key.key)}
 
 
 @cell_silo_test
@@ -614,6 +619,16 @@ class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase, BaseWorkfl
             {"name": "teamId", "value": "1"},
             {"name": "assigneeId", "value": "3"},
         ]
+
+    def test_create_requires_alerts_write_scope_for_api_keys(self) -> None:
+        response = self.client.post(
+            reverse(self.endpoint, args=[self.organization.slug]),
+            data=self.valid_workflow,
+            format="json",
+            **self._auth_headers("org:write"),
+        )
+
+        assert response.status_code == 403
 
     @mock.patch("sentry.workflow_engine.endpoints.validators.base.workflow.create_audit_entry")
     def test_create_workflow__basic(self, mock_audit: mock.MagicMock) -> None:
@@ -1194,6 +1209,16 @@ class OrganizationWorkflowPutTest(OrganizationWorkflowAPITestCase):
         self.workflow_three = self.create_workflow(
             organization_id=self.organization.id, name="Third Workflow", enabled=False
         )
+
+    def test_bulk_enable_requires_alerts_write_scope_for_api_keys(self) -> None:
+        response = self.client.put(
+            f"{reverse(self.endpoint, args=[self.organization.slug])}?id={self.workflow.id}",
+            data={"enabled": True},
+            format="json",
+            **self._auth_headers("org:write"),
+        )
+
+        assert response.status_code == 403
 
     def test_bulk_enable_workflows_by_ids_success(self) -> None:
         response = self.get_success_response(

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
@@ -620,7 +620,9 @@ class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase, BaseWorkfl
             {"name": "assigneeId", "value": "3"},
         ]
 
-    def test_create_requires_alerts_write_scope_for_api_keys(self) -> None:
+    # TODO(api-write-scope-compat): Remove this legacy org:* coverage once
+    # public workflow clients have migrated to alerts:write.
+    def test_create_allows_legacy_org_write_scope_for_api_keys(self) -> None:
         response = self.client.post(
             reverse(self.endpoint, args=[self.organization.slug]),
             data=self.valid_workflow,
@@ -628,7 +630,17 @@ class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase, BaseWorkfl
             **self._auth_headers("org:write"),
         )
 
-        assert response.status_code == 403
+        assert response.status_code == 201
+
+    def test_create_allows_alerts_write_scope_for_api_keys(self) -> None:
+        response = self.client.post(
+            reverse(self.endpoint, args=[self.organization.slug]),
+            data=self.valid_workflow,
+            format="json",
+            **self._auth_headers("alerts:write"),
+        )
+
+        assert response.status_code == 201
 
     @mock.patch("sentry.workflow_engine.endpoints.validators.base.workflow.create_audit_entry")
     def test_create_workflow__basic(self, mock_audit: mock.MagicMock) -> None:
@@ -1210,7 +1222,9 @@ class OrganizationWorkflowPutTest(OrganizationWorkflowAPITestCase):
             organization_id=self.organization.id, name="Third Workflow", enabled=False
         )
 
-    def test_bulk_enable_requires_alerts_write_scope_for_api_keys(self) -> None:
+    # TODO(api-write-scope-compat): Remove this legacy org:* coverage once
+    # public workflow clients have migrated to alerts:write.
+    def test_bulk_enable_allows_legacy_org_write_scope_for_api_keys(self) -> None:
         response = self.client.put(
             f"{reverse(self.endpoint, args=[self.organization.slug])}?id={self.workflow.id}",
             data={"enabled": True},
@@ -1218,7 +1232,21 @@ class OrganizationWorkflowPutTest(OrganizationWorkflowAPITestCase):
             **self._auth_headers("org:write"),
         )
 
-        assert response.status_code == 403
+        assert response.status_code == 200
+        self.workflow.refresh_from_db()
+        assert self.workflow.enabled is True
+
+    def test_bulk_enable_allows_alerts_write_scope_for_api_keys(self) -> None:
+        response = self.client.put(
+            f"{reverse(self.endpoint, args=[self.organization.slug])}?id={self.workflow.id}",
+            data={"enabled": True},
+            format="json",
+            **self._auth_headers("alerts:write"),
+        )
+
+        assert response.status_code == 200
+        self.workflow.refresh_from_db()
+        assert self.workflow.enabled is True
 
     def test_bulk_enable_workflows_by_ids_success(self) -> None:
         response = self.get_success_response(
@@ -1372,6 +1400,24 @@ class OrganizationWorkflowDeleteTest(OrganizationWorkflowAPITestCase):
         self.workflow_three = self.create_workflow(
             organization_id=self.organization.id, name="Third Workflow"
         )
+
+    # TODO(api-write-scope-compat): Remove this legacy org:* coverage once
+    # public workflow clients have migrated to alerts:write.
+    def test_delete_workflows_allows_legacy_org_write_scope_for_api_keys(self) -> None:
+        response = self.client.delete(
+            f"{reverse(self.endpoint, args=[self.organization.slug])}?id={self.workflow.id}",
+            **self._auth_headers("org:write"),
+        )
+
+        assert response.status_code == 204
+
+    def test_delete_workflows_allows_alerts_write_scope_for_api_keys(self) -> None:
+        response = self.client.delete(
+            f"{reverse(self.endpoint, args=[self.organization.slug])}?id={self.workflow.id}",
+            **self._auth_headers("alerts:write"),
+        )
+
+        assert response.status_code == 204
 
     def test_delete_workflows_by_ids_success(self) -> None:
         """Test successful deletion of workflows by specific IDs"""

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
@@ -39,9 +39,9 @@ class OrganizationWorkflowAPITestCase(APITestCase):
         super().setUp()
         self.login_as(user=self.user)
 
-    def _auth_headers(self, *scopes: str) -> dict[str, str]:
+    def _auth_header(self, *scopes: str) -> bytes:
         api_key = self.create_api_key(organization=self.organization, scope_list=list(scopes))
-        return {"HTTP_AUTHORIZATION": self.create_basic_auth_header(api_key.key)}
+        return self.create_basic_auth_header(api_key.key)
 
 
 @cell_silo_test
@@ -627,7 +627,7 @@ class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase, BaseWorkfl
             reverse(self.endpoint, args=[self.organization.slug]),
             data=self.valid_workflow,
             format="json",
-            **self._auth_headers("org:write"),
+            HTTP_AUTHORIZATION=self._auth_header("org:write"),
         )
 
         assert response.status_code == 201
@@ -637,7 +637,7 @@ class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase, BaseWorkfl
             reverse(self.endpoint, args=[self.organization.slug]),
             data=self.valid_workflow,
             format="json",
-            **self._auth_headers("alerts:write"),
+            HTTP_AUTHORIZATION=self._auth_header("alerts:write"),
         )
 
         assert response.status_code == 201
@@ -1229,7 +1229,7 @@ class OrganizationWorkflowPutTest(OrganizationWorkflowAPITestCase):
             f"{reverse(self.endpoint, args=[self.organization.slug])}?id={self.workflow.id}",
             data={"enabled": True},
             format="json",
-            **self._auth_headers("org:write"),
+            HTTP_AUTHORIZATION=self._auth_header("org:write"),
         )
 
         assert response.status_code == 200
@@ -1241,7 +1241,7 @@ class OrganizationWorkflowPutTest(OrganizationWorkflowAPITestCase):
             f"{reverse(self.endpoint, args=[self.organization.slug])}?id={self.workflow.id}",
             data={"enabled": True},
             format="json",
-            **self._auth_headers("alerts:write"),
+            HTTP_AUTHORIZATION=self._auth_header("alerts:write"),
         )
 
         assert response.status_code == 200
@@ -1406,7 +1406,7 @@ class OrganizationWorkflowDeleteTest(OrganizationWorkflowAPITestCase):
     def test_delete_workflows_allows_legacy_org_write_scope_for_api_keys(self) -> None:
         response = self.client.delete(
             f"{reverse(self.endpoint, args=[self.organization.slug])}?id={self.workflow.id}",
-            **self._auth_headers("org:write"),
+            HTTP_AUTHORIZATION=self._auth_header("org:write"),
         )
 
         assert response.status_code == 204
@@ -1414,7 +1414,7 @@ class OrganizationWorkflowDeleteTest(OrganizationWorkflowAPITestCase):
     def test_delete_workflows_allows_alerts_write_scope_for_api_keys(self) -> None:
         response = self.client.delete(
             f"{reverse(self.endpoint, args=[self.organization.slug])}?id={self.workflow.id}",
-            **self._auth_headers("alerts:write"),
+            HTTP_AUTHORIZATION=self._auth_header("alerts:write"),
         )
 
         assert response.status_code == 204


### PR DESCRIPTION
Tighten published mutation scope enforcement and annotate the remaining published mutations that intentionally still accept readonly or member scopes.

This supersedes #113120 and #113194. The old stacked PR and the clean rebuild had diverged; this PR carries the validated branch state directly against `master`, including the compatibility shims, the follow-up 404 fixes, and the published-mutation audit notes.

Behavioral scope changes
- Alerts: `OrganizationAlertRulePermission` and `OrganizationDetectorPermission` now route alert mutations through `OrganizationAlertingMutationPermission`, whose `POST` / `PUT` / `DELETE` scope map is `alerts:write`.
- Alerts: alert-rule and detector detail flows resolve the target project before object-permission checks so project-scoped `alerts:write` tokens work without regressing missing alert-rule or detector IDs from `404` to `403`.
- Alerts: deprecated public metric-alert create, update, and delete flows keep temporary API-token compatibility for `org:write` only. `org:read`, `org:admin`, and `project:read` are not retained for those mutation paths.
- Alerts: workflow and detector mutation flows now accept `alerts:write` consistently. Workflow and detector endpoints still retain their previous `org:write` / `org:admin` API-token compatibility where those scopes were already accepted.
- Alerts: uptime alert preview, uptime assertion suggestions, Seer anomaly preview, and cron monitor create/update now follow `alerts:write` semantics. They keep temporary `org:write` compatibility only; readonly organization scopes are no longer accepted.
- Event data export: `POST` now requires `event:write` or `event:admin`; `event:read` no longer authorizes export creation.
- Issues: project user issue creation now requires `event:write` or `event:admin`; `event:read` no longer authorizes creating a derived issue occurrence.
- Replays: replay delete now requires `event:admin`; `project:read`, `project:write`, and `event:write` no longer authorize deletion. Replay summary generation stays read-like and is explicitly documented as such.

Published mutation note coverage
- Search and member preference surfaces: added `readonly_mutation_scope_exceptions` notes for pinned searches, saved searches, recent searches, dashboards, dashboard starring, Discover and Explore saved queries, insights segment starring, and group search view preference endpoints.
- Personal/member-state writes that still rely on readonly org or member scopes now carry `TODO(api-scope-personalization)` comments. These are intentionally left as follow-up taxonomy work, not treated as semantically ideal scopes.
- Onboarding and project setup helpers: added notes for onboarding continuation email, onboarding task updates, repo path parsing, organization project experiment create, relaxed project detail updates, and dashboard generation.
- Membership, integrations, and request helpers: added notes for organization change requests, member invite and invite-request flows, team membership helpers, relaxed member delete behavior, bulk code mapping suggestions, Codecov token and repo sync helpers, conduit demo credentials, org auth tokens, and webhook signing secret helpers.
- Read-like helper POSTs: added notes for Seer explorer chat and update, Seer RPC, issue title generation, trace summary, trace explorer AI setup, preprod comparison helpers, Sentry App external issue creation, replay summary generation, and notification action helper endpoints.
- Audit guard: added permission tests that fail any published mutation endpoint that still accepts readonly scopes unless the endpoint or permission class carries a justification note, and fail alert mutation legacy maps that reintroduce readonly scopes.

Future legacy compat to remove
- `TODO(api-write-scope-compat)` in `OrganizationAlertRuleIndexEndpoint.POST`: drop temporary `org:write`.
- `TODO(api-write-scope-compat)` in `OrganizationAlertRuleDetailsEndpoint.PUT` and `.DELETE`: drop temporary `org:write`.
- `TODO(api-write-scope-compat)` in alert-rule project validation: drop temporary `org:write` project-field fallback.
- `TODO(api-write-scope-compat)` in workflow and detector endpoints: drop temporary `org:write` / `org:admin` compatibility after public clients migrate to `alerts:write`.
- `TODO(api-write-scope-compat)` in uptime preview, uptime assertion suggestions, Seer anomaly preview, and cron monitor endpoints: drop temporary `org:write`.
- `TODO(api-scope-personalization)` on personal/member-state writes: introduce a narrow personal or member preference write scope, grant it to normal Sentry member RBAC roles, and move these endpoints off readonly scopes.
- The temporary compat allowances and the regression tests that cover them all carry grepable TODO markers so the eventual cleanup is easy to find.

The OpenAPI scope diff is expected on this PR because the documented security requirements intentionally change.

Refs getsentry/getsentry#19897