### PR TITLE
ref(selective-testing): Re-add make test-selective command

### DIFF
--- a/.github/workflows/scripts/selective-testing/confirm-test-selection.py
+++ b/.github/workflows/scripts/selective-testing/confirm-test-selection.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+LARGE_SELECTION_THRESHOLD = 300
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("Usage: confirm-test-selection.py <selected-tests-file>", file=sys.stderr)
+        return 1
+
+    selected_tests_path = Path(sys.argv[1])
+
+    if not selected_tests_path.exists():
+        print(f"Selected tests file not found: {selected_tests_path}", file=sys.stderr)
+        return 1
+
+    selected_files = [
+        line.strip() for line in selected_tests_path.read_text().splitlines() if line.strip()
+    ]
+    count = len(selected_files)
+
+    if count == 0:
+        prompt = (
+            "The full test suite will be run, usually due to a change in a file that triggers the full suite (see logs above).\n"
+            "Continue? [y/N] "
+        )
+    elif count >= LARGE_SELECTION_THRESHOLD:
+        prompt = f"{count} test files selected, a large amount to run locally. Continue? [y/N] "
+    else:
+        print(f"{count} test files selected")
+        return 0
+
+    try:
+        response = input(prompt).strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        print("\nAborted.")
+        return 1
+
+    if response in ("y", "yes"):
+        return 0
+
+    print("Aborted.")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/scripts/selective-testing/fetch-coverage.py
+++ b/.github/workflows/scripts/selective-testing/fetch-coverage.py
@@ -32,7 +32,19 @@ def check_auth() -> None:
     )
     if result.returncode != 0:
         print("Error: Not authenticated with gcloud.", file=sys.stderr)
-        print("Run: gcloud auth login", file=sys.stderr)
+        print("", file=sys.stderr)
+        print("To authenticate, run:", file=sys.stderr)
+        print("  gcloud auth login", file=sys.stderr)
+        print("  gcloud config set project sentry-dev-tooling", file=sys.stderr)
+        print("", file=sys.stderr)
+        print(
+            "You'll need access to the 'sentry-dev-tooling' GCP project.",
+            file=sys.stderr,
+        )
+        print(
+            "Request access in #discuss-dev-infra if you don't have it.",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
 

--- a/.github/workflows/scripts/selective-testing/fetch-coverage.py
+++ b/.github/workflows/scripts/selective-testing/fetch-coverage.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+GCS_PATH = "gs://getsentry-coverage-data/latest/.coverage.combined"
+COVERAGE_FILENAME = ".coverage.combined"
+CACHE_DIR = Path.home() / ".cache" / "sentry" / "coverage" / "latest"
+
+
+def check_gcloud() -> None:
+    if shutil.which("gcloud") is None:
+        print("Error: gcloud is not installed.", file=sys.stderr)
+        print(
+            "Install the Google Cloud CLI: https://cloud.google.com/sdk/docs/install",
+            file=sys.stderr,
+        )
+        print("  macOS (Homebrew): brew install --cask google-cloud-sdk", file=sys.stderr)
+        sys.exit(1)
+
+
+def check_auth() -> None:
+    result = subprocess.run(
+        ["gcloud", "auth", "print-access-token"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        print("Error: Not authenticated with gcloud.", file=sys.stderr)
+        print("Run: gcloud auth login", file=sys.stderr)
+        sys.exit(1)
+
+
+def get_remote_generation() -> str | None:
+    """Return the GCS object generation number, used to detect staleness."""
+    result = subprocess.run(
+        ["gcloud", "storage", "ls", "-l", GCS_PATH],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return None
+    # Output format: "  <size>  <created>  gs://..."
+    for line in result.stdout.splitlines():
+        parts = line.split()
+        if len(parts) >= 3 and parts[-1].startswith("gs://"):
+            return parts[1]  # creation/update timestamp as cache key
+    return None
+
+
+def download_coverage(output_path: Path) -> None:
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    cached_file = CACHE_DIR / COVERAGE_FILENAME
+    generation_file = CACHE_DIR / ".generation"
+
+    remote_gen = get_remote_generation()
+
+    if cached_file.exists() and remote_gen and generation_file.exists():
+        if generation_file.read_text().strip() == remote_gen:
+            print(f"Using cached coverage data (generation {remote_gen})")
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(cached_file, output_path)
+            return
+
+    print(f"Downloading coverage data from {GCS_PATH}...")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    result = subprocess.run(
+        ["gcloud", "storage", "cp", GCS_PATH, str(output_path)],
+        check=False,
+    )
+    if result.returncode != 0:
+        print("Error: Failed to download coverage database from GCS.", file=sys.stderr)
+        sys.exit(1)
+
+    shutil.copy2(output_path, cached_file)
+    if remote_gen:
+        generation_file.write_text(remote_gen)
+    print(f"Coverage database written to {output_path}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Fetch latest coverage data from GCS for selective testing"
+    )
+    parser.add_argument(
+        "--output",
+        default=".cache/coverage.db",
+        help="Output path for the coverage database (default: .cache/coverage.db)",
+    )
+    args = parser.parse_args()
+
+    check_gcloud()
+    check_auth()
+    download_coverage(Path(args.output))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Makefile
+++ b/Makefile
@@ -153,6 +153,28 @@ test-backend-ci-with-coverage:
 		-o junit_suite_name=pytest
 	@echo ""
 
+test-selective:
+	@echo "--> Running selective tests based on branch changes"
+	python3 .github/workflows/scripts/selective-testing/fetch-coverage.py \
+		--output .cache/coverage.db
+	mkdir -p .cache && > .cache/selected-tests.txt
+	python3 .github/workflows/scripts/compute-sentry-selected-tests.py \
+		--coverage-db .cache/coverage.db \
+		--changed-files "$$(git diff --name-only $$(git merge-base origin/master HEAD))" \
+		--output .cache/selected-tests.txt
+	python3 .github/workflows/scripts/selective-testing/confirm-test-selection.py \
+		.cache/selected-tests.txt
+	SELECTED_TESTS_FILE=.cache/selected-tests.txt \
+	python3 -b -m pytest \
+		tests \
+		--reuse-db \
+		--ignore tests/acceptance \
+		--ignore tests/apidocs \
+		--ignore tests/js \
+		--ignore tests/tools \
+		-svv
+	@echo ""
+
 # it's not possible to change settings.DATABASE after django startup, so
 # unfortunately these tests must be run in a separate pytest process. References:
 #   * https://docs.djangoproject.com/en/4.2/topics/testing/tools/#overriding-settings


### PR DESCRIPTION
Allows for `make test-selective` to run just tests against changed files locally. Downloads latest coverage data since shas won't match getsentry shas, but should be good enough.

Will force a gcloud cli login to be able to fetch the coverage data. We'll wire this up to a service as a follow on/improvement soon