### PR TITLE
ref(relay): Option to prepare removal of metric extraction

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1504,6 +1504,11 @@ register("relay.static_auth", default={}, flags=FLAG_NOSTORE)
 # Example value: [{"project_id": 42}, {"project_id": 123}]
 register("relay.drop-transaction-metrics", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE)
 
+# When True, disables transaction metrics extraction globally.
+register(
+    "relay.transaction-metrics-extraction.disabled", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE
+)
+
 # Relay should emit a usage metric to track total spans.
 register("relay.span-usage-metric", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)
 

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -1172,6 +1172,9 @@ def _filter_option_to_config_setting(flt: _FilterSpec, setting: str) -> Mapping[
 
 
 def _should_extract_transaction_metrics(project: Project) -> bool:
+    if options.get("relay.transaction-metrics-extraction.disabled"):
+        return False
+
     return features.has(
         "organizations:transaction-metrics-extraction", project.organization
     ) and not killswitches.killswitch_matches_context(


### PR DESCRIPTION
We can possibly use the killswitch as well.

The idea is to have an option to prepare for the removal of the code. All of dashboards and alerts have been migrated away from generic metrics.