### PR TITLE
fix(monitors): Move edit breadcrumbs into the top bar

### DIFF
--- a/static/app/views/detectors/components/details/error/index.tsx
+++ b/static/app/views/detectors/components/details/error/index.tsx
@@ -79,34 +79,6 @@ function ResolveSection({project}: {project: Project}) {
   );
 }
 
-function ErrorDetailsBreadcrumbs({
-  detector,
-  project,
-}: {
-  detector: Detector;
-  project: Project;
-}) {
-  const organization = useOrganization();
-
-  return (
-    <Breadcrumbs
-      crumbs={[
-        {
-          label: t('Monitors'),
-          to: makeMonitorBasePathname(organization.slug),
-        },
-        {
-          label: getDetectorTypeLabel(detector.type),
-          to: makeMonitorTypePathname(organization.slug, detector.type),
-        },
-        {
-          label: <ProjectBadge disableLink project={project} avatarSize={16} />,
-        },
-      ]}
-    />
-  );
-}
-
 export function ErrorDetectorDetails({detector, project}: ErrorDetectorDetailsProps) {
   const organization = useOrganization();
   const canEdit = useCanEditDetectorWorkflowConnections({projectId: project.id});
@@ -118,7 +90,21 @@ export function ErrorDetectorDetails({detector, project}: ErrorDetectorDetailsPr
       {hasPageFrameFeature ? (
         <Fragment>
           <TopBar.Slot name="title">
-            <ErrorDetailsBreadcrumbs detector={detector} project={project} />
+            <Breadcrumbs
+              crumbs={[
+                {
+                  label: t('Monitors'),
+                  to: makeMonitorBasePathname(organization.slug),
+                },
+                {
+                  label: getDetectorTypeLabel(detector.type),
+                  to: makeMonitorTypePathname(organization.slug, detector.type),
+                },
+                {
+                  label: <ProjectBadge disableLink project={project} avatarSize={16} />,
+                },
+              ]}
+            />
           </TopBar.Slot>
           <TopBar.Slot name="actions">
             <EditDetectorAction detector={detector} canEdit={canEdit} />

--- a/static/app/views/detectors/components/details/error/index.tsx
+++ b/static/app/views/detectors/components/details/error/index.tsx
@@ -3,6 +3,8 @@ import {Fragment} from 'react';
 import {ExternalLink, Link} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
+import {Breadcrumbs} from 'sentry/components/breadcrumbs';
+import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import {DatePageFilter} from 'sentry/components/pageFilters/date/datePageFilter';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {Placeholder} from 'sentry/components/placeholder';
@@ -19,8 +21,12 @@ import {DisabledAlert} from 'sentry/views/detectors/components/details/common/di
 import {DetectorExtraDetails} from 'sentry/views/detectors/components/details/common/extraDetails';
 import {DetectorDetailsDefaultHeaderContent} from 'sentry/views/detectors/components/details/common/header';
 import {DetectorDetailsOngoingIssues} from 'sentry/views/detectors/components/details/common/ongoingIssues';
-import {ErrorDetectorProjectBreadcrumbs} from 'sentry/views/detectors/components/forms/common/breadcrumbs';
 import {MonitorFeedbackButton} from 'sentry/views/detectors/components/monitorFeedbackButton';
+import {
+  makeMonitorBasePathname,
+  makeMonitorTypePathname,
+} from 'sentry/views/detectors/pathnames';
+import {getDetectorTypeLabel} from 'sentry/views/detectors/utils/detectorTypeConfig';
 import {useCanEditDetectorWorkflowConnections} from 'sentry/views/detectors/utils/useCanEditDetector';
 import {TopBar} from 'sentry/views/navigation/topBar';
 import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
@@ -73,6 +79,34 @@ function ResolveSection({project}: {project: Project}) {
   );
 }
 
+function ErrorDetailsBreadcrumbs({
+  detector,
+  project,
+}: {
+  detector: Detector;
+  project: Project;
+}) {
+  const organization = useOrganization();
+
+  return (
+    <Breadcrumbs
+      crumbs={[
+        {
+          label: t('Monitors'),
+          to: makeMonitorBasePathname(organization.slug),
+        },
+        {
+          label: getDetectorTypeLabel(detector.type),
+          to: makeMonitorTypePathname(organization.slug, detector.type),
+        },
+        {
+          label: <ProjectBadge disableLink project={project} avatarSize={16} />,
+        },
+      ]}
+    />
+  );
+}
+
 export function ErrorDetectorDetails({detector, project}: ErrorDetectorDetailsProps) {
   const organization = useOrganization();
   const canEdit = useCanEditDetectorWorkflowConnections({projectId: project.id});
@@ -84,7 +118,7 @@ export function ErrorDetectorDetails({detector, project}: ErrorDetectorDetailsPr
       {hasPageFrameFeature ? (
         <Fragment>
           <TopBar.Slot name="title">
-            <ErrorDetectorProjectBreadcrumbs detector={detector} project={project} />
+            <ErrorDetailsBreadcrumbs detector={detector} project={project} />
           </TopBar.Slot>
           <TopBar.Slot name="actions">
             <EditDetectorAction detector={detector} canEdit={canEdit} />

--- a/static/app/views/detectors/components/details/error/index.tsx
+++ b/static/app/views/detectors/components/details/error/index.tsx
@@ -19,6 +19,7 @@ import {DisabledAlert} from 'sentry/views/detectors/components/details/common/di
 import {DetectorExtraDetails} from 'sentry/views/detectors/components/details/common/extraDetails';
 import {DetectorDetailsDefaultHeaderContent} from 'sentry/views/detectors/components/details/common/header';
 import {DetectorDetailsOngoingIssues} from 'sentry/views/detectors/components/details/common/ongoingIssues';
+import {ErrorDetectorProjectBreadcrumbs} from 'sentry/views/detectors/components/forms/common/breadcrumbs';
 import {MonitorFeedbackButton} from 'sentry/views/detectors/components/monitorFeedbackButton';
 import {useCanEditDetectorWorkflowConnections} from 'sentry/views/detectors/utils/useCanEditDetector';
 import {TopBar} from 'sentry/views/navigation/topBar';
@@ -82,7 +83,9 @@ export function ErrorDetectorDetails({detector, project}: ErrorDetectorDetailsPr
     <DetailLayout>
       {hasPageFrameFeature ? (
         <Fragment>
-          <DetectorDetailsDefaultHeaderContent detector={detector} project={project} />
+          <TopBar.Slot name="title">
+            <ErrorDetectorProjectBreadcrumbs detector={detector} project={project} />
+          </TopBar.Slot>
           <TopBar.Slot name="actions">
             <EditDetectorAction detector={detector} canEdit={canEdit} />
           </TopBar.Slot>

--- a/static/app/views/detectors/components/forms/common/breadcrumbs.tsx
+++ b/static/app/views/detectors/components/forms/common/breadcrumbs.tsx
@@ -78,7 +78,14 @@ export function ErrorDetectorProjectBreadcrumbs({
           to: makeMonitorTypePathname(organization.slug, detector.type),
         },
         ...(project
-          ? [{label: <ProjectBadge disableLink project={project} avatarSize={16} />}]
+          ? [
+              {
+                label: <ProjectBadge disableLink project={project} avatarSize={16} />,
+                ...(includeConfigure
+                  ? {to: makeMonitorDetailsPathname(organization.slug, detector.id)}
+                  : {}),
+              },
+            ]
           : []),
         ...(includeConfigure ? [{label: t('Configure')}] : []),
       ]}

--- a/static/app/views/detectors/components/forms/common/breadcrumbs.tsx
+++ b/static/app/views/detectors/components/forms/common/breadcrumbs.tsx
@@ -1,5 +1,7 @@
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
+import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import {t} from 'sentry/locale';
+import type {Project} from 'sentry/types/project';
 import type {Detector, DetectorType} from 'sentry/types/workflowEngine/detectors';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {
@@ -48,6 +50,37 @@ export function EditDetectorBreadcrumbs({detector}: {detector: Detector}) {
           to: makeMonitorDetailsPathname(organization.slug, detector.id),
         },
         {label: t('Configure')},
+      ]}
+    />
+  );
+}
+
+export function ErrorDetectorProjectBreadcrumbs({
+  detector,
+  project,
+  includeConfigure = false,
+}: {
+  detector: Detector;
+  includeConfigure?: boolean;
+  project?: Project;
+}) {
+  const organization = useOrganization();
+
+  return (
+    <Breadcrumbs
+      crumbs={[
+        {
+          label: t('Monitors'),
+          to: makeMonitorBasePathname(organization.slug),
+        },
+        {
+          label: getDetectorTypeLabel(detector.type),
+          to: makeMonitorTypePathname(organization.slug, detector.type),
+        },
+        ...(project
+          ? [{label: <ProjectBadge disableLink project={project} avatarSize={16} />}]
+          : []),
+        ...(includeConfigure ? [{label: t('Configure')}] : []),
       ]}
     />
   );

--- a/static/app/views/detectors/components/forms/common/breadcrumbs.tsx
+++ b/static/app/views/detectors/components/forms/common/breadcrumbs.tsx
@@ -1,7 +1,5 @@
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
-import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import {t} from 'sentry/locale';
-import type {Project} from 'sentry/types/project';
 import type {Detector, DetectorType} from 'sentry/types/workflowEngine/detectors';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {
@@ -50,44 +48,6 @@ export function EditDetectorBreadcrumbs({detector}: {detector: Detector}) {
           to: makeMonitorDetailsPathname(organization.slug, detector.id),
         },
         {label: t('Configure')},
-      ]}
-    />
-  );
-}
-
-export function ErrorDetectorProjectBreadcrumbs({
-  detector,
-  project,
-  includeConfigure = false,
-}: {
-  detector: Detector;
-  includeConfigure?: boolean;
-  project?: Project;
-}) {
-  const organization = useOrganization();
-
-  return (
-    <Breadcrumbs
-      crumbs={[
-        {
-          label: t('Monitors'),
-          to: makeMonitorBasePathname(organization.slug),
-        },
-        {
-          label: getDetectorTypeLabel(detector.type),
-          to: makeMonitorTypePathname(organization.slug, detector.type),
-        },
-        ...(project
-          ? [
-              {
-                label: <ProjectBadge disableLink project={project} avatarSize={16} />,
-                ...(includeConfigure
-                  ? {to: makeMonitorDetailsPathname(organization.slug, detector.id)}
-                  : {}),
-              },
-            ]
-          : []),
-        ...(includeConfigure ? [{label: t('Configure')}] : []),
       ]}
     />
   );

--- a/static/app/views/detectors/components/forms/editDetectorLayout.tsx
+++ b/static/app/views/detectors/components/forms/editDetectorLayout.tsx
@@ -23,6 +23,8 @@ import {DetectorNameField} from 'sentry/views/detectors/components/forms/common/
 import {getSubmitButtonTitle} from 'sentry/views/detectors/components/forms/common/getSubmitButtonTitle';
 import {MonitorFeedbackButton} from 'sentry/views/detectors/components/monitorFeedbackButton';
 import {useEditDetectorFormSubmit} from 'sentry/views/detectors/hooks/useEditDetectorFormSubmit';
+import {TopBar} from 'sentry/views/navigation/topBar';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 type EditDetectorLayoutProps<TDetector, TFormData, TUpdatePayload> = {
   children: React.ReactNode;
@@ -49,6 +51,7 @@ export function EditDetectorLayout<
 }: EditDetectorLayoutProps<TDetector, TFormData, TUpdatePayload>) {
   const theme = useTheme();
   const maxWidth = theme.breakpoints.xl;
+  const hasPageFrame = useHasPageFrameFeature();
   const [formModel] = useState(() => new FormModel());
   const {onFieldChange} = useFormEagerValidation(formModel);
 
@@ -73,7 +76,13 @@ export function EditDetectorLayout<
     <EditLayout formProps={formProps}>
       <EditLayout.Header maxWidth={maxWidth}>
         <EditLayout.HeaderContent>
-          <EditDetectorBreadcrumbs detector={detector} />
+          {hasPageFrame ? (
+            <TopBar.Slot name="title">
+              <EditDetectorBreadcrumbs detector={detector} />
+            </TopBar.Slot>
+          ) : (
+            <EditDetectorBreadcrumbs detector={detector} />
+          )}
         </EditLayout.HeaderContent>
 
         <div>

--- a/static/app/views/detectors/components/forms/error/index.tsx
+++ b/static/app/views/detectors/components/forms/error/index.tsx
@@ -8,13 +8,16 @@ import {Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
+import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import {FormContext} from 'sentry/components/forms/formContext';
+import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingError} from 'sentry/components/loadingError';
 import {EditLayout} from 'sentry/components/workflowEngine/layout/edit';
 import {Container} from 'sentry/components/workflowEngine/ui/container';
 import {FormSection} from 'sentry/components/workflowEngine/ui/formSection';
 import {t, tct} from 'sentry/locale';
+import type {Project} from 'sentry/types/project';
 import type {ErrorDetector} from 'sentry/types/workflowEngine/detectors';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjectFromId} from 'sentry/utils/useProjectFromId';
@@ -22,6 +25,11 @@ import {AutomationFeedbackButton} from 'sentry/views/automations/components/auto
 import {AutomateSection} from 'sentry/views/detectors/components/forms/automateSection';
 import {EditDetectorBreadcrumbs} from 'sentry/views/detectors/components/forms/common/breadcrumbs';
 import {useEditDetectorFormSubmit} from 'sentry/views/detectors/hooks/useEditDetectorFormSubmit';
+import {
+  makeMonitorBasePathname,
+  makeMonitorTypePathname,
+} from 'sentry/views/detectors/pathnames';
+import {getDetectorTypeLabel} from 'sentry/views/detectors/utils/detectorTypeConfig';
 import {getNoPermissionToEditMonitorTooltip} from 'sentry/views/detectors/utils/monitorAccessMessages';
 import {useCanEditDetectorWorkflowConnections} from 'sentry/views/detectors/utils/useCanEditDetector';
 import {TopBar} from 'sentry/views/navigation/topBar';
@@ -117,6 +125,35 @@ export function NewErrorDetectorForm() {
   );
 }
 
+function ErrorEditBreadcrumbs({
+  detector,
+  project,
+}: {
+  detector: ErrorDetector;
+  project?: Project;
+}) {
+  const organization = useOrganization();
+
+  return (
+    <Breadcrumbs
+      crumbs={[
+        {
+          label: t('Monitors'),
+          to: makeMonitorBasePathname(organization.slug),
+        },
+        {
+          label: getDetectorTypeLabel(detector.type),
+          to: makeMonitorTypePathname(organization.slug, detector.type),
+        },
+        ...(project
+          ? [{label: <ProjectBadge disableLink project={project} avatarSize={16} />}]
+          : []),
+        {label: t('Configure')},
+      ]}
+    />
+  );
+}
+
 export function EditExistingErrorDetectorForm({detector}: {detector: ErrorDetector}) {
   const project = useProjectFromId({project_id: detector.projectId});
   const theme = useTheme();
@@ -154,9 +191,8 @@ export function EditExistingErrorDetectorForm({detector}: {detector: ErrorDetect
       {hasPageFrameFeature ? (
         <Fragment>
           <TopBar.Slot name="title">
-            <EditDetectorBreadcrumbs detector={detector} />
+            <ErrorEditBreadcrumbs detector={detector} project={project} />
           </TopBar.Slot>
-          <Layout.Title>{detector.name}</Layout.Title>
           <AutomationFeedbackButton />
         </Fragment>
       ) : (

--- a/static/app/views/detectors/components/forms/error/index.tsx
+++ b/static/app/views/detectors/components/forms/error/index.tsx
@@ -8,28 +8,23 @@ import {Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
-import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import {FormContext} from 'sentry/components/forms/formContext';
-import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingError} from 'sentry/components/loadingError';
 import {EditLayout} from 'sentry/components/workflowEngine/layout/edit';
 import {Container} from 'sentry/components/workflowEngine/ui/container';
 import {FormSection} from 'sentry/components/workflowEngine/ui/formSection';
 import {t, tct} from 'sentry/locale';
-import type {Project} from 'sentry/types/project';
 import type {ErrorDetector} from 'sentry/types/workflowEngine/detectors';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjectFromId} from 'sentry/utils/useProjectFromId';
 import {AutomationFeedbackButton} from 'sentry/views/automations/components/automationFeedbackButton';
 import {AutomateSection} from 'sentry/views/detectors/components/forms/automateSection';
-import {EditDetectorBreadcrumbs} from 'sentry/views/detectors/components/forms/common/breadcrumbs';
-import {useEditDetectorFormSubmit} from 'sentry/views/detectors/hooks/useEditDetectorFormSubmit';
 import {
-  makeMonitorBasePathname,
-  makeMonitorTypePathname,
-} from 'sentry/views/detectors/pathnames';
-import {getDetectorTypeLabel} from 'sentry/views/detectors/utils/detectorTypeConfig';
+  EditDetectorBreadcrumbs,
+  ErrorDetectorProjectBreadcrumbs,
+} from 'sentry/views/detectors/components/forms/common/breadcrumbs';
+import {useEditDetectorFormSubmit} from 'sentry/views/detectors/hooks/useEditDetectorFormSubmit';
 import {getNoPermissionToEditMonitorTooltip} from 'sentry/views/detectors/utils/monitorAccessMessages';
 import {useCanEditDetectorWorkflowConnections} from 'sentry/views/detectors/utils/useCanEditDetector';
 import {TopBar} from 'sentry/views/navigation/topBar';
@@ -125,35 +120,6 @@ export function NewErrorDetectorForm() {
   );
 }
 
-function ErrorEditBreadcrumbs({
-  detector,
-  project,
-}: {
-  detector: ErrorDetector;
-  project?: Project;
-}) {
-  const organization = useOrganization();
-
-  return (
-    <Breadcrumbs
-      crumbs={[
-        {
-          label: t('Monitors'),
-          to: makeMonitorBasePathname(organization.slug),
-        },
-        {
-          label: getDetectorTypeLabel(detector.type),
-          to: makeMonitorTypePathname(organization.slug, detector.type),
-        },
-        ...(project
-          ? [{label: <ProjectBadge disableLink project={project} avatarSize={16} />}]
-          : []),
-        {label: t('Configure')},
-      ]}
-    />
-  );
-}
-
 export function EditExistingErrorDetectorForm({detector}: {detector: ErrorDetector}) {
   const project = useProjectFromId({project_id: detector.projectId});
   const theme = useTheme();
@@ -191,7 +157,11 @@ export function EditExistingErrorDetectorForm({detector}: {detector: ErrorDetect
       {hasPageFrameFeature ? (
         <Fragment>
           <TopBar.Slot name="title">
-            <ErrorEditBreadcrumbs detector={detector} project={project} />
+            <ErrorDetectorProjectBreadcrumbs
+              detector={detector}
+              project={project}
+              includeConfigure
+            />
           </TopBar.Slot>
           <AutomationFeedbackButton />
         </Fragment>

--- a/static/app/views/detectors/components/forms/error/index.tsx
+++ b/static/app/views/detectors/components/forms/error/index.tsx
@@ -17,7 +17,6 @@ import {EditLayout} from 'sentry/components/workflowEngine/layout/edit';
 import {Container} from 'sentry/components/workflowEngine/ui/container';
 import {FormSection} from 'sentry/components/workflowEngine/ui/formSection';
 import {t, tct} from 'sentry/locale';
-import type {Project} from 'sentry/types/project';
 import type {ErrorDetector} from 'sentry/types/workflowEngine/detectors';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjectFromId} from 'sentry/utils/useProjectFromId';
@@ -126,41 +125,8 @@ export function NewErrorDetectorForm() {
   );
 }
 
-function ErrorEditBreadcrumbs({
-  detector,
-  project,
-}: {
-  detector: ErrorDetector;
-  project?: Project;
-}) {
-  const organization = useOrganization();
-
-  return (
-    <Breadcrumbs
-      crumbs={[
-        {
-          label: t('Monitors'),
-          to: makeMonitorBasePathname(organization.slug),
-        },
-        {
-          label: getDetectorTypeLabel(detector.type),
-          to: makeMonitorTypePathname(organization.slug, detector.type),
-        },
-        ...(project
-          ? [
-              {
-                label: <ProjectBadge disableLink project={project} avatarSize={16} />,
-                to: makeMonitorDetailsPathname(organization.slug, detector.id),
-              },
-            ]
-          : []),
-        {label: t('Configure')},
-      ]}
-    />
-  );
-}
-
 export function EditExistingErrorDetectorForm({detector}: {detector: ErrorDetector}) {
+  const organization = useOrganization();
   const project = useProjectFromId({project_id: detector.projectId});
   const theme = useTheme();
   const maxWidth = theme.breakpoints.xl;
@@ -197,7 +163,29 @@ export function EditExistingErrorDetectorForm({detector}: {detector: ErrorDetect
       {hasPageFrameFeature ? (
         <Fragment>
           <TopBar.Slot name="title">
-            <ErrorEditBreadcrumbs detector={detector} project={project} />
+            <Breadcrumbs
+              crumbs={[
+                {
+                  label: t('Monitors'),
+                  to: makeMonitorBasePathname(organization.slug),
+                },
+                {
+                  label: getDetectorTypeLabel(detector.type),
+                  to: makeMonitorTypePathname(organization.slug, detector.type),
+                },
+                ...(project
+                  ? [
+                      {
+                        label: (
+                          <ProjectBadge disableLink project={project} avatarSize={16} />
+                        ),
+                        to: makeMonitorDetailsPathname(organization.slug, detector.id),
+                      },
+                    ]
+                  : []),
+                {label: t('Configure')},
+              ]}
+            />
           </TopBar.Slot>
           <AutomationFeedbackButton />
         </Fragment>

--- a/static/app/views/detectors/components/forms/error/index.tsx
+++ b/static/app/views/detectors/components/forms/error/index.tsx
@@ -1,3 +1,4 @@
+import {Fragment} from 'react';
 import {Link} from 'react-router-dom';
 import {useTheme} from '@emotion/react';
 import {Observer} from 'mobx-react-lite';
@@ -157,9 +158,11 @@ export function EditExistingErrorDetectorForm({detector}: {detector: ErrorDetect
               <EditDetectorBreadcrumbs detector={detector} />
             </TopBar.Slot>
           ) : (
-            <EditDetectorBreadcrumbs detector={detector} />
+            <Fragment>
+              <EditDetectorBreadcrumbs detector={detector} />
+              <EditLayout.Title title={detector.name} project={project} />
+            </Fragment>
           )}
-          <EditLayout.Title title={detector.name} project={project} />
         </EditLayout.HeaderContent>
         <EditLayout.Actions>
           <AutomationFeedbackButton />

--- a/static/app/views/detectors/components/forms/error/index.tsx
+++ b/static/app/views/detectors/components/forms/error/index.tsx
@@ -151,23 +151,26 @@ export function EditExistingErrorDetectorForm({detector}: {detector: ErrorDetect
         onSubmit: handleFormSubmit,
       }}
     >
-      <EditLayout.Header>
-        <EditLayout.HeaderContent>
-          {hasPageFrameFeature ? (
-            <TopBar.Slot name="title">
-              <EditDetectorBreadcrumbs detector={detector} />
-            </TopBar.Slot>
-          ) : (
+      {hasPageFrameFeature ? (
+        <Fragment>
+          <TopBar.Slot name="title">
+            <EditDetectorBreadcrumbs detector={detector} />
+          </TopBar.Slot>
+          <AutomationFeedbackButton />
+        </Fragment>
+      ) : (
+        <EditLayout.Header>
+          <EditLayout.HeaderContent>
             <Fragment>
               <EditDetectorBreadcrumbs detector={detector} />
               <EditLayout.Title title={detector.name} project={project} />
             </Fragment>
-          )}
-        </EditLayout.HeaderContent>
-        <EditLayout.Actions>
-          <AutomationFeedbackButton />
-        </EditLayout.Actions>
-      </EditLayout.Header>
+          </EditLayout.HeaderContent>
+          <EditLayout.Actions>
+            <AutomationFeedbackButton />
+          </EditLayout.Actions>
+        </EditLayout.Header>
+      )}
 
       <EditLayout.Body>
         <ErrorDetectorForm detector={detector} />

--- a/static/app/views/detectors/components/forms/error/index.tsx
+++ b/static/app/views/detectors/components/forms/error/index.tsx
@@ -9,6 +9,7 @@ import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
 import {FormContext} from 'sentry/components/forms/formContext';
+import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingError} from 'sentry/components/loadingError';
 import {EditLayout} from 'sentry/components/workflowEngine/layout/edit';
@@ -155,6 +156,7 @@ export function EditExistingErrorDetectorForm({detector}: {detector: ErrorDetect
         <Fragment>
           <TopBar.Slot name="title">
             <EditDetectorBreadcrumbs detector={detector} />
+            {project && <ProjectBadge disableLink project={project} avatarSize={16} />}
           </TopBar.Slot>
           <AutomationFeedbackButton />
         </Fragment>

--- a/static/app/views/detectors/components/forms/error/index.tsx
+++ b/static/app/views/detectors/components/forms/error/index.tsx
@@ -23,6 +23,8 @@ import {EditDetectorBreadcrumbs} from 'sentry/views/detectors/components/forms/c
 import {useEditDetectorFormSubmit} from 'sentry/views/detectors/hooks/useEditDetectorFormSubmit';
 import {getNoPermissionToEditMonitorTooltip} from 'sentry/views/detectors/utils/monitorAccessMessages';
 import {useCanEditDetectorWorkflowConnections} from 'sentry/views/detectors/utils/useCanEditDetector';
+import {TopBar} from 'sentry/views/navigation/topBar';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 type ErrorDetectorFormData = {
   workflowIds: string[];
@@ -118,6 +120,7 @@ export function EditExistingErrorDetectorForm({detector}: {detector: ErrorDetect
   const project = useProjectFromId({project_id: detector.projectId});
   const theme = useTheme();
   const maxWidth = theme.breakpoints.xl;
+  const hasPageFrameFeature = useHasPageFrameFeature();
 
   // Error monitors only allow editing workflow connections right now, so that's the only permission we need to check
   const canEditWorkflowConnections = useCanEditDetectorWorkflowConnections({
@@ -149,7 +152,13 @@ export function EditExistingErrorDetectorForm({detector}: {detector: ErrorDetect
     >
       <EditLayout.Header>
         <EditLayout.HeaderContent>
-          <EditDetectorBreadcrumbs detector={detector} />
+          {hasPageFrameFeature ? (
+            <TopBar.Slot name="title">
+              <EditDetectorBreadcrumbs detector={detector} />
+            </TopBar.Slot>
+          ) : (
+            <EditDetectorBreadcrumbs detector={detector} />
+          )}
           <EditLayout.Title title={detector.name} project={project} />
         </EditLayout.HeaderContent>
         <EditLayout.Actions>

--- a/static/app/views/detectors/components/forms/error/index.tsx
+++ b/static/app/views/detectors/components/forms/error/index.tsx
@@ -8,23 +8,29 @@ import {Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
+import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import {FormContext} from 'sentry/components/forms/formContext';
+import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingError} from 'sentry/components/loadingError';
 import {EditLayout} from 'sentry/components/workflowEngine/layout/edit';
 import {Container} from 'sentry/components/workflowEngine/ui/container';
 import {FormSection} from 'sentry/components/workflowEngine/ui/formSection';
 import {t, tct} from 'sentry/locale';
+import type {Project} from 'sentry/types/project';
 import type {ErrorDetector} from 'sentry/types/workflowEngine/detectors';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjectFromId} from 'sentry/utils/useProjectFromId';
 import {AutomationFeedbackButton} from 'sentry/views/automations/components/automationFeedbackButton';
 import {AutomateSection} from 'sentry/views/detectors/components/forms/automateSection';
-import {
-  EditDetectorBreadcrumbs,
-  ErrorDetectorProjectBreadcrumbs,
-} from 'sentry/views/detectors/components/forms/common/breadcrumbs';
+import {EditDetectorBreadcrumbs} from 'sentry/views/detectors/components/forms/common/breadcrumbs';
 import {useEditDetectorFormSubmit} from 'sentry/views/detectors/hooks/useEditDetectorFormSubmit';
+import {
+  makeMonitorBasePathname,
+  makeMonitorDetailsPathname,
+  makeMonitorTypePathname,
+} from 'sentry/views/detectors/pathnames';
+import {getDetectorTypeLabel} from 'sentry/views/detectors/utils/detectorTypeConfig';
 import {getNoPermissionToEditMonitorTooltip} from 'sentry/views/detectors/utils/monitorAccessMessages';
 import {useCanEditDetectorWorkflowConnections} from 'sentry/views/detectors/utils/useCanEditDetector';
 import {TopBar} from 'sentry/views/navigation/topBar';
@@ -120,6 +126,40 @@ export function NewErrorDetectorForm() {
   );
 }
 
+function ErrorEditBreadcrumbs({
+  detector,
+  project,
+}: {
+  detector: ErrorDetector;
+  project?: Project;
+}) {
+  const organization = useOrganization();
+
+  return (
+    <Breadcrumbs
+      crumbs={[
+        {
+          label: t('Monitors'),
+          to: makeMonitorBasePathname(organization.slug),
+        },
+        {
+          label: getDetectorTypeLabel(detector.type),
+          to: makeMonitorTypePathname(organization.slug, detector.type),
+        },
+        ...(project
+          ? [
+              {
+                label: <ProjectBadge disableLink project={project} avatarSize={16} />,
+                to: makeMonitorDetailsPathname(organization.slug, detector.id),
+              },
+            ]
+          : []),
+        {label: t('Configure')},
+      ]}
+    />
+  );
+}
+
 export function EditExistingErrorDetectorForm({detector}: {detector: ErrorDetector}) {
   const project = useProjectFromId({project_id: detector.projectId});
   const theme = useTheme();
@@ -157,11 +197,7 @@ export function EditExistingErrorDetectorForm({detector}: {detector: ErrorDetect
       {hasPageFrameFeature ? (
         <Fragment>
           <TopBar.Slot name="title">
-            <ErrorDetectorProjectBreadcrumbs
-              detector={detector}
-              project={project}
-              includeConfigure
-            />
+            <ErrorEditBreadcrumbs detector={detector} project={project} />
           </TopBar.Slot>
           <AutomationFeedbackButton />
         </Fragment>

--- a/static/app/views/detectors/components/forms/error/index.tsx
+++ b/static/app/views/detectors/components/forms/error/index.tsx
@@ -17,9 +17,9 @@ import {EditLayout} from 'sentry/components/workflowEngine/layout/edit';
 import {Container} from 'sentry/components/workflowEngine/ui/container';
 import {FormSection} from 'sentry/components/workflowEngine/ui/formSection';
 import {t, tct} from 'sentry/locale';
+import type {Project} from 'sentry/types/project';
 import type {ErrorDetector} from 'sentry/types/workflowEngine/detectors';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {useProjectFromId} from 'sentry/utils/useProjectFromId';
 import {AutomationFeedbackButton} from 'sentry/views/automations/components/automationFeedbackButton';
 import {AutomateSection} from 'sentry/views/detectors/components/forms/automateSection';
 import {EditDetectorBreadcrumbs} from 'sentry/views/detectors/components/forms/common/breadcrumbs';
@@ -39,9 +39,8 @@ type ErrorDetectorFormData = {
   workflowIds: string[];
 };
 
-function ErrorDetectorForm({detector}: {detector: ErrorDetector}) {
+function ErrorDetectorForm({project}: {project: Project}) {
   const organization = useOrganization();
-  const project = useProjectFromId({project_id: detector.projectId});
   const theme = useTheme();
 
   return (
@@ -54,7 +53,7 @@ function ErrorDetectorForm({detector}: {detector: ErrorDetector}) {
               {
                 link: (
                   <Link
-                    to={`/settings/${organization.slug}/projects/${project?.slug}/issue-grouping/`}
+                    to={`/settings/${organization.slug}/projects/${project.slug}/issue-grouping/`}
                   />
                 ),
               }
@@ -70,7 +69,7 @@ function ErrorDetectorForm({detector}: {detector: ErrorDetector}) {
               {
                 link: (
                   <Link
-                    to={`/settings/${organization.slug}/projects/${project?.slug}/ownership/`}
+                    to={`/settings/${organization.slug}/projects/${project.slug}/ownership/`}
                   />
                 ),
               }
@@ -100,7 +99,7 @@ function ErrorDetectorForm({detector}: {detector: ErrorDetector}) {
               {
                 link: (
                   <Link
-                    to={`/settings/${organization.slug}/projects/${project?.slug}/#resolveAge`}
+                    to={`/settings/${organization.slug}/projects/${project.slug}/#resolveAge`}
                   />
                 ),
               }
@@ -125,9 +124,14 @@ export function NewErrorDetectorForm() {
   );
 }
 
-export function EditExistingErrorDetectorForm({detector}: {detector: ErrorDetector}) {
+export function EditExistingErrorDetectorForm({
+  detector,
+  project,
+}: {
+  detector: ErrorDetector;
+  project: Project;
+}) {
   const organization = useOrganization();
-  const project = useProjectFromId({project_id: detector.projectId});
   const theme = useTheme();
   const maxWidth = theme.breakpoints.xl;
   const hasPageFrameFeature = useHasPageFrameFeature();
@@ -173,16 +177,10 @@ export function EditExistingErrorDetectorForm({detector}: {detector: ErrorDetect
                   label: getDetectorTypeLabel(detector.type),
                   to: makeMonitorTypePathname(organization.slug, detector.type),
                 },
-                ...(project
-                  ? [
-                      {
-                        label: (
-                          <ProjectBadge disableLink project={project} avatarSize={16} />
-                        ),
-                        to: makeMonitorDetailsPathname(organization.slug, detector.id),
-                      },
-                    ]
-                  : []),
+                {
+                  label: <ProjectBadge disableLink project={project} avatarSize={16} />,
+                  to: makeMonitorDetailsPathname(organization.slug, detector.id),
+                },
                 {label: t('Configure')},
               ]}
             />
@@ -204,7 +202,7 @@ export function EditExistingErrorDetectorForm({detector}: {detector: ErrorDetect
       )}
 
       <EditLayout.Body>
-        <ErrorDetectorForm detector={detector} />
+        <ErrorDetectorForm project={project} />
       </EditLayout.Body>
 
       <FormContext.Consumer>

--- a/static/app/views/detectors/components/forms/error/index.tsx
+++ b/static/app/views/detectors/components/forms/error/index.tsx
@@ -9,7 +9,6 @@ import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
 import {FormContext} from 'sentry/components/forms/formContext';
-import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingError} from 'sentry/components/loadingError';
 import {EditLayout} from 'sentry/components/workflowEngine/layout/edit';
@@ -156,8 +155,8 @@ export function EditExistingErrorDetectorForm({detector}: {detector: ErrorDetect
         <Fragment>
           <TopBar.Slot name="title">
             <EditDetectorBreadcrumbs detector={detector} />
-            {project && <ProjectBadge disableLink project={project} avatarSize={16} />}
           </TopBar.Slot>
+          <Layout.Title>{detector.name}</Layout.Title>
           <AutomationFeedbackButton />
         </Fragment>
       ) : (

--- a/static/app/views/detectors/components/forms/index.tsx
+++ b/static/app/views/detectors/components/forms/index.tsx
@@ -4,6 +4,7 @@ import {Stack} from '@sentry/scraps/layout';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingError} from 'sentry/components/loadingError';
 import {t} from 'sentry/locale';
+import type {Project} from 'sentry/types/project';
 import type {Detector, DetectorType} from 'sentry/types/workflowEngine/detectors';
 import {unreachable} from 'sentry/utils/unreachable';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -65,7 +66,13 @@ export function NewDetectorForm({detectorType}: {detectorType: DetectorType}) {
   }
 }
 
-export function EditExistingDetectorForm({detector}: {detector: Detector}) {
+export function EditExistingDetectorForm({
+  detector,
+  project,
+}: {
+  detector: Detector;
+  project: Project;
+}) {
   const detectorType = detector.type;
   switch (detectorType) {
     case 'metric_issue':
@@ -73,7 +80,7 @@ export function EditExistingDetectorForm({detector}: {detector: Detector}) {
     case 'uptime_domain_failure':
       return <EditExistingUptimeDetectorForm detector={detector} />;
     case 'error':
-      return <EditExistingErrorDetectorForm detector={detector} />;
+      return <EditExistingErrorDetectorForm detector={detector} project={project} />;
     case 'monitor_check_in_failure':
       return <EditExistingCronDetectorForm detector={detector} />;
     case 'issue_stream':

--- a/static/app/views/detectors/edit.tsx
+++ b/static/app/views/detectors/edit.tsx
@@ -41,7 +41,7 @@ export default function DetectorEdit() {
 
   return (
     <DetectorFormProvider detectorType={detector.type} detector={detector}>
-      <EditExistingDetectorForm detector={detector} />
+      <EditExistingDetectorForm detector={detector} project={project} />
     </DetectorFormProvider>
   );
 }


### PR DESCRIPTION
**Before**

https://github.com/user-attachments/assets/90f32a36-8e81-4ee4-8b84-c6f9c40f47f4




**After**

https://github.com/user-attachments/assets/599270d3-7878-43ba-b549-6577ac8032c7

closes https://linear.app/getsentry/issue/DE-1141/monitors-doesnt-render-breadcrumbs-into-the-title-slot