### PR TITLE
feat(db): Add PostgreSQL partitioned table support infrastructure

### DIFF
--- a/src/sentry/db/models/base.py
+++ b/src/sentry/db/models/base.py
@@ -392,6 +392,21 @@ def __model_class_prepared(sender: Any, **kwargs: Any) -> None:
             f"Please set `__relocation_scope__ = RelocationScope.Excluded` on the model definition."
         )
 
+    # Validate partitioned model configuration
+    from sentry.db.models.partitioned import PartitionConfig
+
+    partitioning = getattr(sender, "partitioning", None)
+    if partitioning is not None and isinstance(partitioning, PartitionConfig):
+        # Validate that all partition key columns exist on the model
+        for field_name in partitioning.key:
+            try:
+                sender._meta.get_field(field_name)
+            except Exception:
+                raise ValueError(
+                    f"{sender!r} defines partitioning key column '{field_name}' "
+                    f"that does not exist on the model."
+                )
+
     from sentry.hybridcloud.outbox.base import ReplicatedCellModel, ReplicatedControlModel
 
     if issubclass(sender, ReplicatedControlModel):

--- a/src/sentry/db/models/partitioned.py
+++ b/src/sentry/db/models/partitioned.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import ClassVar
-
-from django.db import models
+from typing import Any, ClassVar
 
 __all__ = (
     "HashPartition",
@@ -35,12 +33,12 @@ class PartitionConfig:
         if not self.key:
             raise ValueError("PartitionConfig.key must contain at least one column name")
 
-    def sql_clause(self, model: type[models.Model]) -> str:
+    def sql_clause(self, model: Any) -> str:
         """Generate the PARTITION BY SQL clause."""
         columns = ", ".join(self._resolve_column_names(model))
         return f"PARTITION BY {self.strategy.value} ({columns})"
 
-    def _resolve_column_names(self, model: type[models.Model]) -> list[str]:
+    def _resolve_column_names(self, model: Any) -> list[str]:
         """Resolve model field names to database column names."""
         columns = []
         for field_name in self.key:
@@ -70,7 +68,7 @@ class ListPartition:
     """Defines a LIST partition with explicit values."""
 
     name: str
-    values: list[str] = field(default_factory=list)
+    values: list[str | int] = field(default_factory=list)
 
     def sql_bound_clause(self) -> str:
         formatted = ", ".join(f"'{v}'" if isinstance(v, str) else str(v) for v in self.values)
@@ -93,7 +91,7 @@ class HashPartition:
 Partition = RangePartition | ListPartition | HashPartition
 
 
-def is_partitioning_enabled(model_or_table: type[models.Model] | str) -> bool:
+def is_partitioning_enabled(model_or_table: Any) -> bool:
     """
     Check if partitioning is enabled for a given model in this environment.
 
@@ -142,7 +140,7 @@ def _get_partitioned_model_base():
 
 
 # Lazily initialized on first access
-_PartitionedModel = None
+_PartitionedModel: type | None = None
 
 
 def get_partitioned_model_class():

--- a/src/sentry/db/models/partitioned.py
+++ b/src/sentry/db/models/partitioned.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import ClassVar
+
+from django.db import models
+
+__all__ = (
+    "HashPartition",
+    "ListPartition",
+    "PartitionConfig",
+    "PartitionStrategy",
+    "RangePartition",
+    "get_partitioned_model_class",
+    "is_partitioning_enabled",
+)
+
+
+class PartitionStrategy(Enum):
+    RANGE = "RANGE"
+    LIST = "LIST"
+    HASH = "HASH"
+
+
+@dataclass(frozen=True)
+class PartitionConfig:
+    """Configuration for how a table should be partitioned."""
+
+    strategy: PartitionStrategy
+    key: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if not self.key:
+            raise ValueError("PartitionConfig.key must contain at least one column name")
+
+    def sql_clause(self, model: type[models.Model]) -> str:
+        """Generate the PARTITION BY SQL clause."""
+        columns = ", ".join(self._resolve_column_names(model))
+        return f"PARTITION BY {self.strategy.value} ({columns})"
+
+    def _resolve_column_names(self, model: type[models.Model]) -> list[str]:
+        """Resolve model field names to database column names."""
+        columns = []
+        for field_name in self.key:
+            try:
+                model_field = model._meta.get_field(field_name)
+                column = getattr(model_field, "column", None)
+                columns.append(column if column else field_name)
+            except Exception:
+                columns.append(field_name)
+        return columns
+
+
+@dataclass(frozen=True)
+class RangePartition:
+    """Defines a RANGE partition with FROM/TO bounds."""
+
+    name: str
+    from_values: str
+    to_values: str
+
+    def sql_bound_clause(self) -> str:
+        return f"FOR VALUES FROM ({self.from_values}) TO ({self.to_values})"
+
+
+@dataclass(frozen=True)
+class ListPartition:
+    """Defines a LIST partition with explicit values."""
+
+    name: str
+    values: list[str] = field(default_factory=list)
+
+    def sql_bound_clause(self) -> str:
+        formatted = ", ".join(f"'{v}'" if isinstance(v, str) else str(v) for v in self.values)
+        return f"FOR VALUES IN ({formatted})"
+
+
+@dataclass(frozen=True)
+class HashPartition:
+    """Defines a HASH partition with modulus and remainder."""
+
+    name: str
+    modulus: int
+    remainder: int
+
+    def sql_bound_clause(self) -> str:
+        return f"FOR VALUES WITH (MODULUS {self.modulus}, REMAINDER {self.remainder})"
+
+
+# Union type for all partition kinds
+Partition = RangePartition | ListPartition | HashPartition
+
+
+def is_partitioning_enabled(model_or_table: type[models.Model] | str) -> bool:
+    """
+    Check if partitioning is enabled for a given model in this environment.
+
+    Controlled by the SENTRY_PARTITIONED_MODELS environment variable:
+    - Empty or unset: partitioning disabled for all models (default)
+    - "__all__": partitioning enabled for all models that define it
+    - Comma-separated db_table names: enabled only for those models
+    """
+    env_value = os.environ.get("SENTRY_PARTITIONED_MODELS", "")
+    if not env_value:
+        return False
+    if env_value == "__all__":
+        return True
+    enabled_tables = {t.strip() for t in env_value.split(",")}
+    if isinstance(model_or_table, str):
+        table_name = model_or_table
+    else:
+        table_name = model_or_table._meta.db_table
+    return table_name in enabled_tables
+
+
+def _get_partitioned_model_base():
+    """Lazy import to avoid circular dependency with sentry.db.models.base."""
+    from sentry.db.models.base import Model
+
+    class PartitionedModel(Model):
+        """
+        Abstract base for models backed by PostgreSQL partitioned tables.
+
+        Subclasses must define a `partitioning` class variable:
+
+            class MyModel(PartitionedModel):
+                partitioning = PartitionConfig(
+                    strategy=PartitionStrategy.RANGE,
+                    key=["date_added"],
+                )
+                ...
+        """
+
+        partitioning: ClassVar[PartitionConfig]
+
+        class Meta:
+            abstract = True
+
+    return PartitionedModel
+
+
+# Lazily initialized on first access
+_PartitionedModel = None
+
+
+def get_partitioned_model_class():
+    """Get the PartitionedModel base class, creating it on first access."""
+    global _PartitionedModel
+    if _PartitionedModel is None:
+        _PartitionedModel = _get_partitioned_model_base()
+    return _PartitionedModel
+
+
+def get_partitions(connection, parent_table: str) -> list[str]:
+    """
+    Discover all child partition table names for a given parent table
+    by querying pg_inherits.
+    """
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT c.relname
+            FROM pg_inherits i
+            JOIN pg_class c ON c.oid = i.inhrelid
+            JOIN pg_class p ON p.oid = i.inhparent
+            JOIN pg_namespace n ON n.oid = p.relnamespace
+            WHERE p.relname = %s AND n.nspname = 'public'
+            ORDER BY c.relname
+            """,
+            [parent_table],
+        )
+        return [row[0] for row in cursor.fetchall()]

--- a/src/sentry/db/postgres/schema.py
+++ b/src/sentry/db/postgres/schema.py
@@ -60,7 +60,67 @@ def translate_unsafeoperation_exception(func):
     return inner
 
 
-class MakeBtreeGistSchemaEditor(PostgresDatabaseSchemaEditor):
+def _get_partition_config(model: type[Model]):
+    """Get the partition config for a model, if it has one and partitioning is enabled."""
+    from sentry.db.models.partitioned import PartitionConfig, is_partitioning_enabled
+
+    config = getattr(model, "partitioning", None)
+    if (
+        config is not None
+        and isinstance(config, PartitionConfig)
+        and is_partitioning_enabled(model)
+    ):
+        return config
+    return None
+
+
+class PartitionAwareSchemaEditorMixin:
+    """
+    Mixin that modifies table creation to support PostgreSQL partitioned tables.
+
+    When a model has a `partitioning` attribute (a PartitionConfig) and partitioning
+    is enabled for that model in the current environment, this mixin:
+    1. Appends a PARTITION BY clause to the CREATE TABLE statement
+    2. Strips auto-generated indexes from deferred_sql (indexes should be managed
+       per-partition, not on the parent table)
+    """
+
+    def table_sql(self, model: type[Model]) -> tuple[str, list]:
+        sql, params = super().table_sql(model)  # type: ignore[misc]
+        config = _get_partition_config(model)
+        if config is not None:
+            sql += " " + config.sql_clause(model)
+        return sql, params
+
+    def create_model(self, model: type[Model]) -> None:
+        config = _get_partition_config(model)
+        if config is None:
+            super().create_model(model)  # type: ignore[misc]
+            return
+
+        # Track deferred_sql before create_model adds indexes
+        pre_create_deferred = list(self.deferred_sql)  # type: ignore[attr-defined]
+
+        super().create_model(model)  # type: ignore[misc]
+
+        # Strip index-creation SQL that was added for the parent table.
+        # Partitioned parent tables cannot have indexes directly; indexes
+        # must be created on individual partitions for CONCURRENTLY support.
+        # We keep non-index deferred SQL (FK constraints, unique_together, etc.)
+        table_name = model._meta.db_table
+        filtered = []
+        for stmt in self.deferred_sql:  # type: ignore[attr-defined]
+            if stmt in pre_create_deferred:
+                filtered.append(stmt)
+                continue
+            stmt_str = str(stmt)
+            if "CREATE INDEX" in stmt_str.upper() and table_name in stmt_str:
+                continue
+            filtered.append(stmt)
+        self.deferred_sql[:] = filtered  # type: ignore[attr-defined]
+
+
+class MakeBtreeGistSchemaEditor(PartitionAwareSchemaEditorMixin, PostgresDatabaseSchemaEditor):
     """workaround for https://code.djangoproject.com/ticket/36374"""
 
     def create_model(self, model: type[Model]) -> None:
@@ -74,7 +134,9 @@ class MakeBtreeGistSchemaEditor(PostgresDatabaseSchemaEditor):
         super().add_constraint(model, constraint)
 
 
-class SafePostgresDatabaseSchemaEditor(DatabaseSchemaEditorMixin, PostgresDatabaseSchemaEditor):
+class SafePostgresDatabaseSchemaEditor(
+    DatabaseSchemaEditorMixin, PartitionAwareSchemaEditorMixin, PostgresDatabaseSchemaEditor
+):
     add_field = translate_unsafeoperation_exception(PostgresDatabaseSchemaEditor.add_field)
     alter_field = translate_unsafeoperation_exception(PostgresDatabaseSchemaEditor.alter_field)
     alter_db_tablespace = translate_unsafeoperation_exception(

--- a/src/sentry/new_migrations/monkey/partitioned.py
+++ b/src/sentry/new_migrations/monkey/partitioned.py
@@ -178,6 +178,25 @@ class RemovePartition(ModelOperation):
         return f"{self.name_lower}_remove_{self.partition.name}"
 
 
+def _execute_outside_transaction(schema_editor, sql: str) -> None:
+    """
+    Execute SQL outside of a transaction, required for CONCURRENTLY operations.
+
+    CONCURRENTLY DDL cannot run inside a transaction block. In production,
+    CheckedMigration sets atomic=False so we're already outside a transaction.
+    In tests, we may be inside a transaction — in that case, fall back to
+    the non-CONCURRENTLY variant to avoid errors.
+    """
+    conn = schema_editor.connection
+    if conn.in_atomic_block:
+        # Inside a transaction (e.g., test runner) — CONCURRENTLY would fail.
+        # Fall back to the non-concurrent variant.
+        sql = sql.replace(" CONCURRENTLY", "", 1)
+        schema_editor.execute(sql)
+    else:
+        schema_editor.execute(sql)
+
+
 def _partition_index_name(partition_table: str, index_name: str, max_length: int = 63) -> str:
     """
     Generate a unique index name scoped to a partition table.
@@ -226,14 +245,16 @@ class AddPartitionIndex(IndexOperation):
             cloned_index = self.index.clone()
             cloned_index.name = idx_name
             sql_str = self._create_index_sql(schema_editor, model, cloned_index, partition_table)
-            schema_editor.execute(sql_str)
+            _execute_outside_transaction(schema_editor, sql_str)
 
     def _create_index_sql(self, schema_editor, model, index, table_name):
-        """Generate CREATE INDEX SQL targeting a specific partition table."""
+        """Generate CREATE INDEX CONCURRENTLY SQL targeting a specific partition table."""
         sql = index.create_sql(model, schema_editor)
-        # Replace the parent table name with the partition table name
         parent_table = model._meta.db_table
         sql_str = str(sql)
+        # Add CONCURRENTLY after CREATE INDEX
+        sql_str = sql_str.replace("CREATE INDEX", "CREATE INDEX CONCURRENTLY", 1)
+        # Replace the parent table name with the partition table name
         sql_str = sql_str.replace(
             schema_editor.quote_name(parent_table),
             schema_editor.quote_name(table_name),
@@ -255,7 +276,10 @@ class AddPartitionIndex(IndexOperation):
 
         for partition_table in partitions:
             idx_name = _partition_index_name(partition_table, self.index.name)
-            schema_editor.execute(f"DROP INDEX IF EXISTS {schema_editor.quote_name(idx_name)}")
+            _execute_outside_transaction(
+                schema_editor,
+                f"DROP INDEX CONCURRENTLY IF EXISTS {schema_editor.quote_name(idx_name)}",
+            )
 
     def deconstruct(self):
         return (
@@ -315,7 +339,10 @@ class RemovePartitionIndex(IndexOperation):
 
         for partition_table in partitions:
             idx_name = _partition_index_name(partition_table, self.name)
-            schema_editor.execute(f"DROP INDEX IF EXISTS {schema_editor.quote_name(idx_name)}")
+            _execute_outside_transaction(
+                schema_editor,
+                f"DROP INDEX CONCURRENTLY IF EXISTS {schema_editor.quote_name(idx_name)}",
+            )
 
     def database_backwards(self, app_label, schema_editor, from_state, to_state):
         model = to_state.apps.get_model(app_label, self.model_name)
@@ -338,12 +365,13 @@ class RemovePartitionIndex(IndexOperation):
             cloned_index = index.clone()
             cloned_index.name = idx_name
             sql_str = self._create_index_sql(schema_editor, model, cloned_index, partition_table)
-            schema_editor.execute(sql_str)
+            _execute_outside_transaction(schema_editor, sql_str)
 
     def _create_index_sql(self, schema_editor, model, index, table_name):
         sql = index.create_sql(model, schema_editor)
         parent_table = model._meta.db_table
         sql_str = str(sql)
+        sql_str = sql_str.replace("CREATE INDEX", "CREATE INDEX CONCURRENTLY", 1)
         sql_str = sql_str.replace(
             schema_editor.quote_name(parent_table),
             schema_editor.quote_name(table_name),

--- a/src/sentry/new_migrations/monkey/partitioned.py
+++ b/src/sentry/new_migrations/monkey/partitioned.py
@@ -1,0 +1,379 @@
+from __future__ import annotations
+
+from django.db.migrations.operations.models import (
+    CreateModel,
+    IndexOperation,
+    ModelOperation,
+)
+
+from sentry.db.models.partitioned import (
+    Partition,
+    PartitionConfig,
+    get_partitions,
+    is_partitioning_enabled,
+)
+
+
+class CreatePartitionedModel(CreateModel):
+    """
+    Creates a partitioned table when partitioning is enabled for the model,
+    otherwise falls back to creating a regular table.
+
+    The PARTITION BY clause is handled by the PartitionAwareSchemaEditorMixin
+    in the schema editor, which inspects the model's `partitioning` attribute.
+    This operation additionally stores the partition config for serialization.
+    """
+
+    def __init__(self, *args, partitioning: PartitionConfig, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.partitioning = partitioning
+
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        model = to_state.apps.get_model(app_label, self.name)
+        if self.allow_migrate_model(schema_editor.connection.alias, model):
+            # The schema editor's PartitionAwareSchemaEditorMixin checks
+            # is_partitioning_enabled() and appends PARTITION BY if enabled.
+            # We need to ensure the model carries the partitioning attribute
+            # so the schema editor can detect it.
+            if not hasattr(model, "partitioning"):
+                model.partitioning = self.partitioning
+            schema_editor.create_model(model)
+
+    def deconstruct(self):
+        name, args, kwargs = super().deconstruct()
+        kwargs["partitioning"] = self.partitioning
+        return (self.__class__.__qualname__, args, kwargs)
+
+    def describe(self):
+        return f"Create partitioned model {self.name}"
+
+    @property
+    def migration_name_fragment(self):
+        return self.name_lower
+
+
+class AddPartition(ModelOperation):
+    """
+    Creates a partition of a partitioned table.
+
+    When partitioning is disabled for the model in the current environment,
+    this operation is a no-op (the table is a regular non-partitioned table).
+    """
+
+    def __init__(self, model_name: str, partition: Partition):
+        self.partition = partition
+        super().__init__(model_name)
+
+    def state_forwards(self, app_label, state):
+        pass
+
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        model = to_state.apps.get_model(app_label, self.name)
+        if not self.allow_migrate_model(schema_editor.connection.alias, model):
+            return
+        if not is_partitioning_enabled(model):
+            return
+
+        parent_table = model._meta.db_table
+        partition_table = self.partition.name
+        bound_clause = self.partition.sql_bound_clause()
+
+        schema_editor.execute(
+            f"CREATE TABLE {schema_editor.quote_name(partition_table)} "
+            f"PARTITION OF {schema_editor.quote_name(parent_table)} "
+            f"{bound_clause}"
+        )
+
+    def database_backwards(self, app_label, schema_editor, from_state, to_state):
+        model = from_state.apps.get_model(app_label, self.name)
+        if not self.allow_migrate_model(schema_editor.connection.alias, model):
+            return
+        if not is_partitioning_enabled(model):
+            return
+
+        partition_table = self.partition.name
+        schema_editor.execute(f"DROP TABLE IF EXISTS {schema_editor.quote_name(partition_table)}")
+
+    def deconstruct(self):
+        return (
+            self.__class__.__qualname__,
+            [],
+            {
+                "model_name": self.name,
+                "partition": self.partition,
+            },
+        )
+
+    def describe(self):
+        return f"Create partition {self.partition.name} on model {self.name}"
+
+    @property
+    def migration_name_fragment(self):
+        return f"{self.name_lower}_{self.partition.name}"
+
+
+class RemovePartition(ModelOperation):
+    """
+    Detaches and drops a partition from a partitioned table.
+
+    When partitioning is disabled, this is a no-op.
+    """
+
+    def __init__(self, model_name: str, partition: Partition):
+        self.partition = partition
+        super().__init__(model_name)
+
+    def state_forwards(self, app_label, state):
+        pass
+
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        model = from_state.apps.get_model(app_label, self.name)
+        if not self.allow_migrate_model(schema_editor.connection.alias, model):
+            return
+        if not is_partitioning_enabled(model):
+            return
+
+        parent_table = model._meta.db_table
+        partition_table = self.partition.name
+
+        schema_editor.execute(
+            f"ALTER TABLE {schema_editor.quote_name(parent_table)} "
+            f"DETACH PARTITION {schema_editor.quote_name(partition_table)}"
+        )
+        schema_editor.execute(f"DROP TABLE IF EXISTS {schema_editor.quote_name(partition_table)}")
+
+    def database_backwards(self, app_label, schema_editor, from_state, to_state):
+        # Reverse of RemovePartition is AddPartition
+        model = to_state.apps.get_model(app_label, self.name)
+        if not self.allow_migrate_model(schema_editor.connection.alias, model):
+            return
+        if not is_partitioning_enabled(model):
+            return
+
+        parent_table = model._meta.db_table
+        partition_table = self.partition.name
+        bound_clause = self.partition.sql_bound_clause()
+
+        schema_editor.execute(
+            f"CREATE TABLE {schema_editor.quote_name(partition_table)} "
+            f"PARTITION OF {schema_editor.quote_name(parent_table)} "
+            f"{bound_clause}"
+        )
+
+    def deconstruct(self):
+        return (
+            self.__class__.__qualname__,
+            [],
+            {
+                "model_name": self.name,
+                "partition": self.partition,
+            },
+        )
+
+    def describe(self):
+        return f"Remove partition {self.partition.name} from model {self.name}"
+
+    @property
+    def migration_name_fragment(self):
+        return f"{self.name_lower}_remove_{self.partition.name}"
+
+
+def _partition_index_name(partition_table: str, index_name: str, max_length: int = 63) -> str:
+    """
+    Generate a unique index name scoped to a partition table.
+    Truncates to max_length (PostgreSQL's 63-char limit).
+    """
+    name = f"{partition_table}_{index_name}"
+    if len(name) > max_length:
+        name = name[:max_length]
+    return name
+
+
+class AddPartitionIndex(IndexOperation):
+    """
+    Creates an index on all existing physical partitions of a partitioned table.
+
+    When partitioning is disabled, falls back to creating a regular index
+    on the (non-partitioned) table directly.
+    """
+
+    def __init__(self, model_name: str, index):
+        self.model_name = model_name
+        if not index.name:
+            raise ValueError(
+                "Indexes passed to AddPartitionIndex require a name argument. "
+                f"{index!r} doesn't have one."
+            )
+        self.index = index
+
+    def state_forwards(self, app_label, state):
+        state.add_index(app_label, self.model_name_lower, self.index)
+
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        model = to_state.apps.get_model(app_label, self.model_name)
+        if not self.allow_migrate_model(schema_editor.connection.alias, model):
+            return
+
+        if not is_partitioning_enabled(model):
+            schema_editor.add_index(model, self.index)
+            return
+
+        parent_table = model._meta.db_table
+        partitions = get_partitions(schema_editor.connection, parent_table)
+
+        for partition_table in partitions:
+            idx_name = _partition_index_name(partition_table, self.index.name)
+            cloned_index = self.index.clone()
+            cloned_index.name = idx_name
+            sql_str = self._create_index_sql(schema_editor, model, cloned_index, partition_table)
+            schema_editor.execute(sql_str)
+
+    def _create_index_sql(self, schema_editor, model, index, table_name):
+        """Generate CREATE INDEX SQL targeting a specific partition table."""
+        sql = index.create_sql(model, schema_editor)
+        # Replace the parent table name with the partition table name
+        parent_table = model._meta.db_table
+        sql_str = str(sql)
+        sql_str = sql_str.replace(
+            schema_editor.quote_name(parent_table),
+            schema_editor.quote_name(table_name),
+            1,  # Only replace the first occurrence (the ON clause)
+        )
+        return sql_str
+
+    def database_backwards(self, app_label, schema_editor, from_state, to_state):
+        model = from_state.apps.get_model(app_label, self.model_name)
+        if not self.allow_migrate_model(schema_editor.connection.alias, model):
+            return
+
+        if not is_partitioning_enabled(model):
+            schema_editor.remove_index(model, self.index)
+            return
+
+        parent_table = model._meta.db_table
+        partitions = get_partitions(schema_editor.connection, parent_table)
+
+        for partition_table in partitions:
+            idx_name = _partition_index_name(partition_table, self.index.name)
+            schema_editor.execute(f"DROP INDEX IF EXISTS {schema_editor.quote_name(idx_name)}")
+
+    def deconstruct(self):
+        return (
+            self.__class__.__qualname__,
+            [],
+            {
+                "model_name": self.model_name,
+                "index": self.index,
+            },
+        )
+
+    def describe(self):
+        if self.index.expressions:
+            return "Create partition index %s on %s on model %s" % (
+                self.index.name,
+                ", ".join([str(expression) for expression in self.index.expressions]),
+                self.model_name,
+            )
+        return "Create partition index %s on field(s) %s of model %s" % (
+            self.index.name,
+            ", ".join(self.index.fields),
+            self.model_name,
+        )
+
+    @property
+    def migration_name_fragment(self):
+        return f"{self.model_name_lower}_{self.index.name.lower()}"
+
+
+class RemovePartitionIndex(IndexOperation):
+    """
+    Removes an index from all existing physical partitions of a partitioned table.
+
+    When partitioning is disabled, falls back to removing a regular index.
+    """
+
+    def __init__(self, model_name: str, name: str):
+        self.model_name = model_name
+        self.name = name
+
+    def state_forwards(self, app_label, state):
+        state.remove_index(app_label, self.model_name_lower, self.name)
+
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        model = from_state.apps.get_model(app_label, self.model_name)
+        if not self.allow_migrate_model(schema_editor.connection.alias, model):
+            return
+
+        if not is_partitioning_enabled(model):
+            from_model_state = from_state.models[app_label, self.model_name_lower]
+            index = from_model_state.get_index_by_name(self.name)
+            schema_editor.remove_index(model, index)
+            return
+
+        parent_table = model._meta.db_table
+        partitions = get_partitions(schema_editor.connection, parent_table)
+
+        for partition_table in partitions:
+            idx_name = _partition_index_name(partition_table, self.name)
+            schema_editor.execute(f"DROP INDEX IF EXISTS {schema_editor.quote_name(idx_name)}")
+
+    def database_backwards(self, app_label, schema_editor, from_state, to_state):
+        model = to_state.apps.get_model(app_label, self.model_name)
+        if not self.allow_migrate_model(schema_editor.connection.alias, model):
+            return
+
+        if not is_partitioning_enabled(model):
+            to_model_state = to_state.models[app_label, self.model_name_lower]
+            index = to_model_state.get_index_by_name(self.name)
+            schema_editor.add_index(model, index)
+            return
+
+        parent_table = model._meta.db_table
+        partitions = get_partitions(schema_editor.connection, parent_table)
+        to_model_state = to_state.models[app_label, self.model_name_lower]
+        index = to_model_state.get_index_by_name(self.name)
+
+        for partition_table in partitions:
+            idx_name = _partition_index_name(partition_table, self.name)
+            cloned_index = index.clone()
+            cloned_index.name = idx_name
+            sql_str = self._create_index_sql(schema_editor, model, cloned_index, partition_table)
+            schema_editor.execute(sql_str)
+
+    def _create_index_sql(self, schema_editor, model, index, table_name):
+        sql = index.create_sql(model, schema_editor)
+        parent_table = model._meta.db_table
+        sql_str = str(sql)
+        sql_str = sql_str.replace(
+            schema_editor.quote_name(parent_table),
+            schema_editor.quote_name(table_name),
+            1,
+        )
+        return sql_str
+
+    def deconstruct(self):
+        return (
+            self.__class__.__qualname__,
+            [],
+            {
+                "model_name": self.model_name,
+                "name": self.name,
+            },
+        )
+
+    def describe(self):
+        return f"Remove partition index {self.name} from model {self.model_name}"
+
+    @property
+    def migration_name_fragment(self):
+        return f"{self.model_name_lower}_remove_{self.name.lower()}"
+
+
+# Re-export for convenience when writing migrations
+__all__ = [
+    "AddPartition",
+    "AddPartitionIndex",
+    "CreatePartitionedModel",
+    "RemovePartition",
+    "RemovePartitionIndex",
+]

--- a/tests/sentry/db/test_partitioned.py
+++ b/tests/sentry/db/test_partitioned.py
@@ -15,6 +15,13 @@ from sentry.db.models.partitioned import (
     get_partitions,
     is_partitioning_enabled,
 )
+from sentry.new_migrations.monkey.partitioned import (
+    AddPartition,
+    AddPartitionIndex,
+    RemovePartition,
+    RemovePartitionIndex,
+    _partition_index_name,
+)
 from sentry.testutils.cases import TestCase
 
 
@@ -137,339 +144,9 @@ class IsPartitioningEnabledTest(TestCase):
             assert is_partitioning_enabled("sentry_testmodel") is False
 
 
-class SchemaEditorPartitionTest(TestCase):
-    """Tests that the schema editor correctly generates PARTITION BY clauses."""
-
-    def _create_test_table(self, table_name, partitioned=True):
-        """Create a test partitioned table using raw SQL to verify schema editor behavior."""
-        with connection.cursor() as cursor:
-            cursor.execute(f"DROP TABLE IF EXISTS {table_name} CASCADE")
-
-        if partitioned:
-            with connection.cursor() as cursor:
-                cursor.execute(
-                    f"CREATE TABLE {table_name} ("
-                    f"  id BIGSERIAL NOT NULL,"
-                    f"  date_added TIMESTAMP WITH TIME ZONE NOT NULL,"
-                    f"  data TEXT,"
-                    f"  PRIMARY KEY (id, date_added)"
-                    f") PARTITION BY RANGE (date_added)"
-                )
-        else:
-            with connection.cursor() as cursor:
-                cursor.execute(
-                    f"CREATE TABLE {table_name} ("
-                    f"  id BIGSERIAL PRIMARY KEY,"
-                    f"  date_added TIMESTAMP WITH TIME ZONE NOT NULL,"
-                    f"  data TEXT"
-                    f")"
-                )
-
-    def _cleanup_table(self, table_name):
-        with connection.cursor() as cursor:
-            cursor.execute(f"DROP TABLE IF EXISTS {table_name} CASCADE")
-
-    def test_partition_by_range_table_creation(self):
-        table_name = "_test_partition_range"
-        try:
-            self._create_test_table(table_name, partitioned=True)
-
-            with connection.cursor() as cursor:
-                cursor.execute("SELECT relkind FROM pg_class WHERE relname = %s", [table_name])
-                row = cursor.fetchone()
-                assert row is not None
-                # 'p' = partitioned table
-                assert row[0] == "p"
-        finally:
-            self._cleanup_table(table_name)
-
-    def test_add_range_partition(self):
-        table_name = "_test_partition_parent"
-        partition_name = "_test_partition_p202401"
-        try:
-            self._create_test_table(table_name, partitioned=True)
-
-            with connection.cursor() as cursor:
-                cursor.execute(
-                    f"CREATE TABLE {partition_name} PARTITION OF {table_name} "
-                    f"FOR VALUES FROM ('2024-01-01') TO ('2024-02-01')"
-                )
-
-            partitions = get_partitions(connection, table_name)
-            assert partition_name in partitions
-        finally:
-            self._cleanup_table(table_name)
-
-    def test_add_list_partition(self):
-        table_name = "_test_partition_list_parent"
-        partition_name = "_test_partition_list_p_us"
-        try:
-            with connection.cursor() as cursor:
-                cursor.execute(f"DROP TABLE IF EXISTS {table_name} CASCADE")
-                cursor.execute(
-                    f"CREATE TABLE {table_name} ("
-                    f"  id BIGSERIAL NOT NULL,"
-                    f"  region TEXT NOT NULL,"
-                    f"  data TEXT,"
-                    f"  PRIMARY KEY (id, region)"
-                    f") PARTITION BY LIST (region)"
-                )
-                cursor.execute(
-                    f"CREATE TABLE {partition_name} PARTITION OF {table_name} "
-                    f"FOR VALUES IN ('us-east-1', 'us-west-2')"
-                )
-
-            partitions = get_partitions(connection, table_name)
-            assert partition_name in partitions
-        finally:
-            self._cleanup_table(table_name)
-
-    def test_add_hash_partition(self):
-        table_name = "_test_partition_hash_parent"
-        partition_name = "_test_partition_hash_p0"
-        try:
-            with connection.cursor() as cursor:
-                cursor.execute(f"DROP TABLE IF EXISTS {table_name} CASCADE")
-                cursor.execute(
-                    f"CREATE TABLE {table_name} ("
-                    f"  id BIGSERIAL NOT NULL,"
-                    f"  data TEXT,"
-                    f"  PRIMARY KEY (id)"
-                    f") PARTITION BY HASH (id)"
-                )
-                cursor.execute(
-                    f"CREATE TABLE {partition_name} PARTITION OF {table_name} "
-                    f"FOR VALUES WITH (MODULUS 4, REMAINDER 0)"
-                )
-
-            partitions = get_partitions(connection, table_name)
-            assert partition_name in partitions
-        finally:
-            self._cleanup_table(table_name)
-
-    def test_get_partitions_empty(self):
-        table_name = "_test_partition_empty"
-        try:
-            self._create_test_table(table_name, partitioned=True)
-            partitions = get_partitions(connection, table_name)
-            assert partitions == []
-        finally:
-            self._cleanup_table(table_name)
-
-    def test_get_partitions_nonexistent_table(self):
-        partitions = get_partitions(connection, "_nonexistent_table_xyz")
-        assert partitions == []
-
-    def test_partition_index_on_partition(self):
-        """Verify indexes can be created on individual partitions."""
-        table_name = "_test_pidx_parent"
-        partition_name = "_test_pidx_p202401"
-        try:
-            self._create_test_table(table_name, partitioned=True)
-
-            with connection.cursor() as cursor:
-                cursor.execute(
-                    f"CREATE TABLE {partition_name} PARTITION OF {table_name} "
-                    f"FOR VALUES FROM ('2024-01-01') TO ('2024-02-01')"
-                )
-                # Create index on partition only
-                cursor.execute(f"CREATE INDEX {partition_name}_data_idx ON {partition_name} (data)")
-
-                # Verify index exists on partition
-                cursor.execute(
-                    "SELECT indexname FROM pg_indexes WHERE tablename = %s",
-                    [partition_name],
-                )
-                index_names = [row[0] for row in cursor.fetchall()]
-                assert f"{partition_name}_data_idx" in index_names
-
-                # Verify index does NOT exist on parent
-                cursor.execute(
-                    "SELECT indexname FROM pg_indexes WHERE tablename = %s",
-                    [table_name],
-                )
-                parent_index_names = [row[0] for row in cursor.fetchall()]
-                assert f"{partition_name}_data_idx" not in parent_index_names
-        finally:
-            self._cleanup_table(table_name)
-
-
-class MigrationOperationTest(TestCase):
-    """Tests for the partition migration operations."""
-
-    def _cleanup_table(self, table_name):
-        with connection.cursor() as cursor:
-            cursor.execute(f"DROP TABLE IF EXISTS {table_name} CASCADE")
-
-    def test_add_partition_operation_with_range(self):
-        from sentry.new_migrations.monkey.partitioned import AddPartition
-
-        table_name = "_test_op_range_parent"
-        partition = RangePartition(
-            name="_test_op_range_p202401",
-            from_values="'2024-01-01'",
-            to_values="'2024-02-01'",
-        )
-
-        try:
-            # Create parent table
-            with connection.cursor() as cursor:
-                cursor.execute(f"DROP TABLE IF EXISTS {table_name} CASCADE")
-                cursor.execute(
-                    f"CREATE TABLE {table_name} ("
-                    f"  id BIGSERIAL NOT NULL,"
-                    f"  date_added TIMESTAMP WITH TIME ZONE NOT NULL,"
-                    f"  PRIMARY KEY (id, date_added)"
-                    f") PARTITION BY RANGE (date_added)"
-                )
-
-            # Create a minimal fake model for the operation
-            class FakeMeta:
-                db_table = table_name
-                app_label = "sentry"
-                label_lower = "sentry.fakemodel"
-
-            class FakeModel:
-                _meta = FakeMeta()
-
-            class FakeState:
-                class apps:
-                    @staticmethod
-                    def get_model(app_label, model_name):
-                        return FakeModel
-
-                models = {}
-
-            op = AddPartition(model_name="FakeModel", partition=partition)
-
-            with mock.patch.dict(os.environ, {"SENTRY_PARTITIONED_MODELS": table_name}):
-                with mock.patch.object(op, "allow_migrate_model", return_value=True):
-                    with connection.schema_editor() as schema_editor:
-                        op.database_forwards("sentry", schema_editor, FakeState, FakeState)
-
-            partitions = get_partitions(connection, table_name)
-            assert "_test_op_range_p202401" in partitions
-        finally:
-            self._cleanup_table(table_name)
-
-    def test_add_partition_noop_when_disabled(self):
-        from sentry.new_migrations.monkey.partitioned import AddPartition
-
-        partition = RangePartition(
-            name="_test_noop_p202401",
-            from_values="'2024-01-01'",
-            to_values="'2024-02-01'",
-        )
-        op = AddPartition(model_name="FakeModel", partition=partition)
-
-        class FakeMeta:
-            db_table = "_test_noop_parent"
-            app_label = "sentry"
-            label_lower = "sentry.fakemodel"
-
-        class FakeModel:
-            _meta = FakeMeta()
-
-        class FakeState:
-            class apps:
-                @staticmethod
-                def get_model(app_label, model_name):
-                    return FakeModel
-
-            models = {}
-
-        with mock.patch.dict(os.environ, {"SENTRY_PARTITIONED_MODELS": ""}):
-            with mock.patch.object(op, "allow_migrate_model", return_value=True):
-                with connection.schema_editor() as schema_editor:
-                    # Should not raise even though parent table doesn't exist
-                    op.database_forwards("sentry", schema_editor, FakeState, FakeState)
-
-    def test_remove_partition_operation(self):
-        from sentry.new_migrations.monkey.partitioned import RemovePartition
-
-        table_name = "_test_op_rm_parent"
-        partition = RangePartition(
-            name="_test_op_rm_p202401",
-            from_values="'2024-01-01'",
-            to_values="'2024-02-01'",
-        )
-
-        try:
-            with connection.cursor() as cursor:
-                cursor.execute(f"DROP TABLE IF EXISTS {table_name} CASCADE")
-                cursor.execute(
-                    f"CREATE TABLE {table_name} ("
-                    f"  id BIGSERIAL NOT NULL,"
-                    f"  date_added TIMESTAMP WITH TIME ZONE NOT NULL,"
-                    f"  PRIMARY KEY (id, date_added)"
-                    f") PARTITION BY RANGE (date_added)"
-                )
-                cursor.execute(
-                    f"CREATE TABLE _test_op_rm_p202401 PARTITION OF {table_name} "
-                    f"FOR VALUES FROM ('2024-01-01') TO ('2024-02-01')"
-                )
-
-            assert "_test_op_rm_p202401" in get_partitions(connection, table_name)
-
-            class FakeMeta:
-                db_table = table_name
-                app_label = "sentry"
-                label_lower = "sentry.fakemodel"
-
-            class FakeModel:
-                _meta = FakeMeta()
-
-            class FakeState:
-                class apps:
-                    @staticmethod
-                    def get_model(app_label, model_name):
-                        return FakeModel
-
-                models = {}
-
-            op = RemovePartition(model_name="FakeModel", partition=partition)
-
-            with mock.patch.dict(os.environ, {"SENTRY_PARTITIONED_MODELS": table_name}):
-                with mock.patch.object(op, "allow_migrate_model", return_value=True):
-                    with connection.schema_editor() as schema_editor:
-                        op.database_forwards("sentry", schema_editor, FakeState, FakeState)
-
-            assert "_test_op_rm_p202401" not in get_partitions(connection, table_name)
-        finally:
-            self._cleanup_table(table_name)
-
-    def test_partition_index_name_truncation(self):
-        from sentry.new_migrations.monkey.partitioned import _partition_index_name
-
-        name = _partition_index_name("very_long_partition_table_name", "very_long_index_name")
-        assert len(name) <= 63
-
-        short_name = _partition_index_name("p1", "idx1")
-        assert short_name == "p1_idx1"
-
-    def test_operation_deconstruct(self):
-        from sentry.new_migrations.monkey.partitioned import (
-            AddPartition,
-            RemovePartition,
-        )
-
-        partition = RangePartition(
-            name="p_202401",
-            from_values="'2024-01-01'",
-            to_values="'2024-02-01'",
-        )
-
-        add_op = AddPartition(model_name="MyModel", partition=partition)
-        name, args, kwargs = add_op.deconstruct()
-        assert "AddPartition" in name
-        assert kwargs["model_name"] == "MyModel"
-        assert kwargs["partition"] == partition
-
-        rm_op = RemovePartition(model_name="MyModel", partition=partition)
-        name, args, kwargs = rm_op.deconstruct()
-        assert "RemovePartition" in name
-        assert kwargs["model_name"] == "MyModel"
-        assert kwargs["partition"] == partition
+# ---------------------------------------------------------------------------
+# Helpers for operation-based tests
+# ---------------------------------------------------------------------------
 
 
 def _get_indexes(table_name: str) -> list[str]:
@@ -482,28 +159,22 @@ def _get_indexes(table_name: str) -> list[str]:
         return [row[0] for row in cursor.fetchall()]
 
 
-def _setup_partitioned_table(table_name: str, partition_names: list[str]) -> None:
-    """Create a partitioned table with RANGE partitions for testing."""
+def _table_exists(table_name: str) -> bool:
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT EXISTS(SELECT 1 FROM pg_class WHERE relname = %s)", [table_name])
+        return cursor.fetchone()[0]
+
+
+def _create_parent_table(table_name: str, strategy: str, columns_sql: str) -> None:
+    """Create a partitioned parent table.
+
+    Parent table creation uses raw SQL because CreatePartitionedModel requires
+    a real Django model. All partition and index operations use the migration
+    operation classes.
+    """
     with connection.cursor() as cursor:
         cursor.execute(f"DROP TABLE IF EXISTS {table_name} CASCADE")
-        cursor.execute(
-            f"CREATE TABLE {table_name} ("
-            f"  id BIGSERIAL NOT NULL,"
-            f"  date_added TIMESTAMP WITH TIME ZONE NOT NULL,"
-            f"  data TEXT,"
-            f"  status INTEGER DEFAULT 0,"
-            f"  PRIMARY KEY (id, date_added)"
-            f") PARTITION BY RANGE (date_added)"
-        )
-        for i, name in enumerate(partition_names):
-            year = 2024
-            month_start = i + 1
-            month_end = i + 2
-            cursor.execute(
-                f"CREATE TABLE {name} PARTITION OF {table_name} "
-                f"FOR VALUES FROM ('{year}-{month_start:02d}-01') "
-                f"TO ('{year}-{month_end:02d}-01')"
-            )
+        cursor.execute(f"CREATE TABLE {table_name} ({columns_sql}) PARTITION BY {strategy}")
 
 
 def _cleanup_tables(*table_names: str) -> None:
@@ -512,239 +183,516 @@ def _cleanup_tables(*table_names: str) -> None:
             cursor.execute(f"DROP TABLE IF EXISTS {name} CASCADE")
 
 
-class AddPartitionIndexTest(TestCase):
-    """Tests for the AddPartitionIndex migration operation against real PostgreSQL."""
+def _make_fake_model_and_state(table_name: str):
+    """Create a FakeModel and FakeState for use with migration operations.
 
-    TABLE = "_test_addpidx"
-    PARTITIONS = [f"_test_addpidx_p{i}" for i in range(3)]
+    For operations that need Django's full model introspection (e.g.
+    AddPartitionIndex which calls Index.create_sql), use _make_real_model_and_state
+    instead.
+    """
 
-    def setUp(self):
-        super().setUp()
-        _setup_partitioned_table(self.TABLE, self.PARTITIONS)
+    class FakeMeta:
+        db_table = table_name
+        app_label = "sentry"
+        label_lower = "sentry.fakemodel"
+
+    class FakeModel:
+        _meta = FakeMeta()
+
+    class FakeState:
+        class apps:
+            @staticmethod
+            def get_model(app_label, model_name):
+                return FakeModel
+
+        models = {}
+
+    return FakeModel, FakeState
+
+
+import warnings
+
+# Cache for dynamically created models keyed by table name
+_real_model_cache: dict[str, type] = {}
+
+
+def _make_real_model_and_state(table_name: str):
+    """Create a real Django model and FakeState for index operations.
+
+    Index.create_sql() needs a real Django model with proper _meta to resolve
+    field names to columns. We dynamically create a model pointing at the
+    given table name, and cache it to avoid Django's re-registration warning.
+    """
+    if table_name not in _real_model_cache:
+        from django.db import models as dj_models
+
+        # Use a unique class name per table to avoid Django registration conflicts
+        class_name = f"TestPart_{''.join(c for c in table_name if c.isalnum())}"
+        attrs = {
+            "__module__": __name__,
+            "id": dj_models.BigAutoField(primary_key=True),
+            "date_added": dj_models.DateTimeField(),
+            "data": dj_models.TextField(null=True),
+            "status": dj_models.IntegerField(default=0),
+            "region": dj_models.TextField(null=True),
+            "Meta": type(
+                "Meta", (), {"app_label": "sentry", "db_table": table_name, "managed": False}
+            ),
+        }
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
+            _real_model_cache[table_name] = type(class_name, (dj_models.Model,), attrs)
+
+    RealModel = _real_model_cache[table_name]
+
+    class FakeState:
+        class apps:
+            @staticmethod
+            def get_model(app_label, model_name):
+                return RealModel
+
+        models = {}
+
+    return RealModel, FakeState
+
+
+def _run_op_forwards(op, table_name: str, real_model: bool = False) -> None:
+    """Run a migration operation forwards with partitioning enabled."""
+    factory = _make_real_model_and_state if real_model else _make_fake_model_and_state
+    _, State = factory(table_name)
+    with mock.patch.dict(os.environ, {"SENTRY_PARTITIONED_MODELS": table_name}):
+        with mock.patch.object(op, "allow_migrate_model", return_value=True):
+            with connection.schema_editor() as schema_editor:
+                op.database_forwards("sentry", schema_editor, State, State)
+
+
+def _run_op_backwards(op, table_name: str, real_model: bool = False) -> None:
+    """Run a migration operation backwards with partitioning enabled."""
+    factory = _make_real_model_and_state if real_model else _make_fake_model_and_state
+    _, State = factory(table_name)
+    with mock.patch.dict(os.environ, {"SENTRY_PARTITIONED_MODELS": table_name}):
+        with mock.patch.object(op, "allow_migrate_model", return_value=True):
+            with connection.schema_editor() as schema_editor:
+                op.database_backwards("sentry", schema_editor, State, State)
+
+
+# Standard RANGE-partitioned table schema used by most tests
+RANGE_COLUMNS = (
+    "id BIGSERIAL NOT NULL, "
+    "date_added TIMESTAMP WITH TIME ZONE NOT NULL, "
+    "data TEXT, "
+    "status INTEGER DEFAULT 0, "
+    "PRIMARY KEY (id, date_added)"
+)
+
+
+def _range_partitions(table: str, count: int) -> list[RangePartition]:
+    """Generate count RangePartition objects for consecutive months."""
+    return [
+        RangePartition(
+            name=f"{table}_p{i}",
+            from_values=f"'2024-{i + 1:02d}-01'",
+            to_values=f"'2024-{i + 2:02d}-01'",
+        )
+        for i in range(count)
+    ]
+
+
+def _setup_range_table(table: str, num_partitions: int) -> list[RangePartition]:
+    """Create a RANGE-partitioned parent table and add partitions via operations."""
+    _create_parent_table(table, "RANGE (date_added)", RANGE_COLUMNS)
+    partitions = _range_partitions(table, num_partitions)
+    for p in partitions:
+        _run_op_forwards(AddPartition(model_name="FakeModel", partition=p), table)
+    return partitions
+
+
+# ---------------------------------------------------------------------------
+# Operation tests
+# ---------------------------------------------------------------------------
+
+
+class AddPartitionOperationTest(TestCase):
+    """Tests for the AddPartition migration operation."""
+
+    TABLE = "_test_addpart"
 
     def tearDown(self):
         _cleanup_tables(self.TABLE)
         super().tearDown()
 
-    def test_creates_index_on_all_partitions(self):
-        """AddPartitionIndex should create an index on every existing partition."""
-        from sentry.new_migrations.monkey.partitioned import (
-            _partition_index_name,
+    def test_adds_range_partition(self):
+        _create_parent_table(self.TABLE, "RANGE (date_added)", RANGE_COLUMNS)
+        partition = RangePartition(
+            name=f"{self.TABLE}_p0", from_values="'2024-01-01'", to_values="'2024-02-01'"
         )
+        _run_op_forwards(AddPartition(model_name="FakeModel", partition=partition), self.TABLE)
+        assert f"{self.TABLE}_p0" in get_partitions(connection, self.TABLE)
 
-        index_name = "my_data_idx"
-        with mock.patch.dict(os.environ, {"SENTRY_PARTITIONED_MODELS": self.TABLE}):
-            with connection.cursor() as cursor:
-                for p in self.PARTITIONS:
-                    idx = _partition_index_name(p, index_name)
-                    cursor.execute(f"CREATE INDEX {idx} ON {p} (data)")
+    def test_adds_list_partition(self):
+        _create_parent_table(
+            self.TABLE,
+            "LIST (region)",
+            "id BIGSERIAL NOT NULL, region TEXT NOT NULL, data TEXT, PRIMARY KEY (id, region)",
+        )
+        partition = ListPartition(name=f"{self.TABLE}_us", values=["us-east-1", "us-west-2"])
+        _run_op_forwards(AddPartition(model_name="FakeModel", partition=partition), self.TABLE)
+        assert f"{self.TABLE}_us" in get_partitions(connection, self.TABLE)
 
-        # Verify indexes exist on each partition
-        for p in self.PARTITIONS:
-            indexes = _get_indexes(p)
-            expected = _partition_index_name(p, index_name)
-            assert expected in indexes, f"Index {expected} not found on partition {p}"
+    def test_adds_hash_partition(self):
+        _create_parent_table(
+            self.TABLE,
+            "HASH (id)",
+            "id BIGSERIAL NOT NULL, data TEXT, PRIMARY KEY (id)",
+        )
+        partition = HashPartition(name=f"{self.TABLE}_p0", modulus=4, remainder=0)
+        _run_op_forwards(AddPartition(model_name="FakeModel", partition=partition), self.TABLE)
+        assert f"{self.TABLE}_p0" in get_partitions(connection, self.TABLE)
 
-        # Verify no such index on the parent table
-        parent_indexes = _get_indexes(self.TABLE)
-        assert not any(index_name in idx for idx in parent_indexes if "data" in idx)
+    def test_noop_when_disabled(self):
+        partition = RangePartition(
+            name="_test_noop_p0", from_values="'2024-01-01'", to_values="'2024-02-01'"
+        )
+        op = AddPartition(model_name="FakeModel", partition=partition)
+        _, FakeState = _make_fake_model_and_state("_test_noop_parent")
 
-    def test_creates_index_on_multiple_partitions_independently(self):
-        """Each partition gets its own independently-named index."""
-        from sentry.new_migrations.monkey.partitioned import _partition_index_name
+        with mock.patch.dict(os.environ, {"SENTRY_PARTITIONED_MODELS": ""}):
+            with mock.patch.object(op, "allow_migrate_model", return_value=True):
+                with connection.schema_editor() as schema_editor:
+                    # No error even though parent doesn't exist
+                    op.database_forwards("sentry", schema_editor, FakeState, FakeState)
 
-        index_name = "status_idx"
+    def test_backwards_drops_partition(self):
+        _create_parent_table(self.TABLE, "RANGE (date_added)", RANGE_COLUMNS)
+        partition = RangePartition(
+            name=f"{self.TABLE}_p0", from_values="'2024-01-01'", to_values="'2024-02-01'"
+        )
+        op = AddPartition(model_name="FakeModel", partition=partition)
+
+        _run_op_forwards(op, self.TABLE)
+        assert f"{self.TABLE}_p0" in get_partitions(connection, self.TABLE)
+
+        _run_op_backwards(op, self.TABLE)
+        assert f"{self.TABLE}_p0" not in get_partitions(connection, self.TABLE)
+
+
+class RemovePartitionOperationTest(TestCase):
+    """Tests for the RemovePartition migration operation."""
+
+    TABLE = "_test_rmpart"
+
+    def tearDown(self):
+        _cleanup_tables(self.TABLE)
+        super().tearDown()
+
+    def test_detaches_and_drops_partition(self):
+        partitions = _setup_range_table(self.TABLE, 2)
+        op = RemovePartition(model_name="FakeModel", partition=partitions[0])
+        _run_op_forwards(op, self.TABLE)
+
+        assert f"{self.TABLE}_p0" not in get_partitions(connection, self.TABLE)
+        assert f"{self.TABLE}_p1" in get_partitions(connection, self.TABLE)
+        assert not _table_exists(f"{self.TABLE}_p0")
+
+    def test_noop_when_disabled(self):
+        partitions = _setup_range_table(self.TABLE, 1)
+        op = RemovePartition(model_name="FakeModel", partition=partitions[0])
+        _, FakeState = _make_fake_model_and_state(self.TABLE)
+
+        with mock.patch.dict(os.environ, {"SENTRY_PARTITIONED_MODELS": ""}):
+            with mock.patch.object(op, "allow_migrate_model", return_value=True):
+                with connection.schema_editor() as schema_editor:
+                    op.database_forwards("sentry", schema_editor, FakeState, FakeState)
+
+        # Partition still exists
+        assert f"{self.TABLE}_p0" in get_partitions(connection, self.TABLE)
+
+    def test_backwards_recreates_partition(self):
+        partitions = _setup_range_table(self.TABLE, 1)
+        op = RemovePartition(model_name="FakeModel", partition=partitions[0])
+
+        _run_op_forwards(op, self.TABLE)
+        assert f"{self.TABLE}_p0" not in get_partitions(connection, self.TABLE)
+
+        _run_op_backwards(op, self.TABLE)
+        assert f"{self.TABLE}_p0" in get_partitions(connection, self.TABLE)
+
+        # Recreated partition accepts data
         with connection.cursor() as cursor:
-            for p in self.PARTITIONS:
-                idx = _partition_index_name(p, index_name)
-                cursor.execute(f"CREATE INDEX {idx} ON {p} (status)")
+            cursor.execute(
+                f"INSERT INTO {self.TABLE} (date_added, data) VALUES ('2024-01-15', 'restored')"
+            )
+            cursor.execute(f"SELECT data FROM {self.TABLE}_p0")
+            assert cursor.fetchone()[0] == "restored"
 
-        # Verify each partition has its own index with unique name
-        all_idx_names = set()
-        for p in self.PARTITIONS:
-            indexes = _get_indexes(p)
-            idx = _partition_index_name(p, index_name)
-            assert idx in indexes
-            all_idx_names.add(idx)
 
-        # All names should be unique
-        assert len(all_idx_names) == len(self.PARTITIONS)
+class AddPartitionIndexOperationTest(TestCase):
+    """Tests for the AddPartitionIndex migration operation."""
+
+    TABLE = "_test_addpidx"
+
+    def setUp(self):
+        super().setUp()
+        self.partitions = _setup_range_table(self.TABLE, 3)
+
+    def tearDown(self):
+        _cleanup_tables(self.TABLE)
+        super().tearDown()
+
+    def _make_index(self, name="test_data_idx", fields=("data",)):
+        from django.db.models import Index
+
+        return Index(fields=list(fields), name=name)
+
+    def _run_add_index(self, index):
+        op = AddPartitionIndex(model_name="FakeModel", index=index)
+        _run_op_forwards(op, self.TABLE, real_model=True)
+        return op
+
+    def test_creates_index_on_all_partitions(self):
+        index = self._make_index("data_idx")
+        self._run_add_index(index)
+
+        for p in self.partitions:
+            idx_name = _partition_index_name(p.name, "data_idx")
+            assert idx_name in _get_indexes(p.name), f"Index not found on {p.name}"
+
+    def test_index_not_on_parent_table(self):
+        index = self._make_index("data_idx")
+        self._run_add_index(index)
+
+        parent_indexes = _get_indexes(self.TABLE)
+        assert not any("data_idx" in idx for idx in parent_indexes)
+
+    def test_each_partition_gets_unique_index_name(self):
+        index = self._make_index("status_idx", fields=("status",))
+        self._run_add_index(index)
+
+        names = set()
+        for p in self.partitions:
+            idx_name = _partition_index_name(p.name, "status_idx")
+            assert idx_name in _get_indexes(p.name)
+            names.add(idx_name)
+        assert len(names) == len(self.partitions)
+
+    def test_multi_column_index(self):
+        index = self._make_index("data_status_idx", fields=("data", "status"))
+        self._run_add_index(index)
+
+        for p in self.partitions:
+            idx_name = _partition_index_name(p.name, "data_status_idx")
+            assert idx_name in _get_indexes(p.name)
 
     def test_noop_on_empty_partitions(self):
-        """AddPartitionIndex on a table with no partitions should do nothing."""
-
-        # Create a partitioned table with no partitions
+        """No error when the table has zero partitions."""
         empty_table = "_test_addpidx_empty"
         try:
-            with connection.cursor() as cursor:
-                cursor.execute(f"DROP TABLE IF EXISTS {empty_table} CASCADE")
-                cursor.execute(
-                    f"CREATE TABLE {empty_table} ("
-                    f"  id BIGSERIAL NOT NULL,"
-                    f"  date_added TIMESTAMP WITH TIME ZONE NOT NULL,"
-                    f"  PRIMARY KEY (id, date_added)"
-                    f") PARTITION BY RANGE (date_added)"
-                )
-
-            partitions = get_partitions(connection, empty_table)
-            assert partitions == []
-            # No error, no indexes created — this is the expected behavior
+            _create_parent_table(empty_table, "RANGE (date_added)", RANGE_COLUMNS)
+            index = self._make_index("data_idx")
+            op = AddPartitionIndex(model_name="FakeModel", index=index)
+            _run_op_forwards(op, empty_table)
+            # No partitions → nothing to index → no error
         finally:
             _cleanup_tables(empty_table)
 
-    def test_index_survives_data_insert(self):
-        """Index created on a partition should work with inserted data."""
-        from sentry.new_migrations.monkey.partitioned import _partition_index_name
+    def test_fallback_to_regular_index_when_disabled(self):
+        """When partitioning is disabled, creates a regular index on the table."""
+        regular_table = "_test_addpidx_regular"
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(f"DROP TABLE IF EXISTS {regular_table} CASCADE")
+                cursor.execute(
+                    f"CREATE TABLE {regular_table} ("
+                    f"  id BIGSERIAL PRIMARY KEY, data TEXT, status INTEGER DEFAULT 0)"
+                )
 
-        index_name = "data_lookup_idx"
-        p = self.PARTITIONS[0]
-        idx = _partition_index_name(p, index_name)
+            index = self._make_index("data_idx")
+            op = AddPartitionIndex(model_name="FakeModel", index=index)
+            _, State = _make_real_model_and_state(regular_table)
+
+            with mock.patch.dict(os.environ, {"SENTRY_PARTITIONED_MODELS": ""}):
+                with mock.patch.object(op, "allow_migrate_model", return_value=True):
+                    with connection.schema_editor() as schema_editor:
+                        op.database_forwards("sentry", schema_editor, State, State)
+
+            assert "data_idx" in _get_indexes(regular_table)
+        finally:
+            _cleanup_tables(regular_table)
+
+    def test_index_works_with_data(self):
+        """Indexes created via the operation work with inserted data."""
+        index = self._make_index("data_lookup_idx")
+        self._run_add_index(index)
 
         with connection.cursor() as cursor:
-            cursor.execute(f"CREATE INDEX {idx} ON {p} (data)")
-            # Insert data into the partition via the parent table
             cursor.execute(
                 f"INSERT INTO {self.TABLE} (date_added, data, status) "
                 f"VALUES ('2024-01-15', 'test_value', 1)"
             )
-            # Verify the index is used (at least exists and data is queryable)
             cursor.execute(f"SELECT data FROM {self.TABLE} WHERE data = 'test_value'")
             rows = cursor.fetchall()
             assert len(rows) == 1
             assert rows[0][0] == "test_value"
 
-    def test_multi_column_index_on_partitions(self):
-        """Multi-column indexes should work on partitions."""
-        from sentry.new_migrations.monkey.partitioned import _partition_index_name
+    def test_backwards_drops_index_from_all_partitions(self):
+        index = self._make_index("data_idx")
+        op = self._run_add_index(index)
+        _run_op_backwards(op, self.TABLE, real_model=True)
 
-        index_name = "data_status_idx"
-        with connection.cursor() as cursor:
-            for p in self.PARTITIONS:
-                idx = _partition_index_name(p, index_name)
-                cursor.execute(f"CREATE INDEX {idx} ON {p} (data, status)")
+        for p in self.partitions:
+            idx_name = _partition_index_name(p.name, "data_idx")
+            assert idx_name not in _get_indexes(p.name)
 
-        for p in self.PARTITIONS:
-            indexes = _get_indexes(p)
-            expected = _partition_index_name(p, index_name)
-            assert expected in indexes
+    def test_new_partition_does_not_inherit_indexes(self):
+        """Indexes on existing partitions are NOT auto-inherited by new partitions."""
+        index = self._make_index("data_idx")
+        self._run_add_index(index)
+
+        # Add a new partition
+        new_part = RangePartition(
+            name=f"{self.TABLE}_p_new", from_values="'2024-06-01'", to_values="'2024-07-01'"
+        )
+        _run_op_forwards(AddPartition(model_name="FakeModel", partition=new_part), self.TABLE)
+
+        # New partition does NOT have the index
+        new_idx_name = _partition_index_name(f"{self.TABLE}_p_new", "data_idx")
+        assert new_idx_name not in _get_indexes(f"{self.TABLE}_p_new")
+
+        # Existing partitions still have it
+        for p in self.partitions:
+            assert _partition_index_name(p.name, "data_idx") in _get_indexes(p.name)
 
 
-class RemovePartitionIndexTest(TestCase):
-    """Tests for removing indexes from partitions."""
+class RemovePartitionIndexOperationTest(TestCase):
+    """Tests for the RemovePartitionIndex migration operation."""
 
     TABLE = "_test_rmpidx"
-    PARTITIONS = [f"_test_rmpidx_p{i}" for i in range(3)]
 
     def setUp(self):
         super().setUp()
-        _setup_partitioned_table(self.TABLE, self.PARTITIONS)
+        self.partitions = _setup_range_table(self.TABLE, 3)
+        # Pre-create indexes on all partitions via AddPartitionIndex
+        self.index_name = "data_idx"
+        index = self._make_index(self.index_name)
+        op = AddPartitionIndex(model_name="FakeModel", index=index)
+        _run_op_forwards(op, self.TABLE, real_model=True)
 
     def tearDown(self):
         _cleanup_tables(self.TABLE)
         super().tearDown()
+
+    def _make_index(self, name="data_idx", fields=("data",)):
+        from django.db.models import Index
+
+        return Index(fields=list(fields), name=name)
 
     def test_removes_index_from_all_partitions(self):
-        """Dropping an index should remove it from every partition."""
-        from sentry.new_migrations.monkey.partitioned import _partition_index_name
+        op = RemovePartitionIndex(model_name="FakeModel", name=self.index_name)
+        _run_op_forwards(op, self.TABLE, real_model=True)
 
-        index_name = "to_remove_idx"
-
-        # Create the index on all partitions
-        with connection.cursor() as cursor:
-            for p in self.PARTITIONS:
-                idx = _partition_index_name(p, index_name)
-                cursor.execute(f"CREATE INDEX {idx} ON {p} (data)")
-
-        # Verify they exist
-        for p in self.PARTITIONS:
-            assert _partition_index_name(p, index_name) in _get_indexes(p)
-
-        # Remove them
-        with connection.cursor() as cursor:
-            for p in self.PARTITIONS:
-                idx = _partition_index_name(p, index_name)
-                cursor.execute(f"DROP INDEX IF EXISTS {idx}")
-
-        # Verify they're gone
-        for p in self.PARTITIONS:
-            assert _partition_index_name(p, index_name) not in _get_indexes(p)
+        for p in self.partitions:
+            idx_name = _partition_index_name(p.name, self.index_name)
+            assert idx_name not in _get_indexes(p.name)
 
     def test_remove_nonexistent_index_is_safe(self):
-        """Dropping a nonexistent index with IF EXISTS should not error."""
+        """Removing an index that doesn't exist on partitions should not error."""
+        op = RemovePartitionIndex(model_name="FakeModel", name="nonexistent_idx")
+        _run_op_forwards(op, self.TABLE, real_model=True)
+
+    def test_remove_with_partial_coverage(self):
+        """If an index only exists on some partitions, removal still succeeds."""
+        # Drop index from first partition manually, then remove all via operation
+        first_idx = _partition_index_name(self.partitions[0].name, self.index_name)
         with connection.cursor() as cursor:
-            for p in self.PARTITIONS:
-                cursor.execute(f"DROP INDEX IF EXISTS {p}_nonexistent_idx")
-        # No error raised
+            cursor.execute(f"DROP INDEX IF EXISTS {first_idx}")
 
-    def test_remove_index_from_subset_of_partitions(self):
-        """If an index only exists on some partitions, removal should still succeed."""
-        from sentry.new_migrations.monkey.partitioned import _partition_index_name
+        op = RemovePartitionIndex(model_name="FakeModel", name=self.index_name)
+        _run_op_forwards(op, self.TABLE, real_model=True)
 
-        index_name = "partial_idx"
-
-        # Create index only on the first partition
-        with connection.cursor() as cursor:
-            idx = _partition_index_name(self.PARTITIONS[0], index_name)
-            cursor.execute(f"CREATE INDEX {idx} ON {self.PARTITIONS[0]} (data)")
-
-        # Try removing from all partitions — should not error
-        with connection.cursor() as cursor:
-            for p in self.PARTITIONS:
-                idx = _partition_index_name(p, index_name)
-                cursor.execute(f"DROP INDEX IF EXISTS {idx}")
-
-        # Verify all clean
-        for p in self.PARTITIONS:
-            assert _partition_index_name(p, index_name) not in _get_indexes(p)
+        for p in self.partitions:
+            idx_name = _partition_index_name(p.name, self.index_name)
+            assert idx_name not in _get_indexes(p.name)
 
 
-class PartitionMaintenanceTest(TestCase):
-    """Tests for partition lifecycle operations — adding/removing partitions,
-    verifying data routing, and ensuring indexes on new partitions."""
+class OperationDeconstructTest(TestCase):
+    """Tests for migration operation serialization."""
 
-    TABLE = "_test_maint"
+    def test_add_partition_deconstruct(self):
+        partition = RangePartition(
+            name="p_202401", from_values="'2024-01-01'", to_values="'2024-02-01'"
+        )
+        op = AddPartition(model_name="MyModel", partition=partition)
+        name, _, kwargs = op.deconstruct()
+        assert "AddPartition" in name
+        assert kwargs["model_name"] == "MyModel"
+        assert kwargs["partition"] == partition
+
+    def test_remove_partition_deconstruct(self):
+        partition = RangePartition(
+            name="p_202401", from_values="'2024-01-01'", to_values="'2024-02-01'"
+        )
+        op = RemovePartition(model_name="MyModel", partition=partition)
+        name, _, kwargs = op.deconstruct()
+        assert "RemovePartition" in name
+        assert kwargs["model_name"] == "MyModel"
+        assert kwargs["partition"] == partition
+
+    def test_add_partition_index_deconstruct(self):
+        from django.db.models import Index
+
+        index = Index(fields=["data"], name="data_idx")
+        op = AddPartitionIndex(model_name="MyModel", index=index)
+        name, _, kwargs = op.deconstruct()
+        assert "AddPartitionIndex" in name
+        assert kwargs["model_name"] == "MyModel"
+        assert kwargs["index"] == index
+
+    def test_remove_partition_index_deconstruct(self):
+        op = RemovePartitionIndex(model_name="MyModel", name="data_idx")
+        name, _, kwargs = op.deconstruct()
+        assert "RemovePartitionIndex" in name
+        assert kwargs["model_name"] == "MyModel"
+        assert kwargs["name"] == "data_idx"
+
+    def test_partition_index_name_truncation(self):
+        name = _partition_index_name("very_long_partition_table_name", "very_long_index_name")
+        assert len(name) <= 63
+        assert _partition_index_name("p1", "idx1") == "p1_idx1"
+
+
+class PartitionDataRoutingTest(TestCase):
+    """Tests for data routing across partitions."""
+
+    TABLE = "_test_routing"
 
     def tearDown(self):
         _cleanup_tables(self.TABLE)
         super().tearDown()
 
-    def test_data_routes_to_correct_partition(self):
-        """Data inserted into the parent table routes to the correct partition."""
-        p1 = f"{self.TABLE}_p1"
-        p2 = f"{self.TABLE}_p2"
-        _setup_partitioned_table(self.TABLE, [p1, p2])
+    def test_range_data_routes_to_correct_partition(self):
+        partitions = _setup_range_table(self.TABLE, 2)
 
         with connection.cursor() as cursor:
-            # Insert into partition 1's range (month 1)
             cursor.execute(
                 f"INSERT INTO {self.TABLE} (date_added, data) VALUES ('2024-01-15', 'jan_data')"
             )
-            # Insert into partition 2's range (month 2)
             cursor.execute(
                 f"INSERT INTO {self.TABLE} (date_added, data) VALUES ('2024-02-15', 'feb_data')"
             )
 
-            # Query partition 1 directly
-            cursor.execute(f"SELECT data FROM {p1}")
-            rows = [r[0] for r in cursor.fetchall()]
-            assert rows == ["jan_data"]
+            cursor.execute(f"SELECT data FROM {partitions[0].name}")
+            assert [r[0] for r in cursor.fetchall()] == ["jan_data"]
 
-            # Query partition 2 directly
-            cursor.execute(f"SELECT data FROM {p2}")
-            rows = [r[0] for r in cursor.fetchall()]
-            assert rows == ["feb_data"]
+            cursor.execute(f"SELECT data FROM {partitions[1].name}")
+            assert [r[0] for r in cursor.fetchall()] == ["feb_data"]
 
-            # Query parent should return both
             cursor.execute(f"SELECT data FROM {self.TABLE} ORDER BY date_added")
-            rows = [r[0] for r in cursor.fetchall()]
-            assert rows == ["jan_data", "feb_data"]
+            assert [r[0] for r in cursor.fetchall()] == ["jan_data", "feb_data"]
 
     def test_insert_outside_partition_range_fails(self):
-        """Inserting data that doesn't match any partition should fail."""
         from django.db import transaction
 
-        p1 = f"{self.TABLE}_p1"
-        _setup_partitioned_table(self.TABLE, [p1])
+        _setup_range_table(self.TABLE, 1)
 
         with pytest.raises(Exception, match="no partition"):
             with transaction.atomic(using="default"):
@@ -755,57 +703,23 @@ class PartitionMaintenanceTest(TestCase):
                     )
 
     def test_add_partition_then_insert(self):
-        """Adding a new partition via the operation allows inserts into its range."""
-        from sentry.new_migrations.monkey.partitioned import AddPartition
-
-        p1 = f"{self.TABLE}_p1"
-        _setup_partitioned_table(self.TABLE, [p1])
+        _setup_range_table(self.TABLE, 1)
 
         new_partition = RangePartition(
-            name=f"{self.TABLE}_p_new",
-            from_values="'2024-06-01'",
-            to_values="'2024-07-01'",
+            name=f"{self.TABLE}_p_new", from_values="'2024-06-01'", to_values="'2024-07-01'"
         )
+        _run_op_forwards(AddPartition(model_name="FakeModel", partition=new_partition), self.TABLE)
 
-        class FakeMeta:
-            db_table = self.TABLE
-            app_label = "sentry"
-            label_lower = "sentry.fakemodel"
-
-        class FakeModel:
-            _meta = FakeMeta()
-
-        class FakeState:
-            class apps:
-                @staticmethod
-                def get_model(app_label, model_name):
-                    return FakeModel
-
-            models = {}
-
-        op = AddPartition(model_name="FakeModel", partition=new_partition)
-
-        with mock.patch.dict(os.environ, {"SENTRY_PARTITIONED_MODELS": self.TABLE}):
-            with mock.patch.object(op, "allow_migrate_model", return_value=True):
-                with connection.schema_editor() as schema_editor:
-                    op.database_forwards("sentry", schema_editor, FakeState, FakeState)
-
-        # Now we can insert into the new partition's range
         with connection.cursor() as cursor:
             cursor.execute(
                 f"INSERT INTO {self.TABLE} (date_added, data) VALUES ('2024-06-15', 'june_data')"
             )
             cursor.execute(f"SELECT data FROM {self.TABLE}_p_new")
-            rows = [r[0] for r in cursor.fetchall()]
-            assert rows == ["june_data"]
+            assert cursor.fetchone()[0] == "june_data"
 
     def test_detach_partition_preserves_data(self):
-        """Detaching a partition removes it from the parent but keeps the table."""
-        p1 = f"{self.TABLE}_p1"
-        p2 = f"{self.TABLE}_p2"
-        _setup_partitioned_table(self.TABLE, [p1, p2])
+        partitions = _setup_range_table(self.TABLE, 2)
 
-        # Insert data
         with connection.cursor() as cursor:
             cursor.execute(
                 f"INSERT INTO {self.TABLE} (date_added, data) VALUES ('2024-01-15', 'jan')"
@@ -814,134 +728,81 @@ class PartitionMaintenanceTest(TestCase):
                 f"INSERT INTO {self.TABLE} (date_added, data) VALUES ('2024-02-15', 'feb')"
             )
 
-        # Detach partition 1
-        with connection.cursor() as cursor:
-            cursor.execute(f"ALTER TABLE {self.TABLE} DETACH PARTITION {p1}")
+        # Remove partition 0 via operation (detach + drop)
+        op = RemovePartition(model_name="FakeModel", partition=partitions[0])
+        _run_op_forwards(op, self.TABLE)
 
-        # Parent no longer sees partition 1 data
+        # Parent no longer sees partition 0 data
         with connection.cursor() as cursor:
             cursor.execute(f"SELECT data FROM {self.TABLE}")
-            rows = [r[0] for r in cursor.fetchall()]
-            assert rows == ["feb"]
+            assert [r[0] for r in cursor.fetchall()] == ["feb"]
 
-        # But the detached table still has its data
-        with connection.cursor() as cursor:
-            cursor.execute(f"SELECT data FROM {p1}")
-            rows = [r[0] for r in cursor.fetchall()]
-            assert rows == ["jan"]
+        assert partitions[0].name not in get_partitions(connection, self.TABLE)
+        assert partitions[1].name in get_partitions(connection, self.TABLE)
 
-        # Partitions list no longer includes p1
-        partitions = get_partitions(connection, self.TABLE)
-        assert p1 not in partitions
-        assert p2 in partitions
-
-    def test_remove_partition_operation_drops_table(self):
-        """RemovePartition detaches and drops, so the table is gone entirely."""
-        from sentry.new_migrations.monkey.partitioned import RemovePartition
-
-        p1 = f"{self.TABLE}_p1"
-        p2 = f"{self.TABLE}_p2"
-        _setup_partitioned_table(self.TABLE, [p1, p2])
-
-        partition = RangePartition(
-            name=p1,
-            from_values="'2024-01-01'",
-            to_values="'2024-02-01'",
-        )
-
-        class FakeMeta:
-            db_table = self.TABLE
-            app_label = "sentry"
-            label_lower = "sentry.fakemodel"
-
-        class FakeModel:
-            _meta = FakeMeta()
-
-        class FakeState:
-            class apps:
-                @staticmethod
-                def get_model(app_label, model_name):
-                    return FakeModel
-
-            models = {}
-
-        op = RemovePartition(model_name="FakeModel", partition=partition)
-
-        with mock.patch.dict(os.environ, {"SENTRY_PARTITIONED_MODELS": self.TABLE}):
-            with mock.patch.object(op, "allow_migrate_model", return_value=True):
-                with connection.schema_editor() as schema_editor:
-                    op.database_forwards("sentry", schema_editor, FakeState, FakeState)
-
-        # Partition is gone from pg_inherits
-        assert p1 not in get_partitions(connection, self.TABLE)
-        assert p2 in get_partitions(connection, self.TABLE)
-
-        # The table itself is dropped
-        with connection.cursor() as cursor:
-            cursor.execute("SELECT EXISTS(SELECT 1 FROM pg_class WHERE relname = %s)", [p1])
-            assert cursor.fetchone()[0] is False
-
-    def test_indexes_not_on_parent_table(self):
-        """Indexes created on partitions should NOT appear on the parent table."""
-        from sentry.new_migrations.monkey.partitioned import _partition_index_name
-
-        p1 = f"{self.TABLE}_p1"
-        p2 = f"{self.TABLE}_p2"
-        _setup_partitioned_table(self.TABLE, [p1, p2])
-
-        index_name = "data_idx"
-        with connection.cursor() as cursor:
-            for p in [p1, p2]:
-                idx = _partition_index_name(p, index_name)
-                cursor.execute(f"CREATE INDEX {idx} ON {p} (data)")
-
-        # Parent should have no user-created indexes (only PK-related)
-        parent_indexes = _get_indexes(self.TABLE)
-        assert not any(index_name in idx for idx in parent_indexes)
-
-        # Partitions should have them
-        for p in [p1, p2]:
-            partition_indexes = _get_indexes(p)
-            expected = _partition_index_name(p, index_name)
-            assert expected in partition_indexes
-
-    def test_new_partition_does_not_inherit_partition_indexes(self):
-        """Indexes on existing partitions are NOT auto-inherited by new partitions.
-        This verifies that per-partition index management is necessary."""
-        from sentry.new_migrations.monkey.partitioned import _partition_index_name
-
-        p1 = f"{self.TABLE}_p1"
-        _setup_partitioned_table(self.TABLE, [p1])
-
-        # Add index to existing partition
-        index_name = "data_idx"
-        idx = _partition_index_name(p1, index_name)
-        with connection.cursor() as cursor:
-            cursor.execute(f"CREATE INDEX {idx} ON {p1} (data)")
-
-        # Add a new partition
-        p2 = f"{self.TABLE}_p_new"
-        with connection.cursor() as cursor:
-            cursor.execute(
-                f"CREATE TABLE {p2} PARTITION OF {self.TABLE} "
-                f"FOR VALUES FROM ('2024-06-01') TO ('2024-07-01')"
+    def test_hash_partition_data_distribution(self):
+        table = "_test_routing_hash"
+        try:
+            _create_parent_table(
+                table, "HASH (id)", "id BIGSERIAL NOT NULL, data TEXT, PRIMARY KEY (id)"
             )
 
-        # The new partition does NOT have the index
-        p2_indexes = _get_indexes(p2)
-        assert _partition_index_name(p2, index_name) not in p2_indexes
+            hash_parts = [
+                HashPartition(name=f"{table}_p{i}", modulus=4, remainder=i) for i in range(4)
+            ]
+            for hp in hash_parts:
+                _run_op_forwards(AddPartition(model_name="FakeModel", partition=hp), table)
 
-        # The existing partition still has it
-        p1_indexes = _get_indexes(p1)
-        assert idx in p1_indexes
+            assert len(get_partitions(connection, table)) == 4
 
-    def test_partition_with_data_and_index_query(self):
-        """End-to-end: create partitions, add data, create indexes, query."""
-        from sentry.new_migrations.monkey.partitioned import _partition_index_name
+            with connection.cursor() as cursor:
+                for i in range(100):
+                    cursor.execute(f"INSERT INTO {table} (data) VALUES ('item_{i}')")
 
-        p1 = f"{self.TABLE}_p1"
-        p2 = f"{self.TABLE}_p2"
-        _setup_partitioned_table(self.TABLE, [p1, p2])
+                cursor.execute(f"SELECT COUNT(*) FROM {table}")
+                assert cursor.fetchone()[0] == 100
+
+                for hp in hash_parts:
+                    cursor.execute(f"SELECT COUNT(*) FROM {hp.name}")
+                    assert cursor.fetchone()[0] > 0
+        finally:
+            _cleanup_tables(table)
+
+    def test_list_partition_data_routing(self):
+        table = "_test_routing_list"
+        try:
+            _create_parent_table(
+                table,
+                "LIST (region)",
+                "id BIGSERIAL NOT NULL, region TEXT NOT NULL, data TEXT, PRIMARY KEY (id, region)",
+            )
+
+            list_parts = [
+                ListPartition(name=f"{table}_us", values=["us-east-1", "us-west-2"]),
+                ListPartition(name=f"{table}_eu", values=["eu-west-1", "eu-central-1"]),
+            ]
+            for lp in list_parts:
+                _run_op_forwards(AddPartition(model_name="FakeModel", partition=lp), table)
+
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    f"INSERT INTO {table} (region, data) VALUES ('us-east-1', 'us_data')"
+                )
+                cursor.execute(
+                    f"INSERT INTO {table} (region, data) VALUES ('eu-west-1', 'eu_data')"
+                )
+
+                cursor.execute(f"SELECT data FROM {table}_us")
+                assert cursor.fetchone()[0] == "us_data"
+
+                cursor.execute(f"SELECT data FROM {table}_eu")
+                assert cursor.fetchone()[0] == "eu_data"
+        finally:
+            _cleanup_tables(table)
+
+    def test_end_to_end_partitions_data_indexes(self):
+        """Full lifecycle: create partitions, insert data, add indexes, query."""
+        partitions = _setup_range_table(self.TABLE, 2)
 
         # Insert data
         with connection.cursor() as cursor:
@@ -953,249 +814,21 @@ class PartitionMaintenanceTest(TestCase):
             for day in range(1, 28):
                 cursor.execute(
                     f"INSERT INTO {self.TABLE} (date_added, data, status) "
-                    f"VALUES ('2024-02-{day:02d}', 'feb_data_{day}', {day % 5})"
+                    f"VALUES ('2024-02-{day:02d}', 'feb_{day}', {day % 5})"
                 )
 
-        # Create indexes on each partition
-        index_name = "status_idx"
-        with connection.cursor() as cursor:
-            for p in [p1, p2]:
-                idx = _partition_index_name(p, index_name)
-                cursor.execute(f"CREATE INDEX {idx} ON {p} (status)")
+        # Add indexes via operation
+        from django.db.models import Index
 
-        # Query with condition that benefits from the index
+        index = Index(fields=["status"], name="status_idx")
+        op = AddPartitionIndex(model_name="FakeModel", index=index)
+        _run_op_forwards(op, self.TABLE, real_model=True)
+
+        # Verify indexes on partitions
+        for p in partitions:
+            assert _partition_index_name(p.name, "status_idx") in _get_indexes(p.name)
+
+        # Query benefits from index
         with connection.cursor() as cursor:
             cursor.execute(f"SELECT COUNT(*) FROM {self.TABLE} WHERE status = 0")
-            count = cursor.fetchone()[0]
-            assert count > 0
-
-            # Query specific partition directly
-            cursor.execute(f"SELECT COUNT(*) FROM {p1} WHERE status = 0")
-            p1_count = cursor.fetchone()[0]
-            assert p1_count > 0
-
-    def test_add_partition_backwards_drops_partition(self):
-        """AddPartition.database_backwards should drop the created partition."""
-        from sentry.new_migrations.monkey.partitioned import AddPartition
-
-        p1 = f"{self.TABLE}_p1"
-        _setup_partitioned_table(self.TABLE, [p1])
-
-        new_partition = RangePartition(
-            name=f"{self.TABLE}_p_rev",
-            from_values="'2024-06-01'",
-            to_values="'2024-07-01'",
-        )
-
-        class FakeMeta:
-            db_table = self.TABLE
-            app_label = "sentry"
-            label_lower = "sentry.fakemodel"
-
-        class FakeModel:
-            _meta = FakeMeta()
-
-        class FakeState:
-            class apps:
-                @staticmethod
-                def get_model(app_label, model_name):
-                    return FakeModel
-
-            models = {}
-
-        op = AddPartition(model_name="FakeModel", partition=new_partition)
-
-        # Forward: create the partition
-        with mock.patch.dict(os.environ, {"SENTRY_PARTITIONED_MODELS": self.TABLE}):
-            with mock.patch.object(op, "allow_migrate_model", return_value=True):
-                with connection.schema_editor() as schema_editor:
-                    op.database_forwards("sentry", schema_editor, FakeState, FakeState)
-
-        assert f"{self.TABLE}_p_rev" in get_partitions(connection, self.TABLE)
-
-        # Backward: remove the partition
-        with mock.patch.dict(os.environ, {"SENTRY_PARTITIONED_MODELS": self.TABLE}):
-            with mock.patch.object(op, "allow_migrate_model", return_value=True):
-                with connection.schema_editor() as schema_editor:
-                    op.database_backwards("sentry", schema_editor, FakeState, FakeState)
-
-        assert f"{self.TABLE}_p_rev" not in get_partitions(connection, self.TABLE)
-
-    def test_remove_partition_backwards_recreates_partition(self):
-        """RemovePartition.database_backwards should recreate the partition."""
-        from sentry.new_migrations.monkey.partitioned import RemovePartition
-
-        p1 = f"{self.TABLE}_p1"
-        _setup_partitioned_table(self.TABLE, [p1])
-
-        partition = RangePartition(
-            name=p1,
-            from_values="'2024-01-01'",
-            to_values="'2024-02-01'",
-        )
-
-        class FakeMeta:
-            db_table = self.TABLE
-            app_label = "sentry"
-            label_lower = "sentry.fakemodel"
-
-        class FakeModel:
-            _meta = FakeMeta()
-
-        class FakeState:
-            class apps:
-                @staticmethod
-                def get_model(app_label, model_name):
-                    return FakeModel
-
-            models = {}
-
-        op = RemovePartition(model_name="FakeModel", partition=partition)
-
-        # Forward: remove the partition
-        with mock.patch.dict(os.environ, {"SENTRY_PARTITIONED_MODELS": self.TABLE}):
-            with mock.patch.object(op, "allow_migrate_model", return_value=True):
-                with connection.schema_editor() as schema_editor:
-                    op.database_forwards("sentry", schema_editor, FakeState, FakeState)
-
-        assert p1 not in get_partitions(connection, self.TABLE)
-
-        # Backward: recreate the partition
-        with mock.patch.dict(os.environ, {"SENTRY_PARTITIONED_MODELS": self.TABLE}):
-            with mock.patch.object(op, "allow_migrate_model", return_value=True):
-                with connection.schema_editor() as schema_editor:
-                    op.database_backwards("sentry", schema_editor, FakeState, FakeState)
-
-        assert p1 in get_partitions(connection, self.TABLE)
-
-        # Verify the recreated partition accepts data
-        with connection.cursor() as cursor:
-            cursor.execute(
-                f"INSERT INTO {self.TABLE} (date_added, data) VALUES ('2024-01-15', 'restored')"
-            )
-            cursor.execute(f"SELECT data FROM {p1}")
-            assert cursor.fetchone()[0] == "restored"
-
-    def test_hash_partitioned_table_operations(self):
-        """Test full lifecycle on a HASH-partitioned table."""
-        from sentry.new_migrations.monkey.partitioned import AddPartition
-
-        table = "_test_maint_hash"
-        try:
-            with connection.cursor() as cursor:
-                cursor.execute(f"DROP TABLE IF EXISTS {table} CASCADE")
-                cursor.execute(
-                    f"CREATE TABLE {table} ("
-                    f"  id BIGSERIAL NOT NULL,"
-                    f"  data TEXT,"
-                    f"  PRIMARY KEY (id)"
-                    f") PARTITION BY HASH (id)"
-                )
-
-            partitions_to_add = [
-                HashPartition(name=f"{table}_p{i}", modulus=4, remainder=i) for i in range(4)
-            ]
-
-            class FakeMeta:
-                db_table = table
-                app_label = "sentry"
-                label_lower = "sentry.fakemodel"
-
-            class FakeModel:
-                _meta = FakeMeta()
-
-            class FakeState:
-                class apps:
-                    @staticmethod
-                    def get_model(app_label, model_name):
-                        return FakeModel
-
-                models = {}
-
-            with mock.patch.dict(os.environ, {"SENTRY_PARTITIONED_MODELS": table}):
-                for part in partitions_to_add:
-                    op = AddPartition(model_name="FakeModel", partition=part)
-                    with mock.patch.object(op, "allow_migrate_model", return_value=True):
-                        with connection.schema_editor() as schema_editor:
-                            op.database_forwards("sentry", schema_editor, FakeState, FakeState)
-
-            assert len(get_partitions(connection, table)) == 4
-
-            # Insert data — hash distributes across partitions
-            with connection.cursor() as cursor:
-                for i in range(100):
-                    cursor.execute(f"INSERT INTO {table} (data) VALUES ('item_{i}')")
-
-                cursor.execute(f"SELECT COUNT(*) FROM {table}")
-                assert cursor.fetchone()[0] == 100
-
-                # Each partition should have some data (probabilistic but 100 rows / 4 partitions)
-                for p in [f"{table}_p{i}" for i in range(4)]:
-                    cursor.execute(f"SELECT COUNT(*) FROM {p}")
-                    count = cursor.fetchone()[0]
-                    assert count > 0, f"Partition {p} has no rows — unexpected for 100 inserts"
-        finally:
-            _cleanup_tables(table)
-
-    def test_list_partitioned_table_operations(self):
-        """Test full lifecycle on a LIST-partitioned table."""
-        from sentry.new_migrations.monkey.partitioned import AddPartition
-
-        table = "_test_maint_list"
-        try:
-            with connection.cursor() as cursor:
-                cursor.execute(f"DROP TABLE IF EXISTS {table} CASCADE")
-                cursor.execute(
-                    f"CREATE TABLE {table} ("
-                    f"  id BIGSERIAL NOT NULL,"
-                    f"  region TEXT NOT NULL,"
-                    f"  data TEXT,"
-                    f"  PRIMARY KEY (id, region)"
-                    f") PARTITION BY LIST (region)"
-                )
-
-            partitions = [
-                ListPartition(name=f"{table}_us", values=["us-east-1", "us-west-2"]),
-                ListPartition(name=f"{table}_eu", values=["eu-west-1", "eu-central-1"]),
-            ]
-
-            class FakeMeta:
-                db_table = table
-                app_label = "sentry"
-                label_lower = "sentry.fakemodel"
-
-            class FakeModel:
-                _meta = FakeMeta()
-
-            class FakeState:
-                class apps:
-                    @staticmethod
-                    def get_model(app_label, model_name):
-                        return FakeModel
-
-                models = {}
-
-            with mock.patch.dict(os.environ, {"SENTRY_PARTITIONED_MODELS": table}):
-                for part in partitions:
-                    op = AddPartition(model_name="FakeModel", partition=part)
-                    with mock.patch.object(op, "allow_migrate_model", return_value=True):
-                        with connection.schema_editor() as schema_editor:
-                            op.database_forwards("sentry", schema_editor, FakeState, FakeState)
-
-            # Insert data
-            with connection.cursor() as cursor:
-                cursor.execute(
-                    f"INSERT INTO {table} (region, data) VALUES ('us-east-1', 'us_data')"
-                )
-                cursor.execute(
-                    f"INSERT INTO {table} (region, data) VALUES ('eu-west-1', 'eu_data')"
-                )
-
-                # Verify routing
-                cursor.execute(f"SELECT data FROM {table}_us")
-                assert cursor.fetchone()[0] == "us_data"
-
-                cursor.execute(f"SELECT data FROM {table}_eu")
-                assert cursor.fetchone()[0] == "eu_data"
-        finally:
-            _cleanup_tables(table)
+            assert cursor.fetchone()[0] > 0

--- a/tests/sentry/db/test_partitioned.py
+++ b/tests/sentry/db/test_partitioned.py
@@ -1,0 +1,472 @@
+from __future__ import annotations
+
+import os
+from unittest import mock
+
+import pytest
+from django.db import connection
+
+from sentry.db.models.partitioned import (
+    HashPartition,
+    ListPartition,
+    PartitionConfig,
+    PartitionStrategy,
+    RangePartition,
+    get_partitions,
+    is_partitioning_enabled,
+)
+from sentry.testutils.cases import TestCase
+
+
+class PartitionConfigTest(TestCase):
+    def test_requires_key(self):
+        with pytest.raises(ValueError, match="must contain at least one column name"):
+            PartitionConfig(strategy=PartitionStrategy.RANGE, key=[])
+
+    def test_sql_clause_range(self):
+        config = PartitionConfig(strategy=PartitionStrategy.RANGE, key=["date_added"])
+
+        class FakeField:
+            column = "date_added"
+
+        class FakeMeta:
+            def get_field(self, name):
+                return FakeField()
+
+        class FakeModel:
+            _meta = FakeMeta()
+
+        assert config.sql_clause(FakeModel) == "PARTITION BY RANGE (date_added)"
+
+    def test_sql_clause_list(self):
+        config = PartitionConfig(strategy=PartitionStrategy.LIST, key=["region"])
+
+        class FakeField:
+            column = "region"
+
+        class FakeMeta:
+            def get_field(self, name):
+                return FakeField()
+
+        class FakeModel:
+            _meta = FakeMeta()
+
+        assert config.sql_clause(FakeModel) == "PARTITION BY LIST (region)"
+
+    def test_sql_clause_hash(self):
+        config = PartitionConfig(strategy=PartitionStrategy.HASH, key=["id"])
+
+        class FakeField:
+            column = "id"
+
+        class FakeMeta:
+            def get_field(self, name):
+                return FakeField()
+
+        class FakeModel:
+            _meta = FakeMeta()
+
+        assert config.sql_clause(FakeModel) == "PARTITION BY HASH (id)"
+
+    def test_sql_clause_multi_key(self):
+        config = PartitionConfig(
+            strategy=PartitionStrategy.RANGE, key=["organization_id", "date_added"]
+        )
+
+        fields = {
+            "organization_id": type("F", (), {"column": "organization_id"})(),
+            "date_added": type("F", (), {"column": "date_added"})(),
+        }
+
+        class FakeMeta:
+            def get_field(self, name):
+                return fields[name]
+
+        class FakeModel:
+            _meta = FakeMeta()
+
+        assert config.sql_clause(FakeModel) == "PARTITION BY RANGE (organization_id, date_added)"
+
+
+class PartitionBoundClauseTest(TestCase):
+    def test_range_partition(self):
+        p = RangePartition(name="p_2024_01", from_values="'2024-01-01'", to_values="'2024-02-01'")
+        assert p.sql_bound_clause() == "FOR VALUES FROM ('2024-01-01') TO ('2024-02-01')"
+
+    def test_list_partition(self):
+        p = ListPartition(name="p_us", values=["us-east-1", "us-west-2"])
+        assert p.sql_bound_clause() == "FOR VALUES IN ('us-east-1', 'us-west-2')"
+
+    def test_list_partition_integers(self):
+        p = ListPartition(name="p_1", values=[1, 2, 3])
+        assert p.sql_bound_clause() == "FOR VALUES IN (1, 2, 3)"
+
+    def test_hash_partition(self):
+        p = HashPartition(name="p_0", modulus=4, remainder=0)
+        assert p.sql_bound_clause() == "FOR VALUES WITH (MODULUS 4, REMAINDER 0)"
+
+
+class IsPartitioningEnabledTest(TestCase):
+    def test_disabled_by_default(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("SENTRY_PARTITIONED_MODELS", None)
+            assert is_partitioning_enabled("sentry_testmodel") is False
+
+    def test_enabled_all(self):
+        with mock.patch.dict(os.environ, {"SENTRY_PARTITIONED_MODELS": "__all__"}):
+            assert is_partitioning_enabled("sentry_testmodel") is True
+
+    def test_enabled_specific(self):
+        with mock.patch.dict(os.environ, {"SENTRY_PARTITIONED_MODELS": "sentry_foo,sentry_bar"}):
+            assert is_partitioning_enabled("sentry_foo") is True
+            assert is_partitioning_enabled("sentry_bar") is True
+            assert is_partitioning_enabled("sentry_baz") is False
+
+    def test_enabled_with_model_class(self):
+        class FakeMeta:
+            db_table = "sentry_mymodel"
+
+        class FakeModel:
+            _meta = FakeMeta()
+
+        with mock.patch.dict(os.environ, {"SENTRY_PARTITIONED_MODELS": "sentry_mymodel"}):
+            assert is_partitioning_enabled(FakeModel) is True
+
+    def test_empty_string_means_disabled(self):
+        with mock.patch.dict(os.environ, {"SENTRY_PARTITIONED_MODELS": ""}):
+            assert is_partitioning_enabled("sentry_testmodel") is False
+
+
+class SchemaEditorPartitionTest(TestCase):
+    """Tests that the schema editor correctly generates PARTITION BY clauses."""
+
+    def _create_test_table(self, table_name, partitioned=True):
+        """Create a test partitioned table using raw SQL to verify schema editor behavior."""
+        with connection.cursor() as cursor:
+            cursor.execute(f"DROP TABLE IF EXISTS {table_name} CASCADE")
+
+        if partitioned:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    f"CREATE TABLE {table_name} ("
+                    f"  id BIGSERIAL NOT NULL,"
+                    f"  date_added TIMESTAMP WITH TIME ZONE NOT NULL,"
+                    f"  data TEXT,"
+                    f"  PRIMARY KEY (id, date_added)"
+                    f") PARTITION BY RANGE (date_added)"
+                )
+        else:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    f"CREATE TABLE {table_name} ("
+                    f"  id BIGSERIAL PRIMARY KEY,"
+                    f"  date_added TIMESTAMP WITH TIME ZONE NOT NULL,"
+                    f"  data TEXT"
+                    f")"
+                )
+
+    def _cleanup_table(self, table_name):
+        with connection.cursor() as cursor:
+            cursor.execute(f"DROP TABLE IF EXISTS {table_name} CASCADE")
+
+    def test_partition_by_range_table_creation(self):
+        table_name = "_test_partition_range"
+        try:
+            self._create_test_table(table_name, partitioned=True)
+
+            with connection.cursor() as cursor:
+                cursor.execute("SELECT relkind FROM pg_class WHERE relname = %s", [table_name])
+                row = cursor.fetchone()
+                assert row is not None
+                # 'p' = partitioned table
+                assert row[0] == "p"
+        finally:
+            self._cleanup_table(table_name)
+
+    def test_add_range_partition(self):
+        table_name = "_test_partition_parent"
+        partition_name = "_test_partition_p202401"
+        try:
+            self._create_test_table(table_name, partitioned=True)
+
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    f"CREATE TABLE {partition_name} PARTITION OF {table_name} "
+                    f"FOR VALUES FROM ('2024-01-01') TO ('2024-02-01')"
+                )
+
+            partitions = get_partitions(connection, table_name)
+            assert partition_name in partitions
+        finally:
+            self._cleanup_table(table_name)
+
+    def test_add_list_partition(self):
+        table_name = "_test_partition_list_parent"
+        partition_name = "_test_partition_list_p_us"
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(f"DROP TABLE IF EXISTS {table_name} CASCADE")
+                cursor.execute(
+                    f"CREATE TABLE {table_name} ("
+                    f"  id BIGSERIAL NOT NULL,"
+                    f"  region TEXT NOT NULL,"
+                    f"  data TEXT,"
+                    f"  PRIMARY KEY (id, region)"
+                    f") PARTITION BY LIST (region)"
+                )
+                cursor.execute(
+                    f"CREATE TABLE {partition_name} PARTITION OF {table_name} "
+                    f"FOR VALUES IN ('us-east-1', 'us-west-2')"
+                )
+
+            partitions = get_partitions(connection, table_name)
+            assert partition_name in partitions
+        finally:
+            self._cleanup_table(table_name)
+
+    def test_add_hash_partition(self):
+        table_name = "_test_partition_hash_parent"
+        partition_name = "_test_partition_hash_p0"
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(f"DROP TABLE IF EXISTS {table_name} CASCADE")
+                cursor.execute(
+                    f"CREATE TABLE {table_name} ("
+                    f"  id BIGSERIAL NOT NULL,"
+                    f"  data TEXT,"
+                    f"  PRIMARY KEY (id)"
+                    f") PARTITION BY HASH (id)"
+                )
+                cursor.execute(
+                    f"CREATE TABLE {partition_name} PARTITION OF {table_name} "
+                    f"FOR VALUES WITH (MODULUS 4, REMAINDER 0)"
+                )
+
+            partitions = get_partitions(connection, table_name)
+            assert partition_name in partitions
+        finally:
+            self._cleanup_table(table_name)
+
+    def test_get_partitions_empty(self):
+        table_name = "_test_partition_empty"
+        try:
+            self._create_test_table(table_name, partitioned=True)
+            partitions = get_partitions(connection, table_name)
+            assert partitions == []
+        finally:
+            self._cleanup_table(table_name)
+
+    def test_get_partitions_nonexistent_table(self):
+        partitions = get_partitions(connection, "_nonexistent_table_xyz")
+        assert partitions == []
+
+    def test_partition_index_on_partition(self):
+        """Verify indexes can be created on individual partitions."""
+        table_name = "_test_pidx_parent"
+        partition_name = "_test_pidx_p202401"
+        try:
+            self._create_test_table(table_name, partitioned=True)
+
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    f"CREATE TABLE {partition_name} PARTITION OF {table_name} "
+                    f"FOR VALUES FROM ('2024-01-01') TO ('2024-02-01')"
+                )
+                # Create index on partition only
+                cursor.execute(f"CREATE INDEX {partition_name}_data_idx ON {partition_name} (data)")
+
+                # Verify index exists on partition
+                cursor.execute(
+                    "SELECT indexname FROM pg_indexes WHERE tablename = %s",
+                    [partition_name],
+                )
+                index_names = [row[0] for row in cursor.fetchall()]
+                assert f"{partition_name}_data_idx" in index_names
+
+                # Verify index does NOT exist on parent
+                cursor.execute(
+                    "SELECT indexname FROM pg_indexes WHERE tablename = %s",
+                    [table_name],
+                )
+                parent_index_names = [row[0] for row in cursor.fetchall()]
+                assert f"{partition_name}_data_idx" not in parent_index_names
+        finally:
+            self._cleanup_table(table_name)
+
+
+class MigrationOperationTest(TestCase):
+    """Tests for the partition migration operations."""
+
+    def _cleanup_table(self, table_name):
+        with connection.cursor() as cursor:
+            cursor.execute(f"DROP TABLE IF EXISTS {table_name} CASCADE")
+
+    def test_add_partition_operation_with_range(self):
+        from sentry.new_migrations.monkey.partitioned import AddPartition
+
+        table_name = "_test_op_range_parent"
+        partition = RangePartition(
+            name="_test_op_range_p202401",
+            from_values="'2024-01-01'",
+            to_values="'2024-02-01'",
+        )
+
+        try:
+            # Create parent table
+            with connection.cursor() as cursor:
+                cursor.execute(f"DROP TABLE IF EXISTS {table_name} CASCADE")
+                cursor.execute(
+                    f"CREATE TABLE {table_name} ("
+                    f"  id BIGSERIAL NOT NULL,"
+                    f"  date_added TIMESTAMP WITH TIME ZONE NOT NULL,"
+                    f"  PRIMARY KEY (id, date_added)"
+                    f") PARTITION BY RANGE (date_added)"
+                )
+
+            # Create a minimal fake model for the operation
+            class FakeMeta:
+                db_table = table_name
+                app_label = "sentry"
+                label_lower = "sentry.fakemodel"
+
+            class FakeModel:
+                _meta = FakeMeta()
+
+            class FakeState:
+                class apps:
+                    @staticmethod
+                    def get_model(app_label, model_name):
+                        return FakeModel
+
+                models = {}
+
+            op = AddPartition(model_name="FakeModel", partition=partition)
+
+            with mock.patch.dict(os.environ, {"SENTRY_PARTITIONED_MODELS": table_name}):
+                with mock.patch.object(op, "allow_migrate_model", return_value=True):
+                    with connection.schema_editor() as schema_editor:
+                        op.database_forwards("sentry", schema_editor, FakeState, FakeState)
+
+            partitions = get_partitions(connection, table_name)
+            assert "_test_op_range_p202401" in partitions
+        finally:
+            self._cleanup_table(table_name)
+
+    def test_add_partition_noop_when_disabled(self):
+        from sentry.new_migrations.monkey.partitioned import AddPartition
+
+        partition = RangePartition(
+            name="_test_noop_p202401",
+            from_values="'2024-01-01'",
+            to_values="'2024-02-01'",
+        )
+        op = AddPartition(model_name="FakeModel", partition=partition)
+
+        class FakeMeta:
+            db_table = "_test_noop_parent"
+            app_label = "sentry"
+            label_lower = "sentry.fakemodel"
+
+        class FakeModel:
+            _meta = FakeMeta()
+
+        class FakeState:
+            class apps:
+                @staticmethod
+                def get_model(app_label, model_name):
+                    return FakeModel
+
+            models = {}
+
+        with mock.patch.dict(os.environ, {"SENTRY_PARTITIONED_MODELS": ""}):
+            with mock.patch.object(op, "allow_migrate_model", return_value=True):
+                with connection.schema_editor() as schema_editor:
+                    # Should not raise even though parent table doesn't exist
+                    op.database_forwards("sentry", schema_editor, FakeState, FakeState)
+
+    def test_remove_partition_operation(self):
+        from sentry.new_migrations.monkey.partitioned import RemovePartition
+
+        table_name = "_test_op_rm_parent"
+        partition = RangePartition(
+            name="_test_op_rm_p202401",
+            from_values="'2024-01-01'",
+            to_values="'2024-02-01'",
+        )
+
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(f"DROP TABLE IF EXISTS {table_name} CASCADE")
+                cursor.execute(
+                    f"CREATE TABLE {table_name} ("
+                    f"  id BIGSERIAL NOT NULL,"
+                    f"  date_added TIMESTAMP WITH TIME ZONE NOT NULL,"
+                    f"  PRIMARY KEY (id, date_added)"
+                    f") PARTITION BY RANGE (date_added)"
+                )
+                cursor.execute(
+                    f"CREATE TABLE _test_op_rm_p202401 PARTITION OF {table_name} "
+                    f"FOR VALUES FROM ('2024-01-01') TO ('2024-02-01')"
+                )
+
+            assert "_test_op_rm_p202401" in get_partitions(connection, table_name)
+
+            class FakeMeta:
+                db_table = table_name
+                app_label = "sentry"
+                label_lower = "sentry.fakemodel"
+
+            class FakeModel:
+                _meta = FakeMeta()
+
+            class FakeState:
+                class apps:
+                    @staticmethod
+                    def get_model(app_label, model_name):
+                        return FakeModel
+
+                models = {}
+
+            op = RemovePartition(model_name="FakeModel", partition=partition)
+
+            with mock.patch.dict(os.environ, {"SENTRY_PARTITIONED_MODELS": table_name}):
+                with mock.patch.object(op, "allow_migrate_model", return_value=True):
+                    with connection.schema_editor() as schema_editor:
+                        op.database_forwards("sentry", schema_editor, FakeState, FakeState)
+
+            assert "_test_op_rm_p202401" not in get_partitions(connection, table_name)
+        finally:
+            self._cleanup_table(table_name)
+
+    def test_partition_index_name_truncation(self):
+        from sentry.new_migrations.monkey.partitioned import _partition_index_name
+
+        name = _partition_index_name("very_long_partition_table_name", "very_long_index_name")
+        assert len(name) <= 63
+
+        short_name = _partition_index_name("p1", "idx1")
+        assert short_name == "p1_idx1"
+
+    def test_operation_deconstruct(self):
+        from sentry.new_migrations.monkey.partitioned import (
+            AddPartition,
+            RemovePartition,
+        )
+
+        partition = RangePartition(
+            name="p_202401",
+            from_values="'2024-01-01'",
+            to_values="'2024-02-01'",
+        )
+
+        add_op = AddPartition(model_name="MyModel", partition=partition)
+        name, args, kwargs = add_op.deconstruct()
+        assert "AddPartition" in name
+        assert kwargs["model_name"] == "MyModel"
+        assert kwargs["partition"] == partition
+
+        rm_op = RemovePartition(model_name="MyModel", partition=partition)
+        name, args, kwargs = rm_op.deconstruct()
+        assert "RemovePartition" in name
+        assert kwargs["model_name"] == "MyModel"
+        assert kwargs["partition"] == partition

--- a/tests/sentry/db/test_partitioned.py
+++ b/tests/sentry/db/test_partitioned.py
@@ -470,3 +470,732 @@ class MigrationOperationTest(TestCase):
         assert "RemovePartition" in name
         assert kwargs["model_name"] == "MyModel"
         assert kwargs["partition"] == partition
+
+
+def _get_indexes(table_name: str) -> list[str]:
+    """Get all index names for a given table."""
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT indexname FROM pg_indexes WHERE tablename = %s ORDER BY indexname",
+            [table_name],
+        )
+        return [row[0] for row in cursor.fetchall()]
+
+
+def _setup_partitioned_table(table_name: str, partition_names: list[str]) -> None:
+    """Create a partitioned table with RANGE partitions for testing."""
+    with connection.cursor() as cursor:
+        cursor.execute(f"DROP TABLE IF EXISTS {table_name} CASCADE")
+        cursor.execute(
+            f"CREATE TABLE {table_name} ("
+            f"  id BIGSERIAL NOT NULL,"
+            f"  date_added TIMESTAMP WITH TIME ZONE NOT NULL,"
+            f"  data TEXT,"
+            f"  status INTEGER DEFAULT 0,"
+            f"  PRIMARY KEY (id, date_added)"
+            f") PARTITION BY RANGE (date_added)"
+        )
+        for i, name in enumerate(partition_names):
+            year = 2024
+            month_start = i + 1
+            month_end = i + 2
+            cursor.execute(
+                f"CREATE TABLE {name} PARTITION OF {table_name} "
+                f"FOR VALUES FROM ('{year}-{month_start:02d}-01') "
+                f"TO ('{year}-{month_end:02d}-01')"
+            )
+
+
+def _cleanup_tables(*table_names: str) -> None:
+    with connection.cursor() as cursor:
+        for name in table_names:
+            cursor.execute(f"DROP TABLE IF EXISTS {name} CASCADE")
+
+
+class AddPartitionIndexTest(TestCase):
+    """Tests for the AddPartitionIndex migration operation against real PostgreSQL."""
+
+    TABLE = "_test_addpidx"
+    PARTITIONS = [f"_test_addpidx_p{i}" for i in range(3)]
+
+    def setUp(self):
+        super().setUp()
+        _setup_partitioned_table(self.TABLE, self.PARTITIONS)
+
+    def tearDown(self):
+        _cleanup_tables(self.TABLE)
+        super().tearDown()
+
+    def test_creates_index_on_all_partitions(self):
+        """AddPartitionIndex should create an index on every existing partition."""
+        from sentry.new_migrations.monkey.partitioned import (
+            _partition_index_name,
+        )
+
+        index_name = "my_data_idx"
+        with mock.patch.dict(os.environ, {"SENTRY_PARTITIONED_MODELS": self.TABLE}):
+            with connection.cursor() as cursor:
+                for p in self.PARTITIONS:
+                    idx = _partition_index_name(p, index_name)
+                    cursor.execute(f"CREATE INDEX {idx} ON {p} (data)")
+
+        # Verify indexes exist on each partition
+        for p in self.PARTITIONS:
+            indexes = _get_indexes(p)
+            expected = _partition_index_name(p, index_name)
+            assert expected in indexes, f"Index {expected} not found on partition {p}"
+
+        # Verify no such index on the parent table
+        parent_indexes = _get_indexes(self.TABLE)
+        assert not any(index_name in idx for idx in parent_indexes if "data" in idx)
+
+    def test_creates_index_on_multiple_partitions_independently(self):
+        """Each partition gets its own independently-named index."""
+        from sentry.new_migrations.monkey.partitioned import _partition_index_name
+
+        index_name = "status_idx"
+        with connection.cursor() as cursor:
+            for p in self.PARTITIONS:
+                idx = _partition_index_name(p, index_name)
+                cursor.execute(f"CREATE INDEX {idx} ON {p} (status)")
+
+        # Verify each partition has its own index with unique name
+        all_idx_names = set()
+        for p in self.PARTITIONS:
+            indexes = _get_indexes(p)
+            idx = _partition_index_name(p, index_name)
+            assert idx in indexes
+            all_idx_names.add(idx)
+
+        # All names should be unique
+        assert len(all_idx_names) == len(self.PARTITIONS)
+
+    def test_noop_on_empty_partitions(self):
+        """AddPartitionIndex on a table with no partitions should do nothing."""
+
+        # Create a partitioned table with no partitions
+        empty_table = "_test_addpidx_empty"
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(f"DROP TABLE IF EXISTS {empty_table} CASCADE")
+                cursor.execute(
+                    f"CREATE TABLE {empty_table} ("
+                    f"  id BIGSERIAL NOT NULL,"
+                    f"  date_added TIMESTAMP WITH TIME ZONE NOT NULL,"
+                    f"  PRIMARY KEY (id, date_added)"
+                    f") PARTITION BY RANGE (date_added)"
+                )
+
+            partitions = get_partitions(connection, empty_table)
+            assert partitions == []
+            # No error, no indexes created — this is the expected behavior
+        finally:
+            _cleanup_tables(empty_table)
+
+    def test_index_survives_data_insert(self):
+        """Index created on a partition should work with inserted data."""
+        from sentry.new_migrations.monkey.partitioned import _partition_index_name
+
+        index_name = "data_lookup_idx"
+        p = self.PARTITIONS[0]
+        idx = _partition_index_name(p, index_name)
+
+        with connection.cursor() as cursor:
+            cursor.execute(f"CREATE INDEX {idx} ON {p} (data)")
+            # Insert data into the partition via the parent table
+            cursor.execute(
+                f"INSERT INTO {self.TABLE} (date_added, data, status) "
+                f"VALUES ('2024-01-15', 'test_value', 1)"
+            )
+            # Verify the index is used (at least exists and data is queryable)
+            cursor.execute(f"SELECT data FROM {self.TABLE} WHERE data = 'test_value'")
+            rows = cursor.fetchall()
+            assert len(rows) == 1
+            assert rows[0][0] == "test_value"
+
+    def test_multi_column_index_on_partitions(self):
+        """Multi-column indexes should work on partitions."""
+        from sentry.new_migrations.monkey.partitioned import _partition_index_name
+
+        index_name = "data_status_idx"
+        with connection.cursor() as cursor:
+            for p in self.PARTITIONS:
+                idx = _partition_index_name(p, index_name)
+                cursor.execute(f"CREATE INDEX {idx} ON {p} (data, status)")
+
+        for p in self.PARTITIONS:
+            indexes = _get_indexes(p)
+            expected = _partition_index_name(p, index_name)
+            assert expected in indexes
+
+
+class RemovePartitionIndexTest(TestCase):
+    """Tests for removing indexes from partitions."""
+
+    TABLE = "_test_rmpidx"
+    PARTITIONS = [f"_test_rmpidx_p{i}" for i in range(3)]
+
+    def setUp(self):
+        super().setUp()
+        _setup_partitioned_table(self.TABLE, self.PARTITIONS)
+
+    def tearDown(self):
+        _cleanup_tables(self.TABLE)
+        super().tearDown()
+
+    def test_removes_index_from_all_partitions(self):
+        """Dropping an index should remove it from every partition."""
+        from sentry.new_migrations.monkey.partitioned import _partition_index_name
+
+        index_name = "to_remove_idx"
+
+        # Create the index on all partitions
+        with connection.cursor() as cursor:
+            for p in self.PARTITIONS:
+                idx = _partition_index_name(p, index_name)
+                cursor.execute(f"CREATE INDEX {idx} ON {p} (data)")
+
+        # Verify they exist
+        for p in self.PARTITIONS:
+            assert _partition_index_name(p, index_name) in _get_indexes(p)
+
+        # Remove them
+        with connection.cursor() as cursor:
+            for p in self.PARTITIONS:
+                idx = _partition_index_name(p, index_name)
+                cursor.execute(f"DROP INDEX IF EXISTS {idx}")
+
+        # Verify they're gone
+        for p in self.PARTITIONS:
+            assert _partition_index_name(p, index_name) not in _get_indexes(p)
+
+    def test_remove_nonexistent_index_is_safe(self):
+        """Dropping a nonexistent index with IF EXISTS should not error."""
+        with connection.cursor() as cursor:
+            for p in self.PARTITIONS:
+                cursor.execute(f"DROP INDEX IF EXISTS {p}_nonexistent_idx")
+        # No error raised
+
+    def test_remove_index_from_subset_of_partitions(self):
+        """If an index only exists on some partitions, removal should still succeed."""
+        from sentry.new_migrations.monkey.partitioned import _partition_index_name
+
+        index_name = "partial_idx"
+
+        # Create index only on the first partition
+        with connection.cursor() as cursor:
+            idx = _partition_index_name(self.PARTITIONS[0], index_name)
+            cursor.execute(f"CREATE INDEX {idx} ON {self.PARTITIONS[0]} (data)")
+
+        # Try removing from all partitions — should not error
+        with connection.cursor() as cursor:
+            for p in self.PARTITIONS:
+                idx = _partition_index_name(p, index_name)
+                cursor.execute(f"DROP INDEX IF EXISTS {idx}")
+
+        # Verify all clean
+        for p in self.PARTITIONS:
+            assert _partition_index_name(p, index_name) not in _get_indexes(p)
+
+
+class PartitionMaintenanceTest(TestCase):
+    """Tests for partition lifecycle operations — adding/removing partitions,
+    verifying data routing, and ensuring indexes on new partitions."""
+
+    TABLE = "_test_maint"
+
+    def tearDown(self):
+        _cleanup_tables(self.TABLE)
+        super().tearDown()
+
+    def test_data_routes_to_correct_partition(self):
+        """Data inserted into the parent table routes to the correct partition."""
+        p1 = f"{self.TABLE}_p1"
+        p2 = f"{self.TABLE}_p2"
+        _setup_partitioned_table(self.TABLE, [p1, p2])
+
+        with connection.cursor() as cursor:
+            # Insert into partition 1's range (month 1)
+            cursor.execute(
+                f"INSERT INTO {self.TABLE} (date_added, data) VALUES ('2024-01-15', 'jan_data')"
+            )
+            # Insert into partition 2's range (month 2)
+            cursor.execute(
+                f"INSERT INTO {self.TABLE} (date_added, data) VALUES ('2024-02-15', 'feb_data')"
+            )
+
+            # Query partition 1 directly
+            cursor.execute(f"SELECT data FROM {p1}")
+            rows = [r[0] for r in cursor.fetchall()]
+            assert rows == ["jan_data"]
+
+            # Query partition 2 directly
+            cursor.execute(f"SELECT data FROM {p2}")
+            rows = [r[0] for r in cursor.fetchall()]
+            assert rows == ["feb_data"]
+
+            # Query parent should return both
+            cursor.execute(f"SELECT data FROM {self.TABLE} ORDER BY date_added")
+            rows = [r[0] for r in cursor.fetchall()]
+            assert rows == ["jan_data", "feb_data"]
+
+    def test_insert_outside_partition_range_fails(self):
+        """Inserting data that doesn't match any partition should fail."""
+        from django.db import transaction
+
+        p1 = f"{self.TABLE}_p1"
+        _setup_partitioned_table(self.TABLE, [p1])
+
+        with pytest.raises(Exception, match="no partition"):
+            with transaction.atomic(using="default"):
+                with connection.cursor() as cursor:
+                    cursor.execute(
+                        f"INSERT INTO {self.TABLE} (date_added, data) "
+                        f"VALUES ('2025-06-15', 'out_of_range')"
+                    )
+
+    def test_add_partition_then_insert(self):
+        """Adding a new partition via the operation allows inserts into its range."""
+        from sentry.new_migrations.monkey.partitioned import AddPartition
+
+        p1 = f"{self.TABLE}_p1"
+        _setup_partitioned_table(self.TABLE, [p1])
+
+        new_partition = RangePartition(
+            name=f"{self.TABLE}_p_new",
+            from_values="'2024-06-01'",
+            to_values="'2024-07-01'",
+        )
+
+        class FakeMeta:
+            db_table = self.TABLE
+            app_label = "sentry"
+            label_lower = "sentry.fakemodel"
+
+        class FakeModel:
+            _meta = FakeMeta()
+
+        class FakeState:
+            class apps:
+                @staticmethod
+                def get_model(app_label, model_name):
+                    return FakeModel
+
+            models = {}
+
+        op = AddPartition(model_name="FakeModel", partition=new_partition)
+
+        with mock.patch.dict(os.environ, {"SENTRY_PARTITIONED_MODELS": self.TABLE}):
+            with mock.patch.object(op, "allow_migrate_model", return_value=True):
+                with connection.schema_editor() as schema_editor:
+                    op.database_forwards("sentry", schema_editor, FakeState, FakeState)
+
+        # Now we can insert into the new partition's range
+        with connection.cursor() as cursor:
+            cursor.execute(
+                f"INSERT INTO {self.TABLE} (date_added, data) VALUES ('2024-06-15', 'june_data')"
+            )
+            cursor.execute(f"SELECT data FROM {self.TABLE}_p_new")
+            rows = [r[0] for r in cursor.fetchall()]
+            assert rows == ["june_data"]
+
+    def test_detach_partition_preserves_data(self):
+        """Detaching a partition removes it from the parent but keeps the table."""
+        p1 = f"{self.TABLE}_p1"
+        p2 = f"{self.TABLE}_p2"
+        _setup_partitioned_table(self.TABLE, [p1, p2])
+
+        # Insert data
+        with connection.cursor() as cursor:
+            cursor.execute(
+                f"INSERT INTO {self.TABLE} (date_added, data) VALUES ('2024-01-15', 'jan')"
+            )
+            cursor.execute(
+                f"INSERT INTO {self.TABLE} (date_added, data) VALUES ('2024-02-15', 'feb')"
+            )
+
+        # Detach partition 1
+        with connection.cursor() as cursor:
+            cursor.execute(f"ALTER TABLE {self.TABLE} DETACH PARTITION {p1}")
+
+        # Parent no longer sees partition 1 data
+        with connection.cursor() as cursor:
+            cursor.execute(f"SELECT data FROM {self.TABLE}")
+            rows = [r[0] for r in cursor.fetchall()]
+            assert rows == ["feb"]
+
+        # But the detached table still has its data
+        with connection.cursor() as cursor:
+            cursor.execute(f"SELECT data FROM {p1}")
+            rows = [r[0] for r in cursor.fetchall()]
+            assert rows == ["jan"]
+
+        # Partitions list no longer includes p1
+        partitions = get_partitions(connection, self.TABLE)
+        assert p1 not in partitions
+        assert p2 in partitions
+
+    def test_remove_partition_operation_drops_table(self):
+        """RemovePartition detaches and drops, so the table is gone entirely."""
+        from sentry.new_migrations.monkey.partitioned import RemovePartition
+
+        p1 = f"{self.TABLE}_p1"
+        p2 = f"{self.TABLE}_p2"
+        _setup_partitioned_table(self.TABLE, [p1, p2])
+
+        partition = RangePartition(
+            name=p1,
+            from_values="'2024-01-01'",
+            to_values="'2024-02-01'",
+        )
+
+        class FakeMeta:
+            db_table = self.TABLE
+            app_label = "sentry"
+            label_lower = "sentry.fakemodel"
+
+        class FakeModel:
+            _meta = FakeMeta()
+
+        class FakeState:
+            class apps:
+                @staticmethod
+                def get_model(app_label, model_name):
+                    return FakeModel
+
+            models = {}
+
+        op = RemovePartition(model_name="FakeModel", partition=partition)
+
+        with mock.patch.dict(os.environ, {"SENTRY_PARTITIONED_MODELS": self.TABLE}):
+            with mock.patch.object(op, "allow_migrate_model", return_value=True):
+                with connection.schema_editor() as schema_editor:
+                    op.database_forwards("sentry", schema_editor, FakeState, FakeState)
+
+        # Partition is gone from pg_inherits
+        assert p1 not in get_partitions(connection, self.TABLE)
+        assert p2 in get_partitions(connection, self.TABLE)
+
+        # The table itself is dropped
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT EXISTS(SELECT 1 FROM pg_class WHERE relname = %s)", [p1])
+            assert cursor.fetchone()[0] is False
+
+    def test_indexes_not_on_parent_table(self):
+        """Indexes created on partitions should NOT appear on the parent table."""
+        from sentry.new_migrations.monkey.partitioned import _partition_index_name
+
+        p1 = f"{self.TABLE}_p1"
+        p2 = f"{self.TABLE}_p2"
+        _setup_partitioned_table(self.TABLE, [p1, p2])
+
+        index_name = "data_idx"
+        with connection.cursor() as cursor:
+            for p in [p1, p2]:
+                idx = _partition_index_name(p, index_name)
+                cursor.execute(f"CREATE INDEX {idx} ON {p} (data)")
+
+        # Parent should have no user-created indexes (only PK-related)
+        parent_indexes = _get_indexes(self.TABLE)
+        assert not any(index_name in idx for idx in parent_indexes)
+
+        # Partitions should have them
+        for p in [p1, p2]:
+            partition_indexes = _get_indexes(p)
+            expected = _partition_index_name(p, index_name)
+            assert expected in partition_indexes
+
+    def test_new_partition_does_not_inherit_partition_indexes(self):
+        """Indexes on existing partitions are NOT auto-inherited by new partitions.
+        This verifies that per-partition index management is necessary."""
+        from sentry.new_migrations.monkey.partitioned import _partition_index_name
+
+        p1 = f"{self.TABLE}_p1"
+        _setup_partitioned_table(self.TABLE, [p1])
+
+        # Add index to existing partition
+        index_name = "data_idx"
+        idx = _partition_index_name(p1, index_name)
+        with connection.cursor() as cursor:
+            cursor.execute(f"CREATE INDEX {idx} ON {p1} (data)")
+
+        # Add a new partition
+        p2 = f"{self.TABLE}_p_new"
+        with connection.cursor() as cursor:
+            cursor.execute(
+                f"CREATE TABLE {p2} PARTITION OF {self.TABLE} "
+                f"FOR VALUES FROM ('2024-06-01') TO ('2024-07-01')"
+            )
+
+        # The new partition does NOT have the index
+        p2_indexes = _get_indexes(p2)
+        assert _partition_index_name(p2, index_name) not in p2_indexes
+
+        # The existing partition still has it
+        p1_indexes = _get_indexes(p1)
+        assert idx in p1_indexes
+
+    def test_partition_with_data_and_index_query(self):
+        """End-to-end: create partitions, add data, create indexes, query."""
+        from sentry.new_migrations.monkey.partitioned import _partition_index_name
+
+        p1 = f"{self.TABLE}_p1"
+        p2 = f"{self.TABLE}_p2"
+        _setup_partitioned_table(self.TABLE, [p1, p2])
+
+        # Insert data
+        with connection.cursor() as cursor:
+            for day in range(1, 28):
+                cursor.execute(
+                    f"INSERT INTO {self.TABLE} (date_added, data, status) "
+                    f"VALUES ('2024-01-{day:02d}', 'data_{day}', {day % 3})"
+                )
+            for day in range(1, 28):
+                cursor.execute(
+                    f"INSERT INTO {self.TABLE} (date_added, data, status) "
+                    f"VALUES ('2024-02-{day:02d}', 'feb_data_{day}', {day % 5})"
+                )
+
+        # Create indexes on each partition
+        index_name = "status_idx"
+        with connection.cursor() as cursor:
+            for p in [p1, p2]:
+                idx = _partition_index_name(p, index_name)
+                cursor.execute(f"CREATE INDEX {idx} ON {p} (status)")
+
+        # Query with condition that benefits from the index
+        with connection.cursor() as cursor:
+            cursor.execute(f"SELECT COUNT(*) FROM {self.TABLE} WHERE status = 0")
+            count = cursor.fetchone()[0]
+            assert count > 0
+
+            # Query specific partition directly
+            cursor.execute(f"SELECT COUNT(*) FROM {p1} WHERE status = 0")
+            p1_count = cursor.fetchone()[0]
+            assert p1_count > 0
+
+    def test_add_partition_backwards_drops_partition(self):
+        """AddPartition.database_backwards should drop the created partition."""
+        from sentry.new_migrations.monkey.partitioned import AddPartition
+
+        p1 = f"{self.TABLE}_p1"
+        _setup_partitioned_table(self.TABLE, [p1])
+
+        new_partition = RangePartition(
+            name=f"{self.TABLE}_p_rev",
+            from_values="'2024-06-01'",
+            to_values="'2024-07-01'",
+        )
+
+        class FakeMeta:
+            db_table = self.TABLE
+            app_label = "sentry"
+            label_lower = "sentry.fakemodel"
+
+        class FakeModel:
+            _meta = FakeMeta()
+
+        class FakeState:
+            class apps:
+                @staticmethod
+                def get_model(app_label, model_name):
+                    return FakeModel
+
+            models = {}
+
+        op = AddPartition(model_name="FakeModel", partition=new_partition)
+
+        # Forward: create the partition
+        with mock.patch.dict(os.environ, {"SENTRY_PARTITIONED_MODELS": self.TABLE}):
+            with mock.patch.object(op, "allow_migrate_model", return_value=True):
+                with connection.schema_editor() as schema_editor:
+                    op.database_forwards("sentry", schema_editor, FakeState, FakeState)
+
+        assert f"{self.TABLE}_p_rev" in get_partitions(connection, self.TABLE)
+
+        # Backward: remove the partition
+        with mock.patch.dict(os.environ, {"SENTRY_PARTITIONED_MODELS": self.TABLE}):
+            with mock.patch.object(op, "allow_migrate_model", return_value=True):
+                with connection.schema_editor() as schema_editor:
+                    op.database_backwards("sentry", schema_editor, FakeState, FakeState)
+
+        assert f"{self.TABLE}_p_rev" not in get_partitions(connection, self.TABLE)
+
+    def test_remove_partition_backwards_recreates_partition(self):
+        """RemovePartition.database_backwards should recreate the partition."""
+        from sentry.new_migrations.monkey.partitioned import RemovePartition
+
+        p1 = f"{self.TABLE}_p1"
+        _setup_partitioned_table(self.TABLE, [p1])
+
+        partition = RangePartition(
+            name=p1,
+            from_values="'2024-01-01'",
+            to_values="'2024-02-01'",
+        )
+
+        class FakeMeta:
+            db_table = self.TABLE
+            app_label = "sentry"
+            label_lower = "sentry.fakemodel"
+
+        class FakeModel:
+            _meta = FakeMeta()
+
+        class FakeState:
+            class apps:
+                @staticmethod
+                def get_model(app_label, model_name):
+                    return FakeModel
+
+            models = {}
+
+        op = RemovePartition(model_name="FakeModel", partition=partition)
+
+        # Forward: remove the partition
+        with mock.patch.dict(os.environ, {"SENTRY_PARTITIONED_MODELS": self.TABLE}):
+            with mock.patch.object(op, "allow_migrate_model", return_value=True):
+                with connection.schema_editor() as schema_editor:
+                    op.database_forwards("sentry", schema_editor, FakeState, FakeState)
+
+        assert p1 not in get_partitions(connection, self.TABLE)
+
+        # Backward: recreate the partition
+        with mock.patch.dict(os.environ, {"SENTRY_PARTITIONED_MODELS": self.TABLE}):
+            with mock.patch.object(op, "allow_migrate_model", return_value=True):
+                with connection.schema_editor() as schema_editor:
+                    op.database_backwards("sentry", schema_editor, FakeState, FakeState)
+
+        assert p1 in get_partitions(connection, self.TABLE)
+
+        # Verify the recreated partition accepts data
+        with connection.cursor() as cursor:
+            cursor.execute(
+                f"INSERT INTO {self.TABLE} (date_added, data) VALUES ('2024-01-15', 'restored')"
+            )
+            cursor.execute(f"SELECT data FROM {p1}")
+            assert cursor.fetchone()[0] == "restored"
+
+    def test_hash_partitioned_table_operations(self):
+        """Test full lifecycle on a HASH-partitioned table."""
+        from sentry.new_migrations.monkey.partitioned import AddPartition
+
+        table = "_test_maint_hash"
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(f"DROP TABLE IF EXISTS {table} CASCADE")
+                cursor.execute(
+                    f"CREATE TABLE {table} ("
+                    f"  id BIGSERIAL NOT NULL,"
+                    f"  data TEXT,"
+                    f"  PRIMARY KEY (id)"
+                    f") PARTITION BY HASH (id)"
+                )
+
+            partitions_to_add = [
+                HashPartition(name=f"{table}_p{i}", modulus=4, remainder=i) for i in range(4)
+            ]
+
+            class FakeMeta:
+                db_table = table
+                app_label = "sentry"
+                label_lower = "sentry.fakemodel"
+
+            class FakeModel:
+                _meta = FakeMeta()
+
+            class FakeState:
+                class apps:
+                    @staticmethod
+                    def get_model(app_label, model_name):
+                        return FakeModel
+
+                models = {}
+
+            with mock.patch.dict(os.environ, {"SENTRY_PARTITIONED_MODELS": table}):
+                for part in partitions_to_add:
+                    op = AddPartition(model_name="FakeModel", partition=part)
+                    with mock.patch.object(op, "allow_migrate_model", return_value=True):
+                        with connection.schema_editor() as schema_editor:
+                            op.database_forwards("sentry", schema_editor, FakeState, FakeState)
+
+            assert len(get_partitions(connection, table)) == 4
+
+            # Insert data — hash distributes across partitions
+            with connection.cursor() as cursor:
+                for i in range(100):
+                    cursor.execute(f"INSERT INTO {table} (data) VALUES ('item_{i}')")
+
+                cursor.execute(f"SELECT COUNT(*) FROM {table}")
+                assert cursor.fetchone()[0] == 100
+
+                # Each partition should have some data (probabilistic but 100 rows / 4 partitions)
+                for p in [f"{table}_p{i}" for i in range(4)]:
+                    cursor.execute(f"SELECT COUNT(*) FROM {p}")
+                    count = cursor.fetchone()[0]
+                    assert count > 0, f"Partition {p} has no rows — unexpected for 100 inserts"
+        finally:
+            _cleanup_tables(table)
+
+    def test_list_partitioned_table_operations(self):
+        """Test full lifecycle on a LIST-partitioned table."""
+        from sentry.new_migrations.monkey.partitioned import AddPartition
+
+        table = "_test_maint_list"
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(f"DROP TABLE IF EXISTS {table} CASCADE")
+                cursor.execute(
+                    f"CREATE TABLE {table} ("
+                    f"  id BIGSERIAL NOT NULL,"
+                    f"  region TEXT NOT NULL,"
+                    f"  data TEXT,"
+                    f"  PRIMARY KEY (id, region)"
+                    f") PARTITION BY LIST (region)"
+                )
+
+            partitions = [
+                ListPartition(name=f"{table}_us", values=["us-east-1", "us-west-2"]),
+                ListPartition(name=f"{table}_eu", values=["eu-west-1", "eu-central-1"]),
+            ]
+
+            class FakeMeta:
+                db_table = table
+                app_label = "sentry"
+                label_lower = "sentry.fakemodel"
+
+            class FakeModel:
+                _meta = FakeMeta()
+
+            class FakeState:
+                class apps:
+                    @staticmethod
+                    def get_model(app_label, model_name):
+                        return FakeModel
+
+                models = {}
+
+            with mock.patch.dict(os.environ, {"SENTRY_PARTITIONED_MODELS": table}):
+                for part in partitions:
+                    op = AddPartition(model_name="FakeModel", partition=part)
+                    with mock.patch.object(op, "allow_migrate_model", return_value=True):
+                        with connection.schema_editor() as schema_editor:
+                            op.database_forwards("sentry", schema_editor, FakeState, FakeState)
+
+            # Insert data
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    f"INSERT INTO {table} (region, data) VALUES ('us-east-1', 'us_data')"
+                )
+                cursor.execute(
+                    f"INSERT INTO {table} (region, data) VALUES ('eu-west-1', 'eu_data')"
+                )
+
+                # Verify routing
+                cursor.execute(f"SELECT data FROM {table}_us")
+                assert cursor.fetchone()[0] == "us_data"
+
+                cursor.execute(f"SELECT data FROM {table}_eu")
+                assert cursor.fetchone()[0] == "eu_data"
+        finally:
+            _cleanup_tables(table)


### PR DESCRIPTION
Add core infrastructure for defining and managing PostgreSQL partitioned tables within Sentry's Django application.

## What

- `PartitionConfig` / `PartitionStrategy` types for declaring partitioning schema (RANGE, LIST, HASH) on models
- `RangePartition`, `ListPartition`, `HashPartition` dataclasses for defining individual partitions
- `PartitionAwareSchemaEditorMixin` that appends `PARTITION BY` to `CREATE TABLE` and strips parent-table indexes from deferred SQL
- Migration operations: `CreatePartitionedModel`, `AddPartition`, `RemovePartition`, `AddPartitionIndex`, `RemovePartitionIndex`
- Per-environment toggle via `SENTRY_PARTITIONED_MODELS` env var
- Model validation in `class_prepared` signal for partition key columns

## Why

As tables grow, PostgreSQL native partitioning enables dropping old data by detaching partitions, concurrent index creation per-partition, and improved query performance via partition pruning. This lays the groundwork for partitioning high-volume tables.

## Design decisions

**Per-environment toggle**: The `SENTRY_PARTITIONED_MODELS` environment variable controls which models are actually created as partitioned tables. When disabled (default), all partition operations gracefully degrade — `CreatePartitionedModel` creates a regular table, `AddPartition`/`RemovePartition` become no-ops, and `AddPartitionIndex` falls back to a regular `AddIndex`. This allows the same migration code to work across all environments with gradual rollout.

**Indexes on partitions only**: Indexes are managed per-physical-partition rather than on the parent table, enabling `CREATE INDEX CONCURRENTLY` on individual partitions. The schema editor mixin strips auto-generated parent-table indexes from `deferred_sql` during partitioned table creation.

**Schema editor mixin approach**: Rather than generating SQL only in custom operations, a `PartitionAwareSchemaEditorMixin` intercepts `table_sql()` and `create_model()`. This means any code path calling `schema_editor.create_model(model)` handles partitioning automatically.

**Partition discovery via `pg_inherits`**: Uses PostgreSQL system catalogs at migration time rather than maintaining a Django-level registry. This is authoritative and avoids state drift.

## What's next

This is Increment 1 (MVP). Follow-up work includes:
- `AddPartitionConstraint` / `RemovePartitionConstraint` operations
- Composite PK handling (PG requires partition key in PK)
- `manage_partitions` management command + Celery task for time-based partition lifecycle
- `DETACH PARTITION ... CONCURRENTLY` support for online partition removal