### PR TITLE
feat(autofix): Show referrer InfoTip in Seer drawer header

### DIFF
--- a/static/app/components/events/autofix/autofixReferrer.tsx
+++ b/static/app/components/events/autofix/autofixReferrer.tsx
@@ -1,0 +1,71 @@
+import {t} from 'sentry/locale';
+import type {Block} from 'sentry/views/seerExplorer/types';
+
+interface ReferrerConfig {
+  pattern: RegExp;
+  tooltip: string | undefined;
+}
+
+const FALLBACK_CONFIG = {
+  pattern: /^.*/,
+  tooltip: undefined,
+};
+
+const REFERRER_CONFIG: ReferrerConfig[] = [
+  {
+    pattern: /^api\.group_ai_autofix$/,
+    tooltip: t('Manually triggered'),
+  },
+  {
+    pattern: /^issue_summary\.alert_fixability$/,
+    tooltip: t('Auto-triggered from alert'),
+  },
+  {
+    pattern: /^issue_summary\.post_process_fixability$/,
+    tooltip: t('Auto-triggered on event ingestion'),
+  },
+  {
+    pattern: /^issue_summary\./,
+    tooltip: t('Auto-triggered from issue summary'),
+  },
+  {pattern: /^slack$/, tooltip: t('Triggered from Slack')},
+  {
+    pattern: /^autofix\.on_completion_hook$/,
+    tooltip: t('Triggered from completion hook'),
+  },
+  FALLBACK_CONFIG,
+];
+
+/**
+ * Iterates through explorer blocks and returns the first referrer found in metadata.
+ */
+export function getReferrerFromBlocks(blocks: Block[]): string | undefined {
+  for (const block of blocks) {
+    const referrer = block.message?.metadata?.referrer;
+    if (referrer) {
+      return referrer;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Returns the matching referrer config for a given referrer string.
+ * Tries each pattern in REFERRER_CONFIG in order and returns the first match.
+ * Returns undefined if no referrer is provided or no pattern matches.
+ */
+export function getReferrerConfig(
+  referrer: string | undefined
+): Readonly<ReferrerConfig> {
+  if (!referrer) {
+    return FALLBACK_CONFIG;
+  }
+
+  for (const config of REFERRER_CONFIG) {
+    if (config.pattern.test(referrer)) {
+      return config;
+    }
+  }
+
+  return FALLBACK_CONFIG;
+}

--- a/static/app/components/events/autofix/v3/drawer.tsx
+++ b/static/app/components/events/autofix/v3/drawer.tsx
@@ -2,6 +2,7 @@ import {useCallback, useMemo} from 'react';
 
 import {Flex} from '@sentry/scraps/layout';
 
+import {getReferrerFromBlocks} from 'sentry/components/events/autofix/autofixReferrer';
 import {
   getAutofixArtifactFromSection,
   getOrderedAutofixSections,
@@ -31,6 +32,11 @@ export function SeerDrawer({group, project}: SeerDrawerProps) {
   const handleCopyMarkdown = useHandleCopyMarkdown({aiAutofix});
   const handleRestart = useHandleRestart({aiAutofix});
 
+  const referrer = useMemo(
+    () => getReferrerFromBlocks(aiAutofix.runState?.blocks ?? []),
+    [aiAutofix.runState?.blocks]
+  );
+
   return (
     <Flex
       className="seer-drawer-container"
@@ -40,7 +46,11 @@ export function SeerDrawer({group, project}: SeerDrawerProps) {
       direction="column"
       background="secondary"
     >
-      <SeerDrawerHeader onCopyMarkdown={handleCopyMarkdown} onReset={handleRestart} />
+      <SeerDrawerHeader
+        onCopyMarkdown={handleCopyMarkdown}
+        onReset={handleRestart}
+        referrer={referrer}
+      />
       <SeerDrawerBody>
         {aiConfig.isAutofixSetupLoading ? (
           <Flex data-test-id="ai-setup-loading-indicator" direction="column" gap="xl">

--- a/static/app/components/events/autofix/v3/header.tsx
+++ b/static/app/components/events/autofix/v3/header.tsx
@@ -1,8 +1,12 @@
+import {useMemo} from 'react';
+
 import {Button} from '@sentry/scraps/button';
+import {InfoTip} from '@sentry/scraps/info';
 import {Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {AutofixFeedback} from 'sentry/components/events/autofix/autofixFeedback';
+import {getReferrerConfig} from 'sentry/components/events/autofix/autofixReferrer';
 import {DrawerHeader} from 'sentry/components/globalDrawer/components';
 import {IconCopy} from 'sentry/icons/iconCopy';
 import {IconRefresh} from 'sentry/icons/iconRefresh';
@@ -11,14 +15,25 @@ import {t} from 'sentry/locale';
 interface SeerDrawerHeaderProps {
   onCopyMarkdown?: () => void;
   onReset?: () => void;
+  referrer?: string;
 }
 
-export function SeerDrawerHeader({onCopyMarkdown, onReset}: SeerDrawerHeaderProps) {
+export function SeerDrawerHeader({
+  onCopyMarkdown,
+  onReset,
+  referrer,
+}: SeerDrawerHeaderProps) {
+  const tooltip = useMemo(() => {
+    const config = getReferrerConfig(referrer);
+    return config.tooltip ?? referrer;
+  }, [referrer]);
+
   return (
     <DrawerHeader>
       <Flex justify="between" width="100%">
         <Flex align="center" gap="xs">
           <Text>{t('Seer Autofix')}</Text>
+          {tooltip && <InfoTip title={tooltip} size="xs" />}
           <Button
             size="xs"
             icon={<IconCopy />}


### PR DESCRIPTION
Show how an autofix run was triggered by displaying an InfoTip (question mark icon with tooltip) next to "Seer Autofix" in the drawer header.

The referrer is extracted by iterating through explorer blocks looking for `metadata.referrer`, then matched against a regex-based config (`REFERRER_CONFIG`) to resolve a human-readable tooltip like "Triggered from Slack" or "Auto-triggered from alert". When no configured tooltip exists, the raw referrer string is shown as fallback.

New utility module `autofixReferrer.tsx` provides:
- `getReferrerFromBlocks()` — iterates blocks to find the first referrer in metadata
- `getReferrerConfig()` — matches a referrer string against ordered regex patterns, returns a readonly config with the tooltip text

Agent transcript: https://claudescope.sentry.dev/share/aTaCECrcTYgbSVVIBMJ_lVUztS8WgT-DAb07COXoEOs

<img width="3304" height="602" alt="CleanShot 2026-04-17 at 15 13 15@2x" src="https://github.com/user-attachments/assets/fc5b104b-f829-461f-900f-3d6effb4b63e" />
