### PR TITLE
ref(commits): Improve fetch commit task observability

### DIFF
--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -110,21 +110,24 @@ def fetch_commits_for_compare_range(
     start_sha: str,
     end_sha: str,
     user: RpcUser | None,
-    lifecycle: Any,
 ) -> list[dict[str, Any]]:
+    set_tag("compare_commits_cache_enabled", cache_enabled)
     if cache_enabled:
         cache_key = get_github_compare_commits_cache_key(
             repo.organization_id, repo.id, repo.provider, start_sha, end_sha
         )
         cached_repo_commits = cache.get(cache_key)
-        lifecycle.add_extra("compare_commits_cache_enabled", True)
         if cached_repo_commits is not None:
-            lifecycle.add_extra("compare_commits_cache_hit", True)
+            logger.info(
+                "fetch_commits.compare_commits_cache_hit",
+                extra={"compare_commits_cache_hit": True, "cache_key": cache_key},
+            )
             return cached_repo_commits
 
-        lifecycle.add_extra("compare_commits_cache_hit", False)
-    else:
-        lifecycle.add_extra("compare_commits_cache_enabled", False)
+        logger.info(
+            "fetch_commits.compare_commits_cache_miss",
+            extra={"compare_commits_cache_miss": False, "cache_key": cache_key},
+        )
 
     if is_integration_repo_provider:
         # New method to decouple the provider from the task
@@ -223,6 +226,7 @@ def fetch_commits(
     commit_list: list[dict[str, Any]] = []
 
     release = Release.objects.get(id=release_id)
+    logger.info("fetch_commits.start", extra={"organization_slug": release.organization.slug})
     set_tag("organization.slug", release.organization.slug)
     # TODO: Need a better way to error handle no user_id. We need the SDK to be able to call this without user context
     # to autoassociate commits to releases
@@ -304,7 +308,6 @@ def fetch_commits(
                         start_sha=start_sha,
                         end_sha=end_sha,
                         user=user,
-                        lifecycle=lifecycle,
                     )
             except NotImplementedError:
                 pass

--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -120,13 +120,13 @@ def fetch_commits_for_compare_range(
         if cached_repo_commits is not None:
             logger.info(
                 "fetch_commits.compare_commits_cache_hit",
-                extra={"compare_commits_cache_hit": True, "cache_key": cache_key},
+                extra={"compare_commits_cache_hit": False, "cache_key": cache_key},
             )
             return cached_repo_commits
 
         logger.info(
             "fetch_commits.compare_commits_cache_miss",
-            extra={"compare_commits_cache_miss": False, "cache_key": cache_key},
+            extra={"compare_commits_cache_miss": True, "cache_key": cache_key},
         )
 
     if is_integration_repo_provider:

--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -117,17 +117,15 @@ def fetch_commits_for_compare_range(
             repo.organization_id, repo.id, repo.provider, start_sha, end_sha
         )
         cached_repo_commits = cache.get(cache_key)
-        if cached_repo_commits is not None:
-            logger.info(
-                "fetch_commits.compare_commits_cache_hit",
-                extra={"compare_commits_cache_hit": False, "cache_key": cache_key},
-            )
-            return cached_repo_commits
-
         logger.info(
-            "fetch_commits.compare_commits_cache_miss",
-            extra={"compare_commits_cache_miss": True, "cache_key": cache_key},
+            "fetch_commits.compare_commits_cache_hit",
+            extra={
+                "compare_commits_cache_hit": cached_repo_commits is not None,
+                "cache_key": cache_key,
+            },
         )
+        if cached_repo_commits is not None:
+            return cached_repo_commits
 
     if is_integration_repo_provider:
         # New method to decouple the provider from the task


### PR DESCRIPTION
Add task-level observability for commit fetch flows by logging when `fetch_commits` starts and emitting structured cache hit/miss events for compare-commits requests.

This makes it easier to trace task execution and cache behavior during investigations without relying only on lifecycle extras.

I considered keeping cache details only in `SCMIntegrationInteractionEvent`, but adding explicit logs and tags gives more direct signal in task logs and cross-tool diagnostics.

Additional context for reviewers: the `fetch_commits.compare_commits_cache_miss` log currently emits `compare_commits_cache_miss: false` to preserve existing semantics in this change. We can follow up with a separate cleanup if we want to switch this flag to represent literal miss state.