### PR TITLE
feat(seer): Gate Night Shift projects behind projects:seer-night-shift

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -310,6 +310,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-explorer-index", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Seer Night Shift nightly autofix cron
     manager.add("organizations:seer-night-shift", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Per-project gate for Seer Night Shift (requires organizations:seer-night-shift on the org)
+    manager.add("projects:seer-night-shift", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable streaming responses for Seer Explorer
     manager.add("organizations:seer-explorer-streaming", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable context engine for Seer Explorer

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -276,11 +276,20 @@ def _get_eligible_projects(
 
     preferences = bulk_read_preferences(organization, list(project_map))
 
-    projects = [
+    candidates = [
         project_map[pid]
         for pid, pref in preferences.items()
         if pref is not None
         and pref.repositories
         and pref.autofix_automation_tuning != AutofixAutomationTuningSettings.OFF
+    ]
+    if not candidates:
+        return [], preferences
+
+    flag_result = features.batch_has(["projects:seer-night-shift"], projects=candidates)
+    projects = [
+        p
+        for p in candidates
+        if (flag_result or {}).get(f"project:{p.id}", {}).get("projects:seer-night-shift", False)
     ]
     return projects, preferences

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -122,10 +122,34 @@ class TestGetEligibleProjects(TestCase):
         # No connected repo
         self.create_project(organization=org)
 
-        with self.feature("organizations:seer-project-settings-read-from-sentry"):
+        with self.feature(
+            [
+                "organizations:seer-project-settings-read-from-sentry",
+                "projects:seer-night-shift",
+            ]
+        ):
             projects, preferences = _get_eligible_projects(org)
             assert projects == [eligible]
             assert eligible.id in preferences
+
+    def test_filters_by_project_flag_disabled(self) -> None:
+        org = self.create_organization()
+
+        project = self.create_project(organization=org)
+        project.update_option(
+            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM
+        )
+        repo = self.create_repo(project=project, provider="github", name="owner/repo")
+        SeerProjectRepository.objects.create(project=project, repository=repo)
+
+        with self.feature(
+            {
+                "organizations:seer-project-settings-read-from-sentry": True,
+                "projects:seer-night-shift": False,
+            }
+        ):
+            projects, _ = _get_eligible_projects(org)
+            assert projects == []
 
 
 @django_db_all
@@ -161,7 +185,12 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
         self.create_project(organization=org)
 
         with (
-            self.feature("organizations:seer-project-settings-read-from-sentry"),
+            self.feature(
+                [
+                    "organizations:seer-project-settings-read-from-sentry",
+                    "projects:seer-night-shift",
+                ]
+            ),
             patch("sentry.tasks.seer.night_shift.cron.logger") as mock_logger,
         ):
             run_night_shift_for_org(org.id)
@@ -191,7 +220,12 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
 
         fake_client = FakeExplorerClient([high_fix.id, low_fix.id])
         with (
-            self.feature("organizations:seer-project-settings-read-from-sentry"),
+            self.feature(
+                [
+                    "organizations:seer-project-settings-read-from-sentry",
+                    "projects:seer-night-shift",
+                ]
+            ),
             patch(
                 "sentry.tasks.seer.night_shift.agentic_triage.SeerExplorerClient",
                 return_value=fake_client,
@@ -231,7 +265,12 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
 
         fake_client = FakeExplorerClient([high_group.id, low_group.id])
         with (
-            self.feature("organizations:seer-project-settings-read-from-sentry"),
+            self.feature(
+                [
+                    "organizations:seer-project-settings-read-from-sentry",
+                    "projects:seer-night-shift",
+                ]
+            ),
             patch(
                 "sentry.tasks.seer.night_shift.agentic_triage.SeerExplorerClient",
                 return_value=fake_client,
@@ -254,7 +293,12 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
         )
 
         with (
-            self.feature("organizations:seer-project-settings-read-from-sentry"),
+            self.feature(
+                [
+                    "organizations:seer-project-settings-read-from-sentry",
+                    "projects:seer-night-shift",
+                ]
+            ),
             patch(
                 "sentry.tasks.seer.night_shift.cron.agentic_triage_strategy",
                 side_effect=RuntimeError("boom"),
@@ -277,7 +321,12 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
 
         fake_client = FakeExplorerClient([group.id], action="autofix")
         with (
-            self.feature("organizations:seer-project-settings-read-from-sentry"),
+            self.feature(
+                [
+                    "organizations:seer-project-settings-read-from-sentry",
+                    "projects:seer-night-shift",
+                ]
+            ),
             patch(
                 "sentry.tasks.seer.night_shift.agentic_triage.SeerExplorerClient",
                 return_value=fake_client,
@@ -303,7 +352,12 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
 
         fake_client = FakeExplorerClient([group.id], action="autofix")
         with (
-            self.feature("organizations:seer-project-settings-read-from-sentry"),
+            self.feature(
+                [
+                    "organizations:seer-project-settings-read-from-sentry",
+                    "projects:seer-night-shift",
+                ]
+            ),
             patch(
                 "sentry.tasks.seer.night_shift.agentic_triage.SeerExplorerClient",
                 return_value=fake_client,
@@ -329,7 +383,12 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
 
         fake_client = FakeExplorerClient([group.id], action="root_cause_only")
         with (
-            self.feature("organizations:seer-project-settings-read-from-sentry"),
+            self.feature(
+                [
+                    "organizations:seer-project-settings-read-from-sentry",
+                    "projects:seer-night-shift",
+                ]
+            ),
             patch(
                 "sentry.tasks.seer.night_shift.agentic_triage.SeerExplorerClient",
                 return_value=fake_client,
@@ -350,7 +409,12 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
         )
 
         with (
-            self.feature("organizations:seer-project-settings-read-from-sentry"),
+            self.feature(
+                [
+                    "organizations:seer-project-settings-read-from-sentry",
+                    "projects:seer-night-shift",
+                ]
+            ),
             patch(
                 "sentry.tasks.seer.night_shift.cron.agentic_triage_strategy",
                 return_value=([], None),


### PR DESCRIPTION
Add a per-project feature flag (`projects:seer-night-shift`) to restrict which projects the Seer Night Shift nightly autofix cron runs on. A project is only eligible if **both** the existing `organizations:seer-night-shift` org flag and the new per-project flag are enabled.

`_get_eligible_projects` uses `features.batch_has` so the flag is resolved for all candidate projects in one call per org, rather than N individual `has()` checks.

Agent transcript: https://claudescope.sentry.dev/share/0wpw6wl0cN4U5Ub6RtbhsSC0X_QWwa8Z5AoxYNd1MyM