### PR TITLE
chore(seer): Accept **kwargs on night_shift instrumented tasks

### DIFF
--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -4,6 +4,7 @@ import logging
 import time
 from collections.abc import Sequence
 from datetime import timedelta
+from typing import Any
 
 import sentry_sdk
 
@@ -47,7 +48,7 @@ FEATURE_NAMES = [
     namespace=seer_tasks,
     processing_deadline_duration=15 * 60,
 )
-def schedule_night_shift() -> None:
+def schedule_night_shift(**kwargs: Any) -> None:
     """
     Nightly scheduler: iterates active orgs in batches, checks feature flags
     in bulk, and dispatches per-org worker tasks with jitter.
@@ -91,6 +92,7 @@ def run_night_shift_for_org(
     organization_id: int,
     dry_run: bool = False,
     max_candidates: int | None = None,
+    **kwargs: Any,
 ) -> int | None:
     try:
         organization = Organization.objects.get(


### PR DESCRIPTION
Add `**kwargs: Any` to both `@instrumented_task` functions in `sentry.tasks.seer.night_shift.cron` (`schedule_night_shift` and `run_night_shift_for_org`).

Task signatures pick up new framework kwargs over time (retries, headers, eta handling, etc.) as celery/taskbroker evolve. Accepting `**kwargs` keeps tasks forward-compatible without signature churn — this matches the pattern used across `src/sentry/tasks/` (`store.py`, `commits.py`, `symbolication.py`, `auto_source_code_config.py`, etc.).

Docs: https://develop.sentry.dev/backend/application-domains/tasks.md


Agent transcript: https://claudescope.sentry.dev/share/VsWYzzAgYGnI2f_cdylrnblUwuoyAlP-A9Pj1z_Acj4