### PR TITLE
feat(explore): Accept crossEvents param on saved queries

### DIFF
--- a/src/sentry/api/serializers/models/exploresavedquery.py
+++ b/src/sentry/api/serializers/models/exploresavedquery.py
@@ -14,6 +14,11 @@ from sentry.users.services.user.service import user_service
 from sentry.utils.dates import outside_retention_with_modified_start, parse_timestamp
 
 
+class CrossEventResponseType(TypedDict):
+    query: str
+    type: str
+
+
 class ExploreSavedQueryResponseOptional(TypedDict, total=False):
     environment: list[str]
     query: str
@@ -22,6 +27,7 @@ class ExploreSavedQueryResponseOptional(TypedDict, total=False):
     end: str
     interval: str
     mode: str
+    crossEvents: list[CrossEventResponseType]
 
 
 class ExploreSavedQueryChangedReasonType(TypedDict):
@@ -104,6 +110,7 @@ class ExploreSavedQueryModelSerializer(Serializer):
             "start",
             "end",
             "interval",
+            "crossEvents",
         ]
         data: ExploreSavedQueryResponse = {
             "id": str(obj.id),

--- a/src/sentry/explore/endpoints/serializers.py
+++ b/src/sentry/explore/endpoints/serializers.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from drf_spectacular.utils import extend_schema_serializer
 from rest_framework import serializers
 from rest_framework.exceptions import ParseError, ValidationError
@@ -7,6 +9,9 @@ from sentry.constants import ALL_ACCESS_PROJECTS
 from sentry.discover.arithmetic import is_equation
 from sentry.explore.models import ExploreSavedQueryDataset
 from sentry.utils.dates import parse_stats_period, validate_interval
+
+MAX_CROSS_EVENT_QUERIES = 2
+MAX_CROSS_EVENT_RANGE = timedelta(days=7)
 
 
 class VisualizeSerializer(serializers.Serializer):
@@ -139,6 +144,19 @@ class QuerySerializer(serializers.Serializer):
     )
 
 
+class CrossEventSerializer(serializers.Serializer):
+    query = serializers.CharField(
+        required=True,
+        allow_blank=True,
+        help_text="The search query for this cross-event entry.",
+    )
+    type = serializers.ChoiceField(
+        choices=["spans", "logs"],
+        required=True,
+        help_text="The event type this cross-event query targets.",
+    )
+
+
 class ExploreSavedQuerySerializer(serializers.Serializer):
     name = serializers.CharField(
         required=True, max_length=255, help_text="The user-defined saved query name."
@@ -178,6 +196,13 @@ class ExploreSavedQuerySerializer(serializers.Serializer):
     interval = serializers.CharField(
         required=False, allow_null=True, help_text="Resolution of the time series."
     )
+    crossEvents = ListField(
+        child=CrossEventSerializer(),
+        required=False,
+        allow_null=True,
+        max_length=MAX_CROSS_EVENT_QUERIES,
+        help_text="Optional cross-event queries across event types. Max 2 entries.",
+    )
     query = ListField(child=QuerySerializer(), required=True, min_length=1)
 
     def validate_projects(self, projects):
@@ -194,6 +219,7 @@ class ExploreSavedQuerySerializer(serializers.Serializer):
             "start",
             "end",
             "interval",
+            "crossEvents",
         ]
 
         inner_query_keys = [
@@ -214,7 +240,14 @@ class ExploreSavedQuerySerializer(serializers.Serializer):
                 value = data[key]
                 if key in ("start", "end"):
                     value = value.isoformat()
+                if key == "crossEvents":
+                    value = [dict(ce) for ce in value]
                 query[key] = value
+
+        if query.get("crossEvents"):
+            date_range = self.context["params"]["end"] - self.context["params"]["start"]
+            if date_range > MAX_CROSS_EVENT_RANGE:
+                raise serializers.ValidationError("Cross event queries are limited to 7 days.")
 
         if "query" in data:
             query["query"] = []

--- a/src/sentry/explore/endpoints/serializers.py
+++ b/src/sentry/explore/endpoints/serializers.py
@@ -245,9 +245,12 @@ class ExploreSavedQuerySerializer(serializers.Serializer):
                 query[key] = value
 
         if query.get("crossEvents"):
-            date_range = self.context["params"]["end"] - self.context["params"]["start"]
-            if date_range > MAX_CROSS_EVENT_RANGE:
-                raise serializers.ValidationError("Cross event queries are limited to 7 days.")
+            start = self.context["params"].get("start")
+            end = self.context["params"].get("end")
+            if start is not None and end is not None:
+                date_range = end - start
+                if date_range > MAX_CROSS_EVENT_RANGE:
+                    raise serializers.ValidationError("Cross event queries are limited to 7 days.")
 
         if "query" in data:
             query["query"] = []

--- a/tests/sentry/explore/endpoints/test_explore_saved_queries.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_queries.py
@@ -1322,6 +1322,129 @@ class ExploreSavedQueriesTest(APITestCase):
         data = response.data
         assert data["query"][0]["caseInsensitive"] is True
 
+    def test_save_with_cross_events(self) -> None:
+        with self.feature(self.features):
+            response = self.client.post(
+                self.url,
+                {
+                    "name": "Cross event query",
+                    "projects": self.project_ids,
+                    "dataset": "spans",
+                    "query": [
+                        {
+                            "fields": ["span.op"],
+                            "mode": "samples",
+                        }
+                    ],
+                    "range": "24h",
+                    "crossEvents": [
+                        {"query": "span.op:db", "type": "spans"},
+                        {"query": "severity:error", "type": "logs"},
+                    ],
+                },
+            )
+        assert response.status_code == 201, response.content
+        data = response.data
+        assert data["crossEvents"] == [
+            {"query": "span.op:db", "type": "spans"},
+            {"query": "severity:error", "type": "logs"},
+        ]
+
+        saved = ExploreSavedQuery.objects.get(id=data["id"])
+        assert saved.query["crossEvents"] == [
+            {"query": "span.op:db", "type": "spans"},
+            {"query": "severity:error", "type": "logs"},
+        ]
+
+    def test_save_without_cross_events(self) -> None:
+        with self.feature(self.features):
+            response = self.client.post(
+                self.url,
+                {
+                    "name": "No cross events",
+                    "projects": self.project_ids,
+                    "dataset": "spans",
+                    "query": [
+                        {
+                            "fields": ["span.op"],
+                            "mode": "samples",
+                        }
+                    ],
+                    "range": "24h",
+                },
+            )
+        assert response.status_code == 201, response.content
+        assert "crossEvents" not in response.data
+
+    def test_save_with_cross_events_too_many(self) -> None:
+        with self.feature(self.features):
+            response = self.client.post(
+                self.url,
+                {
+                    "name": "Too many cross events",
+                    "projects": self.project_ids,
+                    "dataset": "spans",
+                    "query": [
+                        {
+                            "fields": ["span.op"],
+                            "mode": "samples",
+                        }
+                    ],
+                    "range": "24h",
+                    "crossEvents": [
+                        {"query": "a", "type": "spans"},
+                        {"query": "b", "type": "logs"},
+                        {"query": "c", "type": "spans"},
+                    ],
+                },
+            )
+        assert response.status_code == 400, response.content
+
+    def test_save_with_cross_events_invalid_type(self) -> None:
+        with self.feature(self.features):
+            response = self.client.post(
+                self.url,
+                {
+                    "name": "Invalid type",
+                    "projects": self.project_ids,
+                    "dataset": "spans",
+                    "query": [
+                        {
+                            "fields": ["span.op"],
+                            "mode": "samples",
+                        }
+                    ],
+                    "range": "24h",
+                    "crossEvents": [
+                        {"query": "foo", "type": "errors"},
+                    ],
+                },
+            )
+        assert response.status_code == 400, response.content
+
+    def test_save_with_cross_events_range_exceeds_seven_days(self) -> None:
+        with self.feature(self.features):
+            response = self.client.post(
+                self.url,
+                {
+                    "name": "Too long range",
+                    "projects": self.project_ids,
+                    "dataset": "spans",
+                    "query": [
+                        {
+                            "fields": ["span.op"],
+                            "mode": "samples",
+                        }
+                    ],
+                    "range": "14d",
+                    "crossEvents": [
+                        {"query": "foo", "type": "spans"},
+                    ],
+                },
+            )
+        assert response.status_code == 400, response.content
+        assert "Cross event queries are limited to 7 days." in str(response.content)
+
     def test_save_replay_query(self) -> None:
         with self.feature(self.features):
             response = self.client.post(

--- a/tests/sentry/explore/endpoints/test_explore_saved_queries.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_queries.py
@@ -1356,26 +1356,6 @@ class ExploreSavedQueriesTest(APITestCase):
             {"query": "severity:error", "type": "logs"},
         ]
 
-    def test_save_without_cross_events(self) -> None:
-        with self.feature(self.features):
-            response = self.client.post(
-                self.url,
-                {
-                    "name": "No cross events",
-                    "projects": self.project_ids,
-                    "dataset": "spans",
-                    "query": [
-                        {
-                            "fields": ["span.op"],
-                            "mode": "samples",
-                        }
-                    ],
-                    "range": "24h",
-                },
-            )
-        assert response.status_code == 201, response.content
-        assert "crossEvents" not in response.data
-
     def test_save_with_cross_events_too_many(self) -> None:
         with self.feature(self.features):
             response = self.client.post(

--- a/tests/sentry/explore/endpoints/test_explore_saved_query_detail.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_query_detail.py
@@ -96,6 +96,28 @@ class ExploreSavedQueryDetailTest(APITestCase, SnubaTestCase):
         assert response.data["starred"] is True
         assert response.data["position"] == 1
 
+    def test_get_with_cross_events(self) -> None:
+        self.model.query = {
+            "query": [{"fields": ["span.op"], "mode": "samples"}],
+            "crossEvents": [
+                {"query": "span.op:db", "type": "spans"},
+                {"query": "severity:error", "type": "logs"},
+            ],
+        }
+        self.model.save()
+
+        with self.feature(self.feature_name):
+            url = reverse(
+                "sentry-api-0-explore-saved-query-detail", args=[self.org.slug, self.query_id]
+            )
+            response = self.client.get(url)
+
+        assert response.status_code == 200, response.content
+        assert response.data["crossEvents"] == [
+            {"query": "span.op:db", "type": "spans"},
+            {"query": "severity:error", "type": "logs"},
+        ]
+
     def test_get_changed_reason(self) -> None:
         migrated_query = ExploreSavedQuery.objects.create(
             organization=self.org,

--- a/tests/sentry/explore/endpoints/test_explore_saved_query_detail.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_query_detail.py
@@ -185,6 +185,80 @@ class ExploreSavedQueryDetailTest(APITestCase, SnubaTestCase):
             }
         ]
 
+    def test_put_adds_cross_events(self) -> None:
+        with self.feature(self.feature_name):
+            url = reverse(
+                "sentry-api-0-explore-saved-query-detail", args=[self.org.slug, self.query_id]
+            )
+
+            response = self.client.put(
+                url,
+                {
+                    "name": "With cross events",
+                    "projects": self.project_ids,
+                    "range": "24h",
+                    "query": [{"fields": ["span.op"], "mode": "samples"}],
+                    "crossEvents": [
+                        {"query": "span.op:db", "type": "spans"},
+                        {"query": "severity:error", "type": "logs"},
+                    ],
+                },
+            )
+
+        assert response.status_code == 200, response.content
+        assert response.data["crossEvents"] == [
+            {"query": "span.op:db", "type": "spans"},
+            {"query": "severity:error", "type": "logs"},
+        ]
+
+    def test_put_removes_cross_events(self) -> None:
+        self.model.query = {
+            "query": [{"fields": ["span.op"], "mode": "samples"}],
+            "crossEvents": [{"query": "span.op:db", "type": "spans"}],
+        }
+        self.model.save()
+
+        with self.feature(self.feature_name):
+            url = reverse(
+                "sentry-api-0-explore-saved-query-detail", args=[self.org.slug, self.query_id]
+            )
+
+            response = self.client.put(
+                url,
+                {
+                    "name": "Cross events cleared",
+                    "projects": self.project_ids,
+                    "range": "24h",
+                    "query": [{"fields": ["span.op"], "mode": "samples"}],
+                },
+            )
+
+        assert response.status_code == 200, response.content
+        assert "crossEvents" not in response.data
+
+    def test_put_invalid_cross_events(self) -> None:
+        with self.feature(self.feature_name):
+            url = reverse(
+                "sentry-api-0-explore-saved-query-detail", args=[self.org.slug, self.query_id]
+            )
+
+            response = self.client.put(
+                url,
+                {
+                    "name": "Too many cross events",
+                    "projects": self.project_ids,
+                    "range": "24h",
+                    "query": [{"fields": ["span.op"], "mode": "samples"}],
+                    "crossEvents": [
+                        {"query": "a", "type": "spans"},
+                        {"query": "b", "type": "logs"},
+                        {"query": "c", "type": "spans"},
+                    ],
+                },
+            )
+
+        assert response.status_code == 400, response.content
+
     def test_put_query_without_access(self) -> None:
         with self.feature(self.feature_name):
             url = reverse(


### PR DESCRIPTION
The goal of this PR is to enable users to save their cross-event queries, so they can easily view them over time.

When accepting an optional cross-event query, we also want to ensure that we follow the same limitations we have set on the FE. This means we limit them to two cross event queries either for `spans` or `logs`, as well as limiting the period selection window to seven days.

As well, this PR includes `POST` and `PUT` request tests for the initial saving of a query, and updating of a query that contains cross event queries.

Closes EXP-667