### PR TITLE
chore(dashboards): Remove dashboards-interval-selection feature flag (frontend)

### DIFF
--- a/static/app/views/dashboards/dashboard.spec.tsx
+++ b/static/app/views/dashboards/dashboard.spec.tsx
@@ -420,9 +420,7 @@ describe('Dashboards > Dashboard', () => {
   describe('Interval selection', () => {
     // Use a SPANS widget with LINE display: both are required by
     // widgetCanUseTimeSeriesVisualization, which gates widgetInterval propagation.
-    const orgWithFlag = OrganizationFixture({
-      features: ['dashboards-interval-selection'],
-    });
+    const org = OrganizationFixture();
     const spansWidget: Widget = {
       id: '3',
       title: 'Test Spans Widget',
@@ -558,7 +556,7 @@ describe('Dashboards > Dashboard', () => {
         // No interval in the URL — the 10m default (second-biggest of [5m, 10m, 30m])
         // is derived from the dashboard's saved 24h period via useDashboardChartInterval.
         const {router} = render(<DashboardWithIntervalSelector />, {
-          organization: orgWithFlag,
+          organization: org,
           initialRouterConfig: {location: {pathname: '/'}},
         });
 
@@ -600,7 +598,7 @@ describe('Dashboards > Dashboard', () => {
         });
 
         const {router} = render(<DashboardWithIntervalSelector />, {
-          organization: orgWithFlag,
+          organization: org,
           initialRouterConfig: {location: {pathname: '/', query: {interval: '30m'}}},
         });
 
@@ -647,7 +645,7 @@ describe('Dashboards > Dashboard', () => {
 
         // 5m is in the URL but is not a valid interval for a 30d window.
         render(<DashboardWithIntervalSelector dashboard={thirtyDayDashboard} />, {
-          organization: orgWithFlag,
+          organization: org,
           initialRouterConfig: {location: {pathname: '/', query: {interval: '5m'}}},
         });
 
@@ -696,7 +694,7 @@ describe('Dashboards > Dashboard', () => {
         });
 
         render(<DashboardWithIntervalSelector dashboard={thirtyDayReleaseDashboard} />, {
-          organization: orgWithFlag,
+          organization: org,
           initialRouterConfig: {location: {pathname: '/', query: {interval: '5m'}}},
         });
 

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -1547,9 +1547,7 @@ export function DashboardDetailWithInjectedProps(
   // Always use the validated chart interval so the UI dropdown and widget
   // requests stay in sync. chartInterval is validated against the current page
   // filter period (e.g. won't return 1m for a 30d range) and always has a value.
-  const widgetInterval = organization.features.includes('dashboards-interval-selection')
-    ? chartInterval
-    : undefined;
+  const widgetInterval = chartInterval;
 
   return (
     <DashboardDetail

--- a/static/app/views/dashboards/filtersBar.tsx
+++ b/static/app/views/dashboards/filtersBar.tsx
@@ -231,9 +231,6 @@ export function FiltersBar({
 
   const hasTemporaryFilters = activeGlobalFilters.some(filter => filter.isTemporary);
 
-  const hasIntervalSelection = organization.features.includes(
-    'dashboards-interval-selection'
-  );
   const [interval, setInterval, intervalOptions] = useDashboardChartInterval();
 
   return (
@@ -367,23 +364,21 @@ export function FiltersBar({
           )}
         <ToggleOnDemand />
       </FiltersRow>
-      {hasIntervalSelection && (
-        <CompactSelect
-          value={interval}
-          onChange={option => setInterval(option.value)}
-          trigger={triggerProps => (
-            <OverlayTrigger.Button
-              {...triggerProps}
-              icon={<IconClock />}
-              priority="transparent"
-              showChevron={false}
-              size="xs"
-            />
-          )}
-          menuTitle={t('Interval')}
-          options={intervalOptions}
-        />
-      )}
+      <CompactSelect
+        value={interval}
+        onChange={option => setInterval(option.value)}
+        trigger={triggerProps => (
+          <OverlayTrigger.Button
+            {...triggerProps}
+            icon={<IconClock />}
+            priority="transparent"
+            showChevron={false}
+            size="xs"
+          />
+        )}
+        menuTitle={t('Interval')}
+        options={intervalOptions}
+      />
     </Wrapper>
   );
 }

--- a/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetPreview.tsx
@@ -112,11 +112,7 @@ export function WidgetPreview({
       isEditingDashboard={false}
       widgetLimitReached={false}
       showContextMenu={false}
-      widgetInterval={
-        organization.features.includes('dashboards-interval-selection')
-          ? chartInterval
-          : undefined
-      }
+      widgetInterval={chartInterval}
       onLegendSelectChanged={() => {}}
       legendOptions={
         widgetLegendState.widgetRequiresLegendUnselection(widget)


### PR DESCRIPTION
Remove all frontend references to the \`dashboards-interval-selection\` feature flag now that the feature has been fully rolled out to GA.

The interval selector in the filters bar is now always rendered, and \`widgetInterval\` is always derived from \`chartInterval\` rather than conditionally set based on the flag. Test fixtures no longer need the feature flag enabled.

Part of a three-PR cleanup — split per Sentry's frontend/backend deployment requirement:
- Backend declaration removal: https://github.com/getsentry/sentry/pull/113290
- Flagpole config removal: https://github.com/getsentry/sentry-options-automator/pull/7339