### PR TITLE
fix(issues): Include group type id in AI-detected fingerprint

### DIFF
--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -203,7 +203,9 @@ def create_issue_occurrence_from_detection(
     transaction_name = normalize_description(detected_issue.transaction_name)
     group_for_fingerprint = detected_issue.group_for_fingerprint
 
-    fingerprint = [f"llm-detected-{group_for_fingerprint.strip().lower().replace(' ', '-')}"]
+    fingerprint = [
+        f"1-{group_type.type_id}-{group_for_fingerprint.strip().lower().replace(' ', '-')}"
+    ]
 
     evidence_data = {
         "trace_id": trace_id,

--- a/tests/sentry/tasks/test_llm_issue_detection.py
+++ b/tests/sentry/tasks/test_llm_issue_detection.py
@@ -110,7 +110,9 @@ class LLMIssueDetectionTest(TestCase):
         assert occurrence.culprit == "test_transaction"
         assert occurrence.level == "warning"
 
-        assert occurrence.fingerprint == ["llm-detected-slow-database-query"]
+        assert occurrence.fingerprint == [
+            f"1-{AIDetectedGeneralGroupType.type_id}-slow-database-query"
+        ]
 
         assert occurrence.evidence_data["trace_id"] == "abc123xyz"
         assert occurrence.evidence_data["transaction"] == "test_transaction"
@@ -160,7 +162,7 @@ class LLMIssueDetectionTest(TestCase):
             project=self.project,
         )
         occurrence = mock_produce_occurrence.call_args.kwargs["occurrence"]
-        assert occurrence.fingerprint == ["llm-detected-n+1-database-queries"]
+        assert occurrence.fingerprint == [f"1-{AIDetectedDBGroupType.type_id}-n+1-database-queries"]
         assert occurrence.type == AIDetectedDBGroupType
 
     @with_feature("organizations:gen-ai-features")


### PR DESCRIPTION
Matches the convention used by other performance group types (e.g. `1-{type_id}-{specifier}`) so fingerprints no longer collide between group types