### PR TITLE
chore(dashboards): Remove dashboards-interval-selection flag declaration (backend)

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -74,8 +74,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:dashboards-edit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True, default=True)
     # Enables import/export functionality for dashboards
     manager.add("organizations:dashboards-import", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable interval selection for dashboards
-    manager.add("organizations:dashboards-interval-selection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable metrics enhanced performance for AM2+ customers as they transition from AM2 to AM3
     manager.add("organizations:dashboards-metrics-transition", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable starred dashboards with reordering


### PR DESCRIPTION
Remove the \`dashboards-interval-selection\` feature flag registration from \`temporary.py\` now that the feature has been fully rolled out to GA.

Part of a three-PR cleanup — split per Sentry's frontend/backend deployment requirement:
- Frontend code cleanup: https://github.com/getsentry/sentry/pull/113288
- Flagpole config removal: https://github.com/getsentry/sentry-options-automator/pull/7339