### PR TITLE
fix(dashboards): Reject new widgets with deprecated display types

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -406,6 +406,16 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
         if data.get("display_type") == DashboardWidgetDisplayTypes.TEXT:
             return self._validate_text_widget(data)
 
+        if (
+            not data.get("id")
+            and data.get("display_type") in DashboardWidgetDisplayTypes.DEPRECATED_TYPES
+        ):
+            raise serializers.ValidationError(
+                {
+                    "displayType": f"{DashboardWidgetDisplayTypes.get_type_name(data['display_type'])} is no longer a supported display type."
+                }
+            )
+
         query_errors = []
         all_columns: set[str] = set()
         has_columns = False
@@ -549,7 +559,7 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
                 f"Dashboard Widget limit was not set. Suggested maximum limit is {limit}."
             )
             raise serializers.ValidationError(
-                {"limit": f"limit is required. The maximum limit is ${limit}."}
+                {"limit": f"limit is required. The maximum limit is {limit}."}
             )
         # Validate limit based on display type: categorical bar charts allow up to 25,
         # all other chart types allow up to 10.

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -412,7 +412,7 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
         ):
             raise serializers.ValidationError(
                 {
-                    "displayType": f"{DashboardWidgetDisplayTypes.get_type_name(data['display_type'])} is no longer a supported display type."
+                    "display_type": f"{DashboardWidgetDisplayTypes.get_type_name(data['display_type'])} is no longer a supported display type."
                 }
             )
 

--- a/src/sentry/models/dashboard_widget.py
+++ b/src/sentry/models/dashboard_widget.py
@@ -207,6 +207,13 @@ class DashboardWidgetDisplayTypes(TypesClass):
     ]
     TYPE_NAMES = [t[1] for t in TYPES]
 
+    # Display types that the frontend no longer exposes in either the widget
+    # builder dropdown or the widget library. TOP_N is converted to AREA at
+    # every UI entry point (widget library, builder URL deserialization). New
+    # widgets should not be created with these, but existing widgets remain
+    # editable.
+    DEPRECATED_TYPES: list[int] = [STACKED_AREA_CHART, TOP_N]
+
 
 @cell_silo_model
 class DashboardWidgetQuery(Model):

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -1721,6 +1721,45 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         widgets = self.get_widgets(self.dashboard.id)
         self.assert_serialized_widget(data["widgets"][0], widgets[0])
 
+    def test_update_widget_with_deprecated_display_type_is_allowed(self) -> None:
+        # Existing widgets created via the API with deprecated display types
+        # should remain editable; the rejection only applies to new widgets.
+        deprecated_widget = DashboardWidget.objects.create(
+            dashboard=self.dashboard,
+            order=4,
+            title="Stacked area",
+            display_type=DashboardWidgetDisplayTypes.STACKED_AREA_CHART,
+            widget_type=DashboardWidgetTypes.DISCOVER,
+            interval="1d",
+            limit=5,
+        )
+        DashboardWidgetQuery.objects.create(
+            widget=deprecated_widget,
+            name="Transactions",
+            fields=["count()"],
+            columns=[],
+            aggregates=["count()"],
+            conditions="event.type:transaction",
+            order=0,
+        )
+
+        data: dict[str, Any] = {
+            "title": "First dashboard",
+            "widgets": [
+                {"id": str(self.widget_1.id)},
+                {"id": str(self.widget_2.id)},
+                {"id": str(self.widget_3.id)},
+                {"id": str(self.widget_4.id)},
+                {"id": str(deprecated_widget.id), "title": "Renamed stacked area"},
+            ],
+        }
+        response = self.do_request("put", self.url(self.dashboard.id), data=data)
+        assert response.status_code == 200, response.data
+
+        deprecated_widget.refresh_from_db()
+        assert deprecated_widget.title == "Renamed stacked area"
+        assert deprecated_widget.display_type == DashboardWidgetDisplayTypes.STACKED_AREA_CHART
+
     def test_update_widget_add_query(self) -> None:
         data: dict[str, Any] = {
             "title": "First dashboard",

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
@@ -2496,3 +2496,33 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         assert not Dashboard.objects.filter(
             organization=self.organization, title="Invalid Dashboard"
         ).exists()
+
+    def test_post_with_deprecated_display_type_rejected(self) -> None:
+        data: dict[str, Any] = {
+            "title": "Dashboard with Deprecated Widget",
+            "widgets": [
+                {
+                    "displayType": "stacked_area",
+                    "interval": "5m",
+                    "title": "Stacked area",
+                    "queries": [
+                        {
+                            "name": "Transactions",
+                            "fields": ["count()"],
+                            "columns": [],
+                            "aggregates": ["count()"],
+                            "conditions": "event.type:transaction",
+                        }
+                    ],
+                },
+            ],
+        }
+        response = self.do_request("post", self.url, data=data)
+        assert response.status_code == 400, response.data
+        assert (
+            "stacked_area is no longer a supported display type."
+            in response.data["widgets"][0]["displayType"][0]
+        )
+        assert not Dashboard.objects.filter(
+            organization=self.organization, title="Dashboard with Deprecated Widget"
+        ).exists()


### PR DESCRIPTION
The widget builder dropdown and widget library no longer expose `stacked_area`, and `top_n` is converted to `area` at every UI entry point (`getTopNConvertedDefaultWidgets`, `deserializeDisplayType`, the typeSelector dropdown). The backend still accepts both via the dashboards POST and PUT endpoints, so an API-direct client can persist widgets the UI cannot subsequently render or edit.

This PR rejects new widgets (no `id`) whose `display_type` is in the new `DashboardWidgetDisplayTypes.DEPRECATED_TYPES` set. The check is gated on `not data.get("id")` so existing widgets persisted before this change remain editable through the dashboard PUT endpoint.

Today the deprecated set is `{STACKED_AREA_CHART, TOP_N}`. Other backend-only types not surfaced by the frontend builder (`WHEEL`, `RAGE_AND_DEAD_CLICKS`, `SERVER_TREE`, `AGENTS_TRACES_TABLE`) are excluded because they're still emitted by the prebuilt widget library configs.

Refs DAIN-1548