### PR TITLE
enh(code-mappings): Improve bulk code mappings validation error message for wrong mappings format 

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
@@ -141,7 +141,26 @@ class OrganizationCodeMappingsBulkEndpoint(OrganizationEndpoint):
     def post(self, request: Request, organization: Organization) -> Response:
         serializer = BulkCodeMappingsRequestSerializer(data=request.data)
         if not serializer.is_valid():
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+            errors = serializer.errors
+            mapping_errors = errors.get("mappings")
+            invalid_indices: list[int] = []
+            if isinstance(mapping_errors, list):
+                invalid_indices = [
+                    i
+                    for i, item_errors in enumerate(mapping_errors)
+                    if isinstance(item_errors, dict) and item_errors
+                ]
+            if invalid_indices:
+                detail = (
+                    "Some of the submitted mappings have an invalid format. "
+                    f"Check the mappings at the following indices: {invalid_indices}. "
+                    "See the 'mappings' field below for per-mapping validation errors."
+                )
+                return Response(
+                    {"detail": detail, **errors},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            return Response(errors, status=status.HTTP_400_BAD_REQUEST)
 
         data = serializer.validated_data
 

--- a/tests/sentry/integrations/api/endpoints/test_organization_code_mappings_bulk.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_code_mappings_bulk.py
@@ -207,6 +207,23 @@ class OrganizationCodeMappingsBulkTest(APITestCase):
         )
         assert response.status_code == 400
 
+    def test_invalid_mappings_detail_message(self) -> None:
+        response = self.make_post(
+            {
+                "mappings": [
+                    {"stackRoot": "valid/path", "sourceRoot": "also/valid"},
+                    {"stackRoot": "has space", "sourceRoot": "valid/path"},
+                    {"stackRoot": "valid/path", "sourceRoot": "has'quote"},
+                ],
+            }
+        )
+        assert response.status_code == 400
+        assert "invalid format" in response.data["detail"]
+        assert "[1, 2]" in response.data["detail"]
+        assert response.data["mappings"][0] == {}
+        assert "stackRoot" in response.data["mappings"][1]
+        assert "sourceRoot" in response.data["mappings"][2]
+
     def test_invalid_branch_name(self) -> None:
         response = self.make_post({"defaultBranch": "/leading-slash"})
         assert response.status_code == 400


### PR DESCRIPTION
Adds a top-level `detail` message to the 400 response from the bulk code mappings endpoint when one or more submitted mappings fail format validation. The message names the specific mapping indices that are invalid and points the caller at the per-field errors still available under the `mappings` key.

Previously the endpoint only returned the raw serializer errors, which made it harder to quickly identify which entries in a large batch needed to be fixed. The existing per-mapping error structure is preserved so clients that parse it continue to work unchanged.

Example response:
```json
{
  "detail": "Some of the submitted mappings have an invalid format. Check the mappings at the following indices: [0, 2]. See the 'mappings' field below for per-mapping validation errors.",
  "mappings": [
    {"stackRoot": ["Path may not contain spaces or quotations"]},
    {},
    {"sourceRoot": ["Path may not contain spaces or quotations"]}
  ]
}
```

Other validation failures (missing fields, empty list, >300 mappings, invalid default branch) are unchanged.