### PR TITLE
docs(agents): forbid customer info in PRs, commits, and code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,6 +241,10 @@ New features should be gated behind a feature flag.
 
 See https://develop.sentry.dev/feature-flags/ for full docs.
 
+## Customer Information
+
+**Never include customer information in pull requests, commits, or code.** This covers organization slugs, user emails, account names, internal IDs tied to specific customers, support ticket details, and any other data that identifies a Sentry customer. Use anonymized or synthetic examples (`org-slug`, `user@example.com`) in PR descriptions, commit messages, code comments, tests, and fixtures. If a real identifier is needed for debugging, keep it in internal tooling (Slack, tickets, private notes)—not in the public git history.
+
 ## Pull Requests
 
 Frontend (`static/`) and backend (`src/`, `tests/`) are **not atomically deployed**. A CI check enforces this.


### PR DESCRIPTION
## Summary

- Add a **Customer Information** section to `AGENTS.md` that explicitly forbids putting customer identifiers (org slugs, emails, account names, customer-tied internal IDs, support ticket details, etc.) in pull requests, commits, or code.
- Direct agents to anonymized or synthetic examples (`org-slug`, `user@example.com`) and route real identifiers to internal tooling (Slack, tickets, private notes) instead of the public git history.

## Test plan

- [ ] No code paths changed; doc-only update.
- [ ] Visually confirm the new section renders correctly on GitHub.


Agent transcript: https://claudescope.sentry.dev/share/1SON1KvpdUmJDecp2pt5JkjLvn-rWXLbwZ024McA44c