### PR TITLE
fix(dashboards): Disable generate dashboard button when dashboard limit is reached

### DIFF
--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -678,6 +678,10 @@ function ManageDashboards() {
                                           </Flex>
                                         ),
                                         onAction: () => onGenerateDashboard(),
+                                        disabled:
+                                          hasReachedDashboardLimit ||
+                                          isLoadingDashboardsLimit,
+                                        details: limitMessage,
                                       },
                                     ]}
                                     trigger={triggerProps => (
@@ -788,6 +792,10 @@ function ManageDashboards() {
                                           </Flex>
                                         ),
                                         onAction: () => onGenerateDashboard(),
+                                        disabled:
+                                          hasReachedDashboardLimit ||
+                                          isLoadingDashboardsLimit,
+                                        details: limitMessage,
                                       },
                                     ]}
                                     trigger={triggerProps => (


### PR DESCRIPTION
Fixes BROWSE-492

Disable generate dashboard button when dashboard limit exists and is reached