### PR TITLE
feat(pipeline): Route additional integrations through API pipeline modal

### DIFF
--- a/static/app/utils/integrations/useAddIntegration.tsx
+++ b/static/app/utils/integrations/useAddIntegration.tsx
@@ -41,9 +41,13 @@ export interface AddIntegrationParams {
 const UNCONDITIONAL_API_PIPELINE_PROVIDERS = [
   'aws_lambda',
   'bitbucket',
+  'discord',
   'github',
   'gitlab',
+  'opsgenie',
+  'pagerduty',
   'slack',
+  'vsts',
 ] as const satisfies ReadonlyArray<ProvidersByType['integration']>;
 
 type UnconditionalApiPipelineProvider =


### PR DESCRIPTION
Add discord, opsgenie, pagerduty, and vsts to the unconditional API
pipeline providers list in useAddIntegration. These integrations now have
frontend pipeline components and backend API pipeline support, so they
no longer need to fall back to the legacy popup-based setup flow.

Fixes [VDY-83](https://linear.app/getsentry/issue/VDY-83/discord-api-driven-integration-setup)
Fixes [VDY-84](https://linear.app/getsentry/issue/VDY-84/pagerduty-api-driven-integration-setup)
Fixes [VDY-89](https://linear.app/getsentry/issue/VDY-89/opsgenie-api-driven-integration-setup)
Fixes [VDY-43](https://linear.app/getsentry/issue/VDY-43/azure-devops-vsts-api-driven-integration-setup)