### PR TITLE
fix(slack): Use only first chart when unfurling multi-aggregate Explore URLs

### DIFF
--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -246,11 +246,10 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
     if metric_json:
         try:
             metric_parsed = json.loads(metric_json)
-            # Each aggregateField with yAxes is a separate chart in Explore,
-            # so take only the first one (along with its chartType).
             for agg_field in metric_parsed.get("aggregateFields", []):
                 if "groupBy" in agg_field and agg_field["groupBy"]:
                     group_bys.append(agg_field["groupBy"])
+                # yAxes and chartType are per-chart; take them from the first entry only.
                 if not y_axes and isinstance(agg_field.get("yAxes"), list):
                     y_axes.extend(agg_field["yAxes"])
                     if isinstance(agg_field.get("chartType"), int):
@@ -264,20 +263,19 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
         except (json.JSONDecodeError, TypeError, AttributeError):
             pass
 
-    # Each aggregateField with yAxes is a separate chart in Explore, so take
-    # only the first one (along with its chartType).
     visualize_fields = raw_query.getlist("visualize") or raw_query.getlist("aggregateField")
     for field_json in visualize_fields:
         try:
             parsed = json.loads(field_json)
-        except (json.JSONDecodeError, TypeError):
+            if "groupBy" in parsed and parsed["groupBy"]:
+                group_bys.append(parsed["groupBy"])
+            # yAxes and chartType are per-chart; take them from the first entry only.
+            if not y_axes and isinstance(parsed.get("yAxes"), list):
+                y_axes.extend(parsed["yAxes"])
+                if isinstance(parsed.get("chartType"), int):
+                    chart_type = parsed["chartType"]
+        except (json.JSONDecodeError, TypeError, AttributeError):
             continue
-        if "groupBy" in parsed and parsed["groupBy"]:
-            group_bys.append(parsed["groupBy"])
-        if not y_axes and isinstance(parsed.get("yAxes"), list):
-            y_axes.extend(parsed["yAxes"])
-            if isinstance(parsed.get("chartType"), int):
-                chart_type = parsed["chartType"]
 
     if not y_axes:
         y_axes = [_get_explore_dataset_defaults(explore_dataset)["y_axis"]]

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -247,12 +247,15 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
         try:
             metric_parsed = json.loads(metric_json)
             for agg_field in metric_parsed.get("aggregateFields", []):
-                if "yAxes" in agg_field and isinstance(agg_field["yAxes"], list):
-                    y_axes.extend(agg_field["yAxes"])
                 if "groupBy" in agg_field and agg_field["groupBy"]:
                     group_bys.append(agg_field["groupBy"])
-                if chart_type is None and isinstance(agg_field.get("chartType"), int):
-                    chart_type = agg_field["chartType"]
+                # Each aggregateField with yAxes is its own chart in Explore;
+                # unfurls only render one, so keep just the first entry's
+                # yAxes and chartType.
+                if not y_axes and isinstance(agg_field.get("yAxes"), list):
+                    y_axes.extend(agg_field["yAxes"])
+                    if isinstance(agg_field.get("chartType"), int):
+                        chart_type = agg_field["chartType"]
             for sort_by in metric_parsed.get("aggregateSortBys", []):
                 field = sort_by.get("field", "")
                 kind = sort_by.get("kind", "desc")
@@ -266,14 +269,16 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
     for field_json in visualize_fields:
         try:
             parsed = json.loads(field_json)
-            if "yAxes" in parsed and isinstance(parsed["yAxes"], list):
-                y_axes.extend(parsed["yAxes"])
-            if "groupBy" in parsed and parsed["groupBy"]:
-                group_bys.append(parsed["groupBy"])
-            if chart_type is None and isinstance(parsed.get("chartType"), int):
-                chart_type = parsed["chartType"]
         except (json.JSONDecodeError, TypeError):
             continue
+        if "groupBy" in parsed and parsed["groupBy"]:
+            group_bys.append(parsed["groupBy"])
+        # Each aggregateField with yAxes is its own chart in Explore; unfurls
+        # only render one, so keep just the first entry's yAxes and chartType.
+        if not y_axes and isinstance(parsed.get("yAxes"), list):
+            y_axes.extend(parsed["yAxes"])
+            if isinstance(parsed.get("chartType"), int):
+                chart_type = parsed["chartType"]
 
     if not y_axes:
         y_axes = [_get_explore_dataset_defaults(explore_dataset)["y_axis"]]

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -246,12 +246,11 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
     if metric_json:
         try:
             metric_parsed = json.loads(metric_json)
+            # Each aggregateField with yAxes is a separate chart in Explore,
+            # so take only the first one (along with its chartType).
             for agg_field in metric_parsed.get("aggregateFields", []):
                 if "groupBy" in agg_field and agg_field["groupBy"]:
                     group_bys.append(agg_field["groupBy"])
-                # Each aggregateField with yAxes is its own chart in Explore;
-                # unfurls only render one, so keep just the first entry's
-                # yAxes and chartType.
                 if not y_axes and isinstance(agg_field.get("yAxes"), list):
                     y_axes.extend(agg_field["yAxes"])
                     if isinstance(agg_field.get("chartType"), int):
@@ -265,6 +264,8 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
         except (json.JSONDecodeError, TypeError, AttributeError):
             pass
 
+    # Each aggregateField with yAxes is a separate chart in Explore, so take
+    # only the first one (along with its chartType).
     visualize_fields = raw_query.getlist("visualize") or raw_query.getlist("aggregateField")
     for field_json in visualize_fields:
         try:
@@ -273,8 +274,6 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
             continue
         if "groupBy" in parsed and parsed["groupBy"]:
             group_bys.append(parsed["groupBy"])
-        # Each aggregateField with yAxes is its own chart in Explore; unfurls
-        # only render one, so keep just the first entry's yAxes and chartType.
         if not y_axes and isinstance(parsed.get("yAxes"), list):
             y_axes.extend(parsed["yAxes"])
             if isinstance(parsed.get("chartType"), int):

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -1877,6 +1877,55 @@ class UnfurlTest(TestCase):
         "sentry.integrations.slack.unfurl.explore.client.get",
     )
     @patch("sentry.charts.backend.generate_chart", return_value="chart-url")
+    def test_unfurl_explore_multi_aggregate_uses_first_chart(
+        self, mock_generate_chart: MagicMock, mock_client_get: MagicMock
+    ) -> None:
+        mock_client_get.return_value = MagicMock(data=self._build_mock_timeseries_response())
+        # Three aggregateField entries: a groupBy, then two separate charts
+        # (avg is the first chart, count+area is the second). The unfurl must
+        # render only the first chart (avg(span.duration) with its default
+        # line style) and not inherit the second chart's area chartType.
+        url = (
+            f"https://sentry.io/organizations/{self.organization.slug}/explore/traces/"
+            "?aggregateField=%7B%22groupBy%22%3A%22%22%7D"
+            "&aggregateField=%7B%22yAxes%22%3A%5B%22avg(span.duration)%22%5D%7D"
+            "&aggregateField=%7B%22yAxes%22%3A%5B%22count(span.duration)%22%5D%2C%22chartType%22%3A2%7D"
+            f"&project={self.project.id}&statsPeriod=24h"
+        )
+        link_type, args = match_link(url)
+
+        if not args or not link_type:
+            raise AssertionError("Missing link_type/args")
+
+        assert args["chart_type"] is None
+        assert args["query"].getlist("yAxis") == ["avg(span.duration)"]
+
+        links = [
+            UnfurlableUrl(url=url, args=args),
+        ]
+
+        with self.feature(["organizations:data-browsing-widget-unfurl"]):
+            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+
+        assert len(unfurls) == 1
+        api_params = mock_client_get.call_args[1]["params"]
+        assert api_params.getlist("yAxis") == ["avg(span.duration)"]
+
+        chart_data = mock_generate_chart.call_args[0][1]
+        # avg defaults to line; second chart's chartType=2 (area) must not leak through
+        assert chart_data["type"] == "line"
+
+        assert (
+            unfurls[url]
+            == SlackDiscoverMessageBuilder(
+                title="Explore Traces - avg(span.duration)", chart_url="chart-url"
+            ).build()
+        )
+
+    @patch(
+        "sentry.integrations.slack.unfurl.explore.client.get",
+    )
+    @patch("sentry.charts.backend.generate_chart", return_value="chart-url")
     def test_unfurl_explore_with_interval(
         self, mock_generate_chart: MagicMock, mock_client_get: MagicMock
     ) -> None:

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -1874,21 +1874,22 @@ class UnfurlTest(TestCase):
         assert chart_data["type"] == "bar"
 
     def test_unfurl_explore_multi_aggregate_uses_first_chart(self) -> None:
-        # Two charts: avg (first, default line) and count with chartType=2
-        # (area). The later chart's chartType must not leak through.
+        # Two charts: count with chartType=2 (area, first) and avg (second).
+        # The unfurl must render only the first chart and not merge avg's
+        # yAxis into the request.
         url = (
             "https://sentry.io/organizations/org1/explore/traces/"
             "?aggregateField=%7B%22groupBy%22%3A%22%22%7D"
-            "&aggregateField=%7B%22yAxes%22%3A%5B%22avg(span.duration)%22%5D%7D"
             "&aggregateField=%7B%22yAxes%22%3A%5B%22count(span.duration)%22%5D%2C%22chartType%22%3A2%7D"
-            "&project=1&statsPeriod=24h"
+            "&aggregateField=%7B%22yAxes%22%3A%5B%22avg(span.duration)%22%5D%7D"
+            "&aggregateSort=-http.status_code&project=1&query=span.category:http&statsPeriod=24h"
         )
         link_type, args = match_link(url)
 
         assert link_type == LinkType.EXPLORE
         assert args is not None
-        assert args["chart_type"] is None
-        assert args["query"].getlist("yAxis") == ["avg(span.duration)"]
+        assert args["chart_type"] == 2
+        assert args["query"].getlist("yAxis") == ["count(span.duration)"]
 
     @patch(
         "sentry.integrations.slack.unfurl.explore.client.get",

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -1873,51 +1873,22 @@ class UnfurlTest(TestCase):
         chart_data = mock_generate_chart.call_args[0][1]
         assert chart_data["type"] == "bar"
 
-    @patch(
-        "sentry.integrations.slack.unfurl.explore.client.get",
-    )
-    @patch("sentry.charts.backend.generate_chart", return_value="chart-url")
-    def test_unfurl_explore_multi_aggregate_uses_first_chart(
-        self, mock_generate_chart: MagicMock, mock_client_get: MagicMock
-    ) -> None:
-        mock_client_get.return_value = MagicMock(data=self._build_mock_timeseries_response())
+    def test_unfurl_explore_multi_aggregate_uses_first_chart(self) -> None:
         # Two charts: avg (first, default line) and count with chartType=2
         # (area). The later chart's chartType must not leak through.
         url = (
-            f"https://sentry.io/organizations/{self.organization.slug}/explore/traces/"
+            "https://sentry.io/organizations/org1/explore/traces/"
             "?aggregateField=%7B%22groupBy%22%3A%22%22%7D"
             "&aggregateField=%7B%22yAxes%22%3A%5B%22avg(span.duration)%22%5D%7D"
             "&aggregateField=%7B%22yAxes%22%3A%5B%22count(span.duration)%22%5D%2C%22chartType%22%3A2%7D"
-            f"&project={self.project.id}&statsPeriod=24h"
+            "&project=1&statsPeriod=24h"
         )
         link_type, args = match_link(url)
 
-        if not args or not link_type:
-            raise AssertionError("Missing link_type/args")
-
+        assert link_type == LinkType.EXPLORE
+        assert args is not None
         assert args["chart_type"] is None
         assert args["query"].getlist("yAxis") == ["avg(span.duration)"]
-
-        links = [
-            UnfurlableUrl(url=url, args=args),
-        ]
-
-        with self.feature(["organizations:data-browsing-widget-unfurl"]):
-            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
-
-        assert len(unfurls) == 1
-        api_params = mock_client_get.call_args[1]["params"]
-        assert api_params.getlist("yAxis") == ["avg(span.duration)"]
-
-        chart_data = mock_generate_chart.call_args[0][1]
-        assert chart_data["type"] == "line"
-
-        assert (
-            unfurls[url]
-            == SlackDiscoverMessageBuilder(
-                title="Explore Traces - avg(span.duration)", chart_url="chart-url"
-            ).build()
-        )
 
     @patch(
         "sentry.integrations.slack.unfurl.explore.client.get",

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -1881,10 +1881,8 @@ class UnfurlTest(TestCase):
         self, mock_generate_chart: MagicMock, mock_client_get: MagicMock
     ) -> None:
         mock_client_get.return_value = MagicMock(data=self._build_mock_timeseries_response())
-        # Three aggregateField entries: a groupBy, then two separate charts
-        # (avg is the first chart, count+area is the second). The unfurl must
-        # render only the first chart (avg(span.duration) with its default
-        # line style) and not inherit the second chart's area chartType.
+        # Two charts: avg (first, default line) and count with chartType=2
+        # (area). The later chart's chartType must not leak through.
         url = (
             f"https://sentry.io/organizations/{self.organization.slug}/explore/traces/"
             "?aggregateField=%7B%22groupBy%22%3A%22%22%7D"
@@ -1912,7 +1910,6 @@ class UnfurlTest(TestCase):
         assert api_params.getlist("yAxis") == ["avg(span.duration)"]
 
         chart_data = mock_generate_chart.call_args[0][1]
-        # avg defaults to line; second chart's chartType=2 (area) must not leak through
         assert chart_data["type"] == "line"
 
         assert (

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -1873,6 +1873,20 @@ class UnfurlTest(TestCase):
         chart_data = mock_generate_chart.call_args[0][1]
         assert chart_data["type"] == "bar"
 
+    def test_unfurl_explore_non_dict_aggregate_field(self) -> None:
+        # aggregateField that parses to a non-dict (int, list, string, null)
+        # must not crash the arg mapper; it should fall back to defaults.
+        url = (
+            "https://sentry.io/organizations/org1/explore/traces/"
+            "?aggregateField=42&aggregateField=%5B%5D&aggregateField=null"
+            "&project=1&statsPeriod=24h"
+        )
+        link_type, args = match_link(url)
+
+        assert link_type == LinkType.EXPLORE
+        assert args is not None
+        assert args["query"].getlist("yAxis") == ["count(span.duration)"]
+
     def test_unfurl_explore_multi_aggregate_uses_first_chart(self) -> None:
         # Two charts: count with chartType=2 (area, first) and avg (second).
         # The unfurl must render only the first chart and not merge avg's


### PR DESCRIPTION
Url unfurls currently only supports one chart, this fixes a bug when multiple charts are present, we display the last chart instead of the first.

Ai comment
Explore URLs can contain multiple `aggregateField` entries, each of which maps to a separate chart in the Explore UI (per `Visualize.fromJSON` in `static/app/views/explore/contexts/pageParamsContext/visualizes.tsx`). The Slack unfurl was merging every `yAxes` entry into one `events-timeseries` request and inheriting a `chartType` from any later entry that defined one, so the rendered chart mixed series from all charts and could adopt the second chart's style (e.g. area) instead of the first chart's default.

Example URL from the issue — three `aggregateField` entries (empty groupBy, `avg(span.duration)`, then `count(span.duration)` with `chartType: 2`): the unfurl was sending both yAxes to the API and rendering as area, when it should show just the first chart (`avg(span.duration)` as a line).

Take `yAxes` and `chartType` from only the first `aggregateField` that has `yAxes` so the unfurl matches the top-most chart on the Explore page. Group-bys still accumulate since they apply to the shared query rather than to a specific chart. Applied the same change to the metric JSON's nested `aggregateFields`.

Fixes DAIN-1551