### PR TITLE
fix(integrations): Read dataset-specific query params in explore unfurls

### DIFF
--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -39,31 +39,39 @@ TOP_N = 5
 EXPLORE_CHART_SIZE: ChartSize = {"width": 1200, "height": 400}
 
 
-class ExploreDatasetDefaults(TypedDict):
-    title: str
-    y_axis: str
+class ExploreDatasetConfig(TypedDict):
+    title_prefix: str
+    default_y_axis: str
+    query_key: str
+    sort_key: str
 
 
-EXPLORE_DATASET_DEFAULTS: dict[SupportedTraceItemType, ExploreDatasetDefaults] = {
+EXPLORE_DATASET_CONFIGS: dict[SupportedTraceItemType, ExploreDatasetConfig] = {
     SupportedTraceItemType.SPANS: {
-        "title": "Explore Traces",
-        "y_axis": "count(span.duration)",
+        "title_prefix": "Explore Traces",
+        "default_y_axis": "count(span.duration)",
+        "query_key": "query",
+        "sort_key": "aggregateSort",
     },
     SupportedTraceItemType.LOGS: {
-        "title": "Explore Logs",
-        "y_axis": "count(message)",
+        "title_prefix": "Explore Logs",
+        "default_y_axis": "count(message)",
+        "query_key": "logsQuery",
+        "sort_key": "logsAggregateSortBys",
     },
     SupportedTraceItemType.TRACEMETRICS: {
-        "title": "Explore Metrics",
-        "y_axis": "sum(value)",
+        "title_prefix": "Explore Metrics",
+        "default_y_axis": "sum(value)",
+        "query_key": "query",
+        "sort_key": "aggregateSort",
     },
 }
 
 
-def _get_explore_dataset_defaults(dataset: SupportedTraceItemType) -> ExploreDatasetDefaults:
-    """Returns the default title and y_axis for the given explore dataset."""
-    return EXPLORE_DATASET_DEFAULTS.get(
-        dataset, EXPLORE_DATASET_DEFAULTS[SupportedTraceItemType.SPANS]
+def _get_explore_dataset_config(dataset: SupportedTraceItemType) -> ExploreDatasetConfig:
+    """Returns the config for the given explore dataset."""
+    return EXPLORE_DATASET_CONFIGS.get(
+        dataset, EXPLORE_DATASET_CONFIGS[SupportedTraceItemType.SPANS]
     )
 
 
@@ -125,11 +133,11 @@ def _unfurl_explore(
         chart_type = link.args.get("chart_type")
 
         explore_dataset = link.args.get("dataset", SupportedTraceItemType.SPANS)
-        defaults = _get_explore_dataset_defaults(explore_dataset)
+        dataset_config = _get_explore_dataset_config(explore_dataset)
 
         y_axes = params.getlist("yAxis")
         if not y_axes:
-            y_axes = [defaults["y_axis"]]
+            y_axes = [dataset_config["default_y_axis"]]
             params.setlist("yAxis", y_axes)
 
         group_bys = params.getlist("groupBy")
@@ -171,7 +179,7 @@ def _unfurl_explore(
             continue
 
         # Only one chart/y-axis is supported at a time in Explore
-        title = f"{defaults['title']} - {y_axes[0]}"
+        title = f"{dataset_config['title_prefix']} - {y_axes[0]}"
         unfurls[link.url] = SlackDiscoverMessageBuilder(
             title=title,
             chart_url=url,
@@ -230,6 +238,7 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
     raw_query = QueryDict(parsed_url.query)
 
     explore_dataset = _get_explore_dataset(url)
+    dataset_config = _get_explore_dataset_config(explore_dataset)
 
     # Parse visualization params from the URL.
     # Each metric uses a "metric" JSON param with nested aggregateFields.
@@ -276,7 +285,7 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
             continue
 
     if not y_axes:
-        y_axes = [_get_explore_dataset_defaults(explore_dataset)["y_axis"]]
+        y_axes = [dataset_config["default_y_axis"]]
 
     # Build query params
     query = QueryDict(mutable=True)
@@ -293,15 +302,11 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
 
     # Each dataset stores query/sort under different URL param keys.
     # Map the dataset-specific key to the API's standard "query"/"sort" params.
-    dataset_query_key = "logsQuery" if explore_dataset == SupportedTraceItemType.LOGS else "query"
-    query_values = raw_query.getlist(dataset_query_key)
+    query_values = raw_query.getlist(dataset_config["query_key"])
     if query_values:
         query.setlist("query", query_values)
 
-    dataset_sort_key = (
-        "logsSortBys" if explore_dataset == SupportedTraceItemType.LOGS else "aggregateSort"
-    )
-    sort_values = raw_query.getlist(dataset_sort_key)
+    sort_values = raw_query.getlist(dataset_config["sort_key"])
     if sort_values:
         query.setlist("sort", sort_values)
 

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -285,17 +285,25 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
     if group_bys:
         query.setlist("groupBy", group_bys)
 
-    # Copy standard params
-    for param in ("project", "statsPeriod", "start", "end", "query", "environment", "interval"):
+    # Copy standard params (query and sort are handled separately per dataset)
+    for param in ("project", "statsPeriod", "start", "end", "environment", "interval"):
         values = raw_query.getlist(param)
         if values:
             query.setlist(param, values)
 
-    # Explore stores the aggregate sort as "aggregateSort" in the URL;
-    # the events-timeseries endpoint expects it as "sort".
-    aggregate_sort = raw_query.getlist("aggregateSort")
-    if aggregate_sort:
-        query.setlist("sort", aggregate_sort)
+    # Each dataset stores query/sort under different URL param keys.
+    # Map the dataset-specific key to the API's standard "query"/"sort" params.
+    dataset_query_key = "logsQuery" if explore_dataset == SupportedTraceItemType.LOGS else "query"
+    query_values = raw_query.getlist(dataset_query_key)
+    if query_values:
+        query.setlist("query", query_values)
+
+    dataset_sort_key = (
+        "logsSortBys" if explore_dataset == SupportedTraceItemType.LOGS else "aggregateSort"
+    )
+    sort_values = raw_query.getlist(dataset_sort_key)
+    if sort_values:
+        query.setlist("sort", sort_values)
 
     # Metrics stores query and sort inside the metric JSON param
     if metric_query:

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -57,7 +57,7 @@ EXPLORE_DATASET_CONFIGS: dict[SupportedTraceItemType, ExploreDatasetConfig] = {
         "title_prefix": "Explore Logs",
         "default_y_axis": "count(message)",
         "query_key": "logsQuery",
-        "sort_key": "logsAggregateSortBys",
+        "sort_key": "logsSortBys",
     },
     SupportedTraceItemType.TRACEMETRICS: {
         "title_prefix": "Explore Metrics",

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -13,7 +13,6 @@ from sentry.integrations.services.integration.serial import serialize_integratio
 from sentry.integrations.slack.message_builder.discover import SlackDiscoverMessageBuilder
 from sentry.integrations.slack.message_builder.issues import SlackIssuesMessageBuilder
 from sentry.integrations.slack.message_builder.metric_alerts import SlackMetricAlertMessageBuilder
-from sentry.integrations.slack.unfurl.explore import map_explore_query_args
 from sentry.integrations.slack.unfurl.handlers import link_handlers, match_link
 from sentry.integrations.slack.unfurl.types import LinkType, UnfurlableUrl
 from sentry.search.eap.types import SupportedTraceItemType
@@ -1942,22 +1941,22 @@ class UnfurlTest(TestCase):
 
     def test_map_explore_query_args_logs_query_and_sort(self) -> None:
         url = f"https://sentry.io/organizations/{self.organization.slug}/explore/logs/?aggregateField=%7B%22yAxes%22%3A%5B%22count(message)%22%5D%7D&logsQuery=severity%3Aerror&logsAggregateSortBys=-timestamp&project={self.project.id}&statsPeriod=24h"
-        args = map_explore_query_args(url, {"org_slug": self.organization.slug})
-        query = args["query"]
+        link_type, args = match_link(url)
 
+        assert link_type == LinkType.EXPLORE
         assert args["dataset"] == SupportedTraceItemType.LOGS
-        assert query["query"] == "severity:error"
-        assert query["sort"] == "-timestamp"
-        assert query["yAxis"] == "count(message)"
+        assert args["query"]["query"] == "severity:error"
+        assert args["query"]["sort"] == "-timestamp"
+        assert args["query"]["yAxis"] == "count(message)"
 
     def test_map_explore_query_args_spans_query_and_sort(self) -> None:
         url = f"https://sentry.io/organizations/{self.organization.slug}/explore/traces/?visualize=%7B%22yAxes%22%3A%5B%22count(span.duration)%22%5D%7D&query=span.op%3Ahttp&aggregateSort=-count(span.duration)&project={self.project.id}&statsPeriod=24h"
-        args = map_explore_query_args(url, {"org_slug": self.organization.slug})
-        query = args["query"]
+        link_type, args = match_link(url)
 
+        assert link_type == LinkType.EXPLORE
         assert args["dataset"] == SupportedTraceItemType.SPANS
-        assert query["query"] == "span.op:http"
-        assert query["sort"] == "-count(span.duration)"
+        assert args["query"]["query"] == "span.op:http"
+        assert args["query"]["sort"] == "-count(span.duration)"
 
     @patch(
         "sentry.integrations.slack.unfurl.explore.client.get",

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -13,6 +13,7 @@ from sentry.integrations.services.integration.serial import serialize_integratio
 from sentry.integrations.slack.message_builder.discover import SlackDiscoverMessageBuilder
 from sentry.integrations.slack.message_builder.issues import SlackIssuesMessageBuilder
 from sentry.integrations.slack.message_builder.metric_alerts import SlackMetricAlertMessageBuilder
+from sentry.integrations.slack.unfurl.explore import map_explore_query_args
 from sentry.integrations.slack.unfurl.handlers import link_handlers, match_link
 from sentry.integrations.slack.unfurl.types import LinkType, UnfurlableUrl
 from sentry.search.eap.types import SupportedTraceItemType
@@ -1939,36 +1940,24 @@ class UnfurlTest(TestCase):
         assert api_params["dataset"] == "logs"
         assert api_params["yAxis"] == "sum(payload_size)"
 
-    @patch(
-        "sentry.integrations.slack.unfurl.explore.client.get",
-    )
-    @patch("sentry.charts.backend.generate_chart", return_value="chart-url")
-    def test_unfurl_explore_logs_with_query(
-        self, mock_generate_chart: MagicMock, mock_client_get: MagicMock
-    ) -> None:
-        mock_client_get.return_value = MagicMock(data=self._build_mock_timeseries_response())
+    def test_map_explore_query_args_logs_query_and_sort(self) -> None:
         url = f"https://sentry.io/organizations/{self.organization.slug}/explore/logs/?aggregateField=%7B%22yAxes%22%3A%5B%22count(message)%22%5D%7D&logsQuery=severity%3Aerror&logsAggregateSortBys=-timestamp&project={self.project.id}&statsPeriod=24h"
-        link_type, args = match_link(url)
+        args = map_explore_query_args(url, {"org_slug": self.organization.slug})
+        query = args["query"]
 
-        if not args or not link_type:
-            raise AssertionError("Missing link_type/args")
+        assert args["dataset"] == SupportedTraceItemType.LOGS
+        assert query["query"] == "severity:error"
+        assert query["sort"] == "-timestamp"
+        assert query["yAxis"] == "count(message)"
 
-        assert link_type == LinkType.EXPLORE
-        assert args["dataset"] == "logs"
+    def test_map_explore_query_args_spans_query_and_sort(self) -> None:
+        url = f"https://sentry.io/organizations/{self.organization.slug}/explore/traces/?visualize=%7B%22yAxes%22%3A%5B%22count(span.duration)%22%5D%7D&query=span.op%3Ahttp&aggregateSort=-count(span.duration)&project={self.project.id}&statsPeriod=24h"
+        args = map_explore_query_args(url, {"org_slug": self.organization.slug})
+        query = args["query"]
 
-        links = [
-            UnfurlableUrl(url=url, args=args),
-        ]
-
-        with self.feature(["organizations:data-browsing-widget-unfurl"]):
-            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
-
-        assert len(unfurls) == 1
-        call_kwargs = mock_client_get.call_args[1]
-        api_params = call_kwargs["params"]
-        assert api_params["dataset"] == "logs"
-        assert api_params["query"] == "severity:error"
-        assert api_params["sort"] == "-timestamp"
+        assert args["dataset"] == SupportedTraceItemType.SPANS
+        assert query["query"] == "span.op:http"
+        assert query["sort"] == "-count(span.duration)"
 
     @patch(
         "sentry.integrations.slack.unfurl.explore.client.get",

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -1943,6 +1943,37 @@ class UnfurlTest(TestCase):
         "sentry.integrations.slack.unfurl.explore.client.get",
     )
     @patch("sentry.charts.backend.generate_chart", return_value="chart-url")
+    def test_unfurl_explore_logs_with_query(
+        self, mock_generate_chart: MagicMock, mock_client_get: MagicMock
+    ) -> None:
+        mock_client_get.return_value = MagicMock(data=self._build_mock_timeseries_response())
+        url = f"https://sentry.io/organizations/{self.organization.slug}/explore/logs/?aggregateField=%7B%22yAxes%22%3A%5B%22count(message)%22%5D%7D&logsQuery=severity%3Aerror&logsSortBys=-timestamp&project={self.project.id}&statsPeriod=24h"
+        link_type, args = match_link(url)
+
+        if not args or not link_type:
+            raise AssertionError("Missing link_type/args")
+
+        assert link_type == LinkType.EXPLORE
+        assert args["dataset"] == "logs"
+
+        links = [
+            UnfurlableUrl(url=url, args=args),
+        ]
+
+        with self.feature(["organizations:data-browsing-widget-unfurl"]):
+            unfurls = link_handlers[link_type].fn(self.integration, links, self.user)
+
+        assert len(unfurls) == 1
+        call_kwargs = mock_client_get.call_args[1]
+        api_params = call_kwargs["params"]
+        assert api_params["dataset"] == "logs"
+        assert api_params["query"] == "severity:error"
+        assert api_params["sort"] == "-timestamp"
+
+    @patch(
+        "sentry.integrations.slack.unfurl.explore.client.get",
+    )
+    @patch("sentry.charts.backend.generate_chart", return_value="chart-url")
     def test_unfurl_explore_logs_customer_domain(
         self, mock_generate_chart: MagicMock, mock_client_get: MagicMock
     ) -> None:

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -1940,7 +1940,7 @@ class UnfurlTest(TestCase):
         assert api_params["yAxis"] == "sum(payload_size)"
 
     def test_map_explore_query_args_logs_query_and_sort(self) -> None:
-        url = f"https://sentry.io/organizations/{self.organization.slug}/explore/logs/?aggregateField=%7B%22yAxes%22%3A%5B%22count(message)%22%5D%7D&logsQuery=severity%3Aerror&logsAggregateSortBys=-timestamp&project={self.project.id}&statsPeriod=24h"
+        url = f"https://sentry.io/organizations/{self.organization.slug}/explore/logs/?aggregateField=%7B%22yAxes%22%3A%5B%22count(message)%22%5D%7D&logsQuery=severity%3Aerror&logsSortBys=-timestamp&project={self.project.id}&statsPeriod=24h"
         link_type, args = match_link(url)
 
         assert link_type == LinkType.EXPLORE

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -1947,7 +1947,7 @@ class UnfurlTest(TestCase):
         self, mock_generate_chart: MagicMock, mock_client_get: MagicMock
     ) -> None:
         mock_client_get.return_value = MagicMock(data=self._build_mock_timeseries_response())
-        url = f"https://sentry.io/organizations/{self.organization.slug}/explore/logs/?aggregateField=%7B%22yAxes%22%3A%5B%22count(message)%22%5D%7D&logsQuery=severity%3Aerror&logsSortBys=-timestamp&project={self.project.id}&statsPeriod=24h"
+        url = f"https://sentry.io/organizations/{self.organization.slug}/explore/logs/?aggregateField=%7B%22yAxes%22%3A%5B%22count(message)%22%5D%7D&logsQuery=severity%3Aerror&logsAggregateSortBys=-timestamp&project={self.project.id}&statsPeriod=24h"
         link_type, args = match_link(url)
 
         if not args or not link_type:

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -1943,6 +1943,9 @@ class UnfurlTest(TestCase):
         url = f"https://sentry.io/organizations/{self.organization.slug}/explore/logs/?aggregateField=%7B%22yAxes%22%3A%5B%22count(message)%22%5D%7D&logsQuery=severity%3Aerror&logsSortBys=-timestamp&project={self.project.id}&statsPeriod=24h"
         link_type, args = match_link(url)
 
+        if not args or not link_type:
+            raise AssertionError("Missing link_type/args")
+
         assert link_type == LinkType.EXPLORE
         assert args["dataset"] == SupportedTraceItemType.LOGS
         assert args["query"]["query"] == "severity:error"
@@ -1952,6 +1955,9 @@ class UnfurlTest(TestCase):
     def test_map_explore_query_args_spans_query_and_sort(self) -> None:
         url = f"https://sentry.io/organizations/{self.organization.slug}/explore/traces/?visualize=%7B%22yAxes%22%3A%5B%22count(span.duration)%22%5D%7D&query=span.op%3Ahttp&aggregateSort=-count(span.duration)&project={self.project.id}&statsPeriod=24h"
         link_type, args = match_link(url)
+
+        if not args or not link_type:
+            raise AssertionError("Missing link_type/args")
 
         assert link_type == LinkType.EXPLORE
         assert args["dataset"] == SupportedTraceItemType.SPANS


### PR DESCRIPTION
Logs URLs use `logsQuery` and `logsAggregateSortBys` for their query and sort
parameters, but the Slack unfurl code only read the generic `query` and
`aggregateSort` keys. This meant logs unfurls never included the user's
search filters.

Consolidates the per-dataset defaults (`ExploreDatasetDefaults`) into a
single `ExploreDatasetConfig` that also carries `query_key` and `sort_key`,
so the param mapping is data-driven instead of inline conditionals. Spans
and metrics are unaffected — spans already used `query`/`aggregateSort`,
and metrics extract both from the `metric` JSON param.

Fixes DAIN-1553