### PR TITLE
feat(pipeline): Optimistically render first step during initialization

### DIFF
--- a/static/app/components/pipeline/pipelineDummyProvider.tsx
+++ b/static/app/components/pipeline/pipelineDummyProvider.tsx
@@ -23,7 +23,7 @@ function DummyStepOne({
 
   return (
     <Stack gap="md">
-      <Text>{stepData.message ?? t('Enter your name to continue')}</Text>
+      <Text>{stepData?.message ?? t('Enter your name to continue')}</Text>
       <InputGroup>
         <InputGroup.Input
           aria-label={t('Your name')}
@@ -50,7 +50,7 @@ function DummyStepTwo({
 }: PipelineStepProps<{greeting: string}>) {
   return (
     <Stack gap="md">
-      <Text>{stepData.greeting ?? t('Dummy step two')}</Text>
+      <Text>{stepData?.greeting ?? t('Dummy step two')}</Text>
       <Button
         size="sm"
         priority="primary"

--- a/static/app/components/pipeline/pipelineIntegrationAwsLambda.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationAwsLambda.spec.tsx
@@ -57,6 +57,16 @@ describe('ProjectSelectStep', () => {
 
     expect(screen.getByRole('button', {name: 'Submitting...'})).toBeDisabled();
   });
+
+  it('disables submit button when isInitializing', () => {
+    ProjectsStore.loadInitialData([ProjectFixture()]);
+
+    render(
+      <ProjectSelectStep {...makeStepProps({stepData: null, isInitializing: true})} />
+    );
+
+    expect(screen.getByRole('button', {name: 'Continue'})).toBeDisabled();
+  });
 });
 
 describe('CloudFormationStep', () => {

--- a/static/app/components/pipeline/pipelineIntegrationAwsLambda.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationAwsLambda.tsx
@@ -37,6 +37,7 @@ function ProjectSelectStep({
   advance,
   advanceError,
   isAdvancing,
+  isInitializing,
 }: PipelineStepProps<Record<string, never>, ProjectSelectAdvanceData>) {
   const {projects} = useProjects();
   const sortedProjects = useMemo(
@@ -100,7 +101,7 @@ function ProjectSelectStep({
           {t('Currently only supports Node and Python Lambda functions.')}
         </Text>
         <Flex>
-          <form.SubmitButton disabled={isAdvancing}>
+          <form.SubmitButton disabled={isAdvancing || isInitializing}>
             {isAdvancing ? t('Submitting...') : t('Continue')}
           </form.SubmitButton>
         </Flex>
@@ -155,23 +156,6 @@ function CloudFormationStep({
   const [showExternalId, setShowExternalId] = useState(false);
   const [defaultExternalId] = useState<string>(() => crypto.randomUUID());
 
-  const cloudFormationParams = new URLSearchParams({
-    templateURL: stepData.templateUrl,
-    stackName: stepData.stackName,
-    param_ExternalId: defaultExternalId,
-  });
-  const cloudFormationUrl = `${stepData.baseCloudformationUrl}?${cloudFormationParams}`;
-
-  const regionOptions = stepData.regionList.map(r => ({value: r, label: r}));
-
-  const trackCloudFormationClick = () => {
-    trackIntegrationAnalytics('integrations.cloudformation_link_clicked', {
-      integration: 'aws_lambda',
-      integration_type: 'first_party',
-      organization,
-    });
-  };
-
   const form = useScrapsForm({
     ...defaultFormOptions,
     defaultValues: {
@@ -188,6 +172,27 @@ function CloudFormationStep({
       setFieldErrors(form, advanceError);
     }
   }, [advanceError, form]);
+
+  if (stepData === null) {
+    return null;
+  }
+
+  const cloudFormationParams = new URLSearchParams({
+    templateURL: stepData.templateUrl,
+    stackName: stepData.stackName,
+    param_ExternalId: defaultExternalId,
+  });
+  const cloudFormationUrl = `${stepData.baseCloudformationUrl}?${cloudFormationParams}`;
+
+  const regionOptions = stepData.regionList.map(r => ({value: r, label: r}));
+
+  const trackCloudFormationClick = () => {
+    trackIntegrationAnalytics('integrations.cloudformation_link_clicked', {
+      integration: 'aws_lambda',
+      integration_type: 'first_party',
+      organization,
+    });
+  };
 
   return (
     <form.AppForm form={form}>
@@ -324,14 +329,18 @@ function InstrumentationStep({
   advance,
   isAdvancing,
 }: PipelineStepProps<InstrumentationStepData, InstrumentationAdvanceData>) {
-  const functions = stepData.functions;
-  const failures = stepData.failures;
+  const functions = stepData?.functions ?? [];
+  const failures = stepData?.failures;
 
   const failedNames = useMemo(() => new Set(failures?.map(f => f.name)), [failures]);
 
   const [enabled, setEnabled] = useState<Record<string, boolean>>(() =>
     Object.fromEntries(functions.map(fn => [fn.name, true]))
   );
+
+  if (stepData === null) {
+    return null;
+  }
 
   const enabledCount = Object.values(enabled).filter(Boolean).length;
   const allEnabled = enabledCount === functions.length;

--- a/static/app/components/pipeline/pipelineIntegrationBitbucket.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationBitbucket.spec.tsx
@@ -103,6 +103,16 @@ describe('BitbucketAuthorizeStep', () => {
     expect(screen.getByRole('button', {name: 'Authorize Bitbucket'})).toBeDisabled();
   });
 
+  it('disables authorize button when isInitializing', () => {
+    render(
+      <BitbucketAuthorizeStep
+        {...makeStepProps({stepData: null, isInitializing: true})}
+      />
+    );
+
+    expect(screen.getByRole('button', {name: 'Authorize Bitbucket'})).toBeDisabled();
+  });
+
   it('shows popup blocked notice when popup fails to open', async () => {
     jest.spyOn(window, 'open').mockReturnValue(null);
     render(

--- a/static/app/components/pipeline/pipelineIntegrationBitbucket.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationBitbucket.tsx
@@ -34,7 +34,7 @@ function BitbucketAuthorizeStep({
   );
 
   const {openPopup, isWaitingForCallback, popupStatus} = useRedirectPopupStep({
-    redirectUrl: stepData.authorizeUrl,
+    redirectUrl: stepData?.authorizeUrl,
     onCallback: handleCallback,
   });
 
@@ -72,7 +72,7 @@ function BitbucketAuthorizeStep({
           size="sm"
           priority="primary"
           onClick={openPopup}
-          disabled={!stepData.authorizeUrl}
+          disabled={!stepData?.authorizeUrl}
         >
           {t('Authorize Bitbucket')}
         </Button>

--- a/static/app/components/pipeline/pipelineIntegrationClaudeCode.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationClaudeCode.spec.tsx
@@ -34,4 +34,12 @@ describe('ClaudeCodeApiKeyStep', () => {
 
     expect(screen.getByRole('button', {name: 'Submitting...'})).toBeDisabled();
   });
+
+  it('disables submit button when isInitializing', () => {
+    render(
+      <ClaudeCodeApiKeyStep {...makeStepProps({stepData: null, isInitializing: true})} />
+    );
+
+    expect(screen.getByRole('button', {name: 'Continue'})).toBeDisabled();
+  });
 });

--- a/static/app/components/pipeline/pipelineIntegrationClaudeCode.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationClaudeCode.tsx
@@ -19,6 +19,7 @@ function ClaudeCodeApiKeyStep({
   advance,
   advanceError,
   isAdvancing,
+  isInitializing,
 }: PipelineStepProps<Record<string, never>, {apiKey: string}>) {
   const form = useScrapsForm({
     ...defaultFormOptions,
@@ -54,7 +55,7 @@ function ClaudeCodeApiKeyStep({
           )}
         </form.AppField>
         <Flex>
-          <form.SubmitButton disabled={isAdvancing}>
+          <form.SubmitButton disabled={isAdvancing || isInitializing}>
             {isAdvancing ? t('Submitting...') : t('Continue')}
           </form.SubmitButton>
         </Flex>

--- a/static/app/components/pipeline/pipelineIntegrationCursor.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationCursor.spec.tsx
@@ -32,4 +32,12 @@ describe('CursorApiKeyStep', () => {
 
     expect(screen.getByRole('button', {name: 'Submitting...'})).toBeDisabled();
   });
+
+  it('disables submit button when isInitializing', () => {
+    render(
+      <CursorApiKeyStep {...makeStepProps({stepData: null, isInitializing: true})} />
+    );
+
+    expect(screen.getByRole('button', {name: 'Continue'})).toBeDisabled();
+  });
 });

--- a/static/app/components/pipeline/pipelineIntegrationCursor.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationCursor.tsx
@@ -19,6 +19,7 @@ function CursorApiKeyStep({
   advance,
   advanceError,
   isAdvancing,
+  isInitializing,
 }: PipelineStepProps<Record<string, never>, {apiKey: string}>) {
   const form = useScrapsForm({
     ...defaultFormOptions,
@@ -54,7 +55,7 @@ function CursorApiKeyStep({
           )}
         </form.AppField>
         <Flex>
-          <form.SubmitButton disabled={isAdvancing}>
+          <form.SubmitButton disabled={isAdvancing || isInitializing}>
             {isAdvancing ? t('Submitting...') : t('Continue')}
           </form.SubmitButton>
         </Flex>

--- a/static/app/components/pipeline/pipelineIntegrationDiscord.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationDiscord.spec.tsx
@@ -78,4 +78,12 @@ describe('DiscordOAuthLoginStep', () => {
 
     expect(screen.getByRole('button', {name: 'Authorize Discord'})).toBeDisabled();
   });
+
+  it('disables authorize button when isInitializing', () => {
+    render(
+      <DiscordOAuthLoginStep {...makeStepProps({stepData: null, isInitializing: true})} />
+    );
+
+    expect(screen.getByRole('button', {name: 'Authorize Discord'})).toBeDisabled();
+  });
 });

--- a/static/app/components/pipeline/pipelineIntegrationDiscord.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationDiscord.tsx
@@ -25,7 +25,7 @@ function DiscordOAuthLoginStep({
 
   return (
     <OAuthLoginStep
-      oauthUrl={stepData.oauthUrl}
+      oauthUrl={stepData?.oauthUrl}
       isLoading={isAdvancing}
       serviceName="Discord"
       onOAuthCallback={handleOAuthCallback}

--- a/static/app/components/pipeline/pipelineIntegrationGitHub.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationGitHub.spec.tsx
@@ -73,6 +73,14 @@ describe('GitHubOAuthLoginStep', () => {
 
     expect(screen.getByRole('button', {name: 'Authorizing...'})).toBeDisabled();
   });
+
+  it('disables authorize button when isInitializing', () => {
+    render(
+      <GitHubOAuthLoginStep {...makeStepProps({stepData: null, isInitializing: true})} />
+    );
+
+    expect(screen.getByRole('button', {name: 'Authorize GitHub'})).toBeDisabled();
+  });
 });
 
 describe('OrgSelectionStep', () => {

--- a/static/app/components/pipeline/pipelineIntegrationGitHub.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationGitHub.tsx
@@ -55,7 +55,7 @@ function GitHubOAuthLoginStep({
 
   return (
     <OAuthLoginStep
-      oauthUrl={stepData.oauthUrl}
+      oauthUrl={stepData?.oauthUrl}
       isLoading={isAdvancing}
       serviceName="GitHub"
       onOAuthCallback={handleOAuthCallback}
@@ -137,8 +137,6 @@ function OrgSelectionStep({
   advance,
   isAdvancing,
 }: PipelineStepProps<OrgSelectionStepData, OrgSelectionAdvanceData>) {
-  const installations = stepData.installationInfo ?? [];
-
   const handleInstallCallback = useCallback(
     (data: Record<string, unknown>) => {
       advance({
@@ -149,9 +147,15 @@ function OrgSelectionStep({
   );
 
   const {openPopup, isWaitingForCallback, popupStatus} = useRedirectPopupStep({
-    redirectUrl: stepData.installAppUrl,
+    redirectUrl: stepData?.installAppUrl,
     onCallback: handleInstallCallback,
   });
+
+  if (stepData === null) {
+    return null;
+  }
+
+  const installations = stepData.installationInfo ?? [];
 
   if (installations.length === 0) {
     return (

--- a/static/app/components/pipeline/pipelineIntegrationGitLab.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationGitLab.spec.tsx
@@ -261,6 +261,19 @@ describe('InstallationConfigStep', () => {
 
     expect(screen.getByRole('button', {name: 'Submitting...'})).toBeDisabled();
   });
+
+  it('disables submit button when isInitializing', async () => {
+    render(
+      <InstallationConfigStep
+        {...makeStepProps({stepData: null, isInitializing: true})}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Next'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Next'}));
+
+    expect(screen.getByRole('button', {name: 'Continue'})).toBeDisabled();
+  });
 });
 
 describe('GitLabOAuthLoginStep', () => {

--- a/static/app/components/pipeline/pipelineIntegrationGitLab.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationGitLab.tsx
@@ -52,9 +52,10 @@ function InstallationConfigStep({
   advance,
   advanceError,
   isAdvancing,
+  isInitializing,
 }: PipelineStepProps<InstallationConfigStepData, InstallationConfigAdvanceData>) {
-  const defaults = stepData.defaults ?? {};
-  const setupValues = stepData.setupValues ?? [];
+  const defaults = stepData?.defaults ?? {};
+  const setupValues = stepData?.setupValues ?? [];
 
   const form = useScrapsForm({
     ...defaultFormOptions,
@@ -200,7 +201,7 @@ function InstallationConfigStep({
           }
         </form.Subscribe>
         <Flex>
-          <form.SubmitButton disabled={isAdvancing}>
+          <form.SubmitButton disabled={isAdvancing || isInitializing}>
             {isAdvancing ? t('Submitting...') : t('Continue')}
           </form.SubmitButton>
         </Flex>
@@ -273,7 +274,7 @@ function GitLabOAuthLoginStep({
 
   return (
     <OAuthLoginStep
-      oauthUrl={stepData.oauthUrl}
+      oauthUrl={stepData?.oauthUrl}
       isLoading={isAdvancing}
       serviceName="GitLab"
       onOAuthCallback={handleOAuthCallback}

--- a/static/app/components/pipeline/pipelineIntegrationOpsgenie.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationOpsgenie.spec.tsx
@@ -78,4 +78,14 @@ describe('OpsgenieInstallationConfigStep', () => {
 
     expect(screen.getByRole('button', {name: 'Submitting...'})).toBeDisabled();
   });
+
+  it('disables submit button when isInitializing', () => {
+    render(
+      <OpsgenieInstallationConfigStep
+        {...makeStepProps({stepData: null, isInitializing: true})}
+      />
+    );
+
+    expect(screen.getByRole('button', {name: 'Continue'})).toBeDisabled();
+  });
 });

--- a/static/app/components/pipeline/pipelineIntegrationOpsgenie.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationOpsgenie.tsx
@@ -37,8 +37,9 @@ function OpsgenieInstallationConfigStep({
   advance,
   advanceError,
   isAdvancing,
+  isInitializing,
 }: PipelineStepProps<InstallationConfigStepData, InstallationConfigAdvanceData>) {
-  const choices = stepData.baseUrlChoices ?? [];
+  const choices = stepData?.baseUrlChoices ?? [];
 
   const form = useScrapsForm({
     ...defaultFormOptions,
@@ -114,7 +115,7 @@ function OpsgenieInstallationConfigStep({
           )}
         </form.AppField>
         <Flex>
-          <form.SubmitButton disabled={isAdvancing}>
+          <form.SubmitButton disabled={isAdvancing || isInitializing}>
             {isAdvancing ? t('Submitting...') : t('Continue')}
           </form.SubmitButton>
         </Flex>

--- a/static/app/components/pipeline/pipelineIntegrationPagerDuty.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationPagerDuty.spec.tsx
@@ -76,4 +76,12 @@ describe('PagerDutyInstallStep', () => {
 
     expect(screen.getByRole('button', {name: 'Install PagerDuty App'})).toBeDisabled();
   });
+
+  it('disables install button when isInitializing', () => {
+    render(
+      <PagerDutyInstallStep {...makeStepProps({stepData: null, isInitializing: true})} />
+    );
+
+    expect(screen.getByRole('button', {name: 'Install PagerDuty App'})).toBeDisabled();
+  });
 });

--- a/static/app/components/pipeline/pipelineIntegrationPagerDuty.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationPagerDuty.tsx
@@ -24,7 +24,7 @@ function PagerDutyInstallStep({
   );
 
   const {openPopup, popupStatus} = useRedirectPopupStep({
-    redirectUrl: stepData.installUrl,
+    redirectUrl: stepData?.installUrl,
     onCallback: handleCallback,
     popup: {height: 900},
   });
@@ -63,7 +63,7 @@ function PagerDutyInstallStep({
           size="sm"
           priority="primary"
           onClick={openPopup}
-          disabled={!stepData.installUrl}
+          disabled={!stepData?.installUrl}
         >
           {t('Install PagerDuty App')}
         </Button>

--- a/static/app/components/pipeline/pipelineIntegrationSlack.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationSlack.spec.tsx
@@ -76,4 +76,12 @@ describe('SlackOAuthLoginStep', () => {
 
     expect(screen.getByRole('button', {name: 'Authorize Slack'})).toBeDisabled();
   });
+
+  it('disables authorize button when isInitializing', () => {
+    render(
+      <SlackOAuthLoginStep {...makeStepProps({stepData: null, isInitializing: true})} />
+    );
+
+    expect(screen.getByRole('button', {name: 'Authorize Slack'})).toBeDisabled();
+  });
 });

--- a/static/app/components/pipeline/pipelineIntegrationSlack.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationSlack.tsx
@@ -22,7 +22,7 @@ function SlackOAuthLoginStep({
 
   return (
     <OAuthLoginStep
-      oauthUrl={stepData.oauthUrl}
+      oauthUrl={stepData?.oauthUrl}
       isLoading={isAdvancing}
       serviceName="Slack"
       onOAuthCallback={handleOAuthCallback}

--- a/static/app/components/pipeline/pipelineIntegrationVercel.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationVercel.spec.tsx
@@ -76,4 +76,12 @@ describe('VercelOAuthLoginStep', () => {
 
     expect(screen.getByRole('button', {name: 'Authorize Vercel'})).toBeDisabled();
   });
+
+  it('disables authorize button when isInitializing', () => {
+    render(
+      <VercelOAuthLoginStep {...makeStepProps({stepData: null, isInitializing: true})} />
+    );
+
+    expect(screen.getByRole('button', {name: 'Authorize Vercel'})).toBeDisabled();
+  });
 });

--- a/static/app/components/pipeline/pipelineIntegrationVercel.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationVercel.tsx
@@ -22,7 +22,7 @@ function VercelOAuthLoginStep({
 
   return (
     <OAuthLoginStep
-      oauthUrl={stepData.oauthUrl}
+      oauthUrl={stepData?.oauthUrl}
       isLoading={isAdvancing}
       serviceName="Vercel"
       onOAuthCallback={handleOAuthCallback}

--- a/static/app/components/pipeline/pipelineIntegrationVsts.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationVsts.spec.tsx
@@ -64,6 +64,14 @@ describe('VstsOAuthLoginStep', () => {
       state: 'state-xyz',
     });
   });
+
+  it('disables authorize button when isInitializing', () => {
+    render(
+      <VstsOAuthLoginStep {...makeStepProps({stepData: null, isInitializing: true})} />
+    );
+
+    expect(screen.getByRole('button', {name: 'Authorize Azure DevOps'})).toBeDisabled();
+  });
 });
 
 describe('VstsAccountSelectionStep', () => {

--- a/static/app/components/pipeline/pipelineIntegrationVsts.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationVsts.tsx
@@ -40,7 +40,7 @@ function VstsOAuthLoginStep({
 
   return (
     <OAuthLoginStep
-      oauthUrl={stepData.oauthUrl}
+      oauthUrl={stepData?.oauthUrl}
       isLoading={isAdvancing}
       serviceName="Azure DevOps"
       onOAuthCallback={handleOAuthCallback}
@@ -53,6 +53,10 @@ function VstsAccountSelectionStep({
   advance,
   isAdvancing,
 }: PipelineStepProps<VstsAccountSelectionStepData, VstsAccountSelectionAdvanceData>) {
+  if (stepData === null) {
+    return null;
+  }
+
   const accounts = stepData.accounts ?? [];
 
   if (accounts.length === 0) {

--- a/static/app/components/pipeline/testUtils.tsx
+++ b/static/app/components/pipeline/testUtils.tsx
@@ -23,6 +23,7 @@ export function createMakeStepProps(
       advance: jest.fn(),
       advanceError: null,
       isAdvancing: false,
+      isInitializing: false,
       stepIndex: 0,
       ...defaults,
       ...overrides,

--- a/static/app/components/pipeline/types.tsx
+++ b/static/app/components/pipeline/types.tsx
@@ -85,7 +85,8 @@ export interface PipelineStepProps<
   advance: (data?: A) => void;
   advanceError: RequestError | null;
   isAdvancing: boolean;
-  stepData: D;
+  isInitializing: boolean;
+  stepData: D | null;
   stepIndex: number;
   totalSteps: number;
 }

--- a/static/app/components/pipeline/usePipeline.tsx
+++ b/static/app/components/pipeline/usePipeline.tsx
@@ -310,7 +310,10 @@ export function usePipeline<
       return <CompletionView data={state.data} finish={finish} />;
     }
 
-    if (!stepDefinition || state.status !== 'active') {
+    if (
+      !stepDefinition ||
+      (state.status !== 'active' && state.status !== 'initializing')
+    ) {
       return null;
     }
 
@@ -319,16 +322,28 @@ export function usePipeline<
     const Component: React.ComponentType<PipelineStepProps<any, any>> =
       stepDefinition.component;
 
-    return (
-      <Component
-        stepIndex={state.stepInfo.stepIndex}
-        totalSteps={state.stepInfo.totalSteps}
-        stepData={state.stepData}
-        advance={advanceMutate}
-        isAdvancing={isAdvancePending}
-        advanceError={advanceError}
-      />
-    );
+    const stepProps: PipelineStepProps<any, any> =
+      state.status === 'active'
+        ? {
+            stepIndex: state.stepInfo.stepIndex,
+            totalSteps: state.stepInfo.totalSteps,
+            stepData: state.stepData,
+            advance: advanceMutate,
+            isAdvancing: isAdvancePending,
+            isInitializing: false,
+            advanceError,
+          }
+        : {
+            stepIndex: 0,
+            totalSteps: definition.steps.length,
+            stepData: null,
+            advance: advanceMutate,
+            isAdvancing: false,
+            isInitializing: true,
+            advanceError: null,
+          };
+
+    return <Component {...stepProps} />;
   }, [
     state,
     stepDefinition,


### PR DESCRIPTION
Add isInitializing and nullable stepData to PipelineStepProps so the
first step of each pipeline renders immediately while the initialization
request is in flight.

First steps use optional chaining on stepData and disable their primary
action button during initialization. Non-first steps add a null guard
after hooks since they will never actually receive null stepData.

Every first step now has an isInitializing test verifying the button is
disabled.