### PR TITLE
feat(seer): Allow filtering the autofix settings table by agent name

### DIFF
--- a/static/app/components/events/autofix/v2/artifactCards.tsx
+++ b/static/app/components/events/autofix/v2/artifactCards.tsx
@@ -8,6 +8,7 @@ import {Heading, Text} from '@sentry/scraps/text';
 
 import {
   CodingAgentProvider,
+  getCodingAgentName,
   getResultButtonLabel,
 } from 'sentry/components/events/autofix/types';
 import type {SolutionArtifact} from 'sentry/components/events/autofix/useExplorerAutofix';
@@ -250,19 +251,6 @@ export function CodingAgentHandoffCard({codingAgents}: CodingAgentHandoffCardPro
     }
   };
 
-  const getProviderDisplayName = (provider: string) => {
-    switch (provider) {
-      case CodingAgentProvider.CURSOR_BACKGROUND_AGENT:
-        return t('Cursor Cloud Agent');
-      case CodingAgentProvider.CLAUDE_CODE_AGENT:
-        return t('Claude Agent');
-      case CodingAgentProvider.GITHUB_COPILOT_AGENT:
-        return t('GitHub Copilot');
-      default:
-        return t('Coding Agent');
-    }
-  };
-
   const getOpenButtonText = (provider: string) => {
     switch (provider) {
       case CodingAgentProvider.CURSOR_BACKGROUND_AGENT:
@@ -276,7 +264,7 @@ export function CodingAgentHandoffCard({codingAgents}: CodingAgentHandoffCardPro
 
   return (
     <ArtifactCard
-      title={getProviderDisplayName(agents[0]?.provider ?? 'Coding Agent')}
+      title={getCodingAgentName(agents[0]?.provider)}
       icon={<IconCode size="md" variant="accent" />}
     >
       <Flex direction="column" gap="xl">

--- a/static/app/utils/seer/preferredAgentFilter.tsx
+++ b/static/app/utils/seer/preferredAgentFilter.tsx
@@ -57,15 +57,24 @@ export function filterCodingAgentQueryOptions({
     ...organizationIntegrationsCodingAgents(organization),
     select: (
       data
-    ): Array<{label: React.ReactNode; value: '' | PreferredAgentProvider}> => [
-      {value: '', label: 'All'},
-      {value: 'seer', label: t('Seer Agent')},
-      ...(data.json.integrations ?? [])
-        .filter(integration => integration.id)
-        .map(integration => ({
-          value: convertAgentNameToCodingAgentProvider(integration.provider),
-          label: integration.name,
-        })),
-    ],
+    ): Array<{label: React.ReactNode; value: '' | PreferredAgentProvider}> => {
+      if (data.json.integrations.length) {
+        return [
+          {value: '', label: 'All'},
+          {value: 'seer', label: t('Seer Agent')},
+          ...Array.from(
+            new Set(
+              (data.json.integrations ?? [])
+                .filter(integration => integration.id)
+                .map(integration => ({
+                  value: convertAgentNameToCodingAgentProvider(integration.provider),
+                  label: integration.name,
+                }))
+            )
+          ).sort((a, b) => a.label.localeCompare(b.label)),
+        ];
+      }
+      return [];
+    },
   });
 }

--- a/static/app/utils/seer/preferredAgentFilter.tsx
+++ b/static/app/utils/seer/preferredAgentFilter.tsx
@@ -62,16 +62,13 @@ export function filterCodingAgentQueryOptions({
         return [
           {value: '', label: 'All'},
           {value: 'seer', label: t('Seer Agent')},
-          ...Array.from(
-            new Set(
-              (data.json.integrations ?? [])
-                .filter(integration => integration.id)
-                .map(integration => ({
-                  value: convertAgentNameToCodingAgentProvider(integration.provider),
-                  label: integration.name,
-                }))
-            )
-          ).sort((a, b) => a.label.localeCompare(b.label)),
+          ...(data.json.integrations ?? [])
+            .filter(integration => integration.id)
+            .map(integration => ({
+              value: convertAgentNameToCodingAgentProvider(integration.provider),
+              label: integration.name,
+            }))
+            .sort((a, b) => a.label.localeCompare(b.label)),
         ];
       }
       return [];

--- a/static/app/utils/seer/preferredAgentFilter.tsx
+++ b/static/app/utils/seer/preferredAgentFilter.tsx
@@ -1,0 +1,61 @@
+import {queryOptions} from '@tanstack/react-query';
+import {parseAsStringEnum} from 'nuqs';
+
+import {CodingAgentProvider} from 'sentry/components/events/autofix/types';
+import {organizationIntegrationsCodingAgents} from 'sentry/components/events/autofix/useAutofix';
+import {t} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
+
+export type PreferredAgentProvider = 'seer' | CodingAgentProvider;
+
+/**
+ * Convert from the format that is returned by the /integrations/coding-agents/
+ * endpoint to the labels that are used with /autofix/automation-settings/.
+ */
+function convertAgentNameToCodingAgentProvider(name: string): PreferredAgentProvider {
+  switch (name) {
+    case CodingAgentProvider.CLAUDE_CODE_AGENT:
+    case 'claude_code':
+      return CodingAgentProvider.CLAUDE_CODE_AGENT;
+    case CodingAgentProvider.CURSOR_BACKGROUND_AGENT:
+    case 'cursor':
+      return CodingAgentProvider.CURSOR_BACKGROUND_AGENT;
+    case CodingAgentProvider.GITHUB_COPILOT_AGENT:
+    case 'github_copilot':
+      return CodingAgentProvider.GITHUB_COPILOT_AGENT;
+    case 'seer':
+    default:
+      return 'seer';
+  }
+}
+
+export const preferredAgentFilterParser = parseAsStringEnum([
+  'seer',
+  ...Object.values(CodingAgentProvider),
+]);
+
+/**
+ * Returns the list of coding agent integrations formatted as select options,
+ * with Seer Agent as the first/default option.
+ */
+export function filterCodingAgentQueryOptions({
+  organization,
+}: {
+  organization: Organization;
+}) {
+  return queryOptions({
+    ...organizationIntegrationsCodingAgents(organization),
+    select: (
+      data
+    ): Array<{label: React.ReactNode; value: '' | PreferredAgentProvider}> => [
+      {value: '', label: 'All'},
+      {value: 'seer', label: t('Seer Agent')},
+      ...(data.json.integrations ?? [])
+        .filter(integration => integration.id)
+        .map(integration => ({
+          value: convertAgentNameToCodingAgentProvider(integration.provider),
+          label: integration.name,
+        })),
+    ],
+  });
+}

--- a/static/app/utils/seer/preferredAgentFilter.tsx
+++ b/static/app/utils/seer/preferredAgentFilter.tsx
@@ -1,7 +1,10 @@
 import {queryOptions} from '@tanstack/react-query';
 import {parseAsStringEnum} from 'nuqs';
 
-import {CodingAgentProvider} from 'sentry/components/events/autofix/types';
+import {
+  CodingAgentProvider,
+  getCodingAgentName,
+} from 'sentry/components/events/autofix/types';
 import {organizationIntegrationsCodingAgents} from 'sentry/components/events/autofix/useAutofix';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
@@ -27,6 +30,13 @@ function convertAgentNameToCodingAgentProvider(name: string): PreferredAgentProv
     default:
       return 'seer';
   }
+}
+
+export function getFilteredCodingAgentName(provider: undefined | string): string {
+  if (!provider || provider === 'seer') {
+    return t('Seer Agent');
+  }
+  return getCodingAgentName(provider);
 }
 
 export const preferredAgentFilterParser = parseAsStringEnum([

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
@@ -324,7 +324,7 @@ function ProjectTable({
             )}
             options={codingAgentCompactSelectOptions}
             onChange={option => setAgentFilter(option.value || null)}
-            value={agentFilter ?? undefined}
+            value={agentFilter ?? ''}
           />
         ) : null}
 

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
@@ -2,7 +2,6 @@ import {useMemo} from 'react';
 import styled from '@emotion/styled';
 import {debounce, parseAsString, useQueryState} from 'nuqs';
 
-import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {InputGroup} from '@sentry/scraps/input';
 import {Flex, Stack} from '@sentry/scraps/layout';
@@ -322,11 +321,6 @@ function ProjectTable({
           options={codingAgentCompactSelectOptions}
           onChange={option => setAgentFilter(option.value || null)}
           value={agentFilter ?? undefined}
-          footer={
-            <Button size="sm" onClick={() => setAgentFilter(null)}>
-              Reset
-            </Button>
-          }
         />
 
         <InputGroup style={{width: '100%'}}>

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
@@ -315,16 +315,18 @@ function ProjectTable({
   return (
     <Stack gap="lg">
       <Flex gap="md">
-        <CompactSelect<'' | PreferredAgentProvider>
-          trigger={triggerProps => (
-            <OverlayTrigger.Button {...triggerProps} size="md" prefix={t('Agent')}>
-              {agentFilter ? triggerProps.children : t('All')}
-            </OverlayTrigger.Button>
-          )}
-          options={codingAgentCompactSelectOptions}
-          onChange={option => setAgentFilter(option.value || null)}
-          value={agentFilter ?? undefined}
-        />
+        {codingAgentCompactSelectOptions.length ? (
+          <CompactSelect<'' | PreferredAgentProvider>
+            trigger={triggerProps => (
+              <OverlayTrigger.Button {...triggerProps} size="md" prefix={t('Agent')}>
+                {agentFilter ? triggerProps.children : t('All')}
+              </OverlayTrigger.Button>
+            )}
+            options={codingAgentCompactSelectOptions}
+            onChange={option => setAgentFilter(option.value || null)}
+            value={agentFilter ?? undefined}
+          />
+        ) : null}
 
         <InputGroup style={{width: '100%'}}>
           <InputGroup.LeadingItems disablePointerEvents>

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
@@ -2,8 +2,11 @@ import {useMemo} from 'react';
 import styled from '@emotion/styled';
 import {debounce, parseAsString, useQueryState} from 'nuqs';
 
+import {Button} from '@sentry/scraps/button';
+import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {InputGroup} from '@sentry/scraps/input';
-import {Stack} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
 import {
   bulkAutofixAutomationSettingsInfiniteOptions,
@@ -22,6 +25,11 @@ import type {Sort} from 'sentry/utils/discover/fields';
 import {ListItemCheckboxProvider} from 'sentry/utils/list/useListItemCheckboxState';
 import {useInfiniteQuery, useQuery, useQueryClient} from 'sentry/utils/queryClient';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
+import type {PreferredAgentProvider} from 'sentry/utils/seer/preferredAgentFilter';
+import {
+  preferredAgentFilterParser,
+  filterCodingAgentQueryOptions,
+} from 'sentry/utils/seer/preferredAgentFilter';
 import {parseAsSort} from 'sentry/utils/url/parseAsSort';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
@@ -36,6 +44,11 @@ export function SeerProjectTable() {
   const {projects, fetching, fetchError} = useProjects();
 
   const agentOptions = useFetchAgentOptions({organization});
+  const codingAgentCompactSelectOptions = useQuery(
+    filterCodingAgentQueryOptions({
+      organization,
+    })
+  );
 
   const autofixSettingsQueryOptions = bulkAutofixAutomationSettingsInfiniteOptions({
     organization,
@@ -108,6 +121,11 @@ export function SeerProjectTable() {
     [autofixAutomationSettings]
   );
 
+  const [agentFilter, setAgentFilter] = useQueryState(
+    'agent',
+    preferredAgentFilterParser
+  );
+
   const [searchTerm, setSearchTerm] = useQueryState(
     'query',
     parseAsString.withDefault('')
@@ -151,20 +169,36 @@ export function SeerProjectTable() {
   }, [projects, sort, autofixSettingsByProjectId]);
 
   const filteredProjects = useMemo(() => {
+    let filtered = sortedProjects;
+
     const lowerCase = searchTerm?.toLowerCase() ?? '';
     if (lowerCase) {
-      return sortedProjects.filter(project =>
+      filtered = filtered.filter(project =>
         project.slug.toLowerCase().includes(lowerCase)
       );
     }
-    return sortedProjects;
-  }, [sortedProjects, searchTerm]);
+
+    if (agentFilter) {
+      filtered = filtered.filter(project => {
+        const settings = autofixSettingsByProjectId.get(project.id);
+        const projectAgentId = settings?.automationHandoff?.target
+          ? String(settings.automationHandoff.target)
+          : 'seer';
+        return projectAgentId === agentFilter;
+      });
+    }
+
+    return filtered;
+  }, [sortedProjects, searchTerm, agentFilter, autofixSettingsByProjectId]);
 
   if (fetching) {
     return (
       <ProjectTable
+        agentFilter={agentFilter}
+        codingAgentCompactSelectOptions={codingAgentCompactSelectOptions.data ?? []}
         projects={filteredProjects}
         onSortClick={setSort}
+        setAgentFilter={setAgentFilter}
         sort={sort}
         searchTerm={searchTerm}
         setSearchTerm={setSearchTerm}
@@ -180,8 +214,11 @@ export function SeerProjectTable() {
   if (fetchError) {
     return (
       <ProjectTable
+        agentFilter={agentFilter}
+        codingAgentCompactSelectOptions={codingAgentCompactSelectOptions.data ?? []}
         projects={filteredProjects}
         onSortClick={setSort}
+        setAgentFilter={setAgentFilter}
         sort={sort}
         searchTerm={searchTerm}
         setSearchTerm={setSearchTerm}
@@ -201,8 +238,11 @@ export function SeerProjectTable() {
       queryKey={queryKey}
     >
       <ProjectTable
+        agentFilter={agentFilter}
+        codingAgentCompactSelectOptions={codingAgentCompactSelectOptions.data ?? []}
         projects={filteredProjects}
         onSortClick={setSort}
+        setAgentFilter={setAgentFilter}
         sort={sort}
         searchTerm={searchTerm}
         setSearchTerm={setSearchTerm}
@@ -211,10 +251,19 @@ export function SeerProjectTable() {
         {filteredProjects.length === 0 ? (
           <SimpleTable.Empty>
             {searchTerm
-              ? tct('No projects found matching [searchTerm]', {
-                  searchTerm: <code>{searchTerm}</code>,
-                })
-              : t('No projects found')}
+              ? agentFilter
+                ? tct('No projects found matching [searchTerm] with [agentFilter]', {
+                    searchTerm: <code>{searchTerm}</code>,
+                    agentFilter: <code>{agentFilter}</code>,
+                  })
+                : tct('No projects found matching [searchTerm]', {
+                    searchTerm: <code>{searchTerm}</code>,
+                  })
+              : agentFilter
+                ? tct('No projects found with [agentFilter]', {
+                    agentFilter: <code>{agentFilter}</code>,
+                  })
+                : t('No projects found')}
           </SimpleTable.Empty>
         ) : (
           filteredProjects.map(project => (
@@ -234,18 +283,27 @@ export function SeerProjectTable() {
 }
 
 function ProjectTable({
+  agentFilter,
+  codingAgentCompactSelectOptions,
   children,
   onSortClick,
   projects,
   searchTerm,
+  setAgentFilter,
   setSearchTerm,
   sort,
   updateBulkAutofixAutomationSettings,
 }: {
+  agentFilter: null | PreferredAgentProvider;
   children: React.ReactNode;
+  codingAgentCompactSelectOptions: Array<{
+    label: React.ReactNode;
+    value: '' | PreferredAgentProvider;
+  }>;
   onSortClick: (sort: Sort) => void;
   projects: Project[];
   searchTerm: string;
+  setAgentFilter: ReturnType<typeof useQueryState<PreferredAgentProvider>>[1];
   setSearchTerm: ReturnType<typeof useQueryState<string>>[1];
   sort: Sort;
   updateBulkAutofixAutomationSettings: ReturnType<
@@ -254,8 +312,24 @@ function ProjectTable({
 }) {
   return (
     <Stack gap="lg">
-      <FiltersContainer>
-        <InputGroup>
+      <Flex gap="md">
+        <CompactSelect<'' | PreferredAgentProvider>
+          trigger={triggerProps => (
+            <OverlayTrigger.Button {...triggerProps} size="md" prefix={t('Agent')}>
+              {agentFilter ? triggerProps.children : t('All')}
+            </OverlayTrigger.Button>
+          )}
+          options={codingAgentCompactSelectOptions}
+          onChange={option => setAgentFilter(option.value || null)}
+          value={agentFilter ?? undefined}
+          footer={
+            <Button size="sm" onClick={() => setAgentFilter(null)}>
+              Reset
+            </Button>
+          }
+        />
+
+        <InputGroup style={{width: '100%'}}>
           <InputGroup.LeadingItems disablePointerEvents>
             <IconSearch />
           </InputGroup.LeadingItems>
@@ -268,7 +342,7 @@ function ProjectTable({
             }
           />
         </InputGroup>
-      </FiltersContainer>
+      </Flex>
 
       <SimpleTableWithColumns>
         <ProjectTableHeader
@@ -282,11 +356,6 @@ function ProjectTable({
     </Stack>
   );
 }
-
-const FiltersContainer = styled('div')`
-  flex-grow: 1;
-  min-width: 0;
-`;
 
 const SimpleTableWithColumns = styled(SimpleTable)`
   grid-template-columns: max-content 3fr minmax(300px, 1fr) repeat(2, max-content);

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
@@ -140,7 +140,7 @@ export function SeerProjectTable() {
 
   const queryKey = [
     'seer-projects',
-    {query: {query: searchTerm, sort}},
+    {query: {query: searchTerm, sort, agent: agentFilter}},
   ] as unknown as ApiQueryKey;
 
   const sortedProjects = useMemo(() => {

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
@@ -24,7 +24,10 @@ import type {Sort} from 'sentry/utils/discover/fields';
 import {ListItemCheckboxProvider} from 'sentry/utils/list/useListItemCheckboxState';
 import {useInfiniteQuery, useQuery, useQueryClient} from 'sentry/utils/queryClient';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
-import type {PreferredAgentProvider} from 'sentry/utils/seer/preferredAgentFilter';
+import {
+  getFilteredCodingAgentName,
+  type PreferredAgentProvider,
+} from 'sentry/utils/seer/preferredAgentFilter';
 import {
   preferredAgentFilterParser,
   filterCodingAgentQueryOptions,
@@ -253,14 +256,14 @@ export function SeerProjectTable() {
               ? agentFilter
                 ? tct('No projects found matching [searchTerm] with [agentFilter]', {
                     searchTerm: <code>{searchTerm}</code>,
-                    agentFilter: <code>{agentFilter}</code>,
+                    agentFilter: <code>{getFilteredCodingAgentName(agentFilter)}</code>,
                   })
                 : tct('No projects found matching [searchTerm]', {
                     searchTerm: <code>{searchTerm}</code>,
                   })
               : agentFilter
                 ? tct('No projects found with [agentFilter]', {
-                    agentFilter: <code>{agentFilter}</code>,
+                    agentFilter: <code>{getFilteredCodingAgentName(agentFilter)}</code>,
                   })
                 : t('No projects found')}
           </SimpleTable.Empty>


### PR DESCRIPTION
If you only have Seer Agent (no 3rd parties) then the filter goes away:
<img width="569" height="236" alt="SCR-20260417-lkbd" src="https://github.com/user-attachments/assets/df2f1f3c-3914-4972-a9ad-4f5b2cf054b8" />


But if there are 3rd parties in there, we show it:
<img width="536" height="316" alt="SCR-20260417-iyuu" src="https://github.com/user-attachments/assets/9cab60f6-2696-45c3-a6fb-31d793f5a829" />

<img width="1169" height="368" alt="SCR-20260417-lgwu" src="https://github.com/user-attachments/assets/c7ec9fb2-4a92-4f9a-bef6-d132e57ce950" />

