### PR TITLE
fix(issue-detection): Don't use "Other" as title for uncategorized AI issues

### DIFF
--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -178,6 +178,9 @@ GROUP_TYPE_TO_SETTING: dict[type[GroupType], str] = {
 }
 
 
+FALLBACK_ISSUE_TITLE = "AI-Detected Application Issue"
+
+
 def get_group_type_for_title(title: str) -> type[GroupType]:
     return TITLE_TO_GROUP_TYPE.get(title, AIDetectedGeneralGroupType)
 
@@ -227,7 +230,9 @@ def create_issue_occurrence_from_detection(
         event_id=event_id,
         project_id=project.id,
         fingerprint=fingerprint,
-        issue_title=detected_issue.title,
+        issue_title=(
+            FALLBACK_ISSUE_TITLE if detected_issue.title == "Other" else detected_issue.title
+        ),
         subtitle=detected_issue.explanation[:200],  # Truncate for subtitle
         resource_id=None,
         evidence_data=evidence_data,

--- a/tests/sentry/tasks/test_llm_issue_detection.py
+++ b/tests/sentry/tasks/test_llm_issue_detection.py
@@ -165,6 +165,27 @@ class LLMIssueDetectionTest(TestCase):
         assert occurrence.fingerprint == [f"1-{AIDetectedDBGroupType.type_id}-n+1-database-queries"]
         assert occurrence.type == AIDetectedDBGroupType
 
+    @patch("sentry.tasks.llm_issue_detection.detection.produce_occurrence_to_kafka")
+    def test_other_title_uses_fallback_display_title(self, mock_produce_occurrence):
+        detected_issue = DetectedIssue(
+            title="Other",
+            explanation="Something unusual happening here",
+            impact="Low",
+            evidence="Observed in trace",
+            offender_span_ids=[],
+            trace_id="trace789",
+            transaction_name="POST /foo",
+            verification_reason="Verified",
+            group_for_fingerprint="Other",
+        )
+        create_issue_occurrence_from_detection(
+            detected_issue=detected_issue,
+            project=self.project,
+        )
+        occurrence = mock_produce_occurrence.call_args.kwargs["occurrence"]
+        assert occurrence.issue_title == "AI-Detected Application Issue"
+        assert occurrence.type == AIDetectedGeneralGroupType
+
     @with_feature("organizations:gen-ai-features")
     @patch("sentry.tasks.llm_issue_detection.detection.mark_traces_as_processed")
     @patch("sentry.tasks.llm_issue_detection.detection._get_unprocessed_traces")


### PR DESCRIPTION
When the LLM can't slot a detected issue into one of the known categories, it returns the literal string "Other". Previously this flowed through as the issue stream title, which read poorly. Map it to "AI-Detected Application Issue" instead as a temporary fix until we update the prompt to give a better name
