### PR TITLE
fix(aci): Restrict percent sessions interval choices to supported values

### DIFF
--- a/static/app/views/automations/components/actionFilters/comparisonBranches.tsx
+++ b/static/app/views/automations/components/actionFilters/comparisonBranches.tsx
@@ -7,21 +7,29 @@ import type {SelectValue} from 'sentry/types/core';
 import {
   COMPARISON_INTERVAL_CHOICES,
   INTERVAL_CHOICES,
+  Interval,
 } from 'sentry/views/automations/components/actionFilters/constants';
 import {useAutomationBuilderErrorContext} from 'sentry/views/automations/components/automationBuilderErrorContext';
 import {useDataConditionNodeContext} from 'sentry/views/automations/components/dataConditionNodes';
 
-export function CountBranch() {
+type IntervalChoice = {label: string; value: Interval};
+
+interface BranchProps {
+  comparisonIntervalChoices?: IntervalChoice[];
+  intervalChoices?: IntervalChoice[];
+}
+
+export function CountBranch({intervalChoices = INTERVAL_CHOICES}: BranchProps) {
   return tct('more than [value] [interval]', {
     value: <ValueField />,
-    interval: <IntervalField />,
+    interval: <IntervalField intervalChoices={intervalChoices} />,
   });
 }
 
-export function PercentBranch() {
+export function PercentBranch({intervalChoices = INTERVAL_CHOICES}: BranchProps) {
   return tct('[value] higher [interval] compared to [comparison_interval]', {
     value: <PercentValueField />,
-    interval: <IntervalField />,
+    interval: <IntervalField intervalChoices={intervalChoices} />,
     comparison_interval: <ComparisonIntervalField />,
   });
 }
@@ -53,7 +61,11 @@ function PercentValueField() {
   );
 }
 
-function IntervalField() {
+function IntervalField({
+  intervalChoices = INTERVAL_CHOICES,
+}: {
+  intervalChoices?: IntervalChoice[];
+}) {
   const {condition, condition_id, onUpdate} = useDataConditionNodeContext();
   const {removeError} = useAutomationBuilderErrorContext();
 
@@ -62,7 +74,7 @@ function IntervalField() {
       name={`${condition_id}.comparison.interval`}
       aria-label={t('Interval')}
       value={condition.comparison.interval}
-      options={INTERVAL_CHOICES}
+      options={intervalChoices}
       onChange={(option: SelectValue<string>) => {
         onUpdate({comparison: {...condition.comparison, interval: option.value}});
         removeError(condition.id);

--- a/static/app/views/automations/components/actionFilters/comparisonBranches.tsx
+++ b/static/app/views/automations/components/actionFilters/comparisonBranches.tsx
@@ -15,7 +15,6 @@ import {useDataConditionNodeContext} from 'sentry/views/automations/components/d
 type IntervalChoice = {label: string; value: Interval};
 
 interface BranchProps {
-  comparisonIntervalChoices?: IntervalChoice[];
   intervalChoices?: IntervalChoice[];
 }
 

--- a/static/app/views/automations/components/actionFilters/constants.tsx
+++ b/static/app/views/automations/components/actionFilters/constants.tsx
@@ -106,7 +106,9 @@ export enum Level {
 export enum Interval {
   ONE_MINUTE = '1m',
   FIVE_MINUTES = '5m',
+  TEN_MINUTES = '10m',
   FIFTEEN_MINUTES = '15m',
+  THIRTY_MINUTES = '30m',
   ONE_HOUR = '1h',
   ONE_DAY = '1d',
   ONE_WEEK = '1w',
@@ -179,6 +181,13 @@ export const INTERVAL_CHOICES = [
   {value: Interval.ONE_DAY, label: t('in one day')},
   {value: Interval.ONE_WEEK, label: t('in one week')},
   {value: Interval.THIRTY_DAYS, label: t('in 30 days')},
+];
+
+export const PERCENT_INTERVAL_CHOICES = [
+  {value: Interval.FIVE_MINUTES, label: t('in 5 minutes')},
+  {value: Interval.TEN_MINUTES, label: t('in 10 minutes')},
+  {value: Interval.THIRTY_MINUTES, label: t('in 30 minutes')},
+  {value: Interval.ONE_HOUR, label: t('in one hour')},
 ];
 
 export const COMPARISON_INTERVAL_CHOICES = [

--- a/static/app/views/automations/components/actionFilters/constants.tsx
+++ b/static/app/views/automations/components/actionFilters/constants.tsx
@@ -174,7 +174,6 @@ export const LEVEL_CHOICES = [
 ];
 
 export const INTERVAL_CHOICES = [
-  {value: Interval.ONE_MINUTE, label: t('in one minute')},
   {value: Interval.FIVE_MINUTES, label: t('in 5 minutes')},
   {value: Interval.FIFTEEN_MINUTES, label: t('in 15 minutes')},
   {value: Interval.ONE_HOUR, label: t('in one hour')},

--- a/static/app/views/automations/components/actionFilters/percentSessions.tsx
+++ b/static/app/views/automations/components/actionFilters/percentSessions.tsx
@@ -9,7 +9,10 @@ import {
   CountBranch,
   PercentBranch,
 } from 'sentry/views/automations/components/actionFilters/comparisonBranches';
-import {PERCENT_INTERVAL_CHOICES} from 'sentry/views/automations/components/actionFilters/constants';
+import {
+  COMPARISON_INTERVAL_CHOICES,
+  PERCENT_INTERVAL_CHOICES,
+} from 'sentry/views/automations/components/actionFilters/constants';
 import {
   SubfilterDetailsList,
   SubfiltersList,
@@ -57,7 +60,7 @@ export function PercentSessionsPercentDetails({condition}: {condition: DataCondi
               choice => choice.value === condition.comparison.interval
             )?.label || condition.comparison.interval,
           comparisonInterval:
-            PERCENT_INTERVAL_CHOICES.find(
+            COMPARISON_INTERVAL_CHOICES.find(
               choice => choice.value === condition.comparison.comparisonInterval
             )?.label || condition.comparison.comparisonInterval,
           where: hasSubfilters ? t('where') : null,

--- a/static/app/views/automations/components/actionFilters/percentSessions.tsx
+++ b/static/app/views/automations/components/actionFilters/percentSessions.tsx
@@ -9,10 +9,7 @@ import {
   CountBranch,
   PercentBranch,
 } from 'sentry/views/automations/components/actionFilters/comparisonBranches';
-import {
-  COMPARISON_INTERVAL_CHOICES,
-  INTERVAL_CHOICES,
-} from 'sentry/views/automations/components/actionFilters/constants';
+import {PERCENT_INTERVAL_CHOICES} from 'sentry/views/automations/components/actionFilters/constants';
 import {
   SubfilterDetailsList,
   SubfiltersList,
@@ -34,7 +31,7 @@ export function PercentSessionsCountDetails({condition}: {condition: DataConditi
         {
           value: condition.comparison.value,
           interval:
-            INTERVAL_CHOICES.find(
+            PERCENT_INTERVAL_CHOICES.find(
               choice => choice.value === condition.comparison.interval
             )?.label || condition.comparison.interval,
           where: hasSubfilters ? t('where') : null,
@@ -56,11 +53,11 @@ export function PercentSessionsPercentDetails({condition}: {condition: DataCondi
         {
           value: condition.comparison.value,
           interval:
-            INTERVAL_CHOICES.find(
+            PERCENT_INTERVAL_CHOICES.find(
               choice => choice.value === condition.comparison.interval
             )?.label || condition.comparison.interval,
           comparisonInterval:
-            COMPARISON_INTERVAL_CHOICES.find(
+            PERCENT_INTERVAL_CHOICES.find(
               choice => choice.value === condition.comparison.comparisonInterval
             )?.label || condition.comparison.comparisonInterval,
           where: hasSubfilters ? t('where') : null,
@@ -94,10 +91,10 @@ function ComparisonTypeField() {
   const {removeError} = useAutomationBuilderErrorContext();
 
   if (condition.type === DataConditionType.PERCENT_SESSIONS_COUNT) {
-    return <CountBranch />;
+    return <CountBranch intervalChoices={PERCENT_INTERVAL_CHOICES} />;
   }
   if (condition.type === DataConditionType.PERCENT_SESSIONS_PERCENT) {
-    return <PercentBranch />;
+    return <PercentBranch intervalChoices={PERCENT_INTERVAL_CHOICES} />;
   }
 
   return (


### PR DESCRIPTION
Closes ISWF-2456

The "percent of sessions affected" filter in the new automation builder was showing all the generic interval options (`15m`, `1d`, `1w`, `30d`) which aren't actually supported for this condition type. The backend defines the supported set as `PERCENT_INTERVALS_TO_DISPLAY`:

https://github.com/getsentry/sentry/blob/4794f48bf03ee3fc01cbd06ce845a3285b1a83fd/src/sentry/rules/conditions/event_frequency.py#L852-L857

_Also_ while looking into this, I found that the old UI actually removes the `1m` option from the UI (presumably because we don't want to support it), so I removed that from the list of standard interval options.

This is something that we could eventually fetch from the backend, but for the the options need to be duplicated on the frontend.

<img width="1546" height="452" alt="CleanShot 2026-04-17 at 09 53 30@2x" src="https://github.com/user-attachments/assets/bf59a02b-3401-4968-aafd-e934f4b79861" />
