### PR TITLE
chore(explore): Add header hints and secondary nav updates

### DIFF
--- a/static/app/views/explore/components/breadcrumb.tsx
+++ b/static/app/views/explore/components/breadcrumb.tsx
@@ -32,7 +32,7 @@ export function ExploreBreadcrumb({
   if (traceItemDataset === TraceItemDataset.TRACEMETRICS) {
     crumbs.push({
       to: makeMetricsPathname({organizationSlug: organization.slug, path: '/'}),
-      label: t('Metrics'),
+      label: t('Application Metrics'),
     });
   }
   if (traceItemDataset === TraceItemDataset.REPLAYS) {

--- a/static/app/views/explore/logs/content.tsx
+++ b/static/app/views/explore/logs/content.tsx
@@ -8,6 +8,7 @@ import {FeedbackButton} from 'sentry/components/feedbackButton/feedbackButton';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {PageFiltersContainer} from 'sentry/components/pageFilters/container';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {withoutLoggingSupport} from 'sentry/data/platformCategories';
 import {platforms} from 'sentry/data/platforms';
@@ -125,14 +126,53 @@ function LogsHeader() {
             orgSlug={organization?.slug}
           />
         ) : null}
-        {title && defined(pageId) ? (
-          <ExploreBreadcrumb
-            traceItemDataset={TraceItemDataset.LOGS}
-            savedQueryName={savedQuery?.name}
-          />
-        ) : null}
-
-        <Layout.Title>{title ? title : t('Logs')}</Layout.Title>
+        {hasPageFrameFeature ? (
+          title && defined(pageId) ? (
+            <TopBar.Slot name="title">
+              <ExploreBreadcrumb
+                traceItemDataset={TraceItemDataset.LOGS}
+                savedQueryName={savedQuery?.name}
+              />
+              <PageHeadingQuestionTooltip
+                docsUrl="https://docs.sentry.io/product/explore/logs/"
+                title={t(
+                  'Detailed structured logs, linked to errors and traces, for debugging and investigation.'
+                )}
+                linkLabel={t('Read the Docs')}
+              />
+            </TopBar.Slot>
+          ) : (
+            <TopBar.Slot name="title">
+              {title ? title : t('Logs')}
+              <PageHeadingQuestionTooltip
+                docsUrl="https://docs.sentry.io/product/explore/logs/"
+                title={t(
+                  'Detailed structured logs, linked to errors and traces, for debugging and investigation.'
+                )}
+                linkLabel={t('Read the Docs')}
+              />
+            </TopBar.Slot>
+          )
+        ) : (
+          <Fragment>
+            {title && defined(pageId) ? (
+              <ExploreBreadcrumb
+                traceItemDataset={TraceItemDataset.LOGS}
+                savedQueryName={savedQuery?.name}
+              />
+            ) : null}
+            <Layout.Title>
+              {title ? title : t('Traces')}
+              <PageHeadingQuestionTooltip
+                docsUrl="https://docs.sentry.io/product/explore/logs/"
+                title={t(
+                  'Detailed structured logs, linked to errors and traces, for debugging and investigation.'
+                )}
+                linkLabel={t('Read the Docs')}
+              />
+            </Layout.Title>
+          </Fragment>
+        )}
       </Layout.HeaderContent>
       {hasPageFrameFeature ? (
         <Fragment>

--- a/static/app/views/explore/logs/content.tsx
+++ b/static/app/views/explore/logs/content.tsx
@@ -162,7 +162,7 @@ function LogsHeader() {
               />
             ) : null}
             <Layout.Title>
-              {title ? title : t('Traces')}
+              {title ? title : t('Logs')}
               <PageHeadingQuestionTooltip
                 docsUrl="https://docs.sentry.io/product/explore/logs/"
                 title={t(

--- a/static/app/views/explore/metrics/content.tsx
+++ b/static/app/views/explore/metrics/content.tsx
@@ -1,3 +1,5 @@
+import {Fragment} from 'react';
+
 import {FeatureBadge} from '@sentry/scraps/badge';
 import {Stack} from '@sentry/scraps/layout';
 
@@ -5,6 +7,7 @@ import {AnalyticsArea} from 'sentry/components/analyticsArea';
 import {FeedbackButton} from 'sentry/components/feedbackButton/feedbackButton';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {PageFiltersContainer} from 'sentry/components/pageFilters/container';
+import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {DataCategory} from 'sentry/types/core';
@@ -101,16 +104,56 @@ function MetricsHeader() {
             orgSlug={organization?.slug}
           />
         ) : null}
-        {title && defined(pageId) ? (
-          <ExploreBreadcrumb
-            traceItemDataset={TraceItemDataset.TRACEMETRICS}
-            savedQueryName={savedQuery?.name}
-          />
-        ) : null}
-        <Layout.Title>
-          {title ? title : METRICS_TITLE}
-          <FeatureBadge type="beta" />
-        </Layout.Title>
+        {hasPageFrameFeature ? (
+          title && defined(pageId) ? (
+            <TopBar.Slot name="title">
+              <ExploreBreadcrumb
+                traceItemDataset={TraceItemDataset.TRACEMETRICS}
+                savedQueryName={savedQuery?.name}
+              />
+              <FeatureBadge type="beta" />
+              <PageHeadingQuestionTooltip
+                docsUrl="https://docs.sentry.io/product/explore/metrics/"
+                title={t(
+                  'Track critical application signals using counters, gauges, and distributions.'
+                )}
+                linkLabel={t('Read the Docs')}
+              />
+            </TopBar.Slot>
+          ) : (
+            <TopBar.Slot name="title">
+              {title ? title : METRICS_TITLE}
+              <FeatureBadge type="beta" />
+              <PageHeadingQuestionTooltip
+                docsUrl="https://docs.sentry.io/product/explore/metrics/"
+                title={t(
+                  'Track critical application signals using counters, gauges, and distributions.'
+                )}
+                linkLabel={t('Read the Docs')}
+              />
+            </TopBar.Slot>
+          )
+        ) : (
+          <Fragment>
+            {title && defined(pageId) ? (
+              <ExploreBreadcrumb
+                traceItemDataset={TraceItemDataset.TRACEMETRICS}
+                savedQueryName={savedQuery?.name}
+              />
+            ) : null}
+            <Layout.Title>
+              {title ? title : METRICS_TITLE}
+              <FeatureBadge type="beta" />
+              <PageHeadingQuestionTooltip
+                docsUrl="https://docs.sentry.io/product/explore/metrics/"
+                title={t(
+                  'Track critical application signals using counters, gauges, and distributions.'
+                )}
+                linkLabel={t('Read the Docs')}
+              />
+            </Layout.Title>
+          </Fragment>
+        )}
       </Layout.HeaderContent>
       <Layout.HeaderActions>
         {hasPageFrameFeature ? (

--- a/static/app/views/explore/spans/content.tsx
+++ b/static/app/views/explore/spans/content.tsx
@@ -175,22 +175,22 @@ function SpansTabHeader() {
                 savedQueryName={savedQuery?.name}
               />
               <PageHeadingQuestionTooltip
-                docsUrl="https://github.com/getsentry/sentry/discussions/81239"
+                docsUrl="https://docs.sentry.io/product/explore/trace-explorer/"
                 title={t(
                   'Find problematic spans/traces or compute real-time metrics via aggregation.'
                 )}
-                linkLabel={t('Read the Discussion')}
+                linkLabel={t('Read the Docs')}
               />
             </TopBar.Slot>
           ) : (
             <TopBar.Slot name="title">
               {title ? title : t('Traces')}
               <PageHeadingQuestionTooltip
-                docsUrl="https://github.com/getsentry/sentry/discussions/81239"
+                docsUrl="https://docs.sentry.io/product/explore/trace-explorer/"
                 title={t(
                   'Find problematic spans/traces or compute real-time metrics via aggregation.'
                 )}
-                linkLabel={t('Read the Discussion')}
+                linkLabel={t('Read the Docs')}
               />
             </TopBar.Slot>
           )
@@ -205,11 +205,11 @@ function SpansTabHeader() {
             <Layout.Title>
               {title ? title : t('Traces')}
               <PageHeadingQuestionTooltip
-                docsUrl="https://github.com/getsentry/sentry/discussions/81239"
+                docsUrl="https://docs.sentry.io/product/explore/trace-explorer/"
                 title={t(
                   'Find problematic spans/traces or compute real-time metrics via aggregation.'
                 )}
-                linkLabel={t('Read the Discussion')}
+                linkLabel={t('Read the Docs')}
               />
             </Layout.Title>
           </Fragment>

--- a/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
@@ -100,7 +100,7 @@ export function ExploreSecondaryNavigation() {
                     analyticsItemName="explore_metrics"
                     trailingItems={<FeatureBadge type="beta" />}
                   >
-                    {t('Metrics')}
+                    {t('Application Metrics')}
                   </SecondaryNavigation.Link>
                 </SecondaryNavigation.ListItem>
               </Feature>

--- a/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
@@ -97,7 +97,7 @@ export function ExploreSecondaryNavigation() {
                 <SecondaryNavigation.ListItem>
                   <SecondaryNavigation.Link
                     to={`${baseUrl}/metrics/`}
-                    analyticsItemName="explore_metrics"
+                    analyticsItemName="explore_application_metrics"
                     trailingItems={<FeatureBadge type="beta" />}
                   >
                     {t('Application Metrics')}


### PR DESCRIPTION
This PR updates the headers for the Logs and Application Metrics pages to be the latest from design engineering setup, as well as adding in tooltips for Logs and Metrics, well updating the docs link for Traces.

Closes EXP-881

|Examples:|||
|-|-|-|
|Logs Tooltips|<img width="303" height="100" alt="Screenshot 2026-04-17 at 13 55 18" src="https://github.com/user-attachments/assets/721e70ae-45b3-4ca4-8956-379edeb2cf4e" />|<img width="510" height="94" alt="Screenshot 2026-04-17 at 13 56 49" src="https://github.com/user-attachments/assets/d7b88cf2-8c43-40b2-a9b0-cf12cfd0c73f" />|
|Application Metrics|<img width="438" height="109" alt="Screenshot 2026-04-17 at 13 54 47" src="https://github.com/user-attachments/assets/d5126c95-709f-4a5b-880d-7a639be1207e" />|<img width="662" height="100" alt="Screenshot 2026-04-17 at 14 19 23" src="https://github.com/user-attachments/assets/332117c3-49a7-4f25-8110-65cb8e14e93d" />|