### PR TITLE
ref(options): Remove 4 unused option registrations

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2994,32 +2994,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# the duration of the first datetime chunk of data queried
-# expressed in hours.
-register(
-    "profiling.flamegraph.query.initial_chunk_delta.hours",
-    type=Int,
-    default=12,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-# the max duration of any datetime chunk of data queried
-# expressed in hours.
-register(
-    "profiling.flamegraph.query.max_delta.hours",
-    type=Int,
-    default=48,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
-# The value by which the current delta is multiplied
-register(
-    "profiling.flamegraph.query.multiplier",
-    type=Int,
-    default=2,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 # list of platform names for which we allow using unsampled profiles for the purpose
 # of improving profile (function) metrics
 register(
@@ -3167,12 +3141,6 @@ register(
     "spans.buffer.max-segment-bytes",
     type=Int,
     default=10 * 1024 * 1024,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
-# When enabled, oversized segments are split into chunks instead of being dropped.
-register(
-    "spans.buffer.chunk-oversized-segments",
-    default=False,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 # Whether to enforce max-segment-bytes during ingestion via the Lua script.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
These options are no longer used in the codebase after recent refactors:

- **`spans.buffer.chunk-oversized-segments`** - Removed from usage in #112606 (commit 78bd3576814). The span buffer now always chunks oversized segments by default.

- **`profiling.flamegraph.query.initial_chunk_delta.hours`** - No longer used after the flamegraph refactor. Remains only in a legacy `get_profile_candidates_from_transactions()` method that is never called.

- **`profiling.flamegraph.query.max_delta.hours`** - No longer used after the flamegraph refactor. Remains only in a legacy `get_profile_candidates_from_transactions()` method that is never called.

- **`profiling.flamegraph.query.multiplier`** - No longer used after the flamegraph refactor. Remains only in a legacy `get_profile_candidates_from_transactions()` method that is never called.

## Verification

Confirmed that:
1. `spans.buffer.chunk-oversized-segments` has no `options.get()` calls after the chunking became the default behavior
2. The three flamegraph options are only defined in a legacy method that is never called anywhere in the codebase

This cleanup resolves the unregistered options alert from Sentaur.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/C04URUC21C5/p1776441601836599?thread_ts=1776441601.836599&cid=C04URUC21C5)

<div><a href="https://cursor.com/agents/bc-d250c161-e354-55b8-b7b2-54e66af245a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d250c161-e354-55b8-b7b2-54e66af245a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

