### PR TITLE
fix(search): Return empty result on disjoint group_id intersection

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -43,7 +43,12 @@ from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
 from sentry.utils import json, metrics
 from sentry.utils.cursors import Cursor, CursorResult
-from sentry.utils.snuba import SnubaQueryParams, aliased_query_params, bulk_raw_query
+from sentry.utils.snuba import (
+    EmptyGroupIdIntersectionError,
+    SnubaQueryParams,
+    aliased_query_params,
+    bulk_raw_query,
+)
 
 FIRST_RELEASE_FILTERS = ["first_release", "firstRelease"]
 
@@ -465,6 +470,10 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
                     aggregate_kwargs,
                 )
             except UnsupportedSearchQuery:
+                pass
+            except EmptyGroupIdIntersectionError:
+                # Postgres candidates and the snuba group_id condition are
+                # disjoint for this category — it can't match anything. Skip it.
                 pass
             else:
                 if query_params is not None:

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -352,6 +352,15 @@ class UnqualifiedQueryError(SnubaError):
     """
 
 
+class EmptyGroupIdIntersectionError(SnubaError):
+    """
+    Raised by SnubaQueryParams when the intersection of `group_id` IN-constraints
+    is empty, meaning the query cannot match any rows. Callers that want to treat
+    this as "no results" (rather than a failure) should catch it explicitly;
+    otherwise it propagates as a generic SnubaError to preserve existing behavior.
+    """
+
+
 class UnexpectedResponseError(SnubaError):
     """
     Exception raised when the Snuba API server returns an unexpected response
@@ -980,7 +989,7 @@ class SnubaQueryParams:
             if len(in_groups) > 0:
                 triple = ["group_id", "IN", get_all_merged_group_ids(in_groups)]
             else:
-                raise SnubaError("Found empty intersection of group_ids")
+                raise EmptyGroupIdIntersectionError("Found empty intersection of group_ids")
         elif len(out_groups) > 0:
             triple = ["group_id", "NOT IN", out_groups]
 

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -2658,6 +2658,16 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         )
         assert set(results) == set()
 
+    def test_issue_shortid_filter_disjoint_with_status(self) -> None:
+        # When the postgres candidate set and the snuba group_id condition
+        # have no overlap, the search should return empty rather than surface
+        # a SnubaError.
+        assert self.group2.status == GroupStatus.RESOLVED
+        results = self.make_query(
+            search_filter_query=f"is:unresolved issue:{self.group2.qualified_short_id}",
+        )
+        assert set(results) == set()
+
 
 class EventsSnubaSearchTest(TestCase, EventsSnubaSearchTestCases):
     pass


### PR DESCRIPTION
Return an empty search result instead of a 500 whenever the postgres candidate set and the snuba `group_id` condition are disjoint — any search where the two sides can't both be true at once.

Concretely, `SnubaQueryParams._preprocess_group_id_redirects` intersects `filter_keys["group_id"]` (postgres candidates) with the `group_id` conditions contributed by the search filters. When that intersection is empty the query can't match anything, but today it raises `SnubaError("Found empty intersection of group_ids")` and surfaces as an internal error.

One example that hits this in production (SENTRY-5MNH): `issue:<shortid>` gets rewritten into a snuba `group_id = Y` condition in `format_search_filter`, but the postgres-side queryset builder only has a `"issue.id"` entry in `_get_queryset_conditions` — not `"issue"`. So a query like `is:unresolved issue:<resolved-shortid>` leaves postgres returning unresolved candidates (without Y) while snuba still constrains to `group_id = Y`, and the intersection collapses.

The raise is narrowed to a new `EmptyGroupIdIntersectionError` subclass so generic `except SnubaError` handlers keep the existing behavior; only the per-category loop in `snuba_search` opts in to treat it as zero results. If all categories skip, `bulk_raw_query([])` naturally yields an empty result.

Fixes SENTRY-5MNH
Refs ID-1482