### PR TITLE
ref(slack): Remove legacy pipeline views

### DIFF
--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -9,7 +9,6 @@ from django.utils.translation import gettext_lazy as _
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
-from sentry.identity.pipeline import IdentityPipeline
 from sentry.identity.slack.provider import SlackIdentityProvider
 from sentry.integrations.base import (
     FeatureDescription,
@@ -38,7 +37,6 @@ from sentry.notifications.platform.slack.provider import (
 from sentry.notifications.platform.target import IntegrationNotificationTarget
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.pipeline.views.base import ApiPipelineSteps, PipelineView
-from sentry.pipeline.views.nested import NestedPipelineView
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.utils.http import absolute_uri
 
@@ -461,20 +459,8 @@ class SlackIntegrationProvider(IntegrationProvider):
     setup_dialog_config = {"width": 600, "height": 900}
     setup_url_path = "/extensions/slack/setup/"
 
-    def _identity_pipeline_view(self) -> PipelineView[IntegrationPipeline]:
-        return NestedPipelineView(
-            bind_key="identity",
-            provider_key=IntegrationProviderSlug.SLACK.value,
-            pipeline_cls=IdentityPipeline,
-            config={
-                "oauth_scopes": self._get_oauth_scopes(),
-                "user_scopes": self.user_scopes,
-                "redirect_url": absolute_uri(self.setup_url_path),
-            },
-        )
-
-    def get_pipeline_views(self) -> Sequence[PipelineView[IntegrationPipeline]]:
-        return [self._identity_pipeline_view()]
+    def get_pipeline_views(self) -> list[PipelineView[IntegrationPipeline]]:
+        return []
 
     def _make_identity_provider(self) -> SlackIdentityProvider:
         return SlackIdentityProvider(
@@ -505,13 +491,7 @@ class SlackIntegrationProvider(IntegrationProvider):
             raise IntegrationError("Could not retrieve Slack team information.")
 
     def build_integration(self, state: Mapping[str, Any]) -> IntegrationData:
-        # TODO: legacy views write token data to state["identity"]["data"] via
-        # NestedPipelineView. API steps write directly to state["oauth_data"].
-        # Remove the legacy path once the old views are retired.
-        if "oauth_data" in state:
-            data = state["oauth_data"]
-        else:
-            data = state["identity"]["data"]
+        data = state["oauth_data"]
         assert data["ok"]
 
         access_token = data["access_token"]

--- a/src/sentry/integrations/slack/staging/integration.py
+++ b/src/sentry/integrations/slack/staging/integration.py
@@ -4,16 +4,12 @@ import logging
 from collections.abc import Mapping
 from typing import Any
 
-from sentry.identity.pipeline import IdentityPipeline
 from sentry.identity.slack.provider import SlackStagingIdentityProvider
 from sentry.integrations.base import (
     IntegrationData,
 )
-from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.slack.integration import SlackIntegrationProvider
 from sentry.integrations.types import IntegrationProviderSlug
-from sentry.pipeline.views.base import PipelineView
-from sentry.pipeline.views.nested import NestedPipelineView
 from sentry.utils.http import absolute_uri
 
 _logger = logging.getLogger("sentry.integrations.slack")
@@ -32,18 +28,6 @@ class SlackStagingIntegrationProvider(SlackIntegrationProvider):
         return SlackStagingIdentityProvider(
             oauth_scopes=self._get_oauth_scopes(),
             redirect_url=absolute_uri(self.setup_url_path),
-        )
-
-    def _identity_pipeline_view(self) -> PipelineView[IntegrationPipeline]:
-        return NestedPipelineView(
-            bind_key="identity",
-            provider_key=IntegrationProviderSlug.SLACK_STAGING.value,
-            pipeline_cls=IdentityPipeline,
-            config={
-                "oauth_scopes": self._get_oauth_scopes(),
-                "user_scopes": self.user_scopes,
-                "redirect_url": absolute_uri(self.setup_url_path),
-            },
         )
 
     def build_integration(self, state: Mapping[str, Any]) -> IntegrationData:

--- a/tests/sentry/integrations/slack/staging/test_feature_flag.py
+++ b/tests/sentry/integrations/slack/staging/test_feature_flag.py
@@ -1,4 +1,7 @@
-from sentry.testutils.cases import APITestCase, TestCase
+from django.urls import reverse
+
+from sentry.integrations.pipeline import IntegrationPipeline
+from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import control_silo_test
 
 
@@ -24,22 +27,34 @@ class SlackStagingConfigVisibilityTest(APITestCase):
 
 
 @control_silo_test
-class SlackStagingSetupAccessTest(TestCase):
+class SlackStagingSetupAccessTest(APITestCase):
     """Test that the slack-staging install flow is gated by the feature flag."""
+
+    endpoint = "sentry-api-0-organization-pipeline"
 
     def setUp(self) -> None:
         super().setUp()
-        self.organization = self.create_organization(name="test", owner=self.user)
         self.login_as(self.user)
-        self.path = f"/organizations/{self.organization.slug}/integrations/slack_staging/setup/"
+        self.pipeline_url = reverse(
+            self.endpoint,
+            args=[self.organization.slug, IntegrationPipeline.pipeline_name],
+        )
 
     def test_setup_blocked_without_flag(self) -> None:
-        resp = self.client.get(self.path)
+        resp = self.client.post(
+            self.pipeline_url,
+            data={"action": "initialize", "provider": "slack_staging"},
+            content_type="application/json",
+        )
         assert resp.status_code == 404
 
     def test_setup_allowed_with_flag(self) -> None:
         with self.feature("organizations:integrations-slack-staging"):
-            resp = self.client.get(self.path)
-        # 302 to Slack OAuth is the expected behavior for a valid setup flow
-        assert resp.status_code == 302
-        assert "slack.com/oauth" in resp["Location"]
+            resp = self.client.post(
+                self.pipeline_url,
+                data={"action": "initialize", "provider": "slack_staging"},
+                content_type="application/json",
+            )
+        assert resp.status_code == 200
+        assert resp.data["step"] == "oauth_login"
+        assert "slack.com/oauth" in resp.data["data"]["oauthUrl"]

--- a/tests/sentry/integrations/slack/test_integration.py
+++ b/tests/sentry/integrations/slack/test_integration.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 from unittest.mock import MagicMock, patch
-from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.parse import parse_qs, urlparse
 
 import orjson
 import pytest
@@ -12,14 +12,12 @@ from responses.matchers import query_string_matcher
 from slack_sdk.errors import SlackApiError
 from slack_sdk.web import SlackResponse
 
-from sentry import audit_log
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.slack import SlackIntegration, SlackIntegrationProvider
 from sentry.integrations.slack.utils.constants import SlackScope
 from sentry.integrations.slack.utils.users import SLACK_GET_USERS_PAGE_SIZE
-from sentry.models.auditlogentry import AuditLogEntry
 from sentry.notifications.platform.slack.provider import SlackNotificationProvider
 from sentry.notifications.platform.target import IntegrationNotificationTarget
 from sentry.notifications.platform.types import (
@@ -28,228 +26,10 @@ from sentry.notifications.platform.types import (
     NotificationTargetResourceType,
 )
 from sentry.shared_integrations.exceptions import IntegrationConfigurationError, IntegrationError
-from sentry.testutils.cases import APITestCase, IntegrationTestCase, TestCase
+from sentry.testutils.cases import APITestCase, TestCase
 from sentry.testutils.notifications.platform import MockNotification, MockNotificationTemplate
 from sentry.testutils.silo import control_silo_test
-from sentry.users.models.identity import Identity, IdentityProvider, IdentityStatus
-
-
-@control_silo_test
-@patch(
-    "slack_sdk.web.client.WebClient._perform_urllib_http_request",
-    return_value={
-        "body": orjson.dumps(
-            {
-                "ok": True,
-                "team": {
-                    "domain": "test-slack-workspace",
-                    "icon": {"image_132": "http://example.com/ws_icon.jpg"},
-                },
-            }
-        ).decode(),
-        "headers": {},
-        "status": 200,
-    },
-)
-class SlackIntegrationTest(IntegrationTestCase):
-    provider = SlackIntegrationProvider
-
-    def setUp(self) -> None:
-        super().setUp()
-
-    def assert_setup_flow(
-        self,
-        team_id="TXXXXXXX1",
-        authorizing_user_id="UXXXXXXX1",
-        expected_client_id="slack-client-id",
-        expected_client_secret="slack-client-secret",
-        customer_domain=None,
-    ):
-        responses.reset()
-
-        kwargs = {}
-        if customer_domain:
-            kwargs["HTTP_HOST"] = customer_domain
-
-        resp = self.client.get(self.init_path, **kwargs)
-        assert resp.status_code == 302
-        redirect = urlparse(resp["Location"])
-        assert redirect.scheme == "https"
-        assert redirect.netloc == "slack.com"
-        assert redirect.path == "/oauth/v2/authorize"
-        params = parse_qs(redirect.query)
-        scopes = self.provider.identity_oauth_scopes
-        assert params["scope"] == [" ".join(scopes)]
-        assert params["state"]
-        assert params["redirect_uri"] == ["http://testserver/extensions/slack/setup/"]
-        assert params["response_type"] == ["code"]
-        assert params["client_id"] == [expected_client_id]
-
-        assert params.get("user_scope") == [" ".join(self.provider.user_scopes)]
-        # once we've asserted on it, switch to a singular values to make life
-        # easier
-        authorize_params = {k: v[0] for k, v in params.items()}
-
-        access_json = {
-            "ok": True,
-            "access_token": "xoxb-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx",
-            "scope": ",".join(sorted(self.provider.identity_oauth_scopes)),
-            "team": {"id": team_id, "name": "Example"},
-            "authed_user": {"id": authorizing_user_id},
-        }
-        responses.add(responses.POST, "https://slack.com/api/oauth.v2.access", json=access_json)
-
-        response_json = {
-            "ok": True,
-            "members": [
-                {
-                    "id": authorizing_user_id,
-                    "team_id": team_id,
-                    "deleted": False,
-                    "profile": {
-                        "email": self.user.email,
-                        "team": team_id,
-                    },
-                },
-            ],
-            "response_metadata": {"next_cursor": ""},
-        }
-        with patch(
-            "slack_sdk.web.client.WebClient.users_list",
-            return_value=SlackResponse(
-                client=None,
-                http_verb="GET",
-                api_url="https://slack.com/api/users.list",
-                req_args={},
-                data=response_json,
-                headers={},
-                status_code=200,
-            ),
-        ) as self.mock_post:
-            resp = self.client.get(
-                "{}?{}".format(
-                    self.setup_path,
-                    urlencode({"code": "oauth-code", "state": authorize_params["state"]}),
-                )
-            )
-
-            if customer_domain:
-                assert resp.status_code == 302
-                assert resp["Location"].startswith(
-                    f"http://{customer_domain}/extensions/slack/setup/"
-                )
-                resp = self.client.get(resp["Location"], **kwargs)
-
-        mock_request = responses.calls[0].request
-        req_params = parse_qs(mock_request.body)
-        assert req_params["grant_type"] == ["authorization_code"]
-        assert req_params["code"] == ["oauth-code"]
-        assert req_params["redirect_uri"] == ["http://testserver/extensions/slack/setup/"]
-        assert req_params["client_id"] == [expected_client_id]
-        assert req_params["client_secret"] == [expected_client_secret]
-
-        assert resp.status_code == 200
-        self.assertDialogSuccess(resp)
-
-    @responses.activate
-    def test_bot_flow(self, mock_api_call: MagicMock) -> None:
-        with self.tasks():
-            self.assert_setup_flow()
-
-        integration = Integration.objects.get(provider=self.provider.key)
-        assert integration.external_id == "TXXXXXXX1"
-        assert integration.name == "Example"
-        assert integration.metadata == {
-            "access_token": "xoxb-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx",
-            "scopes": sorted(self.provider.identity_oauth_scopes),
-            "icon": "http://example.com/ws_icon.jpg",
-            "domain_name": "test-slack-workspace.slack.com",
-            "installation_type": "born_as_bot",
-        }
-        oi = OrganizationIntegration.objects.get(
-            integration=integration, organization_id=self.organization.id
-        )
-        assert oi.config == {}
-
-        idp = IdentityProvider.objects.get(type="slack", external_id="TXXXXXXX1")
-        identity = Identity.objects.get(idp=idp, user=self.user, external_id="UXXXXXXX1")
-        assert identity.status == IdentityStatus.VALID
-
-        audit_entry = AuditLogEntry.objects.get(event=audit_log.get_event_id("INTEGRATION_ADD"))
-        audit_log_event = audit_log.get(audit_entry.event)
-        assert audit_log_event.render(audit_entry) == "installed Example for the slack integration"
-
-    @responses.activate
-    def test_bot_flow_customer_domains(self, mock_api_call: MagicMock) -> None:
-        with self.tasks():
-            self.assert_setup_flow(customer_domain=f"{self.organization.slug}.testserver")
-
-        integration = Integration.objects.get(provider=self.provider.key)
-        assert integration.external_id == "TXXXXXXX1"
-        assert integration.name == "Example"
-        assert integration.metadata == {
-            "access_token": "xoxb-xxxxxxxxx-xxxxxxxxxx-xxxxxxxxxxxx",
-            "scopes": sorted(self.provider.identity_oauth_scopes),
-            "icon": "http://example.com/ws_icon.jpg",
-            "domain_name": "test-slack-workspace.slack.com",
-            "installation_type": "born_as_bot",
-        }
-        oi = OrganizationIntegration.objects.get(
-            integration=integration, organization_id=self.organization.id
-        )
-        assert oi.config == {}
-
-        idp = IdentityProvider.objects.get(type="slack", external_id="TXXXXXXX1")
-        identity = Identity.objects.get(idp=idp, user=self.user, external_id="UXXXXXXX1")
-        assert identity.status == IdentityStatus.VALID
-
-        audit_entry = AuditLogEntry.objects.get(event=audit_log.get_event_id("INTEGRATION_ADD"))
-        audit_log_event = audit_log.get(audit_entry.event)
-        assert audit_log_event.render(audit_entry) == "installed Example for the slack integration"
-
-    @responses.activate
-    def test_multiple_integrations(self, mock_api_call: MagicMock) -> None:
-        with self.tasks():
-            self.assert_setup_flow()
-        with self.tasks():
-            self.assert_setup_flow(team_id="TXXXXXXX2", authorizing_user_id="UXXXXXXX2")
-
-        integrations = Integration.objects.filter(provider=self.provider.key).order_by(
-            "external_id"
-        )
-
-        assert integrations.count() == 2
-        assert integrations[0].external_id == "TXXXXXXX1"
-        assert integrations[1].external_id == "TXXXXXXX2"
-
-        oi = OrganizationIntegration.objects.get(
-            integration=integrations[1], organization_id=self.organization.id
-        )
-        assert oi.config == {}
-
-        idps = IdentityProvider.objects.filter(type="slack")
-
-        assert idps.count() == 2
-
-        identities = Identity.objects.all()
-
-        assert identities.count() == 2
-        assert identities[0].external_id != identities[1].external_id
-        assert identities[0].idp != identities[1].idp
-
-    @responses.activate
-    def test_reassign_user(self, mock_api_call: MagicMock) -> None:
-        """Test that when you install and then later re-install and the user who installs it
-        has a different external ID, their Identity is updated to reflect that
-        """
-        with self.tasks():
-            self.assert_setup_flow()
-        identity = Identity.objects.get()
-        assert identity.external_id == "UXXXXXXX1"
-        with self.tasks():
-            self.assert_setup_flow(authorizing_user_id="UXXXXXXX2")
-        identity = Identity.objects.get()
-        assert identity.external_id == "UXXXXXXX2"
+from sentry.users.models.identity import Identity, IdentityStatus
 
 
 @patch("slack_sdk.web.client.WebClient._perform_urllib_http_request")


### PR DESCRIPTION
The Slack integration now uses the API-driven pipeline exclusively.
Remove the old view-based pipeline step (_identity_pipeline_view with
NestedPipelineView), the legacy state["identity"]["data"] fallback in
build_integration, the staging override, and the SlackIntegrationTest
class that tested the legacy flow.

Refs [VDY-59](https://linear.app/getsentry/issue/VDY-59/remove-legacy-slack-integration-setup-views)