### PR TITLE
ref(discord): Remove legacy pipeline views

### DIFF
--- a/src/sentry/integrations/discord/integration.py
+++ b/src/sentry/integrations/discord/integration.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from typing import Any
 from urllib.parse import urlencode
 
-from django.http import HttpResponseRedirect
 from django.http.request import HttpRequest
-from django.http.response import HttpResponseBase
 from django.utils.translation import gettext_lazy as _
 from rest_framework.fields import CharField
 
@@ -234,8 +232,8 @@ class DiscordIntegrationProvider(IntegrationProvider):
         self.configure_url = absolute_uri("extensions/discord/configure/")
         super().__init__()
 
-    def get_pipeline_views(self) -> Sequence[PipelineView[IntegrationPipeline]]:
-        return [DiscordInstallPipeline(self.get_params_for_oauth())]
+    def get_pipeline_views(self) -> list[PipelineView[IntegrationPipeline]]:
+        return []
 
     def get_pipeline_api_steps(self) -> ApiPipelineSteps[IntegrationPipeline]:
         return [
@@ -351,16 +349,6 @@ class DiscordIntegrationProvider(IntegrationProvider):
             raise IntegrationError("Failed to get Discord user ID from key.")
         return user_id
 
-    def get_params_for_oauth(
-        self,
-    ):
-        return {
-            "client_id": self.application_id,
-            "permissions": self.bot_permissions,
-            "scope": " ".join(self.oauth_scopes),
-            "response_type": "code",
-        }
-
     def _credentials_exist(self) -> bool:
         has_credentials = all(
             (self.application_id, self.public_key, self.bot_token, self.client_secret)
@@ -376,30 +364,3 @@ class DiscordIntegrationProvider(IntegrationProvider):
                 },
             )
         return has_credentials
-
-
-class DiscordInstallPipeline:
-    def __init__(self, params):
-        self.params = params
-        super().__init__()
-
-    def dispatch(self, request: HttpRequest, pipeline: IntegrationPipeline) -> HttpResponseBase:
-        if "guild_id" not in request.GET or "code" not in request.GET:
-            state = pipeline.fetch_state(key=IntegrationProviderSlug.DISCORD.value) or {}
-            redirect_uri = (
-                absolute_uri("extensions/discord/configure/")
-                if state.get("use_configure") == "1"
-                else absolute_uri("extensions/discord/setup/")
-            )
-            params = urlencode(
-                {
-                    "redirect_uri": redirect_uri,
-                    **self.params,
-                }
-            )
-            redirect_uri = f"https://discord.com/api/oauth2/authorize?{params}"
-            return HttpResponseRedirect(redirect_uri)
-
-        pipeline.bind_state("guild_id", request.GET["guild_id"])
-        pipeline.bind_state("code", request.GET["code"])
-        return pipeline.next_step()

--- a/tests/sentry/integrations/discord/test_integration.py
+++ b/tests/sentry/integrations/discord/test_integration.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from typing import Any
 from unittest import mock
-from urllib.parse import parse_qs, urlencode, urlparse
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 import responses
 from django.urls import reverse
-from responses.matchers import header_matcher, json_params_matcher
+from responses.matchers import header_matcher
 
-from sentry import audit_log, options
+from sentry import options
 from sentry.integrations.discord.client import (
     APPLICATION_COMMANDS_URL,
     DISCORD_BASE_URL,
@@ -24,7 +24,6 @@ from sentry.integrations.discord.integration import (
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.pipeline import IntegrationPipeline
-from sentry.models.auditlogentry import AuditLogEntry
 from sentry.notifications.platform.discord.provider import DiscordRenderable
 from sentry.notifications.platform.target import IntegrationNotificationTarget
 from sentry.notifications.platform.types import (
@@ -41,7 +40,7 @@ from sentry.testutils.silo import control_silo_test
 from sentry.utils import json
 
 
-class DiscordSetupTestCase(IntegrationTestCase):
+class DiscordIntegrationTest(IntegrationTestCase):
     provider = DiscordIntegrationProvider
 
     def setUp(self) -> None:
@@ -55,229 +54,6 @@ class DiscordSetupTestCase(IntegrationTestCase):
         options.set("discord.bot-token", self.bot_token)
         options.set("discord.client-secret", self.client_secret)
         self.token_url = f"{DISCORD_BASE_URL}/oauth2/token"
-
-    @mock.patch("sentry.integrations.discord.client.DiscordClient.set_application_command")
-    def assert_setup_flow(
-        self,
-        mock_set_application_command: mock.MagicMock,
-        guild_id: str = "1234567890",
-        server_name: str = "Cool server",
-        auth_code: str = "auth_code",
-        command_response_empty: bool = True,
-    ) -> None:
-        responses.reset()
-
-        resp = self.client.get(self.init_path)
-        assert resp.status_code == 302
-        redirect = urlparse(resp["Location"])
-        assert redirect.scheme == "https"
-        assert redirect.netloc == "discord.com"
-        assert redirect.path == "/api/oauth2/authorize"
-        params = parse_qs(redirect.query)
-        assert params["client_id"] == [self.application_id]
-        assert params["permissions"] == [str(self.provider.bot_permissions)]
-        assert params["redirect_uri"] == ["http://testserver/extensions/discord/setup/"]
-        assert params["response_type"] == ["code"]
-        scopes = self.provider.oauth_scopes
-        assert params["scope"] == [" ".join(scopes)]
-
-        responses.add(
-            responses.GET,
-            url=f"{DiscordClient.base_url}{GUILD_URL.format(guild_id=guild_id)}",
-            match=[header_matcher({"Authorization": f"Bot {self.bot_token}"})],
-            json={
-                "id": guild_id,
-                "name": server_name,
-            },
-        )
-
-        responses.add(
-            responses.GET,
-            url=f"{DiscordClient.base_url}{APPLICATION_COMMANDS_URL.format(application_id=self.application_id)}",
-            match=[header_matcher({"Authorization": f"Bot {self.bot_token}"})],
-            json=[] if command_response_empty else COMMANDS,
-        )
-
-        responses.add(
-            responses.GET,
-            url=f"{DiscordClient.base_url}/users/@me/guilds/{guild_id}/member",
-            json={},
-        )
-
-        if command_response_empty:
-            for command in COMMANDS:
-                responses.add(
-                    responses.POST,
-                    url=f"{DiscordClient.base_url}{APPLICATION_COMMANDS_URL.format(application_id=self.application_id)}",
-                    match=[
-                        header_matcher({"Authorization": f"Bot {self.bot_token}"}),
-                        json_params_matcher({"data": command}),
-                    ],
-                )
-
-        responses.add(
-            responses.POST,
-            url=self.token_url,
-            json={
-                "access_token": "access_token",
-            },
-        )
-        responses.add(
-            responses.GET, url=f"{DiscordClient.base_url}/users/@me", json={"id": "user_1234"}
-        )
-
-        resp = self.client.get(
-            "{}?{}".format(
-                self.setup_path,
-                urlencode({"guild_id": guild_id, "code": auth_code}),
-            )
-        )
-
-        call_list = responses.calls
-        assert call_list[0].request.headers["Authorization"] == f"Bot {self.bot_token}"
-        assert f"code={auth_code}" in call_list[1].request.body
-        assert call_list[2].request.headers["Authorization"] == "Bearer access_token"
-
-        assert resp.status_code == 200
-        self.assertDialogSuccess(resp)
-
-        if command_response_empty:
-            assert mock_set_application_command.call_count == 3
-        else:
-            assert mock_set_application_command.call_count == 0
-
-    def assert_setup_flow_from_discord(
-        self,
-        guild_id: str = "1234567890",
-        server_name: str = "Cool server",
-        auth_code: str = "auth_code",
-    ) -> None:
-        responses.reset()
-
-        resp = self.client.get(self.configure_path)
-        assert resp.status_code == 302
-        redirect = urlparse(resp["Location"])
-        assert redirect.scheme == "https"
-        assert redirect.netloc == "discord.com"
-        assert redirect.path == "/api/oauth2/authorize"
-        params = parse_qs(redirect.query)
-        assert params["client_id"] == [self.application_id]
-        assert params["permissions"] == [str(self.provider.bot_permissions)]
-        assert params["redirect_uri"] == ["http://testserver/extensions/discord/configure/"]
-        assert params["response_type"] == ["code"]
-        scopes = self.provider.oauth_scopes
-        assert params["scope"] == [" ".join(scopes)]
-
-        responses.add(
-            responses.GET,
-            url=f"{DiscordClient.base_url}{GUILD_URL.format(guild_id=guild_id)}",
-            match=[header_matcher({"Authorization": f"Bot {self.bot_token}"})],
-            json={
-                "id": guild_id,
-                "name": server_name,
-            },
-        )
-
-        responses.add(
-            responses.GET,
-            url=f"{DiscordClient.base_url}{APPLICATION_COMMANDS_URL.format(application_id=self.application_id)}",
-            match=[header_matcher({"Authorization": f"Bot {self.bot_token}"})],
-            json=COMMANDS,
-        )
-
-        responses.add(
-            responses.POST,
-            url=self.token_url,
-            json={
-                "access_token": "access_token",
-            },
-        )
-
-        responses.add(
-            responses.GET,
-            url=f"{DiscordClient.base_url}/users/@me/guilds/{guild_id}/member",
-            json={},
-        )
-
-        responses.add(
-            responses.GET, url=f"{DiscordClient.base_url}/users/@me", json={"id": "user_1234"}
-        )
-
-        resp = self.client.get(
-            "{}?{}".format(
-                self.setup_path,
-                urlencode({"guild_id": guild_id, "code": auth_code}),
-            )
-        )
-
-        call_list = responses.calls
-        assert call_list[0].request.headers["Authorization"] == f"Bot {self.bot_token}"
-        assert f"code={auth_code}" in call_list[1].request.body
-        assert call_list[2].request.headers["Authorization"] == "Bearer access_token"
-
-        assert resp.status_code == 200
-        self.assertDialogSuccess(resp)
-
-
-@control_silo_test
-class DiscordSetupIntegrationTest(DiscordSetupTestCase):
-    @responses.activate
-    def test_bot_flow(self) -> None:
-        with self.tasks():
-            self.assert_setup_flow()
-
-        integration = Integration.objects.get(provider=self.provider.key)
-        assert integration.external_id == "1234567890"
-        assert integration.name == "Cool server"
-
-        audit_entry = AuditLogEntry.objects.get(event=audit_log.get_event_id("INTEGRATION_ADD"))
-        audit_log_event = audit_log.get(audit_entry.event)
-        assert (
-            audit_log_event.render(audit_entry)
-            == "installed Cool server for the discord integration"
-        )
-
-    @responses.activate
-    def test_bot_flow_from_discord(self) -> None:
-        with self.tasks():
-            self.assert_setup_flow_from_discord()
-
-        integration = Integration.objects.get(provider=self.provider.key)
-        assert integration.external_id == "1234567890"
-        assert integration.name == "Cool server"
-
-        audit_entry = AuditLogEntry.objects.get(event=audit_log.get_event_id("INTEGRATION_ADD"))
-        audit_log_event = audit_log.get(audit_entry.event)
-        assert (
-            audit_log_event.render(audit_entry)
-            == "installed Cool server for the discord integration"
-        )
-
-    @responses.activate
-    def test_multiple_integrations(self) -> None:
-        with self.tasks():
-            self.assert_setup_flow()
-        with self.tasks():
-            self.assert_setup_flow(
-                guild_id="0987654321",
-                server_name="Uncool server",
-                command_response_empty=False,
-            )
-
-        integrations = Integration.objects.filter(provider=self.provider.key).order_by(
-            "external_id"
-        )
-
-        assert integrations.count() == 2
-        assert integrations[0].external_id == "0987654321"
-        assert integrations[0].name == "Uncool server"
-        assert integrations[1].external_id == "1234567890"
-        assert integrations[1].name == "Cool server"
-
-
-class DiscordIntegrationTest(DiscordSetupTestCase):
-    def setUp(self) -> None:
-        super().setUp()
         self.user_id = "user1234"
         self.guild_id = "12345"
         self.guild_name = "guild_name"


### PR DESCRIPTION
The Discord integration now uses the API-driven pipeline exclusively.
Remove the old view-based pipeline step (DiscordInstallPipeline),
get_params_for_oauth helper, and the DiscordSetupTestCase/
DiscordSetupIntegrationTest classes that tested the legacy flow.

Refs [VDY-32](https://linear.app/getsentry/issue/VDY-32/migrate-integration-setup-pipelines-to-api-driven-flows)