### PR TITLE
feat(integrations): Route Claude Code and Cursor through API pipeline modal

### DIFF
--- a/static/app/utils/integrations/useAddIntegration.tsx
+++ b/static/app/utils/integrations/useAddIntegration.tsx
@@ -41,6 +41,8 @@ export interface AddIntegrationParams {
 const UNCONDITIONAL_API_PIPELINE_PROVIDERS = [
   'aws_lambda',
   'bitbucket',
+  'claude_code',
+  'cursor',
   'discord',
   'github',
   'gitlab',


### PR DESCRIPTION
Add claude_code and cursor to UNCONDITIONAL_API_PIPELINE_PROVIDERS so
clicking "Add Agent" on their integration detail pages opens the
API-driven pipeline modal instead of falling through to the legacy
window.open() popup flow.

Both providers already have pipeline definitions registered in the
frontend pipeline registry and API steps on the backend — they just
weren't listed in useAddIntegration's provider allowlist.

Fixes [VDY-91](https://linear.app/getsentry/issue/VDY-91)
Fixes [VDY-92](https://linear.app/getsentry/issue/VDY-92)