### PR TITLE
feat(preprod): Add snapshot and approval search filters

### DIFF
--- a/src/sentry/preprod/artifact_search.py
+++ b/src/sentry/preprod/artifact_search.py
@@ -132,17 +132,6 @@ FIELD_MAPPINGS: dict[str, str] = {
     "size_state": "preprodartifactsizemetrics__state",
 }
 
-IMAGE_COMPARISON_KEYS: frozenset[str] = frozenset(
-    {
-        "images_added",
-        "images_changed",
-        "images_removed",
-        "images_renamed",
-        "images_skipped",
-        "images_unchanged",
-    }
-)
-
 SIZE_STATE_VALUES: dict[str, int] = {
     member.name.lower(): member.value for member in PreprodArtifactSizeMetrics.SizeAnalysisState
 }
@@ -172,6 +161,16 @@ def _translate_size_state(value: object) -> int:
     return SIZE_STATE_VALUES[raw]
 
 
+def _base_searchable_queryset() -> PreprodArtifactQuerySet:
+    return (
+        PreprodArtifact.objects.get_queryset()
+        .annotate_download_count()
+        .annotate_installable()
+        .annotate_main_size_metrics()
+        .annotate_platform_name()
+    )
+
+
 def queryset_for_query(
     query: str,
     organization: Organization,
@@ -192,14 +191,8 @@ def queryset_for_query(
     Raises:
         InvalidSearchQuery: If the query string is invalid
     """
-    queryset = PreprodArtifact.objects.get_queryset()
-    queryset = queryset.annotate_download_count()
-    queryset = queryset.annotate_installable()
-    queryset = queryset.annotate_main_size_metrics()
-    queryset = queryset.annotate_platform_name()
-
     search_filters = parse_search_query(query, config=search_config, get_field_type=get_field_type)
-    return apply_filters(queryset, search_filters, organization)
+    return apply_filters(_base_searchable_queryset(), search_filters, organization)
 
 
 def artifact_in_queryset(
@@ -304,7 +297,6 @@ def apply_filters(
                 queryset = queryset.exclude(q)
             else:
                 queryset = queryset.filter(q)
-            queryset = queryset.distinct()
             continue
 
         if name == "distribution_error_code":
@@ -351,16 +343,7 @@ def apply_filters(
         elif token.operator == "!=" and token.value.value == "":
             # !has: filter
             q = Q(**{f"{db_field}__isnull": False})
-        elif token.operator == "=":
-            q = Q(**{f"{db_field}__exact": token.value.value})
-        elif token.operator == "!=" and name in IMAGE_COMPARISON_KEYS:
-            q = Q(**{f"{db_field}__gt": token.value.value}) | Q(
-                **{f"{db_field}__lt": token.value.value}
-            )
-            queryset = queryset.filter(q).distinct()
-            continue
-        elif token.operator == "!=":
-            # Negation handled below (is_negation handles !=)
+        elif token.operator in ("=", "!="):
             q = Q(**{f"{db_field}__exact": token.value.value})
         else:
             raise InvalidSearchQuery(f"Unknown operator {token.operator}.")
@@ -368,9 +351,7 @@ def apply_filters(
         if token.is_negation or token.operator == "!~":
             q = ~q
         queryset = queryset.filter(q)
-        if name in IMAGE_COMPARISON_KEYS:
-            queryset = queryset.distinct()
-    return queryset
+    return queryset.distinct()
 
 
 def get_sequential_base_artifact(
@@ -394,11 +375,7 @@ def get_sequential_base_artifact(
     Returns:
         The most recent prior PreprodArtifact matching the criteria, or None.
     """
-    queryset = PreprodArtifact.objects.get_queryset()
-    queryset = queryset.annotate_download_count()
-    queryset = queryset.annotate_installable()
-    queryset = queryset.annotate_main_size_metrics()
-    queryset = queryset.annotate_platform_name()
+    queryset = _base_searchable_queryset()
 
     if query and query.strip():
         search_filters = parse_search_query(

--- a/src/sentry/preprod/artifact_search.py
+++ b/src/sentry/preprod/artifact_search.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
-from django.db.models import Q
+from django.db.models import Exists, OuterRef, Q
 
 from sentry.api.event_search import (
     AggregateFilter,
@@ -19,6 +19,7 @@ from sentry.preprod.models import (
     PreprodArtifact,
     PreprodArtifactQuerySet,
     PreprodArtifactSizeMetrics,
+    PreprodComparisonApproval,
 )
 
 search_config = SearchConfig.create_from(
@@ -39,6 +40,13 @@ search_config = SearchConfig.create_from(
         "download_count",
         "download_size",
         "git_pr_number",
+        "image_count",
+        "images_added",
+        "images_changed",
+        "images_removed",
+        "images_renamed",
+        "images_skipped",
+        "images_unchanged",
         "install_size",
         "state",
     },
@@ -48,6 +56,7 @@ search_config = SearchConfig.create_from(
     key_mappings={},
     boolean_keys={
         "installable",
+        "is_approved",
     },
     # Allowed search keys
     allowed_keys={
@@ -65,9 +74,17 @@ search_config = SearchConfig.create_from(
         "git_head_sha",
         "git_pr_number",
         "has",
+        "image_count",
+        "images_added",
+        "images_changed",
+        "images_removed",
+        "images_renamed",
+        "images_skipped",
+        "images_unchanged",
         "install_size",
         "installable",
         "is",
+        "is_approved",
         "platform_name",
         "size_state",
         "state",
@@ -105,8 +122,26 @@ FIELD_MAPPINGS: dict[str, str] = {
     "git_head_sha": "commit_comparison__head_sha",
     "git_pr_number": "commit_comparison__pr_number",
     "distribution_error_code": "installable_app_error_code",
+    "image_count": "preprodsnapshotmetrics__image_count",
+    "images_added": "preprodsnapshotmetrics__snapshot_comparisons_head_metrics__images_added",
+    "images_changed": "preprodsnapshotmetrics__snapshot_comparisons_head_metrics__images_changed",
+    "images_removed": "preprodsnapshotmetrics__snapshot_comparisons_head_metrics__images_removed",
+    "images_renamed": "preprodsnapshotmetrics__snapshot_comparisons_head_metrics__images_renamed",
+    "images_skipped": "preprodsnapshotmetrics__snapshot_comparisons_head_metrics__images_skipped",
+    "images_unchanged": "preprodsnapshotmetrics__snapshot_comparisons_head_metrics__images_unchanged",
     "size_state": "preprodartifactsizemetrics__state",
 }
+
+IMAGE_COMPARISON_KEYS: frozenset[str] = frozenset(
+    {
+        "images_added",
+        "images_changed",
+        "images_removed",
+        "images_renamed",
+        "images_skipped",
+        "images_unchanged",
+    }
+)
 
 SIZE_STATE_VALUES: dict[str, int] = {
     member.name.lower(): member.value for member in PreprodArtifactSizeMetrics.SizeAnalysisState
@@ -281,6 +316,19 @@ def apply_filters(
                 queryset = queryset.filter(q)
             continue
 
+        if name == "is_approved":
+            approved_exists = PreprodComparisonApproval.objects.filter(
+                preprod_artifact=OuterRef("pk"),
+                preprod_feature_type=PreprodComparisonApproval.FeatureType.SNAPSHOTS,
+                approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
+            )
+            want_approved = bool(token.value.value) ^ token.is_negation
+            if want_approved:
+                queryset = queryset.filter(Exists(approved_exists))
+            else:
+                queryset = queryset.filter(~Exists(approved_exists))
+            continue
+
         # We don't have to handle boolean operators or parens here
         # since allow_boolean is not set in SearchConfig.
         if token.is_in_filter:
@@ -305,6 +353,12 @@ def apply_filters(
             q = Q(**{f"{db_field}__isnull": False})
         elif token.operator == "=":
             q = Q(**{f"{db_field}__exact": token.value.value})
+        elif token.operator == "!=" and name in IMAGE_COMPARISON_KEYS:
+            q = Q(**{f"{db_field}__gt": token.value.value}) | Q(
+                **{f"{db_field}__lt": token.value.value}
+            )
+            queryset = queryset.filter(q).distinct()
+            continue
         elif token.operator == "!=":
             # Negation handled below (is_negation handles !=)
             q = Q(**{f"{db_field}__exact": token.value.value})
@@ -314,6 +368,8 @@ def apply_filters(
         if token.is_negation or token.operator == "!~":
             q = ~q
         queryset = queryset.filter(q)
+        if name in IMAGE_COMPARISON_KEYS:
+            queryset = queryset.distinct()
     return queryset
 
 
@@ -339,6 +395,10 @@ def get_sequential_base_artifact(
         The most recent prior PreprodArtifact matching the criteria, or None.
     """
     queryset = PreprodArtifact.objects.get_queryset()
+    queryset = queryset.annotate_download_count()
+    queryset = queryset.annotate_installable()
+    queryset = queryset.annotate_main_size_metrics()
+    queryset = queryset.annotate_platform_name()
 
     if query and query.strip():
         search_filters = parse_search_query(

--- a/src/sentry/search/eap/preprod_size/attributes.py
+++ b/src/sentry/search/eap/preprod_size/attributes.py
@@ -64,46 +64,6 @@ PREPROD_SIZE_ATTRIBUTE_DEFINITIONS = {
             search_type="boolean",
         ),
         ResolvedAttribute(
-            public_alias="image_count",
-            internal_name="image_count",
-            search_type="number",
-        ),
-        ResolvedAttribute(
-            public_alias="images_added",
-            internal_name="images_added",
-            search_type="number",
-        ),
-        ResolvedAttribute(
-            public_alias="images_changed",
-            internal_name="images_changed",
-            search_type="number",
-        ),
-        ResolvedAttribute(
-            public_alias="images_removed",
-            internal_name="images_removed",
-            search_type="number",
-        ),
-        ResolvedAttribute(
-            public_alias="images_renamed",
-            internal_name="images_renamed",
-            search_type="number",
-        ),
-        ResolvedAttribute(
-            public_alias="images_skipped",
-            internal_name="images_skipped",
-            search_type="number",
-        ),
-        ResolvedAttribute(
-            public_alias="images_unchanged",
-            internal_name="images_unchanged",
-            search_type="number",
-        ),
-        ResolvedAttribute(
-            public_alias="is_approved",
-            internal_name="is_approved",
-            search_type="boolean",
-        ),
-        ResolvedAttribute(
             public_alias="timestamp",
             internal_name="sentry.timestamp",
             internal_type=constants.DOUBLE,

--- a/src/sentry/search/eap/preprod_size/attributes.py
+++ b/src/sentry/search/eap/preprod_size/attributes.py
@@ -64,6 +64,46 @@ PREPROD_SIZE_ATTRIBUTE_DEFINITIONS = {
             search_type="boolean",
         ),
         ResolvedAttribute(
+            public_alias="image_count",
+            internal_name="image_count",
+            search_type="number",
+        ),
+        ResolvedAttribute(
+            public_alias="images_added",
+            internal_name="images_added",
+            search_type="number",
+        ),
+        ResolvedAttribute(
+            public_alias="images_changed",
+            internal_name="images_changed",
+            search_type="number",
+        ),
+        ResolvedAttribute(
+            public_alias="images_removed",
+            internal_name="images_removed",
+            search_type="number",
+        ),
+        ResolvedAttribute(
+            public_alias="images_renamed",
+            internal_name="images_renamed",
+            search_type="number",
+        ),
+        ResolvedAttribute(
+            public_alias="images_skipped",
+            internal_name="images_skipped",
+            search_type="number",
+        ),
+        ResolvedAttribute(
+            public_alias="images_unchanged",
+            internal_name="images_unchanged",
+            search_type="number",
+        ),
+        ResolvedAttribute(
+            public_alias="is_approved",
+            internal_name="is_approved",
+            search_type="boolean",
+        ),
+        ResolvedAttribute(
             public_alias="timestamp",
             internal_name="sentry.timestamp",
             internal_type=constants.DOUBLE,

--- a/src/sentry/testutils/factories.py
+++ b/src/sentry/testutils/factories.py
@@ -141,6 +141,9 @@ from sentry.preprod.models import (
     PreprodArtifactSizeComparison,
     PreprodArtifactSizeMetrics,
     PreprodBuildConfiguration,
+    PreprodComparisonApproval,
+    PreprodSnapshotComparison,
+    PreprodSnapshotMetrics,
 )
 from sentry.sentry_apps.installations import (
     SentryAppInstallationCreator,
@@ -2559,6 +2562,61 @@ class Factories:
             error_code=error_code,
             error_message=error_message,
             analysis_file_id=analysis_file_id,
+        )
+
+    @staticmethod
+    @assume_test_silo_mode(SiloMode.CELL)
+    def create_preprod_snapshot_metrics(
+        preprod_artifact: PreprodArtifact,
+        image_count: int = 0,
+        is_selective: bool = False,
+    ) -> PreprodSnapshotMetrics:
+        return PreprodSnapshotMetrics.objects.create(
+            preprod_artifact=preprod_artifact,
+            image_count=image_count,
+            is_selective=is_selective,
+        )
+
+    @staticmethod
+    @assume_test_silo_mode(SiloMode.CELL)
+    def create_preprod_snapshot_comparison(
+        head_snapshot_metrics: PreprodSnapshotMetrics,
+        base_snapshot_metrics: PreprodSnapshotMetrics,
+        state: int = PreprodSnapshotComparison.State.SUCCESS,
+        images_added: int = 0,
+        images_removed: int = 0,
+        images_changed: int = 0,
+        images_unchanged: int = 0,
+        images_renamed: int = 0,
+        images_skipped: int = 0,
+    ) -> PreprodSnapshotComparison:
+        return PreprodSnapshotComparison.objects.create(
+            head_snapshot_metrics=head_snapshot_metrics,
+            base_snapshot_metrics=base_snapshot_metrics,
+            state=state,
+            images_added=images_added,
+            images_removed=images_removed,
+            images_changed=images_changed,
+            images_unchanged=images_unchanged,
+            images_renamed=images_renamed,
+            images_skipped=images_skipped,
+        )
+
+    @staticmethod
+    @assume_test_silo_mode(SiloMode.CELL)
+    def create_preprod_comparison_approval(
+        preprod_artifact: PreprodArtifact,
+        preprod_feature_type: int = PreprodComparisonApproval.FeatureType.SNAPSHOTS,
+        approval_status: int = PreprodComparisonApproval.ApprovalStatus.APPROVED,
+        approved_at: datetime | None = None,
+        approved_by_id: int | None = None,
+    ) -> PreprodComparisonApproval:
+        return PreprodComparisonApproval.objects.create(
+            preprod_artifact=preprod_artifact,
+            preprod_feature_type=preprod_feature_type,
+            approval_status=approval_status,
+            approved_at=approved_at,
+            approved_by_id=approved_by_id,
         )
 
     @staticmethod

--- a/src/sentry/testutils/fixtures.py
+++ b/src/sentry/testutils/fixtures.py
@@ -46,6 +46,9 @@ from sentry.preprod.models import (
     PreprodArtifactSizeComparison,
     PreprodArtifactSizeMetrics,
     PreprodBuildConfiguration,
+    PreprodComparisonApproval,
+    PreprodSnapshotComparison,
+    PreprodSnapshotMetrics,
 )
 from sentry.services.eventstore.models import Event
 from sentry.silo.base import SiloMode
@@ -952,6 +955,32 @@ class Fixtures:
             head_size_analysis=head_size_analysis,
             base_size_analysis=base_size_analysis,
             **kwargs,
+        )
+
+    def create_preprod_snapshot_metrics(
+        self, preprod_artifact: PreprodArtifact, **kwargs
+    ) -> PreprodSnapshotMetrics:
+        return Factories.create_preprod_snapshot_metrics(
+            preprod_artifact=preprod_artifact, **kwargs
+        )
+
+    def create_preprod_snapshot_comparison(
+        self,
+        head_snapshot_metrics: PreprodSnapshotMetrics,
+        base_snapshot_metrics: PreprodSnapshotMetrics,
+        **kwargs,
+    ) -> PreprodSnapshotComparison:
+        return Factories.create_preprod_snapshot_comparison(
+            head_snapshot_metrics=head_snapshot_metrics,
+            base_snapshot_metrics=base_snapshot_metrics,
+            **kwargs,
+        )
+
+    def create_preprod_comparison_approval(
+        self, preprod_artifact: PreprodArtifact, **kwargs
+    ) -> PreprodComparisonApproval:
+        return Factories.create_preprod_comparison_approval(
+            preprod_artifact=preprod_artifact, **kwargs
         )
 
     def create_preprod_build_configuration(

--- a/tests/sentry/preprod/api/endpoints/test_builds.py
+++ b/tests/sentry/preprod/api/endpoints/test_builds.py
@@ -4,7 +4,11 @@ import pytest
 from django.urls import reverse
 from django.utils.functional import cached_property
 
-from sentry.preprod.models import PreprodArtifact, PreprodArtifactSizeMetrics
+from sentry.preprod.models import (
+    PreprodArtifact,
+    PreprodArtifactSizeMetrics,
+    PreprodComparisonApproval,
+)
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.datetime import before_now
 
@@ -869,6 +873,62 @@ class BuildsEndpointTest(APITestCase):
         data = response.json()
         assert len(data) == 1
         assert data[0]["app_info"]["app_id"] == "recent.app"
+
+    def test_query_image_count(self) -> None:
+        matching_artifact = self.create_preprod_artifact(app_id="com.match.app")
+        self.create_preprod_snapshot_metrics(preprod_artifact=matching_artifact, image_count=25)
+        non_matching_artifact = self.create_preprod_artifact(app_id="com.nomatch.app")
+        self.create_preprod_snapshot_metrics(preprod_artifact=non_matching_artifact, image_count=3)
+
+        response = self._request({"display": "snapshot", "query": "image_count:>=20"})
+        self._assert_is_successful(response)
+        app_ids = {entry["app_info"]["app_id"] for entry in response.json()}
+        assert app_ids == {"com.match.app"}
+
+    def test_query_images_changed(self) -> None:
+        head_artifact = self.create_preprod_artifact(app_id="com.changed.app")
+        head_metrics = self.create_preprod_snapshot_metrics(
+            preprod_artifact=head_artifact, image_count=10
+        )
+        base_artifact = self.create_preprod_artifact(app_id="com.base.app")
+        base_metrics = self.create_preprod_snapshot_metrics(
+            preprod_artifact=base_artifact, image_count=10
+        )
+        self.create_preprod_snapshot_comparison(
+            head_snapshot_metrics=head_metrics,
+            base_snapshot_metrics=base_metrics,
+            images_changed=10,
+        )
+
+        unrelated_artifact = self.create_preprod_artifact(app_id="com.unrelated.app")
+        self.create_preprod_snapshot_metrics(preprod_artifact=unrelated_artifact, image_count=10)
+
+        response = self._request({"display": "snapshot", "query": "images_changed:>5"})
+        self._assert_is_successful(response)
+        app_ids = {entry["app_info"]["app_id"] for entry in response.json()}
+        assert app_ids == {"com.changed.app"}
+
+    def test_query_is_approved(self) -> None:
+        approved_artifact = self.create_preprod_artifact(app_id="com.approved.app")
+        self.create_preprod_snapshot_metrics(preprod_artifact=approved_artifact)
+        self.create_preprod_comparison_approval(
+            preprod_artifact=approved_artifact,
+            preprod_feature_type=PreprodComparisonApproval.FeatureType.SNAPSHOTS,
+            approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
+        )
+
+        pending_artifact = self.create_preprod_artifact(app_id="com.pending.app")
+        self.create_preprod_snapshot_metrics(preprod_artifact=pending_artifact)
+        self.create_preprod_comparison_approval(
+            preprod_artifact=pending_artifact,
+            preprod_feature_type=PreprodComparisonApproval.FeatureType.SNAPSHOTS,
+            approval_status=PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL,
+        )
+
+        response = self._request({"display": "snapshot", "query": "is_approved:true"})
+        self._assert_is_successful(response)
+        app_ids = {entry["app_info"]["app_id"] for entry in response.json()}
+        assert app_ids == {"com.approved.app"}
 
 
 class QuerysetForQueryTest(APITestCase):

--- a/tests/sentry/preprod/test_artifact_search.py
+++ b/tests/sentry/preprod/test_artifact_search.py
@@ -2,8 +2,17 @@ from datetime import timedelta
 
 from django.utils import timezone
 
-from sentry.preprod.artifact_search import get_sequential_base_artifact
-from sentry.preprod.models import PreprodArtifact, PreprodArtifactSizeMetrics
+from sentry.preprod.artifact_search import (
+    artifact_matches_query,
+    get_sequential_base_artifact,
+    queryset_for_query,
+)
+from sentry.preprod.models import (
+    PreprodArtifact,
+    PreprodArtifactSizeMetrics,
+    PreprodComparisonApproval,
+    PreprodSnapshotMetrics,
+)
 from sentry.testutils.cases import TestCase
 
 
@@ -137,6 +146,15 @@ class GetSequentialBaseArtifactTest(TestCase):
         assert result is not None
         assert result.id == matching.id
 
+    def test_applies_query_filter_on_annotated_field(self) -> None:
+        now = timezone.now()
+        base = self._create_artifact_with_metrics(date_added=now - timedelta(hours=2))
+        head = self._create_artifact_with_metrics(date_added=now - timedelta(hours=1))
+
+        result = get_sequential_base_artifact(head, "install_size:>500", self.organization)
+        assert result is not None
+        assert result.id == base.id
+
     def test_empty_query_matches_all(self) -> None:
         now = timezone.now()
         base = self._create_artifact_with_metrics(date_added=now - timedelta(hours=2))
@@ -160,3 +178,145 @@ class GetSequentialBaseArtifactTest(TestCase):
         result = get_sequential_base_artifact(head, "", self.organization)
         assert result is not None
         assert result.id == base.id
+
+
+class ArtifactMatchesQuerySnapshotFiltersTest(TestCase):
+    def _create_snapshot_comparison(
+        self,
+        head_image_count: int = 0,
+        base_image_count: int = 0,
+        **comparison_fields: int,
+    ) -> PreprodArtifact:
+        head_artifact = self.create_preprod_artifact(project=self.project)
+        head_metrics = self.create_preprod_snapshot_metrics(
+            preprod_artifact=head_artifact, image_count=head_image_count
+        )
+        self._add_comparison(head_metrics, base_image_count=base_image_count, **comparison_fields)
+        return head_artifact
+
+    def _add_comparison(
+        self,
+        head_metrics: PreprodSnapshotMetrics,
+        base_image_count: int = 0,
+        **comparison_fields: int,
+    ) -> None:
+        base_artifact = self.create_preprod_artifact(project=self.project)
+        base_metrics = self.create_preprod_snapshot_metrics(
+            preprod_artifact=base_artifact, image_count=base_image_count
+        )
+        self.create_preprod_snapshot_comparison(
+            head_snapshot_metrics=head_metrics,
+            base_snapshot_metrics=base_metrics,
+            **comparison_fields,
+        )
+
+    def test_image_count_operators(self) -> None:
+        artifact = self.create_preprod_artifact(project=self.project)
+        self.create_preprod_snapshot_metrics(preprod_artifact=artifact, image_count=10)
+
+        assert artifact_matches_query(artifact, "image_count:>5", self.organization)
+        assert not artifact_matches_query(artifact, "image_count:>15", self.organization)
+        assert artifact_matches_query(artifact, "image_count:10", self.organization)
+        assert not artifact_matches_query(artifact, "image_count:11", self.organization)
+
+    def test_images_changed_operators(self) -> None:
+        artifact = self._create_snapshot_comparison(images_changed=10)
+
+        assert artifact_matches_query(artifact, "images_changed:>5", self.organization)
+        assert not artifact_matches_query(artifact, "images_changed:>15", self.organization)
+        assert artifact_matches_query(artifact, "images_changed:10", self.organization)
+        assert not artifact_matches_query(artifact, "images_changed:11", self.organization)
+        assert artifact_matches_query(artifact, "images_changed:<=10", self.organization)
+        assert not artifact_matches_query(artifact, "images_changed:<=9", self.organization)
+        assert artifact_matches_query(artifact, "images_changed:>=10", self.organization)
+        assert not artifact_matches_query(artifact, "images_changed:>=11", self.organization)
+
+    def test_image_comparison_fields_all_wired(self) -> None:
+        artifact = self._create_snapshot_comparison(
+            images_added=1,
+            images_removed=2,
+            images_unchanged=4,
+            images_renamed=5,
+            images_skipped=6,
+        )
+        assert artifact_matches_query(artifact, "images_added:1", self.organization)
+        assert artifact_matches_query(artifact, "images_removed:2", self.organization)
+        assert artifact_matches_query(artifact, "images_unchanged:4", self.organization)
+        assert artifact_matches_query(artifact, "images_renamed:5", self.organization)
+        assert artifact_matches_query(artifact, "images_skipped:6", self.organization)
+
+    def test_multiple_comparisons_no_duplicates(self) -> None:
+        """A head artifact with two matching comparisons should appear exactly once."""
+        head_artifact = self.create_preprod_artifact(project=self.project)
+        head_metrics = self.create_preprod_snapshot_metrics(
+            preprod_artifact=head_artifact, image_count=20
+        )
+        for _ in range(2):
+            self._add_comparison(head_metrics, base_image_count=20, images_changed=10)
+
+        queryset = queryset_for_query("images_changed:>5", self.organization)
+        assert queryset.filter(pk=head_artifact.pk).count() == 1
+
+    def test_images_changed_not_equal_any_row_semantics(self) -> None:
+        """`!=3` is at-least-one semantics: artifact with comparisons [3, 5] matches."""
+        head_artifact = self.create_preprod_artifact(project=self.project)
+        head_metrics = self.create_preprod_snapshot_metrics(
+            preprod_artifact=head_artifact, image_count=20
+        )
+        for images_changed in (3, 5):
+            self._add_comparison(head_metrics, base_image_count=20, images_changed=images_changed)
+
+        assert artifact_matches_query(head_artifact, "images_changed:!=3", self.organization)
+
+
+class ArtifactMatchesQueryIsApprovedFilterTest(TestCase):
+    def _create_artifact_with_approval(
+        self,
+        feature_type: int = PreprodComparisonApproval.FeatureType.SNAPSHOTS,
+        status: int = PreprodComparisonApproval.ApprovalStatus.APPROVED,
+        with_approval_row: bool = True,
+    ) -> PreprodArtifact:
+        artifact = self.create_preprod_artifact(project=self.project)
+        if with_approval_row:
+            self.create_preprod_comparison_approval(
+                preprod_artifact=artifact,
+                preprod_feature_type=feature_type,
+                approval_status=status,
+            )
+        return artifact
+
+    def test_is_approved_by_status(self) -> None:
+        approved = self._create_artifact_with_approval()
+        pending = self._create_artifact_with_approval(
+            status=PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL
+        )
+        rejected = self._create_artifact_with_approval(
+            status=PreprodComparisonApproval.ApprovalStatus.REJECTED
+        )
+        no_row = self._create_artifact_with_approval(with_approval_row=False)
+
+        assert artifact_matches_query(approved, "is_approved:true", self.organization)
+        assert not artifact_matches_query(pending, "is_approved:true", self.organization)
+        assert not artifact_matches_query(rejected, "is_approved:true", self.organization)
+        assert not artifact_matches_query(no_row, "is_approved:true", self.organization)
+
+        assert not artifact_matches_query(approved, "is_approved:false", self.organization)
+        assert artifact_matches_query(pending, "is_approved:false", self.organization)
+        assert artifact_matches_query(rejected, "is_approved:false", self.organization)
+        assert artifact_matches_query(no_row, "is_approved:false", self.organization)
+
+    def test_is_approved_scoped_to_snapshots_feature_type(self) -> None:
+        artifact = self._create_artifact_with_approval(
+            feature_type=PreprodComparisonApproval.FeatureType.SIZE,
+        )
+
+        assert not artifact_matches_query(artifact, "is_approved:true", self.organization)
+
+    def test_is_approved_negation_operator(self) -> None:
+        approved_artifact = self._create_artifact_with_approval()
+        pending_artifact = self._create_artifact_with_approval(
+            status=PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL
+        )
+
+        assert not artifact_matches_query(approved_artifact, "!is_approved:true", self.organization)
+        assert artifact_matches_query(pending_artifact, "!is_approved:true", self.organization)

--- a/tests/sentry/preprod/test_artifact_search.py
+++ b/tests/sentry/preprod/test_artifact_search.py
@@ -257,16 +257,23 @@ class ArtifactMatchesQuerySnapshotFiltersTest(TestCase):
         queryset = queryset_for_query("images_changed:>5", self.organization)
         assert queryset.filter(pk=head_artifact.pk).count() == 1
 
-    def test_images_changed_not_equal_any_row_semantics(self) -> None:
-        """`!=3` is at-least-one semantics: artifact with comparisons [3, 5] matches."""
+    def test_images_changed_not_equal(self) -> None:
         head_artifact = self.create_preprod_artifact(project=self.project)
         head_metrics = self.create_preprod_snapshot_metrics(
             preprod_artifact=head_artifact, image_count=20
         )
-        for images_changed in (3, 5):
-            self._add_comparison(head_metrics, base_image_count=20, images_changed=images_changed)
+        self._add_comparison(head_metrics, base_image_count=20, images_changed=5)
 
         assert artifact_matches_query(head_artifact, "images_changed:!=3", self.organization)
+        assert not artifact_matches_query(head_artifact, "images_changed:!=5", self.organization)
+
+    def test_images_changed_not_equal_no_comparison_row(self) -> None:
+        no_metrics = self.create_preprod_artifact(project=self.project)
+        no_comparison = self.create_preprod_artifact(project=self.project)
+        self.create_preprod_snapshot_metrics(preprod_artifact=no_comparison, image_count=0)
+
+        assert artifact_matches_query(no_metrics, "images_changed:!=3", self.organization)
+        assert artifact_matches_query(no_comparison, "images_changed:!=3", self.organization)
 
 
 class ArtifactMatchesQueryIsApprovedFilterTest(TestCase):


### PR DESCRIPTION
Adds support for filtering the Builds list by snapshot-comparison counters and approval state.

New accepted keys on `/organizations/$org/builds/`:
- `image_count`, `images_added`, `images_changed`, `images_removed`, `images_renamed`, `images_skipped`, `images_unchanged` — numeric; joins through `PreprodSnapshotMetrics` and `PreprodSnapshotComparison`.
- `is_approved` — boolean; uses an `Exists` subquery against `PreprodComparisonApproval` scoped to `FeatureType.SNAPSHOTS` / `ApprovalStatus.APPROVED`.

## Other changes

- Fixes a latent `FieldError` in `get_sequential_base_artifact`: the queryset lacked the annotations that `apply_filters` expects, so queries touching `install_size` / `download_size` / `download_count` / `installable` / `platform_name` would raise at runtime. Regression test added.
- Registers the new fields in the EAP attribute registry (`PREPROD_SIZE_ATTRIBUTE_DEFINITIONS`). The Snapshots tab typeahead reads from the EAP `/trace-items/attributes/` endpoint to advertise available keys; query execution stays on the Django path. The frontend PR (#113332) stacks on this one and wires the actual typeahead exposure.
- Adds testutils factory and fixture helpers for `PreprodSnapshotMetrics`, `PreprodSnapshotComparison`, and `PreprodComparisonApproval`.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
