### PR TITLE
fix(traces): Add md gap in explore content section

### DIFF
--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -284,7 +284,7 @@ function SpanTabContentSection({
           : null;
 
   return (
-    <ExploreContentSection>
+    <ExploreContentSection gap="md">
       <OverChartButtonGroup>
         <ChevronButton
           aria-label={


### PR DESCRIPTION
Adds in missing gap setting for the traces page.

Example:
<img width="1294" height="85" alt="Screenshot 2026-04-17 at 14 50 43" src="https://github.com/user-attachments/assets/44d965a2-fd41-4d20-bf18-136e52f2fede" />
