### PR TITLE
feat(aci): Add `Moved` Banner and redirects to `Crons` and `Uptime` nav items

### DIFF
--- a/static/app/views/navigation/secondary/sections/insights/insightsSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/insights/insightsSecondaryNavigation.tsx
@@ -1,9 +1,13 @@
 import {Fragment} from 'react';
 
+import {Badge} from '@sentry/scraps/badge';
+import {Link} from '@sentry/scraps/link';
+import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
 import Feature from 'sentry/components/acl/feature';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {useUser} from 'sentry/utils/useUser';
 import {makeMonitorBasePathname} from 'sentry/views/detectors/pathnames';
 import {
   AGENTS_LANDING_SUB_PATH,
@@ -30,12 +34,10 @@ import {SecondaryNavigation} from 'sentry/views/navigation/secondary/components'
 import {ProjectsNavigationItems} from 'sentry/views/navigation/secondary/sections/projects/starredProjectsList';
 
 export function InsightsSecondaryNavigation() {
-  const user = useUser();
   const organization = useOrganization();
   const baseUrl = `/organizations/${organization.slug}/${DOMAIN_VIEW_BASE_URL}`;
 
-  const shouldRedirectToMonitors =
-    organization.features.includes('workflow-engine-ui') && !user?.isStaff;
+  const hasWorkflowEngineUI = organization.features.includes('workflow-engine-ui');
   const hasInsightsToDashboards = organization.features.includes(
     'insights-to-dashboards-ui-rollout'
   );
@@ -99,11 +101,34 @@ export function InsightsSecondaryNavigation() {
             <SecondaryNavigation.ListItem>
               <SecondaryNavigation.Link
                 to={
-                  shouldRedirectToMonitors
-                    ? `${makeMonitorBasePathname(organization.slug)}crons/?insightsRedirect=true`
+                  hasWorkflowEngineUI
+                    ? `${makeMonitorBasePathname(organization.slug)}crons/`
                     : `${baseUrl}/crons/`
                 }
                 analyticsItemName="insights_crons"
+                trailingItems={
+                  hasWorkflowEngineUI ? (
+                    <Tooltip
+                      isHoverable
+                      title={
+                        <Fragment>
+                          <Text as="p">{t('Crons now live under Monitors.')}</Text>
+                          <Text as="p">
+                            {tct('See the [link:new Crons page here.]', {
+                              link: (
+                                <Link
+                                  to={`/organizations/${organization.slug}/monitors/crons/`}
+                                />
+                              ),
+                            })}
+                          </Text>
+                        </Fragment>
+                      }
+                    >
+                      <Badge variant="muted">{t('Moved')}</Badge>
+                    </Tooltip>
+                  ) : null
+                }
               >
                 {t('Crons')}
               </SecondaryNavigation.Link>
@@ -112,11 +137,34 @@ export function InsightsSecondaryNavigation() {
               <SecondaryNavigation.ListItem>
                 <SecondaryNavigation.Link
                   to={
-                    shouldRedirectToMonitors
-                      ? `${makeMonitorBasePathname(organization.slug)}uptime/?insightsRedirect=true`
+                    hasWorkflowEngineUI
+                      ? `${makeMonitorBasePathname(organization.slug)}uptime/`
                       : `${baseUrl}/uptime/`
                   }
                   analyticsItemName="insights_uptime"
+                  trailingItems={
+                    hasWorkflowEngineUI ? (
+                      <Tooltip
+                        isHoverable
+                        title={
+                          <Fragment>
+                            <Text as="p">{t('Uptime now lives under Monitors.')}</Text>
+                            <Text as="p">
+                              {tct('See the [link:new Uptime page here.]', {
+                                link: (
+                                  <Link
+                                    to={`/organizations/${organization.slug}/monitors/uptime/`}
+                                  />
+                                ),
+                              })}
+                            </Text>
+                          </Fragment>
+                        }
+                      >
+                        <Badge variant="muted">{t('Moved')}</Badge>
+                      </Tooltip>
+                    ) : null
+                  }
                 >
                   {t('Uptime')}
                 </SecondaryNavigation.Link>

--- a/static/app/views/navigation/secondary/sections/insights/insightsSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/insights/insightsSecondaryNavigation.tsx
@@ -102,7 +102,7 @@ export function InsightsSecondaryNavigation() {
               <SecondaryNavigation.Link
                 to={
                   hasWorkflowEngineUI
-                    ? `${makeMonitorBasePathname(organization.slug)}crons/`
+                    ? `${makeMonitorBasePathname(organization.slug)}crons/?insightsRedirect=true`
                     : `${baseUrl}/crons/`
                 }
                 analyticsItemName="insights_crons"
@@ -117,7 +117,7 @@ export function InsightsSecondaryNavigation() {
                             {tct('See the [link:new Crons page here.]', {
                               link: (
                                 <Link
-                                  to={`/organizations/${organization.slug}/monitors/crons/`}
+                                  to={`${makeMonitorBasePathname(organization.slug)}/crons/`}
                                 />
                               ),
                             })}
@@ -138,7 +138,7 @@ export function InsightsSecondaryNavigation() {
                 <SecondaryNavigation.Link
                   to={
                     hasWorkflowEngineUI
-                      ? `${makeMonitorBasePathname(organization.slug)}uptime/`
+                      ? `${makeMonitorBasePathname(organization.slug)}/uptime/?insightsRedirect=true`
                       : `${baseUrl}/uptime/`
                   }
                   analyticsItemName="insights_uptime"
@@ -153,7 +153,7 @@ export function InsightsSecondaryNavigation() {
                               {tct('See the [link:new Uptime page here.]', {
                                 link: (
                                   <Link
-                                    to={`/organizations/${organization.slug}/monitors/uptime/`}
+                                    to={`${makeMonitorBasePathname(organization.slug)}/uptime/`}
                                   />
                                 ),
                               })}

--- a/static/app/views/navigation/secondary/sections/insights/insightsSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/insights/insightsSecondaryNavigation.tsx
@@ -117,7 +117,7 @@ export function InsightsSecondaryNavigation() {
                             {tct('See the [link:new Crons page here.]', {
                               link: (
                                 <Link
-                                  to={`${makeMonitorBasePathname(organization.slug)}/crons/`}
+                                  to={`${makeMonitorBasePathname(organization.slug)}crons/`}
                                 />
                               ),
                             })}
@@ -138,7 +138,7 @@ export function InsightsSecondaryNavigation() {
                 <SecondaryNavigation.Link
                   to={
                     hasWorkflowEngineUI
-                      ? `${makeMonitorBasePathname(organization.slug)}/uptime/?insightsRedirect=true`
+                      ? `${makeMonitorBasePathname(organization.slug)}uptime/?insightsRedirect=true`
                       : `${baseUrl}/uptime/`
                   }
                   analyticsItemName="insights_uptime"
@@ -153,7 +153,7 @@ export function InsightsSecondaryNavigation() {
                               {tct('See the [link:new Uptime page here.]', {
                                 link: (
                                   <Link
-                                    to={`${makeMonitorBasePathname(organization.slug)}/uptime/`}
+                                    to={`${makeMonitorBasePathname(organization.slug)}uptime/`}
                                   />
                                 ),
                               })}


### PR DESCRIPTION
# Description
Since we couldn't fully link the rollouts for ACI / Insights, we are adding a `Moved` pill to Crons / Uptime in the UI and redirect to the new pages.

This will only be exposed to AM1 customers, because those customers are excluded from the Insights changes.

https://github.com/user-attachments/assets/6104c275-1cdd-4f90-91ac-a405c0a196c6

Let me know if we should add any tests here too; i didn't since it's a temporary thing and is mostly visual.