### PR TITLE
ref(seer): Send proxy_headers as JWT instead of legacy JSON+HMAC

### DIFF
--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -305,10 +305,12 @@ def collect_user_org_context(
 def get_proxy_headers() -> dict[str, str] | None:
     """Build auth headers for Seer to echo back to Sentry on callbacks.
 
-    Returns a dict of headers (X-Viewer-Context + signature) or None.
+    Returns a single ``X-Viewer-Context`` JWT header, or ``None`` when no
+    ViewerContext is set. Matches the format used by the standard inbound
+    Seer → Sentry path (``X-Viewer-Context`` JWT, no separate signature
+    header), so Sentry's middleware decodes both with the same code path.
     """
-    from sentry.seer.signed_seer_api import sign_viewer_context
-    from sentry.viewer_context import get_viewer_context
+    from sentry.viewer_context import encode_viewer_context, get_viewer_context
 
     ctx = get_viewer_context()
     if ctx is None or ctx.user_id is None:
@@ -317,12 +319,11 @@ def get_proxy_headers() -> dict[str, str] | None:
     if not settings.SEER_API_SHARED_SECRET:
         return None
 
-    context_bytes = orjson.dumps(ctx.serialize())
-    signature = sign_viewer_context(context_bytes)
-    return {
-        "X-Viewer-Context": context_bytes.decode("utf-8"),
-        "X-Viewer-Context-Signature": signature,
-    }
+    try:
+        return {"X-Viewer-Context": encode_viewer_context(ctx)}
+    except Exception:
+        logger.exception("Failed to encode viewer context JWT for proxy headers")
+        return None
 
 
 def fetch_run_status(run_id: int, organization: Organization) -> SeerRunState:

--- a/tests/sentry/seer/explorer/test_client_utils.py
+++ b/tests/sentry/seer/explorer/test_client_utils.py
@@ -1,12 +1,17 @@
+import jwt
+from django.test import override_settings
+
 from sentry.models.organizationmember import OrganizationMember
 from sentry.seer.explorer.client_utils import (
     collect_user_org_context,
+    get_proxy_headers,
     has_seer_explorer_access_with_detail,
     snapshot_to_markdown,
 )
 from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import TestCase
 from sentry.testutils.requests import make_request
+from sentry.viewer_context import ActorType, ViewerContext, viewer_context_scope
 
 
 class TestHasSeerExplorerAccessWithDetail(TestCase):
@@ -253,3 +258,58 @@ class SnapshotToMarkdownTest(TestCase):
         result = snapshot_to_markdown(snapshot)
         assert "# Widget" in result
         assert '- "some string"' in result
+
+
+_TEST_SECRET = "test-secret-must-be-at-least-32-bytes-long-for-hs256"
+
+
+@override_settings(SEER_API_SHARED_SECRET=_TEST_SECRET)
+class TestGetProxyHeaders(TestCase):
+    """Headers Seer echoes back to Sentry on Code Mode callbacks."""
+
+    def test_no_viewer_context_returns_none(self) -> None:
+        # Outside any viewer_context_scope — nothing to encode.
+        assert get_proxy_headers() is None
+
+    def test_viewer_context_without_user_returns_none(self) -> None:
+        # System-only context (no user_id) shouldn't produce callback auth —
+        # callbacks only make sense for user-initiated runs.
+        with viewer_context_scope(ViewerContext(organization_id=42)):
+            assert get_proxy_headers() is None
+
+    @override_settings(SEER_API_SHARED_SECRET="")
+    def test_no_shared_secret_returns_none(self) -> None:
+        with viewer_context_scope(
+            ViewerContext(organization_id=42, user_id=7, actor_type=ActorType.USER)
+        ):
+            assert get_proxy_headers() is None
+
+    def test_returns_single_jwt_header(self) -> None:
+        with viewer_context_scope(
+            ViewerContext(organization_id=42, user_id=7, actor_type=ActorType.USER)
+        ):
+            headers = get_proxy_headers()
+        assert headers is not None
+        # Single header — no separate signature header (legacy two-header
+        # format replaced with self-contained JWT).
+        assert set(headers.keys()) == {"X-Viewer-Context"}
+
+    def test_jwt_payload_carries_viewer_fields(self) -> None:
+        with viewer_context_scope(
+            ViewerContext(organization_id=42, user_id=7, actor_type=ActorType.USER)
+        ):
+            headers = get_proxy_headers()
+        assert headers is not None
+        decoded = jwt.decode(
+            headers["X-Viewer-Context"],
+            _TEST_SECRET,
+            algorithms=["HS256"],
+            issuer="sentry",
+        )
+        assert decoded["organization_id"] == 42
+        assert decoded["user_id"] == 7
+        assert decoded["actor_type"] == "user"
+        # Standard JWT claims present
+        assert "iat" in decoded
+        assert "exp" in decoded
+        assert decoded["iss"] == "sentry"


### PR DESCRIPTION
`get_proxy_headers()` builds the auth Seer echoes back to Sentry on Code Mode callbacks. Today it uses the legacy two-header format — a JSON-serialized ViewerContext under `X-Viewer-Context` plus a separate `X-Viewer-Context-Signature` HMAC header. That format predates the JWT path used everywhere else in the ViewerContext flow.

Switch to a single `X-Viewer-Context` JWT, encoded with the existing `encode_viewer_context()` helper. Sentry's middleware already accepts both formats (JWT first, fallback to legacy with signature), so the receiving side needs no change. The JWT also carries an `exp` claim, which the legacy format didn't — strictly tighter than today.

Seer just echoes whatever it got as a dict, so the single-header response works on the Seer side without any change there.

Tests: 5 new cases in `tests/sentry/seer/explorer/test_client_utils.py::TestGetProxyHeaders` covering no-VC, VC-without-user, no-shared-secret, single-header shape, and full JWT payload roundtrip.

Refs [RFC: Unified ViewerContext via ContextVar](https://www.notion.so/sentry/RFC-Unified-ViewerContext-via-ContextVar-32f8b10e4b5d81988625cb5787035e02).