### PR TITLE
ref(issues): Migrate similar stack trace to react-query

### DIFF
--- a/static/app/stores/groupingStore.spec.tsx
+++ b/static/app/stores/groupingStore.spec.tsx
@@ -1,4 +1,3 @@
-import * as GroupActionCreators from 'sentry/actionCreators/group';
 import {GroupingStore} from 'sentry/stores/groupingStore';
 
 describe('Grouping Store', () => {
@@ -57,47 +56,6 @@ describe('Grouping Store', () => {
         },
       ],
     });
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/issues/groupId/similar/',
-      body: [
-        [
-          {
-            id: '274',
-          },
-          {
-            'exception:stacktrace:pairs': 0.375,
-            'exception:stacktrace:application-chunks': 0.175,
-            'message:message:character-shingles': 0.775,
-          },
-        ],
-        [
-          {
-            id: '275',
-          },
-          {'exception:stacktrace:pairs': 1.0},
-        ],
-        [
-          {
-            id: '216',
-          },
-          {
-            'exception:stacktrace:application-chunks': 0.000235,
-            'exception:stacktrace:pairs': 0.001488,
-          },
-        ],
-        [
-          {
-            id: '217',
-          },
-          {
-            'exception:message:character-shingles': null,
-            'exception:stacktrace:application-chunks': 0.25,
-            'exception:stacktrace:pairs': 0.25,
-            'message:message:character-shingles': 0.7,
-          },
-        ],
-      ],
-    });
   });
 
   afterEach(() => {
@@ -116,104 +74,12 @@ describe('Grouping Store', () => {
       expect(trigger).toHaveBeenCalledWith(
         expect.objectContaining({
           error: false,
-          filteredSimilarItems: [],
           loading: true,
-          mergeState: new Map(),
           mergedItems: [],
           mergedLinks: '',
-          similarItems: [],
-          similarLinks: '',
           unmergeState: new Map(),
         })
       );
-    });
-
-    it('fetches list of similar items', async () => {
-      await GroupingStore.onFetch([
-        {dataKey: 'similar', endpoint: '/organizations/org-slug/issues/groupId/similar/'},
-      ]);
-
-      expect(trigger).toHaveBeenCalled();
-      const calls = trigger.mock.calls;
-      const arg: any = calls[calls.length - 1][0];
-
-      expect(arg.filteredSimilarItems).toHaveLength(1);
-      expect(arg.similarItems).toHaveLength(3);
-      expect(arg).toMatchObject({
-        loading: false,
-        error: false,
-        mergeState: new Map(),
-        mergedItems: [],
-        similarItems: [
-          {
-            isBelowThreshold: false,
-            issue: {
-              id: '274',
-            },
-          },
-          {
-            isBelowThreshold: false,
-            issue: {
-              id: '275',
-            },
-          },
-          {
-            isBelowThreshold: false,
-            issue: {
-              id: '217',
-            },
-          },
-        ],
-        filteredSimilarItems: [
-          {
-            isBelowThreshold: true,
-            issue: {
-              id: '216',
-            },
-          },
-        ],
-        unmergeState: new Map(),
-      });
-    });
-
-    it('unsuccessfully fetches list of similar items', () => {
-      MockApiClient.clearMockResponses();
-      MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/issues/groupId/similar/',
-        statusCode: 500,
-        body: {message: 'failed'},
-      });
-
-      const promise = GroupingStore.onFetch([
-        {dataKey: 'similar', endpoint: '/organizations/org-slug/issues/groupId/similar/'},
-      ]);
-
-      expect(trigger).toHaveBeenCalled();
-      const calls = trigger.mock.calls;
-      return promise.then(() => {
-        const arg = calls[calls.length - 1][0];
-        expect(arg).toMatchObject({
-          loading: false,
-          error: true,
-          mergeState: new Map(),
-          mergedItems: [],
-          unmergeState: new Map(),
-        });
-      });
-    });
-
-    it('ignores null scores in aggregate', async () => {
-      await GroupingStore.onFetch([
-        {dataKey: 'similar', endpoint: '/organizations/org-slug/issues/groupId/similar/'},
-      ]);
-
-      expect(trigger).toHaveBeenCalled();
-      const calls = trigger.mock.calls;
-      const arg: any = calls[calls.length - 1][0];
-
-      const item = arg.similarItems.find(({issue}: any) => issue.id === '217');
-      expect(item.aggregate.exception).toBe(0.25);
-      expect(item.aggregate.message).toBe(0.7);
     });
 
     it('fetches list of hashes', () => {
@@ -229,9 +95,6 @@ describe('Grouping Store', () => {
         expect(arg).toMatchObject({
           loading: false,
           error: false,
-          similarItems: [],
-          filteredSimilarItems: [],
-          mergeState: new Map(),
           unmergeState: new Map([
             ['1', {busy: true}],
             ['2', {busy: false}],
@@ -285,230 +148,9 @@ describe('Grouping Store', () => {
         expect(arg).toMatchObject({
           loading: false,
           error: true,
-          mergeState: new Map(),
           mergedItems: [],
           unmergeState: new Map(),
         });
-      });
-    });
-  });
-
-  describe('Similar Issues list (to be merged)', () => {
-    let mergeList: (typeof GroupingStore)['state']['mergeList'];
-    let mergeState: (typeof GroupingStore)['state']['mergeState'];
-
-    beforeEach(() => {
-      GroupingStore.init();
-      mergeList = [];
-      mergeState = new Map();
-      GroupingStore.onFetch([
-        {dataKey: 'similar', endpoint: '/organizations/org-slug/issues/groupId/similar/'},
-      ]);
-    });
-
-    describe('onToggleMerge (checkbox state)', () => {
-      // Attempt to check first item but its "locked" so should not be able to do anything
-      it('can check and uncheck item', () => {
-        GroupingStore.onToggleMerge('1');
-
-        mergeList = ['1'];
-        mergeState.set('1', {checked: true});
-        expect(GroupingStore.getState().mergeList).toEqual(mergeList);
-        expect(GroupingStore.getState().mergeState).toEqual(mergeState);
-
-        // Uncheck
-        GroupingStore.onToggleMerge('1');
-        mergeList = mergeList.filter(item => item !== '1');
-        mergeState.set('1', {checked: false});
-
-        // Check all
-        GroupingStore.onToggleMerge('1');
-        GroupingStore.onToggleMerge('2');
-        GroupingStore.onToggleMerge('3');
-
-        mergeList = ['1', '2', '3'];
-        mergeState.set('1', {checked: true});
-        mergeState.set('2', {checked: true});
-        mergeState.set('3', {checked: true});
-
-        expect(GroupingStore.getState().mergeList).toEqual(mergeList);
-        expect(GroupingStore.getState().mergeState).toEqual(mergeState);
-
-        expect(trigger).toHaveBeenLastCalledWith({
-          mergeDisabled: false,
-          mergeList,
-          mergeState,
-        });
-      });
-    });
-
-    describe('onMerge', () => {
-      beforeEach(() => {
-        MockApiClient.clearMockResponses();
-        MockApiClient.addMockResponse({
-          method: 'PUT',
-          url: '/projects/orgId/projectId/issues/',
-        });
-        GroupingStore.init();
-      });
-
-      it('disables rows to be merged', async () => {
-        const mergeMock = jest.spyOn(GroupActionCreators, 'mergeGroups');
-
-        trigger.mockReset();
-        GroupingStore.onToggleMerge('1');
-        mergeList = ['1'];
-        mergeState.set('1', {checked: true});
-
-        expect(trigger).toHaveBeenLastCalledWith(
-          expect.objectContaining({
-            mergeDisabled: false,
-            mergeList,
-            mergeState,
-          })
-        );
-
-        trigger.mockReset();
-
-        // Everything is sync so trigger will have been called multiple times
-        const promise = GroupingStore.onMerge({
-          params: {
-            orgId: 'orgId',
-            groupId: 'groupId',
-          },
-          projectId: 'projectId',
-        });
-
-        mergeState.set('1', {checked: true, busy: true});
-
-        expect(trigger).toHaveBeenCalledWith(
-          expect.objectContaining({
-            mergeDisabled: true,
-            mergeList,
-            mergeState,
-          })
-        );
-
-        await promise;
-
-        expect(mergeMock).toHaveBeenCalledWith(
-          expect.anything(),
-          {
-            orgId: 'orgId',
-            projectId: 'projectId',
-            itemIds: ['1', 'groupId'],
-            query: undefined,
-          },
-          {
-            error: expect.any(Function),
-            success: expect.any(Function),
-            complete: expect.any(Function),
-          }
-        );
-
-        // Should be removed from mergeList after merged
-        mergeList = mergeList.filter(item => item !== '1');
-        mergeState.set('1', {checked: false, busy: true});
-        expect(trigger).toHaveBeenLastCalledWith(
-          expect.objectContaining({
-            mergeDisabled: false,
-            mergeList,
-            mergeState,
-          })
-        );
-      });
-
-      it('keeps rows in "busy" state and unchecks after successfully adding to merge queue', async () => {
-        GroupingStore.onToggleMerge('1');
-        mergeList = ['1'];
-        mergeState.set('1', {checked: true});
-
-        // Expect checked
-        expect(trigger).toHaveBeenCalledWith(
-          expect.objectContaining({
-            mergeDisabled: false,
-            mergeList,
-            mergeState,
-          })
-        );
-
-        trigger.mockReset();
-
-        // Start unmerge
-        const promise = GroupingStore.onMerge({
-          params: {
-            orgId: 'orgId',
-            groupId: 'groupId',
-          },
-          projectId: 'projectId',
-        });
-
-        mergeState.set('1', {checked: true, busy: true});
-
-        // Expect checked to remain the same, but is now busy
-        expect(trigger).toHaveBeenCalledWith(
-          expect.objectContaining({
-            mergeDisabled: true,
-            mergeList,
-            mergeState,
-          })
-        );
-
-        await promise;
-
-        mergeState.set('1', {checked: false, busy: true});
-
-        // After promise, reset checked to false, but keep busy
-        expect(trigger).toHaveBeenLastCalledWith(
-          expect.objectContaining({
-            mergeDisabled: false,
-            mergeList: [],
-            mergeState,
-          })
-        );
-      });
-
-      it('resets busy state and has same items checked after error when trying to merge', async () => {
-        MockApiClient.clearMockResponses();
-        MockApiClient.addMockResponse({
-          method: 'PUT',
-          url: '/projects/orgId/projectId/issues/',
-          statusCode: 500,
-          body: {},
-        });
-
-        GroupingStore.onToggleMerge('1');
-        mergeList = ['1'];
-        mergeState.set('1', {checked: true});
-
-        const promise = GroupingStore.onMerge({
-          params: {
-            orgId: 'orgId',
-            groupId: 'groupId',
-          },
-          projectId: 'projectId',
-        });
-
-        mergeState.set('1', {checked: true, busy: true});
-        expect(trigger).toHaveBeenCalledWith(
-          expect.objectContaining({
-            mergeDisabled: true,
-            mergeList,
-            mergeState,
-          })
-        );
-
-        await promise;
-
-        // Error state
-        mergeState.set('1', {checked: true, busy: false});
-        expect(trigger).toHaveBeenLastCalledWith(
-          expect.objectContaining({
-            mergeDisabled: false,
-            mergeList,
-            mergeState,
-          })
-        );
       });
     });
   });

--- a/static/app/stores/groupingStore.tsx
+++ b/static/app/stores/groupingStore.tsx
@@ -1,7 +1,6 @@
 import pick from 'lodash/pick';
 import {createStore} from 'reflux';
 
-import {mergeGroups} from 'sentry/actionCreators/group';
 import {
   addErrorMessage,
   addLoadingMessage,
@@ -11,32 +10,17 @@ import {Client} from 'sentry/api';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import type {Organization} from 'sentry/types/organization';
-import type {Project} from 'sentry/types/project';
 import {toArray} from 'sentry/utils/array/toArray';
 
 import type {StrictStoreDefinition} from './types';
 
-// Between 0-100
-const MIN_SCORE = 0.6;
-
-const checkBelowThreshold = (scores: ScoreMap = {}) => {
-  return !Object.values(scores).some(score => Number(score) >= MIN_SCORE);
-};
-
 type State = {
-  // "Compare" button state
   enableFingerprintCompare: boolean;
   error: boolean;
-  filteredSimilarItems: SimilarItem[];
   loading: boolean;
-  mergeDisabled: boolean;
-  mergeList: string[];
-  mergeState: Map<any, Readonly<{busy?: boolean; checked?: boolean}>>;
   // List of fingerprints that belong to issue
   mergedItems: Fingerprint[];
   mergedLinks: string;
-  similarItems: SimilarItem[];
-  similarLinks: string;
   // Disabled state of "Unmerge" button in "Merged" tab (for Issues)
   unmergeDisabled: boolean;
   // If "Collapse All" was just used, this will be true
@@ -48,8 +32,6 @@ type State = {
     Map<any, Readonly<{busy?: boolean; checked?: boolean; collapsed?: boolean}>>
   >;
 };
-
-type ScoreMap = Record<string, number | null | string>;
 
 type ApiFingerprint = {
   id: string;
@@ -85,45 +67,6 @@ export type Fingerprint = {
   state?: string;
 };
 
-export type SimilarItem = {
-  isBelowThreshold: boolean;
-  issue: Group;
-  aggregate?: {
-    exception: number;
-    message: number;
-    shouldBeGrouped?: string;
-  };
-  score?: Record<string, number | null>;
-  scoresByInterface?: {
-    exception: Array<[string, number | null]>;
-    message: Array<[string, any | null]>;
-    shouldBeGrouped?: Array<[string, string | null]>;
-  };
-};
-
-type ResponseProcessors = {
-  merged: (item: ApiFingerprint[]) => Fingerprint[];
-  similar: (data: [Group, ScoreMap]) => {
-    aggregate: Record<string, number | string>;
-    isBelowThreshold: boolean;
-    issue: Group;
-    score: ScoreMap;
-    scoresByInterface: Record<string, Array<[string, number | null]>>;
-  };
-};
-
-type DataKey = keyof ResponseProcessors;
-
-type ResultsAsArrayDataMerged = Parameters<ResponseProcessors['merged']>[0];
-
-type ResultsAsArrayDataSimilar = Array<Parameters<ResponseProcessors['similar']>[0]>;
-
-type ResultsAsArray = Array<{
-  data: ResultsAsArrayDataMerged | ResultsAsArrayDataSimilar;
-  dataKey: DataKey;
-  links: string | null;
-}>;
-
 type IdState = {
   busy?: boolean;
   checked?: boolean;
@@ -146,22 +89,13 @@ interface GroupingStoreDefinition extends StrictStoreDefinition<State> {
   isAllUnmergedSelected(): boolean;
   onFetch(
     toFetchArray: Array<{
-      dataKey: DataKey;
+      dataKey: 'merged';
       endpoint: string;
       queryParams?: Record<string, any>;
     }>
   ): Promise<any>;
-  onMerge(props: {
-    projectId: Project['id'];
-    params?: {
-      groupId: Group['id'];
-      orgId: Organization['id'];
-    };
-    query?: string;
-  }): undefined | Promise<any>;
   onToggleCollapseFingerprint(fingerprint: string): void;
   onToggleCollapseFingerprints(): void;
-  onToggleMerge(id: string): void;
   onToggleUnmerge(props: [string, string] | string): void;
   onUnmerge(props: {
     groupId: Group['id'];
@@ -171,29 +105,15 @@ interface GroupingStoreDefinition extends StrictStoreDefinition<State> {
     successMessage?: string;
   }): Promise<UnmergeResponse>;
   /**
-   * Updates mergeState
+   * Updates unmergeState
    */
   setStateForId(
-    stateProperty: 'mergeState' | 'unmergeState',
+    stateProperty: 'unmergeState',
     idOrIds: string[] | string,
     newState: IdState
   ): void;
   triggerFetchState(): Readonly<
-    Pick<
-      State,
-      | 'similarItems'
-      | 'filteredSimilarItems'
-      | 'mergedItems'
-      | 'mergedLinks'
-      | 'similarLinks'
-      | 'mergeState'
-      | 'unmergeState'
-      | 'loading'
-      | 'error'
-    >
-  >;
-  triggerMergeState(): Readonly<
-    Pick<State, 'mergeState' | 'mergeDisabled' | 'mergeList'>
+    Pick<State, 'mergedItems' | 'mergedLinks' | 'unmergeState' | 'loading' | 'error'>
   >;
   triggerUnmergeState(): Readonly<UnmergeResponse>;
 }
@@ -224,13 +144,7 @@ const storeConfig: GroupingStoreDefinition = {
       unmergeLastCollapsed: false,
       // "Compare" button state
       enableFingerprintCompare: false,
-      similarItems: [],
-      filteredSimilarItems: [],
-      similarLinks: '',
-      mergeState: new Map(),
-      mergeList: [],
       mergedLinks: '',
-      mergeDisabled: false,
       loading: true,
       error: false,
     };
@@ -267,13 +181,12 @@ const storeConfig: GroupingStoreDefinition = {
     this.triggerFetchState();
 
     const promises = toFetchArray.map(
-      ({endpoint, dataKey}) =>
+      ({endpoint}) =>
         new Promise((resolve, reject) => {
           this.api.request(endpoint, {
             method: 'GET',
             success: (data, _, resp) => {
               resolve({
-                dataKey,
                 data,
                 links: resp ? resp.getResponseHeader('Link') : null,
               });
@@ -287,124 +200,62 @@ const storeConfig: GroupingStoreDefinition = {
         })
     );
 
-    const responseProcessors: ResponseProcessors = {
-      merged: items => {
-        const newItemsMap: Record<string, Fingerprint> = {};
-        const newItems: Fingerprint[] = [];
+    const processMerged = (items: ApiFingerprint[]): Fingerprint[] => {
+      const newItemsMap: Record<string, Fingerprint> = {};
+      const newItems: Fingerprint[] = [];
 
-        items.forEach(item => {
-          if (!newItemsMap[item.id]) {
-            const newItem = {
-              eventCount: 0,
-              children: [],
-              // lastSeen and latestEvent properties are correct
-              // since the server returns items in
-              // descending order of lastSeen
-              ...item,
-            };
-            // Check for locked items
-            this.setStateForId('unmergeState', item.id, {
-              busy: item.state === 'locked',
-            });
+      items.forEach(item => {
+        if (!newItemsMap[item.id]) {
+          const newItem = {
+            eventCount: 0,
+            children: [],
+            // lastSeen and latestEvent properties are correct
+            // since the server returns items in
+            // descending order of lastSeen
+            ...item,
+          };
+          // Check for locked items
+          this.setStateForId('unmergeState', item.id, {
+            busy: item.state === 'locked',
+          });
 
-            newItemsMap[item.id] = newItem;
-            newItems.push(newItem);
-          }
+          newItemsMap[item.id] = newItem;
+          newItems.push(newItem);
+        }
 
-          const newItem = newItemsMap[item.id]!;
-          const {childId, childLabel, eventCount, lastSeen, latestEvent} = item;
+        const newItem = newItemsMap[item.id]!;
+        const {childId, childLabel, eventCount, lastSeen, latestEvent} = item;
 
-          if (eventCount) {
-            newItem.eventCount += eventCount;
-          }
+        if (eventCount) {
+          newItem.eventCount += eventCount;
+        }
 
-          if (childId) {
-            newItem.children.push({
-              childId,
-              childLabel,
-              lastSeen,
-              latestEvent,
-              eventCount,
-            });
-          }
-        });
+        if (childId) {
+          newItem.children.push({
+            childId,
+            childLabel,
+            lastSeen,
+            latestEvent,
+            eventCount,
+          });
+        }
+      });
 
-        return newItems;
-      },
-      similar: ([issue, scoreMap]) => {
-        // Check which similarity endpoint is being used
-        const hasSimilarityEmbeddingsFeature = toFetchArray[0]?.endpoint.includes(
-          'similar-issues-embeddings'
-        );
-
-        // Hide items with a low scores
-        const isBelowThreshold = hasSimilarityEmbeddingsFeature
-          ? false
-          : checkBelowThreshold(scoreMap);
-
-        // List of scores indexed by interface (i.e., exception and message)
-        // Note: for v2, the interface is always "similarity". When v2 is
-        // rolled out we can get rid of this grouping entirely.
-        const scoresByInterface = Object.entries(scoreMap).reduce(
-          (acc, [scoreKey, score]) => {
-            // v1 layout: '<interface>:...'
-            const [interfaceName] = String(scoreKey).split(':') as [string];
-
-            // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-            if (!acc[interfaceName]) {
-              // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-              acc[interfaceName] = [];
-            }
-            // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-            acc[interfaceName].push([scoreKey, score]);
-
-            return acc;
-          },
-          {}
-        );
-
-        // Aggregate score by interface
-        const aggregate = Object.entries(scoresByInterface).reduce(
-          (acc, [interfaceName, allScores]) => {
-            // `null` scores means feature was not present in both issues, do not
-            // include in aggregate
-            // @ts-expect-error TS(7031): Binding element 'score' implicitly has an 'any' ty... Remove this comment to see the full error message
-            const scores = allScores.filter(([, score]) => score !== null);
-
-            const avg =
-              scores.reduce((sum: any, [, score]: any) => sum + score, 0) / scores.length;
-            // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
-            acc[interfaceName] = hasSimilarityEmbeddingsFeature ? scores[0][1] : avg;
-            return acc;
-          },
-          {}
-        );
-
-        return {
-          issue,
-          score: scoreMap,
-          scoresByInterface,
-          aggregate,
-          isBelowThreshold,
-        };
-      },
+      return newItems;
     };
 
     return Promise.all(promises).then(
       resultsArray => {
-        (resultsArray as ResultsAsArray).forEach(({dataKey, data, links}) => {
-          const items =
-            dataKey === 'similar'
-              ? (data as ResultsAsArrayDataSimilar).map(responseProcessors[dataKey])
-              : responseProcessors[dataKey](data as ResultsAsArrayDataMerged);
-
-          this.state = {
-            ...this.state,
-            // Types here are pretty rough
-            [`${dataKey}Items`]: items,
-            [`${dataKey}Links`]: links,
-          };
-        });
+        (resultsArray as Array<{data: ApiFingerprint[]; links: string | null}>).forEach(
+          ({data, links}) => {
+            const items = processMerged(data);
+            this.state = {
+              ...this.state,
+              mergedItems: items,
+              mergedLinks: links ?? '',
+            };
+          }
+        );
 
         this.state = {...this.state, loading: false, error: false};
         this.triggerFetchState();
@@ -416,34 +267,6 @@ const storeConfig: GroupingStoreDefinition = {
         return [];
       }
     );
-  },
-
-  // Toggle merge checkbox
-  onToggleMerge(id) {
-    let checked = false;
-
-    // Don't do anything if item is busy
-    const state = this.state.mergeState.has(id)
-      ? this.state.mergeState.get(id)
-      : undefined;
-
-    if (state?.busy === true) {
-      return;
-    }
-
-    if (this.state.mergeList.includes(id)) {
-      this.state = {
-        ...this.state,
-        mergeList: this.state.mergeList.filter(item => item !== id),
-      };
-    } else {
-      this.state = {...this.state, mergeList: [...this.state.mergeList, id]};
-      checked = true;
-    }
-
-    this.setStateForId('mergeState', id, {checked});
-
-    this.triggerMergeState();
   },
 
   // Toggle unmerge check box
@@ -524,59 +347,6 @@ const storeConfig: GroupingStoreDefinition = {
     });
   },
 
-  // For cross-project views, we need to pass projectId instead of
-  // depending on router params (since we will only have orgId in that case)
-  onMerge({params, query, projectId}) {
-    if (!params) {
-      return undefined;
-    }
-
-    const ids = this.state.mergeList;
-
-    this.state = {...this.state, mergeDisabled: true};
-
-    this.setStateForId('mergeState', ids, {busy: true});
-
-    this.triggerMergeState();
-
-    const promise = new Promise(resolve => {
-      // Disable merge button
-      const {orgId, groupId} = params;
-
-      mergeGroups(
-        this.api,
-        {
-          orgId,
-          projectId,
-          itemIds: [...ids, groupId],
-          query,
-        },
-        {
-          success: data => {
-            if (data?.merge?.parent) {
-              this.trigger({
-                mergedParent: data.merge.parent,
-              });
-            }
-
-            // Hide rows after successful merge
-            this.setStateForId('mergeState', ids, {checked: false, busy: true});
-            this.state = {...this.state, mergeList: []};
-          },
-          error: () => {
-            this.setStateForId('mergeState', ids, {checked: true, busy: false});
-          },
-          complete: () => {
-            this.state = {...this.state, mergeDisabled: false};
-            resolve(this.triggerMergeState());
-          },
-        }
-      );
-    });
-
-    return promise;
-  },
-
   // Toggle collapsed state of all fingerprints
   onToggleCollapseFingerprints() {
     this.setStateForId(
@@ -605,17 +375,15 @@ const storeConfig: GroupingStoreDefinition = {
   },
 
   triggerFetchState() {
-    this.state = {
-      ...this.state,
-      similarItems: this.state.similarItems.filter(
-        ({isBelowThreshold}) => !isBelowThreshold
-      ),
-      filteredSimilarItems: this.state.similarItems.filter(
-        ({isBelowThreshold}) => isBelowThreshold
-      ),
-    };
-    this.trigger(this.state);
-    return this.state;
+    const state = pick(this.state, [
+      'mergedItems',
+      'mergedLinks',
+      'unmergeState',
+      'loading',
+      'error',
+    ]);
+    this.trigger(state);
+    return state;
   },
 
   triggerUnmergeState() {
@@ -626,12 +394,6 @@ const storeConfig: GroupingStoreDefinition = {
       'enableFingerprintCompare',
       'unmergeLastCollapsed',
     ]);
-    this.trigger(state);
-    return state;
-  },
-
-  triggerMergeState() {
-    const state = pick(this.state, ['mergeDisabled', 'mergeState', 'mergeList']);
     this.trigger(state);
     return state;
   },

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -146,13 +146,6 @@ export type IssueEventParameters = {
     group_id: string;
     project_id: string;
   };
-  'issue_details.similar_issues.similarity_embeddings_feedback_recieved': {
-    groupId: string;
-    parentGroupId: string;
-    value: string;
-    projectId?: string;
-    wouldGroup?: string;
-  };
   'issue_details.streamline_ui_toggle': {
     enforced_streamline_ui: boolean;
     isEnabled: boolean;
@@ -338,8 +331,6 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
     'Issue Details: Merged Issues Drawer Opened',
   'issue_details.similar_issues.diff_clicked':
     'Issue Details: Similar Issues: Diff Clicked',
-  'issue_details.similar_issues.similarity_embeddings_feedback_recieved':
-    'Issue Details: Similar Issues: Similarity Embeddings Feedback Recieved',
   'issue_details.streamline_ui_toggle': 'Streamline: UI Toggle Clicked',
   'issue_details.tour.skipped': 'Issue Details: Tour Skipped',
   'issue_details.tour.started': 'Issue Details: Tour Started',

--- a/static/app/views/issueDetails/groupSimilarIssues/similarIssues.spec.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarIssues.spec.tsx
@@ -47,8 +47,9 @@ describe('Issues Similar View', () => {
 
   beforeEach(() => {
     mock = MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/issues/${group.id}/similar/?limit=50`,
+      url: `/organizations/org-slug/issues/${group.id}/similar/`,
       body: mockData.similar,
+      match: [MockApiClient.matchQuery({limit: 50})],
     });
     MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/${group.id}/`,
@@ -163,8 +164,9 @@ describe('Issues Similar View', () => {
 
   it('shows empty message', async () => {
     mock = MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/issues/${group.id}/similar/?limit=50`,
+      url: `/organizations/org-slug/issues/${group.id}/similar/`,
       body: [],
+      match: [MockApiClient.matchQuery({limit: 50})],
     });
 
     render(<GroupSimilarIssues />, {
@@ -216,8 +218,9 @@ describe('Issues Similar Embeddings View', () => {
 
   beforeEach(() => {
     mock = MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/issues/${group.id}/similar-issues-embeddings/?k=10&threshold=0.01`,
+      url: `/organizations/org-slug/issues/${group.id}/similar-issues-embeddings/`,
       body: mockData.similarEmbeddings,
+      match: [MockApiClient.matchQuery({k: 10, threshold: 0.01})],
     });
     MockApiClient.addMockResponse({
       url: `/organizations/org-slug/issues/${group.id}/`,
@@ -330,8 +333,9 @@ describe('Issues Similar Embeddings View', () => {
 
   it('shows empty message', async () => {
     mock = MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/issues/${group.id}/similar-issues-embeddings/?k=10&threshold=0.01`,
+      url: `/organizations/org-slug/issues/${group.id}/similar-issues-embeddings/`,
       body: [],
+      match: [MockApiClient.matchQuery({k: 10, threshold: 0.01})],
     });
 
     render(<GroupSimilarIssues />, {

--- a/static/app/views/issueDetails/groupSimilarIssues/similarIssuesDrawer.spec.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarIssuesDrawer.spec.tsx
@@ -31,9 +31,10 @@ describe('SimilarIssuesDrawer', () => {
     GroupStore.init();
 
     mockSimilarIssues = MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/issues/${group.id}/similar/?limit=50`,
+      url: `/organizations/${organization.slug}/issues/${group.id}/similar/`,
       body: [[group, {'exception:stacktrace:pairs': 0.375}]],
       method: 'GET',
+      match: [MockApiClient.matchQuery({limit: 50})],
     });
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/issues/${group.id}/`,

--- a/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/index.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/index.tsx
@@ -1,206 +1,175 @@
-import {Fragment, useCallback, useEffect, useState} from 'react';
+import {Fragment, useCallback, useState} from 'react';
 import styled from '@emotion/styled';
-import * as qs from 'query-string';
+import {skipToken, useMutation, useQuery} from '@tanstack/react-query';
 
+import {mergeGroups} from 'sentry/actionCreators/group';
 import {EmptyStateWarning} from 'sentry/components/emptyStateWarning';
 import {HookOrDefault} from 'sentry/components/hookOrDefault';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Panel} from 'sentry/components/panels/panel';
 import {t} from 'sentry/locale';
-import type {SimilarItem} from 'sentry/stores/groupingStore';
-import {GroupingStore} from 'sentry/stores/groupingStore';
 import type {Project} from 'sentry/types/project';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useDetailedProject} from 'sentry/utils/project/useDetailedProject';
+import {useApi} from 'sentry/utils/useApi';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
-import {usePrevious} from 'sentry/utils/usePrevious';
 import {useGroupEvent} from 'sentry/views/issueDetails/useGroupEvent';
 
 import {List} from './list';
+import {processSimilarItem} from './types';
+import type {SimilarApiResponse} from './types';
 
 type Props = {
   project: Project;
-};
-
-type ItemState = {
-  filtered: SimilarItem[];
-  pageLinks: string | null;
-  similar: SimilarItem[];
 };
 
 const DataConsentBanner = HookOrDefault({
   hookName: 'component:data-consent-banner',
   defaultComponent: null,
 });
+
+const LONG_STACKTRACE_PLATFORMS = ['go', 'javascript', 'node', 'php', 'python', 'ruby'];
+const EMPTY_SET: ReadonlySet<string> = new Set();
+
 export function SimilarStackTrace({project}: Props) {
+  const api = useApi({persistInFlight: true});
   const location = useLocation();
   const organization = useOrganization();
   const params = useParams<{groupId: string; orgId: string}>();
-
-  const [items, setItems] = useState<ItemState>({
-    similar: [],
-    filtered: [],
-    pageLinks: null,
-  });
-  const [status, setStatus] = useState<'loading' | 'error' | 'ready'>('loading');
-
   const navigate = useNavigate();
-  const prevLocationSearch = usePrevious(location.search);
+
+  const [checkedIds, setCheckedIds] = useState<Set<string>>(new Set());
+
   const hasSimilarityFeature = project.features.includes('similarity-view');
-  const {data: projectData, isPending} = useDetailedProject({
+  const {data: projectData, isPending: isProjectPending} = useDetailedProject({
     orgSlug: organization.slug,
     projectSlug: project.slug,
   });
   // similarity-embeddings feature is only available on project details
-  const hasSimilarityEmbeddingsFeature =
+  const hasEmbeddings =
     projectData?.features.includes('similarity-embeddings') ||
     location.query.similarityEmbeddings === '1';
-  const fetchData = useCallback(() => {
-    if (isPending) {
-      return;
-    }
-    setStatus('loading');
 
-    const reqs: Parameters<typeof GroupingStore.onFetch>[0] = [];
+  const canFetch = !isProjectPending && (hasSimilarityFeature || hasEmbeddings);
 
-    if (hasSimilarityEmbeddingsFeature) {
-      reqs.push({
-        endpoint: `/organizations/${organization.slug}/issues/${params.groupId}/similar-issues-embeddings/?${qs.stringify(
-          {
-            k: 10,
-            threshold: 0.01,
-          }
-        )}`,
-        dataKey: 'similar',
-      });
-    } else if (hasSimilarityFeature) {
-      reqs.push({
-        endpoint: `/organizations/${organization.slug}/issues/${params.groupId}/similar/?${qs.stringify(
-          {
-            ...location.query,
-            limit: 50,
-          }
-        )}`,
-        dataKey: 'similar',
-      });
-    }
-
-    GroupingStore.onFetch(reqs);
-  }, [
-    location.query,
-    params.groupId,
-    organization.slug,
-    hasSimilarityFeature,
-    hasSimilarityEmbeddingsFeature,
+  const {
+    data: result,
     isPending,
-  ]);
-
-  const onGroupingChange = useCallback(
-    ({
-      mergedParent,
-      similarItems: updatedSimilarItems,
-      filteredSimilarItems: updatedFilteredSimilarItems,
-      similarLinks: updatedSimilarLinks,
-      loading,
-      error,
-    }: any) => {
-      if (updatedSimilarItems) {
-        setItems({
-          similar: updatedSimilarItems,
-          filtered: updatedFilteredSimilarItems,
-          pageLinks: updatedSimilarLinks,
-        });
-        setStatus(error ? 'error' : loading ? 'loading' : 'ready');
-        return;
+    isError,
+    refetch,
+  } = useQuery({
+    ...apiOptions.as<SimilarApiResponse>()(
+      hasEmbeddings
+        ? '/organizations/$organizationIdOrSlug/issues/$issueId/similar-issues-embeddings/'
+        : '/organizations/$organizationIdOrSlug/issues/$issueId/similar/',
+      {
+        path: canFetch
+          ? {organizationIdOrSlug: organization.slug, issueId: params.groupId}
+          : skipToken,
+        query: hasEmbeddings ? {k: 10, threshold: 0.01} : {...location.query, limit: 50},
+        staleTime: 0,
       }
-
-      if (mergedParent && mergedParent !== params.groupId) {
-        // Merge success, since we can't specify target, we need to redirect to new parent
-        navigate(`/organizations/${organization.slug}/issues/${mergedParent}/similar/`);
-      }
+    ),
+    select: response => {
+      const items = response.json.map(tuple => processSimilarItem(tuple, hasEmbeddings));
+      return {
+        similar: items.filter(item => !item.isBelowThreshold),
+        filtered: items.filter(item => item.isBelowThreshold),
+        pageLinks: response.headers.Link ?? null,
+      };
     },
-    [navigate, params.groupId, organization.slug]
-  );
-
-  useEffect(() => {
-    fetchData();
-  }, [fetchData]);
-
-  useEffect(() => {
-    if (prevLocationSearch !== location.search) {
-      fetchData();
-    }
-  }, [fetchData, prevLocationSearch, location.search]);
-
-  useEffect(() => {
-    const unsubscribe = GroupingStore.listen(onGroupingChange, undefined);
-    return () => {
-      unsubscribe();
-    };
-  }, [onGroupingChange]);
-
-  const handleMerge = useCallback(() => {
-    if (!params) {
-      return;
-    }
-
-    // You need at least 1 similarItem OR filteredSimilarItems to be able to merge,
-    // so `firstIssue` should always exist from one of those lists.
-    //
-    // Similar issues API currently does not return issues across projects,
-    // so we can assume that the first issues project slug is the project in
-    // scope
-    const [firstIssue] = items.similar.length ? items.similar : items.filtered;
-
-    GroupingStore.onMerge({
-      params,
-      query: location.query.query as string,
-      projectId: firstIssue!.issue.project.slug,
-    });
-  }, [params, location.query, items]);
-
-  const hasSimilarItems =
-    (hasSimilarityFeature || hasSimilarityEmbeddingsFeature) &&
-    (items.similar.length > 0 || items.filtered.length > 0);
-
-  const {data: event} = useGroupEvent({
-    groupId: params.groupId,
-    eventId: 'latest',
   });
 
-  const platformSupportsLongStacktraces = [
-    'go',
-    'javascript',
-    'node',
-    'php',
-    'python',
-    'ruby',
-  ].includes(event?.platform ?? '');
+  // During an in-flight merge, the ids being merged are frozen on the mutation's
+  // `variables`; we derive the "busy" set from that instead of a second useState.
+  const {
+    mutate: mergeMutate,
+    isPending: isMerging,
+    variables,
+  } = useMutation<
+    {merge?: {parent?: string}} | undefined,
+    Error,
+    {ids: string[]; projectSlug: string; query?: string}
+  >({
+    mutationFn: ({ids, projectSlug, query}) =>
+      new Promise((resolve, reject) => {
+        mergeGroups(
+          api,
+          {
+            orgId: organization.slug,
+            projectId: projectSlug,
+            itemIds: [...ids, params.groupId],
+            query,
+          },
+          {
+            success: (data: any) => resolve(data),
+            error: (err: any) =>
+              reject(err instanceof Error ? err : new Error('Failed to merge issues')),
+          }
+        );
+      }),
+    onSuccess: data => {
+      if (data?.merge?.parent && data.merge.parent !== params.groupId) {
+        navigate(
+          `/organizations/${organization.slug}/issues/${data.merge.parent}/similar/`
+        );
+      }
+      setCheckedIds(new Set());
+    },
+  });
 
-  function getEmptyStateWarning() {
-    let message = '';
-    if (!hasSimilarityEmbeddingsFeature && platformSupportsLongStacktraces) {
-      message = t("There don't seem to be any similar issues.");
-    } else if (hasSimilarityEmbeddingsFeature && platformSupportsLongStacktraces) {
-      message = t(
-        "There don't seem to be any similar issues. This can occur when the issue has no stacktrace or in-app frames."
-      );
-    } else if (!platformSupportsLongStacktraces) {
-      message = t(
-        "There don't seem to be any similar issues. This can occur when the issue has no stacktrace or in-app frames, or when the stacktrace has over 30 frames."
-      );
+  const busyIds = isMerging && variables ? new Set(variables.ids) : EMPTY_SET;
+  const {similar = [], filtered = [], pageLinks = null} = result ?? {};
+
+  const handleToggle = useCallback(
+    (id: string) => {
+      if (isMerging) {
+        return;
+      }
+      setCheckedIds(prev => {
+        const next = new Set(prev);
+        if (next.has(id)) {
+          next.delete(id);
+        } else {
+          next.add(id);
+        }
+        return next;
+      });
+    },
+    [isMerging]
+  );
+
+  const handleMerge = useCallback(() => {
+    if (checkedIds.size === 0) {
+      return;
     }
-    return (
-      <Panel>
-        <EmptyStateWarning>
-          <p>{message}</p>
-        </EmptyStateWarning>
-      </Panel>
-    );
-  }
+    // Similar issues API does not return issues across projects, so the first
+    // item's project slug is the project in scope.
+    const [firstIssue] = similar.length ? similar : filtered;
+    if (!firstIssue) {
+      return;
+    }
+    mergeMutate({
+      ids: Array.from(checkedIds),
+      projectSlug: firstIssue.issue.project.slug,
+      query: location.query.query as string,
+    });
+  }, [checkedIds, similar, filtered, location.query, mergeMutate]);
+
+  const {data: event} = useGroupEvent({groupId: params.groupId, eventId: 'latest'});
+  const platformSupportsLongStacktraces = LONG_STACKTRACE_PLATFORMS.includes(
+    event?.platform ?? ''
+  );
+
+  const hasSimilarItems =
+    (hasSimilarityFeature || hasEmbeddings) &&
+    (similar.length > 0 || filtered.length > 0);
+
+  const loading = isPending || isProjectPending || !canFetch;
 
   return (
     <Fragment>
@@ -212,39 +181,53 @@ export function SimilarStackTrace({project}: Props) {
           )}
         </small>
       </HeaderWrapper>
-      {status === 'loading' && <LoadingIndicator />}
-      {status === 'error' && (
+      {isError ? (
         <LoadingError
           message={t('Unable to load similar issues, please try again later')}
-          onRetry={fetchData}
+          onRetry={() => refetch()}
         />
-      )}
-      {status === 'ready' && !hasSimilarItems && getEmptyStateWarning()}
-      {status === 'ready' && hasSimilarItems && !hasSimilarityEmbeddingsFeature && (
+      ) : loading ? (
+        <LoadingIndicator />
+      ) : hasSimilarItems ? (
         <List
-          items={items.similar}
-          filteredItems={items.filtered}
+          items={similar}
+          filteredItems={filtered}
           onMerge={handleMerge}
+          onToggle={handleToggle}
+          checkedIds={checkedIds}
+          busyIds={busyIds}
           project={project}
           groupId={params.groupId}
-          pageLinks={items.pageLinks}
-          hasSimilarityEmbeddingsFeature={hasSimilarityEmbeddingsFeature}
+          pageLinks={pageLinks}
+          hasSimilarityEmbeddingsFeature={hasEmbeddings}
         />
-      )}
-      {status === 'ready' && hasSimilarItems && hasSimilarityEmbeddingsFeature && (
-        <List
-          items={items.similar.concat(items.filtered)}
-          filteredItems={[]}
-          onMerge={handleMerge}
-          project={project}
-          groupId={params.groupId}
-          pageLinks={items.pageLinks}
-          hasSimilarityEmbeddingsFeature={hasSimilarityEmbeddingsFeature}
-        />
+      ) : (
+        <Panel>
+          <EmptyStateWarning>
+            <p>{getEmptyMessage(hasEmbeddings, platformSupportsLongStacktraces)}</p>
+          </EmptyStateWarning>
+        </Panel>
       )}
       <DataConsentBanner source="grouping" />
     </Fragment>
   );
+}
+
+function getEmptyMessage(
+  hasEmbeddings: boolean,
+  platformSupportsLongStacktraces: boolean
+) {
+  if (!platformSupportsLongStacktraces) {
+    return t(
+      "There don't seem to be any similar issues. This can occur when the issue has no stacktrace or in-app frames, or when the stacktrace has over 30 frames."
+    );
+  }
+  if (hasEmbeddings) {
+    return t(
+      "There don't seem to be any similar issues. This can occur when the issue has no stacktrace or in-app frames."
+    );
+  }
+  return t("There don't seem to be any similar issues.");
 }
 
 const Title = styled('h4')`

--- a/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/index.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/index.tsx
@@ -1,6 +1,6 @@
 import {Fragment, useCallback, useState} from 'react';
 import styled from '@emotion/styled';
-import {skipToken, useMutation, useQuery} from '@tanstack/react-query';
+import {useMutation, useQuery} from '@tanstack/react-query';
 
 import {mergeGroups} from 'sentry/actionCreators/group';
 import {EmptyStateWarning} from 'sentry/components/emptyStateWarning';
@@ -67,13 +67,12 @@ export function SimilarStackTrace({project}: Props) {
         ? '/organizations/$organizationIdOrSlug/issues/$issueId/similar-issues-embeddings/'
         : '/organizations/$organizationIdOrSlug/issues/$issueId/similar/',
       {
-        path: canFetch
-          ? {organizationIdOrSlug: organization.slug, issueId: params.groupId}
-          : skipToken,
+        path: {organizationIdOrSlug: organization.slug, issueId: params.groupId},
         query: hasEmbeddings ? {k: 10, threshold: 0.01} : {...location.query, limit: 50},
         staleTime: 0,
       }
     ),
+    enabled: canFetch,
     select: response => {
       const items = response.json.map(tuple => processSimilarItem(tuple, hasEmbeddings));
       return {

--- a/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/item.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/item.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useState} from 'react';
+import {useCallback} from 'react';
 import {css, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import classNames from 'classnames';
@@ -16,14 +16,16 @@ import {PanelItem} from 'sentry/components/panels/panelItem';
 import {ScoreBar} from 'sentry/components/scoreBar';
 import {SimilarScoreCard} from 'sentry/components/similarScoreCard';
 import {t} from 'sentry/locale';
-import {GroupingStore} from 'sentry/stores/groupingStore';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 
 type Props = {
+  busy: boolean;
+  checked: boolean;
   groupId: Group['id'];
   hasSimilarityEmbeddingsFeature: boolean;
   issue: Group;
+  onToggle: (id: string) => void;
   project: Project;
   aggregate?: {
     exception: number;
@@ -39,46 +41,21 @@ type Props = {
 const similarityEmbeddingScoreValues = [0.9, 0.925, 0.95, 0.975, 0.99, 1];
 
 export function SimilarStackTraceItem(props: Props) {
-  const {aggregate, scoresByInterface, issue, hasSimilarityEmbeddingsFeature} = props;
-  const [checked, setChecked] = useState<boolean>(false);
-  const [busy, setBusy] = useState<boolean>(false);
-
-  const onGroupChange = useCallback(
-    ({mergeState}: ReturnType<typeof GroupingStore.getState>) => {
-      if (!mergeState) {
-        return;
-      }
-
-      const stateForId = mergeState.has(issue.id) && mergeState.get(issue.id);
-
-      if (!stateForId) {
-        return;
-      }
-
-      setChecked(prev =>
-        typeof stateForId.checked === 'undefined' ? prev : stateForId.checked
-      );
-      setBusy(prev => (typeof stateForId.busy === 'undefined' ? prev : stateForId.busy));
-    },
-    [issue.id]
-  );
-
-  useEffect(() => {
-    const unsubscribe = GroupingStore.listen(
-      (data: ReturnType<typeof GroupingStore.getState>) => onGroupChange(data),
-      undefined
-    );
-    return () => {
-      unsubscribe?.();
-    };
-  }, [onGroupChange]);
+  const {
+    aggregate,
+    scoresByInterface,
+    issue,
+    hasSimilarityEmbeddingsFeature,
+    checked,
+    busy,
+    onToggle,
+  } = props;
 
   const handleToggle = useCallback(() => {
-    // clicking anywhere in the row will toggle the checkbox
     if (!busy) {
-      GroupingStore.onToggleMerge(issue.id);
+      onToggle(issue.id);
     }
-  }, [busy, issue.id]);
+  }, [busy, issue.id, onToggle]);
 
   const handleShowDiff = (event: React.MouseEvent) => {
     const {groupId: baseIssueId, project} = props;

--- a/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/list.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/list.tsx
@@ -9,25 +9,24 @@ import {Panel} from 'sentry/components/panels/panel';
 import {PanelBody} from 'sentry/components/panels/panelBody';
 import {SimilarSpectrum} from 'sentry/components/similarSpectrum';
 import {t} from 'sentry/locale';
-import type {SimilarItem} from 'sentry/stores/groupingStore';
 import type {Project} from 'sentry/types/project';
-import {useOrganization} from 'sentry/utils/useOrganization';
 
 import {SimilarStackTraceItem} from './item';
 import {SimilarToolbar} from './toolbar';
-
-type DefaultProps = {
-  filteredItems: SimilarItem[];
-};
+import type {SimilarItem} from './types';
 
 type Props = {
+  busyIds: ReadonlySet<string>;
+  checkedIds: ReadonlySet<string>;
+  filteredItems: SimilarItem[];
   groupId: string;
   hasSimilarityEmbeddingsFeature: boolean;
   items: SimilarItem[];
   onMerge: () => void;
+  onToggle: (id: string) => void;
   pageLinks: string | null;
   project: Project;
-} & DefaultProps;
+};
 
 function Empty() {
   return (
@@ -48,6 +47,9 @@ export function List({
   filteredItems = [],
   pageLinks,
   onMerge,
+  onToggle,
+  checkedIds,
+  busyIds,
   hasSimilarityEmbeddingsFeature,
 }: Props) {
   const [showAllItems, setShowAllItems] = useState(false);
@@ -55,13 +57,6 @@ export function List({
   const hasHiddenItems = !!filteredItems.length;
   const hasResults = items.length > 0 || hasHiddenItems;
   const itemsWithFiltered = items.concat(showAllItems ? filteredItems : []);
-  const organization = useOrganization();
-  const itemsWouldGroup = hasSimilarityEmbeddingsFeature
-    ? itemsWithFiltered.map(item => ({
-        id: item.issue.id,
-        shouldBeGrouped: item.aggregate?.shouldBeGrouped,
-      }))
-    : undefined;
 
   if (!hasResults) {
     return <Empty />;
@@ -86,10 +81,7 @@ export function List({
       <Panel>
         <SimilarToolbar
           onMerge={onMerge}
-          groupId={groupId}
-          project={project}
-          organization={organization}
-          itemsWouldGroup={itemsWouldGroup}
+          mergeCount={checkedIds.size}
           hasSimilarityEmbeddingsFeature={hasSimilarityEmbeddingsFeature}
         />
 
@@ -100,6 +92,9 @@ export function List({
               groupId={groupId}
               project={project}
               hasSimilarityEmbeddingsFeature={hasSimilarityEmbeddingsFeature}
+              checked={checkedIds.has(item.issue.id)}
+              busy={busyIds.has(item.issue.id)}
+              onToggle={onToggle}
               {...item}
             />
           ))}

--- a/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/toolbar.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/toolbar.tsx
@@ -1,110 +1,47 @@
-import {Component} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 
-import {addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {Confirm} from 'sentry/components/confirm';
 import {PanelHeader} from 'sentry/components/panels/panelHeader';
 import {ToolbarHeader} from 'sentry/components/toolbarHeader';
 import {t} from 'sentry/locale';
-import {GroupingStore} from 'sentry/stores/groupingStore';
-import type {Organization} from 'sentry/types/organization';
-import type {Project} from 'sentry/types/project';
-import {trackAnalytics} from 'sentry/utils/analytics';
 
 type Props = {
   hasSimilarityEmbeddingsFeature: boolean;
+  mergeCount: number;
   onMerge: () => void;
-  groupId?: string;
-  itemsWouldGroup?: Array<{id: string; shouldBeGrouped: string | undefined}> | undefined;
-  organization?: Organization;
-  project?: Project;
 };
 
-const initialState = {
-  mergeCount: 0,
-  mergeList: [] as string[],
-};
+export function SimilarToolbar({
+  hasSimilarityEmbeddingsFeature,
+  mergeCount,
+  onMerge,
+}: Props) {
+  return (
+    <PanelHeader hasButtons>
+      <Flex gap="md">
+        <Confirm
+          disabled={mergeCount === 0}
+          message={t('Are you sure you want to merge these issues?')}
+          onConfirm={onMerge}
+        >
+          <Button size="xs" tooltipProps={{title: t('Merging %s issues', mergeCount)}}>
+            {t('Merge %s', `(${mergeCount || 0})`)}
+          </Button>
+        </Confirm>
+      </Flex>
 
-type State = typeof initialState;
-
-export class SimilarToolbar extends Component<Props, State> {
-  state: State = initialState;
-
-  componentWillUnmount() {
-    this.listener?.();
-  }
-
-  onGroupChange = ({mergeList}: any) => {
-    if (!mergeList?.length) {
-      this.setState({mergeCount: 0});
-      return;
-    }
-
-    if (mergeList.length !== this.state.mergeCount) {
-      this.setState({mergeCount: mergeList.length, mergeList});
-    }
-  };
-
-  listener = GroupingStore.listen(this.onGroupChange, undefined);
-
-  handleSimilarityEmbeddings = (value: string) => {
-    if (
-      this.state.mergeList.length === 0 ||
-      !this.props.organization ||
-      !this.props.groupId
-    ) {
-      return;
-    }
-    for (const parentGroupId of this.state.mergeList) {
-      const itemWouldGroup = this.props.itemsWouldGroup?.find(
-        item => item.id === parentGroupId
-      );
-      trackAnalytics(
-        'issue_details.similar_issues.similarity_embeddings_feedback_recieved',
-        {
-          organization: this.props.organization,
-          projectId: this.props.project?.id,
-          parentGroupId,
-          groupId: this.props.groupId,
-          value,
-          wouldGroup: itemWouldGroup?.shouldBeGrouped,
-        }
-      );
-    }
-    addSuccessMessage('Sent analytic for similarity embeddings grouping');
-  };
-
-  render() {
-    const {onMerge, hasSimilarityEmbeddingsFeature} = this.props;
-    const {mergeCount} = this.state;
-
-    return (
-      <PanelHeader hasButtons>
-        <Flex gap="md">
-          <Confirm
-            disabled={mergeCount === 0}
-            message={t('Are you sure you want to merge these issues?')}
-            onConfirm={onMerge}
-          >
-            <Button size="xs" tooltipProps={{title: t('Merging %s issues', mergeCount)}}>
-              {t('Merge %s', `(${mergeCount || 0})`)}
-            </Button>
-          </Confirm>
-        </Flex>
-
-        <Flex align="center" flexShrink={0} width="325px" minWidth="325px">
-          <StyledToolbarHeader>{t('Events')}</StyledToolbarHeader>
-          <StyledToolbarHeader>{t('Exception')}</StyledToolbarHeader>
-          {!hasSimilarityEmbeddingsFeature && (
-            <StyledToolbarHeader>{t('Message')}</StyledToolbarHeader>
-          )}
-        </Flex>
-      </PanelHeader>
-    );
-  }
+      <Flex align="center" flexShrink={0} width="325px" minWidth="325px">
+        <StyledToolbarHeader>{t('Events')}</StyledToolbarHeader>
+        <StyledToolbarHeader>{t('Exception')}</StyledToolbarHeader>
+        {!hasSimilarityEmbeddingsFeature && (
+          <StyledToolbarHeader>{t('Message')}</StyledToolbarHeader>
+        )}
+      </Flex>
+    </PanelHeader>
+  );
 }
 
 const StyledToolbarHeader = styled(ToolbarHeader)`

--- a/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/types.ts
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/types.ts
@@ -1,0 +1,69 @@
+import type {Group} from 'sentry/types/group';
+
+export type ScoreMap = Record<string, number | null | string>;
+
+export type SimilarItem = {
+  isBelowThreshold: boolean;
+  issue: Group;
+  aggregate?: {
+    exception: number;
+    message: number;
+    shouldBeGrouped?: string;
+  };
+  score?: Record<string, number | null>;
+  scoresByInterface?: {
+    exception: Array<[string, number | null]>;
+    message: Array<[string, any | null]>;
+    shouldBeGrouped?: Array<[string, string | null]>;
+  };
+};
+
+export type SimilarApiResponse = Array<[Group, ScoreMap]>;
+
+const MIN_SCORE = 0.6;
+
+function checkBelowThreshold(scores: ScoreMap) {
+  return !Object.values(scores).some(score => Number(score) >= MIN_SCORE);
+}
+
+export function processSimilarItem(
+  [issue, scoreMap]: [Group, ScoreMap],
+  hasSimilarityEmbeddingsFeature: boolean
+): SimilarItem {
+  const isBelowThreshold = hasSimilarityEmbeddingsFeature
+    ? false
+    : checkBelowThreshold(scoreMap);
+
+  const scoresByInterface = Object.entries(scoreMap).reduce<
+    Record<string, Array<[string, number | null | string]>>
+  >((acc, [scoreKey, score]) => {
+    const [interfaceName] = String(scoreKey).split(':') as [string];
+
+    if (!acc[interfaceName]) {
+      acc[interfaceName] = [];
+    }
+    acc[interfaceName].push([scoreKey, score]);
+
+    return acc;
+  }, {});
+
+  const aggregate = Object.entries(scoresByInterface).reduce<
+    Record<string, number | string>
+  >((acc, [interfaceName, allScores]) => {
+    const scores = allScores.filter(([, score]) => score !== null);
+
+    const avg = scores.reduce((sum, [, score]) => sum + Number(score), 0) / scores.length;
+    acc[interfaceName] = hasSimilarityEmbeddingsFeature
+      ? (scores[0]![1] as number | string)
+      : avg;
+    return acc;
+  }, {});
+
+  return {
+    issue,
+    score: scoreMap as Record<string, number | null>,
+    scoresByInterface: scoresByInterface as SimilarItem['scoresByInterface'],
+    aggregate: aggregate as SimilarItem['aggregate'],
+    isBelowThreshold,
+  };
+}

--- a/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/types.ts
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/types.ts
@@ -2,6 +2,9 @@ import type {Group} from 'sentry/types/group';
 
 export type ScoreMap = Record<string, number | null | string>;
 
+type ScoresByInterface = NonNullable<SimilarItem['scoresByInterface']>;
+type Aggregate = NonNullable<SimilarItem['aggregate']>;
+
 export type SimilarItem = {
   isBelowThreshold: boolean;
   issue: Group;
@@ -10,7 +13,7 @@ export type SimilarItem = {
     message: number;
     shouldBeGrouped?: string;
   };
-  score?: Record<string, number | null>;
+  score?: ScoreMap;
   scoresByInterface?: {
     exception: Array<[string, number | null]>;
     message: Array<[string, any | null]>;
@@ -34,36 +37,34 @@ export function processSimilarItem(
     ? false
     : checkBelowThreshold(scoreMap);
 
-  const scoresByInterface = Object.entries(scoreMap).reduce<
-    Record<string, Array<[string, number | null | string]>>
-  >((acc, [scoreKey, score]) => {
-    const [interfaceName] = String(scoreKey).split(':') as [string];
+  const scoresByInterface: Record<string, Array<[string, number | null | string]>> = {};
+  for (const [scoreKey, score] of Object.entries(scoreMap)) {
+    const [interfaceName = scoreKey] = scoreKey.split(':');
+    (scoresByInterface[interfaceName] ??= []).push([scoreKey, score]);
+  }
 
-    if (!acc[interfaceName]) {
-      acc[interfaceName] = [];
+  const aggregate: Record<string, number | string> = {};
+  for (const [interfaceName, allScores] of Object.entries(scoresByInterface)) {
+    const scores = allScores.filter(
+      (entry): entry is [string, number | string] => entry[1] !== null
+    );
+
+    if (hasSimilarityEmbeddingsFeature) {
+      const firstScore = scores[0]?.[1];
+      if (firstScore !== undefined) {
+        aggregate[interfaceName] = firstScore;
+      }
+    } else {
+      aggregate[interfaceName] =
+        scores.reduce((sum, [, score]) => sum + Number(score), 0) / scores.length;
     }
-    acc[interfaceName].push([scoreKey, score]);
-
-    return acc;
-  }, {});
-
-  const aggregate = Object.entries(scoresByInterface).reduce<
-    Record<string, number | string>
-  >((acc, [interfaceName, allScores]) => {
-    const scores = allScores.filter(([, score]) => score !== null);
-
-    const avg = scores.reduce((sum, [, score]) => sum + Number(score), 0) / scores.length;
-    acc[interfaceName] = hasSimilarityEmbeddingsFeature
-      ? (scores[0]![1] as number | string)
-      : avg;
-    return acc;
-  }, {});
+  }
 
   return {
     issue,
-    score: scoreMap as Record<string, number | null>,
-    scoresByInterface: scoresByInterface as SimilarItem['scoresByInterface'],
-    aggregate: aggregate as SimilarItem['aggregate'],
+    score: scoreMap,
+    scoresByInterface: scoresByInterface as ScoresByInterface,
+    aggregate: aggregate as Aggregate,
     isBelowThreshold,
   };
 }


### PR DESCRIPTION
Moves the Similar Issues tab off the Reflux `GroupingStore` and onto react-query + `apiOptions`. Selection and merge state live in local React state now, and the in-flight merge drives the row busy state off the mutation's `variables` instead of a parallel store.

Also strips out the similar-only half of `GroupingStore` since nothing else reads from it. Merged/unmerge state stays intact for the Merged Issues tab.

First of two stacked PRs - the SimpleTable layout migration follows in #113341.