### PR TITLE
fix(dashboards): add character limit to text widget content

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -383,6 +383,12 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
                 {"widget_type": "Text widgets don't have a widget type or dataset"}
             )
 
+        description = data.get("description")
+        if description is not None and len(description) > 15000:
+            raise serializers.ValidationError(
+                {"description": "Description must not exceed 15,000 characters"}
+            )
+
         queries = data.get("queries")
         if queries and len(queries) > 0:
             raise serializers.ValidationError({"queries": "Text widgets don't have queries"})

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -1332,6 +1332,28 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
             assert response.status_code == 200, response.data
             assert response.data["widgets"][1]["description"] == "x" * 256
 
+    def test_update_text_widget_description_exceeds_15000_chars(self) -> None:
+        with self.feature("organizations:dashboards-text-widgets"):
+            data = {
+                "title": "First dashboard",
+                "widgets": [
+                    {"id": str(self.widget_1.id)},
+                    {
+                        "id": str(self.widget_2.id),
+                        "title": "Text Widget",
+                        "displayType": "text",
+                        "description": "x" * 15001,
+                    },
+                ],
+            }
+            response = self.do_request("put", self.url(self.dashboard.id), data=data)
+            assert response.status_code == 400, response.data
+            assert "description" in response.data["widgets"][1], response.data
+            assert (
+                response.data["widgets"][1]["description"][0]
+                == "Description must not exceed 15,000 characters"
+            )
+
     def test_add_widget_with_limit(self) -> None:
         data = {
             "title": "First dashboard",

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_widget_details.py
@@ -1489,6 +1489,20 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             assert response.status_code == 400, response.data
             assert "title" in response.data, response.data
 
+    def test_text_widget_description_exceeds_max_length(self) -> None:
+        with self.feature("organizations:dashboards-text-widgets"):
+            data = {
+                "title": "Text Widget Title",
+                "displayType": "text",
+                "description": "x" * 15001,
+            }
+            response = self.do_request("post", self.url(), data=data)
+            assert response.status_code == 400, response.data
+            assert "description" in response.data, response.data
+            assert (
+                response.data["description"][0] == "Description must not exceed 15,000 characters"
+            )
+
     def test_widget_with_invalid_dataset_source(self) -> None:
         data = {
             "title": "Errors over time",


### PR DESCRIPTION
had a discussion with James and Ben a little while ago about adding a limit in and then i forgot about it whoops BUT i remembered now so here it is 🤩 