### PR TITLE
test(explore): Use paste instead of type for spans tab query input

### DIFF
--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -461,10 +461,11 @@ describe('SpansTabContent', () => {
 
       const input = screen.getByRole('combobox');
       await userEvent.click(input);
-      await userEvent.type(input, 'span.duration:>10ms{enter}');
+      await userEvent.paste('span.duration:>10ms');
+      await userEvent.keyboard('{Enter}');
 
       await userEvent.click(input);
-      await userEvent.type(input, ' random');
+      await userEvent.paste(' random');
 
       const askSeer = await screen.findByText(/Ask AI to build your query/);
       await userEvent.click(askSeer);


### PR DESCRIPTION
https://github.com/getsentry/sentry/actions/runs/24581633107/job/71880744125?pr=113344 test was timing out in CI, switch to paste to avoid rerendering on every key down event.