### PR TITLE
fix(onboarding): Emit scm_platform_selected on auto-detection

### DIFF
--- a/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.spec.tsx
@@ -532,6 +532,46 @@ describe('ScmPlatformFeatures', () => {
       );
     });
 
+    it('fires platform selected event once when auto-detection resolves', async () => {
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/repos/42/platforms/`,
+        body: {
+          platforms: [
+            DetectedPlatformFixture(),
+            DetectedPlatformFixture({
+              platform: 'python-django',
+              language: 'Python',
+              priority: 2,
+            }),
+          ],
+        },
+      });
+
+      render(
+        <ScmPlatformFeatures
+          onComplete={jest.fn()}
+          stepIndex={2}
+          genSkipOnboardingLink={() => null}
+        />,
+        {
+          organization,
+          additionalWrapper: makeOnboardingWrapper({
+            selectedRepository: mockRepository,
+          }),
+        }
+      );
+
+      await screen.findByText('What do you want to set up?');
+
+      const detectedCalls = trackAnalyticsSpy.mock.calls.filter(
+        ([event, params]) =>
+          event === 'onboarding.scm_platform_selected' &&
+          params.platform === 'javascript-nextjs' &&
+          params.source === 'detected'
+      );
+      expect(detectedCalls).toHaveLength(1);
+    });
+
     it('fires feature toggled event when toggling a feature', async () => {
       MockApiClient.addMockResponse({
         url: `/organizations/${organization.slug}/repos/42/platforms/`,

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useMemo, useState} from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {LayoutGroup, motion} from 'framer-motion';
 import {PlatformIcon} from 'platformicons';
 
@@ -131,6 +131,27 @@ export function ScmPlatformFeatures({onComplete}: StepProps) {
   const detectedPlatformKey = resolvedPlatforms[0]?.platform;
   // Derive platform from explicit selection, falling back to first detected
   const currentPlatformKey = selectedPlatform?.key ?? detectedPlatformKey;
+
+  // Fire scm_platform_selected once when detection auto-resolves a platform
+  // and the user hasn't explicitly chosen one. Otherwise a user who accepts
+  // the recommendation and clicks Continue never emits the event, leaving
+  // the funnel without a platform-selected step.
+  const autoDetectionTrackedRef = useRef(false);
+  useEffect(() => {
+    if (
+      autoDetectionTrackedRef.current ||
+      !detectedPlatformKey ||
+      selectedPlatform?.key
+    ) {
+      return;
+    }
+    autoDetectionTrackedRef.current = true;
+    trackAnalytics('onboarding.scm_platform_selected', {
+      organization,
+      platform: detectedPlatformKey,
+      source: 'detected',
+    });
+  }, [detectedPlatformKey, selectedPlatform?.key, organization]);
 
   const availableFeatures = useMemo(
     () =>


### PR DESCRIPTION
Fire `onboarding.scm_platform_selected` with `source: 'detected'` once when the SCM onboarding platform auto-detection resolves and the user has not explicitly chosen a platform.

Previously the event only fired when the user clicked a detected platform card or picked manually. Users who accepted the recommended platform and advanced with Continue never emitted a platform-selected event, leaving the funnel without a step between `scm_platform_features_step_viewed` and `scm_platform_features_continue_clicked`.

The event is gated by a ref so it fires at most once per mount. A test asserts that exactly one `source: 'detected'` event fires when detection resolves on mount with no explicit selection.

Refs VDY-90