### PR TITLE
fix(aci): Only show gridline information, if we have data available

### DIFF
--- a/static/app/views/detectors/components/detectorListTable/index.tsx
+++ b/static/app/views/detectors/components/detectorListTable/index.tsx
@@ -190,7 +190,7 @@ export function DetectorListTable({
             {additionalColumns.map(col => (
               <Fragment key={col.id}>{col.renderHeaderCell()}</Fragment>
             ))}
-            {hasVisualization && (
+            {hasVisualization && detectors.length > 0 && (
               <VisualizationHeaderContainer
                 data-column-name="visualization"
                 ref={elementRef}
@@ -255,7 +255,7 @@ export function DetectorListTable({
             </StyledFlex>
           </SimpleTable.Empty>
         )}
-        {hasVisualization && (
+        {hasVisualization && detectors.length > 0 && (
           <PositionedGridLineOverlay
             stickyCursor
             allowZoom


### PR DESCRIPTION
# Description
Currently, we're showing gridlines ontop of things in uptime because we aren't checking to see if there is data or not when rendering. This ends up looking weird and covering the empty state.

### Before
<img width="2672" height="1522" alt="Screenshot 2026-04-17 at 1 28 23 PM" src="https://github.com/user-attachments/assets/463714f8-6c52-4804-be7c-0da5a1fadb47" />
<img width="1392" height="1522" alt="Screenshot 2026-04-17 at 1 28 28 PM" src="https://github.com/user-attachments/assets/f2ac4514-dfb3-434d-8a0b-a80ed0268ee7" />


### Afte
<img width="1392" height="1522" alt="Screenshot 2026-04-17 at 1 25 53 PM" src="https://github.com/user-attachments/assets/1967a266-3e14-4f15-968b-9efa4ff0f07f" />
<img width="2672" height="1522" alt="Screenshot 2026-04-17 at 1 25 57 PM" src="https://github.com/user-attachments/assets/9a083b51-2c21-4e7e-a1b9-59c9cd585db1" />
r