### PR TITLE
fix(dropdowns): match focused item mask to overlay background token

### DIFF
--- a/static/app/components/core/menuListItem/menuListItem.tsx
+++ b/static/app/components/core/menuListItem/menuListItem.tsx
@@ -105,7 +105,7 @@ const StyledInnerWrap = styled('div', {
       z-index: 1;
       /* Background to hide the previous item's divider */
       ::before {
-        background: ${p.theme.tokens.background.primary};
+        background: ${p.theme.tokens.background.overlay};
       }
     `}
 `;

--- a/static/app/components/overlay.tsx
+++ b/static/app/components/overlay.tsx
@@ -140,9 +140,7 @@ const OverlayInner = styled(motion.div)<{
   border-radius: ${p => p.theme.radius.md};
   border: 1px solid ${p => p.theme.tokens.border.primary};
   /* eslint-disable-next-line @sentry/scraps/use-semantic-token */
-  box-shadow:
-    0 2px 0 ${p => p.theme.tokens.border.primary},
-    ${p => p.theme.shadow.medium};
+  box-shadow: 0 2px 0 ${p => p.theme.tokens.border.primary};
   font-size: ${p => p.theme.font.size.md};
 
   /* Override z-index from useOverlayPosition */


### PR DESCRIPTION
Fixes incorrect highlighting for dropdown selectors
Before:
<img width="389" height="171" alt="Screenshot 2026-04-17 at 1 20 29 PM" src="https://github.com/user-attachments/assets/26420284-935b-4039-9eb2-3ec87283a285" />
After:
<img width="397" height="142" alt="Screenshot 2026-04-17 at 1 30 55 PM" src="https://github.com/user-attachments/assets/e90de8bc-8ed2-46f7-a5b3-bc6402d0ebb7" />
