### PR TITLE
fix(aci): Don't allowe editing a project

### DIFF
--- a/static/app/views/detectors/components/forms/common/projectField.tsx
+++ b/static/app/views/detectors/components/forms/common/projectField.tsx
@@ -9,9 +9,10 @@ import {useCanEditDetector} from 'sentry/views/detectors/utils/useCanEditDetecto
 
 export function ProjectField() {
   const {projects, fetching} = useProjects();
-  const {detectorType} = useDetectorFormContext();
+  const {detectorType, detector} = useDetectorFormContext();
   const project = useDetectorFormProject();
   const canEditDetector = useCanEditDetector({projectId: project.id, detectorType});
+  const isEditing = !!detector;
 
   return (
     <StyledProjectField
@@ -28,7 +29,7 @@ export function ProjectField() {
       label={t('Project')}
       placeholder={t('Project')}
       aria-label={t('Select Project')}
-      disabled={fetching}
+      disabled={fetching || isEditing}
       size="sm"
       required
       validate={() => {


### PR DESCRIPTION
# Description
https://linear.app/getsentry/issue/ISWF-2124/cant-update-project-on-detector outlines some of why this is harder to allow editing the project. instead, this will disable editing in the UI to make it clearer that it's not intentional.

## Before
<img width="1392" height="1522" alt="Screenshot 2026-04-17 at 1 55 54 PM" src="https://github.com/user-attachments/assets/52700212-7880-435d-befa-1cb0a9cbc0ea" />

## After
<img width="1392" height="1522" alt="Screenshot 2026-04-17 at 1 55 06 PM" src="https://github.com/user-attachments/assets/3fe55f4c-57ec-4121-9730-facc5aee44c1" />
