### PR TITLE
ref(ci): retry devservices up with telemetry

### DIFF
--- a/.github/actions/setup-devservices/action.yml
+++ b/.github/actions/setup-devservices/action.yml
@@ -1,13 +1,17 @@
 name: 'Early Devservices'
-description: 'Starts devservices in the background so image pulls overlap with venv setup'
+description: 'Starts devservices in the background so image pulls overlap with venv setup. Retries on failure with per-line timestamped logs and a docker/host heartbeat.'
 inputs:
   mode:
     description: 'devservices mode (must match the mode passed to setup-sentry)'
     required: true
   timeout-minutes:
-    description: 'Maximum minutes for devservices up'
+    description: 'Per-attempt timeout for devservices up (minutes). Total budget = timeout-minutes × max-attempts.'
     required: false
-    default: '10'
+    default: '4'
+  max-attempts:
+    description: 'Number of attempts before giving up'
+    required: false
+    default: '3'
 
 runs:
   using: 'composite'
@@ -34,5 +38,9 @@ runs:
         uv pip install --python /tmp/ds-venv/bin/python -q \
           --index-url https://pypi.devinfra.sentry.io/simple \
           "devservices==${DS_VERSION}"
-        (set +e; timeout ${{ inputs.timeout-minutes }}m /tmp/ds-venv/bin/devservices up --mode ${{ inputs.mode }}; echo $? > /tmp/ds-exit) \
+        : > /tmp/ds-heartbeat.log
+        "${GITHUB_ACTION_PATH}/run.sh" \
+          "${{ inputs.mode }}" \
+          "${{ inputs.timeout-minutes }}m" \
+          "${{ inputs.max-attempts }}" \
           > /tmp/ds.log 2>&1 &

--- a/.github/actions/setup-devservices/run.sh
+++ b/.github/actions/setup-devservices/run.sh
@@ -54,11 +54,22 @@ dump_diag() {
   echo "::endgroup::"
 }
 
+stamp_lines() {
+  # Prefix each stdin line with a UTC wall-clock time. Python3 is always on
+  # GH-hosted runners; `ts` (moreutils) is not.
+  python3 -u -c '
+import sys, time
+for line in sys.stdin:
+    sys.stdout.write("[%s] %s" % (time.strftime("%H:%M:%S", time.gmtime()), line))
+    sys.stdout.flush()
+'
+}
+
 rc=1
 for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
   echo "::group::devservices up attempt $attempt/$MAX_ATTEMPTS (per-attempt timeout: $ATTEMPT_TIMEOUT, $(elapsed))"
   stdbuf -oL -eL timeout "$ATTEMPT_TIMEOUT" "$DS" up --mode "$MODE" 2>&1 \
-    | ts '[%H:%M:%.S]'
+    | stamp_lines
   rc=${PIPESTATUS[0]}
   echo "attempt $attempt finished rc=$rc ($(elapsed))"
   echo "::endgroup::"

--- a/.github/actions/setup-devservices/run.sh
+++ b/.github/actions/setup-devservices/run.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Runs `devservices up` with retries and telemetry. Intended to be launched in
+# the background by setup-devservices/action.yml. Writes the final exit code
+# to /tmp/ds-exit after all attempts, and structured output (including
+# per-line timestamps on devservices output) to stdout — the caller redirects
+# that to /tmp/ds.log. A separate heartbeat sidecar appends docker + host
+# state to /tmp/ds-heartbeat.log every 15s, so a future silent hang can be
+# diagnosed from the heartbeat trail.
+#
+# Usage: run.sh <mode> <attempt-timeout> <max-attempts>
+#   mode             devservices mode, e.g. acceptance-ci
+#   attempt-timeout  per-attempt timeout passed to `timeout`, e.g. 4m
+#   max-attempts     integer >= 1
+set +e
+
+MODE="$1"
+ATTEMPT_TIMEOUT="$2"
+MAX_ATTEMPTS="$3"
+DS=/tmp/ds-venv/bin/devservices
+START_EPOCH=$(date +%s)
+
+elapsed() { echo "+$(( $(date +%s) - START_EPOCH ))s"; }
+
+(
+  while :; do
+    {
+      echo "=== heartbeat $(date -u +%T) ($(elapsed)) ==="
+      echo "-- docker ps --"
+      timeout 5 docker ps -a --format 'table {{.Names}}\t{{.Status}}\t{{.Image}}' \
+        || echo "docker ps hung or failed"
+      echo "-- docker/compose procs --"
+      pgrep -af 'docker|compose|devservices' || echo "none"
+      echo "-- df / --"; df -h / | tail -1
+      echo "-- free --";  free -m | awk 'NR<=2'
+      echo
+    } >> /tmp/ds-heartbeat.log 2>&1
+    sleep 15
+  done
+) &
+HB_PID=$!
+trap 'kill "$HB_PID" 2>/dev/null' EXIT
+
+dump_diag() {
+  local tag="$1"
+  echo "::group::$tag diagnostics"
+  echo "-- docker info --"
+  timeout 10 docker info 2>&1 | head -40 || true
+  echo "-- docker ps -a --"
+  timeout 10 docker ps -a 2>&1 || true
+  echo "-- procs --"
+  pgrep -af 'docker|compose|devservices' || true
+  echo "-- journalctl docker (last 10m, tail 50) --"
+  sudo journalctl -u docker.service --since "10 min ago" --no-pager 2>&1 | tail -50 || true
+  echo "::endgroup::"
+}
+
+rc=1
+for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+  echo "::group::devservices up attempt $attempt/$MAX_ATTEMPTS (per-attempt timeout: $ATTEMPT_TIMEOUT, $(elapsed))"
+  stdbuf -oL -eL timeout "$ATTEMPT_TIMEOUT" "$DS" up --mode "$MODE" 2>&1 \
+    | ts '[%H:%M:%.S]'
+  rc=${PIPESTATUS[0]}
+  echo "attempt $attempt finished rc=$rc ($(elapsed))"
+  echo "::endgroup::"
+  if [ "$rc" -eq 0 ]; then
+    break
+  fi
+  dump_diag "attempt $attempt failure"
+  if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+    echo "::group::cleanup before retry"
+    timeout 60 "$DS" down --mode "$MODE" 2>&1 \
+      || echo "devservices down hung or failed (non-fatal)"
+    echo "::endgroup::"
+    sleep 3
+  fi
+done
+
+echo "$rc" > /tmp/ds-exit

--- a/.github/actions/setup-devservices/wait.sh
+++ b/.github/actions/setup-devservices/wait.sh
@@ -1,15 +1,29 @@
 #!/bin/bash
 set -euo pipefail
 
-# Wait for the background devservices process started by the setup-devservices action.
+# Wait for the background devservices process started by setup-devservices/action.yml.
+# run.sh handles retries internally and writes the final rc to /tmp/ds-exit, so
+# this ceiling just needs to cover the worst-case retry budget
+# (default: 3 attempts × 4m + diagnostics/sleeps ≈ 13m). Bumped from 600s.
 # Usage: wait.sh [timeout_seconds]
-TIMEOUT=${1:-600}
+TIMEOUT=${1:-900}
+
+dump_logs() {
+  if [ -f /tmp/ds.log ]; then
+    echo "--- /tmp/ds.log ---"
+    cat /tmp/ds.log
+  fi
+  if [ -f /tmp/ds-heartbeat.log ]; then
+    echo "--- /tmp/ds-heartbeat.log (last 200 lines) ---"
+    tail -n 200 /tmp/ds-heartbeat.log
+  fi
+}
 
 SECONDS=0
 while [ ! -f /tmp/ds-exit ]; do
   if [ $SECONDS -gt "$TIMEOUT" ]; then
     echo "::error::Timed out waiting for devservices after ${TIMEOUT}s"
-    cat /tmp/ds.log
+    dump_logs
     exit 1
   fi
   sleep 2
@@ -17,8 +31,8 @@ done
 
 DS_RC=$(< /tmp/ds-exit)
 if [ "$DS_RC" -ne 0 ]; then
-  echo "::error::devservices up failed (exit $DS_RC)"
-  cat /tmp/ds.log
+  echo "::error::devservices up failed (exit $DS_RC) after retries"
+  dump_logs
   exit 1
 fi
 


### PR DESCRIPTION
Acceptance and backend shards occasionally fail on `devservices up` with exit 124 — the 10-min SIGKILL — with no actionable log, forcing a manual rerun. [Example job](https://github.com/getsentry/sentry/actions/runs/24583849686/job/71888363725). We also can't tell from the log whether pulls took 1 min or 9 min, because devservices writes to /tmp/ds.log in the background and the file only gets flushed to GitHub when a later step runs `cat`, collapsing every line to a single ingest timestamp.

This change replaces the single-shot `timeout 10m devservices up` with a retry-aware runner and adds telemetry so the next failure self-diagnoses.

Key points:

- Up to 3 attempts × 4 min each, instead of 1 attempt × 10 min. Worst case ~13 min (was 10 min); typical transient-hang recovery drops from 10 min fail + manual rerun to ~6 min, fully automatic.
- Between attempts: `devservices down` + dump of `docker info`, `docker ps -a`, process tree, and `journalctl -u docker`.
- Per-line wall-clock timestamps on devservices stdout via a python wrapper (`ts`/moreutils isn't preinstalled on GH-hosted runners).
- 15s heartbeat sidecar writes `docker ps`, relevant procs, disk, and memory to `/tmp/ds-heartbeat.log` throughout the run — so a silent hang leaves a timeline instead of a blank wall.
- `wait.sh` ceiling bumped 600s → 900s to cover the retry budget and dumps the heartbeat tail alongside ds.log on failure.
- New `max-attempts` input (default 3). `timeout-minutes` default changes 10 → 4 and becomes **per-attempt**; no caller passes it explicitly.

Test plan:

- [ ] CI green
- [ ] On a successful run, `/tmp/ds.log` is timestamped per line and `/tmp/ds-heartbeat.log` shows the expected 15s cadence
- [ ] On the next natural flake, the heartbeat + timestamped log determine whether the hang is in pulls vs post-pull so we can tune recovery in a follow-up