### PR TITLE
ref(performance): Get transaction replay count with EAP

### DIFF
--- a/static/app/components/replays/replayCountBadge.tsx
+++ b/static/app/components/replays/replayCountBadge.tsx
@@ -1,6 +1,15 @@
 import {Badge} from '@sentry/scraps/badge';
 
-export function ReplayCountBadge({count}: {count: undefined | number}) {
-  const display = count && count > 50 ? '50+' : (count ?? null);
+export function ReplayCountBadge({
+  count,
+  limit,
+}: {
+  count: undefined | number;
+  limit: number;
+}) {
+  if (count === undefined) {
+    return null;
+  }
+  const display = count > limit ? `${limit}+` : count;
   return <Badge variant="muted">{display}</Badge>;
 }

--- a/static/app/utils/replayCount/useReplayCountForTransactions.tsx
+++ b/static/app/utils/replayCount/useReplayCountForTransactions.tsx
@@ -1,36 +1,41 @@
-import {useMemo} from 'react';
-
-import {useReplayCount} from 'sentry/utils/replayCount/useReplayCount';
-import {useOrganization} from 'sentry/utils/useOrganization';
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
+import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 
 interface Props {
-  bufferLimit?: number;
+  limit: number;
+  transaction: string;
   statsPeriod?: string;
 }
 
-/**
- * Query results for whether a Transaction has replays associated.
- */
 export function useReplayCountForTransactions({
-  bufferLimit = 25,
+  limit,
+  transaction,
   statsPeriod = '14d',
-}: Props = {}) {
-  const organization = useOrganization();
-  const {getOne, getMany, hasOne, hasMany} = useReplayCount({
-    bufferLimit,
-    dataSource: 'discover',
-    fieldName: 'transaction',
-    organization,
-    statsPeriod,
-  });
+}: Props): number | undefined {
+  const {selection} = usePageFilters();
 
-  return useMemo(
-    () => ({
-      getReplayCountForTransaction: getOne,
-      getReplayCountForTransactions: getMany,
-      transactionHasReplay: hasOne,
-      transactionsHaveReplay: hasMany,
-    }),
-    [getMany, getOne, hasMany, hasOne]
+  const search = new MutableSearch('has:replay.id is_transaction:true');
+  search.addFilterValue('transaction', transaction);
+
+  const {data, isPending} = useSpans(
+    {
+      search,
+      // `count()` ensures we get one row per unique replay ID
+      fields: ['replay.id', 'count()'],
+      limit: limit + 1,
+      pageFilters: {
+        ...selection,
+        datetime: {
+          period: statsPeriod,
+          start: null,
+          end: null,
+          utc: selection.datetime.utc,
+        },
+      },
+    },
+    'api.performance.transaction-summary.replay-count'
   );
+
+  return isPending ? undefined : data.length;
 }

--- a/static/app/views/performance/transactionSummary/header.spec.tsx
+++ b/static/app/views/performance/transactionSummary/header.spec.tsx
@@ -52,8 +52,8 @@ describe('Performance > Transaction Summary Header', () => {
   beforeEach(() => {
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/replay-count/',
-      body: {},
+      url: '/organizations/org-slug/events/',
+      body: {data: []},
     });
   });
 

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -50,6 +50,8 @@ import TeamKeyTransactionButton from './teamKeyTransactionButton';
 import TransactionThresholdButton from './transactionThresholdButton';
 import type {TransactionThresholdMetric} from './transactionThresholdModal';
 
+const REPLAY_COUNT_LIMIT = 50;
+
 type Props = {
   currentTab: Tab;
   eventView: EventView;
@@ -151,10 +153,11 @@ export function TransactionHeader({
     isProfilingSupportedOrProjectHasProfiles(project);
 
   // Hard-code 90d for the replay tab to surface more interesting data.
-  const {getReplayCountForTransaction} = useReplayCountForTransactions({
+  const replaysCount = useReplayCountForTransactions({
+    transaction: transactionName,
     statsPeriod: '90d',
+    limit: REPLAY_COUNT_LIMIT,
   });
-  const replaysCount = getReplayCountForTransaction(transactionName);
 
   const tabList = (
     <TabList
@@ -169,7 +172,7 @@ export function TransactionHeader({
       </TabList.Item>
       <TabList.Item key={Tab.REPLAYS} textValue={t('Replays')} hidden={!hasSessionReplay}>
         {t('Replays')}
-        <ReplayCountBadge count={replaysCount} />
+        <ReplayCountBadge count={replaysCount} limit={REPLAY_COUNT_LIMIT} />
       </TabList.Item>
       <TabList.Item key={Tab.PROFILING} textValue={t('Profiling')} hidden={!hasProfiling}>
         {t('Profiles')}
@@ -415,7 +418,7 @@ export function TransactionHeader({
           hidden={!hasSessionReplay}
         >
           {t('Replays')}
-          <ReplayCountBadge count={replaysCount} />
+          <ReplayCountBadge count={replaysCount} limit={REPLAY_COUNT_LIMIT} />
         </TabList.Item>
         <TabList.Item
           key={Tab.PROFILING}

--- a/static/app/views/performance/transactionSummary/transactionReplays/index.spec.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/index.spec.tsx
@@ -156,7 +156,14 @@ describe('TransactionReplays', () => {
 
     expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
     await waitFor(() => {
-      expect(mockApi).toHaveBeenCalledTimes(1);
+      expect(mockApi).toHaveBeenCalledWith(
+        mockEventsUrl,
+        expect.objectContaining({
+          query: expect.objectContaining({
+            query: 'event.type:transaction transaction:"Settings Page" !replayId:""',
+          }),
+        })
+      );
     });
   });
 


### PR DESCRIPTION
Migrate `useReplayCountForTransactions` off the legacy `transactions` dataset (via `/replay-count/` endpoint) and onto the spans/EAP dataset via `useSpans`, matching where the rest of insights is moving.

The hook only has one caller (transaction summary header) and only ever asked for a single transaction at a time, so the four-function indirection (`getReplayCountForTransaction`, `getReplayCountForTransactions`, `transactionHasReplay`, `transactionsHaveReplay`) is dropped in favour of a hook that returns the count directly for the transaction it's called with.

I'm guessing that querying `limit + 1` rows instead of a `count_unique` on replay IDs is faster since we can return results as soon as the limit is reached, but the `count()` we're doing to dedupe might defeat that. Nonetheless, the query appears faster on Sentry than it used to be (in local testing).

Fixes DAIN-1471.

Also fixes DAIN-1456.