### PR TITLE
chore(iswf): Uses repository URL by default when linking external repos

### DIFF
--- a/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeRow.tsx
+++ b/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeRow.tsx
@@ -315,7 +315,7 @@ function RepoRow({
           {node.repo.url || node.integration.domainName ? (
             <ExternalLink
               href={
-                node.repo.url ??
+                node.repo.url ||
                 `https://${node.integration.domainName}/${node.repo.name}`
               }
             >

--- a/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeRow.tsx
+++ b/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeRow.tsx
@@ -312,12 +312,15 @@ function RepoRow({
           marginLeft="2xl"
           paddingLeft="3xl"
         >
-          {node.integration.domainName ? (
+          {node.repo.url || node.integration.domainName ? (
             <ExternalLink
-              href={`https://${node.integration.domainName}/${node.repo.name}`}
+              href={
+                node.repo.url ??
+                `https://${node.integration.domainName}/${node.repo.name}`
+              }
             >
               <Flex align="center" gap="sm">
-                {node.integration.domainName}/{node.repo.name}
+                {node.repo.name}
                 <IconOpen size="xs" />
               </Flex>
             </ExternalLink>

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -112,6 +112,7 @@ export type IntegrationRepository = {
   isInstalled: boolean;
   name: string;
   defaultBranch?: string | null;
+  url?: string | null;
 };
 
 export type Commit = {


### PR DESCRIPTION
Follow up to #113358, uses the Repository's URL property first when creating links, but falls back to the domain and repo names if it's not available.

Resolves ISWF-2487