### PR TITLE
fix(explorer): clear loading and rethink states on completed state

### DIFF
--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
@@ -389,57 +389,5 @@ describe('useSeerExplorer', () => {
       const blocks = result.current.sessionData?.blocks ?? [];
       expect(blocks.some(b => b.message.role === 'assistant' && b.loading)).toBe(true);
     });
-
-    it('keeps optimistic state when rethinking with the same message', async () => {
-      const chatUrl = `/organizations/${organization.slug}/seer/explorer-chat/`;
-      const ts = '2024-01-01T00:00:00Z';
-
-      MockApiClient.addMockResponse({url: chatUrl, method: 'GET', body: {session: null}});
-      MockApiClient.addMockResponse({
-        url: `${chatUrl}789/`,
-        method: 'GET',
-        body: {
-          session: {
-            blocks: [
-              {
-                id: 'u0',
-                message: {role: 'user', content: 'hello'},
-                timestamp: ts,
-                loading: false,
-              },
-              {
-                id: 'a1',
-                message: {role: 'assistant', content: 'Hi!'},
-                timestamp: ts,
-                loading: false,
-              },
-            ],
-            run_id: 789,
-            status: 'completed',
-            updated_at: ts,
-          },
-        },
-      });
-      MockApiClient.addMockResponse({
-        url: `${chatUrl}789/`,
-        method: 'POST',
-        body: {run_id: 789},
-      });
-
-      const {result} = renderHookWithProviders(() => useSeerExplorer(), {organization});
-
-      act(() => result.current.switchToRun(789));
-      await waitFor(() => result.current.sessionData?.blocks?.length === 2);
-
-      act(() => result.current.deleteFromIndex(0));
-      act(() => {
-        result.current.sendMessage('hello');
-      });
-
-      await waitFor(() => {
-        expect(result.current.sessionData?.blocks?.some(b => b.loading)).toBe(true);
-        expect(result.current.deletedFromIndex).toBe(0);
-      });
-    });
   });
 });

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -546,13 +546,15 @@ export const useSeerExplorer = () => {
   }, [apiData?.session?.blocks, apiData?.session?.updated_at, optimistic]);
 
   // On any completed state
+  const isCompleted = isSessionComplete(apiData?.session);
+
   useEffect(() => {
-    if (isSessionComplete(apiData?.session)) {
+    if (isCompleted) {
       setWaitingForInterrupt(false);
       setOptimistic(null);
       setDeletedFromIndex(null);
     }
-  }, [apiData?.session]);
+  }, [isCompleted]);
 
   // Detect PR creation errors and show error messages
   useEffect(() => {

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -549,6 +549,8 @@ export const useSeerExplorer = () => {
   useEffect(() => {
     if (isSessionComplete(apiData?.session)) {
       setWaitingForInterrupt(false);
+      setOptimistic(null);
+      setDeletedFromIndex(null);
     }
   }, [apiData?.session]);
 


### PR DESCRIPTION
Clear optimistic block and rethink index when session data transitions to a completed state. In 99% case these should both already be cleared by the effect above this one, but doesn't hurt to assert this. 

Cleans up an incorrect test - rethink behavior isn't correctly simulated because the server response doesn't update after sending the message. Though the assertions were passing, it's still incorrect and I don't the original purpose of it