### PR TITLE
feat(onboarding): Fire distinct analytics events for SCM welcome

### DIFF
--- a/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
@@ -71,7 +71,7 @@ export type OnboardingEventParameters = {
     team: string;
   };
   'onboarding.scm_welcome_continue_clicked': Record<string, unknown>;
-  'onboarding.scm_welcome_loaded': Record<string, unknown>;
+  'onboarding.scm_welcome_step_viewed': Record<string, unknown>;
   'onboarding.select_framework_modal_close_button_clicked': {
     platform: string;
   };
@@ -157,5 +157,5 @@ export const onboardingEventMap: Record<keyof OnboardingEventParameters, string>
   'onboarding.scm_project_details_team_selected':
     'Onboarding: SCM Project Details Team Selected',
   'onboarding.scm_welcome_continue_clicked': 'Onboarding: SCM Welcome Continue Clicked',
-  'onboarding.scm_welcome_loaded': 'Onboarding: SCM Welcome Loaded',
+  'onboarding.scm_welcome_step_viewed': 'Onboarding: SCM Welcome Step Viewed',
 };

--- a/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
@@ -70,6 +70,8 @@ export type OnboardingEventParameters = {
   'onboarding.scm_project_details_team_selected': {
     team: string;
   };
+  'onboarding.scm_welcome_continue_clicked': Record<string, unknown>;
+  'onboarding.scm_welcome_loaded': Record<string, unknown>;
   'onboarding.select_framework_modal_close_button_clicked': {
     platform: string;
   };
@@ -154,4 +156,6 @@ export const onboardingEventMap: Record<keyof OnboardingEventParameters, string>
     'Onboarding: SCM Project Details Step Viewed',
   'onboarding.scm_project_details_team_selected':
     'Onboarding: SCM Project Details Team Selected',
+  'onboarding.scm_welcome_continue_clicked': 'Onboarding: SCM Welcome Continue Clicked',
+  'onboarding.scm_welcome_loaded': 'Onboarding: SCM Welcome Loaded',
 };

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -695,11 +695,11 @@ describe('Onboarding', () => {
       });
     });
 
-    it('fires scm_welcome_loaded on welcome mount and not the legacy event', () => {
+    it('fires scm_welcome_step_viewed on welcome mount and not the legacy event', () => {
       renderOnboarding('welcome');
 
       expect(trackAnalytics).toHaveBeenCalledWith(
-        'onboarding.scm_welcome_loaded',
+        'onboarding.scm_welcome_step_viewed',
         expect.objectContaining({organization: scmOrganization})
       );
       expect(trackAnalytics).not.toHaveBeenCalledWith(

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -695,6 +695,34 @@ describe('Onboarding', () => {
       });
     });
 
+    it('fires scm_welcome_loaded on welcome mount and not the legacy event', () => {
+      renderOnboarding('welcome');
+
+      expect(trackAnalytics).toHaveBeenCalledWith(
+        'onboarding.scm_welcome_loaded',
+        expect.objectContaining({organization: scmOrganization})
+      );
+      expect(trackAnalytics).not.toHaveBeenCalledWith(
+        'growth.onboarding_start_onboarding',
+        expect.anything()
+      );
+    });
+
+    it('fires scm_welcome_continue_clicked on start click and not the legacy event', async () => {
+      renderOnboarding('welcome');
+
+      await userEvent.click(screen.getByTestId('onboarding-welcome-start'));
+
+      expect(trackAnalytics).toHaveBeenCalledWith(
+        'onboarding.scm_welcome_continue_clicked',
+        expect.objectContaining({organization: scmOrganization})
+      );
+      expect(trackAnalytics).not.toHaveBeenCalledWith(
+        'growth.onboarding_clicked_instrument_app',
+        expect.anything()
+      );
+    });
+
     it('auto-selects existing integration and shows connected view', async () => {
       MockApiClient.clearMockResponses();
       MockApiClient.addMockResponse({

--- a/static/app/views/onboarding/useWelcomeAnalyticsEffect.ts
+++ b/static/app/views/onboarding/useWelcomeAnalyticsEffect.ts
@@ -2,22 +2,30 @@ import {useEffect} from 'react';
 
 import {useOnboardingContext} from 'sentry/components/onboarding/onboardingContext';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {useExperiment} from 'sentry/utils/useExperiment';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {ONBOARDING_WELCOME_SCREEN_SOURCE} from 'sentry/views/onboarding/consts';
 
 export function useWelcomeAnalyticsEffect() {
   const organization = useOrganization();
   const onboardingContext = useOnboardingContext();
+  const {inExperiment: hasScmOnboarding} = useExperiment({
+    feature: 'onboarding-scm-experiment',
+  });
 
   useEffect(() => {
-    trackAnalytics('growth.onboarding_start_onboarding', {
-      organization,
-      source: ONBOARDING_WELCOME_SCREEN_SOURCE,
-    });
+    if (hasScmOnboarding) {
+      trackAnalytics('onboarding.scm_welcome_loaded', {organization});
+    } else {
+      trackAnalytics('growth.onboarding_start_onboarding', {
+        organization,
+        source: ONBOARDING_WELCOME_SCREEN_SOURCE,
+      });
+    }
 
     if (onboardingContext.selectedPlatform) {
       // At this point the selectedSDK shall be undefined but just in case, cleaning this up here too
       onboardingContext.setSelectedPlatform(undefined);
     }
-  }, [organization, onboardingContext]);
+  }, [organization, onboardingContext, hasScmOnboarding]);
 }

--- a/static/app/views/onboarding/useWelcomeAnalyticsEffect.ts
+++ b/static/app/views/onboarding/useWelcomeAnalyticsEffect.ts
@@ -15,7 +15,7 @@ export function useWelcomeAnalyticsEffect() {
 
   useEffect(() => {
     if (hasScmOnboarding) {
-      trackAnalytics('onboarding.scm_welcome_loaded', {organization});
+      trackAnalytics('onboarding.scm_welcome_step_viewed', {organization});
     } else {
       trackAnalytics('growth.onboarding_start_onboarding', {
         organization,

--- a/static/app/views/onboarding/useWelcomeHandleComplete.ts
+++ b/static/app/views/onboarding/useWelcomeHandleComplete.ts
@@ -1,6 +1,7 @@
 import {useCallback} from 'react';
 
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {useExperiment} from 'sentry/utils/useExperiment';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {ONBOARDING_WELCOME_SCREEN_SOURCE} from 'sentry/views/onboarding/consts';
 
@@ -8,13 +9,20 @@ import type {StepProps} from './types';
 
 export function useWelcomeHandleComplete(onComplete: StepProps['onComplete']) {
   const organization = useOrganization();
+  const {inExperiment: hasScmOnboarding} = useExperiment({
+    feature: 'onboarding-scm-experiment',
+  });
 
   return useCallback(() => {
-    trackAnalytics('growth.onboarding_clicked_instrument_app', {
-      organization,
-      source: ONBOARDING_WELCOME_SCREEN_SOURCE,
-    });
+    if (hasScmOnboarding) {
+      trackAnalytics('onboarding.scm_welcome_continue_clicked', {organization});
+    } else {
+      trackAnalytics('growth.onboarding_clicked_instrument_app', {
+        organization,
+        source: ONBOARDING_WELCOME_SCREEN_SOURCE,
+      });
+    }
 
     onComplete();
-  }, [organization, onComplete]);
+  }, [organization, onComplete, hasScmOnboarding]);
 }


### PR DESCRIPTION
This PR prevents the SCM onboarding experiment from polluting Sentry's existing Amplitude onboarding charts. Per guidance from BI, SCM traffic should be fully excluded from those charts.

When the SCM experiment is active, the shared welcome screen now fires `onboarding.scm_welcome_step_viewed` and `onboarding.scm_welcome_continue_clicked` instead of `growth.onboarding_start_onboarding` and `growth.onboarding_clicked_instrument_app`. The control group is unchanged.

The legacy events are steps 1-2 of the existing Amplitude onboarding funnels. SCM flows skip step 3 (`growth.select_platform`) because SCM's platform step uses its own component rather than the shared `PlatformPicker`, so SCM users were entering those ordered funnels at steps 1-2 and vanishing at step 3, which also excluded them from steps 4-5 even when onboarding completed. Without this change, the funnels' conversion metrics would degrade as SCM rolls out in a way that looks like a regression but is purely an instrumentation artifact.