### PR TITLE
chore(repositories): Default `is_rate_limited_error` to False

### DIFF
--- a/src/sentry/integrations/base.py
+++ b/src/sentry/integrations/base.py
@@ -553,7 +553,7 @@ class IntegrationInstallation(abc.ABC):
             raise IntegrationError(self.message_from_error(exc)).with_traceback(sys.exc_info()[2])
 
     def is_rate_limited_error(self, exc: ApiError) -> bool:
-        raise NotImplementedError
+        return False
 
     @property
     def metadata(self) -> dict[str, Any]:


### PR DESCRIPTION
Only github implements this, and it's causing some errors in scm syncing. Better to just return false and treat these errors as standard errors
