### PR TITLE
fix(seer): Bill seat-based autofix based on Seer project preferences instead of code mappings and tuning

### DIFF
--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -537,11 +537,21 @@ def resolve_repository_ids(
     def _resolve_repo(repo: SeerRepoDefinition) -> SeerRepoDefinition:
         if repo.repository_id is not None:
             return repo
+
         resolved_id = resolved_ids.get(
             (repo.external_id, repo.provider.removeprefix("integrations:"))
         )
         if resolved_id is not None:
             return repo.copy(update={"repository_id": resolved_id})
+
+        logger.warning(
+            "seer.resolve_repository_ids.unresolved",
+            extra={
+                "organization_id": organization_id,
+                "external_id": repo.external_id,
+                "provider": repo.provider,
+            },
+        )
         return repo
 
     return [

--- a/src/sentry/seer/code_review/contributor_seats.py
+++ b/src/sentry/seer/code_review/contributor_seats.py
@@ -81,7 +81,7 @@ def _is_autofix_enabled_for_repo(organization: Organization, repository_id: int)
         return False
 
     return any(
-        any(repo.repository_id == repository_id for repo in pref.repositories)
+        any(repo.repository_id == repository_id for repo in pref.repositories if repo.repository_id)
         for pref in resolved_preferences
     )
 

--- a/src/sentry/seer/code_review/contributor_seats.py
+++ b/src/sentry/seer/code_review/contributor_seats.py
@@ -81,8 +81,9 @@ def _is_autofix_enabled_for_repo(organization: Organization, repository_id: int)
         return False
 
     return any(
-        any(repo.repository_id == repository_id for repo in pref.repositories)
+        repo.repository_id == repository_id
         for pref in resolved_preferences
+        for repo in pref.repositories
     )
 
 

--- a/src/sentry/seer/code_review/contributor_seats.py
+++ b/src/sentry/seer/code_review/contributor_seats.py
@@ -108,9 +108,9 @@ def should_increment_contributor_seat(
     """
     if (
         repo.integration_id is None
-        or not _has_code_review_or_autofix_enabled(organization, repo.id)
         or contributor.is_bot
         or not features.has("organizations:seat-based-seer-enabled", organization)
+        or not _has_code_review_or_autofix_enabled(organization, repo.id)
     ):
         return False
 

--- a/src/sentry/seer/code_review/contributor_seats.py
+++ b/src/sentry/seer/code_review/contributor_seats.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import logging
 
 from django.db import router, transaction
+from orjson import JSONDecodeError
+from urllib3.exceptions import HTTPError
 
 from sentry import features, quotas
 from sentry.constants import DataCategory, ObjectStatus
@@ -62,7 +64,7 @@ def _is_autofix_enabled_for_repo(organization: Organization, repository_id: int)
 
     try:
         preferences = bulk_get_project_preferences(organization.id, project_ids)
-    except SeerApiError:
+    except (SeerApiError, HTTPError, JSONDecodeError):
         logger.exception(
             "seer.contributor_seats.autofix_check_error",
             extra={"organization_id": organization.id, "repository_id": repository_id},

--- a/src/sentry/seer/code_review/contributor_seats.py
+++ b/src/sentry/seer/code_review/contributor_seats.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 
+import sentry_sdk
 from django.db import router, transaction
 from orjson import JSONDecodeError
 from urllib3.exceptions import HTTPError
@@ -65,10 +66,13 @@ def _is_autofix_enabled_for_repo(organization: Organization, repository_id: int)
     try:
         preferences = bulk_get_project_preferences(organization.id, project_ids)
     except (SeerApiError, HTTPError, JSONDecodeError):
-        logger.exception(
+        logger.warning(
             "seer.contributor_seats.autofix_check_error",
             extra={"organization_id": organization.id, "repository_id": repository_id},
         )
+        return False
+    except Exception as e:
+        sentry_sdk.capture_exception(e, level="warning")
         return False
 
     return any(

--- a/src/sentry/seer/code_review/contributor_seats.py
+++ b/src/sentry/seer/code_review/contributor_seats.py
@@ -12,6 +12,7 @@ import logging
 import sentry_sdk
 from django.db import router, transaction
 from orjson import JSONDecodeError
+from pydantic import ValidationError
 from urllib3.exceptions import HTTPError
 
 from sentry import features, quotas
@@ -24,9 +25,9 @@ from sentry.models.organizationcontributors import (
 from sentry.models.project import Project
 from sentry.models.repository import Repository
 from sentry.models.repositorysettings import RepositorySettings
-from sentry.seer.autofix.utils import bulk_get_project_preferences
+from sentry.seer.autofix.utils import bulk_get_project_preferences, resolve_repository_ids
 from sentry.seer.models.project_repository import SeerProjectRepository
-from sentry.seer.models.seer_api_models import SeerApiError
+from sentry.seer.models.seer_api_models import SeerApiError, SeerProjectPreference
 from sentry.tasks.organization_contributors import assign_seat_to_organization_contributor
 
 logger = logging.getLogger(__name__)
@@ -64,23 +65,24 @@ def _is_autofix_enabled_for_repo(organization: Organization, repository_id: int)
         return False
 
     try:
-        preferences = bulk_get_project_preferences(organization.id, project_ids)
+        raw_preferences = bulk_get_project_preferences(organization.id, project_ids)
+        validated_preferences = [
+            SeerProjectPreference.validate(pref) for pref in raw_preferences.values() if pref
+        ]
+        resolved_preferences = resolve_repository_ids(organization.id, validated_preferences)
     except (SeerApiError, HTTPError):
         logger.warning(
             "seer.contributor_seats.autofix_check_error",
             extra={"organization_id": organization.id, "repository_id": repository_id},
         )
         return False
-    except (JSONDecodeError, Exception) as e:
-        sentry_sdk.capture_exception(e, level="warning")
+    except (JSONDecodeError, ValidationError, Exception):
+        sentry_sdk.capture_exception()
         return False
 
     return any(
-        pref
-        and any(
-            repo.get("repository_id") == repository_id for repo in (pref.get("repositories") or [])
-        )
-        for pref in preferences.values()
+        any(repo.repository_id == repository_id for repo in pref.repositories)
+        for pref in resolved_preferences
     )
 
 

--- a/src/sentry/seer/code_review/contributor_seats.py
+++ b/src/sentry/seer/code_review/contributor_seats.py
@@ -13,16 +13,17 @@ from django.db import router, transaction
 
 from sentry import features, quotas
 from sentry.constants import DataCategory, ObjectStatus
-from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
-from sentry.models.options.project_option import ProjectOption
 from sentry.models.organization import Organization
 from sentry.models.organizationcontributors import (
     ORGANIZATION_CONTRIBUTOR_ACTIVATION_THRESHOLD,
     OrganizationContributors,
 )
+from sentry.models.project import Project
 from sentry.models.repository import Repository
 from sentry.models.repositorysettings import RepositorySettings
-from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
+from sentry.seer.autofix.utils import bulk_get_project_preferences
+from sentry.seer.models.project_repository import SeerProjectRepository
+from sentry.seer.models.seer_api_models import SeerApiError
 from sentry.tasks.organization_contributors import assign_seat_to_organization_contributor
 
 logger = logging.getLogger(__name__)
@@ -36,38 +37,54 @@ def _is_code_review_enabled_for_repo(repository_id: int) -> bool:
     ).exists()
 
 
-def _is_autofix_enabled_for_repo(organization_id: int, repository_id: int) -> bool:
+def _is_autofix_enabled_for_repo(organization: Organization, repository_id: int) -> bool:
     """
-    Check if autofix automation is enabled (not "off") for any project
-    associated with this repository via code mappings.
+    Check if autofix is enabled for any active project associated with
+    this repository, ie, if any project has this repository configured
+    in Seer preferences.
     """
-    repo_configs = RepositoryProjectPathConfig.objects.filter(
-        repository_id=repository_id,
-        organization_id=organization_id,
-    ).values_list("project_id", flat=True)
+    if features.has("organizations:seer-project-settings-read-from-sentry", organization):
+        return SeerProjectRepository.objects.filter(
+            repository_id=repository_id,
+            project__organization_id=organization.id,
+            project__status=ObjectStatus.ACTIVE,
+        ).exists()
 
-    if not repo_configs:
+    project_ids = list(
+        Project.objects.filter(
+            organization_id=organization.id,
+            status=ObjectStatus.ACTIVE,
+        ).values_list("id", flat=True)
+    )
+
+    if not project_ids:
         return False
 
-    return (
-        ProjectOption.objects.filter(
-            project_id__in=repo_configs,
-            project__status=ObjectStatus.ACTIVE,
-            key="sentry:autofix_automation_tuning",
+    try:
+        preferences = bulk_get_project_preferences(organization.id, project_ids)
+    except SeerApiError:
+        logger.exception(
+            "seer.contributor_seats.autofix_check_error",
+            extra={"organization_id": organization.id, "repository_id": repository_id},
         )
-        .exclude(value=AutofixAutomationTuningSettings.OFF.value)
-        .exclude(value__isnull=True)
-        .exists()
+        return False
+
+    return any(
+        pref
+        and any(
+            repo.get("repository_id") == repository_id for repo in (pref.get("repositories") or [])
+        )
+        for pref in preferences.values()
     )
 
 
-def _has_code_review_or_autofix_enabled(organization_id: int, repository_id: int) -> bool:
+def _has_code_review_or_autofix_enabled(organization: Organization, repository_id: int) -> bool:
     """
     Check if either code review is enabled for the repo OR autofix automation
     is enabled for any linked project.
     """
     return _is_code_review_enabled_for_repo(repository_id) or _is_autofix_enabled_for_repo(
-        organization_id, repository_id
+        organization, repository_id
     )
 
 
@@ -83,7 +100,7 @@ def should_increment_contributor_seat(
     """
     if (
         repo.integration_id is None
-        or not _has_code_review_or_autofix_enabled(organization.id, repo.id)
+        or not _has_code_review_or_autofix_enabled(organization, repo.id)
         or contributor.is_bot
         or not features.has("organizations:seat-based-seer-enabled", organization)
     ):

--- a/src/sentry/seer/code_review/contributor_seats.py
+++ b/src/sentry/seer/code_review/contributor_seats.py
@@ -65,13 +65,13 @@ def _is_autofix_enabled_for_repo(organization: Organization, repository_id: int)
 
     try:
         preferences = bulk_get_project_preferences(organization.id, project_ids)
-    except (SeerApiError, HTTPError, JSONDecodeError):
+    except (SeerApiError, HTTPError):
         logger.warning(
             "seer.contributor_seats.autofix_check_error",
             extra={"organization_id": organization.id, "repository_id": repository_id},
         )
         return False
-    except Exception as e:
+    except (JSONDecodeError, Exception) as e:
         sentry_sdk.capture_exception(e, level="warning")
         return False
 

--- a/src/sentry/seer/code_review/contributor_seats.py
+++ b/src/sentry/seer/code_review/contributor_seats.py
@@ -81,7 +81,7 @@ def _is_autofix_enabled_for_repo(organization: Organization, repository_id: int)
         return False
 
     return any(
-        any(repo.repository_id == repository_id for repo in pref.repositories if repo.repository_id)
+        any(repo.repository_id == repository_id for repo in pref.repositories)
         for pref in resolved_preferences
     )
 

--- a/tests/sentry/seer/code_review/test_contributor_seats.py
+++ b/tests/sentry/seer/code_review/test_contributor_seats.py
@@ -8,6 +8,7 @@ from sentry.seer.code_review.contributor_seats import (
     should_increment_contributor_seat,
     track_contributor_seat,
 )
+from sentry.seer.models.project_repository import SeerProjectRepository
 from sentry.testutils.cases import TestCase
 
 
@@ -96,10 +97,14 @@ class ShouldIncrementContributorSeatTest(TestCase):
     def test_returns_true_when_autofix_enabled_and_quota_available(
         self, mock_quota: MagicMock
     ) -> None:
-        self.create_code_mapping(project=self.project, repo=self.repo)
-        self.project.update_option("sentry:autofix_automation_tuning", "medium")
+        SeerProjectRepository.objects.create(project=self.project, repository=self.repo)
 
-        with self.feature("organizations:seat-based-seer-enabled"):
+        with self.feature(
+            {
+                "organizations:seat-based-seer-enabled": True,
+                "organizations:seer-project-settings-read-from-sentry": True,
+            }
+        ):
             result = should_increment_contributor_seat(
                 self.organization, self.repo, self.contributor
             )

--- a/tests/sentry/seer/code_review/test_contributor_seats.py
+++ b/tests/sentry/seer/code_review/test_contributor_seats.py
@@ -1,16 +1,140 @@
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+from sentry.constants import ObjectStatus
 from sentry.models.organizationcontributors import (
     ORGANIZATION_CONTRIBUTOR_ACTIVATION_THRESHOLD,
     OrganizationContributors,
 )
+from sentry.models.project import Project
 from sentry.seer.code_review.contributor_seats import (
+    _is_autofix_enabled_for_repo,
     should_increment_contributor_seat,
     track_contributor_seat,
 )
 from sentry.seer.models.project_repository import SeerProjectRepository
+from sentry.seer.models.seer_api_models import SeerApiError
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.features import with_feature
+
+
+class IsAutofixEnabledForRepoTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.integration = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            external_id="github:1",
+        )
+        self.repo = self.create_repo(
+            project=self.project,
+            provider="integrations:github",
+            integration_id=self.integration.id,
+            external_id="123",
+        )
+
+    def _mock_preference(
+        self, *, repository_id: int | None = None, external_id: str = "123"
+    ) -> dict[str, Any]:
+        repo: dict[str, Any] = {
+            "provider": self.repo.provider,
+            "owner": "owner",
+            "name": "name",
+            "external_id": external_id,
+        }
+        if repository_id is not None:
+            repo["repository_id"] = repository_id
+        return {
+            "organization_id": self.organization.id,
+            "project_id": self.project.id,
+            "repositories": [repo],
+        }
+
+    @with_feature("organizations:seer-project-settings-read-from-sentry")
+    def test_seer_project_repository_exists_for_repo(self) -> None:
+        SeerProjectRepository.objects.create(project=self.project, repository=self.repo)
+
+        assert _is_autofix_enabled_for_repo(self.organization, self.repo.id) is True
+
+    @with_feature("organizations:seer-project-settings-read-from-sentry")
+    def test_no_seer_project_repository_exists(self) -> None:
+        assert _is_autofix_enabled_for_repo(self.organization, self.repo.id) is False
+
+    @with_feature("organizations:seer-project-settings-read-from-sentry")
+    def test_seer_project_repository_exists_for_different_repo(
+        self,
+    ) -> None:
+        other_repo = self.create_repo(
+            project=self.project,
+            provider="integrations:github",
+            integration_id=self.integration.id,
+        )
+        SeerProjectRepository.objects.create(project=self.project, repository=other_repo)
+
+        assert _is_autofix_enabled_for_repo(self.organization, self.repo.id) is False
+
+    @with_feature("organizations:seer-project-settings-read-from-sentry")
+    def test_project_is_inactive(self) -> None:
+        SeerProjectRepository.objects.create(project=self.project, repository=self.repo)
+        self.project.update(status=ObjectStatus.PENDING_DELETION)
+
+        assert _is_autofix_enabled_for_repo(self.organization, self.repo.id) is False
+
+    def test_organization_has_no_active_projects(self) -> None:
+        Project.objects.filter(organization_id=self.organization.id).update(
+            status=ObjectStatus.PENDING_DELETION
+        )
+
+        assert _is_autofix_enabled_for_repo(self.organization, self.repo.id) is False
+
+    @patch("sentry.seer.code_review.contributor_seats.bulk_get_project_preferences")
+    def test_preferences_resolve_to_repo(
+        self, mock_bulk_get_project_preferences: MagicMock
+    ) -> None:
+        mock_bulk_get_project_preferences.return_value = {
+            str(self.project.id): self._mock_preference(external_id=self.repo.external_id)
+        }
+
+        assert _is_autofix_enabled_for_repo(self.organization, self.repo.id) is True
+
+    @patch("sentry.seer.code_review.contributor_seats.bulk_get_project_preferences")
+    def test_repo_id_cannot_be_resolved(self, mock_bulk_get_project_preferences: MagicMock) -> None:
+        mock_bulk_get_project_preferences.return_value = {
+            str(self.project.id): self._mock_preference(external_id="unknown-external-id")
+        }
+
+        assert _is_autofix_enabled_for_repo(self.organization, self.repo.id) is False
+
+    @patch("sentry.seer.code_review.contributor_seats.bulk_get_project_preferences")
+    def test_preferences_exclude_repo(self, mock_bulk_get_project_preferences: MagicMock) -> None:
+        mock_bulk_get_project_preferences.return_value = {
+            str(self.project.id): self._mock_preference(repository_id=self.repo.id + 1)
+        }
+
+        assert _is_autofix_enabled_for_repo(self.organization, self.repo.id) is False
+
+    @patch(
+        "sentry.seer.code_review.contributor_seats.bulk_get_project_preferences",
+        return_value={},
+    )
+    def test_preferences_response_is_empty(
+        self, mock_bulk_get_project_preferences: MagicMock
+    ) -> None:
+        assert _is_autofix_enabled_for_repo(self.organization, self.repo.id) is False
+
+    @patch(
+        "sentry.seer.code_review.contributor_seats.bulk_get_project_preferences",
+        side_effect=SeerApiError("error", status=500),
+    )
+    def test_seer_api_error(self, mock_bulk_get_project_preferences: MagicMock) -> None:
+        assert _is_autofix_enabled_for_repo(self.organization, self.repo.id) is False
+
+    @patch(
+        "sentry.seer.code_review.contributor_seats.bulk_get_project_preferences",
+        side_effect=ValueError("error"),
+    )
+    def test_unexpected_exception(self, mock_bulk_get_project_preferences: MagicMock) -> None:
+        assert _is_autofix_enabled_for_repo(self.organization, self.repo.id) is False
 
 
 class ShouldIncrementContributorSeatTest(TestCase):

--- a/tests/sentry/seer/code_review/test_contributor_seats.py
+++ b/tests/sentry/seer/code_review/test_contributor_seats.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from sentry.models.organizationcontributors import (
@@ -31,6 +32,21 @@ class ShouldIncrementContributorSeatTest(TestCase):
             external_identifier="12345",
             alias="testuser",
         )
+
+    def _mock_preference(self, repository_id: int) -> dict[str, Any]:
+        return {
+            "organization_id": self.organization.id,
+            "project_id": self.project.id,
+            "repositories": [
+                {
+                    "provider": self.repo.provider,
+                    "owner": "owner",
+                    "name": "name",
+                    "external_id": "external-id",
+                    "repository_id": repository_id,
+                },
+            ],
+        }
 
     def test_returns_false_when_seat_based_seer_disabled(self) -> None:
         self.create_repository_settings(repository=self.repo, enabled_code_review=True)
@@ -85,9 +101,7 @@ class ShouldIncrementContributorSeatTest(TestCase):
                 patch(
                     "sentry.seer.code_review.contributor_seats.bulk_get_project_preferences",
                     return_value={
-                        str(self.project.id): {
-                            "repositories": [{"repository_id": self.repo.id + 1}],
-                        },
+                        str(self.project.id): self._mock_preference(repository_id=self.repo.id + 1)
                     },
                 ),
                 self.feature("organizations:seat-based-seer-enabled"),
@@ -172,9 +186,7 @@ class ShouldIncrementContributorSeatTest(TestCase):
                 patch(
                     "sentry.seer.code_review.contributor_seats.bulk_get_project_preferences",
                     return_value={
-                        str(self.project.id): {
-                            "repositories": [{"repository_id": self.repo.id}],
-                        },
+                        str(self.project.id): self._mock_preference(repository_id=self.repo.id)
                     },
                 ),
                 self.feature("organizations:seat-based-seer-enabled"),

--- a/tests/sentry/seer/code_review/test_contributor_seats.py
+++ b/tests/sentry/seer/code_review/test_contributor_seats.py
@@ -38,12 +38,65 @@ class ShouldIncrementContributorSeatTest(TestCase):
         result = should_increment_contributor_seat(self.organization, self.repo, self.contributor)
         assert result is False
 
-    def test_returns_false_when_no_code_review_or_autofix_enabled(self) -> None:
+    @patch(
+        "sentry.seer.code_review.contributor_seats.bulk_get_project_preferences",
+        return_value={},
+    )
+    def test_returns_false_when_no_code_review_or_autofix_enabled(
+        self, mock_bulk_get_project_preferences: MagicMock
+    ) -> None:
         with self.feature("organizations:seat-based-seer-enabled"):
             result = should_increment_contributor_seat(
                 self.organization, self.repo, self.contributor
             )
             assert result is False
+
+    @patch(
+        "sentry.seer.code_review.contributor_seats.quotas.backend.check_seer_quota",
+        return_value=True,
+    )
+    def test_returns_false_when_autofix_disabled(self, mock_quota: MagicMock) -> None:
+        self.create_repository_settings(repository=self.repo, enabled_code_review=False)
+
+        with self.subTest("no SeerProjectRepository row for repo when flag on"):
+            other_repo = self.create_repo(
+                project=self.project,
+                provider="integrations:github",
+                integration_id=self.integration.id,
+            )
+            SeerProjectRepository.objects.create(project=self.project, repository=other_repo)
+
+            with self.feature(
+                {
+                    "organizations:seat-based-seer-enabled": True,
+                    "organizations:seer-project-settings-read-from-sentry": True,
+                }
+            ):
+                result = should_increment_contributor_seat(
+                    self.organization, self.repo, self.contributor
+                )
+                assert result is False
+                mock_quota.assert_not_called()
+
+        mock_quota.reset_mock()
+
+        with self.subTest("Seer preferences exclude repo when flag off"):
+            with (
+                patch(
+                    "sentry.seer.code_review.contributor_seats.bulk_get_project_preferences",
+                    return_value={
+                        str(self.project.id): {
+                            "repositories": [{"repository_id": self.repo.id + 1}],
+                        },
+                    },
+                ),
+                self.feature("organizations:seat-based-seer-enabled"),
+            ):
+                result = should_increment_contributor_seat(
+                    self.organization, self.repo, self.contributor
+                )
+                assert result is False
+                mock_quota.assert_not_called()
 
     def test_returns_false_when_repo_has_no_integration_id(self) -> None:
         repo_no_integration = self.create_repo(
@@ -97,19 +150,40 @@ class ShouldIncrementContributorSeatTest(TestCase):
     def test_returns_true_when_autofix_enabled_and_quota_available(
         self, mock_quota: MagicMock
     ) -> None:
-        SeerProjectRepository.objects.create(project=self.project, repository=self.repo)
+        with self.subTest("reads from SeerProjectRepository when flag on"):
+            SeerProjectRepository.objects.create(project=self.project, repository=self.repo)
 
-        with self.feature(
-            {
-                "organizations:seat-based-seer-enabled": True,
-                "organizations:seer-project-settings-read-from-sentry": True,
-            }
-        ):
-            result = should_increment_contributor_seat(
-                self.organization, self.repo, self.contributor
-            )
-            assert result is True
-            mock_quota.assert_called_once()
+            with self.feature(
+                {
+                    "organizations:seat-based-seer-enabled": True,
+                    "organizations:seer-project-settings-read-from-sentry": True,
+                }
+            ):
+                result = should_increment_contributor_seat(
+                    self.organization, self.repo, self.contributor
+                )
+                assert result is True
+                mock_quota.assert_called_once()
+
+        mock_quota.reset_mock()
+
+        with self.subTest("reads from Seer preferences when flag off"):
+            with (
+                patch(
+                    "sentry.seer.code_review.contributor_seats.bulk_get_project_preferences",
+                    return_value={
+                        str(self.project.id): {
+                            "repositories": [{"repository_id": self.repo.id}],
+                        },
+                    },
+                ),
+                self.feature("organizations:seat-based-seer-enabled"),
+            ):
+                result = should_increment_contributor_seat(
+                    self.organization, self.repo, self.contributor
+                )
+                assert result is True
+                mock_quota.assert_called_once()
 
     @patch(
         "sentry.seer.code_review.contributor_seats.quotas.backend.check_seer_quota",


### PR DESCRIPTION
Fixes AIML-2754

Determine whether autofix is enabled for a repository (and whether this contributor is billable) by checking Seer project preferences, instead of code mappings plus the `sentry:autofix_automation_tuning` project option. Autofix is enabled if any project has the given repository added to its Seer preference.

[Context](https://sentry.slack.com/archives/C0AAF0JD0GK/p1776284922120519)