### PR TITLE
fix(iswf): Surfaces linked issues for Sentry Apps with no UI components

### DIFF
--- a/static/app/components/group/externalIssuesList/hooks/useSentryAppExternalIssues.tsx
+++ b/static/app/components/group/externalIssuesList/hooks/useSentryAppExternalIssues.tsx
@@ -39,6 +39,7 @@ export function useSentryAppExternalIssues({
     isLoading,
   };
 
+  const displayedExternalIssues = new Set<string>();
   for (const component of sentryAppComponents) {
     const installation = sentryAppInstallations.find(
       i => i.app.uuid === component.sentryApp.uuid
@@ -78,6 +79,8 @@ export function useSentryAppExternalIssues({
             });
         },
       });
+
+      displayedExternalIssues.add(externalIssue.id);
     } else {
       result.integrations.push({
         key: `sentryapp-${component.sentryApp.slug}`,
@@ -102,6 +105,39 @@ export function useSentryAppExternalIssues({
         ],
       });
     }
+  }
+
+  for (const externalIssue of externalIssues) {
+    // Loop through to find any issues that are not already displayed
+    if (displayedExternalIssues.has(externalIssue.id)) {
+      continue;
+    }
+
+    const installations = sentryAppInstallations.filter(
+      i => i.app.slug === externalIssue.serviceType
+    );
+    if (installations.length === 0) {
+      continue;
+    }
+
+    result.linkedIssues.push({
+      key: `sentryapp-linked-${externalIssue.id}`,
+      displayName: externalIssue.displayName,
+      url: externalIssue.webUrl,
+      title: externalIssue.displayName,
+      onUnlink: () => {
+        deleteExternalIssue(api, organization.slug, group.id, externalIssue.id)
+          .then(_data => {
+            onDeleteExternalIssue(externalIssue);
+            addSuccessMessage(t('Successfully unlinked issue.'));
+          })
+          .catch(_error => {
+            addErrorMessage(t('Unable to unlink issue.'));
+          });
+      },
+    });
+
+    displayedExternalIssues.add(externalIssue.id);
   }
 
   return result;


### PR DESCRIPTION
Shows linked Sentry App issues, even if now UI components for Link or Create are defined. As before, these linked issues will only be visible for Sentry Apps that are installed. Unlinking functionality will still work the same as before.

Some notable caveats:
1. This will not show the Sentry App icon due to the missing components
2. As mentioned before, this will not include linked issues for uninstalled Sentry Apps
3. Installation lookup uses the `service_type` field on the `PlatformExternalIssue` model, which can be a little funky if a Sentry App slug is changed, meaning issues can disappear if this occurs

Resolves #108103

