### PR TITLE
ref(flags): Remove dead projects:data-forwarding flag

### DIFF
--- a/src/sentry/apidocs/examples/project_examples.py
+++ b/src/sentry/apidocs/examples/project_examples.py
@@ -59,7 +59,6 @@ BASE_PROJECT = {
     "features": [
         "alert-filters",
         "custom-inbound-filters",
-        "data-forwarding",
         "discard-groups",
         "minidump",
         "rate-limits",
@@ -315,7 +314,6 @@ PROJECT_SUMMARY = {
     "features": [
         "alert-filters",
         "custom-inbound-filters",
-        "data-forwarding",
         "discard-groups",
         "minidump",
         "rate-limits",

--- a/src/sentry/apidocs/examples/team_examples.py
+++ b/src/sentry/apidocs/examples/team_examples.py
@@ -207,7 +207,6 @@ class TeamExamples:
                             "features": [
                                 "alert-filters",
                                 "custom-inbound-filters",
-                                "data-forwarding",
                                 "discard-groups",
                                 "minidump",
                                 "rate-limits",
@@ -268,7 +267,6 @@ class TeamExamples:
                             "features": [
                                 "alert-filters",
                                 "custom-inbound-filters",
-                                "data-forwarding",
                                 "discard-groups",
                                 "minidump",
                                 "rate-limits",

--- a/src/sentry/features/permanent.py
+++ b/src/sentry/features/permanent.py
@@ -123,8 +123,6 @@ def register_permanent_features(manager: FeatureManager) -> None:
     }
 
     permanent_project_features = {
-        # Enable data forwarding functionality for projects.
-        "projects:data-forwarding": True,
         # Enable functionality for rate-limiting events on projects.
         "projects:rate-limits": True,
         # Enable functionality to specify custom inbound filters on events.


### PR DESCRIPTION
The flag scanner classified this as dead. The flag was registered in permanent.py but never checked anywhere — the feature gate that actually controls data forwarding is organizations:data-forwarding (org-scoped), which remains unchanged.

Also updates apidocs examples to drop the stale "data-forwarding" entry from project features lists.

<!-- Describe your PR here. -->