### PR TITLE
ref(flags): Remove organizations:migrate-transaction-queries-to-spans registration

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -108,8 +108,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:discover", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Enable the discover saved queries deprecation warnings
     manager.add("organizations:discover-saved-queries-deprecation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable migration of transaction widgets and queries to spans
-    manager.add("organizations:migrate-transaction-queries-to-spans", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable migration of transaction alerts and queries to spans
     manager.add("organizations:migrate-transaction-alerts-to-spans", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable migration of AM1 metrics alerts to transactions


### PR DESCRIPTION
The flag scanner classified this as job-only. The companion jobs in getsentry (dashboards_transactions_migration,
dashboards_transactions_rerun_migration, discover_transactions_migration) and their manifests are being removed in getsentry/getsentry; this PR removes the sentry registration.
