### PR TITLE
fix(replay): Add tooltip to timestamp settings button

### DIFF
--- a/static/app/views/replays/list/replayIndexTimestampPrefPicker.tsx
+++ b/static/app/views/replays/list/replayIndexTimestampPrefPicker.tsx
@@ -31,6 +31,7 @@ export function ReplayIndexTimestampPrefPicker() {
           icon={<IconSettings />}
           size={hasPageFrameFeature ? 'sm' : undefined}
           aria-label={t('Configure timestamp settings')}
+          tooltipProps={{title: t('Configure timestamp settings')}}
         />
       )}
       value={prefs.timestampType}


### PR DESCRIPTION
Add a tooltip title to the replay list timestamp settings icon button.

The button already had an accessible label, but page-frame users only saw an unlabeled cog in the top bar. This makes the control consistent with the rest of the toolbar actions without changing placement or behavior.

Fixes DE-1125