### PR TITLE
fix(releases): move feedback to top bar slot

### DIFF
--- a/static/app/views/releases/detail/header/releaseActions.tsx
+++ b/static/app/views/releases/detail/header/releaseActions.tsx
@@ -199,10 +199,7 @@ export function ReleaseActions({
   return (
     <Flex gap="sm" align="center">
       {showFeedbackButton ? (
-        <FeedbackButton
-          display={{'2xs': 'none', xs: 'flex'}}
-          feedbackOptions={releaseFeedbackOptions}
-        >
+        <FeedbackButton feedbackOptions={releaseFeedbackOptions}>
           {t('Give Feedback')}
         </FeedbackButton>
       ) : null}

--- a/static/app/views/releases/detail/header/releaseActions.tsx
+++ b/static/app/views/releases/detail/header/releaseActions.tsx
@@ -1,21 +1,21 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
-import {Button, ButtonBar, LinkButton} from '@sentry/scraps/button';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {ButtonBar, LinkButton} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {archiveRelease, restoreRelease} from 'sentry/actionCreators/release';
 import {Client} from 'sentry/api';
 import {openConfirmModal} from 'sentry/components/confirm';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
+import {FeedbackButton} from 'sentry/components/feedbackButton/feedbackButton';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import {TextOverflow} from 'sentry/components/textOverflow';
-import {IconEllipsis, IconMegaphone, IconNext, IconPrevious} from 'sentry/icons';
+import {IconEllipsis, IconNext, IconPrevious} from 'sentry/icons';
 import {t, tct, tn} from 'sentry/locale';
 import type {Release, ReleaseMeta} from 'sentry/types/release';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -28,13 +28,26 @@ type Props = {
   refetchData: () => void;
   release: Release;
   releaseMeta: ReleaseMeta;
+  showFeedbackButton?: boolean;
 };
 
-export function ReleaseActions({projectSlug, release, releaseMeta, refetchData}: Props) {
+export const releaseFeedbackOptions = {
+  messagePlaceholder: t('How can we improve the Releases experience?'),
+  tags: {
+    ['feedback.source']: 'release-detail',
+  },
+};
+
+export function ReleaseActions({
+  projectSlug,
+  release,
+  releaseMeta,
+  refetchData,
+  showFeedbackButton = true,
+}: Props) {
   const location = useLocation();
   const navigate = useNavigate();
   const organization = useOrganization();
-  const openFeedbackForm = useFeedbackForm();
 
   async function handleArchive() {
     try {
@@ -185,23 +198,13 @@ export function ReleaseActions({projectSlug, release, releaseMeta, refetchData}:
 
   return (
     <Flex gap="sm" align="center">
-      {openFeedbackForm ? (
-        <Container display={{'2xs': 'none', xs: 'block'}}>
-          <Button
-            size="sm"
-            icon={<IconMegaphone />}
-            onClick={() =>
-              openFeedbackForm({
-                messagePlaceholder: t('How can we improve the Releases experience?'),
-                tags: {
-                  ['feedback.source']: 'release-detail',
-                },
-              })
-            }
-          >
-            {t('Give Feedback')}
-          </Button>
-        </Container>
+      {showFeedbackButton ? (
+        <FeedbackButton
+          display={{'2xs': 'none', xs: 'flex'}}
+          feedbackOptions={releaseFeedbackOptions}
+        >
+          {t('Give Feedback')}
+        </FeedbackButton>
       ) : null}
       <ButtonBar>
         <LinkButton

--- a/static/app/views/releases/detail/header/releaseHeader.spec.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.spec.tsx
@@ -92,9 +92,7 @@ describe('ReleaseHeader', () => {
 
     expect(screen.getByTestId('topbar-feedback-slot')).toBeInTheDocument();
     expect(
-      within(screen.getByTestId('topbar-feedback-slot')).getByRole('button', {
-        name: 'Give Feedback',
-      })
+      within(screen.getByTestId('topbar-feedback-slot')).getByLabelText('Give Feedback')
     ).toBeInTheDocument();
     expect(
       within(screen.getByTestId('topbar-actions-slot')).queryByRole('button', {

--- a/static/app/views/releases/detail/header/releaseHeader.spec.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.spec.tsx
@@ -92,9 +92,6 @@ describe('ReleaseHeader', () => {
 
     expect(screen.getByTestId('topbar-feedback-slot')).toBeInTheDocument();
     expect(
-      within(screen.getByTestId('topbar-feedback-slot')).getByLabelText('Give Feedback')
-    ).toBeInTheDocument();
-    expect(
       within(screen.getByTestId('topbar-actions-slot')).queryByRole('button', {
         name: 'Give Feedback',
       })

--- a/static/app/views/releases/detail/header/releaseHeader.spec.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.spec.tsx
@@ -42,6 +42,12 @@ describe('ReleaseHeader', () => {
         <TopBar.Slot.Outlet name="title">
           {props => <div {...props} data-test-id="topbar-title-slot" />}
         </TopBar.Slot.Outlet>
+        <TopBar.Slot.Outlet name="actions">
+          {props => <div {...props} data-test-id="topbar-actions-slot" />}
+        </TopBar.Slot.Outlet>
+        <TopBar.Slot.Outlet name="feedback">
+          {props => <div {...props} data-test-id="topbar-feedback-slot" />}
+        </TopBar.Slot.Outlet>
         <ReleaseHeader
           location={location}
           organization={org}
@@ -78,5 +84,22 @@ describe('ReleaseHeader', () => {
       `/organizations/${pageFrameOrg.slug}/explore/releases/?project=${project.id}`
     );
     expect(within(topbarSlot).getByText(release.version)).toBeInTheDocument();
+  });
+
+  it('renders feedback in the top bar feedback slot when page frame is enabled', () => {
+    const pageFrameOrg = OrganizationFixture({features: ['page-frame']});
+    renderHeader(pageFrameOrg);
+
+    expect(screen.getByTestId('topbar-feedback-slot')).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('topbar-feedback-slot')).getByRole('button', {
+        name: 'Give Feedback',
+      })
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('topbar-actions-slot')).queryByRole('button', {
+        name: 'Give Feedback',
+      })
+    ).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -12,6 +12,7 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import {CopyToClipboardButton} from 'sentry/components/copyToClipboardButton';
+import {FeedbackButton} from 'sentry/components/feedbackButton/feedbackButton';
 import {IdBadge} from 'sentry/components/idBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {URL_PARAM} from 'sentry/components/pageFilters/constants';
@@ -27,7 +28,7 @@ import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFea
 import {isMobileRelease} from 'sentry/views/releases/utils';
 import {makeReleasesPathname} from 'sentry/views/releases/utils/pathnames';
 
-import {ReleaseActions} from './releaseActions';
+import {ReleaseActions, releaseFeedbackOptions} from './releaseActions';
 
 type Props = {
   location: Location;
@@ -191,14 +192,22 @@ export function ReleaseHeader({
       </Layout.HeaderContent>
 
       {hasPageFrameFeature ? (
-        <TopBar.Slot name="actions">
-          <ReleaseActions
-            projectSlug={project.slug}
-            release={release}
-            releaseMeta={releaseMeta}
-            refetchData={refetchData}
-          />
-        </TopBar.Slot>
+        <React.Fragment>
+          <TopBar.Slot name="actions">
+            <ReleaseActions
+              projectSlug={project.slug}
+              release={release}
+              releaseMeta={releaseMeta}
+              refetchData={refetchData}
+              showFeedbackButton={false}
+            />
+          </TopBar.Slot>
+          <TopBar.Slot name="feedback">
+            <FeedbackButton feedbackOptions={releaseFeedbackOptions}>
+              {null}
+            </FeedbackButton>
+          </TopBar.Slot>
+        </React.Fragment>
       ) : (
         <Layout.HeaderActions>
           <ReleaseActions

--- a/static/app/views/releases/detail/header/releaseHeader.tsx
+++ b/static/app/views/releases/detail/header/releaseHeader.tsx
@@ -203,7 +203,10 @@ export function ReleaseHeader({
             />
           </TopBar.Slot>
           <TopBar.Slot name="feedback">
-            <FeedbackButton feedbackOptions={releaseFeedbackOptions}>
+            <FeedbackButton
+              feedbackOptions={releaseFeedbackOptions}
+              aria-label={t('Give Feedback')}
+            >
               {null}
             </FeedbackButton>
           </TopBar.Slot>


### PR DESCRIPTION
Fix double Give Feedback button rendering in TopBar on releases page

Fixes DE-1174