### PR TITLE
fix(cmdk): Do not fire selections on Tab key press

### DIFF
--- a/static/app/components/commandPalette/ui/commandPalette.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.tsx
@@ -389,11 +389,9 @@ export function CommandPalette(props: CommandPaletteProps) {
                         }
                       }
 
-                      if (e.key === 'Enter' || e.key === 'Tab') {
-                        // Only forward shiftKey for Enter — Shift+Tab is reverse tab
-                        // navigation, not an "open in new tab" gesture.
+                      if (e.key === 'Enter') {
                         onActionSelection(treeState.selectionManager.focusedKey, {
-                          modifierKeys: {shiftKey: e.key === 'Enter' && e.shiftKey},
+                          modifierKeys: {shiftKey: e.shiftKey},
                         });
                         return;
                       }


### PR DESCRIPTION
Tab key events in the command palette input were calling `onActionSelection`,
causing the focused item to be activated whenever the user pressed Tab (e.g.
to move focus away from the palette). Only Enter should trigger item selection.

Also removes the now-unnecessary comment about Shift+Tab and cleans up the
`shiftKey` guard that was compensating for the Tab case.

Refs DE-1064