### PR TITLE
fix(settings): Avoid duplicate dynamic sampling title

### DIFF
--- a/static/app/views/settings/dynamicSampling/index.tsx
+++ b/static/app/views/settings/dynamicSampling/index.tsx
@@ -13,6 +13,7 @@ import {
   hasDynamicSamplingFeature,
 } from 'sentry/utils/dynamicSampling/features';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 import {OrganizationSampling} from 'sentry/views/settings/dynamicSampling/organizationSampling';
 import {ProjectSampling} from 'sentry/views/settings/dynamicSampling/projectSampling';
@@ -22,6 +23,7 @@ import {OrganizationPermissionAlert} from 'sentry/views/settings/organization/or
 export default function DynamicSamplingSettings() {
   const organization = useOrganization();
   const hasReadAccess = useHasDynamicSamplingReadAccess();
+  const hasPageFrameFeature = useHasPageFrameFeature();
 
   if (
     hasDynamicSamplingFeature(organization) &&
@@ -69,10 +71,14 @@ export default function DynamicSamplingSettings() {
       <SentryDocumentTitle title={t('Dynamic Sampling')} orgSlug={organization.slug} />
       <SettingsPageHeader
         title={
-          <Fragment>
-            {t('Dynamic Sampling')}
-            <FeatureBadge type="alpha" />
-          </Fragment>
+          hasPageFrameFeature ? (
+            t('Dynamic Sampling')
+          ) : (
+            <Fragment>
+              {t('Dynamic Sampling')}
+              <FeatureBadge type="alpha" />
+            </Fragment>
+          )
         }
         action={
           <LinkButton

--- a/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
+++ b/static/app/views/settings/organizationMembers/organizationMemberDetail.tsx
@@ -45,6 +45,7 @@ import {useApi} from 'sentry/utils/useApi';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 import {TeamSelect as TeamSelectForMember} from 'sentry/views/settings/components/teamSelect/teamSelectForMember';
 
@@ -96,6 +97,7 @@ function OrganizationMemberDetailContent({member}: {member: Member}) {
   const queryClient = useQueryClient();
   const organization = useOrganization();
   const navigate = useNavigate();
+  const hasPageFrameFeature = useHasPageFrameFeature();
 
   const [orgRole, setOrgRole] = useState<Member['orgRole']>(member.orgRole);
   const [teamRoles, setTeamRoles] = useState<Member['teamRoles']>(member.teamRoles);
@@ -260,10 +262,14 @@ function OrganizationMemberDetailContent({member}: {member: Member}) {
       <SentryDocumentTitle title={t('%s Member Settings', member.name || member.email)} />
       <SettingsPageHeader
         title={
-          <Fragment>
-            <div>{member.name}</div>
-            <ExtraHeaderText>{t('Member Settings')}</ExtraHeaderText>
-          </Fragment>
+          hasPageFrameFeature ? (
+            member.name || t('Member Settings')
+          ) : (
+            <Fragment>
+              <div>{member.name}</div>
+              <ExtraHeaderText>{t('Member Settings')}</ExtraHeaderText>
+            </Fragment>
+          )
         }
       />
 

--- a/static/gsApp/hooks/seerSettingsRoutes.ts
+++ b/static/gsApp/hooks/seerSettingsRoutes.ts
@@ -13,26 +13,32 @@ export const seerSettingsRoutes = (): SentryRouteObject => ({
     },
     {
       index: true,
+      name: t('Overview'),
       component: make(() => import('getsentry/views/seerAutomation/seerAutomation')),
     },
     {
       path: 'scm/',
+      name: t('Repositories'),
       component: make(() => import('getsentry/views/seerAutomation/scm')),
     },
     {
       path: 'projects/',
+      name: t('Autofix'),
       component: make(() => import('getsentry/views/seerAutomation/projects')),
     },
     {
       path: 'repos/',
+      name: t('Code Review'),
       component: make(() => import('getsentry/views/seerAutomation/repos')),
     },
     {
       path: 'repos/:repoId/',
+      name: t('Repository Details'),
       component: make(() => import('getsentry/views/seerAutomation/repoDetails')),
     },
     {
       path: 'advanced/',
+      name: t('Advanced Settings'),
       component: make(() => import('getsentry/views/seerAutomation/advanced')),
     },
     {


### PR DESCRIPTION
Updates a few pages to no longer render double breadcrumbs. In the case of dynamic sampling, I've removed the feature flag from the title, which is consistent with how Mobile builds and Snapshots render in project settings.

Also fixes seer pages to show breadcrumbs for sub routes and tabs
<img width="1290" height="242" alt="CleanShot 2026-04-18 at 12 05 08@2x" src="https://github.com/user-attachments/assets/03716a4f-705b-44fe-ac1d-fa8f7e461c77" />


Fixes DE-1156