### PR TITLE
feat(cmdk): Add settings field actions

### DIFF
--- a/static/app/components/search/sources/formSource.tsx
+++ b/static/app/components/search/sources/formSource.tsx
@@ -17,6 +17,7 @@ type FormSearchField = {
 };
 
 let ALL_FORM_FIELDS_CACHED: FormSearchField[] | null = null;
+let DEFAULT_FUZZY_PROMISE: Promise<Fuse<FormSearchField>> | null = null;
 
 type SearchMapParams = {
   fields: Record<string, Field>;
@@ -119,11 +120,50 @@ function getSearchMap() {
   return ALL_FORM_FIELDS_CACHED;
 }
 
+function createFormFieldSearch(
+  searchOptions?: Fuse.IFuseOptions<FormSearchField>
+): Promise<Fuse<FormSearchField>> {
+  return createFuzzySearch(getSearchMap(), {
+    ...searchOptions,
+    keys: ['title', 'description'],
+    getFn: strGetFn,
+  });
+}
+
+function getDefaultFormFieldSearch() {
+  if (DEFAULT_FUZZY_PROMISE === null) {
+    DEFAULT_FUZZY_PROMISE = createFormFieldSearch();
+  }
+
+  return DEFAULT_FUZZY_PROMISE;
+}
+
+function mapResults(fuzzy: Fuse<FormSearchField>, query: string): Result[] {
+  const resolvedTs = makeResolvedTs();
+
+  return fuzzy.search(query).map<Result>(({item, ...rest}) => ({
+    item: {
+      ...item,
+      sourceType: 'field',
+      resultType: 'field',
+      to: {pathname: item.route, hash: `#${encodeURIComponent(item.field.name)}`},
+      resolvedTs,
+    },
+    ...rest,
+  }));
+}
+
+export async function getFormSourceResults(query: string): Promise<Result[]> {
+  const fuzzy = await getDefaultFormFieldSearch();
+  return mapResults(fuzzy, query);
+}
+
 /**
  * @internal Used specifically for tests
  */
 export function setSearchMap(fields: FormSearchField[]) {
   ALL_FORM_FIELDS_CACHED = fields;
+  DEFAULT_FUZZY_PROMISE = null;
 }
 
 interface Props {
@@ -142,31 +182,13 @@ export function FormSource({searchOptions, query, children}: Props) {
   const [fuzzy, setFuzzy] = useState<Fuse<FormSearchField> | null>(null);
 
   const createSearch = useCallback(async () => {
-    setFuzzy(
-      await createFuzzySearch(getSearchMap(), {
-        ...searchOptions,
-        keys: ['title', 'description'],
-        getFn: strGetFn,
-      })
-    );
+    setFuzzy(await createFormFieldSearch(searchOptions));
   }, [searchOptions]);
 
   useEffect(() => void createSearch(), [createSearch]);
 
   const results = useMemo(() => {
-    const resolvedTs = makeResolvedTs();
-    return (
-      fuzzy?.search(query).map<Result>(({item, ...rest}) => ({
-        item: {
-          ...item,
-          sourceType: 'field',
-          resultType: 'field',
-          to: {pathname: item.route, hash: `#${encodeURIComponent(item.field.name)}`},
-          resolvedTs,
-        },
-        ...rest,
-      })) ?? []
-    );
+    return fuzzy ? mapResults(fuzzy, query) : [];
   }, [fuzzy, query]);
 
   return children({

--- a/static/app/views/settings/components/settingsCommandPaletteActions.spec.tsx
+++ b/static/app/views/settings/components/settingsCommandPaletteActions.spec.tsx
@@ -1,0 +1,38 @@
+import {setSearchMap} from 'sentry/components/search/sources/formSource';
+
+import {getSettingsFormActions} from './settingsCommandPaletteActions';
+
+describe('getSettingsFormActions', () => {
+  beforeEach(() => {
+    setSearchMap([
+      {
+        title: 'Create Rage Click Issues',
+        description: 'Toggles whether or not to create Session Replay Rage Click Issues',
+        route: '/settings/:orgId/projects/:projectId/replays/',
+        field: {name: 'sentry:replay_rage_click_issues'},
+      },
+    ]);
+  });
+
+  it('resolves settings route params for form search actions', async () => {
+    const actions = await getSettingsFormActions('rage', {
+      orgId: 'org-slug',
+      projectId: 'project-slug',
+    });
+
+    const rageClickAction = actions.find(
+      action => action.display.label === 'Create Rage Click Issues'
+    );
+
+    expect(rageClickAction).toEqual({
+      display: {
+        label: 'Create Rage Click Issues',
+        details: 'Toggles whether or not to create Session Replay Rage Click Issues',
+      },
+      to: {
+        pathname: '/settings/org-slug/projects/project-slug/replays/',
+        hash: '#sentry%3Areplay_rage_click_issues',
+      },
+    });
+  });
+});

--- a/static/app/views/settings/components/settingsCommandPaletteActions.tsx
+++ b/static/app/views/settings/components/settingsCommandPaletteActions.tsx
@@ -1,0 +1,88 @@
+import {cmdkQueryOptions} from 'sentry/components/commandPalette/types';
+import type {
+  CMDKQueryOptions,
+  CommandPaletteAction,
+} from 'sentry/components/commandPalette/types';
+import {CMDKAction} from 'sentry/components/commandPalette/ui/cmdk';
+import {CommandPaletteSlot} from 'sentry/components/commandPalette/ui/commandPaletteSlot';
+import {getFormSourceResults} from 'sentry/components/search/sources/formSource';
+import {IconSearch} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {replaceRouterParams} from 'sentry/utils/replaceRouterParams';
+import {useParams} from 'sentry/utils/useParams';
+
+function renderAsyncResult(item: CommandPaletteAction, index: number) {
+  if ('to' in item) {
+    return <CMDKAction key={index} {...item} />;
+  }
+
+  if ('onAction' in item) {
+    return <CMDKAction key={index} {...item} />;
+  }
+
+  return null;
+}
+
+export async function getSettingsFormActions(
+  query: string,
+  params: {
+    orgId?: string;
+    projectId?: string;
+    teamId?: string;
+  }
+): Promise<CommandPaletteAction[]> {
+  const results = await getFormSourceResults(query);
+
+  return results.flatMap(({item}) => {
+    if (!item.to) {
+      return [];
+    }
+
+    return [
+      {
+        display: {
+          label: typeof item.title === 'string' ? item.title : '',
+          details: typeof item.description === 'string' ? item.description : undefined,
+        },
+        to:
+          typeof item.to === 'string'
+            ? replaceRouterParams(item.to, params)
+            : {
+                ...item.to,
+                pathname: replaceRouterParams(item.to.pathname, params),
+              },
+      },
+    ];
+  });
+}
+
+export function SettingsCommandPaletteActions() {
+  const params = useParams<{
+    orgId?: string;
+    projectId?: string;
+    teamId?: string;
+  }>();
+
+  return (
+    <CommandPaletteSlot name="page">
+      <CMDKAction
+        display={{
+          label: t('Settings Fields'),
+          icon: <IconSearch />,
+        }}
+        prompt={t('Search settings...')}
+        limit={10}
+        resource={(query: string): CMDKQueryOptions =>
+          cmdkQueryOptions({
+            queryKey: ['command-palette-settings-form-search', query, params],
+            enabled: query.trim().length > 0,
+            queryFn: () => getSettingsFormActions(query, params),
+            staleTime: 30_000,
+          })
+        }
+      >
+        {data => data.map((item, index) => renderAsyncResult(item, index))}
+      </CMDKAction>
+    </CommandPaletteSlot>
+  );
+}

--- a/static/app/views/settings/components/settingsLayout.tsx
+++ b/static/app/views/settings/components/settingsLayout.tsx
@@ -9,6 +9,7 @@ import {TopBar} from 'sentry/views/navigation/topBar';
 import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 import {SettingsBreadcrumb} from './settingsBreadcrumb';
+import {SettingsCommandPaletteActions} from './settingsCommandPaletteActions';
 import {SettingsHeader} from './settingsHeader';
 import {SettingsSearch} from './settingsSearch';
 
@@ -24,6 +25,7 @@ export function SettingsLayout({children}: Props) {
 
   return (
     <SettingsColumn>
+      <SettingsCommandPaletteActions />
       {hasPageFrame ? (
         <Fragment>
           <TopBar.Slot name="title">


### PR DESCRIPTION
Add a settings-scoped command palette action that surfaces searchable form fields while users are on settings routes.

This reuses the extracted FormSearch field registry so the settings search bar and CMDK share the same field lookup data and route resolution behavior. It also resolves route params before navigation so project- and team-scoped settings links point at the active context.

The implementation keeps the action mounted from the shared settings layout, adds a focused test for the route resolution helper, and preserves the existing settings search source as the single source of truth for these fields.