### PR TITLE
fix(external-install): use theme-aware border color for footer divider

### DIFF
--- a/static/app/components/modals/sentryAppDetailsModal.tsx
+++ b/static/app/components/modals/sentryAppDetailsModal.tsx
@@ -256,7 +256,7 @@ const Footer = styled('div')`
   display: flex;
   align-items: center;
   padding: 20px 30px;
-  border-top: 1px solid #e2dee6;
+  border-top: 1px solid ${p => p.theme.tokens.border.secondary};
   margin: 20px -30px -30px;
   justify-content: space-between;
 `;


### PR DESCRIPTION
The `Footer` styled-component in `sentryAppDetailsModal` uses a hardcoded `#e2dee6` for `border-top`, which is a light purple that sticks out as a harsh bright line in dark mode. Replace it with `theme.tokens.border.secondary`, the same token used for divider borders elsewhere in the codebase (e.g. `forms/form.tsx`).

Fixes #112440.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here is the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.