### PR TITLE
fix(search): handle IN operator for release.version multi-select filter

### DIFF
--- a/src/sentry/search/events/datasets/filter_aliases.py
+++ b/src/sentry/search/events/datasets/filter_aliases.py
@@ -206,8 +206,39 @@ def semver_filter_converter(
         raise ValueError("organization is a required param")
     organization_id: int = builder.params.organization.id
     # We explicitly use `raw_value` here to avoid converting wildcards to shell values
-    version: str = search_filter.value.raw_value
+    raw_version = search_filter.value.raw_value
     operator: str = search_filter.operator
+
+    # Handle multi-value (IN operator) by resolving each version individually
+    # with the = operator, similar to how release_filter_converter works.
+    if operator == "IN" and isinstance(raw_version, list):
+        versions: list[str] = []
+        for version_str in raw_version:
+            qs = (
+                Release.objects.filter_by_semver(
+                    organization_id,
+                    parse_semver(version_str, "="),
+                    project_ids=builder.params.project_ids,
+                )
+                .values_list("version", flat=True)
+                .order_by(*Release.SEMVER_COLS)[: constants.MAX_SEARCH_RELEASES]
+            )
+            versions.extend(qs)
+        versions = list(dict.fromkeys(versions))  # deduplicate while preserving order
+
+        if not validate_snuba_array_parameter(versions):
+            raise InvalidSearchQuery(
+                "There are too many releases that match your release.version filter, please try again with a narrower range"
+            )
+
+        if not versions:
+            versions = [constants.SEMVER_EMPTY_RELEASE]
+
+        return Condition(builder.column("release"), Op.IN, versions)
+
+    if not isinstance(raw_version, str):
+        raise InvalidSearchQuery("Invalid operation 'IN' for semantic version filter.")
+    version: str = raw_version
 
     # Note that we sort this such that if we end up fetching more than
     # MAX_SEMVER_SEARCH_RELEASES, we will return the releases that are closest to

--- a/src/sentry/search/events/filter.py
+++ b/src/sentry/search/events/filter.py
@@ -334,10 +334,33 @@ def _semver_filter_converter(
     project_ids = params.get("project_id")
     # We explicitly use `raw_value` here to avoid converting wildcards to shell values
     raw_version = search_filter.value.raw_value
+    operator: str = search_filter.operator
+
+    # Handle multi-value (IN operator) by resolving each version individually
+    # with the = operator, similar to how release_filter_converter works.
+    if operator == "IN" and isinstance(raw_version, list):
+        versions: list[str] = []
+        for version_str in raw_version:
+            qs = (
+                Release.objects.filter_by_semver(
+                    organization_id,
+                    parse_semver(version_str, "="),
+                    project_ids=project_ids,
+                )
+                .values_list("version", flat=True)
+                .order_by(*Release.SEMVER_COLS)[:MAX_SEARCH_RELEASES]
+            )
+            versions.extend(qs)
+        versions = list(dict.fromkeys(versions))  # deduplicate while preserving order
+
+        if not versions:
+            versions = [SEMVER_EMPTY_RELEASE]
+
+        return ["release", "IN", versions]
+
     if not isinstance(raw_version, str):
         raise InvalidSearchQuery("Invalid operation 'IN' for semantic version filter.")
     version: str = raw_version
-    operator: str = search_filter.operator
 
     # Note that we sort this such that if we end up fetching more than
     # MAX_SEMVER_SEARCH_RELEASES, we will return the releases that are closest to

--- a/tests/sentry/search/events/test_filter.py
+++ b/tests/sentry/search/events/test_filter.py
@@ -204,10 +204,25 @@ class SemverFilterConverterTest(BaseSemverConverterTest):
         ):
             _semver_filter_converter(filter, key, {"organization_id": self.organization.id})
 
-    def test_in_operator_rejected(self) -> None:
-        filter = SearchFilter(SearchKey(self.key), "IN", SearchValue(["1.0.0", "2.0.0"]))
-        with pytest.raises(InvalidSearchQuery, match="Invalid operation 'IN'"):
-            _semver_filter_converter(filter, self.key, {"organization_id": self.organization.id})
+    def test_in_operator_multi_value(self) -> None:
+        release = self.create_release(version="test@1.2.3")
+        release_2 = self.create_release(version="test@1.2.4")
+        filter = SearchFilter(SearchKey(self.key), "IN", SearchValue(["1.2.3", "1.2.4"]))
+        converted = _semver_filter_converter(
+            filter, self.key, {"organization_id": self.organization.id}
+        )
+        assert converted[0] == "release"
+        assert converted[1] == "IN"
+        assert set(converted[2]) == {release.version, release_2.version}
+
+    def test_in_operator_no_match(self) -> None:
+        filter = SearchFilter(SearchKey(self.key), "IN", SearchValue(["9.9.9"]))
+        converted = _semver_filter_converter(
+            filter, self.key, {"organization_id": self.organization.id}
+        )
+        assert converted[0] == "release"
+        assert converted[1] == "IN"
+        assert converted[2] == [SEMVER_EMPTY_RELEASE]
 
     def test_empty(self) -> None:
         self.run_test(">", "1.2.3", "IN", [SEMVER_EMPTY_RELEASE])


### PR DESCRIPTION
When multiple values are selected for the `release.version` filter in a dashboard widget, the query builder emits an `IN` operator that was not handled by the semver converter, causing a 400 "Invalid Query" response.

**Root cause**: `_semver_filter_converter` in `filter.py` and `semver_filter_converter` in `filter_aliases.py` assume `search_filter.value.raw_value` is a string. When multi-select is used, it is a list, and the `IN` operator is not in `OPERATOR_TO_DJANGO`, triggering an `InvalidSearchQuery`.

**Fix**: When the `IN` operator is received with a list value, resolve each version individually through the semver pipeline with the `=` operator and combine results into a single `IN` clause — the same approach used by `release_filter_converter` for the plain `release` filter.

Fixes #113135

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here is the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.