### PR TITLE
fix(pageFrame): remove muted variant from InfoTip

### DIFF
--- a/static/app/components/pageHeadingQuestionTooltip.tsx
+++ b/static/app/components/pageHeadingQuestionTooltip.tsx
@@ -32,5 +32,5 @@ export function PageHeadingQuestionTooltip({
     </Flex>
   );
 
-  return <InfoTip title={contents} size="sm" variant="muted" position="right" />;
+  return <InfoTip title={contents} size="sm" position="right" />;
 }


### PR DESCRIPTION
before:

<img width="652" height="222" alt="CleanShot 2026-04-14 at 17 47 36@2x" src="https://github.com/user-attachments/assets/6713b4a7-155e-4800-b07d-67574812a920" />

after:

<img width="966" height="349" alt="Screenshot 2026-04-20 at 12 19 46" src="https://github.com/user-attachments/assets/f2654173-dd6a-43b5-ac3c-783b0ee86f98" />
