### PR TITLE
fix(pageFrame): integration layout header

### DIFF
--- a/static/app/views/settings/components/settingsBreadcrumb/index.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/index.tsx
@@ -86,6 +86,7 @@ export function SettingsBreadcrumb({className, routes, params}: Props) {
 // routes do not have organization information.
 export const CrumbLink = styled(RouterLink)`
   display: block;
+  line-height: ${p => p.theme.font.lineHeight.default};
 
   color: ${p => p.theme.tokens.content.secondary};
   &:hover {

--- a/static/app/views/settings/components/settingsPageHeader.tsx
+++ b/static/app/views/settings/components/settingsPageHeader.tsx
@@ -51,13 +51,7 @@ function UnstyledSettingsPageHeader({
         {typeof title === 'string' ? (
           <BreadcrumbTitle routes={routes} title={title} />
         ) : (
-          title && (
-            <TitleWrapper>
-              <Title styled={noTitleStyles}>
-                <Layout.Title>{title}</Layout.Title>
-              </Title>
-            </TitleWrapper>
-          )
+          title && <Layout.Title>{title}</Layout.Title>
         )}
         {action && <TopBar.Slot name="actions">{action}</TopBar.Slot>}
         {body && <BodyWrapper>{body}</BodyWrapper>}

--- a/static/app/views/settings/components/settingsPageHeader.tsx
+++ b/static/app/views/settings/components/settingsPageHeader.tsx
@@ -19,14 +19,6 @@ type Props = {
   body?: React.ReactNode;
   className?: string;
   /**
-   * Use a purple color for the subtitle
-   */
-  colorSubtitle?: boolean;
-  /**
-   * Icon to the left of the title
-   */
-  icon?: React.ReactNode;
-  /**
    * Disables font styles in the title. Allows for more custom titles.
    */
   noTitleStyles?: boolean;
@@ -35,10 +27,8 @@ type Props = {
 };
 
 function UnstyledSettingsPageHeader({
-  icon,
   title,
   subtitle,
-  colorSubtitle,
   action,
   body,
   tabs,
@@ -63,7 +53,6 @@ function UnstyledSettingsPageHeader({
         ) : (
           title && (
             <TitleWrapper>
-              {icon && <Icon>{icon}</Icon>}
               <Title tabs={tabs} styled={noTitleStyles}>
                 <Layout.Title>{title}</Layout.Title>
               </Title>
@@ -81,11 +70,10 @@ function UnstyledSettingsPageHeader({
     <div {...props}>
       <TitleAndActions isNarrow={isNarrow}>
         <TitleWrapper>
-          {icon && <Icon>{icon}</Icon>}
           {title && (
             <Title tabs={tabs} styled={noTitleStyles}>
               <Layout.Title>{title}</Layout.Title>
-              {subtitle && <Subtitle colorSubtitle={colorSubtitle}>{subtitle}</Subtitle>}
+              {subtitle && <Subtitle>{subtitle}</Subtitle>}
             </Title>
           )}
         </TitleWrapper>
@@ -117,16 +105,11 @@ const Title = styled('div')<TitleProps>`
   margin: ${p => p.theme.space['3xl']} ${p => p.theme.space.xl}
     ${p => p.theme.space['2xl']} 0;
 `;
-const Subtitle = styled('div')<{colorSubtitle?: boolean}>`
-  color: ${p =>
-    p.colorSubtitle ? p.theme.tokens.content.accent : p.theme.colors.gray500};
+const Subtitle = styled('div')`
+  color: ${p => p.theme.tokens.content.secondary};
   font-weight: ${p => p.theme.font.weight.sans.regular};
   font-size: ${p => p.theme.font.size.md};
   padding: ${p => p.theme.space.lg} 0 0;
-`;
-
-const Icon = styled('div')`
-  margin-right: ${p => p.theme.space.md};
 `;
 
 const Action = styled('div')<{isNarrow?: boolean}>`

--- a/static/app/views/settings/components/settingsPageHeader.tsx
+++ b/static/app/views/settings/components/settingsPageHeader.tsx
@@ -53,7 +53,7 @@ function UnstyledSettingsPageHeader({
         ) : (
           title && (
             <TitleWrapper>
-              <Title tabs={tabs} styled={noTitleStyles}>
+              <Title styled={noTitleStyles}>
                 <Layout.Title>{title}</Layout.Title>
               </Title>
             </TitleWrapper>
@@ -71,7 +71,7 @@ function UnstyledSettingsPageHeader({
       <TitleAndActions isNarrow={isNarrow}>
         <TitleWrapper>
           {title && (
-            <Title tabs={tabs} styled={noTitleStyles}>
+            <Title styled={noTitleStyles}>
               <Layout.Title>{title}</Layout.Title>
               {subtitle && <Subtitle>{subtitle}</Subtitle>}
             </Title>
@@ -86,11 +86,6 @@ function UnstyledSettingsPageHeader({
   );
 }
 
-interface TitleProps extends React.HTMLAttributes<HTMLDivElement> {
-  styled?: boolean;
-  tabs?: React.ReactNode;
-}
-
 const TitleAndActions = styled('div')<{isNarrow?: boolean}>`
   display: flex;
   align-items: ${p => (p.isNarrow ? 'center' : 'flex-start')};
@@ -99,7 +94,7 @@ const TitleWrapper = styled('div')`
   flex: 1;
 `;
 
-const Title = styled('div')<TitleProps>`
+const Title = styled('div')<{styled?: boolean}>`
   ${p =>
     !p.styled && `font-size: 20px; font-weight: ${p.theme.font.weight.sans.medium};`};
   margin: ${p => p.theme.space['3xl']} ${p => p.theme.space.xl}

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -48,6 +48,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useProjects} from 'sentry/utils/useProjects';
 import {useRoutes} from 'sentry/utils/useRoutes';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {BreadcrumbTitle} from 'sentry/views/settings/components/settingsBreadcrumb/breadcrumbTitle';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 
@@ -88,6 +89,7 @@ function ConfigureIntegration() {
   const api = useApi();
   const queryClient = useQueryClient();
   const organization = useOrganization();
+  const hasPageFrame = useHasPageFrameFeature();
   const tabParam = decodeScalar(location.query.tab) as Tab | undefined;
   const tab = tabParam && TABS.includes(tabParam) ? tabParam : 'repos';
   const {integrationId, providerKey} = useParams<{
@@ -530,18 +532,9 @@ function ConfigureIntegration() {
       <SentryDocumentTitle
         title={integration ? integration.provider.name : 'Configure Integration'}
       />
-      <BackButtonWrapper>
-        <LinkButton
-          icon={<IconArrow direction="left" size="sm" />}
-          size="sm"
-          to={`/settings/${organization.slug}/integrations/${provider.key}/`}
-        >
-          {t('Back')}
-        </LinkButton>
-      </BackButtonWrapper>
       <SettingsPageHeader
         noTitleStyles
-        title={<IntegrationItem integration={integration} />}
+        title={<IntegrationItem integration={integration} compact={hasPageFrame} />}
         action={getAction()}
       />
       {renderMainContent()}
@@ -583,8 +576,3 @@ const TabsContainer = styled('div')`
 `;
 
 export default ConfigureIntegration;
-
-const BackButtonWrapper = styled('div')`
-  margin-bottom: ${p => p.theme.space.xl};
-  width: 100%;
-`;

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
@@ -128,9 +128,9 @@ describe('IntegrationDetailedView', () => {
       initialRouterConfig: createRouterConfig('bitbucket', {tab: 'configurations'}),
       organization,
     });
-    expect(await screen.findByTestId('integration-name')).toHaveTextContent(
-      '{fb715533-bbd7-4666-aa57-01dc93dd9cc0}'
-    );
+    expect(
+      await screen.findByText('{fb715533-bbd7-4666-aa57-01dc93dd9cc0}')
+    ).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Configure'})).toBeEnabled();
   });
 

--- a/static/app/views/settings/organizationIntegrations/integrationItem.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationItem.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
 import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
 
 import type {Integration} from 'sentry/types/integrations';
 import {IntegrationIcon} from 'sentry/views/settings/organizationIntegrations/integrationIcon';
@@ -14,43 +15,34 @@ export function IntegrationItem({integration, compact = false}: Props) {
   return (
     <Flex align="center">
       <div>
-        <IntegrationIcon size={compact ? 22 : 32} integration={integration} />
+        <IntegrationIcon size={compact ? 18 : 32} integration={integration} />
       </div>
-      <Labels compact={compact}>
-        <IntegrationName data-test-id="integration-name">
+      <Flex
+        direction={compact ? 'row' : 'column'}
+        align={compact ? 'center' : undefined}
+        justify="center"
+        paddingLeft="md"
+        minWidth={0}
+      >
+        <Text size="md" bold>
           {integration.name}
-        </IntegrationName>
-        <DomainName compact={compact}>{integration.domainName}</DomainName>
-      </Labels>
+        </Text>
+        <DomainName compact={compact}>
+          <Text size="sm" variant="muted" density="comfortable">
+            {integration.domainName}
+          </Text>
+        </DomainName>
+      </Flex>
     </Flex>
   );
 }
-
-const Labels = styled('div')<{compact: boolean}>`
-  box-sizing: border-box;
-  display: flex;
-  ${p => (p.compact ? 'align-items: center;' : '')};
-  flex-direction: ${p => (p.compact ? 'row' : 'column')};
-  padding-left: ${p => p.theme.space.md};
-  min-width: 0;
-  justify-content: center;
-`;
-
-const IntegrationName = styled('div')`
-  font-size: ${p => p.theme.font.size.md};
-  font-weight: ${p => p.theme.font.weight.sans.medium};
-  line-height: ${p => p.theme.font.lineHeight.default};
-`;
 
 // Not using the overflowEllipsis style import here
 // as it sets width 100% which causes layout issues in the
 // integration list.
 const DomainName = styled('div')<{compact: boolean}>`
-  color: ${p => p.theme.tokens.content.secondary};
   margin-left: ${p => (p.compact ? p.theme.space.md : 'inherit')};
   margin-top: ${p => (p.compact ? 'inherit' : 0)};
-  font-size: ${p => p.theme.font.size.sm};
   overflow: hidden;
   text-overflow: ellipsis;
-  line-height: ${p => p.theme.font.lineHeight.comfortable};
 `;


### PR DESCRIPTION
before:

<img width="2030" height="304" alt="image (37)" src="https://github.com/user-attachments/assets/1ec87bda-966a-4cc7-ad2e-9d02081083aa" />


after:

<img width="1426" height="160" alt="Screenshot 2026-04-20 at 14 06 06" src="https://github.com/user-attachments/assets/09b7ee11-284c-4132-95dc-59ea42c73bb7" />

---

note: I removed the `back` button for the old and the new layout. That’s what we have breadCrumbs for.