### PR TITLE
ci(snapshots): Bump sentry-cli to 3.4.0

### DIFF
--- a/.github/workflows/frontend-snapshots.yml
+++ b/.github/workflows/frontend-snapshots.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Install sentry-cli
         if: ${{ !cancelled() }}
-        run: curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=3.3.5 sh
+        run: curl -sL https://sentry.io/get-cli/ | SENTRY_CLI_VERSION=3.4.0 sh
 
       - name: Upload snapshots
         id: upload
@@ -89,6 +89,6 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_SNAPSHOTS_DSN }}
         run: |
           sentry-cli send-event \
-            --message "Frontend snapshot upload failed"
+            --message "Frontend snapshot upload failed" \
             --tag workflow:frontend-snapshots \
             --tag commit:"${{ github.sha }}"


### PR DESCRIPTION
Bump `sentry-cli` to the latest version, which includes changes to how snapshots are uploaded (concurrency/fd exhaustion prevention) as well as authentication with Objectstore.

Also fixes a typo in the command to send Sentry events for failures, as it was missing a `\` for the newline.