### PR TITLE
feat(seer): Add thinking blocks toggle to explorer chat

### DIFF
--- a/static/app/views/seerExplorer/components/blockComponents.spec.tsx
+++ b/static/app/views/seerExplorer/components/blockComponents.spec.tsx
@@ -278,6 +278,73 @@ describe('BlockComponent', () => {
     expect(downButton).toBeEnabled();
   });
 
+  describe('Thinking Content', () => {
+    it('renders a collapsible thinking section when showThinking is true and thinking_content is present', async () => {
+      const block = createResponseBlock({
+        message: {
+          role: 'assistant',
+          content: 'The answer is 42.',
+          thinking_content: 'Let me reason through this step by step.',
+        },
+      });
+      render(
+        <BlockComponent
+          block={block}
+          blockIndex={0}
+          onClick={mockOnClick}
+          runId={runId}
+          showThinking
+        />
+      );
+
+      expect(screen.getByText('Thinking')).toBeInTheDocument();
+      expect(screen.getByText('The answer is 42.')).toBeInTheDocument();
+
+      // Expand the thinking section
+      await userEvent.click(screen.getByText('Thinking'));
+      expect(
+        screen.getByText('Let me reason through this step by step.')
+      ).toBeInTheDocument();
+    });
+
+    it('does not render thinking section when showThinking is false', () => {
+      const block = createResponseBlock({
+        message: {
+          role: 'assistant',
+          content: 'The answer is 42.',
+          thinking_content: 'Let me reason through this step by step.',
+        },
+      });
+      render(
+        <BlockComponent
+          block={block}
+          blockIndex={0}
+          onClick={mockOnClick}
+          runId={runId}
+          showThinking={false}
+        />
+      );
+
+      expect(screen.queryByText('Thinking')).not.toBeInTheDocument();
+      expect(screen.getByText('The answer is 42.')).toBeInTheDocument();
+    });
+
+    it('does not render thinking section when thinking_content is absent', () => {
+      const block = createResponseBlock();
+      render(
+        <BlockComponent
+          block={block}
+          blockIndex={0}
+          onClick={mockOnClick}
+          runId={runId}
+          showThinking
+        />
+      );
+
+      expect(screen.queryByText('Thinking')).not.toBeInTheDocument();
+    });
+  });
+
   describe('Markdown Content', () => {
     it('renders markdown content in response blocks', () => {
       const block = createResponseBlock({

--- a/static/app/views/seerExplorer/components/blockComponents.tsx
+++ b/static/app/views/seerExplorer/components/blockComponents.tsx
@@ -5,6 +5,7 @@ import type {LocationDescriptor} from 'history';
 
 import {Button} from '@sentry/scraps/button';
 import {inlineCodeStyles} from '@sentry/scraps/code';
+import {Disclosure} from '@sentry/scraps/disclosure';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -51,6 +52,7 @@ interface BlockProps {
   readOnly?: boolean;
   ref?: React.Ref<HTMLDivElement>;
   runId?: number;
+  showThinking?: boolean;
 }
 
 function hasValidContent(content: string): boolean {
@@ -156,6 +158,7 @@ export function BlockComponent({
   onRegisterEnterHandler,
   readOnly = false,
   ref,
+  showThinking = false,
 }: BlockProps) {
   const {copy} = useCopyToClipboard();
   const organization = useOrganization();
@@ -165,9 +168,18 @@ export function BlockComponent({
   const toolsUsed = getToolsStringFromBlock(block);
   const hasTools = toolsUsed.length > 0;
   const hasContent = hasValidContent(block.message.content);
+  const hasThinkingContentToShow =
+    showThinking && hasValidContent(block.message.thinking_content ?? '');
   const processedContent = useMemo(
     () => postProcessLLMMarkdown(block.message.content),
     [block.message.content]
+  );
+  const processedThinkingContent = useMemo(
+    () =>
+      hasThinkingContentToShow
+        ? postProcessLLMMarkdown(block.message.thinking_content ?? '')
+        : '',
+    [block.message.thinking_content, hasThinkingContentToShow]
   );
 
   // State to track selected tool link (for navigation)
@@ -386,9 +398,23 @@ export function BlockComponent({
           <Flex align="start" width="100%">
             <ResponseDot
               status={getToolStatus(block)}
-              hasOnlyTools={!hasContent && hasTools}
+              hasOnlyTools={!hasContent && !hasThinkingContentToShow && hasTools}
             />
-            <BlockContentWrapper hasOnlyTools={!hasContent && hasTools}>
+            <BlockContentWrapper
+              hasOnlyTools={!hasContent && !hasThinkingContentToShow && hasTools}
+            >
+              {hasThinkingContentToShow && (
+                <ThinkingDisclosure>
+                  <Disclosure.Title>
+                    <Text size="xs" variant="muted" monospace>
+                      {t('Thinking')}
+                    </Text>
+                  </Disclosure.Title>
+                  <Disclosure.Content>
+                    <ThinkingContent text={processedThinkingContent} />
+                  </Disclosure.Content>
+                </ThinkingDisclosure>
+              )}
               {hasContent && (
                 <BlockContent
                   text={processedContent}
@@ -762,4 +788,30 @@ const TodoListContent = styled(MarkedText)`
   font-size: ${p => p.theme.font.size.xs};
   font-family: ${p => p.theme.font.family.mono};
   color: ${p => p.theme.tokens.content.secondary};
+`;
+
+const ThinkingDisclosure = styled(Disclosure)`
+  margin-bottom: ${p => p.theme.space.md};
+`;
+
+const ThinkingContent = styled(MarkedText)`
+  font-size: ${p => p.theme.font.size.sm};
+  color: ${p => p.theme.tokens.content.secondary};
+  white-space: pre-wrap;
+  word-wrap: break-word;
+
+  code:not(pre code) {
+    ${p => inlineCodeStyles(p.theme)};
+  }
+
+  p,
+  li,
+  ul,
+  ol {
+    margin: -${p => p.theme.space.md} 0;
+  }
+
+  p:first-child {
+    margin-top: 0;
+  }
 `;

--- a/static/app/views/seerExplorer/components/panel/explorerPanel.tsx
+++ b/static/app/views/seerExplorer/components/panel/explorerPanel.tsx
@@ -65,6 +65,7 @@ export function ExplorerPanel() {
   const isSeerDrawerOpen = !!location.query?.seerDrawer;
 
   const [inputValue, setInputValue] = useState('');
+  const [showThinking, setShowThinking] = useState(false);
   const [focusedBlockIndex, setFocusedBlockIndex] = useState(-1); // -1 means input is focused
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -619,6 +620,9 @@ export function ExplorerPanel() {
         sessionHistoryButtonRef={sessionHistoryButtonRef}
         overrideCtxEngEnable={overrideCtxEngEnable}
         onOverrideCtxEngEnableToggle={() => setOverrideCtxEngEnable(v => !v)}
+        showThinking={showThinking}
+        onShowThinkingToggle={() => setShowThinking(v => !v)}
+        showThinkingToggle={user.isStaff}
         showContextEngineToggle={
           !!organization?.features.includes(
             'seer-explorer-context-engine-fe-override-ui-flag'
@@ -653,6 +657,7 @@ export function ExplorerPanel() {
                 isAwaitingFileApproval={isFileApprovalPending}
                 isAwaitingQuestion={isQuestionPending}
                 isLatestTodoBlock={index === latestTodoBlockIndex}
+                showThinking={showThinking}
                 isLast={
                   index === blocks.length - 1 && !(isAwaitingUserInput && pendingInput)
                 }

--- a/static/app/views/seerExplorer/components/topBar.tsx
+++ b/static/app/views/seerExplorer/components/topBar.tsx
@@ -36,6 +36,7 @@ interface TopBarProps {
   onOverrideCodeModeEnableToggle: () => void;
   onOverrideCtxEngEnableToggle: () => void;
   onSessionHistoryClick: (buttonRef: React.RefObject<HTMLElement | null>) => void;
+  onShowThinkingToggle: () => void;
   onSizeToggleClick: () => void;
   overrideCodeModeEnable: boolean;
   overrideCtxEngEnable: boolean;
@@ -43,6 +44,8 @@ interface TopBarProps {
   sessionHistoryButtonRef: React.RefObject<HTMLButtonElement | null>;
   showCodeModeToggle: boolean;
   showContextEngineToggle: boolean;
+  showThinking: boolean;
+  showThinkingToggle: boolean;
 }
 
 export function TopBar({
@@ -59,10 +62,13 @@ export function TopBar({
   onSizeToggleClick,
   onOverrideCtxEngEnableToggle,
   onOverrideCodeModeEnableToggle,
+  onShowThinkingToggle,
   overrideCtxEngEnable,
   overrideCodeModeEnable,
   showContextEngineToggle,
   showCodeModeToggle,
+  showThinking,
+  showThinkingToggle,
   panelSize,
   isCopySessionEnabled,
   isCopyLinkEnabled,
@@ -158,6 +164,27 @@ export function TopBar({
               />
               <Text size="sm" variant="muted">
                 {t('CM')}
+              </Text>
+            </Flex>
+          </Tooltip>
+        )}
+        {showThinkingToggle && (
+          <Tooltip
+            title={
+              showThinking
+                ? t('Hide thinking blocks (click to hide)')
+                : t('Show thinking blocks (click to show)')
+            }
+          >
+            <Flex align="center" gap="xs" padding="xs sm" height="100%">
+              <Switch
+                size="sm"
+                checked={showThinking}
+                onChange={onShowThinkingToggle}
+                aria-label={t('Toggle thinking blocks')}
+              />
+              <Text size="sm" variant="muted">
+                {t('Show thinking (debug)')}
               </Text>
             </Flex>
           </Tooltip>


### PR DESCRIPTION
Add a staff-only toggle in the explorer top bar to show/hide LLM
thinking content in chat blocks. When enabled, assistant messages
with thinking_content display a collapsible Disclosure section.

The toggle is gated behind user.isStaff, matching the cmd-k admin
section pattern.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

Agent transcript: https://claudescope.sentry.dev/share/KzpOJlQltlg77oHgDCVFjNwrpUJDmidBzjgH2iKrUXI
