### PR TITLE
feat(preprod): Normalize distribution error messages (EME-883)

### DIFF
--- a/src/sentry/preprod/api/endpoints/project_preprod_distribution.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_distribution.py
@@ -18,6 +18,7 @@ from sentry.preprod.authentication import (
     LaunchpadRpcSignatureAuthentication,
 )
 from sentry.preprod.build_distribution_webhooks import send_build_distribution_webhook
+from sentry.preprod.distribution_errors import normalize_installable_app_error_message
 from sentry.preprod.models import PreprodArtifact
 
 logger = logging.getLogger(__name__)
@@ -47,7 +48,9 @@ class ProjectPreprodDistributionEndpoint(PreprodArtifactEndpoint):
         put: PutDistribution = parse_request_with_pydantic(request, cast(Any, PutDistribution))
 
         head_artifact.installable_app_error_code = put.error_code
-        head_artifact.installable_app_error_message = put.error_message
+        head_artifact.installable_app_error_message = normalize_installable_app_error_message(
+            put.error_message
+        )
         head_artifact.save(
             update_fields=[
                 "installable_app_error_code",

--- a/src/sentry/preprod/distribution_errors.py
+++ b/src/sentry/preprod/distribution_errors.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+# Short codes historically sent by launchpad in lieu of a human-readable sentence.
+# New reasons should be emitted as sentences upstream and will pass through unchanged.
+_KNOWN_SHORT_CODES: dict[str, str] = {
+    "invalid_signature": "The build's code signature could not be verified.",
+    "simulator": "Simulator builds cannot be distributed.",
+}
+
+
+def normalize_installable_app_error_message(message: str | None) -> str | None:
+    if message is None:
+        return None
+    return _KNOWN_SHORT_CODES.get(message, message)

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_distribution.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_distribution.py
@@ -80,6 +80,24 @@ class ProjectPreprodDistributionEndpointTest(TestCase):
         assert call_kwargs.kwargs["organization_id"] == self.project.organization_id
 
     @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SECRET_FOR_TESTS])
+    @patch(
+        "sentry.preprod.api.endpoints.project_preprod_distribution.send_build_distribution_webhook"
+    )
+    def test_normalizes_known_short_code_error_message(self, mock_send_webhook) -> None:
+        response = self._put(orjson.dumps({"error_code": 2, "error_message": "invalid_signature"}))
+
+        assert response.status_code == 200
+        self.artifact.refresh_from_db()
+        assert (
+            self.artifact.installable_app_error_code
+            == PreprodArtifact.InstallableAppErrorCode.SKIPPED
+        )
+        assert (
+            self.artifact.installable_app_error_message
+            == "The build's code signature could not be verified."
+        )
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SECRET_FOR_TESTS])
     def test_invalid_error_code(self) -> None:
         response = self._put(orjson.dumps({"error_code": 99, "error_message": "bad"}))
         assert response.status_code == 400

--- a/tests/sentry/preprod/test_distribution_errors.py
+++ b/tests/sentry/preprod/test_distribution_errors.py
@@ -1,0 +1,30 @@
+from sentry.preprod.distribution_errors import normalize_installable_app_error_message
+
+
+def test_normalizes_invalid_signature() -> None:
+    assert (
+        normalize_installable_app_error_message("invalid_signature")
+        == "The build's code signature could not be verified."
+    )
+
+
+def test_normalizes_simulator() -> None:
+    assert (
+        normalize_installable_app_error_message("simulator")
+        == "Simulator builds cannot be distributed."
+    )
+
+
+def test_passes_unknown_message_through() -> None:
+    assert normalize_installable_app_error_message("Unsupported artifact type") == (
+        "Unsupported artifact type"
+    )
+
+
+def test_passes_none_through() -> None:
+    assert normalize_installable_app_error_message(None) is None
+
+
+def test_idempotent_on_already_normalized_message() -> None:
+    sentence = "The build's code signature could not be verified."
+    assert normalize_installable_app_error_message(sentence) == sentence


### PR DESCRIPTION
Normalize known launchpad distribution error messages to human-readable sentences at the write site.

Launchpad sends short machine-readable codes (e.g. `invalid_signature`, `simulator`) in the distribution `PUT` payload, and we store those verbatim in `PreprodArtifact.installable_app_error_message`. That forces the frontend to pattern-match on backend-internal strings to render anything human, which is brittle whenever launchpad introduces a new reason.

This PR adds `sentry.preprod.distribution_errors.normalize_installable_app_error_message` and calls it in `project_preprod_distribution.py` before the assignment. Known short codes map to sentences; unknown strings pass through unchanged so launchpad can emit a new human-readable message without requiring a Sentry deploy.

No schema change, no new enum values, no backfill — legacy rows keep whatever was stored. The follow-up frontend PR will consume normalized messages and drop the ad-hoc string matching in `installDetailsContent.tsx`.

Refs EME-883