### PR TITLE
feat(spans): Add flush_id to flushed segment messages

### DIFF
--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -199,6 +199,9 @@ class FlushedSegment(NamedTuple):
 
         If the segment size exceeds `spans.buffer.max_segment_bytes`, the segment is split
         into multiple messages with skip_enrichment=True. Otherwise, returns a single message.
+
+        Each message gets a unique flush_id generated at call time, ensuring duplicate
+        flushes from Redis produce distinct IDs.
         """
         max_segment_bytes = options.get("spans.buffer.max-segment-bytes")
 
@@ -206,7 +209,7 @@ class FlushedSegment(NamedTuple):
 
         sizes = [len(orjson.dumps(s)) for s in spans]
         if sum(sizes) <= max_segment_bytes:
-            return [{"spans": spans}]
+            return [{"flush_id": uuid.uuid4().hex, "spans": spans}]
 
         messages: list[dict[str, Any]] = []
         current: list[SpanPayload] = []
@@ -214,14 +217,18 @@ class FlushedSegment(NamedTuple):
 
         for span, size in zip(spans, sizes):
             if current and current_size + size > max_segment_bytes:
-                messages.append({"spans": current, "skip_enrichment": True})
+                messages.append(
+                    {"flush_id": uuid.uuid4().hex, "spans": current, "skip_enrichment": True}
+                )
                 current = []
                 current_size = 0
             current.append(span)
             current_size += size
 
         if current:
-            messages.append({"spans": current, "skip_enrichment": True})
+            messages.append(
+                {"flush_id": uuid.uuid4().hex, "spans": current, "skip_enrichment": True}
+            )
 
         if len(messages) > 1:
             metrics.timing(

--- a/tests/sentry/spans/consumers/process/test_consumer.py
+++ b/tests/sentry/spans/consumers/process/test_consumer.py
@@ -80,7 +80,9 @@ def test_basic(kafka_slice_id: int | None) -> None:
 
             (_, msg, _) = messages[0]
 
-            assert orjson.loads(msg.value) == {
+            result = orjson.loads(msg.value)
+            assert result.pop("flush_id")
+            assert result == {
                 "spans": [
                     {
                         "attributes": {

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -1055,8 +1055,10 @@ def test_to_messages_under_limit(buffer: SpansBuffer) -> None:
     ):
         messages = segment.to_messages()
     assert len(messages) == 1
-    assert messages[0] == {"spans": spans}
+    assert messages[0]["spans"] == spans
     assert "skip_enrichment" not in messages[0]
+    assert "flush_id" in messages[0]
+    assert len(messages[0]["flush_id"]) == 32  # UUID hex string
 
 
 def test_to_messages_splits_oversized(buffer: SpansBuffer) -> None:
@@ -1108,6 +1110,12 @@ def test_to_messages_splits_oversized(buffer: SpansBuffer) -> None:
 
     for message in messages:
         assert message["skip_enrichment"] is True
+        assert "flush_id" in message
+        assert len(message["flush_id"]) == 32
+
+    # Each chunk gets a unique flush_id
+    flush_ids = [m["flush_id"] for m in messages]
+    assert len(set(flush_ids)) == len(flush_ids)
 
     for message in messages[:-1]:
         chunk_size = sum(len(orjson.dumps(s)) for s in message["spans"])
@@ -1130,6 +1138,28 @@ def test_to_messages_single_large_span(buffer: SpansBuffer) -> None:
         messages = segment.to_messages()
     assert len(messages) == 1
     assert messages[0]["skip_enrichment"] is True
+    assert "flush_id" in messages[0]
+    assert len(messages[0]["flush_id"]) == 32
+
+
+def test_to_messages_unique_flush_ids_across_calls(buffer: SpansBuffer) -> None:
+    """Calling to_messages() twice produces unique flush_ids (dedup detection)."""
+    spans = [{"span_id": "a"}, {"span_id": "b"}]
+    segment = FlushedSegment(
+        queue_key=b"test",
+        spans=[OutputSpan(payload=s) for s in spans],
+        project_id=1,
+    )
+    with override_options(
+        {
+            **DEFAULT_OPTIONS,
+            "spans.buffer.max-segment-bytes": 10000,
+        }
+    ):
+        messages1 = segment.to_messages()
+        messages2 = segment.to_messages()
+
+    assert messages1[0]["flush_id"] != messages2[0]["flush_id"]
 
 
 def test_kafka_slice_id(buffer: SpansBuffer) -> None:


### PR DESCRIPTION
Add a unique UUID (`flush_id`) to each message produced by `FlushedSegment.to_messages()`. The UUID is generated at call time, right before JSON serialization.

This allows us to see whether the duplicate segments we observe "come from" redis, or whether they are created post-serialization.

ref INC-2116
ref STREAM-881