### PR TITLE
ref(commits): Simplify main loop, extra logging & CODEOWNERS update

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -684,6 +684,7 @@ tests/sentry/api/endpoints/test_organization_attribute_mappings.py          @get
 /src/sentry/tasks/clear_expired_rulesnoozes.py              @getsentry/issue-detection-backend
 /src/sentry/tasks/clear_expired_snoozes.py                  @getsentry/issue-detection-backend
 /src/sentry/tasks/codeowners/                               @getsentry/coding-workflows-sentry-backend
+/src/sentry/tasks/commits.py                                @getsentry/coding-workflows-sentry-backend
 /src/sentry/tasks/commit_context.py                         @getsentry/coding-workflows-sentry-backend
 /src/sentry/tasks/seer/delete_seer_grouping_records.py      @getsentry/issue-detection-backend
 /src/sentry/tasks/embeddings_grouping/                      @getsentry/issue-detection-backend

--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping, Sequence
-from typing import Any
+from typing import Any, NamedTuple
 
 import sentry_sdk
 from django.urls import reverse
@@ -103,7 +103,7 @@ def get_github_compare_commits_cache_key(
 
 def fetch_commits_for_compare_range(
     *,
-    cache_enabled: bool,
+    github_compare_commits_cache_feature_enabled: bool,
     repo: Repository,
     provider: Any,
     is_integration_repo_provider: bool,
@@ -111,6 +111,11 @@ def fetch_commits_for_compare_range(
     end_sha: str,
     user: RpcUser | None,
 ) -> list[dict[str, Any]]:
+    cache_enabled = (
+        github_compare_commits_cache_feature_enabled
+        and isinstance(repo.provider, str)
+        and repo.provider in GITHUB_CACHEABLE_REPOSITORY_PROVIDERS
+    )
     set_tag("compare_commits_cache_enabled", cache_enabled)
     if cache_enabled:
         cache_key = get_github_compare_commits_cache_key(
@@ -236,78 +241,140 @@ def get_start_sha_for_ref(
     return None
 
 
+class ResolvedRef(NamedTuple):
+    repo: Repository
+    provider: Any
+    is_integration_repo_provider: bool
+    provider_key: str
+    start_sha: str | None
+    end_sha: str
+
+
+def resolve_ref(
+    *,
+    ref: Mapping[str, str],
+    release: Release,
+    prev_release: Release | None,
+    user_id: int,
+) -> ResolvedRef | None:
+    """Turn a ref into the concrete objects needed to fetch commits, or None to skip.
+
+    Returns None (and logs via the underlying helpers) when the repository is missing
+    or no provider binding is registered, so the caller can skip without emitting
+    SCM lifecycle events for refs that would never succeed.
+    """
+    repo = get_repo_for_ref(release=release, ref=ref, user_id=user_id)
+    if repo is None:
+        return None
+
+    provider_values = get_provider_for_repo(repo=repo)
+    if provider_values is None:
+        return None
+    provider, is_integration_repo_provider, provider_key = provider_values
+
+    start_sha = get_start_sha_for_ref(
+        ref=ref,
+        release=release,
+        repo=repo,
+        prev_release=prev_release,
+    )
+    return ResolvedRef(
+        repo=repo,
+        provider=provider,
+        is_integration_repo_provider=is_integration_repo_provider,
+        provider_key=provider_key,
+        start_sha=start_sha,
+        end_sha=ref["commit"],
+    )
+
+
 def fetch_commits_for_ref_with_lifecycle(
     *,
-    provider_key: str,
-    repo: Repository,
-    provider: Any,
+    resolved: ResolvedRef,
     release: Release,
-    start_sha: str | None,
-    end_sha: str,
     user_id: int,
     user: RpcUser | None,
-    is_integration_repo_provider: bool,
-    compare_commits_cache_enabled: bool,
+    github_compare_commits_cache_feature_enabled: bool,
+    task_extra: Mapping[str, Any],
 ) -> list[dict[str, Any]] | None:
-    with SCMIntegrationInteractionEvent(
-        SCMIntegrationInteractionType.COMPARE_COMMITS,
-        provider_key=provider_key,
-        organization_id=repo.organization_id,
-        integration_id=repo.integration_id,
-    ).capture() as lifecycle:
-        lifecycle.add_extras(
-            {
-                "organization_id": repo.organization_id,
-                "user_id": user_id,
-                "repository": repo.name,
-                "provider": provider.id,
-                "end_sha": end_sha,
-                "start_sha": start_sha,
-            }
-        )
-        try:
-            if start_sha is None:
-                return fetch_recent_commits(
-                    repo=repo,
-                    provider=provider,
-                    is_integration_repo_provider=is_integration_repo_provider,
-                    end_sha=end_sha,
-                    user=user,
-                )
-            return fetch_commits_for_compare_range(
-                cache_enabled=compare_commits_cache_enabled,
-                repo=repo,
-                provider=provider,
-                is_integration_repo_provider=is_integration_repo_provider,
-                start_sha=start_sha,
-                end_sha=end_sha,
-                user=user,
+    repo = resolved.repo
+    start_sha = resolved.start_sha
+    end_sha = resolved.end_sha
+    loop_extra = {
+        **task_extra,
+        "repository": repo.name,
+        "start_sha": start_sha,
+        "end_sha": end_sha,
+    }
+    logger.info("fetch_commits.loop.start", extra=loop_extra)
+    repo_commits: list[dict[str, Any]] | None = None
+    try:
+        with SCMIntegrationInteractionEvent(
+            SCMIntegrationInteractionType.COMPARE_COMMITS,
+            provider_key=resolved.provider_key,
+            organization_id=repo.organization_id,
+            integration_id=repo.integration_id,
+        ).capture() as lifecycle:
+            lifecycle.add_extras(
+                {
+                    "organization_id": repo.organization_id,
+                    "user_id": user_id,
+                    "repository": repo.name,
+                    "provider": resolved.provider.id,
+                    "end_sha": end_sha,
+                    "start_sha": start_sha,
+                }
             )
-        except NotImplementedError:
-            return None
-        except IntegrationResourceNotFoundError:
-            return None
-        except Exception as e:
-            span = sentry_sdk.get_current_span()
-            if span:
-                span.set_status("unknown_error")
+            try:
+                if start_sha is None:
+                    repo_commits = fetch_recent_commits(
+                        repo=repo,
+                        provider=resolved.provider,
+                        is_integration_repo_provider=resolved.is_integration_repo_provider,
+                        end_sha=end_sha,
+                        user=user,
+                    )
+                else:
+                    repo_commits = fetch_commits_for_compare_range(
+                        github_compare_commits_cache_feature_enabled=github_compare_commits_cache_feature_enabled,
+                        repo=repo,
+                        provider=resolved.provider,
+                        is_integration_repo_provider=resolved.is_integration_repo_provider,
+                        start_sha=start_sha,
+                        end_sha=end_sha,
+                        user=user,
+                    )
+            except NotImplementedError:
+                repo_commits = None
+            except IntegrationResourceNotFoundError:
+                repo_commits = None
+            except Exception as e:
+                span = sentry_sdk.get_current_span()
+                if span:
+                    span.set_status("unknown_error")
 
-            if isinstance(e, InvalidIdentity) and getattr(e, "identity", None):
-                handle_invalid_identity(identity=e.identity, commit_failure=True)
-                lifecycle.record_halt(e)
-            elif isinstance(e, (PluginError, InvalidIdentity, IntegrationError)):
-                msg = generate_fetch_commits_error_email(release, repo, str(e))
-                emails = get_emails_for_user_or_org(user, release.organization_id)
-                msg.send_async(to=emails)
-                lifecycle.record_halt(e)
-            else:
-                msg = generate_fetch_commits_error_email(
-                    release, repo, "An internal system error occurred."
-                )
-                emails = get_emails_for_user_or_org(user, release.organization_id)
-                msg.send_async(to=emails)
-                lifecycle.record_failure(e)
-            return None
+                if isinstance(e, InvalidIdentity) and getattr(e, "identity", None):
+                    handle_invalid_identity(identity=e.identity, commit_failure=True)
+                    lifecycle.record_halt(e)
+                elif isinstance(e, (PluginError, InvalidIdentity, IntegrationError)):
+                    msg = generate_fetch_commits_error_email(release, repo, str(e))
+                    emails = get_emails_for_user_or_org(user, release.organization_id)
+                    msg.send_async(to=emails)
+                    lifecycle.record_halt(e)
+                else:
+                    msg = generate_fetch_commits_error_email(
+                        release, repo, "An internal system error occurred."
+                    )
+                    emails = get_emails_for_user_or_org(user, release.organization_id)
+                    msg.send_async(to=emails)
+                    lifecycle.record_failure(e)
+                repo_commits = None
+        return repo_commits
+    finally:
+        logger.info(
+            "fetch_commits.loop.complete",
+            extra={**loop_extra, "num_commits": len(repo_commits or [])},
+        )
 
 
 @instrumented_task(
@@ -328,12 +395,23 @@ def fetch_commits(
     commit_list: list[dict[str, Any]] = []
 
     release = Release.objects.get(id=release_id)
-    logger.info("fetch_commits.start", extra={"organization_slug": release.organization.slug})
-    set_tag("organization.slug", release.organization.slug)
     # TODO: Need a better way to error handle no user_id. We need the SDK to be able to call this without user context
     # to autoassociate commits to releases
     user = user_service.get_user(user_id) if user_id is not None else None
-    # user = User.objects.get(id=user_id) if user_id is not None else None
+    organization = release.organization
+    github_compare_commits_cache_feature_enabled = features.has(
+        GITHUB_FETCH_COMMITS_COMPARE_CACHE_FEATURE, organization, actor=user
+    )
+    set_tag("organization.slug", release.organization.slug)
+    extra = {
+        "organization_id": release.organization_id,
+        "user_id": user_id,
+        "refs": refs,
+        "num_refs": len(refs),
+        "prev_release_id": prev_release_id,
+        "github_compare_commits_cache_feature_enabled": github_compare_commits_cache_feature_enabled,
+    }
+    logger.info("fetch_commits.start", extra=extra)
     prev_release = None
     if prev_release_id is not None:
         try:
@@ -341,60 +419,18 @@ def fetch_commits(
         except Release.DoesNotExist:
             pass
 
-    organization = release.organization
-    github_compare_commits_cache_feature_enabled = features.has(
-        GITHUB_FETCH_COMMITS_COMPARE_CACHE_FEATURE, organization, actor=user
-    )
-    extra = {
-        "organization_id": release.organization_id,
-        "user_id": user_id,
-        "github_compare_commits_cache_feature_enabled": github_compare_commits_cache_feature_enabled,
-    }
-    logger.info("fetch_commits.config", extra=extra)
-
     for ref in refs:
-        repo = get_repo_for_ref(release=release, ref=ref, user_id=user_id)
-        if repo is None:
+        resolved = resolve_ref(ref=ref, release=release, prev_release=prev_release, user_id=user_id)
+        if resolved is None:
             continue
-
-        provider_values = get_provider_for_repo(repo=repo)
-        if provider_values is None:
-            continue
-        provider, is_integration_repo_provider, provider_key = provider_values
-
-        start_sha = get_start_sha_for_ref(
-            ref=ref,
-            release=release,
-            repo=repo,
-            prev_release=prev_release,
-        )
-
-        end_sha = ref["commit"]
-        extra = extra | {"repository": repo.name, "end_sha": end_sha, "start_sha": start_sha}
-        logger.info("fetch_commits.loop.start", extra=extra)
-
-        provider_name = repo.provider
-        compare_commits_cache_enabled = (
-            github_compare_commits_cache_feature_enabled
-            and isinstance(provider_name, str)
-            and provider_name in GITHUB_CACHEABLE_REPOSITORY_PROVIDERS
-        )
 
         repo_commits = fetch_commits_for_ref_with_lifecycle(
-            provider_key=provider_key,
-            repo=repo,
-            provider=provider,
+            resolved=resolved,
             release=release,
-            start_sha=start_sha,
-            end_sha=end_sha,
             user_id=user_id,
             user=user,
-            is_integration_repo_provider=is_integration_repo_provider,
-            compare_commits_cache_enabled=compare_commits_cache_enabled,
-        )
-        logger.info(
-            "fetch_commits.loop.complete",
-            extra=extra | {"num_commits": len(repo_commits or [])},
+            github_compare_commits_cache_feature_enabled=github_compare_commits_cache_feature_enabled,
+            task_extra=extra,
         )
         if repo_commits is None:
             continue
@@ -409,14 +445,7 @@ def fetch_commits(
     except ReleaseCommitError:
         # Another task or webworker is currently setting commits on this
         # release. Return early as that task will do the remaining work.
-        logger.info(
-            "fetch_commits.duplicate",
-            extra={
-                "release_id": release.id,
-                "organization_id": release.organization_id,
-                "user_id": user_id,
-            },
-        )
+        logger.info("fetch_commits.duplicate", extra=extra)
         return
 
     deploys = Deploy.objects.filter(
@@ -462,6 +491,8 @@ def fetch_commits(
 
     for deploy_id in pending_notifications:
         Deploy.notify_if_ready(deploy_id, fetch_complete=True)
+
+    logger.info("fetch_commits.complete", extra=extra)
 
 
 def is_integration_provider(provider: str | None) -> bool:

--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -398,6 +398,12 @@ def fetch_commits(
     # TODO: Need a better way to error handle no user_id. We need the SDK to be able to call this without user context
     # to autoassociate commits to releases
     user = user_service.get_user(user_id) if user_id is not None else None
+    prev_release = None
+    if prev_release_id is not None:
+        try:
+            prev_release = Release.objects.get(id=prev_release_id)
+        except Release.DoesNotExist:
+            pass
     organization = release.organization
     github_compare_commits_cache_feature_enabled = features.has(
         GITHUB_FETCH_COMMITS_COMPARE_CACHE_FEATURE, organization, actor=user
@@ -412,12 +418,6 @@ def fetch_commits(
         "github_compare_commits_cache_feature_enabled": github_compare_commits_cache_feature_enabled,
     }
     logger.info("fetch_commits.start", extra=extra)
-    prev_release = None
-    if prev_release_id is not None:
-        try:
-            prev_release = Release.objects.get(id=prev_release_id)
-        except Release.DoesNotExist:
-            pass
 
     for ref in refs:
         resolved = resolve_ref(ref=ref, release=release, prev_release=prev_release, user_id=user_id)


### PR DESCRIPTION
Follow-up refactor to #113293.

It adds some context missing from some of the logging lines and makes the main for loop shorter and easier to read.

This also makes the task be owned by @getsentry/coding-workflows's backend team. 

Reshapes the `fetch_commits` task body around two ideas:

1. A new `resolve_ref` helper 
2. Concerns now live with the code that consumes them:
   - The compare-commits cache gating (provider allowlist + feature flag) moved into `fetch_commits_for_compare_range`, next to the `cache.get`/`cache.set` and the `compare_commits_cache_enabled` span tag. The task just passes the flag through.
   - `fetch_commits.loop.start` / `fetch_commits.loop.complete` logs moved into `fetch_commits_for_ref_with_lifecycle`, which now owns its `loop_extra` construction from a task-level `task_extra` mapping. The complete log runs in a `finally` so it still fires on every swallowed-error path (`NotImplementedError`, `IntegrationResourceNotFoundError`, the handled `Exception` branches).

No behavior change. All existing tests in `tests/sentry/tasks/test_commits.py` pass unmodified.

Made with [Cursor](https://cursor.com)