### PR TITLE
chromy/2026 04 20 noop change 2

### DIFF
--- a/static/app/views/seerExplorer/components/topBar.tsx
+++ b/static/app/views/seerExplorer/components/topBar.tsx
@@ -45,6 +45,8 @@ interface TopBarProps {
   showContextEngineToggle: boolean;
 }
 
+// NOOP
+
 export function TopBar({
   isPolling,
   isEmptyState,

--- a/tests/acceptance/test_accept_organization_invite.py
+++ b/tests/acceptance/test_accept_organization_invite.py
@@ -10,6 +10,7 @@ from sentry.testutils.silo import no_silo_test
 
 # When we want to set this @cell_silo_test, we'll need to configure regions in order for invites to work.
 # See the accept_organization_invite.py#get_invite_state logic
+# Some change
 @no_silo_test
 class AcceptOrganizationInviteTest(AcceptanceTestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
- **DNM: No op change**
- **DNM: No op change**

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
