### PR TITLE
ref(typing): Convert RegressionDetector + AttributeHandler config to ClassVar

### DIFF
--- a/src/sentry/rules/conditions/event_attribute.py
+++ b/src/sentry/rules/conditions/event_attribute.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from dataclasses import dataclass
-from typing import Any
+from typing import Any, ClassVar
 
 import sentry_sdk
 from django import forms
@@ -18,9 +17,8 @@ from sentry.types.condition_activity import ConditionActivity
 from sentry.utils.registry import NoRegistrationExistsError, Registry
 
 
-@dataclass(frozen=True)
 class AttributeHandler(ABC):
-    minimum_path_length: int
+    minimum_path_length: ClassVar[int]
 
     @classmethod
     def handle(cls, path: list[str], event: GroupEvent) -> list[str]:

--- a/src/sentry/statistical_detectors/detector.py
+++ b/src/sentry/statistical_detectors/detector.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from collections.abc import Generator, Iterable
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from typing import ClassVar
 
 import sentry_sdk
 
@@ -52,15 +53,14 @@ class TrendBundle:
     regression_group: RegressionGroup | None = None
 
 
-@dataclass(frozen=True)
 class RegressionDetector(ABC):
-    source: str
-    kind: str
-    regression_type: RegressionType
-    min_change: int
-    buffer_period: timedelta
-    resolution_rel_threshold: float
-    escalation_rel_threshold: float
+    source: ClassVar[str]
+    kind: ClassVar[str]
+    regression_type: ClassVar[RegressionType]
+    min_change: ClassVar[int]
+    buffer_period: ClassVar[timedelta]
+    resolution_rel_threshold: ClassVar[float]
+    escalation_rel_threshold: ClassVar[float]
 
     @classmethod
     @abstractmethod


### PR DESCRIPTION
Both `RegressionDetector` (`src/sentry/statistical_detectors/detector.py`) and `AttributeHandler` (`src/sentry/rules/conditions/event_attribute.py`) declared their configuration fields as dataclass instance attributes via `@dataclass(frozen=True)`, but every usage accesses them through the class (`cls.source`, `cls.minimum_path_length`, etc.). The classes are never instantiated; subclasses override the fields as class-level attributes (`source = "transaction"`, `minimum_path_length = 1`).

Convert the fields to `ClassVar[T]` and drop the no-op `@dataclass(frozen=True)` decorators. No runtime behavior change.

### Why this PR exists

Prep for the mypy upgrade to 1.20.1 in #113419. 1.20.1 adds a new `[misc]` check, "Cannot access instance-only attribute on class object," which surfaces this pattern. Splitting the fix out so each targeted reviewer only has to look at their own area.

This PR is safe under the current mypy (1.19.1).


Agent transcript: https://claudescope.sentry.dev/share/8Gzqw1K3cHTGBqYv-FAytvqDyA86B3vsiZyoJkHL7DM