### PR TITLE
fix(typing): Annotate group_status parameters as int

### DIFF
--- a/src/sentry/incidents/typings/metric_detector.py
+++ b/src/sentry/incidents/typings/metric_detector.py
@@ -41,7 +41,7 @@ def fetch_threshold_type(
     return CONDITION_TO_ALERT_RULE_THRESHOLD_TYPE[condition_type]
 
 
-def fetch_alert_threshold(condition: dict[str, Any], group_status: GroupStatus) -> float | None:
+def fetch_alert_threshold(condition: dict[str, Any], group_status: int) -> float | None:
     condition_type = condition["type"]
     if condition_type == Condition.ANOMALY_DETECTION:
         return 0
@@ -52,7 +52,7 @@ def fetch_alert_threshold(condition: dict[str, Any], group_status: GroupStatus) 
         return comparison_value
 
 
-def fetch_resolve_threshold(condition: dict[str, Any], group_status: GroupStatus) -> float | None:
+def fetch_resolve_threshold(condition: dict[str, Any], group_status: int) -> float | None:
     """
     This is the opposite of `fetch_alert_threshold`.
     We keep it explicitly separate to make it clear that we are fetching the resolve threshold and to consolidate tech debt.
@@ -114,7 +114,7 @@ class AlertContext:
         cls,
         detector: Detector,
         evidence_data: MetricIssueEvidenceData,
-        group_status: GroupStatus,
+        group_status: int,
         detector_priority_level: DetectorPriorityLevel,
     ) -> AlertContext:
         try:

--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -430,7 +430,7 @@ class BaseMetricAlertHandler(ABC):
         cls,
         detector: Detector,
         evidence_data: MetricIssueEvidenceData,
-        group_status: GroupStatus,
+        group_status: int,
         detector_priority_level: DetectorPriorityLevel,
     ) -> AlertContext:
         return AlertContext.from_workflow_engine_models(


### PR DESCRIPTION
\`sentry.models.group.GroupStatus\` is a plain class whose members are ints (\`RESOLVED = 1\`, \`IGNORED = 2\`, etc.) — not an enum. Callers of the functions below all pass ints, and the in-function \`==\` comparisons (\`group_status == GroupStatus.RESOLVED\`) are int-vs-int. But the parameters were annotated as \`GroupStatus\`, i.e. \"instance of GroupStatus\", which is never what the callers pass.

Under \`strict_equality = true\` the comparisons become semantically unreachable (instance-of-class never equals int). Stricter mypy reports them as \`[unreachable]\`.

Change the annotations to \`int\` to match actual usage:

- \`fetch_alert_threshold\`
- \`fetch_resolve_threshold\`
- \`AlertContext.from_workflow_engine_models\`
- \`MetricAlertNotificationMessageBuilder.build_alert_context\`

No runtime behavior change. Prep for the mypy 1.20 upgrade (#113419). Safe under 1.19.1.


Agent transcript: https://claudescope.sentry.dev/share/wKKwnZeeYc-V3zQbolQDCON52n93vyqkCmPrIs_kbnI