### PR TITLE
ref: Drop redundant casts in search builders

### DIFF
--- a/src/sentry/search/eap/columns.py
+++ b/src/sentry/search/eap/columns.py
@@ -452,7 +452,7 @@ class TraceMetricAggregateDefinition(AggregateDefinition):
                 trace_metric.metric_unit in constants.DURATION_TYPE
                 or trace_metric.metric_unit in constants.SIZE_TYPE
             ):
-                resolved_search_type = cast(constants.SearchType, trace_metric.metric_unit)
+                resolved_search_type = trace_metric.metric_unit
 
         return ResolvedTraceMetricAggregate(
             public_alias=alias,

--- a/src/sentry/search/eap/trace_metrics/config.py
+++ b/src/sentry/search/eap/trace_metrics/config.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import cast
 
 from rest_framework.request import Request
 from sentry_protos.snuba.v1.trace_item_filter_pb2 import TraceItemFilter
@@ -119,6 +118,6 @@ def get_trace_metric_from_request(
 
     return TraceMetric(
         metric_name=metric_name,
-        metric_type=cast(TraceMetricType, metric_type),
+        metric_type=metric_type,
         metric_unit=metric_unit,
     )

--- a/src/sentry/search/events/builder/base.py
+++ b/src/sentry/search/events/builder/base.py
@@ -1200,9 +1200,9 @@ class BaseQueryBuilder:
 
     def resolve_measurement_value(self, unit: str, value: float) -> float:
         if unit in constants.SIZE_UNITS:
-            return constants.SIZE_UNITS[cast(constants.SizeUnit, unit)] * value
+            return constants.SIZE_UNITS[unit] * value
         elif unit in constants.DURATION_UNITS:
-            return constants.DURATION_UNITS[cast(constants.DurationUnit, unit)] * value
+            return constants.DURATION_UNITS[unit] * value
         return value
 
     def convert_aggregate_filter_to_condition(


### PR DESCRIPTION
Three \`cast(...)\` calls that mypy already infers correctly — they fire \`[redundant-cast]\` under mypy 1.20.1 and are genuinely redundant under 1.19.1 too. Each is inside a branch already guarded by a membership check or early-return that narrows the value.

- \`src/sentry/search/eap/columns.py\`: \`cast(constants.SearchType, trace_metric.metric_unit)\` — inside \`if ... in DURATION_TYPE or ... in SIZE_TYPE\`.
- \`src/sentry/search/events/builder/base.py\`: \`cast(constants.SizeUnit, unit)\` / \`cast(constants.DurationUnit, unit)\` — inside \`if unit in constants.SIZE_UNITS\` / \`DURATION_UNITS\`.
- \`src/sentry/search/eap/trace_metrics/config.py\`: \`cast(TraceMetricType, metric_type)\` — already narrowed by the \`if metric_type not in ALLOWED_METRIC_TYPES: return None\` guard above.

Prep for the mypy 1.20 upgrade (#113419). Safe under 1.19.1.


Agent transcript: https://claudescope.sentry.dev/share/lVivF9WN2X9tBvTh2KH4Va299tH3t04bTyP0awki7SU