### PR TITLE
test(typing): Refetch via queryset instead of refresh_from_db after narrowing

### DIFF
--- a/tests/sentry/grouping/seer_similarity/test_training_mode.py
+++ b/tests/sentry/grouping/seer_similarity/test_training_mode.py
@@ -78,7 +78,7 @@ class MaybeSendSeerForNewModelTrainingTest(TestCase):
             assert call_args[1]["raise_on_error"] is True
 
             # Should update seer_latest_training_model without touching seer_model
-            metadata.refresh_from_db()
+            metadata = GroupHashMetadata.objects.get(id=metadata.id)
             assert metadata.seer_latest_training_model == "v2"
             assert metadata.seer_model is None
 
@@ -123,7 +123,7 @@ class MaybeSendSeerForNewModelTrainingTest(TestCase):
             assert call_args[1]["raise_on_error"] is True
 
             # Should update seer_latest_training_model without touching seer_model
-            metadata.refresh_from_db()
+            metadata = GroupHashMetadata.objects.get(id=metadata.id)
             assert metadata.seer_latest_training_model == "v2"
             assert metadata.seer_model == "v1"
 

--- a/tests/sentry/models/test_dashboard.py
+++ b/tests/sentry/models/test_dashboard.py
@@ -153,11 +153,11 @@ class DashboardFavoriteUserTest(TestCase):
             self.organization, self.user.id, [should_be_first.id, should_be_second.id]
         )
 
-        for favorite_dashboard in [second_favorite_dashboard, first_favorite_dashboard]:
-            favorite_dashboard.refresh_from_db()
+        second_favorite_dashboard.refresh_from_db()
+        first_favorite_dashboard.refresh_from_db()
 
-        assert second_favorite_dashboard.position == 1
-        assert first_favorite_dashboard.position == 0
+        assert DashboardFavoriteUser.objects.get(id=second_favorite_dashboard.id).position == 1
+        assert DashboardFavoriteUser.objects.get(id=first_favorite_dashboard.id).position == 0
 
     def test_deletes_and_increments_existing_positions(self) -> None:
         first_dashboard = self.create_dashboard(

--- a/tests/sentry/models/test_dashboard.py
+++ b/tests/sentry/models/test_dashboard.py
@@ -153,9 +153,6 @@ class DashboardFavoriteUserTest(TestCase):
             self.organization, self.user.id, [should_be_first.id, should_be_second.id]
         )
 
-        second_favorite_dashboard.refresh_from_db()
-        first_favorite_dashboard.refresh_from_db()
-
         assert DashboardFavoriteUser.objects.get(id=second_favorite_dashboard.id).position == 1
         assert DashboardFavoriteUser.objects.get(id=first_favorite_dashboard.id).position == 0
 

--- a/tests/sentry/monitors/logic/test_mark_ok.py
+++ b/tests/sentry/monitors/logic/test_mark_ok.py
@@ -214,7 +214,7 @@ class MarkOkTestCase(TestCase):
             mark_ok(checkin, checkin.date_added)
 
         # recovery has hit threshold, monitor should be in an ok state
-        incident.refresh_from_db()
+        incident = MonitorIncident.objects.get(id=incident.id)
         monitor_environment.refresh_from_db()
 
         assert monitor_environment.status == MonitorStatus.OK

--- a/tests/snuba/api/endpoints/test_organization_events_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_mep.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from rest_framework.response import Response
 
 from sentry.discover.models import DatasetSourcesTypes, TeamKeyTransaction
-from sentry.models.dashboard_widget import DashboardWidgetTypes
+from sentry.models.dashboard_widget import DashboardWidget, DashboardWidgetTypes
 from sentry.models.projectteam import ProjectTeam
 from sentry.models.transaction_threshold import (
     ProjectTransactionThreshold,
@@ -3936,7 +3936,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
             "discoverSplitDecision"
         ) is DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.TRANSACTION_LIKE)
 
-        widget.refresh_from_db()
+        widget = DashboardWidget.objects.get(id=widget.id)
         assert widget.discover_widget_split == DashboardWidgetTypes.TRANSACTION_LIKE
         assert widget.dataset_source == DatasetSourcesTypes.INFERRED.value
 
@@ -3964,7 +3964,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
             "discoverSplitDecision"
         ) == DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.ERROR_EVENTS)
 
-        widget.refresh_from_db()
+        widget = DashboardWidget.objects.get(id=widget.id)
         assert widget.discover_widget_split == DashboardWidgetTypes.ERROR_EVENTS
         assert widget.dataset_source == DatasetSourcesTypes.FORCED.value
 
@@ -4011,7 +4011,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTestWithOnDemandMetric
             "discoverSplitDecision"
         ) == DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.ERROR_EVENTS)
 
-        widget.refresh_from_db()
+        widget = DashboardWidget.objects.get(id=widget.id)
         assert widget.discover_widget_split == DashboardWidgetTypes.ERROR_EVENTS
         assert widget.dataset_source == DatasetSourcesTypes.FORCED.value
 

--- a/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats_mep.py
@@ -850,7 +850,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
             "discoverSplitDecision"
         ) is DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.TRANSACTION_LIKE)
 
-        widget.refresh_from_db()
+        widget = DashboardWidget.objects.get(id=widget.id)
         assert widget.discover_widget_split == DashboardWidgetTypes.TRANSACTION_LIKE
         assert widget.dataset_source == DatasetSourcesTypes.INFERRED.value
 
@@ -928,7 +928,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
             "discoverSplitDecision"
         ) is DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.TRANSACTION_LIKE)
 
-        widget.refresh_from_db()
+        widget = DashboardWidget.objects.get(id=widget.id)
         assert widget.discover_widget_split == DashboardWidgetTypes.TRANSACTION_LIKE
         assert widget.dataset_source == DatasetSourcesTypes.INFERRED.value
 
@@ -956,7 +956,7 @@ class OrganizationEventsStatsMetricsEnhancedPerformanceEndpointTest(
             "discoverSplitDecision"
         ) == DashboardWidgetTypes.get_type_name(DashboardWidgetTypes.ERROR_EVENTS)
 
-        widget.refresh_from_db()
+        widget = DashboardWidget.objects.get(id=widget.id)
         assert widget.discover_widget_split == DashboardWidgetTypes.ERROR_EVENTS
         assert widget.dataset_source == DatasetSourcesTypes.FORCED.value
 


### PR DESCRIPTION
Tests like:

\`\`\`python
assert widget.discover_widget_split is None   # narrows to None
...
widget.refresh_from_db()                      # mypy keeps the narrowing
assert widget.discover_widget_split == TRANSACTION_LIKE  # mypy: unreachable
\`\`\`

\`refresh_from_db()\` mutates the object in place, so mypy doesn't reset the narrowed attribute type — subsequent assertions comparing against non-None values become semantically unreachable under stricter checkers. Replace with \`x = Model.objects.get(id=x.id)\`, which is semantically equivalent (fresh row from the same table) and an assignment resets the inferred type.

Applied in:

- \`tests/sentry/models/test_dashboard.py\`
- \`tests/snuba/api/endpoints/test_organization_events_mep.py\`
- \`tests/snuba/api/endpoints/test_organization_events_stats_mep.py\`
- \`tests/sentry/monitors/logic/test_mark_ok.py\`
- \`tests/sentry/grouping/seer_similarity/test_training_mode.py\`

### Why this PR exists

Prep for the mypy upgrade to 1.20.1 in #113419. Safe under the current mypy (1.19.1). Misc other test-side typing nits live separately in the companion PR.