### PR TITLE
test(typing): Misc test-side type hint fixes

### DIFF
--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -2977,7 +2977,7 @@ class UpdateAlertRuleTriggerAction(BaseAlertRuleTriggerActionTest):
         assert action.alert_rule_trigger == self.trigger
         assert action.type == type.value
         assert action.target_type == target_type.value
-        assert action.target_identifier == target_identifier
+        assert action.target_identifier == str(target_identifier)
         assert action.target_display == "hellboi"
         assert action.integration_id == integration.id
 

--- a/tests/sentry/incidents/test_logic.py
+++ b/tests/sentry/incidents/test_logic.py
@@ -2977,7 +2977,7 @@ class UpdateAlertRuleTriggerAction(BaseAlertRuleTriggerActionTest):
         assert action.alert_rule_trigger == self.trigger
         assert action.type == type.value
         assert action.target_type == target_type.value
-        assert action.target_identifier == str(target_identifier)
+        assert str(action.target_identifier) == str(target_identifier)
         assert action.target_display == "hellboi"
         assert action.integration_id == integration.id
 

--- a/tests/sentry/integrations/vsts/test_provider.py
+++ b/tests/sentry/integrations/vsts/test_provider.py
@@ -99,7 +99,7 @@ class TestVSTSNewOAuth2CallbackView(TestCase):
             },
         )
 
-        result = view.exchange_token(request, pipeline, "oauth-code")
+        result: dict[str, Any] = view.exchange_token(request, pipeline, "oauth-code")
         mock_request = responses.calls[0].request
         req_params = parse_qs(mock_request.body)
 
@@ -149,7 +149,7 @@ class TestVSTSNewOAuth2CallbackView(TestCase):
             },
         )
 
-        result = view.exchange_token(request, pipeline, "oauth-code")
+        result: dict[str, Any] = view.exchange_token(request, pipeline, "oauth-code")
         mock_request = responses.calls[0].request
         req_params = parse_qs(mock_request.body)
 

--- a/tests/sentry/issues/test_occurrence_consumer.py
+++ b/tests/sentry/issues/test_occurrence_consumer.py
@@ -530,7 +530,7 @@ class ParseEventPayloadTest(IssueOccurrenceTestBase):
         assert kwargs["occurrence_data"]["level"] == kwargs["event_data"]["level"]
 
     def test_debug_meta(self) -> None:
-        debug_meta_cases = [
+        debug_meta_cases: list[dict[str, Any]] = [
             {"debug_meta": {}},
             {"debug_meta": None},
             {"debug_meta": {"images": []}},

--- a/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
@@ -372,7 +372,7 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         notification_context = self.handler.build_notification_context(self.action)
         assert isinstance(notification_context, NotificationContext)
         assert notification_context.target_identifier == "channel456"
-        assert notification_context.integration_id == "1234567890"
+        assert notification_context.integration_id == 1234567890
         assert notification_context.sentry_app_config is None
 
     def test_build_alert_context(self) -> None:

--- a/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
@@ -291,7 +291,7 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
         super().setUp()
         self.action = self.create_action(
             type=Action.Type.DISCORD,
-            integration_id="1234567890",
+            integration_id=1234567890,
             config={"target_identifier": "channel456", "target_type": ActionTarget.SPECIFIC},
             data={"tags": "environment,user,my_tag"},
         )

--- a/tests/sentry/sentry_apps/api/endpoints/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/api/endpoints/test_sentry_apps.py
@@ -186,7 +186,7 @@ class SentryAppsTest(APITestCase):
         return getattr(self.client, method)(
             reverse(endpoint),
             format="json",
-            **data,
+            **(data or {}),
             HTTP_AUTHORIZATION=f"Bearer {token.token}",
             headers={"Content-Type": "application/json"},
         )

--- a/tests/sentry/snuba/metrics/test_naming_layer.py
+++ b/tests/sentry/snuba/metrics/test_naming_layer.py
@@ -73,6 +73,7 @@ def test_invalid_public_name_regex(name) -> None:
 )
 def test_parse_mri_with_valid_mri(name, expected) -> None:
     parsed_mri = parse_mri(name)
+    assert parsed_mri is not None
     assert parsed_mri == expected
     assert parsed_mri.mri_string == name
 


### PR DESCRIPTION
Small one-off type hint corrections in tests, each behavior-neutral. Split off from the `refresh_from_db()` refactor in #113427 so the patterns can be reviewed separately.

- `test_naming_layer.py`: `assert parsed_mri is not None` before dereferencing `.mri_string`.
- `test_provider.py`: annotate the `exchange_token` test result as `dict[str, Any]`. The declared return type is `dict[str, str]`, but real OAuth responses include ints (`expires_in`) — this is a preexisting lie in the production signature, so the test locally widens until that gets fixed separately.
- `test_occurrence_consumer.py`: annotate a heterogeneous debug_meta case list as `list[dict[str, Any]]`.
- `test_sentry_apps.py`: guard `Mapping | None` before `**data`.
- `test_metric_alert_registry_handlers.py`: pass `integration_id` as an int in the fixture so the in-memory dataclass value matches the declared `int | None` type (no DB round-trip coerces it).
- `test_logic.py`: stringify both sides of the `target_identifier` assertion in the update path. `update_alert_rule_trigger_action` leaves `target.identifier` as int in memory (unlike the create path, which wraps with `str()`), so stringifying avoids the runtime mismatch while keeping mypy happy.

### Why this PR exists

Prep for the mypy upgrade to 1.20.1 in #113419. Safe under the current mypy (1.19.1).


Agent transcript: https://claudescope.sentry.dev/share/OOKfaLYBcSwWWD48Y6-ebfs_iQCylldqs4WhtB_1ibU