### PR TITLE
chore(insights): remove starfish-mobile-ui-module feature flag

### DIFF
--- a/static/app/views/insights/mobile/ui/settings.ts
+++ b/static/app/views/insights/mobile/ui/settings.ts
@@ -5,4 +5,4 @@ export const BASE_URL = 'ui';
 
 export const MODULE_DOC_LINK = 'https://docs.sentry.io/product/insights/mobile/';
 
-export const MODULE_FEATURES = ['insight-modules', 'starfish-mobile-ui-module'];
+export const MODULE_FEATURES = ['insight-modules'];


### PR DESCRIPTION
Remove the `starfish-mobile-ui-module` entry from the Mobile UI module's `MODULE_FEATURES` list in `static/app/views/insights/mobile/ui/settings.ts`.

The flag is fully rolled out, so the Mobile UI module no longer needs to be gated by it. The module remains gated by the broader `insight-modules` flag.

Related PRs:
- Backend: https://github.com/getsentry/sentry/pull/113430
- Flagpole cleanup: https://github.com/getsentry/sentry-options-automator/pull/7357