### PR TITLE
chore(insights): remove starfish-mobile-ui-module feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -399,8 +399,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seat-based-seer-enabled", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Enable new SentryApp webhook request endpoint
     manager.add("organizations:sentry-app-webhook-requests", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable mobile starfish ui module view
-    manager.add("organizations:starfish-mobile-ui-module", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable the new experimental starfish view
     manager.add("organizations:starfish-view", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Allow organizations to configure all symbol sources.


### PR DESCRIPTION
Remove the registration of the `organizations:starfish-mobile-ui-module` feature flag from `src/sentry/features/temporary.py`.

The flag is fully rolled out. The Mobile UI module no longer needs to be gated by it.

Related PRs:
- Frontend: https://github.com/getsentry/sentry/pull/113429
- Flagpole cleanup: https://github.com/getsentry/sentry-options-automator/pull/7357