### PR TITLE
fix(seer): Linkify short IDs with multi-hyphen project slugs

### DIFF
--- a/static/app/views/seerExplorer/utils.spec.tsx
+++ b/static/app/views/seerExplorer/utils.spec.tsx
@@ -1,0 +1,58 @@
+import {postProcessLLMMarkdown} from 'sentry/views/seerExplorer/utils';
+
+describe('postProcessLLMMarkdown', () => {
+  describe('issue short ID linkification', () => {
+    it('linkifies a simple short ID', () => {
+      expect(postProcessLLMMarkdown('see PROJECT-1 please')).toBe(
+        'see [PROJECT-1](/issues/PROJECT-1/) please'
+      );
+    });
+
+    it('linkifies multi-hyphen short IDs without truncating trailing segments', () => {
+      expect(postProcessLLMMarkdown('caused by FRONTEND-REACT-59A today')).toBe(
+        'caused by [FRONTEND-REACT-59A](/issues/FRONTEND-REACT-59A/) today'
+      );
+      expect(postProcessLLMMarkdown('BACKEND-FLASK-F2 is flaky')).toBe(
+        '[BACKEND-FLASK-F2](/issues/BACKEND-FLASK-F2/) is flaky'
+      );
+      expect(postProcessLLMMarkdown('see BACKEND-RUBY-ON-RAILS-58')).toBe(
+        'see [BACKEND-RUBY-ON-RAILS-58](/issues/BACKEND-RUBY-ON-RAILS-58/)'
+      );
+    });
+
+    it('linkifies multiple short IDs in one string', () => {
+      expect(
+        postProcessLLMMarkdown('FRONTEND-REACT-59A and BACKEND-FLASK-F2 are related')
+      ).toBe(
+        '[FRONTEND-REACT-59A](/issues/FRONTEND-REACT-59A/) and [BACKEND-FLASK-F2](/issues/BACKEND-FLASK-F2/) are related'
+      );
+    });
+
+    it('does not linkify lowercase tokens', () => {
+      expect(postProcessLLMMarkdown('lowercase-not-matched here')).toBe(
+        'lowercase-not-matched here'
+      );
+    });
+
+    it('does not linkify short IDs inside existing markdown links', () => {
+      const input = 'see [FRONTEND-REACT-59A](https://example.com/foo) for details';
+      expect(postProcessLLMMarkdown(input)).toBe(input);
+    });
+
+    it('does not linkify short IDs inside inline code', () => {
+      const input = 'the id `FRONTEND-REACT-59A` is raw';
+      expect(postProcessLLMMarkdown(input)).toBe(input);
+    });
+
+    it('does not linkify short IDs inside URLs', () => {
+      const input = 'go to https://example.com/issues/FRONTEND-REACT-59A now';
+      expect(postProcessLLMMarkdown(input)).toBe(input);
+    });
+
+    it('returns empty string for null / undefined / empty input', () => {
+      expect(postProcessLLMMarkdown(null)).toBe('');
+      expect(postProcessLLMMarkdown(undefined)).toBe('');
+      expect(postProcessLLMMarkdown('')).toBe('');
+    });
+  });
+});

--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -416,7 +416,9 @@ function linkifyIssueShortIds(text: string): string {
   // Pattern matches: PROJECT_SLUG-SHORT_ID (uppercase only, case-sensitive)
   // Requires at least 2 chars before hyphen and 1+ chars after
   // First segment must contain at least one uppercase letter (all letters must be uppercase)
-  const shortIdPattern = /\b((?:[A-Z][A-Z0-9_]+|[0-9_]+[A-Z][A-Z0-9_]*)-[A-Z0-9]+)\b/g;
+  // Allows multi-hyphen project slugs like FRONTEND-REACT-59A or BACKEND-RUBY-ON-RAILS-58
+  const shortIdPattern =
+    /\b((?:[A-Z][A-Z0-9_]+|[0-9_]+[A-Z][A-Z0-9_]*)(?:-[A-Z0-9]+)+)\b/g;
 
   // Track positions that should be excluded (inside code blocks, links, or URLs)
   const excludedRanges: Array<{end: number; start: number}> = [];


### PR DESCRIPTION
Fix Seer explorer issue-short-ID linkification so IDs with multi-hyphen project slugs (e.g. `FRONTEND-REACT-59A`, `BACKEND-FLASK-F2`, `BACKEND-RUBY-ON-RAILS-58`) produce correct links.

The regex in `linkifyIssueShortIds` only allowed a single `-[A-Z0-9]+` suffix, so anything after the second hyphen was dropped from the link. `FRONTEND-REACT-59A` was rendered as a link to `/issues/FRONTEND-REACT/` with a dangling `-59A` in the text — broken navigation from Seer responses.

Allow one or more trailing `-[A-Z0-9]+` segments so the full short ID is captured. Existing short IDs (`PROJECT-1`, `JAVASCRIPT-2SDJ`, `INTERNAL-4K`) continue to match.

Surfaced while demoing the Seer agent — links in agent output were pointing at the wrong (or non-existent) issues. Adds `utils.spec.tsx` covering single- and multi-hyphen IDs plus the existing code-block / markdown-link / URL exclusion paths.


Agent transcript: https://claudescope.sentry.dev/share/RxwksDlKS0reKAGgdnK0yVb--9ijSdmRNb5bmM29wYo