### PR TITLE
chore(insights): remove starfish-view feature flag

### DIFF
--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -109,7 +109,6 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
         feature_names = [
             "organizations:profiling",
             "organizations:dynamic-sampling",
-            "organizations:starfish-view",
             "organizations:on-demand-metrics-extraction",
             "organizations:on-demand-metrics-extraction-widgets",
             "organizations:on-demand-metrics-extraction-experimental",

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -69,7 +69,6 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
         self, organization: Organization, request: Request
     ) -> Mapping[str, bool | None]:
         feature_names = [
-            "organizations:starfish-view",
             "organizations:on-demand-metrics-extraction",
             "organizations:on-demand-metrics-extraction-widgets",
         ]

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -399,8 +399,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:sentry-app-webhook-requests", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable mobile starfish ui module view
     manager.add("organizations:starfish-mobile-ui-module", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enable the new experimental starfish view
-    manager.add("organizations:starfish-view", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Allow organizations to configure all symbol sources.
     manager.add("organizations:symbol-sources", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=True)
     # Enable static ClickHouse sampling for `OrganizationTagsEndpoint`

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -27,9 +27,7 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
 
     def setUp(self) -> None:
         super().setUp()
-        self.features = {
-            "organizations:starfish-view": True,
-        }
+        self.features = {}
 
     @pytest.mark.xfail(reason="spm is not implemented, as spm will be replaced with spm")
     def test_spm(self) -> None:

--- a/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_indexed.py
@@ -25,10 +25,6 @@ class OrganizationEventsSpansEndpointTest(OrganizationEventsEndpointTestBase):
     def do_request(self, query, features=None, **kwargs):
         return super().do_request(query, features, **kwargs)
 
-    def setUp(self) -> None:
-        super().setUp()
-        self.features = {}
-
     @pytest.mark.xfail(reason="spm is not implemented, as spm will be replaced with spm")
     def test_spm(self) -> None:
         self.store_spans(

--- a/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
@@ -27,7 +27,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         self.min_ago = before_now(minutes=1)
         self.six_min_ago = before_now(minutes=6)
         self.three_days_ago = before_now(days=3)
-        self.features = {}
+        self.features: dict[str, bool] = {}
 
     def do_request(self, query, features=None):
         if features is None:

--- a/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_span_metrics.py
@@ -27,9 +27,7 @@ class OrganizationEventsMetricsEnhancedPerformanceEndpointTest(MetricsEnhancedPe
         self.min_ago = before_now(minutes=1)
         self.six_min_ago = before_now(minutes=6)
         self.three_days_ago = before_now(days=3)
-        self.features = {
-            "organizations:starfish-view": True,
-        }
+        self.features = {}
 
     def do_request(self, query, features=None):
         if features is None:


### PR DESCRIPTION
Removes the `starfish-view` feature flag. The flag was declared in `temporary.py` but was not actually gating any real behavior — it appeared in `batch_has()` feature name lists in `organization_events` and `organization_events_stats` endpoints but the returned value was never consumed downstream.

Cleanup after the feature is fully released (effectively always-on).

- Removed the declaration from `src/sentry/features/temporary.py`
- Removed the listings in the two endpoint `get_features` methods
- Removed the `setUp()` entries in the span indexed and span metrics test files

Companion PR (flagpole config removal): https://github.com/getsentry/sentry-options-automator/pull/7359