### PR TITLE
feat(seer): Add feature flag for thinking blocks toggle

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -324,6 +324,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-explorer-chat-coding", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable code mode tools (sentry_api_search/execute) in Seer Explorer
     manager.add("organizations:seer-explorer-code-mode-tools", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable the thinking blocks toggle in the Seer Explorer top bar
+    manager.add("organizations:seer-explorer-thinking-blocks", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable structured LLM context (JSON snapshot) instead of ASCII DOM snapshot
     manager.add("organizations:context-engine-structured-page-context", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Allow root_cause as a valid automated run stopping point and org-level default


### PR DESCRIPTION
Register `organizations:seer-explorer-thinking-blocks` so the Seer Explorer top-bar toggle for LLM thinking blocks can be gated behind a flag, matching the existing context-engine and code-mode toggles.

The corresponding frontend change that reads the flag is #113182.


Agent transcript: https://claudescope.sentry.dev/share/YhKW2ejWMJaKutTmRpLTZzD9cHS7Qf_lm7xaYp0OtFw