### PR TITLE
feat(preprod): Add granular installable app error codes (EME-883)

### DIFF
--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
@@ -437,16 +437,13 @@ class ProjectPreprodArtifactUpdateEndpoint(PreprodArtifactEndpoint):
         else:
             if distro_skip_reason == "quota":
                 distro_error_code = PreprodArtifact.InstallableAppErrorCode.NO_QUOTA
-                distro_error_message = "Distribution quota exceeded"
             elif distro_skip_reason == "disabled":
-                distro_error_code = PreprodArtifact.InstallableAppErrorCode.SKIPPED
-                distro_error_message = "Distribution disabled for this project"
+                distro_error_code = PreprodArtifact.InstallableAppErrorCode.DISTRIBUTION_DISABLED
             else:
-                distro_error_code = PreprodArtifact.InstallableAppErrorCode.SKIPPED
-                distro_error_message = "Distribution filtered out by project settings"
+                distro_error_code = PreprodArtifact.InstallableAppErrorCode.DISTRIBUTION_FILTERED
 
             head_artifact.installable_app_error_code = distro_error_code
-            head_artifact.installable_app_error_message = distro_error_message
+            head_artifact.installable_app_error_message = None
             head_artifact.save(
                 update_fields=[
                     "installable_app_error_code",

--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
@@ -437,13 +437,16 @@ class ProjectPreprodArtifactUpdateEndpoint(PreprodArtifactEndpoint):
         else:
             if distro_skip_reason == "quota":
                 distro_error_code = PreprodArtifact.InstallableAppErrorCode.NO_QUOTA
+                distro_error_message = "Distribution quota exceeded"
             elif distro_skip_reason == "disabled":
                 distro_error_code = PreprodArtifact.InstallableAppErrorCode.DISTRIBUTION_DISABLED
+                distro_error_message = "Distribution disabled for this project"
             else:
                 distro_error_code = PreprodArtifact.InstallableAppErrorCode.DISTRIBUTION_FILTERED
+                distro_error_message = "Build filtered out by project settings"
 
             head_artifact.installable_app_error_code = distro_error_code
-            head_artifact.installable_app_error_message = None
+            head_artifact.installable_app_error_message = distro_error_message
             head_artifact.save(
                 update_fields=[
                     "installable_app_error_code",

--- a/src/sentry/preprod/api/endpoints/project_preprod_distribution.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_distribution.py
@@ -23,9 +23,47 @@ from sentry.preprod.models import PreprodArtifact
 logger = logging.getLogger(__name__)
 
 
+_MAX_ERROR_CODE = max(int(c) for c in PreprodArtifact.InstallableAppErrorCode)
+
+
 class PutDistribution(BaseModel):
-    error_code: int = Field(ge=0, le=3)
+    error_code: int = Field(ge=0, le=_MAX_ERROR_CODE)
     error_message: str
+
+
+# Launchpad historically encoded specific reasons inside the free-form
+# error_message field (e.g. error_code=SKIPPED + error_message="invalid_signature").
+# Translate those legacy payloads to the new granular enum values so the frontend
+# can work purely off error_code. Remove once all launchpad deployments emit the
+# new codes directly.
+_LEGACY_MESSAGE_TO_CODE: dict[
+    tuple[PreprodArtifact.InstallableAppErrorCode, str],
+    PreprodArtifact.InstallableAppErrorCode,
+] = {
+    (
+        PreprodArtifact.InstallableAppErrorCode.SKIPPED,
+        "invalid_signature",
+    ): PreprodArtifact.InstallableAppErrorCode.INVALID_CODE_SIGNATURE,
+    (
+        PreprodArtifact.InstallableAppErrorCode.SKIPPED,
+        "simulator",
+    ): PreprodArtifact.InstallableAppErrorCode.SIMULATOR_BUILD,
+    (
+        PreprodArtifact.InstallableAppErrorCode.PROCESSING_ERROR,
+        "Unsupported artifact type",
+    ): PreprodArtifact.InstallableAppErrorCode.UNSUPPORTED_ARTIFACT_TYPE,
+}
+
+
+def _translate_legacy_payload(error_code: int, error_message: str) -> tuple[int, str | None]:
+    try:
+        code = PreprodArtifact.InstallableAppErrorCode(error_code)
+    except ValueError:
+        return error_code, error_message
+    translated = _LEGACY_MESSAGE_TO_CODE.get((code, error_message))
+    if translated is None:
+        return error_code, error_message
+    return int(translated), None
 
 
 @internal_cell_silo_endpoint
@@ -46,8 +84,9 @@ class ProjectPreprodDistributionEndpoint(PreprodArtifactEndpoint):
     ) -> Response:
         put: PutDistribution = parse_request_with_pydantic(request, cast(Any, PutDistribution))
 
-        head_artifact.installable_app_error_code = put.error_code
-        head_artifact.installable_app_error_message = put.error_message
+        error_code, error_message = _translate_legacy_payload(put.error_code, put.error_message)
+        head_artifact.installable_app_error_code = error_code
+        head_artifact.installable_app_error_message = error_message
         head_artifact.save(
             update_fields=[
                 "installable_app_error_code",

--- a/src/sentry/preprod/api/endpoints/project_preprod_distribution.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_distribution.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Any, cast
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -23,47 +23,9 @@ from sentry.preprod.models import PreprodArtifact
 logger = logging.getLogger(__name__)
 
 
-_MAX_ERROR_CODE = max(int(c) for c in PreprodArtifact.InstallableAppErrorCode)
-
-
 class PutDistribution(BaseModel):
-    error_code: int = Field(ge=0, le=_MAX_ERROR_CODE)
+    error_code: PreprodArtifact.InstallableAppErrorCode
     error_message: str
-
-
-# Launchpad historically encoded specific reasons inside the free-form
-# error_message field (e.g. error_code=SKIPPED + error_message="invalid_signature").
-# Translate those legacy payloads to the new granular enum values so the frontend
-# can work purely off error_code. Remove once all launchpad deployments emit the
-# new codes directly.
-_LEGACY_MESSAGE_TO_CODE: dict[
-    tuple[PreprodArtifact.InstallableAppErrorCode, str],
-    PreprodArtifact.InstallableAppErrorCode,
-] = {
-    (
-        PreprodArtifact.InstallableAppErrorCode.SKIPPED,
-        "invalid_signature",
-    ): PreprodArtifact.InstallableAppErrorCode.INVALID_CODE_SIGNATURE,
-    (
-        PreprodArtifact.InstallableAppErrorCode.SKIPPED,
-        "simulator",
-    ): PreprodArtifact.InstallableAppErrorCode.SIMULATOR_BUILD,
-    (
-        PreprodArtifact.InstallableAppErrorCode.PROCESSING_ERROR,
-        "Unsupported artifact type",
-    ): PreprodArtifact.InstallableAppErrorCode.UNSUPPORTED_ARTIFACT_TYPE,
-}
-
-
-def _translate_legacy_payload(error_code: int, error_message: str) -> tuple[int, str | None]:
-    try:
-        code = PreprodArtifact.InstallableAppErrorCode(error_code)
-    except ValueError:
-        return error_code, error_message
-    translated = _LEGACY_MESSAGE_TO_CODE.get((code, error_message))
-    if translated is None:
-        return error_code, error_message
-    return int(translated), None
 
 
 @internal_cell_silo_endpoint
@@ -84,9 +46,8 @@ class ProjectPreprodDistributionEndpoint(PreprodArtifactEndpoint):
     ) -> Response:
         put: PutDistribution = parse_request_with_pydantic(request, cast(Any, PutDistribution))
 
-        error_code, error_message = _translate_legacy_payload(put.error_code, put.error_message)
-        head_artifact.installable_app_error_code = error_code
-        head_artifact.installable_app_error_message = error_message
+        head_artifact.installable_app_error_code = put.error_code
+        head_artifact.installable_app_error_message = put.error_message
         head_artifact.save(
             update_fields=[
                 "installable_app_error_code",

--- a/src/sentry/preprod/models.py
+++ b/src/sentry/preprod/models.py
@@ -159,9 +159,19 @@ class PreprodArtifact(DefaultFieldsModel):
         NO_QUOTA = 1
         """No quota available for distribution."""
         SKIPPED = 2
-        """Distribution was not requested on this build."""
+        """Generic skip; a more specific code should be used when available."""
         PROCESSING_ERROR = 3
-        """Distribution failed due to a processing error."""
+        """Generic distribution failure; a more specific code should be used when available."""
+        DISTRIBUTION_DISABLED = 4
+        """Build distribution is disabled in the project's settings."""
+        DISTRIBUTION_FILTERED = 5
+        """Build does not match the project's distribution filter rules."""
+        INVALID_CODE_SIGNATURE = 6
+        """The build's code signature could not be verified."""
+        SIMULATOR_BUILD = 7
+        """Simulator builds cannot be distributed."""
+        UNSUPPORTED_ARTIFACT_TYPE = 8
+        """The artifact type is not supported for distribution."""
 
         @classmethod
         def as_choices(cls) -> tuple[tuple[int, str], ...]:
@@ -170,6 +180,11 @@ class PreprodArtifact(DefaultFieldsModel):
                 (cls.NO_QUOTA, "no_quota"),
                 (cls.SKIPPED, "skipped"),
                 (cls.PROCESSING_ERROR, "processing_error"),
+                (cls.DISTRIBUTION_DISABLED, "distribution_disabled"),
+                (cls.DISTRIBUTION_FILTERED, "distribution_filtered"),
+                (cls.INVALID_CODE_SIGNATURE, "invalid_code_signature"),
+                (cls.SIMULATOR_BUILD, "simulator_build"),
+                (cls.UNSUPPORTED_ARTIFACT_TYPE, "unsupported_artifact_type"),
             )
 
     __relocation_scope__ = RelocationScope.Excluded

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
@@ -648,10 +648,10 @@ class ProjectPreprodArtifactUpdateEndpointTest(TestCase):
             self.preprod_artifact.installable_app_error_code
             == PreprodArtifact.InstallableAppErrorCode.NO_QUOTA
         )
-        assert self.preprod_artifact.installable_app_error_message == "Distribution quota exceeded"
+        assert self.preprod_artifact.installable_app_error_message is None
 
     @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
-    def test_update_sets_error_code_skipped_when_filtered(self) -> None:
+    def test_update_sets_error_code_distribution_filtered(self) -> None:
         self.preprod_artifact.app_id = "com.my.app"
         self.preprod_artifact.save()
 
@@ -664,12 +664,26 @@ class ProjectPreprodArtifactUpdateEndpointTest(TestCase):
         self.preprod_artifact.refresh_from_db()
         assert (
             self.preprod_artifact.installable_app_error_code
-            == PreprodArtifact.InstallableAppErrorCode.SKIPPED
+            == PreprodArtifact.InstallableAppErrorCode.DISTRIBUTION_FILTERED
         )
+        assert self.preprod_artifact.installable_app_error_message is None
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
+    def test_update_sets_error_code_distribution_disabled(self) -> None:
+        from sentry.preprod.quotas import DISTRIBUTION_ENABLED_KEY
+
+        self.project.update_option(DISTRIBUTION_ENABLED_KEY, False)
+
+        data = {"artifact_type": 1}
+        response = self._make_request(data)
+
+        assert response.status_code == 200
+        self.preprod_artifact.refresh_from_db()
         assert (
-            self.preprod_artifact.installable_app_error_message
-            == "Distribution filtered out by project settings"
+            self.preprod_artifact.installable_app_error_code
+            == PreprodArtifact.InstallableAppErrorCode.DISTRIBUTION_DISABLED
         )
+        assert self.preprod_artifact.installable_app_error_message is None
 
 
 class FindOrCreateReleaseTest(TestCase):

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
@@ -648,7 +648,7 @@ class ProjectPreprodArtifactUpdateEndpointTest(TestCase):
             self.preprod_artifact.installable_app_error_code
             == PreprodArtifact.InstallableAppErrorCode.NO_QUOTA
         )
-        assert self.preprod_artifact.installable_app_error_message is None
+        assert self.preprod_artifact.installable_app_error_message == "Distribution quota exceeded"
 
     @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
     def test_update_sets_error_code_distribution_filtered(self) -> None:
@@ -666,7 +666,10 @@ class ProjectPreprodArtifactUpdateEndpointTest(TestCase):
             self.preprod_artifact.installable_app_error_code
             == PreprodArtifact.InstallableAppErrorCode.DISTRIBUTION_FILTERED
         )
-        assert self.preprod_artifact.installable_app_error_message is None
+        assert (
+            self.preprod_artifact.installable_app_error_message
+            == "Build filtered out by project settings"
+        )
 
     @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
     def test_update_sets_error_code_distribution_disabled(self) -> None:
@@ -683,7 +686,10 @@ class ProjectPreprodArtifactUpdateEndpointTest(TestCase):
             self.preprod_artifact.installable_app_error_code
             == PreprodArtifact.InstallableAppErrorCode.DISTRIBUTION_DISABLED
         )
-        assert self.preprod_artifact.installable_app_error_message is None
+        assert (
+            self.preprod_artifact.installable_app_error_message
+            == "Distribution disabled for this project"
+        )
 
 
 class FindOrCreateReleaseTest(TestCase):

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_distribution.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_distribution.py
@@ -61,7 +61,56 @@ class ProjectPreprodDistributionEndpointTest(TestCase):
     @patch(
         "sentry.preprod.api.endpoints.project_preprod_distribution.send_build_distribution_webhook"
     )
-    def test_set_error(self, mock_send_webhook) -> None:
+    def test_accepts_generic_processing_error(self, mock_send_webhook) -> None:
+        response = self._put(orjson.dumps({"error_code": 3, "error_message": "some novel failure"}))
+
+        assert response.status_code == 200
+        self.artifact.refresh_from_db()
+        assert (
+            self.artifact.installable_app_error_code
+            == PreprodArtifact.InstallableAppErrorCode.PROCESSING_ERROR
+        )
+        assert self.artifact.installable_app_error_message == "some novel failure"
+
+        mock_send_webhook.assert_called_once()
+        call_kwargs = mock_send_webhook.call_args
+        assert call_kwargs.kwargs["organization_id"] == self.project.organization_id
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SECRET_FOR_TESTS])
+    @patch(
+        "sentry.preprod.api.endpoints.project_preprod_distribution.send_build_distribution_webhook"
+    )
+    def test_translates_legacy_invalid_signature(self, mock_send_webhook) -> None:
+        response = self._put(orjson.dumps({"error_code": 2, "error_message": "invalid_signature"}))
+
+        assert response.status_code == 200
+        self.artifact.refresh_from_db()
+        assert (
+            self.artifact.installable_app_error_code
+            == PreprodArtifact.InstallableAppErrorCode.INVALID_CODE_SIGNATURE
+        )
+        assert self.artifact.installable_app_error_message is None
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SECRET_FOR_TESTS])
+    @patch(
+        "sentry.preprod.api.endpoints.project_preprod_distribution.send_build_distribution_webhook"
+    )
+    def test_translates_legacy_simulator(self, mock_send_webhook) -> None:
+        response = self._put(orjson.dumps({"error_code": 2, "error_message": "simulator"}))
+
+        assert response.status_code == 200
+        self.artifact.refresh_from_db()
+        assert (
+            self.artifact.installable_app_error_code
+            == PreprodArtifact.InstallableAppErrorCode.SIMULATOR_BUILD
+        )
+        assert self.artifact.installable_app_error_message is None
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SECRET_FOR_TESTS])
+    @patch(
+        "sentry.preprod.api.endpoints.project_preprod_distribution.send_build_distribution_webhook"
+    )
+    def test_translates_legacy_unsupported_artifact_type(self, mock_send_webhook) -> None:
         response = self._put(
             orjson.dumps({"error_code": 3, "error_message": "Unsupported artifact type"})
         )
@@ -70,14 +119,33 @@ class ProjectPreprodDistributionEndpointTest(TestCase):
         self.artifact.refresh_from_db()
         assert (
             self.artifact.installable_app_error_code
-            == PreprodArtifact.InstallableAppErrorCode.PROCESSING_ERROR
+            == PreprodArtifact.InstallableAppErrorCode.UNSUPPORTED_ARTIFACT_TYPE
         )
-        assert self.artifact.installable_app_error_message == "Unsupported artifact type"
+        assert self.artifact.installable_app_error_message is None
 
-        # Verify webhook was sent
-        mock_send_webhook.assert_called_once()
-        call_kwargs = mock_send_webhook.call_args
-        assert call_kwargs.kwargs["organization_id"] == self.project.organization_id
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SECRET_FOR_TESTS])
+    @patch(
+        "sentry.preprod.api.endpoints.project_preprod_distribution.send_build_distribution_webhook"
+    )
+    def test_accepts_new_granular_code(self, mock_send_webhook) -> None:
+        response = self._put(
+            orjson.dumps(
+                {
+                    "error_code": int(
+                        PreprodArtifact.InstallableAppErrorCode.INVALID_CODE_SIGNATURE
+                    ),
+                    "error_message": "",
+                }
+            )
+        )
+
+        assert response.status_code == 200
+        self.artifact.refresh_from_db()
+        assert (
+            self.artifact.installable_app_error_code
+            == PreprodArtifact.InstallableAppErrorCode.INVALID_CODE_SIGNATURE
+        )
+        assert self.artifact.installable_app_error_message == ""
 
     @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SECRET_FOR_TESTS])
     def test_invalid_error_code(self) -> None:

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_distribution.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_distribution.py
@@ -80,48 +80,20 @@ class ProjectPreprodDistributionEndpointTest(TestCase):
     @patch(
         "sentry.preprod.api.endpoints.project_preprod_distribution.send_build_distribution_webhook"
     )
-    def test_translates_legacy_invalid_signature(self, mock_send_webhook) -> None:
+    def test_legacy_payload_stored_verbatim(self, mock_send_webhook) -> None:
+        # Launchpad deployments that still send the legacy shape
+        # (error_code=SKIPPED + error_message="invalid_signature", etc.)
+        # should continue to write unchanged until launchpad emits the
+        # new granular codes directly.
         response = self._put(orjson.dumps({"error_code": 2, "error_message": "invalid_signature"}))
 
         assert response.status_code == 200
         self.artifact.refresh_from_db()
         assert (
             self.artifact.installable_app_error_code
-            == PreprodArtifact.InstallableAppErrorCode.INVALID_CODE_SIGNATURE
+            == PreprodArtifact.InstallableAppErrorCode.SKIPPED
         )
-        assert self.artifact.installable_app_error_message is None
-
-    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SECRET_FOR_TESTS])
-    @patch(
-        "sentry.preprod.api.endpoints.project_preprod_distribution.send_build_distribution_webhook"
-    )
-    def test_translates_legacy_simulator(self, mock_send_webhook) -> None:
-        response = self._put(orjson.dumps({"error_code": 2, "error_message": "simulator"}))
-
-        assert response.status_code == 200
-        self.artifact.refresh_from_db()
-        assert (
-            self.artifact.installable_app_error_code
-            == PreprodArtifact.InstallableAppErrorCode.SIMULATOR_BUILD
-        )
-        assert self.artifact.installable_app_error_message is None
-
-    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SECRET_FOR_TESTS])
-    @patch(
-        "sentry.preprod.api.endpoints.project_preprod_distribution.send_build_distribution_webhook"
-    )
-    def test_translates_legacy_unsupported_artifact_type(self, mock_send_webhook) -> None:
-        response = self._put(
-            orjson.dumps({"error_code": 3, "error_message": "Unsupported artifact type"})
-        )
-
-        assert response.status_code == 200
-        self.artifact.refresh_from_db()
-        assert (
-            self.artifact.installable_app_error_code
-            == PreprodArtifact.InstallableAppErrorCode.UNSUPPORTED_ARTIFACT_TYPE
-        )
-        assert self.artifact.installable_app_error_message is None
+        assert self.artifact.installable_app_error_message == "invalid_signature"
 
     @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=[SHARED_SECRET_FOR_TESTS])
     @patch(


### PR DESCRIPTION
This is a follow up from [this comment](https://github.com/getsentry/sentry/pull/113149/changes#r3092931499) to make the error messages human readable.

Extend `InstallableAppErrorCode` with specific values so the backend can express the precise reason a build isn't installable without stuffing semantics into the free-form `installable_app_error_message` string.

New codes:
- `DISTRIBUTION_DISABLED` (4) — project has build distribution turned off
- `DISTRIBUTION_FILTERED` (5) — build doesn't match project filter rules
- `INVALID_CODE_SIGNATURE` (6) — code signature could not be verified
- `SIMULATOR_BUILD` (7) — simulator builds cannot be distributed
- `UNSUPPORTED_ARTIFACT_TYPE` (8) — artifact type not supported

The Sentry-side emission sites in `project_preprod_artifact_update.py` now use the new specific codes for the disabled / filtered cases instead of `SKIPPED` with hard-coded sentences. The launchpad-facing distribution PUT endpoint types `error_code` directly as `PreprodArtifact.InstallableAppErrorCode` so pydantic validates against the enum. Legacy launchpad payloads (e.g. `error_code=SKIPPED + error_message="invalid_signature"`) continue to pass validation and write to the DB unchanged — `SKIPPED` and `PROCESSING_ERROR` remain valid enum members for exactly that reason — until launchpad ships the follow-up and starts emitting the new codes directly.

## Why

The frontend has been pattern-matching on backend-internal strings (`"invalid_signature"`, `"simulator"`) to render anything human on the install page. That coupling is brittle whenever launchpad introduces a new reason. Adding structured enum values flips the contract: the frontend switches on `error_code` alone, and `error_message` becomes purely optional human detail.

## Rollout

1. **This PR** — Sentry accepts both the legacy and new payload shapes. No schema migration (Django doesn't persist `choices` for integer fields).
2. **Follow-up in `getsentry/launchpad`** — update `InstallableAppErrorCode` in `launchpad/src/launchpad/constants.py` to mirror the new enum and switch `artifact_processor.py:337,343` (and `UNSUPPORTED_ARTIFACT_TYPE` emission) to send the specific codes directly.
3. **Frontend PR** — drop ad-hoc message pattern-matching in `installDetailsContent.tsx` and render titles / links off `error_code` only.

No backfill. Legacy rows keep whatever was stored; the frontend compatibility path (when it lands) will tolerate them.

Refs EME-883