### PR TITLE
feat(dashboards): Add UI to view dashboard revisions

### DIFF
--- a/static/app/actionCreators/dashboards.tsx
+++ b/static/app/actionCreators/dashboards.tsx
@@ -343,6 +343,22 @@ export function updateDashboardPermissions(
   return promise;
 }
 
+export type DashboardRevision = {
+  createdBy: {email: string; id: string; name: string} | null;
+  dateCreated: string;
+  id: string;
+  source: string;
+  title: string;
+};
+
+export function makeDashboardRevisionsQueryKey(orgSlug: string, dashboardId: string) {
+  return [
+    getApiUrl('/organizations/$organizationIdOrSlug/dashboards/$dashboardId/revisions/', {
+      path: {organizationIdOrSlug: orgSlug, dashboardId},
+    }),
+  ] as const;
+}
+
 export function validateWidget(
   api: Client,
   orgId: string,

--- a/static/app/actionCreators/dashboards.tsx
+++ b/static/app/actionCreators/dashboards.tsx
@@ -347,7 +347,7 @@ export type DashboardRevision = {
   createdBy: {email: string; id: string; name: string} | null;
   dateCreated: string;
   id: string;
-  source: string;
+  source: 'edit' | 'pre-restore';
   title: string;
 };
 

--- a/static/app/actionCreators/dashboards.tsx
+++ b/static/app/actionCreators/dashboards.tsx
@@ -343,22 +343,6 @@ export function updateDashboardPermissions(
   return promise;
 }
 
-export type DashboardRevision = {
-  createdBy: {email: string; id: string; name: string} | null;
-  dateCreated: string;
-  id: string;
-  source: 'edit' | 'pre-restore';
-  title: string;
-};
-
-export function makeDashboardRevisionsQueryKey(orgSlug: string, dashboardId: string) {
-  return [
-    getApiUrl('/organizations/$organizationIdOrSlug/dashboards/$dashboardId/revisions/', {
-      path: {organizationIdOrSlug: orgSlug, dashboardId},
-    }),
-  ] as const;
-}
-
 export function validateWidget(
   api: Client,
   orgId: string,

--- a/static/app/views/dashboards/controls.tsx
+++ b/static/app/views/dashboards/controls.tsx
@@ -31,6 +31,7 @@ import {useDuplicatePrebuiltDashboard} from 'sentry/views/dashboards/hooks/useDu
 import {DataSet} from 'sentry/views/dashboards/widgetBuilder/utils';
 
 import {checkUserHasEditAccess} from './utils/checkUserHasEditAccess';
+import {DashboardRevisionsButton} from './dashboardRevisions';
 import {UNSAVED_FILTERS_MESSAGE} from './detail';
 import {exportDashboard} from './exportDashboard';
 import type {DashboardDetails, DashboardListItem, DashboardPermissions} from './types';
@@ -386,6 +387,9 @@ export function Controls({
                 }}
               </DashboardCreateLimitWrapper>
             )}
+            <Feature features="organizations:dashboards-revisions">
+              <DashboardRevisionsButton dashboard={dashboard} />
+            </Feature>
           </Fragment>
         )}
       </DashboardEditFeature>

--- a/static/app/views/dashboards/controls.tsx
+++ b/static/app/views/dashboards/controls.tsx
@@ -387,9 +387,7 @@ export function Controls({
                 }}
               </DashboardCreateLimitWrapper>
             )}
-            <Feature features="organizations:dashboards-revisions">
-              <DashboardRevisionsButton dashboard={dashboard} />
-            </Feature>
+            <DashboardRevisionsButton dashboard={dashboard} />
           </Fragment>
         )}
       </DashboardEditFeature>

--- a/static/app/views/dashboards/controls.tsx
+++ b/static/app/views/dashboards/controls.tsx
@@ -327,9 +327,11 @@ export function Controls({
               </Tooltip>
             )}
             {renderEditButton(hasFeature)}
-            <Feature features="dashboards-revisions">
-              <DashboardRevisionsButton dashboard={dashboard} />
-            </Feature>
+            {hasFeature && (
+              <Feature features="dashboards-revisions">
+                <DashboardRevisionsButton dashboard={dashboard} />
+              </Feature>
+            )}
             {hasFeature && !isPrebuiltDashboard && (
               <Tooltip
                 title={tooltipMessage}

--- a/static/app/views/dashboards/controls.tsx
+++ b/static/app/views/dashboards/controls.tsx
@@ -327,7 +327,9 @@ export function Controls({
               </Tooltip>
             )}
             {renderEditButton(hasFeature)}
-            <DashboardRevisionsButton dashboard={dashboard} />
+            <Feature features="dashboards-revisions">
+              <DashboardRevisionsButton dashboard={dashboard} />
+            </Feature>
             {hasFeature && !isPrebuiltDashboard && (
               <Tooltip
                 title={tooltipMessage}

--- a/static/app/views/dashboards/controls.tsx
+++ b/static/app/views/dashboards/controls.tsx
@@ -327,6 +327,7 @@ export function Controls({
               </Tooltip>
             )}
             {renderEditButton(hasFeature)}
+            <DashboardRevisionsButton dashboard={dashboard} />
             {hasFeature && !isPrebuiltDashboard && (
               <Tooltip
                 title={tooltipMessage}
@@ -387,7 +388,6 @@ export function Controls({
                 }}
               </DashboardCreateLimitWrapper>
             )}
-            <DashboardRevisionsButton dashboard={dashboard} />
           </Fragment>
         )}
       </DashboardEditFeature>

--- a/static/app/views/dashboards/dashboardRevisions.spec.tsx
+++ b/static/app/views/dashboards/dashboardRevisions.spec.tsx
@@ -1,0 +1,130 @@
+import {DashboardFixture} from 'sentry-fixture/dashboard';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {
+  render,
+  renderGlobalModal,
+  screen,
+  userEvent,
+} from 'sentry-test/reactTestingLibrary';
+
+import {DashboardRevisionsButton} from './dashboardRevisions';
+
+const REVISIONS_URL = '/organizations/org-slug/dashboards/1/revisions/';
+
+function makeRevision(overrides = {}) {
+  return {
+    id: '1',
+    title: 'My Dashboard',
+    source: 'edit',
+    createdBy: {id: '42', name: 'Alice', email: 'alice@example.com'},
+    dateCreated: '2024-01-15T10:00:00Z',
+    ...overrides,
+  };
+}
+
+function renderButton(
+  dashboardOverrides = {},
+  orgFeatures: string[] = ['dashboards-revisions']
+) {
+  const organization = OrganizationFixture({features: orgFeatures});
+  const dashboard = DashboardFixture([], {
+    id: '1',
+    title: 'My Dashboard',
+    ...dashboardOverrides,
+  });
+  render(<DashboardRevisionsButton dashboard={dashboard} />, {organization});
+}
+
+describe('DashboardRevisionsButton', () => {
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('does not render when dashboards-revisions feature flag is off', () => {
+    renderButton({}, []);
+    expect(
+      screen.queryByRole('button', {name: 'Dashboard Revisions'})
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not render for the default-overview dashboard', () => {
+    renderButton({id: 'default-overview'});
+    expect(
+      screen.queryByRole('button', {name: 'Dashboard Revisions'})
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not render for prebuilt dashboards', () => {
+    renderButton({prebuiltId: 'some-prebuilt-id'});
+    expect(
+      screen.queryByRole('button', {name: 'Dashboard Revisions'})
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the button for a valid custom dashboard', () => {
+    MockApiClient.addMockResponse({url: REVISIONS_URL, body: []});
+    renderButton();
+    expect(screen.getByRole('button', {name: 'Dashboard Revisions'})).toBeInTheDocument();
+  });
+
+  it('does not call the revisions endpoint until the button is clicked', () => {
+    const revisionsRequest = MockApiClient.addMockResponse({
+      url: REVISIONS_URL,
+      body: [],
+    });
+    renderButton();
+    expect(revisionsRequest).not.toHaveBeenCalled();
+  });
+
+  it('opens the modal and fetches revisions when clicked', async () => {
+    const revisionsRequest = MockApiClient.addMockResponse({
+      url: REVISIONS_URL,
+      body: [makeRevision()],
+    });
+
+    renderButton();
+    renderGlobalModal();
+    await userEvent.click(screen.getByRole('button', {name: 'Dashboard Revisions'}));
+
+    expect(revisionsRequest).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText('My Dashboard')).toBeInTheDocument();
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+  });
+
+  it('falls back to email when createdBy has no name', async () => {
+    MockApiClient.addMockResponse({
+      url: REVISIONS_URL,
+      body: [makeRevision({createdBy: {id: '42', name: '', email: 'alice@example.com'}})],
+    });
+
+    renderButton();
+    renderGlobalModal();
+    await userEvent.click(screen.getByRole('button', {name: 'Dashboard Revisions'}));
+
+    expect(await screen.findByText('alice@example.com')).toBeInTheDocument();
+  });
+
+  it('shows "Unknown" when createdBy is null', async () => {
+    MockApiClient.addMockResponse({
+      url: REVISIONS_URL,
+      body: [makeRevision({createdBy: null})],
+    });
+
+    renderButton();
+    renderGlobalModal();
+    await userEvent.click(screen.getByRole('button', {name: 'Dashboard Revisions'}));
+
+    expect(await screen.findByText('Unknown')).toBeInTheDocument();
+  });
+
+  it('shows the empty state when no revisions exist', async () => {
+    MockApiClient.addMockResponse({url: REVISIONS_URL, body: []});
+
+    renderButton();
+    renderGlobalModal();
+    await userEvent.click(screen.getByRole('button', {name: 'Dashboard Revisions'}));
+
+    expect(await screen.findByText('No revisions found.')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/dashboards/dashboardRevisions.spec.tsx
+++ b/static/app/views/dashboards/dashboardRevisions.spec.tsx
@@ -16,7 +16,7 @@ function makeRevision(overrides = {}) {
   return {
     id: '1',
     title: 'My Dashboard',
-    source: 'edit',
+    source: 'edit' as const,
     createdBy: {id: '42', name: 'Alice', email: 'alice@example.com'},
     dateCreated: '2024-01-15T10:00:00Z',
     ...overrides,
@@ -116,6 +116,23 @@ describe('DashboardRevisionsButton', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Dashboard Revisions'}));
 
     expect(await screen.findByText('Unknown')).toBeInTheDocument();
+  });
+
+  it('shows the pre-restore badge for revisions with source pre-restore', async () => {
+    MockApiClient.addMockResponse({
+      url: REVISIONS_URL,
+      body: [
+        makeRevision({source: 'pre-restore' as const}),
+        makeRevision({id: '2', title: 'Other', source: 'edit' as const}),
+      ],
+    });
+
+    renderButton();
+    renderGlobalModal();
+    await userEvent.click(screen.getByRole('button', {name: 'Dashboard Revisions'}));
+
+    expect(await screen.findByText('pre-restore')).toBeInTheDocument();
+    expect(screen.getAllByText('pre-restore')).toHaveLength(1);
   });
 
   it('shows the empty state when no revisions exist', async () => {

--- a/static/app/views/dashboards/dashboardRevisions.spec.tsx
+++ b/static/app/views/dashboards/dashboardRevisions.spec.tsx
@@ -127,4 +127,16 @@ describe('DashboardRevisionsButton', () => {
 
     expect(await screen.findByText('No revisions found.')).toBeInTheDocument();
   });
+
+  it('shows an error state when the API request fails', async () => {
+    MockApiClient.addMockResponse({url: REVISIONS_URL, statusCode: 500, body: {}});
+
+    renderButton();
+    renderGlobalModal();
+    await userEvent.click(screen.getByRole('button', {name: 'Dashboard Revisions'}));
+
+    expect(
+      await screen.findByText('Failed to load dashboard revisions.')
+    ).toBeInTheDocument();
+  });
 });

--- a/static/app/views/dashboards/dashboardRevisions.spec.tsx
+++ b/static/app/views/dashboards/dashboardRevisions.spec.tsx
@@ -23,11 +23,8 @@ function makeRevision(overrides = {}) {
   };
 }
 
-function renderButton(
-  dashboardOverrides = {},
-  orgFeatures: string[] = ['dashboards-revisions']
-) {
-  const organization = OrganizationFixture({features: orgFeatures});
+function renderButton(dashboardOverrides = {}) {
+  const organization = OrganizationFixture({features: ['dashboards-revisions']});
   const dashboard = DashboardFixture([], {
     id: '1',
     title: 'My Dashboard',
@@ -41,31 +38,24 @@ describe('DashboardRevisionsButton', () => {
     MockApiClient.clearMockResponses();
   });
 
-  it('does not render when dashboards-revisions feature flag is off', () => {
-    renderButton({}, []);
-    expect(
-      screen.queryByRole('button', {name: 'Dashboard Revisions'})
-    ).not.toBeInTheDocument();
+  it('renders the button', () => {
+    MockApiClient.addMockResponse({url: REVISIONS_URL, body: []});
+    renderButton();
+    expect(screen.getByRole('button', {name: 'Dashboard Revisions'})).toBeInTheDocument();
   });
 
-  it('does not render for the default-overview dashboard', () => {
+  it('renders nothing for the default-overview dashboard', () => {
     renderButton({id: 'default-overview'});
     expect(
       screen.queryByRole('button', {name: 'Dashboard Revisions'})
     ).not.toBeInTheDocument();
   });
 
-  it('does not render for prebuilt dashboards', () => {
-    renderButton({prebuiltId: 'some-prebuilt-id'});
+  it('renders nothing for a prebuilt dashboard', () => {
+    renderButton({prebuiltId: 'default-overview'});
     expect(
       screen.queryByRole('button', {name: 'Dashboard Revisions'})
     ).not.toBeInTheDocument();
-  });
-
-  it('renders the button for a valid custom dashboard', () => {
-    MockApiClient.addMockResponse({url: REVISIONS_URL, body: []});
-    renderButton();
-    expect(screen.getByRole('button', {name: 'Dashboard Revisions'})).toBeInTheDocument();
   });
 
   it('does not call the revisions endpoint until the button is clicked', () => {

--- a/static/app/views/dashboards/dashboardRevisions.tsx
+++ b/static/app/views/dashboards/dashboardRevisions.tsx
@@ -15,7 +15,7 @@ import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {TimeSince} from 'sentry/components/timeSince';
 import {IconClock} from 'sentry/icons/iconClock';
 import {t} from 'sentry/locale';
-import {useOrganization} from 'sentry/utils/useOrganization';
+import {defined} from 'sentry/utils';
 
 import type {DashboardRevision} from './hooks/useDashboardRevisions';
 import {useDashboardRevisions} from './hooks/useDashboardRevisions';
@@ -26,19 +26,17 @@ interface DashboardRevisionsButtonProps {
 }
 
 export function DashboardRevisionsButton({dashboard}: DashboardRevisionsButtonProps) {
-  const organization = useOrganization();
-
-  const hasFeatureFlag = organization.features.includes('dashboards-revisions');
-  const isValidDashboard =
-    !!dashboard.id && dashboard.id !== 'default-overview' && !dashboard.prebuiltId;
+  if (
+    !dashboard.id ||
+    dashboard.id === 'default-overview' ||
+    defined(dashboard.prebuiltId)
+  ) {
+    return null;
+  }
 
   const handleClick = () => {
     openModal(props => <DashboardRevisionsModal {...props} dashboardId={dashboard.id} />);
   };
-
-  if (!hasFeatureFlag || !isValidDashboard) {
-    return null;
-  }
 
   return (
     <Tooltip title={t('Dashboard Revisions')}>

--- a/static/app/views/dashboards/dashboardRevisions.tsx
+++ b/static/app/views/dashboards/dashboardRevisions.tsx
@@ -1,0 +1,136 @@
+import {Fragment} from 'react';
+import styled from '@emotion/styled';
+
+import {Button} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import type {DashboardRevision} from 'sentry/actionCreators/dashboards';
+import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import {openModal} from 'sentry/actionCreators/modal';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {TimeSince} from 'sentry/components/timeSince';
+import {IconClock} from 'sentry/icons/iconClock';
+import {t} from 'sentry/locale';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+import {useDashboardRevisions} from './hooks/useDashboardRevisions';
+import type {DashboardDetails} from './types';
+
+interface DashboardRevisionsButtonProps {
+  dashboard: DashboardDetails;
+}
+
+export function DashboardRevisionsButton({dashboard}: DashboardRevisionsButtonProps) {
+  const organization = useOrganization();
+
+  const isValidDashboard =
+    !!dashboard.id && dashboard.id !== 'default-overview' && !dashboard.prebuiltId;
+
+  const handleClick = () => {
+    openModal(props => (
+      <DashboardRevisionsModal
+        {...props}
+        dashboardId={dashboard.id}
+        orgSlug={organization.slug}
+      />
+    ));
+  };
+
+  if (!isValidDashboard) {
+    return null;
+  }
+
+  return (
+    <Tooltip title={t('Dashboard Revisions')}>
+      <Button
+        size="sm"
+        icon={<IconClock />}
+        aria-label={t('Dashboard Revisions')}
+        onClick={handleClick}
+      />
+    </Tooltip>
+  );
+}
+
+function DashboardRevisionsModal({
+  Header,
+  Body,
+  dashboardId,
+}: ModalRenderProps & {
+  dashboardId: string;
+  orgSlug: string;
+}) {
+  const {data: revisions, isPending} = useDashboardRevisions({dashboardId});
+
+  return (
+    <Fragment>
+      <Header closeButton>{t('Dashboard Revisions')}</Header>
+      <Body>
+        {isPending ? (
+          <LoadingIndicator />
+        ) : revisions?.length ? (
+          <RevisionList revisions={revisions} />
+        ) : (
+          <Flex align="center" justify="center" padding="xl">
+            <Text variant="muted">{t('No revisions found.')}</Text>
+          </Flex>
+        )}
+      </Body>
+    </Fragment>
+  );
+}
+
+function RevisionList({revisions}: {revisions: DashboardRevision[]}) {
+  return (
+    <Table>
+      <thead>
+        <tr>
+          <Th>{t('Title')}</Th>
+          <Th>{t('Created By')}</Th>
+          <Th>{t('Created At')}</Th>
+        </tr>
+      </thead>
+      <tbody>
+        {revisions.map(revision => (
+          <tr key={revision.id}>
+            <Td>
+              <Text size="sm">{revision.title}</Text>
+            </Td>
+            <Td>
+              <Text size="sm" variant="muted">
+                {revision.createdBy
+                  ? revision.createdBy.name || revision.createdBy.email
+                  : t('Unknown')}
+              </Text>
+            </Td>
+            <Td>
+              <TimeSince date={revision.dateCreated} />
+            </Td>
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  );
+}
+
+const Table = styled('table')`
+  width: 100%;
+  border-collapse: collapse;
+`;
+
+const Th = styled('th')`
+  text-align: left;
+  padding: ${p => p.theme.space.sm} ${p => p.theme.space.md};
+  border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
+  font-weight: ${p => p.theme.font.weight.sans.medium};
+  font-size: ${p => p.theme.font.size.sm};
+  color: ${p => p.theme.tokens.content.secondary};
+`;
+
+const Td = styled('td')`
+  padding: ${p => p.theme.space.sm} ${p => p.theme.space.md};
+  border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
+  vertical-align: middle;
+`;

--- a/static/app/views/dashboards/dashboardRevisions.tsx
+++ b/static/app/views/dashboards/dashboardRevisions.tsx
@@ -8,15 +8,16 @@ import {Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import type {DashboardRevision} from 'sentry/actionCreators/dashboards';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {openModal} from 'sentry/actionCreators/modal';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {TimeSince} from 'sentry/components/timeSince';
 import {IconClock} from 'sentry/icons/iconClock';
 import {t} from 'sentry/locale';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
+import type {DashboardRevision} from './hooks/useDashboardRevisions';
 import {useDashboardRevisions} from './hooks/useDashboardRevisions';
 import type {DashboardDetails} from './types';
 
@@ -82,67 +83,38 @@ function DashboardRevisionsModal({
 
 function RevisionList({revisions}: {revisions: DashboardRevision[]}) {
   return (
-    <Table>
-      <thead>
-        <tr>
-          <Th>
-            <Text size="sm" variant="muted" bold as="span">
-              {t('Title')}
+    <RevisionsTable>
+      <SimpleTable.Header>
+        <SimpleTable.HeaderCell>{t('Title')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell>{t('Created By')}</SimpleTable.HeaderCell>
+        <SimpleTable.HeaderCell>{t('Created At')}</SimpleTable.HeaderCell>
+      </SimpleTable.Header>
+      {revisions.map(revision => (
+        <SimpleTable.Row key={revision.id}>
+          <SimpleTable.RowCell>
+            <Flex align="center" gap="sm">
+              <Text size="sm">{revision.title}</Text>
+              {revision.source === 'pre-restore' && (
+                <Tag variant="muted">{t('pre-restore')}</Tag>
+              )}
+            </Flex>
+          </SimpleTable.RowCell>
+          <SimpleTable.RowCell>
+            <Text size="sm" variant="muted">
+              {revision.createdBy
+                ? revision.createdBy.name || revision.createdBy.email
+                : t('Unknown')}
             </Text>
-          </Th>
-          <Th>
-            <Text size="sm" variant="muted" bold as="span">
-              {t('Created By')}
-            </Text>
-          </Th>
-          <Th>
-            <Text size="sm" variant="muted" bold as="span">
-              {t('Created At')}
-            </Text>
-          </Th>
-        </tr>
-      </thead>
-      <tbody>
-        {revisions.map(revision => (
-          <tr key={revision.id}>
-            <Td>
-              <Flex align="center" gap="sm">
-                <Text size="sm">{revision.title}</Text>
-                {revision.source === 'pre-restore' && (
-                  <Tag variant="muted">{t('pre-restore')}</Tag>
-                )}
-              </Flex>
-            </Td>
-            <Td>
-              <Text size="sm" variant="muted">
-                {revision.createdBy
-                  ? revision.createdBy.name || revision.createdBy.email
-                  : t('Unknown')}
-              </Text>
-            </Td>
-            <Td>
-              <TimeSince date={revision.dateCreated} />
-            </Td>
-          </tr>
-        ))}
-      </tbody>
-    </Table>
+          </SimpleTable.RowCell>
+          <SimpleTable.RowCell>
+            <TimeSince date={revision.dateCreated} />
+          </SimpleTable.RowCell>
+        </SimpleTable.Row>
+      ))}
+    </RevisionsTable>
   );
 }
 
-const Table = styled('table')`
-  width: 100%;
-  border-collapse: collapse;
-`;
-
-const Th = styled('th')`
-  text-align: left;
-  padding: ${p => p.theme.space.sm} ${p => p.theme.space.md};
-  border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
-`;
-
-const Td = styled('td')`
-  padding: ${p => p.theme.space.sm} ${p => p.theme.space.md};
-  border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
-  vertical-align: middle;
+const RevisionsTable = styled(SimpleTable)`
+  grid-template-columns: minmax(200px, 2fr) minmax(150px, 1fr) minmax(120px, auto);
 `;

--- a/static/app/views/dashboards/dashboardRevisions.tsx
+++ b/static/app/views/dashboards/dashboardRevisions.tsx
@@ -25,6 +25,7 @@ interface DashboardRevisionsButtonProps {
 export function DashboardRevisionsButton({dashboard}: DashboardRevisionsButtonProps) {
   const organization = useOrganization();
 
+  const hasFeatureFlag = organization.features.includes('dashboards-revisions');
   const isValidDashboard =
     !!dashboard.id && dashboard.id !== 'default-overview' && !dashboard.prebuiltId;
 
@@ -38,7 +39,7 @@ export function DashboardRevisionsButton({dashboard}: DashboardRevisionsButtonPr
     ));
   };
 
-  if (!isValidDashboard) {
+  if (!hasFeatureFlag || !isValidDashboard) {
     return null;
   }
 

--- a/static/app/views/dashboards/dashboardRevisions.tsx
+++ b/static/app/views/dashboards/dashboardRevisions.tsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {Alert} from '@sentry/scraps/alert';
+import {Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
@@ -105,7 +106,12 @@ function RevisionList({revisions}: {revisions: DashboardRevision[]}) {
         {revisions.map(revision => (
           <tr key={revision.id}>
             <Td>
-              <Text size="sm">{revision.title}</Text>
+              <Flex align="center" gap="sm">
+                <Text size="sm">{revision.title}</Text>
+                {revision.source === 'pre-restore' && (
+                  <Tag variant="muted">{t('pre-restore')}</Tag>
+                )}
+              </Flex>
             </Td>
             <Td>
               <Text size="sm" variant="muted">

--- a/static/app/views/dashboards/dashboardRevisions.tsx
+++ b/static/app/views/dashboards/dashboardRevisions.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
@@ -30,13 +31,7 @@ export function DashboardRevisionsButton({dashboard}: DashboardRevisionsButtonPr
     !!dashboard.id && dashboard.id !== 'default-overview' && !dashboard.prebuiltId;
 
   const handleClick = () => {
-    openModal(props => (
-      <DashboardRevisionsModal
-        {...props}
-        dashboardId={dashboard.id}
-        orgSlug={organization.slug}
-      />
-    ));
+    openModal(props => <DashboardRevisionsModal {...props} dashboardId={dashboard.id} />);
   };
 
   if (!hasFeatureFlag || !isValidDashboard) {
@@ -61,9 +56,8 @@ function DashboardRevisionsModal({
   dashboardId,
 }: ModalRenderProps & {
   dashboardId: string;
-  orgSlug: string;
 }) {
-  const {data: revisions, isPending} = useDashboardRevisions({dashboardId});
+  const {data: revisions, isPending, isError} = useDashboardRevisions({dashboardId});
 
   return (
     <Fragment>
@@ -71,6 +65,8 @@ function DashboardRevisionsModal({
       <Body>
         {isPending ? (
           <LoadingIndicator />
+        ) : isError ? (
+          <Alert variant="danger">{t('Failed to load dashboard revisions.')}</Alert>
         ) : revisions?.length ? (
           <RevisionList revisions={revisions} />
         ) : (
@@ -88,9 +84,21 @@ function RevisionList({revisions}: {revisions: DashboardRevision[]}) {
     <Table>
       <thead>
         <tr>
-          <Th>{t('Title')}</Th>
-          <Th>{t('Created By')}</Th>
-          <Th>{t('Created At')}</Th>
+          <Th>
+            <Text size="sm" variant="muted" bold as="span">
+              {t('Title')}
+            </Text>
+          </Th>
+          <Th>
+            <Text size="sm" variant="muted" bold as="span">
+              {t('Created By')}
+            </Text>
+          </Th>
+          <Th>
+            <Text size="sm" variant="muted" bold as="span">
+              {t('Created At')}
+            </Text>
+          </Th>
         </tr>
       </thead>
       <tbody>
@@ -125,9 +133,6 @@ const Th = styled('th')`
   text-align: left;
   padding: ${p => p.theme.space.sm} ${p => p.theme.space.md};
   border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
-  font-weight: ${p => p.theme.font.weight.sans.medium};
-  font-size: ${p => p.theme.font.size.sm};
-  color: ${p => p.theme.tokens.content.secondary};
 `;
 
 const Td = styled('td')`

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -61,6 +61,7 @@ import {useParams} from 'sentry/utils/useParams';
 import {useProjects} from 'sentry/utils/useProjects';
 import {useRouter} from 'sentry/utils/useRouter';
 import {useDashboardChartInterval} from 'sentry/views/dashboards/hooks/useDashboardChartInterval';
+import {getDashboardRevisionsQueryKey} from 'sentry/views/dashboards/hooks/useDashboardRevisions';
 import {
   cloneDashboard,
   getCurrentPageFilters,
@@ -561,7 +562,8 @@ class DashboardDetail extends Component<Props, State> {
   };
 
   handleUpdateWidgetList = (widgets: Widget[]) => {
-    const {organization, dashboard, api, onDashboardUpdate, location} = this.props;
+    const {organization, dashboard, api, onDashboardUpdate, location, queryClient} =
+      this.props;
     const {modifiedDashboard} = this.state;
 
     // Use the new widgets for calculating layout because widgets has
@@ -582,6 +584,9 @@ class DashboardDetail extends Component<Props, State> {
     }
     return updateDashboard(api, organization.slug, newModifiedDashboard).then(
       (newDashboard: DashboardDetails) => {
+        queryClient.invalidateQueries({
+          queryKey: getDashboardRevisionsQueryKey(organization.slug, newDashboard.id),
+        });
         if (onDashboardUpdate) {
           onDashboardUpdate(newDashboard);
           this.setState({
@@ -837,7 +842,8 @@ class DashboardDetail extends Component<Props, State> {
   };
 
   onCommit = () => {
-    const {api, organization, location, dashboard, onDashboardUpdate} = this.props;
+    const {api, organization, location, dashboard, onDashboardUpdate, queryClient} =
+      this.props;
     const {modifiedDashboard, dashboardState} = this.state;
 
     switch (dashboardState) {
@@ -918,6 +924,12 @@ class DashboardDetail extends Component<Props, State> {
           });
           updateDashboard(api, organization.slug, modifiedDashboard).then(
             (newDashboard: DashboardDetails) => {
+              queryClient.invalidateQueries({
+                queryKey: getDashboardRevisionsQueryKey(
+                  organization.slug,
+                  newDashboard.id
+                ),
+              });
               if (onDashboardUpdate) {
                 onDashboardUpdate(newDashboard);
               }
@@ -1153,6 +1165,7 @@ class DashboardDetail extends Component<Props, State> {
       onDashboardUpdate,
       pageAlerts,
       projects,
+      queryClient,
     } = this.props;
     const {
       modifiedDashboard,
@@ -1325,6 +1338,12 @@ class DashboardDetail extends Component<Props, State> {
                                   newModifiedDashboard
                                 ).then(
                                   (newDashboard: DashboardDetails) => {
+                                    queryClient.invalidateQueries({
+                                      queryKey: getDashboardRevisionsQueryKey(
+                                        organization.slug,
+                                        newDashboard.id
+                                      ),
+                                    });
                                     addSuccessMessage(t('Dashboard filters updated'));
                                     trackAnalytics('dashboards2.filter.save', {
                                       organization,

--- a/static/app/views/dashboards/hooks/useDashboardRevisions.tsx
+++ b/static/app/views/dashboards/hooks/useDashboardRevisions.tsx
@@ -11,6 +11,16 @@ export type DashboardRevision = {
   title: string;
 };
 
+const REVISIONS_PATH =
+  '/organizations/$organizationIdOrSlug/dashboards/$dashboardId/revisions/' as const;
+
+export function getDashboardRevisionsQueryKey(orgSlug: string, dashboardId: string) {
+  return apiOptions.as<DashboardRevision[]>()(REVISIONS_PATH, {
+    path: {organizationIdOrSlug: orgSlug, dashboardId},
+    staleTime: 30_000,
+  }).queryKey;
+}
+
 interface UseDashboardRevisionsOptions {
   dashboardId: string;
 }
@@ -18,12 +28,9 @@ interface UseDashboardRevisionsOptions {
 export function useDashboardRevisions({dashboardId}: UseDashboardRevisionsOptions) {
   const organization = useOrganization();
   return useQuery(
-    apiOptions.as<DashboardRevision[]>()(
-      '/organizations/$organizationIdOrSlug/dashboards/$dashboardId/revisions/',
-      {
-        path: {organizationIdOrSlug: organization.slug, dashboardId},
-        staleTime: 30_000,
-      }
-    )
+    apiOptions.as<DashboardRevision[]>()(REVISIONS_PATH, {
+      path: {organizationIdOrSlug: organization.slug, dashboardId},
+      staleTime: 30_000,
+    })
   );
 }

--- a/static/app/views/dashboards/hooks/useDashboardRevisions.tsx
+++ b/static/app/views/dashboards/hooks/useDashboardRevisions.tsx
@@ -1,25 +1,31 @@
-import {
-  makeDashboardRevisionsQueryKey,
-  type DashboardRevision,
-} from 'sentry/actionCreators/dashboards';
-import {useApiQuery} from 'sentry/utils/queryClient';
+import {useQuery} from '@tanstack/react-query';
+
+import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
+
+export type DashboardRevision = {
+  createdBy: {email: string; id: string; name: string} | null;
+  dateCreated: string;
+  id: string;
+  source: 'edit' | 'pre-restore';
+  title: string;
+};
+
+export function makeDashboardRevisionsQueryOptions(orgSlug: string, dashboardId: string) {
+  return apiOptions.as<DashboardRevision[]>()(
+    '/organizations/$organizationIdOrSlug/dashboards/$dashboardId/revisions/',
+    {
+      path: {organizationIdOrSlug: orgSlug, dashboardId},
+      staleTime: 30_000,
+    }
+  );
+}
 
 interface UseDashboardRevisionsOptions {
   dashboardId: string;
-  enabled?: boolean;
 }
 
-export function useDashboardRevisions({
-  dashboardId,
-  enabled = true,
-}: UseDashboardRevisionsOptions) {
+export function useDashboardRevisions({dashboardId}: UseDashboardRevisionsOptions) {
   const organization = useOrganization();
-  return useApiQuery<DashboardRevision[]>(
-    makeDashboardRevisionsQueryKey(organization.slug, dashboardId),
-    {
-      staleTime: 30_000,
-      enabled,
-    }
-  );
+  return useQuery(makeDashboardRevisionsQueryOptions(organization.slug, dashboardId));
 }

--- a/static/app/views/dashboards/hooks/useDashboardRevisions.tsx
+++ b/static/app/views/dashboards/hooks/useDashboardRevisions.tsx
@@ -11,21 +11,19 @@ export type DashboardRevision = {
   title: string;
 };
 
-export function makeDashboardRevisionsQueryOptions(orgSlug: string, dashboardId: string) {
-  return apiOptions.as<DashboardRevision[]>()(
-    '/organizations/$organizationIdOrSlug/dashboards/$dashboardId/revisions/',
-    {
-      path: {organizationIdOrSlug: orgSlug, dashboardId},
-      staleTime: 30_000,
-    }
-  );
-}
-
 interface UseDashboardRevisionsOptions {
   dashboardId: string;
 }
 
 export function useDashboardRevisions({dashboardId}: UseDashboardRevisionsOptions) {
   const organization = useOrganization();
-  return useQuery(makeDashboardRevisionsQueryOptions(organization.slug, dashboardId));
+  return useQuery(
+    apiOptions.as<DashboardRevision[]>()(
+      '/organizations/$organizationIdOrSlug/dashboards/$dashboardId/revisions/',
+      {
+        path: {organizationIdOrSlug: organization.slug, dashboardId},
+        staleTime: 30_000,
+      }
+    )
+  );
 }

--- a/static/app/views/dashboards/hooks/useDashboardRevisions.tsx
+++ b/static/app/views/dashboards/hooks/useDashboardRevisions.tsx
@@ -1,0 +1,25 @@
+import {
+  makeDashboardRevisionsQueryKey,
+  type DashboardRevision,
+} from 'sentry/actionCreators/dashboards';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+interface UseDashboardRevisionsOptions {
+  dashboardId: string;
+  enabled?: boolean;
+}
+
+export function useDashboardRevisions({
+  dashboardId,
+  enabled = true,
+}: UseDashboardRevisionsOptions) {
+  const organization = useOrganization();
+  return useApiQuery<DashboardRevision[]>(
+    makeDashboardRevisionsQueryKey(organization.slug, dashboardId),
+    {
+      staleTime: 30_000,
+      enabled,
+    }
+  );
+}


### PR DESCRIPTION
Adds a clock icon button to the dashboard controls toolbar that opens a modal listing the revision history for the current dashboard. Each row shows the revision title, who created it, and a relative timestamp.

The button is gated behind the `dashboards-revisions` feature flag and hidden for prebuilt and default-overview dashboards (which have no stored revisions). The revisions endpoint is not called until the modal is opened — no eager fetch on page load.

Refs DAIN-1545