### PR TITLE
feat(identity): Add identity_ext_ids filter to identity RPC service

### DIFF
--- a/src/sentry/identity/services/identity/impl.py
+++ b/src/sentry/identity/services/identity/impl.py
@@ -97,6 +97,8 @@ class DatabaseBackedIdentityService(IdentityService):
                 query = query.filter(user_id=filters["user_id"])
             if "identity_ext_id" in filters:
                 query = query.filter(external_id=filters["identity_ext_id"])
+            if "identity_ext_ids" in filters:
+                query = query.filter(external_id__in=filters["identity_ext_ids"])
             if "provider_id" in filters:
                 query = query.filter(idp_id=filters["provider_id"])
             if "provider_ext_id" in filters:

--- a/src/sentry/identity/services/identity/model.py
+++ b/src/sentry/identity/services/identity/model.py
@@ -40,6 +40,7 @@ class IdentityFilterArgs(TypedDict, total=False):
     id: int
     user_id: int
     identity_ext_id: str
+    identity_ext_ids: list[str]
     provider_id: int
     provider_ext_id: str
     provider_type: str

--- a/tests/sentry/identity/services/test_identity.py
+++ b/tests/sentry/identity/services/test_identity.py
@@ -1,0 +1,25 @@
+from sentry.identity.services.identity import identity_service
+from sentry.testutils.cases import TestCase
+
+
+class GetIdentitiesFilterTest(TestCase):
+    def test_filters_by_identity_ext_ids(self) -> None:
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="slack",
+            external_id="TXXXX",
+        )
+        idp = self.create_identity_provider(integration=integration)
+
+        user_a = self.create_user()
+        user_b = self.create_user()
+        user_c = self.create_user()
+        self.create_identity(user=user_a, identity_provider=idp, external_id="UA")
+        self.create_identity(user=user_b, identity_provider=idp, external_id="UB")
+        self.create_identity(user=user_c, identity_provider=idp, external_id="UC")
+
+        identities = identity_service.get_identities(
+            filter={"provider_id": idp.id, "identity_ext_ids": ["UA", "UC", "UNLINKED"]}
+        )
+
+        assert {i.external_id for i in identities} == {"UA", "UC"}


### PR DESCRIPTION
Adds an `identity_ext_ids` list filter to `IdentityService.get_identities` so callers can batch-fetch identities by a list of external IDs in one query instead of multiple RPC calls.

We will use this in #113318 to fetch multiple identities to see which users in the Slack thread are linked to Sentry when Sentry is mentioned.

Refs ISWF-2482