### PR TITLE
fix(ourlogs): pipe case sensitivity through Highlight component

### DIFF
--- a/static/app/components/highlight.spec.tsx
+++ b/static/app/components/highlight.spec.tsx
@@ -13,6 +13,27 @@ describe('Highlight', () => {
     expect(wrapper.container.childNodes[2]).toHaveTextContent('y@sentry.io');
   });
 
+  it('highlights with a case-insensitive match when caseSensitive is falsy', () => {
+    const wrapper = render(
+      <HighlightComponent text="Apple">apple Apple APPLE</HighlightComponent>
+    );
+    expect(wrapper.container.childNodes).toHaveLength(2);
+    expect(wrapper.container.childNodes[0]).toHaveTextContent('apple');
+    expect(wrapper.container.childNodes[1]).toHaveTextContent('Apple APPLE');
+  });
+
+  it('highlights with a case-sensitive match when caseSensitive is true', () => {
+    const wrapper = render(
+      <HighlightComponent caseSensitive text="Apple">
+        apple Apple APPLE
+      </HighlightComponent>
+    );
+    expect(wrapper.container.childNodes).toHaveLength(3);
+    expect(wrapper.container.childNodes[0]).toHaveTextContent('apple');
+    expect(wrapper.container.childNodes[1]).toHaveTextContent('Apple');
+    expect(wrapper.container.childNodes[2]).toHaveTextContent('APPLE');
+  });
+
   it('does not have highlighted text if `text` prop is not found in main text', () => {
     render(<HighlightComponent text="invalid">billy@sentry.io</HighlightComponent>);
 

--- a/static/app/components/highlight.tsx
+++ b/static/app/components/highlight.tsx
@@ -10,6 +10,10 @@ type HighlightProps = {
    */
   text: string;
   /**
+   * Whether to only highlight text that matches case too
+   */
+  caseSensitive?: boolean;
+  /**
    * Should highlighting be disabled?
    */
   disabled?: boolean;
@@ -18,14 +22,15 @@ type HighlightProps = {
 type Props = Omit<React.HTMLAttributes<HTMLDivElement>, keyof HighlightProps> &
   HighlightProps;
 
-function HighlightComponent({className, children, disabled, text}: Props) {
+function HighlightComponent({caseSensitive, className, children, disabled, text}: Props) {
   // There are instances when children is not string in breadcrumbs but not caught by TS
   if (!text || disabled || typeof children !== 'string') {
     return <Fragment>{children}</Fragment>;
   }
 
-  const highlightText = text.toLowerCase();
-  const idx = children.toLowerCase().indexOf(highlightText);
+  const idx = caseSensitive
+    ? children.indexOf(text)
+    : children.toLowerCase().indexOf(text.toLowerCase());
 
   if (idx === -1) {
     return <Fragment>{children}</Fragment>;
@@ -34,10 +39,8 @@ function HighlightComponent({className, children, disabled, text}: Props) {
   return (
     <Fragment>
       {children.substring(0, idx)}
-      <span className={className}>
-        {children.substring(idx, idx + highlightText.length)}
-      </span>
-      {children.substring(idx + highlightText.length)}
+      <span className={className}>{children.substring(idx, idx + text.length)}</span>
+      {children.substring(idx + text.length)}
     </Fragment>
   );
 }

--- a/static/app/views/explore/logs/fieldRenderers.spec.tsx
+++ b/static/app/views/explore/logs/fieldRenderers.spec.tsx
@@ -42,6 +42,7 @@ describe('Logs Field Renderers', () => {
       theme: ThemeFixture(),
       attributeTypes: {},
       attributes,
+      caseSensitiveHighlighting: false,
       highlightTerms: [],
       logColors: {
         text: '#000',

--- a/static/app/views/explore/logs/fieldRenderers.tsx
+++ b/static/app/views/explore/logs/fieldRenderers.tsx
@@ -456,7 +456,7 @@ export function LogBodyRenderer(props: LogFieldRendererProps) {
     >
       <WrappingText wrapText={props.extra.wrapBody}>
         <LogsHighlight
-          caseSensitive={!props.extra.caseSensitiveHighlighting}
+          caseSensitive={props.extra.caseSensitiveHighlighting}
           text={highlightTerm}
         >
           {stripAnsi(attribute_value)}

--- a/static/app/views/explore/logs/fieldRenderers.tsx
+++ b/static/app/views/explore/logs/fieldRenderers.tsx
@@ -72,6 +72,7 @@ export interface RendererExtra extends RenderFunctionBaggage {
     TraceItemResponseAttribute['type'] | EventsMetaType['fields'][string]
   >;
   attributes: Record<string, string | number | boolean>;
+  caseSensitiveHighlighting: boolean;
   highlightTerms: string[];
   logColors: ReturnType<typeof getLogColors>;
   align?: 'left' | 'center' | 'right';
@@ -454,7 +455,12 @@ export function LogBodyRenderer(props: LogFieldRendererProps) {
       isAppendingTemplate={!!templateText}
     >
       <WrappingText wrapText={props.extra.wrapBody}>
-        <LogsHighlight text={highlightTerm}>{stripAnsi(attribute_value)}</LogsHighlight>
+        <LogsHighlight
+          caseSensitive={!props.extra.caseSensitiveHighlighting}
+          text={highlightTerm}
+        >
+          {stripAnsi(attribute_value)}
+        </LogsHighlight>
         {isBodyFiltered && templateText && (
           <FieldReplacementHelper
             original={attribute_value}

--- a/static/app/views/explore/logs/tables/logsAggregateTable.tsx
+++ b/static/app/views/explore/logs/tables/logsAggregateTable.tsx
@@ -151,6 +151,7 @@ export function LogsAggregateTable({
             const extra: RendererExtra = {
               attributes: row,
               attributeTypes: data?.meta?.fields ?? {},
+              caseSensitiveHighlighting: false,
               highlightTerms: [],
               logColors: getLogColors(level, theme),
               location,

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -10,6 +10,7 @@ import {Flex} from '@sentry/scraps/layout';
 import {EmptyStreamWrapper} from 'sentry/components/emptyStateWarning';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {useCaseInsensitivity} from 'sentry/components/searchQueryBuilder/hooks';
 import {IconAdd, IconJson, IconSubtract, IconWarning} from 'sentry/icons';
 import {IconChevron} from 'sentry/icons/iconChevron';
 import {t} from 'sentry/locale';
@@ -258,9 +259,11 @@ export const LogRowContent = memo(function LogRowContent({
     sharedHoverTimeoutRef,
     timeout: prefetchTimeout,
   });
+  const [caseInsensitivity] = useCaseInsensitivity();
 
   const rendererExtra: RendererExtra = {
     highlightTerms,
+    caseSensitiveHighlighting: !caseInsensitivity,
     logColors,
     useFullSeverityText: false,
     location,
@@ -476,6 +479,7 @@ function LogRowDetails({
   const projectSlug = project?.slug ?? '';
   const fields = useQueryParamsFields();
   const getActions = useLogAttributesTreeActions({embedded});
+  const [caseInsensitivity] = useCaseInsensitivity();
   const severityNumber = dataRow[OurLogKnownFieldKey.SEVERITY_NUMBER];
   const severityText = dataRow[OurLogKnownFieldKey.SEVERITY];
 
@@ -544,6 +548,7 @@ function LogRowDetails({
                       wrapBody: true,
                       location,
                       organization,
+                      caseSensitiveHighlighting: !caseInsensitivity,
                       projectSlug,
                       attributes,
                       attributeTypes,
@@ -565,6 +570,7 @@ function LogRowDetails({
                   getAdjustedAttributeKey={adjustAliases}
                   renderers={LogAttributesRendererMap}
                   rendererExtra={{
+                    caseSensitiveHighlighting: !caseInsensitivity,
                     highlightTerms,
                     logColors,
                     location,

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -263,7 +263,7 @@ export const LogRowContent = memo(function LogRowContent({
 
   const rendererExtra: RendererExtra = {
     highlightTerms,
-    caseSensitiveHighlighting: !caseInsensitivity,
+    caseSensitiveHighlighting: !!caseInsensitivity,
     logColors,
     useFullSeverityText: false,
     location,
@@ -548,7 +548,7 @@ function LogRowDetails({
                       wrapBody: true,
                       location,
                       organization,
-                      caseSensitiveHighlighting: !caseInsensitivity,
+                      caseSensitiveHighlighting: !!caseInsensitivity,
                       projectSlug,
                       attributes,
                       attributeTypes,
@@ -570,7 +570,7 @@ function LogRowDetails({
                   getAdjustedAttributeKey={adjustAliases}
                   renderers={LogAttributesRendererMap}
                   rendererExtra={{
-                    caseSensitiveHighlighting: !caseInsensitivity,
+                    caseSensitiveHighlighting: !!caseInsensitivity,
                     highlightTerms,
                     logColors,
                     location,

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -263,7 +263,7 @@ export const LogRowContent = memo(function LogRowContent({
 
   const rendererExtra: RendererExtra = {
     highlightTerms,
-    caseSensitiveHighlighting: !!caseInsensitivity,
+    caseSensitiveHighlighting: !caseInsensitivity,
     logColors,
     useFullSeverityText: false,
     location,
@@ -548,7 +548,7 @@ function LogRowDetails({
                       wrapBody: true,
                       location,
                       organization,
-                      caseSensitiveHighlighting: !!caseInsensitivity,
+                      caseSensitiveHighlighting: !caseInsensitivity,
                       projectSlug,
                       attributes,
                       attributeTypes,
@@ -570,7 +570,7 @@ function LogRowDetails({
                   getAdjustedAttributeKey={adjustAliases}
                   renderers={LogAttributesRendererMap}
                   rendererExtra={{
-                    caseSensitiveHighlighting: !!caseInsensitivity,
+                    caseSensitiveHighlighting: !caseInsensitivity,
                     highlightTerms,
                     logColors,
                     location,

--- a/static/app/views/explore/metrics/metricInfoTabs/metricDetails.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricDetails.tsx
@@ -91,6 +91,7 @@ export function MetricDetails({
                       acc[attr.name] = attr.value;
                       return acc;
                     }, {}),
+                    caseSensitiveHighlighting: false,
                     highlightTerms: [],
                     logColors: getLogColors(SeverityLevel.INFO, theme),
                     location,


### PR DESCRIPTION
Adds a `caseSensitive` prop to `Highlight`, then uses it in `LogBodyRenderer` -> `LogsHighlight`.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="843" height="410" alt="image" src="https://github.com/user-attachments/assets/c1c974ef-88b6-4b31-a084-9d28ec38f55a" />
</td>
<td>
<img width="843" height="410" alt="image" src="https://github.com/user-attachments/assets/07716434-4cd9-41b2-9f91-4e4317445356" />
</td>
</tr>
</tbody>
</table>

Fixes LOGS-689.