### PR TITLE
fix(seer): Add kwargs to Seer cleanup tasks for safe arg change deploy

### DIFF
--- a/src/sentry/tasks/seer/cleanup.py
+++ b/src/sentry/tasks/seer/cleanup.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
     silo_mode=SiloMode.CELL,
 )
 def cleanup_seer_repository_preferences(
-    organization_id: int, repo_external_id: str, repo_provider: str
+    organization_id: int, repo_external_id: str, repo_provider: str, **kwargs
 ) -> None:
     """
     Clean up Seer preferences for a deleted repository.
@@ -73,7 +73,7 @@ def cleanup_seer_repository_preferences(
     silo_mode=SiloMode.CELL,
 )
 def bulk_cleanup_seer_repository_preferences(
-    organization_id: int, repos: list[dict[str, str]]
+    organization_id: int, repos: list[dict[str, str]], **kwargs
 ) -> None:
     """
     Removes multiple repositories from Seer project preferences when the repository


### PR DESCRIPTION
Want to deploy https://github.com/getsentry/sentry/pull/113345 which adds some optional args to these tasks. Let's add **kwargs to the signatures so if we have to revert that PR we can do it safely. 