### PR TITLE
fix(migrations): 0007 had the wrong migration dependency

### DIFF
--- a/src/sentry/explore/migrations/0007_update_numeric_attrs_to_bools.py
+++ b/src/sentry/explore/migrations/0007_update_numeric_attrs_to_bools.py
@@ -207,7 +207,7 @@ class Migration(CheckedMigration):
     is_post_deployment = True
 
     dependencies = [
-        ("sentry", "1055_rename_regiontombstone_to_celltombstone"),
+        ("sentry", "1041_projectkeymapping"),
         ("explore", "0006_add_changed_reason_field_explore"),
     ]
 


### PR DESCRIPTION
- Tested this by doing the following
  1. Checkout sentry before the migration was applied: `git checkout 6e0f32a6b7d9aa4db746911a7a767dccb703dc28`
  2. Checkout current master, try to apply migrations, get the Inconsistent Migration History error
  3. Change to 1041 as the clanker suggested
  4. Apply migrations again, not get any errors