### PR TITLE
ref(ci): tolerate action-download flakes on collect-test-data

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -158,6 +158,7 @@ jobs:
       - name: Collect test data
         uses: ./.github/actions/collect-test-data
         if: ${{ !cancelled() }}
+        continue-on-error: true
         with:
           artifact_path: .artifacts/pytest.acceptance.json
           gcs_bucket: ${{ secrets.COLLECT_TEST_DATA_GCS_BUCKET }}

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -351,6 +351,7 @@ jobs:
       - name: Collect test data
         uses: ./.github/actions/collect-test-data
         if: ${{ !cancelled() }}
+        continue-on-error: true
         with:
           artifact_path: .artifacts/pytest.json
           gcs_bucket: ${{ secrets.COLLECT_TEST_DATA_GCS_BUCKET }}
@@ -634,6 +635,7 @@ jobs:
       - name: Collect test data
         uses: ./.github/actions/collect-test-data
         if: ${{ !cancelled() }}
+        continue-on-error: true
         with:
           artifact_path: .artifacts/pytest.monolith-dbs.json
           gcs_bucket: ${{ secrets.COLLECT_TEST_DATA_GCS_BUCKET }}


### PR DESCRIPTION
Currently we're seeing transient Github Actions infra flakes in the collect test data step which is failing the job.

It's somewhat inconvenient to add retry logic as it's the prepare phase here (using a retry action would run into the same download problem; shell scripts inside `run` only happen after the step's own `prepare` phase which is failing here),  but fundamentally test collection is telemetry and not test correctness so we shouldn't fail the workflow for this.

The inner composite step already has continue-on-error, but that only covers the step's run phase. When tarball downloads during the action prepare phase 404 (which happens before any step runs), the attribute never gets a chance to apply. Putting it on the outer step catches the prepare-phase failures too. 

With this change, the step itself will be marked as failed in the UI with a warning icon, but the job conclusion and run stays green.