### PR TITLE
fix(dashboards): Apply prebuilt globalFilter to saved prebuilt dashboards

### DIFF
--- a/static/app/views/dashboards/globalFilter/utils.tsx
+++ b/static/app/views/dashboards/globalFilter/utils.tsx
@@ -19,6 +19,40 @@ export function globalFilterKeysAreEqual(a: GlobalFilter, b: GlobalFilter): bool
   return a.tag.key === b.tag.key && a.dataset === b.dataset;
 }
 
+/**
+ * Merges two lists of global filters. Walks `baseFilters` in order and
+ * replaces each entry with its match from `overrideFilters` (by tag key +
+ * dataset) when one exists. Override filters that don't match any base
+ * entry are appended at the end.
+ */
+export function mergeGlobalFilters(
+  baseFilters: GlobalFilter[],
+  overrideFilters: GlobalFilter[]
+): GlobalFilter[] {
+  const overridesByKey = new Map(
+    overrideFilters.map(f => [`${f.tag.key}:${f.dataset}`, f])
+  );
+  const usedKeys = new Set<string>();
+
+  const merged = baseFilters.map(f => {
+    const key = `${f.tag.key}:${f.dataset}`;
+    const override = overridesByKey.get(key);
+    if (override) {
+      usedKeys.add(key);
+      return override;
+    }
+    return f;
+  });
+
+  for (const f of overrideFilters) {
+    if (!usedKeys.has(`${f.tag.key}:${f.dataset}`)) {
+      merged.push(f);
+    }
+  }
+
+  return merged;
+}
+
 export function getFieldDefinitionForDataset(
   tag: Tag,
   datasetType: WidgetType

--- a/static/app/views/dashboards/orgDashboards.spec.tsx
+++ b/static/app/views/dashboards/orgDashboards.spec.tsx
@@ -10,6 +10,11 @@ import {
 
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {OrgDashboards} from 'sentry/views/dashboards/orgDashboards';
+import {WidgetType} from 'sentry/views/dashboards/types';
+import {
+  PREBUILT_DASHBOARDS,
+  PrebuiltDashboardId,
+} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 
 describe('OrgDashboards', () => {
   const organization = OrganizationFixture({
@@ -226,6 +231,88 @@ describe('OrgDashboards', () => {
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
     expect(router.location.query).toEqual({});
+  });
+
+  it('uses prebuilt globalFilter when saved dashboard has none', async () => {
+    const prebuiltConfig = PREBUILT_DASHBOARDS[PrebuiltDashboardId.FRONTEND_ASSETS];
+    const mockPrebuiltDashboard = {
+      dateCreated: '2021-08-10T21:20:46.798237Z',
+      id: '1',
+      title: 'Frontend Assets',
+      widgets: [],
+      projects: [],
+      filters: {},
+      prebuiltId: PrebuiltDashboardId.FRONTEND_ASSETS,
+    };
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/dashboards/1/',
+      method: 'GET',
+      body: mockPrebuiltDashboard,
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/dashboards/',
+      body: [mockPrebuiltDashboard],
+    });
+
+    let receivedDashboard: any;
+    render(
+      <OrgDashboards>
+        {({dashboard}) => {
+          receivedDashboard = dashboard;
+          return <div>Test</div>;
+        }}
+      </OrgDashboards>,
+      {initialRouterConfig, organization}
+    );
+
+    await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
+
+    expect(receivedDashboard?.filters?.globalFilter).toEqual(
+      prebuiltConfig.filters.globalFilter
+    );
+  });
+
+  it('uses saved globalFilter when the user has customized filters', async () => {
+    const savedGlobalFilter = [
+      {
+        dataset: WidgetType.SPANS,
+        tag: {key: 'custom.tag', name: 'custom.tag', kind: 'tag' as const},
+        value: 'custom.tag:foo',
+      },
+    ];
+    const mockPrebuiltDashboard = {
+      dateCreated: '2021-08-10T21:20:46.798237Z',
+      id: '1',
+      title: 'Frontend Assets',
+      widgets: [],
+      projects: [],
+      filters: {globalFilter: savedGlobalFilter},
+      prebuiltId: PrebuiltDashboardId.FRONTEND_ASSETS,
+    };
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/dashboards/1/',
+      method: 'GET',
+      body: mockPrebuiltDashboard,
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/dashboards/',
+      body: [mockPrebuiltDashboard],
+    });
+
+    let receivedDashboard: any;
+    render(
+      <OrgDashboards>
+        {({dashboard}) => {
+          receivedDashboard = dashboard;
+          return <div>Test</div>;
+        }}
+      </OrgDashboards>,
+      {initialRouterConfig, organization}
+    );
+
+    await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
+
+    expect(receivedDashboard?.filters?.globalFilter).toEqual(savedGlobalFilter);
   });
 
   it('applies saved filters after navigating back from a dashboard without filters', async () => {

--- a/static/app/views/dashboards/orgDashboards.spec.tsx
+++ b/static/app/views/dashboards/orgDashboards.spec.tsx
@@ -10,7 +10,6 @@ import {
 
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {OrgDashboards} from 'sentry/views/dashboards/orgDashboards';
-import {WidgetType} from 'sentry/views/dashboards/types';
 import {
   PREBUILT_DASHBOARDS,
   PrebuiltDashboardId,
@@ -272,21 +271,22 @@ describe('OrgDashboards', () => {
     );
   });
 
-  it('uses saved globalFilter when the user has customized filters', async () => {
-    const savedGlobalFilter = [
-      {
-        dataset: WidgetType.SPANS,
-        tag: {key: 'custom.tag', name: 'custom.tag', kind: 'tag' as const},
-        value: 'custom.tag:foo',
-      },
-    ];
+  it('merges saved globalFilter with prebuilt filters', async () => {
+    const prebuiltConfig = PREBUILT_DASHBOARDS[PrebuiltDashboardId.FRONTEND_ASSETS];
+    const prebuiltGlobalFilters = prebuiltConfig.filters.globalFilter!;
+
+    // Override one of the prebuilt filters with a saved value
+    const overriddenFilter = {
+      ...prebuiltGlobalFilters[0]!,
+      value: `${prebuiltGlobalFilters[0]!.tag.key}:custom-value`,
+    };
     const mockPrebuiltDashboard = {
       dateCreated: '2021-08-10T21:20:46.798237Z',
       id: '1',
       title: 'Frontend Assets',
       widgets: [],
       projects: [],
-      filters: {globalFilter: savedGlobalFilter},
+      filters: {globalFilter: [overriddenFilter]},
       prebuiltId: PrebuiltDashboardId.FRONTEND_ASSETS,
     };
     MockApiClient.addMockResponse({
@@ -312,7 +312,11 @@ describe('OrgDashboards', () => {
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
 
-    expect(receivedDashboard?.filters?.globalFilter).toEqual(savedGlobalFilter);
+    const resultFilters = receivedDashboard?.filters?.globalFilter;
+    // The overridden filter replaces its prebuilt match
+    expect(resultFilters).toContainEqual(overriddenFilter);
+    // The remaining prebuilt filters are still present
+    expect(resultFilters).toHaveLength(prebuiltGlobalFilters.length);
   });
 
   it('applies saved filters after navigating back from a dashboard without filters', async () => {

--- a/static/app/views/dashboards/orgDashboards.tsx
+++ b/static/app/views/dashboards/orgDashboards.tsx
@@ -18,7 +18,6 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
-import {PREBUILT_DASHBOARDS} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import {useGetPrebuiltDashboard} from 'sentry/views/dashboards/utils/usePopulateLinkedDashboards';
 
 import {assignTempId} from './layoutUtils';
@@ -91,10 +90,9 @@ export function OrgDashboards({children, initialDashboard}: OrgDashboardsProps) 
   // If the dashboard is a prebuilt dashboard, merge the prebuilt dashboard data into the selected dashboard.
   // Preserve user-saved state (filters and page filters) from the DB record so changes persist.
   if (selectedDashboard?.prebuiltId) {
-    const prebuiltConfig = PREBUILT_DASHBOARDS[selectedDashboard.prebuiltId];
     const globalFilter = selectedDashboard.filters?.globalFilter?.length
       ? selectedDashboard.filters.globalFilter
-      : prebuiltConfig?.filters?.globalFilter;
+      : prebuiltDashboard?.filters?.globalFilter;
 
     selectedDashboard = {
       ...selectedDashboard,

--- a/static/app/views/dashboards/orgDashboards.tsx
+++ b/static/app/views/dashboards/orgDashboards.tsx
@@ -18,6 +18,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
+import {PREBUILT_DASHBOARDS} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 import {useGetPrebuiltDashboard} from 'sentry/views/dashboards/utils/usePopulateLinkedDashboards';
 
 import {assignTempId} from './layoutUtils';
@@ -90,11 +91,16 @@ export function OrgDashboards({children, initialDashboard}: OrgDashboardsProps) 
   // If the dashboard is a prebuilt dashboard, merge the prebuilt dashboard data into the selected dashboard.
   // Preserve user-saved state (filters and page filters) from the DB record so changes persist.
   if (selectedDashboard?.prebuiltId) {
+    const prebuiltConfig = PREBUILT_DASHBOARDS[selectedDashboard.prebuiltId];
+    const globalFilter = selectedDashboard.filters?.globalFilter?.length
+      ? selectedDashboard.filters.globalFilter
+      : prebuiltConfig?.filters?.globalFilter;
+
     selectedDashboard = {
       ...selectedDashboard,
       ...prebuiltDashboard,
       id: selectedDashboard.id,
-      filters: selectedDashboard.filters,
+      filters: {...selectedDashboard.filters, globalFilter},
       projects: selectedDashboard.projects,
       environment: selectedDashboard.environment,
       period: selectedDashboard.period,

--- a/static/app/views/dashboards/orgDashboards.tsx
+++ b/static/app/views/dashboards/orgDashboards.tsx
@@ -20,6 +20,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useGetPrebuiltDashboard} from 'sentry/views/dashboards/utils/usePopulateLinkedDashboards';
 
+import {mergeGlobalFilters} from './globalFilter/utils';
 import {assignTempId} from './layoutUtils';
 import type {DashboardDetails, DashboardListItem} from './types';
 import {getCurrentPageFilters, hasSavedPageFilters} from './utils';
@@ -90,9 +91,9 @@ export function OrgDashboards({children, initialDashboard}: OrgDashboardsProps) 
   // If the dashboard is a prebuilt dashboard, merge the prebuilt dashboard data into the selected dashboard.
   // Preserve user-saved state (filters and page filters) from the DB record so changes persist.
   if (selectedDashboard?.prebuiltId) {
-    const globalFilter = selectedDashboard.filters?.globalFilter?.length
-      ? selectedDashboard.filters.globalFilter
-      : prebuiltDashboard?.filters?.globalFilter;
+    const prebuiltGlobalFilters = prebuiltDashboard?.filters?.globalFilter ?? [];
+    const savedGlobalFilters = selectedDashboard.filters?.globalFilter ?? [];
+    const globalFilter = mergeGlobalFilters(prebuiltGlobalFilters, savedGlobalFilters);
 
     selectedDashboard = {
       ...selectedDashboard,

--- a/static/app/views/dashboards/orgDashboards.tsx
+++ b/static/app/views/dashboards/orgDashboards.tsx
@@ -98,7 +98,7 @@ export function OrgDashboards({children, initialDashboard}: OrgDashboardsProps) 
       ...selectedDashboard,
       ...prebuiltDashboard,
       id: selectedDashboard.id,
-      filters: {...selectedDashboard.filters, globalFilter},
+      filters: {release: selectedDashboard.filters?.release, globalFilter},
       projects: selectedDashboard.projects,
       environment: selectedDashboard.environment,
       period: selectedDashboard.period,

--- a/static/app/views/dashboards/orgDashboards.tsx
+++ b/static/app/views/dashboards/orgDashboards.tsx
@@ -98,7 +98,7 @@ export function OrgDashboards({children, initialDashboard}: OrgDashboardsProps) 
       ...selectedDashboard,
       ...prebuiltDashboard,
       id: selectedDashboard.id,
-      filters: {release: selectedDashboard.filters?.release, globalFilter},
+      filters: {...selectedDashboard.filters, globalFilter},
       projects: selectedDashboard.projects,
       environment: selectedDashboard.environment,
       period: selectedDashboard.period,

--- a/static/app/views/dashboards/prebuiltDashboardRenderer.tsx
+++ b/static/app/views/dashboards/prebuiltDashboardRenderer.tsx
@@ -26,6 +26,7 @@ import {
 } from 'sentry/views/dashboards/types';
 import {useGetPrebuiltDashboard} from 'sentry/views/dashboards/utils/usePopulateLinkedDashboards';
 
+import {mergeGlobalFilters} from './globalFilter/utils';
 import {PREBUILT_DASHBOARDS, PrebuiltDashboardId} from './utils/prebuiltConfigs';
 
 type PrebuiltDashboardRendererProps = {
@@ -80,32 +81,13 @@ export function PrebuiltDashboardRenderer({
   const {title, filters} = prebuiltDashboard;
   const widgets = populatedPrebuiltDashboard?.widgets ?? prebuiltDashboard.widgets;
 
-  // Merge the dashboard's built-in filters with any additional global filters.
-  // Overrides replace matching filters in-place (by tag key + dataset) to preserve order.
-  // Filters with no match in the base list are appended at the end.
   const mergedFilters: DashboardFilters = {...filters};
 
   if (additionalGlobalFilters) {
-    const filterKey = (f: GlobalFilter) => `${f.tag.key}:${f.dataset}`;
-    const overridesByKey = new Map(additionalGlobalFilters.map(f => [filterKey(f), f]));
-    const usedKeys = new Set<string>();
-
-    const baseFilters = filters?.globalFilter ?? [];
-    mergedFilters.globalFilter = baseFilters.map(f => {
-      const override = overridesByKey.get(filterKey(f));
-      if (override) {
-        usedKeys.add(filterKey(f));
-        return override;
-      }
-      return f;
-    });
-
-    // Append any additional filters that didn't match a base filter
-    for (const f of additionalGlobalFilters) {
-      if (!usedKeys.has(filterKey(f))) {
-        mergedFilters.globalFilter.push(f);
-      }
-    }
+    mergedFilters.globalFilter = mergeGlobalFilters(
+      filters?.globalFilter ?? [],
+      additionalGlobalFilters
+    );
   }
 
   const dashboard: DashboardDetails = {


### PR DESCRIPTION
When a prebuilt dashboard is loaded from the DB via `OrgDashboards`, the saved filters were used directly (`filters: selectedDashboard.filters`), discarding the prebuilt config's `globalFilter`. If the user never customized filters, the DB record has no `globalFilter`, so built-in constraints like the `span.op` resource type filter were lost — causing the Frontend Assets dashboard to show non-asset data (e.g. queries).

Falls back to the prebuilt config's `globalFilter` when the saved dashboard has none. If saved global filters exist, they're used as-is (no merging) to correctly handle cases where the user explicitly removed a filter.

Fixes DAIN-1558