### PR TITLE
fix(codeBlock): Contain codeblock tabs row on narrow viewports

### DIFF
--- a/static/app/components/core/code/codeBlock.tsx
+++ b/static/app/components/core/code/codeBlock.tsx
@@ -271,6 +271,7 @@ const FileName = styled('span')`
 const TabsWrapper = styled('div')`
   padding: 0;
   display: flex;
+  overflow-x: scroll;
 `;
 
 const Tab = styled('button')<{isSelected: boolean}>`

--- a/static/app/components/core/code/codeBlock.tsx
+++ b/static/app/components/core/code/codeBlock.tsx
@@ -271,7 +271,7 @@ const FileName = styled('span')`
 const TabsWrapper = styled('div')`
   padding: 0;
   display: flex;
-  overflow-x: scroll;
+  overflow-x: auto;
 `;
 
 const Tab = styled('button')<{isSelected: boolean}>`


### PR DESCRIPTION
## Summary

- Add `overflow-x: auto` to `TabsWrapper` in `codeBlock.tsx` so the tab strip stays within its parent width.
- On mobile and other constrained widths the tab row could otherwise stretch past the container and distort the surrounding layout.

**before**:
<img width="250" alt="Screenshot 2026-04-20 at 12 38 39 PM" src="https://github.com/user-attachments/assets/b708be8f-8636-4888-b5e4-61ad52809c21" />

<img width="250" alt="Screenshot 2026-04-20 at 12 38 45 PM" src="https://github.com/user-attachments/assets/ea2baa4c-ae4d-470d-a9da-d5bc6427fd2c" />




**after**:

<img width="250" alt="Screenshot 2026-04-20 at 12 38 24 PM" src="https://github.com/user-attachments/assets/8a337a4f-74c3-4d6f-80aa-f13f4e312df5" />


## Test plan

- [ ] Open a page that renders a `CodeBlock` with multiple file tabs.
- [ ] Resize the viewport to a narrow width (or open on mobile).
- [ ] Confirm the tab strip stays contained, scrolls horizontally within the block, and the surrounding page layout is unaffected.