### PR TITLE
fix(explore): Handle nullable aggregations in equations

### DIFF
--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -1327,11 +1327,37 @@ class SearchResolver:
         if isinstance(proto_definition, AttributeKey):
             return Column(key=proto_definition), contexts
 
+        # Because all aggregations in snuba by default have orNull on them, when an aggregate evaluates to 0 instead it
+        # becomes null. This is a problem with equations on aggregates since any operation on a null value in clickhouse
+        # resolves to null, so if one term of your equation is null the entire equation becomes null. Instead we want to
+        # treat these nulls like 0 to do this for an equation like (a + b), where a may be null sometimes we change the
+        # equation instead to be ((a + 0) + (b + 0)) and use the default_value option on BinaryFormulas so that when a
+        # is null instead we get 0 + b as expected instead of null + b
         if isinstance(proto_definition, AttributeAggregation):
-            return Column(aggregation=proto_definition), contexts
+            return (
+                Column(
+                    formula=Column.BinaryFormula(
+                        op=constants.ARITHMETIC_OPERATOR_MAP["plus"],
+                        left=Column(literal=LiteralValue(val_double=0)),
+                        right=Column(aggregation=proto_definition),
+                        default_value_double=0,
+                    )
+                ),
+                contexts,
+            )
 
         if isinstance(proto_definition, AttributeConditionalAggregation):
-            return Column(conditional_aggregation=proto_definition), contexts
+            return (
+                Column(
+                    formula=Column.BinaryFormula(
+                        op=constants.ARITHMETIC_OPERATOR_MAP["plus"],
+                        left=Column(literal=LiteralValue(val_double=0)),
+                        right=Column(conditional_aggregation=proto_definition),
+                        default_value_double=0,
+                    )
+                ),
+                contexts,
+            )
 
         if isinstance(proto_definition, Column.BinaryFormula):
             return Column(formula=proto_definition), contexts

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_trace_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_trace_metrics.py
@@ -3,7 +3,9 @@ from datetime import timedelta
 from django.urls import reverse
 
 from sentry.testutils.helpers.datetime import before_now
-from tests.snuba.api.endpoints.test_organization_events import OrganizationEventsEndpointTestBase
+from tests.snuba.api.endpoints.test_organization_events import (
+    OrganizationEventsEndpointTestBase,
+)
 from tests.snuba.api.endpoints.test_organization_events_timeseries_spans import (
     AnyConfidence,
     build_expected_timeseries,
@@ -365,10 +367,18 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
         trace_metrics = [
             self.create_trace_metric("request_count", 1, "counter", timestamp=self.start),
             self.create_trace_metric(
-                "request_count", 1, "counter", metric_unit="millisecond", timestamp=self.start
+                "request_count",
+                1,
+                "counter",
+                metric_unit="millisecond",
+                timestamp=self.start,
             ),
             self.create_trace_metric(
-                "request_count", 1, "counter", metric_unit="millisecond", timestamp=self.start
+                "request_count",
+                1,
+                "counter",
+                metric_unit="millisecond",
+                timestamp=self.start,
             ),
         ]
         self.store_eap_items(trace_metrics)
@@ -394,10 +404,18 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
         trace_metrics = [
             self.create_trace_metric("request_count", 1, "counter", timestamp=self.start),
             self.create_trace_metric(
-                "request_count", 1, "counter", metric_unit="second", timestamp=self.start
+                "request_count",
+                1,
+                "counter",
+                metric_unit="second",
+                timestamp=self.start,
             ),
             self.create_trace_metric(
-                "request_count", 1, "counter", metric_unit="millisecond", timestamp=self.start
+                "request_count",
+                1,
+                "counter",
+                metric_unit="millisecond",
+                timestamp=self.start,
             ),
             self.create_trace_metric(
                 "request_count", 1, "counter", metric_unit="byte", timestamp=self.start
@@ -426,10 +444,18 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
         trace_metrics = [
             self.create_trace_metric("request_count", 1, "counter", timestamp=self.start),
             self.create_trace_metric(
-                "request_count", 1, "counter", metric_unit="second", timestamp=self.start
+                "request_count",
+                1,
+                "counter",
+                metric_unit="second",
+                timestamp=self.start,
             ),
             self.create_trace_metric(
-                "request_count", 1, "counter", metric_unit="millisecond", timestamp=self.start
+                "request_count",
+                1,
+                "counter",
+                metric_unit="millisecond",
+                timestamp=self.start,
             ),
             self.create_trace_metric(
                 "request_count", 1, "counter", metric_unit="byte", timestamp=self.start
@@ -453,3 +479,43 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
 
         # only the metrics with a unit of none should be counted
         assert response.data["timeSeries"][0]["values"][0]["value"] == 1
+
+    def test_equation_where_one_term_has_no_data(self):
+        trace_metrics = []
+        for hour in range(5):
+            trace_metrics.append(
+                self.create_trace_metric(
+                    "request_count",
+                    1,
+                    "counter",
+                    metric_unit="requests",
+                    timestamp=self.start + timedelta(hours=hour),
+                )
+            )
+            if hour != 3:
+                trace_metrics.append(
+                    self.create_trace_metric(
+                        "request_count.error",
+                        1,
+                        "counter",
+                        metric_unit="requests",
+                        timestamp=self.start + timedelta(hours=hour),
+                    )
+                )
+        self.store_eap_items(trace_metrics)
+
+        response = self._do_request(
+            data={
+                "start": self.start,
+                "end": self.start + timedelta(hours=5),
+                "interval": "1h",
+                "yAxis": "equation|count(value,request_count.error,counter,requests) + count(value,request_count,counter,requests)",
+                "project": self.project.id,
+                "dataset": "tracemetrics",
+            },
+        )
+        assert response.status_code == 200, response.content
+        timeseries = response.data["timeSeries"][0]
+        assert timeseries["values"] == build_expected_timeseries(
+            self.start, 3_600_000, [2, 2, 2, 1, 2], ignore_accuracy=True
+        )


### PR DESCRIPTION
- This is a hack into the equations so that we can do arithmetic on potentially nullable values in a reasonable and expected way instead of just getting 0 unexpectedly
- Ideally instead snuba can handle 0-able values in a reasonable way, but in the meantime lets do this
- Because all aggregations in snuba by default have orNull on them, when an aggregate evaluates to 0 instead it becomes null. This is a problem with equations on aggregates since any operation on a null value in clickhouse resolves to null, so if one term of your equation is null the entire equation becomes null. Instead we want to treat these nulls like 0 to do this for an equation like (a + b), where a may be null sometimes we change the equation instead to be ((a + 0) + (b + 0)) and use the default_value option on BinaryFormulas so that when a is null instead we get 0 + b as expected instead of null + b