### PR TITLE
fix(seer): Handle SeerApiError in Explorer chat endpoint

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 
+import sentry_sdk
 from rest_framework import serializers
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
@@ -19,7 +20,7 @@ from sentry.seer.explorer.client_utils import (
     has_seer_explorer_access_with_detail,
     snapshot_to_markdown,
 )
-from sentry.seer.models import SeerPermissionError
+from sentry.seer.models import SeerApiError, SeerPermissionError
 from sentry.seer.seer_setup import has_seer_access_with_detail
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.utils import json
@@ -119,6 +120,14 @@ class OrganizationSeerExplorerChatEndpoint(OrganizationEndpoint):
             return Response({"session": state.dict()})
         except SeerPermissionError as e:
             raise PermissionDenied(e.message) from e
+        except SeerApiError as e:
+            sentry_sdk.capture_exception(e)
+            if e.status == 404:
+                return Response({"session": None}, status=404)
+            return Response(
+                {"detail": "Failed to fetch run state"},
+                status=500,
+            )
         except ValueError:
             logger.exception("Error getting Explorer run state")
             return Response({"session": None}, status=404)
@@ -215,3 +224,9 @@ class OrganizationSeerExplorerChatEndpoint(OrganizationEndpoint):
             return Response({"run_id": result_run_id})
         except SeerPermissionError as e:
             raise PermissionDenied(e.message) from e
+        except SeerApiError as e:
+            sentry_sdk.capture_exception(e)
+            return Response(
+                {"detail": "Failed to start or continue chat session"},
+                status=500,
+            )


### PR DESCRIPTION
Catch `SeerApiError` in both the GET and POST handlers of the Explorer chat endpoint. Previously the exception bubbled up unhandled to the global Django REST Framework exception handler, which returned a generic error response.

With this fix:
- Seer 404s on GET return `{"session": None}` with 404, matching the response shape the frontend already expects from other error paths
- Other Seer errors on GET return `{"detail": "Failed to fetch run state"}` with 500, giving the frontend a structured error message
- Seer errors on POST return `{"detail": "Failed to start or continue chat session"}` with 500, which the frontend displays in a toast via `e.responseJSON.detail`
- All errors are still reported to Sentry via `sentry_sdk.capture_exception()` for continued visibility

Fixes SENTRY-5MVK