### PR TITLE
fix(metrics): Prevent page scroll when opening metric selector

### DIFF
--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -248,6 +248,7 @@ export function MetricSelector({
         if (scrollElementRef.current) {
           scrollElementRef.current.scrollTop = 0;
         }
+        searchRef.current?.focus({preventScroll: true});
       });
       return;
     }
@@ -446,7 +447,6 @@ export function MetricSelector({
                         {...comboBoxInputProps}
                         placeholder={t('Search metrics\u2026')}
                         size="xs"
-                        autoFocus
                         ref={searchRef}
                       />
                     </InputGroup>


### PR DESCRIPTION
Introduce our own focus logic to prevent the page from scrolling when the trace metrics selector dropdown is opened. 