### PR TITLE
chore(ACI): Replace multiple flag usage with single flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -457,9 +457,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Use workflow engine exclusively for OrganizationCombinedRuleIndexEndpoint.get results.
     # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
     manager.add("organizations:workflow-engine-combinedruleindex-get", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Use workflow engine exclusively for OrganizationIncidentDetailsEndpoint.get results.
-    # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
-    manager.add("organizations:workflow-engine-orgincidentdetails-get", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Use workflow engine exclusively for legacy issue alert rule.get results.
     # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
     manager.add("organizations:workflow-engine-issue-alert-endpoints-get", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
@@ -469,26 +466,11 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Use workflow engine exclusively for legacy issue alert rule.delete
     # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
     manager.add("organizations:workflow-engine-issue-alert-endpoints-delete", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Use workflow engine exclusively for OrganizationIncidentIndexEndpoint.get results.
-    # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
-    manager.add("organizations:workflow-engine-orgincidentindex-get", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Use workflow engine exclusively for OrganizationAlertRuleDetailsEndpoint.get results.
-    # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
-    manager.add("organizations:workflow-engine-orgalertruledetails-get", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Use workflow engine exclusively for OrganizationAlertRuleDetailsEndpoint.delete.
     # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
     manager.add("organizations:workflow-engine-orgalertruledetails-delete", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable metric detector limits by plan type
     manager.add("organizations:workflow-engine-metric-detector-limit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Use workflow engine exclusively for OrganizationAlertRuleIndexEndpoint.get results.
-    # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
-    manager.add("organizations:workflow-engine-orgalertruleindex-get", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Use workflow engine exclusively for ProjectAlertRuleIndexEndpoint.get results.
-    # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
-    manager.add("organizations:workflow-engine-projectalertruleindex-get", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Use workflow engine exclusively for ProjectAlertRuleDetailsEndpoint.get results.
-    # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
-    manager.add("organizations:workflow-engine-projectalertruledetails-get", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable EventUniqueUserFrequencyConditionWithConditions special alert condition
     manager.add("organizations:event-unique-user-frequency-condition-with-conditions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable our logs product (known internally as ourlogs) in UI and backend

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -337,7 +337,7 @@ def _check_project_access[T](
 @cell_silo_endpoint
 class OrganizationAlertRuleDetailsEndpoint(WorkflowEngineOrganizationAlertRuleEndpoint):
     workflow_engine_method_flags = {
-        "GET": "organizations:workflow-engine-orgalertruledetails-get",
+        "GET": "organizations:organizations:workflow-engine-metric-alert-endpoints-get",
         "DELETE": "organizations:workflow-engine-orgalertruledetails-delete",
     }
     owner = ApiOwner.ISSUES

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -337,7 +337,7 @@ def _check_project_access[T](
 @cell_silo_endpoint
 class OrganizationAlertRuleDetailsEndpoint(WorkflowEngineOrganizationAlertRuleEndpoint):
     workflow_engine_method_flags = {
-        "GET": "organizations:organizations:workflow-engine-metric-alert-endpoints-get",
+        "GET": "organizations:workflow-engine-metric-alert-endpoints-get",
         "DELETE": "organizations:workflow-engine-orgalertruledetails-delete",
     }
     owner = ApiOwner.ISSUES

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -916,7 +916,7 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationAlertRuleBaseEndpoint, Aler
     }
     permission_classes = (OrganizationAlertRulePermission,)
     workflow_engine_method_flags = {
-        "GET": "organizations:workflow-engine-orgalertruleindex-get",
+        "GET": "organizations:organizations:workflow-engine-metric-alert-endpoints-get",
     }
 
     @extend_schema(

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -916,7 +916,7 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationAlertRuleBaseEndpoint, Aler
     }
     permission_classes = (OrganizationAlertRulePermission,)
     workflow_engine_method_flags = {
-        "GET": "organizations:organizations:workflow-engine-metric-alert-endpoints-get",
+        "GET": "organizations:workflow-engine-metric-alert-endpoints-get",
     }
 
     @extend_schema(

--- a/src/sentry/incidents/endpoints/organization_incident_details.py
+++ b/src/sentry/incidents/endpoints/organization_incident_details.py
@@ -73,7 +73,7 @@ class OrganizationIncidentDetailsEndpoint(IncidentEndpoint):
             raise ResourceDoesNotExist
 
         has_workflow_engine_flags = features.has(
-            "organizations:workflow-engine-orgincidentdetails-get", organization
+            "organizations:organizations:workflow-engine-metric-alert-endpoints-get", organization
         ) or features.has("organizations:workflow-engine-rule-serializers", organization)
 
         if request.method == "GET" and has_workflow_engine_flags:

--- a/src/sentry/incidents/endpoints/organization_incident_details.py
+++ b/src/sentry/incidents/endpoints/organization_incident_details.py
@@ -73,7 +73,7 @@ class OrganizationIncidentDetailsEndpoint(IncidentEndpoint):
             raise ResourceDoesNotExist
 
         has_workflow_engine_flags = features.has(
-            "organizations:organizations:workflow-engine-metric-alert-endpoints-get", organization
+            "organizations:workflow-engine-metric-alert-endpoints-get", organization
         ) or features.has("organizations:workflow-engine-rule-serializers", organization)
 
         if request.method == "GET" and has_workflow_engine_flags:

--- a/src/sentry/incidents/endpoints/organization_incident_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_index.py
@@ -81,7 +81,9 @@ class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
 
         use_workflow_engine = features.has(
             "organizations:workflow-engine-rule-serializers", organization
-        ) or features.has("organizations:workflow-engine-orgincidentindex-get", organization)
+        ) or features.has(
+            "organizations:organizations:workflow-engine-metric-alert-endpoints-get", organization
+        )
 
         if use_workflow_engine:
             return self._get_workflow_engine(

--- a/src/sentry/incidents/endpoints/organization_incident_index.py
+++ b/src/sentry/incidents/endpoints/organization_incident_index.py
@@ -81,9 +81,7 @@ class OrganizationIncidentIndexEndpoint(OrganizationEndpoint):
 
         use_workflow_engine = features.has(
             "organizations:workflow-engine-rule-serializers", organization
-        ) or features.has(
-            "organizations:organizations:workflow-engine-metric-alert-endpoints-get", organization
-        )
+        ) or features.has("organizations:workflow-engine-metric-alert-endpoints-get", organization)
 
         if use_workflow_engine:
             return self._get_workflow_engine(

--- a/src/sentry/incidents/endpoints/project_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_details.py
@@ -25,7 +25,7 @@ class ProjectAlertRuleDetailsEndpoint(WorkflowEngineProjectAlertRuleEndpoint):
         "PUT": ApiPublishStatus.EXPERIMENTAL,
     }
     workflow_engine_method_flags = {
-        "GET": "organizations:organizations:workflow-engine-metric-alert-endpoints-get",
+        "GET": "organizations:workflow-engine-metric-alert-endpoints-get",
     }
 
     @track_alert_endpoint_execution("GET", "sentry-api-0-project-alert-rule-details")

--- a/src/sentry/incidents/endpoints/project_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_details.py
@@ -25,7 +25,7 @@ class ProjectAlertRuleDetailsEndpoint(WorkflowEngineProjectAlertRuleEndpoint):
         "PUT": ApiPublishStatus.EXPERIMENTAL,
     }
     workflow_engine_method_flags = {
-        "GET": "organizations:workflow-engine-projectalertruledetails-get",
+        "GET": "organizations:organizations:workflow-engine-metric-alert-endpoints-get",
     }
 
     @track_alert_endpoint_execution("GET", "sentry-api-0-project-alert-rule-details")

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -23,7 +23,7 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint, AlertRuleFetchMixin):
     }
     permission_classes = (ProjectAlertRulePermission,)
     workflow_engine_method_flags = {
-        "GET": "organizations:organizations:workflow-engine-metric-alert-endpoints-get",
+        "GET": "organizations:workflow-engine-metric-alert-endpoints-get",
     }
 
     @track_alert_endpoint_execution("GET", "sentry-api-0-project-alert-rules")

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -23,7 +23,7 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint, AlertRuleFetchMixin):
     }
     permission_classes = (ProjectAlertRulePermission,)
     workflow_engine_method_flags = {
-        "GET": "organizations:workflow-engine-projectalertruleindex-get",
+        "GET": "organizations:organizations:workflow-engine-metric-alert-endpoints-get",
     }
 
     @track_alert_endpoint_execution("GET", "sentry-api-0-project-alert-rules")

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -160,7 +160,7 @@ class AlertRuleDetailsGetDeltaTest(AlertRuleDetailsBase):
 @with_feature(
     [
         "organizations:incidents",
-        "organizations:organizations:workflow-engine-metric-alert-endpoints-get",
+        "organizations:workflow-engine-metric-alert-endpoints-get",
     ]
 )
 class AlertRuleDetailsGetEndpointWorkflowEngineMethodFlagTest(AlertRuleDetailsBase):

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_details.py
@@ -158,7 +158,10 @@ class AlertRuleDetailsGetDeltaTest(AlertRuleDetailsBase):
 
 
 @with_feature(
-    ["organizations:incidents", "organizations:workflow-engine-projectalertruledetails-get"]
+    [
+        "organizations:incidents",
+        "organizations:organizations:workflow-engine-metric-alert-endpoints-get",
+    ]
 )
 class AlertRuleDetailsGetEndpointWorkflowEngineMethodFlagTest(AlertRuleDetailsBase):
     """Verify that the per-method flag alone (without the broad rule-serializers flag)

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -79,7 +79,10 @@ class AlertRuleListDeltaTest(APITestCase):
 
 
 @with_feature(
-    ["organizations:incidents", "organizations:workflow-engine-projectalertruleindex-get"]
+    [
+        "organizations:incidents",
+        "organizations:organizations:workflow-engine-metric-alert-endpoints-get",
+    ]
 )
 class AlertRuleListEndpointWorkflowEngineMethodFlagTest(APITestCase):
     """Verify that the per-method flag alone (without the broad rule-serializers flag)

--- a/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_project_alert_rule_index.py
@@ -81,7 +81,7 @@ class AlertRuleListDeltaTest(APITestCase):
 @with_feature(
     [
         "organizations:incidents",
-        "organizations:organizations:workflow-engine-metric-alert-endpoints-get",
+        "organizations:workflow-engine-metric-alert-endpoints-get",
     ]
 )
 class AlertRuleListEndpointWorkflowEngineMethodFlagTest(APITestCase):


### PR DESCRIPTION
Condense 6 flags into 1 - all of these are individually GA'd and the replacement flag is GA'd too (once https://github.com/getsentry/sentry-options-automator/pull/7370 is merged). 