### PR TITLE
feat(seer): Add get_metric_metadata RPC for Seer metrics agent

### DIFF
--- a/src/sentry/seer/assisted_query/metrics_tools.py
+++ b/src/sentry/seer/assisted_query/metrics_tools.py
@@ -71,6 +71,10 @@ def get_metric_metadata(
         {
             "candidates": [{"name", "type", "unit", "count"}, ...],
             "has_more": bool,
+            "error": str,  # present only on handler-side failure (e.g.
+                           # "organization_not_found", "events_query_failed").
+                           # Callers should treat a non-empty error as a tool
+                           # failure rather than an empty result set.
         }
     """
     substrings = [s for s in (name_substrings or []) if s][:MAX_SUBSTRINGS]
@@ -85,7 +89,7 @@ def get_metric_metadata(
         organization = Organization.objects.get(id=org_id)
     except Organization.DoesNotExist:
         logger.warning("get_metric_metadata: organization not found", extra={"org_id": org_id})
-        return {"candidates": [], "has_more": False}
+        return {"candidates": [], "has_more": False, "error": "organization_not_found"}
 
     # Over-fetch by 1 to detect has_more.
     per_page = max(1, limit) + 1
@@ -115,7 +119,7 @@ def get_metric_metadata(
             "get_metric_metadata: events query failed",
             extra={"org_id": org_id, "project_ids": project_ids},
         )
-        return {"candidates": [], "has_more": False}
+        return {"candidates": [], "has_more": False, "error": "events_query_failed"}
 
     raw_rows = (resp.data or {}).get("data") or []
 

--- a/src/sentry/seer/assisted_query/metrics_tools.py
+++ b/src/sentry/seer/assisted_query/metrics_tools.py
@@ -1,0 +1,143 @@
+import logging
+from typing import Any, TypedDict
+
+from sentry.api import client
+from sentry.constants import ALL_ACCESS_PROJECT_ID
+from sentry.models.apikey import ApiKey
+from sentry.models.organization import Organization
+from sentry.snuba.referrer import Referrer
+
+logger = logging.getLogger(__name__)
+
+API_KEY_SCOPES = ["org:read", "project:read", "event:read"]
+
+# Upper bound on how many substrings a caller may pass in a single request.
+MAX_SUBSTRINGS = 8
+
+
+class MetricMetadataRow(TypedDict):
+    name: str
+    type: str
+    unit: str
+    count: int
+
+
+def _build_or_query(name_substrings: list[str]) -> str:
+    """
+    Build a Sentry search query that matches any of the substrings against metric.name.
+
+    Uses wildcards for substring match. Substrings containing quotes are skipped
+    to avoid query-parse errors — callers should pass identifier fragments.
+    """
+    clauses: list[str] = []
+    for sub in name_substrings:
+        if '"' in sub or "\\" in sub:
+            continue
+        clauses.append(f'metric.name:"*{sub}*"')
+    if not clauses:
+        return ""
+    if len(clauses) == 1:
+        return clauses[0]
+    return "(" + " OR ".join(clauses) + ")"
+
+
+def get_metric_metadata(
+    *,
+    org_id: int,
+    project_ids: list[int],
+    name_substrings: list[str],
+    stats_period: str = "7d",
+    limit: int = 20,
+) -> dict[str, Any]:
+    """
+    Return distinct (metric.name, metric.type, metric.unit) tuples matching any of
+    the given name substrings, ordered by event count descending.
+
+    Intended for Seer's metrics assisted-query agent to short-circuit the
+    get_field_values(metric.name) + get_field_values(metric.type) discovery
+    loop with a single call that returns all three fields plus an event count
+    for tie-breaking.
+
+    Args:
+        org_id: Organization ID.
+        project_ids: Projects to query. Empty list means all accessible projects.
+        name_substrings: Up to MAX_SUBSTRINGS keyword substrings. A metric matches
+            if metric.name ILIKE %sub% for any one substring.
+        stats_period: Time window, e.g. "7d". Defaults to 7d.
+        limit: Maximum number of distinct tuples to return. Caller may over-fetch
+            to rerank on their side.
+
+    Returns:
+        {
+            "candidates": [{"name", "type", "unit", "count"}, ...],
+            "has_more": bool,
+        }
+    """
+    substrings = [s for s in (name_substrings or []) if s][:MAX_SUBSTRINGS]
+    if not substrings:
+        return {"candidates": [], "has_more": False}
+
+    query = _build_or_query(substrings)
+    if not query:
+        return {"candidates": [], "has_more": False}
+
+    try:
+        organization = Organization.objects.get(id=org_id)
+    except Organization.DoesNotExist:
+        logger.warning("get_metric_metadata: organization not found", extra={"org_id": org_id})
+        return {"candidates": [], "has_more": False}
+
+    # Over-fetch by 1 to detect has_more.
+    per_page = max(1, limit) + 1
+
+    params: dict[str, Any] = {
+        "dataset": "tracemetrics",
+        # Selecting metric.name/type/unit plus count() groups by the selected
+        # non-aggregate fields, giving us distinct tuples with event counts.
+        "field": ["metric.name", "metric.type", "metric.unit", "count()"],
+        "query": query,
+        "sort": "-count()",
+        "per_page": per_page,
+        "statsPeriod": stats_period,
+        "project": project_ids or [ALL_ACCESS_PROJECT_ID],
+        "referrer": Referrer.SEER_EXPLORER_TOOLS,
+    }
+
+    try:
+        resp = client.get(
+            auth=ApiKey(organization_id=organization.id, scope_list=API_KEY_SCOPES),
+            user=None,
+            path=f"/organizations/{organization.slug}/events/",
+            params=params,
+        )
+    except client.ApiError:
+        logger.exception(
+            "get_metric_metadata: events query failed",
+            extra={"org_id": org_id, "project_ids": project_ids},
+        )
+        return {"candidates": [], "has_more": False}
+
+    raw_rows = (resp.data or {}).get("data") or []
+
+    candidates: list[MetricMetadataRow] = []
+    for row in raw_rows:
+        name = row.get("metric.name")
+        mtype = row.get("metric.type")
+        munit = row.get("metric.unit") or "none"
+        if not name or not mtype:
+            continue
+        # count() may come back as "count()" or "count" depending on the dataset shape.
+        count = row.get("count()")
+        if count is None:
+            count = row.get("count", 0)
+        candidates.append(
+            MetricMetadataRow(
+                name=str(name),
+                type=str(mtype),
+                unit=str(munit),
+                count=int(count or 0),
+            )
+        )
+
+    has_more = len(candidates) > limit
+    return {"candidates": candidates[:limit], "has_more": has_more}

--- a/src/sentry/seer/assisted_query/metrics_tools.py
+++ b/src/sentry/seer/assisted_query/metrics_tools.py
@@ -123,6 +123,13 @@ def get_metric_metadata(
 
     raw_rows = (resp.data or {}).get("data") or []
 
+    # We over-fetch by 1 (per_page = limit + 1) specifically to detect whether
+    # Sentry has more matches than the caller asked for. That signal must be
+    # derived from what the API returned, not from what survived our local
+    # parse filter — if we filter a malformed row we would otherwise under-
+    # report `has_more` and hide the existence of further matches.
+    has_more = len(raw_rows) > limit
+
     candidates: list[MetricMetadataRow] = []
     for row in raw_rows:
         name = row.get("metric.name")
@@ -143,5 +150,4 @@ def get_metric_metadata(
             )
         )
 
-    has_more = len(candidates) > limit
     return {"candidates": candidates[:limit], "has_more": has_more}

--- a/src/sentry/seer/endpoints/organization_seer_rpc.py
+++ b/src/sentry/seer/endpoints/organization_seer_rpc.py
@@ -29,6 +29,7 @@ from sentry.seer.assisted_query.issues_tools import (
     get_issue_filter_keys,
     get_issues_stats,
 )
+from sentry.seer.assisted_query.metrics_tools import get_metric_metadata
 from sentry.seer.assisted_query.traces_tools import (
     get_attribute_names,
     get_attribute_values_with_substring,
@@ -98,6 +99,7 @@ public_org_seer_method_registry: dict[str, Callable] = {
     "get_attribute_names": map_org_id_param(get_attribute_names),
     "get_attribute_values_with_substring": map_org_id_param(get_attribute_values_with_substring),
     "get_attributes_and_values": map_org_id_param(get_attributes_and_values),
+    "get_metric_metadata": map_org_id_param(get_metric_metadata),
     "get_event_filter_keys": map_org_id_param(get_event_filter_keys),
     "get_event_filter_key_values": map_org_id_param(get_event_filter_key_values),
     "get_issue_filter_keys": map_org_id_param(get_issue_filter_keys),

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -68,6 +68,7 @@ from sentry.seer.assisted_query.issues_tools import (
     get_issue_filter_keys,
     get_issues_stats,
 )
+from sentry.seer.assisted_query.metrics_tools import get_metric_metadata
 from sentry.seer.assisted_query.traces_tools import (
     get_attribute_names,
     get_attribute_values_with_substring,
@@ -941,6 +942,7 @@ seer_method_registry: dict[str, Callable] = {  # return type must be serialized
     "get_attribute_names": get_attribute_names,
     "get_attribute_values_with_substring": get_attribute_values_with_substring,
     "get_attributes_and_values": get_attributes_and_values,
+    "get_metric_metadata": get_metric_metadata,
     "get_issue_filter_keys": get_issue_filter_keys,
     "get_filter_key_values": get_filter_key_values,
     "get_issues_stats": get_issues_stats,

--- a/src/sentry/seer/endpoints/trace_explorer_ai_translate_agentic.py
+++ b/src/sentry/seer/endpoints/trace_explorer_ai_translate_agentic.py
@@ -64,6 +64,7 @@ def send_translate_agentic_request(
     natural_language_query: str,
     strategy: str = "Traces",
     model_name: str | None = None,
+    metric_context: dict[str, Any] | None = None,
     viewer_context: SeerViewerContext | None = None,
 ) -> Any:
     """
@@ -79,6 +80,8 @@ def send_translate_agentic_request(
     options: dict[str, Any] = {}
     if model_name is not None:
         options["model_name"] = model_name
+    if metric_context is not None:
+        options["metric_context"] = metric_context
     if options:
         body["options"] = options
 
@@ -114,6 +117,7 @@ class SearchAgentTranslateEndpoint(OrganizationEndpoint):
         strategy = validated_data.get("strategy", "Traces")
         options = validated_data.get("options") or {}
         model_name = options.get("model_name")
+        metric_context = options.get("metric_context")
 
         projects = self.get_projects(
             request, organization, project_ids=set(validated_data["project_ids"])
@@ -147,6 +151,7 @@ class SearchAgentTranslateEndpoint(OrganizationEndpoint):
             natural_language_query,
             strategy=strategy,
             model_name=model_name,
+            metric_context=metric_context,
             viewer_context=viewer_context,
         )
         return Response(data)

--- a/tests/sentry/seer/assisted_query/test_metrics_tools.py
+++ b/tests/sentry/seer/assisted_query/test_metrics_tools.py
@@ -119,6 +119,46 @@ class TestGetMetricMetadata(TestCase):
         assert len(result["candidates"]) == 2
 
     @patch("sentry.seer.assisted_query.metrics_tools.client")
+    def test_has_more_uses_raw_row_count_not_filtered_count(self, mock_client: MagicMock) -> None:
+        """Regression: has_more must be computed from what Sentry returned, not
+        from what survived our local parse filter. We over-fetch by 1 specifically
+        to detect \"Sentry has more matches than you asked for\"; filtering a
+        malformed row shouldn't hide that signal from the caller."""
+        # limit=2, per_page=3. Return 3 rows where one is malformed.
+        # Post-filter: 2 candidates (== limit). Pre-filter: 3 rows (> limit).
+        # has_more must be True because Sentry had 3 matches, caller asked for 2.
+        response = MagicMock()
+        response.data = {
+            "data": [
+                {
+                    "metric.name": "a",
+                    "metric.type": "counter",
+                    "metric.unit": "none",
+                    "count()": 30,
+                },
+                # Malformed — will be filtered out locally.
+                {"metric.name": None, "metric.type": "counter", "metric.unit": "none"},
+                {
+                    "metric.name": "b",
+                    "metric.type": "counter",
+                    "metric.unit": "none",
+                    "count()": 20,
+                },
+            ]
+        }
+        mock_client.get.return_value = response
+
+        result = get_metric_metadata(
+            org_id=self.org.id,
+            project_ids=[self.project.id],
+            name_substrings=["x"],
+            limit=2,
+        )
+
+        assert result["has_more"] is True
+        assert len(result["candidates"]) == 2
+
+    @patch("sentry.seer.assisted_query.metrics_tools.client")
     def test_skips_rows_missing_name_or_type(self, mock_client: MagicMock) -> None:
         response = MagicMock()
         response.data = {

--- a/tests/sentry/seer/assisted_query/test_metrics_tools.py
+++ b/tests/sentry/seer/assisted_query/test_metrics_tools.py
@@ -1,0 +1,165 @@
+from unittest.mock import MagicMock, patch
+
+from sentry.seer.assisted_query.metrics_tools import (
+    _build_or_query,
+    get_metric_metadata,
+)
+from sentry.testutils.cases import TestCase
+
+
+class TestBuildOrQuery(TestCase):
+    def test_single_substring(self) -> None:
+        assert _build_or_query(["http"]) == 'metric.name:"*http*"'
+
+    def test_multiple_substrings_joined_with_or(self) -> None:
+        assert _build_or_query(["http", "api"]) == '(metric.name:"*http*" OR metric.name:"*api*")'
+
+    def test_rejects_substrings_with_quotes(self) -> None:
+        # Substrings containing double-quotes would break the search grammar.
+        # They should be silently dropped rather than trigger a parse error.
+        assert _build_or_query(['foo"bar']) == ""
+
+    def test_all_rejected_returns_empty(self) -> None:
+        assert _build_or_query(['"']) == ""
+
+
+class TestGetMetricMetadata(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.org = self.create_organization()
+        self.project = self.create_project(organization=self.org)
+
+    @patch("sentry.seer.assisted_query.metrics_tools.client")
+    def test_returns_distinct_tuples_with_count(self, mock_client: MagicMock) -> None:
+        response = MagicMock()
+        response.data = {
+            "data": [
+                {
+                    "metric.name": "http.request.duration",
+                    "metric.type": "distribution",
+                    "metric.unit": "millisecond",
+                    "count()": 1200,
+                },
+                {
+                    "metric.name": "api.request.count",
+                    "metric.type": "counter",
+                    "metric.unit": "none",
+                    "count()": 800,
+                },
+            ]
+        }
+        mock_client.get.return_value = response
+
+        result = get_metric_metadata(
+            org_id=self.org.id,
+            project_ids=[self.project.id],
+            name_substrings=["http", "api"],
+            stats_period="7d",
+            limit=10,
+        )
+
+        assert result["has_more"] is False
+        assert len(result["candidates"]) == 2
+        dist = result["candidates"][0]
+        assert dist["name"] == "http.request.duration"
+        assert dist["type"] == "distribution"
+        assert dist["unit"] == "millisecond"
+        assert dist["count"] == 1200
+
+        # Assert query params carry the expected shape.
+        _args, kwargs = mock_client.get.call_args
+        params = kwargs["params"]
+        assert params["dataset"] == "tracemetrics"
+        assert params["field"] == [
+            "metric.name",
+            "metric.type",
+            "metric.unit",
+            "count()",
+        ]
+        assert params["sort"] == "-count()"
+        assert params["query"] == '(metric.name:"*http*" OR metric.name:"*api*")'
+        # over-fetch by 1 to detect has_more
+        assert params["per_page"] == 11
+
+    @patch("sentry.seer.assisted_query.metrics_tools.client")
+    def test_empty_substrings_short_circuits(self, mock_client: MagicMock) -> None:
+        result = get_metric_metadata(
+            org_id=self.org.id,
+            project_ids=[self.project.id],
+            name_substrings=[],
+        )
+        assert result == {"candidates": [], "has_more": False}
+        mock_client.get.assert_not_called()
+
+    @patch("sentry.seer.assisted_query.metrics_tools.client")
+    def test_has_more_when_result_exceeds_limit(self, mock_client: MagicMock) -> None:
+        # Asking for limit=2 means we over-fetch 3. If we actually see 3, has_more=True.
+        response = MagicMock()
+        response.data = {
+            "data": [
+                {
+                    "metric.name": f"m.{i}",
+                    "metric.type": "counter",
+                    "metric.unit": "none",
+                    "count()": 100 - i,
+                }
+                for i in range(3)
+            ]
+        }
+        mock_client.get.return_value = response
+
+        result = get_metric_metadata(
+            org_id=self.org.id,
+            project_ids=[self.project.id],
+            name_substrings=["m"],
+            limit=2,
+        )
+        assert result["has_more"] is True
+        assert len(result["candidates"]) == 2
+
+    @patch("sentry.seer.assisted_query.metrics_tools.client")
+    def test_skips_rows_missing_name_or_type(self, mock_client: MagicMock) -> None:
+        response = MagicMock()
+        response.data = {
+            "data": [
+                {
+                    "metric.name": "good",
+                    "metric.type": "counter",
+                    "metric.unit": "none",
+                    "count()": 10,
+                },
+                {"metric.name": "", "metric.type": "counter", "metric.unit": "none"},
+                {"metric.name": "no-type", "metric.type": None, "metric.unit": "none"},
+            ]
+        }
+        mock_client.get.return_value = response
+
+        result = get_metric_metadata(
+            org_id=self.org.id,
+            project_ids=[self.project.id],
+            name_substrings=["x"],
+        )
+        assert len(result["candidates"]) == 1
+        assert result["candidates"][0]["name"] == "good"
+
+    @patch("sentry.seer.assisted_query.metrics_tools.client")
+    def test_missing_unit_defaults_to_none(self, mock_client: MagicMock) -> None:
+        response = MagicMock()
+        response.data = {
+            "data": [
+                {
+                    "metric.name": "foo",
+                    "metric.type": "counter",
+                    "metric.unit": None,
+                    "count()": 5,
+                }
+            ]
+        }
+        mock_client.get.return_value = response
+
+        result = get_metric_metadata(
+            org_id=self.org.id,
+            project_ids=[self.project.id],
+            name_substrings=["foo"],
+        )
+        assert result["candidates"][0]["unit"] == "none"

--- a/tests/sentry/seer/assisted_query/test_metrics_tools.py
+++ b/tests/sentry/seer/assisted_query/test_metrics_tools.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock, patch
 
+from sentry.api import client
 from sentry.seer.assisted_query.metrics_tools import (
     _build_or_query,
     get_metric_metadata,
@@ -163,3 +164,43 @@ class TestGetMetricMetadata(TestCase):
             name_substrings=["foo"],
         )
         assert result["candidates"][0]["unit"] == "none"
+
+    @patch("sentry.seer.assisted_query.metrics_tools.client")
+    def test_organization_not_found_returns_error(self, mock_client: MagicMock) -> None:
+        """Missing organization must surface as an explicit error code, not a silent
+        empty result. Seer translates the error key into success=False so Langfuse
+        traces distinguish real failures from sparse metric catalogs."""
+        # Pass a non-existent org_id; the handler should catch DoesNotExist.
+        result = get_metric_metadata(
+            org_id=99999999,
+            project_ids=[self.project.id],
+            name_substrings=["foo"],
+        )
+
+        assert result == {
+            "candidates": [],
+            "has_more": False,
+            "error": "organization_not_found",
+        }
+        # No events query should be attempted.
+        mock_client.get.assert_not_called()
+
+    @patch("sentry.seer.assisted_query.metrics_tools.client")
+    def test_events_query_failure_returns_error(self, mock_client: MagicMock) -> None:
+        """When the underlying events API raises ApiError, return an explicit
+        error code rather than a silent empty result."""
+        mock_client.ApiError = client.ApiError
+        mock_client.get.side_effect = client.ApiError(500, "snuba exploded")
+
+        result = get_metric_metadata(
+            org_id=self.org.id,
+            project_ids=[self.project.id],
+            name_substrings=["foo"],
+        )
+
+        assert result == {
+            "candidates": [],
+            "has_more": False,
+            "error": "events_query_failed",
+        }
+        mock_client.get.assert_called_once()

--- a/tests/sentry/seer/endpoints/test_trace_explorer_ai_translate_agentic.py
+++ b/tests/sentry/seer/endpoints/test_trace_explorer_ai_translate_agentic.py
@@ -52,11 +52,43 @@ class SearchAgentTranslateEndpointTest(APITestCase):
             "Find slow transactions",
             strategy="Traces",
             model_name=None,
+            metric_context=None,
             viewer_context={
                 "organization_id": self.organization.id,
                 "user_id": self.user.id,
             },
         )
+
+    @patch(
+        "sentry.seer.endpoints.trace_explorer_ai_translate_agentic.send_translate_agentic_request"
+    )
+    @patch("django.conf.settings.SEER_AUTOFIX_URL", "https://seer.example.com")
+    def test_translate_forwards_metric_context(self, mock_send_request: MagicMock) -> None:
+        """Metrics tab scopes the agent to a specific metric via options.metric_context.
+        The sync translate path must forward it like the async /start/ path does."""
+        mock_send_request.return_value = {"query": "metric.name:foo", "status": "ok"}
+
+        metric_context = {
+            "metric_name": "http.request.duration",
+            "metric_type": "distribution",
+            "metric_unit": "millisecond",
+        }
+
+        response = self.client.post(
+            self.url,
+            data={
+                "project_ids": [self.project.id],
+                "natural_language_query": "p95 of request duration",
+                "strategy": "Metrics",
+                "options": {"metric_context": metric_context},
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        _, kwargs = mock_send_request.call_args
+        assert kwargs["strategy"] == "Metrics"
+        assert kwargs["metric_context"] == metric_context
 
     def test_translate_missing_parameters(self) -> None:
         response = self.client.post(


### PR DESCRIPTION
## Summary

- Add a new cross-project RPC `get_metric_metadata(org_id, project_ids, name_substrings, stats_period, limit)` that returns distinct `(metric.name, metric.type, metric.unit)` tuples — plus per-row event counts — matching any of the provided metric-name substrings, ordered by count descending.
- Registered in both `seer_rpc.py` and `organization_seer_rpc.py`. Implemented via `/events/` with `dataset=tracemetrics`, selecting `metric.name / metric.type / metric.unit / count()` which implicitly groups by the non-aggregate fields.
- Fix an unrelated-but-adjacent bug in the sync `/search-agent/translate/` endpoint: `SearchAgentTranslateEndpoint` previously dropped `options.metric_context` (only forwarded `model_name`), so a metrics-tab fallback from async polling to the sync path would silently lose the metric scope. Signature of `send_translate_agentic_request` now accepts and forwards `metric_context`, matching the async `/search-agent/start/` path.

This is the **Sentry-side half** of adding candidate discovery to Seer's metrics agent; the Seer-side consumer lives in getsentry/seer#TBD (pushed in parallel). Seer falls back to `get_field_values` when this RPC is unavailable, so the two PRs can ship independently — but this one should land first so the Seer tool has something to call.

Refs: follow-on to #113232 (which wired the metrics tab to Seer's metrics strategy).

## Test plan

- [ ] `pytest tests/sentry/seer/assisted_query/test_metrics_tools.py -vv` — new unit tests cover query shape (`dataset=tracemetrics`, `sort=-count()`, OR-combined `metric.name:"*sub*"` clauses), tuple-level dedupe, `has_more` detection via over-fetch, and graceful handling of rows missing `metric.name` / `metric.type`.
- [ ] `pytest tests/sentry/seer/endpoints/test_trace_explorer_ai_translate_agentic.py -vv` — existing happy-path test updated to assert the new `metric_context=None` default; new test `test_translate_forwards_metric_context` verifies sync-path forwarding.
- [ ] Manual: hit `/api/0/organizations/<slug>/search-agent/translate/` with `strategy=Metrics` and `options.metric_context={…}` — confirm the payload reaching Seer carries `metric_context` in options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)