### PR TITLE
feat(integrations): track cache hit ratio by API request type

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -11,6 +11,7 @@ import sentry_sdk
 from django.core.cache import cache
 from requests import PreparedRequest
 
+from sentry import options
 from sentry.constants import ObjectStatus
 from sentry.integrations.github.blame import (
     create_blame_query,
@@ -353,6 +354,7 @@ class GitHubBaseClient(
             f"/repos/{repo}/commits",
             params={"sha": end_sha, "per_page": per_page},
             endpoint=GitHubApiEndpoint.GET_COMMITS,
+            cache_time=options.get("integrations.github.get-last-commits.cache-ttl"),
         )
 
     def compare_commits(self, repo: str, start_sha: str, end_sha: str) -> list[Any]:

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -11,7 +11,6 @@ import sentry_sdk
 from django.core.cache import cache
 from requests import PreparedRequest
 
-from sentry import options
 from sentry.constants import ObjectStatus
 from sentry.integrations.github.blame import (
     create_blame_query,
@@ -95,7 +94,7 @@ class GitHubReaction(StrEnum):
     EYES = "eyes"
 
 
-class GitHubApiEndpoint(StrEnum):
+class GitHubApiRequestType(StrEnum):
     COMPARE_COMMITS = "compare_commits"
     GET_COMMITS = "get_commits"
     GET_COMMIT = "get_commit"
@@ -353,8 +352,7 @@ class GitHubBaseClient(
         return self.get_cached(
             f"/repos/{repo}/commits",
             params={"sha": end_sha, "per_page": per_page},
-            endpoint=GitHubApiEndpoint.GET_COMMITS,
-            cache_time=options.get("integrations.github.get-last-commits.cache-ttl"),
+            api_request_type=GitHubApiRequestType.GET_COMMITS,
         )
 
     def compare_commits(self, repo: str, start_sha: str, end_sha: str) -> list[Any]:
@@ -365,7 +363,7 @@ class GitHubBaseClient(
         return self._get_with_pagination(
             f"/repos/{repo}/compare/{start_sha}...{end_sha}",
             response_key="commits",
-            endpoint=GitHubApiEndpoint.COMPARE_COMMITS,
+            api_request_type=GitHubApiRequestType.COMPARE_COMMITS,
         )
 
     def repo_hooks(self, repo: str) -> Sequence[Any]:
@@ -378,14 +376,14 @@ class GitHubBaseClient(
         """
         https://docs.github.com/en/rest/commits/commits#list-commits
         """
-        return self.get(f"/repos/{repo}/commits", endpoint=GitHubApiEndpoint.GET_COMMITS)
+        return self.get(f"/repos/{repo}/commits", api_request_type=GitHubApiRequestType.GET_COMMITS)
 
     def get_commit(self, repo: str, sha: str) -> Any:
         """
         https://docs.github.com/en/rest/commits/commits#get-a-commit
         """
         return self.get_cached(
-            f"/repos/{repo}/commits/{sha}", endpoint=GitHubApiEndpoint.GET_COMMIT
+            f"/repos/{repo}/commits/{sha}", api_request_type=GitHubApiRequestType.GET_COMMIT
         )
 
     def get_installation_info(self, installation_id: int | str) -> Any:
@@ -621,7 +619,7 @@ class GitHubBaseClient(
         path: str,
         response_key: str | None = None,
         page_number_limit: int | None = None,
-        endpoint: GitHubApiEndpoint | None = None,
+        api_request_type: GitHubApiRequestType | None = None,
     ) -> list[Any]:
         """
         Github uses the Link header to provide pagination links. Github
@@ -642,7 +640,9 @@ class GitHubBaseClient(
             output: list[dict[str, Any]] = []
 
             page_number = 1
-            resp = self.get(path, params={"per_page": self.page_size}, endpoint=endpoint)
+            resp = self.get(
+                path, params={"per_page": self.page_size}, api_request_type=api_request_type
+            )
             output.extend(resp) if not response_key else output.extend(resp[response_key])
             next_link = get_next_link(resp)
 
@@ -651,7 +651,7 @@ class GitHubBaseClient(
             while next_link and page_number < page_number_limit:
                 # If a per_page is specified, GitHub preserves the per_page value
                 # in the response headers.
-                resp = self.get(next_link, endpoint=endpoint)
+                resp = self.get(next_link, api_request_type=api_request_type)
                 output.extend(resp) if not response_key else output.extend(resp[response_key])
 
                 next_link = get_next_link(resp)
@@ -784,7 +784,7 @@ class GitHubBaseClient(
         return self.head_cached(
             path=f"/repos/{repo.name}/contents/{path}",
             params={"ref": version},
-            endpoint=GitHubApiEndpoint.CHECK_FILE,
+            api_request_type=GitHubApiRequestType.CHECK_FILE,
         )
 
     def get_file(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -114,14 +114,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Integrations
-register(
-    "integrations.github.get-last-commits.cache-ttl",
-    type=Int,
-    default=900,  # 15 minutes
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 # Redis
 register(
     "redis.clusters",

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -114,6 +114,14 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Integrations
+register(
+    "integrations.github.get-last-commits.cache-ttl",
+    type=Int,
+    default=900,  # 15 minutes
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Redis
 register(
     "redis.clusters",

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -366,11 +366,10 @@ class BaseApiClient:
         key = self.get_cache_key(path, method, query, data)
         result = self.check_cache(key)
         api_request_type = kwargs.get("api_request_type") or kwargs.get("endpoint")
-        api_request_type_tag = (
-            api_request_type.value
-            if hasattr(api_request_type, "value")
-            else api_request_type or "unknown"
-        )
+        if api_request_type is None:
+            api_request_type_tag = "unknown"
+        else:
+            api_request_type_tag = str(api_request_type)
         metrics.incr(
             f"{self.metrics_prefix}.get_cached",
             sample_rate=1.0,

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -371,11 +371,12 @@ class BaseApiClient:
             api_request_type_tag = "unknown"
         else:
             api_request_type_tag = str(api_request_type)
+        integration_tag_key = self.integration_type or "integration"
         metrics.incr(
             f"{self.metrics_prefix}.get_cached",
             sample_rate=1.0,
             tags={
-                "integration": self.name,
+                integration_tag_key: self.name,
                 "api_request_type": str(api_request_type_tag),
                 "result": "hit" if result is not None else "miss",
             },

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -91,6 +91,8 @@ class BaseApiClient:
         extra: Mapping[str, str] | None = None,
     ) -> None:
         tags: dict[str, str | int] = {self.integration_type: self.name, "status": code}
+        if extra and "api_request_type" in extra:
+            tags["api_request_type"] = extra["api_request_type"]
         metrics.incr(
             f"{self.metrics_prefix}.http_response",
             sample_rate=1.0,
@@ -177,7 +179,6 @@ class BaseApiClient:
         prepared_request: PreparedRequest | None = None,
         stream: bool | None = None,
         raw_response: Literal[True] = ...,
-        endpoint: str | None = None,
         api_request_type: str | None = None,
     ) -> Response: ...
 
@@ -198,7 +199,6 @@ class BaseApiClient:
         prepared_request: PreparedRequest | None = None,
         stream: bool | None = None,
         raw_response: bool = ...,
-        endpoint: str | None = None,
         api_request_type: str | None = None,
     ) -> Any: ...
 
@@ -218,7 +218,6 @@ class BaseApiClient:
         prepared_request: PreparedRequest | None = None,
         stream: bool | None = None,
         raw_response: bool = False,
-        endpoint: str | None = None,
         api_request_type: str | None = None,
     ) -> Any | Response:
         if allow_redirects is None:
@@ -232,7 +231,11 @@ class BaseApiClient:
 
         full_url = self.build_url(path)
 
+        api_request_type_tag = str(api_request_type) if api_request_type is not None else None
+
         request_tags: dict[str, str] = {self.integration_type: self.name}
+        if api_request_type_tag is not None:
+            request_tags["api_request_type"] = api_request_type_tag
         metrics.incr(
             f"{self.metrics_prefix}.http_request",
             sample_rate=1.0,
@@ -260,10 +263,8 @@ class BaseApiClient:
         integration_id = getattr(self, "integration_id", None)
         if integration_id is not None:
             extra["integration_id"] = str(integration_id)
-        if api_request_type is not None:
-            extra["api_request_type"] = api_request_type
-        elif endpoint is not None:
-            extra["api_request_type"] = endpoint
+        if api_request_type_tag is not None:
+            extra["api_request_type"] = api_request_type_tag
 
         try:
             with self.build_session() as session:
@@ -365,7 +366,7 @@ class BaseApiClient:
 
         key = self.get_cache_key(path, method, query, data)
         result = self.check_cache(key)
-        api_request_type = kwargs.get("api_request_type") or kwargs.get("endpoint")
+        api_request_type = kwargs.get("api_request_type")
         if api_request_type is None:
             api_request_type_tag = "unknown"
         else:

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -361,11 +361,18 @@ class BaseApiClient:
         key = self.get_cache_key(path, method, query, data)
         result = self.check_cache(key)
         integration_tag_key = self.integration_type or "integration"
+        api_request_type = kwargs.get("api_request_type")
+        api_request_type_tag = (
+            api_request_type.value
+            if hasattr(api_request_type, "value")
+            else api_request_type or "unknown"
+        )
         metrics.incr(
             f"{self.metrics_prefix}.get_cached",
             sample_rate=1.0,
             tags={
                 integration_tag_key: self.name,
+                "api_request_type": str(api_request_type_tag),
                 "result": "hit" if result is not None else "miss",
             },
         )

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -360,7 +360,6 @@ class BaseApiClient:
 
         key = self.get_cache_key(path, method, query, data)
         result = self.check_cache(key)
-        integration_tag_key = self.integration_type or "integration"
         api_request_type = kwargs.get("api_request_type")
         api_request_type_tag = (
             api_request_type.value
@@ -371,7 +370,7 @@ class BaseApiClient:
             f"{self.metrics_prefix}.get_cached",
             sample_rate=1.0,
             tags={
-                integration_tag_key: self.name,
+                "integration": self.name,
                 "api_request_type": str(api_request_type_tag),
                 "result": "hit" if result is not None else "miss",
             },

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -360,6 +360,15 @@ class BaseApiClient:
 
         key = self.get_cache_key(path, method, query, data)
         result = self.check_cache(key)
+        integration_tag_key = self.integration_type or "integration"
+        metrics.incr(
+            f"{self.metrics_prefix}.get_cached",
+            sample_rate=1.0,
+            tags={
+                integration_tag_key: self.name,
+                "result": "hit" if result is not None else "miss",
+            },
+        )
         if result is None:
             cache_time = kwargs.pop("cache_time", None) or self.cache_time
             result = self.request(method, path, *args, **kwargs)

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -178,6 +178,7 @@ class BaseApiClient:
         stream: bool | None = None,
         raw_response: Literal[True] = ...,
         endpoint: str | None = None,
+        api_request_type: str | None = None,
     ) -> Response: ...
 
     @overload
@@ -198,6 +199,7 @@ class BaseApiClient:
         stream: bool | None = None,
         raw_response: bool = ...,
         endpoint: str | None = None,
+        api_request_type: str | None = None,
     ) -> Any: ...
 
     def _request(
@@ -217,6 +219,7 @@ class BaseApiClient:
         stream: bool | None = None,
         raw_response: bool = False,
         endpoint: str | None = None,
+        api_request_type: str | None = None,
     ) -> Any | Response:
         if allow_redirects is None:
             allow_redirects = self.allow_redirects
@@ -257,8 +260,10 @@ class BaseApiClient:
         integration_id = getattr(self, "integration_id", None)
         if integration_id is not None:
             extra["integration_id"] = str(integration_id)
-        if endpoint is not None:
-            extra["endpoint"] = endpoint
+        if api_request_type is not None:
+            extra["api_request_type"] = api_request_type
+        elif endpoint is not None:
+            extra["api_request_type"] = endpoint
 
         try:
             with self.build_session() as session:
@@ -360,7 +365,7 @@ class BaseApiClient:
 
         key = self.get_cache_key(path, method, query, data)
         result = self.check_cache(key)
-        api_request_type = kwargs.get("api_request_type")
+        api_request_type = kwargs.get("api_request_type") or kwargs.get("endpoint")
         api_request_type_tag = (
             api_request_type.value
             if hasattr(api_request_type, "value")

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -13,7 +13,7 @@ from responses import matchers
 
 from sentry.constants import ObjectStatus
 from sentry.integrations.github.blame import create_blame_query, generate_file_path_mapping
-from sentry.integrations.github.client import GitHubApiClient, GitHubApiEndpoint, GitHubReaction
+from sentry.integrations.github.client import GitHubApiClient, GitHubApiRequestType, GitHubReaction
 from sentry.integrations.github.constants import GITHUB_API_ACCEPT_HEADER
 from sentry.integrations.github.integration import GitHubIntegration
 from sentry.integrations.source_code_management.commit_context import (
@@ -131,7 +131,7 @@ class GitHubApiClientTest(TestCase):
         mock_head_cached.assert_called_once_with(
             path=f"/repos/{self.repo.name}/contents/README.md",
             params={"ref": "master"},
-            endpoint=GitHubApiEndpoint.CHECK_FILE,
+            api_request_type=GitHubApiRequestType.CHECK_FILE,
         )
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
@@ -188,7 +188,7 @@ class GitHubApiClientTest(TestCase):
         mock_get_with_pagination.assert_called_once_with(
             f"/repos/{self.repo.name}/compare/abc...xyz",
             response_key="commits",
-            endpoint="compare_commits",
+            api_request_type="compare_commits",
         )
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
@@ -200,7 +200,7 @@ class GitHubApiClientTest(TestCase):
         mock_get_cached.assert_called_once_with(
             f"/repos/{self.repo.name}/commits",
             params={"sha": "abc", "per_page": 20},
-            endpoint=GitHubApiEndpoint.GET_COMMITS,
+            api_request_type=GitHubApiRequestType.GET_COMMITS,
         )
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
@@ -211,7 +211,7 @@ class GitHubApiClientTest(TestCase):
 
         mock_get_cached.assert_called_once_with(
             f"/repos/{self.repo.name}/commits/abc",
-            endpoint="get_commit",
+            api_request_type="get_commit",
         )
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -30,6 +30,7 @@ from sentry.silo.base import SiloMode
 from sentry.silo.util import PROXY_BASE_PATH, PROXY_OI_HEADER, PROXY_SIGNATURE_HEADER
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.integrations import get_installation_of_type
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 from sentry.utils.cache import cache
 from tests.sentry.integrations.test_helpers import add_control_silo_proxy_response
@@ -201,6 +202,23 @@ class GitHubApiClientTest(TestCase):
             f"/repos/{self.repo.name}/commits",
             params={"sha": "abc", "per_page": 20},
             endpoint=GitHubApiEndpoint.GET_COMMITS,
+            cache_time=900,
+        )
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_get_last_commits_honors_cache_ttl_option(self, get_jwt) -> None:
+        with (
+            override_options({"integrations.github.get-last-commits.cache-ttl": 3600}),
+            mock.patch.object(self.github_client, "get_cached") as mock_get_cached,
+        ):
+            self.github_client.get_last_commits(self.repo.name, "abc")
+
+        mock_get_cached.assert_called_once_with(
+            f"/repos/{self.repo.name}/commits",
+            params={"sha": "abc", "per_page": 20},
+            endpoint=GitHubApiEndpoint.GET_COMMITS,
+            cache_time=3600,
         )
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -30,7 +30,6 @@ from sentry.silo.base import SiloMode
 from sentry.silo.util import PROXY_BASE_PATH, PROXY_OI_HEADER, PROXY_SIGNATURE_HEADER
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.integrations import get_installation_of_type
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 from sentry.utils.cache import cache
 from tests.sentry.integrations.test_helpers import add_control_silo_proxy_response
@@ -202,23 +201,6 @@ class GitHubApiClientTest(TestCase):
             f"/repos/{self.repo.name}/commits",
             params={"sha": "abc", "per_page": 20},
             endpoint=GitHubApiEndpoint.GET_COMMITS,
-            cache_time=900,
-        )
-
-    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
-    @responses.activate
-    def test_get_last_commits_honors_cache_ttl_option(self, get_jwt) -> None:
-        with (
-            override_options({"integrations.github.get-last-commits.cache-ttl": 3600}),
-            mock.patch.object(self.github_client, "get_cached") as mock_get_cached,
-        ):
-            self.github_client.get_last_commits(self.repo.name, "abc")
-
-        mock_get_cached.assert_called_once_with(
-            f"/repos/{self.repo.name}/commits",
-            params={"sha": "abc", "per_page": 20},
-            endpoint=GitHubApiEndpoint.GET_COMMITS,
-            cache_time=3600,
         )
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")

--- a/tests/sentry/integrations/msteams/test_webhook.py
+++ b/tests/sentry/integrations/msteams/test_webhook.py
@@ -490,7 +490,26 @@ class MsTeamsWebhookTest(APITestCase):
                 tags={"integration": "msteams", "status": 200},
             ),
         ] * 4
-        assert self.metrics.incr.mock_calls == calls
+        assert [
+            c for c in self.metrics.incr.mock_calls if c.args[0] == "integrations.http_request"
+        ] == [c for c in calls if c.args[0] == "integrations.http_request"]
+        assert [
+            c for c in self.metrics.incr.mock_calls if c.args[0] == "integrations.http_response"
+        ] == [c for c in calls if c.args[0] == "integrations.http_response"]
+        assert [
+            c for c in self.metrics.incr.mock_calls if c.args[0] == "integrations.get_cached"
+        ] == [
+            call(
+                "integrations.get_cached",
+                sample_rate=1.0,
+                tags={"integration": "msteams", "api_request_type": "unknown", "result": "miss"},
+            ),
+            call(
+                "integrations.get_cached",
+                sample_rate=1.0,
+                tags={"integration": "msteams", "api_request_type": "unknown", "result": "miss"},
+            ),
+        ]
 
         assert_slo_metric(mock_record, EventLifecycleOutcome.SUCCESS)
 

--- a/tests/sentry/shared_integrations/client/test_base.py
+++ b/tests/sentry/shared_integrations/client/test_base.py
@@ -155,7 +155,7 @@ class BaseApiClientTest(TestCase):
         with patch.object(self.api_client, "check_cache", return_value={"cached": True}):
             self.api_client.get_cached(
                 "https://example.com/repos/example/repo/commits",
-                endpoint="get_commits",
+                api_request_type="get_commits",
             )
 
         mock_metrics_incr.assert_called_once_with(

--- a/tests/sentry/shared_integrations/client/test_base.py
+++ b/tests/sentry/shared_integrations/client/test_base.py
@@ -104,7 +104,7 @@ class BaseApiClientTest(TestCase):
 
     @patch("sentry.shared_integrations.client.base.metrics.incr")
     @patch.object(Session, "send")
-    def test_request_and_response_metrics_do_not_include_api_request_type(
+    def test_request_and_response_metrics_include_api_request_type(
         self, mock_session_send, mock_metrics_incr
     ) -> None:
         response = MagicMock()
@@ -116,12 +116,12 @@ class BaseApiClientTest(TestCase):
         mock_metrics_incr.assert_any_call(
             "None.http_request",
             sample_rate=1.0,
-            tags={"integration": "base"},
+            tags={"integration": "base", "api_request_type": "compare_commits"},
         )
         mock_metrics_incr.assert_any_call(
             "None.http_response",
             sample_rate=1.0,
-            tags={"integration": "base", "status": 204},
+            tags={"integration": "base", "status": 204, "api_request_type": "compare_commits"},
         )
 
     @patch("sentry.shared_integrations.client.base.metrics.incr")

--- a/tests/sentry/shared_integrations/client/test_base.py
+++ b/tests/sentry/shared_integrations/client/test_base.py
@@ -123,3 +123,29 @@ class BaseApiClientTest(TestCase):
             sample_rate=1.0,
             tags={"integration": "base", "status": 204},
         )
+
+    @patch("sentry.shared_integrations.client.base.metrics.incr")
+    def test_get_cached_emits_hit_metric(self, mock_metrics_incr) -> None:
+        with patch.object(self.api_client, "check_cache", return_value={"cached": True}):
+            self.api_client.get_cached("https://example.com/repos/example/repo/commits")
+
+        mock_metrics_incr.assert_called_once_with(
+            "None.get_cached",
+            sample_rate=1.0,
+            tags={"integration": "base", "result": "hit"},
+        )
+
+    @patch("sentry.shared_integrations.client.base.metrics.incr")
+    def test_get_cached_emits_miss_metric(self, mock_metrics_incr) -> None:
+        with (
+            patch.object(self.api_client, "check_cache", return_value=None),
+            patch.object(self.api_client, "request", return_value={"fresh": True}),
+            patch.object(self.api_client, "set_cache"),
+        ):
+            self.api_client.get_cached("https://example.com/repos/example/repo/commits")
+
+        mock_metrics_incr.assert_any_call(
+            "None.get_cached",
+            sample_rate=1.0,
+            tags={"integration": "base", "result": "miss"},
+        )

--- a/tests/sentry/shared_integrations/client/test_base.py
+++ b/tests/sentry/shared_integrations/client/test_base.py
@@ -104,14 +104,14 @@ class BaseApiClientTest(TestCase):
 
     @patch("sentry.shared_integrations.client.base.metrics.incr")
     @patch.object(Session, "send")
-    def test_request_and_response_metrics_do_not_include_endpoint(
+    def test_request_and_response_metrics_do_not_include_api_request_type(
         self, mock_session_send, mock_metrics_incr
     ) -> None:
         response = MagicMock()
         response.status_code = 204
         mock_session_send.return_value = response
 
-        self.api_client.get("https://example.com/get", endpoint="compare_commits")
+        self.api_client.get("https://example.com/get", api_request_type="compare_commits")
 
         mock_metrics_incr.assert_any_call(
             "None.http_request",
@@ -132,7 +132,7 @@ class BaseApiClientTest(TestCase):
         mock_metrics_incr.assert_called_once_with(
             "None.get_cached",
             sample_rate=1.0,
-            tags={"integration": "base", "result": "hit"},
+            tags={"integration": "base", "api_request_type": "unknown", "result": "hit"},
         )
 
     @patch("sentry.shared_integrations.client.base.metrics.incr")
@@ -147,5 +147,19 @@ class BaseApiClientTest(TestCase):
         mock_metrics_incr.assert_any_call(
             "None.get_cached",
             sample_rate=1.0,
-            tags={"integration": "base", "result": "miss"},
+            tags={"integration": "base", "api_request_type": "unknown", "result": "miss"},
+        )
+
+    @patch("sentry.shared_integrations.client.base.metrics.incr")
+    def test_get_cached_emits_api_request_type_metric_tag(self, mock_metrics_incr) -> None:
+        with patch.object(self.api_client, "check_cache", return_value={"cached": True}):
+            self.api_client.get_cached(
+                "https://example.com/repos/example/repo/commits",
+                endpoint="get_commits",
+            )
+
+        mock_metrics_incr.assert_called_once_with(
+            "None.get_cached",
+            sample_rate=1.0,
+            tags={"integration": "base", "api_request_type": "get_commits", "result": "hit"},
         )


### PR DESCRIPTION
Track shared integration-client cache behavior by API request type.

We want to measure whether commit-fetch caching changes improve cache effectiveness for GitHub commit requests. The previous metric shape did not clearly capture request intent, and "endpoint" was ambiguous for operations that can share URL patterns while representing different request types.

This change standardizes on `api_request_type` and includes it in:
- shared `get_cached` metrics (`hit`/`miss`), and
- shared `http_request` / `http_response` metrics.

It also updates GitHub client call sites and tests to pass `api_request_type` consistently (compare-commits, list-commits, single-commit, and check-file operations), so request volume, response status, and cache ratio can all be analyzed by the same request-type dimension.

I considered keeping `endpoint` as the dimension, but `api_request_type` better matches the operation-level behavior we want to track.