### PR TITLE
fix(slack): add slack-staging to a list of of new oauth pipeline providers

### DIFF
--- a/static/app/components/pipeline/pipelineIntegrationSlack.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationSlack.tsx
@@ -45,3 +45,18 @@ export const slackIntegrationPipeline = {
     },
   ],
 } as const satisfies PipelineDefinition;
+
+export const slackStagingIntegrationPipeline = {
+  type: 'integration',
+  provider: 'slack_staging',
+  actionTitle: t('Installing Slack (Staging) Integration'),
+  getCompletionData: pipelineComplete<IntegrationWithConfig>,
+  completionView: null,
+  steps: [
+    {
+      stepId: 'oauth_login',
+      shortDescription: t('Authorizing via Slack OAuth'),
+      component: SlackOAuthLoginStep,
+    },
+  ],
+} as const satisfies PipelineDefinition;

--- a/static/app/components/pipeline/registry.tsx
+++ b/static/app/components/pipeline/registry.tsx
@@ -8,7 +8,10 @@ import {githubIntegrationPipeline} from './pipelineIntegrationGitHub';
 import {gitlabIntegrationPipeline} from './pipelineIntegrationGitLab';
 import {opsgenieIntegrationPipeline} from './pipelineIntegrationOpsgenie';
 import {pagerDutyIntegrationPipeline} from './pipelineIntegrationPagerDuty';
-import {slackIntegrationPipeline} from './pipelineIntegrationSlack';
+import {
+  slackIntegrationPipeline,
+  slackStagingIntegrationPipeline,
+} from './pipelineIntegrationSlack';
 import {vercelIntegrationPipeline} from './pipelineIntegrationVercel';
 import {vstsIntegrationPipeline} from './pipelineIntegrationVsts';
 
@@ -27,6 +30,7 @@ export const PIPELINE_REGISTRY = [
   opsgenieIntegrationPipeline,
   pagerDutyIntegrationPipeline,
   slackIntegrationPipeline,
+  slackStagingIntegrationPipeline,
   vstsIntegrationPipeline,
   vercelIntegrationPipeline,
 ] as const;

--- a/static/app/utils/integrations/useAddIntegration.tsx
+++ b/static/app/utils/integrations/useAddIntegration.tsx
@@ -49,6 +49,7 @@ const UNCONDITIONAL_API_PIPELINE_PROVIDERS = [
   'opsgenie',
   'pagerduty',
   'slack',
+  'slack_staging',
   'vsts',
 ] as const satisfies ReadonlyArray<ProvidersByType['integration']>;
 


### PR DESCRIPTION
We added slack staging provider to allow an experimental Slack app to be installed to workspaces for testing purposes.

The frontend code was changed to use the new OAuth pipeline in #113067. However, Slack staging wasn't added here.

This wasn't a problem until #113321 was merged, which removed legacy pipelines. This broke Slack staging installation pipeline because now the frontend tries to initiate the legacy way of oauth pipeline but the backend does not support it.