### PR TITLE
feat(issue-detection): Add weighted project selection

### DIFF
--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -342,7 +342,10 @@ def detect_llm_issues_for_org(org_id: int) -> None:
     if not project_id:
         return
 
-    project = Project.objects.get_from_cache(id=project_id)
+    try:
+        project = Project.objects.get_from_cache(id=project_id)
+    except Project.DoesNotExist:
+        return
     perf_settings = project.get_option("sentry:performance_issue_settings", default={})
     if not perf_settings.get("ai_issue_detection_enabled", True):
         return

--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -320,6 +320,7 @@ def detect_llm_issues_for_org(org_id: int) -> None:
     Budget enforcement happens on the Seer side.
     """
     from sentry.tasks.llm_issue_detection.trace_data import (  # circular imports
+        get_next_project_id,
         get_project_top_transaction_traces_for_llm_detection,
     )
 
@@ -337,7 +338,9 @@ def detect_llm_issues_for_org(org_id: int) -> None:
     if not project_ids:
         return
 
-    project_id = random.choice(project_ids)
+    project_id = get_next_project_id(organization, project_ids)
+    if not project_id:
+        return
 
     project = Project.objects.get_from_cache(id=project_id)
     perf_settings = project.get_option("sentry:performance_issue_settings", default={})

--- a/src/sentry/tasks/llm_issue_detection/trace_data.py
+++ b/src/sentry/tasks/llm_issue_detection/trace_data.py
@@ -13,6 +13,7 @@ from sentry.seer.explorer.utils import normalize_description
 from sentry.snuba.referrer import Referrer
 from sentry.snuba.spans_rpc import Spans
 from sentry.tasks.llm_issue_detection.detection import TraceMetadataWithSpanCount
+from sentry.utils.redis import redis_clusters
 
 logger = logging.getLogger(__name__)
 
@@ -75,8 +76,6 @@ def get_next_project_id(
 
     Returns None if there are no active projects with traffic.
     """
-    from sentry.utils.redis import redis_clusters
-
     client = redis_clusters.get("default")
     cache_key = f"{PROJECT_PLAYLIST_CACHE_KEY_PREFIX}:{organization.id}"
 

--- a/src/sentry/tasks/llm_issue_detection/trace_data.py
+++ b/src/sentry/tasks/llm_issue_detection/trace_data.py
@@ -91,7 +91,10 @@ def get_next_project_id(
     client.rpush(cache_key, *playlist)
     client.expire(cache_key, PROJECT_PLAYLIST_CACHE_TTL)
 
-    return int(client.lpop(cache_key))
+    next_id = client.lpop(cache_key)
+    if next_id is not None:
+        return int(next_id)
+    return random.choice(project_ids) if project_ids else None
 
 
 def _build_project_playlist(
@@ -130,10 +133,11 @@ def _build_project_playlist(
         sampling_mode="NORMAL",
     )
 
+    valid_ids = set(project_ids)
     weights = {
         row["project_id"]: row["count()"]
         for row in result.get("data", [])
-        if row.get("project_id") in set(project_ids)
+        if row.get("project_id") in valid_ids
     }
 
     if not weights:

--- a/src/sentry/tasks/llm_issue_detection/trace_data.py
+++ b/src/sentry/tasks/llm_issue_detection/trace_data.py
@@ -4,11 +4,8 @@ import logging
 import random
 import re
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from sentry.models.organization import Organization
-
+from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.search.eap.types import SearchResolverConfig
 from sentry.search.events.types import SnubaParams
@@ -78,24 +75,23 @@ def get_next_project_id(
 
     Returns None if there are no active projects with traffic.
     """
-    from django.core.cache import cache
+    from sentry.utils.redis import redis_clusters
 
+    client = redis_clusters.get("default")
     cache_key = f"{PROJECT_PLAYLIST_CACHE_KEY_PREFIX}:{organization.id}"
-    playlist = cache.get(cache_key)
 
+    project_id_raw = client.lpop(cache_key)
+    if project_id_raw is not None:
+        return int(project_id_raw)
+
+    playlist = _build_project_playlist(organization, project_ids, start_time_delta_minutes)
     if not playlist:
-        playlist = _build_project_playlist(organization, project_ids, start_time_delta_minutes)
-        if not playlist:
-            return random.choice(project_ids) if project_ids else None
-        cache.set(cache_key, playlist, PROJECT_PLAYLIST_CACHE_TTL)
+        return random.choice(project_ids) if project_ids else None
 
-    project_id = playlist.pop(0)
-    if playlist:
-        cache.set(cache_key, playlist, PROJECT_PLAYLIST_CACHE_TTL)
-    else:
-        cache.delete(cache_key)
+    client.rpush(cache_key, *playlist)
+    client.expire(cache_key, PROJECT_PLAYLIST_CACHE_TTL)
 
-    return project_id
+    return int(client.lpop(cache_key))
 
 
 def _build_project_playlist(

--- a/src/sentry/tasks/llm_issue_detection/trace_data.py
+++ b/src/sentry/tasks/llm_issue_detection/trace_data.py
@@ -4,6 +4,10 @@ import logging
 import random
 import re
 from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sentry.models.organization import Organization
 
 from sentry.models.project import Project
 from sentry.search.eap.types import SearchResolverConfig
@@ -53,6 +57,97 @@ def get_valid_trace_ids_by_span_count(
         for row in result.get("data", [])
         if LOWER_SPAN_LIMIT <= row["count()"] <= UPPER_SPAN_LIMIT
     }
+
+
+PROJECT_PLAYLIST_SIZE = 20
+PROJECT_PLAYLIST_CACHE_KEY_PREFIX = "llm_detection:project_playlist"
+PROJECT_PLAYLIST_CACHE_TTL = 86400 * 7  # 7 days
+
+
+def get_next_project_id(
+    organization: Organization,
+    project_ids: list[int],
+    start_time_delta_minutes: int = 60,
+) -> int | None:
+    """
+    Pop the next project ID from a cached playlist weighted by traffic.
+
+    The playlist is a shuffled list of project IDs where higher-traffic
+    projects appear more often. When the playlist is empty or missing,
+    a new one is generated from a Snuba query and cached.
+
+    Returns None if there are no active projects with traffic.
+    """
+    from django.core.cache import cache
+
+    cache_key = f"{PROJECT_PLAYLIST_CACHE_KEY_PREFIX}:{organization.id}"
+    playlist = cache.get(cache_key)
+
+    if not playlist:
+        playlist = _build_project_playlist(organization, project_ids, start_time_delta_minutes)
+        if not playlist:
+            return random.choice(project_ids) if project_ids else None
+        cache.set(cache_key, playlist, PROJECT_PLAYLIST_CACHE_TTL)
+
+    project_id = playlist.pop(0)
+    if playlist:
+        cache.set(cache_key, playlist, PROJECT_PLAYLIST_CACHE_TTL)
+    else:
+        cache.delete(cache_key)
+
+    return project_id
+
+
+def _build_project_playlist(
+    organization: Organization,
+    project_ids: list[int],
+    start_time_delta_minutes: int,
+) -> list[int]:
+    """
+    Build a shuffled playlist of PROJECT_PLAYLIST_SIZE project IDs
+    weighted by transaction count.
+    """
+    projects = list(Project.objects.filter(id__in=project_ids))
+    if not projects:
+        return []
+
+    end_time = datetime.now(UTC)
+    start_time = end_time - timedelta(minutes=start_time_delta_minutes)
+    config = SearchResolverConfig(auto_fields=True)
+
+    snuba_params = SnubaParams(
+        start=start_time,
+        end=end_time,
+        projects=projects,
+        organization=organization,
+    )
+
+    result = Spans.run_table_query(
+        params=snuba_params,
+        query_string="is_transaction:true",
+        selected_columns=["project_id", "count()"],
+        orderby=None,
+        offset=0,
+        limit=len(project_ids),
+        referrer=Referrer.ISSUES_LLM_ISSUE_DETECTION_TRANSACTION.value,
+        config=config,
+        sampling_mode="NORMAL",
+    )
+
+    weights = {
+        row["project_id"]: row["count()"]
+        for row in result.get("data", [])
+        if row.get("project_id") in set(project_ids)
+    }
+
+    if not weights:
+        return []
+
+    weighted_ids = list(weights.keys())
+    weighted_counts = list(weights.values())
+    playlist = random.choices(weighted_ids, weights=weighted_counts, k=PROJECT_PLAYLIST_SIZE)
+    random.shuffle(playlist)
+    return playlist
 
 
 def get_project_top_transaction_traces_for_llm_detection(

--- a/src/sentry/tasks/llm_issue_detection/trace_data.py
+++ b/src/sentry/tasks/llm_issue_detection/trace_data.py
@@ -88,13 +88,11 @@ def get_next_project_id(
     if not playlist:
         return random.choice(project_ids) if project_ids else None
 
-    client.rpush(cache_key, *playlist)
-    client.expire(cache_key, PROJECT_PLAYLIST_CACHE_TTL)
+    if len(playlist) > 1:
+        client.rpush(cache_key, *playlist[1:])
+        client.expire(cache_key, PROJECT_PLAYLIST_CACHE_TTL)
 
-    next_id = client.lpop(cache_key)
-    if next_id is not None:
-        return int(next_id)
-    return random.choice(project_ids) if project_ids else None
+    return playlist[0]
 
 
 def _build_project_playlist(


### PR DESCRIPTION
the new scheduling in https://github.com/getsentry/sentry/pull/113060 means that we needed a better way to pick which projects we are running detection on. Now we will build a shuffled playlist of 20 project IDs weighted by transaction traffic and cache it per org for 7 days. Each dispatch pops the next project off the list. When exhausted, regenerates from a fresh Snuba query. 
