### PR TITLE
fix(dashboards): Guard getTimeseriesSortOptions call in widget builder

### DIFF
--- a/static/app/views/dashboards/datasetConfig/base.tsx
+++ b/static/app/views/dashboards/datasetConfig/base.tsx
@@ -153,6 +153,15 @@ export interface DatasetConfig<SeriesResponse, TableResponse> {
     displayType?: DisplayType
   ) => Record<string, SelectValue<FieldValue>>;
   /**
+   * Generate the list of sort options for timeseries
+   * displays on the 'Sort by' step of the Widget Builder.
+   */
+  getTimeseriesSortOptions: (
+    organization: Organization,
+    widgetQuery: WidgetQuery,
+    tags?: TagCollection
+  ) => Record<string, SelectValue<FieldValue>>;
+  /**
    * List of supported display types for dataset.
    */
   supportedDisplayTypes: DisplayType[];
@@ -274,15 +283,6 @@ export interface DatasetConfig<SeriesResponse, TableResponse> {
     organization: Organization,
     widgetQuery: WidgetQuery
   ) => Array<SelectValue<string>>;
-  /**
-   * Generate the list of sort options for timeseries
-   * displays on the 'Sort by' step of the Widget Builder.
-   */
-  getTimeseriesSortOptions?: (
-    organization: Organization,
-    widgetQuery: WidgetQuery,
-    tags?: TagCollection
-  ) => Record<string, SelectValue<FieldValue>>;
   /**
    * Apply dataset specific overrides to the logic that handles
    * column updates for tables in the Widget Builder.

--- a/static/app/views/dashboards/datasetConfig/issues.tsx
+++ b/static/app/views/dashboards/datasetConfig/issues.tsx
@@ -84,6 +84,7 @@ export const IssuesConfig: DatasetConfig<IssuesSeriesResponse, Group[]> = {
   transformSeries: transformIssuesResponseToSeries,
   filterYAxisOptions,
   getTableSortOptions,
+  getTimeseriesSortOptions: () => ({}),
   getTableFieldOptions: (organization, _tags, _customMeasurements, _api, displayType) =>
     generateIssueWidgetFieldOptions(organization, displayType),
   getFieldHeaderMap: () => ISSUE_FIELD_TO_HEADER_MAP,

--- a/static/app/views/dashboards/widgetBuilder/components/sortBySelectors.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/sortBySelectors.tsx
@@ -87,7 +87,7 @@ export function SortBySelectors({
   const timeseriesSortOptions = useMemo(() => {
     let options: Record<string, SelectValue<FieldValue>> = {};
     if (displayType !== DisplayType.TABLE) {
-      options = datasetConfig.getTimeseriesSortOptions!(organization, widgetQuery, tags);
+      options = datasetConfig.getTimeseriesSortOptions(organization, widgetQuery, tags);
       const parsedFunction = parseFunction(values.sortBy);
       if (
         widgetType === WidgetType.SPANS &&


### PR DESCRIPTION
Fixes DAIN-1510

- The `issues` dataset config did not implement `getTimeseriesSortOptions`, causing a `N.getTimeseriesSortOptions is not a function` crash in the widget builder's sort-by selector.
- Adds a no-op implementation (`() => ({})`) to the issues config.
- Makes `getTimeseriesSortOptions` required on the `DatasetConfig` interface so missing implementations are caught at compile time instead of crashing at runtime.