### PR TITLE
chore(issue-detection): Make AI issue types searchable when feature flag

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -233,7 +233,6 @@ const HIDDEN_ISSUE_TYPES: IssueType[] = [
 ];
 
 export const AI_DETECTED_ISSUE_TYPES = new Set<IssueType>([
-  IssueType.LLM_DETECTED_EXPERIMENTAL_V2,
   IssueType.AI_DETECTED_HTTP,
   IssueType.AI_DETECTED_DB,
   IssueType.AI_DETECTED_RUNTIME_PERFORMANCE,

--- a/static/app/views/issueList/utils/useFetchIssueTags.tsx
+++ b/static/app/views/issueList/utils/useFetchIssueTags.tsx
@@ -10,6 +10,7 @@ import {
   IssueCategory,
   PriorityLevel,
   VALID_ISSUE_CATEGORIES,
+  AI_DETECTED_ISSUE_TYPES,
   VISIBLE_ISSUE_TYPES,
   type TagCollection,
 } from 'sentry/types/group';
@@ -204,6 +205,7 @@ export const useFetchIssueTags = ({
       currentTags: renamedTags,
       assigneeFieldValues: assignedValues,
       bookmarksValues: usernames,
+      organization: org,
     });
 
     return {
@@ -216,6 +218,7 @@ export const useFetchIssueTags = ({
     featureFlagTagsQuery.data,
     usernames,
     assignedValues,
+    org,
   ]);
 
   return {
@@ -235,10 +238,12 @@ function builtInIssuesFields({
   currentTags,
   assigneeFieldValues = [],
   bookmarksValues = [],
+  organization,
 }: {
   assigneeFieldValues: SearchGroup[] | string[];
   bookmarksValues: string[];
   currentTags: TagCollection;
+  organization: Organization;
 }): TagCollection {
   const semverFields: TagCollection = Object.values(SEMVER_TAGS).reduce<TagCollection>(
     (acc, tag) => {
@@ -322,7 +327,12 @@ function builtInIssuesFields({
     [FieldKey.ISSUE_TYPE]: {
       ...PREDEFINED_FIELDS[FieldKey.ISSUE_TYPE]!,
       name: 'Issue Type',
-      values: VISIBLE_ISSUE_TYPES.map(value => ({
+      values: [
+        ...VISIBLE_ISSUE_TYPES,
+        ...(organization.features.includes('ai-issue-detection')
+          ? [...AI_DETECTED_ISSUE_TYPES]
+          : []),
+      ].map(value => ({
         icon: null,
         title: value,
         name: value,


### PR DESCRIPTION
Include AI detected issue types in the issue stream search dropdown when the org has the ai-issue-detection feature flag. 
