### PR TITLE
feat(perforce): Add frontend pipeline steps for Perforce integration setup

### DIFF
--- a/static/app/components/pipeline/pipelineIntegrationPerforce.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationPerforce.spec.tsx
@@ -1,0 +1,136 @@
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {perforceIntegrationPipeline} from './pipelineIntegrationPerforce';
+import {createMakeStepProps} from './testUtils';
+
+const PerforceInstallationConfigStep = perforceIntegrationPipeline.steps[0].component;
+
+const makeStepProps = createMakeStepProps({totalSteps: 1});
+
+describe('PerforceInstallationConfigStep', () => {
+  it('renders the config form', () => {
+    render(<PerforceInstallationConfigStep {...makeStepProps({stepData: {}})} />);
+
+    expect(
+      screen.getByRole('textbox', {name: 'P4PORT (Server Address)'})
+    ).toBeInTheDocument();
+    expect(screen.getByRole('textbox', {name: 'Perforce Username'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Connect'})).toBeInTheDocument();
+  });
+
+  it('calls advance with form data on submit', async () => {
+    const advance = jest.fn();
+    render(
+      <PerforceInstallationConfigStep {...makeStepProps({stepData: {}, advance})} />
+    );
+
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'P4PORT (Server Address)'}),
+      'ssl:perforce.example.com:1666'
+    );
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'Perforce Username'}),
+      'sentry-bot'
+    );
+    await userEvent.type(screen.getByLabelText('Password / Ticket'), 'secret123');
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'SSL Fingerprint'}),
+      'AB:CD:EF'
+    );
+    await userEvent.click(screen.getByRole('button', {name: 'Connect'}));
+
+    await waitFor(() => {
+      expect(advance).toHaveBeenCalledWith({
+        p4port: 'ssl:perforce.example.com:1666',
+        user: 'sentry-bot',
+        authType: 'password',
+        password: 'secret123',
+        client: undefined,
+        sslFingerprint: 'AB:CD:EF',
+        webUrl: undefined,
+      });
+    });
+  });
+
+  it('requires sslFingerprint when p4port is ssl', async () => {
+    const advance = jest.fn();
+    render(
+      <PerforceInstallationConfigStep {...makeStepProps({stepData: {}, advance})} />
+    );
+
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'P4PORT (Server Address)'}),
+      'ssl:perforce.example.com:1666'
+    );
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'Perforce Username'}),
+      'sentry-bot'
+    );
+    await userEvent.type(screen.getByLabelText('Password / Ticket'), 'secret123');
+    await userEvent.click(screen.getByRole('button', {name: 'Connect'}));
+
+    expect(
+      await screen.findByText('SSL fingerprint is required when P4PORT uses ssl:')
+    ).toBeInTheDocument();
+    expect(advance).not.toHaveBeenCalled();
+  });
+
+  it('includes optional fields when provided', async () => {
+    const advance = jest.fn();
+    render(
+      <PerforceInstallationConfigStep {...makeStepProps({stepData: {}, advance})} />
+    );
+
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'P4PORT (Server Address)'}),
+      'ssl:p4.example.com:1666'
+    );
+    await userEvent.type(screen.getByRole('textbox', {name: 'Perforce Username'}), 'bot');
+    await userEvent.type(screen.getByLabelText('Password / Ticket'), 'pass');
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'Perforce Client/Workspace'}),
+      'my-workspace'
+    );
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'SSL Fingerprint'}),
+      'AB:CD:EF'
+    );
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'P4 Code Review URL'}),
+      'https://swarm.example.com'
+    );
+    await userEvent.click(screen.getByRole('button', {name: 'Connect'}));
+
+    await waitFor(() => {
+      expect(advance).toHaveBeenCalledWith({
+        p4port: 'ssl:p4.example.com:1666',
+        user: 'bot',
+        authType: 'password',
+        password: 'pass',
+        client: 'my-workspace',
+        sslFingerprint: 'AB:CD:EF',
+        webUrl: 'https://swarm.example.com',
+      });
+    });
+  });
+
+  it('shows loading state when isAdvancing', () => {
+    render(
+      <PerforceInstallationConfigStep
+        {...makeStepProps({stepData: {}, isAdvancing: true})}
+      />
+    );
+
+    expect(screen.getByRole('button', {name: 'Connecting...'})).toBeDisabled();
+  });
+
+  it('disables submit button when isInitializing', () => {
+    render(
+      <PerforceInstallationConfigStep
+        {...makeStepProps({stepData: null, isInitializing: true})}
+      />
+    );
+
+    expect(screen.getByRole('button', {name: 'Connect'})).toBeDisabled();
+  });
+});

--- a/static/app/components/pipeline/pipelineIntegrationPerforce.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationPerforce.tsx
@@ -1,0 +1,201 @@
+import {useEffect} from 'react';
+import {z} from 'zod';
+
+import {defaultFormOptions, setFieldErrors, useScrapsForm} from '@sentry/scraps/form';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {t} from 'sentry/locale';
+import type {IntegrationWithConfig} from 'sentry/types/integrations';
+
+import type {PipelineDefinition, PipelineStepProps} from './types';
+import {pipelineComplete} from './types';
+
+const AUTH_TYPE_CHOICES = [
+  {value: 'password', label: t('Password')},
+  {value: 'ticket', label: t('P4 Ticket')},
+];
+
+interface InstallationConfigAdvanceData {
+  authType: string;
+  p4port: string;
+  password: string;
+  user: string;
+  client?: string;
+  sslFingerprint?: string;
+  webUrl?: string;
+}
+
+const installationConfigSchema = z
+  .object({
+    p4port: z.string().min(1, t('Server address is required')),
+    user: z.string().min(1, t('Username is required')),
+    authType: z.string().min(1, t('Authentication type is required')),
+    password: z.string().min(1, t('Password is required')),
+    client: z.string(),
+    sslFingerprint: z.string(),
+    webUrl: z.string(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.p4port.startsWith('ssl:') && !data.sslFingerprint) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['sslFingerprint'],
+        message: t('SSL fingerprint is required when P4PORT uses ssl:'),
+      });
+    }
+  });
+
+function PerforceInstallationConfigStep({
+  advance,
+  advanceError,
+  isAdvancing,
+  isInitializing,
+}: PipelineStepProps<Record<string, unknown>, InstallationConfigAdvanceData>) {
+  const form = useScrapsForm({
+    ...defaultFormOptions,
+    defaultValues: {
+      p4port: '',
+      user: '',
+      authType: 'password',
+      password: '',
+      client: '',
+      sslFingerprint: '',
+      webUrl: '',
+    },
+    validators: {onDynamic: installationConfigSchema},
+    onSubmit: ({value}) => {
+      advance({
+        p4port: value.p4port,
+        user: value.user,
+        authType: value.authType,
+        password: value.password,
+        client: value.client || undefined,
+        sslFingerprint: value.sslFingerprint || undefined,
+        webUrl: value.webUrl || undefined,
+      });
+    },
+  });
+
+  useEffect(() => {
+    if (advanceError) {
+      setFieldErrors(form, advanceError);
+    }
+  }, [advanceError, form]);
+
+  return (
+    <form.AppForm form={form}>
+      <Stack gap="lg">
+        <Text>
+          {t(
+            'Configure your Perforce server connection to enable stacktrace linking and commit tracking.'
+          )}
+        </Text>
+        <form.AppField name="p4port">
+          {field => (
+            <field.Layout.Stack
+              label={t('P4PORT (Server Address)')}
+              hintText={t(
+                "Perforce server address in P4PORT format (e.g. 'ssl:perforce.company.com:1666')"
+              )}
+              required
+            >
+              <field.Input
+                value={field.state.value}
+                onChange={field.handleChange}
+                placeholder="ssl:perforce.company.com:1666"
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+        <form.AppField name="user">
+          {field => (
+            <field.Layout.Stack label={t('Perforce Username')} required>
+              <field.Input
+                value={field.state.value}
+                onChange={field.handleChange}
+                placeholder="sentry-bot"
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+        <form.AppField name="authType">
+          {field => (
+            <field.Layout.Stack label={t('Authentication Type')} required>
+              <field.Select
+                value={field.state.value}
+                onChange={field.handleChange}
+                options={AUTH_TYPE_CHOICES}
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+        <form.AppField name="password">
+          {field => (
+            <field.Layout.Stack label={t('Password / Ticket')} required>
+              <field.Input
+                value={field.state.value}
+                onChange={field.handleChange}
+                placeholder={t('Password or P4 ticket')}
+                type="password"
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+        <form.AppField name="client">
+          {field => (
+            <field.Layout.Stack label={t('Perforce Client/Workspace')}>
+              <field.Input
+                value={field.state.value}
+                onChange={field.handleChange}
+                placeholder="sentry-workspace"
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+        <form.AppField name="sslFingerprint">
+          {field => (
+            <field.Layout.Stack label={t('SSL Fingerprint')}>
+              <field.Input
+                value={field.state.value}
+                onChange={field.handleChange}
+                placeholder="AB:CD:EF:..."
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+        <form.AppField name="webUrl">
+          {field => (
+            <field.Layout.Stack label={t('P4 Code Review URL')}>
+              <field.Input
+                value={field.state.value}
+                onChange={field.handleChange}
+                placeholder="https://swarm.company.com"
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+        <Flex>
+          <form.SubmitButton disabled={isAdvancing || isInitializing}>
+            {isAdvancing ? t('Connecting...') : t('Connect')}
+          </form.SubmitButton>
+        </Flex>
+      </Stack>
+    </form.AppForm>
+  );
+}
+
+export const perforceIntegrationPipeline = {
+  type: 'integration',
+  provider: 'perforce',
+  actionTitle: t('Installing Perforce Integration'),
+  getCompletionData: pipelineComplete<IntegrationWithConfig>,
+  completionView: null,
+  steps: [
+    {
+      stepId: 'installation_config',
+      shortDescription: t('Configuring Perforce connection'),
+      component: PerforceInstallationConfigStep,
+    },
+  ],
+} as const satisfies PipelineDefinition;

--- a/static/app/components/pipeline/registry.tsx
+++ b/static/app/components/pipeline/registry.tsx
@@ -8,6 +8,7 @@ import {githubIntegrationPipeline} from './pipelineIntegrationGitHub';
 import {gitlabIntegrationPipeline} from './pipelineIntegrationGitLab';
 import {opsgenieIntegrationPipeline} from './pipelineIntegrationOpsgenie';
 import {pagerDutyIntegrationPipeline} from './pipelineIntegrationPagerDuty';
+import {perforceIntegrationPipeline} from './pipelineIntegrationPerforce';
 import {
   slackIntegrationPipeline,
   slackStagingIntegrationPipeline,
@@ -29,6 +30,7 @@ export const PIPELINE_REGISTRY = [
   gitlabIntegrationPipeline,
   opsgenieIntegrationPipeline,
   pagerDutyIntegrationPipeline,
+  perforceIntegrationPipeline,
   slackIntegrationPipeline,
   slackStagingIntegrationPipeline,
   vstsIntegrationPipeline,


### PR DESCRIPTION
Add PerforceInstallationConfigStep component with form fields for
server address, credentials, auth type, and optional SSL/workspace
config. Register the pipeline definition in the pipeline registry.

Refs [VDY-107: Perforce: API-driven integration setup](https://linear.app/getsentry/issue/VDY-107/perforce-api-driven-integration-setup)