### PR TITLE
feat(explorer): Use local storage for explorer override

### DIFF
--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -12,6 +12,7 @@ import {
   useQueryClient,
 } from 'sentry/utils/queryClient';
 import type {RequestError} from 'sentry/utils/requestError/requestError';
+import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -131,8 +132,12 @@ export const useSeerExplorer = () => {
   const orgSlug = organization?.slug;
   const captureAsciiSnapshot = useAsciiSnapshot();
   const {getLLMContext} = useLLMContext();
-  const [overrideCtxEngEnable, setOverrideCtxEngEnable] = useState<boolean>(true);
-  const [overrideCodeModeEnable, setOverrideCodeModeEnable] = useState<boolean>(true);
+  const [overrideCtxEngEnable, setOverrideCtxEngEnable] = useLocalStorageState<boolean>(
+    'seer-explorer.override.ctx-eng',
+    true
+  );
+  const [overrideCodeModeEnable, setOverrideCodeModeEnable] =
+    useLocalStorageState<boolean>('seer-explorer.override.code-mode', true);
 
   const [runId, setRunId] = useSessionStorage<number | null>(
     'seer-explorer-run-id',


### PR DESCRIPTION
Use local storage instead of just state so it persists across sessions.