### PR TITLE
fix(releases): Remove unused statsPeriod query parameter

### DIFF
--- a/static/app/views/releases/detail/index.tsx
+++ b/static/app/views/releases/detail/index.tsx
@@ -308,6 +308,7 @@ function ReleasesDetailContainer() {
 
   return (
     <PageFiltersContainer
+      skipInitializeUrlParams
       shouldForceProject={projects.length === 1}
       forceProject={
         projects.length === 1 ? {...projects[0]!, id: String(projects[0]!.id)} : undefined

--- a/static/app/views/releases/list/releaseCard/index.tsx
+++ b/static/app/views/releases/list/releaseCard/index.tsx
@@ -13,7 +13,6 @@ import {ExternalLink, Link} from '@sentry/scraps/link';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {Collapsible} from 'sentry/components/collapsible';
-import {extractSelectionParameters} from 'sentry/components/pageFilters/parse';
 import {Panel} from 'sentry/components/panels/panel';
 import {PanelHeader} from 'sentry/components/panels/panelHeader';
 import {TextOverflow} from 'sentry/components/textOverflow';
@@ -128,7 +127,7 @@ export function ReleaseCard({
                 path: `/${encodeURIComponent(version)}/`,
               }),
               query: {
-                ...extractSelectionParameters(location.query),
+                environment: location.query.environment,
                 project: getReleaseProjectId(release, selection),
               },
             }}

--- a/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
+++ b/static/app/views/releases/list/releaseCard/releaseCardProjectRow.tsx
@@ -245,7 +245,7 @@ export function ReleaseCardProjectRow({
                   path: `/${encodeURIComponent(releaseVersion)}/`,
                 }),
                 query: {
-                  ...extractSelectionParameters(location.query),
+                  environment: location.query.environment,
                   project: project.id,
                   yAxis: undefined,
                 },


### PR DESCRIPTION
Navigating from the releases list to a release detail briefly showed `statsPeriod` in the URL before stripping it, causing an extra rerenders and i think queries?

Remove from the link passing it in and add a prop that prevents adding it.