### PR TITLE
feat(ACI): Make metric alert rule POST method backwards compatible

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -454,6 +454,9 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:workflow-engine-redirect-opt-out", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Use workflow engine serializers to return data for old rule / incident endpoints
     manager.add("organizations:workflow-engine-rule-serializers", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Use workflow engine exclusively for legacy metric alert rule.post results.
+    # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
+    manager.add("organizations:workflow-engine-metric-alert-endpoints-post", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Use workflow engine exclusively for OrganizationCombinedRuleIndexEndpoint.get results.
     # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
     manager.add("organizations:workflow-engine-combinedruleindex-get", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -325,7 +325,7 @@ def translate_metric_alert_to_detector_payload(data: dict[str, Any]) -> dict[str
                 if alert_threshold is not None:
                     trigger["alertThreshold"] = translate_threshold(threshold_type, alert_threshold)
 
-            if data.get("resolveThreshold") is not None:
+            if resolve_threshold is not None:
                 resolve_threshold = translate_threshold(threshold_type, resolve_threshold)
 
         for trigger in triggers:

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -171,7 +171,15 @@ def translate_metric_alert_to_detector_payload(data: dict[str, Any]) -> dict[str
     - timeWindow (minutes) -> time_window (seconds)
     """
     # build up data conditions
-    detection_type = data.get("detectionType", AlertRuleDetectionType.STATIC)
+    detection_type = data.get("detectionType")
+    if not detection_type:
+        if data.get("comparisonDelta"):
+            detection_type = AlertRuleDetectionType.PERCENT
+        elif data.get("seasonality") or data.get("sensitivity"):
+            detection_type = AlertRuleDetectionType.DYNAMIC
+        else:
+            detection_type = AlertRuleDetectionType.STATIC
+
     threshold_type = data.get("thresholdType", AlertRuleThresholdType.ABOVE.value)
     triggers = data.get("triggers", [])
     conditions: list[dict[str, Any]] = []
@@ -341,11 +349,11 @@ def create_metric_alert(
             "request": request,
             "user": request.user,
         }
-        validator = MetricIssueDetectorValidator(data=detector_data, context=context)
-        if not validator.is_valid():
-            raise ValidationError(validator.errors)
+        detector_validator = MetricIssueDetectorValidator(data=detector_data, context=context)
+        if not detector_validator.is_valid():
+            raise ValidationError(detector_validator.errors)
 
-        detector = validator.save()
+        detector = detector_validator.save()
 
         return Response(
             serialize(

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -243,10 +243,7 @@ def translate_metric_alert_to_detector_payload(data: dict[str, Any]) -> dict[str
         data_source["extrapolation_mode"] = data["extrapolationMode"]
 
     # build up config
-    config: dict[str, Any] = {
-        "detection_type": data.get("detectionType")
-        or data.get("detection_type", AlertRuleDetectionType.STATIC),
-    }
+    config: dict[str, Any] = {"detection_type": detection_type}
     if data.get("comparisonDelta"):
         config["comparison_delta"] = int(data["comparisonDelta"] * 60)  # minutes -> seconds
 
@@ -308,9 +305,12 @@ def create_metric_alert(
 
         context_project = project
         if context_project is None and data.get("projects"):
-            context_project = Project.objects.get(
-                slug=data["projects"][0], organization=organization
-            )
+            try:
+                context_project = Project.objects.get(
+                    slug=data["projects"][0], organization=organization
+                )
+            except Project.DoesNotExist:
+                raise ValidationError("Project slug must be passed")
 
         context = {
             "organization": organization,

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -2,6 +2,7 @@ import logging
 from collections.abc import Sequence
 from copy import deepcopy
 from datetime import UTC, datetime
+from typing import Any
 
 from django.db import connections, router, transaction
 from django.db.models import (
@@ -61,7 +62,12 @@ from sentry.incidents.endpoints.serializers.workflow_engine_detector import (
 from sentry.incidents.endpoints.utils import parse_team_params
 from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.logic import get_slack_actions_with_async_lookups
-from sentry.incidents.models.alert_rule import AlertRule
+from sentry.incidents.metric_issue_detector import MetricIssueDetectorValidator
+from sentry.incidents.models.alert_rule import (
+    AlertRule,
+    AlertRuleDetectionType,
+    AlertRuleThresholdType,
+)
 from sentry.incidents.models.incident import Incident, IncidentStatus
 from sentry.incidents.serializers import AlertRuleSerializer as DrfAlertRuleSerializer
 from sentry.incidents.utils.sentry_apps import trigger_sentry_app_action_creators_for_incidents
@@ -106,6 +112,7 @@ from sentry.workflow_engine.models import (
     DetectorState,
     Workflow,
 )
+from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.types import DetectorPriorityLevel
 from sentry.workflow_engine.utils.legacy_metric_tracking import (
     report_used_legacy_models,
@@ -151,6 +158,122 @@ def filter_detectors_by_datasets(
 VALID_COMBINED_RULE_SORT_KEYS = {"date_added", "name", "incident_status", "date_triggered"}
 
 
+def translate_metric_alert_to_detector_payload(data: dict[str, Any]) -> dict[str, Any]:
+    """
+    Translate a metric alert rule payload into the shape expected by MetricIssueDetectorValidator.
+
+    Mapping:
+    - thresholdType ABOVE: triggers use GREATER, resolution uses LESS_OR_EQUAL
+    - thresholdType BELOW: triggers use LESS, resolution uses GREATER_OR_EQUAL
+    - critical trigger -> HIGH priority condition
+    - warning trigger -> MEDIUM priority condition
+    - resolveThreshold -> OK priority condition (falls back to warning/critical alertThreshold)
+    - timeWindow (minutes) -> time_window (seconds)
+    """
+    # build up data conditions
+    detection_type = data.get("detectionType", AlertRuleDetectionType.STATIC)
+    threshold_type = data.get("thresholdType", AlertRuleThresholdType.ABOVE.value)
+    triggers = data.get("triggers", [])
+    conditions: list[dict[str, Any]] = []
+
+    if detection_type == AlertRuleDetectionType.DYNAMIC:
+        # Anomaly detection: a single anomaly detection condition for the critical trigger
+        # No resolve condition is needed; the handler manages state transitions
+        conditions.append(
+            {
+                "type": Condition.ANOMALY_DETECTION,
+                "comparison": {
+                    "sensitivity": data.get("sensitivity"),
+                    "seasonality": data.get("seasonality"),
+                    "threshold_type": threshold_type,
+                },
+                "condition_result": DetectorPriorityLevel.HIGH,
+            }
+        )
+    else:
+        # Static / percent: generate GREATER/LESS conditions from triggers
+        # Note: ABOVE_AND_BELOW is not used
+        if threshold_type == AlertRuleThresholdType.ABOVE.value:
+            trigger_condition_type = Condition.GREATER
+            resolve_condition_type = Condition.LESS_OR_EQUAL
+        else:  # BELOW
+            trigger_condition_type = Condition.LESS
+            resolve_condition_type = Condition.GREATER_OR_EQUAL
+
+        for trigger in triggers:
+            label = trigger.get("label")
+            condition_result = (
+                DetectorPriorityLevel.HIGH if label == "critical" else DetectorPriorityLevel.MEDIUM
+            )
+            conditions.append(
+                {
+                    "type": trigger_condition_type,
+                    "comparison": trigger.get("alertThreshold"),
+                    "condition_result": condition_result,
+                }
+            )
+
+        resolve_threshold = data.get("resolveThreshold")
+        if resolve_threshold is None:
+            warning = next((t for t in triggers if t.get("label") == "warning"), None)
+            critical = next((t for t in triggers if t.get("label") == "critical"), None)
+            resolve_threshold = (warning or critical or {}).get("alertThreshold")
+
+        if resolve_threshold is not None:
+            conditions.append(
+                {
+                    "type": resolve_condition_type,
+                    "comparison": resolve_threshold,
+                    "condition_result": DetectorPriorityLevel.OK,
+                }
+            )
+
+    # build up data source
+    data_source: dict[str, Any] = {
+        "dataset": data.get("dataset", "events"),
+        "query": data.get("query", ""),
+        "aggregate": data.get("aggregate", ""),
+        "time_window": int(data.get("timeWindow", 1)) * 60,  # minutes -> seconds
+        "environment": data.get("environment"),
+        "event_types": data.get("eventTypes", []),
+    }
+    if "queryType" in data:
+        data_source["query_type"] = data["queryType"]
+    if "extrapolationMode" in data:
+        data_source["extrapolation_mode"] = data["extrapolationMode"]
+
+    # build up config
+    config: dict[str, Any] = {
+        "detection_type": data.get("detectionType")
+        or data.get("detection_type", AlertRuleDetectionType.STATIC),
+    }
+    if data.get("comparisonDelta"):
+        config["comparison_delta"] = int(data["comparisonDelta"] * 60)  # minutes -> seconds
+
+    if data.get("sensitivity"):
+        config["sensitivity"] = data.get("sensitivity")
+
+    if data.get("seasonality"):
+        config["seasonality"] = data.get("seasonality")
+
+    detector_payload: dict[str, Any] = {
+        "name": data.get("name", ""),
+        "type": MetricIssue.slug,
+        "data_sources": [data_source],
+        "condition_group": {
+            "logic_type": "any",
+            "conditions": conditions,
+        },
+        "config": config,
+    }
+    if "owner" in data:
+        detector_payload["owner"] = data["owner"]
+    if "description" in data:
+        detector_payload["description"] = data["description"]
+
+    return detector_payload
+
+
 def create_metric_alert(
     request: Request, organization: Organization, project: Project | None = None
 ) -> HttpResponseBase:
@@ -177,6 +300,38 @@ def create_metric_alert(
 
     if project:
         data["projects"] = [project.slug]
+
+    if features.has("organizations:workflow-engine-rule-serializers", organization) or features.has(
+        "organizations:workflow-engine-metric-alert-endpoints-post", organization
+    ):
+        detector_data = translate_metric_alert_to_detector_payload(data)
+
+        context_project = project
+        if context_project is None and data.get("projects"):
+            context_project = Project.objects.get(
+                slug=data["projects"][0], organization=organization
+            )
+
+        context = {
+            "organization": organization,
+            "project": context_project,
+            "request": request,
+            "user": request.user,
+        }
+        validator = MetricIssueDetectorValidator(data=detector_data, context=context)
+        if not validator.is_valid():
+            raise ValidationError(validator.errors)
+
+        detector = validator.save()
+
+        return Response(
+            serialize(
+                detector,
+                request.user,
+                WorkflowEngineDetectorSerializer(),
+            ),
+            status=status.HTTP_201_CREATED,
+        )
 
     validator = DrfAlertRuleSerializer(
         context={
@@ -211,19 +366,6 @@ def create_metric_alert(
         return Response({"uuid": client.uuid}, status=202)
     else:
         alert_rule = validator.save()
-        if features.has("organizations:workflow-engine-rule-serializers", organization):
-            try:
-                detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
-                return Response(
-                    serialize(
-                        detector,
-                        request.user,
-                        WorkflowEngineDetectorSerializer(),
-                    ),
-                    status=status.HTTP_201_CREATED,
-                )
-            except Detector.DoesNotExist:
-                return Response(status=status.HTTP_404_NOT_FOUND)
         return Response(serialize(alert_rule, request.user), status=status.HTTP_201_CREATED)
 
 

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -106,10 +106,12 @@ from sentry.uptime.types import (
 )
 from sentry.utils.cursors import Cursor, StringCursor
 from sentry.workflow_engine.endpoints.utils.ids import to_valid_int_id
+from sentry.workflow_engine.endpoints.validators.base.workflow import WorkflowValidator
 from sentry.workflow_engine.endpoints.validators.utils import log_alerting_quota_hit
 from sentry.workflow_engine.models import (
     Detector,
     DetectorState,
+    DetectorWorkflow,
     Workflow,
 )
 from sentry.workflow_engine.models.data_condition import Condition
@@ -156,6 +158,104 @@ def filter_detectors_by_datasets(
 
 # Valid sort keys for combined rules endpoint
 VALID_COMBINED_RULE_SORT_KEYS = {"date_added", "name", "incident_status", "date_triggered"}
+
+
+def translate_metric_alert_to_workflow_payload(data: dict[str, Any]) -> dict[str, Any]:
+    """
+    Translate a metric alert rule payload into the shape expected by WorkflowValidator.
+
+    Each trigger becomes an actionFilter with an issue_priority_greater_or_equal condition:
+    - critical trigger -> DetectorPriorityLevel.HIGH
+    - warning trigger -> DetectorPriorityLevel.MEDIUM
+    """
+    action_filters: list[dict[str, Any]] = []
+
+    for trigger in data.get("triggers", []):
+        label = trigger.get("label", "critical")
+        priority = (
+            DetectorPriorityLevel.HIGH if label == "critical" else DetectorPriorityLevel.MEDIUM
+        )
+
+        actions: list[dict[str, Any]] = []
+        for action in trigger.get("actions", []):
+            action_type = action.get("type")
+            target_identifier = action.get("targetIdentifier")
+            target_type = action.get("targetType")
+
+            # build target_identifier
+            if action_type == "sentry_app":
+                sentry_app_id = action.get("sentryAppId")
+                if sentry_app_id is not None:
+                    target_identifier = str(sentry_app_id)
+                target_type = "sentry_app"
+            elif action_type == "slack" and action.get("inputChannelId"):
+                target_identifier = str(action["inputChannelId"])
+
+            if target_identifier is not None:
+                target_identifier = str(target_identifier)
+
+            config: dict[str, Any] = {
+                "targetType": target_type,
+                "targetIdentifier": target_identifier,
+                "targetDisplay": action.get("targetDisplay"),
+            }
+
+            # build action data
+            if action_type in ("pagerduty", "opsgenie") and action.get("priority"):
+                action_data: dict[str, Any] = {"priority": action["priority"]}
+            elif action_type == "sentry_app":
+                sentry_app_config = action.get("sentryAppConfig") or action.get("sentry_app_config")
+                if sentry_app_config is not None:
+                    settings = (
+                        sentry_app_config
+                        if isinstance(sentry_app_config, list)
+                        else [sentry_app_config]
+                    )
+                    action_data = {"settings": settings}
+                else:
+                    action_data = {}
+            else:
+                action_data = {}
+
+            workflow_action: dict[str, Any] = {
+                "type": action_type,
+                "config": config,
+                "data": action_data,
+            }
+            if "integrationId" in action:
+                workflow_action["integrationId"] = action["integrationId"]
+
+            actions.append(workflow_action)
+
+        action_filters.append(
+            {
+                "logicType": "any",
+                "conditions": [
+                    {
+                        "type": Condition.ISSUE_PRIORITY_GREATER_OR_EQUAL,
+                        "comparison": priority,
+                        "conditionResult": True,
+                    }
+                ],
+                "actions": actions,
+            }
+        )
+
+    payload: dict[str, Any] = {
+        "name": data.get("name", ""),
+        "enabled": True,
+        "config": {},
+        "triggers": {
+            "logicType": "any",
+            "conditions": [],
+        },
+        "actionFilters": action_filters,
+    }
+
+    if "owner" in data:
+        payload["owner"] = data["owner"]
+
+    return payload
 
 
 def translate_metric_alert_to_detector_payload(data: dict[str, Any]) -> dict[str, Any]:
@@ -353,7 +453,18 @@ def create_metric_alert(
         if not detector_validator.is_valid():
             raise ValidationError(detector_validator.errors)
 
-        detector = detector_validator.save()
+        workflow_data = translate_metric_alert_to_workflow_payload(data)
+        workflow_validator = WorkflowValidator(
+            data=workflow_data,
+            context={"organization": organization, "request": request},
+        )
+        workflow_validator.is_valid(raise_exception=True)
+
+        with transaction.atomic(router.db_for_write(AlertRule)):
+            workflow = workflow_validator.create(workflow_validator.validated_data)
+            detector = detector_validator.save()
+
+            DetectorWorkflow.objects.create(workflow=workflow, detector=detector)
 
         return Response(
             serialize(

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -200,6 +200,26 @@ def translate_metric_alert_to_detector_payload(data: dict[str, Any]) -> dict[str
             trigger_condition_type = Condition.LESS
             resolve_condition_type = Condition.GREATER_OR_EQUAL
 
+        # When comparisonDelta is set, the frontend sends a percent delta (e.g. 200 for "200%
+        # higher"). Translate to a total-percentage comparison the way DrfAlertRuleSerializer
+        # does: ABOVE → threshold + 100 (200 → 300), BELOW → 100 - threshold (40 → 60).
+        if data.get("comparisonDelta") is not None:
+            if threshold_type == AlertRuleThresholdType.ABOVE.value:
+
+                def translate_threshold(t: float) -> float:
+                    return t + 100
+
+            else:
+
+                def translate_threshold(t: float) -> float:
+                    return 100 - t
+
+            for trigger in triggers:
+                if trigger.get("alertThreshold") is not None:
+                    trigger["alertThreshold"] = translate_threshold(trigger["alertThreshold"])
+            if data.get("resolveThreshold") is not None:
+                data["resolveThreshold"] = translate_threshold(data["resolveThreshold"])
+
         for trigger in triggers:
             label = trigger.get("label")
             condition_result = (

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -208,25 +208,25 @@ def translate_metric_alert_to_detector_payload(data: dict[str, Any]) -> dict[str
             trigger_condition_type = Condition.LESS
             resolve_condition_type = Condition.GREATER_OR_EQUAL
 
+        resolve_threshold = data.get("resolveThreshold")
         # When comparisonDelta is set, the frontend sends a percent delta (e.g. 200 for "200%
         # higher"). Translate to a total-percentage comparison the way DrfAlertRuleSerializer
         # does: ABOVE → threshold + 100 (200 → 300), BELOW → 100 - threshold (40 → 60).
         if data.get("comparisonDelta") is not None:
-            if threshold_type == AlertRuleThresholdType.ABOVE.value:
 
-                def translate_threshold(t: float) -> float:
-                    return t + 100
-
-            else:
-
-                def translate_threshold(t: float) -> float:
-                    return 100 - t
+            def translate_threshold(threshold_type: int, threshold: float) -> float:
+                if threshold_type == AlertRuleThresholdType.ABOVE.value:
+                    return threshold + 100
+                else:
+                    return 100 - threshold
 
             for trigger in triggers:
-                if trigger.get("alertThreshold") is not None:
-                    trigger["alertThreshold"] = translate_threshold(trigger["alertThreshold"])
+                alert_threshold = trigger.get("alertThreshold")
+                if alert_threshold is not None:
+                    trigger["alertThreshold"] = translate_threshold(threshold_type, alert_threshold)
+
             if data.get("resolveThreshold") is not None:
-                data["resolveThreshold"] = translate_threshold(data["resolveThreshold"])
+                resolve_threshold = translate_threshold(threshold_type, resolve_threshold)
 
         for trigger in triggers:
             label = trigger.get("label")
@@ -241,7 +241,6 @@ def translate_metric_alert_to_detector_payload(data: dict[str, Any]) -> dict[str
                 }
             )
 
-        resolve_threshold = data.get("resolveThreshold")
         if resolve_threshold is None:
             warning = next((t for t in triggers if t.get("label") == "warning"), None)
             critical = next((t for t in triggers if t.get("label") == "critical"), None)
@@ -329,7 +328,8 @@ def create_metric_alert(
     if features.has("organizations:workflow-engine-rule-serializers", organization) or features.has(
         "organizations:workflow-engine-metric-alert-endpoints-post", organization
     ):
-        detector_data = translate_metric_alert_to_detector_payload(data)
+        detector_data = deepcopy(data)
+        detector_data = translate_metric_alert_to_detector_payload(detector_data)
 
         context_project = project
         if context_project is None and data.get("projects"):

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -264,7 +264,7 @@ def translate_metric_alert_to_detector_payload(data: dict[str, Any]) -> dict[str
 
     # build up config
     config: dict[str, Any] = {"detection_type": detection_type}
-    if data.get("comparisonDelta"):
+    if data.get("comparisonDelta") is not None:
         config["comparison_delta"] = int(data["comparisonDelta"] * 60)  # minutes -> seconds
 
     if data.get("sensitivity"):
@@ -331,6 +331,9 @@ def create_metric_alert(
                 )
             except Project.DoesNotExist:
                 raise ValidationError("Project slug must be passed")
+
+        if context_project is None:
+            raise ValidationError("Project slug must be passed")
 
         context = {
             "organization": organization,

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -129,8 +129,8 @@ class AlertRuleBase(APITestCase):
         return {
             "aggregate": "count()",
             "query": "",
-            "time_window": 30,
-            "detection_type": AlertRuleDetectionType.DYNAMIC,
+            "timeWindow": 30,
+            "detectionType": AlertRuleDetectionType.DYNAMIC,
             "sensitivity": AlertRuleSensitivity.LOW,
             "seasonality": AlertRuleSeasonality.AUTO,
             "thresholdType": 0,
@@ -521,11 +521,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         assert "upsampled_count() is not allowed as user input" in str(resp.data)
         assert "Use count() instead" in str(resp.data)
 
-    def test_workflow_engine_serializer(self) -> None:
-        team = self.create_team(organization=self.organization, members=[self.user])
-        ProjectTeam.objects.create(project=self.project, team=team)
-        self.login_as(self.user)
-
+    def test_workflow_engine_post_creates_only_detector(self) -> None:
         with (
             outbox_runner(),
             self.feature(
@@ -542,8 +538,93 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
                 **self.alert_rule_dict,
             )
 
-        detector = Detector.objects.get(alertruledetector__alert_rule_id=int(resp.data.get("id")))
+        assert not AlertRule.objects.filter(name=self.alert_rule_dict["name"]).exists()
+        detector = Detector.objects.get(type=MetricIssue.slug, project=self.project)
         assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
+
+    def test_workflow_engine_post_creates_only_detector_eap(self) -> None:
+        data = {
+            **self.alert_rule_dict,
+            "dataset": "events_analytics_platform",
+            "alertType": "eap_metrics",
+            "queryType": 1,
+            "aggregate": "count()",
+        }
+        with (
+            outbox_runner(),
+            self.feature(
+                [
+                    "organizations:incidents",
+                    "organizations:performance-view",
+                    "organizations:visibility-explore-view",
+                    "organizations:workflow-engine-rule-serializers",
+                ]
+            ),
+        ):
+            resp = self.get_success_response(
+                self.organization.slug,
+                status_code=201,
+                **data,
+            )
+
+        assert not AlertRule.objects.filter(name=self.alert_rule_dict["name"]).exists()
+        detector = Detector.objects.get(type=MetricIssue.slug, project=self.project)
+        assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
+        data_source = DataSource.objects.get(detector=detector)
+        query_sub = QuerySubscription.objects.get(id=data_source.source_id)
+        assert query_sub.snuba_query.dataset == Dataset.EventsAnalyticsPlatform.value
+
+    def test_workflow_engine_post_creates_only_detector_percent_based(self) -> None:
+        data = {
+            **self.alert_rule_dict,
+            "comparisonDelta": 10080.0,
+        }
+        with (
+            outbox_runner(),
+            self.feature(
+                [
+                    "organizations:incidents",
+                    "organizations:performance-view",
+                    "organizations:workflow-engine-rule-serializers",
+                ]
+            ),
+        ):
+            resp = self.get_success_response(
+                self.organization.slug,
+                status_code=201,
+                **data,
+            )
+
+        assert not AlertRule.objects.filter(name=self.alert_rule_dict["name"]).exists()
+        detector = Detector.objects.get(type=MetricIssue.slug, project=self.project)
+        assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
+
+    @patch("sentry.incidents.metric_issue_detector.send_new_detector_data")
+    def test_workflow_engine_post_creates_only_detector_anomaly_detection(
+        self, mock_send_new_detector_data: MagicMock
+    ) -> None:
+        with (
+            outbox_runner(),
+            self.feature(
+                [
+                    "organizations:incidents",
+                    "organizations:performance-view",
+                    "organizations:anomaly-detection-alerts",
+                    "organizations:workflow-engine-rule-serializers",
+                ]
+            ),
+        ):
+            resp = self.get_success_response(
+                self.organization.slug,
+                status_code=201,
+                **self.dynamic_alert_rule_dict,
+            )
+
+        assert not AlertRule.objects.filter(name=self.alert_rule_dict["name"]).exists()
+        detector = Detector.objects.get(type=MetricIssue.slug, project=self.project)
+        assert detector.config.get("detection_type") == AlertRuleDetectionType.DYNAMIC.value
+        assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
+        assert mock_send_new_detector_data.call_count == 1
 
     def test_create_alert_rule_aci(self) -> None:
         with (
@@ -1039,7 +1120,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
     @with_feature("organizations:incidents")
     def test_anomaly_detection_alert_validation_error(self) -> None:
         data = self.dynamic_alert_rule_dict
-        data["time_window"] = 10
+        data["timeWindow"] = 10
         with outbox_runner():
             resp = self.get_error_response(
                 self.organization.slug,

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -654,6 +654,22 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
             )
         assert resp.data == ["Project slug must be passed"]
 
+    def test_workflow_engine_post_missing_projects(self) -> None:
+        data = {k: v for k, v in self.alert_rule_dict.items() if k != "projects"}
+        with self.feature(
+            [
+                "organizations:incidents",
+                "organizations:performance-view",
+                "organizations:workflow-engine-rule-serializers",
+            ]
+        ):
+            resp = self.get_error_response(
+                self.organization.slug,
+                status_code=400,
+                **data,
+            )
+        assert resp.data == ["Project slug must be passed"]
+
     def test_create_alert_rule_aci(self) -> None:
         with (
             outbox_runner(),

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -43,6 +43,7 @@ from sentry.integrations.slack.utils.channel import SlackChannelIdData
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.projectteam import ProjectTeam
+from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.seer.anomaly_detection.store_data import seer_anomaly_detection_connection_pool
 from sentry.seer.anomaly_detection.types import StoreDataResponse
 from sentry.sentry_metrics import indexer
@@ -65,7 +66,16 @@ from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
 from sentry.utils.snuba import _snuba_pool
-from sentry.workflow_engine.models import Action, DataSource, Detector
+from sentry.workflow_engine.models import (
+    Action,
+    Condition,
+    DataCondition,
+    DataConditionGroup,
+    DataSource,
+    Detector,
+    DetectorWorkflow,
+    WorkflowDataConditionGroup,
+)
 from sentry.workflow_engine.types import DetectorPriorityLevel
 from tests.sentry.incidents.serializers.test_workflow_engine_base import (
     TestWorkflowEngineSerializer,
@@ -542,6 +552,63 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         assert not AlertRule.objects.filter(name=self.alert_rule_dict["name"]).exists()
         detector = Detector.objects.get(type=MetricIssue.slug, project=self.project)
         assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
+
+        # Verify the Workflow was created and linked to the Detector
+        detector_workflow = DetectorWorkflow.objects.get(detector=detector)
+        workflow = detector_workflow.workflow
+        assert workflow.name == self.alert_rule_dict["name"]
+        assert workflow.enabled is True
+        assert workflow.config == {}
+
+        # Workflow should have one action filter per trigger (critical + warning)
+        workflow_dcgs = WorkflowDataConditionGroup.objects.filter(workflow=workflow)
+        assert workflow_dcgs.count() == 2
+
+        # Critical action filter: HIGH priority condition + 1 email-to-team action
+        critical_dcg = DataConditionGroup.objects.get(
+            workflowdataconditiongroup__workflow=workflow,
+            conditions__comparison=DetectorPriorityLevel.HIGH,
+            conditions__type=Condition.ISSUE_PRIORITY_GREATER_OR_EQUAL,
+        )
+        critical_condition = DataCondition.objects.get(
+            condition_group=critical_dcg,
+            type=Condition.ISSUE_PRIORITY_GREATER_OR_EQUAL,
+        )
+        assert critical_condition.comparison == DetectorPriorityLevel.HIGH
+        assert critical_condition.condition_result is True
+
+        critical_actions = Action.objects.filter(
+            dataconditiongroupaction__condition_group=critical_dcg
+        )
+        assert critical_actions.count() == 1
+        critical_action = critical_actions.get()
+        assert critical_action.type == Action.Type.EMAIL
+        assert critical_action.data == {}
+        assert critical_action.config["target_type"] == ActionTarget.TEAM
+        assert critical_action.config["target_identifier"] == str(self.team.id)
+
+        # Warning action filter: MEDIUM priority condition + 2 email actions
+        warning_dcg = DataConditionGroup.objects.get(
+            workflowdataconditiongroup__workflow=workflow,
+            conditions__comparison=DetectorPriorityLevel.MEDIUM,
+            conditions__type=Condition.ISSUE_PRIORITY_GREATER_OR_EQUAL,
+        )
+        warning_condition = DataCondition.objects.get(
+            condition_group=warning_dcg,
+            type=Condition.ISSUE_PRIORITY_GREATER_OR_EQUAL,
+        )
+        assert warning_condition.comparison == DetectorPriorityLevel.MEDIUM
+        assert warning_condition.condition_result is True
+
+        warning_actions = Action.objects.filter(
+            dataconditiongroupaction__condition_group=warning_dcg
+        )
+        assert warning_actions.count() == 2
+        warning_action_configs = {
+            a.config["target_type"]: a.config["target_identifier"] for a in warning_actions
+        }
+        assert warning_action_configs[ActionTarget.TEAM] == str(self.team.id)
+        assert warning_action_configs[ActionTarget.USER] == str(self.user.id)
 
     def test_workflow_engine_post_creates_only_detector_eap(self) -> None:
         data = {

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -66,6 +66,7 @@ from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
 from sentry.utils.snuba import _snuba_pool
 from sentry.workflow_engine.models import Action, DataSource, Detector
+from sentry.workflow_engine.types import DetectorPriorityLevel
 from tests.sentry.incidents.serializers.test_workflow_engine_base import (
     TestWorkflowEngineSerializer,
 )
@@ -575,6 +576,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         assert query_sub.snuba_query.dataset == Dataset.EventsAnalyticsPlatform.value
 
     def test_workflow_engine_post_creates_only_detector_percent_based(self) -> None:
+        # alert_rule_dict uses thresholdType=ABOVE (0), critical=200, warning=150, resolveThreshold=100
         data = {
             **self.alert_rule_dict,
             "comparisonDelta": 10080.0,
@@ -598,6 +600,13 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         assert not AlertRule.objects.filter(name=self.alert_rule_dict["name"]).exists()
         detector = Detector.objects.get(type=MetricIssue.slug, project=self.project)
         assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
+
+        # Percent-change thresholds must be translated: ABOVE adds 100, so frontend delta 200 → 300,
+        # 150 → 250, resolveThreshold 100 → 200. Storing raw deltas would fire at the wrong level.
+        conditions = {c.condition_result: c.comparison for c in detector.get_conditions()}
+        assert conditions[DetectorPriorityLevel.HIGH] == 300  # critical 200 + 100
+        assert conditions[DetectorPriorityLevel.MEDIUM] == 250  # warning 150 + 100
+        assert conditions[DetectorPriorityLevel.OK] == 200  # resolve 100 + 100
 
     @patch("sentry.incidents.metric_issue_detector.send_new_detector_data")
     def test_workflow_engine_post_creates_only_detector_anomaly_detection(

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -626,6 +626,25 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
         assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
         assert mock_send_new_detector_data.call_count == 1
 
+    def test_workflow_engine_post_invalid_project_slug(self) -> None:
+        data = {
+            **self.alert_rule_dict,
+            "projects": ["nonexistent-project-slug"],
+        }
+        with self.feature(
+            [
+                "organizations:incidents",
+                "organizations:performance-view",
+                "organizations:workflow-engine-rule-serializers",
+            ]
+        ):
+            resp = self.get_error_response(
+                self.organization.slug,
+                status_code=400,
+                **data,
+            )
+        assert resp.data == ["Project slug must be passed"]
+
     def test_create_alert_rule_aci(self) -> None:
         with (
             outbox_runner(),


### PR DESCRIPTION
Take a metric alert rule payload and form it into a metric detector payload. Single write a metric detector and return the response in the shape of a metric alert rule