### PR TITLE
feat(tracemetrics): Add updating functionality to alerts

### DIFF
--- a/static/app/views/detectors/components/forms/metric/metric.tsx
+++ b/static/app/views/detectors/components/forms/metric/metric.tsx
@@ -22,7 +22,7 @@ import {pulse} from 'sentry/styles/animations';
 import {PriorityLevel} from 'sentry/types/group';
 import {DataConditionType} from 'sentry/types/workflowEngine/dataConditions';
 import type {Detector, MetricDetectorConfig} from 'sentry/types/workflowEngine/detectors';
-import {generateFieldAsString, isEquation} from 'sentry/utils/discover/fields';
+import {generateFieldAsString} from 'sentry/utils/discover/fields';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {
@@ -407,10 +407,6 @@ function CustomizeMetricSection({step}: {step?: number}) {
   const query = useMetricDetectorFormField(METRIC_DETECTOR_FORM_FIELDS.query);
   const isTransactionsDataset = dataset === DetectorDataset.TRANSACTIONS;
 
-  const aggregateFunction = useMetricDetectorFormField(
-    METRIC_DETECTOR_FORM_FIELDS.aggregateFunction
-  );
-
   return (
     <Container>
       <FormSection step={step} title={t('Customize Metric')}>
@@ -483,9 +479,7 @@ function CustomizeMetricSection({step}: {step?: number}) {
           </DisabledSection>
         </Tooltip>
         {canUseMetricsEquationsInAlerts(organization) &&
-        dataset === DetectorDataset.METRICS &&
-        aggregateFunction &&
-        isEquation(aggregateFunction) ? null : (
+        dataset === DetectorDataset.METRICS ? null : (
           <Tooltip
             title={TRANSACTIONS_DATASET_DEPRECATION_MESSAGE}
             isHoverable

--- a/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
@@ -52,6 +52,19 @@ import {
 const FUNCTION_GRID_COLUMNS = '24px 24px 3fr 2fr 6fr 40px';
 const EQUATION_GRID_COLUMNS = '24px 24px 5fr 6fr 40px';
 
+function computeEquationReferencedLabels(
+  equationQuery: MetricQuery | undefined,
+  referenceMap: Record<string, string>
+): string[] {
+  const visualize = equationQuery?.queryParams.visualizes[0];
+  if (!visualize || !isVisualizeEquation(visualize)) {
+    return [];
+  }
+  const labelSet = new Set(Object.keys(referenceMap));
+  const unresolvedText = unresolveExpression(visualize.expression.text, referenceMap);
+  return extractReferenceLabels(new Expression(unresolvedText, labelSet));
+}
+
 export function MetricsEquationVisualize() {
   const organization = useOrganization();
   const hasEquations = canUseMetricsEquationsInAlerts(organization);
@@ -134,27 +147,21 @@ function MetricsEquationVisualizeContent() {
     [metricQueries]
   );
 
-  // Labels (A, B, …) from the function rows that are actually used inside
-  // the equation expression. Metrics in this set cannot be deleted without
-  // leaving dangling references.
-  const referencedLabels = useMemo(() => {
-    if (!equationQuery) {
-      return new Set<string>();
+  // Labels (A, B, etc) from the function rows used inside the equation.
+  const [equationReferencedLabels, setEquationReferencedLabels] = useState<string[]>(() =>
+    computeEquationReferencedLabels(equationQuery, referenceMap)
+  );
+  const referencedLabels = useMemo(
+    () => new Set(equationReferencedLabels),
+    [equationReferencedLabels]
+  );
+
+  const hasEquationRow = Boolean(equationQuery);
+  useEffect(() => {
+    if (!hasEquationRow) {
+      setEquationReferencedLabels([]);
     }
-    const equationVisualize = equationQuery.queryParams.visualizes[0];
-    if (!equationVisualize || !isVisualizeEquation(equationVisualize)) {
-      return new Set<string>();
-    }
-    const labelSet = new Set(
-      functionQueries.map(q => q.label).filter((l): l is string => Boolean(l))
-    );
-    const unresolvedText = unresolveExpression(
-      equationVisualize.expression.text,
-      referenceMap
-    );
-    const expr = new Expression(unresolvedText, labelSet);
-    return new Set(extractReferenceLabels(expr));
-  }, [equationQuery, functionQueries, referenceMap]);
+  }, [hasEquationRow]);
 
   return (
     <Stack gap="md">
@@ -187,6 +194,7 @@ function MetricsEquationVisualizeContent() {
                 selectedLabel !== undefined && selectedLabel === equationQuery.label
               }
               onRowSelection={onRowSelection}
+              onReferenceLabelsChange={setEquationReferencedLabels}
             />
           </RowProvider>
         </Fragment>
@@ -281,12 +289,14 @@ function MetricToolbar({
   canDelete,
   isSelected,
   onRowSelection,
+  onReferenceLabelsChange,
 }: {
   canDelete: boolean;
   isSelected: boolean;
   metricQuery: MetricQuery;
   onRowSelection: (label: string) => void;
   referenceMap: Record<string, string>;
+  onReferenceLabelsChange?: (labels: string[]) => void;
 }) {
   const visualize = useMetricVisualize();
   const setVisualize = useSetMetricVisualize();
@@ -299,11 +309,19 @@ function MetricToolbar({
     },
     [metricQuery]
   );
-  const handleExpressionChange = (resolvedExpression: Expression) => {
+  const handleExpressionChange = (
+    resolvedExpression: Expression,
+    internalText: string
+  ) => {
     if (isVisualizeEquation(visualize)) {
       setVisualize(
         visualize.replace({yAxis: `${EQUATION_PREFIX}${resolvedExpression.text}`})
       );
+      // Report the user's typed labels (pre-resolve) so identical rows don't
+      // collapse the lock onto whichever label sorts first in the map.
+      const labelSet = new Set(Object.keys(referenceMap));
+      const expr = new Expression(internalText, labelSet);
+      onReferenceLabelsChange?.(extractReferenceLabels(expr));
     }
   };
 

--- a/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
@@ -240,18 +240,24 @@ function FunctionColumnHeaders() {
     <Grid width="100%" align="center" gap="md" columns={FUNCTION_GRID_COLUMNS}>
       <div />
       <div />
-      <Tooltip title={t('The metric to aggregate in this row.')} showUnderline>
-        <SectionLabel>{t('Metric')}</SectionLabel>
-      </Tooltip>
-      <Tooltip title={t('The aggregation operation to apply.')} showUnderline>
-        <SectionLabel>{t('Operation')}</SectionLabel>
-      </Tooltip>
-      <Tooltip
-        title={t('Restrict this metric to events matching a filter.')}
-        showUnderline
-      >
-        <SectionLabel>{t('Filter')}</SectionLabel>
-      </Tooltip>
+      <div>
+        <Tooltip title={t('The metric to aggregate in this row.')} showUnderline>
+          <SectionLabel>{t('Metric')}</SectionLabel>
+        </Tooltip>
+      </div>
+      <div>
+        <Tooltip title={t('The aggregation operation to apply.')} showUnderline>
+          <SectionLabel>{t('Operation')}</SectionLabel>
+        </Tooltip>
+      </div>
+      <div>
+        <Tooltip
+          title={t('Restrict this metric to events matching a filter.')}
+          showUnderline
+        >
+          <SectionLabel>{t('Filter')}</SectionLabel>
+        </Tooltip>
+      </div>
       <div />
     </Grid>
   );
@@ -262,18 +268,22 @@ function EquationColumnHeader() {
     <Grid width="100%" align="center" gap="md" columns={EQUATION_GRID_COLUMNS}>
       <div />
       <div />
-      <Tooltip
-        title={t('Combine the metrics above with an arithmetic expression.')}
-        showUnderline
-      >
-        <SectionLabel>{t('Equation')}</SectionLabel>
-      </Tooltip>
-      <Tooltip
-        title={t('Restrict this equation to events matching a filter.')}
-        showUnderline
-      >
-        <SectionLabel>{t('Filter')}</SectionLabel>
-      </Tooltip>
+      <div>
+        <Tooltip
+          title={t('Combine the metrics above with an arithmetic expression.')}
+          showUnderline
+        >
+          <SectionLabel>{t('Equation')}</SectionLabel>
+        </Tooltip>
+      </div>
+      <div>
+        <Tooltip
+          title={t('Restrict this equation to events matching a filter.')}
+          showUnderline
+        >
+          <SectionLabel>{t('Filter')}</SectionLabel>
+        </Tooltip>
+      </div>
       <div />
     </Grid>
   );

--- a/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
@@ -174,9 +174,7 @@ function MetricsEquationVisualizeContent() {
               metricQuery={metricQuery}
               referenceMap={referenceMap}
               canDelete={functionQueries.length > 1 && !isReferenced}
-              isSelected={
-                selectedLabel !== undefined && selectedLabel === metricQuery.label
-              }
+              isSelected={selectedLabel === metricQuery.label}
               onRowSelection={onRowSelection}
             />
           </RowProvider>
@@ -190,9 +188,7 @@ function MetricsEquationVisualizeContent() {
               metricQuery={equationQuery}
               referenceMap={referenceMap}
               canDelete
-              isSelected={
-                selectedLabel !== undefined && selectedLabel === equationQuery.label
-              }
+              isSelected={selectedLabel === equationQuery.label}
               onRowSelection={onRowSelection}
               onReferenceLabelsChange={setEquationReferencedLabels}
             />

--- a/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
@@ -77,7 +77,7 @@ export function MetricsEquationVisualize() {
   // discarded so unsaved row edits survive form writes. Remounting the provider
   // (via a `key` on this component) is the escape hatch for true re-hydration.
   const initialQueries = useMemo(() => {
-    const parsed = parseAggregateExpression(aggregateFunction, query);
+    const parsed = parseAggregateExpression(aggregateFunction ?? '', query);
     return parsed.equationRow
       ? [...parsed.metricQueries, parsed.equationRow]
       : parsed.metricQueries;

--- a/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
@@ -238,8 +238,7 @@ function RowProvider({
 function FunctionColumnHeaders() {
   return (
     <Grid width="100%" align="center" gap="md" columns={FUNCTION_GRID_COLUMNS}>
-      <div />
-      <div />
+      <div style={{gridColumn: 'span 2'}} />
       <div>
         <Tooltip title={t('The metric to aggregate in this row.')} showUnderline>
           <SectionLabel>{t('Metric')}</SectionLabel>
@@ -266,8 +265,7 @@ function FunctionColumnHeaders() {
 function EquationColumnHeader() {
   return (
     <Grid width="100%" align="center" gap="md" columns={EQUATION_GRID_COLUMNS}>
-      <div />
-      <div />
+      <div style={{gridColumn: 'span 2'}} />
       <div>
         <Tooltip
           title={t('Combine the metrics above with an arithmetic expression.')}

--- a/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
@@ -58,12 +58,13 @@ export function MetricsEquationVisualize() {
   const aggregateFunction = useMetricDetectorFormField(
     METRIC_DETECTOR_FORM_FIELDS.aggregateFunction
   );
+  const query = useMetricDetectorFormField(METRIC_DETECTOR_FORM_FIELDS.query);
 
   // Parse once at mount; subsequent aggregateFunction changes are intentionally
   // discarded so unsaved row edits survive form writes. Remounting the provider
   // (via a `key` on this component) is the escape hatch for true re-hydration.
   const initialQueries = useMemo(() => {
-    const parsed = parseAggregateExpression(aggregateFunction ?? '');
+    const parsed = parseAggregateExpression(aggregateFunction, query);
     return parsed.equationRow
       ? [...parsed.metricQueries, parsed.equationRow]
       : parsed.metricQueries;

--- a/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
@@ -1,11 +1,14 @@
-import {Fragment, useMemo} from 'react';
+import {Fragment, useCallback, useContext, useEffect, useMemo, useState} from 'react';
 import noop from 'lodash/noop';
 
 import {Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Radio} from '@sentry/scraps/radio';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {Expression} from 'sentry/components/arithmeticBuilder/expression';
+import {FormContext} from 'sentry/components/forms/formContext';
 import {t} from 'sentry/locale';
+import {EQUATION_PREFIX} from 'sentry/utils/discover/fields';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   METRIC_DETECTOR_FORM_FIELDS,
@@ -19,11 +22,12 @@ import {
   unresolveExpression,
 } from 'sentry/views/explore/metrics/equationBuilder/utils';
 import {useMetricReferences} from 'sentry/views/explore/metrics/hooks/useMetricReferences';
-import type {MetricQuery} from 'sentry/views/explore/metrics/metricQuery';
+import type {MetricQuery, TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
 import {canUseMetricsEquationsInAlerts} from 'sentry/views/explore/metrics/metricsFlags';
 import {
   MetricsQueryParamsProvider,
   useMetricVisualize,
+  useSetMetricVisualize,
   useTraceMetric,
 } from 'sentry/views/explore/metrics/metricsQueryParams';
 import {AggregateDropdown} from 'sentry/views/explore/metrics/metricToolbar/aggregateDropdown';
@@ -36,14 +40,17 @@ import {
   useAddMetricQuery,
   useMultiMetricsQueryParams,
 } from 'sentry/views/explore/metrics/multiMetricsQueryParams';
-import {parseAggregateExpression} from 'sentry/views/explore/metrics/parseAggregateExpression';
+import {
+  EQUATION_LABEL,
+  parseAggregateExpression,
+} from 'sentry/views/explore/metrics/parseAggregateExpression';
 import {
   isVisualizeEquation,
   isVisualizeFunction,
 } from 'sentry/views/explore/queryParams/visualize';
 
-const FUNCTION_GRID_COLUMNS = '24px 3fr 2fr 6fr 40px';
-const EQUATION_GRID_COLUMNS = '24px 5fr 6fr 40px';
+const FUNCTION_GRID_COLUMNS = '24px 24px 3fr 2fr 6fr 40px';
+const EQUATION_GRID_COLUMNS = '24px 24px 5fr 6fr 40px';
 
 export function MetricsEquationVisualize() {
   const organization = useOrganization();
@@ -74,10 +81,48 @@ export function MetricsEquationVisualize() {
 }
 
 function MetricsEquationVisualizeContent() {
+  const formContext = useContext(FormContext);
+  const initialAggregate = useMetricDetectorFormField(
+    METRIC_DETECTOR_FORM_FIELDS.aggregateFunction
+  );
   const metricQueries = useMultiMetricsQueryParams();
   const referenceMap = useMetricReferences(metricQueries);
   const addAggregate = useAddMetricQuery({type: 'aggregate'});
   const addEquation = useAddMetricQuery({type: 'equation'});
+
+  // Track the selected row by its stable label (A, B, …)
+  const [selectedLabel, setSelectedLabel] = useState<string | undefined>(() => {
+    const match = metricQueries.find(
+      q => q.queryParams.visualizes[0]?.yAxis === initialAggregate
+    );
+    return match?.label ?? metricQueries[0]?.label;
+  });
+
+  const onRowSelection = useCallback((label: string) => {
+    setSelectedLabel(label);
+  }, []);
+
+  // Keep the form's aggregate + filter query in sync with whichever row the
+  // radio currently points at, following edits to that row.
+  useEffect(() => {
+    let selectedQuery = metricQueries.find(q => q.label === selectedLabel);
+    if (!selectedQuery && metricQueries.length > 0) {
+      selectedQuery = metricQueries[0];
+      setSelectedLabel(selectedQuery?.label);
+    }
+
+    const selectedYAxis = selectedQuery?.queryParams.visualizes[0]?.yAxis;
+    const selectedFilter = selectedQuery?.queryParams.query;
+    if (selectedYAxis !== undefined) {
+      formContext.form?.setValue(
+        METRIC_DETECTOR_FORM_FIELDS.aggregateFunction,
+        selectedYAxis
+      );
+    }
+    if (selectedFilter !== undefined) {
+      formContext.form?.setValue(METRIC_DETECTOR_FORM_FIELDS.query, selectedFilter);
+    }
+  }, [metricQueries, selectedLabel, formContext.form]);
 
   const functionQueries = useMemo(
     () => metricQueries.filter(q => isVisualizeFunction(q.queryParams.visualizes[0]!)),
@@ -121,6 +166,10 @@ function MetricsEquationVisualizeContent() {
               metricQuery={metricQuery}
               referenceMap={referenceMap}
               canDelete={functionQueries.length > 1 && !isReferenced}
+              isSelected={
+                selectedLabel !== undefined && selectedLabel === metricQuery.label
+              }
+              onRowSelection={onRowSelection}
             />
           </RowProvider>
         );
@@ -133,6 +182,10 @@ function MetricsEquationVisualizeContent() {
               metricQuery={equationQuery}
               referenceMap={referenceMap}
               canDelete
+              isSelected={
+                selectedLabel !== undefined && selectedLabel === equationQuery.label
+              }
+              onRowSelection={onRowSelection}
             />
           </RowProvider>
         </Fragment>
@@ -181,6 +234,7 @@ function FunctionColumnHeaders() {
   return (
     <Grid width="100%" align="center" gap="md" columns={FUNCTION_GRID_COLUMNS}>
       <div />
+      <div />
       <Tooltip title={t('The metric to aggregate in this row.')} showUnderline>
         <SectionLabel>{t('Metric')}</SectionLabel>
       </Tooltip>
@@ -201,6 +255,7 @@ function FunctionColumnHeaders() {
 function EquationColumnHeader() {
   return (
     <Grid width="100%" align="center" gap="md" columns={EQUATION_GRID_COLUMNS}>
+      <div />
       <div />
       <Tooltip
         title={t('Combine the metrics above with an arithmetic expression.')}
@@ -223,18 +278,33 @@ function MetricToolbar({
   metricQuery,
   referenceMap,
   canDelete,
+  isSelected,
+  onRowSelection,
 }: {
   canDelete: boolean;
+  isSelected: boolean;
   metricQuery: MetricQuery;
+  onRowSelection: (label: string) => void;
   referenceMap: Record<string, string>;
 }) {
   const visualize = useMetricVisualize();
+  const setVisualize = useSetMetricVisualize();
   const traceMetric = useTraceMetric();
   const queryLabel = metricQuery.label ?? '';
 
-  const setTraceMetric = () => {};
-  const handleExpressionChange = () => {};
-  const handleReferenceLabelsChange = () => {};
+  const setTraceMetric = useCallback(
+    (newTraceMetric: TraceMetric) => {
+      metricQuery.setTraceMetric(newTraceMetric);
+    },
+    [metricQuery]
+  );
+  const handleExpressionChange = (resolvedExpression: Expression) => {
+    if (isVisualizeEquation(visualize)) {
+      setVisualize(
+        visualize.replace({yAxis: `${EQUATION_PREFIX}${resolvedExpression.text}`})
+      );
+    }
+  };
 
   return (
     <Grid
@@ -246,6 +316,15 @@ function MetricToolbar({
       }
       data-test-id="metric-toolbar"
     >
+      <Radio
+        name="metricAggregateRow"
+        checked={isSelected}
+        onChange={() =>
+          onRowSelection(isVisualizeEquation(visualize) ? EQUATION_LABEL : queryLabel)
+        }
+        aria-label={t('Use row %s as the alert aggregate', queryLabel)}
+        disabled={isVisualizeFunction(visualize) && traceMetric.name === ''}
+      />
       <VisualizeLabel
         label={queryLabel}
         visualize={visualize}
@@ -265,7 +344,6 @@ function MetricToolbar({
             expression={visualize.expression.text}
             referenceMap={referenceMap}
             handleExpressionChange={handleExpressionChange}
-            onReferenceLabelsChange={handleReferenceLabelsChange}
           />
           <Filter traceMetric={traceMetric} skipTraceMetricFilter />
           <DeleteMetricButton />

--- a/static/app/views/detectors/components/forms/metric/visualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/visualize.tsx
@@ -12,7 +12,7 @@ import {FormContext} from 'sentry/components/forms/formContext';
 import {t} from 'sentry/locale';
 import type {SelectValue} from 'sentry/types/core';
 import type {AggregateParameter} from 'sentry/utils/discover/fields';
-import {isEquation, parseFunction} from 'sentry/utils/discover/fields';
+import {parseFunction} from 'sentry/utils/discover/fields';
 import {
   AggregationKey,
   ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
@@ -224,11 +224,8 @@ export function Visualize() {
   const organization = useOrganization();
   const dataset = useMetricDetectorFormField(METRIC_DETECTOR_FORM_FIELDS.dataset);
 
-  const aggregateFunction = useMetricDetectorFormField(
-    METRIC_DETECTOR_FORM_FIELDS.aggregateFunction
-  );
   if (dataset === DetectorDataset.METRICS) {
-    if (canUseMetricsEquationsInAlerts(organization) && isEquation(aggregateFunction)) {
+    if (canUseMetricsEquationsInAlerts(organization)) {
       return <MetricsEquationVisualize />;
     }
     return <MetricsVisualize />;

--- a/static/app/views/explore/metrics/parseAggregateExpression.tsx
+++ b/static/app/views/explore/metrics/parseAggregateExpression.tsx
@@ -91,13 +91,13 @@ function makeMetricQuery(
   };
 }
 
-function makeEquationRow(prefixedEquation: string, query: string): BaseMetricQuery {
+function makeEquationRow(prefixedEquation: string, query?: string): BaseMetricQuery {
   const base = defaultMetricQuery({type: 'equation'});
   return {
     metric: {name: '', type: ''},
     queryParams: base.queryParams.replace({
       aggregateFields: [new VisualizeEquation(prefixedEquation)],
-      query,
+      query: query ?? '',
     }),
     label: EQUATION_LABEL,
   };
@@ -120,7 +120,7 @@ function defaultRow(label: string): BaseMetricQuery {
  */
 export function parseAggregateExpression(
   aggregate: string,
-  query: string
+  query?: string
 ): ParsedAggregateExpression {
   if (!isEquation(aggregate)) {
     const tokens = tokenizeExpression(aggregate);

--- a/static/app/views/explore/metrics/parseAggregateExpression.tsx
+++ b/static/app/views/explore/metrics/parseAggregateExpression.tsx
@@ -13,7 +13,12 @@ import {
   VisualizeEquation,
   VisualizeFunction,
 } from 'sentry/views/explore/queryParams/visualize';
-import {getFunctionLabel} from 'sentry/views/explore/toolbar/toolbarVisualize';
+import {
+  getFunctionLabel,
+  getVisualizeLabel,
+} from 'sentry/views/explore/toolbar/toolbarVisualize';
+
+export const EQUATION_LABEL = getVisualizeLabel(1, true);
 
 interface ParsedAggregateExpression {
   /**
@@ -89,6 +94,7 @@ function makeEquationRow(prefixedEquation: string): BaseMetricQuery {
     queryParams: base.queryParams.replace({
       aggregateFields: [new VisualizeEquation(prefixedEquation)],
     }),
+    label: EQUATION_LABEL,
   };
 }
 

--- a/static/app/views/explore/metrics/parseAggregateExpression.tsx
+++ b/static/app/views/explore/metrics/parseAggregateExpression.tsx
@@ -73,7 +73,11 @@ function normalizeFunctionToken(token: TokenFunction): ParsedEquationComponent {
   return {plainAggregate, filterQuery};
 }
 
-function makeMetricQuery(token: TokenFunction, label: string): BaseMetricQuery {
+function makeMetricQuery(
+  token: TokenFunction,
+  label: string,
+  filterOverride?: string
+): BaseMetricQuery {
   const {plainAggregate, filterQuery} = normalizeFunctionToken(token);
   const {traceMetric} = parseMetricAggregate(plainAggregate);
   const base = defaultMetricQuery();
@@ -82,17 +86,18 @@ function makeMetricQuery(token: TokenFunction, label: string): BaseMetricQuery {
     label,
     queryParams: base.queryParams.replace({
       aggregateFields: [new VisualizeFunction(plainAggregate)],
-      query: filterQuery,
+      query: filterOverride ?? filterQuery,
     }),
   };
 }
 
-function makeEquationRow(prefixedEquation: string): BaseMetricQuery {
+function makeEquationRow(prefixedEquation: string, query: string): BaseMetricQuery {
   const base = defaultMetricQuery({type: 'equation'});
   return {
     metric: {name: '', type: ''},
     queryParams: base.queryParams.replace({
       aggregateFields: [new VisualizeEquation(prefixedEquation)],
+      query,
     }),
     label: EQUATION_LABEL,
   };
@@ -113,14 +118,17 @@ function defaultRow(label: string): BaseMetricQuery {
  * expression may repeat a label (e.g. `A + A` when the user summed a metric
  * with an equivalent version of itself).
  */
-export function parseAggregateExpression(aggregate: string): ParsedAggregateExpression {
+export function parseAggregateExpression(
+  aggregate: string,
+  query: string
+): ParsedAggregateExpression {
   if (!isEquation(aggregate)) {
     const tokens = tokenizeExpression(aggregate);
     const functionToken = tokens.find(isTokenFunction);
     const label = getFunctionLabel(0);
     return {
       metricQueries: [
-        functionToken ? makeMetricQuery(functionToken, label) : defaultRow(label),
+        functionToken ? makeMetricQuery(functionToken, label, query) : defaultRow(label),
       ],
       compactExpression: null,
       equationRow: null,
@@ -156,6 +164,6 @@ export function parseAggregateExpression(aggregate: string): ParsedAggregateExpr
   return {
     metricQueries,
     compactExpression,
-    equationRow: makeEquationRow(aggregate),
+    equationRow: makeEquationRow(aggregate, query),
   };
 }

--- a/static/app/views/explore/metrics/parseAggregateExpression.tsx
+++ b/static/app/views/explore/metrics/parseAggregateExpression.tsx
@@ -86,7 +86,7 @@ function makeMetricQuery(
     label,
     queryParams: base.queryParams.replace({
       aggregateFields: [new VisualizeFunction(plainAggregate)],
-      query: token.text.endsWith(IF_SUFFIX) ? filterQuery : defaultFilter,
+      query: token.function.endsWith(IF_SUFFIX) ? filterQuery : defaultFilter,
     }),
   };
 }

--- a/static/app/views/explore/metrics/parseAggregateExpression.tsx
+++ b/static/app/views/explore/metrics/parseAggregateExpression.tsx
@@ -76,7 +76,7 @@ function normalizeFunctionToken(token: TokenFunction): ParsedEquationComponent {
 function makeMetricQuery(
   token: TokenFunction,
   label: string,
-  filterOverride?: string
+  defaultFilter?: string
 ): BaseMetricQuery {
   const {plainAggregate, filterQuery} = normalizeFunctionToken(token);
   const {traceMetric} = parseMetricAggregate(plainAggregate);
@@ -86,7 +86,7 @@ function makeMetricQuery(
     label,
     queryParams: base.queryParams.replace({
       aggregateFields: [new VisualizeFunction(plainAggregate)],
-      query: filterOverride ?? filterQuery,
+      query: token.text.endsWith(IF_SUFFIX) ? filterQuery : defaultFilter,
     }),
   };
 }


### PR DESCRIPTION
Uses the existing hooks to trigger updates to the alert detector state. When the metric queries changes, it also triggers an update of the form state so it's always in sync with what's selected

Also adds radio buttons so we can add multiple items and select which one we commit. Turns the default metrics experience into a single row with a radio button UI.

<img width="1395" height="393" alt="Screenshot 2026-04-20 at 5 54 36 PM" src="https://github.com/user-attachments/assets/9e8db608-4ac1-4cc5-a323-895c8a903e41" />
