### PR TITLE
ref(np): Refactors notification context into a new class

### DIFF
--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -21,11 +21,11 @@ from sentry.incidents.typings.metric_detector import (
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.services.integration.service import integration_service
 from sentry.models.activity import Activity
-from sentry.models.group import Group, GroupStatus
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.rule import Rule, RuleSource
 from sentry.notifications.types import TEST_NOTIFICATION_ID
+from sentry.notifications.utils.issue_notification_context import IssueNotificationContext
 from sentry.rules.processing.processor import activate_downstream_actions
 from sentry.services.eventstore.models import GroupEvent
 from sentry.shared_integrations.exceptions import (
@@ -431,41 +431,6 @@ class BaseMetricAlertHandler(ABC):
     ACTIVITIES_TO_INVOKE_ON = [ActivityType.SET_RESOLVED.value]
 
     @classmethod
-    def build_notification_context(cls, action: Action) -> NotificationContext:
-        return NotificationContext.from_action_model(action)
-
-    @classmethod
-    def build_alert_context(
-        cls,
-        detector: Detector,
-        evidence_data: MetricIssueEvidenceData,
-        group_status: int,
-        detector_priority_level: DetectorPriorityLevel,
-    ) -> AlertContext:
-        return AlertContext.from_workflow_engine_models(
-            detector, evidence_data, group_status, detector_priority_level
-        )
-
-    @classmethod
-    def build_metric_issue_context(
-        cls,
-        group: Group,
-        evidence_data: MetricIssueEvidenceData,
-        detector_priority_level: DetectorPriorityLevel,
-    ) -> MetricIssueContext:
-        return MetricIssueContext.from_group_event(group, evidence_data, detector_priority_level)
-
-    @classmethod
-    def build_open_period_context(cls, group: Group) -> OpenPeriodContext:
-        return OpenPeriodContext.from_group(group)
-
-    @classmethod
-    def get_trigger_status(cls, group: Group) -> TriggerStatus:
-        if group.status == GroupStatus.RESOLVED or group.status == GroupStatus.IGNORED:
-            return TriggerStatus.RESOLVED
-        return TriggerStatus.ACTIVE
-
-    @classmethod
     def send_alert(
         cls,
         notification_context: NotificationContext,
@@ -521,29 +486,13 @@ class BaseMetricAlertHandler(ABC):
 
     @classmethod
     def invoke_legacy_registry(cls, invocation: ActionInvocation) -> None:
-        event = invocation.event_data.event
+        issue_notification_context = IssueNotificationContext(invocation)
 
-        # Extract evidence data and priority based on event type
-        if isinstance(event, GroupEvent):
-            evidence_data, priority = cls._extract_from_group_event(event)
-        elif isinstance(event, Activity):
-            evidence_data, priority = cls._extract_from_activity(event)
-        else:
-            raise ValueError(
-                "WorkflowEventData.event must be a GroupEvent or Activity to invoke metric alert legacy registry"
-            )
-
-        notification_context = cls.build_notification_context(invocation.action)
-        alert_context = cls.build_alert_context(
-            invocation.detector, evidence_data, invocation.event_data.group.status, priority
-        )
-
-        metric_issue_context = cls.build_metric_issue_context(
-            invocation.event_data.group, evidence_data, priority
-        )
-        open_period_context = cls.build_open_period_context(invocation.event_data.group)
-
-        trigger_status = cls.get_trigger_status(invocation.event_data.group)
+        notification_context = issue_notification_context.notification_context
+        alert_context = issue_notification_context.alert_context
+        metric_issue_context = issue_notification_context.metric_issue_context
+        open_period_context = issue_notification_context.open_period_context
+        trigger_status = issue_notification_context.trigger_status
 
         logger.info(
             "notification_action.execute_via_metric_alert_handler",

--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -10,7 +10,6 @@ from taskbroker_client.worker.workerchild import ProcessingDeadlineExceeded
 
 from sentry.constants import ObjectStatus
 from sentry.exceptions import InvalidIdentity
-from sentry.incidents.grouptype import MetricIssueEvidenceData
 from sentry.incidents.models.incident import TriggerStatus
 from sentry.incidents.typings.metric_detector import (
     AlertContext,
@@ -20,7 +19,6 @@ from sentry.incidents.typings.metric_detector import (
 )
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.services.integration.service import integration_service
-from sentry.models.activity import Activity
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.models.rule import Rule, RuleSource
@@ -38,7 +36,6 @@ from sentry.types.rules import RuleFuture
 from sentry.workflow_engine.models import Action, AlertRuleWorkflow, Detector, Workflow
 from sentry.workflow_engine.types import (
     ActionInvocation,
-    DetectorPriorityLevel,
     WorkflowEventData,
     WorkflowId,
 )
@@ -443,46 +440,6 @@ class BaseMetricAlertHandler(ABC):
         project: Project,
     ) -> None:
         raise NotImplementedError
-
-    @staticmethod
-    def _extract_from_group_event(
-        event: GroupEvent,
-    ) -> tuple[MetricIssueEvidenceData, DetectorPriorityLevel]:
-        """
-        Extract evidence data and priority from a GroupEvent
-        """
-
-        if event.occurrence is None:
-            raise ValueError("Event occurrence is required for alert context")
-
-        if event.occurrence.priority is None:
-            raise ValueError("Event occurrence priority is required for alert context")
-
-        evidence_data = MetricIssueEvidenceData(**event.occurrence.evidence_data)
-        priority = DetectorPriorityLevel(event.occurrence.priority)
-        return evidence_data, priority
-
-    @staticmethod
-    def _extract_from_activity(
-        event: Activity,
-    ) -> tuple[MetricIssueEvidenceData, DetectorPriorityLevel]:
-        """
-        Extract evidence data and priority from an Activity event
-        """
-
-        if event.type != ActivityType.SET_RESOLVED.value:
-            raise ValueError(
-                "Activity type must be SET_RESOLVED to invoke metric alert legacy registry"
-            )
-
-        if event.data is None or not event.data:
-            raise ValueError("Activity data is required for alert context")
-
-        evidence_data_dict = dict(event.data)
-        priority = DetectorPriorityLevel.OK
-        evidence_data = MetricIssueEvidenceData(**evidence_data_dict)
-
-        return evidence_data, priority
 
     @classmethod
     def invoke_legacy_registry(cls, invocation: ActionInvocation) -> None:

--- a/src/sentry/notifications/notification_action/utils.py
+++ b/src/sentry/notifications/notification_action/utils.py
@@ -1,6 +1,11 @@
 import logging
 
+import sentry_sdk
+
+from sentry import features
+from sentry.incidents.charts import build_metric_alert_chart
 from sentry.incidents.grouptype import MetricIssue
+from sentry.integrations.metric_alerts import incident_attachment_info
 from sentry.models.activity import Activity
 from sentry.notifications.notification_action.registry import (
     group_type_notification_registry,
@@ -12,6 +17,8 @@ from sentry.notifications.platform.templates.issue import (
     IssueNotificationData,
     SerializableRuleProxy,
 )
+from sentry.notifications.platform.templates.metric_alert import MetricAlertNotificationData
+from sentry.notifications.utils.issue_notification_context import IssueNotificationContext
 from sentry.utils.registry import NoRegistrationExistsError
 from sentry.workflow_engine.types import ActionInvocation
 
@@ -133,4 +140,73 @@ def issue_notification_data_factory(invocation: ActionInvocation) -> IssueNotifi
         group_id=event_data.group.id,
         notification_uuid=invocation.notification_uuid,
         rule=rule,
+    )
+
+
+def metric_alert_notification_data_factory(
+    invocation: ActionInvocation,
+) -> MetricAlertNotificationData:
+    from sentry.notifications.notification_action.metric_alert_registry.handlers.utils import (
+        get_alert_rule_serializer,
+        get_detailed_incident_serializer,
+        get_detector_serializer,
+    )
+
+    issue_notif_context = IssueNotificationContext(invocation)
+    notification_context = issue_notif_context.notification_context
+    alert_context = issue_notif_context.alert_context
+    metric_issue_context = issue_notif_context.metric_issue_context
+    open_period_context = issue_notif_context.open_period_context
+    organization = issue_notif_context.organization
+
+    if notification_context.integration_id is None:
+        raise ValueError("Integration ID is None")
+
+    if notification_context.target_identifier is None:
+        raise ValueError("Slack channel is None")
+
+    referrer = f"metric_alert_{invocation.action.type}"
+    attachment_info = incident_attachment_info(
+        organization=organization,
+        alert_context=alert_context,
+        metric_issue_context=metric_issue_context,
+        notification_uuid=invocation.notification_uuid,
+        referrer=referrer,
+    )
+
+    alert_rule_serialized_response = get_alert_rule_serializer(invocation.detector)
+    detector_serialized_response = get_detector_serializer(invocation.detector)
+    incident_serialized_response = get_detailed_incident_serializer(issue_notif_context.open_period)
+
+    chart_url = None
+    if (
+        features.has("organizations:metric-alert-chartcuterie", organization)
+        and alert_rule_serialized_response
+        and incident_serialized_response
+    ):
+        try:
+            chart_url = build_metric_alert_chart(
+                organization=organization,
+                alert_rule_serialized_response=alert_rule_serialized_response,
+                snuba_query=metric_issue_context.snuba_query,
+                alert_context=alert_context,
+                open_period_context=open_period_context,
+                selected_incident_serialized=incident_serialized_response,
+                subscription=metric_issue_context.subscription,
+                detector_serialized_response=detector_serialized_response,
+            )
+        except Exception as e:
+            sentry_sdk.capture_exception(e)
+
+    return MetricAlertNotificationData(
+        group_id=metric_issue_context.id,
+        organization_id=organization.id,
+        notification_uuid=invocation.notification_uuid,
+        action_id=notification_context.id,
+        open_period_context=open_period_context,
+        new_status=metric_issue_context.new_status.value,
+        title=attachment_info["title"],
+        title_link=attachment_info["title_link"],
+        text=attachment_info["text"],
+        chart_url=chart_url,
     )

--- a/src/sentry/notifications/notification_action/utils.py
+++ b/src/sentry/notifications/notification_action/utils.py
@@ -144,7 +144,7 @@ def issue_notification_data_factory(invocation: ActionInvocation) -> IssueNotifi
 
 
 def metric_alert_notification_data_factory(
-    invocation: ActionInvocation,
+    issue_notif_context: IssueNotificationContext,
 ) -> MetricAlertNotificationData:
     from sentry.notifications.notification_action.metric_alert_registry.handlers.utils import (
         get_alert_rule_serializer,
@@ -152,7 +152,6 @@ def metric_alert_notification_data_factory(
         get_detector_serializer,
     )
 
-    issue_notif_context = IssueNotificationContext(invocation)
     notification_context = issue_notif_context.notification_context
     alert_context = issue_notif_context.alert_context
     metric_issue_context = issue_notif_context.metric_issue_context
@@ -165,17 +164,17 @@ def metric_alert_notification_data_factory(
     if notification_context.target_identifier is None:
         raise ValueError("Slack channel is None")
 
-    referrer = f"metric_alert_{invocation.action.type}"
+    referrer = f"metric_alert_{issue_notif_context.action_type}"
     attachment_info = incident_attachment_info(
         organization=organization,
         alert_context=alert_context,
         metric_issue_context=metric_issue_context,
-        notification_uuid=invocation.notification_uuid,
+        notification_uuid=issue_notif_context.notification_uuid,
         referrer=referrer,
     )
 
-    alert_rule_serialized_response = get_alert_rule_serializer(invocation.detector)
-    detector_serialized_response = get_detector_serializer(invocation.detector)
+    alert_rule_serialized_response = get_alert_rule_serializer(issue_notif_context.detector)
+    detector_serialized_response = get_detector_serializer(issue_notif_context.detector)
     incident_serialized_response = get_detailed_incident_serializer(issue_notif_context.open_period)
 
     chart_url = None
@@ -201,7 +200,7 @@ def metric_alert_notification_data_factory(
     return MetricAlertNotificationData(
         group_id=metric_issue_context.id,
         organization_id=organization.id,
-        notification_uuid=invocation.notification_uuid,
+        notification_uuid=issue_notif_context.notification_uuid,
         action_id=notification_context.id,
         open_period_context=open_period_context,
         new_status=metric_issue_context.new_status.value,

--- a/src/sentry/notifications/notification_action/utils.py
+++ b/src/sentry/notifications/notification_action/utils.py
@@ -162,7 +162,7 @@ def metric_alert_notification_data_factory(
         raise ValueError("Integration ID is None")
 
     if notification_context.target_identifier is None:
-        raise ValueError("Slack channel is None")
+        raise ValueError("Target identifier is None")
 
     referrer = f"metric_alert_{issue_notif_context.action_type}"
     attachment_info = incident_attachment_info(

--- a/src/sentry/notifications/utils/issue_notification_context.py
+++ b/src/sentry/notifications/utils/issue_notification_context.py
@@ -10,6 +10,8 @@ from sentry.incidents.typings.metric_detector import (
 )
 from sentry.models.activity import Activity
 from sentry.models.group import Group, GroupStatus
+from sentry.models.groupopenperiod import GroupOpenPeriod
+from sentry.models.organization import Organization
 from sentry.services.eventstore.models import GroupEvent
 from sentry.types.activity import ActivityType
 from sentry.workflow_engine.types import ActionInvocation, DetectorPriorityLevel
@@ -108,3 +110,11 @@ class IssueNotificationContext:
     @cached_property
     def open_period_context(self) -> OpenPeriodContext:
         return OpenPeriodContext.from_group(self.group)
+
+    @cached_property
+    def organization(self) -> Organization:
+        return self._invocation.detector.project.organization
+
+    @cached_property
+    def open_period(self) -> GroupOpenPeriod:
+        return GroupOpenPeriod.objects.get(id=self.metric_issue_context.open_period_identifier)

--- a/src/sentry/notifications/utils/issue_notification_context.py
+++ b/src/sentry/notifications/utils/issue_notification_context.py
@@ -1,0 +1,110 @@
+from functools import cached_property
+
+from sentry.incidents.grouptype import MetricIssueEvidenceData
+from sentry.incidents.models.incident import TriggerStatus
+from sentry.incidents.typings.metric_detector import (
+    AlertContext,
+    MetricIssueContext,
+    NotificationContext,
+    OpenPeriodContext,
+)
+from sentry.models.activity import Activity
+from sentry.models.group import Group, GroupStatus
+from sentry.services.eventstore.models import GroupEvent
+from sentry.types.activity import ActivityType
+from sentry.workflow_engine.types import ActionInvocation, DetectorPriorityLevel
+
+
+class IssueNotificationContext:
+    def __init__(self, invocation: ActionInvocation) -> None:
+        self._invocation = invocation
+
+    @staticmethod
+    def _extract_from_group_event(
+        event: GroupEvent,
+    ) -> tuple[MetricIssueEvidenceData, DetectorPriorityLevel]:
+        """
+        Extract evidence data and priority from a GroupEvent
+        """
+
+        if event.occurrence is None:
+            raise ValueError("Event occurrence is required for alert context")
+
+        if event.occurrence.priority is None:
+            raise ValueError("Event occurrence priority is required for alert context")
+
+        evidence_data = MetricIssueEvidenceData(**event.occurrence.evidence_data)
+        priority = DetectorPriorityLevel(event.occurrence.priority)
+        return evidence_data, priority
+
+    @staticmethod
+    def _extract_from_activity(
+        event: Activity,
+    ) -> tuple[MetricIssueEvidenceData, DetectorPriorityLevel]:
+        """
+        Extract evidence data and priority from an Activity event
+        """
+
+        if event.type != ActivityType.SET_RESOLVED.value:
+            raise ValueError(
+                "Activity type must be SET_RESOLVED to invoke metric alert legacy registry"
+            )
+
+        if event.data is None or not event.data:
+            raise ValueError("Activity data is required for alert context")
+
+        evidence_data_dict = dict(event.data)
+        priority = DetectorPriorityLevel.OK
+        evidence_data = MetricIssueEvidenceData(**evidence_data_dict)
+
+        return evidence_data, priority
+
+    @cached_property
+    def evidence_data_and_priority(self) -> tuple[MetricIssueEvidenceData, DetectorPriorityLevel]:
+        if isinstance(self._invocation.event_data.event, GroupEvent):
+            return self._extract_from_group_event(self._invocation.event_data.event)
+        elif isinstance(self._invocation.event_data.event, Activity):
+            return self._extract_from_activity(self._invocation.event_data.event)
+        else:
+            raise ValueError(
+                "WorkflowEventData.event must be a GroupEvent or Activity to invoke metric alert legacy registry"
+            )
+
+    @cached_property
+    def group(self) -> Group:
+        return self._invocation.event_data.group
+
+    @cached_property
+    def trigger_status(self) -> TriggerStatus:
+        group_status = self._invocation.event_data.group.status
+        if group_status == GroupStatus.RESOLVED or group_status == GroupStatus.IGNORED:
+            return TriggerStatus.RESOLVED
+        return TriggerStatus.ACTIVE
+
+    @cached_property
+    def notification_context(self) -> NotificationContext:
+        return NotificationContext.from_action_model(self._invocation.action)
+
+    @cached_property
+    def alert_context(self) -> AlertContext:
+        evidence_data, priority = self.evidence_data_and_priority
+
+        return AlertContext.from_workflow_engine_models(
+            detector=self._invocation.detector,
+            evidence_data=evidence_data,
+            group_status=self.group.status,
+            detector_priority_level=priority,
+        )
+
+    @cached_property
+    def metric_issue_context(self) -> MetricIssueContext:
+        evidence_data, priority = self.evidence_data_and_priority
+        return MetricIssueContext.from_group_event(
+            group=self.group,
+            evidence_data=evidence_data,
+            detector_priority_level=priority,
+        )
+
+    @cached_property
+    def open_period_context(self) -> OpenPeriodContext:
+        return OpenPeriodContext.from_group(self.group)

--- a/src/sentry/notifications/utils/issue_notification_context.py
+++ b/src/sentry/notifications/utils/issue_notification_context.py
@@ -14,6 +14,7 @@ from sentry.models.groupopenperiod import GroupOpenPeriod
 from sentry.models.organization import Organization
 from sentry.services.eventstore.models import GroupEvent
 from sentry.types.activity import ActivityType
+from sentry.workflow_engine.models import Detector
 from sentry.workflow_engine.types import ActionInvocation, DetectorPriorityLevel
 
 
@@ -118,3 +119,15 @@ class IssueNotificationContext:
     @cached_property
     def open_period(self) -> GroupOpenPeriod:
         return GroupOpenPeriod.objects.get(id=self.metric_issue_context.open_period_identifier)
+
+    @cached_property
+    def notification_uuid(self) -> str:
+        return self._invocation.notification_uuid
+
+    @cached_property
+    def action_type(self) -> str:
+        return self._invocation.action.type
+
+    @cached_property
+    def detector(self) -> Detector:
+        return self._invocation.detector

--- a/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
+++ b/tests/sentry/notifications/notification_action/test_metric_alert_registry_handlers.py
@@ -369,45 +369,6 @@ class TestBaseMetricAlertHandler(MetricAlertHandlerBase):
             == IncidentStatus.CLOSED
         )
 
-    def test_build_notification_context(self) -> None:
-        notification_context = self.handler.build_notification_context(self.action)
-        assert isinstance(notification_context, NotificationContext)
-        assert notification_context.target_identifier == "channel456"
-        assert notification_context.integration_id == 1234567890
-        assert notification_context.sentry_app_config is None
-
-    def test_build_alert_context(self) -> None:
-        assert self.group_event.occurrence is not None
-        assert self.group_event.occurrence.priority is not None
-        alert_context = self.handler.build_alert_context(
-            self.detector,
-            self.evidence_data,
-            self.group_event.group.status,
-            DetectorPriorityLevel(self.group_event.occurrence.priority),
-        )
-        assert isinstance(alert_context, AlertContext)
-        assert alert_context.name == self.detector.name
-        assert alert_context.action_identifier_id == self.detector.id
-        assert alert_context.threshold_type == AlertRuleThresholdType.ABOVE
-        assert alert_context.comparison_delta is None
-
-    def test_build_alert_context_anomaly_detection(self) -> None:
-        assert self.group_event.occurrence is not None
-        assert self.group_event.occurrence.priority is not None
-        alert_context = self.handler.build_alert_context(
-            self.detector,
-            self.anomaly_detection_evidence_data,
-            self.group_event.group.status,
-            DetectorPriorityLevel(self.group_event.occurrence.priority),
-        )
-        assert isinstance(alert_context, AlertContext)
-        assert alert_context.name == self.detector.name
-        assert alert_context.action_identifier_id == self.detector.id
-        assert alert_context.threshold_type == AnomalyDetectionThresholdType.ABOVE_AND_BELOW
-        assert alert_context.comparison_delta is None
-        assert alert_context.alert_threshold == 0
-        assert alert_context.resolve_threshold == 0
-
     def test_get_new_status(self) -> None:
         assert self.group_event.occurrence is not None
         assert self.group_event.occurrence.priority is not None

--- a/tests/sentry/notifications/utils/test_issue_notification_context.py
+++ b/tests/sentry/notifications/utils/test_issue_notification_context.py
@@ -1,15 +1,24 @@
 import uuid
 from dataclasses import asdict
 
+import pytest
+
+from sentry.db.models import NodeData
+from sentry.incidents.grouptype import MetricIssueEvidenceData
 from sentry.incidents.models.alert_rule import AlertRuleThresholdType
-from sentry.incidents.typings.metric_detector import AlertContext, NotificationContext
+from sentry.incidents.models.incident import IncidentStatus, TriggerStatus
+from sentry.incidents.typings.metric_detector import MetricIssueContext, OpenPeriodContext
+from sentry.models.activity import Activity
+from sentry.models.group import GroupStatus
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.utils.issue_notification_context import IssueNotificationContext
 from sentry.seer.anomaly_detection.types import AnomalyDetectionThresholdType
+from sentry.services.eventstore.models import GroupEvent
 from sentry.testutils.skips import requires_snuba
+from sentry.types.activity import ActivityType
 from sentry.types.group import PriorityLevel
 from sentry.workflow_engine.models import Action
-from sentry.workflow_engine.types import ActionInvocation, WorkflowEventData
+from sentry.workflow_engine.types import ActionInvocation, DetectorPriorityLevel, WorkflowEventData
 from tests.sentry.notifications.notification_action.test_metric_alert_registry_handlers import (
     MetricAlertHandlerBase,
 )
@@ -22,21 +31,25 @@ class TestIssueNotificationContext(MetricAlertHandlerBase):
         super().setUp()
         self.action = self.create_action(
             type=Action.Type.DISCORD,
-            integration_id="1234567890",
+            integration_id=1234567890,
             config={"target_identifier": "channel456", "target_type": ActionTarget.SPECIFIC},
             data={"tags": "environment,user,my_tag"},
         )
 
-    def _make_context(self, group_event=None) -> IssueNotificationContext:
-        event_data = self.event_data
+    def _make_context(
+        self,
+        group_event: GroupEvent | None = None,
+        event_data: WorkflowEventData | None = None,
+    ) -> IssueNotificationContext:
+        ed = event_data or self.event_data
         if group_event is not None:
-            event_data = WorkflowEventData(
+            ed = WorkflowEventData(
                 event=group_event,
                 workflow_env=self.workflow.environment,
                 group=group_event.group,
             )
         invocation = ActionInvocation(
-            event_data=event_data,
+            event_data=ed,
             action=self.action,
             detector=self.detector,
             notification_uuid=str(uuid.uuid4()),
@@ -47,16 +60,14 @@ class TestIssueNotificationContext(MetricAlertHandlerBase):
         ctx = self._make_context()
         notification_context = ctx.notification_context
 
-        assert isinstance(notification_context, NotificationContext)
         assert notification_context.target_identifier == "channel456"
-        assert notification_context.integration_id == "1234567890"
+        assert notification_context.integration_id == 1234567890
         assert notification_context.sentry_app_config is None
 
     def test_alert_context(self) -> None:
         ctx = self._make_context()
         alert_context = ctx.alert_context
 
-        assert isinstance(alert_context, AlertContext)
         assert alert_context.name == self.detector.name
         assert alert_context.action_identifier_id == self.detector.id
         assert alert_context.threshold_type == AlertRuleThresholdType.ABOVE
@@ -74,10 +85,125 @@ class TestIssueNotificationContext(MetricAlertHandlerBase):
         ctx = self._make_context(group_event=anomaly_group_event)
         alert_context = ctx.alert_context
 
-        assert isinstance(alert_context, AlertContext)
         assert alert_context.name == self.detector.name
         assert alert_context.action_identifier_id == self.detector.id
         assert alert_context.threshold_type == AnomalyDetectionThresholdType.ABOVE_AND_BELOW
         assert alert_context.comparison_delta is None
         assert alert_context.alert_threshold == 0
         assert alert_context.resolve_threshold == 0
+
+    def test_evidence_data_and_priority_from_group_event(self) -> None:
+        ctx = self._make_context()
+        evidence_data, priority = ctx.evidence_data_and_priority
+
+        assert isinstance(evidence_data, MetricIssueEvidenceData)
+        assert evidence_data.detector_id == self.detector.id
+        assert evidence_data.value == self.evidence_data.value
+        assert priority == DetectorPriorityLevel.HIGH
+
+    def test_evidence_data_and_priority_from_activity(self) -> None:
+        activity = Activity.objects.create(
+            project=self.project,
+            group=self.group,
+            type=ActivityType.SET_RESOLVED.value,
+            data=asdict(self.evidence_data),
+        )
+        event_data = WorkflowEventData(
+            event=activity,
+            workflow_env=self.workflow.environment,
+            group=self.group,
+        )
+
+        ctx = self._make_context(event_data=event_data)
+        evidence_data, priority = ctx.evidence_data_and_priority
+
+        assert isinstance(evidence_data, MetricIssueEvidenceData)
+        assert evidence_data.detector_id == self.detector.id
+        assert priority == DetectorPriorityLevel.OK
+
+    def test_evidence_data_and_priority_missing_occurrence(self) -> None:
+        event_data = WorkflowEventData(
+            event=GroupEvent(self.project.id, "test", self.group, NodeData("test-id")),
+            group=self.group,
+        )
+
+        ctx = self._make_context(event_data=event_data)
+
+        with pytest.raises(ValueError, match="Event occurrence is required"):
+            ctx.evidence_data_and_priority
+
+    def test_evidence_data_and_priority_activity_missing_data(self) -> None:
+        activity = Activity.objects.create(
+            project=self.project,
+            group=self.group,
+            type=ActivityType.SET_RESOLVED.value,
+            data=None,
+        )
+        event_data = WorkflowEventData(
+            event=activity,
+            workflow_env=self.workflow.environment,
+            group=self.group,
+        )
+
+        ctx = self._make_context(event_data=event_data)
+
+        with pytest.raises(ValueError, match="Activity data is required"):
+            ctx.evidence_data_and_priority
+
+    def test_group(self) -> None:
+        ctx = self._make_context()
+        assert ctx.group == self.group
+
+    def test_trigger_status_active(self) -> None:
+        ctx = self._make_context()
+        assert ctx.trigger_status == TriggerStatus.ACTIVE
+
+    def test_trigger_status_resolved(self) -> None:
+        self.group.status = GroupStatus.RESOLVED
+        self.group.save()
+
+        ctx = self._make_context()
+        assert ctx.trigger_status == TriggerStatus.RESOLVED
+
+    def test_trigger_status_ignored(self) -> None:
+        self.group.status = GroupStatus.IGNORED
+        self.group.save()
+
+        ctx = self._make_context()
+        assert ctx.trigger_status == TriggerStatus.RESOLVED
+
+    def test_metric_issue_context(self) -> None:
+        ctx = self._make_context()
+        metric_issue_context = ctx.metric_issue_context
+
+        assert isinstance(metric_issue_context, MetricIssueContext)
+        self.assert_metric_issue_context(
+            metric_issue_context,
+            open_period_identifier=self.open_period.id,
+            snuba_query=self.snuba_query,
+            new_status=IncidentStatus.CRITICAL,
+            metric_value=self.evidence_data.value,
+            title=self.group_event.group.title,
+            group=self.group_event.group,
+            subscription=self.subscription,
+        )
+
+    def test_open_period_context(self) -> None:
+        ctx = self._make_context()
+        open_period_context = ctx.open_period_context
+
+        assert isinstance(open_period_context, OpenPeriodContext)
+        self.assert_open_period_context(
+            open_period_context,
+            id=self.open_period.id,
+            date_started=self.open_period.date_started,
+            date_closed=None,
+        )
+
+    def test_organization(self) -> None:
+        ctx = self._make_context()
+        assert ctx.organization == self.detector.project.organization
+
+    def test_open_period(self) -> None:
+        ctx = self._make_context()
+        assert ctx.open_period == self.open_period

--- a/tests/sentry/notifications/utils/test_issue_notification_context.py
+++ b/tests/sentry/notifications/utils/test_issue_notification_context.py
@@ -1,0 +1,83 @@
+import uuid
+from dataclasses import asdict
+
+from sentry.incidents.models.alert_rule import AlertRuleThresholdType
+from sentry.incidents.typings.metric_detector import AlertContext, NotificationContext
+from sentry.notifications.models.notificationaction import ActionTarget
+from sentry.notifications.utils.issue_notification_context import IssueNotificationContext
+from sentry.seer.anomaly_detection.types import AnomalyDetectionThresholdType
+from sentry.testutils.skips import requires_snuba
+from sentry.types.group import PriorityLevel
+from sentry.workflow_engine.models import Action
+from sentry.workflow_engine.types import ActionInvocation, WorkflowEventData
+from tests.sentry.notifications.notification_action.test_metric_alert_registry_handlers import (
+    MetricAlertHandlerBase,
+)
+
+pytestmark = [requires_snuba]
+
+
+class TestIssueNotificationContext(MetricAlertHandlerBase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.action = self.create_action(
+            type=Action.Type.DISCORD,
+            integration_id="1234567890",
+            config={"target_identifier": "channel456", "target_type": ActionTarget.SPECIFIC},
+            data={"tags": "environment,user,my_tag"},
+        )
+
+    def _make_context(self, group_event=None) -> IssueNotificationContext:
+        event_data = self.event_data
+        if group_event is not None:
+            event_data = WorkflowEventData(
+                event=group_event,
+                workflow_env=self.workflow.environment,
+                group=group_event.group,
+            )
+        invocation = ActionInvocation(
+            event_data=event_data,
+            action=self.action,
+            detector=self.detector,
+            notification_uuid=str(uuid.uuid4()),
+        )
+        return IssueNotificationContext(invocation)
+
+    def test_notification_context(self) -> None:
+        ctx = self._make_context()
+        notification_context = ctx.notification_context
+
+        assert isinstance(notification_context, NotificationContext)
+        assert notification_context.target_identifier == "channel456"
+        assert notification_context.integration_id == "1234567890"
+        assert notification_context.sentry_app_config is None
+
+    def test_alert_context(self) -> None:
+        ctx = self._make_context()
+        alert_context = ctx.alert_context
+
+        assert isinstance(alert_context, AlertContext)
+        assert alert_context.name == self.detector.name
+        assert alert_context.action_identifier_id == self.detector.id
+        assert alert_context.threshold_type == AlertRuleThresholdType.ABOVE
+        assert alert_context.comparison_delta is None
+
+    def test_alert_context_anomaly_detection(self) -> None:
+        _, _, anomaly_group_event = self.create_group_event(
+            occurrence=self.create_issue_occurrence(
+                priority=PriorityLevel.HIGH.value,
+                level="error",
+                evidence_data=asdict(self.anomaly_detection_evidence_data),
+            ),
+        )
+
+        ctx = self._make_context(group_event=anomaly_group_event)
+        alert_context = ctx.alert_context
+
+        assert isinstance(alert_context, AlertContext)
+        assert alert_context.name == self.detector.name
+        assert alert_context.action_identifier_id == self.detector.id
+        assert alert_context.threshold_type == AnomalyDetectionThresholdType.ABOVE_AND_BELOW
+        assert alert_context.comparison_delta is None
+        assert alert_context.alert_threshold == 0
+        assert alert_context.resolve_threshold == 0

--- a/tests/sentry/notifications/utils/test_issue_notification_context.py
+++ b/tests/sentry/notifications/utils/test_issue_notification_context.py
@@ -53,6 +53,7 @@ class TestIssueNotificationContext(MetricAlertHandlerBase):
             action=self.action,
             detector=self.detector,
             notification_uuid=str(uuid.uuid4()),
+            workflow_id=self.workflow.id,
         )
         return IssueNotificationContext(invocation)
 


### PR DESCRIPTION
Some initial refactors of our alert context creation logic, which is fairly buried in our dispatcher code. This unifies most of the context data creation utilized by our notification dispatch, allowing us to sidestep some of our legacy notification logic.

The `IssueNotificationContext` class is meant to construct and carry most of the relevant data for Notification dispatch, with the eventual goal of eliminating our nested registries and dispatch flows.