### PR TITLE
feat(st): install gcloud for local selective testing

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -154,6 +154,9 @@ fi
 # this is the standard repo-local bin root
 PATH_add "${PWD}/.devenv/bin"
 
+# gcloud and friends
+PATH_add "/opt/homebrew/share/google-cloud-sdk/bin"
+
 ### prek ###
 
 debug "Checking prek..."

--- a/.github/workflows/scripts/selective-testing/confirm-test-selection.py
+++ b/.github/workflows/scripts/selective-testing/confirm-test-selection.py
@@ -24,14 +24,16 @@ def main() -> int:
     count = len(selected_files)
 
     if count == 0:
-        prompt = (
-            "The full test suite will be run, usually due to a change in a file that triggers the full suite (see logs above).\n"
-            "Continue? [y/N] "
+        raise SystemExit(
+            "All tests selected (a changed file triggers the full suite — see logs above).\n"
+            "You likely do not want to run the entire test suite locally. Selective testing is more conservative sometimes so that we don't undertest in CI. In some cases this won't translate well to local selective testing."
         )
     elif count >= LARGE_SELECTION_THRESHOLD:
         prompt = f"{count} test files selected, a large amount to run locally. Continue? [y/N] "
     else:
-        print(f"{count} test files selected")
+        print(f"{count} test files selected:")
+        for f in selected_files:
+            print(f"  {f}")
         return 0
 
     try:

--- a/.github/workflows/scripts/selective-testing/fetch-coverage.py
+++ b/.github/workflows/scripts/selective-testing/fetch-coverage.py
@@ -12,40 +12,47 @@ COVERAGE_FILENAME = ".coverage.combined"
 CACHE_DIR = Path.home() / ".cache" / "sentry" / "coverage" / "latest"
 
 
-def check_gcloud() -> None:
+def ensure_gcloud_authed() -> None:
     if shutil.which("gcloud") is None:
-        print("Error: gcloud is not installed.", file=sys.stderr)
-        print(
-            "Install the Google Cloud CLI: https://cloud.google.com/sdk/docs/install",
-            file=sys.stderr,
+        raise SystemExit(
+            """\
+Error: gcloud is not installed.
+
+Make sure you've run `direnv allow`.
+
+Install the Google Cloud CLI: https://cloud.google.com/sdk/docs/install
+  macOS (Homebrew): brew install --cask google-cloud-sdk"""
         )
-        print("  macOS (Homebrew): brew install --cask google-cloud-sdk", file=sys.stderr)
-        sys.exit(1)
 
-
-def check_auth() -> None:
+    # gcloud config config-helper exits 1 if there is no active account,
+    # and also prompts for yubikey 2FA if it needs refreshing.
     result = subprocess.run(
-        ["gcloud", "auth", "print-access-token"],
+        ["gcloud", "config", "config-helper"],
         capture_output=True,
-        text=True,
+        check=False,
+    )
+    if result.returncode == 0:
+        return
+
+    subprocess.run(
+        ["gcloud", "auth", "login", "--activate", "--update-adc"],
+        check=False,
+    )
+
+    # Check again, and if something's still wrong then exit.
+    result = subprocess.run(
+        ["gcloud", "config", "config-helper"],
+        capture_output=True,
         check=False,
     )
     if result.returncode != 0:
-        print("Error: Not authenticated with gcloud.", file=sys.stderr)
-        print("", file=sys.stderr)
-        print("To authenticate, run:", file=sys.stderr)
-        print("  gcloud auth login", file=sys.stderr)
-        print("  gcloud config set project sentry-dev-tooling", file=sys.stderr)
-        print("", file=sys.stderr)
-        print(
-            "You'll need access to the 'sentry-dev-tooling' GCP project.",
-            file=sys.stderr,
+        raise SystemExit(
+            """\
+Error: Not authenticated with gcloud.
+
+To authenticate, run:
+  gcloud auth login"""
         )
-        print(
-            "Request access in #discuss-dev-infra if you don't have it.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
 
 
 def get_remote_generation() -> str | None:
@@ -88,8 +95,7 @@ def download_coverage(output_path: Path) -> None:
         check=False,
     )
     if result.returncode != 0:
-        print("Error: Failed to download coverage database from GCS.", file=sys.stderr)
-        sys.exit(1)
+        raise SystemExit("Error: Failed to download coverage database from GCS.")
 
     shutil.copy2(output_path, cached_file)
     if remote_gen:
@@ -108,8 +114,7 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    check_gcloud()
-    check_auth()
+    ensure_gcloud_authed()
     download_coverage(Path(args.output))
     return 0
 

--- a/.github/workflows/scripts/selective-testing/fetch-coverage.py
+++ b/.github/workflows/scripts/selective-testing/fetch-coverage.py
@@ -109,7 +109,7 @@ def main() -> int:
     )
     parser.add_argument(
         "--output",
-        default="/tmp/sentry-selective-testing-cache/coverage.db",
+        default=".cache/coverage.db",
         help="Output path for the coverage database (default: .cache/coverage.db)",
     )
     args = parser.parse_args()

--- a/.github/workflows/scripts/selective-testing/fetch-coverage.py
+++ b/.github/workflows/scripts/selective-testing/fetch-coverage.py
@@ -109,7 +109,7 @@ def main() -> int:
     )
     parser.add_argument(
         "--output",
-        default=".cache/coverage.db",
+        default="/tmp/sentry-selective-testing-cache/coverage.db",
         help="Output path for the coverage database (default: .cache/coverage.db)",
     )
     args = parser.parse_args()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,8 @@ If a hook fails, fix the issues, stage changes, then re-run until it passes.
 
 #### Testing
 
+For backend-scoped changes, always try `make test-selective` first. It detects which tests are affected by your local diff and runs only those, making the feedback loop much faster. Fall back to `pytest` when you need to run a specific file or `test-selective` doesn't cover your case.
+
 ```bash
 # Run a specific test file.
 # Do not run pytest by itself; it'll take forever!

--- a/Brewfile
+++ b/Brewfile
@@ -1,15 +1,14 @@
 brew 'uv'
 
-# required to run devservices
-# colima is a docker-compatible container runtime
-# devenv installs and manages it as we want control over the version,
-# but we leave the qemu part to brew
-brew 'qemu'
 # while not needed by devservices, the docker cli itself is still useful
 # (not docker desktop/daemon which is provided by the cask)
 # and is used by some make targets
 brew 'docker'
 brew 'docker-buildx'
+
+# required for make test-selective
+# greedy forces cask updates
+cask 'gcloud-cli', greedy: true
 
 ### If updating below this line, please also update REQUIRED_APT_PKGS in devenv/post_fetch.py ###
 

--- a/Makefile
+++ b/Makefile
@@ -166,13 +166,14 @@ test-selective:
 		.cache/selected-tests.txt
 	SELECTED_TESTS_FILE=.cache/selected-tests.txt \
 	python3 -b -m pytest \
+		-n3 \
 		tests \
 		--reuse-db \
 		--ignore tests/acceptance \
 		--ignore tests/apidocs \
 		--ignore tests/js \
 		--ignore tests/tools \
-		-svv
+		--quiet
 	@echo ""
 
 # it's not possible to change settings.DATABASE after django startup, so

--- a/Makefile
+++ b/Makefile
@@ -156,10 +156,10 @@ test-backend-ci-with-coverage:
 test-selective:
 	@echo "--> Running selective tests based on branch changes"
 	python3 .github/workflows/scripts/selective-testing/fetch-coverage.py \
-		--output /tmp/sentry-selective-testing-cache/coverage.db
+		--output .cache/coverage.db
 	mkdir -p .cache && > .cache/selected-tests.txt
 	python3 .github/workflows/scripts/compute-sentry-selected-tests.py \
-		--coverage-db /tmp/sentry-selective-testing-cache/coverage.db \
+		--coverage-db .cache/coverage.db \
 		--changed-files "$$(git diff --name-only $$(git merge-base origin/master HEAD))" \
 		--output .cache/selected-tests.txt
 	python3 .github/workflows/scripts/selective-testing/confirm-test-selection.py \

--- a/Makefile
+++ b/Makefile
@@ -156,10 +156,10 @@ test-backend-ci-with-coverage:
 test-selective:
 	@echo "--> Running selective tests based on branch changes"
 	python3 .github/workflows/scripts/selective-testing/fetch-coverage.py \
-		--output .cache/coverage.db
+		--output /tmp/sentry-selective-testing-cache/coverage.db
 	mkdir -p .cache && > .cache/selected-tests.txt
 	python3 .github/workflows/scripts/compute-sentry-selected-tests.py \
-		--coverage-db .cache/coverage.db \
+		--coverage-db /tmp/sentry-selective-testing-cache/coverage.db \
 		--changed-files "$$(git diff --name-only $$(git merge-base origin/master HEAD))" \
 		--output .cache/selected-tests.txt
 	python3 .github/workflows/scripts/selective-testing/confirm-test-selection.py \

--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -9,7 +9,7 @@ import tempfile
 import urllib.request
 import zipfile
 
-from devenv.lib import colima, config, fs, limactl, proc
+from devenv.lib import brew, colima, config, fs, limactl, proc
 
 from devenv import constants
 
@@ -187,6 +187,13 @@ def main(context: dict[str, str]) -> int:
     FRONTEND_ONLY = os.environ.get("SENTRY_DEVENV_FRONTEND_ONLY") is not None
     SKIP_FRONTEND = os.environ.get("SENTRY_DEVENV_SKIP_FRONTEND") is not None
     IN_GIT_WORKTREE = os.path.isfile(f"{reporoot}/.git")
+
+    brew.install()
+
+    proc.run(
+        (f"{constants.homebrew_bin}/brew", "bundle"),
+        cwd=reporoot,
+    )
 
     if constants.DARWIN and os.path.exists(f"{constants.root}/bin/colima"):
         binroot = f"{reporoot}/.devenv/bin"

--- a/devenv/sync.py
+++ b/devenv/sync.py
@@ -188,12 +188,13 @@ def main(context: dict[str, str]) -> int:
     SKIP_FRONTEND = os.environ.get("SENTRY_DEVENV_SKIP_FRONTEND") is not None
     IN_GIT_WORKTREE = os.path.isfile(f"{reporoot}/.git")
 
-    brew.install()
+    if constants.DARWIN:
+        brew.install()
 
-    proc.run(
-        (f"{constants.homebrew_bin}/brew", "bundle"),
-        cwd=reporoot,
-    )
+        proc.run(
+            (f"{constants.homebrew_bin}/brew", "bundle"),
+            cwd=reporoot,
+        )
 
     if constants.DARWIN and os.path.exists(f"{constants.root}/bin/colima"):
         binroot = f"{reporoot}/.devenv/bin"


### PR DESCRIPTION
this installs gcloud via brew for local selective testing (we don't have this as a service yet)

also includes a lot of small quality of life fixes

- automatic gcloud yubikey 2fa prompting (taken from ops devenv, which I also wrote)
- -n3 (xdist) and --quiet for `make test-selective` - agents don't need verbose pytest output, only failures are relevant
- qemu uninstalled (i forgot to remove this a long time ago ever since we dropped support for macos intel, colima doesn't use qemu anymore on mac arm)
- moved the coverage cache dir into /tmp just cause im scared of somehow someone committing it lol