### PR TITLE
feat(supergroups): Track drawer opens and add feedback button to header

### DIFF
--- a/static/app/components/stream/supergroups/supergroupRow.tsx
+++ b/static/app/components/stream/supergroups/supergroupRow.tsx
@@ -56,7 +56,11 @@ export function SupergroupRow({
   const highlighted = isActive && isDrawerOpen;
 
   return (
-    <Wrapper onClick={handleClick} highlighted={highlighted}>
+    <Wrapper
+      onClick={handleClick}
+      highlighted={highlighted}
+      data-sentry-component="SupergroupRow"
+    >
       <InteractionStateLayer />
       <IconArea>
         <AccentIcon size="md" />

--- a/static/app/utils/analytics/workflowAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/workflowAnalyticsEvents.tsx
@@ -181,6 +181,9 @@ export type TeamInsightsEventParameters = {
   'releases_list.click_add_release_health': {
     project_id: number;
   };
+  'supergroup.drawer_opened': {
+    supergroup_id: number;
+  };
   'supergroup.feedback_submitted': {
     choice_selected: boolean;
     supergroup_id: number;
@@ -264,6 +267,7 @@ export const workflowEventMap: Record<TeamInsightsEventKey, string | null> = {
   'releases_list.click_add_release_health': 'Releases List: Click Add Release Health',
   trace_timeline_clicked: 'Trace Timeline Clicked',
   trace_timeline_more_events_clicked: 'Trace Timeline More Events Clicked',
+  'supergroup.drawer_opened': 'Supergroup Drawer Opened',
   'supergroup.feedback_submitted': 'Supergroup Feedback Submitted',
   'suspect_commit.feedback_submitted': 'Suspect Commit Feedback Submitted',
 };

--- a/static/app/views/issueList/supergroups/supergroupDrawer.tsx
+++ b/static/app/views/issueList/supergroups/supergroupDrawer.tsx
@@ -99,7 +99,6 @@ export function SupergroupDetailDrawer({
               },
             }}
             tooltipProps={{title: t('Give feedback on Issue Groups')}}
-            aria-label={t('Give feedback on Issue Groups')}
           />
         </Flex>
       </DrawerHeader>

--- a/static/app/views/issueList/supergroups/supergroupDrawer.tsx
+++ b/static/app/views/issueList/supergroups/supergroupDrawer.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useMemo, useState} from 'react';
+import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Badge} from '@sentry/scraps/badge';
@@ -16,6 +16,7 @@ import {
 } from 'sentry/actionCreators/indicator';
 import type {IndexedMembersByProject} from 'sentry/actionCreators/members';
 import {NavigationCrumbs} from 'sentry/components/events/eventDrawer';
+import {FeedbackButton} from 'sentry/components/feedbackButton/feedbackButton';
 import {DrawerBody, DrawerHeader} from 'sentry/components/globalDrawer/components';
 import type {GroupListColumn} from 'sentry/components/issues/groupList';
 import {IssueStreamHeaderLabel} from 'sentry/components/IssueStreamHeaderLabel';
@@ -32,6 +33,7 @@ import {IconChevron, IconFilter} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {GroupStore} from 'sentry/stores/groupStore';
 import type {Group} from 'sentry/types/group';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {uniq} from 'sentry/utils/array/uniq';
 import {MarkedText} from 'sentry/utils/marked/markedText';
@@ -70,6 +72,15 @@ export function SupergroupDetailDrawer({
   memberList,
   filterWithCurrentSearch,
 }: SupergroupDetailDrawerProps) {
+  const organization = useOrganization();
+
+  useEffect(() => {
+    trackAnalytics('supergroup.drawer_opened', {
+      supergroup_id: supergroup.id,
+      organization,
+    });
+  }, [supergroup.id, organization]);
+
   return (
     <Fragment>
       <DrawerHeader hideBar>
@@ -78,6 +89,18 @@ export function SupergroupDetailDrawer({
             <NavigationCrumbs crumbs={[{label: t('Issue Groups')}]} />
             <Badge variant="experimental">{t('Experimental')}</Badge>
           </Flex>
+          <FeedbackButton
+            size="xs"
+            feedbackOptions={{
+              formTitle: t('Give feedback on Issue Groups'),
+              messagePlaceholder: t('How can we make Issue Groups better for you?'),
+              tags: {
+                ['feedback.source']: 'supergroup_drawer',
+              },
+            }}
+            tooltipProps={{title: t('Give feedback on Issue Groups')}}
+            aria-label={t('Give feedback on Issue Groups')}
+          />
         </Flex>
       </DrawerHeader>
       <DrawerContentBody>


### PR DESCRIPTION
Fires a new `supergroup.drawer_opened` analytics event on mount of the supergroup detail drawer.

Adds a `FeedbackButton` (icon-only megaphone) into the drawer header row alongside the breadcrumbs