### PR TITLE
ref(seer): Remove duplicate useFetchAgentOptions, replaced by useCodingAgentSelectQueryOptions

### DIFF
--- a/static/app/utils/seer/preferredAgent.tsx
+++ b/static/app/utils/seer/preferredAgent.tsx
@@ -1,4 +1,4 @@
-import type {QueryClient} from '@tanstack/react-query';
+import {queryOptions, type QueryClient} from '@tanstack/react-query';
 
 import {bulkAutofixAutomationSettingsInfiniteOptions} from 'sentry/components/events/autofix/preferences/hooks/useBulkAutofixAutomationSettings';
 import {
@@ -19,21 +19,20 @@ import {
   getApiQueryData,
   mutationOptions,
   setApiQueryData,
-  useQuery,
 } from 'sentry/utils/queryClient';
 
-type PreferredAgent = 'seer' | CodingAgentIntegration;
+export type PreferredAgent = 'seer' | CodingAgentIntegration;
 
 /**
  * Returns the list of coding agent integrations formatted as select options,
  * with Seer Agent as the first/default option.
  */
-export function useCodingAgentSelectOptions({
+export function getCodingAgentSelectQueryOptions({
   organization,
 }: {
   organization: Organization;
 }) {
-  return useQuery({
+  return queryOptions({
     ...organizationIntegrationsCodingAgents(organization),
     select: (data): Array<{label: string; value: PreferredAgent}> => [
       {value: 'seer', label: t('Seer Agent')},

--- a/static/app/views/settings/seer/overview/utils/seerPreferredAgent.spec.ts
+++ b/static/app/views/settings/seer/overview/utils/seerPreferredAgent.spec.ts
@@ -1,35 +1,17 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+import {act, renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
 import * as indicators from 'sentry/actionCreators/indicator';
 import type {SeerPreferencesResponse} from 'sentry/components/events/autofix/preferences/hooks/useProjectSeerPreferences';
 import type {CodingAgentIntegration} from 'sentry/components/events/autofix/useAutofix';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
-import {
-  useBulkMutateSelectedAgent,
-  useFetchAgentOptions,
-} from 'sentry/views/settings/seer/overview/utils/seerPreferredAgent';
+import {useBulkMutateSelectedAgent} from 'sentry/views/settings/seer/overview/utils/seerPreferredAgent';
 
 describe('seerPreferredAgent', () => {
   const organization = OrganizationFixture({slug: 'org-slug'});
   const project = ProjectFixture({slug: 'project-slug', id: '1'});
-
-  const integrations: CodingAgentIntegration[] = [
-    {id: '42', name: 'Cursor', provider: 'cursor'},
-    {id: '99', name: 'Claude Code', provider: 'claude_code'},
-  ];
-
-  function mockIntegrationsEndpoint(
-    body: {integrations: CodingAgentIntegration[]} = {integrations}
-  ) {
-    return MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/integrations/coding-agents/`,
-      method: 'GET',
-      body,
-    });
-  }
 
   beforeEach(() => {
     ProjectsStore.loadInitialData([project]);
@@ -39,65 +21,6 @@ describe('seerPreferredAgent', () => {
     MockApiClient.clearMockResponses();
     jest.resetAllMocks();
     ProjectsStore.reset();
-  });
-
-  describe('useFetchPreferredAgentOptions', () => {
-    it('includes "seer" as first option plus integration options', async () => {
-      mockIntegrationsEndpoint();
-
-      const {result} = renderHookWithProviders(useFetchAgentOptions, {
-        initialProps: {organization},
-        organization,
-      });
-
-      await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      const options = result.current.data!;
-      expect(options).toHaveLength(3);
-      expect(options[0]).toEqual({value: 'seer', label: expect.any(String)});
-      expect(options[1]).toMatchObject({
-        value: {id: '42', name: 'Cursor'},
-        label: 'Cursor',
-      });
-      expect(options[2]).toMatchObject({
-        value: {id: '99', name: 'Claude Code'},
-        label: 'Claude Code',
-      });
-    });
-
-    it('filters out integrations without an id', async () => {
-      mockIntegrationsEndpoint({
-        integrations: [
-          {id: null, name: 'No Id', provider: 'other'},
-          {id: '1', name: 'With Id', provider: 'cursor'},
-        ],
-      });
-
-      const {result} = renderHookWithProviders(useFetchAgentOptions, {
-        initialProps: {organization},
-        organization,
-      });
-
-      await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      const options = result.current.data!;
-      expect(options).toHaveLength(2); // seer + one integration
-      expect(options[1]).toMatchObject({
-        value: {id: '1', name: 'With Id'},
-        label: 'With Id',
-      });
-    });
-
-    it('returns only "seer" when there are no integrations', async () => {
-      mockIntegrationsEndpoint({integrations: []});
-
-      const {result} = renderHookWithProviders(useFetchAgentOptions, {
-        initialProps: {organization},
-        organization,
-      });
-
-      await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(result.current.data).toHaveLength(1);
-      expect(result.current.data![0]).toEqual({value: 'seer', label: expect.any(String)});
-    });
   });
 
   describe('useBulkMutateSelectedAgent', () => {

--- a/static/app/views/settings/seer/overview/utils/seerPreferredAgent.ts
+++ b/static/app/views/settings/seer/overview/utils/seerPreferredAgent.ts
@@ -7,46 +7,15 @@ import type {SeerPreferencesResponse} from 'sentry/components/events/autofix/pre
 import {PROVIDER_TO_HANDOFF_TARGET} from 'sentry/components/events/autofix/types';
 import type {ProjectSeerPreferences} from 'sentry/components/events/autofix/types';
 import type {CodingAgentIntegration} from 'sentry/components/events/autofix/useAutofix';
-import {organizationIntegrationsCodingAgents} from 'sentry/components/events/autofix/useAutofix';
 import {t} from 'sentry/locale';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
-import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {processInChunks} from 'sentry/utils/array/procesInChunks';
-import {
-  fetchDataQuery,
-  fetchMutation,
-  useQueryClient,
-  useQuery,
-} from 'sentry/utils/queryClient';
+import {fetchDataQuery, fetchMutation, useQueryClient} from 'sentry/utils/queryClient';
 import {RequestError} from 'sentry/utils/requestError/requestError';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 type PreferredAgent = 'seer' | CodingAgentIntegration;
-
-export function useFetchAgentOptions({
-  organization,
-  enabled = true,
-}: {
-  organization: Organization;
-  enabled?: boolean;
-}) {
-  return useQuery({
-    ...organizationIntegrationsCodingAgents(organization),
-    enabled,
-    select: (data): Array<{label: string; value: PreferredAgent}> => {
-      return [
-        {value: 'seer', label: t('Seer Agent')},
-        ...(data.json.integrations ?? [])
-          .filter(integration => integration.id)
-          .map(integration => ({
-            value: integration,
-            label: integration.name,
-          })),
-      ];
-    },
-  });
-}
 
 export function useBulkMutateSelectedAgent() {
   const organization = useOrganization();

--- a/static/gsApp/views/seerAutomation/components/projectDetails/autofixAgent.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectDetails/autofixAgent.tsx
@@ -11,10 +11,10 @@ import {LoadingError} from 'sentry/components/loadingError';
 import {Placeholder} from 'sentry/components/placeholder';
 import {t, tct} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
-import {useQueryClient} from 'sentry/utils/queryClient';
+import {useQuery, useQueryClient} from 'sentry/utils/queryClient';
 import {
   getProjectAgentMutationOptions,
-  useCodingAgentSelectOptions,
+  getCodingAgentSelectQueryOptions,
   getSelectedAgentForProject,
 } from 'sentry/utils/seer/preferredAgent';
 import {
@@ -34,7 +34,7 @@ export function AutofixAgent({canWrite, preference, project}: Props) {
   const organization = useOrganization();
   const queryClient = useQueryClient();
 
-  const agentOptions = useCodingAgentSelectOptions({organization});
+  const agentOptions = useQuery(getCodingAgentSelectQueryOptions({organization}));
 
   // Derive the integration objects from the options data for the agent selector
   const integrations = useMemo(

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
@@ -27,7 +27,7 @@ import {
   useQueryClient,
 } from 'sentry/utils/queryClient';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
-import {useCodingAgentSelectOptions} from 'sentry/utils/seer/preferredAgent';
+import {getCodingAgentSelectQueryOptions} from 'sentry/utils/seer/preferredAgent';
 import {
   getFilteredCodingAgentName,
   type PreferredAgentProvider,
@@ -53,7 +53,7 @@ export function SeerProjectTable() {
   const organization = useOrganization();
   const {projects, fetching, fetchError} = useProjects();
 
-  const agentOptions = useCodingAgentSelectOptions({organization});
+  const agentOptions = useQuery(getCodingAgentSelectQueryOptions({organization}));
   const codingAgentCompactSelectOptions = useQuery(
     filterCodingAgentQueryOptions({
       organization,
@@ -258,8 +258,9 @@ export function SeerProjectTable() {
         </Flex>
         <SimpleTableWithColumns>
           <ProjectTableHeader
-            projects={filteredProjects}
+            agentOptions={agentOptions}
             onSortClick={setSort}
+            projects={filteredProjects}
             sort={sort}
             updateBulkAutofixAutomationSettings={updateBulkAutofixAutomationSettings}
           />

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
@@ -27,6 +27,7 @@ import {
   useQueryClient,
 } from 'sentry/utils/queryClient';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
+import {useCodingAgentSelectOptions} from 'sentry/utils/seer/preferredAgent';
 import {
   getFilteredCodingAgentName,
   type PreferredAgentProvider,
@@ -43,7 +44,6 @@ import {
 import {parseAsSort} from 'sentry/utils/url/parseAsSort';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
-import {useFetchAgentOptions} from 'sentry/views/settings/seer/overview/utils/seerPreferredAgent';
 
 import {ProjectTableHeader} from 'getsentry/views/seerAutomation/components/projectTable/seerProjectTableHeader';
 import {SeerProjectTableRow} from 'getsentry/views/seerAutomation/components/projectTable/seerProjectTableRow';
@@ -53,7 +53,7 @@ export function SeerProjectTable() {
   const organization = useOrganization();
   const {projects, fetching, fetchError} = useProjects();
 
-  const agentOptions = useFetchAgentOptions({organization});
+  const agentOptions = useCodingAgentSelectOptions({organization});
   const codingAgentCompactSelectOptions = useQuery(
     filterCodingAgentQueryOptions({
       organization,

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableHeader.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableHeader.tsx
@@ -17,12 +17,10 @@ import type {Project} from 'sentry/types/project';
 import {parseQueryKey} from 'sentry/utils/api/apiQueryKey';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {useListItemCheckboxContext} from 'sentry/utils/list/useListItemCheckboxState';
+import {useCodingAgentSelectOptions} from 'sentry/utils/seer/preferredAgent';
 import {PROJECT_STOPPING_POINT_OPTIONS} from 'sentry/utils/seer/stoppingPoint';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {
-  useBulkMutateSelectedAgent,
-  useFetchAgentOptions,
-} from 'sentry/views/settings/seer/overview/utils/seerPreferredAgent';
+import {useBulkMutateSelectedAgent} from 'sentry/views/settings/seer/overview/utils/seerPreferredAgent';
 
 import {useCanWriteSettings} from 'getsentry/views/seerAutomation/components/useCanWriteSettings';
 
@@ -124,7 +122,7 @@ export function ProjectTableHeader({
     [projects, selectedIds]
   );
 
-  const agentOptions = useFetchAgentOptions({organization});
+  const agentOptions = useCodingAgentSelectOptions({organization});
   const bulkMutateSelectedAgent = useBulkMutateSelectedAgent();
 
   return (

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableHeader.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableHeader.tsx
@@ -1,5 +1,6 @@
 import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
+import type {UseQueryResult} from '@tanstack/react-query';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Checkbox} from '@sentry/scraps/checkbox';
@@ -17,7 +18,7 @@ import type {Project} from 'sentry/types/project';
 import {parseQueryKey} from 'sentry/utils/api/apiQueryKey';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {useListItemCheckboxContext} from 'sentry/utils/list/useListItemCheckboxState';
-import {useCodingAgentSelectOptions} from 'sentry/utils/seer/preferredAgent';
+import type {PreferredAgent} from 'sentry/utils/seer/preferredAgent';
 import {PROJECT_STOPPING_POINT_OPTIONS} from 'sentry/utils/seer/stoppingPoint';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useBulkMutateSelectedAgent} from 'sentry/views/settings/seer/overview/utils/seerPreferredAgent';
@@ -25,6 +26,7 @@ import {useBulkMutateSelectedAgent} from 'sentry/views/settings/seer/overview/ut
 import {useCanWriteSettings} from 'getsentry/views/seerAutomation/components/useCanWriteSettings';
 
 interface Props {
+  agentOptions: UseQueryResult<Array<{label: string; value: PreferredAgent}>, Error>;
   onSortClick: (key: Sort) => void;
   projects: Project[];
   sort: Sort;
@@ -100,6 +102,7 @@ export function ProjectTableHeader({
   onSortClick,
   sort,
   updateBulkAutofixAutomationSettings,
+  agentOptions,
 }: Props) {
   const organization = useOrganization();
   const canWrite = useCanWriteSettings();
@@ -122,7 +125,6 @@ export function ProjectTableHeader({
     [projects, selectedIds]
   );
 
-  const agentOptions = useCodingAgentSelectOptions({organization});
   const bulkMutateSelectedAgent = useBulkMutateSelectedAgent();
 
   return (

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableRow.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableRow.tsx
@@ -17,13 +17,13 @@ import {IconWarning} from 'sentry/icons/iconWarning';
 import {t, tct} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
 import {useListItemCheckboxContext} from 'sentry/utils/list/useListItemCheckboxState';
+import type {useCodingAgentSelectOptions} from 'sentry/utils/seer/preferredAgent';
 import {
   getProjectStoppingPointValueFromSettings,
   type MutateStoppingPoint,
   PROJECT_STOPPING_POINT_OPTIONS,
 } from 'sentry/utils/seer/stoppingPoint';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import type {useFetchAgentOptions} from 'sentry/views/settings/seer/overview/utils/seerPreferredAgent';
 import {
   useMutateSelectedAgent,
   useSelectedAgentFromBulkSettings,
@@ -32,7 +32,7 @@ import {
 import {useCanWriteSettings} from 'getsentry/views/seerAutomation/components/useCanWriteSettings';
 
 interface Props {
-  agentOptions: ReturnType<typeof useFetchAgentOptions>;
+  agentOptions: ReturnType<typeof useCodingAgentSelectOptions>;
   autofixSettings: undefined | AutofixAutomationSettings;
   integrations: CodingAgentIntegration[];
   isPendingIntegrations: boolean;

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableRow.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableRow.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import type {UseQueryResult} from '@tanstack/react-query';
 
 import {Checkbox} from '@sentry/scraps/checkbox';
 import {Flex, Stack} from '@sentry/scraps/layout';
@@ -17,7 +18,7 @@ import {IconWarning} from 'sentry/icons/iconWarning';
 import {t, tct} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
 import {useListItemCheckboxContext} from 'sentry/utils/list/useListItemCheckboxState';
-import type {useCodingAgentSelectOptions} from 'sentry/utils/seer/preferredAgent';
+import type {PreferredAgent} from 'sentry/utils/seer/preferredAgent';
 import {
   getProjectStoppingPointValueFromSettings,
   type MutateStoppingPoint,
@@ -32,7 +33,7 @@ import {
 import {useCanWriteSettings} from 'getsentry/views/seerAutomation/components/useCanWriteSettings';
 
 interface Props {
-  agentOptions: ReturnType<typeof useCodingAgentSelectOptions>;
+  agentOptions: UseQueryResult<Array<{label: string; value: PreferredAgent}>, Error>;
   autofixSettings: undefined | AutofixAutomationSettings;
   integrations: CodingAgentIntegration[];
   isPendingIntegrations: boolean;


### PR DESCRIPTION
Quick swap of 
```
- const agentOptions = useFetchAgentOptions({organization});
+ const agentOptions = useQuery(getCodingAgentSelectQueryOptions({organization}));
```
because we had duplicate utils going on 