### PR TITLE
ref(seer): Reapply JWT proxy_headers for Seer callbacks

### DIFF
--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -305,10 +305,12 @@ def collect_user_org_context(
 def get_proxy_headers() -> dict[str, str] | None:
     """Build auth headers for Seer to echo back to Sentry on callbacks.
 
-    Returns a dict of headers (X-Viewer-Context + signature) or None.
+    Returns a single ``X-Viewer-Context`` JWT header, or ``None`` when no
+    ViewerContext is set. Matches the format used by the standard inbound
+    Seer → Sentry path (``X-Viewer-Context`` JWT, no separate signature
+    header), so Sentry's middleware decodes both with the same code path.
     """
-    from sentry.seer.signed_seer_api import sign_viewer_context
-    from sentry.viewer_context import get_viewer_context
+    from sentry.viewer_context import encode_viewer_context, get_viewer_context
 
     ctx = get_viewer_context()
     if ctx is None or ctx.user_id is None:
@@ -317,12 +319,11 @@ def get_proxy_headers() -> dict[str, str] | None:
     if not settings.SEER_API_SHARED_SECRET:
         return None
 
-    context_bytes = orjson.dumps(ctx.serialize())
-    signature = sign_viewer_context(context_bytes)
-    return {
-        "X-Viewer-Context": context_bytes.decode("utf-8"),
-        "X-Viewer-Context-Signature": signature,
-    }
+    try:
+        return {"X-Viewer-Context": encode_viewer_context(ctx)}
+    except Exception:
+        logger.exception("Failed to encode viewer context JWT for proxy headers")
+        return None
 
 
 def fetch_run_status(run_id: int, organization: Organization) -> SeerRunState:

--- a/tests/sentry/seer/explorer/test_client_utils.py
+++ b/tests/sentry/seer/explorer/test_client_utils.py
@@ -1,12 +1,17 @@
+import jwt
+from django.test import override_settings
+
 from sentry.models.organizationmember import OrganizationMember
 from sentry.seer.explorer.client_utils import (
     collect_user_org_context,
+    get_proxy_headers,
     has_seer_explorer_access_with_detail,
     snapshot_to_markdown,
 )
 from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import TestCase
 from sentry.testutils.requests import make_request
+from sentry.viewer_context import ActorType, ViewerContext, viewer_context_scope
 
 
 class TestHasSeerExplorerAccessWithDetail(TestCase):
@@ -253,3 +258,58 @@ class SnapshotToMarkdownTest(TestCase):
         result = snapshot_to_markdown(snapshot)
         assert "# Widget" in result
         assert '- "some string"' in result
+
+
+_TEST_SECRET = "test-secret-must-be-at-least-32-bytes-long-for-hs256"
+
+
+@override_settings(SEER_API_SHARED_SECRET=_TEST_SECRET)
+class TestGetProxyHeaders(TestCase):
+    """Headers Seer echoes back to Sentry on Code Mode callbacks."""
+
+    def test_no_viewer_context_returns_none(self) -> None:
+        # Outside any viewer_context_scope — nothing to encode.
+        assert get_proxy_headers() is None
+
+    def test_viewer_context_without_user_returns_none(self) -> None:
+        # System-only context (no user_id) shouldn't produce callback auth —
+        # callbacks only make sense for user-initiated runs.
+        with viewer_context_scope(ViewerContext(organization_id=42)):
+            assert get_proxy_headers() is None
+
+    @override_settings(SEER_API_SHARED_SECRET="")
+    def test_no_shared_secret_returns_none(self) -> None:
+        with viewer_context_scope(
+            ViewerContext(organization_id=42, user_id=7, actor_type=ActorType.USER)
+        ):
+            assert get_proxy_headers() is None
+
+    def test_returns_single_jwt_header(self) -> None:
+        with viewer_context_scope(
+            ViewerContext(organization_id=42, user_id=7, actor_type=ActorType.USER)
+        ):
+            headers = get_proxy_headers()
+        assert headers is not None
+        # Single header — no separate signature header (legacy two-header
+        # format replaced with self-contained JWT).
+        assert set(headers.keys()) == {"X-Viewer-Context"}
+
+    def test_jwt_payload_carries_viewer_fields(self) -> None:
+        with viewer_context_scope(
+            ViewerContext(organization_id=42, user_id=7, actor_type=ActorType.USER)
+        ):
+            headers = get_proxy_headers()
+        assert headers is not None
+        decoded = jwt.decode(
+            headers["X-Viewer-Context"],
+            _TEST_SECRET,
+            algorithms=["HS256"],
+            issuer="sentry",
+        )
+        assert decoded["organization_id"] == 42
+        assert decoded["user_id"] == 7
+        assert decoded["actor_type"] == "user"
+        # Standard JWT claims present
+        assert "iat" in decoded
+        assert "exp" in decoded
+        assert decoded["iss"] == "sentry"


### PR DESCRIPTION
Reapply the JWT `X-Viewer-Context` proxy header format for Seer callback
requests.

This restores the earlier change that switched Code Mode proxy headers from the
legacy JSON+HMAC pair to the single JWT `X-Viewer-Context` header. The revert
was used as a mitigation while we investigated auth failures in production.

I want to keep this change ready to land again once the infrastructure-side
routing/header issue is resolved. Restoring it here makes the intended callback
auth format explicit again and keeps the tests aligned with the JWT path.

This only reapplies the previous behavior; it does not attempt to address the
infra issue in this PR.