### PR TITLE
feat(seer): Add Night Shift workflows list page

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -1649,6 +1649,12 @@ function buildRoutes(): RouteObject[] {
     children: replayChildren,
   };
 
+  const seerRoutes: SentryRouteObject = {
+    path: '/seer/workflows/',
+    component: make(() => import('sentry/views/seerWorkflows')),
+    withOrgPath: true,
+  };
+
   const releaseChildren: SentryRouteObject[] = [
     {
       index: true,
@@ -2785,6 +2791,7 @@ function buildRoutes(): RouteObject[] {
       preprodRoutes,
       pullRequestRoutes,
       replayRoutes,
+      seerRoutes,
       releasesRoutes,
       statsRoutes,
       discoverRoutes,

--- a/static/app/views/seerWorkflows/index.spec.tsx
+++ b/static/app/views/seerWorkflows/index.spec.tsx
@@ -1,0 +1,105 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import SeerWorkflows from 'sentry/views/seerWorkflows';
+
+describe('SeerWorkflows', () => {
+  const organization = OrganizationFixture();
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('renders list of runs', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/workflows/`,
+      body: [
+        {
+          id: '1',
+          dateAdded: '2026-04-20T00:00:00Z',
+          triageStrategy: 'agentic',
+          errorMessage: null,
+          extras: {},
+          issues: [
+            {
+              id: '10',
+              groupId: '100',
+              action: 'autofix_triggered',
+              seerRunId: 'seer-1',
+              dateAdded: '2026-04-20T00:00:01Z',
+            },
+          ],
+        },
+      ],
+    });
+
+    render(<SeerWorkflows />, {organization});
+
+    expect(await screen.findByText('Night Shift')).toBeInTheDocument();
+    expect(screen.getByText('agentic')).toBeInTheDocument();
+    expect(screen.getByText('Completed')).toBeInTheDocument();
+    expect(screen.getByRole('heading', {name: 'Seer Workflows'})).toBeInTheDocument();
+  });
+
+  it('expands a row to show issue drill-down', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/workflows/`,
+      body: [
+        {
+          id: '1',
+          dateAdded: '2026-04-20T00:00:00Z',
+          triageStrategy: 'agentic',
+          errorMessage: null,
+          extras: {foo: 'bar'},
+          issues: [
+            {
+              id: '10',
+              groupId: '100',
+              action: 'autofix_triggered',
+              seerRunId: 'seer-1',
+              dateAdded: '2026-04-20T00:00:01Z',
+            },
+          ],
+        },
+      ],
+    });
+
+    render(<SeerWorkflows />, {organization});
+
+    const expandButton = await screen.findByRole('button', {name: 'Expand run'});
+    await userEvent.click(expandButton);
+
+    expect(screen.getByText('autofix_triggered')).toBeInTheDocument();
+    expect(screen.getByText('seer-1')).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: '100'})).toHaveAttribute(
+      'href',
+      `/organizations/${organization.slug}/issues/100/`
+    );
+  });
+
+  it('shows empty state when no runs', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/workflows/`,
+      body: [],
+    });
+
+    render(<SeerWorkflows />, {organization});
+
+    expect(await screen.findByText('No workflow runs yet.')).toBeInTheDocument();
+  });
+
+  it('shows error state when fetch fails', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/workflows/`,
+      statusCode: 404,
+      body: {detail: 'not found'},
+    });
+
+    render(<SeerWorkflows />, {organization});
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', {name: /retry/i})).toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/views/seerWorkflows/index.spec.tsx
+++ b/static/app/views/seerWorkflows/index.spec.tsx
@@ -78,6 +78,51 @@ describe('SeerWorkflows', () => {
     );
   });
 
+  it('links to Seer Explorer when agent_run_id is present in extras', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/workflows/`,
+      body: [
+        {
+          id: '1',
+          dateAdded: '2026-04-20T00:00:00Z',
+          triageStrategy: 'agentic',
+          errorMessage: null,
+          extras: {agent_run_id: 42},
+          issues: [],
+        },
+      ],
+    });
+
+    render(<SeerWorkflows />, {organization});
+
+    const link = await screen.findByRole('button', {name: 'Explorer'});
+    expect(link).toHaveAttribute(
+      'href',
+      `/organizations/${organization.slug}/issues/?explorerRunId=42`
+    );
+  });
+
+  it('omits Explorer link when agent_run_id is missing', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/workflows/`,
+      body: [
+        {
+          id: '1',
+          dateAdded: '2026-04-20T00:00:00Z',
+          triageStrategy: 'agentic',
+          errorMessage: null,
+          extras: {},
+          issues: [],
+        },
+      ],
+    });
+
+    render(<SeerWorkflows />, {organization});
+
+    await screen.findByText('Night Shift');
+    expect(screen.queryByRole('button', {name: 'Explorer'})).not.toBeInTheDocument();
+  });
+
   it('shows empty state when no runs', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/seer/workflows/`,

--- a/static/app/views/seerWorkflows/index.tsx
+++ b/static/app/views/seerWorkflows/index.tsx
@@ -157,7 +157,7 @@ function RunDetail({
           <Text bold size="xs" variant="muted" uppercase>
             {t('Extras')}
           </Text>
-          <Text as="pre" size="sm" monospace>
+          <Text as="div" size="sm" monospace style={{whiteSpace: 'pre-wrap'}}>
             {JSON.stringify(run.extras, null, 2)}
           </Text>
         </Flex>

--- a/static/app/views/seerWorkflows/index.tsx
+++ b/static/app/views/seerWorkflows/index.tsx
@@ -1,0 +1,253 @@
+import {Fragment, useState} from 'react';
+import styled from '@emotion/styled';
+import {useQuery} from '@tanstack/react-query';
+
+import {Button} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
+import {Link} from '@sentry/scraps/link';
+import {Heading, Text} from '@sentry/scraps/text';
+
+import {DateTime} from 'sentry/components/dateTime';
+import {LoadingError} from 'sentry/components/loadingError';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
+import {SimpleTable} from 'sentry/components/tables/simpleTable';
+import {IconChevron} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+type SeerNightShiftRunIssue = {
+  action: string;
+  dateAdded: string;
+  groupId: string;
+  id: string;
+  seerRunId: string | null;
+};
+
+type SeerNightShiftRun = {
+  dateAdded: string;
+  errorMessage: string | null;
+  extras: Record<string, unknown>;
+  id: string;
+  issues: SeerNightShiftRunIssue[];
+  triageStrategy: string;
+};
+
+function SeerWorkflows() {
+  const organization = useOrganization();
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const {data, isPending, isError, refetch} = useQuery(
+    apiOptions.as<SeerNightShiftRun[]>()(
+      '/organizations/$organizationIdOrSlug/seer/workflows/',
+      {
+        path: {organizationIdOrSlug: organization.slug},
+        staleTime: 0,
+      }
+    )
+  );
+
+  const toggleExpanded = (runId: string) => {
+    setExpanded(prev => {
+      const next = new Set(prev);
+      if (next.has(runId)) {
+        next.delete(runId);
+      } else {
+        next.add(runId);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <SentryDocumentTitle title={t('Seer Workflows')} orgSlug={organization.slug}>
+      <Container>
+        <Heading as="h1">{t('Seer Workflows')}</Heading>
+        <Text as="p" variant="muted">
+          {t('Historical runs of Seer workflows for this organization.')}
+        </Text>
+
+        {isError ? (
+          <LoadingError onRetry={refetch} />
+        ) : isPending ? (
+          <LoadingIndicator />
+        ) : (
+          <RunsTable>
+            <SimpleTable.Header>
+              <SimpleTable.HeaderCell />
+              <SimpleTable.HeaderCell>{t('Date')}</SimpleTable.HeaderCell>
+              <SimpleTable.HeaderCell>{t('Workflow')}</SimpleTable.HeaderCell>
+              <SimpleTable.HeaderCell>{t('Strategy')}</SimpleTable.HeaderCell>
+              <SimpleTable.HeaderCell>{t('Status')}</SimpleTable.HeaderCell>
+              <SimpleTable.HeaderCell>{t('Issues')}</SimpleTable.HeaderCell>
+            </SimpleTable.Header>
+
+            {data?.length === 0 ? (
+              <SimpleTable.Empty>{t('No workflow runs yet.')}</SimpleTable.Empty>
+            ) : (
+              (data ?? []).map(run => {
+                const isExpanded = expanded.has(run.id);
+                const status = run.errorMessage ? t('Error') : t('Completed');
+                return (
+                  <Fragment key={run.id}>
+                    <SimpleTable.Row>
+                      <SimpleTable.RowCell>
+                        <Button
+                          aria-label={isExpanded ? t('Collapse run') : t('Expand run')}
+                          size="xs"
+                          priority="transparent"
+                          icon={<IconChevron direction={isExpanded ? 'down' : 'right'} />}
+                          onClick={() => toggleExpanded(run.id)}
+                        />
+                      </SimpleTable.RowCell>
+                      <SimpleTable.RowCell>
+                        <DateTime date={run.dateAdded} />
+                      </SimpleTable.RowCell>
+                      <SimpleTable.RowCell>{t('Night Shift')}</SimpleTable.RowCell>
+                      <SimpleTable.RowCell>{run.triageStrategy}</SimpleTable.RowCell>
+                      <SimpleTable.RowCell>
+                        <Text variant={run.errorMessage ? 'danger' : undefined}>
+                          {status}
+                        </Text>
+                      </SimpleTable.RowCell>
+                      <SimpleTable.RowCell>{run.issues.length}</SimpleTable.RowCell>
+                    </SimpleTable.Row>
+
+                    {isExpanded && (
+                      <SimpleTable.Row variant="faded">
+                        <FullWidthCell>
+                          <RunDetail run={run} organizationSlug={organization.slug} />
+                        </FullWidthCell>
+                      </SimpleTable.Row>
+                    )}
+                  </Fragment>
+                );
+              })
+            )}
+          </RunsTable>
+        )}
+      </Container>
+    </SentryDocumentTitle>
+  );
+}
+
+function RunDetail({
+  run,
+  organizationSlug,
+}: {
+  organizationSlug: string;
+  run: SeerNightShiftRun;
+}) {
+  return (
+    <Flex direction="column" gap="sm" padding="md lg">
+      {run.errorMessage ? (
+        <Text variant="danger" size="sm">
+          {t('Error: ')}
+          {run.errorMessage}
+        </Text>
+      ) : null}
+
+      {Object.keys(run.extras).length > 0 ? (
+        <Fragment>
+          <Text bold size="xs" variant="muted" uppercase>
+            {t('Extras')}
+          </Text>
+          <ExtrasPre>{JSON.stringify(run.extras, null, 2)}</ExtrasPre>
+        </Fragment>
+      ) : null}
+
+      <Text bold size="xs" variant="muted" uppercase>
+        {t('Issues (%s)', run.issues.length)}
+      </Text>
+
+      {run.issues.length === 0 ? (
+        <Text variant="muted" size="sm">
+          {t('No issues processed in this run.')}
+        </Text>
+      ) : (
+        <IssuesTable>
+          <colgroup>
+            <col style={{width: '120px'}} />
+            <col style={{width: '200px'}} />
+            <col />
+          </colgroup>
+          <thead>
+            <tr>
+              <th>{t('Group')}</th>
+              <th>{t('Action')}</th>
+              <th>{t('Seer Run ID')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {run.issues.map(issue => (
+              <tr key={issue.id}>
+                <td>
+                  <Link
+                    to={`/organizations/${organizationSlug}/issues/${issue.groupId}/`}
+                  >
+                    {issue.groupId}
+                  </Link>
+                </td>
+                <td>{issue.action}</td>
+                <td>{issue.seerRunId ?? '-'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </IssuesTable>
+      )}
+    </Flex>
+  );
+}
+
+const Container = styled('div')`
+  padding: ${p => p.theme.space.xl};
+  display: flex;
+  flex-direction: column;
+  gap: ${p => p.theme.space.lg};
+`;
+
+const RunsTable = styled(SimpleTable)`
+  grid-template-columns: min-content 1fr 1fr 1fr 1fr min-content;
+`;
+
+const FullWidthCell = styled('div')`
+  grid-column: 1 / -1;
+  background: ${p => p.theme.backgroundSecondary};
+`;
+
+const ExtrasPre = styled('pre')`
+  margin: 0;
+  padding: ${p => p.theme.space.md};
+  background: ${p => p.theme.surface100};
+  border-radius: ${p => p.theme.radius.md};
+  font-size: ${p => p.theme.font.size.sm};
+  white-space: pre-wrap;
+`;
+
+const IssuesTable = styled('table')`
+  width: auto;
+  border-collapse: collapse;
+  font-size: ${p => p.theme.font.size.sm};
+  table-layout: fixed;
+
+  th,
+  td {
+    padding: ${p => p.theme.space.xs} ${p => p.theme.space.md};
+    text-align: left;
+    border-bottom: 1px solid ${p => p.theme.tokens.border.secondary};
+    vertical-align: middle;
+    white-space: nowrap;
+  }
+
+  th {
+    font-weight: ${p => p.theme.font.weight.sans.medium};
+    color: ${p => p.theme.tokens.content.secondary};
+  }
+
+  tr:last-child td {
+    border-bottom: none;
+  }
+`;
+
+export default SeerWorkflows;

--- a/static/app/views/seerWorkflows/index.tsx
+++ b/static/app/views/seerWorkflows/index.tsx
@@ -118,7 +118,7 @@ function SeerWorkflows() {
                       <SimpleTable.Row variant="faded">
                         <Container
                           background="secondary"
-                          padding="md lg"
+                          padding="lg xl"
                           style={{gridColumn: '1 / -1'}}
                         >
                           <RunDetail run={run} organizationSlug={organization.slug} />
@@ -144,7 +144,7 @@ function RunDetail({
   run: SeerNightShiftRun;
 }) {
   return (
-    <Flex direction="column" gap="sm">
+    <Flex direction="column" gap="lg">
       {run.errorMessage ? (
         <Text variant="danger" size="sm">
           {t('Error: ')}
@@ -153,51 +153,53 @@ function RunDetail({
       ) : null}
 
       {Object.keys(run.extras).length > 0 ? (
-        <Fragment>
+        <Flex direction="column" gap="sm">
           <Text bold size="xs" variant="muted" uppercase>
             {t('Extras')}
           </Text>
           <Text as="pre" size="sm" monospace>
             {JSON.stringify(run.extras, null, 2)}
           </Text>
-        </Fragment>
+        </Flex>
       ) : null}
 
-      <Text bold size="xs" variant="muted" uppercase>
-        {t('Issues (%s)', run.issues.length)}
-      </Text>
-
-      {run.issues.length === 0 ? (
-        <Text variant="muted" size="sm">
-          {t('No issues processed in this run.')}
+      <Flex direction="column" gap="sm">
+        <Text bold size="xs" variant="muted" uppercase>
+          {t('Issues (%s)', run.issues.length)}
         </Text>
-      ) : (
-        <Grid columns="max-content max-content 1fr" gap="xs md">
-          <Text bold size="xs" variant="muted">
-            {t('Group')}
+
+        {run.issues.length === 0 ? (
+          <Text variant="muted" size="sm">
+            {t('No issues processed in this run.')}
           </Text>
-          <Text bold size="xs" variant="muted">
-            {t('Action')}
-          </Text>
-          <Text bold size="xs" variant="muted">
-            {t('Seer Run ID')}
-          </Text>
-          {run.issues.flatMap(issue => [
-            <Link
-              key={`${issue.id}-group`}
-              to={`/organizations/${organizationSlug}/issues/${issue.groupId}/`}
-            >
-              {issue.groupId}
-            </Link>,
-            <Text key={`${issue.id}-action`} size="sm">
-              {issue.action}
-            </Text>,
-            <Text key={`${issue.id}-seer`} size="sm" variant="muted">
-              {issue.seerRunId ?? '-'}
-            </Text>,
-          ])}
-        </Grid>
-      )}
+        ) : (
+          <Grid columns="max-content max-content 1fr" gap="sm xl" align="center">
+            <Text bold size="xs" variant="muted">
+              {t('Group')}
+            </Text>
+            <Text bold size="xs" variant="muted">
+              {t('Action')}
+            </Text>
+            <Text bold size="xs" variant="muted">
+              {t('Seer Run ID')}
+            </Text>
+            {run.issues.flatMap(issue => [
+              <Link
+                key={`${issue.id}-group`}
+                to={`/organizations/${organizationSlug}/issues/${issue.groupId}/`}
+              >
+                {issue.groupId}
+              </Link>,
+              <Text key={`${issue.id}-action`} size="sm">
+                {issue.action}
+              </Text>,
+              <Text key={`${issue.id}-seer`} size="sm" variant="muted">
+                {issue.seerRunId ?? '-'}
+              </Text>,
+            ])}
+          </Grid>
+        )}
+      </Flex>
     </Flex>
   );
 }

--- a/static/app/views/seerWorkflows/index.tsx
+++ b/static/app/views/seerWorkflows/index.tsx
@@ -2,7 +2,7 @@ import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
 
-import {Button} from '@sentry/scraps/button';
+import {Button, LinkButton} from '@sentry/scraps/button';
 import {Container, Flex, Grid} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {Heading, Text} from '@sentry/scraps/text';
@@ -12,7 +12,7 @@ import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
-import {IconChevron} from 'sentry/icons';
+import {IconChevron, IconOpen} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -81,6 +81,7 @@ function SeerWorkflows() {
               <SimpleTable.HeaderCell>{t('Strategy')}</SimpleTable.HeaderCell>
               <SimpleTable.HeaderCell>{t('Status')}</SimpleTable.HeaderCell>
               <SimpleTable.HeaderCell>{t('Issues')}</SimpleTable.HeaderCell>
+              <SimpleTable.HeaderCell />
             </SimpleTable.Header>
 
             {data?.length === 0 ? (
@@ -89,6 +90,7 @@ function SeerWorkflows() {
               (data ?? []).map(run => {
                 const isExpanded = expanded.has(run.id);
                 const status = run.errorMessage ? t('Error') : t('Completed');
+                const explorerRunId = getExplorerRunId(run);
                 return (
                   <Fragment key={run.id}>
                     <SimpleTable.Row>
@@ -112,6 +114,20 @@ function SeerWorkflows() {
                         </Text>
                       </SimpleTable.RowCell>
                       <SimpleTable.RowCell>{run.issues.length}</SimpleTable.RowCell>
+                      <SimpleTable.RowCell>
+                        {explorerRunId === null ? null : (
+                          <LinkButton
+                            size="xs"
+                            icon={<IconOpen />}
+                            to={{
+                              pathname: `/organizations/${organization.slug}/issues/`,
+                              query: {explorerRunId},
+                            }}
+                          >
+                            {t('Explorer')}
+                          </LinkButton>
+                        )}
+                      </SimpleTable.RowCell>
                     </SimpleTable.Row>
 
                     {isExpanded && (
@@ -205,7 +221,15 @@ function RunDetail({
 }
 
 const RunsTable = styled(SimpleTable)`
-  grid-template-columns: min-content 1fr 1fr 1fr 1fr min-content;
+  grid-template-columns: min-content 1fr 1fr 1fr 1fr min-content min-content;
 `;
+
+function getExplorerRunId(run: SeerNightShiftRun): number | string | null {
+  const value = run.extras.agent_run_id;
+  if (typeof value === 'number' || typeof value === 'string') {
+    return value;
+  }
+  return null;
+}
 
 export default SeerWorkflows;

--- a/static/app/views/seerWorkflows/index.tsx
+++ b/static/app/views/seerWorkflows/index.tsx
@@ -168,17 +168,6 @@ function RunDetail({
         </Text>
       ) : null}
 
-      {Object.keys(run.extras).length > 0 ? (
-        <Flex direction="column" gap="sm">
-          <Text bold size="xs" variant="muted" uppercase>
-            {t('Extras')}
-          </Text>
-          <Text as="div" size="sm" monospace style={{whiteSpace: 'pre-wrap'}}>
-            {JSON.stringify(run.extras, null, 2)}
-          </Text>
-        </Flex>
-      ) : null}
-
       <Flex direction="column" gap="sm">
         <Text bold size="xs" variant="muted" uppercase>
           {t('Issues (%s)', run.issues.length)}

--- a/static/app/views/seerWorkflows/index.tsx
+++ b/static/app/views/seerWorkflows/index.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {Container, Flex, Grid} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {Heading, Text} from '@sentry/scraps/text';
 
@@ -62,7 +62,7 @@ function SeerWorkflows() {
 
   return (
     <SentryDocumentTitle title={t('Seer Workflows')} orgSlug={organization.slug}>
-      <Container>
+      <Flex direction="column" gap="lg" padding="xl">
         <Heading as="h1">{t('Seer Workflows')}</Heading>
         <Text as="p" variant="muted">
           {t('Historical runs of Seer workflows for this organization.')}
@@ -116,9 +116,13 @@ function SeerWorkflows() {
 
                     {isExpanded && (
                       <SimpleTable.Row variant="faded">
-                        <FullWidthCell>
+                        <Container
+                          background="secondary"
+                          padding="md lg"
+                          style={{gridColumn: '1 / -1'}}
+                        >
                           <RunDetail run={run} organizationSlug={organization.slug} />
-                        </FullWidthCell>
+                        </Container>
                       </SimpleTable.Row>
                     )}
                   </Fragment>
@@ -127,7 +131,7 @@ function SeerWorkflows() {
             )}
           </RunsTable>
         )}
-      </Container>
+      </Flex>
     </SentryDocumentTitle>
   );
 }
@@ -140,7 +144,7 @@ function RunDetail({
   run: SeerNightShiftRun;
 }) {
   return (
-    <Flex direction="column" gap="sm" padding="md lg">
+    <Flex direction="column" gap="sm">
       {run.errorMessage ? (
         <Text variant="danger" size="sm">
           {t('Error: ')}
@@ -153,7 +157,9 @@ function RunDetail({
           <Text bold size="xs" variant="muted" uppercase>
             {t('Extras')}
           </Text>
-          <ExtrasPre>{JSON.stringify(run.extras, null, 2)}</ExtrasPre>
+          <Text as="pre" size="sm" monospace>
+            {JSON.stringify(run.extras, null, 2)}
+          </Text>
         </Fragment>
       ) : null}
 
@@ -166,88 +172,38 @@ function RunDetail({
           {t('No issues processed in this run.')}
         </Text>
       ) : (
-        <IssuesTable>
-          <colgroup>
-            <col style={{width: '120px'}} />
-            <col style={{width: '200px'}} />
-            <col />
-          </colgroup>
-          <thead>
-            <tr>
-              <th>{t('Group')}</th>
-              <th>{t('Action')}</th>
-              <th>{t('Seer Run ID')}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {run.issues.map(issue => (
-              <tr key={issue.id}>
-                <td>
-                  <Link
-                    to={`/organizations/${organizationSlug}/issues/${issue.groupId}/`}
-                  >
-                    {issue.groupId}
-                  </Link>
-                </td>
-                <td>{issue.action}</td>
-                <td>{issue.seerRunId ?? '-'}</td>
-              </tr>
-            ))}
-          </tbody>
-        </IssuesTable>
+        <Grid columns="max-content max-content 1fr" gap="xs md">
+          <Text bold size="xs" variant="muted">
+            {t('Group')}
+          </Text>
+          <Text bold size="xs" variant="muted">
+            {t('Action')}
+          </Text>
+          <Text bold size="xs" variant="muted">
+            {t('Seer Run ID')}
+          </Text>
+          {run.issues.flatMap(issue => [
+            <Link
+              key={`${issue.id}-group`}
+              to={`/organizations/${organizationSlug}/issues/${issue.groupId}/`}
+            >
+              {issue.groupId}
+            </Link>,
+            <Text key={`${issue.id}-action`} size="sm">
+              {issue.action}
+            </Text>,
+            <Text key={`${issue.id}-seer`} size="sm" variant="muted">
+              {issue.seerRunId ?? '-'}
+            </Text>,
+          ])}
+        </Grid>
       )}
     </Flex>
   );
 }
 
-const Container = styled('div')`
-  padding: ${p => p.theme.space.xl};
-  display: flex;
-  flex-direction: column;
-  gap: ${p => p.theme.space.lg};
-`;
-
 const RunsTable = styled(SimpleTable)`
   grid-template-columns: min-content 1fr 1fr 1fr 1fr min-content;
-`;
-
-const FullWidthCell = styled('div')`
-  grid-column: 1 / -1;
-  background: ${p => p.theme.backgroundSecondary};
-`;
-
-const ExtrasPre = styled('pre')`
-  margin: 0;
-  padding: ${p => p.theme.space.md};
-  background: ${p => p.theme.surface100};
-  border-radius: ${p => p.theme.radius.md};
-  font-size: ${p => p.theme.font.size.sm};
-  white-space: pre-wrap;
-`;
-
-const IssuesTable = styled('table')`
-  width: auto;
-  border-collapse: collapse;
-  font-size: ${p => p.theme.font.size.sm};
-  table-layout: fixed;
-
-  th,
-  td {
-    padding: ${p => p.theme.space.xs} ${p => p.theme.space.md};
-    text-align: left;
-    border-bottom: 1px solid ${p => p.theme.tokens.border.secondary};
-    vertical-align: middle;
-    white-space: nowrap;
-  }
-
-  th {
-    font-weight: ${p => p.theme.font.weight.sans.medium};
-    color: ${p => p.theme.tokens.content.secondary};
-  }
-
-  tr:last-child td {
-    border-bottom: none;
-  }
 `;
 
 export default SeerWorkflows;


### PR DESCRIPTION
Stacked on top of #113491.

Add an internal, direct-link-only page at
`/organizations/:orgSlug/seer/workflows/` that lists historical Night Shift
runs for the current org. Each row expands in place to show the issues the
run processed (group, action taken, Seer run id) plus any run-level error
message.

Not linked from any nav — it is only reachable by typing the URL. Orgs
without the `organizations:seer-night-shift` feature flag see a generic
"retry" error state since the endpoint returns 404, which is sufficient for
an internal page.

Uses the existing `SimpleTable` primitive for the list so the row, header,
and grid-template widths stay consistent with the rest of Sentry. The
nested issues drilldown uses a plain HTML table with fixed widths to keep
it compact inside the expanded row.

Refs #113491