### PR TITLE
ref(flags): Remove organizations:releases-serializer-v2

### DIFF
--- a/src/sentry/api/endpoints/organization_releases.py
+++ b/src/sentry/api/endpoints/organization_releases.py
@@ -335,10 +335,7 @@ class OrganizationReleasesEndpoint(OrganizationReleasesBaseEndpoint, ReleaseAnal
         parameters=[CursorQueryParam],
     )
     def get(self, request: Request, organization: Organization) -> Response:
-        if (
-            features.has("organizations:releases-serializer-v2", organization, actor=request.user)
-            or request.headers.get("X-Performance-Optimizations") == "enabled"
-        ):
+        if request.headers.get("X-Performance-Optimizations") == "enabled":
             return self.__get_new(request, organization)
         else:
             return self.__get_old(request, organization)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -290,8 +290,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:replay-ai-summaries", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable reading replay details using EAP query
     manager.add("organizations:replay-details-eap-query", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable version 2 of release serializer
-    manager.add("organizations:releases-serializer-v2", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Add build code and build number to semver ordering
     manager.add("organizations:semver-ordering-with-build-code", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable revocation of org auth keys when a user renames an org slug


### PR DESCRIPTION
The flag scanner classified this as flagpole-disabled. The flagpole config is disabled, so the flag clause in the get() branch is always False. The X-Performance-Optimizations header path is preserved.