### PR TITLE
feat(issues): Tag issue stream analytics with AnalyticsArea

### DIFF
--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -9,6 +9,7 @@ import {Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
+import {useAnalyticsArea} from 'sentry/components/analyticsArea';
 import type {AssignableEntity} from 'sentry/components/assigneeSelectorDropdown';
 import {GuideAnchor} from 'sentry/components/assistant/guideAnchor';
 import {GroupStatusChart} from 'sentry/components/charts/groupStatusChart';
@@ -290,6 +291,7 @@ export function StreamGroup({
   const organization = useOrganization();
   const navigate = useNavigate();
   const location = useLocation();
+  const area = useAnalyticsArea();
   const selectionEnabled =
     canSelect && !!issueSelectionSummary && !!issueSelectionActions;
   const originalInboxState = useRef(group.inbox as InboxDetails | null);
@@ -334,6 +336,7 @@ export function StreamGroup({
                 assigned_suggestion_reason:
                   newAssignee.suggestedAssignee?.suggestedReason,
                 assigned_type: newAssignee.type,
+                area,
               });
             }
             onAssigneeChange?.(newAssignee);
@@ -341,7 +344,15 @@ export function StreamGroup({
         }
       );
     },
-    [assignMutate, groupId, onAssigneeChange, organization.slug, query, sharedAnalytics]
+    [
+      area,
+      assignMutate,
+      groupId,
+      onAssigneeChange,
+      organization.slug,
+      query,
+      sharedAnalytics,
+    ]
   );
 
   const clickHasBeenHandled = useCallback((evt: React.MouseEvent<HTMLDivElement>) => {

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -242,15 +242,18 @@ export type IssueEventParameters = {
     sort: string;
   };
   'issues_stream.archived': {
+    area: string;
     action_status_details?: string;
     action_substatus?: string | null;
   };
   'issues_stream.issue_assigned': IssueStream & {
+    area: string;
     assigned_type: string;
     did_assign_suggestion: boolean;
     assigned_suggestion_reason?: string;
   };
   'issues_stream.merged': {
+    area: string;
     items_merged: number | 'all_in_query' | undefined;
     platform: string | undefined;
     project_id: string | undefined;
@@ -265,6 +268,7 @@ export type IssueEventParameters = {
     sort: string;
   };
   'issues_stream.updated_priority': {
+    area: string;
     priority: PriorityLevel;
   };
   'one_other_related_trace_issue.clicked': {

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -264,6 +264,10 @@ export type IssueEventParameters = {
   'issues_stream.realtime_clicked': {
     enabled: boolean;
   };
+  'issues_stream.resolved': {
+    area: string;
+    action_status_details?: string;
+  };
   'issues_stream.sort_changed': {
     sort: string;
   };
@@ -375,6 +379,7 @@ export const issueEventMap: Record<IssueEventKey, string | null> = {
   'issues_stream.realtime_clicked': 'Issues Stream: Realtime Clicked',
   'issues_stream.issue_assigned': 'Assigned Issue from Issues Stream',
   'issues_stream.merged': 'Merged Issues from Issues Stream',
+  'issues_stream.resolved': 'Issues Stream: Resolved',
   'issues_stream.sort_changed': 'Changed Sort on Issues Stream',
   'issues_stream.paginate': 'Paginate Issues Stream',
   'issue.shared_publicly': 'Issue Shared Publicly',

--- a/static/app/views/issueList/actions/actionSet.tsx
+++ b/static/app/views/issueList/actions/actionSet.tsx
@@ -72,6 +72,23 @@ export function ActionSet({
           area,
         });
       }
+      if ('status' in data && data.status === 'resolved') {
+        const statusDetails =
+          'inRelease' in data.statusDetails
+            ? 'inRelease'
+            : 'inNextRelease' in data.statusDetails
+              ? 'inNextRelease'
+              : 'inCommit' in data.statusDetails
+                ? 'inCommit'
+                : 'inUpcomingRelease' in data.statusDetails
+                  ? 'inUpcomingRelease'
+                  : undefined;
+        trackAnalytics('issues_stream.resolved', {
+          organization,
+          action_status_details: statusDetails,
+          area,
+        });
+      }
       if ('priority' in data) {
         trackAnalytics('issues_stream.updated_priority', {
           organization,

--- a/static/app/views/issueList/actions/actionSet.tsx
+++ b/static/app/views/issueList/actions/actionSet.tsx
@@ -1,8 +1,9 @@
-import {Fragment} from 'react';
+import {Fragment, useCallback} from 'react';
 
 import {Button} from '@sentry/scraps/button';
 
 import {ArchiveActions} from 'sentry/components/actions/archive';
+import {useAnalyticsArea} from 'sentry/components/analyticsArea';
 import {makeGroupPriorityDropdownOptions} from 'sentry/components/badge/groupPriority';
 import {openConfirmModal} from 'sentry/components/confirm';
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
@@ -12,6 +13,7 @@ import {t} from 'sentry/locale';
 import {GroupStore} from 'sentry/stores/groupStore';
 import type {BaseGroup} from 'sentry/types/group';
 import {GroupStatus} from 'sentry/types/group';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
 import type {IssueTypeConfig} from 'sentry/utils/issueTypeConfig/types';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -50,6 +52,37 @@ export function ActionSet({
   selectedProjectSlug,
 }: Props) {
   const organization = useOrganization();
+  const area = useAnalyticsArea();
+
+  const handleUpdate = useCallback(
+    (data: IssueUpdateData) => {
+      if ('status' in data && data.status === 'ignored') {
+        const statusDetails =
+          'ignoreCount' in data.statusDetails
+            ? 'ignoreCount'
+            : 'ignoreDuration' in data.statusDetails
+              ? 'ignoreDuration'
+              : 'ignoreUserCount' in data.statusDetails
+                ? 'ignoreUserCount'
+                : undefined;
+        trackAnalytics('issues_stream.archived', {
+          organization,
+          action_status_details: statusDetails,
+          action_substatus: data.substatus,
+          area,
+        });
+      }
+      if ('priority' in data) {
+        trackAnalytics('issues_stream.updated_priority', {
+          organization,
+          priority: data.priority,
+          area,
+        });
+      }
+      onUpdate(data);
+    },
+    [area, onUpdate, organization]
+  );
   const numIssues = issues.size;
   const confirm = getConfirm({
     numIssues,
@@ -122,7 +155,7 @@ export function ActionSet({
       label: t('Mark Reviewed'),
       hidden: !nestReview,
       disabled: !canMarkReviewed,
-      onAction: () => onUpdate({inbox: false}),
+      onAction: () => handleUpdate({inbox: false}),
     },
     {
       key: 'bookmark',
@@ -131,7 +164,7 @@ export function ActionSet({
       onAction: () => {
         openConfirmModal({
           bypass: !onShouldConfirm(ConfirmAction.BOOKMARK),
-          onConfirm: () => onUpdate({isBookmarked: true}),
+          onConfirm: () => handleUpdate({isBookmarked: true}),
           message: confirm({action: ConfirmAction.BOOKMARK, canBeUndone: false}),
           confirmText: label('bookmark'),
         });
@@ -144,7 +177,7 @@ export function ActionSet({
       onAction: () => {
         openConfirmModal({
           bypass: !onShouldConfirm(ConfirmAction.UNBOOKMARK),
-          onConfirm: () => onUpdate({isBookmarked: false}),
+          onConfirm: () => handleUpdate({isBookmarked: false}),
           message: confirm({
             action: ConfirmAction.UNBOOKMARK,
             canBeUndone: false,
@@ -161,7 +194,8 @@ export function ActionSet({
       onAction: () => {
         openConfirmModal({
           bypass: !onShouldConfirm(ConfirmAction.UNRESOLVE),
-          onConfirm: () => onUpdate({status: GroupStatus.UNRESOLVED, statusDetails: {}}),
+          onConfirm: () =>
+            handleUpdate({status: GroupStatus.UNRESOLVED, statusDetails: {}}),
           message: confirm({action: ConfirmAction.UNRESOLVE, canBeUndone: true}),
           confirmText: label('unresolve'),
         });
@@ -194,7 +228,7 @@ export function ActionSet({
             openConfirmModal({
               bypass: !onShouldConfirm(ConfirmAction.UNRESOLVE),
               onConfirm: () =>
-                onUpdate({status: GroupStatus.UNRESOLVED, statusDetails: {}}),
+                handleUpdate({status: GroupStatus.UNRESOLVED, statusDetails: {}}),
               message: confirm({action: ConfirmAction.UNRESOLVE, canBeUndone: true}),
               confirmText: label('unarchive'),
             });
@@ -206,14 +240,14 @@ export function ActionSet({
       ) : null}
       <ResolveActions
         onShouldConfirm={onShouldConfirm}
-        onUpdate={onUpdate}
+        onUpdate={handleUpdate}
         anySelected={anySelected}
         confirm={confirm}
         label={label}
         selectedProjectSlug={selectedProjectSlug}
       />
       <ArchiveActions
-        onUpdate={onUpdate}
+        onUpdate={handleUpdate}
         shouldConfirm={onShouldConfirm(ConfirmAction.ARCHIVE)}
         confirmMessage={() => confirm({action: ConfirmAction.ARCHIVE, canBeUndone: true})}
         confirmLabel={label('archive')}
@@ -234,7 +268,7 @@ export function ActionSet({
           onChange: priority => {
             openConfirmModal({
               bypass: !onShouldConfirm(ConfirmAction.SET_PRIORITY),
-              onConfirm: () => onUpdate({priority}),
+              onConfirm: () => handleUpdate({priority}),
               message: confirm({
                 action: ConfirmAction.SET_PRIORITY,
                 append: ` to ${priority}`,
@@ -245,7 +279,9 @@ export function ActionSet({
           },
         })}
       />
-      {!nestReview && <ReviewAction disabled={!canMarkReviewed} onUpdate={onUpdate} />}
+      {!nestReview && (
+        <ReviewAction disabled={!canMarkReviewed} onUpdate={handleUpdate} />
+      )}
       <DropdownMenu
         size="sm"
         items={menuItems}

--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -13,6 +13,7 @@ import {
   addLoadingMessage,
   clearIndicators,
 } from 'sentry/actionCreators/indicator';
+import {useAnalyticsArea} from 'sentry/components/analyticsArea';
 import {IssueStreamHeaderLabel} from 'sentry/components/IssueStreamHeaderLabel';
 import {Sticky} from 'sentry/components/sticky';
 import {t, tct, tn} from 'sentry/locale';
@@ -183,6 +184,7 @@ export function IssueListActions({
     SAVED_SEARCHES_SIDEBAR_OPEN_LOCALSTORAGE_KEY,
     false
   );
+  const area = useAnalyticsArea();
   const theme = useTheme();
 
   const disableActions = useMedia(
@@ -247,6 +249,7 @@ export function IssueListActions({
           project_id: trackProject?.id,
           platform: trackProject?.platform,
           items_merged: allInQuerySelected ? 'all_in_query' : itemIds?.length,
+          area,
         });
       }
     });
@@ -273,29 +276,6 @@ export function IssueListActions({
   }
 
   function handleUpdate(data: IssueUpdateData) {
-    if ('status' in data && data.status === 'ignored') {
-      const statusDetails =
-        'ignoreCount' in data.statusDetails
-          ? 'ignoreCount'
-          : 'ignoreDuration' in data.statusDetails
-            ? 'ignoreDuration'
-            : 'ignoreUserCount' in data.statusDetails
-              ? 'ignoreUserCount'
-              : undefined;
-      trackAnalytics('issues_stream.archived', {
-        action_status_details: statusDetails,
-        action_substatus: data.substatus,
-        organization,
-      });
-    }
-
-    if ('priority' in data) {
-      trackAnalytics('issues_stream.updated_priority', {
-        organization,
-        priority: data.priority,
-      });
-    }
-
     actionSelectedGroups(itemIds => {
       // If `itemIds` is undefined then it means we expect to bulk update all items
       // that match the query.

--- a/static/app/views/issueList/supergroups/supergroupDrawer.tsx
+++ b/static/app/views/issueList/supergroups/supergroupDrawer.tsx
@@ -15,6 +15,7 @@ import {
   clearIndicators,
 } from 'sentry/actionCreators/indicator';
 import type {IndexedMembersByProject} from 'sentry/actionCreators/members';
+import {AnalyticsArea, useAnalyticsArea} from 'sentry/components/analyticsArea';
 import {NavigationCrumbs} from 'sentry/components/events/eventDrawer';
 import {DrawerBody, DrawerHeader} from 'sentry/components/globalDrawer/components';
 import type {GroupListColumn} from 'sentry/components/issues/groupList';
@@ -32,6 +33,7 @@ import {IconChevron, IconFilter} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {GroupStore} from 'sentry/stores/groupStore';
 import type {Group} from 'sentry/types/group';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {uniq} from 'sentry/utils/array/uniq';
 import {MarkedText} from 'sentry/utils/marked/markedText';
@@ -71,7 +73,7 @@ export function SupergroupDetailDrawer({
   filterWithCurrentSearch,
 }: SupergroupDetailDrawerProps) {
   return (
-    <Fragment>
+    <AnalyticsArea name="supergroup_drawer">
       <DrawerHeader hideBar>
         <Flex justify="between" align="center" gap="md" flexGrow={1}>
           <Flex align="center" gap="sm">
@@ -125,7 +127,7 @@ export function SupergroupDetailDrawer({
           </Container>
         )}
       </DrawerContentBody>
-    </Fragment>
+    </AnalyticsArea>
   );
 }
 
@@ -302,6 +304,7 @@ function DrawerActionsBar({groupIds}: {groupIds: string[]}) {
   const api = useApi();
   const organization = useOrganization();
   const queryClient = useQueryClient();
+  const area = useAnalyticsArea();
   const {selection} = usePageFilters();
   const {toggleSelectAllVisible, deselectAll} = useIssueSelectionActions();
   const {pageSelected, anySelected, multiSelected, selectedIdsSet} =
@@ -382,8 +385,15 @@ function DrawerActionsBar({groupIds}: {groupIds: string[]}) {
       },
       {}
     );
+    trackAnalytics('issues_stream.merged', {
+      organization,
+      project_id: undefined,
+      platform: undefined,
+      items_merged: itemIds.length,
+      area,
+    });
     deselectAll();
-  }, [api, organization.slug, selectedIdsSet, selection, deselectAll]);
+  }, [api, area, organization, selectedIdsSet, selection, deselectAll]);
 
   const onShouldConfirm = useCallback(
     (action: ConfirmAction) => {


### PR DESCRIPTION
Uses an analytics "area" to associate actions with either the issues stream or the supergroup drawer

Adds missing analytic event for resolution