### PR TITLE
ref(stories): automatic categories via index

### DIFF
--- a/build-utils/frontmatter-index-loader.ts
+++ b/build-utils/frontmatter-index-loader.ts
@@ -1,11 +1,11 @@
-import * as fs from 'node:fs';
-import * as path from 'node:path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import type {LoaderDefinitionFunction} from '@rspack/core';
 import {parse as parseYaml} from 'yaml';
 
 const frontmatterIndexLoader: LoaderDefinitionFunction = function () {
-  const staticAppDir = path.resolve(__dirname, '../static/app');
+  const staticAppDir = path.resolve(import.meta.dirname, '../static/app');
 
   this.addContextDependency(staticAppDir);
 

--- a/build-utils/frontmatter-index-loader.ts
+++ b/build-utils/frontmatter-index-loader.ts
@@ -13,7 +13,7 @@ const frontmatterIndexLoader: LoaderDefinitionFunction = function () {
     string,
     {category?: string; description?: string; title?: string}
   > = {};
-  for (const relPath of fs.globSync('static/app/**/*.mdx', {cwd: staticAppDir})) {
+  for (const relPath of fs.globSync('**/*.mdx', {cwd: staticAppDir})) {
     const absPath = path.join(staticAppDir, relPath);
     this.addDependency(absPath);
 

--- a/build-utils/frontmatter-index-loader.ts
+++ b/build-utils/frontmatter-index-loader.ts
@@ -13,7 +13,7 @@ const frontmatterIndexLoader: LoaderDefinitionFunction = function () {
     string,
     {category?: string; description?: string; title?: string}
   > = {};
-  for (const relPath of fs.globSync('**/*.mdx', {cwd: staticAppDir})) {
+  for (const relPath of fs.globSync('static/app/**/*.mdx', {cwd: staticAppDir})) {
     const absPath = path.join(staticAppDir, relPath);
     this.addDependency(absPath);
 

--- a/build-utils/frontmatter-index-loader.ts
+++ b/build-utils/frontmatter-index-loader.ts
@@ -1,0 +1,42 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import type {LoaderDefinitionFunction} from '@rspack/core';
+import {parse as parseYaml} from 'yaml';
+
+const frontmatterIndexLoader: LoaderDefinitionFunction = function () {
+  const staticAppDir = path.resolve(__dirname, '../static/app');
+
+  this.addContextDependency(staticAppDir);
+
+  const entries: Record<
+    string,
+    {category?: string; description?: string; title?: string}
+  > = {};
+  for (const relPath of fs.globSync('**/*.mdx', {cwd: staticAppDir})) {
+    const absPath = path.join(staticAppDir, relPath);
+    this.addDependency(absPath);
+
+    const source = fs.readFileSync(absPath, 'utf8');
+    const frontmatterBlock = source.match(/^---\s*\n([\s\S]*?)\n---/)?.[1];
+    if (!frontmatterBlock) {
+      continue;
+    }
+
+    const parsed = parseYaml(frontmatterBlock);
+    if (!parsed || typeof parsed !== 'object') {
+      continue;
+    }
+
+    const normalizedKey = 'app/' + relPath.replaceAll('\\', '/');
+    entries[normalizedKey] = {
+      title: parsed.title,
+      description: parsed.description,
+      category: parsed.category,
+    };
+  }
+
+  return `export const storyFrontmatterIndex = ${JSON.stringify(entries, null, 2)};`;
+};
+
+export default frontmatterIndexLoader;

--- a/package.json
+++ b/package.json
@@ -221,6 +221,7 @@
     "ts-checker-rspack-plugin": "1.2.6",
     "tslib": "^2.8.1",
     "type-fest": "^5.2.0",
+    "yaml": "2.8.3",
     "zod": "4.3.5",
     "zrender": "6.0.0",
     "zxcvbn": "^4.4.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -530,6 +530,9 @@ importers:
       type-fest:
         specifier: ^5.2.0
         version: 5.2.0
+      yaml:
+        specifier: 2.8.3
+        version: 2.8.3
       zod:
         specifier: 4.3.5
         version: 4.3.5(patch_hash=2bb6d33b2c713a7a2c559c18ad0aa6cfb261f01d935ee1288dfec6c84411aa76)
@@ -9257,13 +9260,8 @@ packages:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
 
-  yaml@2.8.0:
-    resolution: {integrity: sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==}
-    engines: {node: '>= 14.6'}
-    hasBin: true
-
-  yaml@2.8.2:
-    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -16644,7 +16642,7 @@ snapshots:
       smol-toml: 1.6.1
       strip-json-comments: 5.0.3
       unbash: 2.2.0
-      yaml: 2.8.2
+      yaml: 2.8.3
       zod: 4.3.5(patch_hash=2bb6d33b2c713a7a2c559c18ad0aa6cfb261f01d935ee1288dfec6c84411aa76)
 
   known-css-properties@0.34.0: {}
@@ -18262,7 +18260,7 @@ snapshots:
       toml: 3.0.0
       unified: 11.0.5
       unist-util-mdx-define: 1.1.2
-      yaml: 2.8.0
+      yaml: 2.8.3
 
   remark-mdx@3.1.0:
     dependencies:
@@ -19215,7 +19213,7 @@ snapshots:
       vfile-message: 4.0.2
       vfile-reporter: 8.1.1
       vfile-statistics: 3.0.0
-      yaml: 2.8.2
+      yaml: 2.8.3
     transitivePeerDependencies:
       - bluebird
       - supports-color
@@ -19729,9 +19727,7 @@ snapshots:
 
   yaml@1.10.2: {}
 
-  yaml@2.8.0: {}
-
-  yaml@2.8.2: {}
+  yaml@2.8.3: {}
 
   yargs-parser@21.1.1: {}
 

--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -300,6 +300,18 @@ const appConfig: Configuration = {
      */
     rules: [
       {
+        test: /stories[/\\]storyFrontmatterIndex\.ts$/,
+        enforce: 'pre',
+        use: [
+          {
+            loader: path.resolve(
+              import.meta.dirname,
+              './build-utils/frontmatter-index-loader.ts'
+            ),
+          },
+        ],
+      },
+      {
         test: /\.(js|jsx|ts|tsx)$/,
         // core-js: Avoids recompiling core-js based on usage imports
         // react-select: Ships pre-compiled ESM with emotion's keyframes already

--- a/static/app/stories/frontmatter.ts
+++ b/static/app/stories/frontmatter.ts
@@ -9,6 +9,7 @@ import type {StoryResources} from './view/useStoriesLoader';
 export interface MDXFrontmatter {
   description: string;
   title: string;
+  category?: string;
   layout?: 'document';
   resources?: StoryResources;
   source?: string;

--- a/static/app/stories/frontmatter.ts
+++ b/static/app/stories/frontmatter.ts
@@ -1,5 +1,17 @@
 import type {StoryResources} from './view/useStoriesLoader';
 
+type ComponentCategory =
+  | 'typography'
+  | 'layout'
+  | 'buttons'
+  | 'controls'
+  | 'forms'
+  | 'navigation'
+  | 'status'
+  | 'display'
+  | 'overlays'
+  | 'utilities'
+  | 'shared';
 /**
  * Frontmatter schema for MDX story files.
  * Validated at type-check time via Volar + @mdx-js/language-service.
@@ -9,7 +21,7 @@ import type {StoryResources} from './view/useStoriesLoader';
 export interface MDXFrontmatter {
   description: string;
   title: string;
-  category?: string;
+  category?: ComponentCategory;
   layout?: 'document';
   resources?: StoryResources;
   source?: string;

--- a/static/app/stories/storyFrontmatterIndex.ts
+++ b/static/app/stories/storyFrontmatterIndex.ts
@@ -1,0 +1,7 @@
+// Content generated at build time by build-utils/frontmatter-index-loader.ts.
+// Maps normalized MDX file paths (e.g. 'app/components/core/form/form.mdx')
+// to the value of the frontmatter `category` field.
+export const storyFrontmatterIndex: Record<
+  string,
+  {category?: string; description?: string; title?: string}
+> = {};

--- a/static/app/stories/view/storySearch.tsx
+++ b/static/app/stories/view/storySearch.tsx
@@ -16,10 +16,10 @@ import {Overlay} from 'sentry/components/overlay';
 import {useSearchTokenCombobox} from 'sentry/components/searchQueryBuilder/tokens/useSearchTokenCombobox';
 import {IconSearch} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {storyFrontmatterIndex} from 'sentry/stories/storyFrontmatterIndex';
 import type {StoryTreeNode} from 'sentry/stories/view/storyTree';
 import {
   COMPONENT_SUBCATEGORY_CONFIG,
-  inferComponentSubcategory,
   SECTION_CONFIG,
   SECTION_ORDER,
   useStoryHierarchy,
@@ -107,10 +107,15 @@ export function StorySearch() {
               {item.options.map(storyItem => {
                 const subcategoryKey =
                   item.key === 'core'
-                    ? inferComponentSubcategory(storyItem.name.toLowerCase())
+                    ? storyFrontmatterIndex[storyItem.filesystemPath]?.category
                     : undefined;
                 const subcategoryLabel = subcategoryKey
-                  ? COMPONENT_SUBCATEGORY_CONFIG[subcategoryKey].label
+                  ? (
+                      COMPONENT_SUBCATEGORY_CONFIG as Record<
+                        string,
+                        {label: string} | undefined
+                      >
+                    )[subcategoryKey]?.label
                   : undefined;
 
                 return (

--- a/static/app/stories/view/storySearch.tsx
+++ b/static/app/stories/view/storySearch.tsx
@@ -115,14 +115,11 @@ export function StorySearch() {
                       >
                     )[subcategoryKey]?.label
                   : undefined;
-                const searchText = [storyItem.label, meta?.title, meta?.description]
-                  .filter(Boolean)
-                  .join(' ');
 
                 return (
                   <Item
                     key={storyItem.filesystemPath}
-                    textValue={searchText}
+                    textValue={storyItem.label}
                     {...({
                       label: storyItem.label,
                       trailingItems: subcategoryLabel ? (

--- a/static/app/stories/view/storySearch.tsx
+++ b/static/app/stories/view/storySearch.tsx
@@ -56,7 +56,7 @@ export function StorySearch() {
       // For components section, consolidate all subcategories into a single section
       if (section === 'core') {
         const allCoreNodes = data.stories.flatMap(subcategoryFolder =>
-          Object.values(subcategoryFolder.children)
+          subcategoryFolder.flat()
         );
 
         if (allCoreNodes.length > 0) {
@@ -105,10 +105,8 @@ export function StorySearch() {
               }
             >
               {item.options.map(storyItem => {
-                const subcategoryKey =
-                  item.key === 'core'
-                    ? storyFrontmatterIndex[storyItem.filesystemPath]?.category
-                    : undefined;
+                const meta = storyFrontmatterIndex[storyItem.filesystemPath];
+                const subcategoryKey = item.key === 'core' ? meta?.category : undefined;
                 const subcategoryLabel = subcategoryKey
                   ? (
                       COMPONENT_SUBCATEGORY_CONFIG as Record<
@@ -117,11 +115,14 @@ export function StorySearch() {
                       >
                     )[subcategoryKey]?.label
                   : undefined;
+                const searchText = [storyItem.label, meta?.title, meta?.description]
+                  .filter(Boolean)
+                  .join(' ');
 
                 return (
                   <Item
                     key={storyItem.filesystemPath}
-                    textValue={storyItem.label}
+                    textValue={searchText}
                     {...({
                       label: storyItem.label,
                       trailingItems: subcategoryLabel ? (

--- a/static/app/stories/view/storyTree.tsx
+++ b/static/app/stories/view/storyTree.tsx
@@ -384,10 +384,6 @@ function isComponentSubcategory(
   return value !== undefined && value in COMPONENT_SUBCATEGORY_CONFIG;
 }
 
-export function inferComponentSubcategory(_componentName: string): ComponentSubcategory {
-  return 'shared';
-}
-
 function isOverviewFile(file: string) {
   return file.includes('components/core/overview');
 }

--- a/static/app/stories/view/storyTree.tsx
+++ b/static/app/stories/view/storyTree.tsx
@@ -6,6 +6,7 @@ import {Link} from '@sentry/scraps/link';
 import {Heading} from '@sentry/scraps/text';
 
 import {IconChevron} from 'sentry/icons';
+import type {MDXFrontmatter} from 'sentry/stories/frontmatter';
 import {storyFrontmatterIndex} from 'sentry/stories/storyFrontmatterIndex';
 import {useStoryParams} from 'sentry/stories/view';
 import {fzf} from 'sentry/utils/search/fzf';
@@ -110,18 +111,7 @@ export type StoryCategory = 'principles' | 'patterns' | 'core' | 'product';
 
 type StorySection = 'overview' | StoryCategory;
 
-type ComponentSubcategory =
-  | 'typography'
-  | 'layout'
-  | 'buttons'
-  | 'controls'
-  | 'forms'
-  | 'navigation'
-  | 'status'
-  | 'display'
-  | 'overlays'
-  | 'utilities'
-  | 'shared';
+type ComponentSubcategory = NonNullable<MDXFrontmatter['category']>;
 
 export const SECTION_CONFIG: Record<StorySection, {label: string}> = {
   overview: {label: 'Overview'},

--- a/static/app/stories/view/storyTree.tsx
+++ b/static/app/stories/view/storyTree.tsx
@@ -6,6 +6,7 @@ import {Link} from '@sentry/scraps/link';
 import {Heading} from '@sentry/scraps/text';
 
 import {IconChevron} from 'sentry/icons';
+import {storyFrontmatterIndex} from 'sentry/stories/storyFrontmatterIndex';
 import {useStoryParams} from 'sentry/stories/view';
 import {fzf} from 'sentry/utils/search/fzf';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
@@ -131,7 +132,6 @@ export const SECTION_CONFIG: Record<StorySection, {label: string}> = {
 };
 
 interface SubcategoryConfig {
-  components: string[];
   label: string;
   subgroups?: Array<{components: string[]; label: string}>;
 }
@@ -140,33 +140,12 @@ export const COMPONENT_SUBCATEGORY_CONFIG: Record<
   ComponentSubcategory,
   SubcategoryConfig
 > = {
-  layout: {
-    label: 'Layout',
-    components: [
-      'composition',
-      'container',
-      'flex',
-      'grid',
-      'stack',
-      'surface',
-      'disclosure',
-    ],
-  },
-  typography: {
-    label: 'Typography',
-    components: ['heading', 'prose', 'text', 'inlinecode', 'quote'],
-  },
-  buttons: {
-    label: 'Buttons',
-    components: ['button', 'linkbutton', 'avatarbutton'],
-  },
-  controls: {
-    label: 'Controls',
-    components: ['buttonbar', 'compactselect', 'composite', 'segmentedcontrol'],
-  },
+  layout: {label: 'Layout'},
+  typography: {label: 'Typography'},
+  buttons: {label: 'Buttons'},
+  controls: {label: 'Controls'},
   forms: {
     label: 'Forms',
-    components: ['form', 'fields', 'autosaveform'],
     subgroups: [
       {
         label: 'Primitives',
@@ -185,30 +164,12 @@ export const COMPONENT_SUBCATEGORY_CONFIG: Record<
       },
     ],
   },
-  navigation: {
-    label: 'Navigation',
-    components: ['link', 'tabs', 'menulistitem'],
-  },
-  status: {
-    label: 'Status',
-    components: ['alert', 'badge', 'tag', 'toast', 'statusindicator'],
-  },
-  display: {
-    label: 'Display',
-    components: ['avatar', 'image', 'codeblock'],
-  },
-  overlays: {
-    label: 'Overlays',
-    components: ['slideoverpanel', 'tooltip', 'infotext', 'infotip'],
-  },
-  utilities: {
-    label: 'Utilities',
-    components: ['separator', 'hotkey', 'interactionstatelayer'],
-  },
-  shared: {
-    label: 'Shared',
-    components: [],
-  },
+  navigation: {label: 'Navigation'},
+  status: {label: 'Status'},
+  display: {label: 'Display'},
+  overlays: {label: 'Overlays'},
+  utilities: {label: 'Utilities'},
+  shared: {label: 'Shared'},
 };
 
 export const SECTION_ORDER: StorySection[] = [
@@ -293,31 +254,9 @@ export function useFlatStoryList(): StoryTreeNode[] {
             continue;
           }
 
-          const config = COMPONENT_SUBCATEGORY_CONFIG[subcategory];
-          const allConfigured = [
-            ...config.components,
-            ...(config.subgroups?.flatMap(sg => sg.components) ?? []),
-          ];
-          const added = new Set<string>();
-
-          // Add configured components in config order
-          for (const componentName of allConfigured) {
-            const file = subcategoryFiles.find(
-              f => inferComponentName(f).toLowerCase() === componentName
-            );
-            if (file) {
-              const name = inferComponentName(file);
-              result.push(new StoryTreeNode(formatName(name), 'core', file));
-              added.add(file);
-            }
-          }
-
-          // Add remaining files not in config (sorted)
           for (const file of subcategoryFiles.sort()) {
-            if (!added.has(file)) {
-              const name = inferComponentName(file);
-              result.push(new StoryTreeNode(formatName(name), 'core', file));
-            }
+            const name = inferComponentName(file);
+            result.push(new StoryTreeNode(formatName(name), 'core', file));
           }
         }
       }
@@ -438,10 +377,10 @@ function inferStoryLocation(path: string): StoryLocation {
     return {section: 'patterns'};
   }
 
-  // Components - determine subcategory
+  // Components - determine subcategory from frontmatter, fall back to 'shared'
   if (isCoreFile(path)) {
-    const componentName = inferComponentName(path).toLowerCase();
-    const subcategory = inferComponentSubcategory(componentName);
+    const category = storyFrontmatterIndex[path]?.category;
+    const subcategory = isComponentSubcategory(category) ? category : 'shared';
     return {section: 'core', subcategory};
   }
 
@@ -449,15 +388,13 @@ function inferStoryLocation(path: string): StoryLocation {
   return {section: 'product'};
 }
 
-export function inferComponentSubcategory(componentName: string): ComponentSubcategory {
-  for (const [subcategory, config] of Object.entries(COMPONENT_SUBCATEGORY_CONFIG)) {
-    if (config.components.includes(componentName)) {
-      return subcategory as ComponentSubcategory;
-    }
-    if (config.subgroups?.some(subgroup => subgroup.components.includes(componentName))) {
-      return subcategory as ComponentSubcategory;
-    }
-  }
+function isComponentSubcategory(
+  value: string | undefined
+): value is ComponentSubcategory {
+  return value !== undefined && value in COMPONENT_SUBCATEGORY_CONFIG;
+}
+
+export function inferComponentSubcategory(_componentName: string): ComponentSubcategory {
   return 'shared';
 }
 
@@ -604,28 +541,10 @@ function buildComponentTree(
       config.subgroups?.flatMap(sg => sg.components) ?? []
     );
 
-    // Add top-level components in config order
-    for (const componentName of config.components) {
-      const file = files.find(f => inferComponentName(f).toLowerCase() === componentName);
-      if (file) {
-        const name = inferComponentName(file);
-        folderNode.children[componentName] = new StoryTreeNode(
-          formatName(name),
-          'core',
-          file
-        );
-      }
-    }
-
-    // Add remaining top-level files not in config.components or subgroups (sorted)
+    // Add top-level files (those not in any subgroup), sorted alphabetically
     for (const file of files.sort()) {
       const name = inferComponentName(file);
-      const lowerName = name.toLowerCase();
-      if (
-        !config.components.includes(lowerName) &&
-        !subgroupComponents.has(lowerName) &&
-        !folderNode.children[name]
-      ) {
+      if (!subgroupComponents.has(name.toLowerCase())) {
         folderNode.children[name] = new StoryTreeNode(formatName(name), 'core', file);
       }
     }


### PR DESCRIPTION
Adds a new rspack plugin (`build-utils/frontmatter-index-loader.ts`) which extracts frontmatter from `*.mdx` story files at compile time. 

`yaml` now added as a direct dependency because it's being used explicitly, but it already existed in our dependency tree from `remark-mdx-frontmatter@5.2.0`, `knip@6.4.1`, and `eslint-plugin-mdx@3.6.2`.

Removes manual category config in `storySearch.tsx` (categories are now fully derived from frontmatter)

Fixes DE-1012, which was an issue with the depth of our search logic