### PR TITLE
feat(api): Allow per-org rate limit overrides for project transfer

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -226,7 +226,7 @@ class Endpoint(APIView):
 
     owner: ApiOwner = ApiOwner.UNOWNED
     publish_status: dict[HTTP_METHOD_NAME, ApiPublishStatus] = {}
-    rate_limits: RateLimitConfig = DEFAULT_RATE_LIMIT_CONFIG
+    rate_limits: RateLimitConfig | Callable[..., RateLimitConfig] = DEFAULT_RATE_LIMIT_CONFIG
     enforce_rate_limit: bool = settings.SENTRY_RATELIMITER_ENABLED
     servers: list[dict[str, Any]] | None = None
 

--- a/src/sentry/core/endpoints/project_transfer.py
+++ b/src/sentry/core/endpoints/project_transfer.py
@@ -44,6 +44,8 @@ class ProjectTransferEndpoint(ProjectEndpoint):
         override = options.get("api.project-transfer.rate-limit-overrides").get(
             str(kwargs.get("organization_id_or_slug", "")), {}
         )
+        if not isinstance(override, dict):
+            override = {}
         return RateLimitConfig(
             limit_overrides={
                 "POST": {

--- a/src/sentry/core/endpoints/project_transfer.py
+++ b/src/sentry/core/endpoints/project_transfer.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 from urllib.parse import urlencode
 from uuid import uuid4
 
@@ -37,15 +38,22 @@ class ProjectTransferEndpoint(ProjectEndpoint):
     permission_classes = (RelaxedProjectPermission,)
 
     enforce_rate_limit = True
-    rate_limits = RateLimitConfig(
-        limit_overrides={
-            "POST": {
-                RateLimitCategory.USER: RateLimit(
-                    limit=3, window=60 * 60
-                ),  # 3 POST requests per hour per user
+
+    @staticmethod
+    def rate_limits(*args: Any, **kwargs: Any) -> RateLimitConfig:
+        override = options.get("api.project-transfer.rate-limit-overrides").get(
+            str(kwargs.get("organization_id_or_slug", "")), {}
+        )
+        return RateLimitConfig(
+            limit_overrides={
+                "POST": {
+                    RateLimitCategory.USER: RateLimit(
+                        limit=override.get("limit", 3),
+                        window=override.get("window", 60 * 60),
+                    ),
+                },
             },
-        },
-    )
+        )
 
     @sudo_required
     def post(self, request: Request, project) -> Response:

--- a/src/sentry/core/endpoints/project_transfer.py
+++ b/src/sentry/core/endpoints/project_transfer.py
@@ -39,19 +39,14 @@ class ProjectTransferEndpoint(ProjectEndpoint):
 
     enforce_rate_limit = True
 
-    @property
     def rate_limits(*args: Any, **kwargs: Any) -> RateLimitConfig:
-        override = options.get("api.project-transfer.rate-limit-overrides").get(
-            str(kwargs.get("organization_id_or_slug", "")), {}
-        )
-        if not isinstance(override, dict):
-            override = {}
+        limit = options.get("api.project-transfer.rate-limit-overrides")
         return RateLimitConfig(
             limit_overrides={
                 "POST": {
                     RateLimitCategory.USER: RateLimit(
-                        limit=override.get("limit", 3),
-                        window=override.get("window", 60 * 60),
+                        limit=limit,
+                        window=60 * 60,
                     ),
                 },
             },

--- a/src/sentry/core/endpoints/project_transfer.py
+++ b/src/sentry/core/endpoints/project_transfer.py
@@ -39,7 +39,7 @@ class ProjectTransferEndpoint(ProjectEndpoint):
 
     enforce_rate_limit = True
 
-    @staticmethod
+    @property
     def rate_limits(*args: Any, **kwargs: Any) -> RateLimitConfig:
         override = options.get("api.project-transfer.rate-limit-overrides").get(
             str(kwargs.get("organization_id_or_slug", "")), {}

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -344,12 +344,11 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Per-organization POST rate-limit overrides for ProjectTransferEndpoint.
-# Keyed by organization id or slug (as string), value is {"limit": int, "window": int}.
+# POST rate limit for ProjectTransferEndpoint, overridable via automator.
 register(
     "api.project-transfer.rate-limit-overrides",
-    type=Dict,
-    default={},
+    type=Int,
+    default=3,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -344,6 +344,15 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Per-organization POST rate-limit overrides for ProjectTransferEndpoint.
+# Keyed by organization id or slug (as string), value is {"limit": int, "window": int}.
+register(
+    "api.project-transfer.rate-limit-overrides",
+    type=Dict,
+    default={},
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Beacon
 register("beacon.anonymous", type=Bool, flags=FLAG_REQUIRED)
 register(

--- a/tests/sentry/core/endpoints/test_project_transfer.py
+++ b/tests/sentry/core/endpoints/test_project_transfer.py
@@ -86,6 +86,29 @@ class ProjectTransferTest(APITestCase):
                 assert not mail.outbox
 
     @override_settings(SENTRY_SELF_HOSTED=False)
+    def test_rate_limit_with_override(self) -> None:
+        project = self.create_project()
+        new_user = self.create_user("b@example.com")
+        self.login_as(user=self.user)
+
+        url = reverse(
+            "sentry-api-0-project-transfer",
+            kwargs={
+                "organization_id_or_slug": project.organization.slug,
+                "project_id_or_slug": project.slug,
+            },
+        )
+
+        with freeze_time("2024-07-01"):
+            with self.options({"api.project-transfer.rate-limit-overrides": 5}):
+                for _ in range(5 + 1):
+                    response = self.client.post(url, {"email": new_user.email})
+        assert response.status_code == 429
+        assert orjson.loads(response.content) == {
+            "detail": "You are attempting to use this endpoint too frequently. Limit is 5 requests in 3600 seconds"
+        }
+
+    @override_settings(SENTRY_SELF_HOSTED=False)
     def test_rate_limit(self) -> None:
         project = self.create_project()
         # new user is not an owner of anything


### PR DESCRIPTION
The `ProjectTransferEndpoint` POST rate limit was a hardcoded 3/hour per
user. Some orgs legitimately need a higher ceiling (e.g. during a bulk
project migration) and bumping the value previously required a code
deploy.

The callable form is required because the rate-limit middleware reads
`view_cls.rate_limits` once per class import for static configs — only a
callable is re-evaluated per request, which is necessary for the option
to actually take effect at runtime.