### PR TITLE
fix(seer): Remove code mappings fallback from has_project_connected_repos

### DIFF
--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -885,7 +885,6 @@ def has_project_connected_repos(
 ) -> bool:
     """
     Check if a project has connected repositories for Seer automation.
-    Checks Seer preferences first, then falls back to Sentry code mappings.
     Results are cached for 15 minutes to minimize API calls.
     """
     cache_key = f"seer-project-has-repos:{organization.id}:{project.id}"
@@ -903,10 +902,6 @@ def has_project_connected_repos(
             has_repos = bool(preference and preference.repositories)
         except (SeerApiError, SeerApiResponseValidationError):
             pass
-
-    if not has_repos:
-        # If it's the first autofix run of project we check code mapping.
-        has_repos = bool(get_autofix_repos_from_project_code_mappings(project))
 
     logger.info(
         "Checking if project has repositories connected",

--- a/tests/sentry/seer/autofix/test_autofix_utils.py
+++ b/tests/sentry/seer/autofix/test_autofix_utils.py
@@ -479,12 +479,9 @@ class TestHasProjectConnectedRepos(TestCase):
             timeout=60 * 15,
         )
 
-    @patch("sentry.seer.autofix.utils.get_autofix_repos_from_project_code_mappings")
     @patch("sentry.seer.autofix.utils.cache")
     @patch("sentry.seer.autofix.utils.get_project_seer_preferences")
-    def test_returns_false_when_no_repos(
-        self, mock_get_preferences, mock_cache, mock_get_code_mappings
-    ):
+    def test_returns_false_when_no_repos(self, mock_get_preferences, mock_cache):
         """Test returns False when project has no connected repositories."""
         mock_cache.get.return_value = None
         mock_preference = Mock()
@@ -492,7 +489,6 @@ class TestHasProjectConnectedRepos(TestCase):
         mock_response = Mock()
         mock_response.preference = mock_preference
         mock_get_preferences.return_value = mock_response
-        mock_get_code_mappings.return_value = []
 
         result = has_project_connected_repos(self.organization, self.project)
 
@@ -503,18 +499,14 @@ class TestHasProjectConnectedRepos(TestCase):
             timeout=60 * 15,
         )
 
-    @patch("sentry.seer.autofix.utils.get_autofix_repos_from_project_code_mappings")
     @patch("sentry.seer.autofix.utils.cache")
     @patch("sentry.seer.autofix.utils.get_project_seer_preferences")
-    def test_returns_false_when_preference_is_none_and_no_code_mappings(
-        self, mock_get_preferences, mock_cache, mock_get_code_mappings
-    ):
-        """Test returns False when preference is None and no code mappings exist."""
+    def test_returns_false_when_preference_is_none(self, mock_get_preferences, mock_cache):
+        """Test returns False when preference is None."""
         mock_cache.get.return_value = None
         mock_response = Mock()
         mock_response.preference = None
         mock_get_preferences.return_value = mock_response
-        mock_get_code_mappings.return_value = []
 
         result = has_project_connected_repos(self.organization, self.project)
 
@@ -522,31 +514,6 @@ class TestHasProjectConnectedRepos(TestCase):
         mock_cache.set.assert_called_once_with(
             f"seer-project-has-repos:{self.organization.id}:{self.project.id}",
             False,
-            timeout=60 * 15,
-        )
-
-    @patch("sentry.seer.autofix.utils.get_autofix_repos_from_project_code_mappings")
-    @patch("sentry.seer.autofix.utils.cache")
-    @patch("sentry.seer.autofix.utils.get_project_seer_preferences")
-    def test_falls_back_to_code_mappings_when_no_seer_preference(
-        self, mock_get_preferences, mock_cache, mock_get_code_mappings
-    ):
-        """Test falls back to code mappings when Seer has no preference."""
-        mock_cache.get.return_value = None
-        mock_response = Mock()
-        mock_response.preference = None
-        mock_get_preferences.return_value = mock_response
-        mock_get_code_mappings.return_value = [
-            {"provider": "github", "owner": "test", "name": "repo"}
-        ]
-
-        result = has_project_connected_repos(self.organization, self.project)
-
-        assert result is True
-        mock_get_code_mappings.assert_called_once()
-        mock_cache.set.assert_called_once_with(
-            f"seer-project-has-repos:{self.organization.id}:{self.project.id}",
-            True,
             timeout=60 * 15,
         )
 
@@ -592,23 +559,21 @@ class TestHasProjectConnectedRepos(TestCase):
         mock_get_preferences.assert_called_once()  # API was called
         mock_cache.set.assert_called_once()  # Cache still updated
 
-    @patch("sentry.seer.autofix.utils.get_autofix_repos_from_project_code_mappings")
     @patch("sentry.seer.autofix.utils.cache")
     @patch("sentry.seer.autofix.utils.get_project_seer_preferences")
-    def test_falls_back_to_code_mappings_on_api_error(
-        self, mock_get_preferences, mock_cache, mock_get_code_mappings
-    ):
-        """Test falls back to code mappings when Seer API fails."""
+    def test_returns_false_on_api_error(self, mock_get_preferences, mock_cache):
+        """Test returns False when Seer API fails."""
         mock_cache.get.return_value = None
         mock_get_preferences.side_effect = SeerApiError("API Error", 500)
-        mock_get_code_mappings.return_value = [
-            {"provider": "github", "owner": "test", "name": "repo"}
-        ]
 
         result = has_project_connected_repos(self.organization, self.project)
 
-        assert result is True
-        mock_get_code_mappings.assert_called_once()
+        assert result is False
+        mock_cache.set.assert_called_once_with(
+            f"seer-project-has-repos:{self.organization.id}:{self.project.id}",
+            False,
+            timeout=60 * 15,
+        )
 
     @with_feature("organizations:seer-project-settings-read-from-sentry")
     @patch("sentry.seer.autofix.utils.read_preference_from_sentry_db")


### PR DESCRIPTION
`has_project_connected_repos` now checks only Seer project preferences to determine whether a project has connected repos.

Consistent with https://github.com/getsentry/sentry/pull/113077 (don't fall back to code mappings if it's our first autofix run) and https://github.com/getsentry/sentry/pull/113369 (bill based on connected project repositories, instead of code mappings).