### PR TITLE
feat(tracemetrics): Open Alert in Explore

### DIFF
--- a/static/app/views/detectors/components/details/metric/getDetectorOpenInDestination.spec.tsx
+++ b/static/app/views/detectors/components/details/metric/getDetectorOpenInDestination.spec.tsx
@@ -230,6 +230,59 @@ describe('getDetectorOpenInDestination', () => {
         expect(result?.to).toContain('my_metric');
         expect(result?.to).toContain('sum%28value%2Cmy_metric%2Ccounter%2C-%29');
       });
+
+      it('expands equation aggregates into per-function rows plus an equation row', () => {
+        const detector = MetricDetectorFixture({
+          dataSources: [
+            SnubaQueryDataSourceFixture({
+              queryObj: {
+                id: '1',
+                status: 1,
+                subscription: '1',
+                snubaQuery: {
+                  id: '1',
+                  aggregate: 'equation|sum(value,a,counter,-) + sum(value,b,counter,-)',
+                  dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
+                  eventTypes: [EventTypes.TRACE_ITEM_METRIC],
+                  query: 'foo:bar',
+                  timeWindow: 300,
+                  environment: 'prod',
+                },
+              },
+            }),
+          ],
+        });
+
+        const result = getDetectorOpenInDestination({
+          detectorName: detector.name,
+          organization,
+          projectId: detector.projectId,
+          snubaQuery: detector.dataSources[0].queryObj.snubaQuery,
+          statsPeriod: '7d',
+        });
+
+        expect(result?.buttonText).toBe('Open in Metrics');
+        const to = result?.to as string;
+        const metricParams = new URL(`https://example.com${to}`).searchParams.getAll(
+          'metric'
+        );
+        expect(metricParams).toHaveLength(3);
+
+        const parsedMetrics = metricParams.map(value => JSON.parse(value));
+        expect(parsedMetrics[0].metric.name).toBe('a');
+        expect(parsedMetrics[0].aggregateFields[0].yAxes).toEqual([
+          'sum(value,a,counter,-)',
+        ]);
+        expect(parsedMetrics[1].metric.name).toBe('b');
+        expect(parsedMetrics[1].aggregateFields[0].yAxes).toEqual([
+          'sum(value,b,counter,-)',
+        ]);
+        // Equation row carries the top-level filter and the full equation text.
+        expect(parsedMetrics[2].query).toBe('foo:bar');
+        expect(parsedMetrics[2].aggregateFields[0].yAxes[0]).toBe(
+          'equation|sum(value,a,counter,-) + sum(value,b,counter,-)'
+        );
+      });
     });
 
     describe('Releases dataset', () => {

--- a/static/app/views/detectors/components/details/metric/getDetectorOpenInDestination.tsx
+++ b/static/app/views/detectors/components/details/metric/getDetectorOpenInDestination.tsx
@@ -14,10 +14,8 @@ import {getDetectorDataset} from 'sentry/views/detectors/datasetConfig/getDetect
 import {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {getLogsUrl} from 'sentry/views/explore/logs/utils';
-import {defaultMetricQuery} from 'sentry/views/explore/metrics/metricQuery';
-import {parseMetricAggregate} from 'sentry/views/explore/metrics/parseMetricsAggregate';
+import {parseAggregateExpression} from 'sentry/views/explore/metrics/parseAggregateExpression';
 import {getMetricsUrl} from 'sentry/views/explore/metrics/utils';
-import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 import {getExploreUrl} from 'sentry/views/explore/utils';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 import {DEFAULT_PROJECT_THRESHOLD} from 'sentry/views/performance/data';
@@ -184,15 +182,18 @@ function getDetectorMetricsUrl({
   const interval = convertTimeWindowSecondsToInterval(snubaQuery.timeWindow);
   const numericProjectId = Number(projectId);
 
-  const {traceMetric} = parseMetricAggregate(snubaQuery.aggregate ?? '');
+  // Expand equation aggregates (e.g. `equation|count(...) + count(...)`) into
+  // one metric row per unique function plus an equation row, so Explore opens
+  // with all the referenced components, not a single opaque VisualizeFunction.
+  const parsed = parseAggregateExpression(snubaQuery.aggregate ?? '', snubaQuery.query);
+  const parsedQueries = parsed.equationRow
+    ? [...parsed.metricQueries, parsed.equationRow]
+    : parsed.metricQueries;
 
-  const metricQuery = defaultMetricQuery();
-  metricQuery.metric = traceMetric;
-  metricQuery.queryParams = metricQuery.queryParams.replace({
-    mode: Mode.AGGREGATE,
-    query: snubaQuery.query,
-    aggregateFields: [new VisualizeFunction(snubaQuery.aggregate)],
-  });
+  const metricQueries = parsedQueries.map(metricQuery => ({
+    ...metricQuery,
+    queryParams: metricQuery.queryParams.replace({mode: Mode.AGGREGATE}),
+  }));
 
   return getMetricsUrl({
     organization,
@@ -207,7 +208,7 @@ function getDetectorMetricsUrl({
       projects: [numericProjectId],
     },
     interval,
-    metricQueries: [metricQuery],
+    metricQueries,
   });
 }
 


### PR DESCRIPTION
Works for both equations and regular aggregate selections. Uses the parser helper to create all of the required metric query objects to open in Metrics Explorer.