### PR TITLE
fix(mcp): sync .cursor/mcp.json with dotagents output

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,11 +1,9 @@
 {
   "mcpServers": {
     "sentry": {
-      "type": "http",
       "url": "https://mcp.sentry.dev/mcp/sentry?experimental=1"
     },
     "devinfra-mcp": {
-      "type": "http",
       "url": "https://devinfra-mcp.getsentry.net/mcp"
     }
   }


### PR DESCRIPTION
Remove the `"type": "http"` field from each entry in `.cursor/mcp.json` so the committed file matches what dotagents' cursor generator produces.

dotagents' cursor serializer omits `type` and relies on Cursor's URL-based transport auto-detection (see `getsentry/dotagents` `src/agents/definitions/cursor.ts`). Because the file here included `type`, every `devenv sync` regenerated it and left the working tree dirty.

```
error: Your local changes to the following files would be overwritten by checkout:
	.cursor/mcp.json
```