### PR TITLE
ref(issue-details): use shared Sticky for event nav

### DIFF
--- a/static/app/views/issueDetails/streamline/eventDetails.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetails.tsx
@@ -72,7 +72,7 @@ const FloatingEventNavigation = styled(Sticky)`
   z-index: ${p => p.theme.zIndex.header};
   border-radius: ${p => p.theme.radius.md} ${p => p.theme.radius.md} 0 0;
 
-  &[data-stuck] > div {
+  &[data-stuck] {
     border-radius: 0;
   }
 `;

--- a/static/app/views/issueDetails/streamline/eventDetails.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetails.tsx
@@ -2,11 +2,11 @@ import {useLayoutEffect, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
+import {Sticky} from 'sentry/components/sticky';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
 import {getConfigForIssueType} from 'sentry/utils/issueTypeConfig';
-import {useIsStuck} from 'sentry/utils/useIsStuck';
 import {
   EventDetailsContent,
   type EventDetailsContentProps,
@@ -45,7 +45,6 @@ export function EventDetails({group, event, project}: EventDetailsContentProps) 
 
 function StickyEventNav({event, group}: {event: Event; group: Group}) {
   const [nav, setNav] = useState<HTMLDivElement | null>(null);
-  const isStuck = useIsStuck(nav);
   const {dispatch} = useIssueDetails();
   const {contentTop} = useTopOffset();
   const stickyTopOffset = Number.parseInt(contentTop, 10);
@@ -62,23 +61,18 @@ function StickyEventNav({event, group}: {event: Event; group: Group}) {
   }, [nav, dispatch, stickyTopOffset]);
 
   return (
-    <FloatingEventNavigation
-      event={event}
-      group={group}
-      ref={setNav}
-      data-stuck={isStuck}
-      style={{top: stickyTopOffset}}
-    />
+    <FloatingEventNavigation style={{top: stickyTopOffset}}>
+      <EventTitle event={event} group={group} ref={setNav} />
+    </FloatingEventNavigation>
   );
 }
 
-const FloatingEventNavigation = styled(EventTitle)`
-  position: sticky;
+const FloatingEventNavigation = styled(Sticky)`
   background: ${p => p.theme.tokens.background.primary};
   z-index: ${p => p.theme.zIndex.header};
   border-radius: ${p => p.theme.radius.md} ${p => p.theme.radius.md} 0 0;
 
-  &[data-stuck='true'] {
+  &[data-stuck] > div {
     border-radius: 0;
   }
 `;

--- a/static/app/views/issueDetails/streamline/eventDetails.tsx
+++ b/static/app/views/issueDetails/streamline/eventDetails.tsx
@@ -61,7 +61,7 @@ function StickyEventNav({event, group}: {event: Event; group: Group}) {
   }, [nav, dispatch, stickyTopOffset]);
 
   return (
-    <FloatingEventNavigation style={{top: stickyTopOffset}}>
+    <FloatingEventNavigation>
       <EventTitle event={event} group={group} ref={setNav} />
     </FloatingEventNavigation>
   );

--- a/static/app/views/navigation/topBar.tsx
+++ b/static/app/views/navigation/topBar.tsx
@@ -34,15 +34,11 @@ function TopBarContent() {
   const {openSeerExplorer} = useSeerExplorerContext();
 
   useEffect(() => {
-    if (!hasPageFrame) {
-      document.documentElement.style.removeProperty(TOP_BAR_HEIGHT_CSS_VAR);
-      return;
-    }
     document.documentElement.style.setProperty(TOP_BAR_HEIGHT_CSS_VAR, contentTop);
     return () => {
       document.documentElement.style.removeProperty(TOP_BAR_HEIGHT_CSS_VAR);
     };
-  }, [hasPageFrame, contentTop]);
+  }, [contentTop]);
 
   if (!hasPageFrame) {
     return null;


### PR DESCRIPTION
Follow-up to [this review comment](https://github.com/getsentry/sentry/pull/113401#discussion_r3111784519) on #113401: wrap the sticky event nav in the shared `Sticky` component from `sentry/components/sticky` instead of hand-rolling the pinning logic with `position: sticky` + `useIsStuck`.

To make `Sticky` a true self-contained primitive, this also makes `--top-bar-height` unconditional in `TopBar`: the CSS variable is now set from `useTopOffset`'s `contentTop` regardless of the page frame feature, so `Sticky`'s `top: var(--top-bar-height, 0px)` works as a single source of truth across desktop/mobile and page-frame-on/off (including the legacy mobile top bar fallback). Consumers no longer need to pass an inline `top` style, and the inline style here is dropped. `useTopOffset` is still consumed in `StickyEventNav` for the scroll-margin math.

Refs DE-1160