### PR TITLE
feat(dashboards): Register Node.js runtime metrics prebuilt dashboard

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboards.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboards.py
@@ -91,6 +91,7 @@ class PrebuiltDashboardId(IntEnum):
     BACKEND_QUEUES = 26
     BACKEND_QUEUE_SUMMARY = 27
     BACKEND_CACHES = 28
+    NODE_RUNTIME_METRICS = 29
 
 
 class PrebuiltDashboard(TypedDict, total=False):
@@ -228,6 +229,10 @@ PREBUILT_DASHBOARDS: list[PrebuiltDashboard] = [
     {
         "prebuilt_id": PrebuiltDashboardId.BACKEND_CACHES,
         "title": "Caches",
+    },
+    {
+        "prebuilt_id": PrebuiltDashboardId.NODE_RUNTIME_METRICS,
+        "title": "Node.js Runtime Metrics",
     },
 ]
 

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboards.py
@@ -2358,6 +2358,28 @@ class OrganizationDashboardsTest(OrganizationDashboardWidgetTestCase):
         prebuilt_ids_in_response = {d["prebuiltId"] for d in prebuilt_in_response}
         assert PrebuiltDashboardId.BACKEND_QUERIES_SUMMARY in prebuilt_ids_in_response
 
+    def test_node_runtime_metrics_prebuilt_dashboard_sync(self) -> None:
+        """The Node.js Runtime Metrics prebuilt dashboard syncs when enabled via options."""
+        with self.feature("organizations:dashboards-prebuilt-insights-dashboards"):
+            with override_options(
+                {"dashboards.prebuilt-dashboard-ids": [PrebuiltDashboardId.NODE_RUNTIME_METRICS]}
+            ):
+                response = self.do_request("get", self.url)
+        assert response.status_code == 200
+
+        dashboard = Dashboard.objects.get(
+            organization=self.organization,
+            prebuilt_id=PrebuiltDashboardId.NODE_RUNTIME_METRICS,
+        )
+        assert dashboard.title == "Node.js Runtime Metrics"
+
+        prebuilt_in_response = [
+            d
+            for d in response.data
+            if d.get("prebuiltId") == PrebuiltDashboardId.NODE_RUNTIME_METRICS
+        ]
+        assert len(prebuilt_in_response) == 1
+
     def test_post_with_text_widget(self) -> None:
         with self.feature("organizations:dashboards-text-widgets"):
             data = {


### PR DESCRIPTION
Register a new `NODE_RUNTIME_METRICS = 29` prebuilt dashboard so it gets synced to the DB when enabled via the `dashboards.prebuilt-dashboard-ids` option or the `dashboards-sync-all-registered-prebuilt-dashboards` feature flag.

ref https://linear.app/getsentry/issue/DAIN-1532/create-prebuilt-nodejs-health-dashboard