### PR TITLE
fix(pageFrame): render settings layout subtitle

### DIFF
--- a/static/app/views/settings/components/settingsPageHeader.tsx
+++ b/static/app/views/settings/components/settingsPageHeader.tsx
@@ -1,6 +1,8 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import {Flex} from '@sentry/scraps/layout';
+
 import * as Layout from 'sentry/components/layouts/thirds';
 import {useRoutes} from 'sentry/utils/useRoutes';
 import {TopBar} from 'sentry/views/navigation/topBar';
@@ -54,6 +56,11 @@ function UnstyledSettingsPageHeader({
           title && <Layout.Title>{title}</Layout.Title>
         )}
         {action && <TopBar.Slot name="actions">{action}</TopBar.Slot>}
+        {subtitle && (
+          <Flex marginBottom="xl">
+            <Subtitle>{subtitle}</Subtitle>
+          </Flex>
+        )}
         {body && <BodyWrapper>{body}</BodyWrapper>}
         {tabs && <TabsWrapper>{tabs}</TabsWrapper>}
       </Fragment>

--- a/static/gsApp/components/subscriptionSettingsLayout.tsx
+++ b/static/gsApp/components/subscriptionSettingsLayout.tsx
@@ -40,7 +40,7 @@ export default function SubscriptionSettingsLayout() {
   };
 
   return (
-    <Flex direction="column" flex={1} minWidth="0">
+    <SettingsColumn direction="column" flex={1} minWidth="0">
       {hasPageFrameFeature ? (
         <Fragment>
           <TopBar.Slot name="title">
@@ -64,9 +64,15 @@ export default function SubscriptionSettingsLayout() {
       <Flex minWidth={0} flex="1" direction="column">
         <Outlet />
       </Flex>
-    </Flex>
+    </SettingsColumn>
   );
 }
+
+const SettingsColumn = styled(Flex)`
+  footer {
+    margin-top: 0;
+  }
+`;
 
 const StyledSettingsBreadcrumb = styled(SettingsBreadcrumb)`
   flex: 1;

--- a/static/gsApp/components/subscriptionSettingsLayout.tsx
+++ b/static/gsApp/components/subscriptionSettingsLayout.tsx
@@ -1,3 +1,4 @@
+import {Fragment} from 'react';
 import {Outlet} from 'react-router-dom';
 import styled from '@emotion/styled';
 
@@ -39,34 +40,33 @@ export default function SubscriptionSettingsLayout() {
   };
 
   return (
-    <SettingsColumn direction="column" flex={1} minWidth="0">
-      <StyledSettingsHeader>
-        <Flex align="center" justify="between" gap="xl">
-          <StyledSettingsBreadcrumb params={params} routes={routes} />
-          <Flex align="center" gap="xl">
-            {hasPageFrameFeature ? (
-              <TopBar.Slot name="feedback">
-                <FeedbackButton feedbackOptions={feedbackOptions}>{null}</FeedbackButton>
-              </TopBar.Slot>
-            ) : (
-              <FeedbackButton feedbackOptions={feedbackOptions} />
-            )}
+    <Flex direction="column" flex={1} minWidth="0">
+      {hasPageFrameFeature ? (
+        <Fragment>
+          <TopBar.Slot name="title">
+            <StyledSettingsBreadcrumb params={params} routes={routes} />
+          </TopBar.Slot>
+          <TopBar.Slot name="actions">
             <SettingsSearch />
+          </TopBar.Slot>
+        </Fragment>
+      ) : (
+        <StyledSettingsHeader>
+          <Flex align="center" justify="between" gap="xl">
+            <StyledSettingsBreadcrumb params={params} routes={routes} />
+            <Flex align="center" gap="xl">
+              <FeedbackButton feedbackOptions={feedbackOptions} />
+              <SettingsSearch />
+            </Flex>
           </Flex>
-        </Flex>
-      </StyledSettingsHeader>
+        </StyledSettingsHeader>
+      )}
       <Flex minWidth={0} flex="1" direction="column">
         <Outlet />
       </Flex>
-    </SettingsColumn>
+    </Flex>
   );
 }
-
-const SettingsColumn = styled(Flex)`
-  footer {
-    margin-top: 0;
-  }
-`;
 
 const StyledSettingsBreadcrumb = styled(SettingsBreadcrumb)`
   flex: 1;

--- a/static/gsApp/views/subscriptionPage/components/subscriptionPageContainer.tsx
+++ b/static/gsApp/views/subscriptionPage/components/subscriptionPageContainer.tsx
@@ -21,7 +21,9 @@ export function SubscriptionPageContainer({
   return (
     <Container
       background={hasPageFrame ? 'primary' : background}
-      borderTop={background === 'secondary' ? 'primary' : undefined}
+      borderTop={
+        hasPageFrame ? undefined : background === 'secondary' ? 'primary' : undefined
+      }
       flexGrow={1}
       padding={hasPageFrame ? {sm: 'sm lg', md: 'md xl'} : {xs: 'xl', md: '3xl'}}
       {...rest}


### PR DESCRIPTION
additionally, I found another layout that wraps some settings pages where the breadcrumbs & search were not yet moved to the topBar. Looks good now:

<img width="1712" height="236" alt="Screenshot 2026-04-21 at 10 49 56" src="https://github.com/user-attachments/assets/e1fdee93-a9ff-440b-8b15-026bae58d0ff" />
