### PR TITLE
feat(trace-view): Support span-based TTID/TTFD and app start vitals

### DIFF
--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -124,6 +124,13 @@ function TraceViewImpl({traceSlug}: {traceSlug: string}) {
       'thread.id',
       'tags[performance.timeOrigin,number]',
       'gen_ai.operation.type',
+      // TODO: switch to clean names (e.g. 'app.vitals.ttid.value') once sentry-conventions
+      // registers these as public aliases in deprecated_attributes.json with backfill status.
+      // The `tags[...,number]` form is a temporary bridge for unregistered attributes.
+      'tags[app.vitals.ttid.value,number]',
+      'tags[app.vitals.ttfd.value,number]',
+      'tags[app.vitals.start.cold.value,number]',
+      'tags[app.vitals.start.warm.value,number]',
     ],
   });
   const tree = useTraceTree({traceSlug, trace, replay: null});

--- a/static/app/views/performance/newTraceDetails/traceContextVitals.tsx
+++ b/static/app/views/performance/newTraceDetails/traceContextVitals.tsx
@@ -58,7 +58,10 @@ export function TraceContextVitals({rootEventResults, tree, containerWidth}: Pro
 
   const collectedVitals =
     traceNode.isEAPEvent && tree.vital_types.has('mobile')
-      ? getMobileVitalsFromRootEventResults(rootEventResults.data)
+      ? mergeVitals(
+          getMobileVitalsFromRootEventResults(rootEventResults.data),
+          Array.from(tree.vitals.values()).flat()
+        )
       : Array.from(tree.vitals.values()).flat();
 
   const primaryVitalsCount = getPrimaryVitalsCount(
@@ -287,4 +290,14 @@ function defaultVitalValueFormatter(vital: Vital, value: number) {
   }
 
   return value.toFixed(2);
+}
+
+// Merges vitals from root event results with span-based vitals from the tree.
+// Root event vitals take priority; span-based vitals fill in keys not present.
+function mergeVitals(
+  rootEventVitals: TraceTree.CollectedVital[],
+  treeVitals: TraceTree.CollectedVital[]
+): TraceTree.CollectedVital[] {
+  const existingKeys = new Set(rootEventVitals.map(v => v.key));
+  return [...rootEventVitals, ...treeVitals.filter(v => !existingKeys.has(v.key))];
 }

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.measurements.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.measurements.tsx
@@ -189,3 +189,129 @@ function isStandaloneSpanMeasurementNode(node: BaseNode): boolean {
 
   return false;
 }
+
+// Configures which span ops carry which vital. `stableKey` is the new span
+// attribute name; `deprecatedKey` is the old key still used internally for
+// indicator type, vitals map key, and acronym lookup. A single op may map to
+// multiple configs (e.g. the generic `app.start` op can carry either the cold
+// or warm attribute).
+type SpanVitalConfig = {
+  deprecatedKey: string;
+  matchOps: readonly string[];
+  stableKey: string;
+  // When true, fall back to reading `deprecatedKey` from span attributes if
+  // `stableKey` is absent. Used for vitals where positioning doesn't matter
+  // (pills only) so either format on the span is acceptable.
+  readDeprecatedFromSpan?: boolean;
+};
+
+export const SPAN_VITAL_CONFIGS: readonly SpanVitalConfig[] = [
+  {
+    matchOps: ['ui.load.initial_display'],
+    stableKey: 'app.vitals.ttid.value',
+    deprecatedKey: 'time_to_initial_display',
+  },
+  {
+    matchOps: ['ui.load.full_display'],
+    stableKey: 'app.vitals.ttfd.value',
+    deprecatedKey: 'time_to_full_display',
+  },
+  {
+    matchOps: ['app.start', 'app.start.cold'],
+    stableKey: 'app.vitals.start.cold.value',
+    deprecatedKey: 'app_start_cold',
+    readDeprecatedFromSpan: true,
+  },
+  {
+    matchOps: ['app.start', 'app.start.warm'],
+    stableKey: 'app.vitals.start.warm.value',
+    deprecatedKey: 'app_start_warm',
+    readDeprecatedFromSpan: true,
+  },
+];
+
+export const SPAN_VITAL_OPS = new Set(SPAN_VITAL_CONFIGS.flatMap(c => c.matchOps));
+
+// Collects vitals from span data attributes for spans with specific ops.
+// New mobile SDKs send these as span attributes instead of transaction-level
+// measurements. TTID/TTFD produce indicator lines positioned at the span's end
+// timestamp; app start vitals are pills-only (no line).
+export function collectSpanBasedVitals(
+  tree: TraceTree,
+  node: BaseNode,
+  vitals: Map<BaseNode, TraceTree.CollectedVital[]>,
+  vital_types: Set<'web' | 'mobile'>
+): TraceTree.Indicator[] {
+  const op = node.op;
+  if (!op) {
+    return [];
+  }
+
+  const indicators: TraceTree.Indicator[] = [];
+
+  for (const config of SPAN_VITAL_CONFIGS) {
+    if (!config.matchOps.includes(op)) {
+      continue;
+    }
+
+    // Backend returns the attribute under the clean key if registered as a
+    // public alias, or under the bracketed `tags[<key>,number]` form when
+    // queried via the untyped-tag fallback.
+    // TODO: drop the `tags[...]` fallback once sentry-conventions registers
+    // these as public aliases and the request in index.tsx uses clean names.
+    let value =
+      node.attributes?.[config.stableKey] ??
+      node.attributes?.[`tags[${config.stableKey},number]`];
+    if ((typeof value !== 'number' || !value) && config.readDeprecatedFromSpan) {
+      value = node.attributes?.[config.deprecatedKey];
+    }
+    if (typeof value !== 'number' || !value) {
+      continue;
+    }
+
+    const measurement: Measurement = {value, unit: 'millisecond'};
+
+    if (!vitals.has(node)) {
+      vitals.set(node, []);
+    }
+    vital_types.add('mobile');
+    vitals.get(node)!.push({
+      key: config.deprecatedKey,
+      measurement,
+      score: undefined,
+    });
+
+    if (!RENDERABLE_MEASUREMENTS[config.deprecatedKey]) {
+      continue;
+    }
+
+    // Place the indicator at the span's end timestamp
+    const spanEndTimestamp = node.space[0] + node.space[1];
+
+    const existingIndicatorIndex = tree.indicators.findIndex(
+      indicator => indicator.type === config.deprecatedKey
+    );
+
+    const indicator: TraceTree.Indicator = {
+      start: spanEndTimestamp,
+      duration: 0,
+      measurement,
+      poor: MEASUREMENT_THRESHOLDS[config.deprecatedKey]
+        ? measurement.value > MEASUREMENT_THRESHOLDS[config.deprecatedKey]
+        : false,
+      type: config.deprecatedKey,
+      label: (
+        MEASUREMENT_ACRONYM_MAPPING[config.deprecatedKey] ?? config.deprecatedKey
+      ).toUpperCase(),
+      score: undefined,
+    };
+
+    if (existingIndicatorIndex === -1) {
+      indicators.push(indicator);
+    } else {
+      tree.indicators[existingIndicatorIndex] = indicator;
+    }
+  }
+
+  return indicators;
+}

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.spec.tsx
@@ -1024,6 +1024,330 @@ describe('TraceTree', () => {
       });
       expect(cyclicNodes).toHaveLength(1);
     });
+
+    it('collects span-based TTID vital from ui.load.initial_display span', () => {
+      const spanEnd = start + 1.2;
+      const tree = TraceTree.FromTrace(
+        makeEAPTrace([
+          makeEAPSpan({
+            event_id: 'root-txn',
+            start_timestamp: start,
+            end_timestamp: start + 2,
+            is_transaction: true,
+            children: [
+              makeEAPSpan({
+                event_id: 'ttid-span',
+                op: 'ui.load.initial_display',
+                start_timestamp: start + 0.5,
+                end_timestamp: spanEnd,
+                is_transaction: false,
+                additional_attributes: {
+                  'app.vitals.ttid.value': 800,
+                },
+                children: [],
+              }),
+            ],
+          }),
+        ]),
+        {meta: null, replay: null, organization}
+      );
+
+      const ttidIndicators = tree.indicators.filter(
+        i => i.type === 'time_to_initial_display'
+      );
+      expect(ttidIndicators).toHaveLength(1);
+      expect(ttidIndicators[0]!.start).toBe(spanEnd * 1e3);
+      expect(ttidIndicators[0]!.label).toBe('TTID');
+      expect(ttidIndicators[0]!.score).toBeUndefined();
+
+      expect(tree.vital_types.has('mobile')).toBe(true);
+
+      const ttidSpanNode = tree.root.findChild(n => n.id === 'ttid-span');
+      expect(tree.vitals.get(ttidSpanNode!)).toEqual([
+        expect.objectContaining({
+          key: 'time_to_initial_display',
+          measurement: {value: 800, unit: 'millisecond'},
+          score: undefined,
+        }),
+      ]);
+    });
+
+    it('collects span-based TTFD vital from ui.load.full_display span', () => {
+      const spanEnd = start + 1.5;
+      const tree = TraceTree.FromTrace(
+        makeEAPTrace([
+          makeEAPSpan({
+            event_id: 'root-txn',
+            start_timestamp: start,
+            end_timestamp: start + 2,
+            is_transaction: true,
+            children: [
+              makeEAPSpan({
+                event_id: 'ttfd-span',
+                op: 'ui.load.full_display',
+                start_timestamp: start + 0.5,
+                end_timestamp: spanEnd,
+                is_transaction: false,
+                additional_attributes: {
+                  'app.vitals.ttfd.value': 1200,
+                },
+                children: [],
+              }),
+            ],
+          }),
+        ]),
+        {meta: null, replay: null, organization}
+      );
+
+      const ttfdIndicators = tree.indicators.filter(
+        i => i.type === 'time_to_full_display'
+      );
+      expect(ttfdIndicators).toHaveLength(1);
+      expect(ttfdIndicators[0]!.start).toBe(spanEnd * 1e3);
+      expect(ttfdIndicators[0]!.label).toBe('TTFD');
+      expect(ttfdIndicators[0]!.score).toBeUndefined();
+    });
+
+    it('does not create indicator for span-based vital with missing attribute', () => {
+      const tree = TraceTree.FromTrace(
+        makeEAPTrace([
+          makeEAPSpan({
+            event_id: 'root-txn',
+            start_timestamp: start,
+            end_timestamp: start + 2,
+            is_transaction: true,
+            children: [
+              makeEAPSpan({
+                event_id: 'ttid-span-no-attr',
+                op: 'ui.load.initial_display',
+                start_timestamp: start + 0.5,
+                end_timestamp: start + 1.2,
+                is_transaction: false,
+                children: [],
+              }),
+            ],
+          }),
+        ]),
+        {meta: null, replay: null, organization}
+      );
+
+      const ttidIndicators = tree.indicators.filter(
+        i => i.type === 'time_to_initial_display'
+      );
+      expect(ttidIndicators).toHaveLength(0);
+    });
+
+    it('does not create indicator for span-based vital with zero value', () => {
+      const tree = TraceTree.FromTrace(
+        makeEAPTrace([
+          makeEAPSpan({
+            event_id: 'root-txn',
+            start_timestamp: start,
+            end_timestamp: start + 2,
+            is_transaction: true,
+            children: [
+              makeEAPSpan({
+                event_id: 'ttid-span-zero',
+                op: 'ui.load.initial_display',
+                start_timestamp: start + 0.5,
+                end_timestamp: start + 1.2,
+                is_transaction: false,
+                additional_attributes: {
+                  'app.vitals.ttid.value': 0,
+                },
+                children: [],
+              }),
+            ],
+          }),
+        ]),
+        {meta: null, replay: null, organization}
+      );
+
+      const ttidIndicators = tree.indicators.filter(
+        i => i.type === 'time_to_initial_display'
+      );
+      expect(ttidIndicators).toHaveLength(0);
+    });
+
+    it('collects app start cold vital from app.start.cold span (stable attribute)', () => {
+      const tree = TraceTree.FromTrace(
+        makeEAPTrace([
+          makeEAPSpan({
+            event_id: 'root-txn',
+            start_timestamp: start,
+            end_timestamp: start + 5,
+            is_transaction: true,
+            children: [
+              makeEAPSpan({
+                event_id: 'app-start-cold-span',
+                op: 'app.start.cold',
+                start_timestamp: start,
+                end_timestamp: start + 2,
+                is_transaction: false,
+                additional_attributes: {
+                  'app.vitals.start.cold.value': 1800,
+                },
+                children: [],
+              }),
+            ],
+          }),
+        ]),
+        {meta: null, replay: null, organization}
+      );
+
+      // App start is pills-only: no indicator line
+      expect(tree.indicators.filter(i => i.type === 'app_start_cold')).toHaveLength(0);
+
+      // But it should populate vitals and vital_types
+      expect(tree.vital_types.has('mobile')).toBe(true);
+      const spanNode = tree.root.findChild(n => n.id === 'app-start-cold-span');
+      expect(tree.vitals.get(spanNode!)).toEqual([
+        expect.objectContaining({
+          key: 'app_start_cold',
+          measurement: {value: 1800, unit: 'millisecond'},
+          score: undefined,
+        }),
+      ]);
+    });
+
+    it('collects app start warm vital from app.start.warm span', () => {
+      const tree = TraceTree.FromTrace(
+        makeEAPTrace([
+          makeEAPSpan({
+            event_id: 'root-txn',
+            start_timestamp: start,
+            end_timestamp: start + 5,
+            is_transaction: true,
+            children: [
+              makeEAPSpan({
+                event_id: 'app-start-warm-span',
+                op: 'app.start.warm',
+                start_timestamp: start,
+                end_timestamp: start + 1,
+                is_transaction: false,
+                additional_attributes: {
+                  'app.vitals.start.warm.value': 900,
+                },
+                children: [],
+              }),
+            ],
+          }),
+        ]),
+        {meta: null, replay: null, organization}
+      );
+
+      const spanNode = tree.root.findChild(n => n.id === 'app-start-warm-span');
+      expect(tree.vitals.get(spanNode!)).toEqual([
+        expect.objectContaining({
+          key: 'app_start_warm',
+          measurement: {value: 900, unit: 'millisecond'},
+        }),
+      ]);
+    });
+
+    it('collects app start cold vital from generic app.start span via attribute', () => {
+      const tree = TraceTree.FromTrace(
+        makeEAPTrace([
+          makeEAPSpan({
+            event_id: 'root-txn',
+            start_timestamp: start,
+            end_timestamp: start + 5,
+            is_transaction: true,
+            children: [
+              makeEAPSpan({
+                event_id: 'app-start-span',
+                op: 'app.start',
+                start_timestamp: start,
+                end_timestamp: start + 2,
+                is_transaction: false,
+                additional_attributes: {
+                  'app.vitals.start.cold.value': 2100,
+                },
+                children: [],
+              }),
+            ],
+          }),
+        ]),
+        {meta: null, replay: null, organization}
+      );
+
+      const spanNode = tree.root.findChild(n => n.id === 'app-start-span');
+      // Should only have cold (because only cold attribute was set)
+      expect(tree.vitals.get(spanNode!)).toEqual([
+        expect.objectContaining({
+          key: 'app_start_cold',
+          measurement: {value: 2100, unit: 'millisecond'},
+        }),
+      ]);
+    });
+
+    it('falls back to deprecated attribute on app.start span when stable is absent', () => {
+      const tree = TraceTree.FromTrace(
+        makeEAPTrace([
+          makeEAPSpan({
+            event_id: 'root-txn',
+            start_timestamp: start,
+            end_timestamp: start + 5,
+            is_transaction: true,
+            children: [
+              makeEAPSpan({
+                event_id: 'app-start-old-span',
+                op: 'app.start.cold',
+                start_timestamp: start,
+                end_timestamp: start + 2,
+                is_transaction: false,
+                additional_attributes: {
+                  app_start_cold: 1500,
+                },
+                children: [],
+              }),
+            ],
+          }),
+        ]),
+        {meta: null, replay: null, organization}
+      );
+
+      const spanNode = tree.root.findChild(n => n.id === 'app-start-old-span');
+      expect(tree.vitals.get(spanNode!)).toEqual([
+        expect.objectContaining({
+          key: 'app_start_cold',
+          measurement: {value: 1500, unit: 'millisecond'},
+        }),
+      ]);
+    });
+
+    it('does not fall back to deprecated attribute on ui.load.initial_display span', () => {
+      // TTID positioning is only valid with the stable attribute, so the
+      // deprecated attribute on the span should NOT trigger collection.
+      const tree = TraceTree.FromTrace(
+        makeEAPTrace([
+          makeEAPSpan({
+            event_id: 'root-txn',
+            start_timestamp: start,
+            end_timestamp: start + 5,
+            is_transaction: true,
+            children: [
+              makeEAPSpan({
+                event_id: 'ttid-old-span',
+                op: 'ui.load.initial_display',
+                start_timestamp: start,
+                end_timestamp: start + 1,
+                is_transaction: false,
+                additional_attributes: {
+                  time_to_initial_display: 800,
+                },
+                children: [],
+              }),
+            ],
+          }),
+        ]),
+        {meta: null, replay: null, organization}
+      );
+
+      expect(
+        tree.indicators.filter(i => i.type === 'time_to_initial_display')
+      ).toHaveLength(0);
+    });
   });
 
   describe('events', () => {

--- a/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
+++ b/static/app/views/performance/newTraceDetails/traceModels/traceTree.tsx
@@ -27,8 +27,10 @@ import {
   isUptimeCheck,
 } from 'sentry/views/performance/newTraceDetails/traceGuards';
 import {
+  collectSpanBasedVitals,
   collectTraceMeasurements,
   type RENDERABLE_MEASUREMENTS,
+  SPAN_VITAL_OPS,
 } from 'sentry/views/performance/newTraceDetails/traceModels/traceTree.measurements';
 import type {TracePreferencesState} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
 import type {ReplayTrace} from 'sentry/views/replays/detail/trace/useReplayTraces';
@@ -542,6 +544,12 @@ export class TraceTree extends TraceTreeEventDispatcher {
         );
       }
 
+      if (c.op && SPAN_VITAL_OPS.has(c.op)) {
+        tree.indicators = tree.indicators.concat(
+          collectSpanBasedVitals(tree, c, tree.vitals, tree.vital_types)
+        );
+      }
+
       if (
         c.parent &&
         c.op === 'pageload' &&
@@ -694,6 +702,12 @@ export class TraceTree extends TraceTreeEventDispatcher {
             this.vitals,
             this.vital_types
           )
+        );
+      }
+
+      if (node.op && SPAN_VITAL_OPS.has(node.op)) {
+        tree.indicators = tree.indicators.concat(
+          collectSpanBasedVitals(tree, node, this.vitals, this.vital_types)
         );
       }
     }


### PR DESCRIPTION
Newer mobile SDKs emit timing information as span attributes on dedicated spans instead of transaction-level measurements:

- `ui.load.initial_display` spans carry `app.vitals.ttid.value`
- `ui.load.full_display` spans carry `app.vitals.ttfd.value`
- `app.start` / `app.start.cold` / `app.start.warm` spans carry `app.vitals.start.cold.value` or `app.vitals.start.warm.value`

The trace view now collects these during tree construction and merges them with the existing measurement-based vitals. TTID/TTFD produce vertical indicator lines positioned at the **span's end timestamp** (only when the new attribute is present — preserves old measurement-based positioning otherwise). App start contributes pills only. Older SDKs continue to flow through the existing `collectTraceMeasurements` path unchanged.