### PR TITLE
ref(pageFrame): move texts into subTitle of SettingsPageHeader

### DIFF
--- a/static/app/components/events/highlights/highlightsSettingsForm.tsx
+++ b/static/app/components/events/highlights/highlightsSettingsForm.tsx
@@ -16,7 +16,6 @@ import {
 } from 'sentry/utils/project/useDetailedProject';
 import {useQueryClient} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
 
 interface HighlightsSettingsFormProps {
   projectSlug: any;
@@ -57,11 +56,6 @@ export function HighlightsSettingsForm({projectSlug}: HighlightsSettingsFormProp
   };
   return (
     <Form {...formProps}>
-      <TextBlock>
-        {t(
-          'Setup Highlights to promote your event data to the top of the issue page for quicker debugging.'
-        )}
-      </TextBlock>
       <JsonForm
         access={access}
         disabled={!hasEveryAccess(['project:write'], {organization, project})}

--- a/static/app/views/settings/account/accountAuthorizations.tsx
+++ b/static/app/views/settings/account/accountAuthorizations.tsx
@@ -67,12 +67,15 @@ function AccountAuthorizations() {
   const isEmpty = data.length === 0;
   return (
     <SentryDocumentTitle title={t('Approved Applications')}>
-      <SettingsPageHeader title="Authorized Applications" />
-      <Description>
-        {tct('You can manage your own applications via the [link:API dashboard].', {
-          link: <Link to="/settings/account/api/" />,
-        })}
-      </Description>
+      <SettingsPageHeader
+        title="Authorized Applications"
+        subtitle={tct(
+          'You can manage your own applications via the [link:API dashboard].',
+          {
+            link: <Link to="/settings/account/api/" />,
+          }
+        )}
+      />
 
       <Panel>
         <PanelHeader>{t('Approved Applications')}</PanelHeader>
@@ -123,11 +126,6 @@ function AccountAuthorizations() {
 }
 
 export default AccountAuthorizations;
-
-const Description = styled('p')`
-  font-size: ${p => p.theme.font.size.sm};
-  margin-bottom: ${p => p.theme.space['3xl']};
-`;
 
 const PanelItemCenter = styled(PanelItem)`
   align-items: center;

--- a/static/app/views/settings/account/accountClose.tsx
+++ b/static/app/views/settings/account/accountClose.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useRef, useState} from 'react';
+import {Fragment, useEffect, useRef, useState} from 'react';
 
 import {LinkButton} from '@sentry/scraps/button';
 import {Flex, Grid} from '@sentry/scraps/layout';
@@ -141,14 +141,19 @@ function AccountClose() {
   return (
     <div>
       <SentryDocumentTitle title={t('Close Account')} />
-      <SettingsPageHeader title={t('Close Account')} />
-
-      <TextBlock>
-        {t(
-          'This will permanently remove all associated data for your user. Any specified organizations will also be deleted. '
-        )}
-        <strong>{t('Closing your account is permanent and cannot be undone')}!</strong>
-      </TextBlock>
+      <SettingsPageHeader
+        title={t('Close Account')}
+        subtitle={
+          <Fragment>
+            {t(
+              'This will permanently remove all associated data for your user. Any specified organizations will also be deleted. '
+            )}
+            <strong>
+              {t('Closing your account is permanent and cannot be undone')}!
+            </strong>
+          </Fragment>
+        }
+      />
 
       <Panel>
         <PanelHeader>{t('Delete the following organizations')}</PanelHeader>

--- a/static/app/views/settings/account/accountSubscriptions.tsx
+++ b/static/app/views/settings/account/accountSubscriptions.tsx
@@ -4,7 +4,7 @@ import moment from 'moment-timezone';
 import {z} from 'zod';
 
 import {AutoSaveForm, FieldGroup, FormSearch} from '@sentry/scraps/form';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
@@ -74,20 +74,25 @@ function AccountSubscriptions() {
   return (
     <div>
       <SentryDocumentTitle title={subscriptionText} />
-      <SettingsPageHeader title={subscriptionText} />
-
-      <TextBlock>
-        {t(`Sentry is committed to respecting your inbox. Our goal is to
+      <SettingsPageHeader
+        title={subscriptionText}
+        subtitle={
+          <Stack gap="md">
+            <div>
+              {t(`Sentry is committed to respecting your inbox. Our goal is to
               provide useful content and resources that make fixing errors less
               painful. Enjoyable even.`)}
-      </TextBlock>
+            </div>
 
-      <TextBlock>
-        {t(`As part of our compliance with the EU's General Data Protection
+            <div>
+              {t(`As part of our compliance with the EU's General Data Protection
               Regulation (GDPR), starting on 25 May 2018, we'll only email you
               according to the marketing categories to which you've explicitly
               opted-in.`)}
-      </TextBlock>
+            </div>
+          </Stack>
+        }
+      />
 
       {subscriptions.length ? (
         <FormSearch route="/settings/account/subscriptions/">

--- a/static/app/views/settings/account/apiNewToken.tsx
+++ b/static/app/views/settings/account/apiNewToken.tsx
@@ -3,7 +3,7 @@ import {z} from 'zod';
 
 import {Button} from '@sentry/scraps/button';
 import {defaultFormOptions, useScrapsForm} from '@sentry/scraps/form';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
 import {
@@ -31,7 +31,6 @@ import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {displayNewToken} from 'sentry/views/settings/components/newTokenHandler';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
-import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
 import {
   PermissionSelection,
   permissionStateToList,
@@ -121,20 +120,26 @@ export default function ApiNewToken() {
   return (
     <SentryDocumentTitle title={t('Create New Personal Token')}>
       <div>
-        <SettingsPageHeader title={t('Create New Personal Token')} />
-        <TextBlock>
-          {t(
-            "Personal tokens allow you to perform actions against the Sentry API on behalf of your account. They're the easiest way to get started using the API."
-          )}
-        </TextBlock>
-        <TextBlock>
-          {tct(
-            'For more information on how to use the web API, see our [link:documentation].',
-            {
-              link: <ExternalLink href="https://docs.sentry.io/api/" />,
-            }
-          )}
-        </TextBlock>
+        <SettingsPageHeader
+          title={t('Create New Personal Token')}
+          subtitle={
+            <Stack gap="md">
+              <div>
+                {t(
+                  "Personal tokens allow you to perform actions against the Sentry API on behalf of your account. They're the easiest way to get started using the API."
+                )}
+              </div>
+              <div>
+                {tct(
+                  'For more information on how to use the web API, see our [link:documentation].',
+                  {
+                    link: <ExternalLink href="https://docs.sentry.io/api/" />,
+                  }
+                )}
+              </div>
+            </Stack>
+          }
+        />
         <form.AppForm form={form}>
           <form.FieldGroup title={t('General')}>
             <form.AppField name="name">

--- a/static/app/views/settings/account/apiTokens.tsx
+++ b/static/app/views/settings/account/apiTokens.tsx
@@ -1,4 +1,5 @@
 import {LinkButton} from '@sentry/scraps/button';
+import {Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
 import {
@@ -24,7 +25,6 @@ import {
 import {useApi} from 'sentry/utils/useApi';
 import {ApiTokenRow} from 'sentry/views/settings/account/apiTokenRow';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
-import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
 
 const PAGE_TITLE = t('Personal Tokens');
 const API_TOKEN_QUERY_KEY = [getApiUrl('/api-tokens/')] as const;
@@ -110,20 +110,27 @@ function ApiTokens() {
 
   return (
     <SentryDocumentTitle title={PAGE_TITLE}>
-      <SettingsPageHeader title={PAGE_TITLE} action={action} />
-      <TextBlock>
-        {t(
-          "Personal tokens allow you to perform actions against the Sentry API on behalf of your account. They're the easiest way to get started using the API."
-        )}
-      </TextBlock>
-      <TextBlock>
-        {tct(
-          'For more information on how to use the web API, see our [link:documentation].',
-          {
-            link: <ExternalLink href="https://docs.sentry.io/api/" />,
-          }
-        )}
-      </TextBlock>
+      <SettingsPageHeader
+        title={PAGE_TITLE}
+        action={action}
+        subtitle={
+          <Stack gap="md">
+            <div>
+              {t(
+                "Personal tokens allow you to perform actions against the Sentry API on behalf of your account. They're the easiest way to get started using the API."
+              )}
+            </div>
+            <div>
+              {tct(
+                'For more information on how to use the web API, see our [link:documentation].',
+                {
+                  link: <ExternalLink href="https://docs.sentry.io/api/" />,
+                }
+              )}
+            </div>
+          </Stack>
+        }
+      />
       <PanelTable
         headers={[t('Token'), t('Created On'), t('Scopes'), '']}
         isEmpty={isEmpty}

--- a/static/app/views/settings/account/notifications/notificationSettings.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettings.tsx
@@ -27,7 +27,6 @@ import {
 } from 'sentry/views/settings/account/notifications/constants';
 import {NOTIFICATION_SETTING_FIELDS} from 'sentry/views/settings/account/notifications/fields';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
-import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
 
 const NOTIFICATIONS_ENDPOINT = getApiUrl('/users/$userId/notifications/', {
   path: {userId: 'me'},
@@ -116,16 +115,16 @@ function NotificationSettings({organizations}: NotificationSettingsProps) {
   return (
     <Fragment>
       <SentryDocumentTitle title={t('Notifications')} />
-      <SettingsPageHeader title={t('Notifications')} />
+      <SettingsPageHeader
+        title={t('Notifications')}
+        subtitle={tct(
+          'Personal notifications sent by email or an integration. Looking to add or remove an email address? [link:Update your email settings.]',
+          {
+            link: <Link to="/settings/account/emails" />,
+          }
+        )}
+      />
       <FormSearch route="/settings/account/notifications/">
-        <TextBlock>
-          {tct(
-            'Personal notifications sent by email or an integration. Looking to add or remove an email address? [link:Update your email settings.]',
-            {
-              link: <Link to="/settings/account/emails" />,
-            }
-          )}
-        </TextBlock>
         {isError && <LoadingError onRetry={refetch} />}
         <Panel>
           <PanelHeader>{t('Notification')}</PanelHeader>

--- a/static/app/views/settings/featureFlags/changeTracking/index.tsx
+++ b/static/app/views/settings/featureFlags/changeTracking/index.tsx
@@ -155,9 +155,9 @@ function OrganizationFeatureFlagsChangeTracking() {
   return (
     <Fragment>
       <SentryDocumentTitle title={t('Change Tracking')} orgSlug={organization.slug} />
-      <SettingsPageHeader title={t('Change Tracking')} />
-      <TextBlock>
-        {tct(
+      <SettingsPageHeader
+        title={t('Change Tracking')}
+        subtitle={tct(
           'Integrating Sentry with your feature flag provider enables Sentry to correlate feature flag changes with new error events and mark certain changes as suspicious. Learn more about how to interact with feature flag insights within the Sentry UI by reading the [link:documentation].',
           {
             link: (
@@ -165,7 +165,7 @@ function OrganizationFeatureFlagsChangeTracking() {
             ),
           }
         )}
-      </TextBlock>
+      />
 
       <Flex justify="between">
         <h5>{t('Providers')}</h5>

--- a/static/app/views/settings/featureFlags/changeTracking/organizationFeatureFlagsNewSecret.tsx
+++ b/static/app/views/settings/featureFlags/changeTracking/organizationFeatureFlagsNewSecret.tsx
@@ -17,7 +17,6 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
-import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
 import {
   makeFetchSecretQueryKey,
   type Secret,
@@ -65,10 +64,9 @@ function OrganizationFeatureFlagsNewSecret() {
   return (
     <Fragment>
       <SentryDocumentTitle title={t('Add New Provider')} />
-      <SettingsPageHeader title={t('Add New Provider')} />
-
-      <TextBlock>
-        {tct(
+      <SettingsPageHeader
+        title={t('Add New Provider')}
+        subtitle={tct(
           'Integrating Sentry with your feature flag provider enables Sentry to correlate feature flag changes with new error events and mark certain changes as suspicious. Learn more about how to interact with feature flag insights within the Sentry UI by reading the [link:documentation].',
           {
             link: (
@@ -76,7 +74,7 @@ function OrganizationFeatureFlagsNewSecret() {
             ),
           }
         )}
-      </TextBlock>
+      />
       <Alert.Container>
         <Alert variant="info">
           {t('Note that each provider can only have one associated signing secret.')}

--- a/static/app/views/settings/featureFlags/index.tsx
+++ b/static/app/views/settings/featureFlags/index.tsx
@@ -14,7 +14,6 @@ import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
-import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
 
 function OrganizationFeatureFlagsIndex() {
   const organization = useOrganization();
@@ -23,9 +22,9 @@ function OrganizationFeatureFlagsIndex() {
   return (
     <Fragment>
       <SentryDocumentTitle title={t('Feature Flags')} orgSlug={organization.slug} />
-      <SettingsPageHeader title={t('Feature Flags')} />
-      <TextBlock>
-        {tct(
+      <SettingsPageHeader
+        title={t('Feature Flags')}
+        subtitle={tct(
           'Integrating Sentry with your feature flag provider enables Sentry to correlate feature flag changes with new error events and mark certain changes as suspicious. To learn more about our feature flag features, [link:read our docs].',
           {
             link: (
@@ -33,7 +32,7 @@ function OrganizationFeatureFlagsIndex() {
             ),
           }
         )}
-      </TextBlock>
+      />
 
       <Panel>
         <PanelHeader>{t('Features')}</PanelHeader>

--- a/static/app/views/settings/organizationAuthTokens/index.tsx
+++ b/static/app/views/settings/organizationAuthTokens/index.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
 
 import {LinkButton} from '@sentry/scraps/button';
+import {Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
@@ -27,7 +28,6 @@ import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {useApi} from 'sentry/utils/useApi';
 import {withOrganization} from 'sentry/utils/withOrganization';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
-import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
 import {OrganizationAuthTokensAuthTokenRow} from 'sentry/views/settings/organizationAuthTokens/authTokenRow';
 
 type FetchOrgAuthTokensResponse = OrgAuthToken[];
@@ -171,21 +171,27 @@ export function OrganizationAuthTokensIndex({
             title={t('Organization Tokens')}
             orgSlug={organization.slug}
           />
-          <SettingsPageHeader title={t('Organization Tokens')} action={createNewToken} />
-
-          <TextBlock>
-            {t(
-              'Organization Tokens can be used in many places to interact with Sentry programatically. For example, they can be used for sentry-cli, bundler plugins or similar uses cases.'
-            )}
-          </TextBlock>
-          <TextBlock>
-            {tct(
-              'For more information on how to use the web API, see our [link:documentation].',
-              {
-                link: <ExternalLink href="https://docs.sentry.io/api/" />,
-              }
-            )}
-          </TextBlock>
+          <SettingsPageHeader
+            title={t('Organization Tokens')}
+            action={createNewToken}
+            subtitle={
+              <Stack gap="md">
+                <div>
+                  {t(
+                    'Organization tokens can be used in many places to interact with Sentry programmatically. For example, they can be used for sentry-cli, bundler plugins or similar uses cases.'
+                  )}
+                </div>
+                <div>
+                  {tct(
+                    'For more information on how to use the web API, see our [link:documentation].',
+                    {
+                      link: <ExternalLink href="https://docs.sentry.io/api/" />,
+                    }
+                  )}
+                </div>
+              </Stack>
+            }
+          />
 
           <ResponsivePanelTable
             isLoading={isPending || isError}

--- a/static/app/views/settings/organizationAuthTokens/newAuthToken.tsx
+++ b/static/app/views/settings/organizationAuthTokens/newAuthToken.tsx
@@ -3,7 +3,7 @@ import {z} from 'zod';
 
 import {Button} from '@sentry/scraps/button';
 import {defaultFormOptions, useScrapsForm} from '@sentry/scraps/form';
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
 import {
@@ -23,7 +23,6 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {displayNewToken} from 'sentry/views/settings/components/newTokenHandler';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
-import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
 import {makeFetchOrgAuthTokensForOrgQueryKey} from 'sentry/views/settings/organizationAuthTokens';
 
 type OrgAuthTokenWithToken = OrgAuthToken & {token: string};
@@ -133,21 +132,27 @@ export default function OrganizationAuthTokensNewAuthToken() {
   return (
     <div>
       <SentryDocumentTitle title={t('Create New Organization Token')} />
-      <SettingsPageHeader title={t('Create New Organization Token')} />
+      <SettingsPageHeader
+        title={t('Create New Organization Token')}
+        subtitle={
+          <Stack gap="md">
+            <div>
+              {t(
+                'Organization tokens can be used in many places to interact with Sentry programmatically. For example, they can be used for sentry-cli, bundler plugins or similar uses cases.'
+              )}
+            </div>
+            <div>
+              {tct(
+                'For more information on how to use the web API, see our [link:documentation].',
+                {
+                  link: <ExternalLink href="https://docs.sentry.io/api/" />,
+                }
+              )}
+            </div>
+          </Stack>
+        }
+      />
 
-      <TextBlock>
-        {t(
-          'Organization tokens can be used in many places to interact with Sentry programmatically. For example, they can be used for sentry-cli, bundler plugins or similar uses cases.'
-        )}
-      </TextBlock>
-      <TextBlock>
-        {tct(
-          'For more information on how to use the web API, see our [link:documentation].',
-          {
-            link: <ExternalLink href="https://docs.sentry.io/api/" />,
-          }
-        )}
-      </TextBlock>
       <AuthTokenCreateForm
         organization={organization}
         onCreatedToken={token => displayNewToken(token.token, handleGoBack)}

--- a/static/app/views/settings/organizationDataForwarding/index.tsx
+++ b/static/app/views/settings/organizationDataForwarding/index.tsx
@@ -3,7 +3,6 @@ import {Fragment} from 'react';
 import {LinkButton} from '@sentry/scraps/button';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
-import {Heading, Text} from '@sentry/scraps/text';
 
 import {Access} from 'sentry/components/acl/access';
 import Feature from 'sentry/components/acl/feature';
@@ -15,6 +14,7 @@ import {IconAdd} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 import {DataForwarderOnboarding} from 'sentry/views/settings/organizationDataForwarding/components/dataForwarderOnboarding';
 import {DataForwarderRow} from 'sentry/views/settings/organizationDataForwarding/components/dataForwarderRow';
 import {getCreateTooltip} from 'sentry/views/settings/organizationDataForwarding/util/forms';
@@ -100,9 +100,9 @@ export default function OrganizationDataForwarding() {
       <Flex direction="column" gap="lg">
         <Flex align="center" justify="between" gap="2xl">
           <Flex direction="column" gap="sm">
-            <Heading as="h1">{t('Data Forwarding')}</Heading>
-            <Text variant="muted">
-              {tct(
+            <SettingsPageHeader
+              title={t('Data Forwarding')}
+              subtitle={tct(
                 'Pipe your Sentry error events into other business intelligence tools. Learn more about this feature in our [link:docs].',
                 {
                   link: (
@@ -117,7 +117,7 @@ export default function OrganizationDataForwarding() {
                   ),
                 }
               )}
-            </Text>
+            />
           </Flex>
         </Flex>
         {isLoading ? (

--- a/static/app/views/settings/organizationDeveloperSettings/index.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/index.tsx
@@ -156,7 +156,7 @@ function OrganizationDeveloperSettings() {
       <SentryDocumentTitle title={t('Custom Integrations')} orgSlug={organization.slug} />
       <SettingsPageHeader
         title={t('Custom Integrations')}
-        body={
+        subtitle={
           <Fragment>
             {t(
               'Create integrations that interact with Sentry using the REST API and webhooks. '

--- a/static/app/views/settings/organizationMcpCli/index.tsx
+++ b/static/app/views/settings/organizationMcpCli/index.tsx
@@ -9,7 +9,6 @@ import {TextCopyInput} from 'sentry/components/textCopyInput';
 import {t} from 'sentry/locale';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
-import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
 
 export default function OrganizationMcpCli() {
   const organization = useOrganization();
@@ -17,10 +16,12 @@ export default function OrganizationMcpCli() {
   return (
     <Fragment>
       <SentryDocumentTitle title={t('MCP & CLI')} orgSlug={organization.slug} />
-      <SettingsPageHeader title={t('MCP & CLI')} />
-      <TextBlock>
-        {t('Connect to Sentry from AI-powered development tools and your terminal.')}
-      </TextBlock>
+      <SettingsPageHeader
+        title={t('MCP & CLI')}
+        subtitle={t(
+          'Connect to Sentry from AI-powered development tools and your terminal.'
+        )}
+      />
 
       <Flex direction="column" gap="xl">
         <Container padding="xl" border="primary" radius="md">

--- a/static/app/views/settings/organizationRelay/relayWrapper.tsx
+++ b/static/app/views/settings/organizationRelay/relayWrapper.tsx
@@ -21,7 +21,6 @@ import {fetchMutation, useApiQuery} from 'sentry/utils/queryClient';
 import {useApi} from 'sentry/utils/useApi';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
-import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
 import {OrganizationPermissionAlert} from 'sentry/views/settings/organization/organizationPermissionAlert';
 
 import {Add} from './modals/add';
@@ -61,6 +60,10 @@ export function RelayWrapper() {
     <SentryDocumentTitle title={t('Relay')} orgSlug={organization.slug}>
       <SettingsPageHeader
         title={t('Relay')}
+        subtitle={tct(
+          'Sentry Relay offers enterprise-grade data security by providing a standalone service that acts as a middle layer between your application and sentry.io. Go to [link:Relay Documentation] for setup and details.',
+          {link: <ExternalLink href={RELAY_DOCS_LINK} />}
+        )}
         action={
           <Button
             tooltipProps={{
@@ -125,12 +128,6 @@ export function RelayWrapper() {
           </AutoSaveForm>
         </FieldGroup>
       )}
-      <TextBlock>
-        {tct(
-          'Sentry Relay offers enterprise-grade data security by providing a standalone service that acts as a middle layer between your application and sentry.io. Go to [link:Relay Documentation] for setup and details.',
-          {link: <ExternalLink href={RELAY_DOCS_LINK} />}
-        )}
-      </TextBlock>
       {relays.length === 0 ? (
         <EmptyState />
       ) : (

--- a/static/app/views/settings/project/loaderScript.tsx
+++ b/static/app/views/settings/project/loaderScript.tsx
@@ -17,7 +17,6 @@ import type {Project, ProjectKey} from 'sentry/types/project';
 import {projectKeysApiOptions} from 'sentry/utils/projectKeys';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
-import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
 import {LoaderSettings} from 'sentry/views/settings/project/projectKeys/details/loaderSettings';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 
@@ -54,10 +53,9 @@ export default function ProjectLoaderScript() {
 
   return (
     <Fragment>
-      <SettingsPageHeader title={t('Loader Script')} />
-
-      <TextBlock>
-        {tct(
+      <SettingsPageHeader
+        title={t('Loader Script')}
+        subtitle={tct(
           'The Loader Script is the easiest way to initialize the Sentry SDK. The Loader Script automatically keeps your Sentry SDK up to date and offers configuration for different Sentry features. [docsLink:Learn more about the Loader Script]. Note: The Loader Script is bound to a Client Key (DSN), to create a new Script, go to the [clientKeysLink:Client Keys page].',
           {
             docsLink: (
@@ -70,7 +68,7 @@ export default function ProjectLoaderScript() {
             ),
           }
         )}
-      </TextBlock>
+      />
 
       {isPending && <LoadingIndicator />}
       {!!error && (

--- a/static/app/views/settings/project/projectFilters/index.tsx
+++ b/static/app/views/settings/project/projectFilters/index.tsx
@@ -9,7 +9,6 @@ import {recreateRoute} from 'sentry/utils/recreateRoute';
 import {useParams} from 'sentry/utils/useParams';
 import {useRoutes} from 'sentry/utils/useRoutes';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
-import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
 import {GroupTombstones} from 'sentry/views/settings/project/projectFilters/groupTombstones';
 import {ProjectFiltersChart} from 'sentry/views/settings/project/projectFilters/projectFiltersChart';
 import {ProjectFiltersSettings} from 'sentry/views/settings/project/projectFilters/projectFiltersSettings';
@@ -31,12 +30,12 @@ export default function ProjectFilters() {
   return (
     <Fragment>
       <SentryDocumentTitle title={t('Inbound Filters')} projectSlug={projectId} />
-      <SettingsPageHeader title={t('Inbound Data Filters')} />
-      <TextBlock>
-        {t(
+      <SettingsPageHeader
+        title={t('Inbound Data Filters')}
+        subtitle={t(
           'Filters allow you to prevent Sentry from storing events in certain situations. Filtered events are tracked separately from rate limits, and do not apply to any project quotas.'
         )}
-      </TextBlock>
+      />
 
       <ProjectPermissionAlert project={project} />
 

--- a/static/app/views/settings/project/projectKeys/list/index.tsx
+++ b/static/app/views/settings/project/projectKeys/list/index.tsx
@@ -29,7 +29,6 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useRoutes} from 'sentry/utils/useRoutes';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
-import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
 import {ProjectPermissionAlert} from 'sentry/views/settings/project/projectPermissionAlert';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 
@@ -191,6 +190,18 @@ export default function ProjectKeys() {
       <SentryDocumentTitle title={t('Client Keys')} projectSlug={project.slug} />
       <SettingsPageHeader
         title={t('Client Keys')}
+        subtitle={tct(
+          `To send data to Sentry you will need to configure an SDK with a client key
+          (usually referred to as the [code:SENTRY_DSN] value). For more
+          information on integrating Sentry with your application take a look at our
+          [link:documentation].`,
+          {
+            link: (
+              <ExternalLink href="https://docs.sentry.io/platform-redirect/?next=/configuration/options/" />
+            ),
+            code: <code />,
+          }
+        )}
         action={
           <Button
             onClick={() => handleCreateKeyMutation.mutate()}
@@ -203,21 +214,6 @@ export default function ProjectKeys() {
           </Button>
         }
       />
-
-      <TextBlock>
-        {tct(
-          `To send data to Sentry you will need to configure an SDK with a client key
-          (usually referred to as the [code:SENTRY_DSN] value). For more
-          information on integrating Sentry with your application take a look at our
-          [link:documentation].`,
-          {
-            link: (
-              <ExternalLink href="https://docs.sentry.io/platform-redirect/?next=/configuration/options/" />
-            ),
-            code: <code />,
-          }
-        )}
-      </TextBlock>
 
       <ProjectPermissionAlert project={project} />
 

--- a/static/app/views/settings/project/projectOwnership/index.tsx
+++ b/static/app/views/settings/project/projectOwnership/index.tsx
@@ -27,7 +27,6 @@ import {
 import {routeTitleGen} from 'sentry/utils/routeTitle';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
-import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
 import {AddCodeOwnerModal} from 'sentry/views/settings/project/projectOwnership/addCodeOwnerModal';
 import {CodeOwnerErrors} from 'sentry/views/settings/project/projectOwnership/codeownerErrors';
 import {CodeOwnerFileTable} from 'sentry/views/settings/project/projectOwnership/codeOwnerFileTable';
@@ -141,6 +140,14 @@ export default function ProjectOwnership() {
       <SentryDocumentTitle title={routeTitleGen(ownershipTitle, project.slug, false)}>
         <SettingsPageHeader
           title={t('Ownership Rules')}
+          subtitle={tct(
+            'Auto-assign issues to users and teams. To learn more, [link:read the docs].',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/product/error-monitoring/issue-owners/" />
+              ),
+            }
+          )}
           action={
             <Grid flow="column" align="center" gap="md">
               {hasCodeowners && (
@@ -178,16 +185,6 @@ export default function ProjectOwnership() {
             </Grid>
           }
         />
-        <TextBlock>
-          {tct(
-            'Auto-assign issues to users and teams. To learn more, [link:read the docs].',
-            {
-              link: (
-                <ExternalLink href="https://docs.sentry.io/product/error-monitoring/issue-owners/" />
-              ),
-            }
-          )}
-        </TextBlock>
         <ProjectPermissionAlert
           access={editOwnershipRulesDisabled ? ['project:write'] : ['project:read']}
           project={project}

--- a/static/app/views/settings/project/projectReleaseTracking.tsx
+++ b/static/app/views/settings/project/projectReleaseTracking.tsx
@@ -27,7 +27,6 @@ import {
 import {useApi} from 'sentry/utils/useApi';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
-import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 
 type TokenResponse = {
@@ -136,12 +135,12 @@ export default function ProjectReleaseTracking() {
   return (
     <div>
       <SentryDocumentTitle title={t('Releases')} projectSlug={project.slug} />
-      <SettingsPageHeader title={t('Release Tracking')} />
-      <TextBlock>
-        {t(
+      <SettingsPageHeader
+        title={t('Release Tracking')}
+        subtitle={t(
           'Configure release tracking for this project to automatically record new releases of your application.'
         )}
-      </TextBlock>
+      />
 
       {!hasWrite && (
         <Alert.Container>

--- a/static/app/views/settings/project/projectTeams.tsx
+++ b/static/app/views/settings/project/projectTeams.tsx
@@ -1,5 +1,7 @@
 import {useQuery} from '@tanstack/react-query';
 
+import {Stack} from '@sentry/scraps/layout';
+
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {
   projectTeamsApiOptions,
@@ -22,7 +24,6 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 import {TeamSelect as TeamSelectForProject} from 'sentry/views/settings/components/teamSelect/teamSelectForProject';
-import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
 import {ProjectPermissionAlert} from 'sentry/views/settings/project/projectPermissionAlert';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 
@@ -77,17 +78,23 @@ export default function ProjectTeams() {
   return (
     <SentryDocumentTitle title={routeTitleGen(t('Project Teams'), project.slug, false)}>
       <div>
-        <SettingsPageHeader title={t('Project Teams for %s', project.slug)} />
-        <TextBlock>
-          {t(
-            'These teams and their members have access to this project. They can be assigned to issues and alerts created in it.'
-          )}
-        </TextBlock>
-        <TextBlock>
-          {t(
-            'Team Admins can grant other teams access to this project. However, they cannot revoke access unless they are admins for the other teams too.'
-          )}
-        </TextBlock>
+        <SettingsPageHeader
+          title={t('Project Teams for %s', project.slug)}
+          subtitle={
+            <Stack gap="md">
+              <div>
+                {t(
+                  'These teams and their members have access to this project. They can be assigned to issues and alerts created in it.'
+                )}
+              </div>
+              <div>
+                {t(
+                  'Team Admins can grant other teams access to this project. However, they cannot revoke access unless they are admins for the other teams too.'
+                )}
+              </div>
+            </Stack>
+          }
+        />
         <ProjectPermissionAlert project={project} />
 
         <TeamSelectForProject

--- a/static/app/views/settings/project/projectToolbar.tsx
+++ b/static/app/views/settings/project/projectToolbar.tsx
@@ -15,7 +15,6 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocationQuery} from 'sentry/utils/url/useLocationQuery';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
-import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
 import {ProjectPermissionAlert} from 'sentry/views/settings/project/projectPermissionAlert';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 
@@ -39,17 +38,15 @@ export default function ProjectToolbarSettings() {
       <SentryDocumentTitle title={t('Toolbar Settings')} projectSlug={project.slug}>
         <SettingsPageHeader
           title={t('Dev Toolbar')}
+          subtitle={t(
+            'Bring critical Sentry insights and tools directly into your web app for easier troubleshooting with the Dev Toolbar.'
+          )}
           action={
             <LinkButton href="https://docs.sentry.io/product/sentry-toolbar/" external>
               {t('Read the Docs')}
             </LinkButton>
           }
         />
-        <TextBlock>
-          {t(
-            'Bring critical Sentry insights and tools directly into your web app for easier troubleshooting with the Dev Toolbar.'
-          )}
-        </TextBlock>
         <ProjectPermissionAlert project={project} />
         {domain && (
           <Alert.Container>

--- a/static/app/views/settings/projectDebugFiles/index.tsx
+++ b/static/app/views/settings/projectDebugFiles/index.tsx
@@ -130,15 +130,14 @@ export default function ProjectDebugSymbols() {
 
   return (
     <SentryDocumentTitle title={routeTitleGen(t('Debug Files'), project.slug, false)}>
-      <SettingsPageHeader title={t('Debug Information Files')} />
-
-      <TextBlock>
-        {t(`
+      <SettingsPageHeader
+        title={t('Debug Information Files')}
+        subtitle={t(`
           Debug information files are used to convert addresses and minified
           function names from native crash reports into function names and
           locations.
         `)}
-      </TextBlock>
+      />
 
       {organization.features.includes('symbol-sources') && (
         <Fragment>

--- a/static/app/views/settings/projectIssueGrouping/index.tsx
+++ b/static/app/views/settings/projectIssueGrouping/index.tsx
@@ -11,7 +11,6 @@ import type {Project} from 'sentry/types/project';
 import {routeTitleGen} from 'sentry/utils/routeTitle';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
-import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
 import {ProjectPermissionAlert} from 'sentry/views/settings/project/projectPermissionAlert';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 
@@ -37,10 +36,9 @@ export default function ProjectIssueGrouping() {
 
   return (
     <SentryDocumentTitle title={routeTitleGen(t('Issue Grouping'), project.slug, false)}>
-      <SettingsPageHeader title={t('Issue Grouping')} />
-
-      <TextBlock>
-        {tct(
+      <SettingsPageHeader
+        title={t('Issue Grouping')}
+        subtitle={tct(
           'All events have a fingerprint. Events with the same fingerprint are grouped together into an issue. To learn more about issue grouping, [link: read the docs].',
           {
             link: (
@@ -48,7 +46,7 @@ export default function ProjectIssueGrouping() {
             ),
           }
         )}
-      </TextBlock>
+      />
 
       <ProjectPermissionAlert project={project} />
 

--- a/static/app/views/settings/projectProguard/index.tsx
+++ b/static/app/views/settings/projectProguard/index.tsx
@@ -16,7 +16,6 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
-import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 
 import {ProjectProguardRow} from './projectProguardRow';
@@ -98,6 +97,14 @@ export default function ProjectProguard() {
     <Fragment>
       <SettingsPageHeader
         title={t('ProGuard Mappings')}
+        subtitle={tct(
+          'ProGuard mapping files are used to convert minified classes, methods and field names into a human readable format. To learn more about proguard mapping files, [link: read the docs].',
+          {
+            link: (
+              <ExternalLink href="https://docs.sentry.io/platforms/android/proguard/" />
+            ),
+          }
+        )}
         action={
           <SearchBar
             placeholder={t('Filter mappings')}
@@ -107,17 +114,6 @@ export default function ProjectProguard() {
           />
         }
       />
-
-      <TextBlock>
-        {tct(
-          'ProGuard mapping files are used to convert minified classes, methods and field names into a human readable format. To learn more about proguard mapping files, [link: read the docs].',
-          {
-            link: (
-              <ExternalLink href="https://docs.sentry.io/platforms/android/proguard/" />
-            ),
-          }
-        )}
-      </TextBlock>
 
       <StyledPanelTable
         headers={[t('Mapping'), <SizeColumn key="size">{t('File Size')}</SizeColumn>, '']}

--- a/static/app/views/settings/projectSourceMaps/sourceMapsList.tsx
+++ b/static/app/views/settings/projectSourceMaps/sourceMapsList.tsx
@@ -35,7 +35,6 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
-import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
 import {AssociatedReleases} from 'sentry/views/settings/projectSourceMaps/associatedReleases';
 import {useDeleteDebugIdBundle} from 'sentry/views/settings/projectSourceMaps/useDeleteDebugIdBundle';
 
@@ -208,15 +207,15 @@ export function SourceMapsList({project}: Props) {
 
   return (
     <Fragment>
-      <SettingsPageHeader title={t('Source Map Uploads')} />
-      <TextBlock>
-        {tct(
+      <SettingsPageHeader
+        title={t('Source Map Uploads')}
+        subtitle={tct(
           'These source map archives help Sentry identify where to look when code is minified. By providing this information, you can get better context for your stack traces when debugging. To learn more about source maps, [link: read the docs].',
           {
             link: <ExternalLink href={sourceMapsLinks.sourcemaps} />,
           }
         )}
-      </TextBlock>
+      />
       <SearchBarWithMarginBottom
         placeholder={t('Filter by Debug ID or Upload ID')}
         onSearch={handleSearch}

--- a/static/app/views/settings/projectTags/index.tsx
+++ b/static/app/views/settings/projectTags/index.tsx
@@ -98,7 +98,12 @@ export default function ProjectTags() {
       <SentryDocumentTitle
         title={routeTitleGen(t('Tags & Context'), project.slug, false)}
       />
-      <SettingsPageHeader title={t('Tags & Context')} />
+      <SettingsPageHeader
+        title={t('Tags & Context')}
+        subtitle={t(
+          'Setup Highlights to promote your event data to the top of the issue page for quicker debugging.'
+        )}
+      />
       <ProjectPermissionAlert project={project} />
       <HighlightsSettingsForm projectSlug={project.slug} />
       <TextBlock>

--- a/static/app/views/settings/projectUserFeedback/index.tsx
+++ b/static/app/views/settings/projectUserFeedback/index.tsx
@@ -19,7 +19,6 @@ import type {Project} from 'sentry/types/project';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
-import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
 import {ProjectPermissionAlert} from 'sentry/views/settings/project/projectPermissionAlert';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 
@@ -83,6 +82,11 @@ export default function ProjectUserFeedback() {
       <SentryDocumentTitle title={t('User Feedback')} projectSlug={project.slug}>
         <SettingsPageHeader
           title={t('User Feedback')}
+          subtitle={t(
+            `Don't rely on stack traces and graphs alone to understand
+            the cause and impact of errors. Enable the User Feedback Widget to collect
+            your users' comments at anytime, or enable the Crash Report Modal to collect additional context only when an error occurs.`
+          )}
           action={
             <Flex gap="md" align="center">
               <LinkButton href="https://docs.sentry.io/product/user-feedback/" external>
@@ -94,13 +98,6 @@ export default function ProjectUserFeedback() {
             </Flex>
           }
         />
-        <TextBlock>
-          {t(
-            `Don't rely on stack traces and graphs alone to understand
-            the cause and impact of errors. Enable the User Feedback Widget to collect
-            your users' comments at anytime, or enable the Crash Report Modal to collect additional context only when an error occurs.`
-          )}
-        </TextBlock>
         <ProjectPermissionAlert project={project} />
 
         <Access access={['project:write']} project={project}>


### PR DESCRIPTION
`subTitle` renders the correct spacing for the new `pageFrame`.

before:

| without pageFrame | with pageFrame |
|--------|--------|
| <img width="1713" height="309" alt="Screenshot 2026-04-21 at 13 00 25" src="https://github.com/user-attachments/assets/b0c6fc2f-fb3b-45fc-96c5-2775c793c462" /> | <img width="1710" height="235" alt="Screenshot 2026-04-21 at 13 00 06" src="https://github.com/user-attachments/assets/856272ac-7626-4fd4-b28b-247827944b82" /> | 

after:

| without pageFrame | with pageFrame |
|--------|--------|
| <img width="1713" height="299" alt="Screenshot 2026-04-21 at 13 01 33" src="https://github.com/user-attachments/assets/7d62cfaf-eea6-4b32-9cbb-0f9b9c0a430a" /> | <img width="1710" height="210" alt="Screenshot 2026-04-21 at 13 01 14" src="https://github.com/user-attachments/assets/38a7bf4e-12de-42e9-b434-f27df14db2cb" /> | 

biggest difference is that the `subTitle` is `muted` while the normal text was not. However, we were using both variants inconsistently before. If we want to make the `subTitle` not muted, we can now easily do it.
