### PR TITLE
fix(alerts): align issue rule cards with page-frame breadcrumb

### DIFF
--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -1234,7 +1234,7 @@ class IssueRuleEditor extends DeprecatedAsyncComponent<Props, State> {
             ) : null
           }
         >
-          <List symbol="colored-numeric">
+          <List>
             {loading && <SemiTransparentLoadingMask data-test-id="loading-mask" />}
             <StyledListItem>
               <StepHeader>{t('Select an environment and project')}</StepHeader>
@@ -1732,11 +1732,7 @@ const StyledFieldWrapper = styled('div')`
   }
 `;
 
-const ContentIndent = styled('div')`
-  @media (min-width: ${p => p.theme.breakpoints.sm}) {
-    margin-left: ${p => p.theme.space['3xl']};
-  }
-`;
+const ContentIndent = styled('div')``;
 
 const AcknowledgeLabel = styled('label')`
   display: flex;


### PR DESCRIPTION
Align the step cards on the issue alert builder (Source, Filter, Action, Frequency, Name) with the breadcrumb and editable title in the page-frame top bar.

**The issue**

On the page-frame layout, `Layout.Header` and `Layout.Body` both use 16px (`xl`) horizontal padding, so the breadcrumb (`Alerts / New Alert`) and the editable title in the top bar already line up at 16px from the page edge. But the form body uses `<List symbol=\"colored-numeric\">`, which applies a 32px `padding-left` to each `<li>` to reserve space for the numeric step bubble, and a `ContentIndent` wrapper adds another 32px `margin-left` for non-list content between steps. The net effect is that every card inside the form sits at 48px — 32px past the breadcrumb.

**What this PR changes**

- Drop `symbol=\"colored-numeric\"` on the outer `<List>` so list items no longer carry the 32px bubble gutter.
- Collapse `ContentIndent` to a no-op wrapper so content between list items no longer gets the extra 32px margin.

Result: cards align with the breadcrumb at 16px. `StepHeader` already uses a larger font size, so the steps remain visually distinguishable without the numeric bubbles.

**Design trade-off — needs review**

This removes the numeric step bubbles (1, 2, 3, ...) from the issue alert builder. If keeping a visible step indicator matters, alternatives to consider:
- Inline the number in the step header text (e.g., \"1. Select an environment and project\").
- Move the bubbles to a column to the *left* of the content (requires widening `Layout.Body`'s padding, which would affect every other page that uses it).

**Scope**

Only the issue alert rule editor is updated in this PR. The metric rule editor (`static/app/views/alerts/rules/metric/ruleForm.tsx`) and uptime editor (`static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx`) use the same `<List symbol=\"colored-numeric\">` pattern and can follow once this direction is approved by design.

Refs DE-1176