### PR TITLE
feat(integrations): Prevent fetching thousands of commits

### DIFF
--- a/src/sentry/integrations/github/repository.py
+++ b/src/sentry/integrations/github/repository.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping, MutableMapping, Sequence
 from typing import TYPE_CHECKING, Any
 
+from sentry import options
 from sentry.constants import ObjectStatus
 from sentry.integrations.base import IntegrationInstallation
 from sentry.integrations.services.integration import integration_service
@@ -19,6 +21,8 @@ if TYPE_CHECKING:
     from sentry.integrations.github.integration import GitHubIntegration  # NOQA
 
 WEBHOOK_EVENTS = ["push", "pull_request"]
+MAX_COMPARE_COMMITS_OPTION_KEY = "github-app.fetch-commits.max-compare-commits"
+logger = logging.getLogger(__name__)
 
 
 class GitHubRepositoryProvider(IntegrationRepositoryProvider["GitHubIntegration"]):
@@ -100,6 +104,20 @@ class GitHubRepositoryProvider(IntegrationRepositoryProvider["GitHubIntegration"
 
         try:
             commits = client.compare_commits(name, start_sha, end_sha)
+            max_compare_commits = options.get(MAX_COMPARE_COMMITS_OPTION_KEY)
+            if max_compare_commits and len(commits) > max_compare_commits:
+                logger.info(
+                    "fetch_commits.truncated",
+                    extra={
+                        "organization_id": repo.organization_id,
+                        "repository": repo.name,
+                        "start_sha": start_sha,
+                        "end_sha": end_sha,
+                        "original_count": len(commits),
+                        "truncated_count": max_compare_commits,
+                    },
+                )
+                commits = commits[-max_compare_commits:]
             return self._format_commits(client, name, commits)
         except Exception as e:
             installation.raise_error(e)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -750,6 +750,12 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "github-app.fetch-commits.max-compare-commits",
+    type=Int,
+    default=500,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "github.webhook.mailbox-bucketing.enabled",
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
@@ -2727,9 +2733,15 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-register("metric_alerts.extended_max_subscriptions", default=1250, flags=FLAG_AUTOMATOR_MODIFIABLE)
 register(
-    "metric_alerts.extended_max_subscriptions_orgs", default=[], flags=FLAG_AUTOMATOR_MODIFIABLE
+    "metric_alerts.extended_max_subscriptions",
+    default=1250,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "metric_alerts.extended_max_subscriptions_orgs",
+    default=[],
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
 # SDK Crash Detection

--- a/tests/sentry/integrations/github/test_repository.py
+++ b/tests/sentry/integrations/github/test_repository.py
@@ -1,5 +1,6 @@
 import datetime
 from functools import cached_property
+from typing import Any
 from unittest import mock
 
 import orjson
@@ -65,7 +66,7 @@ class GitHubAppsProviderTest(TestCase):
                 config={"name": "getsentry/example-repo"},
             )
 
-    def _build_compare_commit_payload(self, count: int) -> list[dict[str, object]]:
+    def _build_compare_commit_payload(self, count: int) -> list[dict[str, Any]]:
         commits = []
         for index in range(count):
             commits.append(

--- a/tests/sentry/integrations/github/test_repository.py
+++ b/tests/sentry/integrations/github/test_repository.py
@@ -7,7 +7,11 @@ import pytest
 import responses
 from django.utils import timezone
 
-from fixtures.github import COMPARE_COMMITS_EXAMPLE, GET_COMMIT_EXAMPLE, GET_LAST_COMMITS_EXAMPLE
+from fixtures.github import (
+    COMPARE_COMMITS_EXAMPLE,
+    GET_COMMIT_EXAMPLE,
+    GET_LAST_COMMITS_EXAMPLE,
+)
 from sentry.constants import ObjectStatus
 from sentry.integrations.github.repository import GitHubRepositoryProvider
 from sentry.integrations.models.integration import Integration
@@ -17,7 +21,11 @@ from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.silo.base import SiloMode
 from sentry.testutils.asserts import assert_commit_shape
 from sentry.testutils.cases import TestCase
-from sentry.testutils.silo import assume_test_silo_mode, assume_test_silo_mode_of, control_silo_test
+from sentry.testutils.silo import (
+    assume_test_silo_mode,
+    assume_test_silo_mode_of,
+    control_silo_test,
+)
 
 
 @control_silo_test
@@ -56,6 +64,24 @@ class GitHubAppsProviderTest(TestCase):
                 url="https://github.com/getsentry/example-repo",
                 config={"name": "getsentry/example-repo"},
             )
+
+    def _build_compare_commit_payload(self, count: int) -> list[dict[str, object]]:
+        commits = []
+        for index in range(count):
+            commits.append(
+                {
+                    "sha": f"{index:040x}",
+                    "commit": {
+                        "author": {
+                            "email": "jane@example.com",
+                            "name": "Jane Doe",
+                            "date": "2024-01-01T00:00:00+00:00",
+                        },
+                        "message": f"commit {index}",
+                    },
+                }
+            )
+        return commits
 
     @responses.activate
     def test_build_repository_config(self) -> None:
@@ -165,6 +191,105 @@ class GitHubAppsProviderTest(TestCase):
         assert len(result) == 2
         assert result[0]["id"] == "6dcb09b5b57875f334f61aebed695e2e4193db5e"
         assert result[1]["id"] == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+    @mock.patch("sentry.integrations.github.repository.logger.info")
+    def test_fetch_commits_for_compare_range_truncates_over_cap(
+        self, log_info: mock.MagicMock
+    ) -> None:
+        client = mock.Mock()
+        client.compare_commits.return_value = self._build_compare_commit_payload(600)
+        client.get_commit.return_value = {"files": []}
+        installation = mock.Mock()
+
+        with (
+            self.options({"github-app.fetch-commits.max-compare-commits": 500}),
+            mock.patch.object(
+                self.provider,
+                "_get_installation_and_client",
+                return_value=(installation, client),
+            ),
+        ):
+            result = self.provider.fetch_commits_for_compare_range(
+                self.repository, "xyz123", "abcdef"
+            )
+
+        assert len(result) == 500
+        assert client.get_commit.call_count == 500
+        log_info.assert_called_once()
+
+    def test_fetch_commits_for_compare_range_keeps_most_recent(self) -> None:
+        client = mock.Mock()
+        commits = self._build_compare_commit_payload(3)
+        client.compare_commits.return_value = commits
+        client.get_commit.return_value = {"files": []}
+        installation = mock.Mock()
+
+        with (
+            self.options({"github-app.fetch-commits.max-compare-commits": 2}),
+            mock.patch.object(
+                self.provider,
+                "_get_installation_and_client",
+                return_value=(installation, client),
+            ),
+        ):
+            result = self.provider.fetch_commits_for_compare_range(
+                self.repository, "xyz123", "abcdef"
+            )
+
+        assert [commit["id"] for commit in result] == [
+            commits[-2]["sha"],
+            commits[-1]["sha"],
+        ]
+
+    @mock.patch("sentry.integrations.github.repository.logger.info")
+    def test_fetch_commits_for_compare_range_no_truncation_under_cap(
+        self, log_info: mock.MagicMock
+    ) -> None:
+        client = mock.Mock()
+        client.compare_commits.return_value = self._build_compare_commit_payload(499)
+        client.get_commit.return_value = {"files": []}
+        installation = mock.Mock()
+
+        with (
+            self.options({"github-app.fetch-commits.max-compare-commits": 500}),
+            mock.patch.object(
+                self.provider,
+                "_get_installation_and_client",
+                return_value=(installation, client),
+            ),
+        ):
+            result = self.provider.fetch_commits_for_compare_range(
+                self.repository, "xyz123", "abcdef"
+            )
+
+        assert len(result) == 499
+        assert client.get_commit.call_count == 499
+        log_info.assert_not_called()
+
+    @mock.patch("sentry.integrations.github.repository.logger.info")
+    def test_fetch_commits_for_compare_range_cap_zero_disables(
+        self, log_info: mock.MagicMock
+    ) -> None:
+        client = mock.Mock()
+        client.compare_commits.return_value = self._build_compare_commit_payload(600)
+        client.get_commit.return_value = {"files": []}
+        installation = mock.Mock()
+
+        with (
+            self.options({"github-app.fetch-commits.max-compare-commits": 0}),
+            mock.patch.object(
+                self.provider,
+                "_get_installation_and_client",
+                return_value=(installation, client),
+            ),
+        ):
+            result = self.provider.fetch_commits_for_compare_range(
+                self.repository, "xyz123", "abcdef"
+            )
+
+        assert len(result) == 600
+        assert client.get_commit.call_count == 600
+        log_info.assert_not_called()
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate


### PR DESCRIPTION
Add a configurable cap for GitHub compare-commit ranges used by `fetch_commits`.

Large compare ranges currently fan out one `get_commit` call per commit to build
patch sets, which creates expensive long-tail tasks. This change adds a
`github-app.fetch-commits.max-compare-commits` option (default `500`) and applies
it in `GitHubRepositoryProvider.fetch_commits_for_compare_range` before
`_format_commits` so the cap reduces the actual fanout work.

I considered moving the cap into the task layer, but applying it in the GitHub
provider is the safest point because it guarantees truncation happens before
patch-set hydration and keeps existing cache behavior unchanged.

Made with [Cursor](https://cursor.com)

You can see [SENTRY-44HA](https://sentry.sentry.io/issues/6722245237/) for an issue fetching thousands of commits and then the task timing out.

You can open [these logs](https://sentry.sentry.io/explore/logs/?aggregateField=%7B%22groupBy%22%3A%22%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22count%28message%29%22%5D%7D&logsAggregateSortBys=-tags%5Bnum_commits%2Cnumber%5D&logsFields=message&logsFields=timestamp&logsFields=url&logsFields=tags%5Bnum_commits%2Cnumber%5D&logsQuery=has%3Atags%5Bnum_commits%2Cnumber%5D%20tags%5Bnum_commits%2Cnumber%5D%3A%3E500%20code.file.path%3Asentry%2Fsrc%2Fsentry%2Ftasks%2Fcommits.py&logsSortBys=-tags%5Bcompare_commits_cache_hit%2Cboolean%5D&mode=aggregate&project=1&statsPeriod=24h) to see how many fetch_commits tasks fetch more than 500 commits.