### PR TITLE
feat(scraps): Add PaginationFooter and replay network pagination

### DIFF
--- a/static/app/components/core/paginationFooter/index.tsx
+++ b/static/app/components/core/paginationFooter/index.tsx
@@ -1,0 +1,1 @@
+export {PaginationFooter, type PaginationFooterSize} from './paginationFooter';

--- a/static/app/components/core/paginationFooter/paginationFooter.mdx
+++ b/static/app/components/core/paginationFooter/paginationFooter.mdx
@@ -1,0 +1,200 @@
+---
+title: PaginationFooter
+description: Right-aligned page summary with previous and next controls for lists and tables.
+category: navigation
+source: '@sentry/scraps/paginationFooter'
+resources:
+  js: https://github.com/getsentry/sentry/blob/master/static/app/components/core/paginationFooter/paginationFooter.tsx
+  a11y:
+    WCAG 2.1.1: https://www.w3.org/TR/WCAG22/#keyboard
+    WCAG 2.4.7: https://www.w3.org/TR/WCAG22/#focus-visible
+    WCAG 2.5.8: https://www.w3.org/TR/WCAG22/#target-size-minimum
+    WAI-ARIA Button Pattern: https://www.w3.org/WAI/ARIA/apg/patterns/button/
+---
+
+import {useState} from 'react';
+
+import {PaginationFooter} from '@sentry/scraps/paginationFooter';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import * as Storybook from 'sentry/stories';
+
+export const documentation = import('!!type-loader!@sentry/scraps/paginationFooter');
+
+`<PaginationFooter>` shows an optional muted caption (for example, “Showing 1–25 of 100”) plus icon-only previous and next buttons. It does not own page state: your caller updates URLs, query cursors, or local `useState` and passes `isPreviousDisabled` / `isNextDisabled` plus handlers.
+
+For issues-stream style pagination that reads `Link` response headers and pushes cursor query params, prefer the `<Pagination>` wrapper in `sentry/components/pagination`, which composes this footer.
+
+```jsx
+<PaginationFooter
+  caption="Page 2 of 10"
+  isPreviousDisabled={false}
+  isNextDisabled={false}
+  onPrevious={() => {}}
+  onNext={() => {}}
+/>
+```
+
+## When to use
+
+Use `<PaginationFooter>` when you need a consistent scraps footer for **client-side** paging, nested panels, or custom data sources where you already compute the caption and enabled state.
+
+For **cursor-based** list paging that syncs with the location bar, use `<Pagination>` instead so link parsing and navigation stay consistent.
+
+> [!NOTE]
+>
+> The root element sets `data-test-id="pagination"` for integration tests.
+
+## Sizes
+
+`size` controls caption typography and spacing between the caption and buttons. `normal` matches the default issues stream footer; `small` fits compact contexts such as nested tables or replay detail panels.
+
+export function NormalPaginationDemo() {
+  const [page, setPage] = useState(2);
+  const totalPages = 6;
+  return (
+    <PaginationFooter
+      caption={`Page ${page} of ${totalPages}`}
+      isPreviousDisabled={page <= 1}
+      isNextDisabled={page >= totalPages}
+      onPrevious={() => setPage(p => Math.max(1, p - 1))}
+      onNext={() => setPage(p => Math.min(totalPages, p + 1))}
+      size="normal"
+    />
+  );
+}
+
+export function SmallPaginationDemo() {
+  const [page, setPage] = useState(2);
+  const totalPages = 6;
+  return (
+    <PaginationFooter
+      caption={`Page ${page} of ${totalPages}`}
+      isPreviousDisabled={page <= 1}
+      isNextDisabled={page >= totalPages}
+      onPrevious={() => setPage(p => Math.max(1, p - 1))}
+      onNext={() => setPage(p => Math.min(totalPages, p + 1))}
+      size="small"
+    />
+  );
+}
+
+<Storybook.Demo>
+  <Stack gap="lg">
+    <Flex direction="column" gap="xs">
+      <Text size="sm" variant="muted">
+        size=&quot;normal&quot; (default)
+      </Text>
+      <NormalPaginationDemo />
+    </Flex>
+    <Flex direction="column" gap="xs">
+      <Text size="sm" variant="muted">
+        size=&quot;small&quot;
+      </Text>
+      <SmallPaginationDemo />
+    </Flex>
+  </Stack>
+</Storybook.Demo>
+
+```jsx
+<PaginationFooter
+  size="normal"
+  caption="Page 2 of 6"
+  isPreviousDisabled={false}
+  isNextDisabled={false}
+  onPrevious={() => {}}
+  onNext={() => {}}
+/>
+
+<PaginationFooter
+  size="small"
+  caption="Page 2 of 6"
+  isPreviousDisabled={false}
+  isNextDisabled={false}
+  onPrevious={() => {}}
+  onNext={() => {}}
+/>
+```
+
+## Button size override
+
+`buttonSize` overrides the default icon button size implied by `size`. Use this when embedding the footer in layouts that already assume a specific `Button` scale (for example, matching legacy `<Pagination size="md" />`).
+
+<Storybook.Demo>
+  <PaginationFooter
+    buttonSize="md"
+    caption='Buttons use md while caption follows size="normal"'
+    isNextDisabled={false}
+    isPreviousDisabled={false}
+    onNext={() => {}}
+    onPrevious={() => {}}
+    size="normal"
+  />
+</Storybook.Demo>
+
+```jsx
+<PaginationFooter
+  size="normal"
+  buttonSize="md"
+  caption="…"
+  isPreviousDisabled={false}
+  isNextDisabled={false}
+  onPrevious={() => {}}
+  onNext={() => {}}
+/>
+```
+
+## Disabled states
+
+Disable previous on the first page and next on the last page (or when there is no additional data). Both controls can be disabled when pagination is not available.
+
+export function DisabledEndsDemo() {
+  const [page, setPage] = useState(1);
+  const totalPages = 3;
+  return (
+    <PaginationFooter
+      caption={`Page ${page} of ${totalPages}`}
+      isPreviousDisabled={page <= 1}
+      isNextDisabled={page >= totalPages}
+      onPrevious={() => setPage(p => Math.max(1, p - 1))}
+      onNext={() => setPage(p => Math.min(totalPages, p + 1))}
+      size="normal"
+    />
+  );
+}
+
+<Storybook.Demo>
+  <DisabledEndsDemo />
+</Storybook.Demo>
+
+```jsx
+const totalPages = 3;
+const [page, setPage] = useState(1);
+
+<PaginationFooter
+  caption={`Page ${page} of ${totalPages}`}
+  isPreviousDisabled={page <= 1}
+  isNextDisabled={page >= totalPages}
+  onPrevious={() => setPage(p => Math.max(1, p - 1))}
+  onNext={() => setPage(p => Math.min(totalPages, p + 1))}
+/>;
+```
+
+## Accessibility
+
+This component meets [WCAG 2.2 AA](https://www.w3.org/TR/WCAG22/) expectations for its building blocks:
+
+- **Keyboard**: Previous and next are focusable `Button` controls (WCAG 2.1.1).
+- **Focus visibility**: Uses the standard button focus ring (WCAG 2.4.7).
+- **Target size**: Meets minimum touch target when default sizes are used (WCAG 2.5.8).
+- **Names**: Previous and next use `aria-label` via the scraps `Button` pattern.
+
+### Developer responsibilities
+
+- Provide a **caption** that makes the current range or position clear when that information matters for understanding the list (“Showing 1–25 of 100”, not only “Next”).
+
+## See also
+
+- [`Pagination`](https://github.com/getsentry/sentry/blob/master/static/app/components/pagination.tsx) (`sentry/components/pagination`) — cursor and URL-aware paging for list endpoints
+- [Button](/stories/core/button/) — underlying control for the icon actions

--- a/static/app/components/core/paginationFooter/paginationFooter.tsx
+++ b/static/app/components/core/paginationFooter/paginationFooter.tsx
@@ -1,0 +1,98 @@
+import {Button, ButtonBar} from '@sentry/scraps/button';
+import {Flex, type FlexProps} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {IconChevron} from 'sentry/icons';
+import {t} from 'sentry/locale';
+
+export type PaginationFooterSize = 'normal' | 'small';
+
+type Props = {
+  isNextDisabled: boolean;
+  isPreviousDisabled: boolean;
+  onNext: () => void;
+  onPrevious: () => void;
+  /**
+   * When set, overrides the default button size implied by `size` (e.g. pass through
+   * legacy `Pagination` `size` values: zero | xs | sm | md).
+   */
+  buttonSize?: React.ComponentProps<typeof Button>['size'];
+  caption?: React.ReactNode;
+  paginationAnalyticsEvent?: (direction: string) => void;
+  /**
+   * `normal` matches the default Issues stream footer (larger caption).
+   * `small` is for compact footers (e.g. nested tables, side panels).
+   */
+  size?: PaginationFooterSize;
+} & Omit<FlexProps<'div'>, 'align' | 'children' | 'justify'>;
+
+const SIZE_STYLES: Record<
+  PaginationFooterSize,
+  {
+    defaultButtonSize: React.ComponentProps<typeof Button>['size'];
+    gap: React.ComponentProps<typeof Flex>['gap'];
+    textSize: React.ComponentProps<typeof Text>['size'];
+  }
+> = {
+  normal: {
+    defaultButtonSize: 'sm',
+    gap: 'xl',
+    textSize: 'md',
+  },
+  small: {
+    defaultButtonSize: 'xs',
+    gap: 'sm',
+    textSize: 'sm',
+  },
+};
+
+/**
+ * Right-aligned range/count label with previous/next icon buttons.
+ * Use with cursor-based navigation (`Pagination`) or client-side page state.
+ */
+export function PaginationFooter({
+  isNextDisabled,
+  isPreviousDisabled,
+  onNext,
+  onPrevious,
+  buttonSize: buttonSizeProp,
+  caption,
+  paginationAnalyticsEvent,
+  size = 'normal',
+  ...flexProps
+}: Props) {
+  const {defaultButtonSize, gap, textSize} = SIZE_STYLES[size];
+  const buttonSize = buttonSizeProp ?? defaultButtonSize;
+
+  return (
+    <Flex align="center" data-test-id="pagination" gap={gap} justify="end" {...flexProps}>
+      {caption ? (
+        <Text size={textSize} variant="muted">
+          {caption}
+        </Text>
+      ) : null}
+      <ButtonBar>
+        <Button
+          aria-label={t('Previous')}
+          disabled={isPreviousDisabled}
+          icon={<IconChevron direction="left" />}
+          size={buttonSize}
+          onClick={() => {
+            onPrevious();
+            paginationAnalyticsEvent?.('Previous');
+          }}
+        />
+        <Button
+          aria-label={t('Next')}
+          disabled={isNextDisabled}
+          icon={<IconChevron direction="right" />}
+          size={buttonSize}
+          onClick={() => {
+            onNext();
+            paginationAnalyticsEvent?.('Next');
+          }}
+        />
+      </ButtonBar>
+    </Flex>
+  );
+}

--- a/static/app/components/pagination.tsx
+++ b/static/app/components/pagination.tsx
@@ -1,12 +1,9 @@
 import {useCallback} from 'react';
-import styled from '@emotion/styled';
 import type {Query} from 'history';
 
-import {Button, ButtonBar} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {PaginationFooter} from '@sentry/scraps/paginationFooter';
 
-import {IconChevron} from 'sentry/icons';
-import {t, tct} from 'sentry/locale';
+import {tct} from 'sentry/locale';
 import {defined} from 'sentry/utils';
 import {parseCursor} from 'sentry/utils/cursor';
 import {parseLinkHeader} from 'sentry/utils/parseLinkHeader';
@@ -68,37 +65,18 @@ export function Pagination({
   const cursorHandler = onCursor ?? defaultCursorHandler;
 
   return (
-    <Flex
-      justify="end"
-      align="center"
-      margin="2xl 0 0 0"
+    <PaginationFooter
+      buttonSize={size}
       className={className}
-      data-test-id="pagination"
-    >
-      {caption && <PaginationCaption>{caption}</PaginationCaption>}
-      <ButtonBar>
-        <Button
-          icon={<IconChevron direction="left" />}
-          aria-label={t('Previous')}
-          size={size}
-          disabled={previousDisabled}
-          onClick={() => {
-            cursorHandler(links.previous?.cursor, path, query, -1);
-            paginationAnalyticsEvent?.('Previous');
-          }}
-        />
-        <Button
-          icon={<IconChevron direction="right" />}
-          aria-label={t('Next')}
-          size={size}
-          disabled={nextDisabled}
-          onClick={() => {
-            cursorHandler(links.next?.cursor, path, query, 1);
-            paginationAnalyticsEvent?.('Next');
-          }}
-        />
-      </ButtonBar>
-    </Flex>
+      caption={caption}
+      isNextDisabled={nextDisabled}
+      isPreviousDisabled={previousDisabled}
+      margin="2xl 0 0 0"
+      paginationAnalyticsEvent={paginationAnalyticsEvent}
+      size="normal"
+      onNext={() => cursorHandler(links.next?.cursor, path, query, 1)}
+      onPrevious={() => cursorHandler(links.previous?.cursor, path, query, -1)}
+    />
   );
 }
 
@@ -131,9 +109,3 @@ export function getPaginationCaption({
     total: total.toLocaleString(),
   });
 }
-
-const PaginationCaption = styled('span')`
-  color: ${p => p.theme.tokens.content.secondary};
-  font-size: ${p => p.theme.font.size.md};
-  margin-right: ${p => p.theme.space.xl};
-`;

--- a/static/app/stories/view/storyTree.tsx
+++ b/static/app/stories/view/storyTree.tsx
@@ -187,7 +187,7 @@ export const COMPONENT_SUBCATEGORY_CONFIG: Record<
   },
   navigation: {
     label: 'Navigation',
-    components: ['link', 'tabs', 'menulistitem'],
+    components: ['link', 'paginationfooter', 'tabs', 'menulistitem'],
   },
   status: {
     label: 'Status',

--- a/static/app/views/replays/detail/network/constants.ts
+++ b/static/app/views/replays/detail/network/constants.ts
@@ -1,5 +1,4 @@
 /**
  * How many replay network requests to show in one paginated page.
  */
-export const NETWORK_LIST_PAGE_SIZE = 100;
-// export const NETWORK_LIST_PAGE_SIZE = 10_000;
+export const NETWORK_LIST_PAGE_SIZE = 10_000;

--- a/static/app/views/replays/detail/network/constants.ts
+++ b/static/app/views/replays/detail/network/constants.ts
@@ -1,0 +1,5 @@
+/**
+ * How many replay network requests to show in one paginated page.
+ */
+export const NETWORK_LIST_PAGE_SIZE = 100;
+// export const NETWORK_LIST_PAGE_SIZE = 10_000;

--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, useRef} from 'react';
+import {useCallback, useRef} from 'react';
 
 import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
@@ -6,12 +6,8 @@ import {ExternalLink} from '@sentry/scraps/link';
 import {Placeholder} from 'sentry/components/placeholder';
 import {JumpButtons} from 'sentry/components/replays/jumpButtons';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
-import {
-  useJumpButtons,
-  type VisibleRange,
-} from 'sentry/components/replays/useJumpButtons';
+import {useJumpButtons} from 'sentry/components/replays/useJumpButtons';
 import {GridTable} from 'sentry/components/replays/virtualizedGrid/gridTable';
-import {OverflowHidden} from 'sentry/components/replays/virtualizedGrid/overflowHidden';
 import {SplitPanel} from 'sentry/components/replays/virtualizedGrid/splitPanel';
 import {useDetailsSplit} from 'sentry/components/replays/virtualizedGrid/useDetailsSplit';
 import {t, tct} from 'sentry/locale';
@@ -28,29 +24,34 @@ import {
   COLUMN_COUNT,
   NetworkHeaderCell,
 } from 'sentry/views/replays/detail/network/networkHeaderCell';
+import {NetworkPaginationRow} from 'sentry/views/replays/detail/network/networkPaginationRow';
 import {NetworkTableCell} from 'sentry/views/replays/detail/network/networkTableCell';
+import {
+  NETWORK_DETAILS_SPLIT_HANDLE_HEIGHT,
+  NETWORK_TABLE_BODY_ROW_HEIGHT,
+  NETWORK_TABLE_DEFAULT_COLUMN_WIDTH,
+  NETWORK_TABLE_DYNAMIC_COLUMN_INDEX,
+  NETWORK_TABLE_HEADER_HEIGHT,
+  NETWORK_TABLE_MIN_DYNAMIC_COLUMN_WIDTH,
+  NETWORK_TABLE_OVERSCAN,
+  NETWORK_TABLE_STATIC_COLUMN_WIDTHS,
+} from 'sentry/views/replays/detail/network/networkTableLayout';
 import {useNetworkFilters} from 'sentry/views/replays/detail/network/useNetworkFilters';
+import {
+  useNetworkListDetailUrlPageSync,
+  useNetworkListPaging,
+  useNetworkListVirtualSync,
+} from 'sentry/views/replays/detail/network/useNetworkListTable';
 import {useSortNetwork} from 'sentry/views/replays/detail/network/useSortNetwork';
 import {NoRowRenderer} from 'sentry/views/replays/detail/noRowRenderer';
 import {useVirtualizedGrid} from 'sentry/views/replays/detail/useVirtualizedGrid';
 import {VirtualTable} from 'sentry/views/replays/detail/virtualizedTableLayout';
-import {
-  getTimelineRowClassName,
-  getVisibleRangeFromVirtualRows,
-} from 'sentry/views/replays/detail/virtualizedTableUtils';
-
-const HEADER_HEIGHT = 25;
-const BODY_HEIGHT = 25;
-const RESIZEABLE_HANDLE_HEIGHT = 90;
-const DEFAULT_COLUMN_WIDTH = 88;
-const DYNAMIC_COLUMN_INDEX = 2;
-const MIN_DYNAMIC_COLUMN_WIDTH = 180;
-const OVERSCAN = 20;
-const STATIC_COLUMN_WIDTHS = [76, 76, 0, 88, 88, 98, 116];
+import {getTimelineRowClassName} from 'sentry/views/replays/detail/virtualizedTableUtils';
 
 export function NetworkList() {
   const organization = useOrganization();
   const replay = useReplayReader();
+  const replayId = replay?.getReplay()?.id;
   const {currentTime} = useReplayContext();
   const [currentHoverTime] = useCurrentHoverTime();
   const {onMouseEnter, onMouseLeave, onClickTimestamp} = useCrumbHandlers();
@@ -66,6 +67,20 @@ export function NetworkList() {
   const clearSearchTerm = () => setSearchTerm('');
   const {handleSort, items, sortConfig} = useSortNetwork({items: filteredItems});
 
+  const {
+    didInitialDetailPageSyncRef,
+    handleScrollToTableRow,
+    onNextPage,
+    onPreviousPage,
+    pageItems,
+    pageOffset,
+    pendingScrollToIndexRef,
+    safePage,
+    scrollGeneration,
+    setPage,
+    totalPages,
+  } = useNetworkListPaging(items, replayId);
+
   const containerRef = useRef<HTMLDivElement>(null);
   const {
     gridTemplateColumns,
@@ -75,32 +90,24 @@ export function NetworkList() {
     virtualizer,
     wrapperRef,
   } = useVirtualizedGrid({
-    defaultColumnWidth: DEFAULT_COLUMN_WIDTH,
-    dynamicColumnIndex: DYNAMIC_COLUMN_INDEX,
-    minDynamicColumnWidth: MIN_DYNAMIC_COLUMN_WIDTH,
-    overscan: OVERSCAN,
-    rowCount: items.length,
-    rowHeight: BODY_HEIGHT,
-    staticColumnWidths: STATIC_COLUMN_WIDTHS,
+    defaultColumnWidth: NETWORK_TABLE_DEFAULT_COLUMN_WIDTH,
+    dynamicColumnIndex: NETWORK_TABLE_DYNAMIC_COLUMN_INDEX,
+    minDynamicColumnWidth: NETWORK_TABLE_MIN_DYNAMIC_COLUMN_WIDTH,
+    overscan: NETWORK_TABLE_OVERSCAN,
+    rowCount: pageItems.length,
+    rowHeight: NETWORK_TABLE_BODY_ROW_HEIGHT,
+    staticColumnWidths: NETWORK_TABLE_STATIC_COLUMN_WIDTHS,
   });
 
-  const handleScrollToTableRow = useCallback(
-    (row: number) => {
-      setTimeout(() => {
-        virtualizer.scrollToIndex(row - 1, {align: 'auto'});
-      }, 50);
-    },
-    [virtualizer]
-  );
-
-  const visibleRange = useMemo<VisibleRange>(() => {
-    return getVisibleRangeFromVirtualRows({
-      indexOffset: 1,
-      scrollOffset: virtualizer.scrollOffset ?? 0,
-      viewportHeight: virtualizer.scrollRect?.height ?? 0,
-      virtualRows,
-    });
-  }, [virtualRows, virtualizer.scrollOffset, virtualizer.scrollRect?.height]);
+  const {visibleRange} = useNetworkListVirtualSync({
+    pageItemsLength: pageItems.length,
+    pageOffset,
+    pendingScrollToIndexRef,
+    safePage,
+    scrollGeneration,
+    virtualRows,
+    virtualizer,
+  });
 
   const {
     handleClick: onClickToJump,
@@ -123,7 +130,7 @@ export function NetworkList() {
   } = useDetailsSplit({
     containerRef,
     frames: networkFrames,
-    handleHeight: RESIZEABLE_HANDLE_HEIGHT,
+    handleHeight: NETWORK_DETAILS_SPLIT_HANDLE_HEIGHT,
     urlParamName: 'n_detail_row',
     onShowDetails: useCallback(
       ({dataIndex, rowIndex}: {dataIndex: number; rowIndex: number}) => {
@@ -150,6 +157,16 @@ export function NetworkList() {
     }, [isNetworkDetailsSetup, organization]),
   });
 
+  useNetworkListDetailUrlPageSync({
+    didInitialDetailPageSyncRef,
+    itemsLength: items.length,
+    pendingScrollToIndexRef,
+    replayId,
+    safePage,
+    selectedIndex,
+    setPage,
+  });
+
   const selectedItem = selectedIndex === null ? null : (items[selectedIndex] ?? null);
 
   return (
@@ -164,122 +181,141 @@ export function NetworkList() {
           }}
         >
           {networkFrames ? (
-            <OverflowHidden>
-              <VirtualTable ref={wrapperRef}>
-                <VirtualTable.BodyScrollContainer ref={scrollContainerRef}>
-                  <VirtualTable.HeaderViewport style={{width: totalColumnWidth}}>
-                    <VirtualTable.HeaderRow
-                      style={{
-                        gridTemplateColumns,
-                      }}
-                    >
-                      {Array.from({length: COLUMN_COUNT}, (_, columnIndex) => (
-                        <NetworkHeaderCell
-                          key={columnIndex}
-                          handleSort={handleSort}
-                          index={columnIndex}
-                          sortConfig={sortConfig}
-                          style={{height: HEADER_HEIGHT}}
-                        />
-                      ))}
-                    </VirtualTable.HeaderRow>
-                  </VirtualTable.HeaderViewport>
-                  {items.length === 0 ? (
-                    <VirtualTable.NoRowsContainer>
-                      <NoRowRenderer
-                        unfilteredItems={networkFrames}
-                        clearSearchTerm={clearSearchTerm}
+            <Flex
+              direction="column"
+              height="100%"
+              minHeight={0}
+              overflow="hidden"
+              position="relative"
+            >
+              <Flex flex={1} direction="column" minHeight={0} position="relative">
+                <VirtualTable ref={wrapperRef}>
+                  <VirtualTable.BodyScrollContainer ref={scrollContainerRef}>
+                    <VirtualTable.HeaderViewport style={{width: totalColumnWidth}}>
+                      <VirtualTable.HeaderRow
+                        style={{
+                          gridTemplateColumns,
+                        }}
                       >
-                        {replay?.getReplay()?.sdk.name?.includes('flutter')
-                          ? tct(
-                              'No network requests recorded. Make sure you are using either the [link1:Sentry Dio] or the [link2:Sentry HTTP] integration.',
-                              {
-                                link1: (
-                                  <ExternalLink href="https://docs.sentry.io/platforms/dart/integrations/dio/" />
-                                ),
-                                link2: (
-                                  <ExternalLink href="https://docs.sentry.io/platforms/dart/integrations/http-integration/" />
-                                ),
-                              }
-                            )
-                          : t('No network requests recorded')}
-                      </NoRowRenderer>
-                    </VirtualTable.NoRowsContainer>
-                  ) : (
-                    <VirtualTable.Content
-                      style={{
-                        height: virtualizer.getTotalSize(),
-                        width: totalColumnWidth,
-                      }}
-                    >
-                      <VirtualTable.Offset
-                        offset={virtualRows[0]?.start ?? 0}
-                        style={{width: totalColumnWidth}}
+                        {Array.from({length: COLUMN_COUNT}, (_, columnIndex) => (
+                          <NetworkHeaderCell
+                            key={columnIndex}
+                            handleSort={handleSort}
+                            index={columnIndex}
+                            sortConfig={sortConfig}
+                            style={{height: NETWORK_TABLE_HEADER_HEIGHT}}
+                          />
+                        ))}
+                      </VirtualTable.HeaderRow>
+                    </VirtualTable.HeaderViewport>
+                    {items.length === 0 ? (
+                      <VirtualTable.NoRowsContainer>
+                        <NoRowRenderer
+                          unfilteredItems={networkFrames}
+                          clearSearchTerm={clearSearchTerm}
+                        >
+                          {replay?.getReplay()?.sdk.name?.includes('flutter')
+                            ? tct(
+                                'No network requests recorded. Make sure you are using either the [link1:Sentry Dio] or the [link2:Sentry HTTP] integration.',
+                                {
+                                  link1: (
+                                    <ExternalLink href="https://docs.sentry.io/platforms/dart/integrations/dio/" />
+                                  ),
+                                  link2: (
+                                    <ExternalLink href="https://docs.sentry.io/platforms/dart/integrations/http-integration/" />
+                                  ),
+                                }
+                              )
+                            : t('No network requests recorded')}
+                        </NoRowRenderer>
+                      </VirtualTable.NoRowsContainer>
+                    ) : (
+                      <VirtualTable.Content
+                        style={{
+                          height: virtualizer.getTotalSize(),
+                          width: totalColumnWidth,
+                        }}
                       >
-                        {virtualRows.map(virtualRow => {
-                          const network = items[virtualRow.index];
-                          if (!network) {
-                            return null;
-                          }
+                        <VirtualTable.Offset
+                          offset={virtualRows[0]?.start ?? 0}
+                          style={{width: totalColumnWidth}}
+                        >
+                          {virtualRows.map(virtualRow => {
+                            const network = pageItems[virtualRow.index];
+                            if (!network) {
+                              return null;
+                            }
 
-                          const rowIndex = virtualRow.index + 1;
-                          const isByTimestamp = sortConfig.by === 'startTimestamp';
-                          const hasOccurred = currentTime >= network.offsetMs;
-                          const isBeforeHover =
-                            currentHoverTime === undefined ||
-                            currentHoverTime >= network.offsetMs;
-                          const isAsc = isByTimestamp ? sortConfig.asc : false;
+                            const rowIndex = pageOffset + virtualRow.index + 1;
+                            const isByTimestamp = sortConfig.by === 'startTimestamp';
+                            const hasOccurred = currentTime >= network.offsetMs;
+                            const isBeforeHover =
+                              currentHoverTime === undefined ||
+                              currentHoverTime >= network.offsetMs;
+                            const isAsc = isByTimestamp ? sortConfig.asc : false;
 
-                          const rowClassName = getTimelineRowClassName({
-                            hasHoverTime: currentHoverTime !== undefined,
-                            hasOccurred,
-                            isAsc,
-                            isBeforeHover,
-                            isByTimestamp,
-                            isLastDataRow: virtualRow.index === items.length - 1,
-                          });
+                            const rowClassName = getTimelineRowClassName({
+                              hasHoverTime: currentHoverTime !== undefined,
+                              hasOccurred,
+                              isAsc,
+                              isBeforeHover,
+                              isByTimestamp,
+                              isLastDataRow:
+                                pageOffset + virtualRow.index === items.length - 1,
+                            });
 
-                          return (
-                            <VirtualTable.BodyRow
-                              useTransparentBorders
-                              key={virtualRow.key}
-                              className={rowClassName}
-                              data-index={virtualRow.index}
-                              style={{
-                                gridTemplateColumns,
-                                height: BODY_HEIGHT,
-                              }}
-                            >
-                              {Array.from({length: COLUMN_COUNT}, (_, columnIndex) => (
-                                <NetworkTableCell
-                                  key={`${virtualRow.key}-${columnIndex}`}
-                                  columnIndex={columnIndex}
-                                  frame={network}
-                                  onMouseEnter={onMouseEnter}
-                                  onMouseLeave={onMouseLeave}
-                                  onClickCell={onClickCell}
-                                  onClickTimestamp={onClickTimestamp}
-                                  rowIndex={rowIndex}
-                                  startTimestampMs={startTimestampMs}
-                                  style={{height: BODY_HEIGHT}}
-                                />
-                              ))}
-                            </VirtualTable.BodyRow>
-                          );
-                        })}
-                      </VirtualTable.Offset>
-                    </VirtualTable.Content>
-                  )}
-                </VirtualTable.BodyScrollContainer>
-              </VirtualTable>
-              {sortConfig.by === 'startTimestamp' && items.length ? (
-                <JumpButtons
-                  jump={showJumpUpButton ? 'up' : showJumpDownButton ? 'down' : undefined}
-                  onClick={onClickToJump}
-                  tableHeaderHeight={HEADER_HEIGHT}
-                />
-              ) : null}
-            </OverflowHidden>
+                            return (
+                              <VirtualTable.BodyRow
+                                useTransparentBorders
+                                key={virtualRow.key}
+                                className={rowClassName}
+                                data-index={virtualRow.index}
+                                style={{
+                                  gridTemplateColumns,
+                                  height: NETWORK_TABLE_BODY_ROW_HEIGHT,
+                                }}
+                              >
+                                {Array.from({length: COLUMN_COUNT}, (_, columnIndex) => (
+                                  <NetworkTableCell
+                                    key={`${virtualRow.key}-${columnIndex}`}
+                                    columnIndex={columnIndex}
+                                    frame={network}
+                                    onMouseEnter={onMouseEnter}
+                                    onMouseLeave={onMouseLeave}
+                                    onClickCell={onClickCell}
+                                    onClickTimestamp={onClickTimestamp}
+                                    rowIndex={rowIndex}
+                                    startTimestampMs={startTimestampMs}
+                                    style={{height: NETWORK_TABLE_BODY_ROW_HEIGHT}}
+                                  />
+                                ))}
+                              </VirtualTable.BodyRow>
+                            );
+                          })}
+                        </VirtualTable.Offset>
+                      </VirtualTable.Content>
+                    )}
+                  </VirtualTable.BodyScrollContainer>
+                </VirtualTable>
+                {sortConfig.by === 'startTimestamp' && items.length ? (
+                  <JumpButtons
+                    jump={
+                      showJumpUpButton ? 'up' : showJumpDownButton ? 'down' : undefined
+                    }
+                    onClick={onClickToJump}
+                    tableHeaderHeight={NETWORK_TABLE_HEADER_HEIGHT}
+                  />
+                ) : null}
+              </Flex>
+              <NetworkPaginationRow
+                onNextPage={onNextPage}
+                onPreviousPage={onPreviousPage}
+                pageOffset={pageOffset}
+                safePage={safePage}
+                totalCount={items.length}
+                totalPages={totalPages}
+              />
+            </Flex>
           ) : (
             <Placeholder height="100%" />
           )}

--- a/static/app/views/replays/detail/network/networkPaginationRow.tsx
+++ b/static/app/views/replays/detail/network/networkPaginationRow.tsx
@@ -1,0 +1,49 @@
+import {PaginationFooter} from '@sentry/scraps/paginationFooter';
+
+import {tct} from 'sentry/locale';
+import {NETWORK_LIST_PAGE_SIZE} from 'sentry/views/replays/detail/network/constants';
+
+type Props = {
+  onNextPage: () => void;
+  onPreviousPage: () => void;
+  pageOffset: number;
+  safePage: number;
+  totalCount: number;
+  totalPages: number;
+};
+
+export function NetworkPaginationRow({
+  onNextPage,
+  onPreviousPage,
+  pageOffset,
+  safePage,
+  totalCount,
+  totalPages,
+}: Props) {
+  if (totalCount <= NETWORK_LIST_PAGE_SIZE) {
+    return null;
+  }
+
+  const rangeStart = pageOffset + 1;
+  const rangeEnd = Math.min(pageOffset + NETWORK_LIST_PAGE_SIZE, totalCount);
+
+  return (
+    <PaginationFooter
+      background="primary"
+      borderTop="primary"
+      caption={tct('[start]–[end] of [total]', {
+        start: rangeStart.toLocaleString(),
+        end: rangeEnd.toLocaleString(),
+        total: totalCount.toLocaleString(),
+      })}
+      flexShrink={0}
+      isNextDisabled={safePage >= totalPages - 1}
+      isPreviousDisabled={safePage === 0}
+      padding="sm md"
+      size="small"
+      width="100%"
+      onNext={onNextPage}
+      onPrevious={onPreviousPage}
+    />
+  );
+}

--- a/static/app/views/replays/detail/network/networkTableLayout.ts
+++ b/static/app/views/replays/detail/network/networkTableLayout.ts
@@ -1,0 +1,10 @@
+/** Layout and virtualized-grid sizing for the replay Network requests table. */
+export const NETWORK_TABLE_HEADER_HEIGHT = 25;
+export const NETWORK_TABLE_BODY_ROW_HEIGHT = 25;
+export const NETWORK_DETAILS_SPLIT_HANDLE_HEIGHT = 90;
+
+export const NETWORK_TABLE_DEFAULT_COLUMN_WIDTH = 88;
+export const NETWORK_TABLE_DYNAMIC_COLUMN_INDEX = 2;
+export const NETWORK_TABLE_MIN_DYNAMIC_COLUMN_WIDTH = 180;
+export const NETWORK_TABLE_OVERSCAN = 20;
+export const NETWORK_TABLE_STATIC_COLUMN_WIDTHS = [76, 76, 0, 88, 88, 98, 116];

--- a/static/app/views/replays/detail/network/useNetworkFilters.spec.tsx
+++ b/static/app/views/replays/detail/network/useNetworkFilters.spec.tsx
@@ -217,6 +217,7 @@ describe('useNetworkFilters', () => {
         query: {
           n_detail_row: '0',
           n_detail_tab: 'response',
+          n_page: '2',
         },
       } as Location<FilterFields>)
       .mockReturnValueOnce({
@@ -225,6 +226,7 @@ describe('useNetworkFilters', () => {
           f_n_type: [TYPE_OPTION.value],
           n_detail_row: '0',
           n_detail_tab: 'response',
+          n_page: '2',
         },
       } as Location<FilterFields>)
       .mockReturnValueOnce({
@@ -234,6 +236,7 @@ describe('useNetworkFilters', () => {
           f_n_status: [STATUS_OPTION.value],
           n_detail_row: '0',
           n_detail_tab: 'response',
+          n_page: '2',
         },
       } as Location<FilterFields>);
 

--- a/static/app/views/replays/detail/network/useNetworkFilters.tsx
+++ b/static/app/views/replays/detail/network/useNetworkFilters.tsx
@@ -25,6 +25,7 @@ export type FilterFields = {
   f_n_type: string[];
   n_detail_row?: string;
   n_detail_tab?: string;
+  n_page?: string;
 };
 
 type Options = {
@@ -76,6 +77,7 @@ export function useNetworkFilters({networkFrames}: Options): Return {
         ...arg,
         n_detail_row: undefined,
         n_detail_tab: undefined,
+        n_page: undefined,
       });
     },
     [setFilter]

--- a/static/app/views/replays/detail/network/useNetworkListTable.ts
+++ b/static/app/views/replays/detail/network/useNetworkListTable.ts
@@ -1,0 +1,198 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MutableRefObject,
+} from 'react';
+import type {VirtualItem, Virtualizer} from '@tanstack/react-virtual';
+import {parseAsInteger, useQueryState} from 'nuqs';
+
+import type {VisibleRange} from 'sentry/components/replays/useJumpButtons';
+import type {SpanFrame} from 'sentry/utils/replays/types';
+import {NETWORK_LIST_PAGE_SIZE} from 'sentry/views/replays/detail/network/constants';
+import {getVisibleRangeFromVirtualRows} from 'sentry/views/replays/detail/virtualizedTableUtils';
+
+type SetPage = (
+  value: number | null | ((old: number | null) => number | null)
+) => Promise<URLSearchParams>;
+
+/**
+ * URL pagination, page window, clamp, jump-to-row, and prev/next for the replay Network table.
+ */
+export function useNetworkListPaging(items: SpanFrame[], replayId: string | undefined) {
+  const [page, setPage] = useQueryState(
+    'n_page',
+    parseAsInteger.withDefault(0).withOptions({history: 'push', throttleMs: 0})
+  );
+
+  const maxPageIndex = useMemo(
+    () =>
+      items.length === 0
+        ? 0
+        : Math.max(0, Math.ceil(items.length / NETWORK_LIST_PAGE_SIZE) - 1),
+    [items.length]
+  );
+
+  const safePage = Math.min(page, maxPageIndex);
+
+  const pageOffset = safePage * NETWORK_LIST_PAGE_SIZE;
+  const pageItems = useMemo(
+    () => items.slice(pageOffset, pageOffset + NETWORK_LIST_PAGE_SIZE),
+    [items, pageOffset]
+  );
+
+  const totalPages = maxPageIndex + 1;
+
+  const pendingScrollToIndexRef = useRef<number | null>(null);
+  /** Bumped on every scroll-to-row request so the virtualizer effect runs even when `safePage` is unchanged. */
+  const [scrollGeneration, setScrollGeneration] = useState(0);
+  const didInitialDetailPageSyncRef = useRef(false);
+
+  useEffect(() => {
+    didInitialDetailPageSyncRef.current = false;
+  }, [replayId]);
+
+  useEffect(() => {
+    if (items.length === 0) {
+      return;
+    }
+    if (page > maxPageIndex) {
+      pendingScrollToIndexRef.current = 0;
+      setPage(maxPageIndex);
+    }
+  }, [page, maxPageIndex, items.length, setPage]);
+
+  const handleScrollToTableRow = useCallback(
+    (row: number) => {
+      const global0 = row - 1;
+      const targetPage = Math.floor(global0 / NETWORK_LIST_PAGE_SIZE);
+      const localIndex = global0 % NETWORK_LIST_PAGE_SIZE;
+      pendingScrollToIndexRef.current = localIndex;
+      setPage(targetPage);
+      setScrollGeneration(g => g + 1);
+    },
+    [setPage]
+  );
+
+  const onPreviousPage = useCallback(() => {
+    pendingScrollToIndexRef.current = 0;
+    setPage(p => Math.max(0, p - 1));
+  }, [setPage]);
+
+  const onNextPage = useCallback(() => {
+    pendingScrollToIndexRef.current = 0;
+    setPage(p => Math.min(maxPageIndex, p + 1));
+  }, [maxPageIndex, setPage]);
+
+  return {
+    didInitialDetailPageSyncRef,
+    handleScrollToTableRow,
+    onNextPage,
+    onPreviousPage,
+    pageItems,
+    pageOffset,
+    pendingScrollToIndexRef,
+    safePage,
+    scrollGeneration,
+    setPage,
+    totalPages,
+  };
+}
+
+/**
+ * After `useVirtualizedGrid`: apply pending scroll to the page window and compute jump-button visible range.
+ */
+export function useNetworkListVirtualSync({
+  pageItemsLength,
+  pageOffset,
+  pendingScrollToIndexRef,
+  safePage,
+  scrollGeneration,
+  virtualRows,
+  virtualizer,
+}: {
+  pageItemsLength: number;
+  pageOffset: number;
+  pendingScrollToIndexRef: MutableRefObject<number | null>;
+  safePage: number;
+  scrollGeneration: number;
+  virtualRows: VirtualItem[];
+  virtualizer: Virtualizer<HTMLDivElement, Element>;
+}): {visibleRange: VisibleRange} {
+  useEffect(() => {
+    const idx = pendingScrollToIndexRef.current;
+    if (idx === null) {
+      return undefined;
+    }
+    pendingScrollToIndexRef.current = null;
+    const timer = window.setTimeout(() => {
+      virtualizer.scrollToIndex(idx, {align: 'auto'});
+    }, 50);
+    return () => {
+      window.clearTimeout(timer);
+    };
+    // scrollGeneration: same-page jump (e.g. Jump to current timestamp) must re-run without a page change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- pendingScrollToIndexRef is a stable ref
+  }, [safePage, virtualizer, pageItemsLength, scrollGeneration]);
+
+  const visibleRange = useMemo<VisibleRange>(() => {
+    return getVisibleRangeFromVirtualRows({
+      indexOffset: pageOffset + 1,
+      scrollOffset: virtualizer.scrollOffset ?? 0,
+      viewportHeight: virtualizer.scrollRect?.height ?? 0,
+      virtualRows,
+    });
+  }, [pageOffset, virtualRows, virtualizer.scrollOffset, virtualizer.scrollRect?.height]);
+
+  return {visibleRange};
+}
+
+/**
+ * Call after `useDetailsSplit`: align `n_page` with `n_detail_row` on first load per replay.
+ */
+export function useNetworkListDetailUrlPageSync({
+  didInitialDetailPageSyncRef,
+  itemsLength,
+  pendingScrollToIndexRef,
+  replayId,
+  safePage,
+  selectedIndex,
+  setPage,
+}: {
+  didInitialDetailPageSyncRef: MutableRefObject<boolean>;
+  itemsLength: number;
+  pendingScrollToIndexRef: MutableRefObject<number | null>;
+  replayId: string | undefined;
+  safePage: number;
+  selectedIndex: number | null;
+  setPage: SetPage;
+}) {
+  useEffect(() => {
+    if (!replayId || itemsLength === 0) {
+      return;
+    }
+    if (didInitialDetailPageSyncRef.current) {
+      return;
+    }
+    if (selectedIndex === null || selectedIndex >= itemsLength) {
+      didInitialDetailPageSyncRef.current = true;
+      return;
+    }
+    const targetPage = Math.floor(selectedIndex / NETWORK_LIST_PAGE_SIZE);
+    if (targetPage !== safePage) {
+      pendingScrollToIndexRef.current = selectedIndex % NETWORK_LIST_PAGE_SIZE;
+      setPage(targetPage);
+    }
+    didInitialDetailPageSyncRef.current = true;
+  }, [
+    didInitialDetailPageSyncRef,
+    itemsLength,
+    pendingScrollToIndexRef,
+    replayId,
+    selectedIndex,
+    safePage,
+    setPage,
+  ]);
+}

--- a/static/app/views/replays/detail/network/useSortNetwork.tsx
+++ b/static/app/views/replays/detail/network/useSortNetwork.tsx
@@ -1,5 +1,11 @@
 import {useCallback, useMemo} from 'react';
-import {parseAsBoolean, parseAsString, parseAsStringLiteral, useQueryState} from 'nuqs';
+import {
+  parseAsBoolean,
+  parseAsInteger,
+  parseAsString,
+  parseAsStringLiteral,
+  useQueryState,
+} from 'nuqs';
 
 import type {SpanFrame} from 'sentry/utils/replays/types';
 
@@ -36,6 +42,10 @@ export function useSortNetwork({items}: Opts) {
     'n_detail_row',
     parseAsString.withDefault('').withOptions({history: 'push', throttleMs: 0})
   );
+  const [, setNetworkPage] = useQueryState(
+    'n_page',
+    parseAsInteger.withDefault(0).withOptions({history: 'push', throttleMs: 0})
+  );
 
   const sortConfig = useMemo(
     () =>
@@ -58,8 +68,9 @@ export function useSortNetwork({items}: Opts) {
         setSortBy(fieldName);
       }
       setDetailRow('');
+      setNetworkPage(0);
     },
-    [sortConfig, setSortAsc, setSortBy, setDetailRow]
+    [sortConfig, setSortAsc, setSortBy, setDetailRow, setNetworkPage]
   );
 
   return {


### PR DESCRIPTION
Add a shared `PaginationFooter` scraps component and wire it into the issues stream `Pagination` plus the replay Network tab, which now paginates long request lists.

`PaginationFooter` exposes `size` (`normal` | `small`) and optional `buttonSize` for legacy icon-button scales. A barrel `index.tsx` makes `@sentry/scraps/paginationFooter` resolve like other core packages. Storybook MDX lives under Navigation in the components catalog.

The replay Network tab uses URL state (`n_page`), slices rows per page for the virtualizer, and resets the page when filters or sort change. Jump to current timestamp could no-op when the target row stayed on the same page because the virtualizer effect only ran on page changes; incrementing a scroll generation on every scroll-to-row request fixes that.

`useNetworkListVirtualSync` types the virtualizer with `HTMLDivElement` to match `useVirtualizedGrid`.

Made with [Cursor](https://cursor.com)