### PR TITLE
ref(replays): Match network scroll-to-row with ErrorList

### DIFF
--- a/static/app/views/replays/detail/network/index.tsx
+++ b/static/app/views/replays/detail/network/index.tsx
@@ -86,9 +86,7 @@ export function NetworkList() {
 
   const handleScrollToTableRow = useCallback(
     (row: number) => {
-      setTimeout(() => {
-        virtualizer.scrollToIndex(row - 1, {align: 'auto'});
-      }, 50);
+      virtualizer.scrollToIndex(row - 1, {align: 'center', behavior: 'smooth'});
     },
     [virtualizer]
   );


### PR DESCRIPTION
The replay Network tab already virtualizes the full filtered/sorted list via `useVirtualizedGrid` (same strategy as ErrorList). This change only aligns **programmatic scroll** when opening a row’s details or using Jump to current timestamp.

We now call `virtualizer.scrollToIndex` with `align: 'center'` and `behavior: 'smooth'`, matching [`errorList/index.tsx`](static/app/views/replays/detail/errorList/index.tsx), instead of wrapping `scrollToIndex` in `setTimeout` with `align: 'auto'`.

Made with [Cursor](https://cursor.com)