### PR TITLE
feat(seer): Support autofix_automation_tuning in preference write path

### DIFF
--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -667,6 +667,7 @@ def _resolve_project_preference(
         repositories=[],
         automated_run_stopping_point=default_stopping_point,
         automation_handoff=default_handoff,
+        autofix_automation_tuning=project.get_option("sentry:autofix_automation_tuning"),
     )
 
     try:

--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -522,6 +522,10 @@ class AutofixOnCompletionHook(ExplorerOnCompletionHook):
                     extra={"run_id": run_id, "organization_id": organization.id},
                 )
                 return
+            if preference is not None:
+                preference.autofix_automation_tuning = project.get_option(
+                    "sentry:autofix_automation_tuning"
+                )
 
         if not preference or preference.automation_handoff is None:
             return

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -18,6 +18,7 @@ from urllib3.util.retry import Retry
 from sentry import features, options, projectoptions, ratelimits
 from sentry.constants import (
     AUTO_OPEN_PRS_DEFAULT,
+    DEFAULT_AUTOFIX_AUTOMATION_TUNING_DEFAULT,
     SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT,
     DataCategory,
     ObjectStatus,
@@ -598,6 +599,12 @@ def _write_preference_project_options(project: Project, preference: SeerProjectP
         project.delete_option("sentry:seer_automation_handoff_integration_id")
         project.delete_option("sentry:seer_automation_handoff_auto_create_pr")
 
+    tuning = preference.autofix_automation_tuning
+    if tuning == DEFAULT_AUTOFIX_AUTOMATION_TUNING_DEFAULT:
+        project.delete_option("sentry:autofix_automation_tuning")
+    else:
+        project.update_option("sentry:autofix_automation_tuning", tuning.value)
+
 
 def _write_preferences_to_sentry_db(
     project_preferences: list[tuple[Project, SeerProjectPreference]],
@@ -677,17 +684,14 @@ def _write_preferences_to_sentry_db(
 
 
 def write_preference_to_sentry_db(project: Project, preference: SeerProjectPreference) -> None:
-    """Write a single Seer project preference to ProjectOption and SeerProjectRepository.
-    TODO(AIML-2753): Add support for writing autofix_automation_tuning"""
+    """Write a single Seer project preference to ProjectOption and SeerProjectRepository."""
     _write_preferences_to_sentry_db([(project, preference)])
 
 
 def bulk_write_preferences_to_sentry_db(
     projects: list[Project], preferences: list[SeerProjectPreference]
 ) -> None:
-    """Write multiple Seer project preferences using bulk operations.
-    TODO(AIML-2753): Add support for writing autofix_automation_tuning
-    """
+    """Write multiple Seer project preferences using bulk operations."""
     projects_by_id = {p.id: p for p in projects}
 
     project_preferences: list[tuple[Project, SeerProjectPreference]] = []

--- a/src/sentry/seer/endpoints/organization_autofix_automation_settings.py
+++ b/src/sentry/seer/endpoints/organization_autofix_automation_settings.py
@@ -381,6 +381,12 @@ class OrganizationAutofixAutomationSettingsEndpoint(OrganizationEndpoint):
                 validated_preferences = [
                     SeerProjectPreference.validate(pref) for pref in preferences_to_set
                 ]
+                # Preserve current autofix_automation_tuning (re-read after the
+                # in-transaction option update above) so the write doesn't clobber it.
+                for pref in validated_preferences:
+                    pref.autofix_automation_tuning = projects_by_id[pref.project_id].get_option(
+                        "sentry:autofix_automation_tuning"
+                    )
                 # Seer API responses don't include repository_id.
                 # Resolve before dual-writing so repos aren't skipped.
                 # This will not be necessary once we start keying by repo ID.

--- a/src/sentry/seer/endpoints/project_seer_preferences.py
+++ b/src/sentry/seer/endpoints/project_seer_preferences.py
@@ -127,6 +127,7 @@ class ProjectSeerPreferencesEndpoint(ProjectEndpoint):
                 **serializer.validated_data,
                 "organization_id": project.organization.id,
                 "project_id": project.id,
+                "autofix_automation_tuning": project.get_option("sentry:autofix_automation_tuning"),
             }
         )
         viewer_context = SeerViewerContext(

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -633,6 +633,10 @@ def trigger_coding_agent_launch(
                     preference = read_preference_from_sentry_db(project)
                 else:
                     preference = get_project_seer_preferences(project.id).preference
+                    if preference is not None:
+                        preference.autofix_automation_tuning = project.get_option(
+                            "sentry:autofix_automation_tuning"
+                        )
 
                 if preference and preference.automation_handoff is not None:
                     updated_preference = preference.copy(update={"automation_handoff": None})

--- a/src/sentry/seer/models/seer_api_models.py
+++ b/src/sentry/seer/models/seer_api_models.py
@@ -98,9 +98,6 @@ class SeerProjectPreference(BaseModel):
     repositories: list[SeerRepoDefinition]
     automated_run_stopping_point: str | None = None
     automation_handoff: SeerAutomationHandoffConfiguration | None = None
-    # Currently we correctly get autofix_automation_tuning in the read path - but
-    # not the write path.
-    # TODO(AIML-2753): Support this field in the write path and not just the read path.
     autofix_automation_tuning: AutofixAutomationTuningSettings = AutofixAutomationTuningSettings.OFF
 
 

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -583,6 +583,7 @@ def set_default_project_seer_preferences(organization: Organization, project: Pr
         repositories=[],
         automated_run_stopping_point=stopping_point,
         automation_handoff=automation_handoff,
+        autofix_automation_tuning=project.get_option("sentry:autofix_automation_tuning"),
     )
 
     try:

--- a/src/sentry/tasks/seer/autofix.py
+++ b/src/sentry/tasks/seer/autofix.py
@@ -303,6 +303,11 @@ def configure_seer_for_existing_org(organization_id: int) -> None:
                 validated_preferences = [
                     SeerProjectPreference.validate(pref) for pref in preferences_to_set
                 ]
+                # Preserve existing autofix_automation_tuning so the write doesn't clobber it.
+                for pref in validated_preferences:
+                    pref.autofix_automation_tuning = projects_by_id[pref.project_id].get_option(
+                        "sentry:autofix_automation_tuning"
+                    )
                 # Seer API responses don't include repository_id.
                 # Resolve before dual-writing so repos aren't skipped.
                 # This will not be necessary once we start keying by repo ID.

--- a/tests/sentry/seer/autofix/test_autofix_utils.py
+++ b/tests/sentry/seer/autofix/test_autofix_utils.py
@@ -5,6 +5,7 @@ import orjson
 import pytest
 
 from sentry.constants import SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT, DataCategory
+from sentry.models.options.project_option import ProjectOption
 from sentry.seer.autofix.constants import AutofixAutomationTuningSettings, AutofixStatus
 from sentry.seer.autofix.trigger import is_issue_eligible_for_seer_automation
 from sentry.seer.autofix.utils import (
@@ -1000,6 +1001,47 @@ class TestWritePreferencesToSentryDb(TestCase):
         assert self.project.get_option("sentry:seer_automation_handoff_target") is None
         assert self.project.get_option("sentry:seer_automation_handoff_integration_id") is None
         assert self.project.get_option("sentry:seer_automation_handoff_auto_create_pr") is False
+        assert (
+            self.project.get_option("sentry:autofix_automation_tuning")
+            == AutofixAutomationTuningSettings.OFF
+        )
+
+    def test_writes_autofix_automation_tuning(self) -> None:
+        preference = SeerProjectPreference(
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            repositories=[],
+            autofix_automation_tuning=AutofixAutomationTuningSettings.HIGH,
+        )
+
+        write_preference_to_sentry_db(self.project, preference)
+
+        assert (
+            self.project.get_option("sentry:autofix_automation_tuning")
+            == AutofixAutomationTuningSettings.HIGH
+        )
+
+    def test_resets_autofix_automation_tuning_to_default(self) -> None:
+        self.project.update_option(
+            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.HIGH
+        )
+
+        preference = SeerProjectPreference(
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+            repositories=[],
+            autofix_automation_tuning=AutofixAutomationTuningSettings.OFF,
+        )
+
+        write_preference_to_sentry_db(self.project, preference)
+
+        assert (
+            self.project.get_option("sentry:autofix_automation_tuning")
+            == AutofixAutomationTuningSettings.OFF
+        )
+        assert not ProjectOption.objects.filter(
+            project=self.project, key="sentry:autofix_automation_tuning"
+        ).exists()
 
     def test_creates_seer_project_repository_with_branch_overrides(self) -> None:
         preference = SeerProjectPreference(


### PR DESCRIPTION
Write the `autofix_automation_tuning` field from `SeerProjectPreference` to the `sentry:autofix_automation_tuning` project option when preferences are written to the Sentry DB. The read path already populates this field from the same option, so the write path was asymmetric — round-tripping a preference through `read_preference_from_sentry_db` → `write_preference_to_sentry_db` would reset tuning to `OFF`.

The write logic mirrors the existing stopping-point pattern in `_write_preference_project_options`: non-default values call `update_option`, and the default (`DEFAULT_AUTOFIX_AUTOMATION_TUNING_DEFAULT` = `OFF`) calls `delete_option` so the project falls back to the registered default.

## Caller updates

Making the write authoritative exposed a latent issue: most existing callers construct `SeerProjectPreference` without populating `autofix_automation_tuning` — they relied on the write path ignoring it. Without fixes, every dual-write would clobber the option back to `OFF`. To preserve existing tuning, each caller now carries the current value forward:

- **`similarity/utils.py` (`set_default_project_seer_preferences`)** — project creation path; populates the field from the project's current option (which was just set by `set_default_project_autofix_automation_tuning`).
- **`autofix/autofix.py` (`resolve_project_preference`)** — fresh preference for unconfigured projects; populates from the project option.
- **`autofix/on_completion_hook.py` and `endpoints/seer_rpc.py`** — read-then-write paths; when reading from Seer API (flag off), patches tuning in from the project option so the subsequent write is correct.
- **`endpoints/organization_autofix_automation_settings.py`** — bulk settings endpoint; re-reads tuning from each project option right before dual-writing, so an in-request tuning update (done via `project.update_option` earlier in the transaction) is preserved.
- **`endpoints/project_seer_preferences.py`** — POST endpoint has no tuning input field; carries the existing option through on validation.
- **`tasks/seer/autofix.py`** — sets tuning on each validated preference before dual-writing.

Removes the `TODO(AIML-2753)` markers from `seer_api_models.py` and both write helpers in `seer/autofix/utils.py`.

Refs AIML-2753