### PR TITLE
ref(ai-monitoring): Remove legacy aiModelCosts config and fetch_ai_model_costs task

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1205,11 +1205,6 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
         "task": "relocation:sentry.relocation.transfer.find_relocation_transfer_region",
         "schedule": crontab("*/5", "*", "*", "*", "*"),
     },
-    # TODO(constantinius): Remove fetch-ai-model-costs once all consumers have migrated to fetch-ai-model-metadata
-    "fetch-ai-model-costs": {
-        "task": "ai_agent_monitoring:sentry.tasks.ai_agent_monitoring.fetch_ai_model_costs",
-        "schedule": crontab("*/30", "*", "*", "*", "*"),
-    },
     "fetch-ai-model-metadata": {
         "task": "ai_agent_monitoring:sentry.tasks.ai_agent_monitoring.fetch_ai_model_metadata",
         "schedule": crontab("*/30", "*", "*", "*", "*"),

--- a/src/sentry/relay/config/ai_model_costs.py
+++ b/src/sentry/relay/config/ai_model_costs.py
@@ -11,32 +11,10 @@ logger = logging.getLogger(__name__)
 type ModelId = str
 
 
-# Legacy cache key for AI model costs (v2 flat format)
-# TODO(constantinius): Remove once all consumers have migrated to AI_MODEL_METADATA_CACHE_KEY
-AI_MODEL_COSTS_CACHE_KEY = "ai-model-costs:v2"
-AI_MODEL_COSTS_CACHE_TTL = 30 * 24 * 60 * 60
-
-# Cache key for storing LLM model metadata (v1 nested format)
+# Cache key for storing AI model metadata
 AI_MODEL_METADATA_CACHE_KEY = "ai-model-metadata:v1"
 # Cache timeout: 30 days (we re-fetch every 30 minutes, so this provides more than enough overlap)
 AI_MODEL_METADATA_CACHE_TTL = 30 * 24 * 60 * 60
-
-
-class AIModelCostV2(TypedDict):
-    """Legacy flat format. TODO(constantinius): Remove once all consumers have migrated."""
-
-    inputPerToken: float
-    outputPerToken: float
-    outputReasoningPerToken: float
-    inputCachedPerToken: float
-    inputCacheWritePerToken: float
-
-
-class AIModelCosts(TypedDict):
-    """Legacy config type. TODO(constantinius): Remove once all consumers have migrated."""
-
-    version: Required[int]
-    models: Required[dict[ModelId, AIModelCostV2]]
 
 
 class AIModelCost(TypedDict):
@@ -57,32 +35,14 @@ class AIModelMetadataConfig(TypedDict):
     models: Required[dict[ModelId, AIModelMetadata]]
 
 
-def ai_model_costs_config() -> AIModelCosts | None:
-    """
-    Legacy: Get AI model costs configuration.
-    TODO(constantinius): Remove once all consumers have migrated to ai_model_metadata_config.
-    """
-    if settings.SENTRY_AIR_GAP:
-        return None
-
-    cached_costs = cache.get(AI_MODEL_COSTS_CACHE_KEY)
-    if cached_costs is not None:
-        return cached_costs
-
-    if not settings.IS_DEV:
-        logger.warning("Empty model costs")
-
-    return None
-
-
 def ai_model_metadata_config() -> AIModelMetadataConfig | None:
     """
-    Get LLM model metadata configuration.
-    LLM model metadata is set in cache by a cron job,
+    Get AI model metadata configuration.
+    AI model metadata is set in cache by a cron job,
     if there is no metadata, it should be investigated why.
 
     Returns:
-        AIModelMetadataConfig containing cost and context size information for LLM models
+        AIModelMetadataConfig containing cost and context size information for AI models
     """
     if settings.SENTRY_AIR_GAP:
         return None
@@ -93,6 +53,6 @@ def ai_model_metadata_config() -> AIModelMetadataConfig | None:
 
     if not settings.IS_DEV:
         # in dev environment, we don't want to log this
-        logger.warning("Empty LLM model metadata")
+        logger.warning("Empty AI model metadata")
 
     return None

--- a/src/sentry/relay/globalconfig.py
+++ b/src/sentry/relay/globalconfig.py
@@ -1,12 +1,7 @@
 from typing import Any, TypedDict
 
 import sentry.options
-from sentry.relay.config.ai_model_costs import (
-    AIModelCosts,
-    AIModelMetadataConfig,
-    ai_model_costs_config,
-    ai_model_metadata_config,
-)
+from sentry.relay.config.ai_model_costs import AIModelMetadataConfig, ai_model_metadata_config
 from sentry.relay.config.measurements import MeasurementsConfig, get_measurements_config
 from sentry.relay.config.metric_extraction import (
     MetricExtractionGroups,
@@ -44,9 +39,6 @@ class SpanOpDefaults(TypedDict):
 
 class GlobalConfig(TypedDict, total=False):
     measurements: MeasurementsConfig
-    aiModelCosts: (
-        AIModelCosts | None
-    )  # TODO(constantinius): Remove once all consumers use aiModelMetadata
     aiModelMetadata: AIModelMetadataConfig | None
     metricExtraction: MetricExtractionGroups
     filters: GenericFiltersConfig | None
@@ -86,7 +78,6 @@ def get_global_config() -> GlobalConfig:
 
     global_config: GlobalConfig = {
         "measurements": get_measurements_config(),
-        "aiModelCosts": ai_model_costs_config(),  # TODO(constantinius): Remove once all consumers use aiModelMetadata
         "aiModelMetadata": ai_model_metadata_config(),
         "metricExtraction": global_metric_extraction_groups(),
         "spanOpDefaults": span_op_defaults(),

--- a/src/sentry/tasks/ai_agent_monitoring.py
+++ b/src/sentry/tasks/ai_agent_monitoring.py
@@ -6,13 +6,9 @@ from django.conf import settings
 
 from sentry.http import safe_urlopen
 from sentry.relay.config.ai_model_costs import (
-    AI_MODEL_COSTS_CACHE_KEY,
-    AI_MODEL_COSTS_CACHE_TTL,
     AI_MODEL_METADATA_CACHE_KEY,
     AI_MODEL_METADATA_CACHE_TTL,
     AIModelCost,
-    AIModelCosts,
-    AIModelCostV2,
     AIModelMetadata,
     AIModelMetadataConfig,
     ModelId,
@@ -75,7 +71,7 @@ def _create_prefix_glob_model_name(model_id: str) -> str:
     return f"*{model_id}"
 
 
-def _add_glob_model_names(models_dict: dict[ModelId, AIModelCostV2]) -> None:
+def _add_glob_model_names(models_dict: dict[ModelId, AIModelMetadata]) -> None:
     """
     Add glob versions of model names to the models dictionary.
 
@@ -102,262 +98,6 @@ def _add_glob_model_names(models_dict: dict[ModelId, AIModelCostV2]) -> None:
 
 
 @instrumented_task(
-    name="sentry.tasks.ai_agent_monitoring.fetch_ai_model_costs",
-    namespace=ai_agent_monitoring_tasks,
-    processing_deadline_duration=35,
-    expires=30,
-    silo_mode=SiloMode.CELL,
-)
-def fetch_ai_model_costs() -> None:
-    """
-    Fetch AI model costs from OpenRouter and models.dev APIs and store them in cache.
-
-    This task fetches model pricing data from both sources and converts it to
-    the AIModelCostV2 format for use by Sentry's LLM cost tracking.
-    OpenRouter prices take precedence over models.dev prices.
-    """
-
-    # this task shouldn't be run in an air gap environment
-    if settings.SENTRY_AIR_GAP:
-        return
-
-    models_dict: dict[ModelId, AIModelCostV2] = {}
-
-    # Fetch from OpenRouter API (takes precedence)
-    try:
-        openrouter_models = _fetch_openrouter_models()
-        models_dict.update(openrouter_models)
-    except Exception as e:
-        logger.warning(
-            "Failed to fetch AI model costs from OpenRouter API", extra={"error": str(e)}
-        )
-        # re-raise to fail the task
-        raise
-
-    # Fetch from models.dev API (only add models not already present)
-    try:
-        models_dev_models = _fetch_models_dev_models()
-        # Only add models that don't already exist (OpenRouter takes precedence)
-        for model_id, model_cost in models_dev_models.items():
-            if model_id not in models_dict:
-                models_dict[model_id] = model_cost
-
-    except Exception as e:
-        logger.warning(
-            "Failed to fetch AI model costs from models.dev API", extra={"error": str(e)}
-        )
-        # re-raise to fail the task
-        raise
-
-    # Add glob versions of model names for flexible matching
-    _add_glob_model_names(models_dict)
-
-    ai_model_costs: AIModelCosts = {"version": 2, "models": models_dict}
-    cache.set(AI_MODEL_COSTS_CACHE_KEY, ai_model_costs, AI_MODEL_COSTS_CACHE_TTL)
-
-
-def _fetch_openrouter_models() -> dict[ModelId, AIModelCostV2]:
-    """Fetch model costs from OpenRouter API
-    Example response:
-    {
-        "data": [
-            {
-                "id": "openai/gpt-4o-mini",
-                "name": "OpenAI: GPT-4o Mini",
-                "context_length": 1000000,
-                "pricing": {
-                    "prompt": "0.0000003",
-                    "completion": "0.00000165",
-                    "internal_reasoning": "0.0000003",
-                    "input_cache_read": "0.0000003",
-                    "input_cache_write": "0.00000125",
-                },
-            },
-        ]
-    }
-    """
-    response = safe_urlopen(OPENROUTER_MODELS_API_URL)
-    response.raise_for_status()
-
-    # Parse the response
-    data = response.json()
-
-    if not isinstance(data, dict) or "data" not in data:
-        raise ValueError("Invalid OpenRouter response format: missing 'data' field")
-
-    models_data = data["data"]
-    if not isinstance(models_data, list):
-        raise ValueError("Invalid OpenRouter response format: 'data' field is not a list")
-
-    # Convert to AIModelCostV2 format
-    models_dict: dict[ModelId, AIModelCostV2] = {}
-
-    for model_data in models_data:
-        if not isinstance(model_data, dict):
-            continue
-
-        model_id = model_data.get("id")
-        if not model_id:
-            continue
-
-        # OpenRouter includes provider name in the model ID, e.g. openai/gpt-4o-mini
-        # We need to extract the model name, since our SDKs only send the model name
-        # (e.g. gpt-4o-mini)
-        if "/" in model_id:
-            model_id = model_id.split("/", maxsplit=1)[1]
-
-        pricing = model_data.get("pricing", {})
-
-        # Convert pricing data to AIModelCostV2 format
-        # OpenRouter provides costs as strings, we need to convert to float
-        try:
-            ai_model_cost = AIModelCostV2(
-                inputPerToken=safe_float_conversion(pricing.get("prompt")),
-                outputPerToken=safe_float_conversion(pricing.get("completion")),
-                outputReasoningPerToken=safe_float_conversion(pricing.get("internal_reasoning")),
-                inputCachedPerToken=safe_float_conversion(pricing.get("input_cache_read")),
-                inputCacheWritePerToken=safe_float_conversion(pricing.get("input_cache_write")),
-            )
-
-            models_dict[model_id] = ai_model_cost
-
-        except (ValueError, TypeError) as e:
-            logger.warning(
-                "fetch_ai_model_costs.openrouter_model_parse_error",
-                extra={"model_id": model_id, "error": str(e)},
-            )
-            continue
-
-    return models_dict
-
-
-def _fetch_models_dev_models() -> dict[ModelId, AIModelCostV2]:
-    """Fetch model costs from models.dev API
-    Example response:
-    {
-        "openai": {
-            "models": {
-                "gpt-4": {
-                    "cost": {
-                        "input": 0.0000003,
-                        "output": 0.00000165,
-                        "cache_read": 0.0000003,
-                        "cache_write": 0.00000125,
-                    }
-                }
-            }
-        }
-    }
-
-    """
-    response = safe_urlopen(MODELS_DEV_API_URL)
-    response.raise_for_status()
-
-    # Parse the response
-    data = response.json()
-
-    if not isinstance(data, dict):
-        raise ValueError("Invalid models.dev response format: expected dict")
-
-    models_dict: dict[ModelId, AIModelCostV2] = {}
-
-    for provider_name, provider_data in data.items():
-        if not isinstance(provider_data, dict):
-            continue
-
-        models = provider_data.get("models", {})
-        if not isinstance(models, dict):
-            continue
-
-        for model_id, model_data in models.items():
-            if not isinstance(model_data, dict):
-                continue
-
-            cost_data = model_data.get("cost", {})
-            if not isinstance(cost_data, dict) or not cost_data:
-                # Skip models with no cost data or empty cost data
-                continue
-
-            # models.dev may include provider name in the model ID, e.g. google/gemini-2.0-flash-001
-            # We need to extract the model name, since our SDKs only send the model name
-            # (e.g. gemini-2.0-flash-001)
-            if "/" in model_id:
-                model_id = model_id.split("/", maxsplit=1)[1]
-
-            # Convert pricing data to AIModelCostV2 format
-            # models.dev provides costs as numbers, but for extra safety convert to our format
-            try:
-                ai_model_cost = AIModelCostV2(
-                    inputPerToken=safe_float_conversion(cost_data.get("input"))
-                    / 1000000,  # models.dev have prices per 1M tokens
-                    outputPerToken=safe_float_conversion(cost_data.get("output"))
-                    / 1000000,  # models.dev have price per 1M tokens
-                    outputReasoningPerToken=0.0,  # models.dev doesn't provide reasoning costs
-                    inputCachedPerToken=safe_float_conversion(cost_data.get("cache_read"))
-                    / 1000000,  # models.dev have price per 1M tokens
-                    inputCacheWritePerToken=safe_float_conversion(cost_data.get("cache_write"))
-                    / 1000000,  # models.dev have price per 1M tokens
-                )
-
-                models_dict[model_id] = ai_model_cost
-
-            except (ValueError, TypeError) as e:
-                logger.warning(
-                    "fetch_ai_model_costs.models_dev_model_parse_error",
-                    extra={"model_id": model_id, "provider": provider_name, "error": str(e)},
-                )
-                continue
-
-    return models_dict
-
-
-def safe_float_conversion(value: Any) -> float:
-    """
-    Safely convert a value to float, handling string inputs and None values.
-
-    Args:
-        value: The value to convert (could be string, float, int, or None)
-
-    Returns:
-        The float value, or 0.0 if the value is None or cannot be converted
-    """
-    if value is None:
-        return 0.0
-
-    if isinstance(value, (int, float)):
-        return float(value)
-
-    if isinstance(value, str):
-        try:
-            return float(value)
-        except ValueError:
-            return 0.0
-
-    return 0.0
-
-
-# ---------------------------------------------------------------------------
-# New task: fetch_ai_model_metadata
-# Fetches model costs + context size into the new AIModelMetadata format.
-# Runs alongside fetch_ai_model_costs during the migration period.
-# ---------------------------------------------------------------------------
-
-
-def _add_glob_model_names_metadata(models_dict: dict[ModelId, AIModelMetadata]) -> None:
-    """Add glob versions of model names to the metadata models dictionary."""
-    model_ids = list(models_dict.keys())
-
-    for model_id in model_ids:
-        normalized_model_id = _normalize_model_id(model_id)
-        if normalized_model_id != model_id and normalized_model_id not in models_dict:
-            models_dict[normalized_model_id] = models_dict[model_id]
-
-        prefix_glob_name = _create_prefix_glob_model_name(normalized_model_id)
-        if prefix_glob_name not in models_dict:
-            models_dict[prefix_glob_name] = models_dict[normalized_model_id]
-
-
-@instrumented_task(
     name="sentry.tasks.ai_agent_monitoring.fetch_ai_model_metadata",
     namespace=ai_agent_monitoring_tasks,
     processing_deadline_duration=35,
@@ -366,7 +106,7 @@ def _add_glob_model_names_metadata(models_dict: dict[ModelId, AIModelMetadata]) 
 )
 def fetch_ai_model_metadata() -> None:
     """
-    Fetch LLM model metadata (costs, context size) from OpenRouter and models.dev APIs
+    Fetch AI model metadata (costs, context size) from OpenRouter and models.dev APIs
     and store them in cache.
 
     This task fetches model pricing and context size data from both sources and
@@ -380,34 +120,34 @@ def fetch_ai_model_metadata() -> None:
 
     # Fetch from OpenRouter API (takes precedence)
     try:
-        openrouter_models = _fetch_openrouter_models_metadata()
+        openrouter_models = _fetch_openrouter_models()
         models_dict.update(openrouter_models)
     except Exception as e:
         logger.warning(
-            "Failed to fetch LLM model metadata from OpenRouter API", extra={"error": str(e)}
+            "Failed to fetch AI model metadata from OpenRouter API", extra={"error": str(e)}
         )
         raise
 
     # Fetch from models.dev API (only add models not already present)
     try:
-        models_dev_models = _fetch_models_dev_models_metadata()
+        models_dev_models = _fetch_models_dev_models()
         for model_id, model_metadata in models_dev_models.items():
             if model_id not in models_dict:
                 models_dict[model_id] = model_metadata
     except Exception as e:
         logger.warning(
-            "Failed to fetch LLM model metadata from models.dev API", extra={"error": str(e)}
+            "Failed to fetch AI model metadata from models.dev API", extra={"error": str(e)}
         )
         raise
 
     # Add glob versions of model names for flexible matching
-    _add_glob_model_names_metadata(models_dict)
+    _add_glob_model_names(models_dict)
 
     metadata_config: AIModelMetadataConfig = {"version": 1, "models": models_dict}
     cache.set(AI_MODEL_METADATA_CACHE_KEY, metadata_config, AI_MODEL_METADATA_CACHE_TTL)
 
 
-def _fetch_openrouter_models_metadata() -> dict[ModelId, AIModelMetadata]:
+def _fetch_openrouter_models() -> dict[ModelId, AIModelMetadata]:
     """Fetch model metadata from OpenRouter API.
 
     Example response:
@@ -486,7 +226,7 @@ def _fetch_openrouter_models_metadata() -> dict[ModelId, AIModelMetadata]:
     return models_dict
 
 
-def _fetch_models_dev_models_metadata() -> dict[ModelId, AIModelMetadata]:
+def _fetch_models_dev_models() -> dict[ModelId, AIModelMetadata]:
     """Fetch model metadata from models.dev API.
 
     Example response:
@@ -574,3 +314,28 @@ def _fetch_models_dev_models_metadata() -> dict[ModelId, AIModelMetadata]:
                 continue
 
     return models_dict
+
+
+def safe_float_conversion(value: Any) -> float:
+    """
+    Safely convert a value to float, handling string inputs and None values.
+
+    Args:
+        value: The value to convert (could be string, float, int, or None)
+
+    Returns:
+        The float value, or 0.0 if the value is None or cannot be converted
+    """
+    if value is None:
+        return 0.0
+
+    if isinstance(value, (int, float)):
+        return float(value)
+
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return 0.0
+
+    return 0.0

--- a/tests/sentry/tasks/test_ai_agent_monitoring.py
+++ b/tests/sentry/tasks/test_ai_agent_monitoring.py
@@ -1,15 +1,10 @@
 import pytest
 import responses
 
-from sentry.relay.config.ai_model_costs import (
-    AI_MODEL_COSTS_CACHE_KEY,
-    AI_MODEL_METADATA_CACHE_KEY,
-    AIModelMetadataConfig,
-)
+from sentry.relay.config.ai_model_costs import AI_MODEL_METADATA_CACHE_KEY, AIModelMetadataConfig
 from sentry.tasks.ai_agent_monitoring import (
     MODELS_DEV_API_URL,
     OPENROUTER_MODELS_API_URL,
-    fetch_ai_model_costs,
     fetch_ai_model_metadata,
 )
 from sentry.testutils.cases import TestCase
@@ -21,13 +16,6 @@ def _get_metadata_from_cache() -> AIModelMetadataConfig | None:
     Utility function to retrieve LLM model metadata from cache.
     """
     return cache.get(AI_MODEL_METADATA_CACHE_KEY)
-
-
-def _get_legacy_costs_from_cache():
-    """
-    Utility function to retrieve legacy AI model costs from cache.
-    """
-    return cache.get(AI_MODEL_COSTS_CACHE_KEY)
 
 
 MOCK_OPENROUTER_API_RESPONSE = {
@@ -190,7 +178,6 @@ class FetchAIModelMetadataTest(TestCase):
         super().setUp()
         # Clear cache before each test
         cache.delete(AI_MODEL_METADATA_CACHE_KEY)
-        cache.delete(AI_MODEL_COSTS_CACHE_KEY)
 
     def _mock_openrouter_api_response(self, mock_response: dict):
         responses.add(
@@ -630,50 +617,6 @@ class FetchAIModelMetadataTest(TestCase):
             gpt4o_mini_normalized["costs"]["outputPerToken"]
             == gpt4o_mini_prefix_glob["costs"]["outputPerToken"]
         )
-
-    @responses.activate
-    def test_fetch_ai_model_metadata_does_not_write_legacy_cache(self) -> None:
-        """Test that the new task only writes the new cache, not the legacy one"""
-        self._mock_openrouter_api_response(MOCK_OPENROUTER_API_RESPONSE)
-        self._mock_models_dev_api_response(MOCK_MODELS_DEV_API_RESPONSE)
-
-        fetch_ai_model_metadata()
-
-        # New cache should be populated
-        new_data = _get_metadata_from_cache()
-        assert new_data is not None
-        assert new_data.get("version") == 1
-
-        # Legacy cache should NOT be populated by this task
-        legacy_data = _get_legacy_costs_from_cache()
-        assert legacy_data is None
-
-    @responses.activate
-    def test_fetch_ai_model_costs_independent(self) -> None:
-        """Test that the legacy task writes only the legacy cache, independently"""
-        self._mock_openrouter_api_response(MOCK_OPENROUTER_API_RESPONSE)
-        self._mock_models_dev_api_response(MOCK_MODELS_DEV_API_RESPONSE)
-
-        fetch_ai_model_costs()
-
-        # Legacy cache should be populated
-        legacy_data = _get_legacy_costs_from_cache()
-        assert legacy_data is not None
-        assert legacy_data.get("version") == 2
-
-        legacy_models = legacy_data.get("models")
-        assert legacy_models is not None
-
-        # Legacy format: flat cost fields, no nested "costs", no contextSize
-        gpt4 = legacy_models["gpt-4"]
-        assert gpt4.get("inputPerToken") == 0.0000003
-        assert gpt4.get("outputPerToken") == 0.00000165
-        assert "costs" not in gpt4
-        assert "contextSize" not in gpt4
-
-        # New cache should NOT be populated by this task
-        new_data = _get_metadata_from_cache()
-        assert new_data is None
 
     def test_normalize_model_id(self) -> None:
         """Test model ID normalization with various date and version formats"""


### PR DESCRIPTION
Remove the legacy flat AIModelCostV2 format and all associated code:

- Remove AIModelCostV2, AIModelCosts types
- Remove AI_MODEL_COSTS_CACHE_KEY/TTL constants
- Remove ai_model_costs_config() function
- Remove fetch_ai_model_costs task and its helpers (_fetch_openrouter_models, _fetch_models_dev_models, _add_glob_model_names returning AIModelCostV2)
- Remove fetch-ai-model-costs cron entry from server.py
- Remove aiModelCosts field from GlobalConfig
- Remove legacy test helpers and tests
- Rename _add_glob_model_names_metadata back to _add_glob_model_names
- Rename _fetch_openrouter_models_metadata back to _fetch_openrouter_models
- Rename _fetch_models_dev_models_metadata back to _fetch_models_dev_models

Only fetch_ai_model_metadata remains, writing to ai-model-metadata:v1.

Co-Authored-By: Claude Sonnet 4 <noreply@anthropic.com>

Contributes to https://linear.app/getsentry/issue/TET-2240/cleanup-double-config-write-in-sentry-and-relay