### PR TITLE
fix(replays): Hide trace ID in replay waterfall

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -667,6 +667,11 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
     return null;
   }
 
+  let waterfallTraceId: string | undefined = props.traceSlug;
+  if (props.source === 'replay') {
+    waterfallTraceId = undefined;
+  }
+
   return (
     <Flex direction="column" flex={1}>
       <Flex gap="md">
@@ -711,7 +716,7 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
               <Trace
                 trace={props.tree}
                 rerender={rerender}
-                trace_id={props.traceSlug}
+                trace_id={waterfallTraceId}
                 onRowClick={onRowClick}
                 onTraceSearch={onTraceSearch}
                 previouslyFocusedNodeRef={previouslyFocusedNodeRef}


### PR DESCRIPTION
Since we fetch all traces associated with a given replay, there is no "root id" that we should display. Instead we need to stop passing the replay trace slug into the waterfall row rendering.

Closes EXP-750

Before:
<img width="389" height="52" alt="Screenshot 2026-04-21 at 10 43 39" src="https://github.com/user-attachments/assets/fab7b83f-72ba-4270-a667-ef374f694522" />

After:
<img width="379" height="50" alt="Screenshot 2026-04-21 at 10 43 07" src="https://github.com/user-attachments/assets/6cc71bc6-4350-4f0f-ae9a-1d0bf4972e92" />