### PR TITLE
ref(integrations): Make GitHub compare-commits caching default

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -142,7 +142,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:integrations-claude-code", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-cursor", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-github-copilot-agent", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    manager.add("organizations:integrations-github-fetch-commits-compare-cache", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:integrations-github-platform-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:github-repo-auto-sync", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:github-repo-auto-sync-apply", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)

--- a/src/sentry/tasks/commits.py
+++ b/src/sentry/tasks/commits.py
@@ -9,7 +9,6 @@ from django.urls import reverse
 from sentry_sdk import set_tag
 from taskbroker_client.retry import Retry
 
-from sentry import features
 from sentry.constants import ObjectStatus
 from sentry.exceptions import InvalidIdentity, PluginError
 from sentry.integrations.source_code_management.metrics import (
@@ -38,9 +37,6 @@ from sentry.utils.http import absolute_uri
 
 logger = logging.getLogger(__name__)
 
-GITHUB_FETCH_COMMITS_COMPARE_CACHE_FEATURE = (
-    "organizations:integrations-github-fetch-commits-compare-cache"
-)
 GITHUB_FETCH_COMMITS_COMPARE_CACHE_TTL_SECONDS = 3600
 GITHUB_CACHEABLE_REPOSITORY_PROVIDERS = frozenset(
     ("integrations:github", "integrations:github_enterprise")
@@ -103,7 +99,6 @@ def get_github_compare_commits_cache_key(
 
 def fetch_commits_for_compare_range(
     *,
-    github_compare_commits_cache_feature_enabled: bool,
     repo: Repository,
     provider: Any,
     start_sha: str,
@@ -111,9 +106,7 @@ def fetch_commits_for_compare_range(
     user: RpcUser | None,
 ) -> list[dict[str, Any]]:
     cache_enabled = (
-        github_compare_commits_cache_feature_enabled
-        and isinstance(repo.provider, str)
-        and repo.provider in GITHUB_CACHEABLE_REPOSITORY_PROVIDERS
+        isinstance(repo.provider, str) and repo.provider in GITHUB_CACHEABLE_REPOSITORY_PROVIDERS
     )
     set_tag("compare_commits_cache_enabled", cache_enabled)
     if cache_enabled:
@@ -275,7 +268,6 @@ def fetch_commits_for_ref_with_lifecycle(
     release: Release,
     user_id: int,
     user: RpcUser | None,
-    github_compare_commits_cache_feature_enabled: bool,
     task_extra: Mapping[str, Any],
 ) -> list[dict[str, Any]] | None:
     repo = resolved.repo
@@ -316,7 +308,6 @@ def fetch_commits_for_ref_with_lifecycle(
                     )
                 else:
                     repo_commits = fetch_commits_for_compare_range(
-                        github_compare_commits_cache_feature_enabled=github_compare_commits_cache_feature_enabled,
                         repo=repo,
                         provider=resolved.provider,
                         start_sha=start_sha,
@@ -383,10 +374,6 @@ def fetch_commits(
             prev_release = Release.objects.get(id=prev_release_id)
         except Release.DoesNotExist:
             pass
-    organization = release.organization
-    github_compare_commits_cache_feature_enabled = features.has(
-        GITHUB_FETCH_COMMITS_COMPARE_CACHE_FEATURE, organization, actor=user
-    )
     set_tag("organization.slug", release.organization.slug)
     extra = {
         "organization_id": release.organization_id,
@@ -394,7 +381,6 @@ def fetch_commits(
         "refs": refs,
         "num_refs": len(refs),
         "prev_release_id": prev_release_id,
-        "github_compare_commits_cache_feature_enabled": github_compare_commits_cache_feature_enabled,
     }
     logger.info("fetch_commits.start", extra=extra)
 
@@ -408,7 +394,6 @@ def fetch_commits(
             release=release,
             user_id=user_id,
             user=user,
-            github_compare_commits_cache_feature_enabled=github_compare_commits_cache_feature_enabled,
             task_extra=extra,
         )
         if repo_commits is None:

--- a/tests/sentry/tasks/test_commits.py
+++ b/tests/sentry/tasks/test_commits.py
@@ -152,7 +152,7 @@ class FetchCommitsTest(TestCase):
     @patch(
         "sentry.integrations.github.repository.GitHubRepositoryProvider.fetch_commits_for_compare_range"
     )
-    def test_github_compare_commits_cache_flag_disabled(
+    def test_github_compare_commits_cache_enabled_by_default(
         self, mock_fetch_commits_for_compare_range: MagicMock, mock_record: MagicMock
     ) -> None:
         self.login_as(user=self.user)
@@ -179,41 +179,6 @@ class FetchCommitsTest(TestCase):
                 prev_release_id=previous_release.id,
             )
 
-        assert mock_fetch_commits_for_compare_range.call_count == 2
-
-    @patch(
-        "sentry.integrations.github.repository.GitHubRepositoryProvider.fetch_commits_for_compare_range"
-    )
-    def test_github_compare_commits_cache_flag_enabled(
-        self, mock_fetch_commits_for_compare_range: MagicMock, mock_record: MagicMock
-    ) -> None:
-        self.login_as(user=self.user)
-        cache.clear()
-
-        org, repo, previous_release, first_release, second_release, refs = (
-            self._setup_github_compare_commits_cache_context()
-        )
-        mock_fetch_commits_for_compare_range.return_value = self._github_compare_commits_result(
-            repo.name, "b" * 40
-        )
-
-        with self.feature(
-            {"organizations:integrations-github-fetch-commits-compare-cache": [org.slug]}
-        ):
-            with self.tasks():
-                fetch_commits(
-                    release_id=first_release.id,
-                    user_id=self.user.id,
-                    refs=refs,
-                    prev_release_id=previous_release.id,
-                )
-                fetch_commits(
-                    release_id=second_release.id,
-                    user_id=self.user.id,
-                    refs=refs,
-                    prev_release_id=previous_release.id,
-                )
-
         assert mock_fetch_commits_for_compare_range.call_count == 1
 
     @patch(
@@ -225,7 +190,7 @@ class FetchCommitsTest(TestCase):
         self.login_as(user=self.user)
         cache.clear()
 
-        org, repo, previous_release, first_release, second_release, refs_first = (
+        _, repo, previous_release, first_release, second_release, refs_first = (
             self._setup_github_compare_commits_cache_context()
         )
         refs_second = [{"repository": repo.name, "commit": "c" * 40}]
@@ -234,22 +199,19 @@ class FetchCommitsTest(TestCase):
             self._github_compare_commits_result(repo.name, "c" * 40),
         ]
 
-        with self.feature(
-            {"organizations:integrations-github-fetch-commits-compare-cache": [org.slug]}
-        ):
-            with self.tasks():
-                fetch_commits(
-                    release_id=first_release.id,
-                    user_id=self.user.id,
-                    refs=refs_first,
-                    prev_release_id=previous_release.id,
-                )
-                fetch_commits(
-                    release_id=second_release.id,
-                    user_id=self.user.id,
-                    refs=refs_second,
-                    prev_release_id=previous_release.id,
-                )
+        with self.tasks():
+            fetch_commits(
+                release_id=first_release.id,
+                user_id=self.user.id,
+                refs=refs_first,
+                prev_release_id=previous_release.id,
+            )
+            fetch_commits(
+                release_id=second_release.id,
+                user_id=self.user.id,
+                refs=refs_second,
+                prev_release_id=previous_release.id,
+            )
 
         assert mock_fetch_commits_for_compare_range.call_count == 2
 
@@ -264,24 +226,21 @@ class FetchCommitsTest(TestCase):
         self.login_as(user=self.user)
         cache.clear()
 
-        org, repo, previous_release, first_release, _, refs = (
+        _, repo, previous_release, first_release, _, refs = (
             self._setup_github_compare_commits_cache_context()
         )
         mock_fetch_commits_for_compare_range.return_value = self._github_compare_commits_result(
             repo.name, "b" * 40
         )
 
-        with self.feature(
-            {"organizations:integrations-github-fetch-commits-compare-cache": [org.slug]}
-        ):
-            with patch("sentry.tasks.commits.cache.set", wraps=cache.set) as mock_cache_set:
-                with self.tasks():
-                    fetch_commits(
-                        release_id=first_release.id,
-                        user_id=self.user.id,
-                        refs=refs,
-                        prev_release_id=previous_release.id,
-                    )
+        with patch("sentry.tasks.commits.cache.set", wraps=cache.set) as mock_cache_set:
+            with self.tasks():
+                fetch_commits(
+                    release_id=first_release.id,
+                    user_id=self.user.id,
+                    refs=refs,
+                    prev_release_id=previous_release.id,
+                )
 
         expected_cache_key = get_github_compare_commits_cache_key(
             organization_id=repo.organization_id,


### PR DESCRIPTION
I added a feature flag to enable compare-commits caching. We're now going to make it the default behaviour.