### PR TITLE
fix(insights): Handle gen_ai.output.messages as JSON object

### DIFF
--- a/static/app/views/insights/pages/conversations/components/messagesPanel.spec.tsx
+++ b/static/app/views/insights/pages/conversations/components/messagesPanel.spec.tsx
@@ -475,6 +475,29 @@ describe('MessagesPanel', () => {
     expect(screen.getByText('weather_api')).toBeInTheDocument();
   });
 
+  it('handles output messages as a JSON object with content key', () => {
+    const requestMessages = JSON.stringify([{role: 'user', content: 'User message'}]);
+    const outputObj = JSON.stringify({content: 'Response from object format'});
+
+    const node = createMockNode({
+      id: 'span-1',
+      attributes: {
+        [SpanFields.GEN_AI_REQUEST_MESSAGES]: requestMessages,
+        [SpanFields.GEN_AI_OUTPUT_MESSAGES]: outputObj,
+      },
+    });
+
+    render(
+      <MessagesPanel
+        nodes={[node] as any}
+        selectedNodeId={null}
+        onSelectNode={mockOnSelectNode}
+      />
+    );
+
+    expect(screen.getByText('Response from object format')).toBeInTheDocument();
+  });
+
   it('carries forward tool calls from spans without text to the next message with text', () => {
     const requestMessages = JSON.stringify([
       {role: 'user', content: 'Compare weather in Spain and Germany'},

--- a/static/app/views/insights/pages/conversations/utils/conversationMessages.spec.ts
+++ b/static/app/views/insights/pages/conversations/utils/conversationMessages.spec.ts
@@ -315,6 +315,29 @@ describe('conversationMessages utilities', () => {
       expect(parseAssistantContent(node as any)).toBeNull();
     });
 
+    it('extracts content from non-array JSON object in output messages', () => {
+      const outputObj = JSON.stringify({content: 'Object content response'});
+      const node = createMockNode({
+        id: 'node-1',
+        attributes: {
+          [SpanFields.GEN_AI_OUTPUT_MESSAGES]: outputObj,
+        },
+      });
+      expect(parseAssistantContent(node as any)).toBe('Object content response');
+    });
+
+    it('falls back to response.text when output messages is object without content', () => {
+      const outputObj = JSON.stringify({other: 'no content key'});
+      const node = createMockNode({
+        id: 'node-1',
+        attributes: {
+          [SpanFields.GEN_AI_OUTPUT_MESSAGES]: outputObj,
+          [SpanFields.GEN_AI_RESPONSE_TEXT]: 'Fallback text',
+        },
+      });
+      expect(parseAssistantContent(node as any)).toBe('Fallback text');
+    });
+
     it('returns [Filtered] when output messages are scrubbed', () => {
       const node = createMockNode({
         id: 'node-1',

--- a/static/app/views/insights/pages/conversations/utils/conversationMessages.ts
+++ b/static/app/views/insights/pages/conversations/utils/conversationMessages.ts
@@ -265,14 +265,21 @@ export function parseAssistantContent(node: AITraceSpanNode): string | null {
     }
 
     try {
-      const messagesArray: RequestMessage[] = JSON.parse(outputMessages);
-      const assistantMessage = messagesArray.findLast(
-        msg => msg.role === 'assistant' && (msg.content || msg.parts)
-      );
-      if (assistantMessage) {
-        const content = extractTextFromMessage(assistantMessage);
-        if (content) {
-          return content;
+      const parsed = JSON.parse(outputMessages);
+      // Handle non-array format: extract "content" from the object directly
+      if (Array.isArray(parsed)) {
+        const assistantMessage = (parsed as RequestMessage[]).findLast(
+          msg => msg.role === 'assistant' && (msg.content || msg.parts)
+        );
+        if (assistantMessage) {
+          const content = extractTextFromMessage(assistantMessage);
+          if (content) {
+            return content;
+          }
+        }
+      } else {
+        if (parsed && typeof parsed === 'object' && typeof parsed.content === 'string') {
+          return parsed.content;
         }
       }
     } catch {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiOutput.tsx
@@ -34,7 +34,11 @@ function extractFromOutputMessages(outputMessages: string): AIOutputData {
 
   try {
     const parsed = JSON.parse(outputMessages);
+    // Handle non-array format: extract "content" from the object directly
     if (!Array.isArray(parsed)) {
+      if (parsed && typeof parsed === 'object' && typeof parsed.content === 'string') {
+        result.responseText = parsed.content;
+      }
       return result;
     }
 


### PR DESCRIPTION
Handle cases where `gen_ai.output.messages` is a JSON object with a `content` key instead of the expected messages array. Extracts the content string instead of silently dropping it.