### PR TITLE
fix(integrations): Cache empty repo tree outcomes and improve error logging

### DIFF
--- a/src/sentry/integrations/source_code_management/repo_trees.py
+++ b/src/sentry/integrations/source_code_management/repo_trees.py
@@ -35,7 +35,6 @@ MAX_CONNECTION_ERRORS = 10
 # When the number of remaining API requests is less than this value, it will
 # fall back to the cache.
 MINIMUM_REQUESTS_REMAINING = 200
-NOT_FOUND_CACHE_SECONDS = 3600 * 24
 
 
 class RepoTreesIntegration(ABC):
@@ -191,6 +190,8 @@ class RepoTreesIntegration(ABC):
 
         repo_full_name: e.g. getsentry/sentry
         tree_sha: A branch or a commit sha
+        shifted_seconds: Staggers cache expiration times across repositories
+            so cache misses and API refreshes are spread out over time.
         only_source_code_files: Include all files or just the source code files
         only_use_cache: Do not hit the network but use the value from the cache
             if any. This is useful if the remaining API requests are low
@@ -211,14 +212,12 @@ class RepoTreesIntegration(ABC):
                     "Caching empty files result for repo",
                     extra={"repo": repo_full_name},
                 )
-                cache.set(key, [], self.CACHE_SECONDS + shifted_seconds)
             except ApiError as error:
                 if _is_not_found_error(error):
                     logger.info(
                         "Caching empty files result for missing repo or ref",
                         extra={"repo": repo_full_name},
                     )
-                    cache.set(key, [], NOT_FOUND_CACHE_SECONDS + shifted_seconds)
                 else:
                     raise
             if tree:
@@ -235,6 +234,8 @@ class RepoTreesIntegration(ABC):
                 # repositories is a single API network request, thus,
                 # being acceptable to sometimes not having everything cached
                 cache.set(key, repo_files, self.CACHE_SECONDS + shifted_seconds)
+            else:
+                cache.set(key, [], self.CACHE_SECONDS + shifted_seconds)
 
             metrics.incr(
                 f"{METRICS_KEY_PREFIX}.get_tree",

--- a/src/sentry/integrations/source_code_management/repo_trees.py
+++ b/src/sentry/integrations/source_code_management/repo_trees.py
@@ -200,6 +200,7 @@ class RepoTreesIntegration(ABC):
         use_api = not cache_hit and not only_use_cache
         repo_files: list[str] = cache.get(key, [])
         if use_api:
+            tree = None
             # Cache miss – fetch from API
             try:
                 tree = self.get_client().get_tree(repo_full_name, tree_sha)
@@ -211,15 +212,13 @@ class RepoTreesIntegration(ABC):
                     extra={"repo": repo_full_name},
                 )
                 cache.set(key, [], self.CACHE_SECONDS + shifted_seconds)
-                tree = None
             except ApiError as error:
                 if _is_not_found_error(error):
                     logger.info(
                         "Caching empty files result for missing repo or ref",
                         extra={"repo": repo_full_name},
                     )
-                    cache.set(key, [], NOT_FOUND_CACHE_SECONDS)
-                    tree = None
+                    cache.set(key, [], NOT_FOUND_CACHE_SECONDS + shifted_seconds)
                 else:
                     raise
             if tree:

--- a/src/sentry/integrations/source_code_management/repo_trees.py
+++ b/src/sentry/integrations/source_code_management/repo_trees.py
@@ -35,6 +35,7 @@ MAX_CONNECTION_ERRORS = 10
 # When the number of remaining API requests is less than this value, it will
 # fall back to the cache.
 MINIMUM_REQUESTS_REMAINING = 200
+NOT_FOUND_CACHE_SECONDS = 3600 * 24
 
 
 class RepoTreesIntegration(ABC):
@@ -211,6 +212,16 @@ class RepoTreesIntegration(ABC):
                 )
                 cache.set(key, [], self.CACHE_SECONDS + shifted_seconds)
                 tree = None
+            except ApiError as error:
+                if _is_not_found_error(error):
+                    logger.info(
+                        "Caching empty files result for missing repo or ref",
+                        extra={"repo": repo_full_name},
+                    )
+                    cache.set(key, [], NOT_FOUND_CACHE_SECONDS)
+                    tree = None
+                else:
+                    raise
             if tree:
                 # Keep files; discard directories
                 repo_files = [node["path"] for node in tree if node["type"] == "blob"]
@@ -296,3 +307,11 @@ def should_include(file_path: str) -> bool:
     if any(file_path.startswith(path) for path in EXCLUDED_PATHS):
         return False
     return True
+
+
+def _is_not_found_error(error: ApiError) -> bool:
+    if error.code == 404:
+        return True
+
+    error_message = error.json.get("message") if error.json else error.text
+    return error_message in ("Not Found", "Not Found.")

--- a/src/sentry/integrations/source_code_management/repo_trees.py
+++ b/src/sentry/integrations/source_code_management/repo_trees.py
@@ -150,6 +150,11 @@ class RepoTreesIntegration(ABC):
                     3600 * (index % 24),
                 )
             except ApiError as error:
+                logger.warning(
+                    "Repo tree fetch failed. Continuing execution.",
+                    extra=extra,
+                    exc_info=True,
+                )
                 if self.get_client().should_count_api_error(error, extra):
                     connection_error_count += 1
             except Exception:

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -379,6 +379,38 @@ class GitHubApiClientTest(TestCase):
             files = self.install.get_cached_repo_files(self.repo.name, "master", 0)
             assert files == ["src/foo.py"]
 
+    @responses.activate
+    def test_get_cached_repo_files_caches_not_found(self) -> None:
+        responses.add(
+            method=responses.GET,
+            url=f"https://api.github.com/repos/{self.repo.name}/git/trees/master?recursive=1",
+            status=404,
+            json={"message": "Not Found"},
+        )
+        repo_key = f"github:repo:{self.repo.name}:source-code"
+        assert cache.get(repo_key) is None
+
+        files = self.install.get_cached_repo_files(self.repo.name, "master", 0)
+        assert files == []
+        assert cache.get(repo_key) == []
+
+        # Negative-cache hit should avoid an additional API request.
+        files = self.install.get_cached_repo_files(self.repo.name, "master", 0)
+        assert files == []
+        assert len(responses.calls) == 1
+
+    @responses.activate
+    def test_get_cached_repo_files_raises_non_not_found_api_error(self) -> None:
+        responses.add(
+            method=responses.GET,
+            url=f"https://api.github.com/repos/{self.repo.name}/git/trees/master?recursive=1",
+            status=500,
+            json={"message": "Server Error"},
+        )
+
+        with pytest.raises(ApiError):
+            self.install.get_cached_repo_files(self.repo.name, "master", 0)
+
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
     def test_update_comment(self, get_jwt) -> None:

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -21,6 +21,7 @@ from sentry.integrations.source_code_management.commit_context import (
     FileBlameInfo,
     SourceLineInfo,
 )
+from sentry.integrations.source_code_management.repo_trees import NOT_FOUND_CACHE_SECONDS
 from sentry.integrations.types import EventLifecycleOutcome
 from sentry.models.pullrequest import PullRequest, PullRequestComment
 from sentry.models.repository import Repository
@@ -398,6 +399,28 @@ class GitHubApiClientTest(TestCase):
         files = self.install.get_cached_repo_files(self.repo.name, "master", 0)
         assert files == []
         assert len(responses.calls) == 1
+
+    @responses.activate
+    def test_get_cached_repo_files_not_found_cache_ttl_is_staggered(self) -> None:
+        responses.add(
+            method=responses.GET,
+            url=f"https://api.github.com/repos/{self.repo.name}/git/trees/master?recursive=1",
+            status=404,
+            json={"message": "Not Found"},
+        )
+
+        shifted_seconds = 3600
+        repo_key = f"github:repo:{self.repo.name}:source-code"
+        with mock.patch(
+            "sentry.integrations.source_code_management.repo_trees.cache.set"
+        ) as cache_set:
+            self.install.get_cached_repo_files(self.repo.name, "master", shifted_seconds)
+
+        cache_set.assert_called_once_with(
+            repo_key,
+            [],
+            NOT_FOUND_CACHE_SECONDS + shifted_seconds,
+        )
 
     @responses.activate
     def test_get_cached_repo_files_raises_non_not_found_api_error(self) -> None:

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -21,7 +21,6 @@ from sentry.integrations.source_code_management.commit_context import (
     FileBlameInfo,
     SourceLineInfo,
 )
-from sentry.integrations.source_code_management.repo_trees import NOT_FOUND_CACHE_SECONDS
 from sentry.integrations.types import EventLifecycleOutcome
 from sentry.models.pullrequest import PullRequest, PullRequestComment
 from sentry.models.repository import Repository
@@ -419,7 +418,7 @@ class GitHubApiClientTest(TestCase):
         cache_set.assert_called_once_with(
             repo_key,
             [],
-            NOT_FOUND_CACHE_SECONDS + shifted_seconds,
+            self.install.CACHE_SECONDS + shifted_seconds,
         )
 
     @responses.activate

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -13,11 +13,13 @@ import responses
 from django.urls import reverse
 
 import sentry
+from fixtures.github import INSTALLATION_EVENT_EXAMPLE
 from sentry.constants import ObjectStatus
 from sentry.integrations.github import client
 from sentry.integrations.github.client import (
     MINIMUM_REQUESTS,
     GitHubApiClient,
+    GitHubBaseClient,
     GithubSetupApiClient,
 )
 from sentry.integrations.github.integration import (
@@ -589,7 +591,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
             GitHubIntegration, integration, self.organization.id
         )
 
-        with patch.object(sentry.integrations.github.client.GitHubBaseClient, "page_size", 1):
+        with patch.object(GitHubBaseClient, "page_size", 1):
             result = installation.get_repositories()
             assert result == [
                 {
@@ -624,10 +626,8 @@ class GitHubIntegrationTest(IntegrationTestCase):
         )
 
         with (
-            patch.object(
-                sentry.integrations.github.client.GitHubBaseClient, "page_number_limit", 1
-            ),
-            patch.object(sentry.integrations.github.client.GitHubBaseClient, "page_size", 1),
+            patch.object(GitHubBaseClient, "page_number_limit", 1),
+            patch.object(GitHubBaseClient, "page_size", 1),
         ):
             result = installation.get_repositories()
             assert result == [

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -791,12 +791,13 @@ class GitHubIntegrationTest(IntegrationTestCase):
 
     def _expected_trees(self, repo_info_list=None):
         result = {}
-        # bar (409 empty repo) returns an empty RepoTree since we cache the result
-        # baz (404) still fails and is excluded
+        # bar (409 empty repo) and baz (404 missing repo/ref) both return empty
+        # RepoTrees since those responses are negative-cached.
         list = repo_info_list or [
             ("xyz", "master", ["src/xyz.py"]),
             ("foo", "master", ["src/sentry/api/endpoints/auth_login.py"]),
             ("bar", "main", []),
+            ("baz", "master", []),
         ]
         for repo, branch, files in list:
             result[f"{self.gh_org}/{repo}"] = RepoTree(
@@ -878,6 +879,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
                     # Now that the rate limit is reset we should get files for foo
                     ("foo", "master", ["src/sentry/api/endpoints/auth_login.py"]),
                     ("bar", "main", []),
+                    ("baz", "master", []),
                 ]
             )
 
@@ -902,7 +904,8 @@ class GitHubIntegrationTest(IntegrationTestCase):
         )
 
         # This time the rate limit will not fail, thus, it will fetch the trees
-        # bar (409 empty repo) now returns an empty RepoTree since we cache the empty result
+        # bar (409) and baz (404) now return empty RepoTrees because those
+        # responses are cached as empty results.
         self.set_rate_limit()
         trees = installation.get_trees_for_org()
         assert trees == self._expected_trees(
@@ -910,6 +913,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
                 ("xyz", "master", ["src/xyz.py"]),
                 ("foo", "master", ["src/sentry/api/endpoints/auth_login.py"]),
                 ("bar", "main", []),
+                ("baz", "master", []),
             ]
         )
 
@@ -956,9 +960,10 @@ class GitHubIntegrationTest(IntegrationTestCase):
                     # xyz is missing because its request errors
                     # foo has data because its API request is made in spite of xyz's error
                     ("foo", "master", ["src/sentry/api/endpoints/auth_login.py"]),
-                    # bar (409 empty repo) is present with empty files since we cache the result
-                    # baz (404) is missing because its API request throws an error
+                    # bar (409) and baz (404) are present with empty files
+                    # because both outcomes are cached as empty results.
                     ("bar", "main", []),
+                    ("baz", "master", []),
                 ]
             )
 


### PR DESCRIPTION
Improve repo tree fetching resiliency for source code mapping by handling expected empty/missing
repository outcomes as cacheable empty results and preserving best-effort behavior for per-repo API
failures.

Previously, missing refs/repos and empty repositories could repeatedly trigger network requests, and
unexpected per-repo tree API failures were continued without traceback context. This made debugging
harder while also wasting rate-limited API calls.

This change consolidates repo-tree behavior by caching 404 and 409 outcomes as empty file sets,
staggering negative-cache TTLs, and keeping the existing circuit-breaker fallback when connection
errors accumulate. It also adds traceback logging when `ApiError` is caught during tree population so
we can investigate failures without aborting processing for other repositories.

The test updates cover the new cache behavior and typing-safe patch usage in GitHub integration tests.

Made with [Cursor](https://cursor.com)