### PR TITLE
fix(explore): Pass timestamp on trace summary investigation links

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceSummary.tsx
+++ b/static/app/views/performance/newTraceDetails/traceSummary.tsx
@@ -6,6 +6,7 @@ import {Link} from '@sentry/scraps/link';
 import {FeedbackButton} from 'sentry/components/feedbackButton/feedbackButton';
 import {useFeedbackSDKIntegration} from 'sentry/components/feedbackButton/useFeedbackSDKIntegration';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {IconInfo} from 'sentry/icons/iconInfo';
 import {IconLightning} from 'sentry/icons/iconLightning';
 import {IconStats} from 'sentry/icons/iconStats';
@@ -160,7 +161,8 @@ export function TraceSummarySection({traceSlug}: {traceSlug: string}) {
                   traceSlug,
                   location,
                   spanId: span.spanId,
-                  dateSelection: {},
+                  timestamp: location.query.timestamp as string | undefined,
+                  dateSelection: normalizeDateTimeParams(location.query),
                 })}
               >
                 {span.spanOp}

--- a/static/app/views/performance/traceDetails/utils.tsx
+++ b/static/app/views/performance/traceDetails/utils.tsx
@@ -61,6 +61,10 @@ export function getTraceDetailsUrl({
   dateSelection: any;
   location: Location;
   organization: Organization;
+  // Required: omitting the timestamp forces the old, slow trace view (see
+  // shouldForceRouteToOldView). Callers must pass it, even if the value is
+  // undefined in a genuinely unknown case.
+  timestamp: string | number | undefined;
   traceSlug: string;
   demo?: string;
   eventId?: string;
@@ -70,7 +74,6 @@ export function getTraceDetailsUrl({
   // targetId represents the span id of the transaction. It will replace eventId once all links
   // to trace view are updated to use spand ids of transactions instead of event ids.
   targetId?: string;
-  timestamp?: string | number;
   view?: DomainView;
 }): LocationDescriptorObject {
   const baseUrl = getBaseTraceUrl(organization, source, view);


### PR DESCRIPTION
The "Suggested Investigations" links in the Trace Summary tab shipped an empty `dateSelection` and no `timestamp`, so `shouldForceRouteToOldView` triggered and the links loaded the trace waterfall without `timestamp`/`node` query params. 

This forwards `location.query.timestamp` and `normalizeDateTimeParams(location.query)` from the parent trace detail page (which already carries both) so the investigation links hit the fast path.

Also tightens `getTraceDetailsUrl` so `timestamp` is a required key on the arg type, matching the sibling `generateLinkToEventInTraceView` helper.

Closes EXP-840