### PR TITLE
feat(compactSelect): Add menuMinWidth prop

### DIFF
--- a/static/app/components/core/compactSelect/control.tsx
+++ b/static/app/components/core/compactSelect/control.tsx
@@ -163,6 +163,12 @@ export interface ControlProps
     | ((actions: {closeOverlay: () => void}) => React.ReactNode);
   menuHeight?: number | string;
   /**
+   * Minimum width for the menu overlay. By default the overlay's min-width matches
+   * the trigger's width; use this to enforce a larger floor (e.g. when the trigger
+   * is intentionally narrow but the options need more room).
+   */
+  menuMinWidth?: number | string;
+  /**
    * Title to display in the menu's header. Keep the title as short as possible.
    */
   menuTitle?: React.ReactNode;
@@ -217,6 +223,7 @@ export function Control({
   menuTitle,
   maxMenuHeight = '32rem',
   menuWidth,
+  menuMinWidth,
   menuHeight,
   menuHeaderTrailingItems,
   menuBody,
@@ -497,7 +504,11 @@ export function Control({
               ref={menuRef}
               width={menuWidth ?? menuFullWidth}
               height={menuHeight}
-              minWidth={overlayProps.style!.minWidth}
+              minWidth={
+                menuMinWidth === undefined
+                  ? overlayProps.style!.minWidth
+                  : `max(${withUnits(overlayProps.style!.minWidth)}, ${withUnits(menuMinWidth)})`
+              }
               maxWidth={
                 overlayProps.style?.maxWidth
                   ? `calc(${withUnits(overlayProps.style.maxWidth)} * 0.9)`

--- a/static/app/components/core/compactSelect/control.tsx
+++ b/static/app/components/core/compactSelect/control.tsx
@@ -163,9 +163,9 @@ export interface ControlProps
     | ((actions: {closeOverlay: () => void}) => React.ReactNode);
   menuHeight?: number | string;
   /**
-   * Minimum width for the menu overlay. By default the overlay's min-width matches
-   * the trigger's width; use this to enforce a larger floor (e.g. when the trigger
-   * is intentionally narrow but the options need more room).
+   * Minimum width for the menu overlay. When unset, the overlay's min-width matches
+   * the trigger's width (popper default). When set, this value is used instead —
+   * useful when the trigger is intentionally narrow but the options need more room.
    */
   menuMinWidth?: number | string;
   /**
@@ -504,7 +504,7 @@ export function Control({
               ref={menuRef}
               width={menuWidth ?? menuFullWidth}
               height={menuHeight}
-              minWidth={`max(${withUnits(overlayProps.style!.minWidth)}, ${withUnits(menuMinWidth ?? 0)})`}
+              minWidth={menuMinWidth ?? overlayProps.style!.minWidth}
               maxWidth={
                 overlayProps.style?.maxWidth
                   ? `calc(${withUnits(overlayProps.style.maxWidth)} * 0.9)`

--- a/static/app/components/core/compactSelect/control.tsx
+++ b/static/app/components/core/compactSelect/control.tsx
@@ -504,11 +504,7 @@ export function Control({
               ref={menuRef}
               width={menuWidth ?? menuFullWidth}
               height={menuHeight}
-              minWidth={
-                menuMinWidth === undefined
-                  ? overlayProps.style!.minWidth
-                  : `max(${withUnits(overlayProps.style!.minWidth)}, ${withUnits(menuMinWidth)})`
-              }
+              minWidth={`max(${withUnits(overlayProps.style!.minWidth)}, ${withUnits(menuMinWidth ?? 0)})`}
               maxWidth={
                 overlayProps.style?.maxWidth
                   ? `calc(${withUnits(overlayProps.style.maxWidth)} * 0.9)`

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/selectRow.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/selectRow.tsx
@@ -201,6 +201,7 @@ export function SelectRow({
         options={sortSelectedFirst(aggregateValue, aggregateOptions)}
         value={aggregateValue}
         position="bottom-start"
+        menuMinWidth={300}
         onChange={dropdownSelection => {
           const isNone = dropdownSelection.value === NONE;
           let newFields = cloneDeep(fields);


### PR DESCRIPTION
Add a `menuMinWidth` prop to `CompactSelect` (via `Control`) that enforces a floor on the overlay's `min-width`, layered on top of popper's default trigger-width match using a CSS `max()` expression. Use it on the widget builder's aggregate selector to prevent the dropdown from collapsing to the trigger button's width.

fixes https://linear.app/getsentry/issue/DAIN-1564/table-widget-aggregate-dropdown-width-breaks-for-spans

### Before
<img width="304" height="372" alt="image" src="https://github.com/user-attachments/assets/6a9c29a5-3041-4d57-a5c5-dafe79b8b038" />


### After
<img width="362" height="347" alt="image" src="https://github.com/user-attachments/assets/9626a82f-e337-4029-aee5-db150f01687a" />


### Repro

1. Open the widget builder, create a custom widget
2. Switch dataset to Spans
3. Select the `avg` aggregate
4. Switch display type to Table
5. Open the aggregate dropdown — the menu is rendered at the width of the narrow trigger button, making options invisible

### Root cause

`CompactSelect`'s virtualization measurement step (added in #104805) renders the longest option, reads `offsetWidth` off the live popper-positioned overlay, then pins that value as the menu width for the lifetime of the component instance. The Spans Table aggregate dropdown includes every span attribute as options (`visualize/index.tsx` adds `traceItemColumnOptions` to the base aggregates for Spans/Logs/Tracemetrics when rendering a Table), which trivially exceeds the default `virtualizeThreshold` of 150.

The `AggregateCompactSelect` wrapper has `width: fit-content` so the trigger sizes to its label (e.g. "avg" ≈ 35px). `useOverlay`'s `applyMinWidth` modifier then pins the overlay's `min-width` to that same narrow width. During the measurement render, `offsetWidth` reads back the narrow trigger width, which gets locked as `measuredMenuWidth` and reused on every subsequent open.

### Approach

Rather than add a framework-wide `minWidthFloor` option to `useOverlay`, the floor is applied one layer up at `StyledOverlay` via the new `menuMinWidth` prop: `min-width: max(triggerWidth, menuMinWidth)`. This keeps the change additive, callsite-local, and preserves the existing "overlay at least as wide as trigger" default for every other consumer.

At the widget builder callsite, `menuMinWidth={300}` keeps the dropdown usable without disabling virtualization (tried `virtualizeThreshold={Infinity}` first — noticeable perf hit from rendering all span attributes eagerly).

### Alternatives considered

- **`menuWidth={300}`**: fixed width, but loses the "grow with content" property for long option labels.
- **`virtualizeThreshold={Infinity}` at the callsite**: disables virtualization, causes perf regression on large span-attribute lists.
- **`min-width` on the styled wrapper**: also widens the trigger button, not just the menu.
- **Extend `useOverlay` with a `minWidthFloor` option that the popper modifier honors**: cleanest API (`overlayProps.style.minWidth` becomes the single source of truth), but broader blast radius since `useOverlay` has many consumers. Happy to follow up with that refactor if preferred.