### PR TITLE
fix(seer): Correct coding agent docs links

### DIFF
--- a/static/app/components/events/autofix/claudeCodeIntegrationCta.spec.tsx
+++ b/static/app/components/events/autofix/claudeCodeIntegrationCta.spec.tsx
@@ -111,7 +111,7 @@ describe('ClaudeCodeIntegrationCta', () => {
       const docsLink = screen.getByRole('link', {name: 'Read the docs'});
       expect(docsLink).toHaveAttribute(
         'href',
-        'https://docs.sentry.io/organization/integrations/claude-code/'
+        'https://docs.sentry.io/organization/integrations/coding-agents/claude/'
       );
     });
   });

--- a/static/app/components/events/autofix/claudeCodeIntegrationCta.tsx
+++ b/static/app/components/events/autofix/claudeCodeIntegrationCta.tsx
@@ -8,5 +8,5 @@ export const ClaudeCodeIntegrationCta = makeCodingAgentIntegrationCta({
   pluginId: 'claude_code',
   displayName: 'Claude',
   headingName: 'Claude Agent',
-  docsUrl: 'https://docs.sentry.io/organization/integrations/claude-code/',
+  docsUrl: 'https://docs.sentry.io/organization/integrations/coding-agents/claude/',
 });

--- a/static/app/components/events/autofix/cursorIntegrationCta.spec.tsx
+++ b/static/app/components/events/autofix/cursorIntegrationCta.spec.tsx
@@ -113,7 +113,7 @@ describe('CursorIntegrationCta', () => {
       const docsLink = screen.getByRole('link', {name: 'Read the docs'});
       expect(docsLink).toHaveAttribute(
         'href',
-        'https://docs.sentry.io/organization/integrations/cursor/'
+        'https://docs.sentry.io/organization/integrations/coding-agents/cursor/'
       );
     });
   });

--- a/static/app/components/events/autofix/cursorIntegrationCta.tsx
+++ b/static/app/components/events/autofix/cursorIntegrationCta.tsx
@@ -8,5 +8,5 @@ export const CursorIntegrationCta = makeCodingAgentIntegrationCta({
   pluginId: 'cursor',
   displayName: 'Cursor',
   headingName: 'Cursor Agent',
-  docsUrl: 'https://docs.sentry.io/organization/integrations/cursor/',
+  docsUrl: 'https://docs.sentry.io/organization/integrations/coding-agents/cursor/',
 });


### PR DESCRIPTION
The "Read the docs" links on the Seer project settings page pointed to outdated URLs. Update both the Claude and Cursor agent CTAs to the new /coding-agents/ docs paths, and update the corresponding spec assertions.