### PR TITLE
feat(seer): Add user_id to SlackSeerAgentResponded analytics event

### DIFF
--- a/src/sentry/seer/entrypoints/slack/analytics.py
+++ b/src/sentry/seer/entrypoints/slack/analytics.py
@@ -8,9 +8,10 @@ class SlackSeerAgentConversation(str, Enum):
     APP_MENTION = "app_mention"
 
 
-@analytics.eventclass("ai.explorer.slack.responded")
+@analytics.eventclass("ai.agent.slack.responded")
 class SlackSeerAgentResponded(analytics.Event):
     org_slug: str
+    user_id: int
     username: str
     thread_ts: str
     prompt_length: int

--- a/src/sentry/seer/entrypoints/slack/tasks.py
+++ b/src/sentry/seer/entrypoints/slack/tasks.py
@@ -176,6 +176,7 @@ def process_mention_for_slack(
 
         analytics_event = SlackSeerAgentResponded(
             org_slug=organization.slug,
+            user_id=user.id,
             username=user.username,
             thread_ts=thread_ts or ts,
             prompt_length=len(prompt),

--- a/tests/sentry/seer/entrypoints/slack/test_tasks.py
+++ b/tests/sentry/seer/entrypoints/slack/test_tasks.py
@@ -81,6 +81,7 @@ class ProcessMentionForSlackTest(TestCase):
             mock_record,
             SlackSeerAgentResponded(
                 org_slug=self.organization.slug,
+                user_id=self.user.id,
                 username="alice",
                 thread_ts="1234567890.123456",
                 prompt_length=len("What is causing this issue?"),
@@ -251,6 +252,7 @@ class ProcessMentionForSlackTest(TestCase):
             mock_record,
             SlackSeerAgentResponded(
                 org_slug=self.organization.slug,
+                user_id=self.user.id,
                 username="alice",
                 thread_ts="1234567890.000001",
                 prompt_length=len("What is causing this issue?"),
@@ -320,6 +322,7 @@ class ProcessMentionForSlackTest(TestCase):
             mock_record,
             SlackSeerAgentResponded(
                 org_slug=self.organization.slug,
+                user_id=self.user.id,
                 username="alice",
                 thread_ts="1234567890.654321",
                 prompt_length=len("What is causing this issue?"),


### PR DESCRIPTION
Add a `user_id` field to the `ai.agent.slack.responded` (also changed from `ai.explorer`) analytics event emitted when Seer Explorer responds to a Slack mention.

Analytics should have user_id in them so it gets automatically aggregated and pushed to Amplitude: https://develop.sentry.dev/development-infrastructure/analytics/#step-3