### PR TITLE
feat(onboarding): Fire distinct analytics for SCM setup-docs events

### DIFF
--- a/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
@@ -73,6 +73,16 @@ export type OnboardingEventParameters = {
   'onboarding.scm_project_details_team_selected': {
     team: string;
   };
+  'onboarding.scm_setup_platform_later_clicked': {
+    platform: string;
+    project_id: string;
+  };
+  'onboarding.scm_take_to_error_clicked': {
+    platform?: string;
+  };
+  'onboarding.scm_view_sample_event_clicked': {
+    platform?: string;
+  };
   'onboarding.scm_welcome_continue_clicked': Record<string, unknown>;
   'onboarding.scm_welcome_step_viewed': Record<string, unknown>;
   'onboarding.select_framework_modal_close_button_clicked': {
@@ -160,6 +170,10 @@ export const onboardingEventMap: Record<keyof OnboardingEventParameters, string>
     'Onboarding: SCM Project Details Step Viewed',
   'onboarding.scm_project_details_team_selected':
     'Onboarding: SCM Project Details Team Selected',
+  'onboarding.scm_setup_platform_later_clicked':
+    'Onboarding: SCM Setup Platform Later Clicked',
+  'onboarding.scm_take_to_error_clicked': 'Onboarding: SCM Take to Error Clicked',
+  'onboarding.scm_view_sample_event_clicked': 'Onboarding: SCM View Sample Event Clicked',
   'onboarding.scm_welcome_continue_clicked': 'Onboarding: SCM Welcome Continue Clicked',
   'onboarding.scm_welcome_step_viewed': 'Onboarding: SCM Welcome Step Viewed',
 };

--- a/static/app/views/onboarding/components/firstEventFooter.tsx
+++ b/static/app/views/onboarding/components/firstEventFooter.tsx
@@ -116,12 +116,19 @@ export function FirstEventFooter({
         {/* if hasn't sent first event, allow creation of sample error */}
         {project.firstEvent ? (
           <LinkButton
-            onClick={() =>
-              trackAnalytics('growth.onboarding_take_to_error', {
-                organization,
-                platform: project.platform,
-              })
-            }
+            onClick={() => {
+              if (hasScmOnboarding) {
+                trackAnalytics('onboarding.scm_take_to_error_clicked', {
+                  organization,
+                  platform: project.platform,
+                });
+              } else {
+                trackAnalytics('growth.onboarding_take_to_error', {
+                  organization,
+                  platform: project.platform,
+                });
+              }
+            }}
             to={`/organizations/${organization.slug}/issues/${
               firstIssue && 'id' in firstIssue ? `${firstIssue.id}/` : ''
             }?referrer=onboarding-first-event-footer`}
@@ -134,6 +141,7 @@ export function FirstEventFooter({
             project={project}
             source="targeted-onboarding"
             priority="primary"
+            hasScmOnboarding={hasScmOnboarding}
           >
             {t('View Sample Error')}
           </CreateSampleEventButton>

--- a/static/app/views/onboarding/createSampleEventButton.spec.tsx
+++ b/static/app/views/onboarding/createSampleEventButton.spec.tsx
@@ -78,6 +78,59 @@ describe('CreateSampleEventButton', () => {
     );
   });
 
+  it('fires the legacy view sample event when hasScmOnboarding is not set', async () => {
+    renderComponent();
+    MockApiClient.addMockResponse({
+      url: `/projects/${org.slug}/${project.slug}/create-sample/`,
+      method: 'POST',
+      body: {groupID},
+    });
+
+    await userEvent.click(await screen.findByRole('button', {name: createSampleText}), {
+      delay: null,
+    });
+
+    expect(trackAnalytics).toHaveBeenCalledWith(
+      'growth.onboarding_view_sample_event',
+      expect.objectContaining({platform: 'javascript'})
+    );
+    expect(trackAnalytics).not.toHaveBeenCalledWith(
+      'onboarding.scm_view_sample_event_clicked',
+      expect.anything()
+    );
+  });
+
+  it('fires the SCM view sample event when hasScmOnboarding is true', async () => {
+    render(
+      <CreateSampleEventButton
+        source="test"
+        project={{...project, platform: 'javascript'}}
+        hasScmOnboarding
+      >
+        {createSampleText}
+      </CreateSampleEventButton>,
+      {organization: org}
+    );
+    MockApiClient.addMockResponse({
+      url: `/projects/${org.slug}/${project.slug}/create-sample/`,
+      method: 'POST',
+      body: {groupID},
+    });
+
+    await userEvent.click(await screen.findByRole('button', {name: createSampleText}), {
+      delay: null,
+    });
+
+    expect(trackAnalytics).toHaveBeenCalledWith(
+      'onboarding.scm_view_sample_event_clicked',
+      expect.objectContaining({platform: 'javascript'})
+    );
+    expect(trackAnalytics).not.toHaveBeenCalledWith(
+      'growth.onboarding_view_sample_event',
+      expect.anything()
+    );
+  });
+
   it('waits for the latest event to be processed', async () => {
     const {router} = renderComponent();
     const createRequest = MockApiClient.addMockResponse({

--- a/static/app/views/onboarding/createSampleEventButton.tsx
+++ b/static/app/views/onboarding/createSampleEventButton.tsx
@@ -23,6 +23,7 @@ type CreateSampleEventButtonProps = ButtonProps & {
   api: Client;
   organization: Organization;
   source: string;
+  hasScmOnboarding?: boolean;
   onClick?: () => void;
   onCreateSampleGroup?: () => void;
   project?: Project;
@@ -107,7 +108,8 @@ class CreateSampleEventButton extends Component<CreateSampleEventButtonProps, St
 
   createSampleGroup = async () => {
     // TODO(dena): swap out for action creator
-    const {api, organization, project, onCreateSampleGroup} = this.props;
+    const {api, organization, project, onCreateSampleGroup, hasScmOnboarding} =
+      this.props;
     let eventData: any;
 
     if (!project) {
@@ -116,6 +118,11 @@ class CreateSampleEventButton extends Component<CreateSampleEventButtonProps, St
 
     if (onCreateSampleGroup) {
       onCreateSampleGroup();
+    } else if (hasScmOnboarding) {
+      trackAnalytics('onboarding.scm_view_sample_event_clicked', {
+        platform: project.platform,
+        organization,
+      });
     } else {
       trackAnalytics('growth.onboarding_view_sample_event', {
         platform: project.platform,
@@ -196,6 +203,7 @@ class CreateSampleEventButton extends Component<CreateSampleEventButtonProps, St
       organization: _organization,
       project: _project,
       source: _source,
+      hasScmOnboarding: _hasScmOnboarding,
       ...props
     } = this.props;
 

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -1031,6 +1031,72 @@ describe('Onboarding', () => {
       expect(stored.createdProjectSlug).toBeUndefined();
     });
 
+    describe('setup-docs analytics', () => {
+      afterEach(() => {
+        jest.restoreAllMocks();
+      });
+
+      function renderSetupDocs(project: ReturnType<typeof ProjectFixture>) {
+        jest
+          .spyOn(useRecentCreatedProjectHook, 'useRecentCreatedProject')
+          .mockImplementation(() => ({project, isProjectActive: false}));
+
+        MockApiClient.addMockResponse({
+          url: `/organizations/${scmOrganization.slug}/sdks/`,
+          body: {},
+        });
+        MockApiClient.addMockResponse({
+          url: `/projects/${scmOrganization.slug}/${project.slug}/keys/`,
+          body: [ProjectKeysFixture()[0]],
+        });
+        MockApiClient.addMockResponse({
+          url: `/projects/${scmOrganization.slug}/${project.slug}/issues/`,
+          body: [],
+        });
+
+        return render(
+          <OnboardingContextProvider initialValue={{selectedPlatform: nextJsPlatform}}>
+            <OnboardingWithoutContext />
+          </OnboardingContextProvider>,
+          {
+            organization: scmOrganization,
+            initialRouterConfig: {
+              location: {
+                pathname: `/onboarding/${scmOrganization.slug}/setup-docs/`,
+              },
+              route: '/onboarding/:orgId/:step/',
+            },
+          }
+        );
+      }
+
+      it('fires scm_take_to_error_clicked on Take me to my error click', async () => {
+        const project = ProjectFixture({
+          platform: 'javascript-nextjs',
+          slug: 'javascript-nextjs',
+          firstEvent: '2026-04-21T00:00:00.000Z',
+        });
+
+        renderSetupDocs(project);
+
+        await userEvent.click(
+          await screen.findByRole('button', {name: 'Take me to my error'})
+        );
+
+        expect(trackAnalytics).toHaveBeenCalledWith(
+          'onboarding.scm_take_to_error_clicked',
+          expect.objectContaining({
+            organization: scmOrganization,
+            platform: 'javascript-nextjs',
+          })
+        );
+        expect(trackAnalytics).not.toHaveBeenCalledWith(
+          'growth.onboarding_take_to_error',
+          expect.anything()
+        );
+      });
+    });
+
     it('clears derived state but preserves integration and repo on repo change', () => {
       const initialContext = {
         selectedIntegration: OrganizationIntegrationsFixture({

--- a/static/app/views/onboarding/setupDocs.tsx
+++ b/static/app/views/onboarding/setupDocs.tsx
@@ -10,6 +10,7 @@ import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {decodeList} from 'sentry/utils/queryString';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
+import {useExperiment} from 'sentry/utils/useExperiment';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -23,6 +24,9 @@ export function SetupDocs({recentCreatedProject: project, genBackButton}: StepPr
   const organization = useOrganization();
   const location = useLocation();
   const navigate = useNavigate();
+  const {inExperiment: hasScmOnboarding} = useExperiment({
+    feature: 'onboarding-scm-experiment',
+  });
   const products = useMemo<ProductSolution[]>(
     () => decodeList(location.query.product ?? []) as ProductSolution[],
     [location.query.product]
@@ -68,11 +72,19 @@ export function SetupDocs({recentCreatedProject: project, genBackButton}: StepPr
         isLast
         leading={genBackButton?.()}
         onClickSetupLater={() => {
-          trackAnalytics('growth.onboarding_clicked_setup_platform_later', {
-            organization,
-            platform: currentPlatformKey,
-            project_id: project.id,
-          });
+          if (hasScmOnboarding) {
+            trackAnalytics('onboarding.scm_setup_platform_later_clicked', {
+              organization,
+              platform: currentPlatformKey,
+              project_id: project.id,
+            });
+          } else {
+            trackAnalytics('growth.onboarding_clicked_setup_platform_later', {
+              organization,
+              platform: currentPlatformKey,
+              project_id: project.id,
+            });
+          }
           navigate(
             normalizeUrl({
               pathname: `/organizations/${organization.slug}/issues/`,

--- a/static/app/views/onboarding/setupDocs.tsx
+++ b/static/app/views/onboarding/setupDocs.tsx
@@ -26,6 +26,7 @@ export function SetupDocs({recentCreatedProject: project, genBackButton}: StepPr
   const navigate = useNavigate();
   const {inExperiment: hasScmOnboarding} = useExperiment({
     feature: 'onboarding-scm-experiment',
+    reportExposure: false,
   });
   const products = useMemo<ProductSolution[]>(
     () => decodeList(location.query.product ?? []) as ProductSolution[],


### PR DESCRIPTION
Splits three shared setup-docs analytics events into SCM-namespaced variants so SCM-experiment traffic stops polluting the legacy Amplitude onboarding funnels. Follows the pattern from #113364 (welcome step); BI guidance there was to fully exclude SCM from the legacy funnels rather than tagging with `is_scm`.

When the SCM experiment is active:

| Legacy event | SCM variant |
| --- | --- |
| `growth.onboarding_take_to_error` | `onboarding.scm_take_to_error_clicked` |
| `growth.onboarding_view_sample_event` | `onboarding.scm_view_sample_event_clicked` |
| `growth.onboarding_clicked_setup_platform_later` | `onboarding.scm_setup_platform_later_clicked` |

### Notes

- The `setup_platform_later` split is defensive. The "Next Platform" button is hidden on setup-docs today because `isLast={true}` is hardcoded, so neither variant fires in the current UI. Wiring it now keeps any future re-enable from polluting the legacy funnel. The SCM event name mirrors the legacy name rather than the UI label so BI funnel mappings stay one-to-one.
- `useConfigureSdk` still fires `growth.onboarding_set_up_your_project` and is intentionally unchanged: SCM skips the legacy `SELECT_PLATFORM` step and never reaches this hook.
- `sample_event.button_viewed` and `sample_event.{created,failed}` are left shared. They are not onboarding funnel events, and `button_viewed` is already flagged high-volume.
- The footer "Skip Onboarding" link is hidden under SCM by #113352 (stacked on), so no split is needed for `growth.onboarding_clicked_skip` here. The header skip button routes to `onboarding.scm_header_skip_clicked` in that PR.

### Stack

Stacked on [#113352 (VDY-90)](https://github.com/getsentry/sentry/pull/113352) for the `FirstEventFooter` changes (the `leading` slot and the in-component `useExperiment` call). Merge that first.

### BI follow-up

New SCM events need to land in the equivalent SCM funnels in the BI/Data Notion doc (`3498b10e4b5d8192a163fc553093f3e3`) before rollout.

Refs VDY-109