### PR TITLE
ref(topbar): Gate 'Ask Seer' button with gen-ai-features and hideAiFeatures

### DIFF
--- a/static/app/views/navigation/topBar.tsx
+++ b/static/app/views/navigation/topBar.tsx
@@ -75,7 +75,10 @@ function TopBarContent() {
             {props => <Flex {...props} align="center" gap="sm" />}
           </Slot.Outlet>
 
-          {organization && isSeerExplorerEnabled(organization) ? (
+          {organization &&
+          isSeerExplorerEnabled(organization) &&
+          organization.features.includes('gen-ai-features') &&
+          !organization.hideAiFeatures ? (
             <Button icon={<IconSeer />} onClick={openSeerExplorer}>
               {t('Ask Seer')}
             </Button>


### PR DESCRIPTION
Check AI feature flags + org setting for the Ask Seer button (opens seer explorer) which isn't accounted for by isSeerExplorerEnabled. 

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This PR gates the 'Ask Seer' button in the top navigation bar with additional feature flag checks to ensure it only appears when:

1. The organization has the `seer-explorer` feature (existing check via `isSeerExplorerEnabled`)
2. The organization has the `gen-ai-features` feature flag
3. The organization has not opted out of AI features (`hideAiFeatures` is `false`)

## Changes

- Updated the conditional rendering logic in `static/app/views/navigation/topBar.tsx` to include checks for:
  - `organization.features.includes('gen-ai-features')`
  - `!organization.hideAiFeatures`

