### PR TITLE
feat(replays): Accept events and transactions data_source on replay count

### DIFF
--- a/src/sentry/replays/endpoints/organization_replay_count.py
+++ b/src/sentry/replays/endpoints/organization_replay_count.py
@@ -29,7 +29,12 @@ from sentry.types.ratelimit import RateLimit, RateLimitCategory
 class ReplayCountQueryParamsValidator(serializers.Serializer):
     query = serializers.CharField(required=True)
     data_source = serializers.ChoiceField(
-        choices=(Dataset.Discover.value, Dataset.IssuePlatform.value),
+        choices=(
+            Dataset.Discover.value,
+            Dataset.Events.value,
+            Dataset.Transactions.value,
+            Dataset.IssuePlatform.value,
+        ),
         default=Dataset.Discover.value,
     )
     returnIds = serializers.BooleanField(default=False)

--- a/src/sentry/replays/usecases/replay_counts.py
+++ b/src/sentry/replays/usecases/replay_counts.py
@@ -4,13 +4,13 @@ import dataclasses
 import uuid
 from collections import defaultdict
 from collections.abc import Generator, Sequence
-from typing import Any, Literal, overload
+from typing import Any, Literal, Protocol, overload
 
 from sentry.api.event_search import ParenExpression, QueryToken, SearchFilter, parse_search_query
 from sentry.models.group import Group
 from sentry.replays.query import query_replays_count
-from sentry.search.events.types import SnubaParams
-from sentry.snuba import discover, issue_platform
+from sentry.search.events.types import EventsResponse, SnubaParams
+from sentry.snuba import discover, errors, issue_platform, transactions
 from sentry.snuba.dataset import Dataset
 
 MAX_REPLAY_COUNT = 51
@@ -21,6 +21,28 @@ MAX_VALS_PROVIDED = {
 }
 
 FILTER_HAS_A_REPLAY = ' AND !replay.id:""'
+
+
+class _DatasetQueryFunc(Protocol):
+    def __call__(
+        self,
+        *,
+        selected_columns: list[str],
+        query: str,
+        snuba_params: SnubaParams,
+        limit: int,
+        offset: int | None,
+        functions_acl: list[str] | None,
+        referrer: str,
+    ) -> EventsResponse: ...
+
+
+_DATASET_QUERY_FUNCS: dict[Dataset, _DatasetQueryFunc] = {
+    Dataset.Discover: discover.query,
+    Dataset.Events: errors.query,
+    Dataset.Transactions: transactions.query,
+    Dataset.IssuePlatform: issue_platform.query,
+}
 
 
 @overload
@@ -83,18 +105,16 @@ def _get_replay_id_mappings(
     If select_column is replay_id, return an identity map of replay_id -> [replay_id].
     The keys of the returned dict are UUIDs, represented as 32 char hex strings (all '-'s stripped)
     """
-    if data_source == Dataset.Discover:
-        search_query_func = discover.query
-    elif data_source == Dataset.IssuePlatform:
-        search_query_func = issue_platform.query  # type: ignore[assignment]
-    else:
+    if data_source not in _DATASET_QUERY_FUNCS:
         raise ValueError("Invalid data source")
+    search_query_func = _DATASET_QUERY_FUNCS[data_source]
 
     select_column, column_value = _get_select_column(query)
-    query = query + FILTER_HAS_A_REPLAY if data_source == Dataset.Discover else query
+    if data_source != Dataset.IssuePlatform:
+        query = query + FILTER_HAS_A_REPLAY
 
     if select_column == "replay_id":
-        # just return a mapping of replay_id:replay_id instead of hitting discover.
+        # just return a mapping of replay_id:replay_id instead of hitting the dataset.
         identity_map = {}
         for replay_id in column_value:
             # raises ValueError if invalid. Strips '-'

--- a/tests/sentry/replays/endpoints/test_organization_replay_count.py
+++ b/tests/sentry/replays/endpoints/test_organization_replay_count.py
@@ -20,6 +20,7 @@ from sentry.testutils.cases import (
     SnubaTestCase,
 )
 from sentry.testutils.helpers.datetime import before_now
+from sentry.utils.samples import load_data
 
 pytestmark = pytest.mark.sentry_metrics
 
@@ -293,6 +294,82 @@ class OrganizationReplayCountEndpointTest(
         }
         assert response.status_code == 200, response.content
         assert response.data == expected
+
+    def test_simple_events(self) -> None:
+        replay1_id = uuid.uuid4().hex
+        replay2_id = uuid.uuid4().hex
+
+        self.store_replays(
+            mock_replay(
+                datetime.datetime.now() - datetime.timedelta(seconds=22),
+                self.project.id,
+                replay1_id,
+            )
+        )
+        self.store_replays(
+            mock_replay(
+                datetime.datetime.now() - datetime.timedelta(seconds=22),
+                self.project.id,
+                replay2_id,
+            )
+        )
+        event_a = self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "timestamp": self.min_ago.isoformat(),
+                "contexts": {"replay": {"replay_id": replay1_id}},
+                "fingerprint": ["group-1"],
+            },
+            project_id=self.project.id,
+        )
+        event_b = self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "timestamp": self.min_ago.isoformat(),
+                "contexts": {"replay": {"replay_id": replay2_id}},
+                "fingerprint": ["group-2"],
+            },
+            project_id=self.project.id,
+        )
+
+        query = {
+            "query": f"issue.id:[{event_a.group.id}, {event_b.group.id}]",
+            "data_source": Dataset.Events.value,
+        }
+        with self.feature(self.features):
+            response = self.client.get(self.url, query, format="json")
+
+        expected = {
+            event_a.group.id: 1,
+            event_b.group.id: 1,
+        }
+        assert response.status_code == 200, response.content
+        assert response.data == expected
+
+    def test_simple_transactions(self) -> None:
+        replay1_id = uuid.uuid4().hex
+
+        self.store_replays(
+            mock_replay(
+                datetime.datetime.now() - datetime.timedelta(seconds=22),
+                self.project.id,
+                replay1_id,
+            )
+        )
+        transaction_data = load_data("transaction", timestamp=self.min_ago)
+        transaction_data["transaction"] = "t-1"
+        transaction_data["contexts"]["replay"] = {"replay_id": replay1_id}
+        self.store_event(transaction_data, project_id=self.project.id)
+
+        query = {
+            "query": "transaction:[t-1]",
+            "data_source": Dataset.Transactions.value,
+        }
+        with self.feature(self.features):
+            response = self.client.get(self.url, query, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data == {"t-1": 1}
 
     def test_invalid_data_source(self) -> None:
         query = {


### PR DESCRIPTION
`OrganizationReplayCountEndpoint` previously only accepted `discover` or `search_issues` for its data source. The `discover` dataset actually delegates to `events` (errors) or `transactions` behind the scenes. Allow callers to target these explicitly. This will let us update the data source used by our frontend callers to be explicit, making migrating away from the deprecated `transactions` dataset easier.

The default remains `discover` so existing callers are unaffected.