### PR TITLE
feat(integrations): Add direct link to GitLab user settings

### DIFF
--- a/static/app/components/pipeline/pipelineIntegrationGitLab.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationGitLab.tsx
@@ -225,8 +225,9 @@ function InstallationConfigStep({
           <Stack gap="xs">
             <Text density="comfortable">
               {tct(
-                'Navigate to [link:User Settings \u203A Access \u203A Applications] in GitLab.',
+                'Navigate to [bold:[link:User Settings \u203A Access \u203A Applications]] in GitLab.',
                 {
+                  bold: <strong />,
                   link: (
                     <ExternalLink href="https://gitlab.com/-/user_settings/applications" />
                   ),

--- a/static/app/components/pipeline/pipelineIntegrationGitLab.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationGitLab.tsx
@@ -4,10 +4,10 @@ import {z} from 'zod';
 import {CodeBlock} from '@sentry/scraps/code';
 import {defaultFormOptions, setFieldErrors, useScrapsForm} from '@sentry/scraps/form';
 import {Flex, Stack} from '@sentry/scraps/layout';
+import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
 import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
-import ExternalLink from 'sentry/components/links/externalLink';
 import {t, tct} from 'sentry/locale';
 import type {IntegrationWithConfig} from 'sentry/types/integrations';
 

--- a/static/app/components/pipeline/pipelineIntegrationGitLab.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationGitLab.tsx
@@ -225,9 +225,8 @@ function InstallationConfigStep({
           <Stack gap="xs">
             <Text density="comfortable">
               {tct(
-                'Navigate to [bold:User Settings \u203A Access \u203A Applications] in GitLab. [link:Open GitLab settings].',
+                'Navigate to [link:User Settings \u203A Access \u203A Applications] in GitLab.',
                 {
-                  bold: <strong />,
                   link: (
                     <ExternalLink href="https://gitlab.com/-/user_settings/applications" />
                   ),

--- a/static/app/components/pipeline/pipelineIntegrationGitLab.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationGitLab.tsx
@@ -7,6 +7,7 @@ import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {GuidedSteps} from 'sentry/components/guidedSteps/guidedSteps';
+import ExternalLink from 'sentry/components/links/externalLink';
 import {t, tct} from 'sentry/locale';
 import type {IntegrationWithConfig} from 'sentry/types/integrations';
 
@@ -224,9 +225,12 @@ function InstallationConfigStep({
           <Stack gap="xs">
             <Text density="comfortable">
               {tct(
-                'Navigate to [bold:User Settings \u203A Access \u203A Applications] in GitLab.',
+                'Navigate to [bold:User Settings \u203A Access \u203A Applications] in GitLab. [link:Open GitLab settings].',
                 {
                   bold: <strong />,
+                  link: (
+                    <ExternalLink href="https://gitlab.com/-/user_settings/applications" />
+                  ),
                 }
               )}
             </Text>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Changes

Added a direct link to the GitLab user settings page (`https://gitlab.com/-/user_settings/applications`) in the GitLab integration setup flow. This makes it easier for users to navigate directly to the correct settings page when setting up the GitLab integration.

## Screenshot

The link appears in Step 1 of the GitLab integration setup:

![GitLab Settings Link](https://github.com/user-attachments/assets/89655732-b97d-4a6f-9c5e-f40a8c5a9b6b)

## Details

- Modified `static/app/components/pipeline/pipelineIntegrationGitLab.tsx`
- Added `ExternalLink` import
- Updated the text in the first guided step to include a clickable link to the GitLab settings page
- The link only applies to hosted GitLab instances (gitlab.com) - self-hosted instances will still need to navigate manually as mentioned in the hint text

## Testing

- [ ] Manual testing in the GitLab integration setup flow
- [ ] Verified link opens to the correct GitLab settings page
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/C0AAW42D205/p1776789575318949?thread_ts=1776789575.318949&cid=C0AAW42D205)

<div><a href="https://cursor.com/agents/bc-8511de20-7f96-54a7-bbfa-525e25c6f97f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8511de20-7f96-54a7-bbfa-525e25c6f97f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

