### PR TITLE
feat(seer): Enable autofix for user feedback issues

### DIFF
--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -1128,6 +1128,7 @@ def is_issue_category_eligible(group: Group) -> bool:
         GroupCategory.FRONTEND,
         GroupCategory.DB_QUERY,
         GroupCategory.HTTP_CLIENT,
+        GroupCategory.FEEDBACK,
     }
 
 


### PR DESCRIPTION
Add `GroupCategory.FEEDBACK` to the `is_issue_category_eligible` allowlist in `src/sentry/seer/autofix/utils.py` so Seer Autofix can run on user feedback issues alongside error, performance, mobile, frontend, DB query, and HTTP client issues.

Previously feedback issues were rejected at the category eligibility gate with `not_eligible.issue_category_ineligible`, blocking both default automation and seat-based automation paths in `seer/autofix/trigger.py` as well as the operator entrypoint and night-shift triage task.


Agent transcript: https://claudescope.sentry.dev/share/umF5YkCOyhfYUh0raMbEkv5K6LlIXqLSKLWvZwfMZzE