### PR TITLE
feat(supergroups): add issues-with-supergroups endpoint 

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -339,6 +339,7 @@ from sentry.issues.endpoints import (
     OrganizationGroupSearchViewsStarredEndpoint,
     OrganizationGroupSearchViewVisitEndpoint,
     OrganizationIssuesCountEndpoint,
+    OrganizationIssuesWithSupergroupsEndpoint,
     OrganizationReleasePreviousCommitsEndpoint,
     OrganizationSearchesEndpoint,
     ProjectEventDetailsEndpoint,
@@ -1974,6 +1975,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/issues-stats/$",
         OrganizationGroupIndexStatsEndpoint.as_view(),
         name="sentry-api-0-organization-group-index-stats",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/issues-with-supergroups/$",
+        OrganizationIssuesWithSupergroupsEndpoint.as_view(),
+        name="sentry-api-0-organization-issues-with-supergroups",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/issues-metrics/$",

--- a/src/sentry/issues/endpoints/__init__.py
+++ b/src/sentry/issues/endpoints/__init__.py
@@ -22,6 +22,7 @@ from .organization_group_search_view_visit import OrganizationGroupSearchViewVis
 from .organization_group_search_views import OrganizationGroupSearchViewsEndpoint
 from .organization_group_search_views_starred import OrganizationGroupSearchViewsStarredEndpoint
 from .organization_issues_count import OrganizationIssuesCountEndpoint
+from .organization_issues_with_supergroups import OrganizationIssuesWithSupergroupsEndpoint
 from .organization_release_previous_commits import OrganizationReleasePreviousCommitsEndpoint
 from .organization_searches import OrganizationSearchesEndpoint
 from .organization_shortid import ShortIdLookupEndpoint
@@ -60,6 +61,7 @@ __all__ = (
     "OrganizationGroupSearchViewVisitEndpoint",
     "OrganizationGroupSearchViewsStarredEndpoint",
     "OrganizationIssuesCountEndpoint",
+    "OrganizationIssuesWithSupergroupsEndpoint",
     "OrganizationReleasePreviousCommitsEndpoint",
     "OrganizationSearchesEndpoint",
     "ProjectEventDetailsEndpoint",

--- a/src/sentry/issues/endpoints/organization_issues_with_supergroups.py
+++ b/src/sentry/issues/endpoints/organization_issues_with_supergroups.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry import features
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import cell_silo_endpoint
+from sentry.api.bases import OrganizationEventPermission
+from sentry.api.bases.organization import OrganizationEndpoint
+from sentry.api.helpers.group_index import calculate_stats_period
+from sentry.api.helpers.group_index.validators import ValidationError
+from sentry.api.utils import get_date_range_from_stats_period, handle_query_errors
+from sentry.issues.endpoints.organization_group_index import (
+    ERR_INVALID_STATS_PERIOD,
+    search_and_serialize_issues,
+    search_issues,
+)
+from sentry.models.organization import Organization
+from sentry.seer.models import SeerApiError
+from sentry.seer.supergroups.by_group import get_supergroups_by_group_ids
+
+logger = logging.getLogger(__name__)
+
+
+@cell_silo_endpoint
+class OrganizationIssuesWithSupergroupsEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+    }
+    owner = ApiOwner.ISSUES
+    permission_classes = (OrganizationEventPermission,)
+    enforce_rate_limit = True
+
+    def get(self, request: Request, organization: Organization) -> Response:
+        if not features.has("organizations:top-issues-ui", organization, actor=request.user):
+            return Response({"detail": "Feature not available"}, status=403)
+
+        stats_period = request.GET.get("groupStatsPeriod")
+        if stats_period not in (None, "", "24h", "14d", "auto"):
+            return Response({"detail": ERR_INVALID_STATS_PERIOD}, status=400)
+
+        try:
+            limit = max(0, int(request.GET.get("limit") or 25))
+        except ValueError:
+            return Response({"detail": "invalid limit"}, status=400)
+
+        start, end = get_date_range_from_stats_period(request.GET)
+        stats_period, stats_period_start, stats_period_end = calculate_stats_period(
+            stats_period, start, end
+        )
+
+        environments = self.get_environments(request, organization)
+        projects = self.get_projects(request, organization)
+        if not projects:
+            return Response([])
+
+        search_kwargs: dict[str, Any] = {
+            "stats_period": stats_period,
+            "stats_period_start": stats_period_start,
+            "stats_period_end": stats_period_end,
+            "start": start,
+            "end": end,
+            "expand": request.GET.getlist("expand", []),
+            "collapse": request.GET.getlist("collapse", []),
+        }
+
+        # Our goal is to provide ~limit number of rows to the client, and deduplicate groups in the same supergroup.
+        # When the client then goes to the next page, we don't want any of the previous rows we served to be sent.
+        # We do this by overfetching 2x the limit, and then collapsing the supergroups, then running an additional
+        # search to get the correct cursor. This means that a supergroup can appear across multiple pages,
+        # but any particular group will only appear on one page.
+        try:
+            with handle_query_errors():
+                # Overfetch 2x so supergroup collapse doesn't starve the page. Max out at 100.
+                groups, cursor_result, _ = search_and_serialize_issues(
+                    request,
+                    organization,
+                    projects,
+                    environments,
+                    limit=min(limit * 2, 100),
+                    **search_kwargs,
+                )
+
+                if not groups:
+                    return Response([])
+
+                # If Seer is down, fall through to plain groups rather than
+                # breaking the stream.
+                try:
+                    supergroup_data = get_supergroups_by_group_ids(
+                        organization, [int(g["id"]) for g in groups], user_id=request.user.id
+                    )
+                except SeerApiError:
+                    logger.exception("issues_with_supergroups.seer_fetch_failed")
+                    supergroup_data = None
+
+                rows, last_consumed = _combine_groups_and_supergroups(
+                    groups,
+                    supergroup_data,
+                    limit,
+                )
+                # Re-run sized to what we actually consumed so its next cursor
+                # sits at our page boundary, not past unemitted groups
+                if last_consumed + 1 < len(groups):
+                    cursor_result, _ = search_issues(
+                        request,
+                        organization,
+                        projects,
+                        environments,
+                        {
+                            "count_hits": True,
+                            "date_to": end,
+                            "date_from": start,
+                            "limit": last_consumed + 1,
+                        },
+                    )
+        except ValidationError as exc:
+            return Response({"detail": str(exc)}, status=400)
+
+        response = Response(rows)
+        # X-Hits is the number of rows we're returning on this page. We skip
+        # X-Max-Hits because cursor_result.max_hits counts raw matching groups,
+        # which overstates the true blended-row total and we can't cheaply
+        # compute the accurate one.
+        response["X-Hits"] = len(rows)
+        response["Link"] = ", ".join(
+            [
+                self.build_cursor_link(request, "previous", cursor_result.prev),
+                self.build_cursor_link(request, "next", cursor_result.next),
+            ]
+        )
+        return response
+
+
+def _combine_groups_and_supergroups(
+    groups: Sequence[Mapping[str, Any]],
+    supergroup_data: Mapping[str, Any] | None,
+    limit: int,
+) -> tuple[list[Mapping[str, Any]], int]:
+    sg_by_group_id: dict[int, Mapping[str, Any]] = {}
+    if supergroup_data is not None:
+        for sg in supergroup_data["data"]:
+            for gid in sg["group_ids"]:
+                sg_by_group_id[gid] = sg
+
+    rows: list[Mapping[str, Any]] = []
+    reps: dict[int, dict[str, Any]] = {}
+    last_consumed = -1
+
+    # For each group, we identify the supergroup it is in. If it is part of a supergroup that is higher up in the list,
+    # we add it to the matchingGroups list of the supergroup. If it is new, we add it as a row and add it to the reps dictionary.
+    # We continue until we would add a new row that exceeds the limit.
+    for i, group in enumerate(groups):
+        supergroup = sg_by_group_id.get(int(group["id"]))
+        # Stop once we would add a new row that exceeds the limit. This would only happen if the new group row does not have a supergroup
+        # or if the row would be a new supergroup we haven't already added.
+        if len(rows) >= limit and (supergroup is None or supergroup["id"] not in reps):
+            break
+        if supergroup is None:
+            rows.append(group)
+        elif supergroup["id"] in reps:
+            reps[supergroup["id"]]["matchingGroups"].append(group)
+        else:
+            rep: dict[str, Any] = {**group, "supergroup": supergroup, "matchingGroups": [group]}
+            reps[supergroup["id"]] = rep
+            rows.append(rep)
+        last_consumed = i
+
+    # Reps whose cluster surfaced only one member on this page become plain
+    # groups — the page filter left nothing to collapse.
+    for i, entry in enumerate(rows):
+        if "matchingGroups" in entry and len(entry["matchingGroups"]) == 1:
+            rows[i] = entry["matchingGroups"][0]
+
+    return rows, last_consumed

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -378,6 +378,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/issues-metrics/'
   | '/organizations/$organizationIdOrSlug/issues-stats/'
   | '/organizations/$organizationIdOrSlug/issues-timeseries/'
+  | '/organizations/$organizationIdOrSlug/issues-with-supergroups/'
   | '/organizations/$organizationIdOrSlug/issues/'
   | '/organizations/$organizationIdOrSlug/issues/$issueId/'
   | '/organizations/$organizationIdOrSlug/issues/$issueId/activities/'

--- a/tests/sentry/issues/endpoints/test_organization_issues_with_supergroups.py
+++ b/tests/sentry/issues/endpoints/test_organization_issues_with_supergroups.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import orjson
+
+from sentry.testutils.cases import APITestCase, SnubaTestCase
+from sentry.testutils.helpers import parse_link_header
+from sentry.testutils.helpers.datetime import before_now
+
+
+def mock_seer_response(data: dict[str, Any], status: int = 200) -> MagicMock:
+    response = MagicMock()
+    response.status = status
+    response.data = orjson.dumps(data) if status == 200 else b""
+    return response
+
+
+class OrganizationIssuesWithSupergroupsEndpointTest(APITestCase, SnubaTestCase):
+    endpoint = "sentry-api-0-organization-issues-with-supergroups"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(self.user)
+
+    def _store(self, fingerprint: str, seconds_ago: int = 10) -> Any:
+        return self.store_event(
+            data={
+                "fingerprint": [fingerprint],
+                "timestamp": before_now(seconds=seconds_ago).isoformat(),
+            },
+            project_id=self.project.id,
+        )
+
+    def test_feature_flag_off_returns_403(self) -> None:
+        self.get_error_response(self.organization.slug, status_code=403)
+
+    @patch("sentry.seer.supergroups.by_group.make_supergroups_get_by_group_ids_request")
+    def test_collapses_cluster_members_into_representative(self, mock_seer: MagicMock) -> None:
+        a = self._store("a")
+        b = self._store("b")
+        c = self._store("c")
+        mock_seer.return_value = mock_seer_response(
+            {
+                "data": [
+                    {
+                        "id": 99,
+                        "group_ids": [a.group_id, b.group_id],
+                        "title": "cluster",
+                    }
+                ]
+            }
+        )
+
+        with self.feature("organizations:top-issues-ui"):
+            response = self.get_success_response(self.organization.slug)
+
+        assert len(response.data) == 2
+        rep = next(r for r in response.data if "supergroup" in r)
+        assert rep["supergroup"]["id"] == 99
+        assert {g["id"] for g in rep["matchingGroups"]} == {str(a.group_id), str(b.group_id)}
+        standalone = next(r for r in response.data if "supergroup" not in r)
+        assert standalone["id"] == str(c.group_id)
+
+    @patch("sentry.seer.supergroups.by_group.make_supergroups_get_by_group_ids_request")
+    def test_demotes_cluster_with_single_visible_member(self, mock_seer: MagicMock) -> None:
+        visible = self._store("visible")
+        mock_seer.return_value = mock_seer_response(
+            {
+                "data": [
+                    {
+                        "id": 99,
+                        "group_ids": [visible.group_id, 99999],
+                        "title": "cluster",
+                    }
+                ]
+            }
+        )
+
+        with self.feature("organizations:top-issues-ui"):
+            response = self.get_success_response(self.organization.slug)
+
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(visible.group_id)
+        assert "supergroup" not in response.data[0]
+
+    @patch("sentry.seer.supergroups.by_group.make_supergroups_get_by_group_ids_request")
+    def test_falls_back_to_plain_groups_when_seer_fails(self, mock_seer: MagicMock) -> None:
+        event = self._store("fallback")
+        mock_seer.return_value = mock_seer_response({}, status=503)
+
+        with self.feature("organizations:top-issues-ui"):
+            response = self.get_success_response(self.organization.slug)
+
+        assert len(response.data) == 1
+        assert response.data[0]["id"] == str(event.group_id)
+        assert "supergroup" not in response.data[0]
+
+    @patch("sentry.seer.supergroups.by_group.make_supergroups_get_by_group_ids_request")
+    def test_paginates_without_group_overlap(self, mock_seer: MagicMock) -> None:
+        events = [self._store(f"e{i}") for i in range(4)]
+        mock_seer.return_value = mock_seer_response({"data": []})
+
+        with self.feature("organizations:top-issues-ui"):
+            page1 = self.get_success_response(self.organization.slug, qs_params={"limit": "2"})
+        assert len(page1.data) == 2
+
+        links = parse_link_header(page1["Link"])
+        next_href = next(url for url, attrs in links.items() if attrs["rel"] == "next")
+
+        with self.feature("organizations:top-issues-ui"):
+            page2 = self.client.get(next_href, format="json")
+        assert page2.status_code == 200
+        assert len(page2.data) == 2
+
+        page1_ids = {r["id"] for r in page1.data}
+        page2_ids = {r["id"] for r in page2.data}
+        assert page1_ids.isdisjoint(page2_ids)
+        assert page1_ids | page2_ids == {str(e.group_id) for e in events}
+
+    @patch("sentry.seer.supergroups.by_group.make_supergroups_get_by_group_ids_request")
+    def test_paginates_with_collapse_no_group_skip(self, mock_seer: MagicMock) -> None:
+        # Staggered timestamps pin sort order so events[0] is first.
+        events = [self._store(f"e{i}", seconds_ago=10 + i) for i in range(5)]
+        # Cluster (e0, e1). Page 1 overfetches [e0..e3] and blends to
+        # [rep(e0,e1), e2] — 3 raw groups consumed for 2 rows — so the
+        # next cursor must land between e2 and e3.
+        mock_seer.return_value = mock_seer_response(
+            {
+                "data": [
+                    {
+                        "id": 99,
+                        "group_ids": [events[0].group_id, events[1].group_id],
+                        "title": "cluster",
+                    }
+                ]
+            }
+        )
+
+        with self.feature("organizations:top-issues-ui"):
+            page1 = self.get_success_response(self.organization.slug, qs_params={"limit": "2"})
+
+        assert len(page1.data) == 2
+        rep = next(r for r in page1.data if "supergroup" in r)
+        assert {g["id"] for g in rep["matchingGroups"]} == {
+            str(events[0].group_id),
+            str(events[1].group_id),
+        }
+        standalone = next(r for r in page1.data if "supergroup" not in r)
+        assert standalone["id"] == str(events[2].group_id)
+
+        links = parse_link_header(page1["Link"])
+        next_href = next(url for url, attrs in links.items() if attrs["rel"] == "next")
+
+        with self.feature("organizations:top-issues-ui"):
+            page2 = self.client.get(next_href, format="json")
+        assert page2.status_code == 200
+        # Without the refetch, page 2 would start past e3 and skip it.
+        assert {r["id"] for r in page2.data} == {
+            str(events[3].group_id),
+            str(events[4].group_id),
+        }
+
+    @patch("sentry.seer.supergroups.by_group.make_supergroups_get_by_group_ids_request")
+    def test_reports_hits_as_row_count(self, mock_seer: MagicMock) -> None:
+        self._store("solo")
+        mock_seer.return_value = mock_seer_response({"data": []})
+
+        with self.feature("organizations:top-issues-ui"):
+            response = self.get_success_response(self.organization.slug)
+
+        assert response["X-Hits"] == "1"


### PR DESCRIPTION
Add a new 'issues' endpoint for a blended issues + supergroups view. This works by fetching x2 results, combining issues that are in the same supergroups, and then fetching that exact number to get the correct cursor for the next page.

Unfortunately this approach requires 2 search queries over basically the same data. The problem is maintaining the cursor here. Let's say we get a request for 25 results and fetch 50. We blend together to get 25 rows, using 40 of the original groups we fetched. We don't have a cursor to return at the 40th result, since each time we fetch a page, we get the cursor from the end of the page — we only have the cursor at 50. To fix this, we make another request for the number of issues we actually used, then modifying that cursor to work accordingly.