### PR TITLE
feat(code-review): Disable code review feature for seer-added

### DIFF
--- a/static/gsApp/views/seerAutomation/components/noActiveSeerSubscriptionBanner.tsx
+++ b/static/gsApp/views/seerAutomation/components/noActiveSeerSubscriptionBanner.tsx
@@ -18,7 +18,7 @@ export function NoActiveSeerSubscriptionBanner() {
         <Container padding="2xl">
           <Text>
             {tct(
-              'You can continue using Seer features like Autofix and Code Review for now. To keep uninterrupted access as Seer plans evolve, set up a Seer subscription in [billing:Billing]. Learn more in the [docs:docs].',
+              'You can continue using Seer features like Autofix for now. To keep uninterrupted access as Seer plans evolve, set up a Seer subscription in [billing:Billing]. Learn more in the [docs:docs].',
               {
                 billing: (
                   <Link

--- a/static/gsApp/views/seerAutomation/components/settingsPageTabs.spec.tsx
+++ b/static/gsApp/views/seerAutomation/components/settingsPageTabs.spec.tsx
@@ -34,7 +34,7 @@ describe('SettingsPageTabs', () => {
     );
   });
 
-  it('shows legacy tab order for legacy and beta cohorts', () => {
+  it('shows legacy tab order for code-review-beta cohorts', () => {
     const organization = OrganizationFixture({
       features: ['code-review-beta'],
     });
@@ -60,6 +60,51 @@ describe('SettingsPageTabs', () => {
     expect(screen.getByRole('link', {name: 'Repositories'})).toHaveAttribute(
       'href',
       `/settings/${organization.slug}/seer/scm/`
+    );
+  });
+
+  it('hides Code Review tab for legacy seer-added-only cohorts', () => {
+    const organization = OrganizationFixture({
+      features: ['seer-added'],
+    });
+
+    render(<SettingsPageTabs />, {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: `/settings/${organization.slug}/seer/`,
+        },
+      },
+    });
+
+    expect(screen.getByRole('link', {name: 'Autofix'})).toHaveAttribute(
+      'href',
+      `/settings/${organization.slug}/seer/`
+    );
+    expect(screen.getByRole('link', {name: 'Repositories'})).toHaveAttribute(
+      'href',
+      `/settings/${organization.slug}/seer/scm/`
+    );
+    expect(screen.queryByRole('link', {name: 'Code Review'})).not.toBeInTheDocument();
+  });
+
+  it('shows Code Review tab when legacy seer-added org also has code-review-beta', () => {
+    const organization = OrganizationFixture({
+      features: ['seer-added', 'code-review-beta'],
+    });
+
+    render(<SettingsPageTabs />, {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: `/settings/${organization.slug}/seer/`,
+        },
+      },
+    });
+
+    expect(screen.getByRole('link', {name: 'Code Review'})).toHaveAttribute(
+      'href',
+      `/settings/${organization.slug}/seer/repos/`
     );
   });
 });

--- a/static/gsApp/views/seerAutomation/components/settingsPageTabs.tsx
+++ b/static/gsApp/views/seerAutomation/components/settingsPageTabs.tsx
@@ -7,26 +7,32 @@ import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
+import {orgHasCodeReviewFeature} from 'getsentry/views/seerAutomation/utils';
+
 export function SettingsPageTabs() {
   const organization = useOrganization();
   const {pathname} = useLocation();
 
   const prefix = `/settings/${organization.slug}`;
-  const tabs = (
-    showNewSeer(organization)
-      ? [
-          [t('Overview'), '/seer/'],
-          [t('Repositories'), '/seer/scm/'],
-          [t('Autofix'), '/seer/projects/'],
-          [t('Code Review'), '/seer/repos/'],
-          [t('Advanced Settings'), '/seer/advanced/'],
-        ]
-      : [
-          [t('Autofix'), '/seer/'],
-          [t('Code Review'), '/seer/repos/'],
-          [t('Repositories'), '/seer/scm/'],
-        ]
-  ) satisfies Array<[string, string]>;
+  const hasCodeReviewAccess = orgHasCodeReviewFeature(organization);
+
+  const tabsData = showNewSeer(organization)
+    ? [
+        [t('Overview'), '/seer/'],
+        [t('Repositories'), '/seer/scm/'],
+        [t('Autofix'), '/seer/projects/'],
+        [t('Code Review'), '/seer/repos/'],
+        [t('Advanced Settings'), '/seer/advanced/'],
+      ]
+    : ([
+        [t('Autofix'), '/seer/'],
+        [t('Code Review'), '/seer/repos/'],
+        [t('Repositories'), '/seer/scm/'],
+      ] satisfies Array<[string, string]>);
+
+  const tabs = hasCodeReviewAccess
+    ? tabsData
+    : tabsData.filter(([label]) => label !== t('Code Review'));
 
   return (
     <Container borderBottom="primary">

--- a/static/gsApp/views/seerAutomation/repoDetails.tsx
+++ b/static/gsApp/views/seerAutomation/repoDetails.tsx
@@ -4,10 +4,10 @@ import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
 import {AnalyticsArea} from 'sentry/components/analyticsArea';
-import {NotFound} from 'sentry/components/errors/notFound';
 import {useIsSeerSupportedProvider} from 'sentry/components/events/autofix/utils';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {NoAccess} from 'sentry/components/noAccess';
 import {RepoProviderIcon} from 'sentry/components/repositories/repoProviderIcon';
 import {useRepositoryWithSettings} from 'sentry/components/repositories/useRepositoryWithSettings';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
@@ -18,16 +18,14 @@ import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageH
 
 import {RepoDetailsForm} from 'getsentry/views/seerAutomation/components/repoDetails/repoDetailsForm';
 import {SeerSettingsPageWrapper} from 'getsentry/views/seerAutomation/components/seerSettingsPageWrapper';
+import {orgHasCodeReviewFeature} from 'getsentry/views/seerAutomation/utils';
 
 export default function SeerRepoDetails() {
   const {repoId} = useParams<{repoId: string}>();
   const organization = useOrganization();
   const isSupportedProvider = useIsSeerSupportedProvider();
 
-  const hasSeer =
-    organization.features.includes('seat-based-seer-enabled') ||
-    organization.features.includes('seer-added') ||
-    organization.features.includes('code-review-beta');
+  const hasCodeReviewAccess = orgHasCodeReviewFeature(organization);
 
   const {
     data: repoWithSettings,
@@ -36,13 +34,13 @@ export default function SeerRepoDetails() {
     refetch,
   } = useRepositoryWithSettings({
     repositoryId: repoId,
-    enabled: hasSeer,
+    enabled: hasCodeReviewAccess,
   });
 
-  if (!hasSeer) {
+  if (!hasCodeReviewAccess) {
     return (
       <AnalyticsArea name="repo-details">
-        <NotFound />
+        <NoAccess />
       </AnalyticsArea>
     );
   }

--- a/static/gsApp/views/seerAutomation/repos.spec.tsx
+++ b/static/gsApp/views/seerAutomation/repos.spec.tsx
@@ -1,0 +1,17 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import SeerAutomationRepos from 'getsentry/views/seerAutomation/repos';
+
+describe('SeerAutomationRepos', () => {
+  it('shows no access for legacy seer-added-only orgs', () => {
+    const organization = OrganizationFixture({
+      features: ['seer-added'],
+    });
+
+    render(<SeerAutomationRepos />, {organization});
+
+    expect(screen.getByText("You don't have access to this feature")).toBeInTheDocument();
+  });
+});

--- a/static/gsApp/views/seerAutomation/repos.tsx
+++ b/static/gsApp/views/seerAutomation/repos.tsx
@@ -1,15 +1,28 @@
 import {ExternalLink} from '@sentry/scraps/link';
 
 import {AnalyticsArea} from 'sentry/components/analyticsArea';
+import {NoAccess} from 'sentry/components/noAccess';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 
 import {SeerRepoTable} from 'getsentry/views/seerAutomation/components/repoTable/seerRepoTable';
 import {SeerSettingsPageContent} from 'getsentry/views/seerAutomation/components/seerSettingsPageContent';
 import {SeerSettingsPageWrapper} from 'getsentry/views/seerAutomation/components/seerSettingsPageWrapper';
+import {orgHasCodeReviewFeature} from 'getsentry/views/seerAutomation/utils';
 
 export default function SeerAutomationRepos() {
+  const organization = useOrganization();
+
+  if (!orgHasCodeReviewFeature(organization)) {
+    return (
+      <AnalyticsArea name="repos">
+        <NoAccess />
+      </AnalyticsArea>
+    );
+  }
+
   return (
     <AnalyticsArea name="repos">
       <SeerSettingsPageWrapper>

--- a/static/gsApp/views/seerAutomation/utils.tsx
+++ b/static/gsApp/views/seerAutomation/utils.tsx
@@ -1,0 +1,12 @@
+import type {Organization} from 'sentry/types/organization';
+
+/**
+ * Whether the org has access to the Code Review feature.
+ * Note that legacy usage-based Seer (`seer-added` only) is excluded.
+ */
+export function orgHasCodeReviewFeature(organization: Organization) {
+  return (
+    organization.features.includes('seat-based-seer-enabled') ||
+    organization.features.includes('code-review-beta')
+  );
+}


### PR DESCRIPTION
[DO NOT MERGE UNTIL APR 22]

Per new product spec, as of Apr 22, legacy usage-based seer plan orgs will no longer have access to the code review feature. Update frontend accordingly.

Changes made:
1. "Code Review" tab hidden for legacy seer orgs

**LEGACY SEER ORG**
<img width="1067" height="584" alt="Screenshot 2026-04-21 at 9 58 48 AM" src="https://github.com/user-attachments/assets/46ffe23f-7c28-458c-a9d1-14cd70f5ce8d" />
<br>
<br>

**SEAT BASED SEER ORG**
<img width="917" height="526" alt="Screenshot 2026-04-21 at 10 01 33 AM" src="https://github.com/user-attachments/assets/7aa7cbbd-4e58-47ee-9552-6598a6db77df" />
<br>
<br>

---
2. If navigating to the repos or repoDetail page url directly, user sees a "No Access"

**LEGACY SEER ORG**
<img width="930" height="442" alt="Screenshot 2026-04-21 at 10 02 40 AM" src="https://github.com/user-attachments/assets/b2fc4579-80fe-4f1e-bf58-092671fa03f2" />
<img width="1053" height="389" alt="Screenshot 2026-04-21 at 10 04 05 AM" src="https://github.com/user-attachments/assets/4b7b14bf-debc-4e89-b3e0-d584a93653b3" />
<br>
<br>

**SEAT BASED SEER ORG**
<img width="1060" height="583" alt="Screenshot 2026-04-21 at 10 03 26 AM" src="https://github.com/user-attachments/assets/ba5c50a4-90dd-40ea-9343-f6325ba8e544" />
<img width="1058" height="526" alt="Screenshot 2026-04-21 at 10 03 42 AM" src="https://github.com/user-attachments/assets/d1dbf62a-2ded-4f5d-b1b5-6955191971be" />
<br>
<br>

---
3. The banner on "Old Experience Seer tabs" now excludes mention of Code Review feature

**NEW**
<img width="1051" height="673" alt="Screenshot 2026-04-21 at 10 10 41 AM" src="https://github.com/user-attachments/assets/a00eb08c-96ca-47da-9c40-09ee19a1f5ab" />
<br>
<br>

**OLD**
<img width="1321" height="566" alt="Screenshot 2026-04-21 at 10 15 39 AM" src="https://github.com/user-attachments/assets/135e921c-b3d2-4256-a9e4-a19748297329" />
<br>
<br>

---
Unchanged, but for reference, screenshot if you have no seer plans and go to any /seer/* route
<img width="1051" height="754" alt="Screenshot 2026-04-21 at 10 04 36 AM" src="https://github.com/user-attachments/assets/40dd6ed6-7bec-470c-9c39-4970a2c4240c" />


Closes https://linear.app/getsentry/issue/CW-1177/update-frontend
