### PR TITLE
fix(dashboards): Restore release bubbles when thresholds are configured

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -400,10 +400,15 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
 
   const yAxes: YAXisComponentOption[] = [leftYAxis, rightYAxis].filter(axis => !!axis);
 
-  // find min/max timestamp of *all* timeSeries
+  // find min/max timestamp of *all* timeSeries. Drop null boundaries from
+  // non-time-bounded plottables (e.g. `Thresholds`) before sorting —
+  // `Array.prototype.sort`'s default lexicographic comparator stringifies
+  // `null` to `"null"`, which sorts after any timestamp and would end up as
+  // `latestTimeStamp`, leaving release bubbles with no `maxTime` to bucket.
   const allBoundaries = props.plottables
     .flatMap(plottable => [plottable.start, plottable.end])
-    .toSorted();
+    .filter(defined)
+    .toSorted((a, b) => a - b);
   const earliestTimeStamp = allBoundaries.at(0);
   const latestTimeStamp = allBoundaries.at(-1);
 


### PR DESCRIPTION
On time-series dashboard widgets, configuring thresholds caused the release
bubbles to disappear entirely from the chart.

### Before
<img width="654" height="472" alt="image" src="https://github.com/user-attachments/assets/4beffdd4-c7bc-49c2-9666-a09a9bd0920e" />


### After
<img width="638" height="465" alt="image" src="https://github.com/user-attachments/assets/5571ad1e-b6ea-46f1-a1e1-befe59b0c5b1" />



The `Thresholds` plottable is a background guide with `start: null` /
`end: null`. `TimeSeriesWidgetVisualization` collects every plottable's
start and end, sorts them, and takes the min and max as the chart's
time range. The sort used the default lexicographic comparator, which
stringifies `null` to `"null"` — sorting after any timestamp string. So
as soon as a `Thresholds` plottable was in the mix, `latestTimeStamp`
came back as `null`, which `useReleaseBubbles` received as `maxTime:
undefined`, short-circuiting bucket creation and returning a null
bubble series.

Filter null boundaries out before sorting, and switch to a numeric
comparator so the code doesn't rely on lexicographic ordering of
timestamp strings.

Fixes DAIN-1542