### PR TITLE
feat(repos): Add NoIntegrationsEmptyState component

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -24,6 +24,8 @@ const productionEntryPoints = [
   'static/app/components/pipeline/**/*.{js,ts,tsx}',
   // TODO: Remove when used
   'static/app/views/seerExplorer/contexts/**/*.{js,ts,tsx}',
+  // TODO: Remove when used by organizationRepositoriesV2
+  'static/app/views/settings/organizationRepositories/noIntegrationsEmptyState.tsx',
 ];
 
 const testingEntryPoints = [

--- a/static/app/views/settings/organizationRepositories/noIntegrationsEmptyState.stories.tsx
+++ b/static/app/views/settings/organizationRepositories/noIntegrationsEmptyState.stories.tsx
@@ -1,0 +1,39 @@
+import * as Storybook from 'sentry/stories';
+import type {IntegrationProvider} from 'sentry/types/integrations';
+import {NoIntegrationsEmptyState} from 'sentry/views/settings/organizationRepositories/noIntegrationsEmptyState';
+
+function makeProvider(key: string, name: string): IntegrationProvider {
+  return {
+    key,
+    slug: key,
+    name,
+    canAdd: true,
+    canDisable: false,
+    features: [],
+    setupDialog: {url: '', width: 600, height: 600},
+    metadata: {
+      description: '',
+      features: [],
+      author: 'Sentry',
+      noun: 'Installation',
+      issue_url: '',
+      source_url: '',
+      aspects: {},
+    },
+  };
+}
+
+const SCM_PROVIDERS: IntegrationProvider[] = [
+  makeProvider('github', 'GitHub'),
+  makeProvider('github_enterprise', 'GitHub Enterprise'),
+  makeProvider('gitlab', 'GitLab'),
+  makeProvider('bitbucket', 'Bitbucket'),
+  makeProvider('bitbucket_server', 'Bitbucket Server'),
+  makeProvider('vsts', 'Azure DevOps'),
+];
+
+export default Storybook.story('NoIntegrationsEmptyState', story => {
+  story('Default', () => (
+    <NoIntegrationsEmptyState providers={SCM_PROVIDERS} onAddIntegration={() => {}} />
+  ));
+});

--- a/static/app/views/settings/organizationRepositories/noIntegrationsEmptyState.tsx
+++ b/static/app/views/settings/organizationRepositories/noIntegrationsEmptyState.tsx
@@ -1,0 +1,52 @@
+import {Tag} from '@sentry/scraps/badge';
+import {Flex} from '@sentry/scraps/layout';
+import {Heading} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {Panel} from 'sentry/components/panels/panel';
+import {PanelItem} from 'sentry/components/panels/panelItem';
+import {IconAdd, IconSeer} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import type {IntegrationProvider, IntegrationWithConfig} from 'sentry/types/integrations';
+import {getIntegrationIcon} from 'sentry/utils/integrationUtil';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {AddIntegrationButton} from 'sentry/views/settings/organizationIntegrations/addIntegrationButton';
+
+const SEER_COMPATIBLE_PROVIDERS = new Set(['github', 'gitlab']);
+
+interface Props {
+  onAddIntegration: (data: IntegrationWithConfig) => void;
+  providers: IntegrationProvider[];
+}
+
+export function NoIntegrationsEmptyState({providers, onAddIntegration}: Props) {
+  const organization = useOrganization();
+
+  return (
+    <Panel>
+      {providers.map(provider => (
+        <PanelItem key={provider.key} center>
+          <Flex align="center" gap="md" flex="1">
+            {getIntegrationIcon(provider.key, 'md')}
+            <Heading as="h4">{provider.name}</Heading>
+            {SEER_COMPATIBLE_PROVIDERS.has(provider.key) && (
+              <Tooltip title={t('Compatible with Seer.')}>
+                <Tag variant="promotion" icon={<IconSeer />}>
+                  {t('Seer')}
+                </Tag>
+              </Tooltip>
+            )}
+          </Flex>
+          <AddIntegrationButton
+            provider={provider}
+            organization={organization}
+            onAddIntegration={onAddIntegration}
+            size="sm"
+            icon={<IconAdd />}
+            buttonText={t('Connect')}
+          />
+        </PanelItem>
+      ))}
+    </Panel>
+  );
+}


### PR DESCRIPTION
A new empty-state panel shown when no SCM integrations are installed.
Lists each supported provider with a Connect button and flags
Seer-compatible providers.