### PR TITLE
feat(repos): Add ScmRepositoryTable component and useRepoSearch hook

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -25,6 +25,8 @@ const productionEntryPoints = [
   // TODO: Remove when used
   'static/app/views/settings/organizationRepositories/connectProviderDropdown.tsx',
   'static/app/views/settings/organizationRepositories/noIntegrationsEmptyState.tsx',
+  'static/app/views/settings/organizationRepositories/scmRepositoryTable.tsx',
+  'static/app/views/settings/organizationRepositories/useRepoSearch.tsx',
 ];
 
 const testingEntryPoints = [

--- a/static/app/views/settings/organizationRepositories/scmRepositoryTable.stories.tsx
+++ b/static/app/views/settings/organizationRepositories/scmRepositoryTable.stories.tsx
@@ -1,0 +1,183 @@
+import {useMemo, useState} from 'react';
+
+import {Input} from '@sentry/scraps/input';
+import {Flex} from '@sentry/scraps/layout';
+
+import * as Storybook from 'sentry/stories';
+import type {
+  Integration,
+  IntegrationProvider,
+  Repository,
+} from 'sentry/types/integrations';
+import {RepositoryStatus} from 'sentry/types/integrations';
+
+import type {ScmInstallation} from './scmRepositoryTable';
+import {ScmRepositoryTable} from './scmRepositoryTable';
+import {useRepoSearch} from './useRepoSearch';
+
+const GITHUB_PROVIDER: IntegrationProvider = {
+  key: 'github',
+  slug: 'github',
+  name: 'GitHub',
+  canAdd: true,
+  canDisable: false,
+  features: [],
+  setupDialog: {url: '', width: 600, height: 600},
+  metadata: {
+    description: '',
+    features: [],
+    author: 'Sentry',
+    noun: 'Installation',
+    issue_url: '',
+    source_url: '',
+    aspects: {},
+  },
+};
+
+function makeIntegration(id: string, name: string): Integration {
+  return {
+    id,
+    name,
+    accountType: '',
+    domainName: `github.com/${name}`,
+    gracePeriodEnd: null,
+    icon: null,
+    organizationIntegrationStatus: 'active',
+    status: 'active',
+    provider: {
+      key: 'github',
+      slug: 'github',
+      name: 'GitHub',
+      canAdd: true,
+      canDisable: false,
+      features: [],
+      aspects: {},
+    },
+  };
+}
+
+function makeRepo(id: string, name: string): Repository {
+  return {
+    id,
+    name,
+    url: `https://github.com/${name}`,
+    provider: {id: 'integrations:github', name: 'GitHub'},
+    status: RepositoryStatus.ACTIVE,
+    externalSlug: name,
+    externalId: id,
+    dateCreated: '',
+    integrationId: '',
+  };
+}
+
+const REPO_NAMES = [
+  'org-name/repo-name',
+  'org-name/repo-name-123',
+  'org-name/repo-name-abc',
+  'org-name/repo-name-kiwi-lemon',
+  'org-name/repo-name-mango-habanero',
+  'org-name/repo-name-empanada',
+];
+
+const INSTALLATIONS: ScmInstallation[] = [
+  {
+    integration: makeIntegration('1', '@org-name-123'),
+    repositories: REPO_NAMES.map((name, i) => makeRepo(`a-${i}`, name)),
+    manageUrl: 'https://github.com/',
+  },
+  {
+    integration: makeIntegration('2', '@org-name-456'),
+    repositories: REPO_NAMES.map((name, i) => makeRepo(`b-${i}`, name)),
+    manageUrl: 'https://github.com/',
+    initiallyExpanded: true,
+  },
+];
+
+const EMPTY_INSTALLATION: ScmInstallation[] = [
+  {
+    integration: makeIntegration('1', '@org-name-123'),
+    repositories: [],
+    manageUrl: 'https://github.com/',
+    initiallyExpanded: true,
+  },
+];
+
+export default Storybook.story('ScmRepositoryTable', story => {
+  story('Default', () => (
+    <ScmRepositoryTable
+      provider={GITHUB_PROVIDER}
+      installations={INSTALLATIONS}
+      onDelete={() => {}}
+      settingsTo="#"
+      overflowMenuItems={[
+        {key: 'disable', label: 'Disable integration', onAction: () => {}},
+      ]}
+      lastSyncedAt={new Date(Date.now() - 5 * 60 * 1000)}
+      onSync={() => {}}
+    />
+  ));
+
+  story('Empty installation', () => (
+    <ScmRepositoryTable
+      provider={GITHUB_PROVIDER}
+      installations={EMPTY_INSTALLATION}
+      onDelete={() => {}}
+      settingsTo="#"
+      overflowMenuItems={[
+        {key: 'disable', label: 'Disable integration', onAction: () => {}},
+      ]}
+      lastSyncedAt={new Date(Date.now() - 5 * 60 * 1000)}
+      onSync={() => {}}
+    />
+  ));
+
+  story('With search', () => {
+    const [query, setQuery] = useState('');
+    const allRepos = useMemo(() => INSTALLATIONS.flatMap(i => i.repositories), []);
+    const repoMatches = useRepoSearch(allRepos, query);
+
+    return (
+      <Flex direction="column" gap="md">
+        <Input
+          type="search"
+          placeholder="Search repositories"
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+        />
+        <ScmRepositoryTable
+          provider={GITHUB_PROVIDER}
+          installations={INSTALLATIONS.map(i => ({...i, initiallyExpanded: true}))}
+          repoMatches={repoMatches}
+          onDelete={() => {}}
+          settingsTo="#"
+        />
+      </Flex>
+    );
+  });
+
+  story('Loading and disabled', () => (
+    <ScmRepositoryTable
+      provider={GITHUB_PROVIDER}
+      installations={[
+        {
+          integration: makeIntegration('1', '@org-name-123'),
+          repositories: REPO_NAMES.map((name, i) => makeRepo(`a-${i}`, name)),
+          manageUrl: 'https://github.com/',
+          isLoading: true,
+          initiallyExpanded: true,
+        },
+        {
+          integration: {
+            ...makeIntegration('2', '@org-name-456'),
+            status: 'disabled',
+          },
+          repositories: [],
+          manageUrl: 'https://github.com/',
+          expandDisabled: true,
+        },
+      ]}
+      onDelete={() => {}}
+      settingsTo="#"
+    />
+  ));
+});

--- a/static/app/views/settings/organizationRepositories/scmRepositoryTable.tsx
+++ b/static/app/views/settings/organizationRepositories/scmRepositoryTable.tsx
@@ -1,0 +1,443 @@
+import {Fragment, useEffect, useRef, useState} from 'react';
+import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import {Tag} from '@sentry/scraps/badge';
+import {Button, LinkButton} from '@sentry/scraps/button';
+import {Flex, Grid} from '@sentry/scraps/layout';
+import {ExternalLink} from '@sentry/scraps/link';
+import {StatusIndicator} from '@sentry/scraps/statusIndicator';
+import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {CircleIndicator} from 'sentry/components/circleIndicator';
+import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
+import {Panel} from 'sentry/components/panels/panel';
+import {PanelHeader} from 'sentry/components/panels/panelHeader';
+import {getRepoStatusLabel} from 'sentry/components/repositories/getRepoStatusLabel';
+import {TimeSince} from 'sentry/components/timeSince';
+import {
+  IconChevron,
+  IconDelete,
+  IconEllipsis,
+  IconOpen,
+  IconSettings,
+  IconSync,
+} from 'sentry/icons';
+import {t, tct, tn} from 'sentry/locale';
+import type {
+  Integration,
+  IntegrationProvider,
+  Repository,
+} from 'sentry/types/integrations';
+import {RepositoryStatus} from 'sentry/types/integrations';
+import type {Fuse} from 'sentry/utils/fuzzySearch';
+import {highlightFuseMatches} from 'sentry/utils/highlightFuseMatches';
+import {getIntegrationIcon} from 'sentry/utils/integrationUtil';
+import {unreachable} from 'sentry/utils/unreachable';
+import {IntegrationIcon} from 'sentry/views/settings/organizationIntegrations/integrationIcon';
+
+/**
+ * Fuse match results keyed by `repository.id`, used to highlight the matched
+ * portions of repository names in the table.
+ */
+export type ScmRepoMatches = Record<string, readonly Fuse.FuseResultMatch[]>;
+
+export interface ScmInstallation {
+  integration: Integration;
+  repositories: Repository[];
+  expandDisabled?: boolean;
+  initiallyExpanded?: boolean;
+  isLoading?: boolean;
+  manageUrl?: string;
+}
+
+interface ScmRepositoryTableProps {
+  installations: ScmInstallation[];
+  provider: IntegrationProvider;
+  lastSyncedAt?: Date;
+  onDelete?: (integration: Integration) => void;
+  onSync?: () => void;
+  overflowMenuItems?: MenuItemProps[];
+  repoMatches?: ScmRepoMatches;
+  settingsTo?: string;
+}
+
+export function ScmRepositoryTable({
+  provider,
+  installations,
+  onDelete,
+  settingsTo,
+  overflowMenuItems,
+  lastSyncedAt,
+  onSync,
+  repoMatches,
+}: ScmRepositoryTableProps) {
+  const showFooter = lastSyncedAt !== undefined || onSync !== undefined;
+
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(() => new Set());
+
+  // `initiallyExpanded` should apply the first time we see a given integration,
+  // not on every render. Tracking which ids we've already considered lets late-
+  // arriving installations honor the flag without resetting user toggles on a
+  // refetch.
+  const seenIds = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    setExpandedIds(prev => {
+      let changed = false;
+      const next = new Set(prev);
+      for (const i of installations) {
+        if (seenIds.current.has(i.integration.id)) {
+          continue;
+        }
+        seenIds.current.add(i.integration.id);
+        if (i.initiallyExpanded) {
+          next.add(i.integration.id);
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [installations]);
+
+  const toggle = (id: string) =>
+    setExpandedIds(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+
+  return (
+    <Panel>
+      <PanelHeader hasButtons>
+        <Flex align="center" gap="sm">
+          {getIntegrationIcon(provider.key, 'sm')}
+          {provider.name}
+        </Flex>
+        <Flex align="center" gap="sm">
+          {settingsTo && (
+            <LinkButton to={settingsTo} size="xs" icon={<IconSettings />}>
+              {t('Settings')}
+            </LinkButton>
+          )}
+          {overflowMenuItems && overflowMenuItems.length > 0 && (
+            <DropdownMenu
+              items={overflowMenuItems}
+              position="bottom-end"
+              triggerProps={{
+                size: 'xs',
+                'aria-label': t('More actions'),
+                icon: <IconEllipsis />,
+              }}
+            />
+          )}
+        </Flex>
+      </PanelHeader>
+      <Grid columns="max-content 1fr" gap="0 md">
+        {installations.map(installation => (
+          <InstallationSubgrid key={installation.integration.id}>
+            <InstallationRow
+              provider={provider}
+              installation={installation}
+              expanded={expandedIds.has(installation.integration.id)}
+              onToggle={() => toggle(installation.integration.id)}
+              onDelete={onDelete ? () => onDelete(installation.integration) : undefined}
+              repoMatches={repoMatches}
+            />
+          </InstallationSubgrid>
+        ))}
+      </Grid>
+      {showFooter && (
+        <Flex
+          align="center"
+          gap="md"
+          background="secondary"
+          borderTop="primary"
+          radius="0 0 md md"
+          padding="md xl"
+        >
+          {lastSyncedAt !== undefined && (
+            <Text variant="muted" size="sm">
+              {tct('Last synced [timeSince] ago', {
+                timeSince: <TimeSince date={lastSyncedAt} suffix="" />,
+              })}
+            </Text>
+          )}
+          {onSync && (
+            <Button
+              priority="transparent"
+              size="zero"
+              icon={<IconSync size="xs" />}
+              onClick={onSync}
+            >
+              {t('Sync')}
+            </Button>
+          )}
+        </Flex>
+      )}
+    </Panel>
+  );
+}
+
+interface InstallationRowProps {
+  expanded: boolean;
+  installation: ScmInstallation;
+  onToggle: () => void;
+  provider: IntegrationProvider;
+  onDelete?: () => void;
+  repoMatches?: ScmRepoMatches;
+}
+
+function InstallationRow({
+  provider,
+  installation,
+  expanded,
+  onToggle,
+  onDelete,
+  repoMatches,
+}: InstallationRowProps) {
+  const {integration, repositories, manageUrl, isLoading, expandDisabled} = installation;
+  const isDisabled = integration.status === 'disabled';
+
+  const handleRowClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (expandDisabled) {
+      return;
+    }
+    if ((event.target as HTMLElement).closest('a, button')) {
+      return;
+    }
+    onToggle();
+  };
+
+  const handleRowKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (expandDisabled || event.target !== event.currentTarget) {
+      return;
+    }
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onToggle();
+    }
+  };
+
+  return (
+    <Fragment>
+      <RowButton
+        role="button"
+        tabIndex={expandDisabled ? -1 : 0}
+        aria-expanded={expandDisabled ? undefined : expanded}
+        aria-disabled={expandDisabled || undefined}
+        onClick={handleRowClick}
+        onKeyDown={handleRowKeyDown}
+      >
+        <IconChevron direction={expanded && !expandDisabled ? 'down' : 'right'} />
+        <Flex column="2" align="center" justify="between" gap="md">
+          <Flex align="center" gap="sm">
+            <IntegrationIcon integration={integration} size={16} />
+            <Text bold>{integration.name}</Text>
+            {isDisabled ? (
+              <Tag variant="warning">{t('Disabled')}</Tag>
+            ) : (
+              <Tag variant="muted">
+                {tn('%s repo connected', '%s repos connected', repositories.length)}
+              </Tag>
+            )}
+          </Flex>
+          <Flex align="center" gap="md">
+            {isLoading && (
+              <Flex align="center" gap="sm">
+                <StatusIndicator variant="accent" />
+                <Text variant="muted" size="xs">
+                  {t('Loading Repositories')}
+                </Text>
+              </Flex>
+            )}
+            {manageUrl && (
+              <LinkButton
+                tooltipProps={{
+                  title: t('Add or remove repository access on %s', provider.name),
+                }}
+                href={manageUrl}
+                external
+                priority="link"
+                size="xs"
+                icon={<IconOpen />}
+              >
+                {t('Manage repositories')}
+              </LinkButton>
+            )}
+            {onDelete && (
+              <Button
+                aria-label={t('Uninstall')}
+                size="xs"
+                priority="transparent"
+                icon={<IconDelete />}
+                onClick={onDelete}
+              />
+            )}
+          </Flex>
+        </Flex>
+      </RowButton>
+      {expanded && !expandDisabled && (
+        <RepoRows
+          repositories={repositories}
+          repoMatches={repoMatches}
+          manageUrl={manageUrl}
+        />
+      )}
+    </Fragment>
+  );
+}
+
+interface RepoRowsProps {
+  repositories: Repository[];
+  manageUrl?: string;
+  repoMatches?: ScmRepoMatches;
+}
+
+function RepoRows({repositories, repoMatches, manageUrl}: RepoRowsProps) {
+  const theme = useTheme();
+
+  const statusColor = (status: RepositoryStatus) => {
+    switch (status) {
+      case RepositoryStatus.DISABLED:
+      case RepositoryStatus.HIDDEN:
+      case RepositoryStatus.DELETION_IN_PROGRESS:
+        return theme.tokens.graphics.danger.vibrant;
+      case RepositoryStatus.PENDING_DELETION:
+        return theme.tokens.graphics.warning.vibrant;
+      case RepositoryStatus.ACTIVE:
+        return theme.tokens.graphics.success.vibrant;
+      default:
+        return unreachable(status);
+    }
+  };
+
+  const visibleRepos =
+    repoMatches === undefined
+      ? repositories
+      : repositories.filter(r => repoMatches[r.id]);
+
+  if (visibleRepos.length === 0) {
+    const message =
+      repoMatches !== undefined && repositories.length > 0
+        ? t('No repositories match your search')
+        : manageUrl
+          ? tct('No repositories available. [link:Manage repository access]', {
+              link: <ExternalLink href={manageUrl} />,
+            })
+          : t('No repositories available.');
+    return (
+      <RepoRow padding="md xl" justify="center">
+        <Text variant="muted">{message}</Text>
+      </RepoRow>
+    );
+  }
+
+  return (
+    <Fragment>
+      {visibleRepos.map(repo => {
+        const statusLabel = getRepoStatusLabel(repo) ?? t('Active');
+        const nameMatch = repoMatches?.[repo.id]?.find(m => m.key === 'name');
+        return (
+          <RepoRow
+            key={repo.id}
+            align="center"
+            justify="between"
+            gap="md"
+            padding="xs xl"
+          >
+            <Flex align="center" gap="md">
+              <Tooltip title={statusLabel} skipWrapper>
+                <CircleIndicator size={4} color={statusColor(repo.status)} />
+              </Tooltip>
+              <Text>
+                {nameMatch ? highlightFuseMatches(nameMatch, HighlightMark) : repo.name}
+              </Text>
+            </Flex>
+            <LinkButton
+              href={repo.url ?? ''}
+              external
+              size="xs"
+              priority="transparent"
+              icon={<IconOpen variant="muted" />}
+              aria-label={t('Open repository')}
+            />
+          </RepoRow>
+        );
+      })}
+    </Fragment>
+  );
+}
+
+const InstallationSubgrid = styled('div')`
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-column: 1 / -1;
+
+  &:not(:last-child) {
+    border-bottom: 1px solid ${p => p.theme.tokens.border.secondary};
+  }
+`;
+
+const RowButton = styled('div')`
+  cursor: pointer;
+  display: grid;
+  grid-template-columns: subgrid;
+  grid-column: 1 / -1;
+  align-items: center;
+  padding: ${p => p.theme.space.md} ${p => p.theme.space.xl};
+
+  &[aria-expanded='true'] {
+    border-bottom: 1px solid ${p => p.theme.tokens.border.secondary};
+  }
+
+  &[aria-disabled='true'] {
+    cursor: default;
+  }
+
+  &:not([aria-disabled='true']):hover {
+    background: ${p => p.theme.tokens.background.secondary};
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${p => p.theme.tokens.focus.default};
+    outline-offset: -2px;
+  }
+
+  *:last-child > &:last-child {
+    border-bottom-left-radius: ${p => p.theme.radius.md};
+    border-bottom-right-radius: ${p => p.theme.radius.md};
+  }
+`;
+
+function RepoRow({
+  children,
+  padding,
+  ...flexProps
+}: Omit<React.ComponentProps<typeof Flex>, 'children'> & {
+  children?: React.ReactNode;
+}) {
+  return (
+    <RepoRowWrapper column="1/-1" columns="subgrid" padding={padding}>
+      <Flex column="2" {...flexProps}>
+        {children}
+      </Flex>
+    </RepoRowWrapper>
+  );
+}
+
+const RepoRowWrapper = styled(Grid)`
+  &:not(:last-child) {
+    border-bottom: 1px solid ${p => p.theme.tokens.border.secondary};
+  }
+`;
+
+const HighlightMark = styled('mark')`
+  background-color: ${p => p.theme.tokens.background.transparent.warning.muted};
+  color: inherit;
+  border-radius: ${p => p.theme.radius.xs};
+`;

--- a/static/app/views/settings/organizationRepositories/useRepoSearch.tsx
+++ b/static/app/views/settings/organizationRepositories/useRepoSearch.tsx
@@ -1,0 +1,36 @@
+import {useMemo} from 'react';
+
+import type {Repository} from 'sentry/types/integrations';
+import {useFuzzySearch} from 'sentry/utils/fuzzySearch';
+
+import type {ScmRepoMatches} from './scmRepositoryTable';
+
+const FUSE_OPTIONS = {keys: ['name']};
+
+/**
+ * Builds a fuzzy search index over the given repositories and returns a
+ * mapping of `repository.id` to Fuse match results for the active query.
+ *
+ * Returns `undefined` when the query is empty, which signals to consumers
+ * (e.g. `ScmRepositoryTable`) that no filtering should be applied.
+ */
+export function useRepoSearch(
+  repositories: Repository[],
+  query: string
+): ScmRepoMatches | undefined {
+  const fuse = useFuzzySearch(repositories, FUSE_OPTIONS);
+
+  return useMemo(() => {
+    if (!query || !fuse) {
+      return undefined;
+    }
+
+    const matches: ScmRepoMatches = {};
+    for (const result of fuse.search(query)) {
+      if (result.matches) {
+        matches[result.item.id] = result.matches;
+      }
+    }
+    return matches;
+  }, [fuse, query]);
+}


### PR DESCRIPTION
Introduce a reusable component for listing SCM integrations and their
repositories, along with a hook that wraps Fuse.js for filtering and
highlighting repository matches.