### PR TITLE
chore(explore): Add header hints and update explore headers

### DIFF
--- a/static/app/views/explore/components/breadcrumb.tsx
+++ b/static/app/views/explore/components/breadcrumb.tsx
@@ -32,7 +32,7 @@ export function ExploreBreadcrumb({
   if (traceItemDataset === TraceItemDataset.TRACEMETRICS) {
     crumbs.push({
       to: makeMetricsPathname({organizationSlug: organization.slug, path: '/'}),
-      label: t('Metrics'),
+      label: t('Application Metrics'),
     });
   }
   if (traceItemDataset === TraceItemDataset.REPLAYS) {

--- a/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
@@ -3,7 +3,7 @@ import {useSortable} from '@dnd-kit/sortable';
 import {CSS} from '@dnd-kit/utilities';
 import styled from '@emotion/styled';
 
-import {Button} from '@sentry/scraps/button';
+import {Button, type ButtonProps} from '@sentry/scraps/button';
 import type {SelectKey, SelectOption} from '@sentry/scraps/compactSelect';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -132,6 +132,7 @@ interface ToolbarVisualizeAddProps {
   disabled: boolean;
   display?: 'button' | 'link';
   label?: string;
+  size?: ButtonProps['size'];
 }
 
 export function ToolbarVisualizeAddChart({
@@ -139,10 +140,11 @@ export function ToolbarVisualizeAddChart({
   disabled,
   label,
   display = 'link',
+  size = 'md',
 }: ToolbarVisualizeAddProps) {
   return (
     <ToolbarFooterButton
-      size={display === 'link' ? 'zero' : 'md'}
+      size={display === 'link' ? 'zero' : size}
       icon={<IconAdd />}
       onClick={add}
       priority={display === 'link' ? 'link' : undefined}

--- a/static/app/views/explore/logs/content.tsx
+++ b/static/app/views/explore/logs/content.tsx
@@ -8,6 +8,7 @@ import {FeedbackButton} from 'sentry/components/feedbackButton/feedbackButton';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {PageFiltersContainer} from 'sentry/components/pageFilters/container';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {withoutLoggingSupport} from 'sentry/data/platformCategories';
 import {platforms} from 'sentry/data/platforms';
@@ -125,14 +126,53 @@ function LogsHeader() {
             orgSlug={organization?.slug}
           />
         ) : null}
-        {title && defined(pageId) ? (
-          <ExploreBreadcrumb
-            traceItemDataset={TraceItemDataset.LOGS}
-            savedQueryName={savedQuery?.name}
-          />
-        ) : null}
-
-        <Layout.Title>{title ? title : t('Logs')}</Layout.Title>
+        {hasPageFrameFeature ? (
+          title && defined(pageId) ? (
+            <TopBar.Slot name="title">
+              <ExploreBreadcrumb
+                traceItemDataset={TraceItemDataset.LOGS}
+                savedQueryName={savedQuery?.name}
+              />
+              <PageHeadingQuestionTooltip
+                docsUrl="https://docs.sentry.io/product/explore/logs/"
+                title={t(
+                  'Detailed structured logs, linked to errors and traces, for debugging and investigation.'
+                )}
+                linkLabel={t('Read the Docs')}
+              />
+            </TopBar.Slot>
+          ) : (
+            <TopBar.Slot name="title">
+              {title ? title : t('Logs')}
+              <PageHeadingQuestionTooltip
+                docsUrl="https://docs.sentry.io/product/explore/logs/"
+                title={t(
+                  'Detailed structured logs, linked to errors and traces, for debugging and investigation.'
+                )}
+                linkLabel={t('Read the Docs')}
+              />
+            </TopBar.Slot>
+          )
+        ) : (
+          <Fragment>
+            {title && defined(pageId) ? (
+              <ExploreBreadcrumb
+                traceItemDataset={TraceItemDataset.LOGS}
+                savedQueryName={savedQuery?.name}
+              />
+            ) : null}
+            <Layout.Title>
+              {title ? title : t('Traces')}
+              <PageHeadingQuestionTooltip
+                docsUrl="https://docs.sentry.io/product/explore/logs/"
+                title={t(
+                  'Detailed structured logs, linked to errors and traces, for debugging and investigation.'
+                )}
+                linkLabel={t('Read the Docs')}
+              />
+            </Layout.Title>
+          </Fragment>
+        )}
       </Layout.HeaderContent>
       {hasPageFrameFeature ? (
         <Fragment>

--- a/static/app/views/explore/logs/content.tsx
+++ b/static/app/views/explore/logs/content.tsx
@@ -162,7 +162,7 @@ function LogsHeader() {
               />
             ) : null}
             <Layout.Title>
-              {title ? title : t('Traces')}
+              {title ? title : t('Logs')}
               <PageHeadingQuestionTooltip
                 docsUrl="https://docs.sentry.io/product/explore/logs/"
                 title={t(

--- a/static/app/views/explore/metrics/content.tsx
+++ b/static/app/views/explore/metrics/content.tsx
@@ -1,3 +1,5 @@
+import {Fragment} from 'react';
+
 import {FeatureBadge} from '@sentry/scraps/badge';
 import {Stack} from '@sentry/scraps/layout';
 
@@ -5,6 +7,7 @@ import {AnalyticsArea} from 'sentry/components/analyticsArea';
 import {FeedbackButton} from 'sentry/components/feedbackButton/feedbackButton';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {PageFiltersContainer} from 'sentry/components/pageFilters/container';
+import {PageHeadingQuestionTooltip} from 'sentry/components/pageHeadingQuestionTooltip';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t} from 'sentry/locale';
 import {DataCategory} from 'sentry/types/core';
@@ -101,16 +104,56 @@ function MetricsHeader() {
             orgSlug={organization?.slug}
           />
         ) : null}
-        {title && defined(pageId) ? (
-          <ExploreBreadcrumb
-            traceItemDataset={TraceItemDataset.TRACEMETRICS}
-            savedQueryName={savedQuery?.name}
-          />
-        ) : null}
-        <Layout.Title>
-          {title ? title : METRICS_TITLE}
-          <FeatureBadge type="beta" />
-        </Layout.Title>
+        {hasPageFrameFeature ? (
+          title && defined(pageId) ? (
+            <TopBar.Slot name="title">
+              <ExploreBreadcrumb
+                traceItemDataset={TraceItemDataset.TRACEMETRICS}
+                savedQueryName={savedQuery?.name}
+              />
+              <FeatureBadge type="beta" />
+              <PageHeadingQuestionTooltip
+                docsUrl="https://docs.sentry.io/product/explore/metrics/"
+                title={t(
+                  'Track critical application signals using counters, gauges, and distributions.'
+                )}
+                linkLabel={t('Read the Docs')}
+              />
+            </TopBar.Slot>
+          ) : (
+            <TopBar.Slot name="title">
+              {title ? title : METRICS_TITLE}
+              <FeatureBadge type="beta" />
+              <PageHeadingQuestionTooltip
+                docsUrl="https://docs.sentry.io/product/explore/metrics/"
+                title={t(
+                  'Track critical application signals using counters, gauges, and distributions.'
+                )}
+                linkLabel={t('Read the Docs')}
+              />
+            </TopBar.Slot>
+          )
+        ) : (
+          <Fragment>
+            {title && defined(pageId) ? (
+              <ExploreBreadcrumb
+                traceItemDataset={TraceItemDataset.TRACEMETRICS}
+                savedQueryName={savedQuery?.name}
+              />
+            ) : null}
+            <Layout.Title>
+              {title ? title : METRICS_TITLE}
+              <FeatureBadge type="beta" />
+              <PageHeadingQuestionTooltip
+                docsUrl="https://docs.sentry.io/product/explore/metrics/"
+                title={t(
+                  'Track critical application signals using counters, gauges, and distributions.'
+                )}
+                linkLabel={t('Read the Docs')}
+              />
+            </Layout.Title>
+          </Fragment>
+        )}
       </Layout.HeaderContent>
       <Layout.HeaderActions>
         {hasPageFrameFeature ? (

--- a/static/app/views/explore/metrics/content.tsx
+++ b/static/app/views/explore/metrics/content.tsx
@@ -155,21 +155,21 @@ function MetricsHeader() {
           </Fragment>
         )}
       </Layout.HeaderContent>
-      <Layout.HeaderActions>
-        {hasPageFrameFeature ? (
-          <TopBar.Slot name="feedback">
-            <FeedbackButton
-              feedbackOptions={metricsFeedbackOptions}
-              aria-label={t('Give Feedback')}
-              tooltipProps={{title: t('Give Feedback')}}
-            >
-              {null}
-            </FeedbackButton>
-          </TopBar.Slot>
-        ) : (
+      {hasPageFrameFeature ? (
+        <TopBar.Slot name="feedback">
+          <FeedbackButton
+            feedbackOptions={metricsFeedbackOptions}
+            aria-label={t('Give Feedback')}
+            tooltipProps={{title: t('Give Feedback')}}
+          >
+            {null}
+          </FeedbackButton>
+        </TopBar.Slot>
+      ) : (
+        <Layout.HeaderActions>
           <FeedbackButton feedbackOptions={metricsFeedbackOptions} />
-        )}
-      </Layout.HeaderActions>
+        </Layout.HeaderActions>
+      )}
     </Layout.Header>
   );
 }

--- a/static/app/views/explore/metrics/content.tsx
+++ b/static/app/views/explore/metrics/content.tsx
@@ -105,6 +105,7 @@ function MetricsHeader() {
   const {data: savedQuery} = useGetSavedQuery(pageId);
   const hasPageFrameFeature = useHasPageFrameFeature();
   const hasEquations = canUseMetricsEquations(organization);
+  const onboardingProject = useOnboardingProject({property: 'hasTraceMetrics'});
 
   const hasSavedQueryTitle =
     defined(pageId) && defined(savedQuery) && savedQuery.name.length > 0;
@@ -180,25 +181,27 @@ function MetricsHeader() {
       </Layout.HeaderContent>
       {hasPageFrameFeature ? (
         <Fragment>
-          <TopBar.Slot name="actions">
-            <ToolbarVisualizeAddChart
-              add={addMetricQuery}
-              disabled={isAddMetricDisabled}
-              label={t('Add Metric')}
-              display="button"
-              size="sm"
-            />
-            {hasEquations && (
+          {defined(onboardingProject) ? null : (
+            <TopBar.Slot name="actions">
               <ToolbarVisualizeAddChart
-                size="sm"
+                add={addMetricQuery}
+                disabled={isAddMetricDisabled}
+                label={t('Add Metric')}
                 display="button"
-                add={addEquationQuery}
-                disabled={metricQueries.length >= MAX_METRICS_ALLOWED}
-                label={t('Add Equation')}
+                size="sm"
               />
-            )}
-            <MetricSaveAs size="sm" />
-          </TopBar.Slot>
+              {hasEquations && (
+                <ToolbarVisualizeAddChart
+                  size="sm"
+                  display="button"
+                  add={addEquationQuery}
+                  disabled={metricQueries.length >= MAX_METRICS_ALLOWED}
+                  label={t('Add Equation')}
+                />
+              )}
+              <MetricSaveAs size="sm" />
+            </TopBar.Slot>
+          )}
           <TopBar.Slot name="feedback">
             <FeedbackButton
               feedbackOptions={metricsFeedbackOptions}

--- a/static/app/views/explore/metrics/content.tsx
+++ b/static/app/views/explore/metrics/content.tsx
@@ -17,9 +17,18 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {ExploreBreadcrumb} from 'sentry/views/explore/components/breadcrumb';
+import {ToolbarVisualizeAddChart} from 'sentry/views/explore/components/toolbar/toolbarVisualize';
 import {useGetSavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
+import {canUseMetricsEquations} from 'sentry/views/explore/metrics/metricsFlags';
 import {MetricsTabOnboarding} from 'sentry/views/explore/metrics/metricsOnboarding';
 import {MetricsTabContent} from 'sentry/views/explore/metrics/metricsTab';
+import {MetricSaveAs} from 'sentry/views/explore/metrics/metricToolbar/metricSaveAs';
+import {
+  MAX_METRICS_ALLOWED,
+  MultiMetricsQueryParamsProvider,
+  useAddMetricQuery,
+  useMultiMetricsQueryParams,
+} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
 import {
   getIdFromLocation,
   getTitleFromLocation,
@@ -40,6 +49,8 @@ export default function MetricsContent() {
     dataCategories: [DataCategory.TRACE_METRICS],
   });
   const datePageFilterProps = useDatePageFilterProps(maxPickableDays);
+  const hasEquations = canUseMetricsEquations(organization);
+
   return (
     <SentryDocumentTitle title={METRICS_TITLE} orgSlug={organization?.slug}>
       <PageFiltersContainer
@@ -59,16 +70,18 @@ export default function MetricsContent() {
       >
         <AnalyticsArea name="explore.metrics">
           <Stack flex={1}>
-            <MetricsHeader />
-            {defined(onboardingProject) ? (
-              <MetricsTabOnboarding
-                organization={organization}
-                project={onboardingProject}
-                datePageFilterProps={datePageFilterProps}
-              />
-            ) : (
-              <MetricsTabContent datePageFilterProps={datePageFilterProps} />
-            )}
+            <MultiMetricsQueryParamsProvider hasEquations={hasEquations}>
+              <MetricsHeader />
+              {defined(onboardingProject) ? (
+                <MetricsTabOnboarding
+                  organization={organization}
+                  project={onboardingProject}
+                  datePageFilterProps={datePageFilterProps}
+                />
+              ) : (
+                <MetricsTabContent datePageFilterProps={datePageFilterProps} />
+              )}
+            </MultiMetricsQueryParamsProvider>
           </Stack>
         </AnalyticsArea>
       </PageFiltersContainer>
@@ -91,9 +104,19 @@ function MetricsHeader() {
   const organization = useOrganization();
   const {data: savedQuery} = useGetSavedQuery(pageId);
   const hasPageFrameFeature = useHasPageFrameFeature();
+  const hasEquations = canUseMetricsEquations(organization);
 
   const hasSavedQueryTitle =
     defined(pageId) && defined(savedQuery) && savedQuery.name.length > 0;
+
+  const addMetricQuery = useAddMetricQuery();
+  const metricQueries = useMultiMetricsQueryParams();
+  const addEquationQuery = useAddMetricQuery({type: 'equation'});
+
+  // Cannot add metric queries beyond Z
+  const isAddMetricDisabled =
+    metricQueries.length >= MAX_METRICS_ALLOWED ||
+    metricQueries.some(q => q.label === 'Z');
 
   return (
     <Layout.Header unified>
@@ -156,15 +179,36 @@ function MetricsHeader() {
         )}
       </Layout.HeaderContent>
       {hasPageFrameFeature ? (
-        <TopBar.Slot name="feedback">
-          <FeedbackButton
-            feedbackOptions={metricsFeedbackOptions}
-            aria-label={t('Give Feedback')}
-            tooltipProps={{title: t('Give Feedback')}}
-          >
-            {null}
-          </FeedbackButton>
-        </TopBar.Slot>
+        <Fragment>
+          <TopBar.Slot name="actions">
+            <ToolbarVisualizeAddChart
+              add={addMetricQuery}
+              disabled={isAddMetricDisabled}
+              label={t('Add Metric')}
+              display="button"
+              size="sm"
+            />
+            {hasEquations && (
+              <ToolbarVisualizeAddChart
+                size="sm"
+                display="button"
+                add={addEquationQuery}
+                disabled={metricQueries.length >= MAX_METRICS_ALLOWED}
+                label={t('Add Equation')}
+              />
+            )}
+            <MetricSaveAs size="sm" />
+          </TopBar.Slot>
+          <TopBar.Slot name="feedback">
+            <FeedbackButton
+              feedbackOptions={metricsFeedbackOptions}
+              aria-label={t('Give Feedback')}
+              tooltipProps={{title: t('Give Feedback')}}
+            >
+              {null}
+            </FeedbackButton>
+          </TopBar.Slot>
+        </Fragment>
       ) : (
         <Layout.HeaderActions>
           <FeedbackButton feedbackOptions={metricsFeedbackOptions} />

--- a/static/app/views/explore/metrics/metricsTab.tsx
+++ b/static/app/views/explore/metrics/metricsTab.tsx
@@ -31,7 +31,6 @@ import {MetricsQueryParamsProvider} from 'sentry/views/explore/metrics/metricsQu
 import {MetricSaveAs} from 'sentry/views/explore/metrics/metricToolbar/metricSaveAs';
 import {
   MAX_METRICS_ALLOWED,
-  MultiMetricsQueryParamsProvider,
   useAddMetricQuery,
   useMultiMetricsQueryParams,
 } from 'sentry/views/explore/metrics/multiMetricsQueryParams';
@@ -40,6 +39,7 @@ import {
   StyledPageFilterBar,
 } from 'sentry/views/explore/metrics/styles';
 import {isVisualizeEquation} from 'sentry/views/explore/queryParams/visualize';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 export const METRICS_CHART_GROUP = 'metrics-charts-group';
 
 type MetricsTabProps = {
@@ -47,16 +47,6 @@ type MetricsTabProps = {
 };
 
 export function MetricsTabContent({datePageFilterProps}: MetricsTabProps) {
-  const organization = useOrganization();
-  const hasEquations = canUseMetricsEquations(organization);
-  return (
-    <MultiMetricsQueryParamsProvider hasEquations={hasEquations}>
-      <MetricsTabContentInner datePageFilterProps={datePageFilterProps} />
-    </MultiMetricsQueryParamsProvider>
-  );
-}
-
-function MetricsTabContentInner({datePageFilterProps}: MetricsTabProps) {
   const {referencedMetricLabels, onEquationLabelsChange} = useEquationReferencedLabels();
 
   return (
@@ -78,6 +68,7 @@ function MetricsTabFilterSection({datePageFilterProps}: MetricsTabProps) {
   const addMetricQuery = useAddMetricQuery();
   const addEquationQuery = useAddMetricQuery({type: 'equation'});
   const hasEquations = canUseMetricsEquations(organization);
+  const hasPageFrameFeature = useHasPageFrameFeature();
 
   // Cannot add metric queries beyond Z
   const isAddMetricDisabled =
@@ -96,24 +87,25 @@ function MetricsTabFilterSection({datePageFilterProps}: MetricsTabProps) {
               searchPlaceholder={t('Custom range: 2h, 4d, 3w')}
             />
           </StyledPageFilterBar>
-          <Flex gap="sm" align="center">
-            <ToolbarVisualizeAddChart
-              add={addMetricQuery}
-              disabled={isAddMetricDisabled}
-              label={t('Add Metric')}
-              display="button"
-            />
-
-            {hasEquations && (
+          {hasPageFrameFeature ? null : (
+            <Flex gap="sm" align="center">
               <ToolbarVisualizeAddChart
+                add={addMetricQuery}
+                disabled={isAddMetricDisabled}
+                label={t('Add Metric')}
                 display="button"
-                add={addEquationQuery}
-                disabled={metricQueries.length >= MAX_METRICS_ALLOWED}
-                label={t('Add Equation')}
               />
-            )}
-            <MetricSaveAs size="md" />
-          </Flex>
+              {hasEquations && (
+                <ToolbarVisualizeAddChart
+                  display="button"
+                  add={addEquationQuery}
+                  disabled={metricQueries.length >= MAX_METRICS_ALLOWED}
+                  label={t('Add Equation')}
+                />
+              )}
+              <MetricSaveAs size="md" />
+            </Flex>
+          )}
         </FilterBarWithSaveAsContainer>
       </Layout.Main>
     </ExploreBodySearch>
@@ -130,6 +122,7 @@ function MetricsTabBodySection({
   onEquationLabelsChange,
 }: SectionProps) {
   const organization = useOrganization();
+  const hasPageFrameFeature = useHasPageFrameFeature();
   const metricQueries = useMultiMetricsQueryParams();
   const addMetricQuery = useAddMetricQuery();
   const [interval] = useChartInterval();
@@ -193,22 +186,24 @@ function MetricsTabBodySection({
             referencedMetricLabels={referencedMetricLabels}
             onEquationLabelsChange={onEquationLabelsChange}
           />
-          <Flex gap="sm" direction="row">
-            <ToolbarVisualizeAddChart
-              add={addMetricQuery}
-              disabled={isAddMetricDisabled}
-              label={t('Add Metric')}
-              display="button"
-            />
-            {hasEquations && (
+          {hasPageFrameFeature ? null : (
+            <Flex gap="sm" direction="row">
               <ToolbarVisualizeAddChart
+                add={addMetricQuery}
+                disabled={isAddMetricDisabled}
+                label={t('Add Metric')}
                 display="button"
-                add={addEquationQuery}
-                disabled={metricQueries.length >= MAX_METRICS_ALLOWED}
-                label={t('Add Equation')}
               />
-            )}
-          </Flex>
+              {hasEquations && (
+                <ToolbarVisualizeAddChart
+                  display="button"
+                  add={addEquationQuery}
+                  disabled={metricQueries.length >= MAX_METRICS_ALLOWED}
+                  label={t('Add Equation')}
+                />
+              )}
+            </Flex>
+          )}
         </WidgetSyncContextProvider>
       </Stack>
     </ExploreContentSection>

--- a/static/app/views/explore/metrics/styles.tsx
+++ b/static/app/views/explore/metrics/styles.tsx
@@ -17,5 +17,4 @@ export const StyledPageFilterBar = styled(PageFilterBar)`
 export const FilterBarWithSaveAsContainer = styled(Flex)`
   justify-content: space-between;
   align-items: center;
-  margin-bottom: ${p => p.theme.space.md};
 `;

--- a/static/app/views/explore/spans/content.tsx
+++ b/static/app/views/explore/spans/content.tsx
@@ -175,22 +175,22 @@ function SpansTabHeader() {
                 savedQueryName={savedQuery?.name}
               />
               <PageHeadingQuestionTooltip
-                docsUrl="https://github.com/getsentry/sentry/discussions/81239"
+                docsUrl="https://docs.sentry.io/product/explore/trace-explorer/"
                 title={t(
                   'Find problematic spans/traces or compute real-time metrics via aggregation.'
                 )}
-                linkLabel={t('Read the Discussion')}
+                linkLabel={t('Read the Docs')}
               />
             </TopBar.Slot>
           ) : (
             <TopBar.Slot name="title">
               {title ? title : t('Traces')}
               <PageHeadingQuestionTooltip
-                docsUrl="https://github.com/getsentry/sentry/discussions/81239"
+                docsUrl="https://docs.sentry.io/product/explore/trace-explorer/"
                 title={t(
                   'Find problematic spans/traces or compute real-time metrics via aggregation.'
                 )}
-                linkLabel={t('Read the Discussion')}
+                linkLabel={t('Read the Docs')}
               />
             </TopBar.Slot>
           )
@@ -205,11 +205,11 @@ function SpansTabHeader() {
             <Layout.Title>
               {title ? title : t('Traces')}
               <PageHeadingQuestionTooltip
-                docsUrl="https://github.com/getsentry/sentry/discussions/81239"
+                docsUrl="https://docs.sentry.io/product/explore/trace-explorer/"
                 title={t(
                   'Find problematic spans/traces or compute real-time metrics via aggregation.'
                 )}
-                linkLabel={t('Read the Discussion')}
+                linkLabel={t('Read the Docs')}
               />
             </Layout.Title>
           </Fragment>

--- a/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
@@ -97,10 +97,10 @@ export function ExploreSecondaryNavigation() {
                 <SecondaryNavigation.ListItem>
                   <SecondaryNavigation.Link
                     to={`${baseUrl}/metrics/`}
-                    analyticsItemName="explore_application_metrics"
+                    analyticsItemName="explore_metrics"
                     trailingItems={<FeatureBadge type="beta" />}
                   >
-                    {t('Application Metrics')}
+                    {t('Metrics')}
                   </SecondaryNavigation.Link>
                 </SecondaryNavigation.ListItem>
               </Feature>

--- a/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
@@ -100,7 +100,7 @@ export function ExploreSecondaryNavigation() {
                     analyticsItemName="explore_metrics"
                     trailingItems={<FeatureBadge type="beta" />}
                   >
-                    {t('Metrics')}
+                    {t('Application Metrics')}
                   </SecondaryNavigation.Link>
                 </SecondaryNavigation.ListItem>
               </Feature>

--- a/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
@@ -97,7 +97,7 @@ export function ExploreSecondaryNavigation() {
                 <SecondaryNavigation.ListItem>
                   <SecondaryNavigation.Link
                     to={`${baseUrl}/metrics/`}
-                    analyticsItemName="explore_metrics"
+                    analyticsItemName="explore_application_metrics"
                     trailingItems={<FeatureBadge type="beta" />}
                   >
                     {t('Application Metrics')}


### PR DESCRIPTION
Updates the headers for the Logs and Application Metrics pages to match the latest design-engineering patterns, adds tooltips/hints on Logs and Metrics, and refreshes the docs link on Traces.

Also moved the action buttons ("Add Metric" / "Add Equation" / "Save As") into the new page frame `TopBar` actions slot. Removing them from the page filter level, and rendering below the panels.

As well, fixed a padding and layout issue on the metrics page causing a slight inconsistency between it and other explore pages, in placement of the header elements.

Replaces #113314, which was opened on the previous branch name before the LOGS scope was folded in.

Closes EXP-881
Closes LOGS-714
Closes LOGS-715

Examples:

|Tooltip|Example|
|-|-|
|Traces tooltip| <img width="316" height="92" alt="Screenshot 2026-04-21 at 15 03 02" src="https://github.com/user-attachments/assets/ad347218-4911-4f3a-8a8b-cd93516190f0" /> |
|Logs tooltip| <img width="303" height="98" alt="Screenshot 2026-04-21 at 15 02 54" src="https://github.com/user-attachments/assets/0d57e92f-484e-4635-a5af-8779c4360e9d" /> |
|Metrics tooltip| <img width="437" height="97" alt="Screenshot 2026-04-21 at 15 02 48" src="https://github.com/user-attachments/assets/30dd71cf-d52c-4867-9be4-5bf5c36dbd4c" /> |

|Metrics Page|Examples|
|-|-|
|Before with `page-frame`| <img width="1659" height="276" alt="Screenshot 2026-04-21 at 15 05 10" src="https://github.com/user-attachments/assets/7dce63e1-80a4-4fe9-997e-71230186378d" /> |
|After with `page-frame`| <img width="1659" height="276" alt="Screenshot 2026-04-21 at 15 05 18" src="https://github.com/user-attachments/assets/e3647362-e429-44cf-901f-b66de8b37869" /> |
|Before without `page-frame`| <img width="1659" height="276" alt="Screenshot 2026-04-21 at 15 06 49" src="https://github.com/user-attachments/assets/02983997-baf1-4974-92b7-da6197997d80" /> |
|After without `page-frame`| <img width="1659" height="276" alt="Screenshot 2026-04-21 at 15 06 51" src="https://github.com/user-attachments/assets/005c60c2-26f5-4bbe-af5b-51b2f61d054c" /> |
|Onboarding Project with `page-frame`| <img width="1659" height="313" alt="Screenshot 2026-04-21 at 15 15 23" src="https://github.com/user-attachments/assets/55ce80cf-0ed0-4828-845b-623358ce2742" /> |