### PR TITLE
fix(supergroups): Fallback to limited query on large supergroups

### DIFF
--- a/static/app/views/issueList/supergroups/supergroupDrawer.spec.tsx
+++ b/static/app/views/issueList/supergroups/supergroupDrawer.spec.tsx
@@ -1,0 +1,71 @@
+import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {SupergroupDetailFixture} from 'sentry-fixture/supergroupDetail';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {SupergroupDetailDrawer} from 'sentry/views/issueList/supergroups/supergroupDrawer';
+
+describe('SupergroupDetailDrawer', () => {
+  const organization = OrganizationFixture();
+  const issuesUrl = `/organizations/${organization.slug}/issues/`;
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [],
+    });
+  });
+
+  it('hoists stream matches to the first page for supergroups too large to inline', async () => {
+    // Over the inline-id limit, so hoisting takes the stream-scan path.
+    const memberIds = Array.from({length: 250}, (_, i) => i + 1);
+    const matchedMemberId = '100';
+    const nonMemberId = '9999';
+
+    // Page fetch: only this request has `group=`.
+    const otherMembers = memberIds
+      .filter(id => String(id) !== matchedMemberId)
+      .slice(0, 24)
+      .map(id => GroupFixture({id: String(id), title: `OTHER_${id}`}));
+    MockApiClient.addMockResponse({
+      url: issuesUrl,
+      method: 'GET',
+      body: [
+        GroupFixture({id: matchedMemberId, metadata: {title: 'MATCHED_MEMBER'}}),
+        ...otherMembers,
+      ],
+      match: [(_url, options) => Array.isArray(options.query?.group)],
+    });
+
+    // Stream scan: one member + one non-member. Only the member should hoist.
+    MockApiClient.addMockResponse({
+      url: issuesUrl,
+      method: 'GET',
+      body: [
+        GroupFixture({id: matchedMemberId, metadata: {title: 'MATCHED_MEMBER'}}),
+        GroupFixture({id: nonMemberId, title: 'NON_MEMBER'}),
+      ],
+      match: [(_url, options) => !options.query?.group],
+    });
+
+    render(
+      <SupergroupDetailDrawer
+        supergroup={SupergroupDetailFixture({group_ids: memberIds})}
+        filterWithCurrentSearch
+      />,
+      {
+        organization,
+        initialRouterConfig: {
+          location: {pathname: '/', query: {query: 'is:unresolved'}},
+        },
+      }
+    );
+
+    // Skeletons share data-test-id="group", wait for real content first.
+    expect(await screen.findByText('MATCHED_MEMBER')).toBeInTheDocument();
+    const rows = screen.getAllByTestId('group');
+    expect(rows[0]).toHaveTextContent('MATCHED_MEMBER');
+  });
+});

--- a/static/app/views/issueList/supergroups/supergroupDrawer.spec.tsx
+++ b/static/app/views/issueList/supergroups/supergroupDrawer.spec.tsx
@@ -58,7 +58,11 @@ describe('SupergroupDetailDrawer', () => {
       {
         organization,
         initialRouterConfig: {
-          location: {pathname: '/', query: {query: 'is:unresolved'}},
+          route: '/organizations/:orgId/issues/',
+          location: {
+            pathname: '/organizations/:orgId/issues/',
+            query: {query: 'is:unresolved'},
+          },
         },
       }
     );

--- a/static/app/views/issueList/supergroups/supergroupDrawer.spec.tsx
+++ b/static/app/views/issueList/supergroups/supergroupDrawer.spec.tsx
@@ -67,7 +67,6 @@ describe('SupergroupDetailDrawer', () => {
       }
     );
 
-    // Skeletons share data-test-id="group", wait for real content first.
     expect(await screen.findByText('MATCHED_MEMBER')).toBeInTheDocument();
     const rows = screen.getAllByTestId('group');
     expect(rows[0]).toHaveTextContent('MATCHED_MEMBER');

--- a/static/app/views/issueList/supergroups/supergroupDrawer.tsx
+++ b/static/app/views/issueList/supergroups/supergroupDrawer.tsx
@@ -131,6 +131,19 @@ export function SupergroupDetailDrawer({
 
 const PAGE_SIZE = 25;
 
+/**
+ * Max member IDs we can embed in an `issue.id:[…]` clause before the GET URL
+ * gets too big. Below the limit we filter the stream query *to* our members;
+ * above it we invert: query the stream unfiltered and intersect locally.
+ */
+const HOIST_INLINE_ID_LIMIT = 200;
+
+/**
+ * When a supergroup is too big to inline its IDs, we look at this many top
+ * stream results and keep the ones that happen to be members.
+ */
+const HOIST_STREAM_SCAN_SIZE = 100;
+
 function SupergroupIssueList({
   groupIds,
   memberList,
@@ -154,8 +167,8 @@ function SupergroupIssueList({
   } = location.query;
   const query = typeof searchQuery === 'string' ? searchQuery : '';
 
-  // Search with the stream query across all member issues so matched issues
-  // can be hoisted to page 1 before pagination.
+  const inlineIdListFits = groupIds.length <= HOIST_INLINE_ID_LIMIT;
+
   const {data: matchedGroups, isPending: matchedPending} = useQuery({
     ...apiOptions.as<Group[]>()('/organizations/$organizationIdOrSlug/issues/', {
       path: {organizationIdOrSlug: organization.slug},
@@ -165,37 +178,57 @@ function SupergroupIssueList({
         statsPeriod,
         start,
         end,
-        query: `${query} issue.id:[${groupIds.join(',')}]`,
-        per_page: PAGE_SIZE,
+        query: inlineIdListFits ? `${query} issue.id:[${groupIds.join(',')}]` : query,
+        per_page: inlineIdListFits ? PAGE_SIZE : HOIST_STREAM_SCAN_SIZE,
       },
       staleTime: 30_000,
     }),
-    enabled: !!filterWithCurrentSearch,
+    enabled: !!filterWithCurrentSearch && groupIds.length > 0,
   });
 
-  const matchedIds = new Set(matchedGroups?.map(g => g.id));
-  const sortedGroupIds = [...groupIds].sort(
-    (a, b) => Number(matchedIds.has(String(b))) - Number(matchedIds.has(String(a)))
+  const matchedIds = useMemo(() => {
+    if (!matchedGroups) {
+      return new Set<string>();
+    }
+    if (inlineIdListFits) {
+      return new Set(matchedGroups.map(g => g.id));
+    }
+    const memberSet = new Set(groupIds.map(String));
+    return new Set(matchedGroups.map(g => g.id).filter(id => memberSet.has(id)));
+  }, [matchedGroups, inlineIdListFits, groupIds]);
+
+  // When filtering with the stream query, wait for the match so the IDs we
+  // fetch reflect the hoisted ordering.
+  const pageFetchReady = !filterWithCurrentSearch || !matchedPending;
+  const sortedGroupIds = useMemo(
+    () =>
+      filterWithCurrentSearch
+        ? [...groupIds].sort(
+            (a, b) =>
+              Number(matchedIds.has(String(b))) - Number(matchedIds.has(String(a)))
+          )
+        : groupIds,
+    [filterWithCurrentSearch, groupIds, matchedIds]
   );
 
-  const totalPages = Math.ceil(sortedGroupIds.length / PAGE_SIZE);
+  const totalPages = Math.max(1, Math.ceil(sortedGroupIds.length / PAGE_SIZE));
   const safePage = Math.min(page, totalPages - 1);
-  const pageGroupIds = sortedGroupIds.slice(
+  const visibleIds = sortedGroupIds.slice(
     safePage * PAGE_SIZE,
     (safePage + 1) * PAGE_SIZE
   );
 
-  // Fetch all groups on this page
-  const {data: allGroups, isPending: allPending} = useQuery(
-    apiOptions.as<Group[]>()('/organizations/$organizationIdOrSlug/issues/', {
+  const {data: allGroups, isPending: allPending} = useQuery({
+    ...apiOptions.as<Group[]>()('/organizations/$organizationIdOrSlug/issues/', {
       path: {organizationIdOrSlug: organization.slug},
       query: {
-        group: pageGroupIds.map(String),
+        group: visibleIds.map(String),
         project: ALL_ACCESS_PROJECTS,
       },
       staleTime: 30_000,
-    })
-  );
+    }),
+    enabled: pageFetchReady,
+  });
 
   if (allPending || (filterWithCurrentSearch && matchedPending)) {
     return (
@@ -214,7 +247,7 @@ function SupergroupIssueList({
             <DrawerColumnHeaders />
           </LoadingHeader>
           <PanelBody>
-            {pageGroupIds.map(id => (
+            {visibleIds.map(id => (
               <LoadingStreamGroup key={id} withChart withColumns={DRAWER_COLUMNS} />
             ))}
           </PanelBody>
@@ -224,11 +257,10 @@ function SupergroupIssueList({
   }
 
   const groupMap = new Map(allGroups?.map(g => [g.id, g]));
-
-  const sortedGroups = pageGroupIds
+  const sortedGroups = visibleIds
     .map(id => groupMap.get(String(id)))
-    .filter((g): g is Group => g !== undefined);
-
+    .filter((g): g is Group => g !== undefined)
+    .sort((a, b) => Number(matchedIds.has(b.id)) - Number(matchedIds.has(a.id)));
   const visibleGroupIds = sortedGroups.map(g => g.id);
 
   return (

--- a/static/app/views/issueList/supergroups/supergroupDrawer.tsx
+++ b/static/app/views/issueList/supergroups/supergroupDrawer.tsx
@@ -132,17 +132,12 @@ export function SupergroupDetailDrawer({
 const PAGE_SIZE = 25;
 
 /**
- * Max member IDs we can embed in an `issue.id:[…]` clause before the GET URL
- * gets too big. Below the limit we filter the stream query *to* our members;
- * above it we invert: query the stream unfiltered and intersect locally.
+ * How many items we're willing to hoist. Doubles as the inline-id cap (members
+ * we'll embed in `issue.id:[…]` before the URL gets too big) and the stream-
+ * scan window (top stream results we inspect when the id list is too big to
+ * inline).
  */
-const HOIST_INLINE_ID_LIMIT = 200;
-
-/**
- * When a supergroup is too big to inline its IDs, we look at this many top
- * stream results and keep the ones that happen to be members.
- */
-const HOIST_STREAM_SCAN_SIZE = 100;
+const HOIST_LIMIT = 100;
 
 function SupergroupIssueList({
   groupIds,
@@ -167,7 +162,7 @@ function SupergroupIssueList({
   } = location.query;
   const query = typeof searchQuery === 'string' ? searchQuery : '';
 
-  const inlineIdListFits = groupIds.length <= HOIST_INLINE_ID_LIMIT;
+  const inlineIdListFits = groupIds.length <= HOIST_LIMIT;
 
   const {data: matchedGroups, isPending: matchedPending} = useQuery({
     ...apiOptions.as<Group[]>()('/organizations/$organizationIdOrSlug/issues/', {
@@ -179,7 +174,7 @@ function SupergroupIssueList({
         start,
         end,
         query: inlineIdListFits ? `${query} issue.id:[${groupIds.join(',')}]` : query,
-        per_page: inlineIdListFits ? PAGE_SIZE : HOIST_STREAM_SCAN_SIZE,
+        per_page: HOIST_LIMIT,
       },
       staleTime: 30_000,
     }),

--- a/static/app/views/issueList/supergroups/supergroupDrawer.tsx
+++ b/static/app/views/issueList/supergroups/supergroupDrawer.tsx
@@ -137,7 +137,7 @@ const PAGE_SIZE = 25;
  * scan window (top stream results we inspect when the id list is too big to
  * inline).
  */
-const HOIST_LIMIT = 100;
+const HOIST_LIMIT = 50;
 
 function SupergroupIssueList({
   groupIds,

--- a/static/app/views/issueList/supergroups/useSuperGroups.spec.tsx
+++ b/static/app/views/issueList/supergroups/useSuperGroups.spec.tsx
@@ -1,30 +1,16 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
+import {SupergroupDetailFixture} from 'sentry-fixture/supergroupDetail';
 
 import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import type {SupergroupDetail} from 'sentry/views/issueList/supergroups/types';
 import {useSuperGroups} from 'sentry/views/issueList/supergroups/useSuperGroups';
 
 const organization = OrganizationFixture({features: ['top-issues-ui']});
 const API_URL = `/organizations/${organization.slug}/seer/supergroups/by-group/`;
 
-function makeSupergroup(overrides: Partial<SupergroupDetail> = {}): SupergroupDetail {
-  return {
-    id: 1,
-    title: 'Test Supergroup',
-    summary: 'A test supergroup',
-    error_type: 'TypeError',
-    code_area: 'frontend',
-    group_ids: [1, 2, 3],
-    created_at: '2024-01-01T00:00:00Z',
-    updated_at: '2024-01-01T00:00:00Z',
-    ...overrides,
-  };
-}
-
 describe('useSuperGroups', () => {
   it('does not show loading state when archiving a group backfills a new one', async () => {
-    const supergroup = makeSupergroup({group_ids: [1, 2, 3]});
+    const supergroup = SupergroupDetailFixture({group_ids: [1, 2, 3]});
     const mockRequest = MockApiClient.addMockResponse({
       url: API_URL,
       body: {data: [supergroup]},
@@ -54,7 +40,7 @@ describe('useSuperGroups', () => {
   });
 
   it('shows loading state when navigating to an entirely new page', async () => {
-    const supergroup = makeSupergroup({group_ids: [1, 2, 3]});
+    const supergroup = SupergroupDetailFixture({group_ids: [1, 2, 3]});
     const mockRequest = MockApiClient.addMockResponse({
       url: API_URL,
       body: {data: [supergroup]},

--- a/tests/js/fixtures/supergroupDetail.ts
+++ b/tests/js/fixtures/supergroupDetail.ts
@@ -1,0 +1,17 @@
+import type {SupergroupDetail} from 'sentry/views/issueList/supergroups/types';
+
+export function SupergroupDetailFixture(
+  params: Partial<SupergroupDetail> = {}
+): SupergroupDetail {
+  return {
+    id: 1,
+    title: 'Test Supergroup',
+    summary: 'A test supergroup',
+    error_type: 'TypeError',
+    code_area: 'frontend',
+    group_ids: [1, 2, 3],
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    ...params,
+  };
+}


### PR DESCRIPTION
Disable matching group hoisting for large super groups.

- `<= 50` members: stream match uses `issue.id:[…]` and returns up to 100 hits, sorted to the front of the list.
- `> 50` members: stream query runs unfiltered with `per_page=100`. Stream results land on page 1.

Each page fetch asks for at most 25 IDs so URL size stays bounded regardless of supergroup size.

Memoizes the member-list sort. Adds a `SupergroupDetailFixture` and a drawer spec for the large-group path.