### PR TITLE
ref(page-frame): Compact editable titles in topbar for dashboards and monitors

### DIFF
--- a/static/app/components/editableText.tsx
+++ b/static/app/components/editableText.tsx
@@ -29,6 +29,11 @@ type Props = {
    */
   placeholder?: string;
   successMessage?: React.ReactNode;
+  /**
+   * "compact" removes fixed heights so the component inherits font-size and
+   * line-height from its context (e.g. when rendered inside a breadcrumb row).
+   */
+  variant?: 'compact';
 };
 
 export function EditableText({
@@ -44,6 +49,7 @@ export function EditableText({
   'aria-label': ariaLabel,
   placeholder,
   allowEmpty = false,
+  variant,
 }: Props) {
   const [isEditing, setIsEditing] = useState(false);
   // Immediately reflect the last committed value while we wait for the parent prop update
@@ -187,6 +193,8 @@ export function EditableText({
     [handleCancel, handleCommit]
   );
 
+  const isCompact = variant === 'compact';
+
   return (
     <Wrapper isDisabled={isDisabled} isEditing={isEditing} className={className}>
       {isEditing ? (
@@ -205,6 +213,7 @@ export function EditableText({
             onFocus={event => autoSelect && event.target.select()}
             maxLength={maxLength}
             placeholder={placeholder}
+            isCompact={isCompact}
           />
           <InputLabel>{currentDraft}</InputLabel>
         </InputWrapper>
@@ -215,7 +224,7 @@ export function EditableText({
           isDisabled={isDisabled}
           data-test-id="editable-text-label"
         >
-          <InnerLabel>{currentValue || placeholder}</InnerLabel>
+          <InnerLabel isCompact={isCompact}>{currentValue || placeholder}</InnerLabel>
           {!isDisabled && <IconEdit />}
         </Label>
       )}
@@ -231,10 +240,11 @@ const Label = styled('div')<{isDisabled: boolean}>`
   cursor: ${p => (p.isDisabled ? 'default' : 'pointer')};
 `;
 
-const InnerLabel = styled(TextOverflow)`
+const InnerLabel = styled(TextOverflow)<{isCompact?: boolean}>`
   border-top: 1px solid transparent;
-  border-bottom: 1px dotted ${p => p.theme.tokens.border.primary};
-  line-height: 38px;
+  border-bottom: ${p =>
+    p.isCompact ? 'none' : `1px dotted ${p.theme.tokens.border.primary}`};
+  line-height: ${p => (p.isCompact ? 'inherit' : '38px')};
 `;
 
 const InputWrapper = styled('div')<{isEmpty: boolean}>`
@@ -246,11 +256,11 @@ const InputWrapper = styled('div')<{isEmpty: boolean}>`
   max-width: calc(100% + ${p => p.theme.space.xl});
 `;
 
-const StyledInput = styled(Input)`
+const StyledInput = styled(Input)<{isCompact?: boolean}>`
   border: none !important;
   background: transparent;
   height: auto;
-  min-height: 40px;
+  min-height: ${p => (p.isCompact ? 'auto' : '40px')};
   padding: 0;
   font-size: inherit;
   &,

--- a/static/app/views/dashboards/title.tsx
+++ b/static/app/views/dashboards/title.tsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react';
 
 import {EditableText} from 'sentry/components/editableText';
 import {t} from 'sentry/locale';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 import type {DashboardDetails} from './types';
 
@@ -12,6 +13,8 @@ type Props = {
 };
 
 export function DashboardTitle({dashboard, isEditingDashboard, onUpdate}: Props) {
+  const hasPageFrame = useHasPageFrameFeature();
+
   return (
     <Fragment>
       {dashboard ? (
@@ -21,6 +24,7 @@ export function DashboardTitle({dashboard, isEditingDashboard, onUpdate}: Props)
           onChange={newTitle => onUpdate({...dashboard, title: newTitle})}
           errorMessage={t('Please set a title for this dashboard')}
           autoSelect
+          variant={hasPageFrame ? 'compact' : undefined}
         />
       ) : (
         t('Dashboards')

--- a/static/app/views/detectors/components/forms/common/detectorNameField.tsx
+++ b/static/app/views/detectors/components/forms/common/detectorNameField.tsx
@@ -3,9 +3,11 @@ import {FormField} from 'sentry/components/forms/formField';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {t} from 'sentry/locale';
 import {useDetectorFormContext} from 'sentry/views/detectors/components/forms/context';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 export function DetectorNameField() {
   const {setHasSetDetectorName} = useDetectorFormContext();
+  const hasPageFrame = useHasPageFrameFeature();
 
   return (
     <Layout.Title>
@@ -24,6 +26,7 @@ export function DetectorNameField() {
             }}
             placeholder={t('New Monitor')}
             aria-label={t('Monitor Name')}
+            variant={hasPageFrame ? 'compact' : undefined}
           />
         )}
       </FormField>

--- a/static/app/views/issueList/editableIssueViewHeader.tsx
+++ b/static/app/views/issueList/editableIssueViewHeader.tsx
@@ -13,12 +13,14 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
 import {useUpdateGroupSearchView} from 'sentry/views/issueList/mutations/useUpdateGroupSearchView';
 import type {GroupSearchView} from 'sentry/views/issueList/types';
+import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 export function EditableIssueViewHeader({view}: {view: GroupSearchView}) {
   // TODO(msun): Add tests for this component
   const organization = useOrganization();
   const [isEditing, setIsEditing] = useState(false);
   const user = useUser();
+  const hasPageFrame = useHasPageFrameFeature();
 
   const {mutate: updateGroupSearchView} = useUpdateGroupSearchView();
 
@@ -62,10 +64,13 @@ export function EditableIssueViewHeader({view}: {view: GroupSearchView}) {
       stopEditing={() => {
         setIsEditing(false);
       }}
+      isCompact={hasPageFrame}
     />
   ) : (
-    <ViewTitleWrapper>
-      <ViewTitle onDoubleClick={handleBeginEditing}>{view.name}</ViewTitle>
+    <ViewTitleWrapper isCompact={hasPageFrame}>
+      <ViewTitle onDoubleClick={handleBeginEditing} isCompact={hasPageFrame}>
+        {view.name}
+      </ViewTitle>
       <Button
         icon={<IconEdit />}
         onClick={handleBeginEditing}
@@ -81,8 +86,10 @@ function EditingViewTitle({
   initialTitle,
   onSave,
   stopEditing,
+  isCompact,
 }: {
   initialTitle: string;
+  isCompact: boolean;
   onSave: (title: string) => void;
   stopEditing: () => void;
 }) {
@@ -121,14 +128,17 @@ function EditingViewTitle({
       onKeyDown={handleOnKeyDown}
       onBlur={() => stopEditing()}
       maxLength={128}
+      isCompact={isCompact}
     />
   );
 }
 
-const ViewTitleWrapper = styled(Layout.Title)`
+const ViewTitleWrapper = styled(Layout.Title)<{isCompact?: boolean}>`
   display: flex;
   align-items: center;
   width: min-content;
+
+  ${p => p.isCompact && `font-size: inherit; font-weight: inherit;`}
 
   :not(:hover, :focus-within) {
     button {
@@ -141,13 +151,14 @@ const ViewTitleWrapper = styled(Layout.Title)`
   }
 `;
 
-const ViewTitle = styled('div')`
-  height: 40px;
+const ViewTitle = styled('div')<{isCompact?: boolean}>`
+  height: ${p => (p.isCompact ? 'auto' : '40px')};
   letter-spacing: normal;
   margin-right: ${p => p.theme.space['2xs']};
   font-size: inherit;
   align-items: center;
-  border-bottom: 1px dotted ${p => p.theme.tokens.border.primary};
+  border-bottom: ${p =>
+    p.isCompact ? 'none' : `1px dotted ${p.theme.tokens.border.primary}`};
 
   display: block;
   width: 100%;
@@ -156,22 +167,22 @@ const ViewTitle = styled('div')`
   text-overflow: ellipsis;
 `;
 
-const StyledGrowingInput = styled(Input)`
+const StyledGrowingInput = styled(Input)<{isCompact?: boolean}>`
   position: relative;
   border: none;
   margin: 0;
   padding: 0;
   background: transparent;
   min-height: 0px;
-  height: 40px;
+  height: ${p => (p.isCompact ? 'auto' : '40px')};
   border-radius: 0px;
   text-overflow: ellipsis;
   cursor: text;
 
   /* <Layout.Title /> styles */
-  font-size: 1.625rem;
-  font-weight: 600;
-  line-height: 40px;
+  font-size: ${p => (p.isCompact ? 'inherit' : '1.625rem')};
+  font-weight: ${p => (p.isCompact ? 'inherit' : '600')};
+  line-height: ${p => (p.isCompact ? 'inherit' : '40px')};
 
   &,
   &:focus,

--- a/static/app/views/issueList/editableIssueViewHeader.tsx
+++ b/static/app/views/issueList/editableIssueViewHeader.tsx
@@ -13,14 +13,12 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
 import {useUpdateGroupSearchView} from 'sentry/views/issueList/mutations/useUpdateGroupSearchView';
 import type {GroupSearchView} from 'sentry/views/issueList/types';
-import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 export function EditableIssueViewHeader({view}: {view: GroupSearchView}) {
   // TODO(msun): Add tests for this component
   const organization = useOrganization();
   const [isEditing, setIsEditing] = useState(false);
   const user = useUser();
-  const hasPageFrame = useHasPageFrameFeature();
 
   const {mutate: updateGroupSearchView} = useUpdateGroupSearchView();
 
@@ -64,13 +62,10 @@ export function EditableIssueViewHeader({view}: {view: GroupSearchView}) {
       stopEditing={() => {
         setIsEditing(false);
       }}
-      isCompact={hasPageFrame}
     />
   ) : (
-    <ViewTitleWrapper isCompact={hasPageFrame}>
-      <ViewTitle onDoubleClick={handleBeginEditing} isCompact={hasPageFrame}>
-        {view.name}
-      </ViewTitle>
+    <ViewTitleWrapper>
+      <ViewTitle onDoubleClick={handleBeginEditing}>{view.name}</ViewTitle>
       <Button
         icon={<IconEdit />}
         onClick={handleBeginEditing}
@@ -86,10 +81,8 @@ function EditingViewTitle({
   initialTitle,
   onSave,
   stopEditing,
-  isCompact,
 }: {
   initialTitle: string;
-  isCompact: boolean;
   onSave: (title: string) => void;
   stopEditing: () => void;
 }) {
@@ -128,17 +121,14 @@ function EditingViewTitle({
       onKeyDown={handleOnKeyDown}
       onBlur={() => stopEditing()}
       maxLength={128}
-      isCompact={isCompact}
     />
   );
 }
 
-const ViewTitleWrapper = styled(Layout.Title)<{isCompact?: boolean}>`
+const ViewTitleWrapper = styled(Layout.Title)`
   display: flex;
   align-items: center;
   width: min-content;
-
-  ${p => p.isCompact && `font-size: inherit; font-weight: inherit;`}
 
   :not(:hover, :focus-within) {
     button {
@@ -151,14 +141,13 @@ const ViewTitleWrapper = styled(Layout.Title)<{isCompact?: boolean}>`
   }
 `;
 
-const ViewTitle = styled('div')<{isCompact?: boolean}>`
-  height: ${p => (p.isCompact ? 'auto' : '40px')};
+const ViewTitle = styled('div')`
+  height: 40px;
   letter-spacing: normal;
   margin-right: ${p => p.theme.space['2xs']};
   font-size: inherit;
   align-items: center;
-  border-bottom: ${p =>
-    p.isCompact ? 'none' : `1px dotted ${p.theme.tokens.border.primary}`};
+  border-bottom: 1px dotted ${p => p.theme.tokens.border.primary};
 
   display: block;
   width: 100%;
@@ -167,22 +156,22 @@ const ViewTitle = styled('div')<{isCompact?: boolean}>`
   text-overflow: ellipsis;
 `;
 
-const StyledGrowingInput = styled(Input)<{isCompact?: boolean}>`
+const StyledGrowingInput = styled(Input)`
   position: relative;
   border: none;
   margin: 0;
   padding: 0;
   background: transparent;
   min-height: 0px;
-  height: ${p => (p.isCompact ? 'auto' : '40px')};
+  height: 40px;
   border-radius: 0px;
   text-overflow: ellipsis;
   cursor: text;
 
   /* <Layout.Title /> styles */
-  font-size: ${p => (p.isCompact ? 'inherit' : '1.625rem')};
-  font-weight: ${p => (p.isCompact ? 'inherit' : '600')};
-  line-height: ${p => (p.isCompact ? 'inherit' : '40px')};
+  font-size: 1.625rem;
+  font-weight: 600;
+  line-height: 40px;
 
   &,
   &:focus,


### PR DESCRIPTION
Add compact variant to editable text and use it when the editable text is present in the page frame header

Fixes DE-1137, DE-1183