### PR TITLE
fix(alerts): More graceful handling of missing Detector in WorkflowEngineDataConditionSerializer

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_data_condition.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_data_condition.py
@@ -144,8 +144,8 @@ class WorkflowEngineDataConditionSerializer(Serializer):
                 key=lambda a: a.id,
             )
 
-            alert_rule_trigger_id = trigger_id_map.get(
-                trigger.id, get_fake_id_from_object_id(trigger.id)
+            alert_rule_trigger_id = trigger_id_map.get(trigger.id) or get_fake_id_from_object_id(
+                trigger.id
             )
 
             serialized_actions = serialize(
@@ -179,9 +179,11 @@ class WorkflowEngineDataConditionSerializer(Serializer):
         **kwargs: Any,
     ) -> dict[str, Any]:
         # XXX: we are assuming that the obj/DataCondition is a detector trigger
-        detector = attrs["detector"]
-        alert_rule_trigger_id = attrs["alert_rule_trigger_id"]
-        alert_rule_id = attrs["alert_rule_id"]
+        detector: Detector | None = attrs["detector"]
+        alert_rule_trigger_id: int = attrs["alert_rule_trigger_id"]
+        alert_rule_id: int | None = attrs["alert_rule_id"]
+
+        comparison_delta = detector.config.get("comparison_delta") if detector else None
 
         if obj.type == Condition.ANOMALY_DETECTION:
             threshold_type = obj.comparison["threshold_type"]
@@ -194,20 +196,19 @@ class WorkflowEngineDataConditionSerializer(Serializer):
             )
             # For static/metric rules, calculate resolve threshold from the resolve condition
             resolve_threshold = translate_data_condition_type(
-                detector.config.get("comparison_delta"),
+                comparison_delta,
                 obj.type,
                 attrs["resolve_threshold"],
             )
-
         return {
             "id": str(alert_rule_trigger_id),
-            "alertRuleId": str(alert_rule_id),
+            "alertRuleId": str(alert_rule_id) if alert_rule_id is not None else None,
             "label": (
                 "critical" if obj.condition_result == DetectorPriorityLevel.HIGH else "warning"
             ),
             "thresholdType": threshold_type,
             "alertThreshold": translate_data_condition_type(
-                detector.config.get("comparison_delta"),
+                comparison_delta,
                 obj.type,
                 (
                     0 if obj.type == Condition.ANOMALY_DETECTION else obj.comparison

--- a/tests/sentry/incidents/serializers/test_workflow_engine_data_condition.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_data_condition.py
@@ -220,6 +220,18 @@ class TestDataConditionSerializer(TestWorkflowEngineSerializer):
         assert len(serialized_warning_condition["actions"]) == 1
         assert serialized_warning_condition["actions"][0]["id"] == str(warning_action.id)
 
+    def test_missing_detector(self) -> None:
+        self.detector.delete()
+
+        serialized = serialize(
+            self.critical_detector_trigger,
+            self.user,
+            WorkflowEngineDataConditionSerializer(),
+        )
+        assert serialized["alertThreshold"] == float(self.critical_detector_trigger.comparison)
+        assert serialized["resolveThreshold"] is not None
+        assert serialized["alertRuleId"] is None
+
     def test_missing_resolve_condition(self) -> None:
         # Delete the resolve condition created during setUp
         DataCondition.objects.filter(


### PR DESCRIPTION
Missing Detectors should be rare, but we've seen this across 4 orgs already, and it causes additional downstream serialization issues, so it's worth trying to fix.

Fixes SENTRY-5N4Z.
