### PR TITLE
feat(code-review): Update backend so legacy seer orgs no code review

### DIFF
--- a/src/sentry/seer/code_review/preflight.py
+++ b/src/sentry/seer/code_review/preflight.py
@@ -84,11 +84,7 @@ class CodeReviewPreflightService:
         return None
 
     def _check_org_feature_enablement(self) -> PreflightDenialReason | None:
-        if (
-            self._is_seat_based_seer_plan_org
-            or self._is_code_review_beta_org
-            or self._is_legacy_usage_based_seer_plan_org
-        ):
+        if self._is_seat_based_seer_plan_org or self._is_code_review_beta_org:
             return None
 
         return PreflightDenialReason.ORG_NOT_ELIGIBLE_FOR_CODE_REVIEW
@@ -123,11 +119,9 @@ class CodeReviewPreflightService:
         ):
             return PreflightDenialReason.PR_AUTHOR_EXCLUDED
 
-        # Code review beta and legacy usage-based plan orgs are exempt from quota checks
-        # as long as they haven't purchased the new seat-based plan
-        if not self._is_seat_based_seer_plan_org and (
-            self._is_code_review_beta_org or self._is_legacy_usage_based_seer_plan_org
-        ):
+        # Code review beta orgs are exempt from quota checks as long as they haven't
+        # purchased the new seat-based plan.
+        if not self._is_seat_based_seer_plan_org and self._is_code_review_beta_org:
             return None
 
         has_quota = quotas.backend.check_seer_quota(
@@ -151,7 +145,3 @@ class CodeReviewPreflightService:
     @cached_property
     def _is_code_review_beta_org(self) -> bool:
         return features.has("organizations:code-review-beta", self.organization)
-
-    @cached_property
-    def _is_legacy_usage_based_seer_plan_org(self) -> bool:
-        return features.has("organizations:seer-added", self.organization)

--- a/tests/sentry/seer/code_review/test_preflight.py
+++ b/tests/sentry/seer/code_review/test_preflight.py
@@ -100,19 +100,45 @@ class TestCodeReviewPreflightService(TestCase):
         assert result.denial_reason == PreflightDenialReason.ORG_NOT_ELIGIBLE_FOR_CODE_REVIEW
 
     # -------------------------------------------------------------------------
-    # Seer-added (legacy usage-based) org tests
+    # Seer-added (legacy usage-based) org tests - not eligible for code review
     # -------------------------------------------------------------------------
 
     @with_feature(["organizations:gen-ai-features", "organizations:seer-added"])
-    def test_denied_when_seer_added_org_has_no_repo_settings(self) -> None:
+    def test_denied_when_seer_added_only_org_not_eligible(self) -> None:
         service = self._create_service()
         result = service.check()
 
         assert result.allowed is False
-        assert result.denial_reason == PreflightDenialReason.REPO_CODE_REVIEW_DISABLED
+        assert result.denial_reason == PreflightDenialReason.ORG_NOT_ELIGIBLE_FOR_CODE_REVIEW
 
     @with_feature(["organizations:gen-ai-features", "organizations:seer-added"])
-    def test_allowed_when_seer_added_org_has_repo_settings_enabled(self) -> None:
+    def test_denied_when_seer_added_only_org_even_with_repo_settings_enabled(self) -> None:
+        self.create_repository_settings(
+            repository=self.repo,
+            enabled_code_review=True,
+        )
+
+        OrganizationContributors.objects.create(
+            organization_id=self.organization.id,
+            integration_id=self.integration.id,
+            external_identifier=self.external_identifier,
+        )
+
+        service = self._create_service()
+        result = service.check()
+
+        assert result.allowed is False
+        assert result.denial_reason == PreflightDenialReason.ORG_NOT_ELIGIBLE_FOR_CODE_REVIEW
+
+    @with_feature(
+        [
+            "organizations:gen-ai-features",
+            "organizations:seer-added",
+            "organizations:code-review-beta",
+        ]
+    )
+    def test_allowed_when_seer_added_and_code_review_beta_org_has_repo_settings(self) -> None:
+        """Legacy seer-added plus beta remains eligible (beta is the code-review gate)."""
         self.create_repository_settings(
             repository=self.repo,
             enabled_code_review=True,
@@ -129,25 +155,6 @@ class TestCodeReviewPreflightService(TestCase):
 
         assert result.allowed is True
         assert result.denial_reason is None
-
-    @with_feature(["organizations:gen-ai-features", "organizations:seer-added"])
-    def test_denied_when_seer_added_org_has_repo_settings_disabled(self) -> None:
-        self.create_repository_settings(
-            repository=self.repo,
-            enabled_code_review=False,
-        )
-
-        OrganizationContributors.objects.create(
-            organization_id=self.organization.id,
-            integration_id=self.integration.id,
-            external_identifier=self.external_identifier,
-        )
-
-        service = self._create_service()
-        result = service.check()
-
-        assert result.allowed is False
-        assert result.denial_reason == PreflightDenialReason.REPO_CODE_REVIEW_DISABLED
 
     # -------------------------------------------------------------------------
     # Seat-based org tests


### PR DESCRIPTION
[DO NOT MERGE UNTIL 4/22]

Update backend so legacy usage-based seer orgs no longer get code review feature starting 4/22.

Closes https://linear.app/getsentry/issue/CW-1178/update-backend