### PR TITLE
ref(explore): Normalize ExploreControlSection padding to md xl

### DIFF
--- a/static/app/views/explore/components/styles.tsx
+++ b/static/app/views/explore/components/styles.tsx
@@ -17,8 +17,7 @@ export const ExploreControlSection = styled('aside')<{expanded: boolean}>`
       p.expanded
         ? css`
             width: 343px; /* 300px for the toolbar + padding */
-            padding: ${p.theme.space.xl} ${p.theme.space.lg} ${p.theme.space.md}
-              ${p.theme.space['3xl']};
+            padding: ${p.theme.space.md} ${p.theme.space.xl};
             border-right: 1px solid ${p.theme.tokens.border.primary};
           `
         : css`


### PR DESCRIPTION
Update left padding to match the page

<img width="188" height="443" alt="CleanShot 2026-04-21 at 11 40 33" src="https://github.com/user-attachments/assets/5d0b629e-dbd8-4b31-9316-889414a01011" />
