### PR TITLE
chore(billing): Renamed metrics to application metric counts(BIL-2237)

### DIFF
--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -633,10 +633,10 @@ export const DATA_CATEGORY_INFO = {
   [DataCategoryExact.TRACE_METRIC]: {
     name: DataCategoryExact.TRACE_METRIC,
     plural: DataCategory.TRACE_METRICS,
-    singular: 'metric',
-    displayName: 'metric',
-    titleName: t('Metrics'),
-    productName: t('Metrics'),
+    singular: 'applicationMetric',
+    displayName: 'application metric',
+    titleName: t('Application Metrics Counts'), // Only currently visible internally, this name should change if we expose this to users.
+    productName: t('Application Metrics'),
     uid: 33,
     isBilledCategory: false,
     statsInfo: {
@@ -648,7 +648,7 @@ export const DATA_CATEGORY_INFO = {
   [DataCategoryExact.TRACE_METRIC_BYTE]: {
     name: DataCategoryExact.TRACE_METRIC_BYTE,
     plural: DataCategory.TRACE_METRIC_BYTE,
-    singular: 'traceMetricByte',
+    singular: 'applicationMetricByte',
     displayName: 'application metric byte',
     titleName: t('Application Metrics'),
     productName: t('Application Metrics'),

--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -635,7 +635,7 @@ export const DATA_CATEGORY_INFO = {
     plural: DataCategory.TRACE_METRICS,
     singular: 'applicationMetric',
     displayName: 'application metric',
-    titleName: t('Application Metrics Counts'), // Only currently visible internally, this name should change if we expose this to users.
+    titleName: t('Application Metric Counts'), // Only currently visible internally, this name should change if we expose this to users.
     productName: t('Application Metrics'),
     uid: 33,
     isBilledCategory: false,

--- a/static/app/views/organizationStats/index.spec.tsx
+++ b/static/app/views/organizationStats/index.spec.tsx
@@ -545,7 +545,7 @@ describe('OrganizationStats', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('shows Application Metrics Counts category when tracemetrics-enabled and explore-dev-features flags are enabled', async () => {
+  it('shows Application Metric Counts category when tracemetrics-enabled and explore-dev-features flags are enabled', async () => {
     const newOrg = OrganizationFixture({
       features: ['team-insights', 'tracemetrics-enabled', 'explore-dev-features'],
     });
@@ -556,11 +556,11 @@ describe('OrganizationStats', () => {
 
     await userEvent.click(await screen.findByText('Category'));
     expect(
-      screen.getByRole('option', {name: 'Application Metrics Counts'})
+      screen.getByRole('option', {name: 'Application Metric Counts'})
     ).toBeInTheDocument();
   });
 
-  it('does not show Application Metrics Counts category without explore-dev-features flag', async () => {
+  it('does not show Application Metric Counts category without explore-dev-features flag', async () => {
     const newOrg = OrganizationFixture({
       features: ['team-insights', 'tracemetrics-enabled'],
     });
@@ -571,7 +571,7 @@ describe('OrganizationStats', () => {
 
     await userEvent.click(await screen.findByText('Category'));
     expect(
-      screen.queryByRole('option', {name: 'Application Metrics Counts'})
+      screen.queryByRole('option', {name: 'Application Metric Counts'})
     ).not.toBeInTheDocument();
   });
 

--- a/static/app/views/organizationStats/index.spec.tsx
+++ b/static/app/views/organizationStats/index.spec.tsx
@@ -545,7 +545,7 @@ describe('OrganizationStats', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('shows Metrics category when tracemetrics-enabled and explore-dev-features flags are enabled', async () => {
+  it('shows Application Metrics Counts category when tracemetrics-enabled and explore-dev-features flags are enabled', async () => {
     const newOrg = OrganizationFixture({
       features: ['team-insights', 'tracemetrics-enabled', 'explore-dev-features'],
     });
@@ -555,10 +555,12 @@ describe('OrganizationStats', () => {
     });
 
     await userEvent.click(await screen.findByText('Category'));
-    expect(screen.getByRole('option', {name: 'Metrics'})).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', {name: 'Application Metrics Counts'})
+    ).toBeInTheDocument();
   });
 
-  it('does not show Metrics category without explore-dev-features flag', async () => {
+  it('does not show Application Metrics Counts category without explore-dev-features flag', async () => {
     const newOrg = OrganizationFixture({
       features: ['team-insights', 'tracemetrics-enabled'],
     });
@@ -568,7 +570,9 @@ describe('OrganizationStats', () => {
     });
 
     await userEvent.click(await screen.findByText('Category'));
-    expect(screen.queryByRole('option', {name: 'Metrics'})).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('option', {name: 'Application Metrics Counts'})
+    ).not.toBeInTheDocument();
   });
 
   it('shows Application Metrics category when tracemetrics-stats-bytes-ui flag is enabled', async () => {


### PR DESCRIPTION
https://linear.app/getsentry/issue/BIL-2237/rename-metrics-to-application-metric-counts

This PR renames metrics to application metric counts, to reflect the shift in naming to application metrics, and to clarify that this represents raw counts, instead of the volume based application metric bytes. This also reflects the logs pattern.