### PR TITLE
fix(tracemetrics): Metric panel padding fixes

### DIFF
--- a/static/app/views/explore/metrics/metricInfoTabs/index.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/index.tsx
@@ -1,10 +1,9 @@
-import {Flex} from '@sentry/scraps/layout';
+import {Container, Flex} from '@sentry/scraps/layout';
 import {TabList, TabPanels, TabStateProvider} from '@sentry/scraps/tabs';
 
 import {t} from 'sentry/locale';
 import {AggregatesTab} from 'sentry/views/explore/metrics/metricInfoTabs/aggregatesTab';
 import {
-  BodyContainer,
   StyledTabPanels,
   TabListWrapper,
 } from 'sentry/views/explore/metrics/metricInfoTabs/metricInfoTabStyles';
@@ -67,7 +66,7 @@ export function MetricInfoTabs({
         </Flex>
       ) : null}
       {visualize.visible && !contentsHidden ? (
-        <BodyContainer>
+        <Container paddingRight="lg" paddingBottom="md" paddingTop="0" height="320px">
           <StyledTabPanels>
             <TabPanels.Item key={Mode.AGGREGATE}>
               <AggregatesTab
@@ -82,7 +81,7 @@ export function MetricInfoTabs({
               />
             </TabPanels.Item>
           </StyledTabPanels>
-        </BodyContainer>
+        </Container>
       ) : null}
     </TabStateProvider>
   );

--- a/static/app/views/explore/metrics/metricInfoTabs/metricInfoTabStyles.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricInfoTabStyles.tsx
@@ -126,13 +126,6 @@ export const NumericSimpleTableRowCell = styled(StyledSimpleTableRowCell)`
   justify-content: flex-end;
 `;
 
-export const BodyContainer = styled('div')`
-  padding: ${p => p.theme.space.md};
-  padding-top: 0;
-  height: 320px;
-  container-type: inline-size;
-`;
-
 export const StyledTabPanels = styled(TabPanels)`
   overflow: auto;
 `;

--- a/static/app/views/explore/metrics/metricToolbar/index.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/index.tsx
@@ -87,7 +87,7 @@ export function MetricToolbar({
   );
 
   const dndGrid = dragListeners ? 'auto ' : '';
-  const removeMetric = canRemoveMetric ? '24px' : '0';
+  const removeMetric = canRemoveMetric ? '24px' : '';
   const columns = isVisualizeFunction(visualize)
     ? isNarrow
       ? `${dndGrid}auto 1fr 1fr ${removeMetric}`


### PR DESCRIPTION
Some small tweaks to better align the metrics panel.

Closes LOGS-716

|||
|-|-|
|Before| <img width="1642" height="437" alt="Screenshot 2026-04-21 at 15 49 28" src="https://github.com/user-attachments/assets/79c70f06-6652-4c5e-83a1-cee180bc46cb" /> |
|After| <img width="1642" height="437" alt="Screenshot 2026-04-21 at 15 49 54" src="https://github.com/user-attachments/assets/b849eab0-7c94-4ee1-9511-37155de2597a" /> |