### PR TITLE
fix(seer): Remove code mappings fallback when configuring Seer for existing org

### DIFF
--- a/src/sentry/tasks/seer/autofix.py
+++ b/src/sentry/tasks/seer/autofix.py
@@ -25,7 +25,6 @@ from sentry.seer.autofix.utils import (
     bulk_read_preferences_from_sentry_db,
     bulk_set_project_preferences,
     bulk_write_preferences_to_sentry_db,
-    deduplicate_repositories,
     get_autofix_state,
     get_org_default_seer_automation_handoff,
     get_seer_seat_based_tier_cache_key,
@@ -286,7 +285,7 @@ def configure_seer_for_existing_org(organization_id: int) -> None:
             {
                 "organization_id": organization_id,
                 "project_id": project_id,
-                "repositories": deduplicate_repositories(repositories) or [],
+                "repositories": repositories,
                 "automated_run_stopping_point": stopping_point,
                 "automation_handoff": handoff,
             }

--- a/src/sentry/tasks/seer/autofix.py
+++ b/src/sentry/tasks/seer/autofix.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime, timedelta
+from typing import Any
 
 import sentry_sdk
 from django.utils import timezone
@@ -25,7 +26,6 @@ from sentry.seer.autofix.utils import (
     bulk_set_project_preferences,
     bulk_write_preferences_to_sentry_db,
     deduplicate_repositories,
-    get_autofix_repos_from_project_code_mappings,
     get_autofix_state,
     get_org_default_seer_automation_handoff,
     get_seer_seat_based_tier_cache_key,
@@ -258,16 +258,13 @@ def configure_seer_for_existing_org(organization_id: int) -> None:
 
     # Determine which projects need updates
     preferences_to_set = []
-    projects_by_id = {p.id: p for p in projects}
     for project_id in project_ids:
         stopping_point = default_stopping_point
         handoff = default_handoff_dict
+        repositories: list[dict[str, Any]] = []
 
         existing_pref = preferences_by_id.get(str(project_id))
-        if not existing_pref:
-            # No existing preferences, get repositories from code mappings
-            repositories = get_autofix_repos_from_project_code_mappings(projects_by_id[project_id])
-        else:
+        if existing_pref:
             repositories = existing_pref.get("repositories") or []
 
             existing_stopping_point = existing_pref.get("automated_run_stopping_point")

--- a/tests/sentry/tasks/seer/test_autofix.py
+++ b/tests/sentry/tasks/seer/test_autofix.py
@@ -437,29 +437,10 @@ class TestConfigureSeerForExistingOrg(SentryTestCase):
         # Cache should be set to True to prevent race conditions
         assert cache.get(cache_key) is True
 
-    @patch("sentry.tasks.seer.autofix.get_autofix_repos_from_project_code_mappings")
-    @patch("sentry.tasks.seer.autofix.bulk_set_project_preferences")
-    @patch("sentry.tasks.seer.autofix.bulk_get_project_preferences")
-    def test_uses_code_mappings_when_no_existing_preferences(
-        self, mock_bulk_get: MagicMock, mock_bulk_set: MagicMock, mock_get_code_mappings: MagicMock
-    ) -> None:
-        """Test that code mappings are used as fallback when no preferences exist."""
-        project = self.create_project(organization=self.organization)
-        mock_bulk_get.return_value = {}
-        mock_repos = [{"provider": "github", "owner": "test-org", "name": "test-repo"}]
-        mock_get_code_mappings.return_value = mock_repos
-
-        configure_seer_for_existing_org(organization_id=self.organization.id)
-
-        mock_get_code_mappings.assert_called_once_with(project)
-        preferences = mock_bulk_set.call_args[0][1]
-        assert preferences[0]["repositories"] == mock_repos
-
-    @patch("sentry.tasks.seer.autofix.get_autofix_repos_from_project_code_mappings")
     @patch("sentry.tasks.seer.autofix.bulk_set_project_preferences")
     @patch("sentry.tasks.seer.autofix.bulk_get_project_preferences")
     def test_preserves_existing_repositories_when_preferences_exist(
-        self, mock_bulk_get: MagicMock, mock_bulk_set: MagicMock, mock_get_code_mappings: MagicMock
+        self, mock_bulk_get: MagicMock, mock_bulk_set: MagicMock
     ) -> None:
         """Test that existing repositories are preserved when preferences exist."""
         project = self.create_project(organization=self.organization)
@@ -468,7 +449,6 @@ class TestConfigureSeerForExistingOrg(SentryTestCase):
 
         configure_seer_for_existing_org(organization_id=self.organization.id)
 
-        mock_get_code_mappings.assert_not_called()
         preferences = mock_bulk_set.call_args[0][1]
         assert preferences[0]["repositories"] == existing_repos
 


### PR DESCRIPTION
Fixes CW-1182

Since we will bill by connected repos https://github.com/getsentry/sentry/pull/113369, let's remove the code mappings fallback when configuring Seer for an existing org and there are no existing repos in the project preference. Ultimately we want to avoid bill shock by adding stuff to users' preferences that will get billed.

Consistent with https://github.com/getsentry/sentry/pull/113077 and https://github.com/getsentry/sentry/pull/113509.

[More context.](https://sentry.slack.com/archives/C0AAF0JD0GK/p1776284922120519)