### PR TITLE
ref(supergroups): always use lightweight RCA read path

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -574,8 +574,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("projects:supergroup-embeddings-explorer", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable lightweight RCA clustering write path (generate embeddings on new issues)
     manager.add("organizations:supergroups-lightweight-rca-clustering-write", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable lightweight RCA clustering read path (query lightweight embeddings in supergroup APIs)
-    manager.add("organizations:supergroups-lightweight-rca-clustering-read", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
 
     manager.add("projects:workflow-engine-performance-detectors", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
 

--- a/src/sentry/seer/supergroups/by_group.py
+++ b/src/sentry/seer/supergroups/by_group.py
@@ -4,7 +4,6 @@ from collections.abc import Sequence
 
 import orjson
 
-from sentry import features
 from sentry.models.organization import Organization
 from sentry.seer.models import SeerApiError
 from sentry.seer.signed_seer_api import (
@@ -21,16 +20,11 @@ def get_supergroups_by_group_ids(
     *,
     user_id: int | None = None,
 ) -> SupergroupsByGroupIdsResponse:
-    rca_source = (
-        RCASource.LIGHTWEIGHT
-        if features.has("organizations:supergroups-lightweight-rca-clustering-read", organization)
-        else RCASource.EXPLORER
-    )
     response = make_supergroups_get_by_group_ids_request(
         {
             "organization_id": organization.id,
             "group_ids": list(group_ids),
-            "rca_source": rca_source,
+            "rca_source": RCASource.LIGHTWEIGHT,
         },
         SeerViewerContext(organization_id=organization.id, user_id=user_id),
         timeout=10,

--- a/src/sentry/seer/supergroups/endpoints/organization_supergroup_details.py
+++ b/src/sentry/seer/supergroups/endpoints/organization_supergroup_details.py
@@ -35,19 +35,11 @@ class OrganizationSupergroupDetailsEndpoint(OrganizationEndpoint):
         if not features.has("organizations:top-issues-ui", organization, actor=request.user):
             return Response({"detail": "Feature not available"}, status=403)
 
-        rca_source = (
-            RCASource.LIGHTWEIGHT
-            if features.has(
-                "organizations:supergroups-lightweight-rca-clustering-read", organization
-            )
-            else RCASource.EXPLORER
-        )
-
         response = make_supergroups_get_request(
             {
                 "organization_id": organization.id,
                 "supergroup_id": supergroup_id,
-                "rca_source": rca_source,
+                "rca_source": RCASource.LIGHTWEIGHT,
             },
             SeerViewerContext(organization_id=organization.id, user_id=request.user.id),
             timeout=10,

--- a/tests/sentry/seer/supergroups/endpoints/test_organization_supergroup_details.py
+++ b/tests/sentry/seer/supergroups/endpoints/test_organization_supergroup_details.py
@@ -40,27 +40,10 @@ class OrganizationSupergroupDetailsEndpointTest(APITestCase):
     @patch(
         "sentry.seer.supergroups.endpoints.organization_supergroup_details.make_supergroups_get_request"
     )
-    def test_rca_source_defaults_to_explorer(self, mock_seer):
+    def test_rca_source_is_lightweight(self, mock_seer):
         mock_seer.return_value = mock_seer_response({"id": 1, "title": "test"})
 
         with self.feature("organizations:top-issues-ui"):
-            self.get_success_response(self.organization.slug, "1")
-
-        body = mock_seer.call_args.args[0]
-        assert body["rca_source"] == "EXPLORER"
-
-    @patch(
-        "sentry.seer.supergroups.endpoints.organization_supergroup_details.make_supergroups_get_request"
-    )
-    def test_rca_source_lightweight_when_flag_enabled(self, mock_seer):
-        mock_seer.return_value = mock_seer_response({"id": 1, "title": "test"})
-
-        with self.feature(
-            {
-                "organizations:top-issues-ui": True,
-                "organizations:supergroups-lightweight-rca-clustering-read": True,
-            }
-        ):
             self.get_success_response(self.organization.slug, "1")
 
         body = mock_seer.call_args.args[0]

--- a/tests/sentry/seer/supergroups/endpoints/test_organization_supergroups_by_group.py
+++ b/tests/sentry/seer/supergroups/endpoints/test_organization_supergroups_by_group.py
@@ -74,28 +74,10 @@ class OrganizationSupergroupsByGroupEndpointTest(APITestCase):
             )
 
     @patch("sentry.seer.supergroups.by_group.make_supergroups_get_by_group_ids_request")
-    def test_rca_source_defaults_to_explorer(self, mock_seer):
+    def test_rca_source_is_lightweight(self, mock_seer):
         mock_seer.return_value = mock_seer_response({"data": []})
 
         with self.feature("organizations:top-issues-ui"):
-            self.get_success_response(
-                self.organization.slug,
-                group_id=[self.unresolved_group.id],
-            )
-
-        body = mock_seer.call_args.args[0]
-        assert body["rca_source"] == "EXPLORER"
-
-    @patch("sentry.seer.supergroups.by_group.make_supergroups_get_by_group_ids_request")
-    def test_rca_source_lightweight_when_flag_enabled(self, mock_seer):
-        mock_seer.return_value = mock_seer_response({"data": []})
-
-        with self.feature(
-            {
-                "organizations:top-issues-ui": True,
-                "organizations:supergroups-lightweight-rca-clustering-read": True,
-            }
-        ):
             self.get_success_response(
                 self.organization.slug,
                 group_id=[self.unresolved_group.id],


### PR DESCRIPTION
Getting rid of this option for now, I'm leaning towards using only lightweight RCAs for reading right now. We can continue writing explorer RCAs for a little bit longer.