### PR TITLE
fix(alerts): Don't log APIException as error in alert rule serializer

### DIFF
--- a/src/sentry/incidents/serializers/alert_rule.py
+++ b/src/sentry/incidents/serializers/alert_rule.py
@@ -13,6 +13,7 @@ from django import forms
 from django.db import router, transaction
 from parsimonious.exceptions import ParseError
 from rest_framework import serializers
+from rest_framework.exceptions import APIException
 from urllib3.exceptions import MaxRetryError, TimeoutError
 
 from sentry import features
@@ -322,6 +323,8 @@ class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRu
             except forms.ValidationError as e:
                 # if we fail in create_metric_alert, then only one message is ever returned
                 raise serializers.ValidationError(e.error_list[0].message)
+            except APIException:
+                raise
             except Exception as e:
                 logger.exception(
                     "Error when creating alert rule",
@@ -376,6 +379,8 @@ class AlertRuleSerializer(SnubaQueryValidator, CamelSnakeModelSerializer[AlertRu
             except forms.ValidationError as e:
                 # if we fail in update_metric_alert, then only one message is ever returned
                 raise serializers.ValidationError(e.error_list[0].message)
+            except APIException:
+                raise
             except Exception as e:
                 logger.exception(
                     "Error when updating alert rule",


### PR DESCRIPTION
Fixes SENTRY-5NP8

A Sentry issue was being created every time a user tried to create a dynamic alert rule without the `organizations:anomaly-detection-alerts` feature. The `create_alert_rule` logic raises `ResourceDoesNotExist`, but `AlertRuleSerializer.create` wraps the call in a broad `except Exception` that calls `logger.exception(...)` and then re-raises as `BadRequest`. That both turns an expected 404 into a 400 and generates error-tracking noise for a totally normal client error.

Fix: add an `except APIException: raise` so 400 exceptions propagate as intended and do not log Sentry errors.