### PR TITLE
feat(eslint): Add no-react-type-import rule to prefer `React.Foo` over imports

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -460,6 +460,7 @@ export default typescript.config([
     plugins: {'@sentry/scraps': sentryScrapsPlugin},
     rules: {
       '@sentry/scraps/no-core-import': 'error',
+      '@sentry/scraps/no-react-type-import': 'error',
       '@sentry/scraps/no-token-import': 'error',
       '@sentry/scraps/use-semantic-token': [
         'error',

--- a/static/app/components/acl/featureDisabledModal.spec.tsx
+++ b/static/app/components/acl/featureDisabledModal.spec.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps, PropsWithChildren} from 'react';
 import styled from '@emotion/styled';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -7,9 +6,9 @@ import {FeatureDisabledModal} from 'sentry/components/acl/featureDisabledModal';
 
 describe('FeatureTourModal', () => {
   const onCloseModal = jest.fn();
-  const styledWrapper = styled((c: PropsWithChildren) => c.children);
+  const styledWrapper = styled((c: React.PropsWithChildren) => c.children);
   const renderComponent = (
-    props: Partial<ComponentProps<typeof FeatureDisabledModal>> = {}
+    props: Partial<React.ComponentProps<typeof FeatureDisabledModal>> = {}
   ) =>
     render(
       <FeatureDisabledModal

--- a/static/app/components/aiPrivacyTooltip.tsx
+++ b/static/app/components/aiPrivacyTooltip.tsx
@@ -1,17 +1,15 @@
-import type {ComponentProps, ReactNode} from 'react';
-
 import {ExternalLink} from '@sentry/scraps/link';
 import {Tooltip, type TooltipProps} from '@sentry/scraps/tooltip';
 
 import {tct} from 'sentry/locale';
 
 interface AiPrivacyNoticeProps {
-  linkProps?: Partial<ComponentProps<typeof ExternalLink>>;
+  linkProps?: Partial<React.ComponentProps<typeof ExternalLink>>;
 }
 
 interface AiPrivacyTooltipProps
   extends Omit<TooltipProps, 'title' | 'children'>, AiPrivacyNoticeProps {
-  children: ReactNode;
+  children: React.ReactNode;
 }
 
 const AI_PRIVACY_NOTICE_LINK =

--- a/static/app/components/alerts/pageBanner.tsx
+++ b/static/app/components/alerts/pageBanner.tsx
@@ -1,4 +1,3 @@
-import type {CSSProperties, ReactNode} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
@@ -10,15 +9,15 @@ import {SvgIcon} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
 
 interface Props {
-  description: ReactNode;
-  heading: ReactNode;
-  icon: ReactNode;
+  description: React.ReactNode;
+  heading: React.ReactNode;
+  icon: React.ReactNode;
   image: any;
-  title: ReactNode;
-  button?: ReactNode;
+  title: React.ReactNode;
+  button?: React.ReactNode;
   className?: string;
   onDismiss?: () => void;
-  style?: CSSProperties;
+  style?: React.CSSProperties;
 }
 
 export function PageBanner({

--- a/static/app/components/analyticsArea.tsx
+++ b/static/app/components/analyticsArea.tsx
@@ -1,4 +1,4 @@
-import {createContext, useContext, type ReactNode} from 'react';
+import {createContext, useContext} from 'react';
 
 const AnalyticsAreaContext = createContext<string>('');
 
@@ -45,7 +45,7 @@ export function AnalyticsArea({
   name,
   overrideParent = false,
 }: {
-  children: ReactNode;
+  children: React.ReactNode;
   name: string;
   overrideParent?: boolean;
 }) {

--- a/static/app/components/arithmeticBuilder/context.tsx
+++ b/static/app/components/arithmeticBuilder/context.tsx
@@ -1,4 +1,3 @@
-import type {Dispatch} from 'react';
 import {createContext, useContext} from 'react';
 
 import type {
@@ -10,7 +9,7 @@ import type {FieldDefinition} from 'sentry/utils/fields';
 
 interface ArithmeticBuilderContextData {
   aggregations: string[];
-  dispatch: Dispatch<ArithmeticBuilderAction>;
+  dispatch: React.Dispatch<ArithmeticBuilderAction>;
   focusOverride: FocusOverride | null;
   functionArguments: FunctionArgument[];
   getFieldDefinition: (key: string) => FieldDefinition | null;

--- a/static/app/components/arithmeticBuilder/token/deletableToken.tsx
+++ b/static/app/components/arithmeticBuilder/token/deletableToken.tsx
@@ -1,4 +1,3 @@
-import type {KeyboardEvent, MouseEvent} from 'react';
 import {useCallback} from 'react';
 import type {ListState} from '@react-stately/list';
 import type {Node} from '@react-types/shared';
@@ -26,7 +25,7 @@ export function DeletableToken({
   const {dispatch} = useArithmeticBuilder();
 
   const onDelete = useCallback(
-    (evt: KeyboardEvent<HTMLDivElement> | MouseEvent<HTMLButtonElement>) => {
+    (evt: React.KeyboardEvent<HTMLDivElement> | React.MouseEvent<HTMLButtonElement>) => {
       evt.preventDefault();
       evt.stopPropagation();
       const itemKey = state.collection.getKeyBefore(item.key);

--- a/static/app/components/arithmeticBuilder/token/freeText.tsx
+++ b/static/app/components/arithmeticBuilder/token/freeText.tsx
@@ -1,4 +1,3 @@
-import type {ChangeEvent, FocusEvent, MouseEvent, RefObject} from 'react';
 import {Fragment, useCallback, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {Item, Section} from '@react-stately/collections';
@@ -96,7 +95,7 @@ type FocusTokenLiteral = {
 type FocusToken = FocusTokenFunction | FocusTokenLiteral;
 
 interface InternalInputProps extends ArithmeticTokenFreeTextProps {
-  rowRef: RefObject<HTMLDivElement | null>;
+  rowRef: React.RefObject<HTMLDivElement | null>;
 }
 
 function InternalInput({
@@ -191,7 +190,7 @@ function InternalInput({
   }, [dispatch, inputValue, token, resetInputValue]);
 
   const onInputChange = useCallback(
-    (evt: ChangeEvent<HTMLInputElement>) => {
+    (evt: React.ChangeEvent<HTMLInputElement>) => {
       const text = evt.target.value;
 
       const tokens = tokenizeExpression(text, references);
@@ -313,7 +312,7 @@ function InternalInput({
     resetInputValue();
   }, [dispatch, token, inputValue, resetInputValue]);
 
-  const onInputFocus = useCallback((_evt: FocusEvent<HTMLInputElement>) => {
+  const onInputFocus = useCallback((_evt: React.FocusEvent<HTMLInputElement>) => {
     // TODO
   }, []);
 
@@ -634,7 +633,7 @@ function useReferenceItems({
   }, [references, nextAllowedTokenKinds]);
 }
 
-function stopPropagation(evt: MouseEvent<HTMLElement>) {
+function stopPropagation(evt: React.MouseEvent<HTMLElement>) {
   evt.stopPropagation();
 }
 

--- a/static/app/components/arithmeticBuilder/token/function.tsx
+++ b/static/app/components/arithmeticBuilder/token/function.tsx
@@ -1,4 +1,3 @@
-import type {ChangeEvent, FocusEvent, RefObject} from 'react';
 import {useCallback, useMemo, useRef, useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -76,7 +75,7 @@ export function ArithmeticTokenFunction({
 type Argument = {label: string; value: string};
 
 interface ArgumentsGridProps extends ArithmeticTokenFunctionProps {
-  rowRef: RefObject<HTMLDivElement | null>;
+  rowRef: React.RefObject<HTMLDivElement | null>;
 }
 
 function ArgumentsGrid({
@@ -129,7 +128,7 @@ interface GridListProps
   arguments: Argument[];
   children: CollectionChildren<TokenAttribute>;
   onArgumentsChange: (index: number, argument: string) => void;
-  rowRef: RefObject<HTMLDivElement | null>;
+  rowRef: React.RefObject<HTMLDivElement | null>;
 }
 
 function ArgumentsGridList({
@@ -212,14 +211,14 @@ interface InternalInputProps {
   argument: Argument;
   argumentIndex: number;
   argumentItem: Node<TokenAttribute>;
-  argumentRef: RefObject<HTMLDivElement | null>;
+  argumentRef: React.RefObject<HTMLDivElement | null>;
   arguments: Argument[];
   argumentsListState: ListState<TokenAttribute>;
   functionItem: Node<Token>;
   functionListState: ListState<Token>;
   functionToken: TokenFunction;
   onArgumentsChange: (index: number, argument: string) => void;
-  rowRef: RefObject<HTMLDivElement | null>;
+  rowRef: React.RefObject<HTMLDivElement | null>;
 }
 
 function InternalInput({
@@ -385,7 +384,7 @@ function InternalInput({
   ]);
 
   const onInputChange = useCallback(
-    (evt: ChangeEvent<HTMLInputElement>) => {
+    (evt: React.ChangeEvent<HTMLInputElement>) => {
       setInputValue(evt.target.value);
       setCurrentValue(evt.target.value);
       setSelectionIndex(evt.target.selectionStart ?? 0);
@@ -436,7 +435,7 @@ function InternalInput({
   }, [resetInputValue]);
 
   const onInputFocus = useCallback(
-    (evt: FocusEvent<HTMLInputElement>) => {
+    (evt: React.FocusEvent<HTMLInputElement>) => {
       // We're stopping propagation because `useGridListItem` in the parent component
       // always steals and sets focus to the first child and we don't want that happening.
       evt.stopPropagation();

--- a/static/app/components/arithmeticBuilder/token/index.spec.tsx
+++ b/static/app/components/arithmeticBuilder/token/index.spec.tsx
@@ -1,4 +1,3 @@
-import type {Dispatch} from 'react';
 import {useCallback} from 'react';
 
 import {
@@ -51,7 +50,7 @@ const getSuggestedKey = (key: string) => {
 
 interface TokensProp {
   expression: string;
-  dispatch?: Dispatch<ArithmeticBuilderAction>;
+  dispatch?: React.Dispatch<ArithmeticBuilderAction>;
   references?: Set<string>;
 }
 

--- a/static/app/components/arithmeticBuilder/token/literal.tsx
+++ b/static/app/components/arithmeticBuilder/token/literal.tsx
@@ -1,4 +1,3 @@
-import type {ChangeEvent, FocusEvent} from 'react';
 import {Fragment, useCallback, useRef, useState} from 'react';
 import type {ListState} from '@react-stately/list';
 import type {KeyboardEvent, Node} from '@react-types/shared';
@@ -97,7 +96,7 @@ function InternalInput({item, state, token}: InternalInputProps) {
   }, [dispatch, inputValue, token, resetInputValue]);
 
   const onInputChange = useCallback(
-    (evt: ChangeEvent<HTMLInputElement>) => {
+    (evt: React.ChangeEvent<HTMLInputElement>) => {
       const text = evt.target.value;
 
       if (text.length <= 0) {
@@ -183,7 +182,7 @@ function InternalInput({item, state, token}: InternalInputProps) {
   }, [dispatch, inputValue, token, resetInputValue]);
 
   const onInputFocus = useCallback(
-    (_evt: FocusEvent<HTMLInputElement>) => {
+    (_evt: React.FocusEvent<HTMLInputElement>) => {
       resetInputValue();
     },
     [resetInputValue]

--- a/static/app/components/arithmeticBuilder/token/reference.tsx
+++ b/static/app/components/arithmeticBuilder/token/reference.tsx
@@ -1,4 +1,3 @@
-import type {ChangeEvent} from 'react';
 import {useCallback, useMemo, useRef, useState} from 'react';
 import {Item, Section} from '@react-stately/collections';
 import type {ListState} from '@react-stately/list';
@@ -113,7 +112,7 @@ function InternalInput({item, state, token, rowRef}: InternalInputProps) {
     setIsCurrentlyEditing(false);
   }, []);
 
-  const onInputChange = useCallback((evt: ChangeEvent<HTMLInputElement>) => {
+  const onInputChange = useCallback((evt: React.ChangeEvent<HTMLInputElement>) => {
     setInputValue(evt.target.value);
   }, []);
 

--- a/static/app/components/arithmeticBuilder/types.tsx
+++ b/static/app/components/arithmeticBuilder/types.tsx
@@ -1,9 +1,7 @@
-import type {ReactNode} from 'react';
-
 import type {FieldKind} from 'sentry/utils/fields';
 
 export interface FunctionArgument {
   kind: FieldKind;
   name: string;
-  label?: ReactNode;
+  label?: React.ReactNode;
 }

--- a/static/app/components/backendJsonFormAdapter/backendJsonAutoSaveForm.tsx
+++ b/static/app/components/backendJsonFormAdapter/backendJsonAutoSaveForm.tsx
@@ -1,4 +1,4 @@
-import {useMemo, useState, type ReactNode} from 'react';
+import {useMemo, useState} from 'react';
 import type {UseMutationOptions} from '@tanstack/react-query';
 import {z} from 'zod';
 
@@ -37,7 +37,7 @@ export function BackendJsonAutoSaveForm<
   mutationOptions,
 }: BackendJsonFormAdapterProps<TField, TData, TContext>) {
   const fieldName = field.name;
-  const [labels, setLabels] = useState<Record<string, ReactNode>>({});
+  const [labels, setLabels] = useState<Record<string, React.ReactNode>>({});
 
   const schema = useMemo(
     () => z.object({[fieldName]: getZodType(field.type)}),

--- a/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
+++ b/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
@@ -1,4 +1,4 @@
-import {useMemo, useRef, useState, type ReactNode, useEffect} from 'react';
+import {useMemo, useRef, useState, useEffect} from 'react';
 import {queryOptions} from '@tanstack/react-query';
 import {z} from 'zod';
 
@@ -168,7 +168,7 @@ export function BackendJsonSubmitForm({
 
   // Labels for choice_mapper rows (maps key to display label)
   const [choiceMapperLabels, setChoiceMapperLabels] = useState<
-    Record<string, Record<string, ReactNode>>
+    Record<string, Record<string, React.ReactNode>>
   >({});
 
   const defaultValues = useMemo(

--- a/static/app/components/backendJsonFormAdapter/choiceMapperAdapter.tsx
+++ b/static/app/components/backendJsonFormAdapter/choiceMapperAdapter.tsx
@@ -1,4 +1,4 @@
-import {useState, type ReactNode} from 'react';
+import {useState} from 'react';
 import {useQuery} from '@tanstack/react-query';
 import type {DistributedPick} from 'type-fest';
 
@@ -26,7 +26,7 @@ type ChoiceMapperConfig = Extract<JsonFormAdapterFieldConfig, {type: 'choice_map
 interface ChoiceMapperDropdownProps {
   config: ChoiceMapperConfig;
   onChange: (value: Record<string, Record<string, unknown>>) => void;
-  onLabelAdd: (value: string, label: ReactNode) => void;
+  onLabelAdd: (value: string, label: React.ReactNode) => void;
   value: Record<string, Record<string, unknown>>;
   disabled?: boolean;
   indicator?: React.ReactNode;
@@ -34,7 +34,7 @@ interface ChoiceMapperDropdownProps {
 
 interface ChoiceMapperTableProps {
   config: ChoiceMapperConfig;
-  labels: Record<string, ReactNode>;
+  labels: Record<string, React.ReactNode>;
   onSave: (value: Record<string, Record<string, unknown>>) => void;
   onUpdate: (value: Record<string, Record<string, unknown>>) => void;
   value: Record<string, Record<string, unknown>>;

--- a/static/app/components/charts/useChartXRangeSelection.tsx
+++ b/static/app/components/charts/useChartXRangeSelection.tsx
@@ -1,11 +1,4 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type DependencyList,
-} from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {createPortal} from 'react-dom';
 import type {BrushComponentOption, EChartsOption, ToolboxComponentOption} from 'echarts';
 import * as echarts from 'echarts';
@@ -97,7 +90,7 @@ export type ChartXRangeSelectionProps = {
   /**
    * The dependencies to be used to re-activate selection or re-paint the box.
    */
-  deps?: DependencyList;
+  deps?: React.DependencyList;
 
   /**
    * Whether selection is disabled.

--- a/static/app/components/commandPalette/types.tsx
+++ b/static/app/components/commandPalette/types.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import type {LocationDescriptor} from 'history';
 
 import {queryOptions} from 'sentry/utils/queryClient';
@@ -11,7 +10,7 @@ interface Action {
     /** Additional context or description */
     details?: string;
     /** Icon to render for this action */
-    icon?: ReactNode;
+    icon?: React.ReactNode;
   };
   /** Optional keywords to improve searchability */
   keywords?: string[];

--- a/static/app/components/contentSliderDiff/index.tsx
+++ b/static/app/components/contentSliderDiff/index.tsx
@@ -1,4 +1,4 @@
-import {useRef, type CSSProperties} from 'react';
+import {useRef} from 'react';
 import styled from '@emotion/styled';
 
 import {NegativeSpaceContainer} from 'sentry/components/container/negativeSpaceContainer';
@@ -15,7 +15,7 @@ interface Props {
    * The content to display before the divider. Usually an image or replay.
    */
   before: React.ReactNode;
-  minHeight?: CSSProperties['minHeight'];
+  minHeight?: React.CSSProperties['minHeight'];
   /**
    * A callback function triggered when the divider is clicked (mouse down event).
    * Useful when we want to track analytics.

--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -1,13 +1,4 @@
-import {
-  Fragment,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type Dispatch,
-  type SetStateAction,
-} from 'react';
+import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {skipToken, useQuery} from '@tanstack/react-query';
 import type {Query} from 'history';
 
@@ -465,7 +456,7 @@ function ConfigUrlContainer(
     configQueryKey: ApiQueryKey;
     organizations: Organization[];
     selectedOrgSlug: string | undefined;
-    setSelectedOrgSlug: Dispatch<SetStateAction<string | undefined>>;
+    setSelectedOrgSlug: React.Dispatch<React.SetStateAction<string | undefined>>;
   }
 ) {
   const {
@@ -515,7 +506,7 @@ function ConfigPickerContent({
   integrationConfigs: Integration[];
   organizations: Organization[];
   selectedOrgSlug: string | undefined;
-  setSelectedOrgSlug: Dispatch<SetStateAction<string | undefined>>;
+  setSelectedOrgSlug: React.Dispatch<React.SetStateAction<string | undefined>>;
 }) {
   const {isSuperuser} = ConfigStore.get('user') || {};
   const shouldShowConfigSelector = integrationConfigs.length > 0 && isSuperuser;

--- a/static/app/components/core/form/FormSearch.tsx
+++ b/static/app/components/core/form/FormSearch.tsx
@@ -1,7 +1,5 @@
-import type {ReactNode} from 'react';
-
 interface FormSearchProps {
-  children: ReactNode;
+  children: React.ReactNode;
   /**
    * Route pattern for SettingsSearch (e.g., '/settings/account/details/').
    * This prop is used by the static extraction script to associate

--- a/static/app/components/core/form/field/baseField.tsx
+++ b/static/app/components/core/form/field/baseField.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useRef, type Ref} from 'react';
+import {useEffect, useRef} from 'react';
 import {mergeRefs} from '@react-aria/utils';
 
 import {useAutoSaveContext} from '@sentry/scraps/form/autoSaveContext';
@@ -12,7 +12,7 @@ import {FieldMeta} from './meta';
 
 export type BaseFieldProps<T extends HTMLElement> = {
   disabled?: boolean | string;
-  ref?: Ref<T>;
+  ref?: React.Ref<T>;
 };
 type FieldChildrenProps<T extends HTMLElement> = {
   'aria-describedby': string;
@@ -21,7 +21,7 @@ type FieldChildrenProps<T extends HTMLElement> = {
   id: string;
   name: string;
   onBlur: () => void;
-  ref: Ref<T>;
+  ref: React.Ref<T>;
 };
 
 export const useAutoSaveIndicator = () => {

--- a/static/app/components/core/form/field/selectField.tsx
+++ b/static/app/components/core/form/field/selectField.tsx
@@ -1,4 +1,4 @@
-import {useRef, type Ref} from 'react';
+import {useRef} from 'react';
 
 import {useAutoSaveContext} from '@sentry/scraps/form/autoSaveContext';
 import {Container, Flex} from '@sentry/scraps/layout';
@@ -14,7 +14,10 @@ function SelectInput({
   selectProps,
   ...props
 }: React.ComponentProps<typeof components.Input> & {
-  selectProps?: {'aria-invalid'?: boolean; inputRef?: Ref<{input: HTMLInputElement}>};
+  selectProps?: {
+    'aria-invalid'?: boolean;
+    inputRef?: React.Ref<{input: HTMLInputElement}>;
+  };
 }) {
   return (
     <components.Input
@@ -100,7 +103,7 @@ export type SelectFieldProps<TValue> =
 // This converts the `ref` value of SelectInput into a format
 // that works for BaseField, which expects `fieldProps.ref: Ref<HTMLElement>`
 const applyInputToRef =
-  (ref: Ref<HTMLInputElement>) =>
+  (ref: React.Ref<HTMLInputElement>) =>
   (instance: null | {input: HTMLInputElement}): void => {
     if (instance) {
       if (typeof ref === 'function') {

--- a/static/app/components/core/image/image.tsx
+++ b/static/app/components/core/image/image.tsx
@@ -1,4 +1,3 @@
-import type {CSSProperties} from 'react';
 import styled from '@emotion/styled';
 
 import type {Responsive} from '@sentry/scraps/layout';
@@ -9,7 +8,7 @@ import type {RadiusSize} from 'sentry/utils/theme';
 export interface ImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
   alt: string;
   src: string;
-  aspectRatio?: CSSProperties['aspectRatio'];
+  aspectRatio?: React.CSSProperties['aspectRatio'];
   height?: string;
   /**
    * Determines if the image should be loaded eagerly or lazily.

--- a/static/app/components/core/layout/flex.tsx
+++ b/static/app/components/core/layout/flex.tsx
@@ -1,4 +1,3 @@
-import type {CSSProperties} from 'react';
 import styled from '@emotion/styled';
 
 import type {SpaceSize} from 'sentry/utils/theme';
@@ -39,7 +38,7 @@ interface FlexLayoutProps {
   /**
    * Shorthand for the flex property.
    */
-  flex?: Responsive<CSSProperties['flex']>;
+  flex?: Responsive<React.CSSProperties['flex']>;
   /**
    * Specifies the spacing between flex items.
    */

--- a/static/app/components/core/layout/grid.tsx
+++ b/static/app/components/core/layout/grid.tsx
@@ -1,4 +1,3 @@
-import type {CSSProperties} from 'react';
 import styled from '@emotion/styled';
 
 import type {SpaceSize} from 'sentry/utils/theme';
@@ -44,22 +43,22 @@ interface GridLayoutProps {
    * Defines named grid areas for child components to reference.
    * Uses CSS grid-template-areas property.
    */
-  areas?: Responsive<CSSProperties['gridTemplateAreas']>;
+  areas?: Responsive<React.CSSProperties['gridTemplateAreas']>;
   /**
    * Specifies the size of auto-generated column tracks.
    * Uses CSS grid-auto-columns property.
    */
-  autoColumns?: Responsive<CSSProperties['gridAutoColumns']>;
+  autoColumns?: Responsive<React.CSSProperties['gridAutoColumns']>;
   /**
    * Specifies the size of auto-generated row tracks.
    * Uses CSS grid-auto-rows property.
    */
-  autoRows?: Responsive<CSSProperties['gridAutoRows']>;
+  autoRows?: Responsive<React.CSSProperties['gridAutoRows']>;
   /**
    * Defines the column tracks of the grid.
    * Uses CSS grid-template-columns property.
    */
-  columns?: Responsive<CSSProperties['gridTemplateColumns']>;
+  columns?: Responsive<React.CSSProperties['gridTemplateColumns']>;
   /**
    * Determines the grid display type.
    */
@@ -86,7 +85,7 @@ interface GridLayoutProps {
    * Defines the row tracks of the grid.
    * Uses CSS grid-template-rows property.
    */
-  rows?: Responsive<CSSProperties['gridTemplateRows']>;
+  rows?: Responsive<React.CSSProperties['gridTemplateRows']>;
 }
 
 export type GridProps<T extends ContainerElement = 'div'> = ContainerProps<T> &

--- a/static/app/components/core/link/linkBehaviorContext.tsx
+++ b/static/app/components/core/link/linkBehaviorContext.tsx
@@ -1,4 +1,4 @@
-import {createContext, useContext, type FunctionComponent} from 'react';
+import {createContext, useContext} from 'react';
 import {Link as RouterLink} from 'react-router-dom';
 import * as Sentry from '@sentry/react';
 
@@ -6,7 +6,7 @@ import type {LinkProps} from './link';
 
 type LinkBehavior = {
   behavior: (props: LinkProps) => LinkProps;
-  component: FunctionComponent<LinkProps>;
+  component: React.FunctionComponent<LinkProps>;
 };
 
 const LinkBehaviorContext = createContext<LinkBehavior | null>(null);

--- a/static/app/components/core/quote/quote.tsx
+++ b/static/app/components/core/quote/quote.tsx
@@ -1,4 +1,4 @@
-import {Fragment, type ReactNode} from 'react';
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {Stack} from '@sentry/scraps/layout';
@@ -7,7 +7,7 @@ import {Text} from '@sentry/scraps/text';
 
 // interface + type union because `extends` doesn't play nicely with generics
 interface QuoteBaseProps {
-  children: ReactNode;
+  children: React.ReactNode;
   source?: {
     author?: string;
     href?: string;

--- a/static/app/components/core/renderToString.tsx
+++ b/static/app/components/core/renderToString.tsx
@@ -1,9 +1,8 @@
-import type {ReactNode} from 'react';
 import {flushSync} from 'react-dom';
 import {createRoot} from 'react-dom/client';
 import {ThemeProvider, useTheme} from '@emotion/react';
 
-const renderToString = (tree: ReactNode) => {
+const renderToString = (tree: React.ReactNode) => {
   const div = document.createElement('div');
   const root = createRoot(div);
 
@@ -21,6 +20,6 @@ const renderToString = (tree: ReactNode) => {
 export const useRenderToString = () => {
   const theme = useTheme();
 
-  return (tree: ReactNode) =>
+  return (tree: React.ReactNode) =>
     renderToString(<ThemeProvider theme={theme}>{tree}</ThemeProvider>);
 };

--- a/static/app/components/deprecatedDropdownMenu.spec.tsx
+++ b/static/app/components/deprecatedDropdownMenu.spec.tsx
@@ -1,12 +1,10 @@
-import type {ComponentProps} from 'react';
-
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {DropdownMenu as DeprecatedDropdownMenu} from 'sentry/components/deprecatedDropdownMenu';
 
 describe('dropdownMenuDeprecated', () => {
   function DeprecatedDropdownImplementation(
-    props: Partial<ComponentProps<typeof DeprecatedDropdownMenu>> = {}
+    props: Partial<React.ComponentProps<typeof DeprecatedDropdownMenu>> = {}
   ) {
     return (
       <DeprecatedDropdownMenu {...props}>

--- a/static/app/components/duration/duration.tsx
+++ b/static/app/components/duration/duration.tsx
@@ -1,10 +1,9 @@
-import type {HTMLAttributes} from 'react';
 import styled from '@emotion/styled';
 
 import {formatDuration, type Format} from 'sentry/utils/duration/formatDuration';
 import type {Duration as TDuration, Unit} from 'sentry/utils/duration/types';
 
-interface Props extends HTMLAttributes<HTMLTimeElement> {
+interface Props extends React.HTMLAttributes<HTMLTimeElement> {
   /**
    * The Duration that you want to render
    */

--- a/static/app/components/events/autofix/autofixFeedback.tsx
+++ b/static/app/components/events/autofix/autofixFeedback.tsx
@@ -1,9 +1,7 @@
-import {type ComponentProps} from 'react';
-
 import {FeedbackButton} from 'sentry/components/feedbackButton/feedbackButton';
 import {t} from 'sentry/locale';
 
-interface AutofixFeedbackProps extends ComponentProps<typeof FeedbackButton> {
+interface AutofixFeedbackProps extends React.ComponentProps<typeof FeedbackButton> {
   iconOnly?: boolean;
 }
 

--- a/static/app/components/events/autofix/autofixOutputStream.tsx
+++ b/static/app/components/events/autofix/autofixOutputStream.tsx
@@ -1,4 +1,4 @@
-import {startTransition, useEffect, useRef, useState, type FormEvent} from 'react';
+import {startTransition, useEffect, useRef, useState} from 'react';
 import {keyframes} from '@emotion/react';
 import styled from '@emotion/styled';
 import {AnimatePresence, motion} from 'framer-motion';
@@ -249,7 +249,7 @@ export function AutofixOutputStream({
     },
   });
 
-  const handleSend = (e: FormEvent) => {
+  const handleSend = (e: React.FormEvent) => {
     e.preventDefault();
     if (isInitializingRun) {
       // don't send message during loading state

--- a/static/app/components/events/autofix/v1/body.tsx
+++ b/static/app/components/events/autofix/v1/body.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useRef, type ReactNode} from 'react';
+import {useCallback, useEffect, useRef} from 'react';
 import styled from '@emotion/styled';
 import {mergeRefs} from '@react-aria/utils';
 
@@ -10,7 +10,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 
 interface SeerDrawerBody {
   aiAutofix: ReturnType<typeof useAiAutofix>;
-  children: ReactNode;
+  children: React.ReactNode;
 }
 
 export function SeerDrawerBody({children, aiAutofix}: SeerDrawerBody) {

--- a/static/app/components/events/autofix/v2/autofixConfigureSeer.tsx
+++ b/static/app/components/events/autofix/v2/autofixConfigureSeer.tsx
@@ -1,4 +1,4 @@
-import {Fragment, type CSSProperties} from 'react';
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
 
@@ -159,14 +159,14 @@ export function AutofixConfigureSeer({event, group, project}: AutofixConfigureSe
   );
 }
 
-export const SeerFeaturesPanel = styled(Panel)<{width: CSSProperties['width']}>`
+export const SeerFeaturesPanel = styled(Panel)<{width: React.CSSProperties['width']}>`
   width: ${p => p.width};
   min-width: ${p => p.width};
   max-width: ${p => p.width};
   margin-bottom: ${p => p.theme.space['2xl']};
 `;
 
-const SeerPreviewPanel = styled(Panel)<{alignSelf: CSSProperties['alignSelf']}>`
+const SeerPreviewPanel = styled(Panel)<{alignSelf: React.CSSProperties['alignSelf']}>`
   align-self: ${p => p.alignSelf};
   width: 70%;
   min-width: 70%;
@@ -196,7 +196,7 @@ const SeerPreviewText = styled('div')`
 `;
 
 export const ImageContainer = styled(Flex)<{
-  aspectRatio?: CSSProperties['aspectRatio'];
+  aspectRatio?: React.CSSProperties['aspectRatio'];
 }>`
   ${p => p.aspectRatio && `aspect-ratio: ${p.aspectRatio}`};
 `;

--- a/static/app/components/events/autofix/v3/autofixCards.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useMemo, useRef, type ReactNode} from 'react';
+import {Fragment, useEffect, useMemo, useRef} from 'react';
 import styled from '@emotion/styled';
 
 import {Tag} from '@sentry/scraps/badge';
@@ -380,9 +380,9 @@ export function CodingAgentCard({section}: AutofixCardProps) {
 }
 
 interface ArtifactCardProps {
-  children: ReactNode;
-  icon: ReactNode;
-  title: ReactNode;
+  children: React.ReactNode;
+  icon: React.ReactNode;
+  title: React.ReactNode;
 }
 
 function ArtifactCard({children, icon, title}: ArtifactCardProps) {
@@ -406,7 +406,7 @@ function ArtifactCard({children, icon, title}: ArtifactCardProps) {
 }
 
 interface ArtifactDetailsProps extends FlexProps {
-  children: ReactNode;
+  children: React.ReactNode;
 }
 
 function ArtifactDetails({children, ...flexProps}: ArtifactDetailsProps) {

--- a/static/app/components/events/autofix/v3/autofixPreviews.tsx
+++ b/static/app/components/events/autofix/v3/autofixPreviews.tsx
@@ -1,4 +1,4 @@
-import {useMemo, type ReactNode} from 'react';
+import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {Tag} from '@sentry/scraps/badge';
@@ -227,9 +227,9 @@ export function CodingAgentPreview({section}: ArtifactPreviewProps) {
 }
 
 interface ArtifactCardProps {
-  children: ReactNode;
-  icon: ReactNode;
-  title: ReactNode;
+  children: React.ReactNode;
+  icon: React.ReactNode;
+  title: React.ReactNode;
 }
 
 function ArtifactCard({children, icon, title}: ArtifactCardProps) {

--- a/static/app/components/events/autofix/v3/body.tsx
+++ b/static/app/components/events/autofix/v3/body.tsx
@@ -1,10 +1,9 @@
-import type {ReactNode} from 'react';
 import styled from '@emotion/styled';
 
 import {DrawerBody} from 'sentry/components/globalDrawer/components';
 
 interface SeerDrawerBody {
-  children: ReactNode;
+  children: React.ReactNode;
 }
 
 export function SeerDrawerBody({children}: SeerDrawerBody) {

--- a/static/app/components/events/autofix/v3/nextStep.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, useState, type ReactNode} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 
 import {Button, ButtonBar} from '@sentry/scraps/button';
 import {MenuComponents} from '@sentry/scraps/compactSelect';
@@ -251,15 +251,15 @@ function CodeChangesNextStep({autofix, group, runId, section, referrer}: NextSte
 
 interface NextStepTemplateProps {
   isProcessing: boolean;
-  labelNevermind: ReactNode;
-  labelNo: ReactNode;
-  labelRethink: ReactNode;
-  labelYes: ReactNode;
+  labelNevermind: React.ReactNode;
+  labelNo: React.ReactNode;
+  labelRethink: React.ReactNode;
+  labelYes: React.ReactNode;
   onClickNo: (prompt: string) => void;
   onClickYes: () => void;
   placeholderPrompt: string;
-  prompt: ReactNode;
-  rethinkPrompt: ReactNode;
+  prompt: React.ReactNode;
+  rethinkPrompt: React.ReactNode;
   codingAgentIntegrations?: CodingAgentIntegration[];
   onCodingAgentHandoff?: (integration: CodingAgentIntegration) => void;
 }

--- a/static/app/components/events/eventDrawer.tsx
+++ b/static/app/components/events/eventDrawer.tsx
@@ -1,4 +1,3 @@
-import type {ComponentPropsWithoutRef} from 'react';
 import styled from '@emotion/styled';
 
 import {InputGroup} from '@sentry/scraps/input';
@@ -56,7 +55,7 @@ const EventDrawerContainerRoot = styled('div')<{hasPageFrameFeature: boolean}>`
     `}
 `;
 
-export function EventDrawerContainer(props: ComponentPropsWithoutRef<'div'>) {
+export function EventDrawerContainer(props: React.ComponentPropsWithoutRef<'div'>) {
   const hasPageFrameFeature = useHasPageFrameFeature();
 
   return (

--- a/static/app/components/events/eventReplay/replayPreviewPlayer.tsx
+++ b/static/app/components/events/eventReplay/replayPreviewPlayer.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps} from 'react';
 import {useEffect, useRef, useState} from 'react';
 import {useMatches} from 'react-router-dom';
 import styled from '@emotion/styled';
@@ -55,7 +54,7 @@ export function ReplayPreviewPlayer({
   handleBackClick?: () => void;
   handleForwardClick?: () => void;
   overlayContent?: React.ReactNode;
-  playPausePriority?: ComponentProps<typeof ReplayPlayPauseButton>['priority'];
+  playPausePriority?: React.ComponentProps<typeof ReplayPlayPauseButton>['priority'];
   query?: Query;
   showNextAndPrevious?: boolean;
 }) {

--- a/static/app/components/events/eventStatisticalDetector/eventRegressionTable.tsx
+++ b/static/app/components/events/eventStatisticalDetector/eventRegressionTable.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo, type ReactNode} from 'react';
+import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 import type {LocationDescriptor} from 'history';
 
@@ -37,7 +37,7 @@ type MetricColumnKey =
 type TableColumnKey = 'description' | 'operation' | MetricColumnKey;
 type TableColumn = {
   key: TableColumnKey;
-  name: ReactNode;
+  name: React.ReactNode;
 };
 
 interface EventRegressionTableProps {
@@ -222,7 +222,7 @@ function changeTextVariant(change: number): 'danger' | 'primary' | 'success' {
   return 'primary';
 }
 
-function CellText({children, numeric}: {children?: ReactNode; numeric?: boolean}) {
+function CellText({children, numeric}: {children?: React.ReactNode; numeric?: boolean}) {
   return (
     <Container width="100%" overflow="hidden">
       <Text as="div" align={numeric ? 'right' : undefined} ellipsis tabular={numeric}>

--- a/static/app/components/events/eventTags/util.tsx
+++ b/static/app/components/events/eventTags/util.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useLayoutEffect, useState, type RefObject} from 'react';
+import {useCallback, useLayoutEffect, useState} from 'react';
 import {useResizeObserver} from '@react-aria/utils';
 
 import type {EventTag, EventTagWithMeta} from 'sentry/types/event';
@@ -169,7 +169,7 @@ const ISSUE_DETAILS_COLUMN_BREAKPOINTS = [
  * accurately describe the available space.
  */
 export function useIssueDetailsColumnCount(
-  elementRef: RefObject<HTMLElement | null>
+  elementRef: React.RefObject<HTMLElement | null>
 ): number {
   const calculateColumnCount = useCallback(() => {
     const width = elementRef.current?.clientWidth || 0;

--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/index.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/index.tsx
@@ -1,4 +1,3 @@
-import type {ReactEventHandler} from 'react';
 import {useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -37,8 +36,8 @@ type Props = {
   screenshot: EventAttachment;
   screenshotInFocus: number;
   totalScreenshots: number;
-  onNext?: ReactEventHandler;
-  onPrevious?: ReactEventHandler;
+  onNext?: React.ReactEventHandler;
+  onPrevious?: React.ReactEventHandler;
   onlyRenderScreenshot?: boolean;
 };
 

--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/modal.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps} from 'react';
 import {Fragment, useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -80,7 +79,7 @@ export function ScreenshotModal({
 
   const {dateCreated, size, mimetype} = currentEventAttachment;
 
-  let paginationProps: ComponentProps<typeof ScreenshotPagination> | null = null;
+  let paginationProps: React.ComponentProps<typeof ScreenshotPagination> | null = null;
   if (screenshots.length > 1 && defined(currentAttachmentIndex)) {
     paginationProps = {
       previousDisabled: currentAttachmentIndex === 0,

--- a/static/app/components/events/featureFlags/onboarding/featureFlagOnboardingSidebar.tsx
+++ b/static/app/components/events/featureFlags/onboarding/featureFlagOnboardingSidebar.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {Fragment, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {parseAsString, useQueryState} from 'nuqs';
@@ -193,7 +192,7 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
 
   const [sdkProvider, setsdkProvider] = useState<{
     value: SdkProviderEnum;
-    label?: ReactNode;
+    label?: React.ReactNode;
   }>(sdkProviderOptions[0]!);
 
   const [setupMode, setSetupMode] = useQueryState(

--- a/static/app/components/events/interfaces/crashContent/exception/utils.tsx
+++ b/static/app/components/events/interfaces/crashContent/exception/utils.tsx
@@ -1,4 +1,3 @@
-import type {ReactElement} from 'react';
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
@@ -14,7 +13,7 @@ interface RenderLinksInTextProps {
 
 export const renderLinksInText = ({
   exceptionText,
-}: RenderLinksInTextProps): ReactElement => {
+}: RenderLinksInTextProps): React.ReactElement => {
   // https?: Matches both "http" and "https"
   // :\/\/: This is a literal match for "://"
   // (?:www\.)?: Matches URLs with or without "www."
@@ -40,7 +39,7 @@ export const renderLinksInText = ({
     const url = urls[index]!;
     const isUrlValid = isUrl(url);
 
-    let link: ReactElement | undefined;
+    let link: React.ReactElement | undefined;
     if (isUrlValid) {
       link = (
         <ExternalLink

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -1,4 +1,3 @@
-import type {MouseEvent} from 'react';
 import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
@@ -239,7 +238,7 @@ function NativeFrame({
   }
 
   // This isn't possible when the page doesn't have the images loaded section
-  function handleGoToImagesLoaded(e: MouseEvent) {
+  function handleGoToImagesLoaded(e: React.MouseEvent) {
     e.stopPropagation(); // to prevent collapsing if collapsible
 
     if (frame.instructionAddr) {
@@ -260,7 +259,7 @@ function NativeFrame({
       ?.scrollIntoView({block: 'start', behavior: 'smooth'});
   }
 
-  function handleToggleContext(e: MouseEvent) {
+  function handleToggleContext(e: React.MouseEvent) {
     if (!expandable) {
       return;
     }

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {Fragment, useMemo} from 'react';
 import {useTheme, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -634,7 +633,7 @@ const makeTransactionNameRow = (
 const makeRow = (
   subject: KeyValueListDataItem['subject'],
   value: KeyValueListDataItem['value'],
-  actionButton?: ReactNode
+  actionButton?: React.ReactNode
 ): KeyValueListDataItem => {
   const itemKey = kebabCase(subject ?? '');
 

--- a/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
+++ b/static/app/components/events/interfaces/sourceMapsDebuggerModal.tsx
@@ -1,4 +1,3 @@
-import type {PropsWithChildren, ReactNode} from 'react';
 import {Fragment, useMemo, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -895,7 +894,11 @@ export function SourceMapsDebuggerModal({
   );
 }
 
-function CheckListItem({children, title, status}: PropsWithChildren<CheckListItemProps>) {
+function CheckListItem({
+  children,
+  title,
+  status,
+}: React.PropsWithChildren<CheckListItemProps>) {
   return (
     <ListItemContainer>
       <Stack align="center">
@@ -1918,7 +1921,7 @@ function ScrapingSourceMapAvailableChecklistItem({
   );
 }
 
-function ExternalLinkWithIcon({href, children}: PropsWithChildren<{href: string}>) {
+function ExternalLinkWithIcon({href, children}: React.PropsWithChildren<{href: string}>) {
   return (
     <ExternalLink href={href}>
       {children} <IconOpen size="xs" />
@@ -1993,7 +1996,7 @@ const CheckList = styled('ul')`
 
 interface CheckListItemProps {
   status: 'none' | 'checked' | 'alert' | 'question';
-  title: ReactNode;
+  title: React.ReactNode;
 }
 
 const ListItemContainer = styled('li')`

--- a/static/app/components/featureShowcase.tsx
+++ b/static/app/components/featureShowcase.tsx
@@ -1,12 +1,4 @@
-import {
-  Children,
-  createContext,
-  isValidElement,
-  useContext,
-  useState,
-  type ReactElement,
-  type ReactNode,
-} from 'react';
+import {Children, createContext, isValidElement, useContext, useState} from 'react';
 
 import {Button} from '@sentry/scraps/button';
 import {Image, type ImageProps} from '@sentry/scraps/image';
@@ -39,7 +31,7 @@ function useShowcaseContext(): ShowcaseContextValue {
   return ctx;
 }
 
-function Step({children}: {children: ReactNode}) {
+function Step({children}: {children: React.ReactNode}) {
   return <Stack gap="md">{children}</Stack>;
 }
 
@@ -47,7 +39,7 @@ function StepImage(props: ImageProps) {
   return <Image objectFit="contain" {...props} />;
 }
 
-function StepTitle({children}: {children: ReactNode}) {
+function StepTitle({children}: {children: React.ReactNode}) {
   const {current, stepCount} = useShowcaseContext();
   return (
     <Stack gap="md">
@@ -61,7 +53,7 @@ function StepTitle({children}: {children: ReactNode}) {
   );
 }
 
-function StepContent({children}: {children: ReactNode}) {
+function StepContent({children}: {children: React.ReactNode}) {
   return <Stack gap="xl">{children}</Stack>;
 }
 
@@ -71,7 +63,7 @@ function StepContent({children}: {children: ReactNode}) {
  * - No children: renders default Back/Next/Done buttons.
  * - With children: rendered alongside the default navigation buttons.
  */
-function StepActions({children}: {children?: ReactNode}) {
+function StepActions({children}: {children?: React.ReactNode}) {
   const {advance, back, close, hasNext, hasPrevious} = useShowcaseContext();
 
   return (
@@ -92,7 +84,7 @@ function StepActions({children}: {children?: ReactNode}) {
 }
 
 type FeatureShowcaseProps = ModalRenderProps & {
-  children: ReactNode;
+  children: React.ReactNode;
   /**
    * Called when the showcase advances to a new step.
    */
@@ -127,7 +119,7 @@ function FeatureShowcase({closeModal, children, onStepChange}: FeatureShowcasePr
   const [current, setCurrent] = useState(0);
 
   const steps = Children.toArray(children).filter(
-    (child): child is ReactElement => isValidElement(child) && child.type === Step
+    (child): child is React.ReactElement => isValidElement(child) && child.type === Step
   );
 
   const stepCount = steps.length;

--- a/static/app/components/feedback/feedbackFilters.tsx
+++ b/static/app/components/feedback/feedbackFilters.tsx
@@ -1,5 +1,3 @@
-import type {CSSProperties} from 'react';
-
 import {DatePageFilter} from 'sentry/components/pageFilters/date/datePageFilter';
 import {EnvironmentPageFilter} from 'sentry/components/pageFilters/environment/environmentPageFilter';
 import {PageFilterBar} from 'sentry/components/pageFilters/pageFilterBar';
@@ -7,7 +5,7 @@ import {ProjectPageFilter} from 'sentry/components/pageFilters/project/projectPa
 
 interface Props {
   className?: string;
-  style?: CSSProperties;
+  style?: React.CSSProperties;
 }
 
 export function FeedbackFilters({className, style}: Props) {

--- a/static/app/components/feedback/feedbackItem/feedbackActions.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackActions.tsx
@@ -1,4 +1,3 @@
-import type {CSSProperties} from 'react';
 import {Fragment, useCallback} from 'react';
 
 import {Button} from '@sentry/scraps/button';
@@ -23,7 +22,7 @@ interface Props {
   feedbackItem: FeedbackIssue;
   size: 'small' | 'medium' | 'large';
   className?: string;
-  style?: CSSProperties;
+  style?: React.CSSProperties;
 }
 
 export function FeedbackActions({

--- a/static/app/components/feedback/feedbackItem/feedbackItemSection.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemSection.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import styled from '@emotion/styled';
 
 import InteractionStateLayer from '@sentry/scraps/interactionStateLayer';
@@ -9,11 +8,11 @@ import {t} from 'sentry/locale';
 import {useSyncedLocalStorageState} from 'sentry/utils/useSyncedLocalStorageState';
 
 interface Props {
-  children: ReactNode;
+  children: React.ReactNode;
   sectionKey: string;
   collapsible?: boolean;
-  icon?: ReactNode;
-  title?: ReactNode;
+  icon?: React.ReactNode;
+  title?: React.ReactNode;
 }
 
 export function FeedbackItemSection({

--- a/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemUsername.tsx
@@ -1,4 +1,4 @@
-import {type CSSProperties, Fragment, useId} from 'react';
+import {Fragment, useId} from 'react';
 import styled from '@emotion/styled';
 
 import {LinkButton} from '@sentry/scraps/button';
@@ -17,7 +17,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 interface Props {
   feedbackIssue: FeedbackIssue;
   className?: string;
-  style?: CSSProperties;
+  style?: React.CSSProperties;
 }
 
 export function FeedbackItemUsername({className, feedbackIssue, style}: Props) {

--- a/static/app/components/feedback/feedbackItem/feedbackShortId.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackShortId.tsx
@@ -1,4 +1,3 @@
-import type {CSSProperties} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import queryString from 'query-string';
@@ -18,7 +17,7 @@ import {makeFeedbackPathname} from 'sentry/views/feedback/pathnames';
 interface Props {
   feedbackItem: FeedbackIssue;
   className?: string;
-  style?: CSSProperties;
+  style?: React.CSSProperties;
 }
 
 const hideDropdown = css`

--- a/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
+++ b/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {Fragment, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import {parseAsStringLiteral, useQueryState} from 'nuqs';
@@ -193,7 +192,7 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
 
   const [jsFramework, setJsFramework] = useState<{
     value: PlatformKey;
-    label?: ReactNode;
+    label?: React.ReactNode;
     textValue?: string;
   }>(jsFrameworkSelectOptions[0]!);
 

--- a/static/app/components/feedback/useFeedbackQueryKeys.tsx
+++ b/static/app/components/feedback/useFeedbackQueryKeys.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {createContext, useCallback, useContext, useRef, useState} from 'react';
 
 import {getFeedbackItemQueryKey} from 'sentry/components/feedback/getFeedbackItemQueryKey';
@@ -8,7 +7,7 @@ import {parseQueryKey} from 'sentry/utils/api/apiQueryKey';
 import type {ApiQueryKey, InfiniteApiQueryKey} from 'sentry/utils/queryClient';
 
 interface Props {
-  children: ReactNode;
+  children: React.ReactNode;
   organization: Organization;
 }
 

--- a/static/app/components/feedbackButton/feedbackButton.tsx
+++ b/static/app/components/feedbackButton/feedbackButton.tsx
@@ -1,4 +1,4 @@
-import {useRef, type ReactNode} from 'react';
+import {useRef} from 'react';
 
 import {Button, type ButtonProps} from '@sentry/scraps/button';
 
@@ -8,7 +8,7 @@ import {t} from 'sentry/locale';
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
 
 interface Props extends Omit<ButtonProps, 'children'> {
-  children?: ReactNode;
+  children?: React.ReactNode;
   feedbackOptions?: UseFeedbackOptions;
 }
 

--- a/static/app/components/forms/collapsibleSection.tsx
+++ b/static/app/components/forms/collapsibleSection.tsx
@@ -1,12 +1,10 @@
-import type {ReactNode} from 'react';
-
 import type {FieldFromConfigProps} from 'sentry/components/forms/fieldFromConfig';
 import JsonForm from 'sentry/components/forms/jsonForm';
 import type {FieldObject} from 'sentry/components/forms/types';
 
 export interface CollapsibleSectionProps extends Omit<FieldFromConfigProps, 'field'> {
   fields: FieldObject[];
-  label: ReactNode | (() => React.ReactNode);
+  label: React.ReactNode | (() => React.ReactNode);
   initiallyCollapsed?: boolean;
 }
 

--- a/static/app/components/forms/controls/multipleCheckbox.tsx
+++ b/static/app/components/forms/controls/multipleCheckbox.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {createContext, useCallback, useContext, useMemo} from 'react';
 import styled from '@emotion/styled';
 import noop from 'lodash/noop';
@@ -7,7 +6,7 @@ import {Checkbox} from '@sentry/scraps/checkbox';
 import {Flex} from '@sentry/scraps/layout';
 
 type Props<T> = {
-  children: ReactNode;
+  children: React.ReactNode;
   name: string;
   value: T[];
   className?: string;
@@ -16,7 +15,7 @@ type Props<T> = {
 };
 
 type CheckboxItemProps<T> = {
-  children: ReactNode;
+  children: React.ReactNode;
   value: T;
   className?: string;
   disabled?: boolean;

--- a/static/app/components/forms/fields/booleanField.tsx
+++ b/static/app/components/forms/fields/booleanField.tsx
@@ -1,5 +1,3 @@
-import type {FormEvent, ReactNode} from 'react';
-
 import {Switch, type SwitchProps} from '@sentry/scraps/switch';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -11,9 +9,9 @@ import type {InputFieldProps, OnEvent} from './inputField';
 
 export interface BooleanFieldProps extends InputFieldProps {
   confirm?: {
-    false?: ReactNode;
+    false?: React.ReactNode;
     isDangerous?: boolean;
-    true?: ReactNode;
+    true?: React.ReactNode;
   };
 }
 
@@ -30,14 +28,14 @@ export function BooleanField({confirm, ...fieldProps}: BooleanFieldProps) {
         ...props
       }: {
         disabled: boolean;
-        disabledReason: ReactNode;
+        disabledReason: React.ReactNode;
         onBlur: OnEvent;
         onChange: OnEvent;
         type: string;
         value: any;
-        children?: ReactNode;
+        children?: React.ReactNode;
       }) => {
-        const handleChange = (event: FormEvent<HTMLInputElement>) => {
+        const handleChange = (event: React.FormEvent<HTMLInputElement>) => {
           const newValue = !value;
           onChange(newValue, event);
           onBlur(newValue, event);
@@ -57,7 +55,7 @@ export function BooleanField({confirm, ...fieldProps}: BooleanFieldProps) {
           return (
             <Confirm
               renderMessage={() => confirmMessage}
-              onConfirm={() => handleChange({} as FormEvent<HTMLInputElement>)}
+              onConfirm={() => handleChange({} as React.FormEvent<HTMLInputElement>)}
               isDangerous={confirm.isDangerous}
             >
               {({open}) => (

--- a/static/app/components/forms/fields/choiceMapperField.spec.tsx
+++ b/static/app/components/forms/fields/choiceMapperField.spec.tsx
@@ -1,5 +1,3 @@
-import type {ComponentProps} from 'react';
-
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {ChoiceMapperField} from 'sentry/components/forms/fields/choiceMapperField';
@@ -8,7 +6,7 @@ describe('ChoiceMapperField', () => {
   const mockOnChange = jest.fn();
   const mockOnBlur = jest.fn();
 
-  const defaultProps: ComponentProps<typeof ChoiceMapperField> = {
+  const defaultProps: React.ComponentProps<typeof ChoiceMapperField> = {
     name: 'test-choice-mapper',
     addButtonText: 'Add Item',
     formatMessageValue: false,
@@ -124,7 +122,7 @@ describe('ChoiceMapperField', () => {
   });
 
   describe('AsyncCompactSelectForIntegrationConfig', () => {
-    const asyncProps: ComponentProps<typeof ChoiceMapperField> = {
+    const asyncProps: React.ComponentProps<typeof ChoiceMapperField> = {
       ...defaultProps,
       addDropdown: {
         items: [],

--- a/static/app/components/forms/fields/projectMapperField.spec.tsx
+++ b/static/app/components/forms/fields/projectMapperField.spec.tsx
@@ -1,5 +1,3 @@
-import type {ComponentProps} from 'react';
-
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 import {selectEvent} from 'sentry-test/selectEvent';
 
@@ -8,7 +6,7 @@ import {FormModel} from 'sentry/components/forms/model';
 import {RenderField} from './projectMapperField';
 
 describe('ProjectMapperField', () => {
-  const defaultProps: ComponentProps<typeof RenderField> = {
+  const defaultProps: React.ComponentProps<typeof RenderField> = {
     mappedDropdown: {
       placeholder: 'mapped-dropdown-placeholder',
       items: [

--- a/static/app/components/groupPreviewTooltip/groupPreviewHovercard.tsx
+++ b/static/app/components/groupPreviewTooltip/groupPreviewHovercard.tsx
@@ -1,11 +1,10 @@
-import type {ComponentProps} from 'react';
 import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Hovercard} from 'sentry/components/hovercard';
 import {useMedia} from 'sentry/utils/useMedia';
 
-interface GroupPreviewHovercardProps extends ComponentProps<typeof Hovercard> {
+interface GroupPreviewHovercardProps extends React.ComponentProps<typeof Hovercard> {
   hide?: boolean;
 }
 

--- a/static/app/components/hook.tsx
+++ b/static/app/components/hook.tsx
@@ -1,11 +1,11 @@
-import {Component, memo, type ComponentType} from 'react';
+import {Component, memo} from 'react';
 
 import {HookStore} from 'sentry/stores/hookStore';
 import type {HookName, Hooks} from 'sentry/types/hooks';
 
 // Only allow hooks that return a React component
 type ComponentHookName = {
-  [K in HookName]: Hooks[K] extends ComponentType<any> ? K : never;
+  [K in HookName]: Hooks[K] extends React.ComponentType<any> ? K : never;
 }[HookName];
 
 type Props<H extends ComponentHookName> = {

--- a/static/app/components/hookOrDefault.tsx
+++ b/static/app/components/hookOrDefault.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps} from 'react';
 import {lazy, Suspense, useEffect, useState} from 'react';
 
 import {HookStore} from 'sentry/stores/hookStore';
@@ -47,8 +46,8 @@ export function HookOrDefault<H extends HookName>({
   hookName,
   defaultComponent,
   defaultComponentPromise,
-}: Params<H>): React.FunctionComponent<ComponentProps<ReturnType<Hooks[H]>>> {
-  type Props = ComponentProps<ReturnType<Hooks[H]>>;
+}: Params<H>): React.FunctionComponent<React.ComponentProps<ReturnType<Hooks[H]>>> {
+  type Props = React.ComponentProps<ReturnType<Hooks[H]>>;
 
   // Defining the props here is unnecessary and slow for typescript
   function getDefaultComponent(): React.ComponentType<any> | undefined {

--- a/static/app/components/keyValueData/index.tsx
+++ b/static/app/components/keyValueData/index.tsx
@@ -1,4 +1,4 @@
-import React, {Children, useRef, useState, type ReactNode} from 'react';
+import React, {Children, useRef, useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -185,9 +185,9 @@ export function Card({
 // {null}
 // <Component2/> --> returns a <Card/>
 // Gives us back [<Component1/>, <Component2/>]
-const filterChildren = (children: ReactNode): ReactNode[] => {
+const filterChildren = (children: React.ReactNode): React.ReactNode[] => {
   return Children.toArray(children).filter(
-    (child: ReactNode) => child !== null && child !== undefined
+    (child: React.ReactNode) => child !== null && child !== undefined
   );
 };
 

--- a/static/app/components/layouts/thirds.tsx
+++ b/static/app/components/layouts/thirds.tsx
@@ -1,4 +1,3 @@
-import {type HTMLAttributes} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -182,7 +181,7 @@ export const Body = styled((props: ContainerProps<'div'> & {noRowGap?: boolean})
   }
 `;
 
-interface MainProps extends HTMLAttributes<HTMLElement> {
+interface MainProps extends React.HTMLAttributes<HTMLElement> {
   children: React.ReactNode;
   /**
    * Set the width of the main content.

--- a/static/app/components/lazyLoad.tsx
+++ b/static/app/components/lazyLoad.tsx
@@ -1,4 +1,4 @@
-import {Component, Suspense, useEffect, useState, type ErrorInfo} from 'react';
+import {Component, Suspense, useEffect, useState} from 'react';
 import * as Sentry from '@sentry/react';
 
 import {Container, Flex} from '@sentry/scraps/layout';
@@ -107,7 +107,7 @@ class ErrorBoundary extends Component<{children: React.ReactNode}, ErrorBoundary
     }
   }
 
-  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
     Sentry.withScope(scope => {
       if (isWebpackChunkLoadingError(error)) {
         scope.setFingerprint(['webpack', 'error loading chunk']);

--- a/static/app/components/modals/createNewIntegrationModal.tsx
+++ b/static/app/components/modals/createNewIntegrationModal.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {Fragment, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -77,7 +76,7 @@ function CreateNewIntegrationModal({Body, Header, Footer, closeModal}: ModalRend
         )}
       </RadioChoiceDescription>,
     ],
-  ] as Array<[string, ReactNode, ReactNode]>;
+  ] as Array<[string, React.ReactNode, React.ReactNode]>;
 
   return (
     <Fragment>

--- a/static/app/components/modals/diffModal.spec.tsx
+++ b/static/app/components/modals/diffModal.spec.tsx
@@ -1,4 +1,3 @@
-import type {PropsWithChildren} from 'react';
 import styled from '@emotion/styled';
 import {ProjectFixture} from 'sentry-fixture/project';
 
@@ -34,7 +33,7 @@ describe('DiffModal', () => {
       body: {features: []},
     });
 
-    const styledWrapper = styled((c: PropsWithChildren) => c.children);
+    const styledWrapper = styled((c: React.PropsWithChildren) => c.children);
 
     render(
       <DiffModal

--- a/static/app/components/modals/emailVerificationModal.spec.tsx
+++ b/static/app/components/modals/emailVerificationModal.spec.tsx
@@ -1,5 +1,3 @@
-import type {PropsWithChildren} from 'react';
-
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import EmailVerificationModal from 'sentry/components/modals/emailVerificationModal';
@@ -13,8 +11,8 @@ describe('Email Verification Modal', () => {
 
     render(
       <EmailVerificationModal
-        Body={((p: PropsWithChildren) => p.children) as any}
-        Header={((p: PropsWithChildren) => p.children) as any}
+        Body={((p: React.PropsWithChildren) => p.children) as any}
+        Header={((p: React.PropsWithChildren) => p.children) as any}
       />
     );
     const message = screen.getByText(

--- a/static/app/components/modals/inviteMembersModal/index.spec.tsx
+++ b/static/app/components/modals/inviteMembersModal/index.spec.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps} from 'react';
 import styled from '@emotion/styled';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {TeamFixture} from 'sentry-fixture/team';
@@ -68,7 +67,7 @@ describe('InviteMembersModal', () => {
     mockApiResponses = [defaultMockOrganizationRoles],
   }: {
     mockApiResponses?: MockApiResponseFn[];
-    modalProps?: ComponentProps<typeof InviteMembersModal>;
+    modalProps?: React.ComponentProps<typeof InviteMembersModal>;
     orgAccess?: Scope[];
     orgTeams?: DetailedTeam[];
     roles?: Array<Record<PropertyKey, unknown>>;

--- a/static/app/components/modals/inviteMissingMembersModal/index.spec.tsx
+++ b/static/app/components/modals/inviteMissingMembersModal/index.spec.tsx
@@ -1,4 +1,3 @@
-import type {PropsWithChildren} from 'react';
 import styled from '@emotion/styled';
 import {MissingMembersFixture} from 'sentry-fixture/missingMembers';
 import {OrganizationFixture} from 'sentry-fixture/organization';
@@ -38,7 +37,7 @@ describe('InviteMissingMembersModal', () => {
   TeamStore.loadInitialData([team]);
   const missingMembers = MissingMembersFixture();
 
-  const styledWrapper = styled((c: PropsWithChildren) => c.children);
+  const styledWrapper = styled((c: React.PropsWithChildren) => c.children);
   const modalProps: InviteMissingMembersModalProps = {
     Body: styledWrapper(),
     Header: p => <span>{p.children}</span>,

--- a/static/app/components/modals/recoveryOptionsModal.spec.tsx
+++ b/static/app/components/modals/recoveryOptionsModal.spec.tsx
@@ -1,4 +1,3 @@
-import type {PropsWithChildren} from 'react';
 import styled from '@emotion/styled';
 import {
   AllAuthenticatorsFixture,
@@ -24,7 +23,7 @@ describe('RecoveryOptionsModal', () => {
   });
 
   function renderComponent() {
-    const styledWrapper = styled((c: PropsWithChildren) => c.children);
+    const styledWrapper = styled((c: React.PropsWithChildren) => c.children);
 
     render(
       <RecoveryOptionsModal

--- a/static/app/components/modals/sentryAppPublishRequestModal/sentryAppPublishRequestModal.spec.tsx
+++ b/static/app/components/modals/sentryAppPublishRequestModal/sentryAppPublishRequestModal.spec.tsx
@@ -1,4 +1,3 @@
-import type {PropsWithChildren} from 'react';
 import styled from '@emotion/styled';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {SentryAppFixture} from 'sentry-fixture/sentryApp';
@@ -9,7 +8,7 @@ import {makeCloseButton} from 'sentry/components/globalModal/components';
 import {SentryAppPublishRequestModal} from 'sentry/components/modals/sentryAppPublishRequestModal/sentryAppPublishRequestModal';
 
 describe('SentryAppDetailsModal', () => {
-  const styledWrapper = styled((c: PropsWithChildren) => c.children);
+  const styledWrapper = styled((c: React.PropsWithChildren) => c.children);
   const sentryApp = SentryAppFixture();
   const onPublishSubmission = jest.fn();
   afterEach(() => {

--- a/static/app/components/modals/teamAccessRequestModal.spec.tsx
+++ b/static/app/components/modals/teamAccessRequestModal.spec.tsx
@@ -1,4 +1,3 @@
-import type {PropsWithChildren} from 'react';
 import styled from '@emotion/styled';
 import {MemberFixture} from 'sentry-fixture/member';
 import {OrganizationFixture} from 'sentry-fixture/organization';
@@ -18,7 +17,7 @@ describe('TeamAccessRequestModal', () => {
   const memberId = MemberFixture().id;
   const teamId = TeamFixture().slug;
 
-  const styledWrapper = styled((c: PropsWithChildren) => c.children);
+  const styledWrapper = styled((c: React.PropsWithChildren) => c.children);
   const modalRenderProps: CreateTeamAccessRequestModalProps = {
     Body: styledWrapper(),
     Footer: styledWrapper(),

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useEffect, useState, type ReactNode} from 'react';
+import {Fragment, useCallback, useEffect, useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
@@ -371,7 +371,7 @@ function AddToDashboardModal({
     (
       hasReachedDashboardLimit: boolean,
       isLoading: boolean,
-      limitMessage: ReactNode | null
+      limitMessage: React.ReactNode | null
     ) => {
       if (dashboards === null) {
         return [];

--- a/static/app/components/modals/widgetBuilder/linkToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/linkToDashboardModal.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useEffect, useState, type ReactNode} from 'react';
+import {Fragment, useCallback, useEffect, useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -136,7 +136,7 @@ export function LinkToDashboardModal({
     (
       hasReachedDashboardLimit: boolean,
       isLoading: boolean,
-      limitMessage: ReactNode | null
+      limitMessage: React.ReactNode | null
     ) => {
       if (dashboards === null) {
         return [];

--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {useEffect, useEffectEvent, useMemo} from 'react';
 import styled from '@emotion/styled';
 
@@ -19,7 +18,7 @@ import type {PlatformKey} from 'sentry/types/project';
 import {useOnboardingQueryParams} from 'sentry/views/onboarding/components/useOnboardingQueryParams';
 
 interface DisabledProduct {
-  reason: ReactNode;
+  reason: React.ReactNode;
   onClick?: () => void;
   requiresUpgrade?: boolean;
 }
@@ -511,7 +510,7 @@ type ProductProps = {
   /**
    * Brief product description
    */
-  description?: ReactNode;
+  description?: React.ReactNode;
   /**
    * If the product is disabled. It contains a reason and an optional onClick handler
    */

--- a/static/app/components/preprod/preprodBuildsDistributionTable.tsx
+++ b/static/app/components/preprod/preprodBuildsDistributionTable.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
@@ -22,7 +21,7 @@ interface PreprodBuildsDistributionTableProps {
   builds: BuildDetailsApiResponse[];
   organizationSlug: string;
   showProjectColumn: boolean;
-  content?: ReactNode;
+  content?: React.ReactNode;
   onRowClick?: (build: BuildDetailsApiResponse) => void;
 }
 

--- a/static/app/components/preprod/preprodBuildsSizeTable.tsx
+++ b/static/app/components/preprod/preprodBuildsSizeTable.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
@@ -29,7 +28,7 @@ interface PreprodBuildsSizeTableProps {
   labels: Labels;
   organizationSlug: string;
   showProjectColumn: boolean;
-  content?: ReactNode;
+  content?: React.ReactNode;
   onRowClick?: (build: BuildDetailsApiResponse) => void;
 }
 

--- a/static/app/components/preprod/preprodBuildsSnapshotTable.tsx
+++ b/static/app/components/preprod/preprodBuildsSnapshotTable.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
@@ -25,7 +24,7 @@ interface PreprodBuildsSnapshotTableProps {
   builds: BuildDetailsApiResponse[];
   organizationSlug: string;
   showProjectColumn: boolean;
-  content?: ReactNode;
+  content?: React.ReactNode;
   onRowClick?: (build: BuildDetailsApiResponse) => void;
 }
 

--- a/static/app/components/profiling/flamegraph/aggregateFlamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/aggregateFlamegraph.tsx
@@ -1,4 +1,3 @@
-import type {ReactElement} from 'react';
 import {Fragment, useEffect, useLayoutEffect, useMemo, useState} from 'react';
 import * as Sentry from '@sentry/react';
 import type {mat3} from 'gl-matrix';
@@ -46,7 +45,7 @@ interface AggregateFlamegraphProps {
   status: QueryStatus;
 }
 
-export function AggregateFlamegraph(props: AggregateFlamegraphProps): ReactElement {
+export function AggregateFlamegraph(props: AggregateFlamegraphProps): React.ReactElement {
   const dispatch = useDispatchFlamegraphState();
 
   const flamegraph = useFlamegraph();

--- a/static/app/components/profiling/flamegraph/aggregateFlamegraphTreeTable.tsx
+++ b/static/app/components/profiling/flamegraph/aggregateFlamegraphTreeTable.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useMemo, useState, type MouseEvent} from 'react';
+import {useCallback, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
 import InteractionStateLayer from '@sentry/scraps/interactionStateLayer';
@@ -474,7 +474,7 @@ export function AggregateFlamegraphTreeTable({
                 {renderItems.map(r => {
                   const handler = handleRowClick(r.key);
                   return fixedRenderRow(r, {
-                    handleRowClick: (evt: MouseEvent<HTMLElement>) => {
+                    handleRowClick: (evt: React.MouseEvent<HTMLElement>) => {
                       trackAnalytics('profiling_views.flamegraph.click.highlight_frame', {
                         organization,
                         profile_type: profileType,
@@ -501,7 +501,7 @@ export function AggregateFlamegraphTreeTable({
                 {renderItems.map(r => {
                   const handler = handleRowClick(r.key);
                   return dynamicRenderRow(r, {
-                    handleRowClick: (evt: MouseEvent<HTMLElement>) => {
+                    handleRowClick: (evt: React.MouseEvent<HTMLElement>) => {
                       handler(evt);
                     },
                     handleRowMouseEnter: handleRowMouseEnter(r.key),

--- a/static/app/components/profiling/flamegraph/continuousFlamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/continuousFlamegraph.tsx
@@ -1,4 +1,3 @@
-import type {ReactElement} from 'react';
 import {
   Fragment,
   useCallback,
@@ -250,7 +249,7 @@ const LOADING_OR_FALLBACK_MEMORY_CHART = FlamegraphChartModel.Empty;
 
 const noopFormatDuration = () => '';
 
-export function ContinuousFlamegraph(): ReactElement {
+export function ContinuousFlamegraph(): React.ReactElement {
   const devicePixelRatio = useDevicePixelRatio();
   const dispatch = useDispatchFlamegraphState();
 

--- a/static/app/components/profiling/flamegraph/differentialFlamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/differentialFlamegraph.tsx
@@ -1,4 +1,3 @@
-import type {ReactElement} from 'react';
 import {useLayoutEffect, useMemo, useState} from 'react';
 import * as Sentry from '@sentry/react';
 import type {mat3} from 'gl-matrix';
@@ -36,7 +35,9 @@ interface DifferentialFlamegraphProps {
   scheduler: CanvasScheduler;
 }
 
-export function DifferentialFlamegraph(props: DifferentialFlamegraphProps): ReactElement {
+export function DifferentialFlamegraph(
+  props: DifferentialFlamegraphProps
+): React.ReactElement {
   const flamegraphTheme = useFlamegraphTheme();
   const {colorCoding} = useFlamegraphPreferences();
 

--- a/static/app/components/profiling/flamegraph/flamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.tsx
@@ -1,4 +1,3 @@
-import type {ReactElement} from 'react';
 import {
   Fragment,
   useCallback,
@@ -211,7 +210,7 @@ const LOADING_OR_FALLBACK_MEMORY_CHART = FlamegraphChartModel.Empty;
 
 const noopFormatDuration = () => '';
 
-function Flamegraph(): ReactElement {
+function Flamegraph(): React.ReactElement {
   const devicePixelRatio = useDevicePixelRatio();
   const profiledTransaction = useProfileTransaction();
   const dispatch = useDispatchFlamegraphState();

--- a/static/app/components/profiling/flamegraph/flamegraphChart.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphChart.tsx
@@ -1,4 +1,3 @@
-import type {CSSProperties} from 'react';
 import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {mat3, vec2} from 'gl-matrix';
@@ -320,7 +319,7 @@ export function FlamegraphChart({
   );
 }
 
-const Canvas = styled('canvas')<{cursor?: CSSProperties['cursor']}>`
+const Canvas = styled('canvas')<{cursor?: React.CSSProperties['cursor']}>`
   width: 100%;
   height: 100%;
   position: absolute;

--- a/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphDrawer.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphDrawer.tsx
@@ -1,4 +1,3 @@
-import type {MouseEventHandler} from 'react';
 import {memo, useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
@@ -41,8 +40,8 @@ interface FlamegraphDrawerProps {
   profileTransaction: ReturnType<typeof useProfileTransaction> | null;
   referenceNode: FlamegraphFrame;
   rootNodes: FlamegraphFrame[];
-  onResize?: MouseEventHandler<HTMLElement>;
-  onResizeReset?: MouseEventHandler<HTMLElement>;
+  onResize?: React.MouseEventHandler<HTMLElement>;
+  onResizeReset?: React.MouseEventHandler<HTMLElement>;
 }
 
 const FlamegraphDrawer = memo(function FlamegraphDrawer(props: FlamegraphDrawerProps) {

--- a/static/app/components/profiling/flamegraph/flamegraphPreview.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphPreview.tsx
@@ -1,4 +1,3 @@
-import type {CSSProperties} from 'react';
 import {useCallback, useEffect, useLayoutEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import {vec2, type mat3} from 'gl-matrix';
@@ -364,8 +363,8 @@ export function computePreviewConfigView(
 }
 
 const Canvas = styled('canvas')<{
-  cursor?: CSSProperties['cursor'];
-  pointerEvents?: CSSProperties['pointerEvents'];
+  cursor?: React.CSSProperties['cursor'];
+  pointerEvents?: React.CSSProperties['pointerEvents'];
 }>`
   left: 0;
   top: 0;

--- a/static/app/components/profiling/flamegraph/flamegraphSpans.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphSpans.tsx
@@ -1,4 +1,3 @@
-import type {CSSProperties} from 'react';
 import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {vec2} from 'gl-matrix';
@@ -539,7 +538,7 @@ export function FlamegraphSpans({
   );
 }
 
-const Canvas = styled('canvas')<{cursor?: CSSProperties['cursor']}>`
+const Canvas = styled('canvas')<{cursor?: React.CSSProperties['cursor']}>`
   width: 100%;
   height: calc(100% - 20px);
   position: absolute;

--- a/static/app/components/profiling/flamegraph/flamegraphUIFrames.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphUIFrames.tsx
@@ -1,4 +1,3 @@
-import type {CSSProperties} from 'react';
 import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
@@ -305,7 +304,7 @@ export function FlamegraphUIFrames({
   );
 }
 
-const Canvas = styled('canvas')<{cursor?: CSSProperties['cursor']}>`
+const Canvas = styled('canvas')<{cursor?: React.CSSProperties['cursor']}>`
   width: 100%;
   height: 100%;
   position: absolute;

--- a/static/app/components/profiling/flamegraph/flamegraphZoomView.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphZoomView.tsx
@@ -1,4 +1,3 @@
-import type {CSSProperties} from 'react';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {vec2} from 'gl-matrix';
@@ -836,8 +835,8 @@ function FlamegraphZoomView({
 }
 
 const Canvas = styled('canvas')<{
-  cursor?: CSSProperties['cursor'];
-  pointerEvents?: CSSProperties['pointerEvents'];
+  cursor?: React.CSSProperties['cursor'];
+  pointerEvents?: React.CSSProperties['pointerEvents'];
 }>`
   left: 0;
   top: 0;

--- a/static/app/components/projectList.tsx
+++ b/static/app/components/projectList.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {css, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -12,7 +11,9 @@ import {useProjects} from 'sentry/utils/useProjects';
 type ProjectListProps = {
   projectSlugs: string[];
   className?: string;
-  collapsedProjectsTooltip?: (projects: Array<Project | {slug: string}>) => ReactNode;
+  collapsedProjectsTooltip?: (
+    projects: Array<Project | {slug: string}>
+  ) => React.ReactNode;
   maxVisibleProjects?: number;
 };
 

--- a/static/app/components/replays/breadcrumbs/breadcrumbDescription.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbDescription.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {useCallback} from 'react';
 import styled from '@emotion/styled';
 
@@ -15,7 +14,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 
 interface Props {
   allowShowSnippet: boolean;
-  description: ReactNode;
+  description: React.ReactNode;
   frame: ReplayFrame | WebVitalFrame;
   onShowSnippet: () => void;
   showSnippet: boolean;

--- a/static/app/components/replays/breadcrumbs/breadcrumbIssueLink.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbIssueLink.tsx
@@ -1,4 +1,3 @@
-import {type MouseEvent} from 'react';
 import styled from '@emotion/styled';
 
 import {ProjectAvatar} from '@sentry/scraps/avatar';
@@ -27,7 +26,7 @@ function CrumbErrorIssue({frame}: {frame: FeedbackFrame | ErrorFrame}) {
   const organization = useOrganization();
   const project = useProjectFromSlug({organization, projectSlug: frame.data.projectSlug});
   const {groupId} = useReplayGroupContext();
-  const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.stopPropagation();
   };
 

--- a/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbItem.tsx
@@ -1,4 +1,3 @@
-import type {CSSProperties} from 'react';
 import {isValidElement, useEffect, useRef} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -37,7 +36,7 @@ interface Props {
   extraction?: Extraction;
   index?: number;
   ref?: React.Ref<HTMLDivElement>;
-  style?: CSSProperties;
+  style?: React.CSSProperties;
   updateDimensions?: () => void;
 }
 

--- a/static/app/components/replays/breadcrumbs/breadcrumbStructuredData.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbStructuredData.tsx
@@ -1,11 +1,10 @@
-import type {ReactNode} from 'react';
 import styled from '@emotion/styled';
 
 import {StructuredEventData} from 'sentry/components/structuredEventData';
 import type {OnExpandCallback} from 'sentry/views/replays/detail/useVirtualizedInspector';
 
 interface Props {
-  description: ReactNode;
+  description: React.ReactNode;
   onInspectorExpanded: OnExpandCallback;
   expandPaths?: string[];
 }

--- a/static/app/components/replays/breadcrumbs/breadcrumbWebVital.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbWebVital.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import styled from '@emotion/styled';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
@@ -14,7 +13,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import type {OnExpandCallback} from 'sentry/views/replays/detail/useVirtualizedInspector';
 
 type MouseCallback = (frame: ReplayFrame, nodeId?: number) => void;
-type LayoutShift = Record<string, ReactNode[]>;
+type LayoutShift = Record<string, React.ReactNode[]>;
 
 interface Props {
   frame: ReplayFrame;
@@ -41,14 +40,14 @@ export function BreadcrumbWebVital({
   }
 
   const selectors = extraction?.selectors;
-  const webVitalData: Record<string, number | ReactNode | LayoutShift[]> = {
+  const webVitalData: Record<string, number | React.ReactNode | LayoutShift[]> = {
     value: frame.data.value,
   };
 
   if (isCLSFrame(frame) && frame.data.attributions && selectors) {
     const layoutShifts: LayoutShift[] = [];
     for (const attr of frame.data.attributions) {
-      const elements: ReactNode[] = [];
+      const elements: React.ReactNode[] = [];
       if ('nodeIds' in attr && Array.isArray(attr.nodeIds)) {
         attr.nodeIds.forEach(nodeId => {
           if (selectors.get(nodeId)) {

--- a/static/app/components/replays/breadcrumbs/errorTitle.tsx
+++ b/static/app/components/replays/breadcrumbs/errorTitle.tsx
@@ -1,4 +1,4 @@
-import {Fragment, type MouseEvent} from 'react';
+import {Fragment} from 'react';
 import capitalize from 'lodash/capitalize';
 
 import {Link} from '@sentry/scraps/link';
@@ -11,7 +11,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 export function CrumbErrorTitle({frame}: {frame: ErrorFrame}) {
   const organization = useOrganization();
   const {eventId} = useReplayGroupContext();
-  const handleClick = (e: MouseEvent<HTMLAnchorElement>) => {
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.stopPropagation();
   };
 

--- a/static/app/components/replays/breadcrumbs/openReplayComparisonButton.tsx
+++ b/static/app/components/replays/breadcrumbs/openReplayComparisonButton.tsx
@@ -1,4 +1,4 @@
-import {Fragment, lazy, Suspense, type ReactNode} from 'react';
+import {Fragment, lazy, Suspense} from 'react';
 import {css} from '@emotion/react';
 
 import {Button, type ButtonProps} from '@sentry/scraps/button';
@@ -16,7 +16,7 @@ const LazyComparisonModal = lazy(
 );
 
 interface Props {
-  children: ReactNode;
+  children: React.ReactNode;
   frameOrEvent: HydrationErrorFrame | Event;
   initialLeftOffsetMs: number;
   initialRightOffsetMs: number;

--- a/static/app/components/replays/diff/diffCompareContext.tsx
+++ b/static/app/components/replays/diff/diffCompareContext.tsx
@@ -1,11 +1,4 @@
-import {
-  createContext,
-  useContext,
-  useState,
-  type Dispatch,
-  type ReactNode,
-  type SetStateAction,
-} from 'react';
+import {createContext, useContext, useState} from 'react';
 
 import type {Event} from 'sentry/types/event';
 import {ReplayReader} from 'sentry/utils/replays/replayReader';
@@ -18,8 +11,8 @@ type ContextType = {
   replay: ReplayReader;
   rightOffsetMs: number;
   rightTimestampMs: number;
-  setLeftOffsetMs: Dispatch<SetStateAction<number>>;
-  setRightOffsetMs: Dispatch<SetStateAction<number>>;
+  setLeftOffsetMs: React.Dispatch<React.SetStateAction<number>>;
+  setRightOffsetMs: React.Dispatch<React.SetStateAction<number>>;
 };
 
 const Context = createContext<ContextType>({
@@ -47,7 +40,7 @@ interface Props {
   initialLeftOffsetMs: number;
   initialRightOffsetMs: number;
   replay: ReplayReader;
-  children?: ReactNode;
+  children?: React.ReactNode;
 }
 
 export function DiffCompareContextProvider({

--- a/static/app/components/replays/diff/learnMoreButton.tsx
+++ b/static/app/components/replays/diff/learnMoreButton.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps, ReactNode} from 'react';
 import {ClassNames, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -16,7 +15,7 @@ function Resource({
   link,
 }: {
   link: string;
-  subtitle: ReactNode;
+  subtitle: React.ReactNode;
   title: string;
 }) {
   const analyticsArea = useAnalyticsArea();
@@ -60,7 +59,7 @@ function Buttons() {
 }
 
 export function LearnMoreButton(
-  hoverCardProps: Partial<ComponentProps<typeof Hovercard>>
+  hoverCardProps: Partial<React.ComponentProps<typeof Hovercard>>
 ) {
   const theme = useTheme();
   return (

--- a/static/app/components/replays/diff/replaySliderDiff.tsx
+++ b/static/app/components/replays/diff/replaySliderDiff.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useRef, type CSSProperties} from 'react';
+import {Fragment, useCallback, useRef} from 'react';
 
 import {ContentSliderDiff} from 'sentry/components/contentSliderDiff';
 import {useDiffCompareContext} from 'sentry/components/replays/diff/diffCompareContext';
@@ -12,7 +12,7 @@ import {ReplayReaderProvider} from 'sentry/utils/replays/playback/providers/repl
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 interface Props {
-  minHeight?: CSSProperties['minHeight'];
+  minHeight?: React.CSSProperties['minHeight'];
 }
 
 export function ReplaySliderDiff({minHeight}: Props) {

--- a/static/app/components/replays/diff/utils.tsx
+++ b/static/app/components/replays/diff/utils.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import styled from '@emotion/styled';
 
 import {Flex} from '@sentry/scraps/layout';
@@ -10,7 +9,7 @@ import {t} from 'sentry/locale';
 interface BeforeAfterProps {
   offset: number;
   startTimestampMs: number;
-  children?: ReactNode;
+  children?: React.ReactNode;
 }
 
 function ReplayDiffTooltip({
@@ -18,7 +17,7 @@ function ReplayDiffTooltip({
   offset,
   startTimestampMs,
 }: {
-  children: ReactNode;
+  children: React.ReactNode;
   offset: number;
   startTimestampMs: number;
 }) {

--- a/static/app/components/replays/header/configureReplayCard.tsx
+++ b/static/app/components/replays/header/configureReplayCard.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import styled from '@emotion/styled';
 import type {Key} from '@react-types/shared';
 import * as Sentry from '@sentry/react';
@@ -200,8 +199,8 @@ function ReplayConfigureDropdownItem({
   title,
   subTitle,
 }: {
-  subTitle: ReactNode;
-  title: ReactNode;
+  subTitle: React.ReactNode;
+  title: React.ReactNode;
 }) {
   return (
     <Flex gap="md" align="center">

--- a/static/app/components/replays/player/__stories__/providers.tsx
+++ b/static/app/components/replays/player/__stories__/providers.tsx
@@ -1,5 +1,3 @@
-import type {ReactNode} from 'react';
-
 import {StaticNoSkipReplayPreferences} from 'sentry/components/replays/preferences/replayPreferences';
 import {ReplayPlayerPluginsContextProvider} from 'sentry/utils/replays/playback/providers/replayPlayerPluginsContext';
 import {ReplayPlayerStateContextProvider} from 'sentry/utils/replays/playback/providers/replayPlayerStateContext';
@@ -11,7 +9,7 @@ export function Providers({
   children,
   replay,
 }: {
-  children: ReactNode;
+  children: React.ReactNode;
   replay: ReplayReader;
 }) {
   return (

--- a/static/app/components/replays/player/__stories__/replaySlugChooser.tsx
+++ b/static/app/components/replays/player/__stories__/replaySlugChooser.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useState, type ReactNode} from 'react';
+import {Fragment, useState} from 'react';
 import {ClassNames} from '@emotion/react';
 import {useInfiniteQuery} from '@tanstack/react-query';
 
@@ -18,7 +18,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {useSessionStorage} from 'sentry/utils/useSessionStorage';
 
 interface Props {
-  children: ReactNode;
+  children: React.ReactNode;
 }
 
 export function ReplaySlugChooser({children}: Props) {
@@ -96,7 +96,13 @@ export function ReplaySlugChooser({children}: Props) {
   );
 }
 
-function Content({children, replaySlug}: {children: ReactNode; replaySlug: string}) {
+function Content({
+  children,
+  replaySlug,
+}: {
+  children: React.ReactNode;
+  replaySlug: string;
+}) {
   const organization = useOrganization();
   const readerResult = useLoadReplayReader({
     orgSlug: organization.slug,

--- a/static/app/components/replays/player/replayLoadingState.tsx
+++ b/static/app/components/replays/player/replayLoadingState.tsx
@@ -1,5 +1,3 @@
-import type {ReactNode} from 'react';
-
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {ArchivedReplayAlert} from 'sentry/components/replays/alerts/archivedReplayAlert';
 import {MissingReplayAlert} from 'sentry/components/replays/alerts/missingReplayAlert';
@@ -21,14 +19,14 @@ export function ReplayLoadingState({
   renderMissing,
   renderProcessingError,
 }: {
-  children: (props: {replay: ReplayReader}) => ReactNode;
+  children: (props: {replay: ReplayReader}) => React.ReactNode;
   readerResult: ReplayReaderResult;
-  renderArchived?: (results: ReplayReaderResult) => ReactNode;
-  renderError?: (results: ReplayReaderResult) => ReactNode;
-  renderLoading?: (results: ReplayReaderResult) => ReactNode;
-  renderMissing?: (results: ReplayReaderResult) => ReactNode;
-  renderProcessingError?: (results: ReplayReaderResult) => ReactNode;
-  renderThrottled?: (results: ReplayReaderResult) => ReactNode;
+  renderArchived?: (results: ReplayReaderResult) => React.ReactNode;
+  renderError?: (results: ReplayReaderResult) => React.ReactNode;
+  renderLoading?: (results: ReplayReaderResult) => React.ReactNode;
+  renderMissing?: (results: ReplayReaderResult) => React.ReactNode;
+  renderProcessingError?: (results: ReplayReaderResult) => React.ReactNode;
+  renderThrottled?: (results: ReplayReaderResult) => React.ReactNode;
 }) {
   const organization = useOrganization();
 

--- a/static/app/components/replays/player/replayPlayer.tsx
+++ b/static/app/components/replays/player/replayPlayer.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useLayoutEffect, useRef, type HTMLAttributes} from 'react';
+import {useEffect, useLayoutEffect, useRef} from 'react';
 import {useTheme, type Interpolation, type Theme} from '@emotion/react';
 import {Replayer} from '@sentry-internal/rrweb';
 
@@ -82,7 +82,7 @@ function useReplayerInstance() {
   return mountPointRef;
 }
 
-interface Props extends HTMLAttributes<HTMLDivElement> {
+interface Props extends React.HTMLAttributes<HTMLDivElement> {
   css?: Interpolation<Theme>;
   inspectable?: boolean;
   offsetMs?: undefined | number;

--- a/static/app/components/replays/player/replayPlayerMeasurer.tsx
+++ b/static/app/components/replays/player/replayPlayerMeasurer.tsx
@@ -1,4 +1,3 @@
-import type {CSSProperties, ReactNode} from 'react';
 import {useEffect, useRef} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -12,7 +11,7 @@ interface Props {
   /**
    * You must pass `styles` into the <ReplayPlayer>
    */
-  children: (styles: CSSProperties) => ReactNode;
+  children: (styles: React.CSSProperties) => React.ReactNode;
 
   /**
    * How to measure and resize the player.

--- a/static/app/components/replays/player/useTimelineMouseTracking.tsx
+++ b/static/app/components/replays/player/useTimelineMouseTracking.tsx
@@ -1,4 +1,3 @@
-import type {RefObject} from 'react';
 import {useCallback} from 'react';
 
 import {useReplayContext} from 'sentry/components/replays/replayContext';
@@ -8,7 +7,7 @@ import {useCurrentHoverTime} from 'sentry/utils/replays/playback/providers/useCu
 import {useMouseTracking} from 'sentry/utils/useMouseTracking';
 
 type Opts<T extends Element> = {
-  elem: RefObject<T | null>;
+  elem: React.RefObject<T | null>;
 };
 
 /**

--- a/static/app/components/replays/renderSortableHeaderCell.tsx
+++ b/static/app/components/replays/renderSortableHeaderCell.tsx
@@ -1,4 +1,3 @@
-import type {MouseEvent} from 'react';
 import type {LocationDescriptorObject} from 'history';
 
 import type {GridColumnOrder} from 'sentry/components/tables/gridEditable';
@@ -8,7 +7,7 @@ import type {Sort} from 'sentry/utils/discover/fields';
 interface Props<Key extends string> {
   currentSort: Sort;
   makeSortLinkGenerator: (column: GridColumnOrder<Key>) => () => LocationDescriptorObject;
-  onClick(column: GridColumnOrder<Key>, e: MouseEvent<HTMLAnchorElement>): void;
+  onClick(column: GridColumnOrder<Key>, e: React.MouseEvent<HTMLAnchorElement>): void;
   rightAlignedColumns: Array<GridColumnOrder<string>>;
   sortableColumns: Array<GridColumnOrder<string>>;
 }

--- a/static/app/components/replays/replayTagsTableRow.tsx
+++ b/static/app/components/replays/replayTagsTableRow.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {Fragment, useMemo} from 'react';
 import styled from '@emotion/styled';
 import type {LocationDescriptor} from 'history';
@@ -38,7 +37,7 @@ const expandedViewKeys = [
 
 const releaseKeys = ['release', 'releases'];
 
-function renderValueList(values: ReactNode[]) {
+function renderValueList(values: React.ReactNode[]) {
   if (typeof values[0] === 'string') {
     return values[0];
   }

--- a/static/app/components/replays/table/replayTable.tsx
+++ b/static/app/components/replays/table/replayTable.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useRef, type RefObject} from 'react';
+import {useEffect, useRef} from 'react';
 import styled from '@emotion/styled';
 import type {Query} from 'history';
 
@@ -35,7 +35,7 @@ type Props = SortProps & {
   highlightedRowIndex?: number;
   pageLinks?: string | null;
   query?: Query;
-  ref?: RefObject<HTMLDivElement | null>;
+  ref?: React.RefObject<HTMLDivElement | null>;
   stickyHeader?: boolean;
 };
 

--- a/static/app/components/replays/table/replayTableColumns.tsx
+++ b/static/app/components/replays/table/replayTableColumns.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {useMatches} from 'react-router-dom';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -64,13 +63,13 @@ export interface ReplayTableColumn {
    * Render the content
    * Content will be automatically wrapped with `<SimpleTable.RowCell>`
    */
-  Component: (props: CellProps) => ReactNode;
+  Component: (props: CellProps) => React.ReactNode;
 
   /**
    * Render the header
    * Header will be automatically wrapped with `<SimpleTable.HeaderCell>`
    */
-  Header: string | ((props: HeaderProps) => ReactNode);
+  Header: string | ((props: HeaderProps) => React.ReactNode);
 
   /**
    * If any columns in the table are interactive, we will add an

--- a/static/app/components/replays/useReplayHighlighting.tsx
+++ b/static/app/components/replays/useReplayHighlighting.tsx
@@ -1,4 +1,3 @@
-import type {RefObject} from 'react';
 import {useCallback} from 'react';
 import type {Replayer} from '@sentry-internal/rrweb';
 
@@ -9,7 +8,7 @@ import {
 } from 'sentry/utils/replays/highlightNode';
 
 interface Props {
-  replayerRef: RefObject<Replayer | null>;
+  replayerRef: React.RefObject<Replayer | null>;
 }
 
 type HighlightParams = Parameters<typeof highlightNode>[1];

--- a/static/app/components/replays/virtualizedGrid/detailsSplitDivider.tsx
+++ b/static/app/components/replays/virtualizedGrid/detailsSplitDivider.tsx
@@ -1,4 +1,3 @@
-import type {MouseEvent, ReactNode} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
@@ -11,7 +10,7 @@ import {SplitDivider} from 'sentry/views/replays/detail/layout/splitDivider';
 
 interface Props extends Omit<ReturnType<typeof useResizableDrawer>, 'size' | 'setSize'> {
   onClose: () => void;
-  children?: ReactNode;
+  children?: React.ReactNode;
 }
 
 export function DetailsSplitDivider({
@@ -35,7 +34,7 @@ export function DetailsSplitDivider({
           aria-label={t('Hide details')}
           priority="transparent"
           icon={<IconClose size="sm" variant="muted" />}
-          onClick={(e: MouseEvent) => {
+          onClick={(e: React.MouseEvent) => {
             e.preventDefault();
             onClose();
           }}

--- a/static/app/components/replays/virtualizedGrid/headerCell.tsx
+++ b/static/app/components/replays/virtualizedGrid/headerCell.tsx
@@ -1,4 +1,3 @@
-import type {CSSProperties, ReactNode} from 'react';
 import styled from '@emotion/styled';
 
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -15,10 +14,10 @@ export interface SortConfig<RecordType extends BaseRecord> {
 type Props<SortableRecord extends BaseRecord> = {
   field: string;
   handleSort: (fieldName: string) => void;
-  label: ReactNode;
+  label: React.ReactNode;
   sortConfig: SortConfig<SortableRecord>;
-  style: CSSProperties;
-  tooltipTitle: undefined | ReactNode;
+  style: React.CSSProperties;
+  tooltipTitle: undefined | React.ReactNode;
   ref?: React.Ref<HTMLButtonElement>;
 };
 
@@ -26,7 +25,7 @@ const StyledIconInfo = styled(IconInfo)`
   display: block;
 `;
 
-function CatchClicks({children}: {children: ReactNode}) {
+function CatchClicks({children}: {children: React.ReactNode}) {
   return <div onClick={e => e.stopPropagation()}>{children}</div>;
 }
 

--- a/static/app/components/replays/virtualizedGrid/useDetailsSplit.tsx
+++ b/static/app/components/replays/virtualizedGrid/useDetailsSplit.tsx
@@ -1,4 +1,3 @@
-import type {RefObject} from 'react';
 import {useCallback} from 'react';
 import {parseAsInteger, useQueryState} from 'nuqs';
 
@@ -10,7 +9,7 @@ interface OnClickProps {
 }
 
 interface Props {
-  containerRef: RefObject<HTMLDivElement | null>;
+  containerRef: React.RefObject<HTMLDivElement | null>;
   frames: undefined | readonly unknown[];
   handleHeight: number;
   urlParamName: string;

--- a/static/app/components/replaysOnboarding/sidebar.tsx
+++ b/static/app/components/replaysOnboarding/sidebar.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {Fragment, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import {parseAsStringLiteral, useQueryState} from 'nuqs';
@@ -209,7 +208,7 @@ function OnboardingContent({
 
   const [jsFramework, setJsFramework] = useState<{
     value: PlatformKey;
-    label?: ReactNode;
+    label?: React.ReactNode;
     textValue?: string;
   }>(jsFrameworkSelectOptions[0]!);
 

--- a/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeRow.tsx
+++ b/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeRow.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useState, type CSSProperties, type ReactNode} from 'react';
+import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Badge, Tag} from '@sentry/scraps/badge';
@@ -38,7 +38,7 @@ type Props = {
     integration: Integration,
     isConnected: boolean
   ) => void;
-  style: CSSProperties;
+  style: React.CSSProperties;
 };
 
 export function ScmIntegrationTreeRow({
@@ -201,7 +201,7 @@ export function ScmIntegrationTreeRow({
   }
 
   if (node.type === 'no-match') {
-    let noMatchMessage: ReactNode;
+    let noMatchMessage: React.ReactNode;
     if (node.search) {
       noMatchMessage = tct('No repos matching "[search]"', {search: node.search});
     } else {
@@ -299,7 +299,7 @@ function RepoRow({
   canAccess: boolean;
   node: Extract<TreeNode, {type: 'repo'}>;
   onToggleRepo: Props['onToggleRepo'];
-  style: CSSProperties;
+  style: React.CSSProperties;
 }) {
   return (
     <RowContainer style={style} role="row" aria-level={3}>
@@ -370,7 +370,7 @@ function DisconnectedRepoRow({
   canAccess: boolean;
   node: Extract<TreeNode, {type: 'disconnected-repo'}>;
   onRemoveDisconnectedRepo: Props['onRemoveDisconnectedRepo'];
-  style: CSSProperties;
+  style: React.CSSProperties;
 }) {
   return (
     <RowContainer style={style} role="row" aria-level={2}>

--- a/static/app/components/savedEntityTable.tsx
+++ b/static/app/components/savedEntityTable.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -23,9 +22,9 @@ import type {AvatarUser} from 'sentry/types/user';
 import {useProjects} from 'sentry/utils/useProjects';
 
 type SavedEntityTableProps = {
-  children: ReactNode;
-  emptyMessage: ReactNode;
-  header: ReactNode;
+  children: React.ReactNode;
+  emptyMessage: React.ReactNode;
+  header: React.ReactNode;
   isEmpty: boolean;
   isError: boolean;
   isLoading: boolean;
@@ -154,7 +153,7 @@ SavedEntityTable.CellName = function CellName({
   children,
   to,
 }: {
-  children: ReactNode;
+  children: React.ReactNode;
   to: string;
 }) {
   return <StyledLink to={to}>{children}</StyledLink>;
@@ -290,7 +289,7 @@ SavedEntityTable.CellUser = function CellUser({user}: {user: AvatarUser | null})
 SavedEntityTable.CellTextContent = function CellTextContent({
   children,
 }: {
-  children: ReactNode;
+  children: React.ReactNode;
 }) {
   return <OverflowEllipsis>{children}</OverflowEllipsis>;
 };

--- a/static/app/components/search/sources/apiSource.spec.tsx
+++ b/static/app/components/search/sources/apiSource.spec.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps} from 'react';
 import {EventFixture} from 'sentry-fixture/event';
 import {EventIdQueryResultFixture} from 'sentry-fixture/eventIdQueryResult';
 import {MembersFixture} from 'sentry-fixture/members';
@@ -21,7 +20,7 @@ describe('ApiSource', () => {
   let eventIdMock: jest.Mock;
   let configState: ReturnType<typeof ConfigStore.getState>;
 
-  const defaultProps: ComponentProps<typeof ApiSource> = {
+  const defaultProps: React.ComponentProps<typeof ApiSource> = {
     query: '',
     debounceDuration: 0,
     children: jest.fn().mockReturnValue(null),

--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -6,7 +6,6 @@ import {
   useMemo,
   useRef,
   useState,
-  type Dispatch,
 } from 'react';
 import * as Sentry from '@sentry/react';
 
@@ -47,7 +46,7 @@ interface SearchQueryBuilderContextData {
   disallowFreeText: boolean;
   disallowLogicalOperators: boolean;
   disallowWildcard: boolean;
-  dispatch: Dispatch<QueryBuilderActions>;
+  dispatch: React.Dispatch<QueryBuilderActions>;
   displayAskSeer: boolean;
   displayAskSeerFeedback: boolean;
   enableAISearch: boolean;

--- a/static/app/components/searchQueryBuilder/hooks/useKeyboardSelection.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useKeyboardSelection.tsx
@@ -1,11 +1,4 @@
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useMemo,
-  useRef,
-  type ReactNode,
-} from 'react';
+import {createContext, useCallback, useContext, useMemo, useRef} from 'react';
 import type {ListState} from '@react-stately/list';
 import type {Key} from '@react-types/shared';
 
@@ -115,7 +108,7 @@ const KeyboardSelectionContext = createContext<KeyboardSelectionData>({
  * Focus is lost when a selection is enabled, so this context is necessary
  * to keep track of the latest cursor position.
  */
-export function KeyboardSelection({children}: {children: ReactNode}) {
+export function KeyboardSelection({children}: {children: React.ReactNode}) {
   const state = useKeyboardSelectionState();
 
   return <KeyboardSelectionContext value={state}>{children}</KeyboardSelectionContext>;

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderGrid.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderGrid.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, type DOMAttributes, type FocusEvent} from 'react';
+import {useCallback, useMemo} from 'react';
 import {useGridList, type AriaGridListOptions} from '@react-aria/gridlist';
 import {ListKeyboardDelegate} from '@react-aria/selection';
 import type {ListState} from '@react-stately/list';
@@ -31,7 +31,7 @@ export function useQueryBuilderGrid({
   state: ListState<ParseResultToken>;
   undo: () => void;
 }): {
-  gridProps: DOMAttributes<HTMLDivElement>;
+  gridProps: React.DOMAttributes<HTMLDivElement>;
 } {
   // The default behavior uses vertical naviation, but we want horizontal navigation
   const delegate = useMemo(
@@ -91,7 +91,7 @@ export function useQueryBuilderGrid({
       // we want to handle ourselves.
       onKeyDownCapture: noop,
       onKeyDown,
-      onFocus: (e: FocusEvent) => {
+      onFocus: (e: React.FocusEvent) => {
         // This element should never take focus from the SelectionKeyHandler
         if (
           e.target === ref.current &&
@@ -113,7 +113,7 @@ export function useQueryBuilderGrid({
           state.selectionManager.setFocusedKey(state.collection.getLastKey());
         }
       },
-      onBlur: (e: FocusEvent) => {
+      onBlur: (e: React.FocusEvent) => {
         const nextFocusedElement = e.relatedTarget;
 
         // If we're leaving the grid, update the focused state

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderGridItem.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderGridItem.tsx
@@ -1,4 +1,4 @@
-import {useCallback, type RefObject} from 'react';
+import {useCallback} from 'react';
 import {focusSafely, getFocusableTreeWalker} from '@react-aria/focus';
 import {useGridListItem} from '@react-aria/gridlist';
 import {isMac} from '@react-aria/utils';
@@ -25,7 +25,7 @@ function focusNextGridCell({
   item: Node<ParseResultToken>;
   state: ListState<ParseResultToken>;
   walker: TreeWalker;
-  wrapperRef: RefObject<HTMLElement | null>;
+  wrapperRef: React.RefObject<HTMLElement | null>;
 }) {
   const nextFocusableChild = walker.nextSibling();
   if (nextFocusableChild) {
@@ -56,7 +56,7 @@ function focusPreviousGridCell({
   item: Node<ParseResultToken>;
   state: ListState<ParseResultToken>;
   walker: TreeWalker;
-  wrapperRef: RefObject<HTMLElement | null>;
+  wrapperRef: React.RefObject<HTMLElement | null>;
 }) {
   const previousFocusableChild = walker.previousSibling();
 
@@ -92,7 +92,7 @@ function focusPreviousGridCell({
 export function useQueryBuilderGridItem(
   item: Node<ParseResultToken>,
   state: ListState<ParseResultToken>,
-  ref: RefObject<FocusableElement | null>
+  ref: React.RefObject<FocusableElement | null>
 ) {
   const {wrapperRef} = useSearchQueryBuilder();
   const {rowProps, gridCellProps} = useGridListItem({node: item}, state, ref);

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useReducer, type Reducer} from 'react';
+import {useCallback, useEffect, useReducer} from 'react';
 
 import {parseFilterValueDate} from 'sentry/components/searchQueryBuilder/tokens/filter/parsers/date/parser';
 import {
@@ -934,7 +934,7 @@ export function useQueryBuilderState({
     clearAskSeerFeedback: false,
   };
 
-  const reducer: Reducer<QueryBuilderState, QueryBuilderActions> = useCallback(
+  const reducer: React.Reducer<QueryBuilderState, QueryBuilderActions> = useCallback(
     (state, action): QueryBuilderState => {
       if (disabled) {
         return state;

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps} from 'react';
 import {destroyAnnouncer} from '@react-aria/live-announcer';
 
 import {
@@ -156,7 +155,7 @@ describe('SearchQueryBuilder', () => {
     jest.restoreAllMocks();
   });
 
-  const defaultProps: ComponentProps<typeof SearchQueryBuilder> = {
+  const defaultProps: React.ComponentProps<typeof SearchQueryBuilder> = {
     getTagValues: jest.fn(() => Promise.resolve([])),
     initialQuery: '',
     filterKeySections: FILTER_KEY_SECTIONS,
@@ -2777,14 +2776,15 @@ describe('SearchQueryBuilder', () => {
 
         await userEvent.click(document.body);
 
-        const updatedFilterKeys: ComponentProps<typeof SearchQueryBuilder>['filterKeys'] =
-          {
-            ...defaultProps.filterKeys,
-            [FieldKey.BROWSER_NAME]: {
-              ...defaultProps.filterKeys[FieldKey.BROWSER_NAME]!,
-              values: ['Safari', 'Opera', 'Firefox', 'Chrome'],
-            },
-          };
+        const updatedFilterKeys: React.ComponentProps<
+          typeof SearchQueryBuilder
+        >['filterKeys'] = {
+          ...defaultProps.filterKeys,
+          [FieldKey.BROWSER_NAME]: {
+            ...defaultProps.filterKeys[FieldKey.BROWSER_NAME]!,
+            values: ['Safari', 'Opera', 'Firefox', 'Chrome'],
+          },
+        };
 
         rerender(
           <SearchQueryBuilder

--- a/static/app/components/searchQueryBuilder/plainTextQueryInput.tsx
+++ b/static/app/components/searchQueryBuilder/plainTextQueryInput.tsx
@@ -1,11 +1,4 @@
-import {
-  useCallback,
-  useRef,
-  useState,
-  type ChangeEvent,
-  type KeyboardEvent,
-  type SyntheticEvent,
-} from 'react';
+import {useCallback, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
@@ -21,7 +14,7 @@ export function PlainTextQueryInput({label}: PlainTextQueryInputProps) {
     useSearchQueryBuilder();
   const [cursorPosition, setCursorPosition] = useState(0);
 
-  const setCursorPositionOnEvent = (event: SyntheticEvent<HTMLTextAreaElement>) => {
+  const setCursorPositionOnEvent = (event: React.SyntheticEvent<HTMLTextAreaElement>) => {
     if (event.currentTarget === document.activeElement) {
       setCursorPosition(event.currentTarget.selectionStart);
     } else {
@@ -30,7 +23,7 @@ export function PlainTextQueryInput({label}: PlainTextQueryInputProps) {
   };
 
   const onChange = useCallback(
-    (e: ChangeEvent<HTMLTextAreaElement>) => {
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
       setCursorPositionOnEvent(e);
       dispatch({type: 'UPDATE_QUERY', query: e.target.value});
     },
@@ -38,7 +31,7 @@ export function PlainTextQueryInput({label}: PlainTextQueryInputProps) {
   );
 
   const onKeyDown = useCallback(
-    (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       setCursorPositionOnEvent(e);
 
       if (e.key === 'Enter') {

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -1,12 +1,4 @@
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  type MouseEventHandler,
-  type ReactNode,
-} from 'react';
+import {useCallback, useEffect, useLayoutEffect, useMemo, useRef} from 'react';
 import {usePopper} from 'react-popper';
 import styled from '@emotion/styled';
 import {type AriaComboBoxProps} from '@react-aria/combobox';
@@ -72,7 +64,7 @@ type SearchQueryBuilderComboboxProps<T extends SelectOptionOrSectionWithKey<stri
    * If the combobox has additional information to display, passing JSX
    * to this prop will display it in an overlay at the top left position.
    */
-  description?: ReactNode;
+  description?: React.ReactNode;
   filterValue?: string;
   /**
    * Whether the combobox is loading async items.
@@ -565,7 +557,7 @@ export function SearchQueryBuilderCombobox<
     DESCRIPTION_POPPER_OPTIONS
   );
 
-  const handleInputClick: MouseEventHandler<HTMLInputElement> = useCallback(
+  const handleInputClick: React.MouseEventHandler<HTMLInputElement> = useCallback(
     e => {
       e.stopPropagation();
       inputProps.onClick?.(e);

--- a/static/app/components/searchQueryBuilder/tokens/components.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/components.tsx
@@ -1,4 +1,3 @@
-import type {DOMAttributes} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {FocusableElement} from '@react-types/shared';
@@ -9,7 +8,7 @@ import type {
   ContainerPropsWithRenderFunction,
 } from '@sentry/scraps/layout';
 
-type BaseGridCellProps = FlexProps & DOMAttributes<FocusableElement>;
+type BaseGridCellProps = FlexProps & React.DOMAttributes<FocusableElement>;
 
 export function BaseGridCell({children, ...props}: BaseGridCellProps) {
   return (

--- a/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/filterOperator.tsx
@@ -1,4 +1,4 @@
-import {useLayoutEffect, useMemo, useRef, useState, type ReactNode} from 'react';
+import {useLayoutEffect, useMemo, useRef, useState} from 'react';
 import isPropValid from '@emotion/is-prop-valid';
 import styled from '@emotion/styled';
 import {useFocusWithin} from '@react-aria/interactions';
@@ -96,7 +96,7 @@ export function getOperatorInfo({
   fieldDefinition: FieldDefinition | null;
   filterToken: TokenResult<Token.FILTER>;
 }): {
-  label: ReactNode;
+  label: React.ReactNode;
   operator: TermOperator;
   options: Array<SelectOption<TermOperator>>;
 } {

--- a/static/app/components/searchQueryBuilder/tokens/filter/parametersCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/parametersCombobox.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useMemo, useRef, useState, type ReactNode} from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {Item} from '@react-stately/collections';
 import type {ComboBoxState} from '@react-stately/combobox';
 import type {ListState} from '@react-stately/list';
@@ -36,8 +36,8 @@ type ParametersComboboxProps = {
 
 type SuggestionItem = {
   value: string;
-  description?: ReactNode;
-  label?: ReactNode;
+  description?: React.ReactNode;
+  label?: React.ReactNode;
 };
 
 function getInitialInputValue(token: AggregateFilter) {

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueComboboxContext.ts
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueComboboxContext.ts
@@ -1,4 +1,4 @@
-import {createContext, useContext, type RefObject} from 'react';
+import {createContext, useContext} from 'react';
 
 import type {SelectOptionWithKey} from '@sentry/scraps/compactSelect';
 
@@ -21,7 +21,7 @@ type ValueComboboxMenuContextValue = {
   onSelectAbsoluteDate: (newDateTimeValue: string) => void;
   showDatePicker: boolean;
   token: TokenResult<Token.FILTER>;
-  wrapperRef: RefObject<HTMLDivElement | null>;
+  wrapperRef: React.RefObject<HTMLDivElement | null>;
 };
 
 export const ValueComboboxContext = createContext<ValueComboboxContextValue | null>(null);

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/types.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueSuggestions/types.tsx
@@ -1,11 +1,9 @@
-import type {ReactNode} from 'react';
-
 import type {SelectOptionWithKey} from '@sentry/scraps/compactSelect';
 
 export type SuggestionItem = {
   value: string;
-  description?: ReactNode;
-  label?: ReactNode;
+  description?: React.ReactNode;
+  label?: React.ReactNode;
 };
 
 export type SuggestionSection = {

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/index.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useMemo, useRef, type ReactNode} from 'react';
+import {Fragment, useEffect, useMemo, useRef} from 'react';
 import {createPortal} from 'react-dom';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -56,7 +56,7 @@ function ListBoxSectionButton({
   selected,
   children,
 }: {
-  children: ReactNode;
+  children: React.ReactNode;
   onClick: () => void;
   selected: boolean;
 }) {

--- a/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/types.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filterKeyListBox/types.tsx
@@ -1,5 +1,3 @@
-import type {ReactNode} from 'react';
-
 import type {
   SelectOptionWithKey,
   SelectSectionWithKey,
@@ -85,6 +83,6 @@ export type FilterKeyItem =
   | LogicFilterItem;
 
 export type Section = {
-  label: ReactNode;
+  label: React.ReactNode;
   value: string;
 };

--- a/static/app/components/searchQueryBuilder/tokens/invalidTokenTooltip.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/invalidTokenTooltip.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import type {ListState} from '@react-stately/list';
 import type {Node} from '@react-types/shared';
 
@@ -10,11 +9,11 @@ import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
 
 interface InvalidTokenTooltipProps extends Omit<TooltipProps, 'title'> {
-  children: ReactNode;
+  children: React.ReactNode;
   item: Node<ParseResultToken>;
   state: ListState<ParseResultToken>;
   token: ParseResultToken;
-  warning?: ReactNode;
+  warning?: React.ReactNode;
 }
 
 function getForceVisible({

--- a/static/app/components/searchQueryBuilder/tokens/useSearchTokenCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSearchTokenCombobox.tsx
@@ -1,4 +1,3 @@
-import type {FocusEvent, KeyboardEvent} from 'react';
 import {useMemo, useRef} from 'react';
 import type {useComboBox} from '@react-aria/combobox';
 import {getItemId, listData} from '@react-aria/listbox';
@@ -80,7 +79,7 @@ export function useSearchTokenCombobox<T>(
     isVirtualized: true,
   });
 
-  const onKeyDown = (e: BaseEvent<KeyboardEvent<any>>) => {
+  const onKeyDown = (e: BaseEvent<React.KeyboardEvent<any>>) => {
     if (e.nativeEvent.isComposing) {
       return;
     }
@@ -117,7 +116,7 @@ export function useSearchTokenCombobox<T>(
     }
   };
 
-  const onBlur = (e: FocusEvent<HTMLInputElement>) => {
+  const onBlur = (e: React.FocusEvent<HTMLInputElement>) => {
     const blurFromButton = buttonRef?.current && buttonRef.current === e.relatedTarget;
     const blurIntoPopover = popoverRef.current?.contains(e.relatedTarget);
     // Ignore blur if focused moved to the button(if exists) or into the popover.
@@ -132,7 +131,7 @@ export function useSearchTokenCombobox<T>(
     state.setFocused(false);
   };
 
-  const onFocus = (e: FocusEvent<HTMLInputElement>) => {
+  const onFocus = (e: React.FocusEvent<HTMLInputElement>) => {
     if (state.isFocused) {
       return;
     }
@@ -151,9 +150,9 @@ export function useSearchTokenCombobox<T>(
       onKeyDown: isReadOnly
         ? props.onKeyDown
         : chain(state.isOpen && collectionProps.onKeyDown, onKeyDown, props.onKeyDown),
-      onBlur: onBlur as (e: FocusEvent<Element, Element>) => void,
+      onBlur: onBlur as (e: React.FocusEvent<Element, Element>) => void,
       value: state.inputValue,
-      onFocus: onFocus as (e: FocusEvent<Element, Element>) => void,
+      onFocus: onFocus as (e: React.FocusEvent<Element, Element>) => void,
       autoComplete: 'off',
       validate: undefined,
       [privateValidationStateProp]: state,

--- a/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/useSortedFilterKeyItems.tsx
@@ -1,4 +1,4 @@
-import {useMemo, type ReactNode} from 'react';
+import {useMemo} from 'react';
 import type Fuse from 'fuse.js';
 
 import {useSearchQueryBuilder} from 'sentry/components/searchQueryBuilder/context';
@@ -90,7 +90,7 @@ function getFilterSearchValues(
     const fieldDef = getFieldDefinition(key.key);
     const values = key.values ?? fieldDef?.values ?? [];
 
-    const addItem = (value: string, description: ReactNode = '') => {
+    const addItem = (value: string, description: React.ReactNode = '') => {
       acc.push({
         value,
         description: typeof description === 'string' ? description : '',

--- a/static/app/components/searchQueryBuilder/types.tsx
+++ b/static/app/components/searchQueryBuilder/types.tsx
@@ -1,11 +1,9 @@
-import type {ReactNode} from 'react';
-
 import type {ParseResult} from 'sentry/components/searchSyntax/parser';
 import type {FieldDefinition} from 'sentry/utils/fields';
 
 export type FilterKeySection = {
   children: string[];
-  label: ReactNode;
+  label: React.ReactNode;
   value: string;
 };
 

--- a/static/app/components/stackTrace/stackTrace.spec.tsx
+++ b/static/app/components/stackTrace/stackTrace.spec.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps} from 'react';
 import {DataScrubbingRelayPiiConfigFixture} from 'sentry-fixture/dataScrubbingRelayPiiConfig';
 import {EventFixture} from 'sentry-fixture/event';
 import {EventEntryStacktraceFixture} from 'sentry-fixture/eventEntryStacktrace';
@@ -49,7 +48,7 @@ function makeStackTraceData(): {
   };
 }
 
-type TestStackTraceProviderProps = ComponentProps<typeof StackTraceProvider> &
+type TestStackTraceProviderProps = React.ComponentProps<typeof StackTraceProvider> &
   Pick<
     StackTraceViewStateProviderProps,
     'defaultIsMinified' | 'defaultIsNewestFirst' | 'defaultView'

--- a/static/app/components/stackTrace/stackTraceFrames.tsx
+++ b/static/app/components/stackTrace/stackTraceFrames.tsx
@@ -1,4 +1,4 @@
-import {Activity, useMemo, useRef, type ComponentType} from 'react';
+import {Activity, useMemo, useRef} from 'react';
 import styled from '@emotion/styled';
 
 import {Container} from '@sentry/scraps/layout';
@@ -23,10 +23,10 @@ function OmittedFramesBanner({omittedFrames}: {omittedFrames: [number, number]})
 }
 
 interface StackTraceFramesProps {
-  frameContextComponent: ComponentType;
+  frameContextComponent: React.ComponentType;
   /** Removes the outer border and border-radius, useful for embedding in hovercards. */
   borderless?: boolean;
-  frameActionsComponent?: ComponentType<{isHovering: boolean}>;
+  frameActionsComponent?: React.ComponentType<{isHovering: boolean}>;
 }
 
 export function StackTraceFrames({

--- a/static/app/components/stackTrace/types.tsx
+++ b/static/app/components/stackTrace/types.tsx
@@ -1,5 +1,3 @@
-import type {ReactNode} from 'react';
-
 import type {FrameSourceMapDebuggerData} from 'sentry/components/events/interfaces/sourceMapsDebuggerModal';
 import type {Event, Frame} from 'sentry/types/event';
 import type {PlatformKey} from 'sentry/types/project';
@@ -19,7 +17,7 @@ export interface StackTraceViewState {
 }
 
 export interface StackTraceViewStateProviderProps {
-  children: ReactNode;
+  children: React.ReactNode;
   defaultIsMinified?: boolean;
   defaultIsNewestFirst?: boolean;
   defaultView?: StackTraceView;
@@ -53,7 +51,7 @@ export type StackTraceMeta = {
 } & Record<string, unknown>;
 
 export interface StackTraceProviderProps {
-  children: ReactNode;
+  children: React.ReactNode;
   event: Event;
   stacktrace: StacktraceType;
   /** When true, all frames start collapsed regardless of their position. */

--- a/static/app/components/structuredEventData/collapsibleValue.tsx
+++ b/static/app/components/structuredEventData/collapsibleValue.tsx
@@ -1,4 +1,4 @@
-import {Children, useState, type ReactNode} from 'react';
+import {Children, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
@@ -9,12 +9,12 @@ import {IconChevron} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 
 interface Props {
-  children: ReactNode;
+  children: React.ReactNode;
   closeTag: string;
   openTag: string;
   path: string;
   noBasePadding?: boolean;
-  prefix?: ReactNode;
+  prefix?: React.ReactNode;
   /**
    * If provided, indicates the total number of children available on the
    * server-side, which may be greater than the rendered children when data

--- a/static/app/components/structuredEventData/useExpandedState.tsx
+++ b/static/app/components/structuredEventData/useExpandedState.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {createContext, useCallback, useContext, useMemo, useRef} from 'react';
 
 import {uniq} from 'sentry/utils/array/uniq';
@@ -16,7 +15,7 @@ const Context = createContext<{
 });
 
 interface Props {
-  children: ReactNode;
+  children: React.ReactNode;
   initialExpandedPaths: () => string[];
   onToggleExpand?: (expandedPaths: string[], path: string, state: State) => void;
 }

--- a/static/app/components/tables/gridEditable/index.tsx
+++ b/static/app/components/tables/gridEditable/index.tsx
@@ -1,4 +1,3 @@
-import type {CSSProperties, ReactNode} from 'react';
 import {Fragment, useCallback, useEffect, useRef} from 'react';
 
 import InteractionStateLayer from '@sentry/scraps/interactionStateLayer';
@@ -65,7 +64,7 @@ type GridEditableProps<
    * in these buttons and updating props to the GridEditable instance.
    */
   headerButtons?: () => React.ReactNode;
-  height?: CSSProperties['height'];
+  height?: React.CSSProperties['height'];
 
   highlightedRowKey?: number;
 
@@ -94,7 +93,7 @@ type GridEditableProps<
    * - `columnSortBy` is not used at the moment, however it might be better to
    *   move sorting into Grid for performance
    */
-  title?: ReactNode;
+  title?: React.ReactNode;
 };
 
 export function GridEditable<

--- a/static/app/components/tables/gridEditable/styles.tsx
+++ b/static/app/components/tables/gridEditable/styles.tsx
@@ -1,4 +1,3 @@
-import type {CSSProperties} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -79,7 +78,7 @@ export const Body = styled(
  */
 export const Grid = styled('table')<{
   fit?: 'max-content';
-  height?: CSSProperties['height'];
+  height?: React.CSSProperties['height'];
   scrollable?: boolean;
 }>`
   position: inherit;

--- a/static/app/components/tables/simpleTable/index.tsx
+++ b/static/app/components/tables/simpleTable/index.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps, HTMLAttributes, RefObject} from 'react';
 import {css} from '@emotion/react';
 import type {Theme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -10,12 +9,12 @@ import {Panel} from 'sentry/components/panels/panel';
 import {IconArrow} from 'sentry/icons';
 import {defined} from 'sentry/utils';
 
-interface TableProps extends HTMLAttributes<HTMLDivElement> {
-  ref?: RefObject<HTMLDivElement | null>;
+interface TableProps extends React.HTMLAttributes<HTMLDivElement> {
+  ref?: React.RefObject<HTMLDivElement | null>;
 }
 
-interface RowProps extends HTMLAttributes<HTMLDivElement> {
-  ref?: RefObject<HTMLDivElement | null>;
+interface RowProps extends React.HTMLAttributes<HTMLDivElement> {
+  ref?: React.RefObject<HTMLDivElement | null>;
   variant?: 'default' | 'faded';
 }
 
@@ -27,7 +26,7 @@ export function SimpleTable({children, ...props}: TableProps) {
   );
 }
 
-function Header({children, ...props}: HTMLAttributes<HTMLDivElement>) {
+function Header({children, ...props}: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <StyledPanelHeader {...props} role="row">
       {children}
@@ -41,7 +40,7 @@ function HeaderCell({
   handleSortClick,
   divider = defined(children) ? true : false,
   ...props
-}: HTMLAttributes<HTMLDivElement> & {
+}: React.HTMLAttributes<HTMLDivElement> & {
   children?: React.ReactNode;
   divider?: boolean;
   handleSortClick?: () => void;
@@ -84,7 +83,7 @@ function Row({children, variant = 'default', ref, ...props}: RowProps) {
 function RowCell({
   children,
   ...props
-}: ComponentProps<typeof Flex> & {
+}: React.ComponentProps<typeof Flex> & {
   children: React.ReactNode;
 }) {
   return (

--- a/static/app/components/textOverflow.tsx
+++ b/static/app/components/textOverflow.tsx
@@ -1,4 +1,3 @@
-import type {CSSProperties} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -25,7 +24,7 @@ type Props = {
    * @default false
    */
   isParagraph?: boolean;
-  style?: CSSProperties;
+  style?: React.CSSProperties;
 };
 
 export const TextOverflow = styled(

--- a/static/app/components/timeline/index.tsx
+++ b/static/app/components/timeline/index.tsx
@@ -1,4 +1,3 @@
-import type {CSSProperties} from 'react';
 import {useTheme, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -24,7 +23,7 @@ export interface TimelineItemProps {
   onMouseLeave?: React.MouseEventHandler<HTMLDivElement>;
   ref?: React.Ref<HTMLDivElement>;
   showLastLine?: boolean;
-  style?: CSSProperties;
+  style?: React.CSSProperties;
   timestamp?: React.ReactNode;
   titleTrailingItems?: React.ReactNode;
 }

--- a/static/app/components/tokenizedInput/grid/useGridList.tsx
+++ b/static/app/components/tokenizedInput/grid/useGridList.tsx
@@ -1,4 +1,3 @@
-import type {RefObject} from 'react';
 import {useMemo} from 'react';
 import type {AriaGridListOptions} from '@react-aria/gridlist';
 import {useGridList as useGridListAria} from '@react-aria/gridlist';
@@ -7,7 +6,7 @@ import type {ListState} from '@react-stately/list';
 
 interface UseGridListProps<T> {
   props: AriaGridListOptions<T>;
-  ref: RefObject<HTMLDivElement | null>;
+  ref: React.RefObject<HTMLDivElement | null>;
   state: ListState<T>;
 }
 

--- a/static/app/components/tokenizedInput/grid/useGridListItem.tsx
+++ b/static/app/components/tokenizedInput/grid/useGridListItem.tsx
@@ -1,4 +1,3 @@
-import type {FocusEvent, RefObject} from 'react';
 import {useCallback, useMemo} from 'react';
 import {useGridListItem as useGridListItemAria} from '@react-aria/gridlist';
 import type {ListState} from '@react-stately/list';
@@ -9,7 +8,7 @@ import {shiftFocusToChild} from 'sentry/components/tokenizedInput/token/utils';
 interface UseGridListItemOptions<T> {
   focusable: boolean;
   item: Node<T>;
-  ref: RefObject<HTMLDivElement | null>;
+  ref: React.RefObject<HTMLDivElement | null>;
   state: ListState<T>;
 }
 
@@ -22,7 +21,7 @@ export function useGridListItem<T>({
   const {rowProps, gridCellProps} = useGridListItemAria({node: item}, state, ref);
 
   const onFocus = useCallback(
-    (evt: FocusEvent<HTMLDivElement>) => {
+    (evt: React.FocusEvent<HTMLDivElement>) => {
       if (focusable) {
         shiftFocusToChild(evt.currentTarget, item, state);
       }

--- a/static/app/components/tokenizedInput/token/comboBox.spec.tsx
+++ b/static/app/components/tokenizedInput/token/comboBox.spec.tsx
@@ -1,11 +1,10 @@
-import type {ComponentProps} from 'react';
 import {Item} from '@react-stately/collections';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {ComboBox} from 'sentry/components/tokenizedInput/token/comboBox';
 
-function ComboBoxWrapper(props: Omit<ComponentProps<typeof ComboBox>, 'children'>) {
+function ComboBoxWrapper(props: Omit<React.ComponentProps<typeof ComboBox>, 'children'>) {
   return (
     <ComboBox {...props}>
       {item => (

--- a/static/app/components/tokenizedInput/token/comboBox.tsx
+++ b/static/app/components/tokenizedInput/token/comboBox.tsx
@@ -1,10 +1,3 @@
-import type {
-  ChangeEventHandler,
-  ClipboardEvent,
-  FocusEventHandler,
-  MouseEventHandler,
-  Ref,
-} from 'react';
 import {useCallback, useEffect, useLayoutEffect, useMemo, useRef} from 'react';
 import styled from '@emotion/styled';
 import type {AriaComboBoxProps} from '@react-aria/combobox';
@@ -38,20 +31,20 @@ interface ComboBoxProps {
   inputValue: string;
   items: Array<SelectOptionOrSectionWithKey<string>>;
   ['data-test-id']?: string;
-  onClick?: MouseEventHandler<HTMLInputElement>;
+  onClick?: React.MouseEventHandler<HTMLInputElement>;
   onInputBlur?: () => void;
-  onInputChange?: ChangeEventHandler<HTMLInputElement>;
+  onInputChange?: React.ChangeEventHandler<HTMLInputElement>;
   onInputCommit?: (value: string) => void;
   onInputEscape?: () => void;
-  onInputFocus?: FocusEventHandler<HTMLInputElement>;
+  onInputFocus?: React.FocusEventHandler<HTMLInputElement>;
   onKeyDown?: (evt: KeyboardEvent) => void;
   onKeyDownCapture?: (evt: React.KeyboardEvent<HTMLInputElement>) => void;
   onKeyUp?: (e: KeyboardEvent) => void;
   onOpenChange?: (newOpenState: boolean) => void;
   onOptionSelected?: (option: SelectOptionWithKey<string>) => void;
-  onPaste?: (e: ClipboardEvent<HTMLInputElement>) => void;
+  onPaste?: (e: React.ClipboardEvent<HTMLInputElement>) => void;
   placeholder?: string;
-  ref?: Ref<HTMLInputElement>;
+  ref?: React.Ref<HTMLInputElement>;
   /**
    * Function to determine whether the menu should close when interacting with
    * other elements.
@@ -171,7 +164,7 @@ export function ComboBox({
     ...comboBoxProps,
   });
 
-  const handleComboBoxFocus: FocusEventHandler<HTMLInputElement> = useCallback(
+  const handleComboBoxFocus: React.FocusEventHandler<HTMLInputElement> = useCallback(
     evt => {
       onInputFocus?.(evt);
       state.open();
@@ -179,7 +172,7 @@ export function ComboBox({
     [onInputFocus, state]
   );
 
-  const handleComboBoxBlur: FocusEventHandler<HTMLInputElement> = useCallback(
+  const handleComboBoxBlur: React.FocusEventHandler<HTMLInputElement> = useCallback(
     evt => {
       if (evt.relatedTarget && !shouldCloseOnInteractOutside?.(evt.relatedTarget)) {
         return;
@@ -283,7 +276,7 @@ export function ComboBox({
     },
   });
 
-  const handleInputClick: MouseEventHandler<HTMLInputElement> = useCallback(
+  const handleInputClick: React.MouseEventHandler<HTMLInputElement> = useCallback(
     evt => {
       evt.stopPropagation();
       inputProps.onClick?.(evt);

--- a/static/app/components/tokenizedInput/token/deletableToken.tsx
+++ b/static/app/components/tokenizedInput/token/deletableToken.tsx
@@ -1,4 +1,3 @@
-import type {KeyboardEvent, MouseEvent} from 'react';
 import {useCallback, useRef} from 'react';
 import styled from '@emotion/styled';
 import type {ListState} from '@react-stately/list';
@@ -16,7 +15,9 @@ interface DeletableTokenProps<T> {
   children: React.ReactNode;
   item: Node<T>;
   label: string;
-  onDelete: (evt: KeyboardEvent<HTMLDivElement> | MouseEvent<HTMLButtonElement>) => void;
+  onDelete: (
+    evt: React.KeyboardEvent<HTMLDivElement> | React.MouseEvent<HTMLButtonElement>
+  ) => void;
   state: ListState<T>;
 }
 
@@ -36,7 +37,7 @@ export function DeletableToken<T>({
   });
 
   const onKeyDownCapture = useCallback(
-    (evt: KeyboardEvent<HTMLInputElement>) => {
+    (evt: React.KeyboardEvent<HTMLInputElement>) => {
       if (evt.key === 'ArrowLeft') {
         focusTarget(state, state.collection.getKeyBefore(item.key));
         return;
@@ -51,7 +52,7 @@ export function DeletableToken<T>({
   );
 
   const handleOnKeyDown = useCallback(
-    (evt: KeyboardEvent<HTMLDivElement>) => {
+    (evt: React.KeyboardEvent<HTMLDivElement>) => {
       if (evt.key === 'Backspace' || evt.key === 'Delete') {
         onDelete?.(evt);
       }
@@ -60,7 +61,7 @@ export function DeletableToken<T>({
   );
 
   const handleOnClick = useCallback(
-    (evt: MouseEvent<HTMLDivElement>) => {
+    (evt: React.MouseEvent<HTMLDivElement>) => {
       evt.stopPropagation();
       shiftFocusToChild(evt.currentTarget, item, state);
     },

--- a/static/app/components/tokenizedInput/token/inputBox.tsx
+++ b/static/app/components/tokenizedInput/token/inputBox.tsx
@@ -1,11 +1,3 @@
-import type {
-  ChangeEventHandler,
-  ClipboardEventHandler,
-  FocusEventHandler,
-  KeyboardEventHandler,
-  MouseEventHandler,
-  Ref,
-} from 'react';
 import {useCallback, useRef} from 'react';
 import styled from '@emotion/styled';
 import {useTextField} from '@react-aria/textfield';
@@ -19,17 +11,17 @@ interface InputBoxProps {
   inputLabel: string;
   inputValue: string;
   ['data-test-id']?: string;
-  onClick?: MouseEventHandler<HTMLInputElement>;
-  onInputBlur?: FocusEventHandler<HTMLInputElement>;
-  onInputChange?: ChangeEventHandler<HTMLInputElement>;
+  onClick?: React.MouseEventHandler<HTMLInputElement>;
+  onInputBlur?: React.FocusEventHandler<HTMLInputElement>;
+  onInputChange?: React.ChangeEventHandler<HTMLInputElement>;
   onInputCommit?: (value: string) => void;
   onInputEscape?: () => void;
-  onInputFocus?: FocusEventHandler<HTMLInputElement>;
+  onInputFocus?: React.FocusEventHandler<HTMLInputElement>;
   onKeyDown?: (evt: KeyboardEvent) => void;
-  onKeyDownCapture?: KeyboardEventHandler<HTMLInputElement>;
-  onPaste?: ClipboardEventHandler<HTMLInputElement>;
+  onKeyDownCapture?: React.KeyboardEventHandler<HTMLInputElement>;
+  onPaste?: React.ClipboardEventHandler<HTMLInputElement>;
   placeholder?: string;
-  ref?: Ref<HTMLInputElement>;
+  ref?: React.Ref<HTMLInputElement>;
   tabIndex?: number;
 }
 
@@ -71,14 +63,14 @@ export function InputBox({
     [inputValue, onInputCommit, onInputEscape, onKeyDown]
   );
 
-  const handleInputBlur: FocusEventHandler<HTMLInputElement> = useCallback(
+  const handleInputBlur: React.FocusEventHandler<HTMLInputElement> = useCallback(
     evt => {
       onInputBlur?.(evt);
     },
     [onInputBlur]
   );
 
-  const handleInputFocus: FocusEventHandler<HTMLInputElement> = useCallback(
+  const handleInputFocus: React.FocusEventHandler<HTMLInputElement> = useCallback(
     evt => {
       onInputFocus?.(evt);
     },
@@ -98,7 +90,7 @@ export function InputBox({
     inputRef
   );
 
-  const handleInputClick: MouseEventHandler<HTMLInputElement> = useCallback(
+  const handleInputClick: React.MouseEventHandler<HTMLInputElement> = useCallback(
     evt => {
       evt.stopPropagation();
       inputProps.onClick?.(evt);

--- a/static/app/components/tours/components.tsx
+++ b/static/app/components/tours/components.tsx
@@ -1,4 +1,3 @@
-import type {CSSProperties, HTMLAttributes} from 'react';
 import {Fragment, useContext, useEffect, useMemo} from 'react';
 import {createPortal} from 'react-dom';
 import {ClassNames, ThemeProvider, useTheme} from '@emotion/react';
@@ -155,7 +154,7 @@ export interface TourRenderProps {
 }
 
 export interface TourElementProps<T extends TourEnumType> extends Omit<
-  HTMLAttributes<HTMLElement>,
+  React.HTMLAttributes<HTMLElement>,
   'id' | 'children' | 'title'
 > {
   /**
@@ -346,7 +345,7 @@ export function TourElementContent<T extends TourEnumType>({
 }
 
 interface TourGuideProps extends Omit<
-  HTMLAttributes<HTMLElement>,
+  React.HTMLAttributes<HTMLElement>,
   'title' | 'id' | 'children'
 > {
   /**
@@ -363,7 +362,7 @@ interface TourGuideProps extends Omit<
   actions?: React.ReactNode;
   handleDismiss?: (e: React.MouseEvent) => void;
   id?: string;
-  margin?: CSSProperties['margin'];
+  margin?: React.CSSProperties['margin'];
   offset?: UseOverlayProps['offset'];
   position?: UseOverlayProps['position'];
   stepCount?: number;
@@ -549,7 +548,7 @@ const BlurWindow = styled('div')`
 function getTourElementStyles(
   theme: ReturnType<typeof useTheme>,
   isOpen: boolean,
-  margin?: CSSProperties['margin']
+  margin?: React.CSSProperties['margin']
 ) {
   if (!isOpen) {
     return undefined;

--- a/static/app/components/workflowEngine/form/automationBuilderInput.tsx
+++ b/static/app/components/workflowEngine/form/automationBuilderInput.tsx
@@ -1,9 +1,8 @@
-import type {ComponentProps} from 'react';
 import styled from '@emotion/styled';
 
 import {Input} from '@sentry/scraps/input';
 
-export function AutomationBuilderInput(props: ComponentProps<typeof Input>) {
+export function AutomationBuilderInput(props: React.ComponentProps<typeof Input>) {
   return <InlineInput type="text" {...props} />;
 }
 

--- a/static/app/components/workflowEngine/form/automationBuilderNumberInput.tsx
+++ b/static/app/components/workflowEngine/form/automationBuilderNumberInput.tsx
@@ -1,9 +1,10 @@
-import type {ComponentProps} from 'react';
 import styled from '@emotion/styled';
 
 import {NumberInput} from '@sentry/scraps/input';
 
-export function AutomationBuilderNumberInput(props: ComponentProps<typeof NumberInput>) {
+export function AutomationBuilderNumberInput(
+  props: React.ComponentProps<typeof NumberInput>
+) {
   return <InlineNumberInput min={0} {...props} />;
 }
 

--- a/static/app/components/workflowEngine/form/automationBuilderSelect.tsx
+++ b/static/app/components/workflowEngine/form/automationBuilderSelect.tsx
@@ -1,9 +1,8 @@
-import type {ComponentProps} from 'react';
 import styled from '@emotion/styled';
 
 import {Select} from '@sentry/scraps/select';
 
-export function AutomationBuilderSelect(props: ComponentProps<typeof Select>) {
+export function AutomationBuilderSelect(props: React.ComponentProps<typeof Select>) {
   return <StyledSelect styles={selectControlStyles} {...props} />;
 }
 

--- a/static/app/debug/notifications/components/debugNotificationsLanding.tsx
+++ b/static/app/debug/notifications/components/debugNotificationsLanding.tsx
@@ -1,4 +1,3 @@
-import type {PropsWithChildren} from 'react';
 import {Fragment} from 'react';
 import {ThemeProvider, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -12,7 +11,7 @@ import {Heading, Text} from '@sentry/scraps/text';
 // eslint-disable-next-line no-restricted-imports
 import {darkTheme} from 'sentry/utils/theme/theme';
 
-function DarkModeProvider(props: PropsWithChildren) {
+function DarkModeProvider(props: React.PropsWithChildren) {
   return <ThemeProvider theme={darkTheme}>{props.children}</ThemeProvider>;
 }
 

--- a/static/app/debug/notifications/components/debugNotificationsSearch.tsx
+++ b/static/app/debug/notifications/components/debugNotificationsSearch.tsx
@@ -1,4 +1,3 @@
-import type {Key} from 'react';
 import {useCallback, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {type AriaComboBoxProps} from '@react-aria/combobox';
@@ -76,7 +75,7 @@ function SearchComboBox<T extends SearchItem>(props: SearchComboBoxProps<T>) {
   const popoverRef = useRef<HTMLDivElement | null>(null);
   const navigate = useNavigate();
   const handleSelectionChange = useCallback(
-    (key: Key | null) => {
+    (key: React.Key | null) => {
       if (key) {
         navigate({query: {source: key}}, {replace: true});
       }

--- a/static/app/icons/svgIcon.spec.tsx
+++ b/static/app/icons/svgIcon.spec.tsx
@@ -1,4 +1,3 @@
-import type {ComponentType} from 'react';
 import {expectTypeOf} from 'expect-type';
 
 import type {IconGraphProps} from 'sentry/icons';
@@ -11,6 +10,8 @@ describe('SVGIconProps', () => {
     // Before the fix, SVGIconProps inherited `type?: string` from React.SVGAttributes,
     // which made IconGraph incompatible with ComponentType<SVGIconProps> due to the
     // narrower union on `type`.
-    expectTypeOf<ComponentType<IconGraphProps>>().toExtend<ComponentType<SVGIconProps>>();
+    expectTypeOf<React.ComponentType<IconGraphProps>>().toExtend<
+      React.ComponentType<SVGIconProps>
+    >();
   });
 });

--- a/static/app/stories/jsx.tsx
+++ b/static/app/stories/jsx.tsx
@@ -1,10 +1,9 @@
-import type {ReactNode} from 'react';
 import {Fragment, isValidElement} from 'react';
 import styled from '@emotion/styled';
 
 interface JSXNodeProps {
   name: string;
-  children?: ReactNode;
+  children?: React.ReactNode;
   props?: Record<string, unknown>;
 }
 

--- a/static/app/stories/playground/slideOverPanel.tsx
+++ b/static/app/stories/playground/slideOverPanel.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useState, type ComponentProps} from 'react';
+import {Fragment, useCallback, useState} from 'react';
 import {AnimatePresence} from 'framer-motion';
 
 import {Alert} from '@sentry/scraps/alert';
@@ -55,7 +55,7 @@ export function SlideOverPanelSkeletonPlayground() {
 }
 
 interface PanelContentsProps {
-  onClick: ComponentProps<typeof Button>['onClick'];
+  onClick: React.ComponentProps<typeof Button>['onClick'];
 }
 
 function PanelContents({onClick}: PanelContentsProps) {

--- a/static/app/stories/storybook.tsx
+++ b/static/app/stories/storybook.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {Children, Fragment, Suspense, lazy, useEffect} from 'react';
 
 import {Container} from '@sentry/scraps/layout';
@@ -18,7 +17,7 @@ function makeStorybookDocumentTitle(title: string | undefined): string {
   return title ? `${title} — Scraps` : 'Scraps';
 }
 
-type StoryRenderFunction = () => ReactNode | ReactNode[];
+type StoryRenderFunction = () => React.ReactNode | React.ReactNode[];
 type StoryContext = (storyName: string, story: StoryRenderFunction) => void;
 type SetupFunction = (
   story: StoryContext,

--- a/static/app/stories/view/index.tsx
+++ b/static/app/stories/view/index.tsx
@@ -1,4 +1,4 @@
-import {Fragment, type PropsWithChildren} from 'react';
+import {Fragment} from 'react';
 import {css, Global, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -137,7 +137,7 @@ function StoryDetail() {
   );
 }
 
-function StoriesLayout(props: PropsWithChildren) {
+function StoriesLayout(props: React.PropsWithChildren) {
   return (
     <Fragment>
       <GlobalStoryStyles key="global-story-styles" />

--- a/static/app/stories/view/landing/index.tsx
+++ b/static/app/stories/view/landing/index.tsx
@@ -1,4 +1,3 @@
-import type {PropsWithChildren} from 'react';
 import {Fragment} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -284,7 +283,7 @@ const CardTitle = styled('span')`
   color: currentColor;
 `;
 
-function CardFigure(props: PropsWithChildren) {
+function CardFigure(props: React.PropsWithChildren) {
   return (
     <Flex as="figure" role="image" align="center" justify="center">
       {props.children}

--- a/static/app/stories/view/storyHeading.tsx
+++ b/static/app/stories/view/storyHeading.tsx
@@ -1,4 +1,3 @@
-import type {ReactElement, ReactNode} from 'react';
 import {Fragment, isValidElement} from 'react';
 import styled from '@emotion/styled';
 
@@ -68,7 +67,7 @@ const StyledLinkButton = styled(LinkButton)`
   }
 `;
 
-function stringifyReactNode(child?: ReactNode): string {
+function stringifyReactNode(child?: React.ReactNode): string {
   switch (true) {
     case typeof child === 'string':
       return child;
@@ -86,9 +85,11 @@ function stringifyReactNode(child?: ReactNode): string {
   }
 }
 
-function hasChildren(node: ReactNode): node is ReactElement<{children: ReactNode}> {
+function hasChildren(
+  node: React.ReactNode
+): node is React.ReactElement<{children: React.ReactNode}> {
   return (
-    isValidElement<{children?: ReactNode}>(node) &&
+    isValidElement<{children?: React.ReactNode}>(node) &&
     node.props.children !== null &&
     node.props.children !== undefined
   );

--- a/static/app/stories/view/storyMdxComponent.tsx
+++ b/static/app/stories/view/storyMdxComponent.tsx
@@ -1,4 +1,3 @@
-import type {HTMLProps, PropsWithChildren} from 'react';
 import React from 'react';
 import {type Callout as CalloutProps} from '@r4ai/remark-callout';
 
@@ -33,8 +32,8 @@ export const storyMdxComponents = {
   h4: (props: HeadingProps) => <StoryHeading as="h5" size="md" {...props} />,
   h5: (props: HeadingProps) => <StoryHeading as="h6" size="sm" {...props} />,
   h6: (props: HeadingProps) => <StoryHeading as="h6" size="xs" {...props} />,
-  code: (props: HTMLProps<HTMLElement>) => <InlineCode {...props} />,
-  Callout: (props: PropsWithChildren<CalloutProps>) => {
+  code: (props: React.HTMLProps<HTMLElement>) => <InlineCode {...props} />,
+  Callout: (props: React.PropsWithChildren<CalloutProps>) => {
     const children = React.Children.toArray(props.children).filter(value => {
       if (React.isValidElement(value)) {
         if (value.props && typeof value.props === 'object') {

--- a/static/app/stories/view/storySearch.tsx
+++ b/static/app/stories/view/storySearch.tsx
@@ -1,4 +1,3 @@
-import type {Key} from 'react';
 import {useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {type AriaComboBoxProps} from '@react-aria/combobox';
@@ -189,7 +188,7 @@ function SearchComboBox(props: SearchComboBoxProps) {
   const navigate = useNavigate();
 
   const organization = useOrganization();
-  const handleSelectionChange = (key: Key | null) => {
+  const handleSelectionChange = (key: React.Key | null) => {
     if (!key) {
       return;
     }
@@ -306,7 +305,7 @@ const StyledOverlay = styled(Overlay)`
 `;
 
 function getStoryTreeNodeFromKey(
-  key: Key,
+  key: React.Key,
   props: SearchComboBoxProps
 ): StoryTreeNode | undefined {
   for (const category of props.defaultItems) {

--- a/static/app/stories/view/useStoriesDarkMode.tsx
+++ b/static/app/stories/view/useStoriesDarkMode.tsx
@@ -1,4 +1,3 @@
-import type {PropsWithChildren} from 'react';
 import {ThemeProvider, type Theme} from '@emotion/react';
 
 // these utils are for stories that have forced dark mode
@@ -21,7 +20,7 @@ export const useStoryDarkModeTheme = (): Theme => {
  *
  * ⚠️ DO NOT USE OUTSIDE OF STORIES
  */
-export function StoryDarkModeProvider(props: PropsWithChildren) {
+export function StoryDarkModeProvider(props: React.PropsWithChildren) {
   const theme = useStoryDarkModeTheme();
   return <ThemeProvider theme={theme}>{props.children}</ThemeProvider>;
 }

--- a/static/app/utils/api/useAggregatedQueryKeys.spec.tsx
+++ b/static/app/utils/api/useAggregatedQueryKeys.spec.tsx
@@ -1,5 +1,3 @@
-import type {ReactNode} from 'react';
-
 import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -10,7 +8,7 @@ import type {ApiQueryKey, QueryClient} from 'sentry/utils/queryClient';
 import {QueryClientProvider} from 'sentry/utils/queryClient';
 
 function makeWrapper(queryClient: QueryClient) {
-  return function wrapper({children}: {children?: ReactNode}) {
+  return function wrapper({children}: {children?: React.ReactNode}) {
     return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
   };
 }

--- a/static/app/utils/list/useListItemCheckboxState.tsx
+++ b/static/app/utils/list/useListItemCheckboxState.tsx
@@ -1,4 +1,3 @@
-import type {Dispatch, RefObject, SetStateAction} from 'react';
 import {
   createContext,
   useCallback,
@@ -13,7 +12,7 @@ import {toArray} from 'sentry/utils/array/toArray';
 import type {ApiQueryKey, InfiniteApiQueryKey} from 'sentry/utils/queryClient';
 
 type QueryKeyValue = undefined | ApiQueryKey | InfiniteApiQueryKey;
-type QueryKeyRef = RefObject<QueryKeyValue>;
+type QueryKeyRef = React.RefObject<QueryKeyValue>;
 
 interface PublicProps {
   /**
@@ -37,7 +36,7 @@ interface PublicProps {
 
 interface InternalProps {
   queryKeyRef: QueryKeyRef;
-  setState: Dispatch<SetStateAction<State>>;
+  setState: React.Dispatch<React.SetStateAction<State>>;
   state: State;
 }
 type MergedProps = Omit<PublicProps, 'queryKey'> & InternalProps;
@@ -122,7 +121,7 @@ const ListItemCheckboxContext = createContext<{
   hits: number;
   knownIds: string[];
   queryKeyRef: QueryKeyRef;
-  setState?: Dispatch<SetStateAction<State>>;
+  setState?: React.Dispatch<React.SetStateAction<State>>;
   state?: State;
 }>({
   hits: 0,

--- a/static/app/utils/makeCombinedReducer.tsx
+++ b/static/app/utils/makeCombinedReducer.tsx
@@ -1,21 +1,19 @@
-import type {Reducer} from 'react';
-
 import type {ReducerAction} from 'sentry/types/reducerAction';
 
 type ReducersObject<S = any, A = any> = {
-  [K in keyof S]: Reducer<S, A>;
+  [K in keyof S]: React.Reducer<S, A>;
 };
 
 type ReducersState<M> = M extends ReducersObject
   ? {
-      [P in keyof M]: M[P] extends Reducer<infer S, any> ? S : never;
+      [P in keyof M]: M[P] extends React.Reducer<infer S, any> ? S : never;
     }
   : never;
 
 type ReducerFromReducersObject<M> = M extends {
   [P in keyof M]: infer R;
 }
-  ? R extends Reducer<any, any>
+  ? R extends React.Reducer<any, any>
     ? R
     : never
   : never;
@@ -25,7 +23,7 @@ type ReducerActions<M> = M extends ReducersObject
   : never;
 
 type CombinedState<S> = {} & S;
-type CombinedReducer<M extends ReducersObject> = Reducer<
+type CombinedReducer<M extends ReducersObject> = React.Reducer<
   CombinedState<ReducersState<M>>,
   ReducerActions<M>
 >;

--- a/static/app/utils/performance/contexts/metricsCardinality.tsx
+++ b/static/app/utils/performance/contexts/metricsCardinality.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps, ReactNode} from 'react';
 import {Fragment, useEffect} from 'react';
 import type {Location} from 'history';
 
@@ -42,7 +41,7 @@ const [_Provider, _useContext, _Context] =
  * make dozens of requests on pages such as performance landing and dashboards.
  */
 export function MetricsCardinalityProvider(props: {
-  children: ReactNode;
+  children: React.ReactNode;
   location: Location;
   organization: Organization;
   sendOutcomeAnalytics?: boolean;
@@ -136,7 +135,7 @@ export function MetricsCardinalityProvider(props: {
 }
 
 function Provider(
-  props: ComponentProps<typeof _Provider> & {
+  props: React.ComponentProps<typeof _Provider> & {
     organization: Organization;
     sendOutcomeAnalytics?: boolean;
   }

--- a/static/app/utils/performance/contexts/metricsEnhancedPerformanceDataContext.tsx
+++ b/static/app/utils/performance/contexts/metricsEnhancedPerformanceDataContext.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {useCallback, useState} from 'react';
 
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -27,7 +26,7 @@ export function MEPDataProvider({
   children,
   chartSetting,
 }: {
-  children: ReactNode;
+  children: React.ReactNode;
   chartSetting?: PerformanceWidgetSetting;
 }) {
   const {setAutoSampleState} = useMEPSettingContext();
@@ -77,7 +76,7 @@ const [_MetricsResultsMetaProvider, _useMetricsResultsMeta] =
   });
 export const useMetricsResultsMeta = _useMetricsResultsMeta;
 
-export function MetricsResultsMetaProvider({children}: {children: ReactNode}) {
+export function MetricsResultsMetaProvider({children}: {children: React.ReactNode}) {
   const [metricsExtractedDataMap, _setMetricsExtractedDataMap] = useState(new Map());
 
   const setIsMetricsExtractedData = useCallback(

--- a/static/app/utils/performance/contexts/metricsEnhancedSetting.tsx
+++ b/static/app/utils/performance/contexts/metricsEnhancedSetting.tsx
@@ -1,4 +1,3 @@
-import type {Dispatch, ReactNode} from 'react';
 import {useCallback, useReducer} from 'react';
 import type {Location} from 'history';
 
@@ -14,8 +13,8 @@ export interface MetricsEnhancedSettingContext {
   autoSampleState: AutoSampleState;
   memoizationKey: string;
   metricSettingState: MEPState | null;
-  setAutoSampleState: Dispatch<AutoSampleState>;
-  setMetricSettingState: Dispatch<MEPState>;
+  setAutoSampleState: React.Dispatch<AutoSampleState>;
+  setMetricSettingState: React.Dispatch<MEPState>;
   shouldQueryProvideMEPAutoParams: boolean;
   shouldQueryProvideMEPMetricParams: boolean;
   shouldQueryProvideMEPTransactionParams: boolean;
@@ -72,7 +71,7 @@ export function MEPSettingProvider({
   _hasMEPState,
   forceTransactions,
 }: {
-  children: ReactNode;
+  children: React.ReactNode;
   _hasMEPState?: MEPState;
   forceTransactions?: boolean;
   location?: Location;

--- a/static/app/utils/performance/contexts/onDemandControl.tsx
+++ b/static/app/utils/performance/contexts/onDemandControl.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {useCallback, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import type {Location} from 'history';
@@ -35,7 +34,7 @@ export function OnDemandControlProvider({
   children,
   location,
 }: {
-  children: ReactNode;
+  children: React.ReactNode;
   location: Location;
 }) {
   const _forceOnDemandQuery = location?.query.forceOnDemand;

--- a/static/app/utils/performanceForSentry/index.tsx
+++ b/static/app/utils/performanceForSentry/index.tsx
@@ -1,4 +1,3 @@
-import type {ProfilerOnRenderCallback, ReactNode} from 'react';
 import {Fragment, Profiler, useEffect, useRef} from 'react';
 import type {MeasurementUnit, Span, TransactionEvent} from '@sentry/core';
 import {browserPerformanceTimeOrigin, timestampInSeconds} from '@sentry/core';
@@ -35,7 +34,11 @@ function getPerformanceTransaction(): Span | undefined {
 /**
  * Callback for React Profiler https://reactjs.org/docs/profiler.html
  */
-export const onRenderCallback: ProfilerOnRenderCallback = (id, phase, actualDuration) => {
+export const onRenderCallback: React.ProfilerOnRenderCallback = (
+  id,
+  phase,
+  actualDuration
+) => {
   try {
     const parentSpan = getPerformanceTransaction();
     if (parentSpan && actualDuration > MIN_UPDATE_SPAN_TIME) {
@@ -137,7 +140,7 @@ export function VisuallyCompleteWithData({
   disabled,
   isLoading,
 }: {
-  children: ReactNode;
+  children: React.ReactNode;
   hasData: boolean;
   id: string;
   disabled?: boolean;

--- a/static/app/utils/replays/getFrameDetails.tsx
+++ b/static/app/utils/replays/getFrameDetails.tsx
@@ -1,4 +1,4 @@
-import {Fragment, type ReactNode} from 'react';
+import {Fragment} from 'react';
 
 import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
@@ -67,10 +67,10 @@ import {MODULE_DOC_LINK} from 'sentry/views/insights/browser/webVitals/settings'
 
 interface Details {
   colorGraphicsToken: GraphicsVariant;
-  description: ReactNode;
-  icon: ReactNode;
+  description: React.ReactNode;
+  icon: React.ReactNode;
   tabKey: TabKey;
-  title: ReactNode;
+  title: React.ReactNode;
 }
 
 const DEVICE_CONNECTIVITY_MESSAGE: Record<string, string> = {

--- a/static/app/utils/replays/playback/providers/replayPlayerPluginsContextProvider.spec.tsx
+++ b/static/app/utils/replays/playback/providers/replayPlayerPluginsContextProvider.spec.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {renderHook} from 'sentry-test/reactTestingLibrary';
@@ -11,7 +10,7 @@ import {
 import {OrganizationContext} from 'sentry/views/organizationContext';
 
 function makeWrapper(organization: Organization) {
-  return function ({children}: {children?: ReactNode}) {
+  return function ({children}: {children?: React.ReactNode}) {
     return (
       <OrganizationContext value={organization}>
         <ReplayPlayerPluginsContextProvider>
@@ -42,7 +41,7 @@ describe('replayPlayerPluginsContext', () => {
     const mockEvents: any[] = [];
 
     const {result} = renderHook(useReplayPlayerPlugins, {
-      wrapper: ({children}: {children?: ReactNode}) => (
+      wrapper: ({children}: {children?: React.ReactNode}) => (
         <OrganizationContext value={mockOrganization}>{children}</OrganizationContext>
       ),
     });

--- a/static/app/utils/replays/playback/providers/replayPlayerSizeContext.tsx
+++ b/static/app/utils/replays/playback/providers/replayPlayerSizeContext.tsx
@@ -1,10 +1,4 @@
-import {
-  createContext,
-  useContext,
-  useState,
-  type Dispatch,
-  type SetStateAction,
-} from 'react';
+import {createContext, useContext, useState} from 'react';
 
 type State = {
   /**
@@ -25,7 +19,7 @@ type State = {
   width: number;
 };
 
-const Context = createContext<[State, Dispatch<SetStateAction<State>>]>([
+const Context = createContext<[State, React.Dispatch<React.SetStateAction<State>>]>([
   {width: 0, height: 0, scale: 0},
   () => {},
 ]);

--- a/static/app/utils/replays/playback/providers/replayPlayerStateContext.spec.tsx
+++ b/static/app/utils/replays/playback/providers/replayPlayerStateContext.spec.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {IncrementalSource, Replayer} from '@sentry-internal/rrweb';
 import {
   RRWebFullSnapshotFrameEventFixture,
@@ -16,7 +15,7 @@ import {
   useReplayUserAction,
 } from 'sentry/utils/replays/playback/providers/replayPlayerStateContext';
 
-function wrapper({children}: {children?: ReactNode}) {
+function wrapper({children}: {children?: React.ReactNode}) {
   return <ReplayPlayerStateContextProvider>{children}</ReplayPlayerStateContextProvider>;
 }
 

--- a/static/app/utils/replays/playback/providers/replayPlayerStateContext.tsx
+++ b/static/app/utils/replays/playback/providers/replayPlayerStateContext.tsx
@@ -1,4 +1,3 @@
-import type {Dispatch, ReactNode} from 'react';
 import {createContext, useCallback, useContext, useReducer} from 'react';
 import type {PlayerState, Replayer, SpeedState} from '@sentry-internal/rrweb';
 import {ReplayerEvents} from '@sentry-internal/rrweb';
@@ -9,7 +8,7 @@ import {clamp} from 'sentry/utils/number/clamp';
 import type {Dimensions} from 'sentry/utils/replays/types';
 
 type ReplayerAction =
-  | {dispatch: Dispatch<ReplayerAction>; replayer: Replayer; type: 'didMountPlayer'}
+  | {dispatch: React.Dispatch<ReplayerAction>; replayer: Replayer; type: 'didMountPlayer'}
   | {replayer: Replayer; type: 'didUnmountPlayer'}
   | {type: 'didStart'}
   | {type: 'didPause'}
@@ -55,10 +54,14 @@ function createInitialState(): State {
 }
 
 const StateContext = createContext<State>(createInitialState());
-const DispatchContext = createContext<Dispatch<ReplayerAction>>(() => {});
+const DispatchContext = createContext<React.Dispatch<ReplayerAction>>(() => {});
 const UserActionContext = createContext((_action: UserAction) => {});
 
-export function ReplayPlayerStateContextProvider({children}: {children: ReactNode}) {
+export function ReplayPlayerStateContextProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   const [state, dispatch] = useReducer(stateReducer, null, createInitialState);
 
   const handleUserAction = useCallback(
@@ -205,7 +208,7 @@ type SkipEventArg = {speed: number};
 type StateChangeEventArg = {player: PlayerState} | {speed: SpeedState};
 
 function makeReplayerEventMap(
-  dispatch: Dispatch<ReplayerAction>
+  dispatch: React.Dispatch<ReplayerAction>
 ): Record<ReplayerEvents, EventHandler> {
   return {
     [ReplayerEvents.Start]: () => {
@@ -254,7 +257,10 @@ function makeReplayerEventMap(
   };
 }
 
-function subscribeToReplayer(replayer: Replayer, dispatch: Dispatch<ReplayerAction>) {
+function subscribeToReplayer(
+  replayer: Replayer,
+  dispatch: React.Dispatch<ReplayerAction>
+) {
   const eventMap = makeReplayerEventMap(dispatch);
   Object.entries(eventMap).forEach(([name, handler]) => {
     replayer.on(name, handler);

--- a/static/app/utils/replays/playback/providers/replayPlaylistProvider.tsx
+++ b/static/app/utils/replays/playback/providers/replayPlaylistProvider.tsx
@@ -1,10 +1,9 @@
-import type {ReactNode} from 'react';
 import {createContext, useContext, useMemo} from 'react';
 
 import type {ReplayListRecord} from 'sentry/views/replays/types';
 
 interface Props {
-  children: ReactNode;
+  children: React.ReactNode;
   currentReplay: ReplayListRecord | undefined;
   isLoading: boolean;
   replays: ReplayListRecord[];

--- a/static/app/utils/replays/playback/providers/replayPreferencesContext.spec.tsx
+++ b/static/app/utils/replays/playback/providers/replayPreferencesContext.spec.tsx
@@ -1,5 +1,3 @@
-import type {ReactNode} from 'react';
-
 import {act, renderHook} from 'sentry-test/reactTestingLibrary';
 
 import {
@@ -13,7 +11,7 @@ import {
 } from 'sentry/utils/replays/playback/providers/replayPreferencesContext';
 
 function makeWrapper(prefsStrategy: PrefsStrategy) {
-  return function ({children}: {children?: ReactNode}) {
+  return function ({children}: {children?: React.ReactNode}) {
     return (
       <ReplayPreferencesContextProvider prefsStrategy={prefsStrategy}>
         {children}

--- a/static/app/utils/replays/playback/providers/replayReaderProvider.tsx
+++ b/static/app/utils/replays/playback/providers/replayReaderProvider.tsx
@@ -1,10 +1,9 @@
-import type {ReactNode} from 'react';
 import {createContext, useContext} from 'react';
 
 import {ReplayReader} from 'sentry/utils/replays/replayReader';
 
 interface Props {
-  children: ReactNode;
+  children: React.ReactNode;
   replay: ReplayReader | null;
 }
 

--- a/static/app/utils/replays/playback/providers/useCurrentHoverTime.tsx
+++ b/static/app/utils/replays/playback/providers/useCurrentHoverTime.tsx
@@ -1,11 +1,17 @@
-import type {Dispatch, ReactNode, SetStateAction} from 'react';
 import {createContext, useContext, useState} from 'react';
 
-type ContextType = [undefined | number, Dispatch<SetStateAction<number | undefined>>];
+type ContextType = [
+  undefined | number,
+  React.Dispatch<React.SetStateAction<number | undefined>>,
+];
 
 const Context = createContext<ContextType>([undefined, () => {}]);
 
-export function ReplayCurrentTimeContextProvider({children}: {children: ReactNode}) {
+export function ReplayCurrentTimeContextProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   const state = useState<undefined | number>(undefined);
 
   return <Context value={state}>{children}</Context>;

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -7,7 +7,6 @@
  * - Light and dark theme definitions
  * - Theme type exports
  */
-import type {CSSProperties} from 'react';
 import {css} from '@emotion/react';
 import {spring, type Transition} from 'framer-motion';
 
@@ -913,7 +912,7 @@ declare module '@emotion/react' {
 }
 
 export type StrictCSSObject = {
-  [K in keyof CSSProperties]?: CSSProperties[K]; // Enforce standard CSS properties
+  [K in keyof React.CSSProperties]?: React.CSSProperties[K]; // Enforce standard CSS properties
 } & Partial<{
   [key: `&${string}`]: StrictCSSObject; // Allow nested selectors
   [key: `> ${string}:last-child`]: StrictCSSObject; // Allow some nested selectors

--- a/static/app/utils/useDatePageFilterProps.tsx
+++ b/static/app/utils/useDatePageFilterProps.tsx
@@ -1,4 +1,4 @@
-import {useMemo, type ReactNode} from 'react';
+import {useMemo} from 'react';
 
 import type {SelectOptionWithKey} from '@sentry/scraps/compactSelect';
 
@@ -17,7 +17,7 @@ export function useDatePageFilterProps({
 }: UseDatePageFilterPropsProps): DatePageFilterProps {
   return useMemo(() => {
     // ensure the available relative options are always sorted
-    const availableRelativeOptions: Array<[number, string, ReactNode]> = [
+    const availableRelativeOptions: Array<[number, string, React.ReactNode]> = [
       [1 / 24, '1h', t('Last hour')],
       [1, '24h', t('Last 24 hours')],
       [7, '7d', t('Last 7 days')],

--- a/static/app/utils/useDimensions.tsx
+++ b/static/app/utils/useDimensions.tsx
@@ -1,9 +1,8 @@
-import type {RefObject} from 'react';
 import {useCallback, useLayoutEffect, useState} from 'react';
 import {useResizeObserver} from '@react-aria/utils';
 
 interface Props {
-  elementRef: RefObject<Element | null>;
+  elementRef: React.RefObject<Element | null>;
 }
 
 /**

--- a/static/app/utils/useDispatchingReducer.tsx
+++ b/static/app/utils/useDispatchingReducer.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import {useCallback, useMemo, useRef, useState, type ReducerState} from 'react';
+import {useCallback, useMemo, useRef, useState} from 'react';
 
 import type {ReducerAction} from 'sentry/types/reducerAction';
 
@@ -13,7 +13,7 @@ import type {ReducerAction} from 'sentry/types/reducerAction';
  */
 
 export interface DispatchingReducerMiddleware<R extends React.Reducer<any, any>> {
-  ['before action']: (S: Readonly<ReducerState<R>>, A: ReducerAction<R>) => void;
+  ['before action']: (S: Readonly<React.ReducerState<R>>, A: ReducerAction<R>) => void;
   ['before next state']: (
     P: Readonly<React.ReducerState<R>>,
     S: Readonly<React.ReducerState<R>>,
@@ -72,7 +72,7 @@ export class DispatchingReducerEmitter<R extends React.Reducer<any, any>> {
 }
 
 function update<R extends React.Reducer<any, any>>(
-  state: ReducerState<R>,
+  state: React.ReducerState<R>,
   actions: Array<ReducerAction<R>>,
   reducer: R,
   emitter: DispatchingReducerEmitter<R>
@@ -95,12 +95,16 @@ function update<R extends React.Reducer<any, any>>(
 
 export function useDispatchingReducer<R extends React.Reducer<any, any>>(
   reducer: R,
-  initialState: ReducerState<R>,
-  initializer?: (arg: ReducerState<R>) => ReducerState<R>
-): [ReducerState<R>, React.Dispatch<ReducerAction<R>>, DispatchingReducerEmitter<R>] {
+  initialState: React.ReducerState<R>,
+  initializer?: (arg: React.ReducerState<R>) => React.ReducerState<R>
+): [
+  React.ReducerState<R>,
+  React.Dispatch<ReducerAction<R>>,
+  DispatchingReducerEmitter<R>,
+] {
   const emitter = useMemo(() => new DispatchingReducerEmitter<R>(), []);
   const [state, setState] = useState(
-    initialState ?? (initializer?.(initialState) as ReducerState<R>)
+    initialState ?? (initializer?.(initialState) as React.ReducerState<R>)
   );
 
   const stateRef = useRef(state);

--- a/static/app/utils/useFeedbackForm.tsx
+++ b/static/app/utils/useFeedbackForm.tsx
@@ -1,11 +1,4 @@
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useRef,
-  type ReactNode,
-} from 'react';
+import {createContext, useCallback, useContext, useEffect, useRef} from 'react';
 import type {FeedbackModalIntegration} from '@sentry/core';
 import isEqual from 'lodash/isEqual';
 
@@ -115,7 +108,7 @@ function useOpenForm() {
 /**
  * Provider for the global feedback form context. Should only be rendered in the app root.
  */
-export function GlobalFeedbackForm({children}: {children: ReactNode}) {
+export function GlobalFeedbackForm({children}: {children: React.ReactNode}) {
   const openForm = useOpenForm();
 
   return (

--- a/static/app/utils/useMaxPickableDays.tsx
+++ b/static/app/utils/useMaxPickableDays.tsx
@@ -1,4 +1,4 @@
-import {useMemo, type ReactNode} from 'react';
+import {useMemo} from 'react';
 
 import {HookOrDefault} from 'sentry/components/hookOrDefault';
 import type {DatePageFilterProps} from 'sentry/components/pageFilters/date/datePageFilter';
@@ -35,7 +35,7 @@ export interface MaxPickableDaysOptions {
    */
   maxUpgradableDays: NonNullable<DatePageFilterProps['maxPickableDays']>;
   defaultPeriod?: DatePageFilterProps['defaultPeriod'];
-  upsellFooter?: ReactNode;
+  upsellFooter?: React.ReactNode;
 }
 
 export interface UseMaxPickableDaysProps {

--- a/static/app/utils/useMouseTracking.tsx
+++ b/static/app/utils/useMouseTracking.tsx
@@ -1,13 +1,12 @@
-import type {DOMAttributes, MouseEvent, RefObject} from 'react';
 import {useCallback, useRef} from 'react';
 import * as Sentry from '@sentry/react';
 
 type CallbackArgs = {height: number; left: number; top: number; width: number};
 
 type Opts<T extends Element> = {
-  elem: RefObject<T | null>;
+  elem: React.RefObject<T | null>;
   onPositionChange: (args: undefined | CallbackArgs) => void;
-} & DOMAttributes<T>;
+} & React.DOMAttributes<T>;
 
 class AbortError extends Error {
   constructor() {
@@ -56,7 +55,7 @@ export function useMouseTracking<T extends Element>({
   const controller = useRef<AbortController>(new AbortController());
 
   const handlePositionChange = useCallback(
-    async (e: MouseEvent<T>) => {
+    async (e: React.MouseEvent<T>) => {
       if (!elem.current) {
         onPositionChange(undefined);
         return;
@@ -95,11 +94,11 @@ export function useMouseTracking<T extends Element>({
 
   return {
     ...rest,
-    onMouseEnter: (e: MouseEvent<T>) => {
+    onMouseEnter: (e: React.MouseEvent<T>) => {
       handlePositionChange(e);
       onMouseEnter?.(e);
     },
-    onMouseMove: (e: MouseEvent<T>) => {
+    onMouseMove: (e: React.MouseEvent<T>) => {
       // prevent outside elements from firing, for example a tooltip
       if (!elem.current?.contains(e.target as Node)) {
         return;
@@ -108,7 +107,7 @@ export function useMouseTracking<T extends Element>({
       handlePositionChange(e);
       onMouseMove?.(e);
     },
-    onMouseLeave: (e: MouseEvent<T>) => {
+    onMouseLeave: (e: React.MouseEvent<T>) => {
       handleOnMouseLeave();
       onMouseLeave?.(e);
     },

--- a/static/app/utils/useResizable.tsx
+++ b/static/app/utils/useResizable.tsx
@@ -1,4 +1,3 @@
-import type {RefObject} from 'react';
 import {useCallback, useEffect, useRef, useState} from 'react';
 
 const RESIZABLE_DEFAULT_WIDTH = 200;
@@ -9,7 +8,7 @@ interface UseResizableOptions {
   /**
    * The ref to the element to be resized.
    */
-  ref: RefObject<HTMLElement | null>;
+  ref: React.RefObject<HTMLElement | null>;
 
   /**
    * The starting size of the container, and the size that is set in the onDoubleClick handler.

--- a/static/app/utils/useSessionStorage.tsx
+++ b/static/app/utils/useSessionStorage.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useState, type SetStateAction} from 'react';
+import {useCallback, useEffect, useState} from 'react';
 
 import {sessionStorageWrapper} from 'sentry/utils/sessionStorage';
 
@@ -26,7 +26,7 @@ export function readStorageValue(key: string, initialValue: unknown) {
 export function useSessionStorage<T>(
   key: string,
   initialValue: T
-): [T, (value: SetStateAction<T>) => void, () => void] {
+): [T, (value: React.SetStateAction<T>) => void, () => void] {
   const [state, setState] = useState<T>(() => readStorageValue(key, initialValue));
 
   useEffect(() => {
@@ -36,7 +36,7 @@ export function useSessionStorage<T>(
   }, [key]);
 
   const wrappedSetState = useCallback(
-    (valueOrUpdater: SetStateAction<T>) => {
+    (valueOrUpdater: React.SetStateAction<T>) => {
       setState(prev => {
         // Cast needed: TS can't narrow SetStateAction<T> via typeof when T
         // could itself be a function type.

--- a/static/app/utils/useUndoableReducer.tsx
+++ b/static/app/utils/useUndoableReducer.tsx
@@ -1,4 +1,3 @@
-import type {ReducerState} from 'react';
 import {useMemo, useReducer} from 'react';
 
 import type {ReducerAction} from 'sentry/types/reducerAction';
@@ -20,7 +19,7 @@ type RedoAction = {
 export type UndoableReducerAction<A> = UndoAction | RedoAction | A;
 
 export type UndoableReducer<R extends React.Reducer<any, any>> = React.Reducer<
-  UndoableNode<ReducerState<R>>,
+  UndoableNode<React.ReducerState<R>>,
   UndoableReducerAction<ReducerAction<R>>
 >;
 
@@ -52,14 +51,14 @@ export function makeUndoableReducer<R extends React.Reducer<any, any>>(
   reducer: R
 ): UndoableReducer<R> {
   return (
-    state: UndoableNode<ReducerState<R>>,
+    state: UndoableNode<React.ReducerState<R>>,
     action: UndoableReducerAction<ReducerAction<R>>
   ) => {
     if (isUndoOrRedoAction(action)) {
       return undoableReducer(state, action);
     }
 
-    const newState: UndoableNode<ReducerState<R>> = {
+    const newState: UndoableNode<React.ReducerState<R>> = {
       next: undefined,
       previous: state,
       current: reducer(state.current, action),
@@ -70,18 +69,20 @@ export function makeUndoableReducer<R extends React.Reducer<any, any>>(
   };
 }
 
-type UndoableReducerState<R extends React.Reducer<ReducerState<R>, ReducerAction<R>>> = [
-  ReducerState<R>,
+type UndoableReducerState<
+  R extends React.Reducer<React.ReducerState<R>, ReducerAction<R>>,
+> = [
+  React.ReducerState<R>,
   React.Dispatch<UndoableReducerAction<ReducerAction<R>>>,
   {
-    nextState: ReducerState<R> | undefined;
-    previousState: ReducerState<R> | undefined;
+    nextState: React.ReducerState<R> | undefined;
+    previousState: React.ReducerState<R> | undefined;
   },
 ];
 
 export function useUndoableReducer<
-  R extends React.Reducer<ReducerState<R>, ReducerAction<R>>,
->(reducer: R, initialState: ReducerState<R>): UndoableReducerState<R> {
+  R extends React.Reducer<React.ReducerState<R>, ReducerAction<R>>,
+>(reducer: R, initialState: React.ReducerState<R>): UndoableReducerState<R> {
   const [state, dispatch] = useReducer(makeUndoableReducer(reducer), {
     current: initialState,
     previous: undefined,

--- a/static/app/utils/window/useFullscreen.tsx
+++ b/static/app/utils/window/useFullscreen.tsx
@@ -1,4 +1,3 @@
-import type {RefObject} from 'react';
 import {useCallback} from 'react';
 import screenfull from 'screenfull';
 
@@ -8,7 +7,7 @@ interface Props<Element extends HTMLElement> {
    * Calling `useFullscreen()` a second time will create a different instance of
    * `ref` and `enter.
    */
-  elementRef: RefObject<Element | null>;
+  elementRef: React.RefObject<Element | null>;
 }
 
 interface Return {

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -1,4 +1,3 @@
-import type {ChangeEvent, ReactNode} from 'react';
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
@@ -472,7 +471,7 @@ class IssueRuleEditor extends DeprecatedAsyncComponent<Props, State> {
     addSuccessMessage(isNew ? t('Created alert rule') : t('Updated alert rule'));
   };
 
-  handleRuleSaveFailure(msg: ReactNode) {
+  handleRuleSaveFailure(msg: React.ReactNode) {
     addErrorMessage(msg);
     metric.endSpan({name: 'saveAlertRule'});
   }
@@ -880,7 +879,7 @@ class IssueRuleEditor extends DeprecatedAsyncComponent<Props, State> {
           value={name}
           data-test-id="alert-name"
           placeholder={t('Enter Alert Name')}
-          onChange={(event: ChangeEvent<HTMLInputElement>) =>
+          onChange={(event: React.ChangeEvent<HTMLInputElement>) =>
             this.handleChange('name', event.target.value)
           }
           onBlur={this.handleValidateRuleName}

--- a/static/app/views/alerts/rules/issue/ruleNodeList.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNodeList.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import {Component, Fragment, type ReactNode} from 'react';
+import {Component, Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {Select} from '@sentry/scraps/select';
@@ -46,10 +46,10 @@ type Props = {
   placeholder: string;
   project: Project;
   additionalAction?: {
-    label: ReactNode;
+    label: React.ReactNode;
     onClick: () => void;
     option: {
-      label: ReactNode;
+      label: React.ReactNode;
       value: IssueAlertRuleActionTemplate;
     };
   };

--- a/static/app/views/alerts/rules/issue/sentryAppRuleModal.spec.tsx
+++ b/static/app/views/alerts/rules/issue/sentryAppRuleModal.spec.tsx
@@ -1,4 +1,3 @@
-import type {PropsWithChildren, ReactElement} from 'react';
 import styled from '@emotion/styled';
 import {SentryAppFixture} from 'sentry-fixture/sentryApp';
 import {SentryAppInstallationFixture} from 'sentry-fixture/sentryAppInstallation';
@@ -14,9 +13,9 @@ import type {
 
 describe('SentryAppRuleModal', () => {
   const modalElements = {
-    Header: (p: PropsWithChildren) => p.children as ReactElement,
-    Body: (p: PropsWithChildren) => p.children,
-    Footer: (p: PropsWithChildren) => p.children,
+    Header: (p: React.PropsWithChildren) => p.children as React.ReactElement,
+    Body: (p: React.PropsWithChildren) => p.children,
+    Footer: (p: React.PropsWithChildren) => p.children,
   };
   let sentryApp: any;
   let sentryAppInstallation: any;
@@ -97,7 +96,7 @@ describe('SentryAppRuleModal', () => {
   };
 
   const createWrapper = (props = {}) => {
-    const styledWrapper = styled((c: PropsWithChildren) => c.children);
+    const styledWrapper = styled((c: React.PropsWithChildren) => c.children);
     return render(
       <SentryAppRuleModal
         {...modalElements}

--- a/static/app/views/alerts/rules/metric/eapField.spec.tsx
+++ b/static/app/views/alerts/rules/metric/eapField.spec.tsx
@@ -1,4 +1,4 @@
-import {useState, type ReactElement} from 'react';
+import {useState} from 'react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -18,7 +18,7 @@ describe('EAPField', () => {
   ];
   let fieldsMock: any;
 
-  function renderWithVisibilityFeature(ui: ReactElement) {
+  function renderWithVisibilityFeature(ui: React.ReactElement) {
     return render(ui, {organization});
   }
 

--- a/static/app/views/alerts/rules/metric/eapMetricsField.tsx
+++ b/static/app/views/alerts/rules/metric/eapMetricsField.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
@@ -35,7 +34,7 @@ interface MetricSelectOption {
   label: string;
   metricName: string;
   metricType: TraceMetricTypeValue;
-  trailingItems: ReactNode;
+  trailingItems: React.ReactNode;
   value: string;
   metricUnit?: string;
 }

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps, ReactNode} from 'react';
 import type {Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
@@ -1036,7 +1035,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
     }
   };
 
-  handleRuleSaveFailure = (msg: ReactNode) => {
+  handleRuleSaveFailure = (msg: React.ReactNode) => {
     addErrorMessage(msg);
     metric.endSpan({name: 'saveAlertRule'});
   };
@@ -1279,7 +1278,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
       isPreloading = !hasMetricSelected && !isMetricQueryDone;
     }
 
-    const chartProps: ComponentProps<typeof TriggersChart> = {
+    const chartProps: React.ComponentProps<typeof TriggersChart> = {
       organization,
       projects: [project],
       triggers,

--- a/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
+++ b/static/app/views/alerts/rules/metric/triggers/chart/index.tsx
@@ -1,4 +1,4 @@
-import React, {Fragment, PureComponent, type ComponentProps} from 'react';
+import React, {Fragment, PureComponent} from 'react';
 import type {Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
@@ -597,7 +597,7 @@ class TriggersChart extends PureComponent<Props, State> {
     }
 
     if (isSessionAggregate(aggregate)) {
-      const baseProps: ComponentProps<typeof SessionsRequest> = {
+      const baseProps: React.ComponentProps<typeof SessionsRequest> = {
         api,
         organization,
         project: projects.map(({id}) => Number(id)),

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/andOpTreeNode.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/andOpTreeNode.tsx
@@ -1,5 +1,3 @@
-import type {ReactNode} from 'react';
-
 import {AndOpRow} from 'sentry/views/alerts/rules/uptime/assertions/assertionFailure/rows/andOpRow';
 import type {UptimeAndOp} from 'sentry/views/alerts/rules/uptime/types';
 
@@ -10,7 +8,7 @@ export class AndOpTreeNode extends TreeNode<UptimeAndOp> {
     return `AND - ${this.id}`;
   }
 
-  renderRow(): ReactNode {
+  renderRow(): React.ReactNode {
     return <AndOpRow node={this} />;
   }
 }

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/headerCheckOpTreeNode.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/headerCheckOpTreeNode.tsx
@@ -1,5 +1,3 @@
-import type {ReactNode} from 'react';
-
 import {HeaderCheckOpRow} from 'sentry/views/alerts/rules/uptime/assertions/assertionFailure/rows/headerCheckOpRow';
 import type {UptimeHeaderCheckOp} from 'sentry/views/alerts/rules/uptime/types';
 
@@ -10,7 +8,7 @@ export class HeaderCheckOpTreeNode extends TreeNode<UptimeHeaderCheckOp> {
     return `HEADER CHECK - ${this.id}`;
   }
 
-  renderRow(): ReactNode {
+  renderRow(): React.ReactNode {
     return <HeaderCheckOpRow node={this} />;
   }
 }

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/jsonPathOpTreeNode.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/jsonPathOpTreeNode.tsx
@@ -1,5 +1,3 @@
-import type {ReactNode} from 'react';
-
 import {JsonPathOpRow} from 'sentry/views/alerts/rules/uptime/assertions/assertionFailure/rows/jsonPathOpRow';
 import type {UptimeJsonPathOp} from 'sentry/views/alerts/rules/uptime/types';
 
@@ -10,7 +8,7 @@ export class JsonPathOpTreeNode extends TreeNode<UptimeJsonPathOp> {
     return `JSON PATH - ${this.id}`;
   }
 
-  renderRow(): ReactNode {
+  renderRow(): React.ReactNode {
     return <JsonPathOpRow node={this} />;
   }
 }

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/notOpTreeNode.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/notOpTreeNode.tsx
@@ -1,5 +1,3 @@
-import type {ReactNode} from 'react';
-
 import {NotOpRow} from 'sentry/views/alerts/rules/uptime/assertions/assertionFailure/rows/notOpRow';
 import type {UptimeNotOp} from 'sentry/views/alerts/rules/uptime/types';
 
@@ -14,7 +12,7 @@ export class NotOpTreeNode extends TreeNode<UptimeNotOp> {
     return `NOT - ${this.id}`;
   }
 
-  renderRow(): ReactNode {
+  renderRow(): React.ReactNode {
     return <NotOpRow />;
   }
 }

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/orOpTreeNode.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/orOpTreeNode.tsx
@@ -1,5 +1,3 @@
-import type {ReactNode} from 'react';
-
 import {OrOpRow} from 'sentry/views/alerts/rules/uptime/assertions/assertionFailure/rows/orOpRow';
 import type {UptimeOrOp} from 'sentry/views/alerts/rules/uptime/types';
 
@@ -10,7 +8,7 @@ export class OrOpTreeNode extends TreeNode<UptimeOrOp> {
     return `OR - ${this.id}`;
   }
 
-  renderRow(): ReactNode {
+  renderRow(): React.ReactNode {
     return <OrOpRow node={this} />;
   }
 }

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/statusCodeOpTreeNode.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/statusCodeOpTreeNode.tsx
@@ -1,5 +1,3 @@
-import type {ReactNode} from 'react';
-
 import {StatusCodeOpRow} from 'sentry/views/alerts/rules/uptime/assertions/assertionFailure/rows/statusCodeOpRow';
 import type {UptimeStatusCodeOp} from 'sentry/views/alerts/rules/uptime/types';
 
@@ -10,7 +8,7 @@ export class StatusCodeOpTreeNode extends TreeNode<UptimeStatusCodeOp> {
     return `STATUS CODE - ${this.id}`;
   }
 
-  renderRow(): ReactNode {
+  renderRow(): React.ReactNode {
     return <StatusCodeOpRow node={this} />;
   }
 }

--- a/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/treeNode.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/assertionFailure/models/treeNode.tsx
@@ -1,5 +1,3 @@
-import type {ReactNode} from 'react';
-
 import type {UptimeOp} from 'sentry/views/alerts/rules/uptime/types';
 
 export type ConnectorType = 'vertical' | 'horizontal';
@@ -77,5 +75,5 @@ export abstract class TreeNode<T extends UptimeOp = UptimeOp> {
 
   abstract printNode(): string;
 
-  abstract renderRow(): ReactNode;
+  abstract renderRow(): React.ReactNode;
 }

--- a/static/app/views/alerts/rules/uptime/assertions/opStatusCode.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/opStatusCode.tsx
@@ -1,4 +1,4 @@
-import {useId, type ChangeEventHandler, type FocusEventHandler} from 'react';
+import {useId} from 'react';
 
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {InputGroup} from '@sentry/scraps/input';
@@ -35,7 +35,7 @@ export function AssertionOpStatusCode({
   );
   const selectedOption = statusCodeOptions.find(opt => opt.value === value.operator.cmp);
 
-  const handleInputChange: ChangeEventHandler<HTMLInputElement> = e => {
+  const handleInputChange: React.ChangeEventHandler<HTMLInputElement> = e => {
     const rawValue = e.target.value;
     // Only allow digits, up to 3 characters
     if (!/^\d*$/.test(rawValue) || rawValue.length > 3) {
@@ -50,7 +50,7 @@ export function AssertionOpStatusCode({
     onChange({...value, value: newValue});
   };
 
-  const handleInputBlur: FocusEventHandler<HTMLInputElement> = e => {
+  const handleInputBlur: React.FocusEventHandler<HTMLInputElement> = e => {
     const newValue = parseInt(e.target.value, 10);
     // Clamp status code to valid HTTP range (100-599) on blur
     if (isNaN(newValue)) {

--- a/static/app/views/automations/components/automationBuilderContext.tsx
+++ b/static/app/views/automations/components/automationBuilderContext.tsx
@@ -1,4 +1,4 @@
-import {createContext, useCallback, useContext, useReducer, type Reducer} from 'react';
+import {createContext, useCallback, useContext, useReducer} from 'react';
 import {uuid4} from '@sentry/core';
 
 import type {
@@ -17,8 +17,8 @@ import {actionNodesMap} from 'sentry/views/automations/components/actionNodes';
 import {dataConditionNodesMap} from 'sentry/views/automations/components/dataConditionNodes';
 
 export function useAutomationBuilderReducer(initialState?: AutomationBuilderState) {
-  const reducer: Reducer<AutomationBuilderState, AutomationBuilderAction> = useCallback(
-    (state, action): AutomationBuilderState => {
+  const reducer: React.Reducer<AutomationBuilderState, AutomationBuilderAction> =
+    useCallback((state, action): AutomationBuilderState => {
       switch (action.type) {
         case 'ADD_WHEN_CONDITION':
           return addWhenCondition(state, action);
@@ -49,9 +49,7 @@ export function useAutomationBuilderReducer(initialState?: AutomationBuilderStat
         default:
           return state;
       }
-    },
-    []
-  );
+    }, []);
 
   const [state, dispatch] = useReducer(
     reducer,

--- a/static/app/views/automations/components/automationBuilderErrorContext.tsx
+++ b/static/app/views/automations/components/automationBuilderErrorContext.tsx
@@ -1,4 +1,4 @@
-import {createContext, useContext, type Dispatch, type SetStateAction} from 'react';
+import {createContext, useContext} from 'react';
 
 import type {RequestError} from 'sentry/utils/requestError/requestError';
 
@@ -6,7 +6,7 @@ export const AutomationBuilderErrorContext = createContext<{
   errors: Record<string, any>;
   mutationErrors: RequestError['responseJSON'];
   removeError: (errorId: string) => void;
-  setErrors: (errors: Dispatch<SetStateAction<Record<string, any>>>) => void;
+  setErrors: (errors: React.Dispatch<React.SetStateAction<Record<string, any>>>) => void;
 } | null>(null);
 
 export const useAutomationBuilderErrorContext = () => {

--- a/static/app/views/automations/components/automationListTable/index.tsx
+++ b/static/app/views/automations/components/automationListTable/index.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, useState, type ComponentProps} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import {parseAsString, useQueryState} from 'nuqs';
 
@@ -54,7 +54,7 @@ function HeaderCell({
   className?: string;
   divider?: boolean;
   sortKey?: string;
-} & Omit<ComponentProps<typeof SimpleTable.HeaderCell>, 'sort'>) {
+} & Omit<React.ComponentProps<typeof SimpleTable.HeaderCell>, 'sort'>) {
   const location = useLocation();
   const navigate = useNavigate();
   const isSortedByField = sort?.field === sortKey;

--- a/static/app/views/automations/components/forms/context.tsx
+++ b/static/app/views/automations/components/forms/context.tsx
@@ -1,5 +1,4 @@
 import {createContext, useContext, useState} from 'react';
-import type {ReactNode} from 'react';
 
 import type {Automation} from 'sentry/types/workflowEngine/automations';
 
@@ -14,7 +13,7 @@ const AutomationFormContext = createContext<AutomationFormContextValue | undefin
 );
 
 interface AutomationFormProviderProps {
-  children: ReactNode;
+  children: React.ReactNode;
   automation?: Automation;
 }
 

--- a/static/app/views/dashboards/contexts/widgetSyncContext.tsx
+++ b/static/app/views/dashboards/contexts/widgetSyncContext.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {useCallback, useEffect, useMemo, useRef} from 'react';
 import type {EChartsType} from 'echarts';
 import * as echarts from 'echarts';
@@ -21,7 +20,7 @@ const [_WidgetSyncProvider, _useWidgetSyncContext, WidgetSyncContext] =
   });
 
 interface WidgetSyncContextProviderProps {
-  children: ReactNode;
+  children: React.ReactNode;
   groupName?: string;
 }
 

--- a/static/app/views/dashboards/createLimitWrapper.tsx
+++ b/static/app/views/dashboards/createLimitWrapper.tsx
@@ -1,12 +1,10 @@
-import type {ReactNode} from 'react';
-
 import {HookOrDefault} from 'sentry/components/hookOrDefault';
 
 type DashboardCreateLimitWrapperResult = {
   dashboardsLimit: number;
   hasReachedDashboardLimit: boolean;
   isLoading: boolean;
-  limitMessage: ReactNode | null;
+  limitMessage: React.ReactNode | null;
 };
 
 export const DashboardCreateLimitWrapper = HookOrDefault({

--- a/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
@@ -1,4 +1,3 @@
-import {type ReactNode} from 'react';
 import pickBy from 'lodash/pickBy';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
@@ -213,7 +212,7 @@ function useTraceMetricsSearchScope() {
 
 export function formatTraceMetricsFunction(
   valueToParse: string | string[],
-  defaultValue?: string | ReactNode
+  defaultValue?: string | React.ReactNode
 ) {
   if (Array.isArray(valueToParse)) {
     const parsedFunctions = valueToParse.map(v => parseFunction(v));

--- a/static/app/views/dashboards/prebuiltDashboardRenderer.spec.tsx
+++ b/static/app/views/dashboards/prebuiltDashboardRenderer.spec.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -7,7 +6,7 @@ import {PrebuiltDashboardRenderer} from 'sentry/views/dashboards/prebuiltDashboa
 import {PrebuiltDashboardId} from 'sentry/views/dashboards/utils/prebuiltConfigs';
 
 jest.mock('sentry/views/dashboards/detail', () => ({
-  DashboardDetailWithInjectedProps: ({pageAlerts}: {pageAlerts?: ReactNode}) => (
+  DashboardDetailWithInjectedProps: ({pageAlerts}: {pageAlerts?: React.ReactNode}) => (
     <div data-test-id="dashboard-detail">{pageAlerts}</div>
   ),
 }));

--- a/static/app/views/dashboards/sortableWidget.tsx
+++ b/static/app/views/dashboards/sortableWidget.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useRef, useState, type ComponentProps} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import cloneDeep from 'lodash/cloneDeep';
 
@@ -124,7 +124,7 @@ export function SortableWidget(props: Props) {
     setTableWidths(widths);
   };
 
-  const widgetProps: ComponentProps<typeof WidgetCard> = {
+  const widgetProps: React.ComponentProps<typeof WidgetCard> = {
     widget: {...widget, queries: queries ?? widget.queries, tableWidths},
     isEditingDashboard,
     widgetLimitReached,

--- a/static/app/views/dashboards/utils/widgetQueryQueue.tsx
+++ b/static/app/views/dashboards/utils/widgetQueryQueue.tsx
@@ -1,4 +1,3 @@
-import type {RefObject} from 'react';
 import {createContext, useContext, useMemo, useRef} from 'react';
 import {metrics} from '@sentry/react';
 import {
@@ -13,7 +12,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 type FetchDataFn = () => Promise<void>;
 
 type QueueItem = {
-  fetchDataRef: RefObject<FetchDataFn>;
+  fetchDataRef: React.RefObject<FetchDataFn>;
 };
 
 type WidgetQueryQueue = ReactAsyncQueuer<QueueItem>;

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/filterResultsStep/spansSearchBar.spec.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps} from 'react';
 import {WidgetQueryFixture} from 'sentry-fixture/widgetQuery';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -18,7 +17,7 @@ function renderWithProvider({
   widgetQuery,
   onSearch,
   onClose,
-}: ComponentProps<typeof SpansSearchBar>) {
+}: React.ComponentProps<typeof SpansSearchBar>) {
   return render(
     <SpansSearchBar widgetQuery={widgetQuery} onSearch={onSearch} onClose={onClose} />,
     {}

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/groupBySelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/groupBySelector.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo, useState, type ReactNode} from 'react';
+import {Fragment, useMemo, useState} from 'react';
 import {closestCenter, DndContext, DragOverlay} from '@dnd-kit/core';
 import {arrayMove, SortableContext, verticalListSortingStrategy} from '@dnd-kit/sortable';
 import {useTheme} from '@emotion/react';
@@ -167,7 +167,7 @@ export function GroupBySelector({
     widgetType &&
     [WidgetType.SPANS, WidgetType.LOGS, WidgetType.TRACEMETRICS].includes(widgetType);
   const renderTagOverride = isEAPType
-    ? (_kind: FieldValueKind, _label: ReactNode, meta: FieldValue['meta']) => {
+    ? (_kind: FieldValueKind, _label: React.ReactNode, meta: FieldValue['meta']) => {
         if (!('dataType' in meta)) {
           return null;
         }

--- a/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/queryField.tsx
+++ b/static/app/views/dashboards/widgetBuilder/buildSteps/groupByStep/queryField.tsx
@@ -1,4 +1,4 @@
-import {Fragment, type ReactNode} from 'react';
+import {Fragment} from 'react';
 import type {DraggableAttributes, DraggableSyntheticListeners} from '@dnd-kit/core';
 import styled from '@emotion/styled';
 
@@ -19,17 +19,17 @@ export interface QueryFieldProps {
   canDelete?: boolean;
   canDrag?: boolean;
   disabled?: boolean;
-  extraActions?: ReactNode;
-  fieldValidationError?: ReactNode;
+  extraActions?: React.ReactNode;
+  fieldValidationError?: React.ReactNode;
   isDragging?: boolean;
   listeners?: DraggableSyntheticListeners;
   onDelete?: () => void;
   ref?: React.Ref<HTMLDivElement>;
   renderTagOverride?: (
     kind: FieldValueKind,
-    label: ReactNode,
+    label: React.ReactNode,
     meta: FieldValue['meta']
-  ) => ReactNode;
+  ) => React.ReactNode;
   style?: React.CSSProperties;
 }
 

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.tsx
@@ -1,11 +1,4 @@
-import {
-  Fragment,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  type CSSProperties,
-} from 'react';
+import {Fragment, useCallback, useEffect, useRef, useState} from 'react';
 import {closestCorners, DndContext, useDraggable, useDroppable} from '@dnd-kit/core';
 import {css, Global, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -284,7 +277,7 @@ export function WidgetPreviewContainer({
 
   const {translate, top, left} = dragPosition ?? {};
 
-  const draggableStyle: CSSProperties = {
+  const draggableStyle: React.CSSProperties = {
     transform: isDragEnabled
       ? `translate3d(${isDragging ? translate?.x : 0}px, ${isDragging ? translate?.y : 0}px, 0)`
       : undefined,

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/index.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo, useState, type ReactNode} from 'react';
+import {Fragment, useMemo, useState} from 'react';
 import {closestCenter, DndContext, DragOverlay} from '@dnd-kit/core';
 import {arrayMove, SortableContext, verticalListSortingStrategy} from '@dnd-kit/sortable';
 import {css, useTheme} from '@emotion/react';
@@ -134,8 +134,8 @@ function formatColumnOptions(
 }
 
 function _sortFn(
-  a: SelectValue<string> & {value: string; label?: string | ReactNode},
-  b: SelectValue<string> & {value: string; label?: string | ReactNode}
+  a: SelectValue<string> & {value: string; label?: string | React.ReactNode},
+  b: SelectValue<string> & {value: string; label?: string | React.ReactNode}
 ) {
   // The labels should always be strings in this component, but we'll
   // handle the cases where they are not.

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -1,11 +1,4 @@
-import {
-  Fragment,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-  type RefCallback,
-} from 'react';
+import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import isEqual from 'lodash/isEqual';
@@ -213,7 +206,7 @@ function WidgetBuilderSlideoutInner({
     [setIsPreviewDraggable]
   );
 
-  const observeForDraggablePreview = useCallback<RefCallback<HTMLDivElement>>(
+  const observeForDraggablePreview = useCallback<React.RefCallback<HTMLDivElement>>(
     elem => {
       if (elem) {
         observer.observe(elem);

--- a/static/app/views/dashboards/widgetCard/dashboardsMEPContext.tsx
+++ b/static/app/views/dashboards/widgetCard/dashboardsMEPContext.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {useState} from 'react';
 
 import {createDefinedContext} from 'sentry/utils/performance/contexts/utils';
@@ -13,7 +12,7 @@ const [_DashboardsMEPProvider, useDashboardsMEPContext, DashboardsMEPContext] =
     name: 'DashboardsMEPContext',
   });
 
-function DashboardsMEPProvider({children}: {children: ReactNode}) {
+function DashboardsMEPProvider({children}: {children: React.ReactNode}) {
   const [isMetricsData, setIsMetricsData] = useState<boolean | undefined>(undefined); // undefined means not initialized
 
   return (

--- a/static/app/views/detectors/components/detectorListTable/index.tsx
+++ b/static/app/views/detectors/components/detectorListTable/index.tsx
@@ -1,11 +1,4 @@
-import {
-  Fragment,
-  useCallback,
-  useMemo,
-  useRef,
-  useState,
-  type ComponentProps,
-} from 'react';
+import {Fragment, useCallback, useMemo, useRef, useState} from 'react';
 import {css, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {useQueryState} from 'nuqs';
@@ -66,7 +59,7 @@ export function HeaderCell({
   children?: React.ReactNode;
   divider?: boolean;
   sortKey?: string;
-} & Omit<ComponentProps<typeof SimpleTable.HeaderCell>, 'sort'>) {
+} & Omit<React.ComponentProps<typeof SimpleTable.HeaderCell>, 'sort'>) {
   const [sort, setSort] = useDetectorListSort();
   const [, setCursor] = useQueryState('cursor');
   const isSortedByField = sort?.field === sortKey;

--- a/static/app/views/detectors/components/forms/metric/metricsVisualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricsVisualize.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {Fragment, useCallback, useContext, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import debounce from 'lodash/debounce';
@@ -38,7 +37,7 @@ import {makeMetricsAggregate} from 'sentry/views/explore/metrics/utils';
 interface MetricSelectOption extends SelectOption<string> {
   metricName: string;
   metricType: TraceMetricTypeValue;
-  trailingItems: ReactNode;
+  trailingItems: React.ReactNode;
   metricUnit?: string;
 }
 

--- a/static/app/views/detectors/list/common/detectorListContent.tsx
+++ b/static/app/views/detectors/list/common/detectorListContent.tsx
@@ -1,4 +1,4 @@
-import {useCallback, type ReactNode} from 'react';
+import {useCallback} from 'react';
 
 import {getPaginationCaption, Pagination} from 'sentry/components/pagination';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
@@ -16,7 +16,7 @@ interface DetectorListContentProps {
   isError: boolean;
   isLoading: boolean;
   isSuccess: boolean;
-  emptyState?: ReactNode;
+  emptyState?: React.ReactNode;
 }
 
 export function DetectorListContent({

--- a/static/app/views/discover/results/resultsHeader.tsx
+++ b/static/app/views/discover/results/resultsHeader.tsx
@@ -1,4 +1,4 @@
-import {Component, Fragment, type ComponentProps} from 'react';
+import {Component, Fragment} from 'react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 
@@ -251,7 +251,7 @@ const Subtitle = styled('h4')`
 const ResultsHeaderWithApi = withApi(ResultsHeader);
 
 type ResultsHeaderWrapperProps = Omit<
-  ComponentProps<typeof ResultsHeaderWithApi>,
+  React.ComponentProps<typeof ResultsHeaderWithApi>,
   'hasPageFrameFeature'
 >;
 

--- a/static/app/views/discover/table/queryField.tsx
+++ b/static/app/views/discover/table/queryField.tsx
@@ -1,4 +1,4 @@
-import {Component, createRef, type ReactNode} from 'react';
+import {Component, createRef} from 'react';
 import {withTheme, type CSSObject, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import cloneDeep from 'lodash/cloneDeep';
@@ -107,9 +107,9 @@ type Props = {
    */
   renderTagOverride?: (
     kind: FieldValueKind,
-    label: ReactNode,
+    label: React.ReactNode,
     meta: FieldValue['meta']
-  ) => ReactNode;
+  ) => React.ReactNode;
   /**
    * Whether or not to add the tag explaining the FieldValueKind of each field
    */
@@ -126,7 +126,10 @@ type Props = {
 
 class _QueryField extends Component<Props> {
   FieldSelectComponents = {
-    SingleValue: ({data, ...props}: SingleValueProps<FieldValueOption>): ReactNode => {
+    SingleValue: ({
+      data,
+      ...props
+    }: SingleValueProps<FieldValueOption>): React.ReactNode => {
       return (
         <components.SingleValue data={data} {...props}>
           <span data-test-id="label">{data.label}</span>

--- a/static/app/views/discover/table/quickContext/quickContextHovercard.tsx
+++ b/static/app/views/discover/table/quickContext/quickContextHovercard.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps} from 'react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 
@@ -133,7 +132,7 @@ function HoverHeader({
   );
 }
 
-interface ContextProps extends ComponentProps<typeof Hovercard> {
+interface ContextProps extends React.ComponentProps<typeof Hovercard> {
   children: React.ReactNode;
   contextType: ContextType;
   dataRow: EventData;

--- a/static/app/views/discover/table/quickContext/quickContextWrapper.tsx
+++ b/static/app/views/discover/table/quickContext/quickContextWrapper.tsx
@@ -1,5 +1,3 @@
-import type {ComponentProps} from 'react';
-
 import {Flex} from '@sentry/scraps/layout';
 
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
@@ -23,7 +21,7 @@ export function NoContext({isLoading}: NoContextProps) {
 }
 
 export function QuickContextHoverWrapper(
-  props: ComponentProps<typeof QuickContextHovercard>
+  props: React.ComponentProps<typeof QuickContextHovercard>
 ) {
   return (
     <Flex align="center" gap="sm">

--- a/static/app/views/explore/components/attributeDetails.tsx
+++ b/static/app/views/explore/components/attributeDetails.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import styled from '@emotion/styled';
 
 import {t} from 'sentry/locale';
@@ -8,7 +7,7 @@ import {TraceItemDataset} from 'sentry/views/explore/types';
 
 interface AttributeDetailsProps {
   column: string;
-  label: ReactNode;
+  label: React.ReactNode;
   traceItemType: TraceItemDataset;
   kind?: FieldKind;
 }

--- a/static/app/views/explore/components/chart/chartVisualization.tsx
+++ b/static/app/views/explore/components/chart/chartVisualization.tsx
@@ -1,4 +1,3 @@
-import type {Ref} from 'react';
 import {useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -23,7 +22,7 @@ import {INGESTION_DELAY} from 'sentry/views/insights/settings';
 
 interface ChartVisualizationProps {
   chartInfo: ChartInfo;
-  chartRef?: Ref<ReactEchartsRef>;
+  chartRef?: React.Ref<ReactEchartsRef>;
   chartXRangeSelection?: Partial<ChartXRangeSelectionProps>;
   hidden?: boolean;
 }

--- a/static/app/views/explore/components/table.tsx
+++ b/static/app/views/explore/components/table.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import {useCallback, useEffect, useMemo, useRef, type CSSProperties} from 'react';
+import {useCallback, useEffect, useMemo, useRef} from 'react';
 import styled from '@emotion/styled';
 
 import {COL_WIDTH_MINIMUM} from 'sentry/components/tables/gridEditable';
@@ -18,7 +18,7 @@ import {defined} from 'sentry/utils';
 import {Actions} from 'sentry/views/discover/table/cellAction';
 
 interface TableProps extends React.ComponentProps<typeof _TableWrapper> {
-  height?: CSSProperties['height'];
+  height?: React.CSSProperties['height'];
   ref?: React.Ref<HTMLTableElement>;
   showVerticalScrollbar?: boolean;
   // Size of the loading element in order to match the height of the row.

--- a/static/app/views/explore/components/tableActionButton.tsx
+++ b/static/app/views/explore/components/tableActionButton.tsx
@@ -1,15 +1,15 @@
-import {Fragment, type ReactNode} from 'react';
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 interface TableActionButtonProps {
   /**
    * Component to render on desktop (≥ md breakpoint)
    */
-  desktop: ReactNode;
+  desktop: React.ReactNode;
   /**
    * Component to render on mobile (< md breakpoint)
    */
-  mobile: ReactNode;
+  mobile: React.ReactNode;
 }
 
 export function TableActionButton({mobile, desktop}: TableActionButtonProps) {

--- a/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {useSortable} from '@dnd-kit/sortable';
 import {CSS} from '@dnd-kit/utilities';
 import styled from '@emotion/styled';
@@ -43,7 +42,7 @@ interface ToolbarVisualizeDropdownProps {
   onChangeArgument: (index: number, option: SelectOption<SelectKey>) => void;
   parsedFunction: ParsedFunction | null;
   dragColumnId?: number;
-  label?: ReactNode;
+  label?: React.ReactNode;
   loading?: boolean;
   onClose?: () => void;
   onDelete?: () => void;

--- a/static/app/views/explore/components/toolbar/toolbarVisualize/visualizeEquation.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/visualizeEquation.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, type ReactNode} from 'react';
+import {useCallback, useMemo} from 'react';
 import {useSortable} from '@dnd-kit/sortable';
 import {CSS} from '@dnd-kit/utilities';
 
@@ -26,7 +26,7 @@ interface VisualizeEquationProps {
   onReplace: (visualize: Visualize) => void;
   visualize: Visualize;
   dragColumnId?: number;
-  label?: ReactNode;
+  label?: React.ReactNode;
   onDelete?: () => void;
 }
 

--- a/static/app/views/explore/components/typeBadge.tsx
+++ b/static/app/views/explore/components/typeBadge.tsx
@@ -1,5 +1,3 @@
-import type {ReactNode} from 'react';
-
 import {Text} from '@sentry/scraps/text';
 
 import {t} from 'sentry/locale';
@@ -9,11 +7,11 @@ import {FieldKind, FieldValueType} from 'sentry/utils/fields';
 import {FieldValueKind} from 'sentry/views/discover/table/types';
 
 interface TypeBadgeProps {
-  deprecatedFields?: ReactNode[];
+  deprecatedFields?: React.ReactNode[];
   func?: ParsedFunction;
   isLogicFilter?: boolean;
   kind?: FieldKind;
-  label?: ReactNode;
+  label?: React.ReactNode;
   valueKind?: FieldValueKind;
   valueType?: FieldValueType;
 }

--- a/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
@@ -1,5 +1,3 @@
-import type {ReactNode} from 'react';
-
 import {act, render} from 'sentry-test/reactTestingLibrary';
 
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
@@ -23,7 +21,7 @@ import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryParamsProvider';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 
-function Wrapper({children}: {children: ReactNode}) {
+function Wrapper({children}: {children: React.ReactNode}) {
   return <SpansQueryParamsProvider>{children}</SpansQueryParamsProvider>;
 }
 

--- a/static/app/views/explore/exploreStateQueryParamsProvider.tsx
+++ b/static/app/views/explore/exploreStateQueryParamsProvider.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {useCallback, useMemo, useState} from 'react';
 
 import type {Sort} from 'sentry/utils/discover/fields';
@@ -15,7 +14,7 @@ import {
 import type {WritableQueryParams} from 'sentry/views/explore/queryParams/writableQueryParams';
 
 interface ExploreStateQueryParamsProviderProps {
-  children: ReactNode;
+  children: React.ReactNode;
   defaultAggregateFields: () => AggregateField[];
   defaultAggregateSortBys: (aggregateFields: AggregateField[]) => Sort[];
   defaultFields: () => string[];

--- a/static/app/views/explore/hooks/useAddToDashboard.spec.tsx
+++ b/static/app/views/explore/hooks/useAddToDashboard.spec.tsx
@@ -1,5 +1,3 @@
-import type {ReactNode} from 'react';
-
 import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {openAddToDashboardModal} from 'sentry/actionCreators/modal';
@@ -13,7 +11,7 @@ import {
 import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryParamsProvider';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 
-function Wrapper({children}: {children: ReactNode}) {
+function Wrapper({children}: {children: React.ReactNode}) {
   return <SpansQueryParamsProvider>{children}</SpansQueryParamsProvider>;
 }
 

--- a/static/app/views/explore/hooks/useAnalytics.tsx
+++ b/static/app/views/explore/hooks/useAnalytics.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useEffectEvent, useMemo, useRef, type RefObject} from 'react';
+import {useEffect, useEffectEvent, useMemo, useRef} from 'react';
 import * as Sentry from '@sentry/react';
 
 import {useOrganizationSeerSetup} from 'sentry/components/events/autofix/useOrganizationSeerSetup';
@@ -1081,7 +1081,7 @@ export function useMetricsAnalytics({
   ]);
 }
 
-function useBox<T>(value: T): RefObject<T> {
+function useBox<T>(value: T): React.RefObject<T> {
   const box = useRef(value);
   box.current = value;
   return box;

--- a/static/app/views/explore/hooks/useCrossEventQueries.spec.tsx
+++ b/static/app/views/explore/hooks/useCrossEventQueries.spec.tsx
@@ -1,4 +1,4 @@
-import {useMemo, type ReactNode} from 'react';
+import {useMemo} from 'react';
 
 import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
@@ -20,7 +20,7 @@ import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQuer
 const mockSetQueryParams = jest.fn();
 
 function Wrapper(crossEvents?: CrossEvent[]) {
-  return function ({children}: {children: ReactNode}) {
+  return function ({children}: {children: React.ReactNode}) {
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const [query] = useResettableState(defaultQuery);
 

--- a/static/app/views/explore/hooks/useExploreAggregatesTable.spec.tsx
+++ b/static/app/views/explore/hooks/useExploreAggregatesTable.spec.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 
 import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -10,7 +9,7 @@ import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryPar
 
 jest.mock('sentry/components/pageFilters/usePageFilters');
 
-function Wrapper({children}: {children: ReactNode}) {
+function Wrapper({children}: {children: React.ReactNode}) {
   return <SpansQueryParamsProvider>{children}</SpansQueryParamsProvider>;
 }
 describe('useExploreAggregatesTable', () => {

--- a/static/app/views/explore/hooks/useExploreSpansTable.spec.tsx
+++ b/static/app/views/explore/hooks/useExploreSpansTable.spec.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 
 import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -10,7 +9,7 @@ import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryPar
 
 jest.mock('sentry/components/pageFilters/usePageFilters');
 
-function Wrapper({children}: {children: ReactNode}) {
+function Wrapper({children}: {children: React.ReactNode}) {
   return <SpansQueryParamsProvider>{children}</SpansQueryParamsProvider>;
 }
 

--- a/static/app/views/explore/hooks/useExploreTimeseries.spec.tsx
+++ b/static/app/views/explore/hooks/useExploreTimeseries.spec.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
 
@@ -11,7 +10,7 @@ import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryPar
 
 jest.mock('sentry/components/pageFilters/usePageFilters');
 
-function Wrapper({children}: {children: ReactNode}) {
+function Wrapper({children}: {children: React.ReactNode}) {
   return <SpansQueryParamsProvider>{children}</SpansQueryParamsProvider>;
 }
 

--- a/static/app/views/explore/hooks/useTab.spec.tsx
+++ b/static/app/views/explore/hooks/useTab.spec.tsx
@@ -1,11 +1,9 @@
-import type {ReactNode} from 'react';
-
 import {act, renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
 import {Tab, useTab} from 'sentry/views/explore/hooks/useTab';
 import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryParamsProvider';
 
-function Wrapper({children}: {children: ReactNode}) {
+function Wrapper({children}: {children: React.ReactNode}) {
   return <SpansQueryParamsProvider>{children}</SpansQueryParamsProvider>;
 }
 

--- a/static/app/views/explore/logs/logsAutoRefresh.tsx
+++ b/static/app/views/explore/logs/logsAutoRefresh.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, type ReactNode} from 'react';
+import {Fragment, useEffect} from 'react';
 
 import {Switch} from '@sentry/scraps/switch';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -185,7 +185,7 @@ function getPreFlightDisableReason({
 
 function getTooltipMessage(
   reason: PreFlightDisableReason | AutoRefreshState | null
-): ReactNode {
+): React.ReactNode {
   switch (reason) {
     case 'rate_limit_initial':
       return tct(

--- a/static/app/views/explore/logs/logsFrozenContext.tsx
+++ b/static/app/views/explore/logs/logsFrozenContext.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode, ReactPortal} from 'react';
 import {useMemo} from 'react';
 
 import {ALL_ACCESS_PROJECTS} from 'sentry/components/pageFilters/constants';
@@ -55,23 +54,23 @@ export type LogsFrozenContextProviderProps =
   | LogsNotFrozenProviderProps;
 
 interface LogsFrozenForTracesProviderWithChildrenProps
-  extends ReactPortal, LogsFrozenForTracesProviderProps {}
+  extends React.ReactPortal, LogsFrozenForTracesProviderProps {}
 
 interface LogsFrozenForTraceProviderWithChildrenProps
-  extends ReactPortal, LogsFrozenForTraceProviderProps {}
+  extends React.ReactPortal, LogsFrozenForTraceProviderProps {}
 
 interface LogsFrozenForSpanProviderWithChildrenProps
-  extends ReactPortal, LogsFrozenForSpanProviderProps {}
+  extends React.ReactPortal, LogsFrozenForSpanProviderProps {}
 
 interface LogsFrozenForReplayProviderWithChildrenProps
-  extends ReactPortal, LogsFrozenForReplayProviderProps {}
+  extends React.ReactPortal, LogsFrozenForReplayProviderProps {}
 
 type LogsFrozenContextProviderWithChildrenProps =
   | LogsFrozenForTracesProviderWithChildrenProps
   | LogsFrozenForTraceProviderWithChildrenProps
   | LogsFrozenForSpanProviderWithChildrenProps
   | LogsFrozenForReplayProviderWithChildrenProps
-  | {children: ReactNode};
+  | {children: React.ReactNode};
 
 function isLogsFrozenForTracesProviderWithChildrenProps(
   value: LogsFrozenContextProviderWithChildrenProps

--- a/static/app/views/explore/logs/logsLocationQueryParamsProvider.tsx
+++ b/static/app/views/explore/logs/logsLocationQueryParamsProvider.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {useCallback, useMemo} from 'react';
 
 import {defined} from 'sentry/utils';
@@ -19,7 +18,7 @@ import type {ReadableQueryParamsOptions} from 'sentry/views/explore/queryParams/
 import type {WritableQueryParams} from 'sentry/views/explore/queryParams/writableQueryParams';
 
 interface LogsLocationQueryParamsProviderProps {
-  children: ReactNode;
+  children: React.ReactNode;
   // Will override the frozen params from the location if the key is provided.
   frozenParams?: Partial<ReadableQueryParamsOptions>;
 }

--- a/static/app/views/explore/logs/logsQueryParamsProvider.tsx
+++ b/static/app/views/explore/logs/logsQueryParamsProvider.tsx
@@ -1,5 +1,3 @@
-import type {ReactNode} from 'react';
-
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import {createDefinedContext} from 'sentry/utils/performance/contexts/utils';
 import {LogsAutoRefreshProvider} from 'sentry/views/explore/contexts/logs/logsAutoRefreshContext';
@@ -23,7 +21,7 @@ export const useLogsAnalyticsPageSource = _useLogsAnalyticsPageSource;
 
 interface LogsQueryParamsProviderProps {
   analyticsPageSource: LogsAnalyticsPageSource;
-  children: ReactNode;
+  children: React.ReactNode;
   source: 'location' | 'state';
   freeze?: LogsFrozenContextProviderProps;
   frozenParams?: Partial<ReadableQueryParams>;

--- a/static/app/views/explore/logs/logsStateQueryParamsProvider.tsx
+++ b/static/app/views/explore/logs/logsStateQueryParamsProvider.tsx
@@ -1,5 +1,3 @@
-import type {ReactNode} from 'react';
-
 import {defaultLogFields} from 'sentry/views/explore/contexts/logs/fields';
 import {defaultSortBys} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
 import {ExploreStateQueryParamsProvider} from 'sentry/views/explore/exploreStateQueryParamsProvider';
@@ -11,7 +9,7 @@ import {defaultGroupBys} from 'sentry/views/explore/queryParams/groupBy';
 import type {ReadableQueryParamsOptions} from 'sentry/views/explore/queryParams/readableQueryParams';
 
 interface LogsStateQueryParamsProviderProps {
-  children: ReactNode;
+  children: React.ReactNode;
   frozenParams?: Partial<ReadableQueryParamsOptions>;
 }
 

--- a/static/app/views/explore/logs/logsToolbar.spec.tsx
+++ b/static/app/views/explore/logs/logsToolbar.spec.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {initializeLogsTest} from 'sentry-fixture/log';
 
 import {
@@ -15,7 +14,7 @@ import {LogsToolbar} from 'sentry/views/explore/logs/logsToolbar';
 import {useQueryParamsMode} from 'sentry/views/explore/queryParams/context';
 import {Mode} from 'sentry/views/explore/queryParams/mode';
 
-function Wrapper({children}: {children: ReactNode}) {
+function Wrapper({children}: {children: React.ReactNode}) {
   return (
     <LogsQueryParamsProvider
       analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -6,8 +6,6 @@ import {
   useMemo,
   useRef,
   useState,
-  type CSSProperties,
-  type RefObject,
 } from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
@@ -755,7 +753,7 @@ export function LoadingRenderer({bytesScanned}: {bytesScanned?: number}) {
 }
 
 const StyledLoadingIndicator = styled(LoadingIndicator)<{
-  margin: CSSProperties['margin'];
+  margin: React.CSSProperties['margin'];
 }>`
   ${p => p.margin && `margin: ${p.margin}`};
 `;
@@ -809,7 +807,7 @@ function BackToTopButton({
   );
 }
 
-function useBox<T>(value: T): RefObject<T> {
+function useBox<T>(value: T): React.RefObject<T> {
   const box = useRef(value);
   box.current = value;
   return box;

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps, SyntheticEvent} from 'react';
 import React, {Fragment, memo, useLayoutEffect, useMemo, useRef, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import classNames from 'classnames';
@@ -164,7 +163,7 @@ export const LogRowContent = memo(function LogRowContent({
   const [shouldRenderHoverElements, setShouldRenderHoverElements] = useState(false);
 
   // This only applies in embedded views where clicking doesn't expand row details.
-  function onClick(event: SyntheticEvent) {
+  function onClick(event: React.SyntheticEvent) {
     if (onEmbeddedRowClick && event.nativeEvent instanceof MouseEvent) {
       event.preventDefault();
       onEmbeddedRowClick(
@@ -175,7 +174,7 @@ export const LogRowContent = memo(function LogRowContent({
     }
   }
 
-  function onPointerUp(event: SyntheticEvent) {
+  function onPointerUp(event: React.SyntheticEvent) {
     // do not expand the context menu if...
     if (event.target instanceof Element) {
       // ... you clicked a button
@@ -278,7 +277,7 @@ export const LogRowContent = memo(function LogRowContent({
     logEnd,
   };
 
-  const rowInteractProps: ComponentProps<typeof LogTableRow> = isPseudoRow
+  const rowInteractProps: React.ComponentProps<typeof LogTableRow> = isPseudoRow
     ? {isClickable: false}
     : blockRowExpanding
       ? onEmbeddedRowClick

--- a/static/app/views/explore/logs/useLogsAggregatesTable.spec.tsx
+++ b/static/app/views/explore/logs/useLogsAggregatesTable.spec.tsx
@@ -1,5 +1,3 @@
-import type {ReactNode} from 'react';
-
 import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
@@ -7,7 +5,7 @@ import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
 import {useLogsAggregatesTable} from 'sentry/views/explore/logs/useLogsAggregatesTable';
 
-function Wrapper({children}: {children: ReactNode}) {
+function Wrapper({children}: {children: React.ReactNode}) {
   return (
     <LogsQueryParamsProvider
       analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}

--- a/static/app/views/explore/logs/useLogsTimeseries.spec.tsx
+++ b/static/app/views/explore/logs/useLogsTimeseries.spec.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
 
@@ -12,7 +11,7 @@ import {useLogsTimeseries} from 'sentry/views/explore/logs/useLogsTimeseries';
 
 jest.mock('sentry/components/pageFilters/usePageFilters');
 
-function Wrapper({children}: {children: ReactNode}) {
+function Wrapper({children}: {children: React.ReactNode}) {
   return (
     <LogsQueryParamsProvider
       analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}

--- a/static/app/views/explore/logs/useStreamingTimeseriesResult.tsx
+++ b/static/app/views/explore/logs/useStreamingTimeseriesResult.tsx
@@ -1,4 +1,3 @@
-import type {RefObject} from 'react';
 import {useEffect, useMemo, useRef} from 'react';
 import isEqual from 'lodash/isEqual';
 import pick from 'lodash/pick';
@@ -197,7 +196,7 @@ function createBufferFromTableData(
   timeseriesIngestDelay: bigint,
   groupBys: readonly string[],
   groupBuffers: Record<string, BufferedTimeseriesGroup>,
-  lastProcessedBucketRef: RefObject<number | null>,
+  lastProcessedBucketRef: React.RefObject<number | null>,
   autoRefresh: boolean,
   aggregateKey?: string,
   originalTimeseries?: TimeSeries[]

--- a/static/app/views/explore/metrics/hooks/testUtils.tsx
+++ b/static/app/views/explore/metrics/hooks/testUtils.tsx
@@ -1,5 +1,3 @@
-import type {ReactNode} from 'react';
-
 import {
   defaultMetricQuery,
   type BaseMetricQuery,
@@ -9,7 +7,7 @@ import {MetricsQueryParamsProvider} from 'sentry/views/explore/metrics/metricsQu
 import {MultiMetricsQueryParamsProvider} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
 
 interface MockMetricQueryParamsContextProps {
-  children: ReactNode;
+  children: React.ReactNode;
   metricQuery?: Partial<BaseMetricQuery>;
   traceMetric?: TraceMetric;
 }

--- a/static/app/views/explore/metrics/hooks/useMetricReferences.spec.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricReferences.spec.tsx
@@ -1,5 +1,3 @@
-import type {ReactNode} from 'react';
-
 import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
@@ -13,7 +11,7 @@ import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 
 import {useMetricReferences} from './useMetricReferences';
 
-function Wrapper({children}: {children: ReactNode}) {
+function Wrapper({children}: {children: React.ReactNode}) {
   return <MultiMetricsQueryParamsProvider>{children}</MultiMetricsQueryParamsProvider>;
 }
 

--- a/static/app/views/explore/metrics/hooks/useMetricTimeseries.spec.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricTimeseries.spec.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
 
@@ -19,7 +18,7 @@ jest.mock('sentry/components/pageFilters/usePageFilters');
 function MockMetricQueryParamsContextWithMultiVisualize({
   children,
 }: {
-  children: ReactNode;
+  children: React.ReactNode;
 }) {
   const mockQueryParams = new ReadableQueryParams({
     extrapolate: true,

--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.spec.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.spec.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 import {
   createTraceMetricFixtures,
@@ -26,7 +25,7 @@ function createWrapper({
   queryParams: ReadableQueryParams;
   traceMetric: TraceMetric;
 }) {
-  return function Wrapper({children}: {children: ReactNode}) {
+  return function Wrapper({children}: {children: React.ReactNode}) {
     return (
       <MultiMetricsQueryParamsProvider>
         <MetricsQueryParamsProvider

--- a/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTableHeader.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTableHeader.tsx
@@ -1,5 +1,3 @@
-import type {ReactNode} from 'react';
-
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {t} from 'sentry/locale';
@@ -62,7 +60,7 @@ function FieldHeaderCellWrapper({
   setSorts,
   embedded = false,
 }: {
-  children: ReactNode;
+  children: React.ReactNode;
   field: SampleTableColumnKey;
   index: number;
   setSorts: (sorts: Sort[]) => void;
@@ -113,8 +111,8 @@ function FieldHeaderCellWrapper({
   );
 }
 
-function getFieldLabel(field: SampleTableColumnKey): ReactNode {
-  const fieldLabels: Record<SampleTableColumnKey, () => ReactNode> = {
+function getFieldLabel(field: SampleTableColumnKey): React.ReactNode {
+  const fieldLabels: Record<SampleTableColumnKey, () => React.ReactNode> = {
     [VirtualTableSampleColumnKey.EXPAND_ROW]: () => null,
     [TraceMetricKnownFieldKey.TRACE]: () => t('Trace ID'),
     [TraceMetricKnownFieldKey.METRIC_VALUE]: () => t('Value'),

--- a/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTableRow.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTableRow.tsx
@@ -1,4 +1,4 @@
-import {useRef, useState, type ReactNode} from 'react';
+import {useRef, useState} from 'react';
 
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
@@ -60,7 +60,7 @@ function FieldCellWrapper({
   index,
   embedded = false,
 }: {
-  children: ReactNode;
+  children: React.ReactNode;
   field: SampleTableColumnKey;
   index: number;
   row: TraceMetricEventsResponseItem;
@@ -209,7 +209,7 @@ export function SampleTableRow({
     );
   };
 
-  const renderMap: Record<SampleTableColumnKey, () => ReactNode> = {
+  const renderMap: Record<SampleTableColumnKey, () => React.ReactNode> = {
     [VirtualTableSampleColumnKey.EXPAND_ROW]: renderExpandRowCell,
     [TraceMetricKnownFieldKey.TRACE]: renderTraceCell,
     [TraceMetricKnownFieldKey.TIMESTAMP]: () =>

--- a/static/app/views/explore/metrics/metricPanel/index.spec.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.spec.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
 import {
   createTraceMetricFixtures,
@@ -26,7 +25,7 @@ function createWrapper({
   queryParams: ReadableQueryParams;
   traceMetric: TraceMetric;
 }) {
-  return function Wrapper({children}: {children: ReactNode}) {
+  return function Wrapper({children}: {children: React.ReactNode}) {
     return (
       <MultiMetricsQueryParamsProvider>
         <MetricsQueryParamsProvider

--- a/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.spec.tsx
@@ -1,4 +1,4 @@
-import {useState, type ReactNode} from 'react';
+import {useState} from 'react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {
@@ -38,7 +38,7 @@ function createWrapper(options: WrapperOptions = {}) {
     aggregateSortBys: [{field: 'sum(value,test_metric,distribution,-)', kind: 'desc'}],
   });
 
-  return function Wrapper({children}: {children: ReactNode}) {
+  return function Wrapper({children}: {children: React.ReactNode}) {
     const [stateQueryParams, setStateQueryParams] = useState(
       options.queryParams ?? defaultQueryParams
     );

--- a/static/app/views/explore/metrics/metricToolbar/index.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/index.spec.tsx
@@ -1,4 +1,3 @@
-import {type ReactNode} from 'react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -17,7 +16,7 @@ function Wrapper({
   children,
   queryParams,
 }: {
-  children: ReactNode;
+  children: React.ReactNode;
   queryParams: ReadableQueryParams;
 }) {
   return (
@@ -78,7 +77,7 @@ describe('MetricToolbar', () => {
       />,
       {
         organization,
-        additionalWrapper: ({children}: {children: ReactNode}) => (
+        additionalWrapper: ({children}: {children: React.ReactNode}) => (
           <Wrapper queryParams={queryParams}>{children}</Wrapper>
         ),
       }
@@ -123,7 +122,7 @@ describe('MetricToolbar', () => {
       />,
       {
         organization,
-        additionalWrapper: ({children}: {children: ReactNode}) => (
+        additionalWrapper: ({children}: {children: React.ReactNode}) => (
           <Wrapper queryParams={queryParams}>{children}</Wrapper>
         ),
       }

--- a/static/app/views/explore/metrics/metricToolbar/visualizeLabel.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/visualizeLabel.tsx
@@ -1,4 +1,3 @@
-import type {MouseEventHandler} from 'react';
 import styled from '@emotion/styled';
 
 import {Container, Flex} from '@sentry/scraps/layout';
@@ -9,7 +8,7 @@ import type {Visualize} from 'sentry/views/explore/queryParams/visualize';
 
 interface VisualizeLabelProps {
   label: string;
-  onClick: MouseEventHandler<HTMLDivElement>;
+  onClick: React.MouseEventHandler<HTMLDivElement>;
   visualize: Visualize;
   disableCollapse?: boolean;
 }

--- a/static/app/views/explore/metrics/metricsFrozenContext.tsx
+++ b/static/app/views/explore/metrics/metricsFrozenContext.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {useMemo} from 'react';
 
 import {ALL_ACCESS_PROJECTS} from 'sentry/components/pageFilters/constants';
@@ -29,7 +28,7 @@ const [_MetricsFrozenContextProvider, _useMetricsFrozenContext, MetricsFrozenCon
 
 export interface MetricsFrozenForTracesProviderProps {
   traceIds: string[];
-  children?: ReactNode;
+  children?: React.ReactNode;
   tracePeriod?: TracePeriod;
 }
 

--- a/static/app/views/explore/metrics/metricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/metricsQueryParams.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {useCallback, useMemo} from 'react';
 
 import {defined} from 'sentry/utils';
@@ -39,7 +38,7 @@ const [_MetricMetadataContextProvider, useTraceMetricContext, TraceMetricContext
   });
 
 interface MetricsQueryParamsProviderProps {
-  children: ReactNode;
+  children: React.ReactNode;
   queryParams: ReadableQueryParams;
   removeMetric: () => void;
   setQueryParams: (queryParams: ReadableQueryParams) => void;

--- a/static/app/views/explore/metrics/metricsStateQueryParamsProvider.tsx
+++ b/static/app/views/explore/metrics/metricsStateQueryParamsProvider.tsx
@@ -1,5 +1,3 @@
-import type {ReactNode} from 'react';
-
 import {ExploreStateQueryParamsProvider} from 'sentry/views/explore/exploreStateQueryParamsProvider';
 import {
   defaultAggregateFields,
@@ -10,7 +8,7 @@ import {
 import type {ReadableQueryParamsOptions} from 'sentry/views/explore/queryParams/readableQueryParams';
 
 interface MetricsStateQueryParamsProviderProps {
-  children: ReactNode;
+  children: React.ReactNode;
   frozenParams?: Partial<ReadableQueryParamsOptions>;
 }
 

--- a/static/app/views/explore/metrics/multiMetricsQueryParams.spec.tsx
+++ b/static/app/views/explore/metrics/multiMetricsQueryParams.spec.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {act, renderHookWithProviders, screen} from 'sentry-test/reactTestingLibrary';
@@ -31,7 +30,7 @@ function TestableMetricComponent() {
   );
 }
 
-function Wrapper({children}: {children: ReactNode}) {
+function Wrapper({children}: {children: React.ReactNode}) {
   const organization = useOrganization();
   const hasEquations = canUseMetricsEquations(organization);
   return (

--- a/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
+++ b/static/app/views/explore/metrics/multiMetricsQueryParams.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, useState, type ReactNode} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 import type {Location} from 'history';
 
 import {defined} from 'sentry/utils';
@@ -35,7 +35,7 @@ const [
 });
 
 interface MultiMetricsQueryParamsProviderProps {
-  children: ReactNode;
+  children: React.ReactNode;
   allowUpTo?: number;
   hasEquations?: boolean;
 }
@@ -87,7 +87,7 @@ function getMultiMetricsQueryParamsFromLocation(
 }
 
 interface LocalMultiMetricsQueryParamsProviderProps {
-  children: ReactNode;
+  children: React.ReactNode;
   /**
    * Initial metric queries to seed local state. Typically derived from a
    * saved aggregate string via `parseAggregateExpression`. If empty, the

--- a/static/app/views/explore/queryParams/context.spec.tsx
+++ b/static/app/views/explore/queryParams/context.spec.tsx
@@ -1,4 +1,4 @@
-import {useMemo, type ReactNode} from 'react';
+import {useMemo} from 'react';
 
 import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
@@ -21,7 +21,7 @@ import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQuer
 
 const mockSetQueryParams = jest.fn();
 
-function Wrapper({children}: {children: ReactNode}) {
+function Wrapper({children}: {children: React.ReactNode}) {
   const [query] = useResettableState(defaultQuery);
 
   const readableQueryParams = useMemo(

--- a/static/app/views/explore/queryParams/context.tsx
+++ b/static/app/views/explore/queryParams/context.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import type {Location} from 'history';
 
@@ -41,7 +40,7 @@ const [_QueryParamsContextProvider, useQueryParamsContext, QueryParamsContext] =
   });
 
 interface QueryParamsContextProps {
-  children: ReactNode;
+  children: React.ReactNode;
   isUsingDefaultFields: boolean;
   queryParams: ReadableQueryParams;
   setQueryParams: (queryParams: WritableQueryParams) => void;

--- a/static/app/views/explore/spans/content.tsx
+++ b/static/app/views/explore/spans/content.tsx
@@ -1,5 +1,4 @@
 import {Fragment, useMemo} from 'react';
-import type {ReactNode} from 'react';
 import * as Sentry from '@sentry/react';
 
 import {Grid, Stack} from '@sentry/scraps/layout';
@@ -117,7 +116,7 @@ function SpansTabWrapper({children}: SpansTabContextProps) {
 }
 
 interface SpansTabContextProps {
-  children: ReactNode;
+  children: React.ReactNode;
 }
 
 function SpansTabTourProvider({children}: SpansTabContextProps) {

--- a/static/app/views/explore/spans/spansExport.spec.tsx
+++ b/static/app/views/explore/spans/spansExport.spec.tsx
@@ -1,5 +1,3 @@
-import type {ReactNode} from 'react';
-
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
@@ -11,7 +9,7 @@ jest.mock('sentry/views/discover/utils', () => ({
   downloadAsCsv: jest.fn(),
 }));
 
-function Wrapper({children}: {children: ReactNode}) {
+function Wrapper({children}: {children: React.ReactNode}) {
   return <SpansQueryParamsProvider>{children}</SpansQueryParamsProvider>;
 }
 

--- a/static/app/views/explore/spans/spansQueryParamsProvider.tsx
+++ b/static/app/views/explore/spans/spansQueryParamsProvider.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {useCallback, useMemo, useRef} from 'react';
 import type {Location} from 'history';
 
@@ -20,7 +19,7 @@ function isSameLocation(a: Location, b: Location): boolean {
 }
 
 interface SpansQueryParamsProviderProps {
-  children: ReactNode;
+  children: React.ReactNode;
 }
 
 export function SpansQueryParamsProvider({children}: SpansQueryParamsProviderProps) {

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {AutofixSetupFixture} from 'sentry-fixture/autofixSetupFixture';
 
 import {initializeOrg} from 'sentry-test/initializeOrg';
@@ -23,7 +22,7 @@ import {
 import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryParamsProvider';
 import {SpansTabContent} from 'sentry/views/explore/spans/spansTab';
 
-function Wrapper({children}: {children: ReactNode}) {
+function Wrapper({children}: {children: React.ReactNode}) {
   return <SpansQueryParamsProvider>{children}</SpansQueryParamsProvider>;
 }
 

--- a/static/app/views/explore/spans/spansTabSearchSection.tsx
+++ b/static/app/views/explore/spans/spansTabSearchSection.tsx
@@ -1,4 +1,4 @@
-import {Fragment, memo, useEffect, useEffectEvent, useMemo, type Key} from 'react';
+import {Fragment, memo, useEffect, useEffectEvent, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
@@ -73,7 +73,7 @@ function CrossEventQueryingDropdown() {
   const crossEvents = useQueryParamsCrossEvents();
   const setCrossEvents = useSetQueryParamsCrossEvents();
 
-  const onAction = (key: Key) => {
+  const onAction = (key: React.Key) => {
     if (typeof key !== 'string' || !isCrossEventType(key)) {
       return;
     }

--- a/static/app/views/explore/tables/fieldRenderer.spec.tsx
+++ b/static/app/views/explore/tables/fieldRenderer.spec.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
@@ -24,7 +23,7 @@ const mockedEventData = {
   transaction: 'GET /foo',
 };
 
-function Wrapper({children}: {children: ReactNode}) {
+function Wrapper({children}: {children: React.ReactNode}) {
   return <SpansQueryParamsProvider>{children}</SpansQueryParamsProvider>;
 }
 

--- a/static/app/views/explore/tables/tracesTable/styles.tsx
+++ b/static/app/views/explore/tables/tracesTable/styles.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -14,11 +13,11 @@ export const StyledPanel = styled(Panel)`
   overflow: hidden;
 `;
 
-interface StyledPanelHeaderProps extends ComponentProps<typeof PanelHeader> {
-  justify: ComponentProps<typeof Flex>['justify'];
+interface StyledPanelHeaderProps extends React.ComponentProps<typeof PanelHeader> {
+  justify: React.ComponentProps<typeof Flex>['justify'];
   children?: React.ReactNode;
   lightText?: boolean;
-  radius?: ComponentProps<typeof Flex>['radius'];
+  radius?: React.ComponentProps<typeof Flex>['radius'];
 }
 
 export function StyledPanelHeader({

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 
@@ -28,7 +27,7 @@ import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryParamsProvider';
 import {ExploreToolbar} from 'sentry/views/explore/toolbar';
 
-function Wrapper({children}: {children: ReactNode}) {
+function Wrapper({children}: {children: React.ReactNode}) {
   return <SpansQueryParamsProvider>{children}</SpansQueryParamsProvider>;
 }
 

--- a/static/app/views/explore/toolbar/toolbarVisualize.tsx
+++ b/static/app/views/explore/toolbar/toolbarVisualize.tsx
@@ -1,4 +1,3 @@
-import type {MouseEventHandler, ReactNode} from 'react';
 import {useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import cloneDeep from 'lodash/cloneDeep';
@@ -161,7 +160,7 @@ export function ToolbarVisualize({
 }
 
 interface VisualizeDropdownProps {
-  label: ReactNode;
+  label: React.ReactNode;
   onReplace: (visualize: Visualize) => void;
   visualize: Visualize;
   dragColumnId?: number;
@@ -262,7 +261,7 @@ function ToolbarVisualizeItem({
 
 interface VisualizeLabelProps {
   index: number;
-  onClick: MouseEventHandler<HTMLDivElement>;
+  onClick: React.MouseEventHandler<HTMLDivElement>;
   visualize: Visualize;
 }
 

--- a/static/app/views/feedback/feedbackListPage.tsx
+++ b/static/app/views/feedback/feedbackListPage.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {Fragment, useEffect, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -46,7 +45,7 @@ function PageContent({
   hasFeedbackContent,
   content,
 }: {
-  content: ReactNode;
+  content: React.ReactNode;
   hasFeedbackContent: boolean;
   hideTop: boolean;
 }) {

--- a/static/app/views/insights/browser/webVitals/components/performanceScoreRing.tsx
+++ b/static/app/views/insights/browser/webVitals/components/performanceScoreRing.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {useMemo} from 'react';
 import type {SerializedStyles, Theme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -70,7 +69,7 @@ export function PerformanceScoreRing({
   const radius = size / 2 - barWidth / 2;
   const circumference = 2 * Math.PI * radius;
 
-  const rings = useMemo<ReactNode[]>(() => {
+  const rings = useMemo<React.ReactNode[]>(() => {
     const sumMaxValues = values
       .map(({maxValue}) => maxValue)
       .reduce((acc, val) => acc + val, 0);

--- a/static/app/views/insights/cache/components/tables/spanSamplesTable.tsx
+++ b/static/app/views/insights/cache/components/tables/spanSamplesTable.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps} from 'react';
 import {useTheme, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
@@ -78,8 +77,8 @@ interface Props {
   error?: Error | null;
   highlightedSpanId?: string;
   meta?: EventsMetaType;
-  onSampleMouseOut?: ComponentProps<typeof GridEditable>['onRowMouseOut'];
-  onSampleMouseOver?: ComponentProps<typeof GridEditable>['onRowMouseOver'];
+  onSampleMouseOut?: React.ComponentProps<typeof GridEditable>['onRowMouseOut'];
+  onSampleMouseOver?: React.ComponentProps<typeof GridEditable>['onRowMouseOver'];
 }
 
 export function SpanSamplesTable({

--- a/static/app/views/insights/common/components/chart.tsx
+++ b/static/app/views/insights/common/components/chart.tsx
@@ -1,4 +1,3 @@
-import type {RefObject} from 'react';
 import {createContext, useContext, useEffect, useMemo, useReducer, useRef} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -106,7 +105,7 @@ type Props = {
   onMouseOver?: EChartMouseOverHandler;
   previousData?: Series[];
   rateUnit?: RateUnit;
-  ref?: RefObject<ReactEchartsRef>;
+  ref?: React.RefObject<ReactEchartsRef>;
   scatterPlot?: Series[];
   showLegend?: boolean;
   stacked?: boolean;

--- a/static/app/views/insights/common/components/fullSpanDescription.tsx
+++ b/static/app/views/insights/common/components/fullSpanDescription.tsx
@@ -1,4 +1,4 @@
-import {Fragment, type ReactNode} from 'react';
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import {CodeBlock} from '@sentry/scraps/code';
@@ -106,7 +106,7 @@ export function FullSpanDescription({
 }
 
 type TruncatedQueryClipBoxProps = {
-  children: ReactNode;
+  children: React.ReactNode;
   group: string | null | undefined;
 };
 

--- a/static/app/views/insights/common/views/spans/selectors/actionSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/actionSelector.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import omit from 'lodash/omit';
 
 import {CompactSelect, type SelectOption} from '@sentry/scraps/compactSelect';
@@ -123,7 +122,7 @@ const HTTP_ACTION_OPTIONS: Array<SelectOption<string>> = [
   })),
 ];
 
-const LABEL_FOR_MODULE_NAME: Record<ModuleName, ReactNode> = {
+const LABEL_FOR_MODULE_NAME: Record<ModuleName, React.ReactNode> = {
   http: t('HTTP Method'),
   db: t('Command'),
   cache: t('Action'),

--- a/static/app/views/insights/common/views/spans/selectors/subregionSelector.tsx
+++ b/static/app/views/insights/common/views/spans/selectors/subregionSelector.tsx
@@ -1,5 +1,3 @@
-import type {ComponentProps} from 'react';
-
 import {
   CompactSelect,
   type SelectOption,
@@ -20,7 +18,7 @@ import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
 import {SpanFields, subregionCodeToName} from 'sentry/views/insights/types';
 
 type Props = {
-  size?: ComponentProps<typeof CompactSelect>['size'];
+  size?: React.ComponentProps<typeof CompactSelect>['size'];
 };
 
 export function SubregionSelector({size}: Props) {

--- a/static/app/views/insights/crons/components/cronsLandingPanel.tsx
+++ b/static/app/views/insights/crons/components/cronsLandingPanel.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useRef, type ComponentType} from 'react';
+import {Fragment, useEffect, useRef} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
@@ -31,7 +31,7 @@ function GuideContent({
   Guide,
   containerRef,
 }: {
-  Guide: ComponentType;
+  Guide: React.ComponentType;
   containerRef: React.RefObject<HTMLDivElement | null>;
 }) {
   return (

--- a/static/app/views/insights/database/utils/formatMongoDBQuery.tsx
+++ b/static/app/views/insights/database/utils/formatMongoDBQuery.tsx
@@ -1,4 +1,3 @@
-import type {ReactElement} from 'react';
 import * as Sentry from '@sentry/react';
 import {jsonrepair} from 'jsonrepair';
 
@@ -36,8 +35,8 @@ export function formatMongoDBQuery(query: string, command: string) {
     }
   }
 
-  const tokens: ReactElement[] = [];
-  const tempTokens: ReactElement[] = [];
+  const tokens: React.ReactElement[] = [];
+  const tempTokens: React.ReactElement[] = [];
 
   const queryEntries = Object.entries(queryObject);
   queryEntries.forEach(([key, val]) => {
@@ -144,6 +143,10 @@ function jsonToTokenizedString(value: JSONValue | JSONValue[], key?: string): st
   return '';
 }
 
-function stringToToken(str: string, keyProp: string, isBold?: boolean): ReactElement {
+function stringToToken(
+  str: string,
+  keyProp: string,
+  isBold?: boolean
+): React.ReactElement {
   return isBold ? <b key={keyProp}>{str}</b> : <span key={keyProp}>{str}</span>;
 }

--- a/static/app/views/insights/http/components/tables/spanSamplesTable.tsx
+++ b/static/app/views/insights/http/components/tables/spanSamplesTable.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps} from 'react';
 import {useTheme, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
@@ -62,8 +61,8 @@ interface Props {
   error?: Error | null;
   highlightedSpanId?: string;
   meta?: EventsMetaType;
-  onSampleMouseOut?: ComponentProps<typeof GridEditable>['onRowMouseOut'];
-  onSampleMouseOver?: ComponentProps<typeof GridEditable>['onRowMouseOver'];
+  onSampleMouseOut?: React.ComponentProps<typeof GridEditable>['onRowMouseOut'];
+  onSampleMouseOver?: React.ComponentProps<typeof GridEditable>['onRowMouseOver'];
   referrer?: string;
 }
 

--- a/static/app/views/insights/mobile/common/components/deviceClassSelector.tsx
+++ b/static/app/views/insights/mobile/common/components/deviceClassSelector.tsx
@@ -1,5 +1,3 @@
-import type {ComponentProps} from 'react';
-
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
@@ -15,7 +13,7 @@ import {ModuleName} from 'sentry/views/insights/types';
 interface Props {
   clearSpansTableCursor?: boolean;
   moduleName?: ModuleName;
-  size?: ComponentProps<typeof CompactSelect>['size'];
+  size?: React.ComponentProps<typeof CompactSelect>['size'];
 }
 
 export function DeviceClassSelector({

--- a/static/app/views/insights/mobile/screenload/components/metricsRibbon.tsx
+++ b/static/app/views/insights/mobile/screenload/components/metricsRibbon.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps} from 'react';
 import {useMemo} from 'react';
 import styled from '@emotion/styled';
 
@@ -21,7 +20,7 @@ type TableData = {
 interface BlockProps {
   dataKey: string | ((data?: TableData['data']) => number | undefined);
   title: string;
-  unit: ComponentProps<typeof MetricReadout>['unit'];
+  unit: React.ComponentProps<typeof MetricReadout>['unit'];
   allowZero?: boolean;
   preferredPolarity?: Polarity;
 }

--- a/static/app/views/insights/pages/conversations/components/conversationsTable.tsx
+++ b/static/app/views/insights/pages/conversations/components/conversationsTable.tsx
@@ -1,4 +1,4 @@
-import {Fragment, memo, useCallback, type ComponentPropsWithRef} from 'react';
+import {Fragment, memo, useCallback} from 'react';
 import styled from '@emotion/styled';
 
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
@@ -152,7 +152,7 @@ function cleanMarkdownForCell(text: string): string {
     .trim();
 }
 
-type CellContentProps = ComponentPropsWithRef<'div'> & {
+type CellContentProps = React.ComponentPropsWithRef<'div'> & {
   text: string;
 };
 

--- a/static/app/views/insights/pages/domainOverviewPageProviders.tsx
+++ b/static/app/views/insights/pages/domainOverviewPageProviders.tsx
@@ -1,5 +1,3 @@
-import type {ReactNode} from 'react';
-
 import {NoProjectMessage} from 'sentry/components/noProjectMessage';
 import {PageFiltersContainer} from 'sentry/components/pageFilters/container';
 import type {DatePageFilterProps} from 'sentry/components/pageFilters/date/datePageFilter';
@@ -11,7 +9,7 @@ import {OVERVIEW_PAGE_TITLE} from 'sentry/views/insights/pages/settings';
 import {useDomainViewFilters} from 'sentry/views/insights/pages/useFilters';
 
 interface DomainOverviewPageProvidersProps {
-  children: ReactNode;
+  children: React.ReactNode;
   maxPickableDays: DatePageFilterProps['maxPickableDays'];
 }
 

--- a/static/app/views/insights/pages/platform/shared/layout.tsx
+++ b/static/app/views/insights/pages/platform/shared/layout.tsx
@@ -1,4 +1,3 @@
-import {type ReactNode} from 'react';
 import styled from '@emotion/styled';
 
 import Feature from 'sentry/components/acl/feature';
@@ -37,7 +36,7 @@ function getFreeTextFromQuery(query: string) {
 }
 
 interface PlatformLandingPageLayoutProps {
-  children: ReactNode;
+  children: React.ReactNode;
   datePageFilterProps: DatePageFilterProps;
 }
 

--- a/static/app/views/insights/queues/components/tables/messageSpanSamplesTable.tsx
+++ b/static/app/views/insights/queues/components/tables/messageSpanSamplesTable.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps} from 'react';
 import {useTheme, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
@@ -105,8 +104,8 @@ interface Props {
   error?: Error | null;
   highlightedSpanId?: string;
   meta?: EventsMetaType;
-  onSampleMouseOut?: ComponentProps<typeof GridEditable>['onRowMouseOut'];
-  onSampleMouseOver?: ComponentProps<typeof GridEditable>['onRowMouseOver'];
+  onSampleMouseOut?: React.ComponentProps<typeof GridEditable>['onRowMouseOut'];
+  onSampleMouseOver?: React.ComponentProps<typeof GridEditable>['onRowMouseOver'];
 }
 
 export function MessageSpanSamplesTable({

--- a/static/app/views/insights/sessions/components/chartMap.tsx
+++ b/static/app/views/insights/sessions/components/chartMap.tsx
@@ -1,5 +1,3 @@
-import type {ReactElement} from 'react';
-
 import CrashFreeSessionsChartWidget from 'sentry/views/insights/common/components/widgets/crashFreeSessionsChartWidget';
 import NewAndResolvedIssueChartWidget from 'sentry/views/insights/common/components/widgets/newAndResolvedIssueChartWidget';
 import ReleaseNewIssuesChartWidget from 'sentry/views/insights/common/components/widgets/releaseNewIssuesChartWidget';
@@ -16,7 +14,7 @@ import type {CHART_TITLES} from 'sentry/views/insights/sessions/settings';
 
 export const CHART_MAP: Record<
   keyof typeof CHART_TITLES,
-  (props: LoadableChartWidgetProps) => ReactElement
+  (props: LoadableChartWidgetProps) => React.ReactElement
 > = {
   CrashFreeSessionsChartWidget,
   UnhealthySessionsChartWidget,

--- a/static/app/views/insights/sessions/components/tables/releaseHealthTable.tsx
+++ b/static/app/views/insights/sessions/components/tables/releaseHealthTable.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo, type ReactNode} from 'react';
+import {useCallback, useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
@@ -130,7 +130,7 @@ export function ReleaseHealthTable({data, isError, isLoading, location, meta}: P
         );
       }
       if (!meta?.fields) {
-        return value as ReactNode;
+        return value as React.ReactNode;
       }
 
       const renderer = getFieldRenderer(column.key, meta.fields, false);

--- a/static/app/views/issueDetails/actions/index.tsx
+++ b/static/app/views/issueDetails/actions/index.tsx
@@ -1,4 +1,3 @@
-import type {MouseEvent} from 'react';
 import {Fragment, useMemo} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -385,8 +384,8 @@ export function GroupActions({group, project, disabled, event}: GroupActionsProp
     ));
   };
 
-  const handleClick = (onClick: (event?: MouseEvent) => void) => {
-    return function (innerEvent: MouseEvent) {
+  const handleClick = (onClick: (event?: React.MouseEvent) => void) => {
+    return function (innerEvent: React.MouseEvent) {
       if (disabled) {
         innerEvent.preventDefault();
         innerEvent.stopPropagation();

--- a/static/app/views/issueDetails/configurationIssues/sourceMapIssues/diagnosisSection.tsx
+++ b/static/app/views/issueDetails/configurationIssues/sourceMapIssues/diagnosisSection.tsx
@@ -1,5 +1,3 @@
-import type {ReactNode} from 'react';
-
 import {LinkButton} from '@sentry/scraps/button';
 import {InlineCode} from '@sentry/scraps/code';
 import {Stack} from '@sentry/scraps/layout';
@@ -16,7 +14,7 @@ import {t, tct} from 'sentry/locale';
 
 function getDiagnosisMessage(
   data: SourceMapDebugBlueThunderResponse | undefined
-): ReactNode | null {
+): React.ReactNode | null {
   if (!data) {
     return (
       <Text>{t('Unable to load source map diagnostic information for this event.')}</Text>
@@ -168,7 +166,7 @@ interface DiagnosisSectionProps {
 export function DiagnosisSection({sourceMapQuery}: DiagnosisSectionProps) {
   const {data, isLoading, isError} = sourceMapQuery;
 
-  function renderContent(): ReactNode {
+  function renderContent(): React.ReactNode {
     if (isLoading) {
       return <LoadingIndicator mini />;
     }

--- a/static/app/views/issueDetails/groupDistributions/groupDistributionsSearchInput.tsx
+++ b/static/app/views/issueDetails/groupDistributions/groupDistributionsSearchInput.tsx
@@ -1,5 +1,3 @@
-import type {Dispatch, SetStateAction} from 'react';
-
 import {InputGroup} from '@sentry/scraps/input';
 
 import {IconSearch} from 'sentry/icons';
@@ -7,7 +5,7 @@ import {t} from 'sentry/locale';
 
 interface Props {
   includeFeatureFlagsTab: boolean;
-  onChange: Dispatch<SetStateAction<string>>;
+  onChange: React.Dispatch<React.SetStateAction<string>>;
   search: string;
 }
 

--- a/static/app/views/issueDetails/streamline/context.tsx
+++ b/static/app/views/issueDetails/streamline/context.tsx
@@ -1,12 +1,4 @@
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useMemo,
-  useReducer,
-  type Dispatch,
-  type Reducer,
-} from 'react';
+import {createContext, useCallback, useContext, useMemo, useReducer} from 'react';
 
 import type {DetectorDetails} from 'sentry/views/issueDetails/streamline/sidebar/detectorSection';
 
@@ -116,7 +108,7 @@ export interface SectionConfig {
 }
 
 interface IssueDetailsContextType extends IssueDetailsState {
-  dispatch: Dispatch<IssueDetailsActions>;
+  dispatch: React.Dispatch<IssueDetailsActions>;
 }
 
 const initialState: IssueDetailsState = {
@@ -210,7 +202,7 @@ function updateEventSection(
  * `useIssueDetails` instead. This hook is just meant to create state for the provider.
  */
 export function IssueDetailsContextProvider({children}: {children: React.ReactNode}) {
-  const reducer: Reducer<IssueDetailsState, IssueDetailsActions> = useCallback(
+  const reducer: React.Reducer<IssueDetailsState, IssueDetailsActions> = useCallback(
     (state, action): IssueDetailsState => {
       switch (action.type) {
         case 'UPDATE_SIDEBAR_STATE':

--- a/static/app/views/issueDetails/streamline/eventTitle.tsx
+++ b/static/app/views/issueDetails/streamline/eventTitle.tsx
@@ -1,4 +1,4 @@
-import {type CSSProperties, Fragment} from 'react';
+import {Fragment} from 'react';
 import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 // eslint-disable-next-line no-restricted-imports
@@ -38,7 +38,7 @@ type EventNavigationProps = {
    */
   'data-stuck'?: boolean;
   ref?: React.Ref<HTMLDivElement>;
-  style?: CSSProperties;
+  style?: React.CSSProperties;
 };
 
 export const MIN_NAV_HEIGHT = 44;

--- a/static/app/views/issueDetails/streamline/foldSection.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.tsx
@@ -1,11 +1,4 @@
-import React, {
-  Fragment,
-  useCallback,
-  useLayoutEffect,
-  useRef,
-  useState,
-  type CSSProperties,
-} from 'react';
+import React, {Fragment, useCallback, useLayoutEffect, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {mergeRefs} from '@react-aria/utils';
 
@@ -60,7 +53,7 @@ export interface FoldSectionProps {
    */
   preventCollapse?: boolean;
   ref?: React.Ref<HTMLDivElement>;
-  style?: CSSProperties;
+  style?: React.CSSProperties;
 }
 
 function useOptionalLocalStorageState(

--- a/static/app/views/issueDetails/streamline/header/header.tsx
+++ b/static/app/views/issueDetails/streamline/header/header.tsx
@@ -1,4 +1,4 @@
-import {Fragment, type ComponentProps, type ReactNode} from 'react';
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 // eslint-disable-next-line no-restricted-imports
 import color from 'color';
@@ -246,8 +246,8 @@ function MaybeTopBarSlot({
   name,
   children,
 }: {
-  children: ReactNode;
-  name: ComponentProps<typeof TopBar.Slot>['name'];
+  children: React.ReactNode;
+  name: React.ComponentProps<typeof TopBar.Slot>['name'];
 }) {
   const hasPageFrameFeature = useHasPageFrameFeature();
   if (hasPageFrameFeature) {

--- a/static/app/views/issueDetails/streamline/sidebar/attributeComparisonSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/attributeComparisonSection.spec.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps} from 'react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -11,7 +10,7 @@ describe('AttributeComparisonSection', () => {
   const openPeriodStart = '2024-01-01T00:00:00Z';
   const openPeriodEnd = '2024-01-01T00:10:00Z';
 
-  const defaultProps: ComponentProps<typeof AttributeComparisonSection> = {
+  const defaultProps: React.ComponentProps<typeof AttributeComparisonSection> = {
     openPeriodStart,
     openPeriodEnd,
     isOpenPeriodLoading: false,

--- a/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
@@ -1,4 +1,4 @@
-import {type CSSProperties, useMemo} from 'react';
+import {useMemo} from 'react';
 import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
 
@@ -425,7 +425,7 @@ function useSeerDrawerLink() {
 }
 
 const ImageContainer = styled(Flex)<{
-  aspectRatio?: CSSProperties['aspectRatio'];
+  aspectRatio?: React.CSSProperties['aspectRatio'];
 }>`
   ${p => p.aspectRatio && `aspect-ratio: ${p.aspectRatio}`};
 `;

--- a/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/metricDetectorTriggeredSection.spec.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps} from 'react';
 import {SnubaQueryDataSourceFixture} from 'sentry-fixture/detectors';
 import {EventFixture} from 'sentry-fixture/event';
 import {GroupFixture} from 'sentry-fixture/group';
@@ -48,7 +47,7 @@ describe('MetricDetectorTriggeredSection', () => {
       detectionTime: '2024-01-01T00:00:00Z',
     },
   });
-  const defaultProps: ComponentProps<typeof MetricDetectorTriggeredSection> = {
+  const defaultProps: React.ComponentProps<typeof MetricDetectorTriggeredSection> = {
     group: defaultGroup,
     event: defaultEvent,
   };

--- a/static/app/views/issueDetails/streamline/sidebar/openPeriodTimelineSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/openPeriodTimelineSection.spec.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps} from 'react';
 import {
   GroupOpenPeriodActivityFixture,
   GroupOpenPeriodFixture,
@@ -13,7 +12,7 @@ describe('OpenPeriodTimelineSection', () => {
     MockApiClient.clearMockResponses();
   });
 
-  const defaultProps: ComponentProps<typeof OpenPeriodTimelineSection> = {
+  const defaultProps: React.ComponentProps<typeof OpenPeriodTimelineSection> = {
     eventId: 'event-2',
     groupId: 'group-1',
   };

--- a/static/app/views/issueDetails/streamline/sidebar/openPeriodTimelineSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/openPeriodTimelineSection.tsx
@@ -1,4 +1,4 @@
-import {Fragment, type ReactNode} from 'react';
+import {Fragment} from 'react';
 import orderBy from 'lodash/orderBy';
 
 import {Flex} from '@sentry/scraps/layout';
@@ -39,7 +39,7 @@ function getOpenPeriodActivityLabel(
 
 function getOpenPeriodActivitySubtext(
   activity: GroupOpenPeriod['activities'][number]
-): ReactNode {
+): React.ReactNode {
   const priority = activity.value;
 
   if (!priority) {
@@ -66,7 +66,7 @@ function getOpenPeriodActivityIcon(activity: GroupOpenPeriod['activities'][numbe
   }
 }
 
-function TimelineSection({children}: {children: ReactNode}) {
+function TimelineSection({children}: {children: React.ReactNode}) {
   return (
     <InterimSection title={t('Timeline')} type="timeline">
       {children}

--- a/static/app/views/issueDetails/streamline/sidebar/sizeAnalysisTriggeredSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/sizeAnalysisTriggeredSection.spec.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps} from 'react';
 import {EventFixture} from 'sentry-fixture/event';
 import {GroupFixture} from 'sentry-fixture/group';
 
@@ -53,7 +52,7 @@ describe('SizeAnalysisTriggeredSection', () => {
     },
   });
 
-  const defaultProps: ComponentProps<typeof SizeAnalysisTriggeredSection> = {
+  const defaultProps: React.ComponentProps<typeof SizeAnalysisTriggeredSection> = {
     group: defaultGroup,
     event: defaultEvent,
   };

--- a/static/app/views/issueList/issueSelectionContext.spec.tsx
+++ b/static/app/views/issueList/issueSelectionContext.spec.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps, ReactNode} from 'react';
 import {useLayoutEffect} from 'react';
 
 import {act, render, renderHook} from 'sentry-test/reactTestingLibrary';
@@ -11,7 +10,10 @@ import {
 
 type SelectionState = ReturnType<typeof useIssueSelectionSummary> &
   ReturnType<typeof useIssueSelectionActions>;
-type ProviderProps = Omit<ComponentProps<typeof IssueSelectionProvider>, 'children'>;
+type ProviderProps = Omit<
+  React.ComponentProps<typeof IssueSelectionProvider>,
+  'children'
+>;
 
 function useSelectionState(): SelectionState {
   const summary = useIssueSelectionSummary();
@@ -29,7 +31,7 @@ function SelectionProbe({onUpdate}: {onUpdate: (state: SelectionState) => void})
 
 function renderSelectionHook(providerProps: ProviderProps) {
   return renderHook(useSelectionState, {
-    wrapper: function Wrapper({children}: {children?: ReactNode}) {
+    wrapper: function Wrapper({children}: {children?: React.ReactNode}) {
       return (
         <IssueSelectionProvider {...providerProps}>{children}</IssueSelectionProvider>
       );

--- a/static/app/views/issueList/issueSelectionContext.tsx
+++ b/static/app/views/issueList/issueSelectionContext.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {createContext, useCallback, useContext, useMemo, useReducer, useRef} from 'react';
 import isEqual from 'lodash/isEqual';
 
@@ -35,7 +34,7 @@ interface IssueSelectionActions {
 }
 
 type IssueSelectionProviderProps = {
-  children: ReactNode;
+  children: React.ReactNode;
   visibleGroupIds: string[];
 };
 

--- a/static/app/views/issueList/issueViewsHeader.tsx
+++ b/static/app/views/issueList/issueViewsHeader.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {useQueryClient} from '@tanstack/react-query';
 
 import {Button} from '@sentry/scraps/button';
@@ -33,12 +32,18 @@ type IssueViewsHeaderProps = {
   onRealtimeChange: (active: boolean) => void;
   realtimeActive: boolean;
   selectedProjectIds: number[];
-  title: ReactNode;
-  description?: ReactNode;
-  headerActions?: ReactNode;
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  headerActions?: React.ReactNode;
 };
 
-function PageTitle({title, description}: {title: ReactNode; description?: ReactNode}) {
+function PageTitle({
+  title,
+  description,
+}: {
+  title: React.ReactNode;
+  description?: React.ReactNode;
+}) {
   const organization = useOrganization();
   const {data: groupSearchView} = useSelectedGroupSearchView();
   const user = useUser();

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
@@ -71,11 +70,11 @@ const DYNAMIC_COUNTS_STATS_PERIODS = new Set(['14d', '24h', 'auto']);
 const MAX_ISSUES_COUNT = 100;
 
 interface Props {
-  headerActions?: ReactNode;
+  headerActions?: React.ReactNode;
   initialQuery?: string;
   shouldFetchOnMount?: boolean;
-  title?: ReactNode;
-  titleDescription?: ReactNode;
+  title?: React.ReactNode;
+  titleDescription?: React.ReactNode;
 }
 
 interface EndpointParams extends Partial<PageFilters['datetime']> {

--- a/static/app/views/issueList/taxonomies.tsx
+++ b/static/app/views/issueList/taxonomies.tsx
@@ -1,5 +1,3 @@
-import type {ReactNode} from 'react';
-
 import {t} from 'sentry/locale';
 import {IssueCategory} from 'sentry/types/group';
 
@@ -14,7 +12,7 @@ export const ISSUE_TAXONOMY_CONFIG: Record<
   IssueTaxonomy,
   {
     categories: IssueCategory[];
-    description: ReactNode;
+    description: React.ReactNode;
     key: string;
     label: string;
     featureFlag?: string;

--- a/static/app/views/navigation/navigation.tsx
+++ b/static/app/views/navigation/navigation.tsx
@@ -1,4 +1,4 @@
-import {Fragment, type RefObject, useMemo, useRef} from 'react';
+import {Fragment, useMemo, useRef} from 'react';
 import {mergeProps} from '@react-aria/utils';
 import {motion, type MotionProps} from 'framer-motion';
 
@@ -139,7 +139,7 @@ export function Navigation() {
 }
 
 interface PrimaryNavigationItemsProps {
-  listRef?: RefObject<HTMLUListElement | null>;
+  listRef?: React.RefObject<HTMLUListElement | null>;
 }
 
 export function PrimaryNavigationItems({listRef}: PrimaryNavigationItemsProps) {

--- a/static/app/views/navigation/primary/components.tsx
+++ b/static/app/views/navigation/primary/components.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useRef, type MouseEventHandler} from 'react';
+import {Fragment, useEffect, useRef} from 'react';
 import {createPortal} from 'react-dom';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -356,7 +356,7 @@ interface PrimaryNavigationMenuProps extends PrimaryNavigationItemBaseProps {
   children?: React.ReactNode;
   icon?: React.ReactNode;
   indicator?: 'accent' | 'danger' | 'warning';
-  onOpen?: MouseEventHandler<HTMLButtonElement>;
+  onOpen?: React.MouseEventHandler<HTMLButtonElement>;
   triggerWrap?: React.ComponentType<{children: React.ReactNode}>;
 }
 

--- a/static/app/views/navigation/secondary/components.tsx
+++ b/static/app/views/navigation/secondary/components.tsx
@@ -1,12 +1,4 @@
-import {
-  createContext,
-  Fragment,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-  type ReactNode,
-} from 'react';
+import {createContext, Fragment, useContext, useEffect, useRef, useState} from 'react';
 import type {To} from 'react-router-dom';
 import {
   closestCenter,
@@ -80,7 +72,7 @@ import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFea
 const MotionContainer = motion.create(Container);
 
 interface SecondarySidebarProps {
-  children: ReactNode;
+  children: React.ReactNode;
 }
 
 function SecondarySidebar({children}: SecondarySidebarProps) {
@@ -224,7 +216,7 @@ const ResizeHandle = styled('div')<{atMaxWidth: boolean; atMinWidth: boolean}>`
 `;
 
 interface SecondaryNavigationListProps {
-  children: ReactNode;
+  children: React.ReactNode;
 }
 
 function SecondaryNavigationList(props: SecondaryNavigationListProps) {
@@ -237,7 +229,7 @@ function SecondaryNavigationList(props: SecondaryNavigationListProps) {
 }
 
 interface SecondaryNavigationListItemProps {
-  children: ReactNode;
+  children: React.ReactNode;
 }
 
 function SecondaryNavigationListItem(props: SecondaryNavigationListItemProps) {
@@ -249,7 +241,7 @@ function SecondaryNavigationListItem(props: SecondaryNavigationListItemProps) {
 }
 
 interface SecondaryNavigationItemProps extends Omit<LinkProps, 'ref' | 'to'> {
-  children: ReactNode;
+  children: React.ReactNode;
   to: To;
   /**
    * Will display the link as active under the given path.
@@ -262,13 +254,13 @@ interface SecondaryNavigationItemProps extends Omit<LinkProps, 'ref' | 'to'> {
    */
   end?: boolean;
   isActive?: boolean;
-  leadingItems?: ReactNode;
+  leadingItems?: React.ReactNode;
   showInteractionStateLayer?: boolean;
-  trailingItems?: ReactNode;
+  trailingItems?: React.ReactNode;
 }
 
 interface SecondaryNavigationHeaderProps {
-  children?: ReactNode;
+  children?: React.ReactNode;
 }
 
 function SecondaryNavigationHeader(props: SecondaryNavigationHeaderProps) {
@@ -330,7 +322,7 @@ function SecondaryNavigationHeader(props: SecondaryNavigationHeaderProps) {
 }
 
 interface SecondaryNavigationBodyProps {
-  children: ReactNode;
+  children: React.ReactNode;
 }
 
 function SecondaryNavigationBody(props: SecondaryNavigationBodyProps) {
@@ -349,10 +341,10 @@ function SecondaryNavigationBody(props: SecondaryNavigationBodyProps) {
 
 interface SectionTitleProps {
   canCollapse: boolean;
-  children: ReactNode;
+  children: React.ReactNode;
   isCollapsed: boolean;
   setIsCollapsed: (isCollapsed: boolean) => void;
-  trailingItems?: ReactNode;
+  trailingItems?: React.ReactNode;
 }
 
 function SectionTitle(props: SectionTitleProps) {
@@ -401,11 +393,11 @@ function SectionTitle(props: SectionTitleProps) {
 }
 
 interface SecondaryNavigationSectionProps {
-  children: ReactNode;
+  children: React.ReactNode;
   id: string;
   collapsible?: boolean;
-  title?: ReactNode;
-  trailingItems?: ReactNode;
+  title?: React.ReactNode;
+  trailingItems?: React.ReactNode;
 }
 
 function SecondaryNavigationSection(props: SecondaryNavigationSectionProps) {
@@ -784,7 +776,7 @@ function useReorderableItemContext() {
 }
 
 interface ReorderableListItemProps<T extends {id: string | number}> {
-  children: ReactNode;
+  children: React.ReactNode;
   item: T;
 }
 
@@ -826,7 +818,7 @@ function ReorderableListItem<T extends {id: string | number}>(
 }
 
 interface SecondaryNavigationReorderableListProps<T extends {id: string | number}> {
-  children: (item: T) => ReactNode;
+  children: (item: T) => React.ReactNode;
   items: T[];
   onDragEnd: (items: T[]) => void;
 }
@@ -894,7 +886,7 @@ interface SecondaryNavigationReorderableLinkProps extends Omit<
   SecondaryNavigationItemProps,
   'leadingItems' | 'onClick'
 > {
-  icon: ReactNode;
+  icon: React.ReactNode;
   onNavigate?: () => void;
 }
 

--- a/static/app/views/navigation/secondary/content.tsx
+++ b/static/app/views/navigation/secondary/content.tsx
@@ -1,5 +1,3 @@
-import type {ReactNode} from 'react';
-
 import {unreachable} from 'sentry/utils/unreachable';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {usePrimaryNavigation} from 'sentry/views/navigation/primaryNavigationContext';
@@ -12,7 +10,7 @@ import {MonitorsSecondaryNavigation} from 'sentry/views/navigation/secondary/sec
 import {ProjectsSecondaryNavigation} from 'sentry/views/navigation/secondary/sections/projects/projectsSecondaryNavigation';
 import {SettingsSecondaryNavigation} from 'sentry/views/navigation/secondary/sections/settings/settingsSecondaryNavigation';
 
-export function SecondaryNavigationContent(): ReactNode {
+export function SecondaryNavigationContent(): React.ReactNode {
   const {activeGroup} = usePrimaryNavigation();
   const organization = useOrganization();
   switch (activeGroup) {

--- a/static/app/views/navigation/useResetActiveNavigationGroup.tsx
+++ b/static/app/views/navigation/useResetActiveNavigationGroup.tsx
@@ -1,4 +1,3 @@
-import type {MouseEventHandler} from 'react';
 import {useCallback, useEffect, useRef} from 'react';
 import type {DOMAttributes, FocusableElement} from '@react-types/shared';
 
@@ -35,7 +34,7 @@ export function useResetActiveNavigationGroup(): DOMAttributes<FocusableElement>
     }
   }, []);
 
-  const onMouseMove = useCallback<MouseEventHandler<FocusableElement>>(
+  const onMouseMove = useCallback<React.MouseEventHandler<FocusableElement>>(
     e => {
       requestAnimationFrame(() => {
         const target = e.target as HTMLElement;

--- a/static/app/views/onboarding/components/newWelcomeProductCard.tsx
+++ b/static/app/views/onboarding/components/newWelcomeProductCard.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import styled from '@emotion/styled';
 import {motion} from 'framer-motion';
 
@@ -10,11 +9,11 @@ import {OnboardingWelcomeProductId} from 'sentry/views/onboarding/types';
 
 export interface ProductOption {
   description: string;
-  icon: ReactNode;
+  icon: React.ReactNode;
   id: OnboardingWelcomeProductId;
   title: string;
-  badge?: ReactNode;
-  footer?: ReactNode;
+  badge?: React.ReactNode;
+  footer?: React.ReactNode;
 }
 
 interface NewWelcomeProductCardProps {

--- a/static/app/views/onboarding/components/pageCorners.tsx
+++ b/static/app/views/onboarding/components/pageCorners.tsx
@@ -1,11 +1,10 @@
-import type {HTMLAttributes} from 'react';
 import styled from '@emotion/styled';
 import type {MotionNodeAnimationOptions, Transition} from 'framer-motion';
 import {motion} from 'framer-motion';
 
 type Props = {
   animateVariant: MotionNodeAnimationOptions['animate'];
-} & HTMLAttributes<HTMLDivElement>;
+} & React.HTMLAttributes<HTMLDivElement>;
 
 export function PageCorners({animateVariant, ...rest}: Props) {
   const baseTransition: Transition = {type: 'spring', duration: 0.8};

--- a/static/app/views/onboarding/components/scmBenefitsCard.tsx
+++ b/static/app/views/onboarding/components/scmBenefitsCard.tsx
@@ -1,5 +1,3 @@
-import type {HTMLAttributes, Ref} from 'react';
-
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
@@ -31,8 +29,8 @@ const BENEFITS = [
   },
 ] as const;
 
-interface ScmBenefitsCardProps extends HTMLAttributes<HTMLDivElement> {
-  ref?: Ref<HTMLDivElement>;
+interface ScmBenefitsCardProps extends React.HTMLAttributes<HTMLDivElement> {
+  ref?: React.Ref<HTMLDivElement>;
   showTitle?: boolean;
 }
 

--- a/static/app/views/onboarding/components/scmFeatureCard.tsx
+++ b/static/app/views/onboarding/components/scmFeatureCard.tsx
@@ -1,5 +1,3 @@
-import type {ComponentType, ReactNode} from 'react';
-
 import {Checkbox} from '@sentry/scraps/checkbox';
 import {Container, Flex, Grid} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
@@ -12,12 +10,12 @@ import {ScmSelectableContainer} from './scmSelectableContainer';
 
 interface ScmFeatureCardProps {
   description: string;
-  icon: ComponentType<SVGIconProps>;
+  icon: React.ComponentType<SVGIconProps>;
   isSelected: boolean;
   label: string;
   onClick: () => void;
   disabled?: boolean;
-  disabledReason?: ReactNode;
+  disabledReason?: React.ReactNode;
 }
 
 export function ScmFeatureCard({

--- a/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
+++ b/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
@@ -1,5 +1,3 @@
-import type {ComponentType} from 'react';
-
 import {Flex, Grid} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
@@ -20,7 +18,7 @@ import {ScmFeatureCard} from './scmFeatureCard';
 
 type FeatureMeta = {
   description: string;
-  icon: ComponentType<SVGIconProps>;
+  icon: React.ComponentType<SVGIconProps>;
   label: string;
   alwaysEnabled?: boolean;
 };

--- a/static/app/views/onboarding/components/scmVirtualizedMenuList.tsx
+++ b/static/app/views/onboarding/components/scmVirtualizedMenuList.tsx
@@ -10,7 +10,7 @@
  * Usage: <Select components={{MenuList: ScmVirtualizedMenuList}} />
  */
 
-import {type Ref, useRef} from 'react';
+import {useRef} from 'react';
 import {mergeRefs} from '@react-aria/utils';
 import {useVirtualizer} from '@tanstack/react-virtual';
 
@@ -20,7 +20,7 @@ const MAX_MENU_HEIGHT = 300;
 interface ScmVirtualizedMenuListProps {
   children: React.ReactNode;
   innerProps?: React.HTMLAttributes<HTMLDivElement>;
-  innerRef?: Ref<HTMLDivElement>;
+  innerRef?: React.Ref<HTMLDivElement>;
   maxHeight?: number;
   optionHeight?: number;
 }

--- a/static/app/views/onboarding/components/welcomeSkipButton.tsx
+++ b/static/app/views/onboarding/components/welcomeSkipButton.tsx
@@ -1,5 +1,3 @@
-import {type PropsWithChildren} from 'react';
-
 import {LinkButton} from '@sentry/scraps/button';
 import {Link} from '@sentry/scraps/link';
 
@@ -15,7 +13,7 @@ interface WelcomeSkipButtonProps {
 export function WelcomeSkipButton({
   children,
   asButton,
-}: PropsWithChildren<WelcomeSkipButtonProps>) {
+}: React.PropsWithChildren<WelcomeSkipButtonProps>) {
   const organization = useOrganization();
   const {activateSidebar} = useOnboardingSidebar();
 

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useState, type PropsWithChildren} from 'react';
+import {useCallback, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 import {AnimatePresence, motion} from 'framer-motion';
 
@@ -115,7 +115,7 @@ interface ContainerVariableProps {
   id: OnboardingStepId;
 }
 
-function ContainerVariable(props: PropsWithChildren<ContainerVariableProps>) {
+function ContainerVariable(props: React.PropsWithChildren<ContainerVariableProps>) {
   const newWelcomeUIStep = props.hasNewWelcomeUI && props.id === OnboardingStepId.WELCOME;
   const Component = newWelcomeUIStep
     ? OnboardingContainerNewWelcomeUI
@@ -133,7 +133,9 @@ interface OnboardingStepVariableProps {
   id: OnboardingStepId;
 }
 
-function OnboardingStepVariable(props: PropsWithChildren<OnboardingStepVariableProps>) {
+function OnboardingStepVariable(
+  props: React.PropsWithChildren<OnboardingStepVariableProps>
+) {
   const Component =
     props.hasNewWelcomeUI && props.id === OnboardingStepId.WELCOME
       ? OnboardingStepNewUi

--- a/static/app/views/organizationContext.tsx
+++ b/static/app/views/organizationContext.tsx
@@ -1,4 +1,4 @@
-import {createContext, useEffect, useRef, type ReactNode} from 'react';
+import {createContext, useEffect, useRef} from 'react';
 import * as Sentry from '@sentry/react';
 
 import {switchOrganization} from 'sentry/actionCreators/organizations';
@@ -22,7 +22,7 @@ import {shutdownIntercom} from 'sentry/utils/intercom';
 import {useParams} from 'sentry/utils/useParams';
 
 interface Props {
-  children: ReactNode;
+  children: React.ReactNode;
 }
 
 /**

--- a/static/app/views/organizationJoinRequest/index.tsx
+++ b/static/app/views/organizationJoinRequest/index.tsx
@@ -1,5 +1,4 @@
 import {useCallback, useState} from 'react';
-import type {MouseEvent} from 'react';
 import styled from '@emotion/styled';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
@@ -32,7 +31,7 @@ export default function OrganizationJoinRequest() {
   }, []);
 
   const handleCancel = useCallback(
-    (e: MouseEvent) => {
+    (e: React.MouseEvent) => {
       e.preventDefault();
       testableWindowLocation.assign(`/auth/login/${orgId}/`);
     },

--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -1,4 +1,3 @@
-import type {MouseEvent as ReactMouseEvent} from 'react';
 import React, {Fragment, useCallback, useMemo} from 'react';
 import styled from '@emotion/styled';
 import moment from 'moment-timezone';
@@ -404,7 +403,7 @@ export function UsageStatsOrganization({
   );
 
   const navigateToInboundFilterSettings = useCallback(
-    (event: ReactMouseEvent) => {
+    (event: React.MouseEvent) => {
       event.preventDefault();
       const url = `/settings/${organization.slug}/projects/:projectId/filters/data-filters/`;
       navigateTo(url, navigate, location);

--- a/static/app/views/performance/landing/widgets/widgets/performanceScoreListWidget.tsx
+++ b/static/app/views/performance/landing/widgets/widgets/performanceScoreListWidget.tsx
@@ -1,4 +1,3 @@
-import type {ReactElement} from 'react';
 import {Fragment, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -175,7 +174,7 @@ export function PerformanceScoreListWidget(props: PerformanceWidgetProps) {
       Queries={{
         // The queries aren't actually happening here, but we propagate these to manage loading state
         timeseries: {
-          component: (provided): ReactElement => {
+          component: (provided): React.ReactElement => {
             return (
               <Fragment>
                 {provided.children({
@@ -194,7 +193,7 @@ export function PerformanceScoreListWidget(props: PerformanceWidgetProps) {
           },
         },
         transaction: {
-          component: (provided): ReactElement => {
+          component: (provided): React.ReactElement => {
             return (
               <Fragment>
                 {provided.children({

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/drawerContainerRefContext.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/drawerContainerRefContext.tsx
@@ -1,6 +1,6 @@
-import {createContext, useContext, type RefObject} from 'react';
+import {createContext, useContext} from 'react';
 
-type DrawerContainerRef = RefObject<HTMLDivElement | null> | null;
+type DrawerContainerRef = React.RefObject<HTMLDivElement | null> | null;
 
 export const DrawerContainerRefContext = createContext<DrawerContainerRef>(null);
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo, useState, type PropsWithChildren} from 'react';
+import {Fragment, useMemo, useState} from 'react';
 import {css, useTheme, type Theme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {useHover} from '@react-aria/interactions';
@@ -128,7 +128,7 @@ const TitleText = styled('div')`
   font-weight: bold;
 `;
 
-function TitleWithTestId(props: PropsWithChildren) {
+function TitleWithTestId(props: React.PropsWithChildren) {
   return <Title data-test-id="trace-drawer-title">{props.children}</Title>;
 }
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiConversations.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiConversations.tsx
@@ -1,4 +1,4 @@
-import {type Key, useCallback, useMemo, useState} from 'react';
+import {useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {LinkButton} from '@sentry/scraps/button';
@@ -40,7 +40,7 @@ export function TraceAiConversations({
   const [activeSubTab, setActiveSubTab] = useState(`chat-${conversationIds[0]}`);
   const [selectedSpanId, setSelectedSpanId] = useState<string | null>(null);
 
-  const handleTabChange = useCallback((key: Key) => {
+  const handleTabChange = useCallback((key: React.Key) => {
     setActiveSubTab(String(key));
     setSelectedSpanId(null);
   }, []);

--- a/static/app/views/performance/table.tsx
+++ b/static/app/views/performance/table.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useRef, useState, type ReactNode} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import type {Theme} from '@emotion/react';
 import type {Location, LocationDescriptorObject} from 'history';
 
@@ -54,8 +54,8 @@ import {
 } from './utils';
 
 type ColumnTitle = {
-  title: string | ReactNode;
-  tooltip?: string | ReactNode;
+  title: string | React.ReactNode;
+  tooltip?: string | React.ReactNode;
 };
 
 const COLUMN_TITLES_OPTIONAL_TOOLTIP = COLUMN_TITLES.map(title => {

--- a/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eventsTable.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import {Fragment, useCallback, useMemo, useState, type ReactNode} from 'react';
+import {Fragment, useCallback, useMemo, useState} from 'react';
 import {useMatches} from 'react-router-dom';
 import type {Theme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -109,7 +109,7 @@ type Props = {
     pageEventsCount: number;
     pageLinks: string | null;
     totalEventsCount: string | number;
-  }) => ReactNode;
+  }) => React.ReactNode;
 };
 
 export function EventsTable({

--- a/static/app/views/performance/transactionSummary/types.tsx
+++ b/static/app/views/performance/transactionSummary/types.tsx
@@ -1,3 +1,1 @@
-import type {SetStateAction as _SetStateAction, Dispatch} from 'react';
-
-export type SetStateAction<T> = Dispatch<_SetStateAction<T>>;
+export type SetStateAction<T> = React.Dispatch<React.SetStateAction<T>>;

--- a/static/app/views/performance/vitalDetail/colorBar.tsx
+++ b/static/app/views/performance/vitalDetail/colorBar.tsx
@@ -1,10 +1,9 @@
-import type {ReactNode} from 'react';
 import styled from '@emotion/styled';
 
 type ColorStop = {
   color: string;
   percent: number;
-  renderBarStatus?: (barStatus: ReactNode, key: string) => ReactNode;
+  renderBarStatus?: (barStatus: React.ReactNode, key: string) => React.ReactNode;
 };
 
 interface Props extends React.HTMLAttributes<HTMLDivElement> {

--- a/static/app/views/preprod/buildComparison/main/buildComparisonMetricCards.tsx
+++ b/static/app/views/preprod/buildComparison/main/buildComparisonMetricCards.tsx
@@ -1,4 +1,4 @@
-import {useMemo, type ReactNode} from 'react';
+import {useMemo} from 'react';
 
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
@@ -27,7 +27,7 @@ interface ComparisonMetric {
   base: number;
   diff: number;
   head: number;
-  icon: ReactNode;
+  icon: React.ReactNode;
   key: string;
   labelTooltip: string;
   percentageChange: number;

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -48,7 +47,7 @@ interface BuildDetailsMetricCardsProps {
 }
 
 interface MetricCardConfig {
-  icon: ReactNode;
+  icon: React.ReactNode;
   key: string;
   title: string;
   value: string;

--- a/static/app/views/preprod/buildDetails/main/insights/insightInfoModal.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/insightInfoModal.tsx
@@ -1,10 +1,10 @@
-import {Fragment, type ReactNode} from 'react';
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 
 type InsightInfoModalOptions = {
-  children: ReactNode;
+  children: React.ReactNode;
   title: string;
 };
 

--- a/static/app/views/preprod/buildDetails/main/insights/optimizeImagesModal.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/optimizeImagesModal.tsx
@@ -1,5 +1,3 @@
-import type {ReactNode} from 'react';
-
 import {CodeBlock} from '@sentry/scraps/code';
 import {Flex} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
@@ -27,7 +25,7 @@ cwebp -lossless input.png -o output.webp
 # Convert JPEG to lossless WebP
 cwebp -lossless input.jpg -o output.webp`;
 
-function getOptimizeImagesContent(platform?: Platform): ReactNode {
+function getOptimizeImagesContent(platform?: Platform): React.ReactNode {
   return platform === 'android' ? (
     <Flex direction="column" gap="2xl">
       <Text>

--- a/static/app/views/preprod/components/installAppButton.tsx
+++ b/static/app/views/preprod/components/installAppButton.tsx
@@ -1,5 +1,3 @@
-import type {MouseEvent} from 'react';
-
 import {Button} from '@sentry/scraps/button';
 
 import {IconDownload} from 'sentry/icons';
@@ -24,7 +22,7 @@ export function InstallAppButton({
   variant = 'text',
 }: InstallAppButtonProps) {
   const organization = useOrganization();
-  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
     event.stopPropagation();
     event.currentTarget.blur();

--- a/static/app/views/preprod/components/installDetailsContent.tsx
+++ b/static/app/views/preprod/components/installDetailsContent.tsx
@@ -1,4 +1,4 @@
-import {Fragment, type ReactNode} from 'react';
+import {Fragment} from 'react';
 import {useTheme} from '@emotion/react';
 
 import {Button} from '@sentry/scraps/button';
@@ -57,7 +57,7 @@ export function InstallDetailsContent({
     }
   );
 
-  let body: ReactNode;
+  let body: React.ReactNode;
   if (isPending) {
     body = (
       <Flex direction="column" align="center" gap={outerGap}>
@@ -265,7 +265,7 @@ export function InstallDetailsContent({
   return body;
 }
 
-function CodeSignatureInfo({children}: {children: ReactNode}) {
+function CodeSignatureInfo({children}: {children: React.ReactNode}) {
   return (
     <Container
       padding="md"

--- a/static/app/views/preprod/components/metricCard.tsx
+++ b/static/app/views/preprod/components/metricCard.tsx
@@ -1,5 +1,3 @@
-import type {CSSProperties, ReactNode} from 'react';
-
 import {Button} from '@sentry/scraps/button';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
@@ -7,18 +5,18 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 
 interface MetricCardAction {
   ariaLabel: string;
-  icon: ReactNode;
+  icon: React.ReactNode;
   onClick: () => void;
-  tooltip: ReactNode;
+  tooltip: React.ReactNode;
 }
 
 interface MetricCardProps {
-  children: ReactNode;
-  icon: ReactNode;
+  children: React.ReactNode;
+  icon: React.ReactNode;
   label: string;
-  labelTooltip: ReactNode;
+  labelTooltip: React.ReactNode;
   action?: MetricCardAction;
-  style?: CSSProperties;
+  style?: React.CSSProperties;
 }
 
 export function MetricCard(props: MetricCardProps) {

--- a/static/app/views/profiling/landing/functionTrendsWidget.tsx
+++ b/static/app/views/profiling/landing/functionTrendsWidget.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
 import type {Theme} from '@emotion/react';
 import {useTheme} from '@emotion/react';
@@ -53,7 +52,7 @@ interface FunctionTrendsWidgetProps {
   trendFunction: 'p50()' | 'p75()' | 'p95()' | 'p99()';
   trendType: TrendType;
   cursorName?: string;
-  header?: ReactNode;
+  header?: React.ReactNode;
   onDataState?: (dataState: DataState) => void;
   userQuery?: string;
   widgetHeight?: string;
@@ -196,7 +195,7 @@ export function FunctionTrendsWidget({
 
 interface FunctionTrendsWidgetHeaderProps {
   handleCursor: CursorHandler;
-  header: ReactNode;
+  header: React.ReactNode;
   pageLinks: string | null;
   paginationAnalyticsEvent: (direction: string) => void;
   trendType: TrendType;

--- a/static/app/views/profiling/landing/slowestFunctionsWidget.tsx
+++ b/static/app/views/profiling/landing/slowestFunctionsWidget.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -77,7 +76,7 @@ const DEFAULT_SORTING_OPTION: SortOption = 'sum()';
 interface SlowestFunctionsWidgetProps<F extends BreakdownFunction> {
   breakdownFunction: F;
   cursorName?: string;
-  header?: ReactNode;
+  header?: React.ReactNode;
   onDataState?: (dataState: DataState) => void;
   userQuery?: string;
   widgetHeight?: string;

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useEffect, useMemo, useState, type ReactNode} from 'react';
+import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
 
 import {Stack} from '@sentry/scraps/layout';
 
@@ -66,7 +66,7 @@ export const enum MultipleCheckboxOptions {
 }
 
 export type IntegrationChannel = {
-  label: ReactNode;
+  label: React.ReactNode;
   value: string;
   new?: boolean;
 };

--- a/static/app/views/replays/detail/body/replayDetailsProviders.tsx
+++ b/static/app/views/replays/detail/body/replayDetailsProviders.tsx
@@ -1,4 +1,4 @@
-import {useEffect, type ReactNode} from 'react';
+import {useEffect} from 'react';
 import {useQuery} from '@tanstack/react-query';
 
 import {LocalStorageReplayPreferences} from 'sentry/components/replays/preferences/replayPreferences';
@@ -23,7 +23,7 @@ import {ReplaySummaryContextProvider} from 'sentry/views/replays/detail/ai/repla
 import {type ReplayListQueryReferrer} from 'sentry/views/replays/types';
 
 interface Props {
-  children: ReactNode;
+  children: React.ReactNode;
   projectSlug: string | null;
   replay: ReplayReader;
 }

--- a/static/app/views/replays/detail/breadcrumbs/useBreadcrumbFilters.tsx
+++ b/static/app/views/replays/detail/breadcrumbs/useBreadcrumbFilters.tsx
@@ -1,4 +1,3 @@
-import type {RefObject} from 'react';
 import {useCallback, useMemo, useRef} from 'react';
 import * as Sentry from '@sentry/react';
 
@@ -19,7 +18,7 @@ type Options = {
 };
 
 type Return = {
-  expandPathsRef: RefObject<Map<number, Set<string>>>;
+  expandPathsRef: React.RefObject<Map<number, Set<string>>>;
   getBreadcrumbTypes: () => Array<{label: string; value: string}>;
   items: ReplayFrame[];
   searchTerm: string;

--- a/static/app/views/replays/detail/console/useConsoleFilters.tsx
+++ b/static/app/views/replays/detail/console/useConsoleFilters.tsx
@@ -1,4 +1,3 @@
-import type {RefObject} from 'react';
 import {useCallback, useMemo, useRef} from 'react';
 
 import {defined} from 'sentry/utils';
@@ -21,7 +20,7 @@ type Options = {
 };
 
 type Return = {
-  expandPathsRef: RefObject<Map<number, Set<string>>>;
+  expandPathsRef: React.RefObject<Map<number, Set<string>>>;
   getLogLevels: () => Array<{label: string; value: string}>;
   items: BreadcrumbFrame[];
   logLevel: string[];

--- a/static/app/views/replays/detail/errorList/errorHeaderCell.tsx
+++ b/static/app/views/replays/detail/errorList/errorHeaderCell.tsx
@@ -1,5 +1,3 @@
-import type {ComponentProps, CSSProperties} from 'react';
-
 import type {Tooltip} from '@sentry/scraps/tooltip';
 
 import {HeaderCell} from 'sentry/components/replays/virtualizedGrid/headerCell';
@@ -11,14 +9,14 @@ type Props = {
   handleSort: ReturnType<typeof useSortErrors>['handleSort'];
   index: number;
   sortConfig: SortConfig;
-  style: CSSProperties;
+  style: React.CSSProperties;
   ref?: React.Ref<HTMLButtonElement>;
 };
 
 const COLUMNS: Array<{
   field: SortConfig['by'];
   label: string;
-  tooltipTitle?: ComponentProps<typeof Tooltip>['title'];
+  tooltipTitle?: React.ComponentProps<typeof Tooltip>['title'];
 }> = [
   {field: 'id', label: t('Event ID')},
   {field: 'title', label: t('Title')},

--- a/static/app/views/replays/detail/errorList/errorTableCell.tsx
+++ b/static/app/views/replays/detail/errorList/errorTableCell.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps, CSSProperties} from 'react';
 import {useMemo} from 'react';
 import {ClassNames} from '@emotion/react';
 
@@ -27,7 +26,7 @@ interface Props extends ReturnType<typeof useCrumbHandlers> {
   columnIndex: number;
   frame: ErrorFrame;
   startTimestampMs: number;
-  style: CSSProperties;
+  style: React.CSSProperties;
   ref?: React.Ref<HTMLDivElement>;
 }
 
@@ -68,7 +67,7 @@ export function ErrorTableCell({
     onMouseLeave: () => onMouseLeave(frame),
     ref,
     style,
-  } as ComponentProps<typeof Cell>;
+  } as React.ComponentProps<typeof Cell>;
 
   const renderFns = [
     () => (

--- a/static/app/views/replays/detail/filterLoadingIndicator.tsx
+++ b/static/app/views/replays/detail/filterLoadingIndicator.tsx
@@ -1,5 +1,3 @@
-import type {ReactNode} from 'react';
-
 import {Stack} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -7,7 +5,7 @@ import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
 
 interface Props {
-  children: ReactNode;
+  children: React.ReactNode;
   isLoading: boolean;
 }
 

--- a/static/app/views/replays/detail/layout/focusTabs.tsx
+++ b/static/app/views/replays/detail/layout/focusTabs.tsx
@@ -1,4 +1,4 @@
-import {useEffect, type ReactNode} from 'react';
+import {useEffect} from 'react';
 
 import {FeatureBadge} from '@sentry/scraps/badge';
 import {Flex, Stack} from '@sentry/scraps/layout';
@@ -30,7 +30,7 @@ function getReplayTabs({
   organization: Organization;
   project?: Project | null;
   replayRecord?: ReplayRecord | null;
-}): Record<TabKey, ReactNode> {
+}): Record<TabKey, React.ReactNode> {
   const hasAiSummary =
     organization.features.includes('replay-ai-summaries') && areAiFeaturesAllowed;
   const hasMobileSummary = organization.features.includes('replay-ai-summaries-mobile');

--- a/static/app/views/replays/detail/layout/splitDivider.tsx
+++ b/static/app/views/replays/detail/layout/splitDivider.tsx
@@ -1,4 +1,3 @@
-import type {DOMAttributes, MouseEventHandler} from 'react';
 import styled from '@emotion/styled';
 
 import {IconGrabbable} from 'sentry/icons';
@@ -6,15 +5,17 @@ import {IconGrabbable} from 'sentry/icons';
 type Props = {
   'data-is-held': boolean;
   'data-slide-direction': 'leftright' | 'updown';
-  onDoubleClick: MouseEventHandler<HTMLElement>;
-  onMouseDown: MouseEventHandler<HTMLElement>;
+  onDoubleClick: React.MouseEventHandler<HTMLElement>;
+  onMouseDown: React.MouseEventHandler<HTMLElement>;
 };
 
-export const SplitDivider = styled((props: Props & DOMAttributes<HTMLDivElement>) => (
-  <div {...props}>
-    <IconGrabbable size="sm" />
-  </div>
-))<Props>`
+export const SplitDivider = styled(
+  (props: Props & React.DOMAttributes<HTMLDivElement>) => (
+    <div {...props}>
+      <IconGrabbable size="sm" />
+    </div>
+  )
+)<Props>`
   display: grid;
   place-items: center;
   height: 100%;

--- a/static/app/views/replays/detail/memoryPanel/memoryChart.tsx
+++ b/static/app/views/replays/detail/memoryPanel/memoryChart.tsx
@@ -1,13 +1,4 @@
-import {
-  memo,
-  useCallback,
-  useEffect,
-  useId,
-  useMemo,
-  useRef,
-  type Dispatch,
-  type SetStateAction,
-} from 'react';
+import {memo, useCallback, useEffect, useId, useMemo, useRef} from 'react';
 import {useTheme} from '@emotion/react';
 
 import type {AreaChartProps, AreaChartSeries} from 'sentry/components/charts/areaChart';
@@ -30,7 +21,7 @@ interface Props
     MemoryChartSeriesProps,
     Pick<ReturnType<typeof useReplayContext>, 'currentTime' | 'setCurrentTime'> {
   currentHoverTime: undefined | number;
-  setCurrentHoverTime: Dispatch<SetStateAction<number | undefined>>;
+  setCurrentHoverTime: React.Dispatch<React.SetStateAction<number | undefined>>;
 }
 
 export function MemoryChart({

--- a/static/app/views/replays/detail/network/details/components.tsx
+++ b/static/app/views/replays/detail/network/details/components.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
@@ -41,7 +40,7 @@ export function Warning({warnings}: {warnings: string[]}) {
   return null;
 }
 
-export function SizeTooltip({children}: {children: ReactNode}) {
+export function SizeTooltip({children}: {children: React.ReactNode}) {
   return (
     <Tooltip
       title={t('It is possible the network transfer size is smaller due to compression.')}
@@ -53,7 +52,7 @@ export function SizeTooltip({children}: {children: ReactNode}) {
 
 export type KeyValueTuple = {
   key: string;
-  value: string | ReactNode;
+  value: string | React.ReactNode;
   type?: 'warning' | 'error';
 };
 
@@ -122,9 +121,9 @@ export function SectionItem({
   title,
   titleExtra,
 }: {
-  children: ReactNode;
-  title: ReactNode;
-  titleExtra?: ReactNode;
+  children: React.ReactNode;
+  title: React.ReactNode;
+  titleExtra?: React.ReactNode;
 }) {
   const [isOpen, setIsOpen] = useState(true);
 

--- a/static/app/views/replays/detail/network/details/sections.tsx
+++ b/static/app/views/replays/detail/network/details/sections.tsx
@@ -1,4 +1,3 @@
-import type {MouseEvent} from 'react';
 import {useEffect, useMemo} from 'react';
 import queryString from 'query-string';
 
@@ -88,7 +87,7 @@ export function GeneralSection({item, startTimestampMs}: SectionProps) {
       value: (
         <TimestampButton
           precision="ms"
-          onClick={(event: MouseEvent) => {
+          onClick={(event: React.MouseEvent) => {
             event.stopPropagation();
             setCurrentTime(item.offsetMs);
           }}

--- a/static/app/views/replays/detail/network/networkHeaderCell.tsx
+++ b/static/app/views/replays/detail/network/networkHeaderCell.tsx
@@ -1,5 +1,3 @@
-import type {ComponentProps, CSSProperties} from 'react';
-
 import {ExternalLink} from '@sentry/scraps/link';
 import type {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -12,14 +10,14 @@ type Props = {
   handleSort: ReturnType<typeof useSortNetwork>['handleSort'];
   index: number;
   sortConfig: SortConfig;
-  style: CSSProperties;
+  style: React.CSSProperties;
   ref?: React.Ref<HTMLButtonElement>;
 };
 
 const COLUMNS: Array<{
   field: SortConfig['by'];
   label: string;
-  tooltipTitle?: ComponentProps<typeof Tooltip>['title'];
+  tooltipTitle?: React.ComponentProps<typeof Tooltip>['title'];
 }> = [
   {field: 'method', label: t('Method')},
   {

--- a/static/app/views/replays/detail/network/networkTableCell.tsx
+++ b/static/app/views/replays/detail/network/networkTableCell.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps, CSSProperties} from 'react';
 import {parseAsInteger, useQueryState} from 'nuqs';
 
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -28,7 +27,7 @@ interface Props extends ReturnType<typeof useCrumbHandlers> {
   onClickCell: (props: {dataIndex: number; rowIndex: number}) => void;
   rowIndex: number;
   startTimestampMs: number;
-  style: CSSProperties;
+  style: React.CSSProperties;
   ref?: React.Ref<HTMLDivElement>;
 }
 
@@ -69,7 +68,7 @@ export function NetworkTableCell({
     onMouseLeave: () => onMouseLeave(frame),
     ref,
     style,
-  } as ComponentProps<typeof Cell>;
+  } as React.ComponentProps<typeof Cell>;
 
   const renderFns = [
     () => (

--- a/static/app/views/replays/detail/noRowRenderer.tsx
+++ b/static/app/views/replays/detail/noRowRenderer.tsx
@@ -1,5 +1,3 @@
-import type {ReactNode} from 'react';
-
 import {Button} from '@sentry/scraps/button';
 
 import {IconClose} from 'sentry/icons';
@@ -7,7 +5,7 @@ import {t} from 'sentry/locale';
 import {StyledEmptyStateWarning as EmptyState} from 'sentry/views/replays/detail/emptyState';
 
 type Props = {
-  children: ReactNode;
+  children: React.ReactNode;
   clearSearchTerm: () => void;
   unfilteredItems: unknown[];
 };

--- a/static/app/views/replays/detail/ourlogs/index.spec.tsx
+++ b/static/app/views/replays/detail/ourlogs/index.spec.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {ReplayRecordFixture} from 'sentry-fixture/replayRecord';
 
 import {render, screen} from 'sentry-test/reactTestingLibrary';
@@ -15,7 +14,7 @@ function Wrappers({
   children,
   replay = null,
 }: {
-  children: ReactNode;
+  children: React.ReactNode;
   replay?: ReplayReader | null;
 }) {
   return (

--- a/static/app/views/replays/detail/timestampButton.tsx
+++ b/static/app/views/replays/detail/timestampButton.tsx
@@ -1,4 +1,3 @@
-import type {MouseEvent} from 'react';
 import styled from '@emotion/styled';
 
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -16,7 +15,7 @@ type Props = {
   startTimestampMs: number;
   timestampMs: number;
   className?: string;
-  onClick?: (event: MouseEvent) => void;
+  onClick?: (event: React.MouseEvent) => void;
   precision?: 'sec' | 'ms';
 };
 

--- a/static/app/views/replays/detail/useVirtualizedInspector.tsx
+++ b/static/app/views/replays/detail/useVirtualizedInspector.tsx
@@ -1,8 +1,7 @@
-import type {RefObject} from 'react';
 import {useCallback} from 'react';
 
 type Opts = {
-  expandPathsRef: RefObject<Map<number, Set<string>>>;
+  expandPathsRef: React.RefObject<Map<number, Set<string>>>;
   onMeasure: (index: number) => void;
 };
 

--- a/static/app/views/replays/list.spec.tsx
+++ b/static/app/views/replays/list.spec.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {UserFixture} from 'sentry-fixture/user';
 
@@ -55,7 +54,7 @@ function getMockOrganizationFixture({features}: {features: string[]}) {
   return mockOrg;
 }
 
-function TopBarActionsWrapper({children}: {children: ReactNode}) {
+function TopBarActionsWrapper({children}: {children: React.ReactNode}) {
   return (
     <SecondaryNavigationContextProvider>
       <TopBar.Slot.Provider>

--- a/static/app/views/replays/list/replayQueryParamsProvider.tsx
+++ b/static/app/views/replays/list/replayQueryParamsProvider.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {useCallback, useMemo} from 'react';
 import type {Location} from 'history';
 
@@ -51,7 +50,7 @@ function getTargetWithReadableQueryParams(
 }
 
 interface ReplayQueryParamsProviderProps {
-  children: ReactNode;
+  children: React.ReactNode;
 }
 
 export function ReplayQueryParamsProvider({children}: ReplayQueryParamsProviderProps) {

--- a/static/app/views/replays/selectors/deadRageSelectorCards.tsx
+++ b/static/app/views/replays/selectors/deadRageSelectorCards.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {useState} from 'react';
 import styled from '@emotion/styled';
 
@@ -82,7 +81,7 @@ function AccordionWidget({
 }: {
   clickType: 'count_dead_clicks' | 'count_rage_clicks';
   deadOrRage: 'dead' | 'rage';
-  header: ReactNode;
+  header: React.ReactNode;
 }) {
   const clickVariant = deadOrRage === 'dead' ? 'warning' : 'danger';
   const [selectedListIndex, setSelectListIndex] = useState(-1);

--- a/static/app/views/seerExplorer/contexts/llmContext.spec.tsx
+++ b/static/app/views/seerExplorer/contexts/llmContext.spec.tsx
@@ -1,5 +1,3 @@
-import type {ReactNode} from 'react';
-
 import {render, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {LLMContextProvider, useLLMContext} from './llmContext';
@@ -40,7 +38,7 @@ function DummyChart({label}: {label?: string}) {
   return <div>{label ?? 'chart'}</div>;
 }
 
-function DummyWidget({title, children}: {children?: ReactNode; title?: string}) {
+function DummyWidget({title, children}: {children?: React.ReactNode; title?: string}) {
   useLLMContext({title: title ?? 'widget', type: 'timeseries', unit: 'ms'});
   return (
     <div>
@@ -50,7 +48,7 @@ function DummyWidget({title, children}: {children?: ReactNode; title?: string}) 
   );
 }
 
-function DummyDashboard({name, children}: {children?: ReactNode; name?: string}) {
+function DummyDashboard({name, children}: {children?: React.ReactNode; name?: string}) {
   useLLMContext({name: name ?? 'dashboard'});
   return (
     <div>

--- a/static/app/views/seerExplorer/contexts/llmContext.tsx
+++ b/static/app/views/seerExplorer/contexts/llmContext.tsx
@@ -1,12 +1,4 @@
-import {
-  createContext,
-  type ReactNode,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-} from 'react';
+import {createContext, useCallback, useContext, useEffect, useMemo, useRef} from 'react';
 
 import {createDefinedContext} from 'sentry/utils/performance/contexts/utils';
 
@@ -108,7 +100,7 @@ function serializeState(
 // LLMContextProvider — root of the entire context tree
 
 interface LLMContextProviderProps {
-  children: ReactNode;
+  children: React.ReactNode;
 }
 
 const INITIAL_STATE: LLMContextState = {

--- a/static/app/views/seerExplorer/contexts/registerLLMContext.tsx
+++ b/static/app/views/seerExplorer/contexts/registerLLMContext.tsx
@@ -1,4 +1,3 @@
-import type {ComponentType} from 'react';
 import {useContext, useEffect, useId} from 'react';
 
 import {LLMNodeContext, useLLMContextRegistry} from './llmContext';
@@ -24,8 +23,8 @@ import type {LLMContextNodeType} from './llmContextTypes';
  */
 export function registerLLMContext<P extends Record<string, unknown>>(
   nodeType: LLMContextNodeType,
-  WrappedComponent: ComponentType<P>
-): ComponentType<P> {
+  WrappedComponent: React.ComponentType<P>
+): React.ComponentType<P> {
   function LLMContextWrapper(props: P) {
     const ctx = useLLMContextRegistry();
 

--- a/static/app/views/seerExplorer/useSeerExplorerContext.tsx
+++ b/static/app/views/seerExplorer/useSeerExplorerContext.tsx
@@ -1,11 +1,4 @@
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useMemo,
-  useState,
-  type ReactNode,
-} from 'react';
+import {createContext, useCallback, useContext, useMemo, useState} from 'react';
 
 import {useHotkeys} from '@sentry/scraps/hotkey';
 
@@ -29,7 +22,7 @@ const SeerExplorerContext = createContext<SeerExplorerContextValue>({
   toggleSeerExplorer: () => {},
 });
 
-export function SeerExplorerContextProvider({children}: {children: ReactNode}) {
+export function SeerExplorerContextProvider({children}: {children: React.ReactNode}) {
   // Initialize the global explorer panel state. Includes hotkeys.
   const [isOpen, setIsOpen] = useState(false);
   const [isMinimized, setIsMinimized] = useState(false);

--- a/static/app/views/settings/components/settingsNavItem.tsx
+++ b/static/app/views/settings/components/settingsNavItem.tsx
@@ -1,4 +1,3 @@
-import type {ReactElement} from 'react';
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
@@ -12,7 +11,7 @@ import {SecondaryNavigation} from 'sentry/views/navigation/secondary/components'
 type Props = {
   label: React.ReactNode;
   to: string;
-  badge?: string | number | null | ReactElement;
+  badge?: string | number | null | React.ReactElement;
   id?: string;
   index?: boolean;
   onClick?: (e: React.MouseEvent) => void;
@@ -23,7 +22,7 @@ const LabelHook = HookOrDefault({
   defaultComponent: ({children}) => <Fragment>{children}</Fragment>,
 });
 
-function SettingsNavBadge({badge}: {badge: string | number | null | ReactElement}) {
+function SettingsNavBadge({badge}: {badge: string | number | null | React.ReactElement}) {
   if (badge === 'new' || badge === 'beta' || badge === 'alpha') {
     return <FeatureBadge type={badge} />;
   }

--- a/static/app/views/settings/featureFlags/changeTracking/newSecretHandler.tsx
+++ b/static/app/views/settings/featureFlags/changeTracking/newSecretHandler.tsx
@@ -1,4 +1,3 @@
-import type {MouseEventHandler} from 'react';
 import styled from '@emotion/styled';
 
 import {Alert} from '@sentry/scraps/alert';
@@ -18,7 +17,7 @@ export function NewSecretHandler({
   provider,
   onGoBack,
 }: {
-  onGoBack: MouseEventHandler;
+  onGoBack: React.MouseEventHandler;
   provider: string;
   secret: string;
 }) {

--- a/static/app/views/settings/organization/organizationPermissionAlert.tsx
+++ b/static/app/views/settings/organization/organizationPermissionAlert.tsx
@@ -1,5 +1,3 @@
-import type {ReactNode} from 'react';
-
 import {Alert, type AlertProps} from '@sentry/scraps/alert';
 
 import {Access} from 'sentry/components/acl/access';
@@ -8,7 +6,7 @@ import type {Scope} from 'sentry/types/core';
 
 interface OrganizationPermissionAlertProps extends Omit<AlertProps, 'variant'> {
   access?: Scope[];
-  message?: ReactNode;
+  message?: React.ReactNode;
 }
 
 export function OrganizationPermissionAlert({

--- a/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.spec.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/subscriptionBox.spec.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps} from 'react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -12,7 +11,9 @@ describe('SubscriptionBox', () => {
   beforeEach(() => {
     onChange.mockReset();
   });
-  function renderComponent(props: Partial<ComponentProps<typeof SubscriptionBox>> = {}) {
+  function renderComponent(
+    props: Partial<React.ComponentProps<typeof SubscriptionBox>> = {}
+  ) {
     return render(
       <SubscriptionBox
         resource="issue"

--- a/static/app/views/settings/project/projectOwnership/addCodeOwnerModal.tsx
+++ b/static/app/views/settings/project/projectOwnership/addCodeOwnerModal.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useState, type Dispatch, type SetStateAction} from 'react';
+import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 import {skipToken, useQuery} from '@tanstack/react-query';
 
@@ -190,7 +190,7 @@ function ApplyCodeMappings({
   codeownersFile: CodeownersFile | undefined;
   mutation: UseMutationResult<CodeOwner, RequestError, TCodeownersVariables, unknown>;
   organization: Organization;
-  setCodeMappingId: Dispatch<SetStateAction<string | null>>;
+  setCodeMappingId: React.Dispatch<React.SetStateAction<string | null>>;
 }) {
   const baseUrl = `/settings/${organization.slug}/integrations/`;
   return (

--- a/static/app/views/settings/projectSeer/addAutofixRepoModal.tsx
+++ b/static/app/views/settings/projectSeer/addAutofixRepoModal.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useMemo, useRef, useState, type ChangeEvent} from 'react';
+import {Fragment, useCallback, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 import {useInfiniteQuery} from '@tanstack/react-query';
 import {useVirtualizer} from '@tanstack/react-virtual';
@@ -125,7 +125,7 @@ export function AddAutofixRepoModal({
               type="text"
               placeholder={t('Search available repositories...')}
               value={modalSearchQuery}
-              onChange={(ev: ChangeEvent<HTMLInputElement>) =>
+              onChange={(ev: React.ChangeEvent<HTMLInputElement>) =>
                 setModalSearchQuery(ev.target.value)
               }
               autoFocus

--- a/static/app/views/settings/projectSeer/autofixRepoItem.tsx
+++ b/static/app/views/settings/projectSeer/autofixRepoItem.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useState, type ChangeEvent} from 'react';
+import {useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
@@ -72,12 +72,12 @@ export function AutofixRepoItem({repo, onRemove, settings, onSettingsChange}: Pr
     setIsDirty(newIsDirty);
   }, [branchInputValue, instructionsValue, branchOverridesValue, originalValues]);
 
-  const handleBranchInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+  const handleBranchInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     e.stopPropagation();
     setBranchInputValue(e.target.value);
   };
 
-  const handleInstructionsChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+  const handleInstructionsChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     e.stopPropagation();
     setInstructionsValue(e.target.value);
   };
@@ -213,7 +213,7 @@ export function AutofixRepoItem({repo, onRemove, settings, onSettingsChange}: Pr
                           <InputGroup.Input
                             type="text"
                             value={override.tag_name}
-                            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                               updateBranchOverride(index, {
                                 ...override,
                                 tag_name: e.target.value,
@@ -227,7 +227,7 @@ export function AutofixRepoItem({repo, onRemove, settings, onSettingsChange}: Pr
                           <InputGroup.Input
                             type="text"
                             value={override.tag_value}
-                            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                               updateBranchOverride(index, {
                                 ...override,
                                 tag_value: e.target.value,
@@ -244,7 +244,7 @@ export function AutofixRepoItem({repo, onRemove, settings, onSettingsChange}: Pr
                           <InputGroup.Input
                             type="text"
                             value={override.branch_name}
-                            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                               updateBranchOverride(index, {
                                 ...override,
                                 branch_name: e.target.value,

--- a/static/app/views/settings/seer/overview/scmOverviewSection.stories.tsx
+++ b/static/app/views/settings/seer/overview/scmOverviewSection.stories.tsx
@@ -1,4 +1,4 @@
-import {Fragment, type ComponentProps} from 'react';
+import {Fragment} from 'react';
 
 import * as Storybook from 'sentry/stories';
 import type {
@@ -37,7 +37,7 @@ const REPOS: IntegrationRepository[] = [
   {identifier: 'my-org/infra', name: 'my-org/infra', isInstalled: true},
 ];
 
-const BASE_PROPS: ComponentProps<typeof SCMOverviewSection> = {
+const BASE_PROPS: React.ComponentProps<typeof SCMOverviewSection> = {
   canWrite: true,
   organizationSlug: 'my-org',
   isError: false,

--- a/static/app/views/settings/types.tsx
+++ b/static/app/views/settings/types.tsx
@@ -1,5 +1,3 @@
-import type {ReactElement} from 'react';
-
 import type {Scope} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
@@ -28,7 +26,7 @@ export type NavigationItem = {
   /**
    * Returns the text of the badge to render next to the navigation.
    */
-  badge?: (opts: NavigationGroupProps) => string | number | null | ReactElement;
+  badge?: (opts: NavigationGroupProps) => string | number | null | React.ReactElement;
   /**
    * The description of the settings section. This will be used in search.
    */

--- a/static/eslint/eslintPluginScraps/src/rules/index.ts
+++ b/static/eslint/eslintPluginScraps/src/rules/index.ts
@@ -1,10 +1,12 @@
 import {noCoreImport} from './no-core-import';
+import {noReactTypeImport} from './no-react-type-import';
 import {noTokenImport} from './no-token-import';
 import {restrictJsxSlotChildren} from './restrict-jsx-slot-children';
 import {useSemanticToken} from './use-semantic-token';
 
 export const rules = {
   'no-core-import': noCoreImport,
+  'no-react-type-import': noReactTypeImport,
   'no-token-import': noTokenImport,
   'restrict-jsx-slot-children': restrictJsxSlotChildren,
   'use-semantic-token': useSemanticToken,

--- a/static/eslint/eslintPluginScraps/src/rules/no-react-type-import.spec.ts
+++ b/static/eslint/eslintPluginScraps/src/rules/no-react-type-import.spec.ts
@@ -1,0 +1,120 @@
+import {RuleTester} from '@typescript-eslint/rule-tester';
+
+import {noReactTypeImport} from './no-react-type-import';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-react-type-import', noReactTypeImport, {
+  valid: [
+    // React namespace access is the preferred pattern.
+    {
+      code: `type Props = {children: React.ReactNode};`,
+      filename: '/static/app/file.tsx',
+    },
+    // Value imports from 'react' are fine (hooks, etc).
+    {
+      code: `import {useState} from 'react';\nconst [x] = useState(0);`,
+      filename: '/static/app/file.tsx',
+    },
+    // Default and namespace imports of React are fine.
+    {
+      code: `import React from 'react';`,
+      filename: '/static/app/file.tsx',
+    },
+    {
+      code: `import * as React from 'react';`,
+      filename: '/static/app/file.tsx',
+    },
+    // Imports from other packages untouched.
+    {
+      code: `import type {Foo} from 'other';\ntype X = Foo;`,
+      filename: '/static/app/file.tsx',
+    },
+  ],
+
+  invalid: [
+    // `import type {X} from 'react'` — remove whole line.
+    {
+      code: `import type {ReactNode} from 'react';\ntype Props = {children: ReactNode};`,
+      filename: '/static/app/file.tsx',
+      errors: [{messageId: 'forbidden', data: {name: 'ReactNode'}}],
+      output: `type Props = {children: React.ReactNode};`,
+    },
+    // `import type {X, Y} from 'react'` — two reports, one fix removes line.
+    {
+      code: `import type {FC, ReactNode} from 'react';\ntype A = FC;\ntype B = ReactNode;`,
+      filename: '/static/app/file.tsx',
+      errors: [
+        {messageId: 'forbidden', data: {name: 'FC'}},
+        {messageId: 'forbidden', data: {name: 'ReactNode'}},
+      ],
+      output: `type A = React.FC;\ntype B = React.ReactNode;`,
+    },
+    // Inline type specifier alongside a value specifier.
+    {
+      code: `import {useState, type ReactNode} from 'react';\ntype P = ReactNode;\nconst [x] = useState(0);`,
+      filename: '/static/app/file.tsx',
+      errors: [{messageId: 'forbidden', data: {name: 'ReactNode'}}],
+      output: `import {useState} from 'react';\ntype P = React.ReactNode;\nconst [x] = useState(0);`,
+    },
+    // Inline type specifier before a value specifier.
+    {
+      code: `import {type ReactNode, useState} from 'react';\ntype P = ReactNode;\nconst [x] = useState(0);`,
+      filename: '/static/app/file.tsx',
+      errors: [{messageId: 'forbidden', data: {name: 'ReactNode'}}],
+      output: `import {useState} from 'react';\ntype P = React.ReactNode;\nconst [x] = useState(0);`,
+    },
+    // All specs are types but sit next to a default import.
+    {
+      code: `import React, {type ReactNode} from 'react';\ntype P = ReactNode;\nReact.createElement('div');`,
+      filename: '/static/app/file.tsx',
+      errors: [{messageId: 'forbidden', data: {name: 'ReactNode'}}],
+      output: `import React from 'react';\ntype P = React.ReactNode;\nReact.createElement('div');`,
+    },
+    // Renamed type import — replacement uses the imported (remote) name.
+    {
+      code: `import type {ReactNode as Node} from 'react';\ntype P = Node;`,
+      filename: '/static/app/file.tsx',
+      errors: [{messageId: 'forbidden', data: {name: 'ReactNode'}}],
+      output: `type P = React.ReactNode;`,
+    },
+    // Used in generic position.
+    {
+      code: `import type {ComponentProps} from 'react';\ntype X = ComponentProps<typeof Foo>;`,
+      filename: '/static/app/file.tsx',
+      errors: [{messageId: 'forbidden', data: {name: 'ComponentProps'}}],
+      output: `type X = React.ComponentProps<typeof Foo>;`,
+    },
+    // Multiple references to the same imported type.
+    {
+      code: `import type {ReactNode} from 'react';\ntype A = ReactNode;\ntype B = ReactNode;`,
+      filename: '/static/app/file.tsx',
+      errors: [{messageId: 'forbidden', data: {name: 'ReactNode'}}],
+      output: `type A = React.ReactNode;\ntype B = React.ReactNode;`,
+    },
+    // Mixed: one flagged, one value, with default import present.
+    {
+      code: `import React, {type ReactNode, useState} from 'react';\ntype P = ReactNode;\nconst [x] = useState(0);\nReact.createElement('div');`,
+      filename: '/static/app/file.tsx',
+      errors: [{messageId: 'forbidden', data: {name: 'ReactNode'}}],
+      output: `import React, {useState} from 'react';\ntype P = React.ReactNode;\nconst [x] = useState(0);\nReact.createElement('div');`,
+    },
+    // Multiple inline type specs alongside value specs, with references far
+    // from the import. Exercises the single-rangehull strategy.
+    {
+      code:
+        `import {useState, type Dispatch, type SetStateAction} from 'react';\n` +
+        `type Foo = {bar: Dispatch<SetStateAction<string>>};\n` +
+        `const [x] = useState('');`,
+      filename: '/static/app/file.tsx',
+      errors: [
+        {messageId: 'forbidden', data: {name: 'Dispatch'}},
+        {messageId: 'forbidden', data: {name: 'SetStateAction'}},
+      ],
+      output:
+        `import {useState} from 'react';\n` +
+        `type Foo = {bar: React.Dispatch<React.SetStateAction<string>>};\n` +
+        `const [x] = useState('');`,
+    },
+  ],
+});

--- a/static/eslint/eslintPluginScraps/src/rules/no-react-type-import.ts
+++ b/static/eslint/eslintPluginScraps/src/rules/no-react-type-import.ts
@@ -1,0 +1,168 @@
+/**
+ * ESLint rule: no-react-type-import
+ *
+ * Disallows importing types from 'react' and autofixes to use `React.Foo`
+ * (which is available via the React UMD global) instead.
+ */
+import type {TSESLint, TSESTree} from '@typescript-eslint/utils';
+import {AST_NODE_TYPES, ESLintUtils} from '@typescript-eslint/utils';
+
+function isTypeSpecifier(
+  spec: TSESTree.ImportSpecifier,
+  declIsTypeOnly: boolean
+): boolean {
+  return declIsTypeOnly || spec.importKind === 'type';
+}
+
+function findVariable(
+  sourceCode: TSESLint.SourceCode,
+  localName: string,
+  spec: TSESTree.ImportSpecifier
+): TSESLint.Scope.Variable | undefined {
+  const scopeManager = sourceCode.scopeManager;
+  if (!scopeManager) return undefined;
+  const stack: TSESLint.Scope.Scope[] = [...scopeManager.scopes];
+  while (stack.length) {
+    const scope = stack.pop()!;
+    const match = scope.variables.find(
+      v => v.name === localName && v.defs.some(d => d.node === spec)
+    );
+    if (match) return match;
+    if (scope.childScopes) stack.push(...scope.childScopes);
+  }
+  return undefined;
+}
+
+export const noReactTypeImport = ESLintUtils.RuleCreator.withoutDocs({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Prefer `React.Foo` over importing types from "react" — React is available as a UMD global.',
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      forbidden: 'Prefer `React.{{name}}` over importing `{{name}}` from "react".',
+    },
+  },
+  create(context) {
+    const sourceCode = context.sourceCode;
+
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value !== 'react') return;
+
+        const declIsTypeOnly = node.importKind === 'type';
+        const namedSpecs = node.specifiers.filter(
+          (spec): spec is TSESTree.ImportSpecifier =>
+            spec.type === AST_NODE_TYPES.ImportSpecifier
+        );
+        const typeSpecs = namedSpecs.filter(s => isTypeSpecifier(s, declIsTypeOnly));
+        if (typeSpecs.length === 0) return;
+
+        const nonTypeNamedSpecs = namedSpecs.filter(
+          s => !isTypeSpecifier(s, declIsTypeOnly)
+        );
+        const defaultOrNamespace = node.specifiers.find(
+          s => s.type !== AST_NODE_TYPES.ImportSpecifier
+        );
+        const allNamedAreTypes = nonTypeNamedSpecs.length === 0;
+
+        // Emit one report per offending specifier so authors see each
+        // violation individually. To avoid ESLint merging multiple reports'
+        // fix rangehulls and marking them as conflicting (which can skip
+        // fixes silently when references live far from the import), we
+        // place ALL autofixes on the first report and leave subsequent
+        // reports fix-less. This yields one rangehull per ImportDeclaration
+        // covering the import plus all references.
+        for (let i = 0; i < typeSpecs.length; i++) {
+          const spec = typeSpecs[i]!;
+          const localName = spec.local.name;
+          const importedName =
+            spec.imported.type === AST_NODE_TYPES.Identifier
+              ? spec.imported.name
+              : localName;
+          const isFirst = i === 0;
+
+          context.report({
+            node: spec,
+            messageId: 'forbidden',
+            data: {name: importedName},
+            fix: isFirst ? fixer => buildDeclarationFixes(fixer, node) : undefined,
+          });
+        }
+
+        function buildDeclarationFixes(
+          fixer: TSESLint.RuleFixer,
+          declNode: TSESTree.ImportDeclaration
+        ): TSESLint.RuleFix[] {
+          const fixes: TSESLint.RuleFix[] = [];
+
+          // Reference replacements for every offending specifier.
+          for (const spec of typeSpecs) {
+            const localName = spec.local.name;
+            const importedName =
+              spec.imported.type === AST_NODE_TYPES.Identifier
+                ? spec.imported.name
+                : localName;
+            const variable = findVariable(sourceCode, localName, spec);
+            if (!variable) continue;
+            for (const ref of variable.references) {
+              if (ref.identifier === spec.local) continue;
+              fixes.push(fixer.replaceText(ref.identifier, `React.${importedName}`));
+            }
+          }
+
+          // Import statement mutation.
+          if (allNamedAreTypes && !defaultOrNamespace) {
+            // Whole declaration is type-only imports — drop the line.
+            const text = sourceCode.getText();
+            let end = declNode.range[1];
+            if (text[end] === '\n') end++;
+            fixes.push(fixer.removeRange([declNode.range[0], end]));
+          } else if (allNamedAreTypes && defaultOrNamespace) {
+            // `import React, {type Foo, type Bar} from 'react'` →
+            // drop everything after the default/namespace specifier
+            // through the closing brace.
+            const lastNamed = namedSpecs[namedSpecs.length - 1]!;
+            const closeBrace = sourceCode.getTokenAfter(lastNamed, {
+              filter: t => t.value === '}',
+            });
+            if (closeBrace) {
+              fixes.push(
+                fixer.removeRange([defaultOrNamespace.range[1], closeBrace.range[1]])
+              );
+            }
+          } else {
+            // Mixed named specs — coalesce adjacent type specs into
+            // single non-overlapping removal ranges.
+            const typeIndices = typeSpecs.map(s => namedSpecs.indexOf(s));
+            const runs: Array<[number, number]> = [];
+            for (const idx of typeIndices) {
+              const last = runs[runs.length - 1];
+              if (last?.[1] === idx - 1) {
+                last[1] = idx;
+              } else {
+                runs.push([idx, idx]);
+              }
+            }
+            for (const [a, b] of runs) {
+              const next = namedSpecs[b + 1];
+              const prev = namedSpecs[a - 1];
+              if (next) {
+                fixes.push(fixer.removeRange([namedSpecs[a]!.range[0], next.range[0]]));
+              } else if (prev) {
+                fixes.push(fixer.removeRange([prev.range[1], namedSpecs[b]!.range[1]]));
+              } else {
+                fixes.push(fixer.remove(namedSpecs[a]!));
+              }
+            }
+          }
+
+          return fixes;
+        }
+      },
+    };
+  },
+});

--- a/static/gsApp/components/ai/aiSetupConfiguration.tsx
+++ b/static/gsApp/components/ai/aiSetupConfiguration.tsx
@@ -1,4 +1,4 @@
-import {Fragment, type CSSProperties} from 'react';
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
 import seerConfigCheckImg from 'sentry-images/spot/seer-config-check.svg';
@@ -124,7 +124,7 @@ const HeroImage = styled(ImageBase)`
   transform: translateX(-47%) translateY(-35%);
 `;
 
-const Image = styled(ImageBase)<{alignSelf?: CSSProperties['alignSelf']}>`
+const Image = styled(ImageBase)<{alignSelf?: React.CSSProperties['alignSelf']}>`
   align-self: ${p => p.alignSelf ?? 'center'};
 `;
 

--- a/static/gsApp/components/profiling/profilingUpgradeModal.tsx
+++ b/static/gsApp/components/profiling/profilingUpgradeModal.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps} from 'react';
 import {useEffect} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -32,7 +31,7 @@ import type {Subscription} from 'getsentry/types';
 import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
 
 type Props = ModalRenderProps &
-  Omit<ComponentProps<typeof ActionButtons>, 'hasPriceChange'> & {
+  Omit<React.ComponentProps<typeof ActionButtons>, 'hasPriceChange'> & {
     organization: Organization;
     subscription: Subscription;
   };

--- a/static/gsApp/components/replayOnboardingAlert.tsx
+++ b/static/gsApp/components/replayOnboardingAlert.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {Fragment} from 'react';
 
 import {withSubscription} from 'getsentry/components/withSubscription';
@@ -6,7 +5,7 @@ import type {Subscription} from 'getsentry/types';
 import {PlanTier} from 'getsentry/types';
 
 type Props = {
-  children: ReactNode;
+  children: React.ReactNode;
   subscription: Subscription;
 };
 

--- a/static/gsApp/components/replayOnboardingCTA.tsx
+++ b/static/gsApp/components/replayOnboardingCTA.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {Fragment, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 
@@ -265,7 +264,7 @@ const ButtonList = styled((props: GridProps) => (
 `;
 
 type ReplayOnboardingCTAProps = {
-  children: ReactNode;
+  children: React.ReactNode;
   organization: Organization;
   subscription: Subscription;
 };

--- a/static/gsApp/components/trialStarter.spec.tsx
+++ b/static/gsApp/components/trialStarter.spec.tsx
@@ -1,4 +1,3 @@
-import type {ComponentProps} from 'react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {TeamFixture} from 'sentry-fixture/team';
@@ -9,7 +8,7 @@ import {act, render, screen} from 'sentry-test/reactTestingLibrary';
 import TrialStarter from 'getsentry/components/trialStarter';
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
 
-type RendererProps = Parameters<ComponentProps<typeof TrialStarter>['children']>[0];
+type RendererProps = Parameters<React.ComponentProps<typeof TrialStarter>['children']>[0];
 
 describe('TrialStarter', () => {
   const org = OrganizationFixture();

--- a/static/gsApp/components/upgradeNowModal/planTable.tsx
+++ b/static/gsApp/components/upgradeNowModal/planTable.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
@@ -144,7 +143,7 @@ function TableItem({
   prev,
   isTotal,
 }: {
-  children: ReactNode;
+  children: React.ReactNode;
   next: string | number;
   prev: string | number;
   isTotal?: boolean;

--- a/static/gsApp/components/upgradeNowModal/usePreviewData.tsx
+++ b/static/gsApp/components/upgradeNowModal/usePreviewData.tsx
@@ -1,5 +1,3 @@
-import type {ReactElement} from 'react';
-
 import type {Organization} from 'sentry/types/organization';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useApiQuery} from 'sentry/utils/queryClient';
@@ -33,7 +31,7 @@ type Result =
     };
 
 type Props = {
-  children: (props: Result) => ReactElement;
+  children: (props: Result) => React.ReactElement;
   organization: Organization;
   subscription: Subscription;
   enabled?: boolean;

--- a/static/gsApp/views/amCheckout/components/billingCycleSelectCard.tsx
+++ b/static/gsApp/views/amCheckout/components/billingCycleSelectCard.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import moment from 'moment-timezone';
 
 import {Tag} from '@sentry/scraps/badge';
@@ -54,7 +53,7 @@ export function BillingCycleSelectCard({
     onUpdate(data);
   };
 
-  let cycleInfo: ReactNode;
+  let cycleInfo: React.ReactNode;
   if (isPartnerMigration) {
     if (isAnnual) {
       cycleInfo = t('Billed annually from your selected start date on submission');

--- a/static/gsApp/views/invoiceDetails/paymentForm.spec.tsx
+++ b/static/gsApp/views/invoiceDetails/paymentForm.spec.tsx
@@ -1,4 +1,3 @@
-import type {ReactNode} from 'react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {InvoiceFixture} from 'getsentry-test/fixtures/invoice';
@@ -41,7 +40,7 @@ describe('InvoiceDetails > Payment Form', () => {
     SubscriptionStore.set(organization.slug, {});
   });
 
-  const modalDummy = ({children}: {children?: ReactNode}) => <div>{children}</div>;
+  const modalDummy = ({children}: {children?: React.ReactNode}) => <div>{children}</div>;
 
   it('renders form', async () => {
     const mockget = MockApiClient.addMockResponse({

--- a/static/gsApp/views/seerAutomation/onboarding/hooks/seerOnboardingContext.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/hooks/seerOnboardingContext.tsx
@@ -6,7 +6,6 @@ import {
   useMemo,
   useRef,
   useState,
-  type RefObject,
 } from 'react';
 import * as Sentry from '@sentry/react';
 import uniqBy from 'lodash/uniqBy';
@@ -27,7 +26,7 @@ import {useIntegrationProvider} from './useIntegrationProvider';
 interface SeerOnboardingContextProps {
   addRepositoryProjectMappings: (additionalMappings: Record<string, string[]>) => void;
   addRootCauseAnalysisRepository: (repoId: string) => void;
-  autoCreatePR: RefObject<boolean | null> | null;
+  autoCreatePR: React.RefObject<boolean | null> | null;
   changeRepositoryProjectMapping: (
     repoId: string,
     index: number,

--- a/static/gsApp/views/spendAllocations/enableSpendAllocations.tsx
+++ b/static/gsApp/views/spendAllocations/enableSpendAllocations.tsx
@@ -1,5 +1,3 @@
-import type {Dispatch} from 'react';
-
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 
@@ -12,7 +10,7 @@ type Props = {
   fetchSpendAllocations: () => Promise<void>;
   hasScope: boolean;
   orgSlug: string;
-  setErrors: Dispatch<string | null>;
+  setErrors: React.Dispatch<string | null>;
 };
 
 export function EnableSpendAllocations({


### PR DESCRIPTION
Adds `@sentry/scraps/no-react-type-import` which disallows importing type
names from `'react'` and autofixes references to use `React.Foo` instead.
The React UMD global is already available everywhere via `@types/react`,
so a dedicated type import adds noise without value.

`import type {ReactNode} from 'react'` → removed; references rewritten
to `React.ReactNode`. Inline `type` specifiers in mixed imports (e.g.
`import {useState, type ReactNode} from 'react'`) are dropped while
leaving value specifiers intact.

Also applies the autofix across the codebase.