### PR TITLE
ref(replays): Make useReplayCount discover uses explicit

### DIFF
--- a/static/app/utils/replayCount/useReplayCount.spec.tsx
+++ b/static/app/utils/replayCount/useReplayCount.spec.tsx
@@ -8,7 +8,7 @@ describe('useReplayCount', () => {
   const organization = OrganizationFixture();
   const initialProps = {
     bufferLimit: 100,
-    dataSource: 'discover',
+    dataSource: 'events' as const,
     fieldName: 'replay_id',
     organization,
     statsPeriod: '90d',

--- a/static/app/utils/replayCount/useReplayCount.tsx
+++ b/static/app/utils/replayCount/useReplayCount.tsx
@@ -8,7 +8,7 @@ import type {ApiQueryKey} from 'sentry/utils/queryClient';
 
 interface Props {
   bufferLimit: number;
-  dataSource: string;
+  dataSource: 'events' | 'transactions' | 'search_issues';
   fieldName: string;
   organization: Organization;
   statsPeriod: string;

--- a/static/app/utils/replayCount/useReplayCountForIssues.tsx
+++ b/static/app/utils/replayCount/useReplayCountForIssues.tsx
@@ -24,7 +24,7 @@ export function useReplayCountForIssues({
     hasMany: hasManyError,
   } = useReplayCount({
     bufferLimit,
-    dataSource: 'discover',
+    dataSource: 'events',
     fieldName: 'issue.id',
     organization,
     statsPeriod,

--- a/static/app/utils/replayCount/useReplayCountForTransactions.tsx
+++ b/static/app/utils/replayCount/useReplayCountForTransactions.tsx
@@ -18,7 +18,7 @@ export function useReplayCountForTransactions({
   const organization = useOrganization();
   const {getOne, getMany, hasOne, hasMany} = useReplayCount({
     bufferLimit,
-    dataSource: 'discover',
+    dataSource: 'transactions',
     fieldName: 'transaction',
     organization,
     statsPeriod,

--- a/static/app/utils/replayCount/useReplayExists.tsx
+++ b/static/app/utils/replayCount/useReplayExists.tsx
@@ -10,7 +10,9 @@ export function useReplayExists({start, end}: {end?: string; start?: string} = {
   const organization = useOrganization();
   const {hasOne, hasMany} = useReplayCount({
     bufferLimit: 100,
-    dataSource: 'discover',
+    // The dataSource doesn't matter here - queries on `replay_id` skip the
+    // given dataSource and go straight to `replays`.
+    dataSource: 'events',
     fieldName: 'replay_id',
     organization,
     statsPeriod: '90d',

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.spec.tsx
@@ -446,7 +446,7 @@ describe('LogsInfiniteTable', () => {
         `/organizations/${organization.slug}/replay-count/`,
         expect.objectContaining({
           query: expect.objectContaining({
-            data_source: 'discover',
+            data_source: 'events',
             project: -1,
             query: 'replay_id:[abc123def456,abc123eef457]',
             start: '2025-04-10T08:00:00.000Z',


### PR DESCRIPTION
Instead of using `discover` (which routes between errors and transactions based on the query), reference the underlying dataset directly: `events` for errors, `transactions` for transactions. Type the `dataSource` property so that `discover` is no longer permissible. This helps for tracking down deprecated `transactions` uses and prevents them from coming back. (Once the sole `transactions` use is removed we'll remove it from the DataSource definition).

One weird bit is the useless `dataSource` when `fieldName` is `replay_id`:

https://github.com/getsentry/sentry/blob/bc7e83bbf64e8d93c40f43b21c93f370f319f3db/src/sentry/replays/usecases/replay_counts.py#L96-L103

Anyway, pick a non-deprecated `dataSource` for it so at least it doesn't look like it has to be migrated.

Fixes DAIN-1471.