### PR TITLE
feat(data-export): render export_format extension in button text

### DIFF
--- a/static/app/views/dataExport/dataDownload.spec.tsx
+++ b/static/app/views/dataExport/dataDownload.spec.tsx
@@ -93,6 +93,30 @@ describe('DataDownload', () => {
     ).toBeInTheDocument();
   });
 
+  it('should render CSV file extension when export format is csv', async () => {
+    const status = DownloadStatus.VALID;
+    getDataExportDetails({dateExpired, status, export_format: 'csv'});
+
+    render(<DataDownload />, {initialRouterConfig});
+    await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
+    expect(screen.getByRole('button', {name: 'Download CSV'})).toHaveAttribute(
+      'href',
+      `/api/0/organizations/${organization.slug}/data-export/${dataExportId}/?download=true`
+    );
+  });
+
+  it('should render JSONL file extension when export format is jsonl', async () => {
+    const status = DownloadStatus.VALID;
+    getDataExportDetails({dateExpired, status, export_format: 'jsonl'});
+
+    render(<DataDownload />, {initialRouterConfig});
+    await waitForElementToBeRemoved(() => screen.queryByTestId('loading-indicator'));
+    expect(screen.getByRole('button', {name: 'Download JSONL'})).toHaveAttribute(
+      'href',
+      `/api/0/organizations/${organization.slug}/data-export/${dataExportId}/?download=true`
+    );
+  });
+
   it('should render the Open in Discover button when needed', async () => {
     const status = DownloadStatus.VALID;
     getDataExportDetails({

--- a/static/app/views/dataExport/dataDownload.tsx
+++ b/static/app/views/dataExport/dataDownload.tsx
@@ -51,6 +51,7 @@ type BaseDownload = {
   };
   dateExpired?: string;
   dateFinished?: string;
+  export_format?: 'csv' | 'jsonl';
 };
 
 type ExploreDownload = BaseDownload & {
@@ -313,7 +314,8 @@ export default function DataDownload() {
   };
 
   const renderValid = (): React.ReactNode => {
-    const {dateExpired, checksum} = download;
+    const {dateExpired, checksum, export_format} = download;
+    const exportFormatLabel = export_format?.toUpperCase() ?? 'CSV';
 
     return (
       <Fragment>
@@ -327,7 +329,7 @@ export default function DataDownload() {
             icon={<IconDownload />}
             href={`/api/0/organizations/${orgSlug}/data-export/${dataExportId}/?download=true`}
           >
-            {t('Download CSV')}
+            {t('Download %s', exportFormatLabel)}
           </LinkButton>
           <p>
             {t("That link won't last forever — it expires:")}


### PR DESCRIPTION
In theory you can generate this by requesting a JSONL export in https://github.com/getsentry/sentry/pull/112674, then visiting `/data-export/*`. In practice I get 403 errors everywhere except prod. But if you manually stub out a response payload to the `data-export` fetch request in the page, you can pretend that 403 isn't there.

<img width="583" height="413" alt="image" src="https://github.com/user-attachments/assets/2356e271-4743-44b0-8dae-bec0db7c3002" />

_(ignore the weird text rendering, that's an unrelated local dev setup issue)_

Fixes LOGS-699