### PR TITLE
ref(viewer-context): Remove legacy header fallback

### DIFF
--- a/src/sentry/api/authentication.py
+++ b/src/sentry/api/authentication.py
@@ -779,7 +779,7 @@ class HmacSignatureAuthentication(StandardAuthentication):
 class ViewerContextAuthentication(BaseAuthentication):
     """Authenticate requests using X-Viewer-Context headers.
 
-    Accepts both JWT (HS256) and legacy JSON + HMAC signature formats.
+    Accepts JWT (HS256) ``X-Viewer-Context`` headers.
     Used by trusted services (e.g., Seer) that echo back the viewer context
     originally signed by Sentry.
 
@@ -795,9 +795,8 @@ class ViewerContextAuthentication(BaseAuthentication):
         if not header:
             return None
 
-        signature = request.META.get("HTTP_X_VIEWER_CONTEXT_SIGNATURE")
         verification_keys = _get_verification_keys()
-        vc = viewer_context_from_header(header, signature)
+        vc = viewer_context_from_header(header)
 
         if vc is None or vc.user_id is None:
             # TODO(jstanley): Temporary logging for debugging non-public prod 401s
@@ -809,8 +808,6 @@ class ViewerContextAuthentication(BaseAuthentication):
                     "reason": "vc_not_resolved" if vc is None else "no_user_id",
                     "header_length": len(header),
                     "header_is_jwt": "." in header and header.count(".") == 2,
-                    "signature_present": signature is not None,
-                    "signature_length": len(signature) if signature else 0,
                     "verification_key_count": len(verification_keys),
                     "path": request.path,
                 },

--- a/src/sentry/middleware/viewer_context.py
+++ b/src/sentry/middleware/viewer_context.py
@@ -28,8 +28,6 @@ def ViewerContextMiddleware(
     there is no authenticated *user* (service-to-service calls that
     authenticate via HMAC but have no user session, e.g. Seer → Sentry).
 
-    Accepts both JWT and legacy JSON + HMAC signature formats.
-
     Gated by ``viewer-context.enabled`` (FLAG_NOSTORE).
     """
     enabled = options.get("viewer-context.enabled")
@@ -77,8 +75,7 @@ def _viewer_context_from_jwt_header(request: HttpRequest) -> ViewerContext | Non
     header_value = request.META.get("HTTP_X_VIEWER_CONTEXT")
     if not header_value:
         return None
-    signature = request.META.get("HTTP_X_VIEWER_CONTEXT_SIGNATURE")
-    return viewer_context_from_header(header_value, signature)
+    return viewer_context_from_header(header_value)
 
 
 def _viewer_context_from_request(request: HttpRequest) -> ViewerContext:

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -305,10 +305,12 @@ def collect_user_org_context(
 def get_proxy_headers() -> dict[str, str] | None:
     """Build auth headers for Seer to echo back to Sentry on callbacks.
 
-    Returns a dict of headers (X-Viewer-Context + signature) or None.
+    Returns a single ``X-Viewer-Context`` JWT header, or ``None`` when no
+    ViewerContext is set. Matches the format used by the standard inbound
+    Seer → Sentry path (``X-Viewer-Context`` JWT, no separate signature
+    header), so Sentry's middleware decodes both with the same code path.
     """
-    from sentry.seer.signed_seer_api import sign_viewer_context
-    from sentry.viewer_context import get_viewer_context
+    from sentry.viewer_context import encode_viewer_context, get_viewer_context
 
     ctx = get_viewer_context()
     if ctx is None or ctx.user_id is None:
@@ -317,12 +319,11 @@ def get_proxy_headers() -> dict[str, str] | None:
     if not settings.SEER_API_SHARED_SECRET:
         return None
 
-    context_bytes = orjson.dumps(ctx.serialize())
-    signature = sign_viewer_context(context_bytes)
-    return {
-        "X-Viewer-Context": context_bytes.decode("utf-8"),
-        "X-Viewer-Context-Signature": signature,
-    }
+    try:
+        return {"X-Viewer-Context": encode_viewer_context(ctx)}
+    except Exception:
+        logger.exception("Failed to encode viewer context JWT for proxy headers")
+        return None
 
 
 def fetch_run_status(run_id: int, organization: Organization) -> SeerRunState:

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -731,12 +731,3 @@ def sign_with_seer_secret(body: bytes) -> dict[str, str]:
         )
         metrics.incr("seer.unsigned_request", sample_rate=1.0)
     return auth_headers
-
-
-def sign_viewer_context(context_bytes: bytes) -> str:
-    """Sign the viewer context payload with the shared secret."""
-    return hmac.new(
-        settings.SEER_API_SHARED_SECRET.encode("utf-8"),
-        context_bytes,
-        hashlib.sha256,
-    ).hexdigest()

--- a/src/sentry/viewer_context.py
+++ b/src/sentry/viewer_context.py
@@ -5,14 +5,12 @@ import contextvars
 import dataclasses
 import enum
 import hashlib
-import hmac
 import logging
 import time
 from collections.abc import Generator
 from typing import TYPE_CHECKING, Any
 
 import jwt as pyjwt
-import orjson
 import sentry_sdk
 from django.conf import settings
 
@@ -275,45 +273,17 @@ def decode_viewer_context(
 
 
 def viewer_context_from_header(
-    header_value: str, signature: str | None = None
+    header_value: str,
 ) -> ViewerContext | None:
-    """Decode a ViewerContext from ``X-Viewer-Context`` header(s).
+    """Decode a ViewerContext from the JWT ``X-Viewer-Context`` header."""
+    if not is_jwt_viewer_context(header_value):
+        return None
 
-    Dual-mode for migration:
-    - JWT (HS256) — new format, self-contained
-    - Raw JSON + ``X-Viewer-Context-Signature`` HMAC — legacy format
-    """
-    if is_jwt_viewer_context(header_value):
-        try:
-            return decode_viewer_context(header_value)
-        except Exception:
-            logger.warning("viewer_context.jwt_decode_failed", exc_info=True)
-            return None
-
-    # Legacy: raw JSON + HMAC signature
-    if signature is not None:
-        return _verify_legacy_viewer_context(header_value, signature)
-
-    return None
-
-
-def _verify_legacy_viewer_context(context_json: str, signature: str) -> ViewerContext | None:
-    """Verify and decode a legacy JSON + HMAC-signed viewer context."""
-    keys_by_kid = _get_verification_keys()
-    context_bytes = context_json.encode("utf-8")
-
-    for key in keys_by_kid.values():
-        computed = hmac.new(key.encode("utf-8"), context_bytes, hashlib.sha256).hexdigest()
-        if hmac.compare_digest(computed, signature):
-            try:
-                data = orjson.loads(context_bytes)
-                return ViewerContext.deserialize(data)
-            except Exception:
-                logger.warning("viewer_context.legacy_decode_failed", exc_info=True)
-                return None
-
-    logger.warning("viewer_context.legacy_signature_mismatch")
-    return None
+    try:
+        return decode_viewer_context(header_value)
+    except Exception:
+        logger.warning("viewer_context.jwt_decode_failed", exc_info=True)
+        return None
 
 
 def is_jwt_viewer_context(header_value: str) -> bool:

--- a/tests/sentry/api/bases/test_organization.py
+++ b/tests/sentry/api/bases/test_organization.py
@@ -1,10 +1,7 @@
-import hashlib
-import hmac
 from datetime import timedelta
 from functools import cached_property
 from unittest import mock
 
-import orjson
 import pytest
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.sessions.backends.base import SessionBase
@@ -46,7 +43,13 @@ from sentry.testutils.silo import assume_test_silo_mode
 from sentry.users.services.user.serial import serialize_rpc_user
 from sentry.users.services.user.service import user_service
 from sentry.utils.security.orgauthtoken_token import hash_token
-from sentry.viewer_context import ViewerContext, get_viewer_context, viewer_context_scope
+from sentry.viewer_context import (
+    ActorType,
+    ViewerContext,
+    encode_viewer_context,
+    get_viewer_context,
+    viewer_context_scope,
+)
 
 
 class MockSuperUser:
@@ -329,17 +332,14 @@ class OrganizationPermissionTest(PermissionBaseTestCase):
             )
             AuthIdentity.objects.create(auth_provider=auth_provider, user=user)
 
-        context = orjson.dumps({"user_id": user.id, "actor_type": "user"}).decode()
-        signature = hmac.new(
-            self.VIEWER_CONTEXT_SHARED_SECRET.encode("utf-8"),
-            context.encode("utf-8"),
-            hashlib.sha256,
-        ).hexdigest()
+        context = encode_viewer_context(
+            ViewerContext(user_id=user.id, actor_type=ActorType.USER),
+            key=self.VIEWER_CONTEXT_SHARED_SECRET,
+        )
 
         request = RequestFactory().get("/api/0/organizations/")
         request.session = SessionBase()
         request.META["HTTP_X_VIEWER_CONTEXT"] = context
-        request.META["HTTP_X_VIEWER_CONTEXT_SIGNATURE"] = signature
 
         drf_request = drf_request_from_request(request)
         result = ViewerContextAuthentication().authenticate(drf_request)

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -43,6 +43,7 @@ from sentry.testutils.silo import assume_test_silo_mode, control_silo_test, no_s
 from sentry.types.token import AuthTokenType
 from sentry.utils import jwt
 from sentry.utils.security.orgauthtoken_token import hash_token
+from sentry.viewer_context import ActorType, ViewerContext, encode_viewer_context
 
 
 def _drf_request(data: dict[str, str] | None = None, path: str = "/example") -> Request:
@@ -990,34 +991,23 @@ class TestAuthenticateHeader:
 class TestViewerContextAuthentication(TestCase):
     SHARED_SECRET = "test-seer-api-shared-secret"
 
-    def _sign_context(self, context_json: str) -> str:
-        import hashlib
-        import hmac as hmac_mod
-
-        return hmac_mod.new(
-            self.SHARED_SECRET.encode("utf-8"),
-            context_json.encode("utf-8"),
-            hashlib.sha256,
-        ).hexdigest()
-
     def _make_request(
         self,
         viewer_context: str | None = None,
-        viewer_signature: str | None = None,
     ) -> Request:
         req = RequestFactory().get("/api/0/organizations/")
         if viewer_context is not None:
             req.META["HTTP_X_VIEWER_CONTEXT"] = viewer_context
-        if viewer_signature is not None:
-            req.META["HTTP_X_VIEWER_CONTEXT_SIGNATURE"] = viewer_signature
         return drf_request_from_request(req)
 
     @override_settings(SEER_API_SHARED_SECRET=SHARED_SECRET)
     def test_valid_viewer_context_authenticates(self) -> None:
-        context = orjson.dumps({"user_id": self.user.id, "actor_type": "user"}).decode()
-        signature = self._sign_context(context)
+        context = encode_viewer_context(
+            ViewerContext(user_id=self.user.id, actor_type=ActorType.USER),
+            key=self.SHARED_SECRET,
+        )
 
-        request = self._make_request(viewer_context=context, viewer_signature=signature)
+        request = self._make_request(viewer_context=context)
         result = ViewerContextAuthentication().authenticate(request)
 
         assert result is not None
@@ -1026,16 +1016,7 @@ class TestViewerContextAuthentication(TestCase):
         assert auth is None
 
     @override_settings(SEER_API_SHARED_SECRET=SHARED_SECRET)
-    def test_invalid_signature_returns_none(self) -> None:
-        context = orjson.dumps({"user_id": self.user.id, "actor_type": "user"}).decode()
-
-        request = self._make_request(viewer_context=context, viewer_signature="bad-signature")
-        result = ViewerContextAuthentication().authenticate(request)
-
-        assert result is None
-
-    @override_settings(SEER_API_SHARED_SECRET=SHARED_SECRET)
-    def test_missing_signature_returns_none(self) -> None:
+    def test_non_jwt_header_returns_none(self) -> None:
         context = orjson.dumps({"user_id": self.user.id, "actor_type": "user"}).decode()
 
         request = self._make_request(viewer_context=context)
@@ -1051,39 +1032,44 @@ class TestViewerContextAuthentication(TestCase):
 
     @override_settings(SEER_API_SHARED_SECRET=SHARED_SECRET)
     def test_unknown_user_id_returns_none(self) -> None:
-        context = orjson.dumps({"user_id": 999999999, "actor_type": "user"}).decode()
-        signature = self._sign_context(context)
+        context = encode_viewer_context(
+            ViewerContext(user_id=999999999, actor_type=ActorType.USER),
+            key=self.SHARED_SECRET,
+        )
 
-        request = self._make_request(viewer_context=context, viewer_signature=signature)
+        request = self._make_request(viewer_context=context)
         result = ViewerContextAuthentication().authenticate(request)
 
         assert result is None
 
     @override_settings(SEER_API_SHARED_SECRET=SHARED_SECRET)
     def test_missing_user_id_returns_none(self) -> None:
-        context = orjson.dumps({"actor_type": "system"}).decode()
-        signature = self._sign_context(context)
+        context = encode_viewer_context(
+            ViewerContext(actor_type=ActorType.SYSTEM),
+            key=self.SHARED_SECRET,
+        )
 
-        request = self._make_request(viewer_context=context, viewer_signature=signature)
+        request = self._make_request(viewer_context=context)
         result = ViewerContextAuthentication().authenticate(request)
 
         assert result is None
 
     @override_settings(SEER_API_SHARED_SECRET="")
     def test_empty_secret_returns_none(self) -> None:
-        context = orjson.dumps({"user_id": self.user.id, "actor_type": "user"}).decode()
+        context = encode_viewer_context(
+            ViewerContext(user_id=self.user.id, actor_type=ActorType.USER),
+            key=self.SHARED_SECRET,
+        )
 
-        request = self._make_request(viewer_context=context, viewer_signature="anything")
+        request = self._make_request(viewer_context=context)
         result = ViewerContextAuthentication().authenticate(request)
 
         assert result is None
 
     @override_settings(SEER_API_SHARED_SECRET=SHARED_SECRET)
     def test_jwt_viewer_context_authenticates(self) -> None:
-        from sentry.viewer_context import ActorType, ViewerContext, encode_viewer_context
-
         vc = ViewerContext(user_id=self.user.id, actor_type=ActorType.USER)
-        token = encode_viewer_context(vc)
+        token = encode_viewer_context(vc, key=self.SHARED_SECRET)
 
         request = self._make_request(viewer_context=token)
         result = ViewerContextAuthentication().authenticate(request)
@@ -1095,8 +1081,6 @@ class TestViewerContextAuthentication(TestCase):
 
     @override_settings(SEER_API_SHARED_SECRET=SHARED_SECRET)
     def test_jwt_wrong_key_returns_none(self) -> None:
-        from sentry.viewer_context import ActorType, ViewerContext, encode_viewer_context
-
         vc = ViewerContext(user_id=self.user.id, actor_type=ActorType.USER)
         token = encode_viewer_context(vc, key="wrong-key")
 

--- a/tests/sentry/api/test_authentication.py
+++ b/tests/sentry/api/test_authentication.py
@@ -1067,19 +1067,6 @@ class TestViewerContextAuthentication(TestCase):
         assert result is None
 
     @override_settings(SEER_API_SHARED_SECRET=SHARED_SECRET)
-    def test_jwt_viewer_context_authenticates(self) -> None:
-        vc = ViewerContext(user_id=self.user.id, actor_type=ActorType.USER)
-        token = encode_viewer_context(vc, key=self.SHARED_SECRET)
-
-        request = self._make_request(viewer_context=token)
-        result = ViewerContextAuthentication().authenticate(request)
-
-        assert result is not None
-        user, auth = result
-        assert user.id == self.user.id
-        assert auth is None
-
-    @override_settings(SEER_API_SHARED_SECRET=SHARED_SECRET)
     def test_jwt_wrong_key_returns_none(self) -> None:
         vc = ViewerContext(user_id=self.user.id, actor_type=ActorType.USER)
         token = encode_viewer_context(vc, key="wrong-key")

--- a/tests/sentry/middleware/test_viewer_context.py
+++ b/tests/sentry/middleware/test_viewer_context.py
@@ -356,42 +356,7 @@ class ViewerContextMiddlewareTest(TestCase):
 
     @override_options({"viewer-context.enabled": True})
     @override_settings(SEER_API_SHARED_SECRET="test-secret")
-    def test_legacy_hmac_header_sets_viewer_context(self):
-        import hashlib
-        import hmac
-
-        import orjson
-
-        context_data = {"actor_type": "integration", "organization_id": 42}
-        context_bytes = orjson.dumps(context_data)
-        signature = hmac.new(b"test-secret", context_bytes, hashlib.sha256).hexdigest()
-
-        captured: list = []
-
-        def get_response(request):
-            captured.append(get_viewer_context())
-            return MagicMock(status_code=200)
-
-        middleware = ViewerContextMiddleware(get_response)
-
-        request = self.factory.get(
-            "/",
-            HTTP_X_VIEWER_CONTEXT=context_bytes.decode("utf-8"),
-            HTTP_X_VIEWER_CONTEXT_SIGNATURE=signature,
-        )
-        request.user = AnonymousUser()
-        request.auth = None
-
-        middleware(request)
-
-        assert len(captured) == 1
-        ctx = captured[0]
-        assert ctx.organization_id == 42
-        assert ctx.actor_type == ActorType.INTEGRATION
-
-    @override_options({"viewer-context.enabled": True})
-    @override_settings(SEER_API_SHARED_SECRET="test-secret")
-    def test_legacy_hmac_bad_signature_ignored(self):
+    def test_non_jwt_header_ignored(self):
         captured: list = []
 
         def get_response(request):
@@ -403,7 +368,6 @@ class ViewerContextMiddlewareTest(TestCase):
         request = self.factory.get(
             "/",
             HTTP_X_VIEWER_CONTEXT='{"actor_type": "integration", "organization_id": 42}',
-            HTTP_X_VIEWER_CONTEXT_SIGNATURE="bad-signature",
         )
         request.user = AnonymousUser()
         request.auth = None

--- a/tests/sentry/seer/explorer/test_client_utils.py
+++ b/tests/sentry/seer/explorer/test_client_utils.py
@@ -1,12 +1,17 @@
+import jwt
+from django.test import override_settings
+
 from sentry.models.organizationmember import OrganizationMember
 from sentry.seer.explorer.client_utils import (
     collect_user_org_context,
+    get_proxy_headers,
     has_seer_explorer_access_with_detail,
     snapshot_to_markdown,
 )
 from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import TestCase
 from sentry.testutils.requests import make_request
+from sentry.viewer_context import ActorType, ViewerContext, viewer_context_scope
 
 
 class TestHasSeerExplorerAccessWithDetail(TestCase):
@@ -253,3 +258,58 @@ class SnapshotToMarkdownTest(TestCase):
         result = snapshot_to_markdown(snapshot)
         assert "# Widget" in result
         assert '- "some string"' in result
+
+
+_TEST_SECRET = "test-secret-must-be-at-least-32-bytes-long-for-hs256"
+
+
+@override_settings(SEER_API_SHARED_SECRET=_TEST_SECRET)
+class TestGetProxyHeaders(TestCase):
+    """Headers Seer echoes back to Sentry on Code Mode callbacks."""
+
+    def test_no_viewer_context_returns_none(self) -> None:
+        # Outside any viewer_context_scope — nothing to encode.
+        assert get_proxy_headers() is None
+
+    def test_viewer_context_without_user_returns_none(self) -> None:
+        # System-only context (no user_id) shouldn't produce callback auth —
+        # callbacks only make sense for user-initiated runs.
+        with viewer_context_scope(ViewerContext(organization_id=42)):
+            assert get_proxy_headers() is None
+
+    @override_settings(SEER_API_SHARED_SECRET="")
+    def test_no_shared_secret_returns_none(self) -> None:
+        with viewer_context_scope(
+            ViewerContext(organization_id=42, user_id=7, actor_type=ActorType.USER)
+        ):
+            assert get_proxy_headers() is None
+
+    def test_returns_single_jwt_header(self) -> None:
+        with viewer_context_scope(
+            ViewerContext(organization_id=42, user_id=7, actor_type=ActorType.USER)
+        ):
+            headers = get_proxy_headers()
+        assert headers is not None
+        # Single header — no separate signature header (legacy two-header
+        # format replaced with self-contained JWT).
+        assert set(headers.keys()) == {"X-Viewer-Context"}
+
+    def test_jwt_payload_carries_viewer_fields(self) -> None:
+        with viewer_context_scope(
+            ViewerContext(organization_id=42, user_id=7, actor_type=ActorType.USER)
+        ):
+            headers = get_proxy_headers()
+        assert headers is not None
+        decoded = jwt.decode(
+            headers["X-Viewer-Context"],
+            _TEST_SECRET,
+            algorithms=["HS256"],
+            issuer="sentry",
+        )
+        assert decoded["organization_id"] == 42
+        assert decoded["user_id"] == 7
+        assert decoded["actor_type"] == "user"
+        # Standard JWT claims present
+        assert "iat" in decoded
+        assert "exp" in decoded
+        assert decoded["iss"] == "sentry"


### PR DESCRIPTION
Remove the legacy raw JSON plus `X-Viewer-Context-Signature` fallback from Sentry and only accept JWT-based `X-Viewer-Context` headers.

This is the Sentry-side cleanup after restoring JWT proxy-header propagation. With the JWT path in place, keeping the legacy branch only preserves dead parsing logic in the viewer-context middleware and auth layer. This also updates the Sentry tests that were still constructing the two-header format so they exercise the current JWT contract instead.

This PR is stacked on top of #113499.
It should land after getsentry/seer#5902.