### PR TITLE
fix(integrations): Match installed repos by external_id

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_integration_repos.py
+++ b/src/sentry/integrations/api/endpoints/organization_integration_repos.py
@@ -64,7 +64,7 @@ class OrganizationIntegrationReposEndpoint(CellOrganizationIntegrationBaseEndpoi
         installed_repos = Repository.objects.filter(
             integration_id=integration.id, organization_id=organization.id
         ).exclude(status=ObjectStatus.HIDDEN)
-        installed_repo_names = {installed_repo.name for installed_repo in installed_repos}
+        installed_external_ids = {repo.external_id for repo in installed_repos}
 
         install = integration.get_installation(organization_id=organization.id)
 
@@ -90,12 +90,12 @@ class OrganizationIntegrationReposEndpoint(CellOrganizationIntegrationBaseEndpoi
                     name=repo["name"],
                     identifier=repo["identifier"],
                     defaultBranch=repo.get("default_branch"),
-                    isInstalled=repo["identifier"] in installed_repo_names,
+                    isInstalled=repo["external_id"] in installed_external_ids,
                     externalId=repo["external_id"],
                     url=repo.get("url"),
                 )
                 for repo in repositories
-                if not installable_only or repo["identifier"] not in installed_repo_names
+                if not installable_only or repo["external_id"] not in installed_external_ids
             ]
             return self.respond(
                 {"repos": serialized_repositories, "searchable": install.repo_search}

--- a/tests/sentry/integrations/api/endpoints/test_organization_integration_repos.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integration_repos.py
@@ -73,6 +73,7 @@ class OrganizationIntegrationReposTest(APITestCase):
             project=self.project,
             integration_id=self.integration.id,
             name="Example/rad-repo",
+            external_id="rad-repo",
         )
 
         response = self.client.get(self.path, format="json", data={"installableOnly": "true"})
@@ -123,6 +124,7 @@ class OrganizationIntegrationReposTest(APITestCase):
             project=self.project,
             integration_id=self.integration.id,
             name="Example/rad-repo",
+            external_id="rad-repo",
         )
 
         response = self.client.get(self.path, format="json", data={"installableOnly": "true"})
@@ -164,7 +166,7 @@ class OrganizationIntegrationReposTest(APITestCase):
                 "name": "rad-repo",
                 "identifier": "Example2/rad-repo",
                 "default_branch": "dev",
-                "external_id": "rad-repo",
+                "external_id": "example2-rad-repo",
             },
         ]
 
@@ -172,6 +174,7 @@ class OrganizationIntegrationReposTest(APITestCase):
             project=self.project,
             integration_id=self.integration.id,
             name="Example/rad-repo",
+            external_id="rad-repo",
         )
 
         response = self.client.get(self.path, format="json")
@@ -191,7 +194,7 @@ class OrganizationIntegrationReposTest(APITestCase):
                     "name": "rad-repo",
                     "identifier": "Example2/rad-repo",
                     "defaultBranch": "dev",
-                    "externalId": "rad-repo",
+                    "externalId": "example2-rad-repo",
                     "isInstalled": False,
                     "url": None,
                 },
@@ -316,6 +319,7 @@ class OrganizationIntegrationReposTest(APITestCase):
             project=self.project,
             integration_id=self.integration.id,
             name="Example/rad-repo",
+            external_id="rad-repo",
         )
 
         response = self.client.get(
@@ -339,6 +343,42 @@ class OrganizationIntegrationReposTest(APITestCase):
             ],
             "searchable": True,
         }
+
+    @patch(
+        "sentry.integrations.github.integration.GitHubIntegration.get_repositories", return_value=[]
+    )
+    def test_is_installed_matches_on_external_id_after_rename(
+        self, get_repositories: MagicMock
+    ) -> None:
+        """
+        When a repo is renamed at the provider, the API returns the new
+        identifier while the stored Repository row still has the old name.
+        isInstalled should match on the stable external_id.
+        """
+        get_repositories.return_value = [
+            {
+                "name": "new-name",
+                "identifier": "Example/new-name",
+                "default_branch": "main",
+                "external_id": "rad-repo",
+            },
+        ]
+
+        self.create_repo(
+            project=self.project,
+            integration_id=self.integration.id,
+            name="Example/old-name",
+            external_id="rad-repo",
+        )
+
+        response = self.client.get(self.path, format="json")
+
+        assert response.status_code == 200, response.content
+        assert response.data["repos"][0]["isInstalled"] is True
+
+        response = self.client.get(self.path, format="json", data={"installableOnly": "true"})
+        assert response.status_code == 200, response.content
+        assert response.data["repos"] == []
 
     def test_no_repository_method(self) -> None:
         integration = self.create_integration(


### PR DESCRIPTION
The OrganizationIntegrationReposEndpoint compared the stored
Repository.name against the provider's repo identifier when computing
isInstalled and applying the installableOnly filter. That worked by
coincidence because Repository.name happens to hold the slug, but it
gets stale when a repo is renamed on the provider side — the API
returns the new identifier while the DB still holds the old name,
so isInstalled would report False for a repo that is in fact
installed.

Switch the comparison to external_id, which is the stable
provider-side identifier and is part of the (organization_id,
provider, external_id) uniqueness constraint on Repository.