### PR TITLE
feat(eslint): Extend no-flag-comments to catch `=`, `*`, `_`, `#`, `~` separators

### DIFF
--- a/scripts/routes.ts
+++ b/scripts/routes.ts
@@ -10,7 +10,7 @@
 //   node scripts/routes.ts --origin https://sentry.io --orgId sentry
 //   node scripts/routes.ts --all
 //
-// ─── AGENT MAINTENANCE GUIDE ─────────────────────────────────────────────────
+// AGENT MAINTENANCE GUIDE
 //
 // HOW THE PARSER WORKS
 //   This script reads static/app/router/routes.tsx line by line and builds full
@@ -73,8 +73,7 @@
 //   Used when --defaults is passed.  If a new :param appears in routes.tsx
 //   that isn't in PARAM_DEFAULTS, it will remain unresolved.  Add it with any
 //   realistic value (fixture IDs, slugs, etc. from tests/js/fixtures/).
-//
-// ─────────────────────────────────────────────────────────────────────────────
+
 import fs from 'node:fs';
 import path from 'node:path';
 import {parseArgs} from 'node:util';

--- a/static/app/components/core/form/__stories__/formDemos.tsx
+++ b/static/app/components/core/form/__stories__/formDemos.tsx
@@ -20,9 +20,7 @@ import {Flex} from '@sentry/scraps/layout';
 
 import {t} from 'sentry/locale';
 
-// ──────────────────────────────────────────────
 // form.mdx demos
-// ──────────────────────────────────────────────
 
 const quickStartSchema = z.object({
   email: z.email('Please enter a valid email'),
@@ -199,9 +197,7 @@ export function ConditionalDemo() {
   );
 }
 
-// ──────────────────────────────────────────────
 // fields.mdx demos
-// ──────────────────────────────────────────────
 
 export function BaseFieldDemo() {
   const form = useScrapsForm({
@@ -248,9 +244,7 @@ export function BaseFieldDemo() {
   );
 }
 
-// ──────────────────────────────────────────────
 // autoSaveForm.mdx demos
-// ──────────────────────────────────────────────
 
 const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 

--- a/static/app/views/releases/detail/index.tsx
+++ b/static/app/views/releases/detail/index.tsx
@@ -229,9 +229,6 @@ function ReleasesDetail({
   );
 }
 
-// ========================================================================
-// RELEASE DETAIL CONTAINER
-// ========================================================================
 function ReleasesDetailContainer() {
   const params = useParams<{release: string}>();
   const location = useLocation();

--- a/static/eslint/eslintPluginSentry/no-flag-comments.spec.ts
+++ b/static/eslint/eslintPluginSentry/no-flag-comments.spec.ts
@@ -11,6 +11,8 @@ ruleTester.run('no-flag-comments', noFlagComments, {
     {code: '/** JSDoc comment */'},
     {code: '// a - b - c'},
     {code: '// --strict flag enables strict mode'},
+    {code: '// =='},
+    {code: '// -=-=-=-=-'},
   ],
   invalid: [
     {
@@ -24,6 +26,38 @@ ruleTester.run('no-flag-comments', noFlagComments, {
     {
       code: '// ----------',
       errors: [{messageId: 'noFlagComment'}],
+    },
+    {
+      code: '// ========================================================================',
+      errors: [{messageId: 'noFlagComment'}],
+    },
+    {
+      code: '// ***',
+      errors: [{messageId: 'noFlagComment'}],
+    },
+    {
+      code: '// ___',
+      errors: [{messageId: 'noFlagComment'}],
+    },
+    {
+      code: '// ###',
+      errors: [{messageId: 'noFlagComment'}],
+    },
+    {
+      code: '// ~~~',
+      errors: [{messageId: 'noFlagComment'}],
+    },
+    {
+      code: '// ─────────',
+      errors: [{messageId: 'noFlagComment'}],
+    },
+    {
+      code: [
+        '// ========================================================================',
+        '// RELEASE DETAIL CONTAINER',
+        '// ========================================================================',
+      ].join('\n'),
+      errors: [{messageId: 'noFlagComment'}, {messageId: 'noFlagComment'}],
     },
     {
       code: [

--- a/static/eslint/eslintPluginSentry/no-flag-comments.ts
+++ b/static/eslint/eslintPluginSentry/no-flag-comments.ts
@@ -4,7 +4,8 @@ export const noFlagComments = ESLintUtils.RuleCreator.withoutDocs({
   meta: {
     type: 'suggestion',
     docs: {
-      description: 'Disallow flag-style section separator comments (e.g. // ----------)',
+      description:
+        'Disallow flag-style section separator comments (e.g. // ---------- or // ==========)',
     },
     schema: [],
     messages: {
@@ -16,7 +17,10 @@ export const noFlagComments = ESLintUtils.RuleCreator.withoutDocs({
     return {
       Program() {
         for (const comment of context.sourceCode.getAllComments()) {
-          if (comment.type === 'Line' && /^-{3,}\s*$/.test(comment.value.trim())) {
+          if (
+            comment.type === 'Line' &&
+            /^([-=*_#~─])\1{2,}\s*$/u.test(comment.value.trim())
+          ) {
             context.report({
               loc: comment.loc,
               messageId: 'noFlagComment',


### PR DESCRIPTION
Previously the rule only matched `---` style flag separators. Extend the
pattern to catch other common separator characters so things like
`// ======` banners are also flagged.