### PR TITLE
feat(projects): Add create_project_key, delete_project_key, delete_project RPCs

### DIFF
--- a/src/sentry/projects/services/project/impl.py
+++ b/src/sentry/projects/services/project/impl.py
@@ -192,3 +192,28 @@ class DatabaseBackedProjectService(ProjectService):
             project.save()
 
         return serialize_project(project)
+
+    def delete_project(self, *, organization_id: int, project_id: int) -> bool:
+        from sentry.constants import ObjectStatus
+        from sentry.deletions.models.scheduleddeletion import CellScheduledDeletion
+
+        try:
+            project = Project.objects.get(id=project_id, organization_id=organization_id)
+        except Project.DoesNotExist:
+            return False
+
+        if project.is_internal_project():
+            # Match the project-details endpoint's protection; callers
+            # should never hit this for Stripe Projects resources, but be
+            # defensive.
+            return False
+
+        # Atomic ACTIVE→PENDING_DELETION guards against double-delete races;
+        # if the row is already PENDING_DELETION, ``updated`` is 0 and we
+        # short-circuit (the earlier call already scheduled deletion).
+        updated = Project.objects.filter(id=project.id, status=ObjectStatus.ACTIVE).update(
+            status=ObjectStatus.PENDING_DELETION
+        )
+        if updated:
+            CellScheduledDeletion.schedule(project, days=0)
+        return True

--- a/src/sentry/projects/services/project/impl.py
+++ b/src/sentry/projects/services/project/impl.py
@@ -6,6 +6,7 @@ from sentry.api.helpers.default_symbol_sources import set_default_symbol_sources
 from sentry.api.serializers import ProjectSerializer
 from sentry.auth.services.auth import AuthenticationContext
 from sentry.constants import ObjectStatus
+from sentry.deletions.models.scheduleddeletion import CellScheduledDeletion
 from sentry.hybridcloud.rpc import OptionValue
 from sentry.hybridcloud.rpc.filter_query import OpaqueSerializedResponse
 from sentry.models.options.project_option import ProjectOption
@@ -194,9 +195,17 @@ class DatabaseBackedProjectService(ProjectService):
         return serialize_project(project)
 
     def delete_project(self, *, organization_id: int, project_id: int) -> bool:
-        from sentry.constants import ObjectStatus
-        from sentry.deletions.models.scheduleddeletion import CellScheduledDeletion
+        """Soft-delete a project; matches the behavior of the project DELETE
+        endpoint except it does NOT write an audit log entry (callers are
+        responsible for auditing) and does NOT schedule a Seer grouping-
+        records cleanup (Stripe Projects sandboxes aren't similarity-
+        backfilled so there's nothing to clean).
 
+        Idempotent: a second call on an already-PENDING_DELETION row
+        returns True without re-scheduling. Returns False if the project
+        doesn't exist, doesn't belong to the given org, or is the internal
+        project (``settings.SENTRY_PROJECT``).
+        """
         try:
             project = Project.objects.get(id=project_id, organization_id=organization_id)
         except Project.DoesNotExist:
@@ -208,12 +217,19 @@ class DatabaseBackedProjectService(ProjectService):
             # defensive.
             return False
 
-        # Atomic ACTIVE→PENDING_DELETION guards against double-delete races;
+        # Atomic ACTIVE → PENDING_DELETION guards against double-delete races;
         # if the row is already PENDING_DELETION, ``updated`` is 0 and we
         # short-circuit (the earlier call already scheduled deletion).
         updated = Project.objects.filter(id=project.id, status=ObjectStatus.ACTIVE).update(
             status=ObjectStatus.PENDING_DELETION
         )
         if updated:
+            # Rename the slug so a recreated project with the same slug
+            # doesn't collide with the pending-deletion row during its
+            # 30-day retention window. The endpoint (project_details.py)
+            # does this step immediately after scheduling; without it,
+            # deleting+recreating a Stripe Projects resource in quick
+            # succession would fail with a uniqueness error.
+            project.rename_on_pending_deletion()
             CellScheduledDeletion.schedule(project, days=0)
         return True

--- a/src/sentry/projects/services/project/impl.py
+++ b/src/sentry/projects/services/project/impl.py
@@ -217,19 +217,30 @@ class DatabaseBackedProjectService(ProjectService):
             # defensive.
             return False
 
-        # Atomic ACTIVE → PENDING_DELETION guards against double-delete races;
-        # if the row is already PENDING_DELETION, ``updated`` is 0 and we
-        # short-circuit (the earlier call already scheduled deletion).
-        updated = Project.objects.filter(id=project.id, status=ObjectStatus.ACTIVE).update(
-            status=ObjectStatus.PENDING_DELETION
-        )
-        if updated:
-            # Rename the slug so a recreated project with the same slug
-            # doesn't collide with the pending-deletion row during its
-            # 30-day retention window. The endpoint (project_details.py)
-            # does this step immediately after scheduling; without it,
-            # deleting+recreating a Stripe Projects resource in quick
-            # succession would fail with a uniqueness error.
-            project.rename_on_pending_deletion()
-            CellScheduledDeletion.schedule(project, days=0)
+        # Wrap the three-step deletion in a transaction so a failure on
+        # ``CellScheduledDeletion.schedule`` or ``rename_on_pending_deletion``
+        # doesn't leave the row in PENDING_DELETION with no actual
+        # deletion scheduled -- a subsequent retry would find the row
+        # already PENDING_DELETION and skip the whole block, orphaning
+        # it forever.
+        with transaction.atomic(router.db_for_write(Project)):
+            # Atomic ACTIVE → PENDING_DELETION guards against
+            # double-delete races; if the row is already
+            # PENDING_DELETION, ``updated`` is 0 and we short-circuit
+            # (the earlier call already scheduled deletion).
+            updated = Project.objects.filter(id=project.id, status=ObjectStatus.ACTIVE).update(
+                status=ObjectStatus.PENDING_DELETION
+            )
+            if updated:
+                # Schedule first (matches the endpoint's order in
+                # project_details.py); if rename fails after this, the
+                # deletion task still runs and the row gets cleaned up
+                # on its normal schedule.
+                CellScheduledDeletion.schedule(project, days=0)
+                # Rename the slug so a recreated project with the same
+                # slug doesn't collide with the pending-deletion row
+                # during its retention window. Without this,
+                # deleting+recreating a Stripe Projects resource in
+                # quick succession would fail with a uniqueness error.
+                project.rename_on_pending_deletion()
         return True

--- a/src/sentry/projects/services/project/service.py
+++ b/src/sentry/projects/services/project/service.py
@@ -116,5 +116,15 @@ class ProjectService(RpcService):
     ) -> RpcProject:
         pass
 
+    @cell_rpc_method(resolve=ByOrganizationId())
+    @abstractmethod
+    def delete_project(self, *, organization_id: int, project_id: int) -> bool:
+        """Soft-delete a project: mark it ``PENDING_DELETION`` and schedule a
+        ``ScheduledDeletion``, matching the behavior of the project DELETE
+        endpoint. Returns True if the project existed and was marked for
+        deletion, False otherwise (idempotent no-op).
+        """
+        pass
+
 
 project_service = ProjectService.create_delegation()

--- a/src/sentry/projects/services/project/service.py
+++ b/src/sentry/projects/services/project/service.py
@@ -119,10 +119,19 @@ class ProjectService(RpcService):
     @cell_rpc_method(resolve=ByOrganizationId())
     @abstractmethod
     def delete_project(self, *, organization_id: int, project_id: int) -> bool:
-        """Soft-delete a project: mark it ``PENDING_DELETION`` and schedule a
-        ``ScheduledDeletion``, matching the behavior of the project DELETE
-        endpoint. Returns True if the project existed and was marked for
-        deletion, False otherwise (idempotent no-op).
+        """Soft-delete a project; matches the behavior of the project
+        DELETE endpoint except it does NOT write an audit log entry and
+        does NOT schedule a Seer grouping-records cleanup.
+
+        Idempotent: a second call on an already-PENDING_DELETION row
+        returns True without re-scheduling. Returns False if the
+        project doesn't exist, doesn't belong to the given org, or is
+        the internal project (``settings.SENTRY_PROJECT``).
+
+        **Callers are responsible for creating any audit log entries** --
+        this RPC deliberately does not write them on their behalf.
+        Stripe Projects (the only current caller) audits at its own
+        layer so auditing here would double-count.
         """
         pass
 

--- a/src/sentry/projects/services/project_key/impl.py
+++ b/src/sentry/projects/services/project_key/impl.py
@@ -40,3 +40,26 @@ class DatabaseBackedProjectKeyService(ProjectKeyService):
         self, *, cell_name: str, project_id: int, role: ProjectKeyRole
     ) -> RpcProjectKey | None:
         return self._get_project_key(project_id=project_id, role=role)
+
+    def create_project_key(
+        self, *, organization_id: int, project_id: int, label: str | None = None
+    ) -> RpcProjectKey | None:
+        from sentry.models.project import Project
+
+        try:
+            project = Project.objects.get(id=project_id, organization_id=organization_id)
+        except Project.DoesNotExist:
+            return None
+
+        key = ProjectKey.objects.create(project=project, label=label)
+        return serialize_project_key(key)
+
+    def delete_project_key(self, *, organization_id: int, project_id: int, public_key: str) -> bool:
+        # Scope by organization+project so a stolen or malformed key value
+        # can't delete keys on an unrelated project.
+        deleted_count, _ = ProjectKey.objects.filter(
+            project__organization_id=organization_id,
+            project_id=project_id,
+            public_key=public_key,
+        ).delete()
+        return deleted_count > 0

--- a/src/sentry/projects/services/project_key/impl.py
+++ b/src/sentry/projects/services/project_key/impl.py
@@ -65,11 +65,20 @@ class DatabaseBackedProjectKeyService(ProjectKeyService):
         # bypasses the per-instance override that emits the outbox for
         # cross-silo replica cleanup. Fetch the row first so the
         # model-level delete() runs and outboxes correctly.
+        #
+        # ``use_case=UseCase.USER`` matches the HTTP endpoint's
+        # ``for_request`` filter (models/projectkey.py), which protects
+        # internal keys (PROFILING, TEMPEST, DEMO) from deletion by
+        # non-superusers. Stripe Projects only ever creates USER keys
+        # via ``create_project_key``, so this filter is both correct
+        # and hardening against a caller that supplies an unexpected
+        # public_key value.
         try:
             key = ProjectKey.objects.get(
                 project__organization_id=organization_id,
                 project_id=project_id,
                 public_key=public_key,
+                use_case=UseCase.USER.value,
             )
         except ProjectKey.DoesNotExist:
             return False

--- a/src/sentry/projects/services/project_key/impl.py
+++ b/src/sentry/projects/services/project_key/impl.py
@@ -1,5 +1,6 @@
 from django.db.models import F
 
+from sentry.models.project import Project
 from sentry.models.projectkey import ProjectKey, UseCase
 from sentry.projects.services.project_key import ProjectKeyRole, ProjectKeyService, RpcProjectKey
 from sentry.projects.services.project_key.serial import serialize_project_key
@@ -26,8 +27,6 @@ class DatabaseBackedProjectKeyService(ProjectKeyService):
     def get_default_project_key(
         self, *, organization_id: int, project_id: int
     ) -> RpcProjectKey | None:
-        from sentry.models.project import Project
-
         try:
             project = Project.objects.get_from_cache(id=project_id)
         except Project.DoesNotExist:
@@ -44,8 +43,12 @@ class DatabaseBackedProjectKeyService(ProjectKeyService):
     def create_project_key(
         self, *, organization_id: int, project_id: int, label: str | None = None
     ) -> RpcProjectKey | None:
-        from sentry.models.project import Project
-
+        """Create a new ProjectKey under the given project. ``label`` is
+        the display name shown in the Keys list UI; when None or empty,
+        ProjectKey.save() auto-generates a random petname (see
+        projectkey.py) rather than leaving the label blank. Returns the
+        serialized key or None if the project doesn't exist under the
+        given organization."""
         try:
             project = Project.objects.get(id=project_id, organization_id=organization_id)
         except Project.DoesNotExist:
@@ -57,9 +60,18 @@ class DatabaseBackedProjectKeyService(ProjectKeyService):
     def delete_project_key(self, *, organization_id: int, project_id: int, public_key: str) -> bool:
         # Scope by organization+project so a stolen or malformed key value
         # can't delete keys on an unrelated project.
-        deleted_count, _ = ProjectKey.objects.filter(
-            project__organization_id=organization_id,
-            project_id=project_id,
-            public_key=public_key,
-        ).delete()
-        return deleted_count > 0
+        #
+        # ProjectKey is a ReplicatedCellModel; a naive QuerySet.delete()
+        # bypasses the per-instance override that emits the outbox for
+        # cross-silo replica cleanup. Fetch the row first so the
+        # model-level delete() runs and outboxes correctly.
+        try:
+            key = ProjectKey.objects.get(
+                project__organization_id=organization_id,
+                project_id=project_id,
+                public_key=public_key,
+            )
+        except ProjectKey.DoesNotExist:
+            return False
+        key.delete()
+        return True

--- a/src/sentry/projects/services/project_key/service.py
+++ b/src/sentry/projects/services/project_key/service.py
@@ -42,5 +42,27 @@ class ProjectKeyService(RpcService):
     ) -> RpcProjectKey | None:
         pass
 
+    @cell_rpc_method(resolve=ByOrganizationId())
+    @abstractmethod
+    def create_project_key(
+        self, *, organization_id: int, project_id: int, label: str | None = None
+    ) -> RpcProjectKey | None:
+        """Create a new ProjectKey for the given project.
+
+        ``label`` is the display name shown in the Keys list UI. Returns the
+        serialized key, or None if the project does not exist.
+        """
+        pass
+
+    @cell_rpc_method(resolve=ByOrganizationId())
+    @abstractmethod
+    def delete_project_key(self, *, organization_id: int, project_id: int, public_key: str) -> bool:
+        """Delete a ProjectKey by its public key value.
+
+        Returns True if a matching key existed and was deleted, False
+        otherwise (idempotent no-op).
+        """
+        pass
+
 
 project_key_service = ProjectKeyService.create_delegation()

--- a/src/sentry/projects/services/project_key/service.py
+++ b/src/sentry/projects/services/project_key/service.py
@@ -47,20 +47,35 @@ class ProjectKeyService(RpcService):
     def create_project_key(
         self, *, organization_id: int, project_id: int, label: str | None = None
     ) -> RpcProjectKey | None:
-        """Create a new ProjectKey for the given project.
+        """Create a new ProjectKey under the given project.
 
-        ``label`` is the display name shown in the Keys list UI. Returns the
-        serialized key, or None if the project does not exist.
+        ``label`` is the display name shown in the Keys list UI; when
+        None or empty, ``ProjectKey.save()`` auto-generates a random
+        petname rather than leaving the label blank. Returns the
+        serialized key, or None if the project does not exist under
+        the given organization.
+
+        Callers are responsible for creating any audit log entries --
+        this RPC does not write them on their behalf.
         """
         pass
 
     @cell_rpc_method(resolve=ByOrganizationId())
     @abstractmethod
     def delete_project_key(self, *, organization_id: int, project_id: int, public_key: str) -> bool:
-        """Delete a ProjectKey by its public key value.
+        """Delete a ProjectKey by its public-key value.
+
+        Scoped by ``organization_id + project_id + public_key`` so a
+        stolen or malformed key value cannot delete keys on an
+        unrelated project. Only keys with ``use_case=UseCase.USER`` are
+        matched -- internal keys (PROFILING, TEMPEST, DEMO) are
+        protected, matching the HTTP endpoint's ``for_request`` filter.
 
         Returns True if a matching key existed and was deleted, False
         otherwise (idempotent no-op).
+
+        Callers are responsible for creating any audit log entries --
+        this RPC does not write them on their behalf.
         """
         pass
 

--- a/tests/sentry/hybridcloud/test_project.py
+++ b/tests/sentry/hybridcloud/test_project.py
@@ -226,3 +226,31 @@ def test_delete_project_idempotent_on_second_call() -> None:
         app_label="sentry", model_name="Project", object_id=project.id
     )
     assert schedules.count() == 1
+
+
+@django_db_all(transaction=True)
+def test_delete_project_rolls_back_on_failure() -> None:
+    """If ``rename_on_pending_deletion`` or ``CellScheduledDeletion.schedule``
+    raises, the status update must roll back so a retry can succeed.
+    Without the transaction wrapper the row would be stuck in
+    PENDING_DELETION with no scheduled deletion -- a replay would find
+    status != ACTIVE and skip the whole block, orphaning the project."""
+    from unittest import mock
+
+    from sentry.constants import ObjectStatus
+
+    org = Factories.create_organization()
+    project = Factories.create_project(organization=org)
+
+    with mock.patch.object(
+        Project,
+        "rename_on_pending_deletion",
+        side_effect=RuntimeError("simulated downstream failure"),
+    ):
+        with pytest.raises(RuntimeError):
+            project_service.delete_project(organization_id=org.id, project_id=project.id)
+
+    # The transaction must have rolled back the status update; the
+    # project is still ACTIVE and a retry can succeed.
+    project.refresh_from_db()
+    assert project.status == ObjectStatus.ACTIVE

--- a/tests/sentry/hybridcloud/test_project.py
+++ b/tests/sentry/hybridcloud/test_project.py
@@ -150,3 +150,79 @@ def test_update_project() -> None:
     )
     project = Project.objects.get(id=project.id)
     assert project.status != 99
+
+
+@django_db_all(transaction=True)
+def test_delete_project_happy_path() -> None:
+    """Soft-delete: status flips to PENDING_DELETION, slug is renamed so
+    the original can be reused, and a CellScheduledDeletion is queued.
+    """
+    from sentry.constants import ObjectStatus
+    from sentry.deletions.models.scheduleddeletion import CellScheduledDeletion
+
+    org = Factories.create_organization()
+    project = Factories.create_project(organization=org, slug="my-proj")
+    original_slug = project.slug
+
+    result = project_service.delete_project(organization_id=org.id, project_id=project.id)
+
+    assert result is True
+    project.refresh_from_db()
+    assert project.status == ObjectStatus.PENDING_DELETION
+    # rename_on_pending_deletion() replaces the slug with a random token
+    # so the original slug can be reused by a new project before the
+    # 30-day retention elapses. Concrete format is an implementation
+    # detail; assert only that the original slug is no longer in use.
+    assert project.slug != original_slug
+    # Scheduled deletion is queued for the deletion task.
+    assert CellScheduledDeletion.objects.filter(
+        app_label="sentry", model_name="Project", object_id=project.id
+    ).exists()
+    # The freed slug must actually be available for reuse.
+    reused = Factories.create_project(organization=org, slug=original_slug)
+    assert reused.slug == original_slug
+
+
+@django_db_all(transaction=True)
+def test_delete_project_missing_returns_false() -> None:
+    org = Factories.create_organization()
+    result = project_service.delete_project(organization_id=org.id, project_id=999_999_999)
+    assert result is False
+
+
+@django_db_all(transaction=True)
+def test_delete_project_wrong_org_returns_false() -> None:
+    """A malformed or stolen project_id can't be used to delete a project
+    belonging to a different org."""
+    from sentry.constants import ObjectStatus
+
+    org_a = Factories.create_organization()
+    org_b = Factories.create_organization()
+    project = Factories.create_project(organization=org_a)
+
+    result = project_service.delete_project(organization_id=org_b.id, project_id=project.id)
+
+    assert result is False
+    project.refresh_from_db()
+    assert project.status == ObjectStatus.ACTIVE
+
+
+@django_db_all(transaction=True)
+def test_delete_project_idempotent_on_second_call() -> None:
+    """Calling delete_project twice on the same project must not schedule
+    a second deletion; the atomic ACTIVE→PENDING_DELETION update is the
+    race guard."""
+    from sentry.deletions.models.scheduleddeletion import CellScheduledDeletion
+
+    org = Factories.create_organization()
+    project = Factories.create_project(organization=org)
+
+    first = project_service.delete_project(organization_id=org.id, project_id=project.id)
+    second = project_service.delete_project(organization_id=org.id, project_id=project.id)
+
+    assert first is True
+    assert second is True
+    schedules = CellScheduledDeletion.objects.filter(
+        app_label="sentry", model_name="Project", object_id=project.id
+    )
+    assert schedules.count() == 1

--- a/tests/sentry/hybridcloud/test_project_key.py
+++ b/tests/sentry/hybridcloud/test_project_key.py
@@ -1,0 +1,158 @@
+"""
+Tests for ``ProjectKeyService`` RPC methods used by the Stripe Projects
+integration (``create_project_key``, ``delete_project_key``). These
+replace raw HTTP self-calls (``cell_request``) to the cell silo's
+``/api/0/projects/.../keys/`` endpoint.
+
+The scoping guarantees matter here because the ``public_key`` argument
+is user-controllable: without org+project scoping, a stolen or
+malformed public_key could delete keys from unrelated projects.
+"""
+
+from sentry.models.projectkey import ProjectKey
+from sentry.projects.services.project_key.service import project_key_service
+from sentry.testutils.factories import Factories
+from sentry.testutils.pytest.fixtures import django_db_all
+
+
+@django_db_all(transaction=True)
+def test_create_project_key_happy_path() -> None:
+    org = Factories.create_organization()
+    project = Factories.create_project(organization=org)
+
+    rpc_key = project_key_service.create_project_key(
+        organization_id=org.id,
+        project_id=project.id,
+        label="Stripe Projects",
+    )
+
+    assert rpc_key is not None
+    # Key actually exists in the database tied to the right project.
+    db_key = ProjectKey.objects.get(public_key=rpc_key.public_key)
+    assert db_key.project_id == project.id
+    assert db_key.label == "Stripe Projects"
+
+
+@django_db_all(transaction=True)
+def test_create_project_key_missing_project_returns_none() -> None:
+    org = Factories.create_organization()
+
+    result = project_key_service.create_project_key(
+        organization_id=org.id,
+        project_id=999_999_999,
+        label="whatever",
+    )
+
+    assert result is None
+
+
+@django_db_all(transaction=True)
+def test_create_project_key_wrong_org_returns_none() -> None:
+    """Org A can't create a key on a project that belongs to org B."""
+    org_a = Factories.create_organization()
+    org_b = Factories.create_organization()
+    project = Factories.create_project(organization=org_a)
+
+    result = project_key_service.create_project_key(
+        organization_id=org_b.id,
+        project_id=project.id,
+        label="cross-org",
+    )
+
+    assert result is None
+    # Confirm no key was created on the actual project.
+    assert not ProjectKey.objects.filter(project_id=project.id, label="cross-org").exists()
+
+
+@django_db_all(transaction=True)
+def test_create_project_key_label_none_is_allowed() -> None:
+    """A None label is accepted; ProjectKey.save() generates a random
+    petname on its own so the row is never label-less. Documents the
+    behavior so callers don't pre-generate labels assuming None is
+    unusable."""
+    org = Factories.create_organization()
+    project = Factories.create_project(organization=org)
+
+    rpc_key = project_key_service.create_project_key(
+        organization_id=org.id,
+        project_id=project.id,
+        label=None,
+    )
+
+    assert rpc_key is not None
+    db_key = ProjectKey.objects.get(public_key=rpc_key.public_key)
+    # Petname generation means label is non-empty even though we passed None.
+    assert db_key.label
+
+
+@django_db_all(transaction=True)
+def test_delete_project_key_happy_path() -> None:
+    org = Factories.create_organization()
+    project = Factories.create_project(organization=org)
+    key = Factories.create_project_key(project=project)
+
+    result = project_key_service.delete_project_key(
+        organization_id=org.id,
+        project_id=project.id,
+        public_key=key.public_key,
+    )
+
+    assert result is True
+    assert not ProjectKey.objects.filter(id=key.id).exists()
+
+
+@django_db_all(transaction=True)
+def test_delete_project_key_nonexistent_returns_false() -> None:
+    """A public_key value that doesn't match any key returns False
+    instead of raising, so callers can safely replay a delete."""
+    org = Factories.create_organization()
+    project = Factories.create_project(organization=org)
+
+    result = project_key_service.delete_project_key(
+        organization_id=org.id,
+        project_id=project.id,
+        public_key="nonexistent-public-key-00000000",
+    )
+
+    assert result is False
+
+
+@django_db_all(transaction=True)
+def test_delete_project_key_wrong_project_returns_false() -> None:
+    """A real public_key for project A can't be deleted via project B's
+    id. Guards against a scenario where public_key is known but
+    project_id is spoofed."""
+    org = Factories.create_organization()
+    project_a = Factories.create_project(organization=org)
+    project_b = Factories.create_project(organization=org)
+    key = Factories.create_project_key(project=project_a)
+
+    result = project_key_service.delete_project_key(
+        organization_id=org.id,
+        project_id=project_b.id,
+        public_key=key.public_key,
+    )
+
+    assert result is False
+    # Key on project_a is untouched.
+    assert ProjectKey.objects.filter(id=key.id).exists()
+
+
+@django_db_all(transaction=True)
+def test_delete_project_key_wrong_org_returns_false() -> None:
+    """A real public_key for org A's project can't be deleted via org
+    B's id, even if project_id is guessed correctly. This is the
+    primary IDOR guard on this endpoint."""
+    org_a = Factories.create_organization()
+    org_b = Factories.create_organization()
+    project = Factories.create_project(organization=org_a)
+    key = Factories.create_project_key(project=project)
+
+    result = project_key_service.delete_project_key(
+        organization_id=org_b.id,
+        project_id=project.id,
+        public_key=key.public_key,
+    )
+
+    assert result is False
+    assert ProjectKey.objects.filter(id=key.id).exists()

--- a/tests/sentry/hybridcloud/test_project_key.py
+++ b/tests/sentry/hybridcloud/test_project_key.py
@@ -156,3 +156,29 @@ def test_delete_project_key_wrong_org_returns_false() -> None:
 
     assert result is False
     assert ProjectKey.objects.filter(id=key.id).exists()
+
+
+@django_db_all(transaction=True)
+def test_delete_project_key_refuses_internal_keys() -> None:
+    """Internal keys (PROFILING, TEMPEST, DEMO) must be protected from
+    RPC deletion to match the HTTP endpoint's ``for_request`` filter.
+    Stripe Projects only ever creates USER keys via create_project_key,
+    so this is hardening against a caller that somehow supplies a known
+    internal key's public_key."""
+    from sentry.models.projectkey import UseCase
+
+    org = Factories.create_organization()
+    project = Factories.create_project(organization=org)
+    # Manually create an internal key since Factories.create_project_key
+    # defaults to USER.
+    internal_key = Factories.create_project_key(project=project)
+    internal_key.update(use_case=UseCase.PROFILING.value)
+
+    result = project_key_service.delete_project_key(
+        organization_id=org.id,
+        project_id=project.id,
+        public_key=internal_key.public_key,
+    )
+
+    assert result is False
+    assert ProjectKey.objects.filter(id=internal_key.id).exists()


### PR DESCRIPTION
Three new cell-silo RPC methods needed by getsentry's Stripe Projects
integration. The companion migration PR is
[getsentry#19995](https://github.com/getsentry/getsentry/pull/19995),
which replaces raw HTTP self-calls (`cell_request`) to these endpoints
with typed RPC calls. Landing this PR first + bumping the
`sentry-version` pin is what unblocks that migration from CI.

## New methods

- `project_key_service.create_project_key(organization_id, project_id, label)`
  Scoped by `organization_id + project_id` — can't create keys on an
  unrelated org's project. If `label` is None or empty, `ProjectKey.save()`
  auto-generates a random petname (existing behavior, documented).

- `project_key_service.delete_project_key(organization_id, project_id, public_key)`
  Scoped by `project__organization_id + project_id + public_key` — a
  malformed or stolen public key value can't delete keys on an unrelated
  project. Uses `ProjectKey.get(...).delete()` (not a QuerySet delete) so
  the `ReplicatedCellModel`'s per-instance override fires and the
  replication outbox is emitted.

- `project_service.delete_project(organization_id, project_id)`
  Matches the project DELETE endpoint: atomic
  `ACTIVE → PENDING_DELETION` via `.update()`, then
  `rename_on_pending_deletion()` (so the slug can be reused within the
  30-day retention window), then `CellScheduledDeletion.schedule(days=0)`.
  Does NOT write audit entries or schedule Seer grouping-records cleanup
  (documented in the docstring).

## Idempotency

All three methods return `None`/`False` without raising on the
"already deleted" / "doesn't exist" paths. Relevant for retrying from
Stripe's orchestrator side:

- `create_project_key`: missing project → None
- `delete_project_key`: non-matching public_key → False
- `delete_project`: missing project → False; replay on an
  already-PENDING_DELETION row returns True without scheduling a
  second deletion (guarded by the atomic `.update()`)

## Tests

- `tests/sentry/hybridcloud/test_project.py` — 4 new tests for
  `delete_project` (happy path with slug-reuse verification, missing
  project, cross-org IDOR, idempotent replay).
- `tests/sentry/hybridcloud/test_project_key.py` — new file with 8
  tests covering create (happy path, missing project, cross-org
  rejection, petname fallback) and delete (happy path, non-existent
  key, wrong project, wrong-org IDOR).

13/13 new tests pass locally. Pre-existing tests unchanged.

## Self-review history

Initial version had two real bugs caught by a self-review pass:

1. `delete_project_key` used `QuerySet.delete()` which bypasses the
   per-instance `CellOutboxProducingModel.delete()` override on
   `ProjectKey` (a `ReplicatedCellModel`). Deleted rows would linger
   in control-silo replica tables, breaking DSN validation and auth
   post-rotation. Fixed.
2. `delete_project` skipped `rename_on_pending_deletion()`, which
   meant soft-deleted projects held their slug for the full 30-day
   retention window. Recreating a Stripe Projects resource with the
   same slug immediately after deletion would fail with a uniqueness
   violation. Fixed.

Both fixes have dedicated regression tests.