### PR TITLE
fix(grouping): Remove redundant time regex

### DIFF
--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -179,9 +179,6 @@ DEFAULT_PARAMETERIZATION_REGEXES = [
             # Date
             (\d{4}-[01]\d-[0-3]\d)
             |
-            # Time
-            ([0-2]\d:[0-5]\d:[0-5]\d)
-            |
             # Old Date Formats, TODO: possibly safe to remove?
             (
                 \b(?:(Sun|Mon|Tue|Wed|Thu|Fri|Sat)\s+)?


### PR DESCRIPTION
In our set of parameterization regexes, we have both "kitchen" time and plain time regexes:

```python
# Kitchen, 12-hr
(
    (?<!\d) # Negative lookbehind to ensure hour has at most two digits
    ([1-9]|1[0-2]) # Hour, no leading zero, 1-12 hours
    :[0-5]\d # Minute
    (:[0-5]\d)? # Optional second
    (?![\d:]) # Negative lookahead to ensure second (or minute, if there are no seconds)
                # has at most two digits, and to make sure that if there are seconds, they
                # get consumed by the optional seconds part of the pattern (and are
                # thereby forced to abide by its restrictions on possible values)
    (?:\s?[aApP][Mm])? # Optional, optionally-space-separated AM/PM
)
|
# Kitchen, 24-hr
(
    (?<!\d) # Negative lookbehind (same logic as 12-hr pattern above)
    (0?\d|1\d|2[0-3]) # Hour, optional leading zero, 0-23 hours
    :[0-5]\d # Minute
    (:[0-5]\d)? # Optional second
    (?![\d:]) # Negative lookahead (same logic as in 12-hr pattern above)
)
# ...
|
# Time
([0-2]\d:[0-5]\d:[0-5]\d)
```

The latter is covered by the former, so this PR removes the latter one, since it's less well-documented and lacks the boundary protections included in the kitchen time regex.