### PR TITLE
feat(autofix): Conform to seer quotas for autofix

### DIFF
--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Literal
 from pydantic import BaseModel
 from rest_framework.exceptions import PermissionDenied
 
-from sentry import analytics, features
+from sentry import analytics, features, quotas
 from sentry.analytics.events.autofix_events import (
     AiAutofixAgentHandoffEvent,
     AiAutofixCodeChangesCompletedEvent,
@@ -24,7 +24,7 @@ from sentry.analytics.events.autofix_events import (
     AiAutofixTriageCompletedEvent,
     AiAutofixTriageStartedEvent,
 )
-from sentry.constants import ENABLE_SEER_CODING_DEFAULT
+from sentry.constants import ENABLE_SEER_CODING_DEFAULT, DataCategory
 from sentry.integrations.services.integration import integration_service
 from sentry.seer.autofix.artifact_schemas import (
     ImpactAssessmentArtifact,
@@ -61,6 +61,10 @@ if TYPE_CHECKING:
     from sentry.models.organization import Organization
 
 logger = logging.getLogger(__name__)
+
+
+class NoSeerQuotaException(Exception):
+    pass
 
 
 class AutofixStep(StrEnum):
@@ -251,6 +255,14 @@ def trigger_autofix_explorer(
     Returns:
         The run ID
     """
+    # check billing quota for triggering a new autofix run
+    if run_id is None:
+        has_budget: bool = quotas.backend.check_seer_quota(
+            org_id=group.organization.id,
+            data_category=DataCategory.SEER_AUTOFIX,
+        )
+        if not has_budget:
+            raise NoSeerQuotaException()
 
     config = STEP_CONFIGS[step]
 
@@ -288,6 +300,11 @@ def trigger_autofix_explorer(
             artifact_key=artifact_key,
             artifact_schema=artifact_schema,
             metadata=metadata,
+        )
+
+        # Make sure to log billing event for seer autofix whenever a new run is started
+        quotas.backend.record_seer_run(
+            group.organization.id, group.project.id, DataCategory.SEER_AUTOFIX
         )
     else:
         client.continue_run(

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -19,7 +19,11 @@ from sentry.locks import locks
 from sentry.models.group import Group
 from sentry.net.http import connection_from_url
 from sentry.seer.autofix.autofix import _get_trace_tree_for_event, trigger_autofix
-from sentry.seer.autofix.autofix_agent import AutofixStep, trigger_autofix_explorer
+from sentry.seer.autofix.autofix_agent import (
+    AutofixStep,
+    NoSeerQuotaException,
+    trigger_autofix_explorer,
+)
 from sentry.seer.autofix.constants import (
     AUTOFIX_AUTOMATION_OCCURRENCE_THRESHOLD,
     AutofixAutomationTuningSettings,
@@ -220,13 +224,16 @@ def _trigger_autofix_task(
         # Route to explorer-based autofix if both feature flags are enabled
         run_id: int | None = None
         if features.has("organizations:autofix-on-explorer", group.organization):
-            run_id = trigger_autofix_explorer(
-                group=group,
-                step=AutofixStep.ROOT_CAUSE,
-                referrer=referrer,
-                run_id=None,
-                stopping_point=stopping_point,
-            )
+            try:
+                run_id = trigger_autofix_explorer(
+                    group=group,
+                    step=AutofixStep.ROOT_CAUSE,
+                    referrer=referrer,
+                    run_id=None,
+                    stopping_point=stopping_point,
+                )
+            except NoSeerQuotaException:
+                pass
         else:
             response = trigger_autofix(
                 group=group,

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -35,6 +35,7 @@ from sentry.ratelimits.config import RateLimitConfig
 from sentry.seer.autofix.autofix import trigger_autofix
 from sentry.seer.autofix.autofix_agent import (
     AutofixStep,
+    NoSeerQuotaException,
     get_autofix_explorer_state,
     trigger_autofix_explorer,
     trigger_coding_agent_handoff,
@@ -296,6 +297,8 @@ class GroupAutofixEndpoint(GroupAiEndpoint):
                 insert_index=data.get("insert_index"),
             )
             return Response({"run_id": run_id}, status=status.HTTP_202_ACCEPTED)
+        except NoSeerQuotaException:
+            return Response("No budget for Seer Autofix.", status=status.HTTP_402_PAYMENT_REQUIRED)
         except SeerPermissionError as e:
             raise PermissionDenied(str(e))
 

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -171,6 +171,7 @@ class SeerAutofixOperator[CachePayloadT]:
     ) -> None:
         from sentry.seer.autofix.autofix_agent import (
             AutofixStep,
+            NoSeerQuotaException,
             get_autofix_explorer_state,
             trigger_autofix_explorer,
             trigger_push_changes,
@@ -249,6 +250,15 @@ class SeerAutofixOperator[CachePayloadT]:
                         referrer=AutofixReferrer.SLACK,
                         run_id=run_id,
                     )
+            except NoSeerQuotaException:
+                error = "No budget for Seer Autofix"
+                with SeerOperatorEventLifecycleMetric(
+                    interaction_type=SeerOperatorInteractionType.ENTRYPOINT_ON_TRIGGER_AUTOFIX_ERROR,
+                    entrypoint_key=self.entrypoint.key,
+                ).capture():
+                    self.entrypoint.on_trigger_autofix_error(error=error)
+                lifecycle.record_failure(failure_reason=error)
+                return
             except Exception as e:
                 with SeerOperatorEventLifecycleMetric(
                     interaction_type=SeerOperatorInteractionType.ENTRYPOINT_ON_TRIGGER_AUTOFIX_ERROR,

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -4,8 +4,10 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 from rest_framework.exceptions import PermissionDenied
 
+from sentry.constants import DataCategory
 from sentry.seer.autofix.autofix_agent import (
     AutofixStep,
+    NoSeerQuotaException,
     build_step_prompt,
     generate_autofix_handoff_prompt,
     trigger_autofix_explorer,
@@ -271,10 +273,12 @@ class TestTriggerAutofixExplorer(TestCase):
         super().setUp()
         self.group = self.create_group(project=self.project)
 
+    @patch("sentry.quotas.backend.record_seer_run")
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
     @patch("sentry.seer.autofix.autofix_agent.SeerExplorerClient")
     def test_trigger_autofix_explorer_sends_started_webhook_for_all_steps(
-        self, mock_client_class, mock_broadcast
+        self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
     ):
         """Sends correct started webhook for all autofix steps."""
         mock_client = MagicMock()
@@ -302,10 +306,12 @@ class TestTriggerAutofixExplorer(TestCase):
             call_kwargs = mock_broadcast.call_args.kwargs
             assert call_kwargs["event_name"] == expected_action.value
 
+    @patch("sentry.quotas.backend.record_seer_run")
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
     @patch("sentry.seer.autofix.autofix_agent.SeerExplorerClient")
     def test_trigger_autofix_explorer_sends_started_webhook_for_continued_run(
-        self, mock_client_class, mock_broadcast
+        self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
     ):
         """Sends started webhook when continuing an existing run."""
         mock_client = MagicMock()
@@ -326,10 +332,12 @@ class TestTriggerAutofixExplorer(TestCase):
         assert call_kwargs["event_name"] == SeerActionType.SOLUTION_STARTED.value
         assert call_kwargs["payload"]["run_id"] == 67890
 
+    @patch("sentry.quotas.backend.record_seer_run")
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
     @patch("sentry.seer.autofix.autofix_agent.SeerExplorerClient")
     def test_trigger_autofix_explorer_passes_project_to_client(
-        self, mock_client_class, mock_broadcast
+        self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
     ):
         """SeerExplorerClient is constructed with project from the group."""
         mock_client = MagicMock()
@@ -347,10 +355,12 @@ class TestTriggerAutofixExplorer(TestCase):
         call_kwargs = mock_client_class.call_args.kwargs
         assert call_kwargs["project"] == self.group.project
 
+    @patch("sentry.quotas.backend.record_seer_run")
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
     @patch("sentry.seer.autofix.autofix_agent.SeerExplorerClient")
     def test_trigger_autofix_explorer_passes_group_id_in_metadata(
-        self, mock_client_class, mock_broadcast
+        self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
     ):
         """start_run is called with metadata containing group_id even without stopping_point."""
         mock_client = MagicMock()
@@ -367,6 +377,87 @@ class TestTriggerAutofixExplorer(TestCase):
         mock_client.start_run.assert_called_once()
         call_kwargs = mock_client.start_run.call_args.kwargs
         assert call_kwargs["metadata"] == {"group_id": self.group.id, "referrer": "unknown"}
+
+    @patch("sentry.seer.autofix.autofix_agent.SeerExplorerClient")
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=False)
+    def test_when_no_quota(self, mock_check_quota, mock_client_class):
+        with pytest.raises(NoSeerQuotaException):
+            trigger_autofix_explorer(
+                group=self.group,
+                step=AutofixStep.ROOT_CAUSE,
+                referrer=AutofixReferrer.UNKNOWN,
+                run_id=None,
+            )
+        mock_check_quota.assert_called_once_with(
+            org_id=self.group.organization.id,
+            data_category=DataCategory.SEER_AUTOFIX,
+        )
+        mock_client_class.assert_not_called()
+
+    @patch("sentry.quotas.backend.record_seer_run")
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
+    @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
+    @patch("sentry.seer.autofix.autofix_agent.SeerExplorerClient")
+    def test_records_seer_run_for_new_run(
+        self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
+    ):
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.start_run.return_value = 12345
+
+        trigger_autofix_explorer(
+            group=self.group,
+            step=AutofixStep.ROOT_CAUSE,
+            referrer=AutofixReferrer.UNKNOWN,
+            run_id=None,
+        )
+
+        mock_record_run.assert_called_once_with(
+            self.group.organization.id, self.group.project.id, DataCategory.SEER_AUTOFIX
+        )
+
+    @patch("sentry.quotas.backend.record_seer_run")
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
+    @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
+    @patch("sentry.seer.autofix.autofix_agent.SeerExplorerClient")
+    def test_does_not_record_seer_run_for_continued_run(
+        self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
+    ):
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.continue_run.return_value = 67890
+
+        trigger_autofix_explorer(
+            group=self.group,
+            step=AutofixStep.SOLUTION,
+            referrer=AutofixReferrer.UNKNOWN,
+            run_id=67890,
+        )
+
+        mock_record_run.assert_not_called()
+
+    @patch("sentry.quotas.backend.record_seer_run")
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=False)
+    @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
+    @patch("sentry.seer.autofix.autofix_agent.SeerExplorerClient")
+    def test_continued_run_permitted_with_no_remaining_budget(
+        self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
+    ):
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.continue_run.return_value = 67890
+
+        run_id = trigger_autofix_explorer(
+            group=self.group,
+            step=AutofixStep.SOLUTION,
+            referrer=AutofixReferrer.UNKNOWN,
+            run_id=67890,
+        )
+
+        assert run_id == 67890
+        mock_client.continue_run.assert_called_once()
+        mock_check_quota.assert_not_called()
+        mock_record_run.assert_not_called()
 
 
 class TestTriggerCodingAgentHandoff(TestCase):

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from unittest.mock import Mock, patch
 
 from sentry.seer.autofix.autofix import TIMEOUT_SECONDS
-from sentry.seer.autofix.autofix_agent import AutofixStep
+from sentry.seer.autofix.autofix_agent import AutofixStep, NoSeerQuotaException
 from sentry.seer.autofix.constants import AutofixReferrer, AutofixStatus
 from sentry.seer.autofix.utils import AutofixState, AutofixStoppingPoint, CodebaseState
 from sentry.seer.explorer.client_models import SeerRunState
@@ -987,6 +987,25 @@ class GroupAutofixEndpointExplorerRoutingTest(APITestCase, SnubaTestCase):
                 user_context=None,
                 insert_index=3,
             )
+
+    @patch("sentry.seer.endpoints.group_ai_autofix.trigger_autofix_explorer")
+    def test_post_returns_402_when_no_seer_quota(self, mock_trigger_explorer):
+        """POST returns 402 Payment Required when quota check fails."""
+        for flag in EXPLORER_FLAGS:
+            mock_trigger_explorer.reset_mock()
+            mock_trigger_explorer.side_effect = NoSeerQuotaException()
+            group = self.create_group()
+
+            self.login_as(user=self.user)
+            with self.feature(flag):
+                response = self.client.post(
+                    self._get_url(group.id, mode="explorer"),
+                    data={"step": "root_cause"},
+                    format="json",
+                )
+
+            assert response.status_code == 402, f"Failed for {flag}: {response.data}"
+            assert response.data == "No budget for Seer Autofix."
 
     @patch("sentry.seer.autofix.autofix._call_autofix")
     @patch("sentry.seer.autofix.autofix._get_trace_tree_for_event")


### PR DESCRIPTION
This does 2 things
1. ensure that we check seer quotas prior to triggering an autofix run
2. record the seer run after it's triggered