### PR TITLE
chore(dashboards): Use Dashboard router hint in revision restore

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboard_revision_restore.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_revision_restore.py
@@ -18,7 +18,7 @@ from sentry.dashboards.endpoints.organization_dashboard_details import (
     OrganizationDashboardBase,
     _take_dashboard_snapshot,
 )
-from sentry.models.dashboard import Dashboard, DashboardRevision, DashboardTombstone
+from sentry.models.dashboard import Dashboard, DashboardRevision
 from sentry.models.organization import Organization
 
 
@@ -96,7 +96,7 @@ class OrganizationDashboardRevisionRestoreEndpoint(OrganizationDashboardBase):
             return Response(serializer.errors, status=400)
 
         try:
-            with transaction.atomic(router.db_for_write(DashboardTombstone)):
+            with transaction.atomic(router.db_for_write(Dashboard)):
                 if snapshot is not None:
                     DashboardRevision.create_for_dashboard(
                         dashboard, request.user, snapshot, source="pre-restore"

--- a/src/sentry/dashboards/endpoints/organization_dashboard_revision_restore.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_revision_restore.py
@@ -96,7 +96,7 @@ class OrganizationDashboardRevisionRestoreEndpoint(OrganizationDashboardBase):
             return Response(serializer.errors, status=400)
 
         try:
-            with transaction.atomic(router.db_for_write(Dashboard)):
+            with transaction.atomic(router.db_for_write(DashboardRevision)):
                 if snapshot is not None:
                     DashboardRevision.create_for_dashboard(
                         dashboard, request.user, snapshot, source="pre-restore"


### PR DESCRIPTION
This stuck out to me while looking at some related code. `DashboardTombstone` is not long for this world, and it seemed strange that it's used as the hint here, since it's not the model being changed! I figured now's a good time to remove it.