### PR TITLE
chore(dashboards): Normalize error responses to use detail key

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboard_details.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_details.py
@@ -158,7 +158,7 @@ class OrganizationDashboardDetailsEndpoint(OrganizationDashboardBase):
         num_tombstones = DashboardTombstone.objects.filter(organization=organization).count()
 
         if isinstance(dashboard, Dashboard) and dashboard.prebuilt_id is not None:
-            return self.respond({"Cannot delete prebuilt Dashboards."}, status=409)
+            return self.respond({"detail": "Cannot delete prebuilt Dashboards."}, status=409)
 
         if isinstance(dashboard, dict):
             if num_dashboards > 0:
@@ -166,11 +166,11 @@ class OrganizationDashboardDetailsEndpoint(OrganizationDashboardBase):
                     organization=organization, slug=dashboard["id"]
                 )
             else:
-                return self.respond({"Cannot delete last Dashboard."}, status=409)
+                return self.respond({"detail": "Cannot delete last Dashboard."}, status=409)
         elif (num_dashboards > 1) or (num_tombstones == 0):
             dashboard.delete()
         else:
-            return self.respond({"Cannot delete last Dashboard."}, status=409)
+            return self.respond({"detail": "Cannot delete last Dashboard."}, status=409)
 
         return self.respond(status=204)
 
@@ -254,7 +254,7 @@ class OrganizationDashboardDetailsEndpoint(OrganizationDashboardBase):
                         organization=organization, slug=tombstone
                     )
         except IntegrityError:
-            return self.respond({"Dashboard with that title already exists."}, status=409)
+            return self.respond({"detail": "Dashboard with that title already exists."}, status=409)
 
         return self.respond(serialize(serializer.instance, request.user), status=200)
 

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -979,7 +979,7 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
             "put", self.url(self.dashboard.id), data={"title": "Dashboard 2"}
         )
         assert response.status_code == 409, response.data
-        assert list(response.data) == ["Dashboard with that title already exists."]
+        assert response.data["detail"] == "Dashboard with that title already exists."
 
     def test_allow_put_when_no_project_access(self) -> None:
         # disable Open Membership


### PR DESCRIPTION
Spotted this awkward usage. Apparently the convention is to use `"detail"` as the key in the error response! This curly creates a one-element set.