### PR TITLE
fix(seer): Render all root nodes in snapshot_to_markdown

### DIFF
--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -388,11 +388,16 @@ def _render_node(node: dict[str, Any], depth: int) -> str:
     return "\n".join(lines)
 
 
+_MAX_ROOT_NODES = 10
+
+
 def snapshot_to_markdown(snapshot: dict[str, Any]) -> str:
     """Convert an LLMContextSnapshot dict to a markdown string.
 
     Expected shape: ``{"version": int, "nodes": [{"nodeType": str, "data": ..., "children": [...]}]}``
-    The top-level nodes list contains a single root node (the page).
+    The top-level nodes list may contain multiple root nodes (e.g. a dashboard
+    and a widget-builder sidebar rendered as siblings).  At most ``_MAX_ROOT_NODES``
+    are rendered to guard against runaway token usage.
     """
     nodes = snapshot.get("nodes", [])
     if not nodes:
@@ -400,4 +405,4 @@ def snapshot_to_markdown(snapshot: dict[str, Any]) -> str:
     preamble = (
         "> This is a structured summary of the page the user is viewing, not an exact screenshot.\n"
     )
-    return preamble + _render_node(nodes[0], 0)
+    return preamble + "\n".join(_render_node(node, 0) for node in nodes[:_MAX_ROOT_NODES])

--- a/tests/sentry/seer/explorer/test_client_utils.py
+++ b/tests/sentry/seer/explorer/test_client_utils.py
@@ -245,6 +245,27 @@ class SnapshotToMarkdownTest(TestCase):
         assert "# Dashboard" in result
         assert "not an exact screenshot" in result
 
+    def test_multiple_root_nodes(self) -> None:
+        snapshot = {
+            "version": 1,
+            "nodes": [
+                {
+                    "nodeType": "dashboard",
+                    "data": {"title": "My Dashboard"},
+                    "children": [],
+                },
+                {
+                    "nodeType": "widget-builder",
+                    "data": {"mode": "creating", "dataset": "error-events"},
+                    "children": [],
+                },
+            ],
+        }
+        result = snapshot_to_markdown(snapshot)
+        assert "# Dashboard" in result
+        assert "# Widget-builder" in result
+        assert '- **mode**: "creating"' in result
+
     def test_node_with_non_dict_data(self) -> None:
         snapshot = {
             "version": 1,


### PR DESCRIPTION
+ `snapshot_to_markdown` only rendered nodes[0], silently dropping any additional root-level nodes. When the widget builder and dashboard register as sibling nodes in the LLM context tree, the widget-builder node was lost. Iterate over all root nodes so every registered context node appears in the markdown sent to Seer.
+ Kept max nodes at 10 as a safeguard.
