### PR TITLE
styles(scraps): Subtract top from SlideOverPanel height

### DIFF
--- a/static/app/components/core/slideOverPanel/slideOverPanel.tsx
+++ b/static/app/components/core/slideOverPanel/slideOverPanel.tsx
@@ -168,7 +168,7 @@ const _SlideOverPanel = styled(motion.div, {
               position: fixed;
 
               width: ${p.panelWidth ?? RIGHT_SIDE_PANEL_WIDTH};
-              height: 100%;
+              height: ${p.mode === 'passive' ? `calc(100% - ${p.top})` : '100%'};
 
               top: ${p.mode === 'passive' ? p.top : 0};
               right: 0;
@@ -180,7 +180,7 @@ const _SlideOverPanel = styled(motion.div, {
 
               width: ${p.panelWidth ?? LEFT_SIDE_PANEL_WIDTH};
               min-width: 450px;
-              height: 100%;
+              height: ${p.mode === 'passive' ? `calc(100% - ${p.top})` : '100%'};
 
               top: ${p.mode === 'passive' ? p.top : 0};
               right: auto;


### PR DESCRIPTION
The `SlideOverPanel` has a `height` of 100% which takes up the height of the full screen. With the page frames flag on, there is a new header component that the panel needs to be under which is done via `top`. Because of this the entire component is shifted downwards and there is an area equal to the height of the offset that is now off screen.
