### PR TITLE
feat(search): Expose recommended issue sort in UI

### DIFF
--- a/src/sentry/models/savedsearch.py
+++ b/src/sentry/models/savedsearch.py
@@ -27,6 +27,7 @@ class SortOptions(StrEnum):
     FREQ = "freq"
     USER = "user"
     INBOX = "inbox"
+    RECOMMENDED = "recommended"
 
     @classmethod
     def as_choices(cls) -> tuple[tuple[SortOptions, _StrPromise], ...]:
@@ -37,10 +38,11 @@ class SortOptions(StrEnum):
             (cls.FREQ, _("Events")),
             (cls.USER, _("Users")),
             (cls.INBOX, _("Date Added")),
+            (cls.RECOMMENDED, _("Recommended")),
         )
 
 
-SORT_LITERALS = Literal["date", "new", "trends", "freq", "user", "inbox"]
+SORT_LITERALS = Literal["date", "new", "trends", "freq", "user", "inbox", "recommended"]
 
 
 class Visibility:

--- a/static/app/views/issueList/actions/sortOptions.tsx
+++ b/static/app/views/issueList/actions/sortOptions.tsx
@@ -31,6 +31,8 @@ function getSortTooltip(key: IssueSortOptions) {
       return t('Number of events.');
     case IssueSortOptions.USER:
       return t('Number of users affected.');
+    case IssueSortOptions.RECOMMENDED:
+      return t('Issues most likely to need attention.');
     case IssueSortOptions.DATE:
     default:
       return t('Last time the issue occurred.');
@@ -53,6 +55,7 @@ export function IssueListSortOptions({
     IssueSortOptions.TRENDS,
     IssueSortOptions.FREQ,
     IssueSortOptions.USER,
+    IssueSortOptions.RECOMMENDED,
   ];
 
   return (

--- a/static/app/views/issueList/utils.tsx
+++ b/static/app/views/issueList/utils.tsx
@@ -30,6 +30,7 @@ export enum IssueSortOptions {
   FREQ = 'freq',
   USER = 'user',
   INBOX = 'inbox',
+  RECOMMENDED = 'recommended',
 }
 
 export const DEFAULT_ISSUE_STREAM_SORT = IssueSortOptions.DATE;
@@ -46,6 +47,8 @@ export function getSortLabel(key: string) {
       return t('Users');
     case IssueSortOptions.INBOX:
       return t('Date Added');
+    case IssueSortOptions.RECOMMENDED:
+      return t('Recommended');
     case IssueSortOptions.DATE:
     default:
       return t('Last Seen');


### PR DESCRIPTION
Add the recommended sort as a first-class option in the issue stream sort dropdown and allow it to be saved as part of issue views. The backend sort implementation already exists; this threads the value through the SortOptions enum, SORT_LITERALS type, IssueSortOptions frontend enum, and the sort dropdown component.