### PR TITLE
fix(alerts): Accept "default" as a valid PagerDuty severity

### DIFF
--- a/src/sentry/integrations/pagerduty/utils.py
+++ b/src/sentry/integrations/pagerduty/utils.py
@@ -25,6 +25,7 @@ from sentry.utils import metrics
 logger = logging.getLogger("sentry.integrations.pagerduty")
 
 PAGERDUTY_CUSTOM_PRIORITIES = {
+    "default",
     "critical",
     "warning",
     "error",


### PR DESCRIPTION
Ref ISWF-2507

If you save a legacy metric alert with a pagerduty action and do not select a priority, it will send `None` which gets translated to `default`, which is supported in issue alerts and workflow engine. However, `default` is not defined as something which is supported for metric alerts, so it ends up sending an error next time a user saves the form.

I believe we can just add `default` as an allowed option and things will work as expected?

https://github.com/getsentry/sentry/blob/fe2815e5731f0c9c56d030748ace99ea2ef19b0c/src/sentry/integrations/pagerduty/client.py#L19-L24