### PR TITLE
docs(agents): mention ViewerContext identity wiring

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,7 +189,7 @@ Workflow steering (commit, pre-commit, hybrid cloud, etc.) lives in **skills** (
 
 ## Viewer/Organization Context
 
-- Viewer identity is wired through the app via the `ViewerContext` contextvar; use `sentry.viewer_context.get_viewer_context()` instead of explicitly threading org/user identity through internal calls when the current viewer is in scope.
+- Viewer identity is wired through the app via the `ViewerContext` contextvar; use `sentry.viewer_context.get_viewer_context()` instead of explicitly threading org/user identity when the current viewer is in scope.
 
 ## Agent Skills
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,10 @@ Use the right AGENTS.md for the area you're working in:
 
 Workflow steering (commit, pre-commit, hybrid cloud, etc.) lives in **skills** (`.agents/skills/`). Attach or read the area `AGENTS.md` when working in that tree. Add or update guidance in the appropriate AGENTS.md or skill—do not duplicate long guidance in editor-specific rule files.
 
+## Viewer/Organization Context
+
+- Viewer identity is wired through the app via the `ViewerContext` contextvar; use `sentry.viewer_context.get_viewer_context()` instead of explicitly threading org/user identity through internal calls when the current viewer is in scope.
+
 ## Agent Skills
 
 Skills under `.agents/skills/` should follow the same current-practice conventions as the rest of the repo:


### PR DESCRIPTION
Add a short AGENTS.md note that viewer identity is available through `sentry.viewer_context.get_viewer_context()` when it is already in scope.

This gives agents a small pointer to the existing viewer-context plumbing without adding more detailed policy or duplicating the implementation docs.