### PR TITLE
fix(repositories): Properly set `external_id` in `organization_code_mappings_bulk`

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
+++ b/src/sentry/integrations/api/endpoints/organization_code_mappings_bulk.py
@@ -126,7 +126,7 @@ class OrganizationCodeMappingsBulkEndpoint(OrganizationEndpoint):
                 organization_id=organization.id,
                 provider=repo_provider,
                 integration_id=org_int.integration_id,
-                external_id=repo_info.get("identifier", ""),
+                external_id=repo_info["external_id"],
             ), None
         except IntegrityError:
             # Race condition — repo was created between our lookup and now

--- a/tests/sentry/integrations/api/endpoints/test_organization_code_mappings_bulk.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_code_mappings_bulk.py
@@ -351,21 +351,18 @@ class OrganizationCodeMappingsBulkTest(APITestCase):
             name=new_repo_name, organization_id=self.organization.id
         ).exists()
 
-        def fake_auto_create(organization, repo_name, provider):
-            repo, _ = Repository.objects.get_or_create(
-                name=repo_name,
-                organization_id=organization.id,
-                defaults={
-                    "integration_id": self.integration.id,
-                    "provider": "integrations:github",
-                },
-            )
-            return repo, None
+        mock_repos = [
+            {
+                "name": "new-repo",
+                "identifier": new_repo_name,
+                "external_id": "99999",
+                "default_branch": "main",
+            }
+        ]
 
         with mock.patch(
-            "sentry.integrations.api.endpoints.organization_code_mappings_bulk."
-            "OrganizationCodeMappingsBulkEndpoint._auto_create_repository",
-            side_effect=fake_auto_create,
+            "sentry.integrations.github.integration.GitHubIntegration.get_repositories",
+            return_value=mock_repos,
         ):
             response = self.make_post(
                 {
@@ -379,6 +376,7 @@ class OrganizationCodeMappingsBulkTest(APITestCase):
         repo = Repository.objects.get(name=new_repo_name, organization_id=self.organization.id)
         assert repo.provider == "integrations:github"
         assert repo.integration_id == self.integration.id
+        assert repo.external_id == "99999"
 
     def test_skip_post_save_does_not_leak_to_fetched_instances(self) -> None:
         """The endpoint sets _skip_post_save on in-memory instances to batch


### PR DESCRIPTION
Different SCM providers determine `external_id` in their own way. We should use `external_id` directly now that it exists, rather than just using `identifier`.

<!-- Describe your PR here. -->