### PR TITLE
feat(seer): Add per-issue Explorer button to workflow run drill-down

### DIFF
--- a/static/app/views/seerWorkflows/index.tsx
+++ b/static/app/views/seerWorkflows/index.tsx
@@ -178,7 +178,11 @@ function RunDetail({
             {t('No issues processed in this run.')}
           </Text>
         ) : (
-          <Grid columns="max-content max-content 1fr" gap="sm xl" align="center">
+          <Grid
+            columns="max-content max-content max-content max-content"
+            gap="sm xl"
+            align="center"
+          >
             <Text bold size="xs" variant="muted">
               {t('Group')}
             </Text>
@@ -188,6 +192,7 @@ function RunDetail({
             <Text bold size="xs" variant="muted">
               {t('Seer Run ID')}
             </Text>
+            <span />
             {run.issues.flatMap(issue => [
               <Link
                 key={`${issue.id}-group`}
@@ -201,6 +206,21 @@ function RunDetail({
               <Text key={`${issue.id}-seer`} size="sm" variant="muted">
                 {issue.seerRunId ?? '-'}
               </Text>,
+              issue.seerRunId === null ? (
+                <span key={`${issue.id}-explorer`} />
+              ) : (
+                <LinkButton
+                  key={`${issue.id}-explorer`}
+                  size="xs"
+                  icon={<IconOpen />}
+                  to={{
+                    pathname: `/organizations/${organizationSlug}/issues/`,
+                    query: {explorerRunId: issue.seerRunId},
+                  }}
+                >
+                  {t('Explorer')}
+                </LinkButton>
+              ),
             ])}
           </Grid>
         )}


### PR DESCRIPTION
Add an Explorer link button to each issue row in the expanded Seer workflows view, mirroring the Explorer button already shown on the main workflow run row.

The main nightshift run row links to `/organizations/<slug>/issues/?explorerRunId=<agent_run_id>` when the run has an `agent_run_id` in extras. Individual issues have their own `seerRunId` but no corresponding way to jump to that run's explorer view — this change closes that gap so users can go straight from a workflow issue entry to its Seer Explorer run. The button is only rendered when `seerRunId` is non-null; otherwise an empty placeholder keeps grid column alignment intact.