### PR TITLE
aci(fix): Fix issue with Metric monitor chart statsPeriod

### DIFF
--- a/static/app/views/detectors/components/details/metric/index.tsx
+++ b/static/app/views/detectors/components/details/metric/index.tsx
@@ -24,6 +24,7 @@ import {
 import {useIsMigratedExtrapolation} from 'sentry/views/detectors/components/details/metric/utils/useIsMigratedExtrapolation';
 import {getDetectorDataset} from 'sentry/views/detectors/datasetConfig/getDetectorDataset';
 import {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
+import {useDetectorStatsPeriods} from 'sentry/views/detectors/hooks/useDetectorStatsPeriods';
 import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 type MetricDetectorDetailsProps = {
@@ -47,6 +48,7 @@ export function MetricDetectorDetails({detector, project}: MetricDetectorDetails
   });
 
   const intervalSeconds = dataSource.queryObj?.snubaQuery.timeWindow;
+  useDetectorStatsPeriods(interval);
 
   return (
     <DetailLayout>

--- a/static/app/views/detectors/hooks/useDetectorStatsPeriods.spec.tsx
+++ b/static/app/views/detectors/hooks/useDetectorStatsPeriods.spec.tsx
@@ -1,0 +1,72 @@
+import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+
+import {useDetectorStatsPeriods} from 'sentry/views/detectors/hooks/useDetectorStatsPeriods';
+
+describe('useDetectorStatsPeriods', () => {
+  it('does nothing when there is no statsPeriod in the URL', () => {
+    const {router} = renderHookWithProviders(() => useDetectorStatsPeriods(3600), {
+      initialRouterConfig: {
+        location: {pathname: '/detectors/1/', query: {}},
+      },
+    });
+
+    expect(router.location.query).toEqual({});
+  });
+
+  it('does nothing when intervalSeconds is 0', () => {
+    const {router} = renderHookWithProviders(() => useDetectorStatsPeriods(0), {
+      initialRouterConfig: {
+        location: {pathname: '/detectors/1/', query: {statsPeriod: '1h'}},
+      },
+    });
+
+    expect(router.location.query.statsPeriod).toBe('1h');
+  });
+
+  it('does nothing when statsPeriod is greater than the interval', () => {
+    // statsPeriod=1d (86400s), interval=3600s (1h)
+    const {router} = renderHookWithProviders(() => useDetectorStatsPeriods(3600), {
+      initialRouterConfig: {
+        location: {pathname: '/detectors/1/', query: {statsPeriod: '1d'}},
+      },
+    });
+
+    expect(router.location.query.statsPeriod).toBe('1d');
+  });
+
+  it('does nothing when statsPeriod equals the interval', () => {
+    // statsPeriod=1h (3600s), interval=3600s
+    const {router} = renderHookWithProviders(() => useDetectorStatsPeriods(3600), {
+      initialRouterConfig: {
+        location: {pathname: '/detectors/1/', query: {statsPeriod: '1h'}},
+      },
+    });
+
+    expect(router.location.query.statsPeriod).toBe('1h');
+  });
+
+  it('replaces statsPeriod when it is smaller than the interval', () => {
+    // statsPeriod=1h (3600s), interval=86400s (1d)
+    const {router} = renderHookWithProviders(() => useDetectorStatsPeriods(86400), {
+      initialRouterConfig: {
+        location: {pathname: '/detectors/1/', query: {statsPeriod: '1h'}},
+      },
+    });
+
+    expect(router.location.query.statsPeriod).toBe('1d');
+  });
+
+  it('preserves other query params when replacing statsPeriod', () => {
+    const {router} = renderHookWithProviders(() => useDetectorStatsPeriods(86400), {
+      initialRouterConfig: {
+        location: {
+          pathname: '/detectors/1/',
+          query: {statsPeriod: '1h', cursor: 'abc123'},
+        },
+      },
+    });
+
+    expect(router.location.query.statsPeriod).toBe('1d');
+    expect(router.location.query.cursor).toBe('abc123');
+  });
+});

--- a/static/app/views/detectors/hooks/useDetectorStatsPeriods.spec.tsx
+++ b/static/app/views/detectors/hooks/useDetectorStatsPeriods.spec.tsx
@@ -69,4 +69,34 @@ describe('useDetectorStatsPeriods', () => {
     expect(router.location.query.statsPeriod).toBe('1d');
     expect(router.location.query.cursor).toBe('abc123');
   });
+
+  it('does nothing when start/end range is greater than the interval', () => {
+    const {router} = renderHookWithProviders(() => useDetectorStatsPeriods(3600), {
+      initialRouterConfig: {
+        location: {
+          pathname: '/detectors/1/',
+          query: {start: '2026-01-01T00:00:00', end: '2026-01-02T00:00:00'},
+        },
+      },
+    });
+
+    expect(router.location.query.start).toBe('2026-01-01T00:00:00');
+    expect(router.location.query.end).toBe('2026-01-02T00:00:00');
+    expect(router.location.query.statsPeriod).toBeUndefined();
+  });
+
+  it('replaces start/end with statsPeriod when range is smaller than the interval', () => {
+    const {router} = renderHookWithProviders(() => useDetectorStatsPeriods(86400), {
+      initialRouterConfig: {
+        location: {
+          pathname: '/detectors/1/',
+          query: {start: '2026-01-01T00:00:00', end: '2026-01-01T01:00:00'},
+        },
+      },
+    });
+
+    expect(router.location.query.statsPeriod).toBe('1d');
+    expect(router.location.query.start).toBeUndefined();
+    expect(router.location.query.end).toBeUndefined();
+  });
 });

--- a/static/app/views/detectors/hooks/useDetectorStatsPeriods.tsx
+++ b/static/app/views/detectors/hooks/useDetectorStatsPeriods.tsx
@@ -1,0 +1,34 @@
+import {useEffect} from 'react';
+
+import {getDuration} from 'sentry/utils/duration/getDuration';
+import {intervalToMilliseconds} from 'sentry/utils/duration/intervalToMilliseconds';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+
+export const useDetectorStatsPeriods = (intervalSeconds: number) => {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const statsPeriod = location.query?.statsPeriod;
+
+    if (!statsPeriod || !intervalSeconds) {
+      return;
+    }
+
+    const periodSeconds = intervalToMilliseconds(statsPeriod) / 1000;
+    if (periodSeconds >= intervalSeconds) {
+      return;
+    }
+
+    // If the url's period is smaller than the detector interval,
+    // relace the period with the interval so subsequent lookups work.
+    navigate({
+      pathname: location.pathname,
+      query: {
+        ...location.query,
+        statsPeriod: getDuration(intervalSeconds, 0, false, true),
+      },
+    });
+  }, [location, navigate, intervalSeconds]);
+};

--- a/static/app/views/detectors/hooks/useDetectorStatsPeriods.tsx
+++ b/static/app/views/detectors/hooks/useDetectorStatsPeriods.tsx
@@ -2,6 +2,7 @@ import {useEffect} from 'react';
 
 import {getDuration} from 'sentry/utils/duration/getDuration';
 import {intervalToMilliseconds} from 'sentry/utils/duration/intervalToMilliseconds';
+import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 
@@ -10,23 +11,35 @@ export const useDetectorStatsPeriods = (intervalSeconds: number) => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    const statsPeriod = location.query?.statsPeriod;
-
-    if (!statsPeriod || !intervalSeconds) {
+    if (!intervalSeconds) {
       return;
     }
 
-    const periodSeconds = intervalToMilliseconds(statsPeriod) / 1000;
+    const statsPeriod = decodeScalar(location.query?.statsPeriod);
+    const start = decodeScalar(location.query?.start);
+    const end = decodeScalar(location.query?.end);
+
+    let periodSeconds: number;
+    if (statsPeriod) {
+      periodSeconds = intervalToMilliseconds(statsPeriod) / 1000;
+    } else if (start && end) {
+      periodSeconds = (new Date(end).getTime() - new Date(start).getTime()) / 1000;
+    } else {
+      return;
+    }
+
     if (periodSeconds >= intervalSeconds) {
       return;
     }
 
     // If the url's period is smaller than the detector interval,
-    // relace the period with the interval so subsequent lookups work.
+    // replace the period with the interval so subsequent lookups work.
     navigate({
       pathname: location.pathname,
       query: {
         ...location.query,
+        start: undefined,
+        end: undefined,
         statsPeriod: getDuration(intervalSeconds, 0, false, true),
       },
     });


### PR DESCRIPTION
# Description
### Before
Before this change, the chart would not load and it would only have a cryptic error about the interval not being allowed to be larger than the date range.
<img width="1704" height="662" alt="image" src="https://github.com/user-attachments/assets/b228757d-0247-4ca1-af5f-0e538f1dfda3" />

### After
Now we redirect to a new statsPeriod that is valid for the detector -- basically handling the cryptic error for the user.
<img width="625" height="335" alt="Screenshot 2026-04-21 at 4 04 56 PM" src="https://github.com/user-attachments/assets/b9e4fb4a-916d-4691-b309-0af9edce07a3" />
as a result, the `Custom Time` has changed and the graph is now visible. The new custom time, is set to the smallest allowed for the monitor (the interval of the query).