### PR TITLE
ref(seer): Filter LLM context to widget-builder on builder routes

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
@@ -347,6 +347,9 @@ describe('NewWidgetBuilder', () => {
     expect(data.visualize).toEqual(['count()']);
     expect(data.fields).toEqual(['browser.name']);
     expect(data.query).toEqual(['browser.name:Firefox']);
+    expect(data.dashboardTitle).toBe('Dashboard');
+    expect(data.dashboardWidgetCount).toBe(0);
+    expect(data.dashboardFilters).toEqual([]);
   });
 
   it('does not register LLM context when the builder is closed', () => {

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -116,6 +116,9 @@ function WidgetBuilderSlideoutInner({
   useLLMContext({
     contextHint:
       'Sentry widget builder. The user is configuring a dashboard widget. visualize is the y-axis metrics (timeseries) or the aggregate (big number/table). fields are group-by columns (timeseries) or visible columns (table). query filters the data and sort controls ordering.',
+    dashboardTitle: dashboard.title,
+    dashboardWidgetCount: dashboard.widgets.length,
+    dashboardFilters: dashboard.filters,
     mode: isEditing ? 'editing' : 'creating',
     title: state.title,
     description: state.description,

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
@@ -2,6 +2,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {useLLMContext} from 'sentry/views/seerExplorer/contexts/llmContext';
 import {usePageReferrer} from 'sentry/views/seerExplorer/utils';
 
 import {useSeerExplorer} from './useSeerExplorer';
@@ -11,12 +12,20 @@ jest.mock('sentry/views/seerExplorer/utils', () => ({
   usePageReferrer: jest.fn(),
 }));
 
+jest.mock('sentry/views/seerExplorer/contexts/llmContext', () => ({
+  ...jest.requireActual('sentry/views/seerExplorer/contexts/llmContext'),
+  useLLMContext: jest.fn(),
+}));
+
 describe('useSeerExplorer', () => {
   beforeEach(() => {
     MockApiClient.clearMockResponses();
     sessionStorage.clear();
     (usePageReferrer as jest.Mock).mockReturnValue({
       getPageReferrer: () => '/issues/',
+    });
+    (useLLMContext as jest.Mock).mockReturnValue({
+      getLLMContext: () => ({version: 0, nodes: []}),
     });
   });
 
@@ -145,6 +154,52 @@ describe('useSeerExplorer', () => {
       await waitFor(() => {
         const ctx = postMock.mock.calls[0][1].data.on_page_context;
         expect(JSON.parse(ctx)).toHaveProperty('nodes');
+      });
+    });
+
+    it('filters to only widget-builder nodes on widget builder routes', async () => {
+      (usePageReferrer as jest.Mock).mockReturnValue({
+        getPageReferrer: () => '/dashboard/:dashboardId/widget-builder/widget/new/',
+      });
+      (useLLMContext as jest.Mock).mockReturnValue({
+        getLLMContext: () => ({
+          version: 1,
+          nodes: [
+            {nodeType: 'dashboard', data: {title: 'My Dashboard'}, children: []},
+            {nodeType: 'widget-builder', data: {mode: 'creating'}, children: []},
+          ],
+        }),
+      });
+      const org = OrganizationFixture({
+        features: ['seer-explorer', 'context-engine-structured-page-context'],
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${org.slug}/seer/explorer-chat/`,
+        method: 'GET',
+        body: {session: null},
+      });
+      const postMock = MockApiClient.addMockResponse({
+        url: `/organizations/${org.slug}/seer/explorer-chat/`,
+        method: 'POST',
+        body: {run_id: 1},
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${org.slug}/seer/explorer-chat/1/`,
+        method: 'GET',
+        body: {session: {blocks: [], run_id: 1, status: 'completed', updated_at: ''}},
+      });
+
+      const {result} = renderHookWithProviders(() => useSeerExplorer(), {
+        organization: org,
+      });
+      act(() => {
+        result.current.sendMessage('q');
+      });
+
+      await waitFor(() => {
+        const ctx = JSON.parse(postMock.mock.calls[0][1].data.on_page_context);
+        expect(ctx.nodes).toHaveLength(1);
+        expect(ctx.nodes[0].nodeType).toBe('widget-builder');
       });
     });
 

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -57,6 +57,12 @@ const NEW_STRUCTURED_CONTEXT_ROUTES = new Set([
   '/dashboard/:dashboardId/widget-builder/widget/:widgetIndex/edit/',
 ]);
 
+/** Widget builder routes — only the builder node is relevant, not the full dashboard tree. */
+const WIDGET_BUILDER_ROUTES = new Set([
+  '/dashboard/:dashboardId/widget-builder/widget/new/',
+  '/dashboard/:dashboardId/widget-builder/widget/:widgetIndex/edit/',
+]);
+
 function supportsStructuredContext(
   referrer: string,
   organization: {features: string[]} | null | undefined
@@ -397,7 +403,14 @@ export const useSeerExplorer = () => {
       let screenshot: string | undefined;
       if (supportsStructuredContext(getPageReferrer(), organization)) {
         try {
-          screenshot = JSON.stringify(getLLMContext());
+          let snapshot = getLLMContext();
+          if (WIDGET_BUILDER_ROUTES.has(getPageReferrer())) {
+            snapshot = {
+              ...snapshot,
+              nodes: snapshot.nodes.filter(n => n.nodeType === 'widget-builder'),
+            };
+          }
+          screenshot = JSON.stringify(snapshot);
         } catch (e) {
           Sentry.captureException(e);
           screenshot = captureAsciiSnapshot?.();


### PR DESCRIPTION
+ When the widget builder is open, both the dashboard and widget-builder register as root-level LLM context nodes. The full dashboard tree is noise on widget builder pages. Filter the snapshot to only include widget-builder nodes on widget builder routes so the Seer agent receives only the relevant context.
+ Also adds dashboard details to the widgetbuilder context.

