### PR TITLE
ref(np): Adds a new notification dispatcher for notification platform testing

### DIFF
--- a/src/sentry/notifications/notification_action/issue_notification_dispatcher.py
+++ b/src/sentry/notifications/notification_action/issue_notification_dispatcher.py
@@ -1,0 +1,126 @@
+from sentry.incidents.grouptype import MetricIssue
+from sentry.models.activity import Activity
+from sentry.notifications.notification_action.types import BaseMetricAlertHandler
+from sentry.notifications.notification_action.utils import (
+    issue_notification_data_factory,
+    metric_alert_notification_data_factory,
+)
+from sentry.notifications.platform.service import NotificationService
+from sentry.notifications.platform.target import IntegrationNotificationTarget
+from sentry.notifications.platform.threading import ThreadingOptions, ThreadKey
+from sentry.notifications.platform.types import (
+    NotificationProviderKey,
+    NotificationSource,
+    NotificationTarget,
+    NotificationTargetResourceType,
+)
+from sentry.notifications.utils.issue_notification_context import IssueNotificationContext
+from sentry.workflow_engine.types import ActionInvocation
+
+
+class NotificationDispatcherError(Exception):
+    pass
+
+
+NOTIFICATION_PLATFORM_ENABLED_PROVIDERS = {
+    NotificationProviderKey.SLACK,
+    NotificationProviderKey.DISCORD,
+}
+
+
+class IssueNotificationDispatcher:
+    def __init__(self, invocation: ActionInvocation):
+        self.invocation = invocation
+        self.issue_notification_context = IssueNotificationContext(invocation)
+
+    def should_send_via_notification_platform(self) -> bool:
+        if not self.invocation.action.type:
+            return False
+
+        if self.invocation.action.type not in NOTIFICATION_PLATFORM_ENABLED_PROVIDERS:
+            return False
+
+        return NotificationService.has_access(
+            self.issue_notification_context.organization, NotificationSource.METRIC_ALERT
+        )
+
+    def dispatch(self) -> None:
+        if not self.should_send_via_notification_platform():
+            raise NotificationDispatcherError("Notification platform not enabled for this action")
+
+        #  Handling for metric and issue alerts differ for now, but eventually
+        #  should have only a single notification type that handles all issue data.
+        if self._is_metric_issue_action_invocation():
+            self._dispatch_metric_alert()
+        else:
+            self._dispatch_issue_alert()
+
+    # Dispatch methods for each notification type
+    def _dispatch_metric_alert(self) -> None:
+        metric_alert_notification_data = metric_alert_notification_data_factory(
+            self.issue_notification_context
+        )
+        notification_service = NotificationService(data=metric_alert_notification_data)
+        thread_key = self._get_metric_alert_thread_key()
+        threading_options = ThreadingOptions(thread_key=thread_key)
+        target = self._extract_notification_target()
+        notification_service.notify_sync(targets=[target], threading_options=threading_options)
+
+    def _dispatch_issue_alert(self) -> None:
+        issue_notification_data = issue_notification_data_factory(self.invocation)
+        notification_service = NotificationService(data=issue_notification_data)
+        notification_service.notify_sync(targets=[self._extract_notification_target()])
+
+    # General helper methods
+    def _extract_notification_target(self) -> NotificationTarget:
+        return IntegrationNotificationTarget(
+            provider_key=self.issue_notification_context.action_type,
+            resource_type=NotificationTargetResourceType.CHANNEL,
+            resource_id=self.issue_notification_context.notification_context.target_identifier,
+            integration_id=self.issue_notification_context.notification_context.integration_id,
+            organization_id=self.issue_notification_context.organization.id,
+        )
+
+    def _is_metric_issue_action_invocation(self) -> bool:
+        if not self._is_activity_action_invocation():
+            return False
+
+        event = self.invocation.event_data.event
+        # Appease the type checker, but we're guaranteed for this to be true
+        assert isinstance(event, Activity)
+
+        is_supported_activity_notification = (
+            event.type in BaseMetricAlertHandler.ACTIVITIES_TO_INVOKE_ON
+        )
+        is_metric_issue = self.invocation.event_data.group.type == MetricIssue.type_id
+        created_by_metric_detector = self.invocation.detector.type == MetricIssue.slug
+
+        return (
+            is_supported_activity_notification and is_metric_issue
+        ) or created_by_metric_detector
+
+    def _is_activity_action_invocation(self) -> bool:
+        return isinstance(self.invocation.event_data.event, Activity)
+
+    def _is_issue_action_invocation(self) -> bool:
+        return not self._is_activity_action_invocation()
+
+    # Thread key generating methods
+    def _get_issue_alert_thread_key(self) -> ThreadKey:
+        return ThreadKey(
+            key_type=NotificationSource.ISSUE,
+            key_data={
+                "action_id": self.invocation.action.id,  # debatable whether we should use actionID as part of the key
+                "group_id": self.invocation.event_data.group.id,
+            },
+        )
+
+    def _get_metric_alert_thread_key(self) -> ThreadKey:
+        return ThreadKey(
+            key_type=NotificationSource.METRIC_ALERT,
+            key_data={
+                "open_period_start": self.issue_notification_context.open_period_context.date_started.isoformat(),
+                "action_id": self.invocation.action.id,
+                "group_id": self.issue_notification_context.group.id,
+            },
+        )

--- a/src/sentry/notifications/notification_action/issue_notification_dispatcher.py
+++ b/src/sentry/notifications/notification_action/issue_notification_dispatcher.py
@@ -69,7 +69,11 @@ class IssueNotificationDispatcher:
     def _dispatch_issue_alert(self) -> None:
         issue_notification_data = issue_notification_data_factory(self.invocation)
         notification_service = NotificationService(data=issue_notification_data)
-        notification_service.notify_sync(targets=[self._extract_notification_target()])
+        target = self._extract_notification_target()
+        threading_options = ThreadingOptions(
+            thread_key=self._get_issue_alert_thread_key(), reply_broadcast=False
+        )
+        notification_service.notify_sync(targets=[target], threading_options=threading_options)
 
     # General helper methods
     def _extract_notification_target(self) -> NotificationTarget:
@@ -93,11 +97,13 @@ class IssueNotificationDispatcher:
             event.type in BaseMetricAlertHandler.ACTIVITIES_TO_INVOKE_ON
         )
         is_metric_issue = self.invocation.event_data.group.type == MetricIssue.type_id
+        # TODO: Double check that this assumption is correct. The notification
+        #  paths currently used in the legacy path appears to be mostly the same.
         created_by_metric_detector = self.invocation.detector.type == MetricIssue.slug
 
-        return (
-            is_supported_activity_notification and is_metric_issue
-        ) or created_by_metric_detector
+        return is_supported_activity_notification and (
+            is_metric_issue or created_by_metric_detector
+        )
 
     def _is_activity_action_invocation(self) -> bool:
         return isinstance(self.invocation.event_data.event, Activity)
@@ -111,7 +117,7 @@ class IssueNotificationDispatcher:
             key_type=NotificationSource.ISSUE,
             key_data={
                 "action_id": self.invocation.action.id,  # debatable whether we should use actionID as part of the key
-                "group_id": self.invocation.event_data.group.id,
+                "group_id": self.issue_notification_context.group.id,
             },
         )
 

--- a/src/sentry/notifications/notification_action/issue_notification_dispatcher.py
+++ b/src/sentry/notifications/notification_action/issue_notification_dispatcher.py
@@ -76,6 +76,7 @@ class IssueNotificationDispatcher:
             self.threading_options = ThreadingOptions(
                 thread_key=self.thread_key, reply_broadcast=False
             )
+        self._prepared = True
 
     def dispatch(self) -> None:
         if not self._prepared:

--- a/src/sentry/notifications/notification_action/issue_notification_dispatcher.py
+++ b/src/sentry/notifications/notification_action/issue_notification_dispatcher.py
@@ -9,6 +9,7 @@ from sentry.notifications.platform.service import NotificationService
 from sentry.notifications.platform.target import IntegrationNotificationTarget
 from sentry.notifications.platform.threading import ThreadingOptions, ThreadKey
 from sentry.notifications.platform.types import (
+    NotificationData,
     NotificationProviderKey,
     NotificationSource,
     NotificationTarget,
@@ -29,9 +30,17 @@ NOTIFICATION_PLATFORM_ENABLED_PROVIDERS = {
 
 
 class IssueNotificationDispatcher:
+    invocation: ActionInvocation
+    issue_notification_context: IssueNotificationContext
+    notification_data: NotificationData | None
+    notification_target: NotificationTarget | None
+    threading_options: ThreadingOptions | None
+    _prepared: bool
+
     def __init__(self, invocation: ActionInvocation):
         self.invocation = invocation
         self.issue_notification_context = IssueNotificationContext(invocation)
+        self._prepared = False
 
     def should_send_via_notification_platform(self) -> bool:
         if not self.invocation.action.type:
@@ -44,36 +53,41 @@ class IssueNotificationDispatcher:
             self.issue_notification_context.organization, NotificationSource.METRIC_ALERT
         )
 
-    def dispatch(self) -> None:
+    def prepare_notification(self) -> None:
+        """
+        Sets NotificationData and ThreadingOptions, which require DB queries.
+        """
+        if self._prepared:
+            return
+
         if not self.should_send_via_notification_platform():
             raise NotificationDispatcherError("Notification platform not enabled for this action")
+        self.notification_target = self._extract_notification_target()
 
-        #  Handling for metric and issue alerts differ for now, but eventually
-        #  should have only a single notification type that handles all issue data.
         if self._is_metric_issue_action_invocation():
-            self._dispatch_metric_alert()
+            self.notification_data = metric_alert_notification_data_factory(
+                self.issue_notification_context
+            )
+            self.thread_key = self._get_metric_alert_thread_key()
+            self.threading_options = ThreadingOptions(thread_key=self.thread_key)
         else:
-            self._dispatch_issue_alert()
+            self.notification_data = issue_notification_data_factory(self.invocation)
+            self.thread_key = self._get_issue_alert_thread_key()
+            self.threading_options = ThreadingOptions(
+                thread_key=self.thread_key, reply_broadcast=False
+            )
 
-    # Dispatch methods for each notification type
-    def _dispatch_metric_alert(self) -> None:
-        metric_alert_notification_data = metric_alert_notification_data_factory(
-            self.issue_notification_context
-        )
-        notification_service = NotificationService(data=metric_alert_notification_data)
-        thread_key = self._get_metric_alert_thread_key()
-        threading_options = ThreadingOptions(thread_key=thread_key)
-        target = self._extract_notification_target()
-        notification_service.notify_sync(targets=[target], threading_options=threading_options)
+    def dispatch(self) -> None:
+        if not self._prepared:
+            self.prepare_notification()
 
-    def _dispatch_issue_alert(self) -> None:
-        issue_notification_data = issue_notification_data_factory(self.invocation)
-        notification_service = NotificationService(data=issue_notification_data)
-        target = self._extract_notification_target()
-        threading_options = ThreadingOptions(
-            thread_key=self._get_issue_alert_thread_key(), reply_broadcast=False
+        assert self.notification_data is not None
+        assert self.notification_target is not None
+
+        notification_service = NotificationService(data=self.notification_data)
+        notification_service.notify_sync(
+            targets=[self.notification_target], threading_options=self.threading_options
         )
-        notification_service.notify_sync(targets=[target], threading_options=threading_options)
 
     # General helper methods
     def _extract_notification_target(self) -> NotificationTarget:

--- a/tests/sentry/notifications/notification_action/test_issue_notification_dispatcher.py
+++ b/tests/sentry/notifications/notification_action/test_issue_notification_dispatcher.py
@@ -1,0 +1,38 @@
+from sentry.workflow_engine.types import ActionInvocation
+from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
+
+
+class TestIssueNotificationDispatcher(BaseWorkflowTest):
+    def _create_invocation(self) -> ActionInvocation:
+        # Create all of the necessary resources for an ActionInvocation, using
+        # default integration, project, and organization available on the base
+        # TestCase.
+        raise NotImplementedError("Not implemented")
+
+    def test_dispatch(self) -> None:
+        # dispatcher = IssueNotificationDispatcher(self._create_invocation())
+        pass
+
+    def rejects_notification_for_non_enabled_providers(self) -> None:
+        pass
+
+    def rejects_notification_for_non_metric_activity_notifications(self) -> None:
+        pass
+
+    def correctly_classifies_metric_alert_notification(self) -> None:
+        pass
+
+    def correctly_dispatches_metric_alert_notification(self) -> None:
+        # Check that the data payload is correct
+        # Check that the target is valid given the integration and target IDs
+        # Check that the threading options are correct
+        pass
+
+    def correctly_classifies_issue_alert_notification(self) -> None:
+        pass
+
+    def correctly_dispatches_issue_alert_notification(self) -> None:
+        # Check that the data payload is correct
+        # Check that the target is valid given the integration and target IDs
+        # Check that the threading options are correct
+        pass

--- a/tests/sentry/notifications/notification_action/test_issue_notification_dispatcher.py
+++ b/tests/sentry/notifications/notification_action/test_issue_notification_dispatcher.py
@@ -1,38 +1,346 @@
-from sentry.workflow_engine.types import ActionInvocation
-from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
+import uuid
+from dataclasses import asdict
+from unittest import mock
+
+import pytest
+
+from sentry.grouping.grouptype import ErrorGroupType
+from sentry.models.activity import Activity
+from sentry.notifications.models.notificationaction import ActionTarget
+from sentry.notifications.notification_action.issue_notification_dispatcher import (
+    IssueNotificationDispatcher,
+    NotificationDispatcherError,
+)
+from sentry.notifications.platform.service import NotificationService
+from sentry.notifications.platform.target import IntegrationNotificationTarget
+from sentry.notifications.platform.types import (
+    NotificationProviderKey,
+    NotificationSource,
+    NotificationTargetResourceType,
+)
+from sentry.testutils.skips import requires_snuba
+from sentry.types.activity import ActivityType
+from sentry.workflow_engine.models import Action
+from sentry.workflow_engine.types import ActionInvocation, WorkflowEventData
+from tests.sentry.notifications.notification_action.test_metric_alert_registry_handlers import (
+    MetricAlertHandlerBase,
+)
+
+pytestmark = [requires_snuba]
 
 
-class TestIssueNotificationDispatcher(BaseWorkflowTest):
-    def _create_invocation(self) -> ActionInvocation:
-        # Create all of the necessary resources for an ActionInvocation, using
-        # default integration, project, and organization available on the base
-        # TestCase.
-        raise NotImplementedError("Not implemented")
+class TestIssueNotificationDispatcher(MetricAlertHandlerBase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.integration = self.create_integration(
+            organization=self.organization,
+            provider="slack",
+            external_id="slack_ext_id",
+        )
+        self.action = self.create_action(
+            type=Action.Type.SLACK,
+            integration_id=self.integration.id,
+            config={
+                "target_identifier": "C12345",
+                "target_display": "#test-channel",
+                "target_type": ActionTarget.SPECIFIC,
+            },
+            data={"tags": "environment,user", "notes": "test note"},
+        )
+        # Link action to workflow (workflow_id is annotated dynamically in production)
+        self.create_workflow_action(workflow=self.workflow, action=self.action)
 
-    def test_dispatch(self) -> None:
-        # dispatcher = IssueNotificationDispatcher(self._create_invocation())
-        pass
+    def _create_metric_alert_invocation(self) -> ActionInvocation:
+        """Create an invocation for a metric alert (Activity-based, resolved)."""
+        activity = Activity.objects.create(
+            project=self.project,
+            group=self.group,
+            type=ActivityType.SET_RESOLVED.value,
+            data=asdict(self.evidence_data),
+        )
+        event_data = WorkflowEventData(
+            event=activity,
+            workflow_env=self.workflow.environment,
+            group=self.group,
+        )
+        return ActionInvocation(
+            event_data=event_data,
+            action=self.action,
+            detector=self.detector,
+            notification_uuid=str(uuid.uuid4()),
+        )
 
-    def rejects_notification_for_non_enabled_providers(self) -> None:
-        pass
+    def _create_issue_alert_invocation(self) -> ActionInvocation:
+        """Create an invocation for an issue alert (GroupEvent-based, error detector)."""
+        _, detector, _, _ = self.create_detector_and_workflow(
+            name_prefix="error",
+            detector_type=ErrorGroupType.slug,
+        )
+        group, _, group_event = self.create_group_event()
+        event_data = WorkflowEventData(
+            event=group_event,
+            workflow_env=self.workflow.environment,
+            group=group,
+        )
+        action = Action.objects.get(id=self.action.id)
+        action.workflow_id = self.workflow.id  # Normally annotated by queryset in production
+        return ActionInvocation(
+            event_data=event_data,
+            action=action,
+            detector=detector,
+            notification_uuid=str(uuid.uuid4()),
+        )
 
-    def rejects_notification_for_non_metric_activity_notifications(self) -> None:
-        pass
+    def _assert_integration_target(
+        self,
+        target: IntegrationNotificationTarget,
+        provider_key: NotificationProviderKey,
+        resource_id: str,
+        integration_id: int,
+    ) -> None:
+        assert isinstance(target, IntegrationNotificationTarget)
+        assert target.provider_key == provider_key
+        assert target.resource_type == NotificationTargetResourceType.CHANNEL
+        assert target.resource_id == resource_id
+        assert target.integration_id == integration_id
+        assert target.organization_id == self.organization.id
 
-    def correctly_classifies_metric_alert_notification(self) -> None:
-        pass
+    @mock.patch.object(NotificationService, "has_access", return_value=True)
+    @mock.patch.object(NotificationService, "notify_sync", return_value={})
+    def test_dispatch(self, mock_notify_sync, mock_has_access) -> None:
+        invocation = self._create_metric_alert_invocation()
+        dispatcher = IssueNotificationDispatcher(invocation)
+        dispatcher.dispatch()
+        assert mock_notify_sync.call_count == 1
 
-    def correctly_dispatches_metric_alert_notification(self) -> None:
-        # Check that the data payload is correct
-        # Check that the target is valid given the integration and target IDs
-        # Check that the threading options are correct
-        pass
+    def test_rejects_notification_for_non_enabled_providers(self) -> None:
+        pagerduty_action = self.create_action(
+            type=Action.Type.PAGERDUTY,
+            integration_id=self.integration.id,
+            config={
+                "target_identifier": "pd_service_key",
+                "target_type": ActionTarget.SPECIFIC,
+            },
+            data={},
+        )
+        invocation = ActionInvocation(
+            event_data=self.event_data,
+            action=pagerduty_action,
+            detector=self.detector,
+            notification_uuid=str(uuid.uuid4()),
+        )
+        dispatcher = IssueNotificationDispatcher(invocation)
+        with pytest.raises(NotificationDispatcherError):
+            dispatcher.dispatch()
 
-    def correctly_classifies_issue_alert_notification(self) -> None:
-        pass
+    @mock.patch.object(NotificationService, "has_access", return_value=False)
+    def test_rejects_notification_when_has_access_returns_false(self, mock_has_access) -> None:
+        invocation = self._create_metric_alert_invocation()
+        dispatcher = IssueNotificationDispatcher(invocation)
+        with pytest.raises(NotificationDispatcherError):
+            dispatcher.dispatch()
 
-    def correctly_dispatches_issue_alert_notification(self) -> None:
-        # Check that the data payload is correct
-        # Check that the target is valid given the integration and target IDs
-        # Check that the threading options are correct
-        pass
+    def test_should_send_returns_false_when_action_type_is_empty(self) -> None:
+        action = Action.objects.get(id=self.action.id)
+        action.type = ""
+        invocation = ActionInvocation(
+            event_data=self.event_data,
+            action=action,
+            detector=self.detector,
+            notification_uuid=str(uuid.uuid4()),
+        )
+        dispatcher = IssueNotificationDispatcher(invocation)
+        assert dispatcher.should_send_via_notification_platform() is False
+
+    def test_correctly_classifies_metric_alert_notification(self) -> None:
+        invocation = self._create_metric_alert_invocation()
+        dispatcher = IssueNotificationDispatcher(invocation)
+        assert dispatcher._is_metric_issue_action_invocation() is True
+
+    def test_correctly_classifies_issue_alert_notification(self) -> None:
+        invocation = self._create_issue_alert_invocation()
+        dispatcher = IssueNotificationDispatcher(invocation)
+        assert dispatcher._is_metric_issue_action_invocation() is False
+        assert dispatcher._is_issue_action_invocation() is True
+
+    def test_group_event_with_metric_group_is_not_metric_invocation(self) -> None:
+        """A GroupEvent (not Activity) is never classified as a metric alert, even with MetricIssue group type."""
+        invocation = ActionInvocation(
+            event_data=self.event_data,  # GroupEvent-based
+            action=self.action,
+            detector=self.detector,
+            notification_uuid=str(uuid.uuid4()),
+        )
+        dispatcher = IssueNotificationDispatcher(invocation)
+        assert dispatcher._is_metric_issue_action_invocation() is False
+
+    def test_non_set_resolved_activity_with_metric_detector_is_not_metric(self) -> None:
+        """An Activity with a non-SET_RESOLVED type should not classify as metric, even with a MetricIssue detector."""
+        activity = Activity.objects.create(
+            project=self.project,
+            group=self.group,
+            type=ActivityType.SET_IGNORED.value,
+            data={},
+        )
+        event_data = WorkflowEventData(
+            event=activity,
+            workflow_env=self.workflow.environment,
+            group=self.group,
+        )
+        invocation = ActionInvocation(
+            event_data=event_data,
+            action=self.action,
+            detector=self.detector,  # MetricIssue.slug type
+            notification_uuid=str(uuid.uuid4()),
+        )
+        dispatcher = IssueNotificationDispatcher(invocation)
+        assert dispatcher._is_metric_issue_action_invocation() is False
+
+    def test_activity_with_non_metric_group_and_detector_is_not_metric(self) -> None:
+        """Activity with SET_RESOLVED but non-metric group type and detector returns False."""
+        _, error_detector, _, _ = self.create_detector_and_workflow(
+            name_prefix="error",
+            detector_type=ErrorGroupType.slug,
+        )
+        group, _, _ = self.create_group_event()  # default error group type
+        activity = Activity.objects.create(
+            project=self.project,
+            group=group,
+            type=ActivityType.SET_RESOLVED.value,
+            data={},
+        )
+        event_data = WorkflowEventData(
+            event=activity,
+            workflow_env=self.workflow.environment,
+            group=group,
+        )
+        invocation = ActionInvocation(
+            event_data=event_data,
+            action=self.action,
+            detector=error_detector,
+            notification_uuid=str(uuid.uuid4()),
+        )
+        dispatcher = IssueNotificationDispatcher(invocation)
+        assert dispatcher._is_metric_issue_action_invocation() is False
+
+    @mock.patch.object(NotificationService, "has_access", return_value=True)
+    @mock.patch.object(NotificationService, "notify_sync", return_value={})
+    def test_correctly_dispatches_metric_alert_notification(
+        self, mock_notify_sync, mock_has_access
+    ) -> None:
+        invocation = self._create_metric_alert_invocation()
+        dispatcher = IssueNotificationDispatcher(invocation)
+        dispatcher.dispatch()
+
+        assert mock_notify_sync.call_count == 1
+        _, kwargs = mock_notify_sync.call_args
+
+        assert len(kwargs["targets"]) == 1
+        self._assert_integration_target(
+            kwargs["targets"][0], NotificationProviderKey.SLACK, "C12345", self.integration.id
+        )
+
+        threading_options = kwargs["threading_options"]
+        assert threading_options is not None
+        thread_key = threading_options.thread_key
+        assert thread_key.key_type == NotificationSource.METRIC_ALERT
+        assert thread_key.key_data["action_id"] == self.action.id
+        assert thread_key.key_data["group_id"] == invocation.event_data.group.id
+        assert "open_period_start" in thread_key.key_data
+
+    @mock.patch.object(NotificationService, "has_access", return_value=True)
+    @mock.patch.object(NotificationService, "notify_sync", return_value={})
+    def test_correctly_dispatches_issue_alert_notification(
+        self, mock_notify_sync, mock_has_access
+    ) -> None:
+        invocation = self._create_issue_alert_invocation()
+        dispatcher = IssueNotificationDispatcher(invocation)
+        dispatcher.dispatch()
+
+        assert mock_notify_sync.call_count == 1
+        _, kwargs = mock_notify_sync.call_args
+
+        assert len(kwargs["targets"]) == 1
+        self._assert_integration_target(
+            kwargs["targets"][0], NotificationProviderKey.SLACK, "C12345", self.integration.id
+        )
+
+        threading_options = kwargs.get("threading_options")
+        assert threading_options is not None
+        assert threading_options.thread_key.key_type == NotificationSource.ISSUE
+        assert threading_options.thread_key.key_data["action_id"] == self.action.id
+        assert threading_options.thread_key.key_data["group_id"] == invocation.event_data.group.id
+        assert threading_options.reply_broadcast is False
+
+    def test_extract_notification_target(self) -> None:
+        invocation = self._create_metric_alert_invocation()
+        dispatcher = IssueNotificationDispatcher(invocation)
+        target = dispatcher._extract_notification_target()
+        self._assert_integration_target(
+            target, NotificationProviderKey.SLACK, "C12345", self.integration.id
+        )
+
+    def test_metric_alert_thread_key(self) -> None:
+        invocation = self._create_metric_alert_invocation()
+        dispatcher = IssueNotificationDispatcher(invocation)
+        thread_key = dispatcher._get_metric_alert_thread_key()
+
+        assert thread_key.key_type == NotificationSource.METRIC_ALERT
+        assert thread_key.key_data["action_id"] == self.action.id
+        assert thread_key.key_data["group_id"] == self.group.id
+        open_period_start = thread_key.key_data["open_period_start"]
+        assert isinstance(open_period_start, str)
+        assert self.open_period.date_started.isoformat() == open_period_start
+
+    def test_issue_alert_thread_key(self) -> None:
+        invocation = self._create_issue_alert_invocation()
+        dispatcher = IssueNotificationDispatcher(invocation)
+        thread_key = dispatcher._get_issue_alert_thread_key()
+
+        assert thread_key.key_type == NotificationSource.ISSUE
+        assert thread_key.key_data["action_id"] == self.action.id
+        assert thread_key.key_data["group_id"] == invocation.event_data.group.id
+
+    @mock.patch.object(NotificationService, "has_access", return_value=True)
+    @mock.patch.object(NotificationService, "notify_sync", return_value={})
+    def test_dispatch_with_discord_provider(self, mock_notify_sync, mock_has_access) -> None:
+        discord_integration = self.create_integration(
+            organization=self.organization,
+            provider="discord",
+            external_id="discord_ext_id",
+        )
+        discord_action = self.create_action(
+            type=Action.Type.DISCORD,
+            integration_id=discord_integration.id,
+            config={
+                "target_identifier": "discord_channel_123",
+                "target_type": ActionTarget.SPECIFIC,
+            },
+            data={"tags": "environment"},
+        )
+        activity = Activity.objects.create(
+            project=self.project,
+            group=self.group,
+            type=ActivityType.SET_RESOLVED.value,
+            data=asdict(self.evidence_data),
+        )
+        event_data = WorkflowEventData(
+            event=activity,
+            workflow_env=self.workflow.environment,
+            group=self.group,
+        )
+        invocation = ActionInvocation(
+            event_data=event_data,
+            action=discord_action,
+            detector=self.detector,
+            notification_uuid=str(uuid.uuid4()),
+        )
+        dispatcher = IssueNotificationDispatcher(invocation)
+        dispatcher.dispatch()
+
+        assert mock_notify_sync.call_count == 1
+        _, kwargs = mock_notify_sync.call_args
+        target = kwargs["targets"][0]
+        assert target.provider_key == NotificationProviderKey.DISCORD
+        assert target.resource_id == "discord_channel_123"
+        assert target.integration_id == discord_integration.id

--- a/tests/sentry/notifications/notification_action/test_issue_notification_dispatcher.py
+++ b/tests/sentry/notifications/notification_action/test_issue_notification_dispatcher.py
@@ -83,7 +83,9 @@ class TestIssueNotificationDispatcher(MetricAlertHandlerBase):
             group=group,
         )
         action = Action.objects.get(id=self.action.id)
-        action.workflow_id = self.workflow.id  # Normally annotated by queryset in production
+        setattr(
+            action, "workflow_id", self.workflow.id
+        )  # Normally annotated by queryset in production
         return ActionInvocation(
             event_data=event_data,
             action=action,
@@ -276,6 +278,7 @@ class TestIssueNotificationDispatcher(MetricAlertHandlerBase):
         invocation = self._create_metric_alert_invocation()
         dispatcher = IssueNotificationDispatcher(invocation)
         target = dispatcher._extract_notification_target()
+        assert isinstance(target, IntegrationNotificationTarget)
         self._assert_integration_target(
             target, NotificationProviderKey.SLACK, "C12345", self.integration.id
         )

--- a/tests/sentry/notifications/notification_action/test_issue_notification_dispatcher.py
+++ b/tests/sentry/notifications/notification_action/test_issue_notification_dispatcher.py
@@ -68,6 +68,7 @@ class TestIssueNotificationDispatcher(MetricAlertHandlerBase):
             action=self.action,
             detector=self.detector,
             notification_uuid=str(uuid.uuid4()),
+            workflow_id=self.workflow.id,
         )
 
     def _create_issue_alert_invocation(self) -> ActionInvocation:
@@ -91,6 +92,7 @@ class TestIssueNotificationDispatcher(MetricAlertHandlerBase):
             action=action,
             detector=detector,
             notification_uuid=str(uuid.uuid4()),
+            workflow_id=self.workflow.id,
         )
 
     def _assert_integration_target(
@@ -109,7 +111,9 @@ class TestIssueNotificationDispatcher(MetricAlertHandlerBase):
 
     @mock.patch.object(NotificationService, "has_access", return_value=True)
     @mock.patch.object(NotificationService, "notify_sync", return_value={})
-    def test_dispatch(self, mock_notify_sync, mock_has_access) -> None:
+    def test_dispatch(
+        self, mock_notify_sync: mock.MagicMock, mock_has_access: mock.MagicMock
+    ) -> None:
         invocation = self._create_metric_alert_invocation()
         dispatcher = IssueNotificationDispatcher(invocation)
         dispatcher.dispatch()
@@ -130,13 +134,16 @@ class TestIssueNotificationDispatcher(MetricAlertHandlerBase):
             action=pagerduty_action,
             detector=self.detector,
             notification_uuid=str(uuid.uuid4()),
+            workflow_id=self.workflow.id,
         )
         dispatcher = IssueNotificationDispatcher(invocation)
         with pytest.raises(NotificationDispatcherError):
             dispatcher.dispatch()
 
     @mock.patch.object(NotificationService, "has_access", return_value=False)
-    def test_rejects_notification_when_has_access_returns_false(self, mock_has_access) -> None:
+    def test_rejects_notification_when_has_access_returns_false(
+        self, mock_has_access: mock.MagicMock
+    ) -> None:
         invocation = self._create_metric_alert_invocation()
         dispatcher = IssueNotificationDispatcher(invocation)
         with pytest.raises(NotificationDispatcherError):
@@ -150,6 +157,7 @@ class TestIssueNotificationDispatcher(MetricAlertHandlerBase):
             action=action,
             detector=self.detector,
             notification_uuid=str(uuid.uuid4()),
+            workflow_id=self.workflow.id,
         )
         dispatcher = IssueNotificationDispatcher(invocation)
         assert dispatcher.should_send_via_notification_platform() is False
@@ -172,6 +180,7 @@ class TestIssueNotificationDispatcher(MetricAlertHandlerBase):
             action=self.action,
             detector=self.detector,
             notification_uuid=str(uuid.uuid4()),
+            workflow_id=self.workflow.id,
         )
         dispatcher = IssueNotificationDispatcher(invocation)
         assert dispatcher._is_metric_issue_action_invocation() is False
@@ -194,6 +203,7 @@ class TestIssueNotificationDispatcher(MetricAlertHandlerBase):
             action=self.action,
             detector=self.detector,  # MetricIssue.slug type
             notification_uuid=str(uuid.uuid4()),
+            workflow_id=self.workflow.id,
         )
         dispatcher = IssueNotificationDispatcher(invocation)
         assert dispatcher._is_metric_issue_action_invocation() is False
@@ -221,6 +231,7 @@ class TestIssueNotificationDispatcher(MetricAlertHandlerBase):
             action=self.action,
             detector=error_detector,
             notification_uuid=str(uuid.uuid4()),
+            workflow_id=self.workflow.id,
         )
         dispatcher = IssueNotificationDispatcher(invocation)
         assert dispatcher._is_metric_issue_action_invocation() is False
@@ -228,7 +239,7 @@ class TestIssueNotificationDispatcher(MetricAlertHandlerBase):
     @mock.patch.object(NotificationService, "has_access", return_value=True)
     @mock.patch.object(NotificationService, "notify_sync", return_value={})
     def test_correctly_dispatches_metric_alert_notification(
-        self, mock_notify_sync, mock_has_access
+        self, mock_notify_sync: mock.MagicMock, mock_has_access: mock.MagicMock
     ) -> None:
         invocation = self._create_metric_alert_invocation()
         dispatcher = IssueNotificationDispatcher(invocation)
@@ -253,7 +264,7 @@ class TestIssueNotificationDispatcher(MetricAlertHandlerBase):
     @mock.patch.object(NotificationService, "has_access", return_value=True)
     @mock.patch.object(NotificationService, "notify_sync", return_value={})
     def test_correctly_dispatches_issue_alert_notification(
-        self, mock_notify_sync, mock_has_access
+        self, mock_notify_sync: mock.MagicMock, mock_has_access: mock.MagicMock
     ) -> None:
         invocation = self._create_issue_alert_invocation()
         dispatcher = IssueNotificationDispatcher(invocation)
@@ -306,7 +317,9 @@ class TestIssueNotificationDispatcher(MetricAlertHandlerBase):
 
     @mock.patch.object(NotificationService, "has_access", return_value=True)
     @mock.patch.object(NotificationService, "notify_sync", return_value={})
-    def test_dispatch_with_discord_provider(self, mock_notify_sync, mock_has_access) -> None:
+    def test_dispatch_with_discord_provider(
+        self, mock_notify_sync: mock.MagicMock, mock_has_access: mock.MagicMock
+    ) -> None:
         discord_integration = self.create_integration(
             organization=self.organization,
             provider="discord",
@@ -337,6 +350,7 @@ class TestIssueNotificationDispatcher(MetricAlertHandlerBase):
             action=discord_action,
             detector=self.detector,
             notification_uuid=str(uuid.uuid4()),
+            workflow_id=self.workflow.id,
         )
         dispatcher = IssueNotificationDispatcher(invocation)
         dispatcher.dispatch()


### PR DESCRIPTION
This is dependent on #113495 merging first

Adds an `IssueNotificationDispatcher` class responsible for the following:
1. Deciding whether or not to send a notification to notification platform
2. Discerning which legacy issue type of notification to dispatch
3. Constructing the correct data and thread objects for the notification
4. Dispatching the notification via notification platform

While the current incarnation of this mostly handles legacy cases, the intention of this is to become the generic IssueNotification handler, which selects the correct template, thread key, and data object for a given ActionInvocation.