### PR TITLE
fix(detectors): Don't assume the Detector cache is limited to enabled

### DIFF
--- a/src/sentry/workflow_engine/caches/detector.py
+++ b/src/sentry/workflow_engine/caches/detector.py
@@ -22,6 +22,7 @@ _detectors_by_data_source = CacheMapping[_DetectorCacheKey, list[Detector]](
 def get_detectors_by_data_source(source_id: str, query_type: str) -> list[Detector]:
     """
     Get detectors from cache, querying the database and populating the cache if necessary.
+    The returned Detectors may be disabled.
     """
     with metrics.timer("workflow_engine.bulk_detector_fetch") as metrics_tags:
         cache_key = _DetectorCacheKey(source_id, query_type)

--- a/src/sentry/workflow_engine/processors/data_source.py
+++ b/src/sentry/workflow_engine/processors/data_source.py
@@ -32,9 +32,11 @@ def bulk_fetch_enabled_detectors(source_id: str, query_type: str) -> list[Detect
         return []
 
     if features.has("organizations:cache-detectors-by-data-source", organization):
-        return get_detectors_by_data_source(source_id, query_type)
+        detectors = get_detectors_by_data_source(source_id, query_type)
     else:
-        return _query_detectors(source_id, query_type)
+        detectors = _query_detectors(source_id, query_type)
+    # Limit to enabled here so our cache layer doesn't need to.
+    return [d for d in detectors if d.enabled]
 
 
 # TODO - @saponifi3d - make query_type optional override, otherwise infer from the data packet.


### PR DESCRIPTION
This is a step towards allowing us to cache disabled Detectors, which can make our cache useful in more contexts (such as for Uptime).
