### PR TITLE
feature(seer agent): change styling of input bar and message bubbles

### DIFF
--- a/static/app/views/seerExplorer/components/blockComponents.spec.tsx
+++ b/static/app/views/seerExplorer/components/blockComponents.spec.tsx
@@ -120,7 +120,7 @@ describe('BlockComponent', () => {
 
   describe('Focus State', () => {
     it('shows reset button when isFocused=true', () => {
-      const block = createUserInputBlock();
+      const block = createResponseBlock();
       render(
         <BlockComponent
           block={block}
@@ -135,7 +135,7 @@ describe('BlockComponent', () => {
     });
 
     it('does not show reset button when isFocused=false', () => {
-      const block = createUserInputBlock();
+      const block = createResponseBlock();
       render(
         <BlockComponent
           block={block}
@@ -169,7 +169,7 @@ describe('BlockComponent', () => {
       ).toBeInTheDocument();
     });
 
-    it('does not show feedback buttons for user blocks', () => {
+    it('does not show any action buttons for user blocks', () => {
       const block = createUserInputBlock();
       render(
         <BlockComponent
@@ -187,6 +187,10 @@ describe('BlockComponent', () => {
       expect(
         screen.queryByRole('button', {name: 'Feedback Thumbs Down'})
       ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', {name: 'Copy block content'})
+      ).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', {name: '↩'})).not.toBeInTheDocument();
     });
 
     it('disables both thumbs buttons after thumbs up is clicked', async () => {

--- a/static/app/views/seerExplorer/components/blockComponents.spec.tsx
+++ b/static/app/views/seerExplorer/components/blockComponents.spec.tsx
@@ -169,7 +169,7 @@ describe('BlockComponent', () => {
       ).toBeInTheDocument();
     });
 
-    it('does not show any action buttons for user blocks', () => {
+    it('only shows rethink action for user blocks', () => {
       const block = createUserInputBlock();
       render(
         <BlockComponent
@@ -190,7 +190,7 @@ describe('BlockComponent', () => {
       expect(
         screen.queryByRole('button', {name: 'Copy block content'})
       ).not.toBeInTheDocument();
-      expect(screen.queryByRole('button', {name: '↩'})).not.toBeInTheDocument();
+      expect(screen.getByRole('button', {name: '↩'})).toBeInTheDocument();
     });
 
     it('disables both thumbs buttons after thumbs up is clicked', async () => {

--- a/static/app/views/seerExplorer/components/blockComponents.tsx
+++ b/static/app/views/seerExplorer/components/blockComponents.tsx
@@ -10,7 +10,7 @@ import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {FlippedReturnIcon} from 'sentry/components/events/autofix/insights/autofixInsightCard';
-import {IconChevron, IconCopy, IconLink, IconThumb} from 'sentry/icons';
+import {IconCopy, IconLink, IconThumb} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {MarkedText} from 'sentry/utils/marked/markedText';
@@ -363,7 +363,8 @@ export function BlockComponent({
     !block.loading &&
     !isAwaitingFileApproval &&
     !isAwaitingQuestion &&
-    !readOnly;
+    !readOnly &&
+    block.message.role !== 'user';
   const showFeedbackButtons = block.message.role === 'assistant';
   const showCopyButton = block.message.role !== 'tool_use';
 
@@ -378,8 +379,7 @@ export function BlockComponent({
     >
       <motion.div initial={{opacity: 0, x: 10}} animate={{opacity: 1, x: 0}}>
         {block.message.role === 'user' ? (
-          <Flex align="start" width="100%">
-            <BlockChevronIcon direction="right" size="sm" />
+          <Flex align="start" justify="end" width="100%" padding="xl">
             <UserBlockContent>{block.message.content ?? ''}</UserBlockContent>
           </Flex>
         ) : (
@@ -520,14 +520,6 @@ const Block = styled('div')<{isFocused?: boolean; isLast?: boolean}>`
     p.isLast ? '1px solid transparent' : `1px solid ${p.theme.tokens.border.primary}`};
   position: relative;
   flex-shrink: 0; /* Prevent blocks from shrinking */
-`;
-
-const BlockChevronIcon = styled(IconChevron)`
-  color: ${p => p.theme.tokens.content.secondary};
-  margin-top: 18px;
-  margin-left: ${p => p.theme.space.xl};
-  margin-right: ${p => p.theme.space.md};
-  flex-shrink: 0;
 `;
 
 function getStatusTooltipText(
@@ -675,11 +667,13 @@ const BlockContent = styled(MarkedText)`
 `;
 
 const UserBlockContent = styled('div')`
-  width: 100%;
-  padding: ${p => p.theme.space.xl} ${p => p.theme.space.xl} ${p => p.theme.space.xl} 0;
+  padding: ${p => p.theme.space.md} ${p => p.theme.space.lg};
   white-space: pre-wrap;
   word-wrap: break-word;
-  color: ${p => p.theme.tokens.content.secondary};
+  color: ${p => p.theme.tokens.content.primary};
+  background: ${p => p.theme.tokens.background.secondary};
+  border: 1px solid ${p => p.theme.tokens.border.primary};
+  border-radius: 6px;
 `;
 
 const ToolCallStack = styled(Stack)`

--- a/static/app/views/seerExplorer/components/blockComponents.tsx
+++ b/static/app/views/seerExplorer/components/blockComponents.tsx
@@ -11,7 +11,14 @@ import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {FlippedReturnIcon} from 'sentry/components/events/autofix/insights/autofixInsightCard';
-import {IconCopy, IconLink, IconThumb} from 'sentry/icons';
+import {
+  IconCheckmark,
+  IconClose,
+  IconCopy,
+  IconExclamation,
+  IconLink,
+  IconThumb,
+} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {MarkedText} from 'sentry/utils/marked/markedText';

--- a/static/app/views/seerExplorer/components/blockComponents.tsx
+++ b/static/app/views/seerExplorer/components/blockComponents.tsx
@@ -47,7 +47,6 @@ interface BlockProps {
   isFocused?: boolean;
   isLast?: boolean;
   isLatestTodoBlock?: boolean;
-  isPolling?: boolean;
   onClick?: () => void;
   onDelete?: () => void;
   onMouseEnter?: () => void;
@@ -149,7 +148,6 @@ export function BlockComponent({
   isLast,
   isLatestTodoBlock,
   isFocused,
-  isPolling,
   onClick,
   onDelete,
   onMouseEnter,
@@ -361,7 +359,6 @@ export function BlockComponent({
 
   const showActions =
     isFocused &&
-    !isPolling &&
     !block.loading &&
     !isAwaitingFileApproval &&
     !isAwaitingQuestion &&

--- a/static/app/views/seerExplorer/components/blockComponents.tsx
+++ b/static/app/views/seerExplorer/components/blockComponents.tsx
@@ -362,10 +362,9 @@ export function BlockComponent({
     !block.loading &&
     !isAwaitingFileApproval &&
     !isAwaitingQuestion &&
-    !readOnly &&
-    block.message.role !== 'user';
+    !readOnly;
   const showFeedbackButtons = block.message.role === 'assistant';
-  const showCopyButton = block.message.role !== 'tool_use';
+  const showCopyButton = block.message.role !== 'user' && !!block.message.content?.trim();
 
   const blockStatus = getToolStatus(block);
 

--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.spec.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.spec.tsx
@@ -92,7 +92,7 @@ describe('ExplorerDrawerContent', () => {
       );
       expect(
         await screen.findByPlaceholderText(
-          'Type your message or / command and press Enter ↵'
+          'Ask Seer a question, or press / for commands.'
         )
       ).toBeInTheDocument();
     });
@@ -374,7 +374,7 @@ describe('ExplorerDrawerContent', () => {
       await waitFor(() => expect(textarea).toBeEnabled());
       expect(textarea).toHaveAttribute(
         'placeholder',
-        'Type your message or / command and press Enter ↵'
+        'Ask Seer a question, or press / for commands.'
       );
     });
 

--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.spec.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.spec.tsx
@@ -92,7 +92,7 @@ describe('ExplorerDrawerContent', () => {
       );
       expect(
         await screen.findByPlaceholderText(
-          'Ask Seer a question, or press / for commands.'
+          'Ask Seer a question and press Enter ↵, or press / for commands.'
         )
       ).toBeInTheDocument();
     });
@@ -374,7 +374,7 @@ describe('ExplorerDrawerContent', () => {
       await waitFor(() => expect(textarea).toBeEnabled());
       expect(textarea).toHaveAttribute(
         'placeholder',
-        'Ask Seer a question, or press / for commands.'
+        'Ask Seer a question and press Enter ↵, or press / for commands.'
       );
     });
 

--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.spec.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.spec.tsx
@@ -92,7 +92,7 @@ describe('ExplorerDrawerContent', () => {
       );
       expect(
         await screen.findByPlaceholderText(
-          'Ask Seer a question and press Enter ↵, or press / for commands.'
+          'Ask seer a question, or press / for commands.'
         )
       ).toBeInTheDocument();
     });
@@ -374,7 +374,7 @@ describe('ExplorerDrawerContent', () => {
       await waitFor(() => expect(textarea).toBeEnabled());
       expect(textarea).toHaveAttribute(
         'placeholder',
-        'Ask Seer a question and press Enter ↵, or press / for commands.'
+        'Ask seer a question, or press / for commands.'
       );
     });
 

--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
@@ -212,6 +212,18 @@ export function ExplorerDrawerContent({
   }, [closeMenu]);
 
   // - Input section handlers -------------------------------------------------
+  const handleSend = useCallback(() => {
+    if (readOnly || isPolling || !inputValue.trim()) {
+      return;
+    }
+    sendMessage(inputValue.trim());
+    setInputValue('');
+    userScrolledUpRef.current = false;
+    if (textareaRef.current) {
+      textareaRef.current.style.height = 'auto';
+    }
+  }, [readOnly, inputValue, isPolling, sendMessage]);
+
   const handleInputKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       if (readOnly || e.nativeEvent.isComposing) {
@@ -220,19 +232,10 @@ export function ExplorerDrawerContent({
 
       if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();
-        if (inputValue.trim() && !isPolling) {
-          sendMessage(inputValue.trim());
-          setInputValue('');
-          // Reset scroll state so we auto-scroll to show the response
-          userScrolledUpRef.current = false;
-          // Reset textarea height
-          if (textareaRef.current) {
-            textareaRef.current.style.height = 'auto';
-          }
-        }
+        handleSend();
       }
     },
-    [readOnly, inputValue, isPolling, sendMessage]
+    [readOnly, handleSend]
   );
 
   const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -506,6 +509,7 @@ export function ExplorerDrawerContent({
         onInputClick={handleInputClick}
         onInterrupt={interruptRun}
         onKeyDown={handleInputKeyDown}
+        onSend={handleSend}
         onPRWidgetClick={openPRWidget}
         prWidgetButtonRef={prWidgetButtonRef}
         repoPRStates={repoPRStates}

--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
@@ -378,7 +378,6 @@ export function ExplorerDrawerContent({
     textareaRef,
     setFocusedBlockIndex,
     isFileApprovalPending,
-    isPolling,
     isQuestionPending,
     onDeleteFromIndex: deleteFromIndex,
     onKeyPress: (blockIndex, key) => {
@@ -445,7 +444,6 @@ export function ExplorerDrawerContent({
                   index === blocks.length - 1 && !(isAwaitingUserInput && pendingInput)
                 }
                 isFocused={focusedBlockIndex === index}
-                isPolling={isPolling}
                 readOnly={readOnly}
                 onMouseEnter={() => {
                   // Don't change focus while menu is open, if already on this block, or if hover is disabled
@@ -505,9 +503,9 @@ export function ExplorerDrawerContent({
         enabled={!readOnly}
         inputValue={inputValue}
         isFocused={focusedBlockIndex === -1}
+        canInterrupt={sessionData?.status === 'processing'} // TODO: update when adding timeouts
         waitingForInterrupt={waitingForInterrupt}
         isMinimized={false} // Drawer doesn't have a minimized state
-        isPolling={isPolling}
         isVisible // Drawer content is always visible when rendered
         onClear={() => setInputValue('')}
         onCreatePR={createPR}

--- a/static/app/views/seerExplorer/components/inputSection.tsx
+++ b/static/app/views/seerExplorer/components/inputSection.tsx
@@ -7,8 +7,7 @@ import {InputGroup} from '@sentry/scraps/input';
 import {Container, Flex, Grid} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
-import {LoadingIndicator} from 'sentry/components/loadingIndicator';
-import {IconPause} from 'sentry/icons';
+import {IconArrow, IconPause} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {PRWidget} from 'sentry/views/seerExplorer/components/prWidget';
 import type {Block, RepoPRState} from 'sentry/views/seerExplorer/types';
@@ -42,6 +41,7 @@ interface InputSectionProps {
   onInterrupt: () => void;
   onKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
   onPRWidgetClick: () => void;
+  onSend: () => void;
   prWidgetButtonRef: React.RefObject<HTMLButtonElement | null>;
   repoPRStates: Record<string, RepoPRState>;
   textAreaRef: React.RefObject<HTMLTextAreaElement | null>;
@@ -66,6 +66,7 @@ export function InputSection({
   onInterrupt,
   onKeyDown,
   onPRWidgetClick,
+  onSend,
   prWidgetButtonRef,
   repoPRStates,
   textAreaRef,
@@ -255,29 +256,35 @@ export function InputSection({
     );
   }
 
-  const renderActionButton = () => {
-    if (waitingForInterrupt) {
-      return (
-        <ActionButtonWrapper title={t('Winding down...')} isDanger>
-          <LoadingIndicator size={16} />
-        </ActionButtonWrapper>
-      );
-    }
+  const lastBlock = blocks[blocks.length - 1];
+  const isAwaitingResponse = Boolean(lastBlock?.loading);
 
-    if (isPolling) {
+  const renderActionButton = () => {
+    if (isPolling || waitingForInterrupt || isAwaitingResponse) {
       return (
-        <Button
-          icon={<IconPause variant="muted" />}
+        <PauseButton
+          icon={<IconPause />}
           onClick={onInterrupt}
-          size="sm"
-          priority="transparent"
+          size="md"
+          priority="primary"
+          disabled={waitingForInterrupt}
           aria-label={t('Interrupt')}
-          tooltipProps={{title: t('Press Esc to interrupt')}}
+          tooltipProps={{
+            title: waitingForInterrupt ? t('Winding down...') : t('Interrupt'),
+          }}
         />
       );
     }
 
-    return null;
+    return (
+      <SendButton
+        icon={<IconArrow direction="right" />}
+        onClick={onSend}
+        size="md"
+        disabled={!inputValue.trim()}
+        aria-label={t('Send message')}
+      />
+    );
   };
 
   return (
@@ -290,12 +297,12 @@ export function InputSection({
             onChange={onInputChange}
             onKeyDown={onKeyDown}
             onClick={onInputClick}
-            placeholder={t('Type your message or / command and press Enter ↵')}
+            placeholder={t('Ask Seer a question, or press / for commands.')}
             rows={1}
             data-test-id="seer-explorer-input"
           />
-          <InputGroup.TrailingItems>{renderActionButton()}</InputGroup.TrailingItems>
         </StyledInputGroup>
+        {renderActionButton()}
         {enabled && hasCodeChanges && (
           <PRWidget
             ref={prWidgetButtonRef}
@@ -349,22 +356,27 @@ const ActionBar = styled(motion.div)`
   bottom: 0;
 `;
 
-const ActionButtonWrapper = styled('div')<{isDanger?: boolean}>`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 28px;
-  height: 28px;
+const SendButton = styled(Button)`
+  width: ${p => p.theme.form.md.height};
+  flex-shrink: 0;
+  background: #ffffff;
+  color: #000000;
 
-  .loading-indicator {
-    margin: 0;
-    padding: 0;
-    ${p =>
-      p.isDanger &&
-      `
-      border-color: ${p.theme.tokens.content.warning};
-      border-left-color: transparent;
-    `}
+  &:hover:not(:disabled),
+  &:focus-visible:not(:disabled) {
+    background: #ffffff;
+    color: #000000;
+  }
+`;
+
+const PauseButton = styled(Button)`
+  width: ${p => p.theme.form.md.height};
+  flex-shrink: 0;
+  background: ${p => p.theme.tokens.background.promotion.vibrant};
+  border-color: ${p => p.theme.tokens.border.promotion.vibrant};
+
+  &:disabled {
+    opacity: 0.5;
   }
 `;
 

--- a/static/app/views/seerExplorer/components/inputSection.tsx
+++ b/static/app/views/seerExplorer/components/inputSection.tsx
@@ -359,13 +359,13 @@ const ActionBar = styled(motion.div)`
 const SendButton = styled(Button)`
   width: ${p => p.theme.form.md.height};
   flex-shrink: 0;
-  background: #ffffff;
-  color: #000000;
+  background: ${p => p.theme.tokens.background.primary};
+  color: ${p => p.theme.tokens.content.primary};
 
   &:hover:not(:disabled),
   &:focus-visible:not(:disabled) {
-    background: #ffffff;
-    color: #000000;
+    background: ${p => p.theme.tokens.background.primary};
+    color: ${p => p.theme.tokens.content.primary};
   }
 `;
 

--- a/static/app/views/seerExplorer/components/inputSection.tsx
+++ b/static/app/views/seerExplorer/components/inputSection.tsx
@@ -31,10 +31,10 @@ interface QuestionActions {
 
 interface InputSectionProps {
   blocks: Block[];
+  canInterrupt: boolean;
   enabled: boolean;
   inputValue: string;
   isFocused: boolean;
-  isPolling: boolean;
   onClear: () => void;
   onCreatePR: (repoName?: string) => void;
   onInputChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
@@ -59,7 +59,7 @@ export function InputSection({
   inputValue,
   isFocused,
   isMinimized = false,
-  isPolling,
+  canInterrupt,
   waitingForInterrupt,
   isVisible = false,
   onCreatePR,
@@ -258,34 +258,6 @@ export function InputSection({
     );
   }
 
-  const renderActionButton = () => {
-    if (isPolling || waitingForInterrupt) {
-      return (
-        <PauseButton
-          icon={<IconPause />}
-          onClick={onInterrupt}
-          size="md"
-          priority="primary"
-          disabled={waitingForInterrupt}
-          aria-label={t('Interrupt')}
-          tooltipProps={{
-            title: waitingForInterrupt ? t('Winding down...') : t('Interrupt'),
-          }}
-        />
-      );
-    }
-
-    return (
-      <SendButton
-        icon={<IconArrow direction="right" />}
-        onClick={onSend}
-        size="md"
-        disabled={!inputValue.trim()}
-        aria-label={t('Send message')}
-      />
-    );
-  };
-
   return (
     <InputBlock>
       <InputRow>
@@ -305,7 +277,27 @@ export function InputSection({
             data-test-id="seer-explorer-input"
           />
         </StyledInputGroup>
-        {renderActionButton()}
+        {canInterrupt || waitingForInterrupt ? (
+          <PauseButton
+            icon={<IconPause />}
+            onClick={onInterrupt}
+            size="md"
+            priority="primary"
+            disabled={waitingForInterrupt}
+            aria-label={t('Interrupt button')}
+            tooltipProps={{
+              title: waitingForInterrupt ? t('Winding down...') : t('Interrupt'),
+            }}
+          />
+        ) : (
+          <SendButton
+            icon={<IconArrow direction="right" />}
+            onClick={onSend}
+            size="md"
+            disabled={!inputValue.trim()}
+            aria-label={t('Send message')}
+          />
+        )}
         {enabled && hasCodeChanges && (
           <PRWidget
             ref={prWidgetButtonRef}

--- a/static/app/views/seerExplorer/components/inputSection.tsx
+++ b/static/app/views/seerExplorer/components/inputSection.tsx
@@ -301,7 +301,7 @@ export function InputSection({
             onClick={onInputClick}
             placeholder={
               isFocused
-                ? t('Ask Seer a question, or press / for commands.')
+                ? t('Ask Seer a question and press Enter ↵, or press / for commands.')
                 : t('Press Tab ⇥ to return here')
             }
             rows={1}

--- a/static/app/views/seerExplorer/components/inputSection.tsx
+++ b/static/app/views/seerExplorer/components/inputSection.tsx
@@ -258,11 +258,8 @@ export function InputSection({
     );
   }
 
-  const lastBlock = blocks[blocks.length - 1];
-  const isAwaitingResponse = Boolean(lastBlock?.loading);
-
   const renderActionButton = () => {
-    if (isPolling || waitingForInterrupt || isAwaitingResponse) {
+    if (isPolling || waitingForInterrupt) {
       return (
         <PauseButton
           icon={<IconPause />}
@@ -301,7 +298,7 @@ export function InputSection({
             onClick={onInputClick}
             placeholder={
               isFocused
-                ? t('Ask Seer a question and press Enter ↵, or press / for commands.')
+                ? t('Ask seer a question, or press / for commands.')
                 : t('Press Tab ⇥ to return here')
             }
             rows={1}

--- a/static/app/views/seerExplorer/hooks/useBlockNavigation.tsx
+++ b/static/app/views/seerExplorer/hooks/useBlockNavigation.tsx
@@ -11,7 +11,6 @@ interface UseBlockNavigationProps {
   textareaRef: React.RefObject<HTMLTextAreaElement | null>;
   isFileApprovalPending?: boolean;
   isMinimized?: boolean;
-  isPolling?: boolean;
   isQuestionPending?: boolean;
   onDeleteFromIndex?: (index: number) => void;
   onKeyPress?: (blockIndex: number, key: 'Enter' | 'ArrowUp' | 'ArrowDown') => boolean;
@@ -27,7 +26,6 @@ export function useBlockNavigation({
   setFocusedBlockIndex,
   isFileApprovalPending = false,
   isMinimized = false,
-  isPolling = false,
   isQuestionPending = false,
   onDeleteFromIndex,
   onKeyPress,
@@ -45,10 +43,7 @@ export function useBlockNavigation({
 
       // Don't handle Enter when file approval or question is pending (it's used for approve/submit)
       // or when the run is loading/polling
-      if (
-        (isFileApprovalPending || isQuestionPending || isPolling) &&
-        e.key === 'Enter'
-      ) {
+      if ((isFileApprovalPending || isQuestionPending) && e.key === 'Enter') {
         return;
       }
 
@@ -116,7 +111,6 @@ export function useBlockNavigation({
     setFocusedBlockIndex,
     isFileApprovalPending,
     isMinimized,
-    isPolling,
     isQuestionPending,
     onDeleteFromIndex,
     onKeyPress,

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
@@ -390,6 +390,45 @@ describe('useSeerExplorer', () => {
       expect(blocks.some(b => b.message.role === 'assistant' && b.loading)).toBe(true);
     });
 
+    it('clears optimistic state when session completes without an assistant response', async () => {
+      const chatUrl = `/organizations/${organization.slug}/seer/explorer-chat/`;
+      const ts = '2024-01-01T00:00:00Z';
+
+      MockApiClient.addMockResponse({url: chatUrl, method: 'GET', body: {session: null}});
+      MockApiClient.addMockResponse({url: chatUrl, method: 'POST', body: {run_id: 321}});
+      MockApiClient.addMockResponse({
+        url: `${chatUrl}321/`,
+        method: 'GET',
+        body: {
+          session: {
+            blocks: [
+              {
+                id: 'user-1',
+                message: {role: 'user', content: 'Test'},
+                timestamp: ts,
+                loading: false,
+              },
+            ],
+            run_id: 321,
+            status: 'completed',
+            updated_at: ts,
+          },
+        },
+      });
+
+      const {result} = renderHookWithProviders(() => useSeerExplorer(), {organization});
+
+      act(() => {
+        result.current.sendMessage('Test');
+      });
+
+      await waitFor(() => {
+        const blocks = result.current.sessionData?.blocks ?? [];
+        expect(blocks.some(b => b.loading)).toBe(false);
+        expect(blocks).toHaveLength(1);
+      });
+    });
+
     it('keeps optimistic state when rethinking with the same message', async () => {
       const chatUrl = `/organizations/${organization.slug}/seer/explorer-chat/`;
       const ts = '2024-01-01T00:00:00Z';

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
@@ -428,57 +428,5 @@ describe('useSeerExplorer', () => {
         expect(blocks).toHaveLength(1);
       });
     });
-
-    it('keeps optimistic state when rethinking with the same message', async () => {
-      const chatUrl = `/organizations/${organization.slug}/seer/explorer-chat/`;
-      const ts = '2024-01-01T00:00:00Z';
-
-      MockApiClient.addMockResponse({url: chatUrl, method: 'GET', body: {session: null}});
-      MockApiClient.addMockResponse({
-        url: `${chatUrl}789/`,
-        method: 'GET',
-        body: {
-          session: {
-            blocks: [
-              {
-                id: 'u0',
-                message: {role: 'user', content: 'hello'},
-                timestamp: ts,
-                loading: false,
-              },
-              {
-                id: 'a1',
-                message: {role: 'assistant', content: 'Hi!'},
-                timestamp: ts,
-                loading: false,
-              },
-            ],
-            run_id: 789,
-            status: 'completed',
-            updated_at: ts,
-          },
-        },
-      });
-      MockApiClient.addMockResponse({
-        url: `${chatUrl}789/`,
-        method: 'POST',
-        body: {run_id: 789},
-      });
-
-      const {result} = renderHookWithProviders(() => useSeerExplorer(), {organization});
-
-      act(() => result.current.switchToRun(789));
-      await waitFor(() => result.current.sessionData?.blocks?.length === 2);
-
-      act(() => result.current.deleteFromIndex(0));
-      act(() => {
-        result.current.sendMessage('hello');
-      });
-
-      await waitFor(() => {
-        expect(result.current.sessionData?.blocks?.some(b => b.loading)).toBe(true);
-        expect(result.current.deletedFromIndex).toBe(0);
-      });
-    });
   });
 });

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -537,6 +537,7 @@ export const useSeerExplorer = () => {
   useEffect(() => {
     if (isSessionComplete(apiData?.session)) {
       setWaitingForInterrupt(false);
+      setOptimistic(null);
     }
   }, [apiData?.session]);
 

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -535,11 +535,15 @@ export const useSeerExplorer = () => {
 
   // On any completed state
   useEffect(() => {
-    if (isSessionComplete(apiData?.session)) {
-      setWaitingForInterrupt(false);
-      setOptimistic(null);
+    if (!isSessionComplete(apiData?.session)) {
+      return;
     }
-  }, [apiData?.session]);
+    setWaitingForInterrupt(false);
+    if (optimistic && apiData?.session?.updated_at !== optimistic.baselineUpdatedAt) {
+      setOptimistic(null);
+      setDeletedFromIndex(null);
+    }
+  }, [apiData?.session, optimistic]);
 
   // Detect PR creation errors and show error messages
   useEffect(() => {

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -534,16 +534,14 @@ export const useSeerExplorer = () => {
   }, [apiData?.session?.blocks, apiData?.session?.updated_at, optimistic]);
 
   // On any completed state
+  const isComplete = isSessionComplete(apiData?.session);
   useEffect(() => {
-    if (!isSessionComplete(apiData?.session)) {
-      return;
-    }
-    setWaitingForInterrupt(false);
-    if (optimistic && apiData?.session?.updated_at !== optimistic.baselineUpdatedAt) {
+    if (isComplete) {
+      setWaitingForInterrupt(false);
       setOptimistic(null);
       setDeletedFromIndex(null);
     }
-  }, [apiData?.session, optimistic]);
+  }, [isComplete]);
 
   // Detect PR creation errors and show error messages
   useEffect(() => {


### PR DESCRIPTION
This PR is part of the multiple styling ones. In this one I change the look of the user message blocks and remove the copy/restart tools from user blocks. This PR also adds the send and pause buttons outside of the input bar. A couple tests were also added


https://github.com/user-attachments/assets/4a14e702-6c76-44ad-b24d-4e1a937b474e

