### PR TITLE
ref(ui): Change bulk delete modal text from 'automations' to 'alerts'

### DIFF
--- a/static/app/views/automations/components/automationListTable/actions.tsx
+++ b/static/app/views/automations/components/automationListTable/actions.tsx
@@ -102,15 +102,15 @@ export function AutomationsTableActions({
   const getDeleteConfirmMessage = useCallback(() => {
     if (allInQuerySelected) {
       return tct(
-        'Are you sure you want to delete all [queryCount] automations that match the search?',
+        'Are you sure you want to delete all [queryCount] alerts that match the search?',
         {
           queryCount,
         }
       );
     }
     return tn(
-      'Are you sure you want to delete this %s automation?',
-      'Are you sure you want to delete these %s automations?',
+      'Are you sure you want to delete this %s alert?',
+      'Are you sure you want to delete these %s alerts?',
       selected.size
     );
   }, [allInQuerySelected, queryCount, selected.size]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
The bulk deletion confirmation modal for alerts was using the term "automations" instead of "alerts", which was inconsistent with the rest of the alerts UI and other confirmation modals in the same component.

## Solution
Updated the `getDeleteConfirmMessage` function in the automations list table to use "alerts" terminology instead of "automations" for:
- Single item deletion: "Are you sure you want to delete this 1 alert?"
- Multiple item deletion: "Are you sure you want to delete these N alerts?"
- Query-based deletion: "Are you sure you want to delete all N alerts that match the search?"

This aligns the delete confirmation with the enable/disable confirmations which already use "alerts" terminology.

## Testing
The change affects only display text in the confirmation modal. The functionality remains unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/C07H2DHMSS0/p1776826498395699?thread_ts=1776826498.395699&cid=C07H2DHMSS0)

<div><a href="https://cursor.com/agents/bc-e3de1432-adba-5de1-918b-3116a5984c2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3de1432-adba-5de1-918b-3116a5984c2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

