### PR TITLE
feature(seer agent): icon changes

### DIFF
--- a/static/app/views/seerExplorer/components/blockComponents.tsx
+++ b/static/app/views/seerExplorer/components/blockComponents.tsx
@@ -1,4 +1,5 @@
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {keyframes} from '@emotion/react';
 import styled from '@emotion/styled';
 import {motion} from 'framer-motion';
 import type {LocationDescriptor} from 'history';
@@ -10,7 +11,15 @@ import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {FlippedReturnIcon} from 'sentry/components/events/autofix/insights/autofixInsightCard';
-import {IconChevron, IconCopy, IconLink, IconThumb} from 'sentry/icons';
+import {
+  IconCheckmark,
+  IconChevron,
+  IconClose,
+  IconCopy,
+  IconExclamation,
+  IconLink,
+  IconThumb,
+} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {MarkedText} from 'sentry/utils/marked/markedText';
@@ -367,6 +376,8 @@ export function BlockComponent({
   const showFeedbackButtons = block.message.role === 'assistant';
   const showCopyButton = block.message.role !== 'tool_use';
 
+  const blockStatus = getToolStatus(block);
+
   return (
     <Block
       ref={ref}
@@ -384,8 +395,8 @@ export function BlockComponent({
           </Flex>
         ) : (
           <Flex align="start" width="100%">
-            <ResponseDot
-              status={getToolStatus(block)}
+            <BlockStatusIndicator
+              status={blockStatus}
               hasOnlyTools={!hasContent && hasTools}
             />
             <BlockContentWrapper hasOnlyTools={!hasContent && hasTools}>
@@ -455,7 +466,12 @@ export function BlockComponent({
                               >
                                 {toolString}
                               </ToolCallText>
-                              <ToolCallLinkIcon size="xs" isHighlighted={isHighlighted} />
+                              <ToolCallLinkIconWrapper isHighlighted={isHighlighted}>
+                                <ToolCallLinkIcon
+                                  size="xs"
+                                  isHighlighted={isHighlighted}
+                                />
+                              </ToolCallLinkIconWrapper>
                               <EnterKeyHint isVisible={isHighlighted}>
                                 enter ⏎
                               </EnterKeyHint>
@@ -530,80 +546,90 @@ const BlockChevronIcon = styled(IconChevron)`
   flex-shrink: 0;
 `;
 
-function getStatusTooltipText(
-  status: 'loading' | 'content' | 'success' | 'failure' | 'mixed' | 'pending'
-): string {
-  switch (status) {
-    case 'loading':
-      return t('Running...');
-    case 'pending':
-      return t('Waiting for approval');
-    case 'content':
-      return t('Response received');
-    case 'success':
-      return t('Completed successfully');
-    case 'failure':
-      return t('Completed with errors');
-    case 'mixed':
-      return t('Completed with partial errors');
-    default:
-      return '';
-  }
-}
-
-function ResponseDot({
+function BlockStatusIndicator({
   status,
   hasOnlyTools,
 }: {
-  status: 'loading' | 'content' | 'success' | 'failure' | 'mixed' | 'pending';
+  status: ReturnType<typeof getToolStatus>;
   hasOnlyTools?: boolean;
 }) {
+  if (status === 'content') {
+    return <BlockIndicatorSpacer />;
+  }
+  if (status === 'loading' || status === 'pending') {
+    return (
+      <Tooltip title={status === 'pending' ? t('Waiting for approval') : t('Running...')}>
+        <BlockSpinner hasOnlyTools={hasOnlyTools} />
+      </Tooltip>
+    );
+  }
+  if (status === 'failure') {
+    return (
+      <Tooltip title={t('All tool calls failed')}>
+        <BlockFailureIcon hasOnlyTools={hasOnlyTools} size="sm" />
+      </Tooltip>
+    );
+  }
+  if (status === 'mixed') {
+    return (
+      <Tooltip title={t('Some tool calls succeeded and some failed')}>
+        <BlockPartialIcon hasOnlyTools={hasOnlyTools} size="sm" />
+      </Tooltip>
+    );
+  }
   return (
-    <Tooltip title={getStatusTooltipText(status)}>
-      <ResponseDotIndicator status={status} hasOnlyTools={hasOnlyTools} />
+    <Tooltip title={t('All tool calls succeeded')}>
+      <BlockSuccessIcon hasOnlyTools={hasOnlyTools} size="sm" />
     </Tooltip>
   );
 }
 
-const ResponseDotIndicator = styled('div')<{
-  status: 'loading' | 'content' | 'success' | 'failure' | 'mixed' | 'pending';
-  hasOnlyTools?: boolean;
-}>`
-  width: 8px;
-  height: 8px;
+const spin = keyframes`
+  to { transform: rotate(360deg); }
+`;
+
+const Spinner = styled('div')`
+  width: 12px;
+  height: 12px;
   border-radius: 50%;
-  margin-top: ${p => (p.hasOnlyTools ? '12px' : '22px')};
+  border: 2px solid ${p => p.theme.tokens.border.primary};
+  border-left-color: ${p => p.theme.tokens.border.accent.vibrant};
+  animation: ${spin} 0.6s linear infinite;
+  flex-shrink: 0;
+`;
+
+const BlockSpinner = styled(Spinner)<{hasOnlyTools?: boolean}>`
+  width: 18px;
+  height: 18px;
+  margin-top: ${p => (p.hasOnlyTools ? '10px' : '18px')};
+  margin-left: ${p => p.theme.space.xl};
+`;
+
+const BlockIndicatorSpacer = styled('div')`
+  width: 18px;
   margin-left: ${p => p.theme.space.xl};
   flex-shrink: 0;
-  background: ${p => {
-    switch (p.status) {
-      case 'loading':
-        return p.theme.tokens.content.promotion;
-      case 'pending':
-        return p.theme.tokens.content.promotion;
-      case 'content':
-        return p.theme.tokens.content.accent;
-      case 'success':
-        return p.theme.tokens.content.success;
-      case 'failure':
-        return p.theme.tokens.content.danger;
-      case 'mixed':
-        return p.theme.tokens.content.warning;
-      default:
-        return p.theme.tokens.content.accent;
-    }
-  }};
+`;
 
-  ${p =>
-    p.status === 'loading' &&
-    `
-    animation: blink 1s infinite;
+const BlockSuccessIcon = styled(IconCheckmark)<{hasOnlyTools?: boolean}>`
+  color: ${p => p.theme.tokens.content.success};
+  flex-shrink: 0;
+  margin-top: ${p => (p.hasOnlyTools ? '10px' : '18px')};
+  margin-left: ${p => p.theme.space.xl};
+`;
 
-    @keyframes blink {
-      0%, 50% { opacity: 1; }
-      51%, 100% { opacity: 0.3; }
-    }
-  `}
+const BlockFailureIcon = styled(IconClose)<{hasOnlyTools?: boolean}>`
+  color: ${p => p.theme.tokens.content.danger};
+  flex-shrink: 0;
+  margin-top: ${p => (p.hasOnlyTools ? '10px' : '18px')};
+  margin-left: ${p => p.theme.space.xl};
+`;
+
+const BlockPartialIcon = styled(IconExclamation)<{hasOnlyTools?: boolean}>`
+  color: ${p => p.theme.tokens.content.warning};
+  flex-shrink: 0;
+  margin-top: ${p => (p.hasOnlyTools ? '10px' : '18px')};
+  margin-left: ${p => p.theme.space.xl};
 `;
 
 const BlockContentWrapper = styled('div')<{hasOnlyTools?: boolean}>`
@@ -725,6 +751,16 @@ const ToolCallLink = styled('button')<{isHighlighted?: boolean}>`
       color: ${p => p.theme.tokens.interactive.link.accent.hover};
       text-decoration-color: ${p => p.theme.tokens.interactive.link.accent.hover};
     }
+  }
+`;
+
+const ToolCallLinkIconWrapper = styled('span')<{isHighlighted?: boolean}>`
+  display: inline-flex;
+  flex-shrink: 0;
+  visibility: ${p => (p.isHighlighted ? 'visible' : 'hidden')};
+
+  ${ToolCallLink}:hover & {
+    visibility: visible;
   }
 `;
 

--- a/static/app/views/seerExplorer/components/blockComponents.tsx
+++ b/static/app/views/seerExplorer/components/blockComponents.tsx
@@ -137,13 +137,7 @@ function getToolStatus(
     return 'success';
   }
 
-  // No tools, check if there's content
-  const hasContent = hasValidContent(block.message.content);
-  if (hasContent) {
-    return 'content';
-  }
-
-  return 'success';
+  return 'content';
 }
 
 export function BlockComponent({

--- a/static/app/views/seerExplorer/components/blockComponents.tsx
+++ b/static/app/views/seerExplorer/components/blockComponents.tsx
@@ -558,29 +558,39 @@ function BlockStatusIndicator({
   }
   if (status === 'loading' || status === 'pending') {
     return (
-      <Tooltip title={status === 'pending' ? t('Waiting for approval') : t('Running...')}>
-        <BlockSpinner hasOnlyTools={hasOnlyTools} />
-      </Tooltip>
+      <BlockIndicatorSlot hasOnlyTools={hasOnlyTools}>
+        <Tooltip
+          title={status === 'pending' ? t('Waiting for approval') : t('Running...')}
+        >
+          <BlockSpinner />
+        </Tooltip>
+      </BlockIndicatorSlot>
     );
   }
   if (status === 'failure') {
     return (
-      <Tooltip title={t('All tool calls failed')}>
-        <BlockFailureIcon hasOnlyTools={hasOnlyTools} size="sm" />
-      </Tooltip>
+      <BlockIndicatorSlot hasOnlyTools={hasOnlyTools}>
+        <Tooltip title={t('All tool calls failed')}>
+          <BlockFailureIcon size="sm" />
+        </Tooltip>
+      </BlockIndicatorSlot>
     );
   }
   if (status === 'mixed') {
     return (
-      <Tooltip title={t('Some tool calls succeeded and some failed')}>
-        <BlockPartialIcon hasOnlyTools={hasOnlyTools} size="sm" />
-      </Tooltip>
+      <BlockIndicatorSlot hasOnlyTools={hasOnlyTools}>
+        <Tooltip title={t('Some tool calls succeeded and some failed')}>
+          <BlockPartialIcon size="sm" />
+        </Tooltip>
+      </BlockIndicatorSlot>
     );
   }
   return (
-    <Tooltip title={t('All tool calls succeeded')}>
-      <BlockSuccessIcon hasOnlyTools={hasOnlyTools} size="sm" />
-    </Tooltip>
+    <BlockIndicatorSlot hasOnlyTools={hasOnlyTools}>
+      <Tooltip title={t('All tool calls succeeded')}>
+        <BlockSuccessIcon size="sm" />
+      </Tooltip>
+    </BlockIndicatorSlot>
   );
 }
 
@@ -598,11 +608,19 @@ const Spinner = styled('div')`
   flex-shrink: 0;
 `;
 
-const BlockSpinner = styled(Spinner)<{hasOnlyTools?: boolean}>`
+const BlockSpinner = styled(Spinner)`
   width: 18px;
   height: 18px;
+`;
+
+const BlockIndicatorSlot = styled('div')<{hasOnlyTools?: boolean}>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
   margin-top: ${p => (p.hasOnlyTools ? '10px' : '18px')};
   margin-left: ${p => p.theme.space.xl};
+  flex-shrink: 0;
 `;
 
 const BlockIndicatorSpacer = styled('div')`
@@ -611,25 +629,19 @@ const BlockIndicatorSpacer = styled('div')`
   flex-shrink: 0;
 `;
 
-const BlockSuccessIcon = styled(IconCheckmark)<{hasOnlyTools?: boolean}>`
+const BlockSuccessIcon = styled(IconCheckmark)`
   color: ${p => p.theme.tokens.content.success};
   flex-shrink: 0;
-  margin-top: ${p => (p.hasOnlyTools ? '10px' : '18px')};
-  margin-left: ${p => p.theme.space.xl};
 `;
 
-const BlockFailureIcon = styled(IconClose)<{hasOnlyTools?: boolean}>`
+const BlockFailureIcon = styled(IconClose)`
   color: ${p => p.theme.tokens.content.danger};
   flex-shrink: 0;
-  margin-top: ${p => (p.hasOnlyTools ? '10px' : '18px')};
-  margin-left: ${p => p.theme.space.xl};
 `;
 
-const BlockPartialIcon = styled(IconExclamation)<{hasOnlyTools?: boolean}>`
+const BlockPartialIcon = styled(IconExclamation)`
   color: ${p => p.theme.tokens.content.warning};
   flex-shrink: 0;
-  margin-top: ${p => (p.hasOnlyTools ? '10px' : '18px')};
-  margin-left: ${p => p.theme.space.xl};
 `;
 
 const BlockContentWrapper = styled('div')<{hasOnlyTools?: boolean}>`


### PR DESCRIPTION
For the upcoming rollout, this PR changes the seer agent icons from coloured dots to symbols representing tool call status (success, failure, mixed)., the thinking dot to a spinner, and only shows tool call link icons on hover. Text blocks with no tool calls just remain indented. An image of the changes are shown below. User messages will be changed in a separate PR

<img width="709" height="615" alt="Screenshot 2026-04-21 at 7 58 49 PM" src="https://github.com/user-attachments/assets/af74b4be-a186-4513-a894-1431a70c7a40" />
