### PR TITLE
fix(experiments): Close Amplitude race on experiment exposure

### DIFF
--- a/static/gsApp/__mocks__/@amplitude/analytics-browser.tsx
+++ b/static/gsApp/__mocks__/@amplitude/analytics-browser.tsx
@@ -8,6 +8,7 @@ export const identify = jest.fn();
 export const init = jest.fn();
 export const track = jest.fn();
 export const setGroup = jest.fn();
+export const groupIdentify = jest.fn();
 export const Types = jest.requireActual('@amplitude/analytics-browser').Types;
 
 export const _identifyInstance = identifyInstance;

--- a/static/gsApp/hooks/useExperiment.spec.tsx
+++ b/static/gsApp/hooks/useExperiment.spec.tsx
@@ -1,6 +1,9 @@
+import * as Amplitude from '@amplitude/analytics-browser';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {ConfigStore} from 'sentry/stores/configStore';
 
 import {_resetExposureTracking, useExperiment} from 'getsentry/hooks/useExperiment';
 
@@ -26,6 +29,7 @@ function TestComponent({
 describe('useExperiment (gsApp)', () => {
   beforeEach(() => {
     _resetExposureTracking();
+    ConfigStore.set('enableAnalytics', true);
   });
 
   it('returns inExperiment: true when feature is enabled', () => {
@@ -93,6 +97,72 @@ describe('useExperiment (gsApp)', () => {
         })
       );
     });
+  });
+
+  it('sets the Amplitude experiment group property on exposure', async () => {
+    const org = OrganizationFixture({
+      features: ['onboarding-scm-experiment'],
+      experiments: {'onboarding-scm-experiment': 'active'},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/experiment-exposure/`,
+      method: 'POST',
+      statusCode: 204,
+    });
+
+    render(<TestComponent feature="onboarding-scm-experiment" />, {organization: org});
+
+    await waitFor(() => {
+      expect(Amplitude.groupIdentify).toHaveBeenCalledWith(
+        'organization_id',
+        org.id,
+        expect.anything()
+      );
+    });
+
+    // Verify hyphens in the experiment name are normalized to underscores,
+    // matching the transform in getsentry/experiments/tasks.py so both the FE
+    // and the BE write the same Amplitude property name.
+    const identifyInstance = jest.mocked(Amplitude.Identify).mock.results[0]!.value;
+    expect(identifyInstance.set).toHaveBeenCalledWith(
+      'experiment_onboarding_scm_experiment',
+      'active'
+    );
+  });
+
+  it('does not set the Amplitude group property when reportExposure is false', () => {
+    const org = OrganizationFixture({
+      features: ['test-experiment'],
+      experiments: {'test-experiment': 'active'},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/experiment-exposure/`,
+      method: 'POST',
+      statusCode: 204,
+    });
+
+    render(<TestComponent feature="test-experiment" reportExposure={false} />, {
+      organization: org,
+    });
+
+    expect(Amplitude.groupIdentify).not.toHaveBeenCalled();
+  });
+
+  it('does not set the Amplitude group property when analytics are disabled', () => {
+    ConfigStore.set('enableAnalytics', false);
+    const org = OrganizationFixture({
+      features: ['test-experiment'],
+      experiments: {'test-experiment': 'active'},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/experiment-exposure/`,
+      method: 'POST',
+      statusCode: 204,
+    });
+
+    render(<TestComponent feature="test-experiment" />, {organization: org});
+
+    expect(Amplitude.groupIdentify).not.toHaveBeenCalled();
   });
 
   it('does not post exposure when reportExposure is false', () => {

--- a/static/gsApp/hooks/useExperiment.spec.tsx
+++ b/static/gsApp/hooks/useExperiment.spec.tsx
@@ -112,21 +112,21 @@ describe('useExperiment (gsApp)', () => {
 
     render(<TestComponent feature="onboarding-scm-experiment" />, {organization: org});
 
-    await waitFor(() => {
-      expect(Amplitude.groupIdentify).toHaveBeenCalledWith(
-        'organization_id',
-        org.id,
-        expect.anything()
-      );
-    });
+    await waitFor(() => expect(Amplitude.groupIdentify).toHaveBeenCalled());
 
-    // Verify hyphens in the experiment name are normalized to underscores,
-    // matching the transform in getsentry/experiments/tasks.py so both the FE
-    // and the BE write the same Amplitude property name.
+    // The property name and value live on the Identify instance's .set call;
+    // groupIdentify just routes that instance to the right group. Asserting
+    // both together verifies the full wiring and the hyphen-to-underscore
+    // transform matches getsentry/experiments/tasks.py.
     const identifyInstance = jest.mocked(Amplitude.Identify).mock.results[0]!.value;
     expect(identifyInstance.set).toHaveBeenCalledWith(
       'experiment_onboarding_scm_experiment',
       'active'
+    );
+    expect(Amplitude.groupIdentify).toHaveBeenCalledWith(
+      'organization_id',
+      org.id,
+      identifyInstance
     );
   });
 

--- a/static/gsApp/hooks/useExperiment.tsx
+++ b/static/gsApp/hooks/useExperiment.tsx
@@ -1,11 +1,43 @@
 import {useEffect} from 'react';
+import * as Amplitude from '@amplitude/analytics-browser';
 import {useMutation} from '@tanstack/react-query';
 
+import {ConfigStore} from 'sentry/stores/configStore';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import type {UseExperimentOptions, UseExperimentResult} from 'sentry/utils/useExperiment';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 const reportedExposures = new Set<string>();
+
+/**
+ * Mirrors the backend transform in getsentry/experiments/tasks.py so both
+ * paths write the same property name to the same org group.
+ */
+function amplitudeGroupPropertyName(feature: string) {
+  return `experiment_${feature.replace(/-/g, '_')}`;
+}
+
+/**
+ * Set the experiment group property on the browser-side Amplitude SDK so
+ * the next tracked event has it available at ingestion. The backend POST
+ * also writes this property via Amplitude's groupidentify HTTP endpoint,
+ * but that path (browser → Sentry → taskbroker → worker → Amplitude) is
+ * too slow to win the race against events fired on the same mount.
+ */
+function setAmplitudeExperimentGroupProperty(
+  organizationId: string,
+  feature: string,
+  assignment: string
+) {
+  if (!ConfigStore.get('enableAnalytics')) {
+    return;
+  }
+  const identify = new Amplitude.Identify().set(
+    amplitudeGroupPropertyName(feature),
+    assignment
+  );
+  Amplitude.groupIdentify('organization_id', organizationId, identify);
+}
 
 /**
  * Used for testing, resets the exposure tracking set.
@@ -49,8 +81,16 @@ export function useExperiment(options: UseExperimentOptions): UseExperimentResul
     }
 
     reportedExposures.add(dedupKey);
+    setAmplitudeExperimentGroupProperty(organization.id, feature, assignment);
     logExposure();
-  }, [reportExposure, organization.slug, feature, assignment, logExposure]);
+  }, [
+    reportExposure,
+    organization.id,
+    organization.slug,
+    feature,
+    assignment,
+    logExposure,
+  ]);
 
   return {inExperiment, experimentAssignment: assignment};
 }


### PR DESCRIPTION
## TL;DR

`onboarding.scm_welcome_step_viewed` events from users arriving via the marketing signup flow land at Amplitude without `experiment_onboarding_scm_experiment` attached. Confirmed in prod. The event wins a race against the backend's async Amplitude `groupidentify` call.

This PR closes the race by writing the group property from the browser SDK alongside the existing exposure POST.

## Why the race happens

When the welcome step mounts, two things fire in parallel:

1. `useWelcomeAnalyticsEffect` sends `trackAnalytics('onboarding.scm_welcome_step_viewed')` directly to Amplitude via the browser SDK.
2. `useExperiment` POSTs to `/experiment-exposure/`. Sentry queues `log_experiment_exposures`, a worker picks it up, Redis dedup, then Amplitude `groupidentify` HTTP.

Path 1 is one network hop. Path 2 is browser → Sentry → taskbroker → worker → Amplitude. Path 1 arrives first.

Path 2 is not the only place the backend fires `groupidentify`. The org serializer's `get_feature_set` calls `features.batch_has` for all org-scoped flags on every authenticated request, which defaults to `auto_log_experiment_exposure=True` and queues an exposure task for each experiment-mode match. In most flows that head start is enough time for the taskbroker to land the `groupidentify` before the first `trackAnalytics` fires.

The marketing signup flow has no head start. The marketing site creates the org and immediately redirects to `/onboarding/<slug>/welcome/`. That onboarding render is the browser's first authenticated request for the new org. The serializer queues exactly one exposure task during that render. The welcome component mounts and fires `trackAnalytics` within a few hundred ms. The taskbroker worker takes longer than that. Amplitude snapshots group properties at ingestion, so the event ships without the label permanently.

## The fix

Write the group property from the browser SDK alongside the exposure POST:

```ts
const identify = new Amplitude.Identify().set(
  `experiment_${feature.replace(/-/g, '_')}`,
  assignment
);
Amplitude.groupIdentify('organization_id', String(organization.id), identify);
```

`Amplitude.groupIdentify` and subsequent `Amplitude.track` calls share the same FIFO SDK queue, so Amplitude ingestion sees the property set before the next event is snapshotted.

The property-name transform mirrors `getsentry/experiments/tasks.py::_send_amplitude_group_identify` so both paths target the same Amplitude property. Gated on `enableAnalytics` for parity with other gsApp Amplitude call sites.

The backend POST keeps firing unchanged. It is still the source of truth for BigQuery exposure rows via `analytics.record`, and it still updates group properties for backend-originated events. The FE call is in addition, not a replacement.

## Not affected

BigQuery. `events_denormalized` is a flat event log; analyses join events against the latest `experiment.exposure` event per (org, experiment) at query time, which does not depend on ingestion ordering.

## Alternative considered

An Amplitude enrichment plugin that attaches experiment assignments as per-event properties instead of relying on group properties. More robust, but requires analysts to migrate segmentation patterns. Kept on the shelf as a fallback if the SDK-queue ordering ever proves insufficient.

## Follow-up

#113698 — stacked on this PR. Gates the hook on `organization.experiments?.[feature] !== undefined` so it stops writing spurious `'control'` values for non-experiment features. Separate concern from the race, extracted for review clarity.

## Out of scope

Separate dedup-key bug in `getsentry/experiments/tasks.py`: the Redis cache key does not include the assignment, so a control-to-active flip within a 24h window is silently dropped for both Amplitude and BigQuery. Backend-only fix, not bundled here.