### PR TITLE
feat(seer agent): Add suggested question buttons to empty state

### DIFF
--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.spec.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.spec.tsx
@@ -97,6 +97,31 @@ describe('ExplorerDrawerContent', () => {
       ).toBeInTheDocument();
     });
 
+    it('sends the suggested question when a suggestion button is clicked', async () => {
+      const sendMessage = jest.fn();
+      jest.spyOn(useSeerExplorerModule, 'useSeerExplorer').mockReturnValue({
+        ...defaultHookReturn,
+        sendMessage,
+      });
+
+      render(
+        <ExplorerDrawerContent
+          onClose={mockOnClose}
+          getPageReferrer={mockGetPageReferrer}
+        />,
+        {organization}
+      );
+
+      const suggestion = await screen.findByRole('button', {
+        name: 'Which of my open issues are getting worse, not better?',
+      });
+      await userEvent.click(suggestion);
+
+      expect(sendMessage).toHaveBeenCalledWith(
+        'Which of my open issues are getting worse, not better?'
+      );
+    });
+
     it('shows error state when isError is true', async () => {
       jest.spyOn(useSeerExplorerModule, 'useSeerExplorer').mockReturnValue({
         ...defaultHookReturn,

--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
@@ -417,7 +417,12 @@ export function ExplorerDrawerContent({
       {menu}
       <BlocksContainer ref={scrollContainerRef} onClick={handleBlocksClick}>
         {isEmptyState ? (
-          <EmptyState isLoading={isPolling} isError={isError} runId={runId} />
+          <EmptyState
+            isLoading={isPolling}
+            isError={isError}
+            runId={runId}
+            onSuggestionClick={readOnly ? undefined : sendMessage}
+          />
         ) : (
           <Fragment>
             {blocks.map((block: Block, index: number) => (

--- a/static/app/views/seerExplorer/components/emptyState.tsx
+++ b/static/app/views/seerExplorer/components/emptyState.tsx
@@ -1,17 +1,32 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import {Button} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
+
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {IconSeer} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 
+const SUGGESTED_QUESTIONS = [
+  t('Which of my open issues are getting worse, not better?'),
+  t('Are there any critical issues without an assigned owner or team?'),
+  t('What are my slowest DB queries?'),
+];
+
 interface EmptyStateProps {
   isError?: boolean;
   isLoading?: boolean;
+  onSuggestionClick?: (question: string) => void;
   runId?: number | null;
 }
 
-export function EmptyState({isLoading = false, isError = false, runId}: EmptyStateProps) {
+export function EmptyState({
+  isLoading = false,
+  isError = false,
+  runId,
+  onSuggestionClick,
+}: EmptyStateProps) {
   const runIdDisplay = runId?.toString() ?? 'null';
   return (
     <Container>
@@ -31,6 +46,19 @@ export function EmptyState({isLoading = false, isError = false, runId}: EmptySta
         <Fragment>
           <IconSeer size="xl" animation="waiting" />
           <Text>{t('Ask Seer anything about your application.')}</Text>
+          {onSuggestionClick && (
+            <Flex direction="column" align="center" gap="md" paddingTop="2xl">
+              {SUGGESTED_QUESTIONS.map(question => (
+                <SuggestionButton
+                  key={question}
+                  size="sm"
+                  onClick={() => onSuggestionClick(question)}
+                >
+                  {question}
+                </SuggestionButton>
+              ))}
+            </Flex>
+          )}
         </Fragment>
       )}
     </Container>
@@ -45,6 +73,14 @@ const Container = styled('div')`
   justify-content: center;
   padding: ${p => p.theme.space['3xl']};
   text-align: center;
+`;
+
+const SuggestionButton = styled(Button)`
+  height: 28px;
+  padding: ${p => p.theme.space.sm} ${p => p.theme.space.md};
+  font-size: ${p => p.theme.font.size.sm};
+  font-weight: ${p => p.theme.font.weight.sans.regular};
+  line-height: 16px;
 `;
 
 const Text = styled('div')`


### PR DESCRIPTION
As part of seer agent style changes, this PR renders three clickable suggestion buttons in the Seer Explorer drawer empty state. Clicking a button auto-sends the suggested question via sendMessage. A follow up task to customize these questions will be added, but for now they are hardcoded 

<img width="549" height="602" alt="Screenshot 2026-04-21 at 8 58 26 PM" src="https://github.com/user-attachments/assets/ae5df546-f1b0-44ae-8469-e0b3cc65566c" />
