### PR TITLE
fix(explorer): use hasSentMessage state to prevent pause button flicker

### DIFF
--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.spec.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.spec.tsx
@@ -21,6 +21,7 @@ const defaultHookReturn: ReturnType<typeof useSeerExplorerModule.useSeerExplorer
   overrideCtxEngEnable: true,
   overrideCodeModeEnable: false,
   sendMessage: jest.fn(),
+  hasSentMessage: false,
   switchToRun: jest.fn(),
   startNewSession: jest.fn(),
   deleteFromIndex: jest.fn(),

--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
@@ -64,6 +64,7 @@ export function ExplorerDrawerContent({
     sessionData,
     isPolling,
     isError,
+    hasSentMessage,
     sendMessage,
     deleteFromIndex,
     startNewSession,
@@ -495,6 +496,7 @@ export function ExplorerDrawerContent({
       <InputSection
         blocks={blocks}
         enabled={!readOnly}
+        hasSentMessage={hasSentMessage}
         inputValue={inputValue}
         waitingForInterrupt={waitingForInterrupt}
         isMinimized={false} // Drawer doesn't have a minimized state

--- a/static/app/views/seerExplorer/components/inputSection.tsx
+++ b/static/app/views/seerExplorer/components/inputSection.tsx
@@ -33,6 +33,7 @@ interface QuestionActions {
 interface InputSectionProps {
   blocks: Block[];
   enabled: boolean;
+  hasSentMessage: boolean;
   inputValue: string;
   isPolling: boolean;
   onClear: () => void;
@@ -55,6 +56,7 @@ interface InputSectionProps {
 export function InputSection({
   blocks,
   enabled,
+  hasSentMessage,
   inputValue,
   isMinimized = false,
   isPolling,
@@ -264,7 +266,7 @@ export function InputSection({
       );
     }
 
-    if (isPolling) {
+    if (isPolling && hasSentMessage) {
       return (
         <Button
           icon={<IconPause variant="muted" />}

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -622,7 +622,6 @@ export const useSeerExplorer = () => {
   }, [apiData?.session, deletedFromIndex, optimistic, runId]);
 
   return {
-    hasSentMessage,
     sessionData: filteredSessionData,
     isPolling: isPolling(
       runId,
@@ -631,6 +630,7 @@ export const useSeerExplorer = () => {
     ),
     isError,
     sendMessage,
+    hasSentMessage,
     runId,
     /** Switches to a different run and fetches its latest state. */
     switchToRun,

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -187,6 +187,7 @@ export const useSeerExplorer = () => {
       });
     },
     onSuccess: (response, params) => {
+      setHasSentMessage(true);
       if (params.runId) {
         // invalidate the query so fresh data is fetched
         queryClient.invalidateQueries({
@@ -445,7 +446,6 @@ export const useSeerExplorer = () => {
         baselineUpdatedAt: apiData?.session?.updated_at,
       });
 
-      setHasSentMessage(true);
       sendMessageMutate({
         query,
         insertIndex: calculatedInsertIndex,

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -140,6 +140,7 @@ export const useSeerExplorer = () => {
   // Support deep links that carry a run id; set it once and clean the URL.
   const {getPageReferrer} = usePageReferrer();
 
+  const [hasSentMessage, setHasSentMessage] = useState<boolean>(false);
   const [waitingForInterrupt, setWaitingForInterrupt] = useState<boolean>(false);
   const [deletedFromIndex, setDeletedFromIndex] = useState<number | null>(null);
   const [optimistic, setOptimistic] = useState<{
@@ -356,6 +357,7 @@ export const useSeerExplorer = () => {
       setOptimistic(null);
       setDeletedFromIndex(null);
       setWaitingForInterrupt(false);
+      setHasSentMessage(false);
 
       // Invalidate the query to force a fresh fetch
       if (orgSlug && newRunId !== null) {
@@ -443,6 +445,7 @@ export const useSeerExplorer = () => {
         baselineUpdatedAt: apiData?.session?.updated_at,
       });
 
+      setHasSentMessage(true);
       sendMessageMutate({
         query,
         insertIndex: calculatedInsertIndex,
@@ -619,6 +622,7 @@ export const useSeerExplorer = () => {
   }, [apiData?.session, deletedFromIndex, optimistic, runId]);
 
   return {
+    hasSentMessage,
     sessionData: filteredSessionData,
     isPolling: isPolling(
       runId,


### PR DESCRIPTION
## Changes

Adds a `hasSentMessage` boolean state to `useSeerExplorer` that tracks whether the user has sent at least one message in the current session.

This prevents the interrupt button from appearing before the user has sent any message in a session, instead of flickering in/out while polling for initial data