### PR TITLE
fix(explorer): fix flickering pause button when loading initial data

### DIFF
--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
@@ -128,7 +128,7 @@ export function ExplorerDrawerContent({
   // - Topbar, menu, and slash command handlers -------------------------------
   const copySessionEnabled = Boolean(runId && organization?.slug);
   const {copySessionToClipboard} = useCopySessionDataToClipboard({
-    blocks: sessionData?.blocks,
+    blocks,
     status: sessionData?.status,
     organization,
     projects,
@@ -496,9 +496,9 @@ export function ExplorerDrawerContent({
         blocks={blocks}
         enabled={!readOnly}
         inputValue={inputValue}
+        showInterruptButton={isPolling && sessionData?.status === 'processing'}
         waitingForInterrupt={waitingForInterrupt}
         isMinimized={false} // Drawer doesn't have a minimized state
-        isPolling={isPolling}
         isVisible // Drawer content is always visible when rendered
         onClear={() => setInputValue('')}
         onCreatePR={createPR}

--- a/static/app/views/seerExplorer/components/inputSection.tsx
+++ b/static/app/views/seerExplorer/components/inputSection.tsx
@@ -34,7 +34,6 @@ interface InputSectionProps {
   blocks: Block[];
   enabled: boolean;
   inputValue: string;
-  isPolling: boolean;
   onClear: () => void;
   onCreatePR: (repoName?: string) => void;
   onInputChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
@@ -44,6 +43,7 @@ interface InputSectionProps {
   onPRWidgetClick: () => void;
   prWidgetButtonRef: React.RefObject<HTMLButtonElement | null>;
   repoPRStates: Record<string, RepoPRState>;
+  showInterruptButton: boolean;
   textAreaRef: React.RefObject<HTMLTextAreaElement | null>;
   waitingForInterrupt: boolean;
   fileApprovalActions?: FileApprovalActions;
@@ -57,7 +57,7 @@ export function InputSection({
   enabled,
   inputValue,
   isMinimized = false,
-  isPolling,
+  showInterruptButton,
   waitingForInterrupt,
   isVisible = false,
   onCreatePR,
@@ -264,7 +264,7 @@ export function InputSection({
       );
     }
 
-    if (isPolling) {
+    if (showInterruptButton) {
       return (
         <Button
           icon={<IconPause variant="muted" />}


### PR DESCRIPTION
before vs after (watch bottom right)

https://github.com/user-attachments/assets/e8fdd9a4-03d0-425f-9f33-e11b4e526b21

https://github.com/user-attachments/assets/628f1eb3-1263-46e6-a214-2546930d9667

both isPolling and status need to be checked to support timeout state later