### PR TITLE
feat(explorer): Tab key returns focus to input

### DIFF
--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
@@ -339,7 +339,12 @@ export function ExplorerDrawerContent({
           setInputValue(prev => prev + e.key);
         }
       }
-      // TODO: support pressing tab to focus input (info msg in placeholder when unfocused)
+
+      if (e.key === 'Tab' && focusedBlockIndex !== -1) {
+        e.preventDefault();
+        setFocusedBlockIndex(-1);
+        textareaRef.current?.focus();
+      }
     };
 
     // Re-enable hover focus changes when mouse actually moves
@@ -496,6 +501,7 @@ export function ExplorerDrawerContent({
         blocks={blocks}
         enabled={!readOnly}
         inputValue={inputValue}
+        isFocused={focusedBlockIndex === -1}
         waitingForInterrupt={waitingForInterrupt}
         isMinimized={false} // Drawer doesn't have a minimized state
         isPolling={isPolling}

--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
@@ -324,26 +324,26 @@ export function ExplorerDrawerContent({
 
     const handleKeyDown = (e: KeyboardEvent) => {
       const isPrintableChar = e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey;
-      if (isPrintableChar) {
-        // If a block is focused, auto-focus input when user starts typing.
-        // Don't do this if file approval or question is pending (textarea isn't visible)
-        if (
-          !readOnly &&
-          focusedBlockIndex !== -1 &&
-          !isFileApprovalPending &&
-          !isQuestionPending
-        ) {
+
+      // If input is enabled and not focused
+      if (
+        focusedBlockIndex !== -1 &&
+        !readOnly &&
+        !isFileApprovalPending &&
+        !isQuestionPending
+      ) {
+        if (isPrintableChar) {
+          // Focus input when user starts typing
           e.preventDefault();
           setFocusedBlockIndex(-1);
           textareaRef.current?.focus();
           setInputValue(prev => prev + e.key);
+        } else if {
+          // Focus input when user presses tab
+          e.preventDefault();
+          setFocusedBlockIndex(-1);
+          textareaRef.current?.focus();
         }
-      }
-
-      if (e.key === 'Tab' && focusedBlockIndex !== -1) {
-        e.preventDefault();
-        setFocusedBlockIndex(-1);
-        textareaRef.current?.focus();
       }
     };
 

--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
@@ -338,7 +338,7 @@ export function ExplorerDrawerContent({
           setFocusedBlockIndex(-1);
           textareaRef.current?.focus();
           setInputValue(prev => prev + e.key);
-        } else if {
+        } else if (e.key === 'Tab') {
           // Focus input when user presses tab
           e.preventDefault();
           setFocusedBlockIndex(-1);

--- a/static/app/views/seerExplorer/components/inputSection.tsx
+++ b/static/app/views/seerExplorer/components/inputSection.tsx
@@ -34,6 +34,7 @@ interface InputSectionProps {
   blocks: Block[];
   enabled: boolean;
   inputValue: string;
+  isFocused: boolean;
   isPolling: boolean;
   onClear: () => void;
   onCreatePR: (repoName?: string) => void;
@@ -56,6 +57,7 @@ export function InputSection({
   blocks,
   enabled,
   inputValue,
+  isFocused,
   isMinimized = false,
   isPolling,
   waitingForInterrupt,
@@ -290,7 +292,11 @@ export function InputSection({
             onChange={onInputChange}
             onKeyDown={onKeyDown}
             onClick={onInputClick}
-            placeholder={t('Type your message or / command and press Enter ↵')}
+            placeholder={
+              isFocused
+                ? t('Type your message or / command and press Enter ↵')
+                : t('Press Tab to return here')
+            }
             rows={1}
             data-test-id="seer-explorer-input"
           />

--- a/static/app/views/seerExplorer/components/inputSection.tsx
+++ b/static/app/views/seerExplorer/components/inputSection.tsx
@@ -295,7 +295,7 @@ export function InputSection({
             placeholder={
               isFocused
                 ? t('Type your message or / command and press Enter ↵')
-                : t('Press Tab to return here')
+                : t('Press Tab ⇥ to return here')
             }
             rows={1}
             data-test-id="seer-explorer-input"


### PR DESCRIPTION
Improves keyboard navigation in the Seer Explorer drawer when a block is focused.