### PR TITLE
fix(dashboards): alignment and sizing of IntervalSelector on Dashboards

### DIFF
--- a/static/app/views/dashboards/filtersBar.tsx
+++ b/static/app/views/dashboards/filtersBar.tsx
@@ -368,13 +368,7 @@ export function FiltersBar({
         value={interval}
         onChange={option => setInterval(option.value)}
         trigger={triggerProps => (
-          <OverlayTrigger.Button
-            {...triggerProps}
-            icon={<IconClock />}
-            priority="transparent"
-            showChevron={false}
-            size="xs"
-          />
+          <OverlayTrigger.Button {...triggerProps} icon={<IconClock />} />
         )}
         menuTitle={t('Interval')}
         options={intervalOptions}


### PR DESCRIPTION
before:

<img width="1415" height="163" alt="Screenshot 2026-04-22 at 09 35 56" src="https://github.com/user-attachments/assets/f3418d42-e5ea-418e-8d7e-25b8580e8ae9" />

after:

<img width="1418" height="171" alt="Screenshot 2026-04-22 at 09 38 21" src="https://github.com/user-attachments/assets/d7bc4171-d933-43d6-81eb-ea3a28f314ae" />
