### PR TITLE
fix(feedback): Use demo DSN for crash report previews

### DIFF
--- a/static/app/utils/openDemoCrashReportModal.ts
+++ b/static/app/utils/openDemoCrashReportModal.ts
@@ -1,0 +1,16 @@
+import * as Sentry from '@sentry/react';
+
+// The SPA DSN only accepts sentry.io origins, so crash report previews break on
+// demo.dev.getsentry.net. Use the internal feedback project DSN for demo modals.
+export const DEMO_CRASH_REPORT_MODAL_DSN =
+  'https://3c5ef4e344a04a0694d187a1272e96de@o1.ingest.sentry.io/6356259';
+
+const DEMO_CRASH_REPORT_MODAL_EVENT_ID = '00000000000000000000000000000000';
+
+export function openDemoCrashReportModal() {
+  Sentry.showReportDialog({
+    dsn: DEMO_CRASH_REPORT_MODAL_DSN,
+    // This should never make it to Sentry, but keep the demo detached from real events.
+    eventId: DEMO_CRASH_REPORT_MODAL_EVENT_ID,
+  });
+}

--- a/static/app/views/feedback/feedbackEmptyState.spec.tsx
+++ b/static/app/views/feedback/feedbackEmptyState.spec.tsx
@@ -1,8 +1,10 @@
+import * as Sentry from '@sentry/react';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {act, render, screen} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {ProjectsStore} from 'sentry/stores/projectsStore';
+import {DEMO_CRASH_REPORT_MODAL_DSN} from 'sentry/utils/openDemoCrashReportModal';
 import {FeedbackEmptyState} from 'sentry/views/feedback/feedbackEmptyState';
 
 describe('FeedbackEmptyState', () => {
@@ -82,5 +84,18 @@ describe('FeedbackEmptyState', () => {
     expect(
       screen.getByRole('heading', {name: 'What do users think?'})
     ).toBeInTheDocument();
+  });
+
+  it('opens the crash report modal example with the demo dsn', async () => {
+    act(() => ProjectsStore.loadInitialData([project]));
+
+    render(<FeedbackEmptyState />);
+
+    await userEvent.click(screen.getByRole('button', {name: 'See an example'}));
+
+    expect(Sentry.showReportDialog).toHaveBeenCalledWith({
+      dsn: DEMO_CRASH_REPORT_MODAL_DSN,
+      eventId: '00000000000000000000000000000000',
+    });
   });
 });

--- a/static/app/views/feedback/feedbackEmptyState.tsx
+++ b/static/app/views/feedback/feedbackEmptyState.tsx
@@ -1,6 +1,5 @@
 import {useCallback, useEffect} from 'react';
 import styled from '@emotion/styled';
-import * as Sentry from '@sentry/react';
 
 import emptyStateImg from 'sentry-images/spot/feedback-empty-state.svg';
 
@@ -12,6 +11,7 @@ import {useFeedbackOnboardingSidebarPanel} from 'sentry/components/feedback/useF
 import {OnboardingPanel} from 'sentry/components/onboardingPanel';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {openDemoCrashReportModal} from 'sentry/utils/openDemoCrashReportModal';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -115,10 +115,7 @@ export function FeedbackEmptyState({projectIds, issueTab = false}: Props) {
         </Button>
         <Button
           onClick={() => {
-            Sentry.showReportDialog({
-              // should never make it to the Sentry API, but just in case, use throwaway id
-              eventId: '00000000000000000000000000000000',
-            });
+            openDemoCrashReportModal();
             trackAnalyticsInternal('user_feedback.dialog_opened');
           }}
         >

--- a/static/app/views/settings/projectUserFeedback/index.spec.tsx
+++ b/static/app/views/settings/projectUserFeedback/index.spec.tsx
@@ -1,6 +1,9 @@
+import * as Sentry from '@sentry/react';
+
 import {initializeOrg} from 'sentry-test/initializeOrg';
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {DEMO_CRASH_REPORT_MODAL_DSN} from 'sentry/utils/openDemoCrashReportModal';
 import ProjectUserFeedback from 'sentry/views/settings/projectUserFeedback';
 
 describe('ProjectUserFeedback', () => {
@@ -69,6 +72,22 @@ describe('ProjectUserFeedback', () => {
     expect(
       screen.getByRole('checkbox', {name: 'Enable Crash Report Notifications'})
     ).toBeInTheDocument();
+  });
+
+  it('opens the crash report modal with the demo dsn', async () => {
+    render(<ProjectUserFeedback />, {
+      organization,
+      outletContext: {project},
+    });
+
+    await userEvent.click(
+      screen.getByRole('button', {name: 'Open the Crash Report Modal'})
+    );
+
+    expect(Sentry.showReportDialog).toHaveBeenCalledWith({
+      dsn: DEMO_CRASH_REPORT_MODAL_DSN,
+      eventId: '00000000000000000000000000000000',
+    });
   });
 
   it('can toggle crash report notifications', async () => {

--- a/static/app/views/settings/projectUserFeedback/index.tsx
+++ b/static/app/views/settings/projectUserFeedback/index.tsx
@@ -1,5 +1,4 @@
 import {useEffect} from 'react';
-import * as Sentry from '@sentry/react';
 import {mutationOptions} from '@tanstack/react-query';
 import {z} from 'zod';
 
@@ -16,6 +15,7 @@ import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {Project} from 'sentry/types/project';
+import {openDemoCrashReportModal} from 'sentry/utils/openDemoCrashReportModal';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
@@ -35,13 +35,6 @@ export default function ProjectUserFeedback() {
   const {project} = useProjectSettingsOutlet();
   const {areAiFeaturesAllowed} = useOrganizationSeerSetup();
   const hasAiEnabled = areAiFeaturesAllowed;
-
-  const handleClick = () => {
-    Sentry.showReportDialog({
-      // should never make it to the Sentry API, but just in case, use throwaway id
-      eventId: '00000000000000000000000000000000',
-    });
-  };
 
   const features = new Set(organization.features);
 
@@ -92,7 +85,7 @@ export default function ProjectUserFeedback() {
               <LinkButton href="https://docs.sentry.io/product/user-feedback/" external>
                 {t('Read the Docs')}
               </LinkButton>
-              <Button priority="primary" onClick={handleClick}>
+              <Button priority="primary" onClick={openDemoCrashReportModal}>
                 {t('Open the Crash Report Modal')}
               </Button>
             </Flex>


### PR DESCRIPTION
Fix the crash report preview buttons on demo.dev.getsentry.net.

The user feedback settings page and feedback empty state both called `Sentry.showReportDialog` without overriding the DSN. In the demo SPA that uses the app DSN, and the embed request gets rejected from `demo.dev.getsentry.net` with a 403, which the browser then surfaces as a strict MIME type error.

Route both preview entry points through a shared helper that uses the demo feedback DSN already configured for that origin. Add focused tests so the preview buttons stay pinned to the demo DSN.

I considered changing origin handling for the SPA DSN, but that would broaden backend behavior for a demo-only preview path. Reusing the existing demo feedback DSN keeps the fix frontend-scoped and limited to the preview flows.