### PR TITLE
fix(tracemetrics): Samples table UI tweaks

### DIFF
--- a/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTable.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTable.tsx
@@ -113,7 +113,7 @@ const SimpleTableGrid = styled(StyledSimpleTable)<{
 }>`
   grid-template-columns: ${p =>
     p.embedded
-      ? 'min-content min-content min-content minmax(0, 1fr) min-content min-content'
-      : 'min-content min-content minmax(0, 1fr) min-content min-content'};
+      ? `${p.theme.space['3xl']} min-content min-content minmax(0, 1fr) min-content min-content`
+      : `${p.theme.space['3xl']} min-content minmax(0, 1fr) min-content min-content`};
   grid-column: 1 / -1;
 `;


### PR DESCRIPTION
Small tweaks to the samples table on the application metrics page. Main one is ensuring that the expand column has a fixed width so that it doesn't get hidden while loading.

Closes LOGS-717

Before:
<img width="808" height="362" alt="Screenshot 2026-04-22 at 07 41 41" src="https://github.com/user-attachments/assets/6beefb08-245a-4f51-a305-62bdc983d5cd" />

After:
<img width="813" height="364" alt="Screenshot 2026-04-22 at 07 32 57" src="https://github.com/user-attachments/assets/09450a5f-342c-401a-82d3-ba662c114456" />
