### PR TITLE
fix(tracemetrics): Aggregates table tweaks

### DIFF
--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
@@ -1,5 +1,5 @@
 import {useMemo} from 'react';
-import {css} from '@emotion/react';
+import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -71,6 +71,7 @@ interface AggregatesTabProps {
 }
 
 export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTabProps) {
+  const theme = useTheme();
   const {selection} = usePageFilters();
   const organization = useOrganization();
   const topEvents = useTopEvents();
@@ -146,8 +147,8 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
   }, [aggregateFieldCount, displayFields.length, groupByFieldCount]);
 
   const firstColumnOffset = useMemo(() => {
-    return groupBys.length > 0 ? '15px' : '8px';
-  }, [groupBys]);
+    return groupBys.length > 0 ? '15px' : theme.space.lg;
+  }, [groupBys, theme.space.lg]);
 
   // Dividers: between last groupBy and first aggregate, and between all aggregates
   const shouldShowDivider = (index: number) => {

--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
@@ -269,10 +269,12 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
 }
 
 const AggregatesSimpleTable = styled(StyledSimpleTable)`
-  overflow: hidden;
+  overflow-x: auto;
+  overflow-y: hidden;
 `;
 
 const AggregatesTableBody = styled(StyledSimpleTableBody)`
+  overflow-x: hidden;
   overflow-y: auto;
 `;
 

--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
@@ -269,11 +269,11 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
 }
 
 const AggregatesSimpleTable = styled(StyledSimpleTable)`
-  overflow: auto;
+  overflow: hidden;
 `;
 
 const AggregatesTableBody = styled(StyledSimpleTableBody)`
-  overflow: unset;
+  overflow-y: auto;
 `;
 
 const AggregatesStyledHeader = styled(StyledSimpleTableHeader)`

--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
@@ -256,7 +256,7 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
           })
         ) : isPending ? (
           <SimpleTable.Empty>
-            <LoadingIndicator />
+            <LoadingIndicator size={40} style={{margin: '1em 1em'}} />
           </SimpleTable.Empty>
         ) : (
           <SimpleTable.Empty>

--- a/static/app/views/explore/metrics/metricInfoTabs/metricInfoTabStyles.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricInfoTabStyles.tsx
@@ -127,14 +127,7 @@ export const NumericSimpleTableRowCell = styled(StyledSimpleTableRowCell)`
 `;
 
 export const StyledTabPanels = styled(TabPanels)`
-  display: flex;
-  min-height: 0;
-  overflow: hidden;
-
-  > * {
-    flex: 1;
-    min-height: 0;
-  }
+  overflow: auto;
 `;
 
 export const TableRowContainer = styled('div')`

--- a/static/app/views/explore/metrics/metricInfoTabs/metricInfoTabStyles.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricInfoTabStyles.tsx
@@ -127,7 +127,14 @@ export const NumericSimpleTableRowCell = styled(StyledSimpleTableRowCell)`
 `;
 
 export const StyledTabPanels = styled(TabPanels)`
-  overflow: auto;
+  display: flex;
+  min-height: 0;
+  overflow: hidden;
+
+  > * {
+    flex: 1;
+    min-height: 0;
+  }
 `;
 
 export const TableRowContainer = styled('div')`


### PR DESCRIPTION
This PR makes a few tweaks to the metrics aggregates table. First fixing up the padding in the far left column, then fixing scroll bar constraints, as well as aligning the search indicators to match that of the samples table.

Closes LOGS-718

**First Column Tweaks:**
| | |
|-|-|
|Before| <img width="808" height="362" alt="Screenshot 2026-04-22 at 07 47 41" src="https://github.com/user-attachments/assets/a8f111ff-cf7a-4e4c-8629-285611199114" /> |
|After| <img width="808" height="362" alt="Screenshot 2026-04-22 at 07 47 37" src="https://github.com/user-attachments/assets/2164bc46-5514-454c-b342-423e10c32026" /> |

**Scroll bar constraints:**
| | |
|-|-|
|Before| <img width="801" height="363" alt="Screenshot 2026-04-22 at 07 48 50" src="https://github.com/user-attachments/assets/2df71b22-4dbe-4e4c-8c46-2f6c58cb654c" /> |
|After| <img width="808" height="364" alt="Screenshot 2026-04-22 at 08 03 41" src="https://github.com/user-attachments/assets/e8bc5738-eedc-441b-a43a-eb8dfd6c4d43" /> |