### PR TITLE
fix(agents): Group Gen AI cost warning Sentry issues

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.spec.tsx
@@ -51,8 +51,8 @@ describe('getHighlightedSpanAttributes', () => {
     };
 
     expect(Sentry.captureMessage).toHaveBeenCalledWith(
-      'Gen AI cost data missing for model: gpt-4',
-      expectedContext
+      'Gen AI cost data missing for model',
+      {...expectedContext, fingerprint: ['Gen AI cost data missing for model']}
     );
   });
 
@@ -102,28 +102,26 @@ describe('getHighlightedSpanAttributes', () => {
       attributes,
     });
 
-    expect(Sentry.captureMessage).toHaveBeenCalledWith(
-      'Gen AI span with negative cost: gpt-4',
-      {
-        level: 'warning',
-        tags: {
-          feature: 'agent-monitoring',
-          span_type: 'gen_ai',
-          has_model: 'true',
-          has_cost: 'true',
-          model: 'gpt-4',
-          integration: 'openai',
-          platform: 'python',
-          version: '2.0.0',
-          org_id: '42',
-          ai_cost_warning: 'true',
-        },
-        extra: {
-          total_costs: '-1',
-          attributes,
-        },
-      }
-    );
+    expect(Sentry.captureMessage).toHaveBeenCalledWith('Gen AI span with negative cost', {
+      level: 'warning',
+      tags: {
+        feature: 'agent-monitoring',
+        span_type: 'gen_ai',
+        has_model: 'true',
+        has_cost: 'true',
+        model: 'gpt-4',
+        integration: 'openai',
+        platform: 'python',
+        version: '2.0.0',
+        org_id: '42',
+        ai_cost_warning: 'true',
+      },
+      extra: {
+        total_costs: '-1',
+        attributes,
+      },
+      fingerprint: ['Gen AI span with negative cost'],
+    });
   });
 
   it('should not emit Sentry error for non-gen_ai spans', () => {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -180,11 +180,11 @@ function getAISpanAttributes({
         (inputTokens || outputTokens) &&
         (!totalCosts || Number(totalCosts) === 0)
       ),
-      messages: [`Gen AI cost data missing for model: ${model?.toString()}`],
+      messages: ['Gen AI cost data missing for model'],
     },
     {
       shouldCapture: Boolean(model && totalCosts && Number(totalCosts) < 0),
-      messages: [`Gen AI span with negative cost: ${model?.toString()}`],
+      messages: ['Gen AI span with negative cost'],
     },
   ];
   const shouldCapture = captureRules.some(rule => rule.shouldCapture);
@@ -220,7 +220,10 @@ function getAISpanAttributes({
       .filter(rule => rule.shouldCapture)
       .flatMap(rule => rule.messages)
       .forEach(message => {
-        Sentry.captureMessage(message, contextData);
+        Sentry.captureMessage(message, {
+          ...contextData,
+          fingerprint: [message],
+        });
       });
   }
 


### PR DESCRIPTION
Remove model name from `captureMessage` strings and add explicit fingerprint so all models produce a single Sentry issue per warning type instead of one per model. Model is already available as a tag.