### PR TITLE
fix(page-frame): remove empty headers and move breadcrumbs

### DIFF
--- a/static/app/views/discover/landing.tsx
+++ b/static/app/views/discover/landing.tsx
@@ -1,3 +1,4 @@
+import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
 
@@ -190,21 +191,19 @@ function DiscoverLanding() {
     >
       <SentryDocumentTitle title={t('Discover')} orgSlug={organization.slug}>
         <Stack flex={1}>
-          <Layout.Header>
-            <Layout.HeaderContent>
-              <Breadcrumbs
-                crumbs={[
-                  {
-                    label: t('Discover'),
-                    to: getDiscoverLandingUrl(organization),
-                  },
-                  {
-                    label: t('Saved Queries'),
-                  },
-                ]}
-              />
-            </Layout.HeaderContent>
-            {hasPageFrameFeature ? (
+          {hasPageFrameFeature ? (
+            <Fragment>
+              <TopBar.Slot name="title">
+                <Breadcrumbs
+                  crumbs={[
+                    {
+                      label: t('Discover'),
+                      to: getDiscoverLandingUrl(organization),
+                    },
+                    {label: t('Saved Queries')},
+                  ]}
+                />
+              </TopBar.Slot>
               <TopBar.Slot name="actions">
                 <LinkButton
                   data-test-id="build-new-query"
@@ -219,7 +218,20 @@ function DiscoverLanding() {
                   {t('Build a new query')}
                 </LinkButton>
               </TopBar.Slot>
-            ) : (
+            </Fragment>
+          ) : (
+            <Layout.Header>
+              <Layout.HeaderContent>
+                <Breadcrumbs
+                  crumbs={[
+                    {
+                      label: t('Discover'),
+                      to: getDiscoverLandingUrl(organization),
+                    },
+                    {label: t('Saved Queries')},
+                  ]}
+                />
+              </Layout.HeaderContent>
               <Layout.HeaderActions>
                 <LinkButton
                   data-test-id="build-new-query"
@@ -235,8 +247,8 @@ function DiscoverLanding() {
                   {t('Build a new query')}
                 </LinkButton>
               </Layout.HeaderActions>
-            )}
-          </Layout.Header>
+            </Layout.Header>
+          )}
           <Layout.Body>
             <Layout.Main width="full">
               <StyledActions>

--- a/static/app/views/discover/results/resultsHeader.tsx
+++ b/static/app/views/discover/results/resultsHeader.tsx
@@ -213,9 +213,7 @@ class ResultsHeader extends Component<Props, State> {
               </Fragment>
             ) : (
               // Only has discover-basic
-              <Fragment>
-                <Layout.Title>{title}</Layout.Title>
-              </Fragment>
+              <Layout.Title>{title}</Layout.Title>
             )}
             {this.renderAuthor()}
           </Layout.HeaderContent>

--- a/static/app/views/discover/results/resultsHeader.tsx
+++ b/static/app/views/discover/results/resultsHeader.tsx
@@ -131,104 +131,99 @@ class ResultsHeader extends Component<Props, State> {
     const {savedQuery, loading, homepageQuery} = this.state;
     const hasDiscoverQueryFeature = organization.features.includes('discover-query');
 
+    const savedQueryButton = (
+      <SavedQueryButtonGroup
+        setSavedQuery={setSavedQuery}
+        location={location}
+        organization={organization}
+        eventView={eventView}
+        savedQuery={savedQuery}
+        queryDataLoading={loading}
+        disabled={errorCode >= 400 && errorCode < 500}
+        updateCallback={() => this.fetchData()}
+        yAxis={yAxis}
+        isHomepage={isHomepage}
+        setHomepageQuery={updatedHomepageQuery => {
+          this.setState({
+            homepageQuery: getSavedQueryWithDataset(updatedHomepageQuery) as SavedQuery,
+          });
+          if (isHomepage) {
+            setSavedQuery(updatedHomepageQuery);
+          }
+        }}
+        homepageQuery={homepageQuery}
+      />
+    );
+
+    const title = (
+      <Fragment>
+        {t('Discover')}
+        <PageHeadingQuestionTooltip
+          docsUrl="https://docs.sentry.io/product/discover-queries/"
+          title={t('Create queries to get insights into the health of your system.')}
+        />
+      </Fragment>
+    );
+
     return (
       <Layout.Header>
-        <Layout.HeaderContent>
-          {isHomepage ? (
-            <GuideAnchor target="discover_landing_header">
-              <Layout.Title>
-                {t('Discover')}
-                <PageHeadingQuestionTooltip
-                  docsUrl="https://docs.sentry.io/product/discover-queries/"
-                  title={t(
-                    'Create queries to get insights into the health of your system.'
-                  )}
-                />
-              </Layout.Title>
-            </GuideAnchor>
-          ) : hasDiscoverQueryFeature ? (
-            <Fragment>
-              <DiscoverBreadcrumb
-                eventView={eventView}
-                organization={organization}
-                location={location}
-                isHomepage={isHomepage}
-              />
-              <EventInputName
-                savedQuery={savedQuery}
-                organization={organization}
-                eventView={eventView}
-                isHomepage={isHomepage}
-              />
-            </Fragment>
-          ) : (
-            // Only has discover-basic
-            <Fragment>
-              <Layout.Title>
-                {t('Discover')}
-                <PageHeadingQuestionTooltip
-                  docsUrl="https://docs.sentry.io/product/discover-queries/"
-                  title={t(
-                    'Create queries to get insights into the health of your system.'
-                  )}
-                />
-              </Layout.Title>
-            </Fragment>
-          )}
-          {this.renderAuthor()}
-        </Layout.HeaderContent>
         {hasPageFrameFeature ? (
-          <TopBar.Slot name="actions">
-            <SavedQueryButtonGroup
-              setSavedQuery={setSavedQuery}
-              location={location}
-              organization={organization}
-              eventView={eventView}
-              savedQuery={savedQuery}
-              queryDataLoading={loading}
-              disabled={errorCode >= 400 && errorCode < 500}
-              updateCallback={() => this.fetchData()}
-              yAxis={yAxis}
-              isHomepage={isHomepage}
-              setHomepageQuery={updatedHomepageQuery => {
-                this.setState({
-                  homepageQuery: getSavedQueryWithDataset(
-                    updatedHomepageQuery
-                  ) as SavedQuery,
-                });
-                if (isHomepage) {
-                  setSavedQuery(updatedHomepageQuery);
-                }
-              }}
-              homepageQuery={homepageQuery}
-            />
+          <TopBar.Slot name="title">
+            {isHomepage ? (
+              <GuideAnchor target="discover_landing_header">{title}</GuideAnchor>
+            ) : hasDiscoverQueryFeature ? (
+              <Fragment>
+                <DiscoverBreadcrumb
+                  eventView={eventView}
+                  organization={organization}
+                  location={location}
+                  isHomepage={isHomepage}
+                />
+                <EventInputName
+                  savedQuery={savedQuery}
+                  organization={organization}
+                  eventView={eventView}
+                  isHomepage={isHomepage}
+                />
+              </Fragment>
+            ) : (
+              title
+            )}
           </TopBar.Slot>
         ) : (
-          <Layout.HeaderActions>
-            <SavedQueryButtonGroup
-              setSavedQuery={setSavedQuery}
-              location={location}
-              organization={organization}
-              eventView={eventView}
-              savedQuery={savedQuery}
-              queryDataLoading={loading}
-              disabled={errorCode >= 400 && errorCode < 500}
-              updateCallback={() => this.fetchData()}
-              yAxis={yAxis}
-              isHomepage={isHomepage}
-              setHomepageQuery={updatedHomepageQuery => {
-                this.setState({
-                  homepageQuery: getSavedQueryWithDataset(
-                    updatedHomepageQuery
-                  ) as SavedQuery,
-                });
-                if (isHomepage) {
-                  setSavedQuery(updatedHomepageQuery);
-                }
-              }}
-              homepageQuery={homepageQuery}
-            />
-          </Layout.HeaderActions>
+          <Layout.HeaderContent>
+            {isHomepage ? (
+              <GuideAnchor target="discover_landing_header">
+                <Layout.Title>{title}</Layout.Title>
+              </GuideAnchor>
+            ) : hasDiscoverQueryFeature ? (
+              <Fragment>
+                <DiscoverBreadcrumb
+                  eventView={eventView}
+                  organization={organization}
+                  location={location}
+                  isHomepage={isHomepage}
+                />
+                <EventInputName
+                  savedQuery={savedQuery}
+                  organization={organization}
+                  eventView={eventView}
+                  isHomepage={isHomepage}
+                />
+              </Fragment>
+            ) : (
+              // Only has discover-basic
+              <Fragment>
+                <Layout.Title>{title}</Layout.Title>
+              </Fragment>
+            )}
+            {this.renderAuthor()}
+          </Layout.HeaderContent>
+        )}
+        {hasPageFrameFeature ? (
+          <TopBar.Slot name="actions">{savedQueryButton}</TopBar.Slot>
+        ) : (
+          <Layout.HeaderActions>{savedQueryButton}</Layout.HeaderActions>
         )}
         <DatasetSelectorTabs
           eventView={eventView}

--- a/static/app/views/discover/results/resultsHeader.tsx
+++ b/static/app/views/discover/results/resultsHeader.tsx
@@ -165,63 +165,55 @@ class ResultsHeader extends Component<Props, State> {
       </Fragment>
     );
 
+    const breadcrumbAndInput = (
+      <Fragment>
+        <DiscoverBreadcrumb
+          eventView={eventView}
+          organization={organization}
+          location={location}
+          isHomepage={isHomepage}
+        />
+        <EventInputName
+          savedQuery={savedQuery}
+          organization={organization}
+          eventView={eventView}
+          isHomepage={isHomepage}
+        />
+      </Fragment>
+    );
+
     return (
       <Layout.Header>
         {hasPageFrameFeature ? (
-          <TopBar.Slot name="title">
-            {isHomepage ? (
-              <GuideAnchor target="discover_landing_header">{title}</GuideAnchor>
-            ) : hasDiscoverQueryFeature ? (
-              <Fragment>
-                <DiscoverBreadcrumb
-                  eventView={eventView}
-                  organization={organization}
-                  location={location}
-                  isHomepage={isHomepage}
-                />
-                <EventInputName
-                  savedQuery={savedQuery}
-                  organization={organization}
-                  eventView={eventView}
-                  isHomepage={isHomepage}
-                />
-              </Fragment>
-            ) : (
-              title
-            )}
-          </TopBar.Slot>
+          <Fragment>
+            <TopBar.Slot name="title">
+              {isHomepage ? (
+                <GuideAnchor target="discover_landing_header">{title}</GuideAnchor>
+              ) : hasDiscoverQueryFeature ? (
+                breadcrumbAndInput
+              ) : (
+                title
+              )}
+            </TopBar.Slot>
+            <TopBar.Slot name="actions">{savedQueryButton}</TopBar.Slot>
+          </Fragment>
         ) : (
-          <Layout.HeaderContent>
-            {isHomepage ? (
-              <GuideAnchor target="discover_landing_header">
+          <Fragment>
+            <Layout.HeaderContent>
+              {isHomepage ? (
+                <GuideAnchor target="discover_landing_header">
+                  <Layout.Title>{title}</Layout.Title>
+                </GuideAnchor>
+              ) : hasDiscoverQueryFeature ? (
+                breadcrumbAndInput
+              ) : (
+                // Only has discover-basic
                 <Layout.Title>{title}</Layout.Title>
-              </GuideAnchor>
-            ) : hasDiscoverQueryFeature ? (
-              <Fragment>
-                <DiscoverBreadcrumb
-                  eventView={eventView}
-                  organization={organization}
-                  location={location}
-                  isHomepage={isHomepage}
-                />
-                <EventInputName
-                  savedQuery={savedQuery}
-                  organization={organization}
-                  eventView={eventView}
-                  isHomepage={isHomepage}
-                />
-              </Fragment>
-            ) : (
-              // Only has discover-basic
-              <Layout.Title>{title}</Layout.Title>
-            )}
-            {this.renderAuthor()}
-          </Layout.HeaderContent>
-        )}
-        {hasPageFrameFeature ? (
-          <TopBar.Slot name="actions">{savedQueryButton}</TopBar.Slot>
-        ) : (
-          <Layout.HeaderActions>{savedQueryButton}</Layout.HeaderActions>
+              )}
+              {this.renderAuthor()}
+            </Layout.HeaderContent>
+            <Layout.HeaderActions>{savedQueryButton}</Layout.HeaderActions>
+          </Fragment>
         )}
         <DatasetSelectorTabs
           eventView={eventView}

--- a/static/app/views/explore/errors/content.tsx
+++ b/static/app/views/explore/errors/content.tsx
@@ -1,3 +1,5 @@
+import {Fragment} from 'react';
+
 import {FeatureBadge} from '@sentry/scraps/badge';
 
 import {FeedbackButton} from 'sentry/components/feedbackButton/feedbackButton';
@@ -40,6 +42,25 @@ export default function ErrorsContent() {
 
 function ErrorsHeader() {
   const hasPageFrameFeature = useHasPageFrameFeature();
+
+  if (hasPageFrameFeature) {
+    return (
+      <Fragment>
+        <TopBar.Slot name="title">
+          {t('Errors')} <FeatureBadge type="alpha" />
+        </TopBar.Slot>
+        <TopBar.Slot name="feedback">
+          <FeedbackButton
+            aria-label={t('Give Feedback')}
+            tooltipProps={{title: t('Give Feedback')}}
+          >
+            {null}
+          </FeedbackButton>
+        </TopBar.Slot>
+      </Fragment>
+    );
+  }
+
   return (
     <Layout.Header unified>
       <Layout.HeaderContent unified>
@@ -48,18 +69,7 @@ function ErrorsHeader() {
         </Layout.Title>
       </Layout.HeaderContent>
       <Layout.HeaderActions>
-        {hasPageFrameFeature ? (
-          <TopBar.Slot name="feedback">
-            <FeedbackButton
-              aria-label={t('Give Feedback')}
-              tooltipProps={{title: t('Give Feedback')}}
-            >
-              {null}
-            </FeedbackButton>
-          </TopBar.Slot>
-        ) : (
-          <FeedbackButton />
-        )}
+        <FeedbackButton />
       </Layout.HeaderActions>
     </Layout.Header>
   );

--- a/static/app/views/explore/errors/content.tsx
+++ b/static/app/views/explore/errors/content.tsx
@@ -27,15 +27,13 @@ export default function ErrorsContent() {
 
   return (
     <SentryDocumentTitle title={t('Errors')} orgSlug={organization?.slug}>
-      <Layout.Page>
-        <ErrorsHeader />
-        <PageFiltersContainer>
-          <ExploreBodySearch>
-            <ErrorsFilterSection />
-          </ExploreBodySearch>
-        </PageFiltersContainer>
-        <ErrorsBody />
-      </Layout.Page>
+      <ErrorsHeader />
+      <PageFiltersContainer>
+        <ExploreBodySearch>
+          <ErrorsFilterSection />
+        </ExploreBodySearch>
+      </PageFiltersContainer>
+      <ErrorsBody />
     </SentryDocumentTitle>
   );
 }

--- a/static/app/views/explore/logs/content.tsx
+++ b/static/app/views/explore/logs/content.tsx
@@ -117,88 +117,79 @@ function LogsHeader() {
   const hasSavedQueryTitle =
     defined(pageId) && defined(savedQuery) && savedQuery.name.length > 0;
 
+  const documentTitle = hasSavedQueryTitle ? (
+    <SentryDocumentTitle
+      title={`${savedQuery.name} — ${t('Logs')}`}
+      orgSlug={organization?.slug}
+    />
+  ) : null;
+
+  const titleTooltip = (
+    <PageHeadingQuestionTooltip
+      docsUrl="https://docs.sentry.io/product/explore/logs/"
+      title={t(
+        'Detailed structured logs, linked to errors and traces, for debugging and investigation.'
+      )}
+      linkLabel={t('Read the Docs')}
+    />
+  );
+
+  const hasBreadcrumb = Boolean(title && defined(pageId));
+
+  if (hasPageFrameFeature) {
+    return (
+      <Fragment>
+        {documentTitle}
+        <TopBar.Slot name="title">
+          {hasBreadcrumb ? (
+            <ExploreBreadcrumb
+              traceItemDataset={TraceItemDataset.LOGS}
+              savedQueryName={savedQuery?.name}
+            />
+          ) : (
+            title || t('Logs')
+          )}
+          {titleTooltip}
+        </TopBar.Slot>
+        {defined(onboardingProject) && (
+          <TopBar.Slot name="actions">
+            <SetupLogsButton />
+          </TopBar.Slot>
+        )}
+        <TopBar.Slot name="feedback">
+          <FeedbackButton
+            feedbackOptions={logsFeedbackOptions}
+            aria-label={t('Give Feedback')}
+            tooltipProps={{title: t('Give Feedback')}}
+          >
+            {null}
+          </FeedbackButton>
+        </TopBar.Slot>
+      </Fragment>
+    );
+  }
+
   return (
     <Layout.Header unified>
       <Layout.HeaderContent unified>
-        {hasSavedQueryTitle ? (
-          <SentryDocumentTitle
-            title={`${savedQuery.name} — ${t('Logs')}`}
-            orgSlug={organization?.slug}
+        {documentTitle}
+        {hasBreadcrumb ? (
+          <ExploreBreadcrumb
+            traceItemDataset={TraceItemDataset.LOGS}
+            savedQueryName={savedQuery?.name}
           />
         ) : null}
-        {hasPageFrameFeature ? (
-          title && defined(pageId) ? (
-            <TopBar.Slot name="title">
-              <ExploreBreadcrumb
-                traceItemDataset={TraceItemDataset.LOGS}
-                savedQueryName={savedQuery?.name}
-              />
-              <PageHeadingQuestionTooltip
-                docsUrl="https://docs.sentry.io/product/explore/logs/"
-                title={t(
-                  'Detailed structured logs, linked to errors and traces, for debugging and investigation.'
-                )}
-                linkLabel={t('Read the Docs')}
-              />
-            </TopBar.Slot>
-          ) : (
-            <TopBar.Slot name="title">
-              {title ? title : t('Logs')}
-              <PageHeadingQuestionTooltip
-                docsUrl="https://docs.sentry.io/product/explore/logs/"
-                title={t(
-                  'Detailed structured logs, linked to errors and traces, for debugging and investigation.'
-                )}
-                linkLabel={t('Read the Docs')}
-              />
-            </TopBar.Slot>
-          )
-        ) : (
-          <Fragment>
-            {title && defined(pageId) ? (
-              <ExploreBreadcrumb
-                traceItemDataset={TraceItemDataset.LOGS}
-                savedQueryName={savedQuery?.name}
-              />
-            ) : null}
-            <Layout.Title>
-              {title ? title : t('Logs')}
-              <PageHeadingQuestionTooltip
-                docsUrl="https://docs.sentry.io/product/explore/logs/"
-                title={t(
-                  'Detailed structured logs, linked to errors and traces, for debugging and investigation.'
-                )}
-                linkLabel={t('Read the Docs')}
-              />
-            </Layout.Title>
-          </Fragment>
-        )}
+        <Layout.Title>
+          {title || t('Logs')}
+          {titleTooltip}
+        </Layout.Title>
       </Layout.HeaderContent>
-      {hasPageFrameFeature ? (
-        <Fragment>
-          {defined(onboardingProject) && (
-            <TopBar.Slot name="actions">
-              <SetupLogsButton />
-            </TopBar.Slot>
-          )}
-          <TopBar.Slot name="feedback">
-            <FeedbackButton
-              feedbackOptions={logsFeedbackOptions}
-              aria-label={t('Give Feedback')}
-              tooltipProps={{title: t('Give Feedback')}}
-            >
-              {null}
-            </FeedbackButton>
-          </TopBar.Slot>
-        </Fragment>
-      ) : (
-        <Layout.HeaderActions>
-          <Grid flow="column" align="center" gap="md">
-            <FeedbackButton feedbackOptions={logsFeedbackOptions} />
-            {defined(onboardingProject) && <SetupLogsButton />}
-          </Grid>
-        </Layout.HeaderActions>
-      )}
+      <Layout.HeaderActions>
+        <Grid flow="column" align="center" gap="md">
+          <FeedbackButton feedbackOptions={logsFeedbackOptions} />
+          {defined(onboardingProject) && <SetupLogsButton />}
+        </Grid>
+      </Layout.HeaderActions>
     </Layout.Header>
   );
 }

--- a/static/app/views/explore/metrics/content.tsx
+++ b/static/app/views/explore/metrics/content.tsx
@@ -119,104 +119,94 @@ function MetricsHeader() {
     metricQueries.length >= MAX_METRICS_ALLOWED ||
     metricQueries.some(q => q.label === 'Z');
 
+  const documentTitle = hasSavedQueryTitle ? (
+    <SentryDocumentTitle
+      title={`${savedQuery.name} — ${METRICS_TITLE}`}
+      orgSlug={organization?.slug}
+    />
+  ) : null;
+
+  const titleTooltip = (
+    <PageHeadingQuestionTooltip
+      docsUrl="https://docs.sentry.io/product/explore/metrics/"
+      title={t(
+        'Track critical application signals using counters, gauges, and distributions.'
+      )}
+      linkLabel={t('Read the Docs')}
+    />
+  );
+
+  const hasBreadcrumb = Boolean(title && defined(pageId));
+
+  if (hasPageFrameFeature) {
+    return (
+      <Fragment>
+        {documentTitle}
+        <TopBar.Slot name="title">
+          {hasBreadcrumb ? (
+            <ExploreBreadcrumb
+              traceItemDataset={TraceItemDataset.TRACEMETRICS}
+              savedQueryName={savedQuery?.name}
+            />
+          ) : (
+            title || METRICS_TITLE
+          )}
+          <FeatureBadge type="beta" />
+          {titleTooltip}
+        </TopBar.Slot>
+        {defined(onboardingProject) ? null : (
+          <TopBar.Slot name="actions">
+            <ToolbarVisualizeAddChart
+              add={addMetricQuery}
+              disabled={isAddMetricDisabled}
+              label={t('Add Metric')}
+              display="button"
+              size="sm"
+            />
+            {hasEquations && (
+              <ToolbarVisualizeAddChart
+                size="sm"
+                display="button"
+                add={addEquationQuery}
+                disabled={metricQueries.length >= MAX_METRICS_ALLOWED}
+                label={t('Add Equation')}
+              />
+            )}
+            <MetricSaveAs size="sm" />
+          </TopBar.Slot>
+        )}
+        <TopBar.Slot name="feedback">
+          <FeedbackButton
+            feedbackOptions={metricsFeedbackOptions}
+            aria-label={t('Give Feedback')}
+            tooltipProps={{title: t('Give Feedback')}}
+          >
+            {null}
+          </FeedbackButton>
+        </TopBar.Slot>
+      </Fragment>
+    );
+  }
+
   return (
     <Layout.Header unified>
       <Layout.HeaderContent unified>
-        {hasSavedQueryTitle ? (
-          <SentryDocumentTitle
-            title={`${savedQuery.name} — ${METRICS_TITLE}`}
-            orgSlug={organization?.slug}
+        {documentTitle}
+        {hasBreadcrumb ? (
+          <ExploreBreadcrumb
+            traceItemDataset={TraceItemDataset.TRACEMETRICS}
+            savedQueryName={savedQuery?.name}
           />
         ) : null}
-        {hasPageFrameFeature ? (
-          title && defined(pageId) ? (
-            <TopBar.Slot name="title">
-              <ExploreBreadcrumb
-                traceItemDataset={TraceItemDataset.TRACEMETRICS}
-                savedQueryName={savedQuery?.name}
-              />
-              <FeatureBadge type="beta" />
-              <PageHeadingQuestionTooltip
-                docsUrl="https://docs.sentry.io/product/explore/metrics/"
-                title={t(
-                  'Track critical application signals using counters, gauges, and distributions.'
-                )}
-                linkLabel={t('Read the Docs')}
-              />
-            </TopBar.Slot>
-          ) : (
-            <TopBar.Slot name="title">
-              {title ? title : METRICS_TITLE}
-              <FeatureBadge type="beta" />
-              <PageHeadingQuestionTooltip
-                docsUrl="https://docs.sentry.io/product/explore/metrics/"
-                title={t(
-                  'Track critical application signals using counters, gauges, and distributions.'
-                )}
-                linkLabel={t('Read the Docs')}
-              />
-            </TopBar.Slot>
-          )
-        ) : (
-          <Fragment>
-            {title && defined(pageId) ? (
-              <ExploreBreadcrumb
-                traceItemDataset={TraceItemDataset.TRACEMETRICS}
-                savedQueryName={savedQuery?.name}
-              />
-            ) : null}
-            <Layout.Title>
-              {title ? title : METRICS_TITLE}
-              <FeatureBadge type="beta" />
-              <PageHeadingQuestionTooltip
-                docsUrl="https://docs.sentry.io/product/explore/metrics/"
-                title={t(
-                  'Track critical application signals using counters, gauges, and distributions.'
-                )}
-                linkLabel={t('Read the Docs')}
-              />
-            </Layout.Title>
-          </Fragment>
-        )}
+        <Layout.Title>
+          {title || METRICS_TITLE}
+          <FeatureBadge type="beta" />
+          {titleTooltip}
+        </Layout.Title>
       </Layout.HeaderContent>
-      {hasPageFrameFeature ? (
-        <Fragment>
-          {defined(onboardingProject) ? null : (
-            <TopBar.Slot name="actions">
-              <ToolbarVisualizeAddChart
-                add={addMetricQuery}
-                disabled={isAddMetricDisabled}
-                label={t('Add Metric')}
-                display="button"
-                size="sm"
-              />
-              {hasEquations && (
-                <ToolbarVisualizeAddChart
-                  size="sm"
-                  display="button"
-                  add={addEquationQuery}
-                  disabled={metricQueries.length >= MAX_METRICS_ALLOWED}
-                  label={t('Add Equation')}
-                />
-              )}
-              <MetricSaveAs size="sm" />
-            </TopBar.Slot>
-          )}
-          <TopBar.Slot name="feedback">
-            <FeedbackButton
-              feedbackOptions={metricsFeedbackOptions}
-              aria-label={t('Give Feedback')}
-              tooltipProps={{title: t('Give Feedback')}}
-            >
-              {null}
-            </FeedbackButton>
-          </TopBar.Slot>
-        </Fragment>
-      ) : (
-        <Layout.HeaderActions>
-          <FeedbackButton feedbackOptions={metricsFeedbackOptions} />
-        </Layout.HeaderActions>
-      )}
+      <Layout.HeaderActions>
+        <FeedbackButton feedbackOptions={metricsFeedbackOptions} />
+      </Layout.HeaderActions>
     </Layout.Header>
   );
 }

--- a/static/app/views/explore/multiQueryMode/index.tsx
+++ b/static/app/views/explore/multiQueryMode/index.tsx
@@ -38,45 +38,48 @@ export default function MultiQueryMode() {
       renderDisabled={NoAccess}
     >
       <SentryDocumentTitle title={t('Compare Queries')} orgSlug={organization.slug}>
-        <Layout.Header unified>
-          <Layout.HeaderContent>
-            <Breadcrumbs
-              crumbs={[
-                {
-                  label: t('Explore'),
-                },
-                {
-                  label: t('Traces'),
-                  to: makeTracesPathname({
-                    organization,
-                    path: '/',
-                  }),
-                },
-                {
-                  label: t('Compare Queries'),
-                },
-              ]}
-            />
-            <Layout.Title>{title ? title : t('Compare Queries')}</Layout.Title>
-          </Layout.HeaderContent>
-          {hasPageFrameFeature ? (
-            <Fragment>
-              <TopBar.Slot name="actions">
-                <StarSavedQueryButton />
-                {defined(id) && savedQuery?.isPrebuilt === false && (
-                  <SavedQueryEditMenu />
-                )}
-              </TopBar.Slot>
-              <TopBar.Slot name="feedback">
-                <FeedbackButton
-                  aria-label={t('Give Feedback')}
-                  tooltipProps={{title: t('Give Feedback')}}
-                >
-                  {null}
-                </FeedbackButton>
-              </TopBar.Slot>
-            </Fragment>
-          ) : (
+        {hasPageFrameFeature ? (
+          <Fragment>
+            <TopBar.Slot name="title">
+              <Breadcrumbs
+                crumbs={[
+                  {label: t('Explore')},
+                  {
+                    label: t('Traces'),
+                    to: makeTracesPathname({organization, path: '/'}),
+                  },
+                  {label: title ? title : t('Compare Queries')},
+                ]}
+              />
+            </TopBar.Slot>
+            <TopBar.Slot name="actions">
+              <StarSavedQueryButton />
+              {defined(id) && savedQuery?.isPrebuilt === false && <SavedQueryEditMenu />}
+            </TopBar.Slot>
+            <TopBar.Slot name="feedback">
+              <FeedbackButton
+                aria-label={t('Give Feedback')}
+                tooltipProps={{title: t('Give Feedback')}}
+              >
+                {null}
+              </FeedbackButton>
+            </TopBar.Slot>
+          </Fragment>
+        ) : (
+          <Layout.Header unified>
+            <Layout.HeaderContent>
+              <Breadcrumbs
+                crumbs={[
+                  {label: t('Explore')},
+                  {
+                    label: t('Traces'),
+                    to: makeTracesPathname({organization, path: '/'}),
+                  },
+                  {label: t('Compare Queries')},
+                ]}
+              />
+              <Layout.Title>{title ? title : t('Compare Queries')}</Layout.Title>
+            </Layout.HeaderContent>
             <Layout.HeaderActions>
               <Grid flow="column" align="center" gap="md">
                 <StarSavedQueryButton />
@@ -86,8 +89,8 @@ export default function MultiQueryMode() {
                 <FeedbackButton />
               </Grid>
             </Layout.HeaderActions>
-          )}
-        </Layout.Header>
+          </Layout.Header>
+        )}
         <Stack flex={1}>
           <MultiQueryModeContent />
         </Stack>

--- a/static/app/views/explore/savedQueries/index.tsx
+++ b/static/app/views/explore/savedQueries/index.tsx
@@ -43,96 +43,67 @@ export default function SavedQueriesView() {
     },
   ];
 
+  const createQueryButton = hasLogsFeature ? (
+    <DropdownMenu
+      items={items}
+      trigger={triggerProps => (
+        <Button
+          {...triggerProps}
+          priority="primary"
+          icon={<IconAdd />}
+          size="sm"
+          aria-label={t('Save as')}
+          onClick={e => {
+            e.stopPropagation();
+            e.preventDefault();
+
+            triggerProps.onClick?.(e);
+          }}
+        >
+          {t('Create Query')}
+        </Button>
+      )}
+    />
+  ) : (
+    <LinkButton
+      priority="primary"
+      icon={<IconAdd />}
+      size="sm"
+      to={getExploreUrl({organization, visualize: []})}
+    >
+      {t('Create Query')}
+    </LinkButton>
+  );
+
   return (
     <SentryDocumentTitle title={t('All Queries')} orgSlug={organization?.slug}>
       <Stack flex={1}>
-        <Layout.Header unified>
-          <Layout.HeaderContent>
-            <Layout.Title>{t('All Queries')}</Layout.Title>
-          </Layout.HeaderContent>
-          {hasPageFrameFeature ? (
-            <Fragment>
-              <TopBar.Slot name="actions">
-                {hasLogsFeature ? (
-                  <DropdownMenu
-                    items={items}
-                    trigger={triggerProps => (
-                      <Button
-                        {...triggerProps}
-                        priority="primary"
-                        icon={<IconAdd />}
-                        size="sm"
-                        aria-label={t('Save as')}
-                        onClick={e => {
-                          e.stopPropagation();
-                          e.preventDefault();
-
-                          triggerProps.onClick?.(e);
-                        }}
-                      >
-                        {t('Create Query')}
-                      </Button>
-                    )}
-                  />
-                ) : (
-                  <LinkButton
-                    priority="primary"
-                    icon={<IconAdd />}
-                    size="sm"
-                    to={getExploreUrl({organization, visualize: []})}
-                  >
-                    {t('Create Query')}
-                  </LinkButton>
-                )}
-              </TopBar.Slot>
-              <TopBar.Slot name="feedback">
-                <FeedbackButton
-                  aria-label={t('Give Feedback')}
-                  tooltipProps={{title: t('Give Feedback')}}
-                >
-                  {null}
-                </FeedbackButton>
-              </TopBar.Slot>
-            </Fragment>
-          ) : (
+        {hasPageFrameFeature ? (
+          <Fragment>
+            <TopBar.Slot name="title">{t('All Queries')}</TopBar.Slot>
+            <TopBar.Slot name="actions">{createQueryButton}</TopBar.Slot>
+            <TopBar.Slot name="feedback">
+              <FeedbackButton
+                aria-label={t('Give Feedback')}
+                tooltipProps={{title: t('Give Feedback')}}
+              >
+                {null}
+              </FeedbackButton>
+            </TopBar.Slot>
+          </Fragment>
+        ) : (
+          <Layout.Header unified>
+            <Layout.HeaderContent>
+              <Layout.Title>{t('All Queries')}</Layout.Title>
+            </Layout.HeaderContent>
             <Layout.HeaderActions>
               <Grid flow="column" align="center" gap="md">
                 <FeedbackButton />
-                {hasLogsFeature ? (
-                  <DropdownMenu
-                    items={items}
-                    trigger={triggerProps => (
-                      <Button
-                        {...triggerProps}
-                        priority="primary"
-                        icon={<IconAdd />}
-                        size="sm"
-                        aria-label={t('Save as')}
-                        onClick={e => {
-                          e.stopPropagation();
-                          e.preventDefault();
-
-                          triggerProps.onClick?.(e);
-                        }}
-                      >
-                        {t('Create Query')}
-                      </Button>
-                    )}
-                  />
-                ) : (
-                  <LinkButton
-                    priority="primary"
-                    icon={<IconAdd />}
-                    size="sm"
-                    to={getExploreUrl({organization, visualize: []})}
-                  >
-                    {t('Create Query')}
-                  </LinkButton>
-                )}
+                {createQueryButton}
               </Grid>
             </Layout.HeaderActions>
-          )}
-        </Layout.Header>
+          </Layout.Header>
+        )}
         <Layout.Body>
           <Layout.Main width="full">
             <SavedQueriesLandingContent />

--- a/static/app/views/projectDetail/projectDetail.tsx
+++ b/static/app/views/projectDetail/projectDetail.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import pick from 'lodash/pick';
 
 import {LinkButton} from '@sentry/scraps/button';
-import {Grid, Stack} from '@sentry/scraps/layout';
+import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 
 import {fetchOrganizationDetails} from 'sentry/actionCreators/organization';
@@ -182,58 +182,60 @@ export function ProjectDetail() {
         <Stack flex={1}>
           <NoProjectMessage organization={organization}>
             <Layout.Header unified>
-              {hasPageFrameFeature ? (
-                <TopBar.Slot name="title">
-                  <Breadcrumbs
-                    crumbs={[
-                      {
-                        to: makeProjectsPathname({path: '/', organization}),
-                        label: t('Projects'),
-                      },
-                      {
-                        label: (
-                          <Fragment>
-                            {project ? (
-                              <IdBadge
-                                project={project}
-                                avatarSize={20}
-                                hideOverflow="100%"
-                                disableLink
-                                hideName
-                              />
-                            ) : null}
-                            {project?.slug}
-                          </Fragment>
-                        ),
-                      },
-                    ]}
-                  />
-                </TopBar.Slot>
-              ) : (
-                <Layout.HeaderContent unified>
-                  <Breadcrumbs
-                    crumbs={[
-                      {
-                        to: makeProjectsPathname({path: '/', organization}),
-                        label: t('Projects'),
-                      },
-                      {label: t('Project Details')},
-                    ]}
-                  />
-                  <Layout.Title>
-                    {project ? (
-                      <IdBadge
-                        project={project}
-                        avatarSize={28}
-                        hideOverflow="100%"
-                        disableLink
-                        hideName
-                      />
-                    ) : null}
-                    {project?.slug}
-                  </Layout.Title>
-                </Layout.HeaderContent>
-              )}
+              <Layout.HeaderContent unified>
+                {hasPageFrameFeature ? (
+                  <TopBar.Slot name="title">
+                    <Breadcrumbs
+                      crumbs={[
+                        {
+                          to: makeProjectsPathname({path: '/', organization}),
+                          label: t('Projects'),
+                        },
+                        {
+                          label: (
+                            <Flex align="center" gap="xs">
+                              {project ? (
+                                <IdBadge
+                                  project={project}
+                                  avatarSize={16}
+                                  hideOverflow="100%"
+                                  disableLink
+                                  hideName
+                                />
+                              ) : null}
+                              {project?.slug}
+                            </Flex>
+                          ),
+                        },
+                      ]}
+                    />
+                  </TopBar.Slot>
+                ) : (
+                  <Fragment>
+                    <Breadcrumbs
+                      crumbs={[
+                        {
+                          to: makeProjectsPathname({path: '/', organization}),
+                          label: t('Projects'),
+                        },
+                        {label: t('Project Details')},
+                      ]}
+                    />
+                    <Layout.Title>
+                      {project ? (
+                        <IdBadge
+                          project={project}
+                          avatarSize={28}
+                          hideOverflow="100%"
+                          disableLink
+                          hideName
+                        />
+                      ) : null}
+                      {project?.slug}
+                    </Layout.Title>
+                  </Fragment>
+                )}
+              </Layout.HeaderContent>
 
               <Layout.HeaderActions>
                 <Grid flow="column" align="center" gap="md">

--- a/static/app/views/projectDetail/projectDetail.tsx
+++ b/static/app/views/projectDetail/projectDetail.tsx
@@ -182,29 +182,58 @@ export function ProjectDetail() {
         <Stack flex={1}>
           <NoProjectMessage organization={organization}>
             <Layout.Header unified>
-              <Layout.HeaderContent unified>
-                <Breadcrumbs
-                  crumbs={[
-                    {
-                      to: makeProjectsPathname({path: '/', organization}),
-                      label: t('Projects'),
-                    },
-                    {label: t('Project Details')},
-                  ]}
-                />
-                <Layout.Title>
-                  {project ? (
-                    <IdBadge
-                      project={project}
-                      avatarSize={28}
-                      hideOverflow="100%"
-                      disableLink
-                      hideName
-                    />
-                  ) : null}
-                  {project?.slug}
-                </Layout.Title>
-              </Layout.HeaderContent>
+              {hasPageFrameFeature ? (
+                <TopBar.Slot name="title">
+                  <Breadcrumbs
+                    crumbs={[
+                      {
+                        to: makeProjectsPathname({path: '/', organization}),
+                        label: t('Projects'),
+                      },
+                      {
+                        label: (
+                          <Fragment>
+                            {project ? (
+                              <IdBadge
+                                project={project}
+                                avatarSize={20}
+                                hideOverflow="100%"
+                                disableLink
+                                hideName
+                              />
+                            ) : null}
+                            {project?.slug}
+                          </Fragment>
+                        ),
+                      },
+                    ]}
+                  />
+                </TopBar.Slot>
+              ) : (
+                <Layout.HeaderContent unified>
+                  <Breadcrumbs
+                    crumbs={[
+                      {
+                        to: makeProjectsPathname({path: '/', organization}),
+                        label: t('Projects'),
+                      },
+                      {label: t('Project Details')},
+                    ]}
+                  />
+                  <Layout.Title>
+                    {project ? (
+                      <IdBadge
+                        project={project}
+                        avatarSize={28}
+                        hideOverflow="100%"
+                        disableLink
+                        hideName
+                      />
+                    ) : null}
+                    {project?.slug}
+                  </Layout.Title>
+                </Layout.HeaderContent>
+              )}
 
               <Layout.HeaderActions>
                 <Grid flow="column" align="center" gap="md">


### PR DESCRIPTION
See screenshots.


contributes to https://linear.app/getsentry/issue/DE-1116/header-renders-as-an-empty-element