### PR TITLE
feat(replay): remove canvas recording

### DIFF
--- a/static/gsApp/utils/useReplayInit.tsx
+++ b/static/gsApp/utils/useReplayInit.tsx
@@ -17,7 +17,7 @@ export function useReplayInit() {
 
   useEffect(() => {
     async function init(sessionSampleRate: number, errorSampleRate: number) {
-      const {replayIntegration, replayCanvasIntegration} = await import('@sentry/react');
+      const {replayIntegration} = await import('@sentry/react');
 
       if (!replayRef) {
         const client = getClient();
@@ -66,7 +66,6 @@ export function useReplayInit() {
           ],
         });
 
-        client.addIntegration(replayCanvasIntegration());
         client.addIntegration(replayRef);
       }
     }


### PR DESCRIPTION
this was causing issues on our profiling page, disabling for now as to not disrupt users using profiling.
