### PR TITLE
ref: Upgrade sentry-scm to 0.5.0 for GitLab token refresh fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ dependencies = [
   "sentry-protos>=0.8.13",
   "sentry-redis-tools>=0.5.0",
   "sentry-relay>=0.9.27",
-  "sentry-scm>=0.1.7",
+  "sentry-scm>=0.5.0",
   "sentry-sdk[http2]>=2.47.0",
   "sentry-usage-accountant>=0.0.10",
   # remove once there are no unmarked transitive dependencies on setuptools

--- a/uv.lock
+++ b/uv.lock
@@ -2331,7 +2331,7 @@ requires-dist = [
     { name = "sentry-protos", specifier = ">=0.8.13" },
     { name = "sentry-redis-tools", specifier = ">=0.5.0" },
     { name = "sentry-relay", specifier = ">=0.9.27" },
-    { name = "sentry-scm", specifier = ">=0.1.7" },
+    { name = "sentry-scm", specifier = ">=0.5.0" },
     { name = "sentry-sdk", extras = ["http2"], specifier = ">=2.47.0" },
     { name = "sentry-usage-accountant", specifier = ">=0.0.10" },
     { name = "setuptools", specifier = ">=70.0.0" },
@@ -2540,14 +2540,14 @@ wheels = [
 
 [[package]]
 name = "sentry-scm"
-version = "0.1.7"
+version = "0.5.0"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "msgspec", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_scm-0.1.7-py3-none-any.whl", hash = "sha256:afed9d4087b98ce29b1c6ea08266149bf68e0fe72806765889690ecae270c847" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_scm-0.5.0-py3-none-any.whl", hash = "sha256:0e8de12bf576e05332e993e37583ad637e981ee9eceac5dda87188711fb0bd35" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

GitLab API tokens were expiring when using the SCM platform, causing 401 errors. This was happening because the scm-platform library was calling `ApiClient._request` (a private method), which bypassed the GitLab token refresh logic in `sentry.integrations.gitlab.client.GitLabApiClient._issue_request_with_auto_token_refresh`.

Error observed:
```
scm.gitlab.upstream_error (provider='gitlab' status_code=401 method='GET' path='/projects/81521667' body_preview='{"error":"invalid_token","error_description":"Token is expired. You can either do re-authorization or token refresh."}')
```

## Solution

Upgraded `sentry-scm` from 0.1.7 to 0.5.0, which includes the fix from [scm-platform PR #13](https://github.com/getsentry/scm-platform/pull/13). This fix makes `ApiClient.request` part of the public interface (renamed from `_request`), allowing Sentry's GitLab client to properly hook into the token refresh flow.

The fix was introduced in sentry-scm 0.3.1, and we're upgrading to the latest version (0.5.0) for any additional improvements.

## Changes

- Updated `pyproject.toml`: `sentry-scm>=0.1.7` → `sentry-scm>=0.5.0`
- Updated `uv.lock` accordingly

## References

- [scm-platform PR #13: Ack. that 'ApiClient.request' is part of the public interface](https://github.com/getsentry/scm-platform/pull/13)
- [Sentry PR #113414: fix: Refresh token when calling GitLab through SCM](https://github.com/getsentry/sentry/pull/113414)
- Linear issue: ENG-7409
- Slack thread: #proj-seer-gitlab
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/C0AKG192UP3/p1776807393947799?thread_ts=1776807393.947799&cid=C0AKG192UP3)

<div><a href="https://cursor.com/agents/bc-acd5b57f-6339-5fea-8dbe-1147b627c40b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-acd5b57f-6339-5fea-8dbe-1147b627c40b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

