### PR TITLE
feat(spans): make salt deterministic for subsegments

### DIFF
--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -104,6 +104,7 @@ import math
 import time
 import uuid
 from collections.abc import Generator, MutableMapping, Sequence
+from hashlib import blake2b
 from typing import Any, NamedTuple, cast
 
 import orjson
@@ -177,6 +178,13 @@ class Subsegment(NamedTuple):
     project_and_trace: tuple[str, str]
     salt: str
     subsegment: list[Span]
+
+
+def _compute_salt(spans: Sequence[Span]) -> str:
+    return blake2b(
+        b"".join(s.span_id.encode("ascii") for s in spans),
+        digest_size=16,
+    ).hexdigest()
 
 
 class OutputSpan(NamedTuple):
@@ -309,9 +317,10 @@ class SpansBuffer:
             for key, subsegment in trees.items():
                 if max_spans_per_evalsha > 0 and len(subsegment) > max_spans_per_evalsha:
                     for chunk in itertools.batched(subsegment, max_spans_per_evalsha):
-                        tree_items.append(Subsegment(key, uuid.uuid4().hex, list(chunk)))
+                        chunk_list = list(chunk)
+                        tree_items.append(Subsegment(key, _compute_salt(chunk_list), chunk_list))
                 else:
-                    tree_items.append(Subsegment(key, uuid.uuid4().hex, subsegment))
+                    tree_items.append(Subsegment(key, _compute_salt(subsegment), subsegment))
 
             tree_batches: Sequence[Sequence[Subsegment]]
             if pipeline_batch_size > 0:

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -310,6 +310,49 @@ def test_observability_metrics(
     emit_observability_metrics.assert_called_once()
 
 
+def test_duplicate_batch_is_idempotent(buffer: SpansBuffer) -> None:
+    spans = [
+        Span(
+            payload=_payload("a" * 16),
+            trace_id="a" * 32,
+            span_id="a" * 16,
+            parent_span_id="b" * 16,
+            segment_id=None,
+            project_id=1,
+        ),
+        Span(
+            payload=_payload("b" * 16),
+            trace_id="a" * 32,
+            span_id="b" * 16,
+            parent_span_id=None,
+            segment_id=None,
+            is_segment_span=True,
+            project_id=1,
+        ),
+    ]
+
+    buffer.process_spans(spans, now=0)
+    buffer.process_spans(spans, now=0)
+
+    rv = buffer.flush_segments(now=11)
+    _normalize_output(rv)
+    assert rv == {
+        _segment_id(1, "a" * 32, "b" * 16): FlushedSegment(
+            queue_key=mock.ANY,
+            score=mock.ANY,
+            ingested_count=mock.ANY,
+            payload_keys=mock.ANY,
+            project_id=1,
+            spans=[
+                _output_segment(b"a" * 16, b"b" * 16, False),
+                _output_segment(b"b" * 16, b"b" * 16, True),
+            ],
+        )
+    }
+    buffer.done_flush_segments(rv)
+    assert_clean(buffer.client)
+
+
 def test_flush_segments_with_null_attributes(buffer: SpansBuffer) -> None:
     spans = [
         Span(


### PR DESCRIPTION
Replace `uuid.uuid4()` with a blake2b hash of the subsegment's span IDs when generating the salt used for subsegment keys in the spans buffer. The salt is now deterministic: the same set of spans always produces the same salt.