### PR TITLE
fix(conversations): Improve trace view conversation panel UX

### DIFF
--- a/static/app/views/insights/pages/agents/utils/timeBounds.spec.tsx
+++ b/static/app/views/insights/pages/agents/utils/timeBounds.spec.tsx
@@ -1,0 +1,31 @@
+import type {AITraceSpanNode} from 'sentry/views/insights/pages/agents/utils/types';
+
+import {getTimeBoundsFromNodes} from './timeBounds';
+
+function makeNode(start: number, end: number): AITraceSpanNode {
+  return {startTimestamp: start, endTimestamp: end} as unknown as AITraceSpanNode;
+}
+
+describe('getTimeBoundsFromNodes', () => {
+  it('returns undefined for empty nodes', () => {
+    expect(getTimeBoundsFromNodes([])).toEqual({
+      startTimestamp: undefined,
+      endTimestamp: undefined,
+    });
+  });
+
+  it('returns bounds from a single node converted to ms', () => {
+    expect(getTimeBoundsFromNodes([makeNode(100, 200)])).toEqual({
+      startTimestamp: 100_000,
+      endTimestamp: 200_000,
+    });
+  });
+
+  it('returns min start and max end across multiple nodes', () => {
+    const nodes = [makeNode(300, 400), makeNode(100, 500), makeNode(200, 350)];
+    expect(getTimeBoundsFromNodes(nodes)).toEqual({
+      startTimestamp: 100_000,
+      endTimestamp: 500_000,
+    });
+  });
+});

--- a/static/app/views/insights/pages/agents/utils/timeBounds.tsx
+++ b/static/app/views/insights/pages/agents/utils/timeBounds.tsx
@@ -1,0 +1,28 @@
+import type {AITraceSpanNode} from 'sentry/views/insights/pages/agents/utils/types';
+
+export function getTimeBoundsFromNodes(nodes: AITraceSpanNode[]): {
+  endTimestamp: number | undefined;
+  startTimestamp: number | undefined;
+} {
+  if (nodes.length === 0) {
+    return {startTimestamp: undefined, endTimestamp: undefined};
+  }
+
+  let min = Infinity;
+  let max = -Infinity;
+
+  for (const node of nodes) {
+    if (node.startTimestamp !== undefined && node.startTimestamp < min) {
+      min = node.startTimestamp;
+    }
+    if (node.endTimestamp !== undefined && node.endTimestamp > max) {
+      max = node.endTimestamp;
+    }
+  }
+
+  // Node timestamps are in seconds; convert to milliseconds for the conversation hook
+  return {
+    startTimestamp: min === Infinity ? undefined : min * 1e3,
+    endTimestamp: max === -Infinity ? undefined : max * 1e3,
+  };
+}

--- a/static/app/views/insights/pages/conversations/components/conversationLayout.tsx
+++ b/static/app/views/insights/pages/conversations/components/conversationLayout.tsx
@@ -109,8 +109,10 @@ export function ConversationLeftPanel({children}: {children: React.ReactNode}) {
 export function ConversationDetailPanel({
   selectedNode,
   nodeTraceMap,
+  initiallyCollapseAiIO = true,
 }: {
   nodeTraceMap: Map<string, string>;
+  initiallyCollapseAiIO?: boolean;
   selectedNode?: AITraceSpanNode;
 }) {
   const organization = useOrganization();
@@ -132,7 +134,7 @@ export function ConversationDetailPanel({
         replay: null,
         traceId: nodeTraceMap.get(selectedNode.id) ?? '',
         hideNodeActions: true,
-        initiallyCollapseAiIO: true,
+        initiallyCollapseAiIO,
       })}
     </Flex>
   );

--- a/static/app/views/insights/pages/conversations/components/conversationSummary.tsx
+++ b/static/app/views/insights/pages/conversations/components/conversationSummary.tsx
@@ -30,6 +30,7 @@ import {
   getIsAiGenerationSpan,
   getIsExecuteToolSpan,
 } from 'sentry/views/insights/pages/agents/utils/query';
+import {getTimeBoundsFromNodes} from 'sentry/views/insights/pages/agents/utils/timeBounds';
 import type {AITraceSpanNode} from 'sentry/views/insights/pages/agents/utils/types';
 import {SpanFields} from 'sentry/views/insights/types';
 
@@ -187,23 +188,8 @@ export function ConversationSummary({
 }: ConversationSummaryProps) {
   const organization = useOrganization();
   const lastMessageDate = useMemo(() => {
-    if (nodes.length === 0) {
-      return null;
-    }
-
-    let endTimestamp = Number.NEGATIVE_INFINITY;
-
-    for (const node of nodes) {
-      if (typeof node.endTimestamp === 'number') {
-        endTimestamp = Math.max(endTimestamp, node.endTimestamp);
-      }
-    }
-
-    if (!Number.isFinite(endTimestamp)) {
-      return null;
-    }
-
-    return new Date(endTimestamp * 1e3);
+    const {endTimestamp} = getTimeBoundsFromNodes(nodes);
+    return endTimestamp === undefined ? null : new Date(endTimestamp);
   }, [nodes]);
 
   const handleCopyConversationId = () => {

--- a/static/app/views/insights/pages/conversations/components/messagesPanel.tsx
+++ b/static/app/views/insights/pages/conversations/components/messagesPanel.tsx
@@ -66,6 +66,7 @@ export function MessagesPanel({nodes, selectedNodeId, onSelectNode}: MessagesPan
         padding="lg lg md md"
         background="secondary"
         minHeight="100%"
+        width="100%"
       >
         <EmptyMessage>{t('No messages found')}</EmptyMessage>
       </Flex>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiConversations.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiConversations.tsx
@@ -9,6 +9,7 @@ import {EmptyMessage} from 'sentry/components/emptyMessage';
 import {t} from 'sentry/locale';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {getTimeBoundsFromNodes} from 'sentry/views/insights/pages/agents/utils/timeBounds';
 import type {AITraceSpanNode} from 'sentry/views/insights/pages/agents/utils/types';
 import {
   ConversationDetailPanel,
@@ -37,7 +38,7 @@ export function TraceAiConversations({
   traceSlug,
 }: TraceAiConversationsProps) {
   const organization = useOrganization();
-  const [activeSubTab, setActiveSubTab] = useState(`chat-${conversationIds[0]}`);
+  const [activeSubTab, setActiveSubTab] = useState('spans');
   const [selectedSpanId, setSelectedSpanId] = useState<string | null>(null);
 
   const handleTabChange = useCallback((key: Key) => {
@@ -53,6 +54,8 @@ export function TraceAiConversations({
     ? activeSubTab.slice('chat-'.length)
     : null;
 
+  const traceTimeBounds = useMemo(() => getTimeBoundsFromNodes(allAiNodes), [allAiNodes]);
+
   const {
     nodes: conversationNodes,
     nodeTraceMap,
@@ -60,6 +63,7 @@ export function TraceAiConversations({
     error,
   } = useConversation({
     conversationId: activeConversationId ?? '',
+    ...traceTimeBounds,
   });
 
   const traceNodes = useMemo(
@@ -67,16 +71,17 @@ export function TraceAiConversations({
     [conversationNodes, nodeTraceMap, traceSlug]
   );
 
-  const tabItems = useMemo(() => {
-    const items: Array<{conversationId: string | null; key: string; label: string}> =
-      conversationIds.map(id => ({
+  const tabItems = useMemo(
+    (): Array<{conversationId: string | null; key: string; label: string}> => [
+      {key: 'spans', label: t('Spans'), conversationId: null},
+      ...conversationIds.map(id => ({
         key: `chat-${id}`,
         label: conversationIds.length === 1 ? t('Chat') : t('Chat %s', id.slice(0, 8)),
         conversationId: id,
-      }));
-    items.push({key: 'spans', label: t('Spans'), conversationId: null});
-    return items;
-  }, [conversationIds]);
+      })),
+    ],
+    [conversationIds]
+  );
 
   const conversationUrl = activeConversationId
     ? normalizeUrl(

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiSpans.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiSpans.tsx
@@ -158,6 +158,7 @@ export function TraceAiSpans({
           replay: null,
           traceId: traceSlug,
           hideNodeActions: true,
+          initiallyCollapseAiIO: false,
         })}
       </RightPanel>
     </Wrapper>
@@ -208,6 +209,7 @@ export function AiSpansSplitView({
         <ConversationDetailPanel
           selectedNode={selectedNode}
           nodeTraceMap={nodeTraceMap}
+          initiallyCollapseAiIO={false}
         />
       }
     />


### PR DESCRIPTION
Fixes conversation panel issues in the trace detail view.

- Empty state in MessagesPanel now fills the full panel width
- Spans tab is first and selected by default when there are multiple tabs
- AI input/output sections expanded by default in spans-only views
- Conversation queries use tight time window from trace nodes instead of broad page filter range
- Extracted `getTimeBoundsFromNodes` to shared util with tests