### PR TITLE
ref(eslint): Enable unicorn/prefer-global-this

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -849,7 +849,6 @@ export default typescript.config([
       'unicorn/prefer-dom-node-dataset': 'off',
       'unicorn/prefer-dom-node-remove': 'off',
       'unicorn/prefer-dom-node-text-content': 'off',
-      'unicorn/prefer-global-this': 'off',
       'unicorn/prefer-math-min-max': 'off',
       'unicorn/prefer-module': 'off',
       'unicorn/prefer-number-properties': 'off',

--- a/static/app/actionCreators/navigation.tsx
+++ b/static/app/actionCreators/navigation.tsx
@@ -48,7 +48,7 @@ export function navigateTo(
           configQueryKey={configQueryKey}
           onFinish={path => {
             modalProps.closeModal();
-            return window.setTimeout(() => navigate(normalizeUrl(path)), 0);
+            return globalThis.setTimeout(() => navigate(normalizeUrl(path)), 0);
           }}
         />
       ),

--- a/static/app/actionCreators/organizations.tsx
+++ b/static/app/actionCreators/organizations.tsx
@@ -54,7 +54,7 @@ export function redirectToRemainingOrganization({
   const route = `/organizations/${firstRemainingOrg.slug}/issues/`;
   if (USING_CUSTOMER_DOMAIN) {
     const {organizationUrl} = firstRemainingOrg.links;
-    window.location.assign(`${organizationUrl}${normalizeUrl(route)}`);
+    globalThis.location.assign(`${organizationUrl}${normalizeUrl(route)}`);
     return;
   }
 

--- a/static/app/api.spec.tsx
+++ b/static/app/api.spec.tsx
@@ -107,8 +107,8 @@ describe('resolveHostname', () => {
 
   beforeEach(() => {
     configstate = ConfigStore.getState();
-    location = window.location;
-    devUi = window.__SENTRY_DEV_UI;
+    location = globalThis.location;
+    devUi = globalThis.__SENTRY_DEV_UI;
 
     ConfigStore.loadInitialData({
       ...configstate,
@@ -122,8 +122,8 @@ describe('resolveHostname', () => {
   });
 
   afterEach(() => {
-    window.location = location as typeof window.location & string;
-    window.__SENTRY_DEV_UI = devUi;
+    globalThis.location = location as typeof globalThis.location & string;
+    globalThis.__SENTRY_DEV_UI = devUi;
     ConfigStore.loadInitialData(configstate);
   });
 
@@ -183,7 +183,7 @@ describe('resolveHostname', () => {
   });
 
   it('uses paths for region silo in dev-ui', () => {
-    window.__SENTRY_DEV_UI = true;
+    globalThis.__SENTRY_DEV_UI = true;
 
     let result = resolveHostname(regionPath);
     expect(result).toBe('/region/us/api/0/organizations/slug/issues/');
@@ -193,7 +193,7 @@ describe('resolveHostname', () => {
   });
 
   it('removes sentryUrl from dev-ui mode requests', () => {
-    window.__SENTRY_DEV_UI = true;
+    globalThis.__SENTRY_DEV_UI = true;
 
     let result = resolveHostname(regionPath, 'https://sentry.io');
     expect(result).toBe('/api/0/organizations/slug/issues/');
@@ -203,7 +203,7 @@ describe('resolveHostname', () => {
   });
 
   it('removes sentryUrl from dev-ui mode requests when feature is off', () => {
-    window.__SENTRY_DEV_UI = true;
+    globalThis.__SENTRY_DEV_UI = true;
     // Org does not have the required feature.
     OrganizationStore.onUpdate(OrganizationFixture());
 

--- a/static/app/api.tsx
+++ b/static/app/api.tsx
@@ -133,7 +133,7 @@ const globalErrorHandlers: Array<
 export const initApiClientErrorHandling = () =>
   globalErrorHandlers.push((resp: ResponseMeta, options: RequestOptions) => {
     const pageAllowsAnon = ALLOWED_ANON_PAGES.find(regex =>
-      regex.test(window.location.pathname)
+      regex.test(globalThis.location.pathname)
     );
 
     // Ignore error unless it is a 401
@@ -162,7 +162,7 @@ export const initApiClientErrorHandling = () =>
 
     // If user must login via SSO, redirect to org login page
     if (code === 'sso-required') {
-      window.location.assign(extra.loginUrl);
+      globalThis.location.assign(extra.loginUrl);
       return true;
     }
 
@@ -179,7 +179,7 @@ export const initApiClientErrorHandling = () =>
     if (EXPERIMENTAL_SPA) {
       browserHistory.replace('/auth/login/');
     } else {
-      window.location.reload();
+      globalThis.location.reload();
     }
     return true;
   });
@@ -514,7 +514,7 @@ export class Client {
 
     // Do not set the X-CSRFToken header when making a request outside of the
     // current domain. Because we use subdomains we loosely compare origins
-    if (!csrfSafeMethod(method) && isSimilarOrigin(fullUrl, window.location.origin)) {
+    if (!csrfSafeMethod(method) && isSimilarOrigin(fullUrl, globalThis.location.origin)) {
       requestHeaders.set('X-CSRFToken', getCsrfToken());
     }
 
@@ -724,7 +724,7 @@ export function resolveHostname(path: string, hostname?: string): string {
     // this we want to explicitly default those requests to be proxied through
     // the control silo which can handle region resolution in exchange for a
     // bit of latency.
-    const isAdmin = window.location.pathname.startsWith('/_admin/');
+    const isAdmin = globalThis.location.pathname.startsWith('/_admin/');
     const isControlSilo = detectControlSiloPath(path);
     if (!isAdmin && !isControlSilo && configLinks.regionUrl) {
       hostname = configLinks.regionUrl;
@@ -738,7 +738,7 @@ export function resolveHostname(path: string, hostname?: string): string {
   // domain, we can drop the domain as webpack devserver will add one.
   // TODO(hybridcloud) This can likely be removed when sentry.types.cell.Region.to_url()
   // loses the monolith mode condition.
-  if (window.__SENTRY_DEV_UI && hostname === configLinks.sentryUrl) {
+  if (globalThis.__SENTRY_DEV_UI && hostname === configLinks.sentryUrl) {
     hostname = '';
   }
 
@@ -746,7 +746,7 @@ export function resolveHostname(path: string, hostname?: string): string {
   // of CORS. Instead we extract the subdomain from the hostname
   // and prepend the URL with `/region/$name` so that webpack-devserver proxy
   // can route requests to the regions.
-  if (hostname && window.__SENTRY_DEV_UI) {
+  if (hostname && globalThis.__SENTRY_DEV_UI) {
     const domainpattern = /https?:\/\/([^.]*)\.sentry\.io/;
     const domainmatch = hostname.match(domainpattern);
     if (domainmatch) {

--- a/static/app/appQueryClient.tsx
+++ b/static/app/appQueryClient.tsx
@@ -41,7 +41,7 @@ const indexedDbPersister = createAsyncStoragePersister({
   key: cacheKey,
 });
 
-const hasIndexedDb = !!window.indexedDB;
+const hasIndexedDb = !!globalThis.indexedDB;
 
 /**
  * Enables the PersistQueryClientProvider when the flag is enabled

--- a/static/app/bootstrap/boostrapRequests.spec.tsx
+++ b/static/app/bootstrap/boostrapRequests.spec.tsx
@@ -73,7 +73,7 @@ describe('useBootstrapOrganizationQuery', () => {
   });
 
   it('removes the promise from window.__sentry_preload after use', async () => {
-    window.__sentry_preload = {
+    globalThis.__sentry_preload = {
       orgSlug: org.slug,
       organization: Promise.resolve<ApiResult<Organization>>([org, undefined, undefined]),
     };
@@ -81,7 +81,7 @@ describe('useBootstrapOrganizationQuery', () => {
       useBootstrapOrganizationQuery(orgSlug)
     );
     await waitFor(() => expect(result.current.data).toBeDefined());
-    expect(window.__sentry_preload?.organization).toBeUndefined();
+    expect(globalThis.__sentry_preload?.organization).toBeUndefined();
   });
 
   it('sets feature flags, activates organization, and sets sentry tags', async () => {

--- a/static/app/bootstrap/bootstrapRequests.tsx
+++ b/static/app/bootstrap/bootstrapRequests.tsx
@@ -217,7 +217,7 @@ function getPreloadedData(
   name: 'organization' | 'projects' | 'teams',
   slug: string
 ): Promise<ApiResult | null> {
-  const data = window.__sentry_preload;
+  const data = globalThis.__sentry_preload;
   if (!data?.[name] || data.orgSlug?.toLowerCase() !== slug.toLowerCase()) {
     throw new Error('Prefetch query not found or slug mismatch');
   }

--- a/static/app/bootstrap/exportGlobals.tsx
+++ b/static/app/bootstrap/exportGlobals.tsx
@@ -44,7 +44,7 @@ const SentryApp = {
 
 globals.SentryApp = SentryApp;
 Object.keys(globals).forEach(name => {
-  Object.defineProperty(window, name, {
+  Object.defineProperty(globalThis, name, {
     value: globals[name],
     writable: true,
   });

--- a/static/app/bootstrap/index.tsx
+++ b/static/app/bootstrap/index.tsx
@@ -6,9 +6,9 @@ import {shouldPreloadData} from 'sentry/utils/shouldPreloadData';
 const BOOTSTRAP_URL = '/api/client-config/';
 
 const bootApplication = (data: Config) => {
-  window.csrfCookieName = data.csrfCookieName;
-  window.superUserCookieName = data.superUserCookieName;
-  window.superUserCookieDomain = data.superUserCookieDomain ?? undefined;
+  globalThis.csrfCookieName = data.csrfCookieName;
+  globalThis.superUserCookieName = data.superUserCookieName;
+  globalThis.superUserCookieDomain = data.superUserCookieDomain ?? undefined;
 
   return data;
 };
@@ -24,8 +24,8 @@ async function bootWithHydration() {
   // Shim up the initialData payload to quack like it came from
   // a customer-domains initial request. Because our initial call to BOOTSTRAP_URL
   // will not be on a customer domain, the response will not include this context.
-  if (data.customerDomain === null && window.__SENTRY_DEV_UI) {
-    const domain = extractSlug(window.location.host);
+  if (data.customerDomain === null && globalThis.__SENTRY_DEV_UI) {
+    const domain = extractSlug(globalThis.location.host);
     if (domain) {
       data.customerDomain = {
         organizationUrl: `https://${domain.slug}.sentry.io`,
@@ -34,7 +34,7 @@ async function bootWithHydration() {
       };
     }
   }
-  window.__initialData = data;
+  globalThis.__initialData = data;
 
   bootApplication(data);
   preloadOrganizationData(data);
@@ -49,8 +49,8 @@ async function promiseRequest(url: string) {
       headers: {
         Accept: 'application/json; charset=utf-8',
         'Content-Type': 'application/json',
-        'sentry-trace': window.__initialData.initialTrace.sentry_trace,
-        baggage: window.__initialData.initialTrace.baggage,
+        'sentry-trace': globalThis.__initialData.initialTrace.sentry_trace,
+        baggage: globalThis.__initialData.initialTrace.baggage,
       },
       credentials: 'include',
       priority: 'high',
@@ -92,7 +92,7 @@ function preloadOrganizationData(config: Config) {
   }
   // When running in 'dev-ui' mode we need to use /region/$region instead of
   // subdomains so that webpack/vercel can proxy requests.
-  if (host && window.__SENTRY_DEV_UI) {
+  if (host && globalThis.__SENTRY_DEV_UI) {
     const domainpattern = /https?:\/\/([^.]*)\.sentry.io/;
     const domainmatch = host.match(domainpattern);
     if (domainmatch) {
@@ -105,7 +105,7 @@ function preloadOrganizationData(config: Config) {
   }
 
   const preloadPromises: Record<string, any> = {orgSlug: slug};
-  window.__sentry_preload = preloadPromises;
+  globalThis.__sentry_preload = preloadPromises;
   try {
     if (!slug) {
       return;
@@ -129,7 +129,7 @@ function preloadOrganizationData(config: Config) {
  * template.
  */
 export async function bootstrap() {
-  const bootstrapData = window.__initialData;
+  const bootstrapData = globalThis.__initialData;
 
   // If __initialData is not already set on the window, we are likely running in
   // pure SPA mode, meaning django is not serving our frontend application and we

--- a/static/app/bootstrap/initializeLocale.tsx
+++ b/static/app/bootstrap/initializeLocale.tsx
@@ -52,7 +52,7 @@ export async function initializeLocale(config: Config) {
 
   // Parse query string for `lang`
   try {
-    queryString = qs.parse(window.location.search) || {};
+    queryString = qs.parse(globalThis.location.search) || {};
   } catch {
     // ignore if this fails to parse
     // this can happen if we have an invalid query string

--- a/static/app/bootstrap/initializeSdk.spec.tsx
+++ b/static/app/bootstrap/initializeSdk.spec.tsx
@@ -17,8 +17,8 @@ const ERROR_MAP: Record<number, string | undefined> = {
 
 describe('initializeSdk', () => {
   beforeAll(() => {
-    window.__initialData = {
-      ...window.__initialData,
+    globalThis.__initialData = {
+      ...globalThis.__initialData,
       customerDomain: null,
     };
   });
@@ -28,7 +28,7 @@ describe('initializeSdk', () => {
   // so that we can have frontend to backend tracing.
   it('enables distributed tracing to sentry api endpoint', () => {
     initializeSdk({
-      ...window.__initialData,
+      ...globalThis.__initialData,
       apmSampling: 1,
       sentryConfig: {
         allowUrls: [],
@@ -47,7 +47,7 @@ describe('initializeSdk', () => {
 
   it('filters malformed [null,null] unhandled rejections', () => {
     initializeSdk({
-      ...window.__initialData,
+      ...globalThis.__initialData,
       apmSampling: 1,
       sentryConfig: {
         allowUrls: [],

--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -73,7 +73,7 @@ function isConsoleBannerMessage(message: string | undefined): boolean {
 // We check for `window.__initialData.user` property and only enable profiling
 // for Sentry employees. This is to prevent a Violation error being visible in
 // the browser console for our users.
-const shouldOverrideBrowserProfiling = window?.__initialData?.user?.isSuperuser;
+const shouldOverrideBrowserProfiling = globalThis?.__initialData?.user?.isSuperuser;
 function getSentryIntegrations() {
   const integrations = [
     Sentry.extraErrorDataIntegration({
@@ -249,11 +249,11 @@ export function initializeSdk(config: Config) {
   if (userIdentity) {
     Sentry.setUser(userIdentity);
   }
-  if (window.__SENTRY__VERSION) {
-    Sentry.setTag('sentry_version', window.__SENTRY__VERSION);
+  if (globalThis.__SENTRY__VERSION) {
+    Sentry.setTag('sentry_version', globalThis.__SENTRY__VERSION);
   }
 
-  const {customerDomain} = window.__initialData;
+  const {customerDomain} = globalThis.__initialData;
 
   if (customerDomain) {
     Sentry.setTag('isCustomerDomain', 'yes');

--- a/static/app/bootstrap/processInitQueue.spec.tsx
+++ b/static/app/bootstrap/processInitQueue.spec.tsx
@@ -17,7 +17,7 @@ import {SentryInitRenderReactComponent} from 'sentry/types/system';
 describe('processInitQueue', () => {
   describe('renderReact', () => {
     it('renders password strength input', async () => {
-      window.__onSentryInit = [
+      globalThis.__onSentryInit = [
         {
           name: 'passwordStrength',
           input: '#password',
@@ -47,7 +47,7 @@ describe('processInitQueue', () => {
     });
 
     it('renders indicators', async () => {
-      window.__onSentryInit = [
+      globalThis.__onSentryInit = [
         {
           component: SentryInitRenderReactComponent.INDICATORS,
           container: '#indicator-container',
@@ -62,7 +62,7 @@ describe('processInitQueue', () => {
       expect(await screen.findByText('Indicator Alert')).toBeInTheDocument();
     });
     it('renders system alerts', async () => {
-      window.__onSentryInit = [
+      globalThis.__onSentryInit = [
         {
           component: SentryInitRenderReactComponent.SYSTEM_ALERTS,
           container: '#system-alerts-container',
@@ -80,7 +80,7 @@ describe('processInitQueue', () => {
       expect(await screen.findByText('System Alert')).toBeInTheDocument();
     });
     it('renders setup wizard', async () => {
-      window.__onSentryInit = [
+      globalThis.__onSentryInit = [
         {
           component: SentryInitRenderReactComponent.SETUP_WIZARD,
           container: '#setup-wizard-container',
@@ -149,7 +149,7 @@ describe('processInitQueue', () => {
     });
 
     it('renders WebAuthn Assert', async () => {
-      window.__onSentryInit = [
+      globalThis.__onSentryInit = [
         {
           component: SentryInitRenderReactComponent.WEB_AUTHN_ASSSERT,
           container: '#webauthn-container',
@@ -170,7 +170,7 @@ describe('processInitQueue', () => {
     });
 
     it('renders superuser staff access form', async () => {
-      window.__onSentryInit = [
+      globalThis.__onSentryInit = [
         {
           component: SentryInitRenderReactComponent.SU_STAFF_ACCESS_FORM,
           container: '#su-staff-access-form-container',
@@ -200,7 +200,7 @@ describe('processInitQueue', () => {
       onReady: mock,
     } as const;
 
-    window.__onSentryInit = [init];
+    globalThis.__onSentryInit = [init];
 
     processInitQueue();
     expect(mock).toHaveBeenCalledTimes(1);
@@ -208,7 +208,7 @@ describe('processInitQueue', () => {
     processInitQueue();
     expect(mock).toHaveBeenCalledTimes(1);
 
-    window.__onSentryInit.push(init);
+    globalThis.__onSentryInit.push(init);
     expect(mock).toHaveBeenCalledTimes(2);
   });
 
@@ -220,7 +220,7 @@ describe('processInitQueue', () => {
       onReady: mock,
     } as const;
 
-    window.__onSentryInit.push(init);
+    globalThis.__onSentryInit.push(init);
     expect(mock).toHaveBeenCalledTimes(1);
 
     processInitQueue();

--- a/static/app/bootstrap/processInitQueue.tsx
+++ b/static/app/bootstrap/processInitQueue.tsx
@@ -156,19 +156,19 @@ export async function processInitQueue() {
   // their plugins ASAP, as `SentryApp` will be loaded async and will require
   // callbacks to access it, instead of via `window` global.
   if (
-    typeof window.__onSentryInit !== 'undefined' &&
-    !Array.isArray(window.__onSentryInit)
+    typeof globalThis.__onSentryInit !== 'undefined' &&
+    !Array.isArray(globalThis.__onSentryInit)
   ) {
     return;
   }
 
-  const queued = window.__onSentryInit;
+  const queued = globalThis.__onSentryInit;
 
   // Stub future calls of `window.__onSentryInit.push` so that it is
   // processed immediately (since bundle is loaded at this point and no
   // longer needs to act as a queue)
   //
-  window.__onSentryInit = {
+  globalThis.__onSentryInit = {
     push: processItem,
   };
 

--- a/static/app/bootstrap/renderMain.tsx
+++ b/static/app/bootstrap/renderMain.tsx
@@ -14,7 +14,7 @@ export function renderMain() {
           'An unencoded "%" has appeared, it is super effective! (See https://github.com/ReactTraining/history/issues/505)'
         )
       );
-      window.location.assign(window.location.pathname);
+      globalThis.location.assign(globalThis.location.pathname);
     }
   }
 }

--- a/static/app/components/assistant/guideAnchor.tsx
+++ b/static/app/components/assistant/guideAnchor.tsx
@@ -127,7 +127,7 @@ function BaseGuideAnchor({
         if (currentGuide) {
           dismissGuide(currentGuide.guide, step, orgId);
         }
-        window.location.hash = '';
+        globalThis.location.hash = '';
       }}
       actions={
         <Grid flow="column" align="center" gap="md">

--- a/static/app/components/autoComplete.tsx
+++ b/static/app/components/autoComplete.tsx
@@ -180,8 +180,8 @@ export class AutoComplete<T extends Item> extends Component<
 
   componentWillUnmount() {
     this._mounted = false;
-    window.clearTimeout(this.blurTimeout);
-    window.clearTimeout(this.cancelCloseTimeout);
+    globalThis.clearTimeout(this.blurTimeout);
+    globalThis.clearTimeout(this.cancelCloseTimeout);
   }
 
   private _mounted = false;
@@ -287,8 +287,8 @@ export class AutoComplete<T extends Item> extends Component<
    */
   makehandleInputBlur<E extends HTMLInputElement>(onBlur: GetInputArgs<E>['onBlur']) {
     return (e: React.FocusEvent<E>) => {
-      window.clearTimeout(this.blurTimeout);
-      this.blurTimeout = window.setTimeout(() => {
+      globalThis.clearTimeout(this.blurTimeout);
+      this.blurTimeout = globalThis.setTimeout(() => {
         this.closeMenu();
         onBlur?.(e);
       }, 200);
@@ -300,13 +300,13 @@ export class AutoComplete<T extends Item> extends Component<
     // Otherwise, it's possible that this gets fired multiple times
     // e.g. click outside triggers closeMenu and at the same time input gets blurred, so
     // a timer is set to close the menu
-    window.clearTimeout(this.blurTimeout);
+    globalThis.clearTimeout(this.blurTimeout);
 
     // Wait until the current macrotask completes, in the case that the click
     // happened on a hovercard or some other element rendered outside of the
     // autocomplete, but controlled by the existence of the autocomplete, we
     // need to ensure any click handlers are run.
-    await new Promise(resolve => window.setTimeout(resolve));
+    await new Promise(resolve => globalThis.setTimeout(resolve));
 
     this.closeMenu();
   };
@@ -352,7 +352,7 @@ export class AutoComplete<T extends Item> extends Component<
         return;
       }
 
-      window.clearTimeout(this.blurTimeout);
+      globalThis.clearTimeout(this.blurTimeout);
 
       this.setState({highlightedIndex: index});
       this.handleSelect(item, e);
@@ -369,10 +369,10 @@ export class AutoComplete<T extends Item> extends Component<
   }
 
   handleMenuMouseDown = () => {
-    window.clearTimeout(this.cancelCloseTimeout);
+    globalThis.clearTimeout(this.cancelCloseTimeout);
     // Cancel close menu from input blur (mouseDown event can occur before input blur :()
-    this.cancelCloseTimeout = window.setTimeout(() => {
-      window.clearTimeout(this.blurTimeout);
+    this.cancelCloseTimeout = globalThis.setTimeout(() => {
+      globalThis.clearTimeout(this.blurTimeout);
     });
   };
 

--- a/static/app/components/avatarChooser/useUploader.tsx
+++ b/static/app/components/avatarChooser/useUploader.tsx
@@ -16,7 +16,7 @@ export function useUploader({onSelect, minImageSize}: UseUploaderOptions) {
 
   const cleanupObjectUrl = useCallback(() => {
     if (objectUrl) {
-      window.URL.revokeObjectURL(objectUrl);
+      globalThis.URL.revokeObjectURL(objectUrl);
     }
   }, [objectUrl]);
 
@@ -53,7 +53,7 @@ export function useUploader({onSelect, minImageSize}: UseUploaderOptions) {
       addErrorMessage(t('That is not a supported file type.'));
       return;
     }
-    const url = window.URL.createObjectURL(file);
+    const url = globalThis.URL.createObjectURL(file);
     const {height, width} = await getImageHeightAndWidth(url);
     const sizeValidation = validateSize(height, width);
 

--- a/static/app/components/carousel.spec.tsx
+++ b/static/app/components/carousel.spec.tsx
@@ -7,7 +7,7 @@ describe('Carousel', () => {
     entries: Array<Partial<IntersectionObserverEntry>>
   ) => void = jest.fn();
 
-  window.IntersectionObserver = class IntersectionObserver {
+  globalThis.IntersectionObserver = class IntersectionObserver {
     root = null;
     rootMargin = '';
     scrollMargin = '';

--- a/static/app/components/checkInTimeline/timelineCursor.tsx
+++ b/static/app/components/checkInTimeline/timelineCursor.tsx
@@ -61,7 +61,7 @@ function useTimelineCursor<E extends HTMLElement>({
   const handleMouseMove = useCallback(
     (e: MouseEvent) => {
       if (rafIdRef.current !== null) {
-        window.cancelAnimationFrame(rafIdRef.current);
+        globalThis.cancelAnimationFrame(rafIdRef.current);
       }
 
       if (containerRef.current === null) {
@@ -89,7 +89,7 @@ function useTimelineCursor<E extends HTMLElement>({
         setIsVisible(isInsideContainer);
       }
 
-      rafIdRef.current = window.requestAnimationFrame(() => {
+      rafIdRef.current = globalThis.requestAnimationFrame(() => {
         if (containerRef.current === null || labelRef.current === null) {
           return;
         }
@@ -113,12 +113,12 @@ function useTimelineCursor<E extends HTMLElement>({
 
   useEffect(() => {
     if (enabled) {
-      window.addEventListener('mousemove', handleMouseMove);
+      globalThis.addEventListener('mousemove', handleMouseMove);
     } else {
       setIsVisible(false);
     }
 
-    return () => window.removeEventListener('mousemove', handleMouseMove);
+    return () => globalThis.removeEventListener('mousemove', handleMouseMove);
   }, [enabled, handleMouseMove]);
 
   const labelOverlay = (

--- a/static/app/components/checkInTimeline/timelineZoom.spec.tsx
+++ b/static/app/components/checkInTimeline/timelineZoom.spec.tsx
@@ -24,7 +24,7 @@ beforeEach(() => {
   document.elementsFromPoint = () => [];
 
   jest
-    .spyOn(window, 'requestAnimationFrame')
+    .spyOn(globalThis, 'requestAnimationFrame')
     .mockImplementation((callback: FrameRequestCallback): number => {
       callback(0);
       return 0;
@@ -32,7 +32,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  jest.mocked(window.requestAnimationFrame).mockRestore();
+  jest.mocked(globalThis.requestAnimationFrame).mockRestore();
 });
 
 function setupTestComponent() {

--- a/static/app/components/checkInTimeline/timelineZoom.tsx
+++ b/static/app/components/checkInTimeline/timelineZoom.tsx
@@ -33,7 +33,7 @@ function useTimelineZoom<E extends HTMLElement>({enabled = true, onSelect}: Opti
   const handleMouseMove = useCallback(
     (e: MouseEvent) => {
       if (rafIdRef.current !== null) {
-        window.cancelAnimationFrame(rafIdRef.current);
+        globalThis.cancelAnimationFrame(rafIdRef.current);
       }
 
       if (containerRef.current === null) {
@@ -46,7 +46,7 @@ function useTimelineZoom<E extends HTMLElement>({enabled = true, onSelect}: Opti
 
       const containerRect = containerRef.current.getBoundingClientRect();
 
-      rafIdRef.current = window.requestAnimationFrame(() => {
+      rafIdRef.current = globalThis.requestAnimationFrame(() => {
         if (containerRef.current === null) {
           return;
         }
@@ -133,17 +133,17 @@ function useTimelineZoom<E extends HTMLElement>({enabled = true, onSelect}: Opti
 
   useEffect(() => {
     if (enabled) {
-      window.addEventListener('mousemove', handleMouseMove);
-      window.addEventListener('mousedown', handleMouseDown);
-      window.addEventListener('mouseup', handleMouseUp);
+      globalThis.addEventListener('mousemove', handleMouseMove);
+      globalThis.addEventListener('mousedown', handleMouseDown);
+      globalThis.addEventListener('mouseup', handleMouseUp);
     } else {
       setIsActive(false);
     }
 
     return () => {
-      window.removeEventListener('mousemove', handleMouseMove);
-      window.removeEventListener('mousedown', handleMouseDown);
-      window.removeEventListener('mouseup', handleMouseUp);
+      globalThis.removeEventListener('mousemove', handleMouseMove);
+      globalThis.removeEventListener('mousedown', handleMouseDown);
+      globalThis.removeEventListener('mouseup', handleMouseUp);
     };
   }, [enabled, handleMouseMove, handleMouseDown, handleMouseUp]);
 

--- a/static/app/components/clippedBox.spec.tsx
+++ b/static/app/components/clippedBox.spec.tsx
@@ -39,7 +39,7 @@ class MockResizeObserver {
 }
 
 function mockGetBoundingClientRect({height}: {height: number}) {
-  window.HTMLDivElement.prototype.getBoundingClientRect = () =>
+  globalThis.HTMLDivElement.prototype.getBoundingClientRect = () =>
     ({
       bottom: 0,
       height,
@@ -51,20 +51,20 @@ function mockGetBoundingClientRect({height}: {height: number}) {
 }
 
 function clearMockGetBoundingClientRect() {
-  window.HTMLDivElement.prototype.getBoundingClientRect =
-    window.HTMLElement.prototype.getBoundingClientRect;
+  globalThis.HTMLDivElement.prototype.getBoundingClientRect =
+    globalThis.HTMLElement.prototype.getBoundingClientRect;
 }
 
 describe('clipped box', () => {
   describe.each([[true], [false]])('with resize observer = %s', enableResizeObserver => {
     beforeEach(() => {
       // @ts-expect-error override readonly property
-      window.ResizeObserver = enableResizeObserver ? MockResizeObserver : undefined;
+      globalThis.ResizeObserver = enableResizeObserver ? MockResizeObserver : undefined;
     });
 
     afterEach(() => {
       // @ts-expect-error override readonly property
-      window.ResizeObserver = null;
+      globalThis.ResizeObserver = null;
       clearMockGetBoundingClientRect();
     });
 

--- a/static/app/components/clippedBox.tsx
+++ b/static/app/components/clippedBox.tsx
@@ -270,7 +270,7 @@ export function ClippedBox(props: ClippedBoxProps) {
         setClipped(_clipped);
       };
 
-      if (supportsResizeObserver(window.ResizeObserver)) {
+      if (supportsResizeObserver(globalThis.ResizeObserver)) {
         observerRef.current = new ResizeObserver(onResize);
         observerRef.current.observe(contentRef.current);
         return;

--- a/static/app/components/commandPalette/ui/commandPalette.spec.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.spec.tsx
@@ -115,7 +115,7 @@ describe('CommandPalette', () => {
 
   it('shift-enter on an internal link opens in a new tab and closes modal', async () => {
     const closeSpy = jest.spyOn(modalActions, 'closeModal');
-    const openSpy = jest.spyOn(window, 'open').mockReturnValue(null);
+    const openSpy = jest.spyOn(globalThis, 'open').mockReturnValue(null);
 
     render(
       <GlobalActionsComponent>

--- a/static/app/components/commandPalette/ui/commandPalette.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.tsx
@@ -292,12 +292,12 @@ export function CommandPalette(props: CommandPaletteProps) {
       modifierKeysRef.current = {shiftKey: event.shiftKey};
     };
 
-    window.addEventListener('keydown', handleKeyDown);
-    window.addEventListener('keyup', handleKeyUp);
+    globalThis.addEventListener('keydown', handleKeyDown);
+    globalThis.addEventListener('keyup', handleKeyUp);
 
     return () => {
-      window.removeEventListener('keydown', handleKeyDown);
-      window.removeEventListener('keyup', handleKeyUp);
+      globalThis.removeEventListener('keydown', handleKeyDown);
+      globalThis.removeEventListener('keyup', handleKeyUp);
     };
   }, []);
 

--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -101,7 +101,7 @@ export function GlobalCommandPaletteActions() {
   const {mutate: exitSuperuser} = useMutation({
     mutationFn: () =>
       QUERY_API_CLIENT.requestPromise('/auth/superuser/', {method: 'DELETE'}),
-    onSuccess: () => window.location.reload(),
+    onSuccess: () => globalThis.location.reload(),
   });
 
   const {data: starredSavedQueries = []} = useGetSavedQueries({

--- a/static/app/components/commandPalette/ui/locationUtils.ts
+++ b/static/app/components/commandPalette/ui/locationUtils.ts
@@ -13,7 +13,7 @@ export function getLocationHref(to: LocationDescriptor): string {
 }
 
 export function isExternalLocation(to: LocationDescriptor): boolean {
-  const currentUrl = new URL(window.location.href);
+  const currentUrl = new URL(globalThis.location.href);
   const targetUrl = new URL(getLocationHref(to), currentUrl.href);
   return targetUrl.origin !== currentUrl.origin;
 }

--- a/static/app/components/commandPalette/ui/modal.spec.tsx
+++ b/static/app/components/commandPalette/ui/modal.spec.tsx
@@ -166,7 +166,7 @@ describe('CommandPaletteModal', () => {
 
   it('opens external links in a new tab', async () => {
     const closeModalSpy = jest.fn();
-    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+    const openSpy = jest.spyOn(globalThis, 'open').mockImplementation(() => null);
 
     render(
       <CommandPaletteProvider>
@@ -191,7 +191,7 @@ describe('CommandPaletteModal', () => {
 
   it('opens internal links in a new tab when shift-enter is used', async () => {
     const closeModalSpy = jest.fn();
-    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+    const openSpy = jest.spyOn(globalThis, 'open').mockImplementation(() => null);
 
     render(
       <CommandPaletteProvider>

--- a/static/app/components/contextPickerModal.tsx
+++ b/static/app/components/contextPickerModal.tsx
@@ -159,7 +159,7 @@ function ContextPickerContent({
   });
 
   useEffect(() => {
-    return () => window.clearTimeout(onFinishTimeoutRef.current);
+    return () => globalThis.clearTimeout(onFinishTimeoutRef.current);
   }, []);
 
   const navigateFinish = useCallback(
@@ -176,7 +176,7 @@ function ContextPickerContent({
         project: projects.find(p => p.slug === projectSlug)?.id,
         teamId: teamSlug ?? undefined,
       });
-      window.clearTimeout(onFinishTimeoutRef.current);
+      globalThis.clearTimeout(onFinishTimeoutRef.current);
       onFinishTimeoutRef.current =
         onFinishRef.current(
           typeof np === 'string' ? newPathname : {...np, pathname: newPathname}

--- a/static/app/components/core/avatar/useAvatar.ts
+++ b/static/app/components/core/avatar/useAvatar.ts
@@ -88,7 +88,10 @@ function useImageSrc(definition?: ImageDefinition): {
   const {data: avatarHash} = useQuery({
     queryKey: ['gravatar', trimmedGravatarId],
     queryFn: () => {
-      if (!trimmedGravatarId || typeof window.crypto?.subtle?.digest === 'undefined') {
+      if (
+        !trimmedGravatarId ||
+        typeof globalThis.crypto?.subtle?.digest === 'undefined'
+      ) {
         return null;
       }
       return hashGravatarId(trimmedGravatarId).catch(err => {
@@ -147,7 +150,7 @@ function useImageSrc(definition?: ImageDefinition): {
 async function hashGravatarId(gravatarId: string): Promise<string> {
   const encoder = new TextEncoder();
   const data = encoder.encode(gravatarId);
-  const hash = await window.crypto.subtle.digest('SHA-256', data);
+  const hash = await globalThis.crypto.subtle.digest('SHA-256', data);
   return Array.from(new Uint8Array(hash))
     .map(b => b.toString(16).padStart(2, '0'))
     .join('');

--- a/static/app/components/core/compactSelect/control.tsx
+++ b/static/app/components/core/compactSelect/control.tsx
@@ -47,8 +47,8 @@ import {getSearchConfig} from './utils';
 // will defer the focus call until the next frame, after the browser and react
 // have had a chance to update the DOM, splitting the perf cost across frames.
 function nextFrameCallback(cb: () => void) {
-  if ('requestAnimationFrame' in window) {
-    window.requestAnimationFrame(() => cb());
+  if ('requestAnimationFrame' in globalThis) {
+    globalThis.requestAnimationFrame(() => cb());
   } else {
     setTimeout(() => {
       cb();

--- a/static/app/components/core/drawer/useDrawerResizing.tsx
+++ b/static/app/components/core/drawer/useDrawerResizing.tsx
@@ -107,16 +107,17 @@ export function useDrawerResizing({
       panel.setAttribute('data-resizing', '');
       initialMousePositionRef.current = e.clientX;
 
-      const viewportWidth = typeof window === 'undefined' ? 1000 : window.innerWidth;
+      const viewportWidth =
+        typeof globalThis.window === 'undefined' ? 1000 : window.innerWidth;
 
       const handleMouseMove = (moveEvent: MouseEvent) => {
         moveEvent.preventDefault();
 
         if (rafIdRef.current !== null) {
-          window.cancelAnimationFrame(rafIdRef.current);
+          globalThis.cancelAnimationFrame(rafIdRef.current);
         }
 
-        rafIdRef.current = window.requestAnimationFrame(() => {
+        rafIdRef.current = globalThis.requestAnimationFrame(() => {
           if (!panel || !handle || initialMousePositionRef.current === null) {
             return;
           }
@@ -140,7 +141,7 @@ export function useDrawerResizing({
 
       const handleMouseUp = () => {
         if (rafIdRef.current !== null) {
-          window.cancelAnimationFrame(rafIdRef.current);
+          globalThis.cancelAnimationFrame(rafIdRef.current);
           rafIdRef.current = null;
         }
 
@@ -151,7 +152,7 @@ export function useDrawerResizing({
         if (panel) {
           panel.removeAttribute('data-resizing');
           // Get the computed width considering min/max constraints and save to localStorage
-          const computedStyle = window.getComputedStyle(panel);
+          const computedStyle = globalThis.getComputedStyle(panel);
           const widthValue = (parseFloat(computedStyle.width) / viewportWidth) * 100;
           setPersistedWidthPercent(widthValue);
         }
@@ -169,7 +170,7 @@ export function useDrawerResizing({
   useLayoutEffect(() => {
     return () => {
       if (rafIdRef.current !== null) {
-        window.cancelAnimationFrame(rafIdRef.current);
+        globalThis.cancelAnimationFrame(rafIdRef.current);
       }
     };
   }, []);

--- a/static/app/components/core/form/field/baseField.spec.tsx
+++ b/static/app/components/core/form/field/baseField.spec.tsx
@@ -300,7 +300,7 @@ describe('Compact variant a11y', () => {
     // The element should have visually hidden styles (checking common patterns)
     expect(hintElement).toBeInTheDocument();
     // React Aria's VisuallyHidden uses specific styles to hide content
-    const styles = window.getComputedStyle(hintElement!);
+    const styles = globalThis.getComputedStyle(hintElement!);
     expect(styles.position).toBe('absolute');
     expect(styles.width).toBe('1px');
     expect(styles.height).toBe('1px');

--- a/static/app/components/core/inspector.spec.tsx
+++ b/static/app/components/core/inspector.spec.tsx
@@ -27,7 +27,7 @@ describe('SentryComponentInspector', () => {
     const mockUser = UserFixture();
     ConfigStore.set('user', mockUser);
 
-    const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+    const addEventListenerSpy = jest.spyOn(globalThis, 'addEventListener');
 
     render(
       <div>
@@ -82,7 +82,7 @@ describe('SentryComponentInspector', () => {
     );
 
     await waitFor(() => {
-      window.dispatchEvent(new Event('devtools.toggle_component_inspector'));
+      globalThis.dispatchEvent(new Event('devtools.toggle_component_inspector'));
     });
     await userEvent.hover(screen.getByText('Test Component Content'));
     expect(await screen.findByText('Hovered Components')).toBeInTheDocument();

--- a/static/app/components/core/inspector.tsx
+++ b/static/app/components/core/inspector.tsx
@@ -102,7 +102,7 @@ export function SentryComponentInspector() {
       return () => {};
     }
     const onMouseMove = (event: MouseEvent & {preventTrace?: boolean}) => {
-      window.requestAnimationFrame(() => {
+      globalThis.requestAnimationFrame(() => {
         if (tooltipRef.current) {
           tooltipPositionRef.current = {
             ...computeTooltipPosition(event, tooltipRef.current),
@@ -261,11 +261,11 @@ export function SentryComponentInspector() {
       document.removeEventListener('pointerdown', handleClickOutside);
     }
 
-    window.addEventListener('devtools.toggle_component_inspector', onInspectorToggle);
+    globalThis.addEventListener('devtools.toggle_component_inspector', onInspectorToggle);
     window.addEventListener('scroll', onScroll, {passive: true});
 
     return () => {
-      window.removeEventListener(
+      globalThis.removeEventListener(
         'devtools.toggle_component_inspector',
         onInspectorToggle
       );
@@ -507,7 +507,7 @@ function MenuItem(props: {
   const currentTarget = useRef<Node | null>(null);
   useLayoutEffect(() => {
     const listener = (e: MouseEvent) => {
-      window.requestAnimationFrame(() => {
+      globalThis.requestAnimationFrame(() => {
         currentTarget.current = e.target as Node;
         if (!currentTarget.current) {
           return;
@@ -703,7 +703,7 @@ function computeTooltipPosition(
   {x, y}: {x: number; y: number},
   container: HTMLDivElement
 ): {left: number; top: number} {
-  const {innerWidth, innerHeight} = window;
+  const {innerWidth, innerHeight} = globalThis;
   let top = y + CURSOR_OFFSET_TOP;
   let left = x + CURSOR_OFFSET_LEFT;
 

--- a/static/app/components/core/layout/styles.spec.tsx
+++ b/static/app/components/core/layout/styles.spec.tsx
@@ -32,9 +32,9 @@ const mockMatchMedia = (matches: boolean) => ({
 const setupMediaQueries = (
   breakpointMatches: Partial<Record<BreakpointSize, boolean>>
 ) => {
-  const originalMatchMedia = window.matchMedia;
+  const originalMatchMedia = globalThis.matchMedia;
 
-  window.matchMedia = jest.fn((query: string) => {
+  globalThis.matchMedia = jest.fn((query: string) => {
     // Extract breakpoint from media query
     const breakpointMatch = query.match(/min-width:\s*(.+?)\)/);
     const breakpointValue = breakpointMatch?.[1];
@@ -52,7 +52,7 @@ const setupMediaQueries = (
   });
 
   return () => {
-    window.matchMedia = originalMatchMedia;
+    globalThis.matchMedia = originalMatchMedia;
   };
 };
 
@@ -264,7 +264,7 @@ describe('useActiveBreakpoint', () => {
 
   it('sets up media queries for all breakpoints', () => {
     const matchMediaSpy = jest.fn(() => mockMatchMedia(false));
-    window.matchMedia = matchMediaSpy;
+    globalThis.matchMedia = matchMediaSpy;
 
     renderHookWithProviders(() => useActiveBreakpoint());
 
@@ -301,7 +301,7 @@ describe('useActiveBreakpoint', () => {
     const mockQueries: Record<string, any> = {};
 
     // Set up mock that tracks listeners
-    window.matchMedia = jest.fn((query: string) => {
+    globalThis.matchMedia = jest.fn((query: string) => {
       const mockQuery = {
         matches: query === `(min-width: ${theme.breakpoints.md})`,
         media: query,
@@ -363,9 +363,9 @@ describe('useActiveBreakpoint', () => {
     } as unknown as AbortController;
 
     const mockAbortController = jest.fn(() => abortController);
-    window.AbortController = mockAbortController;
+    globalThis.AbortController = mockAbortController;
 
-    window.matchMedia = jest.fn(() => ({
+    globalThis.matchMedia = jest.fn(() => ({
       matches: false,
       media: '',
       addEventListener,

--- a/static/app/components/core/layout/styles.tsx
+++ b/static/app/components/core/layout/styles.tsx
@@ -274,7 +274,7 @@ export function useActiveBreakpoint(): BreakpointSize {
   const theme = useTheme();
 
   const mediaQueries = useMemo(() => {
-    if (typeof window === 'undefined' || !window.matchMedia) {
+    if (typeof globalThis.window === 'undefined' || !globalThis.matchMedia) {
       return [];
     }
 
@@ -290,7 +290,7 @@ export function useActiveBreakpoint(): BreakpointSize {
 
       queries.push({
         breakpoint: bp,
-        query: window.matchMedia(`(min-width: ${theme.breakpoints[bp]})`),
+        query: globalThis.matchMedia(`(min-width: ${theme.breakpoints[bp]})`),
       });
     }
 

--- a/static/app/components/core/trackingContext.tsx
+++ b/static/app/components/core/trackingContext.tsx
@@ -3,7 +3,7 @@ import {createContext, useContext} from 'react';
 import type {DO_NOT_USE_ButtonProps as ButtonProps} from './button/types';
 
 const defaultButtonTracking = (props: ButtonProps) => {
-  const hasAnalyticsDebug = window.localStorage?.getItem('DEBUG_ANALYTICS') === '1';
+  const hasAnalyticsDebug = globalThis.localStorage?.getItem('DEBUG_ANALYTICS') === '1';
   return () => {
     const hasCustomAnalytics =
       props.analyticsEventName || props.analyticsEventKey || props.analyticsParams;

--- a/static/app/components/core/useScrollLock.spec.tsx
+++ b/static/app/components/core/useScrollLock.spec.tsx
@@ -159,7 +159,7 @@ describe('useScrollLock', () => {
     const originalClientWidth = document.body.clientWidth;
     const originalScrollX = window.scrollX;
     const originalScrollY = window.scrollY;
-    Object.defineProperty(window, 'innerWidth', {
+    Object.defineProperty(globalThis, 'innerWidth', {
       configurable: true,
       value: 1200,
     });
@@ -167,15 +167,15 @@ describe('useScrollLock', () => {
       configurable: true,
       value: 1180,
     });
-    Object.defineProperty(window, 'scrollX', {
+    Object.defineProperty(globalThis, 'scrollX', {
       configurable: true,
       value: scrollX,
     });
-    Object.defineProperty(window, 'scrollY', {
+    Object.defineProperty(globalThis, 'scrollY', {
       configurable: true,
       value: scrollY,
     });
-    const scrollToSpy = jest.spyOn(window, 'scrollTo').mockImplementation(() => {});
+    const scrollToSpy = jest.spyOn(globalThis, 'scrollTo').mockImplementation(() => {});
 
     const {result} = renderHook(() => useScrollLock(document.body));
 
@@ -202,7 +202,7 @@ describe('useScrollLock', () => {
     jest.runAllTimers();
     expect(scrollToSpy).toHaveBeenCalledWith(scrollX, scrollY);
 
-    Object.defineProperty(window, 'innerWidth', {
+    Object.defineProperty(globalThis, 'innerWidth', {
       configurable: true,
       value: originalInnerWidth,
     });
@@ -210,11 +210,11 @@ describe('useScrollLock', () => {
       configurable: true,
       value: originalClientWidth,
     });
-    Object.defineProperty(window, 'scrollX', {
+    Object.defineProperty(globalThis, 'scrollX', {
       configurable: true,
       value: originalScrollX,
     });
-    Object.defineProperty(window, 'scrollY', {
+    Object.defineProperty(globalThis, 'scrollY', {
       configurable: true,
       value: originalScrollY,
     });
@@ -225,7 +225,7 @@ describe('useScrollLock', () => {
     const originalInnerWidth = window.innerWidth;
     const originalClientWidth = document.body.clientWidth;
     const originalScrollY = window.scrollY;
-    Object.defineProperty(window, 'innerWidth', {
+    Object.defineProperty(globalThis, 'innerWidth', {
       configurable: true,
       value: 1200,
     });
@@ -233,11 +233,11 @@ describe('useScrollLock', () => {
       configurable: true,
       value: 1180,
     });
-    Object.defineProperty(window, 'scrollY', {
+    Object.defineProperty(globalThis, 'scrollY', {
       configurable: true,
       value: 0,
     });
-    const scrollToSpy = jest.spyOn(window, 'scrollTo').mockImplementation(() => {});
+    const scrollToSpy = jest.spyOn(globalThis, 'scrollTo').mockImplementation(() => {});
 
     // Set existing paddingRight on body
     document.body.style.paddingRight = '10px';
@@ -255,7 +255,7 @@ describe('useScrollLock', () => {
     expect(document.body).toHaveStyle({paddingRight: '10px'});
 
     document.body.style.paddingRight = '';
-    Object.defineProperty(window, 'innerWidth', {
+    Object.defineProperty(globalThis, 'innerWidth', {
       configurable: true,
       value: originalInnerWidth,
     });
@@ -263,7 +263,7 @@ describe('useScrollLock', () => {
       configurable: true,
       value: originalClientWidth,
     });
-    Object.defineProperty(window, 'scrollY', {
+    Object.defineProperty(globalThis, 'scrollY', {
       configurable: true,
       value: originalScrollY,
     });

--- a/static/app/components/deprecatedAsyncComponent.tsx
+++ b/static/app/components/deprecatedAsyncComponent.tsx
@@ -39,7 +39,7 @@ function wrapErrorHandling<T extends any[], U>(
     } catch (error: any) {
       // eslint-disable-next-line no-console
       console.error(error);
-      window.setTimeout(() => {
+      globalThis.setTimeout(() => {
         throw error;
       });
       component.setState({error});

--- a/static/app/components/deprecatedDropdownMenu.tsx
+++ b/static/app/components/deprecatedDropdownMenu.tsx
@@ -194,7 +194,7 @@ export function DropdownMenu({
       // happened on a hovercard or some other element rendered outside of the
       // dropdown, but controlled by the existence of the dropdown, we need to
       // ensure any click handlers are run.
-      await new Promise(resolve => window.setTimeout(resolve));
+      await new Promise(resolve => globalThis.setTimeout(resolve));
 
       handleClose();
     },
@@ -218,7 +218,7 @@ export function DropdownMenu({
         setIsOpenState(true);
       }
 
-      window.clearTimeout(mouseLeaveTimeout.current);
+      globalThis.clearTimeout(mouseLeaveTimeout.current);
 
       // If we always render menu (e.g. DropdownLink), then add the check click outside handlers when we open the menu
       // instead of when the menu component mounts. Otherwise we will have many click handlers attached on initial load.
@@ -248,8 +248,8 @@ export function DropdownMenu({
           dropdownMenu.current &&
           (!(toElement instanceof Element) || !dropdownMenu.current.contains(toElement))
         ) {
-          window.clearTimeout(mouseLeaveTimeout.current);
-          mouseLeaveTimeout.current = window.setTimeout(() => {
+          globalThis.clearTimeout(mouseLeaveTimeout.current);
+          mouseLeaveTimeout.current = globalThis.setTimeout(() => {
             handleClose(e);
           }, MENU_CLOSE_DELAY);
         }
@@ -310,16 +310,16 @@ export function DropdownMenu({
             return;
           }
 
-          window.clearTimeout(mouseEnterTimeout.current);
-          window.clearTimeout(mouseLeaveTimeout.current);
+          globalThis.clearTimeout(mouseEnterTimeout.current);
+          globalThis.clearTimeout(mouseLeaveTimeout.current);
 
-          mouseEnterTimeout.current = window.setTimeout(() => {
+          mouseEnterTimeout.current = globalThis.setTimeout(() => {
             handleOpen(e);
           }, MENU_CLOSE_DELAY);
         },
         onMouseLeave: (e: React.MouseEvent<E>) => {
-          window.clearTimeout(mouseEnterTimeout.current);
-          window.clearTimeout(mouseLeaveTimeout.current);
+          globalThis.clearTimeout(mouseEnterTimeout.current);
+          globalThis.clearTimeout(mouseLeaveTimeout.current);
 
           handleMouseLeave(e);
         },
@@ -371,7 +371,7 @@ export function DropdownMenu({
         onMouseEnter: () => {
           // There is a delay before closing a menu on mouse leave, cancel this
           // action if mouse enters menu again
-          window.clearTimeout(mouseLeaveTimeout.current);
+          globalThis.clearTimeout(mouseLeaveTimeout.current);
         },
         onMouseLeave: handleMouseLeave,
         onClick: handleDropdownMenuClick,
@@ -389,8 +389,8 @@ export function DropdownMenu({
   // Cleanup effect (equivalent to componentWillUnmount)
   useEffect(() => {
     return () => {
-      window.clearTimeout(mouseLeaveTimeout.current);
-      window.clearTimeout(mouseEnterTimeout.current);
+      globalThis.clearTimeout(mouseLeaveTimeout.current);
+      globalThis.clearTimeout(mouseEnterTimeout.current);
     };
   }, []);
 

--- a/static/app/components/events/autofix/FlyingLinesEffect.tsx
+++ b/static/app/components/events/autofix/FlyingLinesEffect.tsx
@@ -20,7 +20,7 @@ export function FlyingLinesEffect({targetElement}: {targetElement: HTMLElement |
       let currentElement = element.parentElement;
 
       while (currentElement) {
-        const overflow = window.getComputedStyle(currentElement).overflow;
+        const overflow = globalThis.getComputedStyle(currentElement).overflow;
         if (overflow.includes('scroll') || overflow.includes('auto')) {
           scrollParents.push(currentElement);
         }
@@ -53,7 +53,7 @@ export function FlyingLinesEffect({targetElement}: {targetElement: HTMLElement |
 
     rafRef.current = requestAnimationFrame(updatePosition);
 
-    const scrollElements = [window, ...getScrollParents(targetElement)];
+    const scrollElements = [globalThis, ...getScrollParents(targetElement)];
     scrollElements.forEach(element => {
       element.addEventListener('scroll', updatePosition, {passive: true});
     });

--- a/static/app/components/events/autofix/autofixChanges.tsx
+++ b/static/app/components/events/autofix/autofixChanges.tsx
@@ -201,7 +201,7 @@ export function AutofixChanges({
       const clickEvent = new MouseEvent('click', {
         bubbles: true,
         cancelable: true,
-        view: window,
+        view: globalThis,
       });
       firstChangeRef.current.dispatchEvent(clickEvent);
     }

--- a/static/app/components/events/autofix/autofixHighlightPopup.tsx
+++ b/static/app/components/events/autofix/autofixHighlightPopup.tsx
@@ -607,7 +607,7 @@ export function AutofixHighlightPopup(props: Props) {
     popupObserver.observe(popupRef.current);
 
     // Track scroll events
-    const scrollElements = [window, ...getScrollParents(referenceElement)];
+    const scrollElements = [globalThis, ...getScrollParents(referenceElement)];
     scrollElements.forEach(element => {
       element.addEventListener('scroll', updatePosition, {passive: true});
     });
@@ -878,7 +878,7 @@ function getScrollParents(element: HTMLElement): Element[] {
   let currentElement = element.parentElement;
 
   while (currentElement) {
-    const overflow = window.getComputedStyle(currentElement).overflow;
+    const overflow = globalThis.getComputedStyle(currentElement).overflow;
     if (overflow.includes('scroll') || overflow.includes('auto')) {
       scrollParents.push(currentElement);
     }

--- a/static/app/components/events/autofix/autofixOutputStream.tsx
+++ b/static/app/components/events/autofix/autofixOutputStream.tsx
@@ -71,14 +71,14 @@ function StreamContentText({stream}: {stream: string}) {
 
     let intervalId: number | undefined;
     if (currentIndexRef.current < combinedText.length) {
-      intervalId = window.setInterval(() => {
+      intervalId = globalThis.setInterval(() => {
         if (currentIndexRef.current < combinedText.length) {
           startTransition(() => {
             setDisplayedText(combinedText.slice(0, currentIndexRef.current + 1));
           });
           currentIndexRef.current++;
         } else {
-          window.clearInterval(intervalId);
+          globalThis.clearInterval(intervalId);
           intervalId = undefined;
         }
       }, 1);
@@ -86,7 +86,7 @@ function StreamContentText({stream}: {stream: string}) {
 
     return () => {
       if (intervalId) {
-        window.clearInterval(intervalId);
+        globalThis.clearInterval(intervalId);
       }
     };
   }, [stream, displayedText]);

--- a/static/app/components/events/autofix/autofixRootCause.tsx
+++ b/static/app/components/events/autofix/autofixRootCause.tsx
@@ -468,7 +468,7 @@ function AutofixRootCauseDisplay({
       const clickEvent = new MouseEvent('click', {
         bubbles: true,
         cancelable: true,
-        view: window,
+        view: globalThis,
       });
       descriptionRef.current.dispatchEvent(clickEvent);
     }
@@ -508,8 +508,8 @@ function AutofixRootCauseDisplay({
   const handleLaunchCodingAgent = (integration: CodingAgentIntegration) => {
     // Redirect to OAuth if the integration requires identity but user hasn't authenticated
     if (integration.requires_identity && !integration.has_identity) {
-      const currentUrl = window.location.href;
-      window.location.href = `/remote/github-copilot/oauth/?next=${encodeURIComponent(currentUrl)}`;
+      const currentUrl = globalThis.location.href;
+      globalThis.location.href = `/remote/github-copilot/oauth/?next=${encodeURIComponent(currentUrl)}`;
       return;
     }
 

--- a/static/app/components/events/autofix/autofixSolution.tsx
+++ b/static/app/components/events/autofix/autofixSolution.tsx
@@ -383,7 +383,7 @@ function AutofixSolutionDisplay({
       const clickEvent = new MouseEvent('click', {
         bubbles: true,
         cancelable: true,
-        view: window,
+        view: globalThis,
       });
       descriptionRef.current.dispatchEvent(clickEvent);
     }

--- a/static/app/components/events/autofix/useAutofix.tsx
+++ b/static/app/components/events/autofix/useAutofix.tsx
@@ -468,9 +468,9 @@ export function useLaunchCodingAgent(groupId: string, runId: string) {
     },
     onError: (error, params) => {
       if (needsGitHubAuth(error)) {
-        const currentUrl = window.location.href;
+        const currentUrl = globalThis.location.href;
         const oauthUrl = `/remote/github-copilot/oauth/?next=${encodeURIComponent(currentUrl)}`;
-        window.location.href = oauthUrl;
+        globalThis.location.href = oauthUrl;
         return;
       }
       const message = getErrorMessage(error, params.agentName);

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -760,8 +760,8 @@ export function useExplorerAutofix(
         });
       } catch (e: any) {
         if (needsGitHubAuth(e)) {
-          const currentUrl = window.location.href;
-          window.location.href = `/remote/github-copilot/oauth/?next=${encodeURIComponent(currentUrl)}`;
+          const currentUrl = globalThis.location.href;
+          globalThis.location.href = `/remote/github-copilot/oauth/?next=${encodeURIComponent(currentUrl)}`;
           return;
         }
         appendCodingAgentErrors([

--- a/static/app/components/events/autofix/useTextSelection.tsx
+++ b/static/app/components/events/autofix/useTextSelection.tsx
@@ -20,7 +20,7 @@ export function useTextSelection(containerRef: React.RefObject<HTMLElement | nul
     if (!container) {
       return '';
     }
-    const sel = window.getSelection();
+    const sel = globalThis.getSelection();
     if (!sel || sel.isCollapsed) {
       return '';
     }

--- a/static/app/components/events/autofix/useTypingAnimation.ts
+++ b/static/app/components/events/autofix/useTypingAnimation.ts
@@ -46,7 +46,7 @@ export function useTypingAnimation({
       setDisplayedText(text);
       currentIndexRef.current = text.length;
       if (animationFrameRef.current) {
-        window.cancelAnimationFrame(animationFrameRef.current);
+        globalThis.cancelAnimationFrame(animationFrameRef.current);
         animationFrameRef.current = null;
       }
       return () => {};
@@ -75,7 +75,7 @@ export function useTypingAnimation({
       }
 
       if (currentIndexRef.current < text.length) {
-        animationFrameRef.current = window.requestAnimationFrame(animate);
+        animationFrameRef.current = globalThis.requestAnimationFrame(animate);
       } else {
         // Final check to ensure full text is displayed
         setDisplayedText(currentDisplayedText => {
@@ -93,14 +93,14 @@ export function useTypingAnimation({
 
     // Clear previous frame before starting
     if (animationFrameRef.current) {
-      window.cancelAnimationFrame(animationFrameRef.current);
+      globalThis.cancelAnimationFrame(animationFrameRef.current);
     }
-    animationFrameRef.current = window.requestAnimationFrame(animate);
+    animationFrameRef.current = globalThis.requestAnimationFrame(animate);
 
     // Cleanup
     return () => {
       if (animationFrameRef.current) {
-        window.cancelAnimationFrame(animationFrameRef.current);
+        globalThis.cancelAnimationFrame(animationFrameRef.current);
         animationFrameRef.current = null;
       }
     };

--- a/static/app/components/events/autofix/v2/nextSteps.tsx
+++ b/static/app/components/events/autofix/v2/nextSteps.tsx
@@ -180,8 +180,8 @@ function StepButton({
       onAction: () => {
         // OAuth redirect for integrations without identity
         if (needsSetup) {
-          const currentUrl = window.location.href;
-          window.location.href = `/remote/github-copilot/oauth/?next=${encodeURIComponent(currentUrl)}`;
+          const currentUrl = globalThis.location.href;
+          globalThis.location.href = `/remote/github-copilot/oauth/?next=${encodeURIComponent(currentUrl)}`;
           return;
         }
         onCodingAgentHandoff?.(integration);

--- a/static/app/components/events/autofix/v3/nextStep.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.tsx
@@ -405,8 +405,8 @@ function useCodingAgents({
     (integration: CodingAgentIntegration) => {
       // OAuth redirect for integrations without identity
       if (integration.requires_identity && !integration.has_identity) {
-        const currentUrl = window.location.href;
-        window.location.href = `/remote/github-copilot/oauth/?next=${encodeURIComponent(currentUrl)}`;
+        const currentUrl = globalThis.location.href;
+        globalThis.location.href = `/remote/github-copilot/oauth/?next=${encodeURIComponent(currentUrl)}`;
         return;
       }
       triggerCodingAgentHandoff(runId, integration);

--- a/static/app/components/events/breadcrumbs/breadcrumbsDataSection.spec.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDataSection.spec.tsx
@@ -17,17 +17,19 @@ import {
 import {EntryType} from 'sentry/types/event';
 
 // Needed to mock useVirtualizer lists.
-jest.spyOn(window.Element.prototype, 'getBoundingClientRect').mockImplementation(() => ({
-  x: 0,
-  y: 0,
-  width: 0,
-  height: 30,
-  left: 0,
-  top: 0,
-  right: 0,
-  bottom: 0,
-  toJSON: jest.fn(),
-}));
+jest
+  .spyOn(globalThis.Element.prototype, 'getBoundingClientRect')
+  .mockImplementation(() => ({
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 30,
+    left: 0,
+    top: 0,
+    right: 0,
+    bottom: 0,
+    toJSON: jest.fn(),
+  }));
 
 describe('BreadcrumbsDataSection', () => {
   it('renders a summary of breadcrumbs with a button to view them all', async () => {

--- a/static/app/components/events/breadcrumbs/breadcrumbsDrawer.spec.tsx
+++ b/static/app/components/events/breadcrumbs/breadcrumbsDrawer.spec.tsx
@@ -9,7 +9,7 @@ import {
 async function renderBreadcrumbDrawer() {
   // Needed to mock useVirtualizer lists.
   jest
-    .spyOn(window.Element.prototype, 'getBoundingClientRect')
+    .spyOn(globalThis.Element.prototype, 'getBoundingClientRect')
     .mockImplementation(() => ({
       x: 0,
       y: 0,

--- a/static/app/components/events/eventDataSection.tsx
+++ b/static/app/components/events/eventDataSection.tsx
@@ -44,8 +44,8 @@ export interface EventDataSectionProps {
 }
 
 function scrollToSection(element: HTMLDivElement) {
-  if (window.location.hash && element) {
-    const [, hash] = window.location.hash.split('#');
+  if (globalThis.location.hash && element) {
+    const [, hash] = globalThis.location.hash.split('#');
 
     try {
       const anchorElement = hash && element.querySelector('div#' + hash);

--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/index.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/index.tsx
@@ -145,7 +145,7 @@ export function Screenshot({
                   key: 'download',
                   label: t('Download'),
                   onAction: () => {
-                    window.location.assign(`${downloadUrl}?download=1`);
+                    globalThis.location.assign(`${downloadUrl}?download=1`);
                     trackAnalytics(
                       'issue_details.issue_tab.screenshot_dropdown_download',
                       {organization}

--- a/static/app/components/events/eventViewHierarchy.spec.tsx
+++ b/static/app/components/events/eventViewHierarchy.spec.tsx
@@ -14,8 +14,8 @@ class ResizeObserver {
   disconnect() {}
 }
 
-window.ResizeObserver = ResizeObserver;
-window.Element.prototype.scrollTo = jest.fn();
+globalThis.ResizeObserver = ResizeObserver;
+globalThis.Element.prototype.scrollTo = jest.fn();
 
 const DEFAULT_VALUES = {alpha: 1, height: 1, width: 1, x: 1, y: 1, visible: true};
 const MOCK_DATA = JSON.stringify({

--- a/static/app/components/events/featureFlags/eventFeatureFlagDrawer.spec.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagDrawer.spec.tsx
@@ -12,7 +12,7 @@ import {
 async function renderFlagDrawer() {
   // Needed to mock useVirtualizer lists.
   jest
-    .spyOn(window.Element.prototype, 'getBoundingClientRect')
+    .spyOn(globalThis.Element.prototype, 'getBoundingClientRect')
     .mockImplementation(() => ({
       x: 0,
       y: 0,

--- a/static/app/components/events/featureFlags/eventFeatureFlagSection.spec.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagSection.spec.tsx
@@ -20,17 +20,19 @@ import {
 } from 'sentry/components/events/featureFlags/testUtils';
 
 // Needed to mock useVirtualizer lists.
-jest.spyOn(window.Element.prototype, 'getBoundingClientRect').mockImplementation(() => ({
-  x: 0,
-  y: 0,
-  width: 0,
-  height: 30,
-  left: 0,
-  top: 0,
-  right: 0,
-  bottom: 0,
-  toJSON: jest.fn(),
-}));
+jest
+  .spyOn(globalThis.Element.prototype, 'getBoundingClientRect')
+  .mockImplementation(() => ({
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 30,
+    left: 0,
+    top: 0,
+    right: 0,
+    bottom: 0,
+    toJSON: jest.fn(),
+  }));
 
 describe('EventFeatureFlagList', () => {
   beforeEach(() => {

--- a/static/app/components/events/featureFlags/onboarding/featureFlagOnboardingSidebar.tsx
+++ b/static/app/components/events/featureFlags/onboarding/featureFlagOnboardingSidebar.tsx
@@ -46,7 +46,7 @@ export function useFeatureFlagOnboardingDrawer() {
 
   useEffect(() => {
     if (isActive && hasProjectAccess) {
-      initialPathname.current = window.location.pathname;
+      initialPathname.current = globalThis.location.pathname;
 
       openDrawer(() => <SidebarContent />, {
         ariaLabel: t('Debug Issues with Feature Flag Context'),
@@ -179,7 +179,7 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
   // useMemo is needed to remember the original hash
   // in case window.location.hash disappears
   const ORIGINAL_HASH = useMemo(() => {
-    return window.location.hash;
+    return globalThis.location.hash;
   }, []);
 
   const sdkProviderOptions = Object.values(SdkProviderEnum)
@@ -271,7 +271,7 @@ function OnboardingContent({currentProject}: {currentProject: Project}) {
               provider: SdkProviderEnum.GENERIC,
             });
           }
-          window.location.hash = ORIGINAL_HASH;
+          globalThis.location.hash = ORIGINAL_HASH;
         }}
       />
     </Container>

--- a/static/app/components/events/featureFlags/onboarding/useFeatureFlagOnboarding.tsx
+++ b/static/app/components/events/featureFlags/onboarding/useFeatureFlagOnboarding.tsx
@@ -35,7 +35,7 @@ export function useFeatureFlagOnboarding({
   const activateSidebar = useCallback(
     (event: React.MouseEvent) => {
       event.preventDefault();
-      window.location.hash = FLAG_HASH;
+      globalThis.location.hash = FLAG_HASH;
       OnboardingDrawerStore.open(OnboardingDrawerKey.FEATURE_FLAG_ONBOARDING);
       trackAnalytics('flags.view-setup-sidebar', {
         organization,

--- a/static/app/components/events/meta/metaProxy.tsx
+++ b/static/app/components/events/meta/metaProxy.tsx
@@ -69,7 +69,10 @@ export function withMeta<T>(event: T): T {
   }
 
   // Return unproxied `event` if browser does not support `Proxy`
-  if (typeof window.Proxy === 'undefined' || typeof window.Reflect === 'undefined') {
+  if (
+    typeof globalThis.Proxy === 'undefined' ||
+    typeof globalThis.Reflect === 'undefined'
+  ) {
     return event;
   }
 

--- a/static/app/components/events/viewHierarchy/index.spec.tsx
+++ b/static/app/components/events/viewHierarchy/index.spec.tsx
@@ -25,9 +25,9 @@ class ResizeObserver {
   disconnect() {}
 }
 
-window.ResizeObserver = ResizeObserver;
-window.Element.prototype.scrollTo = jest.fn();
-window.Element.prototype.scrollIntoView = jest.fn();
+globalThis.ResizeObserver = ResizeObserver;
+globalThis.Element.prototype.scrollTo = jest.fn();
+globalThis.Element.prototype.scrollIntoView = jest.fn();
 
 const DEFAULT_VALUES = {alpha: 1, height: 1, width: 1, x: 1, y: 1, visible: true};
 const DEFAULT_MOCK_DATA = {

--- a/static/app/components/featureFeedback/feedbackModal.tsx
+++ b/static/app/components/featureFeedback/feedbackModal.tsx
@@ -124,7 +124,7 @@ export function FeedbackModal<T extends Data>({
       const commonEventProps: Event = {
         message,
         request: {
-          url: window.location.href, // gives the full url (origin + pathname)
+          url: globalThis.location.href, // gives the full url (origin + pathname)
         },
         extra: {
           orgFeatures: organization?.features ?? [],

--- a/static/app/components/feedback/feedbackItem/feedbackItemUsername.spec.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItemUsername.spec.tsx
@@ -128,7 +128,7 @@ describe('FeedbackItemUsername', () => {
     await userEvent.click(username);
 
     await waitFor(() => {
-      expect(window.getSelection()?.toString()).toBe('Foo Bar•foo@bar.com');
+      expect(globalThis.getSelection()?.toString()).toBe('Foo Bar•foo@bar.com');
     });
 
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith('Foo Bar <foo@bar.com>');

--- a/static/app/components/feedback/feedbackItem/feedbackShortId.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackShortId.tsx
@@ -43,7 +43,7 @@ export function FeedbackShortId({className, feedbackItem, style}: Props) {
   // for the copy url button below. normalizeUrl can return an object if `query`
   // or other options are passed, which breaks the copy-paste.
   const feedbackUrl =
-    window.location.origin +
+    globalThis.location.origin +
     makeFeedbackPathname({
       path: '/',
       organization,

--- a/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
+++ b/static/app/components/feedback/feedbackOnboarding/sidebar.tsx
@@ -60,7 +60,7 @@ export function useFeedbackOnboardingDrawer() {
         ariaLabel: t('Getting Started with User Feedback'),
         // Prevent the drawer from closing when the query params change
         shouldCloseOnLocationChange: location =>
-          location.pathname !== window.location.pathname,
+          location.pathname !== globalThis.location.pathname,
       });
     }
   }, [isActive, hasProjectAccess, openDrawer]);

--- a/static/app/components/feedback/useFeedbackOnboarding.tsx
+++ b/static/app/components/feedback/useFeedbackOnboarding.tsx
@@ -29,14 +29,14 @@ export function useFeedbackOnboardingSidebarPanel() {
 
   const activateSidebar = useCallback((event: {preventDefault: () => void}) => {
     event.preventDefault();
-    window.location.hash = FEEDBACK_HASH;
+    globalThis.location.hash = FEEDBACK_HASH;
     OnboardingDrawerStore.open(OnboardingDrawerKey.FEEDBACK_ONBOARDING);
   }, []);
 
   const activateSidebarIssueDetails = useCallback(
     (event: {preventDefault: () => void}) => {
       event.preventDefault();
-      window.location.hash = CRASH_REPORT_HASH;
+      globalThis.location.hash = CRASH_REPORT_HASH;
       OnboardingDrawerStore.open(OnboardingDrawerKey.FEEDBACK_ONBOARDING);
     },
     []

--- a/static/app/components/footer.tsx
+++ b/static/app/components/footer.tsx
@@ -82,7 +82,7 @@ function BaseFooter({className}: Props) {
           <Button
             priority="transparent"
             size="xs"
-            onClick={() => window.location.reload()}
+            onClick={() => globalThis.location.reload()}
             tooltipProps={{
               title: t(
                 "An improved version of Sentry's Frontend Application is now available. Click to update now."

--- a/static/app/components/forms/formField/index.tsx
+++ b/static/app/components/forms/formField/index.tsx
@@ -299,7 +299,7 @@ export function FormField(props: FormFieldProps) {
     (node: HTMLElement | null) => {
       if (node && !inputRef.current) {
         // TODO(mark) Clean this up. FormContext could include the location
-        const hash = window.location?.hash;
+        const hash = globalThis.location?.hash;
 
         if (!hash) {
           return;

--- a/static/app/components/forms/useFormTypingAnimation.ts
+++ b/static/app/components/forms/useFormTypingAnimation.ts
@@ -31,7 +31,7 @@ export function useFormTypingAnimation({
   const cancelFormTypingAnimation = useCallback(() => {
     runIdRef.current += 1;
     if (animationFrameRef.current !== null) {
-      window.cancelAnimationFrame(animationFrameRef.current);
+      globalThis.cancelAnimationFrame(animationFrameRef.current);
       animationFrameRef.current = null;
     }
   }, []);
@@ -78,7 +78,7 @@ export function useFormTypingAnimation({
         }
 
         if (currentIndexRef.current < text.length) {
-          animationFrameRef.current = window.requestAnimationFrame(animate);
+          animationFrameRef.current = globalThis.requestAnimationFrame(animate);
           return;
         }
 
@@ -87,7 +87,7 @@ export function useFormTypingAnimation({
         formModel.setValue(fieldName, text);
       };
 
-      animationFrameRef.current = window.requestAnimationFrame(animate);
+      animationFrameRef.current = globalThis.requestAnimationFrame(animate);
     },
     [cancelFormTypingAnimation, defaultSpeed]
   );

--- a/static/app/components/globalModal/index.tsx
+++ b/static/app/components/globalModal/index.tsx
@@ -152,8 +152,8 @@ export function GlobalModal({onClose}: Props) {
   const portal = getModalPortal();
   const focusTrap = useRef<FocusTrap | null>(null);
   // SentryApp might be missing on tests
-  if (window.SentryApp) {
-    window.SentryApp.modalFocusTrap = focusTrap;
+  if (globalThis.SentryApp) {
+    globalThis.SentryApp.modalFocusTrap = focusTrap;
   }
 
   useEffect(() => {

--- a/static/app/components/lazyRender.tsx
+++ b/static/app/components/lazyRender.tsx
@@ -12,7 +12,7 @@ function maybeCleanupObserver(
 }
 
 function supportsIntersectionObserver(): boolean {
-  return 'IntersectionObserver' in window;
+  return 'IntersectionObserver' in globalThis;
 }
 
 const DEFAULT_OPTIONS: IntersectionObserverInit = {

--- a/static/app/components/modals/debugFileCustomRepository/index.tsx
+++ b/static/app/components/modals/debugFileCustomRepository/index.tsx
@@ -52,7 +52,7 @@ function DebugFileCustomRepository({
   function handleSave(data?: Record<string, any>) {
     if (!data) {
       closeModal();
-      window.location.reload();
+      globalThis.location.reload();
       return;
     }
 

--- a/static/app/components/modals/privateGamingSdkAccessModal.tsx
+++ b/static/app/components/modals/privateGamingSdkAccessModal.tsx
@@ -249,7 +249,7 @@ export function PrivateGamingSdkAccessModal({
                 onClick={() => {
                   const separator = currentPath.includes('?') ? '&' : '?';
                   const pathWithReopenFlag = `${currentPath}${separator}reopenGamingSdkModal=1`;
-                  window.location.href = `/identity/login/github/?next=${encodeURIComponent(pathWithReopenFlag)}`;
+                  globalThis.location.href = `/identity/login/github/?next=${encodeURIComponent(pathWithReopenFlag)}`;
                 }}
               >
                 {t('Log in with GitHub')}

--- a/static/app/components/modals/redirectToProject.tsx
+++ b/static/app/components/modals/redirectToProject.tsx
@@ -30,9 +30,9 @@ function RedirectToProjectModal({slug, Header, Body}: Props) {
   });
 
   useEffect(() => {
-    const interval = window.setInterval(() => setTimer(value => value - 1), 1000);
+    const interval = globalThis.setInterval(() => setTimer(value => value - 1), 1000);
 
-    return () => window.clearInterval(interval);
+    return () => globalThis.clearInterval(interval);
   }, []);
 
   useEffect(() => {

--- a/static/app/components/modals/sudoModal.spec.tsx
+++ b/static/app/components/modals/sudoModal.spec.tsx
@@ -11,8 +11,8 @@ describe('Sudo Modal', () => {
     ConfigStore.set('user', {...ConfigStore.get('user'), hasPasswordAuth});
 
   beforeEach(() => {
-    window.__initialData = {
-      ...window.__initialData,
+    globalThis.__initialData = {
+      ...globalThis.__initialData,
       links: {
         organizationUrl: 'https://albertos-apples.sentry.io',
         regionUrl: 'https://albertos-apples.sentry.io',

--- a/static/app/components/modals/sudoModal.tsx
+++ b/static/app/components/modals/sudoModal.tsx
@@ -187,7 +187,7 @@ function SudoModal({
         {replace: true}
       );
       if (needsReload) {
-        window.location.reload();
+        globalThis.location.reload();
       }
       return;
     }
@@ -249,9 +249,9 @@ function SudoModal({
   );
 
   const getAuthLoginPath = (): string => {
-    const authLoginPath = `/auth/login/?next=${encodeURIComponent(window.location.href)}`;
-    const {superuserUrl} = window.__initialData.links;
-    if (window.__initialData?.customerDomain && superuserUrl) {
+    const authLoginPath = `/auth/login/?next=${encodeURIComponent(globalThis.location.href)}`;
+    const {superuserUrl} = globalThis.__initialData.links;
+    if (globalThis.__initialData?.customerDomain && superuserUrl) {
       return `${trimEnd(superuserUrl, '/')}${authLoginPath}`;
     }
     return authLoginPath;

--- a/static/app/components/onboardingWizard/content.tsx
+++ b/static/app/components/onboardingWizard/content.tsx
@@ -340,9 +340,9 @@ function ExpandedTaskGroup({tasks, hidePanel}: ExpandedTaskGroupProps) {
   );
 
   function completionTimeout(time: number): Promise<void> {
-    window.clearTimeout(markCompletionTimeout.current);
+    globalThis.clearTimeout(markCompletionTimeout.current);
     return new Promise(resolve => {
-      markCompletionTimeout.current = window.setTimeout(resolve, time);
+      markCompletionTimeout.current = globalThis.setTimeout(resolve, time);
     });
   }
 
@@ -373,7 +373,7 @@ function ExpandedTaskGroup({tasks, hidePanel}: ExpandedTaskGroupProps) {
     }
 
     return () => {
-      window.clearTimeout(markCompletionTimeout.current);
+      globalThis.clearTimeout(markCompletionTimeout.current);
     };
   }, [unseenDoneTasks, markSeenOnOpen]);
 

--- a/static/app/components/pageFilters/actions.tsx
+++ b/static/app/components/pageFilters/actions.tsx
@@ -480,7 +480,7 @@ async function persistPageFilters(filter: PinnedPageFilter | null, options?: Opt
   // XXX(epurkhiser): Since this is called immediately after updating the
   // store, wait for a tick since stores are not updated fully synchronously.
   // A bit goofy, but it works fine.
-  await new Promise(resolve => window.setTimeout(resolve, 0));
+  await new Promise(resolve => globalThis.setTimeout(resolve, 0));
 
   const {organization} = OrganizationStore.getState();
   const orgSlug = organization?.slug ?? null;

--- a/static/app/components/pageFilters/useStagedCompactSelect.tsx
+++ b/static/app/components/pageFilters/useStagedCompactSelect.tsx
@@ -420,12 +420,12 @@ export function useStagedCompactSelect<Value extends SelectKey>({
       keyRef.current = null;
       setModifierActive(false);
     };
-    window.addEventListener('keydown', onKeyChange);
-    window.addEventListener('keyup', onKeyChange);
+    globalThis.addEventListener('keydown', onKeyChange);
+    globalThis.addEventListener('keyup', onKeyChange);
     window.addEventListener('blur', onBlur);
     return () => {
-      window.removeEventListener('keydown', onKeyChange);
-      window.removeEventListener('keyup', onKeyChange);
+      globalThis.removeEventListener('keydown', onKeyChange);
+      globalThis.removeEventListener('keyup', onKeyChange);
       window.removeEventListener('blur', onBlur);
     };
   }, []);

--- a/static/app/components/pageOverlay.tsx
+++ b/static/app/components/pageOverlay.tsx
@@ -180,7 +180,7 @@ export function PageOverlay({
     let bgResizeObserver: ResizeObserver | null = null;
 
     // Observe changes to the upsell container to reanchor if available
-    if (window.ResizeObserver) {
+    if (globalThis.ResizeObserver) {
       bgResizeObserver = new ResizeObserver(anchorWrapper);
       bgResizeObserver.observe(contentRef.current);
     }

--- a/static/app/components/performanceOnboarding/sidebar.tsx
+++ b/static/app/components/performanceOnboarding/sidebar.tsx
@@ -65,7 +65,7 @@ export function usePerformanceOnboardingDrawer() {
 
   useEffect(() => {
     if (isActive && hasProjectAccess) {
-      initialPathname.current = window.location.pathname;
+      initialPathname.current = globalThis.location.pathname;
 
       openDrawer(() => <DrawerContent />, {
         ariaLabel: t('Boost Performance'),

--- a/static/app/components/pipeline/pipelineIntegrationBitbucket.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationBitbucket.spec.tsx
@@ -114,7 +114,7 @@ describe('BitbucketAuthorizeStep', () => {
   });
 
   it('shows popup blocked notice when popup fails to open', async () => {
-    jest.spyOn(window, 'open').mockReturnValue(null);
+    jest.spyOn(globalThis, 'open').mockReturnValue(null);
     render(
       <BitbucketAuthorizeStep
         {...makeStepProps({

--- a/static/app/components/pipeline/pipelineIntegrationGitHub.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationGitHub.spec.tsx
@@ -254,7 +254,7 @@ describe('OrgSelectionStep', () => {
   });
 
   it('shows popup blocked notice when popup fails to open', async () => {
-    jest.spyOn(window, 'open').mockReturnValue(null);
+    jest.spyOn(globalThis, 'open').mockReturnValue(null);
 
     render(
       <OrgSelectionStep

--- a/static/app/components/pipeline/shared/oauthLoginStep.spec.tsx
+++ b/static/app/components/pipeline/shared/oauthLoginStep.spec.tsx
@@ -175,7 +175,7 @@ describe('OAuthLoginStep', () => {
   });
 
   it('shows warning when popup is blocked by the browser', async () => {
-    jest.spyOn(window, 'open').mockReturnValue(null);
+    jest.spyOn(globalThis, 'open').mockReturnValue(null);
 
     render(
       <OAuthLoginStep

--- a/static/app/components/pipeline/testUtils.tsx
+++ b/static/app/components/pipeline/testUtils.tsx
@@ -41,7 +41,7 @@ export function setupMockPopup(): Window {
     close: jest.fn(),
     focus: jest.fn(),
   } as unknown as Window;
-  jest.spyOn(window, 'open').mockReturnValue(popup);
+  jest.spyOn(globalThis, 'open').mockReturnValue(popup);
   return popup;
 }
 
@@ -60,6 +60,6 @@ export function dispatchPipelineMessage({
   act(() => {
     const event = new MessageEvent('message', {data, origin});
     Object.defineProperty(event, 'source', {value: source});
-    window.dispatchEvent(event);
+    globalThis.dispatchEvent(event);
   });
 }

--- a/static/app/components/profiling/boundTooltip.tsx
+++ b/static/app/components/profiling/boundTooltip.tsx
@@ -113,11 +113,11 @@ function BoundTooltip({
       }
 
       if (rafIdRef.current) {
-        window.cancelAnimationFrame(rafIdRef.current);
+        globalThis.cancelAnimationFrame(rafIdRef.current);
         rafIdRef.current = null;
       }
 
-      rafIdRef.current = window.requestAnimationFrame(() => {
+      rafIdRef.current = globalThis.requestAnimationFrame(() => {
         if (!sizeCache.current || sizeCache.current?.value !== children) {
           sizeCache.current = {value: children, size: node.getBoundingClientRect()};
         }

--- a/static/app/components/profiling/flamegraph/continuousFlamegraph.tsx
+++ b/static/app/components/profiling/flamegraph/continuousFlamegraph.tsx
@@ -225,7 +225,7 @@ function findLongestMatchingFrame(
 }
 
 function decodeConfigSpace(): [number, number] {
-  const qs = new URLSearchParams(window.location.search);
+  const qs = new URLSearchParams(globalThis.location.search);
   const startedAt = qs.get('start');
   const endedAt = qs.get('end');
   if (!startedAt || !endedAt) {

--- a/static/app/components/profiling/flamegraph/flamegraph.spec.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraph.spec.tsx
@@ -8,8 +8,8 @@ import {FlamegraphRendererDOM as mockFlameGraphRenderer} from 'sentry/utils/prof
 import ProfileFlamegraph from 'sentry/views/profiling/profileFlamechart';
 import ProfilesAndTransactionProvider from 'sentry/views/profiling/transactionProfileProvider';
 
-window.ResizeObserver =
-  window.ResizeObserver ||
+globalThis.ResizeObserver =
+  globalThis.ResizeObserver ||
   jest.fn().mockImplementation(() => ({
     disconnect: jest.fn(),
     observe: jest.fn(),

--- a/static/app/components/profiling/flamegraph/flamegraphChart.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphChart.tsx
@@ -189,10 +189,10 @@ export function FlamegraphChart({
   }, []);
 
   useEffect(() => {
-    window.addEventListener('mouseup', onMapCanvasMouseUp);
+    globalThis.addEventListener('mouseup', onMapCanvasMouseUp);
 
     return () => {
-      window.removeEventListener('mouseup', onMapCanvasMouseUp);
+      globalThis.removeEventListener('mouseup', onMapCanvasMouseUp);
     };
   }, [onMapCanvasMouseUp]);
 

--- a/static/app/components/profiling/flamegraph/flamegraphSpans.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphSpans.tsx
@@ -193,7 +193,7 @@ export function FlamegraphSpans({
       return;
     }
 
-    const span_id = qs.parse(window.location.search).spanId;
+    const span_id = qs.parse(globalThis.location.search).spanId;
     if (!span_id) {
       return;
     }
@@ -310,10 +310,10 @@ export function FlamegraphSpans({
   });
 
   useEffect(() => {
-    window.addEventListener('mouseup', onMinimapCanvasMouseUp);
+    globalThis.addEventListener('mouseup', onMinimapCanvasMouseUp);
 
     return () => {
-      window.removeEventListener('mouseup', onMinimapCanvasMouseUp);
+      globalThis.removeEventListener('mouseup', onMinimapCanvasMouseUp);
     };
   }, [onMinimapCanvasMouseUp]);
 

--- a/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphSearch.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphToolbar/flamegraphSearch.tsx
@@ -330,7 +330,7 @@ function FlamegraphSearch({
   const handleChange: (query: string) => void = useCallback(
     query => {
       if (rafHandler.current) {
-        window.cancelAnimationFrame(rafHandler.current.id);
+        globalThis.cancelAnimationFrame(rafHandler.current.id);
       }
 
       if (!query) {

--- a/static/app/components/profiling/flamegraph/flamegraphUIFrames.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphUIFrames.tsx
@@ -189,10 +189,10 @@ export function FlamegraphUIFrames({
   });
 
   useEffect(() => {
-    window.addEventListener('mouseup', onMapCanvasMouseUp);
+    globalThis.addEventListener('mouseup', onMapCanvasMouseUp);
 
     return () => {
-      window.removeEventListener('mouseup', onMapCanvasMouseUp);
+      globalThis.removeEventListener('mouseup', onMapCanvasMouseUp);
     };
   }, [onMapCanvasMouseUp]);
 

--- a/static/app/components/profiling/flamegraph/flamegraphZoomViewMinimap.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphZoomViewMinimap.tsx
@@ -403,10 +403,10 @@ function FlamegraphZoomViewMinimap({
   );
 
   useEffect(() => {
-    window.addEventListener('mouseup', onMinimapCanvasMouseUp);
+    globalThis.addEventListener('mouseup', onMinimapCanvasMouseUp);
 
     return () => {
-      window.removeEventListener('mouseup', onMinimapCanvasMouseUp);
+      globalThis.removeEventListener('mouseup', onMinimapCanvasMouseUp);
     };
   }, [onMinimapCanvasMouseUp]);
 

--- a/static/app/components/profiling/flamegraph/interactions/useCanvasZoomOrScroll.tsx
+++ b/static/app/components/profiling/flamegraph/interactions/useCanvasZoomOrScroll.tsx
@@ -26,7 +26,7 @@ export function useCanvasZoomOrScroll({
     let wheelStopTimeoutId: {current: number | undefined} = {current: undefined};
     function onCanvasWheel(evt: WheelEvent) {
       if (wheelStopTimeoutId.current !== undefined) {
-        window.cancelAnimationFrame(wheelStopTimeoutId.current);
+        globalThis.cancelAnimationFrame(wheelStopTimeoutId.current);
       }
       wheelStopTimeoutId = requestAnimationFrameTimeout(() => {
         setLastInteraction?.(null);
@@ -50,7 +50,7 @@ export function useCanvasZoomOrScroll({
 
     return () => {
       if (wheelStopTimeoutId.current !== undefined) {
-        window.cancelAnimationFrame(wheelStopTimeoutId.current);
+        globalThis.cancelAnimationFrame(wheelStopTimeoutId.current);
       }
       canvas.removeEventListener('wheel', onCanvasWheel);
     };

--- a/static/app/components/profiling/flamegraph/interactions/useViewKeyboardNavigation.tsx
+++ b/static/app/components/profiling/flamegraph/interactions/useViewKeyboardNavigation.tsx
@@ -69,7 +69,7 @@ export function useViewKeyboardNavigation(
       }
 
       if (animationRef.current !== null) {
-        window.cancelAnimationFrame(animationRef.current);
+        globalThis.cancelAnimationFrame(animationRef.current);
       }
 
       if (event.key === 'w') {

--- a/static/app/components/profiling/profilingOnboardingSidebar.tsx
+++ b/static/app/components/profiling/profilingOnboardingSidebar.tsx
@@ -71,7 +71,7 @@ export function useProfilingOnboardingDrawer() {
 
   useLayoutEffect(() => {
     if (isActive && hasProjectAccess) {
-      initialPathname.current = window.location.pathname;
+      initialPathname.current = globalThis.location.pathname;
 
       openDrawer(() => <DrawerContent />, {
         ariaLabel: t('Profile Code'),

--- a/static/app/components/replays/breadcrumbs/replayTimelineTooltip.tsx
+++ b/static/app/components/replays/breadcrumbs/replayTimelineTooltip.tsx
@@ -34,12 +34,12 @@ export function TimelineTooltip({container}: Props) {
   const [lastHoverTime, setLastHoverTime] = useState<number | undefined>(undefined);
   useEffect(() => {
     if (currentHoverTime === undefined) {
-      timeoutRef.current = window.setTimeout(() => {
+      timeoutRef.current = globalThis.setTimeout(() => {
         setLastHoverTime(undefined);
       }, 0);
     } else {
       if (timeoutRef.current) {
-        window.clearTimeout(timeoutRef.current);
+        globalThis.clearTimeout(timeoutRef.current);
         timeoutRef.current = undefined;
       }
       setLastHoverTime(currentHoverTime);
@@ -47,7 +47,7 @@ export function TimelineTooltip({container}: Props) {
 
     return () => {
       if (timeoutRef.current) {
-        window.clearTimeout(timeoutRef.current);
+        globalThis.clearTimeout(timeoutRef.current);
       }
     };
   }, [currentHoverTime]);

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -261,16 +261,16 @@ export function Provider({
       // Clear previous timers. Without this (but with the setTimeout) multiple
       // requests to set the currentTime could finish out of order and cause jumping.
       if (playTimer.current) {
-        window.clearTimeout(playTimer.current);
+        globalThis.clearTimeout(playTimer.current);
       }
 
       replayer.setConfig({skipInactive});
 
       if (isPlaying) {
-        playTimer.current = window.setTimeout(() => replayer.play(time), 0);
+        playTimer.current = globalThis.setTimeout(() => replayer.play(time), 0);
         setIsPlaying(true);
       } else {
-        playTimer.current = window.setTimeout(() => replayer.pause(time), 0);
+        playTimer.current = globalThis.setTimeout(() => replayer.pause(time), 0);
         setIsPlaying(false);
       }
     },

--- a/static/app/components/replays/replayPlayer.tsx
+++ b/static/app/components/replays/replayPlayer.tsx
@@ -108,7 +108,7 @@ function BasePlayerRoot({
   useResizeObserver({ref: windowEl, onResize: updateWindowDimensions});
   // If your browser doesn't have ResizeObserver then set the size once.
   useEffect(() => {
-    if (typeof window.ResizeObserver !== 'undefined') {
+    if (typeof globalThis.ResizeObserver !== 'undefined') {
       return;
     }
     updateWindowDimensions();

--- a/static/app/components/replays/videoReplayer.spec.tsx
+++ b/static/app/components/replays/videoReplayer.spec.tsx
@@ -9,9 +9,9 @@ import {VideoReplayer} from './videoReplayer';
 //
 // advancing by 2000ms ~== 20000s in Timer, but this may depend on hardware, TBD
 jest.useFakeTimers();
-jest.spyOn(window.HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
+jest.spyOn(globalThis.HTMLMediaElement.prototype, 'pause').mockImplementation(() => {});
 jest
-  .spyOn(window.HTMLMediaElement.prototype, 'play')
+  .spyOn(globalThis.HTMLMediaElement.prototype, 'play')
   .mockImplementation(() => Promise.resolve());
 
 describe('VideoReplayer - no starting gap', () => {

--- a/static/app/components/replaysOnboarding/sidebar.tsx
+++ b/static/app/components/replaysOnboarding/sidebar.tsx
@@ -55,7 +55,7 @@ export function useReplaysOnboardingDrawer() {
         ariaLabel: t('Getting Started with Session Replay'),
         // Prevent the drawer from closing when the query params change
         shouldCloseOnLocationChange: location =>
-          location.pathname !== window.location.pathname,
+          location.pathname !== globalThis.location.pathname,
       });
     }
   }, [isActive, hasProjectAccess, openDrawer]);

--- a/static/app/components/scrollCarousel.spec.tsx
+++ b/static/app/components/scrollCarousel.spec.tsx
@@ -7,7 +7,7 @@ describe('ScrollCarousel', () => {
     entries: Array<Partial<IntersectionObserverEntry>>
   ) => void = jest.fn();
 
-  window.IntersectionObserver = class IntersectionObserver {
+  globalThis.IntersectionObserver = class IntersectionObserver {
     root = null;
     rootMargin = '';
     scrollMargin = '';

--- a/static/app/components/search/index.spec.tsx
+++ b/static/app/components/search/index.spec.tsx
@@ -118,7 +118,7 @@ describe('Search', () => {
     const opener = {opener: 'Sentry.io', location: {href: null}};
 
     // @ts-expect-error this is a partial mock of the window object
-    const windowSpy = jest.spyOn(window, 'open').mockReturnValue(opener);
+    const windowSpy = jest.spyOn(globalThis, 'open').mockReturnValue(opener);
 
     await userEvent.click(screen.getByPlaceholderText('Search Input'));
     await userEvent.keyboard('Import');
@@ -155,7 +155,7 @@ describe('Search', () => {
     const opener = {opener: 'Sentry.io', location: {href: null}};
 
     // @ts-expect-error this is a partial mock of the window object
-    const windowSpy = jest.spyOn(window, 'open').mockReturnValue(opener);
+    const windowSpy = jest.spyOn(globalThis, 'open').mockReturnValue(opener);
 
     await userEvent.click(screen.getByPlaceholderText('Search Input'));
     await userEvent.keyboard('Import');

--- a/static/app/components/search/sources/commandSource.tsx
+++ b/static/app/components/search/sources/commandSource.tsx
@@ -77,7 +77,7 @@ const ACTIONS: Action[] = [
     requiresSuperuser: true,
     action: () => {
       toggleLocaleDebug();
-      window.location.reload();
+      globalThis.location.reload();
     },
   },
 
@@ -92,11 +92,11 @@ const ACTIONS: Action[] = [
 ];
 
 // Add a command palette option for opening in production when using dev-ui
-if (NODE_ENV === 'development' && window?.__initialData?.isSelfHosted === false) {
+if (NODE_ENV === 'development' && globalThis?.__initialData?.isSelfHosted === false) {
   const customerUrl = new URL(
-    USING_CUSTOMER_DOMAIN && window?.__initialData?.customerDomain?.organizationUrl
-      ? window.__initialData.customerDomain.organizationUrl
-      : window.__initialData?.links?.sentryUrl
+    USING_CUSTOMER_DOMAIN && globalThis?.__initialData?.customerDomain?.organizationUrl
+      ? globalThis.__initialData.customerDomain.organizationUrl
+      : globalThis.__initialData?.links?.sentryUrl
   );
 
   ACTIONS.push({
@@ -104,7 +104,7 @@ if (NODE_ENV === 'development' && window?.__initialData?.isSelfHosted === false)
     description: t('Open the current page in sentry.io'),
     requiresSuperuser: false,
     action: () => {
-      const url = new URL(window.location.toString());
+      const url = new URL(globalThis.location.toString());
       url.host = customerUrl.host;
       url.protocol = customerUrl.protocol;
       url.port = '';
@@ -113,13 +113,13 @@ if (NODE_ENV === 'development' && window?.__initialData?.isSelfHosted === false)
   });
 }
 
-if (NODE_ENV === 'development' && typeof window !== 'undefined') {
+if (NODE_ENV === 'development' && typeof globalThis.window !== 'undefined') {
   ACTIONS.push({
     title: t('Toggle Component Inspector'),
     description: t('Toggle the component inspector.'),
     requiresSuperuser: true,
     action: () => {
-      window.dispatchEvent(new Event('devtools.toggle_component_inspector'));
+      globalThis.dispatchEvent(new Event('devtools.toggle_component_inspector'));
     },
   });
 }

--- a/static/app/components/searchSyntax/renderer.tsx
+++ b/static/app/components/searchSyntax/renderer.tsx
@@ -128,7 +128,7 @@ function useTokenValidation(
     style.animation = 'none';
     void tokenElementRef.current.offsetTop;
 
-    window.requestAnimationFrame(
+    globalThis.requestAnimationFrame(
       () => (style.animation = `${shakeAnimation.name} 300ms`)
     );
   }, [reduceMotion, showInvalid]);

--- a/static/app/components/stackTrace/frame/frameHeader.tsx
+++ b/static/app/components/stackTrace/frame/frameHeader.tsx
@@ -83,7 +83,7 @@ export function FrameHeader({actions}: FrameHeaderProps) {
       aria-expanded={isExpandable ? isExpanded : undefined}
       aria-controls={isExpandable ? frameContextId : undefined}
       onClick={() => {
-        const selectedText = window.getSelection()?.toString();
+        const selectedText = globalThis.getSelection()?.toString();
         if (isExpandable && !selectedText) {
           toggleExpansion();
         }

--- a/static/app/components/stream/group.tsx
+++ b/static/app/components/stream/group.tsx
@@ -607,7 +607,7 @@ export function StreamGroup({
 
     if (selectionEnabled && e.shiftKey) {
       issueSelectionActions?.shiftToggleSelect(group.id);
-      window.getSelection()?.removeAllRanges();
+      globalThis.getSelection()?.removeAllRanges();
       return;
     }
 

--- a/static/app/components/superuserStaffAccessForm.tsx
+++ b/static/app/components/superuserStaffAccessForm.tsx
@@ -135,7 +135,7 @@ class SuperuserStaffAccessFormContent extends Component<Props, State> {
   };
 
   handleSuccess = () => {
-    window.location.reload();
+    globalThis.location.reload();
   };
 
   handleError = (err: any) => {
@@ -168,14 +168,14 @@ class SuperuserStaffAccessFormContent extends Component<Props, State> {
   };
 
   handleLogout = () => {
-    const {superuserUrl} = window.__initialData.links;
+    const {superuserUrl} = globalThis.__initialData.links;
     const urlOrigin =
-      window.__initialData.customerDomain && superuserUrl
+      globalThis.__initialData.customerDomain && superuserUrl
         ? superuserUrl
-        : window.location.origin;
+        : globalThis.location.origin;
 
     const nextUrl = new URL('/auth/login/', urlOrigin);
-    nextUrl.searchParams.set('next', window.location.href);
+    nextUrl.searchParams.set('next', globalThis.location.href);
 
     logout(this.props.api, nextUrl.toString());
   };

--- a/static/app/components/tables/gridEditable/index.tsx
+++ b/static/app/components/tables/gridEditable/index.tsx
@@ -128,7 +128,7 @@ export function GridEditable<
   const clearWindowLifecycleEvents = useCallback(() => {
     Object.keys(resizeWindowLifecycleEvents.current).forEach(e => {
       resizeWindowLifecycleEvents.current[e]!.forEach(c =>
-        window.removeEventListener(e, c)
+        globalThis.removeEventListener(e, c)
       );
       resizeWindowLifecycleEvents.current[e] = [];
     });
@@ -181,10 +181,10 @@ export function GridEditable<
       cursorX: e.clientX,
     };
 
-    window.addEventListener('mousemove', onResizeMouseMove);
+    globalThis.addEventListener('mousemove', onResizeMouseMove);
     resizeWindowLifecycleEvents.current.mousemove!.push(onResizeMouseMove);
 
-    window.addEventListener('mouseup', onResizeMouseUp);
+    globalThis.addEventListener('mouseup', onResizeMouseUp);
     resizeWindowLifecycleEvents.current.mouseup!.push(onResizeMouseUp);
   };
 
@@ -212,7 +212,7 @@ export function GridEditable<
       return;
     }
 
-    window.requestAnimationFrame(() => resizeGridColumn(e, current));
+    globalThis.requestAnimationFrame(() => resizeGridColumn(e, current));
   };
 
   const resizeGridColumn = (e: MouseEvent, metadata: ColResizeMetadata) => {

--- a/static/app/components/timeSince.tsx
+++ b/static/app/components/timeSince.tsx
@@ -141,9 +141,9 @@ export function TimeSince({
           : liveUpdateInterval;
 
     // Start a ticker to update the relative time
-    const ticker = window.setInterval(() => setTick(prev => prev + 1), interval);
+    const ticker = globalThis.setInterval(() => setTick(prev => prev + 1), interval);
 
-    return () => window.clearInterval(ticker);
+    return () => globalThis.clearInterval(ticker);
   }, [liveUpdateInterval]);
 
   const dateObj = getDateObj(date);

--- a/static/app/components/tours/tour.stories.tsx
+++ b/static/app/components/tours/tour.stories.tsx
@@ -281,11 +281,11 @@ export const MY_TOUR_KEY = 'tour.my_tour';
                 closeModal={props.closeModal}
                 onDismissTour={() => {
                   // eslint-disable-next-line no-alert
-                  window.alert('Tour dismissed');
+                  globalThis.alert('Tour dismissed');
                 }}
                 onStartTour={() => {
                   // eslint-disable-next-line no-alert
-                  window.alert('Start Tour Clicked');
+                  globalThis.alert('Start Tour Clicked');
                 }}
                 header="Start Tour Modal"
                 description="Take the tour to learn more about this page (if you dare)."

--- a/static/app/components/webAuthn/webAuthnAssert.tsx
+++ b/static/app/components/webAuthn/webAuthnAssert.tsx
@@ -65,7 +65,7 @@ export function WebAuthnAssert({
   challengeData,
   mode = 'signin',
 }: WebAuthnAssertProps) {
-  const isSupported = !!window.PublicKeyCredential;
+  const isSupported = !!globalThis.PublicKeyCredential;
   const challenge = JSON.stringify(challengeData);
 
   const inputRef = useRef<HTMLInputElement>(null);

--- a/static/app/components/webAuthn/webAuthnEnroll.tsx
+++ b/static/app/components/webAuthn/webAuthnEnroll.tsx
@@ -21,7 +21,7 @@ const UNSUPPORTED_NOTICE = t(
 const FAILURE_MESSAGE = t('There was a problem enrolling, please try again.');
 
 export function WebAuthnEnroll({challengeData}: WebAuthnEnrollProps) {
-  const isSupported = !!window.PublicKeyCredential;
+  const isSupported = !!globalThis.PublicKeyCredential;
   const challenge = JSON.stringify(challengeData);
 
   const [activated, setActivated] = useState(false);

--- a/static/app/constants/index.tsx
+++ b/static/app/constants/index.tsx
@@ -14,12 +14,14 @@ import type {Organization, OrgRole} from 'sentry/types/organization';
 export const ROOT_ELEMENT = 'blk_router';
 
 export const USING_CUSTOMER_DOMAIN =
-  typeof window === 'undefined' ? false : Boolean(window?.__initialData?.customerDomain);
+  typeof globalThis.window === 'undefined'
+    ? false
+    : Boolean(globalThis?.__initialData?.customerDomain);
 
 export const CUSTOMER_DOMAIN =
-  typeof window === 'undefined'
+  typeof globalThis.window === 'undefined'
     ? undefined
-    : window?.__initialData?.customerDomain?.subdomain;
+    : globalThis?.__initialData?.customerDomain?.subdomain;
 
 // Constant used for tracking referrer in session storage rather than
 // ?referrer=foo get parameter:

--- a/static/app/main.tsx
+++ b/static/app/main.tsx
@@ -30,7 +30,7 @@ export function Main() {
   const [router] = useState(buildRouter);
 
   useEffect(() => {
-    preload(router.routes, window.location.pathname);
+    preload(router.routes, globalThis.location.pathname);
   }, [router.routes]);
 
   return (

--- a/static/app/plugins/pluginComponentBase.tsx
+++ b/static/app/plugins/pluginComponentBase.tsx
@@ -53,8 +53,8 @@ export abstract class PluginComponentBase<
 
   componentWillUnmount() {
     this.api.clear();
-    window.clearTimeout(this.successMessageTimeout);
-    window.clearTimeout(this.errorMessageTimeout);
+    globalThis.clearTimeout(this.successMessageTimeout);
+    globalThis.clearTimeout(this.errorMessageTimeout);
   }
 
   successMessageTimeout: number | undefined = undefined;
@@ -120,8 +120,8 @@ export abstract class PluginComponentBase<
       () => callback?.()
     );
 
-    window.clearTimeout(this.successMessageTimeout);
-    this.successMessageTimeout = window.setTimeout(() => {
+    globalThis.clearTimeout(this.successMessageTimeout);
+    this.successMessageTimeout = globalThis.setTimeout(() => {
       addSuccessMessage(t('Success!'));
     }, 0);
   }
@@ -135,8 +135,8 @@ export abstract class PluginComponentBase<
       () => callback?.()
     );
 
-    window.clearTimeout(this.errorMessageTimeout);
-    this.errorMessageTimeout = window.setTimeout(() => {
+    globalThis.clearTimeout(this.errorMessageTimeout);
+    this.errorMessageTimeout = globalThis.setTimeout(() => {
       addErrorMessage(t('Unable to save changes. Please try again.'));
     }, 0);
   }

--- a/static/app/stores/alertStore.tsx
+++ b/static/app/stores/alertStore.tsx
@@ -71,7 +71,7 @@ const storeConfig: AlertStoreDefinition = {
     }
 
     if (alert.expireAfter && !alert.neverExpire) {
-      window.setTimeout(() => {
+      globalThis.setTimeout(() => {
         this.closeAlert(alert);
       }, alert.expireAfter);
     }

--- a/static/app/stores/guideStore.spec.tsx
+++ b/static/app/stores/guideStore.spec.tsx
@@ -66,12 +66,12 @@ describe('GuideStore', () => {
     ];
 
     GuideStore.fetchSucceeded(data);
-    window.location.hash = '#assistant';
-    window.dispatchEvent(new Event('load'));
+    globalThis.location.hash = '#assistant';
+    globalThis.dispatchEvent(new Event('load'));
     expect(GuideStore.getState().currentGuide?.guide).toBe('issue');
     GuideStore.closeGuide();
     expect(GuideStore.getState().currentGuide?.guide).toBe('issue_stream');
-    window.location.hash = '';
+    globalThis.location.hash = '';
   });
 
   it('should force hide', () => {
@@ -94,7 +94,7 @@ describe('GuideStore', () => {
 
     expect(spy).toHaveBeenCalledTimes(1);
 
-    window.dispatchEvent(new Event('load'));
+    globalThis.dispatchEvent(new Event('load'));
     expect(spy).toHaveBeenCalledTimes(1);
 
     GuideStore.nextStep();

--- a/static/app/stores/guideStore.tsx
+++ b/static/app/stores/guideStore.tsx
@@ -77,7 +77,7 @@ const defaultState: GuideStoreState = {
 };
 
 function isForceEnabled() {
-  return window.location.hash === '#assistant';
+  return globalThis.location.hash === '#assistant';
 }
 
 interface GuideStoreDefinition extends StrictStoreDefinition<GuideStoreState> {

--- a/static/app/stores/indicatorStore.tsx
+++ b/static/app/stores/indicatorStore.tsx
@@ -86,7 +86,7 @@ const storeConfig: IndicatorStoreDefinition = {
     };
 
     if (options.duration) {
-      indicator.clearId = window.setTimeout(() => {
+      indicator.clearId = globalThis.setTimeout(() => {
         this.remove(indicator);
       }, options.duration);
     }
@@ -125,7 +125,7 @@ const storeConfig: IndicatorStoreDefinition = {
     this.state = this.state.filter(item => item !== indicator);
 
     if (indicator.clearId) {
-      window.clearTimeout(indicator.clearId);
+      globalThis.clearTimeout(indicator.clearId);
       indicator.clearId = null;
     }
 

--- a/static/app/stores/onboardingDrawerStore.tsx
+++ b/static/app/stores/onboardingDrawerStore.tsx
@@ -47,7 +47,7 @@ const storeConfig: OnboardingDrawerStoreDefinition = {
     this.state = '';
 
     if (hash) {
-      window.location.hash = window.location.hash.replace(`#${hash}`, '');
+      globalThis.location.hash = globalThis.location.hash.replace(`#${hash}`, '');
     }
 
     this.trigger(this.state);

--- a/static/app/stories/view/storyHeading.tsx
+++ b/static/app/stories/view/storyHeading.tsx
@@ -30,7 +30,7 @@ export function StoryHeading(props: HeadingProps) {
         href={`#${id}`}
         icon={<IconLink />}
         onClick={() =>
-          copy(`${window.location.toString().replace(/#.*$/, '')}#${id}`, {
+          copy(`${globalThis.location.toString().replace(/#.*$/, '')}#${id}`, {
             successMessage: (
               <Fragment>
                 Copied link to{' '}

--- a/static/app/utils.tsx
+++ b/static/app/utils.tsx
@@ -158,8 +158,8 @@ export function escapeDoubleQuotes(str: string) {
 }
 
 export function generateOrgSlugUrl(orgSlug: any) {
-  const sentryDomain = window.__initialData.links.sentryUrl.split('/')[2];
-  return `${window.location.protocol}//${orgSlug}.${sentryDomain}${window.location.pathname}`;
+  const sentryDomain = globalThis.__initialData.links.sentryUrl.split('/')[2];
+  return `${globalThis.location.protocol}//${orgSlug}.${sentryDomain}${globalThis.location.pathname}`;
 }
 
 /**

--- a/static/app/utils/analytics.tsx
+++ b/static/app/utils/analytics.tsx
@@ -293,11 +293,11 @@ export const metric: RecordMetric = (name, value, tags) =>
 
 // JSDOM implements window.performance but not window.performance.mark
 export const CAN_MARK =
-  window.performance &&
-  typeof window.performance.mark === 'function' &&
-  typeof window.performance.measure === 'function' &&
-  typeof window.performance.getEntriesByName === 'function' &&
-  typeof window.performance.clearMeasures === 'function';
+  globalThis.performance &&
+  typeof globalThis.performance.mark === 'function' &&
+  typeof globalThis.performance.measure === 'function' &&
+  typeof globalThis.performance.getEntriesByName === 'function' &&
+  typeof globalThis.performance.clearMeasures === 'function';
 
 metric.mark = function metricMark({name, data = {}}) {
   // Just ignore if browser is old enough that it doesn't support this
@@ -309,7 +309,7 @@ metric.mark = function metricMark({name, data = {}}) {
     throw new Error('Invalid argument provided to `metric.mark`');
   }
 
-  window.performance.mark(name);
+  globalThis.performance.mark(name);
   metricDataStore.set(name, data);
 };
 
@@ -330,7 +330,7 @@ metric.measure = function metricMeasure({name, start, end, data = {}, noCleanup}
   let endMarkName = end;
 
   // Can't destructure from performance
-  const {performance} = window;
+  const {performance} = globalThis;
 
   // NOTE: Edge REQUIRES an end mark if it is given a start mark
   // If we don't have an end mark, create one now.

--- a/static/app/utils/analytics/makeAnalyticsFunction.tsx
+++ b/static/app/utils/analytics/makeAnalyticsFunction.tsx
@@ -13,7 +13,8 @@ import type {Organization} from 'sentry/types/organization';
 const rawTrackAnalyticsEvent: Hooks['analytics:raw-track-event'] = (data, options) =>
   HookStore.get('analytics:raw-track-event').forEach(cb => cb(data, options));
 
-const hasAnalyticsDebug = () => window.localStorage?.getItem('DEBUG_ANALYTICS') === '1';
+const hasAnalyticsDebug = () =>
+  globalThis.localStorage?.getItem('DEBUG_ANALYTICS') === '1';
 
 type OptionalOrg = {
   organization: Organization | string | null;

--- a/static/app/utils/cursorPoller.tsx
+++ b/static/app/utils/cursorPoller.tsx
@@ -37,7 +37,7 @@ export class CursorPoller {
       return;
     }
 
-    const issueEndpoint = new URL(linkPreviousHref, window.location.origin);
+    const issueEndpoint = new URL(linkPreviousHref, globalThis.location.origin);
 
     // Remove collapse stats
     issueEndpoint.searchParams.delete('collapse');
@@ -52,13 +52,13 @@ export class CursorPoller {
     this.disable();
 
     this.active = true;
-    this.timeoutId = window.setTimeout(this.poll.bind(this), this.getDelay());
+    this.timeoutId = globalThis.setTimeout(this.poll.bind(this), this.getDelay());
   }
 
   disable() {
     this.active = false;
     if (this.timeoutId) {
-      window.clearTimeout(this.timeoutId);
+      globalThis.clearTimeout(this.timeoutId);
       this.timeoutId = null;
     }
 
@@ -111,7 +111,7 @@ export class CursorPoller {
         this.lastRequest = null;
 
         if (this.active) {
-          this.timeoutId = window.setTimeout(this.poll.bind(this), this.getDelay());
+          this.timeoutId = globalThis.setTimeout(this.poll.bind(this), this.getDelay());
         }
       },
     });

--- a/static/app/utils/demoMode/index.spec.tsx
+++ b/static/app/utils/demoMode/index.spec.tsx
@@ -16,13 +16,13 @@ describe('Demo Mode Functions', () => {
 
   describe('extraQueryParameter', () => {
     it('returns empty URLSearchParams if no extraQueryString is set', () => {
-      window.SandboxData = {};
+      globalThis.SandboxData = {};
       const params = extraQueryParameter();
       expect(params.toString()).toBe('');
     });
 
     it('returns URLSearchParams from extraQueryString', () => {
-      window.SandboxData = {extraQueryString: 'key=value&key2=value2'};
+      globalThis.SandboxData = {extraQueryString: 'key=value&key2=value2'};
       const params = extraQueryParameter();
       expect(params.get('key')).toBe('value');
       expect(params.get('key2')).toBe('value2');
@@ -32,13 +32,13 @@ describe('Demo Mode Functions', () => {
   describe('extraQueryParameterWithEmail', () => {
     it('appends email to URLSearchParams if present in localStorage', () => {
       localStorage.setItem('email', 'test@example.com');
-      window.SandboxData = {extraQueryString: 'key=value'};
+      globalThis.SandboxData = {extraQueryString: 'key=value'};
       const params = extraQueryParameterWithEmail();
       expect(params.get('email')).toBe('test@example.com');
     });
 
     it('does not append email if not present in localStorage', () => {
-      window.SandboxData = {extraQueryString: 'key=value'};
+      globalThis.SandboxData = {extraQueryString: 'key=value'};
       const params = extraQueryParameterWithEmail();
       expect(params.get('email')).toBeNull();
     });

--- a/static/app/utils/demoMode/index.tsx
+++ b/static/app/utils/demoMode/index.tsx
@@ -2,7 +2,7 @@ import {ConfigStore} from 'sentry/stores/configStore';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 
 export function extraQueryParameter(): URLSearchParams {
-  const extraQueryString = window.SandboxData?.extraQueryString || '';
+  const extraQueryString = globalThis.SandboxData?.extraQueryString || '';
   const extraQuery = new URLSearchParams(extraQueryString);
   return extraQuery;
 }

--- a/static/app/utils/demoMode/utils.tsx
+++ b/static/app/utils/demoMode/utils.tsx
@@ -71,7 +71,7 @@ function initDemoAnalytics() {
     const mainScript = document.createElement('script');
     mainScript.id = 'plausible-script';
     mainScript.defer = true;
-    mainScript.setAttribute('data-domain', window.location.hostname);
+    mainScript.setAttribute('data-domain', globalThis.location.hostname);
     mainScript.src = 'https://plausible.io/js/script.pageview-props.tagged-events.js';
 
     const queueScript = document.createElement('script');

--- a/static/app/utils/demoMode/utm.tsx
+++ b/static/app/utils/demoMode/utm.tsx
@@ -19,7 +19,7 @@ type UTMState = {
 };
 
 export function getUTMState(): UTMState {
-  const query = qs.parse(window.location.search);
+  const query = qs.parse(globalThis.location.search);
   const trackableQuery: Record<string, string> = Object.keys(query).reduce((a, k) => {
     return trackableParamsRegExp.test(k) && !!query[k] ? {...a, [k]: query[k]} : a;
   }, {});

--- a/static/app/utils/getCsrfToken.tsx
+++ b/static/app/utils/getCsrfToken.tsx
@@ -1,5 +1,5 @@
 import Cookies from 'js-cookie';
 
 export function getCsrfToken() {
-  return Cookies.get(window.csrfCookieName ?? 'sc') ?? '';
+  return Cookies.get(globalThis.csrfCookieName ?? 'sc') ?? '';
 }

--- a/static/app/utils/integrationUtil.tsx
+++ b/static/app/utils/integrationUtil.tsx
@@ -201,7 +201,7 @@ export const convertIntegrationTypeToSnakeCase = (
 
 export const safeGetQsParam = (param: string) => {
   try {
-    const query = qs.parse(window.location.search) || {};
+    const query = qs.parse(globalThis.location.search) || {};
     return query[param];
   } catch {
     return undefined;

--- a/static/app/utils/integrations/useAddIntegration.spec.tsx
+++ b/static/app/utils/integrations/useAddIntegration.spec.tsx
@@ -46,7 +46,7 @@ describe('useAddIntegration', () => {
       origin: document.location.origin,
     });
     Object.defineProperty(event, 'source', {value: popup});
-    window.dispatchEvent(event);
+    globalThis.dispatchEvent(event);
   }
 
   describe('legacy flow', () => {
@@ -54,7 +54,7 @@ describe('useAddIntegration', () => {
 
     beforeEach(() => {
       popup = {focus: jest.fn(), close: jest.fn()} as unknown as Window;
-      jest.spyOn(window, 'open').mockReturnValue(popup);
+      jest.spyOn(globalThis, 'open').mockReturnValue(popup);
     });
 
     it('opens a popup window when startFlow is called', () => {
@@ -211,7 +211,7 @@ describe('useAddIntegration', () => {
       });
       Object.defineProperty(event, 'source', {value: popup});
 
-      window.dispatchEvent(event);
+      globalThis.dispatchEvent(event);
 
       await act(async () => {
         await new Promise(resolve => setTimeout(resolve, 50));
@@ -307,7 +307,7 @@ describe('useAddIntegration', () => {
 
     it('does not open a popup window when the pipeline modal is used', () => {
       jest.spyOn(pipelineModal, 'openPipelineModal');
-      jest.spyOn(window, 'open');
+      jest.spyOn(globalThis, 'open');
 
       const organization = OrganizationFixture({features: []});
 
@@ -351,7 +351,7 @@ describe('useAddIntegration', () => {
     it('falls back to legacy flow when the provider is not API driven', () => {
       const openPipelineModalSpy = jest.spyOn(pipelineModal, 'openPipelineModal');
       jest
-        .spyOn(window, 'open')
+        .spyOn(globalThis, 'open')
         .mockReturnValue({focus: jest.fn(), close: jest.fn()} as unknown as Window);
 
       const organization = OrganizationFixture({features: []});

--- a/static/app/utils/isActiveSuperuser.tsx
+++ b/static/app/utils/isActiveSuperuser.tsx
@@ -3,8 +3,8 @@ import Cookies from 'js-cookie';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {OrganizationStore} from 'sentry/stores/organizationStore';
 
-const SUPERUSER_COOKIE_NAME = window.superUserCookieName ?? 'su';
-const SUPERUSER_COOKIE_DOMAIN = window.superUserCookieDomain;
+const SUPERUSER_COOKIE_NAME = globalThis.superUserCookieName ?? 'su';
+const SUPERUSER_COOKIE_DOMAIN = globalThis.superUserCookieDomain;
 
 /**
  * Checking for just isSuperuser on a config object may not be enough as backend

--- a/static/app/utils/localStorage.tsx
+++ b/static/app/utils/localStorage.tsx
@@ -1,3 +1,3 @@
 import {createStorage} from './createStorage';
 
-export const localStorageWrapper = createStorage(() => window.localStorage);
+export const localStorageWrapper = createStorage(() => globalThis.localStorage);

--- a/static/app/utils/performanceForSentry/index.tsx
+++ b/static/app/utils/performanceForSentry/index.tsx
@@ -85,7 +85,7 @@ const PerformanceInteraction = (function () {
         _INTERACTION_SPAN = span || null;
 
         // Auto interaction timeout
-        _INTERACTION_TIMEOUT_ID = window.setTimeout(() => {
+        _INTERACTION_TIMEOUT_ID = globalThis.setTimeout(() => {
           if (!_INTERACTION_SPAN) {
             return;
           }
@@ -194,7 +194,7 @@ export function VisuallyCompleteWithData({
 
         performance.mark(`${id}-${VCD_END}-pretimeout`);
 
-        window.setTimeout(() => {
+        globalThis.setTimeout(() => {
           if (!browserPerformanceTimeOrigin) {
             return;
           }
@@ -585,8 +585,8 @@ export const addUIElementTag = (transaction: TransactionEvent) => {
 
 function supportsINP() {
   return (
-    'PerformanceObserver' in window &&
-    'PerformanceEventTiming' in window &&
+    'PerformanceObserver' in globalThis &&
+    'PerformanceEventTiming' in globalThis &&
     'interactionId' in PerformanceEventTiming.prototype
   );
 }

--- a/static/app/utils/profiling/canvasScheduler.tsx
+++ b/static/app/utils/profiling/canvasScheduler.tsx
@@ -133,10 +133,10 @@ export class CanvasScheduler {
 
   draw(): void {
     if (this.requestAnimationFrame) {
-      window.cancelAnimationFrame(this.requestAnimationFrame);
+      globalThis.cancelAnimationFrame(this.requestAnimationFrame);
     }
 
-    this.requestAnimationFrame = window.requestAnimationFrame(() => {
+    this.requestAnimationFrame = globalThis.requestAnimationFrame(() => {
       for (const cb of this.beforeFrameCallbacks) {
         cb();
       }

--- a/static/app/utils/profiling/hooks/useContextMenu.tsx
+++ b/static/app/utils/profiling/hooks/useContextMenu.tsx
@@ -141,7 +141,7 @@ export function useContextMenu({container}: UseContextMenuOptions) {
       return undefined;
     }
 
-    const resizeObserver = new window.ResizeObserver(entries => {
+    const resizeObserver = new globalThis.ResizeObserver(entries => {
       const contentRect = entries[0]!.contentRect;
       setMenuCoordinates(new Rect(0, 0, contentRect.width, contentRect.height));
     });
@@ -159,7 +159,7 @@ export function useContextMenu({container}: UseContextMenuOptions) {
       return undefined;
     }
 
-    const resizeObserver = new window.ResizeObserver(entries => {
+    const resizeObserver = new globalThis.ResizeObserver(entries => {
       const contentRect = entries[0]!.contentRect;
       setContainerCoordinates(new Rect(0, 0, contentRect.width, contentRect.height));
     });

--- a/static/app/utils/profiling/hooks/useInternalFlamegraphDebugMode.ts
+++ b/static/app/utils/profiling/hooks/useInternalFlamegraphDebugMode.ts
@@ -24,8 +24,8 @@ export function useInternalFlamegraphDebugMode() {
         });
       }
     }
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
+    globalThis.addEventListener('keydown', handleKeyDown);
+    return () => globalThis.removeEventListener('keydown', handleKeyDown);
   });
 
   return isEnabled;

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.spec.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.spec.tsx
@@ -31,8 +31,8 @@ class ResizeObserver {
   disconnect() {}
 }
 
-window.ResizeObserver = ResizeObserver;
-window.requestAnimationFrame = (cb: FrameRequestCallback) => {
+globalThis.ResizeObserver = ResizeObserver;
+globalThis.requestAnimationFrame = (cb: FrameRequestCallback) => {
   cb(performance.now());
   return 0;
 };

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
@@ -240,10 +240,10 @@ export function useVirtualizedTree<T extends TreeLike>(
       }
       const scrollTop = Math.max(0, evt.target.scrollTop);
       if (raf !== undefined) {
-        window.cancelAnimationFrame(raf);
+        globalThis.cancelAnimationFrame(raf);
       }
 
-      raf = window.requestAnimationFrame(() => {
+      raf = globalThis.requestAnimationFrame(() => {
         dispatch({type: 'set scroll top', payload: scrollTop});
         if (Array.isArray(props.scrollContainer)) {
           for (const element of props.scrollContainer) {
@@ -325,7 +325,7 @@ export function useVirtualizedTree<T extends TreeLike>(
 
     return () => {
       if (raf !== undefined) {
-        window.cancelAnimationFrame(raf);
+        globalThis.cancelAnimationFrame(raf);
       }
       if (!scrollContainer) {
         return;
@@ -871,8 +871,8 @@ export function useVirtualizedTree<T extends TreeLike>(
       return undefined;
     }
     let rafId: number | undefined;
-    const resizeObserver = new window.ResizeObserver(elements => {
-      rafId = window.requestAnimationFrame(() => {
+    const resizeObserver = new globalThis.ResizeObserver(elements => {
+      rafId = globalThis.requestAnimationFrame(() => {
         // We only care about changes to the height of the scroll container,
         // if it has not changed then do not update the scroll height.
         if (elements[0]?.contentRect?.height !== latestStateRef.current.scrollHeight) {
@@ -894,7 +894,7 @@ export function useVirtualizedTree<T extends TreeLike>(
 
     return () => {
       if (typeof rafId === 'number') {
-        window.cancelAnimationFrame(rafId);
+        globalThis.cancelAnimationFrame(rafId);
       }
       resizeObserver.disconnect();
     };

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/virtualizedTreeUtils.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/virtualizedTreeUtils.tsx
@@ -137,25 +137,25 @@ export function requestAnimationTimeout(
 
   const timeout = () => {
     if (start === undefined) {
-      frame.id = window.requestAnimationFrame(timeout);
+      frame.id = globalThis.requestAnimationFrame(timeout);
       return;
     }
     if (Date.now() - start >= delay) {
       callback();
     } else {
-      frame.id = window.requestAnimationFrame(timeout);
+      frame.id = globalThis.requestAnimationFrame(timeout);
     }
   };
 
   const frame: AnimationTimeoutId = {
-    id: window.requestAnimationFrame(timeout),
+    id: globalThis.requestAnimationFrame(timeout),
   };
 
   return frame;
 }
 
 export function cancelAnimationTimeout(frame: AnimationTimeoutId) {
-  window.cancelAnimationFrame(frame.id);
+  globalThis.cancelAnimationFrame(frame.id);
 }
 
 function findOptimisticStartIndex<T extends TreeLike>({

--- a/static/app/utils/replays/hooks/useShareReplayAtTimestamp.tsx
+++ b/static/app/utils/replays/hooks/useShareReplayAtTimestamp.tsx
@@ -19,7 +19,7 @@ function ShareModal({currentTimeSec, Header, Body}: any) {
   const [customSeconds, setSeconds] = useState(currentTimeSec);
   const [shareMode, setShareMode] = useState<'current' | 'user'>('current');
 
-  const url = new URL(window.location.href);
+  const url = new URL(globalThis.location.href);
   const {searchParams} = url;
   searchParams.set('referrer', getRouteStringFromRoutes({matches}));
   searchParams.set(

--- a/static/app/utils/replays/playback/hooks/useTouchEventsCheck.tsx
+++ b/static/app/utils/replays/playback/hooks/useTouchEventsCheck.tsx
@@ -23,7 +23,7 @@ export function useTouchEventsCheck({replay}: Props) {
           pointer_id: t?.[0]?.data.pointerId,
           number_of_events: t?.length,
           replay_id: replayData.id,
-          url: window.location.href,
+          url: globalThis.location.href,
         });
       }
     });

--- a/static/app/utils/replays/replayerStepper.tsx
+++ b/static/app/utils/replays/replayerStepper.tsx
@@ -80,7 +80,7 @@ export function replayerStepper<
     const considerFrame = (frame: Frame) => {
       if (shouldVisitFrame(frame, replayer)) {
         frameRef.current = frame;
-        window.requestAnimationFrame(() => {
+        globalThis.requestAnimationFrame(() => {
           const timestamp =
             'offsetMs' in frame ? frame.offsetMs : frame.timestamp - startTimestampMs;
           replayer.pause(timestamp);

--- a/static/app/utils/replays/timer.tsx
+++ b/static/app/utils/replays/timer.tsx
@@ -16,7 +16,7 @@ export class Timer extends EventTarget {
       return;
     }
 
-    this._time = (window.performance.now() - this._start) * this._speed;
+    this._time = (globalThis.performance.now() - this._start) * this._speed;
     // We don't expect _callbacks to be very large, so we can deal with a
     // linear search
     this._callbacks.forEach((value, key, callbacks) => {
@@ -26,7 +26,7 @@ export class Timer extends EventTarget {
         callbacks.set(key, []);
       }
     });
-    this._id = window.requestAnimationFrame(this.step);
+    this._id = globalThis.requestAnimationFrame(this.step);
   };
 
   /**
@@ -37,7 +37,7 @@ export class Timer extends EventTarget {
     // we're dividing by the speed here because we multiply
     // by the same factor up in step(). doing the math,
     // you'll see that this._time turns out to be just `seconds`.
-    this._start = window.performance.now() - (seconds ?? 0) / this._speed;
+    this._start = globalThis.performance.now() - (seconds ?? 0) / this._speed;
     this.resume();
     this.step();
   }
@@ -50,9 +50,9 @@ export class Timer extends EventTarget {
       // already paused, do nothing
       return;
     }
-    this._pausedAt = window.performance.now();
+    this._pausedAt = globalThis.performance.now();
     if (this._id) {
-      window.cancelAnimationFrame(this._id);
+      globalThis.cancelAnimationFrame(this._id);
     }
     this._active = false;
   }
@@ -66,11 +66,11 @@ export class Timer extends EventTarget {
 
     // adjust for time passing since pausing
     if (this._pausedAt) {
-      this._start += window.performance.now() - this._pausedAt;
+      this._start += globalThis.performance.now() - this._pausedAt;
       this._pausedAt = 0;
     }
 
-    this._id = window.requestAnimationFrame(this.step);
+    this._id = globalThis.requestAnimationFrame(this.step);
   }
 
   reset() {

--- a/static/app/utils/resolveRoute.spec.tsx
+++ b/static/app/utils/resolveRoute.spec.tsx
@@ -29,19 +29,19 @@ describe('resolveRoute', () => {
   });
 
   beforeEach(() => {
-    devUi = window.__SENTRY_DEV_UI;
+    devUi = globalThis.__SENTRY_DEV_UI;
     configState = ConfigStore.getState();
     ConfigStore.set('features', new Set(['system:multi-region']));
   });
   afterEach(() => {
-    window.__SENTRY_DEV_UI = devUi;
+    globalThis.__SENTRY_DEV_UI = devUi;
     ConfigStore.loadInitialData(configState);
 
     mockDeployPreviewConfig.mockReset();
   });
 
   it('should replace domains with dev-ui mode on localhost', () => {
-    window.__SENTRY_DEV_UI = true;
+    globalThis.__SENTRY_DEV_UI = true;
     setWindowLocation('http://acme.localhost:7999');
 
     const result = resolveRoute('/issues/', organization, otherOrg);
@@ -49,7 +49,7 @@ describe('resolveRoute', () => {
   });
 
   it('should replace domains with dev-ui mode on dev.getsentry.net', () => {
-    window.__SENTRY_DEV_UI = true;
+    globalThis.__SENTRY_DEV_UI = true;
     setWindowLocation('http://acme.dev.getsentry.net:7999');
 
     const result = resolveRoute('/issues/', organization, otherOrg);
@@ -58,7 +58,7 @@ describe('resolveRoute', () => {
 
   it('should use path slugs on sentry.dev', () => {
     // Vercel previews don't let us have additional subdomains.
-    window.__SENTRY_DEV_UI = true;
+    globalThis.__SENTRY_DEV_UI = true;
     setWindowLocation('http://sentry-abc123.sentry.dev');
 
     mockDeployPreviewConfig.mockReturnValue({
@@ -79,7 +79,7 @@ describe('resolveRoute', () => {
   });
 
   it('will not replace domains with dev-ui mode and an unsafe host', () => {
-    window.__SENTRY_DEV_UI = true;
+    globalThis.__SENTRY_DEV_UI = true;
     setWindowLocation('http://bad-domain.com');
 
     const result = resolveRoute('/issues/', organization, otherOrg);

--- a/static/app/utils/resolveRoute.tsx
+++ b/static/app/utils/resolveRoute.tsx
@@ -10,15 +10,15 @@ import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
  * In order to not redirect to production we swap domains.
  */
 function localizeDomain(domain?: string) {
-  if (!window.__SENTRY_DEV_UI || !domain) {
+  if (!globalThis.__SENTRY_DEV_UI || !domain) {
     return domain;
   }
   // Vercel doesn't support subdomains, stay on the current host.
   if (DEPLOY_PREVIEW_CONFIG) {
-    return `https://${window.location.host}`;
+    return `https://${globalThis.location.host}`;
   }
 
-  const slugDomain = extractSlug(window.location.host);
+  const slugDomain = extractSlug(globalThis.location.host);
   if (!slugDomain) {
     return domain;
   }

--- a/static/app/utils/scheduleMicroTask.ts
+++ b/static/app/utils/scheduleMicroTask.ts
@@ -1,15 +1,15 @@
-const SUPPORTS_QUEUE_MICROTASK = window && 'queueMicrotask' in window;
+const SUPPORTS_QUEUE_MICROTASK = globalThis && 'queueMicrotask' in globalThis;
 
 export function scheduleMicroTask(callback: () => void) {
   if (SUPPORTS_QUEUE_MICROTASK) {
-    window.queueMicrotask(callback);
+    globalThis.queueMicrotask(callback);
   } else {
     Promise.resolve()
       .then(callback)
       .catch(e => {
         // Escape the promise and throw the error so it gets reported
-        if (window) {
-          window.setTimeout(() => {
+        if (globalThis) {
+          globalThis.setTimeout(() => {
             throw e;
           });
         } else {

--- a/static/app/utils/selectText.tsx
+++ b/static/app/utils/selectText.tsx
@@ -7,11 +7,11 @@ export function selectText(node: HTMLElement): void {
     return;
   }
 
-  if (node instanceof Node && window.getSelection) {
+  if (node instanceof Node && globalThis.getSelection) {
     const range = document.createRange();
     range.selectNode(node);
 
-    const selection = window.getSelection();
+    const selection = globalThis.getSelection();
     selection?.removeAllRanges();
     selection?.addRange(range);
   }

--- a/static/app/utils/sessionStorage.tsx
+++ b/static/app/utils/sessionStorage.tsx
@@ -1,3 +1,3 @@
 import {createStorage} from './createStorage';
 
-export const sessionStorageWrapper = createStorage(() => window.sessionStorage);
+export const sessionStorageWrapper = createStorage(() => globalThis.sessionStorage);

--- a/static/app/utils/shouldPreloadData.tsx
+++ b/static/app/utils/shouldPreloadData.tsx
@@ -2,7 +2,7 @@ import type {Config} from 'sentry/types/system';
 
 // Skips data preload if the user is on an invitation acceptance page as they might not have access to the data yet, leading to a 403 error.
 export function shouldPreloadData(config: Config): boolean {
-  if (window.location.pathname.startsWith('/accept/')) {
+  if (globalThis.location.pathname.startsWith('/accept/')) {
     return false;
   }
 

--- a/static/app/utils/silence-react-unsafe-warnings.ts
+++ b/static/app/utils/silence-react-unsafe-warnings.ts
@@ -10,7 +10,7 @@ const ignoredWarnings = [
   /moment construction falls back/,
 ];
 
-window.console.warn = (message: any, ...args: any[]) => {
+globalThis.console.warn = (message: any, ...args: any[]) => {
   if (
     typeof message === 'string' &&
     ignoredWarnings.some(warning => warning.test(message))

--- a/static/app/utils/statics-setup.tsx
+++ b/static/app/utils/statics-setup.tsx
@@ -17,4 +17,4 @@ declare var __webpack_public_path__: string; // eslint-disable-line no-var
  * for now as a quick workaround for the index.html being aware of versioned
  * asset paths.
  */
-__webpack_public_path__ = window.__initialData?.distPrefix || '/_assets/';
+__webpack_public_path__ = globalThis.__initialData?.distPrefix || '/_assets/';

--- a/static/app/utils/testableWindowLocation.tsx
+++ b/static/app/utils/testableWindowLocation.tsx
@@ -1,8 +1,8 @@
 /**
  * This object is mocked in tests to work around JSDOM's non configurable location.
  */
-export const testableWindowLocation = window.location as Pick<
-  typeof window.location,
+export const testableWindowLocation = globalThis.location as Pick<
+  typeof globalThis.location,
   // Use `setWindowLocation` to modify the window.location.pathname instead of mocking properties on the testableLocation object
   'assign' | 'replace' | 'reload'
 >;

--- a/static/app/utils/touch.tsx
+++ b/static/app/utils/touch.tsx
@@ -14,7 +14,7 @@ export function getPointerPosition(
   property: 'pageX' | 'pageY' | 'clientX' | 'clientY'
 ): number {
   const actual = isReactEvent(event) ? event.nativeEvent : event;
-  if (window.TouchEvent && actual instanceof TouchEvent) {
+  if (globalThis.TouchEvent && actual instanceof TouchEvent) {
     return actual.targetTouches[0]![property];
   }
   if (actual instanceof MouseEvent) {

--- a/static/app/utils/url/urlParamBatchContext.tsx
+++ b/static/app/utils/url/urlParamBatchContext.tsx
@@ -26,9 +26,9 @@ export function UrlParamBatchProvider({children}: {children: React.ReactNode}) {
 
     navigate(
       {
-        pathname: window.location.pathname,
+        pathname: globalThis.location.pathname,
         query: {
-          ...qs.parse(window.location.search),
+          ...qs.parse(globalThis.location.search),
           ...pendingUpdates.current,
         },
       },

--- a/static/app/utils/useDevicePixelRatio.tsx
+++ b/static/app/utils/useDevicePixelRatio.tsx
@@ -15,12 +15,12 @@ function useDevicePixelRatio(): number {
   }, []);
 
   useLayoutEffect(() => {
-    window
+    globalThis
       .matchMedia(`(resolution: ${devicePixelRatio}dppx)`)
       .addEventListener('change', updateDevicePixelRatio, {once: true});
 
     return () => {
-      window
+      globalThis
         .matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`)
         .removeEventListener('change', updateDevicePixelRatio);
     };

--- a/static/app/utils/useDispatchingReducer.spec.tsx
+++ b/static/app/utils/useDispatchingReducer.spec.tsx
@@ -5,12 +5,12 @@ import {useDispatchingReducer} from 'sentry/utils/useDispatchingReducer';
 
 describe('useDispatchingReducer', () => {
   beforeEach(() => {
-    window.requestAnimationFrame = jest
+    globalThis.requestAnimationFrame = jest
       .fn()
       .mockImplementation((cb: FrameRequestCallback) => {
         return setTimeout(cb, 0);
       });
-    window.cancelAnimationFrame = jest.fn().mockImplementation(id => {
+    globalThis.cancelAnimationFrame = jest.fn().mockImplementation(id => {
       return clearTimeout(id);
     });
     jest.useFakeTimers();

--- a/static/app/utils/useDispatchingReducer.tsx
+++ b/static/app/utils/useDispatchingReducer.tsx
@@ -121,11 +121,11 @@ export function useDispatchingReducer<R extends React.Reducer<any, any>>(
       actionQueue.current.push(a);
 
       if (updatesRef.current) {
-        window.cancelAnimationFrame(updatesRef.current);
+        globalThis.cancelAnimationFrame(updatesRef.current);
         updatesRef.current = null;
       }
 
-      updatesRef.current = window.requestAnimationFrame(() => {
+      updatesRef.current = globalThis.requestAnimationFrame(() => {
         setState(s => {
           const next = update(s, actionQueue.current, reducerRef.current, emitter);
           stateRef.current = next;

--- a/static/app/utils/useHoverOverlay.tsx
+++ b/static/app/utils/useHoverOverlay.tsx
@@ -156,7 +156,7 @@ export function isOverflown(el: Element): boolean {
 
 function maybeClearRefTimeout(ref: React.MutableRefObject<number | undefined>) {
   if (typeof ref.current === 'number') {
-    window.clearTimeout(ref.current);
+    globalThis.clearTimeout(ref.current);
     ref.current = undefined;
   }
 }
@@ -257,7 +257,7 @@ function useHoverOverlay({
       return;
     }
 
-    delayOpenTimeoutRef.current = window.setTimeout(
+    delayOpenTimeoutRef.current = globalThis.setTimeout(
       () => setIsVisible(true),
       delay ?? OPEN_DELAY
     );
@@ -272,7 +272,7 @@ function useHoverOverlay({
       return;
     }
 
-    delayHideTimeoutRef.current = window.setTimeout(() => {
+    delayHideTimeoutRef.current = globalThis.setTimeout(() => {
       setIsVisible(false);
     }, displayTimeout ?? CLOSE_DELAY);
   }, [isHoverable, displayTimeout]);

--- a/static/app/utils/useLocalStorageState.spec.tsx
+++ b/static/app/utils/useLocalStorageState.spec.tsx
@@ -192,7 +192,7 @@ describe('useLocalStorageState', () => {
     const recursiveReferenceMap = new Map();
     recursiveReferenceMap.set('key', recursiveReferenceMap);
 
-    jest.spyOn(window, 'queueMicrotask').mockImplementation(cb => cb());
+    jest.spyOn(globalThis, 'queueMicrotask').mockImplementation(cb => cb());
 
     const {result} = renderHook(
       (args: Parameters<typeof useLocalStorageState>) =>
@@ -209,7 +209,7 @@ describe('useLocalStorageState', () => {
     const recursiveObject: Record<string, any> = {};
     recursiveObject.key = recursiveObject;
 
-    jest.spyOn(window, 'queueMicrotask').mockImplementation(cb => cb());
+    jest.spyOn(globalThis, 'queueMicrotask').mockImplementation(cb => cb());
 
     const {result} = renderHook(
       (args: Parameters<typeof useLocalStorageState>) =>
@@ -243,7 +243,7 @@ describe('useLocalStorageState', () => {
     );
 
     // Immediately execute microtask so that the error is not thrown from the current execution stack and can be caught by a try/catch
-    jest.spyOn(window, 'queueMicrotask').mockImplementation(cb => cb());
+    jest.spyOn(globalThis, 'queueMicrotask').mockImplementation(cb => cb());
 
     expect(() => result.current[1](value)).toThrow(
       `useLocalStorage: Native serialization of ${type.split(' ')[0]} is not supported`

--- a/static/app/utils/useLocalStorageState.ts
+++ b/static/app/utils/useLocalStorageState.ts
@@ -4,7 +4,7 @@ import {localStorageWrapper} from 'sentry/utils/localStorage';
 
 import {scheduleMicroTask} from './scheduleMicroTask';
 
-const SUPPORTS_LOCAL_STORAGE = window && 'localStorage' in window;
+const SUPPORTS_LOCAL_STORAGE = globalThis && 'localStorage' in globalThis;
 
 // Attempt to parse JSON. If it fails, swallow the error and return null.
 // As an improvement, we should maybe allow users to intercept here or possibly use

--- a/static/app/utils/useMedia.tsx
+++ b/static/app/utils/useMedia.tsx
@@ -4,15 +4,15 @@ import {useEffect, useState} from 'react';
  * Hook that updates when a media query result changes
  */
 export function useMedia(query: string) {
-  const [state, setState] = useState(() => window.matchMedia?.(query)?.matches);
+  const [state, setState] = useState(() => globalThis.matchMedia?.(query)?.matches);
 
   useEffect(() => {
     let mounted = true;
-    if (!window.matchMedia) {
+    if (!globalThis.matchMedia) {
       return undefined;
     }
 
-    const mql = window.matchMedia(query);
+    const mql = globalThis.matchMedia(query);
     const onChange = () => {
       if (!mounted) {
         return;
@@ -29,7 +29,7 @@ export function useMedia(query: string) {
     };
   }, [query]);
 
-  if (!window.matchMedia) {
+  if (!globalThis.matchMedia) {
     return false;
   }
 

--- a/static/app/utils/useRAF.tsx
+++ b/static/app/utils/useRAF.tsx
@@ -4,8 +4,8 @@ export function useRAF(callback: () => unknown, opts?: {enabled: boolean}) {
   const {enabled = true} = opts ?? {};
   useEffect(() => {
     if (enabled) {
-      const timer = window.requestAnimationFrame(callback);
-      return () => window.cancelAnimationFrame(timer);
+      const timer = globalThis.requestAnimationFrame(callback);
+      return () => globalThis.cancelAnimationFrame(timer);
     }
     return () => {};
   }, [callback, enabled]);

--- a/static/app/utils/useResizableDrawer.tsx
+++ b/static/app/utils/useResizableDrawer.tsx
@@ -108,10 +108,10 @@ export function useResizableDrawer(options: UseResizableDrawerOptions): {
       document.documentElement.style.cursor = isXAxis ? 'ew-resize' : 'ns-resize';
 
       if (rafIdRef.current !== null) {
-        window.cancelAnimationFrame(rafIdRef.current);
+        globalThis.cancelAnimationFrame(rafIdRef.current);
       }
 
-      rafIdRef.current = window.requestAnimationFrame(() => {
+      rafIdRef.current = globalThis.requestAnimationFrame(() => {
         if (!currentMouseVectorRaf.current) {
           return;
         }
@@ -165,7 +165,7 @@ export function useResizableDrawer(options: UseResizableDrawerOptions): {
   useLayoutEffect(() => {
     return () => {
       if (rafIdRef.current !== null) {
-        window.cancelAnimationFrame(rafIdRef.current);
+        globalThis.cancelAnimationFrame(rafIdRef.current);
       }
     };
   });

--- a/static/app/utils/useSessionStorage.tsx
+++ b/static/app/utils/useSessionStorage.tsx
@@ -2,7 +2,7 @@ import {useCallback, useEffect, useState, type SetStateAction} from 'react';
 
 import {sessionStorageWrapper} from 'sentry/utils/sessionStorage';
 
-const isBrowser = typeof window !== 'undefined';
+const isBrowser = typeof globalThis.window !== 'undefined';
 
 export function readStorageValue(key: string, initialValue: unknown) {
   const value = sessionStorageWrapper.getItem(key);

--- a/static/app/utils/useSyncedLocalStorageState.tsx
+++ b/static/app/utils/useSyncedLocalStorageState.tsx
@@ -37,7 +37,7 @@ export function useSyncedLocalStorageState<S>(
       setValue(newValue);
 
       // We use a custom event to notify all consumers of this hook
-      window.dispatchEvent(
+      globalThis.dispatchEvent(
         new CustomEvent(SYNCED_STORAGE_EVENT, {detail: {key, value: newValue}})
       );
     },
@@ -51,10 +51,13 @@ export function useSyncedLocalStorageState<S>(
       }
     };
 
-    window.addEventListener(SYNCED_STORAGE_EVENT, handleNewSyncedLocalStorageEvent);
+    globalThis.addEventListener(SYNCED_STORAGE_EVENT, handleNewSyncedLocalStorageEvent);
 
     return () => {
-      window.removeEventListener(SYNCED_STORAGE_EVENT, handleNewSyncedLocalStorageEvent);
+      globalThis.removeEventListener(
+        SYNCED_STORAGE_EVENT,
+        handleNewSyncedLocalStorageEvent
+      );
     };
   }, [key, setValue, value]);
 

--- a/static/app/utils/useTimeout.tsx
+++ b/static/app/utils/useTimeout.tsx
@@ -16,14 +16,14 @@ export function useTimeout({timeMs, onTimeout}: Options) {
 
   const saveTimeout = useCallback((timeout: number | null) => {
     if (timeoutRef.current) {
-      window.clearTimeout(timeoutRef.current);
+      globalThis.clearTimeout(timeoutRef.current);
     }
     timeoutRef.current = timeout;
   }, []);
 
   const start = useCallback(() => {
     saveTimeout(null);
-    saveTimeout(window.setTimeout(() => onTimeoutRef.current(), timeMs));
+    saveTimeout(globalThis.setTimeout(() => onTimeoutRef.current(), timeMs));
   }, [saveTimeout, timeMs]);
 
   const cancel = useCallback(() => {

--- a/static/app/utils/withDomainRedirect.tsx
+++ b/static/app/utils/withDomainRedirect.tsx
@@ -44,7 +44,7 @@ export function withDomainRedirect(WrappedComponent: RouteComponent) {
 
     if (customerDomain) {
       // Customer domain is being used on a route that has an :orgId parameter.
-      const redirectPath = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+      const redirectPath = `${globalThis.location.pathname}${globalThis.location.search}${globalThis.location.hash}`;
       const redirectURL = `${trimEnd(sentryUrl, '/')}/${trimStart(redirectPath, '/')}`;
 
       // If we have domain information, but the subdomain and slug are different
@@ -74,8 +74,8 @@ export function withDomainRedirect(WrappedComponent: RouteComponent) {
 
       const orglessRedirectPath = generatePath(orglessSlugRoute, params);
       const redirectOrgURL = `/${trim(orglessRedirectPath, '/')}/${
-        window.location.search
-      }${window.location.hash}`;
+        globalThis.location.search
+      }${globalThis.location.hash}`;
 
       // Redirect to a route path with :orgId omitted.
       return <Redirect to={redirectOrgURL} router={router} />;

--- a/static/app/utils/withDomainRequired.tsx
+++ b/static/app/utils/withDomainRequired.tsx
@@ -42,7 +42,7 @@ export function withDomainRequired(WrappedComponent: RouteComponent) {
     if (!customerDomain || !hasCustomerDomain) {
       // This route should only be accessed if a customer domain is used.
       // We redirect the user to the sentryUrl.
-      const redirectPath = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+      const redirectPath = `${globalThis.location.pathname}${globalThis.location.search}${globalThis.location.hash}`;
       const redirectURL = `${trimEnd(sentryUrl, '/')}/${trimStart(redirectPath, '/')}`;
       testableWindowLocation.replace(redirectURL);
       return null;

--- a/static/app/utils/zendesk.tsx
+++ b/static/app/utils/zendesk.tsx
@@ -5,7 +5,7 @@
  */
 export async function activateZendesk() {
   if (await zendeskIsLoaded()) {
-    window.zE.activate({hideOnClose: true});
+    globalThis.zE.activate({hideOnClose: true});
   }
 }
 
@@ -14,7 +14,7 @@ export async function activateZendesk() {
  * widget is correctly loaded.
  */
 export function hasZendesk() {
-  return window.zE && typeof window.zE.activate === 'function';
+  return globalThis.zE && typeof globalThis.zE.activate === 'function';
 }
 
 /**
@@ -22,7 +22,7 @@ export function hasZendesk() {
  * configurations (such as Firefox's Strict Mode)
  */
 export async function zendeskIsLoaded() {
-  if (!window.zE || typeof window.zE.activate !== 'function') {
+  if (!globalThis.zE || typeof globalThis.zE.activate !== 'function') {
     return false;
   }
 

--- a/static/app/views/acceptProjectTransfer/index.spec.tsx
+++ b/static/app/views/acceptProjectTransfer/index.spec.tsx
@@ -36,8 +36,8 @@ describe('AcceptProjectTransfer', () => {
   });
 
   it('renders and fetches data from the region url', () => {
-    window.__initialData = {
-      ...window.__initialData,
+    globalThis.__initialData = {
+      ...globalThis.__initialData,
       links: {
         regionUrl: 'http://us.sentry.io',
         sentryUrl: 'http://sentry.io',

--- a/static/app/views/acceptProjectTransfer/index.tsx
+++ b/static/app/views/acceptProjectTransfer/index.tsx
@@ -29,7 +29,7 @@ function AcceptProjectTransfer() {
     // Because this route happens outside of OrganizationContext we
     // need to use initial data to decide which host to send the request to
     // as `/accept-transfer/` cannot be resolved to a region.
-    const initialData = window.__initialData;
+    const initialData = globalThis.__initialData;
     let host: string | undefined = undefined;
     if (initialData && initialData.links?.regionUrl !== initialData.links?.sentryUrl) {
       host = initialData.links.regionUrl;

--- a/static/app/views/alerts/rules/issue/addIntegrationRow.spec.tsx
+++ b/static/app/views/alerts/rules/issue/addIntegrationRow.spec.tsx
@@ -47,7 +47,7 @@ describe('AddIntegrationRow', () => {
     const focus = jest.fn();
     const open = jest.fn().mockReturnValue({focus, close: jest.fn()});
     // any is needed here because getSentry has different types for global
-    (global as any).open = open;
+    (globalThis as any).open = open;
 
     render(getComponent(), {organization: org});
 

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -187,7 +187,7 @@ class IssueRuleEditor extends DeprecatedAsyncComponent<Props, State> {
   componentWillUnmount() {
     super.componentWillUnmount();
     this.isUnmounted = true;
-    window.clearTimeout(this.pollingTimeout);
+    globalThis.clearTimeout(this.pollingTimeout);
     this.checkIncompatibleRuleDebounced.cancel();
   }
 
@@ -331,9 +331,9 @@ class IssueRuleEditor extends DeprecatedAsyncComponent<Props, State> {
       const {status, rule, error} = response;
 
       if (status === 'pending') {
-        window.clearTimeout(this.pollingTimeout);
+        globalThis.clearTimeout(this.pollingTimeout);
 
-        this.pollingTimeout = window.setTimeout(() => {
+        this.pollingTimeout = globalThis.setTimeout(() => {
           this.pollHandler(quitTime);
         }, 1000);
         return;
@@ -408,9 +408,9 @@ class IssueRuleEditor extends DeprecatedAsyncComponent<Props, State> {
     // or failed status but we don't want to poll forever so we pass
     // in a hard stop time of 3 minutes before we bail.
     const quitTime = Date.now() + POLLING_MAX_TIME_LIMIT;
-    window.clearTimeout(this.pollingTimeout);
+    globalThis.clearTimeout(this.pollingTimeout);
 
-    this.pollingTimeout = window.setTimeout(() => {
+    this.pollingTimeout = globalThis.setTimeout(() => {
       this.pollHandler(quitTime);
     }, 1000);
   }

--- a/static/app/views/alerts/rules/issue/ruleNodeList.tsx
+++ b/static/app/views/alerts/rules/issue/ruleNodeList.tsx
@@ -136,7 +136,7 @@ const groupSelectOptions = (actions: IssueAlertRuleActionTemplate[]) => {
 
 export class RuleNodeList extends Component<Props> {
   componentWillUnmount() {
-    window.clearTimeout(this.propertyChangeTimeout);
+    globalThis.clearTimeout(this.propertyChangeTimeout);
   }
 
   propertyChangeTimeout: number | undefined = undefined;
@@ -210,8 +210,8 @@ export class RuleNodeList extends Component<Props> {
           // is undefined even if initial value is defined
           // can't directly call onPropertyChange, because
           // getNode is called during render
-          window.clearTimeout(this.propertyChangeTimeout);
-          this.propertyChangeTimeout = window.setTimeout(() =>
+          globalThis.clearTimeout(this.propertyChangeTimeout);
+          this.propertyChangeTimeout = globalThis.setTimeout(() =>
             onPropertyChange(itemIdx, 'comparisonInterval', '1w')
           );
         }

--- a/static/app/views/alerts/rules/metric/details/anomalyDetectionFeedbackBanner.tsx
+++ b/static/app/views/alerts/rules/metric/details/anomalyDetectionFeedbackBanner.tsx
@@ -34,7 +34,7 @@ export function AnomalyDetectionFeedbackBanner({
     });
     feedbackClient.captureEvent({
       request: {
-        url: window.location.href, // gives the full url (origin + pathname)
+        url: globalThis.location.href, // gives the full url (origin + pathname)
       },
       tags: {
         featureName: 'anomaly-detection-alerts-feedback',

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -210,7 +210,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
   }
 
   componentWillUnmount() {
-    window.clearTimeout(this.pollingTimeout);
+    globalThis.clearTimeout(this.pollingTimeout);
   }
 
   getDefaultState(): State {
@@ -325,8 +325,8 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
     // or failed status but we don't want to poll forever so we pass
     // in a hard stop time of 3 minutes before we bail.
     const quitTime = Date.now() + POLLING_MAX_TIME_LIMIT;
-    window.clearTimeout(this.pollingTimeout);
-    this.pollingTimeout = window.setTimeout(() => {
+    globalThis.clearTimeout(this.pollingTimeout);
+    this.pollingTimeout = globalThis.setTimeout(() => {
       this.pollHandler(model, quitTime, loadingSlackIndicator);
     }, 1000);
   }
@@ -357,9 +357,9 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
       const {status, alertRule, error} = response;
 
       if (status === 'pending') {
-        window.clearTimeout(this.pollingTimeout);
+        globalThis.clearTimeout(this.pollingTimeout);
 
-        this.pollingTimeout = window.setTimeout(() => {
+        this.pollingTimeout = globalThis.setTimeout(() => {
           this.pollHandler(model, quitTime, loadingSlackIndicator);
         }, 1000);
         return;

--- a/static/app/views/automations/components/editConnectedMonitors.tsx
+++ b/static/app/views/automations/components/editConnectedMonitors.tsx
@@ -233,7 +233,7 @@ function SpecificMonitorsSection({
       {
         ariaLabel: t('Connect Monitors'),
         shouldCloseOnLocationChange: nextLocation =>
-          nextLocation.pathname !== window.location.pathname,
+          nextLocation.pathname !== globalThis.location.pathname,
         shouldCloseOnInteractOutside: el => {
           if (!ref.current) {
             return true;

--- a/static/app/views/dashboards/dashboard.tsx
+++ b/static/app/views/dashboards/dashboard.tsx
@@ -217,7 +217,7 @@ function DashboardInner({
         queue.clear();
       }
       window.removeEventListener('resize', debouncedHandleResize);
-      window.clearTimeout(forceCheckTimeout.current);
+      globalThis.clearTimeout(forceCheckTimeout.current);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -386,8 +386,8 @@ function DashboardInner({
       // Force check lazyLoad elements that might have shifted into view after (re)moving an upper widget
       // Unfortunately need to use window.setTimeout since React Grid Layout animates widgets into view when layout changes
       // RGL doesn't provide a handler for post animation layout change
-      window.clearTimeout(forceCheckTimeout.current);
-      forceCheckTimeout.current = window.setTimeout(forceCheck, 400);
+      globalThis.clearTimeout(forceCheckTimeout.current);
+      forceCheckTimeout.current = globalThis.setTimeout(forceCheck, 400);
     },
     [dashboard.widgets, isMobile, onUpdate, isEditingDashboard]
   );

--- a/static/app/views/dashboards/detail.spec.tsx
+++ b/static/app/views/dashboards/detail.spec.tsx
@@ -127,7 +127,7 @@ describe('Dashboards > Detail', () => {
     await screen.findByRole('button', {name: 'Save and Finish'});
   }
 
-  window.IntersectionObserver = MockIntersectionObserver as any;
+  globalThis.IntersectionObserver = MockIntersectionObserver as any;
 
   describe('prebuilt dashboards', () => {
     let initialData!: ReturnType<typeof initializeOrg>;
@@ -283,7 +283,7 @@ describe('Dashboards > Detail', () => {
     let mockScrollIntoView!: jest.Mock;
 
     beforeEach(() => {
-      window.confirm = jest.fn();
+      globalThis.confirm = jest.fn();
       initialData = initializeOrg({
         organization,
         router: {
@@ -447,7 +447,7 @@ describe('Dashboards > Detail', () => {
       });
 
       mockScrollIntoView = jest.fn();
-      window.HTMLElement.prototype.scrollIntoView = mockScrollIntoView;
+      globalThis.HTMLElement.prototype.scrollIntoView = mockScrollIntoView;
     });
 
     afterEach(() => {
@@ -815,7 +815,7 @@ describe('Dashboards > Detail', () => {
       await activateDashboardEditMode();
       await userEvent.click(await screen.findByText('Cancel'));
 
-      expect(window.confirm).not.toHaveBeenCalled();
+      expect(globalThis.confirm).not.toHaveBeenCalled();
     });
 
     it('opens the widget viewer modal using the widget index specified in the url', async () => {

--- a/static/app/views/dashboards/exportDashboard.tsx
+++ b/static/app/views/dashboards/exportDashboard.tsx
@@ -31,7 +31,7 @@ export async function exportDashboard() {
 }
 
 function getAPIParams(structure: any) {
-  const url = window.location.href;
+  const url = globalThis.location.href;
   const regex = {
     base_url: /(\/\/)(.*?)(\/)/,
     dashboard_id: /(dashboard\/)(.*?)(\/)/,

--- a/static/app/views/dashboards/widgetBuilder/hooks/useCacheBuilderState.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useCacheBuilderState.tsx
@@ -9,7 +9,7 @@ import {convertWidgetToBuilderState} from 'sentry/views/dashboards/widgetBuilder
 
 const WIDGET_BUILDER_DATASET_STATE_KEY = 'dashboards:widget-builder:dataset';
 
-const STORAGE = createStorage(() => window.sessionStorage);
+const STORAGE = createStorage(() => globalThis.sessionStorage);
 
 function cleanUpDatasetState() {
   for (let i = 0; i < STORAGE.length; i++) {

--- a/static/app/views/dashboards/widgetCard/autoSizedText.tsx
+++ b/static/app/views/dashboards/widgetCard/autoSizedText.tsx
@@ -21,7 +21,7 @@ export function AutoSizedText({children}: Props) {
       return undefined;
     }
 
-    if (!window.ResizeObserver) {
+    if (!globalThis.ResizeObserver) {
       // `ResizeObserver` is missing in a test environment. In this case,
       // run one iteration of the resize behaviour so a test can at least
       // verify that the component doesn't crash.

--- a/static/app/views/discover/table/columnEditCollection.tsx
+++ b/static/app/views/discover/table/columnEditCollection.tsx
@@ -135,10 +135,10 @@ class ColumnEditCollection extends Component<Props, State> {
 
   cleanUpListeners() {
     if (this.state.isDragging) {
-      window.removeEventListener('mousemove', this.onDragMove);
-      window.removeEventListener('touchmove', this.onDragMove);
-      window.removeEventListener('mouseup', this.onDragEnd);
-      window.removeEventListener('touchend', this.onDragEnd);
+      globalThis.removeEventListener('mousemove', this.onDragMove);
+      globalThis.removeEventListener('touchmove', this.onDragMove);
+      globalThis.removeEventListener('mouseup', this.onDragEnd);
+      globalThis.removeEventListener('touchend', this.onDragEnd);
     }
   }
 
@@ -263,10 +263,10 @@ class ColumnEditCollection extends Component<Props, State> {
     });
 
     // attach event listeners so that the mouse cursor can drag anywhere
-    window.addEventListener('mousemove', this.onDragMove);
-    window.addEventListener('touchmove', this.onDragMove);
-    window.addEventListener('mouseup', this.onDragEnd);
-    window.addEventListener('touchend', this.onDragEnd);
+    globalThis.addEventListener('mousemove', this.onDragMove);
+    globalThis.addEventListener('touchmove', this.onDragMove);
+    globalThis.addEventListener('mouseup', this.onDragEnd);
+    globalThis.addEventListener('touchend', this.onDragEnd);
 
     this.setState({
       isDragging: true,

--- a/static/app/views/explore/components/schemaHints/schemaHintsList.tsx
+++ b/static/app/views/explore/components/schemaHints/schemaHintsList.tsx
@@ -236,7 +236,7 @@ export function SchemaHintsList({
         document.body.appendChild(measureDiv);
 
         // Clone the container styles
-        const styles = window.getComputedStyle(container);
+        const styles = globalThis.getComputedStyle(container);
         measureDiv.style.display = styles.display;
         measureDiv.style.gap = styles.gap;
         measureDiv.style.width = styles.width;

--- a/static/app/views/explore/components/table.tsx
+++ b/static/app/views/explore/components/table.tsx
@@ -145,12 +145,12 @@ export function useTableStyles(
         resizingColumnIndex.current = null;
 
         // Cleaning up event listeners
-        window.removeEventListener('mousemove', onMouseMove);
-        window.removeEventListener('mouseup', onMouseUp);
+        globalThis.removeEventListener('mousemove', onMouseMove);
+        globalThis.removeEventListener('mouseup', onMouseUp);
       }
 
-      window.addEventListener('mousemove', onMouseMove);
-      window.addEventListener('mouseup', onMouseUp);
+      globalThis.addEventListener('mousemove', onMouseMove);
+      globalThis.addEventListener('mouseup', onMouseUp);
     },
     [tableRef, minimumColumnWidth, prefixColumnWidth]
   );

--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -414,7 +414,7 @@ describe('logsTableRow', () => {
 
   it('copies log as JSON when Copy as JSON button is clicked', async () => {
     const mockWriteText = jest.fn().mockResolvedValue(undefined);
-    Object.defineProperty(window.navigator, 'clipboard', {
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
       value: {
         writeText: mockWriteText,
       },
@@ -479,7 +479,7 @@ describe('logsTableRow', () => {
 
   it('does not toggle row when clicking cell action menu items', async () => {
     const mockWriteText = jest.fn().mockResolvedValue(undefined);
-    Object.defineProperty(window.navigator, 'clipboard', {
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
       value: {
         writeText: mockWriteText,
       },

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -193,7 +193,7 @@ export const LogRowContent = memo(function LogRowContent({
       }
     }
 
-    if (window.getSelection()?.toString() === '') {
+    if (globalThis.getSelection()?.toString() === '') {
       toggleExpanded();
     }
   }

--- a/static/app/views/explore/logs/useVirtualStreaming.spec.tsx
+++ b/static/app/views/explore/logs/useVirtualStreaming.spec.tsx
@@ -38,11 +38,11 @@ describe('useVirtualStreaming', () => {
     jest.resetAllMocks();
 
     requestAnimationFrameSpy = jest
-      .spyOn(window, 'requestAnimationFrame')
+      .spyOn(globalThis, 'requestAnimationFrame')
       .mockImplementation((_callback: FrameRequestCallback): number => {
         return 1;
       });
-    cancelAnimationFrameSpy = jest.spyOn(window, 'cancelAnimationFrame');
+    cancelAnimationFrameSpy = jest.spyOn(globalThis, 'cancelAnimationFrame');
   });
 
   afterEach(() => {

--- a/static/app/views/explore/logs/useVirtualStreaming.tsx
+++ b/static/app/views/explore/logs/useVirtualStreaming.tsx
@@ -281,7 +281,7 @@ export function useVirtualStreaming({
     return () => {
       rafOn.current = false;
       if (rafId) {
-        window.cancelAnimationFrame(rafId);
+        globalThis.cancelAnimationFrame(rafId);
       }
     };
   }, [autoRefresh, getMostRecentPageDataTimestamp, refreshInterval, setLogsAutoRefresh]);

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -43,8 +43,8 @@ export const NONE_UNIT = 'none';
 const METRIC_ATTRIBUTES_DEBOUNCE_DURATION = 200;
 
 function nextFrameCallback(cb: () => void) {
-  if ('requestAnimationFrame' in window) {
-    window.requestAnimationFrame(() => cb());
+  if ('requestAnimationFrame' in globalThis) {
+    globalThis.requestAnimationFrame(() => cb());
   } else {
     setTimeout(() => {
       cb();

--- a/static/app/views/feedback/feedbackEmptyState.tsx
+++ b/static/app/views/feedback/feedbackEmptyState.tsx
@@ -52,7 +52,7 @@ export function FeedbackEmptyState({projectIds, issueTab = false}: Props) {
   }, []);
 
   useEffect(() => {
-    window.sentryEmbedCallback = function (embed) {
+    globalThis.sentryEmbedCallback = function (embed) {
       // Mock the embed's submit xhr to always be successful
       // NOTE: this will not have errors if the form is empty
       embed.submit = function (_body: Record<string, unknown>) {
@@ -72,7 +72,7 @@ export function FeedbackEmptyState({projectIds, issueTab = false}: Props) {
       });
     }
     return () => {
-      window.sentryEmbedCallback = null;
+      globalThis.sentryEmbedCallback = null;
     };
   }, [hasAnyFeedback, organization, projectIds]);
 

--- a/static/app/views/insights/pages/conversations/utils/urlParams.tsx
+++ b/static/app/views/insights/pages/conversations/utils/urlParams.tsx
@@ -6,5 +6,5 @@ export function getConversationsUrl(
   conversationId: number | string
 ): string {
   const basePath = `/organizations/${organizationSlug}/explore/${CONVERSATIONS_LANDING_SUB_PATH}/${encodeURIComponent(conversationId)}/`;
-  return `${window.location.origin}${normalizeUrl(basePath)}`;
+  return `${globalThis.location.origin}${normalizeUrl(basePath)}`;
 }

--- a/static/app/views/integrationOrganizationLink/index.spec.tsx
+++ b/static/app/views/integrationOrganizationLink/index.spec.tsx
@@ -14,7 +14,7 @@ import IntegrationOrganizationLink from 'sentry/views/integrationOrganizationLin
 
 function setupConfigStore(organization: Organization) {
   const defaultConfig = ConfigFixture();
-  window.__initialData = {
+  globalThis.__initialData = {
     ...defaultConfig,
     customerDomain: {
       subdomain: organization.slug,
@@ -26,12 +26,12 @@ function setupConfigStore(organization: Organization) {
       sentryUrl: 'https://sentry.io',
     },
   };
-  ConfigStore.loadInitialData(window.__initialData);
+  ConfigStore.loadInitialData(globalThis.__initialData);
 }
 
 function teardownConfigStore() {
-  window.__initialData = ConfigFixture();
-  ConfigStore.loadInitialData(window.__initialData);
+  globalThis.__initialData = ConfigFixture();
+  ConfigStore.loadInitialData(globalThis.__initialData);
 }
 
 describe('IntegrationOrganizationLink', () => {

--- a/static/app/views/integrationOrganizationLink/index.tsx
+++ b/static/app/views/integrationOrganizationLink/index.tsx
@@ -187,7 +187,7 @@ export default function IntegrationOrganizationLink() {
       const normalizedUrl = normalizeUrl(
         `/settings/${orgId}/integrations/${data.provider.key}/${data.id}/`
       );
-      window.location.assign(
+      globalThis.location.assign(
         `${organization?.links.organizationUrl || ''}${normalizedUrl}`
       );
     },
@@ -204,7 +204,7 @@ export default function IntegrationOrganizationLink() {
       provider,
     });
     // need to send to control silo to finish the installation
-    window.location.assign(
+    globalThis.location.assign(
       `${organization?.links.organizationUrl || ''}/extensions/${
         integrationSlug
       }/configure/?${urlEncode(query)}`

--- a/static/app/views/issueDetails/actions/seerCommandPaletteActions.tsx
+++ b/static/app/views/issueDetails/actions/seerCommandPaletteActions.tsx
@@ -110,8 +110,8 @@ export function SeerCommandPaletteActions({
       return;
     }
     if (integration.requires_identity && !integration.has_identity) {
-      const currentUrl = window.location.href;
-      window.location.href = `/remote/github-copilot/oauth/?next=${encodeURIComponent(currentUrl)}`;
+      const currentUrl = globalThis.location.href;
+      globalThis.location.href = `/remote/github-copilot/oauth/?next=${encodeURIComponent(currentUrl)}`;
       return;
     }
     openSeerDrawer();

--- a/static/app/views/issueDetails/actions/shareModal.tsx
+++ b/static/app/views/issueDetails/actions/shareModal.tsx
@@ -38,7 +38,7 @@ type UrlRef = React.ElementRef<typeof AutoSelectText>;
 
 export function getShareUrl(organization: Organization, group: Group) {
   const path = `/organizations/${organization.slug}/share/issue/${group.shareId}/`;
-  return `${window.location.origin}${normalizeUrl(path)}`;
+  return `${globalThis.location.origin}${normalizeUrl(path)}`;
 }
 
 export function ShareIssueModal({
@@ -68,11 +68,11 @@ export function ShareIssueModal({
 
   const issueUrl =
     includeEventId && event
-      ? window.location.origin +
+      ? globalThis.location.origin +
         normalizeUrl(
           `/organizations/${organization.slug}/issues/${group?.id}/events/${event.id}/`
         )
-      : window.location.origin +
+      : globalThis.location.origin +
         normalizeUrl(`/organizations/${organization.slug}/issues/${group?.id}/`);
 
   const markdownLink = `[${group?.shortId}](${issueUrl})`;

--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -181,10 +181,10 @@ function useRefetchGroupForReprocessing({
   refetchGroup,
 }: Pick<FetchGroupDetailsState, 'refetchGroup'>) {
   useEffect(() => {
-    const refetchInterval = window.setInterval(refetchGroup, 30000);
+    const refetchInterval = globalThis.setInterval(refetchGroup, 30000);
 
     return () => {
-      window.clearInterval(refetchInterval);
+      globalThis.clearInterval(refetchInterval);
     };
   }, [refetchGroup]);
 }
@@ -356,7 +356,7 @@ function useFetchGroupDetails(): FetchGroupDetailsState {
   }, [api, group?.hasSeen, group?.project, organization.slug, params.groupId, projects]);
 
   useEffect(() => {
-    const locationQuery = qs.parse(window.location.search) || {};
+    const locationQuery = qs.parse(globalThis.location.search) || {};
     const allProjectsFlag = locationQuery._allp;
 
     // We use _allp as a temporary measure to know they came from the
@@ -378,7 +378,7 @@ function useFetchGroupDetails(): FetchGroupDetailsState {
       group?.project.id
     ) {
       locationQuery.project = group?.project.id;
-      navigate({...window.location, query: locationQuery}, {replace: true});
+      navigate({...globalThis.location, query: locationQuery}, {replace: true});
     }
 
     if (allProjectsFlag && !allProjectChanged) {
@@ -387,7 +387,7 @@ function useFetchGroupDetails(): FetchGroupDetailsState {
       // this is not an ideal solution and will ultimately be replaced with
       // something smarter.
       delete locationQuery._allp;
-      navigate({...window.location, query: locationQuery}, {replace: true});
+      navigate({...globalThis.location, query: locationQuery}, {replace: true});
       setAllProjectChanged(true);
     }
   }, [group?.project.id, allProjectChanged, navigate]);

--- a/static/app/views/issueDetails/groupTags/tagDetailsLink.tsx
+++ b/static/app/views/issueDetails/groupTags/tagDetailsLink.tsx
@@ -28,14 +28,14 @@ export function TagDetailsLink({
   // We only want to prefetch if the user hovers over the tag for 1 second
   // This is to prevent every tag from prefetch when a user scrolls
   const handleMouseEnter = () => {
-    hoverTimeoutRef.current = window.setTimeout(() => {
+    hoverTimeoutRef.current = globalThis.setTimeout(() => {
       setPrefetchEnabled(true);
     }, 1000);
   };
 
   const handleMouseLeave = () => {
     if (hoverTimeoutRef.current) {
-      window.clearTimeout(hoverTimeoutRef.current);
+      globalThis.clearTimeout(hoverTimeoutRef.current);
       hoverTimeoutRef.current = undefined;
     }
   };
@@ -43,7 +43,7 @@ export function TagDetailsLink({
   useEffect(() => {
     return () => {
       if (hoverTimeoutRef.current) {
-        window.clearTimeout(hoverTimeoutRef.current);
+        globalThis.clearTimeout(hoverTimeoutRef.current);
       }
     };
   }, []);

--- a/static/app/views/issueDetails/streamline/foldSection.tsx
+++ b/static/app/views/issueDetails/streamline/foldSection.tsx
@@ -96,8 +96,8 @@ function useScrollToSection(
       hasAttemptedScroll.current = true;
 
       // scroll to element if it's the current section on page load
-      if (window.location.hash) {
-        const [, hash] = window.location.hash.split('#');
+      if (globalThis.location.hash) {
+        const [, hash] = globalThis.location.hash.split('#');
         if (hash === sectionKey) {
           if (!expanded) {
             setIsCollapsed(false);

--- a/static/app/views/issueDetails/useEngagedViewTracking.tsx
+++ b/static/app/views/issueDetails/useEngagedViewTracking.tsx
@@ -38,7 +38,7 @@ export function useEngagedViewTracking({group, project}: UseEngagedViewTrackingP
       return undefined;
     }
 
-    const timeoutId = window.setTimeout(() => {
+    const timeoutId = globalThis.setTimeout(() => {
       if (trackedGroupId.current !== group.id) {
         trackedGroupId.current = group.id;
         trackEngagedView();
@@ -46,7 +46,7 @@ export function useEngagedViewTracking({group, project}: UseEngagedViewTrackingP
     }, ENGAGED_VIEW_THRESHOLD_MS);
 
     return () => {
-      window.clearTimeout(timeoutId);
+      globalThis.clearTimeout(timeoutId);
     };
   }, [group.id]);
 }

--- a/static/app/views/issueList/index.tsx
+++ b/static/app/views/issueList/index.tsx
@@ -44,7 +44,7 @@ function useHydrateIssueViewQueryParams({view}: {view: GroupSearchView | undefin
   const previousViewData = usePrevious(view);
 
   useEffect(() => {
-    const query = qs.parse(window.location.search);
+    const query = qs.parse(globalThis.location.search);
 
     if (
       view &&

--- a/static/app/views/navigation/primary/helpMenu.tsx
+++ b/static/app/views/navigation/primary/helpMenu.tsx
@@ -58,7 +58,7 @@ function getContactSupportItem(organization: Organization): MenuItemProps | null
           await showIntercom(organization.slug);
         } catch {
           // Fall back to mailto
-          window.location.href = `mailto:${supportEmail}`;
+          globalThis.location.href = `mailto:${supportEmail}`;
         }
       },
     };

--- a/static/app/views/navigation/primary/whatsNew.tsx
+++ b/static/app/views/navigation/primary/whatsNew.tsx
@@ -93,13 +93,13 @@ function WhatsNewContent({
     }
 
     const MARK_SEEN_DELAY = 2000;
-    const markSeenTimeout = window.setTimeout(() => {
+    const markSeenTimeout = globalThis.setTimeout(() => {
       markBroadcastsAsSeen(unseenPostIds);
     }, MARK_SEEN_DELAY);
 
     return () => {
       if (markSeenTimeout) {
-        window.clearTimeout(markSeenTimeout);
+        globalThis.clearTimeout(markSeenTimeout);
       }
     };
   }, [unseenPostIds, markBroadcastsAsSeen]);

--- a/static/app/views/onboarding/components/newWelcome.tsx
+++ b/static/app/views/onboarding/components/newWelcome.tsx
@@ -138,7 +138,7 @@ export function NewWelcomeUI(props: StepProps) {
   // Scroll to top on mount to fix iOS Safari retaining scroll position from previous page.
   // Skip if there's a hash in the URL to avoid conflicting with anchor-based scrolling.
   useEffect(() => {
-    if (!window.location.hash) {
+    if (!globalThis.location.hash) {
       window.scrollTo(0, 0);
     }
   }, []);

--- a/static/app/views/onboarding/components/scmProviderPills.spec.tsx
+++ b/static/app/views/onboarding/components/scmProviderPills.spec.tsx
@@ -77,7 +77,7 @@ describe('ScmProviderPills', () => {
   });
 
   it('triggers install flow when clicking a dropdown item', async () => {
-    const open = jest.spyOn(window, 'open').mockReturnValue({
+    const open = jest.spyOn(globalThis, 'open').mockReturnValue({
       focus: jest.fn(),
       close: jest.fn(),
     } as any);

--- a/static/app/views/onboarding/createSampleEventButton.tsx
+++ b/static/app/views/onboarding/createSampleEventButton.tsx
@@ -47,7 +47,7 @@ async function latestEventAvailable(
       return {eventCreated: false, retries: retries - 1};
     }
 
-    await new Promise(resolve => window.setTimeout(resolve, EVENT_POLL_INTERVAL));
+    await new Promise(resolve => globalThis.setTimeout(resolve, EVENT_POLL_INTERVAL));
 
     try {
       await api.requestPromise(

--- a/static/app/views/performance/newTraceDetails/trace.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.spec.tsx
@@ -61,7 +61,7 @@ function mockQueryString(queryString: `?${string}` | '') {
   setWindowLocation(
     `http://localhost/organizations/org-slug/performance/trace/trace-id/${queryString}`
   );
-  expect(window.location.search).toBe(queryString);
+  expect(globalThis.location.search).toBe(queryString);
 }
 
 function mockTracePreferences(preferences: Partial<StoredTracePreferences>) {

--- a/static/app/views/performance/newTraceDetails/traceApi/useTrace.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTrace.spec.tsx
@@ -144,7 +144,7 @@ describe('useTrace', () => {
       [`?node=error-${invalidUUid}`],
     ])('does NOT call EAP endpoint with errorId when URL has %s', async search => {
       // Set up mocked URL before hook runs
-      window.history.pushState({}, '', `/some-path${search}`);
+      globalThis.history.pushState({}, '', `/some-path${search}`);
 
       // Set up EAP enabled
       useIsEAPTraceEnabled.mockReturnValue(true);
@@ -228,7 +228,7 @@ describe('useTrace', () => {
       'calls tracing endpoint with query param options %s',
       async ({search, mockEapEnabled, endpoint, expectedParamKey}) => {
         // Mock URL before hook runs
-        window.history.pushState({}, '', `/some-path${search}`);
+        globalThis.history.pushState({}, '', `/some-path${search}`);
 
         // Mock EAP toggle
         useIsEAPTraceEnabled.mockReturnValue(mockEapEnabled);

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/entries.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/entries.tsx
@@ -84,7 +84,7 @@ function EventEntryContent({entry, projectSlug, event}: EventEntryContentProps) 
       return null;
     // this should not happen
     default:
-      if (window.console) {
+      if (globalThis.console) {
         // eslint-disable-next-line no-console
         console.error?.('Unregistered interface: ' + (entry as any).type);
       }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/usePassiveResizeableDrawer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/usePassiveResizeableDrawer.tsx
@@ -47,10 +47,10 @@ export function usePassiveResizableDrawer(options: UsePassiveResizableDrawerOpti
       document.documentElement.style.cursor = isXAxis ? 'ew-resize' : 'ns-resize';
 
       if (rafIdRef.current !== null) {
-        window.cancelAnimationFrame(rafIdRef.current);
+        globalThis.cancelAnimationFrame(rafIdRef.current);
       }
 
-      rafIdRef.current = window.requestAnimationFrame(() => {
+      rafIdRef.current = globalThis.requestAnimationFrame(() => {
         if (!currentMouseVectorRaf.current) {
           return;
         }
@@ -131,7 +131,7 @@ export function usePassiveResizableDrawer(options: UsePassiveResizableDrawerOpti
     return () => {
       observer.disconnect();
       if (rafIdRef.current !== null) {
-        window.cancelAnimationFrame(rafIdRef.current);
+        globalThis.cancelAnimationFrame(rafIdRef.current);
       }
     };
   }, [options.direction, options.ref]);

--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceRowWidthMeasurer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceRowWidthMeasurer.tsx
@@ -67,9 +67,9 @@ export class TraceRowWidthMeasurer<T> {
     this.queue.push([node, element]);
 
     if (this.drainRaf !== null) {
-      window.cancelAnimationFrame(this.drainRaf);
+      globalThis.cancelAnimationFrame(this.drainRaf);
     }
-    this.drainRaf = window.requestAnimationFrame(this.drain);
+    this.drainRaf = globalThis.requestAnimationFrame(this.drain);
   }
 
   drain() {

--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceVirtualizedList.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceVirtualizedList.tsx
@@ -162,13 +162,13 @@ export const useVirtualizedList = (
       }
 
       if (rafId.current !== null) {
-        window.cancelAnimationFrame(rafId.current);
+        globalThis.cancelAnimationFrame(rafId.current);
       }
 
       managerRef.current.scrolling_source = 'list';
       managerRef.current.enqueueOnScrollEndOutOfBoundsCheck();
 
-      rafId.current = window.requestAnimationFrame(() => {
+      rafId.current = globalThis.requestAnimationFrame(() => {
         scrollTopRef.current = Math.max(0, event.target?.scrollTop ?? 0);
 
         const recomputedItems = findRenderedItems({
@@ -190,7 +190,7 @@ export const useVirtualizedList = (
       }
 
       if (pointerEventsRaf.current) {
-        window.cancelAnimationFrame(pointerEventsRaf.current.id);
+        globalThis.cancelAnimationFrame(pointerEventsRaf.current.id);
       }
 
       pointerEventsRaf.current = requestAnimationTimeout(() => {

--- a/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/virtualizedViewManager.tsx
@@ -526,7 +526,7 @@ export class VirtualizedViewManager {
 
   onBringRowIntoView(space: [number, number]) {
     if (this.timers.onZoomIntoSpace !== null) {
-      window.cancelAnimationFrame(this.timers.onZoomIntoSpace);
+      globalThis.cancelAnimationFrame(this.timers.onZoomIntoSpace);
       this.timers.onZoomIntoSpace = null;
     }
 
@@ -599,7 +599,7 @@ export class VirtualizedViewManager {
           x,
           width,
         });
-        this.timers.onZoomIntoSpace = window.requestAnimationFrame(rafCallback);
+        this.timers.onZoomIntoSpace = globalThis.requestAnimationFrame(rafCallback);
       } else {
         this.timers.onZoomIntoSpace = null;
         this.scheduler.dispatch('set trace view', {
@@ -609,7 +609,7 @@ export class VirtualizedViewManager {
       }
     };
 
-    this.timers.onZoomIntoSpace = window.requestAnimationFrame(rafCallback);
+    this.timers.onZoomIntoSpace = globalThis.requestAnimationFrame(rafCallback);
   }
 
   resetZoom() {
@@ -618,7 +618,7 @@ export class VirtualizedViewManager {
 
   enqueueOnWheelEndRaf() {
     if (this.timers.onWheelEnd !== null) {
-      window.cancelAnimationFrame(this.timers.onWheelEnd);
+      globalThis.cancelAnimationFrame(this.timers.onWheelEnd);
     }
 
     const start = performance.now();
@@ -627,11 +627,11 @@ export class VirtualizedViewManager {
       if (elapsed > 100) {
         this.onWheelEnd();
       } else {
-        this.timers.onWheelEnd = window.requestAnimationFrame(rafCallback);
+        this.timers.onWheelEnd = globalThis.requestAnimationFrame(rafCallback);
       }
     };
 
-    this.timers.onWheelEnd = window.requestAnimationFrame(rafCallback);
+    this.timers.onWheelEnd = globalThis.requestAnimationFrame(rafCallback);
   }
 
   onWheelStart() {
@@ -695,7 +695,7 @@ export class VirtualizedViewManager {
 
   enqueueFOVQueryParamSync(view: TraceView) {
     if (this.timers.onFovChange !== null) {
-      window.cancelAnimationFrame(this.timers.onFovChange.id);
+      globalThis.cancelAnimationFrame(this.timers.onFovChange.id);
     }
 
     this.timers.onFovChange = requestAnimationTimeout(() => {
@@ -818,7 +818,7 @@ export class VirtualizedViewManager {
     }
 
     if (this.timers.onRowIntoView !== null) {
-      window.cancelAnimationFrame(this.timers.onRowIntoView);
+      globalThis.cancelAnimationFrame(this.timers.onRowIntoView);
       this.timers.onRowIntoView = null;
     }
 
@@ -936,7 +936,7 @@ export class VirtualizedViewManager {
       return;
     }
 
-    window.cancelAnimationFrame(this.timers.onScrollEndSync?.id ?? 0);
+    globalThis.cancelAnimationFrame(this.timers.onScrollEndSync?.id ?? 0);
 
     this.timers.onScrollEndSync = requestAnimationTimeout(() => {
       this.onScrollEndOutOfBoundsCheck();
@@ -1050,7 +1050,7 @@ export class VirtualizedViewManager {
 
       if (progress < 1) {
         this.columns.list.translate[0] = pos;
-        this.timers.onRowIntoView = window.requestAnimationFrame(animate);
+        this.timers.onRowIntoView = globalThis.requestAnimationFrame(animate);
       } else {
         this.timers.onRowIntoView = null;
         if (this.horizontal_scrollbar_container) {
@@ -1062,7 +1062,7 @@ export class VirtualizedViewManager {
       dispatchJestScrollUpdate(this.horizontal_scrollbar_container!);
     };
 
-    this.timers.onRowIntoView = window.requestAnimationFrame(animate);
+    this.timers.onRowIntoView = globalThis.requestAnimationFrame(animate);
   }
 
   initialize(container: HTMLElement) {
@@ -1826,7 +1826,7 @@ function dispatchJestScrollUpdate(container: HTMLElement) {
     return;
   }
   // since we do not tightly control how browsers handle event dispatching, dispatch it async
-  window.requestAnimationFrame(() => {
+  globalThis.requestAnimationFrame(() => {
     container.dispatchEvent(new CustomEvent('scroll'));
   });
 }

--- a/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.tsx
+++ b/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.tsx
@@ -136,7 +136,7 @@ export function searchInTraceTreeTokens(
             Sentry.captureMessage('Unbalanced tree - missing left or right token');
             info(fmt`Unbalanced tree - missing left or right token`);
             if (typeof handle.id === 'number') {
-              window.cancelAnimationFrame(handle.id);
+              globalThis.cancelAnimationFrame(handle.id);
             }
             cb([[], resultLookup, null]);
             return;
@@ -158,7 +158,7 @@ export function searchInTraceTreeTokens(
       );
       info(fmt`Invalid state in searchInTraceTreeTokens, missing boolean token`);
       if (typeof handle.id === 'number') {
-        window.cancelAnimationFrame(handle.id);
+        globalThis.cancelAnimationFrame(handle.id);
       }
       cb([[], resultLookup, null]);
       return;
@@ -169,7 +169,7 @@ export function searchInTraceTreeTokens(
       );
       info(fmt`Invalid state in searchInTraceTreeTokens, missing left or right token`);
       if (typeof handle.id === 'number') {
-        window.cancelAnimationFrame(handle.id);
+        globalThis.cancelAnimationFrame(handle.id);
       }
       cb([[], resultLookup, null]);
       return;

--- a/static/app/views/performance/newTraceDetails/traceSearch/traceSearchInput.tsx
+++ b/static/app/views/performance/newTraceDetails/traceSearch/traceSearchInput.tsx
@@ -50,7 +50,7 @@ export function TraceSearchInput(props: TraceSearchInputProps) {
 
   useLayoutEffect(() => {
     if (typeof timeoutRef.current === 'number') {
-      window.clearTimeout(timeoutRef.current);
+      globalThis.clearTimeout(timeoutRef.current);
       timeoutRef.current = undefined;
     }
 
@@ -72,7 +72,7 @@ export function TraceSearchInput(props: TraceSearchInputProps) {
       }
 
       const schedule = nextStatus[0] + MIN_LOADING_TIME - performance.now();
-      timeoutRef.current = window.setTimeout(() => {
+      timeoutRef.current = globalThis.setTimeout(() => {
         if (!cancel) {
           setStatus(nextStatus);
         }

--- a/static/app/views/performance/newTraceDetails/traceState/tracePreferences.tsx
+++ b/static/app/views/performance/newTraceDetails/traceState/tracePreferences.tsx
@@ -75,7 +75,7 @@ export function storeTraceViewPreferences(
   };
 
   // Make sure we dont fire this during a render phase
-  window.requestAnimationFrame(() => {
+  globalThis.requestAnimationFrame(() => {
     try {
       localStorage.setItem(key, JSON.stringify(storedState));
     } catch (e) {

--- a/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
+++ b/static/app/views/performance/newTraceDetails/traceWaterfall.tsx
@@ -188,7 +188,7 @@ export function TraceWaterfall(props: TraceWaterfallProps) {
       behavior: 'track result' | 'persist'
     ) => {
       if (searchingRaf.current?.id) {
-        window.cancelAnimationFrame(searchingRaf.current.id);
+        globalThis.cancelAnimationFrame(searchingRaf.current.id);
         searchingRaf.current = null;
       }
 

--- a/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.tsx
@@ -101,7 +101,7 @@ export function useTraceLayoutTabs({
   });
   const tabOptions = getTabOptions({sections: {...sections}});
 
-  const queryParams = qs.parse(window.location.search);
+  const queryParams = qs.parse(globalThis.location.search);
   const tabSlugFromUrl = queryParams.tab;
   const initialTab =
     tabOptions.find(tab => tab.slug === tabSlugFromUrl) ??

--- a/static/app/views/performance/newTraceDetails/useTraceQueryParamStateSync.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceQueryParamStateSync.tsx
@@ -24,11 +24,11 @@ export function useTraceQueryParamStateSync(query: Record<string, string | undef
     }
 
     if (syncStateTimeoutRef.current !== null) {
-      window.clearTimeout(syncStateTimeoutRef.current);
+      globalThis.clearTimeout(syncStateTimeoutRef.current);
     }
 
     previousQueryRef.current = query;
-    syncStateTimeoutRef.current = window.setTimeout(() => {
+    syncStateTimeoutRef.current = globalThis.setTimeout(() => {
       navigate(
         {
           pathname: location.pathname,

--- a/static/app/views/performance/onboarding.tsx
+++ b/static/app/views/performance/onboarding.tsx
@@ -261,7 +261,7 @@ export function LegacyOnboarding({organization, project}: OnboardingProps) {
         priority="primary"
         onClick={event => {
           event.preventDefault();
-          window.location.hash = 'performance-sidequest';
+          globalThis.location.hash = 'performance-sidequest';
           OnboardingDrawerStore.open(OnboardingDrawerKey.PERFORMANCE_ONBOARDING);
         }}
       >
@@ -635,12 +635,12 @@ export function Onboarding({organization, project}: OnboardingProps) {
                           title: traceId ? undefined : t('Processing trace\u2026'),
                         }}
                         onClick={() => {
-                          const params = new URLSearchParams(window.location.search);
+                          const params = new URLSearchParams(globalThis.location.search);
                           params.set('table', Tab.TRACE);
                           params.set('query', `trace:${traceId}`);
                           params.delete('guidedStep');
                           testableWindowLocation.assign(
-                            `${window.location.pathname}?${params.toString()}`
+                            `${globalThis.location.pathname}?${params.toString()}`
                           );
                         }}
                       >

--- a/static/app/views/preprod/buildDetails/buildDetails.tsx
+++ b/static/app/views/preprod/buildDetails/buildDetails.tsx
@@ -113,7 +113,7 @@ export default function BuildDetails() {
     onSuccess: () => {
       addSuccessMessage(t('Analysis rerun started successfully!'));
       setTimeout(() => {
-        window.location.reload();
+        globalThis.location.reload();
       }, 1000);
     },
     onError: error => {

--- a/static/app/views/preprod/utils/staffPermissionError.ts
+++ b/static/app/views/preprod/utils/staffPermissionError.ts
@@ -11,7 +11,7 @@ export function handleStaffPermissionError(responseDetail: StaffErrorDetail) {
       )
     );
     setTimeout(() => {
-      window.location.href = '/_admin/';
+      globalThis.location.href = '/_admin/';
     }, 2000);
     return;
   }

--- a/static/app/views/profiling/continuousProfileFlamegraph.tsx
+++ b/static/app/views/profiling/continuousProfileFlamegraph.tsx
@@ -76,7 +76,7 @@ export default function ContinuousProfileFlamegraphWrapper() {
 
   const initialFlamegraphPreferencesState = useMemo((): DeepPartial<FlamegraphState> => {
     const queryStringState = decodeFlamegraphStateFromQueryParams(
-      qs.parse(window.location.search)
+      qs.parse(globalThis.location.search)
     );
 
     return {

--- a/static/app/views/profiling/profileFlamechart.tsx
+++ b/static/app/views/profiling/profileFlamechart.tsx
@@ -77,7 +77,7 @@ export default function ProfileFlamegraphWrapper() {
 
   const initialFlamegraphPreferencesState = useMemo((): DeepPartial<FlamegraphState> => {
     const queryStringState = decodeFlamegraphStateFromQueryParams(
-      qs.parse(window.location.search)
+      qs.parse(globalThis.location.search)
     );
 
     return {

--- a/static/app/views/profiling/profileGroupProvider.tsx
+++ b/static/app/views/profiling/profileGroupProvider.tsx
@@ -40,7 +40,7 @@ export function ProfileGroupProvider(props: ProfileGroupProviderProps) {
     if (!props.input) {
       return LOADING_PROFILE_GROUP;
     }
-    const qs = new URLSearchParams(window.location.search);
+    const qs = new URLSearchParams(globalThis.location.search);
     const threadId = qs.get('tid');
 
     try {

--- a/static/app/views/profiling/utils.tsx
+++ b/static/app/views/profiling/utils.tsx
@@ -9,16 +9,16 @@ export function requestAnimationFrameTimeout(cb: () => void, timeout: number) {
 
   function timer() {
     if (rafId.current) {
-      window.cancelAnimationFrame(rafId.current);
+      globalThis.cancelAnimationFrame(rafId.current);
     }
     if (performance.now() - start > timeout) {
       cb();
       return;
     }
-    rafId.current = window.requestAnimationFrame(timer);
+    rafId.current = globalThis.requestAnimationFrame(timer);
   }
 
-  rafId.current = window.requestAnimationFrame(timer);
+  rafId.current = globalThis.requestAnimationFrame(timer);
   return rafId;
 }
 

--- a/static/app/views/projectInstall/createProject.spec.tsx
+++ b/static/app/views/projectInstall/createProject.spec.tsx
@@ -295,7 +295,7 @@ describe('CreateProject', () => {
     TeamStore.loadUserTeams([teamWithAccess]);
 
     // Simulate a previously created project stored in localStorage
-    window.localStorage.setItem(
+    globalThis.localStorage.setItem(
       'created-project-context',
       JSON.stringify({
         id: '12345',
@@ -337,7 +337,7 @@ describe('CreateProject', () => {
     expect(screen.getByPlaceholderText('project-slug')).toHaveValue('my-custom-name');
 
     // Clean up localStorage
-    window.localStorage.removeItem('created-project-context');
+    globalThis.localStorage.removeItem('created-project-context');
   });
 
   it('should update project slug on platform change when slug was not manually modified', async () => {
@@ -353,7 +353,7 @@ describe('CreateProject', () => {
 
     TeamStore.loadUserTeams([teamWithAccess]);
 
-    window.localStorage.setItem(
+    globalThis.localStorage.setItem(
       'created-project-context',
       JSON.stringify({
         id: '12345',
@@ -392,7 +392,7 @@ describe('CreateProject', () => {
 
     expect(screen.getByPlaceholderText('project-slug')).toHaveValue('apple-ios');
 
-    window.localStorage.removeItem('created-project-context');
+    globalThis.localStorage.removeItem('created-project-context');
   });
 
   it('should display success message on proj creation', async () => {

--- a/static/app/views/projectInstall/platform.tsx
+++ b/static/app/views/projectInstall/platform.tsx
@@ -73,7 +73,7 @@ export function ProjectInstallPlatform({project, platform}: Props) {
 
   const issueStreamLink = `/organizations/${organization.slug}/issues/`;
   const showPerformancePrompt = performancePlatforms.includes(platform.id);
-  const isGettingStarted = window.location.href.indexOf('getting-started') > 0;
+  const isGettingStarted = globalThis.location.href.indexOf('getting-started') > 0;
   const showDocsWithProductSelection =
     (platformProductAvailability[platform.id] ?? []).length > 0;
 

--- a/static/app/views/releases/detail/overview/sidebar/projectReleaseDetails.tsx
+++ b/static/app/views/releases/detail/overview/sidebar/projectReleaseDetails.tsx
@@ -97,7 +97,7 @@ export function ProjectReleaseDetails({release, releaseMeta, project}: Props) {
                       onClick={() => {
                         finalizeRelease.mutate([release], {
                           onSettled() {
-                            window.location.reload();
+                            globalThis.location.reload();
                           },
                         });
                       }}

--- a/static/app/views/releases/list/releaseCard/index.tsx
+++ b/static/app/views/releases/list/releaseCard/index.tsx
@@ -198,7 +198,7 @@ export function ReleaseCard({
                     onClick={() =>
                       finalizeRelease.mutate([release], {
                         onSettled() {
-                          window.location.reload();
+                          globalThis.location.reload();
                         },
                       })
                     }

--- a/static/app/views/replays/detail/console/index.tsx
+++ b/static/app/views/replays/detail/console/index.tsx
@@ -95,7 +95,7 @@ export function Console() {
 
   const handleMeasure = useCallback(
     (index: number) => {
-      window.requestAnimationFrame(() => {
+      globalThis.requestAnimationFrame(() => {
         const row = scrollContainerRef.current?.querySelector<HTMLElement>(
           `[data-index="${index}"]`
         );

--- a/static/app/views/replays/detail/header/replayDetailsPageBreadcrumbs.tsx
+++ b/static/app/views/replays/detail/header/replayDetailsPageBreadcrumbs.tsx
@@ -61,7 +61,7 @@ export function ReplayDetailsPageBreadcrumbs({readerResult}: Props) {
   // Create URL with current timestamp for copying
   const replayUrlWithTimestamp = replayRecord
     ? (() => {
-        const url = new URL(window.location.href);
+        const url = new URL(globalThis.location.href);
         const currentTimeInSeconds = Math.floor(currentTime / 1000);
         url.searchParams.set('t', String(currentTimeInSeconds));
         return url.toString();

--- a/static/app/views/replays/detail/useVirtualizedGrid.tsx
+++ b/static/app/views/replays/detail/useVirtualizedGrid.tsx
@@ -42,8 +42,8 @@ export function useVirtualizedGrid({
 
   useEffect(() => {
     updateMeasurements();
-    const frame = window.requestAnimationFrame(updateMeasurements);
-    return () => window.cancelAnimationFrame(frame);
+    const frame = globalThis.requestAnimationFrame(updateMeasurements);
+    return () => globalThis.cancelAnimationFrame(frame);
   }, [updateMeasurements]);
 
   const virtualizer = useVirtualizer({

--- a/static/app/views/routeError.tsx
+++ b/static/app/views/routeError.tsx
@@ -70,7 +70,7 @@ function RouteError({error, disableLogSentry, disableReport, project}: Props) {
 
     // TODO(dcramer): show something in addition to embed (that contains it?)
     // throw this in a timeout so if it errors we don't fall over
-    const reportDialogTimeout = window.setTimeout(() => {
+    const reportDialogTimeout = globalThis.setTimeout(() => {
       Sentry.withScope(scope => {
         enrichScopeContext(scope);
         Sentry.captureException(error);
@@ -82,7 +82,7 @@ function RouteError({error, disableLogSentry, disableReport, project}: Props) {
     });
 
     return function cleanup() {
-      window.clearTimeout(reportDialogTimeout);
+      globalThis.clearTimeout(reportDialogTimeout);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [error, disableLogSentry]);
@@ -104,7 +104,7 @@ function RouteError({error, disableLogSentry, disableReport, project}: Props) {
           {t("If you're daring, you may want to try the following:")}
         </p>
         <List symbol="bullet">
-          {window?.adblockSuspected && (
+          {globalThis?.adblockSuspected && (
             <ListItem>
               {t(
                 "We detected something AdBlock-like. Try disabling it, as it's known to cause issues."
@@ -116,7 +116,7 @@ function RouteError({error, disableLogSentry, disableReport, project}: Props) {
               link: (
                 <a
                   onClick={() => {
-                    window.location.href = String(window.location.href);
+                    globalThis.location.href = String(globalThis.location.href);
                   }}
                 />
               ),

--- a/static/app/views/seerExplorer/hooks/useAsciiSnapshot.tsx
+++ b/static/app/views/seerExplorer/hooks/useAsciiSnapshot.tsx
@@ -145,7 +145,7 @@ function createIsVisible(
   viewportHeight: number
 ): (el: Element) => boolean {
   return (el: Element) => {
-    const style = window.getComputedStyle(el);
+    const style = globalThis.getComputedStyle(el);
     if (
       style.display === 'none' ||
       style.visibility === 'hidden' ||
@@ -732,7 +732,7 @@ function renderTextNodes(
         const rects = Array.from(range.getClientRects());
 
         if (rects.length > 0) {
-          const style = window.getComputedStyle(parent);
+          const style = globalThis.getComputedStyle(parent);
           const whiteSpace = style.whiteSpace || '';
           const noWrap = /nowrap|pre/.test(whiteSpace);
           const hasEllipsis = (style.textOverflow || '').includes('ellipsis');
@@ -837,7 +837,7 @@ export function buildResult(
   chartTables: string[],
   projectSlugs: string[]
 ): string {
-  const url = window.location.href;
+  const url = globalThis.location.href;
 
   // Step 1: Strip trailing spaces from each row. The grid is initialized as
   // all-space cells so rows are always full-width;
@@ -888,7 +888,7 @@ export function useAsciiSnapshot() {
   const {projects} = useProjects();
 
   const capture = useCallback(() => {
-    if (typeof document === 'undefined' || typeof window === 'undefined') {
+    if (typeof document === 'undefined' || typeof globalThis.window === 'undefined') {
       return '';
     }
 

--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -965,11 +965,11 @@ function formatSessionData(
 function locationToUrl(location: LocationDescriptor): string | null {
   if (typeof location === 'string') {
     const hasOrigin = /^https?:\/\//.test(location);
-    return hasOrigin ? location : `${window.location.origin}${location}`;
+    return hasOrigin ? location : `${globalThis.location.origin}${location}`;
   }
 
   const {pathname = '', hash, query} = location;
-  const base = `${window.location.origin}${pathname}`;
+  const base = `${globalThis.location.origin}${pathname}`;
 
   const queryPart = query ? `?${queryString.stringify(query)}` : '';
 
@@ -984,7 +984,7 @@ const RUN_ID_QUERY_PARAM = 'explorerRunId';
  * Returns the URL of the current window with the run ID query param set.
  */
 export function getExplorerUrl(runId: number | string): string {
-  const url = new URL(window.location.href);
+  const url = new URL(globalThis.location.href);
   url.searchParams.set(RUN_ID_QUERY_PARAM, String(runId));
   return url.toString();
 }

--- a/static/app/views/sentryAppExternalInstallation/index.spec.tsx
+++ b/static/app/views/sentryAppExternalInstallation/index.spec.tsx
@@ -81,18 +81,18 @@ describe('SentryAppExternalInstallation', () => {
         body: [],
       });
 
-      window.__initialData = ConfigFixture({
+      globalThis.__initialData = ConfigFixture({
         customerDomain: {
           subdomain: 'org1',
           organizationUrl: 'https://org1.sentry.io',
           sentryUrl: 'https://sentry.io',
         },
         links: {
-          ...window.__initialData?.links,
+          ...globalThis.__initialData?.links,
           sentryUrl: 'https://sentry.io',
         },
       });
-      ConfigStore.loadInitialData(window.__initialData);
+      ConfigStore.loadInitialData(globalThis.__initialData);
     });
 
     it('sets the org automatically', async () => {
@@ -217,18 +217,18 @@ describe('SentryAppExternalInstallation', () => {
         body: [],
       });
 
-      window.__initialData = ConfigFixture({
+      globalThis.__initialData = ConfigFixture({
         customerDomain: {
           subdomain: 'org1',
           organizationUrl: 'https://org1.sentry.io',
           sentryUrl: 'https://sentry.io',
         },
         links: {
-          ...window.__initialData?.links,
+          ...globalThis.__initialData?.links,
           sentryUrl: 'https://sentry.io',
         },
       });
-      ConfigStore.loadInitialData(window.__initialData);
+      ConfigStore.loadInitialData(globalThis.__initialData);
     });
 
     it('sets the org automatically', async () => {
@@ -251,14 +251,14 @@ describe('SentryAppExternalInstallation', () => {
     });
 
     it('loads orgs from multiple regions', async () => {
-      window.__initialData = {
-        ...window.__initialData,
+      globalThis.__initialData = {
+        ...globalThis.__initialData,
         memberRegions: [
           {name: 'us', url: 'https://us.example.org'},
           {name: 'de', url: 'https://de.example.org'},
         ],
       };
-      ConfigStore.loadInitialData(window.__initialData);
+      ConfigStore.loadInitialData(globalThis.__initialData);
 
       const deorg = OrganizationFixture({slug: 'de-org'});
       const getDeOrgs = MockApiClient.addMockResponse({
@@ -287,18 +287,18 @@ describe('SentryAppExternalInstallation', () => {
     it('selecting org changes the url', async () => {
       const preselectedOrg = OrganizationFixture();
 
-      window.__initialData = ConfigFixture({
+      globalThis.__initialData = ConfigFixture({
         customerDomain: {
           subdomain: 'org1',
           organizationUrl: 'https://org1.sentry.io',
           sentryUrl: 'https://sentry.io',
         },
         links: {
-          ...window.__initialData?.links,
+          ...globalThis.__initialData?.links,
           sentryUrl: 'https://sentry.io',
         },
       });
-      ConfigStore.loadInitialData(window.__initialData);
+      ConfigStore.loadInitialData(globalThis.__initialData);
 
       getOrgMock = MockApiClient.addMockResponse({
         url: '/organizations/org1/',

--- a/static/app/views/settings/account/accountClose.tsx
+++ b/static/app/views/settings/account/accountClose.tsx
@@ -26,7 +26,7 @@ import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageH
 import {TextBlock} from 'sentry/views/settings/components/text/textBlock';
 
 const BYE_URL = '/';
-const leaveRedirect = () => (window.location.href = BYE_URL);
+const leaveRedirect = () => (globalThis.location.href = BYE_URL);
 
 function GoodbyeModalContent({Header, Body, Footer}: ModalRenderProps) {
   return (
@@ -76,7 +76,7 @@ function AccountClose() {
 
   useEffect(() => {
     return () => {
-      window.clearTimeout(leaveRedirectTimeout.current);
+      globalThis.clearTimeout(leaveRedirectTimeout.current);
     };
   }, []);
 
@@ -117,8 +117,8 @@ function AccountClose() {
         });
       });
       // Redirect after 10 seconds
-      window.clearTimeout(leaveRedirectTimeout.current);
-      leaveRedirectTimeout.current = window.setTimeout(leaveRedirect, 10000);
+      globalThis.clearTimeout(leaveRedirectTimeout.current);
+      leaveRedirectTimeout.current = globalThis.setTimeout(leaveRedirect, 10000);
     },
     onError: () => {
       addErrorMessage('Error closing account');

--- a/static/app/views/settings/account/accountSecurity/accountSecurityEnroll.spec.tsx
+++ b/static/app/views/settings/account/accountSecurity/accountSecurityEnroll.spec.tsx
@@ -34,8 +34,8 @@ describe('AccountSecurityEnroll', () => {
 
     beforeEach(() => {
       setWindowLocation('https://example.test');
-      window.__initialData = {
-        ...window.__initialData,
+      globalThis.__initialData = {
+        ...globalThis.__initialData,
         links: {
           organizationUrl: undefined,
           regionUrl: undefined,
@@ -85,8 +85,8 @@ describe('AccountSecurityEnroll', () => {
 
     it('can enroll from org subdomain', async () => {
       setWindowLocation('https://us-org.example.test');
-      window.__initialData = {
-        ...window.__initialData,
+      globalThis.__initialData = {
+        ...globalThis.__initialData,
         links: {
           organizationUrl: 'https://us-org.example.test',
           regionUrl: 'https://us.example.test',
@@ -136,8 +136,8 @@ describe('AccountSecurityEnroll', () => {
 
     it('can enroll from main domain', async () => {
       OrganizationsStore.load([]);
-      window.__initialData = {
-        ...window.__initialData,
+      globalThis.__initialData = {
+        ...globalThis.__initialData,
         links: {
           organizationUrl: 'https://us-org.example.test',
           regionUrl: 'https://us.example.test',

--- a/static/app/views/settings/account/accountSecurity/accountSecurityEnroll.tsx
+++ b/static/app/views/settings/account/accountSecurity/accountSecurityEnroll.tsx
@@ -232,7 +232,7 @@ export default function AccountSecurityEnroll() {
     // (this is usually only the case for a newly claimed relocated user), we redirect to the org
     // slug's subdomain now.
     const isAlreadyInOrgSubDomain = orgs.some(org => {
-      return org.links.organizationUrl === new URL(window.location.href).origin;
+      return org.links.organizationUrl === new URL(globalThis.location.href).origin;
     });
     if (!isAlreadyInOrgSubDomain) {
       testableWindowLocation.assign(generateOrgSlugUrl(orgs[0]!.slug));

--- a/static/app/views/settings/components/settingsBreadcrumb/breadcrumbDropdown.tsx
+++ b/static/app/views/settings/components/settingsBreadcrumb/breadcrumbDropdown.tsx
@@ -108,19 +108,19 @@ function MenuCrumb({crumbLabel, menuHasHover, isLast, ...props}: MenuCrumbProps)
   }, [overlayState]);
 
   const queueMenuClose = useCallback(() => {
-    window.clearTimeout(closeTimeoutRef.current);
-    closeTimeoutRef.current = window.setTimeout(() => close?.(), CLOSE_MENU_TIMEOUT);
+    globalThis.clearTimeout(closeTimeoutRef.current);
+    closeTimeoutRef.current = globalThis.setTimeout(() => close?.(), CLOSE_MENU_TIMEOUT);
   }, [close]);
 
   const handleOpen = () => {
     activeCrumbStates.forEach(state => state?.close());
-    window.clearTimeout(closeTimeoutRef.current);
+    globalThis.clearTimeout(closeTimeoutRef.current);
     open?.();
   };
 
   useEffect(() => {
     if (menuHasHover) {
-      window.clearTimeout(closeTimeoutRef.current);
+      globalThis.clearTimeout(closeTimeoutRef.current);
     } else {
       queueMenuClose();
     }

--- a/static/app/views/settings/components/settingsNavigation.tsx
+++ b/static/app/views/settings/components/settingsNavigation.tsx
@@ -66,7 +66,7 @@ export class SettingsNavigation extends Component<Props> {
         // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
         scope.setExtra(key, errorInfo[key]);
       });
-      scope.setExtra('url', window.location.href);
+      scope.setExtra('url', globalThis.location.href);
       Sentry.captureException(error);
     });
   }

--- a/static/app/views/settings/components/settingsNavigationGroup.tsx
+++ b/static/app/views/settings/components/settingsNavigationGroup.tsx
@@ -21,7 +21,7 @@ export function SettingsNavigationGroup(props: NavigationGroupProps) {
 
     const handleClick = () => {
       // only call the analytics event if the URL is changing
-      if (recordAnalytics && to !== window.location.pathname && organization) {
+      if (recordAnalytics && to !== globalThis.location.pathname && organization) {
         trackAnalytics('sidebar.item_clicked', {
           organization,
           project_id: project?.id,

--- a/static/app/views/settings/dynamicSampling/projectsTable.spec.tsx
+++ b/static/app/views/settings/dynamicSampling/projectsTable.spec.tsx
@@ -7,7 +7,7 @@ import type {ProjectionSamplePeriod} from 'sentry/views/settings/dynamicSampling
 
 import {ProjectsTable} from './projectsTable';
 
-jest.spyOn(window.Element.prototype, 'getBoundingClientRect').mockReturnValue({
+jest.spyOn(globalThis.Element.prototype, 'getBoundingClientRect').mockReturnValue({
   height: 400,
   width: 500,
   x: 0,

--- a/static/app/views/settings/featureFlags/changeTracking/newProviderForm.tsx
+++ b/static/app/views/settings/featureFlags/changeTracking/newProviderForm.tsx
@@ -220,7 +220,7 @@ function WebhookUrlField({
       <Container flexGrow={1}>
         <TextCopyInput aria-label={t('Webhook URL')} disabled={!provider.length}>
           {provider.length
-            ? `${window.location.origin}/api/0/organizations/${organizationSlug}/flags/hooks/provider/${provider.toLowerCase()}/`
+            ? `${globalThis.location.origin}/api/0/organizations/${organizationSlug}/flags/hooks/provider/${provider.toLowerCase()}/`
             : ''}
         </TextCopyInput>
       </Container>

--- a/static/app/views/settings/organizationAuth/index.tsx
+++ b/static/app/views/settings/organizationAuth/index.tsx
@@ -55,7 +55,7 @@ function OrganizationAuth() {
     const path = `/organizations/${organization.slug}/auth/configure/`;
 
     // Use replace so we don't go back to the /settings/auth and hit this path again.
-    window.location.replace(path);
+    globalThis.location.replace(path);
   }, [organization.slug, shouldRedirectToProvider]);
 
   if (loadingProvider || loadingProviders || shouldRedirectToProvider) {

--- a/static/app/views/settings/organizationIntegrations/SplitInstallationIdModal.tsx
+++ b/static/app/views/settings/organizationIntegrations/SplitInstallationIdModal.tsx
@@ -21,7 +21,7 @@ export function SplitInstallationIdModal(props: Props) {
 
   useEffect(() => {
     return () => {
-      window.clearTimeout(openAdminIntegrationTimeoutRef.current);
+      globalThis.clearTimeout(openAdminIntegrationTimeoutRef.current);
     };
   }, []);
 
@@ -34,9 +34,9 @@ export function SplitInstallationIdModal(props: Props) {
     onCopy();
     addSuccessMessage('Copied to clipboard');
 
-    window.clearTimeout(openAdminIntegrationTimeoutRef.current);
+    globalThis.clearTimeout(openAdminIntegrationTimeoutRef.current);
 
-    openAdminIntegrationTimeoutRef.current = window.setTimeout(() => {
+    openAdminIntegrationTimeoutRef.current = globalThis.setTimeout(() => {
       window.open('https://app.split.io/org/admin/integrations');
     }, 2000);
   };

--- a/static/app/views/settings/organizationIntegrations/addIntegrationButton.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/addIntegrationButton.spec.tsx
@@ -1,4 +1,3 @@
-/* global global */
 import {IntegrationProviderFixture} from 'sentry-fixture/integrationProvider';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
@@ -13,7 +12,7 @@ describe('AddIntegrationButton', () => {
     const focus = jest.fn();
     const open = jest.fn().mockReturnValue({focus, close: jest.fn()});
     // any is needed here because getSentry has different types for global
-    (global as any).open = open;
+    (globalThis as any).open = open;
 
     render(
       <AddIntegrationButton

--- a/static/app/views/settings/organizationIntegrations/integrationButton.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationButton.spec.tsx
@@ -50,7 +50,7 @@ describe('AddIntegrationButton', () => {
     const focus = jest.fn();
     const open = jest.fn().mockReturnValue({focus, close: jest.fn()});
     // any is needed here because getSentry has different types for global
-    (global as any).open = open;
+    (globalThis as any).open = open;
 
     render(getComponent());
 

--- a/static/app/views/settings/projectDebugFiles/sources/customRepositories/index.tsx
+++ b/static/app/views/settings/projectDebugFiles/sources/customRepositories/index.tsx
@@ -85,7 +85,7 @@ export function CustomRepositories({
         addSuccessMessage(successMessage);
 
         if (refresh) {
-          window.location.reload();
+          globalThis.location.reload();
         }
       });
 

--- a/static/app/views/settings/projectGeneralSettings/index.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.tsx
@@ -122,7 +122,7 @@ export function ProjectGeneralSettings({project, onChangeSlug}: Props) {
     try {
       await transferProject(api, organization.slug, project, form.email);
       // Need to hard reload because lots of components do not listen to Projects Store
-      window.location.assign('/');
+      globalThis.location.assign('/');
     } catch (err: any) {
       if (err.status >= 500) {
         handleXhrErrorResponse('Unable to transfer project', err);

--- a/static/app/views/settings/projectSeer/index.spec.tsx
+++ b/static/app/views/settings/projectSeer/index.spec.tsx
@@ -19,17 +19,19 @@ import type {Project} from 'sentry/types/project';
 import {ProjectSeerContainer as ProjectSeer} from 'sentry/views/settings/projectSeer';
 
 // Needed to mock useVirtualizer lists.
-jest.spyOn(window.Element.prototype, 'getBoundingClientRect').mockImplementation(() => ({
-  x: 0,
-  y: 0,
-  width: 0,
-  height: 30,
-  left: 0,
-  top: 0,
-  right: 0,
-  bottom: 0,
-  toJSON: jest.fn(),
-}));
+jest
+  .spyOn(globalThis.Element.prototype, 'getBoundingClientRect')
+  .mockImplementation(() => ({
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 30,
+    left: 0,
+    top: 0,
+    right: 0,
+    bottom: 0,
+    toJSON: jest.fn(),
+  }));
 
 describe('ProjectSeer', () => {
   let project: Project;

--- a/static/app/views/settings/projectUserFeedback/index.tsx
+++ b/static/app/views/settings/projectUserFeedback/index.tsx
@@ -48,12 +48,12 @@ export default function ProjectUserFeedback() {
   // We need this mock here, otherwise the demo crash modal report will send to Sentry.
   // We also need to unset window.sentryEmbedCallback, otherwise if we get a legit crash modal in our app this code would gobble it up.
   useEffect(() => {
-    window.sentryEmbedCallback = function (embed) {
+    globalThis.sentryEmbedCallback = function (embed) {
       // Mock the embed's submit xhr to always be successful
       // NOTE: this will not have errors if the form is empty
       embed.submit = function (_body: any) {
         this._submitInProgress = true;
-        window.setTimeout(() => {
+        globalThis.setTimeout(() => {
           this._submitInProgress = false;
           this.onSuccess();
         }, 500);
@@ -61,7 +61,7 @@ export default function ProjectUserFeedback() {
     };
 
     return () => {
-      window.sentryEmbedCallback = null;
+      globalThis.sentryEmbedCallback = null;
     };
   }, []);
 

--- a/static/app/views/setupWizard/waitingForWizardToConnect.tsx
+++ b/static/app/views/setupWizard/waitingForWizardToConnect.tsx
@@ -26,7 +26,7 @@ export function WaitingForWizardToConnect({
   useEffect(() => {
     return () => {
       if (closeTimeoutRef.current) {
-        window.clearTimeout(closeTimeoutRef.current);
+        globalThis.clearTimeout(closeTimeoutRef.current);
       }
     };
   }, []);
@@ -39,15 +39,15 @@ export function WaitingForWizardToConnect({
       await api.requestPromise(`/wizard/${hash}/`);
     } catch {
       setFinished(true);
-      window.clearTimeout(closeTimeoutRef.current);
-      closeTimeoutRef.current = window.setTimeout(() => window.close(), 10000);
+      globalThis.clearTimeout(closeTimeoutRef.current);
+      closeTimeoutRef.current = globalThis.setTimeout(() => window.close(), 10000);
       trackWizardCompleted();
     }
   }, [api, hash, trackWizardCompleted, finished]);
 
   useEffect(() => {
-    const pollingInterval = window.setInterval(checkFinished, 1000);
-    return () => window.clearInterval(pollingInterval);
+    const pollingInterval = globalThis.setInterval(checkFinished, 1000);
+    return () => globalThis.clearInterval(pollingInterval);
   }, [checkFinished]);
 
   return finished ? (

--- a/static/app/views/sharedGroupDetails/index.tsx
+++ b/static/app/views/sharedGroupDetails/index.tsx
@@ -32,7 +32,7 @@ function SharedGroupDetails() {
     if (orgId) {
       return orgId;
     }
-    const {customerDomain} = window.__initialData || {};
+    const {customerDomain} = globalThis.__initialData || {};
     if (customerDomain?.subdomain) {
       return customerDomain.subdomain;
     }

--- a/static/gsAdmin/components/addOrRemoveOrgModal.tsx
+++ b/static/gsAdmin/components/addOrRemoveOrgModal.tsx
@@ -28,7 +28,7 @@ function AddToOrgModal({Header, Body, userId, closeModal}: AddOrRemoveOrgModalPr
         })
         .then(() => {
           closeModal();
-          window.location.reload();
+          globalThis.location.reload();
         });
     } catch (err: any) {
       setError(err.responseJSON.detail);
@@ -84,7 +84,7 @@ function RemoveFromOrgModal({
         })
         .then(() => {
           closeModal();
-          window.location.reload();
+          globalThis.location.reload();
         });
     } catch (err: any) {
       setError(err.responseJSON.detail);

--- a/static/gsAdmin/init.tsx
+++ b/static/gsAdmin/init.tsx
@@ -24,7 +24,7 @@ export function init(config: Config) {
   // Initialize the config store after the SDK, so we can log errors to Sentry during config initialization if needed
   commonInitialization(config);
 
-  ConfigStore.set('getsentry.sendgridApiKey', window.__sendGridApiKey);
+  ConfigStore.set('getsentry.sendgridApiKey', globalThis.__sendGridApiKey);
 }
 
 const queryClient = new QueryClient(DEFAULT_QUERY_CLIENT_CONFIG);
@@ -49,4 +49,4 @@ export function renderApp() {
 }
 
 // Make the sentry client available to the configurations beforeSend
-window.Sentry = Sentry;
+globalThis.Sentry = Sentry;

--- a/static/gsAdmin/views/billingPlans.spec.tsx
+++ b/static/gsAdmin/views/billingPlans.spec.tsx
@@ -14,8 +14,8 @@ import {BillingPlans, type BillingPlansResponse} from './billingPlans';
 jest.mock('@sentry/react');
 
 // Mock URL.createObjectURL and URL.revokeObjectURL
-global.URL.createObjectURL = jest.fn(() => 'blob:http://localhost/fake-url');
-global.URL.revokeObjectURL = jest.fn();
+globalThis.URL.createObjectURL = jest.fn(() => 'blob:http://localhost/fake-url');
+globalThis.URL.revokeObjectURL = jest.fn();
 
 // We'll use this to hold a reference to the created <a> element
 let downloadLink: HTMLAnchorElement | null = null;
@@ -159,7 +159,7 @@ describe('BillingPlans Component', () => {
     const TEST_BLOB_CONSTRUCTOR = jest.fn();
 
     jest
-      .spyOn(global, 'Blob')
+      .spyOn(globalThis, 'Blob')
       .mockImplementationOnce((...args) => TEST_BLOB_CONSTRUCTOR(...args));
 
     render(<BillingPlans />);

--- a/static/gsAdmin/views/policyDetails.tsx
+++ b/static/gsAdmin/views/policyDetails.tsx
@@ -105,7 +105,7 @@ export function PolicyDetails() {
                 {...deps}
                 policy={policy}
                 onSuccess={(_newRevision: PolicyRevision) => {
-                  window.location.reload();
+                  globalThis.location.reload();
                 }}
               />
             ));

--- a/static/gsAdmin/views/sentryEmployees.tsx
+++ b/static/gsAdmin/views/sentryEmployees.tsx
@@ -88,7 +88,7 @@ export function SentryEmployees() {
                   user={row}
                   onSubmit={() => {
                     // TODO: ideally this would update the user instead of refresh the page
-                    window.location.reload();
+                    globalThis.location.reload();
                   }}
                 />
               ));

--- a/static/gsApp/components/creditCardEdit/intentForms/paymentIntentForm.tsx
+++ b/static/gsApp/components/creditCardEdit/intentForms/paymentIntentForm.tsx
@@ -59,7 +59,7 @@ export function PaymentIntentForm(props: IntentFormProps) {
         clientSecret: intentData.clientSecret,
         redirect: 'if_required', // if the payment method requires redirects, we redirect to the return_url on completion
         confirmParams: {
-          return_url: window.location.href,
+          return_url: globalThis.location.href,
         },
       })
       .then((result: PaymentIntentResult) => {

--- a/static/gsApp/components/creditCardEdit/intentForms/setupIntentForm.tsx
+++ b/static/gsApp/components/creditCardEdit/intentForms/setupIntentForm.tsx
@@ -93,7 +93,7 @@ export function SetupIntentForm(props: IntentFormProps) {
         clientSecret: intentData.clientSecret,
         redirect: 'if_required', // if the payment method requires redirects, we redirect to the return_url on completion
         confirmParams: {
-          return_url: window.location.href,
+          return_url: globalThis.location.href,
         },
       })
       .then((result: SetupIntentResult) => {

--- a/static/gsApp/components/features/disabledPerformancePage.tsx
+++ b/static/gsApp/components/features/disabledPerformancePage.tsx
@@ -65,7 +65,7 @@ function DisabledPerformancePage({
           shortTitle: t('Upgrade'),
           url: new URL(
             `/checkout/${organization.slug}/`,
-            window.location.origin
+            globalThis.location.origin
           ).toString(),
         },
       }}

--- a/static/gsApp/components/features/illustrations/alertsBackground.tsx
+++ b/static/gsApp/components/features/illustrations/alertsBackground.tsx
@@ -112,7 +112,7 @@ export function AlertsBackground({anchorRef}: Props) {
       style.animation = 'none';
       void alert.getBBox();
 
-      window.requestAnimationFrame(
+      globalThis.requestAnimationFrame(
         () => (style.animation = `${alertFlashKeyframes.name} 400ms ${random(5, 10)}`)
       );
     };

--- a/static/gsApp/components/gsBanner.spec.tsx
+++ b/static/gsApp/components/gsBanner.spec.tsx
@@ -39,7 +39,7 @@ jest.mock('sentry/stores/guideStore', () => ({
 
 function setUpTests() {
   jest.clearAllMocks();
-  delete window.pendo;
+  delete globalThis.pendo;
 
   MockApiClient.clearMockResponses();
   MockApiClient.addMockResponse({
@@ -790,7 +790,7 @@ describe('GSBanner', () => {
       body: promotionData,
     });
 
-    window.pendo = {
+    globalThis.pendo = {
       initialize: jest.fn(),
     };
 
@@ -813,7 +813,7 @@ describe('GSBanner', () => {
     });
 
     await waitFor(() => {
-      expect(window.pendo.initialize).toHaveBeenCalledWith({
+      expect(globalThis.pendo.initialize).toHaveBeenCalledWith({
         visitor: {
           id: `${organization.id}.${user.id}`,
           userId: user.id,
@@ -837,7 +837,7 @@ describe('GSBanner', () => {
       });
     });
 
-    delete window.pendo;
+    delete globalThis.pendo;
   });
 
   it('delays pendo guides if other guides are active', async () => {
@@ -856,7 +856,7 @@ describe('GSBanner', () => {
       body: {},
     });
 
-    window.pendo = {
+    globalThis.pendo = {
       initialize: jest.fn(),
     };
 
@@ -897,7 +897,7 @@ describe('GSBanner', () => {
     });
 
     await waitFor(() => {
-      expect(window.pendo.initialize).toHaveBeenCalledWith(
+      expect(globalThis.pendo.initialize).toHaveBeenCalledWith(
         expect.objectContaining({
           guides: {
             delay: true,

--- a/static/gsApp/components/gsBanner.tsx
+++ b/static/gsApp/components/gsBanner.tsx
@@ -161,7 +161,7 @@ function NoticeModal({
         referrer: 'modal-billing-failure',
       });
     }
-    if (link === window.location.pathname) {
+    if (link === globalThis.location.pathname) {
       return;
     }
     navigate(link);
@@ -377,7 +377,7 @@ class GSBanner extends Component<Props, State> {
 
   async initializePendo() {
     const {organization, subscription} = this.props;
-    if (!window.pendo || typeof window.pendo.initialize !== 'function') {
+    if (!globalThis.pendo || typeof globalThis.pendo.initialize !== 'function') {
       return;
     }
     try {
@@ -393,7 +393,7 @@ class GSBanner extends Component<Props, State> {
       // if no current active guide, can just start Pendo
       // TODO: should delay Pendo if there is any popup at all that's blocking and not just guides
       const guideIsActive = !!GuideStore.state.currentGuide;
-      window.pendo.initialize({
+      globalThis.pendo.initialize({
         guides: {
           delay: guideIsActive,
         },
@@ -873,7 +873,7 @@ class GSBanner extends Component<Props, State> {
   renderProductTrialAlerts() {
     const {subscription, organization, api} = this.props;
 
-    const productPath = getProductForPath(subscription, window.location.pathname);
+    const productPath = getProductForPath(subscription, globalThis.location.pathname);
     if (!productPath) {
       return null;
     }

--- a/static/gsApp/components/productSelectionAvailability.tsx
+++ b/static/gsApp/components/productSelectionAvailability.tsx
@@ -151,7 +151,7 @@ function ProductSelectionAvailabilityContainer({
     subscription,
     surface: 'profiling',
     onComplete: () => {
-      window.location.reload();
+      globalThis.location.reload();
     },
     enabled: !hasSessionReplay,
   });
@@ -159,7 +159,7 @@ function ProductSelectionAvailabilityContainer({
   const profilingUpsellModal = useAM2ProfilingUpsellModal({
     subscription,
     onComplete: () => {
-      window.location.reload();
+      globalThis.location.reload();
     },
   });
 

--- a/static/gsApp/components/productUnavailableCTA.tsx
+++ b/static/gsApp/components/productUnavailableCTA.tsx
@@ -171,7 +171,7 @@ function UpdatePlanAlert({
     subscription,
     surface: 'replay_project_creation',
     onComplete: () => {
-      window.location.reload();
+      globalThis.location.reload();
     },
   });
 

--- a/static/gsApp/components/replayOnboardingCTA.tsx
+++ b/static/gsApp/components/replayOnboardingCTA.tsx
@@ -119,7 +119,7 @@ function ReplayOnboardingCTAUpsell({
         organization,
         subscription,
         onComplete: () => {
-          window.location.hash = 'replay-sidequest';
+          globalThis.location.hash = 'replay-sidequest';
           OnboardingDrawerStore.open(OnboardingDrawerKey.REPLAYS_ONBOARDING);
           onComplete();
         },

--- a/static/gsApp/components/superuser/superuserWarning.tsx
+++ b/static/gsApp/components/superuser/superuserWarning.tsx
@@ -41,7 +41,7 @@ function handleExitSuperuser(api: Client) {
     .requestPromise('/staff-auth/', {
       method: 'DELETE',
     })
-    .then(() => window.location.reload());
+    .then(() => globalThis.location.reload());
 }
 
 function ExitSuperuserButton() {

--- a/static/gsApp/components/upgradeNowModal/actionButtons.tsx
+++ b/static/gsApp/components/upgradeNowModal/actionButtons.tsx
@@ -64,7 +64,7 @@ export function ActionButtons({
         closeModal();
         addSuccessMessage(t('Subscription Updated!'));
 
-        window.location.hash = 'replay-sidequest';
+        globalThis.location.hash = 'replay-sidequest';
         OnboardingDrawerStore.open(OnboardingDrawerKey.REPLAYS_ONBOARDING);
 
         trackGetsentryAnalytics('upgrade_now.modal.update_now', {

--- a/static/gsApp/components/upsellModal/details.tsx
+++ b/static/gsApp/components/upsellModal/details.tsx
@@ -229,9 +229,15 @@ export class Details extends Component<Props, State> {
 
     const firstAutoRotate = () => {
       this.showNextFeature();
-      this.autoRotateInterval = window.setInterval(this.showNextFeature, ROTATE_INTERVAL);
+      this.autoRotateInterval = globalThis.setInterval(
+        this.showNextFeature,
+        ROTATE_INTERVAL
+      );
     };
-    this.autoRotateInterval = window.setTimeout(firstAutoRotate, FIRST_ROTATE_TIMEOUT);
+    this.autoRotateInterval = globalThis.setTimeout(
+      firstAutoRotate,
+      FIRST_ROTATE_TIMEOUT
+    );
   }
 
   componentWillUnmount() {

--- a/static/gsApp/components/zendeskLink.tsx
+++ b/static/gsApp/components/zendeskLink.tsx
@@ -44,7 +44,7 @@ function ZendeskLink({
 
   let mailto = `mailto:${address ?? 'support'}@sentry.io`;
   if (subject) {
-    mailto = `${mailto}?subject=${window.encodeURIComponent(subject)}`;
+    mailto = `${mailto}?subject=${globalThis.encodeURIComponent(subject)}`;
   }
 
   const LinkComponent = Component ?? ExternalLink;

--- a/static/gsApp/hooks/analyticsInitUser.tsx
+++ b/static/gsApp/hooks/analyticsInitUser.tsx
@@ -22,7 +22,7 @@ type MarketingEventSchema = {
  * events to Google Analytics and storing the previous_referrer into local storage
  */
 export function analyticsInitUser(user: User) {
-  const {frontend_events, referrer} = qs.parse(window.location.search) || {};
+  const {frontend_events, referrer} = qs.parse(globalThis.location.search) || {};
   // store the referrer in sessionStorage so we know what it was when the user
   // navigates to another page
   if (referrer && typeof referrer === 'string') {

--- a/static/gsApp/hooks/handleGuideUpdate.tsx
+++ b/static/gsApp/hooks/handleGuideUpdate.tsx
@@ -5,12 +5,12 @@ export function handleGuideUpdate(
   {dismissed}: {dismissed?: boolean}
 ) {
   // if not ready, ignore
-  if (!window.pendo?.isReady?.()) {
+  if (!globalThis.pendo?.isReady?.()) {
     return;
   }
   // only start Pendo if there is no next guide
   // and the user did not dismiss
   if (!nextGuide && !dismissed) {
-    window.pendo.startGuides();
+    globalThis.pendo.startGuides();
   }
 }

--- a/static/gsApp/hooks/settingsRoutes.tsx
+++ b/static/gsApp/hooks/settingsRoutes.tsx
@@ -110,7 +110,7 @@ export const settingsRoutes = (): SentryRouteObject => ({
       name: 'Support',
       path: 'support/',
       component: () => {
-        window.location.replace('https://sentry.zendesk.com/hc/en-us');
+        globalThis.location.replace('https://sentry.zendesk.com/hc/en-us');
         return null;
       },
     },

--- a/static/gsApp/hooks/useRouteActivatedHook.tsx
+++ b/static/gsApp/hooks/useRouteActivatedHook.tsx
@@ -139,7 +139,7 @@ export function useRouteActivatedHook({location, matches}: Props) {
     }
     // after the context first loads, we need to wait DELAY_TIME_MS
     // before we send the analytics event
-    const timeoutId = window.setTimeout(() => {
+    const timeoutId = globalThis.setTimeout(() => {
       if (!hasSentAnalytics) {
         setReadyToSend(true);
       }

--- a/static/gsApp/initializeBundleMetrics.tsx
+++ b/static/gsApp/initializeBundleMetrics.tsx
@@ -4,14 +4,14 @@ import {ConfigStore} from 'sentry/stores/configStore';
 
 export function initializeBundleMetrics() {
   if (
-    !window.performance ||
-    typeof window.performance.measure !== 'function' ||
+    !globalThis.performance ||
+    typeof globalThis.performance.measure !== 'function' ||
     !ConfigStore.get('enableAnalytics')
   ) {
     return;
   }
 
-  const release = window.__initialData.sentryConfig?.release;
+  const release = globalThis.__initialData.sentryConfig?.release;
   try {
     const headMark = performance.getEntriesByName('head-start')[0];
     if (headMark) {
@@ -19,7 +19,7 @@ export function initializeBundleMetrics() {
     }
     performance.getEntriesByType('measure').forEach(measurement => {
       // `window.ra` can potentially be undefined here (e.g. it did not successfully load)
-      window.ra?.metric(measurement.name, measurement.duration, {
+      globalThis.ra?.metric(measurement.name, measurement.duration, {
         release,
       });
     });

--- a/static/gsApp/utils/rawTrackAnalyticsEvent.tsx
+++ b/static/gsApp/utils/rawTrackAnalyticsEvent.tsx
@@ -72,7 +72,7 @@ const hasAnalyticsDebug = () =>
 const getCustomReferrer = () => {
   try {
     // pull the referrer from the query parameter of the page
-    const {referrer} = qs.parse(window.location.search) || {};
+    const {referrer} = qs.parse(globalThis.location.search) || {};
     // pull the referrer from session storage.
     const storedReferrer = readStorageValue(CUSTOM_REFERRER_KEY, null) as string | null;
     // ?referrer takes precedence, but still unset session stored referrer.
@@ -228,7 +228,7 @@ export function rawTrackAnalyticsEvent(
 
       // add in url for amplitude events as reload has it automatically added
       const dataWithUrl = {
-        url: window.location.href,
+        url: globalThis.location.href,
         user_age: userAge,
         organization_age: orgAge,
         ...data,

--- a/static/gsApp/utils/routeAnalytics.tsx
+++ b/static/gsApp/utils/routeAnalytics.tsx
@@ -41,7 +41,7 @@ export function getEventPath(matches: Array<UIMatch<unknown, unknown>>) {
  * @returns A string representing the route path
  */
 export function getUrlFromLocation(location: Location) {
-  const previousUrlObj = new URL(window.location.origin + location.pathname);
+  const previousUrlObj = new URL(globalThis.location.origin + location.pathname);
   previousUrlObj.search = location.search;
   previousUrlObj.hash = location.hash;
   return previousUrlObj.toString();

--- a/static/gsApp/utils/trackMarketingEvent.spec.tsx
+++ b/static/gsApp/utils/trackMarketingEvent.spec.tsx
@@ -8,16 +8,16 @@ describe('trackMarketingEvent', () => {
   const eventName = 'my_event';
   beforeEach(() => {
     ConfigStore.set('enableAnalytics', true);
-    window.ga = jest.fn();
+    globalThis.ga = jest.fn();
   });
   afterEach(() => {
-    window.ga.mockClear();
+    globalThis.ga.mockClear();
   });
 
   it('calls window.ga with event_label', () => {
     const data = {event_label: 'my_label'};
     trackMarketingEvent(eventName, data);
-    expect(window.ga).toHaveBeenCalledWith('send', {
+    expect(globalThis.ga).toHaveBeenCalledWith('send', {
       hitType: 'event',
       eventCategory: 'User',
       eventAction: eventName,
@@ -26,7 +26,7 @@ describe('trackMarketingEvent', () => {
   });
   it('calls window.ga without event_label', () => {
     trackMarketingEvent(eventName);
-    expect(window.ga).toHaveBeenCalledWith('send', {
+    expect(globalThis.ga).toHaveBeenCalledWith('send', {
       hitType: 'event',
       eventCategory: 'User',
       eventAction: eventName,
@@ -36,6 +36,6 @@ describe('trackMarketingEvent', () => {
   it('enableAnalytics is false', () => {
     ConfigStore.set('enableAnalytics', false);
     trackMarketingEvent(eventName);
-    expect(window.ga).not.toHaveBeenCalled();
+    expect(globalThis.ga).not.toHaveBeenCalled();
   });
 });

--- a/static/gsApp/utils/trackMarketingEvent.tsx
+++ b/static/gsApp/utils/trackMarketingEvent.tsx
@@ -10,13 +10,13 @@ export function trackMarketingEvent(
   }
 
   // Google
-  window.ga =
-    window.ga ||
+  globalThis.ga =
+    globalThis.ga ||
     function (...args: any[]) {
-      (window.ga.q = window.ga.q || []).push(args);
+      (globalThis.ga.q = globalThis.ga.q || []).push(args);
     };
-  window.ga.l = Date.now();
-  window.ga('send', {
+  globalThis.ga.l = Date.now();
+  globalThis.ga('send', {
     hitType: 'event',
     eventCategory: 'User',
     eventAction: event_type,
@@ -24,7 +24,7 @@ export function trackMarketingEvent(
   });
 
   // GA4
-  window.gtag?.('event', event_type, {
+  globalThis.gtag?.('event', event_type, {
     event_category: 'User',
     event_label: options?.event_label,
   });

--- a/static/gsApp/utils/trackPendoEvent.tsx
+++ b/static/gsApp/utils/trackPendoEvent.tsx
@@ -1,8 +1,8 @@
 export function trackPendoEvent(eventName: string, data: Record<PropertyKey, unknown>) {
   // make sure we have the tracking function
-  if (typeof window.pendo?.track !== 'function') {
+  if (typeof globalThis.pendo?.track !== 'function') {
     return;
   }
   // TODO: force all data to lower case field properties
-  window.pendo.track(eventName, data);
+  globalThis.pendo.track(eventName, data);
 }

--- a/static/gsApp/utils/trackReloadEvent.spec.tsx
+++ b/static/gsApp/utils/trackReloadEvent.spec.tsx
@@ -9,19 +9,19 @@ describe('trackReloadEvent', () => {
   const data = {foo: 'bar'};
   beforeEach(() => {
     ConfigStore.set('enableAnalytics', true);
-    window.ra = {event: jest.fn()};
+    globalThis.ra = {event: jest.fn()};
   });
   afterEach(() => {
-    window.ra.event.mockClear();
+    globalThis.ra.event.mockClear();
   });
 
   it('calls window.ra.event with data', () => {
     trackReloadEvent(eventName, data);
-    expect(window.ra.event).toHaveBeenCalledWith(eventName, data);
+    expect(globalThis.ra.event).toHaveBeenCalledWith(eventName, data);
   });
   it('enableAnalytics is false', () => {
     ConfigStore.set('enableAnalytics', false);
     trackReloadEvent(eventName, data);
-    expect(window.ra.event).not.toHaveBeenCalled();
+    expect(globalThis.ra.event).not.toHaveBeenCalled();
   });
 });

--- a/static/gsApp/utils/trackReloadEvent.tsx
+++ b/static/gsApp/utils/trackReloadEvent.tsx
@@ -5,5 +5,5 @@ export function trackReloadEvent(eventType: string, data: Record<PropertyKey, un
   if (!ConfigStore.get('enableAnalytics')) {
     return;
   }
-  window.ra?.event(eventType, data);
+  globalThis.ra?.event(eventType, data);
 }

--- a/static/gsApp/views/seerAutomation/components/seerConnectGitHubBanner.tsx
+++ b/static/gsApp/views/seerAutomation/components/seerConnectGitHubBanner.tsx
@@ -25,7 +25,7 @@ export function SeerConnectGitHubBanner() {
   );
 
   const handleAddIntegration = useCallback(() => {
-    window.location.reload();
+    globalThis.location.reload();
   }, []);
 
   if (!isFetched || isError || data?.hasSupportedScmIntegration) {

--- a/static/gsApp/views/seerAutomation/onboarding/connectGithubStep.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/connectGithubStep.tsx
@@ -13,7 +13,7 @@ import {GithubButton} from './githubButton';
 
 export function ConnectGithubStep() {
   const handleAddIntegration = useCallback(() => {
-    window.location.reload();
+    globalThis.location.reload();
   }, []);
 
   return (

--- a/static/gsApp/views/seerAutomation/onboarding/repositorySelector.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/repositorySelector.tsx
@@ -152,7 +152,7 @@ export function RepositorySelector() {
                         <IntegrationButton
                           userHasAccess={hasAccess}
                           onAddIntegration={() => {
-                            window.location.reload();
+                            globalThis.location.reload();
                           }}
                           onExternalClick={() => {}}
                           buttonProps={{

--- a/static/gsApp/views/subscriptionPage/headerCards/paygCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/paygCard.tsx
@@ -117,14 +117,14 @@ export function PaygCard({
   }, [isEditing]);
 
   useEffect(() => {
-    if (window.location.hash === '#open-ondemand-modal') {
+    if (globalThis.location.hash === '#open-ondemand-modal') {
       handleEditPayg(true);
 
       // Clear hash to prevent modal reopening or focus state on refresh
-      window.history.replaceState(
+      globalThis.history.replaceState(
         null,
         '',
-        window.location.pathname + window.location.search
+        globalThis.location.pathname + globalThis.location.search
       );
     }
   }, [handleEditPayg]);

--- a/static/gsApp/views/subscriptionPage/overview.tsx
+++ b/static/gsApp/views/subscriptionPage/overview.tsx
@@ -56,14 +56,14 @@ function Overview({subscription}: Props) {
   useEffect(() => {
     // Open on-demand budget modal if hash fragment present
     // Modal logic handles checking perms
-    if (window.location.hash === '#open-ondemand-modal') {
+    if (globalThis.location.hash === '#open-ondemand-modal') {
       openOnDemandBudgetEditModal({organization, subscription});
 
       // Clear hash to prevent modal reopening on refresh
-      window.history.replaceState(
+      globalThis.history.replaceState(
         null,
         '',
-        window.location.pathname + window.location.search
+        globalThis.location.pathname + globalThis.location.search
       );
     }
   }, [organization, subscription]);

--- a/tests/js/sentry-test/utils.tsx
+++ b/tests/js/sentry-test/utils.tsx
@@ -49,14 +49,14 @@ export function resetMockDate() {
  */
 export function setWindowLocation(url: string) {
   // global jsdom is coming from `@sentry/jest-environment`
-  (global as any).jsdom.reconfigure({url});
+  (globalThis as any).jsdom.reconfigure({url});
 }
 
 /**
  * Mocks window.matchMedia to always return the provided `matches`.
  */
 export function mockMatchMedia(matches: boolean) {
-  jest.spyOn(window, 'matchMedia').mockImplementation(() => ({
+  jest.spyOn(globalThis, 'matchMedia').mockImplementation(() => ({
     matches,
     media: '',
     onchange: null,

--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -300,22 +300,22 @@ declare global {
 }
 
 // needed by cbor-web for webauthn
-window.TextEncoder = TextEncoder as typeof window.TextEncoder;
-window.TextDecoder = TextDecoder as typeof window.TextDecoder;
+globalThis.TextEncoder = TextEncoder as typeof globalThis.TextEncoder;
+globalThis.TextDecoder = TextDecoder as typeof globalThis.TextDecoder;
 
 // This is so we can use async/await in tests instead of wrapping with `setTimeout`.
-window.tick = () => new Promise(resolve => setTimeout(resolve));
+globalThis.tick = () => new Promise(resolve => setTimeout(resolve));
 
-window.MockApiClient = jest.requireMock('sentry/api').Client;
+globalThis.MockApiClient = jest.requireMock('sentry/api').Client;
 
 window.scrollTo = jest.fn();
 
-window.ra = {event: jest.fn()};
+globalThis.ra = {event: jest.fn()};
 
 // The JSDOM implementation is too slow
 // Especially for dropdowns that try to position themselves
 // perf issue - https://github.com/jsdom/jsdom/issues/3234
-Object.defineProperty(window, 'getComputedStyle', {
+Object.defineProperty(globalThis, 'getComputedStyle', {
   value: (el: HTMLElement) => {
     /**
      * This is based on the jsdom implementation of getComputedStyle
@@ -341,7 +341,7 @@ Object.defineProperty(window, 'getComputedStyle', {
   writable: true,
 });
 
-Object.defineProperty(window, 'matchMedia', {
+Object.defineProperty(globalThis, 'matchMedia', {
   writable: true,
   value: (query: string) => ({
     matches: false,
@@ -355,7 +355,7 @@ Object.defineProperty(window, 'matchMedia', {
   }),
 });
 
-window.IntersectionObserver = class IntersectionObserver {
+globalThis.IntersectionObserver = class IntersectionObserver {
   root = null;
   rootMargin = '';
   scrollMargin = '';
@@ -367,14 +367,14 @@ window.IntersectionObserver = class IntersectionObserver {
   disconnect() {}
 };
 
-window.ResizeObserver = class ResizeObserver {
+globalThis.ResizeObserver = class ResizeObserver {
   observe() {}
   unobserve() {}
   disconnect() {}
 };
 
 // Mock the crypto.subtle API for Gravatar
-Object.defineProperty(global.self, 'crypto', {
+Object.defineProperty(globalThis.self, 'crypto', {
   value: {
     subtle: webcrypto.subtle,
   },


### PR DESCRIPTION
Enable `unicorn/prefer-global-this` in `eslint.config.ts` and apply autofixes (`globalThis` instead of `window` / `self` where appropriate).

Remove a stale `/* global global */` directive in `addIntegrationButton.spec.tsx` after the autofix switched the test to `globalThis`.

Fixes ENG-7424.

Made with [Cursor](https://cursor.com)