### PR TITLE
feat(tracemetrics): Add equation support in old tracemetric alerts

### DIFF
--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -58,6 +58,7 @@ import {withApi} from 'sentry/utils/withApi';
 import {withProjects} from 'sentry/utils/withProjects';
 import {withTags} from 'sentry/utils/withTags';
 import {getIsMigratedExtrapolationMode} from 'sentry/views/alerts/rules/metric/details/utils';
+import {MetricsEquationVisualizeField} from 'sentry/views/alerts/rules/metric/traceMetrics/metricsEquationVisualizeField';
 import {WizardField} from 'sentry/views/alerts/rules/metric/wizardField';
 import {getProjectOptions, isEapAlertType} from 'sentry/views/alerts/rules/utils';
 import {
@@ -74,6 +75,7 @@ import {getTraceItemTypeForDatasetAndEventType} from 'sentry/views/alerts/wizard
 import {SESSIONS_FILTER_TAGS} from 'sentry/views/dashboards/widgetBuilder/releaseWidget/fields';
 import {TraceItemSearchQueryBuilder} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
 import {useTraceItemDatasetAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
+import {canUseMetricsEquationsInAlerts} from 'sentry/views/explore/metrics/metricsFlags';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {
   deprecateTransactionAlerts,
@@ -481,6 +483,15 @@ class RuleConditionsForm extends PureComponent<Props, State> {
     );
   }
 
+  get useMetricsEquationEditor() {
+    const {organization, dataset, eventTypes} = this.props;
+    return (
+      canUseMetricsEquationsInAlerts(organization) &&
+      getTraceItemTypeForDatasetAndEventType(dataset, eventTypes) ===
+        TraceItemDataset.TRACEMETRICS
+    );
+  }
+
   renderInterval() {
     const {
       organization,
@@ -491,9 +502,27 @@ class RuleConditionsForm extends PureComponent<Props, State> {
       dataset,
       comparisonType,
       onTimeWindowChange,
+      onFilterSearch,
       isEditing,
       eventTypes,
     } = this.props;
+
+    const timeWindowSelect = (
+      <Tooltip
+        title={this.transactionAlertDisabledMessage}
+        disabled={!this.disableTransactionAlertType}
+        isHoverable
+      >
+        <Select
+          name="timeWindow"
+          styles={this.selectControlStyles}
+          options={getTimeWindowOptions(dataset, comparisonType)}
+          isDisabled={disabled || this.disableTransactionAlertType}
+          value={timeWindow}
+          onChange={({value}) => onTimeWindowChange(value)}
+        />
+      </Tooltip>
+    );
 
     return (
       <Fragment>
@@ -502,46 +531,65 @@ class RuleConditionsForm extends PureComponent<Props, State> {
             <div>{t('Define your metric')}</div>
           </StyledListTitle>
         </StyledListItem>
-        <FormRow>
-          <WizardField
-            name="aggregate"
-            help={null}
-            organization={organization}
-            disabled={disabled}
-            project={project}
-            style={{
-              ...this.formElemBaseStyle,
-              flex: 1,
-            }}
-            inline={false}
-            flexibleControlStateSize
-            columnWidth={200}
-            alertType={alertType}
-            required
-            isEditing={isEditing}
-            eventTypes={eventTypes}
-            disabledReason={
-              this.disableTransactionAlertType
-                ? this.transactionAlertDisabledMessage
-                : undefined
-            }
-            onMetricLoadingChange={this.props.onMetricLoadingChange}
-          />
-          <Tooltip
-            title={this.transactionAlertDisabledMessage}
-            disabled={!this.disableTransactionAlertType}
-            isHoverable
-          >
-            <Select
-              name="timeWindow"
-              styles={this.selectControlStyles}
-              options={getTimeWindowOptions(dataset, comparisonType)}
-              isDisabled={disabled || this.disableTransactionAlertType}
-              value={timeWindow}
-              onChange={({value}) => onTimeWindowChange(value)}
+        {this.useMetricsEquationEditor ? (
+          <Fragment>
+            <Flex gap="xs">
+              <WizardField
+                name="aggregate"
+                help={null}
+                organization={organization}
+                disabled={disabled}
+                project={project}
+                style={{
+                  ...this.formElemBaseStyle,
+                  flex: 1,
+                }}
+                inline={false}
+                flexibleControlStateSize
+                columnWidth={200}
+                alertType={alertType}
+                required
+                isEditing={isEditing}
+                eventTypes={eventTypes}
+                hideAggregateEditor
+                onMetricLoadingChange={this.props.onMetricLoadingChange}
+              />
+              {timeWindowSelect}
+            </Flex>
+            <MetricsEquationVisualizeField
+              project={project}
+              onFilterSearch={onFilterSearch}
             />
-          </Tooltip>
-        </FormRow>
+          </Fragment>
+        ) : (
+          <FormRow>
+            <WizardField
+              name="aggregate"
+              help={null}
+              organization={organization}
+              disabled={disabled}
+              project={project}
+              style={{
+                ...this.formElemBaseStyle,
+                flex: 1,
+              }}
+              inline={false}
+              flexibleControlStateSize
+              columnWidth={200}
+              alertType={alertType}
+              required
+              isEditing={isEditing}
+              eventTypes={eventTypes}
+              disabledReason={
+                this.disableTransactionAlertType
+                  ? this.transactionAlertDisabledMessage
+                  : undefined
+              }
+              onMetricLoadingChange={this.props.onMetricLoadingChange}
+            />
+            {timeWindowSelect}
+          </FormRow>
+        )}
       </Fragment>
     );
   }
@@ -703,138 +751,146 @@ class RuleConditionsForm extends PureComponent<Props, State> {
                 {allowChangeEventTypes && this.renderEventTypeFilter()}
               </FormRow>
             </Tooltip>
-            <FormRow noMargin>
-              <FormField
-                name="query"
-                inline={false}
-                style={{
-                  ...this.formElemBaseStyle,
-                  flex: '6 0 500px',
-                }}
-                flexibleControlStateSize
-              >
-                {({onChange, onBlur, initialData, value}: any) => {
-                  return isEapAlertType(alertType) ? (
-                    <EAPSearchQueryBuilderWithContext
-                      initialQuery={value ?? ''}
-                      onSearch={(query, {parsedQuery}) => {
-                        onFilterSearch(query, parsedQuery);
-                        onChange(query, {});
-                      }}
-                      enabled={organization.features.includes('visibility-explore-view')}
-                      project={project}
-                      traceItemType={traceItemType ?? TraceItemDataset.SPANS}
-                    />
-                  ) : (
-                    <Flex align="center" gap="md">
-                      <SearchQueryBuilder
-                        initialQuery={initialData?.query ?? ''}
-                        getTagValues={this.getEventFieldValues}
-                        placeholder={this.searchPlaceholder}
-                        searchSource="alert_builder"
-                        filterKeys={filterKeys}
-                        disabled={
-                          disabled || isErrorMigration || this.disableTransactionAlertType
-                        }
-                        onChange={onChange}
-                        invalidMessages={{
-                          ...defaultConfig.invalidMessages,
-                          [InvalidReason.WILDCARD_NOT_ALLOWED]: t(
-                            'The wildcard operator is not supported here.'
-                          ),
-                          [InvalidReason.FREE_TEXT_NOT_ALLOWED]: t(
-                            'Free text search is not allowed. If you want to partially match transaction names, use glob patterns like "transaction:*transaction-name*"'
-                          ),
-                        }}
-                        onSearch={query => {
-                          onFilterSearch(query, true);
-                          onChange(query, {});
-                        }}
-                        onBlur={(query, {parsedQuery}) => {
-                          onFilterSearch(query, parsedQuery);
-                          onBlur(query);
-                        }}
-                        // We only need strict validation for Transaction queries, everything else is fine
-                        disallowUnsupportedFilters={
-                          organization.features.includes('alert-allow-indexed') ||
-                          (hasOnDemandMetricAlertFeature(organization) &&
-                            isOnDemandQueryString(value))
-                            ? false
-                            : dataset === Dataset.GENERIC_METRICS
-                        }
-                      />
-                      {isExtrapolatedChartData &&
-                        isOnDemandQueryString(value) &&
-                        (isOnDemandLimitReached ? (
-                          <OnDemandWarningIcon
-                            variant="danger"
-                            msg={tct(
-                              'We don’t routinely collect metrics from [fields] and you’ve already reached the limit of [docLink:alerts with advanced filters] for your organization.',
-                              {
-                                fields: (
-                                  <strong>
-                                    {getOnDemandKeys(value)
-                                      .map(key => `"${key}"`)
-                                      .join(', ')}
-                                  </strong>
-                                ),
-                                docLink: (
-                                  <ExternalLink href="https://docs.sentry.io/product/alerts/create-alerts/metric-alert-config/#advanced-filters-for-transactions" />
-                                ),
-                              }
-                            )}
-                            isHoverable
+            {!this.useMetricsEquationEditor && (
+              <Fragment>
+                <FormRow noMargin>
+                  <FormField
+                    name="query"
+                    inline={false}
+                    style={{
+                      ...this.formElemBaseStyle,
+                      flex: '6 0 500px',
+                    }}
+                    flexibleControlStateSize
+                  >
+                    {({onChange, onBlur, initialData, value}: any) => {
+                      return isEapAlertType(alertType) ? (
+                        <EAPSearchQueryBuilderWithContext
+                          initialQuery={value ?? ''}
+                          onSearch={(query, {parsedQuery}) => {
+                            onFilterSearch(query, parsedQuery);
+                            onChange(query, {});
+                          }}
+                          enabled={organization.features.includes(
+                            'visibility-explore-view'
+                          )}
+                          project={project}
+                          traceItemType={traceItemType ?? TraceItemDataset.SPANS}
+                        />
+                      ) : (
+                        <Flex align="center" gap="md">
+                          <SearchQueryBuilder
+                            initialQuery={initialData?.query ?? ''}
+                            getTagValues={this.getEventFieldValues}
+                            placeholder={this.searchPlaceholder}
+                            searchSource="alert_builder"
+                            filterKeys={filterKeys}
+                            disabled={
+                              disabled ||
+                              isErrorMigration ||
+                              this.disableTransactionAlertType
+                            }
+                            onChange={onChange}
+                            invalidMessages={{
+                              ...defaultConfig.invalidMessages,
+                              [InvalidReason.WILDCARD_NOT_ALLOWED]: t(
+                                'The wildcard operator is not supported here.'
+                              ),
+                              [InvalidReason.FREE_TEXT_NOT_ALLOWED]: t(
+                                'Free text search is not allowed. If you want to partially match transaction names, use glob patterns like "transaction:*transaction-name*"'
+                              ),
+                            }}
+                            onSearch={query => {
+                              onFilterSearch(query, true);
+                              onChange(query, {});
+                            }}
+                            onBlur={(query, {parsedQuery}) => {
+                              onFilterSearch(query, parsedQuery);
+                              onBlur(query);
+                            }}
+                            // We only need strict validation for Transaction queries, everything else is fine
+                            disallowUnsupportedFilters={
+                              organization.features.includes('alert-allow-indexed') ||
+                              (hasOnDemandMetricAlertFeature(organization) &&
+                                isOnDemandQueryString(value))
+                                ? false
+                                : dataset === Dataset.GENERIC_METRICS
+                            }
                           />
-                        ) : (
-                          <OnDemandWarningIcon
-                            variant="primary"
-                            msg={tct(
-                              'We don’t routinely collect metrics from [fields]. However, we’ll do so [strong:once this alert has been saved.]',
-                              {
-                                fields: (
-                                  <strong>
-                                    {getOnDemandKeys(value)
-                                      .map(key => `"${key}"`)
-                                      .join(', ')}
-                                  </strong>
-                                ),
-                                strong: <strong />,
-                              }
+                          {isExtrapolatedChartData &&
+                            isOnDemandQueryString(value) &&
+                            (isOnDemandLimitReached ? (
+                              <OnDemandWarningIcon
+                                variant="danger"
+                                msg={tct(
+                                  'We don’t routinely collect metrics from [fields] and you’ve already reached the limit of [docLink:alerts with advanced filters] for your organization.',
+                                  {
+                                    fields: (
+                                      <strong>
+                                        {getOnDemandKeys(value)
+                                          .map(key => `"${key}"`)
+                                          .join(', ')}
+                                      </strong>
+                                    ),
+                                    docLink: (
+                                      <ExternalLink href="https://docs.sentry.io/product/alerts/create-alerts/metric-alert-config/#advanced-filters-for-transactions" />
+                                    ),
+                                  }
+                                )}
+                                isHoverable
+                              />
+                            ) : (
+                              <OnDemandWarningIcon
+                                variant="primary"
+                                msg={tct(
+                                  'We don’t routinely collect metrics from [fields]. However, we’ll do so [strong:once this alert has been saved.]',
+                                  {
+                                    fields: (
+                                      <strong>
+                                        {getOnDemandKeys(value)
+                                          .map(key => `"${key}"`)
+                                          .join(', ')}
+                                      </strong>
+                                    ),
+                                    strong: <strong />,
+                                  }
+                                )}
+                              />
+                            ))}
+                        </Flex>
+                      );
+                    }}
+                  </FormField>
+                </FormRow>
+                <FormRow noMargin>
+                  <FormField
+                    name="query"
+                    inline={false}
+                    style={{
+                      ...this.formElemBaseStyle,
+                      flex: '6 0 500px',
+                    }}
+                    flexibleControlStateSize
+                  >
+                    {(args: any) => {
+                      if (
+                        args.value?.includes('is:unresolved') &&
+                        comparisonType === AlertRuleComparisonType.DYNAMIC
+                      ) {
+                        return (
+                          <OnDemandMetricAlert
+                            message={t(
+                              "'is:unresolved' queries are not supported by Anomaly Detection alerts."
                             )}
                           />
-                        ))}
-                    </Flex>
-                  );
-                }}
-              </FormField>
-            </FormRow>
-            <FormRow noMargin>
-              <FormField
-                name="query"
-                inline={false}
-                style={{
-                  ...this.formElemBaseStyle,
-                  flex: '6 0 500px',
-                }}
-                flexibleControlStateSize
-              >
-                {(args: any) => {
-                  if (
-                    args.value?.includes('is:unresolved') &&
-                    comparisonType === AlertRuleComparisonType.DYNAMIC
-                  ) {
-                    return (
-                      <OnDemandMetricAlert
-                        message={t(
-                          "'is:unresolved' queries are not supported by Anomaly Detection alerts."
-                        )}
-                      />
-                    );
-                  }
-                  return null;
-                }}
-              </FormField>
-            </FormRow>
+                        );
+                      }
+                      return null;
+                    }}
+                  </FormField>
+                </FormRow>
+              </Fragment>
+            )}
           </Fragment>
         )}
       </Fragment>

--- a/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleConditionsForm.tsx
@@ -532,8 +532,8 @@ class RuleConditionsForm extends PureComponent<Props, State> {
           </StyledListTitle>
         </StyledListItem>
         {this.useMetricsEquationEditor ? (
-          <Fragment>
-            <Flex gap="xs">
+          <FormRow>
+            <Flex gap="xs" width="100%">
               <WizardField
                 name="aggregate"
                 help={null}
@@ -560,7 +560,7 @@ class RuleConditionsForm extends PureComponent<Props, State> {
               project={project}
               onFilterSearch={onFilterSearch}
             />
-          </Fragment>
+          </FormRow>
         ) : (
           <FormRow>
             <WizardField
@@ -719,7 +719,10 @@ class RuleConditionsForm extends PureComponent<Props, State> {
               disabled={!this.disableTransactionAlertType}
               isHoverable
             >
-              <FormRow noMargin columns={1 + (allowChangeEventTypes ? 1 : 0) + 1}>
+              <FormRow
+                noMargin={!this.useMetricsEquationEditor}
+                columns={1 + (allowChangeEventTypes ? 1 : 0) + 1}
+              >
                 {this.renderProjectSelector()}
                 <SelectField
                   name="environment"

--- a/static/app/views/alerts/rules/metric/traceMetrics/metricsEquationVisualizeField.tsx
+++ b/static/app/views/alerts/rules/metric/traceMetrics/metricsEquationVisualizeField.tsx
@@ -1,0 +1,33 @@
+import {useCallback} from 'react';
+
+import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
+import type {Project} from 'sentry/types/project';
+import {MetricsEquationVisualize} from 'sentry/views/detectors/components/forms/metric/metricsEquationVisualize';
+
+export function MetricsEquationVisualizeField({
+  project,
+  onFilterSearch,
+}: {
+  onFilterSearch: (query: string, isQueryValid: any) => void;
+  project: Project;
+}) {
+  const projectId = useFormField<string>('projectId') ?? project.id;
+  const environment = useFormField<string | null>('environment') ?? null;
+
+  // Must be stable — it's a dep of the editor's sync-to-form effect, so an
+  // inline lambda would re-run the effect on every parent re-render and loop
+  // through `setValue` → `handleFieldChange` → `setState`.
+  const onQueryChange = useCallback(
+    (query: string) => onFilterSearch(query, true),
+    [onFilterSearch]
+  );
+
+  return (
+    <MetricsEquationVisualize
+      aggregateFieldName="aggregate"
+      projectIds={projectId ? [Number(projectId)] : []}
+      environments={environment ? [environment] : undefined}
+      onQueryChange={onQueryChange}
+    />
+  );
+}

--- a/static/app/views/alerts/rules/metric/wizardField.tsx
+++ b/static/app/views/alerts/rules/metric/wizardField.tsx
@@ -43,6 +43,12 @@ type Props = Omit<FormFieldProps, 'children'> & {
    */
   columnWidth?: number;
   eventTypes?: EventTypes[];
+  /**
+   * Render only the alert-type Select, hiding the aggregate editor below.
+   * Useful when the aggregate is being edited by a different control elsewhere
+   * in the form (e.g. the trace metrics equation editor).
+   */
+  hideAggregateEditor?: boolean;
   inFieldLabels?: boolean;
   isEditing?: boolean;
   onMetricLoadingChange?: (isLoading: boolean) => void;
@@ -56,6 +62,7 @@ export function WizardField({
   alertType,
   eventTypes,
   onMetricLoadingChange,
+  hideAggregateEditor,
   ...fieldProps
 }: Props) {
   const isDeprecatedTransactionAlertType =
@@ -245,7 +252,8 @@ export function WizardField({
           1 +
           numParameters -
           (hideParameterSelector ? 1 : 0) -
-          (hidePrimarySelector ? 1 : 0);
+          (hidePrimarySelector ? 1 : 0) -
+          (hideAggregateEditor ? 1 : 0);
 
         return (
           <Container alertType={alertType} hideGap={gridColumns < 1}>
@@ -264,7 +272,7 @@ export function WizardField({
                 model.setValue('alertType', option.value);
               }}
             />
-            {alertType === 'trace_item_metrics' ? (
+            {hideAggregateEditor ? null : alertType === 'trace_item_metrics' ? (
               <EAPMetricsField
                 aggregate={aggregate}
                 projectId={project.id}

--- a/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
@@ -7,13 +7,11 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {Expression} from 'sentry/components/arithmeticBuilder/expression';
 import {FormContext} from 'sentry/components/forms/formContext';
+import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
 import {t} from 'sentry/locale';
 import {EQUATION_PREFIX} from 'sentry/utils/discover/fields';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {
-  METRIC_DETECTOR_FORM_FIELDS,
-  useMetricDetectorFormField,
-} from 'sentry/views/detectors/components/forms/metric/metricFormData';
+import {METRIC_DETECTOR_FORM_FIELDS} from 'sentry/views/detectors/components/forms/metric/metricFormData';
 import {SectionLabel} from 'sentry/views/detectors/components/forms/sectionLabel';
 import {ToolbarVisualizeAddChart} from 'sentry/views/explore/components/toolbar/toolbarVisualize';
 import {EquationBuilder} from 'sentry/views/explore/metrics/equationBuilder';
@@ -65,13 +63,32 @@ function computeEquationReferencedLabels(
   return extractReferenceLabels(new Expression(unresolvedText, labelSet));
 }
 
-export function MetricsEquationVisualize() {
+interface MetricsEquationVisualizeProps {
+  /**
+   * Form field that stores the aggregate expression. Defaults to the metric
+   * detector field; the legacy alert form passes `aggregate`.
+   */
+  aggregateFieldName?: typeof METRIC_DETECTOR_FORM_FIELDS.aggregateFunction | 'aggregate';
+  environments?: string[];
+  /**
+   * Called when the selected row's filter query changes. The legacy alert
+   * form uses this to run `onFilterSearch` so the threshold chart refresh
+   * on filter-bar edits.
+   */
+  onQueryChange?: (query: string) => void;
+  projectIds?: number[];
+}
+
+export function MetricsEquationVisualize({
+  aggregateFieldName = METRIC_DETECTOR_FORM_FIELDS.aggregateFunction,
+  projectIds,
+  environments,
+  onQueryChange,
+}: MetricsEquationVisualizeProps) {
   const organization = useOrganization();
   const hasEquations = canUseMetricsEquationsInAlerts(organization);
-  const aggregateFunction = useMetricDetectorFormField(
-    METRIC_DETECTOR_FORM_FIELDS.aggregateFunction
-  );
-  const query = useMetricDetectorFormField(METRIC_DETECTOR_FORM_FIELDS.query);
+  const aggregateFunction = useFormField<string>(aggregateFieldName);
+  const query = useFormField<string>(METRIC_DETECTOR_FORM_FIELDS.query);
 
   // Parse once at mount; subsequent aggregateFunction changes are intentionally
   // discarded so unsaved row edits survive form writes. Remounting the provider
@@ -89,16 +106,29 @@ export function MetricsEquationVisualize() {
       initialQueries={initialQueries}
       hasEquations={hasEquations}
     >
-      <MetricsEquationVisualizeContent />
+      <MetricsEquationVisualizeContent
+        aggregateFieldName={aggregateFieldName}
+        projectIds={projectIds}
+        environments={environments}
+        onQueryChange={onQueryChange}
+      />
     </LocalMultiMetricsQueryParamsProvider>
   );
 }
 
-function MetricsEquationVisualizeContent() {
+function MetricsEquationVisualizeContent({
+  aggregateFieldName,
+  projectIds,
+  environments,
+  onQueryChange,
+}: {
+  aggregateFieldName: string;
+  environments?: string[];
+  onQueryChange?: (query: string) => void;
+  projectIds?: number[];
+}) {
   const formContext = useContext(FormContext);
-  const initialAggregate = useMetricDetectorFormField(
-    METRIC_DETECTOR_FORM_FIELDS.aggregateFunction
-  );
+  const initialAggregate = useFormField<string>(aggregateFieldName);
   const metricQueries = useMultiMetricsQueryParams();
   const referenceMap = useMetricReferences(metricQueries);
   const addAggregate = useAddMetricQuery({type: 'aggregate'});
@@ -128,15 +158,13 @@ function MetricsEquationVisualizeContent() {
     const selectedYAxis = selectedQuery?.queryParams.visualizes[0]?.yAxis;
     const selectedFilter = selectedQuery?.queryParams.query;
     if (selectedYAxis !== undefined) {
-      formContext.form?.setValue(
-        METRIC_DETECTOR_FORM_FIELDS.aggregateFunction,
-        selectedYAxis
-      );
+      formContext.form?.setValue(aggregateFieldName, selectedYAxis);
     }
     if (selectedFilter !== undefined) {
       formContext.form?.setValue(METRIC_DETECTOR_FORM_FIELDS.query, selectedFilter);
+      onQueryChange?.(selectedFilter);
     }
-  }, [metricQueries, selectedLabel, formContext.form]);
+  }, [metricQueries, selectedLabel, formContext.form, aggregateFieldName, onQueryChange]);
 
   const functionQueries = useMemo(
     () => metricQueries.filter(q => isVisualizeFunction(q.queryParams.visualizes[0]!)),
@@ -176,6 +204,8 @@ function MetricsEquationVisualizeContent() {
               canDelete={functionQueries.length > 1 && !isReferenced}
               isSelected={selectedLabel === metricQuery.label}
               onRowSelection={onRowSelection}
+              projectIds={projectIds}
+              environments={environments}
             />
           </RowProvider>
         );
@@ -191,6 +221,8 @@ function MetricsEquationVisualizeContent() {
               isSelected={selectedLabel === equationQuery.label}
               onRowSelection={onRowSelection}
               onReferenceLabelsChange={setEquationReferencedLabels}
+              projectIds={projectIds}
+              environments={environments}
             />
           </RowProvider>
         </Fragment>
@@ -294,13 +326,17 @@ function MetricToolbar({
   isSelected,
   onRowSelection,
   onReferenceLabelsChange,
+  projectIds,
+  environments,
 }: {
   canDelete: boolean;
   isSelected: boolean;
   metricQuery: MetricQuery;
   onRowSelection: (label: string) => void;
   referenceMap: Record<string, string>;
+  environments?: string[];
   onReferenceLabelsChange?: (labels: string[]) => void;
+  projectIds?: number[];
 }) {
   const visualize = useMetricVisualize();
   const setVisualize = useSetMetricVisualize();
@@ -328,16 +364,6 @@ function MetricToolbar({
       onReferenceLabelsChange?.(extractReferenceLabels(expr));
     }
   };
-
-  const projectId = useMetricDetectorFormField(METRIC_DETECTOR_FORM_FIELDS.projectId);
-  const environment = useMetricDetectorFormField(METRIC_DETECTOR_FORM_FIELDS.environment);
-
-  const projectIds = useMemo(() => {
-    if (projectId) {
-      return [Number(projectId)];
-    }
-    return [];
-  }, [projectId]);
 
   return (
     <Grid
@@ -370,7 +396,7 @@ function MetricToolbar({
             traceMetric={traceMetric}
             onChange={setTraceMetric}
             projectIds={projectIds}
-            environments={environment ? [environment] : undefined}
+            environments={environments}
           />
           <AggregateDropdown traceMetric={traceMetric} />
           <Filter traceMetric={traceMetric} />

--- a/static/app/views/detectors/components/forms/metric/visualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/visualize.tsx
@@ -223,10 +223,17 @@ function buildAggregateFunction(aggregate: string, parameters: string[]): string
 export function Visualize() {
   const organization = useOrganization();
   const dataset = useMetricDetectorFormField(METRIC_DETECTOR_FORM_FIELDS.dataset);
+  const projectId = useMetricDetectorFormField(METRIC_DETECTOR_FORM_FIELDS.projectId);
+  const environment = useMetricDetectorFormField(METRIC_DETECTOR_FORM_FIELDS.environment);
 
   if (dataset === DetectorDataset.METRICS) {
     if (canUseMetricsEquationsInAlerts(organization)) {
-      return <MetricsEquationVisualize />;
+      return (
+        <MetricsEquationVisualize
+          projectIds={projectId ? [Number(projectId)] : undefined}
+          environments={environment ? [environment] : undefined}
+        />
+      );
     }
     return <MetricsVisualize />;
   }


### PR DESCRIPTION
Only adds the equation builder to old tracemetrics alerts

Best viewed with whitespace changes off since some component structures were indented to allow for the feature flag branch