### PR TITLE
feat(dashboards): Store revision source for AI-assisted saves

### DIFF
--- a/src/sentry/dashboards/endpoints/organization_dashboard_details.py
+++ b/src/sentry/dashboards/endpoints/organization_dashboard_details.py
@@ -244,10 +244,16 @@ class OrganizationDashboardDetailsEndpoint(OrganizationDashboardBase):
         ):
             snapshot = _take_dashboard_snapshot(dashboard, request.user)
 
+        revision_source = request.data.get("revisionSource", "edit")
+        if revision_source not in ("edit", "edit-with-agent"):
+            revision_source = "edit"
+
         try:
             with transaction.atomic(router.db_for_write(DashboardTombstone)):
                 if snapshot is not None and isinstance(dashboard, Dashboard):
-                    DashboardRevision.create_for_dashboard(dashboard, request.user, snapshot)
+                    DashboardRevision.create_for_dashboard(
+                        dashboard, request.user, snapshot, source=revision_source
+                    )
                 serializer.save()
                 if tombstone:
                     DashboardTombstone.objects.get_or_create(

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_details.py
@@ -4155,6 +4155,35 @@ class OrganizationDashboardDetailsPutTest(OrganizationDashboardDetailsTestCase):
         # No revision should be created for a pre-built dashboard that hasn't been saved yet
         assert DashboardRevision.objects.count() == 0
 
+    def test_put_revision_source_defaults_to_edit(self) -> None:
+        with self.feature("organizations:dashboards-revisions"):
+            self.do_request("put", self.url(self.dashboard.id), data={"title": "Updated"})
+
+        revision = DashboardRevision.objects.get(dashboard=self.dashboard)
+        assert revision.source == "edit"
+
+    def test_put_revision_source_edit_with_agent(self) -> None:
+        with self.feature("organizations:dashboards-revisions"):
+            self.do_request(
+                "put",
+                self.url(self.dashboard.id),
+                data={"title": "Updated", "revisionSource": "edit-with-agent"},
+            )
+
+        revision = DashboardRevision.objects.get(dashboard=self.dashboard)
+        assert revision.source == "edit-with-agent"
+
+    def test_put_revision_source_ignores_unknown_values(self) -> None:
+        with self.feature("organizations:dashboards-revisions"):
+            self.do_request(
+                "put",
+                self.url(self.dashboard.id),
+                data={"title": "Updated", "revisionSource": "malicious-value"},
+            )
+
+        revision = DashboardRevision.objects.get(dashboard=self.dashboard)
+        assert revision.source == "edit"
+
 
 class OrganizationDashboardDetailsOnDemandTest(OrganizationDashboardDetailsTestCase):
     widget_type = DashboardWidgetTypes.TRANSACTION_LIKE

--- a/tests/sentry/models/test_dashboard.py
+++ b/tests/sentry/models/test_dashboard.py
@@ -203,6 +203,13 @@ class DashboardRevisionTest(TestCase):
         assert revision.snapshot == snapshot
         assert revision.snapshot_schema_version == DashboardRevision.SNAPSHOT_SCHEMA_VERSION
         assert revision.created_by_id == self.user.id
+        assert revision.source == "edit"
+
+    def test_create_for_dashboard_stores_custom_source(self) -> None:
+        revision = DashboardRevision.create_for_dashboard(
+            self.dashboard, self.user, {}, source="edit-with-agent"
+        )
+        assert revision.source == "edit-with-agent"
 
     def test_create_for_dashboard_prunes_beyond_retention_limit(self) -> None:
         for i in range(DashboardRevision.RETENTION_LIMIT):


### PR DESCRIPTION
When a dashboard is saved after applying Seer AI suggestions, the frontend sends \`revisionSource='edit-with-agent'\` in the PUT request body. The backend reads this field, validates it against an allowlist (\`edit\` or \`edit-with-agent\`), and stores it on the \`DashboardRevision\` via \`create_for_dashboard\`. Unknown values are silently normalised to \`edit\`.

This enables the revision history UI to distinguish AI-assisted saves from manual edits.

**Deployment safety:** Safe for split deploys in both directions. When the old frontend sends no \`revisionSource\`, the backend defaults to \`edit\`. When the new frontend sends \`revisionSource\` against the old backend (before this PR), the field is ignored — no errors.

Frontend changes are in a #113671


Refs DAIN-1537