### PR TITLE
feat(dashboards): Pass revision source for AI-assisted saves

### DIFF
--- a/static/app/actionCreators/dashboards.spec.tsx
+++ b/static/app/actionCreators/dashboards.spec.tsx
@@ -1,0 +1,49 @@
+import {DashboardFixture} from 'sentry-fixture/dashboard';
+
+import {updateDashboard} from 'sentry/actionCreators/dashboards';
+
+describe('updateDashboard', () => {
+  const api = new MockApiClient();
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('does not include revisionSource in the request body by default', async () => {
+    const dashboard = DashboardFixture([]);
+    const mockPut = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/dashboards/${dashboard.id}/`,
+      method: 'PUT',
+      body: dashboard,
+    });
+
+    await updateDashboard(api, 'org-slug', dashboard);
+
+    expect(mockPut).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.not.objectContaining({revisionSource: expect.anything()}),
+      })
+    );
+  });
+
+  it('includes revisionSource in the request body when provided', async () => {
+    const dashboard = DashboardFixture([]);
+    const mockPut = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/dashboards/${dashboard.id}/`,
+      method: 'PUT',
+      body: dashboard,
+    });
+
+    await updateDashboard(api, 'org-slug', dashboard, {
+      revisionSource: 'edit-with-agent',
+    });
+
+    expect(mockPut).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({revisionSource: 'edit-with-agent'}),
+      })
+    );
+  });
+});

--- a/static/app/actionCreators/dashboards.tsx
+++ b/static/app/actionCreators/dashboards.tsx
@@ -207,11 +207,12 @@ export function fetchDashboard(
 export function updateDashboard(
   api: Client,
   orgId: string,
-  dashboard: DashboardDetails
+  dashboard: DashboardDetails,
+  {revisionSource}: {revisionSource?: string} = {}
 ): Promise<DashboardDetails> {
   const {title, widgets, projects, environment, period, start, end, filters, utc} =
     dashboard;
-  const data: Partial<DashboardDetails> = {
+  const data: Partial<DashboardDetails> & {revisionSource?: string} = {
     title,
     projects,
     environment,
@@ -221,6 +222,9 @@ export function updateDashboard(
     filters,
     utc,
   };
+  if (revisionSource) {
+    data.revisionSource = revisionSource;
+  }
   if (widgets) {
     data.widgets = widgets
       .map(widget => omit(widget, ['tempId']))

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -922,7 +922,9 @@ class DashboardDetail extends Component<Props, State> {
           this.setState({
             isCommittingChanges: true,
           });
-          updateDashboard(api, organization.slug, modifiedDashboard).then(
+          updateDashboard(api, organization.slug, modifiedDashboard, {
+            revisionSource: this.state.seerEditApplied ? 'edit-with-agent' : undefined,
+          }).then(
             (newDashboard: DashboardDetails) => {
               queryClient.invalidateQueries({
                 queryKey: getDashboardRevisionsQueryKey(


### PR DESCRIPTION
When a dashboard is committed after the user has applied Seer AI suggestions, pass \`revisionSource='edit-with-agent'\` in the PUT body so the backend can store it on the revision record.

\`updateDashboard\` now accepts an optional \`{revisionSource}\` option. \`detail.tsx\` passes \`'edit-with-agent'\` when \`seerEditApplied\` is set, otherwise omits the field entirely (backend defaults to \`'edit'\`).

**Depends on the backend PR first:** https://github.com/getsentry/sentry/pull/113670

Refs DAIN-1537