### PR TITLE
ref(metrics): Align trace metrics layout spacing

### DIFF
--- a/static/app/views/explore/metrics/metricInfoTabs/index.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/index.tsx
@@ -67,7 +67,7 @@ export function MetricInfoTabs({
           </Flex>
         ) : null}
         {visualize.visible && !contentsHidden ? (
-          <Container height="320px">
+          <Container height="312px">
             <StyledTabPanels>
               <TabPanels.Item key={Mode.AGGREGATE}>
                 <AggregatesTab

--- a/static/app/views/explore/metrics/metricInfoTabs/index.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/index.tsx
@@ -42,47 +42,49 @@ export function MetricInfoTabs({
       }}
       size="md"
     >
-      {visualize.visible ? (
-        <Flex direction="row" justify="between" align="center" paddingRight="xl">
-          <TabListWrapper>
-            <TabList variant="floating">
-              <TabList.Item
-                key={Mode.SAMPLES}
-                disabled={contentsHidden || isVisualizeEquation(visualize)}
-                tooltip={{
-                  title: isVisualizeEquation(visualize)
-                    ? t('Samples are not available for equations')
-                    : undefined,
-                }}
-              >
-                {t('Samples')}
-              </TabList.Item>
-              <TabList.Item key={Mode.AGGREGATE} disabled={contentsHidden}>
-                {t('Aggregates')}
-              </TabList.Item>
-            </TabList>
-          </TabListWrapper>
-          {additionalActions}
-        </Flex>
-      ) : null}
-      {visualize.visible && !contentsHidden ? (
-        <Container paddingRight="lg" paddingBottom="md" paddingTop="0" height="320px">
-          <StyledTabPanels>
-            <TabPanels.Item key={Mode.AGGREGATE}>
-              <AggregatesTab
-                traceMetric={traceMetric}
-                isMetricOptionsEmpty={isMetricOptionsEmpty}
-              />
-            </TabPanels.Item>
-            <TabPanels.Item key={Mode.SAMPLES}>
-              <SamplesTab
-                traceMetric={traceMetric}
-                isMetricOptionsEmpty={isMetricOptionsEmpty}
-              />
-            </TabPanels.Item>
-          </StyledTabPanels>
-        </Container>
-      ) : null}
+      <Container paddingRight="xl" paddingLeft="xl" paddingBottom="md" paddingTop="md">
+        {visualize.visible ? (
+          <Flex direction="row" justify="between" align="center" paddingRight="xl">
+            <TabListWrapper>
+              <TabList variant="floating">
+                <TabList.Item
+                  key={Mode.SAMPLES}
+                  disabled={contentsHidden || isVisualizeEquation(visualize)}
+                  tooltip={{
+                    title: isVisualizeEquation(visualize)
+                      ? t('Samples are not available for equations')
+                      : undefined,
+                  }}
+                >
+                  {t('Samples')}
+                </TabList.Item>
+                <TabList.Item key={Mode.AGGREGATE} disabled={contentsHidden}>
+                  {t('Aggregates')}
+                </TabList.Item>
+              </TabList>
+            </TabListWrapper>
+            {additionalActions}
+          </Flex>
+        ) : null}
+        {visualize.visible && !contentsHidden ? (
+          <Container height="320px">
+            <StyledTabPanels>
+              <TabPanels.Item key={Mode.AGGREGATE}>
+                <AggregatesTab
+                  traceMetric={traceMetric}
+                  isMetricOptionsEmpty={isMetricOptionsEmpty}
+                />
+              </TabPanels.Item>
+              <TabPanels.Item key={Mode.SAMPLES}>
+                <SamplesTab
+                  traceMetric={traceMetric}
+                  isMetricOptionsEmpty={isMetricOptionsEmpty}
+                />
+              </TabPanels.Item>
+            </StyledTabPanels>
+          </Container>
+        ) : null}
+      </Container>
     </TabStateProvider>
   );
 }

--- a/static/app/views/explore/metrics/metricInfoTabs/index.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/index.tsx
@@ -44,7 +44,7 @@ export function MetricInfoTabs({
     >
       <Container paddingRight="xl" paddingLeft="xl" paddingBottom="md" paddingTop="md">
         {visualize.visible ? (
-          <Flex direction="row" justify="between" align="center" paddingRight="xl">
+          <Flex direction="row" justify="between" align="center">
             <TabListWrapper>
               <TabList variant="floating">
                 <TabList.Item

--- a/static/app/views/explore/metrics/metricInfoTabs/metricInfoTabStyles.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricInfoTabStyles.tsx
@@ -9,7 +9,6 @@ import {StyledPanel} from 'sentry/views/explore/tables/tracesTable/styles';
 
 export const TabListWrapper = styled('div')`
   width: 100%;
-  padding-left: ${p => p.theme.space.md};
 `;
 
 export const StyledTopResultsIndicator = styled(TopResultsIndicator)``;

--- a/static/app/views/explore/metrics/metricInfoTabs/metricInfoTabStyles.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricInfoTabStyles.tsx
@@ -10,7 +10,6 @@ import {StyledPanel} from 'sentry/views/explore/tables/tracesTable/styles';
 export const TabListWrapper = styled('div')`
   width: 100%;
   padding-left: ${p => p.theme.space.md};
-  padding-top: ${p => p.theme.space.md};
 `;
 
 export const StyledTopResultsIndicator = styled(TopResultsIndicator)``;

--- a/static/app/views/explore/metrics/metricToolbar/index.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/index.tsx
@@ -99,8 +99,8 @@ export function MetricToolbar({
       direction="column"
       gap="md"
       width="100%"
-      paddingLeft="lg"
-      paddingRight="lg"
+      paddingLeft="xl"
+      paddingRight="xl"
       paddingTop="md"
       data-test-id="metric-toolbar"
     >


### PR DESCRIPTION
Align the trace metrics toolbar and metric info tabs so the view uses a single horizontal gutter and more consistent panel spacing.

The tabs previously mixed wrapper-level and panel-level padding, which left the header and content slightly out of alignment with the toolbar. This moves the shared spacing to the parent container and widens the toolbar gutters to match.

This is a small UI-only cleanup with no behavior change.

Closes LOGS-719

| | |
|-|-|
|Before| <img width="1633" height="428" alt="Screenshot 2026-04-22 at 12 08 24" src="https://github.com/user-attachments/assets/9f737bce-4b3c-49d9-bf33-5752e3754e7f" /> |
|After| <img width="1633" height="428" alt="Screenshot 2026-04-22 at 12 08 36" src="https://github.com/user-attachments/assets/acda6ce3-ee2b-4dab-acf2-954d7a4a9c45" /> |