### PR TITLE
feat(eslint): Enable unicorn/no-useless-collection-argument

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -835,7 +835,6 @@ export default typescript.config([
       'unicorn/no-unnecessary-array-splice-count': 'off',
       'unicorn/no-unnecessary-slice-end': 'off',
       'unicorn/no-unreadable-array-destructuring': 'off',
-      'unicorn/no-useless-collection-argument': 'off',
       'unicorn/no-useless-promise-resolve-reject': 'off',
       'unicorn/no-useless-spread': 'off',
       'unicorn/no-useless-switch-case': 'off',

--- a/static/app/components/events/eventTags/eventTagsTreeRow.tsx
+++ b/static/app/components/events/eventTags/eventTagsTreeRow.tsx
@@ -142,7 +142,7 @@ function EventTagsTreeRowDropdown({
   }
 
   const referrer = 'event-tags-table';
-  const highlightTagSet = new Set(project?.highlightTags ?? []);
+  const highlightTagSet = new Set(project?.highlightTags);
   const hideAddHighlightsOption =
     // Check for existing highlight record to prevent replacing all with a single tag if we receive a project summary (instead of a detailed project)
     project?.highlightTags &&

--- a/static/app/components/events/highlights/editHighlightsModal.tsx
+++ b/static/app/components/events/highlights/editHighlightsModal.tsx
@@ -238,7 +238,7 @@ function EditContextHighlightSection({
   ).reduce(
     (disableMap, [contextType, contextKeys]) => ({
       ...disableMap,
-      [contextType]: new Set(contextKeys ?? []),
+      [contextType]: new Set(contextKeys),
     }),
     {}
   );

--- a/static/app/components/modals/inviteMissingMembersModal/index.tsx
+++ b/static/app/components/modals/inviteMissingMembersModal/index.tsx
@@ -67,7 +67,7 @@ export function InviteMissingMembersModal({
       const invites = prevInvites.map(i => ({...i}));
       invites[index]!.role = role;
       if (!allowedRolesMap[role]!.isTeamRolesAllowed) {
-        invites[index]!.teamSlugs = new Set([]);
+        invites[index]!.teamSlugs = new Set();
       }
       return invites;
     });

--- a/static/app/components/replays/utils.spec.tsx
+++ b/static/app/components/replays/utils.spec.tsx
@@ -100,7 +100,7 @@ describe('getFramesByColumn', () => {
   it('should return an empty list when no crumbs exist', () => {
     const columnCount = 3;
     const columns = getFramesByColumn(durationMs, [], columnCount);
-    expect(columns).toEqual(new Map([]));
+    expect(columns).toEqual(new Map());
   });
 
   it('should put a crumbs in the first and last buckets', () => {

--- a/static/app/components/search/sources/routeSource.tsx
+++ b/static/app/components/search/sources/routeSource.tsx
@@ -67,8 +67,8 @@ export function RouteSource({searchOptions, query, children}: Props) {
     const context = {
       project,
       organization,
-      access: new Set(organization?.access ?? []),
-      features: new Set(project?.features ?? []),
+      access: new Set(organization?.access),
+      features: new Set(project?.features),
     } as Context;
 
     const navigationFromHook = organization

--- a/static/app/components/searchSyntax/parser.tsx
+++ b/static/app/components/searchSyntax/parser.tsx
@@ -1466,7 +1466,7 @@ export const defaultConfig: SearchConfig = {
     'team_key_transaction',
     'symbolicated_in_app',
   ]),
-  sizeKeys: new Set([]),
+  sizeKeys: new Set(),
   disallowedLogicalOperators: new Set(),
   disallowFreeText: false,
   disallowWildcard: false,

--- a/static/app/debug/notifications/components/debugNotificationsSearch.tsx
+++ b/static/app/debug/notifications/components/debugNotificationsSearch.tsx
@@ -126,7 +126,7 @@ function SearchComboBox<T extends SearchItem>(props: SearchComboBoxProps<T>) {
           <ListBox
             listState={state}
             hasSearch={!!state.inputValue}
-            hiddenOptions={new Set([])}
+            hiddenOptions={new Set()}
             overlayIsOpen={state.isOpen}
             size="sm"
             {...listBoxProps}

--- a/static/app/stories/view/storyTree.tsx
+++ b/static/app/stories/view/storyTree.tsx
@@ -523,9 +523,7 @@ function buildComponentTree(
     const folderNode = new StoryTreeNode(config.label, subcategory, files[0]);
 
     // Collect subgroup component names for filtering
-    const subgroupComponents = new Set(
-      config.subgroups?.flatMap(sg => sg.components) ?? []
-    );
+    const subgroupComponents = new Set(config.subgroups?.flatMap(sg => sg.components));
 
     // Add top-level files (those not in any subgroup), sorted alphabetically
     for (const file of files.sort()) {

--- a/static/app/utils/resolveRoute.spec.tsx
+++ b/static/app/utils/resolveRoute.spec.tsx
@@ -96,7 +96,7 @@ describe('resolveRoute', () => {
   });
 
   it('should use path slugs when switching orgs without multi-region', () => {
-    ConfigStore.set('features', new Set([]));
+    ConfigStore.set('features', new Set());
     ConfigStore.set('customerDomain', null);
 
     const result = resolveRoute(

--- a/static/app/views/automations/hooks/utils.tsx
+++ b/static/app/views/automations/hooks/utils.tsx
@@ -65,7 +65,7 @@ export function useAutomationProjectSlugs(automation: Automation) {
   });
 
   const projectIds = [
-    ...new Set(detectors?.map(detector => detector.projectId).filter(defined) ?? []),
+    ...new Set(detectors?.map(detector => detector.projectId).filter(defined)),
   ];
 
   const projectSlugs = projectIds

--- a/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
+++ b/static/app/views/dashboards/datasetConfig/traceMetrics.tsx
@@ -414,7 +414,7 @@ function formatMetricsTimeseriesLabel({
     ? `${func.name}(${func.arguments[1] ?? '…'})`
     : timeSeries.yAxis;
 
-  const multiYAxis = new Set(widgetQuery.aggregates ?? []).size > 1;
+  const multiYAxis = new Set(widgetQuery.aggregates).size > 1;
   const hasGroupings = new Set(widgetQuery.columns).size > 0;
 
   let baseName = formatTimeSeriesLabel({...timeSeries, yAxis: formattedYAxis});

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -223,7 +223,7 @@ export function LogsInfiniteTable({
   const tableBodyRef = useRef<HTMLTableSectionElement>(null);
   const {width: tableWidth} = useDimensions({elementRef: tableRef});
   const [expandedLogRows, setExpandedLogRows] = useState<Set<string>>(
-    new Set(embeddedOptions?.openWithExpandedIds ?? [])
+    new Set(embeddedOptions?.openWithExpandedIds)
   );
   const [expandedLogRowsHeights, setExpandedLogRowsHeights] = useState<
     Record<string, number>

--- a/static/app/views/relocation/index.spec.tsx
+++ b/static/app/views/relocation/index.spec.tsx
@@ -48,7 +48,7 @@ describe('Relocation Onboarding Container', () => {
   });
 
   it('should not render if feature disabled', async () => {
-    ConfigStore.set('features', new Set([]));
+    ConfigStore.set('features', new Set());
     render(<RelocationOnboardingContainer />, {
       initialRouterConfig: {
         location: {

--- a/static/app/views/settings/organizationTeams/organizationTeams.spec.tsx
+++ b/static/app/views/settings/organizationTeams/organizationTeams.spec.tsx
@@ -69,7 +69,7 @@ describe('OrganizationTeams', () => {
         ProjectFixture({slug: 'project-2', teams: [team]}),
       ]);
       createWrapper({
-        access: new Set([]),
+        access: new Set(),
       });
       expect(screen.getByLabelText('Join Team')).toBeInTheDocument();
 
@@ -98,7 +98,7 @@ describe('OrganizationTeams', () => {
       const mockTeams = [team];
       TeamStore.loadInitialData(mockTeams, false, null);
 
-      createWrapper({access: new Set([])});
+      createWrapper({access: new Set()});
       await userEvent.click(screen.getByLabelText('Join Team'));
 
       await waitFor(() => {
@@ -120,7 +120,7 @@ describe('OrganizationTeams', () => {
       ];
       TeamStore.loadInitialData(mockTeams, false, null);
       createWrapper({
-        access: new Set([]),
+        access: new Set(),
       });
 
       expect(screen.getByRole('button', {name: 'Join Team'})).toBeDisabled();
@@ -139,8 +139,8 @@ describe('OrganizationTeams', () => {
       render(
         <OrganizationTeams
           organization={organization}
-          access={new Set([])}
-          features={new Set([])}
+          access={new Set()}
+          features={new Set()}
           requestList={[]}
           onRemoveAccessRequest={() => {}}
           {...props}
@@ -155,7 +155,7 @@ describe('OrganizationTeams', () => {
         }),
       ];
       TeamStore.loadInitialData(mockTeams, false, null);
-      createWrapper({access: new Set([])});
+      createWrapper({access: new Set()});
 
       expect(screen.getByLabelText('Request Access')).toBeInTheDocument();
 
@@ -172,7 +172,7 @@ describe('OrganizationTeams', () => {
       ];
       TeamStore.loadInitialData(mockTeams, false, null);
       createWrapper({
-        access: new Set([]),
+        access: new Set(),
       });
 
       expect(screen.getByLabelText('Leave Team')).toBeInTheDocument();
@@ -184,7 +184,7 @@ describe('OrganizationTeams', () => {
       ];
       TeamStore.loadInitialData(mockTeams, false, null);
       createWrapper({
-        access: new Set([]),
+        access: new Set(),
       });
 
       expect(screen.getByRole('button', {name: 'Request Access'})).toBeDisabled();
@@ -194,7 +194,7 @@ describe('OrganizationTeams', () => {
       const mockTeams = [TeamFixture({flags: {'idp:provisioned': true}, isMember: true})];
       TeamStore.loadInitialData(mockTeams, false, null);
       createWrapper({
-        access: new Set([]),
+        access: new Set(),
       });
 
       expect(screen.getByRole('button', {name: 'Leave Team'})).toBeDisabled();
@@ -225,8 +225,8 @@ describe('OrganizationTeams', () => {
       render(
         <OrganizationTeams
           organization={organization}
-          access={new Set([])}
-          features={new Set([])}
+          access={new Set()}
+          features={new Set()}
           requestList={requestList}
           onRemoveAccessRequest={() => {}}
           {...props}
@@ -312,7 +312,7 @@ describe('OrganizationTeams', () => {
         <OrganizationTeams
           organization={organization}
           access={new Set(['project:admin'])}
-          features={new Set([])}
+          features={new Set()}
           requestList={[]}
           onRemoveAccessRequest={() => {}}
         />
@@ -336,7 +336,7 @@ describe('OrganizationTeams', () => {
         <OrganizationTeams
           organization={organization}
           access={new Set(['project:admin'])}
-          features={new Set([])}
+          features={new Set()}
           requestList={[]}
           onRemoveAccessRequest={() => {}}
         />
@@ -360,7 +360,7 @@ describe('OrganizationTeams', () => {
         <OrganizationTeams
           organization={organization}
           access={new Set(['project:admin'])}
-          features={new Set([])}
+          features={new Set()}
           requestList={[]}
           onRemoveAccessRequest={() => {}}
         />
@@ -381,8 +381,8 @@ describe('OrganizationTeams', () => {
       render(
         <OrganizationTeams
           organization={organization}
-          access={new Set([])}
-          features={new Set([])}
+          access={new Set()}
+          features={new Set()}
           requestList={[]}
           onRemoveAccessRequest={() => {}}
         />

--- a/static/eslint/eslintPluginScraps/src/rules/restrict-jsx-slot-children.ts
+++ b/static/eslint/eslintPluginScraps/src/rules/restrict-jsx-slot-children.ts
@@ -213,7 +213,7 @@ export const restrictJsxSlotChildren = ESLintUtils.RuleCreator.withoutDocs<
         })),
         allowedNames: new Set(),
         hint: buildAllowedHint(allowed),
-        componentNames: new Set(slot.componentNames ?? []),
+        componentNames: new Set(slot.componentNames),
       };
       for (const propName of slot.propNames) {
         if (slotState.has(propName)) {

--- a/static/gsAdmin/views/customerDetails.spec.tsx
+++ b/static/gsAdmin/views/customerDetails.spec.tsx
@@ -684,7 +684,7 @@ function setUpMocks(
 describe('Customer Details', () => {
   const {organization} = initializeOrg();
 
-  const mockUser = UserFixture({permissions: new Set([])});
+  const mockUser = UserFixture({permissions: new Set()});
   ConfigStore.loadInitialData(ConfigFixture({user: mockUser}));
 
   afterEach(() => {

--- a/static/gsAdmin/views/invoiceDetails.spec.tsx
+++ b/static/gsAdmin/views/invoiceDetails.spec.tsx
@@ -106,7 +106,7 @@ describe('InvoiceDetails', () => {
     });
 
     it('requires billing admin permission', async () => {
-      ConfigStore.set('user', UserFixture({permissions: new Set([])}));
+      ConfigStore.set('user', UserFixture({permissions: new Set()}));
 
       const invoice = InvoiceFixture({isClosed: false});
       MockApiClient.addMockResponse({

--- a/static/gsApp/views/seerAutomation/components/projectDetails/autofixRepositoriesList.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectDetails/autofixRepositoriesList.tsx
@@ -75,7 +75,7 @@ export function AutofixRepositories({canWrite, preference, project}: Props) {
   const tableHeaders = getTableHeaders(organization);
 
   const repoMap = useMemo(
-    () => new Map(preference?.repositories.map(repo => [repo.external_id, repo]) ?? []),
+    () => new Map(preference?.repositories.map(repo => [repo.external_id, repo])),
     [preference]
   );
 


### PR DESCRIPTION
Removes the disable of [`unicorn/no-useless-collection-argument`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/3f51bc64093fc47df672697f67bf93b149bc7303/docs/rules/no-useless-collection-argument.md) and fixes its reports via `pnpm lint:js --fix`.

Fixes ENG-7432.

Made with [Cursor](https://cursor.com)