### PR TITLE
feat(eslint): Enable @typescript-eslint/prefer-return-this-type

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -628,7 +628,6 @@ export default typescript.config([
           '@typescript-eslint/prefer-includes': 'off',
           '@typescript-eslint/prefer-nullish-coalescing': 'off',
           '@typescript-eslint/prefer-regexp-exec': 'off',
-          '@typescript-eslint/prefer-return-this-type': 'off',
           '@typescript-eslint/prefer-string-starts-ends-with': 'off',
           '@typescript-eslint/restrict-plus-operands': 'off',
           '@typescript-eslint/restrict-template-expressions': 'off',

--- a/static/app/utils/profiling/profile/continuousProfile.tsx
+++ b/static/app/utils/profiling/profile/continuousProfile.tsx
@@ -160,7 +160,7 @@ export class ContinuousProfile extends Profile {
     throw new Error('Not implemented');
   }
 
-  build(): ContinuousProfile {
+  build(): this {
     this.duration = Math.max(
       this.duration,
       this.weights.reduce((a, b) => a + b, 0)

--- a/static/app/utils/profiling/profile/eventedProfile.tsx
+++ b/static/app/utils/profiling/profile/eventedProfile.tsx
@@ -209,7 +209,7 @@ export class EventedProfile extends Profile {
     this.lastValue = at;
   }
 
-  build(): EventedProfile {
+  build(): this {
     if (this.calltree.length > 1) {
       throw new Error('Unbalanced append order stack');
     }

--- a/static/app/utils/profiling/profile/jsSelfProfile.tsx
+++ b/static/app/utils/profiling/profile/jsSelfProfile.tsx
@@ -170,7 +170,7 @@ export class JSSelfProfile extends Profile {
     }
   }
 
-  build(): JSSelfProfile {
+  build(): this {
     this.duration = Math.max(
       this.duration,
       this.weights.reduce((a, b) => a + b, 0)

--- a/static/app/utils/profiling/profile/profile.tsx
+++ b/static/app/utils/profiling/profile/profile.tsx
@@ -149,7 +149,7 @@ export class Profile {
     }
   }
 
-  build(): Profile {
+  build(): this {
     this.duration = Math.max(
       this.duration,
       this.weights.reduce((a, b) => a + b, 0)

--- a/static/app/utils/profiling/profile/sampledProfile.tsx
+++ b/static/app/utils/profiling/profile/sampledProfile.tsx
@@ -321,7 +321,7 @@ export class SampledProfile extends Profile {
     }
   }
 
-  build(): Profile {
+  build(): this {
     this.duration = Math.max(
       this.duration,
       this.weights.reduce((a, b) => a + b, 0)

--- a/static/app/utils/profiling/profile/sentrySampledProfile.tsx
+++ b/static/app/utils/profiling/profile/sentrySampledProfile.tsx
@@ -151,7 +151,7 @@ export class SentrySampledProfile extends Profile {
     }
   }
 
-  build(): Profile {
+  build(): this {
     this.duration = Math.max(
       this.duration,
       this.weights.reduce((a, b) => a + b, 0)


### PR DESCRIPTION
Removes the disable of [`@typescript-eslint/prefer-return-this-type`](https://typescript-eslint.io/rules/prefer-return-this-type) and fixes its reports via `pnpm lint:js --fix`. A couple touchups were needed in 71f59cd205fd722924f432f8dc975179ba8c63ee too.

Fixes ENG-7433.

Made with [Cursor](https://cursor.com)