### PR TITLE
feat(repos): Track last_sync on OrganizationIntegration config

### DIFF
--- a/src/sentry/integrations/github/tasks/sync_repos_on_install_change.py
+++ b/src/sentry/integrations/github/tasks/sync_repos_on_install_change.py
@@ -14,6 +14,7 @@ from sentry.integrations.source_code_management.metrics import (
     SCMIntegrationInteractionType,
 )
 from sentry.integrations.source_code_management.repo_audit import log_repo_change
+from sentry.integrations.source_code_management.sync_repos import bump_org_integration_last_sync
 from sentry.organizations.services.organization import organization_service
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.plugins.providers.integration_repository import get_integration_repository_provider
@@ -95,6 +96,9 @@ def sync_repos_on_install_change(
                 repos_added=repos_added,
                 repos_removed=repos_removed,
             )
+            removals_enabled = features.has("organizations:scm-repo-auto-sync-removal", rpc_org)
+            repos_changed = bool(repos_added or (repos_removed and removals_enabled))
+            bump_org_integration_last_sync(oi.id, repos_changed=repos_changed)
 
 
 def _sync_repos_for_org(

--- a/src/sentry/integrations/source_code_management/sync_repos.py
+++ b/src/sentry/integrations/source_code_management/sync_repos.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import logging
 from datetime import timedelta
 
+from django.utils import timezone
 from taskbroker_client.retry import Retry
 
 from sentry import features
@@ -55,6 +56,25 @@ SCM_SYNC_PROVIDERS = [
 ]
 
 SYNC_BATCH_SIZE = 100
+
+
+def bump_org_integration_last_sync(
+    organization_integration_id: int, *, repos_changed: bool = False
+) -> None:
+    """
+    Record the time we most recently synced repositories from the provider for
+    a given OrganizationIntegration by stamping `config["last_sync"]`. When
+    `repos_changed` is True, also stamp `config["last_repos_change"]` to record
+    the last time the repo set actually changed.
+    """
+    oi = OrganizationIntegration.objects.filter(id=organization_integration_id).first()
+    if oi is None:
+        return
+    now = timezone.now().isoformat()
+    oi.config["last_sync"] = now
+    if repos_changed:
+        oi.config["last_repos_change"] = now
+    oi.save(update_fields=["config"])
 
 
 def _has_feature(flag: str, org: object) -> bool:
@@ -184,6 +204,12 @@ def sync_repos_for_org(organization_integration_id: int) -> None:
         if dry_run:
             return
 
+        removals_enabled = _has_feature("organizations:scm-repo-auto-sync-removal", rpc_org)
+        bump_org_integration_last_sync(
+            organization_integration_id,
+            repos_changed=bool(new_ids or restored_ids or (removed_ids and removals_enabled)),
+        )
+
         # Build repo configs for new repos
         new_repo_configs = [
             {
@@ -206,7 +232,7 @@ def sync_repos_for_org(organization_integration_id: int) -> None:
                 }
             )
 
-        if _has_feature("organizations:scm-repo-auto-sync-removal", rpc_org):
+        if removals_enabled:
             for removed_batch in chunked(removed_id_list, SYNC_BATCH_SIZE):
                 disable_repos_batch.apply_async(
                     kwargs={

--- a/tests/sentry/integrations/github/tasks/test_sync_repos_on_install_change.py
+++ b/tests/sentry/integrations/github/tasks/test_sync_repos_on_install_change.py
@@ -6,6 +6,7 @@ from sentry.integrations.github.integration import GitHubIntegrationProvider
 from sentry.integrations.github.tasks.sync_repos_on_install_change import (
     sync_repos_on_install_change,
 )
+from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.repository import Repository
 from sentry.silo.base import SiloMode
@@ -195,6 +196,52 @@ class SyncReposOnInstallChangeTestCase(IntegrationTestCase):
 
         with assume_test_silo_mode(SiloMode.CELL):
             assert Repository.objects.count() == 0
+
+    def test_stamps_last_sync_on_org_integration(self, _: MagicMock) -> None:
+        oi = OrganizationIntegration.objects.get(
+            organization_id=self.organization.id, integration=self.integration
+        )
+        oi.config = {
+            "last_sync": "2020-01-01T00:00:00+00:00",
+            "last_repos_change": "2020-01-01T00:00:00+00:00",
+        }
+        oi.save()
+
+        with self.feature(FEATURE_FLAG):
+            sync_repos_on_install_change(
+                integration_id=self.integration.id,
+                action="added",
+                repos_added=self._make_repos_added(),
+                repos_removed=[],
+                repository_selection="selected",
+            )
+
+        oi.refresh_from_db()
+        assert oi.config["last_sync"] > "2020-01-01T00:00:00+00:00"
+        assert oi.config["last_repos_change"] > "2020-01-01T00:00:00+00:00"
+
+    def test_does_not_stamp_last_repos_change_when_no_diff(self, _: MagicMock) -> None:
+        oi = OrganizationIntegration.objects.get(
+            organization_id=self.organization.id, integration=self.integration
+        )
+        oi.config = {
+            "last_sync": "2020-01-01T00:00:00+00:00",
+            "last_repos_change": "2020-01-01T00:00:00+00:00",
+        }
+        oi.save()
+
+        with self.feature(FEATURE_FLAG):
+            sync_repos_on_install_change(
+                integration_id=self.integration.id,
+                action="added",
+                repos_added=[],
+                repos_removed=[],
+                repository_selection="selected",
+            )
+
+        oi.refresh_from_db()
+        assert oi.config["last_sync"] > "2020-01-01T00:00:00+00:00"
+        assert oi.config["last_repos_change"] == "2020-01-01T00:00:00+00:00"
 
     def test_does_not_disable_already_disabled_repos(self, _: MagicMock) -> None:
         with assume_test_silo_mode(SiloMode.CELL):

--- a/tests/sentry/integrations/source_code_management/test_sync_repos.py
+++ b/tests/sentry/integrations/source_code_management/test_sync_repos.py
@@ -174,6 +174,55 @@ class SyncReposForOrgTestCase(IntegrationTestCase):
             assert len(repos) == 1
             assert repos[0].status == ObjectStatus.ACTIVE
 
+    @responses.activate
+    def test_stamps_last_sync_on_org_integration(self, _: MagicMock) -> None:
+        self.oi.config = {
+            "last_sync": "2020-01-01T00:00:00+00:00",
+            "last_repos_change": "2020-01-01T00:00:00+00:00",
+        }
+        self.oi.save()
+
+        self._add_repos_response([{"id": 1, "full_name": "getsentry/sentry", "name": "sentry"}])
+
+        with self.feature(
+            ["organizations:github-repo-auto-sync", "organizations:github-repo-auto-sync-apply"]
+        ):
+            with self.tasks():
+                sync_repos_for_org(self.oi.id)
+
+        self.oi.refresh_from_db()
+        assert self.oi.config["last_sync"] > "2020-01-01T00:00:00+00:00"
+        assert self.oi.config["last_repos_change"] > "2020-01-01T00:00:00+00:00"
+
+    @responses.activate
+    def test_does_not_stamp_last_repos_change_when_no_diff(self, _: MagicMock) -> None:
+        with assume_test_silo_mode(SiloMode.CELL):
+            Repository.objects.create(
+                organization_id=self.organization.id,
+                name="getsentry/sentry",
+                external_id="1",
+                integration_id=self.integration.id,
+                provider="integrations:github",
+            )
+
+        self.oi.config = {
+            "last_sync": "2020-01-01T00:00:00+00:00",
+            "last_repos_change": "2020-01-01T00:00:00+00:00",
+        }
+        self.oi.save()
+
+        self._add_repos_response([{"id": 1, "full_name": "getsentry/sentry", "name": "sentry"}])
+
+        with self.feature(
+            ["organizations:github-repo-auto-sync", "organizations:github-repo-auto-sync-apply"]
+        ):
+            with self.tasks():
+                sync_repos_for_org(self.oi.id)
+
+        self.oi.refresh_from_db()
+        assert self.oi.config["last_sync"] > "2020-01-01T00:00:00+00:00"
+        assert self.oi.config["last_repos_change"] == "2020-01-01T00:00:00+00:00"
+
     def test_missing_org_integration(self, _: MagicMock) -> None:
         sync_repos_for_org(0)
 


### PR DESCRIPTION
Stamp `OrganizationIntegration.config["last_sync"]` after each run of
the SCM sync cron and each time the GitHub `installation_repositories`
webhook processes an OI. Stored as an ISO-8601 string so the existing
`configData` serializer exposes it to the frontend without schema
changes.

This will back a "Last synced X ago" indicator in the repository
settings UI.