### PR TITLE
fix: normalize issues and replays to info alerts with icons

### DIFF
--- a/static/app/components/replays/table/replayTableHeader.tsx
+++ b/static/app/components/replays/table/replayTableHeader.tsx
@@ -87,8 +87,8 @@ export function ReplayTableHeader({
       ) : null}
 
       {isAllSelected === 'indeterminate' ? (
-        <FullGridAlert variant="warning" system>
-          <Flex justify="center" wrap="wrap" gap="md">
+        <FullGridAlert variant="info" system>
+          <Flex justify="start" width="100%" wrap="wrap" gap="md">
             {tn(
               'Selected %s visible replay.',
               'Selected %s visible replays.',
@@ -106,22 +106,14 @@ export function ReplayTableHeader({
       ) : null}
 
       {isAllSelected === true ? (
-        <FullGridAlert variant="warning" system>
-          <Flex justify="center" wrap="wrap">
-            <span>
-              {queryString
-                ? tct('Selected all replays matching: [queryString].', {
-                    queryString: <var>{queryString}</var>,
-                  })
-                : countSelected > replays.length
-                  ? t('Selected all %s+ replays.', replays.length)
-                  : tn(
-                      'Selected all %s replay.',
-                      'Selected all %s replays.',
-                      countSelected
-                    )}
-            </span>
-          </Flex>
+        <FullGridAlert variant="info" system>
+          {queryString
+            ? tct('Selected all replays matching: [queryString].', {
+                queryString: <var>{queryString}</var>,
+              })
+            : countSelected > replays.length
+              ? t('Selected all %s+ replays.', replays.length)
+              : tn('Selected all %s replay.', 'Selected all %s replays.', countSelected)}
         </FullGridAlert>
       ) : null}
     </Fragment>

--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -357,8 +357,8 @@ export function IssueListActions({
         onSelectStatsPeriod={onSelectStatsPeriod}
       />
       {!allResultsVisible && pageSelected && (
-        <Alert system variant="warning" showIcon={false}>
-          <Flex justify="center" wrap="wrap" gap="md">
+        <Alert system variant="info">
+          <Flex justify="start" wrap="wrap" gap="md">
             {allInQuerySelected ? (
               queryCount >= BULK_LIMIT ? (
                 tct(


### PR DESCRIPTION
Turns out Issues was already using the design system component, `Alert`, after all. It's just manually setting `showIcon={false}`. 

This switches both Issues and Replays to be left-aligned per Martha's note. It removes unnecessary flex wrapping too.

<table>
<thead>
<th>Area</th>
<th>Before</th>
<th>After</th>
</thead>
<tr>
<tbody>
<tr>
<td>Issues</td>
<td>
<img width="911" height="225" alt="image" src="https://github.com/user-attachments/assets/15124a40-db87-4a1b-9487-1952e0ae505b" />
</td>
<td>
<img width="911" height="225" alt="image" src="https://github.com/user-attachments/assets/e8eb38d4-1e1c-420c-893c-64cb74802179" />
</td>
</tr>
<tr>
<td>Replays</td>
<td>
<img width="911" height="225" alt="image" src="https://github.com/user-attachments/assets/f4d68767-134d-4f4c-8430-960675378508" />
</td>
<td>
<img width="911" height="225" alt="image" src="https://github.com/user-attachments/assets/834740b7-dc13-4451-a17b-74f796801887" />
</td>
</tr>
</tbody>
</table>

Fixes DE-1185.