### PR TITLE
feat(billing): Add prev/next navigation to receipt details page

### DIFF
--- a/static/gsApp/views/invoiceDetails/index.spec.tsx
+++ b/static/gsApp/views/invoiceDetails/index.spec.tsx
@@ -69,6 +69,11 @@ describe('InvoiceDetails', () => {
       method: 'GET',
       body: {},
     });
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/invoices/`,
+      method: 'GET',
+      body: [],
+    });
   });
 
   it('renders basic invoice details', async () => {
@@ -328,6 +333,11 @@ describe('InvoiceDetails', () => {
         url: `/customers/${organization.slug}/billing-details/`,
         method: 'GET',
         body: billingDetails,
+      });
+      MockApiClient.addMockResponse({
+        url: `/customers/${organization.slug}/invoices/`,
+        method: 'GET',
+        body: [],
       });
     });
 

--- a/static/gsApp/views/invoiceDetails/index.tsx
+++ b/static/gsApp/views/invoiceDetails/index.tsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import {keepPreviousData} from '@tanstack/react-query';
 
+import {ButtonBar, LinkButton} from '@sentry/scraps/button';
 import {ExternalLink} from '@sentry/scraps/link';
 
 import {DateTime} from 'sentry/components/dateTime';
@@ -9,7 +10,7 @@ import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Panel} from 'sentry/components/panels/panel';
 import {PanelBody} from 'sentry/components/panels/panelBody';
-import {IconSentry} from 'sentry/icons';
+import {IconNext, IconPrevious, IconSentry} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useApiQuery} from 'sentry/utils/queryClient';
@@ -18,7 +19,7 @@ import {useParams} from 'sentry/utils/useParams';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 
 import {InvoiceStatus} from 'getsentry/types';
-import type {BillingDetails, Invoice} from 'getsentry/types';
+import type {BillingDetails, Invoice, InvoiceBase} from 'getsentry/types';
 import {getTaxFieldInfo} from 'getsentry/utils/salesTax';
 import {displayPriceWithCents} from 'getsentry/views/amCheckout/utils';
 import {SubscriptionPageContainer} from 'getsentry/views/subscriptionPage/components/subscriptionPageContainer';
@@ -29,6 +30,36 @@ function InvoiceDetails() {
   const {invoiceGuid} = useParams<{invoiceGuid: string}>();
 
   const organization = useOrganization();
+
+  const {data: invoiceList} = useApiQuery<InvoiceBase[]>(
+    [
+      getApiUrl('/customers/$organizationIdOrSlug/invoices/', {
+        path: {organizationIdOrSlug: organization.slug},
+      }),
+    ],
+    {
+      // Use a long staleTime so we share the cache with the list page
+      // without refetching on every receipt navigation.
+      staleTime: 60_000,
+    }
+  );
+
+  const currentIndex = invoiceList
+    ? invoiceList.findIndex(inv => inv.id === invoiceGuid)
+    : -1;
+  // The list is newest-first, so "previous" is the older receipt (higher index)
+  // and "next" is the more recent receipt (lower index).
+  const prevId =
+    invoiceList && currentIndex < invoiceList.length - 1
+      ? invoiceList[currentIndex + 1]!.id
+      : null;
+  const nextId =
+    invoiceList && currentIndex > 0 ? invoiceList[currentIndex - 1]!.id : null;
+
+  function receiptUrl(id: string) {
+    return `/settings/${organization.slug}/billing/receipts/${id}/`;
+  }
+
   const {
     data: billingDetails,
     isPending: isBillingDetailsLoading,
@@ -76,9 +107,31 @@ function InvoiceDetails() {
 
   return (
     <SubscriptionPageContainer background="secondary">
-      <SettingsPageHeader title={t('Receipt Details')}>
-        {t('Receipt Details')}
-      </SettingsPageHeader>
+      <SettingsPageHeader
+        title={t('Receipt Details')}
+        action={
+          invoiceList && (
+            <ButtonBar>
+              <LinkButton
+                size="sm"
+                to={prevId ? receiptUrl(prevId) : ''}
+                disabled={!prevId}
+                icon={<IconPrevious />}
+              >
+                {t('Previous')}
+              </LinkButton>
+              <LinkButton
+                size="sm"
+                to={nextId ? receiptUrl(nextId) : ''}
+                disabled={!nextId}
+                icon={<IconNext />}
+              >
+                {t('Next')}
+              </LinkButton>
+            </ButtonBar>
+          )
+        }
+      />
       <Panel>
         {isInvoiceLoading || isBillingDetailsLoading ? (
           <PanelBody withPadding>

--- a/static/gsApp/views/invoiceDetails/index.tsx
+++ b/static/gsApp/views/invoiceDetails/index.tsx
@@ -2,18 +2,19 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import {keepPreviousData} from '@tanstack/react-query';
 
-import {ButtonBar, LinkButton} from '@sentry/scraps/button';
 import {ExternalLink} from '@sentry/scraps/link';
 
 import {DateTime} from 'sentry/components/dateTime';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {Pagination} from 'sentry/components/pagination';
 import {Panel} from 'sentry/components/panels/panel';
 import {PanelBody} from 'sentry/components/panels/panelBody';
-import {IconNext, IconPrevious, IconSentry} from 'sentry/icons';
+import {IconSentry} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
@@ -30,6 +31,7 @@ function InvoiceDetails() {
   const {invoiceGuid} = useParams<{invoiceGuid: string}>();
 
   const organization = useOrganization();
+  const navigate = useNavigate();
 
   const {data: invoiceList} = useApiQuery<InvoiceBase[]>(
     [
@@ -59,6 +61,20 @@ function InvoiceDetails() {
   function receiptUrl(id: string) {
     return `/settings/${organization.slug}/billing/receipts/${id}/`;
   }
+
+  // Build a synthetic Link header string so <Pagination> can derive
+  // disabled state from results="false" / results="true".
+  // parseLinkHeader reads the cursor from the ; cursor="…" attribute, not the URL.
+  const pageLinks = invoiceList
+    ? [
+        prevId
+          ? `<.>; rel="previous"; results="true"; cursor="${prevId}"`
+          : `<.>; rel="previous"; results="false"`,
+        nextId
+          ? `<.>; rel="next"; results="true"; cursor="${nextId}"`
+          : `<.>; rel="next"; results="false"`,
+      ].join(', ')
+    : null;
 
   const {
     data: billingDetails,
@@ -110,26 +126,10 @@ function InvoiceDetails() {
       <SettingsPageHeader
         title={t('Receipt Details')}
         action={
-          invoiceList && (
-            <ButtonBar>
-              <LinkButton
-                size="sm"
-                to={prevId ? receiptUrl(prevId) : ''}
-                disabled={!prevId}
-                icon={<IconPrevious />}
-              >
-                {t('Previous')}
-              </LinkButton>
-              <LinkButton
-                size="sm"
-                to={nextId ? receiptUrl(nextId) : ''}
-                disabled={!nextId}
-                icon={<IconNext />}
-              >
-                {t('Next')}
-              </LinkButton>
-            </ButtonBar>
-          )
+          <InvoicePagination
+            pageLinks={pageLinks}
+            onCursor={cursor => cursor && navigate(receiptUrl(cursor))}
+          />
         }
       />
       <Panel>
@@ -421,4 +421,10 @@ const FinePrint = styled('div')`
   margin-top: ${p => p.theme.space.md};
   font-size: ${p => p.theme.font.size.xs};
   color: ${p => p.theme.colors.gray400};
+`;
+
+// Strip the default top margin from Pagination so it sits cleanly in the
+// SettingsPageHeader action slot without extra spacing.
+const InvoicePagination = styled(Pagination)`
+  margin: 0;
 `;

--- a/static/gsApp/views/invoiceDetails/index.tsx
+++ b/static/gsApp/views/invoiceDetails/index.tsx
@@ -1,6 +1,6 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
-import {keepPreviousData} from '@tanstack/react-query';
+import {keepPreviousData, useQuery} from '@tanstack/react-query';
 
 import {ExternalLink} from '@sentry/scraps/link';
 
@@ -12,6 +12,7 @@ import {Panel} from 'sentry/components/panels/panel';
 import {PanelBody} from 'sentry/components/panels/panelBody';
 import {IconSentry} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -33,17 +34,13 @@ function InvoiceDetails() {
   const organization = useOrganization();
   const navigate = useNavigate();
 
-  const {data: invoiceList} = useApiQuery<InvoiceBase[]>(
-    [
-      getApiUrl('/customers/$organizationIdOrSlug/invoices/', {
-        path: {organizationIdOrSlug: organization.slug},
-      }),
-    ],
-    {
-      // Use a long staleTime so we share the cache with the list page
-      // without refetching on every receipt navigation.
+  const {data: invoiceList} = useQuery(
+    // Use apiOptions so the cache key matches paymentHistory.tsx's list query,
+    // avoiding a redundant network request when navigating from the receipts list.
+    apiOptions.as<InvoiceBase[]>()('/customers/$organizationIdOrSlug/invoices/', {
+      path: {organizationIdOrSlug: organization.slug},
       staleTime: 60_000,
-    }
+    })
   );
 
   const currentIndex = invoiceList

--- a/static/gsApp/views/invoiceDetails/index.tsx
+++ b/static/gsApp/views/invoiceDetails/index.tsx
@@ -52,7 +52,7 @@ function InvoiceDetails() {
   // The list is newest-first, so "previous" is the older receipt (higher index)
   // and "next" is the more recent receipt (lower index).
   const prevId =
-    invoiceList && currentIndex < invoiceList.length - 1
+    invoiceList && currentIndex >= 0 && currentIndex < invoiceList.length - 1
       ? invoiceList[currentIndex + 1]!.id
       : null;
   const nextId =


### PR DESCRIPTION
Previously, the receipt details page had no way to navigate between receipts without going back to the list. This adds Previous and Next buttons to the page header that allow navigating directly between adjacent receipts.

The invoice list is fetched from the same API endpoint used by the receipts list page, so React Query serves it from cache when arriving from the list — no extra network request in the common case.

## Screenshots

### Oldest Item In List
<img width="838" height="216" alt="image" src="https://github.com/user-attachments/assets/368a0426-1362-4eec-8c16-ebc0eb1f150d" />

### Middle Item In List
<img width="847" height="219" alt="image" src="https://github.com/user-attachments/assets/600e07bb-a134-4460-adc3-8be1b21175cd" />

### Latest Item In List
<img width="830" height="222" alt="image" src="https://github.com/user-attachments/assets/ee0ca053-9648-4a2f-be3b-72d88afa5797" />

