### PR TITLE
fix(java): Remap exceptions without a module

### DIFF
--- a/src/sentry/lang/java/exceptions.py
+++ b/src/sentry/lang/java/exceptions.py
@@ -33,7 +33,7 @@ class Exceptions:
         self._processable_exceptions_with_values: list[tuple[Any, list[Any]]] = []
 
         for exc in get_path(data, "exception", "values", filter=True, default=()):
-            if exc.get("type", None) and exc.get("module", None):
+            if exc.get("type", None):
                 self._processable_exceptions.append(exc)
             if value := exc.get("value", None):
                 class_matches = _JAVA_CLASS_IN_TEXT_RE.findall(value)
@@ -64,8 +64,8 @@ class Exceptions:
         """
         # Deobfuscate exception module and type first
         for raw_exc, exc in zip(self._processable_exceptions, mapped_exceptions):
-            raw_exc["raw_module"] = raw_exc["module"]
-            raw_exc["raw_type"] = raw_exc["type"]
+            raw_exc["raw_module"] = raw_exc.get("module")
+            raw_exc["raw_type"] = raw_exc.get("type")
             raw_exc["module"] = exc["module"]
             raw_exc["type"] = exc["type"]
 

--- a/src/sentry/lang/java/processing.py
+++ b/src/sentry/lang/java/processing.py
@@ -183,8 +183,13 @@ def process_jvm_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
     stacktraces = [
         {
             **(
-                {"exception": {"type": sinfo.exception_type, "module": sinfo.exception_module}}
-                if sinfo.exception_type and sinfo.exception_module
+                {
+                    "exception": {
+                        "type": sinfo.exception_type,
+                        "module": sinfo.exception_module or "",
+                    }
+                }
+                if sinfo.exception_type
                 else {}
             ),
             "frames": [
@@ -219,7 +224,8 @@ def process_jvm_stacktraces(symbolicator: Symbolicator, data: Any) -> Any:
     response = symbolicator.process_jvm(
         platform=data.get("platform"),
         exceptions=[
-            {"module": exc["module"], "type": exc["type"]} for exc in processable_exceptions
+            {"module": exc.get("module") or "", "type": exc["type"]}
+            for exc in processable_exceptions
         ],
         stacktraces=stacktraces,
         modules=modules,

--- a/tests/sentry/lang/java/test_exceptions.py
+++ b/tests/sentry/lang/java/test_exceptions.py
@@ -1,4 +1,5 @@
 import re
+from typing import Any
 
 from sentry.lang.java.exceptions import Exceptions
 
@@ -99,7 +100,7 @@ def test_deobfuscate_and_save_deobfuscates_types_and_values_multiple_values() ->
 def test_deobfuscate_and_save_root_package_exception() -> None:
     # R8 aggressive mode produces root-package classes with no module;
     # raw_module must be preserved as None when originally absent.
-    exc = {"type": "kj", "value": "compose boom"}
+    exc: dict[str, Any] = {"type": "kj", "value": "compose boom"}
     data = build_event([exc])
 
     excs = Exceptions(data)

--- a/tests/sentry/lang/java/test_exceptions.py
+++ b/tests/sentry/lang/java/test_exceptions.py
@@ -7,11 +7,13 @@ def build_event(exceptions_values):
     return {"exception": {"values": exceptions_values}}
 
 
-def test_get_processable_exceptions_filters_by_module_and_type() -> None:
+def test_get_processable_exceptions_filters_by_type() -> None:
     data = build_event(
         [
             {"type": "RuntimeException", "module": "java.lang", "value": "boom"},
             {"type": "IllegalStateException", "value": "oops"},
+            # Root-package obfuscated exception (R8 aggressive mode) — no module.
+            {"type": "kj", "value": "compose boom"},
             {"module": "kotlin", "value": "meh"},
             {"value": "just text"},
         ]
@@ -20,9 +22,11 @@ def test_get_processable_exceptions_filters_by_module_and_type() -> None:
     excs = Exceptions(data)
     processable = excs.get_processable_exceptions()
 
-    assert len(processable) == 1
+    assert len(processable) == 3
     assert processable[0]["type"] == "RuntimeException"
     assert processable[0]["module"] == "java.lang"
+    assert processable[1]["type"] == "IllegalStateException"
+    assert processable[2]["type"] == "kj"
 
 
 def test_value_class_names_matches_fqcn_inner_and_quoted_multiple_values() -> None:
@@ -90,6 +94,29 @@ def test_deobfuscate_and_save_deobfuscates_types_and_values_multiple_values() ->
     assert "io.sample.MainActivity" in exc3["value"]
     assert "alpha.beta.C$1" in exc3["value"]
     assert exc3["raw_value"].startswith("Caused by com.example.myapp.MainActivity")
+
+
+def test_deobfuscate_and_save_root_package_exception() -> None:
+    # R8 aggressive mode produces root-package classes with no module;
+    # raw_module must be preserved as None when originally absent.
+    exc = {"type": "kj", "value": "compose boom"}
+    data = build_event([exc])
+
+    excs = Exceptions(data)
+
+    mapped_exceptions = [
+        {
+            "type": "DiagnosticComposeException",
+            "module": "androidx.compose.runtime.tooling",
+        }
+    ]
+
+    excs.deobfuscate_and_save(None, mapped_exceptions)
+
+    assert exc["raw_type"] == "kj"
+    assert exc["raw_module"] is None
+    assert exc["type"] == "DiagnosticComposeException"
+    assert exc["module"] == "androidx.compose.runtime.tooling"
 
 
 def test_deobfuscate_value_replaces_longest_tokens_first() -> None:


### PR DESCRIPTION
## Summary

R8 aggressive mode can rename a class into the root package, so the Sentry SDK emits the exception with an empty or absent `module` and a bare `type` such as `kj` (e.g. Compose's `androidx.compose.runtime.tooling.DiagnosticComposeException`). `Exceptions.__init__` filtered these out with `if exc.get("type") and exc.get("module")`, so they never reached symbolicator — leaving `exception.type` obfuscated on the event even though the same class resolved fine when seen as a stack frame's `module`.

- Drop the `module` requirement from the processable-exceptions filter; only `type` is required.
- Use `.get()` when snapshotting `raw_module`/`raw_type` so a missing `module` doesn't raise.
- In `process_jvm_stacktraces`, forward the per-stacktrace `exception` whenever `exception_type` is set, defaulting `module` to `""`, and same for the top-level `exceptions=[…]` payload.

Requires https://github.com/getsentry/symbolicator/pull/1933 — symbolicator's key construction (`"{module}.{ty}"`) currently produces `.kj` for root-package classes and misses the lookup. Without that companion fix, this change forwards the exception but symbolicator still can't remap it.

## Test plan

- [x] Renamed `test_get_processable_exceptions_filters_by_module_and_type` → `…_filters_by_type`, added a `kj` fixture row to verify it's now kept
- [x] New `test_deobfuscate_and_save_root_package_exception` covering the `raw_module is None` preservation invariant
- [x] Full `tests/sentry/lang/java/test_exceptions.py`: 7/7 pass