### PR TITLE
fix(spans): Enable better_backpressure in span buffer RunTask

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ dependencies = [
   "rfc3339-validator>=0.1.2",
   "rfc3986-validator>=0.1.1",
   # [end] jsonschema format validators
-  "sentry-arroyo>=2.38.7",
+  "sentry-arroyo>=2.39.0",
   "sentry-conventions>=0.3.0",
   "sentry-forked-email-reply-parser>=0.5.12.post1",
   "sentry-kafka-schemas>=2.1.27",

--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -121,6 +121,7 @@ class ProcessSpansStrategyFactory(ProcessingStrategyFactory[KafkaPayload]):
                     buffer,
                 ),
                 next_step=flusher,
+                better_backpressure=True,
             )
 
         batch = BatchStep(

--- a/uv.lock
+++ b/uv.lock
@@ -2323,7 +2323,7 @@ requires-dist = [
     { name = "requests-oauthlib", specifier = ">=1.2.0" },
     { name = "rfc3339-validator", specifier = ">=0.1.2" },
     { name = "rfc3986-validator", specifier = ">=0.1.1" },
-    { name = "sentry-arroyo", specifier = ">=2.38.7" },
+    { name = "sentry-arroyo", specifier = ">=2.39.0" },
     { name = "sentry-conventions", specifier = ">=0.3.0" },
     { name = "sentry-forked-email-reply-parser", specifier = ">=0.5.12.post1" },
     { name = "sentry-kafka-schemas", specifier = ">=2.1.27" },
@@ -2415,13 +2415,13 @@ dev = [
 
 [[package]]
 name = "sentry-arroyo"
-version = "2.38.7"
+version = "2.39.0"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "confluent-kafka", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_arroyo-2.38.7-py3-none-any.whl", hash = "sha256:088f8620e1fa6af950d588e4ddae259b849fb799af9a78dd5b9912ccedd19a4a" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_arroyo-2.39.0-py3-none-any.whl", hash = "sha256:fb5fce90a6eb2aede72cfa6511133d8bbe9b3b83a83ee50105d604ef5c05164d" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps arroyo to 2.39.0 and enables the new `better_backpressure=True` flag in the span buffer's RunTask.

When the flusher applies backpressure, the current RunTask implementation re-raises `MessageRejected` and re-runs the user function on each retry attempt. This causes increased CPU load on Redis because `add-buffer.lua` executes multiple times per message.

With `better_backpressure=True`, the function runs exactly once per message — transformed messages are stored on backpressure and retried in `poll()` instead.

See https://github.com/getsentry/arroyo/pull/536 for the arroyo change.

Ref STREAM-881