### PR TITLE
fix(repositories): Make sure we write `external_id` during auto source code mapping

### DIFF
--- a/src/sentry/integrations/source_code_management/repo_trees.py
+++ b/src/sentry/integrations/source_code_management/repo_trees.py
@@ -22,6 +22,7 @@ EXCLUDED_PATHS = ["tests/"]
 class RepoAndBranch(NamedTuple):
     name: str
     branch: str
+    external_id: str
 
 
 class RepoTree(NamedTuple):
@@ -92,6 +93,7 @@ class RepoTreesIntegration(ABC):
                 {
                     "full_name": str(repo_info["identifier"]),
                     "default_branch": repo_info.get("default_branch") or "",
+                    "external_id": repo_info["external_id"],
                 }
                 for repo_info in self.get_repositories()
                 if not repo_info.get("archived")
@@ -145,7 +147,13 @@ class RepoTreesIntegration(ABC):
                 # The API rate limit is reset every hour
                 # Spread the expiration of the cache of each repo across the day
                 trees[repo_full_name] = self._populate_tree(
-                    RepoAndBranch(repo_full_name, repo_info["default_branch"]),
+                    # Use .get() for external_id since cached entries from before this field
+                    # was added won't have it. The cache TTL will naturally cycle them out.
+                    RepoAndBranch(
+                        repo_full_name,
+                        repo_info["default_branch"],
+                        repo_info.get("external_id", ""),
+                    ),
                     use_cache,
                     3600 * (index % 24),
                 )

--- a/src/sentry/issues/auto_source_code_config/code_mapping.py
+++ b/src/sentry/issues/auto_source_code_config/code_mapping.py
@@ -362,7 +362,10 @@ def create_code_mapping(
     repository, _ = Repository.objects.get_or_create(
         name=code_mapping.repo.name,
         organization_id=organization.id,
-        defaults={"integration_id": installation.model.id},
+        defaults={
+            "integration_id": installation.model.id,
+            "external_id": code_mapping.repo.external_id,
+        },
     )
     new_code_mapping, _ = RepositoryProjectPathConfig.objects.update_or_create(
         project=project,

--- a/src/sentry/issues/auto_source_code_config/derived_code_mappings_endpoint.py
+++ b/src/sentry/issues/auto_source_code_config/derived_code_mappings_endpoint.py
@@ -6,6 +6,7 @@ from sentry.integrations.source_code_management.repo_trees import (
     RepoAndBranch,
     RepoTreesIntegration,
 )
+from sentry.integrations.source_code_management.repository import RepositoryIntegration
 from sentry.models.organization import Organization
 
 from .code_mapping import CodeMapping, CodeMappingTreesHelper
@@ -34,11 +35,21 @@ def get_frame_info_from_request(request: Request) -> FrameInfo:
     return create_frame_info(frame, request.GET.get("platform"))
 
 
-def get_code_mapping_from_request(request: Request) -> CodeMapping:
+def get_code_mapping_from_request(
+    request: Request, installation: RepositoryIntegration
+) -> CodeMapping:
+    repo_name = request.data["repoName"]
+    repos = installation.get_repositories(query=repo_name)
+    repo_info = RepositoryIntegration.find_repo_info(repos, repo_name)
+    if not repo_info:
+        raise KeyError(f"Repository {repo_name} not found on provider")
+    external_id = repo_info["external_id"]
+
     return CodeMapping(
         repo=RepoAndBranch(
-            name=request.data["repoName"],
+            name=repo_name,
             branch=request.data["defaultBranch"],
+            external_id=external_id,
         ),
         stacktrace_root=request.data["stackRoot"],
         source_path=request.data["sourceRoot"],

--- a/src/sentry/issues/auto_source_code_config/derived_code_mappings_endpoint.py
+++ b/src/sentry/issues/auto_source_code_config/derived_code_mappings_endpoint.py
@@ -42,7 +42,7 @@ def get_code_mapping_from_request(
     repos = installation.get_repositories(query=repo_name)
     repo_info = RepositoryIntegration.find_repo_info(repos, repo_name)
     if not repo_info:
-        raise KeyError(f"Repository {repo_name} not found on provider")
+        raise ValueError(f"Repository {repo_name} not found on provider")
     external_id = repo_info["external_id"]
 
     return CodeMapping(

--- a/src/sentry/issues/auto_source_code_config/task.py
+++ b/src/sentry/issues/auto_source_code_config/task.py
@@ -212,7 +212,9 @@ def create_configurations(
     tags: Mapping[str, str | bool] = {"platform": platform, "dry_run": dry_run}
     with metrics.timer(f"{METRIC_PREFIX}.create_configurations.duration", tags=tags):
         for code_mapping in code_mappings:
-            repository = create_repository(code_mapping.repo.name, org_integration, tags)
+            repository = create_repository(
+                code_mapping.repo.name, org_integration, tags, code_mapping.repo.external_id
+            )
             create_code_mapping(code_mapping, repository, project, org_integration, tags)
 
     in_app_stack_trace_rules: list[str] = []

--- a/src/sentry/issues/auto_source_code_config/utils/repository.py
+++ b/src/sentry/issues/auto_source_code_config/utils/repository.py
@@ -8,7 +8,10 @@ from ..constants import METRIC_PREFIX
 
 
 def create_repository(
-    repo_name: str, org_integration: RpcOrganizationIntegration, tags: Mapping[str, str | bool]
+    repo_name: str,
+    org_integration: RpcOrganizationIntegration,
+    tags: Mapping[str, str | bool],
+    external_id: str,
 ) -> Repository | None:
     organization_id = org_integration.organization_id
     created = False
@@ -23,6 +26,9 @@ def create_repository(
                 name=repo_name,
                 organization_id=organization_id,
                 integration_id=org_integration.integration_id,
+                defaults={
+                    "external_id": external_id,
+                },
             )
         if created or tags["dry_run"]:
             metrics.incr(key=f"{METRIC_PREFIX}.repository.created", tags=tags, sample_rate=1.0)

--- a/src/sentry/issues/endpoints/organization_derive_code_mappings.py
+++ b/src/sentry/issues/endpoints/organization_derive_code_mappings.py
@@ -123,6 +123,8 @@ class OrganizationDeriveCodeMappingsEndpoint(OrganizationEndpoint):
             assert isinstance(installation, RepositoryIntegration)
             code_mapping = get_code_mapping_from_request(request, installation)
             new_code_mapping = create_code_mapping(organization, code_mapping, project)
+        except ValueError as e:
+            return self.respond({"text": str(e)}, status=status.HTTP_404_NOT_FOUND)
         except KeyError:
             return self.respond(
                 {"text": "Missing required parameters"}, status=status.HTTP_400_BAD_REQUEST

--- a/src/sentry/issues/endpoints/organization_derive_code_mappings.py
+++ b/src/sentry/issues/endpoints/organization_derive_code_mappings.py
@@ -13,6 +13,7 @@ from sentry.api.bases.organization import (
     OrganizationIntegrationsLoosePermission,
 )
 from sentry.api.serializers import serialize
+from sentry.integrations.source_code_management.repository import RepositoryIntegration
 from sentry.issues.auto_source_code_config.code_mapping import create_code_mapping
 from sentry.issues.auto_source_code_config.derived_code_mappings_endpoint import (
     get_code_mapping_from_request,
@@ -119,7 +120,8 @@ class OrganizationDeriveCodeMappingsEndpoint(OrganizationEndpoint):
             if not installation.org_integration:
                 raise InstallationNotFoundError
 
-            code_mapping = get_code_mapping_from_request(request)
+            assert isinstance(installation, RepositoryIntegration)
+            code_mapping = get_code_mapping_from_request(request, installation)
             new_code_mapping = create_code_mapping(organization, code_mapping, project)
         except KeyError:
             return self.respond(

--- a/tests/sentry/api/endpoints/issues/test_organization_derive_code_mappings.py
+++ b/tests/sentry/api/endpoints/issues/test_organization_derive_code_mappings.py
@@ -1,5 +1,5 @@
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.db import router
 from django.urls import reverse
@@ -57,6 +57,7 @@ class OrganizationDeriveCodeMappingsTest(APITestCase):
                 RepoAndBranch(
                     name="getsentry/codemap",
                     branch="master",
+                    external_id="1",
                 ),
                 files=["stack/root/file.py"],
             )
@@ -89,6 +90,7 @@ class OrganizationDeriveCodeMappingsTest(APITestCase):
                 RepoAndBranch(
                     name="getsentry/codemap",
                     branch="master",
+                    external_id="1",
                 ),
                 files=["app/src/main/java/com/waffleware/billing/Billing.kt"],
             )
@@ -129,6 +131,7 @@ class OrganizationDeriveCodeMappingsTest(APITestCase):
                 RepoAndBranch(
                     name="getsentry/codemap",
                     branch="master",
+                    external_id="1",
                 ),
                 files=[
                     "sentry-graphql/src/main/java/io/sentry/graphql/GraphQLFetcher.java",
@@ -158,6 +161,7 @@ class OrganizationDeriveCodeMappingsTest(APITestCase):
                 RepoAndBranch(
                     name="getsentry/codemap",
                     branch="master",
+                    external_id="1",
                 ),
                 files=["stack/root/file.py"],
             )
@@ -194,6 +198,7 @@ class OrganizationDeriveCodeMappingsTest(APITestCase):
                 RepoAndBranch(
                     name="getsentry/codemap",
                     branch="master",
+                    external_id="1",
                 ),
                 files=["stack/root/file.py"],
             ),
@@ -201,6 +206,7 @@ class OrganizationDeriveCodeMappingsTest(APITestCase):
                 RepoAndBranch(
                     name="getsentry/foobar",
                     branch="master",
+                    external_id="2",
                 ),
                 files=["stack/root/file.py"],
             ),
@@ -243,6 +249,7 @@ class OrganizationDeriveCodeMappingsTest(APITestCase):
                 RepoAndBranch(
                     name="getsentry/codemap",
                     branch="master",
+                    external_id="1",
                 ),
                 files=["top_level_file.py"],
             )
@@ -267,7 +274,13 @@ class OrganizationDeriveCodeMappingsTest(APITestCase):
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert response.data == {"text": "Could not find project"}
 
-    def test_non_project_member_permissions(self) -> None:
+    @patch(
+        "sentry.integrations.github.integration.GitHubIntegration.get_repositories",
+        return_value=[
+            {"name": "codemap", "identifier": "getsentry/codemap", "external_id": "99999"}
+        ],
+    )
+    def test_non_project_member_permissions(self, mock_get_repos: MagicMock) -> None:
         config_data = {
             "projectId": self.project.id,
             "stackRoot": "/stack/root",
@@ -287,7 +300,13 @@ class OrganizationDeriveCodeMappingsTest(APITestCase):
         response = self.client.post(self.url, data=config_data, format="json")
         assert response.status_code == status.HTTP_201_CREATED
 
-    def test_post_simple(self) -> None:
+    @patch(
+        "sentry.integrations.github.integration.GitHubIntegration.get_repositories",
+        return_value=[
+            {"name": "codemap", "identifier": "getsentry/codemap", "external_id": "99999"}
+        ],
+    )
+    def test_post_simple(self, mock_get_repos: MagicMock) -> None:
         config_data = {
             "projectId": self.project.id,
             "stackRoot": "/stack/root",
@@ -342,7 +361,11 @@ class OrganizationDeriveCodeMappingsTest(APITestCase):
         response = self.client.post(self.url, data=config_data, format="json")
         assert response.status_code == 404, response.content
 
-    def test_post_existing_code_mapping(self) -> None:
+    @patch(
+        "sentry.integrations.github.integration.GitHubIntegration.get_repositories",
+        return_value=[{"name": "name", "identifier": "name", "external_id": "88888"}],
+    )
+    def test_post_existing_code_mapping(self, mock_get_repos: MagicMock) -> None:
         RepositoryProjectPathConfig.objects.create(
             project=self.project,
             stack_root="/stack/root",

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -791,6 +791,7 @@ class GitHubIntegrationTest(IntegrationTestCase):
 
     def _expected_trees(self, repo_info_list=None):
         result = {}
+        repo_ids = {"xyz": "1234567", "foo": "1296269", "bar": "9876574", "baz": "1276555"}
         # bar (409 empty repo) returns an empty RepoTree since we cache the result
         # baz (404) also returns an empty RepoTree because we cache not-found outcomes
         list = repo_info_list or [
@@ -801,16 +802,28 @@ class GitHubIntegrationTest(IntegrationTestCase):
         ]
         for repo, branch, files in list:
             result[f"{self.gh_org}/{repo}"] = RepoTree(
-                RepoAndBranch(f"{self.gh_org}/{repo}", branch), files
+                RepoAndBranch(f"{self.gh_org}/{repo}", branch, str(repo_ids.get(repo, ""))), files
             )
         return result
 
     def _expected_cached_repos(self):
         return [
-            {"full_name": f"{self.gh_org}/xyz", "default_branch": "master"},
-            {"full_name": f"{self.gh_org}/foo", "default_branch": "master"},
-            {"full_name": f"{self.gh_org}/bar", "default_branch": "main"},
-            {"full_name": f"{self.gh_org}/baz", "default_branch": "master"},
+            {
+                "full_name": f"{self.gh_org}/xyz",
+                "default_branch": "master",
+                "external_id": "1234567",
+            },
+            {
+                "full_name": f"{self.gh_org}/foo",
+                "default_branch": "master",
+                "external_id": "1296269",
+            },
+            {"full_name": f"{self.gh_org}/bar", "default_branch": "main", "external_id": "9876574"},
+            {
+                "full_name": f"{self.gh_org}/baz",
+                "default_branch": "master",
+                "external_id": "1276555",
+            },
         ]
 
     @responses.activate

--- a/tests/sentry/issues/auto_source_code_config/test_code_mapping.py
+++ b/tests/sentry/issues/auto_source_code_config/test_code_mapping.py
@@ -100,8 +100,8 @@ class TestDerivedCodeMappings(TestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        self.foo_repo = RepoAndBranch("Test-Organization/foo", "master")
-        self.bar_repo = RepoAndBranch("Test-Organization/bar", "main")
+        self.foo_repo = RepoAndBranch("Test-Organization/foo", "master", "1")
+        self.bar_repo = RepoAndBranch("Test-Organization/bar", "main", "2")
         self.code_mapping_helper = CodeMappingTreesHelper(
             {
                 self.foo_repo.name: RepoTree(self.foo_repo, files=SENTRY_FILES),
@@ -149,7 +149,7 @@ class TestDerivedCodeMappings(TestCase):
         code_mappings = self.code_mapping_helper.generate_code_mappings(frames)
         assert code_mappings == [
             CodeMapping(
-                repo=RepoAndBranch(name="Test-Organization/foo", branch="master"),
+                repo=RepoAndBranch(name="Test-Organization/foo", branch="master", external_id="1"),
                 stacktrace_root="sentry/",
                 source_path="src/sentry/",
             )

--- a/tests/sentry/issues/auto_source_code_config/test_process_event.py
+++ b/tests/sentry/issues/auto_source_code_config/test_process_event.py
@@ -40,7 +40,7 @@ class ExpectedCodeMapping(TypedDict):
 
 
 def _repo_info(name: str, branch: str) -> dict[str, str]:
-    return {"full_name": name, "default_branch": branch}
+    return {"full_name": name, "default_branch": branch, "external_id": name}
 
 
 def _repo_tree_files(files: Sequence[str]) -> list[dict[str, Any]]:
@@ -887,7 +887,7 @@ class TestJavaDeriveCodeMappings(LanguageSpecificDeriveCodeMappings):
 
         # Let's pretend that we have already added the two level tld rule
         # This means that the uk.co.not-example.baz.qux will be in-app
-        repo = RepoAndBranch(name="repo1", branch="default")
+        repo = RepoAndBranch(name="repo1", branch="default", external_id="1")
         # The source root will only work for the foo package
         cm = CodeMapping(repo=repo, stacktrace_root="uk/co/", source_path="src/main/uk/co/")
         create_code_mapping(self.organization, cm, self.project)


### PR DESCRIPTION
Currently we don't write `external_id` if we create a `Repository` during auto source code mapping. This pr fixes this by passing it through `RepoAndBranch` when available, and if not, fetching it via the SCM's api.
