### PR TITLE
fix(experiments): Skip exposure for non-experiment features

### DIFF
--- a/static/gsApp/hooks/useExperiment.spec.tsx
+++ b/static/gsApp/hooks/useExperiment.spec.tsx
@@ -165,6 +165,30 @@ describe('useExperiment (gsApp)', () => {
     expect(Amplitude.groupIdentify).not.toHaveBeenCalled();
   });
 
+  it('does not report exposure when the feature has no experiment assignment', () => {
+    // Feature is enabled via organization.features (e.g. SENTRY_FEATURES or a
+    // regular non-experiment flag) but has no entry in organization.experiments.
+    // The BE only fires auto-exposure for flags with experiment_mode set, so we
+    // match that behavior here and skip both the Amplitude write and the POST.
+    const org = OrganizationFixture({
+      features: ['not-an-experiment'],
+      experiments: {},
+    });
+    const mockExposure = MockApiClient.addMockResponse({
+      url: `/organizations/${org.slug}/experiment-exposure/`,
+      method: 'POST',
+      statusCode: 204,
+    });
+
+    render(<TestComponent feature="not-an-experiment" />, {organization: org});
+
+    expect(Amplitude.groupIdentify).not.toHaveBeenCalled();
+    expect(mockExposure).not.toHaveBeenCalled();
+    // The hook still returns a sensible default for consumers.
+    expect(screen.getByTestId('in-experiment')).toHaveTextContent('true');
+    expect(screen.getByTestId('assignment')).toHaveTextContent('control');
+  });
+
   it('does not post exposure when reportExposure is false', () => {
     const org = OrganizationFixture({
       features: ['test-experiment'],

--- a/static/gsApp/hooks/useExperiment.tsx
+++ b/static/gsApp/hooks/useExperiment.tsx
@@ -70,8 +70,18 @@ export function useExperiment(options: UseExperimentOptions): UseExperimentResul
     retry: false,
   });
 
+  // Only report exposure for features that are actually experiments.
+  // organization.experiments is populated by get_experiment_assignments
+  // which filters to flags with experiment_mode set, so its absence signals
+  // "not an experiment" (or "entity handler not available in dev/test").
+  // This mirrors the backend's auto-exposure gate in getsentry/features.py,
+  // which only fires exposure for flags with experiment_mode. The hook
+  // return value still falls through to 'control' for consumers that need
+  // a default.
+  const hasExperimentAssignment = organization.experiments?.[feature] !== undefined;
+
   useEffect(() => {
-    if (!reportExposure) {
+    if (!reportExposure || !hasExperimentAssignment) {
       return;
     }
 
@@ -85,6 +95,7 @@ export function useExperiment(options: UseExperimentOptions): UseExperimentResul
     logExposure();
   }, [
     reportExposure,
+    hasExperimentAssignment,
     organization.id,
     organization.slug,
     feature,


### PR DESCRIPTION
## TL;DR

The `useExperiment` hook was writing spurious `'control'` values to Amplitude group properties and BigQuery exposure rows whenever it was called for a non-experiment feature. Gate exposure on `organization.experiments?.[feature] !== undefined` to match the backend's `experiment_mode` gate.

## Why

`organization.experiments` is populated by `get_experiment_assignments`, which filters to flagpole flags with `experiment_mode` set. Its absence signals "not an experiment" or "entity handler not available in dev/test."

The backend's auto-exposure at `getsentry/features.py:1513-1522` only fires for flags with `experiment_mode`. The FE hook should match that. Previously, calling `useExperiment('some-non-experiment-flag')` would fall through to `assignment = 'control'` and still POST to `/experiment-exposure/`, which in turn wrote `experiment_some_non_experiment_flag = 'control'` to Amplitude's group property bag and an `experiment.exposure` row to BigQuery. That pollution accumulates forever on the org's Amplitude group since Amplitude has no TTL on group properties (some of the stale, typo'd `experiment_*` keys seen in production org groups are likely a symptom of this class of bug from past experiment renames).

## Behavior

- `organization.experiments[feature]` defined (real experiment with `experiment_mode`): exposure fires as before.
- `organization.experiments[feature]` undefined (non-experiment, or getsentry entity handler not present): exposure is skipped entirely.
- Hook return value still falls through to `'control'` for consumers that need a default. No consumer-facing API change.

## Stack

Stacked on top of #113635 (race fix). Merge the race PR first; this PR's base will then rebase onto `master` automatically when that merges.