### PR TITLE
fix(tracemetrics): Styling on visualize field for alerts

### DIFF
--- a/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
@@ -192,7 +192,7 @@ function MetricsEquationVisualizeContent({
   }, [hasEquationRow]);
 
   return (
-    <Stack gap="md">
+    <Stack gap="md" flex="1">
       {functionQueries.length > 0 && <FunctionColumnHeaders />}
       {functionQueries.map(metricQuery => {
         const isReferenced = referencedLabels.has(metricQuery.label ?? '');
@@ -392,12 +392,14 @@ function MetricToolbar({
       />
       {isVisualizeFunction(visualize) ? (
         <Fragment>
-          <MetricSelector
-            traceMetric={traceMetric}
-            onChange={setTraceMetric}
-            projectIds={projectIds}
-            environments={environments}
-          />
+          <Flex minWidth={0}>
+            <MetricSelector
+              traceMetric={traceMetric}
+              onChange={setTraceMetric}
+              projectIds={projectIds}
+              environments={environments}
+            />
+          </Flex>
           <AggregateDropdown traceMetric={traceMetric} />
           <Filter traceMetric={traceMetric} />
           <DeleteMetricButton disabled={!canDelete} />

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -400,7 +400,7 @@ export function MetricSelector({
       <OverlayTrigger.Button
         {...mergedTriggerProps}
         style={{width: '100%', fontWeight: 'bold', textAlign: 'left'}}
-        disabled={(isFetching && !traceMetric.name) || !metricOptions.length}
+        disabled={isFetching && !traceMetric.name}
         tooltipProps={{title: traceMetric.name || t('None')}}
       >
         <Text ellipsis>{traceMetric.name || t('None')}</Text>

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -400,7 +400,7 @@ export function MetricSelector({
       <OverlayTrigger.Button
         {...mergedTriggerProps}
         style={{width: '100%', fontWeight: 'bold', textAlign: 'left'}}
-        disabled={isFetching && !traceMetric.name}
+        disabled={(isFetching && !traceMetric.name) || !metricOptions.length}
         tooltipProps={{title: traceMetric.name || t('None')}}
       >
         <Text ellipsis>{traceMetric.name || t('None')}</Text>


### PR DESCRIPTION
- disables the metric selector if there aren't any options
- stretches the field the entire row
- prevents long metric names from overflowing

| description | before | after |
| ----- | ------ | ----- |
| stretches the entire row | <img width="1026" height="318" alt="Screenshot 2026-04-22 at 1 42 50 PM" src="https://github.com/user-attachments/assets/43745a5e-d52f-4273-9c4e-a0c012847290" /> | <img width="1035" height="338" alt="Screenshot 2026-04-22 at 1 44 16 PM" src="https://github.com/user-attachments/assets/53dbc470-db53-45d9-bb14-074c317ff239" /> |
| prevents long metric names from overflowing | <img width="1197" height="219" alt="Screenshot 2026-04-22 at 1 45 31 PM" src="https://github.com/user-attachments/assets/1522a85d-574d-4746-9307-2ae269cf1fbd" /> | <img width="1047" height="239" alt="Screenshot 2026-04-22 at 1 45 54 PM" src="https://github.com/user-attachments/assets/c36716fc-d19e-4e07-9480-83376960d2d4" /> |
