### PR TITLE
feat(seer): Add organization_id to Slack Seer agent analytics

### DIFF
--- a/src/sentry/seer/entrypoints/slack/analytics.py
+++ b/src/sentry/seer/entrypoints/slack/analytics.py
@@ -10,6 +10,7 @@ class SlackSeerAgentConversation(str, Enum):
 
 @analytics.eventclass("ai.agent.slack.responded")
 class SlackSeerAgentResponded(analytics.Event):
+    organization_id: int
     org_slug: str
     user_id: int
     username: str

--- a/src/sentry/seer/entrypoints/slack/tasks.py
+++ b/src/sentry/seer/entrypoints/slack/tasks.py
@@ -175,6 +175,7 @@ def process_mention_for_slack(
             linked_user_count = 0
 
         analytics_event = SlackSeerAgentResponded(
+            organization_id=organization.id,
             org_slug=organization.slug,
             user_id=user.id,
             username=user.username,

--- a/tests/sentry/seer/entrypoints/slack/test_tasks.py
+++ b/tests/sentry/seer/entrypoints/slack/test_tasks.py
@@ -80,6 +80,7 @@ class ProcessMentionForSlackTest(TestCase):
         assert_last_analytics_event(
             mock_record,
             SlackSeerAgentResponded(
+                organization_id=self.organization.id,
                 org_slug=self.organization.slug,
                 user_id=self.user.id,
                 username="alice",
@@ -251,6 +252,7 @@ class ProcessMentionForSlackTest(TestCase):
         assert_last_analytics_event(
             mock_record,
             SlackSeerAgentResponded(
+                organization_id=self.organization.id,
                 org_slug=self.organization.slug,
                 user_id=self.user.id,
                 username="alice",
@@ -321,6 +323,7 @@ class ProcessMentionForSlackTest(TestCase):
         assert_last_analytics_event(
             mock_record,
             SlackSeerAgentResponded(
+                organization_id=self.organization.id,
                 org_slug=self.organization.slug,
                 user_id=self.user.id,
                 username="alice",


### PR DESCRIPTION
We need organization_id in order for the ETL pipeline to process our analytics as unaggregated events. Unaggregated data needs organization id:

https://github.com/getsentry/etl/blob/3899398c56608a9fd9707ab604edb1bfbc0a5686/workspace/dags/sql/analytics/amplitude-analytics-unagg.sql#L6-L9  