### PR TITLE
devenv: optional gcloud

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -6,10 +6,6 @@ brew 'uv'
 brew 'docker'
 brew 'docker-buildx'
 
-# required for make test-selective
-# greedy forces cask updates
-cask 'gcloud-cli', greedy: true
-
 ### If updating below this line, please also update REQUIRED_APT_PKGS in devenv/post_fetch.py ###
 
 # required for pnpm test -u


### PR DESCRIPTION
Introduced in https://github.com/getsentry/sentry/pull/113496 for local selective testing but some people are having trouble installing it. I don't have time to debug this right now, so opting everyone out for now. `make test-selective` will prompt people to install manually via brew.

This works on my machine but I wasn't expecting it to be brittle for others.

```
Creating virtualenv...
ERROR: (gcloud.config.virtualenv.create) virtualenv: command not found
Error: Failure while executing; `/usr/bin/env /opt/homebrew/share/google-cloud-sdk/bin/gcloud config virtualenv create --python-to-use /opt/homebrew/opt/python@3.13/libexec/bin/python` exited with 1. Here's the output:
WARNING:  Python 3.9.x is no longer officially supported by the Google Cloud CLI
and may not function correctly. Please use Python version 3.10 and up.
To reinstall gcloud, run:
    $ gcloud components reinstall

This will also prompt to install a compatible version of Python.

If you have a compatible Python interpreter installed, you can use it by setting
the CLOUDSDK_PYTHON environment variable to point to it.

Creating virtualenv...
ERROR: (gcloud.config.virtualenv.create) virtualenv: command not found
==> Unlinking Binary '/opt/homebrew/bin/git-credential-gcloud'
==> Unlinking Binary '/opt/homebrew/bin/gcloud'
==> Unlinking Binary '/opt/homebrew/bin/docker-credential-gcloud'
==> Unlinking Binary '/opt/homebrew/bin/bq'
==> Unlinking Binary '/opt/homebrew/bin/gsutil'
==> Unlinking Zsh Completion '/opt/homebrew/share/zsh/site-functions/_google_cloud_sdk'
==> Unlinking Bash Completion '/opt/homebrew/etc/bash_completion.d/google-cloud-sdk'
==> Purging files for version 565.0.0 of Cask gcloud-cli
Installing gcloud-cli has failed!
Using watchman
`brew bundle` failed! 1 Brewfile dependency failed to install
```