### PR TITLE
fix(slack): Apply dashboard-stored filters when unfurling widget URLs

### DIFF
--- a/src/sentry/integrations/slack/unfurl/dashboards.py
+++ b/src/sentry/integrations/slack/unfurl/dashboards.py
@@ -15,6 +15,7 @@ from sentry.api import client
 from sentry.api.endpoints.timeseries import TimeSeries
 from sentry.charts import backend as charts
 from sentry.charts.types import ChartSize, ChartType
+from sentry.constants import ALL_ACCESS_PROJECT_ID
 from sentry.integrations.messaging.metrics import (
     MessagingInteractionEvent,
     MessagingInteractionType,
@@ -48,7 +49,10 @@ class DashboardsUnfurlArgs(TypedDict):
 
 _logger = logging.getLogger(__name__)
 
-DEFAULT_PERIOD = "14d"
+# Matches the dashboards-specific DEFAULT_STATS_PERIOD in
+# static/app/views/dashboards/data.tsx so unfurls show the same window the
+# dashboard UI does when no period is set anywhere.
+DEFAULT_PERIOD = "24h"
 TOP_N = 5
 
 DASHBOARDS_CHART_SIZE: ChartSize = {"width": 1200, "height": 400}
@@ -197,6 +201,7 @@ def _get_widget(
             dashboard_id=dashboard_id,
             dashboard__organization_id=organization_id,
         )
+        .select_related("dashboard")
         .prefetch_related(
             Prefetch(
                 "dashboardwidgetquery_set",
@@ -218,8 +223,10 @@ def build_widget_timeseries_params(
     if dataset is None:
         raise ValueError(f"Unsupported widget type: {widget.widget_type}")
 
+    dashboard_filters = widget.dashboard.get_filters()
+
     return [
-        _params_for_widget_query(wq, url_params, dataset)
+        _params_for_widget_query(wq, url_params, dataset, dashboard_filters)
         for wq in widget.dashboardwidgetquery_set.all()
     ]
 
@@ -228,6 +235,7 @@ def _params_for_widget_query(
     widget_query: DashboardWidgetQuery,
     url_params: QueryDict,
     dataset: SupportedTraceItemType,
+    dashboard_filters: Mapping[str, Any],
 ) -> dict[str, str | list[str]]:
     params: dict[str, str | list[str]] = {}
 
@@ -250,18 +258,78 @@ def _params_for_widget_query(
         # when grouping without an explicit sort.
         params["sort"] = f"-{aggregates[0]}"
 
-    for param in ("project", "environment", "statsPeriod", "start", "end", "interval"):
-        values = url_params.getlist(param)
-        if values:
-            params[param] = values if len(values) > 1 else values[0]
-
-    if "statsPeriod" not in params and "start" not in params:
-        params["statsPeriod"] = DEFAULT_PERIOD
+    _apply_page_filters(params, url_params, dashboard_filters)
 
     params["dataset"] = dataset.value
     params["referrer"] = Referrer.DASHBOARDS_SLACK_UNFURL.value
 
     return params
+
+
+def _apply_page_filters(
+    params: dict[str, str | list[str]],
+    url_params: QueryDict,
+    dashboard_filters: Mapping[str, Any],
+) -> None:
+    """Resolve page filters (project, environment, date range, interval).
+
+    Precedence mirrors the dashboard UI's PageFilters resolution:
+      URL query params -> dashboard-saved filters -> hardcoded FE defaults.
+    localStorage-pinned filters are deliberately not replicated; they aren't
+    reachable from a webhook context.
+    """
+    # project: URL wins. Otherwise fall back to the dashboard's projects.
+    # An unconfigured dashboard (no projects, no all_projects) falls through
+    # to "All Projects" so the unfurl shows data instead of an empty chart.
+    project_values = url_params.getlist("project")
+    if not project_values:
+        project_values = [str(p) for p in dashboard_filters.get("projects") or []]
+    if not project_values:
+        project_values = [str(ALL_ACCESS_PROJECT_ID)]
+    params["project"] = project_values if len(project_values) > 1 else project_values[0]
+
+    # environment: URL wins. Otherwise fall back to dashboard, or omit (no
+    # filter) to match the FE default of "All Environments".
+    env_values = url_params.getlist("environment")
+    if not env_values:
+        env_values = list(dashboard_filters.get("environment") or [])
+    if env_values:
+        params["environment"] = env_values if len(env_values) > 1 else env_values[0]
+
+    # Date range: treat as a single unit. If the URL carries any date info at
+    # all, trust it holistically (don't mix URL start with dashboard period).
+    url_start = url_params.get("start")
+    url_end = url_params.get("end")
+    url_stats_period = url_params.get("statsPeriod")
+    url_utc = url_params.get("utc")
+
+    if url_stats_period or url_start or url_end:
+        if url_stats_period:
+            params["statsPeriod"] = url_stats_period
+        if url_start:
+            params["start"] = url_start
+        if url_end:
+            params["end"] = url_end
+        if url_utc:
+            params["utc"] = url_utc
+    else:
+        dash_start = dashboard_filters.get("start")
+        dash_end = dashboard_filters.get("end")
+        dash_period = dashboard_filters.get("period")
+        dash_utc = dashboard_filters.get("utc")
+        if dash_start and dash_end:
+            params["start"] = str(dash_start)
+            params["end"] = str(dash_end)
+            if dash_utc is not None:
+                params["utc"] = str(dash_utc)
+        elif dash_period:
+            params["statsPeriod"] = str(dash_period)
+        else:
+            params["statsPeriod"] = DEFAULT_PERIOD
+
+    interval_value = url_params.get("interval")
+    if interval_value:
+        params["interval"] = interval_value
 
 
 def map_dashboards_query_args(url: str, args: Mapping[str, str | None]) -> DashboardsUnfurlArgs:

--- a/src/sentry/integrations/slack/unfurl/dashboards.py
+++ b/src/sentry/integrations/slack/unfurl/dashboards.py
@@ -298,10 +298,11 @@ def _apply_page_filters(
 
     # Date range: treat as a single unit. If the URL carries any date info at
     # all, trust it holistically (don't mix URL start with dashboard period).
+    # ``utc`` is intentionally not forwarded: the events-timeseries endpoint
+    # doesn't consume it, and unfurls are shared across mixed-timezone audiences.
     url_start = url_params.get("start")
     url_end = url_params.get("end")
     url_stats_period = url_params.get("statsPeriod")
-    url_utc = url_params.get("utc")
 
     if url_stats_period or url_start or url_end:
         if url_stats_period:
@@ -310,18 +311,13 @@ def _apply_page_filters(
             params["start"] = url_start
         if url_end:
             params["end"] = url_end
-        if url_utc:
-            params["utc"] = url_utc
     else:
         dash_start = dashboard_filters.get("start")
         dash_end = dashboard_filters.get("end")
         dash_period = dashboard_filters.get("period")
-        dash_utc = dashboard_filters.get("utc")
         if dash_start and dash_end:
             params["start"] = str(dash_start)
             params["end"] = str(dash_end)
-            if dash_utc is not None:
-                params["utc"] = str(dash_utc)
         elif dash_period:
             params["statsPeriod"] = str(dash_period)
         else:

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -2615,7 +2615,9 @@ class BuildWidgetTimeseriesParamsTest(TestCase):
         assert "statsPeriod" not in params
         assert params["start"] == "2026-01-01T00:00:00"
         assert params["end"] == "2026-01-02T00:00:00"
-        assert params["utc"] == "True"
+        # utc is intentionally dropped - not consumed by events-timeseries and
+        # irrelevant for a cross-timezone Slack audience.
+        assert "utc" not in params
 
     def test_url_period_supersedes_dashboard_start_end(self) -> None:
         # When the URL carries any date info, the dashboard's date range is

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -2523,7 +2523,8 @@ class BuildWidgetTimeseriesParamsTest(TestCase):
 
         params = build_widget_timeseries_params(widget, QueryDict())[0]
 
-        assert params["statsPeriod"] == "14d"
+        # Matches DEFAULT_STATS_PERIOD in static/app/views/dashboards/data.tsx
+        assert params["statsPeriod"] == "24h"
 
     def test_url_start_end_supersedes_default_stats_period(self) -> None:
         widget = self._make_widget()
@@ -2535,3 +2536,99 @@ class BuildWidgetTimeseriesParamsTest(TestCase):
         assert "statsPeriod" not in params
         assert params["start"] == "2026-01-01T00:00:00"
         assert params["end"] == "2026-01-02T00:00:00"
+
+    def test_defaults_to_all_projects_when_no_url_or_dashboard_project(self) -> None:
+        widget = self._make_widget()
+
+        params = build_widget_timeseries_params(widget, QueryDict())[0]
+
+        # ALL_ACCESS_PROJECT_ID (-1) so an unconfigured dashboard still renders
+        # data rather than an empty chart.
+        assert params["project"] == "-1"
+
+    def test_dashboard_projects_used_when_url_missing(self) -> None:
+        project_a = self.create_project(organization=self.organization)
+        project_b = self.create_project(organization=self.organization)
+        widget = self._make_widget()
+        widget.dashboard.projects.set([project_a, project_b])
+
+        params = build_widget_timeseries_params(widget, QueryDict())[0]
+
+        assert sorted(params["project"]) == sorted([str(project_a.id), str(project_b.id)])
+
+    def test_dashboard_all_projects_flag_maps_to_sentinel(self) -> None:
+        widget = self._make_widget()
+        widget.dashboard.filters = {"all_projects": True}
+        widget.dashboard.save()
+
+        params = build_widget_timeseries_params(widget, QueryDict())[0]
+
+        assert params["project"] == "-1"
+
+    def test_url_project_overrides_dashboard_projects(self) -> None:
+        project_a = self.create_project(organization=self.organization)
+        widget = self._make_widget()
+        widget.dashboard.projects.set([project_a])
+
+        params = build_widget_timeseries_params(widget, QueryDict("project=99"))[0]
+
+        assert params["project"] == "99"
+
+    def test_dashboard_environment_used_when_url_missing(self) -> None:
+        widget = self._make_widget()
+        widget.dashboard.filters = {"environment": ["prod", "staging"]}
+        widget.dashboard.save()
+
+        params = build_widget_timeseries_params(widget, QueryDict())[0]
+
+        assert params["environment"] == ["prod", "staging"]
+
+    def test_url_environment_overrides_dashboard_environment(self) -> None:
+        widget = self._make_widget()
+        widget.dashboard.filters = {"environment": ["prod"]}
+        widget.dashboard.save()
+
+        params = build_widget_timeseries_params(widget, QueryDict("environment=dev"))[0]
+
+        assert params["environment"] == "dev"
+
+    def test_dashboard_period_used_when_url_missing(self) -> None:
+        widget = self._make_widget()
+        widget.dashboard.filters = {"period": "7d"}
+        widget.dashboard.save()
+
+        params = build_widget_timeseries_params(widget, QueryDict())[0]
+
+        assert params["statsPeriod"] == "7d"
+
+    def test_dashboard_start_end_used_when_url_missing(self) -> None:
+        widget = self._make_widget()
+        widget.dashboard.filters = {
+            "start": "2026-01-01T00:00:00",
+            "end": "2026-01-02T00:00:00",
+            "utc": True,
+        }
+        widget.dashboard.save()
+
+        params = build_widget_timeseries_params(widget, QueryDict())[0]
+
+        assert "statsPeriod" not in params
+        assert params["start"] == "2026-01-01T00:00:00"
+        assert params["end"] == "2026-01-02T00:00:00"
+        assert params["utc"] == "True"
+
+    def test_url_period_supersedes_dashboard_start_end(self) -> None:
+        # When the URL carries any date info, the dashboard's date range is
+        # ignored entirely so we don't mix URL statsPeriod with a saved range.
+        widget = self._make_widget()
+        widget.dashboard.filters = {
+            "start": "2026-01-01T00:00:00",
+            "end": "2026-01-02T00:00:00",
+        }
+        widget.dashboard.save()
+
+        params = build_widget_timeseries_params(widget, QueryDict("statsPeriod=7d"))[0]
+
+        assert params["statsPeriod"] == "7d"
+        assert "start" not in params
+        assert "end" not in params


### PR DESCRIPTION
Pasting a dashboard widget URL into Slack produced a blank chart when the URL had no query params. The unfurl handler read `project`, `environment`, and the date range exclusively from URL params, so a bare `/dashboard/{id}/widget/{index}/` link sent an `events-timeseries` request with no project filter and returned no data.

The dashboard UI itself resolves those filters from `Dashboard.projects` / `Dashboard.filters` (and its own `DEFAULT_STATS_PERIOD='24h'`) when the URL doesn't carry them. This change mirrors that precedence server-side:

1. URL query params (as before)
2. Dashboard-saved filters via `Dashboard.get_filters()` — projects, environment, period, start/end, utc, and the `all_projects` sentinel
3. Hardcoded FE defaults — `DEFAULT_PERIOD` bumped from `14d` to `24h` to match `static/app/views/dashboards/data.tsx`; project falls back to `ALL_ACCESS_PROJECT_ID` (`-1`) so unconfigured dashboards still render data instead of an empty chart

Date range is treated as a unit: if the URL carries any of `statsPeriod`/`start`/`end`, the dashboard-saved range is ignored (no mixing URL `statsPeriod` with a saved `start`/`end`).

localStorage-pinned `PageFilters` are deliberately not replicated — they aren't reachable from a webhook context, and dashboards pass `disablePersistence={true}` anyway.

Also adds `select_related("dashboard")` to `_get_widget` so accessing `widget.dashboard.get_filters()` doesn't trigger an extra lazy query.

Refs DAIN-1574