### PR TITLE
fix(tracemetrics): Disable multi select for aggregations field in alerts

### DIFF
--- a/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
@@ -398,7 +398,7 @@ function MetricToolbar({
             projectIds={projectIds}
             environments={environments}
           />
-          <AggregateDropdown traceMetric={traceMetric} />
+          <AggregateDropdown traceMetric={traceMetric} singleSelect />
           <Filter traceMetric={traceMetric} />
           <DeleteMetricButton disabled={!canDelete} />
         </Fragment>

--- a/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.spec.tsx
@@ -505,4 +505,48 @@ describe('AggregateDropdown', () => {
       expect(within(trigger).getByText('+1')).toBeInTheDocument();
     });
   });
+
+  it('renders all groups as single-select and keeps only the last selection when singleSelect is passed', async () => {
+    const organization = OrganizationFixture({
+      features: ['tracemetrics-enabled'],
+    });
+
+    const queryParams = new ReadableQueryParams({
+      extrapolate: true,
+      mode: Mode.SAMPLES,
+      query: '',
+      cursor: '',
+      fields: ['id', 'timestamp'],
+      sortBys: [{field: 'timestamp', kind: 'desc'}],
+      aggregateCursor: '',
+      aggregateFields: [new VisualizeFunction('p50(value,test_metric,distribution,-)')],
+      aggregateSortBys: [{field: 'p50(value,test_metric,distribution,-)', kind: 'desc'}],
+    });
+
+    render(
+      <AggregateDropdown
+        traceMetric={{name: 'test_metric', type: 'distribution'}}
+        singleSelect
+      />,
+      {
+        organization,
+        additionalWrapper: createWrapper({queryParams, stateful: true}),
+      }
+    );
+
+    const trigger = screen.getByRole('button', {name: /Agg/});
+    await userEvent.click(trigger);
+
+    await waitFor(() => {
+      expect(screen.getByRole('option', {name: 'p50'})).toHaveAttribute(
+        'aria-selected',
+        'true'
+      );
+    });
+
+    await userEvent.click(screen.getByRole('option', {name: 'p75'}));
+
+    expect(await within(trigger).findByText('p75')).toBeInTheDocument();
+    expect(within(trigger).queryByText(/^\+\d/)).not.toBeInTheDocument();
+  });
 });

--- a/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
@@ -24,7 +24,13 @@ import {isVisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 
 const MULTI_SELECT_GROUP_KEYS = new Set(['percentiles', 'stats']);
 
-export function AggregateDropdown({traceMetric}: {traceMetric: TraceMetric}) {
+export function AggregateDropdown({
+  traceMetric,
+  singleSelect = false,
+}: {
+  traceMetric: TraceMetric;
+  singleSelect?: boolean;
+}) {
   const visualize = useMetricVisualize();
   const visualizes = useMetricVisualizes();
   const setMetricVisualizes = useSetMetricVisualizes();
@@ -93,7 +99,7 @@ export function AggregateDropdown({traceMetric}: {traceMetric: TraceMetric}) {
     >
       {groups.map(group => {
         const groupKey = String(group.key);
-        const isMulti = MULTI_SELECT_GROUP_KEYS.has(groupKey);
+        const isMulti = !singleSelect && MULTI_SELECT_GROUP_KEYS.has(groupKey);
         const activeValues = group.options
           .map(opt => String(opt.value))
           .filter(v => selectedNames.has(v));


### PR DESCRIPTION
Disable multi-select from the equations component in alerts. It doesn't make sense in the context of equations and it does not make sense for alerts since we only plot a single series at a time.