### PR TITLE
fix(marked): Sanitize image src in marked text

### DIFF
--- a/static/app/utils/marked/marked.tsx
+++ b/static/app/utils/marked/marked.tsx
@@ -101,7 +101,7 @@ const ALLOWED_TAGS = [
   'sup',
 ];
 
-const ALLOWED_ATTR = ['href', 'title', 'src', 'alt', 'class', 'id', 'align'];
+const ALLOWED_ATTR = ['href', 'title', 'alt', 'class', 'id', 'align'];
 
 function postprocess(html: string) {
   return dompurify.sanitize(html, {

--- a/static/app/utils/marked/markedText.spec.tsx
+++ b/static/app/utils/marked/markedText.spec.tsx
@@ -117,4 +117,11 @@ console.log("Hello, world!");
       expect(codeElement).toBeInTheDocument();
     });
   });
+
+  it('sanitizes image src', async () => {
+    render(<MarkedText text="![image](https://example.com)" />);
+
+    const image = await screen.findByAltText('image');
+    expect(image).not.toHaveAttribute('src');
+  });
 });


### PR DESCRIPTION
Sanize the `src` attribute to prevent loading of images from external domains.