### PR TITLE
ref(seer): Add priority-based root node selection to snapshot_to_markdown

### DIFF
--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -400,10 +400,10 @@ def _get_priority(node: dict[str, Any]) -> int:
 def snapshot_to_markdown(snapshot: dict[str, Any]) -> str:
     """Convert an LLMContextSnapshot dict to a markdown string.
 
-    Expected shape: ``{"version": int, "nodes": [{"nodeType": str, "data": ..., "children": [...]}]}``
+    Expected shape: ``{"version": int, "nodes": [{"nodeType": str, "priority": int, "data": ..., "children": [...]}]}``
     The top-level nodes list may contain multiple root nodes (e.g. a dashboard
     and a widget-builder sidebar rendered as siblings).  Nodes are sorted by
-    ``data.priority`` (descending, default 0) and only nodes at the highest
+    ``priority`` (descending, default 0) and only nodes at the highest
     priority level are rendered.  At most ``_MAX_ROOT_NODES`` are emitted to
     guard against runaway token usage.
     """

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -379,6 +379,8 @@ def _render_node(node: dict[str, Any], depth: int) -> str:
     data = node.get("data")
     if isinstance(data, dict):
         for key, value in data.items():
+            if key == "priority":
+                continue
             lines.append(f"- **{key}**: {orjson.dumps(value).decode()}")
     elif data is not None:
         lines.append(f"- {orjson.dumps(data).decode()}")
@@ -392,18 +394,28 @@ def _render_node(node: dict[str, Any], depth: int) -> str:
 _MAX_ROOT_NODES = 10
 
 
+def _get_priority(node: dict[str, Any]) -> int:
+    data = node.get("data")
+    return data.get("priority", 0) if isinstance(data, dict) else 0
+
+
 def snapshot_to_markdown(snapshot: dict[str, Any]) -> str:
     """Convert an LLMContextSnapshot dict to a markdown string.
 
     Expected shape: ``{"version": int, "nodes": [{"nodeType": str, "data": ..., "children": [...]}]}``
     The top-level nodes list may contain multiple root nodes (e.g. a dashboard
-    and a widget-builder sidebar rendered as siblings).  At most ``_MAX_ROOT_NODES``
-    are rendered to guard against runaway token usage.
+    and a widget-builder sidebar rendered as siblings).  Nodes are sorted by
+    ``data.priority`` (descending, default 0) and only nodes at the highest
+    priority level are rendered.  At most ``_MAX_ROOT_NODES`` are emitted to
+    guard against runaway token usage.
     """
     nodes = snapshot.get("nodes", [])
     if not nodes:
         return ""
+    sorted_nodes = sorted(nodes, key=_get_priority, reverse=True)
+    top_priority = _get_priority(sorted_nodes[0])
+    selected = [n for n in sorted_nodes if _get_priority(n) == top_priority][:_MAX_ROOT_NODES]
     preamble = (
         "> This is a structured summary of the page the user is viewing, not an exact screenshot.\n"
     )
-    return preamble + "\n".join(_render_node(node, 0) for node in nodes[:_MAX_ROOT_NODES])
+    return preamble + "\n".join(_render_node(node, 0) for node in selected)

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -379,8 +379,6 @@ def _render_node(node: dict[str, Any], depth: int) -> str:
     data = node.get("data")
     if isinstance(data, dict):
         for key, value in data.items():
-            if key == "priority":
-                continue
             lines.append(f"- **{key}**: {orjson.dumps(value).decode()}")
     elif data is not None:
         lines.append(f"- {orjson.dumps(data).decode()}")
@@ -395,8 +393,7 @@ _MAX_ROOT_NODES = 10
 
 
 def _get_priority(node: dict[str, Any]) -> int:
-    data = node.get("data")
-    priority = data.get("priority") if isinstance(data, dict) else None
+    priority = node.get("priority")
     return priority if isinstance(priority, int) else 0
 
 

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -396,7 +396,8 @@ _MAX_ROOT_NODES = 10
 
 def _get_priority(node: dict[str, Any]) -> int:
     data = node.get("data")
-    return data.get("priority", 0) if isinstance(data, dict) else 0
+    priority = data.get("priority") if isinstance(data, dict) else None
+    return priority if isinstance(priority, int) else 0
 
 
 def snapshot_to_markdown(snapshot: dict[str, Any]) -> str:

--- a/tests/sentry/seer/explorer/test_client_utils.py
+++ b/tests/sentry/seer/explorer/test_client_utils.py
@@ -271,6 +271,55 @@ class SnapshotToMarkdownTest(TestCase):
         assert "# Widget-builder" in result
         assert '- **mode**: "creating"' in result
 
+    def test_priority_selects_highest(self) -> None:
+        snapshot = {
+            "version": 1,
+            "nodes": [
+                {
+                    "nodeType": "dashboard",
+                    "data": {"title": "My Dashboard"},
+                    "children": [
+                        {"nodeType": "widget", "data": {"title": "W1"}, "children": []},
+                    ],
+                },
+                {
+                    "nodeType": "widget-builder",
+                    "data": {"priority": 1, "mode": "creating"},
+                    "children": [],
+                },
+            ],
+        }
+        result = snapshot_to_markdown(snapshot)
+        assert "# Widget-builder" in result
+        assert '- **mode**: "creating"' in result
+        assert "Dashboard" not in result
+        assert "priority" not in result
+
+    def test_priority_equal_renders_all(self) -> None:
+        snapshot = {
+            "version": 1,
+            "nodes": [
+                {"nodeType": "dashboard", "data": {"title": "D1"}, "children": []},
+                {"nodeType": "dashboard", "data": {"title": "D2"}, "children": []},
+            ],
+        }
+        result = snapshot_to_markdown(snapshot)
+        assert result.count("# Dashboard") == 2
+
+    def test_priority_multiple_highest(self) -> None:
+        snapshot = {
+            "version": 1,
+            "nodes": [
+                {"nodeType": "a", "data": {"priority": 1}, "children": []},
+                {"nodeType": "b", "data": {"priority": 1}, "children": []},
+                {"nodeType": "c", "data": {"priority": 0}, "children": []},
+            ],
+        }
+        result = snapshot_to_markdown(snapshot)
+        assert "# A" in result
+        assert "# B" in result
+        assert "# C" not in result
+
     def test_node_with_non_dict_data(self) -> None:
         snapshot = {
             "version": 1,

--- a/tests/sentry/seer/explorer/test_client_utils.py
+++ b/tests/sentry/seer/explorer/test_client_utils.py
@@ -284,7 +284,8 @@ class SnapshotToMarkdownTest(TestCase):
                 },
                 {
                     "nodeType": "widget-builder",
-                    "data": {"priority": 1, "mode": "creating"},
+                    "priority": 1,
+                    "data": {"mode": "creating"},
                     "children": [],
                 },
             ],
@@ -293,7 +294,6 @@ class SnapshotToMarkdownTest(TestCase):
         assert "# Widget-builder" in result
         assert '- **mode**: "creating"' in result
         assert "Dashboard" not in result
-        assert "priority" not in result
 
     def test_priority_equal_renders_all(self) -> None:
         snapshot = {
@@ -310,8 +310,8 @@ class SnapshotToMarkdownTest(TestCase):
         snapshot = {
             "version": 1,
             "nodes": [
-                {"nodeType": "a", "data": {"priority": None}, "children": []},
-                {"nodeType": "b", "data": {"priority": 1}, "children": []},
+                {"nodeType": "a", "priority": None, "data": {}, "children": []},
+                {"nodeType": "b", "priority": 1, "data": {}, "children": []},
             ],
         }
         result = snapshot_to_markdown(snapshot)
@@ -322,9 +322,9 @@ class SnapshotToMarkdownTest(TestCase):
         snapshot = {
             "version": 1,
             "nodes": [
-                {"nodeType": "a", "data": {"priority": 1}, "children": []},
-                {"nodeType": "b", "data": {"priority": 1}, "children": []},
-                {"nodeType": "c", "data": {"priority": 0}, "children": []},
+                {"nodeType": "a", "priority": 1, "data": {}, "children": []},
+                {"nodeType": "b", "priority": 1, "data": {}, "children": []},
+                {"nodeType": "c", "data": {}, "children": []},
             ],
         }
         result = snapshot_to_markdown(snapshot)

--- a/tests/sentry/seer/explorer/test_client_utils.py
+++ b/tests/sentry/seer/explorer/test_client_utils.py
@@ -306,6 +306,18 @@ class SnapshotToMarkdownTest(TestCase):
         result = snapshot_to_markdown(snapshot)
         assert result.count("# Dashboard") == 2
 
+    def test_priority_null_treated_as_zero(self) -> None:
+        snapshot = {
+            "version": 1,
+            "nodes": [
+                {"nodeType": "a", "data": {"priority": None}, "children": []},
+                {"nodeType": "b", "data": {"priority": 1}, "children": []},
+            ],
+        }
+        result = snapshot_to_markdown(snapshot)
+        assert "# B" in result
+        assert "# A" not in result
+
     def test_priority_multiple_highest(self) -> None:
         snapshot = {
             "version": 1,


### PR DESCRIPTION
+ Sort root nodes by data.priority (descending, default 0) and render only nodes at the highest priority level. This lets frontend components declare their importance so the backend selects the most relevant context without frontend route-based filtering.
+ Currently root nodes don't have priority but the followup frontend PR will add it- https://github.com/getsentry/sentry/pull/113717

