### PR TITLE
ref(seer): Use priority field instead of frontend route filtering

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
@@ -347,6 +347,7 @@ describe('NewWidgetBuilder', () => {
     expect(data.visualize).toEqual(['count()']);
     expect(data.fields).toEqual(['browser.name']);
     expect(data.query).toEqual(['browser.name:Firefox']);
+    expect(node.priority).toBe(1);
     expect(data.dashboardTitle).toBe('Dashboard');
     expect(data.dashboardWidgetCount).toBe(0);
     expect(data.dashboardFilters).toEqual([]);

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -114,6 +114,7 @@ function WidgetBuilderSlideoutInner({
 
   // Push widget builder state into the LLM context tree for Seer Explorer.
   useLLMContext({
+    priority: 1,
     contextHint:
       'Sentry widget builder. The user is configuring a dashboard widget. visualize is the y-axis metrics (timeseries) or the aggregate (big number/table). fields are group-by columns (timeseries) or visible columns (table). query filters the data and sort controls ordering.',
     dashboardTitle: dashboard.title,

--- a/static/app/views/seerExplorer/contexts/llmContext.spec.tsx
+++ b/static/app/views/seerExplorer/contexts/llmContext.spec.tsx
@@ -103,14 +103,17 @@ describe('registerLLMContext — nesting', () => {
         nodes: [
           {
             nodeType: 'dashboard',
+            priority: 0,
             data: {name: 'Backend Health'},
             children: [
               {
                 nodeType: 'widget',
+                priority: 0,
                 data: {title: 'Error Rate', type: 'timeseries', unit: 'ms'},
                 children: [
                   {
                     nodeType: 'chart',
+                    priority: 0,
                     data: {label: 'p99'},
                     children: [],
                   },

--- a/static/app/views/seerExplorer/contexts/llmContext.tsx
+++ b/static/app/views/seerExplorer/contexts/llmContext.tsx
@@ -68,9 +68,12 @@ function buildTree(
   const children: LLMContextNodeSnapshot[] = [];
   for (const [id, node] of nodes) {
     if (node.parentId === parentId) {
+      const raw = (nodeData.has(id) ? nodeData.get(id) : {}) as Record<string, unknown>;
+      const {priority, ...data} = raw;
       children.push({
         nodeType: node.nodeType,
-        data: nodeData.has(id) ? nodeData.get(id) : {},
+        priority: typeof priority === 'number' ? priority : 0,
+        data,
         children: buildTree(nodes, nodeData, id),
       });
     }
@@ -88,12 +91,18 @@ function serializeState(
     if (!node) {
       return {version: state.version, nodes: []};
     }
+    const raw = (nodeData.has(fromNodeId) ? nodeData.get(fromNodeId) : {}) as Record<
+      string,
+      unknown
+    >;
+    const {priority, ...data} = raw;
     return {
       version: state.version,
       nodes: [
         {
           nodeType: node.nodeType,
-          data: nodeData.has(fromNodeId) ? nodeData.get(fromNodeId) : {},
+          priority: typeof priority === 'number' ? priority : 0,
+          data,
           children: buildTree(state.nodes, nodeData, fromNodeId),
         },
       ],

--- a/static/app/views/seerExplorer/contexts/llmContext.tsx
+++ b/static/app/views/seerExplorer/contexts/llmContext.tsx
@@ -68,11 +68,19 @@ function buildTree(
   const children: LLMContextNodeSnapshot[] = [];
   for (const [id, node] of nodes) {
     if (node.parentId === parentId) {
-      const raw = (nodeData.has(id) ? nodeData.get(id) : {}) as Record<string, unknown>;
-      const {priority, ...data} = raw;
+      const raw = nodeData.has(id) ? nodeData.get(id) : {};
+      let priority = 0;
+      let data = raw;
+      if (raw !== null && typeof raw === 'object' && !Array.isArray(raw)) {
+        const {priority: p, ...rest} = raw as Record<string, unknown>;
+        if (typeof p === 'number') {
+          priority = p;
+        }
+        data = rest;
+      }
       children.push({
         nodeType: node.nodeType,
-        priority: typeof priority === 'number' ? priority : 0,
+        priority,
         data,
         children: buildTree(nodes, nodeData, id),
       });
@@ -91,17 +99,22 @@ function serializeState(
     if (!node) {
       return {version: state.version, nodes: []};
     }
-    const raw = (nodeData.has(fromNodeId) ? nodeData.get(fromNodeId) : {}) as Record<
-      string,
-      unknown
-    >;
-    const {priority, ...data} = raw;
+    const raw = nodeData.has(fromNodeId) ? nodeData.get(fromNodeId) : {};
+    let priority = 0;
+    let data = raw;
+    if (raw !== null && typeof raw === 'object' && !Array.isArray(raw)) {
+      const {priority: p, ...rest} = raw as Record<string, unknown>;
+      if (typeof p === 'number') {
+        priority = p;
+      }
+      data = rest;
+    }
     return {
       version: state.version,
       nodes: [
         {
           nodeType: node.nodeType,
-          priority: typeof priority === 'number' ? priority : 0,
+          priority,
           data,
           children: buildTree(state.nodes, nodeData, fromNodeId),
         },

--- a/static/app/views/seerExplorer/contexts/llmContextTypes.ts
+++ b/static/app/views/seerExplorer/contexts/llmContextTypes.ts
@@ -58,6 +58,7 @@ export interface LLMContextNodeSnapshot {
   children: LLMContextNodeSnapshot[];
   data: unknown;
   nodeType: string;
+  priority: number;
 }
 
 /**

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
@@ -156,52 +156,6 @@ describe('useSeerExplorer', () => {
       });
     });
 
-    it('filters to only widget-builder nodes on widget builder routes', async () => {
-      (usePageReferrer as jest.Mock).mockReturnValue({
-        getPageReferrer: () => '/dashboard/:dashboardId/widget-builder/widget/new/',
-      });
-      (useLLMContext as jest.Mock).mockReturnValue({
-        getLLMContext: () => ({
-          version: 1,
-          nodes: [
-            {nodeType: 'dashboard', data: {title: 'My Dashboard'}, children: []},
-            {nodeType: 'widget-builder', data: {mode: 'creating'}, children: []},
-          ],
-        }),
-      });
-      const org = OrganizationFixture({
-        features: ['seer-explorer', 'context-engine-structured-page-context'],
-      });
-      MockApiClient.addMockResponse({
-        url: `/organizations/${org.slug}/seer/explorer-chat/`,
-        method: 'GET',
-        body: {session: null},
-      });
-      const postMock = MockApiClient.addMockResponse({
-        url: `/organizations/${org.slug}/seer/explorer-chat/`,
-        method: 'POST',
-        body: {run_id: 1},
-      });
-      MockApiClient.addMockResponse({
-        url: `/organizations/${org.slug}/seer/explorer-chat/1/`,
-        method: 'GET',
-        body: {session: {blocks: [], run_id: 1, status: 'completed', updated_at: ''}},
-      });
-
-      const {result} = renderHookWithProviders(() => useSeerExplorer(), {
-        organization: org,
-      });
-      act(() => {
-        result.current.sendMessage('q');
-      });
-
-      await waitFor(() => {
-        const ctx = JSON.parse(postMock.mock.calls[0][1].data.on_page_context);
-        expect(ctx.nodes).toHaveLength(1);
-        expect(ctx.nodes[0].nodeType).toBe('widget-builder');
-      });
-    });
-
     it('falls back to ASCII screenshot on non-dashboard page', async () => {
       const org = OrganizationFixture({
         features: ['seer-explorer', 'seer-explorer-context-engine'],

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -58,12 +58,6 @@ const NEW_STRUCTURED_CONTEXT_ROUTES = new Set([
   '/dashboard/:dashboardId/widget-builder/widget/:widgetIndex/edit/',
 ]);
 
-/** Widget builder routes — only the builder node is relevant, not the full dashboard tree. */
-const WIDGET_BUILDER_ROUTES = new Set([
-  '/dashboard/:dashboardId/widget-builder/widget/new/',
-  '/dashboard/:dashboardId/widget-builder/widget/:widgetIndex/edit/',
-]);
-
 function supportsStructuredContext(
   referrer: string,
   organization: {features: string[]} | null | undefined
@@ -354,14 +348,7 @@ export const useSeerExplorer = () => {
       let screenshot: string | undefined;
       if (supportsStructuredContext(getPageReferrer(), organization)) {
         try {
-          let snapshot = getLLMContext();
-          if (WIDGET_BUILDER_ROUTES.has(getPageReferrer())) {
-            snapshot = {
-              ...snapshot,
-              nodes: snapshot.nodes.filter(n => n.nodeType === 'widget-builder'),
-            };
-          }
-          screenshot = JSON.stringify(snapshot);
+          screenshot = JSON.stringify(getLLMContext());
         } catch (e) {
           Sentry.captureException(e);
           screenshot = captureAsciiSnapshot?.();


### PR DESCRIPTION
+ Add priority: 1 to widget-builder's useLLMContext data so the backend selects it over the dashboard node. Remove the WIDGET_BUILDER_ROUTES frontend filtering that was doing this client-side.
+ Will merge this after the backend PR: https://github.com/getsentry/sentry/pull/113715