### PR TITLE
fix(seer): wrap user messages

### DIFF
--- a/static/app/views/seerExplorer/components/blockComponents.tsx
+++ b/static/app/views/seerExplorer/components/blockComponents.tsx
@@ -691,6 +691,9 @@ const UserBlockContent = styled('div')`
   padding: ${p => p.theme.space.md} ${p => p.theme.space.lg};
   white-space: pre-wrap;
   word-wrap: break-word;
+  overflow-wrap: anywhere;
+  max-width: 100%;
+  min-width: 0;
   color: ${p => p.theme.tokens.content.primary};
   background: ${p => p.theme.tokens.background.secondary};
   border: 1px solid ${p => p.theme.tokens.border.primary};


### PR DESCRIPTION
Wraps very long seer user messages so they don't overflow the panel

<img width="1426" height="818" alt="CleanShot 2026-04-22 at 12 12 26@2x" src="https://github.com/user-attachments/assets/1b23eb67-00b3-4ab2-b5a0-2a4397140226" />
