### PR TITLE
fix(seer): Don't allow images in markdown

### DIFF
--- a/static/app/utils/marked/marked.spec.tsx
+++ b/static/app/utils/marked/marked.spec.tsx
@@ -48,18 +48,13 @@ describe('marked', () => {
     }
   });
 
-  it('normal images get rendered as html', () => {
+  it('strips images from markdown output', () => {
     for (const test of [
-      ['![](http://example.com)', '<img src="http://example.com" alt="">'],
-      ['![x](http://example.com)', '<img src="http://example.com" alt="x">'],
-      ['![x](https://example.com)', '<img src="https://example.com" alt="x">'],
+      ['![](http://example.com)', ''],
+      ['![x](http://example.com)', ''],
+      ['![x](https://example.com)', ''],
+      ['![x](javascript:foo)', ''],
     ]) {
-      expectMarkdown(test);
-    }
-  });
-
-  it("rejected images shouldn't be rendered at all", () => {
-    for (const test of [['![x](javascript:foo)', '<img alt="x">']]) {
       expectMarkdown(test);
     }
   });
@@ -191,7 +186,7 @@ describe('marked', () => {
 
   it('strips event handler attributes', () => {
     const imgResult = sanitizedMarked('<img src="x" onerror="alert(1)">');
-    expect(imgResult).toContain('<img src="x">');
+    expect(imgResult).not.toContain('<img');
     expect(imgResult).not.toContain('onerror');
 
     const linkResult = sanitizedMarked(

--- a/static/app/utils/marked/marked.tsx
+++ b/static/app/utils/marked/marked.tsx
@@ -9,8 +9,6 @@ import {loadPrismLanguage} from 'sentry/utils/prism';
 // Only https and mailto, (e.g. no javascript, vbscript, data protocols)
 const safeLinkPattern = /^(https?:|mailto:)/i;
 
-const safeImagePattern = /^https?:\/\/./i;
-
 function isSafeHref(href: string, pattern: RegExp) {
   try {
     return pattern.test(decodeURIComponent(unescape(href)));
@@ -34,15 +32,6 @@ class SafeRenderer extends marked.Renderer {
       ALLOWED_TAGS,
       ALLOWED_ATTR,
     });
-  }
-
-  image(tokens: Tokens.Image) {
-    // For a bad image, return an empty string
-    if (!isSafeHref(tokens.href, safeImagePattern)) {
-      return '';
-    }
-
-    return super.image(tokens);
   }
 }
 

--- a/static/app/utils/marked/marked.tsx
+++ b/static/app/utils/marked/marked.tsx
@@ -89,7 +89,6 @@ const ALLOWED_TAGS = [
   'td',
   // Inline elements
   'a',
-  'img',
   'code',
   'em',
   'strong',
@@ -101,7 +100,7 @@ const ALLOWED_TAGS = [
   'sup',
 ];
 
-const ALLOWED_ATTR = ['href', 'title', 'src', 'alt', 'class', 'id', 'align'];
+const ALLOWED_ATTR = ['href', 'title', 'alt', 'class', 'id', 'align'];
 
 function postprocess(html: string) {
   return dompurify.sanitize(html, {


### PR DESCRIPTION
I don't know of valid use cases for embedding images in markdown
rendered in sentry.io - and it is a potential source of XSS.