### PR TITLE
feat(tracemetrics): Link Explore to Alerts/Detectors

### DIFF
--- a/static/app/views/detectors/components/forms/metric/useInitialMetricDetectorFormData.tsx
+++ b/static/app/views/detectors/components/forms/metric/useInitialMetricDetectorFormData.tsx
@@ -1,5 +1,9 @@
 import type {Organization} from 'sentry/types/organization';
-import {generateFieldAsString, parseFunction} from 'sentry/utils/discover/fields';
+import {
+  generateFieldAsString,
+  isEquation,
+  parseFunction,
+} from 'sentry/utils/discover/fields';
 import {decodeScalar} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -31,6 +35,10 @@ function getLocationAggregate(
   const raw = decodeScalar(query.aggregate);
   if (!raw) {
     return undefined;
+  }
+
+  if (datasetConfig.supportsEquations && isEquation(raw)) {
+    return raw;
   }
 
   const parsedAggregate = parseFunction(raw);

--- a/static/app/views/detectors/datasetConfig/base.tsx
+++ b/static/app/views/detectors/datasetConfig/base.tsx
@@ -152,4 +152,9 @@ export interface DetectorDatasetConfig<SeriesResponse> {
    * e.g. For the errors dataset, count() will be formatted as 'Number of errors'
    */
   formatAggregateForTitle?: (aggregate: string) => string;
+
+  /**
+   * Whether the dataset supports equations
+   */
+  supportsEquations?: boolean;
 }

--- a/static/app/views/detectors/datasetConfig/eapBase.tsx
+++ b/static/app/views/detectors/datasetConfig/eapBase.tsx
@@ -39,6 +39,7 @@ interface EapDatasetOptions {
   ) => Record<string, SelectValue<FieldValue>>;
   name: string;
   SearchBar?: DetectorDatasetConfig<EventsStats>['SearchBar'];
+  supportsEquations?: boolean;
 }
 
 /**
@@ -56,6 +57,7 @@ export function createEapDetectorConfig(
     discoverDataset,
     formatAggregateForTitle,
     SearchBar: CustomSearchBar,
+    supportsEquations,
   } = options;
 
   const config: DetectorDatasetConfig<EapSeriesResponse> = {
@@ -96,6 +98,7 @@ export function createEapDetectorConfig(
     supportedDetectionTypes: ['static', 'percent', 'dynamic'],
     getDiscoverDataset: () => discoverDataset,
     formatAggregateForTitle,
+    supportsEquations,
   };
 
   return config;

--- a/static/app/views/detectors/datasetConfig/metrics.tsx
+++ b/static/app/views/detectors/datasetConfig/metrics.tsx
@@ -18,4 +18,5 @@ export const DetectorMetricsConfig = createEapDetectorConfig({
     }
     return aggregate;
   },
+  supportsEquations: true,
 });

--- a/static/app/views/explore/metrics/useSaveAsMetricItems.spec.tsx
+++ b/static/app/views/explore/metrics/useSaveAsMetricItems.spec.tsx
@@ -31,7 +31,11 @@ const mockOpenSaveQueryModal = jest.mocked(modal.openSaveQueryModal);
 
 describe('useSaveAsMetricItems', () => {
   const organization = OrganizationFixture({
-    features: ['tracemetrics-enabled', 'tracemetrics-alerts'],
+    features: [
+      'tracemetrics-enabled',
+      'tracemetrics-alerts',
+      'tracemetrics-equations-in-alerts',
+    ],
   });
   const project = ProjectFixture({id: '1'});
   const queryClient = makeTestQueryClient();

--- a/static/app/views/explore/metrics/useSaveAsMetricItems.spec.tsx
+++ b/static/app/views/explore/metrics/useSaveAsMetricItems.spec.tsx
@@ -15,7 +15,10 @@ import {MockMetricQueryParamsContext} from 'sentry/views/explore/metrics/hooks/t
 import {encodeMetricQueryParams} from 'sentry/views/explore/metrics/metricQuery';
 import {useSaveAsMetricItems} from 'sentry/views/explore/metrics/useSaveAsMetricItems';
 import {ReadableQueryParams} from 'sentry/views/explore/queryParams/readableQueryParams';
-import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
+import {
+  VisualizeEquation,
+  VisualizeFunction,
+} from 'sentry/views/explore/queryParams/visualize';
 import {OrganizationContext} from 'sentry/views/organizationContext';
 
 jest.mock('sentry/utils/useLocation');
@@ -28,7 +31,7 @@ const mockOpenSaveQueryModal = jest.mocked(modal.openSaveQueryModal);
 
 describe('useSaveAsMetricItems', () => {
   const organization = OrganizationFixture({
-    features: ['tracemetrics-enabled'],
+    features: ['tracemetrics-enabled', 'tracemetrics-alerts'],
   });
   const project = ProjectFixture({id: '1'});
   const queryClient = makeTestQueryClient();
@@ -203,5 +206,50 @@ describe('useSaveAsMetricItems', () => {
         }),
       ])
     );
+  });
+
+  it('formats alerts submenu labels for equations', () => {
+    const equation =
+      'equation|sum(value,metric.a,counter,none) + avg(value,metric.a,counter,none)';
+    const encodedMetricQuery = encodeMetricQueryParams({
+      metric: {name: 'metric.a', type: 'counter'},
+      queryParams: new ReadableQueryParams({
+        extrapolate: true,
+        mode: Mode.AGGREGATE,
+        query: 'release:1.2.3',
+        aggregateCursor: '',
+        aggregateFields: [new VisualizeEquation(equation)],
+        aggregateSortBys: [{field: equation, kind: 'desc'}],
+        cursor: '',
+        fields: [],
+        sortBys: [],
+      }),
+      label: 'ƒ1',
+    });
+
+    mockedUseLocation.mockReturnValue(
+      LocationFixture({
+        query: {
+          interval: '5m',
+          metric: [encodedMetricQuery],
+        },
+      })
+    );
+
+    const {result} = renderHook(useSaveAsMetricItems, {
+      wrapper: createWrapper(),
+      initialProps: {interval: '5m'},
+    });
+
+    const createAlertItems = result.current.find(item => item.key === 'create-alert') as
+      | {children: Array<{label: string; to: string}>}
+      | undefined;
+    const createAlertItem = createAlertItems?.children?.find(item => item.label === 'ƒ1');
+
+    expect(createAlertItem).toBeDefined();
+
+    const url = new URL(createAlertItem?.to as string, 'http://example.com');
+    const queryParams = new URLSearchParams(url.search);
+    expect(queryParams.get('aggregate')).toBe(equation);
   });
 });

--- a/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
+++ b/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
@@ -31,7 +31,11 @@ import {getVisualizeLabel} from 'sentry/views/explore/toolbar/toolbarVisualize';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
 
-import {canUseMetricsAlertsUI, canUseMetricsSavedQueriesUI} from './metricsFlags';
+import {
+  canUseMetricsAlertsUI,
+  canUseMetricsEquationsInAlerts,
+  canUseMetricsSavedQueriesUI,
+} from './metricsFlags';
 
 interface UseSaveAsMetricItemsOptions {
   interval: string;
@@ -112,41 +116,47 @@ export function useSaveAsMetricItems(options: UseSaveAsMetricItemsOptions) {
       return [];
     }
 
-    const alertsUrls = metricQueries.map((metricQuery, index) => {
-      const visualize = metricQuery.queryParams.visualizes[0]!;
-      const yAxis = visualize.yAxis;
+    const alertsUrls = metricQueries
+      .filter(
+        metricQuery =>
+          canUseMetricsEquationsInAlerts(organization) ||
+          isVisualizeFunction(metricQuery.queryParams.visualizes[0]!)
+      )
+      .map((metricQuery, index) => {
+        const visualize = metricQuery.queryParams.visualizes[0]!;
+        const yAxis = visualize.yAxis;
 
-      const query = metricQuery.queryParams.query ?? '';
-      let label = yAxis;
-      if (isVisualizeFunction(visualize)) {
-        const func = parseFunction(yAxis);
-        label = func ? prettifyParsedFunction(func) : yAxis;
-      } else if (isVisualizeEquation(visualize)) {
-        label = metricQuery.label ?? '';
-      }
+        const query = metricQuery.queryParams.query ?? '';
+        let label = yAxis;
+        if (isVisualizeFunction(visualize)) {
+          const func = parseFunction(yAxis);
+          label = func ? prettifyParsedFunction(func) : yAxis;
+        } else if (isVisualizeEquation(visualize)) {
+          label = metricQuery.label ?? '';
+        }
 
-      return {
-        key: `create-alert-${index}`,
-        label,
-        to: getAlertsUrl({
-          project,
-          query,
-          pageFilters: pageFilters.selection,
-          aggregate: yAxis,
-          organization,
-          dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
-          interval: options.interval,
-          eventTypes: [EventTypes.TRACE_ITEM_METRIC],
-        }),
-        onAction: () => {
-          trackAnalytics('metrics.save_as', {
-            save_type: 'alert',
-            ui_source: 'searchbar',
+        return {
+          key: `create-alert-${index}`,
+          label,
+          to: getAlertsUrl({
+            project,
+            query,
+            pageFilters: pageFilters.selection,
+            aggregate: yAxis,
             organization,
-          });
-        },
-      };
-    });
+            dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
+            interval: options.interval,
+            eventTypes: [EventTypes.TRACE_ITEM_METRIC],
+          }),
+          onAction: () => {
+            trackAnalytics('metrics.save_as', {
+              save_type: 'alert',
+              ui_source: 'searchbar',
+              organization,
+            });
+          },
+        };
+      });
 
     const newAlertLabel = organization.features.includes('workflow-engine-ui')
       ? t('Monitor for')

--- a/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
+++ b/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
@@ -112,37 +112,41 @@ export function useSaveAsMetricItems(options: UseSaveAsMetricItemsOptions) {
       return [];
     }
 
-    const alertsUrls = metricQueries
-      .filter(mq => isVisualizeFunction(mq.queryParams.visualizes[0]!))
-      .map((metricQuery, index) => {
-        const visualize = metricQuery.queryParams.visualizes[0]!;
-        const yAxis = isVisualizeFunction(visualize) ? visualize.yAxis : '';
-        const func = parseFunction(yAxis);
-        const label = func ? prettifyParsedFunction(func) : yAxis;
-        const query = metricQuery.queryParams.query ?? '';
+    const alertsUrls = metricQueries.map((metricQuery, index) => {
+      const visualize = metricQuery.queryParams.visualizes[0]!;
+      const yAxis = visualize.yAxis;
 
-        return {
-          key: `create-alert-${index}`,
-          label,
-          to: getAlertsUrl({
-            project,
-            query,
-            pageFilters: pageFilters.selection,
-            aggregate: yAxis,
+      const query = metricQuery.queryParams.query ?? '';
+      let label = yAxis;
+      if (isVisualizeFunction(visualize)) {
+        const func = parseFunction(yAxis);
+        label = func ? prettifyParsedFunction(func) : yAxis;
+      } else if (isVisualizeEquation(visualize)) {
+        label = metricQuery.label ?? '';
+      }
+
+      return {
+        key: `create-alert-${index}`,
+        label,
+        to: getAlertsUrl({
+          project,
+          query,
+          pageFilters: pageFilters.selection,
+          aggregate: yAxis,
+          organization,
+          dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
+          interval: options.interval,
+          eventTypes: [EventTypes.TRACE_ITEM_METRIC],
+        }),
+        onAction: () => {
+          trackAnalytics('metrics.save_as', {
+            save_type: 'alert',
+            ui_source: 'searchbar',
             organization,
-            dataset: Dataset.EVENTS_ANALYTICS_PLATFORM,
-            interval: options.interval,
-            eventTypes: [EventTypes.TRACE_ITEM_METRIC],
-          }),
-          onAction: () => {
-            trackAnalytics('metrics.save_as', {
-              save_type: 'alert',
-              ui_source: 'searchbar',
-              organization,
-            });
-          },
-        };
-      });
+          });
+        },
+      };
+    });
 
     const newAlertLabel = organization.features.includes('workflow-engine-ui')
       ? t('Monitor for')
@@ -187,15 +191,18 @@ export function useSaveAsMetricItems(options: UseSaveAsMetricItemsOptions) {
             : []),
           ...metricQueries.map((metricQuery, index) => {
             const visualize = metricQuery.queryParams.visualizes[0]!;
+            const label = isVisualizeFunction(visualize)
+              ? `${metricQuery.label ?? getVisualizeLabel(index, isVisualizeEquation(visualize))}: ${
+                  formatTraceMetricsFunction(
+                    metricQuery.queryParams.aggregateFields
+                      .filter(isVisualize)
+                      .map(v => v.yAxis)
+                  ) as string
+                }`
+              : (metricQuery.label ?? '');
             return {
               key: `add-to-dashboard-${index}`,
-              label: `${metricQuery.label ?? getVisualizeLabel(index, isVisualizeEquation(visualize))}: ${
-                formatTraceMetricsFunction(
-                  metricQuery.queryParams.aggregateFields
-                    .filter(isVisualize)
-                    .map(v => v.yAxis)
-                ) as string
-              }`,
+              label,
               onAction: () => {
                 if (isVisualizeEquation(visualize)) {
                   return;


### PR DESCRIPTION
Updates the Save As options for explore to parse equations and open them in alerts/detectors

Needed to update the dataset config for metrics to define a `supportsEquations` field so I can check that and verify if the `aggregate` sent in the URL was also an equation. Previously it only parsed functions