### PR TITLE
fix(ourlogs): use default yAxisSplitNumber behavior for TimeSeriesWidgetVisualization

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -36,7 +36,6 @@ import {defined, escape} from 'sentry/utils';
 import {uniq} from 'sentry/utils/array/uniq';
 import type {AggregationOutputType} from 'sentry/utils/discover/fields';
 import {RangeMap, type Range} from 'sentry/utils/number/rangeMap';
-import {useIsShortViewport} from 'sentry/utils/useIsShortViewport';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useWidgetSyncContext} from 'sentry/views/dashboards/contexts/widgetSyncContext';
@@ -141,7 +140,6 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
   // have the same difference in `timestamp`s) even though this is rare, since
   // the backend zerofills the data
 
-  const isShortViewport = useIsShortViewport();
   const chartRef = useRef<ReactEchartsRef | null>(null);
   const unregisterRef = useRef<(() => void) | null>(null);
   const {register: registerWithWidgetSyncContext, groupName} = useWidgetSyncContext();
@@ -253,11 +251,8 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
 
   const axisRangeProp = getAxisRange(props.axisRange) ?? 'auto';
 
-  const yAxisSplitNumber = isShortViewport ? 2 : 5;
-
   const leftYAxis = TimeSeriesWidgetYAxis(
     {
-      splitNumber: yAxisSplitNumber,
       axisLabel: {
         formatter: (value: number) =>
           formatYAxisValue(value, leftYAxisType, unitForType[leftYAxisType] ?? undefined),
@@ -271,7 +266,6 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
   const rightYAxis = rightYAxisType
     ? TimeSeriesWidgetYAxis(
         {
-          splitNumber: yAxisSplitNumber,
           axisLabel: {
             formatter: (value: number) =>
               formatYAxisValue(


### PR DESCRIPTION
Removes the tieing of split numbers to the viewport. The behavior on very small screens is now arguably maybe perhaps slightly worse, but it's more predictable - and very small charts are pretty unreadable anyway. 

<table>
<thead>
<tr>
<th>Viewport Height</th>
<th>Before</th>
<th>Now</th>
</tr>
</thead>
<tbody>
<tr>
<td>Normal</td>
<td>
<img width="368" height="193" alt="image" src="https://github.com/user-attachments/assets/b31035bd-5932-46a0-aef3-8734887fd3ee" />
</td>
<td><em>(same)</em></td>
</tr>
<tr>
<td>smol</td>
<td>
<img width="368" height="193" alt="image" src="https://github.com/user-attachments/assets/6f4fc58a-1b5b-40b7-b1dc-877b0aeefb76" />
</td>
<td>
<img width="368" height="193" alt="image" src="https://github.com/user-attachments/assets/cf969a5a-9576-4bd6-b371-bfd3579061c9" />
</td>
</tr>
</tbody>
</table>

Fixes LOGS-722