### PR TITLE
test(replays): fix flaky test_export_replay_row_set 

### DIFF
--- a/tests/sentry/replays/integration/test_data_export.py
+++ b/tests/sentry/replays/integration/test_data_export.py
@@ -48,7 +48,7 @@ def test_export_replay_row_set(replay_store) -> None:  # type: ignore[no-untyped
     replay1_id = "030c5419-9e0f-46eb-ae18-bfe5fd0331b5"
     replay2_id = "0dbda2b3-9286-4ecc-a409-aa32b241563d"
     replay3_id = "ff08c103-a9a4-47c0-9c29-73b932c2da34"
-    t0 = datetime.datetime(year=2025, month=1, day=1)
+    t0 = datetime.datetime.utcnow().replace(second=0, microsecond=0) - datetime.timedelta(hours=1)
     t1 = t0 + datetime.timedelta(seconds=30)
     t2 = t0 + datetime.timedelta(minutes=1)
 


### PR DESCRIPTION
fixes https://sentry.sentry.io/issues/6918185853/events/?alert_rule_id=14448768&project=2423079 / SENTRY-TESTS-19MW

`t0` was hardcoded to `datetime(2025, 1, 1)`, so replay rows written at that timestamp fell outside the export query window once wall-clock time passed that date, causing `assert 2 == 3` failures.

Replaced with `utcnow() - 1 hour` so the test data is always recent relative to when the test runs.