### PR TITLE
fix(seer): avoid stale `runId`

### DIFF
--- a/static/app/views/seerExplorer/components/drawer/useSeerExplorerDrawer.tsx
+++ b/static/app/views/seerExplorer/components/drawer/useSeerExplorerDrawer.tsx
@@ -66,6 +66,9 @@ export const useSeerExplorerDrawer = ({
         return;
       }
 
+      const nextRunId =
+        openRunId === undefined ? (startNewRun ? null : runId) : openRunId;
+
       if (openRunId !== undefined) {
         setRunId(openRunId);
       } else if (startNewRun) {
@@ -76,7 +79,7 @@ export const useSeerExplorerDrawer = ({
         () => (
           <ExplorerDrawerContent
             getPageReferrer={getPageReferrer}
-            runId={runId}
+            runId={nextRunId}
             setRunId={setRunId}
           />
         ),


### PR DESCRIPTION
Follow-up on https://github.com/getsentry/sentry/pull/113727#discussion_r3126813602

At useSeerExplorerDrawer.tsx:75-82, the renderer passed to openDrawer closes over the runId variable from the current useCallback closure. setRunId(openRunId) is an asynchronous state update on the context-level runId (stored in useSessionStorage one level up in SeerExplorerContextProvider), so at the moment openDrawer runs, runId in the closure is still the previous value — null on first open, or a stale session id otherwise.