### PR TITLE
chore(aci): Unschedule prune_old_open_period_activity

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1021,10 +1021,6 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
         "task": "workflow_engine:sentry.workflow_engine.tasks.workflows.schedule_delayed_workflows",
         "schedule": timedelta(seconds=15),
     },
-    "prune-old-open-period-activity": {
-        "task": "workflow_engine:sentry.workflow_engine.tasks.cleanup.prune_old_open_period_activity",
-        "schedule": timedelta(minutes=2),
-    },
     "resolve-stale-sourcemap-detectors": {
         "task": "workflow_engine:sentry.processing_errors.tasks.resolve_stale_sourcemap_detectors",
         "schedule": crontab("*/5", "*", "*", "*", "*"),


### PR DESCRIPTION
The GroupOpenPeriodActivity cleanup should now be handled by incinerator, so we can stop running the task.
Actual task removal to happen in a follow-up.
