### PR TITLE
feat(seer): Add batch-endpoint mode to supergroups lightweight backfill

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1419,6 +1419,12 @@ register(
     default=20,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "seer.supergroups_backfill_lightweight.use_batch_endpoint",
+    type=Bool,
+    default=False,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # ## sentry.killswitches
 #

--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -433,6 +433,18 @@ class LightweightRCAClusterRequest(TypedDict):
     project_id: int
 
 
+class BatchLightweightRCAClusterItem(TypedDict):
+    group_id: int
+    project_id: int
+    issue: dict[str, Any]
+    trace_tree: NotRequired[dict[str, Any] | None]
+
+
+class BatchLightweightRCAClusterRequest(TypedDict):
+    organization_id: int
+    items: list[BatchLightweightRCAClusterItem]
+
+
 class SupergroupsGetRequest(TypedDict):
     organization_id: int
     supergroup_id: int
@@ -568,6 +580,20 @@ def make_lightweight_rca_cluster_request(
     return make_signed_seer_api_request(
         seer_autofix_default_connection_pool,
         "/v0/issues/supergroups/cluster-lightweight",
+        body=orjson.dumps(body, option=orjson.OPT_NON_STR_KEYS),
+        timeout=timeout,
+        viewer_context=viewer_context,
+    )
+
+
+def make_batch_lightweight_rca_cluster_request(
+    body: BatchLightweightRCAClusterRequest,
+    timeout: int | float | None = None,
+    viewer_context: SeerViewerContext | None = None,
+) -> BaseHTTPResponse:
+    return make_signed_seer_api_request(
+        seer_autofix_default_connection_pool,
+        "/v0/issues/supergroups/cluster-lightweight/batch",
         body=orjson.dumps(body, option=orjson.OPT_NON_STR_KEYS),
         timeout=timeout,
         viewer_context=viewer_context,

--- a/src/sentry/tasks/seer/backfill_supergroups_lightweight.py
+++ b/src/sentry/tasks/seer/backfill_supergroups_lightweight.py
@@ -11,8 +11,11 @@ from sentry.models.group import DEFAULT_TYPE_ID, Group, GroupStatus
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.seer.signed_seer_api import (
+    BatchLightweightRCAClusterItem,
+    BatchLightweightRCAClusterRequest,
     LightweightRCAClusterRequest,
     SeerViewerContext,
+    make_batch_lightweight_rca_cluster_request,
     make_lightweight_rca_cluster_request,
 )
 from sentry.services.eventstore.models import Event
@@ -153,61 +156,16 @@ def _backfill_org(
     # Phase 1: Batch fetch event data
     group_event_pairs = _batch_fetch_events(groups, organization_id)
 
-    # Phase 2: Send to Seer (per-group for now, bulk-ready)
-    failure_count = 0
-    success_count = 0
-    last_processed_group_id = last_group_id
+    # Phase 2: Send to Seer
     viewer_context = SeerViewerContext(organization_id=organization_id)
+    use_batch_endpoint = options.get("seer.supergroups_backfill_lightweight.use_batch_endpoint")
 
-    for group, serialized_event in group_event_pairs:
-        try:
-            body = LightweightRCAClusterRequest(
-                group_id=group.id,
-                issue={
-                    "id": group.id,
-                    "title": group.title,
-                    "short_id": group.qualified_short_id,
-                    "events": [serialized_event],
-                },
-                organization_slug=organization.slug,
-                organization_id=organization_id,
-                project_id=group.project_id,
-            )
-            response = make_lightweight_rca_cluster_request(
-                body, timeout=30, viewer_context=viewer_context
-            )
-            if response.status >= 400:
-                logger.warning(
-                    "supergroups_backfill_lightweight.seer_error",
-                    extra={
-                        "group_id": group.id,
-                        "project_id": group.project_id,
-                        "status": response.status,
-                    },
-                )
-                failure_count += 1
-            else:
-                success_count += 1
-        except Exception:
-            logger.exception(
-                "supergroups_backfill_lightweight.group_failed",
-                extra={"group_id": group.id, "project_id": group.project_id},
-            )
-            failure_count += 1
-
-        last_processed_group_id = group.id
-
-        if max_failures_per_batch > 0 and failure_count >= max_failures_per_batch:
-            logger.error(
-                "supergroups_backfill_lightweight.max_failures_reached",
-                extra={
-                    "organization_id": organization_id,
-                    "project_id": project.id,
-                    "failure_count": failure_count,
-                    "last_processed_group_id": last_processed_group_id,
-                },
-            )
-            break
+    if use_batch_endpoint:
+        success_count, failure_count = _send_batch(group_event_pairs, organization, viewer_context)
+    else:
+        success_count, failure_count = _send_per_group(
+            group_event_pairs, organization, viewer_context, max_failures_per_batch, project.id
+        )
 
     metrics.incr(
         "seer.supergroups_backfill_lightweight.groups_processed",
@@ -332,3 +290,119 @@ def _batch_fetch_events(groups: Sequence[Group], organization_id: int) -> list[t
         for group, serialized_event in zip(valid_groups, serialized_events)
         if serialized_event
     ]
+
+
+def _send_per_group(
+    group_event_pairs: Sequence[tuple[Group, dict]],
+    organization: Organization,
+    viewer_context: SeerViewerContext,
+    max_failures_per_batch: int,
+    project_id: int,
+) -> tuple[int, int]:
+    success_count = 0
+    failure_count = 0
+    last_processed_group_id = 0
+
+    for group, serialized_event in group_event_pairs:
+        try:
+            body = LightweightRCAClusterRequest(
+                group_id=group.id,
+                issue={
+                    "id": group.id,
+                    "title": group.title,
+                    "short_id": group.qualified_short_id,
+                    "events": [serialized_event],
+                },
+                organization_slug=organization.slug,
+                organization_id=organization.id,
+                project_id=group.project_id,
+            )
+            response = make_lightweight_rca_cluster_request(
+                body, timeout=30, viewer_context=viewer_context
+            )
+            if response.status >= 400:
+                logger.warning(
+                    "supergroups_backfill_lightweight.seer_error",
+                    extra={
+                        "group_id": group.id,
+                        "project_id": group.project_id,
+                        "status": response.status,
+                    },
+                )
+                failure_count += 1
+            else:
+                success_count += 1
+        except Exception:
+            logger.exception(
+                "supergroups_backfill_lightweight.group_failed",
+                extra={"group_id": group.id, "project_id": group.project_id},
+            )
+            failure_count += 1
+
+        last_processed_group_id = group.id
+
+        if max_failures_per_batch > 0 and failure_count >= max_failures_per_batch:
+            logger.error(
+                "supergroups_backfill_lightweight.max_failures_reached",
+                extra={
+                    "organization_id": organization.id,
+                    "project_id": project_id,
+                    "failure_count": failure_count,
+                    "last_processed_group_id": last_processed_group_id,
+                },
+            )
+            break
+
+    return success_count, failure_count
+
+
+def _send_batch(
+    group_event_pairs: Sequence[tuple[Group, dict]],
+    organization: Organization,
+    viewer_context: SeerViewerContext,
+) -> tuple[int, int]:
+    if not group_event_pairs:
+        return 0, 0
+
+    items: list[BatchLightweightRCAClusterItem] = [
+        BatchLightweightRCAClusterItem(
+            group_id=group.id,
+            project_id=group.project_id,
+            issue={
+                "id": group.id,
+                "title": group.title,
+                "short_id": group.qualified_short_id,
+                "events": [serialized_event],
+            },
+            trace_tree=None,
+        )
+        for group, serialized_event in group_event_pairs
+    ]
+    batch_len = len(items)
+    body = BatchLightweightRCAClusterRequest(
+        organization_id=organization.id,
+        items=items,
+    )
+
+    try:
+        response = make_batch_lightweight_rca_cluster_request(
+            body, timeout=30, viewer_context=viewer_context
+        )
+        if response.status >= 400:
+            logger.warning(
+                "supergroups_backfill_lightweight.seer_error",
+                extra={
+                    "organization_id": organization.id,
+                    "status": response.status,
+                    "batch_size": batch_len,
+                    "mode": "batch",
+                },
+            )
+            return 0, batch_len
+        return batch_len, 0
+    except Exception:
+        logger.exception(
+            "supergroups_backfill_lightweight.batch_failed",
+            extra={"organization_id": organization.id, "batch_size": batch_len},
+        )
+        return 0, batch_len

--- a/tests/sentry/tasks/seer/test_backfill_supergroups_lightweight.py
+++ b/tests/sentry/tasks/seer/test_backfill_supergroups_lightweight.py
@@ -259,6 +259,90 @@ class BackfillSupergroupsLightweightForOrgTest(TestCase):
 
     @with_feature("organizations:supergroups-lightweight-rca-clustering-write")
     @patch(
+        "sentry.tasks.seer.backfill_supergroups_lightweight.make_batch_lightweight_rca_cluster_request"
+    )
+    @patch(
+        "sentry.tasks.seer.backfill_supergroups_lightweight.make_lightweight_rca_cluster_request"
+    )
+    def test_batch_mode_sends_single_request(self, mock_per_group, mock_batch):
+        mock_batch.return_value = MagicMock(status=200)
+
+        for i in range(2):
+            evt = self.store_event(
+                data={"message": f"err {i}", "level": "error", "fingerprint": [f"batch-{i}"]},
+                project_id=self.project.id,
+            )
+            assert evt.group is not None
+            evt.group.substatus = GroupSubStatus.NEW
+            evt.group.save(update_fields=["substatus"])
+
+        with self.options({"seer.supergroups_backfill_lightweight.use_batch_endpoint": True}):
+            backfill_supergroups_lightweight_for_org(self.organization.id)
+
+        mock_per_group.assert_not_called()
+        mock_batch.assert_called_once()
+        body = mock_batch.call_args.args[0]
+        assert body["organization_id"] == self.organization.id
+        assert len(body["items"]) == 3
+        for item in body["items"]:
+            assert item["project_id"] == self.project.id
+            assert "events" in item["issue"]
+            assert item["trace_tree"] is None
+
+    @with_feature("organizations:supergroups-lightweight-rca-clustering-write")
+    @patch(
+        "sentry.tasks.seer.backfill_supergroups_lightweight.make_batch_lightweight_rca_cluster_request"
+    )
+    def test_batch_mode_counts_all_items_as_failed_on_http_error(self, mock_batch):
+        mock_batch.return_value = MagicMock(status=500)
+
+        for i in range(2):
+            evt = self.store_event(
+                data={"message": f"err {i}", "level": "error", "fingerprint": [f"batch-err-{i}"]},
+                project_id=self.project.id,
+            )
+            assert evt.group is not None
+            evt.group.substatus = GroupSubStatus.NEW
+            evt.group.save(update_fields=["substatus"])
+
+        with (
+            self.options(
+                {
+                    "seer.supergroups_backfill_lightweight.use_batch_endpoint": True,
+                    "seer.supergroups_backfill_lightweight.max_failures_per_batch": 2,
+                }
+            ),
+            patch(
+                "sentry.tasks.seer.backfill_supergroups_lightweight.backfill_supergroups_lightweight_for_org.apply_async"
+            ) as mock_chain,
+        ):
+            backfill_supergroups_lightweight_for_org(self.organization.id)
+
+            mock_batch.assert_called_once()
+            # Batch failure count (3 items) exceeds max_failures_per_batch (2), so no chaining
+            mock_chain.assert_not_called()
+
+    @with_feature("organizations:supergroups-lightweight-rca-clustering-write")
+    @patch(
+        "sentry.tasks.seer.backfill_supergroups_lightweight.make_batch_lightweight_rca_cluster_request"
+    )
+    def test_batch_mode_skips_seer_call_when_no_events(self, mock_batch):
+        self.group.last_seen = datetime.now(UTC) - timedelta(days=91)
+        self.group.save(update_fields=["last_seen"])
+
+        with (
+            self.options({"seer.supergroups_backfill_lightweight.use_batch_endpoint": True}),
+            patch(
+                "sentry.tasks.seer.backfill_supergroups_lightweight.bulk_snuba_queries"
+            ) as mock_snuba,
+        ):
+            mock_snuba.return_value = [{"data": []}]
+            backfill_supergroups_lightweight_for_org(self.organization.id)
+
+        mock_batch.assert_not_called()
+
+    @with_feature("organizations:supergroups-lightweight-rca-clustering-write")
+    @patch(
         "sentry.tasks.seer.backfill_supergroups_lightweight.make_lightweight_rca_cluster_request"
     )
     def test_chains_then_completes_on_exact_batch_boundary(self, mock_request):


### PR DESCRIPTION
Adds an opt-in toggle to the supergroups lightweight RCA backfill task so each batch of groups is sent to Seer's new batch clustering endpoint (`POST /v0/issues/supergroups/cluster-lightweight/batch`) in a single request, instead of one per group. Per-group remains the default.

Gated by new option `seer.supergroups_backfill_lightweight.use_batch_endpoint` (default `False`). Metrics/logging/cursor/`max_failures_per_batch` are shared between both paths; an HTTP failure in batch mode counts every item as failed, composing naturally with the existing gate.