### PR TITLE
fix(explorer): fix  broken runId state

### DIFF
--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.spec.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.spec.tsx
@@ -55,46 +55,25 @@ describe('ExplorerDrawerContent', () => {
 
   describe('Empty State', () => {
     it('renders the drawer root element', () => {
-      render(
-        <ExplorerDrawerContent
-          getPageReferrer={mockGetPageReferrer}
-          runId={null}
-          setRunId={jest.fn()}
-        />,
-        {
-          organization,
-        }
-      );
+      render(<ExplorerDrawerContent getPageReferrer={mockGetPageReferrer} />, {
+        organization,
+      });
       expect(document.querySelector('[data-seer-explorer-root]')).toBeInTheDocument();
     });
 
     it('shows empty state when no messages exist', async () => {
-      render(
-        <ExplorerDrawerContent
-          getPageReferrer={mockGetPageReferrer}
-          runId={null}
-          setRunId={jest.fn()}
-        />,
-        {
-          organization,
-        }
-      );
+      render(<ExplorerDrawerContent getPageReferrer={mockGetPageReferrer} />, {
+        organization,
+      });
       expect(
         await screen.findByText('Ask Seer anything about your application.')
       ).toBeInTheDocument();
     });
 
     it('shows input', async () => {
-      render(
-        <ExplorerDrawerContent
-          getPageReferrer={mockGetPageReferrer}
-          runId={null}
-          setRunId={jest.fn()}
-        />,
-        {
-          organization,
-        }
-      );
+      render(<ExplorerDrawerContent getPageReferrer={mockGetPageReferrer} />, {
+        organization,
+      });
       expect(
         await screen.findByPlaceholderText(
           'Ask seer a question, or press / for commands.'
@@ -109,16 +88,9 @@ describe('ExplorerDrawerContent', () => {
         sendMessage,
       });
 
-      render(
-        <ExplorerDrawerContent
-          getPageReferrer={mockGetPageReferrer}
-          runId={null}
-          setRunId={jest.fn()}
-        />,
-        {
-          organization,
-        }
-      );
+      render(<ExplorerDrawerContent getPageReferrer={mockGetPageReferrer} />, {
+        organization,
+      });
 
       const suggestion = await screen.findByRole('button', {
         name: 'Which of my open issues are getting worse, not better?',
@@ -137,16 +109,9 @@ describe('ExplorerDrawerContent', () => {
         isError: true,
       });
 
-      render(
-        <ExplorerDrawerContent
-          getPageReferrer={mockGetPageReferrer}
-          runId={123}
-          setRunId={jest.fn()}
-        />,
-        {
-          organization,
-        }
-      );
+      render(<ExplorerDrawerContent getPageReferrer={mockGetPageReferrer} />, {
+        organization,
+      });
 
       expect(
         await screen.findByText('Error loading this session (ID=123).')
@@ -182,16 +147,9 @@ describe('ExplorerDrawerContent', () => {
         } as useSeerExplorerModule.SeerExplorerResponse['session'],
       });
 
-      render(
-        <ExplorerDrawerContent
-          getPageReferrer={mockGetPageReferrer}
-          runId={null}
-          setRunId={jest.fn()}
-        />,
-        {
-          organization,
-        }
-      );
+      render(<ExplorerDrawerContent getPageReferrer={mockGetPageReferrer} />, {
+        organization,
+      });
 
       expect(await screen.findByText('What is this error?')).toBeInTheDocument();
       expect(screen.getByText('This is a null pointer exception.')).toBeInTheDocument();
@@ -203,16 +161,9 @@ describe('ExplorerDrawerContent', () => {
 
   describe('Input Handling', () => {
     it('can type in the textarea', async () => {
-      render(
-        <ExplorerDrawerContent
-          getPageReferrer={mockGetPageReferrer}
-          runId={null}
-          setRunId={jest.fn()}
-        />,
-        {
-          organization,
-        }
-      );
+      render(<ExplorerDrawerContent getPageReferrer={mockGetPageReferrer} />, {
+        organization,
+      });
       const textarea = await screen.findByTestId('seer-explorer-input');
       await userEvent.type(textarea, 'Test message');
       expect(textarea).toHaveValue('Test message');
@@ -225,16 +176,9 @@ describe('ExplorerDrawerContent', () => {
         sendMessage,
       });
 
-      render(
-        <ExplorerDrawerContent
-          getPageReferrer={mockGetPageReferrer}
-          runId={null}
-          setRunId={jest.fn()}
-        />,
-        {
-          organization,
-        }
-      );
+      render(<ExplorerDrawerContent getPageReferrer={mockGetPageReferrer} />, {
+        organization,
+      });
 
       const textarea = await screen.findByTestId('seer-explorer-input');
       await userEvent.type(textarea, 'Test message');
@@ -298,16 +242,9 @@ describe('ExplorerDrawerContent', () => {
         },
       });
 
-      render(
-        <ExplorerDrawerContent
-          getPageReferrer={mockGetPageReferrer}
-          runId={null}
-          setRunId={jest.fn()}
-        />,
-        {
-          organization,
-        }
-      );
+      render(<ExplorerDrawerContent getPageReferrer={mockGetPageReferrer} />, {
+        organization,
+      });
 
       const textarea = await screen.findByTestId('seer-explorer-input');
       await userEvent.type(textarea, 'What is this error?');
@@ -329,16 +266,9 @@ describe('ExplorerDrawerContent', () => {
         sendMessage,
       });
 
-      render(
-        <ExplorerDrawerContent
-          getPageReferrer={mockGetPageReferrer}
-          runId={null}
-          setRunId={jest.fn()}
-        />,
-        {
-          organization,
-        }
-      );
+      render(<ExplorerDrawerContent getPageReferrer={mockGetPageReferrer} />, {
+        organization,
+      });
 
       await screen.findByTestId('seer-explorer-input');
       await userEvent.keyboard('{Enter}');
@@ -354,16 +284,9 @@ describe('ExplorerDrawerContent', () => {
         isPolling: true,
       });
 
-      render(
-        <ExplorerDrawerContent
-          getPageReferrer={mockGetPageReferrer}
-          runId={null}
-          setRunId={jest.fn()}
-        />,
-        {
-          organization,
-        }
-      );
+      render(<ExplorerDrawerContent getPageReferrer={mockGetPageReferrer} />, {
+        organization,
+      });
 
       const textarea = await screen.findByTestId('seer-explorer-input');
       await userEvent.type(textarea, 'Test message');
@@ -387,16 +310,9 @@ describe('ExplorerDrawerContent', () => {
         } as useSeerExplorerModule.SeerExplorerResponse['session'],
       });
 
-      render(
-        <ExplorerDrawerContent
-          getPageReferrer={mockGetPageReferrer}
-          runId={null}
-          setRunId={jest.fn()}
-        />,
-        {
-          organization,
-        }
-      );
+      render(<ExplorerDrawerContent getPageReferrer={mockGetPageReferrer} />, {
+        organization,
+      });
 
       const textarea = await screen.findByTestId('seer-explorer-input');
       await waitFor(() => expect(textarea).toBeDisabled());
@@ -419,16 +335,9 @@ describe('ExplorerDrawerContent', () => {
         } as useSeerExplorerModule.SeerExplorerResponse['session'],
       });
 
-      render(
-        <ExplorerDrawerContent
-          getPageReferrer={mockGetPageReferrer}
-          runId={null}
-          setRunId={jest.fn()}
-        />,
-        {
-          organization,
-        }
-      );
+      render(<ExplorerDrawerContent getPageReferrer={mockGetPageReferrer} />, {
+        organization,
+      });
 
       const textarea = await screen.findByTestId('seer-explorer-input');
       await waitFor(() => expect(textarea).toBeEnabled());
@@ -451,16 +360,9 @@ describe('ExplorerDrawerContent', () => {
         } as useSeerExplorerModule.SeerExplorerResponse['session'],
       });
 
-      render(
-        <ExplorerDrawerContent
-          getPageReferrer={mockGetPageReferrer}
-          runId={null}
-          setRunId={jest.fn()}
-        />,
-        {
-          organization,
-        }
-      );
+      render(<ExplorerDrawerContent getPageReferrer={mockGetPageReferrer} />, {
+        organization,
+      });
 
       const textarea = await screen.findByTestId('seer-explorer-input');
       await waitFor(() => expect(textarea).toBeEnabled());
@@ -474,16 +376,9 @@ describe('ExplorerDrawerContent', () => {
     });
 
     it('does not show toggle without the feature flag', async () => {
-      render(
-        <ExplorerDrawerContent
-          getPageReferrer={mockGetPageReferrer}
-          runId={null}
-          setRunId={jest.fn()}
-        />,
-        {
-          organization,
-        }
-      );
+      render(<ExplorerDrawerContent getPageReferrer={mockGetPageReferrer} />, {
+        organization,
+      });
       await screen.findByTestId('seer-explorer-input');
       expect(
         screen.queryByRole('checkbox', {name: 'Toggle context engine'})
@@ -491,16 +386,9 @@ describe('ExplorerDrawerContent', () => {
     });
 
     it('shows toggle when feature flag is enabled', async () => {
-      render(
-        <ExplorerDrawerContent
-          getPageReferrer={mockGetPageReferrer}
-          runId={null}
-          setRunId={jest.fn()}
-        />,
-        {
-          organization: orgWithFlag,
-        }
-      );
+      render(<ExplorerDrawerContent getPageReferrer={mockGetPageReferrer} />, {
+        organization: orgWithFlag,
+      });
       expect(
         await screen.findByRole('checkbox', {name: 'Toggle context engine'})
       ).toBeInTheDocument();

--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
@@ -28,12 +28,8 @@ import {
 
 export function ExplorerDrawerContent({
   getPageReferrer,
-  runId,
-  setRunId,
 }: {
   getPageReferrer: () => string;
-  runId: number | null;
-  setRunId: (value: number | null) => void;
 }) {
   const organization = useOrganization({allowNull: true});
   const {projects} = useProjects();
@@ -58,6 +54,7 @@ export function ExplorerDrawerContent({
 
   // - Session data and mutators ----------------------------------------------
   const {
+    runId,
     sessionData,
     isPolling,
     isError,
@@ -72,7 +69,7 @@ export function ExplorerDrawerContent({
     setOverrideCtxEngEnable,
     overrideCodeModeEnable,
     setOverrideCodeModeEnable,
-  } = useSeerExplorer({runId, setRunId});
+  } = useSeerExplorer();
 
   const readOnly =
     sessionData?.owner_user_id !== undefined &&

--- a/static/app/views/seerExplorer/components/drawer/useSeerExplorerDrawer.spec.tsx
+++ b/static/app/views/seerExplorer/components/drawer/useSeerExplorerDrawer.spec.tsx
@@ -8,16 +8,7 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import {sessionStorageWrapper} from 'sentry/utils/sessionStorage';
-import {useSessionStorage} from 'sentry/utils/useSessionStorage';
 import {useSeerExplorerDrawer} from 'sentry/views/seerExplorer/components/drawer/useSeerExplorerDrawer';
-
-function useTestSeerExplorerDrawer() {
-  const [runId, setRunId] = useSessionStorage<number | null>(
-    'seer-explorer-run-id',
-    null
-  );
-  return useSeerExplorerDrawer({runId, setRunId});
-}
 
 jest.mock('sentry/views/seerExplorer/components/drawer/explorerDrawerContent', () => ({
   ExplorerDrawerContent: () => <div data-seer-explorer-root="" />,
@@ -51,7 +42,7 @@ describe('useSeerExplorerDrawer', () => {
 
   describe('openSeerExplorerDrawer', () => {
     it('opens the Seer Explorer drawer', async () => {
-      const {result} = renderHookWithProviders(() => useTestSeerExplorerDrawer(), {
+      const {result} = renderHookWithProviders(() => useSeerExplorerDrawer(), {
         organization: enabledOrg,
       });
 
@@ -62,7 +53,7 @@ describe('useSeerExplorerDrawer', () => {
     });
 
     it('sets isOpen to true after opening', async () => {
-      const {result} = renderHookWithProviders(() => useTestSeerExplorerDrawer(), {
+      const {result} = renderHookWithProviders(() => useSeerExplorerDrawer(), {
         organization: enabledOrg,
       });
 
@@ -72,7 +63,7 @@ describe('useSeerExplorerDrawer', () => {
     });
 
     it('seeds sessionStorage with runId when provided', () => {
-      const {result} = renderHookWithProviders(() => useTestSeerExplorerDrawer(), {
+      const {result} = renderHookWithProviders(() => useSeerExplorerDrawer(), {
         organization: enabledOrg,
       });
 
@@ -84,7 +75,7 @@ describe('useSeerExplorerDrawer', () => {
     it('clears runId when startNewRun is true', () => {
       sessionStorageWrapper.setItem('seer-explorer-run-id', '42');
 
-      const {result} = renderHookWithProviders(() => useTestSeerExplorerDrawer(), {
+      const {result} = renderHookWithProviders(() => useSeerExplorerDrawer(), {
         organization: enabledOrg,
       });
 
@@ -99,7 +90,7 @@ describe('useSeerExplorerDrawer', () => {
     it('does not touch sessionStorage when no options provided', () => {
       sessionStorageWrapper.setItem('seer-explorer-run-id', '55');
 
-      const {result} = renderHookWithProviders(() => useTestSeerExplorerDrawer(), {
+      const {result} = renderHookWithProviders(() => useSeerExplorerDrawer(), {
         organization: enabledOrg,
       });
 
@@ -111,7 +102,7 @@ describe('useSeerExplorerDrawer', () => {
 
   describe('closeSeerExplorerDrawer', () => {
     it('is a no-op when the drawer is not open', () => {
-      const {result} = renderHookWithProviders(() => useTestSeerExplorerDrawer(), {
+      const {result} = renderHookWithProviders(() => useSeerExplorerDrawer(), {
         organization: enabledOrg,
       });
 
@@ -124,7 +115,7 @@ describe('useSeerExplorerDrawer', () => {
     });
 
     it('closes the drawer when open', async () => {
-      const {result} = renderHookWithProviders(() => useTestSeerExplorerDrawer(), {
+      const {result} = renderHookWithProviders(() => useSeerExplorerDrawer(), {
         organization: enabledOrg,
       });
 
@@ -140,7 +131,7 @@ describe('useSeerExplorerDrawer', () => {
 
   describe('toggleSeerExplorerDrawer', () => {
     it('opens the drawer when closed', async () => {
-      const {result} = renderHookWithProviders(() => useTestSeerExplorerDrawer(), {
+      const {result} = renderHookWithProviders(() => useSeerExplorerDrawer(), {
         organization: enabledOrg,
       });
 
@@ -150,7 +141,7 @@ describe('useSeerExplorerDrawer', () => {
     });
 
     it('closes the drawer when open', async () => {
-      const {result} = renderHookWithProviders(() => useTestSeerExplorerDrawer(), {
+      const {result} = renderHookWithProviders(() => useSeerExplorerDrawer(), {
         organization: enabledOrg,
       });
 

--- a/static/app/views/seerExplorer/components/drawer/useSeerExplorerDrawer.tsx
+++ b/static/app/views/seerExplorer/components/drawer/useSeerExplorerDrawer.tsx
@@ -4,6 +4,7 @@ import {useDrawer} from '@sentry/scraps/drawer';
 
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {sessionStorageWrapper} from 'sentry/utils/sessionStorage';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {ExplorerDrawerContent} from 'sentry/views/seerExplorer/components/drawer/explorerDrawerContent';
 import {isSeerExplorerEnabled, usePageReferrer} from 'sentry/views/seerExplorer/utils';
@@ -21,13 +22,7 @@ export type OpenSeerExplorerDrawerOptions = {
   startNewRun?: boolean;
 };
 
-export const useSeerExplorerDrawer = ({
-  runId,
-  setRunId,
-}: {
-  runId: number | null;
-  setRunId: (value: number | null) => void;
-}) => {
+export const useSeerExplorerDrawer = () => {
   const organization = useOrganization({allowNull: true});
 
   const {openDrawer, closeDrawer, isDrawerOpen} = useDrawer();
@@ -59,37 +54,33 @@ export const useSeerExplorerDrawer = ({
 
   const openSeerExplorerDrawer = useCallback(
     (options?: OpenSeerExplorerDrawerOptions) => {
-      const {runId: openRunId, startNewRun} = options ?? {};
-
       if (isDrawerOpenRef.current) {
-        // TODO: setting runId while drawer is open can lead to broken UI state, need to use switchToRun within DrawerContent
+        // runId seeding doesn't work when the drawer is already open
         return;
       }
 
-      if (openRunId !== undefined) {
-        setRunId(openRunId);
-      } else if (startNewRun) {
-        setRunId(null);
+      const {runId, startNewRun} = options ?? {};
+
+      // Seed runId state with sessionStorage, before rendering drawer
+      try {
+        if (runId !== undefined) {
+          sessionStorageWrapper.setItem('seer-explorer-run-id', JSON.stringify(runId));
+        } else if (startNewRun) {
+          sessionStorageWrapper.removeItem('seer-explorer-run-id');
+        }
+      } catch {
+        // Best effort
       }
 
-      openDrawer(
-        () => (
-          <ExplorerDrawerContent
-            getPageReferrer={getPageReferrer}
-            runId={runId}
-            setRunId={setRunId}
-          />
-        ),
-        {
-          ariaLabel: t('Seer Explorer Drawer'),
-          drawerKey: 'seer-explorer-drawer',
-          resizable: true,
-          mode: 'passive',
-          onOpen,
-        }
-      );
+      openDrawer(() => <ExplorerDrawerContent getPageReferrer={getPageReferrer} />, {
+        ariaLabel: t('Seer Explorer Drawer'),
+        drawerKey: 'seer-explorer-drawer',
+        resizable: true,
+        mode: 'passive',
+        onOpen,
+      });
     },
-    [openDrawer, onOpen, getPageReferrer, runId, setRunId]
+    [openDrawer, onOpen, getPageReferrer]
   );
 
   const toggleSeerExplorerDrawer = useCallback(() => {

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
@@ -1,4 +1,3 @@
-import {useState} from 'react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -7,12 +6,6 @@ import {useLLMContext} from 'sentry/views/seerExplorer/contexts/llmContext';
 import {usePageReferrer} from 'sentry/views/seerExplorer/utils';
 
 import {useSeerExplorer} from './useSeerExplorer';
-
-// Wrapper that owns runId state
-function useTestSeerExplorer() {
-  const [runId, setRunId] = useState<number | null>(null);
-  return useSeerExplorer({runId, setRunId});
-}
 
 jest.mock('sentry/views/seerExplorer/utils', () => ({
   ...jest.requireActual('sentry/views/seerExplorer/utils'),
@@ -43,7 +36,7 @@ describe('useSeerExplorer', () => {
 
   describe('Initial State', () => {
     it('returns initial state with no session data', () => {
-      const {result} = renderHookWithProviders(() => useTestSeerExplorer(), {
+      const {result} = renderHookWithProviders(() => useSeerExplorer(), {
         organization,
       });
 
@@ -102,7 +95,7 @@ describe('useSeerExplorer', () => {
         },
       });
 
-      const {result} = renderHookWithProviders(() => useTestSeerExplorer(), {
+      const {result} = renderHookWithProviders(() => useSeerExplorer(), {
         organization,
       });
 
@@ -150,7 +143,7 @@ describe('useSeerExplorer', () => {
         body: {session: {blocks: [], run_id: 1, status: 'completed', updated_at: ''}},
       });
 
-      const {result} = renderHookWithProviders(() => useTestSeerExplorer(), {
+      const {result} = renderHookWithProviders(() => useSeerExplorer(), {
         organization: org,
       });
       act(() => {
@@ -195,7 +188,7 @@ describe('useSeerExplorer', () => {
         body: {session: {blocks: [], run_id: 1, status: 'completed', updated_at: ''}},
       });
 
-      const {result} = renderHookWithProviders(() => useTestSeerExplorer(), {
+      const {result} = renderHookWithProviders(() => useSeerExplorer(), {
         organization: org,
       });
       act(() => {
@@ -229,7 +222,7 @@ describe('useSeerExplorer', () => {
         body: {session: {blocks: [], run_id: 1, status: 'completed', updated_at: ''}},
       });
 
-      const {result} = renderHookWithProviders(() => useTestSeerExplorer(), {
+      const {result} = renderHookWithProviders(() => useSeerExplorer(), {
         organization: org,
       });
       act(() => {
@@ -257,7 +250,7 @@ describe('useSeerExplorer', () => {
         body: {detail: 'Server error'},
       });
 
-      const {result} = renderHookWithProviders(() => useTestSeerExplorer(), {
+      const {result} = renderHookWithProviders(() => useSeerExplorer(), {
         organization,
       });
 
@@ -279,7 +272,7 @@ describe('useSeerExplorer', () => {
         body: {session: null},
       });
 
-      const {result} = renderHookWithProviders(() => useTestSeerExplorer(), {
+      const {result} = renderHookWithProviders(() => useSeerExplorer(), {
         organization,
       });
 
@@ -296,7 +289,7 @@ describe('useSeerExplorer', () => {
     const runId = 999;
 
     it('returns false for polling when no session exists', () => {
-      const {result} = renderHookWithProviders(() => useTestSeerExplorer(), {
+      const {result} = renderHookWithProviders(() => useSeerExplorer(), {
         organization,
       });
 
@@ -310,7 +303,7 @@ describe('useSeerExplorer', () => {
         body: {runId, session: {status: 'processing'}},
       });
 
-      const {result} = renderHookWithProviders(() => useTestSeerExplorer(), {
+      const {result} = renderHookWithProviders(() => useSeerExplorer(), {
         organization,
       });
       act(() => {
@@ -328,7 +321,7 @@ describe('useSeerExplorer', () => {
         body: {runId, session: {blocks: [{loading: true}]}},
       });
 
-      const {result} = renderHookWithProviders(() => useTestSeerExplorer(), {
+      const {result} = renderHookWithProviders(() => useSeerExplorer(), {
         organization,
       });
       act(() => {
@@ -349,7 +342,7 @@ describe('useSeerExplorer', () => {
         },
       });
 
-      const {result} = renderHookWithProviders(() => useTestSeerExplorer(), {
+      const {result} = renderHookWithProviders(() => useSeerExplorer(), {
         organization,
       });
       act(() => {
@@ -374,7 +367,7 @@ describe('useSeerExplorer', () => {
         },
       });
 
-      const {result} = renderHookWithProviders(() => useTestSeerExplorer(), {
+      const {result} = renderHookWithProviders(() => useSeerExplorer(), {
         organization,
       });
       act(() => {
@@ -412,7 +405,7 @@ describe('useSeerExplorer', () => {
         },
       });
 
-      const {result} = renderHookWithProviders(() => useTestSeerExplorer(), {
+      const {result} = renderHookWithProviders(() => useSeerExplorer(), {
         organization,
       });
 
@@ -454,7 +447,7 @@ describe('useSeerExplorer', () => {
         },
       });
 
-      const {result} = renderHookWithProviders(() => useTestSeerExplorer(), {
+      const {result} = renderHookWithProviders(() => useSeerExplorer(), {
         organization,
       });
 

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -13,6 +13,7 @@ import {
 import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {useSessionStorage} from 'sentry/utils/useSessionStorage';
 import {useLLMContext} from 'sentry/views/seerExplorer/contexts/llmContext';
 import {useAsciiSnapshot} from 'sentry/views/seerExplorer/hooks/useAsciiSnapshot';
 import {
@@ -110,13 +111,7 @@ const makeErrorSeerExplorerData = (errorMessage: string): SeerExplorerResponse =
   },
 });
 
-export const useSeerExplorer = ({
-  runId,
-  setRunId,
-}: {
-  runId: number | null;
-  setRunId: (runId: number | null) => void;
-}) => {
+export const useSeerExplorer = () => {
   const queryClient = useQueryClient();
   const organization = useOrganization({allowNull: true});
   const orgSlug = organization?.slug;
@@ -129,7 +124,11 @@ export const useSeerExplorer = ({
   const [overrideCodeModeEnable, setOverrideCodeModeEnable] =
     useLocalStorageState<boolean>('seer-explorer.override.code-mode', true);
 
-  // Support deep links that carry a run id; set it once and clean the URL.
+  const [runId, setRunId] = useSessionStorage<number | null>(
+    'seer-explorer-run-id',
+    null
+  );
+
   const {getPageReferrer} = usePageReferrer();
 
   const [waitingForInterrupt, setWaitingForInterrupt] = useState<boolean>(false);
@@ -315,11 +314,7 @@ export const useSeerExplorer = ({
 
   const isMutatePending = isPendingSendMessage || isPendingUserInput || isPendingCreatePR;
 
-  const {
-    apiData,
-    isError,
-    isPolling: isPollingNow,
-  } = useSeerExplorerPolling({runId, isMutatePending});
+  const {apiData, isError, isPolling} = useSeerExplorerPolling({runId, isMutatePending});
 
   /** Switches to a different run and fetches its latest state. */
   const switchToRun = useCallback(
@@ -327,6 +322,7 @@ export const useSeerExplorer = ({
       if (newRunId === runId) {
         return;
       }
+
       // Set the new run ID
       setRunId(newRunId);
 
@@ -581,7 +577,7 @@ export const useSeerExplorer = ({
 
   return {
     sessionData: filteredSessionData,
-    isPolling: isPollingNow,
+    isPolling,
     isError,
     sendMessage,
     runId,

--- a/static/app/views/seerExplorer/useSeerExplorerContext.tsx
+++ b/static/app/views/seerExplorer/useSeerExplorerContext.tsx
@@ -55,7 +55,7 @@ export function SeerExplorerContextProvider({children}: {children: ReactNode}) {
     closeSeerExplorerDrawer,
     toggleSeerExplorerDrawer,
     isOpen,
-  } = useSeerExplorerDrawer({runId, setRunId});
+  } = useSeerExplorerDrawer();
 
   // Observes the shared session query so the button can reflect activity even
   // when the drawer is closed. Shares the underlying query with


### PR DESCRIPTION
due to the open drawer callback, we can't pass outer state into drawer content. Fixes broken change session feature but temporarily breaks loading indicator