### PR TITLE
styles(explorer): Fix spacing in explorer block content

### DIFF
--- a/static/app/views/seerExplorer/components/blockComponents.tsx
+++ b/static/app/views/seerExplorer/components/blockComponents.tsx
@@ -655,10 +655,8 @@ const BlockContentWrapper = styled('div')<{hasOnlyTools?: boolean}>`
 const BlockContent = styled(MarkedText)`
   width: 100%;
   color: ${p => p.theme.tokens.content.primary};
-  white-space: pre-wrap;
   word-wrap: break-word;
   padding-bottom: 0;
-  margin-bottom: -${p => p.theme.space.md};
 
   code:not(pre code) {
     ${p => inlineCodeStyles(p.theme)};
@@ -668,7 +666,7 @@ const BlockContent = styled(MarkedText)`
   li,
   ul,
   ol {
-    margin: -${p => p.theme.space.md} 0;
+    margin: ${p => p.theme.space.md} 0;
   }
 
   h1,
@@ -677,7 +675,7 @@ const BlockContent = styled(MarkedText)`
   h4,
   h5,
   h6 {
-    margin: 0;
+    margin: ${p => p.theme.space.md} 0;
     font-size: ${p => p.theme.font.size.lg};
   }
 
@@ -699,16 +697,8 @@ const BlockContent = styled(MarkedText)`
     font-weight: ${p => p.theme.font.weight.sans.medium};
   }
 
-  p:first-child,
-  li:first-child,
-  ul:first-child,
-  h1:first-child,
-  h2:first-child,
-  h3:first-child,
-  h4:first-child,
-  h5:first-child,
-  h6:first-child {
-    margin-top: 0;
+  hr {
+    margin: ${p => p.theme.space.md} 0;
   }
 `;
 


### PR DESCRIPTION
When we translate markdown into html, new line characters are often inserted. Because of `white-space: pre-wrap`, they are preserved resulting in too much white space. This removes it and uses the default and adjusts the margins.

| Before | After |
| ------ | ----- |
| <img width="1196" height="1244" alt="image" src="https://github.com/user-attachments/assets/99e74feb-b8d7-495b-8bc8-be356f1b5a5d" /> | <img width="1274" height="1244" alt="image" src="https://github.com/user-attachments/assets/1d740c7f-5aad-41ee-8f7e-2d858c09ea53" /> |