### PR TITLE
chore(ACI): Return workflow response from issue alert POST and PUT endpoints

### DIFF
--- a/src/sentry/api/bases/rule.py
+++ b/src/sentry/api/bases/rule.py
@@ -56,9 +56,9 @@ class WorkflowEngineRuleEndpoint(RuleEndpoint):
             raise ResourceDoesNotExist
 
         method_flag = self.workflow_engine_method_flags.get(request.method or "")
-        use_workflow_engine = features.has(
-            "organizations:workflow-engine-rule-serializers", project.organization
-        ) or (method_flag is not None and features.has(method_flag, project.organization))
+        use_workflow_engine = method_flag is not None and features.has(
+            method_flag, project.organization
+        )
         if use_workflow_engine:
             try:
                 arw = AlertRuleWorkflow.objects.get(

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import cast
-
 import sentry_sdk
 from django.db import router, transaction
 from drf_spectacular.utils import extend_schema
@@ -9,15 +7,13 @@ from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import analytics, audit_log
+from sentry import analytics, audit_log, features
 from sentry.analytics.events.rule_reenable import RuleReenableEdit
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.rule import WorkflowEngineRuleEndpoint
 from sentry.api.endpoints.project_rules import (
-    ProjectRulePostData,
     find_duplicate_rule,
-    format_request_data,
 )
 from sentry.api.fields.actor import OwnerActorField
 from sentry.api.serializers import serialize
@@ -45,10 +41,8 @@ from sentry.rules.actions import trigger_sentry_app_action_creators_for_issues
 from sentry.sentry_apps.utils.errors import SentryAppBaseError
 from sentry.signals import alert_rule_edited
 from sentry.types.actor import Actor
-from sentry.workflow_engine.endpoints.validators.base.workflow import WorkflowValidator
 from sentry.workflow_engine.models.alertrule_workflow import AlertRuleWorkflow
 from sentry.workflow_engine.models.workflow import Workflow
-from sentry.workflow_engine.models.workflow_data_condition_group import WorkflowDataConditionGroup
 from sentry.workflow_engine.utils.legacy_metric_tracking import (
     report_used_legacy_models,
     track_alert_endpoint_execution,
@@ -192,7 +186,7 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
         examples=IssueAlertExamples.UPDATE_PROJECT_RULE,
     )
     @track_alert_endpoint_execution("PUT", "sentry-api-0-project-rule-details")
-    def put(self, request: Request, project: Project, rule: Rule | Workflow) -> Response:
+    def put(self, request: Request, project: Project, rule: Rule) -> Response:
         """
         ## Deprecated
         🚧 Use [Update an Alert by ID](/api/monitors/update-an-alert-by-id) instead.
@@ -206,48 +200,6 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
         - Filters - help control noise by triggering an alert only if the issue matches the specified criteria.
         - Actions - specify what should happen when the trigger conditions are met and the filters match.
         """
-        if isinstance(rule, Workflow):
-            workflow = rule
-            organization = project.organization
-
-            data = request.data.copy()
-
-            if not data.get("filterMatch"):
-                # if filterMatch is not passed, don't overwrite it with default value, use the saved dcg type
-                wdcg = WorkflowDataConditionGroup.objects.filter(workflow=workflow).first()
-                if wdcg:
-                    data["filterMatch"] = wdcg.condition_group.logic_type
-
-            request_data = format_request_data(cast(ProjectRulePostData, data), project)
-            if not request_data.get("config", {}).get("frequency"):
-                request_data["config"] = workflow.config
-
-            validator = WorkflowValidator(
-                data=request_data,
-                context={
-                    "organization": organization,
-                    "request": request,
-                    "workflow": workflow,
-                },
-            )
-            validator.is_valid(raise_exception=True)
-
-            with transaction.atomic(router.db_for_write(Workflow)):
-                validator.update(workflow, validator.validated_data)
-                self.create_audit_entry(
-                    request=request,
-                    organization=organization,
-                    target_object=workflow.id,
-                    event=audit_log.get_event_id("WORKFLOW_EDIT"),
-                    data=workflow.get_audit_log_data(),
-                )
-
-            workflow.refresh_from_db()
-            return Response(
-                serialize(workflow, request.user, WorkflowEngineRuleSerializer()),
-                status=200,
-            )
-
         report_used_legacy_models()
         rule_data_before = dict(rule.data)
         if rule.environment_id:
@@ -378,6 +330,18 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
                 sender=self,
                 is_api_token=request.auth is not None,
             )
+            if features.has(
+                "organizations:workflow-engine-rule-serializers", project.organization
+            ) or features.has(
+                "organizations:workflow-engine-issue-alert-endpoints-put", project.organization
+            ):
+                try:
+                    workflow = AlertRuleWorkflow.objects.get(rule_id=updated_rule.id).workflow
+                    return Response(
+                        serialize(workflow, request.user, WorkflowEngineRuleSerializer()),
+                    )
+                except AlertRuleWorkflow.DoesNotExist:
+                    return Response(serialize(updated_rule, request.user))
 
             return Response(serialize(updated_rule, request.user))
 

--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 import sentry_sdk
 from django.db import router, transaction
 from drf_spectacular.utils import extend_schema
@@ -47,6 +49,8 @@ from sentry.workflow_engine.utils.legacy_metric_tracking import (
     report_used_legacy_models,
     track_alert_endpoint_execution,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class ProjectRuleDetailsPutSerializer(serializers.Serializer):
@@ -341,6 +345,7 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
                         serialize(workflow, request.user, WorkflowEngineRuleSerializer()),
                     )
                 except AlertRuleWorkflow.DoesNotExist:
+                    logger.info("alertruleworkflow-doesnotexist", extra={"rule_id": rule.id})
                     return Response(serialize(updated_rule, request.user))
 
             return Response(serialize(updated_rule, request.user))

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Literal, NotRequired, TypedDict, cast
+from typing import Any, Literal, NotRequired, TypedDict
 
 from django.conf import settings
 from django.db.models.signals import pre_save
@@ -50,7 +50,6 @@ from sentry.workflow_engine.endpoints.validators.base.data_condition_group impor
 from sentry.workflow_engine.endpoints.validators.base.workflow import (
     ActionFilterInput,
     WorkflowInput,
-    WorkflowValidator,
 )
 from sentry.workflow_engine.migration_helpers.issue_alert_conditions import (
     translate_to_data_condition_data,
@@ -58,7 +57,7 @@ from sentry.workflow_engine.migration_helpers.issue_alert_conditions import (
 from sentry.workflow_engine.migration_helpers.rule_action import (
     translate_rule_data_actions_to_notification_actions,
 )
-from sentry.workflow_engine.models import DataConditionGroup, Workflow
+from sentry.workflow_engine.models import AlertRuleWorkflow, DataConditionGroup, Workflow
 from sentry.workflow_engine.models.detector import Detector
 from sentry.workflow_engine.utils.legacy_metric_tracking import (
     report_used_legacy_models,
@@ -916,20 +915,6 @@ class ProjectRulesEndpoint(ProjectEndpoint):
         - Filters: help control noise by triggering an alert only if the issue matches the specified criteria.
         - Actions: specify what should happen when the trigger conditions are met and the filters match.
         """
-        if features.has("organizations:workflow-engine-rule-serializers", project.organization):
-            request_data = format_request_data(cast(ProjectRulePostData, request.data), project)
-            validator = WorkflowValidator(
-                data=request_data,
-                context={"organization": project.organization, "request": request},
-            )
-            validator.is_valid(raise_exception=True)
-            workflow = validator.create(validator.validated_data)
-
-            return Response(
-                serialize(workflow, request.user, WorkflowEngineRuleSerializer()),
-                status=201,
-            )
-
         serializer = DrfRuleSerializer(
             context={"project": project, "organization": project.organization, "request": request},
             data=request.data,
@@ -1076,5 +1061,18 @@ class ProjectRulesEndpoint(ProjectEndpoint):
             duplicate_rule=duplicate_rule,
             wizard_v3=wizard_v3,
         )
+        if features.has(
+            "organizations:workflow-engine-rule-serializers", project.organization
+        ) or features.has(
+            "organizations:workflow-engine-issue-alert-endpoints-post", project.organization
+        ):
+            try:
+                workflow = AlertRuleWorkflow.objects.get(rule_id=rule.id).workflow
+                return Response(
+                    serialize(workflow, request.user, WorkflowEngineRuleSerializer()),
+                    status=201,
+                )
+            except AlertRuleWorkflow.DoesNotExist:
+                return Response(serialize(rule, request.user))
 
         return Response(serialize(rule, request.user))

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Literal, NotRequired, TypedDict
@@ -63,6 +64,8 @@ from sentry.workflow_engine.utils.legacy_metric_tracking import (
     report_used_legacy_models,
     track_alert_endpoint_execution,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def clean_rule_data(data):
@@ -1073,6 +1076,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
                     status=201,
                 )
             except AlertRuleWorkflow.DoesNotExist:
+                logger.info("alertruleworkflow-doesnotexist", extra={"rule_id": rule.id})
                 return Response(serialize(rule, request.user))
 
         return Response(serialize(rule, request.user))

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -1073,6 +1073,6 @@ class ProjectRulesEndpoint(ProjectEndpoint):
                     status=201,
                 )
             except AlertRuleWorkflow.DoesNotExist:
-                return Response(serialize(rule, request.user))
+                return Response(serialize(rule, request.user), status=201)
 
-        return Response(serialize(rule, request.user))
+        return Response(serialize(rule, request.user), status=201)

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -1073,6 +1073,6 @@ class ProjectRulesEndpoint(ProjectEndpoint):
                     status=201,
                 )
             except AlertRuleWorkflow.DoesNotExist:
-                return Response(serialize(rule, request.user), status=201)
+                return Response(serialize(rule, request.user))
 
-        return Response(serialize(rule, request.user), status=201)
+        return Response(serialize(rule, request.user))

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -459,6 +459,12 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Use workflow engine exclusively for legacy issue alert rule.get results.
     # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
     manager.add("organizations:workflow-engine-issue-alert-endpoints-get", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Use workflow engine exclusively for legacy issue alert rule.post results.
+    # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
+    manager.add("organizations:workflow-engine-issue-alert-endpoints-post", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Use workflow engine exclusively for legacy issue alert rule.put results.
+    # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
+    manager.add("organizations:workflow-engine-issue-alert-endpoints-put", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Use workflow engine exclusively for legacy metric alert rule.get results.
     # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
     manager.add("organizations:workflow-engine-metric-alert-endpoints-get", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)

--- a/src/sentry/projects/project_rules/updater.py
+++ b/src/sentry/projects/project_rules/updater.py
@@ -45,14 +45,14 @@ class ProjectRuleUpdater:
             # Mark that we're using legacy Rule models
             report_used_legacy_models()
 
-        # Called outside the transaction so RPC calls in dual-write are allowed
-        workflow = update_migrated_issue_alert(self.rule)
-        if workflow:
-            logger.info(
-                "workflow_engine.issue_alert.updated",
-                extra={"rule_id": self.rule.id, "workflow_id": workflow.id},
-            )
-        return self.rule
+            # uncaught errors will rollback the transaction
+            workflow = update_migrated_issue_alert(self.rule)
+            if workflow:
+                logger.info(
+                    "workflow_engine.issue_alert.updated",
+                    extra={"rule_id": self.rule.id, "workflow_id": workflow.id},
+                )
+            return self.rule
 
     def _update_name(self) -> None:
         if self.name:

--- a/src/sentry/projects/project_rules/updater.py
+++ b/src/sentry/projects/project_rules/updater.py
@@ -45,14 +45,14 @@ class ProjectRuleUpdater:
             # Mark that we're using legacy Rule models
             report_used_legacy_models()
 
-            # uncaught errors will rollback the transaction
-            workflow = update_migrated_issue_alert(self.rule)
-            if workflow:
-                logger.info(
-                    "workflow_engine.issue_alert.updated",
-                    extra={"rule_id": self.rule.id, "workflow_id": workflow.id},
-                )
-            return self.rule
+        # Called outside the transaction so RPC calls in dual-write are allowed
+        workflow = update_migrated_issue_alert(self.rule)
+        if workflow:
+            logger.info(
+                "workflow_engine.issue_alert.updated",
+                extra={"rule_id": self.rule.id, "workflow_id": workflow.id},
+            )
+        return self.rule
 
     def _update_name(self) -> None:
         if self.name:

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -1522,20 +1522,30 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             "conditions": [],
             "filters": [],
         }
-        response = self.get_success_response(
-            self.organization.slug, self.project.slug, self.rule.id, status_code=200, **payload
-        )
-        assert_rule_from_payload(self.rule, payload)
-        assert len(responses.calls) == 1
-
-        with self.feature("organizations:workflow-engine-rule-serializers"):
-            workflow_response = self.get_success_response(
-                self.organization.slug,
-                self.project.slug,
-                self.rule.id,
-                status_code=status.HTTP_200_OK,
-                **payload,
+        mock_install = MagicMock()
+        mock_install.sentry_app.id = self.sentry_app.id
+        mock_app_service = MagicMock()
+        mock_app_service.get_many.return_value = [mock_install]
+        # Patch app_service by name in notification_action's namespace only, so validation
+        # calls in notify_event.py still use the real service (outside the transaction).
+        with patch(
+            "sentry.workflow_engine.typings.notification_action.app_service",
+            new=mock_app_service,
+        ):
+            response = self.get_success_response(
+                self.organization.slug, self.project.slug, self.rule.id, status_code=200, **payload
             )
+            assert_rule_from_payload(self.rule, payload)
+            assert len(responses.calls) == 1
+
+            with self.feature("organizations:workflow-engine-rule-serializers"):
+                workflow_response = self.get_success_response(
+                    self.organization.slug,
+                    self.project.slug,
+                    self.rule.id,
+                    status_code=status.HTTP_200_OK,
+                    **payload,
+                )
         assert_serializer_results_match(response.data, workflow_response.data)
 
     @responses.activate

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -1926,11 +1926,7 @@ class GetProjectRuleDetailsDeltaTest(ProjectRuleDetailsBaseTestCase):
         assert legacy_response.data["id"] == str(rule.id)
         assert legacy_response.data["snooze"]
         assert legacy_response.data["snoozeForEveryone"]
-        assert_serializer_parity(
-            old=legacy_response.data,
-            new=we_response.data,
-            known_differences={"snoozeCreatedBy"},
-        )
+        assert_serializer_parity(old=legacy_response.data, new=we_response.data)
 
     def test_dual_written_rule_with_filters_parity(self) -> None:
         rule = self.create_project_rule(

--- a/tests/sentry/api/endpoints/test_project_rule_details.py
+++ b/tests/sentry/api/endpoints/test_project_rule_details.py
@@ -229,7 +229,7 @@ class ProjectRuleDetailsTest(ProjectRuleDetailsBaseTestCase):
         assert response.data["environment"] is None
         assert response.data["conditions"][0]["name"]
 
-    @with_feature("organizations:workflow-engine-rule-serializers")
+    @with_feature("organizations:workflow-engine-issue-alert-endpoints-get")
     def test_workflow_engine_serializer_dual_written_rule(self) -> None:
         response = self.get_success_response(
             self.organization.slug, self.project.slug, self.rule.id, status_code=200
@@ -238,7 +238,7 @@ class ProjectRuleDetailsTest(ProjectRuleDetailsBaseTestCase):
         assert response.data["environment"] is None
         assert response.data["conditions"][0]["name"]
 
-    @with_feature("organizations:workflow-engine-rule-serializers")
+    @with_feature("organizations:workflow-engine-issue-alert-endpoints-get")
     def test_workflow_engine_serializer_single_written_rule(self) -> None:
         response = self.get_success_response(
             self.organization.slug, self.project.slug, self.fake_workflow_id, status_code=200
@@ -718,7 +718,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             workflow_response = self.get_success_response(
                 self.organization.slug,
                 self.project.slug,
-                self.fake_dual_written_workflow_id,
+                self.rule.id,
                 status_code=200,
                 **payload,
             )
@@ -762,7 +762,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             workflow_response = self.get_success_response(
                 self.organization.slug,
                 self.project.slug,
-                self.fake_dual_written_workflow_id,
+                self.rule.id,
                 status_code=200,
                 **payload,
             )
@@ -791,7 +791,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             workflow_response = self.get_success_response(
                 self.organization.slug,
                 self.project.slug,
-                self.fake_dual_written_workflow_id,
+                self.rule.id,
                 status_code=200,
                 **payload,
             )
@@ -821,7 +821,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             workflow_response = self.get_success_response(
                 self.organization.slug,
                 self.project.slug,
-                self.fake_dual_written_workflow_id,
+                self.rule.id,
                 status_code=200,
                 **payload,
             )
@@ -898,7 +898,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             workflow_response = self.get_success_response(
                 self.organization.slug,
                 self.project.slug,
-                self.fake_dual_written_workflow_id,
+                self.rule.id,
                 status_code=status.HTTP_200_OK,
                 **payload,
             )
@@ -941,7 +941,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             workflow_response = self.get_success_response(
                 self.organization.slug,
                 self.project.slug,
-                self.fake_dual_written_workflow_id,
+                self.rule.id,
                 status_code=status.HTTP_200_OK,
                 **payload,
             )
@@ -970,15 +970,11 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
         )
         assert_rule_from_payload(rule, payload)
 
-        arw = AlertRuleWorkflow.objects.get(rule_id=rule.id)
-        dual_written_workflow = arw.workflow
-        fake_dual_written_workflow_id = get_fake_id_from_object_id(dual_written_workflow.id)
-
         with self.feature("organizations:workflow-engine-rule-serializers"):
             workflow_response = self.get_success_response(
                 self.organization.slug,
                 self.project.slug,
-                fake_dual_written_workflow_id,
+                rule.id,
                 status_code=status.HTTP_200_OK,
                 **payload,
             )
@@ -1225,14 +1221,11 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             ),
         )
 
-        arw = AlertRuleWorkflow.objects.get(rule_id=rule.id)
-        dual_written_workflow = arw.workflow
-        fake_dual_written_workflow_id = get_fake_id_from_object_id(dual_written_workflow.id)
         with self.feature("organizations:workflow-engine-rule-serializers"):
             workflow_response = self.get_success_response(
                 self.organization.slug,
                 self.project.slug,
-                fake_dual_written_workflow_id,
+                rule.id,
                 status_code=status.HTTP_200_OK,
                 **payload,
             )
@@ -1260,7 +1253,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             workflow_response = self.get_success_response(
                 self.organization.slug,
                 self.project.slug,
-                self.fake_dual_written_workflow_id,
+                self.rule.id,
                 status_code=status.HTTP_200_OK,
                 **payload,
             )
@@ -1291,7 +1284,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             workflow_response = self.get_success_response(
                 self.organization.slug,
                 self.project.slug,
-                self.fake_dual_written_workflow_id,
+                self.rule.id,
                 status_code=status.HTTP_200_OK,
                 **payload,
             )
@@ -1339,7 +1332,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
                     self.get_error_response(
                         self.organization.slug,
                         self.project.slug,
-                        self.fake_dual_written_workflow_id,
+                        self.rule.id,
                         status_code=400,
                         **payload,
                     )
@@ -1377,7 +1370,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
                 workflow_response = self.get_success_response(
                     self.organization.slug,
                     self.project.slug,
-                    self.fake_dual_written_workflow_id,
+                    self.rule.id,
                     status_code=status.HTTP_200_OK,
                     **payload,
                 )
@@ -1398,7 +1391,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             self.get_error_response(
                 self.organization.slug,
                 self.project.slug,
-                self.fake_dual_written_workflow_id,
+                self.rule.id,
                 status_code=400,
                 **payload,
             )
@@ -1418,7 +1411,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             self.get_error_response(
                 self.organization.slug,
                 self.project.slug,
-                self.fake_dual_written_workflow_id,
+                self.rule.id,
                 status_code=400,
                 **payload,
             )
@@ -1438,7 +1431,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             self.get_error_response(
                 self.organization.slug,
                 self.project.slug,
-                self.fake_dual_written_workflow_id,
+                self.rule.id,
                 status_code=400,
                 **payload,
             )
@@ -1499,7 +1492,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             workflow_response = self.get_success_response(
                 self.organization.slug,
                 self.project.slug,
-                self.fake_dual_written_workflow_id,
+                self.rule.id,
                 status_code=status.HTTP_200_OK,
                 **payload,
             )
@@ -1539,7 +1532,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             workflow_response = self.get_success_response(
                 self.organization.slug,
                 self.project.slug,
-                self.fake_dual_written_workflow_id,
+                self.rule.id,
                 status_code=status.HTTP_200_OK,
                 **payload,
             )
@@ -1580,8 +1573,8 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             self.get_error_response(
                 self.organization.slug,
                 self.project.slug,
-                self.fake_dual_written_workflow_id,
-                status_code=400,
+                self.rule.id,
+                status_code=500,
                 **payload,
             )
 
@@ -1622,8 +1615,8 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             self.get_error_response(
                 self.organization.slug,
                 self.project.slug,
-                self.fake_dual_written_workflow_id,
-                status_code=400,
+                self.rule.id,
+                status_code=409,
                 **payload,
             )
 
@@ -1670,8 +1663,8 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             self.get_error_response(
                 self.organization.slug,
                 self.project.slug,
-                self.fake_dual_written_workflow_id,
-                status_code=400,
+                self.rule.id,
+                status_code=510,
                 **payload,
             )
 
@@ -1715,8 +1708,8 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             self.get_error_response(
                 self.organization.slug,
                 self.project.slug,
-                self.fake_dual_written_workflow_id,
-                status_code=400,
+                self.rule.id,
+                status_code=500,
                 **payload,
             )
 
@@ -1736,7 +1729,7 @@ class UpdateProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             workflow_response = self.get_success_response(
                 self.organization.slug,
                 self.project.slug,
-                self.fake_dual_written_workflow_id,
+                self.rule.id,
                 status_code=200,
                 **payload,
             )
@@ -1769,7 +1762,7 @@ class DeleteProjectRuleTest(ProjectRuleDetailsBaseTestCase):
             id=self.rule.id, project=self.project, status=ObjectStatus.PENDING_DELETION
         ).exists()
 
-    @with_feature("organizations:workflow-engine-rule-serializers")
+    @with_feature("organizations:workflow-engine-issue-alert-endpoints-delete")
     def test_single_written_workflow_passed(self) -> None:
         self.get_success_response(
             self.organization.slug, self.project.slug, self.fake_workflow_id, status_code=202

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from typing import Any
-from unittest import mock
 from unittest.mock import patch
 from uuid import uuid4
 
@@ -16,32 +15,12 @@ from sentry.api.endpoints.project_rules import get_max_alerts
 from sentry.constants import ObjectStatus
 from sentry.incidents.endpoints.serializers.utils import (
     get_fake_id_from_object_id,
-    get_object_id_from_fake_id,
 )
 from sentry.integrations.slack.tasks.find_channel_id_for_rule import find_channel_id_for_rule
 from sentry.integrations.slack.utils.channel import SlackChannelIdData
 from sentry.models.environment import Environment
 from sentry.models.rule import Rule, RuleActivity, RuleActivityType
-from sentry.rules.conditions.event_attribute import EventAttributeCondition
-from sentry.rules.conditions.event_frequency import (
-    EventFrequencyCondition,
-    EventFrequencyPercentCondition,
-    EventUniqueUserFrequencyCondition,
-)
 from sentry.rules.conditions.existing_high_priority_issue import ExistingHighPriorityIssueCondition
-from sentry.rules.conditions.first_seen_event import FirstSeenEventCondition
-from sentry.rules.conditions.level import LevelCondition
-from sentry.rules.conditions.new_high_priority_issue import NewHighPriorityIssueCondition
-from sentry.rules.filters.age_comparison import AgeComparisonFilter
-from sentry.rules.filters.assigned_to import AssignedToFilter
-from sentry.rules.filters.event_attribute import EventAttributeFilter
-from sentry.rules.filters.issue_category import IssueCategoryFilter
-from sentry.rules.filters.issue_occurrences import IssueOccurrencesFilter
-from sentry.rules.filters.issue_type import IssueTypeFilter
-from sentry.rules.filters.latest_adopted_release_filter import LatestAdoptedReleaseFilter
-from sentry.rules.filters.latest_release import LatestReleaseFilter
-from sentry.rules.filters.level import LevelFilter
-from sentry.rules.filters.tagged_event import TaggedEventFilter
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import install_slack, with_feature
@@ -50,14 +29,8 @@ from sentry.testutils.silo import assume_test_silo_mode
 from sentry.users.models.user import User
 from sentry.workflow_engine.models import (
     Condition,
-    DataCondition,
-    DataConditionGroup,
-    DataConditionGroupAction,
-    DetectorWorkflow,
     Workflow,
-    WorkflowDataConditionGroup,
 )
-from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 from tests.sentry.api.endpoints.test_project_rule_details import assert_serializer_results_match
 from tests.sentry.workflow_engine.test_base import BaseWorkflowTest
 
@@ -493,6 +466,9 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
                 )
 
         assert RuleActivity.objects.filter(rule=rule, type=RuleActivityType.CREATED.value).exists()
+
+        # Mark the rule as non-active so the duplicate check doesn't block the second creation.
+        Rule.objects.filter(id=rule.id).update(status=ObjectStatus.PENDING_DELETION)
 
         # Verify that the workflow engine serializer returns the same response shape.
         with self.feature("organizations:workflow-engine-rule-serializers"):
@@ -1398,221 +1374,6 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
         )
         clean_rule = Rule.objects.get(id=response.data.get("id"))
         assert not clean_rule.data.get("comparisonInterval")
-
-    @with_feature("organizations:workflow-engine-rule-serializers")
-    @responses.activate
-    @mock.patch("sentry.integrations.slack.actions.form.validate_slack_entity_id")
-    def test_workflow_engine(self, mock_validate_slack_entity_id: mock.MagicMock) -> None:
-        conditions = [
-            {"id": ExistingHighPriorityIssueCondition.id},
-            {"id": NewHighPriorityIssueCondition.id},
-            {"id": FirstSeenEventCondition.id},
-            {"id": LevelCondition.id, "match": "eq", "level": "50"},
-            {
-                "id": EventAttributeCondition.id,
-                "attribute": "message",
-                "match": "eq",
-                "value": "test",
-            },
-            {
-                "id": EventFrequencyCondition.id,
-                "interval": "1h",
-                "value": 100,
-                "comparisonType": "count",
-            },
-            {
-                "id": EventFrequencyCondition.id,
-                "interval": "1h",
-                "value": 50,
-                "comparisonType": "percent",
-                "comparisonInterval": "1d",
-            },
-            {
-                "id": EventUniqueUserFrequencyCondition.id,
-                "interval": "1h",
-                "value": 50,
-                "comparisonType": "count",
-            },
-            {
-                "id": EventUniqueUserFrequencyCondition.id,
-                "interval": "1h",
-                "value": 50,
-                "comparisonType": "percent",
-                "comparisonInterval": "1d",
-            },
-            {
-                "id": EventFrequencyPercentCondition.id,
-                "interval": "1h",
-                "value": 50,
-                "comparisonType": "count",
-            },
-            {
-                "id": EventFrequencyPercentCondition.id,
-                "interval": "1h",
-                "value": 50,
-                "comparisonType": "percent",
-                "comparisonInterval": "1d",
-            },
-        ]
-        filters = [
-            {
-                "id": TaggedEventFilter.id,
-                "match": "is",
-                "key": "environment",
-                "value": "",  # initializing RuleBase requires "value" key
-            },
-            {
-                "id": AgeComparisonFilter.id,
-                "comparison_type": "older",
-                "value": 10,
-                "time": "hour",
-            },
-            {
-                "id": AssignedToFilter.id,
-                "targetType": "Member",
-                "targetIdentifier": self.user.id,
-            },
-            {
-                "id": IssueCategoryFilter.id,
-                "value": "1",
-                "include": "true",
-            },
-            {
-                "id": IssueOccurrencesFilter.id,
-                "value": "10",
-            },
-            {
-                "id": IssueTypeFilter.id,
-                "value": "error",
-            },
-            {
-                "id": LatestAdoptedReleaseFilter.id,
-                "oldest_or_newest": "oldest",
-                "older_or_newer": "newer",
-                "environment": self.environment.name + "fake",
-            },
-            {
-                "id": LatestReleaseFilter.id,
-            },
-            {
-                "id": LevelFilter.id,
-                "match": "eq",
-                "level": "50",
-            },
-            {
-                "id": EventAttributeFilter.id,
-                "attribute": "message",
-                "match": "ns",
-                "value": "",
-            },
-            {
-                "id": AssignedToFilter.id,
-                "targetType": "Unassigned",
-                "targetIdentifier": "",
-            },
-        ]
-        payload = {
-            "name": "Owner Alert",
-            "frequency": 1440,
-            "environment": self.environment.name,
-            "status": "active",
-            "snooze": False,
-            "conditions": conditions,
-            "filters": filters,
-            "actions": [
-                {
-                    "targetType": "Member",
-                    "fallthroughType": "ActiveMembers",
-                    "id": "sentry.mail.actions.NotifyEmailAction",
-                    "targetIdentifier": self.user.id,
-                },
-                {
-                    "id": "sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction",
-                    "settings": self.sentry_app_settings_payload,
-                    "sentryAppInstallationUuid": self.sentry_app_installation.uuid,
-                    "hasSchemaFormConfig": True,
-                    "uuid": str(uuid4()),
-                },
-                self.notify_issue_owners_action[0],
-                self.notify_event_action[0],
-                self.slack_actions[0],
-            ],
-            "actionMatch": "any",
-            "filterMatch": "all",
-            "owner": f"team:{self.team.id}",
-            "projects": [self.project.slug],
-        }
-        responses.add(
-            method=responses.POST,
-            url="https://example.com/sentry/alert-rule",
-            status=status.HTTP_202_ACCEPTED,
-        )
-        response = self.get_success_response(
-            self.project.organization.slug,
-            self.project.slug,
-            **payload,
-        )
-        assert len(response.data["conditions"]) == len(conditions)
-        assert len(response.data["filters"]) == len(filters)
-        assert len(response.data["actions"]) == len(payload["actions"])
-
-        workflow = Workflow.objects.get(id=get_object_id_from_fake_id(int(response.data["id"])))
-        assert workflow.environment is not None
-        assert workflow.environment.name == payload["environment"]
-        assert workflow.name == payload["name"]
-        assert workflow.enabled is True
-
-        assert DetectorWorkflow.objects.filter(
-            workflow=workflow, detector__type=IssueStreamGroupType.slug
-        ).exists()
-
-        triggers = DataCondition.objects.filter(condition_group=workflow.when_condition_group)
-        assert len(triggers) == len(payload["conditions"])
-        # spot check
-        event_attr_trigger = None
-        for trigger in triggers:
-            if trigger.type == Condition.EVENT_ATTRIBUTE.value:
-                event_attr_trigger = trigger
-
-        assert event_attr_trigger
-        assert event_attr_trigger.comparison == {
-            "match": "eq",
-            "attribute": "message",
-            "value": "test",
-        }
-        assert event_attr_trigger.condition_result is True
-
-        wdcg = WorkflowDataConditionGroup.objects.get(workflow=workflow)
-        dcgs = DataConditionGroup.objects.filter(id=wdcg.condition_group_id)
-        dc_filters = DataCondition.objects.filter(condition_group__in=dcgs)
-        assert len(dc_filters) == len(payload["filters"])
-        # spot check
-        tagged_event_filter = None
-        for f in dc_filters:
-            if f.type == Condition.TAGGED_EVENT.value:
-                tagged_event_filter = f
-
-        assert tagged_event_filter
-        assert tagged_event_filter.comparison == {
-            "match": "is",
-            "key": "environment",
-        }
-        assert tagged_event_filter.condition_result is True
-
-        dcgas = DataConditionGroupAction.objects.filter(condition_group__in=[dcg for dcg in dcgs])
-        # spot check
-        slack_action = None
-        for action in [dcga.action for dcga in dcgas]:
-            if action.type == "slack":
-                slack_action = action
-
-        assert slack_action
-        assert slack_action.data == {"notes": "", "tags": ""}
-        assert slack_action.config == {
-            "target_type": 0,
-            "target_display": "team-team-team",
-            "target_identifier": "CSVK0921",
-        }
 
 
 class GetProjectRulesDeltaTest(APITestCase):

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -640,7 +640,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
             frequency=5,
             actions=actions,
             conditions=self.first_seen_condition,
-            status_code=status.HTTP_200_OK,
+            status_code=status.HTTP_201_CREATED,
         )
         rule = Rule.objects.get(id=response.data.get("id"))
         assert rule.data["actions"][0] == {
@@ -788,7 +788,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
             actions=self.notify_event_action,
             conditions=self.first_seen_condition,
         )
-        assert response.status_code == 200
+        assert response.status_code == 201
         assert response.data["owner"] == f"team:{team.id}"
 
         rule = Rule.objects.get(id=response.data["id"])
@@ -846,7 +846,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
             actions=self.notify_event_action,
             conditions=self.first_seen_condition,
         )
-        assert response.status_code == 200
+        assert response.status_code == 201
         assert response.data["owner"] == f"team:{team.id}"
 
         rule = Rule.objects.get(id=response.data["id"])
@@ -877,7 +877,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
             actions=self.notify_event_action,
             conditions=self.first_seen_condition,
         )
-        assert response.status_code == 200
+        assert response.status_code == 201
         assert response.data["owner"] == f"user:{other_user.id}"
 
         rule = Rule.objects.get(id=response.data["id"])
@@ -919,7 +919,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
             filterMatch="any",
             actions=self.notify_event_action,
             conditions=[condition],
-            status_code=status.HTTP_200_OK,
+            status_code=status.HTTP_201_CREATED,
         )
 
     def test_match_values(self) -> None:
@@ -1271,7 +1271,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
             self.organization.slug,
             self.project.slug,
             **payload,
-            status_code=status.HTTP_200_OK,
+            status_code=status.HTTP_201_CREATED,
         )
         new_rule_id = response.data["id"]
         assert new_rule_id is not None

--- a/tests/sentry/api/endpoints/test_project_rules.py
+++ b/tests/sentry/api/endpoints/test_project_rules.py
@@ -640,7 +640,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
             frequency=5,
             actions=actions,
             conditions=self.first_seen_condition,
-            status_code=status.HTTP_201_CREATED,
+            status_code=status.HTTP_200_OK,
         )
         rule = Rule.objects.get(id=response.data.get("id"))
         assert rule.data["actions"][0] == {
@@ -788,7 +788,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
             actions=self.notify_event_action,
             conditions=self.first_seen_condition,
         )
-        assert response.status_code == 201
+        assert response.status_code == 200
         assert response.data["owner"] == f"team:{team.id}"
 
         rule = Rule.objects.get(id=response.data["id"])
@@ -846,7 +846,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
             actions=self.notify_event_action,
             conditions=self.first_seen_condition,
         )
-        assert response.status_code == 201
+        assert response.status_code == 200
         assert response.data["owner"] == f"team:{team.id}"
 
         rule = Rule.objects.get(id=response.data["id"])
@@ -877,7 +877,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
             actions=self.notify_event_action,
             conditions=self.first_seen_condition,
         )
-        assert response.status_code == 201
+        assert response.status_code == 200
         assert response.data["owner"] == f"user:{other_user.id}"
 
         rule = Rule.objects.get(id=response.data["id"])
@@ -919,7 +919,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
             filterMatch="any",
             actions=self.notify_event_action,
             conditions=[condition],
-            status_code=status.HTTP_201_CREATED,
+            status_code=status.HTTP_200_OK,
         )
 
     def test_match_values(self) -> None:
@@ -1271,7 +1271,7 @@ class CreateProjectRuleTest(ProjectRuleBaseTestCase):
             self.organization.slug,
             self.project.slug,
             **payload,
-            status_code=status.HTTP_201_CREATED,
+            status_code=status.HTTP_200_OK,
         )
         new_rule_id = response.data["id"]
         assert new_rule_id is not None


### PR DESCRIPTION
Pivoting from single writing we are now just going to return the `Workflow` that was dual written/updated upon POST or PUT for issue alerts. 