### PR TITLE
feat(cells) Expand org create tests and expand provisioning options

### DIFF
--- a/src/sentry/core/endpoints/organization_index.py
+++ b/src/sentry/core/endpoints/organization_index.py
@@ -398,6 +398,9 @@ class OrganizationIndexEndpoint(Endpoint):
                     slug=result.get("slug") or result["name"],
                     owning_user_id=request.user.id,
                     create_default_team=create_default_team,
+                    ip_address=request.META["REMOTE_ADDR"],
+                    aggregated_data_consent=result.get("aggregatedDataConsent"),
+                    agree_terms=result.get("agreeTerms"),
                 ),
                 post_provision_options=PostProvisionOptions(
                     getsentry_options=None, sentry_options=None

--- a/src/sentry/hybridcloud/services/cell_organization_provisioning/impl.py
+++ b/src/sentry/hybridcloud/services/cell_organization_provisioning/impl.py
@@ -45,6 +45,9 @@ class DatabaseBackedCellOrganizationProvisioningRpcService(CellOrganizationProvi
         is_test: bool = False,
         user_id: int | None = None,
         email: str | None = None,
+        ip_address: str | None = None,
+        agree_terms: bool | None = None,
+        aggregated_data_consent: bool | None = None,
     ) -> Organization:
         assert (user_id is None and email) or (user_id and email is None), (
             "Must set either user_id or email"
@@ -157,6 +160,9 @@ class DatabaseBackedCellOrganizationProvisioningRpcService(CellOrganizationProvi
                 create_default_team=provision_options.create_default_team,
                 organization_id=organization_id,
                 is_test=provision_options.is_test,
+                ip_address=provision_options.ip_address,
+                agree_terms=provision_options.agree_terms,
+                aggregated_data_consent=provision_options.aggregated_data_consent,
             )
 
             create_post_provision_outbox(

--- a/src/sentry/services/organization/model.py
+++ b/src/sentry/services/organization/model.py
@@ -10,6 +10,9 @@ class OrganizationOptions(pydantic.BaseModel):
     owning_email: str | None = None
     create_default_team: bool = True
     is_test: bool = False
+    ip_address: str | None = None
+    agree_terms: bool | None = None
+    aggregated_data_consent: bool | None = None
 
 
 class PostProvisionOptions(pydantic.BaseModel):

--- a/tests/sentry/core/endpoints/test_organization_index.py
+++ b/tests/sentry/core/endpoints/test_organization_index.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 import re
 from typing import Any
+from unittest import mock
 from unittest.mock import MagicMock, patch
 
 from django.test import override_settings
 from django.urls import reverse
 
+from sentry import audit_log
+from sentry.analytics.events.organization_created import OrganizationCreatedEvent
 from sentry.api.bases.organization import OrganizationPermission
 from sentry.auth.authenticators.totp import TotpInterface
 from sentry.models.apitoken import ApiToken
@@ -17,9 +20,12 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.team import Team
 from sentry.silo.base import SiloMode
+from sentry.testutils.asserts import assert_org_audit_log_exists
 from sentry.testutils.cases import APITestCase, TwoFactorAPITestCase
+from sentry.testutils.helpers.analytics import assert_any_analytics_event
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.hybrid_cloud import HybridCloudTestMixin
+from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import (
     assume_test_silo_mode,
     cell_silo_test,
@@ -386,6 +392,30 @@ class OrganizationsCreateTest(OrganizationIndexTest, HybridCloudTestMixin):
             organization_id=response.data["id"], user_id=self.user.id
         )
         self.assert_org_member_mapping(org_member=org_member)
+
+    @mock.patch("sentry.analytics.record")
+    def test_success_analytics_recorded(self, mock_record: mock.MagicMock) -> None:
+        self.login_as(user=self.user)
+
+        with outbox_runner():
+            response = self.get_success_response(name="org name")
+        assert response.status_code == 201
+
+        org = Organization.objects.get(slug="org-name")
+
+        assert_any_analytics_event(
+            mock_record,
+            OrganizationCreatedEvent(
+                id=org.id,
+                actor_id=self.user.id,
+                name=org.name,
+                slug=org.slug,
+            ),
+        )
+        assert_org_audit_log_exists(
+            organization=org,
+            event=audit_log.get_event_id("ORG_ADD"),
+        )
 
     def test_data_consent(self) -> None:
         data = {"name": "hello world original", "agreeTerms": True}

--- a/tests/sentry/core/endpoints/test_organization_index.py
+++ b/tests/sentry/core/endpoints/test_organization_index.py
@@ -9,6 +9,9 @@ from django.test import override_settings
 from django.urls import reverse
 
 from sentry import audit_log
+from sentry.analytics.events.data_consent_org_creation import (
+    AggregatedDataConsentOrganizationCreatedEvent,
+)
 from sentry.analytics.events.organization_created import OrganizationCreatedEvent
 from sentry.api.bases.organization import OrganizationPermission
 from sentry.auth.authenticators.totp import TotpInterface
@@ -398,7 +401,7 @@ class OrganizationsCreateTest(OrganizationIndexTest, HybridCloudTestMixin):
         self.login_as(user=self.user)
 
         with outbox_runner():
-            response = self.get_success_response(name="org name")
+            response = self.get_success_response(name="org name", aggregatedDataConsent=True)
         assert response.status_code == 201
 
         org = Organization.objects.get(slug="org-name")
@@ -412,10 +415,14 @@ class OrganizationsCreateTest(OrganizationIndexTest, HybridCloudTestMixin):
                 slug=org.slug,
             ),
         )
+        assert_any_analytics_event(
+            mock_record, AggregatedDataConsentOrganizationCreatedEvent(organization_id=org.id)
+        )
         assert_org_audit_log_exists(
             organization=org,
             event=audit_log.get_event_id("ORG_ADD"),
         )
+        assert org.get_option("sentry:aggregated_data_consent") is True
 
     def test_data_consent(self) -> None:
         data = {"name": "hello world original", "agreeTerms": True}


### PR DESCRIPTION
As part of cells work, we want to consolidate all provisioning flows into Control. This requires reworking the `POST /organizations` endpoint to work in control. 

Before making any significant changes to provisioning I wanted to address some testing gaps, and expand the supported provisioning options so that I can more easily move audits and analytics into the RPC services.

Refs INFRENG-186