### PR TITLE
fix(checkout): Remove TopBar.Slot usage from CheckoutSuccess

### DIFF
--- a/static/gsApp/views/amCheckout/components/checkoutSuccess.tsx
+++ b/static/gsApp/views/amCheckout/components/checkoutSuccess.tsx
@@ -16,8 +16,6 @@ import {FeedbackButton} from 'sentry/components/feedbackButton/feedbackButton';
 import {t, tct} from 'sentry/locale';
 import {defined} from 'sentry/utils';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {TopBar} from 'sentry/views/navigation/topBar';
-import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 import {GIGABYTE} from 'getsentry/constants';
 import type {
@@ -516,7 +514,6 @@ export function CheckoutSuccess({
   previewData,
 }: CheckoutSuccessProps) {
   const organization = useOrganization();
-  const hasPageFrameFeature = useHasPageFrameFeature();
   const viewSubscriptionQueryParams =
     nextQueryParams.length > 0 ? `?${nextQueryParams.join('&')}` : '';
 
@@ -619,18 +616,7 @@ export function CheckoutSuccess({
             >
               {t('Edit plan')}
             </LinkButton>
-            {hasPageFrameFeature ? (
-              <TopBar.Slot name="feedback">
-                <FeedbackButton feedbackOptions={checkoutSuccessFeedbackOptions}>
-                  {null}
-                </FeedbackButton>
-              </TopBar.Slot>
-            ) : (
-              <FeedbackButton
-                feedbackOptions={checkoutSuccessFeedbackOptions}
-                size="md"
-              />
-            )}
+            <FeedbackButton feedbackOptions={checkoutSuccessFeedbackOptions} size="md" />
           </Flex>
         </Flex>
       </Flex>


### PR DESCRIPTION
The /checkout/ route renders outside OrganizationLayout, so TopBar.Slot.Provider is never mounted in the component tree. Using TopBar.Slot (a SlotConsumer) without the provider throws "SlotContext not found".

The checkout page has its own standalone layout with no navigation top bar, so injecting into the slot was never meaningful anyway. Render the FeedbackButton directly instead.

Fixes JAVASCRIPT-3946

<!-- Describe your PR here. -->