### PR TITLE
fix(seer): introduce synced useSeerExplorerRunId hook

### DIFF
--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -13,13 +13,13 @@ import {
 import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {useSessionStorage} from 'sentry/utils/useSessionStorage';
 import {useLLMContext} from 'sentry/views/seerExplorer/contexts/llmContext';
 import {useAsciiSnapshot} from 'sentry/views/seerExplorer/hooks/useAsciiSnapshot';
 import {
   isSessionComplete,
   useSeerExplorerPolling,
 } from 'sentry/views/seerExplorer/hooks/useSeerExplorerPolling';
+import {useSeerExplorerRunId} from 'sentry/views/seerExplorer/hooks/useSeerExplorerRunId';
 import type {Block, RepoPRState} from 'sentry/views/seerExplorer/types';
 import {makeSeerExplorerQueryKey, usePageReferrer} from 'sentry/views/seerExplorer/utils';
 
@@ -124,10 +124,7 @@ export const useSeerExplorer = () => {
   const [overrideCodeModeEnable, setOverrideCodeModeEnable] =
     useLocalStorageState<boolean>('seer-explorer.override.code-mode', true);
 
-  const [runId, setRunId] = useSessionStorage<number | null>(
-    'seer-explorer-run-id',
-    null
-  );
+  const [runId, setRunId] = useSeerExplorerRunId();
 
   const {getPageReferrer} = usePageReferrer();
 

--- a/static/app/views/seerExplorer/hooks/useSeerExplorerRunId.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorerRunId.tsx
@@ -1,0 +1,80 @@
+import {useCallback, useSyncExternalStore, type SetStateAction} from 'react';
+
+import {sessionStorageWrapper} from 'sentry/utils/sessionStorage';
+
+// Session-storage backed `runId` store. `useSessionStorage` keeps each hook
+// instance's state local, so when `useSeerExplorer` (inside the drawer) and
+// `SeerExplorerContextProvider` (driving the nav button's `sessionState`)
+// subscribe to the same key, writes from one don't re-render the other.
+//
+// This hook routes both subscribers through a single module-level store, so
+// switching runs in the drawer immediately updates the nav button indicator.
+
+const KEY = 'seer-explorer-run-id';
+
+const listeners = new Set<() => void>();
+
+let cachedRaw: string | null | undefined;
+let cachedValue: number | null = null;
+
+function readFromStorage(): number | null {
+  const raw = sessionStorageWrapper.getItem(KEY);
+  if (cachedRaw === raw) {
+    return cachedValue;
+  }
+  cachedRaw = raw;
+  if (raw === null || raw === 'undefined') {
+    cachedValue = null;
+  } else {
+    try {
+      const parsed = JSON.parse(raw);
+      cachedValue = typeof parsed === 'number' ? parsed : null;
+    } catch {
+      cachedValue = null;
+    }
+  }
+  return cachedValue;
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function notify(): void {
+  cachedRaw = undefined;
+  listeners.forEach(l => l());
+}
+
+function getServerSnapshot(): number | null {
+  return null;
+}
+
+export function useSeerExplorerRunId(): [
+  number | null,
+  (value: SetStateAction<number | null>) => void,
+] {
+  const runId = useSyncExternalStore(subscribe, readFromStorage, getServerSnapshot);
+
+  const setRunId = useCallback((valueOrUpdater: SetStateAction<number | null>) => {
+    const prev = readFromStorage();
+    const next =
+      typeof valueOrUpdater === 'function'
+        ? (valueOrUpdater as (prev: number | null) => number | null)(prev)
+        : valueOrUpdater;
+    try {
+      if (next === null) {
+        sessionStorageWrapper.removeItem(KEY);
+      } else {
+        sessionStorageWrapper.setItem(KEY, JSON.stringify(next));
+      }
+    } catch {
+      // Best effort.
+    }
+    notify();
+  }, []);
+
+  return [runId, setRunId];
+}

--- a/static/app/views/seerExplorer/useSeerExplorerContext.tsx
+++ b/static/app/views/seerExplorer/useSeerExplorerContext.tsx
@@ -12,12 +12,12 @@ import {
 import {useHotkeys} from '@sentry/scraps/hotkey';
 
 import {useGlobalModal} from 'sentry/components/globalModal/useGlobalModal';
-import {useSessionStorage} from 'sentry/utils/useSessionStorage';
 import {
   type OpenSeerExplorerDrawerOptions,
   useSeerExplorerDrawer,
 } from 'sentry/views/seerExplorer/components/drawer/useSeerExplorerDrawer';
 import {useSeerExplorerPolling} from 'sentry/views/seerExplorer/hooks/useSeerExplorerPolling';
+import {useSeerExplorerRunId} from 'sentry/views/seerExplorer/hooks/useSeerExplorerRunId';
 
 type SeerExplorerSessionState = 'inactive' | 'thinking' | 'done-thinking';
 
@@ -45,10 +45,7 @@ export const SeerExplorerContext = createContext<SeerExplorerContextValue>({
 });
 
 export function SeerExplorerContextProvider({children}: {children: ReactNode}) {
-  const [runId, setRunId] = useSessionStorage<number | null>(
-    'seer-explorer-run-id',
-    null
-  );
+  const [runId, setRunId] = useSeerExplorerRunId();
 
   const {
     openSeerExplorerDrawer,


### PR DESCRIPTION
Follow-up to #113727 and #113748, this PR adds a new `useSeerExplorerRunId` hook that's a `useSyncExternalStore`-backed hook with a module-level listener set and `sessionStorage` as the backing store. Every hook consumer is now synced, so the loading state in the `AskSeer` button will remain aligned with the chat.