### PR TITLE
feat(chunk-upload): Add zstd compression support for sourcemap uploads

### DIFF
--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -1,7 +1,7 @@
 import logging
 import re
 from collections.abc import Iterator
-from gzip import GzipFile
+from gzip import BadGzipFile, GzipFile
 from io import BytesIO
 from typing import IO, Protocol
 
@@ -331,6 +331,13 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
         except zstandard.ZstdError:
             logger.info("chunkupload.end", extra={"status": status.HTTP_400_BAD_REQUEST})
             return Response({"error": "Invalid zstd payload"}, status=status.HTTP_400_BAD_REQUEST)
+        except (BadGzipFile, EOFError):
+            # BadGzipFile: bad magic / bad header. EOFError: stream truncated
+            # mid-decompression. GzipFile raises these via its read() path, so
+            # we also cover the legacy file_gzip multipart upload, not just
+            # Content-Encoding: gzip.
+            logger.info("chunkupload.end", extra={"status": status.HTTP_400_BAD_REQUEST})
+            return Response({"error": "Invalid gzip payload"}, status=status.HTTP_400_BAD_REQUEST)
 
         logger.info("chunkupload.post.files", extra={"len": len(files)})
 

--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -237,7 +237,7 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
 
         encoding = request.headers.get("Content-Encoding", "").strip().lower()
         if encoding and encoding not in CHUNK_UPLOAD_COMPRESSION:
-            logger.info("chunkupload.end", extra={"status": status.HTTP_400_BAD_REQUEST})
+            logger.warning("chunkupload.end", extra={"status": status.HTTP_400_BAD_REQUEST})
             return Response(
                 {"error": "Unsupported Content-Encoding"}, status=status.HTTP_400_BAD_REQUEST
             )
@@ -246,7 +246,7 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
         files_gzip_legacy = request.FILES.getlist("file_gzip")
 
         if encoding and files_gzip_legacy:
-            logger.info("chunkupload.end", extra={"status": status.HTTP_400_BAD_REQUEST})
+            logger.warning("chunkupload.end", extra={"status": status.HTTP_400_BAD_REQUEST})
             return Response(
                 {"error": "Cannot combine Content-Encoding with file_gzip field"},
                 status=status.HTTP_400_BAD_REQUEST,
@@ -271,14 +271,14 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
         try:
             for chunk, name in get_files(request, encoding):
                 if chunk.size > settings.SENTRY_CHUNK_UPLOAD_BLOB_SIZE:
-                    logger.info("chunkupload.end", extra={"status": status.HTTP_400_BAD_REQUEST})
+                    logger.warning("chunkupload.end", extra={"status": status.HTTP_400_BAD_REQUEST})
                     return Response(
                         {"error": "Chunk size too large"}, status=status.HTTP_400_BAD_REQUEST
                     )
 
                 total_size += chunk.size
                 if total_size > MAX_REQUEST_SIZE:
-                    logger.info("chunkupload.end", extra={"status": status.HTTP_400_BAD_REQUEST})
+                    logger.warning("chunkupload.end", extra={"status": status.HTTP_400_BAD_REQUEST})
                     return Response(
                         {"error": "Request too large"}, status=status.HTTP_400_BAD_REQUEST
                     )
@@ -286,13 +286,13 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
                 files.append(chunk)
                 checksums.append(name)
         except ChunkTooLarge:
-            logger.info("chunkupload.end", extra={"status": status.HTTP_400_BAD_REQUEST})
+            logger.warning("chunkupload.end", extra={"status": status.HTTP_400_BAD_REQUEST})
             return Response({"error": "Chunk size too large"}, status=status.HTTP_400_BAD_REQUEST)
         except zstandard.ZstdError:
-            logger.info("chunkupload.end", extra={"status": status.HTTP_400_BAD_REQUEST})
+            logger.warning("chunkupload.end", extra={"status": status.HTTP_400_BAD_REQUEST})
             return Response({"error": "Invalid zstd payload"}, status=status.HTTP_400_BAD_REQUEST)
         except (BadGzipFile, EOFError):
-            logger.info("chunkupload.end", extra={"status": status.HTTP_400_BAD_REQUEST})
+            logger.warning("chunkupload.end", extra={"status": status.HTTP_400_BAD_REQUEST})
             return Response({"error": "Invalid gzip payload"}, status=status.HTTP_400_BAD_REQUEST)
 
         logger.info("chunkupload.post.files", extra={"len": len(files)})

--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -3,7 +3,7 @@ import re
 from collections.abc import Iterator
 from gzip import GzipFile
 from io import BytesIO
-from typing import IO
+from typing import IO, Protocol
 
 import zstandard
 from django.conf import settings
@@ -64,7 +64,32 @@ class ChunkTooLarge(OSError):
     """Raised when a (possibly decompressed) chunk exceeds the per-chunk size limit."""
 
 
-def _read_bounded(reader: IO[bytes], limit: int) -> bytes:
+class _Reader(Protocol):
+    """Minimal structural type for any bounded-read source.
+
+    Covers the concrete types we pass in (``GzipFile`` from ``gzip`` and
+    ``ZstdDecompressor().stream_reader`` from ``zstandard``) without forcing
+    them to satisfy the full ``IO[bytes]`` protocol -- which they don't.
+    """
+
+    def read(self, __n: int = ...) -> bytes: ...
+
+
+class _SizedChunk(Protocol):
+    """A chunk we can size and name before handing it to ``FileBlob.from_files``.
+
+    Both Django's ``UploadedFile`` (plain uploads) and our ``GzipChunk``/
+    ``ZstdChunk`` wrappers expose ``.size`` and ``.name``; the underlying
+    ``IO[bytes]`` type does not, which is why we need this narrower protocol.
+    """
+
+    size: int
+    name: str
+
+    def read(self, __n: int = ...) -> bytes: ...
+
+
+def _read_bounded(reader: _Reader, limit: int) -> bytes:
     """Read up to ``limit`` bytes from ``reader``; raise :class:`ChunkTooLarge` if more.
 
     We ask for ``limit + 1`` bytes and let the stream produce as much as it can within
@@ -267,7 +292,7 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        files: list[IO[bytes]] = []
+        files: list[_SizedChunk] = []
         checksums: list[str] = []
         total_size = 0
 
@@ -319,7 +344,7 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
         return Response(status=status.HTTP_200_OK)
 
 
-def get_files(request: Request, encoding: str) -> Iterator[tuple[IO[bytes], str]]:
+def get_files(request: Request, encoding: str) -> Iterator[tuple[_SizedChunk, str]]:
     """Yield ``(chunk, checksum)`` tuples for every uploaded chunk.
 
     ``encoding`` is the (lowercased) value of the request's ``Content-Encoding``

--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -59,14 +59,20 @@ class ChunkTooLarge(OSError):
 def _read_bounded(reader, limit):
     """Read up to ``limit`` bytes from ``reader``; raise :class:`ChunkTooLarge` if more.
 
-    Asks for ``limit + 1`` bytes so that any overflow can be detected in bounded
-    memory -- this caps peak allocation regardless of how well-compressed the
-    input is, protecting against zstd/gzip decompression bombs.
+    Loops until the reader signals EOF or we exceed ``limit``. The loop matters
+    for ``ZstdDecompressor.stream_reader``, which may short-read when its
+    underlying source does (a real file-backed ``TemporaryUploadedFile`` can);
+    without looping, a bomb payload that happens to short-read past the cap
+    could slip through. Peak memory stays bounded at ``limit + 1`` bytes.
     """
-    data = reader.read(limit + 1)
-    if len(data) > limit:
-        raise ChunkTooLarge("Chunk size too large")
-    return data
+    buf = bytearray()
+    while True:
+        chunk = reader.read(limit + 1 - len(buf))
+        if not chunk:
+            return bytes(buf)
+        buf.extend(chunk)
+        if len(buf) > limit:
+            raise ChunkTooLarge("Chunk size too large")
 
 
 class GzipChunk(BytesIO):

--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -86,7 +86,12 @@ class GzipChunk(BytesIO):
 
 class ZstdChunk(BytesIO):
     def __init__(self, file):
-        reader = zstandard.ZstdDecompressor().stream_reader(file)
+        # `read_across_frames=True` mirrors the behaviour of `GzipFile.read()`
+        # (which reads across concatenated gzip members) and matches the
+        # convention in `src/sentry/models/eventattachment.py`. Without it a
+        # multi-frame zstd payload would silently decode only the first frame
+        # and produce a misleading checksum-mismatch error.
+        reader = zstandard.ZstdDecompressor().stream_reader(file, read_across_frames=True)
         data = _read_bounded(reader, settings.SENTRY_CHUNK_UPLOAD_BLOB_SIZE)
         self.size = len(data)
         self.name = file.name

--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -1,9 +1,7 @@
 import logging
 import re
-from collections.abc import Iterator
 from gzip import BadGzipFile, GzipFile
 from io import BytesIO
-from typing import IO, Protocol
 
 import zstandard
 from django.conf import settings
@@ -51,12 +49,6 @@ CHUNK_UPLOAD_ACCEPT = (
     "dartsymbolmap",  # Dart/Flutter symbol mapping files
 )
 
-# Compression codecs advertised to clients via the `compression` field of the
-# chunk-upload options response. Clients use this list to decide how to encode
-# chunks on upload. New codecs must:
-#   - be detectable via the HTTP `Content-Encoding` request header on POST, AND
-#   - decompress with a hard cap of `settings.SENTRY_CHUNK_UPLOAD_BLOB_SIZE` to
-#     prevent decompression bombs.
 CHUNK_UPLOAD_COMPRESSION = ("gzip", "zstd")
 
 
@@ -64,66 +56,34 @@ class ChunkTooLarge(OSError):
     """Raised when a (possibly decompressed) chunk exceeds the per-chunk size limit."""
 
 
-class _Reader(Protocol):
-    """Minimal structural type for any bounded-read source.
-
-    Covers the concrete types we pass in (``GzipFile`` from ``gzip`` and
-    ``ZstdDecompressor().stream_reader`` from ``zstandard``) without forcing
-    them to satisfy the full ``IO[bytes]`` protocol -- which they don't.
-    """
-
-    def read(self, __n: int = ...) -> bytes: ...
-
-
-class _SizedChunk(Protocol):
-    """A chunk we can size and name before handing it to ``FileBlob.from_files``.
-
-    Both Django's ``UploadedFile`` (plain uploads) and our ``GzipChunk``/
-    ``ZstdChunk`` wrappers expose ``.size`` and ``.name``; the underlying
-    ``IO[bytes]`` type does not, which is why we need this narrower protocol.
-    """
-
-    size: int
-    name: str
-
-    def read(self, __n: int = ...) -> bytes: ...
-
-
-def _read_bounded(reader: _Reader, limit: int) -> bytes:
+def _read_bounded(reader, limit):
     """Read up to ``limit`` bytes from ``reader``; raise :class:`ChunkTooLarge` if more.
 
-    We ask for ``limit + 1`` bytes and let the stream produce as much as it can within
-    that budget. If any more bytes are available after that read, the stream exceeds
-    the cap and we bail. This keeps memory bounded at ``limit + 1`` bytes regardless
-    of how well-compressed the input is (protects against zstd/gzip decompression
-    bombs where a small compressed payload expands to hundreds of megabytes).
+    Asks for ``limit + 1`` bytes so that any overflow can be detected in bounded
+    memory -- this caps peak allocation regardless of how well-compressed the
+    input is, protecting against zstd/gzip decompression bombs.
     """
     data = reader.read(limit + 1)
     if len(data) > limit:
-        raise ChunkTooLarge("Chunk size too large")
-    # Guard against streams that returned short and still have more data available
-    # after a short read (shouldn't happen with BufferedReader but be defensive).
-    extra = reader.read(1)
-    if extra:
         raise ChunkTooLarge("Chunk size too large")
     return data
 
 
 class GzipChunk(BytesIO):
-    def __init__(self, file: IO[bytes]) -> None:
+    def __init__(self, file):
         reader = GzipFile(fileobj=file, mode="rb")
         data = _read_bounded(reader, settings.SENTRY_CHUNK_UPLOAD_BLOB_SIZE)
         self.size = len(data)
-        self.name = getattr(file, "name", "")
+        self.name = file.name
         super().__init__(data)
 
 
 class ZstdChunk(BytesIO):
-    def __init__(self, file: IO[bytes]) -> None:
+    def __init__(self, file):
         reader = zstandard.ZstdDecompressor().stream_reader(file)
         data = _read_bounded(reader, settings.SENTRY_CHUNK_UPLOAD_BLOB_SIZE)
         self.size = len(data)
-        self.name = getattr(file, "name", "")
+        self.name = file.name
         super().__init__(data)
 
 
@@ -215,7 +175,7 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
             # If user overridden upload url prefix, we want an absolute, versioned endpoint, with user-configured prefix
             url = absolute_uri(relative_url, endpoint)
 
-        compression: list[str] = (
+        compression = (
             []
             if organization.id in options.get("chunk-upload.no-compression")
             else list(CHUNK_UPLOAD_COMPRESSION)
@@ -248,21 +208,14 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
         Requests to this endpoint should use the region-specific domain
         eg. `us.sentry.io` or `de.sentry.io`
 
-        Compression is negotiated via the HTTP ``Content-Encoding`` request
-        header. Supported values are listed in the ``compression`` field of the
-        ``GET`` response (currently ``gzip`` and ``zstd``). When set, every
-        chunk delivered under the ``file`` multipart field is decoded using
-        that codec.
+        Chunks may be compressed with ``gzip`` or ``zstd``. Codec is selected
+        via the ``Content-Encoding`` request header; the legacy ``file_gzip``
+        multipart field is still accepted but cannot be combined with the
+        header.
 
-        The legacy ``file_gzip`` multipart field is still accepted for
-        backwards compatibility with older clients, but is deprecated in favor
-        of ``Content-Encoding: gzip`` on the ``file`` field. Requests that mix
-        ``Content-Encoding`` with a ``file_gzip`` entry are rejected with 400
-        to avoid ambiguity -- clients must pick one mechanism per request.
-
-        :pparam file file: The filename should be sha1 hash of the (decoded)
-                            content. Also note you can add up to
-                            MAX_CHUNKS_PER_REQUEST files in this request.
+        :pparam file file: The filename should be sha1 hash of the content.
+                            Also not you can add up to MAX_CHUNKS_PER_REQUEST files
+                            in this request.
 
         :auth: required
         """
@@ -281,10 +234,6 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
         files_plain = request.FILES.getlist("file")
         files_gzip_legacy = request.FILES.getlist("file_gzip")
 
-        # Mixing the new Content-Encoding mechanism with the deprecated
-        # `file_gzip` field is ambiguous: the legacy field always means gzip
-        # regardless of the header, so a request with both is asking the server
-        # to apply two different codecs in one upload. Reject up front.
         if encoding and files_gzip_legacy:
             logger.info("chunkupload.end", extra={"status": status.HTTP_400_BAD_REQUEST})
             return Response(
@@ -292,8 +241,8 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        files: list[_SizedChunk] = []
-        checksums: list[str] = []
+        files = []
+        checksums = []
         total_size = 0
 
         # Validate if chunks exceed the maximum chunk limit before attempting to decompress them.
@@ -332,10 +281,6 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
             logger.info("chunkupload.end", extra={"status": status.HTTP_400_BAD_REQUEST})
             return Response({"error": "Invalid zstd payload"}, status=status.HTTP_400_BAD_REQUEST)
         except (BadGzipFile, EOFError):
-            # BadGzipFile: bad magic / bad header. EOFError: stream truncated
-            # mid-decompression. GzipFile raises these via its read() path, so
-            # we also cover the legacy file_gzip multipart upload, not just
-            # Content-Encoding: gzip.
             logger.info("chunkupload.end", extra={"status": status.HTTP_400_BAD_REQUEST})
             return Response({"error": "Invalid gzip payload"}, status=status.HTTP_400_BAD_REQUEST)
 
@@ -351,18 +296,7 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
         return Response(status=status.HTTP_200_OK)
 
 
-def get_files(request: Request, encoding: str) -> Iterator[tuple[_SizedChunk, str]]:
-    """Yield ``(chunk, checksum)`` tuples for every uploaded chunk.
-
-    ``encoding`` is the (lowercased) value of the request's ``Content-Encoding``
-    header and must be ``""``, ``"gzip"``, or ``"zstd"`` (validated by the
-    caller). When non-empty, every chunk under the ``file`` multipart field is
-    decoded using that codec.
-
-    The legacy ``file_gzip`` multipart field is always decoded as gzip
-    independent of the header. It is deprecated in favor of
-    ``Content-Encoding: gzip`` on the ``file`` field.
-    """
+def get_files(request: Request, encoding: str):
     for chunk in request.FILES.getlist("file"):
         if encoding == "gzip":
             yield GzipChunk(chunk), chunk.name
@@ -371,8 +305,7 @@ def get_files(request: Request, encoding: str) -> Iterator[tuple[_SizedChunk, st
         else:
             yield chunk, chunk.name
 
-    # Deprecated: prefer `Content-Encoding: gzip` on the `file` field. Retained
-    # for backwards compatibility with older sentry-cli versions that always
-    # dispatch gzipped chunks under this field name.
+    # Legacy: older clients send gzipped chunks under `file_gzip` with no
+    # Content-Encoding header. Prefer `Content-Encoding: gzip` on `file`.
     for chunk in request.FILES.getlist("file_gzip"):
         yield GzipChunk(chunk), chunk.name

--- a/src/sentry/api/endpoints/chunk.py
+++ b/src/sentry/api/endpoints/chunk.py
@@ -1,8 +1,11 @@
 import logging
 import re
+from collections.abc import Iterator
 from gzip import GzipFile
 from io import BytesIO
+from typing import IO
 
+import zstandard
 from django.conf import settings
 from django.urls import reverse
 from rest_framework import status
@@ -48,12 +51,54 @@ CHUNK_UPLOAD_ACCEPT = (
     "dartsymbolmap",  # Dart/Flutter symbol mapping files
 )
 
+# Compression codecs advertised to clients via the `compression` field of the
+# chunk-upload options response. Clients use this list to decide how to encode
+# chunks on upload. New codecs must:
+#   - be detectable via the HTTP `Content-Encoding` request header on POST, AND
+#   - decompress with a hard cap of `settings.SENTRY_CHUNK_UPLOAD_BLOB_SIZE` to
+#     prevent decompression bombs.
+CHUNK_UPLOAD_COMPRESSION = ("gzip", "zstd")
+
+
+class ChunkTooLarge(OSError):
+    """Raised when a (possibly decompressed) chunk exceeds the per-chunk size limit."""
+
+
+def _read_bounded(reader: IO[bytes], limit: int) -> bytes:
+    """Read up to ``limit`` bytes from ``reader``; raise :class:`ChunkTooLarge` if more.
+
+    We ask for ``limit + 1`` bytes and let the stream produce as much as it can within
+    that budget. If any more bytes are available after that read, the stream exceeds
+    the cap and we bail. This keeps memory bounded at ``limit + 1`` bytes regardless
+    of how well-compressed the input is (protects against zstd/gzip decompression
+    bombs where a small compressed payload expands to hundreds of megabytes).
+    """
+    data = reader.read(limit + 1)
+    if len(data) > limit:
+        raise ChunkTooLarge("Chunk size too large")
+    # Guard against streams that returned short and still have more data available
+    # after a short read (shouldn't happen with BufferedReader but be defensive).
+    extra = reader.read(1)
+    if extra:
+        raise ChunkTooLarge("Chunk size too large")
+    return data
+
 
 class GzipChunk(BytesIO):
-    def __init__(self, file):
-        data = GzipFile(fileobj=file, mode="rb").read()
+    def __init__(self, file: IO[bytes]) -> None:
+        reader = GzipFile(fileobj=file, mode="rb")
+        data = _read_bounded(reader, settings.SENTRY_CHUNK_UPLOAD_BLOB_SIZE)
         self.size = len(data)
-        self.name = file.name
+        self.name = getattr(file, "name", "")
+        super().__init__(data)
+
+
+class ZstdChunk(BytesIO):
+    def __init__(self, file: IO[bytes]) -> None:
+        reader = zstandard.ZstdDecompressor().stream_reader(file)
+        data = _read_bounded(reader, settings.SENTRY_CHUNK_UPLOAD_BLOB_SIZE)
+        self.size = len(data)
+        self.name = getattr(file, "name", "")
         super().__init__(data)
 
 
@@ -145,8 +190,10 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
             # If user overridden upload url prefix, we want an absolute, versioned endpoint, with user-configured prefix
             url = absolute_uri(relative_url, endpoint)
 
-        compression = (
-            [] if organization.id in options.get("chunk-upload.no-compression") else ["gzip"]
+        compression: list[str] = (
+            []
+            if organization.id in options.get("chunk-upload.no-compression")
+            else list(CHUNK_UPLOAD_COMPRESSION)
         )
         accept = CHUNK_UPLOAD_ACCEPT
 
@@ -176,9 +223,21 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
         Requests to this endpoint should use the region-specific domain
         eg. `us.sentry.io` or `de.sentry.io`
 
-        :pparam file file: The filename should be sha1 hash of the content.
-                            Also not you can add up to MAX_CHUNKS_PER_REQUEST files
-                            in this request.
+        Compression is negotiated via the HTTP ``Content-Encoding`` request
+        header. Supported values are listed in the ``compression`` field of the
+        ``GET`` response (currently ``gzip`` and ``zstd``). When set, every
+        chunk delivered under the ``file`` multipart field is decoded using
+        that codec.
+
+        The legacy ``file_gzip`` multipart field is still accepted for
+        backwards compatibility with older clients, but is deprecated in favor
+        of ``Content-Encoding: gzip`` on the ``file`` field. Requests that mix
+        ``Content-Encoding`` with a ``file_gzip`` entry are rejected with 400
+        to avoid ambiguity -- clients must pick one mechanism per request.
+
+        :pparam file file: The filename should be sha1 hash of the (decoded)
+                            content. Also note you can add up to
+                            MAX_CHUNKS_PER_REQUEST files in this request.
 
         :auth: required
         """
@@ -187,12 +246,33 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
         logger = logging.getLogger("sentry.files")
         logger.info("chunkupload.start")
 
-        files = []
-        checksums = []
+        encoding = request.headers.get("Content-Encoding", "").strip().lower()
+        if encoding and encoding not in CHUNK_UPLOAD_COMPRESSION:
+            logger.info("chunkupload.end", extra={"status": status.HTTP_400_BAD_REQUEST})
+            return Response(
+                {"error": "Unsupported Content-Encoding"}, status=status.HTTP_400_BAD_REQUEST
+            )
+
+        files_plain = request.FILES.getlist("file")
+        files_gzip_legacy = request.FILES.getlist("file_gzip")
+
+        # Mixing the new Content-Encoding mechanism with the deprecated
+        # `file_gzip` field is ambiguous: the legacy field always means gzip
+        # regardless of the header, so a request with both is asking the server
+        # to apply two different codecs in one upload. Reject up front.
+        if encoding and files_gzip_legacy:
+            logger.info("chunkupload.end", extra={"status": status.HTTP_400_BAD_REQUEST})
+            return Response(
+                {"error": "Cannot combine Content-Encoding with file_gzip field"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        files: list[IO[bytes]] = []
+        checksums: list[str] = []
         total_size = 0
 
         # Validate if chunks exceed the maximum chunk limit before attempting to decompress them.
-        num_files = len(request.FILES.getlist("file")) + len(request.FILES.getlist("file_gzip"))
+        num_files = len(files_plain) + len(files_gzip_legacy)
 
         if num_files > MAX_CHUNKS_PER_REQUEST:
             logger.info("chunkupload.end", extra={"status": status.HTTP_400_BAD_REQUEST})
@@ -203,20 +283,29 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
             logger.info("chunkupload.end", extra={"status": status.HTTP_200_OK})
             return Response(status=status.HTTP_200_OK)
 
-        for chunk, name in get_files(request):
-            if chunk.size > settings.SENTRY_CHUNK_UPLOAD_BLOB_SIZE:
-                logger.info("chunkupload.end", extra={"status": status.HTTP_400_BAD_REQUEST})
-                return Response(
-                    {"error": "Chunk size too large"}, status=status.HTTP_400_BAD_REQUEST
-                )
+        try:
+            for chunk, name in get_files(request, encoding):
+                if chunk.size > settings.SENTRY_CHUNK_UPLOAD_BLOB_SIZE:
+                    logger.info("chunkupload.end", extra={"status": status.HTTP_400_BAD_REQUEST})
+                    return Response(
+                        {"error": "Chunk size too large"}, status=status.HTTP_400_BAD_REQUEST
+                    )
 
-            total_size += chunk.size
-            if total_size > MAX_REQUEST_SIZE:
-                logger.info("chunkupload.end", extra={"status": status.HTTP_400_BAD_REQUEST})
-                return Response({"error": "Request too large"}, status=status.HTTP_400_BAD_REQUEST)
+                total_size += chunk.size
+                if total_size > MAX_REQUEST_SIZE:
+                    logger.info("chunkupload.end", extra={"status": status.HTTP_400_BAD_REQUEST})
+                    return Response(
+                        {"error": "Request too large"}, status=status.HTTP_400_BAD_REQUEST
+                    )
 
-            files.append(chunk)
-            checksums.append(name)
+                files.append(chunk)
+                checksums.append(name)
+        except ChunkTooLarge:
+            logger.info("chunkupload.end", extra={"status": status.HTTP_400_BAD_REQUEST})
+            return Response({"error": "Chunk size too large"}, status=status.HTTP_400_BAD_REQUEST)
+        except zstandard.ZstdError:
+            logger.info("chunkupload.end", extra={"status": status.HTTP_400_BAD_REQUEST})
+            return Response({"error": "Invalid zstd payload"}, status=status.HTTP_400_BAD_REQUEST)
 
         logger.info("chunkupload.post.files", extra={"len": len(files)})
 
@@ -230,10 +319,28 @@ class ChunkUploadEndpoint(OrganizationEndpoint):
         return Response(status=status.HTTP_200_OK)
 
 
-def get_files(request: Request):
-    for chunk in request.FILES.getlist("file"):
-        yield chunk, chunk.name
+def get_files(request: Request, encoding: str) -> Iterator[tuple[IO[bytes], str]]:
+    """Yield ``(chunk, checksum)`` tuples for every uploaded chunk.
 
+    ``encoding`` is the (lowercased) value of the request's ``Content-Encoding``
+    header and must be ``""``, ``"gzip"``, or ``"zstd"`` (validated by the
+    caller). When non-empty, every chunk under the ``file`` multipart field is
+    decoded using that codec.
+
+    The legacy ``file_gzip`` multipart field is always decoded as gzip
+    independent of the header. It is deprecated in favor of
+    ``Content-Encoding: gzip`` on the ``file`` field.
+    """
+    for chunk in request.FILES.getlist("file"):
+        if encoding == "gzip":
+            yield GzipChunk(chunk), chunk.name
+        elif encoding == "zstd":
+            yield ZstdChunk(chunk), chunk.name
+        else:
+            yield chunk, chunk.name
+
+    # Deprecated: prefer `Content-Encoding: gzip` on the `file` field. Retained
+    # for backwards compatibility with older sentry-cli versions that always
+    # dispatch gzipped chunks under this field name.
     for chunk in request.FILES.getlist("file_gzip"):
-        decompressed_chunk = GzipChunk(chunk)
-        yield decompressed_chunk, chunk.name
+        yield GzipChunk(chunk), chunk.name

--- a/tests/sentry/api/endpoints/test_chunk_upload.py
+++ b/tests/sentry/api/endpoints/test_chunk_upload.py
@@ -540,6 +540,9 @@ class ChunkUploadTest(APITestCase):
         )
 
         assert response.status_code == 400, response.content
+        assert response.json() == {
+            "error": "Cannot combine Content-Encoding with file_gzip field"
+        }
         assert not FileBlob.objects.exists()
 
     def test_upload_rejects_unsupported_content_encoding(self) -> None:
@@ -556,6 +559,7 @@ class ChunkUploadTest(APITestCase):
         )
 
         assert response.status_code == 400, response.content
+        assert response.json() == {"error": "Unsupported Content-Encoding"}
         assert not FileBlob.objects.exists()
 
     def test_upload_zstd_decompression_bomb(self) -> None:
@@ -579,6 +583,7 @@ class ChunkUploadTest(APITestCase):
         )
 
         assert response.status_code == 400, response.content
+        assert response.json() == {"error": "Chunk size too large"}
         assert not FileBlob.objects.exists()
 
     def test_upload_invalid_zstd_payload(self) -> None:
@@ -594,6 +599,7 @@ class ChunkUploadTest(APITestCase):
         )
 
         assert response.status_code == 400, response.content
+        assert response.json() == {"error": "Invalid zstd payload"}
 
     def test_upload_invalid_gzip_payload_content_encoding(self) -> None:
         """Malformed gzip payload via Content-Encoding should return 400, not 500."""
@@ -610,6 +616,7 @@ class ChunkUploadTest(APITestCase):
         )
 
         assert response.status_code == 400, response.content
+        assert response.json() == {"error": "Invalid gzip payload"}
 
     def test_upload_invalid_gzip_payload_legacy_field(self) -> None:
         """Malformed gzip via legacy file_gzip field should return 400, not 500."""
@@ -625,6 +632,7 @@ class ChunkUploadTest(APITestCase):
         )
 
         assert response.status_code == 400, response.content
+        assert response.json() == {"error": "Invalid gzip payload"}
 
     def test_upload_truncated_gzip_payload(self) -> None:
         """Truncated gzip (valid header, missing tail) should return 400, not 500."""
@@ -641,3 +649,4 @@ class ChunkUploadTest(APITestCase):
         )
 
         assert response.status_code == 400, response.content
+        assert response.json() == {"error": "Invalid gzip payload"}

--- a/tests/sentry/api/endpoints/test_chunk_upload.py
+++ b/tests/sentry/api/endpoints/test_chunk_upload.py
@@ -540,9 +540,7 @@ class ChunkUploadTest(APITestCase):
         )
 
         assert response.status_code == 400, response.content
-        assert response.json() == {
-            "error": "Cannot combine Content-Encoding with file_gzip field"
-        }
+        assert response.json() == {"error": "Cannot combine Content-Encoding with file_gzip field"}
         assert not FileBlob.objects.exists()
 
     def test_upload_rejects_unsupported_content_encoding(self) -> None:

--- a/tests/sentry/api/endpoints/test_chunk_upload.py
+++ b/tests/sentry/api/endpoints/test_chunk_upload.py
@@ -476,6 +476,28 @@ class ChunkUploadTest(APITestCase):
         stored_checksums = {fb.checksum for fb in file_blobs}
         assert stored_checksums == {checksum1, checksum2}
 
+    def test_upload_content_encoding_zstd_multi_frame(self) -> None:
+        """Multi-frame zstd payload should decode fully (read_across_frames)."""
+        part_a = b"first frame payload "
+        part_b = b"second frame payload"
+        data = part_a + part_b
+        compressor = zstandard.ZstdCompressor()
+        # Concatenate two independent zstd frames into one blob.
+        compressed = compressor.compress(part_a) + compressor.compress(part_b)
+        checksum = sha1(data).hexdigest()
+        blob = SimpleUploadedFile(checksum, compressed, content_type="multipart/form-data")
+
+        response = self.client.post(
+            self.url,
+            data={"file": [blob]},
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+            HTTP_CONTENT_ENCODING="zstd",
+            format="multipart",
+        )
+
+        assert response.status_code == 200, response.content
+        assert FileBlob.objects.filter(checksum=checksum).exists()
+
     def test_upload_content_encoding_zstd_mixed_case(self) -> None:
         """Content-Encoding should be normalized (case-insensitive per RFC 7231)."""
         data = b"hello zstd"

--- a/tests/sentry/api/endpoints/test_chunk_upload.py
+++ b/tests/sentry/api/endpoints/test_chunk_upload.py
@@ -1,7 +1,9 @@
+import gzip
 import math
 from hashlib import sha1
 
 import pytest
+import zstandard
 from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import override_settings
@@ -11,6 +13,7 @@ from sentry import options
 from sentry.api.endpoints.chunk import (
     API_PREFIX,
     CHUNK_UPLOAD_ACCEPT,
+    CHUNK_UPLOAD_COMPRESSION,
     HASH_ALGORITHM,
     MAX_CHUNKS_PER_REQUEST,
     MAX_CONCURRENCY,
@@ -59,6 +62,9 @@ class ChunkUploadTest(APITestCase):
         assert response.data["hashAlgorithm"] == HASH_ALGORITHM
         assert response.data["url"] == generate_locality_url() + self.url
         assert response.data["accept"] == CHUNK_UPLOAD_ACCEPT
+        assert response.data["compression"] == list(CHUNK_UPLOAD_COMPRESSION)
+        assert "gzip" in response.data["compression"]
+        assert "zstd" in response.data["compression"]
 
         with override_options({"system.upload-url-prefix": "test"}):
             response = self.client.get(
@@ -428,6 +434,162 @@ class ChunkUploadTest(APITestCase):
             self.url,
             data={"file": files},
             HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+            format="multipart",
+        )
+
+        assert response.status_code == 400, response.content
+
+    def test_chunk_parameters_no_compression_option(self) -> None:
+        with override_options({"chunk-upload.no-compression": [self.organization.id]}):
+            response = self.client.get(
+                self.url, HTTP_AUTHORIZATION=f"Bearer {self.token.token}", format="json"
+            )
+
+        assert response.status_code == 200, response.content
+        assert response.data["compression"] == []
+
+    def test_upload_content_encoding_zstd(self) -> None:
+        data1 = b"1 this is my testString"
+        data2 = b"2 this is my testString"
+        checksum1 = sha1(data1).hexdigest()
+        checksum2 = sha1(data2).hexdigest()
+        compressor = zstandard.ZstdCompressor()
+        blob1 = SimpleUploadedFile(
+            checksum1, compressor.compress(data1), content_type="multipart/form-data"
+        )
+        blob2 = SimpleUploadedFile(
+            checksum2, compressor.compress(data2), content_type="multipart/form-data"
+        )
+
+        response = self.client.post(
+            self.url,
+            data={"file": [blob1, blob2]},
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+            HTTP_CONTENT_ENCODING="zstd",
+            format="multipart",
+        )
+
+        assert response.status_code == 200, response.content
+
+        file_blobs = FileBlob.objects.all()
+        assert len(file_blobs) == 2
+        stored_checksums = {fb.checksum for fb in file_blobs}
+        assert stored_checksums == {checksum1, checksum2}
+
+    def test_upload_content_encoding_zstd_mixed_case(self) -> None:
+        """Content-Encoding should be normalized (case-insensitive per RFC 7231)."""
+        data = b"hello zstd"
+        checksum = sha1(data).hexdigest()
+        blob = SimpleUploadedFile(
+            checksum, zstandard.ZstdCompressor().compress(data), content_type="multipart/form-data"
+        )
+
+        response = self.client.post(
+            self.url,
+            data={"file": [blob]},
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+            HTTP_CONTENT_ENCODING="ZSTD",
+            format="multipart",
+        )
+
+        assert response.status_code == 200, response.content
+        assert FileBlob.objects.filter(checksum=checksum).exists()
+
+    def test_upload_content_encoding_gzip(self) -> None:
+        data = b"hello gzip"
+        checksum = sha1(data).hexdigest()
+        blob = SimpleUploadedFile(checksum, gzip.compress(data), content_type="multipart/form-data")
+
+        response = self.client.post(
+            self.url,
+            data={"file": [blob]},
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+            HTTP_CONTENT_ENCODING="gzip",
+            format="multipart",
+        )
+
+        assert response.status_code == 200, response.content
+        assert FileBlob.objects.filter(checksum=checksum).exists()
+
+    def test_upload_legacy_file_gzip_still_works(self) -> None:
+        data = b"legacy gzip field"
+        checksum = sha1(data).hexdigest()
+        blob = SimpleUploadedFile(checksum, gzip.compress(data), content_type="multipart/form-data")
+
+        response = self.client.post(
+            self.url,
+            data={"file_gzip": [blob]},
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+            format="multipart",
+        )
+
+        assert response.status_code == 200, response.content
+        assert FileBlob.objects.filter(checksum=checksum).exists()
+
+    def test_upload_rejects_content_encoding_with_file_gzip(self) -> None:
+        data = b"ambiguous"
+        checksum = sha1(data).hexdigest()
+        blob = SimpleUploadedFile(checksum, gzip.compress(data), content_type="multipart/form-data")
+
+        response = self.client.post(
+            self.url,
+            data={"file_gzip": [blob]},
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+            HTTP_CONTENT_ENCODING="gzip",
+            format="multipart",
+        )
+
+        assert response.status_code == 400, response.content
+        assert not FileBlob.objects.exists()
+
+    def test_upload_rejects_unsupported_content_encoding(self) -> None:
+        data = b"brotli?"
+        checksum = sha1(data).hexdigest()
+        blob = SimpleUploadedFile(checksum, data, content_type="multipart/form-data")
+
+        response = self.client.post(
+            self.url,
+            data={"file": [blob]},
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+            HTTP_CONTENT_ENCODING="br",
+            format="multipart",
+        )
+
+        assert response.status_code == 400, response.content
+        assert not FileBlob.objects.exists()
+
+    def test_upload_zstd_decompression_bomb(self) -> None:
+        """A tiny zstd payload that would decompress to >chunkSize must be rejected."""
+        # Highly compressible payload: 8 MiB + 1 byte of the same character. Zstd
+        # compresses this to well under 1 KiB, so the compressed chunk easily
+        # passes the raw per-chunk size check, but decompression must still bail.
+        raw = b"a" * (settings.SENTRY_CHUNK_UPLOAD_BLOB_SIZE + 1)
+        compressed = zstandard.ZstdCompressor().compress(raw)
+        assert len(compressed) < settings.SENTRY_CHUNK_UPLOAD_BLOB_SIZE
+        blob = SimpleUploadedFile(
+            sha1(raw).hexdigest(), compressed, content_type="multipart/form-data"
+        )
+
+        response = self.client.post(
+            self.url,
+            data={"file": [blob]},
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+            HTTP_CONTENT_ENCODING="zstd",
+            format="multipart",
+        )
+
+        assert response.status_code == 400, response.content
+        assert not FileBlob.objects.exists()
+
+    def test_upload_invalid_zstd_payload(self) -> None:
+        """Malformed zstd payload should return 400, not 500."""
+        blob = SimpleUploadedFile("0" * 40, b"not a zstd frame", content_type="multipart/form-data")
+
+        response = self.client.post(
+            self.url,
+            data={"file": [blob]},
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+            HTTP_CONTENT_ENCODING="zstd",
             format="multipart",
         )
 

--- a/tests/sentry/api/endpoints/test_chunk_upload.py
+++ b/tests/sentry/api/endpoints/test_chunk_upload.py
@@ -628,11 +628,8 @@ class ChunkUploadTest(APITestCase):
 
     def test_upload_truncated_gzip_payload(self) -> None:
         """Truncated gzip (valid header, missing tail) should return 400, not 500."""
-        import gzip as gzip_mod
-
-        full = gzip_mod.compress(b"some real data that gzip will compress")
         # Keep only the first 6 bytes -- valid magic + method but no data
-        truncated = full[:6]
+        truncated = gzip.compress(b"some real data that gzip will compress")[:6]
         blob = SimpleUploadedFile("0" * 40, truncated, content_type="multipart/form-data")
 
         response = self.client.post(

--- a/tests/sentry/api/endpoints/test_chunk_upload.py
+++ b/tests/sentry/api/endpoints/test_chunk_upload.py
@@ -594,3 +594,53 @@ class ChunkUploadTest(APITestCase):
         )
 
         assert response.status_code == 400, response.content
+
+    def test_upload_invalid_gzip_payload_content_encoding(self) -> None:
+        """Malformed gzip payload via Content-Encoding should return 400, not 500."""
+        blob = SimpleUploadedFile(
+            "0" * 40, b"not a gzip stream", content_type="multipart/form-data"
+        )
+
+        response = self.client.post(
+            self.url,
+            data={"file": [blob]},
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+            HTTP_CONTENT_ENCODING="gzip",
+            format="multipart",
+        )
+
+        assert response.status_code == 400, response.content
+
+    def test_upload_invalid_gzip_payload_legacy_field(self) -> None:
+        """Malformed gzip via legacy file_gzip field should return 400, not 500."""
+        blob = SimpleUploadedFile(
+            "0" * 40, b"not a gzip stream", content_type="multipart/form-data"
+        )
+
+        response = self.client.post(
+            self.url,
+            data={"file_gzip": [blob]},
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+            format="multipart",
+        )
+
+        assert response.status_code == 400, response.content
+
+    def test_upload_truncated_gzip_payload(self) -> None:
+        """Truncated gzip (valid header, missing tail) should return 400, not 500."""
+        import gzip as gzip_mod
+
+        full = gzip_mod.compress(b"some real data that gzip will compress")
+        # Keep only the first 6 bytes -- valid magic + method but no data
+        truncated = full[:6]
+        blob = SimpleUploadedFile("0" * 40, truncated, content_type="multipart/form-data")
+
+        response = self.client.post(
+            self.url,
+            data={"file": [blob]},
+            HTTP_AUTHORIZATION=f"Bearer {self.token.token}",
+            HTTP_CONTENT_ENCODING="gzip",
+            format="multipart",
+        )
+
+        assert response.status_code == 400, response.content


### PR DESCRIPTION
## Summary

Extends the chunk-upload endpoint used by sourcemap / artifact-bundle / DIF / preprod uploads to accept **zstd-compressed** chunks in addition to the existing gzip path, advertised to clients via the `compression` capability list in the GET response.

## Protocol changes

- **New `Content-Encoding` detection path.** When `Content-Encoding: gzip` or `Content-Encoding: zstd` is set on a chunk upload POST, every chunk delivered under the standard `file` multipart field is decoded using that codec.
- **Legacy `file_gzip` field still works** for backwards compatibility with older `sentry-cli` / `@sentry/cli` versions that only know how to send chunks under that field name.
- **Ambiguous requests are rejected** with HTTP 400 (`Cannot combine Content-Encoding with file_gzip field`). A single request cannot use both mechanisms.
- **Unsupported encodings** return HTTP 400 (`Unsupported Content-Encoding`).
- **`compression` list extended** to `["gzip", "zstd"]`. No `CHUNK_UPLOAD_ACCEPT` entry is added — clients have always feature-detected compression via this list. The existing `chunk-upload.no-compression` org allowlist kill-switch continues to disable all compression codecs.

## Security / safety

Decompression is **streamed** through `zstandard.ZstdDecompressor().stream_reader(file)` (and `GzipFile` for gzip) via a bounded-read helper that loops until EOF or a hard cap of `settings.SENTRY_CHUNK_UPLOAD_BLOB_SIZE` (8 MiB) on decoded output per chunk. The loop handles short reads from streaming decoders (important for `ZstdDecompressor.stream_reader` + file-backed `TemporaryUploadedFile`). Excess bytes raise `ChunkTooLarge` → 400. Peak memory stays bounded at `limit + 1` bytes regardless of how well-compressed the input is, protecting against decompression-bomb inputs where a tiny compressed payload would expand to hundreds of megabytes.

Invalid / malformed payloads are all converted to 400 (never 500):
- `zstandard.ZstdError` → `Invalid zstd payload`
- `gzip.BadGzipFile` (bad magic / header) → `Invalid gzip payload`
- `EOFError` (truncated stream) → `Invalid gzip payload`

## End-to-end verified

Ran the full request pipeline (middleware + auth + DRF + endpoint) against the live getsentry devservices stack on a fresh Coder VM and confirmed:

- GET options endpoint advertises `"compression": ["gzip", "zstd"]`.
- POST with `Content-Encoding: zstd` + a zstd-compressed chunk → 200 + `FileBlob` persisted.
- POST with `Content-Encoding: gzip` + a gzipped chunk → 200 (new gzip-via-header path).
- POST with legacy `file_gzip` field (no header) → 200 (backwards compat).
- POST combining both forms → 400 `{"error": "Cannot combine Content-Encoding with file_gzip field"}`.
- POST with `Content-Encoding: br` → 400 `{"error": "Unsupported Content-Encoding"}`.
- POST with a zstd payload that would decompress to 8 MiB+1 → 400 `{"error": "Chunk size too large"}` without OOMing.

## Tests

- Updated `test_chunk_parameters` to assert `compression == ["gzip", "zstd"]`.
- Added 12 new tests in `tests/sentry/api/endpoints/test_chunk_upload.py`:
  - `test_chunk_parameters_no_compression_option` — kill switch zeroes the list.
  - `test_upload_content_encoding_zstd` — happy path, 2 chunks.
  - `test_upload_content_encoding_zstd_multi_frame` — concatenated zstd frames decode fully (`read_across_frames=True`).
  - `test_upload_content_encoding_zstd_mixed_case` — `Content-Encoding: ZSTD` accepted (RFC 7231 case-insensitive).
  - `test_upload_content_encoding_gzip` — gzip-via-header path.
  - `test_upload_legacy_file_gzip_still_works` — backwards compat.
  - `test_upload_rejects_content_encoding_with_file_gzip` — 400 on ambiguous request.
  - `test_upload_rejects_unsupported_content_encoding` — 400 on `br`.
  - `test_upload_zstd_decompression_bomb` — rejects 8 MiB+1 expansion.
  - `test_upload_invalid_zstd_payload` — malformed zstd → 400, not 500.
  - `test_upload_invalid_gzip_payload_content_encoding` — malformed gzip via header → 400.
  - `test_upload_invalid_gzip_payload_legacy_field` — malformed gzip via `file_gzip` → 400.
  - `test_upload_truncated_gzip_payload` — valid header, truncated stream → 400.

Negative tests also pin the exact error-body shape so a typo in the error string would be caught.

`pytest --reuse-db tests/sentry/api/endpoints/test_chunk_upload.py` → **30 passed**. mypy + pre-commit clean.

## Scope boundaries

- No changes to `src/sentry/tasks/assemble.py`, `src/sentry/debug_files/upload.py`, or the assemble endpoints — they operate on already-decompressed `FileBlob`s keyed by sha1.
- `zstandard>=0.18.0` is already a direct dep in `pyproject.toml` and used extensively elsewhere (`src/sentry/utils/codecs.py`, `src/sentry/attachments/base.py`, `src/sentry/spans/buffer.py`, etc.). No new dependencies.
- No protocol version bump needed — clients feature-detect via the `compression` list, matching the existing pattern.
- Error responses use `{"error": ...}` to stay consistent with the rest of this file (4 pre-existing `"error"` sites at lines 264/276/283/304) and with the neighbouring chunk-upload surface (`organization_artifactbundle_assemble.py`). `src/AGENTS.md` now recommends `{"detail": ...}` for new endpoints; migrating the whole chunk-upload subsystem is out of scope for this PR.

## Companion PR

CLI side: getsentry/cli#823 (merged) — teaches the new TS/Bun `@loreai/cli` to send zstd-compressed chunks via the `Content-Encoding: zstd` header when the server advertises it.
