### PR TITLE
feat(dashboards): Accept 7d interval in RPC granularities

### DIFF
--- a/src/sentry/search/eap/constants.py
+++ b/src/sentry/search/eap/constants.py
@@ -150,6 +150,7 @@ VALID_GRANULARITIES = frozenset(
         6 * 3600,
         12 * 3600,
         24 * 3600,  # hours
+        7 * 24 * 3600,  # days
     }
 )
 TRUTHY_VALUES = {"1", "true"}

--- a/src/sentry/snuba/snuba_query_validator.py
+++ b/src/sentry/snuba/snuba_query_validator.py
@@ -54,10 +54,15 @@ UNSUPPORTED_QUERIES = {"release:latest"}
 CRASH_RATE_ALERTS_ALLOWED_TIME_WINDOWS = [1800, 3600, 7200, 14400, 43200, 86400]
 
 MIN_EAP_ALERT_TIME_WINDOW_SECONDS = 300
+# EAP alert windows are capped at 1 day — larger granularities in VALID_GRANULARITIES
+# (e.g. 7d, used by the dashboards weekly interval) are not meaningful as alert windows.
+MAX_EAP_ALERT_TIME_WINDOW_SECONDS = 24 * 3600
 
-# Valid time windows for EAP alerts: valid Snuba granularities at or above the alert minimum.
+# Valid time windows for EAP alerts: valid Snuba granularities within the allowed alert range.
 EAP_ALERTS_ALLOWED_TIME_WINDOWS = sorted(
-    g for g in VALID_GRANULARITIES if g >= MIN_EAP_ALERT_TIME_WINDOW_SECONDS
+    g
+    for g in VALID_GRANULARITIES
+    if MIN_EAP_ALERT_TIME_WINDOW_SECONDS <= g <= MAX_EAP_ALERT_TIME_WINDOW_SECONDS
 )
 
 

--- a/tests/sentry/snuba/test_validators.py
+++ b/tests/sentry/snuba/test_validators.py
@@ -292,6 +292,23 @@ class SnubaQueryValidatorTest(TestCase):
             "user",
         ]
 
+    def test_eap_rejects_seven_day_time_window(self) -> None:
+        # 7 days (604800s) is a valid dashboards granularity but must not be accepted as an
+        # EAP alert time window — alerts are capped at 1 day.
+        data = {
+            "dataset": Dataset.EventsAnalyticsPlatform.value,
+            "query": "",
+            "aggregate": "count()",
+            "timeWindow": 7 * 24 * 3600,
+            "environment": self.environment.name,
+            "eventTypes": [SnubaQueryEventType.EventType.TRACE_ITEM_SPAN.name.lower()],
+        }
+        validator = SnubaQueryValidator(data=data, context=self.context, timeWindowSeconds=True)
+        assert not validator.is_valid()
+        assert any(
+            "Invalid Time Window" in str(err) for errs in validator.errors.values() for err in errs
+        )
+
     def test_eap_user_misery_aggregate(self) -> None:
         data = {
             "dataset": Dataset.EventsAnalyticsPlatform.value,

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -963,6 +963,21 @@ class OrganizationEventsStatsEndpointTest(APITestCase, SnubaTestCase, SearchIssu
         assert response.status_code == 200
         assert [attrs for time, attrs in response.data["data"]] == [[{"count": 0}], [{"count": 1}]]
 
+    def test_seven_day_interval_over_thirty_day_range(self) -> None:
+        response = self.do_request(
+            data={
+                "project": self.project.id,
+                "end": self.day_ago,
+                "start": self.day_ago - timedelta(days=30),
+                "interval": "7d",
+                "yAxis": "count()",
+            },
+        )
+        assert response.status_code == 200, response.content
+        # 30d at 7d buckets is ~5 points (rollup may emit a partial leading/trailing bucket);
+        # assert it's bounded so we catch regressions in the bucket-count cap.
+        assert 4 <= len(response.data["data"]) <= 6
+
     @mock.patch("sentry.snuba.discover.timeseries_query", return_value={})
     def test_multiple_yaxis_only_one_query(self, mock_query: mock.MagicMock) -> None:
         self.do_request(


### PR DESCRIPTION
This is the backend half of adding a 7 day bucket option to the dashboards interval dropdown — customers on 30d+ time ranges can view week-over-week error rates once the follow-up frontend PR exposes the new option.

re: https://github.com/getsentry/sentry/pull/112562 (the previous changes made to re-balance interval options), here's how the new point will look moving forwards:

| Duration Range | 1m | 5m | 10m | 30m | 1h | 3h | 6h | 12h | 7d |
|---|---|---|---|---|---|---|---|---|---|
| **1h–6h** | **60–359** | 12–71 | - | - | - | - | - | - | - |
| **6h–12h** | *360–719* | **72–143** | 36–71 | - | - | - | - | - | - |
| **12h–2d** | - | *144–575* | **72–287** | 24–95 | - | - | - | - | - |
| **2d–4d** | - | - | *288–575* | **96–191** | 48–95 | - | - | - | - |
| **4d–14d** | - | - | - | *192–671* | **96–335** | 32–111 | - | - | - |
| **14d–30d** | - | - | - | - | *336–719* | **112–239** | 56–119 | - | - |
| **30d–90d** | - | - | - | - | - | *240–720* | **120–360** | 60–180 | _4-13_ |

## Review notes

- No feature flag — this is enabling a granularity the backend already understands mathematically. The user-visible dropdown ships behind its own frontend PR that I'll open once this one is deployed.

Refs LINEAR-DAIN-1529
Refs GH-113096