### PR TITLE
fix(onboarding): Sync SCM context with product toggles on setup-docs

### DIFF
--- a/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
@@ -54,7 +54,7 @@ export type OnboardingLayoutProps = {
    * onProductSelectionChange. Used by SCM onboarding to keep its context in
    * sync when the user changes products on the setup-docs step.
    */
-  onProductsChange?: (products: ProductSolution[]) => void;
+  onProductSelectionSync?: (products: ProductSolution[]) => void;
 };
 
 const EMPTY_ARRAY: never[] = [];
@@ -68,7 +68,7 @@ export function OnboardingLayout({
   newOrg,
   projectKeyId,
   configType = 'onboarding',
-  onProductsChange,
+  onProductSelectionSync,
 }: OnboardingLayoutProps) {
   const api = useApi();
   const organization = useOrganization();
@@ -169,9 +169,9 @@ export function OnboardingLayout({
   const handleProductSelectionChange = useCallback(
     (params: {previousProducts: ProductSolution[]; products: ProductSolution[]}) => {
       onProductSelectionChange?.(params);
-      onProductsChange?.(params.products);
+      onProductSelectionSync?.(params.products);
     },
-    [onProductSelectionChange, onProductsChange]
+    [onProductSelectionChange, onProductSelectionSync]
   );
 
   const hideInstructionsCopy = (docsConfig[configType] ?? docsConfig.onboarding)

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useMemo} from 'react';
+import {Fragment, useCallback, useEffect, useMemo} from 'react';
 import styled from '@emotion/styled';
 
 import {Stack} from '@sentry/scraps/layout';
@@ -49,6 +49,12 @@ export type OnboardingLayoutProps = {
   activeProductSelection?: ProductSolution[];
   configType?: ConfigType;
   newOrg?: boolean;
+  /**
+   * Fires after every product toggle in addition to the doc's
+   * onProductSelectionChange. Used by SCM onboarding to keep its context in
+   * sync when the user changes products on the setup-docs step.
+   */
+  onProductsChange?: (products: ProductSolution[]) => void;
 };
 
 const EMPTY_ARRAY: never[] = [];
@@ -62,6 +68,7 @@ export function OnboardingLayout({
   newOrg,
   projectKeyId,
   configType = 'onboarding',
+  onProductsChange,
 }: OnboardingLayoutProps) {
   const api = useApi();
   const organization = useOrganization();
@@ -159,6 +166,14 @@ export function OnboardingLayout({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const handleProductSelectionChange = useCallback(
+    (params: {previousProducts: ProductSolution[]; products: ProductSolution[]}) => {
+      onProductSelectionChange?.(params);
+      onProductsChange?.(params.products);
+    },
+    [onProductSelectionChange, onProductsChange]
+  );
+
   const hideInstructionsCopy = (docsConfig[configType] ?? docsConfig.onboarding)
     ?.hideInstructionsCopy;
 
@@ -172,7 +187,7 @@ export function OnboardingLayout({
               <ProductSelectionAvailabilityHook
                 organization={organization}
                 platform={platformKey}
-                onChange={onProductSelectionChange}
+                onChange={handleProductSelectionChange}
                 onLoad={onProductSelectionLoad}
               />
             )}

--- a/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.tsx
@@ -18,7 +18,7 @@ type SdkDocumentationProps = {
   project: Project;
   configType?: ConfigType;
   newOrg?: boolean;
-  onProductsChange?: (products: ProductSolution[]) => void;
+  onProductSelectionSync?: (products: ProductSolution[]) => void;
 };
 
 // Loads the component containing the documentation for the specified platform
@@ -29,7 +29,7 @@ export function SdkDocumentation({
   newOrg,
   configType,
   organization,
-  onProductsChange,
+  onProductSelectionSync,
 }: SdkDocumentationProps) {
   const {isLoading, isError, dsn, docs, refetch, projectKeyId} = useLoadGettingStarted({
     orgSlug: organization.slug,
@@ -97,7 +97,7 @@ export function SdkDocumentation({
       project={project}
       configType={configType}
       projectKeyId={projectKeyId}
-      onProductsChange={onProductsChange}
+      onProductSelectionSync={onProductSelectionSync}
     />
   );
 }

--- a/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.tsx
@@ -18,6 +18,7 @@ type SdkDocumentationProps = {
   project: Project;
   configType?: ConfigType;
   newOrg?: boolean;
+  onProductsChange?: (products: ProductSolution[]) => void;
 };
 
 // Loads the component containing the documentation for the specified platform
@@ -28,6 +29,7 @@ export function SdkDocumentation({
   newOrg,
   configType,
   organization,
+  onProductsChange,
 }: SdkDocumentationProps) {
   const {isLoading, isError, dsn, docs, refetch, projectKeyId} = useLoadGettingStarted({
     orgSlug: organization.slug,
@@ -95,6 +97,7 @@ export function SdkDocumentation({
       project={project}
       configType={configType}
       projectKeyId={projectKeyId}
+      onProductsChange={onProductsChange}
     />
   );
 }

--- a/static/app/views/onboarding/setupDocs.spec.tsx
+++ b/static/app/views/onboarding/setupDocs.spec.tsx
@@ -6,14 +6,19 @@ import {
   render,
   screen,
   userEvent,
+  waitFor,
   waitForElementToBeRemoved,
 } from 'sentry-test/reactTestingLibrary';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {OnboardingContextProvider} from 'sentry/components/onboarding/onboardingContext';
+import {
+  OnboardingContextProvider,
+  useOnboardingContext,
+} from 'sentry/components/onboarding/onboardingContext';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
+import {sessionStorageWrapper} from 'sentry/utils/sessionStorage';
 import {SetupDocs} from 'sentry/views/onboarding/setupDocs';
 
 const PROJECT_KEY = ProjectKeysFixture()[0];
@@ -56,6 +61,10 @@ function renderMockRequests({
 }
 
 describe('Onboarding Setup Docs', () => {
+  beforeEach(() => {
+    sessionStorageWrapper.clear();
+  });
+
   it('does not render Product Selection', async () => {
     const organization = OrganizationFixture();
     const project = ProjectFixture({
@@ -373,7 +382,7 @@ describe('Onboarding Setup Docs', () => {
         await screen.findByRole('radio', {name: 'Loader Script'})
       ).toBeInTheDocument();
 
-      await userEvent.click(screen.getByRole('button', {name: 'Session Replay'}));
+      await userEvent.click(await screen.findByRole('button', {name: 'Session Replay'}));
       expect(updateLoaderMock).toHaveBeenCalledTimes(2);
 
       expect(updateLoaderMock).toHaveBeenLastCalledWith(
@@ -424,6 +433,144 @@ describe('Onboarding Setup Docs', () => {
         await screen.findByRole('heading', {name: 'Configure Other SDK'})
       ).toBeInTheDocument();
     });
+  });
+
+  it('syncs product toggles into onboarding context for SCM onboarding', async () => {
+    const organization = OrganizationFixture({
+      features: ['session-replay', 'performance-view', 'onboarding-scm-experiment'],
+    });
+    const project = ProjectFixture({
+      slug: 'javascript-react',
+      platform: 'javascript-react',
+    });
+
+    ProjectsStore.init();
+    ProjectsStore.loadInitialData([project]);
+
+    renderMockRequests({project, orgSlug: organization.slug});
+
+    function FeaturesObserver() {
+      const {selectedFeatures} = useOnboardingContext();
+      return (
+        <div data-test-id="selected-features">{(selectedFeatures ?? []).join(',')}</div>
+      );
+    }
+
+    render(
+      <OnboardingContextProvider
+        initialValue={{
+          selectedFeatures: [
+            ProductSolution.PERFORMANCE_MONITORING,
+            ProductSolution.SESSION_REPLAY,
+          ],
+        }}
+      >
+        <FeaturesObserver />
+        <SetupDocs
+          onComplete={() => {}}
+          stepIndex={2}
+          genSkipOnboardingLink={() => ''}
+          recentCreatedProject={project}
+        />
+      </OnboardingContextProvider>,
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: `/onboarding/${organization.slug}/setup-docs/`,
+            query: {
+              product: [
+                ProductSolution.PERFORMANCE_MONITORING,
+                ProductSolution.SESSION_REPLAY,
+              ],
+            },
+          },
+          route: '/onboarding/:orgId/setup-docs/',
+        },
+      }
+    );
+
+    expect(
+      await screen.findByRole('heading', {name: 'Configure React SDK'})
+    ).toBeInTheDocument();
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Session Replay'}));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-features')).toHaveTextContent(
+        ProductSolution.PERFORMANCE_MONITORING
+      );
+    });
+    expect(screen.getByTestId('selected-features')).not.toHaveTextContent(
+      ProductSolution.SESSION_REPLAY
+    );
+  });
+
+  it('does not sync product toggles into onboarding context for legacy onboarding', async () => {
+    const organization = OrganizationFixture({
+      features: ['session-replay', 'performance-view'],
+    });
+    const project = ProjectFixture({
+      slug: 'javascript-react',
+      platform: 'javascript-react',
+    });
+
+    ProjectsStore.init();
+    ProjectsStore.loadInitialData([project]);
+
+    renderMockRequests({project, orgSlug: organization.slug});
+
+    function FeaturesObserver() {
+      const {selectedFeatures} = useOnboardingContext();
+      return (
+        <div data-test-id="selected-features">{(selectedFeatures ?? []).join(',')}</div>
+      );
+    }
+
+    render(
+      <OnboardingContextProvider
+        initialValue={{
+          selectedFeatures: [
+            ProductSolution.PERFORMANCE_MONITORING,
+            ProductSolution.SESSION_REPLAY,
+          ],
+        }}
+      >
+        <FeaturesObserver />
+        <SetupDocs
+          onComplete={() => {}}
+          stepIndex={2}
+          genSkipOnboardingLink={() => ''}
+          recentCreatedProject={project}
+        />
+      </OnboardingContextProvider>,
+      {
+        organization,
+        initialRouterConfig: {
+          location: {
+            pathname: `/onboarding/${organization.slug}/setup-docs/`,
+            query: {
+              product: [
+                ProductSolution.PERFORMANCE_MONITORING,
+                ProductSolution.SESSION_REPLAY,
+              ],
+            },
+          },
+          route: '/onboarding/:orgId/setup-docs/',
+        },
+      }
+    );
+
+    expect(
+      await screen.findByRole('heading', {name: 'Configure React SDK'})
+    ).toBeInTheDocument();
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Session Replay'}));
+
+    // Context remains at its initial value; toggle only updated URL, not context.
+    expect(screen.getByTestId('selected-features')).toHaveTextContent(
+      ProductSolution.SESSION_REPLAY
+    );
   });
 
   it('reads feature selections from URL params', async () => {

--- a/static/app/views/onboarding/setupDocs.tsx
+++ b/static/app/views/onboarding/setupDocs.tsx
@@ -63,7 +63,9 @@ export function SetupDocs({recentCreatedProject: project, genBackButton}: StepPr
                 organization={organization}
                 project={project}
                 activeProductSelection={products}
-                onProductsChange={hasScmOnboarding ? setSelectedFeatures : undefined}
+                onProductSelectionSync={
+                  hasScmOnboarding ? setSelectedFeatures : undefined
+                }
                 newOrg
               />
             )}

--- a/static/app/views/onboarding/setupDocs.tsx
+++ b/static/app/views/onboarding/setupDocs.tsx
@@ -5,6 +5,7 @@ import {Flex} from '@sentry/scraps/layout';
 
 import {SdkDocumentation} from 'sentry/components/onboarding/gettingStartedDoc/sdkDocumentation';
 import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {useOnboardingContext} from 'sentry/components/onboarding/onboardingContext';
 import {otherPlatform, allPlatforms as platforms} from 'sentry/data/platforms';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -24,6 +25,7 @@ export function SetupDocs({recentCreatedProject: project, genBackButton}: StepPr
   const organization = useOrganization();
   const location = useLocation();
   const navigate = useNavigate();
+  const {setSelectedFeatures} = useOnboardingContext();
   const {inExperiment: hasScmOnboarding} = useExperiment({
     feature: 'onboarding-scm-experiment',
     reportExposure: false,
@@ -61,6 +63,7 @@ export function SetupDocs({recentCreatedProject: project, genBackButton}: StepPr
                 organization={organization}
                 project={project}
                 activeProductSelection={products}
+                onProductsChange={hasScmOnboarding ? setSelectedFeatures : undefined}
                 newOrg
               />
             )}


### PR DESCRIPTION
## TL;DR

Product toggles on the setup-docs step don't sync back into `OnboardingContext`, so SCM back-navigation shows stale selections and re-expands deselected products on Continue.

This PR wires a callback from `ProductSelection` through `SdkDocumentation` and `OnboardingLayout` into `setSelectedFeatures`, keeping the context aligned with URL state when the SCM experiment is active.

## Background

SCM onboarding preselects products in `scmPlatformFeatures` and forwards them to setup-docs via URL query. `ProductSelection` on the setup-docs step still renders and writes toggles back to the URL, but not to `OnboardingContext`. Back-navigation then reads stale `selectedFeatures`, shows previously-deselected items as checked, and re-expands them on Continue.

## The fix

Thread an optional `onProductSelectionSync` callback through `SdkDocumentation` and `OnboardingLayout` so `setupDocs` can wire `setSelectedFeatures` in when the SCM experiment is active. The callback is composed with the existing `doc.onProductSelectionChange` handler so both fire on every toggle. Legacy onboarding passes `undefined` and is unchanged.

## Not addressed

Toggles on setup-docs do not fire `onboarding.scm_platform_feature_toggled`. The legacy `ProductSelection` has no analytics on toggle at all, so there is no parallel event to emit; that would need a new handler if funnel coverage on this edge becomes important.