### PR TITLE
feat(dashboards): Add 7d interval option for 30d+ periods

### DIFF
--- a/static/app/utils/useChartInterval.spec.tsx
+++ b/static/app/utils/useChartInterval.spec.tsx
@@ -53,6 +53,79 @@ describe('useChartInterval', () => {
     });
     expect(chartInterval).toBe('5m');
   });
+
+  it('offers 7d interval when period is >= 30d', () => {
+    let intervalOptions!: ReturnType<typeof useChartInterval>[2];
+
+    function TestPage() {
+      [, , intervalOptions] = useChartInterval();
+      return null;
+    }
+
+    act(() =>
+      PageFiltersStore.updateDateTime({
+        period: '30d',
+        start: null,
+        end: null,
+        utc: true,
+      })
+    );
+
+    render(<TestPage />);
+
+    expect(intervalOptions).toContainEqual({value: '7d', label: '7 days'});
+    expect(intervalOptions).toContainEqual({value: '1d', label: '1 day'});
+  });
+
+  it('does not offer 7d interval below the 30d threshold', () => {
+    let intervalOptions!: ReturnType<typeof useChartInterval>[2];
+
+    function TestPage() {
+      [, , intervalOptions] = useChartInterval();
+      return null;
+    }
+
+    act(() =>
+      PageFiltersStore.updateDateTime({
+        period: '29d',
+        start: null,
+        end: null,
+        utc: true,
+      })
+    );
+
+    render(<TestPage />);
+
+    expect(intervalOptions).not.toContainEqual({value: '7d', label: '7 days'});
+    // 1d is still offered for periods >= 14d
+    expect(intervalOptions).toContainEqual({value: '1d', label: '1 day'});
+  });
+
+  it('falls back to default when URL interval is 7d but the period dropped below 30d', () => {
+    let chartInterval!: ReturnType<typeof useChartInterval>[0];
+    let intervalOptions!: ReturnType<typeof useChartInterval>[2];
+
+    function TestPage() {
+      [chartInterval, , intervalOptions] = useChartInterval();
+      return null;
+    }
+
+    act(() =>
+      PageFiltersStore.updateDateTime({
+        period: '14d',
+        start: null,
+        end: null,
+        utc: true,
+      })
+    );
+
+    render(<TestPage />, {
+      initialRouterConfig: {location: {pathname: '/foo/', query: {interval: '7d'}}},
+    });
+
+    expect(intervalOptions).not.toContainEqual({value: '7d', label: '7 days'});
+    expect(chartInterval).not.toBe('7d');
+  });
 });
 
 describe('getIntervalOptionsForPageFilter', () => {

--- a/static/app/utils/useChartInterval.tsx
+++ b/static/app/utils/useChartInterval.tsx
@@ -80,6 +80,10 @@ function useChartIntervalImpl({
       options.push(ONE_DAY_OPTION);
     }
 
+    if (diffInMinutes >= MINIMUM_DURATION_FOR_SEVEN_DAY_INTERVAL) {
+      options.push(SEVEN_DAY_OPTION);
+    }
+
     return {intervalOptions: options, defaultInterval: fallback};
   }, [datetime, unspecifiedStrategy]);
 
@@ -147,6 +151,9 @@ const MAXIMUM_INTERVAL = new GranularityLadder([
 
 const ONE_DAY_OPTION = {value: '1d', label: t('1 day')};
 const MINIMUM_DURATION_FOR_ONE_DAY_INTERVAL = TWO_WEEKS;
+
+const SEVEN_DAY_OPTION = {value: '7d', label: t('7 days')};
+const MINIMUM_DURATION_FOR_SEVEN_DAY_INTERVAL = THIRTY_DAYS;
 
 export function getIntervalOptionsForPageFilter(datetime: PageFilters['datetime']) {
   const diffInMinutes = getDiffInMinutes(datetime);


### PR DESCRIPTION
Add a 7 day (weekly) option to the dashboard chart interval dropdown so users can view week-over-week charts on long time ranges. The option is appended when the selected period is at least 30 days, mirroring the existing 1 day carve-out that's gated on 14 days.

Note that this will impact Explore in addition to Dashboards since `useChartInterval` is a shared hook between Dashboards and Explore.

Depends on https://github.com/getsentry/sentry/pull/113762 (backend changes)

Refs LINEAR-DAIN-1529
Refs GH-113096