### PR TITLE
fix(aci): Fix bug in detector query filter when using workflow_ids

### DIFF
--- a/static/app/views/automations/components/connectedMonitorsList.tsx
+++ b/static/app/views/automations/components/connectedMonitorsList.tsx
@@ -102,7 +102,7 @@ export function ConnectedMonitorsList({
         ? new MutableSearch([query ?? '', `workflow:${workflowId}`]).formatString()
         : query,
       includeIssueStreamDetectors: true,
-      projects: [...projectIds, '-1'],
+      projects: [...projectIds, -1],
     }),
     select: selectJsonWithHeaders,
     enabled: !defined(detectorIds) || !emptySelection,

--- a/static/app/views/automations/components/connectedMonitorsList.tsx
+++ b/static/app/views/automations/components/connectedMonitorsList.tsx
@@ -85,7 +85,7 @@ export function ConnectedMonitorsList({
   limit = DEFAULT_DETECTORS_PER_PAGE,
   query,
   openInNewTab,
-  projectIds,
+  projectIds = [],
   workflowId,
   ...props
 }: Props) {
@@ -102,7 +102,7 @@ export function ConnectedMonitorsList({
         ? new MutableSearch([query ?? '', `workflow:${workflowId}`]).formatString()
         : query,
       includeIssueStreamDetectors: true,
-      projects: projectIds,
+      projects: [...projectIds, '-1'],
     }),
     select: selectJsonWithHeaders,
     enabled: !defined(detectorIds) || !emptySelection,

--- a/static/app/views/automations/components/connectedMonitorsList.tsx
+++ b/static/app/views/automations/components/connectedMonitorsList.tsx
@@ -85,7 +85,7 @@ export function ConnectedMonitorsList({
   limit = DEFAULT_DETECTORS_PER_PAGE,
   query,
   openInNewTab,
-  projectIds = [],
+  projectIds,
   workflowId,
   ...props
 }: Props) {
@@ -102,7 +102,7 @@ export function ConnectedMonitorsList({
         ? new MutableSearch([query ?? '', `workflow:${workflowId}`]).formatString()
         : query,
       includeIssueStreamDetectors: true,
-      projects: [...projectIds, -1],
+      projects: projectIds ?? [-1],
     }),
     select: selectJsonWithHeaders,
     enabled: !defined(detectorIds) || !emptySelection,

--- a/static/app/views/automations/components/connectedProjectsList.tsx
+++ b/static/app/views/automations/components/connectedProjectsList.tsx
@@ -46,7 +46,7 @@ export function ConnectedProjectsList({automationId}: Props) {
   const {data, isPending, isError, isSuccess} = useQuery({
     ...detectorListApiOptions(organization, {
       query: `type:issue_stream workflow:${automationId}`,
-      projects: ['-1'],
+      projects: [-1],
       includeIssueStreamDetectors: true,
       limit: LIMIT,
       cursor,

--- a/static/app/views/automations/components/connectedProjectsList.tsx
+++ b/static/app/views/automations/components/connectedProjectsList.tsx
@@ -46,6 +46,7 @@ export function ConnectedProjectsList({automationId}: Props) {
   const {data, isPending, isError, isSuccess} = useQuery({
     ...detectorListApiOptions(organization, {
       query: `type:issue_stream workflow:${automationId}`,
+      projects: ['-1'],
       includeIssueStreamDetectors: true,
       limit: LIMIT,
       cursor,


### PR DESCRIPTION
# Description
Before, the self.get_projects did not include `include_all_accessible`, so it filtered the project lists to only projects i have access to. (This is the only logic change)

The rest of the changes are just small tweaks; getting the filters early to determine if we should include all accessible projects or not. The other is to simplify the filter iteration, now it can be less indented because we check for filters earlier.