### PR TITLE
fix(repositories): Don't raise errors for broken scms in repo sync task

### DIFF
--- a/src/sentry/integrations/source_code_management/sync_repos.py
+++ b/src/sentry/integrations/source_code_management/sync_repos.py
@@ -36,8 +36,8 @@ from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.plugins.providers.integration_repository import get_integration_repository_provider
 from sentry.shared_integrations.exceptions import (
     ApiError,
-    ApiPaginationTruncated,
     ApiForbiddenError,
+    ApiPaginationTruncated,
     ApiUnauthorized,
     IntegrationError,
 )

--- a/src/sentry/integrations/source_code_management/sync_repos.py
+++ b/src/sentry/integrations/source_code_management/sync_repos.py
@@ -229,11 +229,14 @@ def sync_repos_for_org(organization_integration_id: int) -> None:
             raise
         except IntegrationError as e:
             # VSTS's get_repositories re-wraps ApiError/IdentityNotValid into an
-            # IntegrationError with message_from_error; recognize the auth-failure
-            # message so broken VSTS installs don't retry or page us. Gated to
-            # VSTS because other providers may raise IntegrationError for
-            # unrelated reasons that shouldn't be silenced.
-            if provider_key == "vsts" and "Unauthorized" in str(e):
+            # IntegrationError via message_from_error. Message text isn't a
+            # reliable signal: ApiUnauthorized maps to ERR_UNAUTHORIZED but
+            # IdentityNotValid maps to ERR_INTERNAL ("An internal error..."),
+            # which wouldn't match a "Unauthorized" string match. Python sets
+            # __context__ to the original exception when you raise inside an
+            # except block, so inspect that directly.
+            cause = e.__context__
+            if provider_key == "vsts" and isinstance(cause, (IdentityNotValid, ApiUnauthorized)):
                 _halt_broken_integration(
                     lifecycle, e, integration.id, rpc_org.id, provider_key, "unauthorized"
                 )

--- a/src/sentry/integrations/source_code_management/sync_repos.py
+++ b/src/sentry/integrations/source_code_management/sync_repos.py
@@ -17,6 +17,7 @@ from django.utils import timezone
 from taskbroker_client.retry import Retry
 
 from sentry import features
+from sentry.auth.exceptions import IdentityNotValid
 from sentry.constants import ObjectStatus
 from sentry.features.exceptions import FeatureNotRegistered
 from sentry.integrations.models.organization_integration import OrganizationIntegration
@@ -29,12 +30,16 @@ from sentry.integrations.source_code_management.metrics import (
 )
 from sentry.integrations.source_code_management.repo_audit import log_repo_change
 from sentry.integrations.source_code_management.repository import RepositoryIntegration
+from sentry.integrations.utils.metrics import IntegrationEventLifecycle
 from sentry.organizations.services.organization import organization_service
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.plugins.providers.integration_repository import get_integration_repository_provider
 from sentry.shared_integrations.exceptions import (
     ApiError,
     ApiPaginationTruncated,
+    ApiForbiddenError,
+    ApiUnauthorized,
+    IntegrationError,
 )
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
@@ -93,6 +98,39 @@ def _has_feature(flag: str, org: object) -> bool:
         return False
 
 
+def _halt_broken_integration(
+    lifecycle: IntegrationEventLifecycle,
+    exc: BaseException,
+    integration_id: int,
+    organization_id: int,
+    provider_key: str,
+    reason: str,
+) -> None:
+    """Record a known broken-integration failure without retrying or paging.
+
+    These are expected terminal states (expired OAuth token, suspended app
+    install, etc.) that the periodic sync can't recover from. We halt the
+    lifecycle so no Sentry issue is created, bump a counter that can be
+    dashboarded to watch the broken-integration population, and let the task
+    return cleanly (no retry).
+    """
+    lifecycle.record_halt(exc, create_issue=False)
+    metrics.incr(
+        "scm.repo_sync.get_repositories_failed",
+        tags={"provider": provider_key, "reason": reason},
+        sample_rate=1.0,
+    )
+    logger.info(
+        "sync_repos_for_org.broken_integration",
+        extra={
+            "integration_id": integration_id,
+            "organization_id": organization_id,
+            "provider": provider_key,
+            "reason": reason,
+        },
+    )
+
+
 @instrumented_task(
     name="sentry.integrations.source_code_management.sync_repos.sync_repos_for_org",
     namespace=integrations_control_tasks,
@@ -124,7 +162,7 @@ def sync_repos_for_org(organization_integration_id: int) -> None:
         integration_id=integration.id,
         organization_id=rpc_org.id,
         provider_key=provider_key,
-    ).capture():
+    ).capture() as lifecycle:
         installation = integration.get_installation(organization_id=rpc_org.id)
         assert isinstance(installation, RepositoryIntegration)
 
@@ -152,15 +190,54 @@ def sync_repos_for_org(organization_integration_id: int) -> None:
                 tags={"provider": provider_key},
                 sample_rate=1.0,
             )
+        except IdentityNotValid as e:
+            _halt_broken_integration(
+                lifecycle, e, integration.id, rpc_org.id, provider_key, "identity_not_valid"
+            )
+            return
         except ApiError as e:
+            # Rate-limit check first — GitHub surfaces rate limiting as a 403,
+            # so it must be detected before the suspended-install branch.
             if installation.is_rate_limited_error(e):
-                logger.info(
-                    "sync_repos_for_org.rate_limited",
-                    extra={
-                        "integration_id": integration.id,
-                        "organization_id": rpc_org.id,
-                    },
+                _halt_broken_integration(
+                    lifecycle, e, integration.id, rpc_org.id, provider_key, "rate_limited"
                 )
+                return
+            if isinstance(e, ApiUnauthorized):
+                _halt_broken_integration(
+                    lifecycle, e, integration.id, rpc_org.id, provider_key, "unauthorized"
+                )
+                return
+            # GitHub returns 403 "This installation has been suspended" when the
+            # user has suspended the app install. Treat as a dead integration.
+            # Gated to GitHub providers to avoid swallowing unrelated "suspended"
+            # 403s from other providers.
+            if (
+                provider_key in ("github", "github_enterprise")
+                and isinstance(e, ApiForbiddenError)
+                and "suspended" in str(e)
+            ):
+                _halt_broken_integration(
+                    lifecycle,
+                    e,
+                    integration.id,
+                    rpc_org.id,
+                    provider_key,
+                    "installation_suspended",
+                )
+                return
+            raise
+        except IntegrationError as e:
+            # VSTS's get_repositories re-wraps ApiError/IdentityNotValid into an
+            # IntegrationError with message_from_error; recognize the auth-failure
+            # message so broken VSTS installs don't retry or page us. Gated to
+            # VSTS because other providers may raise IntegrationError for
+            # unrelated reasons that shouldn't be silenced.
+            if provider_key == "vsts" and "Unauthorized" in str(e):
+                _halt_broken_integration(
+                    lifecycle, e, integration.id, rpc_org.id, provider_key, "unauthorized"
+                )
+                return
             raise
 
         provider_external_ids = {repo["external_id"] for repo in provider_repos}

--- a/tests/sentry/integrations/source_code_management/test_sync_repos.py
+++ b/tests/sentry/integrations/source_code_management/test_sync_repos.py
@@ -334,9 +334,6 @@ class SyncReposForOrgTestCase(IntegrationTestCase):
         with assume_test_silo_mode(SiloMode.CELL):
             assert Repository.objects.count() == 0
 
-        with assume_test_silo_mode(SiloMode.CELL):
-            assert Repository.objects.count() == 0
-
     @patch("sentry.integrations.github.client.GitHubBaseClient.get_repos")
     def test_truncated_fetch_skips_disable(self, mock_get_repos: MagicMock, _: MagicMock) -> None:
         from sentry.shared_integrations.exceptions import ApiPaginationTruncated

--- a/tests/sentry/integrations/source_code_management/test_sync_repos.py
+++ b/tests/sentry/integrations/source_code_management/test_sync_repos.py
@@ -688,11 +688,7 @@ class SyncReposForOrgVstsTestCase(TestCase):
         assert len(repos) == 2
         assert repos[0].provider == "integrations:vsts"
 
-    @patch("sentry.integrations.vsts.integration.VstsIntegration.get_repositories")
-    def test_vsts_integration_error_halts_without_retry(
-        self, mock_get_repositories: MagicMock
-    ) -> None:
-        from sentry.shared_integrations.exceptions import IntegrationError
+    def _create_vsts_integration(self) -> OrganizationIntegration:
         from sentry.users.models.identity import Identity
 
         integration = self.create_provider_integration(
@@ -713,14 +709,56 @@ class SyncReposForOrgVstsTestCase(TestCase):
             },
         )
         integration.add_organization(self.organization, self.user, identity.id)
-        oi = OrganizationIntegration.objects.get(
+        return OrganizationIntegration.objects.get(
             organization_id=self.organization.id, integration=integration
         )
 
-        mock_get_repositories.side_effect = IntegrationError(
-            "Unauthorized: either your access token was invalid or you do not have access"
-        )
+    @patch("sentry.integrations.vsts.integration.VstsIntegration.get_repositories")
+    def test_vsts_wrapped_unauthorized_halts_without_retry(
+        self, mock_get_repositories: MagicMock
+    ) -> None:
+        from sentry.shared_integrations.exceptions import ApiUnauthorized, IntegrationError
 
+        def _wrap_unauthorized(*args: object, **kwargs: object) -> None:
+            # Mirror VSTS's real wrapping: raise IntegrationError from inside the
+            # ApiUnauthorized except block so __context__ is populated.
+            try:
+                raise ApiUnauthorized("bad token")
+            except ApiUnauthorized:
+                raise IntegrationError(
+                    "Unauthorized: either your access token was invalid or you do not have access"
+                )
+
+        mock_get_repositories.side_effect = _wrap_unauthorized
+
+        oi = self._create_vsts_integration()
+        with self.feature("organizations:vsts-repo-auto-sync"), self.tasks():
+            sync_repos_for_org(oi.id)
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            assert Repository.objects.count() == 0
+
+    @patch("sentry.integrations.vsts.integration.VstsIntegration.get_repositories")
+    def test_vsts_wrapped_identity_not_valid_halts_without_retry(
+        self, mock_get_repositories: MagicMock
+    ) -> None:
+        # VSTS wraps IdentityNotValid in IntegrationError with ERR_INTERNAL,
+        # so the message does NOT contain "Unauthorized". The sync code must
+        # still halt by detecting the original via __context__.
+        from sentry.auth.exceptions import IdentityNotValid
+        from sentry.shared_integrations.exceptions import IntegrationError
+
+        def _wrap_identity_not_valid(*args: object, **kwargs: object) -> None:
+            try:
+                raise IdentityNotValid()
+            except IdentityNotValid:
+                raise IntegrationError(
+                    "An internal error occurred with the integration and the Sentry team has been notified"
+                )
+
+        mock_get_repositories.side_effect = _wrap_identity_not_valid
+
+        oi = self._create_vsts_integration()
         with self.feature("organizations:vsts-repo-auto-sync"), self.tasks():
             sync_repos_for_org(oi.id)
 

--- a/tests/sentry/integrations/source_code_management/test_sync_repos.py
+++ b/tests/sentry/integrations/source_code_management/test_sync_repos.py
@@ -1,8 +1,6 @@
 from unittest.mock import MagicMock, patch
 
-import pytest
 import responses
-from taskbroker_client.retry import RetryTaskError
 
 from sentry import audit_log
 from sentry.constants import ObjectStatus
@@ -303,7 +301,7 @@ class SyncReposForOrgTestCase(IntegrationTestCase):
             assert Repository.objects.count() == 0
 
     @responses.activate
-    def test_rate_limited_raises_for_retry(self, _: MagicMock) -> None:
+    def test_rate_limited_halts_without_retry(self, _: MagicMock) -> None:
         responses.add(
             responses.GET,
             self.base_url + "/installation/repositories?per_page=100",
@@ -314,9 +312,27 @@ class SyncReposForOrgTestCase(IntegrationTestCase):
             },
         )
 
-        with self.feature("organizations:github-repo-auto-sync"), pytest.raises(RetryTaskError):
-            with self.tasks():
-                sync_repos_for_org(self.oi.id)
+        with self.feature("organizations:github-repo-auto-sync"), self.tasks():
+            sync_repos_for_org(self.oi.id)
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            assert Repository.objects.count() == 0
+
+    @patch("sentry.integrations.github.integration.GitHubIntegration.get_repositories")
+    def test_installation_suspended_halts_without_retry(
+        self, mock_get_repositories: MagicMock, _: MagicMock
+    ) -> None:
+        from sentry.shared_integrations.exceptions import ApiForbiddenError
+
+        mock_get_repositories.side_effect = ApiForbiddenError(
+            '{"message":"This installation has been suspended"}'
+        )
+
+        with self.feature("organizations:github-repo-auto-sync"), self.tasks():
+            sync_repos_for_org(self.oi.id)
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            assert Repository.objects.count() == 0
 
         with assume_test_silo_mode(SiloMode.CELL):
             assert Repository.objects.count() == 0
@@ -671,3 +687,82 @@ class SyncReposForOrgVstsTestCase(TestCase):
 
         assert len(repos) == 2
         assert repos[0].provider == "integrations:vsts"
+
+    @patch("sentry.integrations.vsts.integration.VstsIntegration.get_repositories")
+    def test_vsts_integration_error_halts_without_retry(
+        self, mock_get_repositories: MagicMock
+    ) -> None:
+        from sentry.shared_integrations.exceptions import IntegrationError
+        from sentry.users.models.identity import Identity
+
+        integration = self.create_provider_integration(
+            provider="vsts",
+            external_id="vsts-account-id",
+            name="MyVSTSAccount",
+            metadata={"domain_name": "https://myvstsaccount.visualstudio.com/"},
+        )
+        identity = Identity.objects.create(
+            idp=self.create_identity_provider(type="vsts"),
+            user=self.user,
+            external_id="vsts123",
+            data={
+                "access_token": "123456789",
+                "expires": 9999999999,
+                "refresh_token": "rxxx",
+                "token_type": "jwt-bearer",
+            },
+        )
+        integration.add_organization(self.organization, self.user, identity.id)
+        oi = OrganizationIntegration.objects.get(
+            organization_id=self.organization.id, integration=integration
+        )
+
+        mock_get_repositories.side_effect = IntegrationError(
+            "Unauthorized: either your access token was invalid or you do not have access"
+        )
+
+        with self.feature("organizations:vsts-repo-auto-sync"), self.tasks():
+            sync_repos_for_org(oi.id)
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            assert Repository.objects.count() == 0
+
+
+@control_silo_test
+class SyncReposForOrgBrokenIdentityTestCase(TestCase):
+    @patch("sentry.integrations.gitlab.integration.GitlabIntegration.get_repositories")
+    def test_identity_not_valid_halts_without_retry(self, mock_get_repositories: MagicMock) -> None:
+        from sentry.auth.exceptions import IdentityNotValid
+        from sentry.users.models.identity import Identity
+
+        integration = self.create_provider_integration(
+            provider="gitlab",
+            name="Example Gitlab",
+            external_id="example.gitlab.com:group-x",
+            metadata={
+                "instance": "example.gitlab.com",
+                "base_url": "https://example.gitlab.com",
+                "domain_name": "example.gitlab.com/group-x",
+                "verify_ssl": False,
+                "group_id": 1,
+                "webhook_secret": "secret123",
+            },
+        )
+        identity = Identity.objects.create(
+            idp=self.create_identity_provider(type="gitlab", config={}),
+            user=self.user,
+            external_id="gitlab123",
+            data={"access_token": "123456789"},
+        )
+        integration.add_organization(self.organization, self.user, identity.id)
+        oi = OrganizationIntegration.objects.get(
+            organization_id=self.organization.id, integration=integration
+        )
+
+        mock_get_repositories.side_effect = IdentityNotValid()
+
+        with self.feature("organizations:gitlab-repo-auto-sync"), self.tasks():
+            sync_repos_for_org(oi.id)
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            assert Repository.objects.count() == 0


### PR DESCRIPTION
These errors are causing a lot of noise and aren't important. Ideally we'd disable these integrations, but that's a separate problem.

<!-- Describe your PR here. -->