### PR TITLE
fix(aci): Preserve additional_data keys when serializing ticket actions

### DIFF
--- a/src/sentry/notifications/notification_action/action_handler_registry/base.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/base.py
@@ -1,7 +1,9 @@
 import logging
 from abc import ABC
-from typing import override
+from typing import Any, override
 
+from sentry.api.serializers import Serializer
+from sentry.api.serializers.rest_framework.base import convert_dict_key_case, snake_to_camel_case
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.notifications.models.notificationaction import ActionTarget
 from sentry.notifications.notification_action.utils import execute_via_issue_alert_handler
@@ -15,7 +17,23 @@ class IntegrationActionHandler(ActionHandler, ABC):
     provider_slug: IntegrationProviderSlug
 
 
+class TicketingActionDataSerializer(Serializer):
+    """
+    `additional_fields`, stores third-party form field names as object
+    keys which must be preserved. (e.g. {"my_field": "my value"})
+    """
+
+    def serialize(self, obj: dict[str, Any], *args: Any, **kwargs: Any) -> dict[str, Any]:
+        rest = {k: v for k, v in obj.items() if k != "additional_fields"}
+        result: dict[str, Any] = convert_dict_key_case(rest, snake_to_camel_case)
+        if "additional_fields" in obj:
+            result["additionalFields"] = obj["additional_fields"]
+        return result
+
+
 class TicketingActionHandler(IntegrationActionHandler, ABC):
+    data_serializer = TicketingActionDataSerializer
+
     config_schema = {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "description": "The configuration schema for a Ticketing Action",

--- a/src/sentry/notifications/notification_action/action_handler_registry/base.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/base.py
@@ -2,7 +2,6 @@ import logging
 from abc import ABC
 from typing import Any, override
 
-from sentry.api.serializers import Serializer
 from sentry.api.serializers.rest_framework.base import convert_dict_key_case, snake_to_camel_case
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.notifications.models.notificationaction import ActionTarget
@@ -17,22 +16,16 @@ class IntegrationActionHandler(ActionHandler, ABC):
     provider_slug: IntegrationProviderSlug
 
 
-class TicketingActionDataSerializer(Serializer):
-    """
-    `additional_fields`, stores third-party form field names as object
-    keys which must be preserved. (e.g. {"my_field": "my value"})
-    """
-
-    def serialize(self, obj: dict[str, Any], *args: Any, **kwargs: Any) -> dict[str, Any]:
-        rest = {k: v for k, v in obj.items() if k != "additional_fields"}
-        result: dict[str, Any] = convert_dict_key_case(rest, snake_to_camel_case)
-        if "additional_fields" in obj:
-            result["additionalFields"] = obj["additional_fields"]
-        return result
-
-
 class TicketingActionHandler(IntegrationActionHandler, ABC):
-    data_serializer = TicketingActionDataSerializer
+    @classmethod
+    def serialize_data(cls, data: dict[str, Any]) -> dict[str, Any]:
+        # `additional_fields` stores third-party form field names as object
+        # keys which must be preserved (e.g. {"my_field": "my value"}).
+        rest = {k: v for k, v in data.items() if k != "additional_fields"}
+        result: dict[str, Any] = convert_dict_key_case(rest, snake_to_camel_case)
+        if "additional_fields" in data:
+            result["additionalFields"] = data["additional_fields"]
+        return result
 
     config_schema = {
         "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/src/sentry/workflow_engine/endpoints/serializers/action_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/action_serializer.py
@@ -20,6 +20,7 @@ class ActionSerializer(Serializer):
     def serialize(self, obj: Action, *args: Any, **kwargs: Any) -> ActionSerializerResponse:
         # Get the action handler and config transformer if available
         action_handler = action_handler_registry.get(obj.type)
+
         config_transformer = action_handler.get_config_transformer()
 
         # Transform config if transformer is available
@@ -28,11 +29,16 @@ class ActionSerializer(Serializer):
         else:
             config = obj.config
 
+        if action_handler.data_serializer is not None:
+            data = action_handler.data_serializer().serialize(obj.data, *args, **kwargs)
+        else:
+            data = convert_dict_key_case(obj.data, snake_to_camel_case)
+
         return {
             "id": str(obj.id),
             "type": obj.type,
             "integrationId": str(obj.integration_id) if obj.integration_id else None,
-            "data": convert_dict_key_case(obj.data, snake_to_camel_case),
+            "data": data,
             "config": convert_dict_key_case(config, snake_to_camel_case),
             "status": obj.get_status_display(),
         }

--- a/src/sentry/workflow_engine/endpoints/serializers/action_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/action_serializer.py
@@ -1,4 +1,3 @@
-from collections.abc import Mapping
 from typing import Any, TypedDict
 
 from sentry.api.serializers import Serializer, register
@@ -11,7 +10,7 @@ class ActionSerializerResponse(TypedDict):
     id: str
     type: str
     integrationId: str | None
-    data: Mapping[str, Any]
+    data: dict[str, Any]
     config: dict[str, Any]
     status: str
 
@@ -21,7 +20,6 @@ class ActionSerializer(Serializer):
     def serialize(self, obj: Action, *args: Any, **kwargs: Any) -> ActionSerializerResponse:
         # Get the action handler and config transformer if available
         action_handler = action_handler_registry.get(obj.type)
-
         config_transformer = action_handler.get_config_transformer()
 
         # Transform config if transformer is available
@@ -30,16 +28,11 @@ class ActionSerializer(Serializer):
         else:
             config = obj.config
 
-        if action_handler.data_serializer is not None:
-            data = action_handler.data_serializer().serialize(obj.data, *args, **kwargs)
-        else:
-            data = convert_dict_key_case(obj.data, snake_to_camel_case)
-
         return {
             "id": str(obj.id),
             "type": obj.type,
             "integrationId": str(obj.integration_id) if obj.integration_id else None,
-            "data": data,
+            "data": action_handler.serialize_data(obj.data),
             "config": convert_dict_key_case(config, snake_to_camel_case),
             "status": obj.get_status_display(),
         }

--- a/src/sentry/workflow_engine/endpoints/serializers/action_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/action_serializer.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from typing import Any, TypedDict
 
 from sentry.api.serializers import Serializer, register
@@ -10,7 +11,7 @@ class ActionSerializerResponse(TypedDict):
     id: str
     type: str
     integrationId: str | None
-    data: dict[str, Any]
+    data: Mapping[str, Any]
     config: dict[str, Any]
     status: str
 

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -14,7 +14,6 @@ from sentry import features, options
 from sentry.types.group import PriorityLevel
 
 if TYPE_CHECKING:
-    from sentry.api.serializers import Serializer
     from sentry.deletions.base import ModelRelation
     from sentry.eventstream.base import GroupState
     from sentry.issues.issue_occurrence import IssueOccurrence
@@ -287,10 +286,6 @@ class ActionHandler:
     config_schema: ClassVar[dict[str, Any]]
     data_schema: ClassVar[dict[str, Any]]
 
-    # Optionally provide a custom serializer for Action.data
-    # If None, data will serialized with snake_to_camel_case
-    data_serializer: ClassVar[type[Serializer] | None] = None
-
     class Group(StrEnum):
         NOTIFICATION = "notification"
         TICKET_CREATION = "ticket_creation"
@@ -301,6 +296,15 @@ class ActionHandler:
     @classmethod
     def get_config_transformer(cls) -> ConfigTransformer | None:
         return None
+
+    @classmethod
+    def serialize_data(cls, data: dict[str, Any]) -> dict[str, Any]:
+        from sentry.api.serializers.rest_framework.base import (
+            convert_dict_key_case,
+            snake_to_camel_case,
+        )
+
+        return convert_dict_key_case(data, snake_to_camel_case)
 
     @staticmethod
     def execute(invocation: ActionInvocation) -> None:

--- a/src/sentry/workflow_engine/types.py
+++ b/src/sentry/workflow_engine/types.py
@@ -14,6 +14,7 @@ from sentry import features, options
 from sentry.types.group import PriorityLevel
 
 if TYPE_CHECKING:
+    from sentry.api.serializers import Serializer
     from sentry.deletions.base import ModelRelation
     from sentry.eventstream.base import GroupState
     from sentry.issues.issue_occurrence import IssueOccurrence
@@ -285,6 +286,10 @@ class ConfigTransformer(ABC):
 class ActionHandler:
     config_schema: ClassVar[dict[str, Any]]
     data_schema: ClassVar[dict[str, Any]]
+
+    # Optionally provide a custom serializer for Action.data
+    # If None, data will serialized with snake_to_camel_case
+    data_serializer: ClassVar[type[Serializer] | None] = None
 
     class Group(StrEnum):
         NOTIFICATION = "notification"

--- a/tests/sentry/workflow_engine/endpoints/serializers/test_action_serializer.py
+++ b/tests/sentry/workflow_engine/endpoints/serializers/test_action_serializer.py
@@ -125,3 +125,32 @@ class TestActionSerializer(TestCase):
             },
             "status": "active",
         }
+
+    def test_serialize_ticketing_data_preserves_additional_fields_keys(self) -> None:
+        jira_integration = self.create_integration(
+            provider="jira",
+            name="jira-integration",
+            external_id="jira-123",
+            metadata={},
+            organization=self.organization,
+        )
+        action = self.create_action(
+            type=Action.Type.JIRA,
+            integration_id=jira_integration.id,
+            data={
+                "dynamic_form_fields": [{"name": "my_field", "label": "My Field"}],
+                "additional_fields": {
+                    "my_field": "my value",
+                },
+            },
+            config={"target_type": ActionTarget.SPECIFIC},
+        )
+
+        result = serialize(action)
+
+        assert result["data"] == {
+            "dynamicFormFields": [{"name": "my_field", "label": "My Field"}],
+            "additionalFields": {
+                "my_field": "my value",
+            },
+        }


### PR DESCRIPTION
Fixes SENTRY-5NNK

The linked [sentry issue](https://sentry.sentry.io/issues/7428267980/) illuminates an issue we have with action serialization. Ticketing actions (like Jira in this case) use `additional_fields` to store key/value pairs where the key is the name of the field from the integration.  Currently, we are camelcasing the entire `data` object, which results in snake_case keys being transformed.

This seemed like it might be a quick fix, but the actions are all very generic and most actions _do_ want to camel-case `data`, so I decided to add a `data_serializer` property to `ActionHandler` to customize the serialization. Ticketing actions pass a custom serializer which skips `additional_fields`.

I'm not married to this particular abstraction, so please lmk if there is a better place to add this configuration.

One other way that we could avoid this is to store `additional_fields` as an array of `{key,value}` instead of an object, but that seems like it would require many other changes