### PR TITLE
feat(cmdk): Always render help search last; fix empty state during fetch

### DIFF
--- a/static/app/components/commandPalette/ui/cmdk.tsx
+++ b/static/app/components/commandPalette/ui/cmdk.tsx
@@ -65,6 +65,12 @@ export function CommandPaletteProvider({children}: {children: React.ReactNode}) 
 interface CMDKActionProps {
   display: DisplayProps;
   children?: React.ReactNode | ((data: CommandPaletteAction[]) => React.ReactNode);
+  /**
+   * Stable reserved key for this node. Use the "cmdk:supplementary:" prefix to
+   * guarantee the section always sorts last in search results regardless of score.
+   * Example: id="cmdk:supplementary:help"
+   */
+  id?: string;
   keywords?: string[];
   /**
    * Maximum number of results to show. For async resources the default is 4;
@@ -87,6 +93,7 @@ export function CMDKAction({
   display,
   keywords,
   children,
+  id,
   to,
   onAction,
   prompt,
@@ -107,7 +114,7 @@ export function CMDKAction({
         : {display, keywords, ref, onAction, limit: effectiveLimit}
       : {display, keywords, ref, to, limit: effectiveLimit};
 
-  const key = CMDKCollection.useRegisterNode(nodeData);
+  const key = CMDKCollection.useRegisterNode(nodeData, id);
   const {query} = useCommandPaletteState();
 
   const resourceOptions = resource

--- a/static/app/components/commandPalette/ui/collection.tsx
+++ b/static/app/components/commandPalette/ui/collection.tsx
@@ -31,7 +31,7 @@ interface CollectionStore<T> {
 interface CollectionInstance<T> {
   Context: React.Context<string | null>;
   Provider: (props: {children: React.ReactNode}) => React.ReactElement;
-  useRegisterNode: (data: T) => string;
+  useRegisterNode: (data: T, reservedId?: string) => string;
   useStore: () => CollectionStore<T>;
 }
 
@@ -140,7 +140,7 @@ export function makeCollection<T>(): CollectionInstance<T> {
     );
   }
 
-  function useRegisterNode(data: T): string {
+  function useRegisterNode(data: T, reservedId?: string): string {
     // Read the stable store from context directly — NOT via useStore() — so
     // that structural node changes (which produce a new useStore() reference)
     // do not invalidate the layout-effect deps and trigger re-registration loops.
@@ -152,7 +152,8 @@ export function makeCollection<T>(): CollectionInstance<T> {
     }
     const parentKey = useContext(Context);
 
-    const key = useId();
+    const generatedKey = useId();
+    const key = reservedId ?? generatedKey;
     // Store data in a ref so tree() always reflects the latest value without
     // needing to re-register when data changes. Structural changes (parentKey)
     // still cause a full re-registration via the effect deps.

--- a/static/app/components/commandPalette/ui/commandPalette.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.tsx
@@ -667,10 +667,17 @@ function flattenActions(
   // groups by their best child score so the most relevant sub-section surfaces
   // first. When we are inside an expanded group we also sort leaf actions by
   // their own score so the full result list matches the limited preview ordering.
+  // Sections with a "cmdk:supplementary:" reserved key always sort last,
+  // regardless of score.
   collected.sort((a, b) => {
     const aRootKey = nodeRootKey.get(a.key)!;
     const bRootKey = nodeRootKey.get(b.key)!;
     if (aRootKey !== bRootKey) {
+      const aIsSupplementary = aRootKey.startsWith('cmdk:supplementary:');
+      const bIsSupplementary = bRootKey.startsWith('cmdk:supplementary:');
+      if (aIsSupplementary !== bIsSupplementary) {
+        return aIsSupplementary ? 1 : -1;
+      }
       return compareCommandPaletteScores(
         rootBestScore.get(aRootKey),
         rootBestScore.get(bRootKey)

--- a/static/app/components/commandPalette/ui/commandPalette.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.tsx
@@ -429,7 +429,7 @@ export function CommandPalette(props: CommandPaletteProps) {
       </Flex>
 
       {treeState.collection.size === 0 ? (
-        isEmptyPromptQuery ? null : (
+        isEmptyPromptQuery || isLoading ? null : (
           <CommandPaletteNoResults />
         )
       ) : (

--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -540,6 +540,7 @@ export function GlobalCommandPaletteActions() {
       </CMDKAction>
 
       <CMDKAction
+        id="cmdk:supplementary:help"
         display={{label: t('Help')}}
         resource={(query: string): CMDKQueryOptions => {
           return cmdkQueryOptions({


### PR DESCRIPTION
## Summary

- Introduces a reserved-key convention (`cmdk:supplementary:<name>`) for `CMDKAction` nodes. Sections registered with this prefix are always sorted after all scored sections in search results, regardless of match quality. The sort checks the root key prefix before comparing scores so supplementary sections can never bubble up due to high relevance.
- Wires up an optional stable `id` prop on `CMDKAction` (threaded through `useRegisterNode`) so callers can opt into a reserved key. The Help section gets `id="cmdk:supplementary:help"`, ensuring its async docs results never displace navigation/action results.
- Fixes a bug where the no-results empty state rendered simultaneously with the loading spinner when a query matched no static actions but a help search fetch was still in flight. The empty state is now suppressed while `isLoading` is true.