### PR TITLE
fix(alerts): skip orphaned triggers during detector serialization

### DIFF
--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_detector.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_detector.py
@@ -93,7 +93,8 @@ class WorkflowEngineDetectorSerializer(Serializer):
         for serialized in serialized_data_conditions:
             errors = []
             alert_rule_id = serialized.get("alertRuleId")
-            assert alert_rule_id
+            if not alert_rule_id:
+                continue
             detector_id = detector_ids_by_alert_rule_id.get(
                 int(alert_rule_id),
                 get_object_id_from_fake_id(int(alert_rule_id)),

--- a/tests/sentry/incidents/serializers/test_workflow_engine_detector.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_detector.py
@@ -198,7 +198,7 @@ class TestDetectorSerializer(TestWorkflowEngineSerializer):
         result: defaultdict[Any, dict[str, Any]] = defaultdict(dict)
         detectors = {self.detector.id: self.detector}
 
-        serialized_data_conditions = [
+        serialized_data_conditions: list[dict[str, Any]] = [
             {
                 "alertRuleId": None,
                 "actions": [],

--- a/tests/sentry/incidents/serializers/test_workflow_engine_detector.py
+++ b/tests/sentry/incidents/serializers/test_workflow_engine_detector.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from datetime import timedelta
 from typing import Any
 from unittest.mock import patch
@@ -191,6 +192,22 @@ class TestDetectorSerializer(TestWorkflowEngineSerializer):
         self.detector.update(enabled=False)
         serialized = serialize(self.detector, self.user, WorkflowEngineDetectorSerializer())
         assert serialized["snooze"] is True
+
+    def test_orphaned_trigger_without_detector(self) -> None:
+        serializer = WorkflowEngineDetectorSerializer()
+        result: defaultdict[Any, dict[str, Any]] = defaultdict(dict)
+        detectors = {self.detector.id: self.detector}
+
+        serialized_data_conditions = [
+            {
+                "alertRuleId": None,
+                "actions": [],
+                "alertThreshold": "100",
+                "label": "critical",
+            },
+        ]
+        serializer.add_triggers_and_actions(result, detectors, {}, serialized_data_conditions, {})
+        assert self.detector not in result
 
     def test_new_models_only(self) -> None:
         # test that we can still serialize if objects do not have lookup table entries


### PR DESCRIPTION
We shouldn't use an assertion for a case that we do expect to happen now and then during deletion.
Better to just skip it.

Fixes ISWF-2517.
