### PR TITLE
ref(tsc): remove getResponseHeader from useApiQuery

### DIFF
--- a/static/app/utils/queryClient.spec.tsx
+++ b/static/app/utils/queryClient.spec.tsx
@@ -19,14 +19,12 @@ describe('queryClient', () => {
       const mock = MockApiClient.addMockResponse({
         url: '/api-tokens/',
         body: {value: 5},
-        headers: {'Custom-Header': 'header value'},
       });
 
       function TestComponent() {
-        const {data, getResponseHeader} = useApiQuery<ResponseData>(
-          [getApiUrl('/api-tokens/')],
-          {staleTime: 0}
-        );
+        const {data} = useApiQuery<ResponseData>([getApiUrl('/api-tokens/')], {
+          staleTime: 0,
+        });
 
         if (!data) {
           return null;
@@ -35,7 +33,6 @@ describe('queryClient', () => {
         return (
           <Fragment>
             <div>{data.value}</div>
-            <div>{getResponseHeader?.('Custom-Header')}</div>
           </Fragment>
         );
       }
@@ -43,7 +40,6 @@ describe('queryClient', () => {
       render(<TestComponent />);
 
       expect(await screen.findByText('5')).toBeInTheDocument();
-      expect(screen.getByText('header value')).toBeInTheDocument();
 
       expect(mock).toHaveBeenCalledWith('/api-tokens/', expect.anything());
     });

--- a/static/app/utils/queryClient.tsx
+++ b/static/app/utils/queryClient.tsx
@@ -9,7 +9,7 @@ import type {
 } from '@tanstack/react-query';
 import {useInfiniteQuery, useQuery} from '@tanstack/react-query';
 
-import type {ApiResult, ResponseMeta} from 'sentry/api';
+import type {ApiResult} from 'sentry/api';
 import {Client} from 'sentry/api';
 import {parseQueryKey} from 'sentry/utils/api/apiQueryKey';
 import type {
@@ -76,12 +76,7 @@ export interface UseApiQueryOptions<TApiResponse, TError = RequestError> extends
   staleTime: number;
 }
 
-export type UseApiQueryResult<TData, TError> = UseQueryResult<TData, TError> & {
-  /**
-   * Get a header value from the response
-   */
-  getResponseHeader?: ResponseMeta['getResponseHeader'];
-};
+export type UseApiQueryResult<TData, TError> = UseQueryResult<TData, TError>;
 
 /**
  * Wraps React Query's useQuery for consistent usage in the Sentry app.
@@ -110,7 +105,6 @@ export function useApiQuery<TResponseData, TError = RequestError>(
 
   const queryResult = {
     data: data?.[0],
-    getResponseHeader: data?.[2]?.getResponseHeader,
     ...rest,
   };
 

--- a/static/app/views/discover/results/tags.tsx
+++ b/static/app/views/discover/results/tags.tsx
@@ -22,8 +22,6 @@ import type {Organization} from 'sentry/types/organization';
 import type {EventView} from 'sentry/utils/discover/eventView';
 import {isAPIPayloadSimilar} from 'sentry/utils/discover/eventView';
 import {parseLinkHeader} from 'sentry/utils/parseLinkHeader';
-import type {UseApiQueryResult} from 'sentry/utils/queryClient';
-import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {withApi} from 'sentry/utils/withApi';
 
 type Props = {
@@ -35,7 +33,6 @@ type Props = {
   totalValues: null | number;
   confirmedQuery?: boolean;
   onTagValueClick?: (title: string, value: TagSegment) => void;
-  tagsQueryResults?: UseApiQueryResult<Tag[], RequestError>;
 };
 
 type State = {
@@ -89,29 +86,6 @@ class Tags extends Component<Props, State> {
     this.setState({loading: true, error: ''});
     if (!appendTags) {
       this.setState({hasLoaded: false, tags: []});
-    }
-
-    // If we have tagsQueryResults, we can use that instead of fetching new data on mount.
-    if (!appendTags && this.props.tagsQueryResults) {
-      const pageLinks =
-        this.props.tagsQueryResults?.getResponseHeader?.('Link') ?? undefined;
-      let hasMore = false;
-      let cursor: string | undefined;
-      if (pageLinks) {
-        const paginationObject = parseLinkHeader(pageLinks);
-        hasMore = paginationObject?.next?.results ?? false;
-        cursor = paginationObject.next?.cursor;
-      }
-
-      this.setState({
-        tags: this.props.tagsQueryResults.data || [],
-        loading: this.props.tagsQueryResults.isPending,
-        hasLoaded: !this.props.tagsQueryResults.isPending,
-        hasMore,
-        nextCursor: cursor,
-        error: this.props.tagsQueryResults.error?.message || '',
-      });
-      return;
     }
 
     // Fetch should be forced after mounting as confirmedQuery isn't guaranteed


### PR DESCRIPTION
If you need response headers, `apiOptions` includes them in the result (`{json, headers})` when used with `select: selectJsonWithHeaders`. `AGENTS.md` already knows this.