### PR TITLE
feat(discover): move build query button to filters row

### DIFF
--- a/static/app/views/discover/landing.tsx
+++ b/static/app/views/discover/landing.tsx
@@ -215,11 +215,26 @@ function DiscoverLanding() {
                   ]}
                 />
               </Layout.HeaderContent>
+              <Layout.HeaderActions>
+                <LinkButton
+                  data-test-id="build-new-query"
+                  to={to}
+                  size="sm"
+                  priority="primary"
+                  onClick={() => {
+                    trackAnalytics('discover_v2.build_new_query', {
+                      organization,
+                    });
+                  }}
+                >
+                  {t('Build a new query')}
+                </LinkButton>
+              </Layout.HeaderActions>
             </Layout.Header>
           )}
           <Layout.Body>
             <Layout.Main width="full">
-              <StyledActions>
+              <StyledActions hasBuildButton={hasPageFrameFeature}>
                 <StyledSearchBar
                   defaultQuery=""
                   query={savedSearchQuery}
@@ -244,18 +259,20 @@ function DiscoverLanding() {
                   onChange={opt => handleSortChange(opt.value)}
                   position="bottom-end"
                 />
-                <LinkButton
-                  data-test-id="build-new-query"
-                  to={to}
-                  priority="primary"
-                  onClick={() => {
-                    trackAnalytics('discover_v2.build_new_query', {
-                      organization,
-                    });
-                  }}
-                >
-                  {t('Build a new query')}
-                </LinkButton>
+                {hasPageFrameFeature && (
+                  <LinkButton
+                    data-test-id="build-new-query"
+                    to={to}
+                    priority="primary"
+                    onClick={() => {
+                      trackAnalytics('discover_v2.build_new_query', {
+                        organization,
+                      });
+                    }}
+                  >
+                    {t('Build a new query')}
+                  </LinkButton>
+                )}
               </StyledActions>
               {status === 'pending' ? (
                 <LoadingIndicator />
@@ -304,10 +321,13 @@ const StyledSearchBar = styled(SearchBar)`
   flex-grow: 1;
 `;
 
-const StyledActions = styled('div')`
+const StyledActions = styled('div')<{hasBuildButton: boolean}>`
   display: grid;
   gap: ${p => p.theme.space.xl};
-  grid-template-columns: auto max-content min-content max-content;
+  grid-template-columns: ${p =>
+    p.hasBuildButton
+      ? 'auto max-content min-content max-content'
+      : 'auto max-content min-content'};
   align-items: center;
   margin-bottom: ${p => p.theme.space.xl};
 

--- a/static/app/views/discover/landing.tsx
+++ b/static/app/views/discover/landing.tsx
@@ -1,4 +1,3 @@
-import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
 
@@ -192,33 +191,17 @@ function DiscoverLanding() {
       <SentryDocumentTitle title={t('Discover')} orgSlug={organization.slug}>
         <Stack flex={1}>
           {hasPageFrameFeature ? (
-            <Fragment>
-              <TopBar.Slot name="title">
-                <Breadcrumbs
-                  crumbs={[
-                    {
-                      label: t('Discover'),
-                      to: getDiscoverLandingUrl(organization),
-                    },
-                    {label: t('Saved Queries')},
-                  ]}
-                />
-              </TopBar.Slot>
-              <TopBar.Slot name="actions">
-                <LinkButton
-                  data-test-id="build-new-query"
-                  to={to}
-                  priority="primary"
-                  onClick={() => {
-                    trackAnalytics('discover_v2.build_new_query', {
-                      organization,
-                    });
-                  }}
-                >
-                  {t('Build a new query')}
-                </LinkButton>
-              </TopBar.Slot>
-            </Fragment>
+            <TopBar.Slot name="title">
+              <Breadcrumbs
+                crumbs={[
+                  {
+                    label: t('Discover'),
+                    to: getDiscoverLandingUrl(organization),
+                  },
+                  {label: t('Saved Queries')},
+                ]}
+              />
+            </TopBar.Slot>
           ) : (
             <Layout.Header>
               <Layout.HeaderContent>
@@ -232,21 +215,6 @@ function DiscoverLanding() {
                   ]}
                 />
               </Layout.HeaderContent>
-              <Layout.HeaderActions>
-                <LinkButton
-                  data-test-id="build-new-query"
-                  to={to}
-                  size="sm"
-                  priority="primary"
-                  onClick={() => {
-                    trackAnalytics('discover_v2.build_new_query', {
-                      organization,
-                    });
-                  }}
-                >
-                  {t('Build a new query')}
-                </LinkButton>
-              </Layout.HeaderActions>
             </Layout.Header>
           )}
           <Layout.Body>
@@ -276,6 +244,18 @@ function DiscoverLanding() {
                   onChange={opt => handleSortChange(opt.value)}
                   position="bottom-end"
                 />
+                <LinkButton
+                  data-test-id="build-new-query"
+                  to={to}
+                  priority="primary"
+                  onClick={() => {
+                    trackAnalytics('discover_v2.build_new_query', {
+                      organization,
+                    });
+                  }}
+                >
+                  {t('Build a new query')}
+                </LinkButton>
               </StyledActions>
               {status === 'pending' ? (
                 <LoadingIndicator />
@@ -327,7 +307,7 @@ const StyledSearchBar = styled(SearchBar)`
 const StyledActions = styled('div')`
   display: grid;
   gap: ${p => p.theme.space.xl};
-  grid-template-columns: auto max-content min-content;
+  grid-template-columns: auto max-content min-content max-content;
   align-items: center;
   margin-bottom: ${p => p.theme.space.xl};
 


### PR DESCRIPTION
**Before**

<img width="2245" height="183" alt="image" src="https://github.com/user-attachments/assets/ddb27c47-c7d8-4a23-be35-472bc0830002" />


**After**

<img width="2134" height="130" alt="image" src="https://github.com/user-attachments/assets/bfab3896-123e-4d9f-a4e6-f3f5e863cf94" />
