### PR TITLE
ref(tsc): remove useInfiniteApiQuery

### DIFF
--- a/static/app/utils/queryClient.tsx
+++ b/static/app/utils/queryClient.tsx
@@ -7,7 +7,7 @@ import type {
   UseQueryOptions,
   UseQueryResult,
 } from '@tanstack/react-query';
-import {useInfiniteQuery, useQuery} from '@tanstack/react-query';
+import {useQuery} from '@tanstack/react-query';
 
 import type {ApiResult} from 'sentry/api';
 import {Client} from 'sentry/api';
@@ -17,7 +17,6 @@ import type {
   InfiniteApiQueryKey,
   QueryKeyEndpointOptions,
 } from 'sentry/utils/api/apiQueryKey';
-import {parseLinkHeader} from 'sentry/utils/parseLinkHeader';
 import type {RequestError} from 'sentry/utils/requestError/requestError';
 
 export type {
@@ -188,50 +187,6 @@ export function setApiQueryData<TResponseData>(
   );
 
   return updateResult?.[0];
-}
-
-function parsePageParam(dir: 'previous' | 'next') {
-  return ([, , resp]: ApiResult<unknown>) => {
-    const parsed = parseLinkHeader(resp?.getResponseHeader('Link') ?? null);
-    return parsed[dir]?.results ? parsed[dir] : null;
-  };
-}
-
-/**
- * Wraps React Query's useInfiniteQuery for consistent usage in the Sentry app.
- * Query keys should be an array which include an endpoint URL and options such as query params.
- * This wrapper will execute the request using the query key URL.
- *
- * See https://tanstack.com/query/v4/docs/overview for docs on React Query.
- */
-export function useInfiniteApiQuery<TResponseData>({
-  queryKey,
-  enabled,
-  staleTime,
-}: {
-  queryKey: InfiniteApiQueryKey;
-  enabled?: boolean;
-  staleTime?: number;
-}) {
-  return useInfiniteQuery({
-    queryKey,
-    queryFn: ({pageParam}): Promise<ApiResult<TResponseData>> => {
-      const {url, options} = parseQueryKey(queryKey);
-      return QUERY_API_CLIENT.requestPromise(url, {
-        includeAllArgs: true,
-        headers: options?.headers,
-        query: {
-          ...options?.query,
-          cursor: pageParam?.cursor,
-        },
-      });
-    },
-    getPreviousPageParam: parsePageParam('previous'),
-    getNextPageParam: parsePageParam('next'),
-    initialPageParam: undefined,
-    enabled: enabled ?? true,
-    staleTime,
-  });
 }
 
 type ApiMutationVariables<

--- a/static/app/utils/useReleaseStats.tsx
+++ b/static/app/utils/useReleaseStats.tsx
@@ -1,7 +1,8 @@
+import {skipToken, useInfiniteQuery} from '@tanstack/react-query';
+
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {useFetchAllPages} from 'sentry/utils/api/apiFetch';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import {useInfiniteApiQuery} from 'sentry/utils/queryClient';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 interface ReleaseMetaBasic {
@@ -27,29 +28,27 @@ interface UseReleaseStatsParams {
  */
 export function useReleaseStats(
   {datetime, environments, projects, maxPages = 10}: UseReleaseStatsParams,
-  queryOptions: {enabled?: boolean; staleTime?: number} = {
-    staleTime: Infinity,
-    enabled: true,
-  }
+  queryOptions?: {enabled?: boolean; staleTime?: number}
 ) {
   const organization = useOrganization();
 
-  const result = useInfiniteApiQuery<ReleaseMetaBasic[]>({
-    queryKey: [
-      {infinite: true, version: 'v1'},
-      getApiUrl('/organizations/$organizationIdOrSlug/releases/stats/', {
-        path: {organizationIdOrSlug: organization.slug},
-      }),
+  const result = useInfiniteQuery(
+    apiOptions.asInfinite<ReleaseMetaBasic[]>()(
+      '/organizations/$organizationIdOrSlug/releases/stats/',
       {
+        path:
+          queryOptions?.enabled === false
+            ? skipToken
+            : {organizationIdOrSlug: organization.slug},
         query: {
           environment: environments,
           project: projects,
           ...normalizeDateTimeParams(datetime),
         },
-      },
-    ],
-    ...queryOptions,
-  });
+        staleTime: queryOptions?.staleTime ?? Infinity,
+      }
+    )
+  );
 
   const {isLoading, isPending, isError, error, data} = result;
   const currentNumberPages = data?.pages.length ?? 0;
@@ -62,6 +61,6 @@ export function useReleaseStats(
     isPending,
     isError,
     error,
-    releases: data?.pages.flatMap(([pageData]) => pageData),
+    releases: data?.pages.flatMap(page => page.json),
   };
 }

--- a/static/app/views/insights/pages/conversations/hooks/useConversation.tsx
+++ b/static/app/views/insights/pages/conversations/hooks/useConversation.tsx
@@ -1,10 +1,10 @@
 import {useEffect, useMemo} from 'react';
+import {skipToken, useInfiniteQuery} from '@tanstack/react-query';
 
 import {ALL_ACCESS_PROJECTS} from 'sentry/components/pageFilters/constants';
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import {useInfiniteApiQuery} from 'sentry/utils/queryClient';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {getGenAiOperationTypeFromSpanName} from 'sentry/views/insights/pages/agents/utils/query';
 import type {AITraceSpanNode} from 'sentry/views/insights/pages/agents/utils/types';
@@ -183,16 +183,6 @@ export function useConversation(
   const organization = useOrganization();
   const {selection} = usePageFilters();
 
-  const queryUrl = getApiUrl(
-    '/organizations/$organizationIdOrSlug/ai-conversations/$conversationId/',
-    {
-      path: {
-        organizationIdOrSlug: organization.slug,
-        conversationId: conversation.conversationId,
-      },
-    }
-  );
-
   // Use conversation timestamps when available (with 1-hour padding), falling back to page filters
   const ONE_HOUR_MS = 60 * 60 * 1000;
   const hasConversationTimestamps =
@@ -215,28 +205,39 @@ export function useConversation(
         per_page: 1000,
       };
 
-  const conversationQuery = useInfiniteApiQuery<ConversationApiSpan[]>({
-    queryKey: [{infinite: true, version: 'v1'}, queryUrl, {query: queryParams}],
-    staleTime: Infinity,
-    enabled: !!conversation.conversationId,
-  });
+  const {
+    data,
+    isFetching,
+    isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
+    isLoading,
+    isError,
+  } = useInfiniteQuery(
+    apiOptions.asInfinite<ConversationApiSpan[]>()(
+      '/organizations/$organizationIdOrSlug/ai-conversations/$conversationId/',
+      {
+        path: conversation.conversationId
+          ? {
+              organizationIdOrSlug: organization.slug,
+              conversationId: conversation.conversationId,
+            }
+          : skipToken,
+        query: queryParams,
+        staleTime: Infinity,
+      }
+    )
+  );
 
-  const currentNumberPages = conversationQuery.data?.pages.length ?? 0;
+  const currentNumberPages = data?.pages.length ?? 0;
 
   useEffect(() => {
-    if (
-      !conversationQuery.isFetching &&
-      conversationQuery.hasNextPage &&
-      currentNumberPages < MAX_PAGES
-    ) {
-      conversationQuery.fetchNextPage();
+    if (!isFetching && hasNextPage && currentNumberPages < MAX_PAGES) {
+      fetchNextPage();
     }
-  }, [conversationQuery, currentNumberPages]);
+  }, [isFetching, hasNextPage, fetchNextPage, currentNumberPages]);
 
-  const allSpans = useMemo(
-    () => conversationQuery.data?.pages.flatMap(([pageData]) => pageData) ?? [],
-    [conversationQuery.data]
-  );
+  const allSpans = useMemo(() => data?.pages.flatMap(page => page.json) ?? [], [data]);
 
   const {nodes, nodeTraceMap} = useMemo(() => {
     if (allSpans.length === 0) {
@@ -266,7 +267,7 @@ export function useConversation(
   return {
     nodes,
     nodeTraceMap,
-    isLoading: conversationQuery.isLoading || conversationQuery.isFetchingNextPage,
-    error: conversationQuery.isError,
+    isLoading: isLoading || isFetchingNextPage,
+    error: isError,
   };
 }


### PR DESCRIPTION
there were only 2 usages, which we can move to `apiOptions.asInfinite`