### PR TITLE
fix(pageFrame): adjust header layout for better spacing above alert

### DIFF
--- a/static/app/components/workflowEngine/layout/list.tsx
+++ b/static/app/components/workflowEngine/layout/list.tsx
@@ -1,3 +1,5 @@
+import {Fragment} from 'react';
+
 import {Flex, Stack} from '@sentry/scraps/layout';
 
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -34,19 +36,25 @@ export function WorkflowEngineListLayout({
   return (
     <Stack flex={1}>
       <NoProjectMessage organization={organization}>
-        <Layout.Header unified>
-          <Layout.HeaderContent>
-            <Layout.Title>
+        {hasPageFrameFeature ? (
+          <Fragment>
+            <TopBar.Slot name="title">
               {title}
               <PageHeadingQuestionTooltip docsUrl={docsUrl} title={description} />
-            </Layout.Title>
-          </Layout.HeaderContent>
-          {hasPageFrameFeature ? (
+            </TopBar.Slot>
             <TopBar.Slot name="actions">{actions}</TopBar.Slot>
-          ) : (
+          </Fragment>
+        ) : (
+          <Layout.Header unified>
+            <Layout.HeaderContent>
+              <Layout.Title>
+                {title}
+                <PageHeadingQuestionTooltip docsUrl={docsUrl} title={description} />
+              </Layout.Title>
+            </Layout.HeaderContent>
             <Layout.HeaderActions>{actions}</Layout.HeaderActions>
-          )}
-        </Layout.Header>
+          </Layout.Header>
+        )}
         <Layout.Body>
           <Layout.Main width="full">
             <Flex direction="column" gap="lg">


### PR DESCRIPTION
before:

<img width="1719" height="246" alt="Screenshot 2026-04-23 at 12 50 08" src="https://github.com/user-attachments/assets/dce91975-9a05-498c-bab5-d4953d893f84" />

after:

<img width="1701" height="274" alt="Screenshot 2026-04-23 at 12 50 20" src="https://github.com/user-attachments/assets/8caded40-ecc2-49ad-8a90-4538d23dfb47" />
