### PR TITLE
feat(snuba): add sample rate option for span with errors tracking

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2274,6 +2274,12 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "performance.trace.span_with_errors_ok_status.sample_rate",
+    type=Float,
+    default=0.01,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "insights.span-samples-query.sample-rate",
     type=Float,
     default=0.0,  # 0 acts as 'no sampling'

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2276,7 +2276,7 @@ register(
 register(
     "performance.trace.span_with_errors_ok_status.sample_rate",
     type=Float,
-    default=0.01,
+    default=0.0,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(

--- a/src/sentry/snuba/trace.py
+++ b/src/sentry/snuba/trace.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from datetime import datetime
 from typing import Any, Literal, NotRequired, TypedDict
 
+from sentry import options
 from sentry.uptime.subscriptions.regions import get_region_config
 from sentry.utils import metrics
 from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
@@ -784,7 +785,9 @@ def query_trace_data(
                 if span.get("span.status", "") == "ok":
                     metrics.incr(
                         "performance.trace.span_with_errors_ok_status",
-                        sample_rate=0.01,
+                        sample_rate=options.get(
+                            "performance.trace.span_with_errors_ok_status.sample_rate"
+                        ),
                         tags={
                             "sdk_name": span.get("sdk.name", ""),
                             "sdk_version": span.get("sdk.version", ""),

--- a/tests/snuba/api/endpoints/test_organization_trace.py
+++ b/tests/snuba/api/endpoints/test_organization_trace.py
@@ -452,7 +452,7 @@ class OrganizationEventsTraceEndpointTest(
 
         mock_metrics.incr.assert_any_call(
             "performance.trace.span_with_errors_ok_status",
-            sample_rate=0.01,
+            sample_rate=mock.ANY,
             tags=mock.ANY,
         )
 


### PR DESCRIPTION
Contributes to https://linear.app/getsentry/issue/TET-2102/detect-spanstatus-inconsistencies-and-report-to-sdk-teams