### PR TITLE
ref(integrations): More GitHub API request tagging + org_id

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -4,6 +4,7 @@ import logging
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta
 from enum import StrEnum
+from functools import cached_property
 from typing import Any, TypedDict
 
 import orjson
@@ -21,7 +22,7 @@ from sentry.integrations.github.blame import (
 from sentry.integrations.github.constants import GITHUB_API_ACCEPT_HEADER
 from sentry.integrations.github.utils import get_jwt, get_next_link
 from sentry.integrations.models.integration import Integration
-from sentry.integrations.services.integration import RpcIntegration
+from sentry.integrations.services.integration import RpcIntegration, integration_service
 from sentry.integrations.source_code_management.commit_context import (
     CommitContextClient,
     FileBlameInfo,
@@ -95,10 +96,48 @@ class GitHubReaction(StrEnum):
 
 
 class GitHubApiRequestType(StrEnum):
-    COMPARE_COMMITS = "compare_commits"
-    GET_COMMITS = "get_commits"
-    GET_COMMIT = "get_commit"
     CHECK_FILE = "check_file"
+    COMPARE_COMMITS = "compare_commits"
+    CREATE_CHECK_RUN = "create_check_run"
+    CREATE_COMMENT = "create_comment"
+    CREATE_COMMENT_REACTION = "create_comment_reaction"
+    CREATE_ISSUE = "create_issue"
+    CREATE_ISSUE_REACTION = "create_issue_reaction"
+    DELETE_ISSUE_REACTION = "delete_issue_reaction"
+    GET_ARCHIVE_LINK = "get_archive_link"
+    GET_ASSIGNEES = "get_assignees"
+    GET_BLAME_FOR_FILES = "get_blame_for_files"
+    GET_CHECK_RUN = "get_check_run"
+    GET_CHECK_RUNS = "get_check_runs"
+    GET_COMMENT_REACTIONS = "get_comment_reactions"
+    GET_COMMIT = "get_commit"
+    GET_COMMITS = "get_commits"
+    GET_FILE = "get_file"
+    GET_INSTALLATION_INFO = "get_installation_info"
+    GET_ISSUE = "get_issue"
+    GET_ISSUE_COMMENTS = "get_issue_comments"
+    GET_ISSUE_REACTIONS = "get_issue_reactions"
+    GET_LANGUAGES = "get_languages"
+    GET_LABELS = "get_labels"
+    GET_ORGANIZATION_MEMBERSHIPS_FOR_USER = "get_organization_memberships_for_user"
+    GET_PULL_REQUEST = "get_pull_request"
+    GET_PULL_REQUEST_COMMENTS = "get_pull_request_comments"
+    GET_PULL_REQUEST_FILES = "get_pull_request_files"
+    GET_PULL_REQUEST_FROM_COMMIT = "get_pull_request_from_commit"
+    GET_RATE_LIMIT = "get_rate_limit"
+    GET_REPO = "get_repo"
+    GET_REPO_TREE = "get_repo_tree"
+    GET_REPOSITORIES = "get_repositories"
+    GET_USER = "get_user"
+    GET_USER_INFO = "get_user_info"
+    GET_USER_INFO_INSTALLATIONS = "get_user_info_installations"
+    REFRESH_ACCESS_TOKEN = "refresh_access_token"
+    REPO_HOOKS = "repo_hooks"
+    SEARCH_ISSUES = "search_issues"
+    SEARCH_REPOSITORIES = "search_repositories"
+    UPDATE_COMMENT = "update_comment"
+    UPDATE_ISSUE_ASSIGNEES = "update_issue_assignees"
+    UPDATE_ISSUE_STATUS = "update_issue_status"
 
 
 class GithubSetupApiClient(IntegrationProxyClient):
@@ -132,28 +171,37 @@ class GithubSetupApiClient(IntegrationProxyClient):
         Authentication: JWT
         Docs: https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#get-an-installation-for-the-authenticated-app
         """
-        return self.get(f"/app/installations/{installation_id}")
+        return self.get(
+            f"/app/installations/{installation_id}",
+            api_request_type=GitHubApiRequestType.GET_INSTALLATION_INFO,
+        )
 
     def get_user_info(self) -> dict[str, Any]:
         """
         Authentication: Access Token
         Docs: https://docs.github.com/en/rest/users/users?apiVersion=2022-11-28#get-the-authenticated-user
         """
-        return self.get("/user")
+        return self.get("/user", api_request_type=GitHubApiRequestType.GET_USER_INFO)
 
     def get_user_info_installations(self):
         """
         Authentication: Access Token
         Docs: https://docs.github.com/en/rest/apps/installations?apiVersion=2022-11-28#list-app-installations-accessible-to-the-user-access-token
         """
-        return self.get("/user/installations")
+        return self.get(
+            "/user/installations",
+            api_request_type=GitHubApiRequestType.GET_USER_INFO_INSTALLATIONS,
+        )
 
     def get_organization_memberships_for_user(self):
         """
         Authentication: Access Token
         Docs: https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#get-an-organization-membership-for-the-authenticated-user
         """
-        return self.get("/user/memberships/orgs")
+        return self.get(
+            "/user/memberships/orgs",
+            api_request_type=GitHubApiRequestType.GET_ORGANIZATION_MEMBERSHIPS_FOR_USER,
+        )
 
 
 class GithubProxyClient(IntegrationProxyClient):
@@ -162,6 +210,21 @@ class GithubProxyClient(IntegrationProxyClient):
     class AccessTokenData(TypedDict):
         access_token: str
         permissions: dict[str, str] | None
+
+    @cached_property
+    def organization_id(self) -> int | None:
+        return self._lookup_organization_id()
+
+    def _lookup_organization_id(self) -> int | None:
+        if self.org_integration_id is None:
+            return None
+
+        org_integrations = integration_service.get_organization_integrations(
+            org_integration_ids=[self.org_integration_id], limit=1
+        )
+        if not org_integrations:
+            return None
+        return org_integrations[0].organization_id
 
     def _get_installation_id(self) -> str:
         """
@@ -192,7 +255,10 @@ class GithubProxyClient(IntegrationProxyClient):
                 "integration_id": self.integration.id,
             },
         )
-        data = self.post(f"/app/installations/{self._get_installation_id()}/access_tokens")
+        data = self.post(
+            f"/app/installations/{self._get_installation_id()}/access_tokens",
+            api_request_type=GitHubApiRequestType.REFRESH_ACCESS_TOKEN,
+        )
         access_token = data["token"]
         expires_at = datetime.strptime(data["expires_at"], "%Y-%m-%dT%H:%M:%SZ").isoformat()
         permissions = data.get("permissions")
@@ -370,7 +436,7 @@ class GitHubBaseClient(
         """
         https://docs.github.com/en/rest/webhooks/repos#list-repository-webhooks
         """
-        return self.get(f"/repos/{repo}/hooks")
+        return self.get(f"/repos/{repo}/hooks", api_request_type=GitHubApiRequestType.REPO_HOOKS)
 
     def get_commits(self, repo: str) -> Sequence[Any]:
         """
@@ -390,7 +456,10 @@ class GitHubBaseClient(
         """
         https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#get-an-installation-for-the-authenticated-app
         """
-        return self.get(f"/app/installations/{installation_id}")
+        return self.get(
+            f"/app/installations/{installation_id}",
+            api_request_type=GitHubApiRequestType.GET_INSTALLATION_INFO,
+        )
 
     def get_merge_commit_sha_from_commit(self, repo: Repository, sha: str) -> str | None:
         """
@@ -417,7 +486,10 @@ class GitHubBaseClient(
 
         Returns the merged pull request that introduced the commit to the repository. If the commit is not present in the default branch, will only return open pull requests associated with the commit.
         """
-        return self.get(f"/repos/{repo}/commits/{sha}/pulls")
+        return self.get(
+            f"/repos/{repo}/commits/{sha}/pulls",
+            api_request_type=GitHubApiRequestType.GET_PULL_REQUEST_FROM_COMMIT,
+        )
 
     def get_pull_request_files(self, repo: str, pull_number: str) -> Any:
         """
@@ -425,7 +497,10 @@ class GitHubBaseClient(
 
         Returns up to 30 files associated with a pull request. Responses are paginated.
         """
-        return self.get(f"/repos/{repo}/pulls/{pull_number}/files")
+        return self.get(
+            f"/repos/{repo}/pulls/{pull_number}/files",
+            api_request_type=GitHubApiRequestType.GET_PULL_REQUEST_FILES,
+        )
 
     def get_pull_request(self, repo: str, pull_number: str) -> Any:
         """
@@ -433,7 +508,10 @@ class GitHubBaseClient(
 
         Returns a single pull request.
         """
-        return self.get(f"/repos/{repo}/pulls/{pull_number}")
+        return self.get(
+            f"/repos/{repo}/pulls/{pull_number}",
+            api_request_type=GitHubApiRequestType.GET_PULL_REQUEST,
+        )
 
     def get_archive_link(self, repo: str, archive_format: str, ref: str) -> str:
         """
@@ -447,6 +525,7 @@ class GitHubBaseClient(
             f"/repos/{repo}/{archive_format}/{ref}",
             allow_redirects=False,
             raw_response=True,
+            api_request_type=GitHubApiRequestType.GET_ARCHIVE_LINK,
         )
         if resp.status_code != 302 or "Location" not in resp.headers:
             raise ApiError.from_response(resp)
@@ -456,7 +535,7 @@ class GitHubBaseClient(
         """
         https://docs.github.com/en/rest/repos/repos#get-a-repository
         """
-        return self.get(f"/repos/{repo}")
+        return self.get(f"/repos/{repo}", api_request_type=GitHubApiRequestType.GET_REPO)
 
     def get_languages(self, repo: str) -> dict[str, int]:
         """
@@ -466,7 +545,10 @@ class GitHubBaseClient(
         :returns: {"Python": 50000, "JavaScript": 30000, ...}
                   Keys are GitHub Linguist names, values are bytes of code.
         """
-        return self.get(f"/repos/{repo}/languages")
+        return self.get(
+            f"/repos/{repo}/languages",
+            api_request_type=GitHubApiRequestType.GET_LANGUAGES,
+        )
 
     # https://docs.github.com/en/rest/rate-limit?apiVersion=2022-11-28
     def get_rate_limit(self, specific_resource: str = "core") -> GithubRateLimitInfo:
@@ -477,8 +559,13 @@ class GitHubBaseClient(
             interaction_type=SCMIntegrationInteractionType.GET_RATE_LIMIT,
             provider_key=self.integration_name,
             integration_id=self.integration.id,
+            organization_id=self.organization_id,
         ).capture():
-            return GithubRateLimitInfo(self.get("/rate_limit")["resources"][specific_resource])
+            return GithubRateLimitInfo(
+                self.get("/rate_limit", api_request_type=GitHubApiRequestType.GET_RATE_LIMIT)[
+                    "resources"
+                ][specific_resource]
+            )
 
     # This method is used by RepoTreesIntegration
     def get_remaining_api_requests(self) -> int:
@@ -492,6 +579,7 @@ class GitHubBaseClient(
             interaction_type=SCMIntegrationInteractionType.GET_REPO_TREE,
             provider_key=self.integration_name,
             integration_id=self.integration.id,
+            organization_id=self.organization_id,
         ).capture() as lifecycle:
             try:
                 # We do not cache this call since it is a rather large object
@@ -499,6 +587,7 @@ class GitHubBaseClient(
                     f"/repos/{repo_full_name}/git/trees/{tree_sha}",
                     # Will cause all objects or subtrees referenced by the tree specified in :tree_sha
                     params={"recursive": 1},
+                    api_request_type=GitHubApiRequestType.GET_REPO_TREE,
                 )
             except ApiConflictError as e:
                 # Empty repos return a 409 which is expected
@@ -565,11 +654,13 @@ class GitHubBaseClient(
             interaction_type=SCMIntegrationInteractionType.GET_REPOSITORIES,
             provider_key=self.integration_name,
             integration_id=self.integration.id,
+            organization_id=self.organization_id,
         ).capture():
             return self._get_with_pagination(
                 "/installation/repositories",
                 response_key="repositories",
                 page_number_limit=page_number_limit,
+                api_request_type=GitHubApiRequestType.GET_REPOSITORIES,
             )
 
     def get_repos_cached(self, ttl: int = 300) -> list[CachedRepo]:
@@ -606,13 +697,20 @@ class GitHubBaseClient(
 
         NOTE: All search APIs (except code search) share a rate limit of 30 requests/minute
         """
-        return self.get("/search/repositories", params={"q": query})
+        return self.get(
+            "/search/repositories",
+            params={"q": query},
+            api_request_type=GitHubApiRequestType.SEARCH_REPOSITORIES,
+        )
 
     def get_assignees(self, repo: str) -> Sequence[Any]:
         """
         https://docs.github.com/en/rest/issues/assignees#list-assignees
         """
-        return self._get_with_pagination(f"/repos/{repo}/assignees")
+        return self._get_with_pagination(
+            f"/repos/{repo}/assignees",
+            api_request_type=GitHubApiRequestType.GET_ASSIGNEES,
+        )
 
     def _get_with_pagination(
         self,
@@ -664,78 +762,109 @@ class GitHubBaseClient(
 
         NOTE: All search APIs (except code search) share a rate limit of 30 requests/minute
         """
-        return self.get("/search/issues", params={"q": query})
+        return self.get(
+            "/search/issues",
+            params={"q": query},
+            api_request_type=GitHubApiRequestType.SEARCH_ISSUES,
+        )
 
     def get_issue(self, repo: str, number: str) -> Any:
         """
         https://docs.github.com/en/rest/issues/issues#get-an-issue
         """
-        return self.get(f"/repos/{repo}/issues/{number}")
+        return self.get(
+            f"/repos/{repo}/issues/{number}",
+            api_request_type=GitHubApiRequestType.GET_ISSUE,
+        )
 
     def get_issue_comments(self, repo: str, issue_number: str) -> Any:
         """
         https://docs.github.com/en/rest/issues/comments#list-issue-comments
         """
-        return self.get(f"/repos/{repo}/issues/{issue_number}/comments")
+        return self.get(
+            f"/repos/{repo}/issues/{issue_number}/comments",
+            api_request_type=GitHubApiRequestType.GET_ISSUE_COMMENTS,
+        )
 
     def get_pull_request_comments(self, repo: str, pull_number: str) -> Any:
         """
         https://docs.github.com/en/rest/pulls/comments#list-review-comments-on-a-pull-request
         """
-        return self.get(f"/repos/{repo}/pulls/{pull_number}/comments")
+        return self.get(
+            f"/repos/{repo}/pulls/{pull_number}/comments",
+            api_request_type=GitHubApiRequestType.GET_PULL_REQUEST_COMMENTS,
+        )
 
     def create_issue(self, repo: str, data: Mapping[str, Any]) -> Any:
         """
         https://docs.github.com/en/rest/issues/issues#create-an-issue
         """
         endpoint = f"/repos/{repo}/issues"
-        return self.post(endpoint, data=data)
+        return self.post(endpoint, data=data, api_request_type=GitHubApiRequestType.CREATE_ISSUE)
 
     def update_issue_assignees(self, repo: str, issue_number: str, assignees: list[str]) -> Any:
         """
         https://docs.github.com/en/rest/issues/issues#update-an-issue
         """
         endpoint = f"/repos/{repo}/issues/{issue_number}"
-        return self.patch(endpoint, data={"assignees": assignees})
+        return self.patch(
+            endpoint,
+            data={"assignees": assignees},
+            api_request_type=GitHubApiRequestType.UPDATE_ISSUE_ASSIGNEES,
+        )
 
     def update_issue_status(self, repo: str, issue_number: str, status: str) -> Any:
         """
         https://docs.github.com/en/rest/issues/issues#update-an-issue
         """
         endpoint = f"/repos/{repo}/issues/{issue_number}"
-        return self.patch(endpoint, data={"state": status})
+        return self.patch(
+            endpoint,
+            data={"state": status},
+            api_request_type=GitHubApiRequestType.UPDATE_ISSUE_STATUS,
+        )
 
     def get_issue_reactions(self, repo: str, issue_number: str) -> list[Any]:
         """
         https://docs.github.com/en/rest/reactions/reactions#list-reactions-for-an-issue
         """
-        return self._get_with_pagination(f"/repos/{repo}/issues/{issue_number}/reactions")
+        return self._get_with_pagination(
+            f"/repos/{repo}/issues/{issue_number}/reactions",
+            api_request_type=GitHubApiRequestType.GET_ISSUE_REACTIONS,
+        )
 
     def create_issue_reaction(self, repo: str, issue_number: str, reaction: GitHubReaction) -> Any:
         """
         https://docs.github.com/en/rest/reactions/reactions#create-reaction-for-an-issue
         """
         endpoint = f"/repos/{repo}/issues/{issue_number}/reactions"
-        return self.post(endpoint, data={"content": reaction.value})
+        return self.post(
+            endpoint,
+            data={"content": reaction.value},
+            api_request_type=GitHubApiRequestType.CREATE_ISSUE_REACTION,
+        )
 
     def delete_issue_reaction(self, repo: str, issue_number: str, reaction_id: str) -> Any:
         """
         https://docs.github.com/en/rest/reactions/reactions#delete-an-issue-reaction
         """
-        return self.delete(f"/repos/{repo}/issues/{issue_number}/reactions/{reaction_id}")
+        return self.delete(
+            f"/repos/{repo}/issues/{issue_number}/reactions/{reaction_id}",
+            api_request_type=GitHubApiRequestType.DELETE_ISSUE_REACTION,
+        )
 
     def create_comment(self, repo: str, issue_id: str, data: dict[str, Any]) -> Any:
         """
         https://docs.github.com/en/rest/issues/comments#create-an-issue-comment
         """
         endpoint = f"/repos/{repo}/issues/{issue_id}/comments"
-        return self.post(endpoint, data=data)
+        return self.post(endpoint, data=data, api_request_type=GitHubApiRequestType.CREATE_COMMENT)
 
     def update_comment(
         self, repo: str, issue_id: str, comment_id: str, data: dict[str, Any]
     ) -> Any:
         endpoint = f"/repos/{repo}/issues/comments/{comment_id}"
-        return self.patch(endpoint, data=data)
+        return self.patch(endpoint, data=data, api_request_type=GitHubApiRequestType.UPDATE_COMMENT)
 
     def create_pr_comment(self, repo: Repository, pr: PullRequest, data: dict[str, Any]) -> Any:
         return self.create_comment(repo.name, pr.key, data)
@@ -753,7 +882,10 @@ class GitHubBaseClient(
         """
         https://docs.github.com/en/rest/reactions/reactions#list-reactions-for-an-issue-comment
         """
-        return self._get_with_pagination(f"/repos/{repo}/issues/comments/{comment_id}/reactions")
+        return self._get_with_pagination(
+            f"/repos/{repo}/issues/comments/{comment_id}/reactions",
+            api_request_type=GitHubApiRequestType.GET_COMMENT_REACTIONS,
+        )
 
     def create_comment_reaction(self, repo: str, comment_id: str, reaction: GitHubReaction) -> Any:
         """
@@ -765,20 +897,27 @@ class GitHubBaseClient(
             reaction: The reaction type
         """
         endpoint = f"/repos/{repo}/issues/comments/{comment_id}/reactions"
-        return self.post(endpoint, data={"content": reaction.value})
+        return self.post(
+            endpoint,
+            data={"content": reaction.value},
+            api_request_type=GitHubApiRequestType.CREATE_COMMENT_REACTION,
+        )
 
     def get_user(self, gh_username: str) -> Any:
         """
         https://docs.github.com/en/rest/users/users#get-a-user
         """
-        return self.get(f"/users/{gh_username}")
+        return self.get(f"/users/{gh_username}", api_request_type=GitHubApiRequestType.GET_USER)
 
     def get_labels(self, owner: str, repo: str) -> list[Any]:
         """
         Fetches all labels for a repository.
         https://docs.github.com/en/rest/issues/labels#list-labels-for-a-repository
         """
-        return self._get_with_pagination(f"/repos/{owner}/{repo}/labels")
+        return self._get_with_pagination(
+            f"/repos/{owner}/{repo}/labels",
+            api_request_type=GitHubApiRequestType.GET_LABELS,
+        )
 
     def check_file(self, repo: Repository, path: str, version: str | None) -> object | None:
         return self.head_cached(
@@ -802,6 +941,7 @@ class GitHubBaseClient(
             params={"ref": ref},
             raw_response=True if codeowners else False,
             headers=headers,
+            api_request_type=GitHubApiRequestType.GET_FILE,
         )
 
         if codeowners:
@@ -859,6 +999,7 @@ class GitHubBaseClient(
                     path="/graphql",
                     data=data,
                     allow_text=False,
+                    api_request_type=GitHubApiRequestType.GET_BLAME_FOR_FILES,
                 )
             except ValueError as e:
                 logger.warning(str(e), log_info)
@@ -914,7 +1055,9 @@ class GitHubBaseClient(
         The repo must be in the format of "owner/repo".
         """
         endpoint = f"/repos/{repo}/check-runs"
-        return self.post(endpoint, data=data)
+        return self.post(
+            endpoint, data=data, api_request_type=GitHubApiRequestType.CREATE_CHECK_RUN
+        )
 
     def get_check_run(self, repo: str, check_run_id: int) -> Any:
         """
@@ -923,7 +1066,7 @@ class GitHubBaseClient(
         The repo must be in the format of "owner/repo".
         """
         endpoint = f"/repos/{repo}/check-runs/{check_run_id}"
-        return self.get(endpoint)
+        return self.get(endpoint, api_request_type=GitHubApiRequestType.GET_CHECK_RUN)
 
     def get_check_runs(self, repo: str, sha: str) -> Any:
         """
@@ -932,7 +1075,7 @@ class GitHubBaseClient(
         The repo must be in the format of "owner/repo". SHA can be any reference.
         """
         endpoint = f"/repos/{repo}/commits/{sha}/check-runs"
-        return self.get(endpoint)
+        return self.get(endpoint, api_request_type=GitHubApiRequestType.GET_CHECK_RUNS)
 
 
 class _IntegrationIdParams(TypedDict, total=False):

--- a/src/sentry/integrations/source_code_management/commit_context.py
+++ b/src/sentry/integrations/source_code_management/commit_context.py
@@ -140,6 +140,13 @@ class CommitContextIntegration(ABC):
     def get_client(self) -> CommitContextClient:
         raise NotImplementedError
 
+    def get_organization_id(self) -> int | None:
+        """
+        Return the organization ID when available on the installation instance.
+        Some unit-test mocks don't inherit IntegrationInstallation and won't have it.
+        """
+        return getattr(self, "organization_id", None)
+
     def get_blame_for_files(
         self, files: Sequence[SourceLineInfo], extra: dict[str, Any]
     ) -> list[FileBlameInfo]:
@@ -152,6 +159,7 @@ class CommitContextIntegration(ABC):
             interaction_type=SCMIntegrationInteractionType.GET_BLAME_FOR_FILES,
             provider_key=self.integration_name,
             integration_id=self.integration_id,
+            organization_id=self.get_organization_id(),
         ).capture() as lifecycle:
             try:
                 client = self.get_client()

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -415,11 +415,16 @@ class GitHubApiClientTest(TestCase):
         ) as cache_set:
             self.install.get_cached_repo_files(self.repo.name, "master", shifted_seconds)
 
-        cache_set.assert_any_call(
-            repo_key,
-            [],
-            self.install.CACHE_SECONDS + shifted_seconds,
-        )
+        matching_calls = [
+            call for call in cache_set.call_args_list if call.args and call.args[0] == repo_key
+        ]
+        assert matching_calls == [
+            mock.call(
+                repo_key,
+                [],
+                self.install.CACHE_SECONDS + shifted_seconds,
+            )
+        ]
 
     @responses.activate
     def test_get_cached_repo_files_raises_non_not_found_api_error(self) -> None:

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -415,7 +415,7 @@ class GitHubApiClientTest(TestCase):
         ) as cache_set:
             self.install.get_cached_repo_files(self.repo.name, "master", shifted_seconds)
 
-        cache_set.assert_called_once_with(
+        cache_set.assert_any_call(
             repo_key,
             [],
             self.install.CACHE_SECONDS + shifted_seconds,

--- a/tests/sentry/integrations/source_code_management/test_commit_context.py
+++ b/tests/sentry/integrations/source_code_management/test_commit_context.py
@@ -11,6 +11,7 @@ from sentry.integrations.source_code_management.commit_context import (
     CommitContextIntegration,
     SourceLineInfo,
 )
+from sentry.integrations.source_code_management.metrics import SCMIntegrationInteractionType
 from sentry.integrations.types import EventLifecycleOutcome
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError, ApiHostError
@@ -58,6 +59,49 @@ class TestCommitContextIntegrationSLO(TestCase):
 
         assert result == []
         assert_slo_metric(mock_record, EventLifecycleOutcome.SUCCESS)
+
+    @patch(
+        "sentry.integrations.source_code_management.commit_context.CommitContextIntegrationInteractionEvent"
+    )
+    def test_get_blame_for_files_event_includes_organization_id(
+        self, mock_interaction_event: MagicMock
+    ) -> None:
+        self.integration.organization_id = self.organization.id
+        self.integration.client.get_blame_for_files.return_value = []
+
+        lifecycle = MagicMock()
+        mock_interaction_event.return_value.capture.return_value.__enter__.return_value = lifecycle
+        mock_interaction_event.return_value.capture.return_value.__exit__.return_value = False
+
+        self.integration.get_blame_for_files([self.source_line], {})
+
+        mock_interaction_event.assert_called_once_with(
+            interaction_type=SCMIntegrationInteractionType.GET_BLAME_FOR_FILES,
+            provider_key=self.integration.integration_name,
+            integration_id=self.integration.integration_id,
+            organization_id=self.organization.id,
+        )
+
+    @patch(
+        "sentry.integrations.source_code_management.commit_context.CommitContextIntegrationInteractionEvent"
+    )
+    def test_get_blame_for_files_event_omits_organization_id_when_unavailable(
+        self, mock_interaction_event: MagicMock
+    ) -> None:
+        self.integration.client.get_blame_for_files.return_value = []
+
+        lifecycle = MagicMock()
+        mock_interaction_event.return_value.capture.return_value.__enter__.return_value = lifecycle
+        mock_interaction_event.return_value.capture.return_value.__exit__.return_value = False
+
+        self.integration.get_blame_for_files([self.source_line], {})
+
+        mock_interaction_event.assert_called_once_with(
+            interaction_type=SCMIntegrationInteractionType.GET_BLAME_FOR_FILES,
+            provider_key=self.integration.integration_name,
+            integration_id=self.integration.integration_id,
+            organization_id=None,
+        )
 
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     def test_get_blame_for_files_missing_identity(self, mock_record: MagicMock) -> None:

--- a/tests/sentry/preprod/api/endpoints/pull_request/test_organization_pullrequest_comments.py
+++ b/tests/sentry/preprod/api/endpoints/pull_request/test_organization_pullrequest_comments.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 from rest_framework.test import APIRequestFactory
 
+from sentry.integrations.github.client import GitHubApiRequestType
 from sentry.models.repository import Repository
 from sentry.preprod.api.endpoints.pull_request.organization_pullrequest_comments import (
     OrganizationPrCommentsEndpoint,
@@ -258,7 +259,7 @@ class OrganizationPrCommentsEndpointTest(TestCase):
     def test_successful_pr_comments_fetch(self, mock_get):
         """Test successful fetch of both general and review comments."""
 
-        def mock_get_side_effect(url):
+        def mock_get_side_effect(url, **kwargs):
             if "issues" in url:
                 return self.mock_general_comments
             elif "pulls" in url:
@@ -272,8 +273,14 @@ class OrganizationPrCommentsEndpointTest(TestCase):
 
         # Verify both API calls were made
         assert mock_get.call_count == 2
-        mock_get.assert_any_call("/repos/getsentry/sentry/issues/100/comments")
-        mock_get.assert_any_call("/repos/getsentry/sentry/pulls/100/comments")
+        mock_get.assert_any_call(
+            "/repos/getsentry/sentry/issues/100/comments",
+            api_request_type=GitHubApiRequestType.GET_ISSUE_COMMENTS,
+        )
+        mock_get.assert_any_call(
+            "/repos/getsentry/sentry/pulls/100/comments",
+            api_request_type=GitHubApiRequestType.GET_PULL_REQUEST_COMMENTS,
+        )
 
         # Verify response structure
         assert "general_comments" in response.data


### PR DESCRIPTION
The changes included make debugging API usages for an organization easier:
* Tag remaining GitHub endpoint calls with `api_request_type` 
* Include `organization_id` in remaining SCM event lifecycles

Made with [Cursor](https://cursor.com)