### PR TITLE
feat(seer): Add Alpha badge to Night Shift settings

### DIFF
--- a/static/gsApp/views/seerAutomation/components/projectDetails/nightShift.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectDetails/nightShift.tsx
@@ -1,3 +1,4 @@
+import {FeatureBadge} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {FieldGroup} from '@sentry/scraps/form';
 import {InfoTip} from '@sentry/scraps/info';
@@ -57,7 +58,14 @@ export function NightShift({canWrite, project}: Props) {
   const disabled = !canWrite || isPending;
 
   return (
-    <FieldGroup title={t('Night Shift')}>
+    <FieldGroup
+      title={
+        <Flex gap="xs" align="center">
+          {t('Night Shift')}
+          <FeatureBadge type="alpha" />
+        </Flex>
+      }
+    >
       <Flex gap="xs" align="center">
         <Text size="sm" variant="muted">
           {t('Debug')}


### PR DESCRIPTION
Add an Alpha `FeatureBadge` to the Night Shift settings section so viewers
can see at a glance that the feature is internal/prototype.

Follow-up to #113697, which scaffolded the section.


Agent transcript: https://claudescope.sentry.dev/share/9iiGvQMNPvLzAmVm3NK-uvkstvnmv-xn9pLwCb_BXOg