### PR TITLE
feat(explore): Accept metrics as a cross-event type on saved queries

### DIFF
--- a/src/sentry/api/serializers/models/exploresavedquery.py
+++ b/src/sentry/api/serializers/models/exploresavedquery.py
@@ -14,9 +14,16 @@ from sentry.users.services.user.service import user_service
 from sentry.utils.dates import outside_retention_with_modified_start, parse_timestamp
 
 
-class CrossEventResponseType(TypedDict):
+class MetricResponseType(TypedDict, total=False):
+    name: str
+    type: str
+    unit: str | None
+
+
+class CrossEventResponseType(TypedDict, total=False):
     query: str
     type: str
+    metric: MetricResponseType
 
 
 class ExploreSavedQueryResponseOptional(TypedDict, total=False):

--- a/src/sentry/api/serializers/models/exploresavedquery.py
+++ b/src/sentry/api/serializers/models/exploresavedquery.py
@@ -14,16 +14,22 @@ from sentry.users.services.user.service import user_service
 from sentry.utils.dates import outside_retention_with_modified_start, parse_timestamp
 
 
-class MetricResponseType(TypedDict, total=False):
-    name: str
-    type: str
+class MetricResponseTypeOptional(TypedDict, total=False):
     unit: str | None
 
 
-class CrossEventResponseType(TypedDict, total=False):
+class MetricResponseType(MetricResponseTypeOptional):
+    name: str
+    type: str
+
+
+class CrossEventResponseTypeOptional(TypedDict, total=False):
+    metric: MetricResponseType
+
+
+class CrossEventResponseType(CrossEventResponseTypeOptional):
     query: str
     type: str
-    metric: MetricResponseType
 
 
 class ExploreSavedQueryResponseOptional(TypedDict, total=False):

--- a/src/sentry/explore/endpoints/serializers.py
+++ b/src/sentry/explore/endpoints/serializers.py
@@ -151,10 +151,26 @@ class CrossEventSerializer(serializers.Serializer):
         help_text="The search query for this cross-event entry.",
     )
     type = serializers.ChoiceField(
-        choices=["spans", "logs"],
+        choices=["spans", "logs", "metrics"],
         required=True,
         help_text="The event type this cross-event query targets.",
     )
+    metric = MetricSerializer(
+        required=False,
+        allow_null=True,
+        help_text="The metric configuration (only used when type is metrics).",
+    )
+
+    def validate(self, data):
+        if data.get("type") == "metrics" and not data.get("metric"):
+            raise serializers.ValidationError(
+                "Metric field is required for metrics cross-event entries"
+            )
+        if data.get("type") != "metrics" and data.get("metric"):
+            raise serializers.ValidationError(
+                "Metric field is only allowed for metrics cross-event entries"
+            )
+        return data
 
 
 class ExploreSavedQuerySerializer(serializers.Serializer):

--- a/tests/sentry/explore/endpoints/test_explore_saved_queries.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_queries.py
@@ -1425,6 +1425,47 @@ class ExploreSavedQueriesTest(APITestCase):
         assert response.status_code == 400, response.content
         assert "Cross event queries are limited to 7 days." in str(response.content)
 
+    def test_get_returns_cross_events_metrics(self) -> None:
+        query = {
+            "range": "24h",
+            "query": [{"fields": ["span.op"], "mode": "samples"}],
+            "crossEvents": [
+                {
+                    "query": "",
+                    "type": "metrics",
+                    "metric": {
+                        "name": "http.response_time",
+                        "type": "distribution",
+                        "unit": "millisecond",
+                    },
+                },
+            ],
+        }
+        model = ExploreSavedQuery.objects.create(
+            organization=self.org,
+            created_by_id=self.user.id,
+            name="Metrics cross event query",
+            query=query,
+        )
+        model.set_projects(self.project_ids)
+
+        with self.feature(self.features):
+            response = self.client.get(self.url, data={"query": "name:Metrics cross event query"})
+
+        assert response.status_code == 200, response.content
+        assert len(response.data) == 1
+        assert response.data[0]["crossEvents"] == [
+            {
+                "query": "",
+                "type": "metrics",
+                "metric": {
+                    "name": "http.response_time",
+                    "type": "distribution",
+                    "unit": "millisecond",
+                },
+            },
+        ]
+
     def test_save_with_cross_events_metrics(self) -> None:
         with self.feature(self.features):
             response = self.client.post(

--- a/tests/sentry/explore/endpoints/test_explore_saved_queries.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_queries.py
@@ -1425,6 +1425,113 @@ class ExploreSavedQueriesTest(APITestCase):
         assert response.status_code == 400, response.content
         assert "Cross event queries are limited to 7 days." in str(response.content)
 
+    def test_save_with_cross_events_metrics(self) -> None:
+        with self.feature(self.features):
+            response = self.client.post(
+                self.url,
+                {
+                    "name": "Cross event metrics query",
+                    "projects": self.project_ids,
+                    "dataset": "spans",
+                    "query": [
+                        {
+                            "fields": ["span.op"],
+                            "mode": "samples",
+                        }
+                    ],
+                    "range": "24h",
+                    "crossEvents": [
+                        {
+                            "query": "",
+                            "type": "metrics",
+                            "metric": {
+                                "name": "http.response_time",
+                                "type": "distribution",
+                                "unit": "millisecond",
+                            },
+                        },
+                    ],
+                },
+            )
+        assert response.status_code == 201, response.content
+        data = response.data
+        assert data["crossEvents"] == [
+            {
+                "query": "",
+                "type": "metrics",
+                "metric": {
+                    "name": "http.response_time",
+                    "type": "distribution",
+                    "unit": "millisecond",
+                },
+            },
+        ]
+
+        saved = ExploreSavedQuery.objects.get(id=data["id"])
+        assert saved.query["crossEvents"] == [
+            {
+                "query": "",
+                "type": "metrics",
+                "metric": {
+                    "name": "http.response_time",
+                    "type": "distribution",
+                    "unit": "millisecond",
+                },
+            },
+        ]
+
+    def test_save_with_cross_events_metrics_missing_metric(self) -> None:
+        with self.feature(self.features):
+            response = self.client.post(
+                self.url,
+                {
+                    "name": "Metrics cross event missing descriptor",
+                    "projects": self.project_ids,
+                    "dataset": "spans",
+                    "query": [
+                        {
+                            "fields": ["span.op"],
+                            "mode": "samples",
+                        }
+                    ],
+                    "range": "24h",
+                    "crossEvents": [
+                        {"query": "", "type": "metrics"},
+                    ],
+                },
+            )
+        assert response.status_code == 400, response.content
+
+    def test_save_with_cross_events_metric_on_non_metrics_type(self) -> None:
+        with self.feature(self.features):
+            response = self.client.post(
+                self.url,
+                {
+                    "name": "Non-metrics cross event with metric",
+                    "projects": self.project_ids,
+                    "dataset": "spans",
+                    "query": [
+                        {
+                            "fields": ["span.op"],
+                            "mode": "samples",
+                        }
+                    ],
+                    "range": "24h",
+                    "crossEvents": [
+                        {
+                            "query": "span.op:db",
+                            "type": "spans",
+                            "metric": {
+                                "name": "http.response_time",
+                                "type": "distribution",
+                                "unit": "millisecond",
+                            },
+                        },
+                    ],
+                },
+            )
+        assert response.status_code == 400, response.content
+
     def test_save_replay_query(self) -> None:
         with self.feature(self.features):
             response = self.client.post(

--- a/tests/sentry/explore/endpoints/test_explore_saved_query_detail.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_query_detail.py
@@ -118,6 +118,82 @@ class ExploreSavedQueryDetailTest(APITestCase, SnubaTestCase):
             {"query": "severity:error", "type": "logs"},
         ]
 
+    def test_get_with_cross_events_metrics(self) -> None:
+        self.model.query = {
+            "query": [{"fields": ["span.op"], "mode": "samples"}],
+            "crossEvents": [
+                {
+                    "query": "",
+                    "type": "metrics",
+                    "metric": {
+                        "name": "http.response_time",
+                        "type": "distribution",
+                        "unit": "millisecond",
+                    },
+                },
+            ],
+        }
+        self.model.save()
+
+        with self.feature(self.feature_name):
+            url = reverse(
+                "sentry-api-0-explore-saved-query-detail", args=[self.org.slug, self.query_id]
+            )
+            response = self.client.get(url)
+
+        assert response.status_code == 200, response.content
+        assert response.data["crossEvents"] == [
+            {
+                "query": "",
+                "type": "metrics",
+                "metric": {
+                    "name": "http.response_time",
+                    "type": "distribution",
+                    "unit": "millisecond",
+                },
+            },
+        ]
+
+    def test_put_adds_cross_events_metrics(self) -> None:
+        with self.feature(self.feature_name):
+            url = reverse(
+                "sentry-api-0-explore-saved-query-detail", args=[self.org.slug, self.query_id]
+            )
+
+            response = self.client.put(
+                url,
+                {
+                    "name": "With metrics cross events",
+                    "projects": self.project_ids,
+                    "range": "24h",
+                    "query": [{"fields": ["span.op"], "mode": "samples"}],
+                    "crossEvents": [
+                        {
+                            "query": "",
+                            "type": "metrics",
+                            "metric": {
+                                "name": "http.response_time",
+                                "type": "distribution",
+                                "unit": "millisecond",
+                            },
+                        },
+                    ],
+                },
+            )
+
+        assert response.status_code == 200, response.content
+        assert response.data["crossEvents"] == [
+            {
+                "query": "",
+                "type": "metrics",
+                "metric": {
+                    "name": "http.response_time",
+                    "type": "distribution",
+                    "unit": "millisecond",
+                },
+            },
+        ]
+
     def test_get_changed_reason(self) -> None:
         migrated_query = ExploreSavedQuery.objects.create(
             organization=self.org,


### PR DESCRIPTION
The goal of this PR is to add in support for metric cross-event queries. We had to update the cross event object when for metrics specifically to include an object that contains the metric info, the cross-event param for metrics looks like:

```json
[{
  "type":"metrics",
  "query":"",
  "metric": {
    "name":"dashboards.widget.onEdit",
    "type":"distribution",
    "unit":"millisecond"
  }
}]
```

The changes also include some test updates to ensure they're saved, updated, and returned correctly.

Closes EXP-897