### PR TITLE
ref(spans): unregister chunk oversized segments option

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3195,12 +3195,6 @@ register(
     default=10 * 1024 * 1024,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
-# When enabled, oversized segments are split into chunks instead of being dropped.
-register(
-    "spans.buffer.chunk-oversized-segments",
-    default=False,
-    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
-)
 # Whether to enforce max-segment-bytes during ingestion via the Lua script.
 register(
     "spans.buffer.enforce-segment-size",


### PR DESCRIPTION
Unregistering the option as it has been fully rolled out and removed from the span buffer logic.