### PR TITLE
test(projects): Harden regression coverage for delete_project and delete_project_key

### DIFF
--- a/tests/sentry/hybridcloud/test_project.py
+++ b/tests/sentry/hybridcloud/test_project.py
@@ -229,15 +229,16 @@ def test_delete_project_idempotent_on_second_call() -> None:
 
 
 @django_db_all(transaction=True)
-def test_delete_project_rolls_back_on_failure() -> None:
-    """If ``rename_on_pending_deletion`` or ``CellScheduledDeletion.schedule``
-    raises, the status update must roll back so a retry can succeed.
-    Without the transaction wrapper the row would be stuck in
-    PENDING_DELETION with no scheduled deletion -- a replay would find
-    status != ACTIVE and skip the whole block, orphaning the project."""
+def test_delete_project_rolls_back_status_and_schedule_when_rename_fails() -> None:
+    """If ``rename_on_pending_deletion`` raises, the transaction wrapper
+    must roll back BOTH the status update AND the CellScheduledDeletion
+    row. The stated purpose of the transaction is to prevent partial
+    state — this test asserts both halves of that invariant, not just
+    the status rollback."""
     from unittest import mock
 
     from sentry.constants import ObjectStatus
+    from sentry.deletions.models.scheduleddeletion import CellScheduledDeletion
 
     org = Factories.create_organization()
     project = Factories.create_project(organization=org)
@@ -250,7 +251,76 @@ def test_delete_project_rolls_back_on_failure() -> None:
         with pytest.raises(RuntimeError):
             project_service.delete_project(organization_id=org.id, project_id=project.id)
 
-    # The transaction must have rolled back the status update; the
-    # project is still ACTIVE and a retry can succeed.
+    # Both invariants must hold: status rolls back AND no phantom
+    # scheduled-deletion row exists. Without the transaction wrapper, a
+    # CellScheduledDeletion row would survive the exception and fire
+    # against a still-ACTIVE project in 30 days.
     project.refresh_from_db()
     assert project.status == ObjectStatus.ACTIVE
+    assert not CellScheduledDeletion.objects.filter(
+        app_label="sentry", model_name="Project", object_id=project.id
+    ).exists()
+
+
+@django_db_all(transaction=True)
+def test_delete_project_rolls_back_when_schedule_fails() -> None:
+    """Covers the OTHER failure point inside the transaction. If
+    ``CellScheduledDeletion.schedule`` raises, the status update must
+    roll back AND the (partial) schedule row must roll back too. Without
+    this test coverage, an optimization that moves ``schedule`` outside
+    the transaction could silently regress the guard."""
+    from unittest import mock
+
+    from sentry.constants import ObjectStatus
+    from sentry.deletions.models.scheduleddeletion import CellScheduledDeletion
+
+    org = Factories.create_organization()
+    project = Factories.create_project(organization=org)
+
+    with mock.patch(
+        "sentry.projects.services.project.impl.CellScheduledDeletion.schedule",
+        side_effect=RuntimeError("simulated schedule failure"),
+    ):
+        with pytest.raises(RuntimeError):
+            project_service.delete_project(organization_id=org.id, project_id=project.id)
+
+    project.refresh_from_db()
+    assert project.status == ObjectStatus.ACTIVE
+    assert not CellScheduledDeletion.objects.filter(
+        app_label="sentry", model_name="Project", object_id=project.id
+    ).exists()
+
+
+@django_db_all(transaction=True)
+def test_delete_project_refuses_internal_project() -> None:
+    """``settings.SENTRY_PROJECT`` is the internal project that
+    ingests Sentry's own events. ``is_internal_project()`` protects it
+    from deletion — deleting it would break Sentry's own error
+    reporting. The RPC must return False (silently, like missing) and
+    leave the status untouched. Stripe Projects callers would never
+    touch this project in practice, but the guard must be tested so a
+    future refactor that removes it fails loudly."""
+    from unittest import mock
+
+    from sentry.constants import ObjectStatus
+    from sentry.deletions.models.scheduleddeletion import CellScheduledDeletion
+
+    org = Factories.create_organization()
+    project = Factories.create_project(organization=org)
+
+    # Patch the instance method to simulate this being the internal
+    # project, since SENTRY_PROJECT is a Django settings integer that
+    # doesn't match our freshly-created test project's id. Matches the
+    # pattern used elsewhere in the test suite for this flag.
+    with mock.patch.object(Project, "is_internal_project", return_value=True):
+        result = project_service.delete_project(organization_id=org.id, project_id=project.id)
+
+    assert result is False
+    # Neither the status update nor the scheduled deletion should have
+    # happened — the guard short-circuits BEFORE entering the
+    # transaction block.
+    project.refresh_from_db()
+    assert project.status == ObjectStatus.ACTIVE
+    assert not CellScheduledDeletion.objects.filter(
+        app_label="sentry", model_name="Project", object_id=project.id
+    ).exists()

--- a/tests/sentry/hybridcloud/test_project_key.py
+++ b/tests/sentry/hybridcloud/test_project_key.py
@@ -9,6 +9,8 @@ is user-controllable: without org+project scoping, a stolen or
 malformed public_key could delete keys from unrelated projects.
 """
 
+from sentry.hybridcloud.models.outbox import CellOutbox
+from sentry.hybridcloud.outbox.category import OutboxCategory
 from sentry.models.projectkey import ProjectKey
 from sentry.projects.services.project_key.service import project_key_service
 from sentry.testutils.factories import Factories
@@ -182,3 +184,40 @@ def test_delete_project_key_refuses_internal_keys() -> None:
 
     assert result is False
     assert ProjectKey.objects.filter(id=internal_key.id).exists()
+
+
+@django_db_all(transaction=True)
+def test_delete_project_key_emits_outbox() -> None:
+    """The reason we fetch-then-delete (rather than
+    ``ProjectKey.objects.filter(...).delete()``) is that QuerySet.delete()
+    bypasses the per-instance override on ``CellOutboxProducingModel``
+    that emits the replication outbox. This test asserts the outbox IS
+    emitted so a "performance optimization" back to QuerySet.delete()
+    fails loudly."""
+    org = Factories.create_organization()
+    project = Factories.create_project(organization=org)
+    key = Factories.create_project_key(project=project)
+    key_id = key.id
+
+    # Clear any outboxes from key creation so we can assert specifically
+    # on the delete-emitted outbox.
+    CellOutbox.objects.filter(
+        category=OutboxCategory.PROJECT_KEY_UPDATE.value,
+        object_identifier=key_id,
+    ).delete()
+
+    result = project_key_service.delete_project_key(
+        organization_id=org.id,
+        project_id=project.id,
+        public_key=key.public_key,
+    )
+
+    assert result is True
+    assert not ProjectKey.objects.filter(id=key_id).exists()
+    # Delete outbox must exist so the control-silo replica also gets
+    # cleaned up. Without this, stale replica rows would continue to
+    # validate DSN lookups and auth checks for a deleted key.
+    assert CellOutbox.objects.filter(
+        category=OutboxCategory.PROJECT_KEY_UPDATE.value,
+        object_identifier=key_id,
+    ).exists()


### PR DESCRIPTION
Follow-up to #113596. A post-merge retrospective review surfaced three
modest coverage gaps — all on test hardening, no source changes. The
prior review rounds caught the genuinely nasty bugs (QuerySet.delete
bypassing outbox, missing `rename_on_pending_deletion`); this PR
strengthens the guards around those fixes so a future "optimization"
that re-introduces either class of bug fails loudly.

## Changes

### 1. `test_delete_project_rolls_back_status_and_schedule_when_rename_fails`

Renamed from `test_delete_project_rolls_back_on_failure`. The
transaction wrapper's stated purpose is to prevent partial state on
failure, but the original test only asserted the status rollback — not
that the `CellScheduledDeletion` row was also rolled back. Without
this, a phantom scheduled deletion could fire against a still-ACTIVE
row 30 days later. Now asserts both invariants.

### 2. `test_delete_project_rolls_back_when_schedule_fails` (new)

The original test only covered the rename-raises path. This covers
the **other** failure point inside the transaction —
`CellScheduledDeletion.schedule()` raising. Without this, an
optimization that moves `schedule()` outside the transaction could
silently regress the guard.

### 3. `test_delete_project_refuses_internal_project` (new)

`is_internal_project()` protects `settings.SENTRY_PROJECT` from
deletion (deleting it would break Sentry's own error reporting). The
branch was completely untested — a future refactor removing the guard
would pass CI. Uses `mock.patch.object(Project, 'is_internal_project')`
since `SENTRY_PROJECT` is a Django settings integer that doesn't match
freshly-created test project ids.

### 4. `test_delete_project_key_emits_outbox` (new)

The entire reason we fetch-then-delete (rather than
`ProjectKey.objects.filter(...).delete()`) is that `QuerySet.delete()`
bypasses the per-instance override on `CellOutboxProducingModel` that
emits the replication outbox. Explicitly asserts the `CellOutbox` row
is produced so a "performance optimization" back to `QuerySet.delete()`
fails loudly — replica tables on the control silo would otherwise
retain stale rows and keep validating deleted DSNs.

Creation-side outbox test was skipped: `ReplicatedCellModel` flushes
outboxes immediately on `save()` by default (`flush=None →
outbox_context → flush=True`), so the row never lingers long enough
for a post-call assertion. The delete path explicitly uses
`flush=False` which is what makes the assertion viable there.

## Process note

This PR is the result of a post-merge subagent review pass done to
catch anything the three prior reviews missed (self-review, sentry-seer,
@dashed). The reviewer surfaced one Important item (I1, now split into
tests #1 and #2) and two minor items (M3, M4 → tests #3 and #4), plus
9 verified-clean items. See
https://github.com/getsentry/sentry/pull/113596 for full context.

No source changes, no behavior changes. 20/20 tests pass locally.