### PR TITLE
chore(workflow-engine-ui): Update example for slack notes

### DIFF
--- a/static/app/views/automations/components/actions/slack.tsx
+++ b/static/app/views/automations/components/actions/slack.tsx
@@ -96,7 +96,7 @@ function NotesField() {
     <AutomationBuilderInput
       name={`${actionId}.data.notes`}
       aria-label={t('Notes')}
-      placeholder={t('e.g., @jane, @on-call-team')}
+      placeholder={t('e.g. @jane, @on-call-team')}
       value={action.data.notes ?? ''}
       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
         onUpdate({

--- a/static/app/views/automations/components/actions/slack.tsx
+++ b/static/app/views/automations/components/actions/slack.tsx
@@ -96,7 +96,7 @@ function NotesField() {
     <AutomationBuilderInput
       name={`${actionId}.data.notes`}
       aria-label={t('Notes')}
-      placeholder={t('example notes')}
+      placeholder={t('e.g., @jane, @on-call-team')}
       value={action.data.notes ?? ''}
       onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
         onUpdate({


### PR DESCRIPTION
Issue alerts had a better example, lifted that into new alert builder

was:

<img width="1051" height="337" alt="image" src="https://github.com/user-attachments/assets/86ff6ec8-bd9d-4cfd-b8a2-e690391e2ccc" />


