### PR TITLE
fix(seer): always use default variant

### DIFF
--- a/static/app/views/seerExplorer/components/askSeerButton.tsx
+++ b/static/app/views/seerExplorer/components/askSeerButton.tsx
@@ -30,7 +30,7 @@ export function AskSeerButton() {
   const props: ButtonProps = {
     'aria-label': t('Ask Seer'),
     'aria-expanded': isOpen ? true : undefined,
-    priority: sessionState === 'thinking' ? 'primary' : 'default',
+    priority: 'default',
     icon: <IconWrapper>{icon}</IconWrapper>,
   };
 


### PR DESCRIPTION
the ask seer button shouldn't switch to `accent` variant when the drawer is open.

this pr makes it so the global ask seer button always uses the `default` variant.