### PR TITLE
fix(pr-comments): align option default in task body with queue gate

### DIFF
--- a/src/sentry/integrations/source_code_management/tasks.py
+++ b/src/sentry/integrations/source_code_management/tasks.py
@@ -99,7 +99,7 @@ def pr_comment_workflow(pr_id: int, project_id: int) -> None:
     if not OrganizationOption.objects.get_value(
         organization=organization,
         key=pr_comment_workflow.organization_option_key,
-        default=True,
+        default=False,
     ):
         logger.info(
             _pr_comment_log(integration_name=integration_name, suffix="option_missing"),

--- a/tests/sentry/integrations/github/tasks/test_pr_comment.py
+++ b/tests/sentry/integrations/github/tasks/test_pr_comment.py
@@ -374,6 +374,9 @@ class TestCommentWorkflow(GithubCommentTestCase):
         self.app_id = "app_1"
         self.pr = self.create_pr_issues()
         self.cache_key = DEBOUNCE_PR_COMMENT_CACHE_KEY(self.pr.id)
+        OrganizationOption.objects.set_value(
+            organization=self.organization, key="sentry:github_pr_bot", value=True
+        )
 
     @patch(
         "sentry.integrations.github.integration.GitHubPRCommentWorkflow.get_top_5_issues_by_count"

--- a/tests/sentry/integrations/gitlab/tasks/test_pr_comment.py
+++ b/tests/sentry/integrations/gitlab/tasks/test_pr_comment.py
@@ -12,6 +12,7 @@ from sentry.integrations.source_code_management.tasks import pr_comment_workflow
 from sentry.models.commit import Commit
 from sentry.models.group import Group
 from sentry.models.groupowner import GroupOwner, GroupOwnerType
+from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.pullrequest import (
     CommentType,
     PullRequest,
@@ -342,6 +343,9 @@ class TestCommentWorkflow(GitlabCommentTestCase):
         self.app_id = "app_1"
         self.pr = self.create_pr_issues()
         self.cache_key = DEBOUNCE_PR_COMMENT_CACHE_KEY(self.pr.id)
+        OrganizationOption.objects.set_value(
+            organization=self.organization, key="sentry:gitlab_pr_bot", value=True
+        )
 
     @patch(
         "sentry.integrations.gitlab.integration.GitlabPRCommentWorkflow.get_top_5_issues_by_count"


### PR DESCRIPTION
The queue gate in `commit_context.py` reads `sentry:github_pr_bot` /
`sentry:gitlab_pr_bot` with `default=False`, but the task body in
`tasks.py` re-read the same option with `default=True`. #103525 flipped
the default to off everywhere but missed this call site, so if the
option was cleared between enqueue and execution the task would run
against the old default-on behavior.

Since the queue gate is the only enqueue path
(`commit_context.py:458-461`, called from `queue_pr_comment_task_if_needed`),
the `default=True` branch is effectively dead in the common case, but
the asymmetry is a latent bug if the option is deleted between enqueue
and task pickup. Aligning the defaults to `False` matches the intent of
#103525.