### PR TITLE
feat(tracemetrics): Hide special metrics keys in scrubbing dropdown

### DIFF
--- a/static/app/views/settings/components/dataScrubbing/modals/form/attributeField.tsx
+++ b/static/app/views/settings/components/dataScrubbing/modals/form/attributeField.tsx
@@ -36,7 +36,11 @@ const datasetToTraceItemType: Record<
 const HIDDEN_SCRUBBING_ATTRIBUTES: Partial<
   Record<AllowedDataScrubbingDatasets, Set<string>>
 > = {
-  [AllowedDataScrubbingDatasets.METRICS]: new Set(['metric.name']),
+  [AllowedDataScrubbingDatasets.METRICS]: new Set([
+    'metric.name',
+    'metric.type',
+    'metric.unit',
+  ]),
 };
 
 type FieldProps = {


### PR DESCRIPTION
We noticed `metric.type` and `metric.unit` were showing up in data scrubbing UI. These shouldn't have PII and we shouldn't make rules against them so add them to the hidden keys list.