### PR TITLE
feat(nav): Lock secondary nav to always be expanded on settings pages

### DIFF
--- a/static/app/views/navigation/index.desktop.spec.tsx
+++ b/static/app/views/navigation/index.desktop.spec.tsx
@@ -760,6 +760,40 @@ describe('desktop navigation', () => {
         });
       });
 
+      describe('settings page', () => {
+        it('is always expanded even when nav was previously collapsed', () => {
+          localStorage.setItem(NAVIGATION_SIDEBAR_COLLAPSED_LOCAL_STORAGE_KEY, 'true');
+
+          render(
+            <PrimaryNavigationContextProvider>
+              <Navigation />
+            </PrimaryNavigationContextProvider>,
+            navigationContext({
+              initialRouterConfig: {location: {pathname: '/settings/org-slug/'}},
+            })
+          );
+
+          expect(
+            screen.queryByTestId('collapsed-secondary-sidebar')
+          ).not.toBeInTheDocument();
+        });
+
+        it('does not show the collapse button', () => {
+          render(
+            <PrimaryNavigationContextProvider>
+              <Navigation />
+            </PrimaryNavigationContextProvider>,
+            navigationContext({
+              initialRouterConfig: {location: {pathname: '/settings/org-slug/'}},
+            })
+          );
+
+          expect(
+            screen.queryByRole('button', {name: 'Collapse'})
+          ).not.toBeInTheDocument();
+        });
+      });
+
       describe('peek preview', () => {
         it('shows the sidebar on hover when collapsed', async () => {
           localStorage.setItem(NAVIGATION_SIDEBAR_COLLAPSED_LOCAL_STORAGE_KEY, 'true');

--- a/static/app/views/navigation/primaryNavigationContext.tsx
+++ b/static/app/views/navigation/primaryNavigationContext.tsx
@@ -71,7 +71,7 @@ export function PrimaryNavigationContextProvider(
 
   return (
     <NavigationTourReminderContextProvider>
-      <SecondaryNavigationContextProvider>
+      <SecondaryNavigationContextProvider activeGroup={activeRouteGroup}>
         <PrimaryNavigationContext.Provider value={value}>
           {props.children}
         </PrimaryNavigationContext.Provider>

--- a/static/app/views/navigation/secondary/components.tsx
+++ b/static/app/views/navigation/secondary/components.tsx
@@ -272,11 +272,12 @@ interface SecondaryNavigationHeaderProps {
 }
 
 function SecondaryNavigationHeader(props: SecondaryNavigationHeaderProps) {
-  const {layout} = usePrimaryNavigation();
+  const {layout, activeGroup} = usePrimaryNavigation();
   const {view, setView} = useSecondaryNavigation();
   const isCollapsed = view !== 'expanded';
   const hasPageFrame = useHasPageFrameFeature();
   const isMobilePageFrame = hasPageFrame && layout === 'mobile';
+  const isLocked = activeGroup === 'settings';
 
   return (
     <Grid
@@ -302,28 +303,29 @@ function SecondaryNavigationHeader(props: SecondaryNavigationHeaderProps) {
         </Text>
       </div>
       <div>
-        {isMobilePageFrame ? (
-          <Button
-            size="xs"
-            icon={<IconClose />}
-            aria-label={isCollapsed ? t('Expand') : t('Collapse')}
-            onClick={() => setView(view === 'expanded' ? 'collapsed' : 'expanded')}
-            priority="transparent"
-          />
-        ) : layout === 'mobile' ? null : (
-          <Button
-            size="xs"
-            icon={<IconChevron direction={isCollapsed ? 'right' : 'left'} isDouble />}
-            aria-label={isCollapsed ? t('Expand') : t('Collapse')}
-            onClick={() => setView(view === 'expanded' ? 'collapsed' : 'expanded')}
-            priority={isCollapsed ? 'primary' : 'transparent'}
-            analyticsEventName="Sidebar: Secondary Toggle Button Clicked"
-            analyticsEventKey="sidebar_secondary_toggle_button_clicked"
-            analyticsParams={{
-              is_collapsed: isCollapsed,
-            }}
-          />
-        )}
+        {!isLocked &&
+          (isMobilePageFrame ? (
+            <Button
+              size="xs"
+              icon={<IconClose />}
+              aria-label={isCollapsed ? t('Expand') : t('Collapse')}
+              onClick={() => setView(view === 'expanded' ? 'collapsed' : 'expanded')}
+              priority="transparent"
+            />
+          ) : layout === 'mobile' ? null : (
+            <Button
+              size="xs"
+              icon={<IconChevron direction={isCollapsed ? 'right' : 'left'} isDouble />}
+              aria-label={isCollapsed ? t('Expand') : t('Collapse')}
+              onClick={() => setView(view === 'expanded' ? 'collapsed' : 'expanded')}
+              priority={isCollapsed ? 'primary' : 'transparent'}
+              analyticsEventName="Sidebar: Secondary Toggle Button Clicked"
+              analyticsEventKey="sidebar_secondary_toggle_button_clicked"
+              analyticsParams={{
+                is_collapsed: isCollapsed,
+              }}
+            />
+          ))}
       </div>
     </Grid>
   );

--- a/static/app/views/navigation/secondaryNavigationContext.tsx
+++ b/static/app/views/navigation/secondaryNavigationContext.tsx
@@ -31,11 +31,14 @@ export function useSecondaryNavigation(): SecondaryNavigationContext {
 
 interface SecondaryNavigationContextProviderProps {
   children: React.ReactNode;
+  activeGroup?: string;
 }
 
 export function SecondaryNavigationContextProvider(
   props: SecondaryNavigationContextProviderProps
 ) {
+  const isLocked = props.activeGroup === 'settings';
+
   const [isCollapsedPersisted, setIsCollapsedPersisted] = useLocalStorageState(
     NAVIGATION_SIDEBAR_COLLAPSED_LOCAL_STORAGE_KEY,
     false
@@ -46,20 +49,23 @@ export function SecondaryNavigationContextProvider(
 
   const setView = useCallback(
     (nextView: SecondaryNavState) => {
+      if (isLocked) {
+        return;
+      }
       setViewState(nextView);
       if (nextView !== 'peek') {
         setIsCollapsedPersisted(nextView === 'collapsed');
       }
     },
-    [setIsCollapsedPersisted]
+    [isLocked, setIsCollapsedPersisted]
   );
 
   const value = useMemo(() => {
     return {
-      view,
+      view: isLocked ? ('expanded' as const) : view,
       setView,
     };
-  }, [view, setView]);
+  }, [isLocked, view, setView]);
 
   return (
     <SecondaryNavigationContext.Provider value={value}>


### PR DESCRIPTION
Settings pages have structured navigation that users need to browse — collapsing the sidebar here creates a worse experience because it removes the primary way to move between settings sections.

When a user is on any settings route, the secondary sidebar is now always visible regardless of their collapsed preference. The collapse toggle button is hidden, and the Ctrl+B/Cmd+B keyboard shortcut has no effect while on settings routes. When the user navigates away from settings, their previous collapsed/expanded preference is restored.

Implemented by passing the active route group as a prop from `PrimaryNavigationContextProvider` down to `SecondaryNavigationContextProvider`, where it overrides the view to `'expanded'` and makes `setView` a no-op when the group is `'settings'`. The header component reads `activeGroup` from `usePrimaryNavigation()` to conditionally hide the toggle button.