### PR TITLE
ref(seer-slack): Remove explorer cache key fallback

### DIFF
--- a/src/sentry/seer/entrypoints/cache.py
+++ b/src/sentry/seer/entrypoints/cache.py
@@ -211,11 +211,6 @@ class SeerOperatorAgentCache[CachePayloadT]:
         return f"seer:agent:{entrypoint_key}:{run_id}"
 
     @classmethod
-    def _get_legacy_cache_key(cls, *, entrypoint_key: str, run_id: int) -> str:
-        # TODO: remove once the rename has fully propagated.
-        return f"seer:explorer:{entrypoint_key}:{run_id}"
-
-    @classmethod
     def set(cls, *, entrypoint_key: str, run_id: int, cache_payload: CachePayloadT) -> None:
         with SeerOperatorEventLifecycleMetric(
             interaction_type=SeerOperatorInteractionType.OPERATOR_CACHE_SET_AGENT,
@@ -232,13 +227,8 @@ class SeerOperatorAgentCache[CachePayloadT]:
             entrypoint_key=entrypoint_key,
         ).capture() as lifecycle:
             cache_key = cls._get_cache_key(entrypoint_key=entrypoint_key, run_id=run_id)
-            legacy_cache_key = cls._get_legacy_cache_key(
-                entrypoint_key=entrypoint_key, run_id=run_id
-            )
-            lifecycle.add_extras(
-                {"run_id": run_id, "cache_key": cache_key, "legacy_cache_key": legacy_cache_key}
-            )
-            cache_payload = cache.get(cache_key) or cache.get(legacy_cache_key)
+            lifecycle.add_extras({"run_id": run_id, "cache_key": cache_key})
+            cache_payload = cache.get(cache_key)
             if not cache_payload:
                 lifecycle.record_halt(halt_reason=CacheHaltReason.CACHE_MISS)
                 return None

--- a/src/sentry/seer/entrypoints/slack/entrypoint.py
+++ b/src/sentry/seer/entrypoints/slack/entrypoint.py
@@ -104,7 +104,12 @@ def _get_missing_scope_settings_url(
     except Organization.DoesNotExist:
         return None
 
-    cache_key = f"seer:explorer:scope_footer:{integration_id}:{channel_id}:{thread_ts}"
+    # TODO: remove the legacy check once MISSING_SCOPE_FOOTER_CACHE_TIMEOUT has elapsed since deploy.
+    legacy_cache_key = f"seer:explorer:scope_footer:{integration_id}:{channel_id}:{thread_ts}"
+    if cache.get(legacy_cache_key):
+        return None
+
+    cache_key = f"seer:agent:scope_footer:{integration_id}:{channel_id}:{thread_ts}"
     if not cache.add(cache_key, True, timeout=MISSING_SCOPE_FOOTER_CACHE_TIMEOUT):
         return None
 


### PR DESCRIPTION
the TTL for the old cache for seer agent has passed, it is now safe to delete the old key fallback.

however, in the process, found the footer cache also has the `explorer` naming. removing that with a fallback too.

Refs iswf-2477