### PR TITLE
fix(onboarding): Recover from repo_exists race in SCM repo selection

### DIFF
--- a/static/app/views/onboarding/components/useScmRepoSelection.spec.tsx
+++ b/static/app/views/onboarding/components/useScmRepoSelection.spec.tsx
@@ -116,6 +116,60 @@ describe('useScmRepoSelection', () => {
     );
   });
 
+  it('recovers from repo_exists race by re-querying after POST', async () => {
+    let getCallCount = 0;
+    const getRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/repos/`,
+      body: () => {
+        getCallCount++;
+        // First GET sees nothing; POST fails with repo_exists because the
+        // background task registered the repo between our GET and POST.
+        // Second GET picks up the now-registered repo.
+        if (getCallCount === 1) {
+          return [];
+        }
+        return [
+          {
+            id: '77',
+            name: 'getsentry/sentry',
+            externalSlug: 'getsentry/sentry',
+            status: 'active',
+          },
+        ];
+      },
+    });
+
+    const addRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/repos/`,
+      method: 'POST',
+      statusCode: 400,
+      body: {
+        detail: {
+          code: 'repo_exists',
+          message: 'A repository with that configuration already exists',
+          extra: {},
+        },
+      },
+    });
+
+    const {result} = renderHookWithProviders(
+      () =>
+        useScmRepoSelection({integration: mockIntegration, onSelect, reposByIdentifier}),
+      {organization}
+    );
+
+    await act(async () => {
+      await result.current.handleSelect({value: 'getsentry/sentry'});
+    });
+
+    expect(getRequest).toHaveBeenCalledTimes(2);
+    expect(addRequest).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({id: '77', name: 'getsentry/sentry'})
+    );
+    expect(onSelect).not.toHaveBeenCalledWith(undefined);
+  });
+
   it('reverts onSelect on POST failure', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/repos/`,

--- a/static/app/views/onboarding/components/useScmRepoSelection.spec.tsx
+++ b/static/app/views/onboarding/components/useScmRepoSelection.spec.tsx
@@ -117,38 +117,35 @@ describe('useScmRepoSelection', () => {
   });
 
   it('recovers from repo_exists race by re-querying after POST', async () => {
-    let getCallCount = 0;
+    // Model the race: GET reflects current BE state; POST flips the BE to
+    // "repo exists" (as if the link_all_repos task landed between the two
+    // requests) and then responds 400 repo_exists.
+    let backendHasRepo = false;
+    const registeredRepo = {
+      id: '77',
+      name: 'getsentry/sentry',
+      externalSlug: 'getsentry/sentry',
+      status: 'active',
+    };
+
     const getRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/repos/`,
-      body: () => {
-        getCallCount++;
-        // First GET sees nothing; POST fails with repo_exists because the
-        // background task registered the repo between our GET and POST.
-        // Second GET picks up the now-registered repo.
-        if (getCallCount === 1) {
-          return [];
-        }
-        return [
-          {
-            id: '77',
-            name: 'getsentry/sentry',
-            externalSlug: 'getsentry/sentry',
-            status: 'active',
-          },
-        ];
-      },
+      body: () => (backendHasRepo ? [registeredRepo] : []),
     });
 
     const addRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/repos/`,
       method: 'POST',
       statusCode: 400,
-      body: {
-        detail: {
-          code: 'repo_exists',
-          message: 'A repository with that configuration already exists',
-          extra: {},
-        },
+      body: () => {
+        backendHasRepo = true;
+        return {
+          detail: {
+            code: 'repo_exists',
+            message: 'A repository with that configuration already exists',
+            extra: {},
+          },
+        };
       },
     });
 

--- a/static/app/views/onboarding/components/useScmRepoSelection.ts
+++ b/static/app/views/onboarding/components/useScmRepoSelection.ts
@@ -50,6 +50,33 @@ export function useScmRepoSelection({
   const queryClient = useQueryClient();
   const [busy, setBusy] = useState(false);
 
+  // Look up the repo in Sentry. The background link_all_repos task registers
+  // all repos after integration install, so most repos will already exist.
+  // The query param is an icontains filter to narrow results and avoid
+  // pagination; the exact match on Repository.name against
+  // IntegrationRepository.identifier mirrors the backend comparison in
+  // organization_integration_repos.py:61,80 used to determine isInstalled.
+  // Can't use externalSlug because it varies by provider (e.g. GitLab
+  // returns a numeric project ID).
+  const findExistingRepo = async (
+    identifier: string
+  ): Promise<Repository | undefined> => {
+    const reposQueryOptions = apiOptions.as<Repository[]>()(
+      '/organizations/$organizationIdOrSlug/repos/',
+      {
+        path: {organizationIdOrSlug: organization.slug},
+        query: {
+          status: 'active',
+          integration_id: integration.id,
+          query: identifier,
+        },
+        staleTime: 0,
+      }
+    );
+    const matches = (await queryClient.fetchQuery(reposQueryOptions)).json;
+    return matches?.find(r => r.name === identifier);
+  };
+
   const handleSelect = async (selection: {value: string}) => {
     const repo = reposByIdentifier.get(selection.value);
     if (!repo) {
@@ -59,36 +86,9 @@ export function useScmRepoSelection({
     const optimistic = buildOptimisticRepo(repo, integration);
     onSelect(optimistic);
 
-    // Look up the repo in Sentry. The background link_all_repos task
-    // registers all repos after integration install, so most repos will
-    // already exist. Use a targeted query filtered by name to avoid
-    // pagination issues with the full list.
-    const reposQueryOptions = apiOptions.as<Repository[]>()(
-      '/organizations/$organizationIdOrSlug/repos/',
-      {
-        path: {organizationIdOrSlug: organization.slug},
-        query: {
-          status: 'active',
-          integration_id: integration.id,
-          query: repo.identifier,
-        },
-        staleTime: 0,
-      }
-    );
-    // The query param above is an icontains filter to narrow results and
-    // avoid pagination. The exact match here uses Repository.name against
-    // IntegrationRepository.identifier — the same comparison the backend
-    // uses in organization_integration_repos.py:61,80 to determine
-    // isInstalled. Can't use externalSlug because it varies by provider
-    // (e.g. GitLab returns a numeric project ID).
-    const findExistingRepo = async () => {
-      const matches = (await queryClient.fetchQuery(reposQueryOptions)).json;
-      return matches?.find(r => r.name === repo.identifier);
-    };
-
     setBusy(true);
     try {
-      const existing = await findExistingRepo();
+      const existing = await findExistingRepo(repo.identifier);
       if (existing) {
         onSelect({...optimistic, ...existing});
         return;
@@ -115,7 +115,7 @@ export function useScmRepoSelection({
           typeof detail === 'object' &&
           detail?.code === 'repo_exists'
         ) {
-          const raced = await findExistingRepo();
+          const raced = await findExistingRepo(repo.identifier);
           if (raced) {
             onSelect({...optimistic, ...raced});
             return;

--- a/static/app/views/onboarding/components/useScmRepoSelection.ts
+++ b/static/app/views/onboarding/components/useScmRepoSelection.ts
@@ -12,6 +12,7 @@ import type {
 import {RepositoryStatus} from 'sentry/types/integrations';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {fetchMutation} from 'sentry/utils/queryClient';
+import {RequestError} from 'sentry/utils/requestError/requestError';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 interface UseScmRepoSelectionOptions {
@@ -62,45 +63,66 @@ export function useScmRepoSelection({
     // registers all repos after integration install, so most repos will
     // already exist. Use a targeted query filtered by name to avoid
     // pagination issues with the full list.
+    const reposQueryOptions = apiOptions.as<Repository[]>()(
+      '/organizations/$organizationIdOrSlug/repos/',
+      {
+        path: {organizationIdOrSlug: organization.slug},
+        query: {
+          status: 'active',
+          integration_id: integration.id,
+          query: repo.identifier,
+        },
+        staleTime: 0,
+      }
+    );
+    // The query param above is an icontains filter to narrow results and
+    // avoid pagination. The exact match here uses Repository.name against
+    // IntegrationRepository.identifier — the same comparison the backend
+    // uses in organization_integration_repos.py:61,80 to determine
+    // isInstalled. Can't use externalSlug because it varies by provider
+    // (e.g. GitLab returns a numeric project ID).
+    const findExistingRepo = async () => {
+      const matches = (await queryClient.fetchQuery(reposQueryOptions)).json;
+      return matches?.find(r => r.name === repo.identifier);
+    };
+
     setBusy(true);
     try {
-      const reposQueryOptions = apiOptions.as<Repository[]>()(
-        '/organizations/$organizationIdOrSlug/repos/',
-        {
-          path: {organizationIdOrSlug: organization.slug},
-          query: {
-            status: 'active',
-            integration_id: integration.id,
-            query: repo.identifier,
-          },
-          staleTime: 0,
-        }
-      );
-      const matches = (await queryClient.fetchQuery(reposQueryOptions)).json;
-      // The query param above is an icontains filter to narrow results
-      // and avoid pagination. The exact match here uses Repository.name
-      // against IntegrationRepository.identifier — the same comparison the
-      // backend uses in organization_integration_repos.py:61,80 to determine
-      // isInstalled. Can't use externalSlug because it varies by provider
-      // (e.g. GitLab returns a numeric project ID).
-      const existing = matches?.find(r => r.name === repo.identifier);
-
+      const existing = await findExistingRepo();
       if (existing) {
         onSelect({...optimistic, ...existing});
         return;
       }
 
-      // Repo not yet registered (link_all_repos may still be running).
-      const created = await fetchMutation<Repository>({
-        url: `/organizations/${organization.slug}/repos/`,
-        method: 'POST',
-        data: {
-          installation: integration.id,
-          identifier: repo.identifier,
-          provider: `integrations:${integration.provider.key}`,
-        },
-      });
-      onSelect({...optimistic, ...created});
+      try {
+        const created = await fetchMutation<Repository>({
+          url: `/organizations/${organization.slug}/repos/`,
+          method: 'POST',
+          data: {
+            installation: integration.id,
+            identifier: repo.identifier,
+            provider: `integrations:${integration.provider.key}`,
+          },
+        });
+        onSelect({...optimistic, ...created});
+      } catch (error) {
+        // Race with link_all_repos: the background task registered the repo
+        // between our GET and POST. Re-query to pick up the row it created.
+        const detail = error instanceof RequestError ? error.responseJSON?.detail : null;
+        if (
+          error instanceof RequestError &&
+          error.status === 400 &&
+          typeof detail === 'object' &&
+          detail?.code === 'repo_exists'
+        ) {
+          const raced = await findExistingRepo();
+          if (raced) {
+            onSelect({...optimistic, ...raced});
+            return;
+          }
+        }
+        throw error;
+      }
     } catch (error) {
       Sentry.captureException(error);
       addErrorMessage(t('Failed to select repository'));


### PR DESCRIPTION
## TL;DR

The SCM repo selection POST can race with the `link_all_repos` taskworker and fail with 400 `repo_exists`. Catch that specific response and re-query the GET to resolve the selection with the existing row instead of surfacing an error.

## Details

The flow does a GET filtered by integration and repo name to see if Sentry has already registered the repo, then POSTs to create it if the GET finds nothing. `link_all_repos` also registers repos after integration install, which opens a narrow race: the GET returns empty, the task lands, then the POST hits and the backend responds 400 `repo_exists`.

On that specific failure (`status === 400` and `detail.code === 'repo_exists'`), re-run the GET to pick up the row the task just created, then resolve the selection with the real id. Any other error (or a still-missing repo on retry) falls through to the existing revert-plus-toast handler.

## Repro

Only reliably reproducible in prod. Running sentry locally with taskworker enabled does not hit this path the same way because `link_all_repos` finishes before the user can select a repo, so the initial GET already has the row and the POST is never attempted. The race needs production-scale installation latency (many repos to enumerate) to open the window between the GET and the POST.

## Testing

No backend changes. Tests exercise the race by flipping a state flag inside the POST mock so the first GET sees `[]`, the POST transitions the simulated backend to "repo exists" and responds 400, and the retry GET picks up the registered repo.