### PR TITLE
fix(integrations): Return existing repo on concurrent create race

### DIFF
--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -191,21 +191,32 @@ class IntegrationRepositoryProvider(Generic[InstT]):
                 self.on_create_repository(new_repository, organization)
                 return result, new_repository
 
-            # A concurrent writer (e.g. link_all_repos) wrote the row before
-            # we could. Find an ACTIVE match without mutating it — the caller's
-            # intent was "create this repo"; the row already exists, so we
-            # simply surface it on the exception. Callers that want to treat
-            # the race as success (dispatch) can read existing_repo; callers
-            # that catch RepoExistsError to skip (the GitHub push webhook)
-            # keep their existing behavior.
+            # if possible update the repo with matching integration
             repositories = repository_service.get_repositories(
                 organization_id=organization.id,
                 integration_id=integration_id,
                 external_id=external_id,
-                status=ObjectStatus.ACTIVE,
             )
-            existing_repo = repositories[0] if repositories else None
-            raise RepoExistsError(repos=[result], existing_repo=existing_repo)
+            active_repo: RpcRepository | None = None
+            if repositories:
+                # We anticipate to only update one repository, but we update any duplicates as well.
+                for repo in repositories:
+                    for field_name, field_value in repo_update_params.items():
+                        setattr(repo, field_name, field_value)
+                    repository_service.update_repository(
+                        organization_id=organization.id,
+                        update=repo,
+                    )
+                    if active_repo is None and repo.status == ObjectStatus.ACTIVE:
+                        active_repo = repo
+
+            # Concurrent writer (e.g. link_all_repos) already created the row.
+            # Surface the active match on the exception so callers that want to
+            # treat the race as success (dispatch) can, while callers that
+            # prefer the historical "skip and try again" behavior (the GitHub
+            # push webhook) stay unaffected by catching RepoExistsError as
+            # before.
+            raise RepoExistsError(repos=[result], existing_repo=active_repo)
 
         return result, repo
 

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -186,17 +186,7 @@ class IntegrationRepositoryProvider(Generic[InstT]):
                 self.on_create_repository(new_repository, organization)
                 return result, new_repository
 
-            # Create failed, typically a unique-constraint violation. Something
-            # else wrote the row first: the link_all_repos background task
-            # after integration install, or a concurrent client. If we find an
-            # active existing repo, update it and treat this as a successful
-            # reclaim; if the existing repo is in a non-active state (e.g.
-            # PENDING_DELETION), fall through to RepoExistsError.
-            #
-            # Intentionally skip on_create_repository in the reclaim path: the
-            # existing row was set up by whoever wrote it, and provider hooks
-            # are not uniformly idempotent (bitbucket_server re-creates its
-            # webhook, bitbucket does not persist webhook_id).
+            # if possible update the repo with matching integration
             repositories = repository_service.get_repositories(
                 organization_id=organization.id,
                 integration_id=integration_id,
@@ -215,6 +205,11 @@ class IntegrationRepositoryProvider(Generic[InstT]):
                     if active_repo is None and repo.status == ObjectStatus.ACTIVE:
                         active_repo = repo
 
+            # Concurrent writer (e.g. link_all_repos) already created the row;
+            # return it as a successful reclaim instead of raising. Skip
+            # on_create_repository — the winning writer already ran it and
+            # provider hooks aren't uniformly idempotent (bitbucket_server
+            # duplicates its webhook).
             if active_repo is not None:
                 return result, active_repo
 

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -48,7 +48,7 @@ class RepoExistsError(SentryAPIException):
         message: str | None = None,
         detail: Any = None,
         repos: list[RepositoryConfig] | None = None,
-        reclaimed_repo: RpcRepository | None = None,
+        existing_repo: RpcRepository | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(code=code, message=message, detail=detail, **kwargs)
@@ -56,7 +56,7 @@ class RepoExistsError(SentryAPIException):
         # Populated when create_repository found an existing ACTIVE row matching
         # the config. Callers that can treat the race as a success (e.g. the
         # REST dispatch) should check this before surfacing the 400.
-        self.reclaimed_repo = reclaimed_repo
+        self.existing_repo = existing_repo
 
     def __str__(self) -> str:
         if self.repos:
@@ -216,7 +216,7 @@ class IntegrationRepositoryProvider(Generic[InstT]):
             # prefer the historical "skip and try again" behavior (the GitHub
             # push webhook) stay unaffected by catching RepoExistsError as
             # before.
-            raise RepoExistsError(repos=[result], reclaimed_repo=active_repo)
+            raise RepoExistsError(repos=[result], existing_repo=active_repo)
 
         return result, repo
 
@@ -323,11 +323,12 @@ class IntegrationRepositoryProvider(Generic[InstT]):
             result, repo = self.create_repository(repo_config=config, organization=organization)
         except RepoExistsError as exc:
             metrics.incr("sentry.integration_repo_provider.repo_exists")
-            if exc.reclaimed_repo is None or not exc.repos:
+            if exc.existing_repo is None or not exc.repos:
                 raise
-            # Reclaim the row a concurrent writer created. Falls through to
-            # the normal success path so repo_linked/analytics still fire.
-            repo = exc.reclaimed_repo
+            # A concurrent writer created the row before we could; return it
+            # as if our create had succeeded so repo_linked/analytics still
+            # fire from the normal success path.
+            repo = exc.existing_repo
             result = exc.repos[0]
         except Exception as e:
             return self.handle_api_error(e)

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -192,6 +192,11 @@ class IntegrationRepositoryProvider(Generic[InstT]):
             # active existing repo, update it and treat this as a successful
             # reclaim; if the existing repo is in a non-active state (e.g.
             # PENDING_DELETION), fall through to RepoExistsError.
+            #
+            # Intentionally skip on_create_repository in the reclaim path: the
+            # existing row was set up by whoever wrote it, and provider hooks
+            # are not uniformly idempotent (bitbucket_server re-creates its
+            # webhook, bitbucket does not persist webhook_id).
             repositories = repository_service.get_repositories(
                 organization_id=organization.id,
                 integration_id=integration_id,
@@ -211,7 +216,6 @@ class IntegrationRepositoryProvider(Generic[InstT]):
                         active_repo = repo
 
             if active_repo is not None:
-                self.on_create_repository(active_repo, organization)
                 metrics.incr("sentry.integration_repo_provider.repo_exists_reclaimed")
                 return result, active_repo
 

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -186,12 +186,18 @@ class IntegrationRepositoryProvider(Generic[InstT]):
                 self.on_create_repository(new_repository, organization)
                 return result, new_repository
 
-            # if possible update the repo with matching integration
+            # Create failed, typically a unique-constraint violation. Something
+            # else wrote the row first: the link_all_repos background task
+            # after integration install, or a concurrent client. If we find an
+            # active existing repo, update it and treat this as a successful
+            # reclaim; if the existing repo is in a non-active state (e.g.
+            # PENDING_DELETION), fall through to RepoExistsError.
             repositories = repository_service.get_repositories(
                 organization_id=organization.id,
                 integration_id=integration_id,
                 external_id=external_id,
             )
+            active_repo: RpcRepository | None = None
             if repositories:
                 # We anticipate to only update one repository, but we update any duplicates as well.
                 for repo in repositories:
@@ -201,6 +207,13 @@ class IntegrationRepositoryProvider(Generic[InstT]):
                         organization_id=organization.id,
                         update=repo,
                     )
+                    if active_repo is None and repo.status == ObjectStatus.ACTIVE:
+                        active_repo = repo
+
+            if active_repo is not None:
+                self.on_create_repository(active_repo, organization)
+                metrics.incr("sentry.integration_repo_provider.repo_exists_reclaimed")
+                return result, active_repo
 
             raise RepoExistsError(repos=[result])
 

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -216,7 +216,6 @@ class IntegrationRepositoryProvider(Generic[InstT]):
                         active_repo = repo
 
             if active_repo is not None:
-                metrics.incr("sentry.integration_repo_provider.repo_exists_reclaimed")
                 return result, active_repo
 
             raise RepoExistsError(repos=[result])

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -48,10 +48,15 @@ class RepoExistsError(SentryAPIException):
         message: str | None = None,
         detail: Any = None,
         repos: list[RepositoryConfig] | None = None,
+        reclaimed_repo: RpcRepository | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(code=code, message=message, detail=detail, **kwargs)
         self.repos = repos
+        # Populated when create_repository found an existing ACTIVE row matching
+        # the config. Callers that can treat the race as a success (e.g. the
+        # REST dispatch) should check this before surfacing the 400.
+        self.reclaimed_repo = reclaimed_repo
 
     def __str__(self) -> str:
         if self.repos:
@@ -205,15 +210,13 @@ class IntegrationRepositoryProvider(Generic[InstT]):
                     if active_repo is None and repo.status == ObjectStatus.ACTIVE:
                         active_repo = repo
 
-            # Concurrent writer (e.g. link_all_repos) already created the row;
-            # return it as a successful reclaim instead of raising. Skip
-            # on_create_repository — the winning writer already ran it and
-            # provider hooks aren't uniformly idempotent (bitbucket_server
-            # duplicates its webhook).
-            if active_repo is not None:
-                return result, active_repo
-
-            raise RepoExistsError(repos=[result])
+            # Concurrent writer (e.g. link_all_repos) already created the row.
+            # Surface the active match on the exception so callers that want to
+            # treat the race as success (dispatch) can, while callers that
+            # prefer the historical "skip and try again" behavior (the GitHub
+            # push webhook) stay unaffected by catching RepoExistsError as
+            # before.
+            raise RepoExistsError(repos=[result], reclaimed_repo=active_repo)
 
         return result, repo
 
@@ -318,9 +321,14 @@ class IntegrationRepositoryProvider(Generic[InstT]):
 
         try:
             result, repo = self.create_repository(repo_config=config, organization=organization)
-        except RepoExistsError:
+        except RepoExistsError as exc:
             metrics.incr("sentry.integration_repo_provider.repo_exists")
-            raise
+            if exc.reclaimed_repo is None or not exc.repos:
+                raise
+            # Reclaim the row a concurrent writer created. Falls through to
+            # the normal success path so repo_linked/analytics still fire.
+            repo = exc.reclaimed_repo
+            result = exc.repos[0]
         except Exception as e:
             return self.handle_api_error(e)
 

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -191,32 +191,21 @@ class IntegrationRepositoryProvider(Generic[InstT]):
                 self.on_create_repository(new_repository, organization)
                 return result, new_repository
 
-            # if possible update the repo with matching integration
+            # A concurrent writer (e.g. link_all_repos) wrote the row before
+            # we could. Find an ACTIVE match without mutating it — the caller's
+            # intent was "create this repo"; the row already exists, so we
+            # simply surface it on the exception. Callers that want to treat
+            # the race as success (dispatch) can read existing_repo; callers
+            # that catch RepoExistsError to skip (the GitHub push webhook)
+            # keep their existing behavior.
             repositories = repository_service.get_repositories(
                 organization_id=organization.id,
                 integration_id=integration_id,
                 external_id=external_id,
+                status=ObjectStatus.ACTIVE,
             )
-            active_repo: RpcRepository | None = None
-            if repositories:
-                # We anticipate to only update one repository, but we update any duplicates as well.
-                for repo in repositories:
-                    for field_name, field_value in repo_update_params.items():
-                        setattr(repo, field_name, field_value)
-                    repository_service.update_repository(
-                        organization_id=organization.id,
-                        update=repo,
-                    )
-                    if active_repo is None and repo.status == ObjectStatus.ACTIVE:
-                        active_repo = repo
-
-            # Concurrent writer (e.g. link_all_repos) already created the row.
-            # Surface the active match on the exception so callers that want to
-            # treat the race as success (dispatch) can, while callers that
-            # prefer the historical "skip and try again" behavior (the GitHub
-            # push webhook) stay unaffected by catching RepoExistsError as
-            # before.
-            raise RepoExistsError(repos=[result], existing_repo=active_repo)
+            existing_repo = repositories[0] if repositories else None
+            raise RepoExistsError(repos=[result], existing_repo=existing_repo)
 
         return result, repo
 

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -186,27 +186,32 @@ class IntegrationRepositoryProvider(Generic[InstT]):
                 self.on_create_repository(new_repository, organization)
                 return result, new_repository
 
-            # Concurrent writer (e.g. link_all_repos) already created the row;
-            # reclaim it instead of raising. Skip on_create_repository — the
-            # winning writer already ran it, and provider hooks aren't
-            # uniformly idempotent (bitbucket_server duplicates its webhook).
-            # Non-ACTIVE matches (e.g. PENDING_DELETION) fall through to
-            # RepoExistsError so a repo on its way out isn't resurrected.
-            existing = repository_service.get_repositories(
+            # if possible update the repo with matching integration
+            repositories = repository_service.get_repositories(
                 organization_id=organization.id,
                 integration_id=integration_id,
                 external_id=external_id,
-                status=ObjectStatus.ACTIVE,
             )
-            if existing:
-                reclaimed = existing[0]
-                for field_name, field_value in repo_update_params.items():
-                    setattr(reclaimed, field_name, field_value)
-                repository_service.update_repository(
-                    organization_id=organization.id,
-                    update=reclaimed,
-                )
-                return result, reclaimed
+            active_repo: RpcRepository | None = None
+            if repositories:
+                # We anticipate to only update one repository, but we update any duplicates as well.
+                for repo in repositories:
+                    for field_name, field_value in repo_update_params.items():
+                        setattr(repo, field_name, field_value)
+                    repository_service.update_repository(
+                        organization_id=organization.id,
+                        update=repo,
+                    )
+                    if active_repo is None and repo.status == ObjectStatus.ACTIVE:
+                        active_repo = repo
+
+            # Concurrent writer (e.g. link_all_repos) already created the row;
+            # return it as a successful reclaim instead of raising. Skip
+            # on_create_repository — the winning writer already ran it and
+            # provider hooks aren't uniformly idempotent (bitbucket_server
+            # duplicates its webhook).
+            if active_repo is not None:
+                return result, active_repo
 
             raise RepoExistsError(repos=[result])
 

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -186,32 +186,27 @@ class IntegrationRepositoryProvider(Generic[InstT]):
                 self.on_create_repository(new_repository, organization)
                 return result, new_repository
 
-            # if possible update the repo with matching integration
-            repositories = repository_service.get_repositories(
+            # Concurrent writer (e.g. link_all_repos) already created the row;
+            # reclaim it instead of raising. Skip on_create_repository — the
+            # winning writer already ran it, and provider hooks aren't
+            # uniformly idempotent (bitbucket_server duplicates its webhook).
+            # Non-ACTIVE matches (e.g. PENDING_DELETION) fall through to
+            # RepoExistsError so a repo on its way out isn't resurrected.
+            existing = repository_service.get_repositories(
                 organization_id=organization.id,
                 integration_id=integration_id,
                 external_id=external_id,
+                status=ObjectStatus.ACTIVE,
             )
-            active_repo: RpcRepository | None = None
-            if repositories:
-                # We anticipate to only update one repository, but we update any duplicates as well.
-                for repo in repositories:
-                    for field_name, field_value in repo_update_params.items():
-                        setattr(repo, field_name, field_value)
-                    repository_service.update_repository(
-                        organization_id=organization.id,
-                        update=repo,
-                    )
-                    if active_repo is None and repo.status == ObjectStatus.ACTIVE:
-                        active_repo = repo
-
-            # Concurrent writer (e.g. link_all_repos) already created the row;
-            # return it as a successful reclaim instead of raising. Skip
-            # on_create_repository — the winning writer already ran it and
-            # provider hooks aren't uniformly idempotent (bitbucket_server
-            # duplicates its webhook).
-            if active_repo is not None:
-                return result, active_repo
+            if existing:
+                reclaimed = existing[0]
+                for field_name, field_value in repo_update_params.items():
+                    setattr(reclaimed, field_name, field_value)
+                repository_service.update_repository(
+                    organization_id=organization.id,
+                    update=reclaimed,
+                )
+                return result, reclaimed
 
             raise RepoExistsError(repos=[result])
 

--- a/tests/sentry/integrations/api/endpoints/test_organization_repositories.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_repositories.py
@@ -475,10 +475,10 @@ class OrganizationIntegrationRepositoriesCreateTest(APITestCase):
     @patch.object(
         ExampleRepositoryProvider, "get_repository_data", return_value={"my_config_key": "some_var"}
     )
-    def test_existing_repo_reclaims_on_race(self, mock_build_repository_config: MagicMock) -> None:
+    def test_existing_repo_race_returns_201(self, mock_build_repository_config: MagicMock) -> None:
         # Simulates a concurrent writer (e.g. link_all_repos) having already
         # inserted the row: matching provider/external_id AND integration_id.
-        # Dispatch should surface this as a 201 reclaim rather than a 400.
+        # Dispatch should return the existing row as 201 rather than 400.
         existing = Repository.objects.create(
             organization_id=self.org.id,
             name="getsentry/sentry",

--- a/tests/sentry/integrations/api/endpoints/test_organization_repositories.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_repositories.py
@@ -471,3 +471,31 @@ class OrganizationIntegrationRepositoriesCreateTest(APITestCase):
             response.content
             == b'{"detail":{"code":"repo_exists","message":"A repository with that configuration already exists","extra":{}}}'
         )
+
+    @patch.object(
+        ExampleRepositoryProvider, "get_repository_data", return_value={"my_config_key": "some_var"}
+    )
+    def test_existing_repo_reclaims_on_race(self, mock_build_repository_config: MagicMock) -> None:
+        # Simulates a concurrent writer (e.g. link_all_repos) having already
+        # inserted the row: matching provider/external_id AND integration_id.
+        # Dispatch should surface this as a 201 reclaim rather than a 400.
+        existing = Repository.objects.create(
+            organization_id=self.org.id,
+            name="getsentry/sentry",
+            status=0,
+            external_id="my_external_id",
+            integration_id=self.integration.id,
+            provider="integrations:example",
+            url="https://github.com/getsentry/sentry",
+        )
+
+        with patch.object(
+            ExampleRepositoryProvider, "build_repository_config", return_value=self.repo_config_data
+        ):
+            response = self.client.post(
+                self.url, data={"provider": "integrations:example", "name": "getsentry/sentry"}
+            )
+
+        assert response.status_code == 201, (response.status_code, response.content)
+        assert response.data["id"] == str(existing.id)
+        assert Repository.objects.count() == 1

--- a/tests/sentry/plugins/test_integration_repository.py
+++ b/tests/sentry/plugins/test_integration_repository.py
@@ -71,9 +71,11 @@ class IntegrationRepositoryTestCase(TestCase):
     def test_create_repository__repo_exists(self, get_jwt: MagicMock) -> None:
         existing = self._create_repo(external_id=self.config["external_id"])
 
-        _, repo = self.provider.create_repository(self.config, self.organization)
+        with pytest.raises(RepoExistsError) as exc_info:
+            self.provider.create_repository(self.config, self.organization)
 
-        assert repo.id == existing.id
+        assert exc_info.value.reclaimed_repo is not None
+        assert exc_info.value.reclaimed_repo.id == existing.id
         assert Repository.objects.count() == 1
 
     def test_create_repository__transfer_repo_in_org(self, get_jwt: MagicMock) -> None:
@@ -96,20 +98,29 @@ class IntegrationRepositoryTestCase(TestCase):
     def test_create_repository__repo_exists_update_name(self, get_jwt: MagicMock) -> None:
         repo = self._create_repo(external_id=self.config["external_id"], name="getsentry/santry")
 
-        _, returned = self.provider.create_repository(self.config, self.organization)
+        with pytest.raises(RepoExistsError) as exc_info:
+            self.provider.create_repository(self.config, self.organization)
 
-        assert returned.id == repo.id
+        reclaimed = exc_info.value.reclaimed_repo
+        assert reclaimed is not None
+        assert reclaimed.id == repo.id
+        assert reclaimed.name == self.repo_name
         repo.refresh_from_db()
         assert repo.name == self.repo_name
-        assert returned.name == self.repo_name
 
-    def test_create_repository__integrity_error_reclaims_existing(self, get_jwt: MagicMock) -> None:
+    def test_create_repository__integrity_error_attaches_reclaimed(
+        self, get_jwt: MagicMock
+    ) -> None:
         existing = self._create_repo(external_id=self.config["external_id"])
 
-        with patch("sentry.models.Repository.objects.create", side_effect=IntegrityError):
-            _, repo = self.provider.create_repository(self.config, self.organization)
+        with (
+            patch("sentry.models.Repository.objects.create", side_effect=IntegrityError),
+            pytest.raises(RepoExistsError) as exc_info,
+        ):
+            self.provider.create_repository(self.config, self.organization)
 
-        assert repo.id == existing.id
+        assert exc_info.value.reclaimed_repo is not None
+        assert exc_info.value.reclaimed_repo.id == existing.id
 
     @patch("sentry.plugins.providers.integration_repository.metrics")
     def test_create_repository__activates_existing_hidden_repo(
@@ -129,8 +140,9 @@ class IntegrationRepositoryTestCase(TestCase):
         repo.status = ObjectStatus.PENDING_DELETION
         repo.save()
 
-        with pytest.raises(RepoExistsError):
+        with pytest.raises(RepoExistsError) as exc_info:
             self.provider.create_repository(self.config, self.organization)
 
+        assert exc_info.value.reclaimed_repo is None
         repo.refresh_from_db()
         assert repo.status == ObjectStatus.PENDING_DELETION

--- a/tests/sentry/plugins/test_integration_repository.py
+++ b/tests/sentry/plugins/test_integration_repository.py
@@ -96,7 +96,10 @@ class IntegrationRepositoryTestCase(TestCase):
         assert repo.name == self.config["identifier"]
         assert repo.url == self.config["url"]
 
-    def test_create_repository__repo_exists_update_name(self, get_jwt: MagicMock) -> None:
+    def test_create_repository__repo_exists_does_not_rename(self, get_jwt: MagicMock) -> None:
+        # The race path no longer mutates the existing row. Intent of a
+        # create POST is "make sure this repo exists" — a rename-sync would be
+        # a different operation.
         repo = self._create_repo(external_id=self.config["external_id"], name="getsentry/santry")
 
         with pytest.raises(RepoExistsError) as exc_info:
@@ -105,9 +108,9 @@ class IntegrationRepositoryTestCase(TestCase):
         existing = exc_info.value.existing_repo
         assert existing is not None
         assert existing.id == repo.id
-        assert existing.name == self.repo_name
+        assert existing.name == "getsentry/santry"
         repo.refresh_from_db()
-        assert repo.name == self.repo_name
+        assert repo.name == "getsentry/santry"
 
     @patch("sentry.models.Repository.objects.create")
     @patch("sentry.plugins.providers.IntegrationRepositoryProvider.on_delete_repository")

--- a/tests/sentry/plugins/test_integration_repository.py
+++ b/tests/sentry/plugins/test_integration_repository.py
@@ -75,8 +75,8 @@ class IntegrationRepositoryTestCase(TestCase):
         with pytest.raises(RepoExistsError) as exc_info:
             self.provider.create_repository(self.config, self.organization)
 
-        assert exc_info.value.reclaimed_repo is not None
-        assert exc_info.value.reclaimed_repo.id == existing.id
+        assert exc_info.value.existing_repo is not None
+        assert exc_info.value.existing_repo.id == existing.id
         assert Repository.objects.count() == 1
 
     def test_create_repository__transfer_repo_in_org(self, get_jwt: MagicMock) -> None:
@@ -102,10 +102,10 @@ class IntegrationRepositoryTestCase(TestCase):
         with pytest.raises(RepoExistsError) as exc_info:
             self.provider.create_repository(self.config, self.organization)
 
-        reclaimed = exc_info.value.reclaimed_repo
-        assert reclaimed is not None
-        assert reclaimed.id == repo.id
-        assert reclaimed.name == self.repo_name
+        existing = exc_info.value.existing_repo
+        assert existing is not None
+        assert existing.id == repo.id
+        assert existing.name == self.repo_name
         repo.refresh_from_db()
         assert repo.name == self.repo_name
 
@@ -123,13 +123,11 @@ class IntegrationRepositoryTestCase(TestCase):
             self.provider.create_repository(self.config, self.organization)
 
         # Pre-existing repo is under the default external_id=123456, not the
-        # config's 654321 — the reclaim query misses, so the race fallback
-        # has nothing to surface.
-        assert exc_info.value.reclaimed_repo is None
+        # config's 654321 — the lookup by (integration_id, external_id) misses,
+        # so the race fallback has nothing to surface.
+        assert exc_info.value.existing_repo is None
 
-    def test_create_repository__integrity_error_attaches_reclaimed(
-        self, get_jwt: MagicMock
-    ) -> None:
+    def test_create_repository__integrity_error_attaches_existing(self, get_jwt: MagicMock) -> None:
         existing = self._create_repo(external_id=self.config["external_id"])
 
         with (
@@ -138,8 +136,8 @@ class IntegrationRepositoryTestCase(TestCase):
         ):
             self.provider.create_repository(self.config, self.organization)
 
-        assert exc_info.value.reclaimed_repo is not None
-        assert exc_info.value.reclaimed_repo.id == existing.id
+        assert exc_info.value.existing_repo is not None
+        assert exc_info.value.existing_repo.id == existing.id
 
     @patch("sentry.plugins.providers.integration_repository.metrics")
     def test_create_repository__activates_existing_hidden_repo(
@@ -162,6 +160,6 @@ class IntegrationRepositoryTestCase(TestCase):
         with pytest.raises(RepoExistsError) as exc_info:
             self.provider.create_repository(self.config, self.organization)
 
-        assert exc_info.value.reclaimed_repo is None
+        assert exc_info.value.existing_repo is None
         repo.refresh_from_db()
         assert repo.status == ObjectStatus.PENDING_DELETION

--- a/tests/sentry/plugins/test_integration_repository.py
+++ b/tests/sentry/plugins/test_integration_repository.py
@@ -9,6 +9,7 @@ from sentry.constants import ObjectStatus
 from sentry.integrations.github.repository import GitHubRepositoryProvider
 from sentry.models.repository import Repository
 from sentry.plugins.providers.integration_repository import RepoExistsError
+from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.testutils.cases import TestCase
 
 
@@ -108,20 +109,22 @@ class IntegrationRepositoryTestCase(TestCase):
         repo.refresh_from_db()
         assert repo.name == self.repo_name
 
-    def test_create_repository__integrity_error_without_match_raises(
-        self, get_jwt: MagicMock
+    @patch("sentry.models.Repository.objects.create")
+    @patch("sentry.plugins.providers.IntegrationRepositoryProvider.on_delete_repository")
+    def test_create_repository__delete_webhook(
+        self, mock_on_delete: MagicMock, mock_repo: MagicMock, get_jwt: MagicMock
     ) -> None:
-        # Pre-existing repo under a different external_id — the reclaim query
-        # (matching integration_id + config's external_id) won't find it, so
-        # the race fallback has nothing to surface.
         self._create_repo()
 
-        with (
-            patch("sentry.models.Repository.objects.create", side_effect=IntegrityError),
-            pytest.raises(RepoExistsError) as exc_info,
-        ):
+        mock_repo.side_effect = IntegrityError
+        mock_on_delete.side_effect = IntegrationError
+
+        with pytest.raises(RepoExistsError) as exc_info:
             self.provider.create_repository(self.config, self.organization)
 
+        # Pre-existing repo is under the default external_id=123456, not the
+        # config's 654321 — the reclaim query misses, so the race fallback
+        # has nothing to surface.
         assert exc_info.value.reclaimed_repo is None
 
     def test_create_repository__integrity_error_attaches_reclaimed(

--- a/tests/sentry/plugins/test_integration_repository.py
+++ b/tests/sentry/plugins/test_integration_repository.py
@@ -108,20 +108,6 @@ class IntegrationRepositoryTestCase(TestCase):
         repo.refresh_from_db()
         assert repo.name == self.repo_name
 
-    def test_create_repository__integrity_error_attaches_reclaimed(
-        self, get_jwt: MagicMock
-    ) -> None:
-        existing = self._create_repo(external_id=self.config["external_id"])
-
-        with (
-            patch("sentry.models.Repository.objects.create", side_effect=IntegrityError),
-            pytest.raises(RepoExistsError) as exc_info,
-        ):
-            self.provider.create_repository(self.config, self.organization)
-
-        assert exc_info.value.reclaimed_repo is not None
-        assert exc_info.value.reclaimed_repo.id == existing.id
-
     def test_create_repository__integrity_error_without_match_raises(
         self, get_jwt: MagicMock
     ) -> None:
@@ -137,6 +123,20 @@ class IntegrationRepositoryTestCase(TestCase):
             self.provider.create_repository(self.config, self.organization)
 
         assert exc_info.value.reclaimed_repo is None
+
+    def test_create_repository__integrity_error_attaches_reclaimed(
+        self, get_jwt: MagicMock
+    ) -> None:
+        existing = self._create_repo(external_id=self.config["external_id"])
+
+        with (
+            patch("sentry.models.Repository.objects.create", side_effect=IntegrityError),
+            pytest.raises(RepoExistsError) as exc_info,
+        ):
+            self.provider.create_repository(self.config, self.organization)
+
+        assert exc_info.value.reclaimed_repo is not None
+        assert exc_info.value.reclaimed_repo.id == existing.id
 
     @patch("sentry.plugins.providers.integration_repository.metrics")
     def test_create_repository__activates_existing_hidden_repo(

--- a/tests/sentry/plugins/test_integration_repository.py
+++ b/tests/sentry/plugins/test_integration_repository.py
@@ -122,6 +122,22 @@ class IntegrationRepositoryTestCase(TestCase):
         assert exc_info.value.reclaimed_repo is not None
         assert exc_info.value.reclaimed_repo.id == existing.id
 
+    def test_create_repository__integrity_error_without_match_raises(
+        self, get_jwt: MagicMock
+    ) -> None:
+        # Pre-existing repo under a different external_id — the reclaim query
+        # (matching integration_id + config's external_id) won't find it, so
+        # the race fallback has nothing to surface.
+        self._create_repo()
+
+        with (
+            patch("sentry.models.Repository.objects.create", side_effect=IntegrityError),
+            pytest.raises(RepoExistsError) as exc_info,
+        ):
+            self.provider.create_repository(self.config, self.organization)
+
+        assert exc_info.value.reclaimed_repo is None
+
     @patch("sentry.plugins.providers.integration_repository.metrics")
     def test_create_repository__activates_existing_hidden_repo(
         self, mock_metrics: MagicMock, get_jwt: MagicMock

--- a/tests/sentry/plugins/test_integration_repository.py
+++ b/tests/sentry/plugins/test_integration_repository.py
@@ -96,10 +96,7 @@ class IntegrationRepositoryTestCase(TestCase):
         assert repo.name == self.config["identifier"]
         assert repo.url == self.config["url"]
 
-    def test_create_repository__repo_exists_does_not_rename(self, get_jwt: MagicMock) -> None:
-        # The race path no longer mutates the existing row. Intent of a
-        # create POST is "make sure this repo exists" — a rename-sync would be
-        # a different operation.
+    def test_create_repository__repo_exists_update_name(self, get_jwt: MagicMock) -> None:
         repo = self._create_repo(external_id=self.config["external_id"], name="getsentry/santry")
 
         with pytest.raises(RepoExistsError) as exc_info:
@@ -108,9 +105,9 @@ class IntegrationRepositoryTestCase(TestCase):
         existing = exc_info.value.existing_repo
         assert existing is not None
         assert existing.id == repo.id
-        assert existing.name == "getsentry/santry"
+        assert existing.name == self.repo_name
         repo.refresh_from_db()
-        assert repo.name == "getsentry/santry"
+        assert repo.name == self.repo_name
 
     @patch("sentry.models.Repository.objects.create")
     @patch("sentry.plugins.providers.IntegrationRepositoryProvider.on_delete_repository")

--- a/tests/sentry/plugins/test_integration_repository.py
+++ b/tests/sentry/plugins/test_integration_repository.py
@@ -9,7 +9,6 @@ from sentry.constants import ObjectStatus
 from sentry.integrations.github.repository import GitHubRepositoryProvider
 from sentry.models.repository import Repository
 from sentry.plugins.providers.integration_repository import RepoExistsError
-from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.testutils.cases import TestCase
 
 
@@ -70,10 +69,12 @@ class IntegrationRepositoryTestCase(TestCase):
         assert repos[0].provider == "integrations:github"
 
     def test_create_repository__repo_exists(self, get_jwt: MagicMock) -> None:
-        self._create_repo(external_id=self.config["external_id"])
+        existing = self._create_repo(external_id=self.config["external_id"])
 
-        with pytest.raises(RepoExistsError):
-            self.provider.create_repository(self.config, self.organization)
+        _, repo = self.provider.create_repository(self.config, self.organization)
+
+        assert repo.id == existing.id
+        assert Repository.objects.count() == 1
 
     def test_create_repository__transfer_repo_in_org(self, get_jwt: MagicMock) -> None:
         # can transfer a disabled repo from one integration to another in a single org
@@ -95,24 +96,20 @@ class IntegrationRepositoryTestCase(TestCase):
     def test_create_repository__repo_exists_update_name(self, get_jwt: MagicMock) -> None:
         repo = self._create_repo(external_id=self.config["external_id"], name="getsentry/santry")
 
-        with pytest.raises(RepoExistsError):
-            self.provider.create_repository(self.config, self.organization)
+        _, returned = self.provider.create_repository(self.config, self.organization)
 
+        assert returned.id == repo.id
         repo.refresh_from_db()
         assert repo.name == self.repo_name
+        assert returned.name == self.repo_name
 
-    @patch("sentry.models.Repository.objects.create")
-    @patch("sentry.plugins.providers.IntegrationRepositoryProvider.on_delete_repository")
-    def test_create_repository__delete_webhook(
-        self, mock_on_delete: MagicMock, mock_repo: MagicMock, get_jwt: MagicMock
-    ) -> None:
-        self._create_repo()
+    def test_create_repository__integrity_error_reclaims_existing(self, get_jwt: MagicMock) -> None:
+        existing = self._create_repo(external_id=self.config["external_id"])
 
-        mock_repo.side_effect = IntegrityError
-        mock_on_delete.side_effect = IntegrationError
+        with patch("sentry.models.Repository.objects.create", side_effect=IntegrityError):
+            _, repo = self.provider.create_repository(self.config, self.organization)
 
-        with pytest.raises(RepoExistsError):
-            self.provider.create_repository(self.config, self.organization)
+        assert repo.id == existing.id
 
     @patch("sentry.plugins.providers.integration_repository.metrics")
     def test_create_repository__activates_existing_hidden_repo(


### PR DESCRIPTION
## TL;DR

`POST /organizations/:slug/repos/` now returns the existing row as a 201 when a concurrent writer (typically the `link_all_repos` background task) inserted the same row first, instead of surfacing a 400 `repo_exists`. Behavior change is scoped to the REST dispatch path; other callers of `create_repository` (notably the GitHub push webhook) still see `RepoExistsError` exactly as before. No changes to the pre-existing mutation-on-race behavior other callers/tests rely on.

## Why

`Repository` has a unique constraint on `(organization_id, provider, external_id)`. When `IntegrationRepositoryProvider.create_repository` races with `link_all_repos` or another concurrent client, `repository_service.create_repository` returns `None` from an `IntegrityError`. The provider re-queries by `(integration_id, external_id)`, updates the match in place, and raises `RepoExistsError` — producing a 400 even though the row the caller wanted already exists.

The SCM onboarding flow (`static/app/views/onboarding/components/useScmRepoSelection.ts`) hits this in prod for users on the onboarding feature flag: the initial GET returns empty, the task lands, the POST 400s, and the user gets "Failed to select repository".

## Change

- Add `existing_repo: RpcRepository | None` to `RepoExistsError`. Populated when `create_repository` finds an `ObjectStatus.ACTIVE` row matching the config, left `None` otherwise (e.g. `PENDING_DELETION` surfaces the error cleanly).
- `create_repository`'s race branch is otherwise untouched: the pre-existing query + in-place update loop runs exactly as before, so any existing caller that relied on the mutation (e.g. renamed-repo name sync) keeps working. Only the raise is enriched with `existing_repo`.
- `dispatch` catches `RepoExistsError`, still bumps `sentry.integration_repo_provider.repo_exists`, and if `existing_repo` is populated, treats it as success: assigns `repo` and `result` from the exception and falls through to the normal 201 path (so `repo_linked`, `IntegrationRepoAddedEvent`, and `serialize_repository` all fire as if the create had succeeded).
- Other `create_repository` callers (the GitHub push webhook at `src/sentry/integrations/github/webhook.py:248`) catch `RepoExistsError` as before and are not affected.
- Intentionally do **not** re-run `on_create_repository` on the existing-row path. Provider hooks are not uniformly idempotent (bitbucket_server re-creates its webhook; bitbucket guards on `webhook_id` but never persists it). The winning writer already ran setup.

## Rollout

Frontend race handling in `useScmRepoSelection.ts` (PR #113811) is still safe to keep short-term; once this lands and rolls out, the FE code can drop the `repo_exists` recovery path in a follow-up PR, since the backend will no longer surface that 400 for the race case. FE/BE are deployed independently, so order matters: BE first.

## Known Pre-existing Issue (out of scope)

The race branch at `integration_repository.py:203-209` does a plain `setattr(repo, "config", config_updates)`, clobbering `config` wholesale. The sibling floating-repo branch at line 175 does `repo.config = {**repo.config, **config_updates}` — a merge with a comment calling out why ("preserve keys like webhook_id"). For GitLab/Bitbucket/Bitbucket-Server this silently drops `webhook_id` persisted by `on_create_repository`, orphaning the provider-side hook on later delete. GitHub (the only provider with `link_all_repos`) is unaffected because its `on_create_repository` is a no-op. Worth filing separately — not touched here to keep this PR scoped.

## Testing

`tests/sentry/plugins/test_integration_repository.py`:
- `test_create_repository__repo_exists` asserts the raised `RepoExistsError` carries the existing row.
- `test_create_repository__repo_exists_update_name` keeps its pre-existing assertion that the stored `name` is rewritten on race, and adds a check that the updated row is accessible via `exc.existing_repo`.
- `test_create_repository__delete_webhook` kept verbatim (original defensive `on_delete_repository` canary still in place) with an added assertion that `existing_repo is None` when the lookup misses.
- `test_create_repository__integrity_error_attaches_existing` pins the `IntegrityError`-on-create path where the existing row is an ACTIVE match.
- `test_create_repository__only_activates_hidden_repo` asserts `existing_repo is None` so `PENDING_DELETION` still surfaces as a plain 400.

`tests/sentry/integrations/api/endpoints/test_organization_repositories.py`:
- New `test_existing_repo_race_returns_201` pins the endpoint-level 201 path with a matching `integration_id`.
- Existing `test_existing_repo` (different `integration_id` → lookup misses → 400) unchanged.