### PR TITLE
chore(ACI): Return serialized Detector for metric alert rule POST and PUT endpoints

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -465,6 +465,12 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Use workflow engine exclusively for legacy issue alert rule.put results.
     # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
     manager.add("organizations:workflow-engine-issue-alert-endpoints-put", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Use workflow engine exclusively for legacy metric alert rule.post results.
+    # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
+    manager.add("organizations:workflow-engine-metric-alert-endpoints-post", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Use workflow engine exclusively for legacy metric alert rule.put results.
+    # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
+    manager.add("organizations:workflow-engine-metric-alert-endpoints-put", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Use workflow engine exclusively for legacy metric alert rule.get results.
     # See src/sentry/workflow_engine/docs/legacy_backport.md for context.
     manager.add("organizations:workflow-engine-metric-alert-endpoints-get", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -165,6 +165,10 @@ def update_alert_rule(
                         status=status.HTTP_200_OK,
                     )
                 except Detector.DoesNotExist:
+                    logger.error(
+                        "Alert rule was not dual written. Returning serialized rule instead of detector",
+                        extra={"rule_id": updated_rule.id},
+                    )
                     return Response(
                         serialize(updated_rule, request.user), status=status.HTTP_200_OK
                     )

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -10,6 +10,7 @@ from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -31,6 +32,7 @@ from sentry.incidents.endpoints.serializers.alert_rule import (
 )
 from sentry.incidents.endpoints.serializers.workflow_engine_detector import (
     DetailedWorkflowEngineDetectorSerializer,
+    WorkflowEngineDetectorSerializer,
 )
 from sentry.incidents.logic import (
     AlreadyDeletedError,
@@ -146,7 +148,25 @@ def update_alert_rule(
             # The user has requested a new Slack channel and we tell the client to check again in a bit
             return Response({"uuid": client.uuid}, status=202)
         else:
-            return Response(serialize(validator.save(), request.user), status=status.HTTP_200_OK)
+            updated_rule = validator.save()
+            if features.has(
+                "organizations:workflow-engine-metric-alert-endpoints-put", organization
+            ):
+                try:
+                    detector = Detector.objects.get(
+                        alertruledetector__alert_rule_id=updated_rule.id
+                    )
+                    return Response(
+                        serialize(
+                            detector,
+                            request.user,
+                            WorkflowEngineDetectorSerializer(),
+                        ),
+                        status=status.HTTP_200_OK,
+                    )
+                except Detector.DoesNotExist:
+                    Response(serialize(updated_rule, request.user), status=status.HTTP_200_OK)
+            return Response(serialize(updated_rule, request.user), status=status.HTTP_200_OK)
 
     return Response(validator.errors, status=status.HTTP_400_BAD_REQUEST)
 

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -165,7 +165,9 @@ def update_alert_rule(
                         status=status.HTTP_200_OK,
                     )
                 except Detector.DoesNotExist:
-                    Response(serialize(updated_rule, request.user), status=status.HTTP_200_OK)
+                    return Response(
+                        serialize(updated_rule, request.user), status=status.HTTP_200_OK
+                    )
             return Response(serialize(updated_rule, request.user), status=status.HTTP_200_OK)
 
     return Response(validator.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -223,7 +223,7 @@ def create_metric_alert(
                     status=status.HTTP_201_CREATED,
                 )
             except Detector.DoesNotExist:
-                Response(serialize(alert_rule, request.user), status=status.HTTP_201_CREATED)
+                return Response(serialize(alert_rule, request.user), status=status.HTTP_201_CREATED)
         return Response(serialize(alert_rule, request.user), status=status.HTTP_201_CREATED)
 
 

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -223,6 +223,10 @@ def create_metric_alert(
                     status=status.HTTP_201_CREATED,
                 )
             except Detector.DoesNotExist:
+                logger.error(
+                    "Alert rule was not dual written. Returning serialized rule instead of detector",
+                    extra={"rule_id": alert_rule.id},
+                )
                 return Response(serialize(alert_rule, request.user), status=status.HTTP_201_CREATED)
         return Response(serialize(alert_rule, request.user), status=status.HTTP_201_CREATED)
 

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -211,7 +211,7 @@ def create_metric_alert(
         return Response({"uuid": client.uuid}, status=202)
     else:
         alert_rule = validator.save()
-        if features.has("organizations:workflow-engine-rule-serializers", organization):
+        if features.has("organizations:workflow-engine-metric-alert-endpoints-post", organization):
             try:
                 detector = Detector.objects.get(alertruledetector__alert_rule_id=alert_rule.id)
                 return Response(
@@ -223,7 +223,7 @@ def create_metric_alert(
                     status=status.HTTP_201_CREATED,
                 )
             except Detector.DoesNotExist:
-                return Response(status=status.HTTP_404_NOT_FOUND)
+                Response(serialize(alert_rule, request.user), status=status.HTTP_201_CREATED)
         return Response(serialize(alert_rule, request.user), status=status.HTTP_201_CREATED)
 
 

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -27,9 +27,6 @@ from sentry.constants import ObjectStatus
 from sentry.deletions.tasks.scheduled import run_scheduled_deletions
 from sentry.incidents.endpoints.serializers.alert_rule import DetailedAlertRuleSerializer
 from sentry.incidents.endpoints.serializers.utils import get_fake_id_from_object_id
-from sentry.incidents.endpoints.serializers.workflow_engine_detector import (
-    WorkflowEngineDetectorSerializer,
-)
 from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.logic import INVALID_TIME_WINDOW
 from sentry.incidents.models.alert_rule import (
@@ -227,8 +224,6 @@ class AlertRuleDetailsBase(AlertRuleBase):
 
         assert resp.status_code == 404
 
-
-class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
     def assert_alert_detail_results_match(self, old_data: dict, new_data: dict) -> None:
         """Compare old and new alert rule serializer outputs field-by-field.
 
@@ -303,6 +298,8 @@ class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
 
         assert not mismatches, "Old vs new serializer differences:\n" + "\n".join(mismatches)
 
+
+class AlertRuleDetailsGetEndpointTest(AlertRuleDetailsBase):
     def test_simple(self) -> None:
         self.create_team(organization=self.organization, members=[self.user])
         self.login_as(self.user)
@@ -1155,7 +1152,7 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         assert alert_rule.snuba_query.aggregate == original_aggregate  # Still upsampled_count()
 
     @with_feature("organizations:incidents")
-    @with_feature("organizations:workflow-engine-metric-alert-endpoints-put")
+    @freeze_time("2024-12-11 03:21:34")
     def test_workflow_engine_serializer(self) -> None:
         self.create_member(
             user=self.user, organization=self.organization, role="owner", teams=[self.team]
@@ -1167,11 +1164,15 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         serialized_alert_rule = self.get_serialized_alert_rule()
         serialized_alert_rule["name"] = "what"
 
-        resp = self.get_success_response(
+        with self.feature("organizations:workflow-engine-metric-alert-endpoints-put"):
+            resp = self.get_success_response(
+                self.organization.slug, alert_rule.id, **serialized_alert_rule
+            )
+
+        rule_resp = self.get_success_response(
             self.organization.slug, alert_rule.id, **serialized_alert_rule
         )
-        detector = Detector.objects.get(alertruledetector__alert_rule_id=int(resp.data.get("id")))
-        assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
+        self.assert_alert_detail_results_match(rule_resp.data, resp.data)
 
     def test_not_updated_fields(self) -> None:
         self.create_member(

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_details.py
@@ -27,6 +27,9 @@ from sentry.constants import ObjectStatus
 from sentry.deletions.tasks.scheduled import run_scheduled_deletions
 from sentry.incidents.endpoints.serializers.alert_rule import DetailedAlertRuleSerializer
 from sentry.incidents.endpoints.serializers.utils import get_fake_id_from_object_id
+from sentry.incidents.endpoints.serializers.workflow_engine_detector import (
+    WorkflowEngineDetectorSerializer,
+)
 from sentry.incidents.grouptype import MetricIssue
 from sentry.incidents.logic import INVALID_TIME_WINDOW
 from sentry.incidents.models.alert_rule import (
@@ -1152,17 +1155,23 @@ class AlertRuleDetailsPutEndpointTest(AlertRuleDetailsBase):
         assert alert_rule.snuba_query.aggregate == original_aggregate  # Still upsampled_count()
 
     @with_feature("organizations:incidents")
-    @with_feature("organizations:workflow-engine-rule-serializers")
+    @with_feature("organizations:workflow-engine-metric-alert-endpoints-put")
     def test_workflow_engine_serializer(self) -> None:
-        self.create_team(organization=self.organization, members=[self.user])
+        self.create_member(
+            user=self.user, organization=self.organization, role="owner", teams=[self.team]
+        )
+
         self.login_as(self.user)
+        alert_rule = self.alert_rule
+        # We need the IDs to force update instead of create, so we just get the rule using our own API. Like frontend would.
+        serialized_alert_rule = self.get_serialized_alert_rule()
+        serialized_alert_rule["name"] = "what"
 
-        ard = AlertRuleDetector.objects.get(alert_rule_id=self.alert_rule.id)
-        self.detector = Detector.objects.get(id=ard.detector_id)
-        fake_detector_id = get_fake_id_from_object_id(self.detector.id)
-
-        with outbox_runner():
-            self.get_error_response(self.organization.slug, fake_detector_id, status_code=400)
+        resp = self.get_success_response(
+            self.organization.slug, alert_rule.id, **serialized_alert_rule
+        )
+        detector = Detector.objects.get(alertruledetector__alert_rule_id=int(resp.data.get("id")))
+        assert resp.data == serialize(detector, self.user, WorkflowEngineDetectorSerializer())
 
     def test_not_updated_fields(self) -> None:
         self.create_member(

--- a/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
+++ b/tests/sentry/incidents/endpoints/test_organization_alert_rule_index.py
@@ -532,7 +532,7 @@ class AlertRuleCreateEndpointTest(AlertRuleIndexBase, SnubaTestCase):
                 [
                     "organizations:incidents",
                     "organizations:performance-view",
-                    "organizations:workflow-engine-rule-serializers",
+                    "organizations:workflow-engine-metric-alert-endpoints-post",
                 ]
             ),
         ):


### PR DESCRIPTION
Metric alert rule version of https://github.com/getsentry/sentry/pull/113752 to return a serialized dual written Detector from the metric alert rule POST and PUT endpoints. 