### PR TITLE
codemod(button-variant): apply changes for crons

### DIFF
--- a/static/app/views/alerts/rules/uptime/assertions/opCommon.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/opCommon.tsx
@@ -99,7 +99,7 @@ export function OpContainer({
             <Flex align="center" gap="sm">
               <Button
                 size="sm"
-                priority="transparent"
+                variant="transparent"
                 icon={<IconDelete />}
                 aria-label={t('Remove assertion')}
                 onClick={onRemove}

--- a/static/app/views/alerts/rules/uptime/assertions/opGroup.tsx
+++ b/static/app/views/alerts/rules/uptime/assertions/opGroup.tsx
@@ -242,7 +242,7 @@ export function AssertionOpGroup({
         {onRemove && (
           <Button
             size="sm"
-            priority="transparent"
+            variant="transparent"
             icon={<IconDelete />}
             aria-label={t('Remove Group')}
             onClick={onRemove}
@@ -267,7 +267,7 @@ export function AssertionOpGroup({
           <AddOpButton
             size="xs"
             triggerProps={{
-              priority: 'transparent',
+              variant: 'transparent',
               size: 'zero',
               icon: <IconAdd size="xs" />,
               tooltipProps: {title: t('Add assertion to group')},

--- a/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeAlertForm.tsx
@@ -245,7 +245,7 @@ function UptimeAlertFormContent({handleDelete, rule}: Props) {
               confirmText={t('Delete Rule')}
               onConfirm={handleDelete}
             >
-              <Button priority="danger">{t('Delete Rule')}</Button>
+              <Button variant="danger">{t('Delete Rule')}</Button>
             </Confirm>
           )}
           {hasRuntimeAssertions && (

--- a/static/app/views/alerts/rules/uptime/uptimeHeadersField.tsx
+++ b/static/app/views/alerts/rules/uptime/uptimeHeadersField.tsx
@@ -116,7 +116,7 @@ function UptimHeadersControl(props: any) {
                 disabled={disabled}
                 icon={<IconDelete />}
                 size="sm"
-                priority="transparent"
+                variant="transparent"
                 aria-label={
                   headerName
                     ? t('Remove %s', disambiguateHeaderName(index))


### PR DESCRIPTION
Applies the [`button-variant` codemod](https://github.com/getsentry/design-engineering/tree/main/codemods/button-variant) to files owned by `@getsentry/crons`.