### PR TITLE
codemod(button-variant): apply changes for alerts-notifications

### DIFF
--- a/static/app/views/alerts/rules/issue/addIntegrationRow.tsx
+++ b/static/app/views/alerts/rules/issue/addIntegrationRow.tsx
@@ -45,7 +45,7 @@ export function AddIntegrationRow({onClick}: Props) {
           return isSelfHosted ? (
             <LinkButton
               href={`https://develop.sentry.dev/integrations/${provider.slug}`}
-              priority="primary"
+              variant="primary"
               external
             >
               Add {provider.metadata.noun}

--- a/static/app/views/alerts/rules/issue/index.tsx
+++ b/static/app/views/alerts/rules/issue/index.tsx
@@ -1217,7 +1217,7 @@ class IssueRuleEditor extends DeprecatedAsyncComponent<Props, State> {
                   rule.name
                 )}
               >
-                <Button priority="danger">{t('Delete Rule')}</Button>
+                <Button variant="danger">{t('Delete Rule')}</Button>
               </Confirm>
             ) : null
           }

--- a/static/app/views/alerts/rules/metric/details/relatedIssuesNotAvailable.tsx
+++ b/static/app/views/alerts/rules/metric/details/relatedIssuesNotAvailable.tsx
@@ -25,7 +25,7 @@ export function RelatedIssuesNotAvailable({buttonTo, buttonText}: Props) {
         variant="info"
         trailingItems={
           <Feature features="discover-basic">
-            <LinkButton priority="default" size="xs" to={buttonTo}>
+            <LinkButton variant="default" size="xs" to={buttonTo}>
               {buttonText}
             </LinkButton>
           </Feature>

--- a/static/app/views/alerts/rules/metric/incompatibleAlertQuery.tsx
+++ b/static/app/views/alerts/rules/metric/incompatibleAlertQuery.tsx
@@ -122,7 +122,7 @@ export function IncompatibleAlertQuery(props: IncompatibleAlertQueryProps) {
             aria-label={t('Close')}
             size="zero"
             onClick={() => setIsOpen(false)}
-            priority="transparent"
+            variant="transparent"
           />
         }
       >

--- a/static/app/views/alerts/rules/metric/ruleForm.tsx
+++ b/static/app/views/alerts/rules/metric/ruleForm.tsx
@@ -1484,7 +1484,7 @@ class RuleFormContainer extends DeprecatedAsyncComponent<Props, State> {
                         this.handleDeleteRule();
                       }}
                     >
-                      <Button priority="danger">{t('Delete Rule')}</Button>
+                      <Button variant="danger">{t('Delete Rule')}</Button>
                     </Confirm>
                   ) : null
                 }

--- a/static/app/views/alerts/rules/userSnoozeDeprecationBanner.tsx
+++ b/static/app/views/alerts/rules/userSnoozeDeprecationBanner.tsx
@@ -31,7 +31,7 @@ export function UserSnoozeDeprecationBanner({projectId}: Props) {
         <Button
           aria-label="Dismiss banner"
           icon={<IconClose variant="accent" />}
-          priority="transparent"
+          variant="transparent"
           onClick={dismissPrompt}
           size="zero"
         />


### PR DESCRIPTION
Applies the [`button-variant` codemod](https://github.com/getsentry/design-engineering/tree/main/codemods/button-variant) to files owned by `@getsentry/alerts-notifications`.