### PR TITLE
fix(iswf): Fixes issue with old Sentry App rules failing to serialize when alert schema is removed

### DIFF
--- a/src/sentry/notifications/notification_action/issue_alert_registry/handlers/sentry_app_issue_alert_handler.py
+++ b/src/sentry/notifications/notification_action/issue_alert_registry/handlers/sentry_app_issue_alert_handler.py
@@ -107,10 +107,7 @@ class SentryAppIssueAlertHandler(BaseIssueAlertHandler):
                 alert_rule_component = component
                 break
 
-        if not alert_rule_component:
-            raise ValidationError(
-                f"Alert Actions are not enabled for the {sentry_app.name} integration."
-            )
-
-        schema_title = alert_rule_component.app_schema.get("title")
+        schema_title = None
+        if alert_rule_component is not None:
+            schema_title = alert_rule_component.app_schema.get("title")
         return schema_title if schema_title is not None else sentry_app.name

--- a/src/sentry/rules/actions/sentry_apps/notify_event.py
+++ b/src/sentry/rules/actions/sentry_apps/notify_event.py
@@ -158,6 +158,11 @@ class NotifyEventSentryAppAction(SentryAppEventAction):
             raise ValidationError("Could not identify integration from the installation uuid.")
 
         sentry_app = installations[0].sentry_app
-        alert_rule_component = self._get_alert_rule_component(sentry_app.id, sentry_app.name)
+        components = app_service.find_app_components(app_id=sentry_app.id)
+        for component in components:
+            if component.type == "alert-rule-action":
+                title = component.app_schema.get("title")
+                if title is not None:
+                    return str(title)
 
-        return str(alert_rule_component.app_schema.get("title"))
+        return sentry_app.name

--- a/tests/sentry/api/serializers/test_rule.py
+++ b/tests/sentry/api/serializers/test_rule.py
@@ -1,4 +1,3 @@
-import pytest
 import responses
 from django.db import DEFAULT_DB_ALIAS, connections
 from django.test.utils import CaptureQueriesContext
@@ -895,8 +894,8 @@ class WorkflowRuleSerializerTest(TestCase):
             include_legacy_rule_id=False,
             include_workflow_id=False,
         )
-        with pytest.raises(ValidationError):
-            self.assert_equal_serializers(rule)
+
+        self.assert_equal_serializers(rule)
 
     @responses.activate
     def test_sentry_app_render_label_no_installation(self) -> None:


### PR DESCRIPTION
Our label rendering logic for Sentry App rules seems to rely on a schema component being defined for alert rule creation, which is reasonable.

Unfortunately, this also breaks rule API queries if this schema component is removed. This PR fixes the issue by defaulting to the Sentry App name when a schema title is not availble.

To reproduce:
1. Create a valid Sentry App, you need to have an active server running that can process webhooks
2. Add the schema for adding alert rules
3. Create a new alert rule. Note: this won't appear as an option if your sentry app server isn't actively running and handling requests
4. Configure the alert rule and trigger it with the test button
5. Remove the schema for adding alert rules

Resolves: ISWF-2340
