### PR TITLE
fix(issue-stream): Prune aged-out issues during real-time updates

### DIFF
--- a/static/app/stores/groupStore.spec.tsx
+++ b/static/app/stores/groupStore.spec.tsx
@@ -92,16 +92,15 @@ describe('GroupStore', () => {
       expect(GroupStore.getAllItemIds()).toEqual(['1']);
     });
 
-    it('keeps items with a missing or invalid lastSeen', () => {
+    it('keeps items with an unparseable lastSeen', () => {
       GroupStore.items = [
-        g('1', {lastSeen: undefined as unknown as string}),
-        g('2', {lastSeen: 'not-a-date'}),
-        g('3', {lastSeen: '2026-04-23T10:00:00Z'}),
+        g('1', {lastSeen: 'not-a-date'}),
+        g('2', {lastSeen: '2026-04-23T10:00:00Z'}),
       ];
 
       GroupStore.pruneOlderThan(new Date('2026-04-23T11:00:00Z').getTime());
 
-      expect(GroupStore.getAllItemIds()).toEqual(['1', '2']);
+      expect(GroupStore.getAllItemIds()).toEqual(['1']);
     });
   });
 

--- a/static/app/stores/groupStore.spec.tsx
+++ b/static/app/stores/groupStore.spec.tsx
@@ -70,6 +70,41 @@ describe('GroupStore', () => {
     });
   });
 
+  describe('pruneOlderThan()', () => {
+    it('removes items with lastSeen older than the floor', () => {
+      GroupStore.items = [
+        g('1', {lastSeen: '2026-04-23T12:00:00Z'}),
+        g('2', {lastSeen: '2026-04-23T11:00:00Z'}),
+        g('3', {lastSeen: '2026-04-23T10:00:00Z'}),
+      ];
+
+      GroupStore.pruneOlderThan(new Date('2026-04-23T11:30:00Z').getTime());
+
+      expect(GroupStore.getAllItemIds()).toEqual(['1']);
+    });
+
+    it('keeps items whose lastSeen equals the floor', () => {
+      const floor = new Date('2026-04-23T12:00:00Z').getTime();
+      GroupStore.items = [g('1', {lastSeen: '2026-04-23T12:00:00Z'})];
+
+      GroupStore.pruneOlderThan(floor);
+
+      expect(GroupStore.getAllItemIds()).toEqual(['1']);
+    });
+
+    it('keeps items with a missing or invalid lastSeen', () => {
+      GroupStore.items = [
+        g('1', {lastSeen: undefined as unknown as string}),
+        g('2', {lastSeen: 'not-a-date'}),
+        g('3', {lastSeen: '2026-04-23T10:00:00Z'}),
+      ];
+
+      GroupStore.pruneOlderThan(new Date('2026-04-23T11:00:00Z').getTime());
+
+      expect(GroupStore.getAllItemIds()).toEqual(['1', '2']);
+    });
+  });
+
   describe('remove()', () => {
     it('should remove entry', () => {
       GroupStore.items = [g('1'), g('2')];

--- a/static/app/stores/groupStore.tsx
+++ b/static/app/stores/groupStore.tsx
@@ -82,6 +82,8 @@ interface GroupStoreDefinition extends StrictStoreDefinition<Item[]>, InternalDe
   onUpdateError: (changeId: string, itemIds: ItemIds, silent: boolean) => void;
   onUpdateSuccess: (changeId: string, itemIds: ItemIds, response: Partial<Group>) => void;
 
+  pruneOlderThan: (minLastSeenMs: number) => void;
+
   remove: (itemIds: ItemIds) => void;
 
   reset: () => void;
@@ -208,6 +210,21 @@ const storeConfig: GroupStoreDefinition = {
     this.items = this.items.filter(item => !itemIds?.includes(item.id));
 
     this.updateItems(itemIds);
+  },
+
+  pruneOlderThan(minLastSeenMs) {
+    const removedIds: string[] = [];
+    this.items = this.items.filter(item => {
+      const lastSeenMs = item.lastSeen ? new Date(item.lastSeen).getTime() : NaN;
+      if (Number.isFinite(lastSeenMs) && lastSeenMs < minLastSeenMs) {
+        removedIds.push(item.id);
+        return false;
+      }
+      return true;
+    });
+    if (removedIds.length > 0) {
+      this.updateItems(removedIds);
+    }
   },
 
   addStatus(id, status) {

--- a/static/app/stores/groupStore.tsx
+++ b/static/app/stores/groupStore.tsx
@@ -215,7 +215,7 @@ const storeConfig: GroupStoreDefinition = {
   pruneOlderThan(minLastSeenMs) {
     const removedIds: string[] = [];
     this.items = this.items.filter(item => {
-      const lastSeenMs = item.lastSeen ? new Date(item.lastSeen).getTime() : NaN;
+      const lastSeenMs = new Date(item.lastSeen).getTime();
       if (Number.isFinite(lastSeenMs) && lastSeenMs < minLastSeenMs) {
         removedIds.push(item.id);
         return false;

--- a/static/app/utils/cursorPoller.tsx
+++ b/static/app/utils/cursorPoller.tsx
@@ -75,23 +75,27 @@ export class CursorPoller {
           return;
         }
 
-        // if theres no data, nothing changes
-        if (!data?.length) {
+        const hasNewData = Boolean(data?.length);
+        if (hasNewData) {
+          if (this.reqsWithoutData > 0) {
+            this.reqsWithoutData -= 1;
+          }
+          const linksHeader = resp?.getResponseHeader('Link') ?? null;
+          const links = parseLinkHeader(linksHeader);
+          if (links?.previous?.href) {
+            this.setEndpoint(links.previous.href);
+          }
+        } else {
           this.reqsWithoutData += 1;
-          return;
         }
 
-        if (this.reqsWithoutData > 0) {
-          this.reqsWithoutData -= 1;
-        }
-
-        const linksHeader = resp?.getResponseHeader('Link') ?? null;
         const hitsHeader = resp?.getResponseHeader('X-Hits') ?? null;
         const queryCount = defined(hitsHeader) ? parseInt(hitsHeader, 10) || 0 : 0;
-        const links = parseLinkHeader(linksHeader);
-        this.setEndpoint(links.previous!.href);
 
-        this.options.success(data, {queryCount});
+        // Always fire success — callers may want to run on every poll tick
+        // (e.g. pruning aged-out items) and not just on polls that returned
+        // new data.
+        this.options.success(data ?? [], {queryCount});
       },
       error: resp => {
         if (!resp) {

--- a/static/app/views/issueList/overview.polling.spec.tsx
+++ b/static/app/views/issueList/overview.polling.spec.tsx
@@ -40,9 +40,15 @@ describe('IssueList -> Polling', () => {
     MockApiClient.clearMockResponses();
   });
 
+  // Pin the fake clock and use a lastSeen inside the statsPeriod window so
+  // the realtime prune (which removes items older than the active
+  // statsPeriod) doesn't strip these fixtures.
+  const NOW = new Date('2026-04-23T12:00:00Z');
+  const RECENT_LAST_SEEN = '2026-04-23T11:00:00Z';
+
   const project = ProjectFixture();
-  const group = GroupFixture({project});
-  const group2 = GroupFixture({project, id: '2'});
+  const group = GroupFixture({project, lastSeen: RECENT_LAST_SEEN});
+  const group2 = GroupFixture({project, id: '2', lastSeen: RECENT_LAST_SEEN});
 
   /* helpers */
   const renderComponent = async () => {
@@ -61,6 +67,7 @@ describe('IssueList -> Polling', () => {
 
   beforeEach(() => {
     jest.useFakeTimers();
+    jest.setSystemTime(NOW);
 
     // The tests fail because we have a "component update was not wrapped in act" error.
     // It should be safe to ignore this error, but we should remove the mock once we move to react testing library
@@ -116,7 +123,10 @@ describe('IssueList -> Polling', () => {
     });
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/issues-stats/',
-      body: [GroupStatsFixture()],
+      body: [
+        GroupStatsFixture({lastSeen: RECENT_LAST_SEEN}),
+        GroupStatsFixture({id: '2', lastSeen: RECENT_LAST_SEEN}),
+      ],
     });
     pollRequest = MockApiClient.addMockResponse({
       url: `/api/0/organizations/org-slug/issues/?cursor=${PREVIOUS_PAGE_CURSOR}:0:1`,
@@ -193,6 +203,31 @@ describe('IssueList -> Polling', () => {
     await screen.findByTestId('2');
 
     expect(screen.getByText(textWithMarkupMatcher('1-2 of 2'))).toBeInTheDocument();
+  });
+
+  it('drops issues whose lastSeen falls outside the active time range', async () => {
+    // Initial issue is within the default 14d window.
+    await renderComponent();
+    expect(await screen.findByTestId('1')).toBeInTheDocument();
+
+    // Enable real-time updates.
+    await userEvent.click(
+      screen.getByRole('button', {name: 'Enable real-time updates'}),
+      {delay: null}
+    );
+
+    // Jump the fake clock 30 days into the future so the initial issue's
+    // lastSeen is now older than the 14d window.
+    jest.setSystemTime(new Date(NOW.getTime() + 30 * 24 * 60 * 60 * 1000));
+
+    // Advance past the 30s prune interval; CursorPoller's empty poll fires
+    // repeatedly, and the interval prunes the aged-out item even without
+    // new poll data.
+    jest.advanceTimersByTime(31_000);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('1')).not.toBeInTheDocument();
+    });
   });
 
   it('stops polling for new issues when endpoint returns a 401', async () => {

--- a/static/app/views/issueList/overview.polling.spec.tsx
+++ b/static/app/views/issueList/overview.polling.spec.tsx
@@ -220,10 +220,10 @@ describe('IssueList -> Polling', () => {
     // lastSeen is now older than the 14d window.
     jest.setSystemTime(new Date(NOW.getTime() + 30 * 24 * 60 * 60 * 1000));
 
-    // Advance past the 30s prune interval; CursorPoller's empty poll fires
-    // repeatedly, and the interval prunes the aged-out item even without
-    // new poll data.
-    jest.advanceTimersByTime(31_000);
+    // First empty poll fires at BASE_DELAY (3s). CursorPoller now always
+    // invokes the success callback, so the prune runs on this tick even
+    // though no new issues arrived.
+    jest.advanceTimersByTime(3001);
 
     await waitFor(() => {
       expect(screen.queryByTestId('1')).not.toBeInTheDocument();

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -206,6 +206,12 @@ function IssueListOverview({
     [getRealtimeWindowStartMs]
   );
 
+  // Keep the poller's `success` callback fresh without recreating the poller.
+  const onRealtimePollRef = useRef(onRealtimePoll);
+  useEffect(() => {
+    onRealtimePollRef.current = onRealtimePoll;
+  }, [onRealtimePoll]);
+
   useEffect(() => {
     // Either cleanup or reuse the poller to prevent a resource leak.
     if (pollerRef.current) {
@@ -215,9 +221,9 @@ function IssueListOverview({
 
     pollerRef.current = new CursorPoller({
       linkPreviousHref: parseLinkHeader(pageLinks)?.previous?.href!,
-      success: onRealtimePoll,
+      success: (data, headers) => onRealtimePollRef.current(data, headers),
     });
-  }, [onRealtimePoll, pageLinks]);
+  }, [pageLinks]);
 
   const query = defined(location.query.query)
     ? (location.query.query as string)

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -17,6 +17,7 @@ import {extractSelectionParameters} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import type {CursorHandler} from 'sentry/components/pagination';
 import {QueryCount} from 'sentry/components/queryCount';
+import {parseStatsPeriod} from 'sentry/components/timeRangeSelector/utils';
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {t, tct} from 'sentry/locale';
 import {GroupStore} from 'sentry/stores/groupStore';
@@ -29,7 +30,6 @@ import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {CursorPoller} from 'sentry/utils/cursorPoller';
 import {getUtcDateString} from 'sentry/utils/dates';
-import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
 import {getCurrentSentryReactRootSpan} from 'sentry/utils/getCurrentSentryReactRootSpan';
 import {parseApiError} from 'sentry/utils/parseApiError';
 import {parseLinkHeader} from 'sentry/utils/parseLinkHeader';
@@ -183,41 +183,31 @@ function IssueListOverview({
     if (!period) {
       return null;
     }
-    const hours = parsePeriodToHours(period);
-    if (hours <= 0) {
+    try {
+      const startMs = new Date(parseStatsPeriod(period).start).getTime();
+      return Number.isFinite(startMs) ? startMs : null;
+    } catch {
+      // parseStatsPeriod throws on malformed input. Skip pruning rather than
+      // breaking the poll callback.
       return null;
     }
-    return Date.now() - hours * 60 * 60 * 1000;
   }, [selection.datetime]);
 
   const onRealtimePoll = useCallback(
     (data: any, {queryCount: newQueryCount}: {queryCount: number}) => {
       // Note: We do not update state with cursors from polling,
       // `CursorPoller` updates itself with new cursors
-      GroupStore.addToFront(data);
+      if (data.length > 0) {
+        GroupStore.addToFront(data);
+        setQueryCount(newQueryCount);
+      }
       const minLastSeenMs = getRealtimeWindowStartMs();
       if (minLastSeenMs !== null) {
         GroupStore.pruneOlderThan(minLastSeenMs);
       }
-      setQueryCount(newQueryCount);
     },
     [getRealtimeWindowStartMs]
   );
-
-  // CursorPoller skips its success callback on empty polls, so prune on a
-  // timer to keep aging items out of the list even when no new issues arrive.
-  useEffect(() => {
-    if (!realtimeActive) {
-      return undefined;
-    }
-    const intervalId = window.setInterval(() => {
-      const minLastSeenMs = getRealtimeWindowStartMs();
-      if (minLastSeenMs !== null) {
-        GroupStore.pruneOlderThan(minLastSeenMs);
-      }
-    }, 30_000);
-    return () => window.clearInterval(intervalId);
-  }, [realtimeActive, getRealtimeWindowStartMs]);
 
   useEffect(() => {
     // Either cleanup or reuse the poller to prevent a resource leak.

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -196,12 +196,14 @@ function IssueListOverview({
       // `CursorPoller` updates itself with new cursors
       if (data.length > 0) {
         GroupStore.addToFront(data);
-        setQueryCount(newQueryCount);
       }
       const minLastSeenMs = getRealtimeWindowStartMs();
       if (minLastSeenMs !== null) {
         GroupStore.pruneOlderThan(minLastSeenMs);
       }
+      // Anchor on the server total, but never below what's actually in the
+      // store after pruning.
+      setQueryCount(Math.max(newQueryCount, GroupStore.getAllItems().length));
     },
     [getRealtimeWindowStartMs]
   );

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -29,6 +29,7 @@ import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {CursorPoller} from 'sentry/utils/cursorPoller';
 import {getUtcDateString} from 'sentry/utils/dates';
+import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
 import {getCurrentSentryReactRootSpan} from 'sentry/utils/getCurrentSentryReactRootSpan';
 import {parseApiError} from 'sentry/utils/parseApiError';
 import {parseLinkHeader} from 'sentry/utils/parseLinkHeader';
@@ -169,15 +170,54 @@ function IssueListOverview({
   const {data: supergroupLookup, isLoading: supergroupsLoading} =
     useSuperGroups(groupIds);
 
+  // The realtime poller only fetches NEW issues via the "previous" cursor; it
+  // never re-queries the current window, so items that age past the time range
+  // would otherwise linger until a full reload. Compute the floor so we can
+  // prune them ourselves.
+  const getRealtimeWindowStartMs = useCallback((): number | null => {
+    const {period, start} = selection.datetime;
+    if (start) {
+      const startMs = new Date(start).getTime();
+      return Number.isFinite(startMs) ? startMs : null;
+    }
+    if (!period) {
+      return null;
+    }
+    const hours = parsePeriodToHours(period);
+    if (hours <= 0) {
+      return null;
+    }
+    return Date.now() - hours * 60 * 60 * 1000;
+  }, [selection.datetime]);
+
   const onRealtimePoll = useCallback(
     (data: any, {queryCount: newQueryCount}: {queryCount: number}) => {
       // Note: We do not update state with cursors from polling,
       // `CursorPoller` updates itself with new cursors
       GroupStore.addToFront(data);
+      const minLastSeenMs = getRealtimeWindowStartMs();
+      if (minLastSeenMs !== null) {
+        GroupStore.pruneOlderThan(minLastSeenMs);
+      }
       setQueryCount(newQueryCount);
     },
-    []
+    [getRealtimeWindowStartMs]
   );
+
+  // CursorPoller skips its success callback on empty polls, so prune on a
+  // timer to keep aging items out of the list even when no new issues arrive.
+  useEffect(() => {
+    if (!realtimeActive) {
+      return undefined;
+    }
+    const intervalId = window.setInterval(() => {
+      const minLastSeenMs = getRealtimeWindowStartMs();
+      if (minLastSeenMs !== null) {
+        GroupStore.pruneOlderThan(minLastSeenMs);
+      }
+    }, 30_000);
+    return () => window.clearInterval(intervalId);
+  }, [realtimeActive, getRealtimeWindowStartMs]);
 
   useEffect(() => {
     // Either cleanup or reuse the poller to prevent a resource leak.

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -17,7 +17,6 @@ import {extractSelectionParameters} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import type {CursorHandler} from 'sentry/components/pagination';
 import {QueryCount} from 'sentry/components/queryCount';
-import {parseStatsPeriod} from 'sentry/components/timeRangeSelector/utils';
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {t, tct} from 'sentry/locale';
 import {GroupStore} from 'sentry/stores/groupStore';
@@ -30,6 +29,7 @@ import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {CursorPoller} from 'sentry/utils/cursorPoller';
 import {getUtcDateString} from 'sentry/utils/dates';
+import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
 import {getCurrentSentryReactRootSpan} from 'sentry/utils/getCurrentSentryReactRootSpan';
 import {parseApiError} from 'sentry/utils/parseApiError';
 import {parseLinkHeader} from 'sentry/utils/parseLinkHeader';
@@ -183,14 +183,11 @@ function IssueListOverview({
     if (!period) {
       return null;
     }
-    try {
-      const startMs = new Date(parseStatsPeriod(period).start).getTime();
-      return Number.isFinite(startMs) ? startMs : null;
-    } catch {
-      // parseStatsPeriod throws on malformed input. Skip pruning rather than
-      // breaking the poll callback.
+    const hours = parsePeriodToHours(period);
+    if (hours <= 0) {
       return null;
     }
+    return Date.now() - hours * 60 * 60 * 1000;
   }, [selection.datetime]);
 
   const onRealtimePoll = useCallback(


### PR DESCRIPTION
Fixes the issues stream showing stale issues when real-time updates is enabled with a time-range filter (e.g. 30m). Items whose `lastSeen` drifted past the active `statsPeriod` kept rendering until a full reload.

The realtime poller uses the Link header's `previous` cursor — an incremental delta that only returns newer issues — and `GroupStore.addToFront` never pruned anything, so stale items accumulated.

Adds `GroupStore.pruneOlderThan` and calls it after each poll plus on a 30s interval while realtime is active (empty polls skip the success callback). Cutoff comes from `selection.datetime`.