### PR TITLE
feat(autofix): Render tool calls as autofix evidence

### DIFF
--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -284,7 +284,7 @@ export function getOrderedArtifactKeys(
 
 export interface AutofixSection {
   artifacts: AutofixArtifact[];
-  messages: Array<Block['message']>;
+  blocks: Block[];
   status: 'processing' | 'completed';
   step: string;
 }
@@ -316,16 +316,16 @@ export function getOrderedAutofixSections(runState: ExplorerAutofixState | null)
   let section: AutofixSection = {
     step: 'unknown',
     artifacts: [],
-    messages: [],
+    blocks: [],
     status: 'processing',
   };
 
   // Closes the current section and pushes it to `sections` (if non-empty).
   function finalizeSection() {
-    if (section.messages.length) {
+    if (section.blocks.length) {
       // Mark the section as completed if the last message is a terminal marker.
-      const lastMessage = section.messages[section.messages.length - 1];
-      if (isLastMessageOfSection(lastMessage)) {
+      const lastBlock = section.blocks[section.blocks.length - 1];
+      if (isLastBlockOfSection(lastBlock)) {
         section.status = 'completed';
       }
 
@@ -361,13 +361,13 @@ export function getOrderedAutofixSections(runState: ExplorerAutofixState | null)
       section = {
         step: metadata.step,
         artifacts: [],
-        messages: [],
+        blocks: [],
         status: 'processing',
       };
     }
 
     // Append the block's message and any inline artifacts to the current section.
-    section.messages.push(message);
+    section.blocks.push(block);
     section.artifacts.push(...(block.artifacts ?? []));
   }
 
@@ -380,7 +380,7 @@ export function getOrderedAutofixSections(runState: ExplorerAutofixState | null)
     sections.push({
       step: 'pull_request',
       artifacts: [pullRequests],
-      messages: [],
+      blocks: [],
       status: pullRequests.some(
         pullRequest => pullRequest.pr_creation_status === 'creating'
       )
@@ -394,7 +394,7 @@ export function getOrderedAutofixSections(runState: ExplorerAutofixState | null)
     sections.push({
       step: 'coding_agents',
       artifacts: [codingAgents],
-      messages: [],
+      blocks: [],
       status: codingAgents.some(
         codingAgent =>
           codingAgent.status === CodingAgentStatus.PENDING ||
@@ -455,11 +455,11 @@ export function getAutofixArtifactFromSection(
   return null;
 }
 
-function isLastMessageOfSection(message?: Block['message']): boolean {
+function isLastBlockOfSection(block?: Block): boolean {
   return (
-    message?.role === 'assistant' &&
-    message?.content !== 'Thinking...' &&
-    !message?.tool_calls?.length
+    block?.message?.role === 'assistant' &&
+    block?.message?.content !== 'Thinking...' &&
+    !block?.message?.tool_calls?.length
   );
 }
 

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -31,7 +31,7 @@ function makeSection(
   status: AutofixSection['status'],
   artifacts: AutofixArtifact[]
 ): AutofixSection {
-  return {step, artifacts, messages: [], status};
+  return {step, artifacts, blocks: [], status};
 }
 
 function makePatch(repoName: string, path: string): ExplorerFilePatch {

--- a/static/app/components/events/autofix/v3/autofixCards.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.tsx
@@ -108,7 +108,7 @@ export function RootCauseCard({autofix, section}: AutofixCardProps) {
           ) : null}
           <ArtifactDetails>
             <Text bold>{t('Evidence')}</Text>
-            {evidence.length > 0 ? (
+            {evidence.length > 0 && (
               <Flex gap="md" wrap="wrap">
                 {evidence.map(e => (
                   <AutofixEvidence
@@ -118,8 +118,6 @@ export function RootCauseCard({autofix, section}: AutofixCardProps) {
                   />
                 ))}
               </Flex>
-            ) : (
-              <Text variant="muted">{t('No evidence available')}</Text>
             )}
           </ArtifactDetails>
         </Fragment>

--- a/static/app/components/events/autofix/v3/autofixCards.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.tsx
@@ -23,6 +23,8 @@ import {
   type AutofixSection,
   type useExplorerAutofix,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
+import {AutofixEvidence} from 'sentry/components/events/autofix/v3/autofixEvidence';
+import {useAutofixSectionEvidence} from 'sentry/components/events/autofix/v3/useAutofixSectionEvidence';
 import {artifactToMarkdown} from 'sentry/components/events/autofix/v3/utils';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {TimeSince} from 'sentry/components/timeSince';
@@ -58,6 +60,8 @@ export function RootCauseCard({autofix, section}: AutofixCardProps) {
   );
   const {startStep} = autofix;
 
+  const evidence = useAutofixSectionEvidence({section});
+
   return (
     <ArtifactCard
       icon={<IconBug />}
@@ -70,7 +74,7 @@ export function RootCauseCard({autofix, section}: AutofixCardProps) {
     >
       {section.status === 'processing' ? (
         <LoadingDetails
-          messages={section.messages}
+          blocks={section.blocks}
           loadingMessage={t('Finding the root cause\u2026')}
         />
       ) : artifact?.data ? (
@@ -100,6 +104,22 @@ export function RootCauseCard({autofix, section}: AutofixCardProps) {
                   </Container>
                 </ArtifactDetails>
               ) : null}
+              <ArtifactDetails>
+                <Text bold>{t('Evidence')}</Text>
+                {evidence.length > 0 ? (
+                  <Flex gap="md" wrap="wrap">
+                    {evidence.map(e => (
+                      <AutofixEvidence
+                        key={e.toolCall.id}
+                        toolCall={e.toolCall}
+                        toolLink={e.toolLink}
+                      />
+                    ))}
+                  </Flex>
+                ) : (
+                  <Text variant="muted">{t('No evidence available')}</Text>
+                )}
+              </ArtifactDetails>
             </Fragment>
           ) : null}
         </Fragment>
@@ -151,7 +171,7 @@ export function SolutionCard({autofix, section}: AutofixCardProps) {
     >
       {section.status === 'processing' ? (
         <LoadingDetails
-          messages={section.messages}
+          blocks={section.blocks}
           loadingMessage={t('Formulating a plan\u2026')}
         />
       ) : artifact?.data ? (
@@ -248,7 +268,7 @@ export function CodeChangesCard({autofix, section}: AutofixCardProps) {
     >
       {section.status === 'processing' ? (
         <LoadingDetails
-          messages={section.messages}
+          blocks={section.blocks}
           loadingMessage={t('Implementing changes\u2026')}
         />
       ) : (
@@ -499,11 +519,11 @@ function ArtifactDetails({children, ...flexProps}: ArtifactDetailsProps) {
 }
 
 interface LoadingDetailsProps {
+  blocks: AutofixSection['blocks'];
   loadingMessage: string;
-  messages: AutofixSection['messages'];
 }
 
-function LoadingDetails({loadingMessage, messages}: LoadingDetailsProps) {
+function LoadingDetails({loadingMessage, blocks}: LoadingDetailsProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
 
@@ -519,7 +539,7 @@ function LoadingDetails({loadingMessage, messages}: LoadingDetailsProps) {
     }
 
     bottomRef.current?.scrollIntoView({behavior: 'smooth', block: 'end'});
-  }, [messages]);
+  }, [blocks]);
 
   return (
     <ArtifactDetails paddingTop="0">
@@ -531,14 +551,14 @@ function LoadingDetails({loadingMessage, messages}: LoadingDetailsProps) {
         maxHeight="200px"
         overflowY="auto"
       >
-        {messages.map((message, index) => {
-          if (message.role === 'user') {
+        {blocks.map((block, index) => {
+          if (block.message.role === 'user') {
             // The user role is used to pass the prompts
             return null;
           }
 
-          if (message.content && message.content !== 'Thinking...') {
-            return <StyledMarkedText key={index} text={message.content} />;
+          if (block.message.content && block.message.content !== 'Thinking...') {
+            return <StyledMarkedText key={index} text={block.message.content} />;
           }
 
           return null;

--- a/static/app/components/events/autofix/v3/autofixCards.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.tsx
@@ -106,9 +106,9 @@ export function RootCauseCard({autofix, section}: AutofixCardProps) {
               ) : null}
             </Fragment>
           ) : null}
-          <ArtifactDetails>
-            <Text bold>{t('Evidence')}</Text>
-            {evidence.length > 0 && (
+          {evidence.length > 0 && (
+            <ArtifactDetails>
+              <Text bold>{t('Evidence')}</Text>
               <Flex gap="md" wrap="wrap">
                 {evidence.map(e => (
                   <AutofixEvidence
@@ -118,8 +118,8 @@ export function RootCauseCard({autofix, section}: AutofixCardProps) {
                   />
                 ))}
               </Flex>
-            )}
-          </ArtifactDetails>
+            </ArtifactDetails>
+          )}
         </Fragment>
       ) : (
         <ArtifactDetails>

--- a/static/app/components/events/autofix/v3/autofixCards.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.tsx
@@ -104,24 +104,24 @@ export function RootCauseCard({autofix, section}: AutofixCardProps) {
                   </Container>
                 </ArtifactDetails>
               ) : null}
-              <ArtifactDetails>
-                <Text bold>{t('Evidence')}</Text>
-                {evidence.length > 0 ? (
-                  <Flex gap="md" wrap="wrap">
-                    {evidence.map(e => (
-                      <AutofixEvidence
-                        key={e.toolCall.id}
-                        toolCall={e.toolCall}
-                        toolLink={e.toolLink}
-                      />
-                    ))}
-                  </Flex>
-                ) : (
-                  <Text variant="muted">{t('No evidence available')}</Text>
-                )}
-              </ArtifactDetails>
             </Fragment>
           ) : null}
+          <ArtifactDetails>
+            <Text bold>{t('Evidence')}</Text>
+            {evidence.length > 0 ? (
+              <Flex gap="md" wrap="wrap">
+                {evidence.map(e => (
+                  <AutofixEvidence
+                    key={e.toolCall.id}
+                    toolCall={e.toolCall}
+                    toolLink={e.toolLink}
+                  />
+                ))}
+              </Flex>
+            ) : (
+              <Text variant="muted">{t('No evidence available')}</Text>
+            )}
+          </ArtifactDetails>
         </Fragment>
       ) : (
         <ArtifactDetails>

--- a/static/app/components/events/autofix/v3/autofixEvidence.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.spec.tsx
@@ -1,0 +1,434 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {render, renderHookWithProviders, screen} from 'sentry-test/reactTestingLibrary';
+
+import type {AutofixSection} from 'sentry/components/events/autofix/useExplorerAutofix';
+import {ProjectsStore} from 'sentry/stores/projectsStore';
+import type {Block, ToolCall, ToolLink} from 'sentry/views/seerExplorer/types';
+
+import {AutofixEvidence} from './autofixEvidence';
+import {useAutofixSectionEvidence} from './useAutofixSectionEvidence';
+
+function makeToolCall(fn: string, args: Record<string, any> = {}, id = 'tc-1'): ToolCall {
+  return {id, function: fn, args: JSON.stringify(args)};
+}
+
+function makeToolLink(kind: string, params: Record<string, any> = {}): ToolLink {
+  return {kind, params};
+}
+
+function makeBlock(overrides: Partial<Block> = {}): Block {
+  return {
+    id: 'block-1',
+    timestamp: '2024-01-01T00:00:00Z',
+    message: {content: '', role: 'assistant'},
+    ...overrides,
+  };
+}
+
+function makeSection(blocks: Block[]): AutofixSection {
+  return {step: 'exploration', status: 'completed', artifacts: [], blocks};
+}
+
+describe('AutofixEvidence', () => {
+  const organization = OrganizationFixture();
+  const project = ProjectFixture({id: '1', slug: 'test-project'});
+
+  beforeEach(() => {
+    ProjectsStore.loadInitialData([project]);
+  });
+
+  describe('null rendering', () => {
+    it('renders nothing when toolLink is missing', () => {
+      const {container} = render(
+        <AutofixEvidence toolCall={makeToolCall('telemetry_live_search')} />,
+        {organization}
+      );
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders nothing when toolLink kind is unknown', () => {
+      const {container} = render(
+        <AutofixEvidence
+          toolCall={makeToolCall('telemetry_live_search')}
+          toolLink={makeToolLink('unknown_kind')}
+        />,
+        {organization}
+      );
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders nothing for unknown toolCall function with valid toolLink', () => {
+      const {container} = render(
+        <AutofixEvidence
+          toolCall={makeToolCall('unknown_function')}
+          toolLink={makeToolLink('telemetry_live_search', {query: 'test'})}
+        />,
+        {organization}
+      );
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  describe('EvidenceTelemetry', () => {
+    it('renders "Query: Spans" for spans dataset', () => {
+      render(
+        <AutofixEvidence
+          toolCall={makeToolCall('telemetry_live_search')}
+          toolLink={makeToolLink('telemetry_live_search', {
+            dataset: 'spans',
+            query: 'test',
+          })}
+        />,
+        {organization}
+      );
+      expect(screen.getByText('Query: Spans')).toBeInTheDocument();
+    });
+
+    it('renders "Query: Issues" for issues dataset', () => {
+      render(
+        <AutofixEvidence
+          toolCall={makeToolCall('telemetry_live_search')}
+          toolLink={makeToolLink('telemetry_live_search', {
+            dataset: 'issues',
+            query: 'test',
+          })}
+        />,
+        {organization}
+      );
+      expect(screen.getByText('Query: Issues')).toBeInTheDocument();
+    });
+
+    it('renders "Query: Errors" for errors dataset', () => {
+      render(
+        <AutofixEvidence
+          toolCall={makeToolCall('telemetry_live_search')}
+          toolLink={makeToolLink('telemetry_live_search', {
+            dataset: 'errors',
+            query: 'test',
+          })}
+        />,
+        {organization}
+      );
+      expect(screen.getByText('Query: Errors')).toBeInTheDocument();
+    });
+
+    it('renders "Query: Logs" for logs dataset', () => {
+      render(
+        <AutofixEvidence
+          toolCall={makeToolCall('telemetry_live_search')}
+          toolLink={makeToolLink('telemetry_live_search', {
+            dataset: 'logs',
+            query: 'test',
+          })}
+        />,
+        {organization}
+      );
+      expect(screen.getByText('Query: Logs')).toBeInTheDocument();
+    });
+
+    it('renders "Query: Metrics" for metrics dataset', () => {
+      render(
+        <AutofixEvidence
+          toolCall={makeToolCall('telemetry_live_search')}
+          toolLink={makeToolLink('telemetry_live_search', {
+            dataset: 'metrics',
+            query: 'test',
+          })}
+        />,
+        {organization}
+      );
+      expect(screen.getByText('Query: Metrics')).toBeInTheDocument();
+    });
+
+    it('renders "Query: Metrics" for tracemetrics dataset', () => {
+      render(
+        <AutofixEvidence
+          toolCall={makeToolCall('telemetry_live_search')}
+          toolLink={makeToolLink('telemetry_live_search', {
+            dataset: 'tracemetrics',
+            query: 'test',
+          })}
+        />,
+        {organization}
+      );
+      expect(screen.getByText('Query: Metrics')).toBeInTheDocument();
+    });
+
+    it('defaults to "Query: Spans" when dataset is undefined', () => {
+      render(
+        <AutofixEvidence
+          toolCall={makeToolCall('telemetry_live_search')}
+          toolLink={makeToolLink('telemetry_live_search', {query: 'test'})}
+        />,
+        {organization}
+      );
+      expect(screen.getByText('Query: Spans')).toBeInTheDocument();
+    });
+  });
+
+  describe('EvidenceTrace', () => {
+    it('renders span label when span_id is provided', () => {
+      render(
+        <AutofixEvidence
+          toolCall={makeToolCall('get_trace_waterfall')}
+          toolLink={makeToolLink('get_trace_waterfall', {
+            trace_id: 'abc123def4567890',
+            span_id: '11223344aabbccdd',
+          })}
+        />,
+        {organization}
+      );
+      expect(screen.getByText('Span: 11223344')).toBeInTheDocument();
+    });
+
+    it('renders trace label when only trace_id is provided', () => {
+      render(
+        <AutofixEvidence
+          toolCall={makeToolCall('get_trace_waterfall')}
+          toolLink={makeToolLink('get_trace_waterfall', {
+            trace_id: 'abc123def4567890',
+          })}
+        />,
+        {organization}
+      );
+      expect(screen.getByText('Trace: abc123de')).toBeInTheDocument();
+    });
+  });
+
+  describe('EvidenceIssue', () => {
+    it('renders error label with event_id via get_event_details', () => {
+      render(
+        <AutofixEvidence
+          toolCall={makeToolCall('get_event_details')}
+          toolLink={makeToolLink('get_event_details', {
+            event_id: 'abcd1234efgh5678',
+            issue_id: '12345',
+          })}
+        />,
+        {organization}
+      );
+      expect(screen.getByText('Error: abcd1234')).toBeInTheDocument();
+    });
+
+    it('renders error label with event_id via get_issue_details', () => {
+      render(
+        <AutofixEvidence
+          toolCall={makeToolCall('get_issue_details')}
+          toolLink={makeToolLink('get_issue_details', {
+            issue_id: '12345',
+            event_id: 'abcd1234efgh5678',
+          })}
+        />,
+        {organization}
+      );
+      expect(screen.getByText('Error: abcd1234')).toBeInTheDocument();
+    });
+
+    it('renders nothing when event_id is missing for get_issue_details', () => {
+      const {container} = render(
+        <AutofixEvidence
+          toolCall={makeToolCall('get_issue_details')}
+          toolLink={makeToolLink('get_issue_details', {issue_id: '12345'})}
+        />,
+        {organization}
+      );
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  describe('EvidenceReplay', () => {
+    it('renders replay label', () => {
+      render(
+        <AutofixEvidence
+          toolCall={makeToolCall('get_replay_details')}
+          toolLink={makeToolLink('get_replay_details', {
+            replay_id: 'aabbccdd11223344',
+          })}
+        />,
+        {organization}
+      );
+      expect(screen.getByText('Replay: aabbccdd')).toBeInTheDocument();
+    });
+  });
+
+  describe('EvidenceProfile', () => {
+    it('renders profile label', () => {
+      render(
+        <AutofixEvidence
+          toolCall={makeToolCall('get_profile_flamegraph')}
+          toolLink={makeToolLink('get_profile_flamegraph', {
+            profile_id: 'prof1234abcd5678',
+            project_id: '1',
+          })}
+        />,
+        {organization}
+      );
+      expect(screen.getByText('Profile: prof1234')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('useAutofixSectionEvidence', () => {
+  it('extracts evidence from blocks with matching tool results', () => {
+    const section = makeSection([
+      makeBlock({
+        message: {
+          content: '',
+          role: 'assistant',
+          tool_calls: [makeToolCall('telemetry_live_search', {}, 'tc-1')],
+        },
+        tool_results: [
+          {
+            tool_call_id: 'tc-1',
+            tool_call_function: 'telemetry_live_search',
+            content: 'results',
+          },
+        ],
+        tool_links: [makeToolLink('telemetry_live_search', {dataset: 'spans'})],
+      }),
+    ]);
+
+    const {result} = renderHookWithProviders(() => useAutofixSectionEvidence({section}));
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].toolCall.id).toBe('tc-1');
+    expect(result.current[0].toolLink?.kind).toBe('telemetry_live_search');
+    expect(result.current[0].toolResult?.tool_call_id).toBe('tc-1');
+  });
+
+  it('extracts multiple evidence items from a single block', () => {
+    const section = makeSection([
+      makeBlock({
+        message: {
+          content: '',
+          role: 'assistant',
+          tool_calls: [
+            makeToolCall('telemetry_live_search', {}, 'tc-1'),
+            makeToolCall('get_trace_waterfall', {}, 'tc-2'),
+          ],
+        },
+        tool_results: [
+          {
+            tool_call_id: 'tc-1',
+            tool_call_function: 'telemetry_live_search',
+            content: 'r1',
+          },
+          {
+            tool_call_id: 'tc-2',
+            tool_call_function: 'get_trace_waterfall',
+            content: 'r2',
+          },
+        ],
+        tool_links: [
+          makeToolLink('telemetry_live_search', {dataset: 'spans'}),
+          makeToolLink('get_trace_waterfall', {trace_id: 'abc'}),
+        ],
+      }),
+    ]);
+
+    const {result} = renderHookWithProviders(() => useAutofixSectionEvidence({section}));
+
+    expect(result.current).toHaveLength(2);
+    expect(result.current[0].toolCall.id).toBe('tc-1');
+    expect(result.current[1].toolCall.id).toBe('tc-2');
+  });
+
+  it('flattens evidence across multiple blocks', () => {
+    const section = makeSection([
+      makeBlock({
+        id: 'b1',
+        message: {
+          content: '',
+          role: 'assistant',
+          tool_calls: [makeToolCall('telemetry_live_search', {}, 'tc-1')],
+        },
+        tool_results: [
+          {
+            tool_call_id: 'tc-1',
+            tool_call_function: 'telemetry_live_search',
+            content: 'r1',
+          },
+        ],
+        tool_links: [makeToolLink('telemetry_live_search', {dataset: 'spans'})],
+      }),
+      makeBlock({
+        id: 'b2',
+        message: {
+          content: '',
+          role: 'assistant',
+          tool_calls: [makeToolCall('get_trace_waterfall', {}, 'tc-2')],
+        },
+        tool_results: [
+          {
+            tool_call_id: 'tc-2',
+            tool_call_function: 'get_trace_waterfall',
+            content: 'r2',
+          },
+        ],
+        tool_links: [makeToolLink('get_trace_waterfall', {trace_id: 'abc'})],
+      }),
+    ]);
+
+    const {result} = renderHookWithProviders(() => useAutofixSectionEvidence({section}));
+
+    expect(result.current).toHaveLength(2);
+  });
+
+  it('returns empty array for empty blocks', () => {
+    const section = makeSection([]);
+
+    const {result} = renderHookWithProviders(() => useAutofixSectionEvidence({section}));
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('returns empty array when blocks have no tool_calls', () => {
+    const section = makeSection([makeBlock({message: {content: '', role: 'assistant'}})]);
+
+    const {result} = renderHookWithProviders(() => useAutofixSectionEvidence({section}));
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('returns empty array when tool_results is undefined', () => {
+    const section = makeSection([
+      makeBlock({
+        message: {
+          content: '',
+          role: 'assistant',
+          tool_calls: [makeToolCall('telemetry_live_search', {}, 'tc-1')],
+        },
+      }),
+    ]);
+
+    const {result} = renderHookWithProviders(() => useAutofixSectionEvidence({section}));
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('sets toolLink to undefined when tool_links array is missing', () => {
+    const section = makeSection([
+      makeBlock({
+        message: {
+          content: '',
+          role: 'assistant',
+          tool_calls: [makeToolCall('telemetry_live_search', {}, 'tc-1')],
+        },
+        tool_results: [
+          {
+            tool_call_id: 'tc-1',
+            tool_call_function: 'telemetry_live_search',
+            content: 'r1',
+          },
+        ],
+      }),
+    ]);
+
+    const {result} = renderHookWithProviders(() => useAutofixSectionEvidence({section}));
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].toolLink).toBeUndefined();
+  });
+});

--- a/static/app/components/events/autofix/v3/autofixEvidence.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.spec.tsx
@@ -293,9 +293,9 @@ describe('useAutofixSectionEvidence', () => {
     const {result} = renderHookWithProviders(() => useAutofixSectionEvidence({section}));
 
     expect(result.current).toHaveLength(1);
-    expect(result.current[0].toolCall.id).toBe('tc-1');
-    expect(result.current[0].toolLink?.kind).toBe('telemetry_live_search');
-    expect(result.current[0].toolResult?.tool_call_id).toBe('tc-1');
+    expect(result.current[0]!.toolCall.id).toBe('tc-1');
+    expect(result.current[0]!.toolLink?.kind).toBe('telemetry_live_search');
+    expect(result.current[0]!.toolResult?.tool_call_id).toBe('tc-1');
   });
 
   it('extracts multiple evidence items from a single block', () => {
@@ -331,8 +331,8 @@ describe('useAutofixSectionEvidence', () => {
     const {result} = renderHookWithProviders(() => useAutofixSectionEvidence({section}));
 
     expect(result.current).toHaveLength(2);
-    expect(result.current[0].toolCall.id).toBe('tc-1');
-    expect(result.current[1].toolCall.id).toBe('tc-2');
+    expect(result.current[0]!.toolCall.id).toBe('tc-1');
+    expect(result.current[1]!.toolCall.id).toBe('tc-2');
   });
 
   it('flattens evidence across multiple blocks', () => {
@@ -429,6 +429,6 @@ describe('useAutofixSectionEvidence', () => {
     const {result} = renderHookWithProviders(() => useAutofixSectionEvidence({section}));
 
     expect(result.current).toHaveLength(1);
-    expect(result.current[0].toolLink).toBeUndefined();
+    expect(result.current[0]!.toolLink).toBeUndefined();
   });
 });

--- a/static/app/components/events/autofix/v3/autofixEvidence.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.spec.tsx
@@ -268,6 +268,130 @@ describe('AutofixEvidence', () => {
       expect(screen.getByText('Profile: prof1234')).toBeInTheDocument();
     });
   });
+
+  describe('EvidenceCodeSearch', () => {
+    it('renders filename for read_file mode', () => {
+      render(
+        <AutofixEvidence
+          toolCall={makeToolCall('code_search', {
+            mode: 'read_file',
+            path: 'src/foo/bar.py',
+          })}
+          toolLink={makeToolLink('code_search', {
+            code_url: 'https://github.com/org/repo/blob/main/src/foo/bar.py',
+          })}
+        />,
+        {organization}
+      );
+      expect(screen.getByText('File: bar.py')).toBeInTheDocument();
+      expect(screen.getByText('File: bar.py').closest('a')).toHaveAttribute(
+        'href',
+        'https://github.com/org/repo/blob/main/src/foo/bar.py'
+      );
+    });
+
+    it('renders truncated filename for read_file mode', () => {
+      render(
+        <AutofixEvidence
+          toolCall={makeToolCall('code_search', {
+            mode: 'read_file',
+            path: 'src/foo/thisisalongfilename.py',
+          })}
+          toolLink={makeToolLink('code_search', {
+            code_url:
+              'https://github.com/org/repo/blob/main/src/foo/thisisalongfilename.py',
+          })}
+        />,
+        {organization}
+      );
+      expect(screen.getByText('File: thisisal\u2026ename.py')).toBeInTheDocument();
+      expect(
+        screen.getByText('File: thisisal\u2026ename.py').closest('a')
+      ).toHaveAttribute(
+        'href',
+        'https://github.com/org/repo/blob/main/src/foo/thisisalongfilename.py'
+      );
+    });
+
+    it('renders nothing when mode is not read_file', () => {
+      const {container} = render(
+        <AutofixEvidence
+          toolCall={makeToolCall('code_search', {mode: 'search', query: 'foo'})}
+          toolLink={makeToolLink('code_search', {
+            code_url: 'https://github.com/org/repo',
+          })}
+        />,
+        {organization}
+      );
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders nothing when mode is missing', () => {
+      const {container} = render(
+        <AutofixEvidence
+          toolCall={makeToolCall('code_search', {path: 'src/foo/bar.py'})}
+          toolLink={makeToolLink('code_search', {
+            code_url: 'https://github.com/org/repo/blob/main/src/foo/bar.py',
+          })}
+        />,
+        {organization}
+      );
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders nothing when toolLink is missing', () => {
+      const {container} = render(
+        <AutofixEvidence
+          toolCall={makeToolCall('code_search', {
+            mode: 'read_file',
+            path: 'src/foo/bar.py',
+          })}
+        />,
+        {organization}
+      );
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders nothing when code_url is missing from toolLink params', () => {
+      const {container} = render(
+        <AutofixEvidence
+          toolCall={makeToolCall('code_search', {
+            mode: 'read_file',
+            path: 'src/foo/bar.py',
+          })}
+          toolLink={makeToolLink('code_search', {})}
+        />,
+        {organization}
+      );
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders nothing when path is missing from args', () => {
+      const {container} = render(
+        <AutofixEvidence
+          toolCall={makeToolCall('code_search', {mode: 'read_file'})}
+          toolLink={makeToolLink('code_search', {
+            code_url: 'https://github.com/org/repo/blob/main/src/foo/bar.py',
+          })}
+        />,
+        {organization}
+      );
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('renders nothing when args is invalid JSON', () => {
+      const {container} = render(
+        <AutofixEvidence
+          toolCall={{id: 'tc-1', function: 'code_search', args: '{invalid json'}}
+          toolLink={makeToolLink('code_search', {
+            code_url: 'https://github.com/org/repo/blob/main/src/foo/bar.py',
+          })}
+        />,
+        {organization}
+      );
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
 });
 
 describe('useAutofixSectionEvidence', () => {

--- a/static/app/components/events/autofix/v3/autofixEvidence.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.tsx
@@ -10,6 +10,8 @@ import {IconPlay} from 'sentry/icons/iconPlay';
 import {IconProfiling} from 'sentry/icons/iconProfiling';
 import {IconSpan} from 'sentry/icons/iconSpan';
 import {t} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
+import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
 import {getShortEventId} from 'sentry/utils/events';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -26,214 +28,17 @@ export function AutofixEvidence({toolCall, toolLink}: AutofixEvidenceProps) {
   const organization = useOrganization();
   const {projects} = useProjects();
 
-  const target = useMemo(() => {
-    if (!defined(toolLink)) {
-      return null;
-    }
-    return buildToolLinkUrl(toolLink, organization.slug, projects);
-  }, [organization, projects, toolLink]);
+  const evidenceProps = useMemo(() => {
+    const resolver = autofixEvidencePropsResolvers[toolCall.function];
+    return resolver?.({organization, projects, toolCall, toolLink}) ?? null;
+  }, [organization, projects, toolCall, toolLink]);
 
-  if (defined(target)) {
-    switch (toolCall.function) {
-      case 'telemetry_live_search': {
-        return (
-          <EvidenceTelemetry target={target} toolCall={toolCall} toolLink={toolLink} />
-        );
-      }
-      case 'get_trace_waterfall': {
-        return <EvidenceTrace target={target} toolCall={toolCall} toolLink={toolLink} />;
-      }
-      case 'get_issue_details': {
-        return <EvidenceIssue target={target} toolCall={toolCall} toolLink={toolLink} />;
-      }
-      case 'get_event_details': {
-        return <EvidenceIssue target={target} toolCall={toolCall} toolLink={toolLink} />;
-      }
-      case 'get_replay_details': {
-        return <EvidenceReplay target={target} toolCall={toolCall} toolLink={toolLink} />;
-      }
-      case 'get_profile_flamegraph': {
-        return (
-          <EvidenceProfile target={target} toolCall={toolCall} toolLink={toolLink} />
-        );
-      }
-    }
-  }
-
-  // some tool calls do generate external links
-  switch (toolCall.function) {
-    case 'code_search': {
-      return <EvidenceCodeSearch toolCall={toolCall} toolLink={toolLink} />;
-    }
-    default:
-      return null;
-  }
-}
-
-interface EvidenceLinkProps {
-  target: LocationDescriptor;
-  toolCall: ToolCall;
-  toolLink?: ToolLink;
-}
-
-function EvidenceTelemetry({target, toolCall, toolLink}: EvidenceLinkProps) {
-  const {args} = toolCall;
-  const {question} = useMemo(() => {
-    try {
-      const parsedArgs = JSON.parse(args) || undefined;
-      return {question: parsedArgs?.question};
-    } catch {
-      return {};
-    }
-  }, [args]);
-
-  const {dataset} = toolLink?.params ?? {};
-  const label = useMemo(() => {
-    switch (dataset) {
-      case 'issues': {
-        return t('Query: Issues');
-      }
-      case 'errors':
-        return t('Query: Errors');
-      case 'logs':
-        return t('Query: Logs');
-      case 'metrics':
-      case 'tracemetrics':
-        return t('Query: Metrics');
-      case 'spans':
-      default:
-        return t('Query: Spans');
-    }
-  }, [dataset]);
-
-  return (
-    <EvidenceButton icon={<IconCompass />} to={target} tooltip={question}>
-      {label}
-    </EvidenceButton>
-  );
-}
-
-function EvidenceTrace({target, toolLink}: EvidenceLinkProps) {
-  const {trace_id, span_id} = toolLink?.params ?? {};
-
-  if (typeof trace_id !== 'string') {
+  if (!defined(evidenceProps)) {
     return null;
   }
 
-  if (defined(span_id) && typeof span_id !== 'string') {
-    return null;
-  }
+  const {label, icon, tooltip, ...rest} = evidenceProps;
 
-  return (
-    <EvidenceButton icon={<IconSpan />} to={target}>
-      {defined(span_id)
-        ? t('Span: %s', getShortEventId(span_id))
-        : t('Trace: %s', getShortEventId(trace_id))}
-    </EvidenceButton>
-  );
-}
-
-function EvidenceIssue({target, toolLink}: EvidenceLinkProps) {
-  const {event_id} = toolLink?.params ?? {};
-
-  if (typeof event_id !== 'string') {
-    return null; // This isn't useful evidence as we're already on the issue details page
-  }
-
-  return (
-    <EvidenceButton icon={<IconIssues />} to={target}>
-      {t('Error: %s', getShortEventId(event_id))}
-    </EvidenceButton>
-  );
-}
-
-function EvidenceReplay({target, toolLink}: EvidenceLinkProps) {
-  const {replay_id} = toolLink?.params ?? {};
-
-  if (typeof replay_id !== 'string') {
-    return null;
-  }
-
-  return (
-    <EvidenceButton icon={<IconPlay />} to={target}>
-      {t('Replay: %s', getShortEventId(replay_id))}
-    </EvidenceButton>
-  );
-}
-
-function EvidenceProfile({target, toolLink}: EvidenceLinkProps) {
-  const {profile_id} = toolLink?.params ?? {};
-
-  if (typeof profile_id !== 'string') {
-    return null;
-  }
-
-  return (
-    <EvidenceButton icon={<IconProfiling />} to={target}>
-      {t('Profile: %s', getShortEventId(profile_id))}
-    </EvidenceButton>
-  );
-}
-
-interface EvidenceCodeSearchProps {
-  toolCall: ToolCall;
-  toolLink?: ToolLink;
-}
-
-function EvidenceCodeSearch({toolCall, toolLink}: EvidenceCodeSearchProps) {
-  const {args} = toolCall;
-  const {mode, path} = useMemo(() => {
-    try {
-      const parsedArgs = JSON.parse(args) || undefined;
-      return {mode: parsedArgs?.mode, path: parsedArgs?.path};
-    } catch {
-      return {};
-    }
-  }, [args]);
-
-  switch (mode) {
-    case 'read_file': {
-      if (typeof path !== 'string') {
-        return null;
-      }
-      const filename = path.split('/').pop();
-      const {code_url} = toolLink?.params ?? {};
-
-      if (!defined(filename) || !defined(code_url)) {
-        return null;
-      }
-
-      return (
-        <EvidenceButton icon={<IconFile />} href={code_url} tooltip={path}>
-          {t('File: %s', truncateText(filename))}
-        </EvidenceButton>
-      );
-    }
-  }
-
-  return null;
-}
-
-interface EvidenceButtonInternalProps {
-  children: ReactNode;
-  icon: ReactNode;
-  to: LocationDescriptor;
-  tooltip?: ReactNode;
-}
-
-interface EvidenceButtonExternalProps {
-  children: ReactNode;
-  href: string;
-  icon: ReactNode;
-  tooltip?: ReactNode;
-}
-
-function EvidenceButton({
-  children,
-  icon,
-  tooltip,
-  ...rest
-}: EvidenceButtonInternalProps | EvidenceButtonExternalProps) {
   if ('to' in rest && defined(rest.to)) {
     return (
       <LinkButton
@@ -242,7 +47,7 @@ function EvidenceButton({
         to={rest.to}
         tooltipProps={tooltip ? {title: tooltip} : undefined}
       >
-        {children}
+        {label}
       </LinkButton>
     );
   }
@@ -256,12 +61,248 @@ function EvidenceButton({
         external
         tooltipProps={tooltip ? {title: tooltip} : undefined}
       >
-        {children}
+        {label}
       </LinkButton>
     );
   }
 
   return null;
+}
+
+interface EvidenceButtonInternalProps {
+  icon: ReactNode;
+  label: ReactNode;
+  to: LocationDescriptor;
+  tooltip?: ReactNode;
+}
+
+interface EvidenceButtonExternalProps {
+  href: string;
+  icon: ReactNode;
+  label: ReactNode;
+  tooltip?: ReactNode;
+}
+
+type EvidenceButtonProps = EvidenceButtonInternalProps | EvidenceButtonExternalProps;
+
+interface GetEvidencePropsPayload {
+  organization: Organization;
+  projects: Project[];
+  toolCall: ToolCall;
+  toolLink?: ToolLink;
+}
+
+function getTelemetryEvidenceProps({
+  organization,
+  projects,
+  toolCall,
+  toolLink,
+}: GetEvidencePropsPayload): EvidenceButtonProps | null {
+  if (!defined(toolLink)) {
+    return null;
+  }
+
+  const target = buildToolLinkUrl(toolLink, organization.slug, projects);
+  if (!defined(target)) {
+    return null;
+  }
+
+  const {question} = parseArgs(toolCall);
+  const {dataset} = toolLink.params ?? {};
+  const label = getTelemetryEvidenceLabel(
+    typeof dataset === 'string' ? dataset : undefined
+  );
+
+  return {
+    to: target,
+    icon: <IconCompass />,
+    label,
+    tooltip: question,
+  };
+}
+
+function getTelemetryEvidenceLabel(dataset?: string) {
+  switch (dataset) {
+    case 'issues': {
+      return t('Query: Issues');
+    }
+    case 'errors':
+      return t('Query: Errors');
+    case 'logs':
+      return t('Query: Logs');
+    case 'metrics':
+    case 'tracemetrics':
+      return t('Query: Metrics');
+    case 'spans':
+    default:
+      return t('Query: Spans');
+  }
+}
+
+function getTraceWaterfallEvidenceProps({
+  organization,
+  projects,
+  toolLink,
+}: GetEvidencePropsPayload): EvidenceButtonProps | null {
+  if (!defined(toolLink)) {
+    return null;
+  }
+
+  const target = buildToolLinkUrl(toolLink, organization.slug, projects);
+  if (!defined(target)) {
+    return null;
+  }
+
+  const {trace_id, span_id} = toolLink.params ?? {};
+
+  if (typeof trace_id !== 'string') {
+    return null;
+  }
+
+  if (defined(span_id) && typeof span_id !== 'string') {
+    return null;
+  }
+
+  const label = defined(span_id)
+    ? t('Span: %s', getShortEventId(span_id))
+    : t('Trace: %s', getShortEventId(trace_id));
+
+  return {
+    to: target,
+    icon: <IconSpan />,
+    label,
+  };
+}
+
+function getIssueDetailsEvidenceProps({
+  organization,
+  projects,
+  toolLink,
+}: GetEvidencePropsPayload): EvidenceButtonProps | null {
+  if (!defined(toolLink)) {
+    return null;
+  }
+
+  const target = buildToolLinkUrl(toolLink, organization.slug, projects);
+  if (!defined(target)) {
+    return null;
+  }
+
+  const {event_id} = toolLink.params ?? {};
+
+  if (typeof event_id !== 'string') {
+    return null; // This isn't useful evidence as we're already on the issue details page
+  }
+
+  return {
+    to: target,
+    icon: <IconIssues />,
+    label: t('Error: %s', getShortEventId(event_id)),
+  };
+}
+
+function getReplayDetailsEvidenceProps({
+  organization,
+  projects,
+  toolLink,
+}: GetEvidencePropsPayload): EvidenceButtonProps | null {
+  if (!defined(toolLink)) {
+    return null;
+  }
+
+  const target = buildToolLinkUrl(toolLink, organization.slug, projects);
+  if (!defined(target)) {
+    return null;
+  }
+
+  const {replay_id} = toolLink.params ?? {};
+
+  if (typeof replay_id !== 'string') {
+    return null;
+  }
+
+  return {
+    to: target,
+    icon: <IconPlay />,
+    label: t('Replay: %s', getShortEventId(replay_id)),
+  };
+}
+
+function getProfileFlamegraphEvidenceProps({
+  organization,
+  projects,
+  toolLink,
+}: GetEvidencePropsPayload): EvidenceButtonProps | null {
+  if (!defined(toolLink)) {
+    return null;
+  }
+
+  const target = buildToolLinkUrl(toolLink, organization.slug, projects);
+  if (!defined(target)) {
+    return null;
+  }
+
+  const {profile_id} = toolLink.params ?? {};
+
+  if (typeof profile_id !== 'string') {
+    return null;
+  }
+
+  return {
+    to: target,
+    icon: <IconProfiling />,
+    label: t('Profile: %s', getShortEventId(profile_id)),
+  };
+}
+
+function getCodeSearchEvidenceProps({
+  toolCall,
+  toolLink,
+}: GetEvidencePropsPayload): EvidenceButtonProps | null {
+  const {mode, path} = parseArgs(toolCall);
+
+  if (mode === 'read_file') {
+    if (typeof path !== 'string') {
+      return null;
+    }
+    const filename = path.split('/').pop();
+    const {code_url} = toolLink?.params ?? {};
+
+    if (!defined(filename) || !defined(code_url)) {
+      return null;
+    }
+
+    return {
+      href: code_url,
+      icon: <IconFile />,
+      label: t('File: %s', truncateText(filename)),
+      tooltip: path,
+    };
+  }
+
+  return null;
+}
+
+const autofixEvidencePropsResolvers: Record<
+  string,
+  (payload: GetEvidencePropsPayload) => EvidenceButtonProps | null
+> = {
+  telemetry_live_search: getTelemetryEvidenceProps,
+  get_trace_waterfall: getTraceWaterfallEvidenceProps,
+  get_issue_details: getIssueDetailsEvidenceProps,
+  get_event_details: getIssueDetailsEvidenceProps,
+  get_replay_details: getReplayDetailsEvidenceProps,
+  get_profile_flamegraph: getProfileFlamegraphEvidenceProps,
+  code_search: getCodeSearchEvidenceProps,
+};
+
+function parseArgs(toolCall: ToolCall): any {
+  try {
+    const parsed = JSON.parse(toolCall.args);
+    return defined(parsed) && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
 }
 
 function truncateText(text: string, maxLength = 16): string {

--- a/static/app/components/events/autofix/v3/autofixEvidence.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.tsx
@@ -3,7 +3,12 @@ import type {LocationDescriptor} from 'history';
 
 import {LinkButton} from '@sentry/scraps/button';
 
-import {IconCompass, IconIssues, IconPlay, IconProfiling, IconSpan} from 'sentry/icons';
+import {IconCompass} from 'sentry/icons/iconCompass';
+import {IconFile} from 'sentry/icons/iconFile';
+import {IconIssues} from 'sentry/icons/iconIssues';
+import {IconPlay} from 'sentry/icons/iconPlay';
+import {IconProfiling} from 'sentry/icons/iconProfiling';
+import {IconSpan} from 'sentry/icons/iconSpan';
 import {t} from 'sentry/locale';
 import {defined} from 'sentry/utils';
 import {getShortEventId} from 'sentry/utils/events';
@@ -28,34 +33,41 @@ export function AutofixEvidence({toolCall, toolLink}: AutofixEvidenceProps) {
     return buildToolLinkUrl(toolLink, organization.slug, projects);
   }, [organization, projects, toolLink]);
 
-  if (!defined(target)) {
-    return null;
+  if (defined(target)) {
+    switch (toolCall.function) {
+      case 'telemetry_live_search': {
+        return (
+          <EvidenceTelemetry target={target} toolCall={toolCall} toolLink={toolLink} />
+        );
+      }
+      case 'get_trace_waterfall': {
+        return <EvidenceTrace target={target} toolCall={toolCall} toolLink={toolLink} />;
+      }
+      case 'get_issue_details': {
+        return <EvidenceIssue target={target} toolCall={toolCall} toolLink={toolLink} />;
+      }
+      case 'get_event_details': {
+        return <EvidenceIssue target={target} toolCall={toolCall} toolLink={toolLink} />;
+      }
+      case 'get_replay_details': {
+        return <EvidenceReplay target={target} toolCall={toolCall} toolLink={toolLink} />;
+      }
+      case 'get_profile_flamegraph': {
+        return (
+          <EvidenceProfile target={target} toolCall={toolCall} toolLink={toolLink} />
+        );
+      }
+    }
   }
 
+  // some tool calls do generate external links
   switch (toolCall.function) {
-    case 'telemetry_live_search': {
-      return (
-        <EvidenceTelemetry target={target} toolCall={toolCall} toolLink={toolLink} />
-      );
+    case 'code_search': {
+      return <EvidenceCodeSearch toolCall={toolCall} toolLink={toolLink} />;
     }
-    case 'get_trace_waterfall': {
-      return <EvidenceTrace target={target} toolCall={toolCall} toolLink={toolLink} />;
-    }
-    case 'get_issue_details': {
-      return <EvidenceIssue target={target} toolCall={toolCall} toolLink={toolLink} />;
-    }
-    case 'get_event_details': {
-      return <EvidenceIssue target={target} toolCall={toolCall} toolLink={toolLink} />;
-    }
-    case 'get_replay_details': {
-      return <EvidenceReplay target={target} toolCall={toolCall} toolLink={toolLink} />;
-    }
-    case 'get_profile_flamegraph': {
-      return <EvidenceProfile target={target} toolCall={toolCall} toolLink={toolLink} />;
-    }
+    default:
+      return null;
   }
-
-  return null;
 }
 
 interface EvidenceLinkProps {
@@ -66,11 +78,12 @@ interface EvidenceLinkProps {
 
 function EvidenceTelemetry({target, toolCall, toolLink}: EvidenceLinkProps) {
   const {args} = toolCall;
-  const question = useMemo(() => {
+  const {question} = useMemo(() => {
     try {
-      return JSON.parse(args).question || undefined;
+      const parsedArgs = JSON.parse(args) || undefined;
+      return {question: parsedArgs?.question};
     } catch {
-      return undefined;
+      return {};
     }
   }, [args]);
 
@@ -144,6 +157,45 @@ function EvidenceProfile({target, toolLink}: EvidenceLinkProps) {
   );
 }
 
+interface EvidenceCodeSearchProps {
+  toolCall: ToolCall;
+  toolLink?: ToolLink;
+}
+
+function EvidenceCodeSearch({toolCall, toolLink}: EvidenceCodeSearchProps) {
+  const {args} = toolCall;
+  const {mode, path} = useMemo(() => {
+    try {
+      const parsedArgs = JSON.parse(args) || undefined;
+      return {mode: parsedArgs?.mode, path: parsedArgs?.path};
+    } catch {
+      return {};
+    }
+  }, [args]);
+
+  switch (mode) {
+    case 'read_file': {
+      if (typeof path !== 'string') {
+        return null;
+      }
+      const filename = path.split('/').pop();
+      const {code_url} = toolLink?.params ?? {};
+
+      if (!defined(filename) || !defined(code_url)) {
+        return null;
+      }
+
+      return (
+        <EvidenceButton icon={<IconFile />} href={code_url} tooltip={path}>
+          {t('File: %s', truncateText(filename))}
+        </EvidenceButton>
+      );
+    }
+  }
+
+  return null;
+}
+
 interface EvidenceButtonInternalProps {
   children: ReactNode;
   icon: ReactNode;
@@ -192,4 +244,12 @@ function EvidenceButton({
   }
 
   return null;
+}
+
+function truncateText(text: string, maxLength = 16): string {
+  const length = text.length;
+  if (length <= maxLength) {
+    return text;
+  }
+  return `${text.substring(0, maxLength / 2)}\u2026${text.substring(length - maxLength / 2, length)}`;
 }

--- a/static/app/components/events/autofix/v3/autofixEvidence.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.tsx
@@ -116,6 +116,14 @@ function EvidenceTelemetry({target, toolCall, toolLink}: EvidenceLinkProps) {
 function EvidenceTrace({target, toolLink}: EvidenceLinkProps) {
   const {trace_id, span_id} = toolLink?.params ?? {};
 
+  if (typeof trace_id !== 'string') {
+    return null;
+  }
+
+  if (defined(span_id) && typeof span_id !== 'string') {
+    return null;
+  }
+
   return (
     <EvidenceButton icon={<IconSpan />} to={target}>
       {defined(span_id)
@@ -128,7 +136,7 @@ function EvidenceTrace({target, toolLink}: EvidenceLinkProps) {
 function EvidenceIssue({target, toolLink}: EvidenceLinkProps) {
   const {event_id} = toolLink?.params ?? {};
 
-  if (!defined(event_id)) {
+  if (typeof event_id !== 'string') {
     return null; // This isn't useful evidence as we're already on the issue details page
   }
 
@@ -141,6 +149,11 @@ function EvidenceIssue({target, toolLink}: EvidenceLinkProps) {
 
 function EvidenceReplay({target, toolLink}: EvidenceLinkProps) {
   const {replay_id} = toolLink?.params ?? {};
+
+  if (typeof replay_id !== 'string') {
+    return null;
+  }
+
   return (
     <EvidenceButton icon={<IconPlay />} to={target}>
       {t('Replay: %s', getShortEventId(replay_id))}
@@ -150,6 +163,11 @@ function EvidenceReplay({target, toolLink}: EvidenceLinkProps) {
 
 function EvidenceProfile({target, toolLink}: EvidenceLinkProps) {
   const {profile_id} = toolLink?.params ?? {};
+
+  if (typeof profile_id !== 'string') {
+    return null;
+  }
+
   return (
     <EvidenceButton icon={<IconProfiling />} to={target}>
       {t('Profile: %s', getShortEventId(profile_id))}

--- a/static/app/components/events/autofix/v3/autofixEvidence.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.tsx
@@ -121,9 +121,7 @@ function EvidenceIssue({target, toolLink}: EvidenceLinkProps) {
 
   return (
     <EvidenceButton icon={<IconIssues />} to={target}>
-      {defined(event_id)
-        ? t('Error: %s', getShortEventId(event_id))
-        : t('Issue: %s', issue_id)}
+      {t('Issue: %s', issue_id)}
     </EvidenceButton>
   );
 }

--- a/static/app/components/events/autofix/v3/autofixEvidence.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.tsx
@@ -1,0 +1,197 @@
+import {type ReactNode, useMemo} from 'react';
+import type {LocationDescriptor} from 'history';
+
+import {LinkButton} from '@sentry/scraps/button';
+
+import {IconCompass, IconIssues, IconPlay, IconProfiling, IconSpan} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {defined} from 'sentry/utils';
+import {getShortEventId} from 'sentry/utils/events';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {useProjects} from 'sentry/utils/useProjects';
+import type {ToolCall, ToolLink} from 'sentry/views/seerExplorer/types';
+import {buildToolLinkUrl} from 'sentry/views/seerExplorer/utils';
+
+interface AutofixEvidenceProps {
+  toolCall: ToolCall;
+  toolLink?: ToolLink;
+}
+
+export function AutofixEvidence({toolCall, toolLink}: AutofixEvidenceProps) {
+  const organization = useOrganization();
+  const {projects} = useProjects();
+
+  const target = useMemo(() => {
+    if (!defined(toolLink)) {
+      return null;
+    }
+    return buildToolLinkUrl(toolLink, organization.slug, projects);
+  }, [organization, projects, toolLink]);
+
+  if (!defined(target)) {
+    return null;
+  }
+
+  switch (toolCall.function) {
+    case 'telemetry_live_search': {
+      return (
+        <EvidenceTelemetry target={target} toolCall={toolCall} toolLink={toolLink} />
+      );
+    }
+    case 'get_trace_waterfall': {
+      return <EvidenceTrace target={target} toolCall={toolCall} toolLink={toolLink} />;
+    }
+    case 'get_issue_details': {
+      return <EvidenceIssue target={target} toolCall={toolCall} toolLink={toolLink} />;
+    }
+    case 'get_event_details': {
+      return <EvidenceIssue target={target} toolCall={toolCall} toolLink={toolLink} />;
+    }
+    case 'get_replay_details': {
+      return <EvidenceReplay target={target} toolCall={toolCall} toolLink={toolLink} />;
+    }
+    case 'get_profile_flamegraph': {
+      return <EvidenceProfile target={target} toolCall={toolCall} toolLink={toolLink} />;
+    }
+  }
+
+  return null;
+}
+
+interface EvidenceLinkProps {
+  target: LocationDescriptor;
+  toolCall: ToolCall;
+  toolLink?: ToolLink;
+}
+
+function EvidenceTelemetry({target, toolCall, toolLink}: EvidenceLinkProps) {
+  const {args} = toolCall;
+  const question = useMemo(() => {
+    try {
+      return JSON.parse(args).question || undefined;
+    } catch {
+      return undefined;
+    }
+  }, [args]);
+
+  const {dataset} = toolLink?.params ?? {};
+  const label = useMemo(() => {
+    switch (dataset) {
+      case 'issues': {
+        return t('Query: Issues');
+      }
+      case 'errors':
+        return t('Query: Errors');
+      case 'logs':
+        return t('Query: Logs');
+      case 'metrics':
+      case 'tracemetrics':
+        return t('Query: Metrics');
+      case 'spans':
+      default:
+        return t('Query: Spans');
+    }
+  }, [dataset]);
+
+  return (
+    <EvidenceButton icon={<IconCompass />} to={target} tooltip={question}>
+      {label}
+    </EvidenceButton>
+  );
+}
+
+function EvidenceTrace({target, toolLink}: EvidenceLinkProps) {
+  const {trace_id, span_id} = toolLink?.params ?? {};
+
+  return (
+    <EvidenceButton icon={<IconSpan />} to={target}>
+      {defined(span_id)
+        ? t('Span: %s', getShortEventId(span_id))
+        : t('Trace: %s', getShortEventId(trace_id))}
+    </EvidenceButton>
+  );
+}
+
+function EvidenceIssue({target, toolLink}: EvidenceLinkProps) {
+  const {issue_id, event_id} = toolLink?.params ?? {};
+
+  if (!defined(event_id)) {
+    return null; // This isn't useful evidence as we're already on the issue details page
+  }
+
+  return (
+    <EvidenceButton icon={<IconIssues />} to={target}>
+      {defined(event_id)
+        ? t('Error: %s', getShortEventId(event_id))
+        : t('Issue: %s', issue_id)}
+    </EvidenceButton>
+  );
+}
+
+function EvidenceReplay({target, toolLink}: EvidenceLinkProps) {
+  const {replay_id} = toolLink?.params ?? {};
+  return (
+    <EvidenceButton icon={<IconPlay />} to={target}>
+      {t('Replay: %s', getShortEventId(replay_id))}
+    </EvidenceButton>
+  );
+}
+
+function EvidenceProfile({target, toolLink}: EvidenceLinkProps) {
+  const {profile_id} = toolLink?.params ?? {};
+  return (
+    <EvidenceButton icon={<IconProfiling />} to={target}>
+      {t('Profile: %s', getShortEventId(profile_id))}
+    </EvidenceButton>
+  );
+}
+
+interface EvidenceButtonInternalProps {
+  children: ReactNode;
+  icon: ReactNode;
+  to: LocationDescriptor;
+  tooltip?: ReactNode;
+}
+
+interface EvidenceButtonExternalProps {
+  children: ReactNode;
+  href: string;
+  icon: ReactNode;
+  tooltip?: ReactNode;
+}
+
+function EvidenceButton({
+  children,
+  icon,
+  tooltip,
+  ...rest
+}: EvidenceButtonInternalProps | EvidenceButtonExternalProps) {
+  if ('to' in rest && defined(rest.to)) {
+    return (
+      <LinkButton
+        icon={icon}
+        size="zero"
+        to={rest.to}
+        tooltipProps={tooltip ? {title: tooltip} : undefined}
+      >
+        {children}
+      </LinkButton>
+    );
+  }
+
+  if ('href' in rest && defined(rest.href)) {
+    return (
+      <LinkButton
+        icon={icon}
+        size="zero"
+        href={rest.href}
+        external
+        tooltipProps={tooltip ? {title: tooltip} : undefined}
+      >
+        {children}
+      </LinkButton>
+    );
+  }
+
+  return null;
+}

--- a/static/app/components/events/autofix/v3/autofixEvidence.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.tsx
@@ -113,7 +113,7 @@ function EvidenceTrace({target, toolLink}: EvidenceLinkProps) {
 }
 
 function EvidenceIssue({target, toolLink}: EvidenceLinkProps) {
-  const {issue_id, event_id} = toolLink?.params ?? {};
+  const {event_id} = toolLink?.params ?? {};
 
   if (!defined(event_id)) {
     return null; // This isn't useful evidence as we're already on the issue details page
@@ -121,7 +121,7 @@ function EvidenceIssue({target, toolLink}: EvidenceLinkProps) {
 
   return (
     <EvidenceButton icon={<IconIssues />} to={target}>
-      {t('Issue: %s', issue_id)}
+      {t('Error: %s', getShortEventId(event_id))}
     </EvidenceButton>
   );
 }

--- a/static/app/components/events/autofix/v3/autofixPreviews.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixPreviews.spec.tsx
@@ -26,7 +26,7 @@ function makeSection(
   artifacts: any[] = [],
   {status}: {status: 'completed' | 'processing'} = {status: 'completed'}
 ): AutofixSection {
-  return {step, artifacts, messages: [], status};
+  return {step, artifacts, blocks: [], status};
 }
 
 describe('RootCausePreview', () => {

--- a/static/app/components/events/autofix/v3/nextStep.spec.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.spec.tsx
@@ -91,7 +91,7 @@ function makeSection(
   return {
     step,
     artifacts: artifacts ?? defaultArtifacts(step),
-    messages: [],
+    blocks: [],
     status: 'completed',
   };
 }

--- a/static/app/components/events/autofix/v3/useAutofixSectionEvidence.tsx
+++ b/static/app/components/events/autofix/v3/useAutofixSectionEvidence.tsx
@@ -1,0 +1,41 @@
+import {useMemo} from 'react';
+
+import type {AutofixSection} from 'sentry/components/events/autofix/useExplorerAutofix';
+import {defined} from 'sentry/utils';
+import type {ToolCall, ToolLink, ToolResult} from 'sentry/views/seerExplorer/types';
+
+interface Evidence {
+  toolCall: ToolCall;
+  toolLink?: ToolLink;
+  toolResult?: ToolResult;
+}
+
+interface UseAutofixSectionEvidence {
+  section: AutofixSection;
+}
+
+export function useAutofixSectionEvidence({section}: UseAutofixSectionEvidence) {
+  return useMemo(() => {
+    return section.blocks.flatMap(block => {
+      const evidence: Evidence[] = [];
+
+      for (const toolCall of block.message.tool_calls ?? []) {
+        const index = block.tool_results?.findIndex(
+          toolResult => toolResult?.tool_call_id === toolCall.id
+        );
+        if (!defined(index)) {
+          continue;
+        }
+        const toolLink = block.tool_links?.[index] ?? undefined;
+        const toolResult = block.tool_results?.[index] ?? undefined;
+        evidence.push({
+          toolCall,
+          toolLink,
+          toolResult,
+        });
+      }
+
+      return evidence;
+    });
+  }, [section.blocks]);
+}


### PR DESCRIPTION
This takes all the tool calls that happened within a section and render that as the evidence so users can click through to see what the agent examined before arriving at the conclusion.

# Examples

<img width="733" height="96" alt="image" src="https://github.com/user-attachments/assets/72301aaf-155a-4a87-92db-d32a2c4e0984" />
