### PR TITLE
fix(cmdk): Defer state reset until close animation completes

### DIFF
--- a/static/app/components/commandPalette/ui/commandPalette.spec.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.spec.tsx
@@ -1040,6 +1040,78 @@ describe('CommandPalette', () => {
     });
   });
 
+  describe('deferred reset on close', () => {
+    // Top-level CMDKActions with children render as section headers (disabled),
+    // so to get a drillable item we nest the target group one level deeper.
+    // "Section" becomes a disabled header; "Drillable Group" is a selectable
+    // item that pushes onto the nav stack when clicked.
+    function ToggleablePalette({showPalette}: {showPalette: boolean}) {
+      return (
+        <CommandPaletteProvider>
+          <CMDKAction display={{label: 'Section'}}>
+            <CMDKAction display={{label: 'Drillable Group'}}>
+              <CMDKAction onAction={jest.fn()} display={{label: 'Child Action'}} />
+            </CMDKAction>
+          </CMDKAction>
+          <CMDKAction to="/root/" display={{label: 'Root Action'}} />
+          {showPalette && <CommandPalette closeModal={jest.fn()} />}
+        </CommandPaletteProvider>
+      );
+    }
+
+    it('does not reset items immediately when a leaf action is triggered', async () => {
+      render(<ToggleablePalette showPalette />);
+
+      await userEvent.click(await screen.findByRole('option', {name: 'Drillable Group'}));
+      await screen.findByRole('option', {name: 'Child Action'});
+      await userEvent.click(screen.getByRole('option', {name: 'Child Action'}));
+
+      // pendingReset is set but the component is still mounted, so items must not
+      // swap back to the root list before the exit animation has completed
+      expect(screen.getByRole('option', {name: 'Child Action'})).toBeInTheDocument();
+      expect(screen.queryByRole('option', {name: 'Root Action'})).not.toBeInTheDocument();
+    });
+
+    it('resets action and query when the component unmounts after triggering an action', async () => {
+      const {rerender} = render(<ToggleablePalette showPalette />);
+
+      await userEvent.click(await screen.findByRole('option', {name: 'Drillable Group'}));
+      await userEvent.click(await screen.findByRole('option', {name: 'Child Action'}));
+
+      // Unmount simulates the exit animation completing and React removing the element
+      rerender(<ToggleablePalette showPalette={false} />);
+
+      // Remount — state should have been reset by the cleanup effect
+      rerender(<ToggleablePalette showPalette />);
+
+      expect(
+        await screen.findByRole('option', {name: 'Root Action'})
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('option', {name: 'Child Action'})
+      ).not.toBeInTheDocument();
+    });
+
+    it('preserves state when closed without triggering an action', async () => {
+      const {rerender} = render(<ToggleablePalette showPalette />);
+
+      // Drill into the group but do not select a leaf action
+      await userEvent.click(await screen.findByRole('option', {name: 'Drillable Group'}));
+      await screen.findByRole('option', {name: 'Child Action'});
+
+      // Unmount (user dismissed the palette without selecting anything)
+      rerender(<ToggleablePalette showPalette={false} />);
+
+      // Remount — state should be preserved (no pendingReset was set)
+      rerender(<ToggleablePalette showPalette />);
+
+      expect(
+        await screen.findByRole('option', {name: 'Child Action'})
+      ).toBeInTheDocument();
+      expect(screen.queryByRole('option', {name: 'Root Action'})).not.toBeInTheDocument();
+    });
+  });
+
   describe('slot rendering', () => {
     it('task slot action is displayed in the palette', async () => {
       render(

--- a/static/app/components/commandPalette/ui/commandPalette.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.tsx
@@ -279,6 +279,20 @@ export function CommandPalette(props: CommandPaletteProps) {
     [actions, analytics, closeModal, dispatch, navigate, prefixMap, state.query]
   );
 
+  // Dispatch the deferred reset once the close animation finishes. framer-motion
+  // only unmounts this component after the exit animation completes, so the
+  // cleanup runs at exactly the right time. If the user re-opens the palette
+  // before the animation ends, the component stays mounted and nothing fires.
+  const pendingResetRef = useRef(state.pendingReset);
+  pendingResetRef.current = state.pendingReset;
+  useEffect(() => {
+    return () => {
+      if (pendingResetRef.current) {
+        dispatch({type: 'reset'});
+      }
+    };
+  }, [dispatch]);
+
   const resultsListRef = useRef<HTMLDivElement>(null);
   const modifierKeysRef = useRef({shiftKey: false});
 

--- a/static/app/components/commandPalette/ui/commandPaletteStateContext.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteStateContext.tsx
@@ -23,6 +23,10 @@ export type CommandPaletteState = {
   action: CMDKNavStack | null;
   input: React.RefObject<HTMLInputElement | null>;
   open: boolean;
+  // When true, action and query are cleared the next time the modal opens.
+  // Set by 'trigger action' so the close animation plays without a jarring
+  // content swap, while still ensuring a clean slate on the next open.
+  pendingReset: boolean;
   query: string;
 };
 
@@ -62,6 +66,7 @@ function commandPaletteReducer(
         ...state,
         action: null,
         query: '',
+        pendingReset: false,
       };
     case 'set query':
       return {...state, query: action.query};
@@ -86,7 +91,7 @@ function commandPaletteReducer(
         query: state.action?.value?.query ?? state.query,
       };
     case 'trigger action':
-      return {...state, action: null, query: ''};
+      return {...state, pendingReset: true};
     default:
       unreachable(type);
       return state;
@@ -124,6 +129,7 @@ export function CommandPaletteStateProvider({
     query: '',
     action: null,
     open: false,
+    pendingReset: false,
   });
 
   return (


### PR DESCRIPTION
## Summary

When a leaf action was selected in the command palette, `trigger action` was dispatched synchronously — clearing `action` and `query` before `closeModal` was called. This caused the item list to visibly swap back to the root state while the 120ms framer-motion exit animation was still running, producing a jarring content jump during close.

**How it works now:**

- `trigger action` only sets a `pendingReset: true` flag on the state, leaving the visible items unchanged. The close animation plays against the same items the user interacted with.
- A cleanup `useEffect` in `CommandPalette` dispatches `reset` on unmount. Since framer-motion only unmounts the component after the exit animation finishes, the reset fires at exactly the right moment.
- If the user re-opens the palette before the animation ends, framer-motion keeps the component mounted — the cleanup never fires and the in-progress state is preserved.
- The `reset` action (X button) also clears `pendingReset`, so a manual reset followed by a close doesn't double-reset on unmount.