### PR TITLE
ref(seer): Read project preferences only from Sentry DB, part 1

### DIFF
--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -35,16 +35,12 @@ from sentry.seer.autofix.types import (
 )
 from sentry.seer.autofix.utils import (
     AutofixStoppingPoint,
-    get_org_default_seer_automation_handoff,
-    get_project_seer_preferences,
     make_autofix_start_request,
     make_autofix_update_request,
     read_preference_from_sentry_db,
-    set_project_seer_preference,
-    write_preference_to_sentry_db,
 )
 from sentry.seer.explorer.utils import _convert_profile_to_execution_tree, fetch_profile_data
-from sentry.seer.models import SeerApiError, SeerApiResponseValidationError, SeerProjectPreference
+from sentry.seer.models import SeerProjectPreference
 from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.seer.utils import get_github_username_for_user
 from sentry.services import eventstore
@@ -460,7 +456,7 @@ def _call_autofix(
     *,
     user: User | AnonymousUser | RpcUser,
     group: Group,
-    repos: list[dict],
+    preference: SeerProjectPreference,
     serialized_event: dict[str, Any],
     profile: dict[str, Any] | None,
     trace_tree: dict[str, Any] | None,
@@ -473,13 +469,13 @@ def _call_autofix(
     auto_run_source: str | None = None,
     stopping_point: AutofixStoppingPoint | None = None,
     github_username: str | None = None,
-    preference: SeerProjectPreference | None = None,
 ):
     body = orjson.dumps(
         {
             "organization_id": group.organization.id,
             "project_id": group.project.id,
-            "repos": repos,
+            "preference": preference.dict(),
+            "repos": [repo.dict() for repo in preference.repositories],
             "issue": {
                 "id": group.id,
                 "title": group.title,
@@ -512,7 +508,6 @@ def _call_autofix(
                 ),
                 "stopping_point": stopping_point.value if stopping_point else None,
             },
-            "preference": preference.dict() if preference else None,
         },
         option=orjson.OPT_NON_STR_KEYS,
     )
@@ -636,61 +631,6 @@ def get_all_tags_overview(
     }
 
 
-def _resolve_project_preference(
-    organization: Organization, project: Project
-) -> SeerProjectPreference | None:
-    """
-    Resolve the Seer project preference for a project before triggering autofix.
-
-    Returns the existing preference if one exists. If not, creates a new one
-    with empty repos and org default settings.
-    """
-    if features.has("organizations:seer-project-settings-read-from-sentry", organization):
-        return read_preference_from_sentry_db(project)
-
-    try:
-        preference = get_project_seer_preferences(project.id).preference
-        if preference:
-            return preference
-    except (SeerApiError, SeerApiResponseValidationError):
-        logger.exception(
-            "seer.resolve_project_preference.get_failed",
-            extra={"project_id": project.id, "organization_id": organization.id},
-        )
-        return None
-
-    # No preference exists — create one with org defaults.
-    default_stopping_point, default_handoff = get_org_default_seer_automation_handoff(organization)
-    preference = SeerProjectPreference(
-        organization_id=organization.id,
-        project_id=project.id,
-        repositories=[],
-        automated_run_stopping_point=default_stopping_point,
-        automation_handoff=default_handoff,
-    )
-
-    try:
-        set_project_seer_preference(preference)
-    except (SeerApiError, SeerApiResponseValidationError):
-        logger.exception(
-            "seer.resolve_project_preference.set_failed",
-            extra={"project_id": project.id, "organization_id": organization.id},
-        )
-        return None
-
-    if features.has("organizations:seer-project-settings-dual-write", organization):
-        try:
-            write_preference_to_sentry_db(project, preference)
-        except Exception:
-            logger.exception(
-                "seer.resolve_project_preference.write_failed",
-                extra={"project_id": project.id, "organization_id": organization.id},
-                exc_info=True,
-            )
-
-    return preference
-
-
 def trigger_autofix(
     *,
     group: Group,
@@ -738,13 +678,7 @@ def trigger_autofix(
 
     code_mappings = get_sorted_code_mapping_configs(group.project)
 
-    # Resolve the project preference, or create a new one with org defaults.
-    # Preference repos are the source of truth (even if empty).
-    preference = _resolve_project_preference(group.organization, group.project)
-    if preference:
-        repos = [repo.dict() for repo in preference.repositories]
-    else:
-        repos = []
+    preference = read_preference_from_sentry_db(group.project)
 
     # Pre-resolve stacktrace frame paths using code mappings so Seer can skip
     # expensive git tree fetches for large repos.
@@ -790,7 +724,7 @@ def trigger_autofix(
         run_id = _call_autofix(
             user=user,
             group=group,
-            repos=repos,
+            preference=preference,
             serialized_event=serialized_event,
             profile=profile,
             trace_tree=trace_tree,
@@ -803,7 +737,6 @@ def trigger_autofix(
             auto_run_source=auto_run_source,
             stopping_point=stopping_point,
             github_username=github_username,
-            preference=preference,
         )
     except Exception:
         logger.exception("Failed to send autofix to seer")

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -842,43 +842,6 @@ def bulk_read_preferences_from_sentry_db(
     return result
 
 
-def bulk_read_preferences(
-    organization: Organization, project_ids: list[int]
-) -> dict[int, SeerProjectPreference | None]:
-    """Read Seer project preferences in bulk, using the correct source based on feature flag.
-
-    Always returns ``dict[int, SeerProjectPreference | None]`` regardless of the
-    underlying read path (Sentry DB or Seer API)."""
-    if features.has("organizations:seer-project-settings-read-from-sentry", organization):
-        return bulk_read_preferences_from_sentry_db(organization.id, project_ids)  # type: ignore[return-value]
-
-    raw = bulk_get_project_preferences(organization.id, project_ids)
-    tuning_by_id = ProjectOption.objects.get_value_bulk_id(
-        project_ids, "sentry:autofix_automation_tuning"
-    )
-    result: dict[int, SeerProjectPreference | None] = {}
-    for pid, data in raw.items():
-        int_pid = int(pid)
-        if data is None:
-            result[int_pid] = None
-            continue
-        try:
-            pref = SeerProjectPreference.validate(data)
-        except pydantic.ValidationError:
-            logger.exception(
-                "seer.bulk_read_preferences.validation_error",
-                extra={"project_id": pid, "organization_id": organization.id},
-            )
-            result[int_pid] = None
-            continue
-        tuning = tuning_by_id.get(int_pid)
-        if tuning is None:
-            tuning = projectoptions.get_well_known_default("sentry:autofix_automation_tuning")
-        pref.autofix_automation_tuning = tuning
-        result[int_pid] = pref
-    return result
-
-
 def set_project_seer_preference(preference: SeerProjectPreference) -> None:
     """Set Seer project preference for a single project via Seer API."""
     response = make_set_project_preference_request(
@@ -890,35 +853,15 @@ def set_project_seer_preference(preference: SeerProjectPreference) -> None:
         raise SeerApiError(response.data.decode("utf-8"), response.status)
 
 
-def has_project_connected_repos(
-    organization: Organization, project: Project, *, skip_cache: bool = False
-) -> bool:
-    """
-    Check if a project has connected repositories for Seer automation.
-    Results are cached for 15 minutes to minimize API calls.
-    """
-    cache_key = f"seer-project-has-repos:{organization.id}:{project.id}"
-    if not skip_cache:
-        cached_value = cache.get(cache_key)
-        if cached_value is not None:
-            return cached_value
-
-    has_repos = False
-    if features.has("organizations:seer-project-settings-read-from-sentry", organization):
-        has_repos = bool(read_preference_from_sentry_db(project).repositories)
-    else:
-        try:
-            preference = get_project_seer_preferences(project.id).preference
-            has_repos = bool(preference and preference.repositories)
-        except (SeerApiError, SeerApiResponseValidationError):
-            pass
-
+def has_project_connected_repos(organization: Organization, project: Project) -> bool:
+    """Check if a project has connected repositories for Seer automation."""
+    has_repos = SeerProjectRepository.objects.filter(
+        project=project, project__status=ObjectStatus.ACTIVE
+    ).exists()
     logger.info(
         "Checking if project has repositories connected",
         extra={"org_id": organization.id, "project_id": project.id, "has_repos": has_repos},
     )
-
-    cache.set(cache_key, has_repos, timeout=60 * 15)  # Cache for 15 minutes
     return has_repos
 
 

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -856,7 +856,9 @@ def set_project_seer_preference(preference: SeerProjectPreference) -> None:
 def has_project_connected_repos(organization: Organization, project: Project) -> bool:
     """Check if a project has connected repositories for Seer automation."""
     return SeerProjectRepository.objects.filter(
-        project=project, project__status=ObjectStatus.ACTIVE
+        project=project,
+        project__organization_id=organization.id,
+        project__status=ObjectStatus.ACTIVE,
     ).exists()
 
 

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -855,14 +855,9 @@ def set_project_seer_preference(preference: SeerProjectPreference) -> None:
 
 def has_project_connected_repos(organization: Organization, project: Project) -> bool:
     """Check if a project has connected repositories for Seer automation."""
-    has_repos = SeerProjectRepository.objects.filter(
+    return SeerProjectRepository.objects.filter(
         project=project, project__status=ObjectStatus.ACTIVE
     ).exists()
-    logger.info(
-        "Checking if project has repositories connected",
-        extra={"org_id": organization.id, "project_id": project.id, "has_repos": has_repos},
-    )
-    return has_repos
 
 
 def bulk_get_project_preferences(

--- a/src/sentry/seer/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/seer/endpoints/group_autofix_setup_check.py
@@ -154,11 +154,8 @@ class GroupAutofixSetupCheck(GroupAiEndpoint):
         # Check if org has github integration and is on seat-based tier.
         if integration_check is None:
             try:
-                # Check if project has repos linked in Seer.
-                # Skip cache to ensure latest data from Seer API.
-                seer_repos_linked = has_project_connected_repos(org, group.project, skip_cache=True)
+                seer_repos_linked = has_project_connected_repos(org, group.project)
             except Exception as e:
-                # Default to False if we can't check if the project has repos linked in Seer.
                 sentry_sdk.capture_exception(e)
 
         autofix_enabled = False

--- a/src/sentry/seer/endpoints/project_seer_preferences.py
+++ b/src/sentry/seer/endpoints/project_seer_preferences.py
@@ -15,11 +15,9 @@ from sentry.api.serializers.rest_framework import CamelSnakeSerializer
 from sentry.models.project import Project
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.seer.autofix.utils import (
-    GetProjectPreferenceRequest,
     SetProjectPreferenceRequest,
     deduplicate_repositories,
     get_autofix_repos_from_project_code_mappings,
-    make_get_project_preference_request,
     make_set_project_preference_request,
     read_preference_from_sentry_db,
     write_preference_to_sentry_db,
@@ -153,26 +151,7 @@ class ProjectSeerPreferencesEndpoint(ProjectEndpoint):
         return Response(status=204)
 
     def get(self, request: Request, project: Project) -> Response:
-        if features.has(
-            "organizations:seer-project-settings-read-from-sentry", project.organization
-        ):
-            preference = read_preference_from_sentry_db(project)
-        else:
-            body = GetProjectPreferenceRequest(project_id=project.id)
-            viewer_context = SeerViewerContext(
-                organization_id=project.organization.id, user_id=request.user.id
-            )
-            response = make_get_project_preference_request(
-                body,
-                connection_pool=seer_autofix_default_connection_pool,
-                viewer_context=viewer_context,
-            )
-
-            if response.status >= 400:
-                raise SeerApiError("Seer request failed", response.status)
-
-            result = response.json()
-            preference = result.get("preference")
+        preference = read_preference_from_sentry_db(project)
 
         code_mapping_repos = get_autofix_repos_from_project_code_mappings(project)
 

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -89,9 +89,6 @@ from sentry.seer.autofix.utils import (
     resolve_repository_ids,
     write_preference_to_sentry_db,
 )
-from sentry.seer.autofix.utils import (
-    bulk_get_project_preferences as bulk_get_project_seer_preferences,
-)
 from sentry.seer.constants import SEER_SUPPORTED_SCM_PROVIDERS, SeerSCMProvider
 from sentry.seer.entrypoints.operator import SeerAutofixOperator, process_autofix_updates
 from sentry.seer.explorer.custom_tool_utils import call_custom_tool
@@ -877,39 +874,26 @@ def check_repository_integrations_status(*, repository_integrations: list[dict[s
     return {"integration_ids": integration_ids}
 
 
-def get_project_preferences(*, organization_id: int, project_id: int) -> dict | None:
+def get_project_preferences(*, organization_id: int, project_id: int) -> dict:
     """Get Seer project preferences for a single project.
 
     Raises Project.DoesNotExist if the project is not found or doesn't belong to the org.
-    Returns None if the project has no preference row in Seer DB.
     """
     project = Project.objects.get_from_cache(id=project_id)
     if project.organization_id != organization_id:
         raise Project.DoesNotExist
 
-    organization = Organization.objects.get_from_cache(id=organization_id)
-    if features.has("organizations:seer-project-settings-read-from-sentry", organization):
-        return read_preference_from_sentry_db(project).dict()
-
-    preference = get_project_seer_preferences(project_id).preference
-    return preference.dict() if preference else None
+    return read_preference_from_sentry_db(project).dict()
 
 
-def bulk_get_project_preferences(*, organization_id: int, project_ids: list[int]) -> dict:
-    """Bulk get Seer project preferences.
+def bulk_get_project_preferences(
+    *, organization_id: int, project_ids: list[int]
+) -> dict[str, dict]:
+    """Bulk get Seer project preferences, keyed by stringified project ID.
 
-    Returns a dict keyed by stringified project ID. Values are preference dicts or None
-    for projects with no configured preferences.
-    """
-    organization = Organization.objects.get_from_cache(id=organization_id)
-    if features.has("organizations:seer-project-settings-read-from-sentry", organization):
-        preferences = bulk_read_preferences_from_sentry_db(organization_id, project_ids)
-        return {
-            str(project_id): preference.dict() if preference else None
-            for project_id, preference in preferences.items()
-        }
-
-    return bulk_get_project_seer_preferences(organization_id, project_ids)
+    Projects not belonging to the given organization are silently skipped."""
+    preferences = bulk_read_preferences_from_sentry_db(organization_id, project_ids)
+    return {str(project_id): pref.dict() for project_id, pref in preferences.items()}
 
 
 seer_method_registry: dict[str, Callable] = {  # return type must be serialized

--- a/src/sentry/tasks/seer/context_engine_index.py
+++ b/src/sentry/tasks/seer/context_engine_index.py
@@ -15,7 +15,6 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.search.events.types import SnubaParams
 from sentry.seer.autofix.utils import (
-    bulk_get_project_preferences,
     bulk_read_preferences_from_sentry_db,
     get_autofix_repos_from_project_code_mappings,
 )
@@ -258,45 +257,34 @@ def index_repos(organization_id: int, *args, **kwargs) -> None:
 
     org_repo_definitions: dict[tuple[str, str, str], RepoDetails] = {}
 
-    if features.has("organizations:seer-project-settings-read-from-sentry", organization):
-        preferences = bulk_read_preferences_from_sentry_db(
-            organization_id, list(project_map.keys())
-        )
-        preferences_by_id = {
-            str(project_id): preference.dict() if preference else None
-            for project_id, preference in preferences.items()
-        }
-    else:
-        preferences_by_id = bulk_get_project_preferences(organization_id, list(project_map.keys()))
+    preferences_by_id = bulk_read_preferences_from_sentry_db(
+        organization_id, list(project_map.keys())
+    )
 
     for project_id, project in project_map.items():
-        existing_pref = preferences_by_id.get(str(project_id))
-        if not existing_pref:
+        existing_pref = preferences_by_id.get(project_id)
+        if existing_pref is None or not existing_pref.repositories:
             continue
 
-        project_pref_repos = existing_pref.get("repositories") or []
-
         autofix_repos = get_autofix_repos_from_project_code_mappings(project)
-        # Use autofix repos to get repo languages
         language_map: dict[tuple[str, str, str], list[str]] = {}
         for autofix_repo in autofix_repos:
             key = (autofix_repo["provider"], autofix_repo["owner"], autofix_repo["name"])
             language_map[key] = autofix_repo["languages"]
 
-        for repo in project_pref_repos:
-            key = (repo["provider"], repo["owner"], repo["name"])
+        for repo in existing_pref.repositories:
+            key = (repo.provider, repo.owner, repo.name)
             if key in org_repo_definitions:
-                repo_definition = org_repo_definitions[key]
-                repo_definition["project_ids"].append(project_id)
+                org_repo_definitions[key]["project_ids"].append(project_id)
             else:
                 org_repo_definitions[key] = {
                     "project_ids": [project_id],
-                    "provider": repo["provider"],
-                    "owner": repo["owner"],
-                    "name": repo["name"],
-                    "external_id": repo["external_id"],
+                    "provider": repo.provider,
+                    "owner": repo.owner,
+                    "name": repo.name,
+                    "external_id": repo.external_id,
                     "languages": language_map.get(key, []),
-                    "integration_id": repo.get("integration_id"),
+                    "integration_id": repo.integration_id,
                 }
 
     viewer_context = SeerViewerContext(organization_id=organization_id)

--- a/src/sentry/tasks/seer/context_engine_index.py
+++ b/src/sentry/tasks/seer/context_engine_index.py
@@ -267,6 +267,7 @@ def index_repos(organization_id: int, *args, **kwargs) -> None:
             continue
 
         autofix_repos = get_autofix_repos_from_project_code_mappings(project)
+        # Use autofix repos to get repo languages
         language_map: dict[tuple[str, str, str], list[str]] = {}
         for autofix_repo in autofix_repos:
             key = (autofix_repo["provider"], autofix_repo["owner"], autofix_repo["name"])

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -19,7 +19,7 @@ from sentry.seer.autofix.constants import (
     SeerAutomationSource,
 )
 from sentry.seer.autofix.issue_summary import referrer_map
-from sentry.seer.autofix.utils import AutofixStoppingPoint, bulk_read_preferences
+from sentry.seer.autofix.utils import AutofixStoppingPoint, bulk_read_preferences_from_sentry_db
 from sentry.seer.models.night_shift import SeerNightShiftRun, SeerNightShiftRunIssue
 from sentry.seer.models.seer_api_models import SeerProjectPreference
 from sentry.tasks.base import instrumented_task
@@ -314,7 +314,7 @@ def _fail_run(
 def _get_eligible_projects(
     organization: Organization,
     project_id: int | None = None,
-) -> tuple[list[Project], dict[int, SeerProjectPreference | None]]:
+) -> tuple[list[Project], dict[int, SeerProjectPreference]]:
     """Return active projects that have automation enabled and connected repos.
 
     When project_id is provided, only that project is considered (for manual
@@ -326,13 +326,12 @@ def _get_eligible_projects(
     if not project_map:
         return [], {}
 
-    preferences = bulk_read_preferences(organization, list(project_map))
+    preferences = bulk_read_preferences_from_sentry_db(organization.id, list(project_map))
 
     candidates = [
         project_map[pid]
         for pid, pref in preferences.items()
-        if pref is not None
-        and pref.repositories
+        if pref.repositories
         and pref.autofix_automation_tuning != AutofixAutomationTuningSettings.OFF
     ]
     if not candidates:

--- a/tests/sentry/seer/autofix/test_autofix.py
+++ b/tests/sentry/seer/autofix/test_autofix.py
@@ -16,7 +16,6 @@ from sentry.seer.autofix.autofix import (
     _get_profile_from_trace_tree,
     _get_trace_tree_for_event,
     _pre_resolve_stacktrace_frames,
-    _resolve_project_preference,
     _respond_with_error,
     get_all_tags_overview,
     trigger_autofix,
@@ -25,11 +24,9 @@ from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.types import AutofixSelectRootCausePayload
 from sentry.seer.explorer.utils import _convert_profile_to_execution_tree
 from sentry.seer.models import (
-    SeerApiError,
-    SeerAutomationHandoffConfiguration,
     SeerProjectPreference,
-    SeerRawPreferenceResponse,
 )
+from sentry.seer.models.project_repository import SeerProjectRepository
 from sentry.seer.utils import get_github_username_for_user
 from sentry.testutils.cases import APITestCase, SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now
@@ -836,10 +833,8 @@ class TestTriggerAutofix(APITestCase, SnubaTestCase, OccurrenceTestMixin):
     @patch("sentry.seer.autofix.autofix._get_trace_tree_for_event")
     @patch("sentry.seer.autofix.autofix._call_autofix")
     @patch("sentry.tasks.seer.autofix.check_autofix_status.apply_async")
-    @patch("sentry.seer.autofix.autofix._resolve_project_preference", return_value=None)
     def test_trigger_autofix_with_event_id(
         self,
-        mock_resolve_pref,
         mock_check_autofix_status,
         mock_call,
         mock_get_trace,
@@ -911,10 +906,8 @@ class TestTriggerAutofix(APITestCase, SnubaTestCase, OccurrenceTestMixin):
     @patch("sentry.seer.autofix.autofix._get_trace_tree_for_event")
     @patch("sentry.seer.autofix.autofix._call_autofix")
     @patch("sentry.tasks.seer.autofix.check_autofix_status.apply_async")
-    @patch("sentry.seer.autofix.autofix._resolve_project_preference")
-    def test_trigger_autofix_passes_resolved_preference(
+    def test_trigger_autofix_passes_project_preference(
         self,
-        mock_resolve_pref,
         mock_check_autofix_status,
         mock_call,
         mock_get_trace,
@@ -922,25 +915,19 @@ class TestTriggerAutofix(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         mock_get_tags,
         mock_record_seer_run,
     ):
-        """Tests that a resolved preference's repos and preference object are passed to _call_autofix."""
+        """Tests that the preference read from Sentry DB is passed to _call_autofix."""
         mock_get_profile.return_value = None
         mock_get_trace.return_value = None
         mock_get_tags.return_value = None
 
-        mock_preference = SeerProjectPreference(
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            repositories=[
-                {
-                    "provider": "integrations:github",
-                    "owner": "getsentry",
-                    "name": "seer",
-                    "external_id": "456",
-                }
-            ],
-            automated_run_stopping_point="code_changes",
+        repo = self.create_repo(
+            project=self.project,
+            provider="integrations:github",
+            external_id="456",
+            name="getsentry/seer",
         )
-        mock_resolve_pref.return_value = mock_preference
+        SeerProjectRepository.objects.create(project=self.project, repository=repo)
+        self.project.update_option("sentry:seer_automated_run_stopping_point", "code_changes")
 
         data = load_data("python", timestamp=before_now(minutes=1))
         data["exception"] = {"values": [{"type": "Exception", "value": "Test exception"}]}
@@ -960,11 +947,13 @@ class TestTriggerAutofix(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         assert response.status_code == 202
 
         call_kwargs = mock_call.call_args.kwargs
-        assert call_kwargs["preference"] == mock_preference
-        # repos should be replaced by preference repos (dict form)
-        assert len(call_kwargs["repos"]) == 1
-        assert call_kwargs["repos"][0]["name"] == "seer"
-        assert call_kwargs["repos"][0]["external_id"] == "456"
+        preference = call_kwargs["preference"]
+        assert isinstance(preference, SeerProjectPreference)
+        assert preference.project_id == self.project.id
+        assert preference.automated_run_stopping_point == "code_changes"
+        assert len(preference.repositories) == 1
+        assert preference.repositories[0].name == "seer"
+        assert preference.repositories[0].external_id == "456"
 
     @patch("sentry.models.Group.get_recommended_event_for_environments")
     @patch("sentry.models.Group.get_latest_event")
@@ -1005,10 +994,8 @@ class TestTriggerAutofix(APITestCase, SnubaTestCase, OccurrenceTestMixin):
     @patch("sentry.seer.autofix.autofix._get_trace_tree_for_event")
     @patch("sentry.seer.autofix.autofix._call_autofix")
     @patch("sentry.tasks.seer.autofix.check_autofix_status.apply_async")
-    @patch("sentry.seer.autofix.autofix._resolve_project_preference", return_value=None)
     def test_trigger_autofix_with_web_vitals_issue(
         self,
-        mock_resolve_pref,
         mock_check_autofix_status,
         mock_call,
         mock_get_trace,
@@ -1097,163 +1084,6 @@ class TestTriggerAutofixWithHideAiFeatures(APITestCase, SnubaTestCase):
         assert "AI features are disabled for this organization" in response.data["detail"]
         # Verify _get_serialized_event was not called since AI features are disabled
         mock_get_serialized_event.assert_not_called()
-
-
-@with_feature("organizations:seer-project-settings-dual-write")
-class TestResolveProjectPreference(TestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.organization = self.create_organization()
-        self.project = self.create_project(organization=self.organization)
-
-    def _mock_repo(self, name: str = "sentry", external_id: str = "123") -> dict:
-        return {
-            "provider": "integrations:github",
-            "owner": "getsentry",
-            "name": name,
-            "external_id": external_id,
-        }
-
-    @patch("sentry.seer.autofix.autofix.write_preference_to_sentry_db")
-    @patch("sentry.seer.autofix.autofix.set_project_seer_preference")
-    @patch("sentry.seer.autofix.autofix.get_project_seer_preferences")
-    def test_returns_existing_preference(self, mock_get_prefs, mock_set_pref, mock_write_sentry):
-        mock_get_prefs.return_value = SeerRawPreferenceResponse(
-            preference=SeerProjectPreference(
-                organization_id=self.organization.id,
-                project_id=self.project.id,
-                repositories=[self._mock_repo("seer", "999")],
-                automated_run_stopping_point="root_cause",
-            )
-        )
-
-        result = _resolve_project_preference(self.organization, self.project)
-
-        assert result is not None
-        assert len(result.repositories) == 1
-        assert result.repositories[0].name == "seer"
-        assert result.repositories[0].external_id == "999"
-        assert result.automated_run_stopping_point == "root_cause"
-        mock_set_pref.assert_not_called()
-        mock_write_sentry.assert_not_called()
-
-    @patch("sentry.seer.autofix.autofix.write_preference_to_sentry_db")
-    @patch("sentry.seer.autofix.autofix.set_project_seer_preference")
-    @patch("sentry.seer.autofix.autofix.get_project_seer_preferences")
-    def test_returns_existing_preference_with_empty_repos(
-        self, mock_get_prefs, mock_set_pref, mock_write_sentry
-    ):
-        mock_get_prefs.return_value = SeerRawPreferenceResponse(
-            preference=SeerProjectPreference(
-                organization_id=self.organization.id,
-                project_id=self.project.id,
-                repositories=[],
-                automated_run_stopping_point="root_cause",
-                automation_handoff=SeerAutomationHandoffConfiguration(
-                    handoff_point="root_cause",
-                    target="cursor_background_agent",
-                    integration_id=42,
-                    auto_create_pr=True,
-                ),
-            )
-        )
-
-        result = _resolve_project_preference(self.organization, self.project)
-
-        assert result is not None
-        assert result.repositories == []
-        assert result.automated_run_stopping_point == "root_cause"
-        assert result.automation_handoff is not None
-        assert result.automation_handoff.handoff_point == "root_cause"
-        assert result.automation_handoff.target == "cursor_background_agent"
-        assert result.automation_handoff.integration_id == 42
-        assert result.automation_handoff.auto_create_pr is True
-        mock_set_pref.assert_not_called()
-        mock_write_sentry.assert_not_called()
-
-    @patch("sentry.seer.autofix.autofix.write_preference_to_sentry_db")
-    @patch("sentry.seer.autofix.autofix.set_project_seer_preference")
-    @patch("sentry.seer.autofix.autofix.get_project_seer_preferences")
-    def test_no_preference_creates_one_with_org_defaults(
-        self, mock_get_prefs, mock_set_pref, mock_write_sentry
-    ):
-        mock_get_prefs.return_value = SeerRawPreferenceResponse(preference=None)
-        self.organization.update_option("sentry:default_automated_run_stopping_point", "open_pr")
-        self.organization.update_option("sentry:auto_open_prs", True)
-
-        result = _resolve_project_preference(self.organization, self.project)
-
-        assert result is not None
-        assert result.project_id == self.project.id
-        assert result.organization_id == self.organization.id
-        assert result.repositories == []
-        assert result.automated_run_stopping_point == "open_pr"
-        mock_set_pref.assert_called_once()
-        mock_write_sentry.assert_called_once()
-
-    @patch("sentry.seer.autofix.autofix.write_preference_to_sentry_db")
-    @patch("sentry.seer.autofix.autofix.set_project_seer_preference")
-    @patch("sentry.seer.autofix.autofix.get_project_seer_preferences")
-    def test_returns_none_on_get_api_error(self, mock_get_prefs, mock_set_pref, mock_write_sentry):
-        mock_get_prefs.side_effect = SeerApiError("test error", 500)
-
-        result = _resolve_project_preference(self.organization, self.project)
-
-        assert result is None
-        mock_set_pref.assert_not_called()
-        mock_write_sentry.assert_not_called()
-
-    @patch("sentry.seer.autofix.autofix.write_preference_to_sentry_db")
-    @patch("sentry.seer.autofix.autofix.set_project_seer_preference")
-    @patch("sentry.seer.autofix.autofix.get_project_seer_preferences")
-    def test_returns_none_on_set_api_error(self, mock_get_prefs, mock_set_pref, mock_write_sentry):
-        mock_get_prefs.return_value = SeerRawPreferenceResponse(preference=None)
-        mock_set_pref.side_effect = SeerApiError("test error", 500)
-
-        result = _resolve_project_preference(self.organization, self.project)
-
-        assert result is None
-        mock_write_sentry.assert_not_called()
-
-    @patch("sentry.seer.autofix.autofix.write_preference_to_sentry_db")
-    @patch("sentry.seer.autofix.autofix.set_project_seer_preference")
-    @patch("sentry.seer.autofix.autofix.get_project_seer_preferences")
-    def test_returns_preference_on_sentry_db_write_error(
-        self, mock_get_prefs, mock_set_pref, mock_write_sentry
-    ):
-        mock_get_prefs.return_value = SeerRawPreferenceResponse(preference=None)
-        mock_write_sentry.side_effect = Exception()
-
-        result = _resolve_project_preference(self.organization, self.project)
-
-        assert result is not None
-        assert result.project_id == self.project.id
-        assert result.repositories == []
-        mock_set_pref.assert_called_once()
-        mock_write_sentry.assert_called_once()
-
-    @with_feature("organizations:seer-project-settings-read-from-sentry")
-    @patch("sentry.seer.autofix.autofix.write_preference_to_sentry_db")
-    @patch("sentry.seer.autofix.autofix.set_project_seer_preference")
-    @patch("sentry.seer.autofix.autofix.read_preference_from_sentry_db")
-    @patch("sentry.seer.autofix.autofix.get_project_seer_preferences")
-    def test_reads_from_sentry_db(
-        self, mock_get_prefs, mock_read_db, mock_set_pref, mock_write_sentry
-    ):
-        """When feature flag enabled, reads preferences from Sentry DB instead of Seer API."""
-        mock_read_db.return_value = SeerProjectPreference(
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            repositories=[self._mock_repo("seer", "999")],
-            automated_run_stopping_point="root_cause",
-        )
-
-        result = _resolve_project_preference(self.organization, self.project)
-
-        assert result is not None
-        assert result.repositories[0].name == "seer"
-        mock_get_prefs.assert_not_called()
-        mock_set_pref.assert_not_called()
 
 
 class TestCallAutofix(TestCase):

--- a/tests/sentry/seer/autofix/test_autofix.py
+++ b/tests/sentry/seer/autofix/test_autofix.py
@@ -25,6 +25,7 @@ from sentry.seer.autofix.types import AutofixSelectRootCausePayload
 from sentry.seer.explorer.utils import _convert_profile_to_execution_tree
 from sentry.seer.models import (
     SeerProjectPreference,
+    SeerRepoDefinition,
 )
 from sentry.seer.models.project_repository import SeerProjectRepository
 from sentry.seer.utils import get_github_username_for_user
@@ -1113,7 +1114,18 @@ class TestCallAutofix(TestCase):
         group.first_seen = now
 
         # Test data
-        repos = [{"name": "test-repo"}]
+        preference = SeerProjectPreference(
+            organization_id=456,
+            project_id=789,
+            repositories=[
+                SeerRepoDefinition(
+                    provider="integrations:github",
+                    owner="getsentry",
+                    name="test-repo",
+                    external_id="123",
+                )
+            ],
+        )
         serialized_event = {"event_id": "test-event"}
         profile = {"profile_data": "test"}
         trace_tree = {"trace_data": "test"}
@@ -1125,7 +1137,7 @@ class TestCallAutofix(TestCase):
         run_id = _call_autofix(
             user=user,
             group=group,
-            repos=repos,
+            preference=preference,
             serialized_event=serialized_event,
             profile=profile,
             trace_tree=trace_tree,
@@ -1147,7 +1159,8 @@ class TestCallAutofix(TestCase):
         body = orjson.loads(mock_request.call_args[0][0])
         assert body["organization_id"] == 456
         assert body["project_id"] == 789
-        assert body["repos"] == repos
+        assert body["repos"] == [repo.dict() for repo in preference.repositories]
+        assert body["preference"] == preference.dict()
         assert body["issue"]["id"] == 101112
         assert body["issue"]["title"] == "Test Group"
         assert body["issue"]["short_id"] == "TEST-123"

--- a/tests/sentry/seer/autofix/test_autofix.py
+++ b/tests/sentry/seer/autofix/test_autofix.py
@@ -916,7 +916,7 @@ class TestTriggerAutofix(APITestCase, SnubaTestCase, OccurrenceTestMixin):
         mock_get_tags,
         mock_record_seer_run,
     ):
-        """Tests that the preference read from Sentry DB is passed to _call_autofix."""
+        """Tests that the preference is passed to _call_autofix."""
         mock_get_profile.return_value = None
         mock_get_trace.return_value = None
         mock_get_tags.return_value = None

--- a/tests/sentry/seer/autofix/test_autofix_utils.py
+++ b/tests/sentry/seer/autofix/test_autofix_utils.py
@@ -37,7 +37,6 @@ from sentry.seer.models.project_repository import (
     SeerProjectRepositoryBranchOverride,
 )
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.features import with_feature
 from sentry.utils.cache import cache
 
 
@@ -459,147 +458,19 @@ class TestHasProjectConnectedRepos(TestCase):
         self.organization = self.create_organization()
         self.project = self.create_project(organization=self.organization)
 
-    @patch("sentry.seer.autofix.utils.cache")
-    @patch("sentry.seer.autofix.utils.get_project_seer_preferences")
-    def test_returns_true_when_repos_exist(self, mock_get_preferences, mock_cache):
-        """Test returns True when project has connected repositories."""
-        mock_cache.get.return_value = None
-        mock_preference = Mock()
-        mock_preference.repositories = [{"provider": "github", "owner": "test", "name": "repo"}]
-        mock_response = Mock()
-        mock_response.preference = mock_preference
-        mock_get_preferences.return_value = mock_response
-
-        result = has_project_connected_repos(self.organization, self.project)
-
-        assert result is True
-        mock_cache.set.assert_called_once_with(
-            f"seer-project-has-repos:{self.organization.id}:{self.project.id}",
-            True,
-            timeout=60 * 15,
+    def test_returns_true_when_repos_exist(self):
+        repo = self.create_repo(
+            project=self.project,
+            provider="integrations:github",
+            external_id="123",
+            name="owner/repo",
         )
+        SeerProjectRepository.objects.create(project=self.project, repository=repo)
 
-    @patch("sentry.seer.autofix.utils.cache")
-    @patch("sentry.seer.autofix.utils.get_project_seer_preferences")
-    def test_returns_false_when_no_repos(self, mock_get_preferences, mock_cache):
-        """Test returns False when project has no connected repositories."""
-        mock_cache.get.return_value = None
-        mock_preference = Mock()
-        mock_preference.repositories = []
-        mock_response = Mock()
-        mock_response.preference = mock_preference
-        mock_get_preferences.return_value = mock_response
+        assert has_project_connected_repos(self.organization, self.project) is True
 
-        result = has_project_connected_repos(self.organization, self.project)
-
-        assert result is False
-        mock_cache.set.assert_called_once_with(
-            f"seer-project-has-repos:{self.organization.id}:{self.project.id}",
-            False,
-            timeout=60 * 15,
-        )
-
-    @patch("sentry.seer.autofix.utils.cache")
-    @patch("sentry.seer.autofix.utils.get_project_seer_preferences")
-    def test_returns_false_when_preference_is_none(self, mock_get_preferences, mock_cache):
-        """Test returns False when preference is None."""
-        mock_cache.get.return_value = None
-        mock_response = Mock()
-        mock_response.preference = None
-        mock_get_preferences.return_value = mock_response
-
-        result = has_project_connected_repos(self.organization, self.project)
-
-        assert result is False
-        mock_cache.set.assert_called_once_with(
-            f"seer-project-has-repos:{self.organization.id}:{self.project.id}",
-            False,
-            timeout=60 * 15,
-        )
-
-    @patch("sentry.seer.autofix.utils.cache")
-    @patch("sentry.seer.autofix.utils.get_project_seer_preferences")
-    def test_returns_cached_value_true(self, mock_get_preferences, mock_cache):
-        """Test returns cached True value without calling API."""
-        mock_cache.get.return_value = True
-
-        result = has_project_connected_repos(self.organization, self.project)
-
-        assert result is True
-        mock_get_preferences.assert_not_called()
-        mock_cache.set.assert_not_called()
-
-    @patch("sentry.seer.autofix.utils.cache")
-    @patch("sentry.seer.autofix.utils.get_project_seer_preferences")
-    def test_returns_cached_value_false(self, mock_get_preferences, mock_cache):
-        """Test returns cached False value without calling API."""
-        mock_cache.get.return_value = False
-
-        result = has_project_connected_repos(self.organization, self.project)
-
-        assert result is False
-        mock_get_preferences.assert_not_called()
-        mock_cache.set.assert_not_called()
-
-    @patch("sentry.seer.autofix.utils.cache")
-    @patch("sentry.seer.autofix.utils.get_project_seer_preferences")
-    def test_skip_cache_bypasses_cached_value(self, mock_get_preferences, mock_cache):
-        """Test skip_cache=True bypasses cache and calls API."""
-        mock_cache.get.return_value = False  # Cache has False
-        mock_preference = Mock()
-        mock_preference.repositories = [{"provider": "github", "owner": "test", "name": "repo"}]
-        mock_response = Mock()
-        mock_response.preference = mock_preference
-        mock_get_preferences.return_value = mock_response
-
-        result = has_project_connected_repos(self.organization, self.project, skip_cache=True)
-
-        assert result is True  # Fresh value from API, not cached False
-        mock_cache.get.assert_not_called()  # Cache not checked
-        mock_get_preferences.assert_called_once()  # API was called
-        mock_cache.set.assert_called_once()  # Cache still updated
-
-    @patch("sentry.seer.autofix.utils.cache")
-    @patch("sentry.seer.autofix.utils.get_project_seer_preferences")
-    def test_returns_false_on_api_error(self, mock_get_preferences, mock_cache):
-        """Test returns False when Seer API fails."""
-        mock_cache.get.return_value = None
-        mock_get_preferences.side_effect = SeerApiError("API Error", 500)
-
-        result = has_project_connected_repos(self.organization, self.project)
-
-        assert result is False
-        mock_cache.set.assert_called_once_with(
-            f"seer-project-has-repos:{self.organization.id}:{self.project.id}",
-            False,
-            timeout=60 * 15,
-        )
-
-    @with_feature("organizations:seer-project-settings-read-from-sentry")
-    @patch("sentry.seer.autofix.utils.read_preference_from_sentry_db")
-    @patch("sentry.seer.autofix.utils.get_project_seer_preferences")
-    @patch("sentry.seer.autofix.utils.cache")
-    def test_reads_from_sentry_db(self, mock_cache, mock_get_prefs, mock_read_db):
-        """When feature flag enabled, reads preferences from Sentry DB instead of Seer API."""
-        mock_cache.get.return_value = None
-        mock_read_db.return_value = SeerProjectPreference(
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            repositories=[
-                SeerRepoDefinition(provider="github", owner="owner", name="repo", external_id="123")
-            ],
-        )
-
-        result = has_project_connected_repos(self.organization, self.project)
-
-        assert result is True
-        mock_get_prefs.assert_not_called()
-        mock_read_db.assert_called_once()
-        mock_cache.set.assert_called_once_with(
-            f"seer-project-has-repos:{self.organization.id}:{self.project.id}",
-            True,
-            timeout=60 * 15,
-        )
+    def test_returns_false_when_no_repos(self):
+        assert has_project_connected_repos(self.organization, self.project) is False
 
 
 class TestSetProjectSeerPreference(TestCase):

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -6,7 +6,8 @@ from sentry.seer.autofix.autofix_agent import AutofixStep, NoSeerQuotaException
 from sentry.seer.autofix.constants import AutofixReferrer, AutofixStatus
 from sentry.seer.autofix.utils import AutofixState, AutofixStoppingPoint, CodebaseState
 from sentry.seer.explorer.client_models import SeerRunState
-from sentry.seer.models import SeerProjectPreference
+from sentry.seer.models import SeerRepoDefinition
+from sentry.seer.models.project_repository import SeerProjectRepository
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.features import with_feature
@@ -316,10 +317,8 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
     @patch("sentry.seer.autofix.autofix._call_autofix")
     @patch("sentry.seer.autofix.autofix._get_trace_tree_for_event")
     @patch("sentry.tasks.seer.autofix.check_autofix_status.apply_async")
-    @patch("sentry.seer.autofix.autofix._resolve_project_preference")
     def test_ai_autofix_post_endpoint(
         self,
-        mock_resolve_pref,
         mock_check_autofix_status,
         mock_get_trace_tree,
         mock_call,
@@ -332,18 +331,13 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
 
         release = self.create_release(project=self.project, version="1.0.0")
 
-        mock_resolve_pref.return_value = SeerProjectPreference(
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            repositories=[
-                {
-                    "provider": "integrations:github",
-                    "owner": "getsentry",
-                    "name": "sentry",
-                    "external_id": "123",
-                }
-            ],
+        repo = self.create_repo(
+            project=self.project,
+            provider="integrations:github",
+            external_id="123",
+            name="getsentry/sentry",
         )
+        SeerProjectRepository.objects.create(project=self.project, repository=repo)
 
         data = load_data("python", timestamp=before_now(minutes=1))
         event = self.store_event(
@@ -374,16 +368,20 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         call_kwargs = mock_call.call_args.kwargs
         assert call_kwargs["group"].id == group.id  # Check that the group object matches
 
-        # Check that the repos parameter contains the expected data
-        expected_repo_fields = {
-            "provider": "integrations:github",
-            "owner": "getsentry",
-            "name": "sentry",
-            "external_id": "123",
-        }
+        # Check that the preference's repositories contain the expected data
+        expected = SeerRepoDefinition(
+            provider="integrations:github",
+            owner="getsentry",
+            name="sentry",
+            external_id="123",
+        )
+        preference = call_kwargs["preference"]
         assert any(
-            all(repo.get(key) == value for key, value in expected_repo_fields.items())
-            for repo in call_kwargs["repos"]
+            repo.provider == expected.provider
+            and repo.owner == expected.owner
+            and repo.name == expected.name
+            and repo.external_id == expected.external_id
+            for repo in preference.repositories
         )
 
         # Check that the instruction was passed correctly
@@ -409,10 +407,8 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
     @patch("sentry.seer.autofix.autofix._call_autofix")
     @patch("sentry.seer.autofix.autofix._get_trace_tree_for_event")
     @patch("sentry.tasks.seer.autofix.check_autofix_status.apply_async")
-    @patch("sentry.seer.autofix.autofix._resolve_project_preference", return_value=None)
     def test_ai_autofix_post_without_code_mappings(
         self,
-        mock_resolve_pref,
         mock_check_autofix_status,
         mock_get_trace_tree,
         mock_call,
@@ -454,8 +450,8 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         call_kwargs = mock_call.call_args.kwargs
         assert call_kwargs["group"].id == group.id  # Check that the group object matches
 
-        # Check that the repos parameter is an empty list (no code mappings)
-        assert call_kwargs["repos"] == []
+        # No SeerProjectRepository rows, so the preference's repositories are empty.
+        assert call_kwargs["preference"].repositories == []
 
         # Check that the instruction was passed correctly
         assert call_kwargs["instruction"] == "Yes"
@@ -480,10 +476,8 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
     @patch("sentry.seer.autofix.autofix._call_autofix")
     @patch("sentry.seer.autofix.autofix._get_trace_tree_for_event")
     @patch("sentry.tasks.seer.autofix.check_autofix_status.apply_async")
-    @patch("sentry.seer.autofix.autofix._resolve_project_preference")
     def test_ai_autofix_post_without_event_id(
         self,
-        mock_resolve_pref,
         mock_check_autofix_status,
         mock_get_trace_tree,
         mock_call,
@@ -496,18 +490,13 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
 
         release = self.create_release(project=self.project, version="1.0.0")
 
-        mock_resolve_pref.return_value = SeerProjectPreference(
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            repositories=[
-                {
-                    "provider": "integrations:github",
-                    "owner": "getsentry",
-                    "name": "sentry",
-                    "external_id": "123",
-                }
-            ],
+        repo = self.create_repo(
+            project=self.project,
+            provider="integrations:github",
+            external_id="123",
+            name="getsentry/sentry",
         )
+        SeerProjectRepository.objects.create(project=self.project, repository=repo)
 
         data = load_data("python", timestamp=before_now(minutes=1))
         event = self.store_event(
@@ -536,16 +525,20 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         call_kwargs = mock_call.call_args.kwargs
         assert call_kwargs["group"].id == group.id  # Check that the group object matches
 
-        # Check that the repos parameter contains the expected data
-        expected_repo_fields = {
-            "provider": "integrations:github",
-            "owner": "getsentry",
-            "name": "sentry",
-            "external_id": "123",
-        }
+        # Check that the preference's repositories contain the expected data
+        expected = SeerRepoDefinition(
+            provider="integrations:github",
+            owner="getsentry",
+            name="sentry",
+            external_id="123",
+        )
+        preference = call_kwargs["preference"]
         assert any(
-            all(repo.get(key) == value for key, value in expected_repo_fields.items())
-            for repo in call_kwargs["repos"]
+            repo.provider == expected.provider
+            and repo.owner == expected.owner
+            and repo.name == expected.name
+            and repo.external_id == expected.external_id
+            for repo in preference.repositories
         )
 
         # Check that the instruction was passed correctly
@@ -571,10 +564,8 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
     @patch("sentry.seer.autofix.autofix._call_autofix")
     @patch("sentry.seer.autofix.autofix._get_trace_tree_for_event")
     @patch("sentry.tasks.seer.autofix.check_autofix_status.apply_async")
-    @patch("sentry.seer.autofix.autofix._resolve_project_preference")
     def test_ai_autofix_post_without_event_id_no_recommended_event(
         self,
-        mock_resolve_pref,
         mock_check_autofix_status,
         mock_get_trace_tree,
         mock_call,
@@ -587,18 +578,13 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
 
         release = self.create_release(project=self.project, version="1.0.0")
 
-        mock_resolve_pref.return_value = SeerProjectPreference(
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            repositories=[
-                {
-                    "provider": "integrations:github",
-                    "owner": "getsentry",
-                    "name": "sentry",
-                    "external_id": "123",
-                }
-            ],
+        repo = self.create_repo(
+            project=self.project,
+            provider="integrations:github",
+            external_id="123",
+            name="getsentry/sentry",
         )
+        SeerProjectRepository.objects.create(project=self.project, repository=repo)
 
         data = load_data("python", timestamp=before_now(minutes=1))
         event = self.store_event(
@@ -627,16 +613,20 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         call_kwargs = mock_call.call_args.kwargs
         assert call_kwargs["group"].id == group.id  # Check that the group object matches
 
-        # Check that the repos parameter contains the expected data
-        expected_repo_fields = {
-            "provider": "integrations:github",
-            "owner": "getsentry",
-            "name": "sentry",
-            "external_id": "123",
-        }
+        # Check that the preference's repositories contain the expected data
+        expected = SeerRepoDefinition(
+            provider="integrations:github",
+            owner="getsentry",
+            name="sentry",
+            external_id="123",
+        )
+        preference = call_kwargs["preference"]
         assert any(
-            all(repo.get(key) == value for key, value in expected_repo_fields.items())
-            for repo in call_kwargs["repos"]
+            repo.provider == expected.provider
+            and repo.owner == expected.owner
+            and repo.name == expected.name
+            and repo.external_id == expected.external_id
+            for repo in preference.repositories
         )
 
         # Check that the instruction was passed correctly
@@ -1010,10 +1000,8 @@ class GroupAutofixEndpointExplorerRoutingTest(APITestCase, SnubaTestCase):
     @patch("sentry.seer.autofix.autofix._call_autofix")
     @patch("sentry.seer.autofix.autofix._get_trace_tree_for_event")
     @patch("sentry.tasks.seer.autofix.check_autofix_status.apply_async")
-    @patch("sentry.seer.autofix.autofix._resolve_project_preference", return_value=None)
     def test_post_routes_to_legacy_with_mode_param(
         self,
-        mock_resolve_pref,
         mock_check_autofix_status,
         mock_get_trace_tree,
         mock_call_autofix,

--- a/tests/sentry/seer/endpoints/test_group_autofix_setup_check.py
+++ b/tests/sentry/seer/endpoints/test_group_autofix_setup_check.py
@@ -119,16 +119,6 @@ class GroupAIAutofixEndpointSuccessTest(APITestCase, SnubaTestCase):
         """Set the cache for is_seer_seat_based_tier_enabled to return the given value."""
         cache.set(f"seer:seat-based-tier:{self.organization.id}", value)
 
-    def _set_project_repos_cache(self, value: bool) -> None:
-        """Set the cache for has_project_connected_repos to return the given value.
-
-        Note: The setup check endpoint now uses skip_cache=True, so this only
-        affects the cache that gets set after the API call, not the lookup.
-        For tests that need to control the return value, use the
-        @patch decorator on has_project_connected_repos instead.
-        """
-        cache.set(f"seer-project-has-repos:{self.organization.id}:{self.project.id}", value)
-
     @patch(
         "sentry.seer.endpoints.group_autofix_setup_check.has_project_connected_repos",
         return_value=True,

--- a/tests/sentry/seer/endpoints/test_project_seer_preferences.py
+++ b/tests/sentry/seer/endpoints/test_project_seer_preferences.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, Mock, patch
 from django.urls import reverse
 
 from sentry.models.repository import Repository
-from sentry.seer.models import PreferenceResponse, SeerProjectPreference, SeerRepoDefinition
+from sentry.seer.models.project_repository import SeerProjectRepository
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
 
@@ -26,30 +26,13 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
                 "project_id_or_slug": self.project.slug,
             },
         )
-        # Create a repository that matches the test data for POST tests
-        self.repository = Repository.objects.create(
-            organization_id=self.org.id,
+        self.repository = self.create_repo(
+            project=self.project,
             name="getsentry/sentry",
             provider="github",
             external_id="123456",
         )
-        self.repo_definition = SeerRepoDefinition(
-            integration_id="111",
-            provider="github",
-            owner="getsentry",
-            name="sentry",
-            external_id="123456",
-        )
-        self.project_preference = SeerProjectPreference(
-            organization_id=self.org.id,
-            project_id=self.project.id,
-            repositories=[self.repo_definition],
-        )
-        self.response_data = PreferenceResponse(
-            preference=self.project_preference, code_mapping_repos=[self.repo_definition]
-        ).dict()
 
-    @patch("sentry.seer.endpoints.project_seer_preferences.make_get_project_preference_request")
     @patch(
         "sentry.seer.endpoints.project_seer_preferences.get_autofix_repos_from_project_code_mappings",
         return_value=[
@@ -62,34 +45,27 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
             }
         ],
     )
-    def test_get(self, mock_get_autofix_repos: MagicMock, mock_request: MagicMock) -> None:
-        """Test that the GET method correctly calls the SEER API and returns the response"""
-        # Setup the mock
-        mock_response = Mock()
-        mock_response.json.return_value = self.response_data
-        mock_response.status = 200
-        mock_request.return_value = mock_response
+    def test_get(self, mock_get_autofix_repos: MagicMock) -> None:
+        """Test that the GET method reads the preference  and returns it alongside code-mapping repos."""
+        SeerProjectRepository.objects.create(project=self.project, repository=self.repository)
 
-        # Make the request
         response = self.client.get(self.url)
 
-        # Assert the response
         assert response.status_code == 200
-        assert response.data == self.response_data
-
-        # Assert that the mock was called with the correct arguments
-        mock_request.assert_called_once()
-        body = mock_request.call_args[0][0]
-
-        # Verify the request body
-        assert body["project_id"] == self.project.id
+        preference = response.data["preference"]
+        assert preference["project_id"] == self.project.id
+        assert preference["organization_id"] == self.org.id
+        assert len(preference["repositories"]) == 1
+        assert preference["repositories"][0]["external_id"] == "123456"
+        assert preference["repositories"][0]["name"] == "sentry"
+        assert len(response.data["code_mapping_repos"]) == 1
+        assert response.data["code_mapping_repos"][0]["external_id"] == "123456"
+        assert response.data["code_mapping_repos"][0]["name"] == "sentry"
 
     @patch("sentry.seer.endpoints.project_seer_preferences.make_set_project_preference_request")
     def test_post(self, mock_request: MagicMock) -> None:
         """Test that the POST method correctly calls the SEER API and returns the response"""
-        # Setup the mock
         mock_response = Mock()
-        mock_response.json.return_value = self.response_data
         mock_response.status = 200
         mock_request.return_value = mock_response
 
@@ -132,32 +108,6 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
         assert preference["repositories"][0]["instructions"] == "test instructions"
         assert preference["repositories"][0]["branch_name"] == "main"
 
-    @patch("sentry.seer.endpoints.project_seer_preferences.make_get_project_preference_request")
-    def test_api_error_handling(self, mock_request: MagicMock) -> None:
-        """Test that the endpoint correctly handles API errors"""
-        # Setup the mock to raise an error
-        mock_request.side_effect = Exception("API Error")
-
-        # Make the request
-        response = self.client.get(self.url)
-
-        # Assert the response indicates an error
-        assert response.status_code == 500
-
-    @patch("sentry.seer.endpoints.project_seer_preferences.make_get_project_preference_request")
-    def test_http_error(self, mock_request: MagicMock) -> None:
-        """Test handling of HTTP errors from the SEER API"""
-        # Setup mock to return error status
-        mock_response = Mock()
-        mock_response.status = 404
-        mock_request.return_value = mock_response
-
-        # Make the request
-        response = self.client.get(self.url)
-
-        # Assert the response indicates an error
-        assert response.status_code == 500
-
     @patch("sentry.seer.endpoints.project_seer_preferences.make_set_project_preference_request")
     def test_invalid_request_data(self, mock_request: MagicMock) -> None:
         """Test handling of invalid request data"""
@@ -181,51 +131,20 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
         # The request to Seer should not be called since validation fails
         mock_request.assert_not_called()
 
-    @patch("sentry.seer.endpoints.project_seer_preferences.make_get_project_preference_request")
-    def test_api_error_status_code(self, mock_request: MagicMock) -> None:
-        """Test handling when the SEER API returns an error status code"""
-        # Setup the mock to return an error status code
-        mock_response = Mock()
-        mock_response.status = 500
-        mock_request.return_value = mock_response
-
-        # Make the request
+    @patch(
+        "sentry.seer.endpoints.project_seer_preferences.get_autofix_repos_from_project_code_mappings",
+        return_value=[],
+    )
+    def test_get_no_seer_project_repositories(self, mock_get_autofix_repos: MagicMock) -> None:
+        """Test that GET method returns empty repositories when the project has no SeerProjectRepository rows."""
         response = self.client.get(self.url)
 
-        # Assert the response indicates an error
-        assert response.status_code == 500
-
-    @patch("sentry.seer.endpoints.project_seer_preferences.make_get_project_preference_request")
-    def test_no_preferences_found(self, mock_request: MagicMock) -> None:
-        """Test handling when no preferences are found for the project"""
-        # Setup the mock to return a response with null preference
-        mock_response = Mock()
-        mock_response.json.return_value = {"preference": None}
-        mock_response.status = 200
-        mock_request.return_value = mock_response
-
-        # Make the request
-        response = self.client.get(self.url)
-
-        # Assert the response is successful but contains a null preference
         assert response.status_code == 200
-        assert response.data["preference"] is None
+        preference = response.data["preference"]
+        assert preference["project_id"] == self.project.id
+        assert preference["repositories"] == []
+        assert preference["automation_handoff"] is None
         assert response.data["code_mapping_repos"] == []
-
-    @patch("sentry.seer.endpoints.project_seer_preferences.make_get_project_preference_request")
-    def test_api_invalid_response_data(self, mock_request: MagicMock) -> None:
-        """Test handling when the SEER API returns invalid data"""
-        # Setup the mock to return invalid data
-        mock_response = Mock()
-        mock_response.json.return_value = {"invalid_key": "invalid_value"}  # Invalid schema
-        mock_response.status = 200
-        mock_request.return_value = mock_response
-
-        # Make the request
-        response = self.client.get(self.url)
-
-        # The actual behavior returns 200 instead of 500 even with invalid data
-        assert response.status_code == 200
 
     @patch("sentry.seer.endpoints.project_seer_preferences.make_set_project_preference_request")
     def test_post_with_blank_string_fields(self, mock_request: MagicMock) -> None:
@@ -371,50 +290,25 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
         # The post to Seer should not be called since validation fails
         mock_request.assert_not_called()
 
-    @patch("sentry.seer.endpoints.project_seer_preferences.make_get_project_preference_request")
     @patch(
         "sentry.seer.endpoints.project_seer_preferences.get_autofix_repos_from_project_code_mappings",
         return_value=[],
     )
-    def test_get_with_automation_handoff(
-        self, mock_get_autofix_repos: MagicMock, mock_request: MagicMock
-    ) -> None:
-        """Test that GET method correctly returns automation_handoff in the response"""
-        from sentry.seer.models import SeerAutomationHandoffConfiguration
-
-        # Create preference with automation_handoff
-        project_preference_with_handoff = SeerProjectPreference(
-            organization_id=self.org.id,
-            project_id=self.project.id,
-            repositories=[self.repo_definition],
-            automation_handoff=SeerAutomationHandoffConfiguration(
-                handoff_point="root_cause",
-                target="cursor_background_agent",
-                integration_id=123,
-            ),
+    def test_get_with_automation_handoff(self, mock_get_autofix_repos: MagicMock) -> None:
+        """Test that GET method correctly returns automation_handoff."""
+        self.project.update_option("sentry:seer_automation_handoff_point", "root_cause")
+        self.project.update_option(
+            "sentry:seer_automation_handoff_target", "cursor_background_agent"
         )
+        self.project.update_option("sentry:seer_automation_handoff_integration_id", 123)
 
-        response_data = PreferenceResponse(
-            preference=project_preference_with_handoff, code_mapping_repos=[]
-        ).dict()
-
-        # Setup the mock
-        mock_response = Mock()
-        mock_response.json.return_value = response_data
-        mock_response.status = 200
-        mock_request.return_value = mock_response
-
-        # Make the request
         response = self.client.get(self.url)
 
-        # Assert the response
         assert response.status_code == 200
-        assert "preference" in response.data
-        assert "automation_handoff" in response.data["preference"]
-        assert response.data["preference"]["automation_handoff"]["handoff_point"] == "root_cause"
-        assert (
-            response.data["preference"]["automation_handoff"]["target"] == "cursor_background_agent"
-        )
+        handoff = response.data["preference"]["automation_handoff"]
+        assert handoff["handoff_point"] == "root_cause"
+        assert handoff["target"] == "cursor_background_agent"
+        assert handoff["integration_id"] == 123
 
     @patch("sentry.seer.endpoints.project_seer_preferences.make_set_project_preference_request")
     def test_post_with_auto_create_pr_in_handoff_config(self, mock_request: MagicMock) -> None:
@@ -460,47 +354,24 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
         assert "automation_handoff" in preference
         assert preference["automation_handoff"]["auto_create_pr"] is True
 
-    @patch("sentry.seer.endpoints.project_seer_preferences.make_get_project_preference_request")
     @patch(
         "sentry.seer.endpoints.project_seer_preferences.get_autofix_repos_from_project_code_mappings",
         return_value=[],
     )
     def test_get_returns_auto_create_pr_in_handoff_config(
-        self, mock_get_autofix_repos: MagicMock, mock_request: MagicMock
+        self, mock_get_autofix_repos: MagicMock
     ) -> None:
-        """Test that GET method correctly returns auto_create_pr in automation_handoff"""
-        from sentry.seer.models import SeerAutomationHandoffConfiguration
-
-        # Create preference with auto_create_pr in automation_handoff
-        project_preference_with_handoff = SeerProjectPreference(
-            organization_id=self.org.id,
-            project_id=self.project.id,
-            repositories=[self.repo_definition],
-            automation_handoff=SeerAutomationHandoffConfiguration(
-                handoff_point="root_cause",
-                target="cursor_background_agent",
-                integration_id=123,
-                auto_create_pr=True,
-            ),
+        """Test that GET method correctly returns auto_create_pr in automation_handoff."""
+        self.project.update_option("sentry:seer_automation_handoff_point", "root_cause")
+        self.project.update_option(
+            "sentry:seer_automation_handoff_target", "cursor_background_agent"
         )
+        self.project.update_option("sentry:seer_automation_handoff_integration_id", 123)
+        self.project.update_option("sentry:seer_automation_handoff_auto_create_pr", True)
 
-        response_data = PreferenceResponse(
-            preference=project_preference_with_handoff, code_mapping_repos=[]
-        ).dict()
-
-        # Setup the mock
-        mock_response = Mock()
-        mock_response.json.return_value = response_data
-        mock_response.status = 200
-        mock_request.return_value = mock_response
-
-        # Make the request
         response = self.client.get(self.url)
 
-        # Assert the response
         assert response.status_code == 200
-        assert "preference" in response.data
-        assert "automation_handoff" in response.data["preference"]
         assert response.data["preference"]["automation_handoff"]["auto_create_pr"] is True
 
     @patch("sentry.seer.endpoints.project_seer_preferences.make_set_project_preference_request")
@@ -736,25 +607,3 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
         assert response.status_code == 204
 
         mock_write_db.assert_called_once()
-
-    @with_feature("organizations:seer-project-settings-read-from-sentry")
-    @patch("sentry.seer.endpoints.project_seer_preferences.read_preference_from_sentry_db")
-    def test_get_reads_from_sentry_db(self, mock_read_db: MagicMock) -> None:
-        """When feature flag enabled, reads from Sentry DB instead of Seer API."""
-        preference = SeerProjectPreference(
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            repositories=[
-                SeerRepoDefinition(
-                    provider="github", owner="getsentry", name="sentry", external_id="123"
-                )
-            ],
-            automated_run_stopping_point="open_pr",
-        )
-        mock_read_db.return_value = preference
-
-        response = self.client.get(self.url)
-
-        mock_read_db.assert_called_once()
-        assert response.status_code == 200
-        assert response.data["preference"] == preference.dict()

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime, timezone
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import orjson
 import pytest
@@ -29,9 +29,9 @@ from sentry.seer.endpoints.seer_rpc import (
     validate_repo,
 )
 from sentry.seer.explorer.tools import get_trace_item_attributes
+from sentry.seer.models.project_repository import SeerProjectRepository
 from sentry.sentry_apps.metrics import SentryAppEventType
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode_of
 from sentry.utils.snuba_rpc import SnubaRPCRateLimitExceeded
 
@@ -1532,21 +1532,28 @@ class TestSeerRpcMethods(APITestCase):
 
         assert result == {"error": "integration_not_found"}
 
-    @with_feature("organizations:seer-project-settings-read-from-sentry")
-    @patch("sentry.seer.endpoints.seer_rpc.read_preference_from_sentry_db")
-    def test_get_project_preferences_returns_preference(self, mock_read: Any) -> None:
+    def test_get_project_preferences_returns_preference(self) -> None:
         project = self.create_project(organization=self.organization)
-        mock_read.return_value = MagicMock(
-            dict=MagicMock(return_value={"project_id": project.id, "repositories": []})
+        repo = self.create_repo(
+            project=project,
+            provider="integrations:github",
+            external_id="123",
+            name="getsentry/sentry",
         )
+        SeerProjectRepository.objects.create(project=project, repository=repo)
+
         result = get_project_preferences(
             organization_id=self.organization.id,
             project_id=project.id,
         )
-        assert result == {"project_id": project.id, "repositories": []}
-        mock_read.assert_called_once()
 
-    @with_feature("organizations:seer-project-settings-read-from-sentry")
+        assert result is not None
+        assert result["project_id"] == project.id
+        assert result["organization_id"] == self.organization.id
+        assert len(result["repositories"]) == 1
+        assert result["repositories"][0]["external_id"] == "123"
+        assert result["repositories"][0]["name"] == "sentry"
+
     def test_get_project_preferences_returns_default_when_no_preference(self) -> None:
         project = self.create_project(organization=self.organization)
         result = get_project_preferences(
@@ -1575,81 +1582,33 @@ class TestSeerRpcMethods(APITestCase):
                 project_id=project.id,
             )
 
-    @patch("sentry.seer.endpoints.seer_rpc.get_project_seer_preferences")
-    def test_get_project_preferences_seer_api(self, mock_seer: Any) -> None:
-        project = self.create_project(organization=self.organization)
-        mock_seer.return_value = MagicMock(
-            preference=MagicMock(
-                dict=MagicMock(return_value={"project_id": project.id, "repositories": []})
-            )
-        )
-        result = get_project_preferences(
-            organization_id=self.organization.id,
-            project_id=project.id,
-        )
-        assert result == {"project_id": project.id, "repositories": []}
-        mock_seer.assert_called_once_with(project.id)
-
-    @patch("sentry.seer.endpoints.seer_rpc.get_project_seer_preferences")
-    def test_get_project_preferences_seer_api_returns_none(self, mock_seer: Any) -> None:
-        project = self.create_project(organization=self.organization)
-        mock_seer.return_value = MagicMock(preference=None)
-        result = get_project_preferences(
-            organization_id=self.organization.id,
-            project_id=project.id,
-        )
-        assert result is None
-
-    @with_feature("organizations:seer-project-settings-read-from-sentry")
-    @patch("sentry.seer.endpoints.seer_rpc.bulk_read_preferences_from_sentry_db")
-    def test_bulk_get_project_preferences_returns_preferences(self, mock_bulk_read: Any) -> None:
+    def test_bulk_get_project_preferences_returns_preferences(self) -> None:
         project1 = self.create_project(organization=self.organization)
         project2 = self.create_project(organization=self.organization)
-        mock_bulk_read.return_value = {
-            project1.id: MagicMock(
-                dict=MagicMock(return_value={"project_id": project1.id, "repositories": []})
-            ),
-            project2.id: None,
-        }
+        repo1 = self.create_repo(
+            project=project1,
+            provider="integrations:github",
+            external_id="111",
+            name="getsentry/p1",
+        )
+        SeerProjectRepository.objects.create(project=project1, repository=repo1)
+
         result = bulk_get_project_preferences(
             organization_id=self.organization.id,
             project_ids=[project1.id, project2.id],
         )
-        assert result == {
-            str(project1.id): {"project_id": project1.id, "repositories": []},
-            str(project2.id): None,
-        }
-        mock_bulk_read.assert_called_once_with(self.organization.id, [project1.id, project2.id])
 
-    @with_feature("organizations:seer-project-settings-read-from-sentry")
-    @patch("sentry.seer.endpoints.seer_rpc.bulk_read_preferences_from_sentry_db")
-    def test_bulk_get_project_preferences_returns_empty_for_no_projects(
-        self, mock_bulk_read: Any
-    ) -> None:
-        mock_bulk_read.return_value = {}
+        assert set(result) == {str(project1.id), str(project2.id)}
+        assert len(result[str(project1.id)]["repositories"]) == 1
+        assert result[str(project1.id)]["repositories"][0]["external_id"] == "111"
+        assert result[str(project2.id)]["repositories"] == []
+
+    def test_bulk_get_project_preferences_returns_empty_for_no_projects(self) -> None:
         result = bulk_get_project_preferences(
             organization_id=self.organization.id,
             project_ids=[],
         )
         assert result == {}
-
-    @patch("sentry.seer.endpoints.seer_rpc.bulk_get_project_seer_preferences")
-    def test_bulk_get_project_preferences_seer_api(self, mock_seer: Any) -> None:
-        project1 = self.create_project(organization=self.organization)
-        project2 = self.create_project(organization=self.organization)
-        mock_seer.return_value = {
-            str(project1.id): {"project_id": project1.id, "repositories": []},
-            str(project2.id): None,
-        }
-        result = bulk_get_project_preferences(
-            organization_id=self.organization.id,
-            project_ids=[project1.id, project2.id],
-        )
-        assert result == {
-            str(project1.id): {"project_id": project1.id, "repositories": []},
-            str(project2.id): None,
-        }
-        mock_seer.assert_called_once_with(self.organization.id, [project1.id, project2.id])
 
 
 class TestTriggerCodingAgentLaunch:

--- a/tests/sentry/tasks/seer/test_context_engine_index.py
+++ b/tests/sentry/tasks/seer/test_context_engine_index.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 
 from sentry.seer.explorer.context_engine_utils import ProjectEventCounts
-from sentry.seer.models import SeerProjectPreference, SeerRepoDefinition
+from sentry.seer.models.project_repository import SeerProjectRepository
 from sentry.tasks.seer.context_engine_index import (
     get_allowed_org_ids_context_engine_indexing,
     index_org_project_knowledge,
@@ -254,71 +254,45 @@ class TestIndexRepos(TestCase):
             organization_integration=self.org_integration,
         )
 
-    @mock.patch("sentry.tasks.seer.context_engine_index.bulk_get_project_preferences")
     @mock.patch("sentry.tasks.seer.context_engine_index.make_org_repo_knowledge_index_request")
     def test_returns_early_when_option_disabled(
-        self, mock_make_org_repo_knowledge_index_request, mock_bulk_get_project_preferences
+        self, mock_make_org_repo_knowledge_index_request
     ) -> None:
         with override_options({"explorer.context_engine_indexing.enable": False}):
             index_repos(self.org.id)
         mock_make_org_repo_knowledge_index_request.assert_not_called()
 
-    @mock.patch("sentry.tasks.seer.context_engine_index.bulk_get_project_preferences")
     @mock.patch("sentry.tasks.seer.context_engine_index.make_org_repo_knowledge_index_request")
     def test_returns_early_when_feature_flag_disabled(
-        self, mock_mock_make_org_repo_knowledge_index_request, mock_bulk_get_project_preferences
+        self, mock_make_org_repo_knowledge_index_request
     ) -> None:
         with override_options({"explorer.context_engine_indexing.enable": True}):
             index_repos(self.org.id)
-        mock_mock_make_org_repo_knowledge_index_request.assert_not_called()
+        mock_make_org_repo_knowledge_index_request.assert_not_called()
 
-    @mock.patch("sentry.tasks.seer.context_engine_index.bulk_get_project_preferences")
     @mock.patch("sentry.tasks.seer.context_engine_index.make_org_repo_knowledge_index_request")
     def test_returns_early_when_no_projects(
-        self, mock_mock_make_org_repo_knowledge_index_request, mock_bulk_get_project_preferences
+        self, mock_make_org_repo_knowledge_index_request
     ) -> None:
         org_without_projects = self.create_organization()
         with override_options({"explorer.context_engine_indexing.enable": True}):
             with self.feature({"organizations:context-engine-experiments": True}):
                 index_repos(org_without_projects.id)
-        mock_mock_make_org_repo_knowledge_index_request.assert_not_called()
+        mock_make_org_repo_knowledge_index_request.assert_not_called()
 
-    @mock.patch("sentry.tasks.seer.context_engine_index.bulk_get_project_preferences")
     @mock.patch("sentry.tasks.seer.context_engine_index.make_org_repo_knowledge_index_request")
     def test_calls_seer_with_correct_org_and_repos(
-        self, mock_mock_make_org_repo_knowledge_index_request, mock_bulk_get_project_preferences
+        self, mock_make_org_repo_knowledge_index_request
     ) -> None:
-        mock_bulk_get_project_preferences.return_value = {
-            str(self.project1.id): {
-                "repositories": [
-                    {
-                        "name": "sentry",
-                        "owner": "getsentry",
-                        "provider": "integrations:github",
-                        "external_id": "123",
-                        "integration_id": str(self.integration.id),
-                    }
-                ],
-            },
-            str(self.project2.id): {
-                "repositories": [
-                    {
-                        "name": "relay",
-                        "owner": "getsentry",
-                        "provider": "integrations:github",
-                        "external_id": "456",
-                        "integration_id": str(self.integration.id),
-                    }
-                ],
-            },
-        }
-        mock_mock_make_org_repo_knowledge_index_request.return_value.status = 200
+        SeerProjectRepository.objects.create(project=self.project1, repository=self.repo1)
+        SeerProjectRepository.objects.create(project=self.project2, repository=self.repo2)
+        mock_make_org_repo_knowledge_index_request.return_value.status = 200
         with override_options({"explorer.context_engine_indexing.enable": True}):
             with self.feature({"organizations:context-engine-experiments": True}):
                 index_repos(self.org.id)
 
-        mock_mock_make_org_repo_knowledge_index_request.assert_called_once()
-        body = mock_mock_make_org_repo_knowledge_index_request.call_args[0][0]
+        mock_make_org_repo_knowledge_index_request.assert_called_once()
+        body = mock_make_org_repo_knowledge_index_request.call_args[0][0]
         assert body["org_id"] == self.org.id
         repos = body["repos"]
         assert len(repos) == 2
@@ -340,36 +314,13 @@ class TestIndexRepos(TestCase):
         assert relay_repo["project_ids"] == [self.project2.id]
         assert relay_repo["integration_id"] == str(self.integration.id)
 
-    @mock.patch("sentry.tasks.seer.context_engine_index.bulk_get_project_preferences")
     @mock.patch("sentry.tasks.seer.context_engine_index.make_org_repo_knowledge_index_request")
     def test_deduplicates_repos_across_projects(
-        self, mock_mock_make_org_repo_knowledge_index_request, mock_bulk_get_project_preferences
+        self, mock_make_org_repo_knowledge_index_request
     ) -> None:
-        mock_bulk_get_project_preferences.return_value = {
-            str(self.project1.id): {
-                "repositories": [
-                    {
-                        "name": "sentry",
-                        "owner": "getsentry",
-                        "provider": "integrations:github",
-                        "external_id": "123",
-                        "integration_id": str(self.integration.id),
-                    }
-                ],
-            },
-            str(self.project2.id): {
-                "repositories": [
-                    {
-                        "name": "sentry",
-                        "owner": "getsentry",
-                        "provider": "integrations:github",
-                        "external_id": "123",
-                        "integration_id": str(self.integration.id),
-                    }
-                ],
-            },
-        }
-        mock_mock_make_org_repo_knowledge_index_request.return_value.status = 200
+        SeerProjectRepository.objects.create(project=self.project1, repository=self.repo1)
+        SeerProjectRepository.objects.create(project=self.project2, repository=self.repo1)
+        mock_make_org_repo_knowledge_index_request.return_value.status = 200
         # Map project2 to the same repo as project1
         self.create_code_mapping(
             project=self.project2,
@@ -383,20 +334,19 @@ class TestIndexRepos(TestCase):
             with self.feature({"organizations:context-engine-experiments": True}):
                 index_repos(self.org.id)
 
-        mock_mock_make_org_repo_knowledge_index_request.assert_called_once()
-        body = mock_mock_make_org_repo_knowledge_index_request.call_args[0][0]
+        mock_make_org_repo_knowledge_index_request.assert_called_once()
+        body = mock_make_org_repo_knowledge_index_request.call_args[0][0]
         repos = body["repos"]
         repos_by_name = {r["name"]: r for r in repos}
 
         sentry_repo = repos_by_name["sentry"]
         assert sorted(sentry_repo["project_ids"]) == sorted([self.project1.id, self.project2.id])
 
-    @mock.patch("sentry.tasks.seer.context_engine_index.bulk_get_project_preferences")
     @mock.patch("sentry.tasks.seer.context_engine_index.make_org_repo_knowledge_index_request")
     def test_uses_seer_project_preferences_if_available(
-        self, mock_mock_make_org_repo_knowledge_index_request, mock_bulk_get_project_preferences
+        self, mock_make_org_repo_knowledge_index_request
     ) -> None:
-        mock_mock_make_org_repo_knowledge_index_request.return_value.status = 200
+        mock_make_org_repo_knowledge_index_request.return_value.status = 200
         # Map project2 to the same repo as project1
         self.create_code_mapping(
             project=self.project2,
@@ -406,29 +356,21 @@ class TestIndexRepos(TestCase):
             source_root="src/",
         )
 
-        mock_bulk_get_project_preferences.return_value = {
-            str(self.project1.id): {
-                "repositories": [
-                    {
-                        "name": "sentry-seer",
-                        "owner": "getsentry",
-                        "provider": "integrations:github",
-                        "external_id": "999",
-                        "integration_id": "000",
-                    }
-                ],
-            },
-            str(self.project2.id): {
-                "repositories": None,
-            },
-        }
+        seer_repo = self.create_repo(
+            project=self.project1,
+            name="getsentry/sentry-seer",
+            provider="integrations:github",
+            external_id="999",
+            integration_id=self.integration.id,
+        )
+        SeerProjectRepository.objects.create(project=self.project1, repository=seer_repo)
 
         with override_options({"explorer.context_engine_indexing.enable": True}):
             with self.feature({"organizations:context-engine-experiments": True}):
                 index_repos(self.org.id)
 
-        mock_mock_make_org_repo_knowledge_index_request.assert_called_once()
-        body = mock_mock_make_org_repo_knowledge_index_request.call_args[0][0]
+        mock_make_org_repo_knowledge_index_request.assert_called_once()
+        body = mock_make_org_repo_knowledge_index_request.call_args[0][0]
         repos = body["repos"]
         repos_by_name = {r["name"]: r for r in repos}
 
@@ -436,84 +378,25 @@ class TestIndexRepos(TestCase):
         sentry_repo = repos_by_name["sentry-seer"]
         assert sorted(sentry_repo["project_ids"]) == sorted([self.project1.id])
 
-    @mock.patch("sentry.tasks.seer.context_engine_index.bulk_get_project_preferences")
     @mock.patch("sentry.tasks.seer.context_engine_index.make_org_repo_knowledge_index_request")
-    def test_skips_projects_without_seer_preferences(
-        self, mock_mock_make_org_repo_knowledge_index_request, mock_bulk_get_project_preferences
+    def test_skips_projects_without_seer_repositories(
+        self, mock_make_org_repo_knowledge_index_request
     ) -> None:
-        mock_mock_make_org_repo_knowledge_index_request.return_value.status = 200
+        mock_make_org_repo_knowledge_index_request.return_value.status = 200
 
-        # Only project1 has preferences; project2 is absent from the map
-        mock_bulk_get_project_preferences.return_value = {
-            str(self.project1.id): {
-                "repositories": [
-                    {
-                        "name": "sentry",
-                        "owner": "getsentry",
-                        "provider": "integrations:github",
-                        "external_id": "123",
-                        "integration_id": str(self.integration.id),
-                    }
-                ],
-            },
-        }
+        SeerProjectRepository.objects.create(project=self.project1, repository=self.repo1)
+        # project2 has no SeerProjectRepository rows.
 
         with override_options({"explorer.context_engine_indexing.enable": True}):
             with self.feature({"organizations:context-engine-experiments": True}):
                 index_repos(self.org.id)
 
-        mock_mock_make_org_repo_knowledge_index_request.assert_called_once()
-        body = mock_mock_make_org_repo_knowledge_index_request.call_args[0][0]
-        repos = body["repos"]
-
-        assert len(repos) == 1
-        assert repos[0]["name"] == "sentry"
-        assert repos[0]["project_ids"] == [self.project1.id]
-
-    @mock.patch("sentry.tasks.seer.context_engine_index.bulk_read_preferences_from_sentry_db")
-    @mock.patch("sentry.tasks.seer.context_engine_index.bulk_get_project_preferences")
-    @mock.patch("sentry.tasks.seer.context_engine_index.make_org_repo_knowledge_index_request")
-    def test_reads_from_sentry_db(
-        self,
-        mock_make_org_repo_knowledge_index_request,
-        mock_bulk_get_preferences,
-        mock_bulk_read_db,
-    ) -> None:
-        """When feature flag enabled, reads preferences from Sentry DB instead of Seer API."""
-        mock_make_org_repo_knowledge_index_request.return_value.status = 200
-        mock_bulk_read_db.return_value = {
-            self.project1.id: SeerProjectPreference(
-                organization_id=self.org.id,
-                project_id=self.project1.id,
-                repositories=[
-                    SeerRepoDefinition(
-                        provider="integrations:github",
-                        owner="getsentry",
-                        name="sentry",
-                        external_id="123",
-                        integration_id=str(self.integration.id),
-                    )
-                ],
-            ),
-        }
-
-        with override_options({"explorer.context_engine_indexing.enable": True}):
-            with self.feature(
-                {
-                    "organizations:context-engine-experiments": True,
-                    "organizations:seer-project-settings-read-from-sentry": True,
-                }
-            ):
-                index_repos(self.org.id)
-
-        mock_bulk_get_preferences.assert_not_called()
-        mock_bulk_read_db.assert_called_once()
         mock_make_org_repo_knowledge_index_request.assert_called_once()
         body = mock_make_org_repo_knowledge_index_request.call_args[0][0]
         repos = body["repos"]
         assert len(repos) == 1
         assert repos[0]["name"] == "sentry"
-        assert repos[0]["owner"] == "getsentry"
+        assert repos[0]["project_ids"] == [self.project1.id]
 
 
 @django_db_all

--- a/tests/sentry/tasks/seer/test_context_engine_index.py
+++ b/tests/sentry/tasks/seer/test_context_engine_index.py
@@ -396,7 +396,7 @@ class TestIndexRepos(TestCase):
         repos = body["repos"]
         assert len(repos) == 1
         assert repos[0]["name"] == "sentry"
-        assert repos[0]["project_ids"] == ["getsentry"]
+        assert repos[0]["project_ids"] == [self.project1.id]
 
 
 @django_db_all

--- a/tests/sentry/tasks/seer/test_context_engine_index.py
+++ b/tests/sentry/tasks/seer/test_context_engine_index.py
@@ -396,7 +396,7 @@ class TestIndexRepos(TestCase):
         repos = body["repos"]
         assert len(repos) == 1
         assert repos[0]["name"] == "sentry"
-        assert repos[0]["project_ids"] == [self.project1.id]
+        assert repos[0]["project_ids"] == ["getsentry"]
 
 
 @django_db_all

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -21,10 +21,7 @@ from sentry.testutils.cases import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.pytest.fixtures import django_db_all
 
-NIGHT_SHIFT_FEATURES = [
-    "organizations:seer-project-settings-read-from-sentry",
-    "projects:seer-night-shift",
-]
+NIGHT_SHIFT_FEATURES = ["projects:seer-night-shift"]
 
 
 class FakeExplorerClient:
@@ -178,12 +175,7 @@ class TestGetEligibleProjects(TestCase):
         repo = self.create_repo(project=project, provider="github", name="owner/repo")
         SeerProjectRepository.objects.create(project=project, repository=repo)
 
-        with self.feature(
-            {
-                "organizations:seer-project-settings-read-from-sentry": True,
-                "projects:seer-night-shift": False,
-            }
-        ):
+        with self.feature({"projects:seer-night-shift": False}):
             projects, _ = _get_eligible_projects(org)
             assert projects == []
 


### PR DESCRIPTION
Relates to CW-1175

First step in migrating project-preference reads off the Seer API. Flips the following read call sites to read from the Sentry DB and removes the `organizations:seer-project-settings-read-from-sentry` flag from them. Writes still dual-write via the Seer API. Types tightened where possible.

Modified callsites:
- `ProjectSeerPreferencesEndpoint.get`
- Seer RPCs `get_project_preferences` / `bulk_get_project_preferences`
- `has_project_connected_repos` and removed the Seer API cache (no longer needed for a local DB hit)
- Deleted the `bulk_read_preferences` wrapper and `_resolve_project_preference`; callers use `bulk_read_preferences_from_sentry_db` / `read_preference_from_sentry_db` directly. `_call_autofix` now derives repos from `preference.repositories` itself.
- night shift `_get_eligible_projects` and context engine `index_repos` consume typed `SeerProjectPreference` objects directly instead of dict round-tripping

Affected tests updated to create real `SeerProjectRepository` rows and project options instead of mocking the Seer API. Removed tests for now-unreachable Seer-API fallback paths. **Most of this large PR is just updated tests** :) 