### PR TITLE
feat(seer-explorer): Disable 'New chat' button when in empty state

### DIFF
--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
@@ -327,6 +327,7 @@ export function ExplorerDrawerContent({
         }}
         onChangeSession={switchToRun}
         copySessionEnabled={copySessionEnabled}
+        isEmptyState={isEmptyState}
         onCopySessionClick={copySessionToClipboard}
         overrideCtxEngEnable={overrideCtxEngEnable}
         onOverrideCtxEngEnableToggle={() => setOverrideCtxEngEnable(v => !v)}

--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerHeader.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerHeader.tsx
@@ -19,6 +19,7 @@ import {isSeerExplorerEnabled} from 'sentry/views/seerExplorer/utils';
 
 interface ExplorerDrawerHeaderProps {
   copySessionEnabled: boolean;
+  isEmptyState: boolean;
   onChangeSession: (runId: number) => void;
   onCopySessionClick: () => void;
   onNewChatClick: () => void;
@@ -34,6 +35,7 @@ export function ExplorerDrawerHeader({
   onNewChatClick,
   onChangeSession,
   copySessionEnabled,
+  isEmptyState,
   onCopySessionClick,
   showContextEngineToggle,
   overrideCtxEngEnable,
@@ -174,6 +176,7 @@ export function ExplorerDrawerHeader({
         <Button
           icon={<IconAdd />}
           onClick={onNewChatClick}
+          disabled={isEmptyState}
           priority="default"
           size="xs"
           aria-label={t('Start a new chat (/new)')}


### PR DESCRIPTION
Disable the 'New chat' button in the Seer Explorer drawer header when the session is in an empty state (no blocks and not awaiting user input).

When `isEmptyState` is true, there is no existing conversation to replace — clicking 'New chat' would be a no-op. Disabling the button makes this state clear to users and avoids confusion about whether the action did anything.

`isEmptyState` is already computed in `ExplorerDrawerContent` and passed down to `ExplorerDrawerHeader` as a new prop.