### PR TITLE
feat(integrations): Add migration to backfill SCM toggles onto OrganizationIntegration config

### DIFF
--- a/migrations_lockfile.txt
+++ b/migrations_lockfile.txt
@@ -31,7 +31,7 @@ replays: 0007_organizationmember_replay_access
 
 seer: 0007_add_extras_to_nightshiftrun
 
-sentry: 1071_add_broadcast_sync_locked
+sentry: 1072_backfill_scm_integration_config
 
 social_auth: 0003_social_auth_json_field
 

--- a/src/sentry/migrations/1072_backfill_scm_integration_config.py
+++ b/src/sentry/migrations/1072_backfill_scm_integration_config.py
@@ -1,0 +1,96 @@
+import logging
+
+from django.db import migrations
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+
+from sentry.constants import ObjectStatus
+from sentry.new_migrations.migrations import CheckedMigration
+from sentry.utils.query import RangeQuerySetWrapperWithProgressBarApprox
+
+logger = logging.getLogger(__name__)
+
+# Maps OrganizationOption key -> (integration provider, OI config key).
+# Mirrors the mapping used by the live fan-out write in
+# src/sentry/core/endpoints/organization_details.py so a backfill and
+# any newly installed OI end up consistent.
+_PROVIDER_KEYS = {
+    "github": [
+        ("sentry:github_pr_bot", "pr_comments"),
+        ("sentry:github_nudge_invite", "nudge_invite"),
+    ],
+    "gitlab": [
+        ("sentry:gitlab_pr_bot", "pr_comments"),
+    ],
+}
+
+
+def backfill_scm_integration_config(
+    apps: StateApps, schema_editor: BaseDatabaseSchemaEditor
+) -> None:
+    OrganizationIntegration = apps.get_model("sentry", "OrganizationIntegration")
+    OrganizationOption = apps.get_model("sentry", "OrganizationOption")
+
+    # Iterate the whole OI table — the approx wrapper needs an unfiltered
+    # queryset, and we don't have an index on (status, id) or
+    # (integration_id, id) for a filtered range scan. Filtering in Python
+    # is cheaper than either alternative.
+    queryset = OrganizationIntegration.objects.all().select_related("integration")
+
+    for oi in RangeQuerySetWrapperWithProgressBarApprox(queryset):
+        if oi.status != ObjectStatus.ACTIVE:
+            continue
+        provider = oi.integration.provider
+        key_pairs = _PROVIDER_KEYS.get(provider)
+        if not key_pairs:
+            continue
+
+        option_keys = [opt_key for opt_key, _ in key_pairs]
+        opts = {
+            opt.key: opt.value
+            for opt in OrganizationOption.objects.filter(
+                organization_id=oi.organization_id,
+                key__in=option_keys,
+            )
+        }
+        if not opts:
+            continue
+
+        config = dict(oi.config or {})
+        changed = False
+        for opt_key, cfg_key in key_pairs:
+            if opt_key in opts and cfg_key not in config:
+                config[cfg_key] = bool(opts[opt_key])
+                changed = True
+
+        if changed:
+            oi.config = config
+            oi.save(update_fields=["config"])
+
+
+class Migration(CheckedMigration):
+    # This flag is used to mark that a migration shouldn't be automatically run in production.
+    # This should only be used for operations where it's safe to run the migration after your
+    # code has deployed. So this should not be used for most operations that alter the schema
+    # of a table.
+    # Here are some things that make sense to mark as post deployment:
+    # - Large data migrations. Typically we want these to be run manually so that they can be
+    #   monitored and not block the deploy for a long period of time while they run.
+    # - Adding indexes to large tables. Since this can take a long time, we'd generally prefer to
+    #   run this outside deployments so that we don't block them. Note that while adding an index
+    #   is a schema change, it's completely safe to run the operation after the code has deployed.
+    # Once deployed, run these manually via: https://develop.sentry.dev/database-migrations/#migration-deployment
+
+    is_post_deployment = True
+
+    dependencies = [
+        ("sentry", "1071_add_broadcast_sync_locked"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            backfill_scm_integration_config,
+            migrations.RunPython.noop,
+            hints={"tables": ["sentry_organizationintegration"]},
+        ),
+    ]

--- a/tests/sentry/migrations/test_1072_backfill_scm_integration_config.py
+++ b/tests/sentry/migrations/test_1072_backfill_scm_integration_config.py
@@ -1,0 +1,101 @@
+import importlib
+
+from django.apps import apps as global_apps
+
+from sentry.constants import ObjectStatus
+from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.models.options.organization_option import OrganizationOption
+from sentry.silo.base import SiloMode
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import assume_test_silo_mode
+
+migration = importlib.import_module("sentry.migrations.1072_backfill_scm_integration_config")
+
+
+class BackfillScmIntegrationConfigTest(TestCase):
+    def test_backfill(self) -> None:
+        github = self.create_integration(
+            organization=self.organization, provider="github", external_id="gh-1"
+        )
+        gitlab = self.create_integration(
+            organization=self.organization, provider="gitlab", external_id="gl-1"
+        )
+        with assume_test_silo_mode(SiloMode.CELL):
+            OrganizationOption.objects.set_value(
+                organization=self.organization, key="sentry:github_pr_bot", value=True
+            )
+            OrganizationOption.objects.set_value(
+                organization=self.organization, key="sentry:github_nudge_invite", value=False
+            )
+            OrganizationOption.objects.set_value(
+                organization=self.organization, key="sentry:gitlab_pr_bot", value=True
+            )
+
+        other_org = self.create_organization()
+        preset_github = self.create_integration(
+            organization=other_org,
+            provider="github",
+            external_id="gh-preset",
+            oi_params={"config": {"pr_comments": False, "other_key": "kept"}},
+        )
+        with assume_test_silo_mode(SiloMode.CELL):
+            OrganizationOption.objects.set_value(
+                organization=other_org, key="sentry:github_pr_bot", value=True
+            )
+            OrganizationOption.objects.set_value(
+                organization=other_org, key="sentry:github_nudge_invite", value=True
+            )
+
+        no_option_org = self.create_organization()
+        untouched_github = self.create_integration(
+            organization=no_option_org, provider="github", external_id="gh-nooptions"
+        )
+
+        disabled_org = self.create_organization()
+        disabled_github = self.create_integration(
+            organization=disabled_org,
+            provider="github",
+            external_id="gh-disabled",
+            oi_params={"status": ObjectStatus.DISABLED},
+        )
+        with assume_test_silo_mode(SiloMode.CELL):
+            OrganizationOption.objects.set_value(
+                organization=disabled_org, key="sentry:github_pr_bot", value=True
+            )
+
+        non_scm_org = self.create_organization()
+        slack = self.create_integration(
+            organization=non_scm_org, provider="slack", external_id="slack-1"
+        )
+
+        with assume_test_silo_mode(SiloMode.MONOLITH):
+            migration.backfill_scm_integration_config(global_apps, None)
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            github_oi = OrganizationIntegration.objects.get(
+                integration_id=github.id, organization_id=self.organization.id
+            )
+            gitlab_oi = OrganizationIntegration.objects.get(
+                integration_id=gitlab.id, organization_id=self.organization.id
+            )
+            preset_oi = OrganizationIntegration.objects.get(
+                integration_id=preset_github.id, organization_id=other_org.id
+            )
+            untouched_oi = OrganizationIntegration.objects.get(
+                integration_id=untouched_github.id, organization_id=no_option_org.id
+            )
+            disabled_oi = OrganizationIntegration.objects.get(
+                integration_id=disabled_github.id, organization_id=disabled_org.id
+            )
+            slack_oi = OrganizationIntegration.objects.get(
+                integration_id=slack.id, organization_id=non_scm_org.id
+            )
+
+        assert github_oi.config == {"pr_comments": True, "nudge_invite": False}
+        assert gitlab_oi.config == {"pr_comments": True}
+        assert preset_oi.config["pr_comments"] is False
+        assert preset_oi.config["nudge_invite"] is True
+        assert preset_oi.config["other_key"] == "kept"
+        assert untouched_oi.config == {}
+        assert disabled_oi.config == {}
+        assert slack_oi.config == {}


### PR DESCRIPTION
Phase 1 of VDY-110. Adds post-deployment migration 1072 that seeds
OrganizationIntegration.config.pr_comments and .nudge_invite from each
org's current sentry:github_pr_bot / sentry:github_nudge_invite /
sentry:gitlab_pr_bot OrganizationOption value, scoped to active GitHub
and GitLab OIs.

The migration is idempotent: it only writes keys that are not already
present on the OI config, so it can be re-run safely and will not
clobber anything seeded by later code. Lands after the dual-write so
new installs are already mirroring before the backfill fills in the
existing population.

Ref: [VDY-110](https://linear.app/getsentry/issue/VDY-110/move-scm-integration-settings-from-org-options-to-per-integration)

## Migration phases

- ○ Phase 1 — Dual-write SCM toggles: [#113842](https://github.com/getsentry/sentry/pull/113842)
- ○ Phase 1 — Backfill existing OIs: [#113841](https://github.com/getsentry/sentry/pull/113841) _(This PR)_
- ○ Phase 2 — Read from OI config behind flag: [#113864](https://github.com/getsentry/sentry/pull/113864)
- ○ Phase 3 — UI move: upcoming
- ○ Phase 4 — Remove legacy code paths: upcoming
