### PR TITLE
feat(integrations): Dual-write SCM org-option toggles onto OrganizationIntegration config

### DIFF
--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import logging
 from copy import copy
 from datetime import datetime, timedelta, timezone
@@ -122,6 +123,50 @@ ERR_NO_2FA = "Cannot require two-factor authentication without personal two-fact
 ERR_SSO_ENABLED = "Cannot require two-factor authentication with SSO enabled"
 ERR_3RD_PARTY_PUBLISHED_APP = "Cannot delete an organization that owns a published integration. Contact support if you need assistance."
 ERR_PLAN_REQUIRED = "A paid plan is required to enable this feature."
+
+
+# Maps legacy organization-option keys to the (integration provider,
+# OrganizationIntegration.config key) they now mirror. Used by the Phase 1
+# dual-write during the VDY-110 migration of SCM toggles onto the
+# per-integration config.
+_SCM_OPTION_TO_OI_CONFIG: dict[str, tuple[str, str]] = {
+    "sentry:github_pr_bot": ("github", "pr_comments"),
+    "sentry:github_nudge_invite": ("github", "nudge_invite"),
+    "sentry:gitlab_pr_bot": ("gitlab", "pr_comments"),
+}
+
+
+def _mirror_scm_option_to_oi_config(organization_id: int, option_key: str, value: bool) -> None:
+    mapping = _SCM_OPTION_TO_OI_CONFIG.get(option_key)
+    if mapping is None:
+        return
+    provider, config_key = mapping
+
+    ois = integration_service.get_organization_integrations(
+        organization_id=organization_id,
+        providers=[provider],
+        status=ObjectStatus.ACTIVE,
+    )
+    for oi in ois:
+        merged = dict(oi.config or {})
+        if merged.get(config_key) == value:
+            continue
+        merged[config_key] = value
+        integration_service.update_organization_integration(org_integration_id=oi.id, config=merged)
+
+
+def _schedule_scm_option_mirror(org: Organization, option_key: str, value: object) -> None:
+    if option_key not in _SCM_OPTION_TO_OI_CONFIG:
+        return
+    transaction.on_commit(
+        functools.partial(
+            _mirror_scm_option_to_oi_config,
+            organization_id=org.id,
+            option_key=option_key,
+            value=bool(value),
+        ),
+        using=router.db_for_write(Organization),
+    )
 
 
 ORG_OPTIONS = (
@@ -669,12 +714,14 @@ class OrganizationSerializer(BaseOrganizationSerializer):
 
                 if data[key] != default_value:
                     changed_data[key] = f"to {data[key]}"
+                    _schedule_scm_option_mirror(org, option, data[key])
             else:
                 option_inst.value = data[key]
                 # check if ORG_OPTIONS changed
                 if has_changed(option_inst, "value"):
                     old_val = old_value(option_inst, "value")
                     changed_data[key] = f"from {old_val} to {option_inst.value}"
+                    _schedule_scm_option_mirror(org, option, data[key])
                 option_inst.save()
 
         trusted_relay_info = data.get("trustedRelays")

--- a/tests/sentry/core/endpoints/test_organization_details.py
+++ b/tests/sentry/core/endpoints/test_organization_details.py
@@ -28,6 +28,7 @@ from sentry.constants import (
 from sentry.core.endpoints.organization_details import ERR_NO_2FA, ERR_SSO_ENABLED
 from sentry.deletions.models.scheduleddeletion import CellScheduledDeletion
 from sentry.dynamic_sampling.types import DynamicSamplingMode
+from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.authprovider import AuthProvider
 from sentry.models.avatars.organization_avatar import OrganizationAvatar
@@ -871,6 +872,103 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         assert "to {}".format(data["issueAlertsThreadFlag"]) in log.data["issueAlertsThreadFlag"]
         assert "to {}".format(data["metricAlertsThreadFlag"]) in log.data["metricAlertsThreadFlag"]
         assert "to Default Mode" in log.data["samplingMode"]
+
+    def test_scm_option_fans_out_to_organization_integration_config(self) -> None:
+        github = self.create_integration(
+            organization=self.organization, provider="github", external_id="gh-1"
+        )
+        gitlab = self.create_integration(
+            organization=self.organization, provider="gitlab", external_id="gl-1"
+        )
+
+        # Freshly created integrations have no SCM-toggle config yet.
+        with assume_test_silo_mode_of(OrganizationIntegration):
+            github_oi = OrganizationIntegration.objects.get(
+                organization_id=self.organization.id, integration=github
+            )
+            gitlab_oi = OrganizationIntegration.objects.get(
+                organization_id=self.organization.id, integration=gitlab
+            )
+        assert github_oi.config.get("pr_comments") is None
+        assert github_oi.config.get("nudge_invite") is None
+        assert gitlab_oi.config.get("pr_comments") is None
+
+        with outbox_runner():
+            self.get_success_response(
+                self.organization.slug,
+                githubPRBot=True,
+                githubNudgeInvite=True,
+                gitlabPRBot=True,
+            )
+
+        with assume_test_silo_mode_of(OrganizationIntegration):
+            github_oi = OrganizationIntegration.objects.get(
+                organization_id=self.organization.id, integration=github
+            )
+            gitlab_oi = OrganizationIntegration.objects.get(
+                organization_id=self.organization.id, integration=gitlab
+            )
+
+        assert github_oi.config.get("pr_comments") is True
+        assert github_oi.config.get("nudge_invite") is True
+        assert gitlab_oi.config.get("pr_comments") is True
+        # GitLab has no nudge_invite key; toggle must not leak across providers.
+        assert "nudge_invite" not in gitlab_oi.config
+
+    def test_scm_option_fanout_only_touches_active_integrations(self) -> None:
+        active = self.create_integration(
+            organization=self.organization, provider="github", external_id="gh-active"
+        )
+        disabled = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            external_id="gh-disabled",
+            oi_params={"status": ObjectStatus.DISABLED},
+        )
+
+        # Both integrations start with no pr_comments config.
+        with assume_test_silo_mode_of(OrganizationIntegration):
+            active_oi = OrganizationIntegration.objects.get(
+                organization_id=self.organization.id, integration=active
+            )
+            disabled_oi = OrganizationIntegration.objects.get(
+                organization_id=self.organization.id, integration=disabled
+            )
+        assert active_oi.config.get("pr_comments") is None
+        assert disabled_oi.config.get("pr_comments") is None
+
+        with outbox_runner():
+            self.get_success_response(self.organization.slug, githubPRBot=True)
+
+        with assume_test_silo_mode_of(OrganizationIntegration):
+            active_oi = OrganizationIntegration.objects.get(
+                organization_id=self.organization.id, integration=active
+            )
+            disabled_oi = OrganizationIntegration.objects.get(
+                organization_id=self.organization.id, integration=disabled
+            )
+
+        assert active_oi.config.get("pr_comments") is True
+        assert disabled_oi.config.get("pr_comments") is None
+
+    def test_scm_option_fanout_preserves_other_config_keys(self) -> None:
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            external_id="gh-keeps",
+            oi_params={"config": {"some_other_setting": "kept"}},
+        )
+
+        with outbox_runner():
+            self.get_success_response(self.organization.slug, githubPRBot=True)
+
+        with assume_test_silo_mode_of(OrganizationIntegration):
+            oi = OrganizationIntegration.objects.get(
+                organization_id=self.organization.id, integration=integration
+            )
+
+        assert oi.config.get("some_other_setting") == "kept"
+        assert oi.config.get("pr_comments") is True
 
     @responses.activate
     @patch(


### PR DESCRIPTION
Phase 1 of VDY-110. The GitHub and GitLab PR-comment and missing-member
toggles are moving from OrganizationOption onto OrganizationIntegration.config
so each install is independently configurable.

- OrganizationSerializer.save() now fans out writes to
  sentry:github_pr_bot, sentry:github_nudge_invite, and
  sentry:gitlab_pr_bot onto the corresponding per-integration config
  key (pr_comments / nudge_invite), scoped to active integrations.
- The fan-out is deferred to transaction.on_commit so the RPC to the
  control silo happens outside the cell-silo write transaction.

Reads still go through OrganizationOption; behavior is unchanged for
users. The next phase flips the read path.

Ref: [VDY-111: Phase 1: Dual-write SCM settings to integration config + backfill](https://linear.app/getsentry/issue/VDY-111/phase-1-dual-write-scm-settings-to-integration-config-backfill)

## Migration phases

- ● Phase 1 — Backfill existing OIs: [#113841](https://github.com/getsentry/sentry/pull/113841) (merged)
- ○ Phase 1 — Backfill cross-silo fix: [#113908](https://github.com/getsentry/sentry/pull/113908)
- ○ Phase 1 — Dual-write SCM toggles: [#113842](https://github.com/getsentry/sentry/pull/113842)
- ○ Phase 2 — Read from OI config behind flag: [#113864](https://github.com/getsentry/sentry/pull/113864)
- ○ Phase 3 — Expose toggles in per-install UI: [#113923](https://github.com/getsentry/sentry/pull/113923)
- ○ Phase 3 — Remove legacy detail-view toggles (frontend): [#113924](https://github.com/getsentry/sentry/pull/113924)
- ○ Phase 3 — Drop SCM toggle fields from PUT endpoint: [#113925](https://github.com/getsentry/sentry/pull/113925)
- ○ Phase 4 — Remove legacy code paths: upcoming
