### PR TITLE
fix(seer-explorer): Restrict block actions and copy button to assistant role only

### DIFF
--- a/static/app/views/seerExplorer/components/blockComponents.tsx
+++ b/static/app/views/seerExplorer/components/blockComponents.tsx
@@ -364,9 +364,10 @@ export function BlockComponent({
     !isAwaitingFileApproval &&
     !isAwaitingQuestion &&
     !readOnly &&
-    block.message.role !== 'user';
+    block.message.role === 'assistant';
   const showFeedbackButtons = block.message.role === 'assistant';
-  const showCopyButton = block.message.role !== 'user' && !!block.message.content?.trim();
+  const showCopyButton =
+    block.message.role === 'assistant' && !!block.message.content?.trim();
 
   const blockStatus = getToolStatus(block);
   const isLoadingPlaceholder = blockStatus === 'loading' && !hasTools;

--- a/static/app/views/seerExplorer/components/blockComponents.tsx
+++ b/static/app/views/seerExplorer/components/blockComponents.tsx
@@ -150,7 +150,6 @@ export function BlockComponent({
   onMouseLeave,
   onNavigate,
   onRegisterEnterHandler,
-  readOnly = false,
   ref,
 }: BlockProps) {
   const {copy} = useCopyToClipboard();

--- a/static/app/views/seerExplorer/components/blockComponents.tsx
+++ b/static/app/views/seerExplorer/components/blockComponents.tsx
@@ -363,7 +363,6 @@ export function BlockComponent({
     !block.loading &&
     !isAwaitingFileApproval &&
     !isAwaitingQuestion &&
-    !readOnly &&
     block.message.role === 'assistant';
   const showFeedbackButtons = block.message.role === 'assistant';
   const showCopyButton =


### PR DESCRIPTION
`showActions` and `showCopyButton` in `BlockComponent` were gated on `role !== 'user'`, which meant they also activated for `tool` blocks. Both conditions are tightened to `role === 'assistant'` so the hover action bar and copy button only appear on assistant messages — matching the existing `showFeedbackButtons` behavior.