### PR TITLE
ref(explorer): Populate project repos in explorer user_org_context

### DIFF
--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -770,7 +770,6 @@ def read_preference_from_sentry_db(project: Project) -> SeerProjectPreference:
     """Read a single project's Seer preferences from Sentry DB.
 
     For now, should only be used under feature flag `organizations:seer-project-settings-read-from-sentry`."""
-
     seer_project_repo_qs = (
         SeerProjectRepository.objects.filter(project=project)
         .select_related("repository")

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -769,7 +769,14 @@ def _build_automation_handoff(
 def read_preference_from_sentry_db(project: Project) -> SeerProjectPreference:
     """Read a single project's Seer preferences from Sentry DB.
 
-    For now, should only be used under feature flag `organizations:seer-project-settings-read-from-sentry`."""
+    Returns an empty default preference if the project is not active."""
+    if project.status != ObjectStatus.ACTIVE:
+        return SeerProjectPreference(
+            organization_id=project.organization_id,
+            project_id=project.id,
+            repositories=[],
+        )
+
     seer_project_repo_qs = (
         SeerProjectRepository.objects.filter(project=project)
         .select_related("repository")
@@ -800,7 +807,13 @@ def bulk_read_preferences_from_sentry_db(
     if not project_ids:
         return {}
 
-    projects = list(Project.objects.filter(id__in=project_ids, organization_id=organization_id))
+    projects = list(
+        Project.objects.filter(
+            id__in=project_ids,
+            organization_id=organization_id,
+            status=ObjectStatus.ACTIVE,
+        )
+    )
 
     repo_definitions_by_project: defaultdict[int, list[SeerRepoDefinition]] = defaultdict(list)
     for project_repo in (

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -767,15 +767,7 @@ def _build_automation_handoff(
 
 
 def read_preference_from_sentry_db(project: Project) -> SeerProjectPreference:
-    """Read a single project's Seer preferences from Sentry DB.
-
-    Returns an empty default preference if the project is not active."""
-    if project.status != ObjectStatus.ACTIVE:
-        return SeerProjectPreference(
-            organization_id=project.organization_id,
-            project_id=project.id,
-            repositories=[],
-        )
+    """Read a single project's Seer preferences from Sentry DB."""
 
     seer_project_repo_qs = (
         SeerProjectRepository.objects.filter(project=project)
@@ -807,13 +799,7 @@ def bulk_read_preferences_from_sentry_db(
     if not project_ids:
         return {}
 
-    projects = list(
-        Project.objects.filter(
-            id__in=project_ids,
-            organization_id=organization_id,
-            status=ObjectStatus.ACTIVE,
-        )
-    )
+    projects = list(Project.objects.filter(id__in=project_ids, organization_id=organization_id))
 
     repo_definitions_by_project: defaultdict[int, list[SeerRepoDefinition]] = defaultdict(list)
     for project_repo in (

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -767,7 +767,9 @@ def _build_automation_handoff(
 
 
 def read_preference_from_sentry_db(project: Project) -> SeerProjectPreference:
-    """Read a single project's Seer preferences from Sentry DB."""
+    """Read a single project's Seer preferences from Sentry DB.
+
+    For now, should only be used under feature flag `organizations:seer-project-settings-read-from-sentry`."""
 
     seer_project_repo_qs = (
         SeerProjectRepository.objects.filter(project=project)

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -240,7 +240,7 @@ def has_seer_explorer_access_with_detail(
 def _collect_repos_by_project_id(
     organization: Organization, project_ids: list[int]
 ) -> dict[str, list[dict[str, Any]]]:
-    """Fetch repo lists for each project, keyed by project_id."""
+    """Fetch repo lists for each project, keyed by project id."""
     if not project_ids:
         return {}
 
@@ -276,7 +276,7 @@ def collect_user_org_context(
     repos_by_pid = _collect_repos_by_project_id(organization, [p["id"] for p in all_projects])
 
     all_org_projects = [
-        {"id": p["id"], "slug": p["slug"], "repos": repos_by_pid.get(str(p["id"]), [])}
+        {"id": p["id"], "slug": p["slug"], "repos": repos_by_pid.get(str(p["id"])) or []}
         for p in all_projects
     ]
 
@@ -313,7 +313,7 @@ def collect_user_org_context(
         .values("id", "slug")
     )
     user_projects = [
-        {"id": p["id"], "slug": p["slug"], "repos": repos_by_pid.get(str(p["id"]), [])}
+        {"id": p["id"], "slug": p["slug"], "repos": repos_by_pid.get(str(p["id"])) or []}
         for p in my_projects
     ]
 

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -25,6 +25,10 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.models.project import Project
 from sentry.net.http import connection_from_url
 from sentry.organizations.services.organization.model import RpcOrganization
+from sentry.seer.autofix.utils import (
+    bulk_get_project_preferences,
+    bulk_read_preferences_from_sentry_db,
+)
 from sentry.seer.explorer.client_models import SeerRunState
 from sentry.seer.models import SeerApiError
 from sentry.seer.seer_setup import has_seer_access_with_detail
@@ -232,6 +236,41 @@ def has_seer_explorer_access_with_detail(
     return True, None
 
 
+def _collect_repos_by_project_id(
+    organization: Organization, project_ids: list[int]
+) -> dict[str, list[dict[str, Any]]]:
+    """Fetch repo lists for each project, keyed by project_id (as string).
+
+    When `organizations:seer-project-settings-read-from-sentry` is on, reads
+    directly from Sentry's DB. Otherwise fetches via the Seer API.
+    """
+    if not project_ids:
+        return {}
+
+    if features.has("organizations:seer-project-settings-read-from-sentry", organization):
+        prefs_by_pid = bulk_read_preferences_from_sentry_db(organization.id, project_ids)
+        return {
+            str(pid): [repo.dict() for repo in pref.repositories]
+            for pid, pref in prefs_by_pid.items()
+        }
+
+    try:
+        seer_prefs = bulk_get_project_preferences(organization.id, project_ids)
+    except Exception:
+        logger.exception(
+            "Failed to fetch Seer project preferences for explorer context",
+            extra={"organization_id": organization.id},
+        )
+        return {}
+
+    repos_by_pid: dict[str, list[dict[str, Any]]] = {}
+    for pid, pref in seer_prefs.items():
+        if not pref:
+            continue
+        repos_by_pid[pid] = pref.get("repositories") or []
+    return repos_by_pid
+
+
 def collect_user_org_context(
     user: SentryUser | RpcUser | AnonymousUser | None,
     organization: Organization,
@@ -241,7 +280,13 @@ def collect_user_org_context(
     all_projects = Project.objects.filter(
         organization=organization, status=ObjectStatus.ACTIVE
     ).values("id", "slug")
-    all_org_projects = [{"id": p["id"], "slug": p["slug"]} for p in all_projects]
+
+    repos_by_pid = _collect_repos_by_project_id(organization, [p["id"] for p in all_projects])
+
+    all_org_projects = [
+        {"id": p["id"], "slug": p["slug"], "repos": repos_by_pid.get(str(p["id"]), [])}
+        for p in all_projects
+    ]
 
     if user is None or isinstance(user, AnonymousUser):
         return {
@@ -275,7 +320,10 @@ def collect_user_org_context(
         .distinct()
         .values("id", "slug")
     )
-    user_projects = [{"id": p["id"], "slug": p["slug"]} for p in my_projects]
+    user_projects = [
+        {"id": p["id"], "slug": p["slug"], "repos": repos_by_pid.get(str(p["id"]), [])}
+        for p in my_projects
+    ]
 
     # Handle name attribute - SentryUser has name
     user_name: str | None = None

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -240,11 +240,7 @@ def has_seer_explorer_access_with_detail(
 def _collect_repos_by_project_id(
     organization: Organization, project_ids: list[int]
 ) -> dict[str, list[dict[str, Any]]]:
-    """Fetch repo lists for each project, keyed by project_id (as string).
-
-    When `organizations:seer-project-settings-read-from-sentry` is on, reads
-    directly from Sentry's DB. Otherwise fetches via the Seer API.
-    """
+    """Fetch repo lists for each project, keyed by project_id."""
     if not project_ids:
         return {}
 

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -38,7 +38,6 @@ from sentry.users.models.user import User as SentryUser
 from sentry.users.services.user.model import RpcUser
 from sentry.users.services.user_option import user_option_service
 from sentry.users.services.user_option.service import get_option_from_list
-from sentry.utils.json import JSONDecodeError
 
 logger = logging.getLogger(__name__)
 
@@ -258,7 +257,7 @@ def _collect_repos_by_project_id(
 
     try:
         seer_prefs = bulk_get_project_preferences(organization.id, project_ids)
-    except (SeerApiError, HTTPError, JSONDecodeError):
+    except (SeerApiError, HTTPError, orjson.JSONDecodeError):
         logger.exception(
             "Failed to fetch Seer project preferences for explorer context",
             extra={"organization_id": organization.id},

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -17,6 +17,7 @@ from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from rest_framework.request import Request
 from urllib3 import BaseHTTPResponse, HTTPConnectionPool
+from urllib3.exceptions import HTTPError
 
 from sentry import features
 from sentry.constants import ObjectStatus
@@ -37,6 +38,7 @@ from sentry.users.models.user import User as SentryUser
 from sentry.users.services.user.model import RpcUser
 from sentry.users.services.user_option import user_option_service
 from sentry.users.services.user_option.service import get_option_from_list
+from sentry.utils.json import JSONDecodeError
 
 logger = logging.getLogger(__name__)
 
@@ -256,7 +258,7 @@ def _collect_repos_by_project_id(
 
     try:
         seer_prefs = bulk_get_project_preferences(organization.id, project_ids)
-    except Exception:
+    except (SeerApiError, HTTPError, JSONDecodeError):
         logger.exception(
             "Failed to fetch Seer project preferences for explorer context",
             extra={"organization_id": organization.id},

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -252,7 +252,7 @@ def _collect_repos_by_project_id(
         }
 
     try:
-        seer_prefs = bulk_get_project_preferences(organization.id, project_ids)
+        pref_dicts_by_pid = bulk_get_project_preferences(organization.id, project_ids)
     except (SeerApiError, HTTPError, orjson.JSONDecodeError):
         logger.exception(
             "Failed to fetch Seer project preferences for explorer context",
@@ -260,12 +260,7 @@ def _collect_repos_by_project_id(
         )
         return {}
 
-    repos_by_pid: dict[str, list[dict[str, Any]]] = {}
-    for pid, pref in seer_prefs.items():
-        if not pref:
-            continue
-        repos_by_pid[pid] = pref.get("repositories") or []
-    return repos_by_pid
+    return {pid: pref.get("repositories") or [] for pid, pref in pref_dicts_by_pid.items() if pref}
 
 
 def collect_user_org_context(

--- a/tests/sentry/seer/explorer/test_client_utils.py
+++ b/tests/sentry/seer/explorer/test_client_utils.py
@@ -10,6 +10,7 @@ from sentry.seer.explorer.client_utils import (
     has_seer_explorer_access_with_detail,
     snapshot_to_markdown,
 )
+from sentry.seer.models import SeerApiError
 from sentry.seer.models.project_repository import SeerProjectRepository
 from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import TestCase
@@ -261,7 +262,7 @@ class CollectUserOrgContextTest(TestCase):
         self, mock_bulk_get: MagicMock
     ) -> None:
         """Seer API failures don't break explorer startup; repos fall back to empty."""
-        mock_bulk_get.side_effect = Exception("seer unavailable")
+        mock_bulk_get.side_effect = SeerApiError("seer unavailable", 503)
 
         context = collect_user_org_context(self.user, self.organization)
 

--- a/tests/sentry/seer/explorer/test_client_utils.py
+++ b/tests/sentry/seer/explorer/test_client_utils.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock, patch
+
 import jwt
 from django.test import override_settings
 
@@ -8,8 +10,10 @@ from sentry.seer.explorer.client_utils import (
     has_seer_explorer_access_with_detail,
     snapshot_to_markdown,
 )
+from sentry.seer.models.project_repository import SeerProjectRepository
 from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.requests import make_request
 from sentry.viewer_context import ActorType, ViewerContext, viewer_context_scope
 
@@ -190,6 +194,81 @@ class CollectUserOrgContextTest(TestCase):
 
         assert context is not None
         assert context.get("user_ip") == request.META.get("REMOTE_ADDR")
+
+    @with_feature("organizations:seer-project-settings-read-from-sentry")
+    def test_collect_context_populates_repos_from_sentry_db(self) -> None:
+        """With the read-from-sentry flag on, repos are pulled from Sentry's DB."""
+        repo1 = self.create_repo(
+            project=self.project1,
+            name="acme/project-1-repo",
+            provider="integrations:github",
+            integration_id=999,
+            external_id="ext-1",
+        )
+        SeerProjectRepository.objects.create(project=self.project1, repository=repo1)
+        repo2 = self.create_repo(
+            project=self.project2,
+            name="acme/project-2-repo",
+            provider="integrations:github",
+            integration_id=999,
+            external_id="ext-2",
+        )
+        SeerProjectRepository.objects.create(project=self.project2, repository=repo2)
+
+        context = collect_user_org_context(self.user, self.organization)
+
+        all_by_id = {p["id"]: p for p in context["all_org_projects"]}
+        assert [r["external_id"] for r in all_by_id[self.project1.id]["repos"]] == ["ext-1"]
+        assert [r["external_id"] for r in all_by_id[self.project2.id]["repos"]] == ["ext-2"]
+        assert all_by_id[self.other_project.id]["repos"] == []
+
+        user_by_id = {p["id"]: p for p in context["user_projects"]}
+        assert [r["external_id"] for r in user_by_id[self.project1.id]["repos"]] == ["ext-1"]
+        assert [r["external_id"] for r in user_by_id[self.project2.id]["repos"]] == ["ext-2"]
+
+    @patch("sentry.seer.explorer.client_utils.bulk_get_project_preferences")
+    def test_collect_context_populates_repos_from_seer_api(self, mock_bulk_get: MagicMock) -> None:
+        """Without the read-from-sentry flag, repos come from the Seer API."""
+        mock_bulk_get.return_value = {
+            str(self.project1.id): {
+                "repositories": [
+                    {"external_id": "seer-ext-1", "owner": "acme", "name": "from-seer"}
+                ]
+            },
+            str(self.project2.id): None,
+        }
+
+        context = collect_user_org_context(self.user, self.organization)
+
+        mock_bulk_get.assert_called_once()
+        call_args = mock_bulk_get.call_args
+        assert call_args.args[0] == self.organization.id
+        assert set(call_args.args[1]) == {
+            self.project1.id,
+            self.project2.id,
+            self.other_project.id,
+        }
+
+        all_by_id = {p["id"]: p for p in context["all_org_projects"]}
+        assert all_by_id[self.project1.id]["repos"] == [
+            {"external_id": "seer-ext-1", "owner": "acme", "name": "from-seer"}
+        ]
+        assert all_by_id[self.project2.id]["repos"] == []
+        assert all_by_id[self.other_project.id]["repos"] == []
+
+    @patch("sentry.seer.explorer.client_utils.bulk_get_project_preferences")
+    def test_collect_context_returns_empty_repos_when_seer_api_fails(
+        self, mock_bulk_get: MagicMock
+    ) -> None:
+        """Seer API failures don't break explorer startup; repos fall back to empty."""
+        mock_bulk_get.side_effect = Exception("seer unavailable")
+
+        context = collect_user_org_context(self.user, self.organization)
+
+        for project in context["all_org_projects"]:
+            assert project["repos"] == []
+        for project in context["user_projects"]:
+            assert project["repos"] == []
 
 
 class SnapshotToMarkdownTest(TestCase):


### PR DESCRIPTION
Populate `repos` on each `ProjectInfo` in `user_org_context` (both `all_org_projects` and `user_projects`) when Sentry builds the context for a Seer explorer chat. 

Seer's explorer reads repos directly from `DbSeerProjectPreference` in three places (`_enrich_projects_with_repos` which functionally does exactly what we do in this PR, `process_event_paths`, `get_external_id_from_preferences`). Pre-populating `repos` in the trigger payload lets those sites consume from run state instead, instead of reading the preferences from Seer DB.

Followup: https://github.com/getsentry/seer/pull/5963