### PR TITLE
fix(discover): nav item has no redirect for discover basic users

### DIFF
--- a/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.spec.tsx
+++ b/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.spec.tsx
@@ -57,4 +57,65 @@ describe('ExploreSecondaryNavigation', () => {
 
     expect(screen.getByText('Traces')).toBeInTheDocument();
   });
+
+  it('links Discover to homepage when discover-query is enabled', () => {
+    const {organization: orgWithQuery} = initializeOrg({
+      organization: {
+        features: [
+          'performance-view',
+          'visibility-explore-view',
+          'discover-basic',
+          'discover-query',
+        ],
+      },
+    });
+
+    render(
+      <PrimaryNavigationContextProvider>
+        <SecondaryNavigationContextProvider>
+          <Navigation />
+          <div id="main" />
+        </SecondaryNavigationContextProvider>
+      </PrimaryNavigationContextProvider>,
+      {
+        organization: orgWithQuery,
+        initialRouterConfig: {
+          location: {pathname: '/organizations/org-slug/explore/traces/'},
+        },
+      }
+    );
+
+    expect(screen.getByRole('link', {name: 'Discover'})).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/explore/discover/homepage/'
+    );
+  });
+
+  it('links Discover to results when discover-query is disabled', () => {
+    const {organization: orgWithoutQuery} = initializeOrg({
+      organization: {
+        features: ['performance-view', 'visibility-explore-view', 'discover-basic'],
+      },
+    });
+
+    render(
+      <PrimaryNavigationContextProvider>
+        <SecondaryNavigationContextProvider>
+          <Navigation />
+          <div id="main" />
+        </SecondaryNavigationContextProvider>
+      </PrimaryNavigationContextProvider>,
+      {
+        organization: orgWithoutQuery,
+        initialRouterConfig: {
+          location: {pathname: '/organizations/org-slug/explore/traces/'},
+        },
+      }
+    );
+
+    expect(screen.getByRole('link', {name: 'Discover'})).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/explore/discover/results/'
+    );
+  });
 });

--- a/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
@@ -64,6 +64,11 @@ export function ExploreSecondaryNavigation() {
     });
   }, [organization, hasMetricsSupportedPlatform, userPlatforms.length]);
 
+  const hasDiscoverQueryFeature = useMemo(
+    () => organization.features.includes('discover-query'),
+    [organization]
+  );
+
   return (
     <Fragment>
       <SecondaryNavigation.Header>{t('Explore')}</SecondaryNavigation.Header>
@@ -123,7 +128,11 @@ export function ExploreSecondaryNavigation() {
             >
               <SecondaryNavigation.ListItem>
                 <SecondaryNavigation.Link
-                  to={`${baseUrl}/discover/homepage/`}
+                  to={
+                    hasDiscoverQueryFeature
+                      ? `${baseUrl}/discover/homepage/`
+                      : `${baseUrl}/discover/results/`
+                  }
                   activeTo={`${baseUrl}/discover/`}
                   analyticsItemName="explore_discover"
                 >


### PR DESCRIPTION
Fixes [JAVASCRIPT-3953](https://sentry.sentry.io/issues/feedback/?feedbackSlug=javascript%3A7436683928&project=11276)

discover basic users (aka team plans) do not have access to the homepage and saved queries so we should be directing them to results instead.

