### PR TITLE
feat(spans): Add redis lock at flush time to not produce duplicate spans

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3241,10 +3241,12 @@ register(
     default=False,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
-# TTL (in seconds) for the per-segment SET NX lock acquired at flush time to
-# prevent two flushers from producing the same segment concurrently. Must be
-# larger than the expected flush+produce+cleanup latency.
-# If set to 0, no locks will be acquired.
+# TTL (in seconds) for the per-segment lock acquired at flush time to
+# prevent two flushers from producing the same segment concurrently.
+# The lock is never explicitly released and only expires via this TTL.
+# Pick a value larger than the expected flush+produce latency but smaller than
+# `spans.buffer.root-timeout` so a re-entered segment isn't blocked from its
+# next flush cycle. If set to 0, no locks will be acquired.
 register(
     "spans.buffer.flusher.flush-lock-ttl",
     type=Int,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3241,6 +3241,16 @@ register(
     default=False,
     flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
 )
+# TTL (in seconds) for the per-segment SET NX lock acquired at flush time to
+# prevent two flushers from producing the same segment concurrently. Must be
+# larger than the expected flush+produce+cleanup latency.
+# If set to 0, no locks will be acquired.
+register(
+    "spans.buffer.flusher.flush-lock-ttl",
+    type=Int,
+    default=0,
+    flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Compression level for spans buffer segments. Default -1 disables compression, 0-22 for zstd levels
 register(

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -93,7 +93,7 @@ Glossary for types of keys:
     * span-buf:hrs:<segment_key> -- flags a segment as "has root span" (HRS).
     * span-buf:ic:<segment_key> -- ingested count, total spans originally ingested for a segment.
     * span-buf:ibc:<segment_key> -- ingested byte count, total bytes originally ingested for a segment.
-    * span-buf:fl:<segment_key> -- a per-segment lock to prevent the same segment from being flushed multiple times concurrently.
+    * span-buf:fl:<segment_key> -- a per-segment lock (with TTL) to prevent the same segment from being flushed multiple times concurrently.
     <segment_key> -- an internal identifier, see `spans.segment_key` module.
 """
 
@@ -665,18 +665,6 @@ class SpansBuffer:
             )
         return locks_acquired
 
-    def _release_flush_locks(self, segment_keys: Sequence[SegmentKey]) -> None:
-        if not segment_keys:
-            return
-
-        if options.get("spans.buffer.flusher.flush-lock-ttl") <= 0:
-            return
-
-        with self.client.pipeline(transaction=False) as p:
-            for segment_key in segment_keys:
-                p.delete(self._get_flush_lock_key(segment_key))
-            p.execute()
-
     def flush_segments(self, now: int) -> dict[SegmentKey, FlushedSegment]:
         cutoff = now
 
@@ -1065,5 +1053,3 @@ class SpansBuffer:
                             p.unlink(payload_key)
 
                 p.execute()
-
-            self._release_flush_locks(list(segment_keys.keys()))

--- a/src/sentry/spans/buffer.py
+++ b/src/sentry/spans/buffer.py
@@ -93,6 +93,7 @@ Glossary for types of keys:
     * span-buf:hrs:<segment_key> -- flags a segment as "has root span" (HRS).
     * span-buf:ic:<segment_key> -- ingested count, total spans originally ingested for a segment.
     * span-buf:ibc:<segment_key> -- ingested byte count, total bytes originally ingested for a segment.
+    * span-buf:fl:<segment_key> -- a per-segment lock to prevent the same segment from being flushed multiple times concurrently.
     <segment_key> -- an internal identifier, see `spans.segment_key` module.
 """
 
@@ -281,6 +282,9 @@ class SpansBuffer:
     def _get_payload_key_index(self, segment_key: SegmentKey) -> bytes:
         project_id, trace_id, span_id = parse_segment_key(segment_key)
         return b"span-buf:mk:{%s:%s}:%s" % (project_id, trace_id, span_id)
+
+    def _get_flush_lock_key(self, segment_key: SegmentKey) -> bytes:
+        return b"span-buf:fl:" + segment_key
 
     @metrics.wraps("spans.buffer.process_spans")
     def process_spans(self, spans: Sequence[Span], now: int):
@@ -632,6 +636,47 @@ class SpansBuffer:
     def get_memory_info(self) -> Generator[ServiceMemory]:
         return iter_cluster_memory_usage(self.client)
 
+    def _acquire_flush_locks(self, segment_keys: Sequence[SegmentKey]) -> set[SegmentKey]:
+        """
+        Attempts to acquire a lock per segment so that two flushers cannot produce the
+        same segment concurrently. Returns the subset of segment keys successfully locked.
+
+        Locking is disabled when `spans.buffer.flusher.flush-lock-ttl` is 0, in that case,
+        we just return all segment keys.
+        """
+        if not segment_keys:
+            return set()
+
+        lock_ttl = options.get("spans.buffer.flusher.flush-lock-ttl")
+        if lock_ttl <= 0:
+            return set(segment_keys)
+
+        with self.client.pipeline(transaction=False) as p:
+            for segment_key in segment_keys:
+                p.set(self._get_flush_lock_key(segment_key), b"1", ex=lock_ttl, nx=True)
+            results = p.execute()
+
+        locks_acquired = {key for key, acquired in zip(segment_keys, results) if acquired}
+        locks_contended = len(segment_keys) - len(locks_acquired)
+        if locks_contended:
+            metrics.incr(
+                "spans.buffer.flush_segments.lock_contention",
+                amount=locks_contended,
+            )
+        return locks_acquired
+
+    def _release_flush_locks(self, segment_keys: Sequence[SegmentKey]) -> None:
+        if not segment_keys:
+            return
+
+        if options.get("spans.buffer.flusher.flush-lock-ttl") <= 0:
+            return
+
+        with self.client.pipeline(transaction=False) as p:
+            for segment_key in segment_keys:
+                p.delete(self._get_flush_lock_key(segment_key))
+            p.execute()
+
     def flush_segments(self, now: int) -> dict[SegmentKey, FlushedSegment]:
         cutoff = now
 
@@ -658,6 +703,9 @@ class SpansBuffer:
         for shard, queue_key, keys_with_scores in zip(self.assigned_shards, queue_keys, result):
             for segment_key, score in keys_with_scores:
                 segment_keys.append((shard, queue_key, segment_key, score))
+
+        acquired_locks = self._acquire_flush_locks([k for _, _, k, _ in segment_keys])
+        segment_keys = [entry for entry in segment_keys if entry[2] in acquired_locks]
 
         data_start = time.monotonic()
         with metrics.timer("spans.buffer.flush_segments.load_segment_data"):
@@ -1017,3 +1065,5 @@ class SpansBuffer:
                             p.unlink(payload_key)
 
                 p.execute()
+
+            self._release_flush_locks(list(segment_keys.keys()))

--- a/src/sentry/spans/consumers/process/flusher.py
+++ b/src/sentry/spans/consumers/process/flusher.py
@@ -365,7 +365,7 @@ class SpanFlusher(ProcessingStrategy[FilteredPayload | int]):
                                     project_id=project_id,
                                     key_id=None,
                                     outcome=Outcome.INVALID,
-                                    reason="segment_too_large",
+                                    reason="failed_to_produce",
                                     category=DataCategory.SPAN_INDEXED,
                                     quantity=dropped,
                                 )

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -31,6 +31,7 @@ DEFAULT_OPTIONS = {
     "spans.buffer.flusher.backpressure-seconds": 10,
     "spans.buffer.flusher.max-unhealthy-seconds": 60,
     "spans.buffer.flusher.use-stuck-detector": False,
+    "spans.buffer.flusher.flush-lock-ttl": 0,
     "spans.buffer.flusher-cumulative-logger-enabled": False,
     "spans.buffer.compression.level": 0,
     "spans.buffer.pipeline-batch-size": 0,
@@ -1523,6 +1524,61 @@ def test_done_flush_phase2_catches_race_after_zrem(buffer: SpansBuffer) -> None:
     # Clean up
     buffer.done_flush_segments(rv2)
     assert_clean(buffer.client)
+
+
+@pytest.mark.parametrize(
+    "flush_lock_ttl, expected_flushed_segments",
+    [
+        pytest.param(0, 2, id="lock-disabled-duplicate-flushes"),
+        pytest.param(10, 1, id="lock-enabled-flush-once"),
+    ],
+)
+def test_segment_flush_lock(
+    buffer: SpansBuffer, flush_lock_ttl: int, expected_flushed_segments: int
+) -> None:
+    """
+    Tests the segment flush lock that prevents two buffers from flushing the same
+    segment concurrently and producing duplicated spans.
+    """
+    spans = [
+        Span(
+            payload=_payload("a" * 16),
+            trace_id="a" * 32,
+            span_id="a" * 16,
+            parent_span_id="b" * 16,
+            segment_id=None,
+            project_id=1,
+            partition=0,
+        ),
+        Span(
+            payload=_payload("b" * 16),
+            trace_id="a" * 32,
+            span_id="b" * 16,
+            parent_span_id=None,
+            segment_id=None,
+            is_segment_span=True,
+            project_id=1,
+            partition=0,
+        ),
+    ]
+    process_spans(spans, buffer, now=0)
+
+    # Replicate the shard-0 queue entry onto shard 1 to simulate the segment
+    # being tracked by two shards simultaneously.
+    segment_key = _segment_id(1, "a" * 32, "b" * 16)
+    score = buffer.client.zscore(b"span-buf:q:0", segment_key)
+    assert score is not None
+    buffer.client.zadd(b"span-buf:q:1", {segment_key: score})
+
+    buffer_a = SpansBuffer(assigned_shards=[0], slice_id=buffer.slice_id)
+    buffer_b = SpansBuffer(assigned_shards=[1], slice_id=buffer.slice_id)
+
+    with override_options({"spans.buffer.flusher.flush-lock-ttl": flush_lock_ttl}):
+        rv_a = buffer_a.flush_segments(now=11)
+        rv_b = buffer_b.flush_segments(now=11)
+        buffer_a.done_flush_segments(rv_a)
+        buffer_b.done_flush_segments(rv_b)
+        assert len(rv_a) + len(rv_b) == expected_flushed_segments
 
 
 # --- Distributed payload keys tests ---

--- a/tests/sentry/spans/test_buffer.py
+++ b/tests/sentry/spans/test_buffer.py
@@ -1533,42 +1533,130 @@ def test_done_flush_phase2_catches_race_after_zrem(buffer: SpansBuffer) -> None:
         pytest.param(10, 1, id="lock-enabled-flush-once"),
     ],
 )
-def test_segment_flush_lock(
+def test_flush_lock(
     buffer: SpansBuffer, flush_lock_ttl: int, expected_flushed_segments: int
 ) -> None:
     """
     Tests the segment flush lock that prevents two buffers from flushing the same
     segment concurrently and producing duplicated spans.
     """
-    spans = [
-        Span(
-            payload=_payload("a" * 16),
-            trace_id="a" * 32,
-            span_id="a" * 16,
-            parent_span_id="b" * 16,
-            segment_id=None,
-            project_id=1,
-            partition=0,
-        ),
-        Span(
-            payload=_payload("b" * 16),
-            trace_id="a" * 32,
-            span_id="b" * 16,
-            parent_span_id=None,
-            segment_id=None,
-            is_segment_span=True,
-            project_id=1,
-            partition=0,
-        ),
-    ]
-    process_spans(spans, buffer, now=0)
+    # First span comes in from partition 0, goes into shard 0's queue.
+    process_spans(
+        [
+            Span(
+                payload=_payload("b" * 16),
+                trace_id="a" * 32,
+                span_id="b" * 16,
+                parent_span_id=None,
+                segment_id=None,
+                is_segment_span=True,
+                project_id=1,
+                partition=0,
+            ),
+        ],
+        buffer,
+        now=0,
+    )
+    # Second span comes in from partition 1, goes into shard 1's queue.
+    process_spans(
+        [
+            Span(
+                payload=_payload("a" * 16),
+                trace_id="a" * 32,
+                span_id="a" * 16,
+                parent_span_id="b" * 16,
+                segment_id=None,
+                project_id=1,
+                partition=1,
+            ),
+        ],
+        buffer,
+        now=0,
+    )
 
-    # Replicate the shard-0 queue entry onto shard 1 to simulate the segment
-    # being tracked by two shards simultaneously.
-    segment_key = _segment_id(1, "a" * 32, "b" * 16)
-    score = buffer.client.zscore(b"span-buf:q:0", segment_key)
-    assert score is not None
-    buffer.client.zadd(b"span-buf:q:1", {segment_key: score})
+    buffer_a = SpansBuffer(assigned_shards=[0], slice_id=buffer.slice_id)
+    buffer_b = SpansBuffer(assigned_shards=[1], slice_id=buffer.slice_id)
+
+    with override_options({"spans.buffer.flusher.flush-lock-ttl": flush_lock_ttl}):
+        rv_a = buffer_a.flush_segments(now=11)
+        rv_b = buffer_b.flush_segments(now=11)
+        buffer_a.done_flush_segments(rv_a)
+        buffer_b.done_flush_segments(rv_b)
+        assert len(rv_a) + len(rv_b) == expected_flushed_segments
+
+
+@pytest.mark.parametrize(
+    "flush_lock_ttl, expected_flushed_segments",
+    [
+        pytest.param(0, 8, id="lock-disabled-segments-double-flushed"),
+        pytest.param(10, 6, id="lock-enabled-contended-segments-flushed-once"),
+    ],
+)
+def test_flush_lock_mixed_contention(
+    buffer: SpansBuffer, flush_lock_ttl: int, expected_flushed_segments: int
+) -> None:
+    """
+    Two buffers with some segments of their own plus two segments that sit in both
+    queues. The lock should only prevent the contended segments from being flushed
+    twice, other segments must still be flushed normally.
+    """
+    contended_traces = ["a" * 32, "b" * 32]
+    shard_0_only_traces = ["c" * 32]
+    shard_1_only_traces = ["d" * 32, "e" * 32, "f" * 32]
+    root_span_id = "1" * 16
+    child_span_id = "2" * 16
+
+    for trace_id in shard_0_only_traces + shard_1_only_traces:
+        partition = 0 if trace_id in shard_0_only_traces else 1
+        process_spans(
+            [
+                Span(
+                    payload=_payload(root_span_id),
+                    trace_id=trace_id,
+                    span_id=root_span_id,
+                    parent_span_id=None,
+                    segment_id=None,
+                    is_segment_span=True,
+                    project_id=1,
+                    partition=partition,
+                ),
+            ],
+            buffer,
+            now=0,
+        )
+
+    for trace_id in contended_traces:
+        process_spans(
+            [
+                Span(
+                    payload=_payload(root_span_id),
+                    trace_id=trace_id,
+                    span_id=root_span_id,
+                    parent_span_id=None,
+                    segment_id=None,
+                    is_segment_span=True,
+                    project_id=1,
+                    partition=0,
+                ),
+            ],
+            buffer,
+            now=0,
+        )
+        process_spans(
+            [
+                Span(
+                    payload=_payload(child_span_id),
+                    trace_id=trace_id,
+                    span_id=child_span_id,
+                    parent_span_id=root_span_id,
+                    segment_id=None,
+                    project_id=1,
+                    partition=1,
+                ),
+            ],
+            buffer,
+            now=0,
+        )
 
     buffer_a = SpansBuffer(assigned_shards=[0], slice_id=buffer.slice_id)
     buffer_b = SpansBuffer(assigned_shards=[1], slice_id=buffer.slice_id)


### PR DESCRIPTION
Refs STREAM-889

- Adds a new option `spans.buffer.flusher.flush-lock-ttl` (default 0 = no lock on flushing).
- When `spans.buffer.flusher.flush-lock-ttl > 0`, we write a SET NX key at `span-buf:fl:<segment_key>` for each segment before loading its payloads to be flushed. Only segments where the locks are successfully acquired can be flushed. After the segment is flushed, we delete the lock in `done_flush_segments`.
- The TTL of the lock is `spans.buffer.flusher.flush-lock-ttl`.