### PR TITLE
feat(seer): Add check for `seer-gitlab-support` to the seer config reminder

### DIFF
--- a/static/gsApp/components/primaryNavSeerConfigReminder.tsx
+++ b/static/gsApp/components/primaryNavSeerConfigReminder.tsx
@@ -25,6 +25,8 @@ function useReminderData() {
   const hasLegacySeer = organization.features.includes('seer-added');
   const hasCodeReviewBeta = organization.features.includes('code-review-beta');
 
+  const hasGitLabSupport = organization.features.includes('seer-gitlab-support');
+
   const analyticsParams = useMemo(() => {
     return {
       can_write_settings: canWrite,
@@ -49,10 +51,14 @@ function useReminderData() {
     return {
       canSeeReminder: true,
       analyticsParams,
-      title: t('Connect GitHub'),
-      description: t(
-        'Seer is enabled, but Github is not connected. Connect your GitHub account to enable Autofix and Code Review.'
-      ),
+      title: hasGitLabSupport ? t('Connect GitHub or GitLab') : t('Connect GitHub'),
+      description: hasGitLabSupport
+        ? t(
+            'Seer is enabled, but repositories are not connected. Connect your GitHub or GitLab account to enable Autofix and Code Review.'
+          )
+        : t(
+            'Seer is enabled, but repositories are not connected. Connect your GitHub account to enable Autofix and Code Review.'
+          ),
     };
   }
 


### PR DESCRIPTION
This relates to https://github.com/getsentry/sentry/pull/113851/

If the backend change isn't deployed then we might show this reminder even though the org has GitLab already. 
As long as both things are deployed, then the feature-flag will sync what users see.