### PR TITLE
ref(seer-explorer): Move widget builder routes into STRUCTURED_CONTEXT_ROUTES

### DIFF
--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -47,12 +47,13 @@ type SeerExplorerUpdateResponse = {
 };
 
 /** Routes where the LLMContext tree provides structured page context. */
-const STRUCTURED_CONTEXT_ROUTES = new Set(['/dashboard/:dashboardId/']);
-/** New experimental routes where the LLMContext tree provides structured page context. */
-const NEW_STRUCTURED_CONTEXT_ROUTES = new Set([
+const STRUCTURED_CONTEXT_ROUTES = new Set([
+  '/dashboard/:dashboardId/',
   '/dashboard/:dashboardId/widget-builder/widget/new/',
   '/dashboard/:dashboardId/widget-builder/widget/:widgetIndex/edit/',
 ]);
+/** New experimental routes where the LLMContext tree provides structured page context. */
+const NEW_STRUCTURED_CONTEXT_ROUTES = new Set([]);
 
 function supportsStructuredContext(
   referrer: string,

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -53,7 +53,7 @@ const STRUCTURED_CONTEXT_ROUTES = new Set([
   '/dashboard/:dashboardId/widget-builder/widget/:widgetIndex/edit/',
 ]);
 /** New experimental routes where the LLMContext tree provides structured page context. */
-const NEW_STRUCTURED_CONTEXT_ROUTES = new Set([]);
+const NEW_STRUCTURED_CONTEXT_ROUTES = new Set<string>([]);
 
 function supportsStructuredContext(
   referrer: string,


### PR DESCRIPTION
+ Move the widget builder new/edit routes from NEW_STRUCTURED_CONTEXT_ROUTES into STRUCTURED_CONTEXT_ROUTES now that they are work as expected. This leaves NEW_STRUCTURED_CONTEXT_ROUTES empty for future experimental routes.