### PR TITLE
feat(supergroups): Add assignee summary to supergroups endpoint

### DIFF
--- a/src/sentry/seer/supergroups/endpoints/organization_supergroups_by_group.py
+++ b/src/sentry/seer/supergroups/endpoints/organization_supergroups_by_group.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from rest_framework import status as status_codes
 from rest_framework.request import Request
@@ -11,10 +12,16 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
+from sentry.api.serializers import serialize
+from sentry.api.serializers.models.actor import ActorSerializer, ActorSerializerResponse
 from sentry.models.group import STATUS_QUERY_CHOICES, Group
+from sentry.models.groupassignee import GroupAssignee
 from sentry.models.organization import Organization
+from sentry.models.team import Team
 from sentry.seer.models import SeerApiError
+from sentry.seer.signed_seer_api import SupergroupDetailData
 from sentry.seer.supergroups.by_group import get_supergroups_by_group_ids
+from sentry.users.services.user.service import user_service
 
 logger = logging.getLogger(__name__)
 
@@ -78,25 +85,58 @@ class OrganizationSupergroupsByGroupEndpoint(OrganizationEndpoint):
         except SeerApiError as exc:
             return Response({"detail": "Failed to fetch supergroups"}, status=exc.status)
 
-        if not status_param:
-            return Response(data)
+        # Seer returns every group_id in each supergroup regardless of request. We apply any
+        # filters from the request after we get the data from Seer.
+        if status_param:
+            all_response_group_ids: list[int] = []
+            for sg in data["data"]:
+                all_response_group_ids.extend(sg["group_ids"])
 
-        # Seer returns every group_id in each supergroup regardless of request,
-        # so apply the status filter after the call.
-        all_response_group_ids: list[int] = []
-        for sg in data["data"]:
-            all_response_group_ids.extend(sg["group_ids"])
+            matching_ids = set(
+                Group.objects.filter(
+                    id__in=all_response_group_ids,
+                    project__organization=organization,
+                    status=STATUS_QUERY_CHOICES[status_param],
+                ).values_list("id", flat=True)
+            )
 
-        matching_ids = set(
-            Group.objects.filter(
-                id__in=all_response_group_ids,
-                project__organization=organization,
-                status=STATUS_QUERY_CHOICES[status_param],
-            ).values_list("id", flat=True)
-        )
+            for sg in data["data"]:
+                sg["group_ids"] = [gid for gid in sg["group_ids"] if gid in matching_ids]
+            data["data"] = [sg for sg in data["data"] if sg["group_ids"]]
 
-        for sg in data["data"]:
-            sg["group_ids"] = [gid for gid in sg["group_ids"] if gid in matching_ids]
-        data["data"] = [sg for sg in data["data"] if sg["group_ids"]]
+        return Response({"data": _add_assignees(organization, data["data"])})
 
-        return Response(data)
+
+def _add_assignees(
+    organization: Organization, supergroups: list[SupergroupDetailData]
+) -> list[dict[str, Any]]:
+    all_group_ids = {gid for sg in supergroups for gid in sg["group_ids"]}
+
+    group_to_user: dict[int, int] = {}
+    group_to_team: dict[int, int] = {}
+    for group_id, user_id, team_id in GroupAssignee.objects.filter(
+        group_id__in=all_group_ids,
+        group__project__organization_id=organization.id,
+    ).values_list("group_id", "user_id", "team_id"):
+        if user_id is not None:
+            group_to_user[group_id] = user_id
+        else:
+            group_to_team[group_id] = team_id
+
+    users = user_service.get_many_by_id(ids=list(set(group_to_user.values())))
+    teams = Team.objects.filter(id__in=set(group_to_team.values()), organization_id=organization.id)
+    actor_by_key: dict[tuple[str, int], ActorSerializerResponse] = {
+        (a["type"], int(a["id"])): a
+        for a in serialize([*users, *teams], serializer=ActorSerializer())
+    }
+
+    result: list[dict[str, Any]] = []
+    for sg in supergroups:
+        keys: set[tuple[str, int]] = set()
+        for gid in sg["group_ids"]:
+            if gid in group_to_user:
+                keys.add(("user", group_to_user[gid]))
+            elif gid in group_to_team:
+                keys.add(("team", group_to_team[gid]))
+        result.append({**sg, "assignees": [actor_by_key[k] for k in keys if k in actor_by_key]})
+    return result

--- a/tests/sentry/seer/supergroups/endpoints/test_organization_supergroups_by_group.py
+++ b/tests/sentry/seer/supergroups/endpoints/test_organization_supergroups_by_group.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import orjson
 
 from sentry.models.group import GroupStatus
+from sentry.models.groupassignee import GroupAssignee
 from sentry.testutils.cases import APITestCase
 
 
@@ -85,3 +86,108 @@ class OrganizationSupergroupsByGroupEndpointTest(APITestCase):
 
         body = mock_seer.call_args.args[0]
         assert body["rca_source"] == "LIGHTWEIGHT"
+
+    @patch("sentry.seer.supergroups.by_group.make_supergroups_get_by_group_ids_request")
+    def test_assignee_summary(self, mock_seer):
+        user_a = self.create_user(email="a@example.com")
+        user_b = self.create_user(email="b@example.com")
+        team = self.create_team(organization=self.organization, slug="backend")
+
+        g1 = self.create_group(project=self.project)
+        g2 = self.create_group(project=self.project)
+        g3 = self.create_group(project=self.project)
+        g_unassigned = self.create_group(project=self.project)
+
+        GroupAssignee.objects.assign(g1, user_a)
+        GroupAssignee.objects.assign(g2, user_b)
+        GroupAssignee.objects.assign(g3, team)
+
+        mock_seer.return_value = mock_seer_response(
+            {
+                "data": [
+                    {
+                        "id": 1,
+                        "group_ids": [g1.id, g2.id, g3.id, g_unassigned.id],
+                        "title": "sg",
+                    }
+                ]
+            }
+        )
+
+        with self.feature("organizations:top-issues-ui"):
+            response = self.get_success_response(
+                self.organization.slug,
+                group_id=[g1.id],
+            )
+
+        sg = response.data["data"][0]
+        assignees = {(a["type"], a["id"]) for a in sg["assignees"]}
+        assert assignees == {
+            ("user", str(user_a.id)),
+            ("user", str(user_b.id)),
+            ("team", str(team.id)),
+        }
+
+    @patch("sentry.seer.supergroups.by_group.make_supergroups_get_by_group_ids_request")
+    def test_assignee_summary_empty(self, mock_seer):
+        unassigned = self.create_group(project=self.project)
+        mock_seer.return_value = mock_seer_response(
+            {"data": [{"id": 1, "group_ids": [unassigned.id], "title": "sg"}]}
+        )
+
+        with self.feature("organizations:top-issues-ui"):
+            response = self.get_success_response(
+                self.organization.slug,
+                group_id=[unassigned.id],
+            )
+
+        sg = response.data["data"][0]
+        assert sg["assignees"] == []
+
+    @patch("sentry.seer.supergroups.by_group.make_supergroups_get_by_group_ids_request")
+    def test_assignee_summary_ignores_cross_org_groups(self, mock_seer):
+        other_org = self.create_organization()
+        other_project = self.create_project(organization=other_org)
+        other_user = self.create_user(email="other@example.com")
+        other_group = self.create_group(project=other_project)
+        GroupAssignee.objects.assign(other_group, other_user)
+
+        mock_seer.return_value = mock_seer_response(
+            {
+                "data": [
+                    {
+                        "id": 1,
+                        "group_ids": [self.unresolved_group.id, other_group.id],
+                        "title": "sg",
+                    }
+                ]
+            }
+        )
+
+        with self.feature("organizations:top-issues-ui"):
+            response = self.get_success_response(
+                self.organization.slug,
+                group_id=[self.unresolved_group.id],
+            )
+
+        sg = response.data["data"][0]
+        assert sg["assignees"] == []
+
+    @patch("sentry.seer.supergroups.by_group.make_supergroups_get_by_group_ids_request")
+    def test_assignee_summary_tolerates_missing_actor(self, mock_seer):
+        # GroupAssignee row references a user_id that `user_service.get_many_by_id` no longer returns
+        assigned = self.create_group(project=self.project)
+        GroupAssignee.objects.create(group=assigned, project=self.project, user_id=999_999)
+
+        mock_seer.return_value = mock_seer_response(
+            {"data": [{"id": 1, "group_ids": [assigned.id], "title": "sg"}]}
+        )
+
+        with self.feature("organizations:top-issues-ui"):
+            response = self.get_success_response(
+                self.organization.slug,
+                group_id=[assigned.id],
+            )
+
+        sg = response.data["data"][0]
+        assert sg["assignees"] == []


### PR DESCRIPTION
Add assignee information to the supergroups endpoint. On fetching supergroups from seer, we now also query `GroupAssignee` to construct a list of assignees for each supergroup. I don't expect this to work for extremely large supergroups, but will likely be fine for now.