### PR TITLE
feat(cells) Move org creation audit + analytics within the RPC call

### DIFF
--- a/src/sentry/core/endpoints/organization_index.py
+++ b/src/sentry/core/endpoints/organization_index.py
@@ -410,12 +410,12 @@ class OrganizationIndexEndpoint(Endpoint):
                 ),
                 post_provision_options=PostProvisionOptions(
                     getsentry_options={
-                        # Define a self-serve trial account for saas.
+                        # Define a self-serve free account for saas. Historically
+                        # these were not trial accounts.
                         # See getsentry/utils/provisioning.py
-                        "subscription_options": {
+                        "subscription": {
                             "channel": 0,
                             "type": 0,
-                            "trial_options": {"should_start_trial": True},
                         },
                         "ip_address": request.META["REMOTE_ADDR"],
                         "provisioning_user_id": request.user.id,

--- a/src/sentry/core/endpoints/organization_index.py
+++ b/src/sentry/core/endpoints/organization_index.py
@@ -48,6 +48,7 @@ from sentry.services.organization import (
 from sentry.services.organization.provisioning import organization_provisioning_service
 from sentry.signals import org_setup_complete, terms_accepted
 from sentry.silo.base import SiloMode
+from sentry.users.services.user.serial import serialize_generic_user
 from sentry.users.services.user.service import user_service
 from sentry.utils.pagination_factory import PaginatorLike
 
@@ -390,13 +391,18 @@ class OrganizationIndexEndpoint(Endpoint):
 
         result = serializer.validated_data
 
+        analytics_in_rpc = options.get("provision_organization_in_cell.record_analytics")
         try:
             create_default_team = bool(result.get("defaultTeam"))
+            rpc_user = serialize_generic_user(request.user)
+            assert rpc_user  # narrow type
+
             provision_args = OrganizationProvisioningOptions(
                 provision_options=OrganizationOptions(
                     name=result["name"],
                     slug=result.get("slug") or result["name"],
                     owning_user_id=request.user.id,
+                    owner=rpc_user,
                     create_default_team=create_default_team,
                     ip_address=request.META["REMOTE_ADDR"],
                     aggregated_data_consent=result.get("aggregatedDataConsent"),
@@ -413,29 +419,30 @@ class OrganizationIndexEndpoint(Endpoint):
             )
             org = Organization.objects.get(id=rpc_org.id)
 
-            org_setup_complete.send_robust(
-                instance=org, user=request.user, sender=self.__class__, referrer="in-app"
-            )
-
-            self.create_audit_entry(
-                request=request,
-                organization=org,
-                target_object=org.id,
-                event=audit_log.get_event_id("ORG_ADD"),
-                data=org.get_audit_log_data(),
-            )
-
-            try:
-                analytics.record(
-                    OrganizationCreatedEvent(
-                        id=org.id,
-                        name=org.name,
-                        slug=org.slug,
-                        actor_id=request.user.id if request.user.is_authenticated else None,
-                    )
+            if not analytics_in_rpc:
+                org_setup_complete.send_robust(
+                    instance=org, user=request.user, sender=self.__class__, referrer="in-app"
                 )
-            except Exception as e:
-                sentry_sdk.capture_exception(e)
+
+                self.create_audit_entry(
+                    request=request,
+                    organization=org,
+                    target_object=org.id,
+                    event=audit_log.get_event_id("ORG_ADD"),
+                    data=org.get_audit_log_data(),
+                )
+
+                try:
+                    analytics.record(
+                        OrganizationCreatedEvent(
+                            id=org.id,
+                            name=org.name,
+                            slug=org.slug,
+                            actor_id=request.user.id if request.user.is_authenticated else None,
+                        )
+                    )
+                except Exception as e:
+                    sentry_sdk.capture_exception(e)
 
         # TODO(hybrid-cloud): We'll need to catch a more generic error
         # when the internal RPC is implemented.
@@ -444,28 +451,29 @@ class OrganizationIndexEndpoint(Endpoint):
                 {"detail": "An organization with this slug already exists."}, status=409
             )
 
-        # failure on sending this signal is acceptable
-        if result.get("agreeTerms"):
-            terms_accepted.send_robust(
-                user=request.user,
-                organization_id=org.id,
-                ip_address=request.META["REMOTE_ADDR"],
-                sender=type(self),
-            )
-
-        if result.get("aggregatedDataConsent"):
-            org.update_option("sentry:aggregated_data_consent", True)
-
-            try:
-                analytics.record(
-                    AggregatedDataConsentOrganizationCreatedEvent(
-                        organization_id=org.id,
-                    )
+        if not analytics_in_rpc:
+            # failure on sending this signal is acceptable
+            if result.get("agreeTerms"):
+                terms_accepted.send_robust(
+                    user=request.user,
+                    organization_id=org.id,
+                    ip_address=request.META["REMOTE_ADDR"],
+                    sender=type(self),
                 )
-            except Exception as e:
-                sentry_sdk.capture_exception(e)
 
-        # New organizations should not see the legacy UI
-        org.update_option("sentry:streamline_ui_only", True)
+            if result.get("aggregatedDataConsent"):
+                org.update_option("sentry:aggregated_data_consent", True)
+
+                try:
+                    analytics.record(
+                        AggregatedDataConsentOrganizationCreatedEvent(
+                            organization_id=org.id,
+                        )
+                    )
+                except Exception as e:
+                    sentry_sdk.capture_exception(e)
+
+            # New organizations should not see the legacy UI
+            org.update_option("sentry:streamline_ui_only", True)
 
         return Response(serialize(org, request.user), status=201)

--- a/src/sentry/core/endpoints/organization_index.py
+++ b/src/sentry/core/endpoints/organization_index.py
@@ -409,7 +409,18 @@ class OrganizationIndexEndpoint(Endpoint):
                     agree_terms=result.get("agreeTerms"),
                 ),
                 post_provision_options=PostProvisionOptions(
-                    getsentry_options=None, sentry_options=None
+                    getsentry_options={
+                        # Define a self-serve trial account for saas.
+                        # See getsentry/utils/provisioning.py
+                        "subscription_options": {
+                            "channel": 0,
+                            "type": 0,
+                            "trial_options": {"should_start_trial": True},
+                        },
+                        "ip_address": request.META["REMOTE_ADDR"],
+                        "provisioning_user_id": request.user.id,
+                    },
+                    sentry_options=None,
                 ),
             )
 

--- a/src/sentry/core/endpoints/organization_index.py
+++ b/src/sentry/core/endpoints/organization_index.py
@@ -392,6 +392,21 @@ class OrganizationIndexEndpoint(Endpoint):
         result = serializer.validated_data
 
         analytics_in_rpc = options.get("provision_organization_in_cell.record_analytics")
+
+        getsentry_options = None
+        if analytics_in_rpc:
+            getsentry_options = {
+                # Define a self-serve free account for saas. Historically
+                # these were not trial accounts.
+                # See getsentry/utils/provisioning.py
+                "subscription": {
+                    "channel": 0,
+                    "type": 0,
+                },
+                "ip_address": request.META["REMOTE_ADDR"],
+                "provisioning_user_id": request.user.id,
+            }
+
         try:
             create_default_team = bool(result.get("defaultTeam"))
             rpc_user = serialize_generic_user(request.user)
@@ -409,17 +424,7 @@ class OrganizationIndexEndpoint(Endpoint):
                     agree_terms=result.get("agreeTerms"),
                 ),
                 post_provision_options=PostProvisionOptions(
-                    getsentry_options={
-                        # Define a self-serve free account for saas. Historically
-                        # these were not trial accounts.
-                        # See getsentry/utils/provisioning.py
-                        "subscription": {
-                            "channel": 0,
-                            "type": 0,
-                        },
-                        "ip_address": request.META["REMOTE_ADDR"],
-                        "provisioning_user_id": request.user.id,
-                    },
+                    getsentry_options=getsentry_options,
                     sentry_options=None,
                 ),
             )

--- a/src/sentry/hybridcloud/models/outbox.py
+++ b/src/sentry/hybridcloud/models/outbox.py
@@ -173,7 +173,7 @@ class OutboxBase(Model):
     category = BoundedPositiveIntegerField(choices=OutboxCategory.as_choices(), null=False)
     object_identifier = BoundedBigIntegerField(null=False)
 
-    # payload is used for webhook payloads.
+    # payload is used for outboxes that need to snapshot state like provisioning and audit logs.
     payload = models.JSONField(null=True)
 
     # The point at which this object was scheduled, used as a diff from scheduled_for to determine the intended delay.

--- a/src/sentry/hybridcloud/services/cell_organization_provisioning/impl.py
+++ b/src/sentry/hybridcloud/services/cell_organization_provisioning/impl.py
@@ -20,7 +20,7 @@ from sentry.models.organization import ORGANIZATION_NAME_MAX_LENGTH, Organizatio
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.organizationslugreservation import OrganizationSlugReservationType
-from sentry.services.organization import OrganizationProvisioningOptions
+from sentry.services.organization import OrganizationOptions, OrganizationProvisioningOptions
 from sentry.signals import terms_accepted
 from sentry.users.services.user.model import RpcUser
 from sentry.utils.audit import create_audit_entry_from_user
@@ -55,10 +55,6 @@ class DatabaseBackedCellOrganizationProvisioningRpcService(CellOrganizationProvi
         user_id: int | None = None,
         # TODO(cells) Deprecated use owner instead
         email: str | None = None,
-        ip_address: str | None = None,
-        agree_terms: bool | None = None,
-        aggregated_data_consent: bool | None = None,
-        channel_name: str | None = None,
     ) -> Organization:
         assert (user_id is None and email) or (user_id and email is None), (
             "Must set either user_id or email"
@@ -87,48 +83,6 @@ class DatabaseBackedCellOrganizationProvisioningRpcService(CellOrganizationProvi
         if create_default_team:
             team = org.team_set.create(name=org.name)
             OrganizationMemberTeam.objects.create(team=team, organizationmember=om, is_active=True)
-
-        if owner and options.get("provision_organization_in_cell.record_analytics"):
-            audit_data = org.get_audit_log_data()
-            actor_label = None
-            if channel_name:
-                audit_data["channel"] = channel_name
-                actor_label = f"provision_channel:{channel_name}"
-            create_audit_entry_from_user(
-                user=owner,
-                ip_address=ip_address,
-                organization=org,
-                target_object=org.id,
-                event=audit_log.get_event_id("ORG_ADD"),
-                data=audit_data,
-                actor_label=actor_label,
-            )
-            try:
-                analytics.record(
-                    OrganizationCreatedEvent(
-                        id=org.id, name=org.name, slug=org.slug, actor_id=owner.id
-                    )
-                )
-            except Exception as e:
-                capture_exception(e)
-
-            if agree_terms:
-                terms_accepted.send_robust(
-                    user=owner,
-                    organization_id=org.id,
-                    ip_address=ip_address,
-                    sender=type(self),
-                )
-
-            if aggregated_data_consent:
-                org.update_option("sentry:aggregated_data_consent", True)
-
-                try:
-                    analytics.record(
-                        AggregatedDataConsentOrganizationCreatedEvent(organization_id=org.id)
-                    )
-                except Exception as e:
-                    capture_exception(e)
 
         return org
 
@@ -214,17 +168,68 @@ class DatabaseBackedCellOrganizationProvisioningRpcService(CellOrganizationProvi
                 create_default_team=provision_options.create_default_team,
                 organization_id=organization_id,
                 is_test=provision_options.is_test,
-                ip_address=provision_options.ip_address,
-                agree_terms=provision_options.agree_terms,
-                aggregated_data_consent=provision_options.aggregated_data_consent,
-                channel_name=provision_options.channel_name,
             )
 
             create_post_provision_outbox(
                 provisioning_options=provision_payload, org_id=organization.id
             ).save()
 
+        self._record_organization_create_analytics(organization, provision_options)
+
         return True
+
+    def _record_organization_create_analytics(
+        self, organization: Organization, provision_options: OrganizationOptions
+    ) -> None:
+        if not (
+            provision_options.owner
+            and options.get("provision_organization_in_cell.record_analytics")
+        ):
+            return
+
+        # These operations involve RPC calls to control so do them outside of the transaction
+        audit_data = organization.get_audit_log_data()
+        actor_label = None
+        if provision_options.channel_name:
+            audit_data["channel"] = provision_options.channel_name
+            actor_label = f"provision_channel:{provision_options.channel_name}"
+        create_audit_entry_from_user(
+            user=provision_options.owner,
+            ip_address=provision_options.ip_address,
+            organization=organization,
+            target_object=organization.id,
+            event=audit_log.get_event_id("ORG_ADD"),
+            data=audit_data,
+            actor_label=actor_label,
+        )
+        try:
+            analytics.record(
+                OrganizationCreatedEvent(
+                    id=organization.id,
+                    name=organization.name,
+                    slug=organization.slug,
+                    actor_id=provision_options.owner.id,
+                )
+            )
+        except Exception as e:
+            capture_exception(e)
+
+        if provision_options.agree_terms:
+            terms_accepted.send_robust(
+                user=provision_options.owner,
+                organization_id=organization.id,
+                ip_address=provision_options.ip_address,
+                sender=type(self),
+            )
+
+        if provision_options.aggregated_data_consent:
+            organization.update_option("sentry:aggregated_data_consent", True)
+            try:
+                analytics.record(
+                    AggregatedDataConsentOrganizationCreatedEvent(organization_id=organization.id)
+                )
+            except Exception as e:
+                capture_exception(e)
 
     def update_organization_slug_from_reservation(
         self,

--- a/src/sentry/hybridcloud/services/cell_organization_provisioning/impl.py
+++ b/src/sentry/hybridcloud/services/cell_organization_provisioning/impl.py
@@ -58,6 +58,7 @@ class DatabaseBackedCellOrganizationProvisioningRpcService(CellOrganizationProvi
         ip_address: str | None = None,
         agree_terms: bool | None = None,
         aggregated_data_consent: bool | None = None,
+        channel_name: str | None = None,
     ) -> Organization:
         assert (user_id is None and email) or (user_id and email is None), (
             "Must set either user_id or email"
@@ -88,13 +89,19 @@ class DatabaseBackedCellOrganizationProvisioningRpcService(CellOrganizationProvi
             OrganizationMemberTeam.objects.create(team=team, organizationmember=om, is_active=True)
 
         if owner and options.get("provision_organization_in_cell.record_analytics"):
+            audit_data = org.get_audit_log_data()
+            actor_label = None
+            if channel_name:
+                audit_data["channel"] = channel_name
+                actor_label = f"provision_channel:{channel_name}"
             create_audit_entry_from_user(
                 user=owner,
                 ip_address=ip_address,
                 organization=org,
                 target_object=org.id,
                 event=audit_log.get_event_id("ORG_ADD"),
-                data=org.get_audit_log_data(),
+                data=audit_data,
+                actor_label=actor_label,
             )
             try:
                 analytics.record(
@@ -210,6 +217,7 @@ class DatabaseBackedCellOrganizationProvisioningRpcService(CellOrganizationProvi
                 ip_address=provision_options.ip_address,
                 agree_terms=provision_options.agree_terms,
                 aggregated_data_consent=provision_options.aggregated_data_consent,
+                channel_name=provision_options.channel_name,
             )
 
             create_post_provision_outbox(

--- a/src/sentry/hybridcloud/services/cell_organization_provisioning/impl.py
+++ b/src/sentry/hybridcloud/services/cell_organization_provisioning/impl.py
@@ -193,15 +193,19 @@ class DatabaseBackedCellOrganizationProvisioningRpcService(CellOrganizationProvi
         if provision_options.channel_name:
             audit_data["channel"] = provision_options.channel_name
             actor_label = f"provision_channel:{provision_options.channel_name}"
-        create_audit_entry_from_user(
-            user=provision_options.owner,
-            ip_address=provision_options.ip_address,
-            organization=organization,
-            target_object=organization.id,
-            event=audit_log.get_event_id("ORG_ADD"),
-            data=audit_data,
-            actor_label=actor_label,
-        )
+        try:
+            create_audit_entry_from_user(
+                user=provision_options.owner,
+                ip_address=provision_options.ip_address,
+                organization=organization,
+                target_object=organization.id,
+                event=audit_log.get_event_id("ORG_ADD"),
+                data=audit_data,
+                actor_label=actor_label,
+            )
+        except Exception as e:
+            capture_exception(e)
+
         try:
             analytics.record(
                 OrganizationCreatedEvent(

--- a/src/sentry/hybridcloud/services/cell_organization_provisioning/impl.py
+++ b/src/sentry/hybridcloud/services/cell_organization_provisioning/impl.py
@@ -2,7 +2,11 @@ from django.db import IntegrityError, router, transaction
 from django.db.models import Q
 from sentry_sdk import capture_exception
 
-from sentry import roles
+from sentry import analytics, audit_log, options, roles
+from sentry.analytics.events.data_consent_org_creation import (
+    AggregatedDataConsentOrganizationCreatedEvent,
+)
+from sentry.analytics.events.organization_created import OrganizationCreatedEvent
 from sentry.db.postgres.transactions import enforce_constraints
 from sentry.hybridcloud.models.outbox import CellOutbox, outbox_context
 from sentry.hybridcloud.outbox.category import OutboxCategory, OutboxScope
@@ -17,6 +21,9 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
 from sentry.models.organizationslugreservation import OrganizationSlugReservationType
 from sentry.services.organization import OrganizationProvisioningOptions
+from sentry.signals import terms_accepted
+from sentry.users.services.user.model import RpcUser
+from sentry.utils.audit import create_audit_entry_from_user
 
 
 def create_post_provision_outbox(
@@ -43,7 +50,10 @@ class DatabaseBackedCellOrganizationProvisioningRpcService(CellOrganizationProvi
         create_default_team: bool,
         organization_id: int,
         is_test: bool = False,
+        owner: RpcUser | None = None,
+        # TODO(cells) Deprecated use owner instead
         user_id: int | None = None,
+        # TODO(cells) Deprecated use owner instead
         email: str | None = None,
         ip_address: str | None = None,
         agree_terms: bool | None = None,
@@ -76,6 +86,42 @@ class DatabaseBackedCellOrganizationProvisioningRpcService(CellOrganizationProvi
         if create_default_team:
             team = org.team_set.create(name=org.name)
             OrganizationMemberTeam.objects.create(team=team, organizationmember=om, is_active=True)
+
+        if owner and options.get("provision_organization_in_cell.record_analytics"):
+            create_audit_entry_from_user(
+                user=owner,
+                ip_address=ip_address,
+                organization=org,
+                target_object=org.id,
+                event=audit_log.get_event_id("ORG_ADD"),
+                data=org.get_audit_log_data(),
+            )
+            try:
+                analytics.record(
+                    OrganizationCreatedEvent(
+                        id=org.id, name=org.name, slug=org.slug, actor_id=owner.id
+                    )
+                )
+            except Exception as e:
+                capture_exception(e)
+
+            if agree_terms:
+                terms_accepted.send_robust(
+                    user=owner,
+                    organization_id=org.id,
+                    ip_address=ip_address,
+                    sender=type(self),
+                )
+
+            if aggregated_data_consent:
+                org.update_option("sentry:aggregated_data_consent", True)
+
+                try:
+                    analytics.record(
+                        AggregatedDataConsentOrganizationCreatedEvent(organization_id=org.id)
+                    )
+                except Exception as e:
+                    capture_exception(e)
 
         return org
 
@@ -153,6 +199,7 @@ class DatabaseBackedCellOrganizationProvisioningRpcService(CellOrganizationProvi
 
         with outbox_context(transaction.atomic(router.db_for_write(Organization))):
             organization = self._create_organization_and_team(
+                owner=provision_options.owner,
                 user_id=provision_options.owning_user_id,
                 email=provision_options.owning_email,
                 slug=provision_options.slug,

--- a/src/sentry/hybridcloud/services/control_organization_provisioning/impl.py
+++ b/src/sentry/hybridcloud/services/control_organization_provisioning/impl.py
@@ -27,6 +27,7 @@ from sentry.models.organizationslugreservation import (
 from sentry.models.orgauthtoken import OrgAuthToken
 from sentry.organizations.services.organization import RpcOrganization
 from sentry.services.organization import OrganizationProvisioningOptions
+from sentry.utils import json
 from sentry.utils.snowflake import generate_snowflake_id
 
 
@@ -47,7 +48,11 @@ def create_organization_provisioning_outbox(
     cell_name: str,
     org_provision_payload: OrganizationProvisioningOptions | None,
 ) -> ControlOutbox:
-    payload = org_provision_payload.dict() if org_provision_payload is not None else None
+    payload = None
+    if org_provision_payload:
+        # Go through a json encode/decode to handle datetimes
+        payload = json.loads(org_provision_payload.json())
+
     return ControlOutbox(
         cell_name=cell_name,
         shard_scope=OutboxScope.PROVISION_SCOPE,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -4095,6 +4095,16 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Cells
+
+# Whether or not provisioning analytics and audits are made in the provision_organization RPC call
+register(
+    "provision_organization_in_cell.record_analytics",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # SCM
 
 register(

--- a/src/sentry/services/organization/model.py
+++ b/src/sentry/services/organization/model.py
@@ -2,12 +2,17 @@ from typing import Any
 
 import pydantic
 
+from sentry.users.services.user.model import RpcUser
+
 
 class OrganizationOptions(pydantic.BaseModel):
     name: str
     slug: str
+    # Deprecated use owner instead.
     owning_user_id: int | None = None
+    # Deprecated use owner instead.
     owning_email: str | None = None
+    owner: RpcUser | None = None
     create_default_team: bool = True
     is_test: bool = False
     ip_address: str | None = None

--- a/src/sentry/services/organization/model.py
+++ b/src/sentry/services/organization/model.py
@@ -18,6 +18,7 @@ class OrganizationOptions(pydantic.BaseModel):
     ip_address: str | None = None
     agree_terms: bool | None = None
     aggregated_data_consent: bool | None = None
+    channel_name: str | None = None
 
 
 class PostProvisionOptions(pydantic.BaseModel):

--- a/tests/sentry/core/endpoints/test_organization_index.py
+++ b/tests/sentry/core/endpoints/test_organization_index.py
@@ -441,6 +441,46 @@ class OrganizationsCreateTest(OrganizationIndexTest, HybridCloudTestMixin):
         assert org.name == data["name"]
         assert OrganizationOption.objects.get_value(org, "sentry:aggregated_data_consent") is True
 
+    @override_options({"provision_organization_in_cell.record_analytics": True})
+    @mock.patch("sentry.analytics.record")
+    def test_success_analytics_in_rpc_call(self, mock_record: mock.MagicMock) -> None:
+        self.login_as(user=self.user)
+
+        with outbox_runner():
+            data = {
+                "name": "org name",
+                "aggregatedDataConsent": True,
+                "agreeTerms": True,
+                "defaultTeam": True,
+            }
+            response = self.get_success_response(**data)
+        assert response.status_code == 201
+
+        org = Organization.objects.get(slug="org-name")
+
+        assert_any_analytics_event(
+            mock_record,
+            OrganizationCreatedEvent(
+                id=org.id,
+                actor_id=self.user.id,
+                name=org.name,
+                slug=org.slug,
+            ),
+        )
+        assert_any_analytics_event(
+            mock_record, AggregatedDataConsentOrganizationCreatedEvent(organization_id=org.id)
+        )
+        assert_org_audit_log_exists(
+            organization=org,
+            event=audit_log.get_event_id("ORG_ADD"),
+        )
+        assert org.get_option("sentry:aggregated_data_consent") is True
+        assert org.get_option("sentry:streamline_ui_only") is True
+        assert OrganizationMember.objects.filter(
+            organization_id=org.id, user_id=self.user.id
+        ).exists()
+        assert Team.objects.filter(organization_id=org.id).exists()
+
     def test_streamline_only_is_true(self) -> None:
         """
         All new organizations should never see the legacy UI.


### PR DESCRIPTION
This is another step towards consolidating all of our provisioning logic into the existing RPC calls. Doing these changes will allow us to consolidate our provisioning logic across the various flows we have and consolidate them all on control scoped endpoints.

I've introduced an option here so that I can control rollouts and co-ordinate changes between sentry and getsentry. When enabled this option will turn off the current code path for audit logs, analytics events and signals in both sentry + getsentry.

Refs INFRENG-186