### PR TITLE
feat(cmdk): Reset palette state on route change

### DIFF
--- a/static/app/components/commandPalette/ui/commandPalette.spec.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.spec.tsx
@@ -1181,11 +1181,9 @@ describe('CommandPalette', () => {
       await userEvent.click(await screen.findByRole('option', {name: 'Drillable Group'}));
       await screen.findByRole('option', {name: 'Child Action'});
 
-      // Close then reopen with no mouse interaction in between
       act(() => testDispatch({type: 'toggle modal'}));
       act(() => testDispatch({type: 'toggle modal'}));
 
-      // Sub-action state should still be intact
       expect(
         await screen.findByRole('option', {name: 'Child Action'})
       ).toBeInTheDocument();
@@ -1200,13 +1198,11 @@ describe('CommandPalette', () => {
       await userEvent.click(await screen.findByRole('option', {name: 'Drillable Group'}));
       await screen.findByRole('option', {name: 'Child Action'});
 
-      // Close CMDK
       act(() => testDispatch({type: 'toggle modal'}));
 
-      // Navigate to a different route while CMDK is closed
+      // Navigate while closed — route change must trigger reset on the next open
       act(() => router.navigate('/new-page/'));
 
-      // Reopen — route change must have set resetOnOpen
       act(() => testDispatch({type: 'toggle modal'}));
 
       expect(

--- a/static/app/components/commandPalette/ui/commandPalette.spec.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.spec.tsx
@@ -163,6 +163,26 @@ describe('CommandPalette', () => {
     ).toHaveAttribute('data-link-type', 'external');
   });
 
+  it('renders both a custom trailingItem and the link indicator for a link action', async () => {
+    render(
+      <GlobalActionsComponent>
+        <CMDKAction
+          to="/target/"
+          display={{
+            label: 'Action with trailing',
+            trailingItem: <span data-testid="custom-trailing">Badge</span>,
+          }}
+        />
+      </GlobalActionsComponent>
+    );
+
+    const option = await screen.findByRole('option', {name: 'Action with trailing'});
+    expect(option.querySelector('[data-testid="custom-trailing"]')).toBeInTheDocument();
+    expect(
+      option.querySelector('[data-test-id="command-palette-link-indicator"]')
+    ).toBeInTheDocument();
+  });
+
   it('clicking action with children shows sub-items, backspace returns', async () => {
     const closeSpy = jest.spyOn(modalActions, 'closeModal');
     render(
@@ -1166,7 +1186,9 @@ describe('CommandPalette', () => {
       act(() => testDispatch({type: 'toggle modal'}));
 
       // Sub-action state should still be intact
-      expect(await screen.findByRole('option', {name: 'Child Action'})).toBeInTheDocument();
+      expect(
+        await screen.findByRole('option', {name: 'Child Action'})
+      ).toBeInTheDocument();
       expect(screen.queryByRole('option', {name: 'Root Action'})).not.toBeInTheDocument();
     });
 
@@ -1187,8 +1209,12 @@ describe('CommandPalette', () => {
       // Reopen — route change must have set resetOnOpen
       act(() => testDispatch({type: 'toggle modal'}));
 
-      expect(await screen.findByRole('option', {name: 'Root Action'})).toBeInTheDocument();
-      expect(screen.queryByRole('option', {name: 'Child Action'})).not.toBeInTheDocument();
+      expect(
+        await screen.findByRole('option', {name: 'Root Action'})
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('option', {name: 'Child Action'})
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/static/app/components/commandPalette/ui/commandPalette.spec.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.spec.tsx
@@ -1,6 +1,6 @@
 import {Fragment} from 'react';
 
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 jest.unmock('lodash/debounce');
 
@@ -32,6 +32,12 @@ import {
 } from 'sentry/components/commandPalette/ui/cmdk';
 import {CommandPalette} from 'sentry/components/commandPalette/ui/commandPalette';
 import {CommandPaletteSlot} from 'sentry/components/commandPalette/ui/commandPaletteSlot';
+import type {CommandPaletteDispatch} from 'sentry/components/commandPalette/ui/commandPaletteStateContext';
+import {
+  CommandPaletteHotkeys,
+  useCommandPaletteDispatch,
+  useCommandPaletteState,
+} from 'sentry/components/commandPalette/ui/commandPaletteStateContext';
 
 function GlobalActionsComponent({children}: {children?: React.ReactNode}) {
   return (
@@ -1109,6 +1115,80 @@ describe('CommandPalette', () => {
         await screen.findByRole('option', {name: 'Child Action'})
       ).toBeInTheDocument();
       expect(screen.queryByRole('option', {name: 'Root Action'})).not.toBeInTheDocument();
+    });
+  });
+
+  describe('reset on open', () => {
+    // Capture dispatch so tests can open/close CMDK without going through
+    // toggleCommandPalette, keeping the setup self-contained.
+    let testDispatch: CommandPaletteDispatch;
+
+    function DispatchCapture() {
+      testDispatch = useCommandPaletteDispatch();
+      return null;
+    }
+
+    function PaletteContent() {
+      const state = useCommandPaletteState();
+      return (
+        <Fragment>
+          <CMDKAction display={{label: 'Section'}}>
+            <CMDKAction display={{label: 'Drillable Group'}}>
+              <CMDKAction onAction={jest.fn()} display={{label: 'Child Action'}} />
+            </CMDKAction>
+          </CMDKAction>
+          <CMDKAction to="/root/" display={{label: 'Root Action'}} />
+          {state.open && <CommandPalette closeModal={jest.fn()} />}
+        </Fragment>
+      );
+    }
+
+    function Wrapper({withHotkeys}: {withHotkeys?: boolean} = {}) {
+      return (
+        <CommandPaletteProvider>
+          <DispatchCapture />
+          {withHotkeys && <CommandPaletteHotkeys />}
+          <PaletteContent />
+        </CommandPaletteProvider>
+      );
+    }
+
+    it('preserves state when toggled closed and open without navigating', async () => {
+      render(<Wrapper />);
+
+      act(() => testDispatch({type: 'toggle modal'}));
+
+      await userEvent.click(await screen.findByRole('option', {name: 'Drillable Group'}));
+      await screen.findByRole('option', {name: 'Child Action'});
+
+      // Close then reopen with no mouse interaction in between
+      act(() => testDispatch({type: 'toggle modal'}));
+      act(() => testDispatch({type: 'toggle modal'}));
+
+      // Sub-action state should still be intact
+      expect(await screen.findByRole('option', {name: 'Child Action'})).toBeInTheDocument();
+      expect(screen.queryByRole('option', {name: 'Root Action'})).not.toBeInTheDocument();
+    });
+
+    it('resets state on the next open if the route changes while CMDK is closed', async () => {
+      const {router} = render(<Wrapper withHotkeys />);
+
+      act(() => testDispatch({type: 'toggle modal'}));
+
+      await userEvent.click(await screen.findByRole('option', {name: 'Drillable Group'}));
+      await screen.findByRole('option', {name: 'Child Action'});
+
+      // Close CMDK
+      act(() => testDispatch({type: 'toggle modal'}));
+
+      // Navigate to a different route while CMDK is closed
+      act(() => router.navigate('/new-page/'));
+
+      // Reopen — route change must have set resetOnOpen
+      act(() => testDispatch({type: 'toggle modal'}));
+
+      expect(await screen.findByRole('option', {name: 'Root Action'})).toBeInTheDocument();
+      expect(screen.queryByRole('option', {name: 'Child Action'})).not.toBeInTheDocument();
     });
   });
 

--- a/static/app/components/commandPalette/ui/commandPaletteStateContext.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteStateContext.tsx
@@ -1,4 +1,4 @@
-import {createContext, useContext, useReducer, useRef} from 'react';
+import {createContext, useContext, useEffect, useReducer, useRef} from 'react';
 
 import {useHotkeys} from '@sentry/scraps/hotkey';
 
@@ -7,6 +7,7 @@ import {
   toggleCommandPalette,
 } from 'sentry/actionCreators/modal';
 import {unreachable} from 'sentry/utils/unreachable';
+import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 /**
@@ -28,6 +29,10 @@ export type CommandPaletteState = {
   // content swap, while still ensuring a clean slate on the next open.
   pendingReset: boolean;
   query: string;
+  // When true, state is reset as part of the next open transition. Set when
+  // the user clicks anywhere on the page after closing CMDK, signalling they
+  // moved on and expect a fresh palette on the next open.
+  resetOnOpen: boolean;
 };
 
 export type CommandPaletteDispatch = React.Dispatch<CommandPaletteAction>;
@@ -44,7 +49,8 @@ export type CommandPaletteAction =
       query?: string;
     }
   | {type: 'trigger action'}
-  | {type: 'pop action'};
+  | {type: 'pop action'}
+  | {type: 'reset on open'};
 
 const CommandPaletteStateContext = createContext<CommandPaletteState | null>(null);
 const CommandPaletteDispatchContext =
@@ -57,6 +63,15 @@ function commandPaletteReducer(
   const type = action.type;
   switch (type) {
     case 'toggle modal':
+      if (!state.open && state.resetOnOpen) {
+        return {
+          ...state,
+          open: true,
+          action: null,
+          query: '',
+          resetOnOpen: false,
+        };
+      }
       return {
         ...state,
         open: !state.open,
@@ -67,7 +82,10 @@ function commandPaletteReducer(
         action: null,
         query: '',
         pendingReset: false,
+        resetOnOpen: false,
       };
+    case 'reset on open':
+      return {...state, resetOnOpen: true};
     case 'set query':
       return {...state, query: action.query};
     case 'push action':
@@ -130,6 +148,7 @@ export function CommandPaletteStateProvider({
     action: null,
     open: false,
     pendingReset: false,
+    resetOnOpen: false,
   });
 
   return (
@@ -149,6 +168,18 @@ export function CommandPaletteHotkeys() {
   const organization = useOrganization({allowNull: true});
   const state = useCommandPaletteState();
   const dispatch = useCommandPaletteDispatch();
+  const location = useLocation();
+
+  // When the route pathname changes, mark state for reset on the next open.
+  // Skip the initial render — only react to actual route changes.
+  const isFirstRenderRef = useRef(true);
+  useEffect(() => {
+    if (isFirstRenderRef.current) {
+      isFirstRenderRef.current = false;
+      return;
+    }
+    dispatch({type: 'reset on open'});
+  }, [location.pathname, dispatch]);
 
   useHotkeys([
     {

--- a/static/app/components/commandPalette/ui/commandPaletteStateContext.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteStateContext.tsx
@@ -70,6 +70,7 @@ function commandPaletteReducer(
           action: null,
           query: '',
           resetOnOpen: false,
+          pendingReset: false,
         };
       }
       return {

--- a/static/app/components/commandPalette/ui/commandPaletteStateContext.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteStateContext.tsx
@@ -30,8 +30,8 @@ export type CommandPaletteState = {
   pendingReset: boolean;
   query: string;
   // When true, state is reset as part of the next open transition. Set when
-  // the user clicks anywhere on the page after closing CMDK, signalling they
-  // moved on and expect a fresh palette on the next open.
+  // the route changes while the palette is closed, so navigation always starts
+  // from a clean slate.
   resetOnOpen: boolean;
 };
 


### PR DESCRIPTION
Break toggle state persistence on navigation events. Prevents awkward cases where users might select a sub menu, then navigate around the dashboard, forgetting they selected a sub menu, and toggling it again only to see the sub-menu persisted