### PR TITLE
chore(seer agent): fix hotkeys

### DIFF
--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
@@ -1,6 +1,7 @@
 import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
 
+import {useDrawer} from '@sentry/scraps/drawer';
 import {Stack} from '@sentry/scraps/layout';
 
 import {useFeedbackForm} from 'sentry/utils/useFeedbackForm';
@@ -34,6 +35,7 @@ export function ExplorerDrawerContent({
   const organization = useOrganization({allowNull: true});
   const {projects} = useProjects();
   const user = useUser();
+  const {closeDrawer} = useDrawer();
 
   const [inputValue, setInputValue] = useState('');
   const [hoveredBlockIndex, setHoveredBlockIndex] = useState(-1);
@@ -222,12 +224,12 @@ export function ExplorerDrawerContent({
       if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();
         handleSend();
-      } else if (e.key === 'Escape' && canInterrupt && !waitingForInterrupt) {
+      } else if (e.key === 'Escape') {
         e.preventDefault();
-        interruptRun();
+        closeDrawer();
       }
     },
-    [readOnly, handleSend, canInterrupt, waitingForInterrupt, interruptRun]
+    [readOnly, handleSend, closeDrawer]
   );
 
   const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {

--- a/static/app/views/seerExplorer/hooks/useBlockNavigation.tsx
+++ b/static/app/views/seerExplorer/hooks/useBlockNavigation.tsx
@@ -43,6 +43,10 @@ export function useBlockNavigation({
         e.preventDefault();
         onKeyPress?.(focusedBlockIndex, 'Enter');
       }
+
+      if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+        e.preventDefault();
+      }
     };
 
     document.addEventListener('keydown', handleKeyDown);


### PR DESCRIPTION
When keyboard shortcuts were removed, up and down arrows fell through to the page behind. Just added a prevent default so that this no longer happens. Also removed the esc key as an interrupt and instead it closes the drawer.