### PR TITLE
feat(integrations): Read SCM toggles from OrganizationIntegration config behind feature flag

### DIFF
--- a/src/sentry/api/endpoints/organization_missing_org_members.py
+++ b/src/sentry/api/endpoints/organization_missing_org_members.py
@@ -13,7 +13,7 @@ from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import roles
+from sentry import features, roles
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -181,10 +181,26 @@ class OrganizationMissingMembersEndpoint(OrganizationEndpoint):
 
         missing_org_members = []
 
+        use_oi_config_reads = features.has("organizations:scm-config-oi-reads", organization)
+
         for integration_provider, integration_ids in integration_provider_to_ids.items():
             # TODO(cathy): allow other integration providers
             if integration_provider != IntegrationProviderSlug.GITHUB.value:
                 continue
+
+            if use_oi_config_reads:
+                nudge_enabled_ids = [
+                    oi.integration_id
+                    for oi in integration_service.get_organization_integrations(
+                        organization_id=organization.id,
+                        providers=[integration_provider],
+                        status=ObjectStatus.ACTIVE,
+                    )
+                    if oi.config.get("nudge_invite", False)
+                ]
+                integration_ids = [iid for iid in integration_ids if iid in nudge_enabled_ids]
+                if not integration_ids:
+                    continue
 
             queryset = _get_missing_organization_members(
                 organization, integration_provider, integration_ids, shared_domain

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, TypedDict, cast
+from typing import TYPE_CHECKING, Any, NamedTuple, TypedDict, cast
 
 import sentry_sdk
 from django.contrib.auth.models import AnonymousUser
@@ -113,6 +113,12 @@ ORGANIZATION_OPTIONS_AS_FEATURES: Mapping[str, list[OptionFeature]] = {
         ("spike-projections", lambda opt: bool(opt.value)),
     ],
 }
+
+
+class ScmConfigBools(NamedTuple):
+    github_pr_bot: bool
+    github_nudge_invite: bool
+    gitlab_pr_bot: bool
 
 
 class _Status(TypedDict):
@@ -658,6 +664,66 @@ class OrganizationSerializer(OrganizationSummarySerializer):
             return SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT
         return stopping_point
 
+    def _scm_config_bools(self, obj: Organization) -> ScmConfigBools:
+        """Derive the three SCM-toggle booleans for the org serializer response.
+
+        Under the org-option read path these come from OrganizationOption. Once
+        the `organizations:scm-config-oi-reads` flag is on, they are derived by
+        OR-ing the matching key across every active GitHub/GitLab
+        OrganizationIntegration config for the org.
+        """
+        if features.has("organizations:scm-config-oi-reads", obj):
+            from sentry.integrations.services.integration import integration_service
+
+            ois = integration_service.get_organization_integrations(
+                organization_id=obj.id,
+                providers=["github", "gitlab"],
+                status=ObjectStatus.ACTIVE,
+            )
+            if not ois:
+                return ScmConfigBools(
+                    github_pr_bot=False, github_nudge_invite=False, gitlab_pr_bot=False
+                )
+
+            provider_by_integration_id = {
+                i.id: i.provider
+                for i in integration_service.get_integrations(
+                    integration_ids=[oi.integration_id for oi in ois],
+                )
+            }
+
+            github_pr_bot = False
+            github_nudge_invite = False
+            gitlab_pr_bot = False
+            for oi in ois:
+                config = oi.config or {}
+                provider = provider_by_integration_id.get(oi.integration_id)
+                if provider == "github":
+                    github_pr_bot = github_pr_bot or bool(config.get("pr_comments", False))
+                    github_nudge_invite = github_nudge_invite or bool(
+                        config.get("nudge_invite", False)
+                    )
+                elif provider == "gitlab":
+                    gitlab_pr_bot = gitlab_pr_bot or bool(config.get("pr_comments", False))
+
+            return ScmConfigBools(
+                github_pr_bot=github_pr_bot,
+                github_nudge_invite=github_nudge_invite,
+                gitlab_pr_bot=gitlab_pr_bot,
+            )
+
+        return ScmConfigBools(
+            github_pr_bot=bool(
+                obj.get_option("sentry:github_pr_bot", GITHUB_COMMENT_BOT_DEFAULT)
+            ),
+            github_nudge_invite=bool(
+                obj.get_option("sentry:github_nudge_invite", GITHUB_COMMENT_BOT_DEFAULT)
+            ),
+            gitlab_pr_bot=bool(
+                obj.get_option("sentry:gitlab_pr_bot", GITLAB_COMMENT_BOT_DEFAULT)
+            ),
+        )
+
     def serialize(  # type: ignore[override]
         self,
         obj: Organization,
@@ -700,6 +766,8 @@ class OrganizationSerializer(OrganizationSummarySerializer):
         coding_agent_integration_id = obj.get_option(
             "sentry:seer_default_coding_agent_integration_id", None
         )
+
+        scm_config = self._scm_config_bools(obj)
 
         context: OrganizationSerializerResponse = {
             **base,
@@ -756,11 +824,9 @@ class OrganizationSerializer(OrganizationSummarySerializer):
             "hideAiFeatures": bool(
                 obj.get_option("sentry:hide_ai_features", HIDE_AI_FEATURES_DEFAULT)
             ),
-            "githubPRBot": bool(obj.get_option("sentry:github_pr_bot", GITHUB_COMMENT_BOT_DEFAULT)),
-            "githubNudgeInvite": bool(
-                obj.get_option("sentry:github_nudge_invite", GITHUB_COMMENT_BOT_DEFAULT)
-            ),
-            "gitlabPRBot": bool(obj.get_option("sentry:gitlab_pr_bot", GITLAB_COMMENT_BOT_DEFAULT)),
+            "githubPRBot": scm_config.github_pr_bot,
+            "githubNudgeInvite": scm_config.github_nudge_invite,
+            "gitlabPRBot": scm_config.gitlab_pr_bot,
             "genAIConsent": bool(
                 obj.get_option("sentry:gen_ai_consent_v2024_11_14", DATA_CONSENT_DEFAULT)
             ),

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -713,15 +713,11 @@ class OrganizationSerializer(OrganizationSummarySerializer):
             )
 
         return ScmConfigBools(
-            github_pr_bot=bool(
-                obj.get_option("sentry:github_pr_bot", GITHUB_COMMENT_BOT_DEFAULT)
-            ),
+            github_pr_bot=bool(obj.get_option("sentry:github_pr_bot", GITHUB_COMMENT_BOT_DEFAULT)),
             github_nudge_invite=bool(
                 obj.get_option("sentry:github_nudge_invite", GITHUB_COMMENT_BOT_DEFAULT)
             ),
-            gitlab_pr_bot=bool(
-                obj.get_option("sentry:gitlab_pr_bot", GITLAB_COMMENT_BOT_DEFAULT)
-            ),
+            gitlab_pr_bot=bool(obj.get_option("sentry:gitlab_pr_bot", GITLAB_COMMENT_BOT_DEFAULT)),
         )
 
     def serialize(  # type: ignore[override]

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -162,6 +162,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:integrations-perforce", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-slack-staging", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:scm-source-context", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    manager.add("organizations:scm-config-oi-reads", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # API-driven integration setup pipeline (per-provider rollout)
     # ...
     # Project Management Integrations Feature Parity Flags

--- a/src/sentry/integrations/source_code_management/commit_context.py
+++ b/src/sentry/integrations/source_code_management/commit_context.py
@@ -14,8 +14,10 @@ from snuba_sdk import Column, Condition, Direction, Entity, Function, Op, OrderB
 from snuba_sdk import Request as SnubaRequest
 
 from sentry.auth.exceptions import IdentityNotValid
+from sentry.integrations.errors import OrganizationIntegrationNotFound
 from sentry.integrations.gitlab.constants import GITLAB_CLOUD_BASE_URL
 from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
+from sentry.integrations.services.integration.model import RpcOrganizationIntegration
 from sentry.integrations.source_code_management.metrics import (
     CommitContextHaltReason,
     CommitContextIntegrationInteractionEvent,
@@ -136,6 +138,11 @@ class CommitContextIntegration(ABC):
     def integration_id(self) -> int:
         raise NotImplementedError
 
+    @property
+    @abstractmethod
+    def org_integration(self) -> RpcOrganizationIntegration:
+        raise NotImplementedError
+
     @abstractmethod
     def get_client(self) -> CommitContextClient:
         raise NotImplementedError
@@ -216,13 +223,22 @@ class CommitContextIntegration(ABC):
         group_owner: GroupOwner,
         group_id: int,
     ) -> None:
+        from sentry import features
+
         try:
             # TODO(jianyuan): Remove this try/except once we have implemented the abstract method for all integrations
             pr_comment_workflow = self.get_pr_comment_workflow()
         except NotImplementedError:
             return
 
-        if not OrganizationOption.objects.get_value(
+        if features.has("organizations:scm-config-oi-reads", project.organization):
+            try:
+                pr_comments_enabled = self.org_integration.config.get("pr_comments", False)
+            except OrganizationIntegrationNotFound:
+                pr_comments_enabled = False
+            if not pr_comments_enabled:
+                return
+        elif not OrganizationOption.objects.get_value(
             organization=project.organization,
             key=pr_comment_workflow.organization_option_key,
             default=False,

--- a/src/sentry/integrations/source_code_management/tasks.py
+++ b/src/sentry/integrations/source_code_management/tasks.py
@@ -1,6 +1,8 @@
 import logging
 
+from sentry import features
 from sentry.constants import ObjectStatus
+from sentry.integrations.errors import OrganizationIntegrationNotFound
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.source_code_management.commit_context import (
     MAX_SUSPECT_COMMITS,
@@ -96,11 +98,21 @@ def pr_comment_workflow(pr_id: int, project_id: int) -> None:
     # cap to 1000 issues in which the merge commit is the suspect commit
     issue_ids = pr_comment_workflow.get_issue_ids_from_pr(pr=pr, limit=MAX_SUSPECT_COMMITS)
 
-    if not OrganizationOption.objects.get_value(
-        organization=organization,
-        key=pr_comment_workflow.organization_option_key,
-        default=False,
-    ):
+    if features.has("organizations:scm-config-oi-reads", organization):
+        try:
+            pr_comments_enabled = installation.org_integration.config.get("pr_comments", False)
+        except OrganizationIntegrationNotFound:
+            pr_comments_enabled = False
+    else:
+        pr_comments_enabled = bool(
+            OrganizationOption.objects.get_value(
+                organization=organization,
+                key=pr_comment_workflow.organization_option_key,
+                default=False,
+            )
+        )
+
+    if not pr_comments_enabled:
         logger.info(
             _pr_comment_log(integration_name=integration_name, suffix="option_missing"),
             extra={"organization_id": organization.id},

--- a/tests/sentry/api/endpoints/test_organization_missing_org_members.py
+++ b/tests/sentry/api/endpoints/test_organization_missing_org_members.py
@@ -264,6 +264,32 @@ class OrganizationMissingMembersTestCase(APITestCase):
         response = self.get_success_response(self.organization.slug)
         assert len(response.data) == 0
 
+    def test_oi_config_reads_flag_skips_non_nudge_integrations(self) -> None:
+        """With the flag on and no OI having nudge_invite, the endpoint returns []."""
+        from sentry.integrations.models.organization_integration import (
+            OrganizationIntegration,
+        )
+        from sentry.testutils.helpers.features import Feature
+
+        with Feature({"organizations:scm-config-oi-reads": True}):
+            response = self.get_success_response(self.organization.slug)
+
+        assert len(response.data) == 0
+
+        # Now turn the nudge_invite flag on for one of the two github OIs. The
+        # endpoint must still return missing members for the org.
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            oi = OrganizationIntegration.objects.get(
+                integration_id=self.integration.id, organization_id=self.organization.id
+            )
+            oi.config = {"nudge_invite": True}
+            oi.save(update_fields=["config"])
+
+        with Feature({"organizations:scm-config-oi-reads": True}):
+            response = self.get_success_response(self.organization.slug)
+        assert response.data[0]["integration"] == "github"
+        assert len(response.data[0]["users"]) > 0
+
     def test_nongithub_integration(self) -> None:
         with assume_test_silo_mode(SiloMode.CONTROL):
             self.integration.delete()

--- a/tests/sentry/core/endpoints/test_organization_details.py
+++ b/tests/sentry/core/endpoints/test_organization_details.py
@@ -970,6 +970,42 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         assert oi.config.get("some_other_setting") == "kept"
         assert oi.config.get("pr_comments") is True
 
+    def test_scm_serializer_derived_from_oi_config_when_flag_on(self) -> None:
+        self.create_integration(
+            organization=self.organization,
+            provider="github",
+            external_id="gh-derived",
+            oi_params={"config": {"pr_comments": True, "nudge_invite": False}},
+        )
+        self.create_integration(
+            organization=self.organization,
+            provider="gitlab",
+            external_id="gl-derived",
+            oi_params={"config": {"pr_comments": False}},
+        )
+        # Legacy org options disagree with the OI config to prove we are
+        # reading from the OI path.
+        OrganizationOption.objects.set_value(
+            organization=self.organization, key="sentry:github_pr_bot", value=False
+        )
+        OrganizationOption.objects.set_value(
+            organization=self.organization, key="sentry:github_nudge_invite", value=True
+        )
+        OrganizationOption.objects.set_value(
+            organization=self.organization, key="sentry:gitlab_pr_bot", value=True
+        )
+
+        self.method = "get"
+        try:
+            with self.feature("organizations:scm-config-oi-reads"):
+                response = self.get_success_response(self.organization.slug)
+        finally:
+            self.method = "put"
+
+        assert response.data["githubPRBot"] is True
+        assert response.data["githubNudgeInvite"] is False
+        assert response.data["gitlabPRBot"] is False
+
     @responses.activate
     @patch(
         "sentry.integrations.github.client.GitHubBaseClient.get_repos",

--- a/tests/sentry/integrations/github/tasks/test_pr_comment.py
+++ b/tests/sentry/integrations/github/tasks/test_pr_comment.py
@@ -562,6 +562,31 @@ class TestCommentWorkflow(GithubCommentTestCase):
     @patch(
         "sentry.integrations.github.integration.GitHubPRCommentWorkflow.get_top_5_issues_by_count"
     )
+    def test_comment_workflow_reads_oi_config_when_flag_on(self, mock_issues: MagicMock) -> None:
+        from sentry.integrations.models.organization_integration import (
+            OrganizationIntegration,
+        )
+        from sentry.testutils.helpers.features import Feature
+
+        # Leave the org option True so the flag-on path is the gating one.
+        OrganizationOption.objects.set_value(
+            organization=self.organization, key="sentry:github_pr_bot", value=True
+        )
+        with assume_test_silo_mode_of(OrganizationIntegration):
+            oi = OrganizationIntegration.objects.get(
+                integration_id=self.integration.id, organization_id=self.organization.id
+            )
+            oi.config = {"pr_comments": False}
+            oi.save(update_fields=["config"])
+
+        with Feature({"organizations:scm-config-oi-reads": True}):
+            github_comment_workflow(self.pr.id, self.project.id)
+
+        assert not mock_issues.called
+
+    @patch(
+        "sentry.integrations.github.integration.GitHubPRCommentWorkflow.get_top_5_issues_by_count"
+    )
     @patch("sentry.models.Project.objects.get_from_cache")
     @patch("sentry.integrations.source_code_management.tasks.metrics")
     def test_comment_workflow_missing_project(

--- a/tests/sentry/integrations/source_code_management/test_commit_context.py
+++ b/tests/sentry/integrations/source_code_management/test_commit_context.py
@@ -30,6 +30,11 @@ class MockCommitContextIntegration(CommitContextIntegration):
     def __init__(self) -> None:
         self.client = Mock()
         self.client.base_url = "https://example.com"
+        self._org_integration = Mock(config={})
+
+    @property
+    def org_integration(self) -> Any:
+        return self._org_integration
 
     def get_client(self) -> CommitContextClient:
         return self.client

--- a/tests/sentry/tasks/test_commit_context.py
+++ b/tests/sentry/tasks/test_commit_context.py
@@ -12,6 +12,7 @@ from sentry.analytics.events.integration_commit_context_all_frames import (
 )
 from sentry.constants import ObjectStatus
 from sentry.integrations.github.integration import GitHubIntegrationProvider
+from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.source_code_management.commit_context import (
     CommitContextIntegration,
@@ -1073,6 +1074,79 @@ class TestGHCommentQueuing(IntegrationTestCase, TestCommitContextIntegration):
                 project_id=self.event.project_id,
             )
             assert not mock_comment_workflow.called
+
+    def test_gh_comment_reads_oi_config_when_flag_on(
+        self, mock_comment_workflow: MagicMock, mock_get_commit_context: MagicMock
+    ) -> None:
+        """With scm-config-oi-reads on, PR comment gating reads OI config."""
+        from sentry.testutils.helpers.features import Feature
+
+        mock_get_commit_context.return_value = [self.blame]
+        OrganizationOption.objects.set_value(
+            organization=self.project.organization, key="sentry:github_pr_bot", value=True
+        )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            OrganizationIntegration.objects.filter(
+                integration_id=self.integration.id,
+                organization_id=self.project.organization.id,
+            ).update(config={"pr_comments": False})
+
+        with Feature({"organizations:scm-config-oi-reads": True}), self.tasks():
+            event_frames = get_frame_paths(self.event)
+            process_commit_context(
+                event_id=self.event.event_id,
+                event_platform=self.event.platform,
+                event_frames=event_frames,
+                group_id=self.event.group_id,
+                project_id=self.event.project_id,
+            )
+            assert not mock_comment_workflow.called
+
+    @responses.activate
+    def test_gh_comment_oi_config_enabled_queues_comment(
+        self, mock_comment_workflow: MagicMock, mock_get_commit_context: MagicMock
+    ) -> None:
+        """With scm-config-oi-reads on and OI config enabled, comment is queued."""
+        from sentry.testutils.helpers.features import Feature
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            oi = OrganizationIntegration.objects.get(
+                integration_id=self.integration.id,
+                organization_id=self.project.organization.id,
+            )
+            oi.config = {"pr_comments": True}
+            oi.save(update_fields=["config"])
+
+        self.add_responses()
+
+        groupowner = GroupOwner.objects.create(
+            group_id=self.event.group_id,
+            type=GroupOwnerType.SUSPECT_COMMIT.value,
+            user_id=1,
+            project_id=self.event.project_id,
+            organization_id=self.project.organization_id,
+            context={
+                "commitId": self.commit.id,
+                "suspectCommitStrategy": SuspectCommitStrategy.SCM_BASED,
+            },
+            date_added=timezone.now(),
+        )
+
+        integration = integration_service.get_integration(
+            organization_id=self.code_mapping.organization_id
+        )
+        assert integration
+        install = integration.get_installation(organization_id=self.code_mapping.organization_id)
+        assert isinstance(install, CommitContextIntegration)
+
+        with Feature({"organizations:scm-config-oi-reads": True}), self.tasks():
+            install.queue_pr_comment_task_if_needed(
+                project=self.project,
+                commit=self.commit,
+                group_owner=groupowner,
+                group_id=self.event.group_id,
+            )
+            assert mock_comment_workflow.call_count == 1
 
     @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate


### PR DESCRIPTION
Phase 2 of VDY-110. Flip the four OrganizationOption read sites for the
GitHub/GitLab PR-comment and missing-member toggles onto the matching
OrganizationIntegration.config entries, gated by
organizations:scm-config-oi-reads so we can dark-launch and roll back.

Read sites updated:

- queue_pr_comment_task_if_needed: gate on the install's own
  org_integration.config["pr_comments"].
- pr_comment_workflow celery task: resolve the per-install OI via
  integration_service.get_organization_integration and gate on
  config["pr_comments"].
- missing-members endpoint: filter active GitHub OIs to those whose
  config["nudge_invite"] is true before querying for missing members.
- OrganizationSerializer: derive githubPRBot / githubNudgeInvite /
  gitlabPRBot as any(...) over the matching provider's active OI
  configs so the existing response shape stays stable.

Flag off (default) behavior is unchanged. Existing tests continue to
exercise the legacy path; new tests cover the flag-on path at each site.

Ref: [VDY-112: Phase 2: Cut over SCM setting readers to per-integration config](https://linear.app/getsentry/issue/VDY-112/phase-2-cut-over-scm-setting-readers-to-per-integration-config)


## Migration phases

- ● Phase 1 — Backfill existing OIs: [#113841](https://github.com/getsentry/sentry/pull/113841) (merged)
- ● Phase 1 — Backfill cross-silo fix: [#113908](https://github.com/getsentry/sentry/pull/113908)
- ● Phase 1 — Dual-write SCM toggles: [#113842](https://github.com/getsentry/sentry/pull/113842)
- ○ Phase 2 — Read from OI config behind flag: [#113864](https://github.com/getsentry/sentry/pull/113864)
- ○ Phase 3 — Expose toggles in per-install UI: [#113923](https://github.com/getsentry/sentry/pull/113923)
- ○ Phase 3 — Remove legacy detail-view toggles (frontend): [#113924](https://github.com/getsentry/sentry/pull/113924)
- ○ Phase 3 — Drop SCM toggle fields from PUT endpoint: [#113925](https://github.com/getsentry/sentry/pull/113925)
- ○ Phase 4 — Remove legacy code paths: upcoming
