### PR TITLE
chore(seer agent): drawer in front of tooltips

### DIFF
--- a/static/app/components/charts/components/tooltip.tsx
+++ b/static/app/components/charts/components/tooltip.tsx
@@ -372,7 +372,7 @@ export function computeChartTooltip(
     trigger: 'item',
     backgroundColor: theme.tokens.background.primary,
     borderWidth: 0,
-    extraCssText: `box-shadow: 0 0 0 1px ${theme.tokens.border.transparent.neutral.muted}, ${theme.shadow.high}`,
+    extraCssText: `box-shadow: 0 0 0 1px ${theme.tokens.border.transparent.neutral.muted}, ${theme.shadow.high}; z-index: ${theme.zIndex.tooltip} !important;`,
     transitionDuration: 0,
     padding: 0,
     className: 'tooltip-container',

--- a/static/app/components/core/drawer/components.tsx
+++ b/static/app/components/core/drawer/components.tsx
@@ -1,10 +1,11 @@
-import {createContext, Fragment, useContext} from 'react';
+import {createContext, Fragment, useContext, useRef} from 'react';
 import styled from '@emotion/styled';
 import {mergeRefs} from '@react-aria/utils';
 
 import {Button} from '@sentry/scraps/button';
 import type {DrawerOptions} from '@sentry/scraps/drawer';
 import {SlideOverPanel} from '@sentry/scraps/slideOverPanel';
+import {TooltipContext} from '@sentry/scraps/tooltip';
 
 import {IconClose} from 'sentry/icons/iconClose';
 import {t} from 'sentry/locale';
@@ -63,19 +64,20 @@ function DrawerPanel({
       drawerWidth,
       enabled: resizable,
     });
+  const tooltipContainerRef = useRef<HTMLDivElement>(null);
 
   // Calculate actual drawer width in pixels
   const actualDrawerWidth =
     (window.innerWidth * (enabled ? persistedWidthPercent : 100)) / 100;
 
   return (
-    <DrawerContainer>
+    <DrawerContainer mode={mode}>
       <DrawerWidthContext.Provider value={actualDrawerWidth}>
         <DrawerSlidePanel
           mode={mode}
           ariaLabel={ariaLabel}
           position="right"
-          ref={mergeRefs(panelRef, ref)}
+          ref={mergeRefs(panelRef, ref, tooltipContainerRef)}
           panelWidth="var(--drawer-width)" // Initial width only
           className="drawer-panel"
         >
@@ -94,9 +96,11 @@ function DrawerPanel({
             For example: <DrawerHeader />, will trigger the custom onClose callback set in openDrawer
             when it's button is pressed.
           */}
-          <DrawerContentContext value={{onClose, ariaLabel}}>
-            {children}
-          </DrawerContentContext>
+          <TooltipContext value={{container: tooltipContainerRef.current}}>
+            <DrawerContentContext value={{onClose, ariaLabel}}>
+              {children}
+            </DrawerContentContext>
+          </TooltipContext>
         </DrawerSlidePanel>
       </DrawerWidthContext.Provider>
     </DrawerContainer>
@@ -202,10 +206,13 @@ export const DrawerBody = styled('aside')`
   font-size: ${p => p.theme.font.size.md};
 `;
 
-const DrawerContainer = styled('div')`
+const DrawerContainer = styled('div')<{mode?: DrawerOptions['mode']}>`
   position: fixed;
   inset: 0;
-  z-index: ${p => p.theme.zIndex.drawer};
+  /* Passive drawers have no backdrop, so elevate above tooltip to keep
+     behind-page tooltips from rendering over the drawer. */
+  z-index: ${p =>
+    p.mode === 'passive' ? p.theme.zIndex.tooltip + 1 : p.theme.zIndex.drawer};
   pointer-events: none;
 
   @media (max-width: ${p => p.theme.breakpoints.sm}) {

--- a/static/app/components/core/drawer/components.tsx
+++ b/static/app/components/core/drawer/components.tsx
@@ -1,4 +1,4 @@
-import {createContext, Fragment, useContext, useRef} from 'react';
+import {createContext, Fragment, useContext, useState} from 'react';
 import styled from '@emotion/styled';
 import {mergeRefs} from '@react-aria/utils';
 
@@ -64,7 +64,7 @@ function DrawerPanel({
       drawerWidth,
       enabled: resizable,
     });
-  const tooltipContainerRef = useRef<HTMLDivElement>(null);
+  const [tooltipContainer, setTooltipContainer] = useState<HTMLDivElement | null>(null);
 
   // Calculate actual drawer width in pixels
   const actualDrawerWidth =
@@ -77,7 +77,9 @@ function DrawerPanel({
           mode={mode}
           ariaLabel={ariaLabel}
           position="right"
-          ref={mergeRefs(panelRef, ref, tooltipContainerRef)}
+          ref={mergeRefs(panelRef, ref, (node: HTMLDivElement | null) =>
+            setTooltipContainer(node)
+          )}
           panelWidth="var(--drawer-width)" // Initial width only
           className="drawer-panel"
         >
@@ -96,7 +98,7 @@ function DrawerPanel({
             For example: <DrawerHeader />, will trigger the custom onClose callback set in openDrawer
             when it's button is pressed.
           */}
-          <TooltipContext value={{container: tooltipContainerRef.current}}>
+          <TooltipContext value={{container: tooltipContainer}}>
             <DrawerContentContext value={{onClose, ariaLabel}}>
               {children}
             </DrawerContentContext>


### PR DESCRIPTION
All drawers were previously behind tooltips from hovering on page behind. Changed this to put passive drawers above tooltips always. Also made the chart tooltips the same level as other ones so that they remain behind drawers too. 