### PR TITLE
fix(cache): Swap self-hosted to ReconnectingMemcache and ban PyMemcacheCache

### DIFF
--- a/self-hosted/sentry.conf.py
+++ b/self-hosted/sentry.conf.py
@@ -110,10 +110,10 @@ if memcached:
     memcached_port = env("SENTRY_MEMCACHED_PORT") or "11211"
     CACHES = {
         "default": {
-            "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
+            "BACKEND": "sentry.cache.backends.reconnectingmemcache.ReconnectingMemcache",
             "LOCATION": [memcached + ":" + memcached_port],
             "TIMEOUT": 3600,
-            "OPTIONS": {"ignore_exc": True},
+            "OPTIONS": {"ignore_exc": True, "reconnect_age": 300},
         }
     }
 

--- a/src/sentry/cache/backends/reconnectingmemcache.py
+++ b/src/sentry/cache/backends/reconnectingmemcache.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping
 from typing import NamedTuple
 
 import pymemcache
-from django.core.cache.backends.memcached import PyMemcacheCache
+from django.core.cache.backends.memcached import PyMemcacheCache  # noqa: S018
 
 from sentry.utils import metrics
 

--- a/tests/tools/test_flake8_plugin.py
+++ b/tests/tools/test_flake8_plugin.py
@@ -289,6 +289,54 @@ def test_S016() -> None:
     assert _run(src) == []
 
 
+def test_S018() -> None:
+    expected_msg = (
+        "S018 Use `sentry.cache.backends.reconnectingmemcache.ReconnectingMemcache` "
+        "instead of `django.core.cache.backends.memcached.PyMemcacheCache`."
+    )
+
+    src = """\
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
+        "LOCATION": ["127.0.0.1:11211"],
+    }
+}
+"""
+    errors = _run(src)
+    assert errors == [f"t.py:3:19: {expected_msg}"]
+
+    src = 'BACKEND = "django.core.cache.backends.memcached.PyMemcacheCache"\n'
+    errors = _run(src)
+    assert errors == [f"t.py:1:10: {expected_msg}"]
+
+    src = "from django.core.cache.backends.memcached import PyMemcacheCache\n"
+    errors = _run(src)
+    assert errors == [f"t.py:1:0: {expected_msg}"]
+
+    src = "from django.core.cache.backends.memcached import PyMemcacheCache, PyLibMCCache\n"
+    errors = _run(src)
+    assert errors == [f"t.py:1:0: {expected_msg}"]
+
+    src = "from django.core.cache.backends.memcached import PyLibMCCache\n"
+    assert _run(src) == []
+
+    src = "from sentry.cache.backends.reconnectingmemcache import ReconnectingMemcache\n"
+    assert _run(src) == []
+
+    src = """\
+CACHES = {
+    "default": {
+        "BACKEND": "sentry.cache.backends.reconnectingmemcache.ReconnectingMemcache",
+    }
+}
+"""
+    assert _run(src) == []
+
+    src = '"PyMemcacheCache is a Django backend"\n'
+    assert _run(src) == []
+
+
 def test_S015_current_or_future_year() -> None:
     cy = datetime.now(timezone.utc).year
     msg = _s015_msg()

--- a/tools/flake8_plugin.py
+++ b/tools/flake8_plugin.py
@@ -48,6 +48,13 @@ S017_msg = (
     "billing/platform/. Use only getsentry.billing.platform.* imports."
 )
 
+S018_msg = (
+    "S018 Use `sentry.cache.backends.reconnectingmemcache.ReconnectingMemcache` "
+    "instead of `django.core.cache.backends.memcached.PyMemcacheCache`."
+)
+S018_fqn = "django.core.cache.backends.memcached.PyMemcacheCache"  # noqa: S018
+S018_module = "django.core.cache.backends.memcached"
+
 
 # --- S015: do not hardcode current or future UTC year as test "now" ---
 # Flag year >= current UTC year at lint time. Module/class scope + freeze_time(datetime(...)).
@@ -137,6 +144,10 @@ class SentryVisitor(ast.NodeVisitor):
                 x.name == "ThreadPoolExecutor" for x in node.names
             ):
                 self.errors.append((node.lineno, node.col_offset, S016_msg))
+            elif node.module == S018_module and any(
+                x.name == "PyMemcacheCache" for x in node.names
+            ):
+                self.errors.append((node.lineno, node.col_offset, S018_msg))
 
         if (
             _is_platform_path(self.filename)
@@ -186,6 +197,12 @@ class SentryVisitor(ast.NodeVisitor):
     def visit_Name(self, node: ast.Name) -> None:
         if node.id == "print":
             self.errors.append((node.lineno, node.col_offset, S002_msg))
+
+        self.generic_visit(node)
+
+    def visit_Constant(self, node: ast.Constant) -> None:
+        if isinstance(node.value, str) and node.value == S018_fqn:
+            self.errors.append((node.lineno, node.col_offset, S018_msg))
 
         self.generic_visit(node)
 


### PR DESCRIPTION
Swap self-hosted's `CACHES["default"]` backend to `ReconnectingMemcache` and add flake8 rule **S018** forbidding `PyMemcacheCache` as either an import or a `BACKEND` string literal elsewhere.

`ContextPropagatingThreadPoolExecutor` copies contextvars into worker threads. Django's cache handler is contextvar-stored, so workers share one `pymemcache.HashClient` socket; concurrent ops corrupt the memcached protocol and hang. Cloud has been on `ReconnectingMemcache` (per-thread client) since getsentry `f4ba387d8f`; self-hosted was the last raw-`PyMemcacheCache` deployment.

Self-hosted users with a customised `sentry.conf.py` need to swap the `BACKEND` string and add `"reconnect_age": 300` to `OPTIONS`. Stock-config users get the change via the image.

Fixes #113643