### PR TITLE
fix(cmdk): Show flat project settings list in browse mode

### DIFF
--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -412,7 +412,7 @@ export function GlobalCommandPaletteActions() {
                   // including the full projects array would be too costly —
                   // some orgs have thousands of projects.
                   // `params.projectId`/`queryProjectIds` bust the cache when
-                  // the active project changes.
+                  // the active project changes (affects "Current" tag display).
                   // eslint-disable-next-line @tanstack/query/exhaustive-deps
                   cmdkQueryOptions({
                     queryKey: [
@@ -421,33 +421,27 @@ export function GlobalCommandPaletteActions() {
                       suffix,
                       params.projectId ?? [...queryProjectIds].join(','),
                     ],
-                    queryFn: () =>
-                      projects
-                        .filter(p => !currentProjectSlugs.has(p.slug))
-                        .map(project => ({
-                          display: {
-                            label: project.slug,
-                            icon: <ProjectAvatar project={project} size={16} />,
-                          },
-                          to: `/settings/${organization.slug}/projects/${project.slug}/${suffix}`,
-                        })),
+                    queryFn: () => {
+                      const sorted = [
+                        ...projects.filter(p => currentProjectSlugs.has(p.slug)),
+                        ...projects.filter(p => !currentProjectSlugs.has(p.slug)),
+                      ];
+                      return sorted.map(project => ({
+                        display: {
+                          label: project.slug,
+                          icon: <ProjectAvatar project={project} size={16} />,
+                          trailingItem: currentProjectSlugs.has(project.slug) ? (
+                            <Tag variant="muted">{t('Current')}</Tag>
+                          ) : undefined,
+                        },
+                        to: `/settings/${organization.slug}/projects/${project.slug}/${suffix}`,
+                      }));
+                    },
                     enabled: state === 'selected',
                     staleTime: Infinity,
                   })
                 }
-              >
-                {currentProjects.map(project => (
-                  <CMDKAction
-                    key={project.id}
-                    display={{
-                      label: project.slug,
-                      icon: <ProjectAvatar project={project} size={16} />,
-                      trailingItem: <Tag variant="muted">{t('Current')}</Tag>,
-                    }}
-                    to={`/settings/${organization.slug}/projects/${project.slug}/${suffix}`}
-                  />
-                ))}
-              </CMDKAction>
+              />
             );
           })}
         </CMDKAction>


### PR DESCRIPTION
When a single project was selected, each project settings entry in the command palette rendered as a disabled section header with the current project as a sub-item beneath it — producing a list like:

```
Alert Settings       ← disabled header
  my-project         ← only option
Client Keys
  my-project
...
```

The root cause: `CMDKAction` nodes with children are treated as groups by `flattenActions`, which promotes them to non-interactive section headers. Each nav item had the current project(s) as static children, so even a single selected project triggered the group layout.

The fix removes the static current-project children entirely. All projects now come from the async `resource` (loaded only when the user selects a setting), with current projects sorted to the top and tagged "Current". This keeps nav items as leaf nodes in browse mode, so they render as a flat selectable list. After selecting a setting, the full project picker appears — including the current project — so users can still navigate to any project's settings.