### PR TITLE
feat(seer-explorer): Add size="md" prop to TextArea components in inputSection

### DIFF
--- a/static/app/views/seerExplorer/components/inputSection.tsx
+++ b/static/app/views/seerExplorer/components/inputSection.tsx
@@ -158,6 +158,7 @@ export function InputSection({
                 'This conversation is owned by another user and is read-only'
               )}
               rows={1}
+              size="md"
               data-test-id="seer-explorer-input"
             />
           </StyledInputGroup>
@@ -270,6 +271,7 @@ export function InputSection({
             rows={1}
             maxRows={5}
             autosize
+            size="md"
             data-test-id="seer-explorer-input"
           />
         </StyledInputGroup>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This PR adds the `size="md"` prop to both `InputGroup.TextArea` components in the Seer Explorer input section.

## Changes
- Added `size="md"` prop to the disabled TextArea (read-only state)
- Added `size="md"` prop to the main input TextArea

## Context
As requested in Slack, this ensures consistent sizing of the TextArea components in the Seer Explorer interface.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/C0ANGU44SMT/p1776972918126849?thread_ts=1776972918.126849&cid=C0ANGU44SMT)

<div><a href="https://cursor.com/agents/bc-cdc8c8a5-79c1-527f-926a-dc2387118041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cdc8c8a5-79c1-527f-926a-dc2387118041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

