### PR TITLE
feat(seer): Open repo details in a GlobalDrawer

### DIFF
--- a/static/gsApp/views/seerAutomation/components/repoDetails/repoDetailsForm.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoDetails/repoDetailsForm.tsx
@@ -88,7 +88,7 @@ export function RepoDetailsForm({organization, repoWithSettings}: Props) {
           )}
         </Alert>
       )}
-      <FieldGroup title={t('AI Code Review')}>
+      <FieldGroup>
         <AutoSaveForm
           name="enabledCodeReview"
           schema={schema}

--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTableRow.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTableRow.tsx
@@ -25,6 +25,7 @@ import {
 } from 'sentry/types/integrations';
 import type {CodeReviewTrigger} from 'sentry/types/seer';
 import {useListItemCheckboxContext} from 'sentry/utils/list/useListItemCheckboxState';
+import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 import {useCanWriteSettings} from 'getsentry/views/seerAutomation/components/useCanWriteSettings';
@@ -44,6 +45,7 @@ export function SeerRepoTableRow({
 }: Props) {
   const queryClient = useQueryClient();
   const organization = useOrganization();
+  const location = useLocation();
   const canWrite = useCanWriteSettings();
   const {isSelected, toggleSelected} = useListItemCheckboxContext();
 
@@ -73,7 +75,7 @@ export function SeerRepoTableRow({
       </SimpleTable.RowCell>
       <SimpleTable.RowCell>
         <Stack gap="xs">
-          <Link to={`/settings/${organization.slug}/seer/repos/${repository.id}/`}>
+          <Link to={{...location, query: {...location.query, repoId: repository.id}}}>
             <Flex align="center">
               <strong>{repository.name}</strong>
               {repository.status !== RepositoryStatus.ACTIVE && (

--- a/static/gsApp/views/seerAutomation/hooks/useRepoDetailsDrawer.tsx
+++ b/static/gsApp/views/seerAutomation/hooks/useRepoDetailsDrawer.tsx
@@ -1,0 +1,112 @@
+import {useEffect, useRef} from 'react';
+
+import {Alert} from '@sentry/scraps/alert';
+import {DrawerBody, DrawerHeader, useDrawer} from '@sentry/scraps/drawer';
+import {Flex} from '@sentry/scraps/layout';
+import {ExternalLink} from '@sentry/scraps/link';
+import {Text} from '@sentry/scraps/text';
+
+import {AnalyticsArea} from 'sentry/components/analyticsArea';
+import {useIsSeerSupportedProvider} from 'sentry/components/events/autofix/utils';
+import {LoadingError} from 'sentry/components/loadingError';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {NoAccess} from 'sentry/components/noAccess';
+import {RepoProviderIcon} from 'sentry/components/repositories/repoProviderIcon';
+import {useRepositoryWithSettings} from 'sentry/components/repositories/useRepositoryWithSettings';
+import {t} from 'sentry/locale';
+import {decodeScalar} from 'sentry/utils/queryString';
+import {useLocationQuery} from 'sentry/utils/url/useLocationQuery';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+import {RepoDetailsForm} from 'getsentry/views/seerAutomation/components/repoDetails/repoDetailsForm';
+import {orgHasCodeReviewFeature} from 'getsentry/views/seerAutomation/utils';
+
+export function useRepoDetailsDrawer() {
+  const {repoId} = useLocationQuery({fields: {repoId: decodeScalar}});
+  const organization = useOrganization();
+  const {openDrawer} = useDrawer();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const isSupportedProvider = useIsSeerSupportedProvider();
+
+  // Keep a ref so the onClose callback always sees the current query without
+  // being listed as an effect dependency (which would re-open the drawer on
+  // every filter/search change while the drawer is already open).
+  const locationRef = useRef(location);
+  useEffect(() => {
+    locationRef.current = location;
+  });
+
+  const hasCodeReviewAccess = orgHasCodeReviewFeature(organization);
+
+  const {
+    data: repoWithSettings,
+    error,
+    isPending,
+    refetch,
+  } = useRepositoryWithSettings({
+    repositoryId: repoId ?? '',
+    enabled: !!repoId && hasCodeReviewAccess,
+  });
+
+  useEffect(() => {
+    if (!repoId) return;
+
+    openDrawer(
+      () => (
+        <AnalyticsArea name="repo-details">
+          <DrawerHeader>
+            {repoWithSettings && (
+              <ExternalLink href={repoWithSettings.url}>
+                <Flex align="center" gap="md" height="100%">
+                  <RepoProviderIcon size="md" provider={repoWithSettings.provider.id} />
+                  <Text monospace>{repoWithSettings.name}</Text>
+                </Flex>
+              </ExternalLink>
+            )}
+          </DrawerHeader>
+          <DrawerBody>
+            {!hasCodeReviewAccess && <NoAccess />}
+            {hasCodeReviewAccess && isPending && <LoadingIndicator />}
+            {hasCodeReviewAccess && error && <LoadingError onRetry={refetch} />}
+            {hasCodeReviewAccess &&
+              repoWithSettings &&
+              (isSupportedProvider(repoWithSettings.provider) ? (
+                <RepoDetailsForm
+                  organization={organization}
+                  repoWithSettings={repoWithSettings}
+                />
+              ) : (
+                <Alert variant="warning">
+                  {t('Seer is not supported for this repository.')}
+                </Alert>
+              ))}
+          </DrawerBody>
+        </AnalyticsArea>
+      ),
+      {
+        ariaLabel: t('Repository Details'),
+        drawerKey: 'repo-details-drawer',
+        resizable: true,
+        onClose: () => {
+          const {repoId: _removed, ...restQuery} = locationRef.current.query;
+          navigate({query: restQuery}, {replace: true});
+        },
+        shouldCloseOnLocationChange: nextLocation => !nextLocation.query.repoId,
+      }
+    );
+  }, [
+    repoId,
+    openDrawer,
+    navigate,
+    organization,
+    hasCodeReviewAccess,
+    isSupportedProvider,
+    isPending,
+    error,
+    refetch,
+    repoWithSettings,
+  ]);
+}

--- a/static/gsApp/views/seerAutomation/repoDetails.tsx
+++ b/static/gsApp/views/seerAutomation/repoDetails.tsx
@@ -1,110 +1,29 @@
-import {Alert} from '@sentry/scraps/alert';
-import {Flex} from '@sentry/scraps/layout';
-import {ExternalLink} from '@sentry/scraps/link';
-import {Text} from '@sentry/scraps/text';
+import {useEffect} from 'react';
 
-import {AnalyticsArea} from 'sentry/components/analyticsArea';
-import {useIsSeerSupportedProvider} from 'sentry/components/events/autofix/utils';
-import {LoadingError} from 'sentry/components/loadingError';
-import {LoadingIndicator} from 'sentry/components/loadingIndicator';
-import {NoAccess} from 'sentry/components/noAccess';
-import {RepoProviderIcon} from 'sentry/components/repositories/repoProviderIcon';
-import {useRepositoryWithSettings} from 'sentry/components/repositories/useRepositoryWithSettings';
-import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
-import {t, tct} from 'sentry/locale';
+import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
-import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
 
-import {RepoDetailsForm} from 'getsentry/views/seerAutomation/components/repoDetails/repoDetailsForm';
-import {SeerSettingsPageWrapper} from 'getsentry/views/seerAutomation/components/seerSettingsPageWrapper';
-import {orgHasCodeReviewFeature} from 'getsentry/views/seerAutomation/utils';
-
-export default function SeerRepoDetails() {
+// Redirect route for backward compat: repos/:repoId/ → repos/?repoId=:repoId
+export default function SeerRepoDetailsRedirect() {
   const {repoId} = useParams<{repoId: string}>();
+  const location = useLocation();
+  const navigate = useNavigate();
   const organization = useOrganization();
-  const isSupportedProvider = useIsSeerSupportedProvider();
 
-  const hasCodeReviewAccess = orgHasCodeReviewFeature(organization);
-
-  const {
-    data: repoWithSettings,
-    error,
-    isPending,
-    refetch,
-  } = useRepositoryWithSettings({
-    repositoryId: repoId,
-    enabled: hasCodeReviewAccess,
-  });
-
-  if (!hasCodeReviewAccess) {
-    return (
-      <AnalyticsArea name="repo-details">
-        <NoAccess />
-      </AnalyticsArea>
+  useEffect(() => {
+    navigate(
+      {
+        pathname: normalizeUrl(`/settings/${organization.slug}/seer/repos/`),
+        query: {...location.query, repoId},
+      },
+      {replace: true}
     );
-  }
+    // Only redirect once on mount — repoId and org are stable for this route instance
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  if (isPending) {
-    return (
-      <AnalyticsArea name="repo-details">
-        <LoadingIndicator />
-      </AnalyticsArea>
-    );
-  }
-
-  if (error) {
-    return (
-      <AnalyticsArea name="repo-details">
-        <LoadingError onRetry={refetch} />
-      </AnalyticsArea>
-    );
-  }
-
-  return (
-    <AnalyticsArea name="repo-details">
-      <SeerSettingsPageWrapper>
-        <SentryDocumentTitle title={t('Code Review for %s', repoWithSettings?.name)} />
-        <SettingsPageHeader
-          title={
-            <Flex align="baseline" gap="md">
-              {tct('Code Review for [repoName] [providerLink]', {
-                repoName: (
-                  <Text as="span" monospace>
-                    {repoWithSettings?.name}
-                  </Text>
-                ),
-                providerLink: (
-                  <ExternalLink href={repoWithSettings?.url}>
-                    <RepoProviderIcon
-                      size="md"
-                      provider={repoWithSettings?.provider.id}
-                    />
-                  </ExternalLink>
-                ),
-              })}
-            </Flex>
-          }
-          subtitle={tct(
-            'Choose how Seer automatically reviews your pull requests. [docs:Read the docs] to learn what Seer can do.',
-            {
-              docs: (
-                <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/code-review/" />
-              ),
-            }
-          )}
-        />
-        {isSupportedProvider(repoWithSettings?.provider) ? (
-          <RepoDetailsForm
-            organization={organization}
-            repoWithSettings={repoWithSettings}
-          />
-        ) : (
-          <Alert variant="warning">
-            {t('Seer is not supported for this repository.')}
-          </Alert>
-        )}
-      </SeerSettingsPageWrapper>
-    </AnalyticsArea>
-  );
+  return null;
 }

--- a/static/gsApp/views/seerAutomation/repos.tsx
+++ b/static/gsApp/views/seerAutomation/repos.tsx
@@ -10,10 +10,12 @@ import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageH
 import {SeerRepoTable} from 'getsentry/views/seerAutomation/components/repoTable/seerRepoTable';
 import {SeerSettingsPageContent} from 'getsentry/views/seerAutomation/components/seerSettingsPageContent';
 import {SeerSettingsPageWrapper} from 'getsentry/views/seerAutomation/components/seerSettingsPageWrapper';
+import {useRepoDetailsDrawer} from 'getsentry/views/seerAutomation/hooks/useRepoDetailsDrawer';
 import {orgHasCodeReviewFeature} from 'getsentry/views/seerAutomation/utils';
 
 export default function SeerAutomationRepos() {
   const organization = useOrganization();
+  useRepoDetailsDrawer();
 
   if (!orgHasCodeReviewFeature(organization)) {
     return (


### PR DESCRIPTION
Repo details now open in a slide-out drawer on the Code Review settings page rather than navigating to a full-page route.

- Add useRepoDetailsDrawer hook that reads a repoId query param and opens the GlobalDrawer with repo data, loading/error states, and the settings form
- Update the repo table row link to set ?repoId= on the current URL instead of navigating away, preserving any active search/filter query params
- Convert the repos/:repoId/ route to a redirect for backward compat with old bookmarks and direct links, forwarding to repos/?repoId=:repoId
- repoDetails.tsx is now only the redirect; drawer content lives in the hook


<img width="995" height="487" alt="SCR-20260423-ocaa" src="https://github.com/user-attachments/assets/90324c7a-4525-49fa-b036-9ef2454915ef" />

