### PR TITLE
feat(onboarding): Add SCM-specific analytics variants to SetupDocs and back actions

### DIFF
--- a/static/app/components/onboarding/frameworkSuggestionModal.tsx
+++ b/static/app/components/onboarding/frameworkSuggestionModal.tsx
@@ -212,10 +212,13 @@ export function FrameworkSuggestionModal({
       return;
     }
 
-    // In the SCM onboarding flow, the caller fires `scm_platform_selected`
-    // from its `onConfigure` handler, so we skip the generic event here to
-    // avoid double-firing into the non-SCM funnel.
-    if (!isScmOnboarding) {
+    if (isScmOnboarding) {
+      trackAnalytics('onboarding.scm_platform_selected', {
+        organization,
+        platform: selectedFramework.key,
+        source: 'manual',
+      });
+    } else {
       trackAnalytics(
         newOrg
           ? 'onboarding.select_framework_modal_configure_sdk_button_clicked'
@@ -239,10 +242,13 @@ export function FrameworkSuggestionModal({
   ]);
 
   const handleSkip = useCallback(() => {
-    // In the SCM onboarding flow, the caller fires `scm_platform_selected`
-    // from its `onSkip` handler, so we skip the generic event here to avoid
-    // double-firing into the non-SCM funnel.
-    if (!isScmOnboarding) {
+    if (isScmOnboarding) {
+      trackAnalytics('onboarding.scm_platform_selected', {
+        organization,
+        platform: selectedPlatform.key,
+        source: 'manual',
+      });
+    } else {
       trackAnalytics(
         newOrg
           ? 'onboarding.select_framework_modal_skip_button_clicked'

--- a/static/app/components/onboarding/frameworkSuggestionModal.tsx
+++ b/static/app/components/onboarding/frameworkSuggestionModal.tsx
@@ -124,6 +124,7 @@ interface FrameworkSuggestionModalProps extends ModalRenderProps {
   onSkip: () => void;
   organization: Organization;
   selectedPlatform: OnboardingSelectedSDK;
+  isScmOnboarding?: boolean;
   newOrg?: boolean;
 }
 
@@ -137,6 +138,7 @@ export function FrameworkSuggestionModal({
   CloseButton,
   organization,
   newOrg,
+  isScmOnboarding,
 }: FrameworkSuggestionModalProps) {
   const isCreatingProjectAndRules = useIsCreatingProjectAndRules();
   const createProjectAndRulesError = useCreateProjectAndRulesError();
@@ -193,47 +195,66 @@ export function FrameworkSuggestionModal({
 
   useEffect(() => {
     trackAnalytics(
-      newOrg
-        ? 'onboarding.select_framework_modal_rendered'
-        : 'project_creation.select_framework_modal_rendered',
+      isScmOnboarding
+        ? 'onboarding.scm_select_framework_modal_rendered'
+        : newOrg
+          ? 'onboarding.select_framework_modal_rendered'
+          : 'project_creation.select_framework_modal_rendered',
       {
         platform: selectedPlatform.key,
         organization,
       }
     );
-  }, [selectedPlatform.key, organization, newOrg]);
+  }, [selectedPlatform.key, organization, newOrg, isScmOnboarding]);
 
   const handleConfigure = useCallback(() => {
     if (!selectedFramework) {
       return;
     }
 
-    trackAnalytics(
-      newOrg
-        ? 'onboarding.select_framework_modal_configure_sdk_button_clicked'
-        : 'project_creation.select_framework_modal_configure_sdk_button_clicked',
-      {
-        platform: selectedPlatform.key,
-        framework: selectedFramework.key,
-        organization,
-      }
-    );
+    // In the SCM onboarding flow, the caller fires `scm_platform_selected`
+    // from its `onConfigure` handler, so we skip the generic event here to
+    // avoid double-firing into the non-SCM funnel.
+    if (!isScmOnboarding) {
+      trackAnalytics(
+        newOrg
+          ? 'onboarding.select_framework_modal_configure_sdk_button_clicked'
+          : 'project_creation.select_framework_modal_configure_sdk_button_clicked',
+        {
+          platform: selectedPlatform.key,
+          framework: selectedFramework.key,
+          organization,
+        }
+      );
+    }
 
     onConfigure(selectedFramework);
-  }, [selectedPlatform, selectedFramework, organization, onConfigure, newOrg]);
+  }, [
+    selectedPlatform,
+    selectedFramework,
+    organization,
+    onConfigure,
+    newOrg,
+    isScmOnboarding,
+  ]);
 
   const handleSkip = useCallback(() => {
-    trackAnalytics(
-      newOrg
-        ? 'onboarding.select_framework_modal_skip_button_clicked'
-        : 'project_creation.select_framework_modal_skip_button_clicked',
-      {
-        platform: selectedPlatform.key,
-        organization,
-      }
-    );
+    // In the SCM onboarding flow, the caller fires `scm_platform_selected`
+    // from its `onSkip` handler, so we skip the generic event here to avoid
+    // double-firing into the non-SCM funnel.
+    if (!isScmOnboarding) {
+      trackAnalytics(
+        newOrg
+          ? 'onboarding.select_framework_modal_skip_button_clicked'
+          : 'project_creation.select_framework_modal_skip_button_clicked',
+        {
+          platform: selectedPlatform.key,
+          organization,
+        }
+      );
+    }
     onSkip();
-  }, [selectedPlatform, organization, onSkip, newOrg]);
+  }, [selectedPlatform, organization, onSkip, newOrg, isScmOnboarding]);
 
   const handleClick = useCallback(() => {
     if (selectedFramework?.key === selectedPlatform.key) {

--- a/static/app/components/onboarding/frameworkSuggestionModal.tsx
+++ b/static/app/components/onboarding/frameworkSuggestionModal.tsx
@@ -124,7 +124,7 @@ interface FrameworkSuggestionModalProps extends ModalRenderProps {
   onSkip: () => void;
   organization: Organization;
   selectedPlatform: OnboardingSelectedSDK;
-  isScmOnboarding?: boolean;
+  hasScmOnboarding?: boolean;
   newOrg?: boolean;
 }
 
@@ -138,7 +138,7 @@ export function FrameworkSuggestionModal({
   CloseButton,
   organization,
   newOrg,
-  isScmOnboarding,
+  hasScmOnboarding,
 }: FrameworkSuggestionModalProps) {
   const isCreatingProjectAndRules = useIsCreatingProjectAndRules();
   const createProjectAndRulesError = useCreateProjectAndRulesError();
@@ -195,7 +195,7 @@ export function FrameworkSuggestionModal({
 
   useEffect(() => {
     trackAnalytics(
-      isScmOnboarding
+      hasScmOnboarding
         ? 'onboarding.scm_select_framework_modal_rendered'
         : newOrg
           ? 'onboarding.select_framework_modal_rendered'
@@ -205,14 +205,14 @@ export function FrameworkSuggestionModal({
         organization,
       }
     );
-  }, [selectedPlatform.key, organization, newOrg, isScmOnboarding]);
+  }, [selectedPlatform.key, organization, newOrg, hasScmOnboarding]);
 
   const handleConfigure = useCallback(() => {
     if (!selectedFramework) {
       return;
     }
 
-    if (isScmOnboarding) {
+    if (hasScmOnboarding) {
       trackAnalytics('onboarding.scm_platform_selected', {
         organization,
         platform: selectedFramework.key,
@@ -238,11 +238,11 @@ export function FrameworkSuggestionModal({
     organization,
     onConfigure,
     newOrg,
-    isScmOnboarding,
+    hasScmOnboarding,
   ]);
 
   const handleSkip = useCallback(() => {
-    if (isScmOnboarding) {
+    if (hasScmOnboarding) {
       trackAnalytics('onboarding.scm_platform_selected', {
         organization,
         platform: selectedPlatform.key,
@@ -260,7 +260,7 @@ export function FrameworkSuggestionModal({
       );
     }
     onSkip();
-  }, [selectedPlatform, organization, onSkip, newOrg, isScmOnboarding]);
+  }, [selectedPlatform, organization, onSkip, newOrg, hasScmOnboarding]);
 
   const handleClick = useCallback(() => {
     if (selectedFramework?.key === selectedPlatform.key) {

--- a/static/app/components/onboarding/gettingStartedDoc/copyDsnField.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/copyDsnField.tsx
@@ -19,10 +19,15 @@ function CopyDsnField({params}: {params: DocsParams<any>}) {
       </p>
       <TextCopyInput
         onCopy={() =>
-          trackAnalytics('onboarding.dsn-copied', {
-            organization: params.organization,
-            platform: params.platformKey,
-          })
+          trackAnalytics(
+            params.isScmOnboarding
+              ? 'onboarding.scm_dsn_copied'
+              : 'onboarding.dsn-copied',
+            {
+              organization: params.organization,
+              platform: params.platformKey,
+            }
+          )
         }
       >
         {params.dsn.public}

--- a/static/app/components/onboarding/gettingStartedDoc/copyDsnField.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/copyDsnField.tsx
@@ -20,7 +20,7 @@ function CopyDsnField({params}: {params: DocsParams<any>}) {
       <TextCopyInput
         onCopy={() =>
           trackAnalytics(
-            params.isScmOnboarding
+            params.hasScmOnboarding
               ? 'onboarding.scm_dsn_copied'
               : 'onboarding.dsn-copied',
             {

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
@@ -48,6 +48,7 @@ export type OnboardingLayoutProps = {
   projectKeyId: ProjectKey['id'];
   activeProductSelection?: ProductSolution[];
   configType?: ConfigType;
+  isScmOnboarding?: boolean;
   newOrg?: boolean;
   /**
    * Fires after every product toggle in addition to the doc's
@@ -69,6 +70,7 @@ export function OnboardingLayout({
   projectKeyId,
   configType = 'onboarding',
   onProductSelectionSync,
+  isScmOnboarding,
 }: OnboardingLayoutProps) {
   const api = useApi();
   const organization = useOrganization();
@@ -113,6 +115,7 @@ export function OnboardingLayout({
       isSelfHosted,
       platformOptions: selectedOptions,
       newOrg,
+      isScmOnboarding,
       profilingOptions: {
         defaultProfilingMode: organization.features.includes('continuous-profiling')
           ? 'continuous'
@@ -129,10 +132,13 @@ export function OnboardingLayout({
           configureSteps: doc.configure(docParams),
           dsn,
           onCopyDsn: () => {
-            trackAnalytics('onboarding.dsn-copied', {
-              organization,
-              platform: platformKey,
-            });
+            trackAnalytics(
+              isScmOnboarding ? 'onboarding.scm_dsn_copied' : 'onboarding.dsn-copied',
+              {
+                organization,
+                platform: platformKey,
+              }
+            );
           },
         }),
         ...doc.verify(docParams),
@@ -159,6 +165,7 @@ export function OnboardingLayout({
     isSelfHosted,
     api,
     projectKeyId,
+    isScmOnboarding,
   ]);
 
   useEffect(() => {
@@ -244,14 +251,19 @@ export function OnboardingLayout({
                       <ExternalLink
                         href={step.link}
                         onClick={() =>
-                          trackAnalytics('onboarding.next_step_clicked', {
-                            organization,
-                            platform: platformKey,
-                            project_id: project.id,
-                            products: activeProductSelection,
-                            step: step.name,
-                            newOrg: newOrg ?? false,
-                          })
+                          trackAnalytics(
+                            isScmOnboarding
+                              ? 'onboarding.scm_next_step_clicked'
+                              : 'onboarding.next_step_clicked',
+                            {
+                              organization,
+                              platform: platformKey,
+                              project_id: project.id,
+                              products: activeProductSelection,
+                              step: step.name,
+                              newOrg: newOrg ?? false,
+                            }
+                          )
                         }
                       >
                         {step.name}

--- a/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/onboardingLayout.tsx
@@ -48,7 +48,7 @@ export type OnboardingLayoutProps = {
   projectKeyId: ProjectKey['id'];
   activeProductSelection?: ProductSolution[];
   configType?: ConfigType;
-  isScmOnboarding?: boolean;
+  hasScmOnboarding?: boolean;
   newOrg?: boolean;
   /**
    * Fires after every product toggle in addition to the doc's
@@ -70,7 +70,7 @@ export function OnboardingLayout({
   projectKeyId,
   configType = 'onboarding',
   onProductSelectionSync,
-  isScmOnboarding,
+  hasScmOnboarding,
 }: OnboardingLayoutProps) {
   const api = useApi();
   const organization = useOrganization();
@@ -115,7 +115,7 @@ export function OnboardingLayout({
       isSelfHosted,
       platformOptions: selectedOptions,
       newOrg,
-      isScmOnboarding,
+      hasScmOnboarding,
       profilingOptions: {
         defaultProfilingMode: organization.features.includes('continuous-profiling')
           ? 'continuous'
@@ -133,7 +133,7 @@ export function OnboardingLayout({
           dsn,
           onCopyDsn: () => {
             trackAnalytics(
-              isScmOnboarding ? 'onboarding.scm_dsn_copied' : 'onboarding.dsn-copied',
+              hasScmOnboarding ? 'onboarding.scm_dsn_copied' : 'onboarding.dsn-copied',
               {
                 organization,
                 platform: platformKey,
@@ -165,7 +165,7 @@ export function OnboardingLayout({
     isSelfHosted,
     api,
     projectKeyId,
-    isScmOnboarding,
+    hasScmOnboarding,
   ]);
 
   useEffect(() => {
@@ -252,7 +252,7 @@ export function OnboardingLayout({
                         href={step.link}
                         onClick={() =>
                           trackAnalytics(
-                            isScmOnboarding
+                            hasScmOnboarding
                               ? 'onboarding.scm_next_step_clicked'
                               : 'onboarding.next_step_clicked',
                             {

--- a/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.tsx
@@ -17,6 +17,7 @@ type SdkDocumentationProps = {
   platform: PlatformIntegration;
   project: Project;
   configType?: ConfigType;
+  isScmOnboarding?: boolean;
   newOrg?: boolean;
   onProductSelectionSync?: (products: ProductSolution[]) => void;
 };
@@ -30,6 +31,7 @@ export function SdkDocumentation({
   configType,
   organization,
   onProductSelectionSync,
+  isScmOnboarding,
 }: SdkDocumentationProps) {
   const {isLoading, isError, dsn, docs, refetch, projectKeyId} = useLoadGettingStarted({
     orgSlug: organization.slug,
@@ -93,6 +95,7 @@ export function SdkDocumentation({
       dsn={dsn}
       activeProductSelection={activeProductSelection}
       newOrg={newOrg}
+      isScmOnboarding={isScmOnboarding}
       platformKey={platform.id}
       project={project}
       configType={configType}

--- a/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/sdkDocumentation.tsx
@@ -17,7 +17,7 @@ type SdkDocumentationProps = {
   platform: PlatformIntegration;
   project: Project;
   configType?: ConfigType;
-  isScmOnboarding?: boolean;
+  hasScmOnboarding?: boolean;
   newOrg?: boolean;
   onProductSelectionSync?: (products: ProductSolution[]) => void;
 };
@@ -31,7 +31,7 @@ export function SdkDocumentation({
   configType,
   organization,
   onProductSelectionSync,
-  isScmOnboarding,
+  hasScmOnboarding,
 }: SdkDocumentationProps) {
   const {isLoading, isError, dsn, docs, refetch, projectKeyId} = useLoadGettingStarted({
     orgSlug: organization.slug,
@@ -95,7 +95,7 @@ export function SdkDocumentation({
       dsn={dsn}
       activeProductSelection={activeProductSelection}
       newOrg={newOrg}
-      isScmOnboarding={isScmOnboarding}
+      hasScmOnboarding={hasScmOnboarding}
       platformKey={platform.id}
       project={project}
       configType={configType}

--- a/static/app/components/onboarding/gettingStartedDoc/types.ts
+++ b/static/app/components/onboarding/gettingStartedDoc/types.ts
@@ -125,6 +125,7 @@ export interface DocsParams<
     name?: boolean;
     screenshot?: boolean;
   };
+  isScmOnboarding?: boolean;
   newOrg?: boolean;
   profilingOptions?: {
     defaultProfilingMode?: 'transaction' | 'continuous';

--- a/static/app/components/onboarding/gettingStartedDoc/types.ts
+++ b/static/app/components/onboarding/gettingStartedDoc/types.ts
@@ -125,7 +125,7 @@ export interface DocsParams<
     name?: boolean;
     screenshot?: boolean;
   };
-  isScmOnboarding?: boolean;
+  hasScmOnboarding?: boolean;
   newOrg?: boolean;
   profilingOptions?: {
     defaultProfilingMode?: 'transaction' | 'continuous';

--- a/static/app/components/onboarding/gettingStartedDoc/utils/index.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/index.tsx
@@ -21,7 +21,7 @@ export function getUploadSourceMapsStep({
   platformKey,
   project,
   newOrg,
-  isScmOnboarding,
+  hasScmOnboarding,
   isSelfHosted,
   description,
 }: DocsParams & {
@@ -58,7 +58,7 @@ export function getUploadSourceMapsStep({
             language="bash"
             onCopy={() =>
               trackEvent(
-                isScmOnboarding
+                hasScmOnboarding
                   ? 'onboarding.scm_source_maps_wizard_button_copy_clicked'
                   : newOrg
                     ? 'onboarding.source_maps_wizard_button_copy_clicked'
@@ -67,7 +67,7 @@ export function getUploadSourceMapsStep({
             }
             onSelectAndCopy={() =>
               trackEvent(
-                isScmOnboarding
+                hasScmOnboarding
                   ? 'onboarding.scm_source_maps_wizard_selected_and_copied'
                   : newOrg
                     ? 'onboarding.source_maps_wizard_selected_and_copied'

--- a/static/app/components/onboarding/gettingStartedDoc/utils/index.tsx
+++ b/static/app/components/onboarding/gettingStartedDoc/utils/index.tsx
@@ -21,6 +21,7 @@ export function getUploadSourceMapsStep({
   platformKey,
   project,
   newOrg,
+  isScmOnboarding,
   isSelfHosted,
   description,
 }: DocsParams & {
@@ -57,16 +58,20 @@ export function getUploadSourceMapsStep({
             language="bash"
             onCopy={() =>
               trackEvent(
-                newOrg
-                  ? 'onboarding.source_maps_wizard_button_copy_clicked'
-                  : 'project_creation.source_maps_wizard_button_copy_clicked'
+                isScmOnboarding
+                  ? 'onboarding.scm_source_maps_wizard_button_copy_clicked'
+                  : newOrg
+                    ? 'onboarding.source_maps_wizard_button_copy_clicked'
+                    : 'project_creation.source_maps_wizard_button_copy_clicked'
               )
             }
             onSelectAndCopy={() =>
               trackEvent(
-                newOrg
-                  ? 'onboarding.source_maps_wizard_selected_and_copied'
-                  : 'project_creation.source_maps_wizard_selected_and_copied'
+                isScmOnboarding
+                  ? 'onboarding.scm_source_maps_wizard_selected_and_copied'
+                  : newOrg
+                    ? 'onboarding.source_maps_wizard_selected_and_copied'
+                    : 'project_creation.source_maps_wizard_selected_and_copied'
               )
             }
           >

--- a/static/app/gettingStartedDocs/javascript/utils.tsx
+++ b/static/app/gettingStartedDocs/javascript/utils.tsx
@@ -341,7 +341,7 @@ export const loaderScriptOnboarding: OnboardingConfig<PlatformOptions> = {
   onPageLoad: params => {
     return () => {
       trackAnalytics(
-        params.isScmOnboarding
+        params.hasScmOnboarding
           ? 'onboarding.scm_setup_loader_docs_rendered'
           : 'onboarding.setup_loader_docs_rendered',
         {
@@ -355,7 +355,7 @@ export const loaderScriptOnboarding: OnboardingConfig<PlatformOptions> = {
   onPlatformOptionsChange: params => {
     return () => {
       trackAnalytics(
-        params.isScmOnboarding
+        params.hasScmOnboarding
           ? 'onboarding.scm_js_loader_npm_docs_shown'
           : 'onboarding.js_loader_npm_docs_shown',
         {
@@ -461,7 +461,7 @@ export const packageManagerOnboarding: OnboardingConfig<PlatformOptions> = {
   onPageLoad: params => {
     return () => {
       trackAnalytics(
-        params.isScmOnboarding
+        params.hasScmOnboarding
           ? 'onboarding.scm_js_loader_npm_docs_shown'
           : 'onboarding.js_loader_npm_docs_shown',
         {
@@ -497,7 +497,7 @@ export const packageManagerOnboarding: OnboardingConfig<PlatformOptions> = {
   onPlatformOptionsChange: params => {
     return () => {
       trackAnalytics(
-        params.isScmOnboarding
+        params.hasScmOnboarding
           ? 'onboarding.scm_setup_loader_docs_rendered'
           : 'onboarding.setup_loader_docs_rendered',
         {

--- a/static/app/gettingStartedDocs/javascript/utils.tsx
+++ b/static/app/gettingStartedDocs/javascript/utils.tsx
@@ -340,20 +340,30 @@ export const loaderScriptOnboarding: OnboardingConfig<PlatformOptions> = {
   },
   onPageLoad: params => {
     return () => {
-      trackAnalytics('onboarding.setup_loader_docs_rendered', {
-        organization: params.organization,
-        platform: params.platformKey,
-        project_id: params.project.id,
-      });
+      trackAnalytics(
+        params.isScmOnboarding
+          ? 'onboarding.scm_setup_loader_docs_rendered'
+          : 'onboarding.setup_loader_docs_rendered',
+        {
+          organization: params.organization,
+          platform: params.platformKey,
+          project_id: params.project.id,
+        }
+      );
     };
   },
   onPlatformOptionsChange: params => {
     return () => {
-      trackAnalytics('onboarding.js_loader_npm_docs_shown', {
-        organization: params.organization,
-        platform: params.platformKey,
-        project_id: params.project.id,
-      });
+      trackAnalytics(
+        params.isScmOnboarding
+          ? 'onboarding.scm_js_loader_npm_docs_shown'
+          : 'onboarding.js_loader_npm_docs_shown',
+        {
+          organization: params.organization,
+          platform: params.platformKey,
+          project_id: params.project.id,
+        }
+      );
     };
   },
   onProductSelectionChange: params => {
@@ -450,11 +460,16 @@ export const packageManagerOnboarding: OnboardingConfig<PlatformOptions> = {
   },
   onPageLoad: params => {
     return () => {
-      trackAnalytics('onboarding.js_loader_npm_docs_shown', {
-        organization: params.organization,
-        platform: params.platformKey,
-        project_id: params.project.id,
-      });
+      trackAnalytics(
+        params.isScmOnboarding
+          ? 'onboarding.scm_js_loader_npm_docs_shown'
+          : 'onboarding.js_loader_npm_docs_shown',
+        {
+          organization: params.organization,
+          platform: params.platformKey,
+          project_id: params.project.id,
+        }
+      );
     };
   },
   onProductSelectionChange: params => {
@@ -481,11 +496,16 @@ export const packageManagerOnboarding: OnboardingConfig<PlatformOptions> = {
   },
   onPlatformOptionsChange: params => {
     return () => {
-      trackAnalytics('onboarding.setup_loader_docs_rendered', {
-        organization: params.organization,
-        platform: params.platformKey,
-        project_id: params.project.id,
-      });
+      trackAnalytics(
+        params.isScmOnboarding
+          ? 'onboarding.scm_setup_loader_docs_rendered'
+          : 'onboarding.setup_loader_docs_rendered',
+        {
+          organization: params.organization,
+          platform: params.platformKey,
+          project_id: params.project.id,
+        }
+      );
     };
   },
 };

--- a/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
@@ -39,12 +39,40 @@ export type OnboardingEventParameters = {
     project_id: string;
     step: string;
   };
+  'onboarding.scm_back_button_clicked': {
+    browserBackButton: boolean;
+    from: string;
+    to: string;
+  };
   'onboarding.scm_connect_repo_selected': {
     provider: string;
     repo: string;
   };
   'onboarding.scm_connect_step_viewed': Record<string, unknown>;
+  'onboarding.scm_data_removal_modal_confirm_button_clicked': {
+    platform: string;
+    project_id: string;
+  };
+  'onboarding.scm_data_removed': {
+    date_created: string;
+    platform: string;
+    project_id: string;
+  };
+  'onboarding.scm_dsn_copied': {
+    platform: string;
+  };
   'onboarding.scm_header_skip_clicked': {
+    step: string;
+  };
+  'onboarding.scm_js_loader_npm_docs_shown': {
+    platform: string;
+    project_id: string;
+  };
+  'onboarding.scm_next_step_clicked': {
+    newOrg: boolean;
+    platform: string;
+    products: string[];
+    project_id: string;
     step: string;
   };
   'onboarding.scm_platform_change_platform_clicked': Record<string, unknown>;
@@ -73,7 +101,22 @@ export type OnboardingEventParameters = {
   'onboarding.scm_project_details_team_selected': {
     team: string;
   };
+  'onboarding.scm_select_framework_modal_rendered': {
+    platform: string;
+  };
+  'onboarding.scm_setup_loader_docs_rendered': {
+    platform: string;
+    project_id: string;
+  };
   'onboarding.scm_setup_platform_later_clicked': {
+    platform: string;
+    project_id: string;
+  };
+  'onboarding.scm_source_maps_wizard_button_copy_clicked': {
+    platform: string;
+    project_id: string;
+  };
+  'onboarding.scm_source_maps_wizard_selected_and_copied': {
     platform: string;
     project_id: string;
   };
@@ -147,8 +190,24 @@ export const onboardingEventMap: Record<keyof OnboardingEventParameters, string>
   'onboarding.take_me_to_issues_clicked': 'Onboarding: Take Me to Issues Clicked',
   'onboarding.slack_setup_clicked': 'Onboarding: Slack Setup Clicked',
   'onboarding.next_step_clicked': 'Onboarding: Next Step Clicked',
+  'onboarding.scm_back_button_clicked': 'Onboarding: SCM Back Button Clicked',
   'onboarding.scm_connect_repo_selected': 'Onboarding: SCM Connect Repo Selected',
   'onboarding.scm_connect_step_viewed': 'Onboarding: SCM Connect Step Viewed',
+  'onboarding.scm_data_removal_modal_confirm_button_clicked':
+    'Onboarding: SCM Data Removal Modal Confirm Button Clicked',
+  'onboarding.scm_data_removed': 'Onboarding: SCM Data Removed',
+  'onboarding.scm_dsn_copied': 'Onboarding: SCM DSN Copied',
+  'onboarding.scm_js_loader_npm_docs_shown':
+    'Onboarding: SCM JS Loader Switch to npm Instructions',
+  'onboarding.scm_next_step_clicked': 'Onboarding: SCM Next Step Clicked',
+  'onboarding.scm_select_framework_modal_rendered':
+    'Onboarding: SCM Framework Modal Rendered',
+  'onboarding.scm_setup_loader_docs_rendered':
+    'Onboarding: SCM Setup Loader Docs Rendered',
+  'onboarding.scm_source_maps_wizard_button_copy_clicked':
+    'Onboarding: SCM Source Maps Wizard Copy Button Clicked',
+  'onboarding.scm_source_maps_wizard_selected_and_copied':
+    'Onboarding: SCM Source Maps Wizard Selected and Copied',
   'onboarding.scm_header_skip_clicked': 'Onboarding: SCM Header Skip Clicked',
   'onboarding.scm_platform_change_platform_clicked':
     'Onboarding: SCM Platform Change Platform Clicked',

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -288,7 +288,7 @@ export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
               closeModal();
             }}
             newOrg
-            isScmOnboarding
+            hasScmOnboarding
           />
         ),
         {modalCss}

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -298,6 +298,7 @@ export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
               closeModal();
             }}
             newOrg
+            isScmOnboarding
           />
         ),
         {modalCss}

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -281,20 +281,10 @@ export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
             selectedPlatform={baseSdk}
             onConfigure={selectedFramework => {
               applyPlatformSelection(selectedFramework);
-              trackAnalytics('onboarding.scm_platform_selected', {
-                organization,
-                platform: selectedFramework.key,
-                source: 'manual',
-              });
               closeModal();
             }}
             onSkip={() => {
               applyPlatformSelection(baseSdk);
-              trackAnalytics('onboarding.scm_platform_selected', {
-                organization,
-                platform: platformKey,
-                source: 'manual',
-              });
               closeModal();
             }}
             newOrg

--- a/static/app/views/onboarding/setupDocs.tsx
+++ b/static/app/views/onboarding/setupDocs.tsx
@@ -67,6 +67,7 @@ export function SetupDocs({recentCreatedProject: project, genBackButton}: StepPr
                   hasScmOnboarding ? setSelectedFeatures : undefined
                 }
                 newOrg
+                isScmOnboarding={hasScmOnboarding}
               />
             )}
           </Fragment>

--- a/static/app/views/onboarding/setupDocs.tsx
+++ b/static/app/views/onboarding/setupDocs.tsx
@@ -67,7 +67,7 @@ export function SetupDocs({recentCreatedProject: project, genBackButton}: StepPr
                   hasScmOnboarding ? setSelectedFeatures : undefined
                 }
                 newOrg
-                isScmOnboarding={hasScmOnboarding}
+                hasScmOnboarding={hasScmOnboarding}
               />
             )}
           </Fragment>

--- a/static/app/views/onboarding/useBackActions.tsx
+++ b/static/app/views/onboarding/useBackActions.tsx
@@ -60,12 +60,15 @@ export function useBackActions({
           origin: 'onboarding',
         });
 
-        trackAnalytics('onboarding.data_removed', {
-          organization,
-          date_created: recentCreatedProject.dateCreated,
-          platform: recentCreatedProject.slug,
-          project_id: recentCreatedProject.id,
-        });
+        trackAnalytics(
+          hasScmOnboarding ? 'onboarding.scm_data_removed' : 'onboarding.data_removed',
+          {
+            organization,
+            date_created: recentCreatedProject.dateCreated,
+            platform: recentCreatedProject.slug,
+            project_id: recentCreatedProject.id,
+          }
+        );
       } catch (error) {
         handleXhrErrorResponse(
           'Unable to delete project in onboarding',
@@ -74,7 +77,7 @@ export function useBackActions({
         // we don't give the user any feedback regarding this error as this shall be silent
       }
     },
-    [api, organization, onboardingContext, recentCreatedProject]
+    [api, organization, onboardingContext, recentCreatedProject, hasScmOnboarding]
   );
 
   const backStepActions = useCallback(
@@ -89,12 +92,17 @@ export function useBackActions({
         return;
       }
 
-      trackAnalytics('onboarding.back_button_clicked', {
-        organization,
-        from: currentStep.id,
-        to: prevStep.id,
-        browserBackButton,
-      });
+      trackAnalytics(
+        hasScmOnboarding
+          ? 'onboarding.scm_back_button_clicked'
+          : 'onboarding.back_button_clicked',
+        {
+          organization,
+          from: currentStep.id,
+          to: prevStep.id,
+          browserBackButton,
+        }
+      );
 
       // from selected platform to welcome
       if (currentStep.id === 'select-platform') {
@@ -113,11 +121,16 @@ export function useBackActions({
         !isRecentCreatedProjectActive &&
         recentCreatedProject
       ) {
-        trackAnalytics('onboarding.data_removal_modal_confirm_button_clicked', {
-          organization,
-          platform: recentCreatedProject.slug,
-          project_id: recentCreatedProject.id,
-        });
+        trackAnalytics(
+          hasScmOnboarding
+            ? 'onboarding.scm_data_removal_modal_confirm_button_clicked'
+            : 'onboarding.data_removal_modal_confirm_button_clicked',
+          {
+            organization,
+            platform: recentCreatedProject.slug,
+            project_id: recentCreatedProject.id,
+          }
+        );
         // Await deletion so the projects store is updated before navigating
         // back. Without this, re-selecting the same platform can see stale
         // store data and skip project creation.


### PR DESCRIPTION
## TL;DR

Events fired from shared onboarding surfaces were conflating SCM and non-SCM cohort data. Each now branches to fire an SCM-specific variant when the experiment is active, so existing Amplitude charts stay immune without needing filter updates.

## Changes

Threads an `isScmOnboarding` flag through the setup-docs chain (`SetupDocs` -> `SdkDocumentation` -> `OnboardingLayout` -> `DocsParams`) and `FrameworkSuggestionModal`. Each analytics call now branches: fire the SCM variant when `isScmOnboarding` is true, otherwise fire the generic event.

For the framework modal's configure/skip clicks, the modal now fires `scm_platform_selected` directly in the SCM cohort. The non-SCM cohort continues to fire the generic `_configure_sdk_button_clicked` / `_skip_button_clicked`. This consolidates modal-triggered analytics into the modal itself, replacing the earlier arrangement where `scmPlatformFeatures` fired `scm_platform_selected` from its callbacks while the modal suppressed its generic events in the SCM cohort.

## Event mapping

| Location | Non-SCM cohort | SCM cohort |
|---|---|---|
| `useBackActions.tsx` back button | `onboarding.back_button_clicked` | `onboarding.scm_back_button_clicked` |
| `useBackActions.tsx` data removal modal confirm | `onboarding.data_removal_modal_confirm_button_clicked` | `onboarding.scm_data_removal_modal_confirm_button_clicked` |
| `useBackActions.tsx` project deletion | `onboarding.data_removed` | `onboarding.scm_data_removed` |
| `onboardingLayout.tsx` DSN copied | `onboarding.dsn-copied` | `onboarding.scm_dsn_copied` |
| `copyDsnField.tsx` DSN copied | `onboarding.dsn-copied` | `onboarding.scm_dsn_copied` |
| `onboardingLayout.tsx` next step link | `onboarding.next_step_clicked` | `onboarding.scm_next_step_clicked` |
| `utils/index.tsx` source maps copy | `onboarding.source_maps_wizard_button_copy_clicked` | `onboarding.scm_source_maps_wizard_button_copy_clicked` |
| `utils/index.tsx` source maps select+copy | `onboarding.source_maps_wizard_selected_and_copied` | `onboarding.scm_source_maps_wizard_selected_and_copied` |
| `javascript/utils.tsx` loader docs rendered | `onboarding.setup_loader_docs_rendered` | `onboarding.scm_setup_loader_docs_rendered` |
| `javascript/utils.tsx` loader npm docs shown | `onboarding.js_loader_npm_docs_shown` | `onboarding.scm_js_loader_npm_docs_shown` |
| `frameworkSuggestionModal.tsx` modal rendered | `onboarding.select_framework_modal_rendered` | `onboarding.scm_select_framework_modal_rendered` |
| `frameworkSuggestionModal.tsx` configure click | `onboarding.select_framework_modal_configure_sdk_button_clicked` | `onboarding.scm_platform_selected` |
| `frameworkSuggestionModal.tsx` skip click | `onboarding.select_framework_modal_skip_button_clicked` | `onboarding.scm_platform_selected` |

## Not touched

- `onboarding.select_framework_modal_close_button_clicked`: only fires from `useConfigureSdk`, which is legacy-only
- `onboarding.js_loader_optional_configuration_shown`, `onboarding.slack_setup_clicked`: no fire sites
- `project_creation.*` variants for the loader and DSN events: these events pre-existed as `onboarding.*` even when fired from project-install, and fixing that naming is out of scope for this PR

Once the SCM experiment ships or is rolled back, the branches collapse back to single `trackAnalytics` calls and the `isScmOnboarding` plumbing on `DocsParams` can be removed.

## Follow-up

After merging, update the [SCM Onboarding Analytics Funnel Construction Guide for BI/Data](https://www.notion.so/sentry/SCM-Onboarding-Analytics-Funnel-Construction-Guide-for-BI-Data-3498b10e4b5d8192a163fc553093f3e3) so the legacy -> SCM event mappings reflect the new variant names.