### PR TITLE
feat(seer): Add get_dsn RPC method for Seer explorer agent

### DIFF
--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -108,6 +108,7 @@ from sentry.seer.explorer.tools import (
     execute_trace_table_query,
     get_baseline_tag_distribution,
     get_comparative_attribute_distributions,
+    get_dsn,
     get_event_details,
     get_issue_and_event_details_v2,
     get_issue_details,
@@ -971,6 +972,7 @@ seer_method_registry: dict[str, Callable] = {  # return type must be serialized
     "get_metric_attributes_for_trace": get_metric_attributes_for_trace,
     "get_baseline_tag_distribution": get_baseline_tag_distribution,
     "get_comparative_attribute_distributions": get_comparative_attribute_distributions,
+    "get_dsn": get_dsn,
     #
     # Replays
     "get_replay_summary_logs": rpc_get_replay_summary_logs,

--- a/src/sentry/seer/explorer/tools.py
+++ b/src/sentry/seer/explorer/tools.py
@@ -28,6 +28,7 @@ from sentry.models.apikey import ApiKey
 from sentry.models.group import EventOrdering, Group
 from sentry.models.organization import Organization
 from sentry.models.project import Project
+from sentry.models.projectkey import ProjectKey
 from sentry.models.repository import Repository
 from sentry.replays.post_process import process_raw_response
 from sentry.replays.query import query_replay_id_by_prefix, query_replay_instance
@@ -2053,4 +2054,39 @@ def get_comparative_attribute_distributions(
         "outliers_distribution": distributions_result["cohort_1_distribution"],
         "total_outliers": distributions_result["total_cohort_1"],
         "outliers_function_value": distributions_result["cohort_1_function_value"],
+    }
+
+
+def get_dsn(
+    *,
+    organization_id: int,
+    project_slug: str,
+) -> dict[str, Any] | None:
+    """
+    Get the public DSN for a single project in an organization.
+
+    Returns a dict with project_id, project_slug, project_name, platform, dsn_public, and
+    key_label, or None if the project does not exist or has no active client key.
+    """
+    organization = Organization.objects.get(id=organization_id)
+
+    project = Project.objects.filter(
+        organization=organization,
+        status=ObjectStatus.ACTIVE,
+        slug=project_slug,
+    ).first()
+    if project is None:
+        return None
+
+    key = ProjectKey.get_default(project)
+    if key is None:
+        return None
+
+    return {
+        "project_id": project.id,
+        "project_slug": project.slug,
+        "project_name": project.name,
+        "platform": project.platform,
+        "dsn_public": key.dsn_public,
+        "key_label": key.label,
     }

--- a/src/sentry/seer/explorer/tools.py
+++ b/src/sentry/seer/explorer/tools.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime, timedelta, timezone
 from typing import Any, cast
 
 from django.core.exceptions import BadRequest
+from django.db import models
 from rest_framework.exceptions import NotFound
 from sentry_protos.snuba.v1.endpoint_get_trace_pb2 import GetTraceRequest
 from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
@@ -28,7 +29,7 @@ from sentry.models.apikey import ApiKey
 from sentry.models.group import EventOrdering, Group
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.models.projectkey import ProjectKey
+from sentry.models.projectkey import ProjectKey, ProjectKeyStatus, UseCase
 from sentry.models.repository import Repository
 from sentry.replays.post_process import process_raw_response
 from sentry.replays.query import query_replay_id_by_prefix, query_replay_instance
@@ -2078,7 +2079,20 @@ def get_dsn(
     if project is None:
         return None
 
-    key = ProjectKey.get_default(project)
+    # Mirror the filters applied by OrganizationProjectKeysEndpoint for non-superuser
+    # callers: user-visible keys only (exclude internal use cases like PROFILING,
+    # TEMPEST, DEMO), with the store role, active. Newest first to match the
+    # endpoint's `-id` ordering.
+    key = (
+        ProjectKey.objects.filter(
+            project=project,
+            status=ProjectKeyStatus.ACTIVE,
+            use_case=UseCase.USER.value,
+            roles=models.F("roles").bitor(ProjectKey.roles.store),
+        )
+        .order_by("-id")
+        .first()
+    )
     if key is None:
         return None
 

--- a/src/sentry/seer/explorer/tools.py
+++ b/src/sentry/seer/explorer/tools.py
@@ -2066,10 +2066,14 @@ def get_dsn(
     """
     Get the public DSN for a single project in an organization.
 
-    Returns a dict with project_id, project_slug, project_name, platform, dsn_public, and
-    key_label, or None if the project does not exist or has no active client key.
+    Returns a dict with project_slug, platform, and dsn_public, or None if the
+    organization/project does not exist or the project has no active client key.
     """
-    organization = Organization.objects.get(id=organization_id)
+    try:
+        organization = Organization.objects.get(id=organization_id)
+    except Organization.DoesNotExist:
+        logger.warning("Organization not found", extra={"organization_id": organization_id})
+        return None
 
     project = Project.objects.filter(
         organization=organization,
@@ -2097,10 +2101,7 @@ def get_dsn(
         return None
 
     return {
-        "project_id": project.id,
         "project_slug": project.slug,
-        "project_name": project.name,
         "platform": project.platform,
         "dsn_public": key.dsn_public,
-        "key_label": key.label,
     }

--- a/tests/sentry/seer/explorer/test_tools.py
+++ b/tests/sentry/seer/explorer/test_tools.py
@@ -27,6 +27,7 @@ from sentry.seer.explorer.tools import (
     execute_trace_table_query,
     get_baseline_tag_distribution,
     get_comparative_attribute_distributions,
+    get_dsn,
     get_event_details,
     get_issue_and_event_details_v2,
     get_issue_and_event_response,
@@ -3646,3 +3647,37 @@ class TestGetComparativeAttributeDistributions(TestCase):
                 range_start="2024-01-01T00:00:00",
                 range_end="2024-01-01T00:00:30",
             )
+
+
+class TestGetDsn(APITestCase):
+    def test_returns_dsn_for_project(self) -> None:
+        project = self.create_project(organization=self.organization, slug="wordcraft")
+
+        result = get_dsn(organization_id=self.organization.id, project_slug="wordcraft")
+
+        assert result is not None
+        assert result["project_id"] == project.id
+        assert result["project_slug"] == "wordcraft"
+        assert result["project_name"] == project.name
+        assert result["dsn_public"].startswith("http")
+        assert result["dsn_public"].endswith(f"/{project.id}")
+
+    def test_returns_none_for_unknown_slug(self) -> None:
+        self.create_project(organization=self.organization, slug="wordcraft")
+
+        assert get_dsn(organization_id=self.organization.id, project_slug="does-not-exist") is None
+
+    def test_does_not_cross_organizations(self) -> None:
+        other_org = self.create_organization()
+        self.create_project(organization=other_org, slug="wordcraft")
+
+        assert get_dsn(organization_id=self.organization.id, project_slug="wordcraft") is None
+
+    def test_ignores_disabled_project(self) -> None:
+        self.create_project(
+            organization=self.organization,
+            slug="archived",
+            status=ObjectStatus.PENDING_DELETION,
+        )
+
+        assert get_dsn(organization_id=self.organization.id, project_slug="archived") is None

--- a/tests/sentry/seer/explorer/test_tools.py
+++ b/tests/sentry/seer/explorer/test_tools.py
@@ -3681,3 +3681,18 @@ class TestGetDsn(APITestCase):
         )
 
         assert get_dsn(organization_id=self.organization.id, project_slug="archived") is None
+
+    def test_excludes_internal_use_case_keys(self) -> None:
+        """Internal keys (PROFILING, TEMPEST, DEMO) must not be returned to the agent."""
+        from sentry.models.projectkey import ProjectKey, UseCase
+
+        project = self.create_project(organization=self.organization, slug="wordcraft")
+        # Default USER key is created by signal. Delete it so the only eligible key
+        # would be the internal PROFILING key.
+        default_key = ProjectKey.objects.get(project=project)
+        default_key.delete()
+        ProjectKey.objects.create(
+            project=project, label="Profiling", use_case=UseCase.PROFILING.value
+        )
+
+        assert get_dsn(organization_id=self.organization.id, project_slug="wordcraft") is None

--- a/tests/sentry/seer/explorer/test_tools.py
+++ b/tests/sentry/seer/explorer/test_tools.py
@@ -3656,9 +3656,11 @@ class TestGetDsn(APITestCase):
         result = get_dsn(organization_id=self.organization.id, project_slug="wordcraft")
 
         assert result is not None
-        assert result["project_id"] == project.id
-        assert result["project_slug"] == "wordcraft"
-        assert result["project_name"] == project.name
+        assert result == {
+            "project_slug": "wordcraft",
+            "platform": project.platform,
+            "dsn_public": result["dsn_public"],
+        }
         assert result["dsn_public"].startswith("http")
         assert result["dsn_public"].endswith(f"/{project.id}")
 
@@ -3666,6 +3668,9 @@ class TestGetDsn(APITestCase):
         self.create_project(organization=self.organization, slug="wordcraft")
 
         assert get_dsn(organization_id=self.organization.id, project_slug="does-not-exist") is None
+
+    def test_returns_none_for_unknown_organization(self) -> None:
+        assert get_dsn(organization_id=999_999_999, project_slug="wordcraft") is None
 
     def test_does_not_cross_organizations(self) -> None:
         other_org = self.create_organization()


### PR DESCRIPTION
Add a `get_dsn` method to the Seer RPC registry that returns the public DSN for a single project, given an organization and project slug.

The Seer explorer agent sees "what's my DSN", "where are the client keys", and "how do I get the DSN for project X" as its top class of user request. Today the agent routes users through docs search or UI instructions; this RPC lets it return a concrete answer instead.

The lookup mirrors the filters applied by `OrganizationProjectKeysEndpoint` via `ProjectKey.objects.for_request(request)` for non-superuser callers:

- `status = ProjectKeyStatus.ACTIVE`
- `use_case = UseCase.USER.value` — excludes internal DSNs (PROFILING, TEMPEST, DEMO)
- `roles` has the `store` bit
- `order_by("-id")` — same as the endpoint's pagination order

`ProjectKey.get_default()` would have been the obvious choice but doesn't apply the `use_case` filter, so in edge cases (e.g. the USER default key was deleted) an internal DSN could leak to the agent. The explicit query avoids that.

Returns `project_slug`, `platform`, and `dsn_public` — the minimum the agent needs to answer "what's my DSN". Returns `None` when the organization or project does not exist, the project is inactive, or there is no eligible user-visible client key. `Organization.DoesNotExist` is caught and logged as a warning, matching sibling RPC functions in this module.

## Rollout

Land and deploy this PR before merging the companion Seer PR (https://github.com/getsentry/seer/pull/5971), which calls the new RPC. Without the Sentry side deployed, the Seer tool would hit `Unknown method`.