### PR TITLE
feat(conversations): Show tool input params in chat tool call lines

### DIFF
--- a/static/app/views/insights/pages/conversations/components/messageToolCalls.tsx
+++ b/static/app/views/insights/pages/conversations/components/messageToolCalls.tsx
@@ -42,10 +42,12 @@ export function MessageToolCalls({
               }
             }}
           >
-            <Flex align="center" gap="sm">
-              <NoShrinkText size="xs" monospace variant="muted">
-                {t('Called tool')}
-              </NoShrinkText>
+            <Flex align="baseline" gap="sm">
+              <Flex flexShrink={0}>
+                <Text size="xs" monospace variant="muted">
+                  {t('Called tool')}
+                </Text>
+              </Flex>
               <ClickableTag
                 variant={tool.hasError ? 'danger' : 'info'}
                 icon={tool.hasError ? <IconFire /> : undefined}
@@ -74,10 +76,6 @@ function ToolInputPreview({node}: {node: AITraceSpanNode}) {
     </Text>
   );
 }
-
-const NoShrinkText = styled(Text)`
-  flex-shrink: 0;
-`;
 
 const ToolCallLine = styled(Container)`
   &:hover {

--- a/static/app/views/insights/pages/conversations/components/messageToolCalls.tsx
+++ b/static/app/views/insights/pages/conversations/components/messageToolCalls.tsx
@@ -71,9 +71,9 @@ function ToolInputPreview({node}: {node: AITraceSpanNode}) {
     return null;
   }
   return (
-      <Text size="xs" monospace variant="muted" ellipsis>
-        {firstInputValue}
-      </Text>
+    <Text size="xs" monospace variant="muted" ellipsis>
+      {firstInputValue}
+    </Text>
   );
 }
 

--- a/static/app/views/insights/pages/conversations/components/messageToolCalls.tsx
+++ b/static/app/views/insights/pages/conversations/components/messageToolCalls.tsx
@@ -6,6 +6,7 @@ import {Text} from '@sentry/scraps/text';
 
 import {IconFire} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {getFirstToolInputValue} from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
 import type {AITraceSpanNode} from 'sentry/views/insights/pages/agents/utils/types';
 import type {ToolCall} from 'sentry/views/insights/pages/conversations/utils/conversationMessages';
 
@@ -42,9 +43,9 @@ export function MessageToolCalls({
             }}
           >
             <Flex align="center" gap="sm">
-              <Text size="xs" monospace variant="muted">
+              <NoShrinkText size="xs" monospace variant="muted">
                 {t('Called tool')}
-              </Text>
+              </NoShrinkText>
               <ClickableTag
                 variant={tool.hasError ? 'danger' : 'info'}
                 icon={tool.hasError ? <IconFire /> : undefined}
@@ -53,6 +54,7 @@ export function MessageToolCalls({
               >
                 {tool.name}
               </ClickableTag>
+              {toolNode && <ToolInputPreview node={toolNode} />}
             </Flex>
           </ToolCallLine>
         );
@@ -60,6 +62,22 @@ export function MessageToolCalls({
     </Flex>
   );
 }
+
+function ToolInputPreview({node}: {node: AITraceSpanNode}) {
+  const firstInputValue = getFirstToolInputValue(node);
+  if (!firstInputValue) {
+    return null;
+  }
+  return (
+    <Text size="xs" monospace variant="muted" ellipsis>
+      {firstInputValue}
+    </Text>
+  );
+}
+
+const NoShrinkText = styled(Text)`
+  flex-shrink: 0;
+`;
 
 const ToolCallLine = styled(Container)`
   &:hover {

--- a/static/app/views/insights/pages/conversations/components/messageToolCalls.tsx
+++ b/static/app/views/insights/pages/conversations/components/messageToolCalls.tsx
@@ -43,11 +43,11 @@ export function MessageToolCalls({
             }}
           >
             <Flex align="baseline" gap="sm">
-              <Flex flexShrink={0}>
+              <Container flexShrink={0}>
                 <Text size="xs" monospace variant="muted">
                   {t('Called tool')}
                 </Text>
-              </Flex>
+              </Container>
               <ClickableTag
                 variant={tool.hasError ? 'danger' : 'info'}
                 icon={tool.hasError ? <IconFire /> : undefined}
@@ -71,9 +71,9 @@ function ToolInputPreview({node}: {node: AITraceSpanNode}) {
     return null;
   }
   return (
-    <Text size="xs" monospace variant="muted" ellipsis>
-      {firstInputValue}
-    </Text>
+      <Text size="xs" monospace variant="muted" ellipsis>
+        {firstInputValue}
+      </Text>
   );
 }
 


### PR DESCRIPTION
Show the first tool input parameter value alongside the tool name in the
chat view's tool call lines. Previously these lines only showed
"Called tool [name]" — now they also display the primary parameter value
(e.g. file path for `read`, command for `sentry`), matching the existing
behavior in the spans view.

Reuses `getFirstToolInputValue` from the agents utils, which extracts and
truncates the first value from the tool's input JSON.

<img width="1208" height="103" alt="CleanShot 2026-04-24 at 11 18 35" src="https://github.com/user-attachments/assets/c70e7dfc-d313-4691-b9b2-7abf910f98e7" />


Closes TET-2255