### PR TITLE
feat(seer): Parse night shift tweaks with a pydantic model

### DIFF
--- a/src/sentry/tasks/seer/night_shift/tweaks.py
+++ b/src/sentry/tasks/seer/night_shift/tweaks.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pydantic
+import sentry_sdk
+
+from sentry import options
+from sentry.models.project import Project
+
+
+class NightShiftTweaks(pydantic.BaseModel):
+    enabled: bool = False
+    candidate_issues: int = pydantic.Field(
+        default_factory=lambda: options.get("seer.night_shift.issues_per_org")
+    )
+
+
+def get_night_shift_tweaks(project: Project) -> NightShiftTweaks:
+    raw = project.get_option("sentry:seer_nightshift_tweaks")
+    if not raw:
+        return NightShiftTweaks()
+    try:
+        return NightShiftTweaks(**raw)
+    except pydantic.ValidationError:
+        sentry_sdk.capture_exception()
+        return NightShiftTweaks()

--- a/src/sentry/tasks/seer/night_shift/tweaks.py
+++ b/src/sentry/tasks/seer/night_shift/tweaks.py
@@ -18,6 +18,11 @@ def get_night_shift_tweaks(project: Project) -> NightShiftTweaks:
     raw = project.get_option("sentry:seer_nightshift_tweaks")
     if not raw:
         return NightShiftTweaks()
+    if not isinstance(raw, dict):
+        sentry_sdk.capture_exception(
+            TypeError(f"sentry:seer_nightshift_tweaks must be a dict, got {type(raw).__name__}")
+        )
+        return NightShiftTweaks()
     try:
         return NightShiftTweaks(**raw)
     except pydantic.ValidationError:

--- a/tests/sentry/tasks/seer/night_shift/test_tweaks.py
+++ b/tests/sentry/tasks/seer/night_shift/test_tweaks.py
@@ -53,6 +53,21 @@ class GetNightShiftTweaksTest(TestCase):
         assert tweaks.enabled is False
         assert tweaks.candidate_issues == 7
 
+    def test_non_dict_value_reports_and_returns_defaults(self) -> None:
+        self.project.update_option(
+            "sentry:seer_nightshift_tweaks",
+            [{"enabled": True}],
+        )
+
+        with patch(
+            "sentry.tasks.seer.night_shift.tweaks.sentry_sdk.capture_exception"
+        ) as mock_capture:
+            tweaks = get_night_shift_tweaks(self.project)
+
+        mock_capture.assert_called_once()
+        assert tweaks.enabled is False
+        assert tweaks.candidate_issues == options.get("seer.night_shift.issues_per_org")
+
     def test_invalid_payload_reports_and_returns_defaults(self) -> None:
         self.project.update_option(
             "sentry:seer_nightshift_tweaks",

--- a/tests/sentry/tasks/seer/night_shift/test_tweaks.py
+++ b/tests/sentry/tasks/seer/night_shift/test_tweaks.py
@@ -1,0 +1,69 @@
+from unittest.mock import patch
+
+from sentry import options
+from sentry.tasks.seer.night_shift.tweaks import NightShiftTweaks, get_night_shift_tweaks
+from sentry.testutils.cases import TestCase
+
+
+class GetNightShiftTweaksTest(TestCase):
+    def test_unset_returns_defaults(self) -> None:
+        tweaks = get_night_shift_tweaks(self.project)
+
+        assert tweaks.enabled is False
+        assert tweaks.candidate_issues == options.get("seer.night_shift.issues_per_org")
+
+    def test_empty_object_returns_defaults(self) -> None:
+        self.project.update_option("sentry:seer_nightshift_tweaks", {})
+
+        tweaks = get_night_shift_tweaks(self.project)
+
+        assert tweaks.enabled is False
+        assert tweaks.candidate_issues == options.get("seer.night_shift.issues_per_org")
+
+    def test_full_override(self) -> None:
+        self.project.update_option(
+            "sentry:seer_nightshift_tweaks",
+            {"enabled": True, "candidate_issues": 25},
+        )
+
+        tweaks = get_night_shift_tweaks(self.project)
+
+        assert tweaks == NightShiftTweaks(enabled=True, candidate_issues=25)
+
+    def test_partial_override_falls_back_to_option(self) -> None:
+        self.project.update_option(
+            "sentry:seer_nightshift_tweaks",
+            {"enabled": True},
+        )
+
+        with self.options({"seer.night_shift.issues_per_org": 42}):
+            tweaks = get_night_shift_tweaks(self.project)
+
+        assert tweaks.enabled is True
+        assert tweaks.candidate_issues == 42
+
+    def test_candidate_issues_only_uses_default_enabled(self) -> None:
+        self.project.update_option(
+            "sentry:seer_nightshift_tweaks",
+            {"candidate_issues": 7},
+        )
+
+        tweaks = get_night_shift_tweaks(self.project)
+
+        assert tweaks.enabled is False
+        assert tweaks.candidate_issues == 7
+
+    def test_invalid_payload_reports_and_returns_defaults(self) -> None:
+        self.project.update_option(
+            "sentry:seer_nightshift_tweaks",
+            {"candidate_issues": "not-an-int"},
+        )
+
+        with patch(
+            "sentry.tasks.seer.night_shift.tweaks.sentry_sdk.capture_exception"
+        ) as mock_capture:
+            tweaks = get_night_shift_tweaks(self.project)
+
+        mock_capture.assert_called_once()
+        assert tweaks.enabled is False
+        assert tweaks.candidate_issues == options.get("seer.night_shift.issues_per_org")


### PR DESCRIPTION
Introduce `NightShiftTweaks`, a pydantic model with `enabled: bool = False`
and `candidate_issues: int` (defaulting to `options.get("seer.night_shift.issues_per_org")`),
plus a `get_night_shift_tweaks(project)` loader that reads the existing
`sentry:seer_nightshift_tweaks` project option.

Behavior:
- Option unset or set to an empty object → returns defaults.
- Partial overrides → missing fields fall back to defaults (e.g. setting
  only `enabled` leaves `candidate_issues` at the `issues_per_org` value).
- Invalid payload (wrong type, etc.) → reported via `sentry_sdk.capture_exception`
  and defaults are returned.

Agent transcript: https://claudescope.sentry.dev/share/oE8m99Y9mONPc8ScYWGDWqW8VTJlxrK3VPWU_JZFMdQ