### PR TITLE
feat(integrations): Include organization_id in response tracking logs

### DIFF
--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -126,6 +126,8 @@ class BaseApiClient:
                 log_params["retry_after"] = retry_after
 
         log_params.update(getattr(self, "logging_context", None) or {})
+        if "organization_id" not in log_params and "org_id" in log_params:
+            log_params["organization_id"] = log_params["org_id"]
         log_level = self.logger.warning if error else self.logger.info
         log_level("%s.http_response", self.integration_type, extra=log_params)
 
@@ -318,6 +320,12 @@ class BaseApiClient:
         integration_id = getattr(self, "integration_id", None)
         if integration_id is not None:
             extra["integration_id"] = str(integration_id)
+        logging_context = getattr(self, "logging_context", None) or {}
+        organization_id = logging_context.get("organization_id")
+        if organization_id is None:
+            organization_id = logging_context.get("org_id")
+        if organization_id is not None:
+            extra["organization_id"] = str(organization_id)
         if api_request_type_tag is not None:
             extra["api_request_type"] = api_request_type_tag
 

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -126,8 +126,11 @@ class BaseApiClient:
                 log_params["retry_after"] = retry_after
 
         log_params.update(getattr(self, "logging_context", None) or {})
-        if "organization_id" not in log_params and "org_id" in log_params:
-            log_params["organization_id"] = log_params["org_id"]
+        organization_id = log_params.get("organization_id")
+        if organization_id is None and "org_id" in log_params:
+            organization_id = log_params["org_id"]
+        if organization_id is not None:
+            log_params["organization_id"] = str(organization_id)
         log_level = self.logger.warning if error else self.logger.info
         log_level("%s.http_response", self.integration_type, extra=log_params)
 

--- a/tests/sentry/integrations/test_client.py
+++ b/tests/sentry/integrations/test_client.py
@@ -360,7 +360,7 @@ class ApiClientTest(TestCase):
         with mock.patch.object(client, "logger") as mock_logger:
             client.get("http://example.com")
             extra = mock_logger.info.call_args.kwargs["extra"]
-            assert extra["organization_id"] == 123
+            assert extra["organization_id"] == "123"
 
     @responses.activate
     def test_track_response_data_logs_organization_id_from_org_id_logging_context(self) -> None:

--- a/tests/sentry/integrations/test_client.py
+++ b/tests/sentry/integrations/test_client.py
@@ -353,6 +353,26 @@ class ApiClientTest(TestCase):
             assert extra["github_request_id"] == "abc-123"
 
     @responses.activate
+    def test_track_response_data_logs_organization_id_from_logging_context(self) -> None:
+        responses.add(responses.GET, "http://example.com", json={})
+
+        client = ApiClient(logging_context={"organization_id": 123})
+        with mock.patch.object(client, "logger") as mock_logger:
+            client.get("http://example.com")
+            extra = mock_logger.info.call_args.kwargs["extra"]
+            assert extra["organization_id"] == 123
+
+    @responses.activate
+    def test_track_response_data_logs_organization_id_from_org_id_logging_context(self) -> None:
+        responses.add(responses.GET, "http://example.com", json={})
+
+        client = ApiClient(logging_context={"org_id": 456})
+        with mock.patch.object(client, "logger") as mock_logger:
+            client.get("http://example.com")
+            extra = mock_logger.info.call_args.kwargs["extra"]
+            assert extra["organization_id"] == "456"
+
+    @responses.activate
     def test_track_response_data_logs_rate_limit_remaining(self) -> None:
         responses.add(
             responses.GET,

--- a/tests/sentry/shared_integrations/client/test_base.py
+++ b/tests/sentry/shared_integrations/client/test_base.py
@@ -102,6 +102,44 @@ class BaseApiClientTest(TestCase):
         assert mock_track_response_data.call_count == 1
         assert mock_track_response_data.mock_calls[0].kwargs["extra"]["integration_id"] == "123"
 
+    @patch.object(BaseApiClient, "track_response_data")
+    @patch.object(Session, "send")
+    def test_track_response_data_includes_organization_id_from_logging_context(
+        self, mock_session_send, mock_track_response_data
+    ) -> None:
+        response = MagicMock()
+        response.status_code = 204
+        mock_session_send.return_value = response
+
+        class Client(BaseApiClient):
+            integration_type = "integration"
+            integration_name = "base"
+
+        api_client = Client(logging_context={"organization_id": 42})
+        api_client.get("https://example.com/get")
+
+        assert mock_track_response_data.call_count == 1
+        assert mock_track_response_data.mock_calls[0].kwargs["extra"]["organization_id"] == "42"
+
+    @patch.object(BaseApiClient, "track_response_data")
+    @patch.object(Session, "send")
+    def test_track_response_data_uses_org_id_fallback_for_organization_id(
+        self, mock_session_send, mock_track_response_data
+    ) -> None:
+        response = MagicMock()
+        response.status_code = 204
+        mock_session_send.return_value = response
+
+        class Client(BaseApiClient):
+            integration_type = "integration"
+            integration_name = "base"
+
+        api_client = Client(logging_context={"org_id": 24})
+        api_client.get("https://example.com/get")
+
+        assert mock_track_response_data.call_count == 1
+        assert mock_track_response_data.mock_calls[0].kwargs["extra"]["organization_id"] == "24"
+
     @patch("sentry.shared_integrations.client.base.metrics.incr")
     @patch.object(Session, "send")
     def test_request_and_response_metrics_include_api_request_type(


### PR DESCRIPTION
The log `integrations.http_response` is missing `organization_id` which makes is easier to do debugging than using `integration_id`.

Made with [Cursor](https://cursor.com)