### PR TITLE
fix(discover): add in redirect for discover-basic homepage

### DIFF
--- a/static/app/views/discover/homepage.spec.tsx
+++ b/static/app/views/discover/homepage.spec.tsx
@@ -18,6 +18,28 @@ import {DEFAULT_EVENT_VIEW} from 'sentry/views/discover/results/data';
 
 import Homepage from './homepage';
 
+describe('Discover > HomepageContainer', () => {
+  it('redirects to results page when organization lacks discover-query feature', () => {
+    const org = OrganizationFixture({features: ['discover-basic']});
+    const {router} = render(<Homepage />, {
+      initialRouterConfig: {
+        location: {
+          pathname: `/organizations/${org.slug}/explore/discover/homepage/`,
+          query: {query: 'event.type:error', dataset: 'errors'},
+        },
+        route: '/organizations/:orgId/explore/discover/homepage/',
+      },
+      organization: org,
+    });
+
+    expect(router.location.pathname).toBe(
+      `/organizations/${org.slug}/explore/discover/results/`
+    );
+    expect(router.location.search).toContain('query=event.type%3Aerror');
+    expect(router.location.search).toContain('dataset=errors');
+  });
+});
+
 describe('Discover > Homepage', () => {
   const features = ['discover-query'];
   let organization: ReturnType<typeof OrganizationFixture>;

--- a/static/app/views/discover/homepage.tsx
+++ b/static/app/views/discover/homepage.tsx
@@ -10,6 +10,7 @@ import {
 } from 'sentry/components/pageFilters/parse';
 import {getPageFilterStorage} from 'sentry/components/pageFilters/persistence';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {Redirect} from 'sentry/components/redirect';
 import type {Organization, SavedQuery} from 'sentry/types/organization';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {EventView} from 'sentry/utils/discover/eventView';
@@ -21,6 +22,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {usePrevious} from 'sentry/utils/usePrevious';
 import {getSavedQueryWithDataset} from 'sentry/views/discover/savedQuery/utils';
 
+import {makeDiscoverPathname} from './pathnames';
 import {Results} from './results';
 
 function makeDiscoverHomepageQueryKey(organization: Organization): ApiQueryKey {
@@ -130,6 +132,17 @@ function Homepage() {
 }
 
 export default function HomepageContainer() {
+  const organization = useOrganization();
+  const location = useLocation();
+
+  if (!organization.features.includes('discover-query')) {
+    return (
+      <Redirect
+        to={`${makeDiscoverPathname({path: '/results/', organization})}${location.search}${location.hash}`}
+      />
+    );
+  }
+
   return (
     <PageFiltersContainer skipInitializeUrlParams>
       <Homepage />


### PR DESCRIPTION
`discover-basic` users don't have access to the homepage. Their discover "landing" page should be the results page instead. I've fixed this in the navigation sidebar but a lot of people may have existing links saved on the homepage so we want to redirect them with the same query onto the results page.