### PR TITLE
feat(seer): Apply night shift tweaks to org and project runs

### DIFF
--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import dataclasses
+import enum
 import logging
 import time
 from collections import Counter
@@ -21,10 +23,10 @@ from sentry.seer.autofix.constants import (
 from sentry.seer.autofix.issue_summary import referrer_map
 from sentry.seer.autofix.utils import AutofixStoppingPoint, bulk_read_preferences_from_sentry_db
 from sentry.seer.models.night_shift import SeerNightShiftRun, SeerNightShiftRunIssue
-from sentry.seer.models.seer_api_models import SeerProjectPreference
 from sentry.tasks.base import instrumented_task
 from sentry.tasks.seer.night_shift.agentic_triage import agentic_triage_strategy
 from sentry.tasks.seer.night_shift.models import TriageAction, TriageResult
+from sentry.tasks.seer.night_shift.tweaks import NightShiftTweaks, get_night_shift_tweaks
 from sentry.taskworker.namespaces import seer_tasks
 from sentry.utils.iterators import chunked
 from sentry.utils.query import RangeQuerySetWrapper
@@ -39,6 +41,11 @@ FEATURE_NAMES = [
     "organizations:gen-ai-features",
     "organizations:seat-based-seer-enabled",
 ]
+
+
+class NightShiftRunSource(enum.Enum):
+    CRON = "cron"
+    MANUAL = "manual"
 
 
 @instrumented_task(
@@ -108,6 +115,7 @@ def run_night_shift_for_org(
 
     return _execute_night_shift_run(
         organization,
+        source=NightShiftRunSource.CRON,
         dry_run=dry_run,
         max_candidates=max_candidates,
         log_extra=log_extra,
@@ -155,7 +163,8 @@ def run_night_shift_for_project(
 
     return _execute_night_shift_run(
         organization,
-        project_id=project.id,
+        source=NightShiftRunSource.MANUAL,
+        project_ids=[project.id],
         dry_run=dry_run,
         max_candidates=max_candidates,
         log_extra=log_extra,
@@ -165,7 +174,8 @@ def run_night_shift_for_project(
 def _execute_night_shift_run(
     organization: Organization,
     *,
-    project_id: int | None = None,
+    source: NightShiftRunSource,
+    project_ids: list[int] | None = None,
     dry_run: bool,
     max_candidates: int | None,
     log_extra: dict[str, object],
@@ -190,7 +200,7 @@ def _execute_night_shift_run(
         return None
 
     try:
-        eligible_projects, _ = _get_eligible_projects(organization, project_id=project_id)
+        eligible = _get_eligible_projects(organization, source, project_ids=project_ids)
     except Exception:
         _fail_run(
             run,
@@ -200,18 +210,19 @@ def _execute_night_shift_run(
         )
         return None
 
-    sentry_sdk.metrics.distribution("night_shift.eligible_projects", len(eligible_projects))
+    sentry_sdk.metrics.distribution("night_shift.eligible_projects", len(eligible))
 
-    if not eligible_projects:
+    if not eligible:
         logger.info("night_shift.no_eligible_projects", extra=log_extra)
         return None
 
     resolved_max_candidates = (
         max_candidates
         if max_candidates is not None
-        else options.get("seer.night_shift.issues_per_org")
+        else max(ep.tweaks.candidate_issues for ep in eligible)
     )
 
+    eligible_projects = [ep.project for ep in eligible]
     agent_run_id = None
     try:
         candidates, agent_run_id = agentic_triage_strategy(
@@ -311,39 +322,52 @@ def _fail_run(
     run.update(error_message=message)
 
 
+@dataclasses.dataclass(frozen=True)
+class EligibleProject:
+    project: Project
+    tweaks: NightShiftTweaks
+
+
 def _get_eligible_projects(
     organization: Organization,
-    project_id: int | None = None,
-) -> tuple[list[Project], dict[int, SeerProjectPreference]]:
-    """Return active projects that have automation enabled and connected repos.
+    source: NightShiftRunSource,
+    project_ids: list[int] | None = None,
+) -> list[EligibleProject]:
+    """Return active projects that have automation enabled and connected repos,
+    each paired with its parsed night shift tweaks.
 
-    When project_id is provided, only that project is considered (for manual
-    per-project triggers)."""
+    When project_ids is provided, the org's projects are restricted to that set.
+    Manual triggers bypass the tweaks.enabled gate — the user explicitly asked
+    for this run. Scheduler runs respect it."""
     project_qs = Project.objects.filter(organization=organization, status=ObjectStatus.ACTIVE)
-    if project_id is not None:
-        project_qs = project_qs.filter(id=project_id)
+    if project_ids is not None:
+        project_qs = project_qs.filter(id__in=project_ids)
     project_map = {p.id: p for p in project_qs}
     if not project_map:
-        return [], {}
+        return []
 
     preferences = bulk_read_preferences_from_sentry_db(organization.id, list(project_map))
 
-    candidates = [
+    with_automation = [
         project_map[pid]
         for pid, pref in preferences.items()
         if pref.repositories
         and pref.autofix_automation_tuning != AutofixAutomationTuningSettings.OFF
     ]
-    if not candidates:
-        return [], preferences
+    if not with_automation:
+        return []
 
-    flag_result = features.batch_has(["projects:seer-night-shift"], projects=candidates)
-    projects = [
+    flag_result = features.batch_has(["projects:seer-night-shift"], projects=with_automation)
+    flagged = [
         p
-        for p in candidates
+        for p in with_automation
         if (flag_result or {}).get(f"project:{p.id}", {}).get("projects:seer-night-shift", False)
     ]
-    return projects, preferences
+
+    eligible = [EligibleProject(project=p, tweaks=get_night_shift_tweaks(p)) for p in flagged]
+    if source is NightShiftRunSource.CRON:
+        eligible = [ep for ep in eligible if ep.tweaks.enabled]
+    return eligible
 
 
 def _run_autofix_for_candidates(

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -11,6 +11,7 @@ from sentry.seer.explorer.client_models import Artifact, MemoryBlock, Message, S
 from sentry.seer.models.night_shift import SeerNightShiftRun, SeerNightShiftRunIssue
 from sentry.seer.models.project_repository import SeerProjectRepository
 from sentry.tasks.seer.night_shift.cron import (
+    NightShiftRunSource,
     _get_eligible_projects,
     run_night_shift_for_org,
     run_night_shift_for_project,
@@ -139,10 +140,13 @@ class TestGetEligibleProjects(TestCase):
         # No connected repo
         self.create_project(organization=org)
 
+        eligible.update_option("sentry:seer_nightshift_tweaks", {"enabled": True})
+
         with self.feature(NIGHT_SHIFT_FEATURES):
-            projects, preferences = _get_eligible_projects(org)
-            assert projects == [eligible]
-            assert eligible.id in preferences
+            result = _get_eligible_projects(org, NightShiftRunSource.MANUAL)
+
+        assert [ep.project for ep in result] == [eligible]
+        assert result[0].tweaks.enabled is True
 
     def test_filters_by_project_id(self) -> None:
         org = self.create_organization()
@@ -162,8 +166,11 @@ class TestGetEligibleProjects(TestCase):
         SeerProjectRepository.objects.create(project=other, repository=other_repo)
 
         with self.feature(NIGHT_SHIFT_FEATURES):
-            projects, _ = _get_eligible_projects(org, project_id=target.id)
-            assert projects == [target]
+            result = _get_eligible_projects(
+                org, NightShiftRunSource.MANUAL, project_ids=[target.id]
+            )
+
+        assert [ep.project for ep in result] == [target]
 
     def test_filters_by_project_flag_disabled(self) -> None:
         org = self.create_organization()
@@ -176,20 +183,46 @@ class TestGetEligibleProjects(TestCase):
         SeerProjectRepository.objects.create(project=project, repository=repo)
 
         with self.feature({"projects:seer-night-shift": False}):
-            projects, _ = _get_eligible_projects(org)
-            assert projects == []
+            assert _get_eligible_projects(org, NightShiftRunSource.MANUAL) == []
+        with self.feature(
+            {
+                "organizations:seer-project-settings-read-from-sentry": True,
+                "projects:seer-night-shift": False,
+            }
+        ):
+            assert _get_eligible_projects(org, NightShiftRunSource.MANUAL) == []
+
+    def test_cron_filters_disabled_tweaks_manual_keeps_them(self) -> None:
+        org = self.create_organization()
+
+        for slug, enabled in (("on", True), ("off", False)):
+            project = self.create_project(organization=org, slug=slug)
+            project.update_option(
+                "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM
+            )
+            repo = self.create_repo(project=project, provider="github", name=f"owner/{slug}")
+            SeerProjectRepository.objects.create(project=project, repository=repo)
+            project.update_option("sentry:seer_nightshift_tweaks", {"enabled": enabled})
+
+        with self.feature(NIGHT_SHIFT_FEATURES):
+            cron_result = _get_eligible_projects(org, NightShiftRunSource.CRON)
+            manual_result = _get_eligible_projects(org, NightShiftRunSource.MANUAL)
+
+        assert [ep.project.slug for ep in cron_result] == ["on"]
+        assert sorted(ep.project.slug for ep in manual_result) == ["off", "on"]
 
 
 @django_db_all
 class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
     reset_snuba_data = False
 
-    def _make_eligible(self, project):
+    def _make_eligible(self, project, **tweak_overrides):
         project.update_option(
             "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM
         )
         repo = self.create_repo(project=project, provider="github", name=f"owner/{project.slug}")
         SeerProjectRepository.objects.create(project=project, repository=repo)
+        project.update_option("sentry:seer_nightshift_tweaks", {"enabled": True, **tweak_overrides})
 
     def _store_event_and_update_group(self, project, fingerprint, **group_attrs):
         event = self.store_event(
@@ -466,6 +499,61 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
         )
         assert issue_run_ids == {ok_group.id: "7"}
 
+    def test_max_candidates_defaults_to_max_tweak_across_projects(self) -> None:
+        org = self.create_organization()
+        low = self.create_project(organization=org, slug="low")
+        high = self.create_project(organization=org, slug="high")
+        self._make_eligible(low, candidate_issues=3)
+        self._make_eligible(high, candidate_issues=11)
+
+        with (
+            self.feature(NIGHT_SHIFT_FEATURES),
+            patch(
+                "sentry.tasks.seer.night_shift.cron.agentic_triage_strategy",
+                return_value=([], None),
+            ) as mock_triage,
+        ):
+            run_night_shift_for_org(org.id)
+
+        mock_triage.assert_called_once()
+        assert mock_triage.call_args.args[2] == 11
+
+    def test_explicit_max_candidates_overrides_tweaks(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        self._make_eligible(project, candidate_issues=50)
+
+        with (
+            self.feature(NIGHT_SHIFT_FEATURES),
+            patch(
+                "sentry.tasks.seer.night_shift.cron.agentic_triage_strategy",
+                return_value=([], None),
+            ) as mock_triage,
+        ):
+            run_night_shift_for_org(org.id, max_candidates=7)
+
+        mock_triage.assert_called_once()
+        assert mock_triage.call_args.args[2] == 7
+
+    def test_scheduler_skips_projects_with_tweaks_disabled(self) -> None:
+        org = self.create_organization()
+        enabled = self.create_project(organization=org, slug="on")
+        disabled = self.create_project(organization=org, slug="off")
+        self._make_eligible(enabled)
+        self._make_eligible(disabled, enabled=False)
+
+        with (
+            self.feature(NIGHT_SHIFT_FEATURES),
+            patch(
+                "sentry.tasks.seer.night_shift.cron.agentic_triage_strategy",
+                return_value=([], None),
+            ) as mock_triage,
+        ):
+            run_night_shift_for_org(org.id)
+
+        mock_triage.assert_called_once()
+        assert [p.id for p in mock_triage.call_args.args[0]] == [enabled.id]
+
 
 @django_db_all
 class TestRunNightShiftForProject(TestCase):
@@ -496,10 +584,33 @@ class TestRunNightShiftForProject(TestCase):
         assert result == 42
         mock_execute.assert_called_once()
         kwargs = mock_execute.call_args.kwargs
-        assert kwargs["project_id"] == project.id
+        assert kwargs["source"] == NightShiftRunSource.MANUAL
+        assert kwargs["project_ids"] == [project.id]
         assert kwargs["dry_run"] is True
         assert kwargs["max_candidates"] == 3
         assert mock_execute.call_args.args[0].id == org.id
+
+    def test_runs_even_when_project_tweak_is_disabled(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        project.update_option(
+            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM
+        )
+        repo = self.create_repo(project=project, provider="github", name=f"owner/{project.slug}")
+        SeerProjectRepository.objects.create(project=project, repository=repo)
+        project.update_option("sentry:seer_nightshift_tweaks", {"enabled": False})
+
+        with (
+            self.feature(NIGHT_SHIFT_FEATURES),
+            patch(
+                "sentry.tasks.seer.night_shift.cron.agentic_triage_strategy",
+                return_value=([], None),
+            ) as mock_triage,
+        ):
+            run_night_shift_for_project(project.id)
+
+        mock_triage.assert_called_once()
+        assert [p.id for p in mock_triage.call_args.args[0]] == [project.id]
 
 
 @django_db_all


### PR DESCRIPTION
Wires the `NightShiftTweaks` loader into the cron scheduler so operators can configure night shift per-project via `sentry:seer_nightshift_tweaks`.

Behavior
- `tweaks.enabled` gates eligibility in the org-wide scheduler path. Projects with `enabled=False` are skipped.
- Manual per-project runs (`run_night_shift_for_project`, triggered from project settings "Run Now") bypass the `enabled` gate — the user explicitly asked, so silently doing nothing would be surprising.
- `tweaks.candidate_issues` replaces the `seer.night_shift.issues_per_org` site-wide option as the default candidate budget for scheduled runs. When multiple projects are eligible in the same org run, we take `max()` across them for now; `sum` may come later once we have signal on how operators want this to behave.
- An explicit `max_candidates` (from the admin endpoint) still overrides both.

Refactor
- `_get_eligible_projects` now returns `list[EligibleProject]`, a dataclass pairing each project with its parsed tweaks. Replaces the prior 3-tuple of list + preferences + tweaks-by-pid. Callers no longer index into a by-id dict to find a project's tweaks, and filtered-out projects can't leak into the returned tweaks map.

Agent transcript: https://claudescope.sentry.dev/share/xK0WXbM67PFP1BtpwtjUe66ifR7HAZlN3w6hXvJw1Is