### PR TITLE
fix(tracemetrics): Update equation filter for chart footer total count

### DIFF
--- a/static/app/views/explore/metrics/metricGraph/index.tsx
+++ b/static/app/views/explore/metrics/metricGraph/index.tsx
@@ -26,10 +26,12 @@ import {
 } from 'sentry/views/explore/metrics/metricsQueryParams';
 import {METRICS_CHART_GROUP} from 'sentry/views/explore/metrics/metricsTab';
 import {useMultiMetricsQueryParams} from 'sentry/views/explore/metrics/multiMetricsQueryParams';
+import {getEquationMetricsTotalFilter} from 'sentry/views/explore/metrics/utils';
 import {
   useQueryParamsQuery,
   useQueryParamsTopEventsLimit,
 } from 'sentry/views/explore/queryParams/context';
+import {isVisualizeEquation} from 'sentry/views/explore/queryParams/visualize';
 import {EXPLORE_CHART_TYPE_OPTIONS} from 'sentry/views/explore/spans/charts';
 import {useRawCounts} from 'sentry/views/explore/useRawCounts';
 import {
@@ -113,8 +115,12 @@ function Graph({
   const traceMetric = useTraceMetric();
   const rawMetricCounts = useRawCounts({
     dataset: DiscoverDatasets.TRACEMETRICS,
-    enabled: Boolean(traceMetric.name),
-    query: createTraceMetricEventsFilter([traceMetric]),
+    enabled:
+      Boolean(traceMetric.name) ||
+      (isVisualizeEquation(visualize) && Boolean(visualize.expression.text)),
+    query: isVisualizeEquation(visualize)
+      ? getEquationMetricsTotalFilter(visualize.expression.text)
+      : createTraceMetricEventsFilter([traceMetric]),
     normalModeExtrapolated: true,
   });
 

--- a/static/app/views/explore/metrics/parseAggregateExpression.tsx
+++ b/static/app/views/explore/metrics/parseAggregateExpression.tsx
@@ -54,7 +54,7 @@ interface ParsedEquationComponent {
  * The main normalization that's occurring here is the removal of the `_if` combinator if
  * applicable and extraction of the query from that combinator.
  */
-function normalizeFunctionToken(token: TokenFunction): ParsedEquationComponent {
+export function normalizeFunctionToken(token: TokenFunction): ParsedEquationComponent {
   if (!token.function.endsWith(IF_SUFFIX) || token.attributes.length === 0) {
     return {plainAggregate: token.text, filterQuery: ''};
   }

--- a/static/app/views/explore/metrics/parseMetricsAggregate.tsx
+++ b/static/app/views/explore/metrics/parseMetricsAggregate.tsx
@@ -13,11 +13,12 @@ export function parseMetricAggregate(aggregate: string): {
     };
   }
 
-  // Format is: aggregate(value,metric_name,metric_type,unit)
+  // Format is: aggregate(value,metric_name,metric_type,unit) or aggregate_if(`query`,value,metric_name,metric_type,unit)
   const args = parsed.arguments ?? [];
-  const metricName = args[1] ?? '';
-  const metricType = args[2] ?? '';
-  const metricUnit = args[3] === '-' ? undefined : args[3];
+  const offset = parsed.name.endsWith('_if') ? 1 : 0;
+  const metricName = args[1 + offset] ?? '';
+  const metricType = args[2 + offset] ?? '';
+  const metricUnit = args[3 + offset] === '-' ? undefined : args[3 + offset];
 
   return {
     aggregation: parsed.name,

--- a/static/app/views/explore/metrics/utils.spec.tsx
+++ b/static/app/views/explore/metrics/utils.spec.tsx
@@ -4,6 +4,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {SavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
 import {decodeMetricsQueryParams} from 'sentry/views/explore/metrics/metricQuery';
 import {
+  getEquationMetricsTotalFilter,
   getMetricsUrlFromSavedQueryUrl,
   mapMetricUnitToFieldType,
 } from 'sentry/views/explore/metrics/utils';
@@ -239,5 +240,16 @@ describe('getMetricsUrlFromSavedQueryUrl', () => {
 
     const decoded = decodeMetricFromUrl(url);
     expect(decoded?.queryParams.sortBys).toEqual([{field: 'timestamp', kind: 'desc'}]);
+  });
+});
+
+describe('getEquationMetricsTotalFilter', () => {
+  it('returns the correct filter for an equation', () => {
+    const equation =
+      'equation|sum(value,metricA,counter,none) + count(value,metricB,distribution,millisecond)';
+    const result = getEquationMetricsTotalFilter(equation);
+    expect(result).toBe(
+      '( metric.name:metricA metric.type:counter ( !has:metric.unit OR metric.unit:none ) ) OR ( metric.name:metricB metric.type:distribution metric.unit:millisecond )'
+    );
   });
 });

--- a/static/app/views/explore/metrics/utils.spec.tsx
+++ b/static/app/views/explore/metrics/utils.spec.tsx
@@ -258,4 +258,13 @@ describe('getEquationMetricsTotalFilter', () => {
     const result = getEquationMetricsTotalFilter(equation);
     expect(result).toBe('');
   });
+
+  it('works with equations that have _if conditions', () => {
+    const equation =
+      'equation|sum_if(`status:[ok,error]`,value,metricA,counter,none) + sum_if(`status:error`,value,metricB,counter,none)';
+    const result = getEquationMetricsTotalFilter(equation);
+    expect(result).toBe(
+      '( metric.name:metricA metric.type:counter ( !has:metric.unit OR metric.unit:none ) ) OR ( metric.name:metricB metric.type:counter ( !has:metric.unit OR metric.unit:none ) )'
+    );
+  });
 });

--- a/static/app/views/explore/metrics/utils.spec.tsx
+++ b/static/app/views/explore/metrics/utils.spec.tsx
@@ -252,4 +252,10 @@ describe('getEquationMetricsTotalFilter', () => {
       '( metric.name:metricA metric.type:counter ( !has:metric.unit OR metric.unit:none ) ) OR ( metric.name:metricB metric.type:distribution metric.unit:millisecond )'
     );
   });
+
+  it('returns an empty string when provided a non-equation', () => {
+    const equation = 'i dont know what this is';
+    const result = getEquationMetricsTotalFilter(equation);
+    expect(result).toBe('');
+  });
 });

--- a/static/app/views/explore/metrics/utils.tsx
+++ b/static/app/views/explore/metrics/utils.tsx
@@ -9,7 +9,6 @@ import {defined} from 'sentry/utils';
 import type {EventsMetaType, MetaType} from 'sentry/utils/discover/eventView';
 import {
   DurationUnit,
-  isEquation,
   RateUnit,
   SizeUnit,
   stripEquationPrefix,
@@ -273,10 +272,6 @@ export function mapMetricUnitToFieldType(metricUnit: string | undefined): {
  * that are used in the equation.
  */
 export function getEquationMetricsTotalFilter(equation: string) {
-  if (!isEquation(equation)) {
-    return '';
-  }
-
   const expression = new Expression(stripEquationPrefix(equation));
   const aggregatesUsed = expression.tokens
     .filter(isTokenFunction)

--- a/static/app/views/explore/metrics/utils.tsx
+++ b/static/app/views/explore/metrics/utils.tsx
@@ -1,5 +1,7 @@
 import qs from 'query-string';
 
+import {Expression} from 'sentry/components/arithmeticBuilder/expression';
+import {isTokenFunction} from 'sentry/components/arithmeticBuilder/token';
 import {MutableSearch} from 'sentry/components/searchSyntax/mutableSearch';
 import type {PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
@@ -7,12 +9,15 @@ import {defined} from 'sentry/utils';
 import type {EventsMetaType, MetaType} from 'sentry/utils/discover/eventView';
 import {
   DurationUnit,
+  isEquation,
   RateUnit,
   SizeUnit,
+  stripEquationPrefix,
   type ColumnType,
 } from 'sentry/utils/discover/fields';
 import {decodeSorts} from 'sentry/utils/queryString';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
+import {createTraceMetricEventsFilter} from 'sentry/views/dashboards/widgetCard/hooks/useWidgetRawCounts';
 import type {
   RawVisualize,
   SavedQuery,
@@ -24,6 +29,7 @@ import {
   encodeMetricQueryParams,
   type BaseMetricQuery,
 } from 'sentry/views/explore/metrics/metricQuery';
+import {parseMetricAggregate} from 'sentry/views/explore/metrics/parseMetricsAggregate';
 import {
   TraceMetricKnownFieldKey,
   type SampleTableColumnKey,
@@ -260,4 +266,26 @@ export function mapMetricUnitToFieldType(metricUnit: string | undefined): {
     return {fieldType: 'percentage', unit: metricUnit};
   }
   return {fieldType: 'number', unit: undefined};
+}
+
+/**
+ * Takes an equation and returns a filter that looks for all metric events
+ * that are used in the equation.
+ */
+export function getEquationMetricsTotalFilter(equation: string) {
+  if (!isEquation(equation)) {
+    return '';
+  }
+
+  const expression = new Expression(stripEquationPrefix(equation));
+  const aggregatesUsed = expression.tokens
+    .filter(isTokenFunction)
+    .map(token => token.text);
+
+  const traceMetricsUsed = aggregatesUsed.map(aggregate => {
+    const {traceMetric} = parseMetricAggregate(aggregate);
+    return traceMetric;
+  });
+
+  return createTraceMetricEventsFilter(traceMetricsUsed);
 }

--- a/static/app/views/explore/metrics/utils.tsx
+++ b/static/app/views/explore/metrics/utils.tsx
@@ -28,6 +28,7 @@ import {
   encodeMetricQueryParams,
   type BaseMetricQuery,
 } from 'sentry/views/explore/metrics/metricQuery';
+import {normalizeFunctionToken} from 'sentry/views/explore/metrics/parseAggregateExpression';
 import {parseMetricAggregate} from 'sentry/views/explore/metrics/parseMetricsAggregate';
 import {
   TraceMetricKnownFieldKey,
@@ -275,7 +276,7 @@ export function getEquationMetricsTotalFilter(equation: string) {
   const expression = new Expression(stripEquationPrefix(equation));
   const aggregatesUsed = expression.tokens
     .filter(isTokenFunction)
-    .map(token => token.text);
+    .map(token => normalizeFunctionToken(token).plainAggregate);
 
   const traceMetricsUsed = aggregatesUsed.map(aggregate => {
     const {traceMetric} = parseMetricAggregate(aggregate);


### PR DESCRIPTION
This fixes the blank number in the confidence footer for equations

<img width="726" height="444" alt="Screenshot 2026-04-24 at 9 58 41 AM" src="https://github.com/user-attachments/assets/25739998-2d0e-422f-9083-dffad36c6fa3" />


Since equations don't have a single tracemetric selected, the existing way of calculating how many metrics doesn't work properly. This PR adds a helper that takes the equation in its raw format (assuming it's valid), and parses out the tracemetrics from the expression (by iterating over the function tokens).

Then I can run those tracemetrics through the `createTraceMetricEventsFilter` helper which spits out a big OR condition for each metric involved.