### PR TITLE
fix(integrations): Use cell RPC for SCM backfill option reads

### DIFF
--- a/src/sentry/migrations/1072_backfill_scm_integration_config.py
+++ b/src/sentry/migrations/1072_backfill_scm_integration_config.py
@@ -5,7 +5,10 @@ from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.migrations.state import StateApps
 
 from sentry.constants import ObjectStatus
+from sentry.hybridcloud.rpc.service import RpcRemoteException
+from sentry.models.organization import Organization
 from sentry.new_migrations.migrations import CheckedMigration
+from sentry.types.cell import CellMappingNotFound
 from sentry.utils.query import RangeQuerySetWrapperWithProgressBarApprox
 
 logger = logging.getLogger(__name__)
@@ -28,14 +31,21 @@ _PROVIDER_KEYS = {
 def backfill_scm_integration_config(
     apps: StateApps, schema_editor: BaseDatabaseSchemaEditor
 ) -> None:
+    # `sentry_organizationintegration` is control-silo; `sentry_organizationoptions`
+    # is region-silo. This migration is routed to control via the `tables` hint
+    # below, so we read OI rows locally but fetch the legacy option values over
+    # the cell RPC instead of a cross-silo SQL query (which is impossible).
+    from sentry.organizations.services.organization import organization_service
+
     OrganizationIntegration = apps.get_model("sentry", "OrganizationIntegration")
-    OrganizationOption = apps.get_model("sentry", "OrganizationOption")
 
     # Iterate the whole OI table — the approx wrapper needs an unfiltered
     # queryset, and we don't have an index on (status, id) or
     # (integration_id, id) for a filtered range scan. Filtering in Python
     # is cheaper than either alternative.
     queryset = OrganizationIntegration.objects.all().select_related("integration")
+
+    option_cache: dict[tuple[int, str], object] = {}
 
     for oi in RangeQuerySetWrapperWithProgressBarApprox(queryset):
         if oi.status != ObjectStatus.ACTIVE:
@@ -45,23 +55,31 @@ def backfill_scm_integration_config(
         if not key_pairs:
             continue
 
-        option_keys = [opt_key for opt_key, _ in key_pairs]
-        opts = {
-            opt.key: opt.value
-            for opt in OrganizationOption.objects.filter(
-                organization_id=oi.organization_id,
-                key__in=option_keys,
-            )
-        }
-        if not opts:
-            continue
-
         config = dict(oi.config or {})
         changed = False
         for opt_key, cfg_key in key_pairs:
-            if opt_key in opts and cfg_key not in config:
-                config[cfg_key] = bool(opts[opt_key])
-                changed = True
+            if cfg_key in config:
+                continue
+            cache_key = (oi.organization_id, opt_key)
+            if cache_key not in option_cache:
+                try:
+                    option_cache[cache_key] = organization_service.get_option(
+                        organization_id=oi.organization_id, key=opt_key
+                    )
+                except (Organization.DoesNotExist, CellMappingNotFound, RpcRemoteException):
+                    # OI references an org that's already been deleted on the
+                    # region silo. The HybridCloudForeignKey cascade is async
+                    # across silos so this window is expected. In monolith /
+                    # tests the region raises Organization.DoesNotExist; in
+                    # split-silo the cell resolver raises CellMappingNotFound
+                    # (mapping gone) or RpcRemoteException (mapping intact,
+                    # region-side DoesNotExist wrapped by the RPC framework).
+                    option_cache[cache_key] = None
+            value = option_cache[cache_key]
+            if value is None:
+                continue
+            config[cfg_key] = bool(value)
+            changed = True
 
         if changed:
             oi.config = config

--- a/tests/sentry/migrations/test_1072_backfill_scm_integration_config.py
+++ b/tests/sentry/migrations/test_1072_backfill_scm_integration_config.py
@@ -1,101 +1,103 @@
-import importlib
-
-from django.apps import apps as global_apps
-
 from sentry.constants import ObjectStatus
-from sentry.integrations.models.organization_integration import OrganizationIntegration
-from sentry.models.options.organization_option import OrganizationOption
-from sentry.silo.base import SiloMode
-from sentry.testutils.cases import TestCase
-from sentry.testutils.silo import assume_test_silo_mode
-
-migration = importlib.import_module("sentry.migrations.1072_backfill_scm_integration_config")
+from sentry.testutils.cases import TestMigrations
+from sentry.testutils.silo import control_silo_test
 
 
-class BackfillScmIntegrationConfigTest(TestCase):
-    def test_backfill(self) -> None:
-        github = self.create_integration(
-            organization=self.organization, provider="github", external_id="gh-1"
+@control_silo_test
+class BackfillScmIntegrationConfigTest(TestMigrations):
+    migrate_from = "1071_add_broadcast_sync_locked"
+    migrate_to = "1072_backfill_scm_integration_config"
+    connection = "control"
+
+    def setup_before_migration(self, apps):
+        Integration = apps.get_model("sentry", "Integration")
+        OrganizationIntegration = apps.get_model("sentry", "OrganizationIntegration")
+        OrganizationOption = apps.get_model("sentry", "OrganizationOption")
+
+        org = self.create_organization()
+        gh = Integration.objects.create(provider="github", external_id="gh-1", name="gh")
+        gl = Integration.objects.create(provider="gitlab", external_id="gl-1", name="gl")
+        self.gh_oi = OrganizationIntegration.objects.create(
+            organization_id=org.id, integration_id=gh.id, status=ObjectStatus.ACTIVE, config={}
         )
-        gitlab = self.create_integration(
-            organization=self.organization, provider="gitlab", external_id="gl-1"
+        self.gl_oi = OrganizationIntegration.objects.create(
+            organization_id=org.id, integration_id=gl.id, status=ObjectStatus.ACTIVE, config={}
         )
-        with assume_test_silo_mode(SiloMode.CELL):
-            OrganizationOption.objects.set_value(
-                organization=self.organization, key="sentry:github_pr_bot", value=True
-            )
-            OrganizationOption.objects.set_value(
-                organization=self.organization, key="sentry:github_nudge_invite", value=False
-            )
-            OrganizationOption.objects.set_value(
-                organization=self.organization, key="sentry:gitlab_pr_bot", value=True
-            )
+        OrganizationOption.objects.create(
+            organization_id=org.id, key="sentry:github_pr_bot", value=True
+        )
+        OrganizationOption.objects.create(
+            organization_id=org.id, key="sentry:github_nudge_invite", value=False
+        )
+        OrganizationOption.objects.create(
+            organization_id=org.id, key="sentry:gitlab_pr_bot", value=True
+        )
 
-        other_org = self.create_organization()
-        preset_github = self.create_integration(
-            organization=other_org,
-            provider="github",
-            external_id="gh-preset",
-            oi_params={"config": {"pr_comments": False, "other_key": "kept"}},
+        preset_org = self.create_organization()
+        preset_gh = Integration.objects.create(
+            provider="github", external_id="gh-preset", name="preset"
         )
-        with assume_test_silo_mode(SiloMode.CELL):
-            OrganizationOption.objects.set_value(
-                organization=other_org, key="sentry:github_pr_bot", value=True
-            )
-            OrganizationOption.objects.set_value(
-                organization=other_org, key="sentry:github_nudge_invite", value=True
-            )
+        self.preset_oi = OrganizationIntegration.objects.create(
+            organization_id=preset_org.id,
+            integration_id=preset_gh.id,
+            status=ObjectStatus.ACTIVE,
+            config={"pr_comments": False, "other_key": "kept"},
+        )
+        OrganizationOption.objects.create(
+            organization_id=preset_org.id, key="sentry:github_pr_bot", value=True
+        )
+        OrganizationOption.objects.create(
+            organization_id=preset_org.id, key="sentry:github_nudge_invite", value=True
+        )
 
         no_option_org = self.create_organization()
-        untouched_github = self.create_integration(
-            organization=no_option_org, provider="github", external_id="gh-nooptions"
+        no_option_gh = Integration.objects.create(
+            provider="github", external_id="gh-nooptions", name="no-opt"
+        )
+        self.untouched_oi = OrganizationIntegration.objects.create(
+            organization_id=no_option_org.id,
+            integration_id=no_option_gh.id,
+            status=ObjectStatus.ACTIVE,
+            config={},
         )
 
         disabled_org = self.create_organization()
-        disabled_github = self.create_integration(
-            organization=disabled_org,
-            provider="github",
-            external_id="gh-disabled",
-            oi_params={"status": ObjectStatus.DISABLED},
+        disabled_gh = Integration.objects.create(
+            provider="github", external_id="gh-disabled", name="disabled"
         )
-        with assume_test_silo_mode(SiloMode.CELL):
-            OrganizationOption.objects.set_value(
-                organization=disabled_org, key="sentry:github_pr_bot", value=True
-            )
+        self.disabled_oi = OrganizationIntegration.objects.create(
+            organization_id=disabled_org.id,
+            integration_id=disabled_gh.id,
+            status=ObjectStatus.DISABLED,
+            config={},
+        )
+        OrganizationOption.objects.create(
+            organization_id=disabled_org.id, key="sentry:github_pr_bot", value=True
+        )
 
         non_scm_org = self.create_organization()
-        slack = self.create_integration(
-            organization=non_scm_org, provider="slack", external_id="slack-1"
+        slack = Integration.objects.create(provider="slack", external_id="slack-1", name="slack")
+        self.slack_oi = OrganizationIntegration.objects.create(
+            organization_id=non_scm_org.id,
+            integration_id=slack.id,
+            status=ObjectStatus.ACTIVE,
+            config={},
         )
 
-        with assume_test_silo_mode(SiloMode.MONOLITH):
-            migration.backfill_scm_integration_config(global_apps, None)
+    def test(self) -> None:
+        from sentry.integrations.models.organization_integration import OrganizationIntegration
 
-        with assume_test_silo_mode(SiloMode.CONTROL):
-            github_oi = OrganizationIntegration.objects.get(
-                integration_id=github.id, organization_id=self.organization.id
-            )
-            gitlab_oi = OrganizationIntegration.objects.get(
-                integration_id=gitlab.id, organization_id=self.organization.id
-            )
-            preset_oi = OrganizationIntegration.objects.get(
-                integration_id=preset_github.id, organization_id=other_org.id
-            )
-            untouched_oi = OrganizationIntegration.objects.get(
-                integration_id=untouched_github.id, organization_id=no_option_org.id
-            )
-            disabled_oi = OrganizationIntegration.objects.get(
-                integration_id=disabled_github.id, organization_id=disabled_org.id
-            )
-            slack_oi = OrganizationIntegration.objects.get(
-                integration_id=slack.id, organization_id=non_scm_org.id
-            )
+        assert OrganizationIntegration.objects.get(id=self.gh_oi.id).config == {
+            "pr_comments": True,
+            "nudge_invite": False,
+        }
+        assert OrganizationIntegration.objects.get(id=self.gl_oi.id).config == {"pr_comments": True}
 
-        assert github_oi.config == {"pr_comments": True, "nudge_invite": False}
-        assert gitlab_oi.config == {"pr_comments": True}
-        assert preset_oi.config["pr_comments"] is False
-        assert preset_oi.config["nudge_invite"] is True
-        assert preset_oi.config["other_key"] == "kept"
-        assert untouched_oi.config == {}
-        assert disabled_oi.config == {}
-        assert slack_oi.config == {}
+        preset = OrganizationIntegration.objects.get(id=self.preset_oi.id).config
+        assert preset["pr_comments"] is False
+        assert preset["nudge_invite"] is True
+        assert preset["other_key"] == "kept"
+
+        assert OrganizationIntegration.objects.get(id=self.untouched_oi.id).config == {}
+        assert OrganizationIntegration.objects.get(id=self.disabled_oi.id).config == {}
+        assert OrganizationIntegration.objects.get(id=self.slack_oi.id).config == {}


### PR DESCRIPTION
The Phase 1 backfill (migration 1072) is routed to the control silo by the `sentry_organizationintegration` table hint, but the previous implementation read `sentry_organizationoptions` directly — that table lives on the region silo, so the migration blew up with `relation "sentry_organizationoptions" does not exist` when run against control in production.

Swap the direct ORM read for `organization_service.get_option`, which is a cell RPC that dispatches to the region silo. Cache results per `(org_id, option_key)` since a single org may own multiple OIs and we'd otherwise issue the same RPC repeatedly.

Ref: [VDY-111: Phase 1: Dual-write SCM settings to integration config + backfill](https://linear.app/getsentry/issue/VDY-111/phase-1-dual-write-scm-settings-to-integration-config-backfill)

## Migration phases

- ● Phase 1 — Backfill existing OIs: [#113841](https://github.com/getsentry/sentry/pull/113841) (merged)
- ○ Phase 1 — Backfill cross-silo fix: [#113908](https://github.com/getsentry/sentry/pull/113908)
- ○ Phase 1 — Dual-write SCM toggles: [#113842](https://github.com/getsentry/sentry/pull/113842)
- ○ Phase 2 — Read from OI config behind flag: [#113864](https://github.com/getsentry/sentry/pull/113864)
- ○ Phase 3 — Expose toggles in per-install UI: [#113923](https://github.com/getsentry/sentry/pull/113923)
- ○ Phase 3 — Remove legacy detail-view toggles (frontend): [#113924](https://github.com/getsentry/sentry/pull/113924)
- ○ Phase 3 — Drop SCM toggle fields from PUT endpoint: [#113925](https://github.com/getsentry/sentry/pull/113925)
- ○ Phase 4 — Remove legacy code paths: upcoming
