### PR TITLE
feat(seer): Add seer-night-shift-settings feature flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -310,6 +310,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-night-shift", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Per-project gate for Seer Night Shift (requires organizations:seer-night-shift on the org)
     manager.add("projects:seer-night-shift", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Display nightshift settings
+    manager.add("organizations:seer-night-shift-settings", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable context engine for Seer Explorer
     manager.add("organizations:seer-explorer-context-engine", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable context engine experimental contexts


### PR DESCRIPTION
Register an org-level flag `organizations:seer-night-shift-settings` to gate the Seer Night Shift settings UI.

Exposed to the frontend (`api_expose=True`) so the settings surface can be hidden or shown based on flag state. Landing backend-first; the frontend gate will follow in a separate PR since `static/` and `src/` are not atomically deployed.


Agent transcript: https://claudescope.sentry.dev/share/tHoijc-VFfA054GzNFgHid7HtBfbTVWJogpE-EA6mck