### PR TITLE
chore(profiling): Migrate profiles to explore layout

### DIFF
--- a/static/app/views/explore/profiling/content.tsx
+++ b/static/app/views/explore/profiling/content.tsx
@@ -389,32 +389,47 @@ function shouldShowProfilingOnboardingPanel(selection: PageFilters, projects: Pr
 
 function ProfilingContentPageHeader() {
   const hasPageFrameFeature = useHasPageFrameFeature();
+
+  const titleTooltip = (
+    <PageHeadingQuestionTooltip
+      docsUrl="https://docs.sentry.io/product/profiling/"
+      title={t(
+        'Profiling collects detailed information in production about the functions executing in your application and how long they take to run, giving you code-level visibility into your hot paths.'
+      )}
+    />
+  );
+
+  if (hasPageFrameFeature) {
+    return (
+      <Fragment>
+        <TopBar.Slot name="title">
+          {t('Profiling')}
+          {titleTooltip}
+        </TopBar.Slot>
+        <TopBar.Slot name="feedback">
+          <FeedbackButton
+            aria-label={t('Give Feedback')}
+            tooltipProps={{title: t('Give Feedback')}}
+          >
+            {null}
+          </FeedbackButton>
+        </TopBar.Slot>
+      </Fragment>
+    );
+  }
+
   return (
-    <StyledLayoutHeader unified>
-      <StyledHeaderContent unified>
+    <Layout.Header unified>
+      <Layout.HeaderContent unified>
         <Layout.Title>
           {t('Profiling')}
-          <PageHeadingQuestionTooltip
-            docsUrl="https://docs.sentry.io/product/profiling/"
-            title={t(
-              'Profiling collects detailed information in production about the functions executing in your application and how long they take to run, giving you code-level visibility into your hot paths.'
-            )}
-          />
+          {titleTooltip}
         </Layout.Title>
-        {hasPageFrameFeature ? (
-          <TopBar.Slot name="feedback">
-            <FeedbackButton
-              aria-label={t('Give Feedback')}
-              tooltipProps={{title: t('Give Feedback')}}
-            >
-              {null}
-            </FeedbackButton>
-          </TopBar.Slot>
-        ) : (
-          <FeedbackButton />
-        )}
-      </StyledHeaderContent>
-    </StyledLayoutHeader>
+      </Layout.HeaderContent>
+      <Layout.HeaderActions>
+        <FeedbackButton />
+      </Layout.HeaderActions>
+    </Layout.Header>
   );
 }
 
@@ -442,17 +457,6 @@ const LandingAggregateFlamegraphContainer = styled('div')`
   position: relative;
   border: 1px solid ${p => p.theme.tokens.border.primary};
   border-radius: ${p => p.theme.radius.md};
-`;
-
-const StyledLayoutHeader = styled(Layout.Header)`
-  display: block;
-`;
-
-const StyledHeaderContent = styled(Layout.HeaderContent)`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  flex-direction: row;
 `;
 
 const WidgetsContainer = styled('div')`

--- a/static/app/views/explore/profiling/content.tsx
+++ b/static/app/views/explore/profiling/content.tsx
@@ -43,6 +43,11 @@ import {useMaxPickableDays} from 'sentry/utils/useMaxPickableDays';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
+import {
+  ExploreBodyContent,
+  ExploreBodySearch,
+  ExploreContentSection,
+} from 'sentry/views/explore/components/styles';
 import {LandingAggregateFlamegraph} from 'sentry/views/explore/profiling/landingAggregateFlamegraph';
 import {Onboarding} from 'sentry/views/explore/profiling/onboarding';
 import {TopBar} from 'sentry/views/navigation/topBar';
@@ -166,18 +171,20 @@ export default function ProfilingContent() {
             <ContinuousProfilingBetaSDKAlertBanner />
           </Feature>
           <ProfilingContentPageHeader />
-          <LayoutBody>
-            <LayoutMain width="full">
-              <ActionBar>
-                <PageFilterBar condensed>
-                  <ProjectPageFilter resetParamsOnChange={CURSOR_PARAMS} />
-                  <EnvironmentPageFilter resetParamsOnChange={CURSOR_PARAMS} />
-                  <DatePageFilter
-                    {...datePageFilterProps}
-                    resetParamsOnChange={CURSOR_PARAMS}
-                  />
-                </PageFilterBar>
-              </ActionBar>
+          <ExploreBodySearch>
+            <Layout.Main width="full">
+              <PageFilterBar condensed>
+                <ProjectPageFilter resetParamsOnChange={CURSOR_PARAMS} />
+                <EnvironmentPageFilter resetParamsOnChange={CURSOR_PARAMS} />
+                <DatePageFilter
+                  {...datePageFilterProps}
+                  resetParamsOnChange={CURSOR_PARAMS}
+                />
+              </PageFilterBar>
+            </Layout.Main>
+          </ExploreBodySearch>
+          <ExploreBodyContent>
+            <ExploreContentSection gap="md">
               {showOnboardingPanel ? (
                 <Onboarding />
               ) : (
@@ -243,8 +250,8 @@ export default function ProfilingContent() {
                   )}
                 </Fragment>
               )}
-            </LayoutMain>
-          </LayoutBody>
+            </ExploreContentSection>
+          </ExploreBodyContent>
         </Stack>
       </PageFiltersContainer>
     </SentryDocumentTitle>
@@ -423,20 +430,6 @@ const ALL_FIELDS = [
 
 type FieldType = (typeof ALL_FIELDS)[number];
 
-const LayoutBody = styled(Layout.Body)`
-  display: grid;
-  align-content: stretch;
-
-  @media (min-width: ${p => p.theme.breakpoints.lg}) {
-    align-content: stretch;
-  }
-`;
-
-const LayoutMain = styled(Layout.Main)`
-  display: flex;
-  flex-direction: column;
-`;
-
 const LandingAggregateFlamegraphSizer = styled('div')`
   height: 100%;
   min-height: max(80vh, 300px);
@@ -460,13 +453,6 @@ const StyledHeaderContent = styled(Layout.HeaderContent)`
   align-items: center;
   justify-content: space-between;
   flex-direction: row;
-`;
-
-const ActionBar = styled('div')`
-  display: grid;
-  gap: ${p => p.theme.space.xl};
-  grid-template-columns: min-content auto;
-  margin-bottom: ${p => p.theme.space.xl};
 `;
 
 const WidgetsContainer = styled('div')`

--- a/static/app/views/explore/profiling/content.tsx
+++ b/static/app/views/explore/profiling/content.tsx
@@ -213,7 +213,7 @@ export default function ProfilingContent() {
                       />
                     </WidgetsContainer>
                   )}
-                  <div>
+                  <Stack gap="lg">
                     <Tabs value={tab} onChange={onTabChange}>
                       <TabList>
                         <TabList.Item key="transactions">
@@ -238,16 +238,16 @@ export default function ProfilingContent() {
                         </TabList.Item>
                       </TabList>
                     </Tabs>
-                  </div>
-                  {tab === 'flamegraph' ? (
-                    <FlamegraphTab onDataState={updateFlamegraphDataState} />
-                  ) : (
-                    <TransactionsTab
-                      location={location}
-                      selection={selection}
-                      onDataState={updateTransactionsTableDataState}
-                    />
-                  )}
+                    {tab === 'flamegraph' ? (
+                      <FlamegraphTab onDataState={updateFlamegraphDataState} />
+                    ) : (
+                      <TransactionsTab
+                        location={location}
+                        selection={selection}
+                        onDataState={updateTransactionsTableDataState}
+                      />
+                    )}
+                  </Stack>
                 </Fragment>
               )}
             </ExploreContentSection>
@@ -330,16 +330,14 @@ function TransactionsTab({onDataState, location, selection}: TabbedContentProps)
   }, [onDataState, hasData, isLoading, isError]);
 
   return (
-    <Fragment>
-      <SearchbarContainer>
-        <TransactionSearchQueryBuilder
-          projects={selection.projects}
-          initialQuery={query}
-          onSearch={handleSearch}
-          searchSource="profile_landing"
-          disallowFreeText={false}
-        />
-      </SearchbarContainer>
+    <Stack gap="lg">
+      <TransactionSearchQueryBuilder
+        projects={selection.projects}
+        initialQuery={query}
+        onSearch={handleSearch}
+        searchSource="profile_landing"
+        disallowFreeText={false}
+      />
       {transactionsError && (
         <Alert.Container>
           <Alert variant="danger">{transactionsError}</Alert>
@@ -358,7 +356,7 @@ function TransactionsTab({onDataState, location, selection}: TabbedContentProps)
           transactions.status === 'success' ? transactions.data.headers.Link : null
         }
       />
-    </Fragment>
+    </Stack>
   );
 }
 
@@ -466,11 +464,6 @@ const WidgetsContainer = styled('div')`
   @media (max-width: ${p => p.theme.breakpoints.sm}) {
     grid-template-columns: 1fr;
   }
-`;
-
-const SearchbarContainer = styled('div')`
-  margin-top: ${p => p.theme.space['2xl']};
-  margin-bottom: ${p => p.theme.space.xl};
 `;
 
 const StyledPagination = styled(Pagination)`


### PR DESCRIPTION
This PR migrates the profiling content page to use the same explore components to bring it in line with the other explore pages.

Closes EXP-906

| | |
|-|-|
|Before| <img width="1658" height="763" alt="Screenshot 2026-04-24 at 11 41 22" src="https://github.com/user-attachments/assets/380dc5a8-5f91-4e85-a1a6-54447790f010" /> |
|After| <img width="1658" height="763" alt="Screenshot 2026-04-24 at 11 41 24" src="https://github.com/user-attachments/assets/2c4e3a91-a587-45d2-8e11-8a85591a873f" /> |