### PR TITLE
fix(discover): Skip homepage query when discover-query is disabled

### DIFF
--- a/static/app/views/discover/results.spec.tsx
+++ b/static/app/views/discover/results.spec.tsx
@@ -974,6 +974,35 @@ describe('Results', () => {
       );
     });
 
+    it('does not fetch the homepage query when discover-query is disabled', async () => {
+      renderMockRequests();
+      const mockHomepageGet = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/discover/homepage/',
+        method: 'GET',
+        statusCode: 404,
+      });
+
+      const organization = OrganizationFixture({
+        features: ['discover-basic', 'page-frame'],
+      });
+
+      ProjectsStore.loadInitialData([ProjectFixture()]);
+
+      render(<Results />, {
+        initialRouterConfig: {
+          location: {
+            pathname: `/organizations/${organization.slug}/explore/discover/results/`,
+            query: generateFields(),
+          },
+          route: '/organizations/:orgId/explore/discover/results/',
+        },
+        organization,
+      });
+
+      expect(await screen.findByText(eventTitle)).toBeInTheDocument();
+      expect(mockHomepageGet).not.toHaveBeenCalled();
+    });
+
     it('Changes the Use as Discover button to a reset button for saved query', async () => {
       renderMockRequests();
 

--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -980,8 +980,11 @@ function DiscoverContextMenu({
     [organization.slug]
   );
 
+  const hasDiscoverQueryFeature = organization.features.includes('discover-query');
+
   const {data: homepageQuery} = useApiQuery<SavedQuery | undefined>(homepageQueryKey, {
     staleTime: 0,
+    enabled: hasDiscoverQueryFeature,
   });
 
   const normalizedHomepageQuery = homepageQuery


### PR DESCRIPTION
`DiscoverContextMenu` (added in #113634) fires `GET /discover/homepage/`
on every Discover results render when the org has the `page-frame`
feature. But the endpoint requires `organizations:discover` or
`organizations:discover-query`. Orgs on `discover-basic` + `page-frame`
(no `discover-query`) now get a 404 on every Discover results view.

Gate the `useApiQuery` on `discover-query` with `enabled:` so the
fetch matches the backend feature gate, same as how the menu items
that consume the result are already gated.