### PR TITLE
feat(eslint): rule that disallows explicit type parameters on getQueryData and setQueryData

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -454,6 +454,7 @@ export default typescript.config([
       '@sentry/no-digits-in-tn': 'error',
       '@sentry/no-dynamic-translations': 'error',
       '@sentry/no-flag-comments': 'error',
+      '@sentry/no-query-data-type-parameters': 'error',
       '@sentry/no-static-translations': 'error',
       '@sentry/no-styled-shortcut': 'error',
       '@sentry/no-unnecessary-use-callback': 'error',

--- a/static/app/components/events/highlights/highlightsSettingsForm.tsx
+++ b/static/app/components/events/highlights/highlightsSettingsForm.tsx
@@ -11,7 +11,6 @@ import {t, tct} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
 import {convertMultilineFieldValue, extractMultilineFields} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import type {ApiResponse} from 'sentry/utils/api/apiFetch';
 import {
   makeDetailedProjectQueryKey,
   useDetailedProject,
@@ -43,7 +42,7 @@ export function HighlightsSettingsForm({projectSlug}: HighlightsSettingsFormProp
     apiMethod: 'PUT',
     apiEndpoint: `/projects/${organization.slug}/${projectSlug}/`,
     onSubmitSuccess: (updatedProject: Project) => {
-      queryClient.setQueryData<ApiResponse<Project>>(
+      queryClient.setQueryData(
         makeDetailedProjectQueryKey({
           orgSlug: organization.slug,
           projectSlug: project.slug,

--- a/static/app/components/repositories/scmIntegrationTree/scmIntegrationTree.tsx
+++ b/static/app/components/repositories/scmIntegrationTree/scmIntegrationTree.tsx
@@ -1,6 +1,6 @@
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
-import {useQueryClient, type InfiniteData} from '@tanstack/react-query';
+import {useQueryClient} from '@tanstack/react-query';
 import {useVirtualizer} from '@tanstack/react-virtual';
 
 import {LinkButton} from '@sentry/scraps/button';
@@ -196,7 +196,7 @@ export function ScmIntegrationTree({search, repoFilter, providerFilter}: Props) 
       try {
         if (isConnected) {
           const connectedRepo = queryClient
-            .getQueryData<InfiniteData<{json: Repository[]}>>(reposQueryOptions.queryKey)
+            .getQueryData(reposQueryOptions.queryKey)
             ?.pages.flatMap(p => p.json)
             .find(r => r.name === repo.identifier);
           if (connectedRepo) {

--- a/static/app/utils/api/useAggregatedQueryKeys.tsx
+++ b/static/app/utils/api/useAggregatedQueryKeys.tsx
@@ -96,6 +96,7 @@ export function useAggregatedQueryKeys<AggregatableQueryKey, Data>({
     () =>
       cache
         .findAll({queryKey: [key]})
+        // eslint-disable-next-line @sentry/no-query-data-type-parameters
         .map(({queryKey}) => queryClient.getQueryData<ApiResult>(queryKey))
         .filter(defined)
         .reduce<Data | undefined>(
@@ -132,6 +133,7 @@ export function useAggregatedQueryKeys<AggregatableQueryKey, Data>({
         predicate: isQueryKeyInBatch,
       });
       queuedAggregatableBatch.forEach(queryKey => {
+        // eslint-disable-next-line @sentry/no-query-data-type-parameters
         queryClient.setQueryData<boolean>(
           ['aggregate', cacheKey, key, 'inFlight', queryKey],
           true
@@ -197,6 +199,7 @@ export function useAggregatedQueryKeys<AggregatableQueryKey, Data>({
       // Cache sentinel data for the new cacheKeys
       newQueryKeys
         .map(agg => ['aggregate', cacheKey, key, 'queued', agg])
+        // eslint-disable-next-line @sentry/no-query-data-type-parameters
         .forEach(queryKey => queryClient.setQueryData<boolean>(queryKey, true));
 
       if (newQueryKeys.length) {

--- a/static/app/utils/project/useUpdateProject.tsx
+++ b/static/app/utils/project/useUpdateProject.tsx
@@ -2,7 +2,6 @@ import {useMutation, useQueryClient} from '@tanstack/react-query';
 
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {Project} from 'sentry/types/project';
-import type {ApiResponse} from 'sentry/utils/api/apiFetch';
 import {makeDetailedProjectQueryKey} from 'sentry/utils/project/useDetailedProject';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -30,7 +29,7 @@ export function useUpdateProject(project: Project) {
 
   return useMutation<Project, Error, Variables, Context>({
     onMutate: (data: Variables) => {
-      const fromCache = queryClient.getQueryData<ApiResponse<Project>>(queryKey)?.json;
+      const fromCache = queryClient.getQueryData(queryKey)?.json;
       const fromStore = ProjectsStore.getById(project.id);
       const fromProp = project;
 
@@ -62,7 +61,7 @@ export function useUpdateProject(project: Project) {
 
       // Update caches optimistically
       ProjectsStore.onUpdateSuccess(updatedProject);
-      queryClient.setQueryData<ApiResponse<Project>>(queryKey, prev => ({
+      queryClient.setQueryData(queryKey, prev => ({
         headers: prev?.headers ?? {},
         json: updatedProject,
       }));
@@ -79,7 +78,7 @@ export function useUpdateProject(project: Project) {
     onError: (_error, _variables, context) => {
       if (context?.previousProject) {
         ProjectsStore.onUpdateSuccess(context.previousProject);
-        queryClient.setQueryData<ApiResponse<Project>>(queryKey, prev => ({
+        queryClient.setQueryData(queryKey, prev => ({
           headers: prev?.headers ?? {},
           json: context.previousProject,
         }));

--- a/static/app/utils/queryClient.tsx
+++ b/static/app/utils/queryClient.tsx
@@ -148,6 +148,7 @@ export function getApiQueryData<TResponseData>(
   if (version !== 'v1') {
     return undefined;
   }
+  // eslint-disable-next-line @sentry/no-query-data-type-parameters
   return queryClient.getQueryData<ApiResult<TResponseData>>(queryKey)?.[0];
 }
 
@@ -165,6 +166,7 @@ export function setApiQueryData<TResponseData>(
   if (version !== 'v1') {
     return undefined;
   }
+  // eslint-disable-next-line @sentry/no-query-data-type-parameters
   const updateResult = queryClient.setQueryData<ApiResult<TResponseData>>(
     queryKey,
     previous => {

--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -411,6 +411,7 @@ type QueryKey = [
  * query cache (same snapshot React Query will use for this key).
  */
 function maxPagesForLogsInfiniteQuery(client: QueryClient, queryKey: QueryKey): number {
+  // eslint-disable-next-line @sentry/no-query-data-type-parameters
   const cached = client.getQueryData<InfiniteData<ApiResult<EventsLogsResult>>>(queryKey);
   const rows =
     cached?.pages?.reduce((n, page) => n + (page[0]?.data?.length ?? 0), 0) ?? 0;

--- a/static/app/views/issueDetails/groupEventAttachments/useDeleteGroupEventAttachment.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/useDeleteGroupEventAttachment.tsx
@@ -43,9 +43,9 @@ export function useDeleteGroupEventAttachment() {
 
       await queryClient.cancelQueries({queryKey});
 
-      const previous = queryClient.getQueryData<ApiResponse<IssueAttachment[]>>(queryKey);
+      const previous = queryClient.getQueryData(queryKey);
 
-      queryClient.setQueryData<ApiResponse<IssueAttachment[]>>(queryKey, oldData => {
+      queryClient.setQueryData(queryKey, oldData => {
         if (!oldData) {
           return oldData;
         }

--- a/static/app/views/settings/dynamicSampling/utils/useSamplingProjectRates.tsx
+++ b/static/app/views/settings/dynamicSampling/utils/useSamplingProjectRates.tsx
@@ -82,6 +82,7 @@ export function useUpdateSamplingProjectRates() {
     },
     onSuccess: data => {
       const queryKey = getQueryKey(organization);
+      // eslint-disable-next-line @sentry/no-query-data-type-parameters
       const previous = queryClient.getQueryData<SamplingProjectRate[]>(queryKey);
       if (!previous) {
         return;

--- a/static/app/views/settings/projectGeneralSettings/index.tsx
+++ b/static/app/views/settings/projectGeneralSettings/index.tsx
@@ -35,7 +35,6 @@ import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import type {Organization} from 'sentry/types/organization';
 import type {PlatformKey, Project} from 'sentry/types/project';
-import type {ApiResponse} from 'sentry/utils/api/apiFetch';
 import {handleXhrErrorResponse} from 'sentry/utils/handleXhrErrorResponse';
 import {makeDetailedProjectQueryKey} from 'sentry/utils/project/useDetailedProject';
 import {recreateRoute} from 'sentry/utils/recreateRoute';
@@ -292,7 +291,7 @@ export function ProjectGeneralSettings({project, onChangeSlug}: Props) {
     apiMethod: 'PUT' as const,
     apiEndpoint: endpoint,
     onSubmitSuccess: resp => {
-      queryClient.setQueryData<ApiResponse<Project>>(projectSettingsQueryKey, prev => ({
+      queryClient.setQueryData(projectSettingsQueryKey, prev => ({
         headers: prev?.headers ?? {},
         json: resp,
       }));

--- a/static/app/views/settings/projectSecurityHeaders/csp.tsx
+++ b/static/app/views/settings/projectSecurityHeaders/csp.tsx
@@ -15,7 +15,6 @@ import {PanelHeader} from 'sentry/components/panels/panelHeader';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
 import type {Project, ProjectKey} from 'sentry/types/project';
-import type {ApiResponse} from 'sentry/utils/api/apiFetch';
 import {
   makeDetailedProjectQueryKey,
   useDetailedProject,
@@ -115,7 +114,7 @@ export default function ProjectCspReports() {
         data: {options: data},
       }),
     onSuccess: (updatedProject: Project) => {
-      queryClient.setQueryData<ApiResponse<Project>>(projectQueryKey, prev => {
+      queryClient.setQueryData(projectQueryKey, prev => {
         const previous = prev?.json;
         const merged = previous
           ? {

--- a/static/app/views/settings/projectSeer/index.tsx
+++ b/static/app/views/settings/projectSeer/index.tsx
@@ -36,7 +36,6 @@ import {DataCategoryExact} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import type {ApiResponse} from 'sentry/utils/api/apiFetch';
 import {makeDetailedProjectQueryKey} from 'sentry/utils/project/useDetailedProject';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useUser} from 'sentry/utils/useUser';
@@ -217,7 +216,7 @@ function ProjectSeerGeneralForm({project}: {project: Project}) {
         orgSlug: organization.slug,
         projectSlug: project.slug,
       });
-      queryClient.setQueryData<ApiResponse<Project>>(projectSettingsQueryKey, prev => ({
+      queryClient.setQueryData(projectSettingsQueryKey, prev => ({
         headers: prev?.headers ?? {},
         json: resp,
       }));

--- a/static/eslint/eslintPluginSentry/index.ts
+++ b/static/eslint/eslintPluginSentry/index.ts
@@ -3,6 +3,7 @@ import {noDefaultExports} from './no-default-exports';
 import {noDigitsInTn} from './no-digits-in-tn';
 import {noDynamicTranslations} from './no-dynamic-translations';
 import {noFlagComments} from './no-flag-comments';
+import {noQueryDataTypeParameters} from './no-query-data-type-parameters';
 import {noStaticTranslations} from './no-static-translations';
 import {noStyledShortcut} from './no-styled-shortcut';
 import {noUnnecessaryTypeAnnotation} from './no-unnecessary-type-annotation';
@@ -15,6 +16,7 @@ export const rules = {
   'no-digits-in-tn': noDigitsInTn,
   'no-dynamic-translations': noDynamicTranslations,
   'no-flag-comments': noFlagComments,
+  'no-query-data-type-parameters': noQueryDataTypeParameters,
   'no-static-translations': noStaticTranslations,
   'no-styled-shortcut': noStyledShortcut,
   'no-unnecessary-type-annotation': noUnnecessaryTypeAnnotation,

--- a/static/eslint/eslintPluginSentry/no-query-data-type-parameters.spec.ts
+++ b/static/eslint/eslintPluginSentry/no-query-data-type-parameters.spec.ts
@@ -1,0 +1,34 @@
+import {RuleTester} from '@typescript-eslint/rule-tester';
+
+import {noQueryDataTypeParameters} from './no-query-data-type-parameters';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-query-data-type-parameters', noQueryDataTypeParameters, {
+  valid: [
+    {code: 'queryClient.getQueryData(queryKey);'},
+    {code: 'queryClient.setQueryData(queryKey, updater);'},
+    {code: 'client.getQueryData(queryKey);'},
+    {code: 'queryClient.invalidateQueries<Foo>({queryKey});'},
+    {code: 'getQueryData<Foo>(queryKey);'},
+    {code: 'setQueryData<Foo>(queryKey, updater);'},
+  ],
+  invalid: [
+    {
+      code: 'queryClient.getQueryData<Foo>(queryKey);',
+      errors: [{messageId: 'noTypeParameters', data: {method: 'getQueryData'}}],
+    },
+    {
+      code: 'queryClient.setQueryData<Foo>(queryKey, updater);',
+      errors: [{messageId: 'noTypeParameters', data: {method: 'setQueryData'}}],
+    },
+    {
+      code: 'client.getQueryData<Foo>(queryKey);',
+      errors: [{messageId: 'noTypeParameters', data: {method: 'getQueryData'}}],
+    },
+    {
+      code: 'queryClient.setQueryData<ApiResponse<Project>>(queryKey, prev => prev);',
+      errors: [{messageId: 'noTypeParameters', data: {method: 'setQueryData'}}],
+    },
+  ],
+});

--- a/static/eslint/eslintPluginSentry/no-query-data-type-parameters.ts
+++ b/static/eslint/eslintPluginSentry/no-query-data-type-parameters.ts
@@ -1,0 +1,41 @@
+import {AST_NODE_TYPES, ESLintUtils} from '@typescript-eslint/utils';
+
+export const noQueryDataTypeParameters = ESLintUtils.RuleCreator.withoutDocs({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow explicit type parameters on queryClient.getQueryData and queryClient.setQueryData',
+    },
+    schema: [],
+    messages: {
+      noTypeParameters:
+        'Do not pass explicit type parameters to {{method}}. Use apiOptions or queryOptions — they infer the correct type from the query key.',
+    },
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (!node.typeArguments || node.typeArguments.params.length === 0) {
+          return;
+        }
+        const {callee} = node;
+        if (
+          callee.type !== AST_NODE_TYPES.MemberExpression ||
+          callee.property.type !== AST_NODE_TYPES.Identifier
+        ) {
+          return;
+        }
+        const method = callee.property.name;
+        if (method !== 'getQueryData' && method !== 'setQueryData') {
+          return;
+        }
+        context.report({
+          node: node.typeArguments,
+          messageId: 'noTypeParameters',
+          data: {method},
+        });
+      },
+    };
+  },
+});

--- a/static/gsApp/utils/promotionUtils.tsx
+++ b/static/gsApp/utils/promotionUtils.tsx
@@ -58,6 +58,7 @@ export async function claimAvailablePromotion({
   }
 
   // note this does not work but but we avoid the problem by mutating the input state
+  // eslint-disable-next-line @sentry/no-query-data-type-parameters
   queryClient.setQueryData<PromotionData>(
     createPromotionCheckQueryKey(organization.slug),
     {

--- a/static/gsApp/views/seerAutomation/components/repoDetails/repoDetailsForm.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoDetails/repoDetailsForm.tsx
@@ -44,6 +44,7 @@ export function RepoDetailsForm({organization, repoWithSettings}: Props) {
     },
     onMutate: (data: {codeReviewTriggers?: string[]; enabledCodeReview?: boolean}) => {
       const previous =
+        // eslint-disable-next-line @sentry/no-query-data-type-parameters
         queryClient.getQueryData<
           [RepositoryWithSettings, string | undefined, Response | undefined]
         >(repoQueryKey);


### PR DESCRIPTION
One of the biggest advantages of `queryOptions` and our own abstraction over it, `apiOptions`, is that result data can be inferred from the `queryFn` of the options, which means `getQueryData` and `setQueryData` get type inference and don’t need manual type parameters being passed to them, which is just a type assertion in disguise.

However, AI seems to still add those to most call-sides, so I’ve made a lint rule that disallows this. For situations where we still pass “raw” queryKeys (e.g. when used with `useApiQuery`), I’ve disabled the rule. The plan is to migrate them over to `apiOptions`.