### PR TITLE
fix(drawer): extend panel background past right edge

### DIFF
--- a/static/app/components/core/drawer/components.tsx
+++ b/static/app/components/core/drawer/components.tsx
@@ -229,6 +229,14 @@ const DrawerSlidePanel = styled(SlideOverPanel)`
   pointer-events: auto;
   height: 100%;
 
+  /* Extend the panel's background 20px past its right edge so the bounce-in
+     overshoot doesn't briefly expose the page beneath. A box-shadow is used
+     (vs. a pseudo-element) because the panel's own overflow: auto would clip
+     anything positioned outside its bounds. */
+  box-shadow:
+    20px 0 0 ${p => p.theme.tokens.background.overlay},
+    ${p => p.theme.shadow.high};
+
   --drawer-width: ${DEFAULT_WIDTH_PERCENT}%;
   --drawer-min-width: ${MIN_WIDTH_PERCENT}%;
   --drawer-max-width: ${MAX_WIDTH_PERCENT}%;


### PR DESCRIPTION
## Summary

The drawer's slide-in spring overshoots its resting position, briefly
pulling the panel's right edge left of the viewport and exposing the
page behind. Adds a 20px solid `box-shadow` on `DrawerSlidePanel` that
extends the panel's background into that gap so it stays covered
through the bounce.