### PR TITLE
fix(discover): remove my /result page redirect hacks

### DIFF
--- a/static/app/views/discover/homepage.spec.tsx
+++ b/static/app/views/discover/homepage.spec.tsx
@@ -18,28 +18,6 @@ import {DEFAULT_EVENT_VIEW} from 'sentry/views/discover/results/data';
 
 import Homepage from './homepage';
 
-describe('Discover > HomepageContainer', () => {
-  it('redirects to results page when organization lacks discover-query feature', () => {
-    const org = OrganizationFixture({features: ['discover-basic']});
-    const {router} = render(<Homepage />, {
-      initialRouterConfig: {
-        location: {
-          pathname: `/organizations/${org.slug}/explore/discover/homepage/`,
-          query: {query: 'event.type:error', dataset: 'errors'},
-        },
-        route: '/organizations/:orgId/explore/discover/homepage/',
-      },
-      organization: org,
-    });
-
-    expect(router.location.pathname).toBe(
-      `/organizations/${org.slug}/explore/discover/results/`
-    );
-    expect(router.location.search).toContain('query=event.type%3Aerror');
-    expect(router.location.search).toContain('dataset=errors');
-  });
-});
-
 describe('Discover > Homepage', () => {
   const features = ['discover-query'];
   let organization: ReturnType<typeof OrganizationFixture>;

--- a/static/app/views/discover/homepage.tsx
+++ b/static/app/views/discover/homepage.tsx
@@ -10,7 +10,6 @@ import {
 } from 'sentry/components/pageFilters/parse';
 import {getPageFilterStorage} from 'sentry/components/pageFilters/persistence';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import {Redirect} from 'sentry/components/redirect';
 import type {Organization, SavedQuery} from 'sentry/types/organization';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {EventView} from 'sentry/utils/discover/eventView';
@@ -22,7 +21,6 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {usePrevious} from 'sentry/utils/usePrevious';
 import {getSavedQueryWithDataset} from 'sentry/views/discover/savedQuery/utils';
 
-import {makeDiscoverPathname} from './pathnames';
 import {Results} from './results';
 
 function makeDiscoverHomepageQueryKey(organization: Organization): ApiQueryKey {
@@ -132,17 +130,6 @@ function Homepage() {
 }
 
 export default function HomepageContainer() {
-  const organization = useOrganization();
-  const location = useLocation();
-
-  if (!organization.features.includes('discover-query')) {
-    return (
-      <Redirect
-        to={`${makeDiscoverPathname({path: '/results/', organization})}${location.search}${location.hash}`}
-      />
-    );
-  }
-
   return (
     <PageFiltersContainer skipInitializeUrlParams>
       <Homepage />

--- a/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.spec.tsx
+++ b/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.spec.tsx
@@ -90,32 +90,4 @@ describe('ExploreSecondaryNavigation', () => {
       '/organizations/org-slug/explore/discover/homepage/'
     );
   });
-
-  it('links Discover to results when discover-query is disabled', () => {
-    const {organization: orgWithoutQuery} = initializeOrg({
-      organization: {
-        features: ['performance-view', 'visibility-explore-view', 'discover-basic'],
-      },
-    });
-
-    render(
-      <PrimaryNavigationContextProvider>
-        <SecondaryNavigationContextProvider>
-          <Navigation />
-          <div id="main" />
-        </SecondaryNavigationContextProvider>
-      </PrimaryNavigationContextProvider>,
-      {
-        organization: orgWithoutQuery,
-        initialRouterConfig: {
-          location: {pathname: '/organizations/org-slug/explore/traces/'},
-        },
-      }
-    );
-
-    expect(screen.getByRole('link', {name: 'Discover'})).toHaveAttribute(
-      'href',
-      '/organizations/org-slug/explore/discover/results/'
-    );
-  });
 });

--- a/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
@@ -64,11 +64,6 @@ export function ExploreSecondaryNavigation() {
     });
   }, [organization, hasMetricsSupportedPlatform, userPlatforms.length]);
 
-  const hasDiscoverQueryFeature = useMemo(
-    () => organization.features.includes('discover-query'),
-    [organization]
-  );
-
   return (
     <Fragment>
       <SecondaryNavigation.Header>{t('Explore')}</SecondaryNavigation.Header>
@@ -128,11 +123,7 @@ export function ExploreSecondaryNavigation() {
             >
               <SecondaryNavigation.ListItem>
                 <SecondaryNavigation.Link
-                  to={
-                    hasDiscoverQueryFeature
-                      ? `${baseUrl}/discover/homepage/`
-                      : `${baseUrl}/discover/results/`
-                  }
+                  to={`${baseUrl}/discover/homepage/`}
                   activeTo={`${baseUrl}/discover/`}
                   analyticsItemName="explore_discover"
                 >


### PR DESCRIPTION
i put in some hacks to make sure discover would load for users without the `discover-query` flag because i wasn't sure what the root cause was. Evan found the root cause and fixed it in [this PR](https://github.com/getsentry/sentry/pull/113911) (thanks Evan!). I tested the changes locally and this fix means we don't need my hacks lol so i'm removing that code.