### PR TITLE
feat(integrations): Expose SCM toggles in integration config UI

### DIFF
--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -524,6 +524,31 @@ class GitHubIntegration(
                     "Your organization does not have access to this feature"
                 )
 
+        # PR-comment and missing-member toggles are self-serveable regardless of
+        # issue-sync entitlement, so they are appended after the gating loop.
+        config.extend(
+            [
+                {
+                    "name": "pr_comments",
+                    "type": "boolean",
+                    "label": _("Enable Comments on Suspect Pull Requests"),
+                    "help": _(
+                        "Allow Sentry to comment on recent pull requests suspected of causing issues."
+                    ),
+                    "default": False,
+                },
+                {
+                    "name": "nudge_invite",
+                    "type": "boolean",
+                    "label": _("Enable Missing Member Detection"),
+                    "help": _(
+                        "Allow Sentry to detect users committing to your GitHub repositories that are not part of your Sentry organization."
+                    ),
+                    "default": False,
+                },
+            ]
+        )
+
         return config
 
     def update_organization_config(self, data: MutableMapping[str, Any]) -> None:

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -350,6 +350,20 @@ class GitlabIntegration(
                     "Your organization does not have access to this feature"
                 )
 
+        # PR-comment toggle is self-serveable regardless of issue-sync
+        # entitlement, so it is appended after the gating loop.
+        config.append(
+            {
+                "name": "pr_comments",
+                "type": "boolean",
+                "label": _("Enable Comments on Suspect Pull Requests"),
+                "help": _(
+                    "Allow Sentry to comment on recent pull requests suspected of causing issues."
+                ),
+                "default": False,
+            }
+        )
+
         return config
 
     def update_organization_config(self, data: MutableMapping[str, Any]) -> None:

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -1295,7 +1295,14 @@ class GitHubIntegrationTest(IntegrationTestCase):
             "sync_forward_assignment",
             "resolution_strategy",
             "sync_comments",
+            "pr_comments",
+            "nudge_invite",
         ]
+        # PR-comment / nudge-invite must never be disabled by the
+        # integrations-issue-sync gating.
+        for field in fields:
+            if field["name"] in ("pr_comments", "nudge_invite"):
+                assert "disabled" not in field
 
     @responses.activate
     def test_update_organization_config(self) -> None:

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -235,7 +235,11 @@ class GitlabIssueSyncTest(GitLabTestCase):
             "sync_comments",
             "sync_status_reverse",
             "resolution_strategy",
+            "pr_comments",
         ]
+        # pr_comments must not be gated behind integrations-issue-sync.
+        pr_field = next(f for f in fields if f["name"] == "pr_comments")
+        assert "disabled" not in pr_field
 
     @responses.activate
     def test_update_organization_config(self) -> None:


### PR DESCRIPTION
Part of Phase 3 of VDY-110. Adds pr_comments (GitHub + GitLab) and nudge_invite (GitHub only) descriptors to `get_organization_config()`, so each install exposes its own toggles in the standard integration config form rather than through org-level options.

Both descriptors are appended after the integrations-issue-sync disabling loop — PR-comment and missing-member detection are self-serveable regardless of issue-sync entitlement, so we intentionally skip the feature gate applied to the other config fields.

Ref: [VDY-113: Phase 3: Move SCM settings UI to per-install integration config](https://linear.app/getsentry/issue/VDY-113/phase-3-move-scm-settings-ui-to-per-install-integration-config)

## Migration phases

- ● Phase 1 — Backfill existing OIs: [#113841](https://github.com/getsentry/sentry/pull/113841) (merged)
- ● Phase 1 — Backfill cross-silo fix: [#113908](https://github.com/getsentry/sentry/pull/113908)
- ● Phase 1 — Dual-write SCM toggles: [#113842](https://github.com/getsentry/sentry/pull/113842)
- ● Phase 2 — Read from OI config behind flag: [#113864](https://github.com/getsentry/sentry/pull/113864)
- ○ Phase 3 — Expose toggles in per-install UI: _(This PR)_
- ○ Phase 3 — Remove legacy detail-view toggles (frontend): upcoming
- ○ Phase 3 — Drop SCM toggle fields from PUT endpoint: upcoming
- ○ Phase 4 — Remove legacy code paths: upcoming