### PR TITLE
ref(integrations): Remove legacy GitHub/GitLab feature toggles from detail view

### DIFF
--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.spec.tsx
@@ -4,12 +4,11 @@ import {GitLabIntegrationFixture} from 'sentry-fixture/gitlabIntegration';
 import {GitLabIntegrationProviderFixture} from 'sentry-fixture/gitlabIntegrationProvider';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import IntegrationDetailedView from 'sentry/views/settings/organizationIntegrations/integrationDetailedView';
 
 describe('IntegrationDetailedView', () => {
-  const ENDPOINT = '/organizations/org-slug/';
   const organization = OrganizationFixture({
     access: ['org:integrations', 'org:write'],
   });
@@ -207,95 +206,22 @@ describe('IntegrationDetailedView', () => {
     expect(await screen.findByRole('button', {name: 'Configure'})).toBeEnabled();
   });
 
-  it('shows features tab for github only', async () => {
+  it('does not show features tab for github', async () => {
     render(<IntegrationDetailedView />, {
       initialRouterConfig: createRouterConfig('github'),
       organization,
     });
-    expect(await screen.findByText('features')).toBeInTheDocument();
+    expect(await screen.findByText('overview')).toBeInTheDocument();
+    expect(screen.queryByText('features')).not.toBeInTheDocument();
   });
 
-  it('cannot enable PR bot without GitHub integration', async () => {
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/integrations/`,
-      match: [MockApiClient.matchQuery({provider_key: 'github', includeConfig: 0})],
-      body: [],
-    });
-    render(<IntegrationDetailedView />, {
-      initialRouterConfig: createRouterConfig('github'),
-      organization,
-    });
-    await userEvent.click(await screen.findByText('features'));
-
-    expect(
-      screen.getByRole('checkbox', {name: /Enable Comments on Suspect Pull Requests/})
-    ).toBeDisabled();
-  });
-
-  it('can enable github features', async () => {
-    render(<IntegrationDetailedView />, {
-      initialRouterConfig: createRouterConfig('github'),
-      organization,
-    });
-    await userEvent.click(await screen.findByText('features'));
-
-    const mock = MockApiClient.addMockResponse({
-      url: ENDPOINT,
-      method: 'PUT',
-    });
-
-    await userEvent.click(
-      screen.getByRole('checkbox', {name: /Enable Comments on Suspect Pull Requests/})
-    );
-
-    await waitFor(() => {
-      expect(mock).toHaveBeenCalledWith(
-        ENDPOINT,
-        expect.objectContaining({
-          data: {githubPRBot: true},
-        })
-      );
-    });
-
-    await userEvent.click(
-      screen.getByRole('checkbox', {name: /Enable Missing Member Detection/})
-    );
-
-    await waitFor(() => {
-      expect(mock).toHaveBeenCalledWith(
-        ENDPOINT,
-        expect.objectContaining({
-          data: {githubNudgeInvite: true},
-        })
-      );
-    });
-  });
-
-  it('can enable gitlab features', async () => {
+  it('does not show features tab for gitlab', async () => {
     render(<IntegrationDetailedView />, {
       initialRouterConfig: createRouterConfig('gitlab'),
       organization,
     });
-
-    await userEvent.click(await screen.findByText('features'));
-
-    const mock = MockApiClient.addMockResponse({
-      url: ENDPOINT,
-      method: 'PUT',
-    });
-
-    await userEvent.click(
-      screen.getByRole('checkbox', {name: /Enable Comments on Suspect Pull Requests/})
-    );
-
-    await waitFor(() => {
-      expect(mock).toHaveBeenCalledWith(
-        ENDPOINT,
-        expect.objectContaining({
-          data: {gitlabPRBot: true},
-        })
-      );
-    });
+    expect(await screen.findByText('overview')).toBeInTheDocument();
+    expect(screen.queryByText('features')).not.toBeInTheDocument();
   });
 
   it('renders alerts without crashing when variant is not provided', async () => {

--- a/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationDetailedView.tsx
@@ -49,7 +49,7 @@ import {IntegrationButton} from 'sentry/views/settings/organizationIntegrations/
 import {IntegrationContext} from 'sentry/views/settings/organizationIntegrations/integrationContext';
 
 // Show the features tab if the org has features for the integration
-const integrationFeatures = ['github', 'gitlab', 'slack'];
+const integrationFeatures = ['slack'];
 
 const FirstPartyIntegrationAlert = HookOrDefault({
   hookName: 'component:first-party-integration-alert',
@@ -64,15 +64,6 @@ const FirstPartyIntegrationAdditionalCTA = HookOrDefault({
 const slackFeaturesSchema = z.object({
   issueAlertsThreadFlag: z.boolean(),
   metricAlertsThreadFlag: z.boolean(),
-});
-
-const githubFeaturesSchema = z.object({
-  githubPRBot: z.boolean(),
-  githubNudgeInvite: z.boolean(),
-});
-
-const gitlabFeaturesSchema = z.object({
-  gitlabPRBot: z.boolean(),
 });
 
 function getOrgMutationOptions(organization: Organization) {
@@ -444,94 +435,6 @@ export default function IntegrationDetailedView() {
     const isDisabled = !hasOrgWrite || !hasIntegration;
 
     switch (provider?.key) {
-      case 'github':
-        return (
-          <FieldGroup>
-            <AutoSaveForm
-              name="githubPRBot"
-              schema={githubFeaturesSchema}
-              initialValue={organization.githubPRBot}
-              mutationOptions={orgMutationOptions}
-            >
-              {field => (
-                <field.Layout.Row
-                  label={t('Enable Comments on Suspect Pull Requests')}
-                  hintText={
-                    hasIntegration
-                      ? t(
-                          'Allow Sentry to comment on recent pull requests suspected of causing issues.'
-                        )
-                      : t('You must have a GitHub integration to enable this feature.')
-                  }
-                >
-                  <field.Switch
-                    checked={field.state.value}
-                    onChange={field.handleChange}
-                    disabled={isDisabled}
-                    aria-label={t('Enable Comments on Suspect Pull Requests')}
-                  />
-                </field.Layout.Row>
-              )}
-            </AutoSaveForm>
-            <AutoSaveForm
-              name="githubNudgeInvite"
-              schema={githubFeaturesSchema}
-              initialValue={organization.githubNudgeInvite}
-              mutationOptions={orgMutationOptions}
-            >
-              {field => (
-                <field.Layout.Row
-                  label={t('Enable Missing Member Detection')}
-                  hintText={
-                    hasIntegration
-                      ? t(
-                          'Allow Sentry to detect users committing to your GitHub repositories that are not part of your Sentry organization..'
-                        )
-                      : t('You must have a GitHub integration to enable this feature.')
-                  }
-                >
-                  <field.Switch
-                    checked={field.state.value}
-                    onChange={field.handleChange}
-                    disabled={isDisabled}
-                    aria-label={t('Enable Missing Member Detection')}
-                  />
-                </field.Layout.Row>
-              )}
-            </AutoSaveForm>
-          </FieldGroup>
-        );
-      case 'gitlab':
-        return (
-          <FieldGroup>
-            <AutoSaveForm
-              name="gitlabPRBot"
-              schema={gitlabFeaturesSchema}
-              initialValue={organization.gitlabPRBot}
-              mutationOptions={orgMutationOptions}
-            >
-              {field => (
-                <field.Layout.Row
-                  label={t('Enable Comments on Suspect Pull Requests')}
-                  hintText={
-                    hasIntegration
-                      ? t(
-                          'Allow Sentry to comment on recent pull requests suspected of causing issues.'
-                        )
-                      : t('You must have a GitLab integration to enable this feature.')
-                  }
-                >
-                  <field.Switch
-                    checked={field.state.value}
-                    onChange={field.handleChange}
-                    disabled={isDisabled}
-                    aria-label={t('Enable Comments on Suspect Pull Requests')}
-                  />
-                </field.Layout.Row>
-              )}
-            </AutoSaveForm>
-          </FieldGroup>
-        );
       case 'slack':
         return (
           <FieldGroup>


### PR DESCRIPTION
Part of Phase 3 of VDY-110. The PR-comment and missing-member toggles are now exposed in the per-install integration configuration form via the standard JSONForm descriptors (landed in the prior backend commit, [#113923](https://github.com/getsentry/sentry/pull/113923)). Drop the custom github/gitlab features tab on the integration detail page so the two code paths don't compete.

The slack case in the same switch stays — slack alert-thread flags are an out-of-scope anti-pattern tracked separately.

Ref: [VDY-113: Phase 3: Move SCM settings UI to per-install integration config](https://linear.app/getsentry/issue/VDY-113/phase-3-move-scm-settings-ui-to-per-install-integration-config)

## Migration phases

- ● Phase 1 — Backfill existing OIs: [#113841](https://github.com/getsentry/sentry/pull/113841) (merged)
- ● Phase 1 — Backfill cross-silo fix: [#113908](https://github.com/getsentry/sentry/pull/113908)
- ● Phase 1 — Dual-write SCM toggles: [#113842](https://github.com/getsentry/sentry/pull/113842)
- ● Phase 2 — Read from OI config behind flag: [#113864](https://github.com/getsentry/sentry/pull/113864)
- ● Phase 3 — Expose toggles in per-install UI: [#113923](https://github.com/getsentry/sentry/pull/113923)
- ○ Phase 3 — Remove legacy detail-view toggles (frontend): _(This PR)_
- ○ Phase 3 — Drop SCM toggle fields from PUT endpoint: upcoming
- ○ Phase 4 — Remove legacy code paths: upcoming