### PR TITLE
feat(integrations): Drop SCM toggle fields from the organization details endpoint

### DIFF
--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -55,8 +55,6 @@ from sentry.constants import (
     ENABLE_SEER_CODING_DEFAULT,
     ENABLED_CONSOLE_PLATFORMS_DEFAULT,
     EVENTS_MEMBER_ADMIN_DEFAULT,
-    GITHUB_COMMENT_BOT_DEFAULT,
-    GITLAB_COMMENT_BOT_DEFAULT,
     HIDE_AI_FEATURES_DEFAULT,
     INGEST_THROUGH_TRUSTED_RELAYS_ONLY_DEFAULT,
     ISSUE_ALERTS_THREAD_DEFAULT,
@@ -231,24 +229,6 @@ ORG_OPTIONS = (
         HIDE_AI_FEATURES_DEFAULT,
     ),
     (
-        "githubPRBot",
-        "sentry:github_pr_bot",
-        bool,
-        GITHUB_COMMENT_BOT_DEFAULT,
-    ),
-    (
-        "githubNudgeInvite",
-        "sentry:github_nudge_invite",
-        bool,
-        GITHUB_COMMENT_BOT_DEFAULT,
-    ),
-    (
-        "gitlabPRBot",
-        "sentry:gitlab_pr_bot",
-        bool,
-        GITLAB_COMMENT_BOT_DEFAULT,
-    ),
-    (
         "issueAlertsThreadFlag",
         "sentry:issue_alerts_thread_flag",
         bool,
@@ -388,9 +368,6 @@ class OrganizationSerializer(BaseOrganizationSerializer):
     isEarlyAdopter = serializers.BooleanField(required=False)
     hideAiFeatures = serializers.BooleanField(required=False)
     codecovAccess = serializers.BooleanField(required=False)
-    githubNudgeInvite = serializers.BooleanField(required=False)
-    githubPRBot = serializers.BooleanField(required=False)
-    gitlabPRBot = serializers.BooleanField(required=False)
     issueAlertsThreadFlag = serializers.BooleanField(required=False)
     metricAlertsThreadFlag = serializers.BooleanField(required=False)
     require2FA = serializers.BooleanField(required=False)
@@ -1122,22 +1099,6 @@ Below is an example of a payload for a set of advanced data scrubbing rules for 
                                           }
                                           ```
                                           """,
-        required=False,
-    )
-
-    # github features
-    githubPRBot = serializers.BooleanField(
-        help_text="Specify `true` to allow Sentry to comment on recent pull requests suspected of causing issues. Requires a GitHub integration.",
-        required=False,
-    )
-    githubNudgeInvite = serializers.BooleanField(
-        help_text="Specify `true` to allow Sentry to detect users committing to your GitHub repositories that are not part of your Sentry organization. Requires a GitHub integration.",
-        required=False,
-    )
-
-    # gitlab features
-    gitlabPRBot = serializers.BooleanField(
-        help_text="Specify `true` to allow Sentry to comment on recent pull requests suspected of causing issues. Requires a GitLab integration.",
         required=False,
     )
 

--- a/tests/sentry/core/endpoints/test_organization_details.py
+++ b/tests/sentry/core/endpoints/test_organization_details.py
@@ -28,7 +28,6 @@ from sentry.constants import (
 from sentry.core.endpoints.organization_details import ERR_NO_2FA, ERR_SSO_ENABLED
 from sentry.deletions.models.scheduleddeletion import CellScheduledDeletion
 from sentry.dynamic_sampling.types import DynamicSamplingMode
-from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.authprovider import AuthProvider
 from sentry.models.avatars.organization_avatar import OrganizationAvatar
@@ -774,9 +773,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
             "allowSuperuserAccess": False,
             "allowMemberInvite": False,
             "hideAiFeatures": True,
-            "githubNudgeInvite": True,
-            "githubPRBot": True,
-            "gitlabPRBot": True,
             "allowSharedIssues": False,
             "enhancedPrivacy": True,
             "dataScrubber": True,
@@ -866,109 +862,30 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
         assert "to {}".format(data["eventsMemberAdmin"]) in log.data["eventsMemberAdmin"]
         assert "to {}".format(data["alertsMemberWrite"]) in log.data["alertsMemberWrite"]
         assert "to {}".format(data["hideAiFeatures"]) in log.data["hideAiFeatures"]
-        assert "to {}".format(data["githubPRBot"]) in log.data["githubPRBot"]
-        assert "to {}".format(data["githubNudgeInvite"]) in log.data["githubNudgeInvite"]
-        assert "to {}".format(data["gitlabPRBot"]) in log.data["gitlabPRBot"]
         assert "to {}".format(data["issueAlertsThreadFlag"]) in log.data["issueAlertsThreadFlag"]
         assert "to {}".format(data["metricAlertsThreadFlag"]) in log.data["metricAlertsThreadFlag"]
         assert "to Default Mode" in log.data["samplingMode"]
 
-    def test_scm_option_fans_out_to_organization_integration_config(self) -> None:
-        github = self.create_integration(
-            organization=self.organization, provider="github", external_id="gh-1"
-        )
-        gitlab = self.create_integration(
-            organization=self.organization, provider="gitlab", external_id="gl-1"
+    def test_scm_option_writes_are_silently_ignored(self) -> None:
+        """PUT with githubPRBot et al. must not raise; the fields are dropped."""
+        OrganizationOption.objects.set_value(
+            organization=self.organization, key="sentry:github_pr_bot", value=False
         )
 
-        # Freshly created integrations have no SCM-toggle config yet.
-        with assume_test_silo_mode_of(OrganizationIntegration):
-            github_oi = OrganizationIntegration.objects.get(
-                organization_id=self.organization.id, integration=github
-            )
-            gitlab_oi = OrganizationIntegration.objects.get(
-                organization_id=self.organization.id, integration=gitlab
-            )
-        assert github_oi.config.get("pr_comments") is None
-        assert github_oi.config.get("nudge_invite") is None
-        assert gitlab_oi.config.get("pr_comments") is None
-
-        with outbox_runner():
-            self.get_success_response(
-                self.organization.slug,
-                githubPRBot=True,
-                githubNudgeInvite=True,
-                gitlabPRBot=True,
-            )
-
-        with assume_test_silo_mode_of(OrganizationIntegration):
-            github_oi = OrganizationIntegration.objects.get(
-                organization_id=self.organization.id, integration=github
-            )
-            gitlab_oi = OrganizationIntegration.objects.get(
-                organization_id=self.organization.id, integration=gitlab
-            )
-
-        assert github_oi.config.get("pr_comments") is True
-        assert github_oi.config.get("nudge_invite") is True
-        assert gitlab_oi.config.get("pr_comments") is True
-        # GitLab has no nudge_invite key; toggle must not leak across providers.
-        assert "nudge_invite" not in gitlab_oi.config
-
-    def test_scm_option_fanout_only_touches_active_integrations(self) -> None:
-        active = self.create_integration(
-            organization=self.organization, provider="github", external_id="gh-active"
-        )
-        disabled = self.create_integration(
-            organization=self.organization,
-            provider="github",
-            external_id="gh-disabled",
-            oi_params={"status": ObjectStatus.DISABLED},
+        self.get_success_response(
+            self.organization.slug,
+            githubPRBot=True,
+            githubNudgeInvite=True,
+            gitlabPRBot=True,
         )
 
-        # Both integrations start with no pr_comments config.
-        with assume_test_silo_mode_of(OrganizationIntegration):
-            active_oi = OrganizationIntegration.objects.get(
-                organization_id=self.organization.id, integration=active
-            )
-            disabled_oi = OrganizationIntegration.objects.get(
-                organization_id=self.organization.id, integration=disabled
-            )
-        assert active_oi.config.get("pr_comments") is None
-        assert disabled_oi.config.get("pr_comments") is None
-
-        with outbox_runner():
-            self.get_success_response(self.organization.slug, githubPRBot=True)
-
-        with assume_test_silo_mode_of(OrganizationIntegration):
-            active_oi = OrganizationIntegration.objects.get(
-                organization_id=self.organization.id, integration=active
-            )
-            disabled_oi = OrganizationIntegration.objects.get(
-                organization_id=self.organization.id, integration=disabled
-            )
-
-        assert active_oi.config.get("pr_comments") is True
-        assert disabled_oi.config.get("pr_comments") is None
-
-    def test_scm_option_fanout_preserves_other_config_keys(self) -> None:
-        integration = self.create_integration(
-            organization=self.organization,
-            provider="github",
-            external_id="gh-keeps",
-            oi_params={"config": {"some_other_setting": "kept"}},
-        )
-
-        with outbox_runner():
-            self.get_success_response(self.organization.slug, githubPRBot=True)
-
-        with assume_test_silo_mode_of(OrganizationIntegration):
-            oi = OrganizationIntegration.objects.get(
-                organization_id=self.organization.id, integration=integration
-            )
-
-        assert oi.config.get("some_other_setting") == "kept"
-        assert oi.config.get("pr_comments") is True
+        options = {
+            o.key: o.value
+            for o in OrganizationOption.objects.filter(organization=self.organization)
+        }
+        assert options.get("sentry:github_pr_bot") is False
+        assert "sentry:github_nudge_invite" not in options
+        assert "sentry:gitlab_pr_bot" not in options
 
     def test_scm_serializer_derived_from_oi_config_when_flag_on(self) -> None:
         self.create_integration(


### PR DESCRIPTION
Part of Phase 3 of VDY-110. The `githubPRBot` / `githubNudgeInvite` / `gitlabPRBot` fields on `PUT /organizations/{slug}/` backed the legacy integration-detail UI that was removed in the prior commit ([#113924](https://github.com/getsentry/sentry/pull/113924)). Every install's toggles now live on `OrganizationIntegration.config` and are edited through the per-integration config endpoint.

- Remove the three entries from `ORG_OPTIONS` so the endpoint no longer writes to `OrganizationOption` for them.
- Drop the three `BooleanField` declarations on `OrganizationSerializer` and the `@extend_schema` docs so the OpenAPI spec stops advertising fields the backend no longer accepts.
- Drop the (now unused) `GITHUB_COMMENT_BOT_DEFAULT` / `GITLAB_COMMENT_BOT_DEFAULT` imports.

`PUT` bodies that still include these fields are silently dropped (DRF unknown-field default). The derived read-side fields on the response continue to exist — the missing-member invite banner still reads `githubNudgeInvite` — and will be audited/removed in Phase 4.

Ref: [VDY-113: Phase 3: Move SCM settings UI to per-install integration config](https://linear.app/getsentry/issue/VDY-113/phase-3-move-scm-settings-ui-to-per-install-integration-config)

## Migration phases

- ● Phase 1 — Backfill existing OIs: [#113841](https://github.com/getsentry/sentry/pull/113841) (merged)
- ● Phase 1 — Backfill cross-silo fix: [#113908](https://github.com/getsentry/sentry/pull/113908)
- ● Phase 1 — Dual-write SCM toggles: [#113842](https://github.com/getsentry/sentry/pull/113842)
- ● Phase 2 — Read from OI config behind flag: [#113864](https://github.com/getsentry/sentry/pull/113864)
- ● Phase 3 — Expose toggles in per-install UI: [#113923](https://github.com/getsentry/sentry/pull/113923)
- ● Phase 3 — Remove legacy detail-view toggles (frontend): [#113924](https://github.com/getsentry/sentry/pull/113924)
- ○ Phase 3 — Drop SCM toggle fields from PUT endpoint: _(This PR)_
- ○ Phase 4 — Remove legacy code paths: upcoming