### PR TITLE
fix(typing): guard None options in ReconnectingMemcache

### DIFF
--- a/src/sentry/cache/backends/reconnectingmemcache.py
+++ b/src/sentry/cache/backends/reconnectingmemcache.py
@@ -66,7 +66,7 @@ class ReconnectingMemcache(PyMemcacheCache):
                 state = None
 
         if state is None:
-            client = self._class(self.client_servers, **self._options)  # type: ignore[arg-type]
+            client = self._class(self.client_servers, **(self._options or {}))
             state = _BackendState(
                 thread_id=current_tid,
                 created_at=time.time(),


### PR DESCRIPTION
## Summary

\`PyMemcacheCache._options\` is typed \`dict | None\` but \`**self._options\` would explode at runtime on \`None\`. Fall back to \`{}\`, which also lets us drop the \`# type: ignore[arg-type]\` that #113419 added.

Agent transcript: https://claudescope.sentry.dev/share/ZoHjMlN-lDWKU2242qjXGR-0l_UDipLzt6dZKGatk3Q