### PR TITLE
docs(typing): annotate save_team_assignments ignore with FIXME

### DIFF
--- a/src/sentry/core/endpoints/organization_member_details.py
+++ b/src/sentry/core/endpoints/organization_member_details.py
@@ -312,6 +312,8 @@ class OrganizationMemberDetailsEndpoint(OrganizationMemberEndpoint):
                 )
 
         if team_roles:
+            # FIXME: when organizations:team-roles is disabled, team_roles contains
+            # (team, None) tuples, which doesn't match save_team_assignments' signature.
             diff = save_team_assignments(member, None, team_roles)  # type: ignore[arg-type]
         else:
             diff = save_team_assignments(member, teams)


### PR DESCRIPTION
## Summary

Adds a FIXME comment above the \`# type: ignore[arg-type]\` on \`save_team_assignments(member, None, team_roles)\` documenting *why* the ignore is there: when \`organizations:team-roles\` is disabled, \`team_roles\` contains \`(team, None)\` tuples, which don't match the declared signature.

Placeholder follow-up — the real fix is to either normalize \`team_roles\` before the call or widen \`save_team_assignments\`' signature to accept the disabled-flag shape. Noting so a future engineer picking this up has context.

Drafted because it depends on #113419.

## Test plan

- [ ] \`.venv/bin/python -m mypy src/sentry/core/endpoints/organization_member_details.py\` passes


Agent transcript: https://claudescope.sentry.dev/share/gdEh4Y7Q4vCAzOLwqVqkl0EXROj79sQG-f7FEo87sPU