### PR TITLE
ref(typing): drop redundant cast in trace metric search type

### DIFF
--- a/src/sentry/search/eap/columns.py
+++ b/src/sentry/search/eap/columns.py
@@ -495,9 +495,7 @@ class TraceMetricAggregateDefinition(AggregateDefinition):
                 trace_metric.metric_unit in constants.DURATION_TYPE
                 or trace_metric.metric_unit in constants.SIZE_TYPE
             ):
-                resolved_search_type = cast(  # type: ignore[redundant-cast]
-                    constants.SearchType, trace_metric.metric_unit
-                )
+                resolved_search_type = trace_metric.metric_unit
 
         return ResolvedTraceMetricAggregate(
             public_alias=alias,


### PR DESCRIPTION
## Summary

Drop the \`cast(constants.SearchType, trace_metric.metric_unit)\` in \`TraceMetricAggregateDefinition\` — mypy 1.20.1 narrows via the \`x in DURATION_TYPE / SIZE_TYPE\` membership checks, so the cast is redundant under the new pin. Removes the \`# type: ignore[redundant-cast]\` that #113419 parked there.

Drafted because it depends on #113419.

## Test plan

- [ ] \`.venv/bin/python -m mypy src/sentry/search/eap/columns.py\` passes


Agent transcript: https://claudescope.sentry.dev/share/s6xsPeER6hqruuVvkujoI7fjuxD2y1wtbo-39lZR6yk