### PR TITLE
ref(typing): drop redundant cast on TraceMetric.metric_type

### DIFF
--- a/src/sentry/search/eap/trace_metrics/config.py
+++ b/src/sentry/search/eap/trace_metrics/config.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import cast
 
 from rest_framework.request import Request
 from sentry_protos.snuba.v1.trace_item_filter_pb2 import TraceItemFilter
@@ -119,6 +118,6 @@ def get_trace_metric_from_request(
 
     return TraceMetric(
         metric_name=metric_name,
-        metric_type=cast(TraceMetricType, metric_type),  # type: ignore[redundant-cast]
+        metric_type=metric_type,
         metric_unit=metric_unit,
     )


### PR DESCRIPTION
## Summary

Drop the \`cast(TraceMetricType, metric_type)\` in \`get_trace_metric_from_request\` — mypy 1.20.1 narrows \`metric_type\` via the preceding validation check, so the cast is redundant under the new pin. Removes the \`# type: ignore[redundant-cast]\` #113419 parked there.

Drafted because it depends on #113419.

## Test plan

- [ ] \`.venv/bin/python -m mypy src/sentry/search/eap/trace_metrics/config.py\` passes


Agent transcript: https://claudescope.sentry.dev/share/EAwMhN54lGJy_R4gjE03VMzhxtMKTejQyHgo_pGSXt4