### PR TITLE
ref(typing): drop redundant casts in resolve_measurement_value

### DIFF
--- a/src/sentry/search/events/builder/base.py
+++ b/src/sentry/search/events/builder/base.py
@@ -1200,9 +1200,9 @@ class BaseQueryBuilder:
 
     def resolve_measurement_value(self, unit: str, value: float) -> float:
         if unit in constants.SIZE_UNITS:
-            return constants.SIZE_UNITS[cast(constants.SizeUnit, unit)] * value  # type: ignore[redundant-cast]
+            return constants.SIZE_UNITS[unit] * value
         elif unit in constants.DURATION_UNITS:
-            return constants.DURATION_UNITS[cast(constants.DurationUnit, unit)] * value  # type: ignore[redundant-cast]
+            return constants.DURATION_UNITS[unit] * value
         return value
 
     def convert_aggregate_filter_to_condition(


### PR DESCRIPTION
## Summary

Drop the two \`cast(...)\` calls in \`BaseQueryBuilder.resolve_measurement_value\` — mypy 1.20.1 narrows \`unit\` via \`in SIZE_UNITS / DURATION_UNITS\` membership, so both casts are redundant under the new pin. Removes the pair of \`# type: ignore[redundant-cast]\` comments #113419 parked on these lines.

Drafted because it depends on #113419.

## Test plan

- [ ] \`.venv/bin/python -m mypy src/sentry/search/events/builder/base.py\` passes


Agent transcript: https://claudescope.sentry.dev/share/9knBZJ8vsizIvYD0SEHZTCEVeYi3SKsV51XS1gS1L0k