### PR TITLE
feat(cmdk): Add docs/documentation keywords to Help > Open Documentation action

### DIFF
--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -647,6 +647,7 @@ export function GlobalCommandPaletteActions() {
       >
         <CMDKAction
           display={{label: t('Open Documentation'), icon: <IconDocs />}}
+          keywords={['docs', 'documentation']}
           to="https://docs.sentry.io"
         />
         <CMDKAction


### PR DESCRIPTION
Adds `keywords` to the "Open Documentation" entry in the command palette's Help section so it more closely matches when users search for "docs" or "documentation".