### PR TITLE
feat(slack): Unfurl error-events dashboard widgets

### DIFF
--- a/src/sentry/integrations/slack/unfurl/dashboards.py
+++ b/src/sentry/integrations/slack/unfurl/dashboards.py
@@ -67,12 +67,13 @@ _TIMESERIES_DISPLAY_TYPES = {
     DashboardWidgetDisplayTypes.TOP_N: "area",
 }
 
-# Widget types that map to EAP trace-item datasets on the events-timeseries
-# endpoint. Other widget types (discover, issue, metrics, etc.) are skipped.
-_WIDGET_TYPE_TO_DATASET = {
-    DashboardWidgetTypes.SPANS: SupportedTraceItemType.SPANS,
-    DashboardWidgetTypes.LOGS: SupportedTraceItemType.LOGS,
-    DashboardWidgetTypes.TRACEMETRICS: SupportedTraceItemType.TRACEMETRICS,
+# Widget types that map to datasets on the events-timeseries endpoint. Other
+# widget types (discover, issue, metrics, transaction-like, etc.) are skipped.
+_WIDGET_TYPE_TO_DATASET: dict[int, str] = {
+    DashboardWidgetTypes.SPANS: SupportedTraceItemType.SPANS.value,
+    DashboardWidgetTypes.LOGS: SupportedTraceItemType.LOGS.value,
+    DashboardWidgetTypes.TRACEMETRICS: SupportedTraceItemType.TRACEMETRICS.value,
+    DashboardWidgetTypes.ERROR_EVENTS: "errors",
 }
 
 
@@ -234,7 +235,7 @@ def build_widget_timeseries_params(
 def _params_for_widget_query(
     widget_query: DashboardWidgetQuery,
     url_params: QueryDict,
-    dataset: SupportedTraceItemType,
+    dataset: str,
     dashboard_filters: Mapping[str, Any],
 ) -> dict[str, str | list[str]]:
     params: dict[str, str | list[str]] = {}
@@ -260,7 +261,7 @@ def _params_for_widget_query(
 
     _apply_page_filters(params, url_params, dashboard_filters)
 
-    params["dataset"] = dataset.value
+    params["dataset"] = dataset
     params["referrer"] = Referrer.DASHBOARDS_SLACK_UNFURL.value
 
     return params

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -2186,7 +2186,7 @@ class UnfurlTest(TestCase):
 
     @patch("sentry.integrations.slack.unfurl.dashboards.client.get")
     @patch("sentry.charts.backend.generate_chart", return_value="chart-url")
-    def test_unfurl_dashboards_non_eap_widget_is_skipped(
+    def test_unfurl_dashboards_unsupported_widget_type_is_skipped(
         self, mock_generate_chart: MagicMock, mock_client_get: MagicMock
     ) -> None:
         mock_client_get.return_value = MagicMock(data=self._build_mock_timeseries_response())
@@ -2194,7 +2194,7 @@ class UnfurlTest(TestCase):
         widget = self.create_dashboard_widget(
             dashboard=dashboard,
             display_type=DashboardWidgetDisplayTypes.LINE_CHART,
-            widget_type=DashboardWidgetTypes.ERROR_EVENTS,
+            widget_type=DashboardWidgetTypes.ISSUE,
             order=0,
         )
         self.create_dashboard_widget_query(
@@ -2437,6 +2437,19 @@ class BuildWidgetTimeseriesParamsTest(TestCase):
         assert len(all_params) == 1
         assert all_params[0]["dataset"] == "tracemetrics"
         assert all_params[0]["yAxis"] == ["sum(value)"]
+
+    def test_errors_widget(self) -> None:
+        widget = self._make_widget(
+            widget_type=DashboardWidgetTypes.ERROR_EVENTS,
+            queries=[{"aggregates": ["count()"], "conditions": "level:error"}],
+        )
+
+        all_params = build_widget_timeseries_params(widget, QueryDict("statsPeriod=7d"))
+
+        assert len(all_params) == 1
+        assert all_params[0]["dataset"] == "errors"
+        assert all_params[0]["yAxis"] == ["count()"]
+        assert all_params[0]["query"] == "level:error"
 
     def test_multiple_queries_returns_one_dict_each_in_order(self) -> None:
         widget = self._make_widget(


### PR DESCRIPTION
code is mostly ai generated, adds support for errors widgets in dashboard url unfurling

### Ai description
Extend Slack dashboard URL unfurling to cover `ERROR_EVENTS` widgets. Previously, only EAP-backed widget types (`SPANS`, `LOGS`, `TRACEMETRICS`) unfurled; links to an errors widget fell into the unsupported-widget skip branch.

The `/organizations/{slug}/events-timeseries/` endpoint already routes `dataset=errors` through `sentry.snuba.errors`, with both the timeseries and top-events paths wired up — so the change is limited to adding the widget-type → dataset-label mapping. Query parsing (error-search syntax like `level:error`, `error.type:*`) is handled by the errors dataset's query builder, and the response shape (`TimeSeries[]`) is unchanged, so the chart renderer doesn't need to know about this.

To accommodate `"errors"` as a non-EAP, non-trace-item dataset label alongside the existing `SupportedTraceItemType` entries, `_WIDGET_TYPE_TO_DATASET` is widened from `dict[int, SupportedTraceItemType]` to `dict[int, str]`. A follow-up can replace the hardcoded `"errors"` literal with `DATASET_LABELS[errors]` to share the canonical label with the rest of the backend.

Refs DAIN-1570