### PR TITLE
feat(cmdk): Add sort and save-view actions to Issues Feed command palette

### DIFF
--- a/.agents/skills/cmdk-actions/SKILL.md
+++ b/.agents/skills/cmdk-actions/SKILL.md
@@ -303,12 +303,14 @@ const assignableUsers = members.filter(m => m.id !== currentUser.id);
 
 ### 7. `trailingItem` — marking the active item
 
-Use `trailingItem` to indicate which item in a list is the currently active one:
+Use `trailingItem` with a `"Current"` badge only for **entity selections** where the user is switching between distinct objects — projects, organizations, users, environments, and similar. The badge answers the question "which one am I on right now?" when the items are otherwise indistinguishable.
+
+**Do not** use `"Current"` for settings or modes (sort order, theme, display density, etc.). Those have a single correct value at any time, and the group's own label or icon already reflects it (see the group-icon-as-state-indicator pattern above). A `"Current"` badge on a settings option duplicates information without adding clarity.
 
 ```tsx
 import {Tag} from '@sentry/scraps/badge';
 
-// Static current item with a "Current" badge, async others via resource
+// ✅ Entity selection — badge makes sense: user sees which project they're on
 <CMDKAction
   display={{label: t('Switch Project')}}
   prompt={t('Select a project...')}
@@ -323,6 +325,26 @@ import {Tag} from '@sentry/scraps/badge';
     }}
     to={`/organizations/${org.slug}/projects/${currentProject.slug}/`}
   />
+</CMDKAction>
+
+// ❌ Settings/mode — do not use a badge; the group label already shows the active value
+<CMDKAction
+  display={{
+    label: t('Sort by: %s', getSortLabel(sort)), // label reflects current state
+    icon: <IconSort />,
+  }}
+>
+  {sortKeys.map(key => (
+    <CMDKAction
+      key={key}
+      display={{
+        label: getSortLabel(key),
+        // trailingItem: key === sort ? <Tag variant="muted">{t('Current')}</Tag> : undefined
+        // ❌ Don't do this — the group label already communicates the active sort
+      }}
+      onAction={() => onSortChange(key)}
+    />
+  ))}
 </CMDKAction>
 ```
 

--- a/static/app/components/commandPalette/ui/commandPalette.spec.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.spec.tsx
@@ -235,6 +235,34 @@ describe('CommandPalette', () => {
     expect(closeSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('onAction that opens a modal leaves the new modal open', async () => {
+    // ModalStore is single-slot: openModal() replaces whatever renderer is set.
+    // The palette must close itself before invoking onAction so that a subsequent
+    // openModal() call inside the callback is not immediately wiped by closeModal().
+    const openModalSpy = jest.spyOn(modalActions, 'openModal');
+    const closeSpy = jest.spyOn(modalActions, 'closeModal');
+
+    render(
+      <GlobalActionsComponent>
+        <CMDKAction
+          display={{label: 'Open a modal'}}
+          onAction={() => modalActions.openModal(() => <div>modal content</div>)}
+        />
+      </GlobalActionsComponent>
+    );
+
+    await userEvent.click(await screen.findByRole('option', {name: 'Open a modal'}));
+
+    // The palette closed itself once
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+    // The action's openModal was called after closeModal, so it is not clobbered
+    expect(openModalSpy).toHaveBeenCalledTimes(1);
+    // closeModal was called before openModal — verify ordering
+    const closeOrder = closeSpy.mock.invocationCallOrder[0]!;
+    const openOrder = openModalSpy.mock.invocationCallOrder[0]!;
+    expect(closeOrder).toBeLessThan(openOrder);
+  });
+
   describe('search', () => {
     it('typing a query filters results to matching items only', async () => {
       render(

--- a/static/app/components/commandPalette/ui/commandPalette.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.tsx
@@ -263,6 +263,12 @@ export function CommandPalette(props: CommandPaletteProps) {
       analytics.recordAction(action, resultIndex, '');
       dispatch({type: 'trigger action'});
 
+      // Close the palette before running the action. ModalStore is a single-slot
+      // system: calling openModal() inside onAction would replace the palette's
+      // renderer, and a closeModal() call afterwards would immediately close the
+      // newly opened modal instead of the palette.
+      closeModal?.();
+
       if ('to' in action) {
         const normalizedTo = normalizeUrl(action.to);
         if (isExternalLocation(normalizedTo) || options?.modifierKeys?.shiftKey) {
@@ -273,8 +279,6 @@ export function CommandPalette(props: CommandPaletteProps) {
       } else if ('onAction' in action) {
         action.onAction();
       }
-
-      closeModal?.();
     },
     [actions, analytics, closeModal, dispatch, navigate, prefixMap, state.query]
   );

--- a/static/app/utils/analytics/issueAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/issueAnalyticsEvents.tsx
@@ -219,8 +219,8 @@ export type IssueEventParameters = {
   };
   'issue_views.reordered_views': Record<string, unknown>;
   'issue_views.reset.clicked': Record<string, unknown>;
-  'issue_views.save.clicked': Record<string, unknown>;
-  'issue_views.save_as.clicked': Record<string, unknown>;
+  'issue_views.save.clicked': {source: 'button' | 'cmdk'};
+  'issue_views.save_as.clicked': {source: 'button' | 'cmdk'};
   'issue_views.save_as.created': {
     ai_title_shown: boolean;
     ai_title_used: boolean;

--- a/static/app/views/issueList/issueListCommandPaletteActions.tsx
+++ b/static/app/views/issueList/issueListCommandPaletteActions.tsx
@@ -1,0 +1,152 @@
+import {Fragment} from 'react';
+
+import {addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {openModal} from 'sentry/actionCreators/modal';
+import {CMDKAction} from 'sentry/components/commandPalette/ui/cmdk';
+import {CommandPaletteSlot} from 'sentry/components/commandPalette/ui/commandPaletteSlot';
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {IconBookmark, IconIssues, IconSort} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {useParams} from 'sentry/utils/useParams';
+import {useUser} from 'sentry/utils/useUser';
+import {createIssueViewFromUrl} from 'sentry/views/issueList/issueViews/createIssueViewFromUrl';
+import {CreateIssueViewModal} from 'sentry/views/issueList/issueViews/createIssueViewModal';
+import {useIssueViewUnsavedChanges} from 'sentry/views/issueList/issueViews/useIssueViewUnsavedChanges';
+import {useSelectedGroupSearchView} from 'sentry/views/issueList/issueViews/useSelectedGroupSeachView';
+import {canEditIssueView} from 'sentry/views/issueList/issueViews/utils';
+import {useUpdateGroupSearchView} from 'sentry/views/issueList/mutations/useUpdateGroupSearchView';
+import {
+  FOR_REVIEW_QUERIES,
+  getSortLabel,
+  IssueSortOptions,
+} from 'sentry/views/issueList/utils';
+
+interface IssueListCommandPaletteActionsProps {
+  onSortChange: (sort: string) => void;
+  query: string;
+  sort: IssueSortOptions;
+}
+
+function SortActions({
+  sort,
+  query,
+  onSortChange,
+}: IssueListCommandPaletteActionsProps) {
+  const sortKeys = [
+    ...(FOR_REVIEW_QUERIES.includes(query) ? [IssueSortOptions.INBOX] : []),
+    IssueSortOptions.DATE,
+    IssueSortOptions.NEW,
+    IssueSortOptions.TRENDS,
+    IssueSortOptions.FREQ,
+    IssueSortOptions.USER,
+  ];
+
+  return (
+    <CMDKAction
+      display={{
+        label: t('Sort by: %s', getSortLabel(sort)),
+        icon: <IconSort />,
+      }}
+      keywords={['order', 'arrange', 'last seen', 'age', 'events', 'users', 'trends']}
+    >
+      {sortKeys.map(key => (
+        <CMDKAction
+          key={key}
+          display={{label: getSortLabel(key)}}
+          onAction={() => onSortChange(key)}
+        />
+      ))}
+    </CMDKAction>
+  );
+}
+
+function SaveViewActions({
+  query,
+  sort,
+}: Pick<IssueListCommandPaletteActionsProps, 'query' | 'sort'>) {
+  const organization = useOrganization();
+  const user = useUser();
+  const {viewId} = useParams();
+  const {selection} = usePageFilters();
+  const location = useLocation();
+  const {data: view} = useSelectedGroupSearchView();
+  const {mutate: updateGroupSearchView} = useUpdateGroupSearchView();
+  const {hasUnsavedChanges} = useIssueViewUnsavedChanges();
+
+  if (!organization.features.includes('issue-views')) {
+    return null;
+  }
+
+  const canEdit = view
+    ? canEditIssueView({user, groupSearchView: view, organization})
+    : false;
+
+  const openSaveAsModal = () => {
+    trackAnalytics('issue_views.save_as.clicked', {organization});
+    openModal(props => (
+      <CreateIssueViewModal
+        {...props}
+        analyticsSurface={viewId ? 'issue-view-details' : 'issues-feed'}
+        name={view ? `${view.name} (Copy)` : undefined}
+        query={query}
+        querySort={sort}
+        projects={selection.projects}
+        environments={selection.environments}
+        timeFilters={selection.datetime}
+      />
+    ));
+  };
+
+  const saveView = () => {
+    if (view) {
+      trackAnalytics('issue_views.save.clicked', {organization});
+      updateGroupSearchView(
+        {
+          id: view.id,
+          name: view.name,
+          ...createIssueViewFromUrl({query: location.query}),
+        },
+        {
+          onSuccess: () => {
+            addSuccessMessage(t('Saved changes'));
+          },
+        }
+      );
+    }
+  };
+
+  return (
+    <Fragment>
+      {canEdit && hasUnsavedChanges && (
+        <CMDKAction
+          display={{label: t('Save view'), icon: <IconBookmark />}}
+          keywords={['save', 'update', 'persist']}
+          onAction={saveView}
+        />
+      )}
+      <CMDKAction
+        display={{label: t('Save as new view'), icon: <IconBookmark />}}
+        keywords={['save as', 'new view', 'create view', 'bookmark']}
+        onAction={openSaveAsModal}
+      />
+    </Fragment>
+  );
+}
+
+export function IssueListCommandPaletteActions({
+  query,
+  sort,
+  onSortChange,
+}: IssueListCommandPaletteActionsProps) {
+  return (
+    <CommandPaletteSlot name="page">
+      <CMDKAction display={{label: t('Issues'), icon: <IconIssues />}}>
+        <SortActions sort={sort} query={query} onSortChange={onSortChange} />
+        <SaveViewActions query={query} sort={sort} />
+      </CMDKAction>
+    </CommandPaletteSlot>
+  );
+}

--- a/static/app/views/issueList/issueListCommandPaletteActions.tsx
+++ b/static/app/views/issueList/issueListCommandPaletteActions.tsx
@@ -81,7 +81,7 @@ function SaveViewActions({
     : false;
 
   const openSaveAsModal = () => {
-    trackAnalytics('issue_views.save_as.clicked', {organization});
+    trackAnalytics('issue_views.save_as.clicked', {organization, source: 'cmdk'});
     openModal(props => (
       <CreateIssueViewModal
         {...props}
@@ -98,7 +98,7 @@ function SaveViewActions({
 
   const saveView = () => {
     if (view) {
-      trackAnalytics('issue_views.save.clicked', {organization});
+      trackAnalytics('issue_views.save.clicked', {organization, source: 'cmdk'});
       updateGroupSearchView(
         {
           id: view.id,

--- a/static/app/views/issueList/issueListCommandPaletteActions.tsx
+++ b/static/app/views/issueList/issueListCommandPaletteActions.tsx
@@ -30,11 +30,7 @@ interface IssueListCommandPaletteActionsProps {
   sort: IssueSortOptions;
 }
 
-function SortActions({
-  sort,
-  query,
-  onSortChange,
-}: IssueListCommandPaletteActionsProps) {
+function SortActions({sort, query, onSortChange}: IssueListCommandPaletteActionsProps) {
   const sortKeys = [
     ...(FOR_REVIEW_QUERIES.includes(query) ? [IssueSortOptions.INBOX] : []),
     IssueSortOptions.DATE,
@@ -143,7 +139,7 @@ export function IssueListCommandPaletteActions({
 }: IssueListCommandPaletteActionsProps) {
   return (
     <CommandPaletteSlot name="page">
-      <CMDKAction display={{label: t('Issues'), icon: <IconIssues />}}>
+      <CMDKAction display={{label: t('Issues Feed'), icon: <IconIssues />}}>
         <SortActions sort={sort} query={query} onSortChange={onSortChange} />
         <SaveViewActions query={query} sort={sort} />
       </CMDKAction>

--- a/static/app/views/issueList/issueViews/issueViewSaveButton.tsx
+++ b/static/app/views/issueList/issueViews/issueViewSaveButton.tsx
@@ -61,7 +61,7 @@ function SegmentedIssueViewSaveButton({
 
   const saveView = () => {
     if (view) {
-      trackAnalytics('issue_views.save.clicked', {organization});
+      trackAnalytics('issue_views.save.clicked', {organization, source: 'button'});
       updateGroupSearchView(
         {
           id: view.id,
@@ -159,7 +159,7 @@ export function IssueViewSaveButton({query, sort}: IssueViewSaveButtonProps) {
   const organization = useOrganization();
 
   const openCreateIssueViewModal = () => {
-    trackAnalytics('issue_views.save_as.clicked', {organization});
+    trackAnalytics('issue_views.save_as.clicked', {organization, source: 'button'});
     openModal(props => (
       <CreateIssueViewModal
         {...props}

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -54,6 +54,7 @@ import {parseIssuePrioritySearch} from 'sentry/views/issueList/utils/parseIssueP
 import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
 import {IssueListFilters} from './filters';
+import {IssueListCommandPaletteActions} from './issueListCommandPaletteActions';
 import {
   DEFAULT_ISSUE_STREAM_SORT,
   DEFAULT_QUERY,
@@ -878,6 +879,11 @@ function IssueListOverview({
 
   return (
     <Stack flex={1}>
+      <IssueListCommandPaletteActions
+        query={query}
+        sort={sort}
+        onSortChange={onSortChange}
+      />
       <IssueViewsHeader
         selectedProjectIds={selection.projects}
         title={title}


### PR DESCRIPTION
Adds sort by and save as action to issue feed UI and fixes a bug where actions that open modals would silently be swallowed due to modalStore.closeModal() being called after the action callback invocation, closing the modal that the action may have opened. 