### PR TITLE
feat(slack): Unfurl mobile-build dashboard widgets

### DIFF
--- a/src/sentry/integrations/slack/unfurl/dashboards.py
+++ b/src/sentry/integrations/slack/unfurl/dashboards.py
@@ -74,6 +74,7 @@ _WIDGET_TYPE_TO_DATASET: dict[int, str] = {
     DashboardWidgetTypes.LOGS: SupportedTraceItemType.LOGS.value,
     DashboardWidgetTypes.TRACEMETRICS: SupportedTraceItemType.TRACEMETRICS.value,
     DashboardWidgetTypes.ERROR_EVENTS: "errors",
+    DashboardWidgetTypes.PREPROD_APP_SIZE: "preprodSize",
 }
 
 

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -2451,6 +2451,18 @@ class BuildWidgetTimeseriesParamsTest(TestCase):
         assert all_params[0]["yAxis"] == ["count()"]
         assert all_params[0]["query"] == "level:error"
 
+    def test_preprod_app_size_widget(self) -> None:
+        widget = self._make_widget(
+            widget_type=DashboardWidgetTypes.PREPROD_APP_SIZE,
+            queries=[{"aggregates": ["max(install_size)"]}],
+        )
+
+        all_params = build_widget_timeseries_params(widget, QueryDict("statsPeriod=7d"))
+
+        assert len(all_params) == 1
+        assert all_params[0]["dataset"] == "preprodSize"
+        assert all_params[0]["yAxis"] == ["max(install_size)"]
+
     def test_multiple_queries_returns_one_dict_each_in_order(self) -> None:
         widget = self._make_widget(
             queries=[


### PR DESCRIPTION
Same as https://github.com/getsentry/sentry/pull/113937      but for mobile builds

### Ai Description
Extend Slack dashboard URL unfurling to cover `PREPROD_APP_SIZE` (mobile build size) widgets. Previously, only `SPANS`, `LOGS`, and `TRACEMETRICS` unfurled; links to a mobile-build widget fell into the unsupported-widget skip branch.

The `/organizations/{slug}/events-timeseries/` endpoint already routes `dataset=preprodSize` through the `PreprodSize` RPC dataset (timeseries and top-events both work), and the response shape (`TimeSeries[]`) is unchanged, so the chart renderer doesn't need to know about this.

`_WIDGET_TYPE_TO_DATASET` is widened from `dict[int, SupportedTraceItemType]` to `dict[int, str]` because `"preprodSize"` is hardcoded in `DATASET_OPTIONS` rather than matching `SupportedTraceItemType.PREPROD.value` (`"preprod"` — the endpoint would reject it).

Refs DAIN-1573