### PR TITLE
chore(replays): Migrate to explore layout

### DIFF
--- a/static/app/views/explore/replays/list.tsx
+++ b/static/app/views/explore/replays/list.tsx
@@ -1,6 +1,6 @@
 import {Fragment} from 'react';
 
-import {Grid, Stack} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 
 import {AnalyticsArea} from 'sentry/components/analyticsArea';
 import {HookOrDefault} from 'sentry/components/hookOrDefault';
@@ -25,6 +25,11 @@ import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjectSdkNeedsUpdate} from 'sentry/utils/useProjectSdkNeedsUpdate';
 import {ExploreBreadcrumb} from 'sentry/views/explore/components/breadcrumb';
+import {
+  ExploreBodyContent,
+  ExploreBodySearch,
+  ExploreContentSection,
+} from 'sentry/views/explore/components/styles';
 import {useGetSavedQuery} from 'sentry/views/explore/hooks/useGetSavedQueries';
 import {
   useQueryParamsId,
@@ -159,28 +164,30 @@ export default function ReplaysListContainer() {
             <Stack flex={1}>
               <ReplaysHeader />
               <PageFiltersContainer>
-                <Layout.Body>
+                <ExploreBodySearch>
                   <Layout.Main width="full">
-                    <Grid gap="xl" columns="100%">
-                      <ReplayListControls
-                        onToggleWidgets={toggleWidgets}
-                        showDeadRageClickCards={showDeadRageClickCards}
-                        widgetIsOpen={widgetIsOpen}
-                      />
-                      <ReplayListPageHeaderHook />
-                      {hasSessionReplay && hasSentReplays.hasSentOneReplay ? (
-                        <ReplayAccess fallback={<ReplayAccessFallbackAlert />}>
-                          <ReplayIndexContainer
-                            showDeadRageClickCards={showDeadRageClickCards}
-                            widgetIsOpen={widgetIsOpen}
-                          />
-                        </ReplayAccess>
-                      ) : (
-                        <ReplayOnboardingPanel />
-                      )}
-                    </Grid>
+                    <ReplayListControls
+                      onToggleWidgets={toggleWidgets}
+                      showDeadRageClickCards={showDeadRageClickCards}
+                      widgetIsOpen={widgetIsOpen}
+                    />
                   </Layout.Main>
-                </Layout.Body>
+                </ExploreBodySearch>
+                <ExploreBodyContent>
+                  <ExploreContentSection gap="xl">
+                    <ReplayListPageHeaderHook />
+                    {hasSessionReplay && hasSentReplays.hasSentOneReplay ? (
+                      <ReplayAccess fallback={<ReplayAccessFallbackAlert />}>
+                        <ReplayIndexContainer
+                          showDeadRageClickCards={showDeadRageClickCards}
+                          widgetIsOpen={widgetIsOpen}
+                        />
+                      </ReplayAccess>
+                    ) : (
+                      <ReplayOnboardingPanel />
+                    )}
+                  </ExploreContentSection>
+                </ExploreBodyContent>
               </PageFiltersContainer>
             </Stack>
           </ReplayQueryParamsProvider>

--- a/static/app/views/explore/replays/list.tsx
+++ b/static/app/views/explore/replays/list.tsx
@@ -162,24 +162,21 @@ export default function ReplaysListContainer() {
                 <Layout.Body>
                   <Layout.Main width="full">
                     <Grid gap="xl" columns="100%">
+                      <ReplayListControls
+                        onToggleWidgets={toggleWidgets}
+                        showDeadRageClickCards={showDeadRageClickCards}
+                        widgetIsOpen={widgetIsOpen}
+                      />
                       <ReplayListPageHeaderHook />
                       {hasSessionReplay && hasSentReplays.hasSentOneReplay ? (
                         <ReplayAccess fallback={<ReplayAccessFallbackAlert />}>
                           <ReplayIndexContainer
-                            onToggleWidgets={toggleWidgets}
                             showDeadRageClickCards={showDeadRageClickCards}
                             widgetIsOpen={widgetIsOpen}
                           />
                         </ReplayAccess>
                       ) : (
-                        <Fragment>
-                          <ReplayListControls
-                            onToggleWidgets={toggleWidgets}
-                            showDeadRageClickCards={showDeadRageClickCards}
-                            widgetIsOpen={widgetIsOpen}
-                          />
-                          <ReplayOnboardingPanel />
-                        </Fragment>
+                        <ReplayOnboardingPanel />
                       )}
                     </Grid>
                   </Layout.Main>

--- a/static/app/views/explore/replays/list/replayIndexContainer.tsx
+++ b/static/app/views/explore/replays/list/replayIndexContainer.tsx
@@ -16,16 +16,11 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {ReplayIndexTable} from 'sentry/views/explore/replays/list/replayIndexTable';
 
 interface Props {
-  onToggleWidgets: () => void;
   showDeadRageClickCards: boolean;
   widgetIsOpen: boolean;
 }
 
-export function ReplayIndexContainer({
-  onToggleWidgets,
-  showDeadRageClickCards,
-  widgetIsOpen,
-}: Props) {
+export function ReplayIndexContainer({showDeadRageClickCards, widgetIsOpen}: Props) {
   const organization = useOrganization();
   const navigate = useNavigate();
 
@@ -68,7 +63,6 @@ export function ReplayIndexContainer({
         isPending={isPending}
         error={error}
         hasMoreResults={Boolean(hasNextResultsPage || hasPrevResultsPage)}
-        onToggleWidgets={onToggleWidgets}
         queryKey={replayListOptions.queryKey}
         showDeadRageClickCards={showDeadRageClickCards}
         widgetIsOpen={widgetIsOpen}

--- a/static/app/views/explore/replays/list/replayIndexTable.tsx
+++ b/static/app/views/explore/replays/list/replayIndexTable.tsx
@@ -19,7 +19,6 @@ import {useDimensions} from 'sentry/utils/useDimensions';
 import {useProjectSdkNeedsUpdate} from 'sentry/utils/useProjectSdkNeedsUpdate';
 import {useAllMobileProj} from 'sentry/views/explore/replays/detail/useAllMobileProj';
 import {BulkDeleteAlert} from 'sentry/views/explore/replays/list/bulkDeleteAlert';
-import {ReplayListControls} from 'sentry/views/explore/replays/list/replayListControls';
 import {useReplayIndexTableColumns} from 'sentry/views/explore/replays/list/useReplayIndexTableColumns';
 import {DeadRageSelectorCards} from 'sentry/views/explore/replays/selectors/deadRageSelectorCards';
 import type {ReplayListRecord} from 'sentry/views/explore/replays/types';
@@ -28,7 +27,6 @@ interface Props {
   error: Error | null | undefined;
   hasMoreResults: boolean;
   isPending: boolean;
-  onToggleWidgets: () => void;
   queryKey: ApiQueryKey;
   replays: ReplayListRecord[];
   showDeadRageClickCards: boolean;
@@ -39,7 +37,6 @@ export function ReplayIndexTable({
   error,
   hasMoreResults,
   isPending,
-  onToggleWidgets,
   queryKey,
   replays,
   showDeadRageClickCards,
@@ -72,11 +69,6 @@ export function ReplayIndexTable({
 
   return (
     <Fragment>
-      <ReplayListControls
-        onToggleWidgets={onToggleWidgets}
-        showDeadRageClickCards={showDeadRageClickCards}
-        widgetIsOpen={widgetIsOpen}
-      />
       {projects.length === 1 ? (
         <BulkDeleteAlert
           projectId={String(projects[0] ?? '')}


### PR DESCRIPTION
This PR migrates the replays page over to the same layout as other explore pages

Closes EXP-907

| | |
|-|-|
|Before w/Widgets | <img width="1658" height="433" alt="Screenshot 2026-04-24 at 13 34 57" src="https://github.com/user-attachments/assets/80c6712f-60b4-4499-b029-93da999269fa" /> |
|After w/Widgets | <img width="1658" height="433" alt="Screenshot 2026-04-24 at 13 35 09" src="https://github.com/user-attachments/assets/8ac1fce4-bba6-4d5d-9bc3-b3d50c8df0d8" /> |
|Before w/o Widgets| <img width="1658" height="433" alt="Screenshot 2026-04-24 at 13 35 03" src="https://github.com/user-attachments/assets/9778c841-9c85-4ff5-8c68-428eaa96950d" /> |
|After w/o Widgets| <img width="1658" height="433" alt="Screenshot 2026-04-24 at 13 35 16" src="https://github.com/user-attachments/assets/104cfcfa-c118-4518-8fc4-c5aee2eadb10" /> |