### PR TITLE
fix(onboarding): Match SCM repo by externalId in useScmRepoSelection

### DIFF
--- a/static/app/views/onboarding/components/scmRepoSelector.spec.tsx
+++ b/static/app/views/onboarding/components/scmRepoSelector.spec.tsx
@@ -159,7 +159,14 @@ describe('ScmRepoSelector', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/integrations/${mockIntegration.id}/repos/`,
       body: {
-        repos: [{identifier: 'getsentry/sentry', name: 'sentry', isInstalled: false}],
+        repos: [
+          {
+            externalId: '1',
+            identifier: 'getsentry/sentry',
+            name: 'sentry',
+            isInstalled: false,
+          },
+        ],
       },
     });
 

--- a/static/app/views/onboarding/components/useScmRepoSelection.spec.tsx
+++ b/static/app/views/onboarding/components/useScmRepoSelection.spec.tsx
@@ -51,6 +51,7 @@ describe('useScmRepoSelection', () => {
         {
           id: '99',
           name: 'getsentry/sentry',
+          externalId: '1',
           externalSlug: 'getsentry/sentry',
           status: 'active',
         },
@@ -191,6 +192,7 @@ describe('useScmRepoSelection', () => {
         {
           id: '99',
           name: 'getsentry/sentry',
+          externalId: '1',
           externalSlug: 'getsentry/sentry',
           status: 'active',
         },

--- a/static/app/views/onboarding/components/useScmRepoSelection.ts
+++ b/static/app/views/onboarding/components/useScmRepoSelection.ts
@@ -77,13 +77,11 @@ export function useScmRepoSelection({
         }
       );
       const matches = (await queryClient.fetchQuery(reposQueryOptions)).json;
-      // The query param above is an icontains filter to narrow results
-      // and avoid pagination. The exact match here uses Repository.name
-      // against IntegrationRepository.identifier — the same comparison the
-      // backend uses in organization_integration_repos.py:61,80 to determine
-      // isInstalled. Can't use externalSlug because it varies by provider
-      // (e.g. GitLab returns a numeric project ID).
-      const existing = matches?.find(r => r.name === repo.identifier);
+      // Match on externalId — the same field the backend uses to compute
+      // IntegrationRepository.isInstalled in organization_integration_repos.py.
+      // repo.name and repo.identifier diverge across providers (GitLab's
+      // identifier is a numeric project ID), but externalId is stable.
+      const existing = matches?.find(r => r.externalId === repo.externalId);
 
       if (existing) {
         onSelect({...optimistic, ...existing});

--- a/static/app/views/onboarding/components/useScmRepoSelection.ts
+++ b/static/app/views/onboarding/components/useScmRepoSelection.ts
@@ -26,7 +26,7 @@ function buildOptimisticRepo(
 ): Repository {
   return {
     id: '',
-    externalId: repo.identifier,
+    externalId: repo.externalId,
     name: repo.name,
     externalSlug: repo.identifier,
     url: '',


### PR DESCRIPTION
`useScmRepoSelection` looked up an existing Repository by comparing `Repository.name` against `IntegrationRepository.identifier`. That matched for GitHub and Bitbucket (`owner/repo` on both sides) but never matched for GitLab, whose `identifier` is a numeric project ID and whose stored `name` is `name_with_namespace`. The GET lookup always missed and the code always fell through to the POST path.

The POST path is idempotent via `external_id` on the backend, so the GitLab onboarding UX was functionally correct. Each selection just paid an extra round trip.

This switches the find to compare `externalId` to `externalId`. Same field the backend uses to compute `IntegrationRepository.isInstalled` in `organization_integration_repos.py`, stable across providers.

This fix is only possible because of recent backend work by @wedamija: #112529 exposed `externalId` on the `OrganizationIntegrationReposEndpoint` response, and #112327 added a canonical `get_repo_external_id` across all SCM providers so the IDs match on both sides of the comparison.

## Stack
- [PR #113949](https://github.com/getsentry/sentry/pull/113949): base. Adds the `IntegrationRepository.externalId` type field and applies the same fix to the SCM integration tree and Seer overview section.
- **PR #113948 (this):** onboarding repo selection, stacked on top of #113949.

Merge #113949 first. After it lands, GitHub will auto-rebase this PR onto master.

Refs ISWF-2476