### PR TITLE
test(escalating): Skip flaky test_is_forecast_out_of_range

### DIFF
--- a/tests/sentry/issues/escalating/test_escalating.py
+++ b/tests/sentry/issues/escalating/test_escalating.py
@@ -296,6 +296,7 @@ class DailyGroupCountsEscalating(BaseGroupCounts):
         # Events are aggregated in the hourly count query by date rather than the last 24hrs
         assert get_group_hourly_count_snuba(group) == (1, False)
 
+    @pytest.mark.skip(reason="flaky")
     @freeze_time(TIME_YESTERDAY)
     def test_is_forecast_out_of_range(self) -> None:
         """


### PR DESCRIPTION
Skip `DailyGroupCountsEscalating.test_is_forecast_out_of_range`, which
intermittently fails in CI with `(False, None) != (True, 1)`.

Matches the adjacent `test_is_escalating_two_weeks`, which is already
skipped as flaky (#94622). Filing as a follow-up so the underlying
escalating-forecast flake can be investigated separately without
keeping CI red.


Agent transcript: https://claudescope.sentry.dev/share/C7E02BqBL8OBDqmebTBImGr1Ina3Tlk4fD03tixw6NM