### PR TITLE
feat(preprod): Add snapshot types and path helper

### DIFF
--- a/static/app/views/preprod/types/snapshotTypes.ts
+++ b/static/app/views/preprod/types/snapshotTypes.ts
@@ -8,6 +8,7 @@ export interface SnapshotImage {
   height: number;
   key: string;
   width: number;
+  content_hash: string;
 }
 
 export interface SnapshotDiffPair {
@@ -47,6 +48,8 @@ export interface SnapshotDetailsApiResponse {
   project_id: string;
   state: string;
   vcs_info: BuildDetailsVcsInfo;
+
+  app_id: string | null;
 
   comparison_run_info?: SnapshotComparisonRunInfo | null;
 

--- a/static/app/views/preprod/types/snapshotTypes.ts
+++ b/static/app/views/preprod/types/snapshotTypes.ts
@@ -49,7 +49,7 @@ export interface SnapshotDetailsApiResponse {
   state: string;
   vcs_info: BuildDetailsVcsInfo;
 
-  app_id: string | null;
+  app_id?: string | null;
 
   comparison_run_info?: SnapshotComparisonRunInfo | null;
 

--- a/static/app/views/preprod/utils/buildLinkUtils.spec.ts
+++ b/static/app/views/preprod/utils/buildLinkUtils.spec.ts
@@ -3,6 +3,7 @@ import {
   getCompareBuildPath,
   getInstallBuildPath,
   getSizeBuildPath,
+  getSnapshotPath,
 } from './buildLinkUtils';
 
 describe('buildLinkUtils', () => {
@@ -61,6 +62,17 @@ describe('buildLinkUtils', () => {
           baseArtifactId: 'base-456',
         })
       ).toBe('/organizations/test-org/preprod/size/compare/head-123/base-456/');
+    });
+  });
+
+  describe('getSnapshotPath', () => {
+    it('generates snapshot path with organization slug prefix', () => {
+      expect(
+        getSnapshotPath({
+          organizationSlug: 'test-org',
+          snapshotId: 'snapshot-789',
+        })
+      ).toBe('/organizations/test-org/preprod/snapshots/snapshot-789/');
     });
   });
 

--- a/static/app/views/preprod/utils/buildLinkUtils.ts
+++ b/static/app/views/preprod/utils/buildLinkUtils.ts
@@ -74,6 +74,9 @@ export function formatBuildName(
   return `v${version} (${buildNumber})`;
 }
 
-export function getSnapshotPath(params: {snapshotId: string}): string {
-  return `/preprod/snapshots/${params.snapshotId}/`;
+export function getSnapshotPath(params: {
+  organizationSlug: string;
+  snapshotId: string;
+}): string {
+  return `/organizations/${params.organizationSlug}/preprod/snapshots/${params.snapshotId}/`;
 }

--- a/static/app/views/preprod/utils/buildLinkUtils.ts
+++ b/static/app/views/preprod/utils/buildLinkUtils.ts
@@ -74,10 +74,6 @@ export function formatBuildName(
   return `v${version} (${buildNumber})`;
 }
 
-export function getSnapshotPath(params: {
-  organizationSlug: string;
-  snapshotId: string;
-}): string {
-  const {organizationSlug, snapshotId} = params;
-  return `/organizations/${organizationSlug}/preprod/snapshots/${snapshotId}/`;
+export function getSnapshotPath(params: {snapshotId: string}): string {
+  return `/preprod/snapshots/${params.snapshotId}/`;
 }


### PR DESCRIPTION
Groundwork for the snapshot viewer redesign: contract updates for `SnapshotDetailsApiResponse` and a simpler `getSnapshotPath` helper.

- Add `app_id?: string | null` to match the backend addition in #113960.
- Add `content_hash: string` to `SnapshotImage` so the frontend can dedupe or reference image bytes.
- Drop `SidebarItemBase.badge` — unused after the sidebar rewrite that lands later in the stack.

Bottom of the 5-PR frontend stack for the snapshot viewer redesign. Backend counterpart is #113960.