### PR TITLE
ref(preprod): Prep diff image display and useD3Zoom for redesign

### DIFF
--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -3,12 +3,10 @@ import styled from '@emotion/styled';
 
 import {Image} from '@sentry/scraps/image';
 import {Flex, Grid} from '@sentry/scraps/layout';
-import {SegmentedControl} from '@sentry/scraps/segmentedControl';
 import {Slider} from '@sentry/scraps/slider';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {ContentSliderDiff} from 'sentry/components/contentSliderDiff';
-import {IconInput, IconPause, IconStack} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {SnapshotDiffPair} from 'sentry/views/preprod/types/snapshotTypes';
 
@@ -27,20 +25,16 @@ interface DiffImageDisplayProps {
   diffImageBaseUrl: string;
   diffMode: DiffMode;
   imageBaseUrl: string;
-  onDiffModeChange: (mode: DiffMode) => void;
   overlayColor: string;
   pair: SnapshotDiffPair;
-  showOverlay: boolean;
 }
 
 export function DiffImageDisplay({
   pair,
   imageBaseUrl,
   diffImageBaseUrl,
-  showOverlay,
   overlayColor,
   diffMode,
-  onDiffModeChange,
 }: DiffImageDisplayProps) {
   const [diffMaskUrl, setDiffMaskUrl] = useState<string | null>(null);
   const [onionOpacity, setOnionOpacity] = useState(50);
@@ -87,26 +81,12 @@ export function DiffImageDisplay({
     };
   }, [diffImageUrl]);
 
-  // >= 1% shows 1 decimal (e.g. "93.5%"), < 1% shows up to 4 without trailing zeros (e.g. "0.0227%")
-  const diffPct = pair.diff === null ? null : pair.diff * 100;
-  const diffPercent =
-    diffPct === null
-      ? null
-      : `${diffPct >= 1 ? diffPct.toFixed(1) : parseFloat(diffPct.toFixed(4))}%`;
-
   return (
     <Flex direction="column" gap="lg" padding="xl" flex="1" minHeight="0">
-      {diffPercent && (
-        <Text variant="muted" size="sm">
-          {t('Diff: %s', diffPercent)}
-        </Text>
-      )}
-
       {diffMode === 'split' && (
         <SplitView
           baseImageUrl={baseImageUrl}
           headImageUrl={headImageUrl}
-          showOverlay={showOverlay}
           overlayColor={overlayColor}
           diffMaskUrl={diffMaskUrl}
         />
@@ -124,20 +104,6 @@ export function DiffImageDisplay({
           onOpacityChange={setOnionOpacity}
         />
       )}
-
-      <Flex justify="center" flexShrink={0}>
-        <SegmentedControl value={diffMode} onChange={onDiffModeChange}>
-          <SegmentedControl.Item key="split" icon={<IconPause />}>
-            {t('Split')}
-          </SegmentedControl.Item>
-          <SegmentedControl.Item key="wipe" icon={<IconInput />}>
-            {t('Wipe')}
-          </SegmentedControl.Item>
-          <SegmentedControl.Item key="onion" icon={<IconStack />}>
-            {t('Onion')}
-          </SegmentedControl.Item>
-        </SegmentedControl>
-      </Flex>
     </Flex>
   );
 }
@@ -147,13 +113,11 @@ interface SplitViewProps {
   diffMaskUrl: string | null;
   headImageUrl: string;
   overlayColor: string;
-  showOverlay: boolean;
 }
 
 function SplitView({
   baseImageUrl,
   headImageUrl,
-  showOverlay,
   overlayColor,
   diffMaskUrl,
 }: SplitViewProps) {
@@ -190,7 +154,7 @@ function SplitView({
             >
               <ImageWrapper>
                 <ZoomableImage src={headImageUrl} alt={t('Current Branch')} />
-                {showOverlay && diffMaskUrl && (
+                {diffMaskUrl && overlayColor !== 'transparent' && (
                   <DiffOverlay $overlayColor={overlayColor} $maskUrl={diffMaskUrl} />
                 )}
               </ImageWrapper>
@@ -295,6 +259,8 @@ const ConstrainedImage = styled(Image)`
 
 const ImageWrapper = styled('div')`
   position: relative;
+  display: inline-block;
+  max-width: 100%;
 `;
 
 const DiffOverlay = styled('span')<{$maskUrl: string; $overlayColor: string}>`

--- a/static/app/views/preprod/snapshots/main/imageDisplay/useD3Zoom.ts
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/useD3Zoom.ts
@@ -6,6 +6,7 @@ interface UseD3ZoomOptions {
   maxScale?: number;
   minScale?: number;
   onTransformChange?: (transform: ZoomTransform) => void;
+  wheelRequiresModifier?: boolean;
 }
 
 interface UseD3ZoomReturn {
@@ -23,6 +24,7 @@ export function useD3Zoom({
   minScale = 0.5,
   maxScale = 10,
   onTransformChange,
+  wheelRequiresModifier = false,
 }: UseD3ZoomOptions = {}): UseD3ZoomReturn {
   const containerRef = useRef<HTMLDivElement>(null);
   const [transform, setTransform] = useState<ZoomTransform>(zoomIdentity);
@@ -39,8 +41,12 @@ export function useD3Zoom({
     const zoomBehavior = zoom<HTMLDivElement, unknown>()
       .scaleExtent([minScale, maxScale])
       .filter(event => {
+        if (event.type === 'wheel') {
+          return (
+            !wheelRequiresModifier || event.ctrlKey || event.metaKey || event.shiftKey
+          );
+        }
         return (
-          event.type === 'wheel' ||
           event.type === 'touchstart' ||
           (event.type === 'mousedown' && !event.button && !event.ctrlKey)
         );
@@ -57,7 +63,7 @@ export function useD3Zoom({
       select(container).on('.zoom', null);
       zoomBehaviorRef.current = null;
     };
-  }, [minScale, maxScale]);
+  }, [minScale, maxScale, wheelRequiresModifier]);
 
   const zoomIn = useCallback(() => {
     const container = containerRef.current;

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -21,7 +21,6 @@ interface SnapshotMainContentProps {
   diffImageBaseUrl: string;
   diffMode: DiffMode;
   imageBaseUrl: string;
-  onDiffModeChange: (mode: DiffMode) => void;
   onOverlayColorChange: (color: string) => void;
   onShowOverlayChange: (show: boolean) => void;
   onVariantChange: (index: number) => void;
@@ -42,7 +41,6 @@ export function SnapshotMainContent({
   overlayColor,
   onOverlayColorChange,
   diffMode,
-  onDiffModeChange,
 }: SnapshotMainContentProps) {
   if (!selectedItem) {
     return (
@@ -99,10 +97,8 @@ export function SnapshotMainContent({
           pair={currentPair}
           imageBaseUrl={imageBaseUrl}
           diffImageBaseUrl={diffImageBaseUrl}
-          showOverlay={showOverlay}
-          overlayColor={overlayColor}
+          overlayColor={showOverlay ? overlayColor : 'transparent'}
           diffMode={diffMode}
-          onDiffModeChange={onDiffModeChange}
         />
       </Flex>
     );

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -81,7 +81,7 @@ export default function SnapshotsPage() {
     const palette = theme.chart.getColorPalette(10);
     return palette.at(-5) ?? palette[0];
   });
-  const [diffMode, setDiffMode] = useState<DiffMode>('split');
+  const [diffMode] = useState<DiffMode>('split');
 
   const {
     size: sidebarWidth,
@@ -362,7 +362,6 @@ export default function SnapshotsPage() {
           overlayColor={overlayColor}
           onOverlayColorChange={setOverlayColor}
           diffMode={diffMode}
-          onDiffModeChange={setDiffMode}
         />
       </Flex>
     </Flex>


### PR DESCRIPTION
Staging changes for the upcoming snapshot viewer redesign. **Do not merge before the redesign PR is ready — this will not typecheck in isolation.**

**`diffImageDisplay.tsx`**
- Removes the `<SegmentedControl>` (Split / Wipe / Onion) and the diff-percentage text. These are relocated to the caller in the redesign PR, not dropped — the user-visible buttons still exist overall, just at a different level.
- Drops `showOverlay` / `onDiffModeChange` from the props interface and replaces the overlay gate with `overlayColor !== 'transparent'`. The existing caller (`snapshotMainContent.tsx`) is not updated on this branch and still passes the removed props — that fix lives in the redesign PR.
- Adds `display: inline-block; max-width: 100%` to `ImageWrapper` so the overlay mask aligns with the image when it shrinks to fit.

**`useD3Zoom.ts`**
- Adds an optional `wheelRequiresModifier` param (defaults to `false`, preserving current behavior). The new list view in the redesign passes `true` so wheel events without ctrl/meta/shift pass through to page scroll instead of being captured by zoom.

No callers of `wheelRequiresModifier` exist until the redesign PR lands.