### PR TITLE
feat(preprod): Update snapshot header with approval actions

### DIFF
--- a/static/app/views/preprod/snapshots/header/snapshotHeaderActions.tsx
+++ b/static/app/views/preprod/snapshots/header/snapshotHeaderActions.tsx
@@ -201,7 +201,10 @@ export function SnapshotHeaderActions({
           const menuItems: MenuItemProps[] = [];
 
           if (data.base_artifact_id) {
-            const baseBuildPath = getSnapshotPath({snapshotId: data.base_artifact_id});
+            const baseBuildPath = getSnapshotPath({
+              organizationSlug,
+              snapshotId: data.base_artifact_id,
+            });
             menuItems.push({
               key: 'go-to-base-build',
               label: (

--- a/static/app/views/preprod/snapshots/header/snapshotHeaderActions.tsx
+++ b/static/app/views/preprod/snapshots/header/snapshotHeaderActions.tsx
@@ -18,6 +18,7 @@ import {
   IconDelete,
   IconEllipsis,
   IconInfo,
+  IconOpen,
   IconRefresh,
   IconThumb,
   IconTimer,
@@ -27,6 +28,7 @@ import type {AvatarUser} from 'sentry/types/user';
 import {useIsSentryEmployee} from 'sentry/utils/useIsSentryEmployee';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import type {SnapshotDetailsApiResponse} from 'sentry/views/preprod/types/snapshotTypes';
+import {getSnapshotPath} from 'sentry/views/preprod/utils/buildLinkUtils';
 import {handleStaffPermissionError} from 'sentry/views/preprod/utils/staffPermissionError';
 
 interface SnapshotHeaderActionsProps {
@@ -192,11 +194,28 @@ export function SnapshotHeaderActions({
         message={t(
           'Are you sure you want to delete this snapshot? This action cannot be undone and will permanently remove all associated files and data.'
         )}
-        confirmInput={data.head_artifact_id}
+        confirmInput="delete"
         onConfirm={handleDelete}
       >
         {({open: openDeleteModal}) => {
-          const menuItems: MenuItemProps[] = [
+          const menuItems: MenuItemProps[] = [];
+
+          if (data.base_artifact_id) {
+            const baseBuildPath = getSnapshotPath({snapshotId: data.base_artifact_id});
+            menuItems.push({
+              key: 'go-to-base-build',
+              label: (
+                <Flex align="center" gap="sm">
+                  <IconOpen size="sm" />
+                  {t('Go to Base Build')}
+                </Flex>
+              ),
+              onAction: () => navigate(baseBuildPath),
+              textValue: t('Go to Base Build'),
+            });
+          }
+
+          menuItems.push(
             {
               key: 'rerun-status-checks',
               label: (
@@ -218,8 +237,8 @@ export function SnapshotHeaderActions({
               ),
               onAction: openDeleteModal,
               textValue: t('Delete Snapshots'),
-            },
-          ];
+            }
+          );
 
           if (isSentryEmployee) {
             menuItems.push({

--- a/static/app/views/preprod/snapshots/header/snapshotHeaderContent.tsx
+++ b/static/app/views/preprod/snapshots/header/snapshotHeaderContent.tsx
@@ -1,23 +1,13 @@
-import {css} from '@emotion/react';
-import styled from '@emotion/styled';
-
-import {Button, LinkButton} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
+import {IdBadge} from 'sentry/components/idBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
-import {
-  IconCommit,
-  IconPullRequest,
-  IconSliders,
-  IconShow,
-  IconStack,
-} from 'sentry/icons';
+import {IconCode, IconCommit, IconPullRequest, IconStack} from 'sentry/icons';
 import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
-import type {Theme} from 'sentry/utils/theme';
-import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
+import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {SnapshotDetailsApiResponse} from 'sentry/views/preprod/types/snapshotTypes';
 import {getBranchUrl, getPrUrl, getShaUrl} from 'sentry/views/preprod/utils/vcsLinkUtils';
 
@@ -32,32 +22,27 @@ interface VcsItemConfig {
 
 interface SnapshotHeaderContentProps {
   data: SnapshotDetailsApiResponse;
-  isSoloView: boolean;
-  onToggleView: () => void;
 }
 
-export function SnapshotHeaderContent({
-  data,
-  isSoloView,
-  onToggleView,
-}: SnapshotHeaderContentProps) {
-  const {vcs_info} = data;
+export function SnapshotHeaderContent({data}: SnapshotHeaderContentProps) {
+  const {vcs_info, app_id: appId} = data;
   const shortSha = vcs_info.head_sha?.slice(0, 7);
+  const project = ProjectsStore.getById(data.project_id);
 
   const vcsItems: VcsItemConfig[] = [
-    {
-      key: 'pr',
-      icon: IconPullRequest,
-      label: vcs_info.pr_number ? `#${vcs_info.pr_number}` : '',
-      href: getPrUrl(vcs_info),
-      requiresHref: true,
-    },
     {
       key: 'sha',
       icon: IconCommit,
       label: shortSha ?? '',
       href: getShaUrl(vcs_info, vcs_info.head_sha),
       monospace: true,
+      requiresHref: true,
+    },
+    {
+      key: 'pr',
+      icon: IconPullRequest,
+      label: vcs_info.pr_number ? `#${vcs_info.pr_number}` : '',
+      href: getPrUrl(vcs_info),
       requiresHref: true,
     },
     {
@@ -69,12 +54,15 @@ export function SnapshotHeaderContent({
   ].filter(item => item.label && (!item.requiresHref || item.href));
 
   return (
-    <Layout.HeaderContent>
-      <Layout.Title>{t('Snapshot')}</Layout.Title>
+    <Layout.HeaderContent unified>
+      <Layout.Title>
+        <Flex align="center" gap="lg" wrap="wrap" minHeight="1lh">
+          <Text size="lg" bold>
+            {t('Snapshot')}
+          </Text>
 
-      {(vcsItems.length > 0 ||
-        (data.diff_threshold !== null && data.diff_threshold !== undefined)) && (
-        <Flex align="center" gap="lg" wrap="wrap">
+          {project && <IdBadge project={project} avatarSize={16} />}
+
           {vcsItems.map(item => (
             <Flex align="center" gap="xs" key={item.key}>
               <item.icon size="xs" />
@@ -89,59 +77,17 @@ export function SnapshotHeaderContent({
               )}
             </Flex>
           ))}
-          {data.diff_threshold !== null && data.diff_threshold !== undefined && (
+
+          {appId && (
             <Flex align="center" gap="xs">
-              <IconSliders size="xs" />
-              <Text size="sm" variant="muted">
-                {t(
-                  'Specified minimum diff: %s%%',
-                  parseFloat((data.diff_threshold * 100).toPrecision(10))
-                )}
+              <IconCode size="xs" />
+              <Text size="sm" variant="muted" monospace>
+                {appId}
               </Text>
             </Flex>
           )}
         </Flex>
-      )}
-
-      {data.comparison_type === 'diff' && data.base_artifact_id && (
-        <Flex align="center" gap="sm" padding="sm 0">
-          <Text size="sm" variant="muted" bold>
-            {t('Comparing:')}
-          </Text>
-          <PillButton
-            size="xs"
-            icon={<IconShow variant={isSoloView ? undefined : 'accent'} />}
-            priority={isSoloView ? 'primary' : 'default'}
-            onClick={onToggleView}
-            aria-pressed={isSoloView}
-          >
-            {t('Head')}
-          </PillButton>
-          <Text size="sm" variant="muted" bold>
-            {t('vs')}
-          </Text>
-          <PillLinkButton
-            size="xs"
-            icon={<IconShow variant="accent" />}
-            priority="default"
-            to={normalizeUrl(`/preprod/snapshots/${data.base_artifact_id}/`)}
-          >
-            {t('Base')}
-          </PillLinkButton>
-        </Flex>
-      )}
+      </Layout.Title>
     </Layout.HeaderContent>
   );
 }
-
-const pillStyle = (p: {theme: Theme}) => css`
-  border-radius: ${p.theme.radius.full};
-`;
-
-const PillButton = styled(Button)`
-  ${pillStyle}
-`;
-
-const PillLinkButton = styled(LinkButton)`
-  ${pillStyle}
-`;

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -580,11 +580,7 @@ export default function SnapshotsPage() {
   return (
     <SentryDocumentTitle title={t('Snapshot')}>
       <Stack flex={1}>
-        <SnapshotHeaderContent
-          data={data}
-          isSoloView={isSoloView}
-          onToggleView={handleToggleView}
-        />
+        <SnapshotHeaderContent data={data} />
         <TopBar.Slot name="actions">
           <SnapshotHeaderActions
             data={data}


### PR DESCRIPTION
Redesigned snapshot header: single-row content plus the right-side actions dropdown.

**`snapshotHeaderContent.tsx`**
- Single wrapping flex row: title → project `IdBadge` → commit short-sha → PR number → branch → `IconCode` + monospace `app_id` (consumes the new field added in #113960 / #113955).
- Drops the old multi-row header and the "Comparing: Head vs Base" pill row. The Head/Base toggle now lives in the content toolbar (handled by the redesign in #113958).

**`snapshotHeaderActions.tsx`**
- Right-side actions group: approval `Tag` + `AvatarList` of approvers + `...` dropdown.
- Dropdown items: "Go to Base Build" (via `getSnapshotPath` from #113955, disabled when no base exists), "Rerun Status Checks", "Delete Snapshots", and an admin-only "Re-run comparison" entry for Sentry employees.
- `ConfirmDelete` now requires typing `delete` rather than the opaque head artifact ID — safer UX for a destructive action.

Top of the 5-PR frontend stack for the snapshot viewer redesign.