### PR TITLE
feat(preprod): Add app_info to snapshot response with prefetch

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -29,6 +29,7 @@ from sentry.preprod.analytics import (
 )
 from sentry.preprod.api.models.project_preprod_build_details_models import (
     BuildDetailsVcsInfo,
+    create_build_details_app_info,
 )
 from sentry.preprod.api.models.snapshots.project_preprod_snapshot_models import (
     SnapshotApprovalInfo,
@@ -188,8 +189,10 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
             return Response({"detail": "Feature not enabled"}, status=403)
 
         try:
-            artifact = PreprodArtifact.objects.select_related("commit_comparison").get(
-                id=snapshot_id, project__organization_id=organization.id
+            artifact = (
+                PreprodArtifact.objects.select_related("commit_comparison", "build_configuration")
+                .prefetch_related("mobile_app_info")
+                .get(id=snapshot_id, project__organization_id=organization.id)
             )
         except (PreprodArtifact.DoesNotExist, ValueError):
             return Response({"detail": "Snapshot not found"}, status=404)
@@ -428,6 +431,7 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                 comparison_type=comparison_type,
                 state=artifact.state,
                 vcs_info=vcs_info,
+                app_info=create_build_details_app_info(artifact),
                 images=image_list,
                 image_count=snapshot_metrics.image_count,
                 changed=categorized.changed,

--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -29,7 +29,6 @@ from sentry.preprod.analytics import (
 )
 from sentry.preprod.api.models.project_preprod_build_details_models import (
     BuildDetailsVcsInfo,
-    create_build_details_app_info,
 )
 from sentry.preprod.api.models.snapshots.project_preprod_snapshot_models import (
     SnapshotApprovalInfo,
@@ -189,10 +188,8 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
             return Response({"detail": "Feature not enabled"}, status=403)
 
         try:
-            artifact = (
-                PreprodArtifact.objects.select_related("commit_comparison", "build_configuration")
-                .prefetch_related("mobile_app_info")
-                .get(id=snapshot_id, project__organization_id=organization.id)
+            artifact = PreprodArtifact.objects.select_related("commit_comparison").get(
+                id=snapshot_id, project__organization_id=organization.id
             )
         except (PreprodArtifact.DoesNotExist, ValueError):
             return Response({"detail": "Snapshot not found"}, status=404)
@@ -431,7 +428,7 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                 comparison_type=comparison_type,
                 state=artifact.state,
                 vcs_info=vcs_info,
-                app_info=create_build_details_app_info(artifact),
+                app_id=artifact.app_id,
                 images=image_list,
                 image_count=snapshot_metrics.image_count,
                 changed=categorized.changed,

--- a/src/sentry/preprod/api/models/snapshots/project_preprod_snapshot_models.py
+++ b/src/sentry/preprod/api/models/snapshots/project_preprod_snapshot_models.py
@@ -5,7 +5,10 @@ from typing import Literal
 
 from pydantic import BaseModel
 
-from sentry.preprod.api.models.project_preprod_build_details_models import BuildDetailsVcsInfo
+from sentry.preprod.api.models.project_preprod_build_details_models import (
+    BuildDetailsAppInfo,
+    BuildDetailsVcsInfo,
+)
 from sentry.preprod.models import PreprodArtifact
 
 
@@ -70,6 +73,7 @@ class SnapshotDetailsApiResponse(BaseModel):
     comparison_type: str
     state: PreprodArtifact.ArtifactState
     vcs_info: BuildDetailsVcsInfo
+    app_info: BuildDetailsAppInfo | None = None
 
     # Solo fields (comparison_type == SOLO)
     images: list[SnapshotImageResponse] = []

--- a/src/sentry/preprod/api/models/snapshots/project_preprod_snapshot_models.py
+++ b/src/sentry/preprod/api/models/snapshots/project_preprod_snapshot_models.py
@@ -5,10 +5,7 @@ from typing import Literal
 
 from pydantic import BaseModel
 
-from sentry.preprod.api.models.project_preprod_build_details_models import (
-    BuildDetailsAppInfo,
-    BuildDetailsVcsInfo,
-)
+from sentry.preprod.api.models.project_preprod_build_details_models import BuildDetailsVcsInfo
 from sentry.preprod.models import PreprodArtifact
 
 
@@ -73,7 +70,7 @@ class SnapshotDetailsApiResponse(BaseModel):
     comparison_type: str
     state: PreprodArtifact.ArtifactState
     vcs_info: BuildDetailsVcsInfo
-    app_info: BuildDetailsAppInfo | None = None
+    app_id: str | None = None
 
     # Solo fields (comparison_type == SOLO)
     images: list[SnapshotImageResponse] = []


### PR DESCRIPTION
Expose the artifact's `app_id` on the snapshot details response.

The frontend snapshot viewer needs this to display app identifier context in the header alongside commit and PR info. `app_id` is already on `PreprodArtifact`, so this is just a passthrough — no extra queries, no new serializer.

Ships independently alongside a 6-PR frontend stack for the snapshot viewer redesign — frontend and backend don't deploy atomically.