### PR TITLE
feat(seer): Replay deferred Slack @-mention after identity link

### DIFF
--- a/src/sentry/integrations/slack/views/link_identity.py
+++ b/src/sentry/integrations/slack/views/link_identity.py
@@ -7,6 +7,10 @@ from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.slack.utils.notifications import SlackCommandResponse
 from sentry.integrations.slack.views.linkage import SlackIdentityLinkageView
+from sentry.middleware.integrations.tasks import route_slack_seer_event
+from sentry.seer.entrypoints.cache import SeerOperatorPendingMentionCache
+from sentry.seer.entrypoints.slack.entrypoint import SlackPendingMentionPayload
+from sentry.seer.entrypoints.types import SeerEntrypointKey
 from sentry.web.frontend.base import control_silo_view
 
 from . import build_linking_url as base_build_linking_url
@@ -54,3 +58,20 @@ class SlackLinkIdentityView(SlackIdentityLinkageView, LinkIdentityView):
             "channel_id": params["channel_id"],
             "team_id": integration.external_id,
         }
+
+    def notify_on_success(
+        self, external_id: str, params: Mapping[str, Any], integration: Integration | None
+    ) -> None:
+        super().notify_on_success(external_id, params, integration)
+        if integration is None:
+            return
+
+        cached = SeerOperatorPendingMentionCache[SlackPendingMentionPayload].pop(
+            entrypoint_key=str(SeerEntrypointKey.SLACK),
+            integration_id=integration.id,
+            user_ext_id=external_id,
+        )
+        if cached is None:
+            return
+
+        route_slack_seer_event.apply_async(kwargs=dict(cached))

--- a/src/sentry/middleware/integrations/tasks.py
+++ b/src/sentry/middleware/integrations/tasks.py
@@ -12,10 +12,14 @@ from rest_framework import status
 from taskbroker_client.retry import Retry
 
 from sentry.constants import ObjectStatus
+from sentry.integrations.messaging.metrics import SeerSlackHaltReason
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.slack.requests.event import resolve_seer_organization_for_slack_user
 from sentry.integrations.types import IntegrationProviderSlug
+from sentry.seer.entrypoints.cache import SeerOperatorPendingMentionCache
+from sentry.seer.entrypoints.slack.entrypoint import SlackPendingMentionPayload
 from sentry.seer.entrypoints.slack.messaging import send_halt_message
+from sentry.seer.entrypoints.types import SeerEntrypointKey
 from sentry.silo.base import SiloMode
 from sentry.silo.client import CellSiloClient
 from sentry.tasks.base import instrumented_task
@@ -232,6 +236,21 @@ def route_slack_seer_event(
     logging_ctx["halt_reason"] = halt_reason
 
     if halt_reason:
+        if halt_reason == SeerSlackHaltReason.IDENTITY_NOT_LINKED:
+            SeerOperatorPendingMentionCache[SlackPendingMentionPayload].set(
+                entrypoint_key=str(SeerEntrypointKey.SLACK),
+                integration_id=integration_id,
+                user_ext_id=slack_user_id,
+                cache_payload=SlackPendingMentionPayload(
+                    payload=payload,
+                    integration_id=integration_id,
+                    slack_user_id=slack_user_id,
+                    channel_id=channel_id,
+                    thread_ts=thread_ts,
+                    message_ts=message_ts,
+                    event_type=event_type,
+                ),
+            )
         send_halt_message(
             integration=integration,
             slack_user_id=slack_user_id,

--- a/src/sentry/seer/entrypoints/slack/entrypoint.py
+++ b/src/sentry/seer/entrypoints/slack/entrypoint.py
@@ -71,6 +71,22 @@ class SlackAgentCachePayload(TypedDict):
     thread: SlackThreadDetails
 
 
+class SlackPendingMentionPayload(TypedDict):
+    """
+    Kwargs for `route_slack_seer_event` stashed on control silo when a Slack
+    @-mention cannot proceed (identity not linked). Popped after identity
+    link so the task can be re-dispatched as if the webhook just arrived.
+    """
+
+    payload: dict[str, Any]
+    integration_id: int
+    slack_user_id: str
+    channel_id: str
+    thread_ts: str
+    message_ts: str
+    event_type: str
+
+
 MISSING_SCOPE_FOOTER_CACHE_TIMEOUT = 60 * 60
 
 

--- a/tests/sentry/integrations/slack/test_link_identity.py
+++ b/tests/sentry/integrations/slack/test_link_identity.py
@@ -137,6 +137,53 @@ class SlackIntegrationLinkIdentityTest(SlackIntegrationLinkIdentityTestBase):
 
         assert len(identity) == 1
 
+    @patch("sentry.integrations.slack.views.link_identity.route_slack_seer_event.apply_async")
+    def test_replays_cached_pending_mention_on_link(self, mock_apply_async: MagicMock) -> None:
+        from sentry.seer.entrypoints.cache import SeerOperatorPendingMentionCache
+        from sentry.seer.entrypoints.slack.entrypoint import SlackPendingMentionPayload
+        from sentry.seer.entrypoints.types import SeerEntrypointKey
+
+        cached_payload = SlackPendingMentionPayload(
+            payload={"method": "POST", "path": "/extensions/slack/event/"},
+            integration_id=self.integration.id,
+            slack_user_id=self.external_id,
+            channel_id="C1",
+            thread_ts="100.000",
+            message_ts="123.456",
+            event_type="app_mention",
+        )
+        SeerOperatorPendingMentionCache[SlackPendingMentionPayload].set(
+            entrypoint_key=str(SeerEntrypointKey.SLACK),
+            integration_id=self.integration.id,
+            user_ext_id=self.external_id,
+            cache_payload=cached_payload,
+        )
+
+        linking_url = build_linking_url(
+            self.integration, self.external_id, self.channel_id, self.response_url
+        )
+        self.client.post(linking_url)
+
+        mock_apply_async.assert_called_once_with(kwargs=dict(cached_payload))
+        # Cache is popped after replay.
+        assert (
+            SeerOperatorPendingMentionCache[SlackPendingMentionPayload].pop(
+                entrypoint_key=str(SeerEntrypointKey.SLACK),
+                integration_id=self.integration.id,
+                user_ext_id=self.external_id,
+            )
+            is None
+        )
+
+    @patch("sentry.integrations.slack.views.link_identity.route_slack_seer_event.apply_async")
+    def test_no_replay_when_cache_empty(self, mock_apply_async: MagicMock) -> None:
+        linking_url = build_linking_url(
+            self.integration, self.external_id, self.channel_id, self.response_url
+        )
+        self.client.post(linking_url)
+
+        mock_apply_async.assert_not_called()
+
     def test_overwrites_existing_identities_with_sdk(self) -> None:
         external_id_2 = "slack-id2"
 

--- a/tests/sentry/middleware/integrations/test_tasks.py
+++ b/tests/sentry/middleware/integrations/test_tasks.py
@@ -340,6 +340,59 @@ class RouteSlackSeerEventTest(TestCase):
             SeerSlackHaltReason.IDENTITY_NOT_LINKED
         )
 
+    @patch("sentry.middleware.integrations.tasks.send_halt_message")
+    @patch("sentry.middleware.integrations.tasks.resolve_seer_organization_for_slack_user")
+    def test_caches_payload_on_identity_not_linked(
+        self, mock_resolve: MagicMock, mock_send_halt: MagicMock
+    ) -> None:
+        from sentry.integrations.messaging.metrics import SeerSlackHaltReason
+        from sentry.seer.entrypoints.cache import SeerOperatorPendingMentionCache
+        from sentry.seer.entrypoints.slack.entrypoint import SlackPendingMentionPayload
+        from sentry.seer.entrypoints.types import SeerEntrypointKey
+
+        mock_resolve.return_value = SeerResolutionResult(
+            organization_id=None, halt_reason=SeerSlackHaltReason.IDENTITY_NOT_LINKED
+        )
+
+        self._run_task()
+
+        cached = SeerOperatorPendingMentionCache[SlackPendingMentionPayload].pop(
+            entrypoint_key=str(SeerEntrypointKey.SLACK),
+            integration_id=self.integration.id,
+            user_ext_id="U_SLACK",
+        )
+        assert cached is not None
+        assert cached["integration_id"] == self.integration.id
+        assert cached["slack_user_id"] == "U_SLACK"
+        assert cached["channel_id"] == "C1"
+        assert cached["thread_ts"] == "100.000"
+        assert cached["message_ts"] == "123.456"
+        assert cached["event_type"] == "app_mention"
+        assert cached["payload"] == self.payload
+
+    @patch("sentry.middleware.integrations.tasks.send_halt_message")
+    @patch("sentry.middleware.integrations.tasks.resolve_seer_organization_for_slack_user")
+    def test_does_not_cache_on_other_halt_reasons(
+        self, mock_resolve: MagicMock, mock_send_halt: MagicMock
+    ) -> None:
+        from sentry.integrations.messaging.metrics import SeerSlackHaltReason
+        from sentry.seer.entrypoints.cache import SeerOperatorPendingMentionCache
+        from sentry.seer.entrypoints.slack.entrypoint import SlackPendingMentionPayload
+        from sentry.seer.entrypoints.types import SeerEntrypointKey
+
+        mock_resolve.return_value = SeerResolutionResult(
+            organization_id=None, halt_reason=SeerSlackHaltReason.NO_VALID_ORGANIZATION
+        )
+
+        self._run_task()
+
+        cached = SeerOperatorPendingMentionCache[SlackPendingMentionPayload].pop(
+            entrypoint_key=str(SeerEntrypointKey.SLACK),
+            integration_id=self.integration.id,
+            user_ext_id="U_SLACK",
+        )
+        assert cached is None
+
     @patch("sentry.middleware.integrations.tasks.resolve_seer_organization_for_slack_user")
     def test_missing_integration_is_noop(self, mock_resolve: MagicMock) -> None:
         self._run_task(integration_id=99999)


### PR DESCRIPTION
Stacked on #113940.

Wires the pending-mention cache added in the base PR so that a Slack @-mention blocked by an unlinked identity is replayed after the user links.

- `route_slack_seer_event` caches its own kwargs on the `IDENTITY_NOT_LINKED` halt (control silo), keyed by `(integration_id, slack_user_id)` with a 15-minute TTL.
- `SlackLinkIdentityView.notify_on_success` pops the cache and calls `route_slack_seer_event.apply_async(kwargs=popped)`, re-entering the canonical routing pipeline. Every check (org membership, feature flag, cell resolution) runs fresh on the replay — no stale routing state, no skipped checks.

Both set and pop happen on control silo and reuse the existing control-to-cell dispatch path. No cross-silo RPC is introduced.

Stale/divergent cache state is bounded:
- 15-minute TTL covers the typical link flow with headroom.
- Only the `IDENTITY_NOT_LINKED` halt populates the cache — other halts (no valid integration, no valid organization) do not.
- If the user's identity is somehow unlinked again during the TTL window, the replay re-halts cleanly with no side effects beyond the prompt.

Refs ISWF-2427