### PR TITLE
feat(ci): report backend test failures cleans up stale comments

### DIFF
--- a/.github/workflows/scripts/report-backend-test-failures.js
+++ b/.github/workflows/scripts/report-backend-test-failures.js
@@ -1,3 +1,21 @@
+// Backend test failure reporter — per-shard, append-only PR comment model.
+//
+// Design goals:
+//   - Failures appear on the PR immediately as each shard finishes, not after
+//     all shards complete. Each shard calls reportShard() independently.
+//   - A single PR comment accumulates all failures for a given commit. Shards
+//     append to it; nodeids already present are skipped (idempotent appends).
+//   - A new push (new SHA) triggers cleanup: stale comments from the previous
+//     commit are deleted and a fresh comment is started.
+//
+// Concurrency: the workflow uses cancel-in-progress, so when a new push lands
+// all prior shards are killed before new ones start. Stale comment deletion is
+// therefore safe: multiple new-push shards may all attempt to delete the same
+// old comment, but the first wins and the rest receive a 404 (caught and
+// swallowed). The one remaining race is two shards from the same push both
+// finding no existing comment and each calling createComment — this produces a
+// short-lived duplicate that subsequent shard appends will converge onto.
+
 import {readFileSync} from 'node:fs';
 import {basename, dirname} from 'node:path';
 
@@ -181,7 +199,7 @@ export async function reportShard({github, context, core}) {
   const failures = shardFailures.map(f => ({...f, jobUrl: jobUrls[f.artifactDir]}));
 
   // Only match comments for the same commit — a new push gets a fresh comment.
-  const existing = comments.find(c => c.body?.includes(marker) && !stale.includes(c));
+  const existing = comments.find(c => c.body?.includes(marker));
 
   // Append-only: skip failures whose nodeid is already in the comment.
   const seen = extractNodeids(existing?.body);

--- a/.github/workflows/scripts/report-backend-test-failures.js
+++ b/.github/workflows/scripts/report-backend-test-failures.js
@@ -139,6 +139,30 @@ export async function reportShard({github, context, core}) {
   }
 
   const rawFailures = parseFailures([jsonPath], core);
+
+  const {owner, repo} = context.repo;
+  const prNumber = context.payload.pull_request.number;
+  const {sha} = context;
+  const marker = commitMarker(sha);
+
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: prNumber,
+  });
+
+  // Delete stale comments from previous commits on every run so a new push cleans up.
+  const stale = comments.filter(
+    c => c.body?.includes(COMMENT_MARKER) && !c.body.includes(marker)
+  );
+  await Promise.all(
+    stale.map(c =>
+      github.rest.issues.deleteComment({owner, repo, comment_id: c.id}).catch(e => {
+        core.warning(`Could not delete stale comment ${c.id}: ${e.message}`);
+      })
+    )
+  );
+
   if (rawFailures.length === 0) {
     core.info('No failures in this shard — skipping.');
     return;
@@ -156,18 +180,8 @@ export async function reportShard({github, context, core}) {
   }
   const failures = shardFailures.map(f => ({...f, jobUrl: jobUrls[f.artifactDir]}));
 
-  const {owner, repo} = context.repo;
-  const prNumber = context.payload.pull_request.number;
-  const {sha} = context;
-  const marker = commitMarker(sha);
-
-  const comments = await github.paginate(github.rest.issues.listComments, {
-    owner,
-    repo,
-    issue_number: prNumber,
-  });
   // Only match comments for the same commit — a new push gets a fresh comment.
-  const existing = comments.find(c => c.body?.includes(marker));
+  const existing = comments.find(c => c.body?.includes(marker) && !stale.includes(c));
 
   // Append-only: skip failures whose nodeid is already in the comment.
   const seen = extractNodeids(existing?.body);

--- a/.github/workflows/scripts/report-backend-test-failures.test.js
+++ b/.github/workflows/scripts/report-backend-test-failures.test.js
@@ -123,6 +123,9 @@ function mockGithub({existingComments = [], jobs = []} = {}) {
         updateComment: async params => {
           calls.push({method: 'updateComment', params});
         },
+        deleteComment: async params => {
+          calls.push({method: 'deleteComment', params});
+        },
       },
       actions: {
         listJobsForWorkflowRun,
@@ -428,7 +431,9 @@ describe('reportShard (integration)', () => {
     const core = mockCore();
     await reportShard({github, context: mockContext(), core});
 
-    assert.equal(github.calls.length, 0);
+    assert.ok(!github.calls.some(c => c.method === 'createComment'));
+    assert.ok(!github.calls.some(c => c.method === 'updateComment'));
+    assert.ok(!github.calls.some(c => c.method === 'deleteComment'));
     assert.ok(core.logs.info.some(m => m.includes('No failures')));
   });
 
@@ -441,6 +446,68 @@ describe('reportShard (integration)', () => {
 
     assert.equal(github.calls.length, 0);
     assert.ok(core.logs.warning.some(m => m.includes('PYTEST_JSON_PATH')));
+  });
+
+  it('deletes stale comments from a previous commit when a new commit has failures', async () => {
+    const oldSha = 'deadbeef00000000000000000000000000000000';
+    const staleBody = buildCommentBody(
+      [{nodeid: FAILED_TEST.nodeid, longrepr: 'old traceback'}],
+      {...TEST_OPTS, sha: oldSha}
+    );
+
+    const jsonPath = writePytestJson('pytest.json', [FAILED_TEST_2]);
+    process.env.PYTEST_JSON_PATH = jsonPath;
+    delete process.env.PYTEST_ARTIFACT_DIR;
+
+    const github = mockGithub({existingComments: [{id: 777, body: staleBody}]});
+    await reportShard({github, context: mockContext(), core: mockCore()});
+
+    const del = github.calls.find(c => c.method === 'deleteComment');
+    assert.ok(del, 'should have called deleteComment');
+    assert.equal(del.params.comment_id, 777);
+
+    const create = github.calls.find(c => c.method === 'createComment');
+    assert.ok(create, 'should have created a new comment');
+    assert.ok(create.params.body.includes(FAILED_TEST_2.nodeid));
+  });
+
+  it('deletes stale comments from a previous commit even when the current shard has no failures', async () => {
+    const oldSha = 'deadbeef00000000000000000000000000000000';
+    const staleBody = buildCommentBody(
+      [{nodeid: FAILED_TEST.nodeid, longrepr: 'old traceback'}],
+      {...TEST_OPTS, sha: oldSha}
+    );
+
+    const jsonPath = writePytestJson('pytest.json', [PASSED_TEST]);
+    process.env.PYTEST_JSON_PATH = jsonPath;
+
+    const github = mockGithub({existingComments: [{id: 888, body: staleBody}]});
+    const core = mockCore();
+    await reportShard({github, context: mockContext(), core});
+
+    const del = github.calls.find(c => c.method === 'deleteComment');
+    assert.ok(del, 'should have called deleteComment');
+    assert.equal(del.params.comment_id, 888);
+
+    assert.ok(!github.calls.some(c => c.method === 'createComment'));
+    assert.ok(core.logs.info.some(m => m.includes('No failures')));
+  });
+
+  it('does not delete comments for the current commit', async () => {
+    const existingBody = buildCommentBody(
+      [{nodeid: FAILED_TEST.nodeid, longrepr: 'traceback'}],
+      TEST_OPTS
+    );
+
+    const jsonPath = writePytestJson('pytest.json', [FAILED_TEST_2]);
+    process.env.PYTEST_JSON_PATH = jsonPath;
+    delete process.env.PYTEST_ARTIFACT_DIR;
+
+    const github = mockGithub({existingComments: [{id: 999, body: existingBody}]});
+    await reportShard({github, context: mockContext(), core: mockCore()});
+
+    assert.ok(!github.calls.some(c => c.method === 'deleteComment'));
+    assert.ok(github.calls.some(c => c.method === 'updateComment'));
   });
 
   it('includes job log link when the shard job is matched', async () => {


### PR DESCRIPTION
this deletes stale backend test failure report comments on every new run - to reduce noise and prevent bot commits from piling up

the way the current system works is individual shards are updating the same comment as they complete (as opposed to a final collector job) so feedback is as fast as possible

there's no concurrency races because of backend.yml's `concurrency cancel-in-progress: true` so we can go for the simplest design here which is simply to delete the stale comment on the next commit 