### PR TITLE
ref(preprod): Drop hash-keyed manifest fallback

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -291,8 +291,7 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
         image_list = [
             SnapshotImageResponse(
                 **{k: v for k, v in metadata.dict().items() if k not in first_class},
-                key=metadata.content_hash
-                or key,  # TODO(EME-977): Remove backwards fallback for hash-keyed manifests once near EA/GA
+                key=metadata.content_hash,
                 display_name=metadata.display_name,
                 image_file_name=key,
                 group=metadata.group,

--- a/src/sentry/preprod/snapshots/comparison_categorizer.py
+++ b/src/sentry/preprod/snapshots/comparison_categorizer.py
@@ -42,8 +42,7 @@ def _build_base_images(
     for key, meta in base_images.items():
         result[key] = SnapshotImageResponse(
             **{k: v for k, v in meta.dict().items() if k not in first_class},
-            key=meta.content_hash
-            or key,  # TODO(EME-977): Remove backwards fallback for hash-keyed manifests once near EA/GA
+            key=meta.content_hash,
             display_name=meta.display_name,
             image_file_name=key,
             group=meta.group,

--- a/src/sentry/preprod/snapshots/manifest.py
+++ b/src/sentry/preprod/snapshots/manifest.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Field
 
 
 class ImageMetadata(BaseModel):
-    content_hash: str | None = None
+    content_hash: str
     display_name: str | None = None
     group: str | None = None
     width: int = Field(ge=0)

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -58,9 +58,8 @@ class _ImageDiffResult(NamedTuple):
 def categorize_image_diff(
     head_manifest: SnapshotManifest, base_manifest: SnapshotManifest
 ) -> _ImageDiffResult:
-    # TODO(EME-977): Remove backwards fallback for hash-keyed manifests once near EA/GA
-    head_by_name = {key: (meta.content_hash or key) for key, meta in head_manifest.images.items()}
-    base_by_name = {key: (meta.content_hash or key) for key, meta in base_manifest.images.items()}
+    head_by_name = {key: meta.content_hash for key, meta in head_manifest.images.items()}
+    base_by_name = {key: meta.content_hash for key, meta in base_manifest.images.items()}
 
     all_image_file_names = head_manifest.all_image_file_names
 
@@ -441,9 +440,8 @@ def compare_snapshots(
         head_images = head_manifest.images
         base_images = base_manifest.images
 
-        # TODO(EME-977): Remove backwards fallback for hash-keyed manifests once near EA/GA
-        head_meta_by_hash = {(m.content_hash or k): m for k, m in head_images.items()}
-        base_meta_by_hash = {(m.content_hash or k): m for k, m in base_images.items()}
+        head_meta_by_hash = {m.content_hash: m for m in head_images.values()}
+        base_meta_by_hash = {m.content_hash: m for m in base_images.values()}
 
         categories = categorize_image_diff(head_manifest, base_manifest)
         renamed_pairs = categories.renamed_pairs

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -34,6 +34,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
             "app_id": "com.example.app",
             "images": {
                 "abc123def456": {
+                    "content_hash": "abc123def456",
                     "display_name": "Test Screen",
                     "image_file_name": "test.png",
                     "width": 375,
@@ -72,6 +73,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
             "pr_number": 123,
             "images": {
                 "img1": {
+                    "content_hash": "img1",
                     "display_name": "Screen 1",
                     "image_file_name": "screen1.png",
                     "width": 100,
@@ -102,6 +104,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
             "app_id": "com.example.app",
             "images": {
                 "hash1": {
+                    "content_hash": "hash1",
                     "display_name": "Screen 1",
                     "image_file_name": "screen1.png",
                     "width": 100,
@@ -253,7 +256,7 @@ class ProjectPreprodSnapshotTest(APITestCase):
     def _selective_data(self, **overrides):
         data = {
             "app_id": "com.test.app",
-            "images": {"screen.png": {"width": 100, "height": 200}},
+            "images": {"screen.png": {"content_hash": "screen", "width": 100, "height": 200}},
             "selective": True,
             "all_image_file_names": ["screen.png", "skipped.png"],
             "head_sha": "a" * 40,
@@ -355,7 +358,12 @@ class ProjectPreprodSnapshotTest(APITestCase):
             "head_repo_name": repo_name,
             "head_ref": "main",
             "images": {
-                "img1": {"display_name": "Screen 1", "width": 375, "height": 812},
+                "img1": {
+                    "content_hash": "img1",
+                    "display_name": "Screen 1",
+                    "width": 375,
+                    "height": 812,
+                },
             },
         }
 
@@ -403,11 +411,13 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
         if images is None:
             images = {
                 "img1": {
+                    "content_hash": "img1",
                     "display_name": "Screen1",
                     "width": 375,
                     "height": 812,
                 },
                 "img2": {
+                    "content_hash": "img2",
                     "display_name": "Screen2",
                     "width": 1080,
                     "height": 1920,
@@ -490,6 +500,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
     def test_get_snapshot_details_returns_all_images(self, mock_get_session):
         images = {
             f"img{i:03d}": {
+                "content_hash": f"img{i:03d}",
                 "display_name": f"Image {i}",
                 "image_file_name": f"image{i}.png",
                 "width": 100,


### PR DESCRIPTION
Resolves the EME-977 TODO: drop the backwards-compat fallback for snapshot manifests that pre-date the `content_hash` field.

`ImageMetadata.content_hash` becomes required (`str`). Manifests from old SDK versions omitted it and relied on a `content_hash or key` fallback at every read site; all callers now assume the hash is present.

Drops the fallback and the EME-977 TODO at three sites:
- `preprod_artifact_snapshot.py` — GET response construction.
- `tasks.py` — `head_by_name` / `base_by_name` for diff matching.
- `tasks.py` — `head_meta_by_hash` / `base_meta_by_hash` for rename detection.

No behavior change for any manifest uploaded by a modern client. If a legacy manifest without `content_hash` is still reachable, snapshot parsing will now raise a pydantic validation error instead of silently keying on the file name.