### PR TITLE
fix(cross-events): Change metrics to application metrics

### DIFF
--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -379,7 +379,7 @@ export function GlobalCommandPaletteActions() {
               to={`${prefix}/monitors/errors/`}
             />
             <CMDKAction
-              display={{label: t('Application Metrics')}}
+              display={{label: t('Metrics')}}
               to={`${prefix}/monitors/metrics/`}
             />
             <CMDKAction display={{label: t('Crons')}} to={`${prefix}/monitors/crons/`} />

--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -236,7 +236,7 @@ export function GlobalCommandPaletteActions() {
           {hasMetricsSupportedPlatform &&
             organization.features.includes('tracemetrics-enabled') && (
               <CMDKAction
-                display={{label: t('Metrics')}}
+                display={{label: t('Application Metrics')}}
                 to={`${prefix}/explore/metrics/`}
               />
             )}
@@ -379,7 +379,7 @@ export function GlobalCommandPaletteActions() {
               to={`${prefix}/monitors/errors/`}
             />
             <CMDKAction
-              display={{label: t('Metrics')}}
+              display={{label: t('Application Metrics')}}
               to={`${prefix}/monitors/metrics/`}
             />
             <CMDKAction display={{label: t('Crons')}} to={`${prefix}/monitors/crons/`} />

--- a/static/app/components/events/metrics/metricsDrawer.tsx
+++ b/static/app/components/events/metrics/metricsDrawer.tsx
@@ -54,7 +54,7 @@ export function MetricsDrawer({event, project, group}: MetricsIssueDrawerProps) 
       </EventDrawerHeader>
       <EventNavigator style={{gap: '0px'}}>
         <SearchQueryBuilder
-          placeholder={t('Search metrics for this trace')}
+          placeholder={t('Search application metrics for this trace')}
           filterKeys={{}}
           getTagValues={() => new Promise<string[]>(() => [])}
           initialQuery={metricsSearch.formatString()}

--- a/static/app/components/events/metrics/metricsDrawer.tsx
+++ b/static/app/components/events/metrics/metricsDrawer.tsx
@@ -48,7 +48,7 @@ export function MetricsDrawer({event, project, group}: MetricsIssueDrawerProps) 
               ),
             },
             {label: getShortEventId(event.id)},
-            {label: t('Metrics')},
+            {label: t('Application Metrics')},
           ]}
         />
       </EventDrawerHeader>

--- a/static/app/components/events/metrics/metricsSection.spec.tsx
+++ b/static/app/components/events/metrics/metricsSection.spec.tsx
@@ -286,7 +286,7 @@ describe('MetricsSection', () => {
     // Check that the drawer contains the expected elements
     expect(within(aside).getByText('Application Metrics')).toBeInTheDocument();
     expect(
-      within(aside).getByPlaceholderText('Search metrics for this trace')
+      within(aside).getByPlaceholderText('Search application metrics for this trace')
     ).toBeInTheDocument();
   });
 

--- a/static/app/components/events/metrics/metricsSection.spec.tsx
+++ b/static/app/components/events/metrics/metricsSection.spec.tsx
@@ -284,7 +284,7 @@ describe('MetricsSection', () => {
     expect(aside).toBeInTheDocument();
 
     // Check that the drawer contains the expected elements
-    expect(within(aside).getByText('Metrics')).toBeInTheDocument();
+    expect(within(aside).getByText('Application Metrics')).toBeInTheDocument();
     expect(
       within(aside).getByPlaceholderText('Search metrics for this trace')
     ).toBeInTheDocument();

--- a/static/app/components/events/metrics/metricsSection.tsx
+++ b/static/app/components/events/metrics/metricsSection.tsx
@@ -137,7 +137,7 @@ function MetricsSectionContent({
     <InterimSection
       key="metrics"
       type={SectionKey.METRICS}
-      title={t('Metrics')}
+      title={t('Application Metrics')}
       data-test-id="metrics-data-section"
     >
       <Flex direction="column" gap="xl">

--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -79,7 +79,10 @@ export function getDisabledProducts(organization: Organization): DisabledProduct
   if (!hasMetrics) {
     disabledProducts[ProductSolution.METRICS] = {
       reason,
-      onClick: createClickHandler('organizations:tracemetrics-enabled', 'Metrics'),
+      onClick: createClickHandler(
+        'organizations:tracemetrics-enabled',
+        'Application Metrics'
+      ),
     };
   }
   return disabledProducts;

--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -687,7 +687,7 @@ export function ProductSelection({
       )}
       {products.includes(ProductSolution.METRICS) && (
         <Product
-          label={t('Metrics')}
+          label={t('Application Metrics')}
           description={t(
             'Custom metrics for tracking application performance and usage, automatically trace-connected.'
           )}

--- a/static/app/components/workflowEngine/ui/alertsMonitorsShowcase.tsx
+++ b/static/app/components/workflowEngine/ui/alertsMonitorsShowcase.tsx
@@ -81,7 +81,7 @@ function AlertsMonitorsShowcase(props: ModalRenderProps) {
               <li>
                 <Text>
                   <Text bold as="span">
-                    {t('Metric')}
+                    {t('Application Metric')}
                   </Text>
                   {' — '}
                   {t('span attributes, logs, custom metrics, and more')}

--- a/static/app/components/workflowEngine/ui/alertsMonitorsShowcase.tsx
+++ b/static/app/components/workflowEngine/ui/alertsMonitorsShowcase.tsx
@@ -81,7 +81,7 @@ function AlertsMonitorsShowcase(props: ModalRenderProps) {
               <li>
                 <Text>
                   <Text bold as="span">
-                    {t('Application Metric')}
+                    {t('Metric')}
                   </Text>
                   {' — '}
                   {t('span attributes, logs, custom metrics, and more')}

--- a/static/app/data/forms/inboundFilters.tsx
+++ b/static/app/data/forms/inboundFilters.tsx
@@ -130,7 +130,7 @@ export const customFilterFields: FieldWithFeature[] = [
     rows: 1,
 
     placeholder: 'e.g. my_metric.*',
-    label: t('Metrics'),
+    label: t('Application Metrics'),
     help: (
       <Fragment>
         {t('Filter metrics by name. ')}

--- a/static/app/data/forms/inboundFilters.tsx
+++ b/static/app/data/forms/inboundFilters.tsx
@@ -133,9 +133,11 @@ export const customFilterFields: FieldWithFeature[] = [
     label: t('Application Metrics'),
     help: (
       <Fragment>
-        {t('Filter metrics by name. ')}
+        {t('Filter application metrics by name. ')}
         {newLineHelpText} {globHelpText}{' '}
-        {t('Metrics are matched on the metric name, for example "my_metric.*".')}
+        {t(
+          'Application metrics are matched on the metric name, for example "my_metric.*".'
+        )}
       </Fragment>
     ),
     getData: getOptionsData,

--- a/static/app/gettingStartedDocs/javascript-angular/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-angular/onboarding.spec.tsx
@@ -170,6 +170,6 @@ describe('javascript-angular onboarding docs', () => {
       ],
     });
 
-    expect(screen.queryByText('Metrics')).not.toBeInTheDocument();
+    expect(screen.queryByText('Application Metrics')).not.toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/javascript-angular/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-angular/onboarding.tsx
@@ -253,7 +253,7 @@ export const onboarding: OnboardingConfig<PlatformOptions> = {
     if (params.isMetricsSelected) {
       steps.push({
         id: 'metrics',
-        name: t('Metrics'),
+        name: t('Application Metrics'),
         description: t(
           'Learn how to track custom metrics to monitor your application performance and business KPIs.'
         ),

--- a/static/app/gettingStartedDocs/javascript-astro/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-astro/onboarding.spec.tsx
@@ -214,6 +214,6 @@ describe('javascript-astro onboarding docs', () => {
       ],
     });
 
-    expect(screen.queryByText('Metrics')).not.toBeInTheDocument();
+    expect(screen.queryByText('Application Metrics')).not.toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/javascript-astro/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-astro/onboarding.tsx
@@ -321,7 +321,7 @@ export const onboarding: OnboardingConfig = {
     if (params.isMetricsSelected) {
       steps.push({
         id: 'metrics',
-        name: t('Metrics'),
+        name: t('Application Metrics'),
         description: t(
           'Learn how to track custom metrics to monitor your application performance and business KPIs.'
         ),

--- a/static/app/gettingStartedDocs/javascript-ember/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-ember/onboarding.spec.tsx
@@ -187,7 +187,7 @@ describe('javascript-ember onboarding docs', () => {
     });
 
     expect(screen.getByText('Configure Ember Options')).toBeInTheDocument();
-    expect(screen.getByText('Metrics')).toBeInTheDocument();
+    expect(screen.getByText('Application Metrics')).toBeInTheDocument();
   });
 
   it('does not show Metrics in next steps when metrics is not selected', () => {
@@ -196,6 +196,6 @@ describe('javascript-ember onboarding docs', () => {
     });
 
     expect(screen.getByText('Configure Ember Options')).toBeInTheDocument();
-    expect(screen.queryByText('Metrics')).not.toBeInTheDocument();
+    expect(screen.queryByText('Application Metrics')).not.toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/javascript-ember/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-ember/onboarding.tsx
@@ -129,7 +129,7 @@ export const onboarding: OnboardingConfig = {
     if (params.isMetricsSelected) {
       steps.push({
         id: 'metrics',
-        name: t('Metrics'),
+        name: t('Application Metrics'),
         description: t(
           'Learn how to track custom metrics to monitor your application performance and business KPIs.'
         ),

--- a/static/app/gettingStartedDocs/javascript-gatsby/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-gatsby/onboarding.spec.tsx
@@ -229,6 +229,6 @@ describe('javascript-gatsby onboarding docs', () => {
       ],
     });
 
-    expect(screen.queryByText('Metrics')).not.toBeInTheDocument();
+    expect(screen.queryByText('Application Metrics')).not.toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/javascript-gatsby/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-gatsby/onboarding.tsx
@@ -101,7 +101,7 @@ export const onboarding: OnboardingConfig = {
     if (params.isMetricsSelected) {
       steps.push({
         id: 'metrics',
-        name: t('Metrics'),
+        name: t('Application Metrics'),
         description: t(
           'Learn how to track custom metrics to monitor your application performance and business KPIs.'
         ),

--- a/static/app/gettingStartedDocs/javascript-nextjs/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-nextjs/onboarding.spec.tsx
@@ -50,6 +50,6 @@ describe('javascript-nextjs onboarding docs', () => {
       ],
     });
 
-    expect(screen.queryByText('Metrics')).not.toBeInTheDocument();
+    expect(screen.queryByText('Application Metrics')).not.toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/javascript-nuxt/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-nuxt/onboarding.spec.tsx
@@ -56,6 +56,6 @@ describe('javascript-nuxt onboarding docs', () => {
       ],
     });
 
-    expect(screen.queryByText('Metrics')).not.toBeInTheDocument();
+    expect(screen.queryByText('Application Metrics')).not.toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/javascript-react-router/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-react-router/onboarding.spec.tsx
@@ -49,6 +49,6 @@ describe('javascript-react-router onboarding docs', () => {
       ],
     });
 
-    expect(screen.queryByText('Metrics')).not.toBeInTheDocument();
+    expect(screen.queryByText('Application Metrics')).not.toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/javascript-react/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-react/onboarding.spec.tsx
@@ -117,7 +117,7 @@ describe('javascript-react onboarding docs', () => {
       ],
     });
 
-    expect(screen.getByText('Metrics')).toBeInTheDocument();
+    expect(screen.getByText('Application Metrics')).toBeInTheDocument();
   });
 
   it('does not show Metrics in next steps when metrics is not selected', () => {
@@ -128,7 +128,7 @@ describe('javascript-react onboarding docs', () => {
       ],
     });
 
-    expect(screen.queryByText('Metrics')).not.toBeInTheDocument();
+    expect(screen.queryByText('Application Metrics')).not.toBeInTheDocument();
   });
 
   it('shows Logging Integrations in next steps when logs is selected', () => {

--- a/static/app/gettingStartedDocs/javascript-react/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-react/onboarding.tsx
@@ -159,7 +159,7 @@ export const onboarding: OnboardingConfig = {
     if (params.isMetricsSelected) {
       steps.push({
         id: 'metrics',
-        name: t('Metrics'),
+        name: t('Application Metrics'),
         description: t(
           'Learn how to track custom metrics to monitor your application performance and business KPIs.'
         ),

--- a/static/app/gettingStartedDocs/javascript-remix/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-remix/onboarding.spec.tsx
@@ -36,6 +36,6 @@ describe('javascript-remix onboarding docs', () => {
       ],
     });
 
-    expect(screen.queryByText('Metrics')).not.toBeInTheDocument();
+    expect(screen.queryByText('Application Metrics')).not.toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/javascript-solid/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-solid/onboarding.spec.tsx
@@ -134,6 +134,6 @@ describe('javascript-solid onboarding docs', () => {
       ],
     });
 
-    expect(screen.queryByText('Metrics')).not.toBeInTheDocument();
+    expect(screen.queryByText('Application Metrics')).not.toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/javascript-solid/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-solid/onboarding.tsx
@@ -149,7 +149,7 @@ export const onboarding: OnboardingConfig = {
     if (params.isMetricsSelected) {
       steps.push({
         id: 'metrics',
-        name: t('Metrics'),
+        name: t('Application Metrics'),
         description: t(
           'Learn how to track custom metrics to monitor your application performance and business KPIs.'
         ),

--- a/static/app/gettingStartedDocs/javascript-svelte/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-svelte/onboarding.spec.tsx
@@ -136,6 +136,6 @@ describe('javascript-svelte onboarding docs', () => {
       ],
     });
 
-    expect(screen.queryByText('Metrics')).not.toBeInTheDocument();
+    expect(screen.queryByText('Application Metrics')).not.toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/javascript-svelte/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-svelte/onboarding.tsx
@@ -151,7 +151,7 @@ export const onboarding: OnboardingConfig = {
     if (params.isMetricsSelected) {
       steps.push({
         id: 'metrics',
-        name: t('Metrics'),
+        name: t('Application Metrics'),
         description: t(
           'Learn how to track custom metrics to monitor your application performance and business KPIs.'
         ),

--- a/static/app/gettingStartedDocs/javascript-sveltekit/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-sveltekit/onboarding.spec.tsx
@@ -50,6 +50,6 @@ describe('javascript-sveltekit onboarding docs', () => {
       ],
     });
 
-    expect(screen.queryByText('Metrics')).not.toBeInTheDocument();
+    expect(screen.queryByText('Application Metrics')).not.toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/javascript-vue/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-vue/onboarding.spec.tsx
@@ -134,6 +134,6 @@ describe('javascript-vue onboarding docs', () => {
       ],
     });
 
-    expect(screen.queryByText('Metrics')).not.toBeInTheDocument();
+    expect(screen.queryByText('Application Metrics')).not.toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/javascript-vue/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-vue/onboarding.tsx
@@ -109,7 +109,7 @@ export const onboarding: OnboardingConfig<PlatformOptions> = {
     if (params.isMetricsSelected) {
       steps.push({
         id: 'metrics',
-        name: t('Metrics'),
+        name: t('Application Metrics'),
         description: t(
           'Learn how to track custom metrics to monitor your application performance and business KPIs.'
         ),

--- a/static/app/gettingStartedDocs/javascript/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript/onboarding.spec.tsx
@@ -142,6 +142,6 @@ describe('javascript onboarding docs', () => {
       ],
     });
 
-    expect(screen.queryByText('Metrics')).not.toBeInTheDocument();
+    expect(screen.queryByText('Application Metrics')).not.toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/javascript/utils.tsx
+++ b/static/app/gettingStartedDocs/javascript/utils.tsx
@@ -328,7 +328,7 @@ export const loaderScriptOnboarding: OnboardingConfig<PlatformOptions> = {
     if (params.isMetricsSelected) {
       steps.push({
         id: 'metrics',
-        name: t('Metrics'),
+        name: t('Application Metrics'),
         description: t(
           'Learn how to track custom metrics to monitor your application performance and business KPIs.'
         ),
@@ -448,7 +448,7 @@ export const packageManagerOnboarding: OnboardingConfig<PlatformOptions> = {
     if (params.isMetricsSelected) {
       steps.push({
         id: 'metrics',
-        name: t('Metrics'),
+        name: t('Application Metrics'),
         description: t(
           'Learn how to track custom metrics to monitor your application performance and business KPIs.'
         ),

--- a/static/app/gettingStartedDocs/node-connect/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-connect/onboarding.spec.tsx
@@ -207,7 +207,7 @@ describe('connect onboarding docs', () => {
       selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.METRICS],
     });
 
-    expect(screen.getByText('Metrics')).toBeInTheDocument();
+    expect(screen.getByText('Application Metrics')).toBeInTheDocument();
   });
 
   it('does not display Metrics in next steps when metrics are not selected', () => {
@@ -215,6 +215,6 @@ describe('connect onboarding docs', () => {
       selectedProducts: [ProductSolution.ERROR_MONITORING],
     });
 
-    expect(screen.queryByText('Metrics')).not.toBeInTheDocument();
+    expect(screen.queryByText('Application Metrics')).not.toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/node-connect/onboarding.tsx
+++ b/static/app/gettingStartedDocs/node-connect/onboarding.tsx
@@ -140,7 +140,7 @@ export const onboarding: OnboardingConfig = {
     if (params.isMetricsSelected) {
       steps.push({
         id: 'metrics',
-        name: t('Metrics'),
+        name: t('Application Metrics'),
         description: t(
           'Learn how to track custom metrics to monitor your application performance and business KPIs.'
         ),

--- a/static/app/gettingStartedDocs/node-express/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-express/onboarding.spec.tsx
@@ -207,7 +207,7 @@ describe('express onboarding docs', () => {
       selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.METRICS],
     });
 
-    expect(screen.getByText('Metrics')).toBeInTheDocument();
+    expect(screen.getByText('Application Metrics')).toBeInTheDocument();
   });
 
   it('does not display Metrics in next steps when metrics are not selected', () => {
@@ -215,6 +215,6 @@ describe('express onboarding docs', () => {
       selectedProducts: [ProductSolution.ERROR_MONITORING],
     });
 
-    expect(screen.queryByText('Metrics')).not.toBeInTheDocument();
+    expect(screen.queryByText('Application Metrics')).not.toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/node-express/onboarding.tsx
+++ b/static/app/gettingStartedDocs/node-express/onboarding.tsx
@@ -174,7 +174,7 @@ app.get("/debug-sentry", function mainHandler(req, res) {${
     if (params.isMetricsSelected) {
       steps.push({
         id: 'metrics',
-        name: t('Metrics'),
+        name: t('Application Metrics'),
         description: t(
           'Learn how to track custom metrics to monitor your application performance and business KPIs.'
         ),

--- a/static/app/gettingStartedDocs/node-fastify/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-fastify/onboarding.spec.tsx
@@ -208,7 +208,7 @@ describe('fastify onboarding docs', () => {
       selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.METRICS],
     });
 
-    expect(screen.getByText('Metrics')).toBeInTheDocument();
+    expect(screen.getByText('Application Metrics')).toBeInTheDocument();
   });
 
   it('does not display Metrics in next steps when metrics are not selected', () => {
@@ -216,6 +216,6 @@ describe('fastify onboarding docs', () => {
       selectedProducts: [ProductSolution.ERROR_MONITORING],
     });
 
-    expect(screen.queryByText('Metrics')).not.toBeInTheDocument();
+    expect(screen.queryByText('Application Metrics')).not.toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/node-fastify/onboarding.tsx
+++ b/static/app/gettingStartedDocs/node-fastify/onboarding.tsx
@@ -160,7 +160,7 @@ app.get("/debug-sentry", function mainHandler(req, res) {${
     if (params.isMetricsSelected) {
       steps.push({
         id: 'metrics',
-        name: t('Metrics'),
+        name: t('Application Metrics'),
         description: t(
           'Learn how to track custom metrics to monitor your application performance and business KPIs.'
         ),

--- a/static/app/gettingStartedDocs/node-koa/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-koa/onboarding.spec.tsx
@@ -208,7 +208,7 @@ describe('koa onboarding docs', () => {
       selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.METRICS],
     });
 
-    expect(screen.getByText('Metrics')).toBeInTheDocument();
+    expect(screen.getByText('Application Metrics')).toBeInTheDocument();
   });
 
   it('does not display Metrics in next steps when metrics are not selected', () => {
@@ -216,6 +216,6 @@ describe('koa onboarding docs', () => {
       selectedProducts: [ProductSolution.ERROR_MONITORING],
     });
 
-    expect(screen.queryByText('Metrics')).not.toBeInTheDocument();
+    expect(screen.queryByText('Application Metrics')).not.toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/node-koa/onboarding.tsx
+++ b/static/app/gettingStartedDocs/node-koa/onboarding.tsx
@@ -164,7 +164,7 @@ export const onboarding: OnboardingConfig = {
     if (params.isMetricsSelected) {
       steps.push({
         id: 'metrics',
-        name: t('Metrics'),
+        name: t('Application Metrics'),
         description: t(
           'Learn how to track custom metrics to monitor your application performance and business KPIs.'
         ),

--- a/static/app/gettingStartedDocs/node-nestjs/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-nestjs/onboarding.spec.tsx
@@ -208,7 +208,7 @@ describe('Nest.js onboarding docs', () => {
       selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.METRICS],
     });
 
-    expect(screen.getByText('Metrics')).toBeInTheDocument();
+    expect(screen.getByText('Application Metrics')).toBeInTheDocument();
   });
 
   it('does not display Metrics in next steps when metrics are not selected', () => {
@@ -216,6 +216,6 @@ describe('Nest.js onboarding docs', () => {
       selectedProducts: [ProductSolution.ERROR_MONITORING],
     });
 
-    expect(screen.queryByText('Metrics')).not.toBeInTheDocument();
+    expect(screen.queryByText('Application Metrics')).not.toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/node-nestjs/onboarding.tsx
+++ b/static/app/gettingStartedDocs/node-nestjs/onboarding.tsx
@@ -258,7 +258,7 @@ export const onboarding: OnboardingConfig = {
     if (params.isMetricsSelected) {
       steps.push({
         id: 'metrics',
-        name: t('Metrics'),
+        name: t('Application Metrics'),
         description: t(
           'Learn how to track custom metrics to monitor your application performance and business KPIs.'
         ),

--- a/static/app/gettingStartedDocs/node/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node/onboarding.spec.tsx
@@ -200,7 +200,7 @@ describe('node onboarding docs', () => {
       selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.METRICS],
     });
 
-    expect(screen.getByText('Metrics')).toBeInTheDocument();
+    expect(screen.getByText('Application Metrics')).toBeInTheDocument();
   });
 
   it('does not display Metrics in next steps when metrics are not selected', () => {
@@ -208,6 +208,6 @@ describe('node onboarding docs', () => {
       selectedProducts: [ProductSolution.ERROR_MONITORING],
     });
 
-    expect(screen.queryByText('Metrics')).not.toBeInTheDocument();
+    expect(screen.queryByText('Application Metrics')).not.toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/node/onboarding.tsx
+++ b/static/app/gettingStartedDocs/node/onboarding.tsx
@@ -191,7 +191,7 @@ try {
     if (params.isMetricsSelected) {
       steps.push({
         id: 'metrics',
-        name: t('Metrics'),
+        name: t('Application Metrics'),
         description: t(
           'Learn how to track custom metrics to monitor your application performance and business KPIs.'
         ),

--- a/static/app/gettingStartedDocs/react-native/metrics.spec.tsx
+++ b/static/app/gettingStartedDocs/react-native/metrics.spec.tsx
@@ -53,7 +53,7 @@ describe('getting started with react-native', () => {
     ).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: /configure sentry/i})).toBeInTheDocument();
     expect(
-      screen.getByRole('heading', {name: /send metrics and verify/i})
+      screen.getByRole('heading', {name: /send application metrics and verify/i})
     ).toBeInTheDocument();
 
     // Goes to the configure step

--- a/static/app/gettingStartedDocs/unity/onboarding.tsx
+++ b/static/app/gettingStartedDocs/unity/onboarding.tsx
@@ -130,7 +130,7 @@ export const onboarding: OnboardingConfig = {
     ...(params.isMetricsSelected
       ? ([
           {
-            title: t('Metrics'),
+            title: t('Application Metrics'),
             content: [metricsVerify(params)],
           },
         ] satisfies OnboardingStep[])

--- a/static/app/views/alerts/rules/metric/eapMetricsField.tsx
+++ b/static/app/views/alerts/rules/metric/eapMetricsField.tsx
@@ -74,7 +74,7 @@ export function EAPMetricsField({
   );
   const optionFromTraceMetric: MetricSelectOption = useMemo(
     () => ({
-      label: traceMetric.name || t('Select a metric'),
+      label: traceMetric.name || t('Select an application metric'),
       value: metricSelectValue,
       metricType: traceMetric.type as TraceMetricTypeValue,
       metricName: traceMetric.name,
@@ -217,8 +217,8 @@ export function EAPMetricsField({
           value={traceMetricSelectValue}
           isLoading={isFetching}
           onInputChange={debouncedSetSearch}
-          placeholder={t('Select a metric')}
-          noOptionsMessage={() => t('No metrics found')}
+          placeholder={t('Select an application metric')}
+          noOptionsMessage={() => t('No application metrics found')}
           onChange={option => handleMetricChange(option as MetricSelectOption)}
           disabled={hasNoMetrics}
         />

--- a/static/app/views/alerts/rules/metric/metricRulePresets.tsx
+++ b/static/app/views/alerts/rules/metric/metricRulePresets.tsx
@@ -70,7 +70,7 @@ export function makeDefaultCta({
     }
     if (traceItemType === TraceItemDataset.TRACEMETRICS) {
       return {
-        buttonText: t('Open in Metrics'),
+        buttonText: t('Open in Application Metrics'),
         to: getAlertRuleMetricsUrl({
           rule,
           organization,

--- a/static/app/views/alerts/rules/metric/wizardField.tsx
+++ b/static/app/views/alerts/rules/metric/wizardField.tsx
@@ -194,7 +194,7 @@ export function WizardField({
     ...(hasTraceMetricsAlerts(organization)
       ? [
           {
-            label: t('METRICS'),
+            label: t('Application Metrics'),
             options: [
               {
                 label: AlertWizardAlertNames.trace_item_metrics,

--- a/static/app/views/alerts/rules/metric/wizardField.tsx
+++ b/static/app/views/alerts/rules/metric/wizardField.tsx
@@ -194,7 +194,7 @@ export function WizardField({
     ...(hasTraceMetricsAlerts(organization)
       ? [
           {
-            label: t('Application Metrics'),
+            label: t('APPLICATION METRICS'),
             options: [
               {
                 label: AlertWizardAlertNames.trace_item_metrics,

--- a/static/app/views/alerts/wizard/index.spec.tsx
+++ b/static/app/views/alerts/wizard/index.spec.tsx
@@ -206,7 +206,7 @@ describe('AlertWizard', () => {
       initialRouterConfig,
     });
 
-    expect(screen.queryByText('Metrics')).not.toBeInTheDocument();
+    expect(screen.queryByText('Application Metrics')).not.toBeInTheDocument();
   });
 
   it('shows custom metrics alerts according to feature flag', () => {
@@ -228,7 +228,7 @@ describe('AlertWizard', () => {
     });
 
     // "Metrics" category heading and "Custom Metrics" option are both visible
-    expect(screen.getByText('Metrics')).toBeInTheDocument();
+    expect(screen.getByText('Application Metrics')).toBeInTheDocument();
     expect(screen.getByText('Custom Metrics')).toBeInTheDocument();
   });
 });

--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -176,7 +176,7 @@ export const getAlertWizardCategories = (org: Organization) => {
 
     if (hasTraceMetricsAlerts(org)) {
       result.push({
-        categoryHeading: t('Metrics'),
+        categoryHeading: t('Application Metrics'),
         options: ['trace_item_metrics' as const],
       });
     }

--- a/static/app/views/dashboards/globalFilter/addFilter.spec.tsx
+++ b/static/app/views/dashboards/globalFilter/addFilter.spec.tsx
@@ -128,9 +128,9 @@ describe('AddFilter', () => {
     );
 
     await userEvent.click(screen.getByRole('button', {name: 'Add Global Filter'}));
-    await userEvent.click(screen.getByText('Metrics'));
+    await userEvent.click(screen.getByText('Application Metrics'));
 
-    expect(screen.getByText('Select Metrics Tag')).toBeInTheDocument();
+    expect(screen.getByText('Select Application Metrics Tag')).toBeInTheDocument();
     expect(screen.getByText(mockFilterKeys['browser.name']!.key)).toBeInTheDocument();
     expect(screen.getByText(mockFilterKeys.environment!.key)).toBeInTheDocument();
   });
@@ -146,7 +146,7 @@ describe('AddFilter', () => {
     );
 
     await userEvent.click(screen.getByRole('button', {name: 'Add Global Filter'}));
-    await userEvent.click(screen.getByText('Metrics'));
+    await userEvent.click(screen.getByText('Application Metrics'));
     await userEvent.click(
       screen.getByRole('option', {name: mockFilterKeys.environment!.key})
     );

--- a/static/app/views/dashboards/globalFilter/addFilter.tsx
+++ b/static/app/views/dashboards/globalFilter/addFilter.tsx
@@ -32,7 +32,7 @@ export const DATASET_CHOICES = new Map<WidgetType, string>([
   [WidgetType.ERRORS, t('Errors')],
   [WidgetType.SPANS, t('Spans')],
   [WidgetType.LOGS, t('Logs')],
-  [WidgetType.TRACEMETRICS, t('Metrics')],
+  [WidgetType.TRACEMETRICS, t('Application Metrics')],
   [WidgetType.RELEASE, t('Releases')],
   [WidgetType.ISSUE, t('Issues')],
 ]);

--- a/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
@@ -65,7 +65,7 @@ export function WidgetBuilderDatasetSelector() {
   if (organization.features.includes('tracemetrics-enabled')) {
     datasetOptions.push({
       value: WidgetType.TRACEMETRICS,
-      label: t('Metrics'),
+      label: t('Application Metrics'),
       details: t('Counters, gauges, and distributions'),
     });
   }

--- a/static/app/views/detectors/components/details/metric/getDetectorOpenInDestination.spec.tsx
+++ b/static/app/views/detectors/components/details/metric/getDetectorOpenInDestination.spec.tsx
@@ -190,7 +190,7 @@ describe('getDetectorOpenInDestination', () => {
     });
 
     describe('Metrics', () => {
-      it('returns "Open in Metrics" with correct query parameters', () => {
+      it('returns "Open in Application Metrics" with correct query parameters', () => {
         const detector = MetricDetectorFixture({
           dataSources: [
             SnubaQueryDataSourceFixture({
@@ -220,7 +220,7 @@ describe('getDetectorOpenInDestination', () => {
           statsPeriod: '7d',
         });
 
-        expect(result?.buttonText).toBe('Open in Metrics');
+        expect(result?.buttonText).toBe('Open in Application Metrics');
         expect(result?.to).toContain('/explore/metrics/');
         expect(result?.to).toContain('project=1');
         expect(result?.to).toContain('environment=prod');
@@ -261,7 +261,7 @@ describe('getDetectorOpenInDestination', () => {
           statsPeriod: '7d',
         });
 
-        expect(result?.buttonText).toBe('Open in Metrics');
+        expect(result?.buttonText).toBe('Open in Application Metrics');
         const to = result?.to as string;
         const metricParams = new URL(`https://example.com${to}`).searchParams.getAll(
           'metric'

--- a/static/app/views/detectors/components/details/metric/getDetectorOpenInDestination.tsx
+++ b/static/app/views/detectors/components/details/metric/getDetectorOpenInDestination.tsx
@@ -218,7 +218,7 @@ function getDetectorMetricsUrl({
  * Returns the appropriate destination based on the detector's dataset:
  * - SPANS/TRANSACTIONS: Open in Explore
  * - LOGS: Open in Logs
- * - METRICS: Open in Metrics
+ * - METRICS: Open in Application Metrics
  * - ERRORS: Open in Discover
  */
 export function getDetectorOpenInDestination(
@@ -240,7 +240,7 @@ export function getDetectorOpenInDestination(
       };
     case DetectorDataset.METRICS:
       return {
-        buttonText: t('Open in Metrics'),
+        buttonText: t('Open in Application Metrics'),
         to: getDetectorMetricsUrl(options),
       };
     case DetectorDataset.SPANS:

--- a/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
@@ -232,7 +232,7 @@ function MetricsEquationVisualizeContent({
         <ToolbarVisualizeAddChart
           add={addAggregate}
           disabled={metricQueries.length >= MAX_METRICS_ALLOWED}
-          label={t('Add Metric')}
+          label={t('Add Application Metric')}
           display="button"
         />
         {!equationQuery && (
@@ -274,7 +274,7 @@ function FunctionColumnHeaders() {
       <div style={{gridColumn: 'span 2'}} />
       <div>
         <Tooltip title={t('The metric to aggregate in this row.')} showUnderline>
-          <SectionLabel>{t('Metric')}</SectionLabel>
+          <SectionLabel>{t('Application Metric')}</SectionLabel>
         </Tooltip>
       </div>
       <div>

--- a/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
@@ -273,7 +273,10 @@ function FunctionColumnHeaders() {
     <Grid width="100%" align="center" gap="md" columns={FUNCTION_GRID_COLUMNS}>
       <div style={{gridColumn: 'span 2'}} />
       <div>
-        <Tooltip title={t('The metric to aggregate in this row.')} showUnderline>
+        <Tooltip
+          title={t('The application metric to aggregate in this row.')}
+          showUnderline
+        >
           <SectionLabel>{t('Application Metric')}</SectionLabel>
         </Tooltip>
       </div>
@@ -284,7 +287,7 @@ function FunctionColumnHeaders() {
       </div>
       <div>
         <Tooltip
-          title={t('Restrict this metric to events matching a filter.')}
+          title={t('Restrict this application metric to events matching a filter.')}
           showUnderline
         >
           <SectionLabel>{t('Filter')}</SectionLabel>
@@ -301,7 +304,9 @@ function EquationColumnHeader() {
       <div style={{gridColumn: 'span 2'}} />
       <div>
         <Tooltip
-          title={t('Combine the metrics above with an arithmetic expression.')}
+          title={t(
+            'Combine the application metrics above with an arithmetic expression.'
+          )}
           showUnderline
         >
           <SectionLabel>{t('Equation')}</SectionLabel>

--- a/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
@@ -232,7 +232,7 @@ function MetricsEquationVisualizeContent({
         <ToolbarVisualizeAddChart
           add={addAggregate}
           disabled={metricQueries.length >= MAX_METRICS_ALLOWED}
-          label={t('Add Application Metric')}
+          label={t('Add Metric')}
           display="button"
         />
         {!equationQuery && (

--- a/static/app/views/detectors/components/forms/metric/metricsVisualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricsVisualize.tsx
@@ -226,14 +226,14 @@ export function MetricsVisualize() {
         <Stack flex="1" gap="xs" maxWidth="425px">
           <div>
             <Tooltip
-              title={t('Select the metric to monitor for this detector.')}
+              title={t('Select the application metric to monitor for this detector.')}
               showUnderline
             >
-              <SectionLabel>{t('Metric')}</SectionLabel>
+              <SectionLabel>{t('Application Metric')}</SectionLabel>
             </Tooltip>
           </div>
           <Tooltip
-            title={t('No metrics found for this project')}
+            title={t('No application metrics found for this project')}
             disabled={!hasNoMetrics}
           >
             <div>
@@ -251,7 +251,7 @@ export function MetricsVisualize() {
                 disabled={hasNoMetrics}
                 trigger={triggerProps => (
                   <OverlayTrigger.Button {...triggerProps}>
-                    {traceMetric.name || t('Select a metric')}
+                    {traceMetric.name || t('Select an application metric')}
                   </OverlayTrigger.Button>
                 )}
               />
@@ -261,7 +261,7 @@ export function MetricsVisualize() {
         <Stack flex="1" gap="xs" maxWidth="425px">
           <div>
             <Tooltip
-              title={t('The aggregation operation to apply to the metric.')}
+              title={t('The aggregation operation to apply to the application metric.')}
               showUnderline
             >
               <SectionLabel>{t('Operation')}</SectionLabel>

--- a/static/app/views/detectors/components/forms/metric/metricsVisualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricsVisualize.tsx
@@ -78,7 +78,7 @@ export function MetricsVisualize() {
   );
   const optionFromTraceMetric: MetricSelectOption = useMemo(
     () => ({
-      label: traceMetric.name || t('Select a metric'),
+      label: traceMetric.name || t('Select an application metric'),
       value: metricSelectValue,
       metricType: traceMetric.type as TraceMetricTypeValue,
       metricName: traceMetric.name,

--- a/static/app/views/detectors/components/forms/metric/metricsVisualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricsVisualize.tsx
@@ -242,7 +242,7 @@ export function MetricsVisualize() {
                 options={isFetching ? previousOptions : (metricOptions ?? [])}
                 value={traceMetricSelectValue}
                 loading={isFetching}
-                menuTitle={t('Metrics')}
+                menuTitle={t('Application Metrics')}
                 onChange={(option: SelectOption<SelectKey>) => {
                   if ('metricType' in option) {
                     handleMetricChange(option as MetricSelectOption);

--- a/static/app/views/detectors/components/forms/metric/templateSection.tsx
+++ b/static/app/views/detectors/components/forms/metric/templateSection.tsx
@@ -122,7 +122,7 @@ export function TemplateSection({step}: {step?: number}) {
 
   return (
     <Container>
-      <FormSection step={step} title={t('Choose Your Metric')}>
+      <FormSection step={step} title={t('Choose Your Application Metric')}>
         <CompactSelect
           options={templateOptions}
           value={currentTemplateValue}

--- a/static/app/views/detectors/components/forms/metric/templateSection.tsx
+++ b/static/app/views/detectors/components/forms/metric/templateSection.tsx
@@ -122,7 +122,7 @@ export function TemplateSection({step}: {step?: number}) {
 
   return (
     <Container>
-      <FormSection step={step} title={t('Choose Your Application Metric')}>
+      <FormSection step={step} title={t('Choose Your Metric')}>
         <CompactSelect
           options={templateOptions}
           value={currentTemplateValue}

--- a/static/app/views/detectors/datasetConfig/metrics.tsx
+++ b/static/app/views/detectors/datasetConfig/metrics.tsx
@@ -14,7 +14,7 @@ export const DetectorMetricsConfig = createEapDetectorConfig({
   SearchBar: MetricsDetectorSearchBar,
   formatAggregateForTitle: aggregate => {
     if (aggregate === 'count()') {
-      return t('Number of metrics');
+      return t('Number of application metrics');
     }
     return aggregate;
   },

--- a/static/app/views/detectors/datasetConfig/metrics.tsx
+++ b/static/app/views/detectors/datasetConfig/metrics.tsx
@@ -6,7 +6,7 @@ import {MetricsDetectorSearchBar} from 'sentry/views/detectors/datasetConfig/com
 import {createEapDetectorConfig} from 'sentry/views/detectors/datasetConfig/eapBase';
 
 export const DetectorMetricsConfig = createEapDetectorConfig({
-  name: t('Metrics'),
+  name: t('Application Metrics'),
   defaultEventTypes: [EventTypes.TRACE_ITEM_METRIC],
   defaultField: TraceMetricsConfig.defaultField,
   getAggregateOptions: TraceMetricsConfig.getTableFieldOptions,

--- a/static/app/views/detectors/new-setting.spec.tsx
+++ b/static/app/views/detectors/new-setting.spec.tsx
@@ -19,6 +19,8 @@ import {selectEvent} from 'sentry-test/selectEvent';
 import * as indicators from 'sentry/actionCreators/indicator';
 import {OrganizationStore} from 'sentry/stores/organizationStore';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
+import {getDatasetConfig} from 'sentry/views/detectors/datasetConfig/getDatasetConfig';
+import {DetectorDataset} from 'sentry/views/detectors/datasetConfig/types';
 import DetectorNewSettings from 'sentry/views/detectors/new-settings';
 
 describe('DetectorEdit', () => {
@@ -812,6 +814,12 @@ describe('DetectorEdit', () => {
       await userEvent.click(screen.getByText('Errors'));
 
       expect(screen.getByRole('menuitemradio', {name: /Metrics/})).toBeInTheDocument();
+    });
+
+    it('auto-generates names using application metrics wording', () => {
+      expect(
+        getDatasetConfig(DetectorDataset.METRICS).formatAggregateForTitle?.('count()')
+      ).toBe('Number of application metrics');
     });
 
     it('can submit a new metric detector with metrics dataset from URL params', async () => {

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -391,7 +391,7 @@ function itemTypeToDefaultPlaceholder(itemType: TraceItemDataset) {
     return t('Search for spans, users, tags, and more');
   }
   if (itemType === TraceItemDataset.TRACEMETRICS) {
-    return t('Search for metrics, users, tags, and more');
+    return t('Search for application metrics, users, tags, and more');
   }
   if (itemType === TraceItemDataset.PREPROD) {
     return t('Search for builds, versions, and more');

--- a/static/app/views/explore/hooks/useGetSavedQueries.tsx
+++ b/static/app/views/explore/hooks/useGetSavedQueries.tsx
@@ -294,7 +294,7 @@ const DATASET_LABEL_MAP: Record<ReadableSavedQuery['dataset'], string> = {
   logs: 'Logs',
   spans: 'Traces',
   segment_spans: 'Traces',
-  metrics: 'Metrics',
+  metrics: 'Application Metrics',
   replays: 'Replays',
 };
 

--- a/static/app/views/explore/metrics/constants.tsx
+++ b/static/app/views/explore/metrics/constants.tsx
@@ -65,7 +65,7 @@ export const HiddenTraceMetricGroupByFields: TraceMetricFieldKey[] = [
 
 const TRACEMETRICS_FILTERS: FilterKeySection = {
   value: 'tracemetrics_filters',
-  label: t('Metrics'),
+  label: t('Application Metrics'),
   children: [...SENTRY_TRACEMETRIC_STRING_TAGS, ...SENTRY_TRACEMETRIC_NUMBER_TAGS],
 };
 

--- a/static/app/views/explore/metrics/content.tsx
+++ b/static/app/views/explore/metrics/content.tsx
@@ -83,7 +83,7 @@ export default function MetricsContent() {
 }
 
 const metricsFeedbackOptions = {
-  messagePlaceholder: t('How can we make metrics work better for you?'),
+  messagePlaceholder: t('How can we make application metrics work better for you?'),
   tags: {
     ['feedback.source']: 'metrics-listing',
     ['feedback.owner']: 'performance',

--- a/static/app/views/explore/metrics/hooks/useMetricAggregatesTable.tsx
+++ b/static/app/views/explore/metrics/hooks/useMetricAggregatesTable.tsx
@@ -124,7 +124,7 @@ function useMetricAggregatesTableImp({
   const eventView = useMemo(() => {
     const discoverQuery: NewQuery = {
       id: undefined,
-      name: 'Explore - Metric Aggregates',
+      name: 'Explore - Application Metric Aggregates',
       fields: [...fields, ...(isEquation ? [] : [makeCountAggregate(traceMetric)])],
       orderby: sortBys.map(formatSort),
       query,

--- a/static/app/views/explore/metrics/metricGraph/index.tsx
+++ b/static/app/views/explore/metrics/metricGraph/index.tsx
@@ -246,7 +246,7 @@ function Graph({
           showEmptyState ? (
             <GenericWidgetEmptyStateWarning
               message={tct(
-                'No metrics found for this time period. If this is unexpected, try updating your filters or [link:learn more] about how to use metrics.',
+                'No application metrics found for this time period. If this is unexpected, try updating your filters or [link:learn more] about how to use application metrics.',
                 {
                   link: (
                     <ExternalLink href="https://docs.sentry.io/product/explore/metrics/">

--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.spec.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.spec.tsx
@@ -101,7 +101,9 @@ describe('AggregatesTab', () => {
     expect(screen.getByRole('columnheader', {name: /sum/i})).toBeInTheDocument();
 
     // Metric name column should be prepended when no group bys are selected
-    expect(screen.getByRole('columnheader', {name: 'Metric'}).tagName).toBe('DIV');
+    expect(screen.getByRole('columnheader', {name: 'Application Metric'}).tagName).toBe(
+      'DIV'
+    );
     expect(screen.getByRole('columnheader', {name: /avg/i}).tagName).toBe('BUTTON');
   });
 
@@ -159,7 +161,9 @@ describe('AggregatesTab', () => {
     expect(screen.getByRole('columnheader', {name: /p95/i})).toBeInTheDocument();
 
     // Metric name column should NOT appear when group bys are selected
-    expect(screen.queryByRole('columnheader', {name: 'Metric'})).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('columnheader', {name: 'Application Metric'})
+    ).not.toBeInTheDocument();
   });
 
   it('shows empty state when no data is returned', async () => {

--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
@@ -184,7 +184,7 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
             null;
           const func = parseFunction(field);
           if (field === TraceMetricKnownFieldKey.METRIC_NAME) {
-            label = t('Metric');
+            label = t('Application Metric');
           } else if (func) {
             label = `${func.name}(…)`;
           } else if (tag) {

--- a/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTableHeader.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTableHeader.tsx
@@ -119,7 +119,7 @@ function getFieldLabel(field: SampleTableColumnKey): ReactNode {
     [TraceMetricKnownFieldKey.TRACE]: () => t('Trace ID'),
     [TraceMetricKnownFieldKey.METRIC_VALUE]: () => t('Value'),
     [TraceMetricKnownFieldKey.TIMESTAMP]: () => t('Timestamp'),
-    [TraceMetricKnownFieldKey.METRIC_NAME]: () => t('Metric'),
+    [TraceMetricKnownFieldKey.METRIC_NAME]: () => t('Application Metric'),
     [VirtualTableSampleColumnKey.PROJECT_BADGE]: () => t('Project'),
   };
   return fieldLabels[field]?.() ?? null;

--- a/static/app/views/explore/metrics/metricToolbar/deleteMetricButton.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/deleteMetricButton.tsx
@@ -15,9 +15,9 @@ export function DeleteMetricButton({disabled}: {disabled?: boolean}) {
       onClick={removeMetric}
       disabled={disabled}
       tooltipProps={{
-        title: disabled ? t('This metric is used in an equation') : undefined,
+        title: disabled ? t('This application metric is used in an equation') : undefined,
       }}
-      aria-label={t('Delete Metric')}
+      aria-label={t('Delete Application Metric')}
     />
   );
 }

--- a/static/app/views/explore/metrics/metricToolbar/deleteMetricButton.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/deleteMetricButton.tsx
@@ -17,7 +17,7 @@ export function DeleteMetricButton({disabled}: {disabled?: boolean}) {
       tooltipProps={{
         title: disabled ? t('This application metric is used in an equation') : undefined,
       }}
-      aria-label={t('Delete Application Metric')}
+      aria-label={t('Delete Metric')}
     />
   );
 }

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.spec.tsx
@@ -204,7 +204,9 @@ describe('MetricSelector', () => {
 
         await userEvent.click(screen.getByRole('button', {name: 'None'}));
 
-        expect(await screen.findByText('No metrics found')).toBeInTheDocument();
+        expect(
+          await screen.findByText('No application metrics found')
+        ).toBeInTheDocument();
       });
     });
 

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.spec.tsx
@@ -214,7 +214,9 @@ describe('MetricSelector', () => {
       });
 
       await userEvent.click(screen.getByRole('button', {name: 'bar'}));
-      const searchInput = await screen.findByPlaceholderText('Search metrics\u2026');
+      const searchInput = await screen.findByPlaceholderText(
+        'Search application metrics\u2026'
+      );
 
       await waitFor(() => {
         expect(searchInput).toHaveFocus();
@@ -229,7 +231,7 @@ describe('MetricSelector', () => {
       await userEvent.click(screen.getByRole('button', {name: 'bar'}));
 
       expect(
-        await screen.findByPlaceholderText('Search metrics\u2026')
+        await screen.findByPlaceholderText('Search application metrics\u2026')
       ).toBeInTheDocument();
     });
 
@@ -239,7 +241,9 @@ describe('MetricSelector', () => {
       });
 
       await userEvent.click(screen.getByRole('button', {name: 'bar'}));
-      const searchInput = await screen.findByPlaceholderText('Search metrics\u2026');
+      const searchInput = await screen.findByPlaceholderText(
+        'Search application metrics\u2026'
+      );
       await userEvent.type(searchInput, 'foo');
 
       expect(searchInput).toHaveValue('foo');
@@ -253,7 +257,9 @@ describe('MetricSelector', () => {
       const trigger = screen.getByRole('button', {name: 'bar'});
       await userEvent.click(trigger);
 
-      const searchInput = await screen.findByPlaceholderText('Search metrics\u2026');
+      const searchInput = await screen.findByPlaceholderText(
+        'Search application metrics\u2026'
+      );
       await userEvent.type(searchInput, 'foo');
 
       expect(searchInput).toHaveValue('foo');
@@ -264,7 +270,9 @@ describe('MetricSelector', () => {
       });
 
       await userEvent.click(trigger);
-      expect(await screen.findByPlaceholderText('Search metrics\u2026')).toHaveValue('');
+      expect(
+        await screen.findByPlaceholderText('Search application metrics\u2026')
+      ).toHaveValue('');
     });
 
     it('ArrowDown followed by Enter selects an option', async () => {
@@ -286,7 +294,9 @@ describe('MetricSelector', () => {
         organization,
       });
       await userEvent.click(screen.getByRole('button', {name: 'bar'}));
-      const searchInput = await screen.findByPlaceholderText('Search metrics\u2026');
+      const searchInput = await screen.findByPlaceholderText(
+        'Search application metrics\u2026'
+      );
       await userEvent.keyboard('{ArrowDown}');
 
       // DOM focus stays on search input; virtual focus moves to first option
@@ -347,7 +357,7 @@ describe('MetricSelector', () => {
         ]
       );
 
-      const searchInput = screen.getByPlaceholderText('Search metrics\u2026');
+      const searchInput = screen.getByPlaceholderText('Search application metrics\u2026');
       await userEvent.type(searchInput, 'b');
 
       // After list shrinks, keyboard selection should still pick a valid option.

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -491,7 +491,7 @@ export function MetricSelector({
                     {collectionItems.length === 0 ? (
                       <Flex align="center" justify="center" padding="xl">
                         <Text variant="muted" size="sm">
-                          {t('No metrics found')}
+                          {t('No application metrics found')}
                         </Text>
                       </Flex>
                     ) : (
@@ -626,7 +626,7 @@ function MetricDetailPanel({
   if (!metric) {
     return (
       <Flex align="center" justify="center" flex="1">
-        <Text variant="muted">{t('Select a metric to see details')}</Text>
+        <Text variant="muted">{t('Select an application metric to see details')}</Text>
       </Flex>
     );
   }

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -451,7 +451,7 @@ export function MetricSelector({
                       </InputGroup.LeadingItems>
                       <InputGroup.Input
                         {...comboBoxInputProps}
-                        placeholder={t('Search metrics\u2026')}
+                        placeholder={t('Search application metrics\u2026')}
                         size="xs"
                         ref={searchRef}
                       />

--- a/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSelector.tsx
@@ -429,7 +429,7 @@ export function MetricSelector({
                 >
                   <Flex align="center" justify="between" padding="sm lg">
                     <Text size="sm" bold wrap="nowrap">
-                      {t('Metrics')}
+                      {t('Application Metrics')}
                     </Text>
                     {isFetching ? (
                       <LoadingIndicator size={12} style={{margin: 0}} />

--- a/static/app/views/explore/metrics/metricsOnboarding.tsx
+++ b/static/app/views/explore/metrics/metricsOnboarding.tsx
@@ -76,10 +76,10 @@ function OnboardingPanel({
             <div>
               <HeaderWrapper>
                 <HeaderText>
-                  <Title>{t('Measure what matters with Metrics')}</Title>
+                  <Title>{t('Measure what matters with Application Metrics')}</Title>
                   <SubTitle>
                     {t(
-                      'Track application metrics with powerful aggregation and visualization capabilities. Metrics will be connected to your errors, logs and spans enabling easier debugging'
+                      'Track application metrics with powerful aggregation and visualization capabilities. Application metrics will be connected to your errors, logs and spans enabling easier debugging'
                     )}
                   </SubTitle>
                   {isUnsupportedPlatform && <div>{children}</div>}
@@ -90,7 +90,7 @@ function OnboardingPanel({
               <Body isUnsupportedPlatform={isUnsupportedPlatform}>
                 {!isUnsupportedPlatform && <Setup>{children}</Setup>}
                 <Preview isUnsupportedPlatform={isUnsupportedPlatform}>
-                  <BodyTitle>{t('Preview a Sentry Metric')}</BodyTitle>
+                  <BodyTitle>{t('Preview a Sentry Application Metric')}</BodyTitle>
                   <Arcade
                     src="https://demo.arcade.software/wNDJOXTJw64xiuVi7Hp6?embed"
                     loading="lazy"
@@ -109,7 +109,7 @@ function OnboardingPanel({
 const STEP_TITLES: Record<StepType, string> = {
   [StepType.INSTALL]: t('Install Sentry'),
   [StepType.CONFIGURE]: t('Configure Sentry'),
-  [StepType.VERIFY]: t('Send Metrics and Verify'),
+  [StepType.VERIFY]: t('Send Application Metrics and Verify'),
 };
 
 function Onboarding({organization, project}: OnboardingProps) {
@@ -171,7 +171,7 @@ function Onboarding({organization, project}: OnboardingProps) {
       <OnboardingPanel project={project}>
         <div>
           {tct(
-            "Fiddlesticks. Metrics isn't available for your [platform] project yet, but we're definitely still working on it. Stay tuned.",
+            "Fiddlesticks. Application Metrics aren't available for your [platform] project yet, but we're definitely still working on it. Stay tuned.",
             {platform: currentPlatform?.name || project.slug}
           )}
         </div>

--- a/static/app/views/explore/metrics/metricsTab.spec.tsx
+++ b/static/app/views/explore/metrics/metricsTab.spec.tsx
@@ -181,7 +181,7 @@ describe('MetricsTabContent', () => {
     });
     expect(screen.getAllByTestId('metric-panel')).toHaveLength(1);
 
-    let addButtons = screen.getAllByRole('button', {name: 'Add Application Metric'});
+    let addButtons = screen.getAllByRole('button', {name: 'Add Metric'});
     expect(addButtons[0]).toBeEnabled();
 
     await userEvent.click(addButtons[0]!);
@@ -197,7 +197,7 @@ describe('MetricsTabContent', () => {
     await userEvent.click(within(toolbars[1]!).getByRole('option', {name: 'foo'}));
     expect(within(toolbars[1]!).getByRole('button', {name: 'foo'})).toBeInTheDocument();
 
-    addButtons = screen.getAllByRole('button', {name: 'Add Application Metric'});
+    addButtons = screen.getAllByRole('button', {name: 'Add Metric'});
     expect(addButtons[0]).toBeEnabled();
 
     await userEvent.click(addButtons[0]!);
@@ -271,7 +271,7 @@ describe('MetricsTabContent', () => {
     expect(trackAnalyticsMock).toHaveBeenCalledTimes(2);
     trackAnalyticsMock.mockClear();
 
-    const addButtons = screen.getAllByRole('button', {name: 'Add Application Metric'});
+    const addButtons = screen.getAllByRole('button', {name: 'Add Metric'});
     await userEvent.click(addButtons[0]!);
 
     await waitFor(() => {
@@ -607,7 +607,7 @@ describe('MetricsTabContent', () => {
         organization,
       }
     );
-    expect(await screen.findAllByText('Add Application Metric')).toHaveLength(1);
+    expect(await screen.findAllByText('Add Metric')).toHaveLength(1);
     expect(screen.queryByText('Add Equation')).not.toBeInTheDocument();
   });
 
@@ -623,7 +623,7 @@ describe('MetricsTabContent', () => {
         organization: orgWithFeature,
       }
     );
-    expect(await screen.findAllByText('Add Application Metric')).toHaveLength(1);
+    expect(await screen.findAllByText('Add Metric')).toHaveLength(1);
     expect(screen.getAllByText('Add Equation').length).toBeGreaterThan(0);
   });
 
@@ -718,12 +718,12 @@ describe('MetricsTabContent', () => {
           },
         }
       );
-      expect(await screen.findAllByText('Add Application Metric')).not.toHaveLength(0);
+      expect(await screen.findAllByText('Add Metric')).not.toHaveLength(0);
       expect(screen.getAllByText('Add Equation').length).toBeGreaterThan(0);
 
       // Only 2 entries (cap is 3) -> both buttons are enabled
       for (const button of screen.getAllByRole('button', {
-        name: 'Add Application Metric',
+        name: 'Add Metric',
       })) {
         expect(button).toBeEnabled();
       }
@@ -732,11 +732,9 @@ describe('MetricsTabContent', () => {
       }
 
       // Add an entry, 3 entries (at cap) -> both buttons are disabled
-      await userEvent.click(
-        screen.getAllByRole('button', {name: 'Add Application Metric'})[0]!
-      );
+      await userEvent.click(screen.getAllByRole('button', {name: 'Add Metric'})[0]!);
       for (const button of screen.getAllByRole('button', {
-        name: 'Add Application Metric',
+        name: 'Add Metric',
       })) {
         expect(button).toBeDisabled();
       }
@@ -807,17 +805,17 @@ describe('MetricsTabContent', () => {
 
     // Metric A should be disabled because it is referenced by the equation
     expect(
-      within(toolbars[0]!).getByRole('button', {name: 'Delete Application Metric'})
+      within(toolbars[0]!).getByRole('button', {name: 'Delete Metric'})
     ).toBeDisabled();
 
     // Metric B should be enabled because it is not referenced by the equation
     expect(
-      within(toolbars[1]!).getByRole('button', {name: 'Delete Application Metric'})
+      within(toolbars[1]!).getByRole('button', {name: 'Delete Metric'})
     ).toBeEnabled();
 
     // Equation deletion should always be enabled
     expect(
-      within(toolbars[2]!).getByRole('button', {name: 'Delete Application Metric'})
+      within(toolbars[2]!).getByRole('button', {name: 'Delete Metric'})
     ).toBeEnabled();
   });
 });

--- a/static/app/views/explore/metrics/metricsTab.spec.tsx
+++ b/static/app/views/explore/metrics/metricsTab.spec.tsx
@@ -181,7 +181,7 @@ describe('MetricsTabContent', () => {
     });
     expect(screen.getAllByTestId('metric-panel')).toHaveLength(1);
 
-    let addButtons = screen.getAllByRole('button', {name: 'Add Metric'});
+    let addButtons = screen.getAllByRole('button', {name: 'Add Application Metric'});
     expect(addButtons[0]).toBeEnabled();
 
     await userEvent.click(addButtons[0]!);
@@ -197,7 +197,7 @@ describe('MetricsTabContent', () => {
     await userEvent.click(within(toolbars[1]!).getByRole('option', {name: 'foo'}));
     expect(within(toolbars[1]!).getByRole('button', {name: 'foo'})).toBeInTheDocument();
 
-    addButtons = screen.getAllByRole('button', {name: 'Add Metric'});
+    addButtons = screen.getAllByRole('button', {name: 'Add Application Metric'});
     expect(addButtons[0]).toBeEnabled();
 
     await userEvent.click(addButtons[0]!);
@@ -271,7 +271,7 @@ describe('MetricsTabContent', () => {
     expect(trackAnalyticsMock).toHaveBeenCalledTimes(2);
     trackAnalyticsMock.mockClear();
 
-    const addButtons = screen.getAllByRole('button', {name: 'Add Metric'});
+    const addButtons = screen.getAllByRole('button', {name: 'Add Application Metric'});
     await userEvent.click(addButtons[0]!);
 
     await waitFor(() => {
@@ -607,7 +607,7 @@ describe('MetricsTabContent', () => {
         organization,
       }
     );
-    expect(await screen.findAllByText('Add Metric')).toHaveLength(1);
+    expect(await screen.findAllByText('Add Application Metric')).toHaveLength(1);
     expect(screen.queryByText('Add Equation')).not.toBeInTheDocument();
   });
 
@@ -623,7 +623,7 @@ describe('MetricsTabContent', () => {
         organization: orgWithFeature,
       }
     );
-    expect(await screen.findAllByText('Add Metric')).toHaveLength(1);
+    expect(await screen.findAllByText('Add Application Metric')).toHaveLength(1);
     expect(screen.getAllByText('Add Equation').length).toBeGreaterThan(0);
   });
 
@@ -718,11 +718,13 @@ describe('MetricsTabContent', () => {
           },
         }
       );
-      expect(await screen.findAllByText('Add Metric')).not.toHaveLength(0);
+      expect(await screen.findAllByText('Add Application Metric')).not.toHaveLength(0);
       expect(screen.getAllByText('Add Equation').length).toBeGreaterThan(0);
 
       // Only 2 entries (cap is 3) -> both buttons are enabled
-      for (const button of screen.getAllByRole('button', {name: 'Add Metric'})) {
+      for (const button of screen.getAllByRole('button', {
+        name: 'Add Application Metric',
+      })) {
         expect(button).toBeEnabled();
       }
       for (const button of screen.getAllByRole('button', {name: 'Add Equation'})) {
@@ -730,8 +732,12 @@ describe('MetricsTabContent', () => {
       }
 
       // Add an entry, 3 entries (at cap) -> both buttons are disabled
-      await userEvent.click(screen.getAllByRole('button', {name: 'Add Metric'})[0]!);
-      for (const button of screen.getAllByRole('button', {name: 'Add Metric'})) {
+      await userEvent.click(
+        screen.getAllByRole('button', {name: 'Add Application Metric'})[0]!
+      );
+      for (const button of screen.getAllByRole('button', {
+        name: 'Add Application Metric',
+      })) {
         expect(button).toBeDisabled();
       }
       for (const button of screen.getAllByRole('button', {name: 'Add Equation'})) {
@@ -801,17 +807,17 @@ describe('MetricsTabContent', () => {
 
     // Metric A should be disabled because it is referenced by the equation
     expect(
-      within(toolbars[0]!).getByRole('button', {name: 'Delete Metric'})
+      within(toolbars[0]!).getByRole('button', {name: 'Delete Application Metric'})
     ).toBeDisabled();
 
     // Metric B should be enabled because it is not referenced by the equation
     expect(
-      within(toolbars[1]!).getByRole('button', {name: 'Delete Metric'})
+      within(toolbars[1]!).getByRole('button', {name: 'Delete Application Metric'})
     ).toBeEnabled();
 
     // Equation deletion should always be enabled
     expect(
-      within(toolbars[2]!).getByRole('button', {name: 'Delete Metric'})
+      within(toolbars[2]!).getByRole('button', {name: 'Delete Application Metric'})
     ).toBeEnabled();
   });
 });

--- a/static/app/views/explore/metrics/metricsTab.tsx
+++ b/static/app/views/explore/metrics/metricsTab.tsx
@@ -92,7 +92,7 @@ function MetricsTabFilterSection({datePageFilterProps}: MetricsTabProps) {
               <ToolbarVisualizeAddChart
                 add={addMetricQuery}
                 disabled={isAddMetricDisabled}
-                label={t('Add Metric')}
+                label={t('Add Application Metric')}
                 display="button"
               />
               {hasEquations && (
@@ -191,7 +191,7 @@ function MetricsTabBodySection({
               <ToolbarVisualizeAddChart
                 add={addMetricQuery}
                 disabled={isAddMetricDisabled}
-                label={t('Add Metric')}
+                label={t('Add Application Metric')}
                 display="button"
               />
               {hasEquations && (

--- a/static/app/views/explore/metrics/metricsTab.tsx
+++ b/static/app/views/explore/metrics/metricsTab.tsx
@@ -92,7 +92,7 @@ function MetricsTabFilterSection({datePageFilterProps}: MetricsTabProps) {
               <ToolbarVisualizeAddChart
                 add={addMetricQuery}
                 disabled={isAddMetricDisabled}
-                label={t('Add Application Metric')}
+                label={t('Add Metric')}
                 display="button"
               />
               {hasEquations && (
@@ -191,7 +191,7 @@ function MetricsTabBodySection({
               <ToolbarVisualizeAddChart
                 add={addMetricQuery}
                 disabled={isAddMetricDisabled}
-                label={t('Add Application Metric')}
+                label={t('Add Metric')}
                 display="button"
               />
               {hasEquations && (

--- a/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
+++ b/static/app/views/explore/metrics/useSaveAsMetricItems.tsx
@@ -172,8 +172,8 @@ export function useSaveAsMetricItems(options: UseSaveAsMetricItemsOptions) {
             ? [
                 {
                   key: 'add-to-dashboard-all',
-                  label: t('All Metrics'),
-                  textValue: t('All Metrics'),
+                  label: t('All Application Metrics'),
+                  textValue: t('All Application Metrics'),
                   onAction: () => {
                     addToDashboard(
                       metricQueries.filter(

--- a/static/app/views/explore/spans/crossEvents/utils.tsx
+++ b/static/app/views/explore/spans/crossEvents/utils.tsx
@@ -19,7 +19,7 @@ export function getCrossEventDropdownItems(
   ];
 
   if (canUseMetricsUI(organization)) {
-    items.push({key: 'metrics', label: t('Metrics')});
+    items.push({key: 'metrics', label: t('Application Metrics')});
   }
 
   return items;
@@ -34,7 +34,7 @@ export function getCrossEventDatasetOptions(
   ];
 
   if (canUseMetricsUI(organization)) {
-    options.push({value: 'metrics', label: t('Metrics')});
+    options.push({value: 'metrics', label: t('Application Metrics')});
   }
 
   return options;

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -498,7 +498,7 @@ describe('SpansTabContent', () => {
       expect(screen.getByRole('menuitemradio', {name: 'Spans'})).toBeInTheDocument();
       expect(screen.getByRole('menuitemradio', {name: 'Logs'})).toBeInTheDocument();
       expect(
-        screen.queryByRole('menuitemradio', {name: 'Metrics'})
+        screen.queryByRole('menuitemradio', {name: 'Application Metrics'})
       ).not.toBeInTheDocument();
     });
 
@@ -515,7 +515,9 @@ describe('SpansTabContent', () => {
         screen.getByRole('button', {name: 'Add a cross event query'})
       );
 
-      expect(screen.getByRole('menuitemradio', {name: 'Metrics'})).toBeInTheDocument();
+      expect(
+        screen.getByRole('menuitemradio', {name: 'Application Metrics'})
+      ).toBeInTheDocument();
     });
 
     it('adds a cross event query', async () => {

--- a/static/app/views/issueDetails/streamline/issueDetailsJumpTo.tsx
+++ b/static/app/views/issueDetails/streamline/issueDetailsJumpTo.tsx
@@ -24,7 +24,7 @@ const sectionLabels: Partial<Record<SectionKey, string>> = {
   [SectionKey.BREADCRUMBS]: t('Breadcrumbs'),
   [SectionKey.TRACE]: t('Trace'),
   [SectionKey.LOGS]: t('Logs'),
-  [SectionKey.METRICS]: t('Metrics'),
+  [SectionKey.METRICS]: t('Application Metrics'),
   [SectionKey.TAGS]: t('Tags'),
   [SectionKey.CONTEXTS]: t('Context'),
   [SectionKey.USER_FEEDBACK]: t('User Feedback'),

--- a/static/app/views/navigation/index.desktop.spec.tsx
+++ b/static/app/views/navigation/index.desktop.spec.tsx
@@ -378,7 +378,7 @@ describe('desktop navigation', () => {
           [`${ORG}/monitors/`, 'Monitors', 'All Monitors'],
           [`${ORG}/monitors/my-monitors/`, 'Monitors', 'My Monitors'],
           [`${ORG}/monitors/errors/`, 'Monitors', 'Errors'],
-          [`${ORG}/monitors/metrics/`, 'Monitors', 'Application Metrics'],
+          [`${ORG}/monitors/metrics/`, 'Monitors', 'Metrics'],
           [`${ORG}/monitors/crons/`, 'Monitors', 'Crons'],
           [`${ORG}/monitors/alerts/`, 'Monitors', 'Alerts'],
           // Settings

--- a/static/app/views/navigation/index.desktop.spec.tsx
+++ b/static/app/views/navigation/index.desktop.spec.tsx
@@ -378,7 +378,7 @@ describe('desktop navigation', () => {
           [`${ORG}/monitors/`, 'Monitors', 'All Monitors'],
           [`${ORG}/monitors/my-monitors/`, 'Monitors', 'My Monitors'],
           [`${ORG}/monitors/errors/`, 'Monitors', 'Errors'],
-          [`${ORG}/monitors/metrics/`, 'Monitors', 'Metrics'],
+          [`${ORG}/monitors/metrics/`, 'Monitors', 'Application Metrics'],
           [`${ORG}/monitors/crons/`, 'Monitors', 'Crons'],
           [`${ORG}/monitors/alerts/`, 'Monitors', 'Alerts'],
           // Settings

--- a/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
@@ -100,7 +100,7 @@ export function ExploreSecondaryNavigation() {
                     analyticsItemName="explore_metrics"
                     trailingItems={<FeatureBadge type="beta" />}
                   >
-                    {t('Metrics')}
+                    {t('Application Metrics')}
                   </SecondaryNavigation.Link>
                 </SecondaryNavigation.ListItem>
               </Feature>

--- a/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
@@ -100,7 +100,7 @@ export function ExploreSecondaryNavigation() {
                     analyticsItemName="explore_metrics"
                     trailingItems={<FeatureBadge type="beta" />}
                   >
-                    {t('Application Metrics')}
+                    {t('Metrics')}
                   </SecondaryNavigation.Link>
                 </SecondaryNavigation.ListItem>
               </Feature>

--- a/static/app/views/navigation/secondary/sections/monitors/monitorsSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/monitors/monitorsSecondaryNavigation.tsx
@@ -53,7 +53,7 @@ export function MonitorsSecondaryNavigation() {
                 to={`${baseUrl}/metrics/`}
                 analyticsItemName="monitors_metrics"
               >
-                {t('Metrics')}
+                {t('Application Metrics')}
               </SecondaryNavigation.Link>
             </SecondaryNavigation.ListItem>
             <SecondaryNavigation.ListItem>

--- a/static/app/views/navigation/secondary/sections/monitors/monitorsSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/monitors/monitorsSecondaryNavigation.tsx
@@ -53,7 +53,7 @@ export function MonitorsSecondaryNavigation() {
                 to={`${baseUrl}/metrics/`}
                 analyticsItemName="monitors_metrics"
               >
-                {t('Application Metrics')}
+                {t('Metrics')}
               </SecondaryNavigation.Link>
             </SecondaryNavigation.ListItem>
             <SecondaryNavigation.ListItem>

--- a/static/app/views/onboarding/components/newWelcome.tsx
+++ b/static/app/views/onboarding/components/newWelcome.tsx
@@ -94,7 +94,7 @@ const PRODUCT_OPTIONS: ProductOption[] = [
   {
     id: OnboardingWelcomeProductId.METRICS,
     icon: <IconGraph size="md" variant="secondary" />,
-    title: t('Metrics'),
+    title: t('Application Metrics'),
     description: t(
       'Track application performance and usage over time with custom metrics.'
     ),

--- a/static/app/views/onboarding/components/scmFeatureSelectionCards.spec.tsx
+++ b/static/app/views/onboarding/components/scmFeatureSelectionCards.spec.tsx
@@ -32,7 +32,7 @@ describe('ScmFeatureSelectionCards', () => {
     expect(screen.getByText('Session replay')).toBeInTheDocument();
     expect(screen.getByText('Profiling')).toBeInTheDocument();
     expect(screen.getByText('Logging')).toBeInTheDocument();
-    expect(screen.getByText('Metrics')).toBeInTheDocument();
+    expect(screen.getByText('Application Metrics')).toBeInTheDocument();
   });
 
   it('renders only passed features', () => {

--- a/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
+++ b/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
@@ -57,7 +57,7 @@ const FEATURE_META: Record<ProductSolution, FeatureMeta> = {
     ),
   },
   [ProductSolution.METRICS]: {
-    label: t('Metrics'),
+    label: t('Application Metrics'),
     icon: IconGraph,
     description: t(
       'Track application performance and usage over time with custom metrics'

--- a/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
@@ -484,7 +484,7 @@ export function getTraceViewBreadcrumbs({
     case TraceViewSources.METRICS:
       return [
         {
-          label: t('Application Metrics'),
+          label: t('Metrics'),
           to: getBreadCrumbTarget(
             normalizeUrl(`/organizations/${organization.slug}/metrics/`),
             location.query

--- a/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/breadcrumbs.tsx
@@ -484,7 +484,7 @@ export function getTraceViewBreadcrumbs({
     case TraceViewSources.METRICS:
       return [
         {
-          label: t('Metrics'),
+          label: t('Application Metrics'),
           to: getBreadCrumbTarget(
             normalizeUrl(`/organizations/${organization.slug}/metrics/`),
             location.query
@@ -523,7 +523,7 @@ export function getTraceViewBreadcrumbs({
     case TraceViewSources.TRACE_METRICS:
       return [
         {
-          label: t('Metrics'),
+          label: t('Application Metrics'),
           to: getBreadCrumbTarget(
             normalizeUrl(`/organizations/${organization.slug}/explore/metrics/`),
             location.query

--- a/static/app/views/performance/newTraceDetails/traceMetrics.tsx
+++ b/static/app/views/performance/newTraceDetails/traceMetrics.tsx
@@ -102,7 +102,7 @@ function MetricsSectionContent() {
   return (
     <Fragment>
       <SearchQueryBuilder
-        placeholder={t('Search metrics for this trace')}
+        placeholder={t('Search application metrics for this trace')}
         filterKeys={{}}
         getTagValues={() => new Promise<string[]>(() => [])}
         initialQuery={metricsSearch.formatString()}

--- a/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.tsx
+++ b/static/app/views/performance/newTraceDetails/useTraceLayoutTabs.tsx
@@ -38,7 +38,7 @@ const TAB_DEFINITIONS: Record<TraceLayoutTabKeys, Tab> = {
   [TraceLayoutTabKeys.LOGS]: {slug: TraceLayoutTabKeys.LOGS, label: t('Logs')},
   [TraceLayoutTabKeys.METRICS]: {
     slug: TraceLayoutTabKeys.METRICS,
-    label: t('Metrics'),
+    label: t('Application Metrics'),
   },
   [TraceLayoutTabKeys.AI_SPANS]: {
     slug: TraceLayoutTabKeys.AI_SPANS,

--- a/static/app/views/settings/components/dataScrubbing/utils.tsx
+++ b/static/app/views/settings/components/dataScrubbing/utils.tsx
@@ -83,7 +83,7 @@ function getDatasetLabel(dataset: AllowedDataScrubbingDatasets) {
   const labelMap: Record<AllowedDataScrubbingDatasets, string> = {
     [AllowedDataScrubbingDatasets.DEFAULT]: t('Events'),
     [AllowedDataScrubbingDatasets.LOGS]: t('Logs'),
-    [AllowedDataScrubbingDatasets.METRICS]: t('Metrics'),
+    [AllowedDataScrubbingDatasets.METRICS]: t('Application Metrics'),
   };
   return labelMap[dataset];
 }
@@ -95,7 +95,7 @@ export function getDatasetLabelLong(dataset: AllowedDataScrubbingDatasets) {
   const labelMap: Record<AllowedDataScrubbingDatasets, string> = {
     [AllowedDataScrubbingDatasets.DEFAULT]: t('Errors, Transactions, Attachments'),
     [AllowedDataScrubbingDatasets.LOGS]: t('Logs'),
-    [AllowedDataScrubbingDatasets.METRICS]: t('Metrics'),
+    [AllowedDataScrubbingDatasets.METRICS]: t('Application Metrics'),
   };
   return labelMap[dataset];
 }


### PR DESCRIPTION
Small tweak to change the label text from `Metrics` to `Application Metrics` for cross event querying.