### PR TITLE
fix(tracemetrics): Remove filter cell actions from aggregates

### DIFF
--- a/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/aggregatesTab.tsx
@@ -14,6 +14,7 @@ import {t} from 'sentry/locale';
 import {isEquation, parseFunction} from 'sentry/utils/discover/fields';
 import {prettifyTagKey} from 'sentry/utils/fields';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {Actions} from 'sentry/views/discover/table/cellAction';
 import type {TableColumn} from 'sentry/views/discover/table/types';
 import {decodeColumnOrder} from 'sentry/views/discover/utils';
 import {EXPLORE_FIVE_MIN_STALE_TIME} from 'sentry/views/explore/constants';
@@ -51,6 +52,14 @@ import {
   traceItemAttributeKeysOptions,
 } from 'sentry/views/explore/utils/traceItemAttributeKeysOptions';
 import {GenericWidgetEmptyStateWarning} from 'sentry/views/performance/landing/widgets/components/selectableList';
+
+// TODO: add back filter actions or just revert this commit
+// once the metrics search bar supports filters on aggregates
+const METRICS_AGGREGATES_CELL_ACTIONS: Actions[] = [
+  Actions.COPY_TO_CLIPBOARD,
+  Actions.OPEN_EXTERNAL_LINK,
+  Actions.OPEN_INTERNAL_LINK,
+];
 
 const RESULT_LIMIT = 50;
 
@@ -250,6 +259,7 @@ export function AggregatesTab({traceMetric, isMetricOptionsEmpty}: AggregatesTab
                       data={displayRow}
                       unit={getMetricsUnit(meta, field)}
                       meta={meta}
+                      allowActions={METRICS_AGGREGATES_CELL_ACTIONS}
                       usePortalOnDropdown
                     />
                   </AggregatesStyledRowCell>

--- a/static/app/views/explore/tables/fieldRenderer.tsx
+++ b/static/app/views/explore/tables/fieldRenderer.tsx
@@ -25,7 +25,11 @@ import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
-import {CellAction, updateQuery} from 'sentry/views/discover/table/cellAction';
+import {
+  type Actions,
+  CellAction,
+  updateQuery,
+} from 'sentry/views/discover/table/cellAction';
 import type {TableColumn} from 'sentry/views/discover/table/types';
 import {ALLOWED_CELL_ACTIONS} from 'sentry/views/explore/components/table';
 import {
@@ -47,6 +51,7 @@ import {getTraceDetailsUrl} from 'sentry/views/performance/traceDetails/utils';
 interface FieldProps {
   data: EventData;
   meta: MetaType;
+  allowActions?: Actions[];
   column?: TableColumn<keyof TableDataRow>;
   unit?: string;
   usePortalOnDropdown?: boolean;
@@ -57,6 +62,7 @@ export function FieldRenderer({
   meta,
   unit,
   column,
+  allowActions,
   usePortalOnDropdown,
 }: FieldProps) {
   const userQuery = useQueryParamsQuery();
@@ -68,6 +74,7 @@ export function FieldRenderer({
       meta={meta}
       unit={unit}
       column={column}
+      allowActions={allowActions}
       userQuery={userQuery}
       setUserQuery={setUserQuery}
       usePortalOnDropdown={usePortalOnDropdown}
@@ -105,7 +112,6 @@ export function MultiQueryFieldRenderer({
 interface BaseFieldProps extends FieldProps {
   setUserQuery: (query: string) => void;
   userQuery: string;
-  usePortalOnDropdown?: boolean;
 }
 
 function BaseExploreFieldRenderer({
@@ -113,6 +119,7 @@ function BaseExploreFieldRenderer({
   meta,
   unit,
   column,
+  allowActions,
   userQuery,
   setUserQuery,
   usePortalOnDropdown,
@@ -289,7 +296,7 @@ function BaseExploreFieldRenderer({
         updateQuery(query, actions, column, value);
         setUserQuery(query.formatString());
       }}
-      allowActions={ALLOWED_CELL_ACTIONS}
+      allowActions={allowActions ?? ALLOWED_CELL_ACTIONS}
       usePortalOnDropdown={usePortalOnDropdown}
     >
       {rendered}


### PR DESCRIPTION
The metrics search bar does not yet support filter actions, so removing actions that append to the search bar. Keeping copy to clipboard and link actions .

Closes LOGS-738
