### PR TITLE
fix(repositories): Fix repo syncing to skip deletions if we hit the pagination limit when fetching repositories

### DIFF
--- a/src/sentry/integrations/bitbucket/integration.py
+++ b/src/sentry/integrations/bitbucket/integration.py
@@ -129,6 +129,7 @@ class BitbucketIntegration(RepositoryIntegration[BitbucketApiClient], BitbucketI
         page_number_limit: int | None = None,
         accessible_only: bool = False,
         use_cache: bool = False,
+        raise_on_page_limit: bool = False,
     ) -> list[RepositoryInfo]:
         username = self.model.metadata.get("uuid", self.username)
         if not query:

--- a/src/sentry/integrations/bitbucket_server/integration.py
+++ b/src/sentry/integrations/bitbucket_server/integration.py
@@ -289,6 +289,7 @@ class BitbucketServerIntegration(RepositoryIntegration[BitbucketServerClient]):
         page_number_limit: int | None = None,
         accessible_only: bool = False,
         use_cache: bool = False,
+        raise_on_page_limit: bool = False,
     ) -> list[RepositoryInfo]:
         if not query:
             resp = self.get_client().get_repos()

--- a/src/sentry/integrations/example/integration.py
+++ b/src/sentry/integrations/example/integration.py
@@ -169,6 +169,7 @@ class ExampleIntegration(RepositoryIntegration, SourceCodeIssueIntegration, Issu
         page_number_limit: int | None = None,
         accessible_only: bool = False,
         use_cache: bool = False,
+        raise_on_page_limit: bool = False,
     ) -> list[RepositoryInfo]:
         return [{"name": "repo", "identifier": "user/repo", "external_id": "1"}]
 

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -42,6 +42,7 @@ from sentry.shared_integrations.client.proxy import IntegrationProxyClient
 from sentry.shared_integrations.exceptions import (
     ApiConflictError,
     ApiError,
+    ApiPaginationTruncated,
     ApiRateLimitedError,
     UnknownHostError,
 )
@@ -407,7 +408,7 @@ class GitHubBaseClient(
     base_url = "https://api.github.com"
     integration_name = IntegrationProviderSlug.GITHUB.value
     # Github gives us links to navigate, however, let's be safe in case we're fed garbage
-    page_number_limit = 50  # With a default of 100 per page -> 5,000 items
+    page_number_limit = 200  # With a default of 100 per page -> 20,000 items
 
     def get_last_commits(self, repo: str, end_sha: str, per_page: int = 20) -> Sequence[Any]:
         """
@@ -642,13 +643,21 @@ class GitHubBaseClient(
 
         return should_count_error
 
-    def get_repos(self, page_number_limit: int | None = None) -> list[dict[str, Any]]:
+    def get_repos(
+        self,
+        page_number_limit: int | None = None,
+        raise_on_page_limit: bool = False,
+    ) -> list[dict[str, Any]]:
         """
         This fetches all repositories accessible to the Github App
         https://docs.github.com/en/rest/apps/installations#list-repositories-accessible-to-the-app-installation
 
         It uses page_size from the base class to specify how many items per page.
         The upper bound of requests is controlled with self.page_number_limit to prevent infinite requests.
+
+        When ``raise_on_page_limit`` is True, raises ``ApiPaginationTruncated`` if the
+        pagination loop exits because it hit the cap while there were still
+        more pages available.
         """
         with SCMIntegrationInteractionEvent(
             interaction_type=SCMIntegrationInteractionType.GET_REPOSITORIES,
@@ -661,6 +670,7 @@ class GitHubBaseClient(
                 response_key="repositories",
                 page_number_limit=page_number_limit,
                 api_request_type=GitHubApiRequestType.GET_REPOSITORIES,
+                raise_on_page_limit=raise_on_page_limit,
             )
 
     def get_repos_cached(self, ttl: int = 300) -> list[CachedRepo]:
@@ -718,6 +728,7 @@ class GitHubBaseClient(
         response_key: str | None = None,
         page_number_limit: int | None = None,
         api_request_type: GitHubApiRequestType | None = None,
+        raise_on_page_limit: bool = False,
     ) -> list[Any]:
         """
         Github uses the Link header to provide pagination links. Github
@@ -726,7 +737,11 @@ class GitHubBaseClient(
         https://docs.github.com/en/rest/guides/traversing-with-pagination
 
         Use response_key when the API stores the results within a key.
-        For instance, the repositories API returns the list of repos under the "repositories" key
+        For instance, the repositories API returns the list of repos under the "repositories" key.
+
+        When ``raise_on_page_limit`` is True and the loop exits because it hit
+        ``page_number_limit`` while Github was still advertising a next page,
+        raises ``ApiPaginationTruncated`` with the partial result attached.
         """
         if page_number_limit is None or page_number_limit > self.page_number_limit:
             page_number_limit = self.page_number_limit
@@ -754,6 +769,12 @@ class GitHubBaseClient(
 
                 next_link = get_next_link(resp)
                 page_number += 1
+
+            if next_link and raise_on_page_limit:
+                raise ApiPaginationTruncated(
+                    output,
+                    f"pagination stopped at page_number_limit={page_number_limit}",
+                )
             return output
 
     def search_issues(self, query: str) -> Mapping[str, Sequence[Mapping[str, Any]]]:

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -664,14 +664,21 @@ class GitHubBaseClient(
             provider_key=self.integration_name,
             integration_id=self.integration.id,
             organization_id=self.organization_id,
-        ).capture():
-            return self._get_with_pagination(
-                "/installation/repositories",
-                response_key="repositories",
-                page_number_limit=page_number_limit,
-                api_request_type=GitHubApiRequestType.GET_REPOSITORIES,
-                raise_on_page_limit=raise_on_page_limit,
-            )
+        ).capture() as lifecycle:
+            try:
+                return self._get_with_pagination(
+                    "/installation/repositories",
+                    response_key="repositories",
+                    page_number_limit=page_number_limit,
+                    api_request_type=GitHubApiRequestType.GET_REPOSITORIES,
+                    raise_on_page_limit=raise_on_page_limit,
+                )
+            except ApiPaginationTruncated as e:
+                # Hitting the pagination cap is an expected signal.
+                # Record as halt so the lifecycle doesn't create a
+                # Sentry every time this is called.
+                lifecycle.record_halt(e, create_issue=False)
+                raise
 
     def get_repos_cached(self, ttl: int = 300) -> list[CachedRepo]:
         """

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -262,6 +262,7 @@ class GitHubIntegration(
         page_number_limit: int | None = None,
         accessible_only: bool = False,
         use_cache: bool = False,
+        raise_on_page_limit: bool = False,
     ) -> list[RepositoryInfo]:
         """
         args:
@@ -271,6 +272,10 @@ class GitHubIntegration(
           (which may return repos outside the installation's scope)
         * use_cache - when True, serve repos from a short-lived cache instead
           of re-fetching all pages from GitHub on every call
+        * raise_on_page_limit - when True and GitHub pagination stops at the
+          page_number_limit cap with more data still available, raise
+          ApiPaginationTruncated (partial result attached). Ignored when
+          ``use_cache`` is True.
 
         This fetches all repositories accessible to the Github App
         https://docs.github.com/en/rest/apps/installations#list-repositories-accessible-to-the-app-installation
@@ -291,7 +296,10 @@ class GitHubIntegration(
         def _get_all_repos():
             if use_cache:
                 return client.get_repos_cached()
-            return client.get_repos(page_number_limit=page_number_limit)
+            return client.get_repos(
+                page_number_limit=page_number_limit,
+                raise_on_page_limit=raise_on_page_limit,
+            )
 
         if not query:
             all_repos = _get_all_repos()

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -65,7 +65,12 @@ from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.pipeline.types import PipelineStepResult
 from sentry.pipeline.views.base import ApiPipelineSteps, PipelineView
 from sentry.shared_integrations.constants import ERR_INTERNAL, ERR_UNAUTHORIZED
-from sentry.shared_integrations.exceptions import ApiError, ApiInvalidRequestError, IntegrationError
+from sentry.shared_integrations.exceptions import (
+    ApiError,
+    ApiInvalidRequestError,
+    ApiPaginationTruncated,
+    IntegrationError,
+)
 from sentry.snuba.referrer import Referrer
 from sentry.utils import metrics
 from sentry.utils.http import absolute_uri
@@ -293,26 +298,30 @@ class GitHubIntegration(
                 for i in raw_repos
             ]
 
-        def _get_all_repos():
-            if use_cache:
-                return client.get_repos_cached()
-            return client.get_repos(
-                page_number_limit=page_number_limit,
-                raise_on_page_limit=raise_on_page_limit,
-            )
+        query_lower = query.lower() if query else None
 
-        if not query:
-            all_repos = _get_all_repos()
-            return to_repo_info(r for r in all_repos if not r.get("archived"))
+        def _process(raw_repos: Iterable[Mapping[str, Any]]) -> list[RepositoryInfo]:
+            filtered = (r for r in raw_repos if not r.get("archived"))
+            if query_lower is not None:
+                filtered = (r for r in filtered if query_lower in r["full_name"].lower())
+            return to_repo_info(filtered)
 
-        if accessible_only:
-            all_repos = _get_all_repos()
-            query_lower = query.lower()
-            return to_repo_info(
-                r
-                for r in all_repos
-                if not r.get("archived") and query_lower in r["full_name"].lower()
-            )
+        def _fetch_and_process() -> list[RepositoryInfo]:
+            try:
+                raw = (
+                    client.get_repos_cached()
+                    if use_cache
+                    else client.get_repos(
+                        page_number_limit=page_number_limit,
+                        raise_on_page_limit=raise_on_page_limit,
+                    )
+                )
+            except ApiPaginationTruncated as e:
+                raise ApiPaginationTruncated(_process(e.partial_data)) from e
+            return _process(raw)
+
+        if not query or accessible_only:
+            return _fetch_and_process()
 
         assert not use_cache, "use_cache is not supported with the Search API path"
         full_query = build_repository_query(self.model.metadata, self.model.name, query)

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping, MutableMapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, MutableMapping, Sequence
 from typing import Any
 from urllib.parse import urlparse
 
@@ -48,7 +48,11 @@ from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.pipeline.views.base import PipelineView
 from sentry.pipeline.views.nested import NestedPipelineView
 from sentry.shared_integrations.constants import ERR_INTERNAL, ERR_UNAUTHORIZED
-from sentry.shared_integrations.exceptions import ApiError, IntegrationError
+from sentry.shared_integrations.exceptions import (
+    ApiError,
+    ApiPaginationTruncated,
+    IntegrationError,
+)
 from sentry.utils import jwt, metrics
 from sentry.utils.http import absolute_uri
 from sentry.web.helpers import render_to_response
@@ -229,11 +233,7 @@ class GitHubEnterpriseIntegration(
         use_cache: bool = False,
         raise_on_page_limit: bool = False,
     ) -> list[RepositoryInfo]:
-        if not query:
-            all_repos = self.get_client().get_repos(
-                page_number_limit=page_number_limit,
-                raise_on_page_limit=raise_on_page_limit,
-            )
+        def _process(raw_repos: Iterable[Mapping[str, Any]]) -> list[RepositoryInfo]:
             return [
                 {
                     "name": i["name"],
@@ -241,9 +241,21 @@ class GitHubEnterpriseIntegration(
                     "external_id": self.get_repo_external_id(i),
                     "default_branch": i.get("default_branch"),
                 }
-                for i in all_repos
+                for i in raw_repos
                 if not i.get("archived")
             ]
+
+        if not query:
+            try:
+                all_repos = self.get_client().get_repos(
+                    page_number_limit=page_number_limit,
+                    raise_on_page_limit=raise_on_page_limit,
+                )
+            except ApiPaginationTruncated as e:
+                # Transform partial data into RepositoryInfo before re-raising
+                # so callers see the same shape regardless of truncation.
+                raise ApiPaginationTruncated(_process(e.partial_data)) from e
+            return _process(all_repos)
 
         full_query = build_repository_query(self.model.metadata, self.model.name, query)
         response = self.get_client().search_repositories(full_query)

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -227,9 +227,13 @@ class GitHubEnterpriseIntegration(
         page_number_limit: int | None = None,
         accessible_only: bool = False,
         use_cache: bool = False,
+        raise_on_page_limit: bool = False,
     ) -> list[RepositoryInfo]:
         if not query:
-            all_repos = self.get_client().get_repos(page_number_limit=page_number_limit)
+            all_repos = self.get_client().get_repos(
+                page_number_limit=page_number_limit,
+                raise_on_page_limit=raise_on_page_limit,
+            )
             return [
                 {
                     "name": i["name"],

--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -179,6 +179,7 @@ class GitlabIntegration(
         page_number_limit: int | None = None,
         accessible_only: bool = False,
         use_cache: bool = False,
+        raise_on_page_limit: bool = False,
     ) -> list[RepositoryInfo]:
         try:
             # Note: gitlab projects are the same things as repos everywhere else

--- a/src/sentry/integrations/perforce/integration.py
+++ b/src/sentry/integrations/perforce/integration.py
@@ -315,6 +315,7 @@ class PerforceIntegration(RepositoryIntegration[PerforceClient], CommitContextIn
         page_number_limit: int | None = None,
         accessible_only: bool = False,
         use_cache: bool = False,
+        raise_on_page_limit: bool = False,
     ) -> list[RepositoryInfo]:
         """
         Get list of depots/streams from Perforce server.

--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -65,6 +65,7 @@ class BaseRepositoryIntegration(ABC):
         page_number_limit: int | None = None,
         accessible_only: bool = False,
         use_cache: bool = False,
+        raise_on_page_limit: bool = False,
     ) -> list[RepositoryInfo]:
         """
         Get a list of available repositories for an installation
@@ -89,6 +90,11 @@ class BaseRepositoryIntegration(ABC):
         only repositories the installation has access to are
         returned, filtering locally instead of using the provider's
         search API.
+
+        When ``raise_on_page_limit`` is True and the provider's fetch hits a
+        pagination cap with more data still available, ``ApiPaginationTruncated``
+        is raised with the partial result attached. Providers without a
+        pagination cap may accept and ignore this argument.
         """
         raise NotImplementedError
 

--- a/src/sentry/integrations/source_code_management/sync_repos.py
+++ b/src/sentry/integrations/source_code_management/sync_repos.py
@@ -176,9 +176,7 @@ def sync_repos_for_org(organization_integration_id: int) -> None:
         new_ids = provider_external_ids - sentry_active_ids - sentry_disabled_ids
         # Skip removals entirely if we didn't manage to fetch all repos for this integration.
         # We have to do this, otherwise we'd incorrectly disable repos that weren't fetched
-        removed_ids: set[str] = (
-            set() if fetch_truncated else sentry_active_ids - provider_external_ids
-        )
+        removed_ids = set() if fetch_truncated else sentry_active_ids - provider_external_ids
         restored_ids = sentry_disabled_ids & provider_external_ids
 
         metric_tags = {

--- a/src/sentry/integrations/source_code_management/sync_repos.py
+++ b/src/sentry/integrations/source_code_management/sync_repos.py
@@ -32,7 +32,10 @@ from sentry.integrations.source_code_management.repository import RepositoryInte
 from sentry.organizations.services.organization import organization_service
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.plugins.providers.integration_repository import get_integration_repository_provider
-from sentry.shared_integrations.exceptions import ApiError
+from sentry.shared_integrations.exceptions import (
+    ApiError,
+    ApiPaginationTruncated,
+)
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task, retry
 from sentry.taskworker.namespaces import integrations_control_tasks
@@ -120,8 +123,30 @@ def sync_repos_for_org(organization_integration_id: int) -> None:
         installation = integration.get_installation(organization_id=rpc_org.id)
         assert isinstance(installation, RepositoryIntegration)
 
+        fetch_truncated = False
         try:
-            provider_repos = installation.get_repositories()
+            provider_repos = installation.get_repositories(raise_on_page_limit=True)
+        except ApiPaginationTruncated as e:
+            # Provider fetch hit a pagination cap with more data still
+            # available. We keep the partial result for create/restore — those
+            # are additive and safe — but skip the disable path so repos that
+            # fell off the tail of the cap aren't wrongly removed.
+            provider_repos = e.partial_data
+            fetch_truncated = True
+            logger.warning(
+                "sync_repos_for_org.pagination_cap_hit",
+                extra={
+                    "integration_id": integration.id,
+                    "organization_id": rpc_org.id,
+                    "provider": provider_key,
+                    "count": len(provider_repos),
+                },
+            )
+            metrics.incr(
+                "scm.repo_sync.pagination_cap_hit",
+                tags={"provider": provider_key},
+                sample_rate=1.0,
+            )
         except ApiError as e:
             if installation.is_rate_limited_error(e):
                 logger.info(
@@ -149,7 +174,11 @@ def sync_repos_for_org(organization_integration_id: int) -> None:
         sentry_disabled_ids = {r.external_id for r in disabled_repos}
 
         new_ids = provider_external_ids - sentry_active_ids - sentry_disabled_ids
-        removed_ids = sentry_active_ids - provider_external_ids
+        # Skip removals entirely if we didn't manage to fetch all repos for this integration.
+        # We have to do this, otherwise we'd incorrectly disable repos that weren't fetched
+        removed_ids: set[str] = (
+            set() if fetch_truncated else sentry_active_ids - provider_external_ids
+        )
         restored_ids = sentry_disabled_ids & provider_external_ids
 
         metric_tags = {

--- a/src/sentry/integrations/vsts/integration.py
+++ b/src/sentry/integrations/vsts/integration.py
@@ -344,6 +344,7 @@ class VstsIntegration(RepositoryIntegration[VstsApiClient], VstsIssuesSpec):
         page_number_limit: int | None = None,
         accessible_only: bool = False,
         use_cache: bool = False,
+        raise_on_page_limit: bool = False,
     ) -> list[RepositoryInfo]:
         try:
             repos = self.get_client().get_repos()

--- a/src/sentry/shared_integrations/exceptions/__init__.py
+++ b/src/sentry/shared_integrations/exceptions/__init__.py
@@ -17,6 +17,7 @@ __all__ = (
     "ApiError",
     "ApiConflictError",
     "ApiHostError",
+    "ApiPaginationTruncated",
     "ApiTimeoutError",
     "ApiUnauthorized",
     "ApiRateLimitedError",
@@ -173,6 +174,21 @@ class UnsupportedResponseType(ApiError):
     @property
     def content_type(self) -> str:
         return self.text
+
+
+class ApiPaginationTruncated(Exception):
+    """
+    Raised by paginated fetch helpers when they hit a cap (e.g. a
+    `page_number_limit`) while more pages were still available on the provider.
+
+    Callers that opt in use this to distinguish "we got everything" from "we got a prefix, there's more."
+    The partial results fetched before the cap are attached as ``partial_data`` so
+    callers can still use what was retrieved.
+    """
+
+    def __init__(self, partial_data: list[Any], message: str = "pagination truncated") -> None:
+        self.partial_data = partial_data
+        super().__init__(message)
 
 
 class IntegrationError(Exception):

--- a/tests/sentry/integrations/source_code_management/test_sync_repos.py
+++ b/tests/sentry/integrations/source_code_management/test_sync_repos.py
@@ -332,22 +332,6 @@ class SyncReposForOrgTestCase(IntegrationTestCase):
                 organization_id=self.organization.id, external_id="1"
             ).exists()
 
-    @patch("sentry.integrations.github.integration.GitHubIntegration.get_repositories")
-    def test_installation_suspended_halts_without_retry(
-        self, mock_get_repositories: MagicMock, _: MagicMock
-    ) -> None:
-        from sentry.shared_integrations.exceptions import ApiForbiddenError
-
-        mock_get_repositories.side_effect = ApiForbiddenError(
-            '{"message":"This installation has been suspended"}'
-        )
-
-        with self.feature("organizations:github-repo-auto-sync"), self.tasks():
-            sync_repos_for_org(self.oi.id)
-
-        with assume_test_silo_mode(SiloMode.CELL):
-            assert Repository.objects.count() == 0
-
 
 @control_silo_test
 class SyncReposForOrgGHETestCase(TestCase):
@@ -396,6 +380,75 @@ class SyncReposForOrgGHETestCase(TestCase):
 
         assert len(repos) == 2
         assert repos[0].provider == "integrations:github_enterprise"
+
+    @patch("sentry.tasks.seer.cleanup.make_bulk_remove_repositories_request")
+    @patch("sentry.integrations.github.client.GitHubBaseClient.get_repos")
+    def test_truncated_fetch_skips_disable_for_ghe(
+        self, mock_get_repos: MagicMock, _: MagicMock
+    ) -> None:
+        # Same partial-data transformation as the GitHub path: when GHE's
+        # client raises ApiPaginationTruncated with raw API dicts, the
+        # integration must transform them to RepositoryInfo before re-raising
+        # so sync_repos doesn't KeyError on `external_id`.
+        from sentry.integrations.github_enterprise.integration import (
+            GitHubEnterpriseIntegrationProvider,
+        )
+        from sentry.shared_integrations.exceptions import ApiPaginationTruncated
+
+        GitHubEnterpriseIntegrationProvider().setup()
+
+        integration = self.create_integration(
+            organization=self.organization,
+            external_id="35.232.149.196:12345",
+            provider="github_enterprise",
+            metadata={
+                "domain_name": "35.232.149.196/testorg",
+                "installation_id": "12345",
+                "installation": {
+                    "id": "2",
+                    "private_key": "private_key",
+                    "verify_ssl": True,
+                },
+            },
+        )
+        oi = OrganizationIntegration.objects.get(
+            organization_id=self.organization.id, integration=integration
+        )
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            repo = Repository.objects.create(
+                organization_id=self.organization.id,
+                name="testorg/old-repo",
+                external_id="99",
+                provider="integrations:github_enterprise",
+                integration_id=integration.id,
+                status=ObjectStatus.ACTIVE,
+            )
+
+        # Raw GHE API dicts in partial_data — must be transformed by the
+        # integration before sync_repos sees them.
+        mock_get_repos.side_effect = ApiPaginationTruncated(
+            partial_data=[{"id": 1, "full_name": "testorg/repo1", "name": "repo1"}]
+        )
+
+        with self.feature(
+            [
+                "organizations:github_enterprise-repo-auto-sync",
+                "organizations:github_enterprise-repo-auto-sync-apply",
+                "organizations:scm-repo-auto-sync-removal",
+            ]
+        ):
+            with self.tasks():
+                sync_repos_for_org(oi.id)
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            repo.refresh_from_db()
+            assert repo.status == ObjectStatus.ACTIVE  # not disabled
+            # Creation still runs on the transformed partial list — fails
+            # if partial_data wasn't run through the transform.
+            assert Repository.objects.filter(
+                organization_id=self.organization.id, external_id="1"
+            ).exists()
 
 
 @control_silo_test

--- a/tests/sentry/integrations/source_code_management/test_sync_repos.py
+++ b/tests/sentry/integrations/source_code_management/test_sync_repos.py
@@ -290,13 +290,10 @@ class SyncReposForOrgTestCase(IntegrationTestCase):
         "sentry.tasks.seer.cleanup.make_bulk_remove_repositories_request",
         return_value=MagicMock(status=200),
     )
-    @patch("sentry.integrations.github.integration.GitHubIntegration.get_repositories")
+    @patch("sentry.integrations.github.client.GitHubBaseClient.get_repos")
     def test_truncated_fetch_skips_disable(
-        self, mock_get_repositories: MagicMock, _: MagicMock, __: MagicMock
+        self, mock_get_repos: MagicMock, _: MagicMock, __: MagicMock
     ) -> None:
-        # The provider fetch hit the pagination cap — it signals this via
-        # ApiPaginationTruncated with partial results attached. We must NOT
-        # disable repos absent from the partial list (they might be past the cap).
         from sentry.shared_integrations.exceptions import ApiPaginationTruncated
 
         with assume_test_silo_mode(SiloMode.CELL):
@@ -309,14 +306,11 @@ class SyncReposForOrgTestCase(IntegrationTestCase):
                 status=ObjectStatus.ACTIVE,
             )
 
-        mock_get_repositories.side_effect = ApiPaginationTruncated(
+        # Raw GitHub API response shape — the integration must transform this
+        # into RepositoryInfo before it reaches sync_repos.
+        mock_get_repos.side_effect = ApiPaginationTruncated(
             partial_data=[
-                {
-                    "name": "sentry",
-                    "identifier": "getsentry/sentry",
-                    "external_id": "1",
-                    "default_branch": None,
-                }
+                {"id": 1, "full_name": "getsentry/sentry", "name": "sentry"},
             ]
         )
 
@@ -333,7 +327,7 @@ class SyncReposForOrgTestCase(IntegrationTestCase):
         with assume_test_silo_mode(SiloMode.CELL):
             repo.refresh_from_db()
             assert repo.status == ObjectStatus.ACTIVE  # not disabled
-            # Creation still runs on the partial list
+            # Creation still runs on the transformed partial list
             assert Repository.objects.filter(
                 organization_id=self.organization.id, external_id="1"
             ).exists()

--- a/tests/sentry/integrations/source_code_management/test_sync_repos.py
+++ b/tests/sentry/integrations/source_code_management/test_sync_repos.py
@@ -283,6 +283,77 @@ class SyncReposForOrgTestCase(IntegrationTestCase):
             with self.tasks():
                 sync_repos_for_org(self.oi.id)
 
+        with assume_test_silo_mode(SiloMode.CELL):
+            assert Repository.objects.count() == 0
+
+    @patch(
+        "sentry.tasks.seer.cleanup.make_bulk_remove_repositories_request",
+        return_value=MagicMock(status=200),
+    )
+    @patch("sentry.integrations.github.integration.GitHubIntegration.get_repositories")
+    def test_truncated_fetch_skips_disable(
+        self, mock_get_repositories: MagicMock, _: MagicMock, __: MagicMock
+    ) -> None:
+        # The provider fetch hit the pagination cap — it signals this via
+        # ApiPaginationTruncated with partial results attached. We must NOT
+        # disable repos absent from the partial list (they might be past the cap).
+        from sentry.shared_integrations.exceptions import ApiPaginationTruncated
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            repo = Repository.objects.create(
+                organization_id=self.organization.id,
+                name="getsentry/old-repo",
+                external_id="99",
+                provider="integrations:github",
+                integration_id=self.integration.id,
+                status=ObjectStatus.ACTIVE,
+            )
+
+        mock_get_repositories.side_effect = ApiPaginationTruncated(
+            partial_data=[
+                {
+                    "name": "sentry",
+                    "identifier": "getsentry/sentry",
+                    "external_id": "1",
+                    "default_branch": None,
+                }
+            ]
+        )
+
+        with self.feature(
+            [
+                "organizations:github-repo-auto-sync",
+                "organizations:github-repo-auto-sync-apply",
+                "organizations:scm-repo-auto-sync-removal",
+            ]
+        ):
+            with self.tasks():
+                sync_repos_for_org(self.oi.id)
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            repo.refresh_from_db()
+            assert repo.status == ObjectStatus.ACTIVE  # not disabled
+            # Creation still runs on the partial list
+            assert Repository.objects.filter(
+                organization_id=self.organization.id, external_id="1"
+            ).exists()
+
+    @patch("sentry.integrations.github.integration.GitHubIntegration.get_repositories")
+    def test_installation_suspended_halts_without_retry(
+        self, mock_get_repositories: MagicMock, _: MagicMock
+    ) -> None:
+        from sentry.shared_integrations.exceptions import ApiForbiddenError
+
+        mock_get_repositories.side_effect = ApiForbiddenError(
+            '{"message":"This installation has been suspended"}'
+        )
+
+        with self.feature("organizations:github-repo-auto-sync"), self.tasks():
+            sync_repos_for_org(self.oi.id)
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            assert Repository.objects.count() == 0
+
 
 @control_silo_test
 class SyncReposForOrgGHETestCase(TestCase):


### PR DESCRIPTION
Some scm integrations have more than 5000 repositories. In these cases, at the moment we'd accidentally disable repositories that we failed to fetch from the api, since it looks like they're no longer present. This pr bumps up the page limit, and also detects when we hit the page limit and skips the disable step.

<!-- Describe your PR here. -->