### PR TITLE
feat(night-shift): Add custom issue-details tool for agentic triage

### DIFF
--- a/src/sentry/tasks/seer/night_shift/agentic_triage.py
+++ b/src/sentry/tasks/seer/night_shift/agentic_triage.py
@@ -18,7 +18,10 @@ from sentry.tasks.seer.night_shift.simple_triage import (
     fixability_score_strategy,
     priority_label,
 )
-from sentry.tasks.seer.night_shift.triage_tools import get_event_details_agentic_triage
+from sentry.tasks.seer.night_shift.triage_tools import (
+    get_event_details_agentic_triage,
+    get_issue_details_agentic_triage,
+)
 
 logger = logging.getLogger("sentry.tasks.seer.night_shift")
 
@@ -73,7 +76,10 @@ def _triage_candidates(
             category_value=f"org-{organization.id}",
             intelligence_level="high",
             reasoning_effort="high",
-            custom_tools=[get_event_details_agentic_triage],
+            custom_tools=[
+                get_event_details_agentic_triage,
+                get_issue_details_agentic_triage,
+            ],
         )
 
         agent_run_id = client.start_run(
@@ -224,6 +230,12 @@ def _build_triage_prompt(
         When fetching event data for an issue, always use the `get_event_details_agentic_triage`
         tool instead of `get_event_details`. It returns the same data in a cleaner,
         more readable format tuned for triage.
+
+        Similarly, when fetching issue-level metadata, always use the
+        `get_issue_details_agentic_triage` tool instead of `get_issue_details`.
+        It returns the header, tag distribution, and recent human activity in a
+        compact markdown format. Do not rely on it for stacktraces — call
+        `get_event_details_agentic_triage` for that.
 
         Before recording any verdict, you MUST read the relevant application code.
         Surface reading of the error message and stacktrace is not enough — many

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -268,6 +268,7 @@ def _execute_night_shift_run(
                     "group_id": c.group.id,
                     "action": c.action,
                     "seer_run_id": seer_run_id_by_group.get(c.group.id),
+                    "num_occurrences": c.group.times_seen,
                 }
                 for c in candidates
             ],

--- a/src/sentry/tasks/seer/night_shift/issue_formatter.py
+++ b/src/sentry/tasks/seer/night_shift/issue_formatter.py
@@ -1,0 +1,189 @@
+"""
+Issue formatter for the Night Shift agentic triage tool.
+
+Triage-tuned: renders the fields from Seer's `get_issue_details` that actually
+move the verdict — header (title/culprit/priority/counts/first-last seen),
+aggregated tag distribution, and recent human activity. The latest-event
+stacktrace excerpt is intentionally omitted so the agent is steered toward
+`get_event_details_agentic_triage` (which exposes the full stack, locals on
+the first in-app frame, and linked repos).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+def format_issue_output(details: Mapping[str, Any]) -> str:
+    """Render Seer's `get_issue_details` response as markdown for triage."""
+    issue = details.get("issue") or {}
+    tags_overview = details.get("tags_overview") or {}
+    activity = details.get("user_activity") or []
+
+    sections = [
+        _format_header(issue),
+        _format_tags(tags_overview),
+        _format_activity(activity),
+    ]
+    return "\n\n".join(s for s in sections if s) + "\n"
+
+
+def _format_header(issue: Mapping[str, Any]) -> str:
+    short_id = issue.get("shortId") or "(no short id)"
+    title = issue.get("title") or "Unknown"
+    lines = [f"# {short_id}: {title}"]
+
+    culprit = issue.get("culprit")
+    if culprit:
+        lines.append(f"**Culprit:** `{culprit}`")
+
+    issue_type = issue.get("issueType")
+    issue_category = issue.get("issueCategory")
+    type_desc = issue.get("issueTypeDescription")
+    type_parts = [p for p in (issue_type, issue_category) if p]
+    if type_parts:
+        suffix = f" — {type_desc}" if type_desc else ""
+        lines.append(f"**Type:** {' / '.join(type_parts)}{suffix}")
+
+    status_bits = [
+        ("Level", issue.get("level")),
+        ("Priority", issue.get("priority")),
+        ("Status", issue.get("status")),
+        ("Substatus", issue.get("substatus")),
+    ]
+    status_line = " | ".join(f"**{k}:** {v}" for k, v in status_bits if v)
+    if status_line:
+        lines.append(status_line)
+
+    first_seen = issue.get("firstSeen")
+    last_seen = issue.get("lastSeen")
+    if first_seen or last_seen:
+        seen_bits = []
+        if first_seen:
+            seen_bits.append(f"**First seen:** {first_seen}")
+        if last_seen:
+            seen_bits.append(f"**Last seen:** {last_seen}")
+        lines.append(" | ".join(seen_bits))
+
+    count = issue.get("count")
+    user_count = issue.get("userCount")
+    count_bits = []
+    if count is not None:
+        count_bits.append(f"**Events:** {count}")
+    if user_count is not None:
+        count_bits.append(f"**Users affected:** {user_count}")
+    if count_bits:
+        lines.append(" | ".join(count_bits))
+
+    assigned_to = issue.get("assignedTo")
+    assignee = _format_actor(assigned_to) if assigned_to else None
+    if assignee:
+        lines.append(f"**Assigned to:** {assignee}")
+
+    platform = issue.get("platform")
+    if platform:
+        lines.append(f"**Platform:** {platform}")
+
+    return "\n".join(lines)
+
+
+def _format_tags(tags_overview: Mapping[str, Any]) -> str:
+    # Seer returns {"tags_overview": [...tags...]} under the response's
+    # "tags_overview" key — unwrap the inner list.
+    inner = tags_overview.get("tags_overview") if isinstance(tags_overview, Mapping) else None
+    if not isinstance(inner, Sequence) or not inner:
+        return ""
+
+    blocks = []
+    for tag in inner:
+        if not isinstance(tag, Mapping):
+            continue
+        key = tag.get("key")
+        if not key:
+            continue
+        name = tag.get("name") or key
+        total = tag.get("total_values")
+        unique = tag.get("unique_values")
+
+        meta_bits = []
+        if total is not None:
+            meta_bits.append(f"{total} total")
+        if unique is not None:
+            meta_bits.append(f"{unique} unique")
+        meta = f" ({', '.join(meta_bits)})" if meta_bits else ""
+
+        header = f"**{name}** (`{key}`){meta}" if name != key else f"**{key}**{meta}"
+
+        top_values = tag.get("top_values") or []
+        value_lines = []
+        for tv in top_values:
+            if not isinstance(tv, Mapping):
+                continue
+            value = tv.get("value")
+            count = tv.get("count")
+            pct = tv.get("percentage")
+            pct_str = f" ({pct})" if pct is not None else ""
+            count_str = f" — {count}" if count is not None else ""
+            value_lines.append(f"- {value}{count_str}{pct_str}")
+
+        if not value_lines:
+            continue
+        blocks.append(header + "\n" + "\n".join(value_lines))
+
+    if not blocks:
+        return ""
+    return "## Tag Distribution\n\n" + "\n\n".join(blocks)
+
+
+def _format_activity(activity: Sequence[Any]) -> str:
+    if not activity:
+        return ""
+
+    lines = []
+    for item in activity:
+        if not isinstance(item, Mapping):
+            continue
+        when = item.get("dateCreated")
+        actor = _format_actor(item.get("user")) or _format_actor(item.get("sentry_app")) or "system"
+        type_ = item.get("type") or "activity"
+        detail = _summarize_activity_data(item.get("data"))
+        when_str = f"{when} — " if when else ""
+        detail_str = f": {detail}" if detail else ""
+        lines.append(f"- {when_str}{actor} ({type_}){detail_str}")
+
+    if not lines:
+        return ""
+    return "## Recent Activity\n\n" + "\n".join(lines)
+
+
+def _format_actor(actor: Any) -> str | None:
+    if not isinstance(actor, Mapping):
+        return None
+    for key in ("email", "username", "name"):
+        value = actor.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _summarize_activity_data(data: Any) -> str:
+    if not isinstance(data, Mapping) or not data:
+        return ""
+    preferred_keys = (
+        "text",
+        "assignee",
+        "assigneeEmail",
+        "version",
+        "commit",
+        "pullRequest",
+    )
+    for key in preferred_keys:
+        value = data.get(key)
+        if isinstance(value, str) and value:
+            return f"{key}={value}"
+        if isinstance(value, Mapping):
+            nested = value.get("id") or value.get("shortId") or value.get("title")
+            if nested:
+                return f"{key}={nested}"
+    return ""

--- a/src/sentry/tasks/seer/night_shift/triage_tools.py
+++ b/src/sentry/tasks/seer/night_shift/triage_tools.py
@@ -100,16 +100,13 @@ class get_event_details_agentic_triage(  # noqa: N801
             return "Event not found. Check the issue_id/event_id and time range."
 
         event = result.get("event") or {}
-        project_id = result.get("project_id")
-        linked_repos = _format_linked_repos(project_id) if project_id else ""
         body = format_event_output(event)
         return (
             f"Event ID: {result.get('event_id')}\n"
             f"Trace ID: {result.get('event_trace_id') or 'N/A'}\n"
             f"Issue ID: {event.get('groupID') or 'N/A'}\n"
-            f"Project ID: {project_id}\n"
+            f"Project ID: {result.get('project_id')}\n"
             f"Project Slug: {result.get('project_slug')}\n"
-            f"{linked_repos}"
             f"\n{body}"
         )
 
@@ -144,10 +141,9 @@ class get_issue_details_agentic_triage(  # noqa: N801
 
     Returns the same underlying issue metadata as Seer's built-in `get_issue_details`,
     but reformats it as triage-tuned markdown: header (title/culprit/priority/counts/
-    first-last seen), aggregated tag distribution, and recent human activity. The
-    latest-event stacktrace excerpt is intentionally omitted so the agent is steered
-    toward `get_event_details_agentic_triage` for stack inspection (which exposes
-    the full stack, locals on the first in-app frame, and linked repos).
+    first-last seen), linked repos, aggregated tag distribution, and recent human
+    activity. The latest-event stacktrace excerpt is intentionally omitted so the
+    agent is steered toward `get_event_details_agentic_triage` for stack inspection.
     """
 
     params_model = GetIssueDetailsAgenticTriageParams
@@ -157,8 +153,9 @@ class get_issue_details_agentic_triage(  # noqa: N801
         return (
             "Fetch issue-level metadata for a Sentry issue: title, culprit, "
             "level/priority/status, first/last seen, event and user counts, "
-            "assignee, aggregated tag distribution across all events, and "
-            "recent human activity (notes, assignments, resolutions).\n\n"
+            "assignee, linked repositories (repo name + source/stack roots), "
+            "aggregated tag distribution across all events, and recent human "
+            "activity (notes, assignments, resolutions).\n\n"
             "Use this to decide whether an issue is worth investigating. For "
             "the actual stacktrace and failing code context, call "
             "`get_event_details_agentic_triage` separately."
@@ -183,11 +180,14 @@ class get_issue_details_agentic_triage(  # noqa: N801
         if result is None:
             return "Issue not found. Check the issue_id and time range."
 
+        project_id = result.get("project_id")
+        linked_repos = _format_linked_repos(project_id) if project_id else ""
         body = format_issue_output(result)
         return (
             f"Issue ID: {params.issue_id}\n"
-            f"Project ID: {result.get('project_id')}\n"
+            f"Project ID: {project_id}\n"
             f"Project Slug: {result.get('project_slug')}\n"
+            f"{linked_repos}"
             f"\n{body}"
         )
 

--- a/src/sentry/tasks/seer/night_shift/triage_tools.py
+++ b/src/sentry/tasks/seer/night_shift/triage_tools.py
@@ -9,8 +9,9 @@ from sentry.integrations.models.repository_project_path_config import (
 from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.seer.explorer.custom_tool_utils import ExplorerTool
-from sentry.seer.explorer.tools import get_event_details
+from sentry.seer.explorer.tools import get_event_details, get_issue_details
 from sentry.tasks.seer.night_shift.event_formatter import format_event_output
+from sentry.tasks.seer.night_shift.issue_formatter import format_issue_output
 
 
 class GetEventDetailsAgenticTriageParams(BaseModel):
@@ -109,6 +110,84 @@ class get_event_details_agentic_triage(  # noqa: N801
             f"Project ID: {project_id}\n"
             f"Project Slug: {result.get('project_slug')}\n"
             f"{linked_repos}"
+            f"\n{body}"
+        )
+
+
+class GetIssueDetailsAgenticTriageParams(BaseModel):
+    issue_id: str = Field(
+        description="The issue ID (numeric) or qualified short ID (e.g. PROJECT-123).",
+    )
+    start: str | None = Field(
+        default=None,
+        description=(
+            "ISO timestamp for the start of the time range. Must be provided together with end."
+        ),
+    )
+    end: str | None = Field(
+        default=None,
+        description=(
+            "ISO timestamp for the end of the time range. Must be provided together with start."
+        ),
+    )
+    project_slug: str | None = Field(
+        default=None,
+        description="The slug of the project (optional).",
+    )
+
+
+# Class name intentionally snake_case — see comment on `get_event_details_agentic_triage`.
+class get_issue_details_agentic_triage(  # noqa: N801
+    ExplorerTool[GetIssueDetailsAgenticTriageParams]
+):
+    """Custom Explorer tool for Night Shift agentic triage.
+
+    Returns the same underlying issue metadata as Seer's built-in `get_issue_details`,
+    but reformats it as triage-tuned markdown: header (title/culprit/priority/counts/
+    first-last seen), aggregated tag distribution, and recent human activity. The
+    latest-event stacktrace excerpt is intentionally omitted so the agent is steered
+    toward `get_event_details_agentic_triage` for stack inspection (which exposes
+    the full stack, locals on the first in-app frame, and linked repos).
+    """
+
+    params_model = GetIssueDetailsAgenticTriageParams
+
+    @classmethod
+    def get_description(cls) -> str:
+        return (
+            "Fetch issue-level metadata for a Sentry issue: title, culprit, "
+            "level/priority/status, first/last seen, event and user counts, "
+            "assignee, aggregated tag distribution across all events, and "
+            "recent human activity (notes, assignments, resolutions).\n\n"
+            "Use this to decide whether an issue is worth investigating. For "
+            "the actual stacktrace and failing code context, call "
+            "`get_event_details_agentic_triage` separately."
+        )
+
+    @classmethod
+    def execute(
+        cls,
+        organization: Organization,
+        params: GetIssueDetailsAgenticTriageParams,
+    ) -> str:
+        try:
+            result = get_issue_details(
+                organization_id=organization.id,
+                issue_id=params.issue_id,
+                start=params.start,
+                end=params.end,
+                project_slug=params.project_slug,
+            )
+        except (BadRequest, Group.DoesNotExist, ValueError) as e:
+            return f"Could not fetch issue: {e}"
+        if result is None:
+            return "Issue not found. Check the issue_id and time range."
+
+        body = format_issue_output(result)
+        return (
+            f"Issue ID: {params.issue_id}\n"
+            f"Project ID: {result.get('project_id')}\n"
+            f"Project Slug: {result.get('project_slug')}\n"
             f"\n{body}"
         )
 

--- a/tests/sentry/tasks/seer/night_shift/test_event_formatter.py
+++ b/tests/sentry/tasks/seer/night_shift/test_event_formatter.py
@@ -1,11 +1,13 @@
+import textwrap
+
 from sentry.tasks.seer.night_shift.event_formatter import format_event_output
 
 
 def test_error_event_comprehensive() -> None:
     # One realistic Python error event exercising the main path: exception with
-    # a stacktrace + enhanced frame (context + locals), HTTP request, user with
-    # geo dedup, tags, contexts. Truncation of a long string local is included
-    # to pin the variable-value cap.
+    # stacktrace + enhanced frame (context + locals), HTTP request, user with
+    # geo dedup, tags, contexts. Truncation of a long string local pins the
+    # variable-value cap.
     event = {
         "platform": "python",
         "entries": [
@@ -51,32 +53,73 @@ def test_error_event_comprehensive() -> None:
 
     output = format_event_output(event)
 
-    # Exception header + enhanced most-relevant frame + context + locals.
+    expected_frame_block = (
+        textwrap.dedent(
+            """
+        **Most Relevant Frame:**
+        ─────────────────────
+          File "src/app.py", line 10, in do_thing
+
+             9 │ def do_thing():
+          → 10 │     raise ValueError('bad input')
+            11 │     return 1
+
+        Local Variables:
+        ├─ x: "broken"
+        └─ long_str: "{long_a}..."
+        """
+        )
+        .strip()
+        .format(long_a="a" * 75)
+    )
+    assert expected_frame_block in output
+
+    expected_request_block = textwrap.dedent(
+        """
+        ### HTTP Request
+
+        **Method:** POST
+        **URL:** https://api.example.com/x
+        """
+    ).strip()
+    assert expected_request_block in output
+
+    # User block — `geo` dedupes "US" appearing in both country_code and region.
+    expected_user_block = textwrap.dedent(
+        """
+        ### User
+
+        **user**: email:alice@example.com
+        **user.geo**: US, NYC
+        """
+    ).strip()
+    assert expected_user_block in output
+
+    expected_tags_block = textwrap.dedent(
+        """
+        ### Tags
+
+        **env**: prod
+        """
+    ).strip()
+    assert expected_tags_block in output
+
+    expected_contexts_block = textwrap.dedent(
+        """
+        ### Additional Context
+
+        These are additional context provided by the user when they're instrumenting their application.
+
+        **runtime**
+        name: "CPython"
+        version: "3.12.0"
+        """
+    ).strip()
+    assert expected_contexts_block in output
+
     assert "### Error" in output
     assert "ValueError: bad input" in output
-    assert "**Most Relevant Frame:**" in output
-    assert "do_thing" in output
-    assert "  → 10 │     raise ValueError('bad input')" in output
-    assert "Local Variables:" in output
-    assert 'x: "broken"' in output
-    assert "..." in output  # long_str was truncated
     assert "**Full Stacktrace:**" in output
-
-    # HTTP request section.
-    assert "### HTTP Request" in output
-    assert "**Method:** POST" in output
-
-    # User with deduped geo ("US" appears in country_code and region but rendered once).
-    assert "alice@example.com" in output
-    geo_line = next(line for line in output.splitlines() if line.startswith("**user.geo**"))
-    assert geo_line.count("US") == 1
-    assert "NYC" in geo_line
-
-    # Tags + contexts.
-    assert "### Tags" in output
-    assert "**env**: prod" in output
-    assert "### Additional Context" in output
-    assert "CPython" in output
 
 
 def test_chained_exceptions_rendered_outer_first() -> None:
@@ -147,9 +190,17 @@ def test_alt_interfaces_threads_message_and_csp() -> None:
 
     output = format_event_output(event)
 
+    expected_csp_block = textwrap.dedent(
+        """
+        ### CSP Violation
+
+        **Blocked URI**: https://evil.example.com/a.js
+        **Violated Directive**: script-src
+        **Document URI**: https://app.example.com/
+        """
+    ).strip()
+    assert expected_csp_block in output
+
     assert "something went wrong" in output
     assert "**Thread** (main)" in output
     assert "crash" in output
-    assert "### CSP Violation" in output
-    assert "**Blocked URI**: https://evil.example.com/a.js" in output
-    assert "**Violated Directive**: script-src" in output

--- a/tests/sentry/tasks/seer/night_shift/test_event_formatter.py
+++ b/tests/sentry/tasks/seer/night_shift/test_event_formatter.py
@@ -1,0 +1,155 @@
+from sentry.tasks.seer.night_shift.event_formatter import format_event_output
+
+
+def test_error_event_comprehensive() -> None:
+    # One realistic Python error event exercising the main path: exception with
+    # a stacktrace + enhanced frame (context + locals), HTTP request, user with
+    # geo dedup, tags, contexts. Truncation of a long string local is included
+    # to pin the variable-value cap.
+    event = {
+        "platform": "python",
+        "entries": [
+            {
+                "type": "exception",
+                "data": {
+                    "values": [
+                        {
+                            "type": "ValueError",
+                            "value": "bad input",
+                            "stacktrace": {
+                                "frames": [
+                                    {
+                                        "filename": "src/app.py",
+                                        "function": "do_thing",
+                                        "lineNo": 10,
+                                        "inApp": True,
+                                        "context": [
+                                            (9, "def do_thing():"),
+                                            (10, "    raise ValueError('bad input')"),
+                                            (11, "    return 1"),
+                                        ],
+                                        "vars": {
+                                            "x": "broken",
+                                            "long_str": "a" * 200,
+                                        },
+                                    }
+                                ],
+                            },
+                        }
+                    ],
+                },
+            },
+            {"type": "request", "data": {"method": "POST", "url": "https://api.example.com/x"}},
+        ],
+        "user": {
+            "email": "alice@example.com",
+            "geo": {"country_code": "US", "city": "NYC", "region": "US"},
+        },
+        "tags": [{"key": "env", "value": "prod"}],
+        "contexts": {"runtime": {"name": "CPython", "version": "3.12.0"}},
+    }
+
+    output = format_event_output(event)
+
+    # Exception header + enhanced most-relevant frame + context + locals.
+    assert "### Error" in output
+    assert "ValueError: bad input" in output
+    assert "**Most Relevant Frame:**" in output
+    assert "do_thing" in output
+    assert "  → 10 │     raise ValueError('bad input')" in output
+    assert "Local Variables:" in output
+    assert 'x: "broken"' in output
+    assert "..." in output  # long_str was truncated
+    assert "**Full Stacktrace:**" in output
+
+    # HTTP request section.
+    assert "### HTTP Request" in output
+    assert "**Method:** POST" in output
+
+    # User with deduped geo ("US" appears in country_code and region but rendered once).
+    assert "alice@example.com" in output
+    geo_line = next(line for line in output.splitlines() if line.startswith("**user.geo**"))
+    assert geo_line.count("US") == 1
+    assert "NYC" in geo_line
+
+    # Tags + contexts.
+    assert "### Tags" in output
+    assert "**env**: prod" in output
+    assert "### Additional Context" in output
+    assert "CPython" in output
+
+
+def test_chained_exceptions_rendered_outer_first() -> None:
+    # Sentry stores exceptions innermost-first; the formatter reverses so the
+    # rethrown/outer exception renders first, then "Caused by:" for the inner.
+    event = {
+        "platform": "python",
+        "entries": [
+            {
+                "type": "exception",
+                "data": {
+                    "values": [
+                        {
+                            "type": "KeyError",
+                            "value": "'missing'",
+                            "stacktrace": {"frames": [{"filename": "a.py", "function": "f"}]},
+                        },
+                        {
+                            "type": "RuntimeError",
+                            "value": "wrapper failed",
+                            "stacktrace": {"frames": [{"filename": "b.py", "function": "g"}]},
+                        },
+                    ],
+                },
+            }
+        ],
+    }
+
+    output = format_event_output(event)
+
+    error_idx = output.index("### Error")
+    caused_by_idx = output.index("**Caused by:**")
+    inner_header_idx = output.index("### KeyError: 'missing'")
+    assert error_idx < caused_by_idx < inner_header_idx
+    assert "RuntimeError: wrapper failed" in output
+
+
+def test_alt_interfaces_threads_message_and_csp() -> None:
+    # Threads, message, and CSP each drive an independent code path. They don't
+    # normally coexist in a real event, but they don't conflict in the
+    # formatter either, so we exercise all three in one fixture.
+    event = {
+        "platform": "javascript",
+        "entries": [
+            {"type": "message", "data": {"formatted": "something went wrong"}},
+            {
+                "type": "threads",
+                "data": {
+                    "values": [
+                        {
+                            "crashed": True,
+                            "name": "main",
+                            "stacktrace": {"frames": [{"filename": "x.js", "function": "crash"}]},
+                        }
+                    ],
+                },
+            },
+            {
+                "type": "csp",
+                "data": {
+                    "blocked_uri": "https://evil.example.com/a.js",
+                    "violated_directive": "script-src",
+                    "document_uri": "https://app.example.com/",
+                },
+            },
+        ],
+    }
+
+    output = format_event_output(event)
+
+    assert "something went wrong" in output
+    assert "**Thread** (main)" in output
+    assert "crash" in output
+    assert "### CSP Violation" in output
+    assert "**Blocked URI**: https://evil.example.com/a.js" in output
+    assert "**Violated Directive**: script-src" in output

--- a/tests/sentry/tasks/seer/night_shift/test_issue_formatter.py
+++ b/tests/sentry/tasks/seer/night_shift/test_issue_formatter.py
@@ -1,11 +1,13 @@
+import textwrap
+
 from sentry.tasks.seer.night_shift.issue_formatter import format_issue_output
 
 
 def test_full_output_comprehensive() -> None:
     # Full populated Seer response: header with all fields, tag overview wrapped
     # in the nested {"tags_overview": {"tags_overview": [...]}} shape that the
-    # Seer RPC actually returns, and mixed activity (assigned + note with a
-    # system-actor fallback).
+    # Seer RPC actually returns, and mixed activity (assigned + note + system-
+    # actor fallback).
     details = {
         "issue": {
             "shortId": "PROJ-123",
@@ -58,39 +60,46 @@ def test_full_output_comprehensive() -> None:
 
     output = format_issue_output(details)
 
-    # Header.
-    assert "# PROJ-123: ValueError: bad input" in output
-    assert "**Culprit:** `app.foo in bar`" in output
-    assert "**Type:** error / error — Error" in output
-    assert "**Priority:** high" in output
-    assert "**Status:** unresolved" in output
-    assert "**Substatus:** new" in output
-    assert "**First seen:** 2026-01-01T00:00:00Z" in output
-    assert "**Events:** 42" in output
-    assert "**Users affected:** 7" in output
-    assert "**Assigned to:** alice@example.com" in output
-    assert "**Platform:** python" in output
+    expected_header = textwrap.dedent(
+        """
+        # PROJ-123: ValueError: bad input
+        **Culprit:** `app.foo in bar`
+        **Type:** error / error — Error
+        **Level:** error | **Priority:** high | **Status:** unresolved | **Substatus:** new
+        **First seen:** 2026-01-01T00:00:00Z | **Last seen:** 2026-01-02T00:00:00Z
+        **Events:** 42 | **Users affected:** 7
+        **Assigned to:** alice@example.com
+        **Platform:** python
+        """
+    ).strip()
+    assert expected_header in output
 
-    # Tag distribution: nested unwrap + unique_values + percentage formatting.
-    assert "## Tag Distribution" in output
-    assert "**Browser** (`browser`) (100 total, 3 unique)" in output
-    assert "- Chrome 120 — 70 (70%)" in output
-    assert "- Firefox 121 — 30 (30%)" in output
+    expected_tags_block = textwrap.dedent(
+        """
+        ## Tag Distribution
 
-    # Activity: user.email, user.username, and system-actor fallback.
-    assert "## Recent Activity" in output
-    assert (
-        "2026-01-03T12:00:00Z — bob@example.com (assigned): assigneeEmail=carol@example.com"
-        in output
-    )
-    assert "2026-01-03T13:00:00Z — alice (note): text=looks like a regression" in output
-    assert "2026-01-04T00:00:00Z — system (set_resolved)" in output
+        **Browser** (`browser`) (100 total, 3 unique)
+        - Chrome 120 — 70 (70%)
+        - Firefox 121 — 30 (30%)
+        """
+    ).strip()
+    assert expected_tags_block in output
+
+    expected_activity_block = textwrap.dedent(
+        """
+        ## Recent Activity
+
+        - 2026-01-03T12:00:00Z — bob@example.com (assigned): assigneeEmail=carol@example.com
+        - 2026-01-03T13:00:00Z — alice (note): text=looks like a regression
+        - 2026-01-04T00:00:00Z — system (set_resolved)
+        """
+    ).strip()
+    assert expected_activity_block in output
 
 
 def test_sparse_input_omits_missing_sections() -> None:
     # Minimal data: sparse issue, empty tag overview (missing inner key), empty
-    # activity list. All optional sections should be silently omitted rather
-    # than rendering empty headers.
+    # activity list. Optional sections should be silently omitted.
     output = format_issue_output(
         {
             "issue": {"shortId": "P-1", "title": "Oops"},

--- a/tests/sentry/tasks/seer/night_shift/test_issue_formatter.py
+++ b/tests/sentry/tasks/seer/night_shift/test_issue_formatter.py
@@ -1,0 +1,107 @@
+from sentry.tasks.seer.night_shift.issue_formatter import format_issue_output
+
+
+def test_full_output_comprehensive() -> None:
+    # Full populated Seer response: header with all fields, tag overview wrapped
+    # in the nested {"tags_overview": {"tags_overview": [...]}} shape that the
+    # Seer RPC actually returns, and mixed activity (assigned + note with a
+    # system-actor fallback).
+    details = {
+        "issue": {
+            "shortId": "PROJ-123",
+            "title": "ValueError: bad input",
+            "culprit": "app.foo in bar",
+            "issueType": "error",
+            "issueCategory": "error",
+            "issueTypeDescription": "Error",
+            "level": "error",
+            "priority": "high",
+            "status": "unresolved",
+            "substatus": "new",
+            "firstSeen": "2026-01-01T00:00:00Z",
+            "lastSeen": "2026-01-02T00:00:00Z",
+            "count": 42,
+            "userCount": 7,
+            "platform": "python",
+            "assignedTo": {"email": "alice@example.com"},
+        },
+        "tags_overview": {
+            "tags_overview": [
+                {
+                    "key": "browser",
+                    "name": "Browser",
+                    "total_values": 100,
+                    "unique_values": 3,
+                    "top_values": [
+                        {"value": "Chrome 120", "count": 70, "percentage": "70%"},
+                        {"value": "Firefox 121", "count": 30, "percentage": "30%"},
+                    ],
+                }
+            ],
+        },
+        "user_activity": [
+            {
+                "type": "assigned",
+                "user": {"email": "bob@example.com"},
+                "data": {"assigneeEmail": "carol@example.com"},
+                "dateCreated": "2026-01-03T12:00:00Z",
+            },
+            {
+                "type": "note",
+                "user": {"username": "alice"},
+                "data": {"text": "looks like a regression"},
+                "dateCreated": "2026-01-03T13:00:00Z",
+            },
+            {"type": "set_resolved", "user": None, "dateCreated": "2026-01-04T00:00:00Z"},
+        ],
+    }
+
+    output = format_issue_output(details)
+
+    # Header.
+    assert "# PROJ-123: ValueError: bad input" in output
+    assert "**Culprit:** `app.foo in bar`" in output
+    assert "**Type:** error / error — Error" in output
+    assert "**Priority:** high" in output
+    assert "**Status:** unresolved" in output
+    assert "**Substatus:** new" in output
+    assert "**First seen:** 2026-01-01T00:00:00Z" in output
+    assert "**Events:** 42" in output
+    assert "**Users affected:** 7" in output
+    assert "**Assigned to:** alice@example.com" in output
+    assert "**Platform:** python" in output
+
+    # Tag distribution: nested unwrap + unique_values + percentage formatting.
+    assert "## Tag Distribution" in output
+    assert "**Browser** (`browser`) (100 total, 3 unique)" in output
+    assert "- Chrome 120 — 70 (70%)" in output
+    assert "- Firefox 121 — 30 (30%)" in output
+
+    # Activity: user.email, user.username, and system-actor fallback.
+    assert "## Recent Activity" in output
+    assert (
+        "2026-01-03T12:00:00Z — bob@example.com (assigned): assigneeEmail=carol@example.com"
+        in output
+    )
+    assert "2026-01-03T13:00:00Z — alice (note): text=looks like a regression" in output
+    assert "2026-01-04T00:00:00Z — system (set_resolved)" in output
+
+
+def test_sparse_input_omits_missing_sections() -> None:
+    # Minimal data: sparse issue, empty tag overview (missing inner key), empty
+    # activity list. All optional sections should be silently omitted rather
+    # than rendering empty headers.
+    output = format_issue_output(
+        {
+            "issue": {"shortId": "P-1", "title": "Oops"},
+            "tags_overview": {},
+            "user_activity": [],
+        }
+    )
+
+    assert "# P-1: Oops" in output
+    assert "Culprit" not in output
+    assert "Type" not in output
+    assert "Assigned to" not in output
+    assert "## Tag Distribution" not in output
+    assert "## Recent Activity" not in output


### PR DESCRIPTION
Adds `get_issue_details_agentic_triage`, a custom Explorer tool that wraps Seer's `get_issue_details` and renders the output as triage-tuned markdown instead of the raw JSON blob. Mirrors the existing custom event-details tool.

The body contains the fields that move a verdict: header, linked repos, aggregated tag distribution, and recent human activity. The latest-event stack excerpt sentry-mcp's `formatIssueOutput` includes is intentionally dropped so the agent reaches for `get_event_details_agentic_triage` (which exposes locals on the first in-app frame). Linked-repo info is moved here from the event-details tool — it's project-level context, and seeing "no repo linked" early is a strong "can't autofix" signal.

Also logs `num_occurrences` in the triage result summary.