### PR TITLE
feat(autofix): Add evidence buttons for git_search tool

### DIFF
--- a/static/app/components/events/autofix/v3/autofixEvidence.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.spec.tsx
@@ -385,7 +385,7 @@ describe('AutofixEvidence', () => {
         })
       );
       render(<AutofixEvidence evidenceButtonProps={props!} />, {organization});
-      expect(screen.getByText('Commits: src/foo/bar.py')).toBeInTheDocument();
+      expect(screen.getByText('Commits: bar.py')).toBeInTheDocument();
     });
 
     it('renders commits label with truncated file_path when file_path is long', () => {
@@ -396,11 +396,11 @@ describe('AutofixEvidence', () => {
           repo_name: REPO_NAME,
           start_date: START_DATE,
           end_date: END_DATE,
-          file_path: 'src/components/evidence.tsx',
+          file_path: 'src/components/thisisalongfilename.tsx',
         })
       );
       render(<AutofixEvidence evidenceButtonProps={props!} />, {organization});
-      expect(screen.getByText('Commits: src/comp…ence.tsx')).toBeInTheDocument();
+      expect(screen.getByText('Commits: thisisal\u2026name.tsx')).toBeInTheDocument();
     });
 
     it('prefers single commit path when both param sets are present', () => {

--- a/static/app/components/events/autofix/v3/autofixEvidence.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.spec.tsx
@@ -316,6 +316,172 @@ describe('AutofixEvidence', () => {
       ).toBeNull();
     });
   });
+
+  describe('EvidenceGitSearch', () => {
+    const FULL_SHA = 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
+    const COMMIT_URL = 'https://github.com/org/repo/commit/a1b2c3d';
+    const COMMITS_URL =
+      'https://github.com/org/repo/commits?since=2024-01-01&until=2024-01-31';
+    const REPO_NAME = 'org/repo';
+    const START_DATE = '2024-01-01';
+    const END_DATE = '2024-01-31';
+
+    it('renders commit label with short hash for single commit', () => {
+      const props = resolveProps(
+        makeToolCall('git_search'),
+        makeToolLink('git_search', {
+          commit_url: COMMIT_URL,
+          sha: FULL_SHA,
+        })
+      );
+      render(<AutofixEvidence evidenceButtonProps={props!} />, {organization});
+      expect(screen.getByText('Commit: a1b2c3d')).toBeInTheDocument();
+      expect(screen.getByText('Commit: a1b2c3d').closest('a')).toHaveAttribute(
+        'href',
+        COMMIT_URL
+      );
+    });
+
+    it('renders full sha when sha is not a 40-char hex hash', () => {
+      const shortSha = 'abc1234';
+      const props = resolveProps(
+        makeToolCall('git_search'),
+        makeToolLink('git_search', {
+          commit_url: COMMIT_URL,
+          sha: shortSha,
+        })
+      );
+      render(<AutofixEvidence evidenceButtonProps={props!} />, {organization});
+      expect(screen.getByText('Commit: abc1234')).toBeInTheDocument();
+    });
+
+    it('renders commits label with repo name when file_path is absent', () => {
+      const props = resolveProps(
+        makeToolCall('git_search'),
+        makeToolLink('git_search', {
+          commits_url: COMMITS_URL,
+          repo_name: REPO_NAME,
+          start_date: START_DATE,
+          end_date: END_DATE,
+        })
+      );
+      render(<AutofixEvidence evidenceButtonProps={props!} />, {organization});
+      expect(screen.getByText(`Commits: ${REPO_NAME}`)).toBeInTheDocument();
+      expect(screen.getByText(`Commits: ${REPO_NAME}`).closest('a')).toHaveAttribute(
+        'href',
+        COMMITS_URL
+      );
+    });
+
+    it('renders commits label with short file_path without truncation', () => {
+      const props = resolveProps(
+        makeToolCall('git_search'),
+        makeToolLink('git_search', {
+          commits_url: COMMITS_URL,
+          repo_name: REPO_NAME,
+          start_date: START_DATE,
+          end_date: END_DATE,
+          file_path: 'src/foo/bar.py',
+        })
+      );
+      render(<AutofixEvidence evidenceButtonProps={props!} />, {organization});
+      expect(screen.getByText('Commits: src/foo/bar.py')).toBeInTheDocument();
+    });
+
+    it('renders commits label with truncated file_path when file_path is long', () => {
+      const props = resolveProps(
+        makeToolCall('git_search'),
+        makeToolLink('git_search', {
+          commits_url: COMMITS_URL,
+          repo_name: REPO_NAME,
+          start_date: START_DATE,
+          end_date: END_DATE,
+          file_path: 'src/components/evidence.tsx',
+        })
+      );
+      render(<AutofixEvidence evidenceButtonProps={props!} />, {organization});
+      expect(screen.getByText('Commits: src/comp…ence.tsx')).toBeInTheDocument();
+    });
+
+    it('prefers single commit path when both param sets are present', () => {
+      const props = resolveProps(
+        makeToolCall('git_search'),
+        makeToolLink('git_search', {
+          commit_url: COMMIT_URL,
+          sha: FULL_SHA,
+          commits_url: COMMITS_URL,
+          repo_name: REPO_NAME,
+          start_date: START_DATE,
+          end_date: END_DATE,
+        })
+      );
+      render(<AutofixEvidence evidenceButtonProps={props!} />, {organization});
+      expect(screen.getByText('Commit: a1b2c3d')).toBeInTheDocument();
+    });
+
+    it('returns null when toolLink is missing', () => {
+      expect(resolveProps(makeToolCall('git_search'))).toBeNull();
+    });
+
+    it('returns null when toolLink params are empty', () => {
+      expect(
+        resolveProps(makeToolCall('git_search'), makeToolLink('git_search', {}))
+      ).toBeNull();
+    });
+
+    it('returns null when commit_url is present but sha is missing', () => {
+      expect(
+        resolveProps(
+          makeToolCall('git_search'),
+          makeToolLink('git_search', {commit_url: COMMIT_URL})
+        )
+      ).toBeNull();
+    });
+
+    it('returns null when sha is present but commit_url is missing', () => {
+      expect(
+        resolveProps(
+          makeToolCall('git_search'),
+          makeToolLink('git_search', {sha: FULL_SHA})
+        )
+      ).toBeNull();
+    });
+
+    it('returns null when commits_url path is missing end_date', () => {
+      expect(
+        resolveProps(
+          makeToolCall('git_search'),
+          makeToolLink('git_search', {
+            commits_url: COMMITS_URL,
+            repo_name: REPO_NAME,
+            start_date: START_DATE,
+          })
+        )
+      ).toBeNull();
+    });
+
+    it('returns null when commits_url path is missing repo_name', () => {
+      expect(
+        resolveProps(
+          makeToolCall('git_search'),
+          makeToolLink('git_search', {
+            commits_url: COMMITS_URL,
+            start_date: START_DATE,
+            end_date: END_DATE,
+          })
+        )
+      ).toBeNull();
+    });
+
+    it('returns null when commit_url is not a string', () => {
+      expect(
+        resolveProps(
+          makeToolCall('git_search'),
+          makeToolLink('git_search', {commit_url: 123, sha: FULL_SHA})
+        )
+      ).toBeNull();
+    });
+  });
 });
 
 describe('useAutofixSectionEvidence', () => {

--- a/static/app/components/events/autofix/v3/autofixEvidence.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.tsx
@@ -5,6 +5,7 @@ import {LinkButton} from '@sentry/scraps/button';
 
 import {IconCompass} from 'sentry/icons/iconCompass';
 import {IconFile} from 'sentry/icons/iconFile';
+import {IconGithub} from 'sentry/icons/iconGithub';
 import {IconIssues} from 'sentry/icons/iconIssues';
 import {IconPlay} from 'sentry/icons/iconPlay';
 import {IconProfiling} from 'sentry/icons/iconProfiling';
@@ -14,6 +15,7 @@ import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
 import {getShortEventId} from 'sentry/utils/events';
+import {getShortCommitHash} from 'sentry/utils/git/getShortCommitHash';
 import type {ToolCall, ToolLink} from 'sentry/views/seerExplorer/types';
 import {buildToolLinkUrl} from 'sentry/views/seerExplorer/utils';
 
@@ -270,6 +272,37 @@ function getCodeSearchEvidenceProps({
   return null;
 }
 
+function getGitSearchEvidenceProps({
+  toolLink,
+}: GetEvidencePropsPayload): EvidenceButtonProps | null {
+  const {commit_url, sha, commits_url, start_date, end_date, file_path} =
+    toolLink?.params ?? {};
+
+  if (typeof commit_url === 'string' && typeof sha === 'string') {
+    return {
+      href: commit_url,
+      icon: <IconGithub />, // TODO: support other SCMs
+      label: t('Commit: %s', getShortCommitHash(sha)),
+      tooltip: sha,
+    };
+  }
+
+  if (
+    typeof commits_url === 'string' &&
+    typeof start_date === 'string' &&
+    typeof end_date === 'string'
+  ) {
+    return {
+      href: commits_url,
+      icon: <IconGithub />, // TODO: support other SCMs
+      label: t('Commits: %s..%s', start_date, end_date),
+      tooltip: typeof file_path === 'string' ? file_path : undefined,
+    };
+  }
+
+  return null;
+}
+
 export const AUTOFIX_EVIDENCE_PROPS_RESOLVER: Record<
   string,
   (payload: GetEvidencePropsPayload) => EvidenceButtonProps | null
@@ -281,6 +314,7 @@ export const AUTOFIX_EVIDENCE_PROPS_RESOLVER: Record<
   get_replay_details: getReplayDetailsEvidenceProps,
   get_profile_flamegraph: getProfileFlamegraphEvidenceProps,
   code_search: getCodeSearchEvidenceProps,
+  git_search: getGitSearchEvidenceProps,
 };
 
 function parseArgs(toolCall: ToolCall): any {

--- a/static/app/components/events/autofix/v3/autofixEvidence.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.tsx
@@ -254,7 +254,7 @@ function getCodeSearchEvidenceProps({
     if (typeof path !== 'string') {
       return null;
     }
-    const filename = path.split('/').pop();
+    const filename = extractFileName(path);
     const {code_url} = toolLink?.params ?? {};
 
     if (!defined(filename) || !defined(code_url)) {
@@ -293,13 +293,12 @@ function getGitSearchEvidenceProps({
     typeof start_date === 'string' &&
     typeof end_date === 'string'
   ) {
+    const fileName =
+      typeof file_path === 'string' ? extractFileName(file_path) : undefined;
     return {
       href: commits_url,
       icon: <IconGithub />, // TODO: support other SCMs
-      label: t(
-        'Commits: %s',
-        typeof file_path === 'string' ? truncateText(file_path) : repo_name
-      ),
+      label: t('Commits: %s', fileName ? truncateText(fileName) : repo_name),
       tooltip: (
         <Fragment>
           {typeof file_path === 'string' ? file_path : repo_name}
@@ -336,6 +335,10 @@ function parseArgs(toolCall: ToolCall): any {
   } catch {
     return {};
   }
+}
+
+function extractFileName(filePath: string): string | undefined {
+  return filePath.split('/').pop();
 }
 
 function truncateText(text: string, maxLength = 16): string {

--- a/static/app/components/events/autofix/v3/autofixEvidence.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.tsx
@@ -1,4 +1,4 @@
-import {type ReactNode} from 'react';
+import {Fragment, type ReactNode} from 'react';
 import type {LocationDescriptor} from 'history';
 
 import {LinkButton} from '@sentry/scraps/button';
@@ -275,28 +275,40 @@ function getCodeSearchEvidenceProps({
 function getGitSearchEvidenceProps({
   toolLink,
 }: GetEvidencePropsPayload): EvidenceButtonProps | null {
-  const {commit_url, sha, commits_url, start_date, end_date, file_path} =
+  const {repo_name, commit_url, sha, commits_url, start_date, end_date, file_path} =
     toolLink?.params ?? {};
 
   if (typeof commit_url === 'string' && typeof sha === 'string') {
     return {
       href: commit_url,
       icon: <IconGithub />, // TODO: support other SCMs
-      label: t('Commit: %s', getShortCommitHash(sha)),
+      label: t('Commit: %s', truncateText(getShortCommitHash(sha))),
       tooltip: sha,
     };
   }
 
   if (
     typeof commits_url === 'string' &&
+    typeof repo_name === 'string' &&
     typeof start_date === 'string' &&
     typeof end_date === 'string'
   ) {
     return {
       href: commits_url,
       icon: <IconGithub />, // TODO: support other SCMs
-      label: t('Commits: %s..%s', start_date, end_date),
-      tooltip: typeof file_path === 'string' ? file_path : undefined,
+      label: t(
+        'Commits: %s',
+        typeof file_path === 'string' ? truncateText(file_path) : repo_name
+      ),
+      tooltip: (
+        <Fragment>
+          {typeof file_path === 'string' ? file_path : repo_name}
+          <br />
+          {start_date}
+          {'\u2014'}
+          {end_date}
+        </Fragment>
+      ),
     };
   }
 


### PR DESCRIPTION
This adds evidence buttons for the git_search tool which can link to the following
1. the list of commits between 2 dates
2. the list of commits between 2 dates for a file
3. the details for a specific commit

# Screenshots

<img width="804" height="386" alt="image" src="https://github.com/user-attachments/assets/6d546e64-c24c-4f94-8263-88866d532c9d" />

