### PR TITLE
fix(api): Add ViewerContextAuthentication to DRF default auth classes

### DIFF
--- a/src/sentry/api/base.py
+++ b/src/sentry/api/base.py
@@ -57,6 +57,7 @@ from .authentication import (
     ApiKeyAuthentication,
     OrgAuthTokenAuthentication,
     UserAuthTokenAuthentication,
+    ViewerContextAuthentication,
     update_token_access_record,
 )
 from .paginator import BadPaginationError, MissingPaginationError, Paginator
@@ -92,6 +93,7 @@ DEFAULT_AUTHENTICATION = (
     UserAuthTokenAuthentication,
     OrgAuthTokenAuthentication,
     ApiKeyAuthentication,
+    ViewerContextAuthentication,
     SessionAuthentication,
 )
 


### PR DESCRIPTION
Add `ViewerContextAuthentication` to DRF's `DEFAULT_AUTHENTICATION` tuple, before `SessionAuthentication`.

Service-to-service calls from Seer using `X-Viewer-Context` JWT headers were getting CSRF 403s on mutating requests (POST/PUT/DELETE). The Django `AuthenticationMiddleware` correctly authenticates these requests at the middleware level, but DRF runs its own authentication pipeline via `DEFAULT_AUTHENTICATION` which didn't include `ViewerContextAuthentication`. When all token-based authenticators returned `None`, `SessionAuthentication` ran and re-enforced CSRF — failing because there's no CSRF cookie on service-to-service calls.

`ViewerContextAuthentication` already inherits from DRF's `BaseAuthentication` and was clearly designed for this use — it just was never added to the list. Placing it before `SessionAuthentication` means DRF authenticates the JWT there and never reaches the CSRF-enforcing fallback.