### PR TITLE
ref(preprod): Use transparent color sentinel for overlay visibility

### DIFF
--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -30,14 +30,12 @@ interface DiffImageDisplayProps {
   onDiffModeChange: (mode: DiffMode) => void;
   overlayColor: string;
   pair: SnapshotDiffPair;
-  showOverlay: boolean;
 }
 
 export function DiffImageDisplay({
   pair,
   imageBaseUrl,
   diffImageBaseUrl,
-  showOverlay,
   overlayColor,
   diffMode,
   onDiffModeChange,
@@ -106,7 +104,6 @@ export function DiffImageDisplay({
         <SplitView
           baseImageUrl={baseImageUrl}
           headImageUrl={headImageUrl}
-          showOverlay={showOverlay}
           overlayColor={overlayColor}
           diffMaskUrl={diffMaskUrl}
         />
@@ -147,13 +144,11 @@ interface SplitViewProps {
   diffMaskUrl: string | null;
   headImageUrl: string;
   overlayColor: string;
-  showOverlay: boolean;
 }
 
 function SplitView({
   baseImageUrl,
   headImageUrl,
-  showOverlay,
   overlayColor,
   diffMaskUrl,
 }: SplitViewProps) {
@@ -190,7 +185,7 @@ function SplitView({
             >
               <ImageWrapper>
                 <ZoomableImage src={headImageUrl} alt={t('Current Branch')} />
-                {showOverlay && diffMaskUrl && (
+                {diffMaskUrl && overlayColor !== 'transparent' && (
                   <DiffOverlay $overlayColor={overlayColor} $maskUrl={diffMaskUrl} />
                 )}
               </ImageWrapper>
@@ -295,6 +290,8 @@ const ConstrainedImage = styled(Image)`
 
 const ImageWrapper = styled('div')`
   position: relative;
+  display: inline-block;
+  max-width: 100%;
 `;
 
 const DiffOverlay = styled('span')<{$maskUrl: string; $overlayColor: string}>`

--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -23,6 +23,8 @@ import {
 
 export type DiffMode = 'split' | 'wipe' | 'onion';
 
+export const TRANSPARENT_COLOR = 'transparent';
+
 interface DiffImageDisplayProps {
   diffImageBaseUrl: string;
   diffMode: DiffMode;
@@ -185,7 +187,7 @@ function SplitView({
             >
               <ImageWrapper>
                 <ZoomableImage src={headImageUrl} alt={t('Current Branch')} />
-                {diffMaskUrl && overlayColor !== 'transparent' && (
+                {diffMaskUrl && overlayColor !== TRANSPARENT_COLOR && (
                   <DiffOverlay $overlayColor={overlayColor} $maskUrl={diffMaskUrl} />
                 )}
               </ImageWrapper>

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -23,11 +23,9 @@ interface SnapshotMainContentProps {
   imageBaseUrl: string;
   onDiffModeChange: (mode: DiffMode) => void;
   onOverlayColorChange: (color: string) => void;
-  onShowOverlayChange: (show: boolean) => void;
   onVariantChange: (index: number) => void;
   overlayColor: string;
   selectedItem: SidebarItem | null;
-  showOverlay: boolean;
   variantIndex: number;
 }
 
@@ -37,8 +35,6 @@ export function SnapshotMainContent({
   onVariantChange,
   imageBaseUrl,
   diffImageBaseUrl,
-  showOverlay,
-  onShowOverlayChange,
   overlayColor,
   onOverlayColorChange,
   diffMode,
@@ -87,8 +83,6 @@ export function SnapshotMainContent({
           </Flex>
           {diffMode === 'split' && (
             <OverlayControls
-              showOverlay={showOverlay}
-              onShowOverlayChange={onShowOverlayChange}
               overlayColor={overlayColor}
               onOverlayColorChange={onOverlayColorChange}
             />
@@ -99,7 +93,6 @@ export function SnapshotMainContent({
           pair={currentPair}
           imageBaseUrl={imageBaseUrl}
           diffImageBaseUrl={diffImageBaseUrl}
-          showOverlay={showOverlay}
           overlayColor={overlayColor}
           diffMode={diffMode}
           onDiffModeChange={onDiffModeChange}
@@ -304,22 +297,20 @@ function ImageFileName({
   return <InlineCode variant="neutral">{fileName}</InlineCode>;
 }
 
+export const TRANSPARENT_COLOR = 'transparent';
+
 function OverlayControls({
-  showOverlay,
-  onShowOverlayChange,
   overlayColor,
   onOverlayColorChange,
 }: {
   onOverlayColorChange: (color: string) => void;
-  onShowOverlayChange: (show: boolean) => void;
   overlayColor: string;
-  showOverlay: boolean;
 }) {
   const theme = useTheme();
   const [isColorPickerOpen, setIsColorPickerOpen] = useState(false);
   const pickerRef = useRef<HTMLDivElement>(null);
 
-  const overlayColors = theme.chart.getColorPalette(10);
+  const overlayColors = [TRANSPARENT_COLOR, ...theme.chart.getColorPalette(10)];
 
   useEffect(() => {
     if (!isColorPickerOpen) {
@@ -336,40 +327,31 @@ function OverlayControls({
   }, [isColorPickerOpen]);
 
   return (
-    <Flex align="center" gap="sm">
-      <Button
-        size="xs"
-        priority={showOverlay ? 'primary' : 'default'}
-        onClick={() => onShowOverlayChange(!showOverlay)}
-      >
-        {showOverlay ? t('Hide Overlay') : t('Show Overlay')}
-      </Button>
-      <ColorPickerWrapper ref={pickerRef}>
-        <ColorTrigger
-          color={overlayColor}
-          aria-label={t('Pick overlay color')}
-          onClick={() => setIsColorPickerOpen(open => !open)}
-        />
-        {isColorPickerOpen && (
-          <ColorPickerDropdown>
-            <Flex gap="xs">
-              {overlayColors.map(color => (
-                <ColorSwatch
-                  key={color}
-                  color={color}
-                  selected={overlayColor === color}
-                  onClick={() => {
-                    onOverlayColorChange(color);
-                    setIsColorPickerOpen(false);
-                  }}
-                  aria-label={t('Overlay color %s', color)}
-                />
-              ))}
-            </Flex>
-          </ColorPickerDropdown>
-        )}
-      </ColorPickerWrapper>
-    </Flex>
+    <ColorPickerWrapper ref={pickerRef}>
+      <ColorTrigger
+        color={overlayColor}
+        aria-label={t('Pick overlay color')}
+        onClick={() => setIsColorPickerOpen(open => !open)}
+      />
+      {isColorPickerOpen && (
+        <ColorPickerDropdown>
+          <Flex gap="xs">
+            {overlayColors.map(color => (
+              <ColorSwatch
+                key={color}
+                color={color}
+                selected={overlayColor === color}
+                onClick={() => {
+                  onOverlayColorChange(color);
+                  setIsColorPickerOpen(false);
+                }}
+                aria-label={t('Overlay color %s', color)}
+              />
+            ))}
+          </Flex>
+        </ColorPickerDropdown>
+      )}
+    </ColorPickerWrapper>
   );
 }
 

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -14,7 +14,11 @@ import {t} from 'sentry/locale';
 import {getImageName} from 'sentry/views/preprod/types/snapshotTypes';
 import type {SidebarItem} from 'sentry/views/preprod/types/snapshotTypes';
 
-import {DiffImageDisplay, type DiffMode} from './imageDisplay/diffImageDisplay';
+import {
+  DiffImageDisplay,
+  type DiffMode,
+  TRANSPARENT_COLOR,
+} from './imageDisplay/diffImageDisplay';
 import {SingleImageDisplay} from './imageDisplay/singleImageDisplay';
 
 interface SnapshotMainContentProps {
@@ -296,8 +300,6 @@ function ImageFileName({
   }
   return <InlineCode variant="neutral">{fileName}</InlineCode>;
 }
-
-export const TRANSPARENT_COLOR = 'transparent';
 
 function OverlayControls({
   overlayColor,

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -11,6 +11,7 @@ import {IconGrabbable} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import {useLocalStorageState} from 'sentry/utils/useLocalStorageState';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -76,11 +77,11 @@ export default function SnapshotsPage() {
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedItemKey, setSelectedItemKey] = useState<string | null>(null);
   const [variantIndex, setVariantIndex] = useState(0);
-  const [showOverlay, setShowOverlay] = useState(true);
-  const [overlayColor, setOverlayColor] = useState<string>(() => {
-    const palette = theme.chart.getColorPalette(10);
-    return palette.at(-5) ?? palette[0];
-  });
+  const palette = theme.chart.getColorPalette(10);
+  const [overlayColor, setOverlayColor] = useLocalStorageState<string>(
+    'snapshot-overlay-color',
+    palette.at(-5) ?? palette[0]
+  );
   const [diffMode, setDiffMode] = useState<DiffMode>('split');
 
   const {
@@ -357,8 +358,6 @@ export default function SnapshotsPage() {
           onVariantChange={setVariantIndex}
           imageBaseUrl={imageBaseUrl}
           diffImageBaseUrl={diffImageBaseUrl}
-          showOverlay={showOverlay}
-          onShowOverlayChange={setShowOverlay}
           overlayColor={overlayColor}
           onOverlayColorChange={setOverlayColor}
           diffMode={diffMode}


### PR DESCRIPTION
Collapse the snapshot diff viewer's overlay state from two pieces (`showOverlay` boolean + `overlayColor` string) into one: a single `overlayColor` string where `'transparent'` means "no overlay." Persists via `useLocalStorageState` so the choice survives navigation.

The user-visible swap:
- The "Hide Overlay" toggle button is gone.
- The color picker now has `TRANSPARENT_COLOR` as the first swatch — clicking it hides the overlay.

Internal changes:
- `snapshots.tsx`: drop `showOverlay` state; `overlayColor` moves to `useLocalStorageState('snapshot-overlay-color', …)`.
- `snapshotMainContent.tsx`: remove `showOverlay`/`onShowOverlayChange` from props; drop the Hide Overlay button; prepend `TRANSPARENT_COLOR` to the swatch palette.
- `diffImageDisplay.tsx`: drop `showOverlay` prop; overlay gate becomes `diffMaskUrl && overlayColor !== 'transparent'`; add `display: inline-block; max-width: 100%` to `ImageWrapper` so the mask aligns when the image shrinks.

First of several PRs slicing up #113958 for review.