### PR TITLE
fix(aci): Add an extra guard to legacy alert matching when executing an action

### DIFF
--- a/src/sentry/notifications/notification_action/types.py
+++ b/src/sentry/notifications/notification_action/types.py
@@ -244,6 +244,7 @@ class BaseIssueAlertHandler(ABC):
             # attempt to find legacy_rule_id from the alert rule workflow
             alert_rule_workflow = AlertRuleWorkflow.objects.filter(
                 workflow_id=workflow_id,
+                rule_id__isnull=False,
             ).first()
             if alert_rule_workflow:
                 try:


### PR DESCRIPTION
Closes ISWF-2545
Fixes SENTRY-5NEX

When building the Slack/issue alert notification payload, we look up `AlertRuleWorkflow` by `workflow_id` to try to resolve a `legacy_rule_id`. If the matching `AlertRuleWorkflow` row has a null `rule_id`, it creates the linked Sentry error:

https://github.com/getsentry/sentry/blob/f59b5995419716a396cefa57b6d3942a4fcd5f32/src/sentry/notifications/notification_action/types.py#L249-L257

In most cases this shouldn't be possible (to have an AlertRuleWorkflow for the workflow but not one that's an issue alert), but there appears to be some misconfigured `AlertRuleWorkflow` instances ([see this Redash query](https://redash.getsentry.net/queries/11061/source)). While this configuration is unintended, I don't think it should prevent the action from being executed.

This adds `rule_id__isnull=False` to the filter so we only match rows that can actually give us a legacy rule. If none exist, we fall through to the workflow-only path as before.