### PR TITLE
ref(seer): Send fresh UserOrgContext on explorer continue_run 

### DIFF
--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -384,6 +384,9 @@ class SeerExplorerClient:
             insert_index=insert_index,
             on_page_context=on_page_context,
             page_name=page_name,
+            user_org_context=collect_user_org_context(
+                self.user, self.organization, request=request
+            ),
             is_interactive=self.is_interactive,
             enable_coding=self.enable_coding,
             enable_code_mode_tools=self.enable_code_mode_tools,

--- a/tests/sentry/seer/explorer/test_explorer_client.py
+++ b/tests/sentry/seer/explorer/test_explorer_client.py
@@ -261,9 +261,11 @@ class TestSeerExplorerClient(TestCase):
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
     @patch("sentry.seer.explorer.client.make_explorer_chat_request")
-    def test_continue_run_basic(self, mock_post, mock_access):
+    @patch("sentry.seer.explorer.client.collect_user_org_context")
+    def test_continue_run_basic(self, mock_collect_context, mock_post, mock_access):
         """Test continuing an existing run"""
         mock_access.return_value = (True, None)
+        mock_collect_context.return_value = {"user_id": self.user.id}
         mock_response = MagicMock()
         mock_response.json.return_value = {"run_id": 456}
         mock_response.status = 200
@@ -273,13 +275,16 @@ class TestSeerExplorerClient(TestCase):
         run_id = client.continue_run(456, "Follow up query")
 
         assert run_id == 456
-        assert mock_post.called
+        body = mock_post.call_args[0][0]
+        assert body["user_org_context"] == {"user_id": self.user.id}
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
     @patch("sentry.seer.explorer.client.make_explorer_chat_request")
-    def test_continue_run_with_all_params(self, mock_post, mock_access):
+    @patch("sentry.seer.explorer.client.collect_user_org_context")
+    def test_continue_run_with_all_params(self, mock_collect_context, mock_post, mock_access):
         """Test continuing a run with all optional parameters"""
         mock_access.return_value = (True, None)
+        mock_collect_context.return_value = {"user_id": self.user.id}
         mock_response = MagicMock()
         mock_response.json.return_value = {"run_id": 789}
         mock_response.status = 200


### PR DESCRIPTION
Depends on https://github.com/getsentry/sentry/pull/113844

Make `SeerExplorerClient.continue_run` pass a freshly built `user_org_context` to Seer on every follow-up message, matching the behavior of `start_run`. https://github.com/getsentry/seer/pull/5963 will overwrite stored state with the fresh payload. 

### Why? 

Seer freezes `user_org_context` (including the per-project repo list) at chat start and never refreshes it. For long-lived explorer chats, this means repos added, renamed, or removed in Sentry mid-chat are invisible to Seer until a new chat is started. The most user-visible symptom is incorrect stacktrace frame → repo annotations in `process_event_paths`, which uses the full repo list from state as authoritative.

Refreshing on continue cuts the repo staleness window from "chat lifetime" to "one user message".