### PR TITLE
feat(preprod): Add view mode toggle between single and list views

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -74,7 +74,6 @@ const config: KnipConfig = {
     'api-docs/**',
     // TODO: remove once preprod snapshot list view lands
     'static/app/views/preprod/snapshots/main/snapshotCards.tsx',
-    'static/app/views/preprod/snapshots/main/snapshotDiffBodies.tsx',
     'static/app/views/preprod/snapshots/main/snapshotListView.tsx',
   ],
   ignoreExportsUsedInFile: isProductionMode,

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -291,7 +291,12 @@ function ViewModeToggle({
   viewMode: ViewMode;
 }) {
   return (
-    <SegmentedControl size="xs" value={viewMode} onChange={onViewModeChange}>
+    <SegmentedControl
+      size="xs"
+      value={viewMode}
+      onChange={onViewModeChange}
+      aria-label={t('View mode')}
+    >
       <SegmentedControl.Item
         key="single"
         icon={<IconExpand />}

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -5,11 +5,12 @@ import styled from '@emotion/styled';
 import {Button} from '@sentry/scraps/button';
 import {InlineCode} from '@sentry/scraps/code';
 import {Flex, Stack} from '@sentry/scraps/layout';
+import {SegmentedControl} from '@sentry/scraps/segmentedControl';
 import {Separator} from '@sentry/scraps/separator';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {IconChevron} from 'sentry/icons';
+import {IconChevron, IconExpand, IconList} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {getImageName} from 'sentry/views/preprod/types/snapshotTypes';
 import type {SidebarItem} from 'sentry/views/preprod/types/snapshotTypes';
@@ -20,17 +21,23 @@ import {
   TRANSPARENT_COLOR,
 } from './imageDisplay/diffImageDisplay';
 import {SingleImageDisplay} from './imageDisplay/singleImageDisplay';
+import {SnapshotListView} from './snapshotListView';
+
+export type ViewMode = 'single' | 'list';
 
 interface SnapshotMainContentProps {
   diffImageBaseUrl: string;
   diffMode: DiffMode;
   imageBaseUrl: string;
+  items: SidebarItem[];
   onDiffModeChange: (mode: DiffMode) => void;
   onOverlayColorChange: (color: string) => void;
   onVariantChange: (index: number) => void;
+  onViewModeChange: (mode: ViewMode) => void;
   overlayColor: string;
   selectedItem: SidebarItem | null;
   variantIndex: number;
+  viewMode: ViewMode;
 }
 
 export function SnapshotMainContent({
@@ -39,29 +46,154 @@ export function SnapshotMainContent({
   onVariantChange,
   imageBaseUrl,
   diffImageBaseUrl,
+  items,
   overlayColor,
   onOverlayColorChange,
   diffMode,
   onDiffModeChange,
+  viewMode,
+  onViewModeChange,
 }: SnapshotMainContentProps) {
-  if (!selectedItem) {
+  if (viewMode === 'list') {
     return (
-      <Flex align="center" justify="center" padding="3xl" width="100%">
-        <Text variant="muted">{t('Select an image from the sidebar.')}</Text>
+      <Flex direction="column" flex="1" minHeight="0" width="100%">
+        <Flex justify="end" padding="md">
+          <ViewModeToggle viewMode={viewMode} onViewModeChange={onViewModeChange} />
+        </Flex>
+        <Separator orientation="horizontal" />
+        <SnapshotListView
+          items={items}
+          imageBaseUrl={imageBaseUrl}
+          diffImageBaseUrl={diffImageBaseUrl}
+          diffMode={diffMode}
+          overlayColor={overlayColor}
+        />
       </Flex>
     );
   }
 
-  if (selectedItem.type === 'changed') {
-    const currentPair = selectedItem.pairs[variantIndex];
-    if (!currentPair) {
-      return null;
+  const body = renderBody();
+
+  return (
+    <Flex direction="column" flex="1" minHeight="0" width="100%">
+      <Flex justify="end" padding="md">
+        <ViewModeToggle viewMode={viewMode} onViewModeChange={onViewModeChange} />
+      </Flex>
+      <Separator orientation="horizontal" />
+      {body}
+    </Flex>
+  );
+
+  function renderBody() {
+    if (!selectedItem) {
+      return (
+        <Flex align="center" justify="center" padding="3xl" width="100%">
+          <Text variant="muted">{t('Select an image from the sidebar.')}</Text>
+        </Flex>
+      );
     }
-    const totalVariants = selectedItem.pairs.length;
-    return (
-      <Flex direction="column" gap="0" padding="0" height="100%" width="100%">
-        <Flex align="center" justify="between" gap="md" padding="xl">
-          <Flex align="center" gap="md">
+
+    if (selectedItem.type === 'changed') {
+      const currentPair = selectedItem.pairs[variantIndex];
+      if (!currentPair) {
+        return null;
+      }
+      const totalVariants = selectedItem.pairs.length;
+      return (
+        <Flex direction="column" gap="0" padding="0" height="100%" width="100%">
+          <Flex align="center" justify="between" gap="md" padding="xl">
+            <Flex align="center" gap="md">
+              {totalVariants > 1 && (
+                <VariantNavigation
+                  variantIndex={variantIndex}
+                  totalVariants={totalVariants}
+                  onVariantChange={onVariantChange}
+                />
+              )}
+              <Stack gap="md">
+                <Flex align="center" gap="md">
+                  {currentPair.head_image.display_name && (
+                    <Text size="lg" bold>
+                      {currentPair.head_image.display_name}
+                    </Text>
+                  )}
+                  <ImageFileName fileName={currentPair.head_image.image_file_name} />
+                </Flex>
+                {totalVariants > 1 && (
+                  <Text variant="muted" size="sm">
+                    {t('Variant %s / %s', variantIndex + 1, totalVariants)}
+                  </Text>
+                )}
+              </Stack>
+            </Flex>
+            {diffMode === 'split' && (
+              <OverlayControls
+                overlayColor={overlayColor}
+                onOverlayColorChange={onOverlayColorChange}
+              />
+            )}
+          </Flex>
+          <Separator orientation="horizontal" />
+          <DiffImageDisplay
+            pair={currentPair}
+            imageBaseUrl={imageBaseUrl}
+            diffImageBaseUrl={diffImageBaseUrl}
+            overlayColor={overlayColor}
+            diffMode={diffMode}
+            onDiffModeChange={onDiffModeChange}
+          />
+        </Flex>
+      );
+    }
+
+    if (selectedItem.type === 'solo') {
+      const currentImage = selectedItem.images[variantIndex];
+      if (!currentImage) {
+        return null;
+      }
+      const displayName = getImageName(currentImage);
+      const totalVariants = selectedItem.images.length;
+      const imageUrl = `${imageBaseUrl}${currentImage.key}/`;
+
+      return (
+        <Flex direction="column" gap="0" padding="0" height="100%" width="100%">
+          <Flex align="center" gap="md" padding="xl">
+            {totalVariants > 1 && (
+              <VariantNavigation
+                variantIndex={variantIndex}
+                totalVariants={totalVariants}
+                onVariantChange={onVariantChange}
+              />
+            )}
+            <Stack gap="md">
+              <Text size="lg" bold>
+                {displayName}
+              </Text>
+              {totalVariants > 1 && (
+                <Text variant="muted" size="sm">
+                  {t('Variant %s / %s', variantIndex + 1, totalVariants)}
+                </Text>
+              )}
+            </Stack>
+          </Flex>
+          <Separator orientation="horizontal" />
+          <SingleImageDisplay imageUrl={imageUrl} alt={displayName} />
+        </Flex>
+      );
+    }
+
+    if (selectedItem.type === 'renamed') {
+      const currentPair = selectedItem.pairs[variantIndex];
+      if (!currentPair) {
+        return null;
+      }
+      const totalVariants = selectedItem.pairs.length;
+      const imageUrl = `${imageBaseUrl}${currentPair.head_image.key}/`;
+      const displayName = getImageName(currentPair.head_image);
+
+      return (
+        <Flex direction="column" gap="0" padding="0" height="100%" width="100%">
+          <Flex align="center" gap="md" padding="xl">
             {totalVariants > 1 && (
               <VariantNavigation
                 variantIndex={variantIndex}
@@ -76,79 +208,42 @@ export function SnapshotMainContent({
                     {currentPair.head_image.display_name}
                   </Text>
                 )}
-                <ImageFileName fileName={currentPair.head_image.image_file_name} />
+                <ImageFileName
+                  fileName={currentPair.head_image.image_file_name}
+                  previousFileName={currentPair.base_image.image_file_name}
+                />
               </Flex>
-              {totalVariants > 1 && (
+              <Flex align="center" gap="sm">
                 <Text variant="muted" size="sm">
-                  {t('Variant %s / %s', variantIndex + 1, totalVariants)}
+                  ({t('Renamed')})
                 </Text>
-              )}
+                {totalVariants > 1 && (
+                  <Text variant="muted" size="sm">
+                    {t('Variant %s / %s', variantIndex + 1, totalVariants)}
+                  </Text>
+                )}
+              </Flex>
             </Stack>
           </Flex>
-          {diffMode === 'split' && (
-            <OverlayControls
-              overlayColor={overlayColor}
-              onOverlayColorChange={onOverlayColorChange}
-            />
-          )}
+          <Separator orientation="horizontal" />
+          <SingleImageDisplay imageUrl={imageUrl} alt={displayName} />
         </Flex>
-        <Separator orientation="horizontal" />
-        <DiffImageDisplay
-          pair={currentPair}
-          imageBaseUrl={imageBaseUrl}
-          diffImageBaseUrl={diffImageBaseUrl}
-          overlayColor={overlayColor}
-          diffMode={diffMode}
-          onDiffModeChange={onDiffModeChange}
-        />
-      </Flex>
-    );
-  }
+      );
+    }
 
-  if (selectedItem.type === 'solo') {
+    // added, removed, unchanged
     const currentImage = selectedItem.images[variantIndex];
     if (!currentImage) {
       return null;
     }
     const displayName = getImageName(currentImage);
-    const totalVariants = selectedItem.images.length;
     const imageUrl = `${imageBaseUrl}${currentImage.key}/`;
-
-    return (
-      <Flex direction="column" gap="0" padding="0" height="100%" width="100%">
-        <Flex align="center" gap="md" padding="xl">
-          {totalVariants > 1 && (
-            <VariantNavigation
-              variantIndex={variantIndex}
-              totalVariants={totalVariants}
-              onVariantChange={onVariantChange}
-            />
-          )}
-          <Stack gap="md">
-            <Text size="lg" bold>
-              {displayName}
-            </Text>
-            {totalVariants > 1 && (
-              <Text variant="muted" size="sm">
-                {t('Variant %s / %s', variantIndex + 1, totalVariants)}
-              </Text>
-            )}
-          </Stack>
-        </Flex>
-        <Separator orientation="horizontal" />
-        <SingleImageDisplay imageUrl={imageUrl} alt={displayName} />
-      </Flex>
-    );
-  }
-
-  if (selectedItem.type === 'renamed') {
-    const currentPair = selectedItem.pairs[variantIndex];
-    if (!currentPair) {
-      return null;
-    }
-    const totalVariants = selectedItem.pairs.length;
-    const imageUrl = `${imageBaseUrl}${currentPair.head_image.key}/`;
-    const displayName = getImageName(currentPair.head_image);
+    const totalVariants = selectedItem.images.length;
+    const STATUS_LABELS: Record<string, string> = {
+      added: t('Added'),
+      removed: t('Removed'),
+    };
+    const statusLabel = STATUS_LABELS[selectedItem.type] ?? t('Unchanged');
 
     return (
       <Flex direction="column" gap="0" padding="0" height="100%" width="100%">
@@ -162,19 +257,16 @@ export function SnapshotMainContent({
           )}
           <Stack gap="md">
             <Flex align="center" gap="md">
-              {currentPair.head_image.display_name && (
+              {currentImage.display_name && (
                 <Text size="lg" bold>
-                  {currentPair.head_image.display_name}
+                  {currentImage.display_name}
                 </Text>
               )}
-              <ImageFileName
-                fileName={currentPair.head_image.image_file_name}
-                previousFileName={currentPair.base_image.image_file_name}
-              />
+              <ImageFileName fileName={currentImage.image_file_name} />
             </Flex>
             <Flex align="center" gap="sm">
               <Text variant="muted" size="sm">
-                ({t('Renamed')})
+                ({statusLabel})
               </Text>
               {totalVariants > 1 && (
                 <Text variant="muted" size="sm">
@@ -189,55 +281,30 @@ export function SnapshotMainContent({
       </Flex>
     );
   }
+}
 
-  // added, removed, unchanged
-  const currentImage = selectedItem.images[variantIndex];
-  if (!currentImage) {
-    return null;
-  }
-  const displayName = getImageName(currentImage);
-  const imageUrl = `${imageBaseUrl}${currentImage.key}/`;
-  const totalVariants = selectedItem.images.length;
-  const STATUS_LABELS: Record<string, string> = {
-    added: t('Added'),
-    removed: t('Removed'),
-  };
-  const statusLabel = STATUS_LABELS[selectedItem.type] ?? t('Unchanged');
-
+function ViewModeToggle({
+  viewMode,
+  onViewModeChange,
+}: {
+  onViewModeChange: (mode: ViewMode) => void;
+  viewMode: ViewMode;
+}) {
   return (
-    <Flex direction="column" gap="0" padding="0" height="100%" width="100%">
-      <Flex align="center" gap="md" padding="xl">
-        {totalVariants > 1 && (
-          <VariantNavigation
-            variantIndex={variantIndex}
-            totalVariants={totalVariants}
-            onVariantChange={onVariantChange}
-          />
-        )}
-        <Stack gap="md">
-          <Flex align="center" gap="md">
-            {currentImage.display_name && (
-              <Text size="lg" bold>
-                {currentImage.display_name}
-              </Text>
-            )}
-            <ImageFileName fileName={currentImage.image_file_name} />
-          </Flex>
-          <Flex align="center" gap="sm">
-            <Text variant="muted" size="sm">
-              ({statusLabel})
-            </Text>
-            {totalVariants > 1 && (
-              <Text variant="muted" size="sm">
-                {t('Variant %s / %s', variantIndex + 1, totalVariants)}
-              </Text>
-            )}
-          </Flex>
-        </Stack>
-      </Flex>
-      <Separator orientation="horizontal" />
-      <SingleImageDisplay imageUrl={imageUrl} alt={displayName} />
-    </Flex>
+    <SegmentedControl size="xs" value={viewMode} onChange={onViewModeChange}>
+      <SegmentedControl.Item
+        key="single"
+        icon={<IconExpand />}
+        aria-label={t('Single image view')}
+        tooltip={t('Single image view')}
+      />
+      <SegmentedControl.Item
+        key="list"
+        icon={<IconList />}
+        aria-label={t('List view')}
+        tooltip={t('List view')}
+      />
+    </SegmentedControl>
   );
 }
 

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -72,128 +72,66 @@ export function SnapshotMainContent({
     );
   }
 
-  const body = renderBody();
-
   return (
     <Flex direction="column" flex="1" minHeight="0" width="100%">
       <Flex justify="end" padding="md">
         <ViewModeToggle viewMode={viewMode} onViewModeChange={onViewModeChange} />
       </Flex>
       <Separator orientation="horizontal" />
-      {body}
+      <SingleViewContent
+        selectedItem={selectedItem}
+        variantIndex={variantIndex}
+        onVariantChange={onVariantChange}
+        imageBaseUrl={imageBaseUrl}
+        diffImageBaseUrl={diffImageBaseUrl}
+        overlayColor={overlayColor}
+        onOverlayColorChange={onOverlayColorChange}
+        diffMode={diffMode}
+        onDiffModeChange={onDiffModeChange}
+      />
     </Flex>
   );
+}
 
-  function renderBody() {
-    if (!selectedItem) {
-      return (
-        <Flex align="center" justify="center" padding="3xl" width="100%">
-          <Text variant="muted">{t('Select an image from the sidebar.')}</Text>
-        </Flex>
-      );
+function SingleViewContent({
+  selectedItem,
+  variantIndex,
+  onVariantChange,
+  imageBaseUrl,
+  diffImageBaseUrl,
+  overlayColor,
+  onOverlayColorChange,
+  diffMode,
+  onDiffModeChange,
+}: {
+  diffImageBaseUrl: string;
+  diffMode: DiffMode;
+  imageBaseUrl: string;
+  onDiffModeChange: (mode: DiffMode) => void;
+  onOverlayColorChange: (color: string) => void;
+  onVariantChange: (index: number) => void;
+  overlayColor: string;
+  selectedItem: SidebarItem | null;
+  variantIndex: number;
+}) {
+  if (!selectedItem) {
+    return (
+      <Flex align="center" justify="center" padding="3xl" width="100%">
+        <Text variant="muted">{t('Select an image from the sidebar.')}</Text>
+      </Flex>
+    );
+  }
+
+  if (selectedItem.type === 'changed') {
+    const currentPair = selectedItem.pairs[variantIndex];
+    if (!currentPair) {
+      return null;
     }
-
-    if (selectedItem.type === 'changed') {
-      const currentPair = selectedItem.pairs[variantIndex];
-      if (!currentPair) {
-        return null;
-      }
-      const totalVariants = selectedItem.pairs.length;
-      return (
-        <Flex direction="column" gap="0" padding="0" height="100%" width="100%">
-          <Flex align="center" justify="between" gap="md" padding="xl">
-            <Flex align="center" gap="md">
-              {totalVariants > 1 && (
-                <VariantNavigation
-                  variantIndex={variantIndex}
-                  totalVariants={totalVariants}
-                  onVariantChange={onVariantChange}
-                />
-              )}
-              <Stack gap="md">
-                <Flex align="center" gap="md">
-                  {currentPair.head_image.display_name && (
-                    <Text size="lg" bold>
-                      {currentPair.head_image.display_name}
-                    </Text>
-                  )}
-                  <ImageFileName fileName={currentPair.head_image.image_file_name} />
-                </Flex>
-                {totalVariants > 1 && (
-                  <Text variant="muted" size="sm">
-                    {t('Variant %s / %s', variantIndex + 1, totalVariants)}
-                  </Text>
-                )}
-              </Stack>
-            </Flex>
-            {diffMode === 'split' && (
-              <OverlayControls
-                overlayColor={overlayColor}
-                onOverlayColorChange={onOverlayColorChange}
-              />
-            )}
-          </Flex>
-          <Separator orientation="horizontal" />
-          <DiffImageDisplay
-            pair={currentPair}
-            imageBaseUrl={imageBaseUrl}
-            diffImageBaseUrl={diffImageBaseUrl}
-            overlayColor={overlayColor}
-            diffMode={diffMode}
-            onDiffModeChange={onDiffModeChange}
-          />
-        </Flex>
-      );
-    }
-
-    if (selectedItem.type === 'solo') {
-      const currentImage = selectedItem.images[variantIndex];
-      if (!currentImage) {
-        return null;
-      }
-      const displayName = getImageName(currentImage);
-      const totalVariants = selectedItem.images.length;
-      const imageUrl = `${imageBaseUrl}${currentImage.key}/`;
-
-      return (
-        <Flex direction="column" gap="0" padding="0" height="100%" width="100%">
-          <Flex align="center" gap="md" padding="xl">
-            {totalVariants > 1 && (
-              <VariantNavigation
-                variantIndex={variantIndex}
-                totalVariants={totalVariants}
-                onVariantChange={onVariantChange}
-              />
-            )}
-            <Stack gap="md">
-              <Text size="lg" bold>
-                {displayName}
-              </Text>
-              {totalVariants > 1 && (
-                <Text variant="muted" size="sm">
-                  {t('Variant %s / %s', variantIndex + 1, totalVariants)}
-                </Text>
-              )}
-            </Stack>
-          </Flex>
-          <Separator orientation="horizontal" />
-          <SingleImageDisplay imageUrl={imageUrl} alt={displayName} />
-        </Flex>
-      );
-    }
-
-    if (selectedItem.type === 'renamed') {
-      const currentPair = selectedItem.pairs[variantIndex];
-      if (!currentPair) {
-        return null;
-      }
-      const totalVariants = selectedItem.pairs.length;
-      const imageUrl = `${imageBaseUrl}${currentPair.head_image.key}/`;
-      const displayName = getImageName(currentPair.head_image);
-
-      return (
-        <Flex direction="column" gap="0" padding="0" height="100%" width="100%">
-          <Flex align="center" gap="md" padding="xl">
+    const totalVariants = selectedItem.pairs.length;
+    return (
+      <Flex direction="column" gap="0" padding="0" height="100%" width="100%">
+        <Flex align="center" justify="between" gap="md" padding="xl">
+          <Flex align="center" gap="md">
             {totalVariants > 1 && (
               <VariantNavigation
                 variantIndex={variantIndex}
@@ -208,42 +146,79 @@ export function SnapshotMainContent({
                     {currentPair.head_image.display_name}
                   </Text>
                 )}
-                <ImageFileName
-                  fileName={currentPair.head_image.image_file_name}
-                  previousFileName={currentPair.base_image.image_file_name}
-                />
+                <ImageFileName fileName={currentPair.head_image.image_file_name} />
               </Flex>
-              <Flex align="center" gap="sm">
+              {totalVariants > 1 && (
                 <Text variant="muted" size="sm">
-                  ({t('Renamed')})
+                  {t('Variant %s / %s', variantIndex + 1, totalVariants)}
                 </Text>
-                {totalVariants > 1 && (
-                  <Text variant="muted" size="sm">
-                    {t('Variant %s / %s', variantIndex + 1, totalVariants)}
-                  </Text>
-                )}
-              </Flex>
+              )}
             </Stack>
           </Flex>
-          <Separator orientation="horizontal" />
-          <SingleImageDisplay imageUrl={imageUrl} alt={displayName} />
+          {diffMode === 'split' && (
+            <OverlayControls
+              overlayColor={overlayColor}
+              onOverlayColorChange={onOverlayColorChange}
+            />
+          )}
         </Flex>
-      );
-    }
+        <Separator orientation="horizontal" />
+        <DiffImageDisplay
+          pair={currentPair}
+          imageBaseUrl={imageBaseUrl}
+          diffImageBaseUrl={diffImageBaseUrl}
+          overlayColor={overlayColor}
+          diffMode={diffMode}
+          onDiffModeChange={onDiffModeChange}
+        />
+      </Flex>
+    );
+  }
 
-    // added, removed, unchanged
+  if (selectedItem.type === 'solo') {
     const currentImage = selectedItem.images[variantIndex];
     if (!currentImage) {
       return null;
     }
     const displayName = getImageName(currentImage);
-    const imageUrl = `${imageBaseUrl}${currentImage.key}/`;
     const totalVariants = selectedItem.images.length;
-    const STATUS_LABELS: Record<string, string> = {
-      added: t('Added'),
-      removed: t('Removed'),
-    };
-    const statusLabel = STATUS_LABELS[selectedItem.type] ?? t('Unchanged');
+    const imageUrl = `${imageBaseUrl}${currentImage.key}/`;
+
+    return (
+      <Flex direction="column" gap="0" padding="0" height="100%" width="100%">
+        <Flex align="center" gap="md" padding="xl">
+          {totalVariants > 1 && (
+            <VariantNavigation
+              variantIndex={variantIndex}
+              totalVariants={totalVariants}
+              onVariantChange={onVariantChange}
+            />
+          )}
+          <Stack gap="md">
+            <Text size="lg" bold>
+              {displayName}
+            </Text>
+            {totalVariants > 1 && (
+              <Text variant="muted" size="sm">
+                {t('Variant %s / %s', variantIndex + 1, totalVariants)}
+              </Text>
+            )}
+          </Stack>
+        </Flex>
+        <Separator orientation="horizontal" />
+        <SingleImageDisplay imageUrl={imageUrl} alt={displayName} />
+      </Flex>
+    );
+  }
+
+  if (selectedItem.type === 'renamed') {
+    const currentPair = selectedItem.pairs[variantIndex];
+    if (!currentPair) {
+      return null;
+    }
+    const totalVariants = selectedItem.pairs.length;
+    const imageUrl = `${imageBaseUrl}${currentPair.head_image.key}/`;
+    const displayName = getImageName(currentPair.head_image);
 
     return (
       <Flex direction="column" gap="0" padding="0" height="100%" width="100%">
@@ -257,16 +232,19 @@ export function SnapshotMainContent({
           )}
           <Stack gap="md">
             <Flex align="center" gap="md">
-              {currentImage.display_name && (
+              {currentPair.head_image.display_name && (
                 <Text size="lg" bold>
-                  {currentImage.display_name}
+                  {currentPair.head_image.display_name}
                 </Text>
               )}
-              <ImageFileName fileName={currentImage.image_file_name} />
+              <ImageFileName
+                fileName={currentPair.head_image.image_file_name}
+                previousFileName={currentPair.base_image.image_file_name}
+              />
             </Flex>
             <Flex align="center" gap="sm">
               <Text variant="muted" size="sm">
-                ({statusLabel})
+                ({t('Renamed')})
               </Text>
               {totalVariants > 1 && (
                 <Text variant="muted" size="sm">
@@ -281,6 +259,56 @@ export function SnapshotMainContent({
       </Flex>
     );
   }
+
+  // added, removed, unchanged
+  const currentImage = selectedItem.images[variantIndex];
+  if (!currentImage) {
+    return null;
+  }
+  const displayName = getImageName(currentImage);
+  const imageUrl = `${imageBaseUrl}${currentImage.key}/`;
+  const totalVariants = selectedItem.images.length;
+  const STATUS_LABELS: Record<string, string> = {
+    added: t('Added'),
+    removed: t('Removed'),
+  };
+  const statusLabel = STATUS_LABELS[selectedItem.type] ?? t('Unchanged');
+
+  return (
+    <Flex direction="column" gap="0" padding="0" height="100%" width="100%">
+      <Flex align="center" gap="md" padding="xl">
+        {totalVariants > 1 && (
+          <VariantNavigation
+            variantIndex={variantIndex}
+            totalVariants={totalVariants}
+            onVariantChange={onVariantChange}
+          />
+        )}
+        <Stack gap="md">
+          <Flex align="center" gap="md">
+            {currentImage.display_name && (
+              <Text size="lg" bold>
+                {currentImage.display_name}
+              </Text>
+            )}
+            <ImageFileName fileName={currentImage.image_file_name} />
+          </Flex>
+          <Flex align="center" gap="sm">
+            <Text variant="muted" size="sm">
+              ({statusLabel})
+            </Text>
+            {totalVariants > 1 && (
+              <Text variant="muted" size="sm">
+                {t('Variant %s / %s', variantIndex + 1, totalVariants)}
+              </Text>
+            )}
+          </Flex>
+        </Stack>
+      </Flex>
+      <Separator orientation="horizontal" />
+      <SingleImageDisplay imageUrl={imageUrl} alt={displayName} />
+    </Flex>
+  );
 }
 
 function ViewModeToggle({

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -37,7 +37,7 @@ import type {
 import {SnapshotHeaderActions} from './header/snapshotHeaderActions';
 import {SnapshotHeaderContent} from './header/snapshotHeaderContent';
 import type {DiffMode} from './main/imageDisplay/diffImageDisplay';
-import {SnapshotMainContent} from './main/snapshotMainContent';
+import {SnapshotMainContent, type ViewMode} from './main/snapshotMainContent';
 import {DIFF_TYPE_ORDER, SnapshotSidebarContent} from './sidebar/snapshotSidebarContent';
 
 export default function SnapshotsPage() {
@@ -97,6 +97,10 @@ export default function SnapshotsPage() {
     palette.at(-5) ?? palette[0]
   );
   const [diffMode, setDiffMode] = useState<DiffMode>('split');
+  const [viewMode, setViewMode] = useLocalStorageState<ViewMode>(
+    'snapshot-view-mode',
+    'single'
+  );
 
   const {
     size: sidebarWidth,
@@ -408,10 +412,13 @@ export default function SnapshotsPage() {
           onVariantChange={setVariantIndex}
           imageBaseUrl={imageBaseUrl}
           diffImageBaseUrl={diffImageBaseUrl}
+          items={filteredItems}
           overlayColor={overlayColor}
           onOverlayColorChange={setOverlayColor}
           diffMode={diffMode}
           onDiffModeChange={setDiffMode}
+          viewMode={viewMode}
+          onViewModeChange={setViewMode}
         />
       </Flex>
     </Flex>

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -99,7 +99,7 @@ export default function SnapshotsPage() {
   const [diffMode, setDiffMode] = useState<DiffMode>('split');
   const [viewMode, setViewMode] = useLocalStorageState<ViewMode>(
     'snapshot-view-mode',
-    'single'
+    'list'
   );
 
   const {


### PR DESCRIPTION
Wire up the \`SnapshotListView\` added in #113992 behind a toggle in the viewer. A new \`SegmentedControl\` in the content header switches between the existing single-item view and the new virtualized list view.

- \`snapshots.tsx\`: add \`viewMode\` localStorage state (default \`'single'\`) and thread it + \`filteredItems\` through to \`SnapshotMainContent\`.
- \`snapshotMainContent.tsx\`: add \`viewMode\` / \`onViewModeChange\` / \`items\` props; early-return \`SnapshotListView\` when \`viewMode === 'list'\`; otherwise wrap the single-view branches (extracted into an inner \`renderBody()\` closure) with a top-level toggle bar.

The toggle persists per-browser via \`useLocalStorageState\`. Sort, navigation, and the rest of the new toolbar controls (diff mode restoration, sort dropdown, prev/next nav) land in follow-up PRs.

4/N in the series slicing up #113958.