### PR TITLE
feat(preprod): Complete the new snapshot viewer toolbar and controls

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -72,9 +72,6 @@ const config: KnipConfig = {
   ignore: [
     // api-docs has its own package.json with its own dependencies
     'api-docs/**',
-    // TODO: remove once preprod snapshot list view lands
-    'static/app/views/preprod/snapshots/main/snapshotCards.tsx',
-    'static/app/views/preprod/snapshots/main/snapshotListView.tsx',
   ],
   ignoreExportsUsedInFile: isProductionMode,
   ignoreDependencies: [

--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -3,12 +3,10 @@ import styled from '@emotion/styled';
 
 import {Image} from '@sentry/scraps/image';
 import {Flex, Grid} from '@sentry/scraps/layout';
-import {SegmentedControl} from '@sentry/scraps/segmentedControl';
 import {Slider} from '@sentry/scraps/slider';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {ContentSliderDiff} from 'sentry/components/contentSliderDiff';
-import {IconInput, IconPause, IconStack} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {SnapshotDiffPair} from 'sentry/views/preprod/types/snapshotTypes';
 
@@ -29,7 +27,6 @@ interface DiffImageDisplayProps {
   diffImageBaseUrl: string;
   diffMode: DiffMode;
   imageBaseUrl: string;
-  onDiffModeChange: (mode: DiffMode) => void;
   overlayColor: string;
   pair: SnapshotDiffPair;
 }
@@ -40,7 +37,6 @@ export function DiffImageDisplay({
   diffImageBaseUrl,
   overlayColor,
   diffMode,
-  onDiffModeChange,
 }: DiffImageDisplayProps) {
   const [diffMaskUrl, setDiffMaskUrl] = useState<string | null>(null);
   const [onionOpacity, setOnionOpacity] = useState(50);
@@ -87,21 +83,8 @@ export function DiffImageDisplay({
     };
   }, [diffImageUrl]);
 
-  // >= 1% shows 1 decimal (e.g. "93.5%"), < 1% shows up to 4 without trailing zeros (e.g. "0.0227%")
-  const diffPct = pair.diff === null ? null : pair.diff * 100;
-  const diffPercent =
-    diffPct === null
-      ? null
-      : `${diffPct >= 1 ? diffPct.toFixed(1) : parseFloat(diffPct.toFixed(4))}%`;
-
   return (
     <Flex direction="column" gap="lg" padding="xl" flex="1" minHeight="0">
-      {diffPercent && (
-        <Text variant="muted" size="sm">
-          {t('Diff: %s', diffPercent)}
-        </Text>
-      )}
-
       {diffMode === 'split' && (
         <SplitView
           baseImageUrl={baseImageUrl}
@@ -123,20 +106,6 @@ export function DiffImageDisplay({
           onOpacityChange={setOnionOpacity}
         />
       )}
-
-      <Flex justify="center" flexShrink={0}>
-        <SegmentedControl value={diffMode} onChange={onDiffModeChange}>
-          <SegmentedControl.Item key="split" icon={<IconPause />}>
-            {t('Split')}
-          </SegmentedControl.Item>
-          <SegmentedControl.Item key="wipe" icon={<IconInput />}>
-            {t('Wipe')}
-          </SegmentedControl.Item>
-          <SegmentedControl.Item key="onion" icon={<IconStack />}>
-            {t('Onion')}
-          </SegmentedControl.Item>
-        </SegmentedControl>
-      </Flex>
     </Flex>
   );
 }

--- a/static/app/views/preprod/snapshots/main/snapshotListView.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.tsx
@@ -74,8 +74,15 @@ function estimateCardHeight(image: SnapshotImage, splitColumns: boolean) {
   const columnWidth = splitColumns
     ? LIST_CONTENT_WIDTH_ASSUMPTION / 2
     : LIST_CONTENT_WIDTH_ASSUMPTION;
+  // The <img> uses width: auto + max-width: 100%, so it never scales up past
+  // its natural size. Mirror that here: only scale down when natural width
+  // exceeds the column.
   const aspectHeight =
-    image.width > 0 ? (image.height / image.width) * columnWidth : MAX_IMAGE_HEIGHT;
+    image.width > 0 && image.height > 0
+      ? image.width <= columnWidth
+        ? image.height
+        : (image.height / image.width) * columnWidth
+      : MAX_IMAGE_HEIGHT;
   const imageBox = Math.min(aspectHeight, MAX_IMAGE_HEIGHT);
   return CARD_CHROME_HEIGHT + imageBox;
 }

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -1,3 +1,4 @@
+import type React from 'react';
 import {Fragment, useEffect, useRef, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
@@ -172,111 +173,49 @@ export function SnapshotMainContent({
 
   const groupName = isItemUngrouped(selectedItem) ? null : selectedItem.name;
 
-  const renderSingleViewCard = ({
-    headerProps,
-    body,
-    rightControls,
-  }: {
-    body: React.ReactNode;
-    headerProps: Omit<React.ComponentProps<typeof CardHeader>, 'isDark' | 'onToggleDark'>;
-    rightControls?: React.ReactNode;
-  }) => {
-    const card = (
-      <SingleViewCard isDark={isDark} isSelected={false}>
-        <CardHeader {...headerProps} isDark={isDark} onToggleDark={toggleDark} />
-        <SingleViewBody>{body}</SingleViewBody>
-      </SingleViewCard>
-    );
-    return (
-      <Flex
-        direction="column"
-        gap="0"
-        padding="0"
-        height="100%"
-        width="100%"
-        background="secondary"
-      >
-        <Flex align="center" justify="between" gap="md" padding="md xl">
-          {toggle}
-          <Flex align="center" gap="md">
-            {rightControls}
-            {soloDiffToggle}
-          </Flex>
-        </Flex>
-        <Separator orientation="horizontal" />
-        <SingleViewScroll>
-          <Flex direction="row" gap="xl" flex="1" minHeight="0" align="stretch">
-            <Flex direction="column" flex="1" minWidth="0">
-              <DarkAware isDark={isDark}>
-                {groupName ? (
-                  <SingleViewGroup>
-                    <GroupHeader name={groupName} />
-                    {card}
-                  </SingleViewGroup>
-                ) : (
-                  card
-                )}
-              </DarkAware>
-            </Flex>
-            <NavGutter>
-              <Tooltip title={t('Previous')} skipWrapper>
-                <Button
-                  size="sm"
-                  icon={<IconArrow direction="up" />}
-                  aria-label={t('Previous snapshot')}
-                  disabled={!canNavigatePrev}
-                  onClick={() => onNavigateSingleView('prev')}
-                />
-              </Tooltip>
-              <Tooltip title={t('Next')} skipWrapper>
-                <Button
-                  size="sm"
-                  icon={<IconArrow direction="down" />}
-                  aria-label={t('Next snapshot')}
-                  disabled={!canNavigateNext}
-                  onClick={() => onNavigateSingleView('next')}
-                />
-              </Tooltip>
-            </NavGutter>
-          </Flex>
-        </SingleViewScroll>
-      </Flex>
-    );
-  };
-
   if (selectedItem.type === 'changed') {
     const currentPair = selectedItem.pairs[variantIndex];
     if (!currentPair) {
       return null;
     }
     const image = currentPair.head_image;
-    return renderSingleViewCard({
-      headerProps: {
-        displayName: image.display_name,
-        fileName: image.image_file_name,
-        status: DiffStatus.CHANGED,
-        diffPercent: currentPair.diff,
-        copyData: currentPair,
-        copyUrl: buildSnapshotLink(image.image_file_name),
-      },
-      rightControls: (
-        <Fragment>
-          {diffMode === 'split' && (
-            <ColorPickerButton color={overlayColor} onChange={onOverlayColorChange} />
-          )}
-          <DiffModeToggle diffMode={diffMode} onDiffModeChange={onDiffModeChange} />
-        </Fragment>
-      ),
-      body: (
-        <DiffImageDisplay
-          pair={currentPair}
-          imageBaseUrl={imageBaseUrl}
-          diffImageBaseUrl={diffImageBaseUrl}
-          overlayColor={overlayColor}
-          diffMode={diffMode}
-        />
-      ),
-    });
+    return (
+      <SingleViewLayout
+        isDark={isDark}
+        onToggleDark={toggleDark}
+        groupName={groupName}
+        toggle={toggle}
+        soloDiffToggle={soloDiffToggle}
+        canNavigatePrev={canNavigatePrev}
+        canNavigateNext={canNavigateNext}
+        onNavigateSingleView={onNavigateSingleView}
+        headerProps={{
+          displayName: image.display_name,
+          fileName: image.image_file_name,
+          status: DiffStatus.CHANGED,
+          diffPercent: currentPair.diff,
+          copyData: currentPair,
+          copyUrl: buildSnapshotLink(image.image_file_name),
+        }}
+        rightControls={
+          <Fragment>
+            {diffMode === 'split' && (
+              <ColorPickerButton color={overlayColor} onChange={onOverlayColorChange} />
+            )}
+            <DiffModeToggle diffMode={diffMode} onDiffModeChange={onDiffModeChange} />
+          </Fragment>
+        }
+        body={
+          <DiffImageDisplay
+            pair={currentPair}
+            imageBaseUrl={imageBaseUrl}
+            diffImageBaseUrl={diffImageBaseUrl}
+            overlayColor={overlayColor}
+            diffMode={diffMode}
+          />
+        }
+      />
+    );
   }
 
   if (selectedItem.type === 'renamed') {
@@ -286,16 +225,26 @@ export function SnapshotMainContent({
     }
     const image = currentPair.head_image;
     const imageUrl = `${imageBaseUrl}${image.key}/`;
-    return renderSingleViewCard({
-      headerProps: {
-        displayName: image.display_name,
-        fileName: image.image_file_name,
-        status: DiffStatus.RENAMED,
-        copyData: currentPair,
-        copyUrl: buildSnapshotLink(image.image_file_name),
-      },
-      body: <SingleImageDisplay imageUrl={imageUrl} alt={getImageName(image)} />,
-    });
+    return (
+      <SingleViewLayout
+        isDark={isDark}
+        onToggleDark={toggleDark}
+        groupName={groupName}
+        toggle={toggle}
+        soloDiffToggle={soloDiffToggle}
+        canNavigatePrev={canNavigatePrev}
+        canNavigateNext={canNavigateNext}
+        onNavigateSingleView={onNavigateSingleView}
+        headerProps={{
+          displayName: image.display_name,
+          fileName: image.image_file_name,
+          status: DiffStatus.RENAMED,
+          copyData: currentPair,
+          copyUrl: buildSnapshotLink(image.image_file_name),
+        }}
+        body={<SingleImageDisplay imageUrl={imageUrl} alt={getImageName(image)} />}
+      />
+    );
   }
 
   const currentImage = selectedItem.images[variantIndex];
@@ -314,16 +263,114 @@ export function SnapshotMainContent({
     status = DiffStatus.UNCHANGED;
   }
 
-  return renderSingleViewCard({
-    headerProps: {
-      displayName: currentImage.display_name,
-      fileName: currentImage.image_file_name,
-      status,
-      copyData: currentImage,
-      copyUrl: buildSnapshotLink(currentImage.image_file_name),
-    },
-    body: <SingleImageDisplay imageUrl={imageUrl} alt={getImageName(currentImage)} />,
-  });
+  return (
+    <SingleViewLayout
+      isDark={isDark}
+      onToggleDark={toggleDark}
+      groupName={groupName}
+      toggle={toggle}
+      soloDiffToggle={soloDiffToggle}
+      canNavigatePrev={canNavigatePrev}
+      canNavigateNext={canNavigateNext}
+      onNavigateSingleView={onNavigateSingleView}
+      headerProps={{
+        displayName: currentImage.display_name,
+        fileName: currentImage.image_file_name,
+        status,
+        copyData: currentImage,
+        copyUrl: buildSnapshotLink(currentImage.image_file_name),
+      }}
+      body={<SingleImageDisplay imageUrl={imageUrl} alt={getImageName(currentImage)} />}
+    />
+  );
+}
+
+function SingleViewLayout({
+  isDark,
+  onToggleDark,
+  groupName,
+  toggle,
+  soloDiffToggle,
+  canNavigatePrev,
+  canNavigateNext,
+  onNavigateSingleView,
+  headerProps,
+  body,
+  rightControls,
+}: {
+  body: React.ReactNode;
+  canNavigateNext: boolean;
+  canNavigatePrev: boolean;
+  groupName: string | null;
+  headerProps: Omit<React.ComponentProps<typeof CardHeader>, 'isDark' | 'onToggleDark'>;
+  isDark: boolean;
+  onNavigateSingleView: (direction: 'prev' | 'next') => void;
+  onToggleDark: () => void;
+  soloDiffToggle: React.ReactNode;
+  toggle: React.ReactNode;
+  rightControls?: React.ReactNode;
+}) {
+  const card = (
+    <SingleViewCard isDark={isDark} isSelected={false}>
+      <CardHeader {...headerProps} isDark={isDark} onToggleDark={onToggleDark} />
+      <SingleViewBody>{body}</SingleViewBody>
+    </SingleViewCard>
+  );
+  return (
+    <Flex
+      direction="column"
+      gap="0"
+      padding="0"
+      height="100%"
+      width="100%"
+      background="secondary"
+    >
+      <Flex align="center" justify="between" gap="md" padding="md xl">
+        {toggle}
+        <Flex align="center" gap="md">
+          {rightControls}
+          {soloDiffToggle}
+        </Flex>
+      </Flex>
+      <Separator orientation="horizontal" />
+      <SingleViewScroll>
+        <Flex direction="row" gap="xl" flex="1" minHeight="0" align="stretch">
+          <Flex direction="column" flex="1" minWidth="0">
+            <DarkAware isDark={isDark}>
+              {groupName ? (
+                <SingleViewGroup>
+                  <GroupHeader name={groupName} />
+                  {card}
+                </SingleViewGroup>
+              ) : (
+                card
+              )}
+            </DarkAware>
+          </Flex>
+          <NavGutter>
+            <Tooltip title={t('Previous')} skipWrapper>
+              <Button
+                size="sm"
+                icon={<IconArrow direction="up" />}
+                aria-label={t('Previous snapshot')}
+                disabled={!canNavigatePrev}
+                onClick={() => onNavigateSingleView('prev')}
+              />
+            </Tooltip>
+            <Tooltip title={t('Next')} skipWrapper>
+              <Button
+                size="sm"
+                icon={<IconArrow direction="down" />}
+                aria-label={t('Next snapshot')}
+                disabled={!canNavigateNext}
+                onClick={() => onNavigateSingleView('next')}
+              />
+            </Tooltip>
+          </NavGutter>
+        </Flex>
+      </SingleViewScroll>
+    </Flex>
+  );
 }
 
 function SoloDiffToggle({

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -39,7 +39,7 @@ import {
 } from './snapshotListView';
 
 export type ViewMode = 'single' | 'list';
-export type SortBy = 'diff' | 'alpha';
+type SortBy = 'diff' | 'alpha';
 
 interface SnapshotMainContentProps {
   canNavigateNext: boolean;

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -1,18 +1,26 @@
-import {useEffect, useRef, useState} from 'react';
+import {Fragment, useEffect, useRef, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import {Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
-import {InlineCode} from '@sentry/scraps/code';
+import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {SegmentedControl} from '@sentry/scraps/segmentedControl';
 import {Separator} from '@sentry/scraps/separator';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {IconChevron, IconExpand, IconList} from 'sentry/icons';
+import {
+  IconArrow,
+  IconExpand,
+  IconInput,
+  IconList,
+  IconPause,
+  IconStack,
+} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {getImageName} from 'sentry/views/preprod/types/snapshotTypes';
+import {DiffStatus, getImageName} from 'sentry/views/preprod/types/snapshotTypes';
 import type {SidebarItem} from 'sentry/views/preprod/types/snapshotTypes';
 
 import {
@@ -21,194 +29,254 @@ import {
   TRANSPARENT_COLOR,
 } from './imageDisplay/diffImageDisplay';
 import {SingleImageDisplay} from './imageDisplay/singleImageDisplay';
-import {SnapshotListView} from './snapshotListView';
+import {Card, CardHeader, DarkAware} from './snapshotCards';
+import {
+  buildSnapshotLink,
+  GroupHeader,
+  isItemUngrouped,
+  SnapshotListView,
+} from './snapshotListView';
 
 export type ViewMode = 'single' | 'list';
+export type SortBy = 'diff' | 'alpha';
 
 interface SnapshotMainContentProps {
+  canNavigateNext: boolean;
+  canNavigatePrev: boolean;
+  comparisonType: 'diff' | 'solo' | undefined;
   diffImageBaseUrl: string;
   diffMode: DiffMode;
   imageBaseUrl: string;
-  items: SidebarItem[];
+  isSoloView: boolean;
+  listItems: SidebarItem[];
   onDiffModeChange: (mode: DiffMode) => void;
+  onNavigateSingleView: (direction: 'prev' | 'next') => void;
   onOverlayColorChange: (color: string) => void;
-  onVariantChange: (index: number) => void;
+  onToggleSoloView: () => void;
   onViewModeChange: (mode: ViewMode) => void;
   overlayColor: string;
   selectedItem: SidebarItem | null;
   variantIndex: number;
   viewMode: ViewMode;
+  headBranch?: string | null;
+  onSelectSnapshot?: (key: string | null) => void;
+  onSortByChange?: (sort: SortBy) => void;
+  selectedSnapshotKey?: string | null;
+  sortBy?: SortBy;
 }
 
 export function SnapshotMainContent({
   selectedItem,
   variantIndex,
-  onVariantChange,
   imageBaseUrl,
   diffImageBaseUrl,
-  items,
   overlayColor,
   onOverlayColorChange,
   diffMode,
   onDiffModeChange,
   viewMode,
   onViewModeChange,
+  listItems,
+  isSoloView,
+  onToggleSoloView,
+  comparisonType,
+  headBranch,
+  selectedSnapshotKey,
+  onSelectSnapshot,
+  sortBy = 'diff',
+  onSortByChange,
+  onNavigateSingleView,
+  canNavigatePrev,
+  canNavigateNext,
 }: SnapshotMainContentProps) {
+  const [isDark, setIsDark] = useState(false);
+  const toggleDark = () => setIsDark(v => !v);
+  const toggle = (
+    <ViewModeToggle viewMode={viewMode} onViewModeChange={onViewModeChange} />
+  );
+  const hasChangedInList = listItems.some(i => i.type === 'changed');
+  const sortDropdown =
+    viewMode === 'list' &&
+    onSortByChange &&
+    comparisonType !== 'solo' &&
+    hasChangedInList ? (
+      <SortDropdown value={sortBy} onChange={onSortByChange} />
+    ) : null;
+  const listDiffControls =
+    viewMode === 'list' && hasChangedInList ? (
+      <Flex align="center" gap="sm">
+        {diffMode === 'split' && (
+          <ColorPickerButton color={overlayColor} onChange={onOverlayColorChange} />
+        )}
+        <DiffModeToggle diffMode={diffMode} onDiffModeChange={onDiffModeChange} />
+      </Flex>
+    ) : null;
+  let soloDiffToggle: React.ReactNode = null;
+  if (comparisonType === 'diff') {
+    soloDiffToggle = (
+      <SoloDiffToggle isSoloView={isSoloView} onToggleSoloView={onToggleSoloView} />
+    );
+  } else if (comparisonType === 'solo') {
+    soloDiffToggle = <Tag variant="promotion">{t('Base')}</Tag>;
+  }
+
   if (viewMode === 'list') {
     return (
-      <Flex direction="column" flex="1" minHeight="0" width="100%">
-        <Flex justify="end" padding="md">
-          <ViewModeToggle viewMode={viewMode} onViewModeChange={onViewModeChange} />
+      <Flex
+        direction="column"
+        gap="0"
+        padding="0"
+        height="100%"
+        width="100%"
+        background="secondary"
+      >
+        <Flex align="center" justify="between" gap="md" padding="md xl">
+          <Flex align="center" gap="md">
+            {toggle}
+            {sortDropdown}
+          </Flex>
+          <Flex align="center" gap="md">
+            {listDiffControls}
+            {soloDiffToggle}
+          </Flex>
         </Flex>
         <Separator orientation="horizontal" />
         <SnapshotListView
-          items={items}
+          items={listItems}
           imageBaseUrl={imageBaseUrl}
-          diffImageBaseUrl={diffImageBaseUrl}
+          headBranch={headBranch}
+          selectedSnapshotKey={selectedSnapshotKey}
+          onSelectSnapshot={onSelectSnapshot}
           diffMode={diffMode}
           overlayColor={overlayColor}
+          diffImageBaseUrl={diffImageBaseUrl}
         />
       </Flex>
     );
   }
 
-  return (
-    <Flex direction="column" flex="1" minHeight="0" width="100%">
-      <Flex justify="end" padding="md">
-        <ViewModeToggle viewMode={viewMode} onViewModeChange={onViewModeChange} />
-      </Flex>
-      <Separator orientation="horizontal" />
-      <SingleViewContent
-        selectedItem={selectedItem}
-        variantIndex={variantIndex}
-        onVariantChange={onVariantChange}
-        imageBaseUrl={imageBaseUrl}
-        diffImageBaseUrl={diffImageBaseUrl}
-        overlayColor={overlayColor}
-        onOverlayColorChange={onOverlayColorChange}
-        diffMode={diffMode}
-        onDiffModeChange={onDiffModeChange}
-      />
-    </Flex>
-  );
-}
-
-function SingleViewContent({
-  selectedItem,
-  variantIndex,
-  onVariantChange,
-  imageBaseUrl,
-  diffImageBaseUrl,
-  overlayColor,
-  onOverlayColorChange,
-  diffMode,
-  onDiffModeChange,
-}: {
-  diffImageBaseUrl: string;
-  diffMode: DiffMode;
-  imageBaseUrl: string;
-  onDiffModeChange: (mode: DiffMode) => void;
-  onOverlayColorChange: (color: string) => void;
-  onVariantChange: (index: number) => void;
-  overlayColor: string;
-  selectedItem: SidebarItem | null;
-  variantIndex: number;
-}) {
   if (!selectedItem) {
     return (
-      <Flex align="center" justify="center" padding="3xl" width="100%">
-        <Text variant="muted">{t('Select an image from the sidebar.')}</Text>
+      <Flex direction="column" gap="0" padding="0" height="100%" width="100%">
+        <Flex align="center" justify="between" gap="md" padding="md xl">
+          {toggle}
+          {soloDiffToggle}
+        </Flex>
+        <Separator orientation="horizontal" />
+        <Flex align="center" justify="center" padding="3xl" width="100%" flex="1">
+          <Text variant="muted">{t('Select an image from the sidebar.')}</Text>
+        </Flex>
       </Flex>
     );
   }
+
+  const groupName = isItemUngrouped(selectedItem) ? null : selectedItem.name;
+
+  const renderSingleViewCard = ({
+    headerProps,
+    body,
+    rightControls,
+  }: {
+    body: React.ReactNode;
+    headerProps: Omit<React.ComponentProps<typeof CardHeader>, 'isDark' | 'onToggleDark'>;
+    rightControls?: React.ReactNode;
+  }) => {
+    const card = (
+      <SingleViewCard isDark={isDark} isSelected={false}>
+        <CardHeader {...headerProps} isDark={isDark} onToggleDark={toggleDark} />
+        <SingleViewBody>{body}</SingleViewBody>
+      </SingleViewCard>
+    );
+    return (
+      <Flex
+        direction="column"
+        gap="0"
+        padding="0"
+        height="100%"
+        width="100%"
+        background="secondary"
+      >
+        <Flex align="center" justify="between" gap="md" padding="md xl">
+          {toggle}
+          <Flex align="center" gap="md">
+            {rightControls}
+            {soloDiffToggle}
+          </Flex>
+        </Flex>
+        <Separator orientation="horizontal" />
+        <SingleViewScroll>
+          <Flex direction="row" gap="xl" flex="1" minHeight="0" align="stretch">
+            <Flex direction="column" flex="1" minWidth="0">
+              <DarkAware isDark={isDark}>
+                {groupName ? (
+                  <SingleViewGroup>
+                    <GroupHeader name={groupName} />
+                    {card}
+                  </SingleViewGroup>
+                ) : (
+                  card
+                )}
+              </DarkAware>
+            </Flex>
+            <NavGutter>
+              <Tooltip title={t('Previous')} skipWrapper>
+                <Button
+                  size="sm"
+                  icon={<IconArrow direction="up" />}
+                  aria-label={t('Previous snapshot')}
+                  disabled={!canNavigatePrev}
+                  onClick={() => onNavigateSingleView('prev')}
+                />
+              </Tooltip>
+              <Tooltip title={t('Next')} skipWrapper>
+                <Button
+                  size="sm"
+                  icon={<IconArrow direction="down" />}
+                  aria-label={t('Next snapshot')}
+                  disabled={!canNavigateNext}
+                  onClick={() => onNavigateSingleView('next')}
+                />
+              </Tooltip>
+            </NavGutter>
+          </Flex>
+        </SingleViewScroll>
+      </Flex>
+    );
+  };
 
   if (selectedItem.type === 'changed') {
     const currentPair = selectedItem.pairs[variantIndex];
     if (!currentPair) {
       return null;
     }
-    const totalVariants = selectedItem.pairs.length;
-    return (
-      <Flex direction="column" gap="0" padding="0" height="100%" width="100%">
-        <Flex align="center" justify="between" gap="md" padding="xl">
-          <Flex align="center" gap="md">
-            {totalVariants > 1 && (
-              <VariantNavigation
-                variantIndex={variantIndex}
-                totalVariants={totalVariants}
-                onVariantChange={onVariantChange}
-              />
-            )}
-            <Stack gap="md">
-              <Flex align="center" gap="md">
-                {currentPair.head_image.display_name && (
-                  <Text size="lg" bold>
-                    {currentPair.head_image.display_name}
-                  </Text>
-                )}
-                <ImageFileName fileName={currentPair.head_image.image_file_name} />
-              </Flex>
-              {totalVariants > 1 && (
-                <Text variant="muted" size="sm">
-                  {t('Variant %s / %s', variantIndex + 1, totalVariants)}
-                </Text>
-              )}
-            </Stack>
-          </Flex>
+    const image = currentPair.head_image;
+    return renderSingleViewCard({
+      headerProps: {
+        displayName: image.display_name,
+        fileName: image.image_file_name,
+        status: DiffStatus.CHANGED,
+        diffPercent: currentPair.diff,
+        copyData: currentPair,
+        copyUrl: buildSnapshotLink(image.image_file_name),
+      },
+      rightControls: (
+        <Fragment>
           {diffMode === 'split' && (
-            <OverlayControls
-              overlayColor={overlayColor}
-              onOverlayColorChange={onOverlayColorChange}
-            />
+            <ColorPickerButton color={overlayColor} onChange={onOverlayColorChange} />
           )}
-        </Flex>
-        <Separator orientation="horizontal" />
+          <DiffModeToggle diffMode={diffMode} onDiffModeChange={onDiffModeChange} />
+        </Fragment>
+      ),
+      body: (
         <DiffImageDisplay
           pair={currentPair}
           imageBaseUrl={imageBaseUrl}
           diffImageBaseUrl={diffImageBaseUrl}
           overlayColor={overlayColor}
           diffMode={diffMode}
-          onDiffModeChange={onDiffModeChange}
         />
-      </Flex>
-    );
-  }
-
-  if (selectedItem.type === 'solo') {
-    const currentImage = selectedItem.images[variantIndex];
-    if (!currentImage) {
-      return null;
-    }
-    const displayName = getImageName(currentImage);
-    const totalVariants = selectedItem.images.length;
-    const imageUrl = `${imageBaseUrl}${currentImage.key}/`;
-
-    return (
-      <Flex direction="column" gap="0" padding="0" height="100%" width="100%">
-        <Flex align="center" gap="md" padding="xl">
-          {totalVariants > 1 && (
-            <VariantNavigation
-              variantIndex={variantIndex}
-              totalVariants={totalVariants}
-              onVariantChange={onVariantChange}
-            />
-          )}
-          <Stack gap="md">
-            <Text size="lg" bold>
-              {displayName}
-            </Text>
-            {totalVariants > 1 && (
-              <Text variant="muted" size="sm">
-                {t('Variant %s / %s', variantIndex + 1, totalVariants)}
-              </Text>
-            )}
-          </Stack>
-        </Flex>
-        <Separator orientation="horizontal" />
-        <SingleImageDisplay imageUrl={imageUrl} alt={displayName} />
-      </Flex>
-    );
+      ),
+    });
   }
 
   if (selectedItem.type === 'renamed') {
@@ -216,98 +284,72 @@ function SingleViewContent({
     if (!currentPair) {
       return null;
     }
-    const totalVariants = selectedItem.pairs.length;
-    const imageUrl = `${imageBaseUrl}${currentPair.head_image.key}/`;
-    const displayName = getImageName(currentPair.head_image);
-
-    return (
-      <Flex direction="column" gap="0" padding="0" height="100%" width="100%">
-        <Flex align="center" gap="md" padding="xl">
-          {totalVariants > 1 && (
-            <VariantNavigation
-              variantIndex={variantIndex}
-              totalVariants={totalVariants}
-              onVariantChange={onVariantChange}
-            />
-          )}
-          <Stack gap="md">
-            <Flex align="center" gap="md">
-              {currentPair.head_image.display_name && (
-                <Text size="lg" bold>
-                  {currentPair.head_image.display_name}
-                </Text>
-              )}
-              <ImageFileName
-                fileName={currentPair.head_image.image_file_name}
-                previousFileName={currentPair.base_image.image_file_name}
-              />
-            </Flex>
-            <Flex align="center" gap="sm">
-              <Text variant="muted" size="sm">
-                ({t('Renamed')})
-              </Text>
-              {totalVariants > 1 && (
-                <Text variant="muted" size="sm">
-                  {t('Variant %s / %s', variantIndex + 1, totalVariants)}
-                </Text>
-              )}
-            </Flex>
-          </Stack>
-        </Flex>
-        <Separator orientation="horizontal" />
-        <SingleImageDisplay imageUrl={imageUrl} alt={displayName} />
-      </Flex>
-    );
+    const image = currentPair.head_image;
+    const imageUrl = `${imageBaseUrl}${image.key}/`;
+    return renderSingleViewCard({
+      headerProps: {
+        displayName: image.display_name,
+        fileName: image.image_file_name,
+        status: DiffStatus.RENAMED,
+        copyData: currentPair,
+        copyUrl: buildSnapshotLink(image.image_file_name),
+      },
+      body: <SingleImageDisplay imageUrl={imageUrl} alt={getImageName(image)} />,
+    });
   }
 
-  // added, removed, unchanged
   const currentImage = selectedItem.images[variantIndex];
   if (!currentImage) {
     return null;
   }
-  const displayName = getImageName(currentImage);
   const imageUrl = `${imageBaseUrl}${currentImage.key}/`;
-  const totalVariants = selectedItem.images.length;
-  const STATUS_LABELS: Record<string, string> = {
-    added: t('Added'),
-    removed: t('Removed'),
-  };
-  const statusLabel = STATUS_LABELS[selectedItem.type] ?? t('Unchanged');
+  let status: DiffStatus | null;
+  if (selectedItem.type === 'solo') {
+    status = null;
+  } else if (selectedItem.type === 'added') {
+    status = DiffStatus.ADDED;
+  } else if (selectedItem.type === 'removed') {
+    status = DiffStatus.REMOVED;
+  } else {
+    status = DiffStatus.UNCHANGED;
+  }
 
+  return renderSingleViewCard({
+    headerProps: {
+      displayName: currentImage.display_name,
+      fileName: currentImage.image_file_name,
+      status,
+      copyData: currentImage,
+      copyUrl: buildSnapshotLink(currentImage.image_file_name),
+    },
+    body: <SingleImageDisplay imageUrl={imageUrl} alt={getImageName(currentImage)} />,
+  });
+}
+
+function SoloDiffToggle({
+  isSoloView,
+  onToggleSoloView,
+}: {
+  isSoloView: boolean;
+  onToggleSoloView: () => void;
+}) {
   return (
-    <Flex direction="column" gap="0" padding="0" height="100%" width="100%">
-      <Flex align="center" gap="md" padding="xl">
-        {totalVariants > 1 && (
-          <VariantNavigation
-            variantIndex={variantIndex}
-            totalVariants={totalVariants}
-            onVariantChange={onVariantChange}
-          />
-        )}
-        <Stack gap="md">
-          <Flex align="center" gap="md">
-            {currentImage.display_name && (
-              <Text size="lg" bold>
-                {currentImage.display_name}
-              </Text>
-            )}
-            <ImageFileName fileName={currentImage.image_file_name} />
-          </Flex>
-          <Flex align="center" gap="sm">
-            <Text variant="muted" size="sm">
-              ({statusLabel})
-            </Text>
-            {totalVariants > 1 && (
-              <Text variant="muted" size="sm">
-                {t('Variant %s / %s', variantIndex + 1, totalVariants)}
-              </Text>
-            )}
-          </Flex>
-        </Stack>
-      </Flex>
-      <Separator orientation="horizontal" />
-      <SingleImageDisplay imageUrl={imageUrl} alt={displayName} />
-    </Flex>
+    <SegmentedControl
+      size="xs"
+      value={isSoloView ? 'head' : 'diff'}
+      onChange={value => {
+        if ((value === 'head') !== isSoloView) {
+          onToggleSoloView();
+        }
+      }}
+    >
+      <SegmentedControl.Item key="diff" tooltip={t('Compare with base')}>
+        {t('Diff')}
+      </SegmentedControl.Item>
+      <SegmentedControl.Item key="head" tooltip={t('Head only')}>
+        {t('Head')}
+      </SegmentedControl.Item>
+    </SegmentedControl>
   );
 }
 
@@ -341,113 +383,73 @@ function ViewModeToggle({
   );
 }
 
-function VariantNavigation({
-  variantIndex,
-  totalVariants,
-  onVariantChange,
+function SortDropdown({
+  value,
+  onChange,
 }: {
-  onVariantChange: (index: number) => void;
-  totalVariants: number;
-  variantIndex: number;
+  onChange: (sort: SortBy) => void;
+  value: SortBy;
 }) {
   return (
-    <Flex align="center" gap="sm">
-      <Button
-        size="md"
-        priority="transparent"
-        icon={<IconChevron direction="left" />}
-        aria-label={t('Previous variant')}
-        disabled={variantIndex === 0}
-        onClick={() => onVariantChange(variantIndex - 1)}
-      />
-      <Button
-        size="md"
-        priority="transparent"
-        icon={<IconChevron direction="right" />}
-        aria-label={t('Next variant')}
-        disabled={variantIndex === totalVariants - 1}
-        onClick={() => onVariantChange(variantIndex + 1)}
-      />
-    </Flex>
+    <CompactSelect
+      size="xs"
+      value={value}
+      onChange={opt => onChange(opt.value)}
+      options={[
+        {value: 'diff' as const, label: t('Diff %')},
+        {value: 'alpha' as const, label: t('A - Z')},
+      ]}
+    />
   );
 }
 
-function ImageFileName({
-  fileName,
-  previousFileName,
+function ColorPickerButton({
+  color,
+  onChange,
 }: {
-  fileName: string;
-  previousFileName?: string;
-}) {
-  if (!fileName) {
-    return null;
-  }
-  if (previousFileName) {
-    return (
-      <Tooltip
-        title={
-          <span>
-            <InlineCode>{previousFileName}</InlineCode>
-            {' → '}
-            <InlineCode>{fileName}</InlineCode>
-          </span>
-        }
-        maxWidth={2000}
-      >
-        <InlineCode>{fileName}</InlineCode>
-      </Tooltip>
-    );
-  }
-  return <InlineCode variant="neutral">{fileName}</InlineCode>;
-}
-
-function OverlayControls({
-  overlayColor,
-  onOverlayColorChange,
-}: {
-  onOverlayColorChange: (color: string) => void;
-  overlayColor: string;
+  color: string;
+  onChange: (color: string) => void;
 }) {
   const theme = useTheme();
-  const [isColorPickerOpen, setIsColorPickerOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
   const pickerRef = useRef<HTMLDivElement>(null);
-
   const overlayColors = [TRANSPARENT_COLOR, ...theme.chart.getColorPalette(10)];
 
   useEffect(() => {
-    if (!isColorPickerOpen) {
+    if (!isOpen) {
       return undefined;
     }
-
     function handleMouseDown(e: MouseEvent) {
       if (pickerRef.current && !pickerRef.current.contains(e.target as Node)) {
-        setIsColorPickerOpen(false);
+        setIsOpen(false);
       }
     }
     document.addEventListener('mousedown', handleMouseDown);
     return () => document.removeEventListener('mousedown', handleMouseDown);
-  }, [isColorPickerOpen]);
+  }, [isOpen]);
 
   return (
     <ColorPickerWrapper ref={pickerRef}>
-      <ColorTrigger
-        color={overlayColor}
-        aria-label={t('Pick overlay color')}
-        onClick={() => setIsColorPickerOpen(open => !open)}
-      />
-      {isColorPickerOpen && (
+      <Tooltip title={t('Overlay color')} skipWrapper>
+        <ColorTrigger
+          color={color}
+          aria-label={t('Pick overlay color')}
+          onClick={() => setIsOpen(v => !v)}
+        />
+      </Tooltip>
+      {isOpen && (
         <ColorPickerDropdown>
           <Flex gap="xs">
-            {overlayColors.map(color => (
+            {overlayColors.map(c => (
               <ColorSwatch
-                key={color}
-                color={color}
-                selected={overlayColor === color}
+                key={c}
+                color={c}
+                selected={color === c}
                 onClick={() => {
-                  onOverlayColorChange(color);
-                  setIsColorPickerOpen(false);
+                  onChange(c);
+                  setIsOpen(false);
                 }}
-                aria-label={t('Overlay color %s', color)}
+                aria-label={t('Overlay color %s', c)}
               />
             ))}
           </Flex>
@@ -456,6 +458,84 @@ function OverlayControls({
     </ColorPickerWrapper>
   );
 }
+
+function DiffModeToggle({
+  diffMode,
+  onDiffModeChange,
+}: {
+  diffMode: DiffMode;
+  onDiffModeChange: (mode: DiffMode) => void;
+}) {
+  return (
+    <SegmentedControl size="xs" value={diffMode} onChange={onDiffModeChange}>
+      <SegmentedControl.Item
+        key="split"
+        icon={<IconPause />}
+        aria-label={t('Split')}
+        tooltip={t('Split')}
+      />
+      <SegmentedControl.Item
+        key="wipe"
+        icon={<IconInput />}
+        aria-label={t('Wipe')}
+        tooltip={t('Wipe')}
+      />
+      <SegmentedControl.Item
+        key="onion"
+        icon={<IconStack />}
+        aria-label={t('Onion')}
+        tooltip={t('Onion')}
+      />
+    </SegmentedControl>
+  );
+}
+
+const SingleViewScroll = styled('div')`
+  flex: 1 1 0;
+  min-height: 0;
+  width: 100%;
+  overflow: auto;
+  padding: ${p => p.theme.space.xl};
+  display: flex;
+  flex-direction: column;
+`;
+
+// Sticky + vertically centered so the nav arrows sit at the viewport's
+// vertical center and stay reachable as the user scrolls tall images.
+const NavGutter = styled('div')`
+  position: sticky;
+  top: 50%;
+  transform: translateY(-50%);
+  align-self: flex-start;
+  display: flex;
+  flex-direction: column;
+  gap: ${p => p.theme.space.sm};
+  flex-shrink: 0;
+`;
+
+const SingleViewGroup = styled(Stack)`
+  background: ${p => p.theme.tokens.background.primary};
+  border: 1px solid ${p => p.theme.tokens.border.primary};
+  border-radius: ${p => p.theme.radius.md};
+  padding: ${p => p.theme.space.lg};
+  gap: ${p => p.theme.space.md};
+  flex: 1 1 0;
+  min-height: 0;
+`;
+
+const SingleViewCard = styled(Card)`
+  flex: 1 1 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+`;
+
+const SingleViewBody = styled('div')`
+  flex: 1 1 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+`;
 
 const ColorPickerWrapper = styled('div')`
   position: relative;
@@ -480,8 +560,17 @@ const ColorTrigger = styled('button')<{color: string}>`
   border-radius: 50%;
   cursor: pointer;
   border: 2px solid ${p => p.theme.tokens.border.primary};
-  background-color: ${p => p.color};
+  background-color: ${p => (p.color === TRANSPARENT_COLOR ? 'transparent' : p.color)};
   padding: 0;
+  ${p =>
+    p.color === TRANSPARENT_COLOR &&
+    `background-image: linear-gradient(
+      to top right,
+      transparent calc(50% - 2px),
+      ${p.theme.tokens.content.danger} calc(50% - 1px),
+      ${p.theme.tokens.content.danger} calc(50% + 1px),
+      transparent calc(50% + 2px)
+    );`}
 
   &:hover {
     border-color: ${p => p.theme.tokens.border.accent};
@@ -495,8 +584,17 @@ const ColorSwatch = styled('button')<{color: string; selected: boolean}>`
   cursor: pointer;
   border: 2px solid
     ${p => (p.selected ? p.theme.tokens.border.accent : p.theme.tokens.border.primary)};
-  background-color: ${p => p.color};
+  background-color: ${p => (p.color === TRANSPARENT_COLOR ? 'transparent' : p.color)};
   padding: 0;
   outline: ${p => (p.selected ? `2px solid ${p.theme.tokens.focus.default}` : 'none')};
   outline-offset: 1px;
+  ${p =>
+    p.color === TRANSPARENT_COLOR &&
+    `background-image: linear-gradient(
+      to top right,
+      transparent calc(50% - 1.5px),
+      ${p.theme.tokens.content.danger} calc(50% - 0.5px),
+      ${p.theme.tokens.content.danger} calc(50% + 0.5px),
+      transparent calc(50% + 1.5px)
+    );`}
 `;

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -536,7 +536,7 @@ export default function SnapshotsPage() {
           listItems={listItems}
           isSoloView={isSoloView}
           onToggleSoloView={handleToggleView}
-          comparisonType={data?.comparison_type}
+          comparisonType={comparisonType}
           headBranch={data?.vcs_info?.head_ref}
           selectedSnapshotKey={selectedSnapshotKey}
           onSelectSnapshot={setSelectedSnapshotKey}

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -1,7 +1,15 @@
-import {useCallback, useDeferredValue, useEffect, useMemo, useRef, useState} from 'react';
+import {
+  Fragment,
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
-import {parseAsArrayOf, parseAsStringLiteral, useQueryState} from 'nuqs';
+import {parseAsArrayOf, parseAsString, parseAsStringLiteral, useQueryState} from 'nuqs';
 
 import {Flex, Stack} from '@sentry/scraps/layout';
 
@@ -22,11 +30,7 @@ import {TopBar} from 'sentry/views/navigation/topBar';
 import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {BuildError} from 'sentry/views/preprod/components/buildError';
 import {BuildProcessing} from 'sentry/views/preprod/components/buildProcessing';
-import {
-  ComparisonState,
-  DiffStatus,
-  getImageGroup,
-} from 'sentry/views/preprod/types/snapshotTypes';
+import {ComparisonState, DiffStatus} from 'sentry/views/preprod/types/snapshotTypes';
 import type {
   SidebarItem,
   SnapshotDetailsApiResponse,
@@ -39,6 +43,67 @@ import {SnapshotHeaderContent} from './header/snapshotHeaderContent';
 import type {DiffMode} from './main/imageDisplay/diffImageDisplay';
 import {SnapshotMainContent, type ViewMode} from './main/snapshotMainContent';
 import {DIFF_TYPE_ORDER, SnapshotSidebarContent} from './sidebar/snapshotSidebarContent';
+
+function imageGroupKey(img: SnapshotImage): string {
+  return img.group ?? img.display_name ?? img.image_file_name;
+}
+
+function groupByKey<T>(items: T[], keyOf: (item: T) => string): Map<string, T[]> {
+  const groups = new Map<string, T[]>();
+  for (const item of items) {
+    const key = keyOf(item);
+    const existing = groups.get(key);
+    if (existing) {
+      existing.push(item);
+    } else {
+      groups.set(key, [item]);
+    }
+  }
+  return groups;
+}
+
+function itemVariantCount(item: SidebarItem): number {
+  return item.type === 'changed' || item.type === 'renamed'
+    ? item.pairs.length
+    : item.images.length;
+}
+
+function snapshotKeyAt(item: SidebarItem, variantIdx: number): string | null {
+  if (item.type === 'changed' || item.type === 'renamed') {
+    return item.pairs[variantIdx]?.head_image.image_file_name ?? null;
+  }
+  return item.images[variantIdx]?.image_file_name ?? null;
+}
+
+function findSnapshotPosition(
+  items: SidebarItem[],
+  snapshotKey: string
+): {itemIdx: number; variantIdx: number} | null {
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i]!;
+    const variantIdx =
+      item.type === 'changed' || item.type === 'renamed'
+        ? item.pairs.findIndex(p => p.head_image.image_file_name === snapshotKey)
+        : item.images.findIndex(img => img.image_file_name === snapshotKey);
+    if (variantIdx !== -1) {
+      return {itemIdx: i, variantIdx};
+    }
+  }
+  return null;
+}
+
+function itemMaxDiff(item: SidebarItem): number {
+  if (item.type === 'changed') {
+    let max = 0;
+    for (const p of item.pairs) {
+      if (p.diff !== null && p.diff > max) {
+        max = p.diff;
+      }
+    }
+    return max;
+  }
+  return 0;
+}
 
 export default function SnapshotsPage() {
   const organization = useOrganization();
@@ -75,11 +140,32 @@ export default function SnapshotsPage() {
   );
 
   const [searchQuery, setSearchQuery] = useState('');
-  const [selectedItemKey, setSelectedItemKey] = useState<string | null>(null);
+  const [selectedGroup, setSelectedGroup] = useQueryState('selectedGroup', parseAsString);
   const [variantIndex, setVariantIndex] = useState(0);
+  const palette = theme.chart.getColorPalette(10);
+  const [overlayColor, setOverlayColor] = useLocalStorageState<string>(
+    'snapshot-overlay-color',
+    palette.at(-5) ?? palette[0]
+  );
+  const [diffMode, setDiffMode] = useLocalStorageState<DiffMode>(
+    'snapshot-diff-mode',
+    'split'
+  );
+  const [viewMode, setViewMode] = useLocalStorageState<ViewMode>(
+    'snapshot-view-mode',
+    'list'
+  );
   const [activeStatusList, setActiveStatusList] = useQueryState(
     'selectedTypes',
     parseAsArrayOf(parseAsStringLiteral(Object.values(DiffStatus))).withDefault([])
+  );
+  const [selectedSnapshotKey, setSelectedSnapshotKey] = useQueryState(
+    'selectedSnapshot',
+    parseAsString
+  );
+  const [sortBy, setSortBy] = useQueryState(
+    'sortBy',
+    parseAsStringLiteral(['diff', 'alpha'] as const).withDefault('diff')
   );
   const activeStatuses = useMemo(() => new Set(activeStatusList), [activeStatusList]);
 
@@ -90,16 +176,6 @@ export default function SnapshotsPage() {
       );
     },
     [setActiveStatusList]
-  );
-  const palette = theme.chart.getColorPalette(10);
-  const [overlayColor, setOverlayColor] = useLocalStorageState<string>(
-    'snapshot-overlay-color',
-    palette.at(-5) ?? palette[0]
-  );
-  const [diffMode, setDiffMode] = useState<DiffMode>('split');
-  const [viewMode, setViewMode] = useLocalStorageState<ViewMode>(
-    'snapshot-view-mode',
-    'list'
   );
 
   const {
@@ -140,62 +216,33 @@ export default function SnapshotsPage() {
     if (comparisonType === 'diff') {
       const items: SidebarItem[] = [];
 
-      const groupDiffPairs = (pairs: SnapshotDiffPair[], type: 'changed' | 'renamed') => {
-        const groups = new Map<string, SnapshotDiffPair[]>();
-        for (const pair of pairs) {
-          const group = getImageGroup(pair.head_image);
-          const existing = groups.get(group);
-          if (existing) {
-            existing.push(pair);
-          } else {
-            groups.set(group, [pair]);
-          }
-        }
-        for (const [groupKey, groupedPairs] of groups) {
-          const label =
-            groupedPairs[0]!.head_image.group ??
-            groupedPairs[0]!.head_image.display_name ??
-            groupedPairs[0]!.head_image.image_file_name;
+      const pushDiffPairs = (pairs: SnapshotDiffPair[], type: 'changed' | 'renamed') => {
+        for (const [groupKey, groupedPairs] of groupByKey(pairs, p =>
+          imageGroupKey(p.head_image)
+        )) {
           items.push({
             type,
             key: `${type}:${groupKey}`,
-            name: label,
+            name: groupKey,
             pairs: groupedPairs,
           });
         }
       };
 
-      const groupImages = (
+      const pushImages = (
         imgs: SnapshotImage[],
         type: 'added' | 'removed' | 'unchanged'
       ) => {
-        const groups = new Map<string, SnapshotImage[]>();
-        for (const img of imgs) {
-          const group = getImageGroup(img);
-          const existing = groups.get(group);
-          if (existing) {
-            existing.push(img);
-          } else {
-            groups.set(group, [img]);
-          }
-        }
-        for (const [groupKey, images] of groups) {
-          const label =
-            images[0]!.group ?? images[0]!.display_name ?? images[0]!.image_file_name;
-          items.push({
-            type,
-            key: `${type}:${groupKey}`,
-            name: label,
-            images,
-          });
+        for (const [groupKey, images] of groupByKey(imgs, imageGroupKey)) {
+          items.push({type, key: `${type}:${groupKey}`, name: groupKey, images});
         }
       };
 
-      groupDiffPairs(data.changed, 'changed');
-      groupDiffPairs(data.renamed ?? [], 'renamed');
-      groupImages(data.added, 'added');
-      groupImages(data.removed, 'removed');
-      groupImages(data.unchanged, 'unchanged');
+      pushDiffPairs(data.changed, 'changed');
+      pushDiffPairs(data.renamed ?? [], 'renamed');
+      pushImages(data.added, 'added');
+      pushImages(data.removed, 'removed');
+      pushImages(data.unchanged, 'unchanged');
 
       items.sort(
         (a, b) => (DIFF_TYPE_ORDER[a.type] ?? 99) - (DIFF_TYPE_ORDER[b.type] ?? 99)
@@ -204,51 +251,77 @@ export default function SnapshotsPage() {
       return items;
     }
 
-    const groups = new Map<string, SnapshotImage[]>();
-    for (const image of data.images) {
-      const group = getImageGroup(image);
-      const existing = groups.get(group);
-      if (existing) {
-        existing.push(image);
-      } else {
-        groups.set(group, [image]);
+    return [...groupByKey(data.images, imageGroupKey).entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([groupKey, images]) => ({
+        type: 'solo' as const,
+        key: `solo:${groupKey}`,
+        name: groupKey,
+        images,
+      }));
+  }, [data, comparisonType]);
+
+  const memberHaystacks = useMemo(
+    () => sidebarItems.map(buildMemberHaystacks),
+    [sidebarItems]
+  );
+
+  const deferredSearchQuery = useDeferredValue(searchQuery);
+  const deferredActiveStatuses = useDeferredValue(activeStatuses);
+
+  const filteredItems = useMemo(() => {
+    const trimmedQuery = deferredSearchQuery.trim().toLowerCase();
+    const hasStatusFilter = deferredActiveStatuses.size > 0;
+    const base: SidebarItem[] = [];
+    for (let i = 0; i < sidebarItems.length; i++) {
+      const item = sidebarItems[i]!;
+      if (hasStatusFilter && !deferredActiveStatuses.has(item.type as DiffStatus)) {
+        continue;
+      }
+      if (!trimmedQuery) {
+        base.push(item);
+        continue;
+      }
+      const narrowed = narrowItemBySearch(item, memberHaystacks[i]!, trimmedQuery);
+      if (narrowed) {
+        base.push(narrowed);
       }
     }
 
-    return [...groups.entries()]
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([groupKey, images]) => {
-        const label =
-          images[0]!.group ?? images[0]!.display_name ?? images[0]!.image_file_name;
-        return {
-          type: 'solo' as const,
-          key: `solo:${groupKey}`,
-          name: label,
-          images,
-        };
-      });
-  }, [data, comparisonType]);
-
-  const filteredItems = useMemo(() => {
-    const query = searchQuery.toLowerCase();
-    const hasStatusFilter = activeStatuses.size > 0;
-    return sidebarItems.filter(item => {
-      if (hasStatusFilter && !activeStatuses.has(item.type as DiffStatus)) {
-        return false;
+    if (sortBy === 'alpha') {
+      return base.sort((a, b) => a.name.localeCompare(b.name));
+    }
+    return base.sort((a, b) => {
+      const diffA = itemMaxDiff(a);
+      const diffB = itemMaxDiff(b);
+      if (diffA !== diffB) {
+        return diffB - diffA;
       }
-      if (query && !item.name.toLowerCase().includes(query)) {
-        return false;
-      }
-      return true;
+      return (DIFF_TYPE_ORDER[a.type] ?? 99) - (DIFF_TYPE_ORDER[b.type] ?? 99);
     });
-  }, [sidebarItems, searchQuery, activeStatuses]);
+  }, [
+    sidebarItems,
+    memberHaystacks,
+    deferredSearchQuery,
+    deferredActiveStatuses,
+    sortBy,
+  ]);
 
-  const isAllSelected = selectedItemKey === null;
+  const isAllSelected = selectedGroup === null;
+  // If the user has a selectedGroup but filters hide it, return null rather
+  // than silently falling back to filteredItems[0] — that would display an
+  // item the user never picked while their URL param still points elsewhere.
+  const currentItem = selectedGroup
+    ? (filteredItems.find(i => i.key === selectedGroup) ?? null)
+    : (filteredItems[0] ?? null);
+  const currentItemKey = currentItem?.key ?? null;
 
-  const handleSelectAll = useCallback(() => {
-    setSelectedItemKey(null);
-    setVariantIndex(0);
-  }, []);
+  const listItems = useMemo(() => {
+    if (isAllSelected) {
+      return filteredItems;
+    }
+    return currentItem ? [currentItem] : [];
+  }, [isAllSelected, filteredItems, currentItem]);
 
   const statusCounts = useMemo<Record<DiffStatus, number> | null>(() => {
     if (comparisonType !== 'diff') {
@@ -269,83 +342,127 @@ export default function SnapshotsPage() {
     return counts;
   }, [sidebarItems, comparisonType]);
 
-  const currentItem =
-    (selectedItemKey && filteredItems.find(i => i.key === selectedItemKey)) ||
-    filteredItems[0] ||
-    null;
-  const currentItemKey = currentItem?.key ?? null;
-
-  // Clamp variantIndex to valid range when the selected item changes implicitly
-  // (e.g. search filtering selects a new item with fewer variants)
-  const variantCount = currentItem
-    ? currentItem.type === 'changed' || currentItem.type === 'renamed'
-      ? currentItem.pairs.length
-      : currentItem.images.length
-    : 0;
+  // Clamp variantIndex when the selected item changes implicitly (e.g. search
+  // filtering selects a new item with fewer variants).
+  const variantCount = currentItem ? itemVariantCount(currentItem) : 0;
   const safeVariantIndex =
     variantCount > 0 ? Math.min(variantIndex, variantCount - 1) : 0;
 
   const handleSelectItem = (name: string) => {
-    setSelectedItemKey(name);
+    setSelectedGroup(name);
     setVariantIndex(0);
   };
 
-  // Ref so the keydown handler reads current state without re-registering
-  const stateRef = useRef({
-    filteredItems,
-    selectedItemKey,
-    currentItemKey,
-    safeVariantIndex,
-    variantCount,
-  });
-  stateRef.current = {
-    filteredItems,
-    selectedItemKey,
-    currentItemKey,
-    safeVariantIndex,
-    variantCount,
+  const handleSelectAll = () => {
+    setSelectedGroup(null);
+    setVariantIndex(0);
   };
+
+  // Scoped to listItems (not sidebarItems) so up/down nav only walks the
+  // snapshots currently visible to the user. Falls back to currentItem +
+  // variantIndex when selectedSnapshotKey can't be resolved.
+  const singleViewPosition = useMemo(() => {
+    if (selectedSnapshotKey) {
+      const pos = findSnapshotPosition(listItems, selectedSnapshotKey);
+      if (pos) {
+        return pos;
+      }
+    }
+    if (!currentItem) {
+      return null;
+    }
+    const itemIdx = listItems.findIndex(i => i.key === currentItem.key);
+    if (itemIdx === -1) {
+      return null;
+    }
+    return {itemIdx, variantIdx: safeVariantIndex};
+  }, [selectedSnapshotKey, listItems, currentItem, safeVariantIndex]);
+
+  const navigateSingleView = useCallback(
+    (direction: 'prev' | 'next') => {
+      if (!singleViewPosition) {
+        return;
+      }
+      const {itemIdx: currentItemIdx, variantIdx: currentVariantIdx} = singleViewPosition;
+      let nextItemIdx = currentItemIdx;
+      let nextVariantIdx = currentVariantIdx;
+      if (direction === 'next') {
+        const variantCountHere = itemVariantCount(listItems[currentItemIdx]!);
+        if (currentVariantIdx + 1 < variantCountHere) {
+          nextVariantIdx = currentVariantIdx + 1;
+        } else if (currentItemIdx + 1 < listItems.length) {
+          nextItemIdx = currentItemIdx + 1;
+          nextVariantIdx = 0;
+        }
+      } else if (currentVariantIdx > 0) {
+        nextVariantIdx = currentVariantIdx - 1;
+      } else if (currentItemIdx > 0) {
+        nextItemIdx = currentItemIdx - 1;
+        nextVariantIdx = itemVariantCount(listItems[nextItemIdx]!) - 1;
+      }
+      if (nextItemIdx === currentItemIdx && nextVariantIdx === currentVariantIdx) {
+        return;
+      }
+      const nextItem = listItems[nextItemIdx]!;
+      const nextSnapshotKey = snapshotKeyAt(nextItem, nextVariantIdx);
+      if (nextSnapshotKey) {
+        setSelectedSnapshotKey(nextSnapshotKey);
+      }
+    },
+    [listItems, singleViewPosition, setSelectedSnapshotKey]
+  );
+
+  const singleViewNav = useMemo(() => {
+    if (!singleViewPosition) {
+      return {canPrev: false, canNext: false};
+    }
+    const {itemIdx, variantIdx} = singleViewPosition;
+    const item = listItems[itemIdx];
+    if (!item) {
+      return {canPrev: false, canNext: false};
+    }
+    const total = itemVariantCount(item);
+    return {
+      canPrev: variantIdx > 0 || itemIdx > 0,
+      canNext: variantIdx + 1 < total || itemIdx + 1 < listItems.length,
+    };
+  }, [listItems, singleViewPosition]);
+
+  // Ref so the keydown handler reads latest state without re-registering.
+  const navRef = useRef({navigateSingleView, setViewMode, viewMode});
+  navRef.current = {navigateSingleView, setViewMode, viewMode};
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
-      if (!['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
+      if (
+        e.key !== 'ArrowUp' &&
+        e.key !== 'ArrowDown' &&
+        e.key !== 'ArrowLeft' &&
+        e.key !== 'ArrowRight'
+      ) {
         return;
       }
       const tag = (e.target as HTMLElement)?.tagName;
       if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') {
         return;
       }
-      e.preventDefault();
 
-      const state = stateRef.current;
-
+      // Left/Right flip between single and list view.
       if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
-        if (state.variantCount <= 1) {
-          return;
-        }
-        const next =
-          e.key === 'ArrowRight'
-            ? Math.min(state.safeVariantIndex + 1, state.variantCount - 1)
-            : Math.max(state.safeVariantIndex - 1, 0);
-        if (next !== state.safeVariantIndex) {
-          setVariantIndex(next);
+        const nextMode = e.key === 'ArrowLeft' ? 'single' : 'list';
+        if (nextMode !== navRef.current.viewMode) {
+          e.preventDefault();
+          navRef.current.setViewMode(nextMode);
         }
         return;
       }
 
-      const currentIndex =
-        state.selectedItemKey === null
-          ? -1
-          : state.filteredItems.findIndex(i => i.key === state.currentItemKey);
-      const nextIndex =
-        e.key === 'ArrowDown'
-          ? Math.min(currentIndex + 1, state.filteredItems.length - 1)
-          : Math.max(currentIndex - 1, -1);
-
-      if (nextIndex !== currentIndex) {
-        setSelectedItemKey(state.filteredItems[nextIndex]?.key ?? null);
-        setVariantIndex(0);
+      // Up/Down only in single view — list view has its own handler.
+      if (navRef.current.viewMode !== 'single') {
+        return;
       }
+      e.preventDefault();
+      navRef.current.navigateSingleView(e.key === 'ArrowDown' ? 'next' : 'prev');
     }
 
     document.addEventListener('keydown', handleKeyDown);
@@ -353,8 +470,17 @@ export default function SnapshotsPage() {
   }, []);
 
   // Defer the item passed to main content so the sidebar stays responsive
-  // while the expensive image rendering catches up
+  // while the expensive image rendering catches up.
   const deferredItem = useDeferredValue(currentItem);
+
+  const singleViewItem =
+    viewMode === 'single' && singleViewPosition
+      ? (listItems[singleViewPosition.itemIdx] ?? deferredItem)
+      : deferredItem;
+  const singleViewVariantIndex =
+    viewMode === 'single' && singleViewPosition
+      ? singleViewPosition.variantIdx
+      : safeVariantIndex;
 
   const isComparisonProcessing =
     !!comparisonRunInfo?.state &&
@@ -375,14 +501,7 @@ export default function SnapshotsPage() {
   );
 
   const snapshotContent = (
-    <Flex
-      direction="row"
-      flex="1"
-      minHeight="0"
-      width="100%"
-      overflow="hidden"
-      style={{maxHeight: 'calc(100vh - 205px)'}}
-    >
+    <Flex direction="row" flex="1" minHeight="0" width="100%" overflow="hidden">
       <Flex flexShrink={0} overflow="auto" style={{width: sidebarWidth}}>
         <SnapshotSidebarContent
           items={filteredItems}
@@ -407,18 +526,28 @@ export default function SnapshotsPage() {
       </DragHandle>
       <Flex flex="1" minWidth={0} overflow="hidden">
         <SnapshotMainContent
-          selectedItem={deferredItem}
-          variantIndex={safeVariantIndex}
-          onVariantChange={setVariantIndex}
+          selectedItem={singleViewItem}
+          variantIndex={singleViewVariantIndex}
           imageBaseUrl={imageBaseUrl}
           diffImageBaseUrl={diffImageBaseUrl}
-          items={filteredItems}
           overlayColor={overlayColor}
           onOverlayColorChange={setOverlayColor}
           diffMode={diffMode}
           onDiffModeChange={setDiffMode}
           viewMode={viewMode}
           onViewModeChange={setViewMode}
+          listItems={listItems}
+          isSoloView={isSoloView}
+          onToggleSoloView={handleToggleView}
+          comparisonType={data?.comparison_type}
+          headBranch={data?.vcs_info?.head_ref}
+          selectedSnapshotKey={selectedSnapshotKey}
+          onSelectSnapshot={setSelectedSnapshotKey}
+          sortBy={sortBy}
+          onSortByChange={setSortBy}
+          onNavigateSingleView={navigateSingleView}
+          canNavigatePrev={singleViewNav.canPrev}
+          canNavigateNext={singleViewNav.canNext}
         />
       </Flex>
     </Flex>
@@ -454,13 +583,9 @@ export default function SnapshotsPage() {
   return (
     <SentryDocumentTitle title={t('Snapshot')}>
       <Stack flex={1}>
-        <Layout.Header paddingTop="lg" paddingBottom="md">
-          <SnapshotHeaderContent
-            data={data}
-            isSoloView={isSoloView}
-            onToggleView={handleToggleView}
-          />
-          {hasPageFrameFeature ? (
+        {hasPageFrameFeature ? (
+          <Fragment>
+            <SnapshotHeaderContent data={data} isSoloView={isSoloView} onToggleView={handleToggleView} />
             <TopBar.Slot name="actions">
               <SnapshotHeaderActions
                 data={data}
@@ -468,7 +593,10 @@ export default function SnapshotsPage() {
                 apiUrl={snapshotApiUrl}
               />
             </TopBar.Slot>
-          ) : (
+          </Fragment>
+        ) : (
+          <Layout.Header paddingTop="0" paddingBottom="0" unified>
+            <SnapshotHeaderContent data={data} isSoloView={isSoloView} onToggleView={handleToggleView} />
             <Layout.HeaderActions style={{alignSelf: 'center'}}>
               <SnapshotHeaderActions
                 data={data}
@@ -476,8 +604,8 @@ export default function SnapshotsPage() {
                 apiUrl={snapshotApiUrl}
               />
             </Layout.HeaderActions>
-          )}
-        </Layout.Header>
+          </Layout.Header>
+        )}
 
         {isComparisonProcessing ? processingContent : snapshotContent}
       </Stack>
@@ -503,3 +631,59 @@ const DragHandle = styled('div')`
     background: ${p => p.theme.tokens.interactive.transparent.neutral.background.active};
   }
 `;
+
+function imageHaystack(image: SnapshotImage): string {
+  const parts: string[] = [];
+  if (image.display_name) parts.push(image.display_name);
+  if (image.image_file_name) parts.push(image.image_file_name);
+  if (image.group) parts.push(image.group);
+  return parts.join('\n').toLowerCase();
+}
+
+function buildMemberHaystacks(item: SidebarItem): string[] {
+  const groupNameLower = item.name ? item.name.toLowerCase() : '';
+  if (item.type === 'changed' || item.type === 'renamed') {
+    return item.pairs.map(pair => {
+      const head = imageHaystack(pair.head_image);
+      const base = imageHaystack(pair.base_image);
+      return groupNameLower ? `${groupNameLower}\n${head}\n${base}` : `${head}\n${base}`;
+    });
+  }
+  return item.images.map(image => {
+    const h = imageHaystack(image);
+    return groupNameLower ? `${groupNameLower}\n${h}` : h;
+  });
+}
+
+function narrowItemBySearch(
+  item: SidebarItem,
+  memberHaystacksForItem: string[],
+  query: string
+): SidebarItem | null {
+  if (item.type === 'changed' || item.type === 'renamed') {
+    const kept: SnapshotDiffPair[] = [];
+    let allMatched = true;
+    for (let i = 0; i < item.pairs.length; i++) {
+      if (memberHaystacksForItem[i]!.includes(query)) {
+        kept.push(item.pairs[i]!);
+      } else {
+        allMatched = false;
+      }
+    }
+    if (kept.length === 0) return null;
+    if (allMatched) return item;
+    return {...item, pairs: kept};
+  }
+  const kept: SnapshotImage[] = [];
+  let allMatched = true;
+  for (let i = 0; i < item.images.length; i++) {
+    if (memberHaystacksForItem[i]!.includes(query)) {
+      kept.push(item.images[i]!);
+    } else {
+      allMatched = false;
+    }
+  }
+  if (kept.length === 0) return null;
+  if (allMatched) return item;
+  return {...item, images: kept};
+}

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -1,19 +1,10 @@
-import {
-  Fragment,
-  useCallback,
-  useDeferredValue,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import {useCallback, useDeferredValue, useEffect, useMemo, useRef, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {parseAsArrayOf, parseAsString, parseAsStringLiteral, useQueryState} from 'nuqs';
 
 import {Flex, Stack} from '@sentry/scraps/layout';
 
-import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {IconGrabbable} from 'sentry/icons';
@@ -27,7 +18,6 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useResizableDrawer} from 'sentry/utils/useResizableDrawer';
 import {TopBar} from 'sentry/views/navigation/topBar';
-import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {BuildError} from 'sentry/views/preprod/components/buildError';
 import {BuildProcessing} from 'sentry/views/preprod/components/buildProcessing';
 import {ComparisonState, DiffStatus} from 'sentry/views/preprod/types/snapshotTypes';
@@ -45,7 +35,7 @@ import {SnapshotMainContent, type ViewMode} from './main/snapshotMainContent';
 import {DIFF_TYPE_ORDER, SnapshotSidebarContent} from './sidebar/snapshotSidebarContent';
 
 function imageGroupKey(img: SnapshotImage): string {
-  return img.group ?? img.display_name ?? img.image_file_name;
+  return img.group ?? img.image_file_name;
 }
 
 function groupByKey<T>(items: T[], keyOf: (item: T) => string): Map<string, T[]> {
@@ -108,7 +98,6 @@ function itemMaxDiff(item: SidebarItem): number {
 export default function SnapshotsPage() {
   const organization = useOrganization();
   const theme = useTheme();
-  const hasPageFrameFeature = useHasPageFrameFeature();
   const {snapshotId} = useParams<{
     snapshotId: string;
   }>();
@@ -261,8 +250,9 @@ export default function SnapshotsPage() {
       }));
   }, [data, comparisonType]);
 
-  const memberHaystacks = useMemo(
-    () => sidebarItems.map(buildMemberHaystacks),
+  // Pre-computed lowercase text per image/pair for fast substring search filtering
+  const memberSearchKeys = useMemo(
+    () => sidebarItems.map(buildMemberSearchKeys),
     [sidebarItems]
   );
 
@@ -282,7 +272,7 @@ export default function SnapshotsPage() {
         base.push(item);
         continue;
       }
-      const narrowed = narrowItemBySearch(item, memberHaystacks[i]!, trimmedQuery);
+      const narrowed = narrowItemBySearch(item, memberSearchKeys[i]!, trimmedQuery);
       if (narrowed) {
         base.push(narrowed);
       }
@@ -301,7 +291,7 @@ export default function SnapshotsPage() {
     });
   }, [
     sidebarItems,
-    memberHaystacks,
+    memberSearchKeys,
     deferredSearchQuery,
     deferredActiveStatuses,
     sortBy,
@@ -590,37 +580,18 @@ export default function SnapshotsPage() {
   return (
     <SentryDocumentTitle title={t('Snapshot')}>
       <Stack flex={1}>
-        {hasPageFrameFeature ? (
-          <Fragment>
-            <SnapshotHeaderContent
-              data={data}
-              isSoloView={isSoloView}
-              onToggleView={handleToggleView}
-            />
-            <TopBar.Slot name="actions">
-              <SnapshotHeaderActions
-                data={data}
-                organizationSlug={organization.slug}
-                apiUrl={snapshotApiUrl}
-              />
-            </TopBar.Slot>
-          </Fragment>
-        ) : (
-          <Layout.Header paddingTop="0" paddingBottom="0" unified>
-            <SnapshotHeaderContent
-              data={data}
-              isSoloView={isSoloView}
-              onToggleView={handleToggleView}
-            />
-            <Layout.HeaderActions style={{alignSelf: 'center'}}>
-              <SnapshotHeaderActions
-                data={data}
-                organizationSlug={organization.slug}
-                apiUrl={snapshotApiUrl}
-              />
-            </Layout.HeaderActions>
-          </Layout.Header>
-        )}
+        <SnapshotHeaderContent
+          data={data}
+          isSoloView={isSoloView}
+          onToggleView={handleToggleView}
+        />
+        <TopBar.Slot name="actions">
+          <SnapshotHeaderActions
+            data={data}
+            organizationSlug={organization.slug}
+            apiUrl={snapshotApiUrl}
+          />
+        </TopBar.Slot>
 
         {isComparisonProcessing ? processingContent : snapshotContent}
       </Stack>
@@ -647,7 +618,7 @@ const DragHandle = styled('div')`
   }
 `;
 
-function imageHaystack(image: SnapshotImage): string {
+function imageSearchKey(image: SnapshotImage): string {
   const parts: string[] = [];
   if (image.display_name) parts.push(image.display_name);
   if (image.image_file_name) parts.push(image.image_file_name);
@@ -655,31 +626,32 @@ function imageHaystack(image: SnapshotImage): string {
   return parts.join('\n').toLowerCase();
 }
 
-function buildMemberHaystacks(item: SidebarItem): string[] {
+// Builds one lowercase search key per image/pair, joining all searchable metadata
+function buildMemberSearchKeys(item: SidebarItem): string[] {
   const groupNameLower = item.name ? item.name.toLowerCase() : '';
   if (item.type === 'changed' || item.type === 'renamed') {
     return item.pairs.map(pair => {
-      const head = imageHaystack(pair.head_image);
-      const base = imageHaystack(pair.base_image);
+      const head = imageSearchKey(pair.head_image);
+      const base = imageSearchKey(pair.base_image);
       return groupNameLower ? `${groupNameLower}\n${head}\n${base}` : `${head}\n${base}`;
     });
   }
   return item.images.map(image => {
-    const h = imageHaystack(image);
+    const h = imageSearchKey(image);
     return groupNameLower ? `${groupNameLower}\n${h}` : h;
   });
 }
 
 function narrowItemBySearch(
   item: SidebarItem,
-  memberHaystacksForItem: string[],
+  memberSearchKeysForItem: string[],
   query: string
 ): SidebarItem | null {
   if (item.type === 'changed' || item.type === 'renamed') {
     const kept: SnapshotDiffPair[] = [];
     let allMatched = true;
     for (let i = 0; i < item.pairs.length; i++) {
-      if (memberHaystacksForItem[i]!.includes(query)) {
+      if (memberSearchKeysForItem[i]!.includes(query)) {
         kept.push(item.pairs[i]!);
       } else {
         allMatched = false;
@@ -692,7 +664,7 @@ function narrowItemBySearch(
   const kept: SnapshotImage[] = [];
   let allMatched = true;
   for (let i = 0; i < item.images.length; i++) {
-    if (memberHaystacksForItem[i]!.includes(query)) {
+    if (memberSearchKeysForItem[i]!.includes(query)) {
       kept.push(item.images[i]!);
     } else {
       allMatched = false;

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -507,7 +507,7 @@ export default function SnapshotsPage() {
       minHeight="0"
       width="100%"
       overflow="hidden"
-      style={{maxHeight: 'calc(100vh - 205px)'}}
+      style={{maxHeight: `calc(100vh - ${hasPageFrameFeature ? 110 : 205}px)`}}
     >
       <Flex flexShrink={0} overflow="auto" style={{width: sidebarWidth}}>
         <SnapshotSidebarContent

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -585,7 +585,11 @@ export default function SnapshotsPage() {
       <Stack flex={1}>
         {hasPageFrameFeature ? (
           <Fragment>
-            <SnapshotHeaderContent data={data} isSoloView={isSoloView} onToggleView={handleToggleView} />
+            <SnapshotHeaderContent
+              data={data}
+              isSoloView={isSoloView}
+              onToggleView={handleToggleView}
+            />
             <TopBar.Slot name="actions">
               <SnapshotHeaderActions
                 data={data}
@@ -596,7 +600,11 @@ export default function SnapshotsPage() {
           </Fragment>
         ) : (
           <Layout.Header paddingTop="0" paddingBottom="0" unified>
-            <SnapshotHeaderContent data={data} isSoloView={isSoloView} onToggleView={handleToggleView} />
+            <SnapshotHeaderContent
+              data={data}
+              isSoloView={isSoloView}
+              onToggleView={handleToggleView}
+            />
             <Layout.HeaderActions style={{alignSelf: 'center'}}>
               <SnapshotHeaderActions
                 data={data}

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -501,7 +501,14 @@ export default function SnapshotsPage() {
   );
 
   const snapshotContent = (
-    <Flex direction="row" flex="1" minHeight="0" width="100%" overflow="hidden">
+    <Flex
+      direction="row"
+      flex="1"
+      minHeight="0"
+      width="100%"
+      overflow="hidden"
+      style={{maxHeight: 'calc(100vh - 205px)'}}
+    >
       <Flex flexShrink={0} overflow="auto" style={{width: sidebarWidth}}>
         <SnapshotSidebarContent
           items={filteredItems}

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -507,7 +507,7 @@ export default function SnapshotsPage() {
       minHeight="0"
       width="100%"
       overflow="hidden"
-      style={{maxHeight: `calc(100vh - ${hasPageFrameFeature ? 110 : 205}px)`}}
+      style={{maxHeight: 'calc(100vh - 205px)'}}
     >
       <Flex flexShrink={0} overflow="auto" style={{width: sidebarWidth}}>
         <SnapshotSidebarContent

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -200,11 +200,11 @@ export default function SnapshotsPage() {
 
   const isSoloView = comparisonType === 'solo';
   const handleToggleView = useCallback(() => {
-    const {view: _view, ...restQuery} = location.query;
+    const {view: _view, selectedGroup: _sg, ...restQuery} = location.query;
     if (isSoloView) {
       navigate({...location, query: restQuery}, {replace: true});
     } else {
-      navigate({...location, query: {...location.query, view: 'solo'}}, {replace: true});
+      navigate({...location, query: {...restQuery, view: 'solo'}}, {replace: true});
     }
   }, [location, navigate, isSoloView]);
 

--- a/static/app/views/preprod/types/snapshotTypes.ts
+++ b/static/app/views/preprod/types/snapshotTypes.ts
@@ -90,10 +90,6 @@ export function getImageName(image: SnapshotImage): string {
   return image.display_name ?? image.image_file_name;
 }
 
-export function getImageGroup(image: SnapshotImage): string {
-  return image.group ?? image.image_file_name;
-}
-
 interface SidebarItemBase {
   key: string;
   name: string;


### PR DESCRIPTION
Final slice of the snapshot viewer redesign. Lands the new toolbar layout and wires up the remaining controls. Together with the four prior PRs in this stack, fully supersedes #113958.

**New toolbar in \`snapshotMainContent.tsx\`**
Replaces the ad-hoc per-branch headers with a unified toolbar holding: view mode toggle, sort dropdown, prev/next snapshot navigation, diff-mode SegmentedControl (split / wipe / onion), and the color picker.

**State changes in \`snapshots.tsx\`**
- \`diffMode\` migrates to \`useLocalStorageState('snapshot-diff-mode')\`. Setter returns — wired to the new toolbar's mode toggle.
- \`selectedItemKey\` (useState) becomes \`selectedGroup\` (query param \`selectedGroup\`).
- New query state: \`selectedSnapshotKey\` (for list-view navigation), \`sortBy\` (\`'diff' | 'alpha'\`).

**DiffImageDisplay cleanup (absorbs #113957's remaining scope)**
Drops its own SegmentedControl and diff-percentage label. Both now live in the toolbar.

**New helpers in \`snapshots.tsx\`**
- \`imageGroupKey\`, \`groupByKey\`, \`itemVariantCount\`, \`snapshotKeyAt\` — layout utilities.
- \`findSnapshotPosition\` — locates a snapshot across items for prev/next.
- \`itemMaxDiff\` — comparator for the new diff-% sort.
- \`imageHaystack\`, \`buildMemberHaystacks\`, \`narrowItemBySearch\` — richer search that matches image file names and narrows visible members per item.

**List view plumbing**
\`listItems\` returns full \`filteredItems\` when the user hasn't selected a specific group, otherwise narrows to the selected item. Prev/next walks \`listItems\` by variant, calling \`setSelectedSnapshotKey\` + \`setVariantIndex\`.

5/5 in the series slicing up #113958. With this landed and the prior four merged, #113958 can be closed.