### PR TITLE
fix(aci): Deduplicate actions w/o the workflow_id

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -443,6 +443,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:workflow-engine-metric-alert-group-by-creation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable caching for workflow action filters
     manager.add("organizations:workflow-engine-action-filters-cache", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    # Enable deduplication of actions across workflows by action configuration
+    manager.add("organizations:workflow-engine-deduplicate-actions", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable ingestion through trusted relays only
     manager.add("organizations:ingest-through-trusted-relays-only", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Disable issue stream detector notifications for metric issues

--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -31,7 +31,7 @@ from sentry.workflow_engine.models import (
 )
 from sentry.workflow_engine.registry import action_handler_registry
 from sentry.workflow_engine.tasks.actions import build_trigger_action_task_params, trigger_action
-from sentry.workflow_engine.types import WorkflowEventData
+from sentry.workflow_engine.types import WorkflowEventData, WorkflowId
 from sentry.workflow_engine.utils import log_context, scopedstats
 
 logger = log_context.get_logger(__name__)
@@ -271,17 +271,20 @@ def fire_actions(
 
 def filter_recently_fired_workflow_actions(
     filtered_action_groups: set[DataConditionGroup], event_data: WorkflowEventData
-) -> BaseQuerySet[Action]:
+) -> tuple[BaseQuerySet[Action], set[WorkflowId]]:
     """
-    Returns actions associated with the provided DataConditionsGroups, excluding those that have been recently fired. Also updates associated WorkflowActionGroupStatus objects.
+    Returns a tuple of (actions, all_workflow_ids) where actions are deduplicated by
+    configuration and filtered by firing frequency, and all_workflow_ids includes every
+    workflow that should be recorded as fired (including those whose actions were
+    deduplicated away). Also updates associated WorkflowActionGroupStatus objects.
     """
 
     data_condition_group_actions = DataConditionGroupAction.objects.filter(
         condition_group__in=filtered_action_groups
     ).values_list("action_id", "condition_group__workflowdataconditiongroup__workflow_id")
 
-    action_to_workflows_ids: dict[int, set[int]] = defaultdict(set)
-    workflow_ids: set[int] = set()
+    action_to_workflows_ids: dict[int, set[WorkflowId]] = defaultdict(set)
+    workflow_ids: set[WorkflowId] = set()
 
     for action_id, workflow_id in data_condition_group_actions:
         # If we are mid-deletion, the workflow_id can be none.
@@ -314,6 +317,34 @@ def filter_recently_fired_workflow_actions(
         if not action_to_workflows_ids[action_id]:
             action_to_workflows_ids.pop(action_id)
 
+    # Deduplicate actions by dedup_key so functionally identical actions
+    # (same type, integration, config, data) only fire once, even if they
+    # appear in multiple workflows.
+    if features.has(
+        "organizations:workflow-engine-deduplicate-actions",
+        event_data.event.project.organization,
+    ):
+        actions_for_dedup = Action.objects.filter(id__in=list(action_to_workflows_ids.keys()))
+        dedup_key_to_entry: dict[str, tuple[int, set[int]]] = {}
+        for action in actions_for_dedup:
+            dedup_key = action.get_dedup_key()
+            if dedup_key in dedup_key_to_entry:
+                kept_action_id, kept_workflows = dedup_key_to_entry[dedup_key]
+                kept_workflows.update(action_to_workflows_ids[action.id])
+            else:
+                dedup_key_to_entry[dedup_key] = (
+                    action.id,
+                    set(action_to_workflows_ids[action.id]),
+                )
+
+        action_to_workflows_ids = {
+            action_id: wf_ids for action_id, wf_ids in dedup_key_to_entry.values()
+        }
+
+    all_workflow_ids: set[WorkflowId] = set()
+    for wf_ids in action_to_workflows_ids.values():
+        all_workflow_ids.update(wf_ids)
+
     actions_queryset = Action.objects.filter(id__in=list(action_to_workflows_ids.keys()))
 
     # annotate actions with workflow_id they are firing for (deduped)
@@ -324,8 +355,14 @@ def filter_recently_fired_workflow_actions(
         for action_id, workflow_ids in action_to_workflows_ids.items()
     ]
 
-    return actions_queryset.annotate(
-        workflow_id=Case(*workflow_id_cases, output_field=models.IntegerField()),
+    return (
+        actions_queryset.annotate(
+            workflow_id=Case(
+                *workflow_id_cases,
+                output_field=models.IntegerField(),
+            ),
+        ),
+        all_workflow_ids,
     )
 
 

--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -278,10 +278,10 @@ def filter_recently_fired_workflow_actions(
     filtered_action_groups: set[DataConditionGroup], event_data: WorkflowEventData
 ) -> FilteredActions:
     """
-    Returns a tuple of (actions, all_workflow_ids) where actions are deduplicated by
-    configuration and filtered by firing frequency, and all_workflow_ids includes every
-    workflow that should be recorded as fired (including those whose actions were
-    deduplicated away). Also updates associated WorkflowActionGroupStatus objects.
+    Returns a FilteredActions containing the actions to fire (deduplicated by
+    configuration and filtered by firing frequency) and all workflow IDs that
+    should be recorded as fired (including those whose actions were deduplicated
+    away). Also updates associated WorkflowActionGroupStatus objects.
     """
 
     data_condition_group_actions = DataConditionGroupAction.objects.filter(

--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -40,6 +40,11 @@ EnqueuedAction = tuple[DataConditionGroup, list[DataCondition]]
 DroppedStatuses = list[tuple[int, int]]  # (workflow_id, action_id)
 
 
+class FilteredActions(NamedTuple):
+    actions: BaseQuerySet[Action]
+    workflow_ids: set[WorkflowId]
+
+
 class StatusUpdateResult(NamedTuple):
     updated: int
     created: int
@@ -271,7 +276,7 @@ def fire_actions(
 
 def filter_recently_fired_workflow_actions(
     filtered_action_groups: set[DataConditionGroup], event_data: WorkflowEventData
-) -> tuple[BaseQuerySet[Action], set[WorkflowId]]:
+) -> FilteredActions:
     """
     Returns a tuple of (actions, all_workflow_ids) where actions are deduplicated by
     configuration and filtered by firing frequency, and all_workflow_ids includes every
@@ -325,11 +330,11 @@ def filter_recently_fired_workflow_actions(
         event_data.event.project.organization,
     ):
         actions_for_dedup = Action.objects.filter(id__in=list(action_to_workflows_ids.keys()))
-        dedup_key_to_entry: dict[str, tuple[int, set[int]]] = {}
+        dedup_key_to_entry: dict[str, tuple[int, set[WorkflowId]]] = {}
         for action in actions_for_dedup:
             dedup_key = action.get_dedup_key()
             if dedup_key in dedup_key_to_entry:
-                kept_action_id, kept_workflows = dedup_key_to_entry[dedup_key]
+                _, kept_workflows = dedup_key_to_entry[dedup_key]
                 kept_workflows.update(action_to_workflows_ids[action.id])
             else:
                 dedup_key_to_entry[dedup_key] = (
@@ -341,9 +346,9 @@ def filter_recently_fired_workflow_actions(
             action_id: wf_ids for action_id, wf_ids in dedup_key_to_entry.values()
         }
 
-    all_workflow_ids: set[WorkflowId] = set()
-    for wf_ids in action_to_workflows_ids.values():
-        all_workflow_ids.update(wf_ids)
+    all_workflow_ids: set[WorkflowId] = {
+        wf_id for wf_ids in action_to_workflows_ids.values() for wf_id in wf_ids
+    }
 
     actions_queryset = Action.objects.filter(id__in=list(action_to_workflows_ids.keys()))
 
@@ -355,14 +360,14 @@ def filter_recently_fired_workflow_actions(
         for action_id, workflow_ids in action_to_workflows_ids.items()
     ]
 
-    return (
-        actions_queryset.annotate(
+    return FilteredActions(
+        actions=actions_queryset.annotate(
             workflow_id=Case(
                 *workflow_id_cases,
                 output_field=models.IntegerField(),
             ),
         ),
-        all_workflow_ids,
+        workflow_ids=all_workflow_ids,
     )
 
 

--- a/src/sentry/workflow_engine/processors/action.py
+++ b/src/sentry/workflow_engine/processors/action.py
@@ -329,7 +329,7 @@ def filter_recently_fired_workflow_actions(
         "organizations:workflow-engine-deduplicate-actions",
         event_data.event.project.organization,
     ):
-        actions_for_dedup = Action.objects.filter(id__in=list(action_to_workflows_ids.keys()))
+        actions_for_dedup = Action.objects.filter(id__in=action_to_workflows_ids.keys())
         dedup_key_to_entry: dict[str, tuple[int, set[WorkflowId]]] = {}
         for action in actions_for_dedup:
             dedup_key = action.get_dedup_key()
@@ -350,14 +350,14 @@ def filter_recently_fired_workflow_actions(
         wf_id for wf_ids in action_to_workflows_ids.values() for wf_id in wf_ids
     }
 
-    actions_queryset = Action.objects.filter(id__in=list(action_to_workflows_ids.keys()))
+    actions_queryset = Action.objects.filter(id__in=action_to_workflows_ids.keys())
 
     # annotate actions with workflow_id they are firing for (deduped)
     workflow_id_cases = [
         When(
-            id=action_id, then=Value(min(list(workflow_ids)))
+            id=action_id, then=Value(min(wf_ids))
         )  # select 1 workflow to fire for, this is arbitrary but deterministic
-        for action_id, workflow_ids in action_to_workflows_ids.items()
+        for action_id, wf_ids in action_to_workflows_ids.items()
     ]
 
     return FilteredActions(

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -735,7 +735,7 @@ def fire_actions_for_groups(
                 workflow_event_data = WorkflowEventData(event=group_event, group=group)
 
                 dcgs_for_group = groups_to_fire.get(group.id, set())
-                filtered_actions = filter_recently_fired_workflow_actions(
+                filtered_actions, all_workflow_ids = filter_recently_fired_workflow_actions(
                     dcgs_for_group, workflow_event_data
                 )
                 # TODO: trigger service hooks from here
@@ -751,6 +751,7 @@ def fire_actions_for_groups(
                     workflow_event_data,
                     is_delayed=True,
                     start_timestamp=start_timestamp,
+                    workflow_ids=all_workflow_ids,
                 )
 
                 # Create mapping: workflow_id -> notification_uuid for propagation

--- a/src/sentry/workflow_engine/processors/delayed_workflow.py
+++ b/src/sentry/workflow_engine/processors/delayed_workflow.py
@@ -735,23 +735,23 @@ def fire_actions_for_groups(
                 workflow_event_data = WorkflowEventData(event=group_event, group=group)
 
                 dcgs_for_group = groups_to_fire.get(group.id, set())
-                filtered_actions, all_workflow_ids = filter_recently_fired_workflow_actions(
+                filtered = filter_recently_fired_workflow_actions(
                     dcgs_for_group, workflow_event_data
                 )
                 # TODO: trigger service hooks from here
 
                 metrics.incr(
                     "workflow_engine.delayed_workflow.triggered_actions",
-                    amount=len(filtered_actions),
+                    amount=len(filtered.actions),
                     tags={"event_type": group_event.group.type},
                 )
 
                 workflow_fire_histories = create_workflow_fire_histories(
-                    filtered_actions,
+                    filtered.actions,
                     workflow_event_data,
                     is_delayed=True,
                     start_timestamp=start_timestamp,
-                    workflow_ids=all_workflow_ids,
+                    workflow_ids=filtered.workflow_ids,
                 )
 
                 # Create mapping: workflow_id -> notification_uuid for propagation
@@ -773,15 +773,15 @@ def fire_actions_for_groups(
                         "workflow_ids": sorted(
                             {wfh.workflow_id for wfh in workflow_fire_histories}
                         ),
-                        "actions": [action.id for action in filtered_actions],
+                        "actions": [action.id for action in filtered.actions],
                         "event_data": workflow_event_data,
                         "event_id": event_id,
                     },
                 )
-                total_actions += len(filtered_actions)
+                total_actions += len(filtered.actions)
 
                 fire_actions(
-                    filtered_actions, workflow_event_data, workflow_uuid_map=workflow_uuid_map
+                    filtered.actions, workflow_event_data, workflow_uuid_map=workflow_uuid_map
                 )
 
     logger.debug(

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -569,7 +569,9 @@ def process_workflows(
 
     enqueue_workflows(batch_client, queue_items_by_workflow_id)
 
-    actions = filter_recently_fired_workflow_actions(actions_to_trigger, event_data)
+    actions, all_workflow_ids = filter_recently_fired_workflow_actions(
+        actions_to_trigger, event_data
+    )
 
     workflow_evaluation_data.action_groups = actions_to_trigger
     workflow_evaluation_data.triggered_actions = set(actions)
@@ -591,6 +593,7 @@ def process_workflows(
         event_data,
         is_delayed=False,
         start_timestamp=event_start_time,
+        workflow_ids=all_workflow_ids,
     )
 
     # Create mapping: workflow_id -> notification_uuid for propagation

--- a/src/sentry/workflow_engine/processors/workflow.py
+++ b/src/sentry/workflow_engine/processors/workflow.py
@@ -569,19 +569,17 @@ def process_workflows(
 
     enqueue_workflows(batch_client, queue_items_by_workflow_id)
 
-    actions, all_workflow_ids = filter_recently_fired_workflow_actions(
-        actions_to_trigger, event_data
-    )
+    filtered = filter_recently_fired_workflow_actions(actions_to_trigger, event_data)
 
     workflow_evaluation_data.action_groups = actions_to_trigger
-    workflow_evaluation_data.triggered_actions = set(actions)
+    workflow_evaluation_data.triggered_actions = set(filtered.actions)
     workflow_evaluation_data.delayed_conditions = queue_items_by_workflow_id
 
     sentry_sdk.set_tag(
         "workflow_engine.triggered_actions", len(workflow_evaluation_data.triggered_actions)
     )
 
-    if not actions:
+    if not filtered.actions:
         return WorkflowEvaluation(
             tainted=True,
             msg="No actions to evaluate; filtered or not triggered",
@@ -589,11 +587,11 @@ def process_workflows(
         )
 
     fire_histories = create_workflow_fire_histories(
-        actions,
+        filtered.actions,
         event_data,
         is_delayed=False,
         start_timestamp=event_start_time,
-        workflow_ids=all_workflow_ids,
+        workflow_ids=filtered.workflow_ids,
     )
 
     # Create mapping: workflow_id -> notification_uuid for propagation
@@ -603,6 +601,6 @@ def process_workflows(
             history.workflow_id: str(history.notification_uuid) for history in fire_histories
         }
 
-    fire_actions(actions, event_data, workflow_uuid_map=workflow_uuid_map)
+    fire_actions(filtered.actions, event_data, workflow_uuid_map=workflow_uuid_map)
 
     return WorkflowEvaluation(tainted=False, data=workflow_evaluation_data)

--- a/src/sentry/workflow_engine/processors/workflow_fire_history.py
+++ b/src/sentry/workflow_engine/processors/workflow_fire_history.py
@@ -31,19 +31,21 @@ def create_workflow_fire_histories(
     event_data: WorkflowEventData,
     is_delayed: bool = False,
     start_timestamp: datetime | None = None,
+    workflow_ids: set[int] | None = None,
 ) -> list[WorkflowFireHistory]:
     """
     Record that the workflows associated with these actions were fired for this
     event.
 
     If we're reporting a fire due to delayed processing, is_delayed should be True.
+    If workflow_ids is provided, use it directly instead of deriving from actions.
     """
-    # Create WorkflowFireHistory objects for workflows we fire actions for
-    workflow_ids = set(
-        WorkflowDataConditionGroup.objects.filter(
-            condition_group__dataconditiongroupaction__action__in=actions_to_fire
-        ).values_list("workflow_id", flat=True)
-    )
+    if workflow_ids is None:
+        workflow_ids = set(
+            WorkflowDataConditionGroup.objects.filter(
+                condition_group__dataconditiongroupaction__action__in=actions_to_fire
+            ).values_list("workflow_id", flat=True)
+        )
 
     event_id = (
         event_data.event.event_id

--- a/src/sentry/workflow_engine/processors/workflow_fire_history.py
+++ b/src/sentry/workflow_engine/processors/workflow_fire_history.py
@@ -17,7 +17,7 @@ from sentry.workflow_engine.models import (
     WorkflowDataConditionGroup,
     WorkflowFireHistory,
 )
-from sentry.workflow_engine.types import WorkflowEventData
+from sentry.workflow_engine.types import WorkflowEventData, WorkflowId
 from sentry.workflow_engine.utils import scopedstats
 
 logger = logging.getLogger(__name__)
@@ -31,7 +31,7 @@ def create_workflow_fire_histories(
     event_data: WorkflowEventData,
     is_delayed: bool = False,
     start_timestamp: datetime | None = None,
-    workflow_ids: set[int] | None = None,
+    workflow_ids: set[WorkflowId] | None = None,
 ) -> list[WorkflowFireHistory]:
     """
     Record that the workflows associated with these actions were fired for this

--- a/tests/sentry/workflow_engine/processors/test_action.py
+++ b/tests/sentry/workflow_engine/processors/test_action.py
@@ -307,6 +307,93 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         assert set(triggered_actions) == {self.action}
         assert getattr(triggered_actions[0], "workflow_id") == workflow.id
 
+    def test_deduplicates_different_actions_with_same_dedup_key(self) -> None:
+        """
+        Two different Action objects with the same dedup_key (same type, config, data)
+        in different workflows should be deduplicated — only one action fires.
+        WAGS should be created for both workflows.
+        """
+        # Create a second workflow with a different action that has the same dedup_key
+        workflow_2 = self.create_workflow(organization=self.organization)
+        self.create_detector_workflow(detector=self.detector, workflow=workflow_2)
+
+        # Create action_2 with identical config to self.action (same dedup_key)
+        action_2 = self.create_action(
+            type=self.action.type,
+            config=self.action.config,
+            data=self.action.data,
+            integration_id=self.action.integration_id,
+        )
+        assert action_2.get_dedup_key() == self.action.get_dedup_key()
+        assert action_2.id != self.action.id
+
+        action_group_2 = self.create_data_condition_group(logic_type="any-short")
+        self.create_data_condition_group_action(
+            condition_group=action_group_2,
+            action=action_2,
+        )
+        self.create_workflow_data_condition_group(workflow_2, action_group_2)
+
+        triggered_actions = filter_recently_fired_workflow_actions(
+            set(DataConditionGroup.objects.all()), self.event_data
+        )
+
+        # Should deduplicate to a single action since both have the same dedup_key
+        assert len(triggered_actions) == 1
+
+        # WAGS should be created for both workflows
+        assert (
+            WorkflowActionGroupStatus.objects.filter(
+                action__in=[self.action, action_2], group=self.group
+            ).count()
+            == 2
+        )
+
+    def test_deduplicates_different_actions_with_same_dedup_key__later_fire(self) -> None:
+        """
+        Same as above but with existing WAGS entries. Both workflows should be
+        marked as triggered even though only one action fires.
+        """
+        workflow_2 = self.create_workflow(organization=self.organization)
+        self.create_detector_workflow(detector=self.detector, workflow=workflow_2)
+
+        action_2 = self.create_action(
+            type=self.action.type,
+            config=self.action.config,
+            data=self.action.data,
+            integration_id=self.action.integration_id,
+        )
+        assert action_2.get_dedup_key() == self.action.get_dedup_key()
+
+        action_group_2 = self.create_data_condition_group(logic_type="any-short")
+        self.create_data_condition_group_action(
+            condition_group=action_group_2,
+            action=action_2,
+        )
+        self.create_workflow_data_condition_group(workflow_2, action_group_2)
+
+        # Both have old WAGS entries that should allow firing
+        status_1 = WorkflowActionGroupStatus.objects.create(
+            workflow=self.workflow, action=self.action, group=self.group
+        )
+        status_1.update(date_updated=timezone.now() - timedelta(days=1))
+        status_2 = WorkflowActionGroupStatus.objects.create(
+            workflow=workflow_2, action=action_2, group=self.group
+        )
+        status_2.update(date_updated=timezone.now() - timedelta(days=1))
+
+        triggered_actions = filter_recently_fired_workflow_actions(
+            set(DataConditionGroup.objects.all()), self.event_data
+        )
+
+        # Should deduplicate to a single action
+        assert len(triggered_actions) == 1
+
+        # Both WAGS should be updated
+        for status in [status_1, status_2]:
+            status.refresh_from_db()
+            assert status.date_updated == timezone.now()
+
     def test_skips_action_with_no_workflow(self) -> None:
         orphan_group = self.create_data_condition_group(logic_type="any-short")
         orphan_action = self.create_action(type=Action.Type.PLUGIN)

--- a/tests/sentry/workflow_engine/processors/test_action.py
+++ b/tests/sentry/workflow_engine/processors/test_action.py
@@ -104,13 +104,13 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         )  # shared action
         self.create_workflow_data_condition_group(workflow, action_group)
 
-        triggered_actions, all_workflow_ids = filter_recently_fired_workflow_actions(
+        result = filter_recently_fired_workflow_actions(
             set(DataConditionGroup.objects.all()), self.event_data
         )
         # dedupes action if both workflows will fire it
-        assert set(triggered_actions) == {self.action}
+        assert set(result.actions) == {self.action}
         # Dedupes action so we have a single workflow_id -> environment to fire with
-        assert getattr(triggered_actions[0], "workflow_id") == self.workflow.id
+        assert getattr(result.actions[0], "workflow_id") == self.workflow.id
 
         assert WorkflowActionGroupStatus.objects.filter(action=self.action).count() == 2
 
@@ -336,15 +336,15 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         )
         self.create_workflow_data_condition_group(workflow_2, action_group_2)
 
-        triggered_actions, all_workflow_ids = filter_recently_fired_workflow_actions(
+        result = filter_recently_fired_workflow_actions(
             set(DataConditionGroup.objects.all()), self.event_data
         )
 
         # Should deduplicate to a single action since both have the same dedup_key
-        assert len(triggered_actions) == 1
+        assert len(result.actions) == 1
 
-        # all_workflow_ids should include both workflows for fire history tracking
-        assert all_workflow_ids == {self.workflow.id, workflow_2.id}
+        # workflow_ids should include both workflows for fire history tracking
+        assert result.workflow_ids == {self.workflow.id, workflow_2.id}
 
         # WAGS should be created for both workflows
         assert (
@@ -388,15 +388,15 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         )
         status_2.update(date_updated=timezone.now() - timedelta(days=1))
 
-        triggered_actions, all_workflow_ids = filter_recently_fired_workflow_actions(
+        result = filter_recently_fired_workflow_actions(
             set(DataConditionGroup.objects.all()), self.event_data
         )
 
         # Should deduplicate to a single action
-        assert len(triggered_actions) == 1
+        assert len(result.actions) == 1
 
-        # all_workflow_ids should include both workflows
-        assert all_workflow_ids == {self.workflow.id, workflow_2.id}
+        # workflow_ids should include both workflows
+        assert result.workflow_ids == {self.workflow.id, workflow_2.id}
 
         # Both WAGS should be updated
         for status in [status_1, status_2]:

--- a/tests/sentry/workflow_engine/processors/test_action.py
+++ b/tests/sentry/workflow_engine/processors/test_action.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 
 from sentry.integrations.base import IntegrationFeatures
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.features import with_feature
 from sentry.workflow_engine.models import (
     Action,
     DataConditionGroup,
@@ -52,7 +53,7 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
             workflow=self.workflow, action=action, group=self.group
         )
 
-        triggered_actions = filter_recently_fired_workflow_actions(
+        triggered_actions, _ = filter_recently_fired_workflow_actions(
             set(DataConditionGroup.objects.all()), self.event_data
         )
         assert set(triggered_actions) == {self.action}
@@ -85,7 +86,7 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         )
         status_3.update(date_updated=timezone.now() - timedelta(days=2))
 
-        triggered_actions = filter_recently_fired_workflow_actions(
+        triggered_actions, _ = filter_recently_fired_workflow_actions(
             set(DataConditionGroup.objects.all()), self.event_data
         )
         assert set(triggered_actions) == {self.action, action_3}
@@ -103,7 +104,7 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         )  # shared action
         self.create_workflow_data_condition_group(workflow, action_group)
 
-        triggered_actions = filter_recently_fired_workflow_actions(
+        triggered_actions, all_workflow_ids = filter_recently_fired_workflow_actions(
             set(DataConditionGroup.objects.all()), self.event_data
         )
         # dedupes action if both workflows will fire it
@@ -127,7 +128,7 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         )
         status.update(date_updated=timezone.now() - timedelta(hours=1))
 
-        triggered_actions = filter_recently_fired_workflow_actions(
+        triggered_actions, _ = filter_recently_fired_workflow_actions(
             set(DataConditionGroup.objects.all()), self.event_data
         )
         # fires one action for the workflow that can fire it
@@ -280,7 +281,7 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
             updated=0, created=0, not_created=[(self.workflow.id, self.action.id)]
         )
 
-        triggered_actions = filter_recently_fired_workflow_actions(
+        triggered_actions, _ = filter_recently_fired_workflow_actions(
             set(DataConditionGroup.objects.all()), self.event_data
         )
 
@@ -300,13 +301,14 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
             updated=0, created=0, not_created=[(self.workflow.id, self.action.id)]
         )
 
-        triggered_actions = filter_recently_fired_workflow_actions(
+        triggered_actions, _ = filter_recently_fired_workflow_actions(
             set(DataConditionGroup.objects.all()), self.event_data
         )
 
         assert set(triggered_actions) == {self.action}
         assert getattr(triggered_actions[0], "workflow_id") == workflow.id
 
+    @with_feature("organizations:workflow-engine-deduplicate-actions")
     def test_deduplicates_different_actions_with_same_dedup_key(self) -> None:
         """
         Two different Action objects with the same dedup_key (same type, config, data)
@@ -334,12 +336,15 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         )
         self.create_workflow_data_condition_group(workflow_2, action_group_2)
 
-        triggered_actions = filter_recently_fired_workflow_actions(
+        triggered_actions, all_workflow_ids = filter_recently_fired_workflow_actions(
             set(DataConditionGroup.objects.all()), self.event_data
         )
 
         # Should deduplicate to a single action since both have the same dedup_key
         assert len(triggered_actions) == 1
+
+        # all_workflow_ids should include both workflows for fire history tracking
+        assert all_workflow_ids == {self.workflow.id, workflow_2.id}
 
         # WAGS should be created for both workflows
         assert (
@@ -349,6 +354,7 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
             == 2
         )
 
+    @with_feature("organizations:workflow-engine-deduplicate-actions")
     def test_deduplicates_different_actions_with_same_dedup_key__later_fire(self) -> None:
         """
         Same as above but with existing WAGS entries. Both workflows should be
@@ -382,12 +388,15 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         )
         status_2.update(date_updated=timezone.now() - timedelta(days=1))
 
-        triggered_actions = filter_recently_fired_workflow_actions(
+        triggered_actions, all_workflow_ids = filter_recently_fired_workflow_actions(
             set(DataConditionGroup.objects.all()), self.event_data
         )
 
         # Should deduplicate to a single action
         assert len(triggered_actions) == 1
+
+        # all_workflow_ids should include both workflows
+        assert all_workflow_ids == {self.workflow.id, workflow_2.id}
 
         # Both WAGS should be updated
         for status in [status_1, status_2]:
@@ -403,7 +412,7 @@ class TestFilterRecentlyFiredWorkflowActions(BaseWorkflowTest):
         )
         # No WorkflowDataConditionGroup links orphan_group to any workflow
 
-        triggered_actions = filter_recently_fired_workflow_actions(
+        triggered_actions, _ = filter_recently_fired_workflow_actions(
             {self.action_group, orphan_group}, self.event_data
         )
 

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -203,6 +203,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
 
     @patch("sentry.workflow_engine.processors.action.filter_recently_fired_workflow_actions")
     def test_populate_workflow_env_for_filters(self, mock_filter: MagicMock) -> None:
+        mock_filter.return_value = (MagicMock(), set())
         # this should not pass because the environment is not None
         self.error_workflow.update(environment=self.group_event.get_environment())
         error_workflow_filters = self.create_data_condition_group(

--- a/tests/sentry/workflow_engine/test_task.py
+++ b/tests/sentry/workflow_engine/test_task.py
@@ -13,6 +13,7 @@ from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import assume_test_silo_mode_of
 from sentry.types.activity import ActivityType
 from sentry.workflow_engine.handlers.workflow import workflow_status_update_handler
+from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.processors.data_condition_group import TriggerResult
 from sentry.workflow_engine.processors.workflow import EvaluationStats
 from sentry.workflow_engine.tasks.utils import fetch_event
@@ -221,6 +222,7 @@ class TestProcessWorkflowActivity(TestCase):
     def test_process_workflow_activity(
         self, mock_logger: mock.MagicMock, mock_filter_actions: mock.MagicMock
     ) -> None:
+        mock_filter_actions.return_value = (Action.objects.none(), set())
         self.workflow = self.create_workflow(organization=self.organization)
 
         self.action_group = self.create_data_condition_group(logic_type="any-short")


### PR DESCRIPTION
# Description
Currently, when a user has an event that triggers multiple workflows, it could send multiple notifications to the same place because the action is replicated across a few workflows. The source of this bug is because we used the `workflow_id` as part of the deduplication of actions before triggering them.

This PR adds a rollout flag `organizations:workflow-engine-deduplicate-actions`, when enabled it will change the mechanism within filtering to _not_ take into account the workflow_id, and thus deduplicate actions across many workflows.