### PR TITLE
feat(copilot): Surface dedicated failure_type for insufficient premium quota

### DIFF
--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -365,6 +365,9 @@ def _launch_agents_for_repos(
                     if e.text and "not licensed" in e.text.lower():
                         failure_type = "github_copilot_not_licensed"
                         error_message = "Your GitHub account does not have an active Copilot license. Please check your GitHub Copilot subscription."
+                    elif e.text and "premium quota" in e.text.lower():
+                        failure_type = "github_copilot_insufficient_quota"
+                        error_message = "Your GitHub Copilot plan does not have enough premium request quota to launch a coding agent. Upgrade your plan or wait for the next billing cycle."
                     else:
                         failure_type = "github_app_permissions"
                         error_message = f"The Sentry GitHub App installation does not have the required permissions for {repo_name}. Please update your GitHub App permissions to include 'contents:write'."

--- a/src/sentry/seer/autofix/coding_agent.py
+++ b/src/sentry/seer/autofix/coding_agent.py
@@ -215,6 +215,46 @@ def _extract_repos_from_solution(autofix_state: AutofixState) -> list[str]:
     return list(repos)
 
 
+def extract_api_error_message_from_api_error(error: ApiError) -> str | None:
+    if isinstance(error.json, dict):
+        nested_error = error.json.get("error")
+        if isinstance(nested_error, dict):
+            message = nested_error.get("message")
+            if isinstance(message, str) and message:
+                return message
+
+        message = error.json.get("message")
+        if isinstance(message, str) and message:
+            return message
+
+    return error.text or None
+
+
+def classify_github_copilot_api_error(error: ApiError, repo_name: str) -> tuple[str, str] | None:
+    error_message = extract_api_error_message_from_api_error(error)
+    error_text = " ".join(part for part in (error.text, error_message) if part).lower()
+
+    if "not licensed" in error_text:
+        return (
+            "github_copilot_not_licensed",
+            "Your GitHub account does not have an active Copilot license. Please check your GitHub Copilot subscription.",
+        )
+
+    if "premium quota" in error_text:
+        return (
+            "github_copilot_insufficient_quota",
+            "Your GitHub Copilot plan does not have enough premium request quota to launch a coding agent. Upgrade your plan or wait for the next billing cycle.",
+        )
+
+    if error.code == 403:
+        return (
+            "github_app_permissions",
+            f"The Sentry GitHub App installation does not have the required permissions for {repo_name}. Please update your GitHub App permissions to include 'contents:write'.",
+        )
+
+    return None
+
+
 def _launch_agents_for_repos(
     autofix_state: AutofixState,
     run_id: int,
@@ -361,16 +401,11 @@ def _launch_agents_for_repos(
             github_installation_id: str | None = None
             if isinstance(e, ApiError):
                 url_part = f" ({e.url})" if e.url else ""
-                if e.code == 403 and client is not None:
-                    if e.text and "not licensed" in e.text.lower():
-                        failure_type = "github_copilot_not_licensed"
-                        error_message = "Your GitHub account does not have an active Copilot license. Please check your GitHub Copilot subscription."
-                    elif e.text and "premium quota" in e.text.lower():
-                        failure_type = "github_copilot_insufficient_quota"
-                        error_message = "Your GitHub Copilot plan does not have enough premium request quota to launch a coding agent. Upgrade your plan or wait for the next billing cycle."
-                    else:
-                        failure_type = "github_app_permissions"
-                        error_message = f"The Sentry GitHub App installation does not have the required permissions for {repo_name}. Please update your GitHub App permissions to include 'contents:write'."
+                if client is not None and (
+                    copilot_failure := classify_github_copilot_api_error(e, repo_name)
+                ):
+                    failure_type, error_message = copilot_failure
+                    if failure_type == "github_app_permissions":
                         if repo and repo.integration_id:
                             try:
                                 sentry_integration = integration_service.get_integration(

--- a/src/sentry/seer/explorer/coding_agent_handoff.py
+++ b/src/sentry/seer/explorer/coding_agent_handoff.py
@@ -150,6 +150,9 @@ def launch_coding_agents(
                     if e.text and "not licensed" in e.text.lower():
                         failure_type = "github_copilot_not_licensed"
                         error_message = "Your GitHub account does not have an active Copilot license. Please check your GitHub Copilot subscription."
+                    elif e.text and "premium quota" in e.text.lower():
+                        failure_type = "github_copilot_insufficient_quota"
+                        error_message = "Your GitHub Copilot plan does not have enough premium request quota to launch a coding agent. Upgrade your plan or wait for the next billing cycle."
                     else:
                         failure_type = "github_app_permissions"
                         error_message = f"The Sentry GitHub App installation does not have the required permissions for {repo_name}. Please update your GitHub App permissions to include 'contents:write'."

--- a/src/sentry/seer/explorer/coding_agent_handoff.py
+++ b/src/sentry/seer/explorer/coding_agent_handoff.py
@@ -24,6 +24,8 @@ from sentry.integrations.services.integration import integration_service
 from sentry.models.organization import Organization
 from sentry.seer.autofix.coding_agent import (
     _validate_and_get_integration,
+    classify_github_copilot_api_error,
+    extract_api_error_message_from_api_error,
     sanitize_branch_name,
     store_coding_agent_states_to_seer,
 )
@@ -146,16 +148,15 @@ def launch_coding_agents(
                 if api_message:
                     error_message = api_message
             elif isinstance(e, ApiError):
-                if e.code == 403 and is_github_copilot:
-                    if e.text and "not licensed" in e.text.lower():
-                        failure_type = "github_copilot_not_licensed"
-                        error_message = "Your GitHub account does not have an active Copilot license. Please check your GitHub Copilot subscription."
-                    elif e.text and "premium quota" in e.text.lower():
-                        failure_type = "github_copilot_insufficient_quota"
-                        error_message = "Your GitHub Copilot plan does not have enough premium request quota to launch a coding agent. Upgrade your plan or wait for the next billing cycle."
-                    else:
-                        failure_type = "github_app_permissions"
-                        error_message = f"The Sentry GitHub App installation does not have the required permissions for {repo_name}. Please update your GitHub App permissions to include 'contents:write'."
+                api_message = extract_api_error_message_from_api_error(e)
+                if api_message:
+                    error_message = api_message
+
+                if is_github_copilot and (
+                    copilot_failure := classify_github_copilot_api_error(e, repo_name)
+                ):
+                    failure_type, error_message = copilot_failure
+                    if failure_type == "github_app_permissions":
                         try:
                             github_integrations = integration_service.get_integrations(
                                 organization_id=organization.id,

--- a/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
@@ -1223,7 +1223,7 @@ class OrganizationCodingAgentsPost403PermissionTest(BaseOrganizationCodingAgents
     @patch("sentry.seer.autofix.coding_agent.get_project_seer_preferences")
     @patch("sentry.seer.autofix.coding_agent.GithubCopilotAgentClient")
     @patch("sentry.seer.autofix.coding_agent.github_copilot_identity_service")
-    def test_copilot_insufficient_premium_quota_returns_quota_failure_type(
+    def test_copilot_insufficient_premium_quota_412_returns_quota_failure_type(
         self,
         mock_identity_service,
         mock_copilot_client_class,
@@ -1232,9 +1232,9 @@ class OrganizationCodingAgentsPost403PermissionTest(BaseOrganizationCodingAgents
         mock_get_autofix_state,
         mock_get_providers,
     ):
-        """Test POST endpoint returns failure_type=github_copilot_insufficient_quota for Copilot 403 quota errors.
+        """Test POST endpoint returns failure_type=github_copilot_insufficient_quota for Copilot 412 quota errors.
 
-        When GitHub Copilot returns a 403 whose body mentions insufficient premium
+        When GitHub Copilot returns a 412 whose body mentions insufficient premium
         quota, the user has Copilot but has exhausted their premium request budget.
         This is distinct from a GitHub App permissions issue or being unlicensed, so
         we surface a dedicated failure type for the frontend to render upgrade guidance.
@@ -1249,7 +1249,8 @@ class OrganizationCodingAgentsPost403PermissionTest(BaseOrganizationCodingAgents
         mock_client_instance = MagicMock()
         mock_copilot_client_class.return_value = mock_client_instance
         mock_client_instance.launch.side_effect = ApiError(
-            "insufficient premium quota to create assignment", code=403
+            '{"documentation_url":"https://docs.github.com/rest","message":"insufficient premium quota to create assignment"}',
+            code=412,
         )
 
         mock_get_autofix_state.return_value = self._create_mock_autofix_state()

--- a/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_coding_agents.py
@@ -1221,6 +1221,56 @@ class OrganizationCodingAgentsPost403PermissionTest(BaseOrganizationCodingAgents
     @patch("sentry.seer.autofix.coding_agent.get_autofix_state")
     @patch("sentry.seer.autofix.coding_agent.get_coding_agent_prompt")
     @patch("sentry.seer.autofix.coding_agent.get_project_seer_preferences")
+    @patch("sentry.seer.autofix.coding_agent.GithubCopilotAgentClient")
+    @patch("sentry.seer.autofix.coding_agent.github_copilot_identity_service")
+    def test_copilot_insufficient_premium_quota_returns_quota_failure_type(
+        self,
+        mock_identity_service,
+        mock_copilot_client_class,
+        mock_get_preferences,
+        mock_get_prompt,
+        mock_get_autofix_state,
+        mock_get_providers,
+    ):
+        """Test POST endpoint returns failure_type=github_copilot_insufficient_quota for Copilot 403 quota errors.
+
+        When GitHub Copilot returns a 403 whose body mentions insufficient premium
+        quota, the user has Copilot but has exhausted their premium request budget.
+        This is distinct from a GitHub App permissions issue or being unlicensed, so
+        we surface a dedicated failure type for the frontend to render upgrade guidance.
+        """
+        mock_get_providers.return_value = ["github"]
+        mock_get_prompt.return_value = "Test prompt"
+        mock_get_preferences.return_value = PreferenceResponse(
+            preference=None, code_mapping_repos=[]
+        )
+        mock_identity_service.get_access_token_for_user.return_value = "test-copilot-token"
+
+        mock_client_instance = MagicMock()
+        mock_copilot_client_class.return_value = mock_client_instance
+        mock_client_instance.launch.side_effect = ApiError(
+            "insufficient premium quota to create assignment", code=403
+        )
+
+        mock_get_autofix_state.return_value = self._create_mock_autofix_state()
+
+        data = {"provider": "github_copilot", "run_id": 123}
+
+        with (
+            self.feature("organizations:integrations-github-copilot-agent"),
+            patch("sentry.seer.autofix.coding_agent.store_coding_agent_states_to_seer"),
+        ):
+            response = self.get_success_response(self.organization.slug, method="post", **data)
+            assert response.data["success"] is False
+            assert response.data["failed_count"] >= 1
+            failure = response.data["failures"][0]
+            assert failure["failure_type"] == "github_copilot_insufficient_quota"
+            assert "premium request quota" in failure["error_message"]
+
+    @patch("sentry.seer.autofix.coding_agent.get_coding_agent_providers")
+    @patch("sentry.seer.autofix.coding_agent.get_autofix_state")
+    @patch("sentry.seer.autofix.coding_agent.get_coding_agent_prompt")
+    @patch("sentry.seer.autofix.coding_agent.get_project_seer_preferences")
     @patch(
         "sentry.integrations.services.integration.integration_service.get_organization_integration"
     )

--- a/tests/sentry/seer/explorer/test_coding_agent_handoff.py
+++ b/tests/sentry/seer/explorer/test_coding_agent_handoff.py
@@ -171,6 +171,49 @@ class TestLaunchCodingAgents(TestCase):
         assert "Copilot license" in failure["error_message"]
 
     @patch("sentry.seer.explorer.coding_agent_handoff.store_coding_agent_states_to_seer")
+    @patch("sentry.seer.explorer.coding_agent_handoff.GithubCopilotAgentClient")
+    @patch("sentry.seer.explorer.coding_agent_handoff.github_copilot_identity_service")
+    @patch("sentry.seer.explorer.coding_agent_handoff.features.has")
+    def test_copilot_insufficient_premium_quota_returns_quota_failure_type(
+        self,
+        mock_features,
+        mock_identity_service,
+        mock_copilot_client_class,
+        mock_store,
+    ):
+        """Test that Copilot 403 'insufficient premium quota' errors return github_copilot_insufficient_quota failure_type.
+
+        When GitHub Copilot returns a 403 whose body mentions insufficient premium
+        quota, the user has Copilot but has exhausted their premium request budget.
+        This is distinct from being unlicensed, so we surface a dedicated failure type
+        so the frontend can guide the user to upgrade or wait for the next cycle.
+        """
+        mock_features.return_value = True
+        mock_identity_service.get_access_token_for_user.return_value = "test-token"
+
+        mock_client_instance = MagicMock()
+        mock_copilot_client_class.return_value = mock_client_instance
+        mock_client_instance.launch.side_effect = ApiError(
+            "insufficient premium quota to create assignment", code=403
+        )
+
+        result = launch_coding_agents(
+            organization=self.organization,
+            integration_id=None,
+            run_id=self.run_id,
+            prompt="Fix the bug",
+            repos=[_repo("owner", "repo")],
+            provider="github_copilot",
+            user_id=1,
+        )
+
+        assert len(result["successes"]) == 0
+        assert len(result["failures"]) == 1
+        failure = result["failures"][0]
+        assert failure["failure_type"] == "github_copilot_insufficient_quota"
+        assert "premium request quota" in failure["error_message"]
+
+    @patch("sentry.seer.explorer.coding_agent_handoff.store_coding_agent_states_to_seer")
     @patch("sentry.seer.explorer.coding_agent_handoff._validate_and_get_integration")
     def test_verify_branch_error_returns_cursor_github_access_failure_type(
         self, mock_validate, mock_store

--- a/tests/sentry/seer/explorer/test_coding_agent_handoff.py
+++ b/tests/sentry/seer/explorer/test_coding_agent_handoff.py
@@ -174,16 +174,16 @@ class TestLaunchCodingAgents(TestCase):
     @patch("sentry.seer.explorer.coding_agent_handoff.GithubCopilotAgentClient")
     @patch("sentry.seer.explorer.coding_agent_handoff.github_copilot_identity_service")
     @patch("sentry.seer.explorer.coding_agent_handoff.features.has")
-    def test_copilot_insufficient_premium_quota_returns_quota_failure_type(
+    def test_copilot_insufficient_premium_quota_412_returns_quota_failure_type(
         self,
         mock_features,
         mock_identity_service,
         mock_copilot_client_class,
         mock_store,
     ):
-        """Test that Copilot 403 'insufficient premium quota' errors return github_copilot_insufficient_quota failure_type.
+        """Test that Copilot 412 'insufficient premium quota' errors return github_copilot_insufficient_quota failure_type.
 
-        When GitHub Copilot returns a 403 whose body mentions insufficient premium
+        When GitHub Copilot returns a 412 whose body mentions insufficient premium
         quota, the user has Copilot but has exhausted their premium request budget.
         This is distinct from being unlicensed, so we surface a dedicated failure type
         so the frontend can guide the user to upgrade or wait for the next cycle.
@@ -194,7 +194,8 @@ class TestLaunchCodingAgents(TestCase):
         mock_client_instance = MagicMock()
         mock_copilot_client_class.return_value = mock_client_instance
         mock_client_instance.launch.side_effect = ApiError(
-            "insufficient premium quota to create assignment", code=403
+            '{"documentation_url":"https://docs.github.com/rest","message":"insufficient premium quota to create assignment"}',
+            code=412,
         )
 
         result = launch_coding_agents(


### PR DESCRIPTION
Map GitHub Copilot's "insufficient premium quota" response into a dedicated
`github_copilot_insufficient_quota` failure_type instead of relying on the
HTTP status alone.

Copilot quota failures can come back as `412 Precondition Failed` with the
useful message in the response body. This change classifies quota and license
failures from the provider error text, while keeping the GitHub App permissions
failure limited to unrecognized `403` responses. The Explorer handoff path also
falls back to the parsed API message instead of the generic "Failed to launch
coding agent" text.

The same mapping is applied in both entry points that can launch Copilot
agents:
- `src/sentry/seer/autofix/coding_agent.py` (endpoint-triggered launches)
- `src/sentry/seer/explorer/coding_agent_handoff.py` (explorer handoff)

## Rollout

This is the backend half only. The follow-up frontend PR will add a modal
that renders when `failure_type === 'github_copilot_insufficient_quota'`.
Per the repo convention (frontend and backend are not atomically deployed),
this backend PR needs to land first so the new `failure_type` is in
production before the frontend begins filtering on it.

Refs SENTRY-5P3D

Agent transcript: https://claudescope.sentry.dev/share/Atne7mAWZiJSxorN0JTIPEmrHj07NZKCuxrAsz47fQY
