### PR TITLE
feat(copilot): Show dedicated modal for insufficient Copilot quota

### DIFF
--- a/static/app/components/events/autofix/autofixGithubCopilotQuotaModal.spec.tsx
+++ b/static/app/components/events/autofix/autofixGithubCopilotQuotaModal.spec.tsx
@@ -1,0 +1,32 @@
+import {act, renderGlobalModal, screen} from 'sentry-test/reactTestingLibrary';
+
+import {openModal} from 'sentry/actionCreators/modal';
+import {AutofixGithubCopilotQuotaModal} from 'sentry/components/events/autofix/autofixGithubCopilotQuotaModal';
+
+describe('AutofixGithubCopilotQuotaModal', () => {
+  it('renders the modal with correct title and body', async () => {
+    renderGlobalModal();
+
+    act(() => {
+      openModal(deps => <AutofixGithubCopilotQuotaModal {...deps} />);
+    });
+
+    expect(
+      await screen.findByText('GitHub Copilot Premium Quota Exhausted')
+    ).toBeInTheDocument();
+    expect(screen.getByText(/premium request quota remaining/)).toBeInTheDocument();
+  });
+
+  it('renders manage button linking to Copilot settings', async () => {
+    renderGlobalModal();
+
+    act(() => {
+      openModal(deps => <AutofixGithubCopilotQuotaModal {...deps} />);
+    });
+
+    const manageButton = await screen.findByRole('button', {
+      name: 'Manage Copilot Plan',
+    });
+    expect(manageButton).toHaveAttribute('href', 'https://github.com/settings/copilot');
+  });
+});

--- a/static/app/components/events/autofix/autofixGithubCopilotQuotaModal.spec.tsx
+++ b/static/app/components/events/autofix/autofixGithubCopilotQuotaModal.spec.tsx
@@ -27,6 +27,9 @@ describe('AutofixGithubCopilotQuotaModal', () => {
     const manageButton = await screen.findByRole('button', {
       name: 'Manage Copilot Plan',
     });
-    expect(manageButton).toHaveAttribute('href', 'https://github.com/settings/copilot');
+    expect(manageButton).toHaveAttribute(
+      'href',
+      'https://github.com/features/copilot/plans'
+    );
   });
 });

--- a/static/app/components/events/autofix/autofixGithubCopilotQuotaModal.tsx
+++ b/static/app/components/events/autofix/autofixGithubCopilotQuotaModal.tsx
@@ -8,9 +8,9 @@ import {Heading, Text} from '@sentry/scraps/text';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {t, tct} from 'sentry/locale';
 
-const COPILOT_PLANS_URL = 'https://github.com/settings/copilot';
+const COPILOT_PLANS_URL = 'https://github.com/features/copilot/plans';
 const COPILOT_QUOTA_DOCS_URL =
-  'https://docs.github.com/en/copilot/managing-copilot/understanding-and-managing-copilot-usage/understanding-and-managing-requests-in-copilot';
+  'https://docs.github.com/en/copilot/concepts/billing/copilot-requests';
 
 export function AutofixGithubCopilotQuotaModal({
   Header,

--- a/static/app/components/events/autofix/autofixGithubCopilotQuotaModal.tsx
+++ b/static/app/components/events/autofix/autofixGithubCopilotQuotaModal.tsx
@@ -1,0 +1,47 @@
+import {Fragment} from 'react';
+
+import {Button, LinkButton} from '@sentry/scraps/button';
+import {Grid} from '@sentry/scraps/layout';
+import {ExternalLink} from '@sentry/scraps/link';
+import {Heading, Text} from '@sentry/scraps/text';
+
+import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import {t, tct} from 'sentry/locale';
+
+const COPILOT_PLANS_URL = 'https://github.com/settings/copilot';
+const COPILOT_QUOTA_DOCS_URL =
+  'https://docs.github.com/en/copilot/managing-copilot/understanding-and-managing-copilot-usage/understanding-and-managing-requests-in-copilot';
+
+export function AutofixGithubCopilotQuotaModal({
+  Header,
+  Body,
+  Footer,
+  closeModal,
+}: ModalRenderProps) {
+  return (
+    <Fragment>
+      <Header closeButton>
+        <Heading as="h3">{t('GitHub Copilot Premium Quota Exhausted')}</Heading>
+      </Header>
+      <Body>
+        <Text as="p">
+          {tct(
+            'Your GitHub Copilot plan does not have enough premium request quota remaining to launch a coding agent. To continue, [plansLink:upgrade your Copilot plan] or wait until your next billing cycle. You can [docsLink:learn more about Copilot premium requests].',
+            {
+              plansLink: <ExternalLink href={COPILOT_PLANS_URL} />,
+              docsLink: <ExternalLink href={COPILOT_QUOTA_DOCS_URL} />,
+            }
+          )}
+        </Text>
+      </Body>
+      <Footer>
+        <Grid flow="column" align="center" gap="md">
+          <Button onClick={closeModal}>{t('Remind me later')}</Button>
+          <LinkButton href={COPILOT_PLANS_URL} external priority="primary">
+            {t('Manage Copilot Plan')}
+          </LinkButton>
+        </Grid>
+      </Footer>
+    </Fragment>
+  );
+}

--- a/static/app/components/events/autofix/useAutofix.tsx
+++ b/static/app/components/events/autofix/useAutofix.tsx
@@ -6,6 +6,7 @@ import {openModal} from 'sentry/actionCreators/modal';
 import {AutofixCursorGithubAccessModal} from 'sentry/components/events/autofix/autofixCursorGithubAccessModal';
 import {AutofixGithubAppPermissionsModal} from 'sentry/components/events/autofix/autofixGithubAppPermissionsModal';
 import {AutofixGithubCopilotPurchaseModal} from 'sentry/components/events/autofix/autofixGithubCopilotPurchaseModal';
+import {AutofixGithubCopilotQuotaModal} from 'sentry/components/events/autofix/autofixGithubCopilotQuotaModal';
 import {
   AutofixStatus,
   AutofixStepType,
@@ -408,6 +409,9 @@ export function useLaunchCodingAgent(groupId: string, runId: string) {
         const copilotLicenseFailures = data.failures.filter(
           f => f.failure_type === 'github_copilot_not_licensed'
         );
+        const copilotQuotaFailures = data.failures.filter(
+          f => f.failure_type === 'github_copilot_insufficient_quota'
+        );
         const cursorGithubAccessFailures = data.failures.filter(
           f => f.failure_type === 'cursor_github_access'
         );
@@ -415,6 +419,7 @@ export function useLaunchCodingAgent(groupId: string, runId: string) {
           f =>
             f.failure_type !== 'github_app_permissions' &&
             f.failure_type !== 'github_copilot_not_licensed' &&
+            f.failure_type !== 'github_copilot_insufficient_quota' &&
             f.failure_type !== 'cursor_github_access'
         );
 
@@ -433,6 +438,10 @@ export function useLaunchCodingAgent(groupId: string, runId: string) {
 
         if (copilotLicenseFailures.length > 0) {
           openModal(deps => <AutofixGithubCopilotPurchaseModal {...deps} />);
+        }
+
+        if (copilotQuotaFailures.length > 0) {
+          openModal(deps => <AutofixGithubCopilotQuotaModal {...deps} />);
         }
 
         if (cursorGithubAccessFailures.length > 0) {

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -10,6 +10,7 @@ import {openModal} from 'sentry/actionCreators/modal';
 import {AutofixCursorGithubAccessModal} from 'sentry/components/events/autofix/autofixCursorGithubAccessModal';
 import {AutofixGithubAppPermissionsModal} from 'sentry/components/events/autofix/autofixGithubAppPermissionsModal';
 import {AutofixGithubCopilotPurchaseModal} from 'sentry/components/events/autofix/autofixGithubCopilotPurchaseModal';
+import {AutofixGithubCopilotQuotaModal} from 'sentry/components/events/autofix/autofixGithubCopilotQuotaModal';
 import {CodingAgentStatus} from 'sentry/components/events/autofix/types';
 import {
   needsGitHubAuth,
@@ -712,6 +713,9 @@ export function useExplorerAutofix(
           const copilotLicenseFailures = response.failures.filter(
             f => f.failure_type === 'github_copilot_not_licensed'
           );
+          const copilotQuotaFailures = response.failures.filter(
+            f => f.failure_type === 'github_copilot_insufficient_quota'
+          );
           const cursorGithubAccessFailures = response.failures.filter(
             f => f.failure_type === 'cursor_github_access'
           );
@@ -719,6 +723,7 @@ export function useExplorerAutofix(
             f =>
               f.failure_type !== 'github_app_permissions' &&
               f.failure_type !== 'github_copilot_not_licensed' &&
+              f.failure_type !== 'github_copilot_insufficient_quota' &&
               f.failure_type !== 'cursor_github_access'
           );
 
@@ -737,6 +742,10 @@ export function useExplorerAutofix(
 
           if (copilotLicenseFailures.length > 0) {
             openModal(deps => <AutofixGithubCopilotPurchaseModal {...deps} />);
+          }
+
+          if (copilotQuotaFailures.length > 0) {
+            openModal(deps => <AutofixGithubCopilotQuotaModal {...deps} />);
           }
 
           if (cursorGithubAccessFailures.length > 0) {


### PR DESCRIPTION
Render a dedicated `AutofixGithubCopilotQuotaModal` when the coding-agent
handoff returns `failure_type=github_copilot_insufficient_quota` (added in
the backend PR below). The modal explains that the user's Copilot plan has
exhausted its premium request budget and links to their Copilot settings so
they can upgrade or review usage — today the response falls through the
generic-error branch and surfaces as an unhelpful toast.

Wires the new modal into both `useAutofix.tsx` (legacy autofix) and
`useExplorerAutofix.tsx` (explorer variant) so the behavior is consistent
across UI surfaces. Mirrors the existing handling for
`github_copilot_not_licensed` and `cursor_github_access`.

## Stack

- Backend: #113996 — adds the new `failure_type`. Must land first so the
  frontend filter has something to match on in production.
- This PR: frontend. Based on the backend branch for a clean diff; rebase
  onto master once the backend merges.

Refs SENTRY-5P3D


Agent transcript: https://claudescope.sentry.dev/share/7MES9HkYZm3xTjSNThKGk9j43tt26DcNMh87VUGzOyI