### PR TITLE
feat(replays): Track event and video event counts on replay load

### DIFF
--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -478,24 +478,23 @@ export function Provider({
     }
   }, [getCurrentPlayerTime, isPlaying, prefs.playbackSpeed]);
 
-  // Emit a metric once per replay, after all segments have been fetched, so we
-  // can track the distribution of video segment counts on mobile replays.
   const replayId = replay?.getReplay().id;
+  const projectId = replay?.getReplay().project_id;
+  const videoElementCount = videoEvents?.length ?? 0;
   useEffect(() => {
-    if (isFetching || !isVideoReplay || !replay || !videoEvents) {
+    if (isFetching || !isVideoReplay || !replayId) {
       return;
     }
     Sentry.metrics.distribution(
       'replay.video_replayer.video_element_count',
-      videoEvents.length,
+      videoElementCount,
       {
         attributes: {
-          project_id: String(replay.getReplay().project_id),
+          project_id: String(projectId),
         },
       }
     );
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- fire once per replay load
-  }, [replayId, isFetching]);
+  }, [replayId, isFetching, isVideoReplay, videoElementCount, projectId]);
 
   const togglePlayPause = useCallback(
     (play: boolean) => {

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -2,6 +2,7 @@ import {createContext, useCallback, useContext, useEffect, useRef, useState} fro
 import {useTheme} from '@emotion/react';
 import {Replayer, ReplayerEvents} from '@sentry-internal/rrweb';
 import type {Mirror} from '@sentry-internal/rrweb-snapshot';
+import * as Sentry from '@sentry/react';
 
 import {useReplayHighlighting} from 'sentry/components/replays/useReplayHighlighting';
 import {VideoReplayerWithInteractions} from 'sentry/components/replays/videoReplayerWithInteractions';
@@ -476,6 +477,25 @@ export function Provider({
       replayer.setConfig({speed: prefs.playbackSpeed});
     }
   }, [getCurrentPlayerTime, isPlaying, prefs.playbackSpeed]);
+
+  // Emit a metric once per replay, after all segments have been fetched, so we
+  // can track the distribution of video segment counts on mobile replays.
+  const replayId = replay?.getReplay().id;
+  useEffect(() => {
+    if (isFetching || !isVideoReplay || !replay || !videoEvents) {
+      return;
+    }
+    Sentry.metrics.distribution(
+      'replay.video_replayer.video_element_count',
+      videoEvents.length,
+      {
+        attributes: {
+          project_id: String(replay.getReplay().project_id),
+        },
+      }
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- fire once per replay load
+  }, [replayId, isFetching]);
 
   const togglePlayPause = useCallback(
     (play: boolean) => {

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -496,7 +496,7 @@ export function Provider({
     }
 
     Sentry.metrics.distribution(
-      'replay.video_replayer.video_element_count',
+      'replay.videoReplayer.videoElementCount',
       videoElementCount,
       {
         attributes: {

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -488,22 +488,20 @@ export function Provider({
 
   const replayId = replay?.getReplay().id;
   const projectId = replay?.getReplay().project_id;
-  const videoElementCount = videoEvents?.length ?? 0;
 
-  const emitVideoElementCountMetric = useEffectEvent(() => {
-    if (!isVideoReplay) {
-      return;
-    }
+  const onLoadAllEvents = useEffectEvent(() => {
+    const attributes = {
+      projectId: String(projectId),
+      replayId,
+    };
 
-    Sentry.metrics.distribution(
-      'replay.videoReplayer.videoElementCount',
-      videoElementCount,
-      {
-        attributes: {
-          project_id: String(projectId),
-        },
-      }
-    );
+    Sentry.metrics.distribution('replay.eventCount', events?.length ?? 0, {
+      attributes,
+    });
+
+    Sentry.metrics.distribution('replay.videoEventCount', videoEvents?.length ?? 0, {
+      attributes,
+    });
   });
 
   useEffect(() => {
@@ -511,7 +509,7 @@ export function Provider({
       return;
     }
 
-    emitVideoElementCountMetric();
+    onLoadAllEvents();
   }, [replayId, isFetching]);
 
   const togglePlayPause = useCallback(

--- a/static/app/components/replays/replayContext.tsx
+++ b/static/app/components/replays/replayContext.tsx
@@ -1,4 +1,12 @@
-import {createContext, useCallback, useContext, useEffect, useRef, useState} from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useEffectEvent,
+  useRef,
+  useState,
+} from 'react';
 import {useTheme} from '@emotion/react';
 import {Replayer, ReplayerEvents} from '@sentry-internal/rrweb';
 import type {Mirror} from '@sentry-internal/rrweb-snapshot';
@@ -481,10 +489,12 @@ export function Provider({
   const replayId = replay?.getReplay().id;
   const projectId = replay?.getReplay().project_id;
   const videoElementCount = videoEvents?.length ?? 0;
-  useEffect(() => {
-    if (isFetching || !isVideoReplay || !replayId) {
+
+  const emitVideoElementCountMetric = useEffectEvent(() => {
+    if (!isVideoReplay) {
       return;
     }
+
     Sentry.metrics.distribution(
       'replay.video_replayer.video_element_count',
       videoElementCount,
@@ -494,7 +504,15 @@ export function Provider({
         },
       }
     );
-  }, [replayId, isFetching, isVideoReplay, videoElementCount, projectId]);
+  });
+
+  useEffect(() => {
+    if (isFetching || !replayId) {
+      return;
+    }
+
+    emitVideoElementCountMetric();
+  }, [replayId, isFetching]);
 
   const togglePlayPause = useCallback(
     (play: boolean) => {


### PR DESCRIPTION
Add some Replay telemetry to count the number of segments, especially video segments. Having too many videos (>1,000) seems like it's causing Chrome crashes, and I'd like to both know how often that happens, and be able to find exemplars. This is in support of REPLAY-831