### PR TITLE
fix(seer): Respect context engine toggle for screenshot selection

### DIFF
--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -343,7 +343,10 @@ export const useSeerExplorer = () => {
       // Send structured LLMContext JSON on supported pages when the feature flag
       // is enabled; fall back to a coarse ASCII screenshot otherwise.
       let screenshot: string | undefined;
-      if (supportsStructuredContext(getPageReferrer(), organization)) {
+      if (
+        overrideCtxEngEnable &&
+        supportsStructuredContext(getPageReferrer(), organization)
+      ) {
         try {
           screenshot = JSON.stringify(getLLMContext());
         } catch (e) {


### PR DESCRIPTION
+ The UI toggle for disabling the context engine (overrideCtxEngEnable) was only being forwarded to the backend. The frontend screenshot selection logic did not check it, so structured LLMContext was still sent on supported routes even when the toggle was off.
+ Gate the supportsStructuredContext check on overrideCtxEngEnable so disabling the toggle correctly falls back to the ASCII snapshot.