### PR TITLE
feat(taskworker): capture task exception context via TaskErrorCaptureHook

### DIFF
--- a/src/sentry/taskworker/adapters.py
+++ b/src/sentry/taskworker/adapters.py
@@ -10,14 +10,17 @@ from __future__ import annotations
 import contextlib
 import logging
 import threading
+import traceback as _traceback
 from collections.abc import MutableMapping
 from contextlib import contextmanager
 from typing import Any, Generator
 
 import orjson
+import sentry_sdk
 from arroyo.backends.kafka import KafkaProducer
 from django.conf import settings
 from django.core.cache.backends.base import BaseCache
+from sentry_protos.taskbroker.v1.taskbroker_pb2 import TaskError
 from sentry_sdk import capture_exception
 from taskbroker_client.metrics import MetricsBackend, Tags
 from taskbroker_client.router import TaskRouter as LibraryRouter
@@ -181,9 +184,11 @@ class ViewerContextHook:
                 ctx = ViewerContext.deserialize(orjson.loads(raw))
             except (orjson.JSONDecodeError, TypeError, KeyError, AttributeError):
                 logger.exception("Failed to deserialize viewer context header")
-        # Only `expected=True` when dispatch actually sent the header. That distinguishes
-        # the noise case (system task with no VC, header genuinely absent) from the bug
-        # case (header sent but deserialization failed → ctx is None).
+
+        # Only `expected=True` when dispatch actually sent the header.
+        # That distinguishes the noise case (system task with no VC, header
+        # genuinely absent) from the bug case (header sent but deserialization
+        # failed → ctx is None).
         observe_viewer_context_propagation(
             "task_execute",
             ctx=ctx,
@@ -192,6 +197,181 @@ class ViewerContextHook:
         if ctx is None:
             return contextlib.nullcontext()
         return viewer_context_scope(ctx)
+
+
+def _qualified_type(exc: BaseException) -> str:
+    cls = type(exc)
+    return f"{cls.__module__}.{cls.__qualname__}"
+
+
+def _task_meta_field(task_meta: object, field: str) -> str | None:
+    value = getattr(task_meta, field, None)
+    if value is not None:
+        return str(value)
+
+    activation = getattr(task_meta, "activation", None)
+    if activation is not None:
+        value = getattr(activation, field, None)
+        if value is not None:
+            return str(value)
+
+    return None
+
+
+def _log_value(value: object) -> str:
+    return orjson.dumps("" if value is None else str(value)).decode()
+
+
+def _smart_truncate(text: str, max_chars: int) -> str:
+    """
+    Truncates a string from the middle, preserving the head and tail.
+    Ideal for tracebacks where the root cause (head) and final exception (tail) are most important.
+    Note: The output may contain newlines and is meant for payloads (e.g., TaskError),
+    not for structured log lines.
+    """
+    if len(text) <= max_chars:
+        return text
+
+    marker = "\n... <TRACEBACK TRUNCATED> ...\n"
+    if max_chars <= len(marker) + 2:
+        return text[:max_chars]
+
+    keep_each = (max_chars - len(marker)) // 2
+    return text[:keep_each] + marker + text[-keep_each:]
+
+
+def _get_root_cause(exc: BaseException) -> BaseException:
+    """
+    Extracts the deepest root cause of an exception (chained exceptions).
+    Includes cycle detection to prevent infinite loops, and respects
+    Python's __suppress_context__ (e.g., raise ... from None).
+    """
+    root = exc
+    seen: set[int] = set()
+    while True:
+        next_exc = root.__cause__
+        if next_exc is None and not root.__suppress_context__:
+            next_exc = root.__context__
+
+        if next_exc is None or id(next_exc) in seen:
+            return root
+
+        seen.add(id(next_exc))
+        root = next_exc
+
+
+def _safe_capture_exception(exc: BaseException) -> None:
+    """
+    Safely captures an exception to Sentry without ever raising.
+    Used within error hooks to ensure we never violate the 'Never raises' contract.
+    """
+    try:
+        sentry_sdk.capture_exception(exc)
+    except Exception:
+        pass
+
+
+class TaskErrorCaptureHook:
+    """
+    On a task exception:
+      1. Ship a Sentry event tagged with task identifiers.
+      2. Emit a structured log line containing the task context, the exception,
+         and the root cause (if chained). We omit the full traceback from the logs
+         to prevent multiline parsing issues and massive log volumes, relying on Sentry
+         as the source of truth for stack traces.
+      3. Return a size-bounded TaskError envelope (with a smartly truncated traceback)
+         for the SetTaskStatus RPC.
+
+    Redundant if taskbroker_client already captures internally; harmless.
+    Never raises — a hook bug must not mask the original task exception.
+    """
+
+    # Character limits. The proto contract is "bounded"; the exact number is
+    # backpressure against runaway payloads reaching the broker's logs and
+    # Kafka, not an exact wire guarantee.
+    MAX_MESSAGE_CHARS = 2_000
+    MAX_TRACEBACK_CHARS = 8_000
+
+    def on_exception(self, task_meta, exc: BaseException) -> TaskError | None:
+        try:
+            exc_type = _qualified_type(exc)
+            task_id = _task_meta_field(task_meta, "id")
+            taskname = _task_meta_field(task_meta, "taskname")
+            namespace = _task_meta_field(task_meta, "namespace")
+            exception_message = str(exc)[: self.MAX_MESSAGE_CHARS]
+
+            # Always extract and log the root cause. If no chain exists, these will
+            # duplicate the outer exception fields. This ensures a stable log schema.
+            root_exc = _get_root_cause(exc)
+            root_type = _qualified_type(root_exc)
+            root_message = str(root_exc)[: self.MAX_MESSAGE_CHARS]
+
+            try:
+                with sentry_sdk.isolation_scope() as scope:
+                    scope.set_tag("taskname", taskname or "")
+                    scope.set_tag("namespace", namespace or "")
+                    scope.set_tag("task_id", task_id or "")
+                    sentry_sdk.capture_exception(exc)
+            except Exception as capture_exc:
+                _safe_capture_exception(capture_exc)
+                try:
+                    logger.error(
+                        "taskworker.error_hook.capture_failed "
+                        f"task_id={_log_value(task_id)} "
+                        f"internal_error_type={_log_value(_qualified_type(capture_exc))} "
+                        f"internal_error_message={_log_value(str(capture_exc))}"
+                    )
+                except Exception:
+                    pass
+
+            try:
+                # Emit a clean, single-line log without raw exc_info tracebacks
+                # to remain perfectly parseable by log aggregators like Vector.
+                logger.error(
+                    "taskworker.task_failed "
+                    f"task_id={_log_value(task_id)} "
+                    f"taskname={_log_value(taskname)} "
+                    f"namespace={_log_value(namespace)} "
+                    f"exception_type={_log_value(exc_type)} "
+                    f"exception_message={_log_value(exception_message)} "
+                    f"root_cause_type={_log_value(root_type)} "
+                    f"root_cause_message={_log_value(root_message)}"
+                )
+            except Exception:
+                pass
+
+            try:
+                tb_string = "".join(_traceback.format_exception(exc))
+                tb_truncated = _smart_truncate(tb_string, self.MAX_TRACEBACK_CHARS)
+
+                return TaskError(
+                    exception_type=exc_type,
+                    exception_message=exception_message,
+                    traceback=tb_truncated,
+                )
+            except Exception as env_exc:
+                _safe_capture_exception(env_exc)
+                try:
+                    logger.error(
+                        "taskworker.error_hook.envelope_failed "
+                        f"task_id={_log_value(task_id)} "
+                        f"internal_error_type={_log_value(_qualified_type(env_exc))} "
+                        f"internal_error_message={_log_value(str(env_exc))}"
+                    )
+                except Exception:
+                    pass
+                return None
+        except Exception as hook_exc:
+            _safe_capture_exception(hook_exc)
+            try:
+                logger.error(
+                    "taskworker.error_hook.failed "
+                    f"internal_error_type={_log_value(_qualified_type(hook_exc))} "
+                    f"internal_error_message={_log_value(str(hook_exc))}"
+                )
+            except Exception:
+                pass
+            return None
 
 
 _producer_local = threading.local()

--- a/src/sentry/taskworker/runtime.py
+++ b/src/sentry/taskworker/runtime.py
@@ -10,6 +10,8 @@ from sentry.taskworker.adapters import (
     make_producer,
 )
 
+from sentry.taskworker.adapters import TaskErrorCaptureHook
+
 app = TaskbrokerApp(
     name="sentry",
     producer_factory=make_producer,
@@ -17,6 +19,7 @@ app = TaskbrokerApp(
     router_class=SentryRouter(),
     at_most_once_store=DjangoCacheAtMostOnceStore(cache),
     context_hooks=[ViewerContextHook()],
+    error_hook=TaskErrorCaptureHook(),
 )
 app.set_config(
     {

--- a/tests/sentry/taskworker/test_error_capture_hook.py
+++ b/tests/sentry/taskworker/test_error_capture_hook.py
@@ -1,0 +1,243 @@
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from sentry.taskworker.adapters import TaskErrorCaptureHook
+
+
+@pytest.fixture
+def task_meta():
+    """Return a representative task metadata object used by the hook."""
+    return SimpleNamespace(
+        id="abc-123",
+        taskname="sentry.tasks.store.save_event",
+        namespace="ingest.errors",
+    )
+
+
+class RootCauseError(Exception):
+    """A helper exception used to test chained root-cause logging."""
+
+
+class FakeOperationalError(Exception):
+    """A fake DB error with a Django-like module path for shape testing."""
+
+
+FakeOperationalError.__module__ = "django.db.utils"
+
+
+def test_envelope_uses_fully_qualified_type(task_meta):
+    """The returned TaskError envelope should use a fully qualified exception type."""
+    hook = TaskErrorCaptureHook()
+    try:
+        raise ValueError("boom")
+    except ValueError as exc:
+        env = hook.on_exception(task_meta, exc)
+
+    assert env is not None
+    assert env.exception_type == "builtins.ValueError"
+    assert env.exception_message == "boom"
+    assert "ValueError: boom" in env.traceback
+
+
+def test_summary_log_contains_task_context_and_exception_fields(task_meta, caplog):
+    """The main ERROR log should be a single-line summary with task and exception fields."""
+    hook = TaskErrorCaptureHook()
+
+    with caplog.at_level("ERROR", logger="sentry.taskworker.adapters"):
+        try:
+            raise ValueError("boom")
+        except ValueError as exc:
+            env = hook.on_exception(task_meta, exc)
+
+    assert env is not None
+    rec = next(r for r in caplog.records if r.message.startswith("taskworker.task_failed "))
+    assert 'task_id="abc-123"' in rec.message
+    assert 'taskname="sentry.tasks.store.save_event"' in rec.message
+    assert 'namespace="ingest.errors"' in rec.message
+    assert 'exception_type="builtins.ValueError"' in rec.message
+    assert 'exception_message="boom"' in rec.message
+    assert 'root_cause_type="builtins.ValueError"' in rec.message
+    assert 'root_cause_message="boom"' in rec.message
+    assert "Traceback (most recent call last)" not in rec.message
+    assert "\n" not in rec.message
+
+
+def test_log_works_outside_active_except_and_envelope_still_has_traceback(task_meta, caplog):
+    """The hook should work outside an active except block and still include traceback in the envelope."""
+    try:
+        raise RuntimeError("boom")
+    except RuntimeError as e:
+        captured = e
+
+    hook = TaskErrorCaptureHook()
+    with caplog.at_level("ERROR", logger="sentry.taskworker.adapters"):
+        env = hook.on_exception(task_meta, captured)
+
+    assert env is not None
+    assert "RuntimeError: boom" in env.traceback
+    rec = next(r for r in caplog.records if r.message.startswith("taskworker.task_failed "))
+    assert 'exception_type="builtins.RuntimeError"' in rec.message
+    assert "Traceback (most recent call last)" not in rec.message
+
+
+def test_summary_log_contains_root_cause_for_chained_exception(task_meta, caplog):
+    """The summary log should include both the top-level exception and the deepest root cause."""
+    hook = TaskErrorCaptureHook()
+
+    try:
+        try:
+            raise RootCauseError("inner boom")
+        except RootCauseError as inner:
+            raise RuntimeError("outer boom") from inner
+    except RuntimeError as exc:
+        with caplog.at_level("ERROR", logger="sentry.taskworker.adapters"):
+            env = hook.on_exception(task_meta, exc)
+
+    assert env is not None
+    rec = next(r for r in caplog.records if r.message.startswith("taskworker.task_failed "))
+    assert 'exception_type="builtins.RuntimeError"' in rec.message
+    assert 'exception_message="outer boom"' in rec.message
+    assert (
+        f'root_cause_type="{RootCauseError.__module__}.{RootCauseError.__qualname__}"'
+        in rec.message
+    )
+    assert 'root_cause_message="inner boom"' in rec.message
+
+
+def test_root_cause_respects_raise_from_none(task_meta, caplog):
+    """Suppressed context from 'raise ... from None' must not appear as the root cause."""
+    hook = TaskErrorCaptureHook()
+
+    try:
+        try:
+            raise ValueError("hidden inner")
+        except ValueError:
+            raise RuntimeError("outer only") from None
+    except RuntimeError as exc:
+        with caplog.at_level("ERROR", logger="sentry.taskworker.adapters"):
+            env = hook.on_exception(task_meta, exc)
+
+    assert env is not None
+    rec = next(r for r in caplog.records if r.message.startswith("taskworker.task_failed "))
+    assert 'exception_type="builtins.RuntimeError"' in rec.message
+    assert 'root_cause_type="builtins.RuntimeError"' in rec.message
+    assert 'root_cause_message="outer only"' in rec.message
+    assert "hidden inner" not in rec.message
+
+
+def test_reproduces_btree_gist_shape(task_meta):
+    """A Django-style database error should preserve a useful type and message in the envelope."""
+    hook = TaskErrorCaptureHook()
+
+    try:
+        raise FakeOperationalError(
+            'could not access file "$libdir/btree_gist": No such file or directory'
+        )
+    except FakeOperationalError as exc:
+        env = hook.on_exception(task_meta, exc)
+
+    assert env is not None
+    assert env.exception_type == "django.db.utils.FakeOperationalError"
+    assert "btree_gist" in env.exception_message
+
+
+def test_capture_exception_called_with_tags(task_meta):
+    """The hook should tag task context on the Sentry isolation scope before capturing."""
+    hook = TaskErrorCaptureHook()
+    with mock.patch("sentry.taskworker.adapters.sentry_sdk") as sdk:
+        scope = sdk.isolation_scope.return_value.__enter__.return_value
+        try:
+            raise RuntimeError("x")
+        except RuntimeError as exc:
+            hook.on_exception(task_meta, exc)
+
+    sdk.capture_exception.assert_called_once()
+    scope.set_tag.assert_any_call("taskname", "sentry.tasks.store.save_event")
+    scope.set_tag.assert_any_call("namespace", "ingest.errors")
+    scope.set_tag.assert_any_call("task_id", "abc-123")
+
+
+def test_message_is_truncated_to_char_limit(task_meta):
+    """The exception message in the envelope should respect the configured character limit."""
+    hook = TaskErrorCaptureHook()
+    big = "x" * 50_000
+    try:
+        raise ValueError(big)
+    except ValueError as exc:
+        env = hook.on_exception(task_meta, exc)
+
+    assert env is not None
+    assert len(env.exception_message) == hook.MAX_MESSAGE_CHARS
+
+
+def test_traceback_is_truncated_to_char_limit(task_meta):
+    """The traceback in the envelope should be truncated to the configured maximum length."""
+    hook = TaskErrorCaptureHook()
+
+    def deep(n):
+        if n == 0:
+            raise RuntimeError("deep")
+        deep(n - 1)
+
+    try:
+        deep(500)
+    except RuntimeError as exc:
+        env = hook.on_exception(task_meta, exc)
+
+    assert env is not None
+    assert len(env.traceback) <= hook.MAX_TRACEBACK_CHARS
+
+
+def test_hook_never_raises_even_if_capture_fails(task_meta):
+    """A Sentry capture failure must not mask the original task exception."""
+    hook = TaskErrorCaptureHook()
+    with mock.patch("sentry.taskworker.adapters.sentry_sdk") as sdk:
+        sdk.capture_exception.side_effect = Exception("sdk broken")
+        try:
+            raise ValueError("original")
+        except ValueError as exc:
+            env = hook.on_exception(task_meta, exc)
+
+    assert env is not None
+    assert env.exception_message == "original"
+
+
+def test_hook_never_raises_even_if_envelope_build_fails(task_meta):
+    """If traceback formatting fails, the hook should return None rather than raise."""
+    hook = TaskErrorCaptureHook()
+    with mock.patch("sentry.taskworker.adapters._traceback.format_exception") as fmt:
+        fmt.side_effect = Exception("traceback broken")
+        try:
+            raise ValueError("original")
+        except ValueError as exc:
+            env = hook.on_exception(task_meta, exc)
+
+    assert env is None
+
+
+def test_hook_never_raises_when_exception_str_is_broken(task_meta):
+    """A broken exception __str__ implementation must not cause the hook to raise."""
+
+    class BrokenStrError(Exception):
+        def __str__(self) -> str:
+            raise RuntimeError("broken __str__")
+
+    hook = TaskErrorCaptureHook()
+    env = hook.on_exception(task_meta, BrokenStrError())
+
+    assert env is None
+
+
+def test_hook_tolerates_missing_task_meta_fields():
+    """The hook should still produce an envelope when task metadata fields are absent."""
+    hook = TaskErrorCaptureHook()
+    minimal = SimpleNamespace()
+    try:
+        raise RuntimeError("x")
+    except RuntimeError as exc:
+        env = hook.on_exception(minimal, exc)
+
+    assert env is not None
+


### PR DESCRIPTION
## Summary

Add a sentry-side `TaskErrorCaptureHook` for taskworker that:

- captures task exceptions to Sentry with task metadata tags
- emits a structured single-line worker log suitable for ingestion by Vector
- returns a bounded `TaskError` envelope to taskbroker-client for broker-side logging

## Dependencies

Depends on:

- getsentry/sentry-protos#215
- getsentry/taskbroker#607

This PR also requires a released `taskbroker-client` version that includes:

- `error_hook`
- worker-side propagation of `TaskError`

## Changes

### Worker hook
- add `TaskErrorCaptureHook` in `src/sentry/taskworker/adapters.py`
- log structured summary on task failure:
  - `task_id`
  - `taskname`
  - `namespace`
  - `exception_type`
  - `exception_message`
  - `root_cause_type`
  - `root_cause_message`
- omit raw traceback from stdout logs
- keep bounded traceback in returned `TaskError`

### Runtime wiring
- wire `TaskErrorCaptureHook()` into `TaskbrokerApp(...)` in `src/sentry/taskworker/runtime.py`

## Why

This makes task failures visible and searchable in three places at once:

- worker logs
- broker logs
- Sentry events

It also keeps worker stdout clean and parseable for log collectors.

## Logging behavior

Expected worker log shape:

`taskworker.task_failed task_id="..." taskname="..." namespace="..." exception_type="..." exception_message="..." root_cause_type="..." root_cause_message="..."`

## Tests

- envelope uses fully qualified exception type
- summary log contains task context and exception fields
- summary log contains root cause for chained exceptions
- `raise ... from None` respects suppressed context
- envelope still contains traceback
- hook does not raise if Sentry capture fails
- hook does not raise if envelope build fails
- hook tolerates missing task metadata fields

## Local validation

Validated locally with a deliberately crashing task:
- worker emitted structured `taskworker.task_failed`
- broker emitted structured `task reported failure`
- task IDs matched across worker and broker
- exception type and message were preserved end-to-end

## Follow-up

Once the companion `taskbroker-client` release is published, `pyproject.toml` should be bumped to that released version before merge.

## Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
