### PR TITLE
fix(supergroups) skip retrieving resolution status and assignee when expensive

### DIFF
--- a/src/sentry/seer/supergroups/endpoints/organization_supergroups_by_group.py
+++ b/src/sentry/seer/supergroups/endpoints/organization_supergroups_by_group.py
@@ -25,6 +25,12 @@ from sentry.users.services.user.service import user_service
 
 logger = logging.getLogger(__name__)
 
+# When the union of group_ids across all supergroups exceeds this, we skip the
+# per-group fan-out: the status filter (which would prune resolved ids from
+# each supergroup) and assignee lookups. Counts/group_ids then reflect what
+# Seer returned, and assignees come back empty.
+_MAX_GROUPS_FOR_FETCH = 100
+
 
 class OrganizationSupergroupsByGroupPermission(OrganizationPermission):
     scope_map = {
@@ -87,11 +93,11 @@ class OrganizationSupergroupsByGroupEndpoint(OrganizationEndpoint):
 
         # Seer returns every group_id in each supergroup regardless of request. We apply any
         # filters from the request after we get the data from Seer.
-        if status_param:
-            all_response_group_ids: list[int] = []
-            for sg in data["data"]:
-                all_response_group_ids.extend(sg["group_ids"])
+        all_response_group_ids = {gid for sg in data["data"] for gid in sg["group_ids"]}
+        if len(all_response_group_ids) > _MAX_GROUPS_FOR_FETCH:
+            return Response({"data": data["data"], "meta": {"estimated": True}})
 
+        if status_param:
             matching_ids = set(
                 Group.objects.filter(
                     id__in=all_response_group_ids,
@@ -104,7 +110,12 @@ class OrganizationSupergroupsByGroupEndpoint(OrganizationEndpoint):
                 sg["group_ids"] = [gid for gid in sg["group_ids"] if gid in matching_ids]
             data["data"] = [sg for sg in data["data"] if sg["group_ids"]]
 
-        return Response({"data": _add_assignees(organization, data["data"])})
+        return Response(
+            {
+                "data": _add_assignees(organization, data["data"]),
+                "meta": {"estimated": False},
+            }
+        )
 
 
 def _add_assignees(

--- a/tests/sentry/seer/supergroups/endpoints/test_organization_supergroups_by_group.py
+++ b/tests/sentry/seer/supergroups/endpoints/test_organization_supergroups_by_group.py
@@ -7,6 +7,7 @@ import orjson
 
 from sentry.models.group import GroupStatus
 from sentry.models.groupassignee import GroupAssignee
+from sentry.seer.supergroups.endpoints import organization_supergroups_by_group
 from sentry.testutils.cases import APITestCase
 
 
@@ -172,6 +173,34 @@ class OrganizationSupergroupsByGroupEndpointTest(APITestCase):
 
         sg = response.data["data"][0]
         assert sg["assignees"] == []
+
+    @patch("sentry.seer.supergroups.by_group.make_supergroups_get_by_group_ids_request")
+    def test_skips_fanout_over_threshold(self, mock_seer):
+        threshold = organization_supergroups_by_group._MAX_GROUPS_FOR_FETCH
+        fake_group_ids = list(range(10_000_000, 10_000_000 + threshold))
+        mock_seer.return_value = mock_seer_response(
+            {
+                "data": [
+                    {
+                        "id": 1,
+                        "group_ids": [self.resolved_group.id, *fake_group_ids],
+                        "title": "too big",
+                    }
+                ]
+            }
+        )
+
+        with self.feature("organizations:top-issues-ui"):
+            response = self.get_success_response(
+                self.organization.slug,
+                group_id=[self.resolved_group.id],
+                status="unresolved",
+            )
+
+        assert response.data["meta"] == {"estimated": True}
+        sg = response.data["data"][0]
+        assert "assignees" not in sg
+        assert self.resolved_group.id in sg["group_ids"]
 
     @patch("sentry.seer.supergroups.by_group.make_supergroups_get_by_group_ids_request")
     def test_assignee_summary_tolerates_missing_actor(self, mock_seer):


### PR DESCRIPTION
When `group_ids` across all supergroups returned by Seer exceeds 100, skip the status filter and assignee lookup and show `meta.estimated=true` in response so callers know counts may include resolved groups and assignees were not resolved. Motivated since we are seeing timeouts for extremely large supergroups on the sentry side.