### PR TITLE
ref(seer): Use seer-night-shift-settings flag for night shift UI

### DIFF
--- a/static/gsApp/views/seerAutomation/projectDetails.tsx
+++ b/static/gsApp/views/seerAutomation/projectDetails.tsx
@@ -87,7 +87,7 @@ function SeerProjectDetails() {
             preference={preference ?? DEFAULT_PREFERENCE}
             project={project}
           />
-          <Feature features="organizations:seer-night-shift">
+          <Feature features="organizations:seer-night-shift-settings">
             <NightShift canWrite={canWrite} project={project} />
           </Feature>
         </Stack>


### PR DESCRIPTION
Switches the `Feature` gate around the project-level NightShift settings panel in `static/gsApp/views/seerAutomation/projectDetails.tsx` from `organizations:seer-night-shift` to the new `organizations:seer-night-shift-settings` flag, so the settings UI can be rolled out independently of the underlying night shift feature.

Agent transcript: https://claudescope.sentry.dev/share/HwA0D1bf46Jml7LO_kcaZROS9c8MsEh7r-Y9NJFYdVs