### PR TITLE
fix(agents): Allow token counts to wrap when space is constrained

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -363,15 +363,18 @@ function HighlightedTokenAttributes({
           <Count value={breakdown.netNewInput} /> {t('in')}
         </Container>
         {hasCached && (
-          <Container display="inline-block">
-            {' + '}
-            <Count value={breakdown.cached} /> {t('cached')}
-          </Container>
-        )}
+          <Fragment>
+            {' '}
+            <Container display="inline-block">
+              {' + '}
+              <Count value={breakdown.cached} /> {t('cached')}
+            </Container>
+          </Fragment>
+        )}{' '}
         <Container display="inline-block">
           {' + '}
           <Count value={breakdown.output} /> {t('out')}
-        </Container>
+        </Container>{' '}
         <Container display="inline-block">
           {' = '}
           <Count value={breakdown.total} /> {t('total')}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -453,5 +453,6 @@ const TokensSpan = styled('span')`
   display: flex;
   align-items: center;
   gap: ${p => p.theme.space.xs};
+  flex-wrap: wrap;
   border-bottom: 1px dashed ${p => p.theme.tokens.border.primary};
 `;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 
 import {Tag} from '@sentry/scraps/badge';
-import {Flex} from '@sentry/scraps/layout';
+import {Container, Flex} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {Count} from 'sentry/components/count';
@@ -359,25 +359,23 @@ function HighlightedTokenAttributes({
       }
     >
       <TokensSpan>
-        <span>
+        <Container display="inline-block">
           <Count value={breakdown.netNewInput} /> {t('in')}
-        </span>
+        </Container>
         {hasCached && (
-          <Fragment>
-            <span>+</span>
-            <span>
-              <Count value={breakdown.cached} /> {t('cached')}
-            </span>
-          </Fragment>
+          <Container display="inline-block">
+            {' + '}
+            <Count value={breakdown.cached} /> {t('cached')}
+          </Container>
         )}
-        <span>+</span>
-        <span>
+        <Container display="inline-block">
+          {' + '}
           <Count value={breakdown.output} /> {t('out')}
-        </span>
-        <span>=</span>
-        <span>
+        </Container>
+        <Container display="inline-block">
+          {' = '}
           <Count value={breakdown.total} /> {t('total')}
-        </span>
+        </Container>
       </TokensSpan>
     </Tooltip>
   );
@@ -453,8 +451,4 @@ const TokensSpan = styled('span')`
   border-bottom: 1px dashed ${p => p.theme.tokens.border.primary};
   -webkit-box-decoration-break: clone;
   box-decoration-break: clone;
-
-  > * + * {
-    margin-left: ${p => p.theme.space.xs};
-  }
 `;

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -359,23 +359,23 @@ function HighlightedTokenAttributes({
       }
     >
       <TokensSpan>
-        <Container display="inline-block">
+        <Container as="span" display="inline-block">
           <Count value={breakdown.netNewInput} /> {t('in')}
         </Container>
         {hasCached && (
           <Fragment>
             {' '}
-            <Container display="inline-block">
+            <Container as="span" display="inline-block">
               {' + '}
               <Count value={breakdown.cached} /> {t('cached')}
             </Container>
           </Fragment>
         )}{' '}
-        <Container display="inline-block">
+        <Container as="span" display="inline-block">
           {' + '}
           <Count value={breakdown.output} /> {t('out')}
         </Container>{' '}
-        <Container display="inline-block">
+        <Container as="span" display="inline-block">
           {' = '}
           <Count value={breakdown.total} /> {t('total')}
         </Container>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -450,9 +450,11 @@ const TokensTooltipTitle = styled('div')`
 `;
 
 const TokensSpan = styled('span')`
-  display: flex;
-  align-items: center;
-  gap: ${p => p.theme.space.xs};
-  flex-wrap: wrap;
   border-bottom: 1px dashed ${p => p.theme.tokens.border.primary};
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
+
+  > * + * {
+    margin-left: ${p => p.theme.space.xs};
+  }
 `;


### PR DESCRIPTION
Use `box-decoration-break: clone` on the token count display so the dashed underline renders continuously across wrapped lines. Each operator-value group (e.g. `+ 1,234 cached`) is wrapped in an inline-block `Container` to ensure line breaks only occur before operators, not mid-token.

**Before**
<img width="386" height="221" alt="Screenshot 2026-04-27 at 11 48 11" src="https://github.com/user-attachments/assets/92369ef0-e237-41e4-bc9d-7f8a837571ec" />


**After**
<img width="386" height="221" alt="Screenshot 2026-04-27 at 11 59 16" src="https://github.com/user-attachments/assets/4c75b2f9-bac3-4f4a-b89c-e546da57ad43" />


Fixes TET-2253