### PR TITLE
ref(forms): Extract shared BackendJsonFieldFromConfig

### DIFF
--- a/static/app/components/backendJsonFormAdapter/backendJsonAutoSaveForm.tsx
+++ b/static/app/components/backendJsonFormAdapter/backendJsonAutoSaveForm.tsx
@@ -5,9 +5,8 @@ import {z} from 'zod';
 import {AutoSaveForm} from '@sentry/scraps/form';
 import {Stack} from '@sentry/scraps/layout';
 
-import {unreachable} from 'sentry/utils/unreachable';
-
 import {ChoiceMapperDropdown, ChoiceMapperTable} from './choiceMapperAdapter';
+import {BackendJsonFieldFromConfig} from './fieldFromConfig';
 import {
   ProjectMapperAddRow,
   ProjectMapperNextButton,
@@ -15,7 +14,7 @@ import {
 } from './projectMapperAdapter';
 import {TableBody, TableHeaderRow} from './tableAdapter';
 import type {FieldValue, JsonFormAdapterFieldConfig} from './types';
-import {getDefaultForField, getZodType, transformChoices} from './utils';
+import {getDefaultForField, getZodType} from './utils';
 
 interface BackendJsonFormAdapterProps<
   TField extends JsonFormAdapterFieldConfig,
@@ -172,85 +171,21 @@ export function BackendJsonAutoSaveForm<
       mutationOptions={mutationOptions}
     >
       {fieldApi => {
-        switch (field.type) {
-          case 'boolean':
-            return (
-              <fieldApi.Layout.Row label={field.label} hintText={field.help}>
-                <fieldApi.Switch
-                  checked={fieldApi.state.value}
-                  onChange={fieldApi.handleChange}
-                  disabled={field.disabled}
-                />
-              </fieldApi.Layout.Row>
-            );
-          case 'textarea':
-            return (
-              <fieldApi.Layout.Row label={field.label} hintText={field.help}>
-                <fieldApi.TextArea
-                  value={fieldApi.state.value}
-                  onChange={fieldApi.handleChange}
-                  placeholder={field.placeholder}
-                  disabled={field.disabled}
-                />
-              </fieldApi.Layout.Row>
-            );
-          case 'number':
-            return (
-              <fieldApi.Layout.Row label={field.label} hintText={field.help}>
-                <fieldApi.Number
-                  value={fieldApi.state.value}
-                  onChange={fieldApi.handleChange}
-                  placeholder={field.placeholder}
-                  disabled={field.disabled}
-                />
-              </fieldApi.Layout.Row>
-            );
-          case 'select':
-          case 'choice':
-            return (
-              <fieldApi.Layout.Row label={field.label} hintText={field.help}>
-                <fieldApi.Select
-                  value={fieldApi.state.value}
-                  onChange={fieldApi.handleChange}
-                  options={transformChoices(field.choices)}
-                  disabled={field.disabled}
-                />
-              </fieldApi.Layout.Row>
-            );
-          case 'secret':
-            return (
-              <fieldApi.Layout.Row label={field.label} hintText={field.help}>
-                <fieldApi.Password
-                  value={fieldApi.state.value}
-                  onChange={fieldApi.handleChange}
-                  placeholder={field.placeholder}
-                  disabled={field.disabled}
-                />
-              </fieldApi.Layout.Row>
-            );
-          case 'string':
-          case 'text':
-          case 'url':
-          case 'email':
-            return (
-              <fieldApi.Layout.Row label={field.label} hintText={field.help}>
-                <fieldApi.Input
-                  value={fieldApi.state.value}
-                  onChange={fieldApi.handleChange}
-                  placeholder={field.placeholder}
-                  disabled={field.disabled}
-                  type={
-                    field.type === 'string' || field.type === 'text' ? 'text' : field.type
-                  }
-                />
-              </fieldApi.Layout.Row>
-            );
-          case 'blank':
-            return null;
-          default:
-            unreachable(field);
-            return null;
+        if (field.type === 'blank') {
+          return null;
         }
+        // Composite cases above already returned. The remaining types are all
+        // simple "label + control" — delegate the control to the shared renderer.
+        return (
+          <fieldApi.Layout.Row label={field.label} hintText={field.help}>
+            <BackendJsonFieldFromConfig
+              field={field}
+              fieldApi={fieldApi}
+              value={fieldApi.state.value}
+              onChange={fieldApi.handleChange}
+            />
+          </fieldApi.Layout.Row>
+        );
       }}
     </AutoSaveForm>
   );

--- a/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
+++ b/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
@@ -15,6 +15,7 @@ import {RequestError} from 'sentry/utils/requestError/requestError';
 import {unreachable} from 'sentry/utils/unreachable';
 
 import {ChoiceMapperDropdown, ChoiceMapperTable} from './choiceMapperAdapter';
+import {BackendJsonFieldFromConfig} from './fieldFromConfig';
 import {ProjectMapperAddRow, ProjectMapperTable} from './projectMapperAdapter';
 import {TableBody, TableHeaderRow} from './tableAdapter';
 import type {JsonFormAdapterFieldConfig} from './types';
@@ -228,35 +229,7 @@ export function BackendJsonSubmitForm({
 
                   switch (field.type) {
                     case 'boolean':
-                      return (
-                        <fieldApi.Layout.Stack
-                          label={field.label}
-                          hintText={field.help}
-                          required={field.required}
-                        >
-                          <fieldApi.Switch
-                            checked={fieldApi.state.value as boolean}
-                            onChange={handleChange}
-                            disabled={field.disabled}
-                          />
-                        </fieldApi.Layout.Stack>
-                      );
                     case 'textarea':
-                      return (
-                        <fieldApi.Layout.Stack
-                          label={field.label}
-                          hintText={field.help}
-                          required={field.required}
-                        >
-                          <fieldApi.TextArea
-                            autosize
-                            value={(fieldApi.state.value as string) ?? ''}
-                            onChange={handleChange}
-                            placeholder={field.placeholder}
-                            disabled={field.disabled}
-                          />
-                        </fieldApi.Layout.Stack>
-                      );
                     case 'number':
                       return (
                         <fieldApi.Layout.Stack
@@ -264,11 +237,12 @@ export function BackendJsonSubmitForm({
                           hintText={field.help}
                           required={field.required}
                         >
-                          <fieldApi.Number
-                            value={fieldApi.state.value as number}
+                          <BackendJsonFieldFromConfig
+                            field={field}
+                            fieldApi={fieldApi}
+                            value={fieldApi.state.value}
                             onChange={handleChange}
-                            placeholder={field.placeholder}
-                            disabled={field.disabled}
+                            autosizeTextarea
                           />
                         </fieldApi.Layout.Stack>
                       );
@@ -407,20 +381,6 @@ export function BackendJsonSubmitForm({
                       );
                     }
                     case 'secret':
-                      return (
-                        <fieldApi.Layout.Stack
-                          label={field.label}
-                          hintText={field.help}
-                          required={field.required}
-                        >
-                          <fieldApi.Password
-                            value={(fieldApi.state.value as string) ?? ''}
-                            onChange={handleChange}
-                            placeholder={field.placeholder}
-                            disabled={field.disabled}
-                          />
-                        </fieldApi.Layout.Stack>
-                      );
                     case 'string':
                     case 'text':
                     case 'url':
@@ -431,16 +391,11 @@ export function BackendJsonSubmitForm({
                           hintText={field.help}
                           required={field.required}
                         >
-                          <fieldApi.Input
-                            value={(fieldApi.state.value as string) ?? ''}
+                          <BackendJsonFieldFromConfig
+                            field={field}
+                            fieldApi={fieldApi}
+                            value={fieldApi.state.value}
                             onChange={handleChange}
-                            placeholder={field.placeholder}
-                            disabled={field.disabled}
-                            type={
-                              field.type === 'string' || field.type === 'text'
-                                ? 'text'
-                                : field.type
-                            }
                           />
                         </fieldApi.Layout.Stack>
                       );

--- a/static/app/components/backendJsonFormAdapter/fieldFromConfig.tsx
+++ b/static/app/components/backendJsonFormAdapter/fieldFromConfig.tsx
@@ -1,0 +1,163 @@
+import type {JsonFormAdapterFieldConfig} from './types';
+import {transformChoices} from './utils';
+
+/**
+ * Subset of `JsonFormAdapterFieldConfig` rendered by `BackendJsonFieldFromConfig`.
+ * Composite fields (`table`, `project_mapper`, `choice_mapper`) and `blank` are
+ * handled inline by each form because their layout differs from the simple
+ * "label + control" pattern. Async select is also handled inline because its
+ * data-fetching wrapper only exists in `BackendJsonSubmitForm`.
+ */
+type SimpleField = Extract<
+  JsonFormAdapterFieldConfig,
+  {
+    type:
+      | 'boolean'
+      | 'string'
+      | 'text'
+      | 'textarea'
+      | 'url'
+      | 'email'
+      | 'secret'
+      | 'number'
+      | 'select'
+      | 'choice';
+  }
+>;
+
+/**
+ * Minimal shape of the field-API used by this renderer. Both `AutoSaveForm`
+ * and `useScrapsForm` + `AppField` provide these components, with slightly
+ * different generic parameters that we erase to `unknown` here so a single
+ * renderer can serve both call sites.
+ */
+interface FieldKit {
+  Input: React.ComponentType<{
+    onChange: (value: string) => void;
+    type: 'text' | 'url' | 'email';
+    value: string;
+    disabled?: boolean;
+    placeholder?: string;
+  }>;
+  Number: React.ComponentType<{
+    onChange: (value: number) => void;
+    value: number;
+    disabled?: boolean;
+    placeholder?: string;
+  }>;
+  Password: React.ComponentType<{
+    onChange: (value: string) => void;
+    value: string;
+    disabled?: boolean;
+    placeholder?: string;
+  }>;
+  Select: React.ComponentType<{
+    onChange: (value: any) => void;
+    options: Array<{label: string; value: string}>;
+    value: any;
+    disabled?: boolean;
+  }>;
+  Switch: React.ComponentType<{
+    checked: boolean;
+    onChange: (value: boolean) => void;
+    disabled?: boolean;
+  }>;
+  TextArea: React.ComponentType<{
+    onChange: (value: string) => void;
+    value: string;
+    autosize?: boolean;
+    disabled?: boolean;
+    placeholder?: string;
+  }>;
+}
+
+interface BackendJsonFieldFromConfigProps {
+  field: SimpleField;
+  fieldApi: FieldKit;
+  onChange: (value: any) => void;
+  value: unknown;
+  /**
+   * Render `<TextArea>` with `autosize`. `BackendJsonSubmitForm` opts in;
+   * `BackendJsonAutoSaveForm` does not.
+   */
+  autosizeTextarea?: boolean;
+}
+
+/**
+ * Renders the input control for a backend-driven JSON form field.
+ *
+ * Returns only the control (no label/hint wrapper) so each form can choose
+ * its own layout — `Layout.Row` for auto-save, `Layout.Stack` with `required`
+ * for submit forms.
+ */
+export function BackendJsonFieldFromConfig({
+  field,
+  fieldApi,
+  value,
+  onChange,
+  autosizeTextarea,
+}: BackendJsonFieldFromConfigProps) {
+  switch (field.type) {
+    case 'boolean':
+      return (
+        <fieldApi.Switch
+          checked={Boolean(value)}
+          onChange={onChange}
+          disabled={field.disabled}
+        />
+      );
+    case 'textarea':
+      return (
+        <fieldApi.TextArea
+          autosize={autosizeTextarea}
+          value={(value as string) ?? ''}
+          onChange={onChange}
+          placeholder={field.placeholder}
+          disabled={field.disabled}
+        />
+      );
+    case 'number':
+      return (
+        <fieldApi.Number
+          value={value as number}
+          onChange={onChange}
+          placeholder={field.placeholder}
+          disabled={field.disabled}
+        />
+      );
+    case 'secret':
+      return (
+        <fieldApi.Password
+          value={(value as string) ?? ''}
+          onChange={onChange}
+          placeholder={field.placeholder}
+          disabled={field.disabled}
+        />
+      );
+    case 'string':
+    case 'text':
+    case 'url':
+    case 'email':
+      return (
+        <fieldApi.Input
+          type={field.type === 'string' || field.type === 'text' ? 'text' : field.type}
+          value={(value as string) ?? ''}
+          onChange={onChange}
+          placeholder={field.placeholder}
+          disabled={field.disabled}
+        />
+      );
+    case 'select':
+    case 'choice':
+      return (
+        <fieldApi.Select
+          value={value}
+          onChange={onChange}
+          options={transformChoices(field.choices)}
+          disabled={field.disabled}
+        />
+      );
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
Pull the per-field-type switch shared by `BackendJsonAutoSaveForm` and `BackendJsonSubmitForm` into a single `BackendJsonFieldFromConfig` component.

The simple cases — `boolean`, `textarea`, `number`, `secret`, `string`/`text`/`url`/`email`, and static `select`/`choice` — now live in one place. Composite cases (`table`, `project_mapper`, `choice_mapper`), async select, and the layout wrappers (`Layout.Row` for auto-save vs `Layout.Stack` with `required` for submit) stay inline because they diverge meaningfully between the two forms.

This is the shared-infrastructure piece of the form-system refactor. Per-area consumer migrations under DE-1008 are mostly done; this consolidates the duplication those migrations introduced so future work has a typed primitive to reuse.

No behavior change: existing adapter and consumer specs pass unchanged.

Refs DE-1057