### PR TITLE
ref: expose function to safeParse an queryKey into our ApiQueryKey schema

### DIFF
--- a/static/app/components/events/autofix/useSeerAcknowledgeMutation.tsx
+++ b/static/app/components/events/autofix/useSeerAcknowledgeMutation.tsx
@@ -1,6 +1,7 @@
 import {useMutation, useQueryClient} from '@tanstack/react-query';
 
 import {promptsUpdate} from 'sentry/actionCreators/prompts';
+import {safeParseQueryKey} from 'sentry/utils/api/apiQueryKey';
 import {useApi} from 'sentry/utils/useApi';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
@@ -29,7 +30,7 @@ export function useSeerAcknowledgeMutation() {
       // Invalidate all group-level autofix setup queries
       queryClient.invalidateQueries({
         predicate: query => {
-          const key = query.queryKey[0];
+          const key = safeParseQueryKey(query.queryKey)?.url;
           return (
             typeof key === 'string' &&
             key.includes(`/organizations/${organization.slug}/issues/`) &&

--- a/static/app/components/feedback/useFeedbackCache.tsx
+++ b/static/app/components/feedback/useFeedbackCache.tsx
@@ -4,6 +4,7 @@ import {useQueryClient} from '@tanstack/react-query';
 import {useFeedbackApiOptions} from 'sentry/components/feedback/useFeedbackApiOptions';
 import {defined} from 'sentry/utils';
 import type {ApiResponse} from 'sentry/utils/api/apiFetch';
+import {safeParseQueryKey} from 'sentry/utils/api/apiQueryKey';
 import type {FeedbackIssue, FeedbackIssueListItem} from 'sentry/utils/feedback/types';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
 import {setApiQueryData} from 'sentry/utils/queryClient';
@@ -16,14 +17,9 @@ type ListCache = {
 };
 
 const issueApiEndpointRegexp = /^\/organizations\/\w+\/issues\/\d+\/$/;
-function isIssueEndpointUrl(query: any) {
-  // v2 keys have metadata at [0] and URL at [1]
-  const key = query.queryKey;
-  const url =
-    typeof key[0] === 'object' && key[0]?.version === 'v2'
-      ? (key[1] ?? '')
-      : (key[0] ?? '');
-  return issueApiEndpointRegexp.test(String(url));
+function isIssueEndpointUrl(query: {queryKey: readonly unknown[]}) {
+  const url = safeParseQueryKey(query.queryKey)?.url;
+  return url !== undefined && issueApiEndpointRegexp.test(url);
 }
 
 export function useFeedbackCache() {

--- a/static/app/utils/api/apiQueryKey.spec.ts
+++ b/static/app/utils/api/apiQueryKey.spec.ts
@@ -1,5 +1,6 @@
 import {
   parseQueryKey,
+  safeParseQueryKey,
   type ApiQueryKey,
   type InfiniteApiQueryKey,
 } from 'sentry/utils/api/apiQueryKey';
@@ -119,6 +120,159 @@ describe('apiQueryKey', () => {
           url: '/api-tokens/',
           options: {query: {filter: 'red'}},
         });
+      });
+    });
+  });
+
+  describe('safeParseQueryKey', () => {
+    describe('happy path', () => {
+      it('parses a v1 query key, without options', () => {
+        expect(safeParseQueryKey(['/api-tokens/'])).toEqual({
+          version: 'v1',
+          isInfinite: false,
+          url: '/api-tokens/',
+          options: undefined,
+        });
+      });
+
+      it('parses a v1 query key, with options', () => {
+        expect(safeParseQueryKey(['/api-tokens/', {query: {filter: 'red'}}])).toEqual({
+          version: 'v1',
+          isInfinite: false,
+          url: '/api-tokens/',
+          options: {query: {filter: 'red'}},
+        });
+      });
+
+      it('parses a v1 infinite query key, without options', () => {
+        expect(
+          safeParseQueryKey([{infinite: true, version: 'v1'}, '/api-tokens/'])
+        ).toEqual({
+          version: 'v1',
+          isInfinite: true,
+          url: '/api-tokens/',
+          options: undefined,
+        });
+      });
+
+      it('parses a v1 infinite query key, with options', () => {
+        expect(
+          safeParseQueryKey([
+            {infinite: true, version: 'v1'},
+            '/api-tokens/',
+            {query: {filter: 'red'}},
+          ])
+        ).toEqual({
+          version: 'v1',
+          isInfinite: true,
+          url: '/api-tokens/',
+          options: {query: {filter: 'red'}},
+        });
+      });
+
+      it('parses a v2 query key, without options', () => {
+        expect(
+          safeParseQueryKey([{infinite: false, version: 'v2'}, '/api-tokens/'])
+        ).toEqual({
+          version: 'v2',
+          isInfinite: false,
+          url: '/api-tokens/',
+          options: undefined,
+        });
+      });
+
+      it('parses a v2 query key, with options', () => {
+        expect(
+          safeParseQueryKey([
+            {infinite: false, version: 'v2'},
+            '/api-tokens/',
+            {query: {filter: 'red'}},
+          ])
+        ).toEqual({
+          version: 'v2',
+          isInfinite: false,
+          url: '/api-tokens/',
+          options: {query: {filter: 'red'}},
+        });
+      });
+
+      it('parses a v2 infinite query key, without options', () => {
+        expect(
+          safeParseQueryKey([{infinite: true, version: 'v2'}, '/api-tokens/'])
+        ).toEqual({
+          version: 'v2',
+          isInfinite: true,
+          url: '/api-tokens/',
+          options: undefined,
+        });
+      });
+
+      it('parses a v2 infinite query key, with options', () => {
+        expect(
+          safeParseQueryKey([
+            {infinite: true, version: 'v2'},
+            '/api-tokens/',
+            {query: {filter: 'red'}},
+          ])
+        ).toEqual({
+          version: 'v2',
+          isInfinite: true,
+          url: '/api-tokens/',
+          options: {query: {filter: 'red'}},
+        });
+      });
+    });
+
+    describe('rejection', () => {
+      it('returns undefined for an empty array', () => {
+        expect(safeParseQueryKey([])).toBeUndefined();
+      });
+
+      it('returns undefined when the first element is a number', () => {
+        expect(safeParseQueryKey([123])).toBeUndefined();
+      });
+
+      it('returns undefined when the first element is null', () => {
+        expect(safeParseQueryKey([null])).toBeUndefined();
+      });
+
+      it('returns undefined for v1 with non-object options', () => {
+        expect(safeParseQueryKey(['/url/', 'not-an-object'])).toBeUndefined();
+      });
+
+      it('returns undefined for an unknown version marker', () => {
+        expect(
+          safeParseQueryKey([{version: 'v3', infinite: false}, '/url/'])
+        ).toBeUndefined();
+      });
+
+      it('returns undefined for v2 missing the url', () => {
+        expect(safeParseQueryKey([{infinite: false, version: 'v2'}])).toBeUndefined();
+      });
+
+      it('returns undefined for v2 with a non-string url', () => {
+        expect(
+          safeParseQueryKey([{infinite: false, version: 'v2'}, 123])
+        ).toBeUndefined();
+      });
+
+      it('returns undefined for an infinite key with non-object options', () => {
+        expect(
+          safeParseQueryKey([{infinite: true, version: 'v1'}, '/url/', 'not-an-object'])
+        ).toBeUndefined();
+      });
+    });
+
+    // The schema validates *shape*, not *intent*. Any [string] or
+    // [string, object] tuple — including non-API TanStack queries that happen
+    // to match — will parse as a V1 key. Predicate callers must still scope by
+    // queryKey filter or check the URL pattern.
+    it('parses any [string, object] tuple as a v1 key', () => {
+      expect(safeParseQueryKey(['filter', {scope: 'feedback'}])).toEqual({
+        version: 'v1',
+        isInfinite: false,
+        url: 'filter',
+        options: {scope: 'feedback'},
       });
     });
   });

--- a/static/app/utils/api/apiQueryKey.ts
+++ b/static/app/utils/api/apiQueryKey.ts
@@ -18,39 +18,57 @@ export type QueryKeyEndpointOptions<
   query?: Query;
 };
 
+const apiUrlSchema = z.custom<ApiUrl>(val => typeof val === 'string');
+const optionsSchema = z.custom<QueryKeyEndpointOptions>(
+  val => typeof val === 'object' && val !== null && !Array.isArray(val)
+);
+
+const v1InfiniteMarkerSchema = z.object({
+  version: z.literal('v1'),
+  infinite: z.literal(true),
+});
+const v2MarkerSchema = z.object({
+  version: z.literal('v2'),
+  infinite: z.literal(false),
+});
+const v2InfiniteMarkerSchema = z.object({
+  version: z.literal('v2'),
+  infinite: z.literal(true),
+});
+
+const v1Schema = z.union([
+  z.tuple([apiUrlSchema]),
+  z.tuple([apiUrlSchema, optionsSchema]),
+]);
+const v1InfiniteSchema = z.union([
+  z.tuple([v1InfiniteMarkerSchema, apiUrlSchema]),
+  z.tuple([v1InfiniteMarkerSchema, apiUrlSchema, optionsSchema]),
+]);
+const v2Schema = z.union([
+  z.tuple([v2MarkerSchema, apiUrlSchema]),
+  z.tuple([v2MarkerSchema, apiUrlSchema, optionsSchema]),
+]);
+const v2InfiniteSchema = z.union([
+  z.tuple([v2InfiniteMarkerSchema, apiUrlSchema]),
+  z.tuple([v2InfiniteMarkerSchema, apiUrlSchema, optionsSchema]),
+]);
+
+// Distributes Readonly<> over a union so each branch becomes a readonly tuple.
+type ReadonlyTuple<T> = T extends readonly unknown[] ? Readonly<T> : never;
+
 /**
  * @deprecated Prefer using `apiOptions.as<T>()(...args)` whenever possible.
  */
-type V1QueryKey =
-  | readonly [url: ApiUrl]
-  | readonly [url: ApiUrl, options: QueryKeyEndpointOptions];
-type V2QueryKey =
-  | readonly [{infinite: false; version: 'v2'}, url: ApiUrl]
-  | readonly [
-      {infinite: false; version: 'v2'},
-      url: ApiUrl,
-      options: QueryKeyEndpointOptions,
-    ];
+type V1QueryKey = ReadonlyTuple<z.infer<typeof v1Schema>>;
+type V2QueryKey = ReadonlyTuple<z.infer<typeof v2Schema>>;
 
 export type ApiQueryKey = V1QueryKey | V2QueryKey;
 
 /**
  * @deprecated Prefer using `apiOptions.asInfinite<T>()(...args)` whenever possible.
  */
-type V1InfiniteQueryKey =
-  | readonly [{infinite: true; version: 'v1'}, url: ApiUrl]
-  | readonly [
-      {infinite: true; version: 'v1'},
-      url: ApiUrl,
-      options: QueryKeyEndpointOptions,
-    ];
-type V2InfiniteQueryKey =
-  | readonly [{infinite: true; version: 'v2'}, url: ApiUrl]
-  | readonly [
-      {infinite: true; version: 'v2'},
-      url: ApiUrl,
-      options: QueryKeyEndpointOptions,
-    ];
+type V1InfiniteQueryKey = ReadonlyTuple<z.infer<typeof v1InfiniteSchema>>;
+type V2InfiniteQueryKey = ReadonlyTuple<z.infer<typeof v2InfiniteSchema>>;
 
 export type InfiniteApiQueryKey = V1InfiniteQueryKey | V2InfiniteQueryKey;
 
@@ -81,81 +99,31 @@ export function parseQueryKey(
     : {version: 'v1', isInfinite: false, url: queryKey[0], options: queryKey[1]};
 }
 
-const optionsSchema = z.custom<QueryKeyEndpointOptions>(
-  val => typeof val === 'object' && val !== null && !Array.isArray(val)
-);
-
-const v1InfiniteMarkerSchema = z.object({
-  version: z.literal('v1'),
-  infinite: z.literal(true),
-});
-const v2NonInfiniteMarkerSchema = z.object({
-  version: z.literal('v2'),
-  infinite: z.literal(false),
-});
-const v2InfiniteMarkerSchema = z.object({
-  version: z.literal('v2'),
-  infinite: z.literal(true),
-});
-
 const queryKeySchema = z.union([
-  z.tuple([z.string()]).transform(([url]) => ({
-    version: 'v1' as const,
-    isInfinite: false,
-    url,
-    options: undefined,
-  })),
-  z.tuple([z.string(), optionsSchema]).transform(([url, options]) => ({
+  v1Schema.transform(([url, options]) => ({
     version: 'v1' as const,
     isInfinite: false,
     url,
     options,
   })),
-
-  z.tuple([v1InfiniteMarkerSchema, z.string()]).transform(([, url]) => ({
+  v1InfiniteSchema.transform(([, url, options]) => ({
     version: 'v1' as const,
     isInfinite: true,
     url,
-    options: undefined,
+    options,
   })),
-  z
-    .tuple([v1InfiniteMarkerSchema, z.string(), optionsSchema])
-    .transform(([, url, options]) => ({
-      version: 'v1' as const,
-      isInfinite: true,
-      url,
-      options,
-    })),
-
-  z.tuple([v2NonInfiniteMarkerSchema, z.string()]).transform(([, url]) => ({
+  v2Schema.transform(([, url, options]) => ({
     version: 'v2' as const,
     isInfinite: false,
     url,
-    options: undefined,
+    options,
   })),
-  z
-    .tuple([v2NonInfiniteMarkerSchema, z.string(), optionsSchema])
-    .transform(([, url, options]) => ({
-      version: 'v2' as const,
-      isInfinite: false,
-      url,
-      options,
-    })),
-
-  z.tuple([v2InfiniteMarkerSchema, z.string()]).transform(([, url]) => ({
+  v2InfiniteSchema.transform(([, url, options]) => ({
     version: 'v2' as const,
     isInfinite: true,
     url,
-    options: undefined,
+    options,
   })),
-  z
-    .tuple([v2InfiniteMarkerSchema, z.string(), optionsSchema])
-    .transform(([, url, options]) => ({
-      version: 'v2' as const,
-      isInfinite: true,
-      url,
-      options,
-    })),
 ]);
 
 type ParsedQueryKey = z.infer<typeof queryKeySchema>;

--- a/static/app/utils/api/apiQueryKey.ts
+++ b/static/app/utils/api/apiQueryKey.ts
@@ -72,33 +72,6 @@ type V2InfiniteQueryKey = ReadonlyTuple<z.infer<typeof v2InfiniteSchema>>;
 
 export type InfiniteApiQueryKey = V1InfiniteQueryKey | V2InfiniteQueryKey;
 
-function isV2QueryKey(
-  queryKey: ApiQueryKey | InfiniteApiQueryKey
-): queryKey is V2QueryKey | V2InfiniteQueryKey {
-  return typeof queryKey[0] === 'object' && queryKey[0].version === 'v2';
-}
-function isInfiniteQueryKey(
-  queryKey: ApiQueryKey | InfiniteApiQueryKey
-): queryKey is V1InfiniteQueryKey | V2InfiniteQueryKey {
-  return typeof queryKey[0] === 'object' && queryKey[0].infinite;
-}
-
-export function parseQueryKey(
-  queryKey: ApiQueryKey | InfiniteApiQueryKey
-): ParsedQueryKey {
-  if (isInfiniteQueryKey(queryKey)) {
-    return {
-      version: isV2QueryKey(queryKey) ? 'v2' : 'v1',
-      isInfinite: true,
-      url: queryKey[1],
-      options: queryKey[2],
-    };
-  }
-  return isV2QueryKey(queryKey)
-    ? {version: 'v2', isInfinite: false, url: queryKey[1], options: queryKey[2]}
-    : {version: 'v1', isInfinite: false, url: queryKey[0], options: queryKey[1]};
-}
-
 const queryKeySchema = z.union([
   v1Schema.transform(([url, options]) => ({
     version: 'v1' as const,
@@ -127,6 +100,12 @@ const queryKeySchema = z.union([
 ]);
 
 type ParsedQueryKey = z.infer<typeof queryKeySchema>;
+
+export function parseQueryKey(
+  queryKey: ApiQueryKey | InfiniteApiQueryKey
+): ParsedQueryKey {
+  return queryKeySchema.parse(queryKey);
+}
 
 export function safeParseQueryKey(
   queryKey: readonly unknown[]

--- a/static/app/utils/api/apiQueryKey.ts
+++ b/static/app/utils/api/apiQueryKey.ts
@@ -1,3 +1,5 @@
+import {z} from 'zod';
+
 import type {getApiUrl} from 'sentry/utils/api/getApiUrl';
 
 export type RequestMethod = 'DELETE' | 'GET' | 'POST' | 'PUT';
@@ -63,7 +65,9 @@ function isInfiniteQueryKey(
   return typeof queryKey[0] === 'object' && queryKey[0].infinite;
 }
 
-export function parseQueryKey(queryKey: ApiQueryKey | InfiniteApiQueryKey) {
+export function parseQueryKey(
+  queryKey: ApiQueryKey | InfiniteApiQueryKey
+): ParsedQueryKey {
   if (isInfiniteQueryKey(queryKey)) {
     return {
       version: isV2QueryKey(queryKey) ? 'v2' : 'v1',
@@ -75,4 +79,89 @@ export function parseQueryKey(queryKey: ApiQueryKey | InfiniteApiQueryKey) {
   return isV2QueryKey(queryKey)
     ? {version: 'v2', isInfinite: false, url: queryKey[1], options: queryKey[2]}
     : {version: 'v1', isInfinite: false, url: queryKey[0], options: queryKey[1]};
+}
+
+const optionsSchema = z.custom<QueryKeyEndpointOptions>(
+  val => typeof val === 'object' && val !== null && !Array.isArray(val)
+);
+
+const v1InfiniteMarkerSchema = z.object({
+  version: z.literal('v1'),
+  infinite: z.literal(true),
+});
+const v2NonInfiniteMarkerSchema = z.object({
+  version: z.literal('v2'),
+  infinite: z.literal(false),
+});
+const v2InfiniteMarkerSchema = z.object({
+  version: z.literal('v2'),
+  infinite: z.literal(true),
+});
+
+const queryKeySchema = z.union([
+  z.tuple([z.string()]).transform(([url]) => ({
+    version: 'v1' as const,
+    isInfinite: false,
+    url,
+    options: undefined,
+  })),
+  z.tuple([z.string(), optionsSchema]).transform(([url, options]) => ({
+    version: 'v1' as const,
+    isInfinite: false,
+    url,
+    options,
+  })),
+
+  z.tuple([v1InfiniteMarkerSchema, z.string()]).transform(([, url]) => ({
+    version: 'v1' as const,
+    isInfinite: true,
+    url,
+    options: undefined,
+  })),
+  z
+    .tuple([v1InfiniteMarkerSchema, z.string(), optionsSchema])
+    .transform(([, url, options]) => ({
+      version: 'v1' as const,
+      isInfinite: true,
+      url,
+      options,
+    })),
+
+  z.tuple([v2NonInfiniteMarkerSchema, z.string()]).transform(([, url]) => ({
+    version: 'v2' as const,
+    isInfinite: false,
+    url,
+    options: undefined,
+  })),
+  z
+    .tuple([v2NonInfiniteMarkerSchema, z.string(), optionsSchema])
+    .transform(([, url, options]) => ({
+      version: 'v2' as const,
+      isInfinite: false,
+      url,
+      options,
+    })),
+
+  z.tuple([v2InfiniteMarkerSchema, z.string()]).transform(([, url]) => ({
+    version: 'v2' as const,
+    isInfinite: true,
+    url,
+    options: undefined,
+  })),
+  z
+    .tuple([v2InfiniteMarkerSchema, z.string(), optionsSchema])
+    .transform(([, url, options]) => ({
+      version: 'v2' as const,
+      isInfinite: true,
+      url,
+      options,
+    })),
+]);
+
+type ParsedQueryKey = z.infer<typeof queryKeySchema>;
+
+export function safeParseQueryKey(
+  queryKey: readonly unknown[]
+): ParsedQueryKey | undefined {
+  return queryKeySchema.safeParse(queryKey).data;
 }

--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -2,6 +2,7 @@ import {useCallback, useMemo} from 'react';
 import {useQueryClient} from '@tanstack/react-query';
 
 import {ALL_ACCESS_PROJECTS} from 'sentry/components/pageFilters/constants';
+import {safeParseQueryKey} from 'sentry/utils/api/apiQueryKey';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useFetchParallelPages} from 'sentry/utils/api/useFetchParallelPages';
 import {useFetchSequentialPages} from 'sentry/utils/api/useFetchSequentialPages';
@@ -276,11 +277,14 @@ export function useReplayData({
     const eventsUrl = `/organizations/${orgSlug}/events/`;
     queryClient.invalidateQueries({
       predicate: query => {
-        const [url, options] = query.queryKey as [
-          string,
-          {query?: {referrer?: string}} | undefined,
-        ];
-        return url === eventsUrl && options?.query?.referrer === 'replay_details';
+        const queryKey = safeParseQueryKey(query.queryKey);
+        if (!queryKey) {
+          return false;
+        }
+        return (
+          queryKey.url === eventsUrl &&
+          queryKey.options?.query?.referrer === 'replay_details'
+        );
       },
     });
   }, [orgSlug, replayId, projectSlug, queryClient]);

--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -24,6 +24,7 @@ import type {PageFilters} from 'sentry/types/core';
 import type {Group} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {safeParseQueryKey} from 'sentry/utils/api/apiQueryKey';
 import {uniq} from 'sentry/utils/array/uniq';
 import {useApi} from 'sentry/utils/useApi';
 import {useMedia} from 'sentry/utils/useMedia';
@@ -317,11 +318,15 @@ export function IssueListActions({
             } else {
               // If we're doing a full query update we invalidate all issue queries to be safe
               queryClient.invalidateQueries({
-                predicate: apiQuery =>
-                  typeof apiQuery.queryKey[0] === 'string' &&
-                  apiQuery.queryKey[0].startsWith(
+                predicate: apiQuery => {
+                  const queryKey = safeParseQueryKey(apiQuery.queryKey);
+                  if (!queryKey) {
+                    return false;
+                  }
+                  return queryKey.url.startsWith(
                     `/organizations/${organization.slug}/issues/`
-                  ),
+                  );
+                },
               });
             }
           },


### PR DESCRIPTION
when used for a `predicate` inside a `QueryFilter`, what we get as input is `unknown[]`. However, our `parseQueryKey` could only pass api query keys of v1 or v2 schema. When queries are created manually without `useApiQuery` (v1) or `apiOptions` (v2) they might not conform to that structure.

Therefore it’s unsafe to use `parseQueryKey` for `predicate` filter functions, and it would also type error.

This PR introduces a `safeParseQueryKey` function that uses a zod schema to safely parse any QueryKey and transforms the various versions into a single, readable structure. It will return `undefined` if the structure doesn’t match.

All places where we did manual `predicate` matching have been updated.