### PR TITLE
feat(seer): Expand Night Shift project settings UI

### DIFF
--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -5,8 +5,19 @@ import type {Organization, Team} from './organization';
 import type {Deploy} from './release';
 import type {DynamicSamplingBias} from './sampling';
 
+export type SeerNightshiftTriageStrategy = 'simple' | 'agentic';
+export type SeerNightshiftIntelligenceLevel = 'low' | 'medium' | 'high';
+export type SeerNightshiftReasoningEffort = 'low' | 'medium' | 'high';
+
 export type SeerNightshiftTweaks = {
+  candidateIssues?: number;
+  dryRun?: boolean;
   enabled?: boolean;
+  extraTriageInstructions?: string;
+  intelligenceLevel?: SeerNightshiftIntelligenceLevel;
+  issueFetchLimit?: number;
+  reasoningEffort?: SeerNightshiftReasoningEffort;
+  triageStrategy?: SeerNightshiftTriageStrategy;
 };
 
 // Minimal project representation for use with avatars.

--- a/static/gsApp/views/seerAutomation/components/projectDetails/nightShift.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectDetails/nightShift.tsx
@@ -1,3 +1,4 @@
+import {useState} from 'react';
 import {useMutation} from '@tanstack/react-query';
 
 import {FeatureBadge} from '@sentry/scraps/badge';
@@ -6,19 +7,57 @@ import {FieldGroup} from '@sentry/scraps/form';
 import {InfoTip} from '@sentry/scraps/info';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
-import {Switch} from '@sentry/scraps/switch';
+import {SegmentedControl} from '@sentry/scraps/segmentedControl';
+import {Slider} from '@sentry/scraps/slider';
 import {Text} from '@sentry/scraps/text';
+import {TextArea} from '@sentry/scraps/textarea';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {t} from 'sentry/locale';
-import type {Project, SeerNightshiftTweaks} from 'sentry/types/project';
+import type {
+  Project,
+  SeerNightshiftIntelligenceLevel,
+  SeerNightshiftReasoningEffort,
+  SeerNightshiftTriageStrategy,
+  SeerNightshiftTweaks,
+} from 'sentry/types/project';
 import {useUpdateProject} from 'sentry/utils/project/useUpdateProject';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
-const DEFAULT_TWEAKS: Required<SeerNightshiftTweaks> = {
-  enabled: false,
-};
+const DEFAULT_CANDIDATE_ISSUES = 10;
+const MIN_CANDIDATE_ISSUES = 1;
+const MAX_CANDIDATE_ISSUES = 100;
+
+const DEFAULT_ISSUE_FETCH_LIMIT = 100;
+const MIN_ISSUE_FETCH_LIMIT = 10;
+const MAX_ISSUE_FETCH_LIMIT = 1000;
+
+type TristateMode = 'default' | 'on' | 'off';
+
+type TriageStrategyChoice = 'default' | SeerNightshiftTriageStrategy;
+type IntelligenceLevelChoice = 'default' | SeerNightshiftIntelligenceLevel;
+type ReasoningEffortChoice = 'default' | SeerNightshiftReasoningEffort;
+
+function toTristateMode(value: boolean | undefined): TristateMode {
+  if (value === true) {
+    return 'on';
+  }
+  if (value === false) {
+    return 'off';
+  }
+  return 'default';
+}
+
+function fromTristateMode(mode: TristateMode): boolean | undefined {
+  if (mode === 'on') {
+    return true;
+  }
+  if (mode === 'off') {
+    return false;
+  }
+  return undefined;
+}
 
 function Row({
   label,
@@ -49,7 +88,7 @@ interface Props {
 
 export function NightShift({canWrite, project}: Props) {
   const organization = useOrganization();
-  const tweaks = {...DEFAULT_TWEAKS, ...project.seerNightshiftTweaks};
+  const tweaks = project.seerNightshiftTweaks ?? ({} as SeerNightshiftTweaks);
 
   const {mutate, isPending} = useUpdateProject(project);
 
@@ -61,6 +100,16 @@ export function NightShift({canWrite, project}: Props) {
       }
     );
 
+  const candidateIssues = tweaks.candidateIssues ?? DEFAULT_CANDIDATE_ISSUES;
+  const [candidateIssuesDraft, setCandidateIssuesDraft] = useState(candidateIssues);
+
+  const issueFetchLimit = tweaks.issueFetchLimit ?? DEFAULT_ISSUE_FETCH_LIMIT;
+  const [issueFetchLimitDraft, setIssueFetchLimitDraft] = useState(issueFetchLimit);
+
+  const [extraInstructionsDraft, setExtraInstructionsDraft] = useState(
+    tweaks.extraTriageInstructions ?? ''
+  );
+
   const {mutate: triggerRun, isPending: isTriggering} = useMutation({
     mutationFn: () =>
       fetchMutation({
@@ -69,6 +118,17 @@ export function NightShift({canWrite, project}: Props) {
       }),
     onSuccess: () => addSuccessMessage(t('Night Shift run started.')),
     onError: () => addErrorMessage(t('Unable to start Night Shift run.')),
+  });
+
+  const {mutate: triggerDryRun, isPending: isDryRunning} = useMutation({
+    mutationFn: () =>
+      fetchMutation({
+        method: 'POST',
+        url: `/projects/${organization.slug}/${project.slug}/seer/night-shift/`,
+        data: {dry_run: true},
+      }),
+    onSuccess: () => addSuccessMessage(t('Night Shift dry run started.')),
+    onError: () => addErrorMessage(t('Unable to start Night Shift dry run.')),
   });
 
   const disabled = !canWrite || isPending;
@@ -91,12 +151,177 @@ export function NightShift({canWrite, project}: Props) {
       <Row
         label={t('Enable Night Shift')}
         hintText={t(
-          'Run Seer on your issues overnight, so fixes are ready when you start your day.'
+          'Run Seer on your issues overnight, so fixes are ready when you start your day. Use "Default" to follow the organization-wide setting.'
         )}
       >
-        <Switch
-          checked={tweaks.enabled}
-          onChange={event => save({...tweaks, enabled: event.target.checked})}
+        <SegmentedControl<TristateMode>
+          aria-label={t('Enable Night Shift')}
+          size="sm"
+          value={toTristateMode(tweaks.enabled)}
+          onChange={mode => save({...tweaks, enabled: fromTristateMode(mode)})}
+          disabled={disabled}
+        >
+          <SegmentedControl.Item key="default">{t('Default')}</SegmentedControl.Item>
+          <SegmentedControl.Item key="on">{t('On')}</SegmentedControl.Item>
+          <SegmentedControl.Item key="off">{t('Off')}</SegmentedControl.Item>
+        </SegmentedControl>
+      </Row>
+      <Row
+        label={t('Dry Run')}
+        hintText={t(
+          'Skip side effects (no fixes posted, no notifications) for scheduled Night Shift runs. Use "Default" to follow the organization-wide setting.'
+        )}
+      >
+        <SegmentedControl<TristateMode>
+          aria-label={t('Dry Run')}
+          size="sm"
+          value={toTristateMode(tweaks.dryRun)}
+          onChange={mode => save({...tweaks, dryRun: fromTristateMode(mode)})}
+          disabled={disabled}
+        >
+          <SegmentedControl.Item key="default">{t('Default')}</SegmentedControl.Item>
+          <SegmentedControl.Item key="on">{t('On')}</SegmentedControl.Item>
+          <SegmentedControl.Item key="off">{t('Off')}</SegmentedControl.Item>
+        </SegmentedControl>
+      </Row>
+      <Row
+        label={t('Candidate Issues')}
+        hintText={t(
+          'Maximum number of issues Night Shift will consider per run for this project.'
+        )}
+      >
+        <Flex align="center" gap="md">
+          <Slider
+            aria-label={t('Candidate Issues')}
+            min={MIN_CANDIDATE_ISSUES}
+            max={MAX_CANDIDATE_ISSUES}
+            step={1}
+            value={candidateIssuesDraft}
+            onChange={setCandidateIssuesDraft}
+            onChangeEnd={value => save({...tweaks, candidateIssues: value})}
+            disabled={disabled}
+          />
+          <Text size="sm" tabular>
+            {candidateIssuesDraft}
+          </Text>
+        </Flex>
+      </Row>
+      <Row
+        label={t('Issue Fetch Limit')}
+        hintText={t(
+          'Maximum number of issues to fetch from the issue list before triage. Larger pools give triage more to choose from but cost more.'
+        )}
+      >
+        <Flex align="center" gap="md">
+          <Slider
+            aria-label={t('Issue Fetch Limit')}
+            min={MIN_ISSUE_FETCH_LIMIT}
+            max={MAX_ISSUE_FETCH_LIMIT}
+            step={10}
+            value={issueFetchLimitDraft}
+            onChange={setIssueFetchLimitDraft}
+            onChangeEnd={value => save({...tweaks, issueFetchLimit: value})}
+            disabled={disabled}
+          />
+          <Text size="sm" tabular>
+            {issueFetchLimitDraft}
+          </Text>
+        </Flex>
+      </Row>
+      <Row
+        label={t('Triage Strategy')}
+        hintText={t(
+          'Choose how Night Shift selects issues to work on. Use "Default" to follow the organization-wide setting.'
+        )}
+      >
+        <SegmentedControl<TriageStrategyChoice>
+          aria-label={t('Triage Strategy')}
+          size="sm"
+          value={tweaks.triageStrategy ?? 'default'}
+          onChange={choice =>
+            save({
+              ...tweaks,
+              triageStrategy: choice === 'default' ? undefined : choice,
+            })
+          }
+          disabled={disabled}
+        >
+          <SegmentedControl.Item key="default">{t('Default')}</SegmentedControl.Item>
+          <SegmentedControl.Item key="simple">{t('Simple')}</SegmentedControl.Item>
+          <SegmentedControl.Item key="agentic">{t('Agentic')}</SegmentedControl.Item>
+        </SegmentedControl>
+      </Row>
+      <Row
+        label={t('Intelligence Level')}
+        hintText={t(
+          'Model intelligence used during triage. Higher levels are more accurate but slower and more expensive.'
+        )}
+      >
+        <SegmentedControl<IntelligenceLevelChoice>
+          aria-label={t('Intelligence Level')}
+          size="sm"
+          value={tweaks.intelligenceLevel ?? 'default'}
+          onChange={choice =>
+            save({
+              ...tweaks,
+              intelligenceLevel: choice === 'default' ? undefined : choice,
+            })
+          }
+          disabled={disabled}
+        >
+          <SegmentedControl.Item key="default">{t('Default')}</SegmentedControl.Item>
+          <SegmentedControl.Item key="low">{t('Low')}</SegmentedControl.Item>
+          <SegmentedControl.Item key="medium">{t('Medium')}</SegmentedControl.Item>
+          <SegmentedControl.Item key="high">{t('High')}</SegmentedControl.Item>
+        </SegmentedControl>
+      </Row>
+      <Row
+        label={t('Reasoning Effort')}
+        hintText={t(
+          'How much reasoning the triage model spends per issue. Higher effort improves quality at the cost of latency and tokens.'
+        )}
+      >
+        <SegmentedControl<ReasoningEffortChoice>
+          aria-label={t('Reasoning Effort')}
+          size="sm"
+          value={tweaks.reasoningEffort ?? 'default'}
+          onChange={choice =>
+            save({
+              ...tweaks,
+              reasoningEffort: choice === 'default' ? undefined : choice,
+            })
+          }
+          disabled={disabled}
+        >
+          <SegmentedControl.Item key="default">{t('Default')}</SegmentedControl.Item>
+          <SegmentedControl.Item key="low">{t('Low')}</SegmentedControl.Item>
+          <SegmentedControl.Item key="medium">{t('Medium')}</SegmentedControl.Item>
+          <SegmentedControl.Item key="high">{t('High')}</SegmentedControl.Item>
+        </SegmentedControl>
+      </Row>
+      <Row
+        label={t('Extra Triage Instructions')}
+        hintText={t(
+          'Additional context appended to the triage prompt. Use to bias Night Shift toward specific kinds of issues for this project.'
+        )}
+      >
+        <TextArea
+          aria-label={t('Extra Triage Instructions')}
+          rows={3}
+          autosize
+          maxRows={8}
+          value={extraInstructionsDraft}
+          onChange={event => setExtraInstructionsDraft(event.target.value)}
+          onBlur={event => {
+            const value = event.target.value;
+            if (value === (tweaks.extraTriageInstructions ?? '')) {
+              return;
+            }
+            save({
+              ...tweaks,
+              extraTriageInstructions: value === '' ? undefined : value,
+            });
+          }}
           disabled={disabled}
         />
       </Row>
@@ -114,14 +339,23 @@ export function NightShift({canWrite, project}: Props) {
           'Kick off a one-off Night Shift run against this project to preview behavior.'
         )}
       >
-        <Button
-          priority="primary"
-          disabled={!canWrite || isTriggering}
-          busy={isTriggering}
-          onClick={() => triggerRun()}
-        >
-          {t('Run Now')}
-        </Button>
+        <Flex gap="sm">
+          <Button
+            priority="primary"
+            disabled={!canWrite || isTriggering || isDryRunning}
+            busy={isTriggering}
+            onClick={() => triggerRun()}
+          >
+            {t('Run Now')}
+          </Button>
+          <Button
+            disabled={!canWrite || isTriggering || isDryRunning}
+            busy={isDryRunning}
+            onClick={() => triggerDryRun()}
+          >
+            {t('Dry Run')}
+          </Button>
+        </Flex>
       </Row>
     </FieldGroup>
   );


### PR DESCRIPTION
Expand the Night Shift section of project Seer settings with the controls
needed to exercise the alpha end-to-end.

Original tristate / slider controls:

- Replace the enabled `Switch` with a tristate (`Default` / `On` / `Off`)
  so per-project settings can fall back to the org-wide configuration
  by clearing the override.
- Add a matching tristate for `dryRun`, which causes scheduled Night
  Shift runs to skip side effects.
- Add a slider for `candidateIssues` — the maximum number of issues a
  scheduled run will consider for the project (1–100, defaults to 10
  to mirror `seer.night_shift.issues_per_org`).
- Add a `Dry Run` button next to `Run Now` for a one-off preview
  trigger; it POSTs `{dry_run: true}` to the existing
  `seer/night-shift/` endpoint.

Experiment tweaks wired up to the new fields on the backend
`NightShiftTweaks` model (chromy/2026-04-27-nightshift-tweaks-backend):

- `issueFetchLimit` slider (10–1000, step 10) for the pre-triage issue
  pool size.
- `triageStrategy` segmented control (Default / Simple / Agentic).
- `intelligenceLevel` segmented control (Default / Low / Medium / High).
- `reasoningEffort` segmented control (Default / Low / Medium / High).
- `extraTriageInstructions` autosizing `TextArea`, persisted on blur.

All choice fields use a "Default = undefined" convention, so unset values
serialize as omitted keys and fall through to backend defaults.

The previous `dryrun` field was renamed to `dryRun` to match the camelCase
JSON produced by the backend's `snake_to_camel_case` alias generator.

Agent transcript: https://claudescope.sentry.dev/share/16bVp1MT2rGMLskudnsjUtmK9wpQnoQKITrVmPzTrBE