### PR TITLE
feat(seer): Add experiment tweaks to NightShiftTweaks model

### DIFF
--- a/src/sentry/tasks/seer/night_shift/tweaks.py
+++ b/src/sentry/tasks/seer/night_shift/tweaks.py
@@ -1,17 +1,34 @@
 from __future__ import annotations
 
+from typing import Literal
+
 import pydantic
 import sentry_sdk
 
 from sentry import options
+from sentry.api.serializers.rest_framework.base import snake_to_camel_case
 from sentry.models.project import Project
+
+TriageStrategy = Literal["simple", "agentic"]
+IntelligenceLevel = Literal["low", "medium", "high"]
+ReasoningEffort = Literal["low", "medium", "high"]
 
 
 class NightShiftTweaks(pydantic.BaseModel):
     enabled: bool = False
+    dry_run: bool = False
     candidate_issues: int = pydantic.Field(
         default_factory=lambda: options.get("seer.night_shift.issues_per_org")
     )
+    triage_strategy: TriageStrategy = "agentic"
+    extra_triage_instructions: str = ""
+    intelligence_level: IntelligenceLevel = "high"
+    reasoning_effort: ReasoningEffort = "high"
+    issue_fetch_limit: int = 100
+
+    class Config:
+        alias_generator = snake_to_camel_case
+        allow_population_by_field_name = True
 
 
 def get_night_shift_tweaks(project: Project) -> NightShiftTweaks:


### PR DESCRIPTION
Expose `dry_run`, `triage_strategy`, `extra_triage_instructions`, `intelligence_level`, `reasoning_effort`, and `issue_fetch_limit` as fields on the per-project `NightShiftTweaks` model so we can experiment with run behavior from project settings without backend changes.

Defaults match the values currently hardcoded in `night_shift/cron.py`, `agentic_triage.py`, and `simple_triage.py`, so this is a no-op until something is actually set on a project.

Also wires a model-wide `alias_generator = snake_to_camel_case` (with `allow_population_by_field_name = True`) so the JSON stored in the project option keeps camelCase keys to match the frontend (`SeerNightshiftTweaks` in `static/app/types/project.tsx`) while Python fields stay snake_case. This avoids per-field `Field(alias=...)` boilerplate.

The call sites in `night_shift/cron.py`, `agentic_triage.py`, and `simple_triage.py` still need to be updated to actually consume these tweaks — that'll come in a follow-up.

Frontend wiring (tristate slider, dry-run toggle, candidate-issues slider) lives on `chromy/feat/nightshift-settings-tristate-slider` and ships as a separate PR per the frontend/backend split rule.


Agent transcript: https://claudescope.sentry.dev/share/rSNykY75s4Osv_IrLCFGz01GGsr_jpRf2z10ye967ic