### PR TITLE
feat(preprod): Add only-if-diff toggle for snapshot PR comments (EME-1046)

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -1225,6 +1225,9 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
             "sentry:preprod_snapshot_pr_comments_enabled": self.get_value_with_default(
                 attrs, "sentry:preprod_snapshot_pr_comments_enabled"
             ),
+            "sentry:preprod_snapshot_pr_comments_only_if_diff": self.get_value_with_default(
+                attrs, "sentry:preprod_snapshot_pr_comments_only_if_diff"
+            ),
         }
 
     def get_value_with_default(self, attrs, key):

--- a/src/sentry/core/endpoints/project_details.py
+++ b/src/sentry/core/endpoints/project_details.py
@@ -121,6 +121,7 @@ class ProjectMemberSerializer(serializers.Serializer):
         required=False, allow_null=True
     )
     preprodSnapshotPrCommentsEnabled = serializers.BooleanField(required=False, allow_null=True)
+    preprodSnapshotPrCommentsOnlyIfDiff = serializers.BooleanField(required=False, allow_null=True)
     preprodSizeEnabledQuery = serializers.CharField(required=False, allow_null=True)
     preprodDistributionEnabledQuery = serializers.CharField(required=False, allow_null=True)
 
@@ -171,6 +172,7 @@ class ProjectMemberSerializer(serializers.Serializer):
         "preprodSnapshotStatusChecksFailOnRemoved",
         "preprodDistributionPrCommentsEnabledByCustomer",
         "preprodSnapshotPrCommentsEnabled",
+        "preprodSnapshotPrCommentsOnlyIfDiff",
     ]
 )
 class ProjectAdminSerializer(ProjectMemberSerializer):
@@ -908,6 +910,14 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
             ):
                 changed_proj_settings["sentry:preprod_snapshot_pr_comments_enabled"] = result[
                     "preprodSnapshotPrCommentsEnabled"
+                ]
+        if "preprodSnapshotPrCommentsOnlyIfDiff" in result:
+            if project.update_option(
+                "sentry:preprod_snapshot_pr_comments_only_if_diff",
+                result["preprodSnapshotPrCommentsOnlyIfDiff"],
+            ):
+                changed_proj_settings["sentry:preprod_snapshot_pr_comments_only_if_diff"] = result[
+                    "preprodSnapshotPrCommentsOnlyIfDiff"
                 ]
         if "debugFilesRole" in result:
             if result["debugFilesRole"] is None:

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -80,6 +80,7 @@ OPTION_KEYS = frozenset(
         "sentry:preprod_snapshot_status_checks_fail_on_removed",
         "sentry:preprod_distribution_pr_comments_enabled_by_customer",
         "sentry:preprod_snapshot_pr_comments_enabled",
+        "sentry:preprod_snapshot_pr_comments_only_if_diff",
         "sentry:scm_source_context_enabled",
         "quotas:spike-protection-disabled",
         "feedback:branding",

--- a/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
@@ -26,6 +26,7 @@ from sentry.taskworker.namespaces import preprod_tasks
 logger = logging.getLogger(__name__)
 
 ENABLED_OPTION_KEY = "sentry:preprod_snapshot_pr_comments_enabled"
+ONLY_IF_DIFF_OPTION_KEY = "sentry:preprod_snapshot_pr_comments_only_if_diff"
 FEATURE_FLAG = "organizations:preprod-snapshot-pr-comments"
 
 
@@ -164,6 +165,13 @@ def create_preprod_snapshot_pr_comment_task(
             fail_on_added=fail_on_added,
             fail_on_removed=fail_on_removed,
         )
+
+        if artifact.project.get_option(ONLY_IF_DIFF_OPTION_KEY) and not any(changes_map.values()):
+            logger.info(
+                "preprod.snapshot_pr_comments.create.skipped_no_diff",
+                extra={"artifact_id": artifact.id},
+            )
+            return
 
         comment_body = format_snapshot_pr_comment(
             all_artifacts,

--- a/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
@@ -166,12 +166,20 @@ def create_preprod_snapshot_pr_comment_task(
             fail_on_removed=fail_on_removed,
         )
 
-        if artifact.project.get_option(ONLY_IF_DIFF_OPTION_KEY) and not any(changes_map.values()):
-            logger.info(
-                "preprod.snapshot_pr_comments.create.skipped_no_diff",
-                extra={"artifact_id": artifact.id},
+        if artifact.project.get_option(ONLY_IF_DIFF_OPTION_KEY):
+            has_changes = any(changes_map.values())
+            # Failed comparisons are absent from changes_map (which only tracks
+            # SUCCESS state), so check comparisons_map directly to avoid
+            # suppressing failure reports.
+            has_failures = any(
+                c.state == PreprodSnapshotComparison.State.FAILED for c in comparisons_map.values()
             )
-            return
+            if not has_changes and not has_failures:
+                logger.info(
+                    "preprod.snapshot_pr_comments.create.skipped_no_diff",
+                    extra={"artifact_id": artifact.id},
+                )
+                return
 
         comment_body = format_snapshot_pr_comment(
             all_artifacts,

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -228,5 +228,8 @@ register(key="sentry:preprod_distribution_pr_comments_enabled_by_customer", defa
 # Boolean to enable/disable snapshot PR comments for this project.
 register(key="sentry:preprod_snapshot_pr_comments_enabled", default=False)
 
+# When True, only post snapshot PR comments if the comparison reports any diffs.
+register(key="sentry:preprod_snapshot_pr_comments_only_if_diff", default=False)
+
 # Whether to enable on-demand source context fetching from SCM integrations
 register(key="sentry:scm_source_context_enabled", default=False)

--- a/tests/sentry/core/endpoints/test_project_details.py
+++ b/tests/sentry/core/endpoints/test_project_details.py
@@ -813,6 +813,13 @@ class ProjectUpdateTest(APITestCase):
         project = Project.objects.get(id=self.project.id)
         assert project.get_option("sentry:preprod_snapshot_pr_comments_enabled") is False
 
+    def test_preprod_snapshot_pr_comments_only_if_diff_option(self) -> None:
+        self.get_success_response(
+            self.org_slug, self.proj_slug, preprodSnapshotPrCommentsOnlyIfDiff=True
+        )
+        project = Project.objects.get(id=self.project.id)
+        assert project.get_option("sentry:preprod_snapshot_pr_comments_only_if_diff") is True
+
     def test_bookmarks(self) -> None:
         self.get_success_response(self.org_slug, self.proj_slug, isBookmarked="false")
         assert not ProjectBookmark.objects.filter(

--- a/tests/sentry/preprod/vcs/pr_comments/test_snapshot_tasks.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_snapshot_tasks.py
@@ -215,6 +215,42 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
 
         mock_get_client.assert_not_called()
 
+    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.format_snapshot_pr_comment")
+    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.get_commit_context_client")
+    def test_skips_when_only_if_diff_enabled_and_no_changes(self, mock_get_client, mock_format):
+        mock_client = Mock()
+        mock_get_client.return_value = mock_client
+        self.project.update_option("sentry:preprod_snapshot_pr_comments_only_if_diff", True)
+
+        artifact, metrics = self._create_artifact_with_metrics()
+
+        with self.feature(self._feature):
+            create_preprod_snapshot_pr_comment_task(artifact.id)
+
+        mock_client.create_comment.assert_not_called()
+        mock_client.update_comment.assert_not_called()
+        mock_format.assert_not_called()
+
+    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.build_changes_map")
+    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.format_snapshot_pr_comment")
+    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.get_commit_context_client")
+    def test_posts_when_only_if_diff_enabled_and_has_changes(
+        self, mock_get_client, mock_format, mock_build_changes_map
+    ):
+        mock_client = Mock()
+        mock_client.create_comment.return_value = {"id": 12345}
+        mock_get_client.return_value = mock_client
+        mock_format.return_value = "body"
+        self.project.update_option("sentry:preprod_snapshot_pr_comments_only_if_diff", True)
+
+        artifact, metrics = self._create_artifact_with_metrics()
+        mock_build_changes_map.return_value = {artifact.id: True}
+
+        with self.feature(self._feature):
+            create_preprod_snapshot_pr_comment_task(artifact.id)
+
+        mock_client.create_comment.assert_called_once()
+
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.get_commit_context_client")
     def test_skips_when_feature_flag_disabled(self, mock_get_client):
         artifact, metrics = self._create_artifact_with_metrics()

--- a/tests/sentry/preprod/vcs/pr_comments/test_snapshot_tasks.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_snapshot_tasks.py
@@ -8,7 +8,7 @@ import pytest
 from sentry.models.commitcomparison import CommitComparison
 from sentry.models.repository import Repository
 from sentry.preprod.models import PreprodArtifact
-from sentry.preprod.snapshots.models import PreprodSnapshotMetrics
+from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
 from sentry.preprod.vcs.pr_comments.snapshot_tasks import create_preprod_snapshot_pr_comment_task
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.testutils.cases import TestCase
@@ -230,6 +230,32 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
         mock_client.create_comment.assert_not_called()
         mock_client.update_comment.assert_not_called()
         mock_format.assert_not_called()
+
+    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.format_snapshot_pr_comment")
+    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.get_commit_context_client")
+    def test_posts_when_only_if_diff_enabled_and_comparison_failed(
+        self, mock_get_client, mock_format
+    ):
+        mock_client = Mock()
+        mock_client.create_comment.return_value = {"id": 67890}
+        mock_get_client.return_value = mock_client
+        mock_format.return_value = "body"
+        self.project.update_option("sentry:preprod_snapshot_pr_comments_only_if_diff", True)
+
+        artifact, metrics = self._create_artifact_with_metrics()
+        base_artifact, base_metrics = self._create_artifact_with_metrics(
+            with_commit_comparison=False, app_id="com.example.base"
+        )
+        PreprodSnapshotComparison.objects.create(
+            head_snapshot_metrics=metrics,
+            base_snapshot_metrics=base_metrics,
+            state=PreprodSnapshotComparison.State.FAILED,
+        )
+
+        with self.feature(self._feature):
+            create_preprod_snapshot_pr_comment_task(artifact.id)
+
+        mock_client.create_comment.assert_called_once()
 
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.build_changes_map")
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.format_snapshot_pr_comment")


### PR DESCRIPTION
## What

Adds a second per-project option, `sentry:preprod_snapshot_pr_comments_only_if_diff` (default `False`), surfaced as `preprodSnapshotPrCommentsOnlyIfDiff` on the project details API. When enabled, `create_preprod_snapshot_pr_comment_task` short-circuits before posting if the comparison reports no changes across any sibling artifact for the PR.

## Why

EME-1046. Today the only knob is "PR comments on/off". Some teams want the comment to appear only when there is something interesting to look at, so they can keep PR comments enabled by default without flooding no-op PRs.