### PR TITLE
feat(seer): Allow manual night shift runs to be dry runs

### DIFF
--- a/src/sentry/seer/endpoints/project_seer_night_shift.py
+++ b/src/sentry/seer/endpoints/project_seer_night_shift.py
@@ -25,5 +25,10 @@ class ProjectSeerNightShiftEndpoint(ProjectEndpoint):
         if not features.has("organizations:seer-night-shift", project.organization):
             raise NotFound
 
-        run_night_shift_for_project.apply_async(args=[project.id])
+        dry_run = bool(request.data.get("dryRun", False))
+
+        run_night_shift_for_project.apply_async(
+            args=[project.id],
+            kwargs={"dry_run": dry_run},
+        )
         return Response(status=202)

--- a/tests/sentry/seer/endpoints/test_project_seer_night_shift.py
+++ b/tests/sentry/seer/endpoints/test_project_seer_night_shift.py
@@ -23,7 +23,27 @@ class ProjectSeerNightShiftTest(APITestCase):
                 status_code=202,
             )
 
-        mock_task.apply_async.assert_called_once_with(args=[self.project.id])
+        mock_task.apply_async.assert_called_once_with(
+            args=[self.project.id],
+            kwargs={"dry_run": False},
+        )
+
+    @with_feature("organizations:seer-night-shift")
+    def test_triggers_task_with_dry_run(self) -> None:
+        with patch(
+            "sentry.seer.endpoints.project_seer_night_shift.run_night_shift_for_project"
+        ) as mock_task:
+            self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                dryRun=True,
+                status_code=202,
+            )
+
+        mock_task.apply_async.assert_called_once_with(
+            args=[self.project.id],
+            kwargs={"dry_run": True},
+        )
 
     def test_without_feature_returns_404(self) -> None:
         with patch(


### PR DESCRIPTION
Add an optional `dryRun` body parameter to the project Run Now endpoint
(`POST /projects/{org}/{project}/seer/night-shift/`). When set, the
endpoint forwards `dry_run=True` to `run_night_shift_for_project`, which
already supports the flag — the run records candidate triage decisions
but skips dispatching autofix.

Useful for previewing what the manual run would do without side effects.