### PR TITLE
feat(tracemetrics): Strip equation prefix from occurrence title

### DIFF
--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -6,9 +6,8 @@ from enum import StrEnum
 from typing import Any, Literal, TypedDict
 
 from sentry import features
-from sentry.api.serializers.rest_framework.dashboard import is_equation
 from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS
-from sentry.discover.arithmetic import strip_equation
+from sentry.discover.arithmetic import is_equation, strip_equation
 from sentry.incidents.handlers.condition import *  # noqa
 from sentry.incidents.metric_issue_detector import MetricIssueDetectorValidator
 from sentry.incidents.models.alert_rule import AlertRuleDetectionType, ComparisonDeltaChoices

--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -6,7 +6,9 @@ from enum import StrEnum
 from typing import Any, Literal, TypedDict
 
 from sentry import features
+from sentry.api.serializers.rest_framework.dashboard import is_equation
 from sentry.constants import CRASH_RATE_ALERT_AGGREGATE_ALIAS
+from sentry.discover.arithmetic import strip_equation
 from sentry.incidents.handlers.condition import *  # noqa
 from sentry.incidents.metric_issue_detector import MetricIssueDetectorValidator
 from sentry.incidents.models.alert_rule import AlertRuleDetectionType, ComparisonDeltaChoices
@@ -282,6 +284,8 @@ class MetricIssueDetectorHandler(StatefulDetectorHandler[MetricUpdate, MetricRes
 
         if is_mri_field(agg_display_key):
             aggregate = format_mri_field(agg_display_key)
+        elif is_equation(agg_display_key):
+            aggregate = strip_equation(agg_display_key)
         elif CRASH_RATE_ALERT_AGGREGATE_ALIAS in agg_display_key:
             agg_display_key = agg_display_key.split(f"AS {CRASH_RATE_ALERT_AGGREGATE_ALIAS}")[
                 0

--- a/tests/sentry/incidents/test_metric_issue_detector_handler.py
+++ b/tests/sentry/incidents/test_metric_issue_detector_handler.py
@@ -216,6 +216,20 @@ class TestConstructTitle(TestEvaluateMetricDetector):
             == f"Critical: Crash free session rate in the last minute above {self.critical_detector_trigger.comparison}"
         )
 
+    def test_title_equation_aggregate(self) -> None:
+        self.snuba_query.aggregate = (
+            'equation|count_if(`agent_name:"Agent Run"`,value,metric_name,distribution,none) * 2'
+        )
+        title = self.handler.construct_title(
+            snuba_query=self.snuba_query,
+            detector_trigger=self.critical_detector_trigger,
+            priority=self.critical_detector_trigger.condition_result,
+        )
+        assert (
+            title
+            == f'Critical: count_if(`agent_name:"Agent Run"`,value,metric_name,distribution,none) * 2 in the last minute above {self.critical_detector_trigger.comparison}'
+        )
+
     def test_dynamic_alert_title(self) -> None:
         self.detector.config.update({"detection_type": "dynamic"})
         self.snuba_query.aggregate = "count_unique(user)"
@@ -244,6 +258,19 @@ class TestConstructTitle(TestEvaluateMetricDetector):
             priority=self.critical_detector_trigger.condition_result,
         )
         assert title == "Detected an anomaly in the query for default_aggregate"
+
+    def test_dynamic_alert_title_equation(self) -> None:
+        self.detector.config.update({"detection_type": "dynamic"})
+        self.snuba_query.aggregate = (
+            'equation|count_if(`agent_name:"Agent Run"`,value,metric_name,distribution,none) * 2'
+        )
+        self.snuba_query.dataset = Dataset.EventsAnalyticsPlatform.value
+        title = self.handler.construct_title(
+            snuba_query=self.snuba_query,
+            detector_trigger=self.critical_detector_trigger,
+            priority=self.critical_detector_trigger.condition_result,
+        )
+        assert title == "Detected an anomaly in the query for eap_metrics"
 
 
 class TestGetAnomalyDetectionIssueTitle(TestCase):
@@ -349,6 +376,13 @@ class TestGetAnomalyDetectionIssueTitle(TestCase):
         assert (
             get_alert_type_from_aggregate_dataset(
                 "count(metric.name,metric_name_two,distribution,-)",
+                Dataset.EventsAnalyticsPlatform,
+            )
+            == "eap_metrics"
+        )
+        assert (
+            get_alert_type_from_aggregate_dataset(
+                'equation|count_if(`agent_name:"Agent Run"`,value,metric_name,distribution,none) * 2',
                 Dataset.EventsAnalyticsPlatform,
             )
             == "eap_metrics"


### PR DESCRIPTION
Since we commit the occurrence title as the issue's message, remove the `equation|` prefix of the aggregate from the title. All other de-facto aggregate fields (i.e. fields that _only_ render the aggregate) are okay to save `equation|...` to avoid making any big changes to the data at the moment.

The frontend can handle rendering the correct label when we know it's an aggregate field. We'd just have trouble doing it cleanly for formatted strings like issue titles