### PR TITLE
ref(api): Tighten accept-invite cleanup-delete path

### DIFF
--- a/src/sentry/api/invite_helper.py
+++ b/src/sentry/api/invite_helper.py
@@ -207,7 +207,9 @@ class ApiInviteHelper:
     def member_already_exists(self) -> bool:
         if not self.user_authenticated:
             return False
-        return self.invite_context.user_id is not None
+        # Must match the authenticated request user — not merely "the resolved
+        # member has some user_id".
+        return self.invite_context.user_id == self.request.user.id
 
     @property
     def valid_request(self) -> bool:
@@ -225,7 +227,7 @@ class ApiInviteHelper:
 
         if self.member_already_exists:
             self.handle_member_already_exists()
-            if self.invite_context.invite_organization_member_id is not None:
+            if self._valid_cleanup_target():
                 organization_service.delete_organization_member(
                     organization_member_id=self.invite_context.invite_organization_member_id,
                     organization_id=self.invite_context.organization.id,
@@ -273,6 +275,41 @@ class ApiInviteHelper:
         )
 
         return member
+
+    def _valid_cleanup_target(self) -> bool:
+        """
+        Authorize the stale-invite cleanup-delete branch of ``accept_invite``.
+
+        When the authenticated user is already a member of the org, the helper
+        may delete the OrganizationMember referenced by the URL (a stale
+        pending invite). To prevent a logged-in user from using this path to
+        delete arbitrary members, require that the caller holds a token
+        matching that specific pending invite.
+
+        ``self.invite_context.member`` is the current user's own OM in this
+        branch — not the invite — so we re-fetch the OM at
+        ``invite_organization_member_id`` (no user_id scoping) to read the
+        invite's own token.
+        """
+        if self.token is None:
+            return False
+        invite_om_id = self.invite_context.invite_organization_member_id
+        if invite_om_id is None:
+            return False
+
+        invite_context = organization_service.get_invite_by_id(
+            organization_id=self.invite_context.organization.id,
+            organization_member_id=invite_om_id,
+        )
+        if invite_context is None or invite_context.member is None:
+            return False
+        invite_om = invite_context.member
+        if not invite_om.is_pending or invite_om.token_expired:
+            return False
+        return constant_time_compare(
+            invite_om.token or invite_om.legacy_token,
+            self.token,
+        )
 
     def _needs_2fa(self) -> bool:
         org_requires_2fa = self.invite_context.organization.flags.require_2fa

--- a/src/sentry/users/api/endpoints/user_authenticator_enroll.py
+++ b/src/sentry/users/api/endpoints/user_authenticator_enroll.py
@@ -20,7 +20,6 @@ from sentry.auth.authenticators.base import EnrollmentStatus, NewEnrollmentDisal
 from sentry.auth.authenticators.sms import SmsInterface, SMSRateLimitExceeded
 from sentry.auth.authenticators.totp import TotpInterface
 from sentry.auth.authenticators.u2f import U2fInterface
-from sentry.organizations.services.organization import organization_service
 from sentry.security.utils import capture_security_activity
 from sentry.users.api.bases.user import UserEndpoint
 from sentry.users.api.serializers.authenticator import get_interface_serializer
@@ -321,16 +320,8 @@ class UserAuthenticatorEnrollEndpoint(UserEndpoint):
         )
         invite_helper = ApiInviteHelper.from_session(request=request, logger=logger)
 
-        if invite_helper:
-            if invite_helper.member_already_exists:
-                invite_helper.handle_member_already_exists()
-                organization_service.delete_organization_member(
-                    organization_member_id=invite_helper.invite_context.invite_organization_member_id,
-                    organization_id=invite_helper.invite_context.organization.id,
-                )
-                remove_invite_details_from_session(request)
-            elif invite_helper.valid_request:
-                invite_helper.accept_invite(user)
-                remove_invite_details_from_session(request)
+        if invite_helper and (invite_helper.member_already_exists or invite_helper.valid_request):
+            invite_helper.accept_invite(user)
+            remove_invite_details_from_session(request)
 
         return response

--- a/tests/sentry/api/endpoints/test_accept_organization_invite.py
+++ b/tests/sentry/api/endpoints/test_accept_organization_invite.py
@@ -349,6 +349,70 @@ class AcceptInviteTest(TestCase, HybridCloudTestMixin):
             assert OrganizationMember.objects.filter(id=other_om.id).exists()
         self.assert_org_member_mapping(org_member=other_om)
 
+    def test_non_member_cannot_delete_other_members_membership(self) -> None:
+        attacker = self.create_user("attacker@example.com")
+        self.login_as(attacker)
+
+        victim = self.create_user("victim@example.com")
+        victim_om = Factories.create_member(
+            user=victim, organization=self.organization, role="owner"
+        )
+
+        path = self._get_path(
+            "sentry-api-0-organization-accept-organization-invite",
+            [victim_om.id, "bogustoken"],
+        )
+        resp = self.client.post(path)
+        assert resp.status_code == 400
+
+        with assume_test_silo_mode_of(OrganizationMember):
+            assert OrganizationMember.objects.filter(id=victim_om.id).exists()
+        self.assert_org_member_mapping(org_member=victim_om)
+
+    def test_existing_member_cannot_delete_other_members_membership(self) -> None:
+        attacker = self.create_user("attacker@example.com")
+        Factories.create_member(user=attacker, organization=self.organization, role="member")
+        self.login_as(attacker)
+
+        victim = self.create_user("victim@example.com")
+        victim_om = Factories.create_member(
+            user=victim, organization=self.organization, role="owner"
+        )
+
+        path = self._get_path(
+            "sentry-api-0-organization-accept-organization-invite",
+            [victim_om.id, "bogustoken"],
+        )
+        resp = self.client.post(path)
+        assert resp.status_code == 400
+
+        with assume_test_silo_mode_of(OrganizationMember):
+            assert OrganizationMember.objects.filter(id=victim_om.id).exists()
+        self.assert_org_member_mapping(org_member=victim_om)
+
+    def test_existing_member_cannot_delete_pending_invite_with_bogus_token(self) -> None:
+        attacker = self.create_user("attacker@example.com")
+        Factories.create_member(user=attacker, organization=self.organization, role="member")
+        self.login_as(attacker)
+
+        pending_om = Factories.create_member(
+            email="pending@example.com",
+            role="member",
+            token="correcttoken",
+            organization=self.organization,
+        )
+
+        path = self._get_path(
+            "sentry-api-0-organization-accept-organization-invite",
+            [pending_om.id, "bogustoken"],
+        )
+        resp = self.client.post(path)
+        assert resp.status_code == 400
+
+        with assume_test_silo_mode_of(OrganizationMember):
+            assert OrganizationMember.objects.filter(id=pending_om.id).exists()
+        self.assert_org_member_mapping(org_member=pending_om)
+
     def test_can_accept_when_user_has_2fa(self) -> None:
         urls = self._get_urls()
 

--- a/tests/sentry/api/test_invite_helper.py
+++ b/tests/sentry/api/test_invite_helper.py
@@ -65,7 +65,11 @@ class ApiInviteHelperTest(TestCase):
         member_id = invite_context.invite_organization_member_id
         assert member_id is not None
 
-        # Without this member_id, don't delete the organization member
+        # Re-invoking accept_invite after the invite was already accepted is a
+        # no-op and must NOT delete any OrganizationMember — token validation
+        # on the cleanup path prevents the caller's own membership (or any
+        # other member) from being removed without a matching pending-invite
+        # token.
         invite_context.invite_organization_member_id = None
         helper = ApiInviteHelper(self.request, invite_context, None)
         with assume_test_silo_mode(SiloMode.CONTROL):
@@ -74,13 +78,14 @@ class ApiInviteHelperTest(TestCase):
         assert om.email is None
         assert om.user_id == self.user.id
 
-        # With the member_id, ensure it's deleted
+        # Even when invite_organization_member_id points back at the caller's
+        # own (already-accepted) OM, no deletion occurs: the OM is no longer
+        # pending and its token was cleared on accept.
         invite_context.invite_organization_member_id = member_id
         helper = ApiInviteHelper(self.request, invite_context, None)
         with assume_test_silo_mode(SiloMode.CONTROL):
             helper.accept_invite(self.user)
-        with pytest.raises(OrganizationMember.DoesNotExist):
-            OrganizationMember.objects.get(id=self.member.id)
+        assert OrganizationMember.objects.filter(id=self.member.id).exists()
 
     def test_accept_invite_with_optional_SSO(self) -> None:
         ap = self.create_auth_provider(organization_id=self.org.id, provider="Friendly IdP")


### PR DESCRIPTION
Validate the invite token and pending state before the cleanup-delete branch of ApiInviteHelper runs, and scope `member_already_exists` to the authenticated user rather than any non-null user_id on the resolved record. Replace the duplicated delete in user_authenticator_enroll with a call through the helper so the new guard applies in both call sites.
