### PR TITLE
chore(issue-detection): Remove unused LLM detection projects-allowlist

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3997,14 +3997,6 @@ register(
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# Allow list for projects with LLM issue detection enabled
-register(
-    "issue-detection.llm-detection.projects-allowlist",
-    type=Sequence,
-    default=[],
-    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 # Controls whether deletion from EAP is enabled.
 register(
     "eventstream.eap.deletion-enabled",


### PR DESCRIPTION
Drops the `issue-detection.llm-detection.projects-allowlist` option registration. 

Pairs with sentry-options-automator#7536.
