### PR TITLE
fix(integrations): Retry SCM backfill as a region-silo true-only scan

### DIFF
--- a/src/sentry/migrations/1072_backfill_scm_integration_config.py
+++ b/src/sentry/migrations/1072_backfill_scm_integration_config.py
@@ -1,21 +1,18 @@
 import logging
+from collections import defaultdict
 
 from django.db import migrations
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.migrations.state import StateApps
 
 from sentry.constants import ObjectStatus
-from sentry.hybridcloud.rpc.service import RpcRemoteException
-from sentry.models.organization import Organization
 from sentry.new_migrations.migrations import CheckedMigration
-from sentry.types.cell import CellMappingNotFound
-from sentry.utils.query import RangeQuerySetWrapperWithProgressBarApprox
 
 logger = logging.getLogger(__name__)
 
-# Maps OrganizationOption key -> (integration provider, OI config key).
-# Mirrors the mapping used by the live fan-out write in
-# src/sentry/core/endpoints/organization_details.py so a backfill and
+# Maps integration provider -> list of (OrganizationOption key, OI config key)
+# pairs. Mirrors the live fan-out write in
+# src/sentry/core/endpoints/organization_details.py so the backfill and
 # any newly installed OI end up consistent.
 _PROVIDER_KEYS = {
     "github": [
@@ -27,63 +24,120 @@ _PROVIDER_KEYS = {
     ],
 }
 
+_LEGACY_KEYS = [opt_key for pairs in _PROVIDER_KEYS.values() for opt_key, _ in pairs]
+
 
 def backfill_scm_integration_config(
     apps: StateApps, schema_editor: BaseDatabaseSchemaEditor
 ) -> None:
-    # `sentry_organizationintegration` is control-silo; `sentry_organizationoptions`
-    # is region-silo. This migration is routed to control via the `tables` hint
-    # below, so we read OI rows locally but fetch the legacy option values over
-    # the cell RPC instead of a cross-silo SQL query (which is impossible).
-    from sentry.organizations.services.organization import organization_service
+    """
+    Iterate the legacy OrganizationOption rows on the region silo (only orgs
+    that ever flipped one of the three toggles — a few thousand in prod) and
+    fan out updates to the control-silo OrganizationIntegration via RPC.
 
-    OrganizationIntegration = apps.get_model("sentry", "OrganizationIntegration")
+    We only consider rows whose value is exactly True; the new read path
+    treats a missing OI config key as false, so any other shape is a no-op.
+    """
+    # Imports are deferred so that breakage in these modules surfaces
+    # at runtime (when this migration is replayed on a fresh DB),
+    # not at migration-plan resolution time for every `migrate`.
+    #
+    # The bigger risk isn't the symbol surface, though -- it's that
+    # `integration_service` reads and writes the live
+    # `sentry_organizationintegration` table, not the historical
+    # snapshot we'd get via `apps.get_model`. If that table's schema
+    # or the meaning of `config` changes in a way this backfill's
+    # payload doesn't account for, replays on fresh self-hosted DBs
+    # will misbehave. We accept that: if/when it happens, this
+    # migration body is noop'd. By then getsentry prod and most
+    # self-hosted installs will already have run it; the residual
+    # risk is a small set of self-hosted users on a very old version
+    # with one of the legacy toggles set to true, who upgrade past
+    # the noop and don't get those toggles carried over to the
+    # per-OI config. That's preferable to keeping the OI table
+    # frozen indefinitely.
+    #
+    # We considered using a new outbox category to drive the
+    # cross-silo write instead. That doesn't actually remove the
+    # risk, it just relocates it onto the outbox tables: the live
+    # worker still dispatches against the current
+    # `sentry_organizationintegration` schema, and our rows would be
+    # tagged with a category enum entry that future code may retire
+    # -- leaving un-migrated installs with outbox rows the worker
+    # can't decode. Same cleanup shape (noop the migration body),
+    # with extra plumbing (category enum, signal receiver, drain
+    # semantics) and no real decoupling. The RPC path is also
+    # synchronous and observable, which is what an operator running
+    # a post-deploy migration wants.
+    from sentry.hybridcloud.rpc.service import RpcRemoteException
+    from sentry.integrations.services.integration import integration_service
+    from sentry.types.cell import CellMappingNotFound
 
-    # Iterate the whole OI table — the approx wrapper needs an unfiltered
-    # queryset, and we don't have an index on (status, id) or
-    # (integration_id, id) for a filtered range scan. Filtering in Python
-    # is cheaper than either alternative.
-    queryset = OrganizationIntegration.objects.all().select_related("integration")
+    OrganizationOption = apps.get_model("sentry", "OrganizationOption")
 
-    option_cache: dict[tuple[int, str], object] = {}
+    queryset = OrganizationOption.objects.filter(key__in=_LEGACY_KEYS, value=True)
 
-    for oi in RangeQuerySetWrapperWithProgressBarApprox(queryset):
-        if oi.status != ObjectStatus.ACTIVE:
-            continue
-        provider = oi.integration.provider
-        key_pairs = _PROVIDER_KEYS.get(provider)
-        if not key_pairs:
-            continue
+    opts_by_org: defaultdict[int, set[str]] = defaultdict(set)
+    for opt in queryset:
+        opts_by_org[opt.organization_id].add(opt.key)
 
-        config = dict(oi.config or {})
-        changed = False
-        for opt_key, cfg_key in key_pairs:
-            if cfg_key in config:
+    # For each org with at least one true-valued legacy option, find the
+    # ACTIVE OIs of each provider that owns one of the matching keys.
+    for organization_id, opts in opts_by_org.items():
+        for provider, key_pairs in _PROVIDER_KEYS.items():
+            # Skip providers whose owned keys aren't set on this org. e.g.
+            # if only sentry:gitlab_pr_bot is true, don't bother RPC-listing
+            # the github OIs.
+            if not any(opt_key in opts for opt_key, _ in key_pairs):
                 continue
-            cache_key = (oi.organization_id, opt_key)
-            if cache_key not in option_cache:
-                try:
-                    option_cache[cache_key] = organization_service.get_option(
-                        organization_id=oi.organization_id, key=opt_key
+
+            try:
+                ois = integration_service.get_organization_integrations(
+                    organization_id=organization_id,
+                    providers=[provider],
+                    status=ObjectStatus.ACTIVE,
+                )
+            except (CellMappingNotFound, RpcRemoteException):
+                logger.exception(
+                    "scm_backfill.list_failed",
+                    extra={
+                        "organization_id": organization_id,
+                        "provider": provider,
+                    },
+                )
+                continue
+
+            # An org can have multiple ACTIVE installs of the same provider
+            # (multi-org GitHub apps); each gets its own per-install config.
+            for oi in ois:
+                config = dict(oi.config or {})
+                set_keys: list[str] = []
+                # Backfill every owned key that's true on the org and not
+                # already present on the OI. Keys already set are left
+                # alone — the per-install UI may have set them explicitly.
+                for opt_key, cfg_key in key_pairs:
+                    if opt_key in opts and cfg_key not in config:
+                        config[cfg_key] = True
+                        set_keys.append(cfg_key)
+
+                if set_keys:
+                    # Exceptions from the write are deliberately uncaught: if
+                    # this fails we want the migration to abort loudly so an
+                    # operator can investigate, rather than silently dropping
+                    # a true toggle on the floor and leaving an org with the
+                    # wrong setting.
+                    integration_service.update_organization_integration(
+                        org_integration_id=oi.id, config=config
                     )
-                except (Organization.DoesNotExist, CellMappingNotFound, RpcRemoteException):
-                    # OI references an org that's already been deleted on the
-                    # region silo. The HybridCloudForeignKey cascade is async
-                    # across silos so this window is expected. In monolith /
-                    # tests the region raises Organization.DoesNotExist; in
-                    # split-silo the cell resolver raises CellMappingNotFound
-                    # (mapping gone) or RpcRemoteException (mapping intact,
-                    # region-side DoesNotExist wrapped by the RPC framework).
-                    option_cache[cache_key] = None
-            value = option_cache[cache_key]
-            if value is None:
-                continue
-            config[cfg_key] = bool(value)
-            changed = True
-
-        if changed:
-            oi.config = config
-            oi.save(update_fields=["config"])
+                    logger.info(
+                        "scm_backfill.set",
+                        extra={
+                            "organization_id": organization_id,
+                            "org_integration_id": oi.id,
+                            "provider": provider,
+                            "keys": set_keys,
+                        },
+                    )
 
 
 class Migration(CheckedMigration):
@@ -109,6 +163,6 @@ class Migration(CheckedMigration):
         migrations.RunPython(
             backfill_scm_integration_config,
             migrations.RunPython.noop,
-            hints={"tables": ["sentry_organizationintegration"]},
+            hints={"tables": ["sentry_organizationoptions"]},
         ),
     ]

--- a/tests/sentry/migrations/test_1072_backfill_scm_integration_config.py
+++ b/tests/sentry/migrations/test_1072_backfill_scm_integration_config.py
@@ -1,103 +1,129 @@
 from sentry.constants import ObjectStatus
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestMigrations
-from sentry.testutils.silo import control_silo_test
+from sentry.testutils.silo import assume_test_silo_mode
 
 
-@control_silo_test
 class BackfillScmIntegrationConfigTest(TestMigrations):
     migrate_from = "1071_add_broadcast_sync_locked"
     migrate_to = "1072_backfill_scm_integration_config"
-    connection = "control"
 
     def setup_before_migration(self, apps):
         Integration = apps.get_model("sentry", "Integration")
         OrganizationIntegration = apps.get_model("sentry", "OrganizationIntegration")
         OrganizationOption = apps.get_model("sentry", "OrganizationOption")
 
-        org = self.create_organization()
-        gh = Integration.objects.create(provider="github", external_id="gh-1", name="gh")
-        gl = Integration.objects.create(provider="gitlab", external_id="gl-1", name="gl")
-        self.gh_oi = OrganizationIntegration.objects.create(
-            organization_id=org.id, integration_id=gh.id, status=ObjectStatus.ACTIVE, config={}
-        )
-        self.gl_oi = OrganizationIntegration.objects.create(
-            organization_id=org.id, integration_id=gl.id, status=ObjectStatus.ACTIVE, config={}
-        )
-        OrganizationOption.objects.create(
-            organization_id=org.id, key="sentry:github_pr_bot", value=True
-        )
-        OrganizationOption.objects.create(
-            organization_id=org.id, key="sentry:github_nudge_invite", value=False
-        )
-        OrganizationOption.objects.create(
-            organization_id=org.id, key="sentry:gitlab_pr_bot", value=True
-        )
+        with assume_test_silo_mode(SiloMode.MONOLITH):
+            true_org = self.create_organization()
+            gh = Integration.objects.create(provider="github", external_id="gh-true", name="gh-t")
+            gl = Integration.objects.create(provider="gitlab", external_id="gl-true", name="gl-t")
+            self.true_gh_oi = OrganizationIntegration.objects.create(
+                organization_id=true_org.id,
+                integration_id=gh.id,
+                status=ObjectStatus.ACTIVE,
+                config={},
+            )
+            self.true_gl_oi = OrganizationIntegration.objects.create(
+                organization_id=true_org.id,
+                integration_id=gl.id,
+                status=ObjectStatus.ACTIVE,
+                config={},
+            )
+            OrganizationOption.objects.create(
+                organization_id=true_org.id, key="sentry:github_pr_bot", value=True
+            )
+            OrganizationOption.objects.create(
+                organization_id=true_org.id, key="sentry:github_nudge_invite", value=True
+            )
+            OrganizationOption.objects.create(
+                organization_id=true_org.id, key="sentry:gitlab_pr_bot", value=True
+            )
 
-        preset_org = self.create_organization()
-        preset_gh = Integration.objects.create(
-            provider="github", external_id="gh-preset", name="preset"
-        )
-        self.preset_oi = OrganizationIntegration.objects.create(
-            organization_id=preset_org.id,
-            integration_id=preset_gh.id,
-            status=ObjectStatus.ACTIVE,
-            config={"pr_comments": False, "other_key": "kept"},
-        )
-        OrganizationOption.objects.create(
-            organization_id=preset_org.id, key="sentry:github_pr_bot", value=True
-        )
-        OrganizationOption.objects.create(
-            organization_id=preset_org.id, key="sentry:github_nudge_invite", value=True
-        )
+            # Org with explicit false value — should NOT be backfilled (new
+            # read path treats missing key as false).
+            false_org = self.create_organization()
+            false_gh = Integration.objects.create(
+                provider="github", external_id="gh-false", name="gh-f"
+            )
+            self.false_gh_oi = OrganizationIntegration.objects.create(
+                organization_id=false_org.id,
+                integration_id=false_gh.id,
+                status=ObjectStatus.ACTIVE,
+                config={},
+            )
+            OrganizationOption.objects.create(
+                organization_id=false_org.id, key="sentry:github_pr_bot", value=False
+            )
 
-        no_option_org = self.create_organization()
-        no_option_gh = Integration.objects.create(
-            provider="github", external_id="gh-nooptions", name="no-opt"
-        )
-        self.untouched_oi = OrganizationIntegration.objects.create(
-            organization_id=no_option_org.id,
-            integration_id=no_option_gh.id,
-            status=ObjectStatus.ACTIVE,
-            config={},
-        )
+            # Mixed org — github_pr_bot=true, github_nudge_invite=false. Only
+            # the true key should populate; the false one stays absent.
+            mixed_org = self.create_organization()
+            mixed_gh = Integration.objects.create(
+                provider="github", external_id="gh-mixed", name="gh-m"
+            )
+            self.mixed_gh_oi = OrganizationIntegration.objects.create(
+                organization_id=mixed_org.id,
+                integration_id=mixed_gh.id,
+                status=ObjectStatus.ACTIVE,
+                config={},
+            )
+            OrganizationOption.objects.create(
+                organization_id=mixed_org.id, key="sentry:github_pr_bot", value=True
+            )
+            OrganizationOption.objects.create(
+                organization_id=mixed_org.id, key="sentry:github_nudge_invite", value=False
+            )
 
-        disabled_org = self.create_organization()
-        disabled_gh = Integration.objects.create(
-            provider="github", external_id="gh-disabled", name="disabled"
-        )
-        self.disabled_oi = OrganizationIntegration.objects.create(
-            organization_id=disabled_org.id,
-            integration_id=disabled_gh.id,
-            status=ObjectStatus.DISABLED,
-            config={},
-        )
-        OrganizationOption.objects.create(
-            organization_id=disabled_org.id, key="sentry:github_pr_bot", value=True
-        )
+            # OI with a preset config — existing keys are not overwritten;
+            # unrelated keys are preserved.
+            preset_org = self.create_organization()
+            preset_gh = Integration.objects.create(
+                provider="github", external_id="gh-preset", name="gh-p"
+            )
+            self.preset_oi = OrganizationIntegration.objects.create(
+                organization_id=preset_org.id,
+                integration_id=preset_gh.id,
+                status=ObjectStatus.ACTIVE,
+                config={"pr_comments": False, "other_key": "kept"},
+            )
+            OrganizationOption.objects.create(
+                organization_id=preset_org.id, key="sentry:github_pr_bot", value=True
+            )
+            OrganizationOption.objects.create(
+                organization_id=preset_org.id, key="sentry:github_nudge_invite", value=True
+            )
 
-        non_scm_org = self.create_organization()
-        slack = Integration.objects.create(provider="slack", external_id="slack-1", name="slack")
-        self.slack_oi = OrganizationIntegration.objects.create(
-            organization_id=non_scm_org.id,
-            integration_id=slack.id,
-            status=ObjectStatus.ACTIVE,
-            config={},
-        )
+            # Disabled OI — skipped.
+            disabled_org = self.create_organization()
+            disabled_gh = Integration.objects.create(
+                provider="github", external_id="gh-disabled", name="gh-d"
+            )
+            self.disabled_oi = OrganizationIntegration.objects.create(
+                organization_id=disabled_org.id,
+                integration_id=disabled_gh.id,
+                status=ObjectStatus.DISABLED,
+                config={},
+            )
+            OrganizationOption.objects.create(
+                organization_id=disabled_org.id, key="sentry:github_pr_bot", value=True
+            )
 
     def test(self) -> None:
         from sentry.integrations.models.organization_integration import OrganizationIntegration
 
-        assert OrganizationIntegration.objects.get(id=self.gh_oi.id).config == {
-            "pr_comments": True,
-            "nudge_invite": False,
-        }
-        assert OrganizationIntegration.objects.get(id=self.gl_oi.id).config == {"pr_comments": True}
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            true_gh = OrganizationIntegration.objects.get(id=self.true_gh_oi.id).config
+            true_gl = OrganizationIntegration.objects.get(id=self.true_gl_oi.id).config
+            false_gh = OrganizationIntegration.objects.get(id=self.false_gh_oi.id).config
+            mixed_gh = OrganizationIntegration.objects.get(id=self.mixed_gh_oi.id).config
+            preset = OrganizationIntegration.objects.get(id=self.preset_oi.id).config
+            disabled = OrganizationIntegration.objects.get(id=self.disabled_oi.id).config
 
-        preset = OrganizationIntegration.objects.get(id=self.preset_oi.id).config
+        assert true_gh == {"pr_comments": True, "nudge_invite": True}
+        assert true_gl == {"pr_comments": True}
+        assert false_gh == {}
+        assert mixed_gh == {"pr_comments": True}
         assert preset["pr_comments"] is False
         assert preset["nudge_invite"] is True
         assert preset["other_key"] == "kept"
-
-        assert OrganizationIntegration.objects.get(id=self.untouched_oi.id).config == {}
-        assert OrganizationIntegration.objects.get(id=self.disabled_oi.id).config == {}
-        assert OrganizationIntegration.objects.get(id=self.slack_oi.id).config == {}
+        assert disabled == {}


### PR DESCRIPTION
The previous 1072 implementation was inefficient, lacked logging, and for reasons I haven't been able to pin down didn't seem to be making progress on prod. It iterated the full `OrganizationIntegration` table on the control silo and RPC-fetched the legacy option per OI.

This approach makes a lot more sense. The set of orgs that ever flipped one of the three legacy toggles is small (~4k rows in prod), so flip the iteration around: scan `sentry_organizationoptions` on the region silo filtered to the three legacy keys with `value=True`, and fan out to control to update `OI.config` via `update_organization_integration`. Skip false rows entirely — the new read path treats a missing OI config key as false.

Adds a `logger.info` per OI we update with `organization_id`, `org_integration_id`, `provider`, and the keys we set, so the next run is observable.

Ref: [VDY-111: Phase 1: Dual-write SCM settings to integration config + backfill](https://linear.app/getsentry/issue/VDY-111/phase-1-dual-write-scm-settings-to-integration-config-backfill)