### PR TITLE
feat(seer): Wire experiment tweaks into night shift runs

### DIFF
--- a/src/sentry/tasks/seer/night_shift/agentic_triage.py
+++ b/src/sentry/tasks/seer/night_shift/agentic_triage.py
@@ -22,6 +22,7 @@ from sentry.tasks.seer.night_shift.triage_tools import (
     get_event_details_agentic_triage,
     get_issue_details_agentic_triage,
 )
+from sentry.tasks.seer.night_shift.tweaks import IntelligenceLevel, ReasoningEffort
 
 logger = logging.getLogger("sentry.tasks.seer.night_shift")
 
@@ -40,6 +41,11 @@ def agentic_triage_strategy(
     projects: Sequence[Project],
     organization: Organization,
     max_candidates: int,
+    *,
+    issue_fetch_limit: int,
+    intelligence_level: IntelligenceLevel,
+    reasoning_effort: ReasoningEffort,
+    extra_instructions: str,
 ) -> tuple[list[TriageResult], int | None]:
     """
     Select candidates via fixability scoring, then use the Seer Explorer agent
@@ -48,16 +54,26 @@ def agentic_triage_strategy(
     Returns a tuple of (triage_results, agent_run_id).
     """
     # TODO: try a new way to get scored issues
-    scored = fixability_score_strategy(projects, max_candidates)
+    scored = fixability_score_strategy(projects, max_candidates, issue_fetch_limit)
     if not scored:
         return [], None
 
-    return _triage_candidates(scored, organization)
+    return _triage_candidates(
+        scored,
+        organization,
+        intelligence_level=intelligence_level,
+        reasoning_effort=reasoning_effort,
+        extra_instructions=extra_instructions,
+    )
 
 
 def _triage_candidates(
     candidates: list[ScoredCandidate],
     organization: Organization,
+    *,
+    intelligence_level: IntelligenceLevel,
+    reasoning_effort: ReasoningEffort,
+    extra_instructions: str,
 ) -> tuple[list[TriageResult], int | None]:
     """
     Start a Seer Explorer run to investigate candidate issues and return
@@ -74,8 +90,8 @@ def _triage_candidates(
             user=None,
             category_key="night_shift",
             category_value=f"org-{organization.id}",
-            intelligence_level="high",
-            reasoning_effort="high",
+            intelligence_level=intelligence_level,
+            reasoning_effort=reasoning_effort,
             custom_tools=[
                 get_event_details_agentic_triage,
                 get_issue_details_agentic_triage,
@@ -83,7 +99,7 @@ def _triage_candidates(
         )
 
         agent_run_id = client.start_run(
-            prompt=_build_triage_prompt(candidates),
+            prompt=_build_triage_prompt(candidates, extra_instructions),
             artifact_key="triage_verdicts",
             artifact_schema=_TriageResponse,
         )
@@ -209,6 +225,7 @@ def _poll_with_logging(
 
 def _build_triage_prompt(
     candidates: list[ScoredCandidate],
+    extra_instructions: str,
 ) -> str:
     candidates_block = "\n".join(
         f"- group_id={c.group.id} | title={c.group.title or 'Unknown error'!r} "
@@ -217,6 +234,12 @@ def _build_triage_prompt(
         f"| first_seen={c.group.first_seen.isoformat()} "
         f"| priority={priority_label(c.group.priority) or 'unknown'}"
         for c in candidates
+    )
+
+    extras_block = (
+        f"\n\nAdditional project-specific instructions:\n{extra_instructions}"
+        if extra_instructions
+        else ""
     )
 
     return textwrap.dedent(f"""\
@@ -271,5 +294,5 @@ def _build_triage_prompt(
         Provide a brief reason for each decision.
 
         Candidates:
-        {candidates_block}
+        {candidates_block}{extras_block}
     """)

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -26,7 +26,13 @@ from sentry.seer.models.night_shift import SeerNightShiftRun, SeerNightShiftRunI
 from sentry.tasks.base import instrumented_task
 from sentry.tasks.seer.night_shift.agentic_triage import agentic_triage_strategy
 from sentry.tasks.seer.night_shift.models import TriageAction, TriageResult
-from sentry.tasks.seer.night_shift.tweaks import NightShiftTweaks, get_night_shift_tweaks
+from sentry.tasks.seer.night_shift.simple_triage import simple_triage_strategy
+from sentry.tasks.seer.night_shift.tweaks import (
+    IntelligenceLevel,
+    NightShiftTweaks,
+    ReasoningEffort,
+    get_night_shift_tweaks,
+)
 from sentry.taskworker.namespaces import seer_tasks
 from sentry.utils.iterators import chunked
 from sentry.utils.query import RangeQuerySetWrapper
@@ -216,18 +222,34 @@ def _execute_night_shift_run(
         logger.info("night_shift.no_eligible_projects", extra=log_extra)
         return None
 
+    aggregated = _aggregate_tweaks([ep.tweaks for ep in eligible])
+    triage_strategy_name = "agentic_triage" if aggregated.use_agentic else "simple_triage"
+    if triage_strategy_name != run.triage_strategy:
+        run.update(triage_strategy=triage_strategy_name)
+
     resolved_max_candidates = (
-        max_candidates
-        if max_candidates is not None
-        else max(ep.tweaks.candidate_issues for ep in eligible)
+        max_candidates if max_candidates is not None else aggregated.candidate_issues
     )
 
     eligible_projects = [ep.project for ep in eligible]
     agent_run_id = None
     try:
-        candidates, agent_run_id = agentic_triage_strategy(
-            eligible_projects, organization, resolved_max_candidates
-        )
+        if aggregated.use_agentic:
+            candidates, agent_run_id = agentic_triage_strategy(
+                eligible_projects,
+                organization,
+                resolved_max_candidates,
+                issue_fetch_limit=aggregated.issue_fetch_limit,
+                intelligence_level=aggregated.intelligence_level,
+                reasoning_effort=aggregated.reasoning_effort,
+                extra_instructions=aggregated.extra_instructions,
+            )
+        else:
+            candidates, agent_run_id = simple_triage_strategy(
+                eligible_projects,
+                resolved_max_candidates,
+                aggregated.issue_fetch_limit,
+            )
         if agent_run_id is not None:
             run.update(extras={**run.extras, "agent_run_id": agent_run_id})
             log_extra["agent_run_id"] = agent_run_id
@@ -247,6 +269,8 @@ def _execute_night_shift_run(
         sentry_sdk.metrics.count("night_shift.triage_action", count, attributes={"action": action})
     sentry_sdk.metrics.distribution("night_shift.org_run_duration", time.monotonic() - start_time)
 
+    dry_run_project_ids = {ep.project.id for ep in eligible if ep.tweaks.dry_run}
+
     seer_run_id_by_group: dict[int, str | None] = {}
     if not dry_run:
         # Populate each candidate group's FK cache so trigger_autofix_explorer doesn't
@@ -260,9 +284,12 @@ def _execute_night_shift_run(
         for c in candidates:
             c.group.project = projects_by_id[c.group.project_id]
 
+        # Per-project dry_run tweak: keep these candidates in the triage record but
+        # don't dispatch autofix for them.
+        dispatchable = [c for c in candidates if c.group.project_id not in dry_run_project_ids]
         issues = _run_autofix_for_candidates(
             run=run,
-            candidates=candidates,
+            candidates=dispatchable,
             log_extra=log_extra,
         )
         seer_run_id_by_group = {i.group_id: i.seer_run_id for i in issues}
@@ -274,12 +301,14 @@ def _execute_night_shift_run(
             "num_eligible_projects": len(eligible_projects),
             "num_candidates": len(candidates),
             "dry_run": dry_run,
+            "triage_strategy": triage_strategy_name,
             "candidates": [
                 {
                     "group_id": c.group.id,
                     "action": c.action,
                     "seer_run_id": seer_run_id_by_group.get(c.group.id),
                     "num_occurrences": c.group.times_seen,
+                    "project_dry_run": c.group.project_id in dry_run_project_ids,
                 }
                 for c in candidates
             ],
@@ -327,6 +356,61 @@ def _fail_run(
 class EligibleProject:
     project: Project
     tweaks: NightShiftTweaks
+
+
+@dataclasses.dataclass(frozen=True)
+class AggregatedTweaks:
+    """Per-project tweaks combined for an org-wide run.
+
+    `candidate_issues` and `issue_fetch_limit` take the max because the
+    underlying queries fan out across all eligible projects in one shot — taking
+    the strictest setting would silently shrink other projects' budgets.
+
+    Intelligence/reasoning levels also take the max so a project asking for the
+    higher tier always gets it, since the Explorer client takes a single value
+    for the whole run.
+
+    `extra_instructions` are concatenated in eligible-project order; per-project
+    prefixing happens only when there are multiple projects with non-empty
+    instructions, to keep the prompt clean for single-project runs.
+
+    `use_agentic` is True if any project's strategy is "agentic" — agentic is
+    the more thorough strategy, so any opt-in dominates."""
+
+    candidate_issues: int
+    issue_fetch_limit: int
+    intelligence_level: IntelligenceLevel
+    reasoning_effort: ReasoningEffort
+    extra_instructions: str
+    use_agentic: bool
+
+
+_LEVEL_ORDER: dict[str, int] = {"low": 0, "medium": 1, "high": 2}
+
+
+def _aggregate_tweaks(tweaks: list[NightShiftTweaks]) -> AggregatedTweaks:
+    instruction_pairs = [
+        (i, t.extra_triage_instructions.strip())
+        for i, t in enumerate(tweaks)
+        if t.extra_triage_instructions.strip()
+    ]
+    if len(instruction_pairs) <= 1:
+        extra_instructions = instruction_pairs[0][1] if instruction_pairs else ""
+    else:
+        extra_instructions = "\n\n".join(
+            f"(Project {i + 1}) {text}" for i, text in instruction_pairs
+        )
+
+    return AggregatedTweaks(
+        candidate_issues=max(t.candidate_issues for t in tweaks),
+        issue_fetch_limit=max(t.issue_fetch_limit for t in tweaks),
+        intelligence_level=max(
+            (t.intelligence_level for t in tweaks), key=_LEVEL_ORDER.__getitem__
+        ),
+        reasoning_effort=max((t.reasoning_effort for t in tweaks), key=_LEVEL_ORDER.__getitem__),
+        extra_instructions=extra_instructions,
+        use_agentic=any(t.triage_strategy == "agentic" for t in tweaks),
+    )
 
 
 def _get_eligible_projects(

--- a/src/sentry/tasks/seer/night_shift/simple_triage.py
+++ b/src/sentry/tasks/seer/night_shift/simple_triage.py
@@ -17,8 +17,6 @@ from sentry.types.group import PriorityLevel
 
 logger = logging.getLogger("sentry.tasks.seer.night_shift")
 
-NIGHT_SHIFT_ISSUE_FETCH_LIMIT = 100
-
 # Weights for candidate scoring. Set to 0 to disable a signal.
 WEIGHT_FIXABILITY = 1.0
 WEIGHT_SEVERITY = 0.0
@@ -49,6 +47,7 @@ class ScoredCandidate(TriageResult):
 def fixability_score_strategy(
     projects: Sequence[Project],
     max_candidates: int,
+    issue_fetch_limit: int,
 ) -> list[ScoredCandidate]:
     """
     Fetch top recommended unresolved issues that haven't been triaged by Seer yet,
@@ -57,7 +56,7 @@ def fixability_score_strategy(
     result = search.backend.query(
         projects=projects,
         sort_by="recommended",
-        limit=NIGHT_SHIFT_ISSUE_FETCH_LIMIT,
+        limit=issue_fetch_limit,
         search_filters=[
             SearchFilter(SearchKey("status"), "=", SearchValue([GroupStatus.UNRESOLVED])),
             SearchFilter(SearchKey("issue.seer_last_run"), "=", SearchValue("")),
@@ -94,6 +93,19 @@ def fixability_score_strategy(
         sentry_sdk.metrics.distribution("night_shift.fixability_score", c.fixability)
 
     return selected
+
+
+def simple_triage_strategy(
+    projects: Sequence[Project],
+    max_candidates: int,
+    issue_fetch_limit: int,
+) -> tuple[list[TriageResult], int | None]:
+    """No-LLM triage: pick top candidates by fixability score and mark all as
+    autofix. Returns (triage_results, agent_run_id) to match the shape of
+    `agentic_triage_strategy` so the cron pipeline can dispatch on strategy.
+    """
+    scored = fixability_score_strategy(projects, max_candidates, issue_fetch_limit)
+    return [TriageResult(group=c.group, action=TriageAction.AUTOFIX) for c in scored], None
 
 
 def priority_label(priority: int | None) -> str | None:

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -12,12 +12,14 @@ from sentry.seer.models.night_shift import SeerNightShiftRun, SeerNightShiftRunI
 from sentry.seer.models.project_repository import SeerProjectRepository
 from sentry.tasks.seer.night_shift.cron import (
     NightShiftRunSource,
+    _aggregate_tweaks,
     _get_eligible_projects,
     run_night_shift_for_org,
     run_night_shift_for_project,
     schedule_night_shift,
 )
 from sentry.tasks.seer.night_shift.simple_triage import fixability_score_strategy
+from sentry.tasks.seer.night_shift.tweaks import NightShiftTweaks
 from sentry.testutils.cases import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.pytest.fixtures import django_db_all
@@ -642,10 +644,208 @@ class TestFixabilityScoreStrategy(TestCase, SnubaTestCase):
                 project, f"null-{i}", seer_fixability_score=None, times_seen=100
             )
 
-        result = fixability_score_strategy([project], max_candidates=10)
+        result = fixability_score_strategy([project], max_candidates=10, issue_fetch_limit=100)
 
         assert result[0].group.id == high.id
         assert result[0].fixability == 0.9
         assert result[0].times_seen == 5
         assert result[0].severity == 1.0
         assert result[1].group.id == low.id
+
+    def test_issue_fetch_limit_caps_search(self) -> None:
+        project = self.create_project()
+        for i in range(5):
+            self._store_event_and_update_group(
+                project, f"hit-{i}", seer_fixability_score=0.5, times_seen=10
+            )
+
+        capped = fixability_score_strategy([project], max_candidates=10, issue_fetch_limit=2)
+        uncapped = fixability_score_strategy([project], max_candidates=10, issue_fetch_limit=10)
+
+        assert len(capped) == 2
+        assert len(uncapped) == 5
+
+
+class TestAggregateTweaks(TestCase):
+    def test_uses_max_for_numeric_and_level_fields(self) -> None:
+        aggregated = _aggregate_tweaks(
+            [
+                NightShiftTweaks(
+                    candidate_issues=5,
+                    issue_fetch_limit=50,
+                    intelligence_level="low",
+                    reasoning_effort="medium",
+                ),
+                NightShiftTweaks(
+                    candidate_issues=20,
+                    issue_fetch_limit=200,
+                    intelligence_level="high",
+                    reasoning_effort="low",
+                ),
+            ]
+        )
+
+        assert aggregated.candidate_issues == 20
+        assert aggregated.issue_fetch_limit == 200
+        assert aggregated.intelligence_level == "high"
+        assert aggregated.reasoning_effort == "medium"
+
+    def test_use_agentic_dominates(self) -> None:
+        all_simple = _aggregate_tweaks(
+            [
+                NightShiftTweaks(triage_strategy="simple"),
+                NightShiftTweaks(triage_strategy="simple"),
+            ]
+        )
+        mixed = _aggregate_tweaks(
+            [
+                NightShiftTweaks(triage_strategy="simple"),
+                NightShiftTweaks(triage_strategy="agentic"),
+            ]
+        )
+
+        assert all_simple.use_agentic is False
+        assert mixed.use_agentic is True
+
+    def test_extra_instructions_unprefixed_for_single_project(self) -> None:
+        aggregated = _aggregate_tweaks(
+            [
+                NightShiftTweaks(extra_triage_instructions=""),
+                NightShiftTweaks(extra_triage_instructions="  focus on auth  "),
+            ]
+        )
+
+        assert aggregated.extra_instructions == "focus on auth"
+
+    def test_extra_instructions_prefixed_for_multiple_projects(self) -> None:
+        aggregated = _aggregate_tweaks(
+            [
+                NightShiftTweaks(extra_triage_instructions="focus on auth"),
+                NightShiftTweaks(extra_triage_instructions=""),
+                NightShiftTweaks(extra_triage_instructions="prefer ts errors"),
+            ]
+        )
+
+        assert "(Project 1) focus on auth" in aggregated.extra_instructions
+        assert "(Project 3) prefer ts errors" in aggregated.extra_instructions
+
+
+@django_db_all
+class TestNightShiftTweaksWiring(TestCase, SnubaTestCase):
+    """End-to-end tests for the per-project tweaks that affect run behavior beyond
+    `enabled` and `candidate_issues` (which are covered above)."""
+
+    reset_snuba_data = False
+
+    def _make_eligible(self, project, **tweak_overrides):
+        project.update_option(
+            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM
+        )
+        repo = self.create_repo(project=project, provider="github", name=f"owner/{project.slug}")
+        SeerProjectRepository.objects.create(project=project, repository=repo)
+        project.update_option("sentry:seer_nightshift_tweaks", {"enabled": True, **tweak_overrides})
+
+    def _store_event_and_update_group(self, project, fingerprint, **group_attrs):
+        event = self.store_event(
+            data={
+                "fingerprint": [fingerprint],
+                "timestamp": before_now(hours=1).isoformat(),
+                "environment": "production",
+            },
+            project_id=project.id,
+        )
+        Group.objects.filter(id=event.group_id).update(**group_attrs)
+        return Group.objects.get(id=event.group_id)
+
+    def test_per_project_dry_run_skips_autofix_only_for_that_project(self) -> None:
+        org = self.create_organization()
+        live = self.create_project(organization=org, slug="live")
+        ghost = self.create_project(organization=org, slug="ghost")
+        self._make_eligible(live)
+        self._make_eligible(ghost, dryRun=True)
+
+        live_group = self._store_event_and_update_group(
+            live, "live-bug", seer_fixability_score=0.9, times_seen=5
+        )
+        ghost_group = self._store_event_and_update_group(
+            ghost, "ghost-bug", seer_fixability_score=0.9, times_seen=5
+        )
+
+        verdicts = [(live_group.id, "autofix"), (ghost_group.id, "autofix")]
+        fake_client = FakeExplorerClient(verdicts)
+        with (
+            self.feature(NIGHT_SHIFT_FEATURES),
+            patch(
+                "sentry.tasks.seer.night_shift.agentic_triage.SeerExplorerClient",
+                return_value=fake_client,
+            ),
+            patch(
+                "sentry.tasks.seer.night_shift.cron.trigger_autofix_explorer",
+                return_value=42,
+            ) as mock_trigger,
+        ):
+            run_night_shift_for_org(org.id)
+
+        triggered_group_ids = {call.kwargs["group"].id for call in mock_trigger.call_args_list}
+        assert triggered_group_ids == {live_group.id}
+
+        run = SeerNightShiftRun.objects.get(organization=org)
+        issue_group_ids = set(
+            SeerNightShiftRunIssue.objects.filter(run=run).values_list("group_id", flat=True)
+        )
+        assert issue_group_ids == {live_group.id}
+
+    def test_simple_strategy_skips_explorer(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        self._make_eligible(project, triageStrategy="simple")
+
+        group = self._store_event_and_update_group(
+            project, "simple", seer_fixability_score=0.9, times_seen=5
+        )
+
+        with (
+            self.feature(NIGHT_SHIFT_FEATURES),
+            patch(
+                "sentry.tasks.seer.night_shift.agentic_triage.SeerExplorerClient",
+            ) as mock_explorer,
+            patch(
+                "sentry.tasks.seer.night_shift.cron.trigger_autofix_explorer",
+                return_value=42,
+            ) as mock_trigger,
+        ):
+            run_night_shift_for_org(org.id)
+
+        mock_explorer.assert_not_called()
+        triggered_group_ids = {call.kwargs["group"].id for call in mock_trigger.call_args_list}
+        assert triggered_group_ids == {group.id}
+
+        run = SeerNightShiftRun.objects.get(organization=org)
+        assert run.triage_strategy == "simple_triage"
+
+    def test_per_project_tweaks_flow_to_agentic_strategy(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        self._make_eligible(
+            project,
+            intelligenceLevel="low",
+            reasoningEffort="medium",
+            extraTriageInstructions="favor frontend bugs",
+            issueFetchLimit=42,
+        )
+
+        with (
+            self.feature(NIGHT_SHIFT_FEATURES),
+            patch(
+                "sentry.tasks.seer.night_shift.cron.agentic_triage_strategy",
+                return_value=([], None),
+            ) as mock_strategy,
+        ):
+            run_night_shift_for_org(org.id)
+
+        mock_strategy.assert_called_once()
+        kwargs = mock_strategy.call_args.kwargs
+        assert kwargs["intelligence_level"] == "low"
+        assert kwargs["reasoning_effort"] == "medium"
+        assert kwargs["extra_instructions"] == "favor frontend bugs"
+        assert kwargs["issue_fetch_limit"] == 42


### PR DESCRIPTION
Hook the per-project `NightShiftTweaks` fields added in #114034 into the cron and manual run pipelines so they actually take effect. Defaults match prior hardcoded values, so this is behavior-preserving until something is set on a project.

What each field controls now:

- `triage_strategy`: dispatch on either agentic (LLM Explorer) or simple (no-LLM, trust fixability score) triage. The `SeerNightShiftRun` row records which strategy was used (`agentic_triage` or `simple_triage`).
- `intelligence_level` / `reasoning_effort`: passed through to `SeerExplorerClient` instead of the previously hardcoded `"high"` / `"high"`.
- `extra_triage_instructions`: appended to the agentic triage prompt under an "Additional project-specific instructions" header.
- `issue_fetch_limit`: replaces the `NIGHT_SHIFT_ISSUE_FETCH_LIMIT` constant as the search-backend limit in `fixability_score_strategy`.
- `dry_run`: a per-project `dry_run` filters out that project's candidates from autofix dispatch while still recording them in the triage log. The task-level `dry_run` flag still wins for whole-run skips.

Aggregation for org-wide cron runs (multiple eligible projects share a single triage call):

- `candidate_issues`, `issue_fetch_limit`: max across projects (consistent with the existing `candidate_issues` aggregation).
- `intelligence_level`, `reasoning_effort`: max across projects — a project asking for the higher tier always gets it.
- `extra_triage_instructions`: concatenated; prefixed with `(Project N)` only when more than one project supplies instructions, to keep single-project prompts clean.
- `triage_strategy`: any project opting into agentic wins (agentic is the more thorough strategy).
- `dry_run`: per-candidate, no aggregation needed.

Single-project (manual) runs see their own tweak values unchanged.

Refs #114034


Agent transcript: https://claudescope.sentry.dev/share/yaqqa4cPZW7MjzBIkyp38jH0-aAR7wL2OzgxfY5JsVU