### PR TITLE
fix(notifications): Recursively serialize datetime in task arguments

### DIFF
--- a/src/sentry/notifications/utils/tasks.py
+++ b/src/sentry/notifications/utils/tasks.py
@@ -24,16 +24,22 @@ LAZY_OBJECT_KEY = "lazyobjectrpcuser"
 MODEL_KEY = "model"
 
 
+def _serialize_value(v: Any) -> Any:
+    """Recursively convert values to JSON-serializable types."""
+    if isinstance(v, datetime):
+        return v.isoformat()
+    if isinstance(v, frozenset):
+        return [_serialize_value(item) for item in v]
+    if isinstance(v, list):
+        return [_serialize_value(item) for item in v]
+    if isinstance(v, dict):
+        return {k: _serialize_value(val) for k, val in v.items()}
+    return v
+
+
 def serialize_lazy_object_user(arg: SimpleLazyObject, key: str | None = None) -> dict[str, Any]:
     raw_data = arg.dict()  # type: ignore[attr-defined]
-    parsed_data = {}
-    for k, v in raw_data.items():
-        if isinstance(v, datetime):
-            v = v.isoformat()
-        if isinstance(v, frozenset):
-            v = list(v)
-
-        parsed_data[k] = v
+    parsed_data = {k: _serialize_value(v) for k, v in raw_data.items()}
 
     return {
         "type": LAZY_OBJECT_KEY,

--- a/tests/sentry/notifications/utils/test_tasks.py
+++ b/tests/sentry/notifications/utils/test_tasks.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -5,7 +6,11 @@ from django.contrib.auth.models import AnonymousUser
 from django.utils.functional import SimpleLazyObject
 
 from sentry.notifications.class_manager import NotificationClassNotSetException, manager, register
-from sentry.notifications.utils.tasks import _send_notification, async_send_notification
+from sentry.notifications.utils.tasks import (
+    _send_notification,
+    _serialize_value,
+    async_send_notification,
+)
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.notifications import AnotherDummyNotification, DummyNotification
 from sentry.users.services.user.serial import serialize_generic_user
@@ -139,3 +144,43 @@ class NotificationTaskTests(TestCase):
     def test_invalid_notification(self) -> None:
         with pytest.raises(NotificationClassNotSetException):
             async_send_notification(DummyNotification, self.organization, "some_value")
+
+
+class SerializeValueTests(TestCase):
+    def test_serialize_datetime(self) -> None:
+        dt = datetime(2024, 1, 15, 12, 30, 45, tzinfo=timezone.utc)
+        assert _serialize_value(dt) == "2024-01-15T12:30:45+00:00"
+
+    def test_serialize_nested_datetime_in_dict(self) -> None:
+        dt = datetime(2024, 1, 15, 12, 30, 45, tzinfo=timezone.utc)
+        data = {"created_at": dt, "name": "test"}
+        result = _serialize_value(data)
+        assert result == {"created_at": "2024-01-15T12:30:45+00:00", "name": "test"}
+
+    def test_serialize_nested_datetime_in_list(self) -> None:
+        dt = datetime(2024, 1, 15, 12, 30, 45, tzinfo=timezone.utc)
+        data = [{"created_at": dt}, {"updated_at": dt}]
+        result = _serialize_value(data)
+        assert result == [
+            {"created_at": "2024-01-15T12:30:45+00:00"},
+            {"updated_at": "2024-01-15T12:30:45+00:00"},
+        ]
+
+    def test_serialize_deeply_nested_datetime(self) -> None:
+        dt = datetime(2024, 1, 15, 12, 30, 45, tzinfo=timezone.utc)
+        data = {"user": {"authenticators": [{"created_at": dt, "type": 1}]}}
+        result = _serialize_value(data)
+        assert result == {
+            "user": {"authenticators": [{"created_at": "2024-01-15T12:30:45+00:00", "type": 1}]}
+        }
+
+    def test_serialize_frozenset(self) -> None:
+        data = frozenset(["a", "b", "c"])
+        result = _serialize_value(data)
+        assert sorted(result) == ["a", "b", "c"]
+
+    def test_serialize_primitive_passthrough(self) -> None:
+        assert _serialize_value("string") == "string"
+        assert _serialize_value(123) == 123
+        assert _serialize_value(None) is None
+        assert _serialize_value(True) is True


### PR DESCRIPTION
## Summary

- Fix msgpack serialization failure when sending notifications via taskbroker
- The `serialize_lazy_object_user` function was only converting top-level datetime fields to isoformat strings
- Nested datetime fields (e.g., `RpcAuthenticator.created_at` inside `RpcUser.authenticators`) were passed through as datetime objects, causing `TypeError: can not serialize 'datetime.datetime' object`

## Why fix on caller side (not in taskbroker)?

Taskbroker was never intended to handle datetime serialization. Datetimes cannot roundtrip properly through msgpack due to lack of type information on the deserialization side - there's no way for the worker to know whether a string should be parsed back into a datetime or kept as a string.

The proper boundary is:
- **Caller responsibility**: Ensure all task arguments are JSON/msgpack-serializable primitives
- **Taskbroker responsibility**: Efficiently serialize/deserialize those primitives

## Test plan

- [x] Added unit tests for `_serialize_value` function covering:
  - Top-level datetime conversion
  - Nested datetime in dicts
  - Nested datetime in lists
  - Deeply nested structures (matching `RpcUser.authenticators` pattern)
  - Frozenset handling
  - Primitive passthrough

Fixes [SENTRY-5NQQ](https://sentry.sentry.io/issues/SENTRY-5NQQ)
Ref [STREAM-882](https://linear.app/getsentry/issue/STREAM-882)