### PR TITLE
fix(api): Tighten project scoping on release-thresholds index

### DIFF
--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_index.py
@@ -47,14 +47,13 @@ class ReleaseThresholdIndexEndpoint(OrganizationEndpoint):
         environments_list = self.get_environments(request, organization)
         projects_list = self.get_projects(request, organization)
 
-        release_query = Q()
+        # `projects_list` is already organization-scoped by `get_projects`, so
+        # `project__in=projects_list` both narrows to the caller's projects and
+        # prevents cross-tenant reads. An empty list yields zero rows.
+        release_query = Q(project__in=projects_list)
         if environments_list:
             release_query &= Q(
                 environment__in=environments_list,
-            )
-        if projects_list:
-            release_query &= Q(
-                project__in=projects_list,
             )
 
         queryset = ReleaseThreshold.objects.filter(release_query)

--- a/tests/sentry/api/endpoints/release_thresholds/test_release_thresholds_index.py
+++ b/tests/sentry/api/endpoints/release_thresholds/test_release_thresholds_index.py
@@ -78,6 +78,41 @@ class ReleaseThresholdTest(APITestCase):
         assert created_threshold["environment"]["id"] == str(self.canary_environment.id)
         assert created_threshold["environment"]["name"] == self.canary_environment.name
 
+    def test_scoped_to_caller_accessible_projects(self) -> None:
+        ReleaseThreshold.objects.create(
+            threshold_type=0,
+            trigger_type=0,
+            value=100,
+            window_in_seconds=1800,
+            project=self.project,
+            environment=self.canary_environment,
+        )
+
+        other_org = self.create_organization()
+        other_project = self.create_project(organization=other_org)
+        other_environment = Environment.objects.create(organization_id=other_org.id, name="canary")
+        ReleaseThreshold.objects.create(
+            threshold_type=0,
+            trigger_type=0,
+            value=200,
+            window_in_seconds=1800,
+            project=other_project,
+            environment=other_environment,
+        )
+
+        # Closed membership so a teamless member has access to zero projects;
+        # otherwise `allow_joinleave` grants global project access and the
+        # `projects_list == []` path that triggered the bug is unreachable.
+        self.organization.flags.allow_joinleave = False
+        self.organization.save()
+
+        member = self.create_user()
+        self.create_member(user=member, organization=self.organization, role="member", teams=[])
+        self.login_as(user=member)
+
+        response = self.get_success_response(self.organization.slug, project="-1")
+        assert response.data == []
+
     def test_get_valid_with_environment(self) -> None:
         response = self.get_success_response(
             self.organization.slug, project="-1", environment="canary"


### PR DESCRIPTION
The release-thresholds index could fall back to an unscoped query when the caller's accessible-project list was empty. Apply project__in unconditionally so the query is always scoped to the caller's projects.
