### PR TITLE
feat(explore): Enable column editor drop downs to search the API

### DIFF
--- a/static/app/views/explore/components/attributeOption.tsx
+++ b/static/app/views/explore/components/attributeOption.tsx
@@ -53,7 +53,17 @@ export function buildAttributeOptions({
   const resolveKind =
     typeof extraColumnKind === 'function' ? extraColumnKind : () => extraColumnKind;
 
+  // Order matters: callers that dedup downstream (e.g. useGroupByFields) keep
+  // the first occurrence by `option.value`. Number/MEASUREMENT comes before
+  // string/TAG and boolean/BOOLEAN so that a key present in multiple typed
+  // collections preserves its measurement variant — matching the prior
+  // hand-rolled ordering before this helper was extracted. extraColumns are
+  // emitted last so server-typed entries always win over a fallback derived
+  // from `extraColumnKind`.
   return [
+    ...Object.values(numberTags).map(tag => optionFromTag(tag, traceItemType)),
+    ...Object.values(stringTags).map(tag => optionFromTag(tag, traceItemType)),
+    ...Object.values(booleanTags).map(tag => optionFromTag(tag, traceItemType)),
     ...extraColumns
       .filter(
         column =>
@@ -68,8 +78,5 @@ export function buildAttributeOptions({
           traceItemType
         )
       ),
-    ...Object.values(stringTags).map(tag => optionFromTag(tag, traceItemType)),
-    ...Object.values(numberTags).map(tag => optionFromTag(tag, traceItemType)),
-    ...Object.values(booleanTags).map(tag => optionFromTag(tag, traceItemType)),
   ];
 }

--- a/static/app/views/explore/components/attributeOption.tsx
+++ b/static/app/views/explore/components/attributeOption.tsx
@@ -10,7 +10,7 @@ export function optionFromTag(tag: Tag, traceItemType: TraceItemDataset) {
   return {
     label: tag.name,
     value: tag.key,
-    textValue: tag.name,
+    textValue: tag.key,
     trailingItems: <TypeBadge kind={tag.kind} />,
     showDetailsInOverlay: true,
     details: (

--- a/static/app/views/explore/components/attributeOption.tsx
+++ b/static/app/views/explore/components/attributeOption.tsx
@@ -10,7 +10,7 @@ export function optionFromTag(tag: Tag, traceItemType: TraceItemDataset) {
   return {
     label: tag.name,
     value: tag.key,
-    textValue: tag.key,
+    textValue: tag.name,
     trailingItems: <TypeBadge kind={tag.kind} />,
     showDetailsInOverlay: true,
     details: (

--- a/static/app/views/explore/components/attributeOption.tsx
+++ b/static/app/views/explore/components/attributeOption.tsx
@@ -1,4 +1,7 @@
-import type {Tag} from 'sentry/types/group';
+import type {SelectOption} from '@sentry/scraps/compactSelect';
+
+import type {Tag, TagCollection} from 'sentry/types/group';
+import {classifyTagKey, FieldKind, prettifyTagKey} from 'sentry/utils/fields';
 import {AttributeDetails} from 'sentry/views/explore/components/attributeDetails';
 import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
 import type {TraceItemDataset} from 'sentry/views/explore/types';
@@ -19,4 +22,54 @@ export function optionFromTag(tag: Tag, traceItemType: TraceItemDataset) {
       />
     ),
   };
+}
+
+interface BuildAttributeOptionsParams {
+  booleanTags: TagCollection;
+  numberTags: TagCollection;
+  stringTags: TagCollection;
+  traceItemType: TraceItemDataset;
+  /**
+   * How to determine the kind for extra columns. Pass a concrete `FieldKind`
+   * to hardcode one, or a function to derive it per column. Defaults to
+   * `classifyTagKey`.
+   */
+  extraColumnKind?: FieldKind | ((column: string) => FieldKind);
+  /**
+   * Extra columns that should be rendered as options even if they are not
+   * present in any of the tag collections.
+   */
+  extraColumns?: readonly string[];
+}
+
+export function buildAttributeOptions({
+  booleanTags,
+  numberTags,
+  stringTags,
+  traceItemType,
+  extraColumns = [],
+  extraColumnKind = classifyTagKey,
+}: BuildAttributeOptionsParams): Array<SelectOption<string>> {
+  const resolveKind =
+    typeof extraColumnKind === 'function' ? extraColumnKind : () => extraColumnKind;
+
+  return [
+    ...extraColumns
+      .filter(
+        column =>
+          column &&
+          !(column in stringTags) &&
+          !(column in numberTags) &&
+          !(column in booleanTags)
+      )
+      .map(column =>
+        optionFromTag(
+          {key: column, name: prettifyTagKey(column), kind: resolveKind(column)},
+          traceItemType
+        )
+      ),
+    ...Object.values(stringTags).map(tag => optionFromTag(tag, traceItemType)),
+    ...Object.values(numberTags).map(tag => optionFromTag(tag, traceItemType)),
+    ...Object.values(booleanTags).map(tag => optionFromTag(tag, traceItemType)),
+  ];
 }

--- a/static/app/views/explore/components/attributeOption.tsx
+++ b/static/app/views/explore/components/attributeOption.tsx
@@ -56,10 +56,8 @@ export function buildAttributeOptions({
   // Order matters: callers that dedup downstream (e.g. useGroupByFields) keep
   // the first occurrence by `option.value`. Number/MEASUREMENT comes before
   // string/TAG and boolean/BOOLEAN so that a key present in multiple typed
-  // collections preserves its measurement variant — matching the prior
-  // hand-rolled ordering before this helper was extracted. extraColumns are
-  // emitted last so server-typed entries always win over a fallback derived
-  // from `extraColumnKind`.
+  // collections preserves its measurement variant, matching the hand-rolled
+  // hand-rolled ordering before this helper was extracted.
   return [
     ...Object.values(numberTags).map(tag => optionFromTag(tag, traceItemType)),
     ...Object.values(stringTags).map(tag => optionFromTag(tag, traceItemType)),

--- a/static/app/views/explore/components/attributeOption.tsx
+++ b/static/app/views/explore/components/attributeOption.tsx
@@ -57,7 +57,7 @@ export function buildAttributeOptions({
   // the first occurrence by `option.value`. Number/MEASUREMENT comes before
   // string/TAG and boolean/BOOLEAN so that a key present in multiple typed
   // collections preserves its measurement variant, matching the hand-rolled
-  // hand-rolled ordering before this helper was extracted.
+  // ordering before this helper was extracted.
   return [
     ...Object.values(numberTags).map(tag => optionFromTag(tag, traceItemType)),
     ...Object.values(stringTags).map(tag => optionFromTag(tag, traceItemType)),

--- a/static/app/views/explore/contexts/traceItemAttributeContext.tsx
+++ b/static/app/views/explore/contexts/traceItemAttributeContext.tsx
@@ -85,7 +85,7 @@ function useTraceItemAttributeConfig({
   const projectIds =
     rawProjects && !isProjectArray(rawProjects) ? rawProjects : undefined;
 
-  const {data, isLoading: attributesLoading} = useQuery({
+  const {data, isFetching: attributesLoading} = useQuery({
     ...traceItemAttributeKeysOptions({
       organization,
       selection,

--- a/static/app/views/explore/contexts/traceItemAttributeContext.tsx
+++ b/static/app/views/explore/contexts/traceItemAttributeContext.tsx
@@ -1,5 +1,5 @@
 import {useMemo} from 'react';
-import {useQuery} from '@tanstack/react-query';
+import {keepPreviousData, useQuery} from '@tanstack/react-query';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import type {TagCollection} from 'sentry/types/group';
@@ -98,6 +98,7 @@ function useTraceItemAttributeConfig({
     }),
     enabled,
     select: selectTraceItemTagCollection(),
+    placeholderData: keepPreviousData,
   });
 
   const booleanBaseKeys = useMemo(() => {

--- a/static/app/views/explore/hooks/useGroupByFields.tsx
+++ b/static/app/views/explore/hooks/useGroupByFields.tsx
@@ -34,15 +34,14 @@ export function useGroupByFields({
   return useMemo(() => {
     const seen = new Set<string>();
     const options = buildAttributeOptions({
-      numberTags,
-      stringTags,
-      booleanTags,
+      numberTags: filterDisallowed(numberTags),
+      stringTags: filterDisallowed(stringTags),
+      booleanTags: filterDisallowed(booleanTags),
       traceItemType,
       extraColumns: groupBys,
       extraColumnKind: FieldKind.TAG,
     })
       .filter(option => {
-        if (DISALLOWED_GROUP_BY_FIELDS.has(option.value)) return false;
         if (seen.has(option.value)) return false;
         seen.add(option.value);
         return true;
@@ -87,6 +86,12 @@ const TRACE_ITEM_FIELD_DEFINITION_TYPE: Partial<
 // Some fields don't make sense to allow users to group by as they create
 // very high cardinality groupings and is not useful.
 const DISALLOWED_GROUP_BY_FIELDS = new Set(['id', 'timestamp']);
+
+function filterDisallowed(tags: TagCollection): TagCollection {
+  return Object.fromEntries(
+    Object.entries(tags).filter(([key]) => !DISALLOWED_GROUP_BY_FIELDS.has(key))
+  );
+}
 
 const Disabled = styled('span')`
   color: ${p => p.theme.tokens.content.secondary};

--- a/static/app/views/explore/hooks/useGroupByFields.tsx
+++ b/static/app/views/explore/hooks/useGroupByFields.tsx
@@ -38,7 +38,7 @@ export function useGroupByFields({
       stringTags: filterDisallowed(stringTags),
       booleanTags: filterDisallowed(booleanTags),
       traceItemType,
-      extraColumns: groupBys,
+      extraColumns: groupBys.filter(column => !DISALLOWED_GROUP_BY_FIELDS.has(column)),
       extraColumnKind: FieldKind.TAG,
     })
       .filter(option => {

--- a/static/app/views/explore/hooks/useGroupByFields.tsx
+++ b/static/app/views/explore/hooks/useGroupByFields.tsx
@@ -5,8 +5,8 @@ import type {SelectOption} from '@sentry/scraps/compactSelect';
 
 import {t} from 'sentry/locale';
 import type {TagCollection} from 'sentry/types/group';
-import {FieldKind, getFieldDefinition, prettifyTagKey} from 'sentry/utils/fields';
-import {optionFromTag} from 'sentry/views/explore/components/attributeOption';
+import {FieldKind, getFieldDefinition} from 'sentry/utils/fields';
+import {buildAttributeOptions} from 'sentry/views/explore/components/attributeOption';
 import {UNGROUPED} from 'sentry/views/explore/contexts/pageParamsContext/groupBys';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
@@ -33,34 +33,16 @@ export function useGroupByFields({
 }: UseGroupByFieldsProps): Array<SelectOption<string>> {
   return useMemo(() => {
     const seen = new Set<string>();
-    const options = [
-      ...Object.entries(numberTags)
-        .filter(([key, _]) => !DISALLOWED_GROUP_BY_FIELDS.has(key))
-        .map(([_, tag]) => optionFromTag(tag, traceItemType)),
-      ...Object.entries(stringTags)
-        .filter(([key, _]) => !DISALLOWED_GROUP_BY_FIELDS.has(key))
-        .map(([_, tag]) => optionFromTag(tag, traceItemType)),
-      ...Object.entries(booleanTags)
-        .filter(([key, _]) => !DISALLOWED_GROUP_BY_FIELDS.has(key))
-        .map(([_, tag]) => optionFromTag(tag, traceItemType)),
-      ...groupBys
-        .filter(
-          groupBy =>
-            groupBy &&
-            !(groupBy in numberTags) &&
-            !(groupBy in stringTags) &&
-            !(groupBy in booleanTags)
-        )
-        .map(groupBy =>
-          optionFromTag(
-            {key: groupBy, name: prettifyTagKey(groupBy), kind: FieldKind.TAG},
-            traceItemType
-          )
-        ),
-    ]
+    const options = buildAttributeOptions({
+      numberTags,
+      stringTags,
+      booleanTags,
+      traceItemType,
+      extraColumns: groupBys,
+      extraColumnKind: FieldKind.TAG,
+    })
       .filter(option => {
-        // Filtering by value here, so it's based off of explicit tags i.e. `key`
-        // or `tags[<key>, <boolean | number | string>]
+        if (DISALLOWED_GROUP_BY_FIELDS.has(option.value)) return false;
         if (seen.has(option.value)) return false;
         seen.add(option.value);
         return true;
@@ -84,9 +66,9 @@ export function useGroupByFields({
         ? []
         : [
             {
-              label: <Disabled>{t('\u2014')}</Disabled>,
+              label: <Disabled>{t('—')}</Disabled>,
               value: UNGROUPED,
-              textValue: t('\u2014'),
+              textValue: t('—'),
             },
           ]),
       ...options,

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -94,6 +94,7 @@ import {
   useSetQueryParamsMode,
 } from 'sentry/views/explore/queryParams/context';
 import {ColumnEditorModal} from 'sentry/views/explore/tables/columnEditorModal';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 import {useRawCounts} from 'sentry/views/explore/useRawCounts';
 
 // eslint-disable-next-line boundaries/dependencies
@@ -362,6 +363,7 @@ export function LogsTabContent({datePageFilterProps, tableExpando}: LogsTabProps
           numberTags={numberAttributes}
           booleanTags={booleanAttributes}
           hiddenKeys={HiddenColumnEditorLogFields}
+          traceItemType={TraceItemDataset.LOGS}
           handleReset={() => {
             onColumnsChange(defaultLogFields());
           }}

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
@@ -32,6 +32,7 @@ import {
   FieldKind,
   getFieldDefinition,
 } from 'sentry/utils/fields';
+import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {DragNDropContext} from 'sentry/views/explore/contexts/dragNDropContext';
 import type {GroupBy} from 'sentry/views/explore/contexts/pageParamsContext/aggregateFields';
@@ -43,6 +44,7 @@ import {
   DEFAULT_VISUALIZATION,
   updateVisualizeAggregate,
 } from 'sentry/views/explore/contexts/pageParamsContext/visualizes';
+import {useSpanItemAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import type {Column} from 'sentry/views/explore/hooks/useDragNDropColumns';
 import {useExploreSuggestedAttribute} from 'sentry/views/explore/hooks/useExploreSuggestedAttribute';
 import {useGroupByFields} from 'sentry/views/explore/hooks/useGroupByFields';
@@ -279,7 +281,20 @@ function GroupBySelector({
   stringTags,
   booleanTags,
 }: GroupBySelectorProps) {
-  const options = useGroupByFields({
+  const [search, setSearch] = useState('');
+  const debouncedSearch = useDebouncedValue(search, 250);
+  const hasSearch = debouncedSearch.length > 0;
+
+  const {attributes: searchedStringTags, isLoading: stringLoading} =
+    useSpanItemAttributes({search: debouncedSearch, enabled: hasSearch}, 'string');
+  const {attributes: searchedNumberTags, isLoading: numberLoading} =
+    useSpanItemAttributes({search: debouncedSearch, enabled: hasSearch}, 'number');
+  const {attributes: searchedBooleanTags, isLoading: booleanLoading} =
+    useSpanItemAttributes({search: debouncedSearch, enabled: hasSearch}, 'boolean');
+
+  const isSearchLoading = hasSearch && (stringLoading || numberLoading || booleanLoading);
+
+  const baseOptions = useGroupByFields({
     groupBys,
     numberTags,
     stringTags,
@@ -287,10 +302,22 @@ function GroupBySelector({
     traceItemType: TraceItemDataset.SPANS,
   });
 
+  const searchedOptions = useGroupByFields({
+    groupBys,
+    numberTags: searchedNumberTags,
+    stringTags: searchedStringTags,
+    booleanTags: searchedBooleanTags,
+    traceItemType: TraceItemDataset.SPANS,
+  });
+
+  const options = hasSearch ? searchedOptions : baseOptions;
+
   const label = useMemo(() => {
-    const tag = options.find(option => option.value === groupBy.groupBy);
+    const tag =
+      options.find(option => option.value === groupBy.groupBy) ??
+      baseOptions.find(option => option.value === groupBy.groupBy);
     return <TriggerLabel>{tag?.label ?? groupBy.groupBy}</TriggerLabel>;
-  }, [groupBy.groupBy, options]);
+  }, [groupBy.groupBy, options, baseOptions]);
 
   const handleChange = useCallback(
     (option: SelectOption<SelectKey>) => {
@@ -305,7 +332,9 @@ function GroupBySelector({
       options={options}
       value={groupBy.groupBy}
       onChange={handleChange}
-      search
+      search={{onChange: setSearch}}
+      loading={isSearchLoading}
+      emptyMessage={isSearchLoading ? t('Loading…') : t('No matching attributes')}
       trigger={triggerProps => (
         <OverlayTrigger.Button
           {...triggerProps}
@@ -362,14 +391,6 @@ function AggregateSelector({
     });
   }, []);
 
-  const argumentOptions = useVisualizeFields({
-    numberTags,
-    stringTags,
-    booleanTags,
-    parsedFunction,
-    traceItemType: TraceItemDataset.SPANS,
-  });
-
   const handleFunctionChange = useCallback(
     (option: SelectOption<SelectKey>) => {
       const newYAxis = updateVisualizeAggregate({
@@ -413,46 +434,101 @@ function AggregateSelector({
           />
         )}
       />
-      {aggregateDefinition?.parameters?.map((param, index) => {
-        return (
-          <DoubleWidthCompactSelect
-            key={param.name}
-            data-test-id="editor-visualize-argument"
-            options={argumentOptions}
-            value={parsedFunction?.arguments[index] ?? param.defaultValue ?? ''}
-            onChange={option => handleArgumentChange(index, option)}
-            search
-            disabled={argumentOptions.length === 1}
-            trigger={triggerProps => (
-              <OverlayTrigger.Button
-                {...triggerProps}
-                style={{
-                  width: '100%',
-                }}
-              />
-            )}
-          />
-        );
-      })}
+      {aggregateDefinition?.parameters?.map((param, index) => (
+        <AttributeArgumentSelect
+          key={param.name}
+          numberTags={numberTags}
+          stringTags={stringTags}
+          booleanTags={booleanTags}
+          parsedFunction={parsedFunction}
+          value={parsedFunction?.arguments[index] ?? param.defaultValue ?? ''}
+          onChange={option => handleArgumentChange(index, option)}
+        />
+      ))}
       {aggregateDefinition?.parameters?.length === 0 && (
-        <DoubleWidthCompactSelect
-          data-test-id="editor-visualize-argument"
-          options={argumentOptions}
+        <AttributeArgumentSelect
+          numberTags={numberTags}
+          stringTags={stringTags}
+          booleanTags={booleanTags}
+          parsedFunction={parsedFunction}
           value={parsedFunction?.arguments[0] ?? ''}
           onChange={option => handleArgumentChange(0, option)}
-          search
-          disabled
-          trigger={triggerProps => (
-            <OverlayTrigger.Button
-              {...triggerProps}
-              style={{
-                width: '100%',
-              }}
-            />
-          )}
+          forceDisabled
         />
       )}
     </Fragment>
+  );
+}
+
+interface AttributeArgumentSelectProps {
+  booleanTags: TagCollection;
+  numberTags: TagCollection;
+  onChange: (option: SelectOption<SelectKey>) => void;
+  parsedFunction: ReturnType<typeof parseFunction>;
+  stringTags: TagCollection;
+  value: string;
+  forceDisabled?: boolean;
+}
+
+function AttributeArgumentSelect({
+  numberTags,
+  stringTags,
+  booleanTags,
+  parsedFunction,
+  value,
+  onChange,
+  forceDisabled,
+}: AttributeArgumentSelectProps) {
+  const [search, setSearch] = useState('');
+  const debouncedSearch = useDebouncedValue(search, 250);
+  const hasSearch = debouncedSearch.length > 0;
+
+  const {attributes: searchedStringTags, isLoading: stringLoading} =
+    useSpanItemAttributes({search: debouncedSearch, enabled: hasSearch}, 'string');
+  const {attributes: searchedNumberTags, isLoading: numberLoading} =
+    useSpanItemAttributes({search: debouncedSearch, enabled: hasSearch}, 'number');
+  const {attributes: searchedBooleanTags, isLoading: booleanLoading} =
+    useSpanItemAttributes({search: debouncedSearch, enabled: hasSearch}, 'boolean');
+
+  const isSearchLoading = hasSearch && (stringLoading || numberLoading || booleanLoading);
+
+  const baseOptions = useVisualizeFields({
+    numberTags,
+    stringTags,
+    booleanTags,
+    parsedFunction,
+    traceItemType: TraceItemDataset.SPANS,
+  });
+
+  const searchedOptions = useVisualizeFields({
+    numberTags: searchedNumberTags,
+    stringTags: searchedStringTags,
+    booleanTags: searchedBooleanTags,
+    parsedFunction,
+    traceItemType: TraceItemDataset.SPANS,
+  });
+
+  const options = hasSearch ? searchedOptions : baseOptions;
+
+  return (
+    <DoubleWidthCompactSelect
+      data-test-id="editor-visualize-argument"
+      options={options}
+      value={value}
+      onChange={onChange}
+      search={{onChange: setSearch}}
+      loading={isSearchLoading}
+      emptyMessage={isSearchLoading ? t('Loading…') : t('No matching attributes')}
+      disabled={forceDisabled || baseOptions.length === 1}
+      trigger={triggerProps => (
+        <OverlayTrigger.Button
+          {...triggerProps}
+          style={{
+            width: '100%',
+          }}
+        />
+      )}
+    />
   );
 }
 

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
@@ -335,7 +335,16 @@ function GroupBySelector({
     hideEmptyOption: true,
   });
 
-  const options = hasSearch ? searchedOptions : baseOptions;
+  // Always feed baseOptions to CompactSelect so its built-in matcher can filter
+  // synchronously while the user types. Merge in any server-only matches once
+  // the debounced search returns.
+  const options = useMemo(() => {
+    if (!hasSearch || searchedOptions.length === 0) return baseOptions;
+    const baseValues = new Set(baseOptions.map(o => o.value));
+    const additions = searchedOptions.filter(o => !baseValues.has(o.value));
+    if (additions.length === 0) return baseOptions;
+    return [...baseOptions, ...additions];
+  }, [hasSearch, baseOptions, searchedOptions]);
 
   const label = useMemo(() => {
     const tag =
@@ -560,7 +569,16 @@ function AttributeArgumentSelect({
     traceItemType: TraceItemDataset.SPANS,
   });
 
-  const options = hasSearch ? searchedOptions : baseOptions;
+  // Always feed baseOptions to CompactSelect so its built-in matcher can filter
+  // synchronously while the user types. Merge in any server-only matches once
+  // the debounced search returns.
+  const options = useMemo(() => {
+    if (!hasSearch || searchedOptions.length === 0) return baseOptions;
+    const baseValues = new Set(baseOptions.map(o => o.value));
+    const additions = searchedOptions.filter(o => !baseValues.has(o.value));
+    if (additions.length === 0) return baseOptions;
+    return [...baseOptions, ...additions];
+  }, [hasSearch, baseOptions, searchedOptions]);
 
   return (
     <DoubleWidthCompactSelect

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
@@ -29,8 +29,10 @@ import {
 } from 'sentry/utils/discover/fields';
 import {
   ALLOWED_EXPLORE_VISUALIZE_AGGREGATES,
+  AggregationKey,
   FieldKind,
   getFieldDefinition,
+  NO_ARGUMENT_SPAN_AGGREGATES,
 } from 'sentry/utils/fields';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -483,14 +485,29 @@ function AttributeArgumentSelect({
   const debouncedSearch = useDebouncedValue(search, 250);
   const hasSearch = debouncedSearch.length > 0;
 
-  const {attributes: searchedStringTags, isLoading: stringLoading} =
-    useSpanItemAttributes({search: debouncedSearch, enabled: hasSearch}, 'string');
-  const {attributes: searchedNumberTags, isLoading: numberLoading} =
-    useSpanItemAttributes({search: debouncedSearch, enabled: hasSearch}, 'number');
-  const {attributes: searchedBooleanTags, isLoading: booleanLoading} =
-    useSpanItemAttributes({search: debouncedSearch, enabled: hasSearch}, 'boolean');
+  const supportedKinds = getSupportedAttributeKinds(parsedFunction?.name);
 
-  const isSearchLoading = hasSearch && (stringLoading || numberLoading || booleanLoading);
+  const {attributes: searchedStringTags, isLoading: stringLoading} =
+    useSpanItemAttributes(
+      {search: debouncedSearch, enabled: hasSearch && supportedKinds.includes('string')},
+      'string'
+    );
+  const {attributes: searchedNumberTags, isLoading: numberLoading} =
+    useSpanItemAttributes(
+      {search: debouncedSearch, enabled: hasSearch && supportedKinds.includes('number')},
+      'number'
+    );
+  const {attributes: searchedBooleanTags, isLoading: booleanLoading} =
+    useSpanItemAttributes(
+      {search: debouncedSearch, enabled: hasSearch && supportedKinds.includes('boolean')},
+      'boolean'
+    );
+
+  const isSearchLoading =
+    hasSearch &&
+    ((supportedKinds.includes('string') && stringLoading) ||
+      (supportedKinds.includes('number') && numberLoading) ||
+      (supportedKinds.includes('boolean') && booleanLoading));
 
   const baseOptions = useVisualizeFields({
     numberTags,
@@ -530,6 +547,18 @@ function AttributeArgumentSelect({
       )}
     />
   );
+}
+
+type AttributeKind = 'string' | 'number' | 'boolean';
+
+function getSupportedAttributeKinds(
+  functionName: string | undefined
+): readonly AttributeKind[] {
+  if (!functionName) return ['number'];
+  if (NO_ARGUMENT_SPAN_AGGREGATES.includes(functionName as AggregationKey)) return [];
+  if (functionName === AggregationKey.COUNT_UNIQUE)
+    return ['string', 'number', 'boolean'];
+  return ['number'];
 }
 
 function EquationSelector({

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
@@ -580,6 +580,17 @@ function AttributeArgumentSelect({
     return [...baseOptions, ...additions];
   }, [hasSearch, baseOptions, searchedOptions]);
 
+  // CompactSelect's default trigger derives its label from the active option
+  // list, which can go blank when a search query doesn't match the current
+  // value. Match the sibling selectors and fall back to baseOptions, then to
+  // the raw value, so the trigger always reflects the current selection.
+  const label = useMemo(() => {
+    const tag =
+      options.find(option => option.value === value) ??
+      baseOptions.find(option => option.value === value);
+    return <TriggerLabel>{tag?.label ?? value}</TriggerLabel>;
+  }, [value, options, baseOptions]);
+
   return (
     <DoubleWidthCompactSelect
       data-test-id="editor-visualize-argument"
@@ -601,7 +612,9 @@ function AttributeArgumentSelect({
           style={{
             width: '100%',
           }}
-        />
+        >
+          {label}
+        </OverlayTrigger.Button>
       )}
     />
   );

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
@@ -310,6 +310,7 @@ function GroupBySelector({
     stringTags: searchedStringTags,
     booleanTags: searchedBooleanTags,
     traceItemType: TraceItemDataset.SPANS,
+    hideEmptyOption: true,
   });
 
   const options = hasSearch ? searchedOptions : baseOptions;
@@ -555,6 +556,8 @@ function getSupportedAttributeKinds(
   functionName: string | undefined
 ): readonly AttributeKind[] {
   if (!functionName) return ['number'];
+  // COUNT renders a fixed SPAN_DURATION option and ignores tag collections.
+  if (functionName === AggregationKey.COUNT) return [];
   if (NO_ARGUMENT_SPAN_AGGREGATES.includes(functionName as AggregationKey)) return [];
   if (functionName === AggregationKey.COUNT_UNIQUE)
     return ['string', 'number', 'boolean'];

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
@@ -36,6 +36,7 @@ import {
 } from 'sentry/utils/fields';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {EXPLORE_FIVE_MIN_STALE_TIME} from 'sentry/views/explore/constants';
 import {DragNDropContext} from 'sentry/views/explore/contexts/dragNDropContext';
 import type {GroupBy} from 'sentry/views/explore/contexts/pageParamsContext/aggregateFields';
 import {
@@ -288,11 +289,32 @@ function GroupBySelector({
   const hasSearch = debouncedSearch.length > 0;
 
   const {attributes: searchedStringTags, isLoading: stringLoading} =
-    useSpanItemAttributes({search: debouncedSearch, enabled: hasSearch}, 'string');
+    useSpanItemAttributes(
+      {
+        search: debouncedSearch,
+        enabled: hasSearch,
+        staleTime: EXPLORE_FIVE_MIN_STALE_TIME,
+      },
+      'string'
+    );
   const {attributes: searchedNumberTags, isLoading: numberLoading} =
-    useSpanItemAttributes({search: debouncedSearch, enabled: hasSearch}, 'number');
+    useSpanItemAttributes(
+      {
+        search: debouncedSearch,
+        enabled: hasSearch,
+        staleTime: EXPLORE_FIVE_MIN_STALE_TIME,
+      },
+      'number'
+    );
   const {attributes: searchedBooleanTags, isLoading: booleanLoading} =
-    useSpanItemAttributes({search: debouncedSearch, enabled: hasSearch}, 'boolean');
+    useSpanItemAttributes(
+      {
+        search: debouncedSearch,
+        enabled: hasSearch,
+        staleTime: EXPLORE_FIVE_MIN_STALE_TIME,
+      },
+      'boolean'
+    );
 
   const isSearchLoading = hasSearch && (stringLoading || numberLoading || booleanLoading);
 
@@ -490,17 +512,29 @@ function AttributeArgumentSelect({
 
   const {attributes: searchedStringTags, isLoading: stringLoading} =
     useSpanItemAttributes(
-      {search: debouncedSearch, enabled: hasSearch && supportedKinds.includes('string')},
+      {
+        search: debouncedSearch,
+        enabled: hasSearch && supportedKinds.includes('string'),
+        staleTime: EXPLORE_FIVE_MIN_STALE_TIME,
+      },
       'string'
     );
   const {attributes: searchedNumberTags, isLoading: numberLoading} =
     useSpanItemAttributes(
-      {search: debouncedSearch, enabled: hasSearch && supportedKinds.includes('number')},
+      {
+        search: debouncedSearch,
+        enabled: hasSearch && supportedKinds.includes('number'),
+        staleTime: EXPLORE_FIVE_MIN_STALE_TIME,
+      },
       'number'
     );
   const {attributes: searchedBooleanTags, isLoading: booleanLoading} =
     useSpanItemAttributes(
-      {search: debouncedSearch, enabled: hasSearch && supportedKinds.includes('boolean')},
+      {
+        search: debouncedSearch,
+        enabled: hasSearch && supportedKinds.includes('boolean'),
+        staleTime: EXPLORE_FIVE_MIN_STALE_TIME,
+      },
       'boolean'
     );
 

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
@@ -305,7 +305,7 @@ function GroupBySelector({
   });
 
   const searchedOptions = useGroupByFields({
-    groupBys,
+    groupBys: [],
     numberTags: searchedNumberTags,
     stringTags: searchedStringTags,
     booleanTags: searchedBooleanTags,

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
@@ -589,7 +589,12 @@ function AttributeArgumentSelect({
       search={{onChange: setSearch}}
       loading={isSearchLoading}
       emptyMessage={isSearchLoading ? t('Loading…') : t('No matching attributes')}
-      disabled={forceDisabled || baseOptions.length === 1}
+      // Stay enabled whenever the function supports server-side search so the
+      // user can type to pull additional attributes, even when baseOptions has
+      // a single entry (e.g. only one number tag fetched in the initial load).
+      disabled={
+        forceDisabled || (supportedKinds.length === 0 && baseOptions.length === 1)
+      }
       trigger={triggerProps => (
         <OverlayTrigger.Button
           {...triggerProps}

--- a/static/app/views/explore/tables/columnEditorModal.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.tsx
@@ -19,6 +19,7 @@ import type {TagCollection} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {buildAttributeOptions} from 'sentry/views/explore/components/attributeOption';
+import {DASHBOARD_ONLY_SPAN_ATTRIBUTES} from 'sentry/views/explore/constants';
 import {DragNDropContext} from 'sentry/views/explore/contexts/dragNDropContext';
 import {useTraceItemDatasetAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import type {Column} from 'sentry/views/explore/hooks/useDragNDropColumns';
@@ -169,23 +170,32 @@ function ColumnEditorRow({
   const debouncedSearch = useDebouncedValue(search, 250);
   const hasSearch = debouncedSearch.length > 0;
 
+  // useSpanItemAttributes folds DASHBOARD_ONLY_SPAN_ATTRIBUTES into hiddenKeys;
+  // useTraceItemDatasetAttributes does not, so we replicate that behavior for spans
+  // to keep search results consistent with the parent-supplied baseOptions.
+  const searchHiddenKeys =
+    traceItemType === TraceItemDataset.SPANS ? DASHBOARD_ONLY_SPAN_ATTRIBUTES : undefined;
+
   const {attributes: searchedStringTags, isLoading: stringLoading} =
     useTraceItemDatasetAttributes(
       traceItemType,
       {search: debouncedSearch, enabled: hasSearch},
-      'string'
+      'string',
+      searchHiddenKeys
     );
   const {attributes: searchedNumberTags, isLoading: numberLoading} =
     useTraceItemDatasetAttributes(
       traceItemType,
       {search: debouncedSearch, enabled: hasSearch},
-      'number'
+      'number',
+      searchHiddenKeys
     );
   const {attributes: searchedBooleanTags, isLoading: booleanLoading} =
     useTraceItemDatasetAttributes(
       traceItemType,
       {search: debouncedSearch, enabled: hasSearch},
-      'boolean'
+      'boolean',
+      searchHiddenKeys
     );
 
   const isSearchLoading = hasSearch && (stringLoading || numberLoading || booleanLoading);
@@ -194,8 +204,11 @@ function ColumnEditorRow({
     if (!hasSearch) {
       return null;
     }
+    // Don't carry the current selection in here — its trigger label falls back
+    // to baseOptions, and including it unconditionally would surface it on
+    // queries that don't actually match it.
     return buildColumnOptions({
-      columns: column.column ? [column.column] : [],
+      columns: [],
       stringTags: searchedStringTags,
       numberTags: searchedNumberTags,
       booleanTags: searchedBooleanTags,
@@ -204,7 +217,6 @@ function ColumnEditorRow({
     });
   }, [
     hasSearch,
-    column.column,
     searchedStringTags,
     searchedNumberTags,
     searchedBooleanTags,

--- a/static/app/views/explore/tables/columnEditorModal.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.tsx
@@ -17,9 +17,7 @@ import {IconDelete} from 'sentry/icons/iconDelete';
 import {t} from 'sentry/locale';
 import type {TagCollection} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
-import {classifyTagKey, FieldKind, prettifyTagKey} from 'sentry/utils/fields';
-import {AttributeDetails} from 'sentry/views/explore/components/attributeDetails';
-import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
+import {buildAttributeOptions} from 'sentry/views/explore/components/attributeOption';
 import {DragNDropContext} from 'sentry/views/explore/contexts/dragNDropContext';
 import type {Column} from 'sentry/views/explore/hooks/useDragNDropColumns';
 import {TraceItemDataset} from 'sentry/views/explore/types';
@@ -51,103 +49,17 @@ export function ColumnEditorModal({
   isDocsButtonHidden = false,
   handleReset,
 }: ColumnEditorModalProps) {
-  const tags: Array<SelectOption<string>> = useMemo(() => {
-    let allTags = [
-      ...columns
-        .filter(
-          column =>
-            !(column in stringTags) && !(column in numberTags) && !(column in booleanTags)
-        )
-        .map(column => {
-          const kind = classifyTagKey(column);
-          const label = prettifyTagKey(column);
-          return {
-            label,
-            value: column,
-            textValue: column,
-            trailingItems: <TypeBadge kind={kind} />,
-            key: `${column}-${classifyTagKey(column)}`,
-            showDetailsInOverlay: true,
-            details: (
-              <AttributeDetails
-                column={column}
-                kind={kind}
-                label={label}
-                traceItemType={TraceItemDataset.SPANS}
-              />
-            ),
-          };
-        }),
-      ...Object.values(stringTags).map(tag => {
-        return {
-          label: tag.name,
-          value: tag.key,
-          textValue: tag.name,
-          trailingItems: <TypeBadge kind={FieldKind.TAG} />,
-          key: `${tag.key}-${FieldKind.TAG}`,
-          showDetailsInOverlay: true,
-          details: (
-            <AttributeDetails
-              column={tag.key}
-              kind={FieldKind.TAG}
-              label={tag.name}
-              traceItemType={TraceItemDataset.SPANS}
-            />
-          ),
-        };
+  const tags = useMemo(
+    () =>
+      buildColumnOptions({
+        columns,
+        stringTags,
+        numberTags,
+        booleanTags,
+        hiddenKeys,
       }),
-      ...Object.values(numberTags).map(tag => {
-        return {
-          label: tag.name,
-          value: tag.key,
-          textValue: tag.name,
-          trailingItems: <TypeBadge kind={FieldKind.MEASUREMENT} />,
-          key: `${tag.key}-${FieldKind.MEASUREMENT}`,
-          showDetailsInOverlay: true,
-          details: (
-            <AttributeDetails
-              column={tag.key}
-              kind={FieldKind.TAG}
-              label={tag.name}
-              traceItemType={TraceItemDataset.SPANS}
-            />
-          ),
-        };
-      }),
-      ...Object.values(booleanTags).map(tag => {
-        return {
-          label: tag.name,
-          value: tag.key,
-          textValue: tag.name,
-          trailingItems: <TypeBadge kind={FieldKind.BOOLEAN} />,
-          key: `${tag.key}-${FieldKind.BOOLEAN}`,
-          showDetailsInOverlay: true,
-          details: (
-            <AttributeDetails
-              column={tag.key}
-              kind={FieldKind.BOOLEAN}
-              label={tag.name}
-              traceItemType={TraceItemDataset.SPANS}
-            />
-          ),
-        };
-      }),
-    ];
-    allTags = allTags
-      .filter(tag => !(hiddenKeys ?? []).includes(tag.label))
-      .toSorted((a, b) => {
-        if (a.label < b.label) {
-          return -1;
-        }
-
-        if (a.label > b.label) {
-          return 1;
-        }
-
-        return 0;
-      });
-    return allTags;
-  }, [booleanTags, columns, hiddenKeys, numberTags, stringTags]);
+    [booleanTags, columns, hiddenKeys, numberTags, stringTags]
+  );
 
   // We keep a temporary state for the columns so that we can apply the changes
   // only when the user clicks on the apply button.
@@ -269,7 +181,7 @@ function ColumnEditorRow({
         );
       }
     }
-    return <TriggerLabel>{column.column || t('\u2014')}</TriggerLabel>;
+    return <TriggerLabel>{column.column || t('—')}</TriggerLabel>;
   }, [column.column, options]);
 
   return (
@@ -312,6 +224,45 @@ function ColumnEditorRow({
       />
     </RowContainer>
   );
+}
+
+interface BuildColumnOptionsParams {
+  booleanTags: TagCollection;
+  columns: readonly string[];
+  numberTags: TagCollection;
+  stringTags: TagCollection;
+  hiddenKeys?: string[];
+}
+
+function buildColumnOptions({
+  columns,
+  stringTags,
+  numberTags,
+  booleanTags,
+  hiddenKeys,
+}: BuildColumnOptionsParams) {
+  return buildAttributeOptions({
+    numberTags,
+    stringTags,
+    booleanTags,
+    traceItemType: TraceItemDataset.SPANS,
+    extraColumns: columns,
+  })
+    .filter(option => {
+      const label = typeof option.label === 'string' ? option.label : option.textValue;
+      return !(hiddenKeys ?? []).includes(label ?? '');
+    })
+    .toSorted((a, b) => {
+      const aLabel = typeof a.label === 'string' ? a.label : (a.textValue ?? '');
+      const bLabel = typeof b.label === 'string' ? b.label : (b.textValue ?? '');
+      if (aLabel < bLabel) {
+        return -1;
+      }
+      if (aLabel > bLabel) {
+        return 1;
+      }
+      return 0;
+    });
 }
 
 const RowContainer = styled('div')`

--- a/static/app/views/explore/tables/columnEditorModal.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.tsx
@@ -20,7 +20,7 @@ import {defined} from 'sentry/utils';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {buildAttributeOptions} from 'sentry/views/explore/components/attributeOption';
 import {DragNDropContext} from 'sentry/views/explore/contexts/dragNDropContext';
-import {useSpanItemAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
+import {useTraceItemDatasetAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import type {Column} from 'sentry/views/explore/hooks/useDragNDropColumns';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
@@ -34,6 +34,7 @@ interface ColumnEditorModalProps extends ModalRenderProps {
   hiddenKeys?: string[];
   isDocsButtonHidden?: boolean;
   requiredTags?: string[];
+  traceItemType?: TraceItemDataset;
 }
 
 export function ColumnEditorModal({
@@ -50,6 +51,7 @@ export function ColumnEditorModal({
   hiddenKeys,
   isDocsButtonHidden = false,
   handleReset,
+  traceItemType = TraceItemDataset.SPANS,
 }: ColumnEditorModalProps) {
   const tags = useMemo(
     () =>
@@ -59,8 +61,9 @@ export function ColumnEditorModal({
         numberTags,
         booleanTags,
         hiddenKeys,
+        traceItemType,
       }),
-    [booleanTags, columns, hiddenKeys, numberTags, stringTags]
+    [booleanTags, columns, hiddenKeys, numberTags, stringTags, traceItemType]
   );
 
   // We keep a temporary state for the columns so that we can apply the changes
@@ -89,6 +92,7 @@ export function ColumnEditorModal({
                   column={column}
                   baseOptions={tags}
                   hiddenKeys={hiddenKeys}
+                  traceItemType={traceItemType}
                   onColumnChange={c => updateColumnAtIndex(i, c)}
                   onColumnDelete={() => deleteColumnAtIndex(i)}
                 />
@@ -142,6 +146,7 @@ interface ColumnEditorRowProps {
   column: Column<string>;
   onColumnChange: (column: string) => void;
   onColumnDelete: () => void;
+  traceItemType: TraceItemDataset;
   hiddenKeys?: string[];
   required?: boolean;
 }
@@ -152,6 +157,7 @@ function ColumnEditorRow({
   required,
   baseOptions,
   hiddenKeys,
+  traceItemType,
   onColumnChange,
   onColumnDelete,
 }: ColumnEditorRowProps) {
@@ -164,11 +170,23 @@ function ColumnEditorRow({
   const hasSearch = debouncedSearch.length > 0;
 
   const {attributes: searchedStringTags, isLoading: stringLoading} =
-    useSpanItemAttributes({search: debouncedSearch, enabled: hasSearch}, 'string');
+    useTraceItemDatasetAttributes(
+      traceItemType,
+      {search: debouncedSearch, enabled: hasSearch},
+      'string'
+    );
   const {attributes: searchedNumberTags, isLoading: numberLoading} =
-    useSpanItemAttributes({search: debouncedSearch, enabled: hasSearch}, 'number');
+    useTraceItemDatasetAttributes(
+      traceItemType,
+      {search: debouncedSearch, enabled: hasSearch},
+      'number'
+    );
   const {attributes: searchedBooleanTags, isLoading: booleanLoading} =
-    useSpanItemAttributes({search: debouncedSearch, enabled: hasSearch}, 'boolean');
+    useTraceItemDatasetAttributes(
+      traceItemType,
+      {search: debouncedSearch, enabled: hasSearch},
+      'boolean'
+    );
 
   const isSearchLoading = hasSearch && (stringLoading || numberLoading || booleanLoading);
 
@@ -182,6 +200,7 @@ function ColumnEditorRow({
       numberTags: searchedNumberTags,
       booleanTags: searchedBooleanTags,
       hiddenKeys,
+      traceItemType,
     });
   }, [
     hasSearch,
@@ -190,6 +209,7 @@ function ColumnEditorRow({
     searchedNumberTags,
     searchedBooleanTags,
     hiddenKeys,
+    traceItemType,
   ]);
 
   const options = searchedOptions ?? baseOptions;
@@ -275,6 +295,7 @@ interface BuildColumnOptionsParams {
   columns: readonly string[];
   numberTags: TagCollection;
   stringTags: TagCollection;
+  traceItemType: TraceItemDataset;
   hiddenKeys?: string[];
 }
 
@@ -284,12 +305,13 @@ function buildColumnOptions({
   numberTags,
   booleanTags,
   hiddenKeys,
+  traceItemType,
 }: BuildColumnOptionsParams) {
   return buildAttributeOptions({
     numberTags,
     stringTags,
     booleanTags,
-    traceItemType: TraceItemDataset.SPANS,
+    traceItemType,
     extraColumns: columns,
   })
     .filter(option => {

--- a/static/app/views/explore/tables/columnEditorModal.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.tsx
@@ -17,8 +17,10 @@ import {IconDelete} from 'sentry/icons/iconDelete';
 import {t} from 'sentry/locale';
 import type {TagCollection} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
+import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {buildAttributeOptions} from 'sentry/views/explore/components/attributeOption';
 import {DragNDropContext} from 'sentry/views/explore/contexts/dragNDropContext';
+import {useSpanItemAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import type {Column} from 'sentry/views/explore/hooks/useDragNDropColumns';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
@@ -85,7 +87,8 @@ export function ColumnEditorModal({
                   canDelete={editableColumns.length > 1}
                   required={requiredTags?.includes(column.column)}
                   column={column}
-                  options={tags}
+                  baseOptions={tags}
+                  hiddenKeys={hiddenKeys}
                   onColumnChange={c => updateColumnAtIndex(i, c)}
                   onColumnDelete={() => deleteColumnAtIndex(i)}
                 />
@@ -134,11 +137,12 @@ export function ColumnEditorModal({
 }
 
 interface ColumnEditorRowProps {
+  baseOptions: Array<SelectOption<string>>;
   canDelete: boolean;
   column: Column<string>;
   onColumnChange: (column: string) => void;
   onColumnDelete: () => void;
-  options: Array<SelectOption<string>>;
+  hiddenKeys?: string[];
   required?: boolean;
 }
 
@@ -146,13 +150,49 @@ function ColumnEditorRow({
   canDelete,
   column,
   required,
-  options,
+  baseOptions,
+  hiddenKeys,
   onColumnChange,
   onColumnDelete,
 }: ColumnEditorRowProps) {
   const {attributes, listeners, setNodeRef, transform, transition} = useSortable({
     id: column.id,
   });
+
+  const [search, setSearch] = useState('');
+  const debouncedSearch = useDebouncedValue(search, 250);
+  const hasSearch = debouncedSearch.length > 0;
+
+  const {attributes: searchedStringTags, isLoading: stringLoading} =
+    useSpanItemAttributes({search: debouncedSearch, enabled: hasSearch}, 'string');
+  const {attributes: searchedNumberTags, isLoading: numberLoading} =
+    useSpanItemAttributes({search: debouncedSearch, enabled: hasSearch}, 'number');
+  const {attributes: searchedBooleanTags, isLoading: booleanLoading} =
+    useSpanItemAttributes({search: debouncedSearch, enabled: hasSearch}, 'boolean');
+
+  const isSearchLoading = hasSearch && (stringLoading || numberLoading || booleanLoading);
+
+  const searchedOptions = useMemo(() => {
+    if (!hasSearch) {
+      return null;
+    }
+    return buildColumnOptions({
+      columns: column.column ? [column.column] : [],
+      stringTags: searchedStringTags,
+      numberTags: searchedNumberTags,
+      booleanTags: searchedBooleanTags,
+      hiddenKeys,
+    });
+  }, [
+    hasSearch,
+    column.column,
+    searchedStringTags,
+    searchedNumberTags,
+    searchedBooleanTags,
+    hiddenKeys,
+  ]);
+
+  const options = searchedOptions ?? baseOptions;
 
   function handleColumnChange(option: SelectOption<SelectKey>) {
     if (defined(option) && typeof option.value === 'string') {
@@ -164,7 +204,9 @@ function ColumnEditorRow({
   // selection. This overrides it to render in a trailing item showing the type.
   const label = useMemo(() => {
     if (defined(column.column)) {
-      const tag = options.find(option => option.value === column.column);
+      const tag =
+        options.find(option => option.value === column.column) ??
+        baseOptions.find(option => option.value === column.column);
       if (defined(tag)) {
         return (
           <TriggerLabel>
@@ -181,8 +223,8 @@ function ColumnEditorRow({
         );
       }
     }
-    return <TriggerLabel>{column.column || t('—')}</TriggerLabel>;
-  }, [column.column, options]);
+    return <TriggerLabel>{column.column || t('\u2014')}</TriggerLabel>;
+  }, [column.column, options, baseOptions]);
 
   return (
     <RowContainer
@@ -201,7 +243,9 @@ function ColumnEditorRow({
         value={column.column ?? ''}
         onChange={handleColumnChange}
         disabled={required}
-        search
+        search={{onChange: setSearch}}
+        loading={isSearchLoading}
+        emptyMessage={isSearchLoading ? t('Loading\u2026') : t('No matching attributes')}
         trigger={triggerProps => (
           <OverlayTrigger.Button
             {...triggerProps}

--- a/static/app/views/explore/tables/columnEditorModal.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.tsx
@@ -350,7 +350,12 @@ function buildColumnOptions({
     traceItemType,
     extraColumns: columns,
   })
-    .filter(option => !(hiddenKeys ?? []).includes(option.value))
+    .filter(option => {
+      const hidden = hiddenKeys ?? [];
+      if (hidden.includes(option.value)) return false;
+      if (typeof option.label === 'string' && hidden.includes(option.label)) return false;
+      return true;
+    })
     .toSorted((a, b) => {
       const aLabel = typeof a.label === 'string' ? a.label : (a.textValue ?? '');
       const bLabel = typeof b.label === 'string' ? b.label : (b.textValue ?? '');

--- a/static/app/views/explore/tables/columnEditorModal.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.tsx
@@ -19,7 +19,10 @@ import type {TagCollection} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
 import {useDebouncedValue} from 'sentry/utils/useDebouncedValue';
 import {buildAttributeOptions} from 'sentry/views/explore/components/attributeOption';
-import {DASHBOARD_ONLY_SPAN_ATTRIBUTES} from 'sentry/views/explore/constants';
+import {
+  DASHBOARD_ONLY_SPAN_ATTRIBUTES,
+  EXPLORE_FIVE_MIN_STALE_TIME,
+} from 'sentry/views/explore/constants';
 import {DragNDropContext} from 'sentry/views/explore/contexts/dragNDropContext';
 import {useTraceItemDatasetAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import type {Column} from 'sentry/views/explore/hooks/useDragNDropColumns';
@@ -185,21 +188,33 @@ function ColumnEditorRow({
   const {attributes: searchedStringTags, isLoading: stringLoading} =
     useTraceItemDatasetAttributes(
       traceItemType,
-      {search: debouncedSearch, enabled: hasSearch},
+      {
+        search: debouncedSearch,
+        enabled: hasSearch,
+        staleTime: EXPLORE_FIVE_MIN_STALE_TIME,
+      },
       'string',
       searchHiddenKeys
     );
   const {attributes: searchedNumberTags, isLoading: numberLoading} =
     useTraceItemDatasetAttributes(
       traceItemType,
-      {search: debouncedSearch, enabled: hasSearch},
+      {
+        search: debouncedSearch,
+        enabled: hasSearch,
+        staleTime: EXPLORE_FIVE_MIN_STALE_TIME,
+      },
       'number',
       searchHiddenKeys
     );
   const {attributes: searchedBooleanTags, isLoading: booleanLoading} =
     useTraceItemDatasetAttributes(
       traceItemType,
-      {search: debouncedSearch, enabled: hasSearch},
+      {
+        search: debouncedSearch,
+        enabled: hasSearch,
+        staleTime: EXPLORE_FIVE_MIN_STALE_TIME,
+      },
       'boolean',
       searchHiddenKeys
     );

--- a/static/app/views/explore/tables/columnEditorModal.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.tsx
@@ -170,11 +170,17 @@ function ColumnEditorRow({
   const debouncedSearch = useDebouncedValue(search, 250);
   const hasSearch = debouncedSearch.length > 0;
 
-  // useSpanItemAttributes folds DASHBOARD_ONLY_SPAN_ATTRIBUTES into hiddenKeys;
-  // useTraceItemDatasetAttributes does not, so we replicate that behavior for spans
-  // to keep search results consistent with the parent-supplied baseOptions.
-  const searchHiddenKeys =
-    traceItemType === TraceItemDataset.SPANS ? DASHBOARD_ONLY_SPAN_ATTRIBUTES : undefined;
+  // The parent's tag collections come pre-filtered: useSpanItemAttributes folds in
+  // DASHBOARD_ONLY_SPAN_ATTRIBUTES, and log callers pass HiddenColumnEditorLogFields
+  // via hiddenKeys. The bare useTraceItemDatasetAttributes does neither, so merge
+  // both here to keep the searched results consistent with baseOptions.
+  const searchHiddenKeys = useMemo(() => {
+    const merged = [...(hiddenKeys ?? [])];
+    if (traceItemType === TraceItemDataset.SPANS) {
+      merged.push(...DASHBOARD_ONLY_SPAN_ATTRIBUTES);
+    }
+    return merged;
+  }, [hiddenKeys, traceItemType]);
 
   const {attributes: searchedStringTags, isLoading: stringLoading} =
     useTraceItemDatasetAttributes(
@@ -326,10 +332,7 @@ function buildColumnOptions({
     traceItemType,
     extraColumns: columns,
   })
-    .filter(option => {
-      const label = typeof option.label === 'string' ? option.label : option.textValue;
-      return !(hiddenKeys ?? []).includes(label ?? '');
-    })
+    .filter(option => !(hiddenKeys ?? []).includes(option.value))
     .toSorted((a, b) => {
       const aLabel = typeof a.label === 'string' ? a.label : (a.textValue ?? '');
       const bLabel = typeof b.label === 'string' ? b.label : (b.textValue ?? '');

--- a/static/app/views/explore/tables/columnEditorModal.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.tsx
@@ -221,14 +221,13 @@ function ColumnEditorRow({
 
   const isSearchLoading = hasSearch && (stringLoading || numberLoading || booleanLoading);
 
-  const searchedOptions = useMemo(() => {
-    if (!hasSearch) {
-      return null;
-    }
-    // Don't carry the current selection in here — its trigger label falls back
-    // to baseOptions, and including it unconditionally would surface it on
-    // queries that don't actually match it.
-    return buildColumnOptions({
+  // Feed CompactSelect the full base list at all times so its built-in matcher
+  // can filter synchronously while typing. Once the debounced server search
+  // returns, merge in any attributes baseOptions doesn't already cover so the
+  // user can still pick keys that weren't in the initial fetch.
+  const options = useMemo(() => {
+    if (!hasSearch) return baseOptions;
+    const searched = buildColumnOptions({
       columns: [],
       stringTags: searchedStringTags,
       numberTags: searchedNumberTags,
@@ -236,16 +235,20 @@ function ColumnEditorRow({
       hiddenKeys,
       traceItemType,
     });
+    if (searched.length === 0) return baseOptions;
+    const baseValues = new Set(baseOptions.map(o => o.value));
+    const additions = searched.filter(o => !baseValues.has(o.value));
+    if (additions.length === 0) return baseOptions;
+    return [...baseOptions, ...additions];
   }, [
     hasSearch,
+    baseOptions,
     searchedStringTags,
     searchedNumberTags,
     searchedBooleanTags,
     hiddenKeys,
     traceItemType,
   ]);
-
-  const options = searchedOptions ?? baseOptions;
 
   function handleColumnChange(option: SelectOption<SelectKey>) {
     if (defined(option) && typeof option.value === 'string') {


### PR DESCRIPTION
This PR updates the column editor for explore attributes so that when the user searches for an attribute we also make a network request so that we can fetch potential attributes that were not sent in the initial request.

Closes EXP-917