### PR TITLE
feat(issue-details): Show detector settings link for AI-detected issues

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidence.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidence.tsx
@@ -32,10 +32,11 @@ function SpanEvidenceInterimSection({
   const typeId = event.occurrence?.type;
   const issueType = getIssueTypeFromOccurrenceType(typeId);
   const issueTitle = event.occurrence?.issueTitle;
-  const sanitizedIssueTitle = issueTitle && sanitizeQuerySelector(issueTitle);
+  const isAiDetected = issueType !== null && AI_DETECTED_ISSUE_TYPES.has(issueType);
   const hasSetting =
-    (isTransactionBased(typeId) && isOccurrenceBased(typeId)) ||
-    (issueType !== null && AI_DETECTED_ISSUE_TYPES.has(issueType));
+    (isTransactionBased(typeId) && isOccurrenceBased(typeId)) || isAiDetected;
+  const hashTitle = isAiDetected ? 'AI Detected' : issueTitle;
+  const sanitizedHash = hashTitle && sanitizeQuerySelector(hashTitle);
 
   return (
     <InterimSection
@@ -52,7 +53,7 @@ function SpanEvidenceInterimSection({
             to={{
               pathname: `/settings/${organization.slug}/projects/${projectSlug}/performance/`,
               query: {issueType},
-              hash: sanitizedIssueTitle,
+              hash: sanitizedHash,
             }}
             size="xs"
             icon={<IconSettings />}

--- a/static/app/components/events/interfaces/performance/spanEvidence.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidence.tsx
@@ -5,6 +5,7 @@ import {IconSettings} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {EventTransaction} from 'sentry/types/event';
 import {
+  AI_DETECTED_ISSUE_TYPES,
   getIssueTypeFromOccurrenceType,
   isOccurrenceBased,
   isTransactionBased,
@@ -32,7 +33,9 @@ function SpanEvidenceInterimSection({
   const issueType = getIssueTypeFromOccurrenceType(typeId);
   const issueTitle = event.occurrence?.issueTitle;
   const sanitizedIssueTitle = issueTitle && sanitizeQuerySelector(issueTitle);
-  const hasSetting = isTransactionBased(typeId) && isOccurrenceBased(typeId);
+  const hasSetting =
+    (isTransactionBased(typeId) && isOccurrenceBased(typeId)) ||
+    (issueType !== null && AI_DETECTED_ISSUE_TYPES.has(issueType));
 
   return (
     <InterimSection

--- a/static/app/views/settings/projectPerformance/projectPerformance.tsx
+++ b/static/app/views/settings/projectPerformance/projectPerformance.tsx
@@ -23,7 +23,7 @@ import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {t, tct} from 'sentry/locale';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {Scope} from 'sentry/types/core';
-import {IssueTitle, IssueType} from 'sentry/types/group';
+import {AI_DETECTED_ISSUE_TYPES, IssueTitle, IssueType} from 'sentry/types/group';
 import type {DynamicSamplingBiasType} from 'sentry/types/sampling';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
@@ -1115,7 +1115,7 @@ export function ProjectPerformance() {
             visible: hasAIIssueDetection,
           },
         ],
-        initiallyCollapsed: issueType !== IssueType.AI_DETECTED_GENERAL,
+        initiallyCollapsed: !AI_DETECTED_ISSUE_TYPES.has(issueType as IssueType),
       },
     ];
 


### PR DESCRIPTION
Render the "Detector Settings" link in the span evidence section for AI-detected issue types. Auto-expand the "AI Detected" group on the project performance settings page when any `ai_detected_*` issue type is passed via the `issueType` query param.
