### PR TITLE
feat(export): Update Storgae config for full trace export for Logs

### DIFF
--- a/src/sentry/data_export/processors/explore.py
+++ b/src/sentry/data_export/processors/explore.py
@@ -196,7 +196,7 @@ class TraceItemFullExportProcessor(ExploreProcessor):
             referrer=Referrer.DATA_EXPORT_TASKS_EXPLORE,
             trace_item_type=self.trace_item_type,
             downsampled_storage_config=DownsampledStorageConfig(
-                mode=DownsampledStorageConfig.MODE_HIGHEST_ACCURACY
+                mode=DownsampledStorageConfig.MODE_HIGHEST_ACCURACY_FLEXTIME
             ),
         )
 

--- a/src/sentry/data_export/processors/explore.py
+++ b/src/sentry/data_export/processors/explore.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any, cast
 
+from sentry_protos.snuba.v1.downsampled_storage_pb2 import DownsampledStorageConfig
 from sentry_protos.snuba.v1.endpoint_trace_items_pb2 import (
     ExportTraceItemsRequest,
     ExportTraceItemsResponse,
@@ -200,6 +201,7 @@ class TraceItemFullExportProcessor(ExploreProcessor):
             end_timestamp=self.snuba_params.rpc_end_date,
             referrer=Referrer.DATA_EXPORT_TASKS_EXPLORE,
             trace_item_type=self.trace_item_type,
+            downsampled_storage_config=DownsampledStorageConfig.MODE_HIGHEST_ACCURACY_FLEXTIME,
         )
 
     def _sync_page_token_from_snuba_response(self, http_resp: ExportTraceItemsResponse) -> None:

--- a/src/sentry/data_export/processors/explore.py
+++ b/src/sentry/data_export/processors/explore.py
@@ -180,15 +180,9 @@ class TraceItemFullExportProcessor(ExploreProcessor):
         *,
         output_mode: OutputMode = OutputMode.CSV,
         page_token: bytes | None = None,
-        last_emitted_item_id_hex: str | None = None,
     ):
         super().__init__(organization, explore_query, output_mode=output_mode)
         self.page_token = page_token
-        self._last_emitted_item_id_hex: str | None = last_emitted_item_id_hex
-
-    @property
-    def last_emitted_item_id_hex(self) -> str | None:
-        return self._last_emitted_item_id_hex
 
     def _create_logs_export_rpc_meta(self) -> RequestMeta:
         if self.snuba_params.organization_id is None:
@@ -201,7 +195,9 @@ class TraceItemFullExportProcessor(ExploreProcessor):
             end_timestamp=self.snuba_params.rpc_end_date,
             referrer=Referrer.DATA_EXPORT_TASKS_EXPLORE,
             trace_item_type=self.trace_item_type,
-            downsampled_storage_config=DownsampledStorageConfig.MODE_HIGHEST_ACCURACY_FLEXTIME,
+            downsampled_storage_config=DownsampledStorageConfig(
+                mode=DownsampledStorageConfig.MODE_HIGHEST_ACCURACY
+            ),
         )
 
     def _sync_page_token_from_snuba_response(self, http_resp: ExportTraceItemsResponse) -> None:
@@ -225,16 +221,5 @@ class TraceItemFullExportProcessor(ExploreProcessor):
         http_resp = export_logs_rpc(request)
         rows = list(iter_export_trace_items_rows(http_resp, self._supported_trace_item_type))
 
-        if self._last_emitted_item_id_hex is not None:
-            while rows and rows[0].get("id") == self._last_emitted_item_id_hex:
-                rows = rows[1:]
-
         self._sync_page_token_from_snuba_response(http_resp)
-
-        if not rows:
-            return []
-
-        last_id = rows[-1].get("id")
-        if isinstance(last_id, str):
-            self._last_emitted_item_id_hex = last_id
-        return rows
+        return rows or []

--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -252,19 +252,16 @@ def _schedule_next_task(
         "export_retries": export_retries,
         "page_token": _page_token_b64_from_processor(processor),
     }
-    should_continue = (
-        new_bytes_written
-        and next_offset < export_limit
-        and (
-            (
-                isinstance(processor, TraceItemFullExportProcessor)
-                and processor.page_token is not None
-            )
-            or (
-                not isinstance(processor, TraceItemFullExportProcessor)
-                and rows
-                and len(rows) >= batch_size
-            )
+    should_continue = next_offset < export_limit and (
+        (
+            isinstance(processor, TraceItemFullExportProcessor)
+            and processor.page_token is not None
+        )
+        or (
+            not isinstance(processor, TraceItemFullExportProcessor)
+            and new_bytes_written
+            and rows
+            and len(rows) >= batch_size
         )
     )
 

--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -253,10 +253,7 @@ def _schedule_next_task(
         "page_token": _page_token_b64_from_processor(processor),
     }
     should_continue = next_offset < export_limit and (
-        (
-            isinstance(processor, TraceItemFullExportProcessor)
-            and processor.page_token is not None
-        )
+        (isinstance(processor, TraceItemFullExportProcessor) and processor.page_token is not None)
         or (
             not isinstance(processor, TraceItemFullExportProcessor)
             and new_bytes_written

--- a/src/sentry/data_export/tasks.py
+++ b/src/sentry/data_export/tasks.py
@@ -134,7 +134,6 @@ def export_chunk_to_stored_blobs(
     data_export: ExportedData,
     export_limit: int,
     environment_id: int | None,
-    last_emitted_item_id_hex: str | None = None,
     first_page: bool = True,
     page_token: str | None = None,
     offset: int = 0,
@@ -148,7 +147,6 @@ def export_chunk_to_stored_blobs(
         environment_id,
         output_mode,
         page_token_b64=page_token,
-        last_emitted_item_id_hex=last_emitted_item_id_hex,
     )
 
     with tempfile.TemporaryFile(mode="w+b") as tf:
@@ -213,7 +211,6 @@ def _schedule_retry(
     environment_id: int | None,
     export_retries: int,
     page_token: str | None,
-    last_emitted_item_id_hex: str | None,
     delay_retry: bool = False,
 ) -> None:
     assemble_download.apply_async(
@@ -226,7 +223,6 @@ def _schedule_retry(
             "environment_id": environment_id,
             "export_retries": export_retries - 1,
             "page_token": page_token,
-            "last_emitted_item_id_hex": last_emitted_item_id_hex,
         },
         countdown=recoverable_retry_countdown(export_retries) if delay_retry else None,
     )
@@ -256,9 +252,6 @@ def _schedule_next_task(
         "export_retries": export_retries,
         "page_token": _page_token_b64_from_processor(processor),
     }
-    if isinstance(processor, TraceItemFullExportProcessor):
-        cont_kwargs["last_emitted_item_id_hex"] = processor.last_emitted_item_id_hex
-
     should_continue = (
         new_bytes_written
         and next_offset < export_limit
@@ -306,7 +299,6 @@ def assemble_download(
     export_retries: int = DEFAULT_EXPORT_RETRIES,
     *,
     page_token: str | None = None,
-    last_emitted_item_id_hex: str | None = None,
     **kwargs: Any,
 ) -> None:
     # The API response to export the data contains the ID which you can use
@@ -337,7 +329,6 @@ def assemble_download(
                 bytes_written=bytes_written,
                 environment_id=environment_id,
                 page_token=page_token,
-                last_emitted_item_id_hex=last_emitted_item_id_hex,
                 first_page=first_page,
             )
         except ExportError as error:
@@ -351,7 +342,6 @@ def assemble_download(
                     environment_id=environment_id,
                     export_retries=export_retries,
                     page_token=page_token,
-                    last_emitted_item_id_hex=last_emitted_item_id_hex,
                     delay_retry=error.delay_retry,
                 )
             else:
@@ -438,7 +428,6 @@ def get_processor(
     output_mode: OutputMode,
     *,
     page_token_b64: str | None = None,
-    last_emitted_item_id_hex: str | None = None,
 ) -> IssuesByTagProcessor | DiscoverProcessor | ExploreProcessor | TraceItemFullExportProcessor:
     try:
         if data_export.query_type == ExportQueryType.ISSUES_BY_TAG:
@@ -473,7 +462,6 @@ def get_processor(
                 organization=data_export.organization,
                 output_mode=output_mode,
                 page_token=page_token,
-                last_emitted_item_id_hex=last_emitted_item_id_hex,
             )
 
         else:

--- a/tests/sentry/data_export/test_tasks.py
+++ b/tests/sentry/data_export/test_tasks.py
@@ -757,7 +757,7 @@ class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogT
                     "rate_limited": "False",
                     "payload_size": p["payload_size"],
                 },
-            )
+            )  # type: ignore[arg-type]
             for i, p in enumerate(per_log)
         ]
         self.store_eap_items(logs)
@@ -803,7 +803,7 @@ class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogT
                 "downsampled_retention_days",
             }
         )
-        return start, end, expected_rows_by_agent, variable_keys
+        return start, end, expected_rows_by_agent, variable_keys  # type: ignore[return-value]
 
     def _assert_explore_logs_jsonl_rows_match_expected(
         self,

--- a/tests/sentry/data_export/test_tasks.py
+++ b/tests/sentry/data_export/test_tasks.py
@@ -743,7 +743,7 @@ class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogT
         ]
         logs = [
             self.create_ourlog(
-                {"body": p["body"], "severity_text": "info", "severity_number": 9},
+                {"body": p["body"], "severity_text": "info", "severity_number": 9},  # type: ignore[arg-type]
                 timestamp=before_now(minutes=10, seconds=i * 30),
                 organization=self.org,
                 project=self.project,
@@ -757,7 +757,7 @@ class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogT
                     "rate_limited": "False",
                     "payload_size": p["payload_size"],
                 },
-            )  # type: ignore[arg-type]
+            )
             for i, p in enumerate(per_log)
         ]
         self.store_eap_items(logs)

--- a/tests/sentry/data_export/test_tasks.py
+++ b/tests/sentry/data_export/test_tasks.py
@@ -717,10 +717,10 @@ class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogT
         self.create_member(user=self.user, organization=self.org, teams=[self.team])
 
     def _store_explore_logs_jsonl_rich_field_fixture(
-        self,
+        self, n: int = 2
     ) -> tuple[str, str, dict[str, dict[str, object]], frozenset[str]]:
         """
-        Two wide logs rows + Snuba ingest. Returns (start_iso, end_iso, expected_rows_by_user_agent, ignore_keys).
+        Store n wide logs rows via Snuba. Returns (start_iso, end_iso, expected_rows_by_user_agent, ignore_keys).
         """
         shared_attrs = {
             "environment": "prod",
@@ -730,89 +730,59 @@ class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogT
             "tags[code.line.number,number]": 148,
             "tags[process.pid,number]": 6639,
         }
+        per_log = [
+            {
+                "body": f"api.access.log{i}",
+                "user_agent": f"agent/{i}",
+                "method": "GET" if i % 2 == 0 else "POST",
+                "path": f"/api/0/log/{i}/",
+                "response": str(200 + i),
+                "payload_size": 1000 + i * 100,
+            }
+            for i in range(n)
+        ]
         logs = [
             self.create_ourlog(
-                {
-                    "body": "api.access.alpha",
-                    "severity_text": "info",
-                    "severity_number": 9,
-                },
-                timestamp=before_now(minutes=10),
+                {"body": p["body"], "severity_text": "info", "severity_number": 9},
+                timestamp=before_now(minutes=10, seconds=i * 30),
                 organization=self.org,
                 project=self.project,
                 attributes={
                     **shared_attrs,
-                    "method": "GET",
-                    "path": "/api/0/projects/acme/issues/",
-                    "user_agent": "python-requests/2.32.5",
+                    "method": p["method"],
+                    "path": p["path"],
+                    "user_agent": p["user_agent"],
                     "logger.name": "sentry.access.api",
-                    "response": "200",
+                    "response": p["response"],
                     "rate_limited": "False",
-                    "payload_size": 981,
+                    "payload_size": p["payload_size"],
                 },
-            ),
-            self.create_ourlog(
-                {
-                    "body": "api.access.beta",
-                    "severity_text": "info",
-                    "severity_number": 9,
-                },
-                timestamp=before_now(minutes=8),
-                organization=self.org,
-                project=self.project,
-                attributes={
-                    **shared_attrs,
-                    "method": "POST",
-                    "path": "/api/0/internal/rpc/",
-                    "user_agent": "curl/8.0",
-                    "logger.name": "sentry.access.api",
-                    "response": "201",
-                    "rate_limited": "False",
-                    "payload_size": 2048,
-                },
-            ),
+            )
+            for i, p in enumerate(per_log)
         ]
         self.store_eap_items(logs)
 
-        expected_rows: list[dict[str, object]] = [
-            {
+        expected_rows_by_agent = {
+            p["user_agent"]: {
                 "sdk.name": "sentry.python.django",
-                "user_agent": "python-requests/2.32.5",
-                "method": "GET",
-                "path": "/api/0/projects/acme/issues/",
                 "sdk.version": "2.47.0",
-                "tags[code.line.number,number]": 148.0,
-                "logger.name": "sentry.access.api",
                 "origin": "auto.log.stdlib",
-                "message": "api.access.alpha",
+                "environment": "prod",
+                "tags[code.line.number,number]": 148.0,
+                "tags[process.pid,number]": 6639.0,
+                "logger.name": "sentry.access.api",
                 "rate_limited": "False",
                 "severity": "info",
-                "environment": "prod",
                 "severity_number": 9.0,
-                "payload_size": 981.0,
-                "tags[process.pid,number]": 6639.0,
-                "response": "200",
-            },
-            {
-                "sdk.name": "sentry.python.django",
-                "user_agent": "curl/8.0",
-                "method": "POST",
-                "path": "/api/0/internal/rpc/",
-                "sdk.version": "2.47.0",
-                "tags[code.line.number,number]": 148.0,
-                "logger.name": "sentry.access.api",
-                "origin": "auto.log.stdlib",
-                "message": "api.access.beta",
-                "rate_limited": "False",
-                "severity": "info",
-                "environment": "prod",
-                "payload_size": 2048.0,
-                "tags[process.pid,number]": 6639.0,
-                "severity_number": 9.0,
-                "response": "201",
-            },
-        ]
-        expected_rows_by_agent = {str(row["user_agent"]): row for row in expected_rows}
+                "user_agent": p["user_agent"],
+                "method": p["method"],
+                "path": p["path"],
+                "message": p["body"],
+                "response": p["response"],
+                "payload_size": float(p["payload_size"]),
+            }
+            for p in per_log
+        }
         start = before_now(minutes=15).isoformat()
         end = before_now(seconds=30).isoformat()
 
@@ -906,14 +876,14 @@ class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogT
         assert de.query_info["dataset"] == "logs"
         return de
 
-    def _assert_rich_field_ndjson_two_rows_match_expected(
+    def _assert_rich_field_ndjson_rows_match_expected(
         self,
         raw_ndjson: bytes,
         expected_rows_by_agent: dict[str, dict[str, object]],
         ignored_keys: frozenset[str],
     ) -> None:
         lines = [ln for ln in raw_ndjson.split(b"\n") if ln]
-        assert len(lines) == 2
+        assert len(lines) == len(expected_rows_by_agent)
         rows = [json.loads(ln.decode("utf-8")) for ln in lines]
         rows_by_agent = {row["user_agent"]: row for row in rows}
         self._assert_explore_logs_jsonl_rows_match_expected(
@@ -1099,7 +1069,7 @@ class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogT
 
         """
         start, end, expected_rows_by_agent, ignored_keys = (
-            self._store_explore_logs_jsonl_rich_field_fixture()
+            self._store_explore_logs_jsonl_rich_field_fixture(n=7)
         )
 
         payload = self._post_explore_logs_jsonl_rich_field_export(start, end)
@@ -1116,7 +1086,7 @@ class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogT
 
         with file.getfile() as f:
             content = f.read().strip()
-        self._assert_rich_field_ndjson_two_rows_match_expected(
+        self._assert_rich_field_ndjson_rows_match_expected(
             content, expected_rows_by_agent, ignored_keys
         )
         assert emailer.called
@@ -1151,7 +1121,7 @@ class AssembleDownloadExploreTest(TestCase, SnubaTestCase, SpanTestCase, OurLogT
         assert file.headers == {"Content-Type": "application/x-ndjson"}
 
         raw = self._get_data_export_download_body(de.id)
-        self._assert_rich_field_ndjson_two_rows_match_expected(
+        self._assert_rich_field_ndjson_rows_match_expected(
             raw, expected_rows_by_agent, ignored_keys
         )
         assert not emailer.called


### PR DESCRIPTION
Full trace item export should use `MODE_HIGHEST_ACCURACY_FLEXTIME`  to handle over scanning data/ and avoid timeouts. It shrinks the scanned window to limit scanning large amounts of data. 

