### PR TITLE
ref(cmdk): Split CMDKAction rendering to avoid useQuery without a resource

### DIFF
--- a/static/app/components/commandPalette/ui/cmdk.tsx
+++ b/static/app/components/commandPalette/ui/cmdk.tsx
@@ -88,6 +88,52 @@ interface CMDKActionProps {
   to?: LocationDescriptor;
 }
 
+interface CMDKActionWithResourceProps {
+  nodeKey: string;
+  query: string;
+  resource: (query: string, context: CMDKResourceContext) => CMDKQueryOptions;
+  state: 'selected' | undefined;
+  children?: React.ReactNode | ((data: CommandPaletteAction[]) => React.ReactNode);
+}
+
+function CMDKActionWithResource({
+  nodeKey,
+  query,
+  state,
+  resource,
+  children,
+}: CMDKActionWithResourceProps) {
+  const resourceOptions = resource(query, {state});
+  const {data} = useQuery({
+    ...resourceOptions,
+    enabled: resourceOptions.enabled ?? true,
+  });
+
+  // Render-prop: call function with async data (existing behavior).
+  // Static children: render as-is. Resource results are auto-rendered alongside
+  // static children so they register in the collection as depth-1 nodes
+  // (no prefix injection in search results).
+  const resolvedChildren =
+    typeof children === 'function' ? (data ? children(data) : null) : (children ?? null);
+
+  const resolvedResourceNodes =
+    typeof children !== 'function' && data
+      ? data.map((item, i) => {
+          // CommandPaletteActionGroup has an `actions` prop that CMDKAction doesn't
+          // accept, so we skip groups here — they can't be auto-rendered as leaf nodes.
+          if ('actions' in item) return null;
+          return <CMDKAction key={i} {...item} />;
+        })
+      : null;
+
+  return (
+    <CMDKCollection.Context.Provider value={nodeKey}>
+      {resolvedChildren}
+      {resolvedResourceNodes}
+    </CMDKCollection.Context.Provider>
+  );
+}
+
 /**
  * Registers a node in the collection. A node becomes a group when it has
  * children — they register under this node as their parent. Provide `to` for
@@ -123,40 +169,26 @@ export function CMDKAction({
   const {query, action: navAction} = useCommandPaletteState();
   const state = navAction?.value.key === key ? 'selected' : undefined;
 
-  const resourceOptions = resource
-    ? resource(query, {state})
-    : {queryKey: [] as unknown[], queryFn: () => null, enabled: false};
-
-  const {data} = useQuery({
-    ...resourceOptions,
-    enabled: !!resource && (resourceOptions.enabled ?? true),
-  });
-
   if (!children && !resource) {
     return null;
   }
 
-  // Render-prop: call function with async data (existing behavior).
-  // Static children: render as-is. Resource results are auto-rendered alongside
-  // static children so they register in the collection as depth-1 nodes
-  // (no prefix injection in search results).
-  const resolvedChildren =
-    typeof children === 'function' ? (data ? children(data) : null) : (children ?? null);
-
-  const resolvedResourceNodes =
-    typeof children !== 'function' && data
-      ? (data as CommandPaletteAction[]).map((item, i) => {
-          // CommandPaletteActionGroup has an `actions` prop that CMDKAction doesn't
-          // accept, so we skip groups here — they can't be auto-rendered as leaf nodes.
-          if ('actions' in item) return null;
-          return <CMDKAction key={i} {...item} />;
-        })
-      : null;
+  if (resource) {
+    return (
+      <CMDKActionWithResource
+        nodeKey={key}
+        query={query}
+        state={state}
+        resource={resource}
+      >
+        {children}
+      </CMDKActionWithResource>
+    );
+  }
 
   return (
     <CMDKCollection.Context.Provider value={key}>
-      {resolvedChildren}
-      {resolvedResourceNodes}
+      {typeof children === 'function' ? null : children}
     </CMDKCollection.Context.Provider>
   );
 }

--- a/static/app/views/explore/spans/content.tsx
+++ b/static/app/views/explore/spans/content.tsx
@@ -33,6 +33,7 @@ import {
   useQueryParamsTitle,
 } from 'sentry/views/explore/queryParams/context';
 import {SavedQueryEditMenu} from 'sentry/views/explore/savedQueryEditMenu';
+import {SpansCommandPaletteActions} from 'sentry/views/explore/spans/spansCommandPaletteActions';
 import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryParamsProvider';
 import {SpansTabContent, SpansTabOnboarding} from 'sentry/views/explore/spans/spansTab';
 import {
@@ -85,6 +86,7 @@ function ExploreContentInner() {
 
   return (
     <SentryDocumentTitle title={t('Traces')} orgSlug={organization?.slug}>
+      <SpansCommandPaletteActions />
       <PageFiltersContainer maxPickableDays={datePageFilterProps.maxPickableDays}>
         <AnalyticsArea name="explore.spans">
           <Stack flex={1}>

--- a/static/app/views/explore/spans/spansCommandPaletteActions.tsx
+++ b/static/app/views/explore/spans/spansCommandPaletteActions.tsx
@@ -1,0 +1,173 @@
+import {useMemo} from 'react';
+import orderBy from 'lodash/orderBy';
+
+import {
+  cmdkQueryOptions,
+  type CMDKQueryOptions,
+} from 'sentry/components/commandPalette/types';
+import {
+  CMDKAction,
+  type CMDKResourceContext,
+} from 'sentry/components/commandPalette/ui/cmdk';
+import {CommandPaletteSlot} from 'sentry/components/commandPalette/ui/commandPaletteSlot';
+import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {IconFilter, IconSpan} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import type {Tag} from 'sentry/types/group';
+import {useApi} from 'sentry/utils/useApi';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {EXPLORE_FIVE_MIN_STALE_TIME} from 'sentry/views/explore/constants';
+import {useSpanItemAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
+import {
+  useAddSearchFilter,
+  useQueryParamsQuery,
+} from 'sentry/views/explore/queryParams/context';
+import {TraceItemDataset} from 'sentry/views/explore/types';
+
+interface SpanAttributeValue {
+  value: string;
+}
+
+function capitalizeLabel(label: string): string {
+  return `${label.charAt(0).toUpperCase()}${label.slice(1)}`;
+}
+
+function FilterActions() {
+  const api = useApi();
+  const organization = useOrganization();
+  const {selection: pageFilters} = usePageFilters();
+  const addSearchFilter = useAddSearchFilter();
+  const currentQuery = useQueryParamsQuery();
+
+  const {attributes: stringAttributes} = useSpanItemAttributes({}, 'string');
+  const {attributes: booleanAttributes} = useSpanItemAttributes({}, 'boolean');
+
+  const pageFilterCacheKey = useMemo(
+    () =>
+      [
+        pageFilters.projects.join(','),
+        pageFilters.datetime.period ?? '',
+        pageFilters.datetime.start?.toString() ?? '',
+        pageFilters.datetime.end?.toString() ?? '',
+      ].join('|'),
+    [pageFilters]
+  );
+
+  const sortedStringAttributes = useMemo(
+    () => orderBy(Object.values(stringAttributes), ['key']),
+    [stringAttributes]
+  );
+
+  const sortedBooleanAttributes = useMemo(
+    () => orderBy(Object.values(booleanAttributes), ['key']),
+    [booleanAttributes]
+  );
+
+  const makeStringFilterItem = (tag: Tag) => ({
+    display: {label: capitalizeLabel(tag.name ?? tag.key)},
+    keywords: [tag.key],
+    prompt: t('Select a value...'),
+    resource: (_q: string, ctx: CMDKResourceContext): CMDKQueryOptions =>
+      // Include currentQuery in the key so onAction closures reference the
+      // current filter state and don't overwrite previously applied filters.
+      // eslint-disable-next-line @tanstack/query/exhaustive-deps
+      cmdkQueryOptions({
+        queryKey: [
+          'cmdk-span-filter-values',
+          tag.key,
+          pageFilterCacheKey,
+          organization.slug,
+          currentQuery,
+        ],
+        queryFn: async () => {
+          const result: SpanAttributeValue[] = await api.requestPromise(
+            `/organizations/${organization.slug}/trace-items/attributes/${tag.key}/values/`,
+            {
+              method: 'GET',
+              query: {
+                itemType: TraceItemDataset.SPANS,
+                attributeType: 'string',
+                ...(pageFilters.projects.length
+                  ? {project: pageFilters.projects.map(String)}
+                  : {}),
+                ...normalizeDateTimeParams(pageFilters.datetime),
+              },
+            }
+          );
+          return result
+            .filter(item => item.value)
+            .map(item => ({
+              display: {label: item.value},
+              onAction: () => addSearchFilter({key: tag.key, value: item.value}),
+            }));
+        },
+        enabled: ctx.state === 'selected',
+        staleTime: EXPLORE_FIVE_MIN_STALE_TIME,
+      }),
+  });
+
+  const makeStringSectionResource =
+    (tags: Tag[], cacheKey: string) =>
+    (_q: string, ctx: CMDKResourceContext): CMDKQueryOptions =>
+      // Include tags.length so the section updates when attributes finish loading.
+      // Include currentQuery so the item closures capture fresh filter state.
+      // eslint-disable-next-line @tanstack/query/exhaustive-deps
+      cmdkQueryOptions({
+        queryKey: [
+          cacheKey,
+          organization.slug,
+          pageFilterCacheKey,
+          currentQuery,
+          tags.length,
+        ],
+        queryFn: () => tags.map(makeStringFilterItem),
+        enabled: ctx.state === 'selected',
+        staleTime: Infinity,
+      });
+
+  return (
+    <CMDKAction
+      display={{label: t('Filter by'), icon: <IconFilter />}}
+      keywords={['search', 'filter', 'narrow', 'where', 'show']}
+    >
+      {sortedStringAttributes.length > 0 && (
+        <CMDKAction
+          display={{label: t('Span Attributes')}}
+          prompt={t('Select a filter...')}
+          limit={4}
+          resource={makeStringSectionResource(
+            sortedStringAttributes,
+            'cmdk-span-filter-keys-string'
+          )}
+        />
+      )}
+      {sortedBooleanAttributes.map(tag => (
+        <CMDKAction
+          key={tag.key}
+          display={{label: capitalizeLabel(tag.name ?? tag.key)}}
+          keywords={[tag.key]}
+        >
+          <CMDKAction
+            display={{label: t('true')}}
+            onAction={() => addSearchFilter({key: tag.key, value: 'true'})}
+          />
+          <CMDKAction
+            display={{label: t('false')}}
+            onAction={() => addSearchFilter({key: tag.key, value: 'false'})}
+          />
+        </CMDKAction>
+      ))}
+    </CMDKAction>
+  );
+}
+
+export function SpansCommandPaletteActions() {
+  return (
+    <CommandPaletteSlot name="page">
+      <CMDKAction display={{label: t('Traces'), icon: <IconSpan />}}>
+        <FilterActions />
+      </CMDKAction>
+    </CommandPaletteSlot>
+  );
+}

--- a/static/app/views/issueList/issueListCommandPaletteActions.tsx
+++ b/static/app/views/issueList/issueListCommandPaletteActions.tsx
@@ -205,12 +205,13 @@ function FilterActions({
       tags: Tag[],
       cacheKey: string
     ): ((q: string, ctx: CMDKResourceContext) => CMDKQueryOptions) =>
-    () =>
+    (_q, ctx) =>
       // Feed query in key ensures onAction closures reference the current query.
       // eslint-disable-next-line @tanstack/query/exhaustive-deps
       cmdkQueryOptions({
         queryKey: [cacheKey, organization.slug, pageFilterCacheKey, query],
         queryFn: () => tags.map(makeFilterKeyItem),
+        enabled: ctx.state === 'selected',
         staleTime: Infinity,
       });
 


### PR DESCRIPTION
Optimize react query observer creations by creating separate component paths for CMDKAction.