### PR TITLE
feat(preprod): Track snapshots tab and row clicks

### DIFF
--- a/static/app/utils/analytics/preprodBuildAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/preprodBuildAnalyticsEvents.tsx
@@ -67,6 +67,9 @@ export type PreprodBuildEventParameters = {
   'preprod.releases.mobile-builds.tab-clicked': {
     organization: Organization;
   };
+  'preprod.releases.snapshots.tab-clicked': {
+    organization: Organization;
+  };
   'preprod.settings.status_check_rule_created': PreprodSettingsEvent;
   'preprod.settings.status_check_rule_deleted': PreprodSettingsEvent;
   'preprod.settings.status_check_rule_updated': PreprodSettingsEvent & {
@@ -74,6 +77,15 @@ export type PreprodBuildEventParameters = {
     measurement: string;
     metric: string;
     value: number;
+  };
+  'preprod.snapshots.list.row_clicked': BasePreprodBuildEvent & {
+    approval_status?: string | null;
+    comparison_state?: string | null;
+    image_count?: number;
+    images_added?: number;
+    images_changed?: number;
+    images_removed?: number;
+    images_unchanged?: number;
   };
 };
 
@@ -100,6 +112,8 @@ export const preprodBuildEventMap: Record<PreprodBuildAnalyticsKey, string | nul
   'preprod.builds.onboarding.docs_clicked': 'Preprod Builds: Onboarding Docs Clicked',
   'preprod.releases.mobile-builds.tab-clicked':
     'Preprod Releases: Mobile Builds Tab Clicked',
+  'preprod.releases.snapshots.tab-clicked': 'Preprod Releases: Snapshots Tab Clicked',
+  'preprod.snapshots.list.row_clicked': 'Preprod Snapshots: List Row Clicked',
   'preprod.settings.status_check_rule_created':
     'Preprod Settings: Status Check Rule Created',
   'preprod.settings.status_check_rule_deleted':

--- a/static/app/views/explore/releases/list/index.tsx
+++ b/static/app/views/explore/releases/list/index.tsx
@@ -375,6 +375,10 @@ export default function ReleasesList() {
       trackAnalytics('preprod.releases.mobile-builds.tab-clicked', {
         organization,
       });
+    } else if (newTab === 'snapshots') {
+      trackAnalytics('preprod.releases.snapshots.tab-clicked', {
+        organization,
+      });
     }
   };
 

--- a/static/app/views/explore/releases/list/mobileBuilds.tsx
+++ b/static/app/views/explore/releases/list/mobileBuilds.tsx
@@ -22,6 +22,7 @@ import {selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {usePreprodBuildsAnalytics} from 'sentry/views/preprod/hooks/usePreprodBuildsAnalytics';
+import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
 import {buildDetailsApiOptions} from 'sentry/views/preprod/utils/buildDetailsApiOptions';
 import {getUpdatedQueryForDisplay} from 'sentry/views/preprod/utils/installableQueryUtils';
 
@@ -170,6 +171,29 @@ export function MobileBuilds({
     [organization, platform]
   );
 
+  const handleRowClick = useCallback(
+    (build: BuildDetailsApiResponse) => {
+      if (activeDisplay !== PreprodBuildsDisplay.SNAPSHOT) {
+        return;
+      }
+      const info = build.snapshot_comparison_info;
+      trackAnalytics('preprod.snapshots.list.row_clicked', {
+        organization,
+        build_id: build.id,
+        platform: build.app_info?.platform ?? null,
+        project_slug: build.project_slug,
+        comparison_state: info?.comparison_state ?? null,
+        approval_status: info?.approval_status ?? null,
+        image_count: info?.image_count,
+        images_added: info?.images_added,
+        images_changed: info?.images_changed,
+        images_removed: info?.images_removed,
+        images_unchanged: info?.images_unchanged,
+      });
+    },
+    [activeDisplay, organization]
+  );
+
   if (selectedProjectIds.length === 0) {
     return <LoadingIndicator />;
   }
@@ -210,6 +234,7 @@ export function MobileBuilds({
             organizationSlug={organization.slug}
             hasSearchQuery={hasSearchQuery}
             showProjectColumn={showProjectColumn}
+            onRowClick={handleRowClick}
           />
         </Fragment>
       )}


### PR DESCRIPTION
Add Amplitude analytics for adoption signal on the snapshots list page (`/explore/releases/?tab=snapshots`).

The snapshot details page is being redesigned, so detail-page instrumentation is deferred. This is the first slice of EME-1006 — capture how users discover and engage with the snapshots list before deeper instrumentation.

The list-load event (`preprod.builds.list.metadata` with `page_source: 'releases_snapshots_tab'`) already fires today. The two gaps were:

1. The Snapshots tab itself was silent on click. Only the Mobile Builds tab fired `preprod.releases.mobile-builds.tab-clicked`.
2. Snapshot row clicks were silent. `PreprodBuildsSnapshotTable` accepted an `onRowClick` prop but `MobileBuilds` did not pass one.

This PR adds:

- `preprod.releases.snapshots.tab-clicked` — fires from `handleTabChange` in the releases list, mirroring the mobile-builds tab event.
- `preprod.snapshots.list.row_clicked` — fires only when `activeDisplay === SNAPSHOT`, with the build identity (`build_id`, `project_slug`, `platform`) plus snapshot-specific dimensions sourced from `BuildDetailsApiResponse.snapshot_comparison_info` (`comparison_state`, `approval_status`, `image_count`, `images_added`, `images_removed`, `images_changed`, `images_unchanged`) so we can slice engagement by snapshot health and change shape.

The mobile-builds row click on this surface is intentionally unchanged — `preprod.builds.release.build_row_clicked` is already wired from the release detail page, and we don't want duplicate events from the list view.

Refs EME-1006