### PR TITLE
fix(seer): Cap profile execution tree depth to prevent Pydantic recursion errors

### DIFF
--- a/src/sentry/seer/explorer/utils.py
+++ b/src/sentry/seer/explorer/utils.py
@@ -50,7 +50,9 @@ def normalize_description(description: str) -> str:
     return description
 
 
-def _convert_profile_to_execution_tree(profile_data: dict) -> tuple[list[dict], str | None]:
+def _convert_profile_to_execution_tree(
+    profile_data: dict, max_depth: int = 200
+) -> tuple[list[dict], str | None]:
     """
     Converts profile data into a hierarchical representation of code execution.
     Selects the thread with the most in_app frames. Returns empty list if no
@@ -256,7 +258,7 @@ def _convert_profile_to_execution_tree(profile_data: dict) -> tuple[list[dict], 
         current = root
         current_path = root["node_id"]
 
-        for frame in stack_frames[1:]:
+        for frame in stack_frames[1:max_depth]:
             current = find_or_create_child(current, frame)
 
             if current["node_id"] is None:

--- a/tests/sentry/seer/explorer/test_explorer_utils.py
+++ b/tests/sentry/seer/explorer/test_explorer_utils.py
@@ -1,6 +1,10 @@
 from typing import Any
 
-from sentry.seer.explorer.utils import convert_profile_to_execution_tree, normalize_description
+from sentry.seer.explorer.utils import (
+    _convert_profile_to_execution_tree,
+    convert_profile_to_execution_tree,
+    normalize_description,
+)
 
 
 class TestNormalizeDescription:
@@ -619,3 +623,45 @@ class TestConvertProfileToExecutionTree:
         assert root.children[0].function == "worker_function_2"
         assert len(root.children[0].children) == 1
         assert root.children[0].children[0].function == "worker_function_1"
+
+    def test_convert_profile_truncates_deep_trees(self) -> None:
+        """Test that extremely deep call stacks are truncated at max_depth."""
+        depth = 300
+        frames = [
+            {
+                "function": f"func_{i}",
+                "module": "app",
+                "filename": "app.py",
+                "lineno": i,
+                "in_app": True,
+            }
+            for i in range(depth)
+        ]
+        # Single stack with all frames: deepest frame first (index 0 = leaf)
+        profile_data: dict[str, Any] = {
+            "profile": {
+                "frames": frames,
+                "stacks": [list(range(depth))],
+                "samples": [
+                    {
+                        "elapsed_since_start_ns": 1000000,
+                        "thread_id": "1",
+                        "stack_id": 0,
+                    }
+                ],
+                "thread_metadata": {"1": {"name": "MainThread"}},
+            }
+        }
+
+        max_depth = 50
+        tree, _ = _convert_profile_to_execution_tree(profile_data, max_depth=max_depth)
+        assert len(tree) == 1
+
+        # Walk the tree to measure actual depth
+        actual_depth = 1
+        node = tree[0]
+        while node.get("children"):
+            actual_depth += 1
+            node = node["children"][0]
+
+        assert actual_depth == max_depth


### PR DESCRIPTION
+ Add max_depth parameter (default 200) to _convert_profile_to_execution_tree to prevent arbitrarily deep trees from triggering Pydantic's recursion guard (~255 levels) during Profile.model_validate() in the Seer explorer index pipeline. Some browser/JS profiles produce 200+ levels of single-child nesting from recursive call chains.

+ Fixes SEER-725 - https://sentry.sentry.io/issues/7147775621/?project=6178942