### PR TITLE
fix(seer): Clear Seer automation handoff preference atomically

### DIFF
--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -21,7 +21,7 @@ from sentry.seer.autofix.coding_agent import IntegrationNotFound
 from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.utils import (
     AutofixStoppingPoint,
-    clear_automation_handoff_preference,
+    clear_preference_automation_handoff,
     read_preference_from_sentry_db,
     set_project_seer_preference,
 )
@@ -509,7 +509,7 @@ class AutofixOnCompletionHook(ExplorerOnCompletionHook):
 
         if features.has("organizations:seer-project-settings-dual-write", organization):
             try:
-                clear_automation_handoff_preference(project)
+                clear_preference_automation_handoff(project)
             except Exception:
                 logger.exception(
                     "seer.write_preferences.failed",

--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -21,10 +21,9 @@ from sentry.seer.autofix.coding_agent import IntegrationNotFound
 from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.utils import (
     AutofixStoppingPoint,
+    clear_automation_handoff_preference,
     read_preference_from_sentry_db,
-    resolve_repository_ids,
     set_project_seer_preference,
-    write_preference_to_sentry_db,
 )
 from sentry.seer.entrypoints.operator import SeerAutofixOperator, process_autofix_updates
 from sentry.seer.explorer.client_models import Artifact
@@ -510,10 +509,7 @@ class AutofixOnCompletionHook(ExplorerOnCompletionHook):
 
         if features.has("organizations:seer-project-settings-dual-write", organization):
             try:
-                resolved_preference = resolve_repository_ids(organization.id, [updated_preference])[
-                    0
-                ]
-                write_preference_to_sentry_db(project, resolved_preference)
+                clear_automation_handoff_preference(project)
             except Exception:
                 logger.exception(
                     "seer.write_preferences.failed",

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -714,7 +714,7 @@ def bulk_write_preferences_to_sentry_db(
     _write_preferences_to_sentry_db(project_preferences)
 
 
-def clear_automation_handoff_preference(project: Project) -> None:
+def clear_preference_automation_handoff(project: Project) -> None:
     """Atomically clear automation_handoff from a project's Seer preferences in Sentry DB."""
     with transaction.atomic(using=router.db_for_write(SeerProjectRepository)):
         # Lock project rows to serialize concurrent preference writes.

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -716,7 +716,7 @@ def bulk_write_preferences_to_sentry_db(
 
 def clear_preference_automation_handoff(project: Project) -> None:
     """Atomically clear automation_handoff from a project's Seer preferences in Sentry DB."""
-    with transaction.atomic(using=router.db_for_write(SeerProjectRepository)):
+    with transaction.atomic(using=router.db_for_write(ProjectOption)):
         # Lock project rows to serialize concurrent preference writes.
         list(Project.objects.select_for_update().filter(id=project.id))
 

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -714,6 +714,18 @@ def bulk_write_preferences_to_sentry_db(
     _write_preferences_to_sentry_db(project_preferences)
 
 
+def clear_automation_handoff_preference(project: Project) -> None:
+    """Atomically clear automation_handoff from a project's Seer preferences in Sentry DB."""
+    with transaction.atomic(using=router.db_for_write(SeerProjectRepository)):
+        # Lock project rows to serialize concurrent preference writes.
+        list(Project.objects.select_for_update().filter(id=project.id))
+
+        project.delete_option("sentry:seer_automation_handoff_point")
+        project.delete_option("sentry:seer_automation_handoff_target")
+        project.delete_option("sentry:seer_automation_handoff_integration_id")
+        project.delete_option("sentry:seer_automation_handoff_auto_create_pr")
+
+
 def build_repo_definition_from_project_repo(
     seer_project_repo: SeerProjectRepository,
 ) -> SeerRepoDefinition | None:

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -84,9 +84,8 @@ from sentry.seer.autofix.coding_agent import (
 from sentry.seer.autofix.utils import (
     AutofixTriggerSource,
     bulk_read_preferences_from_sentry_db,
+    clear_automation_handoff_preference,
     read_preference_from_sentry_db,
-    resolve_repository_ids,
-    write_preference_to_sentry_db,
 )
 from sentry.seer.constants import SEER_SUPPORTED_SCM_PROVIDERS, SeerSCMProvider
 from sentry.seer.entrypoints.operator import SeerAutofixOperator, process_autofix_updates
@@ -624,15 +623,8 @@ def trigger_coding_agent_launch(
                 project = Project.objects.get_from_cache(id=project_id)
                 if project.organization_id != organization_id:
                     raise Project.DoesNotExist
-                preference = read_preference_from_sentry_db(project)
-
-                if preference.automation_handoff is not None:
-                    updated_preference = preference.copy(update={"automation_handoff": None})
-                    resolved_preference = resolve_repository_ids(
-                        organization.id, [updated_preference]
-                    )[0]
-                    write_preference_to_sentry_db(project, resolved_preference)
-                    # Returning the error code will prompt Seer to clear the preference handoff in its own DB too.
+                clear_automation_handoff_preference(project)
+                # Returning the error code will prompt Seer to clear the preference handoff in its own DB too.
         except Exception:
             logger.exception(
                 "coding_agent.clear_handoff_preference_failed",

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -84,7 +84,7 @@ from sentry.seer.autofix.coding_agent import (
 from sentry.seer.autofix.utils import (
     AutofixTriggerSource,
     bulk_read_preferences_from_sentry_db,
-    clear_automation_handoff_preference,
+    clear_preference_automation_handoff,
     read_preference_from_sentry_db,
 )
 from sentry.seer.constants import SEER_SUPPORTED_SCM_PROVIDERS, SeerSCMProvider
@@ -623,7 +623,7 @@ def trigger_coding_agent_launch(
                 project = Project.objects.get_from_cache(id=project_id)
                 if project.organization_id != organization_id:
                     raise Project.DoesNotExist
-                clear_automation_handoff_preference(project)
+                clear_preference_automation_handoff(project)
                 # Returning the error code will prompt Seer to clear the preference handoff in its own DB too.
         except Exception:
             logger.exception(

--- a/tests/sentry/seer/autofix/test_autofix_utils.py
+++ b/tests/sentry/seer/autofix/test_autofix_utils.py
@@ -13,7 +13,7 @@ from sentry.seer.autofix.utils import (
     CodingAgentStatus,
     bulk_read_preferences_from_sentry_db,
     bulk_write_preferences_to_sentry_db,
-    clear_automation_handoff_preference,
+    clear_preference_automation_handoff,
     deduplicate_repositories,
     extract_api_error_message,
     get_autofix_prompt,
@@ -1088,7 +1088,7 @@ class TestWritePreferencesToSentryDb(TestCase):
         assert p2_repo.branch_name == "project-2-branch"
 
 
-class TestClearAutomationHandoffPreference(TestCase):
+class TestClearPreferenceAutomationHandoff(TestCase):
     def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization()
@@ -1114,39 +1114,27 @@ class TestClearAutomationHandoffPreference(TestCase):
         self.project.update_option("sentry:seer_automation_handoff_integration_id", 42)
         self.project.update_option("sentry:seer_automation_handoff_auto_create_pr", True)
 
-        clear_automation_handoff_preference(self.project)
+        clear_preference_automation_handoff(self.project)
 
         self._assert_handoff_options_cleared()
 
     def test_preserves_unrelated_preference_fields(self) -> None:
-        write_preference_to_sentry_db(
-            self.project,
-            SeerProjectPreference(
-                organization_id=self.organization.id,
-                project_id=self.project.id,
-                repositories=[
-                    SeerRepoDefinition(
-                        repository_id=self.repo.id,
-                        provider="github",
-                        owner="test-org",
-                        name="test-repo",
-                        external_id="ext123",
-                        branch_name="develop",
-                        instructions="Use conventional commits",
-                    ),
-                ],
-                automated_run_stopping_point="open_pr",
-                automation_handoff=SeerAutomationHandoffConfiguration(
-                    handoff_point="root_cause",
-                    target="cursor_background_agent",
-                    integration_id=42,
-                    auto_create_pr=True,
-                ),
-            ),
+        self.project.update_option("sentry:seer_automation_handoff_point", "root_cause")
+        self.project.update_option(
+            "sentry:seer_automation_handoff_target", "cursor_background_agent"
         )
+        self.project.update_option("sentry:seer_automation_handoff_integration_id", 42)
+        self.project.update_option("sentry:seer_automation_handoff_auto_create_pr", True)
+        self.project.update_option("sentry:seer_automated_run_stopping_point", "open_pr")
         self.project.update_option("sentry:autofix_automation_tuning", "high")
+        SeerProjectRepository.objects.create(
+            project=self.project,
+            repository_id=self.repo.id,
+            branch_name="develop",
+            instructions="Use conventional commits",
+        )
 
-        clear_automation_handoff_preference(self.project)
+        clear_preference_automation_handoff(self.project)
 
         self._assert_handoff_options_cleared()
         assert self.project.get_option("sentry:seer_automated_run_stopping_point") == "open_pr"
@@ -1158,7 +1146,7 @@ class TestClearAutomationHandoffPreference(TestCase):
         assert seer_repo.instructions == "Use conventional commits"
 
     def test_preserves_no_handoff(self) -> None:
-        clear_automation_handoff_preference(self.project)
+        clear_preference_automation_handoff(self.project)
 
         self._assert_handoff_options_cleared()
 
@@ -1166,7 +1154,7 @@ class TestClearAutomationHandoffPreference(TestCase):
         self.project.update_option("sentry:seer_automation_handoff_point", "root_cause")
         self.project.update_option("sentry:seer_automation_handoff_integration_id", 42)
 
-        clear_automation_handoff_preference(self.project)
+        clear_preference_automation_handoff(self.project)
 
         self._assert_handoff_options_cleared()
 

--- a/tests/sentry/seer/autofix/test_autofix_utils.py
+++ b/tests/sentry/seer/autofix/test_autofix_utils.py
@@ -13,6 +13,7 @@ from sentry.seer.autofix.utils import (
     CodingAgentStatus,
     bulk_read_preferences_from_sentry_db,
     bulk_write_preferences_to_sentry_db,
+    clear_automation_handoff_preference,
     deduplicate_repositories,
     extract_api_error_message,
     get_autofix_prompt,
@@ -1085,6 +1086,91 @@ class TestWritePreferencesToSentryDb(TestCase):
         assert p1_repo.branch_name == "new-branch"
         p2_repo = SeerProjectRepository.objects.get(project=project2)
         assert p2_repo.branch_name == "project-2-branch"
+
+
+class TestClearAutomationHandoffPreference(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.organization = self.create_organization()
+        self.project = self.create_project(organization=self.organization)
+        self.repo = self.create_repo(
+            project=self.project,
+            provider="integrations:github",
+            external_id="ext123",
+            name="test-org/test-repo",
+        )
+
+    def _assert_handoff_options_cleared(self) -> None:
+        assert self.project.get_option("sentry:seer_automation_handoff_point") is None
+        assert self.project.get_option("sentry:seer_automation_handoff_target") is None
+        assert self.project.get_option("sentry:seer_automation_handoff_integration_id") is None
+        assert self.project.get_option("sentry:seer_automation_handoff_auto_create_pr") is False
+
+    def test_clears_all_four_handoff_options(self) -> None:
+        self.project.update_option("sentry:seer_automation_handoff_point", "root_cause")
+        self.project.update_option(
+            "sentry:seer_automation_handoff_target", "cursor_background_agent"
+        )
+        self.project.update_option("sentry:seer_automation_handoff_integration_id", 42)
+        self.project.update_option("sentry:seer_automation_handoff_auto_create_pr", True)
+
+        clear_automation_handoff_preference(self.project)
+
+        self._assert_handoff_options_cleared()
+
+    def test_leaves_unrelated_preference_fields_untouched(self) -> None:
+        """The race-condition fix: clearing handoff must not touch repos, stopping_point,
+        or tuning, which are written via the same SeerProjectPreference object."""
+        write_preference_to_sentry_db(
+            self.project,
+            SeerProjectPreference(
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                repositories=[
+                    SeerRepoDefinition(
+                        repository_id=self.repo.id,
+                        provider="github",
+                        owner="test-org",
+                        name="test-repo",
+                        external_id="ext123",
+                        branch_name="develop",
+                        instructions="Use conventional commits",
+                    ),
+                ],
+                automated_run_stopping_point="open_pr",
+                automation_handoff=SeerAutomationHandoffConfiguration(
+                    handoff_point="root_cause",
+                    target="cursor_background_agent",
+                    integration_id=42,
+                    auto_create_pr=True,
+                ),
+            ),
+        )
+        self.project.update_option("sentry:autofix_automation_tuning", "high")
+
+        clear_automation_handoff_preference(self.project)
+
+        self._assert_handoff_options_cleared()
+        assert self.project.get_option("sentry:seer_automated_run_stopping_point") == "open_pr"
+        assert self.project.get_option("sentry:autofix_automation_tuning") == "high"
+
+        seer_repo = SeerProjectRepository.objects.get(project=self.project)
+        assert seer_repo.repository_id == self.repo.id
+        assert seer_repo.branch_name == "develop"
+        assert seer_repo.instructions == "Use conventional commits"
+
+    def test_preserves_no_handoff(self) -> None:
+        clear_automation_handoff_preference(self.project)
+
+        self._assert_handoff_options_cleared()
+
+    def test_clears_partial_handoff(self) -> None:
+        self.project.update_option("sentry:seer_automation_handoff_point", "root_cause")
+        self.project.update_option("sentry:seer_automation_handoff_integration_id", 42)
+
+        clear_automation_handoff_preference(self.project)
+
+        self._assert_handoff_options_cleared()
 
 
 class TestReadPreferenceFromSentryDb(TestCase):

--- a/tests/sentry/seer/autofix/test_autofix_utils.py
+++ b/tests/sentry/seer/autofix/test_autofix_utils.py
@@ -1118,9 +1118,7 @@ class TestClearAutomationHandoffPreference(TestCase):
 
         self._assert_handoff_options_cleared()
 
-    def test_leaves_unrelated_preference_fields_untouched(self) -> None:
-        """The race-condition fix: clearing handoff must not touch repos, stopping_point,
-        or tuning, which are written via the same SeerProjectPreference object."""
+    def test_preserves_unrelated_preference_fields(self) -> None:
         write_preference_to_sentry_db(
             self.project,
             SeerProjectPreference(

--- a/tests/sentry/seer/autofix/test_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_on_completion_hook.py
@@ -18,12 +18,9 @@ class TestTriggerCodingAgentHandoff(TestCase):
         self.project = self.create_project(organization=self.organization)
         self.group = self.create_group(project=self.project)
 
-    @patch("sentry.seer.autofix.on_completion_hook.write_preference_to_sentry_db")
     @patch("sentry.seer.autofix.on_completion_hook.set_project_seer_preference")
     @patch("sentry.seer.autofix.on_completion_hook.trigger_coding_agent_handoff")
-    def test_not_found_clears_automation_handoff(
-        self, mock_trigger, mock_set_pref, mock_write_db
-    ) -> None:
+    def test_not_found_clears_automation_handoff(self, mock_trigger, mock_set_pref) -> None:
         mock_trigger.side_effect = IntegrationNotFound("Integration not found")
 
         self.project.update_option("sentry:seer_automation_handoff_point", "root_cause")
@@ -31,6 +28,7 @@ class TestTriggerCodingAgentHandoff(TestCase):
             "sentry:seer_automation_handoff_target", CodingAgentProviderType.CURSOR_BACKGROUND_AGENT
         )
         self.project.update_option("sentry:seer_automation_handoff_integration_id", 789)
+        self.project.update_option("sentry:seer_automation_handoff_auto_create_pr", True)
 
         AutofixOnCompletionHook._trigger_coding_agent_handoff(
             organization=self.organization,
@@ -47,16 +45,14 @@ class TestTriggerCodingAgentHandoff(TestCase):
         updated_pref = mock_set_pref.call_args[0][0]
         assert updated_pref.automation_handoff is None
 
-        mock_write_db.assert_called_once()
-        assert mock_write_db.call_args[0][0] == self.project
-        assert mock_write_db.call_args[0][1].automation_handoff is None
+        assert self.project.get_option("sentry:seer_automation_handoff_point") is None
+        assert self.project.get_option("sentry:seer_automation_handoff_target") is None
+        assert self.project.get_option("sentry:seer_automation_handoff_integration_id") is None
+        assert self.project.get_option("sentry:seer_automation_handoff_auto_create_pr") is False
 
-    @patch("sentry.seer.autofix.on_completion_hook.write_preference_to_sentry_db")
     @patch("sentry.seer.autofix.on_completion_hook.set_project_seer_preference")
     @patch("sentry.seer.autofix.on_completion_hook.trigger_coding_agent_handoff")
-    def test_not_found_no_handoff_does_not_call_set(
-        self, mock_trigger, mock_set_pref, mock_write_db
-    ) -> None:
+    def test_not_found_no_handoff_does_not_call_set(self, mock_trigger, mock_set_pref) -> None:
         """With no handoff options set on the project, set_project_seer_preference is skipped."""
         mock_trigger.side_effect = IntegrationNotFound("Integration not found")
 
@@ -75,4 +71,3 @@ class TestTriggerCodingAgentHandoff(TestCase):
         )
 
         mock_set_pref.assert_not_called()
-        mock_write_db.assert_not_called()


### PR DESCRIPTION
Replace read-modify-write of the full SeerProjectPreference with a helper that locks the project row and deletes only the four handoff ProjectOption keys. 

We avoid potential race conditions here where we read the pref, something else modifies a non-handoff part of the pref, then we write the pref with cleared handoff but stale in other parts of the pref.