### PR TITLE
feat(seer): Code mode slash commands (off/on/only)

### DIFF
--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.spec.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.spec.tsx
@@ -16,7 +16,7 @@ const defaultHookReturn: ReturnType<typeof useSeerExplorerModule.useSeerExplorer
   runId: null,
   waitingForInterrupt: false,
   overrideCtxEngEnable: true,
-  overrideCodeModeEnable: false,
+  overrideCodeModeEnable: 'off',
   sendMessage: jest.fn(),
   switchToRun: jest.fn(),
   startNewSession: jest.fn(),

--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
@@ -70,7 +70,6 @@ export function ExplorerDrawerContent({
     waitingForInterrupt,
     overrideCtxEngEnable,
     setOverrideCtxEngEnable,
-    overrideCodeModeEnable,
     setOverrideCodeModeEnable,
   } = useSeerExplorer();
 
@@ -209,6 +208,9 @@ export function ExplorerDrawerContent({
       onFeedback: openFeedbackForm ? handleFeedback : undefined,
       onLangfuse: langfuseUrl ? handleOpenLangfuse : undefined,
       onConversations: conversationsUrl ? handleOpenConversations : undefined,
+      onCodeMode: organization?.features.includes('seer-explorer-code-mode-tools')
+        ? setOverrideCodeModeEnable
+        : undefined,
     },
     inputAnchorRef: textareaRef,
     prWidgetAnchorRef: prWidgetButtonRef,
@@ -334,11 +336,6 @@ export function ExplorerDrawerContent({
           !!organization?.features.includes(
             'seer-explorer-context-engine-fe-override-ui-flag'
           )
-        }
-        overrideCodeModeEnable={overrideCodeModeEnable}
-        onOverrideCodeModeEnableChange={setOverrideCodeModeEnable}
-        showCodeModeToggle={
-          !!organization?.features.includes('seer-explorer-code-mode-tools')
         }
         showThinking={showThinking}
         onShowThinkingToggle={() => setShowThinking(v => !v)}

--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
@@ -336,7 +336,7 @@ export function ExplorerDrawerContent({
           )
         }
         overrideCodeModeEnable={overrideCodeModeEnable}
-        onOverrideCodeModeEnableToggle={() => setOverrideCodeModeEnable(v => !v)}
+        onOverrideCodeModeEnableChange={setOverrideCodeModeEnable}
         showCodeModeToggle={
           !!organization?.features.includes('seer-explorer-code-mode-tools')
         }

--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerHeader.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerHeader.tsx
@@ -5,7 +5,6 @@ import {FeatureBadge} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {DrawerHeader} from '@sentry/scraps/drawer';
 import {Flex} from '@sentry/scraps/layout';
-import {SegmentedControl} from '@sentry/scraps/segmentedControl';
 import {Switch} from '@sentry/scraps/switch';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -24,12 +23,9 @@ interface ExplorerDrawerHeaderProps {
   onCopyLinkClick: (() => void) | undefined;
   onCopySessionClick: (() => void) | undefined;
   onNewChatClick: () => void;
-  onOverrideCodeModeEnableChange: (value: 'off' | 'on' | 'only') => void;
   onOverrideCtxEngEnableToggle: () => void;
   onShowThinkingToggle: () => void;
-  overrideCodeModeEnable: 'off' | 'on' | 'only';
   overrideCtxEngEnable: boolean;
-  showCodeModeToggle: boolean;
   showContextEngineToggle: boolean;
   showThinking: boolean;
   showThinkingToggle: boolean;
@@ -44,9 +40,6 @@ export function ExplorerDrawerHeader({
   showContextEngineToggle,
   overrideCtxEngEnable,
   onOverrideCtxEngEnableToggle,
-  showCodeModeToggle,
-  overrideCodeModeEnable,
-  onOverrideCodeModeEnableChange,
   showThinking,
   showThinkingToggle,
   onShowThinkingToggle,
@@ -135,23 +128,6 @@ export function ExplorerDrawerHeader({
               </Text>
             </Flex>
           </Tooltip>
-        )}
-        {showCodeModeToggle && (
-          <Flex align="center" gap="xs" padding="xs sm" height="100%">
-            <Text size="sm" variant="muted">
-              {t('CM')}
-            </Text>
-            <SegmentedControl
-              size="xs"
-              value={overrideCodeModeEnable}
-              onChange={onOverrideCodeModeEnableChange}
-              aria-label={t('Code mode')}
-            >
-              <SegmentedControl.Item key="off">{t('Off')}</SegmentedControl.Item>
-              <SegmentedControl.Item key="on">{t('On')}</SegmentedControl.Item>
-              <SegmentedControl.Item key="only">{t('Only')}</SegmentedControl.Item>
-            </SegmentedControl>
-          </Flex>
         )}
         {showThinkingToggle && (
           <Tooltip

--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerHeader.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerHeader.tsx
@@ -5,6 +5,7 @@ import {FeatureBadge} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {DrawerHeader} from '@sentry/scraps/drawer';
 import {Flex} from '@sentry/scraps/layout';
+import {SegmentedControl} from '@sentry/scraps/segmentedControl';
 import {Switch} from '@sentry/scraps/switch';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -23,10 +24,10 @@ interface ExplorerDrawerHeaderProps {
   onCopyLinkClick: (() => void) | undefined;
   onCopySessionClick: (() => void) | undefined;
   onNewChatClick: () => void;
-  onOverrideCodeModeEnableToggle: () => void;
+  onOverrideCodeModeEnableChange: (value: 'off' | 'on' | 'only') => void;
   onOverrideCtxEngEnableToggle: () => void;
   onShowThinkingToggle: () => void;
-  overrideCodeModeEnable: boolean;
+  overrideCodeModeEnable: 'off' | 'on' | 'only';
   overrideCtxEngEnable: boolean;
   showCodeModeToggle: boolean;
   showContextEngineToggle: boolean;
@@ -45,7 +46,7 @@ export function ExplorerDrawerHeader({
   onOverrideCtxEngEnableToggle,
   showCodeModeToggle,
   overrideCodeModeEnable,
-  onOverrideCodeModeEnableToggle,
+  onOverrideCodeModeEnableChange,
   showThinking,
   showThinkingToggle,
   onShowThinkingToggle,
@@ -136,25 +137,21 @@ export function ExplorerDrawerHeader({
           </Tooltip>
         )}
         {showCodeModeToggle && (
-          <Tooltip
-            title={
-              overrideCodeModeEnable
-                ? t('Code mode enabled (click to disable)')
-                : t('Code mode disabled (click to enable)')
-            }
-          >
-            <Flex align="center" gap="xs" padding="xs sm" height="100%">
-              <Switch
-                size="sm"
-                checked={overrideCodeModeEnable}
-                onChange={onOverrideCodeModeEnableToggle}
-                aria-label={t('Toggle code mode')}
-              />
-              <Text size="sm" variant="muted">
-                {t('CM')}
-              </Text>
-            </Flex>
-          </Tooltip>
+          <Flex align="center" gap="xs" padding="xs sm" height="100%">
+            <Text size="sm" variant="muted">
+              {t('CM')}
+            </Text>
+            <SegmentedControl
+              size="xs"
+              value={overrideCodeModeEnable}
+              onChange={onOverrideCodeModeEnableChange}
+              aria-label={t('Code mode')}
+            >
+              <SegmentedControl.Item key="off">{t('Off')}</SegmentedControl.Item>
+              <SegmentedControl.Item key="on">{t('On')}</SegmentedControl.Item>
+              <SegmentedControl.Item key="only">{t('Only')}</SegmentedControl.Item>
+            </SegmentedControl>
+          </Flex>
         )}
         {showThinkingToggle && (
           <Tooltip

--- a/static/app/views/seerExplorer/components/explorerMenu.tsx
+++ b/static/app/views/seerExplorer/components/explorerMenu.tsx
@@ -333,19 +333,19 @@ function useSlashCommands({
       ...(onCodeMode
         ? [
             {
-              title: '/code-mode off',
+              title: '/code-mode-off',
               key: '/code-mode-off',
               description: 'Disable code mode tools',
               handler: () => onCodeMode('off'),
             },
             {
-              title: '/code-mode on',
+              title: '/code-mode-on',
               key: '/code-mode-on',
               description: 'Enable code mode tools alongside standard tools',
               handler: () => onCodeMode('on'),
             },
             {
-              title: '/code-mode only',
+              title: '/code-mode-only',
               key: '/code-mode-only',
               description: 'Use only code mode tools (no standard tools)',
               handler: () => onCodeMode('only'),

--- a/static/app/views/seerExplorer/components/explorerMenu.tsx
+++ b/static/app/views/seerExplorer/components/explorerMenu.tsx
@@ -330,7 +330,7 @@ function useSlashCommands({
             },
           ]
         : []),
-      ...(onCodeMode
+      ...(isSentryEmployee && onCodeMode
         ? [
             {
               title: '/code-mode-off',

--- a/static/app/views/seerExplorer/components/explorerMenu.tsx
+++ b/static/app/views/seerExplorer/components/explorerMenu.tsx
@@ -8,6 +8,7 @@ type MenuMode = 'slash-commands-keyboard' | 'pr-widget' | 'hidden';
 interface SlashCommandHandlers {
   onFeedback: (() => void) | undefined;
   onNew: () => void;
+  onCodeMode?: (value: 'off' | 'on' | 'only') => void;
   onConversations?: () => void;
   onLangfuse?: () => void;
   onMaxSize?: () => void;
@@ -287,6 +288,7 @@ function useSlashCommands({
   onFeedback,
   onLangfuse,
   onConversations,
+  onCodeMode,
 }: SlashCommandHandlers): MenuItemProps[] {
   const isSentryEmployee = useIsSentryEmployee();
 
@@ -328,6 +330,28 @@ function useSlashCommands({
             },
           ]
         : []),
+      ...(onCodeMode
+        ? [
+            {
+              title: '/code-mode off',
+              key: '/code-mode-off',
+              description: 'Disable code mode tools',
+              handler: () => onCodeMode('off'),
+            },
+            {
+              title: '/code-mode on',
+              key: '/code-mode-on',
+              description: 'Enable code mode tools alongside standard tools',
+              handler: () => onCodeMode('on'),
+            },
+            {
+              title: '/code-mode only',
+              key: '/code-mode-only',
+              description: 'Use only code mode tools (no standard tools)',
+              handler: () => onCodeMode('only'),
+            },
+          ]
+        : []),
       ...(isSentryEmployee && onLangfuse
         ? [
             {
@@ -354,6 +378,7 @@ function useSlashCommands({
       onMaxSize,
       onMedSize,
       onFeedback,
+      onCodeMode,
       onLangfuse,
       onConversations,
       isSentryEmployee,

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -114,8 +114,24 @@ export const useSeerExplorer = () => {
     'seer-explorer.override.ctx-eng',
     true
   );
+  type CodeModeValue = 'off' | 'on' | 'only';
   const [overrideCodeModeEnable, setOverrideCodeModeEnable] =
-    useLocalStorageState<boolean>('seer-explorer.override.code-mode', true);
+    useLocalStorageState<CodeModeValue>(
+      'seer-explorer.override.code-mode',
+      (storedValue?: unknown): CodeModeValue => {
+        if (storedValue === 'off' || storedValue === 'on' || storedValue === 'only') {
+          return storedValue;
+        }
+        // Migrate legacy boolean values
+        if (storedValue === true) {
+          return 'on';
+        }
+        if (storedValue === false) {
+          return 'off';
+        }
+        return 'on'; // default
+      }
+    );
 
   const [runId, setRunId] = useSeerExplorerRunId();
 
@@ -139,7 +155,7 @@ export const useSeerExplorer = () => {
     {
       insertIndex: number;
       orgSlug: string;
-      overrideCodeModeEnable: boolean;
+      overrideCodeModeEnable: 'off' | 'on' | 'only';
       overrideCtxEngEnable: boolean;
       pageName: string;
       query: string;


### PR DESCRIPTION
## Summary

Frontend change to add `/code-mode-off`, `/code-mode-on`, `/code-mode-only` slash commands to the Explorer chat.

**Depends on:** #114259 (backend: tri-state code mode serializer)

## Changes

- Add `/code-mode-off`, `/code-mode-on`, `/code-mode-only` slash commands gated by feature flag + `isSentryEmployee`
- Remove SegmentedControl from drawer header (was overflowing 30% sidebar)
- Update `useSeerExplorer` hook to store tri-state value in localStorage
- Context engine and thinking toggles remain unchanged in header

## Test plan

- [x] `CI=true pnpm test explorerDrawerContent.spec.tsx` — 16/16 passing
- [x] Lint: eslint passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)