### PR TITLE
ref(seer): tweak loading state

### DIFF
--- a/static/app/icons/iconSeer.tsx
+++ b/static/app/icons/iconSeer.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import {useReducedMotion} from 'framer-motion';
 
 import type {SVGIconProps} from './svgIcon';
 import {SvgIcon} from './svgIcon';
@@ -10,12 +11,14 @@ interface IconSeerProps extends SVGIconProps {
 export function IconSeer({animation, ...props}: IconSeerProps) {
   const commonPath =
     'M8.01759 0.25C8.23262 0.249787 8.43757 0.341936 8.58009 0.50293C9.70729 1.77804 11.2269 3.70119 12.626 5.82324C13.9841 7.8832 15.2561 10.1746 15.9317 12.2656C15.9736 12.3357 16.005 12.4135 16.0225 12.4971C16.0949 12.8447 15.9134 13.1959 15.5879 13.3379C13.4024 14.2912 11.151 15 8.01857 15C4.88669 15 2.63318 14.2943 0.451185 13.3457C0.17589 13.226 -0.00176762 12.9535 1.33514e-05 12.6533C0.00080069 12.526 0.0359022 12.4049 0.0947399 12.2979C0.767604 10.203 2.04619 7.9014 3.41115 5.83105C4.81012 3.70913 6.32944 1.78347 7.45607 0.503906L7.51173 0.447266C7.64909 0.321318 7.82933 0.250248 8.01759 0.25ZM13.666 10.6562C12.0686 11.1903 10.117 11.5 8.01857 11.5C5.92124 11.5 3.96583 11.1911 2.37111 10.6572C2.11538 11.1963 1.88727 11.7258 1.69923 12.2402C3.54489 12.9877 5.45222 13.5 8.01857 13.5C10.5835 13.5 12.4883 12.9863 14.336 12.2354C14.1485 11.7218 13.9206 11.1939 13.666 10.6562ZM8.01857 5.5C5.93882 5.50013 4.03972 6.99814 3.14259 9.3291C4.50943 9.74712 6.18916 9.99997 8.01857 10C9.84849 9.99998 11.5258 9.74671 12.8955 9.32812C11.9966 6.998 10.098 5.50012 8.01857 5.5ZM8.01954 2.15234C7.51245 2.75664 6.94957 3.46183 6.37013 4.23438C6.89523 4.08216 7.44681 4.00003 8.01857 4C8.59213 4.00002 9.14526 4.08221 9.67189 4.23535C9.09134 3.46176 8.52751 2.756 8.01954 2.15234Z';
+  const prefersReducedMotion = useReducedMotion();
 
-  if (animation === 'waiting') {
-    return (
-      <SvgIcon {...props}>
-        <Fragment>
-          <style>{`
+  if (!prefersReducedMotion) {
+    if (animation === 'waiting') {
+      return (
+        <SvgIcon {...props}>
+          <Fragment>
+            <style>{`
             @keyframes moveHorizontal {
               0% { transform: translateX(0); }
               5%, 40% { transform: translateX(-1.6px); }
@@ -27,28 +30,29 @@ export function IconSeer({animation, ...props}: IconSeerProps) {
               animation: moveHorizontal 4s ease-out infinite;
             }
           `}</style>
-          <path d={commonPath} />
-          <circle className="pupil-waiting" cx="8" cy="9" r="2" />
-        </Fragment>
-      </SvgIcon>
-    );
-  }
+            <path d={commonPath} />
+            <circle className="pupil-waiting" cx="8" cy="9" r="2" />
+          </Fragment>
+        </SvgIcon>
+      );
+    }
 
-  if (animation === 'loading') {
-    return (
-      <SvgIcon {...props}>
-        <Fragment>
-          <path d={commonPath} />
-          <circle className="pupil-loading" r="2">
-            <animateMotion
-              path="M 8 7 A 1 1 0 0 1 8 9 A 1 1 0 0 1 8 7"
-              dur="1s"
-              repeatCount="indefinite"
-            />
-          </circle>
-        </Fragment>
-      </SvgIcon>
-    );
+    if (animation === 'loading') {
+      return (
+        <SvgIcon {...props}>
+          <Fragment>
+            <path d={commonPath} />
+            <circle className="pupil-loading" r="2">
+              <animateMotion
+                path="M 8 7 A 1 1 0 0 1 8 9 A 1 1 0 0 1 8 7"
+                dur="1s"
+                repeatCount="indefinite"
+              />
+            </circle>
+          </Fragment>
+        </SvgIcon>
+      );
+    }
   }
 
   return (

--- a/static/app/views/seerExplorer/components/askSeerButton.tsx
+++ b/static/app/views/seerExplorer/components/askSeerButton.tsx
@@ -1,62 +1,92 @@
-import type {PropsWithChildren} from 'react';
 import styled from '@emotion/styled';
+import {useReducedMotion} from 'framer-motion';
 
 import type {ButtonProps} from '@sentry/scraps/button';
 import {Button} from '@sentry/scraps/button';
 import {Hotkey} from '@sentry/scraps/hotkey';
-import {Flex} from '@sentry/scraps/layout';
+import {Container, Flex} from '@sentry/scraps/layout';
 import {IndeterminateLoader} from '@sentry/scraps/loader';
 import {StatusIndicator} from '@sentry/scraps/statusIndicator';
 
 import {IconSeer} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {useSeerExplorerContext} from 'sentry/views/seerExplorer/useSeerExplorerContext';
+import {
+  useSeerExplorerContext,
+  type SeerExplorerSessionState,
+} from 'sentry/views/seerExplorer/useSeerExplorerContext';
 import {isSeerExplorerEnabled} from 'sentry/views/seerExplorer/utils';
 
 export function AskSeerButton() {
   const organization = useOrganization({allowNull: true});
-  const {isOpen, toggleSeerExplorer, sessionState} = useSeerExplorerContext();
+  const {isOpen, toggleSeerExplorer, sessionState: state} = useSeerExplorerContext();
 
   if (!organization || !isSeerExplorerEnabled(organization)) {
     return null;
   }
 
-  const visibility = sessionState === 'thinking' ? 'hidden' : undefined;
-
-  const icon =
-    !isOpen && sessionState === 'done-thinking' ? (
-      <StatusIndicator variant="accent" />
-    ) : (
-      <IconSeer
-        visibility={visibility}
-        animation={sessionState === 'thinking' ? 'loading' : undefined}
-      />
-    );
   const props: ButtonProps = {
-    'aria-label': sessionState === 'thinking' ? t('Seer is thinking...') : t('Ask Seer'),
+    'aria-label': state === 'thinking' ? t('Seer is thinking...') : t('Ask Seer'),
     'aria-expanded': isOpen ? true : undefined,
     priority: 'default',
-    icon: <IconWrapper>{icon}</IconWrapper>,
+    icon: <MessageIndicator state={state} isOpen={isOpen} />,
   };
 
   return (
     <SeerButton {...props} onClick={toggleSeerExplorer}>
-      <Flex align="center" gap="sm" visibility={visibility}>
-        {t('Ask Seer')}
-        <Hotkey value="command+/" variant="debossed" />
+      <Flex position="relative">
+        <Flex
+          align="center"
+          gap="sm"
+          visibility={state === 'thinking' ? 'hidden' : undefined}
+        >
+          <Container>{t('Ask Seer')}</Container>
+          <Hotkey value="command+/" variant="debossed" />
+        </Flex>
+        <ThinkingIndicator state={state} />
       </Flex>
-      {sessionState === 'thinking' ? (
-        <SeerLoader position="absolute" inset="0" align="center">
-          <IndeterminateLoader variant="monochrome" />
-        </SeerLoader>
-      ) : null}
     </SeerButton>
   );
 }
 
-function IconWrapper(props: PropsWithChildren) {
-  return <Flex width="14px" align="center" justify="center" {...props} />;
+interface IndicatorProps {
+  state: SeerExplorerSessionState;
+  isOpen?: boolean;
+}
+
+function ThinkingIndicator({state}: IndicatorProps) {
+  const prefersReducedMotion = useReducedMotion();
+  if (state !== 'thinking') {
+    return null;
+  }
+
+  return (
+    <SeerLoader
+      position="absolute"
+      inset="0"
+      align="center"
+      marginLeft="auto"
+      marginRight="auto"
+    >
+      {prefersReducedMotion ? (
+        t('Thinking...')
+      ) : (
+        <IndeterminateLoader variant="monochrome" />
+      )}
+    </SeerLoader>
+  );
+}
+
+function MessageIndicator({state, isOpen = false}: IndicatorProps) {
+  return (
+    <Flex width="14px" align="center" justify="center">
+      {!isOpen && state === 'done-thinking' ? (
+        <StatusIndicator variant="accent" />
+      ) : (
+        <IconSeer />
+      )}
+    </Flex>
+  );
 }
 
 const SeerLoader = styled(Flex)`

--- a/static/app/views/seerExplorer/components/askSeerButton.tsx
+++ b/static/app/views/seerExplorer/components/askSeerButton.tsx
@@ -78,7 +78,7 @@ function ThinkingIndicator({state}: IndicatorProps) {
       marginRight="auto"
     >
       {prefersReducedMotion ? (
-        <Text variant="secondary">{t('Thinking...')}</Text>
+        <Text variant="primary">{t('Thinking...')}</Text>
       ) : (
         <IndeterminateLoader variant="monochrome" />
       )}

--- a/static/app/views/seerExplorer/components/askSeerButton.tsx
+++ b/static/app/views/seerExplorer/components/askSeerButton.tsx
@@ -7,6 +7,7 @@ import {Hotkey} from '@sentry/scraps/hotkey';
 import {Container, Flex} from '@sentry/scraps/layout';
 import {IndeterminateLoader} from '@sentry/scraps/loader';
 import {StatusIndicator} from '@sentry/scraps/statusIndicator';
+import {Text} from '@sentry/scraps/text';
 
 import {IconSeer} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -20,6 +21,7 @@ import {isSeerExplorerEnabled} from 'sentry/views/seerExplorer/utils';
 export function AskSeerButton() {
   const organization = useOrganization({allowNull: true});
   const {isOpen, toggleSeerExplorer, sessionState: state} = useSeerExplorerContext();
+  const showMessageIndicator = useShowMessageIndicator({state, isOpen});
 
   if (!organization || !isSeerExplorerEnabled(organization)) {
     return null;
@@ -29,7 +31,13 @@ export function AskSeerButton() {
     'aria-label': state === 'thinking' ? t('Seer is thinking...') : t('Ask Seer'),
     'aria-expanded': isOpen ? true : undefined,
     priority: 'default',
-    icon: <MessageIndicator state={state} isOpen={isOpen} />,
+    icon: (
+      <IconSeer
+        animation={
+          showMessageIndicator ? 'waiting' : state === 'thinking' ? 'loading' : undefined
+        }
+      />
+    ),
   };
 
   return (
@@ -44,6 +52,7 @@ export function AskSeerButton() {
           <Hotkey value="command+/" variant="debossed" />
         </Flex>
         <ThinkingIndicator state={state} />
+        <MessageIndicator state={state} isOpen={isOpen} />
       </Flex>
     </SeerButton>
   );
@@ -69,7 +78,7 @@ function ThinkingIndicator({state}: IndicatorProps) {
       marginRight="auto"
     >
       {prefersReducedMotion ? (
-        t('Thinking...')
+        <Text variant="secondary">{t('Thinking...')}</Text>
       ) : (
         <IndeterminateLoader variant="monochrome" />
       )}
@@ -77,16 +86,28 @@ function ThinkingIndicator({state}: IndicatorProps) {
   );
 }
 
-function MessageIndicator({state, isOpen = false}: IndicatorProps) {
+function MessageIndicator(props: IndicatorProps) {
+  const shouldShow = useShowMessageIndicator(props);
+  if (!shouldShow) {
+    return null;
+  }
   return (
-    <Flex width="14px" align="center" justify="center">
-      {!isOpen && state === 'done-thinking' ? (
-        <StatusIndicator variant="accent" />
-      ) : (
-        <IconSeer />
-      )}
+    <Flex
+      position="absolute"
+      right="-6px"
+      top="-2px"
+      width="8px"
+      height="8px"
+      align="center"
+      justify="center"
+    >
+      <StatusIndicator variant="accent" />
     </Flex>
   );
+}
+
+function useShowMessageIndicator({state, isOpen}: IndicatorProps): boolean {
+  return !isOpen && state === 'done-thinking';
 }
 
 const SeerLoader = styled(Flex)`

--- a/static/app/views/seerExplorer/useSeerExplorerContext.tsx
+++ b/static/app/views/seerExplorer/useSeerExplorerContext.tsx
@@ -20,7 +20,7 @@ import {useSeerExplorerPolling} from 'sentry/views/seerExplorer/hooks/useSeerExp
 import {useSeerExplorerRunId} from 'sentry/views/seerExplorer/hooks/useSeerExplorerRunId';
 import {useSeerExplorerDeepLink} from 'sentry/views/seerExplorer/utils';
 
-type SeerExplorerSessionState = 'inactive' | 'thinking' | 'done-thinking';
+export type SeerExplorerSessionState = 'inactive' | 'thinking' | 'done-thinking';
 
 type SeerExplorerContextValue = {
   closeSeerExplorer: () => void;


### PR DESCRIPTION
some minor tweaks to the Ask Seer loading state:

- to better accommodate `(prefers-reduced-motion: reduce)`, the button will say "Thinking..." rather than show an unanimated loader
- the seer icon is always visible—only the text is replaced with the loader
- the status indicator is moved to the top right side of the button

**Refined Animations**

https://github.com/user-attachments/assets/9196262e-c8eb-451d-9e92-e21e29f0d1de

**Reduced Motion**

https://github.com/user-attachments/assets/b6eeb401-886c-40b5-b52f-6da3d11248e1
