### PR TITLE
feat(billing): Add product trial banners for trace metrics

### DIFF
--- a/static/gsApp/components/productTrial/productTrialAlert.spec.tsx
+++ b/static/gsApp/components/productTrial/productTrialAlert.spec.tsx
@@ -330,6 +330,14 @@ describe('getProductForPath', () => {
     });
   });
 
+  it('normalizes /explore/metrics/ to /metrics/', () => {
+    const result = getProductForPath(subscription, '/explore/metrics/');
+    expect(result).toEqual({
+      product: DataCategory.TRACE_METRIC_BYTE,
+      categories: [DataCategory.TRACE_METRIC_BYTE],
+    });
+  });
+
   it('returns null for unknown path', () => {
     const result = getProductForPath(subscription, '/unknown/');
     expect(result).toBeNull();

--- a/static/gsApp/components/productTrial/productTrialPaths.tsx
+++ b/static/gsApp/components/productTrial/productTrialPaths.tsx
@@ -47,6 +47,10 @@ const PATHS_FOR_PRODUCT_TRIALS: Record<Path, Product> = {
     product: DataCategory.LOG_BYTE,
     categories: [DataCategory.LOG_BYTE],
   },
+  '/metrics/': {
+    product: DataCategory.TRACE_METRIC_BYTE,
+    categories: [DataCategory.TRACE_METRIC_BYTE],
+  },
 };
 
 const PATHS_FOR_PRODUCT_TRIALS_AM3_OVERRIDES: Record<Path, Product> = {
@@ -89,6 +93,8 @@ function normalizePath(path: string): string {
       return '/replays/';
     case '/explore/logs/':
       return '/logs/';
+    case '/explore/metrics/':
+      return '/metrics/';
     default:
       return path;
   }


### PR DESCRIPTION
Map TRACE_METRIC_BYTE to the explore metrics pages so the product trial banner appears.


