### PR TITLE
feat(ACI): Add deprecation headers to legacy rule endpoints

### DIFF
--- a/src/sentry/api/endpoints/project_rule_details.py
+++ b/src/sentry/api/endpoints/project_rule_details.py
@@ -18,6 +18,7 @@ from sentry.api.endpoints.project_rules import (
     find_duplicate_rule,
 )
 from sentry.api.fields.actor import OwnerActorField
+from sentry.api.helpers.deprecation import deprecated
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.rule import RuleSerializer, WorkflowEngineRuleSerializer
 from sentry.api.serializers.rest_framework.rule import RuleNodeField
@@ -30,7 +31,7 @@ from sentry.apidocs.constants import (
 )
 from sentry.apidocs.examples.issue_alert_examples import IssueAlertExamples
 from sentry.apidocs.parameters import GlobalParams, IssueAlertParams
-from sentry.constants import ObjectStatus
+from sentry.constants import ALERTS_API_DEPRECATION_DATE, ObjectStatus
 from sentry.deletions.models.scheduleddeletion import CellScheduledDeletion
 from sentry.integrations.jira.actions.create_ticket import JiraCreateTicketAction
 from sentry.integrations.jira_server.actions.create_ticket import JiraServerCreateTicketAction
@@ -127,6 +128,10 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
         examples=IssueAlertExamples.GET_PROJECT_RULE,
     )
     @track_alert_endpoint_execution("GET", "sentry-api-0-project-rule-details")
+    @deprecated(
+        ALERTS_API_DEPRECATION_DATE,
+        suggested_api="/api/0/organizations/:slug/workflows/:workflow_id/",
+    )
     def get(self, request: Request, project: Project, rule: Rule | Workflow) -> Response:
         """
         ## Deprecated
@@ -190,6 +195,10 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
         examples=IssueAlertExamples.UPDATE_PROJECT_RULE,
     )
     @track_alert_endpoint_execution("PUT", "sentry-api-0-project-rule-details")
+    @deprecated(
+        ALERTS_API_DEPRECATION_DATE,
+        suggested_api="/api/0/organizations/:slug/workflows/:workflow_id/",
+    )
     def put(self, request: Request, project: Project, rule: Rule) -> Response:
         """
         ## Deprecated
@@ -367,6 +376,10 @@ class ProjectRuleDetailsEndpoint(WorkflowEngineRuleEndpoint):
         },
     )
     @track_alert_endpoint_execution("DELETE", "sentry-api-0-project-rule-details")
+    @deprecated(
+        ALERTS_API_DEPRECATION_DATE,
+        suggested_api="/api/0/organizations/:slug/workflows/:workflow_id/",
+    )
     def delete(self, request: Request, project: Project, rule: Rule | Workflow) -> Response:
         """
         ## Deprecated

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -18,6 +18,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
 from sentry.api.fields.actor import OwnerActorField
+from sentry.api.helpers.deprecation import deprecated
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.rule import (
     RuleSerializer,
@@ -30,7 +31,7 @@ from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RES
 from sentry.apidocs.examples.issue_alert_examples import IssueAlertExamples
 from sentry.apidocs.parameters import CursorQueryParam, GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
-from sentry.constants import ObjectStatus
+from sentry.constants import ALERTS_API_DEPRECATION_DATE, ObjectStatus
 from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.integrations.slack.tasks.find_channel_id_for_rule import find_channel_id_for_rule
 from sentry.integrations.slack.utils.rule_status import RedisRuleStatus
@@ -848,6 +849,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
         examples=IssueAlertExamples.LIST_PROJECT_RULES,
     )
     @track_alert_endpoint_execution("GET", "sentry-api-0-project-rules")
+    @deprecated(ALERTS_API_DEPRECATION_DATE, suggested_api="/api/0/organizations/:slug/workflows/")
     def get(self, request: Request, project: Project) -> Response:
         """
         ## Deprecated
@@ -905,6 +907,10 @@ class ProjectRulesEndpoint(ProjectEndpoint):
         examples=IssueAlertExamples.CREATE_ISSUE_ALERT_RULE,
     )
     @track_alert_endpoint_execution("POST", "sentry-api-0-project-rules")
+    @deprecated(
+        ALERTS_API_DEPRECATION_DATE,
+        suggested_api="/api/0/organizations/:slug/workflows/:workflow_id/",
+    )
     def post(self, request: Request, project) -> Response:
         """
         ## Deprecated

--- a/src/sentry/api/endpoints/project_rules.py
+++ b/src/sentry/api/endpoints/project_rules.py
@@ -909,7 +909,7 @@ class ProjectRulesEndpoint(ProjectEndpoint):
     @track_alert_endpoint_execution("POST", "sentry-api-0-project-rules")
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
-        suggested_api="/api/0/organizations/:slug/workflows/:workflow_id/",
+        suggested_api="/api/0/organizations/:slug/workflows/",
     )
     def post(self, request: Request, project) -> Response:
         """

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -1072,3 +1072,4 @@ EXTENSION_LANGUAGE_MAP = {
 # After this date APIs that are incompatible with cell routing
 # will begin periodic brownouts.
 CELL_API_DEPRECATION_DATE = datetime(2026, 5, 15, 0, 0, 0, tzinfo=UTC)
+ALERTS_API_DEPRECATION_DATE = datetime(2026, 5, 4, 0, 0, 0, tzinfo=UTC)

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -1072,4 +1072,4 @@ EXTENSION_LANGUAGE_MAP = {
 # After this date APIs that are incompatible with cell routing
 # will begin periodic brownouts.
 CELL_API_DEPRECATION_DATE = datetime(2026, 5, 15, 0, 0, 0, tzinfo=UTC)
-ALERTS_API_DEPRECATION_DATE = datetime(2026, 5, 4, 0, 0, 0, tzinfo=UTC)
+ALERTS_API_DEPRECATION_DATE = datetime(2026, 5, 7, 0, 0, 0, tzinfo=UTC)

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -1072,4 +1072,4 @@ EXTENSION_LANGUAGE_MAP = {
 # After this date APIs that are incompatible with cell routing
 # will begin periodic brownouts.
 CELL_API_DEPRECATION_DATE = datetime(2026, 5, 15, 0, 0, 0, tzinfo=UTC)
-ALERTS_API_DEPRECATION_DATE = datetime(2026, 5, 7, 0, 0, 0, tzinfo=UTC)
+ALERTS_API_DEPRECATION_DATE = datetime(2026, 5, 14, 0, 0, 0, tzinfo=UTC)

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -15,6 +15,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.fields.actor import OwnerActorField
+from sentry.api.helpers.deprecation import deprecated
 from sentry.api.serializers import serialize
 from sentry.api.serializers.rest_framework.project import ProjectField
 from sentry.apidocs.constants import (
@@ -25,6 +26,7 @@ from sentry.apidocs.constants import (
 )
 from sentry.apidocs.examples.metric_alert_examples import MetricAlertExamples
 from sentry.apidocs.parameters import GlobalParams, MetricAlertParams
+from sentry.constants import ALERTS_API_DEPRECATION_DATE
 from sentry.incidents.endpoints.bases import WorkflowEngineOrganizationAlertRuleEndpoint
 from sentry.incidents.endpoints.serializers.alert_rule import (
     AlertRuleSerializer,
@@ -386,6 +388,10 @@ class OrganizationAlertRuleDetailsEndpoint(WorkflowEngineOrganizationAlertRuleEn
     )
     @track_alert_endpoint_execution("GET", "sentry-api-0-organization-alert-rule-details")
     @_check_project_access
+    @deprecated(
+        ALERTS_API_DEPRECATION_DATE,
+        suggested_api="/api/0/organizations/:slug/detectors/:detector_id/",
+    )
     def get(
         self, request: Request, organization: Organization, alert_rule: AlertRule | Detector
     ) -> Response:
@@ -419,6 +425,10 @@ class OrganizationAlertRuleDetailsEndpoint(WorkflowEngineOrganizationAlertRuleEn
     )
     @track_alert_endpoint_execution("PUT", "sentry-api-0-organization-alert-rule-details")
     @_check_project_access
+    @deprecated(
+        ALERTS_API_DEPRECATION_DATE,
+        suggested_api="/api/0/organizations/:slug/detectors/:detector_id/",
+    )
     def put(
         self, request: Request, organization: Organization, alert_rule: AlertRule | Detector
     ) -> Response:
@@ -455,6 +465,10 @@ class OrganizationAlertRuleDetailsEndpoint(WorkflowEngineOrganizationAlertRuleEn
     )
     @track_alert_endpoint_execution("DELETE", "sentry-api-0-organization-alert-rule-details")
     @_check_project_access
+    @deprecated(
+        ALERTS_API_DEPRECATION_DATE,
+        suggested_api="/api/0/organizations/:slug/detectors/:detector_id/",
+    )
     def delete(
         self, request: Request, organization: Organization, alert_rule: AlertRule | Detector
     ) -> Response:

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -386,12 +386,12 @@ class OrganizationAlertRuleDetailsEndpoint(WorkflowEngineOrganizationAlertRuleEn
         },
         examples=MetricAlertExamples.GET_METRIC_ALERT_RULE,
     )
-    @track_alert_endpoint_execution("GET", "sentry-api-0-organization-alert-rule-details")
-    @_check_project_access
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="/api/0/organizations/:slug/detectors/:detector_id/",
     )
+    @track_alert_endpoint_execution("GET", "sentry-api-0-organization-alert-rule-details")
+    @_check_project_access
     def get(
         self, request: Request, organization: Organization, alert_rule: AlertRule | Detector
     ) -> Response:
@@ -423,12 +423,12 @@ class OrganizationAlertRuleDetailsEndpoint(WorkflowEngineOrganizationAlertRuleEn
         },
         examples=MetricAlertExamples.UPDATE_METRIC_ALERT_RULE,
     )
-    @track_alert_endpoint_execution("PUT", "sentry-api-0-organization-alert-rule-details")
-    @_check_project_access
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="/api/0/organizations/:slug/detectors/:detector_id/",
     )
+    @track_alert_endpoint_execution("PUT", "sentry-api-0-organization-alert-rule-details")
+    @_check_project_access
     def put(
         self, request: Request, organization: Organization, alert_rule: AlertRule | Detector
     ) -> Response:
@@ -463,12 +463,12 @@ class OrganizationAlertRuleDetailsEndpoint(WorkflowEngineOrganizationAlertRuleEn
             404: RESPONSE_NOT_FOUND,
         },
     )
-    @track_alert_endpoint_execution("DELETE", "sentry-api-0-organization-alert-rule-details")
-    @_check_project_access
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="/api/0/organizations/:slug/detectors/:detector_id/",
     )
+    @track_alert_endpoint_execution("DELETE", "sentry-api-0-organization-alert-rule-details")
+    @_check_project_access
     def delete(
         self, request: Request, organization: Organization, alert_rule: AlertRule | Detector
     ) -> Response:

--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -386,11 +386,11 @@ class OrganizationAlertRuleDetailsEndpoint(WorkflowEngineOrganizationAlertRuleEn
         },
         examples=MetricAlertExamples.GET_METRIC_ALERT_RULE,
     )
+    @track_alert_endpoint_execution("GET", "sentry-api-0-organization-alert-rule-details")
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="/api/0/organizations/:slug/detectors/:detector_id/",
     )
-    @track_alert_endpoint_execution("GET", "sentry-api-0-organization-alert-rule-details")
     @_check_project_access
     def get(
         self, request: Request, organization: Organization, alert_rule: AlertRule | Detector
@@ -423,11 +423,11 @@ class OrganizationAlertRuleDetailsEndpoint(WorkflowEngineOrganizationAlertRuleEn
         },
         examples=MetricAlertExamples.UPDATE_METRIC_ALERT_RULE,
     )
+    @track_alert_endpoint_execution("PUT", "sentry-api-0-organization-alert-rule-details")
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="/api/0/organizations/:slug/detectors/:detector_id/",
     )
-    @track_alert_endpoint_execution("PUT", "sentry-api-0-organization-alert-rule-details")
     @_check_project_access
     def put(
         self, request: Request, organization: Organization, alert_rule: AlertRule | Detector
@@ -463,11 +463,11 @@ class OrganizationAlertRuleDetailsEndpoint(WorkflowEngineOrganizationAlertRuleEn
             404: RESPONSE_NOT_FOUND,
         },
     )
+    @track_alert_endpoint_execution("DELETE", "sentry-api-0-organization-alert-rule-details")
     @deprecated(
         ALERTS_API_DEPRECATION_DATE,
         suggested_api="/api/0/organizations/:slug/detectors/:detector_id/",
     )
-    @track_alert_endpoint_execution("DELETE", "sentry-api-0-organization-alert-rule-details")
     @_check_project_access
     def delete(
         self, request: Request, organization: Organization, alert_rule: AlertRule | Detector

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -31,6 +31,7 @@ from sentry.api.bases.organization import OrganizationAlertRulePermission, Organ
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.fields.actor import OwnerActorField
 from sentry.api.helpers.constants import ALERT_RULES_COUNT_HEADER, MAX_QUERY_SUBSCRIPTIONS_HEADER
+from sentry.api.helpers.deprecation import deprecated
 from sentry.api.paginator import (
     CombinedQuerysetIntermediary,
     CombinedQuerysetPaginator,
@@ -42,7 +43,7 @@ from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RES
 from sentry.apidocs.examples.metric_alert_examples import MetricAlertExamples
 from sentry.apidocs.parameters import GlobalParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
-from sentry.constants import ObjectStatus
+from sentry.constants import ALERTS_API_DEPRECATION_DATE, ObjectStatus
 from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
 from sentry.exceptions import InvalidParams
@@ -938,6 +939,7 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationAlertRuleBaseEndpoint, Aler
         examples=MetricAlertExamples.LIST_METRIC_ALERT_RULES,  # TODO: make
     )
     @track_alert_endpoint_execution("GET", "sentry-api-0-organization-alert-rules")
+    @deprecated(ALERTS_API_DEPRECATION_DATE, suggested_api="/api/0/organizations/:slug/detectors/")
     def get(self, request: Request, organization: Organization) -> HttpResponseBase:
         """
         ## Deprecated
@@ -969,6 +971,7 @@ class OrganizationAlertRuleIndexEndpoint(OrganizationAlertRuleBaseEndpoint, Aler
         examples=MetricAlertExamples.CREATE_METRIC_ALERT_RULE,
     )
     @track_alert_endpoint_execution("POST", "sentry-api-0-organization-alert-rules")
+    @deprecated(ALERTS_API_DEPRECATION_DATE, suggested_api="/api/0/organizations/:slug/detectors/")
     def post(self, request: Request, organization: Organization) -> HttpResponseBase:
         """
         ## Deprecated

--- a/src/sentry/incidents/endpoints/project_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_details.py
@@ -4,6 +4,8 @@ from rest_framework.response import Response
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
+from sentry.api.helpers.deprecation import deprecated
+from sentry.constants import ALERTS_API_DEPRECATION_DATE
 from sentry.incidents.endpoints.bases import WorkflowEngineProjectAlertRuleEndpoint
 from sentry.incidents.endpoints.organization_alert_rule_details import (
     fetch_alert_rule,
@@ -29,6 +31,10 @@ class ProjectAlertRuleDetailsEndpoint(WorkflowEngineProjectAlertRuleEndpoint):
     }
 
     @track_alert_endpoint_execution("GET", "sentry-api-0-project-alert-rule-details")
+    @deprecated(
+        ALERTS_API_DEPRECATION_DATE,
+        suggested_api="/api/0/organizations/:slug/detectors/:detector_id/",
+    )
     def get(self, request: Request, project: Project, alert_rule: AlertRule | Detector) -> Response:
         """
         Fetch a metric alert rule. @deprecated. Use OrganizationAlertRuleDetailsEndpoint instead.
@@ -38,6 +44,10 @@ class ProjectAlertRuleDetailsEndpoint(WorkflowEngineProjectAlertRuleEndpoint):
         return fetch_alert_rule(request, project.organization, alert_rule)
 
     @track_alert_endpoint_execution("PUT", "sentry-api-0-project-alert-rule-details")
+    @deprecated(
+        ALERTS_API_DEPRECATION_DATE,
+        suggested_api="/api/0/organizations/:slug/detectors/:detector_id/",
+    )
     def put(self, request: Request, project: Project, alert_rule: AlertRule | Detector) -> Response:
         """
         Update a metric alert rule. @deprecated. Use OrganizationAlertRuleDetailsEndpoint instead.
@@ -47,6 +57,10 @@ class ProjectAlertRuleDetailsEndpoint(WorkflowEngineProjectAlertRuleEndpoint):
         return update_alert_rule(request, project.organization, alert_rule)
 
     @track_alert_endpoint_execution("DELETE", "sentry-api-0-project-alert-rule-details")
+    @deprecated(
+        ALERTS_API_DEPRECATION_DATE,
+        suggested_api="/api/0/organizations/:slug/detectors/:detector_id/",
+    )
     def delete(
         self, request: Request, project: Project, alert_rule: AlertRule | Detector
     ) -> Response:

--- a/src/sentry/incidents/endpoints/project_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/project_alert_rule_index.py
@@ -7,6 +7,8 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectAlertRulePermission, ProjectEndpoint
+from sentry.api.helpers.deprecation import deprecated
+from sentry.constants import ALERTS_API_DEPRECATION_DATE
 from sentry.incidents.endpoints.organization_alert_rule_index import (
     AlertRuleFetchMixin,
     create_metric_alert,
@@ -27,6 +29,7 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint, AlertRuleFetchMixin):
     }
 
     @track_alert_endpoint_execution("GET", "sentry-api-0-project-alert-rules")
+    @deprecated(ALERTS_API_DEPRECATION_DATE, suggested_api="/api/0/organizations/:slug/detectors/")
     def get(self, request: Request, project) -> HttpResponseBase:
         """
         Fetches metric alert rules for a project - @deprecated. Use OrganizationAlertRuleIndexEndpoint instead.
@@ -34,6 +37,7 @@ class ProjectAlertRuleIndexEndpoint(ProjectEndpoint, AlertRuleFetchMixin):
         return self.fetch_metric_alerts(request, project.organization, [project])
 
     @track_alert_endpoint_execution("POST", "sentry-api-0-project-alert-rules")
+    @deprecated(ALERTS_API_DEPRECATION_DATE, suggested_api="/api/0/organizations/:slug/detectors/")
     def post(self, request: Request, project) -> HttpResponseBase:
         """
         Create an alert rule - @deprecated. Use OrganizationAlertRuleIndexEndpoint instead.


### PR DESCRIPTION
Add deprecation headers to legacy rule endpoints to start sending deprecation headers to API users.

Note that the deprecation date is the date at which brownouts start (by default it's 1 minute blackout at noon UTC), not the date at which the endpoint will stop responding. We're responsible for following up and manually removing usage of the endpoints. 