### PR TITLE
fix(discover): HAndle status in selected columns

### DIFF
--- a/src/sentry/search/events/builder/base.py
+++ b/src/sentry/search/events/builder/base.py
@@ -660,7 +660,12 @@ class BaseQueryBuilder:
                 continue
             # need to make sure the column is resolved with the appropriate alias
             # because the resolved snuba name may be different
-            resolved_column = self.resolve_column(column, alias=True)
+            if hasattr(self, "select_as_tag_columns") and column in self.select_as_tag_columns:
+                resolved_column = AliasedExpression(
+                    self.resolve_column(f"tags[{column}]"), alias=column
+                )
+            else:
+                resolved_column = self.resolve_column(column, alias=True)
 
             if resolved_column not in self.columns:
                 resolved_columns.append(resolved_column)

--- a/src/sentry/search/events/builder/errors.py
+++ b/src/sentry/search/events/builder/errors.py
@@ -34,6 +34,7 @@ class ErrorsQueryBuilderMixin:
     def __init__(self, *args, **kwargs):
         self.match = None
         self.entities = set()
+        self.select_as_tag_columns = {"status"}
         super().__init__(*args, **kwargs)
 
     def parse_query(self, query: str | None) -> ParsedTerms:

--- a/tests/snuba/api/endpoints/test_organization_events.py
+++ b/tests/snuba/api/endpoints/test_organization_events.py
@@ -7163,6 +7163,50 @@ class OrganizationEventsErrorsDatasetEndpointTest(OrganizationEventsEndpointTest
         assert response.status_code == 200, response.content
         assert response.data["data"][0]["count()"] == 1
 
+    def test_status_in_field(self) -> None:
+        self.store_event(
+            data={
+                "event_id": "a" * 32,
+                "timestamp": self.ten_mins_ago_iso,
+                "fingerprint": ["group1"],
+                "tags": {"status": "good"},
+            },
+            project_id=self.project.id,
+        ).group
+        self.store_event(
+            data={
+                "event_id": "b" * 32,
+                "timestamp": self.ten_mins_ago_iso,
+                "fingerprint": ["group2"],
+                "tags": {"status": "bad"},
+            },
+            project_id=self.project.id,
+        ).group
+        self.store_event(
+            data={
+                "event_id": "c" * 32,
+                "timestamp": self.ten_mins_ago_iso,
+                "fingerprint": ["group3"],
+                "tags": {"status": "good"},
+            },
+            project_id=self.project.id,
+        ).group
+
+        query = {
+            "field": ["status", "count()"],
+            "statsPeriod": "2h",
+            "query": "",
+            "dataset": "errors",
+            "orderby": "-count()",
+        }
+        response = self.do_request(query)
+        assert response.status_code == 200, response.content
+        assert len(response.data["data"]) == 2
+        assert response.data["data"][0]["count()"] == 2
+        assert response.data["data"][0]["status"] == "good"
+        assert response.data["data"][1]["count()"] == 1
+        assert response.data["data"][1]["status"] == "bad"
+
     def test_short_group_id(self) -> None:
         group_1 = self.store_event(
             data={


### PR DESCRIPTION
- This makes it so if status ia selected column its always treated as a tag since status (as an error field) should only ever be used in the filter bar