### PR TITLE
ref(seer): use neutral variant for `code`

### DIFF
--- a/static/app/components/events/autofix/v2/utils.tsx
+++ b/static/app/components/events/autofix/v2/utils.tsx
@@ -35,6 +35,6 @@ export const cardAnimationProps: MotionNodeAnimationOptions = {
  */
 export const StyledMarkedText = styled(MarkedText)`
   code:not(pre code) {
-    ${p => inlineCodeStyles(p.theme)};
+    ${p => inlineCodeStyles(p.theme, {variant: 'neutral'})};
   }
 `;

--- a/static/app/views/seerExplorer/components/blockComponents.tsx
+++ b/static/app/views/seerExplorer/components/blockComponents.tsx
@@ -656,7 +656,7 @@ const BlockContent = styled(MarkedText)`
   padding-bottom: 0;
 
   code:not(pre code) {
-    ${p => inlineCodeStyles(p.theme)};
+    ${p => inlineCodeStyles(p.theme, {variant: 'neutral'})};
   }
 
   p,


### PR DESCRIPTION
updates the `<code>` elements in Seer's chat interface to use `variant="neutral"` rather than `variant="accent"`

| Before | After |
|--------|--------|
| <img width="684" height="640" alt="code-before" src="https://github.com/user-attachments/assets/379bc0c6-1d9d-4f18-b443-3ed24db879a6" /> | <img width="691" height="645" alt="code-after" src="https://github.com/user-attachments/assets/bbe2ce9c-75d3-41d4-bed0-70273d2475a5" /> |