### PR TITLE
fix(api): Sync email_unique when primary email changes

### DIFF
--- a/src/sentry/users/api/endpoints/user_emails.py
+++ b/src/sentry/users/api/endpoints/user_emails.py
@@ -217,7 +217,9 @@ class UserEmailsEndpoint(UserEndpoint):
 
         has_new_username = old_email == user.username
 
-        update_kwargs = {"email": new_email}
+        # email_unique mirrors email under a DB-level unique constraint.
+        # It is normally synced by User.save(), which this update() bypasses.
+        update_kwargs = {"email": new_email, "email_unique": new_email}
 
         if has_new_username and not User.objects.filter(username__iexact=new_email).exists():
             update_kwargs["username"] = new_email

--- a/tests/sentry/users/api/endpoints/test_user_emails.py
+++ b/tests/sentry/users/api/endpoints/test_user_emails.py
@@ -62,6 +62,21 @@ class UserEmailsTest(APITestCase):
         assert user.email == "altemail1@example.com"
         assert user.username == "altemail1@example.com"
 
+    def test_change_primary_email_updates_email_unique(self) -> None:
+        user = self.create_user(email="unique@example.com", is_test_user=False)
+        self.login_as(user=user)
+        url = reverse("sentry-api-0-user-emails", kwargs={"user_id": user.id})
+        UserEmail.objects.create(user=user, email="newprimary@example.com", is_verified=True)
+
+        assert user.email_unique == "unique@example.com"
+
+        response = self.client.put(url, data={"email": "newprimary@example.com"})
+        assert response.status_code == 200, response.data
+
+        user = User.objects.get(id=user.id)
+        assert user.email == "newprimary@example.com"
+        assert user.email_unique == "newprimary@example.com"
+
     def test_change_unverified_secondary_to_primary(self) -> None:
         UserEmail.objects.create(user=self.user, email="altemail1@example.com", is_verified=False)
         response = self.client.put(self.url, data={"email": "altemail1@example.com"})


### PR DESCRIPTION
The PUT /users/{id}/emails/ endpoint updates User.email via instance.update(), which bypasses User.save() — the only place email_unique is computed. After a primary email change, email_unique stayed pinned to the previous value, breaking the column's invariant and risking false collisions on later changes via its unique constraint.

Set email_unique alongside email in update_kwargs so the column tracks the authoritative email field.

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
