### PR TITLE
feat(nav): sync status indicator variant with latest update

### DIFF
--- a/static/app/views/navigation/primary/components.tsx
+++ b/static/app/views/navigation/primary/components.tsx
@@ -254,11 +254,13 @@ function PrimaryNavigationLink(props: PrimaryNavigationLinkProps) {
   );
 }
 
+type PrimaryNavigationIndicatorVariant = 'accent' | 'danger' | 'warning' | 'success';
+
 interface PrimaryNavigationButtonProps extends PrimaryNavigationItemBaseProps {
   label: React.ReactNode;
   buttonProps?: Omit<ButtonProps, 'aria-label' | 'size'>;
   children?: React.ReactNode;
-  indicator?: 'accent' | 'danger' | 'warning';
+  indicator?: PrimaryNavigationIndicatorVariant;
 }
 
 function PrimaryNavigationButton(props: PrimaryNavigationButtonProps) {
@@ -315,7 +317,7 @@ function PrimaryNavigationButton(props: PrimaryNavigationButtonProps) {
 }
 
 interface PrimaryNavigationUnreadIndicatorProps extends React.HTMLAttributes<HTMLSpanElement> {
-  variant: 'accent' | 'danger' | 'warning';
+  variant: PrimaryNavigationIndicatorVariant;
 }
 
 function PrimaryNavigationUnreadIndicator({
@@ -343,6 +345,8 @@ function PrimaryNavigationUnreadIndicator({
           {...mergeProps(p, props)}
           variant={variant}
           data-unread-indicator
+          data-variant={variant}
+          data-test-id="primary-nav-unread-indicator"
         />
       )}
     </Container>
@@ -354,7 +358,7 @@ interface PrimaryNavigationMenuProps extends PrimaryNavigationItemBaseProps {
   label: string;
   children?: React.ReactNode;
   icon?: React.ReactNode;
-  indicator?: 'accent' | 'danger' | 'warning';
+  indicator?: PrimaryNavigationIndicatorVariant;
   onOpen?: MouseEventHandler<HTMLButtonElement>;
   triggerWrap?: React.ComponentType<{children: React.ReactNode}>;
 }

--- a/static/app/views/navigation/primary/serviceIncidents.spec.tsx
+++ b/static/app/views/navigation/primary/serviceIncidents.spec.tsx
@@ -53,4 +53,97 @@ describe('PrimaryNavigationServiceIncidents', () => {
     expect(screen.getByText('Things look bad')).toBeInTheDocument();
     expect(screen.getByText('Monitoring')).toBeInTheDocument();
   });
+
+  it.each([
+    {status: 'investigating' as const, expectedVariant: 'danger'},
+    {status: 'identified' as const, expectedVariant: 'accent'},
+    {status: 'monitoring' as const, expectedVariant: 'warning'},
+  ])(
+    'shows $expectedVariant indicator when latest update is $status',
+    async ({status, expectedVariant}) => {
+      const incident = ServiceIncidentFixture({
+        incident_updates: [
+          {
+            id: 'older',
+            incident_id: '1',
+            status: 'investigating',
+            body: 'Older investigation update',
+            affected_components: [],
+            created_at: '2022-05-23T12:00:00.000-07:00',
+            updated_at: '2022-05-23T12:00:00.000-07:00',
+            display_at: '2022-05-23T12:00:00.000-07:00',
+          },
+          {
+            id: 'latest',
+            incident_id: '1',
+            status,
+            body: 'Latest update',
+            affected_components: [],
+            created_at: '2022-05-23T18:00:00.000-07:00',
+            updated_at: '2022-05-23T18:00:00.000-07:00',
+            display_at: '2022-05-23T18:00:00.000-07:00',
+          },
+        ],
+      });
+
+      fetchMock.mockResponse(req =>
+        req.url.endsWith('incidents/unresolved.json')
+          ? Promise.resolve(JSON.stringify({incidents: [incident]}))
+          : Promise.reject(new Error('not found'))
+      );
+
+      render(<PrimaryNavigationServiceIncidents />);
+
+      await screen.findByRole('button', {name: 'Service status'});
+      const indicator = await screen.findByTestId('primary-nav-unread-indicator');
+      expect(indicator).toHaveAttribute('data-variant', expectedVariant);
+    }
+  );
+
+  it('uses the most recent update across multiple incidents', async () => {
+    const olderIncident = ServiceIncidentFixture({
+      id: 'older',
+      name: 'Older incident',
+      incident_updates: [
+        {
+          id: 'older-update',
+          incident_id: 'older',
+          status: 'investigating',
+          body: 'Investigating older incident',
+          affected_components: [],
+          created_at: '2022-05-23T12:00:00.000-07:00',
+          updated_at: '2022-05-23T12:00:00.000-07:00',
+          display_at: '2022-05-23T12:00:00.000-07:00',
+        },
+      ],
+    });
+    const newerIncident = ServiceIncidentFixture({
+      id: 'newer',
+      name: 'Newer incident',
+      incident_updates: [
+        {
+          id: 'newer-update',
+          incident_id: 'newer',
+          status: 'monitoring',
+          body: 'Monitoring newer incident',
+          affected_components: [],
+          created_at: '2022-05-23T18:00:00.000-07:00',
+          updated_at: '2022-05-23T18:00:00.000-07:00',
+          display_at: '2022-05-23T18:00:00.000-07:00',
+        },
+      ],
+    });
+
+    fetchMock.mockResponse(req =>
+      req.url.endsWith('incidents/unresolved.json')
+        ? Promise.resolve(JSON.stringify({incidents: [olderIncident, newerIncident]}))
+        : Promise.reject(new Error('not found'))
+    );
+
+    render(<PrimaryNavigationServiceIncidents />);
+
+    await screen.findByRole('button', {name: 'Service status'});
+    const indicator = await screen.findByTestId('primary-nav-unread-indicator');
+    expect(indicator).toHaveAttribute('data-variant', 'warning');
+  });
 });

--- a/static/app/views/navigation/primary/serviceIncidents.tsx
+++ b/static/app/views/navigation/primary/serviceIncidents.tsx
@@ -1,16 +1,64 @@
-import {Fragment} from 'react';
+import {Fragment, useMemo} from 'react';
 
 import {Stack} from '@sentry/scraps/layout';
 
 import {ServiceIncidentDetails} from 'sentry/components/serviceIncidentDetails';
 import {IconFire} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import type {StatuspageIncident} from 'sentry/types/system';
+import type {StatusPageIncidentUpdate, StatuspageIncident} from 'sentry/types/system';
 import {useServiceIncidents} from 'sentry/utils/useServiceIncidents';
 import {
   PrimaryNavigation,
   usePrimaryNavigationButtonOverlay,
 } from 'sentry/views/navigation/primary/components';
+
+type IndicatorVariant = 'accent' | 'danger' | 'warning' | 'success';
+
+/**
+ * Map an incident update status to a {@link PrimaryNavigation.Button}
+ * indicator variant. The variants here intentionally mirror the colors used
+ * for the timeline bullet in {@link ServiceIncidentDetails} so that the nav
+ * indicator matches the latest status update visible inside the overlay.
+ */
+function statusToIndicatorVariant(
+  status: StatusPageIncidentUpdate['status']
+): IndicatorVariant {
+  switch (status) {
+    case 'investigating':
+      return 'danger';
+    case 'identified':
+      return 'accent';
+    case 'monitoring':
+      return 'warning';
+    case 'resolved':
+      return 'success';
+    default:
+      return 'danger';
+  }
+}
+
+/**
+ * Returns the most recent {@link StatusPageIncidentUpdate} across all of the
+ * provided incidents (sorted by display/created time).
+ */
+function getLatestUpdate(
+  incidents: StatuspageIncident[]
+): StatusPageIncidentUpdate | undefined {
+  let latest: StatusPageIncidentUpdate | undefined;
+  let latestTime = -Infinity;
+
+  for (const incident of incidents) {
+    for (const update of incident.incident_updates) {
+      const time = new Date(update.display_at ?? update.created_at).getTime();
+      if (Number.isFinite(time) && time > latestTime) {
+        latestTime = time;
+        latest = update;
+      }
+    }
+  }
+
+  return latest;
+}
 
 function ServiceIncidentsButton({incidents}: {incidents: StatuspageIncident[]}) {
   const {
@@ -19,12 +67,17 @@ function ServiceIncidentsButton({incidents}: {incidents: StatuspageIncident[]}) 
     overlayProps,
   } = usePrimaryNavigationButtonOverlay();
 
+  const indicator = useMemo<IndicatorVariant>(() => {
+    const latestUpdate = getLatestUpdate(incidents);
+    return latestUpdate ? statusToIndicatorVariant(latestUpdate.status) : 'danger';
+  }, [incidents]);
+
   return (
     <Fragment>
       <PrimaryNavigation.Button
         analyticsKey="statusupdate"
         label={t('Service status')}
-        indicator="danger"
+        indicator={indicator}
         buttonProps={{
           ...overlayTriggerProps,
           icon: <IconFire />,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The Service Status button in the primary navigation always showed a `danger`-colored dot, even when the most recent incident update had moved the incident into a less severe state (e.g. `monitoring`).

This makes the indicator dot reflect the **most recent status update** across all unresolved incidents — matching the bullet color shown for that update inside the existing overlay.

### Status → indicator variant mapping
| Latest update status | Nav indicator |
| --- | --- |
| `investigating` | `danger` (red) |
| `identified` | `accent` (blurple) |
| `monitoring` | `warning` (yellow) |
| `resolved` | `success` (green) |

These match the bullet colors already used in `ServiceIncidentDetails`.

### Changes
- `serviceIncidents.tsx`: derive the indicator variant from the latest `display_at`/`created_at` update across the active incidents (memoized).
- `components.tsx`:
  - widen `PrimaryNavigation.Button` / `PrimaryNavigation.Menu` `indicator` prop to include `'success'`.
  - add `data-variant` and `data-test-id` to the `StatusIndicator` so the variant can be asserted in tests.

### Tests
- New parameterized test covers `investigating`/`identified`/`monitoring` latest updates.
- New test confirms the indicator picks the latest update across multiple incidents.
- Existing tests still pass (15 nav suites, 77 tests).

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/C087YQX2WH2/p1777321210159659?thread_ts=1777321210.159659&cid=C087YQX2WH2)

<div><a href="https://cursor.com/agents/bc-382adc6d-235b-580a-a11b-2328e0ad337e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-382adc6d-235b-580a-a11b-2328e0ad337e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

