### PR TITLE
ref(seer-slack): omit seer fix button when no other actions are present

### DIFF
--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -710,13 +710,12 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
                     )
                 )
 
-        if self._has_autofix and not self.is_unfurl:
-            autofix_button = SeerSlackRenderer.render_autofix_button(group=self.group)
-            # We have to coerce this since we're not using the proper SlackSDK client to emit this
-            # notification yet, it just takes JSON.
-            actions.append(autofix_button.to_dict())
-
         if actions:
+            if self._has_autofix and not self.is_unfurl:
+                autofix_button = SeerSlackRenderer.render_autofix_button(group=self.group)
+                # We have to coerce this since we're not using the proper SlackSDK client to emit this
+                # notification yet, it just takes JSON.
+                actions.append(autofix_button.to_dict())
             action_block = {"type": "actions", "elements": [action for action in actions]}
             blocks.append(action_block)
 

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -1152,6 +1152,19 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         blocks = SlackIssuesMessageBuilder(group, is_unfurl=True).build()
         assert not self._has_autofix_button(blocks)
 
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
+    @with_feature(
+        {
+            "organizations:gen-ai-features": True,
+            "organizations:seer-slack-workflows": True,
+        }
+    )
+    def test_autofix_button_hidden_when_no_other_actions(self, mock_quota: MagicMock) -> None:
+        self.organization.update_option("sentry:enable_seer_enhanced_alerts", True)
+        group = self.create_group(project=self.project)
+        blocks = SlackIssuesMessageBuilder(group, issue_details=True).build()
+        assert not self._has_autofix_button(blocks)
+
 
 class BuildGroupAttachmentReplaysTest(TestCase):
     @patch("sentry.models.group.Group.has_replays")


### PR DESCRIPTION
makes it so that other actions must be present for autofix button to appear. This will omit it from workflow notifications (e.g. User A commented on issue) which can show up to some as slack notifications.


refs ISWF-2526