### PR TITLE
feat(slack): Request extended OAuth scopes on production install

### DIFF
--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -351,9 +351,9 @@ class SlackIntegrationProvider(IntegrationProvider):
     identity_oauth_scopes = frozenset(
         [
             "channels:read",
-            "channels:history",
+            SlackScope.CHANNELS_HISTORY,
             "groups:read",
-            "groups:history",
+            SlackScope.GROUPS_HISTORY,
             "users:read",
             "chat:write",
             "links:read",
@@ -364,8 +364,8 @@ class SlackIntegrationProvider(IntegrationProvider):
             "chat:write.public",
             "chat:write.customize",
             "commands",
-            "app_mentions:read",
-            "assistant:write",
+            SlackScope.APP_MENTIONS_READ,
+            SlackScope.ASSISTANT_WRITE,
         ]
     )
     # Stage new scopes here to test them via SlackStagingIntegrationProvider

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -351,7 +351,9 @@ class SlackIntegrationProvider(IntegrationProvider):
     identity_oauth_scopes = frozenset(
         [
             "channels:read",
+            "channels:history",
             "groups:read",
+            "groups:history",
             "users:read",
             "chat:write",
             "links:read",
@@ -362,19 +364,11 @@ class SlackIntegrationProvider(IntegrationProvider):
             "chat:write.public",
             "chat:write.customize",
             "commands",
+            "app_mentions:read",
+            "assistant:write",
         ]
     )
-    # Extended scopes that require Slack marketplace approval. Required for
-    # @mention-driven Seer Explorer (app_mentions:read, channels/groups:history)
-    # and the assistant surface.
-    extended_oauth_scopes = frozenset(
-        [
-            SlackScope.CHANNELS_HISTORY,
-            SlackScope.GROUPS_HISTORY,
-            SlackScope.APP_MENTIONS_READ,
-            SlackScope.ASSISTANT_WRITE,
-        ]
-    )
+    extended_oauth_scopes: frozenset[str] = frozenset()
     user_scopes = frozenset(
         [
             "links:read",
@@ -387,7 +381,7 @@ class SlackIntegrationProvider(IntegrationProvider):
         """
         Returns the OAuth scopes to request during installation.
         """
-        return self.identity_oauth_scopes | self.extended_oauth_scopes
+        return self.identity_oauth_scopes
 
     setup_dialog_config = {"width": 600, "height": 900}
     setup_url_path = "/extensions/slack/setup/"

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -368,6 +368,9 @@ class SlackIntegrationProvider(IntegrationProvider):
             "assistant:write",
         ]
     )
+    # Stage new scopes here to test them via SlackStagingIntegrationProvider
+    # (which unions these into its install scopes) before promoting to
+    # identity_oauth_scopes. Empty in steady state.
     extended_oauth_scopes: frozenset[str] = frozenset()
     user_scopes = frozenset(
         [

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -348,6 +348,9 @@ class SlackIntegrationProvider(IntegrationProvider):
     integration_cls = SlackIntegration
 
     # some info here: https://api.slack.com/authentication/quickstart
+    # If you're adding a new scope to perform an action,
+    # you must check whether the user's app installation has the appropriate scope.
+    # This is because they may have an outdated installation of the Slack App without the new scope.
     identity_oauth_scopes = frozenset(
         [
             "channels:read",

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -371,7 +371,7 @@ class SlackIntegrationProvider(IntegrationProvider):
     # Stage new scopes here to test them via SlackStagingIntegrationProvider
     # (which unions these into its install scopes) before promoting to
     # identity_oauth_scopes. Empty in steady state.
-    extended_oauth_scopes: frozenset[str] = frozenset()
+    staging_oauth_scopes: frozenset[str] = frozenset()
     user_scopes = frozenset(
         [
             "links:read",

--- a/src/sentry/integrations/slack/integration.py
+++ b/src/sentry/integrations/slack/integration.py
@@ -364,8 +364,9 @@ class SlackIntegrationProvider(IntegrationProvider):
             "commands",
         ]
     )
-    # Extended scopes that require Slack marketplace approval
-    # Used by SlackStagingIntegrationProvider
+    # Extended scopes that require Slack marketplace approval. Required for
+    # @mention-driven Seer Explorer (app_mentions:read, channels/groups:history)
+    # and the assistant surface.
     extended_oauth_scopes = frozenset(
         [
             SlackScope.CHANNELS_HISTORY,
@@ -386,7 +387,7 @@ class SlackIntegrationProvider(IntegrationProvider):
         """
         Returns the OAuth scopes to request during installation.
         """
-        return self.identity_oauth_scopes
+        return self.identity_oauth_scopes | self.extended_oauth_scopes
 
     setup_dialog_config = {"width": 600, "height": 900}
     setup_url_path = "/extensions/slack/setup/"

--- a/src/sentry/integrations/slack/staging/integration.py
+++ b/src/sentry/integrations/slack/staging/integration.py
@@ -22,7 +22,7 @@ class SlackStagingIntegrationProvider(SlackIntegrationProvider):
     setup_url_path = "/extensions/slack-staging/setup/"
 
     def _get_oauth_scopes(self) -> frozenset[str]:
-        return self.identity_oauth_scopes | self.extended_oauth_scopes
+        return self.identity_oauth_scopes | self.staging_oauth_scopes
 
     def _make_identity_provider(self) -> SlackStagingIdentityProvider:
         return SlackStagingIdentityProvider(


### PR DESCRIPTION
we have the approval from slack to publish the updated version of our slack app with upgraded permissions.

when we launch, we will need to request upgraded permissions with the production slack app. we now include the new permissions that we'll be approved for in the list of permissions we request.

we will keep the `extended_oauth_scopes` and the logic behind the staging app, so in the future, if we want to test out a new scope, we can use the staging app.

DO NOT MERGE UNTIL APP UPDATE HAS BEEN PUBLISHED

completes iswf-2551