### PR TITLE
feat(seer): Add structured LLM context for trace details page

### DIFF
--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -29,6 +29,8 @@ import {
   TraceLayoutTabKeys,
   useTraceLayoutTabs,
 } from 'sentry/views/performance/newTraceDetails/useTraceLayoutTabs';
+import {useLLMContext} from 'sentry/views/seerExplorer/contexts/llmContext';
+import {registerLLMContext} from 'sentry/views/seerExplorer/contexts/registerLLMContext';
 
 import {useTrace} from './traceApi/useTrace';
 import {useTraceMeta} from './traceApi/useTraceMeta';
@@ -80,7 +82,7 @@ export default function TraceView() {
         initialPreferences={preferences}
         preferencesStorageKey={TRACE_VIEW_PREFERENCES_KEY}
       >
-        <TraceViewImpl traceSlug={traceSlug} />
+        <ContextAwareTraceViewImpl traceSlug={traceSlug} />
       </TraceStateProvider>
     </TraceViewLogsDataProvider>
   );
@@ -145,6 +147,44 @@ function TraceViewImpl({traceSlug}: {traceSlug: string}) {
     tree,
     logs: logsData,
     metrics: metricsData,
+  });
+
+  // Push trace metadata into the LLM context tree for Seer Explorer.
+  useLLMContext({
+    contextHint:
+      'Sentry trace detail page. topLevelNodes lists root transactions/spans. webVitals shows Core Web Vitals if available. ' +
+      'Tools: get_trace_waterfall(trace_id, span_id?) for full waterfall or specific span; ' +
+      'get_event_details(event_id?, issue_id?) for error event details; ' +
+      'get_issue_details(issue_id) for issue aggregate stats; ' +
+      'get_log_attributes(trace_id, log_message_substring) for log entries in this trace; ' +
+      'get_metric_attributes(trace_id, metric_name) for metric samples in this trace; ' +
+      'get_profile_flamegraph(profile_id, trace_id?) for CPU/memory flamegraph; ' +
+      'telemetry_live_search(dataset, question, project_slugs) for related spans/errors/logs/metrics.',
+    traceId: traceSlug,
+    traceType: tree.type,
+    activeTab: currentTab,
+    shape: tree.type === 'trace' ? tree.shape : undefined,
+    durationMs: tree.root.children[0]?.space?.[1],
+    nodeCount: tree.list.length,
+    projects: Array.from(tree.projects.values())
+      .map(p => p.slug)
+      .slice(0, 10),
+    errors: meta.data?.errors,
+    performanceIssues: meta.data?.performance_issues,
+    spanCount: meta.data?.span_count,
+    webVitals: tree.indicators.map(i => ({
+      type: i.type,
+      label: i.label,
+      value: i.measurement.value,
+      unit: i.measurement.unit,
+      poor: i.poor,
+    })),
+    topLevelNodes: tree.root.children[0]?.children.slice(0, 10).map(n => ({
+      op: n.op,
+      description: n.description?.slice(0, 120),
+      durationMs: n.space?.[1],
+      projectSlug: n.projectSlug,
+    })),
   });
 
   return (
@@ -216,6 +256,8 @@ function TraceViewImpl({traceSlug}: {traceSlug: string}) {
     </SentryDocumentTitle>
   );
 }
+
+const ContextAwareTraceViewImpl = registerLLMContext('trace', TraceViewImpl);
 
 // @TODO(JonasBadalic): Remove this component once the page-frame feature is GA'd
 // When that feature is enabled, the footer is no longer rendered at the bottom of the page.

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -82,7 +82,7 @@ export default function TraceView() {
         initialPreferences={preferences}
         preferencesStorageKey={TRACE_VIEW_PREFERENCES_KEY}
       >
-        <ContextAwareTraceViewImpl traceSlug={traceSlug} />
+        <TraceViewImpl traceSlug={traceSlug} />
       </TraceStateProvider>
     </TraceViewLogsDataProvider>
   );
@@ -105,7 +105,7 @@ function useInitialLogsData(): OurLogsResponseItem[] | undefined {
   return initialDataRef.current;
 }
 
-function TraceViewImpl({traceSlug}: {traceSlug: string}) {
+function TraceViewImplInner({traceSlug}: {traceSlug: string}) {
   const organization = useOrganization();
   const queryParams = useTraceQueryParams();
   const traceEventView = useTraceEventView(traceSlug, queryParams);
@@ -167,9 +167,7 @@ function TraceViewImpl({traceSlug}: {traceSlug: string}) {
       'get_profile_flamegraph(profile_id, trace_id?) for CPU/memory flamegraph; ' +
       'telemetry_live_search(dataset, question, project_slugs) for related spans/errors/logs/metrics.',
     traceId: traceSlug,
-    traceType: tree.type,
     activeTab: currentTab,
-    shape: tree.type === 'trace' ? tree.shape : undefined,
     durationMs: tree.root.children[0]?.space?.[1],
     nodeCount: tree.list.length,
     projects: Array.from(tree.projects.values())
@@ -268,7 +266,7 @@ function TraceViewImpl({traceSlug}: {traceSlug: string}) {
   );
 }
 
-const ContextAwareTraceViewImpl = registerLLMContext('trace', TraceViewImpl);
+const TraceViewImpl = registerLLMContext('trace', TraceViewImplInner);
 
 // @TODO(JonasBadalic): Remove this component once the page-frame feature is GA'd
 // When that feature is enabled, the footer is no longer rendered at the bottom of the page.

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -40,7 +40,7 @@ import {
   DEFAULT_TRACE_VIEW_PREFERENCES,
   getInitialTracePreferences,
 } from './traceState/tracePreferences';
-import {TraceStateProvider} from './traceState/traceStateProvider';
+import {TraceStateProvider, useTraceState} from './traceState/traceStateProvider';
 import {ErrorsOnlyWarnings} from './traceTypeWarnings/errorsOnlyWarnings';
 import {TraceMetaDataHeader} from './traceHeader';
 import {useInitialTraceMetricData} from './useInitialTraceMetricData';
@@ -150,9 +150,15 @@ function TraceViewImpl({traceSlug}: {traceSlug: string}) {
   });
 
   // Push trace metadata into the LLM context tree for Seer Explorer.
+  const traceState = useTraceState();
+  const drawerNode =
+    typeof traceState.tabs.current_tab?.node === 'string'
+      ? null
+      : (traceState.tabs.current_tab?.node ?? null);
+
   useLLMContext({
     contextHint:
-      'Sentry trace detail page. topLevelNodes lists root transactions/spans. webVitals shows Core Web Vitals if available. ' +
+      'Sentry trace detail page. focusedSpan is the span currently open in the drawer — it may or may not be relevant to the user question. ' +
       'Tools: get_trace_waterfall(trace_id, span_id?) for full waterfall or specific span; ' +
       'get_event_details(event_id?, issue_id?) for error event details; ' +
       'get_issue_details(issue_id) for issue aggregate stats; ' +
@@ -179,12 +185,17 @@ function TraceViewImpl({traceSlug}: {traceSlug: string}) {
       unit: i.measurement.unit,
       poor: i.poor,
     })),
-    topLevelNodes: tree.root.children[0]?.children.slice(0, 10).map(n => ({
-      op: n.op,
-      description: n.description?.slice(0, 120),
-      durationMs: n.space?.[1],
-      projectSlug: n.projectSlug,
-    })),
+    focusedSpan: drawerNode
+      ? {
+          spanId: drawerNode.id,
+          op: drawerNode.op,
+          description: drawerNode.description?.slice(0, 120),
+          durationMs: drawerNode.space?.[1],
+          projectSlug: drawerNode.projectSlug,
+          errors: drawerNode.errors.size,
+          profileId: drawerNode.profileId,
+        }
+      : undefined,
   });
 
   return (

--- a/static/app/views/performance/newTraceDetails/index.tsx
+++ b/static/app/views/performance/newTraceDetails/index.tsx
@@ -40,7 +40,7 @@ import {
   DEFAULT_TRACE_VIEW_PREFERENCES,
   getInitialTracePreferences,
 } from './traceState/tracePreferences';
-import {TraceStateProvider, useTraceState} from './traceState/traceStateProvider';
+import {TraceStateProvider} from './traceState/traceStateProvider';
 import {ErrorsOnlyWarnings} from './traceTypeWarnings/errorsOnlyWarnings';
 import {TraceMetaDataHeader} from './traceHeader';
 import {useInitialTraceMetricData} from './useInitialTraceMetricData';
@@ -150,15 +150,9 @@ function TraceViewImplInner({traceSlug}: {traceSlug: string}) {
   });
 
   // Push trace metadata into the LLM context tree for Seer Explorer.
-  const traceState = useTraceState();
-  const drawerNode =
-    typeof traceState.tabs.current_tab?.node === 'string'
-      ? null
-      : (traceState.tabs.current_tab?.node ?? null);
-
   useLLMContext({
     contextHint:
-      'Sentry trace detail page. focusedSpan is the span currently open in the drawer — it may or may not be relevant to the user question. ' +
+      'Sentry trace detail page. services lists the projects (services) involved in this trace. ' +
       'Tools: get_trace_waterfall(trace_id, span_id?) for full waterfall or specific span; ' +
       'get_event_details(event_id?, issue_id?) for error event details; ' +
       'get_issue_details(issue_id) for issue aggregate stats; ' +
@@ -170,9 +164,7 @@ function TraceViewImplInner({traceSlug}: {traceSlug: string}) {
     activeTab: currentTab,
     durationMs: tree.root.children[0]?.space?.[1],
     nodeCount: tree.list.length,
-    projects: Array.from(tree.projects.values())
-      .map(p => p.slug)
-      .slice(0, 10),
+    services: Array.from(tree.projects.values()).map(p => p.slug),
     errors: meta.data?.errors,
     performanceIssues: meta.data?.performance_issues,
     spanCount: meta.data?.span_count,
@@ -183,17 +175,6 @@ function TraceViewImplInner({traceSlug}: {traceSlug: string}) {
       unit: i.measurement.unit,
       poor: i.poor,
     })),
-    focusedSpan: drawerNode
-      ? {
-          spanId: drawerNode.id,
-          op: drawerNode.op,
-          description: drawerNode.description?.slice(0, 120),
-          durationMs: drawerNode.space?.[1],
-          projectSlug: drawerNode.projectSlug,
-          errors: drawerNode.errors.size,
-          profileId: drawerNode.profileId,
-        }
-      : undefined,
   });
 
   return (

--- a/static/app/views/seerExplorer/contexts/llmContext.spec.tsx
+++ b/static/app/views/seerExplorer/contexts/llmContext.spec.tsx
@@ -256,6 +256,61 @@ describe('useLLMContext — data updates', () => {
   });
 });
 
+describe('registerLLMContext — trace node type', () => {
+  it('registers a trace node and includes trace metadata in snapshot', async () => {
+    const {ContextCapture, getSnapshot} = makeContextCapture();
+
+    function DummyTrace() {
+      useLLMContext({
+        contextHint: 'Sentry trace detail page.',
+        traceId: 'abc123',
+        traceType: 'trace',
+        activeTab: 'waterfall',
+        shape: 'one_root',
+        durationMs: 1500,
+        nodeCount: 42,
+        errors: 2,
+        spanCount: 40,
+        webVitals: [
+          {type: 'lcp', label: 'LCP', value: 2500, unit: 'millisecond', poor: true},
+        ],
+        topLevelNodes: [
+          {
+            op: 'http.server',
+            description: 'GET /api/users',
+            durationMs: 1200,
+            projectSlug: 'backend',
+          },
+        ],
+      });
+      return <div>trace</div>;
+    }
+    const ContextTrace = registerLLMContext('trace', DummyTrace);
+
+    render(
+      <LLMContextProvider>
+        <ContextTrace />
+        <ContextCapture />
+      </LLMContextProvider>
+    );
+
+    await waitFor(() => {
+      const snapshot = getSnapshot();
+      expect(snapshot.nodes).toHaveLength(1);
+      expect(snapshot.nodes[0]?.nodeType).toBe('trace');
+      const data = snapshot.nodes[0]?.data as Record<string, unknown>;
+      expect(data.traceId).toBe('abc123');
+      expect(data.traceType).toBe('trace');
+      expect(data.activeTab).toBe('waterfall');
+      expect(data.shape).toBe('one_root');
+      expect(data.durationMs).toBe(1500);
+      expect(data.errors).toBe(2);
+      expect(data.webVitals).toHaveLength(1);
+      expect(data.topLevelNodes).toHaveLength(1);
+    });
+  });
+});
+
 describe('getLLMContext — full tree vs componentOnly', () => {
   it('getLLMContext() returns full tree including sibling branches', async () => {
     const {ContextCapture, getSnapshot} = makeContextCapture();

--- a/static/app/views/seerExplorer/contexts/llmContextTypes.ts
+++ b/static/app/views/seerExplorer/contexts/llmContextTypes.ts
@@ -17,7 +17,12 @@
  * Known node types for the LLM context tree.
  * Add new types here as new context-aware components are registered.
  */
-export type LLMContextNodeType = 'chart' | 'dashboard' | 'widget' | 'widget-builder';
+export type LLMContextNodeType =
+  | 'chart'
+  | 'dashboard'
+  | 'trace'
+  | 'widget'
+  | 'widget-builder';
 
 /**
  * A single node in the flat registry.

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -53,7 +53,9 @@ const STRUCTURED_CONTEXT_ROUTES = new Set([
   '/dashboard/:dashboardId/widget-builder/widget/:widgetIndex/edit/',
 ]);
 /** New experimental routes where the LLMContext tree provides structured page context. */
-const NEW_STRUCTURED_CONTEXT_ROUTES = new Set<string>();
+const NEW_STRUCTURED_CONTEXT_ROUTES = new Set<string>([
+  '/explore/traces/trace/:traceSlug/',
+]);
 
 function supportsStructuredContext(
   referrer: string,


### PR DESCRIPTION
+ Register the trace details page with the LLM context system so the Seer Explorer agent receives a structured JSON summary instead of an ASCII DOM snapshot. Pushes trace metadata (shape, duration, web vitals, error/span counts, top-level transactions) and tool-call hints for deeper investigation.

+ The idea here is to give the agent the minimal amount of information to make the right tool calls. 

+ Behind the context-engine-structured-page-context feature flag on the /explore/traces/trace/:traceSlug/ route. Currenlty only enabled for me and Shruthi.
