### PR TITLE
fix(dashboards): Allow wheel widgets to save with null limit

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -544,9 +544,12 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
         # Validate limit on chart widgets with group-by columns:
         # if there are too many groups the server cannot serve the
         # request to get widget data and hence the chart fails to load.
+        # WHEEL widgets render a single aggregated row and don't use `limit`,
+        # so they're exempted from this check.
         if (
             data.get("display_type") != DashboardWidgetDisplayTypes.TABLE
             and data.get("display_type") != DashboardWidgetDisplayTypes.BIG_NUMBER
+            and data.get("display_type") != DashboardWidgetDisplayTypes.WHEEL
             and data.get("limit") is None
             and has_columns
         ):

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_widget_details.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_widget_details.py
@@ -1332,6 +1332,37 @@ class OrganizationDashboardWidgetDetailsTestCase(OrganizationDashboardWidgetTest
             "limit": "limit is required. The maximum limit is 5."
         }
 
+    def test_wheel_widget_allows_null_limit(self) -> None:
+        data = {
+            "title": "Performance Score",
+            "widgetType": "spans",
+            "displayType": "wheel",
+            "queries": [
+                {
+                    "name": "",
+                    "conditions": "",
+                    "fields": [
+                        "performance_score(measurements.score.lcp)",
+                        "performance_score(measurements.score.total)",
+                    ],
+                    "columns": [
+                        "performance_score(measurements.score.lcp)",
+                        "performance_score(measurements.score.total)",
+                    ],
+                    "aggregates": [],
+                    "orderby": "",
+                }
+            ],
+        }
+
+        response = self.do_request(
+            "post",
+            self.url(),
+            data=data,
+        )
+
+        assert response.status_code == 200, response.data
+
     def test_valid_widget_is_filters(self) -> None:
         data = {
             "title": "Errors over time",


### PR DESCRIPTION
Fixes a bug where the wheel widget failed to save due to "limit is required". Wheel widget don't require a limit, it just queries for aggregates with no group by, so having a limit isn't necessary as there will always be the same number of results.

Fixes DAIN-1584