### PR TITLE
fix(ACI): Require 'repo' to be passed when creating GitHub ticket action

### DIFF
--- a/src/sentry/integrations/github/handlers/github_handler.py
+++ b/src/sentry/integrations/github/handlers/github_handler.py
@@ -11,3 +11,41 @@ from sentry.workflow_engine.types import ActionHandler
 class GithubActionHandler(TicketingActionHandler):
     group = ActionHandler.Group.TICKET_CREATION
     provider_slug = IntegrationProviderSlug.GITHUB
+
+    data_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "description": "Schema for GitHub ticket creation action data blob",
+        "properties": {
+            "dynamic_form_fields": {
+                "type": "array",
+                "description": "Dynamic form fields from customer configuration",
+                "items": {"type": "object"},
+                "default": [],
+            },
+            "additional_fields": {
+                "type": "object",
+                "description": "Additional fields that aren't part of standard fields",
+                "additionalProperties": True,
+                "properties": {
+                    "repo": {"type": "string"},
+                    "labels": {
+                        "type": ["array", "null"],
+                        "items": {"type": "string"},
+                        "default": [],
+                    },
+                    "assignee": {
+                        "type": ["string", "null"],
+                    },
+                    "integration": {
+                        "type": [
+                            "string",
+                        ],
+                    },
+                },
+                "required": ["repo", "integration"],
+            },
+        },
+        "required": ["additional_fields"],
+        "additionalProperties": False,
+    }

--- a/src/sentry/integrations/github_enterprise/handlers/github_enterprise_handler.py
+++ b/src/sentry/integrations/github_enterprise/handlers/github_enterprise_handler.py
@@ -1,13 +1,11 @@
+from sentry.integrations.github.handlers.github_handler import GithubActionHandler
 from sentry.integrations.types import IntegrationProviderSlug
-from sentry.notifications.notification_action.action_handler_registry.base import (
-    TicketingActionHandler,
-)
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.registry import action_handler_registry
 from sentry.workflow_engine.types import ActionHandler
 
 
 @action_handler_registry.register(Action.Type.GITHUB_ENTERPRISE)
-class GithubEnterpriseActionHandler(TicketingActionHandler):
+class GithubEnterpriseActionHandler(GithubActionHandler):
     group = ActionHandler.Group.TICKET_CREATION
     provider_slug = IntegrationProviderSlug.GITHUB_ENTERPRISE

--- a/src/sentry/notifications/notification_action/action_validation.py
+++ b/src/sentry/notifications/notification_action/action_validation.py
@@ -123,20 +123,13 @@ class AzureDevOpsActionValidatorHandler(TicketingActionValidatorHandler):
     provider = Action.Type.AZURE_DEVOPS
 
 
-class SharedGitHubValidatorHandler(TicketingActionValidatorHandler):
-    def clean_data(self) -> dict[str, Any]:
-        if not self.validated_data.get("data", {}).get("additional_fields", {}).get("repo"):
-            raise ValidationError("'repo' is required")
-        return super().clean_data()
-
-
 @action_validator_registry.register(Action.Type.GITHUB)
-class GithubActionValidatorHandler(SharedGitHubValidatorHandler):
+class GithubActionValidatorHandler(TicketingActionValidatorHandler):
     provider = Action.Type.GITHUB
 
 
 @action_validator_registry.register(Action.Type.GITHUB_ENTERPRISE)
-class GithubEnterpriseActionValidatorHandler(SharedGitHubValidatorHandler):
+class GithubEnterpriseActionValidatorHandler(TicketingActionValidatorHandler):
     provider = Action.Type.GITHUB_ENTERPRISE
 
 

--- a/src/sentry/notifications/notification_action/action_validation.py
+++ b/src/sentry/notifications/notification_action/action_validation.py
@@ -123,13 +123,20 @@ class AzureDevOpsActionValidatorHandler(TicketingActionValidatorHandler):
     provider = Action.Type.AZURE_DEVOPS
 
 
+class SharedGitHubValidatorHandler(TicketingActionValidatorHandler):
+    def clean_data(self) -> dict[str, Any]:
+        if not self.validated_data.get("data", {}).get("additional_fields", {}).get("repo"):
+            raise ValidationError("'repo' is required")
+        return super().clean_data()
+
+
 @action_validator_registry.register(Action.Type.GITHUB)
-class GithubActionValidatorHandler(TicketingActionValidatorHandler):
+class GithubActionValidatorHandler(SharedGitHubValidatorHandler):
     provider = Action.Type.GITHUB
 
 
 @action_validator_registry.register(Action.Type.GITHUB_ENTERPRISE)
-class GithubEnterpriseActionValidatorHandler(TicketingActionValidatorHandler):
+class GithubEnterpriseActionValidatorHandler(SharedGitHubValidatorHandler):
     provider = Action.Type.GITHUB_ENTERPRISE
 
 

--- a/tests/sentry/workflow_engine/endpoints/validators/actions/test_ticketing.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/actions/test_ticketing.py
@@ -35,7 +35,9 @@ class BaseTicketingActionValidatorTest(TestCase):
 class TestGitHubActionValidator(BaseTicketingActionValidatorTest):
     def setUp(self) -> None:
         super().setUp()
-        self.valid_data["data"] = {"additional_fields": {"repo": "owner/test-repo"}}
+        self.valid_data["data"] = {
+            "additional_fields": {"repo": "owner/test-repo", "integration": "12345"}
+        }
 
 
 class TestJiraActionValidator(BaseTicketingActionValidatorTest):

--- a/tests/sentry/workflow_engine/endpoints/validators/actions/test_ticketing.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/actions/test_ticketing.py
@@ -32,6 +32,14 @@ class BaseTicketingActionValidatorTest(TestCase):
         assert result is True
 
 
+class TestGitHubActionValidator(BaseTicketingActionValidatorTest):
+    __test__ = False
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.valid_data["data"] = {"additional_fields": {"repo": "owner/test-repo"}}
+
+
 class TestJiraActionValidator(BaseTicketingActionValidatorTest):
     __test__ = True
     provider = Action.Type.JIRA
@@ -47,11 +55,27 @@ class TestAzureDevOpsActionValidator(BaseTicketingActionValidatorTest):
     provider = Action.Type.AZURE_DEVOPS
 
 
-class TestGithubActionValidator(BaseTicketingActionValidatorTest):
+class TestGithubActionValidator(TestGitHubActionValidator):
     __test__ = True
     provider = Action.Type.GITHUB
 
+    def test_validate_missing_repo(self) -> None:
+        data = {**self.valid_data, "data": {}}
+        validator = BaseActionValidator(
+            data=data,
+            context={"organization": self.organization},
+        )
+        assert validator.is_valid() is False
 
-class TestGithubEnterpriseActionValidator(BaseTicketingActionValidatorTest):
+
+class TestGithubEnterpriseActionValidator(TestGitHubActionValidator):
     __test__ = True
     provider = Action.Type.GITHUB_ENTERPRISE
+
+    def test_validate_missing_repo(self) -> None:
+        data = {**self.valid_data, "data": {}}
+        validator = BaseActionValidator(
+            data=data,
+            context={"organization": self.organization},
+        )
+        assert validator.is_valid() is False

--- a/tests/sentry/workflow_engine/endpoints/validators/actions/test_ticketing.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/actions/test_ticketing.py
@@ -33,8 +33,6 @@ class BaseTicketingActionValidatorTest(TestCase):
 
 
 class TestGitHubActionValidator(BaseTicketingActionValidatorTest):
-    __test__ = False
-
     def setUp(self) -> None:
         super().setUp()
         self.valid_data["data"] = {"additional_fields": {"repo": "owner/test-repo"}}


### PR DESCRIPTION
We have some front end validation here but if using the API directly it's possible to create a GitHub ticketing workflow that can't function if you fail to pass in the repo name. This PR adds validation on the GitHub ticketing action to make sure it's passed.