### PR TITLE
ref(seer): Update isSeerExplorerEnabled to use gen-ai-features flag

### DIFF
--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.spec.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.spec.tsx
@@ -30,7 +30,8 @@ const defaultHookReturn: ReturnType<typeof useSeerExplorerModule.useSeerExplorer
 describe('ExplorerDrawerContent', () => {
   const organization = OrganizationFixture({
     openMembership: true,
-    features: ['seer-explorer'],
+    features: ['seer-explorer', 'gen-ai-features'],
+    hideAiFeatures: false,
   });
 
   beforeEach(() => {

--- a/static/app/views/seerExplorer/components/drawer/useSeerExplorerDrawer.spec.tsx
+++ b/static/app/views/seerExplorer/components/drawer/useSeerExplorerDrawer.spec.tsx
@@ -23,7 +23,8 @@ const DRAWER_LABEL = 'Seer Explorer Drawer';
 
 const enabledOrg = OrganizationFixture({
   openMembership: true,
-  features: ['seer-explorer'],
+  features: ['seer-explorer', 'gen-ai-features'],
+  hideAiFeatures: false,
 });
 
 function queryDrawer(): HTMLElement | null {

--- a/static/app/views/seerExplorer/components/panel/explorerFAB.spec.tsx
+++ b/static/app/views/seerExplorer/components/panel/explorerFAB.spec.tsx
@@ -13,7 +13,7 @@ jest.mock('react-dom', () => ({
 }));
 
 const organization = OrganizationFixture({
-  features: ['seer-explorer'],
+  features: ['seer-explorer', 'gen-ai-features'],
   hideAiFeatures: false,
   openMembership: true,
 });
@@ -52,7 +52,7 @@ describe('ExplorerFloatingActionButton', () => {
     it('does not render when feature flag is disabled', () => {
       const {container} = renderFAB({
         organization: OrganizationFixture({
-          features: [],
+          features: ['gen-ai-features'],
           hideAiFeatures: false,
           openMembership: true,
         }),
@@ -63,9 +63,31 @@ describe('ExplorerFloatingActionButton', () => {
     it('does not render when open membership is disabled', () => {
       const {container} = renderFAB({
         organization: OrganizationFixture({
-          features: ['seer-explorer'],
+          features: ['seer-explorer', 'gen-ai-features'],
           hideAiFeatures: false,
           openMembership: false,
+        }),
+      });
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('does not render when hideAiFeatures is true', () => {
+      const {container} = renderFAB({
+        organization: OrganizationFixture({
+          features: ['seer-explorer', 'gen-ai-features'],
+          hideAiFeatures: true,
+          openMembership: true,
+        }),
+      });
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('does not render when gen-ai-features feature flag is disabled', () => {
+      const {container} = renderFAB({
+        organization: OrganizationFixture({
+          features: ['seer-explorer'],
+          hideAiFeatures: false,
+          openMembership: true,
         }),
       });
       expect(container).toBeEmptyDOMElement();

--- a/static/app/views/seerExplorer/hooks/useExplorerSessions.tsx
+++ b/static/app/views/seerExplorer/hooks/useExplorerSessions.tsx
@@ -2,6 +2,7 @@ import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import type {ExplorerSession} from 'sentry/views/seerExplorer/types';
+import {isSeerExplorerEnabled} from 'sentry/views/seerExplorer/utils';
 
 interface SessionsResponse {
   data: ExplorerSession[];
@@ -27,8 +28,8 @@ export function useExplorerSessions({
       },
     ],
     {
-      staleTime: Infinity,
-      enabled: enabled && Boolean(organization),
+      staleTime: 0,
+      enabled: enabled && !!organization && isSeerExplorerEnabled(organization),
     }
   );
 

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.spec.tsx
@@ -30,8 +30,9 @@ describe('useSeerExplorer', () => {
   });
 
   const organization = OrganizationFixture({
-    features: ['seer-explorer'],
+    features: ['seer-explorer', 'gen-ai-features'],
     hideAiFeatures: false,
+    openMembership: true,
   });
 
   describe('Initial State', () => {

--- a/static/app/views/seerExplorer/hooks/useSeerExplorerPolling.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorerPolling.tsx
@@ -2,7 +2,10 @@ import {useApiQuery} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import type {SeerExplorerResponse} from 'sentry/views/seerExplorer/hooks/useSeerExplorer';
 import type {Block} from 'sentry/views/seerExplorer/types';
-import {makeSeerExplorerQueryKey} from 'sentry/views/seerExplorer/utils';
+import {
+  isSeerExplorerEnabled,
+  makeSeerExplorerQueryKey,
+} from 'sentry/views/seerExplorer/utils';
 
 const POLL_INTERVAL = 500; // Poll every 500ms
 /** Checks if session is in a terminal state where the agent is done processing. */
@@ -52,7 +55,7 @@ export const useSeerExplorerPolling = ({
     {
       staleTime: 0,
       retry: false,
-      enabled: !!runId && !!orgSlug,
+      enabled: !!runId && !!orgSlug && isSeerExplorerEnabled(organization),
       refetchInterval: query => {
         if (isPolling(runId, query.state.data?.[0]?.session, isMutatePending)) {
           return POLL_INTERVAL;

--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -1060,9 +1060,9 @@ export function getExplorerFeedbackOptions(runId: number | null): UseFeedbackOpt
  */
 export function isSeerExplorerEnabled(organization: Organization): boolean {
   return (
-    organization.openMembership
-    && !organization.hideAiFeatures
-    && organization.features.includes('gen-ai-features')
-    && organization.features.includes('seer-explorer')
+    organization.openMembership &&
+    !organization.hideAiFeatures &&
+    organization.features.includes('gen-ai-features') &&
+    organization.features.includes('seer-explorer')
   );
 }

--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -1054,10 +1054,11 @@ export function getExplorerFeedbackOptions(runId: number | null): UseFeedbackOpt
 /**
  * Checks if Seer Explorer is enabled for the organization.
  * Requires all of the following conditions:
- * - 'seer-explorer' feature flag
- * - Organization has open membership
- * Does not check general AI features access or org consent.
+ * - 'gen-ai-features' feature flag
+ * - Organization has not disabled AI features (hideAiFeatures is false)
  */
 export function isSeerExplorerEnabled(organization: Organization): boolean {
-  return organization.openMembership && organization.features.includes('seer-explorer');
+  return (
+    !organization.hideAiFeatures && organization.features.includes('gen-ai-features')
+  );
 }

--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -1053,12 +1053,16 @@ export function getExplorerFeedbackOptions(runId: number | null): UseFeedbackOpt
 
 /**
  * Checks if Seer Explorer is enabled for the organization.
- * Requires all of the following conditions:
+ * Requires the rollout flag and:
  * - 'gen-ai-features' feature flag
+ * - Organization has not disabled open membership
  * - Organization has not disabled AI features (hideAiFeatures is false)
  */
 export function isSeerExplorerEnabled(organization: Organization): boolean {
   return (
-    !organization.hideAiFeatures && organization.features.includes('gen-ai-features')
+    organization.openMembership
+    && !organization.hideAiFeatures
+    && organization.features.includes('gen-ai-features')
+    && organization.features.includes('seer-explorer')
   );
 }


### PR DESCRIPTION
## Changes

- Updated `isSeerExplorerEnabled` in `static/app/views/seerExplorer/utils.tsx` to gate on `!organization.hideAiFeatures` and `organization.features.includes('gen-ai-features')` too as they are killswitches for all AI features