### PR TITLE
chore(settings): Update Seer settings docs link for Autofix

### DIFF
--- a/static/gsApp/views/seerAutomation/advanced.tsx
+++ b/static/gsApp/views/seerAutomation/advanced.tsx
@@ -41,7 +41,7 @@ export default function SeerAutomationAdvancedSettings() {
           'Configure how Seer works with your codebase. Seer includes [autofix:Autofix] and [code_review:Code Review]. Autofix will triage your Issues as they are created, and can automatically send them to a coding agent for Root Cause Analysis, Solution generation, and PR creation. Code Review will review your pull requests to detect issues before they happen. [docs:Read the docs] to learn what Seer can do.',
           {
             autofix: (
-              <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/autofix/#root-cause-analysis" />
+              <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/autofix/" />
             ),
             code_review: (
               <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/code-review/" />

--- a/static/gsApp/views/seerAutomation/settings.tsx
+++ b/static/gsApp/views/seerAutomation/settings.tsx
@@ -68,7 +68,7 @@ export function SeerAutomationSettings() {
           'Configure how Seer works with your codebase. Seer includes [autofix:Autofix] and [code_review:Code Review]. Autofix will triage your Issues as they are created, and can automatically send them to a coding agent for Root Cause Analysis, Solution generation, and PR creation. Code Review will review your pull requests to detect issues before they happen. [docs:Read the docs] to learn what Seer can do.',
           {
             autofix: (
-              <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/autofix/#root-cause-analysis" />
+              <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/autofix/" />
             ),
             code_review: (
               <ExternalLink href="https://docs.sentry.io/product/ai-in-sentry/seer/code-review/" />


### PR DESCRIPTION
I _think_ https://docs.sentry.io/product/ai-in-sentry/seer/autofix/#root-cause-analysis is the incorrect docs link from Seer settings, and we actually want the main Autofix route of https://docs.sentry.io/product/ai-in-sentry/seer/autofix/.