### PR TITLE
perf(releases): Filter artifact bundle joins by organization_id

### DIFF
--- a/src/sentry/models/release.py
+++ b/src/sentry/models/release.py
@@ -726,8 +726,10 @@ class Release(Model):
         """
         qs = (
             ArtifactBundle.objects.filter(
-                organization_id=self.organization.id,
+                organization_id=self.organization_id,
+                releaseartifactbundle__organization_id=self.organization_id,
                 releaseartifactbundle__release_name=self.version,
+                projectartifactbundle__organization_id=self.organization_id,
                 projectartifactbundle__project_id__in=project_ids,
             )
             .annotate(count=Sum(Func(F("artifact_count"), 1, function="COALESCE")))


### PR DESCRIPTION
`Release.count_artifacts_in_artifact_bundles` filters `release_name` on the joined `releaseartifactbundle` table but not `organization_id`. The composite index on that table leads with `organization_id`, so without it the planner falls back to the FK auto-index and post-filters release_name row by row.

Adds the redundant `organization_id` filters on `releaseartifactbundle` and `projectartifactbundle` so the composite index is usable.

https://github.com/getsentry/sentry/blob/3b372e8e2e02bea4022f41a508d0239bcb02c441/src/sentry/models/artifactbundle.py#L171-L175

Wasn't able to run explain on this table since it doesn't exist in redash. But hopefully fixes SENTRY-3WGA