### PR TITLE
ref(ci): re-apply parallel devservices startup for backend tests

### DIFF
--- a/.github/actions/setup-devservices/action.yml
+++ b/.github/actions/setup-devservices/action.yml
@@ -1,0 +1,41 @@
+name: 'Early Devservices'
+description: 'Starts devservices in the background so image pulls overlap with venv setup'
+inputs:
+  mode:
+    description: 'devservices mode (must match the mode passed to setup-sentry)'
+    required: true
+  timeout-minutes:
+    description: 'Maximum minutes for devservices up'
+    required: false
+    default: '10'
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
+      with:
+        version: '0.9.28'
+        enable-cache: false
+
+    - name: Start devservices in background
+      shell: bash --noprofile --norc -euo pipefail {0}
+      env:
+        TIMEOUT_MINUTES: ${{ inputs.timeout-minutes }}
+        MODE: ${{ inputs.mode }}
+      run: |
+        DS_VERSION=$(python3 -c "
+        import tomllib
+        with open('uv.lock', 'rb') as f:
+            lock = tomllib.load(f)
+        for pkg in lock['package']:
+            if pkg['name'] == 'devservices':
+                print(pkg['version'])
+                break
+        ")
+        echo "Installing devservices==${DS_VERSION}"
+        uv venv /tmp/ds-venv --python python3 -q
+        uv pip install --python /tmp/ds-venv/bin/python -q \
+          --index-url https://pypi.devinfra.sentry.io/simple \
+          "devservices==${DS_VERSION}"
+        (set +e; timeout "${TIMEOUT_MINUTES}m" /tmp/ds-venv/bin/devservices up --mode "$MODE"; echo $? > /tmp/ds-exit) \
+          > /tmp/ds.log 2>&1 &

--- a/.github/actions/setup-devservices/wait.py
+++ b/.github/actions/setup-devservices/wait.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Wait for the background devservices process started by the setup-devservices action.
+
+Usage: wait.py [timeout_seconds]
+
+Reads:  /tmp/ds-exit, /tmp/ds.log  (written by the setup-devservices action)
+Writes: $GITHUB_ENV  (DJANGO_LIVE_TEST_SERVER_ADDRESS)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+DS_EXIT = Path("/tmp/ds-exit")
+DS_LOG = Path("/tmp/ds.log")
+TIMEOUT = 300
+
+
+def log(msg: str) -> None:
+    print(msg, flush=True)
+
+
+def docker(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["docker", *args], capture_output=True, text=True)
+
+
+def stream_log(pos: int) -> int:
+    """Print any new content written to DS_LOG since pos. Returns the new position."""
+    if not DS_LOG.exists():
+        return pos
+    with DS_LOG.open() as f:
+        f.seek(pos)
+        chunk = f.read()
+        if chunk:
+            sys.stdout.write(chunk)
+            sys.stdout.flush()
+        return f.tell()
+
+
+def container_inspect_dump() -> None:
+    ids = docker("ps", "-aq").stdout.split()
+    if not ids:
+        return
+
+    r = docker("inspect", *ids)
+    if r.returncode != 0:
+        return
+
+    containers = json.loads(r.stdout)
+    for c in containers:
+        name = c["Name"].lstrip("/")
+        status = c["State"]["Status"]
+        health = c["State"].get("Health")
+        health_status = health["Status"] if health else "n/a"
+        log(f"{name}  status={status}  health={health_status}")
+
+    log("")
+    for c in containers:
+        health = c["State"].get("Health")
+        if not health or health["Status"] == "healthy":
+            continue
+        name = c["Name"].lstrip("/")
+        log(f"--- {name} last health check ---")
+        for entry in health.get("Log", []):
+            log(f"  exit={entry['ExitCode']}  {entry['Output'].strip()}")
+
+
+def wait(timeout: int = TIMEOUT) -> None:
+    start = time.monotonic()
+    log_pos = 0
+
+    while not DS_EXIT.exists():
+        elapsed = time.monotonic() - start
+        if elapsed > timeout:
+            log_pos = stream_log(log_pos)
+            log(f"::error::Timed out waiting for devservices after {timeout}s")
+            log("--- container health on timeout ---")
+            container_inspect_dump()
+            sys.exit(1)
+        log_pos = stream_log(log_pos)
+        time.sleep(2)
+
+    # Drain any remaining log output.
+    stream_log(log_pos)
+
+    rc = int(DS_EXIT.read_text().strip())
+    if rc != 0:
+        log(f"::error::devservices up failed (exit {rc})")
+        log("--- container health on failure ---")
+        container_inspect_dump()
+        sys.exit(1)
+
+    r = docker(
+        "network",
+        "inspect",
+        "bridge",
+        "--format",
+        "{{(index .IPAM.Config 0).Gateway}}",
+    )
+    if r.returncode != 0:
+        log(f"::error::docker network inspect bridge failed: {r.stderr.strip()}")
+        sys.exit(1)
+    gateway = r.stdout.strip()
+    github_env = os.environ.get("GITHUB_ENV")
+    if github_env:
+        with open(github_env, "a") as f:
+            f.write(f"DJANGO_LIVE_TEST_SERVER_ADDRESS={gateway}\n")
+
+    r2 = docker("ps", "-a")
+    if r2.stdout.strip():
+        log(r2.stdout.strip())
+
+
+if __name__ == "__main__":
+    wait(int(sys.argv[1]) if len(sys.argv) > 1 else TIMEOUT)

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -59,11 +59,23 @@ jobs:
           node-version-file: '.node-version'
 
       - uses: pnpm/action-setup@9b5745cdf0a2e8c2620f0746130f809adb911c19 # v4
+
+      - name: Start devservices early
+        uses: ./.github/actions/setup-devservices
+        with:
+          mode: default
+
       - name: Setup sentry python env
         uses: ./.github/actions/setup-sentry
         id: setup
         with:
           mode: default
+          skip-devservices: 'true'
+
+      - name: Wait for devservices
+        run: |
+          sentry init
+          ./.github/actions/setup-devservices/wait.py
 
       - name: Run API docs tests
         run: |
@@ -234,11 +246,31 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Start devservices early
+        uses: ./.github/actions/setup-devservices
+        with:
+          mode: backend-ci
+
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry
         id: setup
         with:
           mode: backend-ci
+          skip-devservices: 'true'
+
+      - name: Wait for devservices
+        run: |
+          sentry init
+          # Start Snuba per-worker bootstrap in background — it polls for
+          # ClickHouse readiness itself, so it can begin before all containers
+          # are healthy, overlapping with the remaining devservices health checks.
+          if [ "${XDIST_PER_WORKER_SNUBA}" = "1" ]; then
+            (
+              python3 ./.github/workflows/scripts/bootstrap-snuba.py
+              echo $? > /tmp/snuba-bootstrap-exit
+            ) &
+          fi
+          ./.github/actions/setup-devservices/wait.py
 
       - name: Download odiff binary
         run: |
@@ -247,9 +279,22 @@ jobs:
           sudo install -m 755 odiff-linux-x64 /usr/local/bin/odiff
           rm odiff-linux-x64
 
-      - name: Bootstrap per-worker Snuba instances
+      - name: Wait for Snuba bootstrap
         if: env.XDIST_PER_WORKER_SNUBA == '1'
-        run: python3 .github/workflows/scripts/bootstrap-snuba.py
+        run: |
+          SECONDS=0
+          while [ ! -f /tmp/snuba-bootstrap-exit ]; do
+            if [ $SECONDS -gt 600 ]; then
+              echo "::error::Timed out waiting for Snuba bootstrap after 600s"
+              exit 1
+            fi
+            sleep 2
+          done
+          SNUBA_RC=$(cat /tmp/snuba-bootstrap-exit)
+          if [ "$SNUBA_RC" -ne 0 ]; then
+            echo "::error::Snuba per-worker bootstrap failed"
+            exit 1
+          fi
 
       - name: Download selected tests artifact
         if: needs.select-tests.outputs.has-selected-tests == 'true'
@@ -290,6 +335,11 @@ jobs:
       - name: Inspect failure
         if: failure()
         run: |
+          if [ -f /tmp/ds.log ]; then
+            echo "--- devservices startup log ---"
+            cat /tmp/ds.log
+          fi
+
           if command -v devservices; then
             devservices logs
           fi
@@ -327,11 +377,22 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Start devservices early
+        uses: ./.github/actions/setup-devservices
+        with:
+          mode: default
+
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry
         id: setup
         with:
           mode: default
+          skip-devservices: 'true'
+
+      - name: Wait for devservices
+        run: |
+          sentry init
+          ./.github/actions/setup-devservices/wait.py
 
       - name: run tests
         run: |
@@ -365,11 +426,22 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Start devservices early
+        uses: ./.github/actions/setup-devservices
+        with:
+          mode: migrations
+
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry
         id: setup
         with:
           mode: migrations
+          skip-devservices: 'true'
+
+      - name: Wait for devservices
+        run: |
+          sentry init
+          ./.github/actions/setup-devservices/wait.py
 
       - name: Run test
         env:
@@ -441,10 +513,21 @@ jobs:
 
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Start devservices early
+        uses: ./.github/actions/setup-devservices
+        with:
+          mode: backend-ci
+
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry
         with:
           mode: backend-ci
+          skip-devservices: 'true'
+
+      - name: Wait for devservices
+        run: |
+          sentry init
+          ./.github/actions/setup-devservices/wait.py
 
       - name: Sync API Urls to TypeScript
         run: |
@@ -467,11 +550,22 @@ jobs:
       - name: Checkout sentry
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Start devservices early
+        uses: ./.github/actions/setup-devservices
+        with:
+          mode: migrations
+
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry
         id: setup
         with:
           mode: migrations
+          skip-devservices: 'true'
+
+      - name: Wait for devservices
+        run: |
+          sentry init
+          ./.github/actions/setup-devservices/wait.py
 
       - name: Migration & lockfile checks
         env:
@@ -501,11 +595,22 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - name: Start devservices early
+        uses: ./.github/actions/setup-devservices
+        with:
+          mode: migrations
+
       - name: Setup sentry env
         uses: ./.github/actions/setup-sentry
         id: setup
         with:
           mode: migrations
+          skip-devservices: 'true'
+
+      - name: Wait for devservices
+        run: |
+          sentry init
+          ./.github/actions/setup-devservices/wait.py
 
       - name: Run test
         run: |


### PR DESCRIPTION
 Re-applies #112381 (parallel devservices + sentinel-based snuba bootstrap) for the backend.yml backend-test job only. The original revert in #113755 was triggered by acceptance flakes; backend was reportedly fine. Acceptance.yml stays as-is.