### PR TITLE
fix(ci): cap bulk_snuba_queries thread pool to 4 under per-worker Snuba

### DIFF
--- a/src/sentry/testutils/pytest/sentry.py
+++ b/src/sentry/testutils/pytest/sentry.py
@@ -143,6 +143,16 @@ def pytest_configure(config: pytest.Config) -> None:
 
     integrationdocs.DOC_FOLDER = os.path.join(TEST_ROOT, os.pardir, "fixtures", "integration-docs")
 
+    # Per-worker Snuba in CI runs against a single worker container with
+    # CrossOrgQueryAllocationPolicy capped at 4 concurrent queries on the
+    # errors storage; bulk_snuba_queries' default fan-out of 10 trips that
+    # policy and surfaces flakes. Cap the pool only when running with
+    # per-worker Snuba so production behavior is unaffected.
+    if os.environ.get("XDIST_PER_WORKER_SNUBA") == "1":
+        from sentry.utils import snuba as _snuba
+
+        _snuba._BULK_QUERY_MAX_WORKERS = 4
+
     configure_split_db()
 
     if os.environ.get("PYTEST_XDIST_WORKER"):

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -58,6 +58,11 @@ ROUND_DOWN = object()
 # in a single query to lessen the load on snuba
 MAX_FIELDS = 50
 
+# Default thread pool size for fan-out in _bulk_snuba_query. Per-worker Snuba in
+# CI overrides this to 4 (see sentry.testutils.pytest.sentry) to stay under the
+# CrossOrgQueryAllocationPolicy concurrent-query limit.
+_BULK_QUERY_MAX_WORKERS = 10
+
 SAFE_FUNCTIONS = frozenset(["NOT IN"])
 SAFE_FUNCTION_RE = re.compile(r"-?[a-zA-Z_][a-zA-Z0-9_]*$")
 # Match any text surrounded by quotes, can't use `.*` here since it
@@ -1254,7 +1259,7 @@ def _bulk_snuba_query(snuba_requests: Sequence[SnubaRequest]) -> ResultSet:
         if len(snuba_requests_list) > 1:
             with ContextPropagatingThreadPoolExecutor(
                 thread_name_prefix=__name__,
-                max_workers=10,
+                max_workers=_BULK_QUERY_MAX_WORKERS,
             ) as query_thread_pool:
                 query_results = list(
                     query_thread_pool.map(


### PR DESCRIPTION
We're seeing flakes in backend tests using bulk_snuba_queries because the default thread pool of 10 fans out wider than Snuba's CrossOrgQueryAllocationPolicy on the errors storage allows (rejection_threshold=4 in CI). The 5th concurrent query gets rejected with RateLimitExceeded. Cap the pool to 4 when XDIST_PER_WORKER_SNUBA=1 so we never exceed the policy. Production keeps the wider pool of 10 since prod has higher thresholds.