### PR TITLE
fix(test): unclosed_files fixture only flags newly-leaked fds

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,7 +64,11 @@ else:
 def unclosed_files() -> Generator[None]:
     fds = _open_files()
     yield
-    assert _open_files() == fds
+    # Only flag NEW files that weren't open before the test. Files closed during
+    # the test (e.g. SSL contexts from a prior test that GC just reclaimed) are
+    # not this test's leak — strict equality would yield false positives.
+    leaked = _open_files() - fds
+    assert not leaked, f"Test leaked file descriptors: {leaked}"
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
We're seeing false-positive failures in the unclosed_files fixture when a prior test leaves an SSL context open (cacert.pem from certifi) and GC reclaims it during the current test. The strict equality check fires even though the current test isn't the leaky one (it's actually cleaning up after a prior test). Fundamentally the fixture is meant to detect leaks introduced by the current test, not files that get closed during it. Now we only assert on newly-opened files that weren't closed by end of test.