### PR TITLE
perf(artifact-bundles): Filter search joins by organization_id

### DIFF
--- a/src/sentry/api/endpoints/artifact_bundles.py
+++ b/src/sentry/api/endpoints/artifact_bundles.py
@@ -92,15 +92,25 @@ class ArtifactBundlesEndpoint(ProjectEndpoint, ArtifactBundlesMixin):
             raise ResourceDoesNotExist
 
         if query:
-            # By default, we want to exact match the release or dist.
-            query_q = Q(releaseartifactbundle__release_name=query) | Q(
-                releaseartifactbundle__dist_name=query
+            org_id = project.organization_id
+            # Include organization_id in each Q so the composite indexes on
+            # releaseartifactbundle and debugidartifactbundle (which both lead
+            # with organization_id) can be used.
+            query_q = Q(
+                releaseartifactbundle__organization_id=org_id,
+                releaseartifactbundle__release_name=query,
+            ) | Q(
+                releaseartifactbundle__organization_id=org_id,
+                releaseartifactbundle__dist_name=query,
             )
 
             # In case the query contains an actual UUID, we will also try to match the bundle id or debug id. Checking
             # for the type before making the query saves us one join when not needed.
             if self.is_valid_uuid(query):
-                query_q |= Q(bundle_id=query) | Q(debugidartifactbundle__debug_id=query)
+                query_q |= Q(bundle_id=query) | Q(
+                    debugidartifactbundle__organization_id=org_id,
+                    debugidartifactbundle__debug_id=query,
+                )
 
             # At the end we apply the chain of OR filters to the query. In case both the release and debug ids tables
             # are used, we will make two left outer joins.


### PR DESCRIPTION
when doing a query with `?query=release-name` we're doing a join on the `releaseartifactbundle` table but not using the index which starts with org id. Potentially doing joins with all releases with the same name before filtering down to the correct org.

Fixing the same thing as #114103 

[trace query](https://sentry.sentry.io/explore/traces/?aggregateField=%7B%22groupBy%22%3A%22%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22p95%28span.duration%29%22%5D%7D&extrapolate=0&field=id&field=span.name&field=span.description&field=span.duration&field=transaction&field=timestamp&mode=samples&project=1&query=http.query%3A%EF%80%8DContains%EF%80%8Dquery%20span.description%3A%2Fapi%2F0%2Fprojects%2F%7Borganization_id_or_slug%7D%2F%7Bproject_id_or_slug%7D%2Ffiles%2Fartifact-bundles%2F&sort=-span.duration&statsPeriod=14d)