### PR TITLE
feat(sentry-apps): Expose creator_label on RpcSentryApp

### DIFF
--- a/src/sentry/sentry_apps/services/app/model.py
+++ b/src/sentry/sentry_apps/services/app/model.py
@@ -80,7 +80,6 @@ class RpcSentryApp(RpcModel):
     application: RpcApiApplication | None = None
     proxy_user_id: int | None = None  # can be null on deletion.
     owner_id: int = -1  # relation to an organization
-    owner_slug: str = ""
     name: str = ""
     slug: str = ""
     uuid: str = ""

--- a/src/sentry/sentry_apps/services/app/model.py
+++ b/src/sentry/sentry_apps/services/app/model.py
@@ -80,6 +80,7 @@ class RpcSentryApp(RpcModel):
     application: RpcApiApplication | None = None
     proxy_user_id: int | None = None  # can be null on deletion.
     owner_id: int = -1  # relation to an organization
+    owner_slug: str = ""
     name: str = ""
     slug: str = ""
     uuid: str = ""
@@ -93,6 +94,7 @@ class RpcSentryApp(RpcModel):
     status: str = ""
     metadata: dict[str, Any] = Field(repr=False, default_factory=dict)
     avatars: list[RpcSentryAppAvatar] = Field(default_factory=list)
+    creator_label: str | None = None
 
     def show_auth_info(self, access: Any) -> bool:
         encoded_scopes = set({"%s" % scope for scope in list(access.scopes)})

--- a/src/sentry/sentry_apps/services/app/serial.py
+++ b/src/sentry/sentry_apps/services/app/serial.py
@@ -1,6 +1,7 @@
 from sentry.constants import SentryAppStatus
 from sentry.models.apiapplication import ApiApplication
 from sentry.models.apitoken import ApiToken
+from sentry.models.organizationmapping import OrganizationMapping
 from sentry.sentry_apps.models.sentry_app import SentryApp
 from sentry.sentry_apps.models.sentry_app_avatar import SentryAppAvatar
 from sentry.sentry_apps.models.sentry_app_component import SentryAppComponent
@@ -29,6 +30,11 @@ def serialize_sentry_app(
 ) -> RpcSentryApp:
     if avatars is None:
         avatars = []
+    owner_slug = ""
+    try:
+        owner_slug = OrganizationMapping.objects.get(organization_id=app.owner_id).slug
+    except OrganizationMapping.DoesNotExist:
+        pass
     return RpcSentryApp(
         id=app.id,
         scope_list=app.scope_list,
@@ -36,6 +42,7 @@ def serialize_sentry_app(
         application=serialize_api_application(app.application),
         proxy_user_id=app.proxy_user_id,
         owner_id=app.owner_id,
+        owner_slug=owner_slug,
         name=app.name,
         slug=app.slug,
         uuid=app.uuid,
@@ -49,6 +56,7 @@ def serialize_sentry_app(
         status=SentryAppStatus.as_str(app.status),
         metadata=app.metadata,
         avatars=[serialize_sentry_app_avatar(avatar) for avatar in avatars],
+        creator_label=app.creator_label,
     )
 
 

--- a/src/sentry/sentry_apps/services/app/serial.py
+++ b/src/sentry/sentry_apps/services/app/serial.py
@@ -1,7 +1,6 @@
 from sentry.constants import SentryAppStatus
 from sentry.models.apiapplication import ApiApplication
 from sentry.models.apitoken import ApiToken
-from sentry.models.organizationmapping import OrganizationMapping
 from sentry.sentry_apps.models.sentry_app import SentryApp
 from sentry.sentry_apps.models.sentry_app_avatar import SentryAppAvatar
 from sentry.sentry_apps.models.sentry_app_component import SentryAppComponent
@@ -30,11 +29,6 @@ def serialize_sentry_app(
 ) -> RpcSentryApp:
     if avatars is None:
         avatars = []
-    owner_slug = ""
-    try:
-        owner_slug = OrganizationMapping.objects.get(organization_id=app.owner_id).slug
-    except OrganizationMapping.DoesNotExist:
-        pass
     return RpcSentryApp(
         id=app.id,
         scope_list=app.scope_list,
@@ -42,7 +36,6 @@ def serialize_sentry_app(
         application=serialize_api_application(app.application),
         proxy_user_id=app.proxy_user_id,
         owner_id=app.owner_id,
-        owner_slug=owner_slug,
         name=app.name,
         slug=app.slug,
         uuid=app.uuid,

--- a/tests/sentry/sentry_apps/services/test_serial.py
+++ b/tests/sentry/sentry_apps/services/test_serial.py
@@ -1,4 +1,3 @@
-from sentry.models.organizationmapping import OrganizationMapping
 from sentry.sentry_apps.models.sentry_app import SentryApp
 from sentry.sentry_apps.services.app.serial import serialize_sentry_app
 from sentry.testutils.cases import TestCase
@@ -18,12 +17,11 @@ class SerializeSentryAppTest(TestCase):
             webhook_url="https://example.com/webhook",
         )
 
-    def test_populates_creator_label_and_owner_slug(self) -> None:
+    def test_populates_creator_label(self) -> None:
         with assume_test_silo_mode_of(SentryApp):
             rpc = serialize_sentry_app(self.sentry_app)
 
         assert rpc.creator_label == "creator@example.com"
-        assert rpc.owner_slug == "my-org"
         assert rpc.owner_id == self.org.id
 
     def test_creator_label_falls_back_to_username_when_no_email(self) -> None:
@@ -37,13 +35,3 @@ class SerializeSentryAppTest(TestCase):
             rpc = serialize_sentry_app(app)
 
         assert rpc.creator_label == "someusername"
-
-    def test_owner_slug_empty_when_mapping_missing(self) -> None:
-        with assume_test_silo_mode_of(OrganizationMapping):
-            OrganizationMapping.objects.filter(organization_id=self.org.id).delete()
-
-        with assume_test_silo_mode_of(SentryApp):
-            rpc = serialize_sentry_app(self.sentry_app)
-
-        assert rpc.owner_slug == ""
-        assert rpc.owner_id == self.org.id

--- a/tests/sentry/sentry_apps/services/test_serial.py
+++ b/tests/sentry/sentry_apps/services/test_serial.py
@@ -1,0 +1,49 @@
+from sentry.models.organizationmapping import OrganizationMapping
+from sentry.sentry_apps.models.sentry_app import SentryApp
+from sentry.sentry_apps.services.app.serial import serialize_sentry_app
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import assume_test_silo_mode_of, control_silo_test
+
+
+@control_silo_test
+class SerializeSentryAppTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.user = self.create_user(email="creator@example.com")
+        self.org = self.create_organization(owner=self.user, slug="my-org")
+        self.sentry_app = self.create_sentry_app(
+            name="Test App",
+            organization=self.org,
+            user=self.user,
+            webhook_url="https://example.com/webhook",
+        )
+
+    def test_populates_creator_label_and_owner_slug(self) -> None:
+        with assume_test_silo_mode_of(SentryApp):
+            rpc = serialize_sentry_app(self.sentry_app)
+
+        assert rpc.creator_label == "creator@example.com"
+        assert rpc.owner_slug == "my-org"
+        assert rpc.owner_id == self.org.id
+
+    def test_creator_label_falls_back_to_username_when_no_email(self) -> None:
+        userless_email = self.create_user(email="", username="someusername")
+        with assume_test_silo_mode_of(SentryApp):
+            app = self.create_sentry_app(
+                name="No Email App",
+                organization=self.org,
+                user=userless_email,
+            )
+            rpc = serialize_sentry_app(app)
+
+        assert rpc.creator_label == "someusername"
+
+    def test_owner_slug_empty_when_mapping_missing(self) -> None:
+        with assume_test_silo_mode_of(OrganizationMapping):
+            OrganizationMapping.objects.filter(organization_id=self.org.id).delete()
+
+        with assume_test_silo_mode_of(SentryApp):
+            rpc = serialize_sentry_app(self.sentry_app)
+
+        assert rpc.owner_slug == ""
+        assert rpc.owner_id == self.org.id


### PR DESCRIPTION
Adds `creator_label` and to `RpcSentryApp` so we can build a settings link and identify the integrator email recipient. Backwards-compatible defaults (`None`/`""`) make this a no-op until consumers read the new fields.
