### PR TITLE
feat(notifications): Add sentry-app-webhook-disabled notification template

### DIFF
--- a/src/sentry/notifications/platform/templates/__init__.py
+++ b/src/sentry/notifications/platform/templates/__init__.py
@@ -1,12 +1,14 @@
 from .data_export import DataExportFailureTemplate, DataExportSuccessTemplate
 from .issue import IssueNotificationTemplate
 from .metric_alert import MetricAlertNotificationTemplate
+from .sentry_app_webhook_disabled import SentryAppWebhookDisabledTemplate
 
 __all__ = (
     "DataExportSuccessTemplate",
     "DataExportFailureTemplate",
     "IssueNotificationTemplate",
     "MetricAlertNotificationTemplate",
+    "SentryAppWebhookDisabledTemplate",
 )
 # All templates should be imported here so they are registered in the notifications Django app.
 # See sentry/notifications/apps.py

--- a/src/sentry/notifications/platform/templates/sentry_app_webhook_disabled.py
+++ b/src/sentry/notifications/platform/templates/sentry_app_webhook_disabled.py
@@ -1,0 +1,55 @@
+from sentry.notifications.platform.registry import template_registry
+from sentry.notifications.platform.types import (
+    CodeTextBlock,
+    NotificationCategory,
+    NotificationData,
+    NotificationRenderedAction,
+    NotificationRenderedTemplate,
+    NotificationSource,
+    NotificationTemplate,
+    ParagraphBlock,
+    PlainTextBlock,
+)
+
+
+class SentryAppWebhookDisabled(NotificationData):
+    source: NotificationSource = NotificationSource.SENTRY_APP_WEBHOOK_DISABLED
+    sentry_app_slug: str
+    sentry_app_name: str
+    webhook_url: str
+    settings_url: str
+
+
+@template_registry.register(NotificationSource.SENTRY_APP_WEBHOOK_DISABLED)
+class SentryAppWebhookDisabledTemplate(NotificationTemplate[SentryAppWebhookDisabled]):
+    category = NotificationCategory.SENTRY_APP
+    example_data = SentryAppWebhookDisabled(
+        sentry_app_slug="example-app",
+        sentry_app_name="Example App",
+        webhook_url="https://example.com/webhook",
+        settings_url="https://sentry.io/settings/example-org/developer-settings/example-app/",
+    )
+
+    def render(self, data: SentryAppWebhookDisabled) -> NotificationRenderedTemplate:
+        return NotificationRenderedTemplate(
+            subject=f"Webhook delivery paused for {data.sentry_app_name}",
+            body=[
+                ParagraphBlock(
+                    blocks=[
+                        PlainTextBlock(text="We're temporarily pausing webhook deliveries to "),
+                        CodeTextBlock(text=data.webhook_url),
+                        PlainTextBlock(
+                            text=(
+                                f" because too many recent requests to {data.sentry_app_name} have failed."
+                            )
+                        ),
+                    ]
+                ),
+            ],
+            actions=[
+                NotificationRenderedAction(
+                    label="View Integration",
+                    link=data.settings_url,
+                )
+            ],
+        )

--- a/src/sentry/notifications/platform/types.py
+++ b/src/sentry/notifications/platform/types.py
@@ -25,6 +25,7 @@ class NotificationCategory(StrEnum):
     SEER = "seer"
     ISSUE = "issue"
     METRIC_ALERT = "metric-alert"
+    SENTRY_APP = "sentry-app"
 
     def get_sources(self) -> list[NotificationSource]:
         return NOTIFICATION_SOURCE_MAP[self]
@@ -68,6 +69,9 @@ class NotificationSource(StrEnum):
     SEER_AGENT_RESPONSE = "seer-agent-response"
     SEER_AGENT_ERROR = "seer-agent-error"
 
+    # SENTRY_APP
+    SENTRY_APP_WEBHOOK_DISABLED = "sentry-app-webhook-disabled"
+
 
 NOTIFICATION_SOURCE_MAP: dict[NotificationCategory, list[NotificationSource]] = {
     NotificationCategory.DEBUG: [
@@ -101,6 +105,9 @@ NOTIFICATION_SOURCE_MAP: dict[NotificationCategory, list[NotificationSource]] = 
         NotificationSource.SEER_AUTOFIX_UPDATE,
         NotificationSource.SEER_AGENT_RESPONSE,
         NotificationSource.SEER_AGENT_ERROR,
+    ],
+    NotificationCategory.SENTRY_APP: [
+        NotificationSource.SENTRY_APP_WEBHOOK_DISABLED,
     ],
 }
 

--- a/tests/sentry/notifications/platform/templates/test_sentry_app_webhook_disabled.py
+++ b/tests/sentry/notifications/platform/templates/test_sentry_app_webhook_disabled.py
@@ -1,0 +1,55 @@
+from sentry.notifications.platform.registry import template_registry
+from sentry.notifications.platform.templates.sentry_app_webhook_disabled import (
+    SentryAppWebhookDisabled,
+    SentryAppWebhookDisabledTemplate,
+)
+from sentry.notifications.platform.types import (
+    NotificationCategory,
+    NotificationRenderedTemplate,
+    NotificationSource,
+)
+from sentry.testutils.cases import TestCase
+
+
+class SentryAppWebhookDisabledTest(TestCase):
+    def test_data_source(self) -> None:
+        data = SentryAppWebhookDisabled(
+            sentry_app_slug="my-app",
+            sentry_app_name="My App",
+            webhook_url="https://example.com/webhook",
+            settings_url="https://sentry.io/settings/my-org/developer-settings/my-app/",
+        )
+        assert data.source == NotificationSource.SENTRY_APP_WEBHOOK_DISABLED
+
+    def test_template_registered(self) -> None:
+        assert template_registry.get(NotificationSource.SENTRY_APP_WEBHOOK_DISABLED) is (
+            SentryAppWebhookDisabledTemplate
+        )
+
+    def test_render(self) -> None:
+        template = SentryAppWebhookDisabledTemplate()
+        data = SentryAppWebhookDisabled(
+            sentry_app_slug="my-app",
+            sentry_app_name="My App",
+            webhook_url="https://example.com/webhook",
+            settings_url="https://sentry.io/settings/my-org/developer-settings/my-app/",
+        )
+
+        result = template.render(data)
+
+        assert isinstance(result, NotificationRenderedTemplate)
+        assert result.subject == "Webhook delivery paused for My App"
+        assert len(result.body) == 1
+        assert len(result.actions) == 1
+        assert result.actions[0].label == "View Integration"
+        assert result.actions[0].link == data.settings_url
+
+    def test_render_example(self) -> None:
+        template = SentryAppWebhookDisabledTemplate()
+        rendered = template.render_example()
+
+        assert isinstance(rendered, NotificationRenderedTemplate)
+        assert "Example App" in rendered.subject
+
+    def test_category(self) -> None:
+        assert SentryAppWebhookDisabledTemplate.category == NotificationCategory.SENTRY_APP


### PR DESCRIPTION
Adds a `SENTRY_APP` notification category and `SENTRY_APP_WEBHOOK_DISABLED` source plus a paired template so we can email a SentryApp's creator when their webhook circuit breaker trips. The template is dormant until the circuit-breaker call site invokes it (added in a follow-up PR) and the NotificationPlatform rollout option is set in `sentry-options-automator`.
