### PR TITLE
feat(sentry apps): Send email when circuit breaker flips for webhook disabling

### DIFF
--- a/src/sentry/sentry_apps/metrics.py
+++ b/src/sentry/sentry_apps/metrics.py
@@ -73,6 +73,7 @@ class SentryAppWebhookHaltReason(StrEnum):
     CONNECTION_RESET = "connection_reset"
     HARD_TIMEOUT = "hard_timeout"
     CIRCUIT_BROKEN = "circuit_broken"
+    EMAIL_FAILED = "email_failed"
 
 
 class SentryAppExternalRequestFailureReason(StrEnum):

--- a/src/sentry/utils/circuit_breaker2.py
+++ b/src/sentry/utils/circuit_breaker2.py
@@ -406,6 +406,11 @@ class CircuitBreaker:
             )
             self.recovery_duration = default_recovery_duration
 
+    def get_state(self) -> CircuitBreakerState:
+        """Return current breaker state (OK, BROKEN, or RECOVERY)."""
+        state, _ = self._get_state_and_remaining_time()
+        return state
+
     def record_success(self) -> None:
         """Record a successful request. Only meaningful when a strategy tracks total requests."""
         now = int(time.time())

--- a/src/sentry/utils/circuit_breaker2.py
+++ b/src/sentry/utils/circuit_breaker2.py
@@ -406,10 +406,10 @@ class CircuitBreaker:
             )
             self.recovery_duration = default_recovery_duration
 
-    def get_state(self) -> CircuitBreakerState:
-        """Return current breaker state (OK, BROKEN, or RECOVERY)."""
+    def is_open(self) -> bool:
+        """Return True if the breaker is BROKEN (i.e. blocking requests)."""
         state, _ = self._get_state_and_remaining_time()
-        return state
+        return state == CircuitBreakerState.BROKEN
 
     def record_success(self) -> None:
         """Record a successful request. Only meaningful when a strategy tracks total requests."""

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -37,7 +37,7 @@ from sentry.sentry_apps.utils.errors import SentryAppSentryError
 from sentry.shared_integrations.exceptions import ApiHostError, ApiTimeoutError, ClientError
 from sentry.taskworker.timeout import timeout_alarm
 from sentry.utils import metrics, redis
-from sentry.utils.circuit_breaker2 import CircuitBreaker, CircuitBreakerState, RateBasedTripStrategy
+from sentry.utils.circuit_breaker2 import CircuitBreaker, RateBasedTripStrategy
 from sentry.utils.http import absolute_uri
 from sentry.utils.sentry_apps import SentryAppWebhookRequestsBuffer
 from sentry.utils.sentry_apps.circuit_breaker import circuit_breaker_tracking
@@ -111,7 +111,10 @@ def _notify_webhook_disabled(
     sentry_app: SentryApp | RpcSentryApp,
     owner_context: RpcUserOrganizationContext | None,
 ) -> None:
-    dedup_ttl = circuit_breaker.broken_state_duration + circuit_breaker.recovery_duration + 60
+    dedup_ttl = max(
+        circuit_breaker.broken_state_duration + circuit_breaker.recovery_duration + 60,
+        86400,  # 24 hours
+    )
     client = redis.redis_clusters.get(settings.SENTRY_RATE_LIMIT_REDIS_CLUSTER)
     dedup_key = f"sentry-app.webhook.circuit-breaker.notified.{sentry_app.slug}"
     if not client.set(dedup_key, "1", ex=dedup_ttl, nx=True):
@@ -271,7 +274,7 @@ def send_and_save_webhook_request(
                 response = _send_webhook_request(url, app_platform_event, owner_context)
 
         except WebhookTimeoutError:
-            if circuit_breaker and circuit_breaker.get_state() == CircuitBreakerState.BROKEN:
+            if circuit_breaker and circuit_breaker.is_open():
                 try:
                     _notify_webhook_disabled(circuit_breaker, sentry_app, owner_context)
                 except Exception as email_error:

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -126,6 +126,14 @@ def _notify_webhook_disabled(
     sentry_app: SentryApp | RpcSentryApp,
     owner_context: RpcUserOrganizationContext | None,
 ) -> None:
+    email = sentry_app.creator_label
+    if not email or "@" not in email:
+        return
+
+    if owner_context is None:
+        return
+    owner_org = owner_context.organization
+
     if not set_dedup_key(sentry_app, circuit_breaker):
         return
 
@@ -135,14 +143,6 @@ def _notify_webhook_disabled(
             extra={"slug": sentry_app.slug},
         )
         return
-
-    email = sentry_app.creator_label
-    if not email or "@" not in email:
-        return
-
-    if owner_context is None:
-        return
-    owner_org = owner_context.organization
 
     data = SentryAppWebhookDisabled(
         sentry_app_slug=sentry_app.slug,

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -15,6 +15,7 @@ from rest_framework import status
 from sentry import features, options
 from sentry.exceptions import RestrictedIPAddress
 from sentry.http import safe_urlopen
+from sentry.hybridcloud.services.organization_mapping import organization_mapping_service
 from sentry.integrations.utils.metrics import EventLifecycle
 from sentry.notifications.platform.service import NotificationService
 from sentry.notifications.platform.target import GenericNotificationTarget
@@ -132,14 +133,20 @@ def _notify_webhook_disabled(
         return
     organization = organization_context.organization
 
-    # owner_slug is exposed on RpcSentryApp; ORM SentryApp callers (control silo) won't
-    # have it on the instance, so fall back to an empty path component if missing.
-    owner_slug = getattr(sentry_app, "owner_slug", "") or ""
+    # The settings link lives on the OWNER org's developer-settings page (which may be
+    # a different cell from the consumer org). organization_mapping_service is anchored
+    # on control silo and is callable from any silo.
+    owner_mapping = organization_mapping_service.get(organization_id=sentry_app.owner_id)
+    if owner_mapping is None:
+        return
+
     data = SentryAppWebhookDisabled(
         sentry_app_slug=sentry_app.slug,
         sentry_app_name=sentry_app.name,
         webhook_url=sentry_app.webhook_url or "",
-        settings_url=absolute_uri(f"/settings/{owner_slug}/developer-settings/{sentry_app.slug}/"),
+        settings_url=absolute_uri(
+            f"/settings/{owner_mapping.slug}/developer-settings/{sentry_app.slug}/"
+        ),
     )
 
     if not NotificationService.has_access(organization, data.source):

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -35,6 +35,7 @@ from sentry.sentry_apps.metrics import (
 from sentry.sentry_apps.models.sentry_app import SentryApp, track_response_code
 from sentry.sentry_apps.utils.errors import SentryAppSentryError
 from sentry.shared_integrations.exceptions import ApiHostError, ApiTimeoutError, ClientError
+from sentry.silo.base import SiloMode
 from sentry.taskworker.timeout import timeout_alarm
 from sentry.utils import metrics, redis
 from sentry.utils.circuit_breaker2 import CircuitBreaker, RateBasedTripStrategy
@@ -98,6 +99,11 @@ def _create_circuit_breaker(
         organization_context.organization,
     ):
         return None
+
+    # We don't want to make a circuit breaker in CONTROL silo as it's only used for installation webhooks which are v. low volume
+    if SiloMode.get_current_mode() == SiloMode.CONTROL:
+        return None
+
     config = options.get("sentry-apps.webhook.circuit-breaker.config")
     return CircuitBreaker(
         key=f"sentry-app.webhook.{sentry_app.slug}",

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -115,6 +115,7 @@ def _notify_webhook_disabled(
     client = redis.redis_clusters.get(settings.SENTRY_RATE_LIMIT_REDIS_CLUSTER)
     dedup_key = f"sentry-app.webhook.circuit-breaker.notified.{sentry_app.slug}"
     if not client.set(dedup_key, "1", ex=dedup_ttl, nx=True):
+        client.expire(dedup_key, dedup_ttl)
         return
 
     if options.get("sentry-apps.webhook.circuit-breaker.dry-run"):

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -36,6 +36,7 @@ from sentry.sentry_apps.models.sentry_app import SentryApp, track_response_code
 from sentry.sentry_apps.utils.errors import SentryAppSentryError
 from sentry.shared_integrations.exceptions import ApiHostError, ApiTimeoutError, ClientError
 from sentry.taskworker.timeout import timeout_alarm
+from sentry.users.services.user.service import user_service
 from sentry.utils import metrics, redis
 from sentry.utils.circuit_breaker2 import CircuitBreaker, RateBasedTripStrategy
 from sentry.utils.http import absolute_uri
@@ -106,6 +107,38 @@ def _create_circuit_breaker(
     )
 
 
+def _resolve_notification_email(
+    sentry_app: SentryApp | RpcSentryApp,
+    owner_org_id: int,
+) -> str | None:
+    """Prefer the app creator if they're still an active org member,
+    otherwise fall back to the first org owner."""
+    creator_email = sentry_app.creator_label
+    if creator_email and "@" in creator_email:
+        users = user_service.get_by_username(username=creator_email, is_active=True)
+        for user in users:
+            member = organization_service.check_membership_by_id(
+                organization_id=owner_org_id,
+                user_id=user.id,
+            )
+            if member is not None:
+                return creator_email
+
+    owners = organization_service.get_organization_owner_members(
+        organization_id=owner_org_id,
+    )
+    owner_user_ids = [o.user_id for o in owners if o.user_id is not None]
+    if not owner_user_ids:
+        return None
+
+    owner_users = user_service.get_many_by_id(ids=owner_user_ids)
+    for owner_user in owner_users:
+        if owner_user.email and "@" in owner_user.email:
+            return owner_user.email
+
+    return None
+
+
 def _notify_webhook_disabled(
     circuit_breaker: CircuitBreaker,
     sentry_app: SentryApp | RpcSentryApp,
@@ -128,13 +161,13 @@ def _notify_webhook_disabled(
         )
         return
 
-    email = sentry_app.creator_label
-    if not email or "@" not in email:
-        return
-
     if owner_context is None:
         return
     owner_org = owner_context.organization
+
+    email = _resolve_notification_email(sentry_app, owner_org.id)
+    if not email:
+        return
 
     data = SentryAppWebhookDisabled(
         sentry_app_slug=sentry_app.slug,

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -106,19 +106,27 @@ def _create_circuit_breaker(
     )
 
 
-def _notify_webhook_disabled(
-    circuit_breaker: CircuitBreaker,
-    sentry_app: SentryApp | RpcSentryApp,
-    owner_context: RpcUserOrganizationContext | None,
-) -> None:
+def set_dedup_key(sentry_app: SentryApp | RpcSentryApp, circuit_breaker: CircuitBreaker) -> bool:
+    """Set the dedup key for circuit breaker notification. Returns True if
+    this is the first notification in the window (caller should send email)."""
     dedup_ttl = max(
-        circuit_breaker.broken_state_duration + circuit_breaker.recovery_duration + 60,
+        circuit_breaker.broken_state_duration + circuit_breaker.recovery_duration,
         86400,  # 24 hours
     )
     client = redis.redis_clusters.get(settings.SENTRY_RATE_LIMIT_REDIS_CLUSTER)
     dedup_key = f"sentry-app.webhook.circuit-breaker.notified.{sentry_app.slug}"
     if not client.set(dedup_key, "1", ex=dedup_ttl, nx=True):
         client.expire(dedup_key, dedup_ttl)
+        return False
+    return True
+
+
+def _notify_webhook_disabled(
+    circuit_breaker: CircuitBreaker,
+    sentry_app: SentryApp | RpcSentryApp,
+    owner_context: RpcUserOrganizationContext | None,
+) -> None:
+    if not set_dedup_key(sentry_app, circuit_breaker):
         return
 
     if options.get("sentry-apps.webhook.circuit-breaker.dry-run"):

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -132,13 +132,14 @@ def _notify_webhook_disabled(
         return
     organization = organization_context.organization
 
+    # owner_slug is exposed on RpcSentryApp; ORM SentryApp callers (control silo) won't
+    # have it on the instance, so fall back to an empty path component if missing.
+    owner_slug = getattr(sentry_app, "owner_slug", "") or ""
     data = SentryAppWebhookDisabled(
         sentry_app_slug=sentry_app.slug,
         sentry_app_name=sentry_app.name,
         webhook_url=sentry_app.webhook_url or "",
-        settings_url=absolute_uri(
-            f"/settings/{sentry_app.owner_slug}/developer-settings/{sentry_app.slug}/"
-        ),
+        settings_url=absolute_uri(f"/settings/{owner_slug}/developer-settings/{sentry_app.slug}/"),
     )
 
     if not NotificationService.has_access(organization, data.source):

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Concatenate, ParamSpec, TypeVar
 from urllib.parse import urlparse
 
 import sentry_sdk
+from django.conf import settings
 from requests import RequestException, Response
 from requests.exceptions import ChunkedEncodingError, ConnectionError, Timeout
 from rest_framework import status
@@ -15,6 +16,15 @@ from sentry import features, options
 from sentry.exceptions import RestrictedIPAddress
 from sentry.http import safe_urlopen
 from sentry.integrations.utils.metrics import EventLifecycle
+from sentry.notifications.platform.service import NotificationService
+from sentry.notifications.platform.target import GenericNotificationTarget
+from sentry.notifications.platform.templates.sentry_app_webhook_disabled import (
+    SentryAppWebhookDisabled,
+)
+from sentry.notifications.platform.types import (
+    NotificationProviderKey,
+    NotificationTargetResourceType,
+)
 from sentry.organizations.services.organization.model import RpcUserOrganizationContext
 from sentry.organizations.services.organization.service import organization_service
 from sentry.sentry_apps.metrics import (
@@ -26,8 +36,9 @@ from sentry.sentry_apps.models.sentry_app import SentryApp, track_response_code
 from sentry.sentry_apps.utils.errors import SentryAppSentryError
 from sentry.shared_integrations.exceptions import ApiHostError, ApiTimeoutError, ClientError
 from sentry.taskworker.timeout import timeout_alarm
-from sentry.utils import metrics
-from sentry.utils.circuit_breaker2 import CircuitBreaker, RateBasedTripStrategy
+from sentry.utils import metrics, redis
+from sentry.utils.circuit_breaker2 import CircuitBreaker, CircuitBreakerState, RateBasedTripStrategy
+from sentry.utils.http import absolute_uri
 from sentry.utils.sentry_apps import SentryAppWebhookRequestsBuffer
 from sentry.utils.sentry_apps.circuit_breaker import circuit_breaker_tracking
 
@@ -92,6 +103,55 @@ def _create_circuit_breaker(
         key=f"sentry-app.webhook.{sentry_app.slug}",
         config=config,
         trip_strategy=RateBasedTripStrategy.from_config(config),
+    )
+
+
+def _notify_webhook_disabled(
+    circuit_breaker: CircuitBreaker,
+    sentry_app: SentryApp | RpcSentryApp,
+    organization_context: RpcUserOrganizationContext | None,
+) -> None:
+    dedup_ttl = circuit_breaker.broken_state_duration + circuit_breaker.recovery_duration + 60
+    client = redis.redis_clusters.get(settings.SENTRY_RATE_LIMIT_REDIS_CLUSTER)
+    dedup_key = f"sentry-app.webhook.circuit-breaker.notified.{sentry_app.slug}"
+    if not client.set(dedup_key, "1", ex=dedup_ttl, nx=True):
+        return
+
+    if options.get("sentry-apps.webhook.circuit-breaker.dry-run"):
+        logger.info(
+            "sentry_app.webhook.circuit_breaker.would_email",
+            extra={"slug": sentry_app.slug},
+        )
+        return
+
+    email = sentry_app.creator_label
+    if not email or "@" not in email:
+        return
+
+    if organization_context is None:
+        return
+    organization = organization_context.organization
+
+    data = SentryAppWebhookDisabled(
+        sentry_app_slug=sentry_app.slug,
+        sentry_app_name=sentry_app.name,
+        webhook_url=sentry_app.webhook_url or "",
+        settings_url=absolute_uri(
+            f"/settings/{sentry_app.owner_slug}/developer-settings/{sentry_app.slug}/"
+        ),
+    )
+
+    if not NotificationService.has_access(organization, data.source):
+        return
+
+    NotificationService(data=data).notify_async(
+        targets=[
+            GenericNotificationTarget(
+                provider_key=NotificationProviderKey.EMAIL,
+                resource_type=NotificationTargetResourceType.EMAIL,
+                resource_id=email,
+            )
+        ]
     )
 
 
@@ -210,6 +270,8 @@ def send_and_save_webhook_request(
                 response = _send_webhook_request(url, app_platform_event, organization_context)
 
         except WebhookTimeoutError:
+            if circuit_breaker and circuit_breaker.get_state() == CircuitBreakerState.BROKEN:
+                _notify_webhook_disabled(circuit_breaker, sentry_app, organization_context)
             lifecycle.record_halt(
                 halt_reason=f"send_and_save_webhook_request.{SentryAppWebhookHaltReason.HARD_TIMEOUT}"
             )

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -15,7 +15,6 @@ from rest_framework import status
 from sentry import features, options
 from sentry.exceptions import RestrictedIPAddress
 from sentry.http import safe_urlopen
-from sentry.hybridcloud.services.organization_mapping import organization_mapping_service
 from sentry.integrations.utils.metrics import EventLifecycle
 from sentry.notifications.platform.service import NotificationService
 from sentry.notifications.platform.target import GenericNotificationTarget
@@ -110,7 +109,7 @@ def _create_circuit_breaker(
 def _notify_webhook_disabled(
     circuit_breaker: CircuitBreaker,
     sentry_app: SentryApp | RpcSentryApp,
-    organization_context: RpcUserOrganizationContext | None,
+    owner_context: RpcUserOrganizationContext | None,
 ) -> None:
     dedup_ttl = circuit_breaker.broken_state_duration + circuit_breaker.recovery_duration + 60
     client = redis.redis_clusters.get(settings.SENTRY_RATE_LIMIT_REDIS_CLUSTER)
@@ -129,27 +128,20 @@ def _notify_webhook_disabled(
     if not email or "@" not in email:
         return
 
-    if organization_context is None:
+    if owner_context is None:
         return
-    organization = organization_context.organization
-
-    # The settings link lives on the OWNER org's developer-settings page (which may be
-    # a different cell from the consumer org). organization_mapping_service is anchored
-    # on control silo and is callable from any silo.
-    owner_mapping = organization_mapping_service.get(organization_id=sentry_app.owner_id)
-    if owner_mapping is None:
-        return
+    owner_org = owner_context.organization
 
     data = SentryAppWebhookDisabled(
         sentry_app_slug=sentry_app.slug,
         sentry_app_name=sentry_app.name,
         webhook_url=sentry_app.webhook_url or "",
         settings_url=absolute_uri(
-            f"/settings/{owner_mapping.slug}/developer-settings/{sentry_app.slug}/"
+            f"/settings/{owner_org.slug}/developer-settings/{sentry_app.slug}/"
         ),
     )
 
-    if not NotificationService.has_access(organization, data.source):
+    if not NotificationService.has_access(owner_org, data.source):
         return
 
     NotificationService(data=data).notify_async(
@@ -265,21 +257,28 @@ def send_and_save_webhook_request(
 
         assert url is not None
         try:
-            organization_context = organization_service.get_organization_by_id(
-                id=app_platform_event.install.organization_id,
+            owner_context = organization_service.get_organization_by_id(
+                id=sentry_app.owner_id,
                 include_projects=False,
                 include_teams=False,
             )
-            circuit_breaker = _create_circuit_breaker(sentry_app, organization_context)
+            circuit_breaker = _create_circuit_breaker(sentry_app, owner_context)
             if not _circuit_breaker_allows_request(circuit_breaker, sentry_app, org_id, lifecycle):
                 return Response()
 
             with circuit_breaker_tracking(circuit_breaker):
-                response = _send_webhook_request(url, app_platform_event, organization_context)
+                response = _send_webhook_request(url, app_platform_event, owner_context)
 
         except WebhookTimeoutError:
             if circuit_breaker and circuit_breaker.get_state() == CircuitBreakerState.BROKEN:
-                _notify_webhook_disabled(circuit_breaker, sentry_app, organization_context)
+                try:
+                    _notify_webhook_disabled(circuit_breaker, sentry_app, owner_context)
+                except Exception as email_error:
+                    lifecycle.add_extras(
+                        {"reason_str": str(SentryAppWebhookHaltReason.EMAIL_FAILED)}
+                    )
+                    lifecycle.record_halt(halt_reason=email_error)
+                    raise
             lifecycle.record_halt(
                 halt_reason=f"send_and_save_webhook_request.{SentryAppWebhookHaltReason.HARD_TIMEOUT}"
             )

--- a/src/sentry/utils/sentry_apps/webhooks.py
+++ b/src/sentry/utils/sentry_apps/webhooks.py
@@ -36,7 +36,6 @@ from sentry.sentry_apps.models.sentry_app import SentryApp, track_response_code
 from sentry.sentry_apps.utils.errors import SentryAppSentryError
 from sentry.shared_integrations.exceptions import ApiHostError, ApiTimeoutError, ClientError
 from sentry.taskworker.timeout import timeout_alarm
-from sentry.users.services.user.service import user_service
 from sentry.utils import metrics, redis
 from sentry.utils.circuit_breaker2 import CircuitBreaker, RateBasedTripStrategy
 from sentry.utils.http import absolute_uri
@@ -107,38 +106,6 @@ def _create_circuit_breaker(
     )
 
 
-def _resolve_notification_email(
-    sentry_app: SentryApp | RpcSentryApp,
-    owner_org_id: int,
-) -> str | None:
-    """Prefer the app creator if they're still an active org member,
-    otherwise fall back to the first org owner."""
-    creator_email = sentry_app.creator_label
-    if creator_email and "@" in creator_email:
-        users = user_service.get_by_username(username=creator_email, is_active=True)
-        for user in users:
-            member = organization_service.check_membership_by_id(
-                organization_id=owner_org_id,
-                user_id=user.id,
-            )
-            if member is not None:
-                return creator_email
-
-    owners = organization_service.get_organization_owner_members(
-        organization_id=owner_org_id,
-    )
-    owner_user_ids = [o.user_id for o in owners if o.user_id is not None]
-    if not owner_user_ids:
-        return None
-
-    owner_users = user_service.get_many_by_id(ids=owner_user_ids)
-    for owner_user in owner_users:
-        if owner_user.email and "@" in owner_user.email:
-            return owner_user.email
-
-    return None
-
-
 def _notify_webhook_disabled(
     circuit_breaker: CircuitBreaker,
     sentry_app: SentryApp | RpcSentryApp,
@@ -161,13 +128,13 @@ def _notify_webhook_disabled(
         )
         return
 
+    email = sentry_app.creator_label
+    if not email or "@" not in email:
+        return
+
     if owner_context is None:
         return
     owner_org = owner_context.organization
-
-    email = _resolve_notification_email(sentry_app, owner_org.id)
-    if not email:
-        return
 
     data = SentryAppWebhookDisabled(
         sentry_app_slug=sentry_app.slug,
@@ -314,7 +281,7 @@ def send_and_save_webhook_request(
                     lifecycle.add_extras(
                         {"reason_str": str(SentryAppWebhookHaltReason.EMAIL_FAILED)}
                     )
-                    lifecycle.record_halt(halt_reason=email_error)
+                    lifecycle.record_failure(failure_reason=email_error)
                     raise
             lifecycle.record_halt(
                 halt_reason=f"send_and_save_webhook_request.{SentryAppWebhookHaltReason.HARD_TIMEOUT}"

--- a/tests/sentry/utils/sentry_apps/test_webhooks.py
+++ b/tests/sentry/utils/sentry_apps/test_webhooks.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 from unittest.mock import Mock, patch
 
 import pytest
+from django.conf import settings
 from requests import Response
 from requests.exceptions import Timeout
 
@@ -12,7 +13,8 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import cell_silo_test
-from sentry.utils.circuit_breaker2 import CircuitBreaker
+from sentry.utils import redis
+from sentry.utils.circuit_breaker2 import CircuitBreaker, CircuitBreakerState
 from sentry.utils.sentry_apps.webhooks import WebhookTimeoutError, send_and_save_webhook_request
 
 
@@ -177,3 +179,182 @@ class WebhookCircuitBreakerTest(TestCase):
             send_and_save_webhook_request(self.sentry_app, self._make_event())
 
         mock_record_success.assert_called_once()
+
+
+@cell_silo_test
+class WebhookCircuitBreakerNotifyTest(TestCase):
+    def setUp(self):
+        self.organization = self.create_organization()
+        self.user = self.create_user(email="creator@example.com")
+        self.sentry_app = self.create_sentry_app(
+            name="TestApp",
+            organization=self.organization,
+            user=self.user,
+            webhook_url="https://example.com/webhook",
+            published=True,
+        )
+        self.install = self.create_sentry_app_installation(
+            organization=self.organization, slug=self.sentry_app.slug
+        )
+        # Clear dedup keys between tests so each test starts fresh.
+        client = redis.redis_clusters.get(settings.SENTRY_RATE_LIMIT_REDIS_CLUSTER)
+        client.delete(f"sentry-app.webhook.circuit-breaker.notified.{self.sentry_app.slug}")
+
+    def _make_event(self):
+        return AppPlatformEvent(
+            resource=SentryAppResourceType.ISSUE,
+            action=IssueActionType.CREATED,
+            install=self.install,
+            data={"test": "data"},
+        )
+
+    @with_feature("organizations:sentry-app-webhook-circuit-breaker")
+    @override_options(CIRCUIT_BREAKER_OPTIONS)
+    @patch("sentry.utils.sentry_apps.webhooks.NotificationService")
+    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
+    @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
+    def test_timeout_with_trip_calls_notify_async(
+        self, MockBreaker, mock_safe_urlopen, MockService
+    ):
+        """When the breaker trips during a timeout, an email is dispatched."""
+        mock_breaker_instance = MockBreaker.return_value
+        mock_breaker_instance.should_allow_request.return_value = True
+        mock_breaker_instance.get_state.return_value = CircuitBreakerState.BROKEN
+        mock_breaker_instance.broken_state_duration = 300
+        mock_breaker_instance.recovery_duration = 600
+        MockService.has_access.return_value = True
+        mock_safe_urlopen.side_effect = WebhookTimeoutError()
+
+        with pytest.raises(WebhookTimeoutError):
+            send_and_save_webhook_request(self.sentry_app, self._make_event())
+
+        MockService.return_value.notify_async.assert_called_once()
+
+    @with_feature("organizations:sentry-app-webhook-circuit-breaker")
+    @override_options(CIRCUIT_BREAKER_OPTIONS)
+    @patch("sentry.utils.sentry_apps.webhooks.NotificationService")
+    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
+    @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
+    def test_timeout_without_trip_does_not_notify(
+        self, MockBreaker, mock_safe_urlopen, MockService
+    ):
+        """A timeout that doesn't trip the breaker should not email."""
+        mock_breaker_instance = MockBreaker.return_value
+        mock_breaker_instance.should_allow_request.return_value = True
+        mock_breaker_instance.get_state.return_value = CircuitBreakerState.OK
+        mock_breaker_instance.broken_state_duration = 300
+        mock_breaker_instance.recovery_duration = 600
+        mock_safe_urlopen.side_effect = WebhookTimeoutError()
+
+        with pytest.raises(WebhookTimeoutError):
+            send_and_save_webhook_request(self.sentry_app, self._make_event())
+
+        MockService.return_value.notify_async.assert_not_called()
+
+    @with_feature("organizations:sentry-app-webhook-circuit-breaker")
+    @override_options(
+        {**CIRCUIT_BREAKER_OPTIONS, "sentry-apps.webhook.circuit-breaker.dry-run": True}
+    )
+    @patch("sentry.utils.sentry_apps.webhooks.logger")
+    @patch("sentry.utils.sentry_apps.webhooks.NotificationService")
+    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
+    @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
+    def test_dry_run_logs_would_email_once_across_concurrent_trips(
+        self, MockBreaker, mock_safe_urlopen, MockService, mock_logger
+    ):
+        """In dry-run mode, exactly one would_email log fires per BROKEN cycle, even if
+        many concurrent timeouts each observe a BROKEN state."""
+        mock_breaker_instance = MockBreaker.return_value
+        mock_breaker_instance.should_allow_request.return_value = True
+        mock_breaker_instance.get_state.return_value = CircuitBreakerState.BROKEN
+        mock_breaker_instance.broken_state_duration = 300
+        mock_breaker_instance.recovery_duration = 600
+        mock_safe_urlopen.side_effect = WebhookTimeoutError()
+
+        for _ in range(5):
+            with pytest.raises(WebhookTimeoutError):
+                send_and_save_webhook_request(self.sentry_app, self._make_event())
+
+        would_email_calls = [
+            c
+            for c in mock_logger.info.call_args_list
+            if c.args and c.args[0] == "sentry_app.webhook.circuit_breaker.would_email"
+        ]
+        assert len(would_email_calls) == 1
+        MockService.return_value.notify_async.assert_not_called()
+
+    @with_feature("organizations:sentry-app-webhook-circuit-breaker")
+    @override_options(CIRCUIT_BREAKER_OPTIONS)
+    @patch("sentry.utils.sentry_apps.webhooks.NotificationService")
+    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
+    @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
+    def test_concurrent_trips_emit_single_email(self, MockBreaker, mock_safe_urlopen, MockService):
+        """In live mode, exactly one notify_async call fires per BROKEN cycle even when
+        N concurrent workers each observe a BROKEN state."""
+        mock_breaker_instance = MockBreaker.return_value
+        mock_breaker_instance.should_allow_request.return_value = True
+        mock_breaker_instance.get_state.return_value = CircuitBreakerState.BROKEN
+        mock_breaker_instance.broken_state_duration = 300
+        mock_breaker_instance.recovery_duration = 600
+        MockService.has_access.return_value = True
+        mock_safe_urlopen.side_effect = WebhookTimeoutError()
+
+        for _ in range(5):
+            with pytest.raises(WebhookTimeoutError):
+                send_and_save_webhook_request(self.sentry_app, self._make_event())
+
+        assert MockService.return_value.notify_async.call_count == 1
+
+    @with_feature("organizations:sentry-app-webhook-circuit-breaker")
+    @override_options(CIRCUIT_BREAKER_OPTIONS)
+    @patch("sentry.utils.sentry_apps.webhooks.NotificationService")
+    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
+    @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
+    def test_creator_label_without_at_sign_skips_email(
+        self, MockBreaker, mock_safe_urlopen, MockService
+    ):
+        """If creator_label is a username (no @), we shouldn't email."""
+        # The helper only reads creator_label off the in-memory instance, so a local
+        # mutation is sufficient — no DB write required.
+        self.sentry_app.creator_label = "no-email-username"
+
+        mock_breaker_instance = MockBreaker.return_value
+        mock_breaker_instance.should_allow_request.return_value = True
+        mock_breaker_instance.get_state.return_value = CircuitBreakerState.BROKEN
+        mock_breaker_instance.broken_state_duration = 300
+        mock_breaker_instance.recovery_duration = 600
+        mock_safe_urlopen.side_effect = WebhookTimeoutError()
+
+        with pytest.raises(WebhookTimeoutError):
+            send_and_save_webhook_request(self.sentry_app, self._make_event())
+
+        MockService.return_value.notify_async.assert_not_called()
+
+    @with_feature("organizations:sentry-app-webhook-circuit-breaker")
+    @override_options(CIRCUIT_BREAKER_OPTIONS)
+    @patch("sentry.utils.sentry_apps.webhooks.NotificationService")
+    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
+    @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
+    def test_new_trip_after_dedup_expires_emails_again(
+        self, MockBreaker, mock_safe_urlopen, MockService
+    ):
+        """After the dedup key expires, a fresh BROKEN trip should email again."""
+        mock_breaker_instance = MockBreaker.return_value
+        mock_breaker_instance.should_allow_request.return_value = True
+        mock_breaker_instance.get_state.return_value = CircuitBreakerState.BROKEN
+        mock_breaker_instance.broken_state_duration = 300
+        mock_breaker_instance.recovery_duration = 600
+        MockService.has_access.return_value = True
+        mock_safe_urlopen.side_effect = WebhookTimeoutError()
+
+        with pytest.raises(WebhookTimeoutError):
+            send_and_save_webhook_request(self.sentry_app, self._make_event())
+
+        # Simulate dedup TTL expiry by deleting the key.
+        client = redis.redis_clusters.get(settings.SENTRY_RATE_LIMIT_REDIS_CLUSTER)
+        client.delete(f"sentry-app.webhook.circuit-breaker.notified.{self.sentry_app.slug}")
+
+        with pytest.raises(WebhookTimeoutError):
+            send_and_save_webhook_request(self.sentry_app, self._make_event())
+
+        assert MockService.return_value.notify_async.call_count == 2

--- a/tests/sentry/utils/sentry_apps/test_webhooks.py
+++ b/tests/sentry/utils/sentry_apps/test_webhooks.py
@@ -15,7 +15,7 @@ from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import cell_silo_test
 from sentry.utils import redis
-from sentry.utils.circuit_breaker2 import CircuitBreaker, CircuitBreakerState
+from sentry.utils.circuit_breaker2 import CircuitBreaker
 from sentry.utils.sentry_apps.webhooks import WebhookTimeoutError, send_and_save_webhook_request
 
 
@@ -211,10 +211,10 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
         )
 
     @staticmethod
-    def _configure_breaker(MockBreaker, state):
+    def _configure_breaker(MockBreaker, *, is_open):
         mock_breaker_instance = MockBreaker.return_value
         mock_breaker_instance.should_allow_request.return_value = True
-        mock_breaker_instance.get_state.return_value = state
+        mock_breaker_instance.is_open.return_value = is_open
         mock_breaker_instance.broken_state_duration = 300
         mock_breaker_instance.recovery_duration = 600
         return mock_breaker_instance
@@ -228,7 +228,7 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
         self, MockBreaker, mock_safe_urlopen, MockService
     ):
         """When the breaker trips during a timeout, an email is dispatched."""
-        self._configure_breaker(MockBreaker, CircuitBreakerState.BROKEN)
+        self._configure_breaker(MockBreaker, is_open=True)
         MockService.has_access.return_value = True
         mock_safe_urlopen.side_effect = WebhookTimeoutError()
 
@@ -246,7 +246,7 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
         self, MockBreaker, mock_safe_urlopen, MockService
     ):
         """A timeout that doesn't trip the breaker should not email."""
-        self._configure_breaker(MockBreaker, CircuitBreakerState.OK)
+        self._configure_breaker(MockBreaker, is_open=False)
         mock_safe_urlopen.side_effect = WebhookTimeoutError()
 
         with pytest.raises(WebhookTimeoutError):
@@ -265,7 +265,7 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
         self, MockBreaker, mock_safe_urlopen, MockService
     ):
         """Dry-run mode skips delivery even when the breaker trips."""
-        self._configure_breaker(MockBreaker, CircuitBreakerState.BROKEN)
+        self._configure_breaker(MockBreaker, is_open=True)
         mock_safe_urlopen.side_effect = WebhookTimeoutError()
 
         with pytest.raises(WebhookTimeoutError):
@@ -278,10 +278,10 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
     @patch("sentry.utils.sentry_apps.webhooks.NotificationService")
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
     @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
-    def test_concurrent_trips_emit_single_email(self, MockBreaker, mock_safe_urlopen, MockService):
-        """In live mode, exactly one notify_async call fires per BROKEN cycle even when
-        N concurrent workers each observe a BROKEN state."""
-        self._configure_breaker(MockBreaker, CircuitBreakerState.BROKEN)
+    def test_concurrent_trips_emit_single_email_within_24h(
+        self, MockBreaker, mock_safe_urlopen, MockService
+    ):
+        self._configure_breaker(MockBreaker, is_open=True)
         MockService.has_access.return_value = True
         mock_safe_urlopen.side_effect = WebhookTimeoutError()
 
@@ -290,6 +290,10 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
                 send_and_save_webhook_request(self.sentry_app, self._make_event())
 
         assert MockService.return_value.notify_async.call_count == 1
+
+        client = redis.redis_clusters.get(settings.SENTRY_RATE_LIMIT_REDIS_CLUSTER)
+        dedup_key = f"sentry-app.webhook.circuit-breaker.notified.{self.sentry_app.slug}"
+        assert client.ttl(dedup_key) >= 86400
 
     @with_feature("organizations:sentry-app-webhook-circuit-breaker")
     @override_options(CIRCUIT_BREAKER_OPTIONS)
@@ -300,11 +304,9 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
         self, MockBreaker, mock_safe_urlopen, MockService
     ):
         """If creator_label is a username (no @), we shouldn't email."""
-        # The helper only reads creator_label off the in-memory instance, so a local
-        # mutation is sufficient — no DB write required.
         self.sentry_app.creator_label = "no-email-username"
 
-        self._configure_breaker(MockBreaker, CircuitBreakerState.BROKEN)
+        self._configure_breaker(MockBreaker, is_open=True)
         mock_safe_urlopen.side_effect = WebhookTimeoutError()
 
         with pytest.raises(WebhookTimeoutError):
@@ -321,7 +323,7 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
         self, MockBreaker, mock_safe_urlopen, MockService
     ):
         """After the dedup key expires, a fresh BROKEN trip should email again."""
-        self._configure_breaker(MockBreaker, CircuitBreakerState.BROKEN)
+        self._configure_breaker(MockBreaker, is_open=True)
         MockService.has_access.return_value = True
         mock_safe_urlopen.side_effect = WebhookTimeoutError()
 
@@ -346,10 +348,8 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
     def test_email_failure_records_halt_and_propagates(
         self, MockBreaker, mock_safe_urlopen, MockService, mock_record
     ):
-        """If _notify_webhook_disabled raises, the email error is recorded as a
-        halt and propagated directly (circuit_breaker_tracking has already
-        completed by the time we reach the except block)."""
-        self._configure_breaker(MockBreaker, CircuitBreakerState.BROKEN)
+        """If the email notification fails, the error is recorded as a halt and propagated directly."""
+        self._configure_breaker(MockBreaker, is_open=True)
         MockService.has_access.side_effect = RuntimeError("email boom")
         mock_safe_urlopen.side_effect = WebhookTimeoutError("hard timeout")
 

--- a/tests/sentry/utils/sentry_apps/test_webhooks.py
+++ b/tests/sentry/utils/sentry_apps/test_webhooks.py
@@ -119,6 +119,7 @@ class WebhookCircuitBreakerTest(TestCase):
         """WebhookTimeoutError (hard timeout) should call record_error() on the circuit breaker."""
         mock_breaker_instance = MockBreaker.return_value
         mock_breaker_instance.should_allow_request.return_value = True
+        mock_breaker_instance.is_open.return_value = False
         mock_safe_urlopen.side_effect = WebhookTimeoutError()
 
         with pytest.raises(WebhookTimeoutError):
@@ -185,8 +186,10 @@ class WebhookCircuitBreakerTest(TestCase):
 @cell_silo_test
 class WebhookCircuitBreakerNotifyTest(TestCase):
     def setUp(self):
-        self.organization = self.create_organization()
+        self.org_owner = self.create_user(email="org-owner@example.com")
+        self.organization = self.create_organization(owner=self.org_owner)
         self.user = self.create_user(email="creator@example.com")
+        self.create_member(organization=self.organization, user=self.user, role="member")
         self.sentry_app = self.create_sentry_app(
             name="TestApp",
             organization=self.organization,
@@ -197,8 +200,6 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
         self.install = self.create_sentry_app_installation(
             organization=self.organization, slug=self.sentry_app.slug
         )
-        # Match the rate-based circuit-breaker tests' convention: flush redis between
-        # tests so dedup state from a previous run doesn't bleed in.
         client = redis.redis_clusters.get(settings.SENTRY_RATE_LIMIT_REDIS_CLUSTER)
         client.flushall()
 
@@ -300,19 +301,20 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
     @patch("sentry.utils.sentry_apps.webhooks.NotificationService")
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
     @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
-    def test_creator_label_without_at_sign_skips_email(
+    def test_creator_label_without_at_sign_falls_back_to_org_owner(
         self, MockBreaker, mock_safe_urlopen, MockService
     ):
-        """If creator_label is a username (no @), we shouldn't email."""
+        """If creator_label is a username (no @), we fall back to the org owner."""
         self.sentry_app.creator_label = "no-email-username"
 
         self._configure_breaker(MockBreaker, is_open=True)
+        MockService.has_access.return_value = True
         mock_safe_urlopen.side_effect = WebhookTimeoutError()
 
         with pytest.raises(WebhookTimeoutError):
             send_and_save_webhook_request(self.sentry_app, self._make_event())
 
-        MockService.return_value.notify_async.assert_not_called()
+        MockService.return_value.notify_async.assert_called_once()
 
     @with_feature("organizations:sentry-app-webhook-circuit-breaker")
     @override_options(CIRCUIT_BREAKER_OPTIONS)
@@ -338,6 +340,46 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
             send_and_save_webhook_request(self.sentry_app, self._make_event())
 
         assert MockService.return_value.notify_async.call_count == 2
+
+    @with_feature("organizations:sentry-app-webhook-circuit-breaker")
+    @override_options(CIRCUIT_BREAKER_OPTIONS)
+    @patch("sentry.utils.sentry_apps.webhooks.NotificationService")
+    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
+    @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
+    def test_non_member_creator_falls_back_to_org_owner(
+        self, MockBreaker, mock_safe_urlopen, MockService
+    ):
+        """When the app creator is no longer an org member, the notification
+        is sent to the org owner instead."""
+        org_owner = self.create_user(email="owner@example.com")
+        org = self.create_organization(owner=org_owner)
+        non_member_creator = self.create_user(email="ex-creator@example.com")
+        sentry_app = self.create_sentry_app(
+            name="FallbackApp",
+            organization=org,
+            user=non_member_creator,
+            webhook_url="https://example.com/webhook",
+            published=True,
+        )
+        install = self.create_sentry_app_installation(organization=org, slug=sentry_app.slug)
+
+        self._configure_breaker(MockBreaker, is_open=True)
+        MockService.has_access.return_value = True
+        mock_safe_urlopen.side_effect = WebhookTimeoutError()
+
+        event = AppPlatformEvent(
+            resource=SentryAppResourceType.ISSUE,
+            action=IssueActionType.CREATED,
+            install=install,
+            data={"test": "data"},
+        )
+
+        with pytest.raises(WebhookTimeoutError):
+            send_and_save_webhook_request(sentry_app, event)
+
+        MockService.return_value.notify_async.assert_called_once()
+        target = MockService.return_value.notify_async.call_args[1]["targets"][0]
+        assert target.resource_id == "owner@example.com"
 
     @with_feature("organizations:sentry-app-webhook-circuit-breaker")
     @override_options(CIRCUIT_BREAKER_OPTIONS)

--- a/tests/sentry/utils/sentry_apps/test_webhooks.py
+++ b/tests/sentry/utils/sentry_apps/test_webhooks.py
@@ -9,7 +9,7 @@ from requests.exceptions import Timeout
 from sentry.sentry_apps.api.serializers.app_platform_event import AppPlatformEvent
 from sentry.sentry_apps.utils.webhooks import IssueActionType, SentryAppResourceType
 from sentry.shared_integrations.exceptions import ApiHostError
-from sentry.testutils.asserts import assert_halt_metric
+from sentry.testutils.asserts import assert_failure_metric
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.options import override_options
@@ -186,10 +186,8 @@ class WebhookCircuitBreakerTest(TestCase):
 @cell_silo_test
 class WebhookCircuitBreakerNotifyTest(TestCase):
     def setUp(self):
-        self.org_owner = self.create_user(email="org-owner@example.com")
-        self.organization = self.create_organization(owner=self.org_owner)
+        self.organization = self.create_organization()
         self.user = self.create_user(email="creator@example.com")
-        self.create_member(organization=self.organization, user=self.user, role="member")
         self.sentry_app = self.create_sentry_app(
             name="TestApp",
             organization=self.organization,
@@ -301,20 +299,19 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
     @patch("sentry.utils.sentry_apps.webhooks.NotificationService")
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
     @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
-    def test_creator_label_without_at_sign_falls_back_to_org_owner(
+    def test_creator_label_without_at_sign_skips_email(
         self, MockBreaker, mock_safe_urlopen, MockService
     ):
-        """If creator_label is a username (no @), we fall back to the org owner."""
+        """If creator_label is a username (no @), we shouldn't email."""
         self.sentry_app.creator_label = "no-email-username"
 
         self._configure_breaker(MockBreaker, is_open=True)
-        MockService.has_access.return_value = True
         mock_safe_urlopen.side_effect = WebhookTimeoutError()
 
         with pytest.raises(WebhookTimeoutError):
             send_and_save_webhook_request(self.sentry_app, self._make_event())
 
-        MockService.return_value.notify_async.assert_called_once()
+        MockService.return_value.notify_async.assert_not_called()
 
     @with_feature("organizations:sentry-app-webhook-circuit-breaker")
     @override_options(CIRCUIT_BREAKER_OPTIONS)
@@ -343,54 +340,14 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
 
     @with_feature("organizations:sentry-app-webhook-circuit-breaker")
     @override_options(CIRCUIT_BREAKER_OPTIONS)
-    @patch("sentry.utils.sentry_apps.webhooks.NotificationService")
-    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
-    @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
-    def test_non_member_creator_falls_back_to_org_owner(
-        self, MockBreaker, mock_safe_urlopen, MockService
-    ):
-        """When the app creator is no longer an org member, the notification
-        is sent to the org owner instead."""
-        org_owner = self.create_user(email="owner@example.com")
-        org = self.create_organization(owner=org_owner)
-        non_member_creator = self.create_user(email="ex-creator@example.com")
-        sentry_app = self.create_sentry_app(
-            name="FallbackApp",
-            organization=org,
-            user=non_member_creator,
-            webhook_url="https://example.com/webhook",
-            published=True,
-        )
-        install = self.create_sentry_app_installation(organization=org, slug=sentry_app.slug)
-
-        self._configure_breaker(MockBreaker, is_open=True)
-        MockService.has_access.return_value = True
-        mock_safe_urlopen.side_effect = WebhookTimeoutError()
-
-        event = AppPlatformEvent(
-            resource=SentryAppResourceType.ISSUE,
-            action=IssueActionType.CREATED,
-            install=install,
-            data={"test": "data"},
-        )
-
-        with pytest.raises(WebhookTimeoutError):
-            send_and_save_webhook_request(sentry_app, event)
-
-        MockService.return_value.notify_async.assert_called_once()
-        target = MockService.return_value.notify_async.call_args[1]["targets"][0]
-        assert target.resource_id == "owner@example.com"
-
-    @with_feature("organizations:sentry-app-webhook-circuit-breaker")
-    @override_options(CIRCUIT_BREAKER_OPTIONS)
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     @patch("sentry.utils.sentry_apps.webhooks.NotificationService")
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
     @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
-    def test_email_failure_records_halt_and_propagates(
+    def test_email_failure_records_failure_and_propagates(
         self, MockBreaker, mock_safe_urlopen, MockService, mock_record
     ):
-        """If the email notification fails, the error is recorded as a halt and propagated directly."""
+        """If the email notification fails, the error is recorded as a failure and propagated."""
         self._configure_breaker(MockBreaker, is_open=True)
         MockService.has_access.side_effect = RuntimeError("email boom")
         mock_safe_urlopen.side_effect = WebhookTimeoutError("hard timeout")
@@ -398,4 +355,4 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
         with pytest.raises(RuntimeError, match="email boom"):
             send_and_save_webhook_request(self.sentry_app, self._make_event())
 
-        assert_halt_metric(mock_record=mock_record, error_msg=RuntimeError("email boom"))
+        assert_failure_metric(mock_record=mock_record, error_msg=RuntimeError("email boom"))

--- a/tests/sentry/utils/sentry_apps/test_webhooks.py
+++ b/tests/sentry/utils/sentry_apps/test_webhooks.py
@@ -2,7 +2,6 @@ from collections import namedtuple
 from unittest.mock import Mock, patch
 
 import pytest
-from django.conf import settings
 from requests import Response
 from requests.exceptions import Timeout
 
@@ -13,7 +12,6 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import cell_silo_test
-from sentry.utils import redis
 from sentry.utils.circuit_breaker2 import CircuitBreaker, CircuitBreakerState
 from sentry.utils.sentry_apps.webhooks import WebhookTimeoutError, send_and_save_webhook_request
 
@@ -181,6 +179,13 @@ class WebhookCircuitBreakerTest(TestCase):
         mock_record_success.assert_called_once()
 
 
+def _make_setnx_client(set_returns):
+    """Build a mock redis client whose .set() returns each value from set_returns in order."""
+    client = Mock()
+    client.set.side_effect = list(set_returns)
+    return client
+
+
 @cell_silo_test
 class WebhookCircuitBreakerNotifyTest(TestCase):
     def setUp(self):
@@ -196,9 +201,6 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
         self.install = self.create_sentry_app_installation(
             organization=self.organization, slug=self.sentry_app.slug
         )
-        # Clear dedup keys between tests so each test starts fresh.
-        client = redis.redis_clusters.get(settings.SENTRY_RATE_LIMIT_REDIS_CLUSTER)
-        client.delete(f"sentry-app.webhook.circuit-breaker.notified.{self.sentry_app.slug}")
 
     def _make_event(self):
         return AppPlatformEvent(
@@ -208,20 +210,27 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
             data={"test": "data"},
         )
 
+    @staticmethod
+    def _configure_breaker(MockBreaker, state):
+        mock_breaker_instance = MockBreaker.return_value
+        mock_breaker_instance.should_allow_request.return_value = True
+        mock_breaker_instance.get_state.return_value = state
+        mock_breaker_instance.broken_state_duration = 300
+        mock_breaker_instance.recovery_duration = 600
+        return mock_breaker_instance
+
     @with_feature("organizations:sentry-app-webhook-circuit-breaker")
     @override_options(CIRCUIT_BREAKER_OPTIONS)
+    @patch("sentry.utils.sentry_apps.webhooks.redis.redis_clusters")
     @patch("sentry.utils.sentry_apps.webhooks.NotificationService")
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
     @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
     def test_timeout_with_trip_calls_notify_async(
-        self, MockBreaker, mock_safe_urlopen, MockService
+        self, MockBreaker, mock_safe_urlopen, MockService, mock_redis_clusters
     ):
         """When the breaker trips during a timeout, an email is dispatched."""
-        mock_breaker_instance = MockBreaker.return_value
-        mock_breaker_instance.should_allow_request.return_value = True
-        mock_breaker_instance.get_state.return_value = CircuitBreakerState.BROKEN
-        mock_breaker_instance.broken_state_duration = 300
-        mock_breaker_instance.recovery_duration = 600
+        self._configure_breaker(MockBreaker, CircuitBreakerState.BROKEN)
+        mock_redis_clusters.get.return_value = _make_setnx_client([True])
         MockService.has_access.return_value = True
         mock_safe_urlopen.side_effect = WebhookTimeoutError()
 
@@ -232,18 +241,16 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
 
     @with_feature("organizations:sentry-app-webhook-circuit-breaker")
     @override_options(CIRCUIT_BREAKER_OPTIONS)
+    @patch("sentry.utils.sentry_apps.webhooks.redis.redis_clusters")
     @patch("sentry.utils.sentry_apps.webhooks.NotificationService")
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
     @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
     def test_timeout_without_trip_does_not_notify(
-        self, MockBreaker, mock_safe_urlopen, MockService
+        self, MockBreaker, mock_safe_urlopen, MockService, mock_redis_clusters
     ):
         """A timeout that doesn't trip the breaker should not email."""
-        mock_breaker_instance = MockBreaker.return_value
-        mock_breaker_instance.should_allow_request.return_value = True
-        mock_breaker_instance.get_state.return_value = CircuitBreakerState.OK
-        mock_breaker_instance.broken_state_duration = 300
-        mock_breaker_instance.recovery_duration = 600
+        self._configure_breaker(MockBreaker, CircuitBreakerState.OK)
+        mock_redis_clusters.get.return_value = _make_setnx_client([True])
         mock_safe_urlopen.side_effect = WebhookTimeoutError()
 
         with pytest.raises(WebhookTimeoutError):
@@ -255,20 +262,21 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
     @override_options(
         {**CIRCUIT_BREAKER_OPTIONS, "sentry-apps.webhook.circuit-breaker.dry-run": True}
     )
+    @patch("sentry.utils.sentry_apps.webhooks.redis.redis_clusters")
     @patch("sentry.utils.sentry_apps.webhooks.logger")
     @patch("sentry.utils.sentry_apps.webhooks.NotificationService")
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
     @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
     def test_dry_run_logs_would_email_once_across_concurrent_trips(
-        self, MockBreaker, mock_safe_urlopen, MockService, mock_logger
+        self, MockBreaker, mock_safe_urlopen, MockService, mock_logger, mock_redis_clusters
     ):
         """In dry-run mode, exactly one would_email log fires per BROKEN cycle, even if
         many concurrent timeouts each observe a BROKEN state."""
-        mock_breaker_instance = MockBreaker.return_value
-        mock_breaker_instance.should_allow_request.return_value = True
-        mock_breaker_instance.get_state.return_value = CircuitBreakerState.BROKEN
-        mock_breaker_instance.broken_state_duration = 300
-        mock_breaker_instance.recovery_duration = 600
+        self._configure_breaker(MockBreaker, CircuitBreakerState.BROKEN)
+        # First SETNX wins, the rest return False (dedup blocks them).
+        mock_redis_clusters.get.return_value = _make_setnx_client(
+            [True, False, False, False, False]
+        )
         mock_safe_urlopen.side_effect = WebhookTimeoutError()
 
         for _ in range(5):
@@ -285,17 +293,19 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
 
     @with_feature("organizations:sentry-app-webhook-circuit-breaker")
     @override_options(CIRCUIT_BREAKER_OPTIONS)
+    @patch("sentry.utils.sentry_apps.webhooks.redis.redis_clusters")
     @patch("sentry.utils.sentry_apps.webhooks.NotificationService")
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
     @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
-    def test_concurrent_trips_emit_single_email(self, MockBreaker, mock_safe_urlopen, MockService):
+    def test_concurrent_trips_emit_single_email(
+        self, MockBreaker, mock_safe_urlopen, MockService, mock_redis_clusters
+    ):
         """In live mode, exactly one notify_async call fires per BROKEN cycle even when
         N concurrent workers each observe a BROKEN state."""
-        mock_breaker_instance = MockBreaker.return_value
-        mock_breaker_instance.should_allow_request.return_value = True
-        mock_breaker_instance.get_state.return_value = CircuitBreakerState.BROKEN
-        mock_breaker_instance.broken_state_duration = 300
-        mock_breaker_instance.recovery_duration = 600
+        self._configure_breaker(MockBreaker, CircuitBreakerState.BROKEN)
+        mock_redis_clusters.get.return_value = _make_setnx_client(
+            [True, False, False, False, False]
+        )
         MockService.has_access.return_value = True
         mock_safe_urlopen.side_effect = WebhookTimeoutError()
 
@@ -307,22 +317,20 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
 
     @with_feature("organizations:sentry-app-webhook-circuit-breaker")
     @override_options(CIRCUIT_BREAKER_OPTIONS)
+    @patch("sentry.utils.sentry_apps.webhooks.redis.redis_clusters")
     @patch("sentry.utils.sentry_apps.webhooks.NotificationService")
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
     @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
     def test_creator_label_without_at_sign_skips_email(
-        self, MockBreaker, mock_safe_urlopen, MockService
+        self, MockBreaker, mock_safe_urlopen, MockService, mock_redis_clusters
     ):
         """If creator_label is a username (no @), we shouldn't email."""
         # The helper only reads creator_label off the in-memory instance, so a local
         # mutation is sufficient — no DB write required.
         self.sentry_app.creator_label = "no-email-username"
 
-        mock_breaker_instance = MockBreaker.return_value
-        mock_breaker_instance.should_allow_request.return_value = True
-        mock_breaker_instance.get_state.return_value = CircuitBreakerState.BROKEN
-        mock_breaker_instance.broken_state_duration = 300
-        mock_breaker_instance.recovery_duration = 600
+        self._configure_breaker(MockBreaker, CircuitBreakerState.BROKEN)
+        mock_redis_clusters.get.return_value = _make_setnx_client([True])
         mock_safe_urlopen.side_effect = WebhookTimeoutError()
 
         with pytest.raises(WebhookTimeoutError):
@@ -332,27 +340,22 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
 
     @with_feature("organizations:sentry-app-webhook-circuit-breaker")
     @override_options(CIRCUIT_BREAKER_OPTIONS)
+    @patch("sentry.utils.sentry_apps.webhooks.redis.redis_clusters")
     @patch("sentry.utils.sentry_apps.webhooks.NotificationService")
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
     @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
     def test_new_trip_after_dedup_expires_emails_again(
-        self, MockBreaker, mock_safe_urlopen, MockService
+        self, MockBreaker, mock_safe_urlopen, MockService, mock_redis_clusters
     ):
         """After the dedup key expires, a fresh BROKEN trip should email again."""
-        mock_breaker_instance = MockBreaker.return_value
-        mock_breaker_instance.should_allow_request.return_value = True
-        mock_breaker_instance.get_state.return_value = CircuitBreakerState.BROKEN
-        mock_breaker_instance.broken_state_duration = 300
-        mock_breaker_instance.recovery_duration = 600
+        self._configure_breaker(MockBreaker, CircuitBreakerState.BROKEN)
+        # Both SETNX calls succeed because we're simulating the TTL expiring between trips.
+        mock_redis_clusters.get.return_value = _make_setnx_client([True, True])
         MockService.has_access.return_value = True
         mock_safe_urlopen.side_effect = WebhookTimeoutError()
 
         with pytest.raises(WebhookTimeoutError):
             send_and_save_webhook_request(self.sentry_app, self._make_event())
-
-        # Simulate dedup TTL expiry by deleting the key.
-        client = redis.redis_clusters.get(settings.SENTRY_RATE_LIMIT_REDIS_CLUSTER)
-        client.delete(f"sentry-app.webhook.circuit-breaker.notified.{self.sentry_app.slug}")
 
         with pytest.raises(WebhookTimeoutError):
             send_and_save_webhook_request(self.sentry_app, self._make_event())

--- a/tests/sentry/utils/sentry_apps/test_webhooks.py
+++ b/tests/sentry/utils/sentry_apps/test_webhooks.py
@@ -9,6 +9,7 @@ from requests.exceptions import Timeout
 from sentry.sentry_apps.api.serializers.app_platform_event import AppPlatformEvent
 from sentry.sentry_apps.utils.webhooks import IssueActionType, SentryAppResourceType
 from sentry.shared_integrations.exceptions import ApiHostError
+from sentry.testutils.asserts import assert_halt_metric
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.options import override_options
@@ -335,3 +336,24 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
             send_and_save_webhook_request(self.sentry_app, self._make_event())
 
         assert MockService.return_value.notify_async.call_count == 2
+
+    @with_feature("organizations:sentry-app-webhook-circuit-breaker")
+    @override_options(CIRCUIT_BREAKER_OPTIONS)
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @patch("sentry.utils.sentry_apps.webhooks.NotificationService")
+    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
+    @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
+    def test_email_failure_records_halt_and_propagates(
+        self, MockBreaker, mock_safe_urlopen, MockService, mock_record
+    ):
+        """If _notify_webhook_disabled raises, the email error is recorded as a
+        halt and propagated directly (circuit_breaker_tracking has already
+        completed by the time we reach the except block)."""
+        self._configure_breaker(MockBreaker, CircuitBreakerState.BROKEN)
+        MockService.has_access.side_effect = RuntimeError("email boom")
+        mock_safe_urlopen.side_effect = WebhookTimeoutError("hard timeout")
+
+        with pytest.raises(RuntimeError, match="email boom"):
+            send_and_save_webhook_request(self.sentry_app, self._make_event())
+
+        assert_halt_metric(mock_record=mock_record, error_msg=RuntimeError("email boom"))

--- a/tests/sentry/utils/sentry_apps/test_webhooks.py
+++ b/tests/sentry/utils/sentry_apps/test_webhooks.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 from unittest.mock import Mock, patch
 
 import pytest
+from django.conf import settings
 from requests import Response
 from requests.exceptions import Timeout
 
@@ -12,6 +13,7 @@ from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import cell_silo_test
+from sentry.utils import redis
 from sentry.utils.circuit_breaker2 import CircuitBreaker, CircuitBreakerState
 from sentry.utils.sentry_apps.webhooks import WebhookTimeoutError, send_and_save_webhook_request
 
@@ -179,13 +181,6 @@ class WebhookCircuitBreakerTest(TestCase):
         mock_record_success.assert_called_once()
 
 
-def _make_setnx_client(set_returns):
-    """Build a mock redis client whose .set() returns each value from set_returns in order."""
-    client = Mock()
-    client.set.side_effect = list(set_returns)
-    return client
-
-
 @cell_silo_test
 class WebhookCircuitBreakerNotifyTest(TestCase):
     def setUp(self):
@@ -201,6 +196,10 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
         self.install = self.create_sentry_app_installation(
             organization=self.organization, slug=self.sentry_app.slug
         )
+        # Match the rate-based circuit-breaker tests' convention: flush redis between
+        # tests so dedup state from a previous run doesn't bleed in.
+        client = redis.redis_clusters.get(settings.SENTRY_RATE_LIMIT_REDIS_CLUSTER)
+        client.flushall()
 
     def _make_event(self):
         return AppPlatformEvent(
@@ -221,16 +220,14 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
 
     @with_feature("organizations:sentry-app-webhook-circuit-breaker")
     @override_options(CIRCUIT_BREAKER_OPTIONS)
-    @patch("sentry.utils.sentry_apps.webhooks.redis.redis_clusters")
     @patch("sentry.utils.sentry_apps.webhooks.NotificationService")
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
     @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
     def test_timeout_with_trip_calls_notify_async(
-        self, MockBreaker, mock_safe_urlopen, MockService, mock_redis_clusters
+        self, MockBreaker, mock_safe_urlopen, MockService
     ):
         """When the breaker trips during a timeout, an email is dispatched."""
         self._configure_breaker(MockBreaker, CircuitBreakerState.BROKEN)
-        mock_redis_clusters.get.return_value = _make_setnx_client([True])
         MockService.has_access.return_value = True
         mock_safe_urlopen.side_effect = WebhookTimeoutError()
 
@@ -241,16 +238,14 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
 
     @with_feature("organizations:sentry-app-webhook-circuit-breaker")
     @override_options(CIRCUIT_BREAKER_OPTIONS)
-    @patch("sentry.utils.sentry_apps.webhooks.redis.redis_clusters")
     @patch("sentry.utils.sentry_apps.webhooks.NotificationService")
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
     @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
     def test_timeout_without_trip_does_not_notify(
-        self, MockBreaker, mock_safe_urlopen, MockService, mock_redis_clusters
+        self, MockBreaker, mock_safe_urlopen, MockService
     ):
         """A timeout that doesn't trip the breaker should not email."""
         self._configure_breaker(MockBreaker, CircuitBreakerState.OK)
-        mock_redis_clusters.get.return_value = _make_setnx_client([True])
         mock_safe_urlopen.side_effect = WebhookTimeoutError()
 
         with pytest.raises(WebhookTimeoutError):
@@ -262,21 +257,16 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
     @override_options(
         {**CIRCUIT_BREAKER_OPTIONS, "sentry-apps.webhook.circuit-breaker.dry-run": True}
     )
-    @patch("sentry.utils.sentry_apps.webhooks.redis.redis_clusters")
     @patch("sentry.utils.sentry_apps.webhooks.logger")
     @patch("sentry.utils.sentry_apps.webhooks.NotificationService")
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
     @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
     def test_dry_run_logs_would_email_once_across_concurrent_trips(
-        self, MockBreaker, mock_safe_urlopen, MockService, mock_logger, mock_redis_clusters
+        self, MockBreaker, mock_safe_urlopen, MockService, mock_logger
     ):
         """In dry-run mode, exactly one would_email log fires per BROKEN cycle, even if
         many concurrent timeouts each observe a BROKEN state."""
         self._configure_breaker(MockBreaker, CircuitBreakerState.BROKEN)
-        # First SETNX wins, the rest return False (dedup blocks them).
-        mock_redis_clusters.get.return_value = _make_setnx_client(
-            [True, False, False, False, False]
-        )
         mock_safe_urlopen.side_effect = WebhookTimeoutError()
 
         for _ in range(5):
@@ -293,19 +283,13 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
 
     @with_feature("organizations:sentry-app-webhook-circuit-breaker")
     @override_options(CIRCUIT_BREAKER_OPTIONS)
-    @patch("sentry.utils.sentry_apps.webhooks.redis.redis_clusters")
     @patch("sentry.utils.sentry_apps.webhooks.NotificationService")
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
     @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
-    def test_concurrent_trips_emit_single_email(
-        self, MockBreaker, mock_safe_urlopen, MockService, mock_redis_clusters
-    ):
+    def test_concurrent_trips_emit_single_email(self, MockBreaker, mock_safe_urlopen, MockService):
         """In live mode, exactly one notify_async call fires per BROKEN cycle even when
         N concurrent workers each observe a BROKEN state."""
         self._configure_breaker(MockBreaker, CircuitBreakerState.BROKEN)
-        mock_redis_clusters.get.return_value = _make_setnx_client(
-            [True, False, False, False, False]
-        )
         MockService.has_access.return_value = True
         mock_safe_urlopen.side_effect = WebhookTimeoutError()
 
@@ -317,12 +301,11 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
 
     @with_feature("organizations:sentry-app-webhook-circuit-breaker")
     @override_options(CIRCUIT_BREAKER_OPTIONS)
-    @patch("sentry.utils.sentry_apps.webhooks.redis.redis_clusters")
     @patch("sentry.utils.sentry_apps.webhooks.NotificationService")
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
     @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
     def test_creator_label_without_at_sign_skips_email(
-        self, MockBreaker, mock_safe_urlopen, MockService, mock_redis_clusters
+        self, MockBreaker, mock_safe_urlopen, MockService
     ):
         """If creator_label is a username (no @), we shouldn't email."""
         # The helper only reads creator_label off the in-memory instance, so a local
@@ -330,7 +313,6 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
         self.sentry_app.creator_label = "no-email-username"
 
         self._configure_breaker(MockBreaker, CircuitBreakerState.BROKEN)
-        mock_redis_clusters.get.return_value = _make_setnx_client([True])
         mock_safe_urlopen.side_effect = WebhookTimeoutError()
 
         with pytest.raises(WebhookTimeoutError):
@@ -340,22 +322,23 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
 
     @with_feature("organizations:sentry-app-webhook-circuit-breaker")
     @override_options(CIRCUIT_BREAKER_OPTIONS)
-    @patch("sentry.utils.sentry_apps.webhooks.redis.redis_clusters")
     @patch("sentry.utils.sentry_apps.webhooks.NotificationService")
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
     @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
     def test_new_trip_after_dedup_expires_emails_again(
-        self, MockBreaker, mock_safe_urlopen, MockService, mock_redis_clusters
+        self, MockBreaker, mock_safe_urlopen, MockService
     ):
         """After the dedup key expires, a fresh BROKEN trip should email again."""
         self._configure_breaker(MockBreaker, CircuitBreakerState.BROKEN)
-        # Both SETNX calls succeed because we're simulating the TTL expiring between trips.
-        mock_redis_clusters.get.return_value = _make_setnx_client([True, True])
         MockService.has_access.return_value = True
         mock_safe_urlopen.side_effect = WebhookTimeoutError()
 
         with pytest.raises(WebhookTimeoutError):
             send_and_save_webhook_request(self.sentry_app, self._make_event())
+
+        # Simulate dedup TTL expiry by deleting the key.
+        client = redis.redis_clusters.get(settings.SENTRY_RATE_LIMIT_REDIS_CLUSTER)
+        client.delete(f"sentry-app.webhook.circuit-breaker.notified.{self.sentry_app.slug}")
 
         with pytest.raises(WebhookTimeoutError):
             send_and_save_webhook_request(self.sentry_app, self._make_event())

--- a/tests/sentry/utils/sentry_apps/test_webhooks.py
+++ b/tests/sentry/utils/sentry_apps/test_webhooks.py
@@ -257,28 +257,19 @@ class WebhookCircuitBreakerNotifyTest(TestCase):
     @override_options(
         {**CIRCUIT_BREAKER_OPTIONS, "sentry-apps.webhook.circuit-breaker.dry-run": True}
     )
-    @patch("sentry.utils.sentry_apps.webhooks.logger")
     @patch("sentry.utils.sentry_apps.webhooks.NotificationService")
     @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen")
     @patch("sentry.utils.sentry_apps.webhooks.CircuitBreaker")
-    def test_dry_run_logs_would_email_once_across_concurrent_trips(
-        self, MockBreaker, mock_safe_urlopen, MockService, mock_logger
+    def test_dry_run_does_not_dispatch_notify_async(
+        self, MockBreaker, mock_safe_urlopen, MockService
     ):
-        """In dry-run mode, exactly one would_email log fires per BROKEN cycle, even if
-        many concurrent timeouts each observe a BROKEN state."""
+        """Dry-run mode skips delivery even when the breaker trips."""
         self._configure_breaker(MockBreaker, CircuitBreakerState.BROKEN)
         mock_safe_urlopen.side_effect = WebhookTimeoutError()
 
-        for _ in range(5):
-            with pytest.raises(WebhookTimeoutError):
-                send_and_save_webhook_request(self.sentry_app, self._make_event())
+        with pytest.raises(WebhookTimeoutError):
+            send_and_save_webhook_request(self.sentry_app, self._make_event())
 
-        would_email_calls = [
-            c
-            for c in mock_logger.info.call_args_list
-            if c.args and c.args[0] == "sentry_app.webhook.circuit_breaker.would_email"
-        ]
-        assert len(would_email_calls) == 1
         MockService.return_value.notify_async.assert_not_called()
 
     @with_feature("organizations:sentry-app-webhook-circuit-breaker")

--- a/tests/sentry/utils/test_circuit_breaker2.py
+++ b/tests/sentry/utils/test_circuit_breaker2.py
@@ -495,31 +495,6 @@ class ShouldAllowRequestTest(TestCase):
             )
 
 
-@freeze_time()
-class GetStateTest(TestCase):
-    def setUp(self) -> None:
-        self.config = DEFAULT_CONFIG
-        self.breaker = MockCircuitBreaker(
-            "dogs_are_great", self.config, CountBasedTripStrategy.from_config(self.config)
-        )
-
-        self.breaker.redis_pipeline.flushall()
-        self.breaker.redis_pipeline.execute()
-
-    def test_reflects_state_through_lifecycle(self) -> None:
-        self.breaker._set_breaker_state(CircuitBreakerState.OK)
-        assert self.breaker.get_state() == CircuitBreakerState.OK
-
-        self.breaker._set_breaker_state(CircuitBreakerState.BROKEN)
-        assert self.breaker.get_state() == CircuitBreakerState.BROKEN
-
-        self.breaker._set_breaker_state(CircuitBreakerState.RECOVERY)
-        assert self.breaker.get_state() == CircuitBreakerState.RECOVERY
-
-        self.breaker._set_breaker_state(CircuitBreakerState.OK)
-        assert self.breaker.get_state() == CircuitBreakerState.OK
-
-
 # --- Rate-based circuit breaker tests ---
 
 DEFAULT_RATE_BASED_CONFIG: RateBasedTripStrategyConfig = {

--- a/tests/sentry/utils/test_circuit_breaker2.py
+++ b/tests/sentry/utils/test_circuit_breaker2.py
@@ -495,6 +495,31 @@ class ShouldAllowRequestTest(TestCase):
             )
 
 
+@freeze_time()
+class GetStateTest(TestCase):
+    def setUp(self) -> None:
+        self.config = DEFAULT_CONFIG
+        self.breaker = MockCircuitBreaker(
+            "dogs_are_great", self.config, CountBasedTripStrategy.from_config(self.config)
+        )
+
+        self.breaker.redis_pipeline.flushall()
+        self.breaker.redis_pipeline.execute()
+
+    def test_reflects_state_through_lifecycle(self) -> None:
+        self.breaker._set_breaker_state(CircuitBreakerState.OK)
+        assert self.breaker.get_state() == CircuitBreakerState.OK
+
+        self.breaker._set_breaker_state(CircuitBreakerState.BROKEN)
+        assert self.breaker.get_state() == CircuitBreakerState.BROKEN
+
+        self.breaker._set_breaker_state(CircuitBreakerState.RECOVERY)
+        assert self.breaker.get_state() == CircuitBreakerState.RECOVERY
+
+        self.breaker._set_breaker_state(CircuitBreakerState.OK)
+        assert self.breaker.get_state() == CircuitBreakerState.OK
+
+
 # --- Rate-based circuit breaker tests ---
 
 DEFAULT_RATE_BASED_CONFIG: RateBasedTripStrategyConfig = {


### PR DESCRIPTION
Adds a public `CircuitBreaker.get_state()` accessor and a set if not exist dedupper via `_notify_webhook_disabled` helper that fires when state changes from OK -> BROKEN. 

In dry-run mode it logs a `would_email` event; in live mode it dispatches the new `SENTRY_APP_WEBHOOK_DISABLED` notification template via NotificationPlatform. The dedup key TTL covers broken+recovery so re-trips during recovery are suppressed but a fresh OK->BROKEN cycle re-emails (assuming after 60s in the OK period).

relies on https://github.com/getsentry/sentry/pull/114113 & https://github.com/getsentry/sentry/pull/114114