### PR TITLE
ref(billing): Remove Developer plan changes link from cancel banner

### DIFF
--- a/static/gsApp/views/cancelSubscription.tsx
+++ b/static/gsApp/views/cancelSubscription.tsx
@@ -5,7 +5,6 @@ import moment from 'moment-timezone';
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
 import {Checkbox} from '@sentry/scraps/checkbox';
-import {ExternalLink} from '@sentry/scraps/link';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import {RadioField as RadioGroupField} from 'sentry/components/forms/fields/radioField';
@@ -194,15 +193,12 @@ function CancelSubscriptionForm() {
           {tct(
             `Your organization is currently subscribed to the [planName] plan on a [interval] contract.
              Cancelling your subscription will downgrade your account to a free plan at the end
-             of your contract on [contractEndDate]. See [changesLink:upcoming changes] to our free Developer plan.`,
+             of your contract on [contractEndDate].`,
             {
               interval: subscription?.contractInterval === ANNUAL ? 'annual' : 'monthly',
               planName: <strong>{subscription?.planDetails?.name}</strong>,
               contractEndDate: (
                 <strong>{moment(subscription.contractPeriodEnd).format('ll')}</strong>
-              ),
-              changesLink: (
-                <ExternalLink href="https://sentry.zendesk.com/hc/en-us/articles/26206897429275-Changes-to-our-Developer-plan" />
               ),
             }
           )}


### PR DESCRIPTION
The link to the Developer plan changes article is no longer relevant and has been removed from the cancellation warning banner.

<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
