### PR TITLE
feat(preprod): Add post-on-added/removed PR comment toggles (EME-1046)

### DIFF
--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -94,6 +94,8 @@ export type Project = {
   preprodSizeStatusChecksRules?: unknown[];
   preprodSnapshotPrCommentsEnabled?: boolean;
   preprodSnapshotPrCommentsOnlyIfDiff?: boolean;
+  preprodSnapshotPrCommentsPostOnAdded?: boolean;
+  preprodSnapshotPrCommentsPostOnRemoved?: boolean;
   preprodSnapshotStatusChecksEnabled?: boolean;
   preprodSnapshotStatusChecksFailOnAdded?: boolean;
   preprodSnapshotStatusChecksFailOnRemoved?: boolean;

--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -93,6 +93,7 @@ export type Project = {
   preprodSizeStatusChecksEnabled?: boolean;
   preprodSizeStatusChecksRules?: unknown[];
   preprodSnapshotPrCommentsEnabled?: boolean;
+  preprodSnapshotPrCommentsOnlyIfDiff?: boolean;
   preprodSnapshotStatusChecksEnabled?: boolean;
   preprodSnapshotStatusChecksFailOnAdded?: boolean;
   preprodSnapshotStatusChecksFailOnRemoved?: boolean;

--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -93,7 +93,6 @@ export type Project = {
   preprodSizeStatusChecksEnabled?: boolean;
   preprodSizeStatusChecksRules?: unknown[];
   preprodSnapshotPrCommentsEnabled?: boolean;
-  preprodSnapshotPrCommentsOnlyIfDiff?: boolean;
   preprodSnapshotPrCommentsPostOnAdded?: boolean;
   preprodSnapshotPrCommentsPostOnRemoved?: boolean;
   preprodSnapshotStatusChecksEnabled?: boolean;

--- a/static/app/views/settings/project/preprod/snapshotPrCommentsToggle.tsx
+++ b/static/app/views/settings/project/preprod/snapshotPrCommentsToggle.tsx
@@ -20,6 +20,10 @@ const ENABLED_READ_KEY = 'sentry:preprod_snapshot_pr_comments_enabled';
 const ENABLED_WRITE_KEY = 'preprodSnapshotPrCommentsEnabled';
 const ONLY_IF_DIFF_READ_KEY = 'sentry:preprod_snapshot_pr_comments_only_if_diff';
 const ONLY_IF_DIFF_WRITE_KEY = 'preprodSnapshotPrCommentsOnlyIfDiff';
+const POST_ON_ADDED_READ_KEY = 'sentry:preprod_snapshot_pr_comments_post_on_added';
+const POST_ON_ADDED_WRITE_KEY = 'preprodSnapshotPrCommentsPostOnAdded';
+const POST_ON_REMOVED_READ_KEY = 'sentry:preprod_snapshot_pr_comments_post_on_removed';
+const POST_ON_REMOVED_WRITE_KEY = 'preprodSnapshotPrCommentsPostOnRemoved';
 
 export function SnapshotPrCommentsToggle() {
   const {project} = useProjectSettingsOutlet();
@@ -30,6 +34,12 @@ export function SnapshotPrCommentsToggle() {
   const onlyIfDiff =
     (project[ONLY_IF_DIFF_WRITE_KEY] ?? project.options?.[ONLY_IF_DIFF_READ_KEY]) ===
     true;
+  const postOnAdded =
+    (project[POST_ON_ADDED_WRITE_KEY] ?? project.options?.[POST_ON_ADDED_READ_KEY]) ===
+    true;
+  const postOnRemoved =
+    (project[POST_ON_REMOVED_WRITE_KEY] ??
+      project.options?.[POST_ON_REMOVED_READ_KEY]) !== false;
 
   function handleUpdate(payload: Record<string, boolean>) {
     addLoadingMessage(t('Saving...'));
@@ -87,6 +97,42 @@ export function SnapshotPrCommentsToggle() {
                   aria-label={t('Toggle only post when there are changes')}
                 />
               </Flex>
+              {onlyIfDiff ? (
+                <Fragment>
+                  <Flex align="center" justify="between">
+                    <Stack gap="xs">
+                      <Text bold>{t('Post on Added Snapshots')}</Text>
+                      <Text size="sm" variant="muted">
+                        {t('Treat new snapshots as a change worth posting a PR comment.')}
+                      </Text>
+                    </Stack>
+                    <Switch
+                      checked={postOnAdded}
+                      onChange={() =>
+                        handleUpdate({[POST_ON_ADDED_WRITE_KEY]: !postOnAdded})
+                      }
+                      aria-label={t('Toggle post on added snapshots')}
+                    />
+                  </Flex>
+                  <Flex align="center" justify="between">
+                    <Stack gap="xs">
+                      <Text bold>{t('Post on Removed Snapshots')}</Text>
+                      <Text size="sm" variant="muted">
+                        {t(
+                          'Treat removed snapshots as a change worth posting a PR comment.'
+                        )}
+                      </Text>
+                    </Stack>
+                    <Switch
+                      checked={postOnRemoved}
+                      onChange={() =>
+                        handleUpdate({[POST_ON_REMOVED_WRITE_KEY]: !postOnRemoved})
+                      }
+                      aria-label={t('Toggle post on removed snapshots')}
+                    />
+                  </Flex>
+                </Fragment>
+              ) : null}
             </Stack>
           ) : null}
         </Fragment>

--- a/static/app/views/settings/project/preprod/snapshotPrCommentsToggle.tsx
+++ b/static/app/views/settings/project/preprod/snapshotPrCommentsToggle.tsx
@@ -18,8 +18,6 @@ import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSet
 
 const ENABLED_READ_KEY = 'sentry:preprod_snapshot_pr_comments_enabled';
 const ENABLED_WRITE_KEY = 'preprodSnapshotPrCommentsEnabled';
-const ONLY_IF_DIFF_READ_KEY = 'sentry:preprod_snapshot_pr_comments_only_if_diff';
-const ONLY_IF_DIFF_WRITE_KEY = 'preprodSnapshotPrCommentsOnlyIfDiff';
 const POST_ON_ADDED_READ_KEY = 'sentry:preprod_snapshot_pr_comments_post_on_added';
 const POST_ON_ADDED_WRITE_KEY = 'preprodSnapshotPrCommentsPostOnAdded';
 const POST_ON_REMOVED_READ_KEY = 'sentry:preprod_snapshot_pr_comments_post_on_removed';
@@ -31,9 +29,6 @@ export function SnapshotPrCommentsToggle() {
 
   const enabled =
     (project[ENABLED_WRITE_KEY] ?? project.options?.[ENABLED_READ_KEY]) !== false;
-  const onlyIfDiff =
-    (project[ONLY_IF_DIFF_WRITE_KEY] ?? project.options?.[ONLY_IF_DIFF_READ_KEY]) ===
-    true;
   const postOnAdded =
     (project[POST_ON_ADDED_WRITE_KEY] ?? project.options?.[POST_ON_ADDED_READ_KEY]) ===
     true;
@@ -69,7 +64,9 @@ export function SnapshotPrCommentsToggle() {
                 {t('Snapshot Pull Request Comments')}
               </Text>
               <Text size="sm" variant="muted">
-                {t('Post snapshot comparison results as comments on pull requests.')}
+                {t(
+                  'Post a comment on pull requests when snapshot comparisons report changes.'
+                )}
               </Text>
             </Stack>
             <Switch
@@ -84,55 +81,32 @@ export function SnapshotPrCommentsToggle() {
             <Stack padding="xl" gap="lg">
               <Flex align="center" justify="between">
                 <Stack gap="xs">
-                  <Text bold>{t('Only post when there are changes')}</Text>
+                  <Text bold>{t('Post on Added Snapshots')}</Text>
                   <Text size="sm" variant="muted">
-                    {t(
-                      'Skip posting the PR comment when no snapshots differ from the base build.'
-                    )}
+                    {t('Treat new snapshots as a change worth posting a PR comment.')}
                   </Text>
                 </Stack>
                 <Switch
-                  checked={onlyIfDiff}
-                  onChange={() => handleUpdate({[ONLY_IF_DIFF_WRITE_KEY]: !onlyIfDiff})}
-                  aria-label={t('Toggle only post when there are changes')}
+                  checked={postOnAdded}
+                  onChange={() => handleUpdate({[POST_ON_ADDED_WRITE_KEY]: !postOnAdded})}
+                  aria-label={t('Toggle post on added snapshots')}
                 />
               </Flex>
-              {onlyIfDiff ? (
-                <Fragment>
-                  <Flex align="center" justify="between">
-                    <Stack gap="xs">
-                      <Text bold>{t('Post on Added Snapshots')}</Text>
-                      <Text size="sm" variant="muted">
-                        {t('Treat new snapshots as a change worth posting a PR comment.')}
-                      </Text>
-                    </Stack>
-                    <Switch
-                      checked={postOnAdded}
-                      onChange={() =>
-                        handleUpdate({[POST_ON_ADDED_WRITE_KEY]: !postOnAdded})
-                      }
-                      aria-label={t('Toggle post on added snapshots')}
-                    />
-                  </Flex>
-                  <Flex align="center" justify="between">
-                    <Stack gap="xs">
-                      <Text bold>{t('Post on Removed Snapshots')}</Text>
-                      <Text size="sm" variant="muted">
-                        {t(
-                          'Treat removed snapshots as a change worth posting a PR comment.'
-                        )}
-                      </Text>
-                    </Stack>
-                    <Switch
-                      checked={postOnRemoved}
-                      onChange={() =>
-                        handleUpdate({[POST_ON_REMOVED_WRITE_KEY]: !postOnRemoved})
-                      }
-                      aria-label={t('Toggle post on removed snapshots')}
-                    />
-                  </Flex>
-                </Fragment>
-              ) : null}
+              <Flex align="center" justify="between">
+                <Stack gap="xs">
+                  <Text bold>{t('Post on Removed Snapshots')}</Text>
+                  <Text size="sm" variant="muted">
+                    {t('Treat removed snapshots as a change worth posting a PR comment.')}
+                  </Text>
+                </Stack>
+                <Switch
+                  checked={postOnRemoved}
+                  onChange={() =>
+                    handleUpdate({[POST_ON_REMOVED_WRITE_KEY]: !postOnRemoved})
+                  }
+                  aria-label={t('Toggle post on removed snapshots')}
+                />
+              </Flex>
             </Stack>
           ) : null}
         </Fragment>

--- a/static/app/views/settings/project/preprod/snapshotPrCommentsToggle.tsx
+++ b/static/app/views/settings/project/preprod/snapshotPrCommentsToggle.tsx
@@ -1,3 +1,5 @@
+import {Fragment} from 'react';
+
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Switch} from '@sentry/scraps/switch';
 import {Text} from '@sentry/scraps/text';
@@ -14,50 +16,80 @@ import {t} from 'sentry/locale';
 import {useUpdateProject} from 'sentry/utils/project/useUpdateProject';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 
-const READ_KEY = 'sentry:preprod_snapshot_pr_comments_enabled';
-const WRITE_KEY = 'preprodSnapshotPrCommentsEnabled';
+const ENABLED_READ_KEY = 'sentry:preprod_snapshot_pr_comments_enabled';
+const ENABLED_WRITE_KEY = 'preprodSnapshotPrCommentsEnabled';
+const ONLY_IF_DIFF_READ_KEY = 'sentry:preprod_snapshot_pr_comments_only_if_diff';
+const ONLY_IF_DIFF_WRITE_KEY = 'preprodSnapshotPrCommentsOnlyIfDiff';
 
 export function SnapshotPrCommentsToggle() {
   const {project} = useProjectSettingsOutlet();
   const {mutate: updateProject} = useUpdateProject(project);
 
-  const enabled = (project[WRITE_KEY] ?? project.options?.[READ_KEY]) !== false;
+  const enabled =
+    (project[ENABLED_WRITE_KEY] ?? project.options?.[ENABLED_READ_KEY]) !== false;
+  const onlyIfDiff =
+    (project[ONLY_IF_DIFF_WRITE_KEY] ?? project.options?.[ONLY_IF_DIFF_READ_KEY]) ===
+    true;
 
-  function handleToggle() {
+  function handleUpdate(payload: Record<string, boolean>) {
     addLoadingMessage(t('Saving...'));
-    updateProject(
-      {[WRITE_KEY]: !enabled},
-      {
-        onSuccess: () => {
-          addSuccessMessage(t('PR comment settings updated'));
-        },
-        onError: () => {
-          addErrorMessage(t('Failed to save changes. Please try again.'));
-        },
-      }
-    );
+    updateProject(payload, {
+      onSuccess: () => {
+        addSuccessMessage(t('PR comment settings updated'));
+      },
+      onError: () => {
+        addErrorMessage(t('Failed to save changes. Please try again.'));
+      },
+    });
   }
 
   return (
     <Panel>
       <PanelHeader>{t('Snapshots - Pull Request Comments')}</PanelHeader>
       <PanelBody>
-        <Flex align="center" justify="between" padding="xl">
-          <Stack gap="xs">
-            <Text size="lg" bold>
-              {t('Snapshot Pull Request Comments')}
-            </Text>
-            <Text size="sm" variant="muted">
-              {t('Post snapshot comparison results as comments on pull requests.')}
-            </Text>
-          </Stack>
-          <Switch
-            size="lg"
-            checked={enabled}
-            onChange={handleToggle}
-            aria-label={t('Toggle snapshot PR comments')}
-          />
-        </Flex>
+        <Fragment>
+          <Flex
+            align="center"
+            justify="between"
+            padding="xl"
+            borderBottom={enabled ? 'primary' : undefined}
+          >
+            <Stack gap="xs">
+              <Text size="lg" bold>
+                {t('Snapshot Pull Request Comments')}
+              </Text>
+              <Text size="sm" variant="muted">
+                {t('Post snapshot comparison results as comments on pull requests.')}
+              </Text>
+            </Stack>
+            <Switch
+              size="lg"
+              checked={enabled}
+              onChange={() => handleUpdate({[ENABLED_WRITE_KEY]: !enabled})}
+              aria-label={t('Toggle snapshot PR comments')}
+            />
+          </Flex>
+
+          {enabled ? (
+            <Stack padding="xl" gap="lg">
+              <Flex align="center" justify="between">
+                <Stack gap="xs">
+                  <Text bold>{t('Only post when there are changes')}</Text>
+                  <Text size="sm" variant="muted">
+                    {t(
+                      'Skip posting the PR comment when no snapshots differ from the base build.'
+                    )}
+                  </Text>
+                </Stack>
+                <Switch
+                  checked={onlyIfDiff}
+                  onChange={() => handleUpdate({[ONLY_IF_DIFF_WRITE_KEY]: !onlyIfDiff})}
+                  aria-label={t('Toggle only post when there are changes')}
+                />
+              </Flex>
+            </Stack>
+          ) : null}
+        </Fragment>
       </PanelBody>
     </Panel>
   );


### PR DESCRIPTION
## Summary

Replace the only-if-diff sub-toggle with explicit "Post on Added" / "Post on Removed" toggles under the main PR comments switch:

- Main switch (`preprodSnapshotPrCommentsEnabled`) now governs whether comments post at all. Enabling it always means "post when there are changes" — the prior always-post mode is gone.
- **Post on Added Snapshots** (`preprodSnapshotPrCommentsPostOnAdded`, default off) — treat newly added snapshots as a change worth posting.
- **Post on Removed Snapshots** (`preprodSnapshotPrCommentsPostOnRemoved`, default on) — treat removed snapshots as a change worth posting.

Backend support is in #114302 — must land first.

EME-1046