### PR TITLE
ref(integrations): Remove org-level gates for SCM source context and Perforce

### DIFF
--- a/src/sentry/core/endpoints/project_details.py
+++ b/src/sentry/core/endpoints/project_details.py
@@ -481,15 +481,6 @@ E.g. `['release', 'environment']`""",
             )
         return value
 
-    def validate_scmSourceContextEnabled(self, value):
-        if value:
-            organization = self.context["project"].organization
-            if not features.has("organizations:scm-source-context", organization):
-                raise serializers.ValidationError(
-                    "Organization does not have the SCM source context feature enabled."
-                )
-        return value
-
     def validate_debugFilesRole(self, value):
         if value is None:
             return value

--- a/src/sentry/integrations/perforce/integration.py
+++ b/src/sentry/integrations/perforce/integration.py
@@ -527,7 +527,6 @@ class PerforceIntegrationProvider(IntegrationProvider):
             IntegrationFeatures.COMMITS,
         ]
     )
-    requires_feature_flag = True
 
     def get_pipeline_views(self) -> list[PipelineView[IntegrationPipeline]]:
         return []

--- a/src/sentry/issues/endpoints/project_stacktrace_source_context.py
+++ b/src/sentry/issues/endpoints/project_stacktrace_source_context.py
@@ -5,7 +5,6 @@ import logging
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -40,13 +39,6 @@ class ProjectStacktraceSourceContextEndpoint(ProjectEndpoint):
     owner = ApiOwner.ISSUES
 
     def get(self, request: Request, project: Project) -> Response:
-        if not features.has(
-            "organizations:scm-source-context",
-            project.organization,
-            actor=request.user,
-        ):
-            return Response(status=404)
-
         if not project.get_option("sentry:scm_source_context_enabled", False):
             return Response(status=404)
 

--- a/tests/sentry/issues/endpoints/test_project_stacktrace_source_context.py
+++ b/tests/sentry/issues/endpoints/test_project_stacktrace_source_context.py
@@ -36,7 +36,8 @@ class ProjectStacktraceSourceContextTest(APITestCase):
         self.login_as(self.user)
         self.project.update_option("sentry:scm_source_context_enabled", True)
 
-    def test_feature_flag_required(self) -> None:
+    def test_project_option_required(self) -> None:
+        self.project.update_option("sentry:scm_source_context_enabled", False)
         response = self.get_response(
             self.organization.slug,
             self.project.slug,
@@ -44,44 +45,31 @@ class ProjectStacktraceSourceContextTest(APITestCase):
         )
         assert response.status_code == 404
 
-    def test_project_option_required(self) -> None:
-        self.project.update_option("sentry:scm_source_context_enabled", False)
-        with self.feature("organizations:scm-source-context"):
-            response = self.get_response(
-                self.organization.slug,
-                self.project.slug,
-                qs_params={"file": "src/main.py", "lineNo": "10", "platform": "python"},
-            )
-            assert response.status_code == 404
-
     def test_missing_filepath(self) -> None:
-        with self.feature("organizations:scm-source-context"):
-            response = self.get_response(
-                self.organization.slug,
-                self.project.slug,
-                qs_params={"lineNo": "10", "platform": "python"},
-            )
-            assert response.status_code == 400
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            qs_params={"lineNo": "10", "platform": "python"},
+        )
+        assert response.status_code == 400
 
     def test_missing_lineno(self) -> None:
-        with self.feature("organizations:scm-source-context"):
-            response = self.get_response(
-                self.organization.slug,
-                self.project.slug,
-                qs_params={"file": "src/main.py", "platform": "python"},
-            )
-            assert response.status_code == 400
+        response = self.get_response(
+            self.organization.slug,
+            self.project.slug,
+            qs_params={"file": "src/main.py", "platform": "python"},
+        )
+        assert response.status_code == 400
 
     def test_no_code_mappings(self) -> None:
         self.code_mapping.delete()
-        with self.feature("organizations:scm-source-context"):
-            response = self.get_success_response(
-                self.organization.slug,
-                self.project.slug,
-                qs_params={"file": "src/main.py", "lineNo": "10", "platform": "python"},
-            )
-            assert response.data["error"] == "no_code_mappings_for_project"
-            assert response.data["context"] == []
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            qs_params={"file": "src/main.py", "lineNo": "10", "platform": "python"},
+        )
+        assert response.data["error"] == "no_code_mappings_for_project"
+        assert response.data["context"] == []
 
     @patch("sentry.integrations.utils.source_context.integration_service")
     def test_successful_fetch(self, mock_service: MagicMock) -> None:
@@ -100,20 +88,19 @@ class ProjectStacktraceSourceContextTest(APITestCase):
 
         mock_install.__class__ = RepositoryIntegration  # type: ignore[assignment]
 
-        with self.feature("organizations:scm-source-context"):
-            response = self.get_success_response(
-                self.organization.slug,
-                self.project.slug,
-                qs_params={
-                    "file": "src/app/main.py",
-                    "lineNo": "10",
-                    "platform": "python",
-                },
-            )
-            assert response.data["error"] is None
-            assert len(response.data["context"]) == 11
-            assert response.data["context"][5] == [10, "line10"]
-            assert response.data["sourceUrl"] == "https://github.com/file"
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            qs_params={
+                "file": "src/app/main.py",
+                "lineNo": "10",
+                "platform": "python",
+            },
+        )
+        assert response.data["error"] is None
+        assert len(response.data["context"]) == 11
+        assert response.data["context"][5] == [10, "line10"]
+        assert response.data["sourceUrl"] == "https://github.com/file"
 
     @patch("sentry.integrations.utils.source_context.integration_service")
     def test_file_not_found(self, mock_service: MagicMock) -> None:
@@ -129,15 +116,14 @@ class ProjectStacktraceSourceContextTest(APITestCase):
         mock_install.get_client.return_value = mock_client
         mock_client.get_file.side_effect = ApiError("Not Found", code=404)
 
-        with self.feature("organizations:scm-source-context"):
-            response = self.get_success_response(
-                self.organization.slug,
-                self.project.slug,
-                qs_params={
-                    "file": "src/app/main.py",
-                    "lineNo": "10",
-                    "platform": "python",
-                },
-            )
-            assert response.data["error"] == "file_not_found"
-            assert response.data["context"] == []
+        response = self.get_success_response(
+            self.organization.slug,
+            self.project.slug,
+            qs_params={
+                "file": "src/app/main.py",
+                "lineNo": "10",
+                "platform": "python",
+            },
+        )
+        assert response.data["error"] == "file_not_found"
+        assert response.data["context"] == []


### PR DESCRIPTION
The SCM source context feature is now gated solely by the per-project sentry:scm_source_context_enabled option, which project admins enable explicitly. Drop the organizations:scm-source-context org-level gate from the stacktrace endpoint and the project-details validator.

Perforce is going GA, so drop requires_feature_flag = True from the provider, which removed the auto-derived organizations:integrations-perforce gate.

Tests updated to match: drop with self.feature(...) wrappers and delete test_feature_flag_required (now redundant with test_project_option_required).

Related:
* Frontend: https://github.com/getsentry/sentry/pull/114133
* Automator: https://github.com/getsentry/sentry-options-automator/pull/7561
* Flags: https://github.com/getsentry/sentry/pull/114134