### PR TITLE
ref(stacktrace): Drop org-flag gate for SCM source context UI

### DIFF
--- a/static/app/components/events/interfaces/stackTraceContext.spec.tsx
+++ b/static/app/components/events/interfaces/stackTraceContext.spec.tsx
@@ -1,3 +1,5 @@
+import {ProjectFixture} from 'sentry-fixture/project';
+
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {StackType, StackView} from 'sentry/types/stacktrace';
@@ -38,6 +40,10 @@ describe('StacktraceContext', () => {
 
   beforeEach(() => {
     localStorageWrapper.clear();
+    MockApiClient.addMockResponse({
+      url: '/projects/org-slug/test-project/',
+      body: ProjectFixture({slug: 'test-project'}),
+    });
   });
 
   it('provides default values', () => {

--- a/static/app/components/events/interfaces/stackTraceContext.tsx
+++ b/static/app/components/events/interfaces/stackTraceContext.tsx
@@ -101,12 +101,11 @@ export function StacktraceContext({
   defaultIsNewestFramesFirst = true,
 }: StackTraceContextOptions) {
   const organization = useOrganization();
-  const hasScmFeature = organization.features.includes('scm-source-context');
   const {data: detailedProject} = useDetailedProject(
     {orgSlug: organization.slug, projectSlug: projectSlug ?? ''},
-    {enabled: hasScmFeature && defined(projectSlug)}
+    {enabled: defined(projectSlug)}
   );
-  const hasScmSourceContext = hasScmFeature && !!detailedProject?.scmSourceContextEnabled;
+  const hasScmSourceContext = !!detailedProject?.scmSourceContextEnabled;
 
   const [isFullStackTrace, setIsFullStackTrace] = useState(false);
   const [isNewestFramesFirst, setIsNewestFramesFirst] = useState(

--- a/static/app/components/events/interfaces/threads.spec.tsx
+++ b/static/app/components/events/interfaces/threads.spec.tsx
@@ -38,6 +38,10 @@ describe('Threads', () => {
       url: `/projects/${organization.slug}/${project.slug}/stacktrace-link/`,
       body: {config, sourceUrl: 'https://something.io', integrations: [integration]},
     });
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/`,
+      body: project,
+    });
     ProjectsStore.loadInitialData([project]);
     ConfigStore.set('user', UserFixture());
 

--- a/static/app/components/stackTrace/issueStackTrace/index.spec.tsx
+++ b/static/app/components/stackTrace/issueStackTrace/index.spec.tsx
@@ -73,6 +73,10 @@ describe('IssueStackTrace', () => {
       url: '/projects/org-slug/project-slug/stacktrace-link/',
       body: {config: null, sourceUrl: null, integrations: []},
     });
+    MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/',
+      body: ProjectFixture({id: '1', slug: 'project-slug'}),
+    });
     Object.assign(navigator, {
       clipboard: {writeText: jest.fn().mockResolvedValue(undefined)},
     });
@@ -666,8 +670,18 @@ describe('IssueStackTrace', () => {
 
   it('fetches and renders SCM source context for frames without embedded context', async () => {
     const {event, stacktrace} = makeCopyTestData();
-    const organization = OrganizationFixture({features: ['scm-source-context']});
-    ProjectsStore.loadInitialData([ProjectFixture({id: '1', slug: 'project-slug'})]);
+    const organization = OrganizationFixture();
+    const project = ProjectFixture({
+      id: '1',
+      slug: 'project-slug',
+      scmSourceContextEnabled: true,
+    });
+    ProjectsStore.loadInitialData([project]);
+
+    MockApiClient.addMockResponse({
+      url: '/projects/org-slug/project-slug/',
+      body: project,
+    });
 
     const sourceContextRequest = MockApiClient.addMockResponse({
       url: '/projects/org-slug/project-slug/stacktrace-source-context/',
@@ -677,6 +691,7 @@ describe('IssueStackTrace', () => {
     render(
       <IssueStackTrace
         event={event}
+        projectSlug="project-slug"
         values={[
           {
             type: 'RuntimeError',
@@ -692,8 +707,8 @@ describe('IssueStackTrace', () => {
       {organization}
     );
 
-    expect(sourceContextRequest).toHaveBeenCalled();
     expect(await screen.findByText('def handle():')).toBeInTheDocument();
+    expect(sourceContextRequest).toHaveBeenCalled();
   });
 
   describe('exception groups', () => {

--- a/static/app/components/stackTrace/issueStackTrace/index.tsx
+++ b/static/app/components/stackTrace/issueStackTrace/index.tsx
@@ -39,6 +39,7 @@ import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import type {StacktraceType} from 'sentry/types/stacktrace';
 import {defined} from 'sentry/utils';
+import {useDetailedProject} from 'sentry/utils/project/useDetailedProject';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
@@ -141,7 +142,11 @@ function IssueStackTraceContent({
 }: IssueStackTraceBaseProps & {isStandalone: boolean; values: ExceptionValue[]}) {
   const {isMinified, isNewestFirst, view} = useStackTraceViewState();
   const organization = useOrganization();
-  const hasScmSourceContext = organization.features.includes('scm-source-context');
+  const {data: detailedProject} = useDetailedProject(
+    {orgSlug: organization.slug, projectSlug: projectSlug ?? ''},
+    {enabled: defined(projectSlug)}
+  );
+  const hasScmSourceContext = !!detailedProject?.scmSourceContextEnabled;
   const {hiddenExceptions, toggleRelatedExceptions, expandException} =
     useHiddenExceptions(values);
 

--- a/static/app/data/forms/projectGeneralSettings.tsx
+++ b/static/app/data/forms/projectGeneralSettings.tsx
@@ -174,7 +174,6 @@ export const fields = {
     help: t(
       "Fetch source code from your connected SCM integration (e.g. GitHub, GitLab) to display in stack traces. When enabled, any project member can view source code for files matched by this project's code mappings."
     ),
-    visible: ({features}) => features.has('scm-source-context'),
     confirm: {
       true: t(
         'Enabling this will allow all members with access to this project to view source code from the connected SCM integration via code mappings. Are you sure you want to enable this?'


### PR DESCRIPTION
The organizations:scm-source-context flag is going away as part of making the feature available behind the per-project setting only.

In stackTraceContext, drop the org-flag check and rely solely on the project's scmSourceContextEnabled option (already fetched via useDetailedProject).

In issueStackTrace, switch from the org-flag check to useDetailedProject so the new issue stacktrace view also respects the per-project setting (previously only the legacy frame UI did).

Also drop the visible: predicate from the project settings form so the toggle is always visible to project admins. The form already disables itself based on project-level write permission.

Related:
* Backend: https://github.com/getsentry/sentry/pull/114132
* Automator: https://github.com/getsentry/sentry-options-automator/pull/7561
* Flags: https://github.com/getsentry/sentry/pull/114134