### PR TITLE
chore(features): Remove graduated SCM source context and Perforce flags

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -161,9 +161,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:bitbucket_server-repo-auto-sync-apply", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:vsts-repo-auto-sync", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     manager.add("organizations:vsts-repo-auto-sync-apply", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    manager.add("organizations:integrations-perforce", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:integrations-slack-staging", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    manager.add("organizations:scm-source-context", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:scm-config-oi-reads", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # API-driven integration setup pipeline (per-provider rollout)
     # ...


### PR DESCRIPTION
Drop the organizations:scm-source-context registration. The feature is now gated solely by the per-project sentry:scm_source_context_enabled option, which project admins enable explicitly.

Drop the organizations:integrations-perforce registration. Perforce is GA; the auto-derived requires_feature_flag gate has been removed from the provider.

Land after the call sites are gone (the backend and frontend PRs in this stack) so the registry never references a non-existent flag.