### PR TITLE
ref(forms): Add async hooks to backend json submit form

### DIFF
--- a/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.spec.tsx
+++ b/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.spec.tsx
@@ -1,3 +1,5 @@
+import type {ComponentProps} from 'react';
+import {queryOptions} from '@tanstack/react-query';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {
@@ -462,6 +464,56 @@ describe('BackendJsonSubmitForm', () => {
 
       await waitFor(() => expect(searchResponse).toHaveBeenCalled());
       expect(await screen.findByText('test-repo')).toBeInTheDocument();
+    });
+
+    it('uses custom async query options instead of the default URL request', async () => {
+      const defaultSearchResponse = MockApiClient.addMockResponse({
+        url: '/search',
+        body: [],
+      });
+      const customQueryOptionsCalls: string[] = [];
+      const customAsyncQueryOptionsFactory: NonNullable<
+        ComponentProps<typeof BackendJsonSubmitForm>['customAsyncQueryOptions']
+      >[string] = debouncedInput => {
+        customQueryOptionsCalls.push(debouncedInput);
+        return queryOptions({
+          queryKey: ['custom-async-repo', debouncedInput],
+          queryFn: () => [
+            {
+              value: debouncedInput,
+              label: `Custom ${debouncedInput}`,
+            },
+          ],
+        });
+      };
+
+      render(
+        <BackendJsonSubmitForm
+          fields={[
+            {
+              name: 'repo',
+              type: 'select',
+              label: 'Repository',
+              url: '/search',
+              choices: [],
+            },
+          ]}
+          onSubmit={onSubmit}
+          submitLabel="Create"
+          customAsyncQueryOptions={{repo: customAsyncQueryOptionsFactory}}
+        />,
+        {organization: org}
+      );
+
+      const textbox = screen.getByRole('textbox', {name: 'Repository'});
+      await userEvent.click(textbox);
+      await userEvent.type(textbox, 'test');
+
+      await waitFor(() => {
+        expect(customQueryOptionsCalls).toContain('test');
+      });
+      expect(await screen.findByText('Custom test')).toBeInTheDocument();
+      expect(defaultSearchResponse).not.toHaveBeenCalled();
     });
 
     it('async select gracefully handles non-array API response', async () => {

--- a/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.spec.tsx
+++ b/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.spec.tsx
@@ -1,5 +1,3 @@
-import type {ComponentProps} from 'react';
-import {queryOptions} from '@tanstack/react-query';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {
@@ -464,56 +462,6 @@ describe('BackendJsonSubmitForm', () => {
 
       await waitFor(() => expect(searchResponse).toHaveBeenCalled());
       expect(await screen.findByText('test-repo')).toBeInTheDocument();
-    });
-
-    it('uses custom async query options instead of the default URL request', async () => {
-      const defaultSearchResponse = MockApiClient.addMockResponse({
-        url: '/search',
-        body: [],
-      });
-      const customQueryOptionsCalls: string[] = [];
-      const customAsyncQueryOptionsFactory: NonNullable<
-        ComponentProps<typeof BackendJsonSubmitForm>['customAsyncQueryOptions']
-      >[string] = debouncedInput => {
-        customQueryOptionsCalls.push(debouncedInput);
-        return queryOptions({
-          queryKey: ['custom-async-repo', debouncedInput],
-          queryFn: () => [
-            {
-              value: debouncedInput,
-              label: `Custom ${debouncedInput}`,
-            },
-          ],
-        });
-      };
-
-      render(
-        <BackendJsonSubmitForm
-          fields={[
-            {
-              name: 'repo',
-              type: 'select',
-              label: 'Repository',
-              url: '/search',
-              choices: [],
-            },
-          ]}
-          onSubmit={onSubmit}
-          submitLabel="Create"
-          customAsyncQueryOptions={{repo: customAsyncQueryOptionsFactory}}
-        />,
-        {organization: org}
-      );
-
-      const textbox = screen.getByRole('textbox', {name: 'Repository'});
-      await userEvent.click(textbox);
-      await userEvent.type(textbox, 'test');
-
-      await waitFor(() => {
-        expect(customQueryOptionsCalls).toContain('test');
-      });
-      expect(await screen.findByText('Custom test')).toBeInTheDocument();
-      expect(defaultSearchResponse).not.toHaveBeenCalled();
     });
 
     it('async select gracefully handles non-array API response', async () => {

--- a/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
+++ b/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
@@ -1,5 +1,5 @@
 import {useMemo, useRef, useState, type ReactNode, useEffect} from 'react';
-import {queryOptions, type QueryKey, type UseQueryOptions} from '@tanstack/react-query';
+import {queryOptions, type UseQueryOptions} from '@tanstack/react-query';
 import {z} from 'zod';
 
 import type {ButtonProps} from '@sentry/scraps/button';
@@ -27,10 +27,10 @@ import {getDefaultForField, transformChoices} from './utils';
 const API_CLIENT = new Client({baseUrl: '', headers: {}});
 
 type AsyncSelectQueryOptions = UseQueryOptions<
-  ReadonlyArray<SelectValue<string>>,
+  Array<SelectValue<string>>,
   Error,
   ReadonlyArray<SelectValue<string>>,
-  QueryKey
+  Array<string | Record<string, unknown> | undefined>
 >;
 
 type AsyncSelectQueryOptionsFactory = (debouncedInput: string) => AsyncSelectQueryOptions;

--- a/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
+++ b/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
@@ -1,5 +1,5 @@
 import {useMemo, useRef, useState, type ReactNode, useEffect} from 'react';
-import {queryOptions} from '@tanstack/react-query';
+import {queryOptions, type UseQueryOptions} from '@tanstack/react-query';
 import {z} from 'zod';
 
 import type {ButtonProps} from '@sentry/scraps/button';
@@ -26,6 +26,15 @@ import {getDefaultForField, transformChoices} from './utils';
  */
 const API_CLIENT = new Client({baseUrl: '', headers: {}});
 
+type AsyncSelectQueryOptions = UseQueryOptions<
+  any,
+  Error,
+  ReadonlyArray<SelectValue<string>>,
+  any
+>;
+
+type AsyncSelectQueryOptionsFactory = (debouncedInput: string) => AsyncSelectQueryOptions;
+
 interface BackendJsonSubmitFormProps {
   /**
    * Field configs from the backend API response.
@@ -36,6 +45,14 @@ interface BackendJsonSubmitFormProps {
    * resolves on success or rejects/throws on error.
    */
   onSubmit: (values: Record<string, unknown>) => Promise<unknown> | void;
+  /**
+   * Override the built-in async query options for specific fields. Map from
+   * field name to a factory that returns query options for a given search input.
+   * When provided for a field, this is used instead of the default URL-based
+   * async loading. Useful when the async endpoint requires a different query
+   * shape than the built-in `buildAsyncSelectQuery`.
+   */
+  customAsyncQueryOptions?: Record<string, AsyncSelectQueryOptionsFactory>;
   /**
    * Current values of dynamic fields, passed as query params to async select endpoints.
    */
@@ -65,12 +82,16 @@ interface BackendJsonSubmitFormProps {
    */
   onAsyncOptionsFetched?: (
     fieldName: string,
-    options: Array<SelectValue<string | number>>
+    options: Array<SelectValue<string>>
   ) => void;
   /**
    * Called when a field with `updatesForm: true` changes value.
    */
   onFieldChange?: (fieldName: string, value: unknown) => void;
+  /**
+   * Called whenever any field value changes.
+   */
+  onValueChange?: (fieldName: string, value: unknown) => void;
   /**
    * Whether the submit button should be disabled (e.g., form has errors).
    */
@@ -158,6 +179,8 @@ export function BackendJsonSubmitForm({
   dynamicFieldValues,
   onAsyncOptionsFetched,
   onFieldChange,
+  onValueChange,
+  customAsyncQueryOptions,
   footer,
 }: BackendJsonSubmitFormProps) {
   // Ref to avoid including the callback in queryKey (would cause refetches)
@@ -221,6 +244,7 @@ export function BackendJsonSubmitForm({
                 {fieldApi => {
                   const handleChange = (value: unknown) => {
                     fieldApi.handleChange(value);
+                    onValueChange?.(field.name, value);
                     if (field.updatesForm && onFieldChange) {
                       onFieldChange(field.name, value);
                     }
@@ -249,7 +273,8 @@ export function BackendJsonSubmitForm({
                           required={field.required}
                         >
                           <fieldApi.TextArea
-                            autosize
+                            autosize={field.autosize ?? true}
+                            maxRows={field.maxRows}
                             value={(fieldApi.state.value as string) ?? ''}
                             onChange={handleChange}
                             placeholder={field.placeholder}
@@ -274,11 +299,12 @@ export function BackendJsonSubmitForm({
                       );
                     case 'select':
                     case 'choice': {
-                      if (field.url) {
+                      if (field.url || customAsyncQueryOptions?.[field.name]) {
                         // Async select: fetch options from URL as user types.
                         // Show static choices as initial options before any search.
                         const staticOptions = transformChoices(field.choices);
-                        const asyncQueryOptions = (debouncedInput: string) =>
+                        const customQueryOptions = customAsyncQueryOptions?.[field.name];
+                        const defaultAsyncQueryOptions = ((debouncedInput: string) =>
                           queryOptions({
                             queryKey: [
                               'backend-json-async-select',
@@ -288,9 +314,7 @@ export function BackendJsonSubmitForm({
                               dynamicFieldValues,
                               JSON.stringify(onAsyncOptionsFetchedRef),
                             ],
-                            queryFn: async (): Promise<
-                              Array<SelectValue<string | number>>
-                            > => {
+                            queryFn: async (): Promise<Array<SelectValue<string>>> => {
                               if (!debouncedInput) {
                                 return staticOptions;
                               }
@@ -311,7 +335,9 @@ export function BackendJsonSubmitForm({
                               }
                               return results;
                             },
-                          });
+                          })) satisfies AsyncSelectQueryOptionsFactory;
+                        const asyncQueryOptions =
+                          customQueryOptions ?? defaultAsyncQueryOptions;
                         if (field.multiple) {
                           return (
                             <fieldApi.Layout.Stack
@@ -321,12 +347,8 @@ export function BackendJsonSubmitForm({
                             >
                               <fieldApi.SelectAsync
                                 multiple
-                                value={
-                                  (fieldApi.state.value as Array<string | number>) ?? []
-                                }
-                                onChange={(value: Array<string | number>) =>
-                                  handleChange(value)
-                                }
+                                value={(fieldApi.state.value as string[]) ?? []}
+                                onChange={(value: string[]) => handleChange(value)}
                                 disabled={field.disabled}
                                 queryOptions={asyncQueryOptions}
                               />
@@ -341,22 +363,16 @@ export function BackendJsonSubmitForm({
                           >
                             {field.required ? (
                               <fieldApi.SelectAsync
-                                value={
-                                  (fieldApi.state.value ?? null) as string | number | null
-                                }
-                                onChange={(value: string | number) => handleChange(value)}
+                                value={(fieldApi.state.value ?? null) as string | null}
+                                onChange={(value: string) => handleChange(value)}
                                 disabled={field.disabled}
                                 queryOptions={asyncQueryOptions}
                               />
                             ) : (
                               <fieldApi.SelectAsync
                                 clearable
-                                value={
-                                  (fieldApi.state.value ?? null) as string | number | null
-                                }
-                                onChange={(value: string | number | null) =>
-                                  handleChange(value)
-                                }
+                                value={(fieldApi.state.value ?? null) as string | null}
+                                onChange={(value: string | null) => handleChange(value)}
                                 disabled={field.disabled}
                                 queryOptions={asyncQueryOptions}
                               />

--- a/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
+++ b/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
@@ -1,5 +1,5 @@
 import {useMemo, useRef, useState, type ReactNode, useEffect} from 'react';
-import {queryOptions, type UseQueryOptions} from '@tanstack/react-query';
+import {queryOptions, type QueryKey, type UseQueryOptions} from '@tanstack/react-query';
 import {z} from 'zod';
 
 import type {ButtonProps} from '@sentry/scraps/button';
@@ -27,10 +27,10 @@ import {getDefaultForField, transformChoices} from './utils';
 const API_CLIENT = new Client({baseUrl: '', headers: {}});
 
 type AsyncSelectQueryOptions = UseQueryOptions<
-  any,
+  ReadonlyArray<SelectValue<string>>,
   Error,
   ReadonlyArray<SelectValue<string>>,
-  any
+  QueryKey
 >;
 
 type AsyncSelectQueryOptionsFactory = (debouncedInput: string) => AsyncSelectQueryOptions;

--- a/static/app/components/backendJsonFormAdapter/types.ts
+++ b/static/app/components/backendJsonFormAdapter/types.ts
@@ -29,6 +29,8 @@ interface JsonFormAdapterBoolean extends JsonFormAdapterBase {
 
 interface JsonFormAdapterString extends JsonFormAdapterBase {
   type: 'string' | 'text' | 'textarea' | 'url' | 'email';
+  autosize?: boolean;
+  maxRows?: number;
 }
 
 interface JsonFormAdapterSecret extends JsonFormAdapterBase {


### PR DESCRIPTION
Add generic async extension points to `BackendJsonSubmitForm`.

This extracts the reusable pieces needed by the Sentry app schema form migration without pulling any sentry-app behavior into the shared adapter.

The adapter can now accept custom async query factories, notify callers when any field value changes, and pass textarea sizing props through to the rendered field. That lets callers keep backend-specific async request shapes and dependency handling outside the adapter.

I split this out first so reviewers can look at the shared form API and tests separately from the larger Sentry app consumer migration.