### PR TITLE
ref(objectstore): Make ObjectstoreEndpoint unauthenticated 

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -466,7 +466,7 @@ from sentry.notifications.api.endpoints.user_notification_settings_providers imp
     UserNotificationSettingsProvidersEndpoint,
 )
 from sentry.notifications.platform.api.endpoints import urls as notification_platform_urls
-from sentry.objectstore.endpoints.organization import OrganizationObjectstoreEndpoint
+from sentry.objectstore.endpoints.organization import ObjectstoreEndpoint
 from sentry.preprod.api.endpoints import urls as preprod_urls
 from sentry.releases.endpoints.organization_release_assemble import (
     OrganizationReleaseAssembleEndpoint,
@@ -2769,7 +2769,7 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/objectstore/(?P<path>.*)$",
-        OrganizationObjectstoreEndpoint.as_view(),
+        ObjectstoreEndpoint.as_view(),
         name="sentry-api-0-organization-objectstore",
     ),
     *preprod_urls.preprod_organization_urlpatterns,

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -192,8 +192,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:on-demand-metrics-query-spec-version-two", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Use the new OrganizationMemberInvite endpoints
     manager.add("organizations:new-organization-member-invite", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Use the OrganizationObjectstoreEndpoint
-    manager.add("organizations:objectstore-endpoint", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Display on demand metrics related UI elements
     manager.add("organizations:on-demand-metrics-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Display on demand metrics related UI elements, for dashboards and widgets. The other flag is for alerts.

--- a/src/sentry/objectstore/endpoints/organization.py
+++ b/src/sentry/objectstore/endpoints/organization.py
@@ -21,19 +21,23 @@ try:
 except ImportError:
     pass
 
-from sentry import features, options
+from sentry import options
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
-from sentry.api.base import cell_silo_endpoint
-from sentry.api.bases import OrganizationEndpoint
-from sentry.api.bases.organization import OrganizationReleasePermission
-from sentry.models.organization import Organization
+from sentry.api.base import Endpoint, cell_silo_endpoint
 from sentry.objectstore import parse_accept_encoding
 from sentry.ratelimits.config import RateLimitConfig
 
 
 @cell_silo_endpoint
-class OrganizationObjectstoreEndpoint(OrganizationEndpoint):
+class ObjectstoreEndpoint(Endpoint):
+    """
+    Transparent proxy to Objectstore.
+
+    This endpoint is unauthenticated at the Django level, as authentication is performed by Objectstore via the `Authorization` or the `X-Os-Auth` header.
+    The `organization_id_or_slug` parameter in the view path and URL kwarg is needed by the API Gateway for cell routing, even though this endpoint does not validate it.
+    """
+
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
         "PUT": ApiPublishStatus.EXPERIMENTAL,
@@ -41,46 +45,29 @@ class OrganizationObjectstoreEndpoint(OrganizationEndpoint):
         "DELETE": ApiPublishStatus.EXPERIMENTAL,
     }
     owner = ApiOwner.FOUNDATIONAL_STORAGE
-    permission_classes = (OrganizationReleasePermission,)
+    authentication_classes = ()
+    permission_classes = ()
     rate_limits = RateLimitConfig(group="CLI")
     parser_classes = ()  # don't attempt to parse request data, so we can access the raw body in wsgi.input
 
-    def _check_flag(self, request: Request, organization: Organization) -> Response | None:
-        if not features.has("organizations:objectstore-endpoint", organization, actor=request.user):
-            return Response(
-                {
-                    "error": "This endpoint requires the organizations:objectstore-endpoint feature flag."
-                },
-                status=403,
-            )
-        return None
-
     def get(
-        self, request: Request, organization: Organization, path: str
+        self, request: Request, organization_id_or_slug: str, path: str
     ) -> Response | StreamingHttpResponse:
-        if response := self._check_flag(request, organization):
-            return response
         return self._proxy(request, path)
 
     def put(
-        self, request: Request, organization: Organization, path: str
+        self, request: Request, organization_id_or_slug: str, path: str
     ) -> Response | StreamingHttpResponse:
-        if response := self._check_flag(request, organization):
-            return response
         return self._proxy(request, path)
 
     def post(
-        self, request: Request, organization: Organization, path: str
+        self, request: Request, organization_id_or_slug: str, path: str
     ) -> Response | StreamingHttpResponse:
-        if response := self._check_flag(request, organization):
-            return response
         return self._proxy(request, path)
 
     def delete(
-        self, request: Request, organization: Organization, path: str
+        self, request: Request, organization_id_or_slug: str, path: str
     ) -> Response | StreamingHttpResponse:
-        if response := self._check_flag(request, organization):
-            return response
         return self._proxy(request, path)
 
     def _proxy(

--- a/src/sentry/objectstore/endpoints/organization.py
+++ b/src/sentry/objectstore/endpoints/organization.py
@@ -32,10 +32,10 @@ from sentry.ratelimits.config import RateLimitConfig
 @cell_silo_endpoint
 class ObjectstoreEndpoint(Endpoint):
     """
-    Transparent proxy to Objectstore.
+    Transparent proxy to the Objectstore service (https://github.com/getsentry/objectstore).
 
     This endpoint is unauthenticated at the Django level, as authentication is performed by Objectstore via the `Authorization` or the `X-Os-Auth` header.
-    The `organization_id_or_slug` parameter in the view path and URL kwarg is needed by the API Gateway for cell routing, even though this endpoint does not validate it.
+    The `organization_id_or_slug` parameter in the view path and URL kwarg is needed by the API Gateway for cell routing, even though this endpoint does not validate nor use it.
     """
 
     publish_status = {

--- a/tests/sentry/objectstore/endpoints/test_organization.py
+++ b/tests/sentry/objectstore/endpoints/test_organization.py
@@ -17,7 +17,6 @@ from sentry.silo.base import SiloMode, SingleProcessSiloModeState
 from sentry.testutils.asserts import assert_status_code
 from sentry.testutils.cases import TransactionTestCase
 from sentry.testutils.cell import override_cells
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import cell_silo_test, create_test_cells
 from sentry.testutils.skips import requires_objectstore
 from sentry.types.cell import Cell
@@ -34,7 +33,7 @@ def local_live_server(request: pytest.FixtureRequest, live_server: LiveServer) -
 @cell_silo_test
 @requires_objectstore
 @pytest.mark.usefixtures("local_live_server")
-class OrganizationObjectstoreEndpointTest(TransactionTestCase):
+class ObjectstoreEndpointTest(TransactionTestCase):
     endpoint = "sentry-api-0-organization-objectstore"
     live_server: LiveServer
 
@@ -68,13 +67,11 @@ class OrganizationObjectstoreEndpointTest(TransactionTestCase):
         session = client.session(Usecase("test"), org=self.organization.id)
         return session
 
-    @with_feature("organizations:objectstore-endpoint")
     def test_health(self) -> None:
         url = self.get_endpoint_url() + "health"
         res = requests.get(url, headers=self.get_auth_headers())
         res.raise_for_status()
 
-    @with_feature("organizations:objectstore-endpoint")
     def test_full_cycle(self) -> None:
         session = self.get_session()
 
@@ -95,7 +92,6 @@ class OrganizationObjectstoreEndpointTest(TransactionTestCase):
         with pytest.raises(RequestError):
             session.get(object_key)
 
-    @with_feature("organizations:objectstore-endpoint")
     def test_uncompressed(self) -> None:
         session = self.get_session()
 
@@ -105,7 +101,6 @@ class OrganizationObjectstoreEndpointTest(TransactionTestCase):
         retrieved = session.get(object_key)
         assert retrieved.payload.read() == b"test data"
 
-    @with_feature("organizations:objectstore-endpoint")
     def test_accept_encoding_passthrough(self) -> None:
         data = os.urandom(10 * 1024)
         ctx = zstandard.ZstdCompressor()
@@ -152,7 +147,6 @@ class OrganizationObjectstoreEndpointTest(TransactionTestCase):
         with dctx.stream_reader(raw_body) as reader:
             assert reader.read() == data
 
-    @with_feature("organizations:objectstore-endpoint")
     def test_large_payload(self) -> None:
         session = self.get_session()
         data = b"A" * 1_000_000
@@ -169,9 +163,8 @@ test_region = create_test_cells("us")[0]
 
 @cell_silo_test(cells=(test_region,))
 @requires_objectstore
-@with_feature("organizations:objectstore-endpoint")
 @pytest.mark.usefixtures("local_live_server")
-class OrganizationObjectstoreEndpointWithControlSiloTest(TransactionTestCase):
+class ObjectstoreEndpointWithControlSiloTest(TransactionTestCase):
     endpoint = "sentry-api-0-organization-objectstore"
     live_server: LiveServer
 


### PR DESCRIPTION
Reshapes the Objectstore proxy endpoint so that authentication is performed entirely by Objectstore.
This allows us to lift the feature flag gate, and is safe now that we're enforcing auth checks.