### PR TITLE
ref(seer): Remove redundant page title from autofix project settings

### DIFF
--- a/static/gsApp/views/seerAutomation/projectDetails.tsx
+++ b/static/gsApp/views/seerAutomation/projectDetails.tsx
@@ -1,7 +1,6 @@
 import {Alert} from '@sentry/scraps/alert';
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
-import {Text} from '@sentry/scraps/text';
 
 import {hasEveryAccess} from 'sentry/components/acl/access';
 import Feature from 'sentry/components/acl/feature';
@@ -42,19 +41,9 @@ function SeerProjectDetails() {
 
   return (
     <AnalyticsArea name="project-details">
-      <SentryDocumentTitle title={t('Autofix for %s', project.slug)} />
+      <SentryDocumentTitle title={t('Seer for %s', project.slug)} />
       <SettingsPageHeader
-        title={
-          <Flex align="baseline" gap="md">
-            {tct('Autofix for [projectName]', {
-              projectName: (
-                <Text as="span" monospace>
-                  {project.slug}
-                </Text>
-              ),
-            })}
-          </Flex>
-        }
+        title={t('Seer')}
         subtitle={tct(
           'Connect repositories to projects, and choose which Agent should automatically process issues. [docs:Read the docs] to learn what Seer can do.',
           {


### PR DESCRIPTION
Converts `Settings > [project] > Autofix for [project]`  to  `Settings > [project] > Seer` on
Seer settings page.

---
Before:

<img width="2672" height="646" alt="CleanShot 2026-04-28 at 12 47 02@2x" src="https://github.com/user-attachments/assets/42bd0d7a-9df8-452f-8b84-496f965339b8" />

---
After:

<img width="2674" height="388" alt="CleanShot 2026-04-28 at 12 47 42@2x" src="https://github.com/user-attachments/assets/696539d9-d7a0-436c-aea5-0f97cc356805" />

---

Agent transcript: https://claudescope.sentry.dev/share/cZDy9dntdSsy9zqmFMWXt3k7pePm9eRHeb6qOCWJ2NQ