### PR TITLE
fix(ai-conversations): Ignore page filters on conversation detail

### DIFF
--- a/static/app/views/explore/conversations/hooks/useConversation.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversation.tsx
@@ -2,8 +2,6 @@ import {useEffect, useMemo} from 'react';
 import {skipToken, useInfiniteQuery} from '@tanstack/react-query';
 
 import {ALL_ACCESS_PROJECTS} from 'sentry/components/pageFilters/constants';
-import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
-import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {getGenAiOperationTypeFromSpanName} from 'sentry/views/insights/pages/agents/utils/query';
@@ -181,29 +179,23 @@ export function useConversation(
   conversation: UseConversationsOptions
 ): UseConversationResult {
   const organization = useOrganization();
-  const {selection} = usePageFilters();
 
-  // Use conversation timestamps when available (with 1-hour padding), falling back to page filters
   const ONE_HOUR_MS = 60 * 60 * 1000;
   const hasConversationTimestamps =
     conversation.startTimestamp !== undefined && conversation.endTimestamp !== undefined;
 
-  // When conversation timestamps are provided (e.g. from a shared link),
-  // search across all projects and environments so the conversation is found
-  // regardless of which project/environment the page filter is currently set to.
-  const queryParams = hasConversationTimestamps
-    ? {
-        project: [ALL_ACCESS_PROJECTS],
-        start: new Date(conversation.startTimestamp! - ONE_HOUR_MS).toISOString(),
-        end: new Date(conversation.endTimestamp! + ONE_HOUR_MS).toISOString(),
-        per_page: 1000,
-      }
-    : {
-        project: selection.projects,
-        environment: selection.environments,
-        ...normalizeDateTimeParams(selection.datetime),
-        per_page: 1000,
-      };
+  // Ignore page-filter project and stats period so the conversation is always
+  // found regardless of the current selection. When conversation timestamps
+  // are provided, narrow the window with 1-hour padding; otherwise let the
+  // backend default to its full retention range.
+  const queryParams = {
+    project: [ALL_ACCESS_PROJECTS],
+    per_page: 1000,
+    ...(hasConversationTimestamps && {
+      start: new Date(conversation.startTimestamp! - ONE_HOUR_MS).toISOString(),
+      end: new Date(conversation.endTimestamp! + ONE_HOUR_MS).toISOString(),
+    }),
+  };
 
   const {
     data,

--- a/static/app/views/explore/conversations/hooks/useConversation.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversation.tsx
@@ -184,10 +184,7 @@ export function useConversation(
   const hasConversationTimestamps =
     conversation.startTimestamp !== undefined && conversation.endTimestamp !== undefined;
 
-  // Ignore page-filter project and stats period so the conversation is always
-  // found regardless of the current selection. When conversation timestamps
-  // are provided, narrow the window with 1-hour padding; otherwise let the
-  // backend default to its full retention range.
+  // Ignore page filters so the conversation is always found.
   const queryParams = {
     project: [ALL_ACCESS_PROJECTS],
     per_page: 1000,

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiConversations.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiConversations.tsx
@@ -83,30 +83,39 @@ export function TraceAiConversations({
     [conversationIds]
   );
 
-  const conversationUrl = activeConversationId
+  const linkConversationId = activeConversationId ?? conversationIds[0] ?? null;
+  const conversationUrl = linkConversationId
     ? normalizeUrl(
-        `/organizations/${organization.slug}/explore/${CONVERSATIONS_LANDING_SUB_PATH}/${activeConversationId}/${selectedSpanId ? `?spanId=${encodeURIComponent(selectedSpanId)}` : ''}`
+        `/organizations/${organization.slug}/explore/${CONVERSATIONS_LANDING_SUB_PATH}/${linkConversationId}/${selectedSpanId && activeConversationId ? `?spanId=${encodeURIComponent(selectedSpanId)}` : ''}`
       )
     : null;
 
   return (
     <Container flex="1" minHeight="0" border="primary" radius="md" overflow="hidden">
       <Flex direction="column" height="100%">
-        {activeConversationId && conversationUrl && (
+        {activeConversationId && (
           <TraceConversationHeader
             conversationId={activeConversationId}
-            conversationUrl={conversationUrl}
             nodes={traceNodes}
             isLoading={isLoading}
           />
         )}
         <StyledTabs value={activeSubTab} onChange={handleTabChange}>
           <Container borderBottom="primary">
-            <TabList>
-              {tabItems.map(item => (
-                <TabList.Item key={item.key}>{item.label}</TabList.Item>
-              ))}
-            </TabList>
+            <Flex align="center" justify="between" gap="md">
+              <TabList>
+                {tabItems.map(item => (
+                  <TabList.Item key={item.key}>{item.label}</TabList.Item>
+                ))}
+              </TabList>
+              {conversationUrl && (
+                <Flex flexShrink={0} padding="0 lg">
+                  <LinkButton size="xs" to={conversationUrl}>
+                    {t('Show full conversation')}
+                  </LinkButton>
+                </Flex>
+              )}
+            </Flex>
           </Container>
           <FullHeightTabPanels>
             {tabItems.map(item =>
@@ -137,29 +146,20 @@ export function TraceAiConversations({
 
 function TraceConversationHeader({
   conversationId,
-  conversationUrl,
   nodes,
   isLoading,
 }: {
   conversationId: string;
-  conversationUrl: string;
   isLoading: boolean;
   nodes: AITraceSpanNode[];
 }) {
   return (
     <Container padding="md lg" borderBottom="primary">
-      <Flex align="center" justify="between" gap="md">
-        <ConversationAggregatesBar
-          nodes={nodes}
-          conversationId={conversationId}
-          isLoading={isLoading}
-        />
-        <Flex flexShrink={0}>
-          <LinkButton size="xs" to={conversationUrl}>
-            {t('Show full conversation')}
-          </LinkButton>
-        </Flex>
-      </Flex>
+      <ConversationAggregatesBar
+        nodes={nodes}
+        conversationId={conversationId}
+        isLoading={isLoading}
+      />
     </Container>
   );
 }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiConversations.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiConversations.tsx
@@ -126,7 +126,6 @@ export function TraceAiConversations({
                     nodeTraceMap={nodeTraceMap}
                     isLoading={isLoading}
                     error={error}
-                    conversationId={item.conversationId}
                     selectedSpanId={selectedSpanId}
                     onSelectSpan={handleSelectSpan}
                   />
@@ -165,7 +164,6 @@ function TraceConversationHeader({
 }
 
 function TraceConversationChat({
-  conversationId,
   nodes,
   nodeTraceMap,
   isLoading,
@@ -173,7 +171,6 @@ function TraceConversationChat({
   selectedSpanId,
   onSelectSpan,
 }: {
-  conversationId: string;
   error: boolean;
   isLoading: boolean;
   nodeTraceMap: Map<string, string>;
@@ -181,8 +178,6 @@ function TraceConversationChat({
   onSelectSpan: (spanId: string) => void;
   selectedSpanId: string | null;
 }) {
-  const organization = useOrganization();
-
   const {selectedNode, handleSelectNode} = useConversationSelection({
     nodes,
     selectedSpanId,
@@ -199,17 +194,8 @@ function TraceConversationChat({
   }
 
   if (nodes.length === 0) {
-    const conversationUrl = normalizeUrl(
-      `/organizations/${organization.slug}/explore/${CONVERSATIONS_LANDING_SUB_PATH}/${conversationId}/`
-    );
     return (
-      <EmptyMessage
-        action={
-          <LinkButton size="sm" to={conversationUrl}>
-            {t('Show full conversation')}
-          </LinkButton>
-        }
-      >
+      <EmptyMessage>
         {t('No chat messages in this portion of the conversation')}
       </EmptyMessage>
     );

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiConversations.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiConversations.tsx
@@ -101,22 +101,22 @@ export function TraceAiConversations({
           />
         )}
         <StyledTabs value={activeSubTab} onChange={handleTabChange}>
-          <Container borderBottom="primary">
-            <Flex align="center" justify="between" gap="md">
+          <Flex direction="row" justify="between" align="center" borderBottom="primary">
+            <Container width="100%" minWidth="0">
               <TabList>
                 {tabItems.map(item => (
                   <TabList.Item key={item.key}>{item.label}</TabList.Item>
                 ))}
               </TabList>
-              {conversationUrl && (
-                <Flex flexShrink={0} padding="0 lg">
-                  <LinkButton size="xs" to={conversationUrl}>
-                    {t('Show full conversation')}
-                  </LinkButton>
-                </Flex>
-              )}
-            </Flex>
-          </Container>
+            </Container>
+            {conversationUrl && (
+              <Flex flexShrink={0} padding="0 lg">
+                <LinkButton size="xs" to={conversationUrl}>
+                  {t('Show full conversation')}
+                </LinkButton>
+              </Flex>
+            )}
+          </Flex>
           <FullHeightTabPanels>
             {tabItems.map(item =>
               item.conversationId ? (


### PR DESCRIPTION
The conversation detail page now ignores page-filter project, environment, and stats period so spans aren't hidden by the active selection. The "Show full conversation" link also moves onto the tab row so it's always visible when a conversation id is present.

Fixes TET-2269