### PR TITLE
fix(feedback): Render AiPrivacyNotice inline with spam detection description

### DIFF
--- a/static/app/views/settings/projectUserFeedback/index.tsx
+++ b/static/app/views/settings/projectUserFeedback/index.tsx
@@ -203,9 +203,9 @@ export default function ProjectUserFeedback() {
                       <Text size="sm" variant="muted">
                         {t(
                           'Toggles whether or not to enable auto spam detection in User Feedback.'
-                        )}
+                        )}{' '}
+                        <AiPrivacyNotice />
                       </Text>
-                      <AiPrivacyNotice />
                     </field.Layout.Stack>
                   )}
                 </AutoSaveForm>


### PR DESCRIPTION
Move `AiPrivacyNotice` inside the muted description `Text` for the "Enable Spam Detection" toggle so the notice flows inline with the surrounding copy instead of rendering as a separate block beneath it.

---

Before:

<img width="2542" height="1086" alt="CleanShot 2026-04-28 at 13 30 35@2x" src="https://github.com/user-attachments/assets/d86f14d0-5fa9-4de0-ae72-b4b91f7e7ee8" />

---

After:

<img width="2534" height="1088" alt="CleanShot 2026-04-28 at 13 30 24@2x" src="https://github.com/user-attachments/assets/7cb97142-f417-45eb-a5c5-d1cf868ceab3" />

---

Agent transcript: https://claudescope.sentry.dev/share/QVleynSd_XXIfd9VA9-rjxlOiXheNactszNG3txqLzA