### PR TITLE
feat(preprod): Pare down dashboard search bar filters (EME-1047)

### DIFF
--- a/static/app/components/preprod/constants.ts
+++ b/static/app/components/preprod/constants.ts
@@ -28,3 +28,16 @@ export const MOBILE_BUILDS_ALLOWED_KEYS = [
   'is_approved',
   'platform_name',
 ];
+
+export const MOBILE_BUILDS_DASHBOARD_ALLOWED_KEYS = [
+  'app_id',
+  'app_name',
+  'artifact_type',
+  'build_number',
+  'git_base_ref',
+  'git_base_sha',
+  'git_head_ref',
+  'git_head_sha',
+  'git_pr_number',
+  'platform_name',
+];

--- a/static/app/views/dashboards/datasetConfig/mobileAppSize.tsx
+++ b/static/app/views/dashboards/datasetConfig/mobileAppSize.tsx
@@ -1,4 +1,5 @@
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {MOBILE_BUILDS_DASHBOARD_ALLOWED_KEYS} from 'sentry/components/preprod/constants';
 import {PreprodSearchBar} from 'sentry/components/preprod/preprodSearchBar';
 import type {PageFilters} from 'sentry/types/core';
 import type {Series} from 'sentry/types/echarts';
@@ -181,6 +182,7 @@ function MobileAppSizeSearchBar({
       onSearch={onSearch}
       portalTarget={portalTarget}
       searchSource="dashboards"
+      allowedKeys={MOBILE_BUILDS_DASHBOARD_ALLOWED_KEYS}
       onChange={(query, state) => {
         onClose?.(query, {validSearch: state.queryIsValid});
       }}

--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -143,6 +143,7 @@ export const HIDDEN_PREPROD_ATTRIBUTES = [
   'metrics_artifact_type',
   'tags[metrics_artifact_type,number]',
   'tags[artifact_type,number]',
+  'tags[git_pr_number,number]',
   ...PREPROD_IMAGE_FIELDS,
   'is_approved',
 ];


### PR DESCRIPTION
## Summary

The Mobile Builds dashboard dataset rendered `PreprodSearchBar` without an `allowedKeys` prop, exposing every PREPROD attribute returned by `/trace-items/attributes/` minus `HIDDEN_PREPROD_ATTRIBUTES` — far too noisy. This narrows the dashboards search bar to a curated 10-field allowlist (`app_id`, `app_name`, `artifact_type`, `platform_name`, `build_number`, `git_base_ref`, `git_base_sha`, `git_head_ref`, `git_head_sha`, `git_pr_number`).

Also suppresses the duplicate generic-numeric `tags[git_pr_number,number]` across all preprod surfaces (dashboards, snapshots, builds list) by adding it to `HIDDEN_PREPROD_ATTRIBUTES`, matching the existing pattern for `build_number` and `artifact_date_built`.

Other Mobile Builds surfaces (builds list, snapshots tab) keep their existing allowlists; trimming those is tracked separately under EME-1071.

Issue: https://linear.app/getsentry/issue/EME-1047/parse-down-filters-on-dashboards