### PR TITLE
feat(preprod): Register git_* attributes in EAP attribute registry (EME-1047)

### DIFF
--- a/src/sentry/search/eap/preprod_size/attributes.py
+++ b/src/sentry/search/eap/preprod_size/attributes.py
@@ -54,8 +54,23 @@ PREPROD_SIZE_ATTRIBUTE_DEFINITIONS = {
             search_type="string",
         ),
         ResolvedAttribute(
+            public_alias="git_base_ref",
+            internal_name="git_base_ref",
+            search_type="string",
+        ),
+        ResolvedAttribute(
+            public_alias="git_base_sha",
+            internal_name="git_base_sha",
+            search_type="string",
+        ),
+        ResolvedAttribute(
             public_alias="git_head_ref",
             internal_name="git_head_ref",
+            search_type="string",
+        ),
+        ResolvedAttribute(
+            public_alias="git_head_sha",
+            internal_name="git_head_sha",
             search_type="string",
         ),
         ResolvedAttribute(

--- a/src/sentry/search/eap/preprod_size/attributes.py
+++ b/src/sentry/search/eap/preprod_size/attributes.py
@@ -59,6 +59,11 @@ PREPROD_SIZE_ATTRIBUTE_DEFINITIONS = {
             search_type="string",
         ),
         ResolvedAttribute(
+            public_alias="git_pr_number",
+            internal_name="git_pr_number",
+            search_type="integer",
+        ),
+        ResolvedAttribute(
             public_alias="installable",
             internal_name="has_installable_file",
             search_type="boolean",


### PR DESCRIPTION
## Summary

Several `git_*` fields are written to EAP by `produce_preprod_size_metric_to_eap` and `produce_preprod_build_distribution_to_eap` and are on the EME-1047 dashboard keep-list, but were missing from `PREPROD_SIZE_ATTRIBUTE_DEFINITIONS` in `src/sentry/search/eap/preprod_size/attributes.py`. Without a typed registration:

- `translate_internal_to_public_alias` falls through to the `USER` source path.
- The trace-items/attributes endpoint exposes the field under the generic `tags[<name>,<type>]` form.
- Combined with the frontend static default (`SENTRY_PREPROD_*_TAGS`), autocomplete surfaces two entries for the same field.

This registers the missing attributes alongside the existing `git_head_ref` entry so each one resolves to a canonical Sentry-source alias and the duplicate generic copies disappear at the source:

- `git_pr_number` — `search_type="integer"` (written as `int_value`)
- `git_base_ref`, `git_base_sha`, `git_head_sha` — `search_type="string"`

Issue: https://linear.app/getsentry/issue/EME-1047/parse-down-filters-on-dashboards