### PR TITLE
feat(tracemetrics): Change beta flags to new flags

### DIFF
--- a/static/app/views/alerts/wizard/options.tsx
+++ b/static/app/views/alerts/wizard/options.tsx
@@ -118,7 +118,7 @@ export const AlertWizardAlertNames: Record<AlertType, string> = {
  */
 export const AlertWizardExtraContent: Partial<Record<AlertType, React.ReactNode>> = {
   uptime_monitor: <FeatureBadge type="new" />,
-  trace_item_metrics: <FeatureBadge type="beta" />,
+  trace_item_metrics: <FeatureBadge type="new" />,
 };
 
 type AlertWizardCategory = {

--- a/static/app/views/detectors/components/forms/metric/useDatasetChoices.tsx
+++ b/static/app/views/detectors/components/forms/metric/useDatasetChoices.tsx
@@ -59,7 +59,7 @@ export function useDatasetChoices(): Array<SelectValue<DetectorDataset>> {
             {
               value: DetectorDataset.METRICS,
               label: t('Application Metrics'),
-              trailingItems: <FeatureBadge type="beta" />,
+              trailingItems: <FeatureBadge type="new" />,
             },
           ]
         : []),

--- a/static/app/views/explore/metrics/content.tsx
+++ b/static/app/views/explore/metrics/content.tsx
@@ -132,7 +132,7 @@ function MetricsHeader() {
           ) : (
             title || METRICS_TITLE
           )}
-          <FeatureBadge type="beta" />
+          <FeatureBadge type="new" />
           {titleTooltip}
         </TopBar.Slot>
         <TopBar.Slot name="feedback">
@@ -160,7 +160,7 @@ function MetricsHeader() {
         ) : null}
         <Layout.Title>
           {title || METRICS_TITLE}
-          <FeatureBadge type="beta" />
+          <FeatureBadge type="new" />
           {titleTooltip}
         </Layout.Title>
       </Layout.HeaderContent>

--- a/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
@@ -56,7 +56,7 @@ export function ExploreSecondaryNavigation() {
                 <SecondaryNavigation.Link
                   to={`${baseUrl}/metrics/`}
                   analyticsItemName="explore_metrics"
-                  trailingItems={<FeatureBadge type="beta" />}
+                  trailingItems={<FeatureBadge type="new" />}
                 >
                   {t('Metrics')}
                 </SecondaryNavigation.Link>


### PR DESCRIPTION
Updates the `BETA` flags to `NEW` flags in the sidebar, metrics explore page header, and a few places in alerts.