### PR TITLE
fix(replays): Require project:write or project:admin to delete a replay

### DIFF
--- a/src/sentry/replays/endpoints/project_replay_details.py
+++ b/src/sentry/replays/endpoints/project_replay_details.py
@@ -23,7 +23,7 @@ class ReplayDetailsPermission(ProjectPermission):
         "GET": ["project:read", "project:write", "project:admin"],
         "POST": ["project:write", "project:admin"],
         "PUT": ["project:write", "project:admin"],
-        "DELETE": ["project:read", "project:write", "project:admin"],
+        "DELETE": ["project:write", "project:admin"],
     }
 
 

--- a/tests/sentry/replays/endpoints/test_project_replay_details.py
+++ b/tests/sentry/replays/endpoints/test_project_replay_details.py
@@ -151,13 +151,18 @@ class ProjectReplayDetailsTest(APITestCase, ReplaysSnubaTestCase):
             )
             assert_expected_response(response_data["data"], expected_response)
 
-    def test_delete_replay_from_filestore(self) -> None:
-        """Test deleting files uploaded through the filestore interface."""
-        # test deleting as a member, as they should be able to
+    def test_delete_forbidden_for_project_read_only_member(self) -> None:
+        """Members with only project:read cannot delete replays."""
         user = self.create_user(is_superuser=False)
         self.create_member(user=user, organization=self.organization, role="member", teams=[])
         self.login_as(user=user)
 
+        with self.feature(REPLAYS_FEATURES):
+            response = self.client.delete(self.url)
+            assert response.status_code == 403
+
+    def test_delete_replay_from_filestore(self) -> None:
+        """Test deleting files uploaded through the filestore interface."""
         file = File.objects.create(name="recording-segment-0", type="application/octet-stream")
         file.putfile(BytesIO(b"replay-recording-segment"))
 


### PR DESCRIPTION
Replay DELETE previously accepted project:read, allowing read-only members to destroy replays. Tighten the scope_map to match other destructive verbs on the project endpoint.

Update test_delete_replay_from_filestore to use the default owner fixture and add test_delete_forbidden_for_project_read_only_member covering the new contract.

GH-20077
