### PR TITLE
feat(integrations): Add SCM_INTEGRATION_CONFIG_BACKFILL outbox category

### DIFF
--- a/src/sentry/hybridcloud/outbox/category.py
+++ b/src/sentry/hybridcloud/outbox/category.py
@@ -66,6 +66,7 @@ class OutboxCategory(IntEnum):
     IDENTITY_UPDATE = 43
     SENTRY_APP_NORMALIZE_ACTIONS = 44
     PROJECT_KEY_UPDATE = 45
+    SCM_INTEGRATION_CONFIG_BACKFILL = 46
 
     @classmethod
     def as_choices(cls) -> Sequence[tuple[int, int]]:
@@ -281,6 +282,7 @@ class OutboxScope(IntEnum):
             OutboxCategory.SEND_VERCEL_INVOICE,
             OutboxCategory.FTC_CONSENT,
             OutboxCategory.PROJECT_KEY_UPDATE,
+            OutboxCategory.SCM_INTEGRATION_CONFIG_BACKFILL,
         },
     )
     USER_SCOPE = scope_categories(

--- a/src/sentry/receivers/outbox/cell.py
+++ b/src/sentry/receivers/outbox/cell.py
@@ -17,7 +17,7 @@ from sentry import options
 from sentry.audit_log.services.log import AuditLogEvent, UserIpEvent, log_rpc_service
 from sentry.auth.services.auth import auth_service
 from sentry.auth.services.orgauthtoken import orgauthtoken_rpc_service
-from sentry.constants import SentryAppInstallationStatus
+from sentry.constants import ObjectStatus, SentryAppInstallationStatus
 from sentry.hybridcloud.outbox.category import OutboxCategory
 from sentry.hybridcloud.outbox.signals import process_cell_outbox
 from sentry.hybridcloud.services.organization_mapping import organization_mapping_service
@@ -25,6 +25,7 @@ from sentry.hybridcloud.services.organization_mapping.model import CustomerId
 from sentry.hybridcloud.services.organization_mapping.serial import (
     update_organization_mapping_from_instance,
 )
+from sentry.integrations.services.integration import integration_service
 from sentry.models.authproviderreplica import AuthProviderReplica
 from sentry.models.files.utils import get_relocation_storage
 from sentry.models.organization import Organization
@@ -82,6 +83,79 @@ def update_sentry_app_action_data(
 
     except Action.DoesNotExist:
         logger.info("Could not update Action", extra={"action_id": shard_identifier})
+
+
+# Maps integration provider -> list of (legacy OrganizationOption key, OI
+# config key) pairs used by the SCM_INTEGRATION_CONFIG_BACKFILL receiver.
+_SCM_BACKFILL_PROVIDER_KEYS: dict[str, list[tuple[str, str]]] = {
+    "github": [
+        ("sentry:github_pr_bot", "pr_comments"),
+        ("sentry:github_nudge_invite", "nudge_invite"),
+    ],
+    "gitlab": [
+        ("sentry:gitlab_pr_bot", "pr_comments"),
+    ],
+}
+
+
+@receiver(process_cell_outbox, sender=OutboxCategory.SCM_INTEGRATION_CONFIG_BACKFILL)
+def backfill_scm_integration_config(shard_identifier: int, payload: Any, **kwds: Any) -> None:
+    """
+    Carry legacy `OrganizationOption`-backed SCM toggles onto each ACTIVE
+    GitHub/GitLab `OrganizationIntegration.config` for an org. The
+    sentry/migrations/1072_backfill_scm_integration_config migration emits
+    one cell outbox per affected org with `payload={"keys": [...]}` listing
+    the legacy option keys whose value is True.
+
+    The receiver runs on the cell silo so it can issue an authenticated RPC
+    to the control silo (which the migration CLI cannot do reliably). Any
+    RPC failure propagates to the outbox runner, which retries the outbox
+    on its own schedule -- no toggle is silently dropped.
+    """
+    organization_id = shard_identifier
+    keys: set[str] = set((payload or {}).get("keys", []))
+    if not keys:
+        return
+
+    for provider, key_pairs in _SCM_BACKFILL_PROVIDER_KEYS.items():
+        # Skip providers whose owned keys aren't set on this org.
+        if not any(opt_key in keys for opt_key, _ in key_pairs):
+            continue
+
+        ois = integration_service.get_organization_integrations(
+            organization_id=organization_id,
+            providers=[provider],
+            status=ObjectStatus.ACTIVE,
+        )
+
+        # An org can have multiple ACTIVE installs of the same provider
+        # (multi-org GitHub apps); each gets its own per-install config.
+        for oi in ois:
+            config = dict(oi.config or {})
+            set_keys: list[str] = []
+            # Backfill every owned key that's true on the org and not
+            # already present on the OI. Keys already set are left alone --
+            # the per-install UI may have set them explicitly.
+            for opt_key, cfg_key in key_pairs:
+                if opt_key in keys and cfg_key not in config:
+                    config[cfg_key] = True
+                    set_keys.append(cfg_key)
+
+            if not set_keys:
+                continue
+
+            integration_service.update_organization_integration(
+                org_integration_id=oi.id, config=config
+            )
+            logger.info(
+                "scm_backfill.set",
+                extra={
+                    "organization_id": organization_id,
+                    "org_integration_id": oi.id,
+                    "provider": provider,
+                    "keys": set_keys,
+                },
+            )
 
 
 @receiver(process_cell_outbox, sender=OutboxCategory.AUDIT_LOG_EVENT)

--- a/tests/sentry/receivers/outbox/test_cell.py
+++ b/tests/sentry/receivers/outbox/test_cell.py
@@ -1,0 +1,118 @@
+from typing import Any
+
+from sentry.constants import ObjectStatus
+from sentry.integrations.models.integration import Integration
+from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.receivers.outbox.cell import backfill_scm_integration_config
+from sentry.silo.base import SiloMode
+from sentry.testutils.cases import TestCase
+from sentry.testutils.silo import assume_test_silo_mode
+
+
+class BackfillScmIntegrationConfigReceiverTest(TestCase):
+    def _create_oi(
+        self,
+        provider: str,
+        external_id: str,
+        config: dict[str, Any] | None = None,
+        status: int = ObjectStatus.ACTIVE,
+    ) -> OrganizationIntegration:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            integration = Integration.objects.create(
+                provider=provider,
+                external_id=external_id,
+                name=f"{provider}-{external_id}",
+            )
+            return OrganizationIntegration.objects.create(
+                organization_id=self.organization.id,
+                integration_id=integration.id,
+                status=status,
+                config=config or {},
+            )
+
+    def _read_config(self, oi: OrganizationIntegration) -> dict[str, Any]:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            return OrganizationIntegration.objects.get(id=oi.id).config
+
+    def test_backfills_github_keys(self) -> None:
+        oi = self._create_oi(provider="github", external_id="gh")
+
+        backfill_scm_integration_config(
+            shard_identifier=self.organization.id,
+            payload={"keys": ["sentry:github_pr_bot", "sentry:github_nudge_invite"]},
+        )
+
+        assert self._read_config(oi) == {"pr_comments": True, "nudge_invite": True}
+
+    def test_backfills_gitlab_key(self) -> None:
+        oi = self._create_oi(provider="gitlab", external_id="gl")
+
+        backfill_scm_integration_config(
+            shard_identifier=self.organization.id,
+            payload={"keys": ["sentry:gitlab_pr_bot"]},
+        )
+
+        assert self._read_config(oi) == {"pr_comments": True}
+
+    def test_preserves_existing_config_keys(self) -> None:
+        oi = self._create_oi(
+            provider="github",
+            external_id="gh",
+            config={"pr_comments": False, "other": "kept"},
+        )
+
+        backfill_scm_integration_config(
+            shard_identifier=self.organization.id,
+            payload={"keys": ["sentry:github_pr_bot", "sentry:github_nudge_invite"]},
+        )
+
+        config = self._read_config(oi)
+        assert config["pr_comments"] is False
+        assert config["nudge_invite"] is True
+        assert config["other"] == "kept"
+
+    def test_skips_provider_with_no_matching_keys(self) -> None:
+        gl = self._create_oi(provider="gitlab", external_id="gl")
+
+        backfill_scm_integration_config(
+            shard_identifier=self.organization.id,
+            payload={"keys": ["sentry:github_pr_bot"]},
+        )
+
+        assert self._read_config(gl) == {}
+
+    def test_skips_disabled_oi(self) -> None:
+        oi = self._create_oi(provider="github", external_id="gh", status=ObjectStatus.DISABLED)
+
+        backfill_scm_integration_config(
+            shard_identifier=self.organization.id,
+            payload={"keys": ["sentry:github_pr_bot"]},
+        )
+
+        assert self._read_config(oi) == {}
+
+    def test_updates_multiple_active_ois_of_same_provider(self) -> None:
+        gh1 = self._create_oi(provider="github", external_id="gh-1")
+        gh2 = self._create_oi(provider="github", external_id="gh-2")
+
+        backfill_scm_integration_config(
+            shard_identifier=self.organization.id,
+            payload={"keys": ["sentry:github_pr_bot"]},
+        )
+
+        assert self._read_config(gh1) == {"pr_comments": True}
+        assert self._read_config(gh2) == {"pr_comments": True}
+
+    def test_empty_payload_is_noop(self) -> None:
+        oi = self._create_oi(provider="github", external_id="gh")
+
+        backfill_scm_integration_config(shard_identifier=self.organization.id, payload={})
+
+        assert self._read_config(oi) == {}
+
+    def test_no_active_oi_for_provider_is_noop(self) -> None:
+        # No OI created for the org.
+        backfill_scm_integration_config(
+            shard_identifier=self.organization.id,
+            payload={"keys": ["sentry:github_pr_bot"]},
+        )


### PR DESCRIPTION
Phase 4.5 of [VDY-110](https://linear.app/getsentry/issue/VDY-110/). The merged backfill migration (#114046) is failing in prod with `RpcRemoteException: Service unavailable (401 status)` because the migration CLI doesn't have a stable RPC auth context to the control silo.

This PR lays the outbox groundwork that lets a follow-up rewrite the migration to emit one cell outbox per affected org instead of issuing RPC directly:

- New `OutboxCategory.SCM_INTEGRATION_CONFIG_BACKFILL` registered to `ORGANIZATION_SCOPE`.
- New `backfill_scm_integration_config` receiver in `receivers/outbox/cell.py`. It reads `payload={"keys": [...]}`, fans out to every ACTIVE GitHub/GitLab OrganizationIntegration for the org, and merges in the legacy toggle keys whose value was True. Existing config keys are preserved (per-install UI may have set them explicitly). RPC failures propagate so the outbox runner retries.

The migration body switch lands in a follow-up so the receiver is deployed before any outbox rows can show up. Patterned after [PR #107208](https://github.com/getsentry/sentry/pull/107208).