### PR TITLE
ref(dashboards): Clean up RevisionListItem logic and naming

### DIFF
--- a/static/app/views/dashboards/revisionListItem.stories.tsx
+++ b/static/app/views/dashboards/revisionListItem.stories.tsx
@@ -47,7 +47,7 @@ export default Storybook.story('RevisionListItem', story => {
     return (
       <ItemContainer>
         <RevisionDiffBody
-          isAnyLoading
+          isLoading
           isError={false}
           snapshot={undefined}
           baseRevisionId={null}
@@ -61,7 +61,7 @@ export default Storybook.story('RevisionListItem', story => {
     return (
       <ItemContainer>
         <RevisionDiffBody
-          isAnyLoading={false}
+          isLoading={false}
           isError
           snapshot={undefined}
           baseRevisionId={null}

--- a/static/app/views/dashboards/revisionListItem.stories.tsx
+++ b/static/app/views/dashboards/revisionListItem.stories.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 
 import * as Storybook from 'sentry/stories';
 
-import {RevisionListItem} from './revisionListItem';
+import {RevisionDiffBody, RevisionListItem} from './revisionListItem';
 import type {DashboardDetails} from './types';
 import {DisplayType} from './types';
 
@@ -40,6 +40,34 @@ export default Storybook.story('RevisionListItem', story => {
           appears and the Revert button in the modal footer becomes enabled.
         </p>
       </Fragment>
+    );
+  });
+
+  story('Loading', () => {
+    return (
+      <ItemContainer>
+        <RevisionDiffBody
+          isAnyLoading
+          isError={false}
+          snapshot={undefined}
+          baseRevisionId={null}
+          baseSnapshot={undefined}
+        />
+      </ItemContainer>
+    );
+  });
+
+  story('Error', () => {
+    return (
+      <ItemContainer>
+        <RevisionDiffBody
+          isAnyLoading={false}
+          isError
+          snapshot={undefined}
+          baseRevisionId={null}
+          baseSnapshot={undefined}
+        />
+      </ItemContainer>
     );
   });
 

--- a/static/app/views/dashboards/revisionListItem.tsx
+++ b/static/app/views/dashboards/revisionListItem.tsx
@@ -87,6 +87,7 @@ export function RevisionListItem({
   const isAnyLoading = isSnapshotLoading || isBaseLoading;
   const isBaseError =
     !baseSnapshotOverride && baseRevisionId !== null && isBaseFetchError;
+  const isError = (!snapshotOverride && isSnapshotError) || isBaseError;
 
   const userForAvatar = createdBy
     ? ({
@@ -133,30 +134,54 @@ export function RevisionListItem({
             </Flex>
           </Flex>
 
-          {isAnyLoading ? (
-            <LoadingIndicator />
-          ) : (!snapshotOverride && isSnapshotError) || isBaseError ? (
-            <Text size="sm" variant="muted">
-              {t('Failed to load revision preview.')}
-            </Text>
-          ) : snapshot && baseRevisionId === null ? (
-            <Text size="sm" variant="muted">
-              {t('This is the oldest revision — no previous state to compare against.')}
-            </Text>
-          ) : snapshot ? (
-            <Flex direction="column" gap="xl">
-              <FilterDiffSection
-                base={baseSnapshot ?? EMPTY_SNAPSHOT}
-                snapshot={snapshot}
-              />
-              <WidgetDiffSection
-                widgetChanges={diffWidgets(baseSnapshot ?? EMPTY_SNAPSHOT, snapshot)}
-              />
-            </Flex>
-          ) : null}
+          <RevisionDiffBody
+            isAnyLoading={isAnyLoading}
+            isError={isError}
+            snapshot={snapshot}
+            baseRevisionId={baseRevisionId}
+            baseSnapshot={baseSnapshot}
+          />
         </Flex>
       </Flex>
     </RevisionItem>
+  );
+}
+
+function RevisionDiffBody({
+  isAnyLoading,
+  isError,
+  snapshot,
+  baseRevisionId,
+  baseSnapshot,
+}: {
+  baseRevisionId: string | null;
+  baseSnapshot: DashboardDetails | undefined;
+  isAnyLoading: boolean;
+  isError: boolean;
+  snapshot: DashboardDetails | undefined;
+}) {
+  if (isAnyLoading) return <LoadingIndicator />;
+  if (isError) {
+    return (
+      <Text size="sm" variant="muted">
+        {t('Failed to load revision preview.')}
+      </Text>
+    );
+  }
+  if (!snapshot) return null;
+  if (baseRevisionId === null) {
+    return (
+      <Text size="sm" variant="muted">
+        {t('This is the oldest revision — no previous state to compare against.')}
+      </Text>
+    );
+  }
+  const base = baseSnapshot ?? EMPTY_SNAPSHOT;
+  return (
+    <Flex direction="column" gap="xl">
+      <FilterDiffSection base={base} snapshot={snapshot} />
+      <WidgetDiffSection widgetChanges={diffWidgets(base, snapshot)} />
+    </Flex>
   );
 }
 

--- a/static/app/views/dashboards/revisionListItem.tsx
+++ b/static/app/views/dashboards/revisionListItem.tsx
@@ -230,15 +230,16 @@ function WidgetDiffCard({change}: {change: WidgetChange}) {
   const fields = status === 'modified' ? change.fields : undefined;
   const layoutChanged = status === 'modified' ? change.layoutChanged : false;
 
-  let statusLabel: string;
-  if (status === 'added') statusLabel = t('Added');
-  else if (status === 'removed') statusLabel = t('Removed');
-  else statusLabel = t('Modified');
+  const STATUS_MAP: Record<
+    WidgetChange['status'],
+    {label: string; variant: 'success' | 'danger' | 'warning'}
+  > = {
+    added: {label: t('Added'), variant: 'success'},
+    removed: {label: t('Removed'), variant: 'danger'},
+    modified: {label: t('Modified'), variant: 'warning'},
+  };
 
-  let tagVariant: 'success' | 'danger' | 'warning';
-  if (status === 'added') tagVariant = 'success';
-  else if (status === 'removed') tagVariant = 'danger';
-  else tagVariant = 'warning';
+  const {label: statusLabel, variant: tagVariant} = STATUS_MAP[status];
 
   return (
     <Flex direction="column" gap="sm" border="secondary" radius="sm" padding="md">

--- a/static/app/views/dashboards/revisionListItem.tsx
+++ b/static/app/views/dashboards/revisionListItem.tsx
@@ -11,6 +11,7 @@ import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {IconGraph} from 'sentry/icons/iconGraph';
 import {t} from 'sentry/locale';
 import type {User} from 'sentry/types/user';
+import type {TagVariant} from 'sentry/utils/theme';
 import {useProjects} from 'sentry/utils/useProjects';
 
 import type {DashboardRevision} from './hooks/useDashboardRevisions';
@@ -135,7 +136,7 @@ export function RevisionListItem({
           </Flex>
 
           <RevisionDiffBody
-            isAnyLoading={isAnyLoading}
+            isLoading={isAnyLoading}
             isError={isError}
             snapshot={snapshot}
             baseRevisionId={baseRevisionId}
@@ -148,7 +149,7 @@ export function RevisionListItem({
 }
 
 export function RevisionDiffBody({
-  isAnyLoading,
+  isLoading,
   isError,
   snapshot,
   baseRevisionId,
@@ -156,11 +157,11 @@ export function RevisionDiffBody({
 }: {
   baseRevisionId: string | null;
   baseSnapshot: DashboardDetails | undefined;
-  isAnyLoading: boolean;
   isError: boolean;
+  isLoading: boolean;
   snapshot: DashboardDetails | undefined;
 }) {
-  if (isAnyLoading) return <LoadingIndicator />;
+  if (isLoading) return <LoadingIndicator />;
   if (isError) {
     return (
       <Text size="sm" variant="muted">
@@ -255,14 +256,12 @@ function WidgetDiffCard({change}: {change: WidgetChange}) {
   const fields = status === 'modified' ? change.fields : undefined;
   const layoutChanged = status === 'modified' ? change.layoutChanged : false;
 
-  const STATUS_MAP: Record<
-    WidgetChange['status'],
-    {label: string; variant: 'success' | 'danger' | 'warning'}
-  > = {
-    added: {label: t('Added'), variant: 'success'},
-    removed: {label: t('Removed'), variant: 'danger'},
-    modified: {label: t('Modified'), variant: 'warning'},
-  };
+  const STATUS_MAP: Record<WidgetChange['status'], {label: string; variant: TagVariant}> =
+    {
+      added: {label: t('Added'), variant: 'success'},
+      removed: {label: t('Removed'), variant: 'danger'},
+      modified: {label: t('Modified'), variant: 'warning'},
+    };
 
   const {label: statusLabel, variant: tagVariant} = STATUS_MAP[status];
 

--- a/static/app/views/dashboards/revisionListItem.tsx
+++ b/static/app/views/dashboards/revisionListItem.tsx
@@ -15,7 +15,7 @@ import {useProjects} from 'sentry/utils/useProjects';
 
 import type {DashboardRevision} from './hooks/useDashboardRevisions';
 import {useDashboardRevisionDetails} from './hooks/useDashboardRevisions';
-import {typeIcons} from './widgetBuilder/components/typeSelector';
+import {DISPLAY_TYPE_ICONS} from './widgetBuilder/components/typeSelector';
 import type {WidgetChange} from './dashboardRevisionsDiff';
 import {diffFilters, diffWidgets, formatProjectIds} from './dashboardRevisionsDiff';
 import type {DashboardDetails} from './types';
@@ -275,7 +275,7 @@ function WidgetDiffCard({change}: {change: WidgetChange}) {
             flexShrink={0}
             style={{color: theme.tokens.content.secondary}}
           >
-            {typeIcons[widget.displayType] ?? <IconGraph />}
+            {DISPLAY_TYPE_ICONS[widget.displayType] ?? <IconGraph />}
           </Flex>
           <Text
             bold

--- a/static/app/views/dashboards/revisionListItem.tsx
+++ b/static/app/views/dashboards/revisionListItem.tsx
@@ -147,7 +147,7 @@ export function RevisionListItem({
   );
 }
 
-function RevisionDiffBody({
+export function RevisionDiffBody({
   isAnyLoading,
   isError,
   snapshot,

--- a/static/app/views/dashboards/widgetBuilder/components/typeSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/typeSelector.tsx
@@ -19,7 +19,7 @@ import {useIsEditingWidget} from 'sentry/views/dashboards/widgetBuilder/hooks/us
 import {BuilderStateAction} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderState';
 import {convertWidgetToBuilderState} from 'sentry/views/dashboards/widgetBuilder/utils/convertWidgetToBuilderStateParams';
 
-export const typeIcons: Partial<Record<DisplayType, React.ReactNode>> = {
+export const DISPLAY_TYPE_ICONS: Partial<Record<DisplayType, React.ReactNode>> = {
   [DisplayType.AREA]: <IconGraph key="area" type="area" />,
   [DisplayType.BAR]: <IconGraph key="bar" type="bar" />,
   [DisplayType.LINE]: <IconGraph key="line" type="line" />,
@@ -166,7 +166,7 @@ export function WidgetBuilderTypeSelector({
         <CompactSelect
           value={state.displayType}
           options={displayTypeOrder.map(({type, label, details}) => ({
-            leadingItems: typeIcons[type],
+            leadingItems: DISPLAY_TYPE_ICONS[type],
             label,
             value: type,
             details,


### PR DESCRIPTION
Small readability refactors to `RevisionListItem` and `typeSelector` — no behavior changes.

* Add mappers and a new component function  for rendering different widget diff statuses
* rename of the widget display map constant
