### PR TITLE
fix(slack): Default dashboard unfurl to My Projects, not All Projects

### DIFF
--- a/src/sentry/integrations/slack/unfurl/dashboards.py
+++ b/src/sentry/integrations/slack/unfurl/dashboards.py
@@ -16,7 +16,6 @@ from sentry.api import client
 from sentry.api.endpoints.timeseries import TimeSeries
 from sentry.charts import backend as charts
 from sentry.charts.types import ChartSize, ChartType
-from sentry.constants import ALL_ACCESS_PROJECT_ID
 from sentry.integrations.messaging.metrics import (
     MessagingInteractionEvent,
     MessagingInteractionType,
@@ -302,14 +301,13 @@ def _apply_page_filters(
     reachable from a webhook context.
     """
     # project: URL wins. Otherwise fall back to the dashboard's projects.
-    # An unconfigured dashboard (no projects, no all_projects) falls through
-    # to "All Projects" so the unfurl shows data instead of an empty chart.
+    # An unconfigured dashboard (no projects, no all_projects) omits the
+    # param so the API defaults to "My Projects", matching the dashboard FE.
     project_values = url_params.getlist("project")
     if not project_values:
         project_values = [str(p) for p in dashboard_filters.get("projects") or []]
-    if not project_values:
-        project_values = [str(ALL_ACCESS_PROJECT_ID)]
-    params["project"] = project_values if len(project_values) > 1 else project_values[0]
+    if project_values:
+        params["project"] = project_values if len(project_values) > 1 else project_values[0]
 
     # environment: URL wins. Otherwise fall back to dashboard, or omit (no
     # filter) to match the FE default of "All Environments".

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -2578,14 +2578,14 @@ class BuildWidgetTimeseriesParamsTest(TestCase):
         assert params["start"] == "2026-01-01T00:00:00"
         assert params["end"] == "2026-01-02T00:00:00"
 
-    def test_defaults_to_all_projects_when_no_url_or_dashboard_project(self) -> None:
+    def test_omits_project_when_no_url_or_dashboard_project(self) -> None:
         widget = self._make_widget()
 
         params = build_widget_timeseries_params(widget, QueryDict())[0]
 
-        # ALL_ACCESS_PROJECT_ID (-1) so an unconfigured dashboard still renders
-        # data rather than an empty chart.
-        assert params["project"] == "-1"
+        # Omitting the param matches the dashboard FE: the API defaults to
+        # "My Projects" rather than "All Projects" (project=-1).
+        assert "project" not in params
 
     def test_dashboard_projects_used_when_url_missing(self) -> None:
         project_a = self.create_project(organization=self.organization)


### PR DESCRIPTION
Updates dashboards url unfurl to match the `project` query param logic that the frontend does. We should omit the `project` query param if it's not saved, this is the behaviour the the frontend does, it does not fallback to `project=-1`