### PR TITLE
fix(integrations): Switch SCM backfill migration to emit cell outboxes

### DIFF
--- a/src/sentry/migrations/1072_backfill_scm_integration_config.py
+++ b/src/sentry/migrations/1072_backfill_scm_integration_config.py
@@ -1,79 +1,45 @@
-import logging
 from collections import defaultdict
 
 from django.db import migrations
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.migrations.state import StateApps
 
-from sentry.constants import ObjectStatus
 from sentry.new_migrations.migrations import CheckedMigration
 
-logger = logging.getLogger(__name__)
+# Legacy OrganizationOption keys whose value=True needs to be carried onto
+# OrganizationIntegration.config. Mirrors _SCM_BACKFILL_PROVIDER_KEYS in
+# src/sentry/receivers/outbox/cell.py.
+_LEGACY_KEYS = (
+    "sentry:github_pr_bot",
+    "sentry:github_nudge_invite",
+    "sentry:gitlab_pr_bot",
+)
 
-# Maps integration provider -> list of (OrganizationOption key, OI config key)
-# pairs. Mirrors the live fan-out write in
-# src/sentry/core/endpoints/organization_details.py so the backfill and
-# any newly installed OI end up consistent.
-_PROVIDER_KEYS = {
-    "github": [
-        ("sentry:github_pr_bot", "pr_comments"),
-        ("sentry:github_nudge_invite", "nudge_invite"),
-    ],
-    "gitlab": [
-        ("sentry:gitlab_pr_bot", "pr_comments"),
-    ],
-}
-
-_LEGACY_KEYS = [opt_key for pairs in _PROVIDER_KEYS.values() for opt_key, _ in pairs]
+# Hardcoded values from sentry.hybridcloud.outbox.category at the time this
+# migration was authored. Pinned as integers so a future enum/scope rename
+# can't break replays on stale databases.
+_ORGANIZATION_SCOPE = 0
+_SCM_INTEGRATION_CONFIG_BACKFILL = 46
 
 
 def backfill_scm_integration_config(
     apps: StateApps, schema_editor: BaseDatabaseSchemaEditor
 ) -> None:
     """
-    Iterate the legacy OrganizationOption rows on the region silo (only orgs
-    that ever flipped one of the three toggles — a few thousand in prod) and
-    fan out updates to the control-silo OrganizationIntegration via RPC.
+    Emit one cell outbox per org with at least one true-valued legacy SCM
+    toggle. The receiver (sentry.receivers.outbox.cell) drains each outbox
+    on the cell silo and fans out to every ACTIVE GitHub/GitLab
+    OrganizationIntegration via RPC.
 
-    We only consider rows whose value is exactly True; the new read path
-    treats a missing OI config key as false, so any other shape is a no-op.
+    The previous body did the RPC directly from the migration CLI and
+    failed in prod with 401 errors against the control silo. Outboxes
+    drain inside a worker that has a stable RPC auth context, retry on
+    transient failures, and run in current code -- so a replay against
+    drifted code is at worst a no-op (the receiver may be retired) rather
+    than a half-applied write.
     """
-    # Imports are deferred so that breakage in these modules surfaces
-    # at runtime (when this migration is replayed on a fresh DB),
-    # not at migration-plan resolution time for every `migrate`.
-    #
-    # The bigger risk isn't the symbol surface, though -- it's that
-    # `integration_service` reads and writes the live
-    # `sentry_organizationintegration` table, not the historical
-    # snapshot we'd get via `apps.get_model`. If that table's schema
-    # or the meaning of `config` changes in a way this backfill's
-    # payload doesn't account for, replays on fresh self-hosted DBs
-    # will misbehave. We accept that: if/when it happens, this
-    # migration body is noop'd. By then getsentry prod and most
-    # self-hosted installs will already have run it; the residual
-    # risk is a small set of self-hosted users on a very old version
-    # with one of the legacy toggles set to true, who upgrade past
-    # the noop and don't get those toggles carried over to the
-    # per-OI config. That's preferable to keeping the OI table
-    # frozen indefinitely.
-    #
-    # We considered using a new outbox category to drive the
-    # cross-silo write instead. That doesn't actually remove the
-    # risk, it just relocates it onto the outbox tables: the live
-    # worker still dispatches against the current
-    # `sentry_organizationintegration` schema, and our rows would be
-    # tagged with a category enum entry that future code may retire
-    # -- leaving un-migrated installs with outbox rows the worker
-    # can't decode. Same cleanup shape (noop the migration body),
-    # with extra plumbing (category enum, signal receiver, drain
-    # semantics) and no real decoupling. The RPC path is also
-    # synchronous and observable, which is what an operator running
-    # a post-deploy migration wants.
-    from sentry.hybridcloud.rpc.service import RpcRemoteException
-    from sentry.integrations.services.integration import integration_service
-    from sentry.types.cell import CellMappingNotFound
-
     OrganizationOption = apps.get_model("sentry", "OrganizationOption")
+    CellOutbox = apps.get_model("sentry", "CellOutbox")
 
     queryset = OrganizationOption.objects.filter(key__in=_LEGACY_KEYS, value=True)
 
@@ -81,63 +47,14 @@ def backfill_scm_integration_config(
     for opt in queryset:
         opts_by_org[opt.organization_id].add(opt.key)
 
-    # For each org with at least one true-valued legacy option, find the
-    # ACTIVE OIs of each provider that owns one of the matching keys.
     for organization_id, opts in opts_by_org.items():
-        for provider, key_pairs in _PROVIDER_KEYS.items():
-            # Skip providers whose owned keys aren't set on this org. e.g.
-            # if only sentry:gitlab_pr_bot is true, don't bother RPC-listing
-            # the github OIs.
-            if not any(opt_key in opts for opt_key, _ in key_pairs):
-                continue
-
-            try:
-                ois = integration_service.get_organization_integrations(
-                    organization_id=organization_id,
-                    providers=[provider],
-                    status=ObjectStatus.ACTIVE,
-                )
-            except (CellMappingNotFound, RpcRemoteException):
-                logger.exception(
-                    "scm_backfill.list_failed",
-                    extra={
-                        "organization_id": organization_id,
-                        "provider": provider,
-                    },
-                )
-                continue
-
-            # An org can have multiple ACTIVE installs of the same provider
-            # (multi-org GitHub apps); each gets its own per-install config.
-            for oi in ois:
-                config = dict(oi.config or {})
-                set_keys: list[str] = []
-                # Backfill every owned key that's true on the org and not
-                # already present on the OI. Keys already set are left
-                # alone — the per-install UI may have set them explicitly.
-                for opt_key, cfg_key in key_pairs:
-                    if opt_key in opts and cfg_key not in config:
-                        config[cfg_key] = True
-                        set_keys.append(cfg_key)
-
-                if set_keys:
-                    # Exceptions from the write are deliberately uncaught: if
-                    # this fails we want the migration to abort loudly so an
-                    # operator can investigate, rather than silently dropping
-                    # a true toggle on the floor and leaving an org with the
-                    # wrong setting.
-                    integration_service.update_organization_integration(
-                        org_integration_id=oi.id, config=config
-                    )
-                    logger.info(
-                        "scm_backfill.set",
-                        extra={
-                            "organization_id": organization_id,
-                            "org_integration_id": oi.id,
-                            "provider": provider,
-                            "keys": set_keys,
-                        },
-                    )
+        CellOutbox(
+            shard_scope=_ORGANIZATION_SCOPE,
+            shard_identifier=organization_id,
+            category=_SCM_INTEGRATION_CONFIG_BACKFILL,
+            object_identifier=organization_id,
+            payload={"keys": sorted(opts)},
+        ).save()
 
 
 class Migration(CheckedMigration):

--- a/tests/sentry/migrations/test_1072_backfill_scm_integration_config.py
+++ b/tests/sentry/migrations/test_1072_backfill_scm_integration_config.py
@@ -1,6 +1,11 @@
+from django.db import router
+
 from sentry.constants import ObjectStatus
+from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.silo.base import SiloMode
+from sentry.silo.safety import unguarded_write
 from sentry.testutils.cases import TestMigrations
+from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
 
 
@@ -13,7 +18,10 @@ class BackfillScmIntegrationConfigTest(TestMigrations):
         OrganizationIntegration = apps.get_model("sentry", "OrganizationIntegration")
         OrganizationOption = apps.get_model("sentry", "OrganizationOption")
 
-        with assume_test_silo_mode(SiloMode.MONOLITH):
+        with (
+            assume_test_silo_mode(SiloMode.MONOLITH),
+            unguarded_write(using=router.db_for_write(OrganizationIntegration)),
+        ):
             true_org = self.create_organization()
             gh = Integration.objects.create(provider="github", external_id="gh-true", name="gh-t")
             gl = Integration.objects.create(provider="gitlab", external_id="gl-true", name="gl-t")
@@ -109,7 +117,11 @@ class BackfillScmIntegrationConfigTest(TestMigrations):
             )
 
     def test(self) -> None:
-        from sentry.integrations.models.organization_integration import OrganizationIntegration
+        # The migration only emits cell outboxes; the receiver in
+        # sentry.receivers.outbox.cell does the actual fan-out, so drain
+        # before asserting.
+        with outbox_runner():
+            pass
 
         with assume_test_silo_mode(SiloMode.CONTROL):
             true_gh = OrganizationIntegration.objects.get(id=self.true_gh_oi.id).config


### PR DESCRIPTION
Phase 4.6 of [VDY-110](https://linear.app/getsentry/issue/VDY-110/), follow-up to #114160.

The merged backfill (#114046) is failing in prod replays with `RpcRemoteException: Service unavailable (401 status)` because the migration CLI doesn't have a stable RPC auth context to the control silo, so every batch logs `scm_backfill.list_failed` and skips the org without backfilling.

This PR rewrites the body of `1072_backfill_scm_integration_config` to emit one `CellOutbox` per affected org tagged with `OutboxCategory.SCM_INTEGRATION_CONFIG_BACKFILL` (added in #114160). The receiver in `sentry/receivers/outbox/cell.py` drains each outbox inside a worker that has the right auth context, retries on transient failures, and runs in current code -- so a replay against drifted code is at worst a no-op rather than a half-applied write.

The shard_scope and category ints are pinned in the migration body so a future enum rename can't break replays on stale self-hosted DBs. The migration is the same `1072_backfill_scm_integration_config` (already merged); only the body changes, and `is_post_deployment = True` means it has not run yet on prod beyond the failing attempts. Test now drains via `outbox_runner()` and the OI/Integration setup creates are wrapped in `unguarded_write` (the receiver's RPC fan-out adds queries that the audit framework now flags against the unfenced setup INSERTs).

Depends on #114160.