### PR TITLE
fix(tracemetrics): Update delete metric tooltip message

### DIFF
--- a/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricsEquationVisualize.tsx
@@ -197,12 +197,18 @@ function MetricsEquationVisualizeContent({
       {functionQueries.length > 0 && <FunctionColumnHeaders />}
       {functionQueries.map(metricQuery => {
         const isReferenced = referencedLabels.has(metricQuery.label ?? '');
+        const deleteDisabledReason =
+          functionQueries.length <= 1
+            ? t('At least one metric is required')
+            : isReferenced
+              ? t('This metric is used in an equation')
+              : undefined;
         return (
           <RowProvider key={metricQuery.label ?? ''} metricQuery={metricQuery}>
             <MetricToolbar
               metricQuery={metricQuery}
               referenceMap={referenceMap}
-              canDelete={functionQueries.length > 1 && !isReferenced}
+              deleteDisabledReason={deleteDisabledReason}
               isSelected={selectedLabel === metricQuery.label}
               onRowSelection={onRowSelection}
               projectIds={projectIds}
@@ -218,7 +224,6 @@ function MetricsEquationVisualizeContent({
             <MetricToolbar
               metricQuery={equationQuery}
               referenceMap={referenceMap}
-              canDelete
               isSelected={selectedLabel === equationQuery.label}
               onRowSelection={onRowSelection}
               onReferenceLabelsChange={setEquationReferencedLabels}
@@ -328,18 +333,18 @@ function EquationColumnHeader() {
 function MetricToolbar({
   metricQuery,
   referenceMap,
-  canDelete,
+  deleteDisabledReason,
   isSelected,
   onRowSelection,
   onReferenceLabelsChange,
   projectIds,
   environments,
 }: {
-  canDelete: boolean;
   isSelected: boolean;
   metricQuery: MetricQuery;
   onRowSelection: (label: string) => void;
   referenceMap: Record<string, string>;
+  deleteDisabledReason?: string;
   environments?: string[];
   onReferenceLabelsChange?: (labels: string[]) => void;
   projectIds?: number[];
@@ -408,7 +413,7 @@ function MetricToolbar({
           </Flex>
           <AggregateDropdown traceMetric={traceMetric} singleSelect />
           <Filter traceMetric={traceMetric} />
-          <DeleteMetricButton disabled={!canDelete} />
+          <DeleteMetricButton disabledReason={deleteDisabledReason} />
         </Fragment>
       ) : isVisualizeEquation(visualize) ? (
         <Fragment>

--- a/static/app/views/explore/metrics/metricToolbar/deleteMetricButton.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/deleteMetricButton.tsx
@@ -4,7 +4,7 @@ import {IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {useRemoveMetric} from 'sentry/views/explore/metrics/metricsQueryParams';
 
-export function DeleteMetricButton({disabled}: {disabled?: boolean}) {
+export function DeleteMetricButton({disabledReason}: {disabledReason?: string}) {
   const removeMetric = useRemoveMetric();
 
   return (
@@ -13,10 +13,8 @@ export function DeleteMetricButton({disabled}: {disabled?: boolean}) {
       icon={<IconDelete />}
       size="zero"
       onClick={removeMetric}
-      disabled={disabled}
-      tooltipProps={{
-        title: disabled ? t('This application metric is used in an equation') : undefined,
-      }}
+      disabled={disabledReason !== undefined}
+      tooltipProps={{title: disabledReason}}
       aria-label={t('Delete Metric')}
     />
   );

--- a/static/app/views/explore/metrics/metricToolbar/index.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/index.tsx
@@ -6,6 +6,7 @@ import {Flex, Grid} from '@sentry/scraps/layout';
 
 import type {Expression} from 'sentry/components/arithmeticBuilder/expression';
 import {DragReorderButton} from 'sentry/components/dnd/dragReorderButton';
+import {t} from 'sentry/locale';
 import {EQUATION_PREFIX} from 'sentry/utils/discover/fields';
 import {useBreakpoints} from 'sentry/utils/useBreakpoints';
 import {EquationBuilder} from 'sentry/views/explore/metrics/equationBuilder';
@@ -154,7 +155,13 @@ export function MetricToolbar({
             )}
           </Flex>
         ) : null}
-        {canRemoveMetric && <DeleteMetricButton disabled={isReferencedByEquation} />}
+        {canRemoveMetric && (
+          <DeleteMetricButton
+            disabledReason={
+              isReferencedByEquation ? t('This metric is used in an equation') : undefined
+            }
+          />
+        )}
       </Grid>
       {isNarrow && (
         <Filter


### PR DESCRIPTION
On the detectors page, the component we added was showing the "this metric is used in an equation" message even though there were no equations, but it was disabled because it was the only metric. The tooltip should not have this message