### PR TITLE
ref(gs*): apply `@typescript-eslint/consistent-type-definitions`

### DIFF
--- a/static/app/utils/analytics/makeAnalyticsFunction.tsx
+++ b/static/app/utils/analytics/makeAnalyticsFunction.tsx
@@ -28,7 +28,7 @@ type Options = Parameters<Hooks['analytics:raw-track-event']>[1];
  * Can make orgnization required with the second generic.
  */
 export function makeAnalyticsFunction<
-  EventParameters extends Record<string, Record<string, any>>,
+  EventParameters,
   // This is used to provide a nice curried type for consumers.
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
   OrgRequirement extends OptionalOrg = OptionalOrg,

--- a/static/gsAdmin/components/addGiftBudgetAction.tsx
+++ b/static/gsAdmin/components/addGiftBudgetAction.tsx
@@ -17,11 +17,11 @@ import {useApi} from 'sentry/utils/useApi';
 import type {Subscription} from 'getsentry/types';
 import {getPlanCategoryName} from 'getsentry/utils/dataCategory';
 
-type Props = {
+interface Props {
   onSuccess: () => void;
   organization: Organization;
   subscription: Subscription;
-};
+}
 
 type ModalProps = Props & ModalRenderProps;
 

--- a/static/gsAdmin/components/addGiftEventsAction.tsx
+++ b/static/gsAdmin/components/addGiftEventsAction.tsx
@@ -26,9 +26,9 @@ type Props = AdminConfirmRenderProps & {
   subscription: Subscription;
 };
 
-type State = {
+interface State {
   freeEvents?: number;
-};
+}
 
 /**
  * Rendered as part of a openAdminConfirmModal call

--- a/static/gsAdmin/components/adminConfirmationModal.tsx
+++ b/static/gsAdmin/components/adminConfirmationModal.tsx
@@ -11,14 +11,14 @@ import {TextareaField} from 'sentry/components/forms/fields/textareaField';
 
 type ConfirmProps = React.ComponentProps<typeof Confirm>;
 
-export type AdminConfirmParams = {
+export interface AdminConfirmParams {
   /**
    * Additional properties may be set via the renderModalSpecificContent
    */
   [key: string]: any;
   notes?: string;
   ticketURL?: string;
-};
+}
 
 export type AdminConfirmRenderProps = Omit<
   ConfirmMessageRenderProps,
@@ -105,12 +105,12 @@ type ConfirmMessageProps = ConfirmMessageRenderProps &
     | 'onConfirm'
   >;
 
-type State = {
+interface State {
   confirmCallback: ((params: AdminConfirmParams) => void) | null;
   invalidTicketURL: boolean;
   notes: string | null;
   ticketURL: string | null;
-};
+}
 
 class AdminConfirmMessage extends Component<ConfirmMessageProps, State> {
   state: State = {

--- a/static/gsAdmin/components/beacons/beaconCheckins.tsx
+++ b/static/gsAdmin/components/beacons/beaconCheckins.tsx
@@ -5,9 +5,9 @@ import {Truncate} from 'sentry/components/truncate';
 import type {BeaconData} from 'admin/components/beacons/beaconOverview';
 import ResultGrid from 'admin/components/resultGrid';
 
-type Props = {
+interface Props {
   data: BeaconData;
-};
+}
 
 const getRow = (row: any) => [
   <td key="id">{moment(row.dateCreated).fromNow()}</td>,

--- a/static/gsAdmin/components/beacons/beaconOverview.tsx
+++ b/static/gsAdmin/components/beacons/beaconOverview.tsx
@@ -4,7 +4,7 @@ import {DetailLabel} from 'admin/components/detailLabel';
 import {DetailList} from 'admin/components/detailList';
 import {DetailsContainer} from 'admin/components/detailsContainer';
 
-export type BeaconData = {
+export interface BeaconData {
   email: string;
   events24h: number;
   firstCheckin: string;
@@ -15,11 +15,11 @@ export type BeaconData = {
   totalProjects: number;
   totalUsers: number;
   version: string;
-};
+}
 
-type Props = {
+interface Props {
   data: BeaconData;
-};
+}
 
 export function BeaconOverview({data}: Props) {
   return (

--- a/static/gsAdmin/components/beacons/relatedBeacons.tsx
+++ b/static/gsAdmin/components/beacons/relatedBeacons.tsx
@@ -7,9 +7,9 @@ import {Truncate} from 'sentry/components/truncate';
 import type {BeaconData} from 'admin/components/beacons/beaconOverview';
 import ResultGrid from 'admin/components/resultGrid';
 
-type Props = {
+interface Props {
   data: BeaconData;
-};
+}
 
 const getRow = (row: any) => [
   <td key="id">

--- a/static/gsAdmin/components/cancelSubscriptionAction.tsx
+++ b/static/gsAdmin/components/cancelSubscriptionAction.tsx
@@ -11,10 +11,10 @@ type Props = AdminConfirmRenderProps & {
   subscription: Subscription;
 };
 
-type State = {
+interface State {
   applyBalance: boolean;
   cancelAtPeriodEnd: boolean;
-};
+}
 
 /**
  * Rendered as part of a openAdminConfirmModal call

--- a/static/gsAdmin/components/changeARRAction.tsx
+++ b/static/gsAdmin/components/changeARRAction.tsx
@@ -6,11 +6,11 @@ import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {openModal} from 'sentry/actionCreators/modal';
 import {NumberField} from 'sentry/components/forms/fields/numberField';
 
-type Props = {
+interface Props {
   // TODO(ts): Type customer when available
   customer: any;
   onAction: (data: any) => void;
-};
+}
 
 export function ChangeARRAction(props: Props) {
   return (
@@ -28,10 +28,10 @@ export function ChangeARRAction(props: Props) {
 
 type ModalProps = ModalRenderProps & Props;
 
-type ModalState = {
+interface ModalState {
   error: boolean;
   newAcv: number;
-};
+}
 
 class ChangeARRModal extends Component<ModalProps, ModalState> {
   state: ModalState = {

--- a/static/gsAdmin/components/changeEffectiveAtAction.tsx
+++ b/static/gsAdmin/components/changeEffectiveAtAction.tsx
@@ -5,9 +5,9 @@ import {openModal} from 'sentry/actionCreators/modal';
 import {InputField} from 'sentry/components/forms/fields/inputField';
 import {Form} from 'sentry/components/forms/form';
 
-type Props = {
+interface Props {
   onAction: (effectiveAt: string) => void;
-};
+}
 
 export const openChangeEffectiveAtModal = ({onAction}: Props) =>
   openModal(({Header, Body, closeModal}) => (

--- a/static/gsAdmin/components/changeGoogleDomainAction.tsx
+++ b/static/gsAdmin/components/changeGoogleDomainAction.tsx
@@ -9,11 +9,11 @@ import {TextField} from 'sentry/components/forms/fields/textField';
 import {Form} from 'sentry/components/forms/form';
 import {withApi} from 'sentry/utils/withApi';
 
-type Props = {
+interface Props {
   api: Client;
   onUpdated: (data: any) => void;
   orgId: string;
-};
+}
 
 const CHANGE_CHOICES = [
   ['swap', 'Swap'],
@@ -22,12 +22,12 @@ const CHANGE_CHOICES = [
 
 type ModalProps = Props & ModalRenderProps;
 
-type ModalState = {
+interface ModalState {
   append: string | null;
   dryRun: boolean | null;
   dryRunInfo: any[];
   loading: boolean;
-};
+}
 
 class ChangeGoogleDomainModal extends Component<ModalProps, ModalState> {
   state: ModalState = {

--- a/static/gsAdmin/components/changePlanAction.tsx
+++ b/static/gsAdmin/components/changePlanAction.tsx
@@ -319,12 +319,12 @@ function ChangePlanAction({
   );
 }
 
-type Options = {
+interface Options {
   onSuccess: () => void;
   organization: Organization;
   partnerPlanId: string | null;
   subscription: Subscription;
-};
+}
 
 export const triggerChangePlanAction = (opts: Options) =>
   openModal(deps => <ChangePlanAction {...deps} {...opts} />);

--- a/static/gsAdmin/components/customerContact.tsx
+++ b/static/gsAdmin/components/customerContact.tsx
@@ -2,9 +2,9 @@ import {ExternalLink} from '@sentry/scraps/link';
 
 import type {Subscription} from 'getsentry/types';
 
-type Props = {
+interface Props {
   owner?: Subscription['owner'];
-};
+}
 
 export function CustomerContact({owner}: Props) {
   return owner ? (

--- a/static/gsAdmin/components/customerStatus.tsx
+++ b/static/gsAdmin/components/customerStatus.tsx
@@ -6,9 +6,9 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 import type {Subscription} from 'getsentry/types';
 import {formatCurrency} from 'getsentry/utils/formatCurrency';
 
-type Props = {
+interface Props {
   customer: Subscription;
-};
+}
 
 const getLabel = (item: Subscription) => {
   if (item.isEnterpriseTrial) {

--- a/static/gsAdmin/components/customers/customerIntegrationDebugDetails.tsx
+++ b/static/gsAdmin/components/customers/customerIntegrationDebugDetails.tsx
@@ -14,7 +14,7 @@ type Props = Partial<React.ComponentProps<typeof ResultGrid>> & {
   orgId: string;
 };
 
-type IntegrationRow = {
+interface IntegrationRow {
   dateAdded: string | null;
   gracePeriodEnd: string | null;
   id: number;
@@ -27,7 +27,7 @@ type IntegrationRow = {
     status: number;
   };
   status: number;
-};
+}
 
 const STATUS_LABELS: Record<number, string> = {
   0: 'Active',

--- a/static/gsAdmin/components/customers/customerMembers.tsx
+++ b/static/gsAdmin/components/customers/customerMembers.tsx
@@ -10,9 +10,9 @@ import {IconMail} from 'sentry/icons';
 
 import ResultGrid from 'admin/components/resultGrid';
 
-type Props = {
+interface Props {
   orgId: string;
-};
+}
 
 const getRow = (row: any) => [
   <td key="name">

--- a/static/gsAdmin/components/customers/customerOnboardingTasks.tsx
+++ b/static/gsAdmin/components/customers/customerOnboardingTasks.tsx
@@ -13,10 +13,10 @@ type Props = Partial<React.ComponentProps<typeof ResultGrid>> & {
 
 type Status = 'complete' | 'pending' | 'skipped';
 
-type StatusTag = {
+interface StatusTag {
   icon: React.ReactNode;
   tagType: TagProps['variant'];
-};
+}
 
 const tagPriority: Record<Status, StatusTag> = {
   pending: {icon: <IconClock size="xs" />, tagType: 'muted'},

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -54,10 +54,10 @@ import {getCountryByCode} from 'getsentry/utils/ISO3166codes';
 import {titleCase} from 'getsentry/utils/titleCase';
 import {displayPriceWithCents} from 'getsentry/views/amCheckout/utils';
 
-type SubscriptionSummaryProps = {
+interface SubscriptionSummaryProps {
   customer: Subscription;
   onAction: (data: any) => void;
-};
+}
 
 function SoftCapTypeDetail({
   categories,
@@ -165,9 +165,9 @@ function SubscriptionSummary({customer, onAction}: SubscriptionSummaryProps) {
   );
 }
 
-type ReservedDataProps = {
+interface ReservedDataProps {
   customer: Subscription;
-};
+}
 
 function ReservedData({customer}: ReservedDataProps) {
   const reservedBudgetMetricHistories: Record<string, ReservedBudgetMetricHistory> = {};
@@ -300,9 +300,9 @@ function ReservedBudgetData({
   );
 }
 
-type OnDemandSummaryProps = {
+interface OnDemandSummaryProps {
   customer: Subscription;
-};
+}
 
 function OnDemandSummary({customer}: OnDemandSummaryProps) {
   const onDemandPeriod = `${moment(customer.onDemandPeriodStart).format('ll')} › ${moment(
@@ -386,11 +386,11 @@ function OnDemandSummary({customer}: OnDemandSummaryProps) {
   );
 }
 
-type Props = {
+interface Props {
   customer: Subscription;
   onAction: (data: any) => void;
   organization: Organization;
-};
+}
 
 function isWithinAcceptedMargin(
   effectiveSampleRate: number,
@@ -939,10 +939,10 @@ const StyledTag = styled(Tag)`
   width: fit-content;
 `;
 
-type ThresholdLabelProps = {
+interface ThresholdLabelProps {
   children: React.ReactNode;
   positive: boolean;
-};
+}
 
 function ThresholdLabel({positive, children}: ThresholdLabelProps) {
   return (

--- a/static/gsAdmin/components/customers/customerProjects.tsx
+++ b/static/gsAdmin/components/customers/customerProjects.tsx
@@ -9,9 +9,9 @@ import {IconProject} from 'sentry/icons';
 
 import ResultGrid from 'admin/components/resultGrid';
 
-type Props = {
+interface Props {
   orgId: string;
-};
+}
 
 export function CustomerProjects({orgId}: Props) {
   return (

--- a/static/gsAdmin/components/customers/customerStats.tsx
+++ b/static/gsAdmin/components/customers/customerStats.tsx
@@ -32,35 +32,35 @@ enum SeriesName {
   DROPPED = 'Dropped (Server)',
 }
 
-type SubSeries = {
+interface SubSeries {
   data: DataPoint[];
   seriesName: string;
-};
+}
 
-type SeriesItem = {
+interface SeriesItem {
   data: DataPoint[];
   seriesName: string;
   color?: string;
   subSeries?: SubSeries[];
-};
+}
 
-export type StatsGroup = {
+export interface StatsGroup {
   by: {
     outcome: string;
     reason: string;
   };
   series: Record<string, number[]>;
   totals: Record<string, number>;
-};
+}
 
-type Stats = {
+interface Stats {
   groups: StatsGroup[];
   intervals: Array<string | number>;
-};
+}
 
-type LegendProps = {
+interface LegendProps {
   points: Stats;
-};
+}
 
 export const useSeries = (): Record<string, SeriesItem> => {
   const theme = useTheme();
@@ -97,12 +97,12 @@ function isAbuseWithoutReason(by: {outcome: string; reason?: string}): boolean {
   return by.outcome === 'abuse' && (!by.reason || by.reason === 'none');
 }
 
-type AbuseData = {
+interface AbuseData {
   intervalMs: number;
   intervals: number[];
   regions: Array<{end: number; start: number}>;
   valueByTimestamp: Map<number, number>;
-};
+}
 
 function getAbuseData(
   intervals: Array<string | number>,
@@ -424,13 +424,13 @@ function FooterLegend({points}: LegendProps) {
   );
 }
 
-type Props = {
+interface Props {
   dataType: DataCategoryExact;
   orgSlug: Organization['slug'];
   onDemandPeriodEnd?: string;
   onDemandPeriodStart?: string;
   projectId?: Project['id'];
-};
+}
 
 export const CustomerStats = memo(
   ({orgSlug, projectId, dataType, onDemandPeriodStart, onDemandPeriodEnd}: Props) => {

--- a/static/gsAdmin/components/customers/customerStatsFilters.tsx
+++ b/static/gsAdmin/components/customers/customerStatsFilters.tsx
@@ -22,13 +22,13 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 
 const ON_DEMAND_PERIOD_KEY = 'onDemand';
 
-type Props = {
+interface Props {
   dataType: DataCategoryExact;
   onChange: (dataType: DataCategoryExact) => void;
   organization: Organization;
   onDemandPeriodEnd?: string;
   onDemandPeriodStart?: string;
-};
+}
 
 export function CustomerStatsFilters({
   dataType,

--- a/static/gsAdmin/components/customers/organizationStatus.tsx
+++ b/static/gsAdmin/components/customers/organizationStatus.tsx
@@ -2,9 +2,9 @@ import {Alert} from '@sentry/scraps/alert';
 
 import type {Subscription} from 'getsentry/types';
 
-type Props = {
+interface Props {
   orgStatus: Subscription['orgStatus'];
-};
+}
 
 export function OrganizationStatus({orgStatus}: Props) {
   if (!orgStatus) {

--- a/static/gsAdmin/components/customers/pendingChanges.tsx
+++ b/static/gsAdmin/components/customers/pendingChanges.tsx
@@ -327,10 +327,10 @@ function getOnDemandChanges(subscription: Subscription) {
   return changes;
 }
 
-type Change = {
+interface Change {
   effectiveDate: string;
   items: React.ReactNode[];
-};
+}
 
 function getChanges(subscription: Subscription, planMigrations: PlanMigration[]) {
   const {pendingChanges} = subscription;

--- a/static/gsAdmin/components/customers/updateRetentionSettingsModal.tsx
+++ b/static/gsAdmin/components/customers/updateRetentionSettingsModal.tsx
@@ -11,11 +11,11 @@ import {useApi} from 'sentry/utils/useApi';
 
 import type {Subscription} from 'getsentry/types';
 
-type Props = {
+interface Props {
   onSuccess: () => void;
   organization: Organization;
   subscription: Subscription;
-};
+}
 
 type ModalProps = Props & ModalRenderProps;
 

--- a/static/gsAdmin/components/debounceSearch.tsx
+++ b/static/gsAdmin/components/debounceSearch.tsx
@@ -8,7 +8,7 @@ import {SearchBar} from 'sentry/components/searchBar';
 import {useApi} from 'sentry/utils/useApi';
 import {useKeyPress} from 'sentry/utils/useKeyPress';
 
-type Props = {
+interface Props {
   onSelectResult: (value: string) => void;
   path: string;
   placeholder: string;
@@ -17,7 +17,7 @@ type Props = {
   host?: string;
   onSearch?: (value: string) => void;
   queryParam?: string;
-};
+}
 
 export function DebounceSearch({
   createSuggestionPath,

--- a/static/gsAdmin/components/deleteBillingMetricHistory.tsx
+++ b/static/gsAdmin/components/deleteBillingMetricHistory.tsx
@@ -11,7 +11,7 @@ import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useApi} from 'sentry/utils/useApi';
 
-type CategoryInfo = {
+interface CategoryInfo {
   api_name: string;
   billed_category: number;
   display_name: string;
@@ -20,18 +20,18 @@ type CategoryInfo = {
   product_name: string;
   singular: string;
   tally_type: number;
-};
+}
 
-type BillingConfig = {
+interface BillingConfig {
   category_info: Record<string, CategoryInfo>;
   outcomes: Record<string, string>;
   reason_codes: Record<string, string>;
-};
+}
 
-type Props = {
+interface Props {
   onSuccess: () => void;
   organization: Organization;
-};
+}
 
 type ModalProps = Props & ModalRenderProps;
 

--- a/static/gsAdmin/components/detailLabel.tsx
+++ b/static/gsAdmin/components/detailLabel.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 
 import {Tag} from '@sentry/scraps/badge';
 
-type Props = {
+interface Props {
   /**
    * The left-hand aligned label
    */
@@ -18,7 +18,7 @@ type Props = {
    * Pass a boolean to render 'yes' or 'no' as the child for true / false
    */
   yesNo?: boolean;
-};
+}
 
 /**
  * Detail label is used within DetailList

--- a/static/gsAdmin/components/detailList.tsx
+++ b/static/gsAdmin/components/detailList.tsx
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled';
 
-type Props = {
+interface Props {
   maxLabelSize?: number;
-};
+}
 
 export const DetailList = styled('dl')<Props>`
   display: grid;

--- a/static/gsAdmin/components/detailsPage.tsx
+++ b/static/gsAdmin/components/detailsPage.tsx
@@ -13,7 +13,7 @@ import type {openAdminConfirmModal} from 'admin/components/adminConfirmationModa
 import {DropdownActions} from 'admin/components/dropdownActions';
 import {PageHeader} from 'admin/components/pageHeader';
 
-export type ActionItem = {
+export interface ActionItem {
   key: string;
   /**
    * Name of the action
@@ -51,9 +51,9 @@ export type ActionItem = {
    * If set to false will hide the item from the menu
    */
   visible?: boolean;
-};
+}
 
-export type BadgeItem = {
+export interface BadgeItem {
   name: string;
   /**
    * A tooltip rendered on the badge
@@ -67,9 +67,9 @@ export type BadgeItem = {
    * If set to false will hide the badge
    */
   visible?: boolean;
-};
+}
 
-type SectionItem = {
+interface SectionItem {
   content: React.ReactElement;
   /**
    * Adds a heading to the panel. Does nothing when noPanel is set.
@@ -90,9 +90,9 @@ type SectionItem = {
    * If set to false will hide the section
    */
   visible?: boolean;
-};
+}
 
-type Props = {
+interface Props {
   /**
    * The name of the specific item we're looking at details of.
    */
@@ -118,7 +118,7 @@ type Props = {
    * List of sections to show. This is the primary content of the page
    */
   sections?: SectionItem[];
-};
+}
 
 export function DetailsPage({
   rootName,

--- a/static/gsAdmin/components/dropdownActions.tsx
+++ b/static/gsAdmin/components/dropdownActions.tsx
@@ -7,7 +7,7 @@ import {IconNot} from 'sentry/icons';
 
 import {openAdminConfirmModal} from 'admin/components/adminConfirmationModal';
 
-type Props = {
+interface Props {
   actions: Array<{
     key: string;
     name: string;
@@ -20,7 +20,7 @@ type Props = {
     visible?: boolean;
   }>;
   label: string;
-};
+}
 
 /**
  * Map actions to a format that can be used by the CompactSelect component. This exists

--- a/static/gsAdmin/components/eventUsers.tsx
+++ b/static/gsAdmin/components/eventUsers.tsx
@@ -5,11 +5,11 @@ import {Button} from '@sentry/scraps/button';
 import {AdminConfirmationModal} from 'admin/components/adminConfirmationModal';
 import ResultGrid from 'admin/components/resultGrid';
 
-type Props = {
+interface Props {
   onRemoveEmail: (hash: string) => void;
   orgId: string;
   projectId: string;
-};
+}
 
 export function EventUsers({orgId, projectId, onRemoveEmail}: Props) {
   const getRow = (row: any) => {

--- a/static/gsAdmin/components/forkCustomer.tsx
+++ b/static/gsAdmin/components/forkCustomer.tsx
@@ -19,9 +19,9 @@ type Props = AdminConfirmRenderProps & {
   organization: Organization;
 };
 
-type State = {
+interface State {
   regionUrl: string;
-};
+}
 
 /**
  * Rendered as part of a openAdminConfirmModal call

--- a/static/gsAdmin/components/percentChange.tsx
+++ b/static/gsAdmin/components/percentChange.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 
-type Props = {
+interface Props {
   current: number;
   prev: number;
-};
+}
 
 export function PercentChange({current, prev}: Props) {
   if (!current || !prev) {

--- a/static/gsAdmin/components/planList.tsx
+++ b/static/gsAdmin/components/planList.tsx
@@ -22,7 +22,7 @@ import {
 import {getPlanCategoryName, isByteCategory} from 'getsentry/utils/dataCategory';
 import {formatCurrency} from 'getsentry/utils/formatCurrency';
 
-type Props = {
+interface Props {
   activePlan: Plan | null;
   formModel: FormModel;
   onCancel: () => void;
@@ -32,7 +32,7 @@ type Props = {
   onSubmitSuccess: (data: Data) => void;
   subscription: Subscription;
   tierPlans: BillingConfig['planList'];
-};
+}
 
 export function PlanList({
   activePlan,

--- a/static/gsAdmin/components/policies/policyRevisions.tsx
+++ b/static/gsAdmin/components/policies/policyRevisions.tsx
@@ -8,10 +8,10 @@ import {ExternalLink} from '@sentry/scraps/link';
 import ResultGrid from 'admin/components/resultGrid';
 import type {Policy, PolicyRevision} from 'getsentry/types';
 
-type Props = {
+interface Props {
   onUpdate: (data: Record<string, any>, version: PolicyRevision['version']) => void;
   policy: Policy;
-};
+}
 
 type RowProps = Props & {row: PolicyRevision};
 

--- a/static/gsAdmin/components/promoCodes/promoCodeClaimants.tsx
+++ b/static/gsAdmin/components/promoCodes/promoCodeClaimants.tsx
@@ -8,11 +8,11 @@ import {CustomerContact} from 'admin/components/customerContact';
 import ResultGrid from 'admin/components/resultGrid';
 import type {PromoCode} from 'admin/types';
 
-type Props = {
+interface Props {
   promoCode: PromoCode;
-};
+}
 
-type PromoClaimant = {
+interface PromoClaimant {
   customer: {
     name: string;
     slug: string;
@@ -20,7 +20,7 @@ type PromoClaimant = {
   dateCreated: string;
   id: string;
   user: User;
-};
+}
 
 const getRow = (row: PromoClaimant) => {
   const {customer, user} = row;

--- a/static/gsAdmin/components/provisionSubscriptionAction.tsx
+++ b/static/gsAdmin/components/provisionSubscriptionAction.tsx
@@ -107,23 +107,23 @@ class DollarsAndCentsFieldNoContext extends InputField<DollarsAndCentsFieldProps
 
 const DollarsAndCentsField = withFormContext(DollarsAndCentsFieldNoContext);
 
-type Props = {
+interface Props {
   api: Client;
   billingConfig: BillingConfig | null;
   onSuccess: () => void;
   orgId: string;
   subscription: Subscription;
-};
+}
 
 type ModalProps = ModalRenderProps & Props;
 
-type ModalState = {
+interface ModalState {
   data: any;
   // TODO(ts)
   effectiveAtDisabled: boolean;
   isLoading: boolean;
   provisionablePlans: Record<string, Plan>;
-};
+}
 
 /**
  * Convert cents to dollars

--- a/static/gsAdmin/components/refundVercelRequestModal.tsx
+++ b/static/gsAdmin/components/refundVercelRequestModal.tsx
@@ -9,15 +9,15 @@ import {useApi} from 'sentry/utils/useApi';
 
 import type {Subscription} from 'getsentry/types';
 
-type Props = {
+interface Props {
   onSuccess: () => void;
   subscription: Subscription;
-};
+}
 
-type RefundVercelApiRequest = {
+interface RefundVercelApiRequest {
   guid: string;
   reason: string;
-};
+}
 
 type ModalProps = Props & ModalRenderProps;
 

--- a/static/gsAdmin/components/relocationBadge.tsx
+++ b/static/gsAdmin/components/relocationBadge.tsx
@@ -2,9 +2,9 @@ import {Tag, type TagProps} from '@sentry/scraps/badge';
 
 import type {Relocation} from 'admin/types';
 
-type Props = {
+interface Props {
   data: Relocation;
-};
+}
 
 export function RelocationBadge({data}: Props) {
   let text = '';

--- a/static/gsAdmin/components/resultGrid.tsx
+++ b/static/gsAdmin/components/resultGrid.tsx
@@ -28,14 +28,14 @@ import {ResultTable} from 'admin/components/resultTable';
 
 type Option = [key: string, label: string];
 
-type FilterProps = {
+interface FilterProps {
   name: string;
   options: Option[];
   queryKey: string;
   value: string;
   location?: Location;
   path?: string;
-};
+}
 
 function Filter({name, queryKey, options, path, location, value}: FilterProps) {
   const {query, pathname} = location ?? {};
@@ -69,13 +69,13 @@ function Filter({name, queryKey, options, path, location, value}: FilterProps) {
 
 type SortFn = (value: string, path: string, query: Location['query']) => void;
 
-type SortByProps = {
+interface SortByProps {
   options: Option[];
   path: string;
   value: string;
   location?: Location;
   onSort?: SortFn;
-};
+}
 
 const defaultOnSort: SortFn = (value, path, query) => {
   const newQuery = {
@@ -106,10 +106,10 @@ function SortBy({options, path, location, value, onSort = defaultOnSort}: SortBy
   );
 }
 
-type FilterDescriptor = {
+interface FilterDescriptor {
   name: string;
   options: Option[];
-};
+}
 
 interface ResultGridProps extends WithRouterProps {
   api: Client;
@@ -213,7 +213,7 @@ interface ResultGridProps extends WithRouterProps {
   useQueryString?: boolean;
 }
 
-export type State = {
+export interface State {
   cursor: string;
   error: boolean;
   filters: Location['query'];
@@ -223,7 +223,7 @@ export type State = {
   region: Region | undefined;
   rows: any[];
   sortBy: string;
-};
+}
 
 const extractQuery = (query: Location['query'][string], defaultVal = '') =>
   (Array.isArray(query) ? query[0] : query) ?? defaultVal;

--- a/static/gsAdmin/components/selectableContainer.tsx
+++ b/static/gsAdmin/components/selectableContainer.tsx
@@ -7,14 +7,14 @@ import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Panel} from 'sentry/components/panels/panel';
 import {PanelHeader} from 'sentry/components/panels/panelHeader';
 
-type SelectableContainerPanelProps = {
+interface SelectableContainerPanelProps {
   children: React.ReactNode;
   extraActions?: React.ReactNode;
-};
+}
 
 export type SelectableContainerPanel = React.ComponentType<SelectableContainerPanelProps>;
 
-type ContentRenderProps = {
+interface ContentRenderProps {
   /**
    * May be used to wrap sections in panels
    */
@@ -23,9 +23,9 @@ type ContentRenderProps = {
    * May be used to render the section selector
    */
   selector: React.ReactNode;
-};
+}
 
-type Section = {
+interface Section {
   /**
    * Renders the content of the section. See the ContentRenderProps to
    * understand what each injected Prop is used for.
@@ -39,9 +39,9 @@ type Section = {
    * The name of the section. Rendered in the dropdown selector
    */
   name: string;
-};
+}
 
-type Props = {
+interface Props {
   /**
    * Each available section
    */
@@ -59,7 +59,7 @@ type Props = {
    * as the panel name
    */
   panelTitle?: string;
-};
+}
 
 export function SelectableContainer({
   dropdownPrefix,

--- a/static/gsAdmin/components/sendWeeklyEmailAction.tsx
+++ b/static/gsAdmin/components/sendWeeklyEmailAction.tsx
@@ -17,11 +17,11 @@ import type {
 
 type Props = {api: Client; orgId: string} & AdminConfirmRenderProps;
 
-type State = {
+interface State {
   deliveryEmail: string;
   dryRun: boolean;
   targetEmail: string;
-};
+}
 
 /**
  * Rendered as part of a openAdminConfirmModal call

--- a/static/gsAdmin/components/sentryAppUpdateModal.tsx
+++ b/static/gsAdmin/components/sentryAppUpdateModal.tsx
@@ -25,11 +25,11 @@ type Props = ModalRenderProps & {
   sentryAppData: any;
 };
 
-type SubmitQueryVariables = {
+interface SubmitQueryVariables {
   data: Record<string, any>;
   onSubmitError: (error: any) => void;
   onSubmitSuccess: (response: Record<string, any>) => void;
-};
+}
 
 type SubmitQueryResponse = Record<string, any>;
 

--- a/static/gsAdmin/components/sponsorshipAction.tsx
+++ b/static/gsAdmin/components/sponsorshipAction.tsx
@@ -14,9 +14,9 @@ type Props = AdminConfirmRenderProps & {
   subscription: Subscription;
 };
 
-type State = {
+interface State {
   sponsoredType?: string | null;
-};
+}
 
 /**
  * Rendered as part of a openAdminConfirmModal call

--- a/static/gsAdmin/components/suspendAccountAction.tsx
+++ b/static/gsAdmin/components/suspendAccountAction.tsx
@@ -14,9 +14,9 @@ const suspendReasons = [
   ['past_due', 'Past Due', 'This account has a past balance which needs to be paid.'],
 ] as const;
 
-type State = {
+interface State {
   suspensionReason: (typeof suspendReasons)[number][0] | null;
-};
+}
 
 /**
  * Rendered as part of a openAdminConfirmModal call

--- a/static/gsAdmin/components/toggleSpendAllocationModal.tsx
+++ b/static/gsAdmin/components/toggleSpendAllocationModal.tsx
@@ -6,12 +6,12 @@ import type {Client} from 'sentry/api';
 import {Form} from 'sentry/components/forms/form';
 import {withApi} from 'sentry/utils/withApi';
 
-type Props = {
+interface Props {
   api: Client;
   onUpdated: (data: any) => void;
   orgId: string;
   spendAllocationEnabled: boolean;
-};
+}
 
 type ModalProps = Props & ModalRenderProps;
 

--- a/static/gsAdmin/components/trialSubscriptionAction.tsx
+++ b/static/gsAdmin/components/trialSubscriptionAction.tsx
@@ -18,11 +18,11 @@ type Props = AdminConfirmRenderProps & {
   startEnterpriseTrial?: boolean;
 };
 
-type State = {
+interface State {
   trialDays: number;
   trialPlanOverride?: string;
   trialTier?: PlanTier;
-};
+}
 
 /**
  * Rendered as part of a openAdminConfirmModal call

--- a/static/gsAdmin/components/users/userCustomers.tsx
+++ b/static/gsAdmin/components/users/userCustomers.tsx
@@ -5,9 +5,9 @@ import {openModal} from 'sentry/actionCreators/modal';
 import {AddToOrgModal, RemoveFromOrgModal} from 'admin/components/addOrRemoveOrgModal';
 import {CustomerGrid} from 'admin/components/customerGrid';
 
-type Props = {
+interface Props {
   userId: string;
-};
+}
 
 export function UserCustomers({userId}: Props) {
   const openAddToOrgModal = () => {

--- a/static/gsAdmin/components/users/userEmailLog.tsx
+++ b/static/gsAdmin/components/users/userEmailLog.tsx
@@ -12,22 +12,22 @@ import type {User} from 'sentry/types/user';
 import {ResultTable} from 'admin/components/resultTable';
 import type {SelectableContainerPanel} from 'admin/components/selectableContainer';
 
-type Props = {
+interface Props {
   /**
    * This component needs to render some additional actions within the
    * SelectableContainer panel, so it must be injected as a property.
    */
   Panel: SelectableContainerPanel;
   user: User;
-};
+}
 
-type State = {
+interface State {
   activeEmail: string;
   error: boolean;
   hideButton: boolean;
   loading: boolean | null;
   results: any[];
-};
+}
 
 export class UserEmailLog extends Component<Props, State> {
   state: State = {

--- a/static/gsAdmin/components/users/userEmails.tsx
+++ b/static/gsAdmin/components/users/userEmails.tsx
@@ -3,10 +3,10 @@ import type {User} from 'sentry/types/user';
 import {ResultTable} from 'admin/components/resultTable';
 import type {SelectableContainerPanel} from 'admin/components/selectableContainer';
 
-type Props = {
+interface Props {
   Panel: SelectableContainerPanel;
   user: User;
-};
+}
 
 export function UserEmails({Panel, user}: Props) {
   const primary = user.email;

--- a/static/gsAdmin/components/users/userOverview.tsx
+++ b/static/gsAdmin/components/users/userOverview.tsx
@@ -17,14 +17,14 @@ import {DetailList} from 'admin/components/detailList';
 import {DetailsContainer} from 'admin/components/detailsContainer';
 import {prettyDate} from 'admin/utils';
 
-type Props = {
+interface Props {
   identities: UserIdentityConfig[];
   onAuthenticatorRemove: (auth: NonNullable<User['authenticators']>[number]) => void;
   onIdentityDisconnect: (identity: UserIdentityConfig) => void;
   revokeToken: (token: InternalAppApiToken) => void;
   tokens: InternalAppApiToken[];
   user: User;
-};
+}
 
 function identityLabel(identity: UserIdentityConfig) {
   if (identity.category === UserIdentityCategory.ORG_IDENTITY) {

--- a/static/gsAdmin/types/index.tsx
+++ b/static/gsAdmin/types/index.tsx
@@ -21,7 +21,7 @@ declare global {
   }
 }
 
-export type PromoCode = {
+export interface PromoCode {
   amount: string;
   campaign: string;
   code: string;
@@ -35,7 +35,7 @@ export type PromoCode = {
   trialDays: number;
   userEmail: string | null;
   userId: number;
-};
+}
 
 type RelocationStatus = 'IN_PROGRESS' | 'SUCCESS' | 'FAILURE' | 'PAUSE';
 
@@ -53,13 +53,13 @@ type RelocationStep = keyof typeof RelocationSteps;
 
 type RelocationProvenance = 'SELF_HOSTED' | 'SAAS_TO_SAAS';
 
-type RelocationAssociatedUser = {
+interface RelocationAssociatedUser {
   email: string;
   id: string;
   username: string;
-};
+}
 
-export type Relocation = {
+export interface Relocation {
   creator: RelocationAssociatedUser | null;
   dateAdded: string;
   dateUpdated: string;
@@ -78,67 +78,67 @@ export type Relocation = {
   uuid: string;
   wantOrgSlugs: string[];
   wantUsernames: string[];
-};
+}
 
-export type ContractDate = {
+export interface ContractDate {
   day?: number;
   month?: number;
   year?: number;
-};
+}
 
-type ContractPricingTier = {
+interface ContractPricingTier {
   end?: string;
   ratePerUnitCpe?: string;
   start?: string;
-};
+}
 
-type ContractTieredPricingRate = {
+interface ContractTieredPricingRate {
   tiers?: ContractPricingTier[];
-};
+}
 
-export type ContractSKUConfig = {
+export interface ContractSKUConfig {
   basePriceCents?: string;
   paygBudgetCents?: string;
   paygRate?: ContractTieredPricingRate;
   reservedRate?: ContractTieredPricingRate;
   reservedVolume?: string;
   sku?: string;
-};
+}
 
-export type ContractSharedSKUBudget = {
+export interface ContractSharedSKUBudget {
   paygBudgetCents?: string;
   reservedBudgetCents?: string;
   skus?: string[];
-};
+}
 
-type ContractMetadata = {
+interface ContractMetadata {
   id?: string;
   organizationId?: string;
-};
+}
 
-type ContractAddress = {
+interface ContractAddress {
   countryCode?: string;
-};
+}
 
-type ContractBillingConfig = {
+interface ContractBillingConfig {
   address?: ContractAddress;
   billingType?: string;
   channel?: string;
   contractEndDate?: ContractDate;
   contractStartDate?: ContractDate;
-};
+}
 
-type ContractPricingConfig = {
+interface ContractPricingConfig {
   basePriceCents?: string;
   billingPeriodEndDate?: ContractDate;
   billingPeriodStartDate?: ContractDate;
   maxSpendCents?: string;
   sharedSkuBudgets?: ContractSharedSKUBudget[];
   skuConfigs?: ContractSKUConfig[];
-};
+}
 
-export type Contract = {
+export interface Contract {
   billingConfig?: ContractBillingConfig;
   metadata?: ContractMetadata;
   pricingConfig?: ContractPricingConfig;
-};
+}

--- a/static/gsAdmin/utils.tsx
+++ b/static/gsAdmin/utils.tsx
@@ -9,10 +9,10 @@ export const isBillingAdmin = () => {
   return !!user?.permissions?.has('billing.admin');
 };
 
-type QueryConditions = {
+interface QueryConditions {
   organizationId?: string;
   projectId?: string;
-};
+}
 
 export function getLogQuery(type: string, conditions: QueryConditions) {
   let query = '';

--- a/static/gsAdmin/views/dataRequests.tsx
+++ b/static/gsAdmin/views/dataRequests.tsx
@@ -17,10 +17,10 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 
 import {PageHeader} from 'admin/components/pageHeader';
 
-type ResultQuery = {
+interface ResultQuery {
   email: string;
   orgSlug: string;
-};
+}
 
 export function DataRequests() {
   const location = useLocation();

--- a/static/gsAdmin/views/debuggingTools.tsx
+++ b/static/gsAdmin/views/debuggingTools.tsx
@@ -18,8 +18,14 @@ import {PageHeader} from 'admin/components/pageHeader';
 const SECOND_TO_MILLISECOND = 1000;
 const MILLISECOND_TO_DAY = SECOND_TO_MILLISECOND * 60 * 60 * 24;
 
-type IssueOwnerMatch = {rule: string; source: string};
-type Forecast = {data: number[]; date_added: number};
+interface IssueOwnerMatch {
+  rule: string;
+  source: string;
+}
+interface Forecast {
+  data: number[];
+  date_added: number;
+}
 type IssueDetailsResponse = Group & {forecast: Forecast};
 
 function IssueOwnerDebbuging() {

--- a/static/gsAdmin/views/dynamicSamplingPanel.tsx
+++ b/static/gsAdmin/views/dynamicSamplingPanel.tsx
@@ -27,24 +27,24 @@ import {useApi} from 'sentry/utils/useApi';
 
 import {SearchInput} from 'admin/components/resultGrid';
 
-type Props = {
+interface Props {
   organization?: Organization;
   projectId?: string;
-};
+}
 
-type ProjectConfig = {
+interface ProjectConfig {
   configs: Record<string, DSNConfig | null>;
-};
+}
 
-type DSNConfig = {
+interface DSNConfig {
   config?: {
     sampling?: {
       rules: RuleV2[];
     };
   };
-};
+}
 
-type RuleV2 = {
+interface RuleV2 {
   condition: {
     inner: InnerElement[] | InnerElement;
   };
@@ -59,11 +59,11 @@ type RuleV2 = {
     end: string;
     start: string;
   };
-};
+}
 
-type InnerElement = {
+interface InnerElement {
   value: unknown;
-};
+}
 
 enum RuleType {
   BOOST_LOW_VOLUME_PROJECTS = 'Boost Low Volume Projects',
@@ -315,11 +315,11 @@ function DynamicSamplingPanelBody({config: dsnConfig}: {config: DSNConfig | null
   );
 }
 
-type DynamicSamplingRulesTableProps = {
+interface DynamicSamplingRulesTableProps {
   baseSampleRate: number;
   searchQuery: string;
   rules?: RuleV2[];
-};
+}
 
 function DynamicSamplingRulesTable({
   baseSampleRate,

--- a/static/gsAdmin/views/instanceLevelOAuth/instanceLevelOAuthDetails.tsx
+++ b/static/gsAdmin/views/instanceLevelOAuth/instanceLevelOAuthDetails.tsx
@@ -20,7 +20,7 @@ import {PageHeader} from 'admin/components/pageHeader';
 
 import {ConfirmClientDeleteModal} from './components/confirmClientDeleteModal';
 
-type ClientDetails = {
+interface ClientDetails {
   allowedOrigins: string | null;
   clientID: string | null;
   createdAt: string | null;
@@ -30,7 +30,7 @@ type ClientDetails = {
   privacyUrl: string | null;
   redirectUris: string | null;
   termsUrl: string | null;
-};
+}
 
 const fieldProps = {
   stacked: true,

--- a/static/gsAdmin/views/relocationArtifactDetails.tsx
+++ b/static/gsAdmin/views/relocationArtifactDetails.tsx
@@ -10,9 +10,9 @@ import {useParams} from 'sentry/utils/useParams';
 
 import {DetailsPage} from 'admin/components/detailsPage';
 
-type RelocationData = {
+interface RelocationData {
   contents: string;
-};
+}
 
 export function RelocationArtifactDetails() {
   const {artifactKind, fileName, regionName, relocationUuid} = useParams<{

--- a/static/gsAdmin/views/relocationDetails.tsx
+++ b/static/gsAdmin/views/relocationDetails.tsx
@@ -48,13 +48,13 @@ enum ArtifactsState {
   ERROR = 3,
 }
 
-type RelocationArtifact = {
+interface RelocationArtifact {
   description: string;
   path: string;
   regionName: string;
   relocation: Relocation;
   sizeInKbs: number;
-};
+}
 
 // A map of each expected relocation artifact to a user-legible description of what it is.
 const expectedRelocationArtifacts = new Map<string, string>(

--- a/static/gsApp/actionCreators/modal.tsx
+++ b/static/gsApp/actionCreators/modal.tsx
@@ -14,24 +14,24 @@ import type {Invoice, Plan, PreviewData, Subscription} from 'getsentry/types';
 import {displayBudgetName, hasBillingAccess, supportsPayg} from 'getsentry/utils/billing';
 import type {AM2UpdateSurfaces} from 'getsentry/utils/trackGetsentryAnalytics';
 
-type UpsellModalOptions = {
+interface UpsellModalOptions {
   organization: Organization;
   source: string;
-};
+}
 
 export async function openUpsellModal(options: UpsellModalOptions) {
   const {default: Modal, modalCss} = await import('getsentry/components/upsellModal');
   openModal(deps => <Modal {...deps} {...options} />, {modalCss});
 }
 
-type TrialModalProps = {
+interface TrialModalProps {
   organization: Organization;
-};
+}
 
-type PartnerPlanModalProps = {
+interface PartnerPlanModalProps {
   organization: Organization;
   subscription: Subscription;
-};
+}
 
 function genTrialModalOnClose(
   options: TrialModalProps,
@@ -140,11 +140,11 @@ const onDemandBudgetEditModalCss = (theme: Theme) => css`
   }
 `;
 
-type OpenInvoicePaymentOptions = {
+interface OpenInvoicePaymentOptions {
   invoice: Invoice;
   organization: Organization;
   reloadInvoice: () => void;
-};
+}
 
 export async function openInvoicePaymentModal(options: OpenInvoicePaymentOptions) {
   const {default: Modal} = await import('getsentry/views/invoiceDetails/paymentForm');
@@ -152,7 +152,7 @@ export async function openInvoicePaymentModal(options: OpenInvoicePaymentOptions
   openModal(deps => <Modal {...deps} {...options} />);
 }
 
-type UpsellModalProps = {
+interface UpsellModalProps {
   organization: Organization;
   plan: Plan;
   previewData: PreviewData;
@@ -161,7 +161,7 @@ type UpsellModalProps = {
   surface: AM2UpdateSurfaces;
   isActionDisabled?: boolean;
   onComplete?: () => void;
-};
+}
 
 export async function openAM2UpsellModal(options: UpsellModalProps) {
   const {default: Modal, modalCss} =
@@ -170,7 +170,7 @@ export async function openAM2UpsellModal(options: UpsellModalProps) {
   openModal(deps => <Modal {...deps} {...options} />, {modalCss});
 }
 
-export type UpsellModalSamePriceProps = {
+export interface UpsellModalSamePriceProps {
   organization: Organization;
   plan: Plan;
   previewData: PreviewData;
@@ -178,7 +178,7 @@ export type UpsellModalSamePriceProps = {
   subscription: Subscription;
   surface: AM2UpdateSurfaces;
   onComplete?: () => void;
-};
+}
 
 export async function openAM2UpsellModalSamePrice(options: UpsellModalSamePriceProps) {
   const {default: Modal, modalCss} =
@@ -187,12 +187,12 @@ export async function openAM2UpsellModalSamePrice(options: UpsellModalSamePriceP
   openModal(deps => <Modal {...deps} {...options} />, {modalCss});
 }
 
-type ProfilingUpsellModalProps = {
+interface ProfilingUpsellModalProps {
   organization: Organization;
   subscription: Subscription;
   isActionDisabled?: boolean;
   onComplete?: () => void;
-};
+}
 
 export async function openAM2ProfilingUpsellModal(options: ProfilingUpsellModalProps) {
   const {default: Modal, modalCss} =

--- a/static/gsApp/components/addEventsCTA.tsx
+++ b/static/gsApp/components/addEventsCTA.tsx
@@ -36,7 +36,7 @@ export type EventType = {
     : never;
 }[keyof typeof DATA_CATEGORY_INFO];
 
-type Props = {
+interface Props {
   api: Client;
   organization: Organization;
   referrer: string;
@@ -47,7 +47,7 @@ type Props = {
   eventTypes?: EventType[];
   handleRequestSent?: () => void;
   notificationType?: 'overage_warning' | 'overage_critical';
-};
+}
 
 /**
  *

--- a/static/gsApp/components/ai/AiSetupDataConsent.tsx
+++ b/static/gsApp/components/ai/AiSetupDataConsent.tsx
@@ -28,9 +28,9 @@ import {useSubscription} from 'getsentry/hooks/useSubscription';
 import {BillingType, OnDemandBudgetMode} from 'getsentry/types';
 import {getPotentialProductTrial, getSeerTrialCategory} from 'getsentry/utils/billing';
 
-type AiSetupDataConsentProps = {
+interface AiSetupDataConsentProps {
   groupId?: string;
-};
+}
 
 export function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
   const api = useApi({persistInFlight: true});

--- a/static/gsApp/components/billingDetails/form.tsx
+++ b/static/gsApp/components/billingDetails/form.tsx
@@ -35,7 +35,7 @@ import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
 
 const COUNTRY_CODE_CHOICES = countryCodes.map(({name, code}) => [code, name]);
 
-type Props = {
+interface Props {
   onSubmitSuccess: (data: Record<PropertyKey, unknown>) => void;
   organization: Organization;
   /**
@@ -72,13 +72,13 @@ type Props = {
    * Form submit button label.
    */
   submitLabel?: string;
-};
+}
 
-type State = {
+interface State {
   showTaxNumber: boolean;
   countryCode?: string | null;
   taxFieldInfo?: TaxFieldInfo;
-};
+}
 
 const GOOGLE_MAPS_API_KEY = ConfigStore.get('getsentry.googleMapsApiKey');
 

--- a/static/gsApp/components/dashboardBanner.tsx
+++ b/static/gsApp/components/dashboardBanner.tsx
@@ -10,9 +10,9 @@ import type {Organization} from 'sentry/types/organization';
 
 import {UpsellButton} from 'getsentry/components/upsellButton';
 
-type Props = {
+interface Props {
   organization: Organization;
-};
+}
 
 export function DashboardBanner({organization}: Props) {
   // No upsell if the user can edit dashboards

--- a/static/gsApp/components/features/disabledAuthProvider.tsx
+++ b/static/gsApp/components/features/disabledAuthProvider.tsx
@@ -17,12 +17,12 @@ type ChildRenderProps = Parameters<ChildrenRenderFn>[0] & {
 
 type ChildRenderFunction = (options: ChildRenderProps) => React.ReactNode;
 
-type Props = {
+interface Props {
   children: React.ReactNode | ChildRenderFunction;
   features: string[];
   hasFeature: boolean;
   organization: Organization;
-};
+}
 
 export function DisabledAuthProvider({
   organization,

--- a/static/gsApp/components/features/disabledCustomInboundFilters.tsx
+++ b/static/gsApp/components/features/disabledCustomInboundFilters.tsx
@@ -13,10 +13,10 @@ import {LearnMoreButton} from 'getsentry/components/features/learnMoreButton';
 import PlanFeature from 'getsentry/components/features/planFeature';
 import {displayPlanName} from 'getsentry/utils/billing';
 
-type Props = {
+interface Props {
   features: string[];
   organization: Organization;
-};
+}
 
 function DisabledAlert({organization, features}: Props) {
   return (

--- a/static/gsApp/components/features/disabledDataForwarding.tsx
+++ b/static/gsApp/components/features/disabledDataForwarding.tsx
@@ -13,10 +13,10 @@ import {LearnMoreButton} from 'getsentry/components/features/learnMoreButton';
 import PlanFeature from 'getsentry/components/features/planFeature';
 import {displayPlanName} from 'getsentry/utils/billing';
 
-type Props = {
+interface Props {
   features: string[];
   organization: Organization;
-};
+}
 
 export function DisabledDataForwarding({organization, features}: Props) {
   return (

--- a/static/gsApp/components/features/disabledDiscardGroup.tsx
+++ b/static/gsApp/components/features/disabledDiscardGroup.tsx
@@ -12,10 +12,10 @@ import {LearnMoreButton} from 'getsentry/components/features/learnMoreButton';
 import PlanFeature from 'getsentry/components/features/planFeature';
 import {displayPlanName} from 'getsentry/utils/billing';
 
-type Props = {
+interface Props {
   features: Organization['features'];
   organization: Organization;
-};
+}
 
 export function DisabledDiscardGroup({organization, features}: Props) {
   return (

--- a/static/gsApp/components/features/disabledRateLimits.tsx
+++ b/static/gsApp/components/features/disabledRateLimits.tsx
@@ -13,10 +13,10 @@ import {LearnMoreButton} from 'getsentry/components/features/learnMoreButton';
 import PlanFeature from 'getsentry/components/features/planFeature';
 import {displayPlanName} from 'getsentry/utils/billing';
 
-type Props = {
+interface Props {
   features: string[];
   organization: Organization;
-};
+}
 
 function DisabledAlert({organization, features}: Props) {
   return (

--- a/static/gsApp/components/features/illustrations/alertsBackground.tsx
+++ b/static/gsApp/components/features/illustrations/alertsBackground.tsx
@@ -81,9 +81,9 @@ const Alerts = styled('g')`
   }
 `;
 
-type Props = {
+interface Props {
   anchorRef: React.Ref<SVGForeignObjectElement>;
-};
+}
 
 export function AlertsBackground({anchorRef}: Props) {
   let alertInterval: undefined | number;

--- a/static/gsApp/components/features/illustrations/dashboardsBackground.tsx
+++ b/static/gsApp/components/features/illustrations/dashboardsBackground.tsx
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled';
 
-type Props = {
+interface Props {
   anchorRef: React.Ref<SVGForeignObjectElement>;
-};
+}
 
 export function DashboardBackground({anchorRef}: Props) {
   return (

--- a/static/gsApp/components/features/illustrations/deactivatedMember.tsx
+++ b/static/gsApp/components/features/illustrations/deactivatedMember.tsx
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled';
 
-type Props = {
+interface Props {
   anchorRef: React.Ref<SVGForeignObjectElement>;
-};
+}
 
 export function DeactivatedMember({anchorRef}: Props) {
   return (

--- a/static/gsApp/components/features/illustrations/discoverBackground.tsx
+++ b/static/gsApp/components/features/illustrations/discoverBackground.tsx
@@ -6,9 +6,9 @@ import {motion} from 'framer-motion';
 // Computed using SVGGeometryElement.getTotalLength()
 const STROKE_LENGTH = 4445;
 
-type Props = {
+interface Props {
   anchorRef: React.Ref<SVGForeignObjectElement>;
-};
+}
 
 const Stroke = styled(motion.path)`
   stroke-dasharray: ${STROKE_LENGTH} ${STROKE_LENGTH};

--- a/static/gsApp/components/features/illustrations/performanceBackground.tsx
+++ b/static/gsApp/components/features/illustrations/performanceBackground.tsx
@@ -83,9 +83,9 @@ const starGroupAnimation = {
   },
 };
 
-type Props = {
+interface Props {
   anchorRef: React.Ref<SVGForeignObjectElement>;
-};
+}
 
 export function PerformanceBackground({anchorRef}: Props) {
   return (

--- a/static/gsApp/components/features/planFeature.tsx
+++ b/static/gsApp/components/features/planFeature.tsx
@@ -9,7 +9,7 @@ import {useBillingConfig} from 'getsentry/hooks/useBillingConfig';
 import type {Plan, Subscription} from 'getsentry/types';
 import {isBizPlanFamily, isDeveloperPlan} from 'getsentry/utils/billing';
 
-type RenderProps = {
+interface RenderProps {
   /**
    * The plan that the user must upgrade to to use this feature.
    *
@@ -23,14 +23,14 @@ type RenderProps = {
    * plan tier that is DIFFERENT from the users current subscription tier.
    */
   tierChange: string | null;
-};
+}
 
-type Props = {
+interface Props {
   children: (opts: RenderProps) => React.ReactNode;
   features: string[];
   organization: Organization;
   subscription: Subscription;
-};
+}
 
 /**
  * Plan feature determines which plan a user must be on in order to access a

--- a/static/gsApp/components/gsBanner.tsx
+++ b/static/gsApp/components/gsBanner.tsx
@@ -284,7 +284,7 @@ function NoticeModal({
   );
 }
 
-type Props = {
+interface Props {
   api: Client;
   isLoading: boolean;
   organization: Organization;
@@ -294,14 +294,14 @@ type Props = {
     completedPromotions: PromotionClaimed[];
   };
   subscription: Subscription;
-};
+}
 
-type State = {
+interface State {
   deactivatedMemberDismissed: boolean;
   overageAlertDismissed: Record<EventType, boolean>;
   overageWarningDismissed: Record<EventType, boolean>;
   productTrialDismissed: Record<EventType, boolean>;
-};
+}
 
 class GSBanner extends Component<Props, State> {
   // assume dismissed until we've checked the backend

--- a/static/gsApp/components/gsBillingNavigationConfig.tsx
+++ b/static/gsApp/components/gsBillingNavigationConfig.tsx
@@ -13,10 +13,10 @@ import type {
 import {withSubscription} from 'getsentry/components/withSubscription';
 import type {Subscription} from 'getsentry/types';
 
-type Props = {
+interface Props {
   organization: Organization;
   subscription: Subscription;
-};
+}
 
 type NavProps = NavigationProps & {
   access?: Set<Scope>;

--- a/static/gsApp/components/helpSearchFooter.tsx
+++ b/static/gsApp/components/helpSearchFooter.tsx
@@ -7,10 +7,10 @@ import type {Organization} from 'sentry/types/organization';
 
 import ZendeskLink from 'getsentry/components/zendeskLink';
 
-type Props = {
+interface Props {
   closeModal: () => void;
   organization: Organization;
-};
+}
 
 export function HelpSearchFooter({organization, closeModal}: Props) {
   return (

--- a/static/gsApp/components/inviteMembersButtonCustomization.tsx
+++ b/static/gsApp/components/inviteMembersButtonCustomization.tsx
@@ -1,10 +1,10 @@
 import type {Organization} from 'sentry/types/organization';
 
-type Props = {
+interface Props {
   children: (opts: {disabled: boolean; onTriggerModal: () => void}) => React.ReactElement;
   onTriggerModal: () => void;
   organization: Organization;
-};
+}
 
 export const InviteMembersButtonCustomization = ({children, onTriggerModal}: Props) => {
   return children({disabled: false, onTriggerModal});

--- a/static/gsApp/components/labelWithPowerIcon.tsx
+++ b/static/gsApp/components/labelWithPowerIcon.tsx
@@ -47,11 +47,11 @@ const POWER_FEATURE_CONFIG = [
   },
 ];
 
-type Props = {
+interface Props {
   children: React.ReactNode;
   subscription: Subscription;
   id?: string;
-};
+}
 
 function LabelWithPowerIcon({children, id, subscription}: Props) {
   // Must return React Elements

--- a/static/gsApp/components/memberInviteModalCustomization.tsx
+++ b/static/gsApp/components/memberInviteModalCustomization.tsx
@@ -15,7 +15,7 @@ import {getTrialLength, hasJustStartedPlanTrial} from 'getsentry/utils/billing';
 
 import {withSubscription} from './withSubscription';
 
-type MemberInviteProps = {
+interface MemberInviteProps {
   children: (opts: {
     canSend: boolean;
     isOverMemberLimit: boolean;
@@ -26,7 +26,7 @@ type MemberInviteProps = {
   organization: Organization;
   subscription: Subscription;
   willInvite: boolean;
-};
+}
 
 function MemberInviteModalCustomization({
   organization,

--- a/static/gsApp/components/openInDiscoverBtn.tsx
+++ b/static/gsApp/components/openInDiscoverBtn.tsx
@@ -8,9 +8,9 @@ import type {Organization} from 'sentry/types/organization';
 import {openUpsellModal} from 'getsentry/actionCreators/modal';
 import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
 
-type Props = {
+interface Props {
   organization: Organization;
-};
+}
 
 export function OpenInDiscoverBtn(props: Props) {
   const {organization} = props;

--- a/static/gsApp/components/performance/quotaExceededAlert.tsx
+++ b/static/gsApp/components/performance/quotaExceededAlert.tsx
@@ -168,11 +168,11 @@ function useQuotaExceededAlertMessage(
 
 type TraceItemDatasetGS = 'logs' | 'spans';
 
-type Props = {
+interface Props {
   referrer: string;
   subscription: Subscription;
   traceItemDataset: TraceItemDatasetGS;
-};
+}
 
 export function QuotaExceededAlert(props: Props) {
   const organization = useOrganization();

--- a/static/gsApp/components/productTrial/productTrialPaths.tsx
+++ b/static/gsApp/components/productTrial/productTrialPaths.tsx
@@ -3,10 +3,10 @@ import {DataCategory} from 'sentry/types/core';
 import type {Subscription} from 'getsentry/types';
 import {PlanTier} from 'getsentry/types';
 
-type Product = {
+interface Product {
   categories: DataCategory[];
   product: DataCategory;
-};
+}
 
 type Path = string;
 

--- a/static/gsApp/components/profiling/profilingUpgradeModal.tsx
+++ b/static/gsApp/components/profiling/profilingUpgradeModal.tsx
@@ -172,13 +172,13 @@ export const modalCss = css`
 
 export default UpsellModal;
 
-type ActionButtonsProps = {
+interface ActionButtonsProps {
   hasPriceChange: boolean;
   organization: Organization;
   subscription: Subscription;
   isActionDisabled?: boolean;
   onComplete?: () => void;
-};
+}
 
 function ActionButtons({
   hasPriceChange,

--- a/static/gsApp/components/replayOnboardingAlert.tsx
+++ b/static/gsApp/components/replayOnboardingAlert.tsx
@@ -5,10 +5,10 @@ import {withSubscription} from 'getsentry/components/withSubscription';
 import type {Subscription} from 'getsentry/types';
 import {PlanTier} from 'getsentry/types';
 
-type Props = {
+interface Props {
   children: ReactNode;
   subscription: Subscription;
-};
+}
 
 function ReplayOnboardingAlert({children, subscription}: Props) {
   // in `sentry` we render an info alert to re-enforce the "Select/Create Project" CTA

--- a/static/gsApp/components/replayOnboardingCTA.tsx
+++ b/static/gsApp/components/replayOnboardingCTA.tsx
@@ -27,10 +27,10 @@ import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
 
 import {redirectToManage} from './upgradeNowModal/utils';
 
-type ReplayOnboardingCTAUpsellProps = {
+interface ReplayOnboardingCTAUpsellProps {
   organization: Organization;
   subscription: Subscription;
-};
+}
 
 function ReplayOnboardingCTAUpsell({
   organization,
@@ -264,11 +264,11 @@ const ButtonList = styled((props: GridProps) => (
   grid-template-columns: repeat(auto-fit, minmax(130px, max-content));
 `;
 
-type ReplayOnboardingCTAProps = {
+interface ReplayOnboardingCTAProps {
   children: ReactNode;
   organization: Organization;
   subscription: Subscription;
-};
+}
 
 /**
  * The majority of orgs have the replays feature, so we check for that first

--- a/static/gsApp/components/subscriptionContext.tsx
+++ b/static/gsApp/components/subscriptionContext.tsx
@@ -4,9 +4,9 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 
 import {ContactBillingMembers} from 'getsentry/views/contactBillingMembers';
 
-type Props = {
+interface Props {
   children: React.ReactNode;
-};
+}
 
 export function SubscriptionContext(props: Props) {
   const organization = useOrganization();

--- a/static/gsApp/components/superuser/superuserWarning.tsx
+++ b/static/gsApp/components/superuser/superuserWarning.tsx
@@ -64,10 +64,10 @@ function ExitSuperuserButton() {
   );
 }
 
-type Props = {
+interface Props {
   className?: string;
   organization?: Organization;
-};
+}
 
 export function SuperuserWarning({organization, className}: Props) {
   const hasPageFrame = useHasPageFrameFeature();

--- a/static/gsApp/components/trialStartedSidebarItem.tsx
+++ b/static/gsApp/components/trialStartedSidebarItem.tsx
@@ -19,13 +19,13 @@ import type {Subscription} from 'getsentry/types';
 import {hasJustStartedPlanTrial} from 'getsentry/utils/billing';
 import {TrialBadge} from 'getsentry/views/subscriptionPage/trial/badge';
 
-type Props = {
+interface Props {
   api: Client;
   children: React.ReactNode;
   organization: Organization;
   subscription: Subscription;
   className?: string;
-};
+}
 
 function TrialStartedSidebarItem({subscription, organization, children}: Props) {
   const [animationComplete, setAnimationComplete] = useState<boolean>(

--- a/static/gsApp/components/trialStarter.tsx
+++ b/static/gsApp/components/trialStarter.tsx
@@ -9,14 +9,14 @@ import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
 import type {Subscription} from 'getsentry/types';
 import {trackMarketingEvent} from 'getsentry/utils/trackMarketingEvent';
 
-type ChildProps = {
+interface ChildProps {
   startTrial: () => Promise<void>;
   subscription: Subscription;
   trialFailed: boolean;
   trialStarted: boolean;
   trialStarting: boolean;
-};
-type Props = {
+}
+interface Props {
   children: (args: ChildProps) => React.ReactNode;
   organization: Organization;
   source: string;
@@ -25,7 +25,7 @@ type Props = {
   // Can't use default prop typings because of HoC wrappers.
   onTrialStarted?: () => void;
   requestData?: Record<string, unknown>;
-};
+}
 
 function TrialStarter(props: Props) {
   const api = useApi({persistInFlight: true});

--- a/static/gsApp/components/upgradeNowModal/actionButtons.tsx
+++ b/static/gsApp/components/upgradeNowModal/actionButtons.tsx
@@ -23,7 +23,7 @@ import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
 import type {Reservations} from './types';
 import {redirectToManage} from './utils';
 
-type Props = {
+interface Props {
   organization: Organization;
   plan: Plan;
   previewData: PreviewData;
@@ -32,7 +32,7 @@ type Props = {
   surface: AM2UpdateSurfaces;
   isActionDisabled?: boolean;
   onComplete?: () => void;
-};
+}
 
 export function ActionButtons({
   isActionDisabled,

--- a/static/gsApp/components/upgradeNowModal/planTable.tsx
+++ b/static/gsApp/components/upgradeNowModal/planTable.tsx
@@ -14,12 +14,12 @@ import {displayPriceWithCents} from 'getsentry/views/amCheckout/utils';
 
 import type {Reservations} from './types';
 
-type Props = {
+interface Props {
   organization: Organization;
   previewData: PreviewData;
   reservations: Reservations;
   subscription: Subscription;
-};
+}
 
 export function PlanTable({
   organization,

--- a/static/gsApp/components/upgradeNowModal/useLogUpgradeNowViewed.tsx
+++ b/static/gsApp/components/upgradeNowModal/useLogUpgradeNowViewed.tsx
@@ -8,12 +8,12 @@ import {
   type AM2UpdateSurfaces,
 } from 'getsentry/utils/trackGetsentryAnalytics';
 
-type Props = {
+interface Props {
   hasPriceChange: boolean;
   organization: Organization;
   subscription: Subscription;
   surface: AM2UpdateSurfaces;
-};
+}
 
 export function useLogUpgradeNowViewed({
   hasPriceChange,

--- a/static/gsApp/components/upgradeNowModal/usePreviewData.tsx
+++ b/static/gsApp/components/upgradeNowModal/usePreviewData.tsx
@@ -32,12 +32,12 @@ type Result =
       reservations: undefined;
     };
 
-type Props = {
+interface Props {
   children: (props: Result) => ReactElement;
   organization: Organization;
   subscription: Subscription;
   enabled?: boolean;
-};
+}
 
 export function usePreviewData({
   organization,

--- a/static/gsApp/components/upgradeNowModal/useUpgradeNowParams.tsx
+++ b/static/gsApp/components/upgradeNowModal/useUpgradeNowParams.tsx
@@ -11,16 +11,16 @@ import {getBucket} from 'getsentry/views/amCheckout/utils';
 
 import type {Reservations} from './types';
 
-type Opts = {
+interface Opts {
   organization: Organization;
   subscription: Subscription;
   enabled?: boolean;
-};
+}
 
-type State = {
+interface State {
   plan: undefined | Plan;
   reservations: undefined | Reservations;
-};
+}
 
 const DEFAULT_STATE: State = {plan: undefined, reservations: undefined};
 

--- a/static/gsApp/components/upgradeOrTrialButton.tsx
+++ b/static/gsApp/components/upgradeOrTrialButton.tsx
@@ -14,10 +14,10 @@ import type {Subscription} from 'getsentry/types';
 import {getTrialLength} from 'getsentry/utils/billing';
 import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
 
-type ChildRenderProps = {
+interface ChildRenderProps {
   action: 'upgrade' | 'trial';
   hasBillingAccess: boolean;
-};
+}
 
 type ChildRenderFunction = (options: ChildRenderProps) => React.ReactNode;
 

--- a/static/gsApp/components/upsellModal/details.tsx
+++ b/static/gsApp/components/upsellModal/details.tsx
@@ -36,7 +36,7 @@ const ROTATE_INTERVAL = 6000;
  */
 const FIRST_ROTATE_TIMEOUT = 10000;
 
-type Props = {
+interface Props {
   onCloseModal: () => void;
   organization: Organization;
   /**
@@ -50,16 +50,16 @@ type Props = {
    * Show specific content related to a trial being rest
    */
   showTrialResetContent?: boolean;
-};
+}
 
-type State = {
+interface State {
   /**
    * When the user clicks a feature we will stop auto-rotating the list of
    * features on a timer.
    */
   hasClickedFeature: boolean;
   highlightedFeatureId: string | null;
-};
+}
 
 /**
  * All available features. Mostly just cataloged into this variable for ease of

--- a/static/gsApp/components/upsellModal/featureList.tsx
+++ b/static/gsApp/components/upsellModal/featureList.tsx
@@ -12,14 +12,14 @@ import {MoreFeaturesLink} from 'getsentry/views/amCheckout/components/moreFeatur
 
 import type {Feature} from './types';
 
-type Props = {
+interface Props {
   features: Feature[];
   onClick: (feat: Feature) => void;
   shouldShowPerformanceFeatures: boolean;
   shouldShowTeamFeatures: boolean;
   selected?: Feature;
   withCountdown?: number;
-};
+}
 
 export function FeatureList({
   features,
@@ -60,11 +60,11 @@ export function FeatureList({
   );
 }
 
-type CountdownRingProps = {
+interface CountdownRingProps {
   id: string;
   theme: Theme;
   totalTime: number;
-};
+}
 
 /**
  * Countdown ring is used to show a countdown ring to the right of the header

--- a/static/gsApp/components/upsellModal/highlightedFeature.tsx
+++ b/static/gsApp/components/upsellModal/highlightedFeature.tsx
@@ -11,11 +11,11 @@ import {displayPlanName, hasPerformance} from 'getsentry/utils/billing';
 
 import type {Feature} from './types';
 
-type Props = {
+interface Props {
   feature: Feature;
   organization: Organization;
   subscription: Subscription;
-};
+}
 
 const IMAGE_SIZE = {height: 'auto', width: '540px'};
 

--- a/static/gsApp/components/upsellModal/types.tsx
+++ b/static/gsApp/components/upsellModal/types.tsx
@@ -1,7 +1,7 @@
-export type Feature = {
+export interface Feature {
   desc: React.ReactNode;
   id: string;
   image: string;
   name: React.ReactNode;
   planFeatures: string[];
-};
+}

--- a/static/gsApp/components/upsellProvider.tsx
+++ b/static/gsApp/components/upsellProvider.tsx
@@ -23,7 +23,7 @@ import {
   type GetsentryEventKey,
 } from 'getsentry/utils/trackGetsentryAnalytics';
 
-type ChildRenderProps = {
+interface ChildRenderProps {
   action:
     | 'start_trial'
     | 'send_to_checkout'
@@ -34,9 +34,9 @@ type ChildRenderProps = {
   defaultButtonText: string;
   hasBillingScope: boolean;
   onClick: (e?: React.MouseEvent) => void;
-};
+}
 
-type Props = {
+interface Props {
   api: Client;
   children: (opts: ChildRenderProps) => React.ReactNode;
   organization: Organization;
@@ -52,7 +52,7 @@ type Props = {
    * if true, non-billing users clicking will trigger trial and plan upgrade requests
    */
   triggerMemberRequests?: boolean;
-};
+}
 
 function LoadingButton(props: {
   defaultOnClick: () => void;

--- a/static/gsApp/components/withSubscription.tsx
+++ b/static/gsApp/components/withSubscription.tsx
@@ -9,28 +9,28 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
 import type {Subscription} from 'getsentry/types';
 
-type InjectedSubscriptionProps = {
+interface InjectedSubscriptionProps {
   subscription: Subscription;
-};
+}
 
-type DependentProps = {
+interface DependentProps {
   organization?: Organization;
   // Generalized type for routing parameters.
   params?: Record<string, any | undefined>;
   subscription?: Subscription;
-};
+}
 
-type Options = {
+interface Options {
   /**
    * Disable displaying the loading indicator while waiting for the
    * subscription to load.
    */
   noLoader?: boolean;
-};
+}
 
-type State = {
+interface State {
   subscription?: Subscription;
-};
+}
 
 /**
  * HoC to inject the subscription object into the wrapped component. The

--- a/static/gsApp/components/zendeskLink.tsx
+++ b/static/gsApp/components/zendeskLink.tsx
@@ -8,7 +8,7 @@ import {activateZendesk, zendeskIsLoaded} from 'sentry/utils/zendesk';
 
 import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
 
-type Props = {
+interface Props {
   organization: Organization;
   Component?: typeof ExternalLink;
   address?: string;
@@ -16,7 +16,7 @@ type Props = {
   className?: string;
   source?: string;
   subject?: string;
-};
+}
 
 function ZendeskLink({
   organization,

--- a/static/gsApp/hooks/analyticsInitUser.tsx
+++ b/static/gsApp/hooks/analyticsInitUser.tsx
@@ -11,10 +11,10 @@ import {trackMarketingEvent} from 'getsentry/utils/trackMarketingEvent';
 const MARKETING_EVENT_SESSION_KEY = 'marketing_event_recorded';
 
 // fields should be string but need to validate
-type MarketingEventSchema = {
+interface MarketingEventSchema {
   event_name: unknown;
   event_label?: unknown;
-};
+}
 
 /**
  * This function initializes the user for analytics (Amplitude)

--- a/static/gsApp/hooks/dashboardsLimit.tsx
+++ b/static/gsApp/hooks/dashboardsLimit.tsx
@@ -65,9 +65,9 @@ export function useDashboardsLimit(): UseDashboardsLimitResult {
   };
 }
 
-type DashboardsLimitProviderProps = {
+interface DashboardsLimitProviderProps {
   children: ((data: UseDashboardsLimitResult & any) => React.ReactNode) | React.ReactNode;
-};
+}
 
 export function DashboardsLimitProvider({
   children,

--- a/static/gsApp/hooks/disabledCustomSymbolSources.tsx
+++ b/static/gsApp/hooks/disabledCustomSymbolSources.tsx
@@ -15,9 +15,9 @@ import {displayPlanName} from 'getsentry/utils/billing';
 
 const FEATURE = 'custom-symbol-sources';
 
-type Props = {
+interface Props {
   organization: Organization;
-};
+}
 
 export function DisabledCustomSymbolSources({organization}: Props) {
   return (

--- a/static/gsApp/hooks/disabledMemberTooltip.tsx
+++ b/static/gsApp/hooks/disabledMemberTooltip.tsx
@@ -6,10 +6,10 @@ import {withSubscription} from 'getsentry/components/withSubscription';
 import type {Subscription} from 'getsentry/types';
 import {displayPlanName} from 'getsentry/utils/billing';
 
-type Props = {
+interface Props {
   children: React.ReactNode;
   subscription: Subscription;
-};
+}
 
 function DisabledMemberTooltip({subscription, children}: Props) {
   // only disabling members for plans with exactly 1 member

--- a/static/gsApp/hooks/disabledMemberView.tsx
+++ b/static/gsApp/hooks/disabledMemberView.tsx
@@ -28,9 +28,9 @@ import {withSubscription} from 'getsentry/components/withSubscription';
 import type {Subscription} from 'getsentry/types';
 import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
 
-type Props = {
+interface Props {
   subscription: Subscription;
-};
+}
 
 function DisabledMemberView(props: Props) {
   const {orgId} = useParams<{orgId: string}>();

--- a/static/gsApp/hooks/firstPartyIntegrationAdditionalCTA.tsx
+++ b/static/gsApp/hooks/firstPartyIntegrationAdditionalCTA.tsx
@@ -4,9 +4,9 @@ import type {Integration} from 'sentry/types/integrations';
 
 import {UpsellButton} from 'getsentry/components/upsellButton';
 
-type Props = {
+interface Props {
   integrations: Integration[];
-};
+}
 
 export function FirstPartyIntegrationAdditionalCTA({integrations}: Props) {
   // only render this upsell CTA when we have disabled integrations or one on grace perioid

--- a/static/gsApp/hooks/firstPartyIntegrationAlertHook.tsx
+++ b/static/gsApp/hooks/firstPartyIntegrationAlertHook.tsx
@@ -9,11 +9,11 @@ import {AlertContainer} from 'sentry/views/settings/organizationIntegrations/int
 
 import {UpsellButton} from 'getsentry/components/upsellButton';
 
-type Props = {
+interface Props {
   integrations: Integration[];
   hideCTA?: boolean;
   wrapWithContainer?: boolean;
-};
+}
 
 export function FirstPartyIntegrationAlertHook({
   integrations,

--- a/static/gsApp/hooks/integrationFeatures.tsx
+++ b/static/gsApp/hooks/integrationFeatures.tsx
@@ -16,23 +16,23 @@ import {useBillingConfig} from 'getsentry/hooks/useBillingConfig';
 import type {BillingConfig, Plan, Subscription} from 'getsentry/types';
 import {displayPlanName} from 'getsentry/utils/billing';
 
-type IntegrationFeature = {
+interface IntegrationFeature {
   description: React.ReactNode;
   featureGate: string;
-};
+}
 
-type GatedFeatureGroup = {
+interface GatedFeatureGroup {
   features: IntegrationFeature[];
   hasFeatures: boolean;
   plan?: Plan;
-};
+}
 
-type MapFeatureGroupsOpts = {
+interface MapFeatureGroupsOpts {
   billingConfig: BillingConfig;
   features: IntegrationFeature[];
   organization: Organization;
   subscription: Subscription;
-};
+}
 
 /**
  * Given a users subscription, billing config, and organization, determine from
@@ -124,7 +124,7 @@ function mapFeatureGroups({
   return {ungatedFeatures, gatedFeatureGroups, disabled, disabledReason};
 }
 
-type RenderProps = {
+interface RenderProps {
   /**
    * Boolean false if the integration may be installed on the current users
    * plan, or a string describing why it cannot be installed.
@@ -142,14 +142,14 @@ type RenderProps = {
    * A list of features that are available for free.
    */
   ungatedFeatures: IntegrationFeature[];
-};
+}
 
-type IntegrationFeaturesProps = {
+interface IntegrationFeaturesProps {
   children: (props: RenderProps) => React.ReactElement;
   features: IntegrationFeature[];
   organization: Organization;
   subscription: Subscription;
-};
+}
 
 function IntegrationFeaturesBase({
   features,
@@ -252,13 +252,13 @@ const HasFeatureIndicator = styled((p: any) => (
   margin-right: 4px;
 `;
 
-type GroupProps = {
+interface GroupProps {
   features: IntegrationFeature[];
   hasFeatures: boolean;
   message: React.ReactNode;
   action?: React.ReactNode;
   className?: string;
-};
+}
 
 const IntegrationFeatureGroup = styled((p: GroupProps) => {
   if (p.features.length === 0) {

--- a/static/gsApp/hooks/memberListHeader.tsx
+++ b/static/gsApp/hooks/memberListHeader.tsx
@@ -14,11 +14,11 @@ import {useBillingConfig} from 'getsentry/hooks/useBillingConfig';
 import type {Subscription} from 'getsentry/types';
 import {displayPlanName, getBestPlanForUnlimitedMembers} from 'getsentry/utils/billing';
 
-type Props = {
+interface Props {
   members: Member[];
   organization: Organization;
   subscription: Subscription;
-};
+}
 
 function MemberListHeader({members, organization, subscription}: Props) {
   const hasDisabledMembers = members.some(isMemberDisabledFromLimit);

--- a/static/gsApp/hooks/orgStatsBanner.tsx
+++ b/static/gsApp/hooks/orgStatsBanner.tsx
@@ -19,11 +19,11 @@ import {
 import {ButtonWrapper, SubscriptionBody} from 'getsentry/views/subscriptionPage/styles';
 import {TrialBadge} from 'getsentry/views/subscriptionPage/trial/badge';
 
-type Props = {
+interface Props {
   organization: Organization;
   subscription: Subscription;
   referrer?: string;
-};
+}
 
 function OrgStatsBanner({organization, subscription, referrer}: Props) {
   if (!subscription.canSelfServe || !hasPerformance(subscription.planDetails)) {

--- a/static/gsApp/hooks/performance/usePerformanceUsageStats.tsx
+++ b/static/gsApp/hooks/performance/usePerformanceUsageStats.tsx
@@ -4,18 +4,18 @@ import type {Organization} from 'sentry/types/organization';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useApiQuery} from 'sentry/utils/queryClient';
 
-type PerformanceStatsGroup = {
+interface PerformanceStatsGroup {
   by: {
     reason: string;
   };
   totals: {
     'sum(quantity)': number;
   };
-};
+}
 
-type PartialUsageStats = {
+interface PartialUsageStats {
   groups?: PerformanceStatsGroup[];
-};
+}
 
 export function usePerformanceUsageStats({
   organization,

--- a/static/gsApp/hooks/targetedOnboardingHeader.tsx
+++ b/static/gsApp/hooks/targetedOnboardingHeader.tsx
@@ -15,10 +15,10 @@ import type {Subscription} from 'getsentry/types';
 import {getTrialDaysLeft} from 'getsentry/utils/billing';
 import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
 
-type Props = {
+interface Props {
   source: string;
   subscription: Subscription;
-};
+}
 
 function TargetedOnboardingHeader({source, subscription}: Props) {
   const organization = useOrganization();

--- a/static/gsApp/hooks/useMetricDetectorLimit.tsx
+++ b/static/gsApp/hooks/useMetricDetectorLimit.tsx
@@ -6,13 +6,13 @@ import {detectorListApiOptions} from 'sentry/views/detectors/hooks/index';
 
 import {useSubscription} from 'getsentry/hooks/useSubscription';
 
-type MetricDetectorLimitResponse = {
+interface MetricDetectorLimitResponse {
   detectorCount: number;
   detectorLimit: number;
   hasReachedLimit: boolean;
   isError: boolean;
   isLoading: boolean;
-};
+}
 
 const UNLIMITED_QUOTA = -1;
 const NO_COUNT = -1;

--- a/static/gsApp/stores/subscriptionStore.tsx
+++ b/static/gsApp/stores/subscriptionStore.tsx
@@ -7,9 +7,9 @@ import type {Subscription} from 'getsentry/types';
 
 type GetCallback = (data: Subscription) => void;
 
-type LoadOptions = {
+interface LoadOptions {
   markStartedTrial?: boolean;
-};
+}
 
 /**
  * Mapping of organizaton slug to subscription details

--- a/static/gsApp/stores/trialRequestedStore.tsx
+++ b/static/gsApp/stores/trialRequestedStore.tsx
@@ -2,13 +2,13 @@ import Reflux from 'reflux';
 
 import {TrialRequestedActions} from 'getsentry/actions/trialRequestedActions';
 
-type State = {
+interface State {
   requested: boolean;
-};
+}
 
-type TrialRequestedStoreInterface = {
+interface TrialRequestedStoreInterface {
   getTrialRequstedState: () => State['requested'];
-};
+}
 
 const storeConfig: Reflux.StoreDefinition & TrialRequestedStoreInterface = {
   state: {

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -37,7 +37,7 @@ declare global {
   }
 
   namespace React {
-    interface DOMAttributes<_T> {
+    interface DOMAttributes<T> {
       'data-test-id'?: string;
     }
   }

--- a/static/gsApp/types/index.tsx
+++ b/static/gsApp/types/index.tsx
@@ -37,7 +37,7 @@ declare global {
   }
 
   namespace React {
-    interface DOMAttributes<T> {
+    interface DOMAttributes<_T> {
       'data-test-id'?: string;
     }
   }
@@ -56,7 +56,7 @@ declare module 'sentry/types/system' {
   }
 }
 
-export type EventBucket = {
+export interface EventBucket {
   events: number;
   price: number;
   onDemandPrice?: number;
@@ -64,7 +64,7 @@ export type EventBucket = {
    * Available in performance plans
    */
   unitPrice?: number;
-};
+}
 
 export enum PlanName {
   DEVELOPER = 'Developer',
@@ -88,7 +88,7 @@ export enum ReservedBudgetCategoryType {
   SEER = 'seer',
 }
 
-export type ReservedBudgetCategory = {
+export interface ReservedBudgetCategory {
   /**
    * The API name of the budget
    */
@@ -133,21 +133,21 @@ export type ReservedBudgetCategory = {
    * The name of the product associated with the budget
    */
   productName: string;
-};
+}
 
 export enum AddOnCategory {
   SEER = 'seer',
   LEGACY_SEER = 'legacySeer',
 }
 
-export type AddOnCategoryInfo = {
+export interface AddOnCategoryInfo {
   apiName: AddOnCategory;
   billingFlag: string | null;
   dataCategories: DataCategory[];
   name: string;
   order: number;
   productName: string;
-};
+}
 
 export type AddOn = AddOnCategoryInfo & {
   /**
@@ -165,12 +165,12 @@ type AddOns = Partial<Record<AddOnCategory, AddOn>>;
 // how addons are represented in the checkout form data
 export type CheckoutAddOns = Partial<Record<AddOnCategory, Pick<AddOn, 'enabled'>>>;
 
-type RetentionSettings = {
+interface RetentionSettings {
   downsampled: number | null;
   standard: number | null;
-};
+}
 
-export type Plan = {
+export interface Plan {
   addOnCategories: Partial<Record<AddOnCategory, AddOnCategoryInfo>>;
   allowAdditionalReservedEvents: boolean;
   allowOnDemand: boolean;
@@ -216,9 +216,9 @@ export type Plan = {
   >;
   checkoutType?: CheckoutType;
   retentions?: Partial<Record<DataCategory, RetentionSettings>>;
-};
+}
 
-type PendingChanges = {
+interface PendingChanges {
   customPrice: number | null;
   customPricePcss: number | null;
   customPrices: Partial<Record<DataCategory, number | null>>;
@@ -232,7 +232,7 @@ type PendingChanges = {
   reserved: Partial<Record<DataCategory, number | null>>;
   reservedBudgets: PendingReservedBudget[];
   reservedCpe: Partial<Record<DataCategory, number | null>>;
-};
+}
 
 enum VatStatus {
   UNKNOWN = 'unknown',
@@ -242,7 +242,7 @@ enum VatStatus {
   OTHER = 'other',
 }
 
-export type GDPRDetails = {
+export interface GDPRDetails {
   dpoAddress: string;
   dpoEmail: string;
   dpoName: string;
@@ -251,9 +251,9 @@ export type GDPRDetails = {
   euRepEmail: string;
   euRepName: string;
   euRepPhone: string;
-};
+}
 
-type Partner = {
+interface Partner {
   externalId: string;
   isActive: boolean;
   name: string;
@@ -262,7 +262,7 @@ type Partner = {
     id: string;
     supportNote: string;
   };
-};
+}
 
 export enum BillingType {
   CREDIT_CARD = 'credit card',
@@ -275,19 +275,19 @@ export enum OnDemandBudgetMode {
   PER_CATEGORY = 'per_category',
 }
 
-export type SharedOnDemandBudget = {
+export interface SharedOnDemandBudget {
   budgetMode: OnDemandBudgetMode.SHARED;
   sharedMaxBudget: number;
-};
+}
 
 type SharedOnDemandBudgetWithSpends = SharedOnDemandBudget & {
   onDemandSpendUsed: number;
 };
 
-export type PerCategoryOnDemandBudget = {
+export interface PerCategoryOnDemandBudget {
   budgetMode: OnDemandBudgetMode.PER_CATEGORY;
   budgets: Partial<Record<DataCategory, number>>;
-};
+}
 
 type PerCategoryOnDemandBudgetWithSpends = PerCategoryOnDemandBudget & {
   usedSpends: Partial<Record<DataCategory, number>>;
@@ -295,9 +295,9 @@ type PerCategoryOnDemandBudgetWithSpends = PerCategoryOnDemandBudget & {
 
 export type OnDemandBudgets = SharedOnDemandBudget | PerCategoryOnDemandBudget;
 
-type OnDemandBudgetsEnabled = {
+interface OnDemandBudgetsEnabled {
   enabled: boolean;
-};
+}
 
 type OnDemandBudgetsWithSpends =
   | SharedOnDemandBudgetWithSpends
@@ -308,7 +308,7 @@ export type SubscriptionOnDemandBudgets = OnDemandBudgetsEnabled &
 
 export type PendingOnDemandBudgets = OnDemandBudgetsEnabled & OnDemandBudgets;
 
-export type ProductTrial = {
+export interface ProductTrial {
   category: DataCategory;
   isStarted: boolean;
   reasonCode: number;
@@ -316,9 +316,9 @@ export type ProductTrial = {
   endDate?: string;
   lengthDays?: number;
   startDate?: string;
-};
+}
 
-export type Subscription = {
+export interface Subscription {
   accountBalance: number;
   billingInterval: 'monthly' | 'annual';
   // billingPeriod varies between 1-12 months. if you're looking for the monthly usage interval, use onDemandPeriodStart
@@ -479,9 +479,9 @@ export type Subscription = {
   vatID?: string | null;
 
   vatStatus?: VatStatus | null;
-};
+}
 
-type DiscountInfo = {
+interface DiscountInfo {
   amount: number;
   billingInterval: 'monthly' | 'annual';
   billingPeriods: number;
@@ -494,9 +494,9 @@ type DiscountInfo = {
   modalDisclaimerText: string;
   planRequirement: 'business' | 'paid' | null;
   reminderText: string;
-};
+}
 
-export type Promotion = {
+export interface Promotion {
   autoOptIn: boolean;
   discountInfo: DiscountInfo;
   endDate: string;
@@ -506,9 +506,9 @@ export type Promotion = {
   slug: string;
   startDate: string;
   timeLimit: string;
-};
+}
 
-export type PromotionClaimed = {
+export interface PromotionClaimed {
   dateClaimed: string;
   dateCompleted: string;
   dateExpired: string;
@@ -516,20 +516,20 @@ export type PromotionClaimed = {
   isLastCycleForFreeEvents: boolean;
   promotion: Promotion;
   claimant?: User;
-};
+}
 
-export type PromotionData = {
+export interface PromotionData {
   activePromotions: PromotionClaimed[];
   availablePromotions: Promotion[];
   completedPromotions: PromotionClaimed[];
-};
+}
 
-export type Feature = {
+export interface Feature {
   description: string;
   name: string;
-};
+}
 
-export type BillingConfig = {
+export interface BillingConfig {
   annualDiscount: number;
   defaultPlan: string;
   defaultReserved: Partial<Record<DataCategory, number>>;
@@ -537,9 +537,9 @@ export type BillingConfig = {
   freePlan: string;
   id: string;
   planList: Plan[];
-};
+}
 
-export type BillingStat = {
+export interface BillingStat {
   accepted: number;
   date: string;
   dropped: {
@@ -557,10 +557,10 @@ export type BillingStat = {
    * Not present when user does not have the correct role
    */
   onDemandCostRunningTotal?: number;
-};
+}
 export type BillingStats = BillingStat[];
 
-export type BillingStatTotal = {
+export interface BillingStatTotal {
   accepted: number;
   dropped: number;
   droppedOther: number;
@@ -568,29 +568,29 @@ export type BillingStatTotal = {
   droppedSpikeProtection: number;
   filtered: number;
   projected: number;
-};
+}
 
-export type CustomerUsage = {
+export interface CustomerUsage {
   periodEnd: string;
   periodStart: string;
   stats: Record<string, BillingStats>;
   totals: Record<string, BillingStatTotal>;
   eventTotals?: Record<string, Record<string, BillingStatTotal>>;
-};
+}
 
-type StructuredAddress = {
+interface StructuredAddress {
   addressLine1: string | null;
   addressLine2: string | null;
   city: string | null;
   countryCode: string | null;
   postalCode: string | null;
   region: string | null;
-};
+}
 
-type TaxNumberName = {
+interface TaxNumberName {
   taxId: string;
   taxIdName: string;
-};
+}
 
 type SentryTaxIds = TaxNumberName & {
   region?: TaxNumberName & {
@@ -598,7 +598,7 @@ type SentryTaxIds = TaxNumberName & {
   };
 };
 
-export type Charge = {
+export interface Charge {
   amount: number;
   amountRefunded: number;
   cardLast4: string | null;
@@ -608,7 +608,7 @@ export type Charge = {
   isPaid: boolean;
   isRefunded: boolean;
   stripeID: string | null;
-};
+}
 
 export type InvoiceBase = StructuredAddress & {
   amount: number;
@@ -656,12 +656,12 @@ export type Invoice = InvoiceBase & {
   stripeInvoiceID: string | null;
 };
 
-type BaseInvoiceItem = {
+interface BaseInvoiceItem {
   amount: number;
   data: {period?: any; plan?: any; quantity?: any};
   description: string;
   type: InvoiceItemType;
-};
+}
 
 export type InvoiceItem = BaseInvoiceItem & {
   periodEnd: string;
@@ -810,7 +810,7 @@ export enum InvoiceStatus {
   AWAITING_PAYMENT = 'awaiting payment',
 }
 
-export type BillingMetricHistory = {
+export interface BillingMetricHistory {
   /**
    * Category name (e.g. "errors")
    */
@@ -834,9 +834,9 @@ export type BillingMetricHistory = {
   usage: number;
   usageExceeded: boolean;
   retention?: {downsampled: number | null; standard: number | null};
-};
+}
 
-export type BillingHistory = {
+export interface BillingHistory {
   categories: Record<string, BillingMetricHistory>;
   hadCustomDynamicSampling: boolean;
   id: string;
@@ -857,9 +857,9 @@ export type BillingHistory = {
   usage: Partial<Record<DataCategory, number>>;
   planDetails?: Plan;
   reservedBudgets?: ReservedBudget[];
-};
+}
 
-export type PreviewData = {
+export interface PreviewData {
   atPeriodEnd: boolean;
   balanceChange: number;
   billedAmount: number;
@@ -871,7 +871,7 @@ export type PreviewData = {
   proratedAmount: number;
   paymentIntent?: string;
   paymentSecret?: string;
-};
+}
 
 export type PreviewInvoiceItem = BaseInvoiceItem & {
   period_end: string;
@@ -912,12 +912,12 @@ type StaticCreditType =
  */
 export type CreditType = DynamicCreditType | StaticCreditType;
 
-type BaseRecurringCredit = {
+interface BaseRecurringCredit {
   amount: number;
   id: number;
   periodEnd: string;
   periodStart: string;
-};
+}
 
 interface RecurringDiscount extends BaseRecurringCredit {
   totalAmountRemaining: number;
@@ -962,13 +962,13 @@ export enum CohortId {
   TEST_ONE = 111,
 }
 
-export type Cohort = {
+export interface Cohort {
   cohortId: CohortId;
   nextPlan: NextPlanInfo | null;
   secondDiscount: number;
-};
+}
 
-export type NextPlanInfo = {
+export interface NextPlanInfo {
   contractPeriod: string;
   discountAmount: number;
   discountMonths: number;
@@ -985,9 +985,9 @@ export type NextPlanInfo = {
       }
     >
   >;
-};
+}
 
-export type PlanMigration = {
+export interface PlanMigration {
   cohort: Cohort | null;
   dateApplied: string | null;
   effectiveAt: string | null;
@@ -995,7 +995,7 @@ export type PlanMigration = {
   planTier: string;
   recurringCredits: RecurringCredit[];
   scheduled: boolean;
-};
+}
 
 export enum PlanTier {
   /**
@@ -1033,19 +1033,19 @@ export enum PlanTier {
 }
 
 // Response from /organizations/:orgSlug/payments/:invoiceId/new/
-export type PaymentCreateResponse = {
+export interface PaymentCreateResponse {
   amount: string;
   clientSecret: string;
   currency: string;
   returnUrl: string;
-};
+}
 // Response from /organizations/:orgSlug/payments/setup/
-export type PaymentSetupCreateResponse = {
+export interface PaymentSetupCreateResponse {
   clientSecret: string;
   id: string;
   lastError: string | null;
   status: string;
-};
+}
 
 export enum FTCConsentLocation {
   CHECKOUT = 0,
@@ -1071,10 +1071,10 @@ export interface MonitorCountResponse {
   overQuotaMonitorCount: number;
 }
 
-export type PendingReservedBudget = {
+export interface PendingReservedBudget {
   categories: Partial<Record<DataCategory, boolean | null>>;
   reservedBudget: number;
-};
+}
 
 export type ReservedBudget = {
   /**
@@ -1103,28 +1103,28 @@ export type ReservedBudget = {
   totalReservedSpend: number;
 } & ReservedBudgetCategory;
 
-export type ReservedBudgetMetricHistory = {
+export interface ReservedBudgetMetricHistory {
   reservedCpe: number; // in cents
   reservedSpend: number;
-};
+}
 
-export type ReservedBudgetForCategory = {
+export interface ReservedBudgetForCategory {
   apiName: string;
   freeBudget: number;
   prepaidBudget: number;
   reservedCpe: number; // in cents
   reservedSpend: number;
   totalReservedBudget: number;
-};
+}
 
-type PolicyConsent = {
+interface PolicyConsent {
   acceptedVersion: string;
   createdAt: string;
   userEmail: string;
   userName: string;
-};
+}
 
-export type Policy = {
+export interface Policy {
   active: boolean;
   /** Policy consent signature data if policy has been signed. Null if not signed or hasSignature is false. */
   consent: PolicyConsent | null;
@@ -1142,21 +1142,21 @@ export type Policy = {
   url: string | null;
   /** The current version */
   version: string | null;
-};
+}
 
-type PolicyFile = {
+interface PolicyFile {
   checksum: string;
   name: string;
   size: number;
-};
+}
 
-export type PolicyRevision = {
+export interface PolicyRevision {
   createdAt: string;
   current: boolean;
   file: PolicyFile | null;
   url: string | null;
   version: string;
-};
+}
 
 export interface BilledDataCategoryInfo extends DataCategoryInfo {
   /**
@@ -1212,7 +1212,7 @@ type SeatStatus =
   | 'REMOVED'
   | 'REALLOCATED';
 
-export type BillingSeatAssignment = {
+export interface BillingSeatAssignment {
   billingMetric: DataCategory;
   created: string;
   displayName: string;
@@ -1221,4 +1221,4 @@ export type BillingSeatAssignment = {
   projectId: number;
   seatIdentifier: string;
   status: SeatStatus;
-};
+}

--- a/static/gsApp/utils/ISO3166codes.ts
+++ b/static/gsApp/utils/ISO3166codes.ts
@@ -1,8 +1,8 @@
-type CountryCode = {
+interface CountryCode {
   code: string;
   'country-code': string;
   name: string;
-};
+}
 
 const countryCodes: CountryCode[] = [
   // prioritize the US, since majority of customers are from there

--- a/static/gsApp/utils/billing.tsx
+++ b/static/gsApp/utils/billing.tsx
@@ -125,12 +125,12 @@ export const getSlot = (
  * isGifted: For gifted data volumes, 0 is displayed as 0 instead of unlimited.
  * useUnitScaling: For Attachments only. Scale from KB -> MB -> GB -> TB -> etc
  */
-type FormatOptions = {
+interface FormatOptions {
   fractionDigits?: number;
   isAbbreviated?: boolean;
   isGifted?: boolean;
   useUnitScaling?: boolean;
-};
+}
 
 /**
  * This expects values from CustomerSerializer, which contains quota/reserved

--- a/static/gsApp/utils/dataCategory.tsx
+++ b/static/gsApp/utils/dataCategory.tsx
@@ -49,13 +49,13 @@ export function getCreditDataCategory(credit: RecurringCredit): DataCategory | n
   return category;
 }
 
-type CategoryNameProps = {
+interface CategoryNameProps {
   category: DataCategory;
   capitalize?: boolean;
   hadCustomDynamicSampling?: boolean;
   plan?: Plan;
   title?: boolean;
-};
+}
 
 /**
  * Convert a billed category to a display name.

--- a/static/gsApp/utils/salesTax.tsx
+++ b/static/gsApp/utils/salesTax.tsx
@@ -2,11 +2,11 @@ import {t} from 'sentry/locale';
 
 import type {BillingDetails} from 'getsentry/types';
 
-type TaxFieldInfo = {
+interface TaxFieldInfo {
   label: string;
   placeholder: string;
   taxNumberName: string;
-};
+}
 
 const getTaxFieldInfo = (countryCode?: BillingDetails['countryCode']): TaxFieldInfo =>
   // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message

--- a/static/gsApp/utils/trackGetsentryAnalytics.tsx
+++ b/static/gsApp/utils/trackGetsentryAnalytics.tsx
@@ -6,7 +6,9 @@ import {makeAnalyticsFunction} from 'sentry/utils/analytics/makeAnalyticsFunctio
 import type {EventType} from 'getsentry/components/addEventsCTA';
 import type {AddOnCategory, CheckoutType, Subscription} from 'getsentry/types';
 
-type HasSub = {subscription: Subscription};
+interface HasSub {
+  subscription: Subscription;
+}
 type QuotaAlert = {event_types: string; is_warning: boolean; source?: string} & HasSub;
 type UpsellProvider = {
   action: string;
@@ -22,9 +24,9 @@ type AddEventCTA = HasSub & {
   source: string;
   event_types?: string;
 };
-type BillingInfoUpdateEvent = {
+interface BillingInfoUpdateEvent {
   referrer?: string;
-};
+}
 type ManualPaymentEvent = BillingInfoUpdateEvent;
 
 type OnDemandBudgetStrategy = 'per_category' | 'shared';
@@ -38,13 +40,13 @@ type OnDemandBudgetUpdate = Partial<Record<OnDemandCategory, number>> & {
   total_budget: number;
 };
 
-export type ProductUnavailableUpsellAlert = {
+export interface ProductUnavailableUpsellAlert {
   action: 'update_plan' | 'manage_subscription' | 'request_update';
   has_performance: boolean;
   has_session_replay: boolean;
-};
+}
 
-type GetsentryEventParameters = {
+interface GetsentryEventParameters {
   'add_event_cta.clicked_cta': AddEventCTA;
   'am_checkout.viewed': HasSub;
   'billing_details.updated_billing_details': BillingInfoUpdateEvent;
@@ -253,7 +255,7 @@ type GetsentryEventParameters = {
   'usage_exceeded_modal.seen': HasSub;
   'zendesk_link.clicked': {source?: string};
   'zendesk_link.viewed': {source?: string};
-};
+}
 
 export type AM2UpdateSurfaces =
   | 'metrics'

--- a/static/gsApp/utils/trackSpendVisibilityAnalytics.tsx
+++ b/static/gsApp/utils/trackSpendVisibilityAnalytics.tsx
@@ -13,13 +13,13 @@ export enum SpendVisibilityEvents {
 }
 
 // The base params for these analytics
-export type SpendVisibilityBaseParams = {
+export interface SpendVisibilityBaseParams {
   subscription?: Subscription;
   view?: 'spike_protection_settings' | 'project_settings' | 'project_stats';
-};
+}
 
 // The parameters required for each event type
-type SpendVisibilityEventParameters = {
+interface SpendVisibilityEventParameters {
   [SpendVisibilityEvents.SP_DOCS_CLICKED]: SpendVisibilityBaseParams & {};
   [SpendVisibilityEvents.SP_DISCOVER_CLICKED]: SpendVisibilityBaseParams & {};
   [SpendVisibilityEvents.SP_PROJECT_TOGGLED]: SpendVisibilityBaseParams & {
@@ -28,7 +28,7 @@ type SpendVisibilityEventParameters = {
   };
   [SpendVisibilityEvents.SP_PROJECT_SEARCHED]: SpendVisibilityBaseParams & {};
   [SpendVisibilityEvents.SP_SETTINGS_VIEWED]: SpendVisibilityBaseParams & {};
-};
+}
 
 // A mapping of event key to readable, searchable name
 const spendVisibilityEventMap: Record<SpendVisibilityEvents, string> = {

--- a/static/gsApp/utils/withPromotions.tsx
+++ b/static/gsApp/utils/withPromotions.tsx
@@ -10,13 +10,13 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import type {PromotionData} from 'getsentry/types';
 import {usePromotionTriggerCheck} from 'getsentry/utils/usePromotionTriggerCheck';
 
-type InjectedPromotionProps = {
+interface InjectedPromotionProps {
   isError?: boolean;
   isLoading?: boolean;
   promotionData?: PromotionData;
   queryClient?: QueryClient;
   refetch?: () => Promise<QueryObserverResult<PromotionData, unknown>>;
-};
+}
 
 export const withPromotions = <P extends InjectedPromotionProps>(
   WrappedComponent: React.ComponentType<P> | typeof LoadingIndicator

--- a/static/gsApp/views/amCheckout/components/billingCycleSelectCard.tsx
+++ b/static/gsApp/views/amCheckout/components/billingCycleSelectCard.tsx
@@ -13,7 +13,7 @@ import {displayBudgetName, isDeveloperPlan} from 'getsentry/utils/billing';
 import {CheckoutOption} from 'getsentry/views/amCheckout/components/checkoutOption';
 import type {CheckoutFormData} from 'getsentry/views/amCheckout/types';
 
-type BillingCycleSelectCardProps = {
+interface BillingCycleSelectCardProps {
   formattedPriceAfterDiscount: string;
   formattedPriceBeforeDiscount: string;
   isSelected: boolean;
@@ -21,7 +21,7 @@ type BillingCycleSelectCardProps = {
   plan: Plan;
   priceAfterDiscount: number;
   subscription: Subscription;
-};
+}
 
 export function BillingCycleSelectCard({
   subscription,

--- a/static/gsApp/views/amCheckout/components/cartDiff.tsx
+++ b/static/gsApp/views/amCheckout/components/cartDiff.tsx
@@ -372,8 +372,8 @@ export function CartDiff({
     currentValues: Partial<Record<DataCategory, number>>;
     newValues: Partial<Record<DataCategory, number>>;
     shouldIncludeZero?: boolean;
-  }): ReservedChange[] | PerCategoryOnDemandChange[] => {
-    const nodes: ReservedChange[] | PerCategoryOnDemandChange[] = [];
+  }) => {
+    const nodes: ReservedChange[] = [];
 
     Object.entries(newValues).forEach(([category, newValue]) => {
       let currentValue = null;

--- a/static/gsApp/views/amCheckout/components/cartDiff.tsx
+++ b/static/gsApp/views/amCheckout/components/cartDiff.tsx
@@ -42,11 +42,11 @@ const DEFAULT_PAYG_BUDGET: SharedOnDemandBudget = {
   sharedMaxBudget: 0,
 };
 
-type CheckoutChange<K, V> = {
+interface CheckoutChange<K, V> {
   currentValue: V | null;
   key: K;
   newValue: V | null;
-};
+}
 
 type PlanChange = CheckoutChange<'plan', string>;
 

--- a/static/gsApp/views/amCheckout/components/moreFeaturesLink.tsx
+++ b/static/gsApp/views/amCheckout/components/moreFeaturesLink.tsx
@@ -6,10 +6,10 @@ import {IconCheckmark} from 'sentry/icons';
 import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
 
-type Props = {
+interface Props {
   color?: string;
   legacySize?: SVGIconProps['legacySize'];
-};
+}
 
 export function MoreFeaturesLink({color, legacySize}: Props) {
   return (

--- a/static/gsApp/views/amCheckout/components/planFeatures.tsx
+++ b/static/gsApp/views/amCheckout/components/planFeatures.tsx
@@ -47,7 +47,7 @@ type FeatureKey =
   | 'relay'
   | DataCategory;
 
-type FeatureInfo = {
+interface FeatureInfo {
   /**
    * A mapping where the key is the minimum plan type needed to
    * display the feature, and the value is the display string.
@@ -57,7 +57,7 @@ type FeatureInfo = {
   displayStringPrefix?: string;
   displayStringSuffix?: string;
   excludedTiers?: PlanTier[];
-};
+}
 
 const ORDERED_PLAN_TYPES = ['developer', 'team', 'business'];
 

--- a/static/gsApp/views/amCheckout/components/stepHeader.tsx
+++ b/static/gsApp/views/amCheckout/components/stepHeader.tsx
@@ -2,9 +2,9 @@ import kebabCase from 'lodash/kebabCase';
 
 import {Heading} from '@sentry/scraps/text';
 
-type Props = {
+interface Props {
   title: string;
-};
+}
 
 export function StepHeader({title}: Props) {
   const dataTestId = `header-${kebabCase(title)}`;

--- a/static/gsApp/views/amCheckout/components/unitTypeItem.tsx
+++ b/static/gsApp/views/amCheckout/components/unitTypeItem.tsx
@@ -3,11 +3,11 @@ import styled from '@emotion/styled';
 import {PanelItem} from 'sentry/components/panels/panelItem';
 import {t} from 'sentry/locale';
 
-type UnitTypeProps = {
+interface UnitTypeProps {
   description: React.ReactNode;
   unitName: React.ReactNode;
   weight: string;
-};
+}
 
 export function UnitTypeItem({unitName, description, weight}: UnitTypeProps) {
   return (

--- a/static/gsApp/views/amCheckout/index.tsx
+++ b/static/gsApp/views/amCheckout/index.tsx
@@ -74,7 +74,7 @@ import {
   parseOnDemandBudgetsFromSubscription,
 } from 'getsentry/views/spendLimits/utils';
 
-type Props = {
+interface Props {
   api: Client;
   checkoutTier: PlanTier;
   isError: boolean;
@@ -85,9 +85,9 @@ type Props = {
   queryClient: QueryClient;
   subscription: Subscription;
   promotionData?: PromotionData;
-};
+}
 
-export type State = {
+export interface State {
   billingConfig: BillingConfig | null;
   error: Error | boolean;
   formData: CheckoutFormData | null;
@@ -97,7 +97,7 @@ export type State = {
   nextQueryParams: string[];
   invoice?: Invoice;
   previewData?: PreviewData;
-};
+}
 
 function AMCheckout(props: Props) {
   const {

--- a/static/gsApp/views/amCheckout/steps/reserveAdditionalVolume.spec.tsx
+++ b/static/gsApp/views/amCheckout/steps/reserveAdditionalVolume.spec.tsx
@@ -12,7 +12,7 @@ import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
 import {PlanTier, type Subscription} from 'getsentry/types';
 import {ReserveAdditionalVolume} from 'getsentry/views/amCheckout/steps/reserveAdditionalVolume';
 
-type SliderInfo = {
+interface SliderInfo {
   billingInterval: string;
   category: string;
   max: string;
@@ -20,7 +20,7 @@ type SliderInfo = {
   selectedTier: string;
   pricePerEvent?: string;
   tierPrice?: number;
-};
+}
 
 function assertSlider({
   category,

--- a/static/gsApp/views/amCheckout/types.tsx
+++ b/static/gsApp/views/amCheckout/types.tsx
@@ -12,13 +12,13 @@ import type {
   Subscription,
 } from 'getsentry/types';
 
-type BaseCheckoutData = {
+interface BaseCheckoutData {
   plan: string;
   addOns?: CheckoutAddOns;
   applyNow?: boolean;
   onDemandBudget?: OnDemandBudgets;
   onDemandMaxSpend?: number;
-};
+}
 
 export type CheckoutFormData = BaseCheckoutData & {
   reserved: Partial<Record<DataCategory, number>>;
@@ -31,7 +31,7 @@ export type CheckoutAPIData = Omit<BaseCheckoutData, 'addOns'> & {
 } & Partial<Reservations> &
   Partial<Record<`addOn${Capitalize<AddOnCategory>}`, boolean>>;
 
-export type StepProps = {
+export interface StepProps {
   activePlan: Plan;
   billingConfig: BillingConfig;
   formData: CheckoutFormData;
@@ -41,10 +41,10 @@ export type StepProps = {
   subscription: Subscription;
   checkoutTier?: PlanTier;
   referrer?: string;
-};
+}
 
-export type PlanContent = {
+export interface PlanContent {
   description: React.ReactNode;
   features: Record<string, React.ReactNode>;
   hasMoreLink?: boolean;
-};
+}

--- a/static/gsApp/views/amCheckout/utils.tsx
+++ b/static/gsApp/views/amCheckout/utils.tsx
@@ -62,20 +62,20 @@ const CURRENCY_LOCALE = 'en-US';
  * 100.30 => $100.30
  * -100 => -$100
  */
-type DisplayPriceTypes = {
+interface DisplayPriceTypes {
   cents: number;
   formatBigNum?: boolean;
-};
+}
 
 // Intent details returned by CustomerSubscriptionEndpoint
 // when there is an error and customer card actions are
 // required.
-export type IntentDetails = {
+export interface IntentDetails {
   paymentIntent: string;
   paymentSecret: string;
-};
+}
 
-type APIDataProps = {
+interface APIDataProps {
   formData: CheckoutFormData;
   isPreview?: boolean;
   onDemandBudget?: OnDemandBudgets;
@@ -83,7 +83,7 @@ type APIDataProps = {
   previewToken?: PreviewData['previewToken'];
   referrer?: string;
   shouldUpdateOnDemand?: boolean;
-};
+}
 
 export function displayPrice({cents, formatBigNum = false}: DisplayPriceTypes): string {
   const dollars = cents / 100;
@@ -128,11 +128,11 @@ export function displayPriceWithCents({
   );
 }
 
-type UnitPriceProps = {
+interface UnitPriceProps {
   cents: number;
   maxDigits?: number;
   minDigits?: number;
-};
+}
 
 /**
  * Includes cents in the price when needed and excludes $ for separate formatting.
@@ -188,7 +188,7 @@ export function getBucket({
   throw new Error('Invalid data category for plan');
 }
 
-type ReservedTotalProps = {
+interface ReservedTotalProps {
   plan: Plan;
   reserved: Partial<Record<DataCategory, number>>;
   addOns?: CheckoutAddOns;
@@ -196,7 +196,7 @@ type ReservedTotalProps = {
   creditCategory?: InvoiceItemType;
   discountType?: string;
   maxDiscount?: number;
-};
+}
 
 /**
  * Returns the price for a reserved budget category (ie. Seer) in cents.
@@ -269,12 +269,12 @@ export function getReservedPriceCents({
   return reservedCents;
 }
 
-type DiscountedPriceProps = {
+interface DiscountedPriceProps {
   amount: number;
   basePrice: number;
   creditCategory: InvoiceItemType | null;
   discountType: string;
-};
+}
 
 /**
  * Gets the price in cents after the discount is applied.

--- a/static/gsApp/views/cancelSubscription.tsx
+++ b/static/gsApp/views/cancelSubscription.tsx
@@ -87,13 +87,13 @@ const CANCEL_STEPS: Array<{
   },
 ];
 
-type State = {
+interface State {
   canSubmit: boolean;
   checkboxes: Record<string, boolean>;
   showFollowup: boolean;
   understandsMembers: boolean;
   val: CancelReason[0] | null;
-};
+}
 
 function CancelSubscriptionForm() {
   const organization = useOrganization();

--- a/static/gsApp/views/invoiceDetails/actions.tsx
+++ b/static/gsApp/views/invoiceDetails/actions.tsx
@@ -20,11 +20,11 @@ import {openInvoicePaymentModal} from 'getsentry/actionCreators/modal';
 import type {Invoice} from 'getsentry/types';
 import {trackGetsentryAnalytics} from 'getsentry/utils/trackGetsentryAnalytics';
 
-type Props = {
+interface Props {
   invoice: Invoice;
   organization: Organization;
   reloadInvoice: () => void;
-};
+}
 
 export function InvoiceDetailsActions({organization, invoice, reloadInvoice}: Props) {
   const api = useApi();

--- a/static/gsApp/views/invoiceDetails/index.tsx
+++ b/static/gsApp/views/invoiceDetails/index.tsx
@@ -196,10 +196,10 @@ function InvoiceDetails() {
   );
 }
 
-type AttributeProps = {
+interface AttributeProps {
   invoice: Invoice;
   billingDetails?: BillingDetails;
-};
+}
 
 function InvoiceAttributes({invoice, billingDetails}: AttributeProps) {
   let paymentStatus = InvoiceStatus.CLOSED;
@@ -255,10 +255,10 @@ function InvoiceAttributes({invoice, billingDetails}: AttributeProps) {
   );
 }
 
-type ContentsProps = {
+interface ContentsProps {
   invoice: Invoice;
   billingDetails?: BillingDetails;
-};
+}
 
 function InvoiceDetailsContents({billingDetails, invoice}: ContentsProps) {
   // If an Invoice has 'isReverseCharge: true', it should be noted in

--- a/static/gsApp/views/legalAndCompliance/policyRow.tsx
+++ b/static/gsApp/views/legalAndCompliance/policyRow.tsx
@@ -18,14 +18,14 @@ import type {Policy, Subscription} from 'getsentry/types';
 import {PolicyStatus} from 'getsentry/views/legalAndCompliance/policyStatus';
 import {PanelItemPolicy} from 'getsentry/views/legalAndCompliance/styles';
 
-type PolicyRowProps = {
+interface PolicyRowProps {
   onAccept: (policy: Policy) => void;
   policies: Record<string, Policy>;
   policy: Policy;
   subscription: Subscription;
   showConsentText?: boolean;
   showUpdated?: boolean;
-};
+}
 
 // TODO(dcramer): we dont yet support multiple parent policies if a policy in the
 // chain does not require signature (and instead would just have you page through it)

--- a/static/gsApp/views/legalAndCompliance/policyStatus.tsx
+++ b/static/gsApp/views/legalAndCompliance/policyStatus.tsx
@@ -7,14 +7,14 @@ import {IconCheckmark, IconSubtract} from 'sentry/icons';
 
 import type {Policy} from 'getsentry/types';
 
-type PolicyStatusProps = {
+interface PolicyStatusProps {
   policy: Policy;
-};
+}
 
-type StatusIconProps = {
+interface StatusIconProps {
   icon: React.ReactNode;
   tooltip: string;
-};
+}
 
 export function StatusIconWithTooltip({icon, tooltip}: StatusIconProps) {
   return (

--- a/static/gsApp/views/seerAutomation/onboarding/onboardingLegacy.tsx
+++ b/static/gsApp/views/seerAutomation/onboarding/onboardingLegacy.tsx
@@ -50,11 +50,11 @@ import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageH
 import {AddAutofixRepoModal} from 'sentry/views/settings/projectSeer/addAutofixRepoModal';
 import {SEER_THRESHOLD_OPTIONS} from 'sentry/views/settings/projectSeer/constants';
 
-type ProjectState = {
+interface ProjectState {
   isPending: boolean;
   preference: any;
   codeMappingRepos?: SeerRepoDefinition[];
-};
+}
 
 type ProjectStateMap = Record<string, ProjectState>;
 

--- a/static/gsApp/views/spendAllocations/components/allocationRow.tsx
+++ b/static/gsApp/views/spendAllocations/components/allocationRow.tsx
@@ -14,12 +14,12 @@ import {bigNumFormatter} from 'getsentry/views/spendAllocations/utils';
 import {Cell, Centered, Divider, HalvedWithDivider} from './styles';
 import type {SpendAllocation} from './types';
 
-type AllocationRowProps = {
+interface AllocationRowProps {
   allocation: SpendAllocation;
   deleteAction: (e: React.MouseEvent) => void;
   metricUnit: BigNumUnits;
   openForm: (e: React.MouseEvent) => void;
-};
+}
 
 export function AllocationRow({
   allocation,

--- a/static/gsApp/views/spendAllocations/components/projectSelectControl.tsx
+++ b/static/gsApp/views/spendAllocations/components/projectSelectControl.tsx
@@ -12,12 +12,12 @@ import type {SelectValue} from 'sentry/types/core';
 import type {Project} from 'sentry/types/project';
 import {useProjects} from 'sentry/utils/useProjects';
 
-type Props = {
+interface Props {
   disabled: boolean;
   filteredIdList: string[];
   onChange: (option: SelectValue<string>) => void;
   value: string; // project ID
-};
+}
 
 export function ProjectSelectControl({
   disabled,

--- a/static/gsApp/views/spendAllocations/components/types.ts
+++ b/static/gsApp/views/spendAllocations/components/types.ts
@@ -1,4 +1,4 @@
-export type SpendAllocation = {
+export interface SpendAllocation {
   billingMetric: string;
   consumedQuantity: number;
   costPerItem: number;
@@ -9,4 +9,4 @@ export type SpendAllocation = {
   targetId: number;
   targetSlug: string;
   targetType: string;
-};
+}

--- a/static/gsApp/views/spendAllocations/enableSpendAllocations.tsx
+++ b/static/gsApp/views/spendAllocations/enableSpendAllocations.tsx
@@ -7,13 +7,13 @@ import type {Client} from 'sentry/api';
 import {Panel} from 'sentry/components/panels/panel';
 import {t} from 'sentry/locale';
 
-type Props = {
+interface Props {
   api: Client;
   fetchSpendAllocations: () => Promise<void>;
   hasScope: boolean;
   orgSlug: string;
   setErrors: Dispatch<string | null>;
-};
+}
 
 export function EnableSpendAllocations({
   hasScope,

--- a/static/gsApp/views/spendAllocations/index.tsx
+++ b/static/gsApp/views/spendAllocations/index.tsx
@@ -48,10 +48,10 @@ import {ProjectAllocationsTable} from './projectAllocationsTable';
 import {RootAllocationCard} from './rootAllocationCard';
 import {BigNumUnits} from './utils';
 
-type Props = {
+interface Props {
   organization: Organization;
   subscription: Subscription;
-};
+}
 
 export function SpendAllocationsRoot({organization, subscription}: Props) {
   const theme = useTheme();

--- a/static/gsApp/views/spendAllocations/projectAllocationsTable.tsx
+++ b/static/gsApp/views/spendAllocations/projectAllocationsTable.tsx
@@ -15,7 +15,7 @@ import type {SpendAllocation} from './components/types';
 import type {BigNumUnits} from './utils';
 import {midPeriod} from './utils';
 
-type Props = {
+interface Props {
   deleteSpendAllocation: (
     selectedMetric: DataCategory | null,
     targetId: number,
@@ -26,7 +26,7 @@ type Props = {
   openForm: (formData?: SpendAllocation) => (e: React.MouseEvent) => void;
   selectedMetric: DataCategory;
   spendAllocations?: SpendAllocation[];
-};
+}
 
 export function ProjectAllocationsTable({
   deleteSpendAllocation,

--- a/static/gsApp/views/spendAllocations/rootAllocationCard.tsx
+++ b/static/gsApp/views/spendAllocations/rootAllocationCard.tsx
@@ -22,12 +22,12 @@ import {Card, HalvedGrid} from './components/styles';
 import type {SpendAllocation} from './components/types';
 import {bigNumFormatter, BigNumUnits} from './utils';
 
-type Props = {
+interface Props {
   createRootAllocation: (e: React.MouseEvent) => void;
   selectedMetric: string;
   subscription: Subscription;
   rootAllocation?: SpendAllocation;
-};
+}
 
 export function RootAllocationCard({
   createRootAllocation,

--- a/static/gsApp/views/spendLimits/editModal.tsx
+++ b/static/gsApp/views/spendLimits/editModal.tsx
@@ -56,11 +56,11 @@ type Props = {
   subscription: Subscription;
 } & ModalRenderProps;
 
-type State = {
+interface State {
   currentOnDemandBudget: OnDemandBudgets;
   onDemandBudget: OnDemandBudgets;
   updateError: undefined | Error | string | Record<string, string[]>;
-};
+}
 class SpendLimitsEditModal extends Component<Props, State> {
   constructor(props: Props) {
     super(props);

--- a/static/gsApp/views/spendLimits/utils.tsx
+++ b/static/gsApp/views/spendLimits/utils.tsx
@@ -88,11 +88,11 @@ export function isOnDemandBudgetsEqual(
   return isEqual(value, other);
 }
 
-type DisplayNameProps = {
+interface DisplayNameProps {
   budget: PerCategoryOnDemandBudget;
   categories: DataCategory[];
   plan: Plan;
-};
+}
 
 function listBudgets({plan, categories, budget}: DisplayNameProps) {
   const categoryNames = categories.map(category => {

--- a/static/gsApp/views/spikeProtection/components/accordionRow.tsx
+++ b/static/gsApp/views/spikeProtection/components/accordionRow.tsx
@@ -5,7 +5,7 @@ import {motion} from 'framer-motion';
 
 import {IconChevron} from 'sentry/icons';
 
-type AccordionRowProps = {
+interface AccordionRowProps {
   /**
    * The body of the accordion that is shown & hidden
    */
@@ -26,7 +26,7 @@ type AccordionRowProps = {
    * Action to execute upon opening accordion
    */
   onOpen?: () => Promise<void>;
-};
+}
 
 export function AccordionRow({
   disabled = false,

--- a/static/gsApp/views/spikeProtection/index.tsx
+++ b/static/gsApp/views/spikeProtection/index.tsx
@@ -20,7 +20,10 @@ import {SPIKE_PROTECTION_DOCS_LINK} from 'getsentry/views/spikeProtection/consta
 import SpikeProtectionProjects from 'getsentry/views/spikeProtection/spikeProtectionProjects';
 import {SubscriptionPageContainer} from 'getsentry/views/subscriptionPage/components/subscriptionPageContainer';
 
-type Props = {organization: Organization; subscription: Subscription};
+interface Props {
+  organization: Organization;
+  subscription: Subscription;
+}
 
 function SpikeProtectionRoot({organization, subscription}: Props) {
   useEffect(() => {

--- a/static/gsApp/views/spikeProtection/spikeProtectionHistoryTable.tsx
+++ b/static/gsApp/views/spikeProtection/spikeProtectionHistoryTable.tsx
@@ -45,7 +45,7 @@ import type {SpikeDetails} from 'getsentry/views/spikeProtection/types';
 
 import {isSpikeProtectionEnabled} from './spikeProtectionProjectToggle';
 
-type Props = {
+interface Props {
   dataCategoryInfo: DataCategoryInfo;
   onEnableSpikeProtection: () => void;
   organization: Organization;
@@ -53,7 +53,7 @@ type Props = {
   spikes: SpikeDetails[];
   subscription: Subscription;
   isLoading?: boolean;
-};
+}
 
 function EnableSpikeProtectionButton({
   onEnableSpikeProtection,

--- a/static/gsApp/views/spikeProtection/types.ts
+++ b/static/gsApp/views/spikeProtection/types.ts
@@ -29,7 +29,7 @@ export interface SpikesList {
   start: string;
 }
 
-export type SpikeThresholds = {
+export interface SpikeThresholds {
   end: string;
   groups: Array<{
     billing_metric: DataCategoryInfo['uid'];
@@ -37,4 +37,4 @@ export type SpikeThresholds = {
   }>;
   intervals: string[];
   start: string;
-};
+}

--- a/static/gsApp/views/subscriptionPage/billingInformation.tsx
+++ b/static/gsApp/views/subscriptionPage/billingInformation.tsx
@@ -17,9 +17,9 @@ import {FTCConsentLocation, type Subscription} from 'getsentry/types';
 import {ContactBillingMembers} from 'getsentry/views/contactBillingMembers';
 import {SubscriptionPageContainer} from 'getsentry/views/subscriptionPage/components/subscriptionPageContainer';
 
-type Props = {
+interface Props {
   subscription: Subscription;
-};
+}
 
 /**
  * Update Billing Information view.

--- a/static/gsApp/views/subscriptionPage/decidePendingChanges.tsx
+++ b/static/gsApp/views/subscriptionPage/decidePendingChanges.tsx
@@ -6,10 +6,10 @@ import type {Subscription} from 'getsentry/types';
 import {PendingChanges} from './pendingChanges';
 import {PlanMigrationActive} from './planMigrationActive';
 
-type Props = {
+interface Props {
   organization: Organization;
   subscription: Subscription;
-};
+}
 
 export function DecidePendingChanges({subscription, organization}: Props) {
   const {planMigrations, isLoading} = usePlanMigrations();

--- a/static/gsApp/views/subscriptionPage/managedNote.tsx
+++ b/static/gsApp/views/subscriptionPage/managedNote.tsx
@@ -44,9 +44,9 @@ const DEFAULT_MESSAGE = tct(
   {mailto: <a href="mailto:support@sentry.io" />}
 );
 
-type Props = {
+interface Props {
   subscription: Subscription;
-};
+}
 
 /**
  * ManagedNote Component

--- a/static/gsApp/views/subscriptionPage/notifications.tsx
+++ b/static/gsApp/views/subscriptionPage/notifications.tsx
@@ -40,10 +40,10 @@ interface SubscriptionNotificationsProps {
   subscription: Subscription;
 }
 
-type ThresholdsType = {
+interface ThresholdsType {
   perProductOndemandPercent: number[];
   reservedPercent: number[];
-};
+}
 
 const OPTIONS = [
   {label: '90%', value: 90},
@@ -181,12 +181,12 @@ function SubscriptionNotifications({subscription}: SubscriptionNotificationsProp
   );
 }
 
-type GenericConsumptionGroupProps = {
+interface GenericConsumptionGroupProps {
   help: string;
   label: string;
   thresholds: number[];
   updateThresholds: (newThresholds: number[]) => void;
-};
+}
 
 function GenericConsumptionGroup(props: GenericConsumptionGroupProps) {
   const {thresholds, updateThresholds, label, help} = props;

--- a/static/gsApp/views/subscriptionPage/overview.tsx
+++ b/static/gsApp/views/subscriptionPage/overview.tsx
@@ -24,9 +24,9 @@ import {RecurringCredits} from './recurringCredits';
 import {SubscriptionHeader} from './subscriptionHeader';
 import {UsageAlert} from './usageAlert';
 
-type Props = {
+interface Props {
   subscription: Subscription;
-};
+}
 
 /**
  * Subscription overview page.

--- a/static/gsApp/views/subscriptionPage/partnershipNote.tsx
+++ b/static/gsApp/views/subscriptionPage/partnershipNote.tsx
@@ -10,9 +10,9 @@ const DEFAULT_MESSAGE = tct(
   {mailto: <a href="mailto:support@sentry.io" />}
 );
 
-type Props = {
+interface Props {
   subscription: Subscription;
-};
+}
 
 export function PartnershipNote({subscription}: Props) {
   return (

--- a/static/gsApp/views/subscriptionPage/pendingChanges.tsx
+++ b/static/gsApp/views/subscriptionPage/pendingChanges.tsx
@@ -34,10 +34,10 @@ import {
   parseOnDemandBudgetsFromSubscription,
 } from 'getsentry/views/spendLimits/utils';
 
-type Props = {
+interface Props {
   organization: Organization;
   subscription: Subscription;
-};
+}
 
 export function PendingChanges({organization, subscription}: Props) {
   const {pendingChanges} = subscription;

--- a/static/gsApp/views/subscriptionPage/planMigrationActive/index.tsx
+++ b/static/gsApp/views/subscriptionPage/planMigrationActive/index.tsx
@@ -14,10 +14,10 @@ import {PanelBodyWithTable} from 'getsentry/views/subscriptionPage/styles';
 
 import {PlanMigrationTable} from './planMigrationTable';
 
-type Props = {
+interface Props {
   migration: undefined | PlanMigration;
   subscription: Subscription;
-};
+}
 
 function NewFeature({title}: {title: string}) {
   return (

--- a/static/gsApp/views/subscriptionPage/planMigrationActive/planMigrationRow.tsx
+++ b/static/gsApp/views/subscriptionPage/planMigrationActive/planMigrationRow.tsx
@@ -10,43 +10,43 @@ import {displayPrice} from 'getsentry/views/amCheckout/utils';
 
 type Props = DataRow | PriceRow | RenewalPriceRow | PlanRow | ContractRow;
 
-type DataRow = {
+interface DataRow {
   currentValue: number | null;
   nextValue: number | null;
   type: DataCategoryExact;
   hasCredits?: boolean;
   previousType?: DataCategoryExact;
   titleOverride?: string;
-};
+}
 
-type PriceRow = {
+interface PriceRow {
   currentValue: number;
   discountPrice: number;
   nextValue: number;
   type: 'price';
   hasCredits?: boolean;
-};
+}
 
 // RenewalPriceRow shown for AUF plans only to differentiate between the first discount at the migration and second discounts at annual contract renewal
-type RenewalPriceRow = {
+interface RenewalPriceRow {
   currentValue: number;
   discountPrice: number;
   nextValue: number;
   type: 'renewal';
   hasCredits?: boolean;
-};
+}
 
-type PlanRow = {
+interface PlanRow {
   currentValue: string;
   nextValue: string;
   type: 'plan';
-};
+}
 
-type ContractRow = {
+interface ContractRow {
   currentValue: string;
   nextValue: string;
   type: 'contract';
-};
+}
 
 function formatCategoryRowString(
   category: DataCategoryExact,

--- a/static/gsApp/views/subscriptionPage/planMigrationActive/planMigrationTable.tsx
+++ b/static/gsApp/views/subscriptionPage/planMigrationActive/planMigrationTable.tsx
@@ -19,10 +19,10 @@ import {AlertStripedTable} from 'getsentry/views/subscriptionPage/styles';
 
 import {PlanMigrationRow} from './planMigrationRow';
 
-type Props = {
+interface Props {
   migration: PlanMigration;
   subscription: Subscription;
-};
+}
 
 export function PlanMigrationTable({subscription, migration}: Props) {
   if (!migration?.cohort?.nextPlan) {

--- a/static/gsApp/views/subscriptionPage/recurringCredits.tsx
+++ b/static/gsApp/views/subscriptionPage/recurringCredits.tsx
@@ -28,10 +28,10 @@ const getActiveDiscounts = (recurringCredits: RecurringCredit[]) =>
       !isExpired(credit.periodEnd)
   );
 
-type Props = {
+interface Props {
   displayType: 'data' | 'discount';
   planDetails: Plan;
-};
+}
 
 export function RecurringCredits({displayType, planDetails}: Props) {
   const {recurringCredits, isLoading} = useRecurringCredits();

--- a/static/gsApp/views/subscriptionPage/reservedUsageChart.tsx
+++ b/static/gsApp/views/subscriptionPage/reservedUsageChart.tsx
@@ -236,11 +236,11 @@ function calculateCategoryOnDemandUsage(
   };
 }
 
-type DroppedBreakdown = {
+interface DroppedBreakdown {
   other: number;
   overQuota: number;
   spikeProtection: number;
-};
+}
 
 export function selectedTransform(location: Location) {
   const transform = decodeScalar(location.query.transform) as

--- a/static/gsApp/views/subscriptionPage/subscriptionHeader.tsx
+++ b/static/gsApp/views/subscriptionPage/subscriptionHeader.tsx
@@ -23,10 +23,10 @@ import {SubscriptionUpsellBanner} from './subscriptionUpsellBanner';
 import {TrialAlert} from './trialAlert';
 import {hasPermissions} from './utils';
 
-type Props = {
+interface Props {
   organization: Organization;
   subscription: Subscription;
-};
+}
 
 /**
  * Header and Tab navigation common across subscription views.

--- a/static/gsApp/views/subscriptionPage/trial/badge.tsx
+++ b/static/gsApp/views/subscriptionPage/trial/badge.tsx
@@ -8,10 +8,10 @@ import type {Organization} from 'sentry/types/organization';
 import type {Subscription} from 'getsentry/types';
 import {getTrialDaysLeft, getTrialLength} from 'getsentry/utils/billing';
 
-type Props = {
+interface Props {
   organization: Organization;
   subscription: Subscription;
-};
+}
 
 export function TrialBadge({subscription, organization}: Props) {
   if (subscription.isTrial) {

--- a/static/gsApp/views/subscriptionPage/trial/trialEnded.tsx
+++ b/static/gsApp/views/subscriptionPage/trial/trialEnded.tsx
@@ -5,9 +5,9 @@ import {tct} from 'sentry/locale';
 import ZendeskLink from 'getsentry/components/zendeskLink';
 import type {Subscription} from 'getsentry/types';
 
-type Props = {
+interface Props {
   subscription: Subscription;
-};
+}
 
 export function TrialEnded({subscription}: Props) {
   const canRequestTrial =

--- a/static/gsApp/views/subscriptionPage/trialAlert.tsx
+++ b/static/gsApp/views/subscriptionPage/trialAlert.tsx
@@ -14,10 +14,10 @@ import {getTrialDaysLeft} from 'getsentry/utils/billing';
 import {TrialBadge} from './trial/badge';
 import {ButtonWrapper, SubscriptionBody} from './styles';
 
-type Props = {
+interface Props {
   organization: Organization;
   subscription: Subscription;
-};
+}
 
 export function TrialAlert({organization, subscription}: Props) {
   if (!subscription.isTrial) {

--- a/static/gsApp/views/subscriptionPage/usageAlert.tsx
+++ b/static/gsApp/views/subscriptionPage/usageAlert.tsx
@@ -33,10 +33,10 @@ import {ButtonWrapper, SubscriptionBody} from './styles';
 
 type ProjectedOverages = string[];
 
-type Props = {
+interface Props {
   subscription: Subscription;
   usage: CustomerUsage;
-};
+}
 
 export function UsageAlert({subscription, usage}: Props) {
   const organization = useOrganization();

--- a/static/gsApp/views/subscriptionPage/usageHistory.tsx
+++ b/static/gsApp/views/subscriptionPage/usageHistory.tsx
@@ -63,11 +63,11 @@ function usagePercentage(usage: number, prepaid: number | null): string {
   return formatPercentage(usage / prepaid, 0);
 }
 
-type DisplayProps = {
+interface DisplayProps {
   metricHistory: BillingMetricHistory;
   hadCustomDynamicSampling?: boolean;
   plan?: Plan;
-};
+}
 
 function getCategoryDisplay({
   plan,
@@ -125,10 +125,10 @@ function UsageHistory({subscription}: Props) {
   );
 }
 
-type RowProps = {
+interface RowProps {
   history: BillingHistory;
   subscription: Subscription;
-};
+}
 
 function UsageHistoryRow({history}: RowProps) {
   const organization = useOrganization();

--- a/static/gsApp/views/subscriptionPage/usageTotalsTable.tsx
+++ b/static/gsApp/views/subscriptionPage/usageTotalsTable.tsx
@@ -32,7 +32,7 @@ const OUTCOMES_SHOWN = [
   'droppedOther',
 ];
 
-type RowProps = {
+interface RowProps {
   category: DataCategory;
   /**
    * Name of outcome reason (e.g. Over Quota, Spike Protection, etc.)
@@ -63,7 +63,7 @@ type RowProps = {
    * Adds an info tooltip to `name`
    */
   tooltipTitle?: TooltipProps['title'];
-};
+}
 
 function OutcomeRow({
   name,
@@ -113,7 +113,7 @@ function OutcomeRow({
   );
 }
 
-type OutcomeSectionProps = {
+interface OutcomeSectionProps {
   category: DataCategory;
   children: React.ReactNode;
   name: string;
@@ -121,7 +121,7 @@ type OutcomeSectionProps = {
   totals: BillingStatTotal;
   expanded?: boolean;
   isEventBreakdown?: boolean;
-};
+}
 
 function OutcomeSection({
   name,
@@ -217,12 +217,12 @@ function IngestionSummary({
   );
 }
 
-type Props = {
+interface Props {
   category: DataCategory;
   subscription: Subscription;
   totals: BillingStatTotal;
   isEventBreakdown?: boolean;
-};
+}
 
 export function UsageTotalsTable({
   category,


### PR DESCRIPTION
Prepares `static/gsApp` and `static/gsAdmin` for [`@typescript-eslint/no-useless-default-assignment`](https://typescript-eslint.io/rules/no-useless-default-assignment) by fixing its reports via `pnpm lint:js --fix` (c77aaa35f89), then touching up a few introduced type-checking complaints (a6a056d8315).

Split out of #113662 because that PR was too big and unwieldy.

Fixes ENG-7545.

Made with [Cursor](https://cursor.com/)