### PR TITLE
feat(nightshift): Reorganize settings

### DIFF
--- a/bin/seer/trigger-night-shift
+++ b/bin/seer/trigger-night-shift
@@ -9,7 +9,11 @@ import sys
 
 from sentry import options
 from sentry.models.organization import Organization
-from sentry.tasks.seer.night_shift.cron import run_night_shift_for_org
+from sentry.seer.models.night_shift import SeerNightShiftRun
+from sentry.tasks.seer.night_shift.cron import (
+    SeerNightShiftRunOptionsPartial,
+    run_night_shift_for_org,
+)
 
 
 def _positive_int(value: str) -> int:
@@ -34,15 +38,28 @@ def _get_explorer_url(org_id: int, run_id: int) -> str | None:
 
 def main(org_id: int, max_candidates: int | None) -> None:
     sys.stdout.write(f"> Running night shift for organization {org_id}...\n")
-    agent_run_id = run_night_shift_for_org(org_id, max_candidates=max_candidates)
+    run_options: SeerNightShiftRunOptionsPartial = {"source": "manual"}
+    if max_candidates is not None:
+        run_options["max_candidates"] = max_candidates
+    run_id = run_night_shift_for_org(org_id, options=run_options)
     sys.stdout.write("> Done.\n")
 
-    if agent_run_id is not None:
-        explorer_url = _get_explorer_url(org_id, agent_run_id)
-        if explorer_url:
-            sys.stdout.write(f"> Explorer run: {explorer_url}\n")
-        else:
-            sys.stdout.write(f"> Explorer run ID: {agent_run_id}\n")
+    if run_id is None:
+        return
+
+    agent_run_id = (
+        SeerNightShiftRun.objects.values_list("extras", flat=True)
+        .get(id=run_id)
+        .get("agent_run_id")
+    )
+    if agent_run_id is None:
+        return
+
+    explorer_url = _get_explorer_url(org_id, agent_run_id)
+    if explorer_url:
+        sys.stdout.write(f"> Explorer run: {explorer_url}\n")
+    else:
+        sys.stdout.write(f"> Explorer run ID: {agent_run_id}\n")
 
 
 if __name__ == "__main__":

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -309,8 +309,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-explorer-index", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Seer Night Shift nightly autofix cron
     manager.add("organizations:seer-night-shift", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Per-project gate for Seer Night Shift (requires organizations:seer-night-shift on the org)
-    manager.add("projects:seer-night-shift", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Display nightshift settings
     manager.add("organizations:seer-night-shift-settings", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable context engine for Seer Explorer

--- a/src/sentry/seer/endpoints/admin_night_shift_trigger.py
+++ b/src/sentry/seer/endpoints/admin_night_shift_trigger.py
@@ -5,7 +5,10 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, internal_cell_silo_endpoint
 from sentry.api.permissions import StaffPermission
-from sentry.tasks.seer.night_shift.cron import run_night_shift_for_org
+from sentry.tasks.seer.night_shift.cron import (
+    SeerNightShiftRunOptionsPartial,
+    run_night_shift_for_org,
+)
 
 
 @internal_cell_silo_endpoint
@@ -40,9 +43,13 @@ class SeerAdminNightShiftTriggerEndpoint(Endpoint):
             if max_candidates < 1:
                 return Response({"detail": "max_candidates must be >= 1"}, status=400)
 
+        options: SeerNightShiftRunOptionsPartial = {"source": "manual", "dry_run": dry_run}
+        if max_candidates is not None:
+            options["max_candidates"] = max_candidates
+
         run_night_shift_for_org.apply_async(
             args=[organization_id],
-            kwargs={"dry_run": dry_run, "max_candidates": max_candidates},
+            kwargs={"options": options, "execute_in_task": True},
         )
 
         return Response(

--- a/src/sentry/seer/endpoints/project_seer_night_shift.py
+++ b/src/sentry/seer/endpoints/project_seer_night_shift.py
@@ -12,7 +12,10 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectEventPermission
 from sentry.models.project import Project
-from sentry.tasks.seer.night_shift.cron import run_nightshift_for_projects
+from sentry.tasks.seer.night_shift.cron import (
+    SeerNightShiftRunOptionsPartial,
+    run_night_shift_for_org,
+)
 from sentry.tasks.seer.night_shift.tweaks import get_night_shift_tweaks
 
 logger = logging.getLogger("sentry.seer.endpoints.project_seer_night_shift")
@@ -49,13 +52,19 @@ class ProjectSeerNightShiftEndpoint(ProjectEndpoint):
             },
         )
 
-        agent_run_id = run_nightshift_for_projects(
+        options: SeerNightShiftRunOptionsPartial = {
+            "source": "manual",
+            "dry_run": dry_run,
+            "max_candidates": tweaks.max_candidates,
+            "intelligence_level": tweaks.intelligence_level,
+            "reasoning_effort": tweaks.reasoning_effort,
+            "extra_triage_instructions": tweaks.extra_triage_instructions,
+        }
+        agent_run_id = run_night_shift_for_org(
+            project.organization_id,
+            options=options,
             project_ids=[project.id],
-            dry_run=dry_run,
-            max_candidates=tweaks.max_candidates,
-            intelligence_level=tweaks.intelligence_level,
-            reasoning_effort=tweaks.reasoning_effort,
-            extra_triage_instructions=tweaks.extra_triage_instructions,
             triggering_user_id=triggering_user_id,
+            execute_in_task=True,
         )
         return Response({"agent_run_id": agent_run_id}, status=200)

--- a/src/sentry/seer/endpoints/project_seer_night_shift.py
+++ b/src/sentry/seer/endpoints/project_seer_night_shift.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 from rest_framework.exceptions import NotFound
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -10,7 +12,10 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint, ProjectEventPermission
 from sentry.models.project import Project
-from sentry.tasks.seer.night_shift.cron import run_night_shift_for_project
+from sentry.tasks.seer.night_shift.cron import run_nightshift_for_projects
+from sentry.tasks.seer.night_shift.tweaks import get_night_shift_tweaks
+
+logger = logging.getLogger("sentry.seer.endpoints.project_seer_night_shift")
 
 
 @cell_silo_endpoint
@@ -26,9 +31,28 @@ class ProjectSeerNightShiftEndpoint(ProjectEndpoint):
             raise NotFound
 
         dry_run = bool(request.data.get("dryRun", False))
+        tweaks = get_night_shift_tweaks(project)
 
-        run_night_shift_for_project.apply_async(
-            args=[project.id],
-            kwargs={"dry_run": dry_run},
+        logger.info(
+            "night_shift.manual_trigger.dispatched",
+            extra={
+                "project_id": project.id,
+                "project_slug": project.slug,
+                "organization_id": project.organization_id,
+                "dry_run": dry_run,
+                "max_candidates": tweaks.max_candidates,
+                "intelligence_level": tweaks.intelligence_level,
+                "reasoning_effort": tweaks.reasoning_effort,
+                "extra_triage_instructions": tweaks.extra_triage_instructions,
+            },
         )
-        return Response(status=202)
+
+        agent_run_id = run_nightshift_for_projects(
+            project_ids=[project.id],
+            dry_run=dry_run,
+            max_candidates=tweaks.max_candidates,
+            intelligence_level=tweaks.intelligence_level,
+            reasoning_effort=tweaks.reasoning_effort,
+            extra_triage_instructions=tweaks.extra_triage_instructions,
+        )
+        return Response({"agent_run_id": agent_run_id}, status=200)

--- a/src/sentry/seer/endpoints/project_seer_night_shift.py
+++ b/src/sentry/seer/endpoints/project_seer_night_shift.py
@@ -32,6 +32,7 @@ class ProjectSeerNightShiftEndpoint(ProjectEndpoint):
 
         dry_run = bool(request.data.get("dryRun", False))
         tweaks = get_night_shift_tweaks(project)
+        triggering_user_id = request.user.id if request.user.is_authenticated else None
 
         logger.info(
             "night_shift.manual_trigger.dispatched",
@@ -39,6 +40,7 @@ class ProjectSeerNightShiftEndpoint(ProjectEndpoint):
                 "project_id": project.id,
                 "project_slug": project.slug,
                 "organization_id": project.organization_id,
+                "triggering_user_id": triggering_user_id,
                 "dry_run": dry_run,
                 "max_candidates": tweaks.max_candidates,
                 "intelligence_level": tweaks.intelligence_level,
@@ -54,5 +56,6 @@ class ProjectSeerNightShiftEndpoint(ProjectEndpoint):
             intelligence_level=tweaks.intelligence_level,
             reasoning_effort=tweaks.reasoning_effort,
             extra_triage_instructions=tweaks.extra_triage_instructions,
+            triggering_user_id=triggering_user_id,
         )
         return Response({"agent_run_id": agent_run_id}, status=200)

--- a/src/sentry/tasks/seer/night_shift/agentic_triage.py
+++ b/src/sentry/tasks/seer/night_shift/agentic_triage.py
@@ -22,6 +22,13 @@ from sentry.tasks.seer.night_shift.triage_tools import (
     get_event_details_agentic_triage,
     get_issue_details_agentic_triage,
 )
+from sentry.tasks.seer.night_shift.tweaks import (
+    DEFAULT_EXTRA_TRIAGE_INSTRUCTIONS,
+    DEFAULT_INTELLIGENCE_LEVEL,
+    DEFAULT_REASONING_EFFORT,
+    IntelligenceLevel,
+    ReasoningEffort,
+)
 
 logger = logging.getLogger("sentry.tasks.seer.night_shift")
 
@@ -40,6 +47,10 @@ def agentic_triage_strategy(
     projects: Sequence[Project],
     organization: Organization,
     max_candidates: int,
+    *,
+    intelligence_level: IntelligenceLevel = DEFAULT_INTELLIGENCE_LEVEL,
+    reasoning_effort: ReasoningEffort = DEFAULT_REASONING_EFFORT,
+    extra_triage_instructions: str = DEFAULT_EXTRA_TRIAGE_INSTRUCTIONS,
 ) -> tuple[list[TriageResult], int | None]:
     """
     Select candidates via fixability scoring, then use the Seer Explorer agent
@@ -52,12 +63,22 @@ def agentic_triage_strategy(
     if not scored:
         return [], None
 
-    return _triage_candidates(scored, organization)
+    return _triage_candidates(
+        scored,
+        organization,
+        intelligence_level=intelligence_level,
+        reasoning_effort=reasoning_effort,
+        extra_triage_instructions=extra_triage_instructions,
+    )
 
 
 def _triage_candidates(
     candidates: list[ScoredCandidate],
     organization: Organization,
+    *,
+    intelligence_level: IntelligenceLevel,
+    reasoning_effort: ReasoningEffort,
+    extra_triage_instructions: str,
 ) -> tuple[list[TriageResult], int | None]:
     """
     Start a Seer Explorer run to investigate candidate issues and return
@@ -74,8 +95,8 @@ def _triage_candidates(
             user=None,
             category_key="night_shift",
             category_value=f"org-{organization.id}",
-            intelligence_level="high",
-            reasoning_effort="high",
+            intelligence_level=intelligence_level,
+            reasoning_effort=reasoning_effort,
             custom_tools=[
                 get_event_details_agentic_triage,
                 get_issue_details_agentic_triage,
@@ -83,7 +104,7 @@ def _triage_candidates(
         )
 
         agent_run_id = client.start_run(
-            prompt=_build_triage_prompt(candidates),
+            prompt=_build_triage_prompt(candidates, extra_triage_instructions),
             artifact_key="triage_verdicts",
             artifact_schema=_TriageResponse,
         )
@@ -209,6 +230,7 @@ def _poll_with_logging(
 
 def _build_triage_prompt(
     candidates: list[ScoredCandidate],
+    extra_triage_instructions: str,
 ) -> str:
     candidates_block = "\n".join(
         f"- group_id={c.group.id} | title={c.group.title or 'Unknown error'!r} "
@@ -217,6 +239,12 @@ def _build_triage_prompt(
         f"| first_seen={c.group.first_seen.isoformat()} "
         f"| priority={priority_label(c.group.priority) or 'unknown'}"
         for c in candidates
+    )
+
+    extras_block = (
+        f"\n\nAdditional instructions from project owners:\n{extra_triage_instructions}\n"
+        if extra_triage_instructions
+        else ""
     )
 
     return textwrap.dedent(f"""\
@@ -271,5 +299,5 @@ def _build_triage_prompt(
         Provide a brief reason for each decision.
 
         Candidates:
-        {candidates_block}
+        {candidates_block}{extras_block}
     """)

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import dataclasses
-import enum
 import logging
 import time
 from collections import Counter
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from datetime import timedelta
-from typing import Any
+from typing import Any, Literal, TypedDict
 
 import sentry_sdk
 
@@ -52,27 +51,31 @@ FEATURE_NAMES = [
 ]
 
 
-class NightShiftRunSource(enum.Enum):
-    CRON = "cron"
-    MANUAL = "manual"
+NightShiftRunSource = Literal["cron", "manual"]
 
 
-@dataclasses.dataclass(frozen=True)
-class SeerNightShiftRunOptions:
+class SeerNightShiftRunOptions(TypedDict):
+    """Fully-resolved options for a night shift run. Persisted directly onto
+    SeerNightShiftRun.extras["options"]. Construct via build_run_options."""
+
     source: NightShiftRunSource
     max_candidates: int
-    intelligence_level: IntelligenceLevel = DEFAULT_INTELLIGENCE_LEVEL
-    reasoning_effort: ReasoningEffort = DEFAULT_REASONING_EFFORT
-    extra_triage_instructions: str = DEFAULT_EXTRA_TRIAGE_INSTRUCTIONS
+    dry_run: bool
+    intelligence_level: IntelligenceLevel
+    reasoning_effort: ReasoningEffort
+    extra_triage_instructions: str
 
-    def as_extras(self) -> dict[str, object]:
-        return {
-            "source": self.source.value,
-            "max_candidates": self.max_candidates,
-            "intelligence_level": self.intelligence_level,
-            "reasoning_effort": self.reasoning_effort,
-            "extra_triage_instructions": self.extra_triage_instructions,
-        }
+
+class SeerNightShiftRunOptionsPartial(TypedDict, total=False):
+    """Caller-facing options dict — every field is optional. Missing fields
+    are filled in by build_run_options with shared defaults."""
+
+    source: NightShiftRunSource
+    max_candidates: int
+    dry_run: bool
+    intelligence_level: IntelligenceLevel
+    reasoning_effort: ReasoningEffort
+    extra_triage_instructions: str
 
 
 @instrumented_task(
@@ -122,172 +125,35 @@ def schedule_night_shift(**kwargs: Any) -> None:
 )
 def run_night_shift_for_org(
     organization_id: int,
-    dry_run: bool = False,
-    max_candidates: int | None = None,
-    intelligence_level: IntelligenceLevel | None = None,
-    reasoning_effort: ReasoningEffort | None = None,
-    extra_triage_instructions: str | None = None,
+    *,
+    options: SeerNightShiftRunOptionsPartial | None = None,
+    project_ids: list[int] | None = None,
+    triggering_user_id: int | None = None,
+    execute_in_task: bool = False,
     **kwargs: Any,
 ) -> int | None:
+    """Run night shift for one organization. `options` is a partial dict —
+    any missing fields are filled in by build_run_options. Cron dispatches
+    with no options (all defaults); manual triggers (project settings "Run
+    Now", admin endpoint) pass `{"source": "manual", ...}` and may scope the
+    run to specific projects.
+
+    When execute_in_task is True, the heavy execution phase (quota check,
+    eligibility, triage, autofix) is dispatched to a separate task so the
+    caller doesn't block on it. The run record is always created synchronously
+    so callers have a stable handle to the run."""
     organization = Organization.objects.filter(
         id=organization_id, status=OrganizationStatus.ACTIVE
     ).first()
     if organization is None:
         return None
 
-    log_extra: dict[str, object] = {
-        "organization_id": organization.id,
-        "organization_slug": organization.slug,
-    }
+    resolved_options = build_run_options(options)
     sentry_sdk.set_tags(
         {"organization_id": organization.id, "organization_slug": organization.slug}
     )
 
-    return _execute_night_shift_run(
-        organization,
-        options=_build_run_options(
-            source=NightShiftRunSource.CRON,
-            max_candidates=max_candidates,
-            intelligence_level=intelligence_level,
-            reasoning_effort=reasoning_effort,
-            extra_triage_instructions=extra_triage_instructions,
-        ),
-        dry_run=dry_run,
-        log_extra=log_extra,
-    )
-
-
-@instrumented_task(
-    name="sentry.tasks.seer.night_shift.run_nightshift_for_projects",
-    namespace=seer_tasks,
-    processing_deadline_duration=5 * 60,
-)
-def run_nightshift_for_projects(
-    *,
-    project_ids: list[int],
-    dry_run: bool = False,
-    max_candidates: int | None = None,
-    intelligence_level: IntelligenceLevel | None = None,
-    reasoning_effort: ReasoningEffort | None = None,
-    extra_triage_instructions: str | None = None,
-    triggering_user_id: int | None = None,
-    **kwargs: Any,
-) -> int | None:
-    """One-off night shift run scoped to one or more projects, e.g. from the
-    project settings "Run Now" button. All project_ids must belong to the same
-    active organization."""
-    try:
-        projects = list(
-            Project.objects.filter(id__in=project_ids, status=ObjectStatus.ACTIVE).select_related(
-                "organization"
-            )
-        )
-        if not projects:
-            logger.info(
-                "night_shift.run_for_projects.no_active_projects",
-                extra={"project_ids": project_ids},
-            )
-            return None
-
-        organization_ids = {p.organization_id for p in projects}
-        if len(organization_ids) > 1:
-            logger.info(
-                "night_shift.run_for_projects.multiple_organizations",
-                extra={
-                    "project_ids": project_ids,
-                    "organization_ids": sorted(organization_ids),
-                },
-            )
-            return None
-
-        organization = projects[0].organization
-        if organization.status != OrganizationStatus.ACTIVE:
-            logger.info(
-                "night_shift.run_for_projects.organization_inactive",
-                extra={"project_ids": project_ids, "organization_id": organization.id},
-            )
-            return None
-
-        log_extra: dict[str, object] = {
-            "organization_id": organization.id,
-            "organization_slug": organization.slug,
-            "project_ids": [p.id for p in projects],
-        }
-        sentry_sdk.set_tags(
-            {
-                "organization_id": organization.id,
-                "organization_slug": organization.slug,
-            }
-        )
-
-        return _execute_night_shift_run(
-            organization,
-            options=_build_run_options(
-                source=NightShiftRunSource.MANUAL,
-                max_candidates=max_candidates,
-                intelligence_level=intelligence_level,
-                reasoning_effort=reasoning_effort,
-                extra_triage_instructions=extra_triage_instructions,
-            ),
-            project_ids=[p.id for p in projects],
-            dry_run=dry_run,
-            triggering_user_id=triggering_user_id,
-            log_extra=log_extra,
-        )
-    except Exception:
-        logger.exception(
-            "night_shift.run_for_projects.failed",
-            extra={"project_ids": project_ids},
-        )
-        return None
-
-
-def _build_run_options(
-    *,
-    source: NightShiftRunSource,
-    max_candidates: int | None,
-    intelligence_level: IntelligenceLevel | None,
-    reasoning_effort: ReasoningEffort | None,
-    extra_triage_instructions: str | None,
-) -> SeerNightShiftRunOptions:
-    """Build options, falling back to shared defaults when a caller didn't pass
-    an override (cron path)."""
-    return SeerNightShiftRunOptions(
-        source=source,
-        max_candidates=max_candidates if max_candidates is not None else default_max_candidates(),
-        intelligence_level=(
-            intelligence_level if intelligence_level is not None else DEFAULT_INTELLIGENCE_LEVEL
-        ),
-        reasoning_effort=(
-            reasoning_effort if reasoning_effort is not None else DEFAULT_REASONING_EFFORT
-        ),
-        extra_triage_instructions=(
-            extra_triage_instructions
-            if extra_triage_instructions is not None
-            else DEFAULT_EXTRA_TRIAGE_INSTRUCTIONS
-        ),
-    )
-
-
-def _execute_night_shift_run(
-    organization: Organization,
-    *,
-    options: SeerNightShiftRunOptions,
-    project_ids: list[int] | None = None,
-    dry_run: bool,
-    triggering_user_id: int | None = None,
-    log_extra: dict[str, object],
-) -> int | None:
-    """Create a SeerNightShiftRun, run triage against eligible projects, and
-    optionally dispatch autofix. Shared between the org-wide scheduler and
-    per-project manual triggers."""
-    start_time = time.monotonic()
-    logger.info("night_shift.execute.start", extra=log_extra)
-
-    extras: dict[str, object] = {
-        "options": options.as_extras(),
-        "dry_run": dry_run,
-    }
+    extras: dict[str, object] = {"options": dict(resolved_options)}
     if project_ids is not None:
         extras["target_project_ids"] = project_ids
     if triggering_user_id is not None:
@@ -298,7 +164,54 @@ def _execute_night_shift_run(
         triage_strategy="agentic_triage",
         extras=extras,
     )
-    log_extra["run_id"] = run.id
+
+    task_kwargs: dict[str, Any] = {"options": dict(resolved_options)}
+    if project_ids is not None:
+        task_kwargs["project_ids"] = project_ids
+
+    if execute_in_task:
+        run_night_shift_execution.apply_async(args=[run.id], kwargs=task_kwargs)
+    else:
+        run_night_shift_execution(run.id, **task_kwargs)
+    return run.id
+
+
+@instrumented_task(
+    name="sentry.tasks.seer.night_shift.run_night_shift_execution",
+    namespace=seer_tasks,
+    processing_deadline_duration=5 * 60,
+)
+def run_night_shift_execution(
+    run_id: int,
+    *,
+    options: SeerNightShiftRunOptionsPartial | None = None,
+    project_ids: list[int] | None = None,
+    **kwargs: Any,
+) -> None:
+    """Heavy phase of a night shift run: quota check, eligibility, triage, and
+    optional autofix dispatch. Single code path used by both sync invocation
+    (from run_night_shift_for_org) and async dispatch (apply_async)."""
+    run = SeerNightShiftRun.objects.select_related("organization").filter(id=run_id).first()
+    if run is None:
+        logger.info("night_shift.missing_run", extra={"run_id": run_id})
+        return None
+
+    organization = run.organization
+    resolved_options = _run_option_defaults(options or {})
+
+    log_extra: dict[str, object] = {
+        "organization_id": organization.id,
+        "organization_slug": organization.slug,
+        "run_id": run.id,
+    }
+    if project_ids is not None:
+        log_extra["project_ids"] = project_ids
+    sentry_sdk.set_tags(
+        {"organization_id": organization.id, "organization_slug": organization.slug}
+    )
+
+    start_time = time.monotonic()
+    logger.info("night_shift.execute.start", extra=log_extra)
 
     if not quotas.backend.check_seer_quota(
         org_id=organization.id,
@@ -309,7 +222,9 @@ def _execute_night_shift_run(
         return None
 
     try:
-        eligible = _get_eligible_projects(organization, options.source, project_ids=project_ids)
+        eligible = _get_eligible_projects(
+            organization, resolved_options["source"], project_ids=project_ids
+        )
     except Exception:
         _fail_run(
             run,
@@ -331,10 +246,10 @@ def _execute_night_shift_run(
         candidates, agent_run_id = agentic_triage_strategy(
             eligible_projects,
             organization,
-            options.max_candidates,
-            intelligence_level=options.intelligence_level,
-            reasoning_effort=options.reasoning_effort,
-            extra_triage_instructions=options.extra_triage_instructions,
+            resolved_options["max_candidates"],
+            intelligence_level=resolved_options["intelligence_level"],
+            reasoning_effort=resolved_options["reasoning_effort"],
+            extra_triage_instructions=resolved_options["extra_triage_instructions"],
         )
         if agent_run_id is not None:
             run.update(extras={**run.extras, "agent_run_id": agent_run_id})
@@ -356,7 +271,7 @@ def _execute_night_shift_run(
     sentry_sdk.metrics.distribution("night_shift.org_run_duration", time.monotonic() - start_time)
 
     seer_run_id_by_group: dict[int, str | None] = {}
-    if not dry_run:
+    if not resolved_options["dry_run"]:
         # Populate each candidate group's FK cache so trigger_autofix_explorer doesn't
         # re-fetch group.project on every call. Group.organization is a property that
         # delegates to self.project.organization, so caching the org on the project is
@@ -381,7 +296,7 @@ def _execute_night_shift_run(
             **log_extra,
             "num_eligible_projects": len(eligible_projects),
             "num_candidates": len(candidates),
-            "dry_run": dry_run,
+            "dry_run": resolved_options["dry_run"],
             "candidates": [
                 {
                     "group_id": c.group.id,
@@ -394,7 +309,31 @@ def _execute_night_shift_run(
         },
     )
 
-    return agent_run_id
+
+def _run_option_defaults(data: Mapping[str, Any]) -> SeerNightShiftRunOptions:
+    """Fill in defaults for any missing fields. Accepts any mapping so it can
+    normalize both partial caller input and loosely-typed dicts read back from
+    run.extras (which may predate later schema additions)."""
+    max_candidates = data.get("max_candidates")
+    return SeerNightShiftRunOptions(
+        source=data.get("source", "cron"),
+        max_candidates=default_max_candidates() if max_candidates is None else max_candidates,
+        dry_run=data.get("dry_run", False),
+        intelligence_level=data.get("intelligence_level", DEFAULT_INTELLIGENCE_LEVEL),
+        reasoning_effort=data.get("reasoning_effort", DEFAULT_REASONING_EFFORT),
+        extra_triage_instructions=data.get(
+            "extra_triage_instructions", DEFAULT_EXTRA_TRIAGE_INSTRUCTIONS
+        ),
+    )
+
+
+def build_run_options(
+    partial: SeerNightShiftRunOptionsPartial | None = None,
+) -> SeerNightShiftRunOptions:
+    """Resolve a partial options dict into a fully-populated one. Cron callers
+    pass nothing (all defaults); manual callers pass at least `source="manual"`
+    plus whichever tweaks they want to override."""
+    return _run_option_defaults(partial or {})
 
 
 def _get_eligible_orgs_from_batch(
@@ -469,7 +408,7 @@ def _get_eligible_projects(
     eligible = [
         EligibleProject(project=p, tweaks=get_night_shift_tweaks(p)) for p in with_automation
     ]
-    if source is NightShiftRunSource.CRON:
+    if source == "cron":
         eligible = [ep for ep in eligible if ep.tweaks.enabled]
     return eligible
 

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -26,7 +26,16 @@ from sentry.seer.models.night_shift import SeerNightShiftRun, SeerNightShiftRunI
 from sentry.tasks.base import instrumented_task
 from sentry.tasks.seer.night_shift.agentic_triage import agentic_triage_strategy
 from sentry.tasks.seer.night_shift.models import TriageAction, TriageResult
-from sentry.tasks.seer.night_shift.tweaks import NightShiftTweaks, get_night_shift_tweaks
+from sentry.tasks.seer.night_shift.tweaks import (
+    DEFAULT_EXTRA_TRIAGE_INSTRUCTIONS,
+    DEFAULT_INTELLIGENCE_LEVEL,
+    DEFAULT_REASONING_EFFORT,
+    IntelligenceLevel,
+    NightShiftTweaks,
+    ReasoningEffort,
+    default_max_candidates,
+    get_night_shift_tweaks,
+)
 from sentry.taskworker.namespaces import seer_tasks
 from sentry.utils.iterators import chunked
 from sentry.utils.query import RangeQuerySetWrapper
@@ -46,6 +55,24 @@ FEATURE_NAMES = [
 class NightShiftRunSource(enum.Enum):
     CRON = "cron"
     MANUAL = "manual"
+
+
+@dataclasses.dataclass(frozen=True)
+class SeerNightShiftRunOptions:
+    source: NightShiftRunSource
+    max_candidates: int
+    intelligence_level: IntelligenceLevel = DEFAULT_INTELLIGENCE_LEVEL
+    reasoning_effort: ReasoningEffort = DEFAULT_REASONING_EFFORT
+    extra_triage_instructions: str = DEFAULT_EXTRA_TRIAGE_INSTRUCTIONS
+
+    def as_extras(self) -> dict[str, object]:
+        return {
+            "source": self.source.value,
+            "max_candidates": self.max_candidates,
+            "intelligence_level": self.intelligence_level,
+            "reasoning_effort": self.reasoning_effort,
+            "extra_triage_instructions": self.extra_triage_instructions,
+        }
 
 
 @instrumented_task(
@@ -97,6 +124,9 @@ def run_night_shift_for_org(
     organization_id: int,
     dry_run: bool = False,
     max_candidates: int | None = None,
+    intelligence_level: IntelligenceLevel | None = None,
+    reasoning_effort: ReasoningEffort | None = None,
+    extra_triage_instructions: str | None = None,
     **kwargs: Any,
 ) -> int | None:
     organization = Organization.objects.filter(
@@ -115,79 +145,153 @@ def run_night_shift_for_org(
 
     return _execute_night_shift_run(
         organization,
-        source=NightShiftRunSource.CRON,
+        options=_build_run_options(
+            source=NightShiftRunSource.CRON,
+            max_candidates=max_candidates,
+            intelligence_level=intelligence_level,
+            reasoning_effort=reasoning_effort,
+            extra_triage_instructions=extra_triage_instructions,
+        ),
         dry_run=dry_run,
-        max_candidates=max_candidates,
         log_extra=log_extra,
     )
 
 
 @instrumented_task(
-    name="sentry.tasks.seer.night_shift.run_night_shift_for_project",
+    name="sentry.tasks.seer.night_shift.run_nightshift_for_projects",
     namespace=seer_tasks,
     processing_deadline_duration=5 * 60,
 )
-def run_night_shift_for_project(
-    project_id: int,
+def run_nightshift_for_projects(
+    *,
+    project_ids: list[int],
     dry_run: bool = False,
     max_candidates: int | None = None,
+    intelligence_level: IntelligenceLevel | None = None,
+    reasoning_effort: ReasoningEffort | None = None,
+    extra_triage_instructions: str | None = None,
     **kwargs: Any,
 ) -> int | None:
-    """One-off night shift run scoped to a single project, e.g. from the
-    project settings "Run Now" button."""
-    project = (
-        Project.objects.filter(id=project_id, status=ObjectStatus.ACTIVE)
-        .select_related("organization")
-        .first()
-    )
-    if project is None:
-        return None
+    """One-off night shift run scoped to one or more projects, e.g. from the
+    project settings "Run Now" button. All project_ids must belong to the same
+    active organization."""
+    try:
+        projects = list(
+            Project.objects.filter(id__in=project_ids, status=ObjectStatus.ACTIVE).select_related(
+                "organization"
+            )
+        )
+        if not projects:
+            logger.info(
+                "night_shift.run_for_projects.no_active_projects",
+                extra={"project_ids": project_ids},
+            )
+            return None
 
-    organization = project.organization
-    if organization.status != OrganizationStatus.ACTIVE:
-        return None
+        organization_ids = {p.organization_id for p in projects}
+        if len(organization_ids) > 1:
+            logger.info(
+                "night_shift.run_for_projects.multiple_organizations",
+                extra={
+                    "project_ids": project_ids,
+                    "organization_ids": sorted(organization_ids),
+                },
+            )
+            return None
 
-    log_extra: dict[str, object] = {
-        "organization_id": organization.id,
-        "organization_slug": organization.slug,
-        "project_id": project.id,
-        "project_slug": project.slug,
-    }
-    sentry_sdk.set_tags(
-        {
+        organization = projects[0].organization
+        if organization.status != OrganizationStatus.ACTIVE:
+            logger.info(
+                "night_shift.run_for_projects.organization_inactive",
+                extra={"project_ids": project_ids, "organization_id": organization.id},
+            )
+            return None
+
+        log_extra: dict[str, object] = {
             "organization_id": organization.id,
             "organization_slug": organization.slug,
-            "project_id": project.id,
+            "project_ids": [p.id for p in projects],
         }
-    )
+        sentry_sdk.set_tags(
+            {
+                "organization_id": organization.id,
+                "organization_slug": organization.slug,
+            }
+        )
 
-    return _execute_night_shift_run(
-        organization,
-        source=NightShiftRunSource.MANUAL,
-        project_ids=[project.id],
-        dry_run=dry_run,
-        max_candidates=max_candidates,
-        log_extra=log_extra,
+        return _execute_night_shift_run(
+            organization,
+            options=_build_run_options(
+                source=NightShiftRunSource.MANUAL,
+                max_candidates=max_candidates,
+                intelligence_level=intelligence_level,
+                reasoning_effort=reasoning_effort,
+                extra_triage_instructions=extra_triage_instructions,
+            ),
+            project_ids=[p.id for p in projects],
+            dry_run=dry_run,
+            log_extra=log_extra,
+        )
+    except Exception:
+        logger.exception(
+            "night_shift.run_for_projects.failed",
+            extra={"project_ids": project_ids},
+        )
+        return None
+
+
+def _build_run_options(
+    *,
+    source: NightShiftRunSource,
+    max_candidates: int | None,
+    intelligence_level: IntelligenceLevel | None,
+    reasoning_effort: ReasoningEffort | None,
+    extra_triage_instructions: str | None,
+) -> SeerNightShiftRunOptions:
+    """Build options, falling back to shared defaults when a caller didn't pass
+    an override (cron path)."""
+    return SeerNightShiftRunOptions(
+        source=source,
+        max_candidates=max_candidates if max_candidates is not None else default_max_candidates(),
+        intelligence_level=(
+            intelligence_level if intelligence_level is not None else DEFAULT_INTELLIGENCE_LEVEL
+        ),
+        reasoning_effort=(
+            reasoning_effort if reasoning_effort is not None else DEFAULT_REASONING_EFFORT
+        ),
+        extra_triage_instructions=(
+            extra_triage_instructions
+            if extra_triage_instructions is not None
+            else DEFAULT_EXTRA_TRIAGE_INSTRUCTIONS
+        ),
     )
 
 
 def _execute_night_shift_run(
     organization: Organization,
     *,
-    source: NightShiftRunSource,
+    options: SeerNightShiftRunOptions,
     project_ids: list[int] | None = None,
     dry_run: bool,
-    max_candidates: int | None,
     log_extra: dict[str, object],
 ) -> int | None:
     """Create a SeerNightShiftRun, run triage against eligible projects, and
     optionally dispatch autofix. Shared between the org-wide scheduler and
     per-project manual triggers."""
     start_time = time.monotonic()
+    logger.info("night_shift.execute.start", extra=log_extra)
+
+    extras: dict[str, object] = {
+        "options": options.as_extras(),
+        "dry_run": dry_run,
+    }
+    if project_ids is not None:
+        extras["target_project_ids"] = project_ids
 
     run = SeerNightShiftRun.objects.create(
         organization=organization,
         triage_strategy="agentic_triage",
+        extras=extras,
     )
     log_extra["run_id"] = run.id
 
@@ -200,7 +304,7 @@ def _execute_night_shift_run(
         return None
 
     try:
-        eligible = _get_eligible_projects(organization, source, project_ids=project_ids)
+        eligible = _get_eligible_projects(organization, options.source, project_ids=project_ids)
     except Exception:
         _fail_run(
             run,
@@ -216,17 +320,16 @@ def _execute_night_shift_run(
         logger.info("night_shift.no_eligible_projects", extra=log_extra)
         return None
 
-    resolved_max_candidates = (
-        max_candidates
-        if max_candidates is not None
-        else max(ep.tweaks.candidate_issues for ep in eligible)
-    )
-
     eligible_projects = [ep.project for ep in eligible]
     agent_run_id = None
     try:
         candidates, agent_run_id = agentic_triage_strategy(
-            eligible_projects, organization, resolved_max_candidates
+            eligible_projects,
+            organization,
+            options.max_candidates,
+            intelligence_level=options.intelligence_level,
+            reasoning_effort=options.reasoning_effort,
+            extra_triage_instructions=options.extra_triage_instructions,
         )
         if agent_run_id is not None:
             run.update(extras={**run.extras, "agent_run_id": agent_run_id})
@@ -358,14 +461,9 @@ def _get_eligible_projects(
     if not with_automation:
         return []
 
-    flag_result = features.batch_has(["projects:seer-night-shift"], projects=with_automation)
-    flagged = [
-        p
-        for p in with_automation
-        if (flag_result or {}).get(f"project:{p.id}", {}).get("projects:seer-night-shift", False)
+    eligible = [
+        EligibleProject(project=p, tweaks=get_night_shift_tweaks(p)) for p in with_automation
     ]
-
-    eligible = [EligibleProject(project=p, tweaks=get_night_shift_tweaks(p)) for p in flagged]
     if source is NightShiftRunSource.CRON:
         eligible = [ep for ep in eligible if ep.tweaks.enabled]
     return eligible

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -170,6 +170,7 @@ def run_nightshift_for_projects(
     intelligence_level: IntelligenceLevel | None = None,
     reasoning_effort: ReasoningEffort | None = None,
     extra_triage_instructions: str | None = None,
+    triggering_user_id: int | None = None,
     **kwargs: Any,
 ) -> int | None:
     """One-off night shift run scoped to one or more projects, e.g. from the
@@ -230,6 +231,7 @@ def run_nightshift_for_projects(
             ),
             project_ids=[p.id for p in projects],
             dry_run=dry_run,
+            triggering_user_id=triggering_user_id,
             log_extra=log_extra,
         )
     except Exception:
@@ -273,6 +275,7 @@ def _execute_night_shift_run(
     options: SeerNightShiftRunOptions,
     project_ids: list[int] | None = None,
     dry_run: bool,
+    triggering_user_id: int | None = None,
     log_extra: dict[str, object],
 ) -> int | None:
     """Create a SeerNightShiftRun, run triage against eligible projects, and
@@ -287,6 +290,8 @@ def _execute_night_shift_run(
     }
     if project_ids is not None:
         extras["target_project_ids"] = project_ids
+    if triggering_user_id is not None:
+        extras["triggering_user_id"] = triggering_user_id
 
     run = SeerNightShiftRun.objects.create(
         organization=organization,

--- a/src/sentry/tasks/seer/night_shift/tweaks.py
+++ b/src/sentry/tasks/seer/night_shift/tweaks.py
@@ -9,22 +9,31 @@ from sentry import options
 from sentry.api.serializers.rest_framework.base import snake_to_camel_case
 from sentry.models.project import Project
 
-TriageStrategy = Literal["simple", "agentic"]
 IntelligenceLevel = Literal["low", "medium", "high"]
 ReasoningEffort = Literal["low", "medium", "high"]
 
+# Defaults shared by the Tweaks model and SeerNightShiftRunOptions. Keep the
+# frontend constants in `static/gsApp/views/seerAutomation/components/projectDetails/nightShift.tsx`
+# in sync with these.
+DEFAULT_INTELLIGENCE_LEVEL: IntelligenceLevel = "high"
+DEFAULT_REASONING_EFFORT: ReasoningEffort = "high"
+DEFAULT_EXTRA_TRIAGE_INSTRUCTIONS = ""
+
+
+def default_max_candidates() -> int:
+    return options.get("seer.night_shift.issues_per_org")
+
 
 class NightShiftTweaks(pydantic.BaseModel):
+    # Global settings — apply to scheduled (cron) runs as well as manual ones.
     enabled: bool = False
-    dry_run: bool = False
-    candidate_issues: int = pydantic.Field(
-        default_factory=lambda: options.get("seer.night_shift.issues_per_org")
-    )
-    triage_strategy: TriageStrategy = "agentic"
-    extra_triage_instructions: str = ""
-    intelligence_level: IntelligenceLevel = "high"
-    reasoning_effort: ReasoningEffort = "high"
-    issue_fetch_limit: int = 100
+    # Manual-run-only settings — read by the manual trigger endpoint and
+    # forwarded into SeerNightShiftRunOptions; cron runs use the shared
+    # defaults instead.
+    max_candidates: int = pydantic.Field(default_factory=default_max_candidates)
+    extra_triage_instructions: str = DEFAULT_EXTRA_TRIAGE_INSTRUCTIONS
+    intelligence_level: IntelligenceLevel = DEFAULT_INTELLIGENCE_LEVEL
+    reasoning_effort: ReasoningEffort = DEFAULT_REASONING_EFFORT
 
     class Config:
         alias_generator = snake_to_camel_case

--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -7,6 +7,10 @@ import type {DynamicSamplingBias} from './sampling';
 
 export type SeerNightshiftTweaks = {
   enabled?: boolean;
+  extra_triage_instructions?: string;
+  intelligence_level?: 'low' | 'medium' | 'high';
+  max_candidates?: number;
+  reasoning_effort?: 'low' | 'medium' | 'high';
 };
 
 // Minimal project representation for use with avatars.

--- a/static/gsApp/views/seerAutomation/components/projectDetails/autofixAgent.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectDetails/autofixAgent.tsx
@@ -197,16 +197,23 @@ export function AutofixAgent({canWrite, preference, project}: Props) {
           schema={z.object({nightShift: z.enum(['on', 'off', 'default'])})}
           initialValue={getNightShiftValue(project)}
           mutationOptions={{
-            mutationFn: ({nightShift}: {nightShift: NightShiftValue}) =>
-              updateProject.mutateAsync({
-                seerNightshiftTweaks:
-                  nightShift === 'default'
-                    ? null
-                    : {
-                        ...project.seerNightshiftTweaks,
-                        enabled: nightShift === 'on',
-                      },
-              }),
+            mutationFn: ({nightShift}: {nightShift: NightShiftValue}) => {
+              if (nightShift === 'default') {
+                // 'default' means "no preference for enabled" — drop just that
+                // key while preserving the manual-run debug fields. If nothing
+                // else was set, send null so the option is unset entirely.
+                const {enabled: _enabled, ...rest} = project.seerNightshiftTweaks ?? {};
+                return updateProject.mutateAsync({
+                  seerNightshiftTweaks: Object.keys(rest).length === 0 ? null : rest,
+                });
+              }
+              return updateProject.mutateAsync({
+                seerNightshiftTweaks: {
+                  ...project.seerNightshiftTweaks,
+                  enabled: nightShift === 'on',
+                },
+              });
+            },
           }}
         >
           {field => (

--- a/static/gsApp/views/seerAutomation/components/projectDetails/autofixAgent.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectDetails/autofixAgent.tsx
@@ -2,16 +2,20 @@ import {useMemo} from 'react';
 import {useQuery, useQueryClient} from '@tanstack/react-query';
 import {z} from 'zod';
 
+import {FeatureBadge} from '@sentry/scraps/badge';
 import {AutoSaveForm, FieldGroup} from '@sentry/scraps/form';
+import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink, Link} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
+import Feature from 'sentry/components/acl/feature';
 import type {ProjectSeerPreferences} from 'sentry/components/events/autofix/types';
 import type {CodingAgentIntegration} from 'sentry/components/events/autofix/useAutofix';
 import {LoadingError} from 'sentry/components/loadingError';
 import {Placeholder} from 'sentry/components/placeholder';
 import {t, tct} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
+import {useUpdateProject} from 'sentry/utils/project/useUpdateProject';
 import {
   getProjectAgentMutationOptions,
   getCodingAgentSelectQueryOptions,
@@ -23,6 +27,26 @@ import {
   getProjectStoppingPointValue,
 } from 'sentry/utils/seer/stoppingPoint';
 import {useOrganization} from 'sentry/utils/useOrganization';
+
+type NightShiftValue = 'on' | 'off' | 'default';
+
+const NIGHT_SHIFT_OPTIONS = [
+  {value: 'on' as const, label: t('On')},
+  {value: 'off' as const, label: t('Off')},
+  {value: 'default' as const, label: t('Default (Off)')},
+];
+
+function getNightShiftValue(project: Project): NightShiftValue {
+  const enabled = project.seerNightshiftTweaks?.enabled;
+  if (enabled === true) {
+    return 'on';
+  }
+  if (enabled === false) {
+    return 'off';
+  }
+  return 'default';
+}
+
 interface Props {
   canWrite: boolean;
   preference: ProjectSeerPreferences;
@@ -32,6 +56,7 @@ interface Props {
 export function AutofixAgent({canWrite, preference, project}: Props) {
   const organization = useOrganization();
   const queryClient = useQueryClient();
+  const updateProject = useUpdateProject(project);
 
   const agentOptions = useQuery(getCodingAgentSelectQueryOptions({organization}));
 
@@ -165,6 +190,47 @@ export function AutofixAgent({canWrite, preference, project}: Props) {
           </field.Layout.Row>
         )}
       </AutoSaveForm>
+
+      <Feature features="organizations:seer-night-shift-settings">
+        <AutoSaveForm
+          name="nightShift"
+          schema={z.object({nightShift: z.enum(['on', 'off', 'default'])})}
+          initialValue={getNightShiftValue(project)}
+          mutationOptions={{
+            mutationFn: ({nightShift}: {nightShift: NightShiftValue}) =>
+              updateProject.mutateAsync({
+                seerNightshiftTweaks:
+                  nightShift === 'default'
+                    ? null
+                    : {
+                        ...project.seerNightshiftTweaks,
+                        enabled: nightShift === 'on',
+                      },
+              }),
+          }}
+        >
+          {field => (
+            <field.Layout.Row
+              label={
+                <Flex gap="xs" align="center">
+                  {t('Enable Night Shift')}
+                  <FeatureBadge type="alpha" />
+                </Flex>
+              }
+              hintText={t(
+                'Run Seer on your issues overnight, so fixes are ready when you start your day.'
+              )}
+            >
+              <field.Select
+                disabled={Boolean(disabledReason)}
+                value={field.state.value}
+                onChange={field.handleChange}
+                options={NIGHT_SHIFT_OPTIONS}
+              />
+            </field.Layout.Row>
+          )}
+        </AutoSaveForm>
+      </Feature>
     </FieldGroup>
   );
 }

--- a/static/gsApp/views/seerAutomation/components/projectDetails/nightShift.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectDetails/nightShift.tsx
@@ -1,12 +1,12 @@
 import {useMutation} from '@tanstack/react-query';
+import {z} from 'zod';
 
+import {Alert} from '@sentry/scraps/alert';
 import {FeatureBadge} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
-import {FieldGroup} from '@sentry/scraps/form';
-import {InfoTip} from '@sentry/scraps/info';
+import {AutoSaveForm, FieldGroup} from '@sentry/scraps/form';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
-import {Switch} from '@sentry/scraps/switch';
 import {Text} from '@sentry/scraps/text';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
@@ -16,9 +16,35 @@ import {useUpdateProject} from 'sentry/utils/project/useUpdateProject';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
-const DEFAULT_TWEAKS: Required<SeerNightshiftTweaks> = {
-  enabled: false,
-};
+// Keep these defaults in sync with the backend source of truth at
+// `src/sentry/tasks/seer/night_shift/tweaks.py` (DEFAULT_INTELLIGENCE_LEVEL,
+// DEFAULT_REASONING_EFFORT, DEFAULT_EXTRA_TRIAGE_INSTRUCTIONS, and the
+// `seer.night_shift.issues_per_org` Sentry option that backs `max_candidates`).
+const DEFAULT_INTELLIGENCE_LEVEL = 'high' as const;
+const DEFAULT_REASONING_EFFORT = 'high' as const;
+const DEFAULT_MAX_CANDIDATES = 10;
+const DEFAULT_EXTRA_TRIAGE_INSTRUCTIONS = '';
+
+type Level = 'low' | 'medium' | 'high';
+
+function levelOptions(defaultValue: Level) {
+  const labels: Record<Level, string> = {
+    low: t('Low'),
+    medium: t('Medium'),
+    high: t('High'),
+  };
+  return (['low', 'medium', 'high'] as const).map(value => ({
+    value,
+    label: value === defaultValue ? t('%s (default)', labels[value]) : labels[value],
+  }));
+}
+
+const INTELLIGENCE_LEVEL_OPTIONS = levelOptions(DEFAULT_INTELLIGENCE_LEVEL);
+const REASONING_EFFORT_OPTIONS = levelOptions(DEFAULT_REASONING_EFFORT);
+
+function getTweaks(project: Project): SeerNightshiftTweaks {
+  return project.seerNightshiftTweaks ?? {};
+}
 
 function Row({
   label,
@@ -49,63 +75,178 @@ interface Props {
 
 export function NightShift({canWrite, project}: Props) {
   const organization = useOrganization();
-  const tweaks = {...DEFAULT_TWEAKS, ...project.seerNightshiftTweaks};
-
-  const {mutate, isPending} = useUpdateProject(project);
-
-  const save = (next: SeerNightshiftTweaks) =>
-    mutate(
-      {seerNightshiftTweaks: next},
-      {
-        onError: () => addErrorMessage(t('Unable to update Night Shift settings.')),
-      }
-    );
+  const updateProject = useUpdateProject(project);
 
   const {mutate: triggerRun, isPending: isTriggering} = useMutation({
-    mutationFn: () =>
+    mutationFn: ({dryRun}: {dryRun: boolean}) =>
       fetchMutation({
         method: 'POST',
         url: `/projects/${organization.slug}/${project.slug}/seer/night-shift/`,
+        data: {dryRun},
       }),
-    onSuccess: () => addSuccessMessage(t('Night Shift run started.')),
-    onError: () => addErrorMessage(t('Unable to start Night Shift run.')),
+    onSuccess: (_data, {dryRun}) =>
+      addSuccessMessage(
+        dryRun ? t('Night Shift dry run started.') : t('Night Shift run started.')
+      ),
+    onError: (_error, {dryRun}) =>
+      addErrorMessage(
+        dryRun
+          ? t('Unable to start Night Shift dry run.')
+          : t('Unable to start Night Shift run.')
+      ),
   });
 
-  const disabled = !canWrite || isPending;
+  const tweaks = getTweaks(project);
+  const disabled = !canWrite;
 
   return (
     <FieldGroup
       title={
         <Flex gap="xs" align="center">
-          {t('Night Shift')}
+          {t('Manually trigger night shift')}
           <FeatureBadge type="alpha" />
         </Flex>
       }
     >
-      <Flex gap="xs" align="center">
-        <Text size="sm" variant="muted">
-          {t('Debug')}
-        </Text>
-        <InfoTip title={t('Prototype settings for Night Shift.')} size="sm" />
-      </Flex>
-      <Row
-        label={t('Enable Night Shift')}
-        hintText={t(
-          'Run Seer on your issues overnight, so fixes are ready when you start your day.'
+      <Alert variant="warning">
+        {t(
+          "Night Shift runs Seer Autofix on a nightly schedule. Instead of reacting to issues one occurrence at a time, it looks at your project's open issues holistically, prioritizes the ones most likely to benefit from a fix, and drafts pull requests overnight so they're ready for review when you start the next day. This is debug UI for experimenting with Night Shift by triggering manual runs. It is not intended to ever be user facing."
         )}
+      </Alert>
+
+      <AutoSaveForm
+        name="intelligence_level"
+        schema={z.object({intelligence_level: z.enum(['low', 'medium', 'high'])})}
+        initialValue={tweaks.intelligence_level ?? DEFAULT_INTELLIGENCE_LEVEL}
+        mutationOptions={{
+          mutationFn: ({intelligence_level}) =>
+            updateProject.mutateAsync({
+              seerNightshiftTweaks: {...getTweaks(project), intelligence_level},
+            }),
+        }}
       >
-        <Switch
-          checked={tweaks.enabled}
-          onChange={event => save({...tweaks, enabled: event.target.checked})}
-          disabled={disabled}
-        />
-      </Row>
+        {field => (
+          <field.Layout.Row
+            label={t('Intelligence Level')}
+            hintText={t('Higher levels improve quality but increase latency and cost.')}
+          >
+            <field.Select
+              disabled={disabled}
+              value={field.state.value}
+              onChange={field.handleChange}
+              options={INTELLIGENCE_LEVEL_OPTIONS}
+            />
+          </field.Layout.Row>
+        )}
+      </AutoSaveForm>
+
+      <AutoSaveForm
+        name="reasoning_effort"
+        schema={z.object({reasoning_effort: z.enum(['low', 'medium', 'high'])})}
+        initialValue={tweaks.reasoning_effort ?? DEFAULT_REASONING_EFFORT}
+        mutationOptions={{
+          mutationFn: ({reasoning_effort}) =>
+            updateProject.mutateAsync({
+              seerNightshiftTweaks: {...getTweaks(project), reasoning_effort},
+            }),
+        }}
+      >
+        {field => (
+          <field.Layout.Row
+            label={t('Reasoning Effort')}
+            hintText={t('How much the agent thinks before answering.')}
+          >
+            <field.Select
+              disabled={disabled}
+              value={field.state.value}
+              onChange={field.handleChange}
+              options={REASONING_EFFORT_OPTIONS}
+            />
+          </field.Layout.Row>
+        )}
+      </AutoSaveForm>
+
+      <AutoSaveForm
+        name="max_candidates"
+        schema={z.object({
+          max_candidates: z
+            .string()
+            .regex(/^\d+$/, t('Must be a positive integer'))
+            .refine(
+              v => Number(v) >= 1 && Number(v) <= 100,
+              t('Must be between 1 and 100')
+            ),
+        })}
+        initialValue={String(tweaks.max_candidates ?? DEFAULT_MAX_CANDIDATES)}
+        mutationOptions={{
+          mutationFn: ({max_candidates}) =>
+            updateProject.mutateAsync({
+              seerNightshiftTweaks: {
+                ...getTweaks(project),
+                max_candidates: Number(max_candidates),
+              },
+            }),
+        }}
+      >
+        {field => (
+          <field.Layout.Row
+            label={t('Max Candidates')}
+            hintText={t(
+              'How many issues to consider on each manual run. Default: %s.',
+              DEFAULT_MAX_CANDIDATES
+            )}
+          >
+            <field.Input
+              type="number"
+              min={1}
+              max={100}
+              disabled={disabled}
+              value={field.state.value}
+              onChange={field.handleChange}
+            />
+          </field.Layout.Row>
+        )}
+      </AutoSaveForm>
+
+      <AutoSaveForm
+        name="extra_triage_instructions"
+        schema={z.object({extra_triage_instructions: z.string()})}
+        initialValue={
+          tweaks.extra_triage_instructions ?? DEFAULT_EXTRA_TRIAGE_INSTRUCTIONS
+        }
+        mutationOptions={{
+          mutationFn: ({extra_triage_instructions}) =>
+            updateProject.mutateAsync({
+              seerNightshiftTweaks: {
+                ...getTweaks(project),
+                extra_triage_instructions,
+              },
+            }),
+        }}
+      >
+        {field => (
+          <field.Layout.Row
+            label={t('Extra Triage Instructions')}
+            hintText={t(
+              'Free-text instructions appended to the triage prompt for this project. Default: empty.'
+            )}
+          >
+            <field.TextArea
+              disabled={disabled}
+              value={field.state.value}
+              onChange={field.handleChange}
+              rows={4}
+            />
+          </field.Layout.Row>
+        )}
+      </AutoSaveForm>
+
       <Row
         label={t('Runs')}
         hintText={t('View past Night Shift runs for this organization.')}
       >
         <Link to={`/organizations/${organization.slug}/seer/workflows/`}>
-          {t('View runs')}
+          {t('View organization runs')}
         </Link>
       </Row>
       <Row
@@ -114,14 +255,23 @@ export function NightShift({canWrite, project}: Props) {
           'Kick off a one-off Night Shift run against this project to preview behavior.'
         )}
       >
-        <Button
-          priority="primary"
-          disabled={!canWrite || isTriggering}
-          busy={isTriggering}
-          onClick={() => triggerRun()}
-        >
-          {t('Run Now')}
-        </Button>
+        <Flex gap="sm">
+          <Button
+            priority="primary"
+            disabled={!canWrite || isTriggering}
+            busy={isTriggering}
+            onClick={() => triggerRun({dryRun: false})}
+          >
+            {t('Run Now')}
+          </Button>
+          <Button
+            disabled={!canWrite || isTriggering}
+            busy={isTriggering}
+            onClick={() => triggerRun({dryRun: true})}
+          >
+            {t('Dry Run')}
+          </Button>
+        </Flex>
       </Row>
     </FieldGroup>
   );

--- a/tests/sentry/seer/endpoints/test_admin_night_shift_trigger.py
+++ b/tests/sentry/seer/endpoints/test_admin_night_shift_trigger.py
@@ -31,7 +31,10 @@ class SeerAdminNightShiftTriggerTest(APITestCase):
         assert response.data["max_candidates"] is None
         mock_task.apply_async.assert_called_once_with(
             args=[self.organization.id],
-            kwargs={"dry_run": False, "max_candidates": None},
+            kwargs={
+                "options": {"source": "manual", "dry_run": False},
+                "execute_in_task": True,
+            },
         )
 
     def test_trigger_with_max_candidates_override(self) -> None:
@@ -48,7 +51,10 @@ class SeerAdminNightShiftTriggerTest(APITestCase):
         assert response.data["max_candidates"] == 3
         mock_task.apply_async.assert_called_once_with(
             args=[self.organization.id],
-            kwargs={"dry_run": True, "max_candidates": 3},
+            kwargs={
+                "options": {"source": "manual", "dry_run": True, "max_candidates": 3},
+                "execute_in_task": True,
+            },
         )
 
     def test_trigger_rejects_invalid_max_candidates(self) -> None:

--- a/tests/sentry/seer/endpoints/test_project_seer_night_shift.py
+++ b/tests/sentry/seer/endpoints/test_project_seer_night_shift.py
@@ -33,6 +33,7 @@ class ProjectSeerNightShiftTest(APITestCase):
             intelligence_level="high",
             reasoning_effort="high",
             extra_triage_instructions="",
+            triggering_user_id=self.user.id,
         )
 
     @with_feature("organizations:seer-night-shift")
@@ -56,6 +57,7 @@ class ProjectSeerNightShiftTest(APITestCase):
             intelligence_level="high",
             reasoning_effort="high",
             extra_triage_instructions="",
+            triggering_user_id=self.user.id,
         )
 
     @with_feature("organizations:seer-night-shift")
@@ -88,6 +90,7 @@ class ProjectSeerNightShiftTest(APITestCase):
             intelligence_level="low",
             reasoning_effort="medium",
             extra_triage_instructions="Be terse.",
+            triggering_user_id=self.user.id,
         )
 
     def test_without_feature_returns_404(self) -> None:

--- a/tests/sentry/seer/endpoints/test_project_seer_night_shift.py
+++ b/tests/sentry/seer/endpoints/test_project_seer_night_shift.py
@@ -16,7 +16,7 @@ class ProjectSeerNightShiftTest(APITestCase):
     @with_feature("organizations:seer-night-shift")
     def test_triggers_task(self) -> None:
         with patch(
-            "sentry.seer.endpoints.project_seer_night_shift.run_nightshift_for_projects",
+            "sentry.seer.endpoints.project_seer_night_shift.run_night_shift_for_org",
             return_value=42,
         ) as mock_task:
             response = self.get_success_response(
@@ -27,19 +27,24 @@ class ProjectSeerNightShiftTest(APITestCase):
 
         assert response.data == {"agent_run_id": 42}
         mock_task.assert_called_once_with(
+            self.organization.id,
+            options={
+                "source": "manual",
+                "dry_run": False,
+                "max_candidates": options.get("seer.night_shift.issues_per_org"),
+                "intelligence_level": "high",
+                "reasoning_effort": "high",
+                "extra_triage_instructions": "",
+            },
             project_ids=[self.project.id],
-            dry_run=False,
-            max_candidates=options.get("seer.night_shift.issues_per_org"),
-            intelligence_level="high",
-            reasoning_effort="high",
-            extra_triage_instructions="",
             triggering_user_id=self.user.id,
+            execute_in_task=True,
         )
 
     @with_feature("organizations:seer-night-shift")
     def test_triggers_task_with_dry_run(self) -> None:
         with patch(
-            "sentry.seer.endpoints.project_seer_night_shift.run_nightshift_for_projects",
+            "sentry.seer.endpoints.project_seer_night_shift.run_night_shift_for_org",
             return_value=None,
         ) as mock_task:
             response = self.get_success_response(
@@ -51,13 +56,18 @@ class ProjectSeerNightShiftTest(APITestCase):
 
         assert response.data == {"agent_run_id": None}
         mock_task.assert_called_once_with(
+            self.organization.id,
+            options={
+                "source": "manual",
+                "dry_run": True,
+                "max_candidates": options.get("seer.night_shift.issues_per_org"),
+                "intelligence_level": "high",
+                "reasoning_effort": "high",
+                "extra_triage_instructions": "",
+            },
             project_ids=[self.project.id],
-            dry_run=True,
-            max_candidates=options.get("seer.night_shift.issues_per_org"),
-            intelligence_level="high",
-            reasoning_effort="high",
-            extra_triage_instructions="",
             triggering_user_id=self.user.id,
+            execute_in_task=True,
         )
 
     @with_feature("organizations:seer-night-shift")
@@ -73,7 +83,7 @@ class ProjectSeerNightShiftTest(APITestCase):
         )
 
         with patch(
-            "sentry.seer.endpoints.project_seer_night_shift.run_nightshift_for_projects",
+            "sentry.seer.endpoints.project_seer_night_shift.run_night_shift_for_org",
             return_value=99,
         ) as mock_task:
             response = self.get_success_response(
@@ -84,18 +94,23 @@ class ProjectSeerNightShiftTest(APITestCase):
 
         assert response.data == {"agent_run_id": 99}
         mock_task.assert_called_once_with(
+            self.organization.id,
+            options={
+                "source": "manual",
+                "dry_run": False,
+                "max_candidates": 25,
+                "intelligence_level": "low",
+                "reasoning_effort": "medium",
+                "extra_triage_instructions": "Be terse.",
+            },
             project_ids=[self.project.id],
-            dry_run=False,
-            max_candidates=25,
-            intelligence_level="low",
-            reasoning_effort="medium",
-            extra_triage_instructions="Be terse.",
             triggering_user_id=self.user.id,
+            execute_in_task=True,
         )
 
     def test_without_feature_returns_404(self) -> None:
         with patch(
-            "sentry.seer.endpoints.project_seer_night_shift.run_nightshift_for_projects"
+            "sentry.seer.endpoints.project_seer_night_shift.run_night_shift_for_org"
         ) as mock_task:
             response = self.get_response(self.organization.slug, self.project.slug)
 

--- a/tests/sentry/seer/endpoints/test_project_seer_night_shift.py
+++ b/tests/sentry/seer/endpoints/test_project_seer_night_shift.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+from sentry import options
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
 
@@ -15,41 +16,85 @@ class ProjectSeerNightShiftTest(APITestCase):
     @with_feature("organizations:seer-night-shift")
     def test_triggers_task(self) -> None:
         with patch(
-            "sentry.seer.endpoints.project_seer_night_shift.run_night_shift_for_project"
+            "sentry.seer.endpoints.project_seer_night_shift.run_nightshift_for_projects",
+            return_value=42,
         ) as mock_task:
-            self.get_success_response(
+            response = self.get_success_response(
                 self.organization.slug,
                 self.project.slug,
-                status_code=202,
+                status_code=200,
             )
 
-        mock_task.apply_async.assert_called_once_with(
-            args=[self.project.id],
-            kwargs={"dry_run": False},
+        assert response.data == {"agent_run_id": 42}
+        mock_task.assert_called_once_with(
+            project_ids=[self.project.id],
+            dry_run=False,
+            max_candidates=options.get("seer.night_shift.issues_per_org"),
+            intelligence_level="high",
+            reasoning_effort="high",
+            extra_triage_instructions="",
         )
 
     @with_feature("organizations:seer-night-shift")
     def test_triggers_task_with_dry_run(self) -> None:
         with patch(
-            "sentry.seer.endpoints.project_seer_night_shift.run_night_shift_for_project"
+            "sentry.seer.endpoints.project_seer_night_shift.run_nightshift_for_projects",
+            return_value=None,
         ) as mock_task:
-            self.get_success_response(
+            response = self.get_success_response(
                 self.organization.slug,
                 self.project.slug,
                 dryRun=True,
-                status_code=202,
+                status_code=200,
             )
 
-        mock_task.apply_async.assert_called_once_with(
-            args=[self.project.id],
-            kwargs={"dry_run": True},
+        assert response.data == {"agent_run_id": None}
+        mock_task.assert_called_once_with(
+            project_ids=[self.project.id],
+            dry_run=True,
+            max_candidates=options.get("seer.night_shift.issues_per_org"),
+            intelligence_level="high",
+            reasoning_effort="high",
+            extra_triage_instructions="",
+        )
+
+    @with_feature("organizations:seer-night-shift")
+    def test_forwards_tweaks_to_task(self) -> None:
+        self.project.update_option(
+            "sentry:seer_nightshift_tweaks",
+            {
+                "max_candidates": 25,
+                "intelligence_level": "low",
+                "reasoning_effort": "medium",
+                "extra_triage_instructions": "Be terse.",
+            },
+        )
+
+        with patch(
+            "sentry.seer.endpoints.project_seer_night_shift.run_nightshift_for_projects",
+            return_value=99,
+        ) as mock_task:
+            response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                status_code=200,
+            )
+
+        assert response.data == {"agent_run_id": 99}
+        mock_task.assert_called_once_with(
+            project_ids=[self.project.id],
+            dry_run=False,
+            max_candidates=25,
+            intelligence_level="low",
+            reasoning_effort="medium",
+            extra_triage_instructions="Be terse.",
         )
 
     def test_without_feature_returns_404(self) -> None:
         with patch(
-            "sentry.seer.endpoints.project_seer_night_shift.run_night_shift_for_project"
+            "sentry.seer.endpoints.project_seer_night_shift.run_nightshift_for_projects"
         ) as mock_task:
             response = self.get_response(self.organization.slug, self.project.slug)
 
         assert response.status_code == 404
-        mock_task.apply_async.assert_not_called()
+        mock_task.assert_not_called()

--- a/tests/sentry/tasks/seer/night_shift/test_tweaks.py
+++ b/tests/sentry/tasks/seer/night_shift/test_tweaks.py
@@ -10,7 +10,7 @@ class GetNightShiftTweaksTest(TestCase):
         tweaks = get_night_shift_tweaks(self.project)
 
         assert tweaks.enabled is False
-        assert tweaks.candidate_issues == options.get("seer.night_shift.issues_per_org")
+        assert tweaks.max_candidates == options.get("seer.night_shift.issues_per_org")
 
     def test_empty_object_returns_defaults(self) -> None:
         self.project.update_option("sentry:seer_nightshift_tweaks", {})
@@ -18,17 +18,17 @@ class GetNightShiftTweaksTest(TestCase):
         tweaks = get_night_shift_tweaks(self.project)
 
         assert tweaks.enabled is False
-        assert tweaks.candidate_issues == options.get("seer.night_shift.issues_per_org")
+        assert tweaks.max_candidates == options.get("seer.night_shift.issues_per_org")
 
     def test_full_override(self) -> None:
         self.project.update_option(
             "sentry:seer_nightshift_tweaks",
-            {"enabled": True, "candidate_issues": 25},
+            {"enabled": True, "max_candidates": 25},
         )
 
         tweaks = get_night_shift_tweaks(self.project)
 
-        assert tweaks == NightShiftTweaks(enabled=True, candidate_issues=25)
+        assert tweaks == NightShiftTweaks(enabled=True, max_candidates=25)
 
     def test_partial_override_falls_back_to_option(self) -> None:
         self.project.update_option(
@@ -40,18 +40,18 @@ class GetNightShiftTweaksTest(TestCase):
             tweaks = get_night_shift_tweaks(self.project)
 
         assert tweaks.enabled is True
-        assert tweaks.candidate_issues == 42
+        assert tweaks.max_candidates == 42
 
-    def test_candidate_issues_only_uses_default_enabled(self) -> None:
+    def test_max_candidates_only_uses_default_enabled(self) -> None:
         self.project.update_option(
             "sentry:seer_nightshift_tweaks",
-            {"candidate_issues": 7},
+            {"max_candidates": 7},
         )
 
         tweaks = get_night_shift_tweaks(self.project)
 
         assert tweaks.enabled is False
-        assert tweaks.candidate_issues == 7
+        assert tweaks.max_candidates == 7
 
     def test_non_dict_value_reports_and_returns_defaults(self) -> None:
         self.project.update_option(
@@ -66,12 +66,12 @@ class GetNightShiftTweaksTest(TestCase):
 
         mock_capture.assert_called_once()
         assert tweaks.enabled is False
-        assert tweaks.candidate_issues == options.get("seer.night_shift.issues_per_org")
+        assert tweaks.max_candidates == options.get("seer.night_shift.issues_per_org")
 
     def test_invalid_payload_reports_and_returns_defaults(self) -> None:
         self.project.update_option(
             "sentry:seer_nightshift_tweaks",
-            {"candidate_issues": "not-an-int"},
+            {"max_candidates": "not-an-int"},
         )
 
         with patch(
@@ -81,4 +81,4 @@ class GetNightShiftTweaksTest(TestCase):
 
         mock_capture.assert_called_once()
         assert tweaks.enabled is False
-        assert tweaks.candidate_issues == options.get("seer.night_shift.issues_per_org")
+        assert tweaks.max_candidates == options.get("seer.night_shift.issues_per_org")

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -11,11 +11,8 @@ from sentry.seer.explorer.client_models import Artifact, MemoryBlock, Message, S
 from sentry.seer.models.night_shift import SeerNightShiftRun, SeerNightShiftRunIssue
 from sentry.seer.models.project_repository import SeerProjectRepository
 from sentry.tasks.seer.night_shift.cron import (
-    NightShiftRunSource,
-    SeerNightShiftRunOptions,
     _get_eligible_projects,
     run_night_shift_for_org,
-    run_nightshift_for_projects,
     schedule_night_shift,
 )
 from sentry.tasks.seer.night_shift.simple_triage import fixability_score_strategy
@@ -141,7 +138,7 @@ class TestGetEligibleProjects(TestCase):
 
         eligible.update_option("sentry:seer_nightshift_tweaks", {"enabled": True})
 
-        result = _get_eligible_projects(org, NightShiftRunSource.MANUAL)
+        result = _get_eligible_projects(org, "manual")
 
         assert [ep.project for ep in result] == [eligible]
         assert result[0].tweaks.enabled is True
@@ -163,7 +160,7 @@ class TestGetEligibleProjects(TestCase):
         other_repo = self.create_repo(project=other, provider="github", name="owner/other")
         SeerProjectRepository.objects.create(project=other, repository=other_repo)
 
-        result = _get_eligible_projects(org, NightShiftRunSource.MANUAL, project_ids=[target.id])
+        result = _get_eligible_projects(org, "manual", project_ids=[target.id])
 
         assert [ep.project for ep in result] == [target]
 
@@ -179,8 +176,8 @@ class TestGetEligibleProjects(TestCase):
             SeerProjectRepository.objects.create(project=project, repository=repo)
             project.update_option("sentry:seer_nightshift_tweaks", {"enabled": enabled})
 
-        cron_result = _get_eligible_projects(org, NightShiftRunSource.CRON)
-        manual_result = _get_eligible_projects(org, NightShiftRunSource.MANUAL)
+        cron_result = _get_eligible_projects(org, "cron")
+        manual_result = _get_eligible_projects(org, "manual")
 
         assert [ep.project.slug for ep in cron_result] == ["on"]
         assert sorted(ep.project.slug for ep in manual_result) == ["off", "on"]
@@ -311,11 +308,11 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
             "options": {
                 "source": "cron",
                 "max_candidates": 10,
+                "dry_run": False,
                 "intelligence_level": "high",
                 "reasoning_effort": "high",
                 "extra_triage_instructions": "",
             },
-            "dry_run": False,
             "agent_run_id": 1,
         }
 
@@ -389,7 +386,7 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
         )
 
         with self._patched_night_shift([(group.id, "autofix")]) as (mock_trigger, mock_logger):
-            run_night_shift_for_org(org.id, dry_run=True)
+            run_night_shift_for_org(org.id, options={"dry_run": True})
 
             mock_trigger.assert_not_called()
             call_extra = mock_logger.info.call_args.kwargs["extra"]
@@ -507,7 +504,7 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
                 return_value=([], None),
             ) as mock_triage,
         ):
-            run_night_shift_for_org(org.id, max_candidates=7)
+            run_night_shift_for_org(org.id, options={"max_candidates": 7})
 
         mock_triage.assert_called_once()
         assert mock_triage.call_args.args[2] == 7
@@ -532,53 +529,49 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
 
 
 @django_db_all
-class TestRunNightshiftForProjects(TestCase):
-    def test_nonexistent_project(self) -> None:
-        with patch("sentry.tasks.seer.night_shift.cron._execute_night_shift_run") as mock_execute:
-            run_nightshift_for_projects(project_ids=[999999999])
-            mock_execute.assert_not_called()
+class TestRunNightShiftForOrgManualPath(TestCase):
+    """Manual-path coverage for run_night_shift_for_org — invoked from the
+    project-settings "Run Now" endpoint with source="manual" and project_ids."""
 
     def test_inactive_org_skipped(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
         org.update(status=OrganizationStatus.PENDING_DELETION)
 
-        with patch("sentry.tasks.seer.night_shift.cron._execute_night_shift_run") as mock_execute:
-            run_nightshift_for_projects(project_ids=[project.id])
+        with patch("sentry.tasks.seer.night_shift.cron.run_night_shift_execution") as mock_execute:
+            run_night_shift_for_org(org.id, options={"source": "manual"}, project_ids=[project.id])
             mock_execute.assert_not_called()
-
-    def test_rejects_projects_from_multiple_organizations(self) -> None:
-        org_a = self.create_organization()
-        org_b = self.create_organization()
-        project_a = self.create_project(organization=org_a)
-        project_b = self.create_project(organization=org_b)
-
-        with patch("sentry.tasks.seer.night_shift.cron._execute_night_shift_run") as mock_execute:
-            run_nightshift_for_projects(project_ids=[project_a.id, project_b.id])
-            mock_execute.assert_not_called()
+            mock_execute.apply_async.assert_not_called()
 
     def test_delegates_to_shared_pipeline_with_project_ids(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
 
         with patch(
-            "sentry.tasks.seer.night_shift.cron._execute_night_shift_run",
-            return_value=42,
+            "sentry.tasks.seer.night_shift.cron.run_night_shift_execution",
         ) as mock_execute:
-            result = run_nightshift_for_projects(
-                project_ids=[project.id], dry_run=True, max_candidates=3
+            result = run_night_shift_for_org(
+                org.id,
+                options={"source": "manual", "dry_run": True, "max_candidates": 3},
+                project_ids=[project.id],
             )
 
-        assert result == 42
         mock_execute.assert_called_once()
+        # Sync invocation passes run_id as the positional arg, options + project_ids as kwargs.
+        run_id = mock_execute.call_args.args[0]
+        assert result == run_id
+        run = SeerNightShiftRun.objects.get(id=run_id)
+        assert run.organization_id == org.id
         kwargs = mock_execute.call_args.kwargs
-        assert kwargs["options"] == SeerNightShiftRunOptions(
-            source=NightShiftRunSource.MANUAL,
-            max_candidates=3,
-        )
+        assert kwargs["options"] == {
+            "source": "manual",
+            "max_candidates": 3,
+            "dry_run": True,
+            "intelligence_level": "high",
+            "reasoning_effort": "high",
+            "extra_triage_instructions": "",
+        }
         assert kwargs["project_ids"] == [project.id]
-        assert kwargs["dry_run"] is True
-        assert mock_execute.call_args.args[0].id == org.id
 
     def test_extras_contain_options_and_target_project_ids(self) -> None:
         org = self.create_organization()
@@ -588,18 +581,22 @@ class TestRunNightshiftForProjects(TestCase):
             "sentry.tasks.seer.night_shift.cron.agentic_triage_strategy",
             return_value=([], None),
         ):
-            run_nightshift_for_projects(project_ids=[project.id], dry_run=True, max_candidates=5)
+            run_night_shift_for_org(
+                org.id,
+                options={"source": "manual", "dry_run": True, "max_candidates": 5},
+                project_ids=[project.id],
+            )
 
         run = SeerNightShiftRun.objects.get(organization=org)
         assert run.extras == {
             "options": {
                 "source": "manual",
                 "max_candidates": 5,
+                "dry_run": True,
                 "intelligence_level": "high",
                 "reasoning_effort": "high",
                 "extra_triage_instructions": "",
             },
-            "dry_run": True,
             "target_project_ids": [project.id],
         }
 
@@ -611,14 +608,17 @@ class TestRunNightshiftForProjects(TestCase):
             "sentry.tasks.seer.night_shift.cron.agentic_triage_strategy",
             return_value=([], None),
         ):
-            run_nightshift_for_projects(
-                project_ids=[project.id], dry_run=True, triggering_user_id=4242
+            run_night_shift_for_org(
+                org.id,
+                options={"source": "manual", "dry_run": True},
+                project_ids=[project.id],
+                triggering_user_id=4242,
             )
 
         run = SeerNightShiftRun.objects.get(organization=org)
         assert run.extras["triggering_user_id"] == 4242
 
-    def test_runs_even_when_project_tweak_is_disabled(self) -> None:
+    def test_manual_runs_even_when_project_tweak_is_disabled(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
         project.update_option(
@@ -634,7 +634,7 @@ class TestRunNightshiftForProjects(TestCase):
                 return_value=([], None),
             ) as mock_triage,
         ):
-            run_nightshift_for_projects(project_ids=[project.id])
+            run_night_shift_for_org(org.id, options={"source": "manual"}, project_ids=[project.id])
 
         mock_triage.assert_called_once()
         assert [p.id for p in mock_triage.call_args.args[0]] == [project.id]

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -603,6 +603,21 @@ class TestRunNightshiftForProjects(TestCase):
             "target_project_ids": [project.id],
         }
 
+    def test_extras_contain_triggering_user_id_when_provided(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+
+        with patch(
+            "sentry.tasks.seer.night_shift.cron.agentic_triage_strategy",
+            return_value=([], None),
+        ):
+            run_nightshift_for_projects(
+                project_ids=[project.id], dry_run=True, triggering_user_id=4242
+            )
+
+        run = SeerNightShiftRun.objects.get(organization=org)
+        assert run.extras["triggering_user_id"] == 4242
+
     def test_runs_even_when_project_tweak_is_disabled(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -12,17 +12,16 @@ from sentry.seer.models.night_shift import SeerNightShiftRun, SeerNightShiftRunI
 from sentry.seer.models.project_repository import SeerProjectRepository
 from sentry.tasks.seer.night_shift.cron import (
     NightShiftRunSource,
+    SeerNightShiftRunOptions,
     _get_eligible_projects,
     run_night_shift_for_org,
-    run_night_shift_for_project,
+    run_nightshift_for_projects,
     schedule_night_shift,
 )
 from sentry.tasks.seer.night_shift.simple_triage import fixability_score_strategy
 from sentry.testutils.cases import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.pytest.fixtures import django_db_all
-
-NIGHT_SHIFT_FEATURES = ["projects:seer-night-shift"]
 
 
 class FakeExplorerClient:
@@ -142,8 +141,7 @@ class TestGetEligibleProjects(TestCase):
 
         eligible.update_option("sentry:seer_nightshift_tweaks", {"enabled": True})
 
-        with self.feature(NIGHT_SHIFT_FEATURES):
-            result = _get_eligible_projects(org, NightShiftRunSource.MANUAL)
+        result = _get_eligible_projects(org, NightShiftRunSource.MANUAL)
 
         assert [ep.project for ep in result] == [eligible]
         assert result[0].tweaks.enabled is True
@@ -165,32 +163,9 @@ class TestGetEligibleProjects(TestCase):
         other_repo = self.create_repo(project=other, provider="github", name="owner/other")
         SeerProjectRepository.objects.create(project=other, repository=other_repo)
 
-        with self.feature(NIGHT_SHIFT_FEATURES):
-            result = _get_eligible_projects(
-                org, NightShiftRunSource.MANUAL, project_ids=[target.id]
-            )
+        result = _get_eligible_projects(org, NightShiftRunSource.MANUAL, project_ids=[target.id])
 
         assert [ep.project for ep in result] == [target]
-
-    def test_filters_by_project_flag_disabled(self) -> None:
-        org = self.create_organization()
-
-        project = self.create_project(organization=org)
-        project.update_option(
-            "sentry:autofix_automation_tuning", AutofixAutomationTuningSettings.MEDIUM
-        )
-        repo = self.create_repo(project=project, provider="github", name="owner/repo")
-        SeerProjectRepository.objects.create(project=project, repository=repo)
-
-        with self.feature({"projects:seer-night-shift": False}):
-            assert _get_eligible_projects(org, NightShiftRunSource.MANUAL) == []
-        with self.feature(
-            {
-                "organizations:seer-project-settings-read-from-sentry": True,
-                "projects:seer-night-shift": False,
-            }
-        ):
-            assert _get_eligible_projects(org, NightShiftRunSource.MANUAL) == []
 
     def test_cron_filters_disabled_tweaks_manual_keeps_them(self) -> None:
         org = self.create_organization()
@@ -204,9 +179,8 @@ class TestGetEligibleProjects(TestCase):
             SeerProjectRepository.objects.create(project=project, repository=repo)
             project.update_option("sentry:seer_nightshift_tweaks", {"enabled": enabled})
 
-        with self.feature(NIGHT_SHIFT_FEATURES):
-            cron_result = _get_eligible_projects(org, NightShiftRunSource.CRON)
-            manual_result = _get_eligible_projects(org, NightShiftRunSource.MANUAL)
+        cron_result = _get_eligible_projects(org, NightShiftRunSource.CRON)
+        manual_result = _get_eligible_projects(org, NightShiftRunSource.MANUAL)
 
         assert [ep.project.slug for ep in cron_result] == ["on"]
         assert sorted(ep.project.slug for ep in manual_result) == ["off", "on"]
@@ -250,7 +224,6 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
 
         fake_client = FakeExplorerClient(verdicts)
         with (
-            self.feature(NIGHT_SHIFT_FEATURES),
             patch(
                 "sentry.tasks.seer.night_shift.agentic_triage.SeerExplorerClient",
                 return_value=fake_client,
@@ -273,12 +246,11 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
         self.create_project(organization=org)
 
         with (
-            self.feature(NIGHT_SHIFT_FEATURES),
             patch("sentry.tasks.seer.night_shift.cron.logger") as mock_logger,
         ):
             run_night_shift_for_org(org.id)
-            mock_logger.info.assert_called_once()
-            assert mock_logger.info.call_args.args[0] == "night_shift.no_eligible_projects"
+            info_events = [call.args[0] for call in mock_logger.info.call_args_list]
+            assert "night_shift.no_eligible_projects" in info_events
 
         run = SeerNightShiftRun.objects.get(organization=org)
         assert run.error_message is None
@@ -289,7 +261,6 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
         self.create_project(organization=org)
 
         with (
-            self.feature(NIGHT_SHIFT_FEATURES),
             patch(
                 "sentry.tasks.seer.night_shift.cron._get_eligible_projects",
                 side_effect=RuntimeError("boom"),
@@ -336,7 +307,17 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
         run = SeerNightShiftRun.objects.get(organization=org)
         assert run.triage_strategy == "agentic_triage"
         assert run.error_message is None
-        assert run.extras == {"agent_run_id": 1}
+        assert run.extras == {
+            "options": {
+                "source": "cron",
+                "max_candidates": 10,
+                "intelligence_level": "high",
+                "reasoning_effort": "high",
+                "extra_triage_instructions": "",
+            },
+            "dry_run": False,
+            "agent_run_id": 1,
+        }
 
         issue_group_ids = set(
             SeerNightShiftRunIssue.objects.filter(run=run).values_list("group_id", flat=True)
@@ -355,7 +336,6 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
         mock_client = MagicMock()
         mock_client.start_run.side_effect = RuntimeError("explorer down")
         with (
-            self.feature(NIGHT_SHIFT_FEATURES),
             patch(
                 "sentry.tasks.seer.night_shift.agentic_triage.SeerExplorerClient",
                 return_value=mock_client,
@@ -449,7 +429,6 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
         )
 
         with (
-            self.feature(NIGHT_SHIFT_FEATURES),
             patch(
                 "sentry.tasks.seer.night_shift.cron.quotas.backend.check_seer_quota",
                 return_value=False,
@@ -499,15 +478,14 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
         )
         assert issue_run_ids == {ok_group.id: "7"}
 
-    def test_max_candidates_defaults_to_max_tweak_across_projects(self) -> None:
+    def test_max_candidates_defaults_to_global_option(self) -> None:
         org = self.create_organization()
         low = self.create_project(organization=org, slug="low")
         high = self.create_project(organization=org, slug="high")
-        self._make_eligible(low, candidate_issues=3)
-        self._make_eligible(high, candidate_issues=11)
+        self._make_eligible(low, max_candidates=3)
+        self._make_eligible(high, max_candidates=11)
 
         with (
-            self.feature(NIGHT_SHIFT_FEATURES),
             patch(
                 "sentry.tasks.seer.night_shift.cron.agentic_triage_strategy",
                 return_value=([], None),
@@ -516,15 +494,14 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
             run_night_shift_for_org(org.id)
 
         mock_triage.assert_called_once()
-        assert mock_triage.call_args.args[2] == 11
+        assert mock_triage.call_args.args[2] == 10
 
     def test_explicit_max_candidates_overrides_tweaks(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
-        self._make_eligible(project, candidate_issues=50)
+        self._make_eligible(project, max_candidates=50)
 
         with (
-            self.feature(NIGHT_SHIFT_FEATURES),
             patch(
                 "sentry.tasks.seer.night_shift.cron.agentic_triage_strategy",
                 return_value=([], None),
@@ -543,7 +520,6 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
         self._make_eligible(disabled, enabled=False)
 
         with (
-            self.feature(NIGHT_SHIFT_FEATURES),
             patch(
                 "sentry.tasks.seer.night_shift.cron.agentic_triage_strategy",
                 return_value=([], None),
@@ -556,10 +532,10 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
 
 
 @django_db_all
-class TestRunNightShiftForProject(TestCase):
+class TestRunNightshiftForProjects(TestCase):
     def test_nonexistent_project(self) -> None:
         with patch("sentry.tasks.seer.night_shift.cron._execute_night_shift_run") as mock_execute:
-            run_night_shift_for_project(999999999)
+            run_nightshift_for_projects(project_ids=[999999999])
             mock_execute.assert_not_called()
 
     def test_inactive_org_skipped(self) -> None:
@@ -568,10 +544,20 @@ class TestRunNightShiftForProject(TestCase):
         org.update(status=OrganizationStatus.PENDING_DELETION)
 
         with patch("sentry.tasks.seer.night_shift.cron._execute_night_shift_run") as mock_execute:
-            run_night_shift_for_project(project.id)
+            run_nightshift_for_projects(project_ids=[project.id])
             mock_execute.assert_not_called()
 
-    def test_delegates_to_shared_pipeline_with_project_id(self) -> None:
+    def test_rejects_projects_from_multiple_organizations(self) -> None:
+        org_a = self.create_organization()
+        org_b = self.create_organization()
+        project_a = self.create_project(organization=org_a)
+        project_b = self.create_project(organization=org_b)
+
+        with patch("sentry.tasks.seer.night_shift.cron._execute_night_shift_run") as mock_execute:
+            run_nightshift_for_projects(project_ids=[project_a.id, project_b.id])
+            mock_execute.assert_not_called()
+
+    def test_delegates_to_shared_pipeline_with_project_ids(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
 
@@ -579,16 +565,43 @@ class TestRunNightShiftForProject(TestCase):
             "sentry.tasks.seer.night_shift.cron._execute_night_shift_run",
             return_value=42,
         ) as mock_execute:
-            result = run_night_shift_for_project(project.id, dry_run=True, max_candidates=3)
+            result = run_nightshift_for_projects(
+                project_ids=[project.id], dry_run=True, max_candidates=3
+            )
 
         assert result == 42
         mock_execute.assert_called_once()
         kwargs = mock_execute.call_args.kwargs
-        assert kwargs["source"] == NightShiftRunSource.MANUAL
+        assert kwargs["options"] == SeerNightShiftRunOptions(
+            source=NightShiftRunSource.MANUAL,
+            max_candidates=3,
+        )
         assert kwargs["project_ids"] == [project.id]
         assert kwargs["dry_run"] is True
-        assert kwargs["max_candidates"] == 3
         assert mock_execute.call_args.args[0].id == org.id
+
+    def test_extras_contain_options_and_target_project_ids(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+
+        with patch(
+            "sentry.tasks.seer.night_shift.cron.agentic_triage_strategy",
+            return_value=([], None),
+        ):
+            run_nightshift_for_projects(project_ids=[project.id], dry_run=True, max_candidates=5)
+
+        run = SeerNightShiftRun.objects.get(organization=org)
+        assert run.extras == {
+            "options": {
+                "source": "manual",
+                "max_candidates": 5,
+                "intelligence_level": "high",
+                "reasoning_effort": "high",
+                "extra_triage_instructions": "",
+            },
+            "dry_run": True,
+            "target_project_ids": [project.id],
+        }
 
     def test_runs_even_when_project_tweak_is_disabled(self) -> None:
         org = self.create_organization()
@@ -601,13 +614,12 @@ class TestRunNightShiftForProject(TestCase):
         project.update_option("sentry:seer_nightshift_tweaks", {"enabled": False})
 
         with (
-            self.feature(NIGHT_SHIFT_FEATURES),
             patch(
                 "sentry.tasks.seer.night_shift.cron.agentic_triage_strategy",
                 return_value=([], None),
             ) as mock_triage,
         ):
-            run_night_shift_for_project(project.id)
+            run_nightshift_for_projects(project_ids=[project.id])
 
         mock_triage.assert_called_once()
         assert [p.id for p in mock_triage.call_args.args[0]] == [project.id]


### PR DESCRIPTION
- Removes `projects:seer-night-shift` - this is superceded by the per project enabled toggle.
- Splits tweaks into two groups: those that effect cron (just enabled currently) and those that only effect manual runs.
- Splits the UI into two reflecting this. The enabled toggle goes with the other autofix settings. The debug UI stays in it's own block.
- Add a dry run button.
- Plumb though missing tweaks to the frontend.
- Remove some tweaks that didn't make much sense (agentic vs. simple, query result limit).
- Add some additional logging and error handling for manual runs.
- Add NightShiftRunOptions to simplify calling nightshift.
- Record all options in `extras`