### PR TITLE
ref(gsadmin): Prepare consistent-type-definitions under static/gsAdmin

### DIFF
--- a/static/gsAdmin/components/addGiftBudgetAction.tsx
+++ b/static/gsAdmin/components/addGiftBudgetAction.tsx
@@ -17,11 +17,11 @@ import {useApi} from 'sentry/utils/useApi';
 import type {Subscription} from 'getsentry/types';
 import {getPlanCategoryName} from 'getsentry/utils/dataCategory';
 
-type Props = {
+interface Props {
   onSuccess: () => void;
   organization: Organization;
   subscription: Subscription;
-};
+}
 
 type ModalProps = Props & ModalRenderProps;
 

--- a/static/gsAdmin/components/addGiftEventsAction.tsx
+++ b/static/gsAdmin/components/addGiftEventsAction.tsx
@@ -26,9 +26,9 @@ type Props = AdminConfirmRenderProps & {
   subscription: Subscription;
 };
 
-type State = {
+interface State {
   freeEvents?: number;
-};
+}
 
 /**
  * Rendered as part of a openAdminConfirmModal call

--- a/static/gsAdmin/components/adminConfirmationModal.tsx
+++ b/static/gsAdmin/components/adminConfirmationModal.tsx
@@ -11,14 +11,14 @@ import {TextareaField} from 'sentry/components/forms/fields/textareaField';
 
 type ConfirmProps = React.ComponentProps<typeof Confirm>;
 
-export type AdminConfirmParams = {
+export interface AdminConfirmParams {
   /**
    * Additional properties may be set via the renderModalSpecificContent
    */
   [key: string]: any;
   notes?: string;
   ticketURL?: string;
-};
+}
 
 export type AdminConfirmRenderProps = Omit<
   ConfirmMessageRenderProps,
@@ -105,12 +105,12 @@ type ConfirmMessageProps = ConfirmMessageRenderProps &
     | 'onConfirm'
   >;
 
-type State = {
+interface State {
   confirmCallback: ((params: AdminConfirmParams) => void) | null;
   invalidTicketURL: boolean;
   notes: string | null;
   ticketURL: string | null;
-};
+}
 
 class AdminConfirmMessage extends Component<ConfirmMessageProps, State> {
   state: State = {

--- a/static/gsAdmin/components/beacons/beaconCheckins.tsx
+++ b/static/gsAdmin/components/beacons/beaconCheckins.tsx
@@ -5,9 +5,9 @@ import {Truncate} from 'sentry/components/truncate';
 import type {BeaconData} from 'admin/components/beacons/beaconOverview';
 import ResultGrid from 'admin/components/resultGrid';
 
-type Props = {
+interface Props {
   data: BeaconData;
-};
+}
 
 const getRow = (row: any) => [
   <td key="id">{moment(row.dateCreated).fromNow()}</td>,

--- a/static/gsAdmin/components/beacons/beaconOverview.tsx
+++ b/static/gsAdmin/components/beacons/beaconOverview.tsx
@@ -4,7 +4,7 @@ import {DetailLabel} from 'admin/components/detailLabel';
 import {DetailList} from 'admin/components/detailList';
 import {DetailsContainer} from 'admin/components/detailsContainer';
 
-export type BeaconData = {
+export interface BeaconData {
   email: string;
   events24h: number;
   firstCheckin: string;
@@ -15,11 +15,11 @@ export type BeaconData = {
   totalProjects: number;
   totalUsers: number;
   version: string;
-};
+}
 
-type Props = {
+interface Props {
   data: BeaconData;
-};
+}
 
 export function BeaconOverview({data}: Props) {
   return (

--- a/static/gsAdmin/components/beacons/relatedBeacons.tsx
+++ b/static/gsAdmin/components/beacons/relatedBeacons.tsx
@@ -7,9 +7,9 @@ import {Truncate} from 'sentry/components/truncate';
 import type {BeaconData} from 'admin/components/beacons/beaconOverview';
 import ResultGrid from 'admin/components/resultGrid';
 
-type Props = {
+interface Props {
   data: BeaconData;
-};
+}
 
 const getRow = (row: any) => [
   <td key="id">

--- a/static/gsAdmin/components/cancelSubscriptionAction.tsx
+++ b/static/gsAdmin/components/cancelSubscriptionAction.tsx
@@ -11,10 +11,10 @@ type Props = AdminConfirmRenderProps & {
   subscription: Subscription;
 };
 
-type State = {
+interface State {
   applyBalance: boolean;
   cancelAtPeriodEnd: boolean;
-};
+}
 
 /**
  * Rendered as part of a openAdminConfirmModal call

--- a/static/gsAdmin/components/changeARRAction.tsx
+++ b/static/gsAdmin/components/changeARRAction.tsx
@@ -6,11 +6,11 @@ import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {openModal} from 'sentry/actionCreators/modal';
 import {NumberField} from 'sentry/components/forms/fields/numberField';
 
-type Props = {
+interface Props {
   // TODO(ts): Type customer when available
   customer: any;
   onAction: (data: any) => void;
-};
+}
 
 export function ChangeARRAction(props: Props) {
   return (
@@ -28,10 +28,10 @@ export function ChangeARRAction(props: Props) {
 
 type ModalProps = ModalRenderProps & Props;
 
-type ModalState = {
+interface ModalState {
   error: boolean;
   newAcv: number;
-};
+}
 
 class ChangeARRModal extends Component<ModalProps, ModalState> {
   state: ModalState = {

--- a/static/gsAdmin/components/changeEffectiveAtAction.tsx
+++ b/static/gsAdmin/components/changeEffectiveAtAction.tsx
@@ -5,9 +5,9 @@ import {openModal} from 'sentry/actionCreators/modal';
 import {InputField} from 'sentry/components/forms/fields/inputField';
 import {Form} from 'sentry/components/forms/form';
 
-type Props = {
+interface Props {
   onAction: (effectiveAt: string) => void;
-};
+}
 
 export const openChangeEffectiveAtModal = ({onAction}: Props) =>
   openModal(({Header, Body, closeModal}) => (

--- a/static/gsAdmin/components/changeGoogleDomainAction.tsx
+++ b/static/gsAdmin/components/changeGoogleDomainAction.tsx
@@ -9,11 +9,11 @@ import {TextField} from 'sentry/components/forms/fields/textField';
 import {Form} from 'sentry/components/forms/form';
 import {withApi} from 'sentry/utils/withApi';
 
-type Props = {
+interface Props {
   api: Client;
   onUpdated: (data: any) => void;
   orgId: string;
-};
+}
 
 const CHANGE_CHOICES = [
   ['swap', 'Swap'],
@@ -22,12 +22,12 @@ const CHANGE_CHOICES = [
 
 type ModalProps = Props & ModalRenderProps;
 
-type ModalState = {
+interface ModalState {
   append: string | null;
   dryRun: boolean | null;
   dryRunInfo: any[];
   loading: boolean;
-};
+}
 
 class ChangeGoogleDomainModal extends Component<ModalProps, ModalState> {
   state: ModalState = {

--- a/static/gsAdmin/components/changePlanAction.tsx
+++ b/static/gsAdmin/components/changePlanAction.tsx
@@ -319,12 +319,12 @@ function ChangePlanAction({
   );
 }
 
-type Options = {
+interface Options {
   onSuccess: () => void;
   organization: Organization;
   partnerPlanId: string | null;
   subscription: Subscription;
-};
+}
 
 export const triggerChangePlanAction = (opts: Options) =>
   openModal(deps => <ChangePlanAction {...deps} {...opts} />);

--- a/static/gsAdmin/components/customerContact.tsx
+++ b/static/gsAdmin/components/customerContact.tsx
@@ -2,9 +2,9 @@ import {ExternalLink} from '@sentry/scraps/link';
 
 import type {Subscription} from 'getsentry/types';
 
-type Props = {
+interface Props {
   owner?: Subscription['owner'];
-};
+}
 
 export function CustomerContact({owner}: Props) {
   return owner ? (

--- a/static/gsAdmin/components/customerStatus.tsx
+++ b/static/gsAdmin/components/customerStatus.tsx
@@ -6,9 +6,9 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 import type {Subscription} from 'getsentry/types';
 import {formatCurrency} from 'getsentry/utils/formatCurrency';
 
-type Props = {
+interface Props {
   customer: Subscription;
-};
+}
 
 const getLabel = (item: Subscription) => {
   if (item.isEnterpriseTrial) {

--- a/static/gsAdmin/components/customers/customerIntegrationDebugDetails.tsx
+++ b/static/gsAdmin/components/customers/customerIntegrationDebugDetails.tsx
@@ -14,7 +14,7 @@ type Props = Partial<React.ComponentProps<typeof ResultGrid>> & {
   orgId: string;
 };
 
-type IntegrationRow = {
+interface IntegrationRow {
   dateAdded: string | null;
   gracePeriodEnd: string | null;
   id: number;
@@ -27,7 +27,7 @@ type IntegrationRow = {
     status: number;
   };
   status: number;
-};
+}
 
 const STATUS_LABELS: Record<number, string> = {
   0: 'Active',

--- a/static/gsAdmin/components/customers/customerMembers.tsx
+++ b/static/gsAdmin/components/customers/customerMembers.tsx
@@ -10,9 +10,9 @@ import {IconMail} from 'sentry/icons';
 
 import ResultGrid from 'admin/components/resultGrid';
 
-type Props = {
+interface Props {
   orgId: string;
-};
+}
 
 const getRow = (row: any) => [
   <td key="name">

--- a/static/gsAdmin/components/customers/customerOnboardingTasks.tsx
+++ b/static/gsAdmin/components/customers/customerOnboardingTasks.tsx
@@ -13,10 +13,10 @@ type Props = Partial<React.ComponentProps<typeof ResultGrid>> & {
 
 type Status = 'complete' | 'pending' | 'skipped';
 
-type StatusTag = {
+interface StatusTag {
   icon: React.ReactNode;
   tagType: TagProps['variant'];
-};
+}
 
 const tagPriority: Record<Status, StatusTag> = {
   pending: {icon: <IconClock size="xs" />, tagType: 'muted'},

--- a/static/gsAdmin/components/customers/customerOverview.tsx
+++ b/static/gsAdmin/components/customers/customerOverview.tsx
@@ -54,10 +54,10 @@ import {getCountryByCode} from 'getsentry/utils/ISO3166codes';
 import {titleCase} from 'getsentry/utils/titleCase';
 import {displayPriceWithCents} from 'getsentry/views/amCheckout/utils';
 
-type SubscriptionSummaryProps = {
+interface SubscriptionSummaryProps {
   customer: Subscription;
   onAction: (data: any) => void;
-};
+}
 
 function SoftCapTypeDetail({
   categories,
@@ -165,9 +165,9 @@ function SubscriptionSummary({customer, onAction}: SubscriptionSummaryProps) {
   );
 }
 
-type ReservedDataProps = {
+interface ReservedDataProps {
   customer: Subscription;
-};
+}
 
 function ReservedData({customer}: ReservedDataProps) {
   const reservedBudgetMetricHistories: Record<string, ReservedBudgetMetricHistory> = {};
@@ -300,9 +300,9 @@ function ReservedBudgetData({
   );
 }
 
-type OnDemandSummaryProps = {
+interface OnDemandSummaryProps {
   customer: Subscription;
-};
+}
 
 function OnDemandSummary({customer}: OnDemandSummaryProps) {
   const onDemandPeriod = `${moment(customer.onDemandPeriodStart).format('ll')} › ${moment(
@@ -386,11 +386,11 @@ function OnDemandSummary({customer}: OnDemandSummaryProps) {
   );
 }
 
-type Props = {
+interface Props {
   customer: Subscription;
   onAction: (data: any) => void;
   organization: Organization;
-};
+}
 
 function isWithinAcceptedMargin(
   effectiveSampleRate: number,
@@ -939,10 +939,10 @@ const StyledTag = styled(Tag)`
   width: fit-content;
 `;
 
-type ThresholdLabelProps = {
+interface ThresholdLabelProps {
   children: React.ReactNode;
   positive: boolean;
-};
+}
 
 function ThresholdLabel({positive, children}: ThresholdLabelProps) {
   return (

--- a/static/gsAdmin/components/customers/customerProjects.tsx
+++ b/static/gsAdmin/components/customers/customerProjects.tsx
@@ -9,9 +9,9 @@ import {IconProject} from 'sentry/icons';
 
 import ResultGrid from 'admin/components/resultGrid';
 
-type Props = {
+interface Props {
   orgId: string;
-};
+}
 
 export function CustomerProjects({orgId}: Props) {
   return (

--- a/static/gsAdmin/components/customers/customerStats.tsx
+++ b/static/gsAdmin/components/customers/customerStats.tsx
@@ -32,35 +32,35 @@ enum SeriesName {
   DROPPED = 'Dropped (Server)',
 }
 
-type SubSeries = {
+interface SubSeries {
   data: DataPoint[];
   seriesName: string;
-};
+}
 
-type SeriesItem = {
+interface SeriesItem {
   data: DataPoint[];
   seriesName: string;
   color?: string;
   subSeries?: SubSeries[];
-};
+}
 
-export type StatsGroup = {
+export interface StatsGroup {
   by: {
     outcome: string;
     reason: string;
   };
   series: Record<string, number[]>;
   totals: Record<string, number>;
-};
+}
 
-type Stats = {
+interface Stats {
   groups: StatsGroup[];
   intervals: Array<string | number>;
-};
+}
 
-type LegendProps = {
+interface LegendProps {
   points: Stats;
-};
+}
 
 export const useSeries = (): Record<string, SeriesItem> => {
   const theme = useTheme();
@@ -97,12 +97,12 @@ function isAbuseWithoutReason(by: {outcome: string; reason?: string}): boolean {
   return by.outcome === 'abuse' && (!by.reason || by.reason === 'none');
 }
 
-type AbuseData = {
+interface AbuseData {
   intervalMs: number;
   intervals: number[];
   regions: Array<{end: number; start: number}>;
   valueByTimestamp: Map<number, number>;
-};
+}
 
 function getAbuseData(
   intervals: Array<string | number>,
@@ -424,13 +424,13 @@ function FooterLegend({points}: LegendProps) {
   );
 }
 
-type Props = {
+interface Props {
   dataType: DataCategoryExact;
   orgSlug: Organization['slug'];
   onDemandPeriodEnd?: string;
   onDemandPeriodStart?: string;
   projectId?: Project['id'];
-};
+}
 
 export const CustomerStats = memo(
   ({orgSlug, projectId, dataType, onDemandPeriodStart, onDemandPeriodEnd}: Props) => {

--- a/static/gsAdmin/components/customers/customerStatsFilters.tsx
+++ b/static/gsAdmin/components/customers/customerStatsFilters.tsx
@@ -22,13 +22,13 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 
 const ON_DEMAND_PERIOD_KEY = 'onDemand';
 
-type Props = {
+interface Props {
   dataType: DataCategoryExact;
   onChange: (dataType: DataCategoryExact) => void;
   organization: Organization;
   onDemandPeriodEnd?: string;
   onDemandPeriodStart?: string;
-};
+}
 
 export function CustomerStatsFilters({
   dataType,

--- a/static/gsAdmin/components/customers/organizationStatus.tsx
+++ b/static/gsAdmin/components/customers/organizationStatus.tsx
@@ -2,9 +2,9 @@ import {Alert} from '@sentry/scraps/alert';
 
 import type {Subscription} from 'getsentry/types';
 
-type Props = {
+interface Props {
   orgStatus: Subscription['orgStatus'];
-};
+}
 
 export function OrganizationStatus({orgStatus}: Props) {
   if (!orgStatus) {

--- a/static/gsAdmin/components/customers/pendingChanges.tsx
+++ b/static/gsAdmin/components/customers/pendingChanges.tsx
@@ -327,10 +327,10 @@ function getOnDemandChanges(subscription: Subscription) {
   return changes;
 }
 
-type Change = {
+interface Change {
   effectiveDate: string;
   items: React.ReactNode[];
-};
+}
 
 function getChanges(subscription: Subscription, planMigrations: PlanMigration[]) {
   const {pendingChanges} = subscription;

--- a/static/gsAdmin/components/customers/updateRetentionSettingsModal.tsx
+++ b/static/gsAdmin/components/customers/updateRetentionSettingsModal.tsx
@@ -11,11 +11,11 @@ import {useApi} from 'sentry/utils/useApi';
 
 import type {Subscription} from 'getsentry/types';
 
-type Props = {
+interface Props {
   onSuccess: () => void;
   organization: Organization;
   subscription: Subscription;
-};
+}
 
 type ModalProps = Props & ModalRenderProps;
 

--- a/static/gsAdmin/components/debounceSearch.tsx
+++ b/static/gsAdmin/components/debounceSearch.tsx
@@ -8,7 +8,7 @@ import {SearchBar} from 'sentry/components/searchBar';
 import {useApi} from 'sentry/utils/useApi';
 import {useKeyPress} from 'sentry/utils/useKeyPress';
 
-type Props = {
+interface Props {
   onSelectResult: (value: string) => void;
   path: string;
   placeholder: string;
@@ -17,7 +17,7 @@ type Props = {
   host?: string;
   onSearch?: (value: string) => void;
   queryParam?: string;
-};
+}
 
 export function DebounceSearch({
   createSuggestionPath,

--- a/static/gsAdmin/components/deleteBillingMetricHistory.tsx
+++ b/static/gsAdmin/components/deleteBillingMetricHistory.tsx
@@ -11,7 +11,7 @@ import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useApi} from 'sentry/utils/useApi';
 
-type CategoryInfo = {
+interface CategoryInfo {
   api_name: string;
   billed_category: number;
   display_name: string;
@@ -20,18 +20,18 @@ type CategoryInfo = {
   product_name: string;
   singular: string;
   tally_type: number;
-};
+}
 
-type BillingConfig = {
+interface BillingConfig {
   category_info: Record<string, CategoryInfo>;
   outcomes: Record<string, string>;
   reason_codes: Record<string, string>;
-};
+}
 
-type Props = {
+interface Props {
   onSuccess: () => void;
   organization: Organization;
-};
+}
 
 type ModalProps = Props & ModalRenderProps;
 

--- a/static/gsAdmin/components/detailLabel.tsx
+++ b/static/gsAdmin/components/detailLabel.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 
 import {Tag} from '@sentry/scraps/badge';
 
-type Props = {
+interface Props {
   /**
    * The left-hand aligned label
    */
@@ -18,7 +18,7 @@ type Props = {
    * Pass a boolean to render 'yes' or 'no' as the child for true / false
    */
   yesNo?: boolean;
-};
+}
 
 /**
  * Detail label is used within DetailList

--- a/static/gsAdmin/components/detailList.tsx
+++ b/static/gsAdmin/components/detailList.tsx
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled';
 
-type Props = {
+interface Props {
   maxLabelSize?: number;
-};
+}
 
 export const DetailList = styled('dl')<Props>`
   display: grid;

--- a/static/gsAdmin/components/detailsPage.tsx
+++ b/static/gsAdmin/components/detailsPage.tsx
@@ -13,7 +13,7 @@ import type {openAdminConfirmModal} from 'admin/components/adminConfirmationModa
 import {DropdownActions} from 'admin/components/dropdownActions';
 import {PageHeader} from 'admin/components/pageHeader';
 
-export type ActionItem = {
+export interface ActionItem {
   key: string;
   /**
    * Name of the action
@@ -51,9 +51,9 @@ export type ActionItem = {
    * If set to false will hide the item from the menu
    */
   visible?: boolean;
-};
+}
 
-export type BadgeItem = {
+export interface BadgeItem {
   name: string;
   /**
    * A tooltip rendered on the badge
@@ -67,9 +67,9 @@ export type BadgeItem = {
    * If set to false will hide the badge
    */
   visible?: boolean;
-};
+}
 
-type SectionItem = {
+interface SectionItem {
   content: React.ReactElement;
   /**
    * Adds a heading to the panel. Does nothing when noPanel is set.
@@ -90,9 +90,9 @@ type SectionItem = {
    * If set to false will hide the section
    */
   visible?: boolean;
-};
+}
 
-type Props = {
+interface Props {
   /**
    * The name of the specific item we're looking at details of.
    */
@@ -118,7 +118,7 @@ type Props = {
    * List of sections to show. This is the primary content of the page
    */
   sections?: SectionItem[];
-};
+}
 
 export function DetailsPage({
   rootName,

--- a/static/gsAdmin/components/dropdownActions.tsx
+++ b/static/gsAdmin/components/dropdownActions.tsx
@@ -7,7 +7,7 @@ import {IconNot} from 'sentry/icons';
 
 import {openAdminConfirmModal} from 'admin/components/adminConfirmationModal';
 
-type Props = {
+interface Props {
   actions: Array<{
     key: string;
     name: string;
@@ -20,7 +20,7 @@ type Props = {
     visible?: boolean;
   }>;
   label: string;
-};
+}
 
 /**
  * Map actions to a format that can be used by the CompactSelect component. This exists

--- a/static/gsAdmin/components/eventUsers.tsx
+++ b/static/gsAdmin/components/eventUsers.tsx
@@ -5,11 +5,11 @@ import {Button} from '@sentry/scraps/button';
 import {AdminConfirmationModal} from 'admin/components/adminConfirmationModal';
 import ResultGrid from 'admin/components/resultGrid';
 
-type Props = {
+interface Props {
   onRemoveEmail: (hash: string) => void;
   orgId: string;
   projectId: string;
-};
+}
 
 export function EventUsers({orgId, projectId, onRemoveEmail}: Props) {
   const getRow = (row: any) => {

--- a/static/gsAdmin/components/forkCustomer.tsx
+++ b/static/gsAdmin/components/forkCustomer.tsx
@@ -19,9 +19,9 @@ type Props = AdminConfirmRenderProps & {
   organization: Organization;
 };
 
-type State = {
+interface State {
   regionUrl: string;
-};
+}
 
 /**
  * Rendered as part of a openAdminConfirmModal call

--- a/static/gsAdmin/components/percentChange.tsx
+++ b/static/gsAdmin/components/percentChange.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 
-type Props = {
+interface Props {
   current: number;
   prev: number;
-};
+}
 
 export function PercentChange({current, prev}: Props) {
   if (!current || !prev) {

--- a/static/gsAdmin/components/planList.tsx
+++ b/static/gsAdmin/components/planList.tsx
@@ -22,7 +22,7 @@ import {
 import {getPlanCategoryName, isByteCategory} from 'getsentry/utils/dataCategory';
 import {formatCurrency} from 'getsentry/utils/formatCurrency';
 
-type Props = {
+interface Props {
   activePlan: Plan | null;
   formModel: FormModel;
   onCancel: () => void;
@@ -32,7 +32,7 @@ type Props = {
   onSubmitSuccess: (data: Data) => void;
   subscription: Subscription;
   tierPlans: BillingConfig['planList'];
-};
+}
 
 export function PlanList({
   activePlan,

--- a/static/gsAdmin/components/policies/policyRevisions.tsx
+++ b/static/gsAdmin/components/policies/policyRevisions.tsx
@@ -8,10 +8,10 @@ import {ExternalLink} from '@sentry/scraps/link';
 import ResultGrid from 'admin/components/resultGrid';
 import type {Policy, PolicyRevision} from 'getsentry/types';
 
-type Props = {
+interface Props {
   onUpdate: (data: Record<string, any>, version: PolicyRevision['version']) => void;
   policy: Policy;
-};
+}
 
 type RowProps = Props & {row: PolicyRevision};
 

--- a/static/gsAdmin/components/promoCodes/promoCodeClaimants.tsx
+++ b/static/gsAdmin/components/promoCodes/promoCodeClaimants.tsx
@@ -8,11 +8,11 @@ import {CustomerContact} from 'admin/components/customerContact';
 import ResultGrid from 'admin/components/resultGrid';
 import type {PromoCode} from 'admin/types';
 
-type Props = {
+interface Props {
   promoCode: PromoCode;
-};
+}
 
-type PromoClaimant = {
+interface PromoClaimant {
   customer: {
     name: string;
     slug: string;
@@ -20,7 +20,7 @@ type PromoClaimant = {
   dateCreated: string;
   id: string;
   user: User;
-};
+}
 
 const getRow = (row: PromoClaimant) => {
   const {customer, user} = row;

--- a/static/gsAdmin/components/provisionSubscriptionAction.tsx
+++ b/static/gsAdmin/components/provisionSubscriptionAction.tsx
@@ -107,23 +107,23 @@ class DollarsAndCentsFieldNoContext extends InputField<DollarsAndCentsFieldProps
 
 const DollarsAndCentsField = withFormContext(DollarsAndCentsFieldNoContext);
 
-type Props = {
+interface Props {
   api: Client;
   billingConfig: BillingConfig | null;
   onSuccess: () => void;
   orgId: string;
   subscription: Subscription;
-};
+}
 
 type ModalProps = ModalRenderProps & Props;
 
-type ModalState = {
+interface ModalState {
   data: any;
   // TODO(ts)
   effectiveAtDisabled: boolean;
   isLoading: boolean;
   provisionablePlans: Record<string, Plan>;
-};
+}
 
 /**
  * Convert cents to dollars

--- a/static/gsAdmin/components/refundVercelRequestModal.tsx
+++ b/static/gsAdmin/components/refundVercelRequestModal.tsx
@@ -9,15 +9,15 @@ import {useApi} from 'sentry/utils/useApi';
 
 import type {Subscription} from 'getsentry/types';
 
-type Props = {
+interface Props {
   onSuccess: () => void;
   subscription: Subscription;
-};
+}
 
-type RefundVercelApiRequest = {
+interface RefundVercelApiRequest {
   guid: string;
   reason: string;
-};
+}
 
 type ModalProps = Props & ModalRenderProps;
 

--- a/static/gsAdmin/components/relocationBadge.tsx
+++ b/static/gsAdmin/components/relocationBadge.tsx
@@ -2,9 +2,9 @@ import {Tag, type TagProps} from '@sentry/scraps/badge';
 
 import type {Relocation} from 'admin/types';
 
-type Props = {
+interface Props {
   data: Relocation;
-};
+}
 
 export function RelocationBadge({data}: Props) {
   let text = '';

--- a/static/gsAdmin/components/resultGrid.tsx
+++ b/static/gsAdmin/components/resultGrid.tsx
@@ -28,14 +28,14 @@ import {ResultTable} from 'admin/components/resultTable';
 
 type Option = [key: string, label: string];
 
-type FilterProps = {
+interface FilterProps {
   name: string;
   options: Option[];
   queryKey: string;
   value: string;
   location?: Location;
   path?: string;
-};
+}
 
 function Filter({name, queryKey, options, path, location, value}: FilterProps) {
   const {query, pathname} = location ?? {};
@@ -69,13 +69,13 @@ function Filter({name, queryKey, options, path, location, value}: FilterProps) {
 
 type SortFn = (value: string, path: string, query: Location['query']) => void;
 
-type SortByProps = {
+interface SortByProps {
   options: Option[];
   path: string;
   value: string;
   location?: Location;
   onSort?: SortFn;
-};
+}
 
 const defaultOnSort: SortFn = (value, path, query) => {
   const newQuery = {
@@ -106,10 +106,10 @@ function SortBy({options, path, location, value, onSort = defaultOnSort}: SortBy
   );
 }
 
-type FilterDescriptor = {
+interface FilterDescriptor {
   name: string;
   options: Option[];
-};
+}
 
 interface ResultGridProps extends WithRouterProps {
   api: Client;
@@ -213,7 +213,7 @@ interface ResultGridProps extends WithRouterProps {
   useQueryString?: boolean;
 }
 
-export type State = {
+export interface State {
   cursor: string;
   error: boolean;
   filters: Location['query'];
@@ -223,7 +223,7 @@ export type State = {
   region: Region | undefined;
   rows: any[];
   sortBy: string;
-};
+}
 
 const extractQuery = (query: Location['query'][string], defaultVal = '') =>
   (Array.isArray(query) ? query[0] : query) ?? defaultVal;

--- a/static/gsAdmin/components/selectableContainer.tsx
+++ b/static/gsAdmin/components/selectableContainer.tsx
@@ -7,14 +7,14 @@ import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Panel} from 'sentry/components/panels/panel';
 import {PanelHeader} from 'sentry/components/panels/panelHeader';
 
-type SelectableContainerPanelProps = {
+interface SelectableContainerPanelProps {
   children: React.ReactNode;
   extraActions?: React.ReactNode;
-};
+}
 
 export type SelectableContainerPanel = React.ComponentType<SelectableContainerPanelProps>;
 
-type ContentRenderProps = {
+interface ContentRenderProps {
   /**
    * May be used to wrap sections in panels
    */
@@ -23,9 +23,9 @@ type ContentRenderProps = {
    * May be used to render the section selector
    */
   selector: React.ReactNode;
-};
+}
 
-type Section = {
+interface Section {
   /**
    * Renders the content of the section. See the ContentRenderProps to
    * understand what each injected Prop is used for.
@@ -39,9 +39,9 @@ type Section = {
    * The name of the section. Rendered in the dropdown selector
    */
   name: string;
-};
+}
 
-type Props = {
+interface Props {
   /**
    * Each available section
    */
@@ -59,7 +59,7 @@ type Props = {
    * as the panel name
    */
   panelTitle?: string;
-};
+}
 
 export function SelectableContainer({
   dropdownPrefix,

--- a/static/gsAdmin/components/sendWeeklyEmailAction.tsx
+++ b/static/gsAdmin/components/sendWeeklyEmailAction.tsx
@@ -17,11 +17,11 @@ import type {
 
 type Props = {api: Client; orgId: string} & AdminConfirmRenderProps;
 
-type State = {
+interface State {
   deliveryEmail: string;
   dryRun: boolean;
   targetEmail: string;
-};
+}
 
 /**
  * Rendered as part of a openAdminConfirmModal call

--- a/static/gsAdmin/components/sentryAppUpdateModal.tsx
+++ b/static/gsAdmin/components/sentryAppUpdateModal.tsx
@@ -25,11 +25,11 @@ type Props = ModalRenderProps & {
   sentryAppData: any;
 };
 
-type SubmitQueryVariables = {
+interface SubmitQueryVariables {
   data: Record<string, any>;
   onSubmitError: (error: any) => void;
   onSubmitSuccess: (response: Record<string, any>) => void;
-};
+}
 
 type SubmitQueryResponse = Record<string, any>;
 

--- a/static/gsAdmin/components/sponsorshipAction.tsx
+++ b/static/gsAdmin/components/sponsorshipAction.tsx
@@ -14,9 +14,9 @@ type Props = AdminConfirmRenderProps & {
   subscription: Subscription;
 };
 
-type State = {
+interface State {
   sponsoredType?: string | null;
-};
+}
 
 /**
  * Rendered as part of a openAdminConfirmModal call

--- a/static/gsAdmin/components/suspendAccountAction.tsx
+++ b/static/gsAdmin/components/suspendAccountAction.tsx
@@ -14,9 +14,9 @@ const suspendReasons = [
   ['past_due', 'Past Due', 'This account has a past balance which needs to be paid.'],
 ] as const;
 
-type State = {
+interface State {
   suspensionReason: (typeof suspendReasons)[number][0] | null;
-};
+}
 
 /**
  * Rendered as part of a openAdminConfirmModal call

--- a/static/gsAdmin/components/toggleSpendAllocationModal.tsx
+++ b/static/gsAdmin/components/toggleSpendAllocationModal.tsx
@@ -6,12 +6,12 @@ import type {Client} from 'sentry/api';
 import {Form} from 'sentry/components/forms/form';
 import {withApi} from 'sentry/utils/withApi';
 
-type Props = {
+interface Props {
   api: Client;
   onUpdated: (data: any) => void;
   orgId: string;
   spendAllocationEnabled: boolean;
-};
+}
 
 type ModalProps = Props & ModalRenderProps;
 

--- a/static/gsAdmin/components/trialSubscriptionAction.tsx
+++ b/static/gsAdmin/components/trialSubscriptionAction.tsx
@@ -18,11 +18,11 @@ type Props = AdminConfirmRenderProps & {
   startEnterpriseTrial?: boolean;
 };
 
-type State = {
+interface State {
   trialDays: number;
   trialPlanOverride?: string;
   trialTier?: PlanTier;
-};
+}
 
 /**
  * Rendered as part of a openAdminConfirmModal call

--- a/static/gsAdmin/components/users/userCustomers.tsx
+++ b/static/gsAdmin/components/users/userCustomers.tsx
@@ -5,9 +5,9 @@ import {openModal} from 'sentry/actionCreators/modal';
 import {AddToOrgModal, RemoveFromOrgModal} from 'admin/components/addOrRemoveOrgModal';
 import {CustomerGrid} from 'admin/components/customerGrid';
 
-type Props = {
+interface Props {
   userId: string;
-};
+}
 
 export function UserCustomers({userId}: Props) {
   const openAddToOrgModal = () => {

--- a/static/gsAdmin/components/users/userEmailLog.tsx
+++ b/static/gsAdmin/components/users/userEmailLog.tsx
@@ -12,22 +12,22 @@ import type {User} from 'sentry/types/user';
 import {ResultTable} from 'admin/components/resultTable';
 import type {SelectableContainerPanel} from 'admin/components/selectableContainer';
 
-type Props = {
+interface Props {
   /**
    * This component needs to render some additional actions within the
    * SelectableContainer panel, so it must be injected as a property.
    */
   Panel: SelectableContainerPanel;
   user: User;
-};
+}
 
-type State = {
+interface State {
   activeEmail: string;
   error: boolean;
   hideButton: boolean;
   loading: boolean | null;
   results: any[];
-};
+}
 
 export class UserEmailLog extends Component<Props, State> {
   state: State = {

--- a/static/gsAdmin/components/users/userEmails.tsx
+++ b/static/gsAdmin/components/users/userEmails.tsx
@@ -3,10 +3,10 @@ import type {User} from 'sentry/types/user';
 import {ResultTable} from 'admin/components/resultTable';
 import type {SelectableContainerPanel} from 'admin/components/selectableContainer';
 
-type Props = {
+interface Props {
   Panel: SelectableContainerPanel;
   user: User;
-};
+}
 
 export function UserEmails({Panel, user}: Props) {
   const primary = user.email;

--- a/static/gsAdmin/components/users/userOverview.tsx
+++ b/static/gsAdmin/components/users/userOverview.tsx
@@ -17,14 +17,14 @@ import {DetailList} from 'admin/components/detailList';
 import {DetailsContainer} from 'admin/components/detailsContainer';
 import {prettyDate} from 'admin/utils';
 
-type Props = {
+interface Props {
   identities: UserIdentityConfig[];
   onAuthenticatorRemove: (auth: NonNullable<User['authenticators']>[number]) => void;
   onIdentityDisconnect: (identity: UserIdentityConfig) => void;
   revokeToken: (token: InternalAppApiToken) => void;
   tokens: InternalAppApiToken[];
   user: User;
-};
+}
 
 function identityLabel(identity: UserIdentityConfig) {
   if (identity.category === UserIdentityCategory.ORG_IDENTITY) {

--- a/static/gsAdmin/types/index.tsx
+++ b/static/gsAdmin/types/index.tsx
@@ -21,7 +21,7 @@ declare global {
   }
 }
 
-export type PromoCode = {
+export interface PromoCode {
   amount: string;
   campaign: string;
   code: string;
@@ -35,7 +35,7 @@ export type PromoCode = {
   trialDays: number;
   userEmail: string | null;
   userId: number;
-};
+}
 
 type RelocationStatus = 'IN_PROGRESS' | 'SUCCESS' | 'FAILURE' | 'PAUSE';
 
@@ -53,13 +53,13 @@ type RelocationStep = keyof typeof RelocationSteps;
 
 type RelocationProvenance = 'SELF_HOSTED' | 'SAAS_TO_SAAS';
 
-type RelocationAssociatedUser = {
+interface RelocationAssociatedUser {
   email: string;
   id: string;
   username: string;
-};
+}
 
-export type Relocation = {
+export interface Relocation {
   creator: RelocationAssociatedUser | null;
   dateAdded: string;
   dateUpdated: string;
@@ -78,67 +78,67 @@ export type Relocation = {
   uuid: string;
   wantOrgSlugs: string[];
   wantUsernames: string[];
-};
+}
 
-export type ContractDate = {
+export interface ContractDate {
   day?: number;
   month?: number;
   year?: number;
-};
+}
 
-type ContractPricingTier = {
+interface ContractPricingTier {
   end?: string;
   ratePerUnitCpe?: string;
   start?: string;
-};
+}
 
-type ContractTieredPricingRate = {
+interface ContractTieredPricingRate {
   tiers?: ContractPricingTier[];
-};
+}
 
-export type ContractSKUConfig = {
+export interface ContractSKUConfig {
   basePriceCents?: string;
   paygBudgetCents?: string;
   paygRate?: ContractTieredPricingRate;
   reservedRate?: ContractTieredPricingRate;
   reservedVolume?: string;
   sku?: string;
-};
+}
 
-export type ContractSharedSKUBudget = {
+export interface ContractSharedSKUBudget {
   paygBudgetCents?: string;
   reservedBudgetCents?: string;
   skus?: string[];
-};
+}
 
-type ContractMetadata = {
+interface ContractMetadata {
   id?: string;
   organizationId?: string;
-};
+}
 
-type ContractAddress = {
+interface ContractAddress {
   countryCode?: string;
-};
+}
 
-type ContractBillingConfig = {
+interface ContractBillingConfig {
   address?: ContractAddress;
   billingType?: string;
   channel?: string;
   contractEndDate?: ContractDate;
   contractStartDate?: ContractDate;
-};
+}
 
-type ContractPricingConfig = {
+interface ContractPricingConfig {
   basePriceCents?: string;
   billingPeriodEndDate?: ContractDate;
   billingPeriodStartDate?: ContractDate;
   maxSpendCents?: string;
   sharedSkuBudgets?: ContractSharedSKUBudget[];
   skuConfigs?: ContractSKUConfig[];
-};
+}
 
-export type Contract = {
+export interface Contract {
   billingConfig?: ContractBillingConfig;
   metadata?: ContractMetadata;
   pricingConfig?: ContractPricingConfig;
-};
+}

--- a/static/gsAdmin/utils.tsx
+++ b/static/gsAdmin/utils.tsx
@@ -9,10 +9,10 @@ export const isBillingAdmin = () => {
   return !!user?.permissions?.has('billing.admin');
 };
 
-type QueryConditions = {
+interface QueryConditions {
   organizationId?: string;
   projectId?: string;
-};
+}
 
 export function getLogQuery(type: string, conditions: QueryConditions) {
   let query = '';

--- a/static/gsAdmin/views/dataRequests.tsx
+++ b/static/gsAdmin/views/dataRequests.tsx
@@ -17,10 +17,10 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 
 import {PageHeader} from 'admin/components/pageHeader';
 
-type ResultQuery = {
+interface ResultQuery {
   email: string;
   orgSlug: string;
-};
+}
 
 export function DataRequests() {
   const location = useLocation();

--- a/static/gsAdmin/views/debuggingTools.tsx
+++ b/static/gsAdmin/views/debuggingTools.tsx
@@ -18,8 +18,14 @@ import {PageHeader} from 'admin/components/pageHeader';
 const SECOND_TO_MILLISECOND = 1000;
 const MILLISECOND_TO_DAY = SECOND_TO_MILLISECOND * 60 * 60 * 24;
 
-type IssueOwnerMatch = {rule: string; source: string};
-type Forecast = {data: number[]; date_added: number};
+interface IssueOwnerMatch {
+  rule: string;
+  source: string;
+}
+interface Forecast {
+  data: number[];
+  date_added: number;
+}
 type IssueDetailsResponse = Group & {forecast: Forecast};
 
 function IssueOwnerDebbuging() {

--- a/static/gsAdmin/views/dynamicSamplingPanel.tsx
+++ b/static/gsAdmin/views/dynamicSamplingPanel.tsx
@@ -27,24 +27,24 @@ import {useApi} from 'sentry/utils/useApi';
 
 import {SearchInput} from 'admin/components/resultGrid';
 
-type Props = {
+interface Props {
   organization?: Organization;
   projectId?: string;
-};
+}
 
-type ProjectConfig = {
+interface ProjectConfig {
   configs: Record<string, DSNConfig | null>;
-};
+}
 
-type DSNConfig = {
+interface DSNConfig {
   config?: {
     sampling?: {
       rules: RuleV2[];
     };
   };
-};
+}
 
-type RuleV2 = {
+interface RuleV2 {
   condition: {
     inner: InnerElement[] | InnerElement;
   };
@@ -59,11 +59,11 @@ type RuleV2 = {
     end: string;
     start: string;
   };
-};
+}
 
-type InnerElement = {
+interface InnerElement {
   value: unknown;
-};
+}
 
 enum RuleType {
   BOOST_LOW_VOLUME_PROJECTS = 'Boost Low Volume Projects',
@@ -315,11 +315,11 @@ function DynamicSamplingPanelBody({config: dsnConfig}: {config: DSNConfig | null
   );
 }
 
-type DynamicSamplingRulesTableProps = {
+interface DynamicSamplingRulesTableProps {
   baseSampleRate: number;
   searchQuery: string;
   rules?: RuleV2[];
-};
+}
 
 function DynamicSamplingRulesTable({
   baseSampleRate,

--- a/static/gsAdmin/views/instanceLevelOAuth/instanceLevelOAuthDetails.tsx
+++ b/static/gsAdmin/views/instanceLevelOAuth/instanceLevelOAuthDetails.tsx
@@ -20,7 +20,7 @@ import {PageHeader} from 'admin/components/pageHeader';
 
 import {ConfirmClientDeleteModal} from './components/confirmClientDeleteModal';
 
-type ClientDetails = {
+interface ClientDetails {
   allowedOrigins: string | null;
   clientID: string | null;
   createdAt: string | null;
@@ -30,7 +30,7 @@ type ClientDetails = {
   privacyUrl: string | null;
   redirectUris: string | null;
   termsUrl: string | null;
-};
+}
 
 const fieldProps = {
   stacked: true,

--- a/static/gsAdmin/views/relocationArtifactDetails.tsx
+++ b/static/gsAdmin/views/relocationArtifactDetails.tsx
@@ -10,9 +10,9 @@ import {useParams} from 'sentry/utils/useParams';
 
 import {DetailsPage} from 'admin/components/detailsPage';
 
-type RelocationData = {
+interface RelocationData {
   contents: string;
-};
+}
 
 export function RelocationArtifactDetails() {
   const {artifactKind, fileName, regionName, relocationUuid} = useParams<{

--- a/static/gsAdmin/views/relocationDetails.tsx
+++ b/static/gsAdmin/views/relocationDetails.tsx
@@ -48,13 +48,13 @@ enum ArtifactsState {
   ERROR = 3,
 }
 
-type RelocationArtifact = {
+interface RelocationArtifact {
   description: string;
   path: string;
   regionName: string;
   relocation: Relocation;
   sizeInKbs: number;
-};
+}
 
 // A map of each expected relocation artifact to a user-legible description of what it is.
 const expectedRelocationArtifacts = new Map<string, string>(


### PR DESCRIPTION
Prepare `static/gsAdmin` for `@typescript-eslint/consistent-type-definitions` by converting eligible object `type` aliases to `interface`. Mechanical consistency only.

**eslint.config.ts**

Rule stays off here; a follow-up enables it after the staged fixes merge.

Refs GH-113662

Made with [Cursor](https://cursor.com)