### PR TITLE
ref(gettingStartedDocs): Prepare consistent-type-definitions

### DIFF
--- a/static/app/gettingStartedDocs/capacitor/utils.tsx
+++ b/static/app/gettingStartedDocs/capacitor/utils.tsx
@@ -45,9 +45,9 @@ export const platformOptions: PlatformOptions = {
 };
 
 // Note: platformOptions is defined in index.tsx where it's used
-export type PlatformOptions = {
+export interface PlatformOptions {
   siblingOption: PlatformOption<SiblingOption>;
-};
+}
 export type Params = DocsParams<PlatformOptions>;
 
 const isAngular = (siblingOption: string): boolean =>

--- a/static/app/gettingStartedDocs/javascript/featureFlag.tsx
+++ b/static/app/gettingStartedDocs/javascript/featureFlag.tsx
@@ -3,12 +3,12 @@ import type {OnboardingConfig} from 'sentry/components/onboarding/gettingStarted
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {t, tct} from 'sentry/locale';
 
-type FeatureFlagConfiguration = {
+interface FeatureFlagConfiguration {
   integrationName: string;
   makeConfigureCode: (dsn: string) => string;
   makeVerifyCode: () => string;
   packageName: string;
-};
+}
 
 const FEATURE_FLAG_CONFIGURATION_MAP: Record<
   FeatureFlagProviderEnum,

--- a/static/app/gettingStartedDocs/node-awslambda/awslambdaArnSelector.tsx
+++ b/static/app/gettingStartedDocs/node-awslambda/awslambdaArnSelector.tsx
@@ -7,14 +7,14 @@ import {CodeBlock} from '@sentry/scraps/code';
 import Select from 'sentry/components/forms/controls/reactSelectWrapper';
 import {t} from 'sentry/locale';
 
-type RegionData = {region: string; version: string};
+interface RegionData {region: string; version: string}
 
-type LayerData = {
+interface LayerData {
   account_number: string;
   canonical: string;
   layer_name: string;
   regions: RegionData[];
-};
+}
 
 export function useAwsLambdaLayers() {
   const awsLambdaLayers = useQuery<Record<string, LayerData>>({

--- a/static/app/gettingStartedDocs/node/featureFlag.tsx
+++ b/static/app/gettingStartedDocs/node/featureFlag.tsx
@@ -3,10 +3,10 @@ import type {OnboardingConfig} from 'sentry/components/onboarding/gettingStarted
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {t} from 'sentry/locale';
 
-type FeatureFlagConfiguration = {
+interface FeatureFlagConfiguration {
   makeConfigureCode: (dsn: string) => string;
   makeVerifyCode: () => string;
-};
+}
 
 // Node.js only supports the generic featureFlagsIntegration. Vendor-specific
 // integrations (LaunchDarkly, OpenFeature, etc.) are browser-only in @sentry/browser.

--- a/static/app/gettingStartedDocs/python/featureFlag.tsx
+++ b/static/app/gettingStartedDocs/python/featureFlag.tsx
@@ -5,11 +5,11 @@ import {t, tct} from 'sentry/locale';
 
 import {getPythonInstallCodeBlock} from './utils';
 
-type FeatureFlagConfiguration = {
+interface FeatureFlagConfiguration {
   integrationName: string;
   makeConfigureCode: (dsn: string) => string;
   makeVerifyCode: () => string;
-};
+}
 
 const FEATURE_FLAG_CONFIGURATION_MAP: Record<
   FeatureFlagProviderEnum,


### PR DESCRIPTION
Prepare `static/app/gettingStartedDocs` for `@typescript-eslint/consistent-type-definitions` by converting eligible object `type` aliases to `interface`. Type-system only; no runtime behavior changes.

Does not enable the rule in `eslint.config.ts`—that lands in a follow-up after the staged file fixes merge.

Refs GH-113662

Made with [Cursor](https://cursor.com)