### PR TITLE
ref(icons): Prepare consistent-type-definitions under static/app/icons

### DIFF
--- a/static/app/icons/icons.stories.tsx
+++ b/static/app/icons/icons.stories.tsx
@@ -24,19 +24,19 @@ import {
   type IdentityIconProps,
 } from 'sentry/views/settings/components/identityIcon';
 
-type TIcon = {
+interface TIcon {
   id: string;
   name: string;
   additionalProps?: string[];
   defaultProps?: Record<string, unknown>;
   groups?: string[];
   keywords?: string[];
-};
-type TSection = {
+}
+interface TSection {
   icons: TIcon[];
   id: string;
   label: string;
-};
+}
 
 const SECTIONS: TSection[] = [
   {


### PR DESCRIPTION
Prepare `static/app/icons` for `@typescript-eslint/consistent-type-definitions` (type → `interface` where applicable). Type-level only.

Rule enablement is a separate PR after staged fixes merge.

Refs GH-113662

Made with [Cursor](https://cursor.com)