### PR TITLE
fix(integrations): Scope serialize_repository RPC by organization_id

### DIFF
--- a/src/sentry/integrations/services/repository/impl.py
+++ b/src/sentry/integrations/services/repository/impl.py
@@ -29,7 +29,7 @@ class DatabaseBackedRepositoryService(RepositoryService):
         id: int,
         as_user: RpcUser | None = None,
     ) -> Any | None:
-        repository = Repository.objects.filter(id=id).first()
+        repository = Repository.objects.filter(organization_id=organization_id, id=id).first()
         if repository is None:
             return None
         return serialize(repository, user=as_user)

--- a/tests/sentry/integrations/services/repository/test_impl.py
+++ b/tests/sentry/integrations/services/repository/test_impl.py
@@ -319,3 +319,38 @@ class DisassociateOrganizationIntegrationTest(TestCase):
         # Tasks should not have been dispatched
         mock_cleanup.apply_async.assert_not_called()
         mock_handoff.apply_async.assert_not_called()
+
+
+@cell_silo_test
+class SerializeRepositoryTest(TestCase):
+    def test_returns_repository_in_same_organization(self) -> None:
+        repo = Repository.objects.create(
+            organization_id=self.organization.id,
+            name="getsentry/sentry",
+            external_id="100",
+            provider="integrations:github",
+        )
+
+        result = repository_service.serialize_repository(
+            organization_id=self.organization.id,
+            id=repo.id,
+        )
+
+        assert result is not None
+        assert result["id"] == str(repo.id)
+
+    def test_returns_none_for_repository_in_other_organization(self) -> None:
+        other_org = self.create_organization()
+        repo = Repository.objects.create(
+            organization_id=other_org.id,
+            name="getsentry/sentry",
+            external_id="100",
+            provider="integrations:github",
+        )
+
+        result = repository_service.serialize_repository(
+            organization_id=self.organization.id,
+            id=repo.id,
+        )
+
+        assert result is None


### PR DESCRIPTION
Filter Repository lookup by both organization_id and id so the RPC cannot return a repository belonging to a different organization. Mirrors the scoping already present in get_repository.



<!-- Describe your PR here. -->

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
