### PR TITLE
feat(dashboards): Default to table view on dashboards landing page

### DIFF
--- a/static/app/views/dashboards/manage/index.spec.tsx
+++ b/static/app/views/dashboards/manage/index.spec.tsx
@@ -241,16 +241,48 @@ describe('Dashboards > Detail', () => {
       },
     });
 
-    expect(await screen.findByTestId('table')).toBeInTheDocument();
-    await userEvent.click(await screen.findByTestId('table'));
-
-    expect(localStorageWrapper.setItem).toHaveBeenCalledWith(LAYOUT_KEY, '"table"');
     expect(await screen.findByTestId('grid-editable')).toBeInTheDocument();
 
     expect(await screen.findByTestId('grid')).toBeInTheDocument();
     await userEvent.click(await screen.findByTestId('grid'));
 
     expect(localStorageWrapper.setItem).toHaveBeenCalledWith(LAYOUT_KEY, '"grid"');
+    expect(await screen.findByTestId('dashboard-grid')).toBeInTheDocument();
+
+    expect(await screen.findByTestId('table')).toBeInTheDocument();
+    await userEvent.click(await screen.findByTestId('table'));
+
+    expect(localStorageWrapper.setItem).toHaveBeenCalledWith(LAYOUT_KEY, '"table"');
+    expect(await screen.findByTestId('grid-editable')).toBeInTheDocument();
+  });
+
+  it('defaults to table view when no layout preference is stored', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/dashboards/',
+      body: [DashboardListItemFixture({title: 'Test Dashboard 1'})],
+      headers: {Link: getPaginationPageLink({numRows: 15, pageSize: 9, offset: 0})},
+    });
+
+    render(<ManageDashboards />, {
+      organization: mockAuthorizedOrg,
+    });
+
+    expect(await screen.findByTestId('grid-editable')).toBeInTheDocument();
+  });
+
+  it('respects stored grid layout preference', async () => {
+    localStorageWrapper.setItem(LAYOUT_KEY, '"grid"');
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/dashboards/',
+      body: [DashboardListItemFixture({title: 'Test Dashboard 1'})],
+      headers: {Link: getPaginationPageLink({numRows: 15, pageSize: 9, offset: 0})},
+    });
+
+    render(<ManageDashboards />, {
+      organization: mockAuthorizedOrg,
+    });
+
     expect(await screen.findByTestId('dashboard-grid')).toBeInTheDocument();
   });
 
@@ -302,6 +334,8 @@ describe('Dashboards > Detail', () => {
     const mockNavigate = jest.fn();
     mockUseNavigate.mockReturnValue(mockNavigate);
     mockUseLocation.mockReturnValue(LocationFixture({query: {sort: 'invalid'}}));
+
+    localStorageWrapper.setItem(LAYOUT_KEY, '"grid"');
 
     render(<ManageDashboards />, {
       organization: org,

--- a/static/app/views/dashboards/manage/index.tsx
+++ b/static/app/views/dashboards/manage/index.tsx
@@ -83,7 +83,7 @@ function getDashboardsOverviewLayout(): DashboardsLayout {
 
   return dashboardsLayout === GRID || dashboardsLayout === TABLE
     ? dashboardsLayout
-    : GRID;
+    : TABLE;
 }
 
 function getSortOptions({


### PR DESCRIPTION
Switch the default layout for the Dashboards landing page from grid to table (but still respect preferences if set). This is the first step toward phasing out the cards view—once we have data on how many users still land on grid, we can decide whether to remove it entirely.

Needed some test updates because the tests right now assume "Grid" view by default.

Closes DAIN-1585