### PR TITLE
feat(profiling): Support span streaming on continuous profile page

### DIFF
--- a/static/app/utils/profiling/hooks/useTransactionAsSpans.spec.tsx
+++ b/static/app/utils/profiling/hooks/useTransactionAsSpans.spec.tsx
@@ -13,7 +13,7 @@ describe('useTransaction', () => {
     MockApiClient.clearMockResponses();
   });
 
-  it('does not fetch when transactionEventId is missing', () => {
+  it('does not fetch when transactionEventId and transactionSpanId are missing', () => {
     const request = MockApiClient.addMockResponse({
       url: `/organizations/${ORG_SLUG}/events/`,
       body: {data: [], meta: {fields: {}}},
@@ -144,6 +144,62 @@ describe('useTransaction', () => {
     expect(query.project).toEqual(['42']);
   });
 
+  it('filters by transactionSpanId and traceId in the query', async () => {
+    const request = MockApiClient.addMockResponse({
+      url: `/organizations/${ORG_SLUG}/events/`,
+      body: {meta: {fields: {}}, data: []},
+    });
+
+    renderHookWithProviders(() =>
+      useTransactionAsSpans({
+        projectIds: [42],
+        transactionSpanId: 'txn-span-id',
+        traceId: 'trace-xyz',
+        start: 1_700_000_000,
+        end: 1_700_000_060,
+        enabled: true,
+      })
+    );
+
+    await waitFor(() => expect(request).toHaveBeenCalled());
+
+    const call = request.mock.calls[0];
+    const query = call![1].query;
+    expect(query.query).toContain('transaction.span_id:txn-span-id');
+    expect(query.query).not.toContain('txn-event-id');
+    expect(query.query).toContain('trace:trace-xyz');
+    expect(query.field).toEqual(expect.arrayContaining(['span_id', 'is_transaction']));
+    expect(query.project).toEqual(['42']);
+  });
+
+  it('filters by transactionSpanId if both transaction ID types are given', async () => {
+    const request = MockApiClient.addMockResponse({
+      url: `/organizations/${ORG_SLUG}/events/`,
+      body: {meta: {fields: {}}, data: []},
+    });
+
+    renderHookWithProviders(() =>
+      useTransactionAsSpans({
+        projectIds: [42],
+        transactionEventId: 'txn-event-id',
+        transactionSpanId: 'txn-span-id',
+        traceId: 'trace-xyz',
+        start: 1_700_000_000,
+        end: 1_700_000_060,
+        enabled: true,
+      })
+    );
+
+    await waitFor(() => expect(request).toHaveBeenCalled());
+
+    const call = request.mock.calls[0];
+    const query = call![1].query;
+    expect(query.query).toContain('transaction.span_id:txn-span-id');
+    expect(query.query).toContain('trace:trace-xyz');
+    expect(query.field).toEqual(expect.arrayContaining(['span_id', 'is_transaction']));
+    expect(query.project).toEqual(['42']);
+  });
+
   it('does not fetch when start or end is missing', () => {
     const request = MockApiClient.addMockResponse({
       url: `/organizations/${ORG_SLUG}/events/`,
@@ -179,6 +235,7 @@ describe('useTransaction', () => {
       useTransactionAsSpans({
         projectIds: [42],
         transactionEventId: 'txn-event-id',
+        transactionSpanId: 'txn-span-id',
         traceId: 'trace-xyz',
         start: 1_700_000_000,
         end: 1_700_000_060,
@@ -192,7 +249,8 @@ describe('useTransaction', () => {
       expect(errorSpy).toHaveBeenCalledWith(
         'Failed to load transaction span for profile',
         {
-          transactionId: 'txn-event-id',
+          transactionEventId: 'txn-event-id',
+          transactionSpanId: 'txn-span-id',
           traceId: 'trace-xyz',
           start: 1_700_000_000,
           end: 1_700_000_060,

--- a/static/app/utils/profiling/hooks/useTransactionAsSpans.tsx
+++ b/static/app/utils/profiling/hooks/useTransactionAsSpans.tsx
@@ -16,27 +16,32 @@ type UseTransactionProps = {
   start?: number;
   traceId?: string;
   transactionEventId?: string;
+  transactionSpanId?: string;
 };
 
 export function useTransactionAsSpans({
   projectIds,
-  transactionEventId: transactionId,
+  transactionEventId,
+  transactionSpanId,
   traceId,
   start,
   end,
   enabled,
 }: UseTransactionProps) {
   const search = useMemo(() => {
-    if (!transactionId) {
+    const s = new MutableSearch('');
+    if (transactionSpanId) {
+      s.setFilterValues(SpanFields.TRANSACTION_SPAN_ID, [transactionSpanId]);
+    } else if (transactionEventId) {
+      s.setFilterValues(SpanFields.TRANSACTION_EVENT_ID, [transactionEventId]);
+    } else {
       return undefined;
     }
-    const s = new MutableSearch('');
-    s.setFilterValues(SpanFields.TRANSACTION_EVENT_ID, [transactionId]);
     if (traceId) {
       s.setFilterValues(SpanFields.TRACE, [traceId]);
     }
     return s;
-  }, [transactionId, traceId]);
+  }, [transactionEventId, transactionSpanId, traceId]);
 
   const result = useSpans(
     {
@@ -93,7 +98,8 @@ export function useTransactionAsSpans({
       return;
     }
     Sentry.logger.error('Failed to load transaction span for profile', {
-      transactionId,
+      transactionEventId,
+      transactionSpanId,
       traceId,
       start,
       end,

--- a/static/app/views/explore/profiling/continuousProfileProvider.tsx
+++ b/static/app/views/explore/profiling/continuousProfileProvider.tsx
@@ -46,10 +46,13 @@ export default function ProfileAndTransactionProvider(): React.ReactElement {
     };
   }, [location.query.start, location.query.end, location.query.profilerId]);
 
+  // Legacy event ID for spans extracted from transactions (`transaction.event_id`)
   const eventId = decodeScalar(location.query.eventId) || undefined;
+  // New transaction ID for streaming spans (`transaction.span_id`)
+  const transactionId = decodeScalar(location.query.transactionId) || undefined;
 
   const [profile, setProfile] = useState<RequestState<Profiling.ProfileInput>>({
-    type: eventId ? 'initial' : 'empty',
+    type: eventId || transactionId ? 'initial' : 'empty',
   });
 
   const traceId = decodeScalar(location.query.traceId) || undefined;
@@ -57,6 +60,7 @@ export default function ProfileAndTransactionProvider(): React.ReactElement {
   const end = profileMeta ? Date.parse(profileMeta.end) / 1000 : undefined;
   const transactionResult = useTransactionAsSpans({
     transactionEventId: eventId,
+    transactionSpanId: transactionId,
     traceId,
     start,
     end,


### PR DESCRIPTION
Previously this page used the `transaction.event_id` property, which is only set on spans that were extracted from transaction events. Add support for the `transaction.span_id` property too (via the `transactionId` query string parameter) so that span-first spans can also link to continuous profiles and have the related transaction load.

The primary entry point for continuous profiles with a transaction overlay, the profiles tab in transaction summary, has already been updated to send the `transactionId` parameter (see https://github.com/getsentry/sentry/pull/113183).

Fixes DAIN-1557.