### PR TITLE
Fix:Reject options-load when integration is not liked to the group's org

### DIFF
--- a/src/sentry/integrations/slack/webhooks/options_load.py
+++ b/src/sentry/integrations/slack/webhooks/options_load.py
@@ -13,6 +13,7 @@ from rest_framework.response import Response
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, cell_silo_endpoint
+from sentry.constants import ObjectStatus
 from sentry.integrations.messaging.message_builder import format_actor_options_slack
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.slack.requests.base import SlackRequestError
@@ -100,9 +101,11 @@ class SlackOptionsLoadEndpoint(Endpoint):
             .first()
         )
 
-        if group and not integration_service.get_organization_integration(
+        if group and not integration_service.get_organization_integrations(
             organization_id=group.project.organization_id,
             integration_id=slack_request.integration.id,
+            status=ObjectStatus.ACTIVE,
+            limit=1,
         ):
             group = None
 

--- a/src/sentry/integrations/slack/webhooks/options_load.py
+++ b/src/sentry/integrations/slack/webhooks/options_load.py
@@ -14,6 +14,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, cell_silo_endpoint
 from sentry.integrations.messaging.message_builder import format_actor_options_slack
+from sentry.integrations.services.integration import integration_service
 from sentry.integrations.slack.requests.base import SlackRequestError
 from sentry.integrations.slack.requests.options_load import SlackOptionsLoadRequest
 from sentry.models.group import Group
@@ -98,6 +99,12 @@ class SlackOptionsLoadEndpoint(Endpoint):
             .filter(id=slack_request.group_id)
             .first()
         )
+
+        if group and not integration_service.get_organization_integration(
+            organization_id=group.project.organization_id,
+            integration_id=slack_request.integration.id,
+        ):
+            group = None
 
         if not group:
             _logger.warning(

--- a/tests/sentry/integrations/slack/webhooks/options_load/test_dynamic_assignment_dropdown.py
+++ b/tests/sentry/integrations/slack/webhooks/options_load/test_dynamic_assignment_dropdown.py
@@ -1,7 +1,11 @@
 import orjson
 
+from sentry.constants import ObjectStatus
+from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.silo.base import SiloMode
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.slack import install_slack
+from sentry.testutils.silo import assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
 
 from . import BaseEventTest
@@ -146,6 +150,28 @@ class DynamicAssignmentDropdownTest(BaseEventTest):
             original_message=self.original_message,
             team_id="TXXXXXXX2",
         )
+
+        assert resp.status_code == 400
+
+    def test_returns_400_when_organization_integration_is_not_active(self) -> None:
+        self.team1 = self.create_team(name="aaaa", slug="aaaa")
+        self.project = self.create_project(teams=[self.team1])
+        self.group = self.create_group(project=self.project)
+        self.original_message["blocks"][0]["block_id"] = orjson.dumps(
+            {"issue": self.group.id}
+        ).decode()
+
+        # The OrganizationIntegration linking the workspace to this org has
+        # been marked for deletion. The link check must reject it as a stale
+        # row rather than treat it as a valid bond between the workspace and
+        # the group's organization.
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            OrganizationIntegration.objects.filter(
+                organization_id=self.organization.id,
+                integration=self.integration,
+            ).update(status=ObjectStatus.PENDING_DELETION)
+
+        resp = self.post_webhook(substring="aaa", original_message=self.original_message)
 
         assert resp.status_code == 400
 

--- a/tests/sentry/integrations/slack/webhooks/options_load/test_dynamic_assignment_dropdown.py
+++ b/tests/sentry/integrations/slack/webhooks/options_load/test_dynamic_assignment_dropdown.py
@@ -1,6 +1,7 @@
 import orjson
 
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.slack import install_slack
 from sentry.testutils.skips import requires_snuba
 
 from . import BaseEventTest
@@ -123,6 +124,28 @@ class DynamicAssignmentDropdownTest(BaseEventTest):
     def test_non_existent_group(self) -> None:
         self.original_message["blocks"][0]["block_id"] = orjson.dumps({"issue": 1}).decode()
         resp = self.post_webhook(substring="bbb", original_message=self.original_message)
+
+        assert resp.status_code == 400
+
+    def test_returns_400_when_integration_not_linked_to_group_org(self) -> None:
+        self.team1 = self.create_team(name="aaaa", slug="aaaa")
+        self.project = self.create_project(teams=[self.team1])
+        self.group = self.create_group(project=self.project)
+        self.original_message["blocks"][0]["block_id"] = orjson.dumps(
+            {"issue": self.group.id}
+        ).decode()
+
+        # Slack integration installed in a different organization (different
+        # workspace_id). It must not be able to look up teams or members of
+        # this victim organization's group.
+        attacker_org = self.create_organization()
+        install_slack(attacker_org, workspace_id="TXXXXXXX2")
+
+        resp = self.post_webhook(
+            substring="aaa",
+            original_message=self.original_message,
+            team_id="TXXXXXXX2",
+        )
 
         assert resp.status_code == 400
 


### PR DESCRIPTION
SlackOptionsLoadEndpoint resolved a Group by id and returned the
project's teams and members regardless of whether the requesting
Slack integration was linked to the group's organization. Add an
OrganizationIntegration lookup tying the integration to the group's
organization, mirroring webhooks/action.get_group.
