### PR TITLE
feat(dashboards): Return avatarUrl in dashboard revision createdBy response

### DIFF
--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -709,8 +709,7 @@ class DashboardRevisionSerializer(Serializer):
     def get_attrs(self, item_list, user, **kwargs):
         user_ids = [r.created_by_id for r in item_list if r.created_by_id is not None]
         users_by_id = {
-            u["id"]: {"id": u["id"], "name": u["name"], "email": u["email"]}
-            for u in user_service.serialize_many(filter={"user_ids": user_ids})
+            u["id"]: u for u in user_service.serialize_many(filter={"user_ids": user_ids})
         }
         return {
             revision: {"created_by": users_by_id.get(str(revision.created_by_id))}
@@ -718,10 +717,18 @@ class DashboardRevisionSerializer(Serializer):
         }
 
     def serialize(self, obj, attrs, user, **kwargs) -> DashboardRevisionResponse:
+        created_by = attrs.get("created_by")
         return {
             "id": str(obj.id),
             "title": obj.title,
             "dateCreated": obj.date_added,
-            "createdBy": attrs.get("created_by"),
+            "createdBy": {
+                "id": created_by["id"],
+                "name": created_by["name"],
+                "email": created_by["email"],
+                "avatarUrl": created_by["avatarUrl"],
+            }
+            if created_by
+            else None,
             "source": obj.source,
         }

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_revisions.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_revisions.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 
 from sentry.models.dashboard import Dashboard, DashboardRevision
 from sentry.testutils.cases import APITestCase
+from sentry.utils.avatar import get_gravatar_url
 
 
 class OrganizationDashboardRevisionsTestCase(APITestCase):
@@ -62,6 +63,7 @@ class GetOrganizationDashboardRevisionsTest(OrganizationDashboardRevisionsTestCa
             "id": str(self.user.id),
             "name": self.user.get_display_name(),
             "email": self.user.email,
+            "avatarUrl": get_gravatar_url(self.user.email, size=32),
         }
         assert "dateCreated" in data
 


### PR DESCRIPTION
Add the user avatar to the dashboard revision list serializer so it can be displayed by the front end (follow-up PR).

I've tested locally that the front-end still works with this new attribute added.