### PR TITLE
test: xfail test_eap_occurrence_stores_exception_stack_as_array_attributes (flaky)

### DIFF
--- a/tests/snuba/api/endpoints/test_organization_events_occurrences.py
+++ b/tests/snuba/api/endpoints/test_organization_events_occurrences.py
@@ -511,6 +511,7 @@ class OrganizationEventsOccurrencesDatasetEndpointTest(
             q["sql"] for q in ctx.captured_queries if Group._meta.db_table in q["sql"]
         ]
 
+    @pytest.mark.xfail(reason="flaky: integer vs string type mismatch in EAP array attributes")
     def test_eap_occurrence_stores_exception_stack_as_array_attributes(self) -> None:
         expected_filenames = ["sentry/web/urls.py", "django/views/base.py"]
         expected_http_url = "https://example.com/items/123"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Marks `test_eap_occurrence_stores_exception_stack_as_array_attributes` as `xfail` to stop the flaky CI failures.

The test currently asserts that line numbers in EAP exception stack array attributes are returned as strings (`['12', '0']`), but the endpoint is returning integers (`[12, 0]`). This is a type mismatch in the EAP array attributes handling that needs a proper fix separately.

Refs: https://github.com/getsentry/sentry/actions/runs/25063278803/job/73423314728
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/C1B4LB39D/p1777392884869209?thread_ts=1777392884.869209&cid=C1B4LB39D)

<div><a href="https://cursor.com/agents/bc-6ed34f06-4507-50b5-8360-e5081aad3bbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ed34f06-4507-50b5-8360-e5081aad3bbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

