### PR TITLE
Fix: Reject card actions with integration is not linked to the group's org

### DIFF
--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -575,9 +575,11 @@ class MsTeamsWebhookEndpoint(Endpoint):
             )
             if integration is None:
                 group = None
-            elif not integration_service.get_organization_integration(
+            elif not integration_service.get_organization_integrations(
                 organization_id=group.project.organization_id,
                 integration_id=integration.id,
+                status=ObjectStatus.ACTIVE,
+                limit=1,
             ):
                 group = None
 

--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -575,6 +575,11 @@ class MsTeamsWebhookEndpoint(Endpoint):
             )
             if integration is None:
                 group = None
+            elif not integration_service.get_organization_integration(
+                organization_id=group.project.organization_id,
+                integration_id=integration.id,
+            ):
+                group = None
 
         if integration is None or group is None:
             logger.info(

--- a/tests/sentry/integrations/msteams/test_action_state_change.py
+++ b/tests/sentry/integrations/msteams/test_action_state_change.py
@@ -287,6 +287,66 @@ class StatusActionTest(APITestCase):
 
     @responses.activate
     @patch("sentry.integrations.msteams.webhook.verify_signature", return_value=True)
+    def test_action_rejected_when_group_org_not_linked_to_integration(
+        self, verify: MagicMock
+    ) -> None:
+        attacker = self.create_user(is_superuser=False)
+        other_org = self.create_organization(owner=attacker)
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            other_integration = self.create_provider_integration(
+                provider="msteams",
+                name="Army of Mordor",
+                external_id="54rum4n",
+                metadata={
+                    "service_url": "https://smba.trafficmanager.net/amer",
+                    "access_token": "y0u_h4v3_ch053n_d347h",
+                    "expires_at": int(time.time()) + 86400,
+                },
+            )
+            self.create_organization_integration(
+                organization_id=other_org.id, integration=other_integration
+            )
+            other_idp = self.create_identity_provider(type="msteams", external_id="54rum4n")
+            Identity.objects.create(
+                external_id="7h3_gr3y",
+                idp=other_idp,
+                user=attacker,
+                status=IdentityStatus.VALID,
+                scopes=[],
+            )
+
+        # Attacker references their own integration but a group from self.org.
+        payload = {
+            "type": "message",
+            "from": {"id": "7h3_gr3y"},
+            "channelData": {
+                "tenant": {"id": "m0rd0r"},
+                "team": {"id": "54rum4n"},
+                "channel": {"id": "54rum4n"},
+            },
+            "conversation": {"conversationType": "channel", "id": "54rum4n"},
+            "value": {
+                "payload": {
+                    "groupId": self.group1.id,
+                    "eventId": self.event1.event_id,
+                    "actionType": ACTION_TYPE.ARCHIVE,
+                    "rules": [],
+                    "integrationId": other_integration.id,
+                },
+                "archiveInput": "-1",
+            },
+            "replyToId": "12345",
+        }
+
+        webhook_url = reverse("sentry-integration-msteams-webhooks")
+        resp = self.client.post(webhook_url, data=payload)
+
+        assert resp.status_code == 404
+        self.group1.refresh_from_db()
+        assert self.group1.get_status() == GroupStatus.UNRESOLVED
+
+    @responses.activate
+    @patch("sentry.integrations.msteams.webhook.verify_signature", return_value=True)
     def test_assign_to_me_multiple_identities(self, verify: MagicMock) -> None:
         org2 = self.create_organization(owner=None)
 

--- a/tests/sentry/integrations/msteams/test_action_state_change.py
+++ b/tests/sentry/integrations/msteams/test_action_state_change.py
@@ -10,6 +10,8 @@ from requests import PreparedRequest
 from rest_framework.response import Response
 
 from sentry.api.client import ApiClient
+from sentry.constants import ObjectStatus
+from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.msteams.card_builder.identity import build_linking_card
 from sentry.integrations.msteams.constants import SALT
 from sentry.integrations.msteams.link_identity import build_linking_url
@@ -284,6 +286,23 @@ class StatusActionTest(APITestCase):
         assert b"Unassign" in responses.calls[0].request.body
         assert "some_channel_id" in responses.calls[0].request.url
         assert f"Assigned to {self.user.email}".encode() in responses.calls[0].request.body
+
+    @responses.activate
+    @patch("sentry.integrations.msteams.webhook.verify_signature", return_value=True)
+    def test_action_rejected_when_organization_integration_is_not_active(
+        self, verify: MagicMock
+    ) -> None:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            OrganizationIntegration.objects.filter(
+                organization_id=self.org.id,
+                integration=self.integration,
+            ).update(status=ObjectStatus.PENDING_DELETION)
+
+        resp = self.post_webhook(action_type=ACTION_TYPE.ARCHIVE, archive_input="-1")
+
+        assert resp.status_code == 404
+        self.group1.refresh_from_db()
+        assert self.group1.get_status() == GroupStatus.UNRESOLVED
 
     @responses.activate
     @patch("sentry.integrations.msteams.webhook.verify_signature", return_value=True)


### PR DESCRIPTION
_handle_action_submitted resolved the integration from the
attacker-supplied payload integrationId and then loaded the group by
id alone. Add an OrganizationIntegration lookup tying the integration
to the group's organization, mirroring Slack's get_group pattern.
