### PR TITLE
feat(detectors): Cache disabled Detectors in the source-based Detector cache

### DIFF
--- a/src/sentry/workflow_engine/caches/detector.py
+++ b/src/sentry/workflow_engine/caches/detector.py
@@ -45,7 +45,6 @@ def _query_detectors(source_id: str, query_type: str) -> list[Detector]:
         Detector.objects.filter(
             data_sources__source_id=source_id,
             data_sources__type=query_type,
-            enabled=True,
         )
         .select_related("workflow_condition_group")
         .prefetch_related("workflow_condition_group__conditions")


### PR DESCRIPTION
This broadens the set of cases where the cache can be used including for uptime processing.

Part of ISWF-2512.
