### PR TITLE
ci: maybe fix git

### DIFF
--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -140,6 +140,12 @@ runs:
       run: |
         sentry init
 
+        # Prevent git from spawning background gc/maintenance processes during
+        # dependency clones, which races with shutil.copytree (git 2.54 regression).
+        git config --global gc.auto 0
+        git config --global maintenance.auto 0
+        git config --global fetch.writeCommitGraph false
+
         # This is necessary to bring up devservices with appropriate sentry config
         cd "$WORKDIR"
 

--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -151,6 +151,10 @@ runs:
 
         timeout "${DEVSERVICES_TIMEOUT}m" devservices up --mode "$DEVSERVICES_MODE"
 
+        git config --global --unset gc.auto
+        git config --global --unset maintenance.auto
+        git config --global --unset fetch.writeCommitGraph
+
         # have tests listen on the docker gateway ip so loopback can occur
         echo "DJANGO_LIVE_TEST_SERVER_ADDRESS=$(docker network inspect bridge --format='{{(index .IPAM.Config 0).Gateway}}')" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
still messed up here: https://github.com/getsentry/sentry/actions/runs/25064614491/job/73428196070

was hoping https://github.com/getsentry/devservices/pull/312 would have fixed things but nope

90%+ sure this has to do with github's runners as it's not affecting getsentry ci at all

runner image 20260426.100.1 (sentry/oss) vs 20260413.86.1 (getsentry) - will patch getsentry in anticipation too