### PR TITLE
feat(timeseries): Match events-timeseries default interval with frontend

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -525,6 +525,10 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
                 if readable_value:
                     result["readable"] = readable_value
 
+    def get_default_interval_from_range(self, date_range: timedelta) -> str:
+        """The interval used when the request omits one."""
+        return get_interval_from_range(date_range, False)
+
     def get_rollup(
         self,
         request: Request,
@@ -533,11 +537,12 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
         use_rpc: bool,
     ) -> int:
         """TODO: we should eventually rely on `SnubaParams.granularity_secs` instead"""
+        default_interval = self.get_default_interval_from_range(snuba_params.date_range)
         try:
             rollup = get_rollup_from_request(
                 request,
                 snuba_params.date_range,
-                default_interval=None,
+                default_interval=default_interval,
                 error=InvalidSearchQuery(),
                 top_events=top_events,
                 allow_interval_over_range=not use_rpc,
@@ -548,8 +553,7 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
             if use_rpc:
                 raise
             sentry_sdk.set_tag("user.invalid_interval", request.GET.get("interval"))
-            date_range = snuba_params.date_range
-            stats_period = parse_stats_period(get_interval_from_range(date_range, False))
+            stats_period = parse_stats_period(default_interval)
             rollup = int(stats_period.total_seconds()) if stats_period is not None else 3600
         return rollup
 

--- a/src/sentry/api/endpoints/organization_events_stats.py
+++ b/src/sentry/api/endpoints/organization_events_stats.py
@@ -46,6 +46,7 @@ from sentry.snuba.referrer import Referrer, is_valid_referrer
 from sentry.snuba.spans_rpc import Spans
 from sentry.snuba.trace_metrics import TraceMetrics
 from sentry.snuba.utils import RPC_DATASETS
+from sentry.utils.dates import get_default_interval_for_chart
 from sentry.utils.snuba import SnubaError, SnubaTSResult
 
 SENTRY_BACKEND_REFERRERS = [
@@ -65,6 +66,9 @@ class OrganizationEventsStatsEndpoint(OrganizationEventsEndpointBase):
     publish_status = {
         "GET": ApiPublishStatus.EXPERIMENTAL,
     }
+
+    def get_default_interval_from_range(self, date_range: timedelta) -> str:
+        return get_default_interval_for_chart(date_range)
 
     def get_features(
         self, organization: Organization, request: Request

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -55,6 +55,7 @@ from sentry.snuba.spans_rpc import Spans
 from sentry.snuba.trace_metrics import TraceMetrics
 from sentry.snuba.utils import DATASET_LABELS, RPC_DATASETS
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
+from sentry.utils.dates import get_default_interval_for_chart
 from sentry.utils.snuba import SnubaTSResult
 
 TOP_EVENTS_DATASETS = {
@@ -97,6 +98,13 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
             }
         }
     )
+
+    def get_default_interval_from_range(self, date_range: timedelta) -> str:
+        # Match Explore's ``useChartInterval`` default so unfurled and
+        # backend-driven charts bucket the same way as the in-app chart when
+        # the request omits an explicit ``interval``. Dashboards will move to
+        # the same default when its frontend dropdown is updated.
+        return get_default_interval_for_chart(date_range)
 
     def get_request_querysource(self, request: Request, referrer: str) -> QuerySource:
         if referrer in SENTRY_BACKEND_REFERRERS:
@@ -361,6 +369,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
                 dataset=DATASET_LABELS[dataset],
                 start=snuba_params.start_date.timestamp() * 1000,
                 end=snuba_params.end_date.timestamp() * 1000,
+                interval=rollup * 1000,
             ),
             timeSeries=self.serialize_result(result, axes, rollup, now),
         )

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -100,10 +100,6 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
     )
 
     def get_default_interval_from_range(self, date_range: timedelta) -> str:
-        # Match Explore's ``useChartInterval`` default so unfurled and
-        # backend-driven charts bucket the same way as the in-app chart when
-        # the request omits an explicit ``interval``. Dashboards will move to
-        # the same default when its frontend dropdown is updated.
         return get_default_interval_for_chart(date_range)
 
     def get_request_querysource(self, request: Request, referrer: str) -> QuerySource:

--- a/src/sentry/api/endpoints/timeseries.py
+++ b/src/sentry/api/endpoints/timeseries.py
@@ -9,6 +9,7 @@ class StatsMeta(TypedDict):
     dataset: str
     start: float
     end: float
+    interval: float
 
 
 class Row(TypedDict):

--- a/src/sentry/apidocs/examples/discover_performance_examples.py
+++ b/src/sentry/apidocs/examples/discover_performance_examples.py
@@ -83,7 +83,12 @@ class DiscoverAndPerformanceExamples:
                             },
                         },
                     ],
-                    "meta": {"dataset": "spans", "start": 1741368281123, "end": 1741368281123},
+                    "meta": {
+                        "dataset": "spans",
+                        "start": 1741368281123,
+                        "end": 1741368281123,
+                        "interval": 3600,
+                    },
                 }
             ),
             status_codes=["200"],

--- a/src/sentry/utils/dates.py
+++ b/src/sentry/utils/dates.py
@@ -137,6 +137,20 @@ def get_interval_from_range(date_range: timedelta, high_fidelity: bool) -> str:
     return "5m" if high_fidelity else "15m"
 
 
+def get_default_interval_for_chart(date_range: timedelta) -> str:
+    if date_range >= timedelta(days=30):
+        return "3h"
+    if date_range >= timedelta(weeks=2):
+        return "1h"
+    if date_range >= timedelta(days=4):
+        return "30m"
+    if date_range >= timedelta(hours=48):
+        return "10m"
+    if date_range >= timedelta(hours=12):
+        return "5m"
+    return "1m"
+
+
 def get_rollup_from_request(
     request: HttpRequest,
     date_range: timedelta,

--- a/tests/snuba/api/endpoints/test_organization_events_stats.py
+++ b/tests/snuba/api/endpoints/test_organization_events_stats.py
@@ -2666,8 +2666,8 @@ class OrganizationEventsStatsTopNEventsSpans(APITestCase, SnubaTestCase):
             )
         assert response.status_code == 200
         assert mock_raw_query.call_count == 2
-        # Should've reset to the default for between 1 and 24h
-        assert mock_raw_query.mock_calls[1].args[0].query.granularity.granularity == 300
+        # Should've reset to the chart default for a 2h window (1m)
+        assert mock_raw_query.mock_calls[1].args[0].query.granularity.granularity == 60
 
         with self.feature(self.enabled_features):
             response = self.client.get(

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries.py
@@ -83,6 +83,21 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
         with self.feature(features):
             return self.client.get(self.url if url is None else url, data=data, format="json")
 
+    def test_default_interval_matches_frontend(self) -> None:
+        # 2-hour window omitting interval should bucket at 1m, matching
+        # Explore's ``useChartInterval`` default.
+        response = self.do_request(
+            {
+                "start": self.start,
+                "end": self.end,
+                "project": [self.project.id, self.project2.id],
+            },
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["meta"]["interval"] == 60_000
+        timeseries = response.data["timeSeries"][0]
+        assert timeseries["meta"]["interval"] == 60_000
+
     def test_no_projects(self) -> None:
         org = self.create_organization(owner=self.user)
         self.login_as(user=self.user)
@@ -111,6 +126,7 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
             "dataset": "discover",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 3_600_000,
         }
         assert len(response.data["timeSeries"]) == 1
         timeseries = response.data["timeSeries"][0]
@@ -155,6 +171,7 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
             "dataset": "discover",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 3_600_000,
         }
         assert len(response.data["timeSeries"]) == 2
         timeseries = response.data["timeSeries"][0]
@@ -228,6 +245,7 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
             "dataset": "discover",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 3_600_000,
         }
         assert len(response.data["timeSeries"]) == 4
         timeseries = response.data["timeSeries"][0]
@@ -361,6 +379,7 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
             "dataset": "discover",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 3_600_000,
         }
         assert len(response.data["timeSeries"]) == 1
         timeseries = response.data["timeSeries"][0]

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_logs.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_logs.py
@@ -67,6 +67,7 @@ class OrganizationEventsStatsOurlogsMetricsEndpointTest(OrganizationEventsEndpoi
             "dataset": "logs",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 3_600_000,
         }
         assert len(response.data["timeSeries"]) == 1
         timeseries = response.data["timeSeries"][0]
@@ -135,6 +136,7 @@ class OrganizationEventsStatsOurlogsMetricsEndpointTest(OrganizationEventsEndpoi
             "dataset": "logs",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 60_000,
         }
         assert len(response.data["timeSeries"]) == 2
 
@@ -186,6 +188,7 @@ class OrganizationEventsStatsOurlogsMetricsEndpointTest(OrganizationEventsEndpoi
             "dataset": "logs",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 3_600_000,
         }
         assert len(response.data["timeSeries"]) == 1
         timeseries = response.data["timeSeries"][0]

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_occurrences.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_occurrences.py
@@ -97,6 +97,7 @@ class OrganizationEventsTimeseriesOccurrencesEndpointTest(
             "dataset": "occurrences",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 3_600_000,
         }
         assert len(response.data["timeSeries"]) == 1
         timeseries = response.data["timeSeries"][0]

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_spans.py
@@ -121,6 +121,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "dataset": "spans",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 3_600_000,
         }
         assert len(response.data["timeSeries"]) == 1
         timeseries = response.data["timeSeries"][0]
@@ -204,6 +205,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "dataset": "spans",
             "start": rounded_start.timestamp() * 1000,
             "end": rounded_end.timestamp() * 1000,
+            "interval": 86_400_000,
         }
         assert len(response.data["timeSeries"]) == 4
         timeseries = response.data["timeSeries"][0]
@@ -305,6 +307,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "dataset": "spans",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 3_600_000,
         }
         assert len(response.data["timeSeries"]) == 1
         timeseries = response.data["timeSeries"][0]
@@ -349,6 +352,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "dataset": "spans",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 3_600_000,
         }
         assert len(response.data["timeSeries"]) == 1
         timeseries = response.data["timeSeries"][0]
@@ -399,6 +403,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "dataset": "spans",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 3_600_000,
         }
         assert len(response.data["timeSeries"]) == 2
 
@@ -475,6 +480,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "dataset": "spans",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 60_000,
         }
         assert len(response.data["timeSeries"]) == 3
 
@@ -631,6 +637,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "dataset": "spans",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 60_000,
         }
         assert len(response.data["timeSeries"]) == 3
 
@@ -721,6 +728,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "dataset": "spans",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 60_000,
         }
         assert len(response.data["timeSeries"]) == 2
 
@@ -789,6 +797,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "dataset": "spans",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 60_000,
         }
         assert len(response.data["timeSeries"]) == 2
 
@@ -857,6 +866,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "dataset": "spans",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 60_000,
         }
         assert len(response.data["timeSeries"]) == 6
 
@@ -996,6 +1006,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "dataset": "spans",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 60_000,
         }
         assert len(response.data["timeSeries"]) == 3
 
@@ -1085,6 +1096,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "dataset": "spans",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 60_000,
         }
         assert len(response.data["timeSeries"]) == 3
 
@@ -1208,6 +1220,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "dataset": "spans",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 3_600_000,
         }
         assert len(response.data["timeSeries"]) == 1
 
@@ -1276,6 +1289,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
                 "dataset": "spans",
                 "start": self.start.timestamp() * 1000,
                 "end": self.end.timestamp() * 1000,
+                "interval": 3_600_000,
             }
             assert len(response.data["timeSeries"]) == 1
 
@@ -1332,6 +1346,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "dataset": "spans",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 3_600_000,
         }
         assert len(response.data["timeSeries"]) == 2
 
@@ -1400,6 +1415,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "dataset": "spans",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 60_000,
         }
         assert len(response.data["timeSeries"]) == 3
 
@@ -1457,6 +1473,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "dataset": "spans",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 3_600_000,
         }
         assert len(response.data["timeSeries"]) == 1
 
@@ -1508,6 +1525,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "dataset": "spans",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 3_600_000,
         }
         assert len(response.data["timeSeries"]) == 1
 
@@ -1588,6 +1606,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
                 "dataset": "spans",
                 "start": self.start.timestamp() * 1000,
                 "end": self.end.timestamp() * 1000,
+                "interval": 3_600_000,
             }
             assert len(response.data["timeSeries"]) == 1
 
@@ -1654,6 +1673,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
                 "dataset": "spans",
                 "start": self.start.timestamp() * 1000,
                 "end": self.end.timestamp() * 1000,
+                "interval": 3_600_000,
             }
             assert len(response.data["timeSeries"]) == 1
 
@@ -1714,6 +1734,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "dataset": "spans",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 60_000,
         }
         assert len(response.data["timeSeries"]) == 0
 
@@ -1784,6 +1805,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "dataset": "spans",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 60_000,
         }
         assert len(response.data["timeSeries"]) == 1
 
@@ -1846,6 +1868,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "dataset": "spans",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 60_000,
         }
         assert len(response.data["timeSeries"]) == 1
 
@@ -1896,6 +1919,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "dataset": "spans",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 60_000,
         }
         assert len(response.data["timeSeries"]) == 1
 
@@ -1945,6 +1969,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "dataset": "spans",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 60_000,
         }
         assert len(response.data["timeSeries"]) == 1
 
@@ -1978,6 +2003,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "dataset": "spans",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 60_000,
         }
         assert len(response.data["timeSeries"]) == 1
 
@@ -2032,6 +2058,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "dataset": "spans",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 60_000,
         }
         assert len(response.data["timeSeries"]) == 1
 
@@ -2071,6 +2098,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "dataset": "spans",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 60_000,
         }
         assert len(response.data["timeSeries"]) == 2
 
@@ -2123,6 +2151,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "dataset": "spans",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 60_000,
         }
         assert len(response.data["timeSeries"]) == 1
 
@@ -2174,6 +2203,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "dataset": "spans",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 60_000,
         }
         assert len(response.data["timeSeries"]) == 1
 
@@ -2224,6 +2254,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "dataset": "spans",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 60_000,
         }
         assert len(response.data["timeSeries"]) == 2
 
@@ -2314,6 +2345,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "dataset": "spans",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 60_000,
         }
         assert len(response.data["timeSeries"]) == 3
 
@@ -2404,6 +2436,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "dataset": "spans",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 3_600_000,
         }
         assert len(response.data["timeSeries"]) == 1
 
@@ -2465,6 +2498,7 @@ class OrganizationEventsStatsSpansMetricsEndpointTest(OrganizationEventsEndpoint
             "dataset": "spans",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 3_600_000,
         }
         assert len(response.data["timeSeries"]) == 1
 

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries_trace_metrics.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries_trace_metrics.py
@@ -67,6 +67,7 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
             "dataset": "tracemetrics",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 3_600_000,
         }
         assert len(response.data["timeSeries"]) == 1
         timeseries = response.data["timeSeries"][0]
@@ -138,6 +139,7 @@ class OrganizationEventsStatsTraceMetricsEndpointTest(OrganizationEventsEndpoint
             "dataset": "tracemetrics",
             "start": self.start.timestamp() * 1000,
             "end": self.end.timestamp() * 1000,
+            "interval": 60_000,
         }
         assert len(response.data["timeSeries"]) == 2
 


### PR DESCRIPTION
Update the event-timeseries and event-stats interval selection to better match explore defaults. Currently explore and dashboards always passes through the interval, so this shouldn't affect anything there.

This is to facilitate a future frontend change, we want to update it to only pass through the interval query param to the backend if it's in the browser url query params. If it's not we will let the backend decide and use the interval in the meta to populate the interval dropdown. This will consolidate interval selection for slack url unfurls

This also ensures users of the api get the same defaults as our ui