### PR TITLE
feat(hotkey): add `mod` as alternative to `cmd`-on-mac, else `ctrl`

### DIFF
--- a/static/app/components/commandPalette/ui/commandPalette.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.tsx
@@ -1166,7 +1166,7 @@ function CommandPaletteHints() {
           <Text size="xs" variant="muted">
             {t('Toggle Command Palette')}
           </Text>
-          <Hotkey variant="debossed" value="command+k" />
+          <Hotkey variant="debossed" value="mod+k" />
         </Flex>
       </Flex>
     </Stack>

--- a/static/app/components/commandPalette/ui/commandPaletteStateContext.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteStateContext.tsx
@@ -187,7 +187,7 @@ export function CommandPaletteHotkeys() {
 
   useHotkeys([
     {
-      match: ['command+shift+p', 'command+k', 'ctrl+shift+p', 'ctrl+k'],
+      match: ['mod+shift+p', 'mod+k'],
       includeInputs: true,
       callback: () => {
         if (organization?.features.includes('cmd-k-supercharged')) {

--- a/static/app/components/core/hotkey/hotkey.mdx
+++ b/static/app/components/core/hotkey/hotkey.mdx
@@ -19,33 +19,35 @@ import * as Storybook from 'sentry/stories';
 
 export const documentation = import('!!type-loader!@sentry/scraps/hotkey');
 
-The `<Hotkey>` component displays keyboard shortcuts using semantic `<kbd>` elements with automatic platform-aware modifier rendering. On Mac, `command` renders as <InlineCode><IconCommand size="xs" /></InlineCode>; on other platforms it renders as `Ctrl`. The `<Kbd>` component renders a single styled key cap.
+The `<Hotkey>` component displays keyboard shortcuts using semantic `<kbd>` elements with automatic platform-aware modifier rendering. The `mod` token resolves to <InlineCode><IconCommand size="xs" /></InlineCode> on macOS and `Ctrl` on Windows/Linux, so a single shortcut definition works everywhere. The `<Kbd>` component renders a single styled key cap.
 
 ## Hotkey
 
 `<Hotkey>` accepts the same key string format as the `useHotkeys` hook, making it easy to display the shortcuts you've already registered.
 
+**Prefer `mod`** for the platform-primary modifier — it's the OS-agnostic shorthand for "command on Mac, ctrl elsewhere" and renders the correct glyph automatically.
+
 <Storybook.Demo>
   <Flex gap="xl" align="center">
     <Flex gap="sm" align="center">
       <Text>Save:</Text>
-      <Hotkey value="command+s" />
+      <Hotkey value="mod+s" />
     </Flex>
     <Flex gap="sm" align="center">
       <Text>Search:</Text>
-      <Hotkey value="command+k" />
+      <Hotkey value="mod+k" />
     </Flex>
     <Flex gap="sm" align="center">
       <Text>Copy:</Text>
-      <Hotkey value="command+c" />
+      <Hotkey value="mod+c" />
     </Flex>
   </Flex>
 </Storybook.Demo>
 
 ```jsx
-<Hotkey value="command+s" />
-<Hotkey value="command+k" />
-<Hotkey value="command+c" />
+<Hotkey value="mod+s" />
+<Hotkey value="mod+k" />
+<Hotkey value="mod+c" />
 ```
 
 ### Platform Mapping
@@ -54,6 +56,7 @@ Modifiers are automatically mapped per platform. No fallback arrays needed for s
 
 | Key name  | Mac                                                | Other platforms                                   |
 | --------- | -------------------------------------------------- | ------------------------------------------------- |
+| `mod`     | <InlineCode><IconCommand size="xs" /></InlineCode> | `Ctrl`                                            |
 | `command` | <InlineCode><IconCommand size="xs" /></InlineCode> | `Ctrl`                                            |
 | `ctrl`    | <InlineCode><IconControl size="xs" /></InlineCode> | `Ctrl`                                            |
 | `alt`     | <InlineCode><IconOption size="xs" /></InlineCode>  | `Alt`                                             |
@@ -61,6 +64,8 @@ Modifiers are automatically mapped per platform. No fallback arrays needed for s
 | `shift`   | <InlineCode><IconShift size="xs" /></InlineCode>   | <InlineCode><IconShift size="xs" /></InlineCode>  |
 | `enter`   | <InlineCode><IconReturn size="xs" /></InlineCode>  | <InlineCode><IconReturn size="xs" /></InlineCode> |
 | `return`  | <InlineCode><IconReturn size="xs" /></InlineCode>  | <InlineCode><IconReturn size="xs" /></InlineCode> |
+
+Use `command` or `ctrl` directly only as an escape hatch for shortcuts that intentionally bind to a specific modifier on every platform (e.g. a Mac-only dev tool, or a shortcut that must be `Ctrl` on macOS).
 
 Keys without an explicit glyph mapping (e.g. `Home`, `End`, `PageUp`) render as title-cased text.
 
@@ -70,11 +75,11 @@ Keys without an explicit glyph mapping (e.g. `Home`, `End`, `PageUp`) render as 
   <Flex gap="xl" align="center">
     <Flex gap="sm" align="center">
       <Text>Undo:</Text>
-      <Hotkey value="command+z" />
+      <Hotkey value="mod+z" />
     </Flex>
     <Flex gap="sm" align="center">
       <Text>Redo:</Text>
-      <Hotkey value="command+shift+z" />
+      <Hotkey value="mod+shift+z" />
     </Flex>
     <Flex gap="sm" align="center">
       <Text>Navigate:</Text>
@@ -84,17 +89,17 @@ Keys without an explicit glyph mapping (e.g. `Home`, `End`, `PageUp`) render as 
 </Storybook.Demo>
 
 ```jsx
-<Hotkey value="command+z" />
-<Hotkey value="command+shift+z" />
+<Hotkey value="mod+z" />
+<Hotkey value="mod+shift+z" />
 <Hotkey value="shift+right" />
 ```
 
 ### Array Form
 
-Pass an array when the actual keys (not just modifiers) differ across platforms. The first combo is used.
+Pass an array when the actual keys (not just modifiers) differ across platforms. The first combo is used. With `mod`, you rarely need this — only reach for it when the non-modifier keys themselves differ.
 
 ```jsx
-<Hotkey value={['command+backspace', 'delete']} />
+<Hotkey value={['mod+backspace', 'delete']} />
 ```
 
 ## Variants
@@ -105,18 +110,18 @@ Both `<Hotkey>` and `<Kbd>` accept a `variant` prop. The default `embossed` vari
   <Flex gap="xl" align="center">
     <Flex gap="sm" align="center">
       <Text>Embossed (default):</Text>
-      <Hotkey value="command+k" variant="embossed" />
+      <Hotkey value="mod+k" variant="embossed" />
     </Flex>
     <Flex gap="sm" align="center">
       <Text>Debossed:</Text>
-      <Hotkey value="command+k" variant="debossed" />
+      <Hotkey value="mod+k" variant="debossed" />
     </Flex>
   </Flex>
 </Storybook.Demo>
 
 ```jsx
-<Hotkey value="command+k" />
-<Hotkey value="command+k" variant="debossed" />
+<Hotkey value="mod+k" />
+<Hotkey value="mod+k" variant="debossed" />
 
 <Kbd>Esc</Kbd>
 <Kbd variant="debossed">Esc</Kbd>
@@ -158,13 +163,13 @@ import {Hotkey, useHotkeys} from '@sentry/scraps/hotkey';
 
 function MyComponent() {
   useHotkeys([
-    {match: 'command+k', callback: () => openSearch()},
-    {match: ['command+/', 'ctrl+/'], callback: () => openHelp()},
+    {match: 'mod+k', callback: () => openSearch()},
+    {match: 'mod+/', callback: () => openHelp()},
   ]);
 
   return (
     <Text>
-      Search: <Hotkey value="command+k" />
+      Search: <Hotkey value="mod+k" />
     </Text>
   );
 }

--- a/static/app/components/core/hotkey/hotkey.tsx
+++ b/static/app/components/core/hotkey/hotkey.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import {isMac as detectIsMac} from '@react-aria/utils';
 
 import {toArray} from 'sentry/utils/array/toArray';
 
@@ -28,12 +27,10 @@ interface HotkeyProps {
 }
 
 export function Hotkey({value, variant}: HotkeyProps) {
-  const isMac = detectIsMac();
-
   const keySets = toArray(value).map(v => v.trim().split('+'));
 
   // Resolve glyphs for each key set
-  const resolved = keySets.map(keys => keys.map(key => resolveKeyGlyph(key, isMac)));
+  const resolved = keySets.map(keys => keys.map(key => resolveKeyGlyph(key)));
 
   // If multiple combos provided, prefer the first one.
   // (With auto platform mapping, a single string works cross-platform,

--- a/static/app/components/core/hotkey/keyMappings.tsx
+++ b/static/app/components/core/hotkey/keyMappings.tsx
@@ -1,3 +1,4 @@
+import {isMac} from '@react-aria/utils';
 import * as Sentry from '@sentry/react';
 
 import {
@@ -30,6 +31,11 @@ const aliases: Record<string, string> = {
 
 export function canonicalize(keyName: string): string {
   const lower = keyName.toLowerCase();
+  // `mod` is the platform-aware modifier: command on macOS, control elsewhere.
+  // Prefer it over hardcoded `command`/`ctrl` pairs in match strings.
+  if (lower === 'mod') {
+    return isMac() ? 'command' : 'control';
+  }
   return aliases[lower] ?? lower;
 }
 
@@ -167,9 +173,9 @@ const universalGlyphs: Record<string, KeyGlyph> = {
  * Resolve a key name to its display glyph for the given platform.
  * Non-special keys fall through to title-cased text (e.g. `'k'` → `'K'`).
  */
-export function resolveKeyGlyph(keyName: string, isMac: boolean): KeyGlyph {
+export function resolveKeyGlyph(keyName: string): KeyGlyph {
   const key = canonicalize(keyName);
-  const platformGlyphs = isMac ? macGlyphs : otherGlyphs;
+  const platformGlyphs = isMac() ? macGlyphs : otherGlyphs;
   const glyph = platformGlyphs[key] ?? universalGlyphs[key];
 
   if (glyph) {

--- a/static/app/components/core/hotkey/useHotkeys.spec.tsx
+++ b/static/app/components/core/hotkey/useHotkeys.spec.tsx
@@ -2,6 +2,13 @@ import {renderHook} from 'sentry-test/reactTestingLibrary';
 
 import {useHotkeys} from '@sentry/scraps/hotkey';
 
+jest.mock('@react-aria/utils', () => ({
+  ...jest.requireActual('@react-aria/utils'),
+  isMac: jest.fn(() => false),
+}));
+
+const {isMac} = jest.requireMock<{isMac: jest.Mock}>('@react-aria/utils');
+
 function keyToKey(k: string): string {
   return k;
 }
@@ -331,5 +338,53 @@ describe('useHotkeys', () => {
     });
 
     expect(callback).toHaveBeenCalled();
+  describe('mod modifier', () => {
+    afterEach(() => {
+      isMac.mockReturnValue(false);
+    });
+
+    it('matches command on macOS', () => {
+      isMac.mockReturnValue(true);
+      const callback = jest.fn();
+
+      renderHook(p => useHotkeys(p), {
+        initialProps: [{match: 'mod+k', callback}],
+      });
+
+      events.keydown!(makeKeyEventFixture('k', {metaKey: true}));
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      events.keydown!(makeKeyEventFixture('k', {ctrlKey: true}));
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('matches control on non-mac platforms', () => {
+      isMac.mockReturnValue(false);
+      const callback = jest.fn();
+
+      renderHook(p => useHotkeys(p), {
+        initialProps: [{match: 'mod+k', callback}],
+      });
+
+      events.keydown!(makeKeyEventFixture('k', {ctrlKey: true}));
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      events.keydown!(makeKeyEventFixture('k', {metaKey: true}));
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects extra non-mod modifiers', () => {
+      // mod+k on Mac canonicalizes to command+k; pressing command+ctrl+k
+      // should NOT fire because ctrl is an unused modifier.
+      isMac.mockReturnValue(true);
+      const callback = jest.fn();
+
+      renderHook(p => useHotkeys(p), {
+        initialProps: [{match: 'mod+k', callback}],
+      });
+
+      events.keydown!(makeKeyEventFixture('k', {metaKey: true, ctrlKey: true}));
+      expect(callback).not.toHaveBeenCalled();
+    });
   });
 });

--- a/static/app/components/core/hotkey/useHotkeys.spec.tsx
+++ b/static/app/components/core/hotkey/useHotkeys.spec.tsx
@@ -9,10 +9,6 @@ jest.mock('@react-aria/utils', () => ({
 
 const {isMac} = jest.requireMock<{isMac: jest.Mock}>('@react-aria/utils');
 
-function keyToKey(k: string): string {
-  return k;
-}
-
 function keyToCode(k: string): string {
   if (k === '/') {
     return 'Slash';
@@ -29,10 +25,10 @@ function keyToCode(k: string): string {
 describe('useHotkeys', () => {
   let events: Record<string, (evt: any) => void> = {};
 
-  function makeKeyEventFixture(keyName: string, options: any = {}) {
+  function makeKeyEventFixture(key: string, options: any = {}) {
     return {
-      key: keyToKey(keyName),
-      code: keyToCode(keyName),
+      key,
+      code: keyToCode(key),
       preventDefault: jest.fn(),
       ...options,
     };
@@ -338,6 +334,8 @@ describe('useHotkeys', () => {
     });
 
     expect(callback).toHaveBeenCalled();
+  });
+
   describe('mod modifier', () => {
     afterEach(() => {
       isMac.mockReturnValue(false);

--- a/static/app/components/core/hotkey/useHotkeys.tsx
+++ b/static/app/components/core/hotkey/useHotkeys.tsx
@@ -62,7 +62,9 @@ export function useHotkeys(hotkeys: Hotkey[]): void {
 
         for (const keyset of keysets) {
           const keys = keyset.split('+').map(k => canonicalize(k));
-          const unusedModifiers = MODIFIER_KEYS.filter(modifier => !keys.includes(modifier));
+          const unusedModifiers = MODIFIER_KEYS.filter(
+            modifier => !keys.includes(modifier)
+          );
 
           const allKeysPressed =
             keys.every(key => matchesKey(key, evt)) &&

--- a/static/app/components/core/hotkey/useHotkeys.tsx
+++ b/static/app/components/core/hotkey/useHotkeys.tsx
@@ -61,10 +61,8 @@ export function useHotkeys(hotkeys: Hotkey[]): void {
         const keysets = toArray(hotkey.match).map(keys => keys.toLowerCase());
 
         for (const keyset of keysets) {
-          const keys = keyset.split('+').map(canonicalize);
-          const unusedModifiers = MODIFIER_KEYS.filter(
-            modifier => !keys.includes(modifier)
-          );
+          const keys = keyset.split('+').map(k => canonicalize(k));
+          const unusedModifiers = MODIFIER_KEYS.filter(modifier => !keys.includes(modifier));
 
           const allKeysPressed =
             keys.every(key => matchesKey(key, evt)) &&

--- a/static/app/components/core/inspector.tsx
+++ b/static/app/components/core/inspector.tsx
@@ -54,7 +54,7 @@ export function SentryComponentInspector() {
 
   useHotkeys([
     {
-      match: 'command+i',
+      match: 'mod+i',
       callback: () => {
         if (NODE_ENV !== 'development') {
           return;

--- a/static/app/components/themeAndStyleProvider.tsx
+++ b/static/app/components/themeAndStyleProvider.tsx
@@ -48,7 +48,7 @@ export function ThemeAndStyleProvider({children}: Props) {
   const themeToggleHotkey = useMemo(
     () => [
       {
-        match: ['command+shift+1', 'ctrl+shift+1'],
+        match: 'mod+shift+1',
         includeInputs: true,
         callback: () => {
           removeBodyTheme();

--- a/static/app/views/issueDetails/streamline/hooks/useCopyIssueDetails.spec.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useCopyIssueDetails.spec.tsx
@@ -406,12 +406,7 @@ describe('useCopyIssueDetails', () => {
 
       expect(useHotkeysMock).toHaveBeenCalledWith([
         {
-          match: 'command+alt+c',
-          callback: expect.any(Function),
-          skipPreventDefault: expect.any(Boolean),
-        },
-        {
-          match: 'ctrl+alt+c',
+          match: 'mod+alt+c',
           callback: expect.any(Function),
           skipPreventDefault: expect.any(Boolean),
         },
@@ -428,7 +423,7 @@ describe('useCopyIssueDetails', () => {
 
       renderHook(() => useCopyIssueDetails(group, undefined));
 
-      await userEvent.keyboard('{Meta>}{Alt>}c{/Alt}{/Meta}');
+      await userEvent.keyboard('{Control>}{Alt>}c{/Alt}{/Control}');
 
       expect(capturedText).toContain(`# ${group.title}`);
       expect(capturedText).toContain(`**Issue ID:** ${group.id}`);
@@ -449,7 +444,7 @@ describe('useCopyIssueDetails', () => {
 
       renderHook(() => useCopyIssueDetails(group, event));
 
-      await userEvent.keyboard('{Meta>}{Alt>}c{/Alt}{/Meta}');
+      await userEvent.keyboard('{Control>}{Alt>}c{/Alt}{/Control}');
 
       expect(capturedText).toContain(`# ${group.title}`);
       expect(capturedText).toContain(`**Issue ID:** ${group.id}`);

--- a/static/app/views/issueDetails/streamline/hooks/useCopyIssueDetails.tsx
+++ b/static/app/views/issueDetails/streamline/hooks/useCopyIssueDetails.tsx
@@ -224,12 +224,7 @@ export const useCopyIssueDetails = (group: Group, event?: Event) => {
 
   useHotkeys([
     {
-      match: 'command+alt+c',
-      callback: handleCopyIssueDetailsAsMarkdown,
-      skipPreventDefault: NODE_ENV === 'development',
-    },
-    {
-      match: 'ctrl+alt+c',
+      match: 'mod+alt+c',
       callback: handleCopyIssueDetailsAsMarkdown,
       skipPreventDefault: NODE_ENV === 'development',
     },

--- a/static/app/views/navigation/index.tsx
+++ b/static/app/views/navigation/index.tsx
@@ -68,7 +68,7 @@ function UserAndOrganizationNavigation() {
       ? []
       : [
           {
-            match: ['command+b', 'ctrl+b'],
+            match: 'mod+b',
             callback: () => setView(view === 'expanded' ? 'collapsed' : 'expanded'),
           },
         ]

--- a/static/app/views/navigation/navigation.tsx
+++ b/static/app/views/navigation/navigation.tsx
@@ -322,7 +322,7 @@ export function PrimaryNavigationFooterItems() {
             organization.features.includes('cmd-k-supercharged') ? (
               <Flex gap="xs" align="center">
                 {t('Open command palette')}
-                <Hotkey value="command+k" variant="debossed" />
+                <Hotkey value="mod+k" variant="debossed" />
               </Flex>
             ) : (
               t('Search support, docs and more')

--- a/static/app/views/seerExplorer/components/askSeerButton.tsx
+++ b/static/app/views/seerExplorer/components/askSeerButton.tsx
@@ -50,7 +50,7 @@ export function AskSeerButton() {
         >
           <Container>{t('Ask Seer')}</Container>
           <Container display={{xs: 'none', md: 'inline-block'}}>
-            <Hotkey value="command+/" variant="debossed" />
+            <Hotkey value="mod+/" variant="debossed" />
           </Container>
         </Flex>
         <ThinkingIndicator state={state} />

--- a/static/app/views/seerExplorer/components/panel/explorerFAB.tsx
+++ b/static/app/views/seerExplorer/components/panel/explorerFAB.tsx
@@ -66,7 +66,7 @@ function SeerFloatingActionButton(props: SeerFloatingActionButtonProps) {
           >
             <Flex align="center" gap="sm">
               <Text size="sm">{t('Ask Seer')}</Text>
-              <Hotkey variant="debossed" value="command+/" />
+              <Hotkey variant="debossed" value="mod+/" />
             </Flex>
           </SeerButton>
         </Container>

--- a/static/app/views/seerExplorer/useSeerExplorerContext.tsx
+++ b/static/app/views/seerExplorer/useSeerExplorerContext.tsx
@@ -125,16 +125,11 @@ export function SeerExplorerContextProvider({children}: {children: ReactNode}) {
       : [
           {
             match: [
-              'command+/', // QWERTY (US, UK, most CJK, RTL scripts)
-              'ctrl+/',
-              'command+.', // macOS-friendly alternative
-              'ctrl+.',
-              'command+shift+7', // QWERTZ (German, Austrian, Swiss): / === Shift+7
-              'ctrl+shift+7',
-              'command+shift+.', // AZERTY (French, Belgian): / === Shift+.
-              'ctrl+shift+.',
-              'command+shift+-', // QWERTY Latin variants (Spanish, Italian, Portuguese): / === Shift+-
-              'ctrl+shift+-',
+              'mod+/', // QWERTY (US, UK, most CJK, RTL scripts)
+              'mod+.', // macOS-friendly alternative
+              'mod+shift+7', // QWERTZ (German, Austrian, Swiss): / === Shift+7
+              'mod+shift+.', // AZERTY (French, Belgian): / === Shift+.
+              'mod+shift+-', // QWERTY Latin variants (Spanish, Italian, Portuguese): / === Shift+-
             ],
             callback: () => {
               toggleSeerExplorerDrawer();


### PR DESCRIPTION
updates the `useHotkeys` and `<Hotkey />` modules to support `mod` as a construct that means `Command`-on-macOS, `Ctrl` elsewhere. 

this makes supporting platform-agnostic keybindings automatic and eliminates a class of bug where windows users would be unable to use shortcuts