### PR TITLE
feat(dashboards): Display avatarUrl in revision list item

### DIFF
--- a/static/app/views/dashboards/hooks/useDashboardRevisions.tsx
+++ b/static/app/views/dashboards/hooks/useDashboardRevisions.tsx
@@ -5,7 +5,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import type {DashboardDetails} from 'sentry/views/dashboards/types';
 
 export type DashboardRevision = {
-  createdBy: {email: string; id: string; name: string} | null;
+  createdBy: {email: string; id: string; name: string; avatarUrl?: string | null} | null;
   dateCreated: string;
   id: string;
   source: 'edit' | 'edit-with-agent' | 'pre-restore';

--- a/static/app/views/dashboards/revisionListItem.spec.tsx
+++ b/static/app/views/dashboards/revisionListItem.spec.tsx
@@ -126,6 +126,21 @@ describe('RevisionListItem', () => {
     expect(await screen.findByText('alice@example.com')).toBeInTheDocument();
   });
 
+  it('renders the avatar image when avatarUrl is provided', async () => {
+    MockApiClient.addMockResponse({url: SNAPSHOT_URL, body: makeSnapshot()});
+    MockApiClient.addMockResponse({url: BASE_SNAPSHOT_URL, body: makeSnapshot()});
+
+    const avatarUrl = 'https://example.com/avatar.jpg';
+    renderItem({
+      createdBy: {id: '42', name: 'Alice', email: 'alice@example.com', avatarUrl},
+    });
+
+    expect(await screen.findByRole('img', {name: 'Alice'})).toHaveAttribute(
+      'src',
+      expect.stringContaining(avatarUrl)
+    );
+  });
+
   it('shows "Unknown" when createdBy is null', async () => {
     MockApiClient.addMockResponse({url: SNAPSHOT_URL, body: makeSnapshot()});
     MockApiClient.addMockResponse({url: BASE_SNAPSHOT_URL, body: makeSnapshot()});

--- a/static/app/views/dashboards/revisionListItem.stories.tsx
+++ b/static/app/views/dashboards/revisionListItem.stories.tsx
@@ -9,6 +9,12 @@ import {DisplayType} from './types';
 
 const ALICE = {id: '1', name: 'Alice', email: 'alice@example.com'};
 const BOB = {id: '2', name: 'Bob', email: 'bob@example.com'};
+const CAROL = {
+  id: '3',
+  name: 'Carol',
+  email: 'carol@example.com',
+  avatarUrl: 'https://gravatar.com/avatar/00000000000000000000000000000000?d=mp&s=120',
+};
 const DATE = '2024-06-01T10:00:00Z';
 const DATE_OLDER = '2024-05-28T09:00:00Z';
 const DASHBOARD_ID = 'demo';
@@ -120,6 +126,28 @@ export default Storybook.story('RevisionListItem', story => {
           dateCreated={null}
           dashboardId={DASHBOARD_ID}
           baseRevisionId="prev"
+          snapshotOverride={snapshot}
+          baseSnapshotOverride={prevSnapshot}
+        />
+      </ItemContainer>
+    );
+  });
+
+  story('With avatar', () => {
+    const [selected, setSelected] = useState(false);
+    const snapshot = base();
+    const prevSnapshot = base({title: 'Old Title'});
+    return (
+      <ItemContainer>
+        <RevisionListItem
+          isSelected={selected}
+          onSelect={() => setSelected(s => !s)}
+          revisionSource="edit"
+          createdBy={CAROL}
+          dateCreated={DATE}
+          dashboardId={DASHBOARD_ID}
+          baseRevisionId="prev"
+          revisionId="rev-avatar"
           snapshotOverride={snapshot}
           baseSnapshotOverride={prevSnapshot}
         />

--- a/static/app/views/dashboards/revisionListItem.tsx
+++ b/static/app/views/dashboards/revisionListItem.tsx
@@ -23,7 +23,7 @@ import type {DashboardDetails} from './types';
 
 interface RevisionListItemProps {
   baseRevisionId: string | null;
-  createdBy: {email: string; id: string; name: string} | null;
+  createdBy: {email: string; id: string; name: string; avatarUrl?: string | null} | null;
   dashboardId: string;
   dateCreated: string | null;
   isSelected: boolean;
@@ -97,6 +97,9 @@ export function RevisionListItem({
         email: createdBy.email,
         ip_address: '',
         username: createdBy.email,
+        avatar: createdBy.avatarUrl
+          ? {avatarType: 'upload', avatarUrl: createdBy.avatarUrl, avatarUuid: null}
+          : undefined,
       } as User)
     : null;
 


### PR DESCRIPTION
Wire the `avatarUrl` now returned by the revisions API into `UserAvatar` so the revision list shows the author's avatar instead of always falling back to initials.

Depends on #114186.

<img width="700" height="149" alt="Screenshot 2026-04-28 at 1 19 11 PM" src="https://github.com/user-attachments/assets/5812ded5-f530-49f6-bde2-b19124255dec" />

Refs #DAIN-1579