### PR TITLE
fix(detectors): propagate environment to metric issue occurrences

### DIFF
--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -255,7 +255,9 @@ class MetricIssueDetectorHandler(StatefulDetectorHandler[MetricUpdate, MetricRes
                 assignee=assignee,
                 priority=priority,
             ),
-            {},
+            {
+                "environment": (snuba_query.environment.name if snuba_query.environment else None),
+            },
         )
 
     def extract_dedupe_value(self, data_packet: DataPacket[MetricUpdate]) -> int:

--- a/src/sentry/workflow_engine/handlers/detector/stateful.py
+++ b/src/sentry/workflow_engine/handlers/detector/stateful.py
@@ -578,7 +578,7 @@ class StatefulDetectorHandler(
             )
 
             # Set the event data with the necessary fields
-            event_data["environment"] = self.detector.config.get("environment")
+            event_data.setdefault("environment", self.detector.config.get("environment"))
             event_data["timestamp"] = detector_result.detection_time
             event_data["project_id"] = detector_result.project_id
             event_data["event_id"] = detector_result.event_id

--- a/tests/sentry/incidents/test_metric_issue_detector_handler.py
+++ b/tests/sentry/incidents/test_metric_issue_detector_handler.py
@@ -3,12 +3,14 @@ from sentry.incidents.grouptype import (
     SessionsAggregate,
     get_alert_type_from_aggregate_dataset,
 )
+from sentry.incidents.utils.types import DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.snuba.dataset import Dataset
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import freeze_time
 from sentry.workflow_engine.models import DataCondition
 from sentry.workflow_engine.models.data_condition import Condition
+from sentry.workflow_engine.processors.data_packet import process_data_packet
 from tests.sentry.incidents.utils.test_metric_issue_base import BaseMetricIssueTest
 
 
@@ -129,6 +131,22 @@ class TestEvaluateMetricDetector(BaseMetricIssueTest):
         DataCondition.objects.all().delete()
         result = self.process_packet_and_return_result(data_packet)
         assert result is None
+
+    def test_event_data_environment(self) -> None:
+        value = self.critical_detector_trigger.comparison + 1
+        data_packet = self.create_subscription_packet(value)
+        results = process_data_packet(data_packet, DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION)
+        evaluation_result = results[0][1][self.detector_group_key]
+        assert evaluation_result.event_data["environment"] == self.environment.name
+
+    def test_event_data_environment_unset(self) -> None:
+        self.snuba_query.environment = None
+        self.snuba_query.save()
+        value = self.critical_detector_trigger.comparison + 1
+        data_packet = self.create_subscription_packet(value)
+        results = process_data_packet(data_packet, DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION)
+        evaluation_result = results[0][1][self.detector_group_key]
+        assert evaluation_result.event_data["environment"] is None
 
     def test_flipped_detector_trigger(self) -> None:
         self.warning_detector_trigger.delete()

--- a/tests/sentry/incidents/test_metric_issue_detector_handler.py
+++ b/tests/sentry/incidents/test_metric_issue_detector_handler.py
@@ -137,6 +137,7 @@ class TestEvaluateMetricDetector(BaseMetricIssueTest):
         data_packet = self.create_subscription_packet(value)
         results = process_data_packet(data_packet, DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION)
         evaluation_result = results[0][1][self.detector_group_key]
+        assert evaluation_result.event_data is not None
         assert evaluation_result.event_data["environment"] == self.environment.name
 
     def test_event_data_environment_unset(self) -> None:
@@ -146,6 +147,7 @@ class TestEvaluateMetricDetector(BaseMetricIssueTest):
         data_packet = self.create_subscription_packet(value)
         results = process_data_packet(data_packet, DATA_SOURCE_SNUBA_QUERY_SUBSCRIPTION)
         evaluation_result = results[0][1][self.detector_group_key]
+        assert evaluation_result.event_data is not None
         assert evaluation_result.event_data["environment"] is None
 
     def test_flipped_detector_trigger(self) -> None:

--- a/tests/sentry/workflow_engine/handlers/detector/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_base.py
@@ -282,7 +282,7 @@ class BaseDetectorHandlerTest(BaseGroupTypeTest):
             event_data = (
                 detector_occurrence.event_data.copy() if detector_occurrence.event_data else {}
             )
-        event_data["environment"] = detector.config.get("environment")
+        event_data.setdefault("environment", detector.config.get("environment"))
         event_data["timestamp"] = issue_occurrence.detection_time
         event_data["project_id"] = detector.project_id
         event_data["event_id"] = occurrence_id


### PR DESCRIPTION
Ref ISWF-2556

Metric detectors store the environment in the snuba query, rather than the detector config. Because of this, they were producing issue occurrences with no `environment` set. The impact is that users filtering by environment would see no issues, even if the env matches the detector's environment.