### PR TITLE
fix(cmdk): keep virtualized keyboard focus stable

### DIFF
--- a/static/app/components/commandPalette/ui/commandPalette.modal.spec.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.modal.spec.tsx
@@ -14,6 +14,7 @@ jest.mock('@tanstack/react-virtual', () => ({
       getTotalSize: () => count * 48,
       measureElement: jest.fn(),
       measure: jest.fn(),
+      scrollToIndex: jest.fn(),
     };
   },
 }));

--- a/static/app/components/commandPalette/ui/commandPalette.spec.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.spec.tsx
@@ -18,6 +18,7 @@ jest.mock('@tanstack/react-virtual', () => ({
       getTotalSize: () => count * 48,
       measureElement: jest.fn(),
       measure: jest.fn(),
+      scrollToIndex: jest.fn(),
     };
   },
 }));
@@ -132,6 +133,38 @@ describe('CommandPalette', () => {
     await userEvent.keyboard('{ArrowDown}{Enter}');
 
     await waitFor(() => expect(router.location.pathname).toBe('/other/'));
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('ArrowUp from the first item wraps to the last selectable item', async () => {
+    const closeSpy = jest.spyOn(modalActions, 'closeModal');
+    const {router} = render(
+      <GlobalActionsComponent>
+        <AllActions />
+      </GlobalActionsComponent>
+    );
+
+    await screen.findByRole('textbox', {name: 'Search commands'});
+    await userEvent.keyboard('{ArrowUp}{Enter}');
+
+    expect(closeSpy).not.toHaveBeenCalled();
+    expect(
+      await screen.findByRole('option', {name: 'Child Action'})
+    ).toBeInTheDocument();
+  });
+
+  it('ArrowDown from the last selectable item wraps to the first item', async () => {
+    const closeSpy = jest.spyOn(modalActions, 'closeModal');
+    const {router} = render(
+      <GlobalActionsComponent>
+        <AllActions />
+      </GlobalActionsComponent>
+    );
+
+    await screen.findByRole('textbox', {name: 'Search commands'});
+    await userEvent.keyboard('{ArrowUp}{ArrowDown}{Enter}');
+
+    await waitFor(() => expect(router.location.pathname).toBe('/target/'));
     expect(closeSpy).toHaveBeenCalledTimes(1);
   });
 

--- a/static/app/components/commandPalette/ui/commandPalette.spec.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.spec.tsx
@@ -138,7 +138,7 @@ describe('CommandPalette', () => {
 
   it('ArrowUp from the first item wraps to the last selectable item', async () => {
     const closeSpy = jest.spyOn(modalActions, 'closeModal');
-    const {router} = render(
+    render(
       <GlobalActionsComponent>
         <AllActions />
       </GlobalActionsComponent>

--- a/static/app/components/commandPalette/ui/commandPalette.spec.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.spec.tsx
@@ -148,9 +148,7 @@ describe('CommandPalette', () => {
     await userEvent.keyboard('{ArrowUp}{Enter}');
 
     expect(closeSpy).not.toHaveBeenCalled();
-    expect(
-      await screen.findByRole('option', {name: 'Child Action'})
-    ).toBeInTheDocument();
+    expect(await screen.findByRole('option', {name: 'Child Action'})).toBeInTheDocument();
   });
 
   it('ArrowDown from the last selectable item wraps to the first item', async () => {

--- a/static/app/components/commandPalette/ui/commandPalette.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.tsx
@@ -300,6 +300,17 @@ export function CommandPalette({
     return undefined;
   }, [treeState.collection, sectionKeys]);
 
+  const lastFocusableKey = useMemo(() => {
+    const items = [...treeState.collection];
+    for (let index = items.length - 1; index >= 0; index--) {
+      const item = items[index];
+      if (item && !sectionKeys.has(String(item.key))) {
+        return item;
+      }
+    }
+    return undefined;
+  }, [treeState.collection, sectionKeys]);
+
   useLayoutEffect(() => {
     if (treeState.selectionManager.focusedKey !== null) {
       return;
@@ -310,14 +321,16 @@ export function CommandPalette({
     }
   }, [treeState.collection, treeState.selectionManager, firstFocusableKey]);
 
+  const resultsListRef = useRef<HTMLDivElement>(null);
+
   const delegate = useMemo(
     () =>
       new ListKeyboardDelegate({
         collection: treeState.collection,
         disabledKeys: treeState.selectionManager.disabledKeys,
-        ref: state.input,
+        ref: resultsListRef,
       }),
-    [treeState.collection, treeState.selectionManager.disabledKeys, state.input]
+    [treeState.collection, treeState.selectionManager.disabledKeys]
   );
 
   const {collectionProps} = useSelectableCollection({
@@ -325,12 +338,18 @@ export function CommandPalette({
     keyboardDelegate: delegate,
     shouldFocusWrap: true,
     ref: state.input,
+    isVirtualized: true,
     // Type-ahead is designed for navigating list items by typing — it intercepts
     // Space (via onKeyDownCapture) when there is already a search term, which
     // prevents the space from being inserted into the text input. Disable it
     // here because filtering is handled by the input's own onChange instead.
     disallowTypeAhead: true,
   });
+  const collectionKeyDown = collectionProps.onKeyDown;
+  const mergedCollectionProps = {
+    ...collectionProps,
+    onKeyDown: undefined,
+  };
 
   const onActionSelection = useCallback(
     (
@@ -423,7 +442,6 @@ export function CommandPalette({
     };
   }, [dispatch]);
 
-  const resultsListRef = useRef<HTMLDivElement>(null);
   const modifierKeysRef = useRef({shiftKey: false});
 
   useEffect(() => {
@@ -504,7 +522,7 @@ export function CommandPalette({
                       ? t('Search inside %s...', state.action.value.label)
                       : t('Search for commands...'))
                   }
-                  {...mergeProps(collectionProps, {
+                  {...mergeProps(mergedCollectionProps, {
                     onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
                       dispatch({type: 'set query', query: e.target.value});
                       treeState.selectionManager.setFocusedKey(null);
@@ -513,6 +531,22 @@ export function CommandPalette({
                       }
                     },
                     onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => {
+                      if (
+                        treeState.selectionManager.focusedKey === null &&
+                        (e.key === 'ArrowDown' || e.key === 'ArrowUp')
+                      ) {
+                        const anchorItem =
+                          e.key === 'ArrowDown' ? firstFocusableKey : lastFocusableKey;
+                        if (anchorItem) {
+                          treeState.selectionManager.setFocused(true);
+                          treeState.selectionManager.setFocusedKey(anchorItem.key);
+                          e.preventDefault();
+                          return;
+                        }
+                      }
+
+                      collectionKeyDown?.(e);
+
                       if (e.key === 'Tab' && !e.shiftKey && seerExplorerEnabled) {
                         e.preventDefault();
                         dispatch({type: 'trigger action'});

--- a/static/app/components/commandPalette/ui/commandPalette.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.tsx
@@ -1224,7 +1224,15 @@ export const modalCss = (theme: Theme) => {
       border-radius: ${theme.radius.xl};
       border-bottom-right-radius: ${theme.radius.md};
       border-bottom-left-radius: ${theme.radius.md};
+      transform: translateZ(0);
+      backface-visibility: hidden;
       will-change: transform;
+
+      * {
+        -webkit-font-smoothing: auto;
+        -moz-osx-font-smoothing: auto;
+        text-rendering: optimizeLegibility;
+      }
     }
   `;
 };

--- a/static/app/components/commandPalette/ui/commandPalette.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.tsx
@@ -350,6 +350,74 @@ export function CommandPalette({
     ...collectionProps,
     onKeyDown: undefined,
   };
+  const inputCollectionProps = mergeProps(mergedCollectionProps, {
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
+      dispatch({type: 'set query', query: e.target.value});
+      treeState.selectionManager.setFocusedKey(null);
+      if (resultsListRef.current) {
+        resultsListRef.current.scrollTop = 0;
+      }
+    },
+    onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (
+        treeState.selectionManager.focusedKey === null &&
+        (e.key === 'ArrowDown' || e.key === 'ArrowUp')
+      ) {
+        const anchorItem = e.key === 'ArrowDown' ? firstFocusableKey : lastFocusableKey;
+        if (anchorItem) {
+          treeState.selectionManager.setFocused(true);
+          treeState.selectionManager.setFocusedKey(anchorItem.key);
+          e.preventDefault();
+          return;
+        }
+      }
+
+      collectionKeyDown?.(e);
+
+      if (e.key === 'Tab' && !e.shiftKey && seerExplorerEnabled) {
+        e.preventDefault();
+        dispatch({type: 'trigger action'});
+        closeModal?.();
+        openSeerExplorer({
+          initialQuery: state.query.trim() || undefined,
+        });
+        return;
+      }
+
+      if (e.key === 'Backspace' && state.query.length === 0) {
+        if (state.action) {
+          animatePop();
+          dispatch({type: 'pop action'});
+          e.preventDefault();
+          return;
+        }
+      }
+
+      if (e.key === 'Escape') {
+        // If the user has typed something into the input and pressed escape,
+        // then clear the input. This falls back nicely through actions and allows
+        // users clear, walk back and eventually close the input.
+        if (state.query.length > 0) {
+          dispatch({type: 'set query', query: ''});
+          e.preventDefault();
+          return;
+        }
+        if (state.action) {
+          animatePop();
+          dispatch({type: 'pop action'});
+          e.preventDefault();
+          e.stopPropagation();
+          return;
+        }
+      }
+
+      if (e.key === 'Enter') {
+        onActionSelection(treeState.selectionManager.focusedKey, {
+          modifierKeys: {shiftKey: e.shiftKey},
+        });
+      }
+    },
+  }) as React.ComponentProps<typeof StyledInputGroupInput>;
 
   const onActionSelection = useCallback(
     (
@@ -522,76 +590,7 @@ export function CommandPalette({
                       ? t('Search inside %s...', state.action.value.label)
                       : t('Search for commands...'))
                   }
-                  {...mergeProps(mergedCollectionProps, {
-                    onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
-                      dispatch({type: 'set query', query: e.target.value});
-                      treeState.selectionManager.setFocusedKey(null);
-                      if (resultsListRef.current) {
-                        resultsListRef.current.scrollTop = 0;
-                      }
-                    },
-                    onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => {
-                      if (
-                        treeState.selectionManager.focusedKey === null &&
-                        (e.key === 'ArrowDown' || e.key === 'ArrowUp')
-                      ) {
-                        const anchorItem =
-                          e.key === 'ArrowDown' ? firstFocusableKey : lastFocusableKey;
-                        if (anchorItem) {
-                          treeState.selectionManager.setFocused(true);
-                          treeState.selectionManager.setFocusedKey(anchorItem.key);
-                          e.preventDefault();
-                          return;
-                        }
-                      }
-
-                      collectionKeyDown?.(e);
-
-                      if (e.key === 'Tab' && !e.shiftKey && seerExplorerEnabled) {
-                        e.preventDefault();
-                        dispatch({type: 'trigger action'});
-                        closeModal?.();
-                        openSeerExplorer({
-                          initialQuery: state.query.trim() || undefined,
-                        });
-                        return;
-                      }
-
-                      if (e.key === 'Backspace' && state.query.length === 0) {
-                        if (state.action) {
-                          animatePop();
-                          dispatch({type: 'pop action'});
-                          e.preventDefault();
-                          return;
-                        }
-                      }
-
-                      if (e.key === 'Escape') {
-                        // If the user has typed something into the input and pressed escape,
-                        // then clear the input. This falls back nicely through actions and allows
-                        // users clear, walk back and eventually close the input.
-                        if (state.query.length > 0) {
-                          dispatch({type: 'set query', query: ''});
-                          e.preventDefault();
-                          return;
-                        }
-                        if (state.action) {
-                          animatePop();
-                          dispatch({type: 'pop action'});
-                          e.preventDefault();
-                          e.stopPropagation();
-                          return;
-                        }
-                      }
-
-                      if (e.key === 'Enter') {
-                        onActionSelection(treeState.selectionManager.focusedKey, {
-                          modifierKeys: {shiftKey: e.shiftKey},
-                        });
-                        return;
-                      }
-                    },
-                  })}
+                  {...inputCollectionProps}
                 />
                 <InputGroup.TrailingItems>
                   {seerExplorerEnabled ? (

--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.spec.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.spec.tsx
@@ -14,6 +14,7 @@ jest.mock('@tanstack/react-virtual', () => ({
       getTotalSize: () => count * 48,
       measureElement: jest.fn(),
       measure: jest.fn(),
+      scrollToIndex: jest.fn(),
     };
   },
 }));

--- a/static/app/components/core/compactSelect/listBox/index.tsx
+++ b/static/app/components/core/compactSelect/listBox/index.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useMemo, useRef, useState} from 'react';
+import {Fragment, useEffect, useMemo, useRef, useState} from 'react';
 import type {AriaListBoxOptions} from '@react-aria/listbox';
 import {useListBox} from '@react-aria/listbox';
 import {mergeProps, mergeRefs} from '@react-aria/utils';
@@ -193,6 +193,24 @@ export function ListBox<T extends ObjectLike>({
 
   const virtualizer = useVirtualizedItems({listItems, virtualized, size});
 
+  useEffect(() => {
+    if (!virtualized || listState.selectionManager.focusedKey === null) {
+      return;
+    }
+
+    const focusedIndex = listItems.findIndex(
+      item => item.key === listState.selectionManager.focusedKey
+    );
+    if (focusedIndex !== -1) {
+      virtualizer.scrollToIndex(focusedIndex);
+    }
+  }, [
+    virtualized,
+    listItems,
+    listState.selectionManager.focusedKey,
+    virtualizer,
+  ]);
+
   const refs = useMemo(() => {
     const overflowTracker = (scrollContainer: HTMLDivElement | null) => {
       if (hasEverOverflowed || listItems.length === 0 || !scrollContainer) {
@@ -299,7 +317,7 @@ function useVirtualizedItems<T extends ObjectLike>({
     getScrollElement: () => scrollElementRef?.current,
     estimateSize: index => {
       const item = listItems[index];
-      if (item?.value && 'details' in item.value) {
+      if (item?.props?.details) {
         return heightEstimation.large;
       }
       return heightEstimation.regular;
@@ -311,6 +329,9 @@ function useVirtualizedItems<T extends ObjectLike>({
     const virtualizedItems = virtualizer.getVirtualItems();
     return {
       items: virtualizedItems,
+      scrollToIndex: (index: number) => {
+        virtualizer.scrollToIndex(index, {align: 'auto'});
+      },
       scrollElementRef,
       itemProps: (index: number) => ({
         ref: virtualizer.measureElement,
@@ -336,6 +357,7 @@ function useVirtualizedItems<T extends ObjectLike>({
 
   return {
     items: listItems.map((_, index) => ({index, start: 0})),
+    scrollToIndex: () => {},
     scrollElementRef: undefined,
     itemProps: () => undefined,
     wrapperProps: {

--- a/static/app/components/core/compactSelect/listBox/index.tsx
+++ b/static/app/components/core/compactSelect/listBox/index.tsx
@@ -204,12 +204,7 @@ export function ListBox<T extends ObjectLike>({
     if (focusedIndex !== -1) {
       virtualizer.scrollToIndex(focusedIndex);
     }
-  }, [
-    virtualized,
-    listItems,
-    listState.selectionManager.focusedKey,
-    virtualizer,
-  ]);
+  }, [virtualized, listItems, listState.selectionManager.focusedKey, virtualizer]);
 
   const refs = useMemo(() => {
     const overflowTracker = (scrollContainer: HTMLDivElement | null) => {


### PR DESCRIPTION
Keep the command palette keyboard focus stable when navigating a virtualized results list.

This updates the shared compact listbox virtualization path to scroll the focused item into view so focused options stay mounted, fixes the row height estimator to use option props, and aligns the command palette input-side keyboard navigation with the virtualized listbox ref.

It also adds a small visual follow-up to reduce blur on the palette during the scale animation.

Tests run:
- `pnpm exec jest --watchman=false --runInBand static/app/components/commandPalette/ui/commandPalette.spec.tsx`
- `pnpm exec jest --watchman=false --runInBand static/app/components/core/compactSelect/listBox/index.spec.tsx`

Fix DE-1063