### PR TITLE
feat(organizations): Add find_organization_id_by_option_value RPC

### DIFF
--- a/src/sentry/organizations/services/organization/impl.py
+++ b/src/sentry/organizations/services/organization/impl.py
@@ -670,9 +670,6 @@ class DatabaseBackedOrganizationService(OrganizationService):
     def find_organization_id_by_option_value(
         self, *, cell_name: str, key: str, value: str
     ) -> int | None:
-        # cell_name is consumed by the @cell_rpc_method resolver; the impl
-        # is already running inside the resolved cell.
-        del cell_name
         return (
             OrganizationOption.objects.filter(key=key, value=value)
             .order_by("organization_id")

--- a/src/sentry/organizations/services/organization/impl.py
+++ b/src/sentry/organizations/services/organization/impl.py
@@ -28,6 +28,7 @@ from sentry.models.groupsearchviewstarred import GroupSearchViewStarred
 from sentry.models.groupseen import GroupSeen
 from sentry.models.groupshare import GroupShare
 from sentry.models.groupsubscription import GroupSubscription
+from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.models.organizationaccessrequest import OrganizationAccessRequest
 from sentry.models.organizationmapping import OrganizationMapping
@@ -665,6 +666,19 @@ class DatabaseBackedOrganizationService(OrganizationService):
     def delete_option(self, *, organization_id: int, key: str) -> None:
         orm_organization = Organization.objects.get_from_cache(id=organization_id)
         orm_organization.delete_option(key)
+
+    def find_organization_id_by_option_value(
+        self, *, cell_name: str, key: str, value: str
+    ) -> int | None:
+        # cell_name is consumed by the @cell_rpc_method resolver; the impl
+        # is already running inside the resolved cell.
+        del cell_name
+        return (
+            OrganizationOption.objects.filter(key=key, value=value)
+            .order_by("organization_id")
+            .values_list("organization_id", flat=True)
+            .first()
+        )
 
     def send_sso_link_emails(
         self, *, organization_id: int, sending_user_email: str, provider_key: str

--- a/src/sentry/organizations/services/organization/service.py
+++ b/src/sentry/organizations/services/organization/service.py
@@ -530,6 +530,26 @@ class OrganizationService(RpcService):
         """
         pass
 
+    @cell_rpc_method(resolve=ByCellName())
+    @abstractmethod
+    def find_organization_id_by_option_value(
+        self, *, cell_name: str, key: str, value: str
+    ) -> int | None:
+        """Find the lowest organization_id whose OrganizationOption(key, value)
+        matches the given pair, in the resolved cell.
+
+        Returns ``None`` when no row matches in this cell. Callers must fan
+        out across ``find_all_cell_names()`` if a global lookup is required.
+
+        OrganizationOption has no DB index on ``(key, value)`` — narrow by
+        ``key`` first; the JSONField equality on ``value`` is acceptable for
+        low-cardinality keys (e.g. ``stripe_projects:account_id``). Ordering
+        by ``organization_id`` gives a deterministic result when multiple
+        rows share the same ``(key, value)`` (the unique constraint is
+        ``(organization, key)``, not ``(key, value)``).
+        """
+        pass
+
     @cell_rpc_method(resolve=ByOrganizationId())
     @abstractmethod
     def send_sso_link_emails(

--- a/src/sentry/organizations/services/organization/service.py
+++ b/src/sentry/organizations/services/organization/service.py
@@ -536,17 +536,12 @@ class OrganizationService(RpcService):
         self, *, cell_name: str, key: str, value: str
     ) -> int | None:
         """Find the lowest organization_id whose OrganizationOption(key, value)
-        matches the given pair, in the resolved cell.
+        matches the pair in the resolved cell.
 
-        Returns ``None`` when no row matches in this cell. Callers must fan
-        out across ``find_all_cell_names()`` if a global lookup is required.
-
-        OrganizationOption has no DB index on ``(key, value)`` — narrow by
-        ``key`` first; the JSONField equality on ``value`` is acceptable for
-        low-cardinality keys (e.g. ``stripe_projects:account_id``). Ordering
-        by ``organization_id`` gives a deterministic result when multiple
-        rows share the same ``(key, value)`` (the unique constraint is
-        ``(organization, key)``, not ``(key, value)``).
+        Returns ``None`` when no row matches. Ordered by organization_id for
+        deterministic selection when multiple rows share the same (key, value)
+        — the unique constraint is (organization, key). Callers fan out
+        across ``find_all_cell_names()`` for a global lookup.
         """
         pass
 

--- a/tests/sentry/organizations/services/test_organization.py
+++ b/tests/sentry/organizations/services/test_organization.py
@@ -1,3 +1,6 @@
+from django.conf import settings
+
+from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.organizations.services.organization.service import organization_service
 from sentry.testutils.cases import TestCase
@@ -69,4 +72,94 @@ class CheckOrganizationTest(TestCase):
                 id=self.organization.id, only_visible=False
             )
             is True
+        )
+
+
+@all_silo_test
+class FindOrganizationIdByOptionValueTest(TestCase):
+    KEY = "stripe_projects:account_id"
+
+    def _set_option(self, organization: Organization, key: str, value: str) -> None:
+        with assume_test_silo_mode_of(OrganizationOption):
+            OrganizationOption.objects.set_value(organization=organization, key=key, value=value)
+
+    def test_returns_org_id_when_exactly_one_match(self) -> None:
+        org = self.create_organization(slug="org-a")
+        self._set_option(org, self.KEY, "acct_xyz")
+
+        assert (
+            organization_service.find_organization_id_by_option_value(
+                cell_name=settings.SENTRY_MONOLITH_REGION,
+                key=self.KEY,
+                value="acct_xyz",
+            )
+            == org.id
+        )
+
+    def test_returns_none_when_no_rows_match(self) -> None:
+        org = self.create_organization(slug="org-a")
+        self._set_option(org, self.KEY, "acct_other")
+
+        assert (
+            organization_service.find_organization_id_by_option_value(
+                cell_name=settings.SENTRY_MONOLITH_REGION,
+                key=self.KEY,
+                value="acct_missing",
+            )
+            is None
+        )
+
+    def test_returns_lowest_org_id_when_multiple_match(self) -> None:
+        # OrganizationOption.unique_together is (organization, key) — two
+        # orgs CAN store the same value for the same key. Pin deterministic
+        # result = lowest organization_id.
+        org_a = self.create_organization(slug="org-a")
+        org_b = self.create_organization(slug="org-b")
+        self._set_option(org_a, self.KEY, "acct_collide")
+        self._set_option(org_b, self.KEY, "acct_collide")
+
+        result = organization_service.find_organization_id_by_option_value(
+            cell_name=settings.SENTRY_MONOLITH_REGION,
+            key=self.KEY,
+            value="acct_collide",
+        )
+        assert result == min(org_a.id, org_b.id)
+
+    def test_value_match_is_exact_no_case_folding(self) -> None:
+        org = self.create_organization(slug="org-a")
+        self._set_option(org, self.KEY, "acct_XYZ")
+
+        assert (
+            organization_service.find_organization_id_by_option_value(
+                cell_name=settings.SENTRY_MONOLITH_REGION,
+                key=self.KEY,
+                value="acct_xyz",
+            )
+            is None
+        )
+
+    def test_value_match_does_not_strip_whitespace(self) -> None:
+        org = self.create_organization(slug="org-a")
+        self._set_option(org, self.KEY, "acct_xyz")
+
+        assert (
+            organization_service.find_organization_id_by_option_value(
+                cell_name=settings.SENTRY_MONOLITH_REGION,
+                key=self.KEY,
+                value=" acct_xyz ",
+            )
+            is None
+        )
+
+    def test_returns_none_when_key_does_not_match(self) -> None:
+        org = self.create_organization(slug="org-a")
+        self._set_option(org, "some:other:key", "acct_xyz")
+
+        assert (
+            organization_service.find_organization_id_by_option_value(
+                cell_name=settings.SENTRY_MONOLITH_REGION,
+                key=self.KEY,
+                value="acct_xyz",
+            )
+            is None
         )


### PR DESCRIPTION
## Summary

- Adds a new cell-routed RPC method `OrganizationService.find_organization_id_by_option_value(*, cell_name, key, value) -> int | None` for cross-silo `OrganizationOption` lookups by `(key, value)`.
- Required by callers (e.g. partner provisioning flows) that want to bind orgs to external account ids stored as options without yet knowing the `organization_id`.
- Uses `@cell_rpc_method(resolve=ByCellName())`, returns a primitive `int | None`, and orders by `organization_id` for deterministic selection when multiple rows share a `(key, value)`. Callers fan out across `find_all_cell_names()` for global lookups.

## Test plan

- [x] `tests/sentry/organizations/services/test_organization.py::FindOrganizationIdByOptionValueTest` — 6 unit cases passing locally:
  - returns None when no rows match
  - returns org_id on exact match
  - returns lowest org_id when multiple rows share `(key, value)` (deterministic ordering)
  - exact value match (no case folding, no whitespace stripping)
  - returns None when key does not match
- [x] `prek run` clean on touched files.

## Notes for reviewers

- This RPC is the silo-safe replacement for direct `OrganizationOption.objects.filter(key=…, value=…)` calls from control-silo endpoints.
- Companion getsentry consumer: getsentry/getsentry#20131. Landing this PR first is the recommended merge order.