### PR TITLE
feat(autofix): Add re-run button to artifact cards

### DIFF
--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -287,6 +287,7 @@ export interface AutofixSection {
   blocks: Block[];
   status: 'processing' | 'completed';
   step: string;
+  index?: number;
 }
 
 /**
@@ -338,7 +339,8 @@ export function getOrderedAutofixSections(runState: ExplorerAutofixState | null)
     }
   }
 
-  for (const block of blocks) {
+  for (let i = 0; i < blocks.length; i++) {
+    const block = blocks[i]!;
     // Accumulate file patches globally — they need to be merged across all
     // blocks regardless of section boundaries so later patches win per file.
     if (block.merged_file_patches?.length) {
@@ -359,6 +361,7 @@ export function getOrderedAutofixSections(runState: ExplorerAutofixState | null)
       }
 
       section = {
+        index: i,
         step: metadata.step,
         artifacts: [],
         blocks: [],
@@ -554,12 +557,29 @@ export function useExplorerAutofix(
   const startStep = useCallback(
     async (
       step: AutofixExplorerStep,
-      startStepOptions?: {runId?: number; userContext?: string}
+      startStepOptions?: {
+        /**
+         * The index of the block to start the step. If specified, existing blocks from this index onwards is reset.
+         */
+        insertIndex?: number;
+        /**
+         * The run id where we want to start the step. If not specified, a new run is created
+         */
+        runId?: number;
+        /**
+         * Additional context from the user. If specified, it is added to the builtin prompt
+         */
+        userContext?: string;
+      }
     ) => {
       setWaitingForResponse(true);
 
       try {
         const data: Record<string, any> = {step};
+
+        if (defined(startStepOptions?.insertIndex)) {
+          data.insert_index = startStepOptions.insertIndex;
+        }
 
         if (defined(startStepOptions?.runId)) {
           data.run_id = startStepOptions.runId;

--- a/static/app/components/events/autofix/v3/artifactCard.tsx
+++ b/static/app/components/events/autofix/v3/artifactCard.tsx
@@ -1,10 +1,11 @@
-import {type ReactNode} from 'react';
+import {Fragment, type ReactNode} from 'react';
 
 import {Button} from '@sentry/scraps/button';
 import {Disclosure} from '@sentry/scraps/disclosure';
 import {Container, Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
+import {IconRefresh} from 'sentry/icons';
 import {IconCopy} from 'sentry/icons/iconCopy';
 import {t} from 'sentry/locale';
 
@@ -12,16 +13,36 @@ interface ArtifactCardProps {
   children: ReactNode;
   icon: ReactNode;
   title: ReactNode;
+  allowReset?: boolean;
   onCopy?: () => void;
+  onReset?: () => void;
 }
 
-export function ArtifactCard({children, icon, title, onCopy}: ArtifactCardProps) {
+export function ArtifactCard({
+  children,
+  icon,
+  title,
+  onCopy,
+  allowReset,
+  onReset,
+}: ArtifactCardProps) {
   return (
     <Container border="primary" radius="md" padding="lg" background="primary">
       <Disclosure defaultExpanded>
         <Disclosure.Title
           trailingItems={
-            onCopy ? (
+            <Fragment>
+              {allowReset && (
+                <Button
+                  size="xs"
+                  priority="transparent"
+                  icon={<IconRefresh size="xs" />}
+                  aria-label={t('Re-run step')}
+                  tooltipProps={{title: t('Re-run step')}}
+                  onClick={onReset}
+                  disabled={!onReset}
+                />
+              )}
               <Button
                 size="xs"
                 priority="transparent"
@@ -29,8 +50,9 @@ export function ArtifactCard({children, icon, title, onCopy}: ArtifactCardProps)
                 aria-label={t('Copy as Markdown')}
                 tooltipProps={{title: t('Copy as Markdown')}}
                 onClick={onCopy}
+                disabled={!onCopy}
               />
-            ) : null
+            </Fragment>
           }
         >
           <Flex gap="md" align="center">

--- a/static/app/components/events/autofix/v3/artifactLoadingDetails.tsx
+++ b/static/app/components/events/autofix/v3/artifactLoadingDetails.tsx
@@ -37,11 +37,10 @@ export function ArtifactLoadingDetails({
   }, [blocks]);
 
   return (
-    <ArtifactDetails paddingTop="0">
+    <ArtifactDetails>
       <Flex
         direction="column"
         gap="md"
-        marginTop="md"
         ref={containerRef}
         maxHeight="200px"
         overflowY="auto"

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -224,9 +224,7 @@ describe('ArtifactCard', () => {
         />
       );
 
-      expect(
-        screen.queryByRole('button', {name: 'Copy as Markdown'})
-      ).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', {name: 'Copy as Markdown'})).toBeDisabled();
     });
   });
 
@@ -322,9 +320,7 @@ describe('ArtifactCard', () => {
         />
       );
 
-      expect(
-        screen.queryByRole('button', {name: 'Copy as Markdown'})
-      ).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', {name: 'Copy as Markdown'})).toBeDisabled();
     });
   });
 
@@ -436,9 +432,7 @@ describe('ArtifactCard', () => {
         />
       );
 
-      expect(
-        screen.queryByRole('button', {name: 'Copy as Markdown'})
-      ).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', {name: 'Copy as Markdown'})).toBeDisabled();
     });
   });
 
@@ -779,9 +773,7 @@ describe('ArtifactCard', () => {
         />
       );
 
-      expect(
-        screen.queryByRole('button', {name: 'Copy as Markdown'})
-      ).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', {name: 'Copy as Markdown'})).toBeDisabled();
     });
   });
 });

--- a/static/app/components/events/autofix/v3/autofixResetPrompt.tsx
+++ b/static/app/components/events/autofix/v3/autofixResetPrompt.tsx
@@ -1,0 +1,57 @@
+import {useState, type ReactNode} from 'react';
+
+import {Button} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+import {TextArea} from '@sentry/scraps/textarea';
+
+import {IconClose} from 'sentry/icons/iconClose';
+import {IconRefresh} from 'sentry/icons/iconRefresh';
+import {t} from 'sentry/locale';
+
+interface AutofixResetPromptProps {
+  onClosePrompt: () => void;
+  onReset: (userContext: string) => void;
+  placeholder: string;
+  prompt: ReactNode;
+}
+
+export function AutofixResetPrompt({
+  onClosePrompt,
+  onReset,
+  placeholder,
+  prompt,
+}: AutofixResetPromptProps) {
+  const [userContext, setUserContext] = useState('');
+
+  return (
+    <Flex direction="column" gap="lg">
+      <Text>{prompt}</Text>
+      <TextArea
+        autosize
+        rows={2}
+        placeholder={placeholder}
+        value={userContext}
+        onChange={event => setUserContext(event.target.value)}
+      />
+      <Flex justify="end" gap="md">
+        <Button
+          size="xs"
+          icon={<IconClose size="xs" />}
+          aria-label={t('Close')}
+          tooltipProps={{title: t('Close')}}
+          onClick={onClosePrompt}
+        />
+        <Button
+          priority="primary"
+          size="xs"
+          icon={<IconRefresh size="xs" />}
+          aria-label={t('Re-run from here')}
+          onClick={() => onReset(userContext)}
+        >
+          {t('Re-run from here')}
+        </Button>
+      </Flex>
+    </Flex>
+  );
+}

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -14,6 +14,8 @@ import {
 import {ArtifactCard} from 'sentry/components/events/autofix/v3/artifactCard';
 import {ArtifactDetails} from 'sentry/components/events/autofix/v3/artifactDetails';
 import {ArtifactLoadingDetails} from 'sentry/components/events/autofix/v3/artifactLoadingDetails';
+import {AutofixResetPrompt} from 'sentry/components/events/autofix/v3/autofixResetPrompt';
+import {useResetAutofixStep} from 'sentry/components/events/autofix/v3/useResetAutofixStep';
 import {artifactToMarkdown} from 'sentry/components/events/autofix/v3/utils';
 import {IconCode} from 'sentry/icons/iconCode';
 import {IconRefresh} from 'sentry/icons/iconRefresh';
@@ -37,6 +39,13 @@ export function CodeChangesCard({autofix, section}: CodeChangesCardProps) {
     () => (artifact ? artifactToMarkdown(artifact) : null),
     [artifact]
   );
+
+  const {canReset, shouldShowReset, setShouldShowReset, handleReset} =
+    useResetAutofixStep({
+      autofix,
+      section,
+      step: 'code_changes',
+    });
 
   const patchesByRepo = useMemo(() => collectPatches(artifact ?? []), [artifact]);
 
@@ -62,9 +71,6 @@ export function CodeChangesCard({autofix, section}: CodeChangesCardProps) {
     return t('%s files changed in %s repos', filesChanged.size, reposChanged);
   }, [patchesByRepo]);
 
-  const {runState, startStep} = autofix;
-  const runId = runState?.run_id;
-
   return (
     <ArtifactCard
       icon={<IconCode />}
@@ -74,6 +80,8 @@ export function CodeChangesCard({autofix, section}: CodeChangesCardProps) {
           ? () => copy(markdown, {successMessage: t('Copied to clipboard.')})
           : undefined
       }
+      allowReset
+      onReset={canReset ? () => setShouldShowReset(true) : undefined}
     >
       {section.status === 'processing' ? (
         <ArtifactLoadingDetails
@@ -82,9 +90,19 @@ export function CodeChangesCard({autofix, section}: CodeChangesCardProps) {
         />
       ) : (
         <Fragment>
+          {shouldShowReset && (
+            <AutofixResetPrompt
+              onClosePrompt={() => setShouldShowReset(false)}
+              onReset={handleReset}
+              placeholder={t('Give seer additional context to improve this code change.')}
+              prompt={t('How can this code change be improved?')}
+            />
+          )}
           {patchesByRepo.size ? (
             <Fragment>
-              <Text>{summary}</Text>
+              <ArtifactDetails>
+                <Text>{summary}</Text>
+              </ArtifactDetails>
               {[...patchesByRepo.entries()].map(([repo, patches]) => (
                 <ArtifactDetails key={repo}>
                   <Flex gap="lg">
@@ -114,7 +132,7 @@ export function CodeChangesCard({autofix, section}: CodeChangesCardProps) {
                 <Button
                   priority="primary"
                   icon={<IconRefresh />}
-                  onClick={() => startStep('code_changes', {runId})}
+                  onClick={() => handleReset()}
                 >
                   {t('Re-run')}
                 </Button>

--- a/static/app/components/events/autofix/v3/content.tsx
+++ b/static/app/components/events/autofix/v3/content.tsx
@@ -91,30 +91,26 @@ function SeerDrawerArtifacts({autofix, sections}: SeerDrawerArtifactsProps) {
   return (
     <Fragment>
       {sections.map(section => {
+        const key = `${section.step}-${section.blocks[0]?.id ?? null}`;
+
         if (isRootCauseSection(section)) {
-          return <RootCauseCard key={section.step} autofix={autofix} section={section} />;
+          return <RootCauseCard key={key} autofix={autofix} section={section} />;
         }
 
         if (isSolutionSection(section)) {
-          return <SolutionCard key={section.step} autofix={autofix} section={section} />;
+          return <SolutionCard key={key} autofix={autofix} section={section} />;
         }
 
         if (isCodeChangesSection(section)) {
-          return (
-            <CodeChangesCard key={section.step} autofix={autofix} section={section} />
-          );
+          return <CodeChangesCard key={key} autofix={autofix} section={section} />;
         }
 
         if (isPullRequestsSection(section)) {
-          return (
-            <PullRequestsCard key={section.step} autofix={autofix} section={section} />
-          );
+          return <PullRequestsCard key={key} autofix={autofix} section={section} />;
         }
 
         if (isCodingAgentsSection(section)) {
-          return (
-            <CodingAgentsCard key={section.step} autofix={autofix} section={section} />
-          );
+          return <CodingAgentsCard key={key} autofix={autofix} section={section} />;
         }
 
         // TODO: maybe send a log?

--- a/static/app/components/events/autofix/v3/nextStep.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.tsx
@@ -116,7 +116,7 @@ function RootCauseNextStep({autofix, group, runId, section, referrer}: NextStepP
 
   const handleNoClick = useCallback(
     (userContext: string) => {
-      startStep('root_cause', {runId, userContext});
+      startStep('root_cause', {runId, userContext, insertIndex: section.index});
       trackAnalytics('autofix.root_cause.re_run', {
         organization,
         group_id: group.id,
@@ -124,7 +124,7 @@ function RootCauseNextStep({autofix, group, runId, section, referrer}: NextStepP
         referrer,
       });
     },
-    [organization, group, startStep, runId, referrer]
+    [organization, group, startStep, runId, referrer, section.index]
   );
 
   const artifact = useMemo(() => getAutofixArtifactFromSection(section), [section]);
@@ -167,7 +167,7 @@ function SolutionNextStep({autofix, group, runId, section, referrer}: NextStepPr
 
   const handleNoClick = useCallback(
     (userContext: string) => {
-      startStep('solution', {runId, userContext});
+      startStep('solution', {runId, userContext, insertIndex: section.index});
       trackAnalytics('autofix.solution.re_run', {
         organization,
         group_id: group.id,
@@ -175,7 +175,7 @@ function SolutionNextStep({autofix, group, runId, section, referrer}: NextStepPr
         referrer,
       });
     },
-    [organization, group, startStep, runId, referrer]
+    [organization, group, startStep, runId, referrer, section.index]
   );
 
   const artifact = useMemo(() => getAutofixArtifactFromSection(section), [section]);
@@ -216,7 +216,7 @@ function CodeChangesNextStep({autofix, group, runId, section, referrer}: NextSte
 
   const handleNoClick = useCallback(
     (userContext: string) => {
-      startStep('code_changes', {runId, userContext});
+      startStep('code_changes', {runId, userContext, insertIndex: section.index});
       trackAnalytics('autofix.code_changes.re_run', {
         organization,
         group_id: group.id,
@@ -224,7 +224,7 @@ function CodeChangesNextStep({autofix, group, runId, section, referrer}: NextSte
         referrer,
       });
     },
-    [organization, group, startStep, runId, referrer]
+    [organization, group, startStep, runId, referrer, section.index]
   );
 
   const artifact = useMemo(() => getAutofixArtifactFromSection(section), [section]);

--- a/static/app/components/events/autofix/v3/rootCauseCard.tsx
+++ b/static/app/components/events/autofix/v3/rootCauseCard.tsx
@@ -62,7 +62,12 @@ export function RootCauseCard({autofix, section}: RootCauseCardProps) {
       allowReset
       onReset={canReset ? () => setShouldShowReset(true) : undefined}
     >
-      {artifact?.data ? (
+      {section.status === 'processing' ? (
+        <ArtifactLoadingDetails
+          blocks={section.blocks}
+          loadingMessage={t('Finding the root cause\u2026')}
+        />
+      ) : artifact?.data ? (
         <Fragment>
           {shouldShowReset && (
             <AutofixResetPrompt
@@ -115,11 +120,6 @@ export function RootCauseCard({autofix, section}: RootCauseCardProps) {
             </ArtifactDetails>
           )}
         </Fragment>
-      ) : section.status === 'processing' ? (
-        <ArtifactLoadingDetails
-          blocks={section.blocks}
-          loadingMessage={t('Finding the root cause\u2026')}
-        />
       ) : (
         <ArtifactDetails>
           <Text>

--- a/static/app/components/events/autofix/v3/rootCauseCard.tsx
+++ b/static/app/components/events/autofix/v3/rootCauseCard.tsx
@@ -14,8 +14,10 @@ import {ArtifactCard} from 'sentry/components/events/autofix/v3/artifactCard';
 import {ArtifactDetails} from 'sentry/components/events/autofix/v3/artifactDetails';
 import {ArtifactLoadingDetails} from 'sentry/components/events/autofix/v3/artifactLoadingDetails';
 import {AutofixEvidence} from 'sentry/components/events/autofix/v3/autofixEvidence';
+import {AutofixResetPrompt} from 'sentry/components/events/autofix/v3/autofixResetPrompt';
 import {StyledMarkedText} from 'sentry/components/events/autofix/v3/styled';
 import {useAutofixSectionEvidence} from 'sentry/components/events/autofix/v3/useAutofixSectionEvidence';
+import {useResetAutofixStep} from 'sentry/components/events/autofix/v3/useResetAutofixStep';
 import {artifactToMarkdown} from 'sentry/components/events/autofix/v3/utils';
 import {IconBug} from 'sentry/icons/iconBug';
 import {IconRefresh} from 'sentry/icons/iconRefresh';
@@ -38,7 +40,13 @@ export function RootCauseCard({autofix, section}: RootCauseCardProps) {
     () => (artifact ? artifactToMarkdown(artifact) : null),
     [artifact]
   );
-  const {startStep} = autofix;
+
+  const {canReset, shouldShowReset, setShouldShowReset, handleReset} =
+    useResetAutofixStep({
+      autofix,
+      section,
+      step: 'root_cause',
+    });
 
   const evidence = useAutofixSectionEvidence({section});
 
@@ -51,15 +59,22 @@ export function RootCauseCard({autofix, section}: RootCauseCardProps) {
           ? () => copy(markdown, {successMessage: t('Copied to clipboard.')})
           : undefined
       }
+      allowReset
+      onReset={canReset ? () => setShouldShowReset(true) : undefined}
     >
-      {section.status === 'processing' ? (
-        <ArtifactLoadingDetails
-          blocks={section.blocks}
-          loadingMessage={t('Finding the root cause\u2026')}
-        />
-      ) : artifact?.data ? (
+      {artifact?.data ? (
         <Fragment>
-          <StyledMarkedText text={artifact.data.one_line_description} />
+          {shouldShowReset && (
+            <AutofixResetPrompt
+              onClosePrompt={() => setShouldShowReset(false)}
+              onReset={handleReset}
+              placeholder={t('Give seer additional context to improve this root cause.')}
+              prompt={t('How can this root cause be improved?')}
+            />
+          )}
+          <ArtifactDetails>
+            <StyledMarkedText text={artifact.data.one_line_description} />
+          </ArtifactDetails>
           {artifact.data.five_whys?.length ? (
             <Fragment>
               <ArtifactDetails>
@@ -100,6 +115,11 @@ export function RootCauseCard({autofix, section}: RootCauseCardProps) {
             </ArtifactDetails>
           )}
         </Fragment>
+      ) : section.status === 'processing' ? (
+        <ArtifactLoadingDetails
+          blocks={section.blocks}
+          loadingMessage={t('Finding the root cause\u2026')}
+        />
       ) : (
         <ArtifactDetails>
           <Text>
@@ -111,7 +131,7 @@ export function RootCauseCard({autofix, section}: RootCauseCardProps) {
             <Button
               priority="primary"
               icon={<IconRefresh />}
-              onClick={() => startStep('root_cause')}
+              onClick={() => handleReset()}
             >
               {t('Re-run')}
             </Button>

--- a/static/app/components/events/autofix/v3/solutionCard.tsx
+++ b/static/app/components/events/autofix/v3/solutionCard.tsx
@@ -13,7 +13,9 @@ import {
 import {ArtifactCard} from 'sentry/components/events/autofix/v3/artifactCard';
 import {ArtifactDetails} from 'sentry/components/events/autofix/v3/artifactDetails';
 import {ArtifactLoadingDetails} from 'sentry/components/events/autofix/v3/artifactLoadingDetails';
+import {AutofixResetPrompt} from 'sentry/components/events/autofix/v3/autofixResetPrompt';
 import {StyledMarkedText} from 'sentry/components/events/autofix/v3/styled';
+import {useResetAutofixStep} from 'sentry/components/events/autofix/v3/useResetAutofixStep';
 import {artifactToMarkdown} from 'sentry/components/events/autofix/v3/utils';
 import {IconList} from 'sentry/icons/iconList';
 import {IconRefresh} from 'sentry/icons/iconRefresh';
@@ -36,8 +38,13 @@ export function SolutionCard({autofix, section}: SolutionCardProps) {
     () => (artifact ? artifactToMarkdown(artifact) : null),
     [artifact]
   );
-  const {runState, startStep} = autofix;
-  const runId = runState?.run_id;
+
+  const {canReset, shouldShowReset, setShouldShowReset, handleReset} =
+    useResetAutofixStep({
+      autofix,
+      section,
+      step: 'solution',
+    });
 
   return (
     <ArtifactCard
@@ -48,15 +55,22 @@ export function SolutionCard({autofix, section}: SolutionCardProps) {
           ? () => copy(markdown, {successMessage: t('Copied to clipboard.')})
           : undefined
       }
+      allowReset
+      onReset={canReset ? () => setShouldShowReset(true) : undefined}
     >
-      {section.status === 'processing' ? (
-        <ArtifactLoadingDetails
-          blocks={section.blocks}
-          loadingMessage={t('Formulating a plan\u2026')}
-        />
-      ) : artifact?.data ? (
+      {artifact?.data ? (
         <Fragment>
-          <StyledMarkedText text={artifact.data.one_line_summary} />
+          {shouldShowReset && (
+            <AutofixResetPrompt
+              onClosePrompt={() => setShouldShowReset(false)}
+              onReset={handleReset}
+              placeholder={t('Give seer additional context to improve this plan.')}
+              prompt={t('How can this plan be improved?')}
+            />
+          )}
+          <ArtifactDetails>
+            <StyledMarkedText text={artifact.data.one_line_summary} />
+          </ArtifactDetails>
           {artifact.data.steps ? (
             <ArtifactDetails>
               <Text bold>{t('Steps to Resolve')}</Text>
@@ -75,6 +89,11 @@ export function SolutionCard({autofix, section}: SolutionCardProps) {
             </ArtifactDetails>
           ) : null}
         </Fragment>
+      ) : section.status === 'processing' ? (
+        <ArtifactLoadingDetails
+          blocks={section.blocks}
+          loadingMessage={t('Formulating a plan\u2026')}
+        />
       ) : (
         <ArtifactDetails>
           <Text>
@@ -86,7 +105,7 @@ export function SolutionCard({autofix, section}: SolutionCardProps) {
             <Button
               priority="primary"
               icon={<IconRefresh />}
-              onClick={() => startStep('solution', {runId})}
+              onClick={() => handleReset()}
             >
               {t('Re-run')}
             </Button>

--- a/static/app/components/events/autofix/v3/solutionCard.tsx
+++ b/static/app/components/events/autofix/v3/solutionCard.tsx
@@ -58,7 +58,12 @@ export function SolutionCard({autofix, section}: SolutionCardProps) {
       allowReset
       onReset={canReset ? () => setShouldShowReset(true) : undefined}
     >
-      {artifact?.data ? (
+      {section.status === 'processing' ? (
+        <ArtifactLoadingDetails
+          blocks={section.blocks}
+          loadingMessage={t('Formulating a plan\u2026')}
+        />
+      ) : artifact?.data ? (
         <Fragment>
           {shouldShowReset && (
             <AutofixResetPrompt
@@ -89,11 +94,6 @@ export function SolutionCard({autofix, section}: SolutionCardProps) {
             </ArtifactDetails>
           ) : null}
         </Fragment>
-      ) : section.status === 'processing' ? (
-        <ArtifactLoadingDetails
-          blocks={section.blocks}
-          loadingMessage={t('Formulating a plan\u2026')}
-        />
       ) : (
         <ArtifactDetails>
           <Text>

--- a/static/app/components/events/autofix/v3/useResetAutofixStep.spec.tsx
+++ b/static/app/components/events/autofix/v3/useResetAutofixStep.spec.tsx
@@ -1,0 +1,235 @@
+import {act, renderHook} from 'sentry-test/reactTestingLibrary';
+
+import type {
+  AutofixSection,
+  useExplorerAutofix,
+} from 'sentry/components/events/autofix/useExplorerAutofix';
+import {useResetAutofixStep} from 'sentry/components/events/autofix/v3/useResetAutofixStep';
+
+function makeAutofix(
+  overrides: Partial<ReturnType<typeof useExplorerAutofix>> = {}
+): ReturnType<typeof useExplorerAutofix> {
+  const base: ReturnType<typeof useExplorerAutofix> = {
+    runState: null,
+    startStep: jest.fn(),
+    createPR: jest.fn(),
+    reset: jest.fn(),
+    triggerCodingAgentHandoff: jest.fn(),
+    codingAgentErrors: [],
+    dismissCodingAgentError: jest.fn(),
+    isLoading: false,
+    isPolling: false,
+  };
+  return {...base, ...overrides};
+}
+
+function makeSection(overrides: Partial<AutofixSection> = {}): AutofixSection {
+  return {
+    artifacts: [],
+    blocks: [],
+    status: 'completed',
+    step: 'root_cause',
+    index: 0,
+    ...overrides,
+  };
+}
+
+describe('useResetAutofixStep', () => {
+  describe('canReset', () => {
+    it('returns true when all conditions are met', () => {
+      const autofix = makeAutofix({
+        runState: {
+          run_id: 1,
+          status: 'completed',
+          blocks: [],
+          updated_at: '2024-01-01T00:00:00Z',
+          repo_pr_states: {},
+          coding_agents: {},
+        },
+      });
+
+      const {result} = renderHook(() =>
+        useResetAutofixStep({autofix, section: makeSection(), step: 'root_cause'})
+      );
+
+      expect(result.current.canReset).toBe(true);
+    });
+
+    it('returns false when status is processing', () => {
+      const autofix = makeAutofix({
+        runState: {
+          run_id: 1,
+          status: 'processing',
+          blocks: [],
+          updated_at: '2024-01-01T00:00:00Z',
+        },
+      });
+
+      const {result} = renderHook(() =>
+        useResetAutofixStep({autofix, section: makeSection(), step: 'root_cause'})
+      );
+
+      expect(result.current.canReset).toBe(false);
+    });
+
+    it('returns false when PRs have been created', () => {
+      const autofix = makeAutofix({
+        runState: {
+          run_id: 1,
+          status: 'completed',
+          blocks: [],
+          updated_at: '2024-01-01T00:00:00Z',
+          repo_pr_states: {
+            'repo-1': {
+              repo_name: 'repo-1',
+              branch_name: 'fix/branch',
+              commit_sha: 'abc123',
+              pr_creation_error: null,
+              pr_creation_status: 'completed',
+              pr_id: 1,
+              pr_number: 42,
+              pr_url: 'https://github.com/org/repo/pull/42',
+              title: 'Fix bug',
+            },
+          },
+          coding_agents: {},
+        },
+      });
+
+      const {result} = renderHook(() =>
+        useResetAutofixStep({autofix, section: makeSection(), step: 'root_cause'})
+      );
+
+      expect(result.current.canReset).toBe(false);
+    });
+
+    it('returns false when coding agents have been started', () => {
+      const autofix = makeAutofix({
+        runState: {
+          run_id: 1,
+          status: 'completed',
+          blocks: [],
+          updated_at: '2024-01-01T00:00:00Z',
+          repo_pr_states: {},
+          coding_agents: {
+            'agent-1': {
+              id: 'agent-1',
+              name: 'Coding Agent',
+              provider: 'github',
+              started_at: '2024-01-01T00:00:00Z',
+              status: 'running',
+            },
+          },
+        },
+      });
+
+      const {result} = renderHook(() =>
+        useResetAutofixStep({autofix, section: makeSection(), step: 'root_cause'})
+      );
+
+      expect(result.current.canReset).toBe(false);
+    });
+
+    it('returns false when reset prompt is showing', () => {
+      const autofix = makeAutofix({
+        runState: {
+          run_id: 1,
+          status: 'completed',
+          blocks: [],
+          updated_at: '2024-01-01T00:00:00Z',
+          repo_pr_states: {},
+          coding_agents: {},
+        },
+      });
+
+      const {result} = renderHook(() =>
+        useResetAutofixStep({autofix, section: makeSection(), step: 'root_cause'})
+      );
+
+      expect(result.current.canReset).toBe(true);
+
+      act(() => {
+        result.current.setShouldShowReset(true);
+      });
+
+      expect(result.current.canReset).toBe(false);
+    });
+  });
+
+  describe('handleReset', () => {
+    it('calls startStep with correct arguments', () => {
+      const autofix = makeAutofix({
+        runState: {
+          run_id: 42,
+          status: 'completed',
+          blocks: [],
+          updated_at: '2024-01-01T00:00:00Z',
+        },
+      });
+      const section = makeSection({index: 3});
+
+      const {result} = renderHook(() =>
+        useResetAutofixStep({autofix, section, step: 'solution'})
+      );
+
+      result.current.handleReset();
+
+      expect(autofix.startStep).toHaveBeenCalledWith('solution', {
+        runId: 42,
+        userContext: undefined,
+        insertIndex: 3,
+      });
+    });
+
+    it('passes userContext when provided', () => {
+      const autofix = makeAutofix({
+        runState: {
+          run_id: 7,
+          status: 'completed',
+          blocks: [],
+          updated_at: '2024-01-01T00:00:00Z',
+        },
+      });
+
+      const {result} = renderHook(() =>
+        useResetAutofixStep({
+          autofix,
+          section: makeSection({index: 1}),
+          step: 'code_changes',
+        })
+      );
+
+      result.current.handleReset('Please focus on the auth module');
+
+      expect(autofix.startStep).toHaveBeenCalledWith('code_changes', {
+        runId: 7,
+        userContext: 'Please focus on the auth module',
+        insertIndex: 1,
+      });
+    });
+  });
+
+  describe('state management', () => {
+    it('defaults shouldShowReset to false and allows toggling', () => {
+      const autofix = makeAutofix();
+
+      const {result} = renderHook(() =>
+        useResetAutofixStep({autofix, section: makeSection(), step: 'root_cause'})
+      );
+
+      expect(result.current.shouldShowReset).toBe(false);
+
+      act(() => {
+        result.current.setShouldShowReset(true);
+      });
+
+      expect(result.current.shouldShowReset).toBe(true);
+
+      act(() => {
+        result.current.setShouldShowReset(false);
+      });
+
+      expect(result.current.shouldShowReset).toBe(false);
+    });
+  });
+});

--- a/static/app/components/events/autofix/v3/useResetAutofixStep.tsx
+++ b/static/app/components/events/autofix/v3/useResetAutofixStep.tsx
@@ -1,0 +1,45 @@
+import {useMemo, useState} from 'react';
+
+import {
+  type AutofixExplorerStep,
+  type AutofixSection,
+  type useExplorerAutofix,
+} from 'sentry/components/events/autofix/useExplorerAutofix';
+
+interface UseResetAutofixStepOptions {
+  autofix: ReturnType<typeof useExplorerAutofix>;
+  section: AutofixSection;
+  step: AutofixExplorerStep;
+}
+
+export function useResetAutofixStep({
+  autofix,
+  section,
+  step,
+}: UseResetAutofixStepOptions) {
+  const [shouldShowReset, setShouldShowReset] = useState(false);
+
+  const {runState, startStep} = autofix;
+  const runId = runState?.run_id;
+
+  const handleReset = useMemo(() => {
+    return (userContext?: string) => {
+      startStep(step, {runId, userContext, insertIndex: section.index});
+    };
+  }, [startStep, step, runId, section.index]);
+
+  return {
+    canReset:
+      // can only reset if reset prompt is not showing
+      !shouldShowReset &&
+      // can only reset if run state is not processing
+      autofix.runState?.status !== 'processing' &&
+      // can only reset if PRs states are empty (i.e. no PR have been created)
+      Object.values(autofix.runState?.repo_pr_states ?? {}).length === 0 &&
+      // can only reset if coding agents are empty (i.e. no coding agents have been started)
+      Object.values(autofix.runState?.coding_agents ?? {}).length === 0,
+    shouldShowReset,
+    setShouldShowReset,
+    handleReset,
+  };
+}


### PR DESCRIPTION
This adds a re-run button to the top of each artifact card. The button can be used whenever a step is completed to re-run from a specific step and allow users to give additional context when doing so.

The button is disabled whenever
- the run is still processing
- or pr have been created
- or coding agents have been started