### PR TITLE
fix(intercom): Move back to user ID

### DIFF
--- a/src/sentry/api/endpoints/organization_intercom_jwt.py
+++ b/src/sentry/api/endpoints/organization_intercom_jwt.py
@@ -69,12 +69,10 @@ class OrganizationIntercomJwtEndpoint(ControlSiloOrganizationEndpoint):
         user = request.user
         now = int(datetime.datetime.now(datetime.UTC).timestamp())
         exp = now + JWT_VALIDITY_WINDOW_SECONDS
-        # intercom creates chat history based on this ID so we need one per (org, user) pair
-        intercom_user_id = f"{user.id}-{organization.id}"
 
         # Build JWT claims - user_id is required by Intercom
         claims = {
-            "user_id": intercom_user_id,
+            "user_id": str(user.id),
             "email": user.email,
             "iat": now,
             "exp": exp,
@@ -92,7 +90,7 @@ class OrganizationIntercomJwtEndpoint(ControlSiloOrganizationEndpoint):
             created_at = int(user.last_active.timestamp())
 
         user_data = {
-            "userId": intercom_user_id,
+            "userId": str(user.id),
             "email": user.email,
             "name": user.get_display_name(),
             "createdAt": created_at,

--- a/tests/sentry/api/endpoints/test_organization_intercom_jwt.py
+++ b/tests/sentry/api/endpoints/test_organization_intercom_jwt.py
@@ -27,7 +27,6 @@ class OrganizationIntercomJwtEndpointTest(APITestCase):
     def test_get_jwt_success(self) -> None:
         """With feature flag and secret configured, should return JWT and user data."""
         test_secret = "test-intercom-secret-key"
-        intercom_user_id = f"{self.user.id}-{self.organization.id}"
 
         with (
             self.feature("organizations:intercom-support"),
@@ -40,7 +39,7 @@ class OrganizationIntercomJwtEndpointTest(APITestCase):
 
         # Verify user data
         user_data = response.data["userData"]
-        assert user_data["userId"] == intercom_user_id
+        assert user_data["userId"] == str(self.user.id)
         assert user_data["email"] == self.user.email
         assert user_data["organizationId"] == str(self.organization.id)
         assert user_data["organizationName"] == self.organization.name
@@ -50,7 +49,7 @@ class OrganizationIntercomJwtEndpointTest(APITestCase):
         token = response.data["jwt"]
         decoded = jwt.decode(token, test_secret, algorithms=["HS256"], audience=False)
 
-        assert decoded["user_id"] == intercom_user_id
+        assert decoded["user_id"] == str(self.user.id)
         assert decoded["email"] == self.user.email
         assert "iat" in decoded
         assert "exp" in decoded


### PR DESCRIPTION
Went back and forth multiple times on this decision but in the end decided that we want intercom user ID to be the same as Sentry user ID.
