### PR TITLE
fix(dashboards): Filter prebuilt dashboards server-side in add to dashboard modal

### DIFF
--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.spec.tsx
@@ -703,8 +703,8 @@ describe('add to dashboard modal', () => {
     ).toBeInTheDocument();
   });
 
-  it('does not show prebuilt dashboards in the list of options', async () => {
-    MockApiClient.addMockResponse({
+  it('requests dashboards with the excludePrebuilt filter', async () => {
+    const dashboardsRequest = MockApiClient.addMockResponse({
       url: '/organizations/org-slug/dashboards/',
       body: [
         {...testDashboardListItem, widgetDisplay: [DisplayType.AREA]},
@@ -714,14 +714,8 @@ describe('add to dashboard modal', () => {
           id: '2',
           widgetDisplay: [DisplayType.AREA],
         },
-        {
-          ...testDashboardListItem,
-          title: 'Prebuilt Dashboard',
-          id: '3',
-          widgetDisplay: [DisplayType.AREA],
-          prebuiltId: 1,
-        },
       ],
+      match: [MockApiClient.matchQuery({filter: 'excludePrebuilt'})],
     });
     render(
       <AddToDashboardModal
@@ -740,8 +734,13 @@ describe('add to dashboard modal', () => {
     await waitFor(() => {
       expect(screen.getByText('Select Dashboard')).toBeEnabled();
     });
+    expect(dashboardsRequest).toHaveBeenCalledWith(
+      '/organizations/org-slug/dashboards/',
+      expect.objectContaining({
+        query: expect.objectContaining({filter: 'excludePrebuilt'}),
+      })
+    );
     await selectEvent.openMenu(screen.getByText('Select Dashboard'));
-    expect(screen.queryByText('Prebuilt Dashboard')).not.toBeInTheDocument();
     expect(screen.getByText('Test Dashboard')).toBeInTheDocument();
     expect(screen.getByText('Other Dashboard')).toBeInTheDocument();
   });

--- a/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
+++ b/static/app/components/modals/widgetBuilder/addToDashboardModal.tsx
@@ -24,7 +24,6 @@ import {pageFiltersToQueryParams} from 'sentry/components/pageFilters/parse';
 import {t, tct, tn} from 'sentry/locale';
 import type {PageFilters, SelectValue} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
-import {defined} from 'sentry/utils';
 import type {Sort} from 'sentry/utils/discover/fields';
 import {MetricsCardinalityProvider} from 'sentry/utils/performance/contexts/metricsCardinality';
 import {MEPSettingProvider} from 'sentry/utils/performance/contexts/metricsEnhancedSetting';
@@ -47,6 +46,7 @@ import type {
   Widget,
 } from 'sentry/views/dashboards/types';
 import {
+  DashboardFilter,
   DEFAULT_WIDGET_NAME,
   DisplayType,
   MAX_WIDGETS,
@@ -167,7 +167,9 @@ function AddToDashboardModal({
     // Track mounted state so we dont call setState on unmounted components
     let unmounted = false;
 
-    fetchDashboards(api, organization.slug).then(response => {
+    fetchDashboards(api, organization.slug, {
+      filter: DashboardFilter.EXCLUDE_PREBUILT,
+    }).then(response => {
       // If component has unmounted, dont set state
       if (unmounted) {
         return;
@@ -386,7 +388,6 @@ function AddToDashboardModal({
           tooltipOptions: {position: 'right', isHoverable: true},
         },
         ...dashboards
-          .filter(dashboard => !defined(dashboard.prebuiltId)) // Cannot add to prebuilt dashboards
           .filter(dashboard =>
             // if adding from a dashboard, currentDashboardId will be set and we'll remove it from the list of options
             currentDashboardId ? dashboard.id !== currentDashboardId : true


### PR DESCRIPTION
This fixes a bug where users are seeing the `General` dashboard in the `add to Dashboard` modal, but we deprecated that dashboard.

The add-to-dashboard modal previously fetched all dashboards and filtered out
prebuilt entries on the client. For accounts whose dashboard list is dominated
by prebuilt dashboards (notably new accounts), this could leave the dropdown
empty or hide valid dashboards behind pagination. Switch to the existing
`excludePrebuilt` filter so the API only returns user-owned dashboards. 


Fixes DAIN-1592