### PR TITLE
ref(seer): Remove enableSeerEnhancedAlerts settings toggle

### DIFF
--- a/static/app/types/organization.tsx
+++ b/static/app/types/organization.tsx
@@ -115,7 +115,6 @@ export interface Organization extends OrganizationSummary {
   defaultSeerScannerAutomation?: boolean;
   desiredSampleRate?: number | null;
   enableSeerCoding?: boolean;
-  enableSeerEnhancedAlerts?: boolean;
   enabledConsolePlatforms?: string[];
   experiments?: Record<string, string>;
   extraOptions?: {

--- a/static/gsApp/views/seerAutomation/advanced.tsx
+++ b/static/gsApp/views/seerAutomation/advanced.tsx
@@ -17,7 +17,6 @@ import {SeerSettingsPageWrapper} from 'getsentry/views/seerAutomation/components
 import {useCanWriteSettings} from 'getsentry/views/seerAutomation/components/useCanWriteSettings';
 
 const schema = z.object({
-  enableSeerEnhancedAlerts: z.boolean(),
   enableSeerCoding: z.boolean(),
 });
 
@@ -54,27 +53,6 @@ export default function SeerAutomationAdvancedSettings() {
       />
       <SeerSettingsPageContent>
         <FieldGroup>
-          <AutoSaveForm
-            name="enableSeerEnhancedAlerts"
-            schema={schema}
-            initialValue={organization.enableSeerEnhancedAlerts ?? true}
-            mutationOptions={orgMutationOpts}
-          >
-            {field => (
-              <field.Layout.Row
-                label={t('Enable Seer Context in Alerts')}
-                hintText={t(
-                  'Enable Seer to include Agent output in alerts when available. This may include code snippets, explanations, and more.'
-                )}
-              >
-                <field.Switch
-                  checked={field.state.value}
-                  onChange={field.handleChange}
-                  disabled={!canWrite}
-                />
-              </field.Layout.Row>
-            )}
-          </AutoSaveForm>
           <AutoSaveForm
             name="enableSeerCoding"
             schema={schema}

--- a/static/gsApp/views/seerAutomation/components/seerAutomationDefault.tsx
+++ b/static/gsApp/views/seerAutomation/components/seerAutomationDefault.tsx
@@ -23,7 +23,6 @@ const seerDefaultsSchema = z.object({
     'high',
     'always',
   ]),
-  enableSeerEnhancedAlerts: z.boolean(),
   enableSeerCoding: z.boolean(),
 });
 
@@ -108,27 +107,6 @@ export function SeerAutomationDefault() {
         )}
       </FieldGroup>
       <FieldGroup title={t('Advanced Settings')}>
-        <AutoSaveForm
-          name="enableSeerEnhancedAlerts"
-          schema={seerDefaultsSchema}
-          initialValue={organization.enableSeerEnhancedAlerts ?? true}
-          mutationOptions={orgMutationOptions}
-        >
-          {field => (
-            <field.Layout.Row
-              label={t('Enable Enhanced Alerts')}
-              hintText={t(
-                'Seer will provide extra context in supported alerts to make them more informative at a glance.'
-              )}
-            >
-              <field.Switch
-                checked={field.state.value}
-                onChange={field.handleChange}
-                disabled={!canWrite}
-              />
-            </field.Layout.Row>
-          )}
-        </AutoSaveForm>
         <AutoSaveForm
           name="enableSeerCoding"
           schema={seerDefaultsSchema}


### PR DESCRIPTION
Remove the Seer Enhanced Alert setting from being configurable. 

Follow up PRs will:
- remove it from the backend code
- remove initial guesses from notifications entirely

<img width="874" height="443" alt="image" src="https://github.com/user-attachments/assets/3d9ee3e2-eef4-46a7-879e-29e19397181e" />
