### PR TITLE
feat(seer-slack): parse legacy attachments

### DIFF
--- a/src/sentry/seer/entrypoints/slack/mention.py
+++ b/src/sentry/seer/entrypoints/slack/mention.py
@@ -133,15 +133,15 @@ def _extract_attachment_text(attachment: Mapping[str, Any]) -> str:
 
     parts: list[str] = []
 
-    pretext = attachment.get("pretext", "")
-    parts.append(pretext)
+    if pretext := attachment.get("pretext", ""):
+        parts.append(pretext)
 
-    title = attachment.get("title", "")
-    title_link = attachment.get("title_link")
-    parts.append(f"<{title_link}|{title}>" if title_link else title)
+    if title := attachment.get("title", ""):
+        title_link = attachment.get("title_link")
+        parts.append(f"<{title_link}|{title}>" if title_link else title)
 
-    text = attachment.get("text", "")
-    parts.append(text)
+    if text := attachment.get("text", ""):
+        parts.append(text)
 
     for field in attachment.get("fields", []):
         if not isinstance(field, dict):
@@ -150,14 +150,13 @@ def _extract_attachment_text(attachment: Mapping[str, Any]) -> str:
         field_value = field.get("value", "")
         if field_title and field_value:
             parts.append(f"{field_title}: {field_value}")
-        else:
+        elif field_value:
             parts.append(field_value)
 
     if parts:
         return "\n".join(parts)
 
-    fallback = attachment.get("fallback", "")
-    return fallback
+    return attachment.get("fallback", "")
 
 
 def _extract_text_from_attachments(attachments: Sequence[Mapping[str, Any]]) -> str:
@@ -166,8 +165,8 @@ def _extract_text_from_attachments(attachments: Sequence[Mapping[str, Any]]) -> 
     for attachment in attachments:
         if not isinstance(attachment, dict):
             continue
-        attachment_text = _extract_attachment_text(attachment)
-        parts.append(attachment_text)
+        if attachment_text := _extract_attachment_text(attachment):
+            parts.append(attachment_text)
     return "\n".join(parts)
 
 
@@ -180,20 +179,21 @@ def build_thread_context(messages: Sequence[Mapping[str, Any]]) -> str:
     for msg in messages:
         user = msg.get("user", "unknown")
 
-        text = ""
-        blocks = msg.get("blocks")
-        if blocks:
-            text = _extract_text_from_blocks(blocks)
+        text_parts: list[str] = []
+        if blocks := msg.get("blocks"):
+            if block_text := _extract_text_from_blocks(blocks):
+                text_parts.append(block_text)
 
-        attachments = msg.get("attachments")
-        if attachments:
-            text += _extract_text_from_attachments(attachments)
+        if not text_parts and (top_level_text := msg.get("text", "")):
+            text_parts.append(top_level_text)
 
-        if not text:
-            text = msg.get("text", "")
+        if attachments := msg.get("attachments"):
+            if attachment_text := _extract_text_from_attachments(attachments):
+                text_parts.append(attachment_text)
 
-        if not text:
+        if not text_parts:
             continue
+        text = "\n".join(text_parts)
         parts.append(f"<@{user}>: {text}")
 
     return "\n".join(parts)

--- a/src/sentry/seer/entrypoints/slack/mention.py
+++ b/src/sentry/seer/entrypoints/slack/mention.py
@@ -116,6 +116,61 @@ def _extract_text_from_blocks(blocks: Sequence[Mapping[str, Any]]) -> str:
     return "\n".join(part for part in parts if part)
 
 
+def _extract_attachment_text(attachment: Mapping[str, Any]) -> str:
+    """Extract readable text from a single legacy/secondary message attachment.
+
+    Slack attachments may either be modern (containing a nested ``blocks``
+    array) or legacy (using fields like ``pretext``/``title``/``text``/
+    ``fields``). See:
+    https://docs.slack.dev/legacy/legacy-messaging/legacy-secondary-message-attachments/
+    """
+    # Attachments may have blocks inside them, if so, it's not using the legacy attachments
+    blocks = attachment.get("blocks")
+    if blocks:
+        block_text = _extract_text_from_blocks(blocks)
+        if block_text:
+            return block_text
+
+    parts: list[str] = []
+
+    pretext = attachment.get("pretext", "")
+    parts.append(pretext)
+
+    title = attachment.get("title", "")
+    title_link = attachment.get("title_link")
+    parts.append(f"<{title_link}|{title}>" if title_link else title)
+
+    text = attachment.get("text", "")
+    parts.append(text)
+
+    for field in attachment.get("fields", []):
+        if not isinstance(field, dict):
+            continue
+        field_title = field.get("title", "")
+        field_value = field.get("value", "")
+        if field_title and field_value:
+            parts.append(f"{field_title}: {field_value}")
+        else:
+            parts.append(field_value)
+
+    if parts:
+        return "\n".join(parts)
+
+    fallback = attachment.get("fallback", "")
+    return fallback
+
+
+def _extract_text_from_attachments(attachments: Sequence[Mapping[str, Any]]) -> str:
+    """Extract readable text from a list of legacy/secondary attachments."""
+    parts: list[str] = []
+    for attachment in attachments:
+        if not isinstance(attachment, dict):
+            continue
+        attachment_text = _extract_attachment_text(attachment)
+        parts.append(attachment_text)
+    return "\n".join(parts)
+
+
 def build_thread_context(messages: Sequence[Mapping[str, Any]]) -> str:
     """Build a context string from thread history for Seer Agent."""
     if not messages:
@@ -129,6 +184,10 @@ def build_thread_context(messages: Sequence[Mapping[str, Any]]) -> str:
         blocks = msg.get("blocks")
         if blocks:
             text = _extract_text_from_blocks(blocks)
+
+        attachments = msg.get("attachments")
+        if attachments:
+            text += _extract_text_from_attachments(attachments)
 
         if not text:
             text = msg.get("text", "")

--- a/tests/sentry/seer/entrypoints/slack/test_mention.py
+++ b/tests/sentry/seer/entrypoints/slack/test_mention.py
@@ -13,7 +13,9 @@ from slack_sdk.models.blocks.block_elements import RichTextElementParts, RichTex
 
 from sentry.seer.entrypoints.slack.mention import (
     IssueLink,
+    _extract_attachment_text,
     _extract_block_text,
+    _extract_text_from_attachments,
     _extract_text_from_blocks,
     build_thread_context,
     extract_issue_links,
@@ -381,3 +383,133 @@ class BuildThreadContextTest(TestCase):
         ]
         result = build_thread_context(messages)
         assert result == "<@UBOT>: Here is the Seer analysis..."
+
+    def test_extracts_attachments_when_no_blocks_or_text(self):
+        messages = [
+            {
+                "user": "UBOT",
+                "attachments": [
+                    {
+                        "title": "ValueError: invalid input",
+                        "title_link": "https://sentry.io/organizations/test-org/issues/456/",
+                        "text": "invalid literal for int()",
+                    }
+                ],
+                "ts": "1234567890.000001",
+            }
+        ]
+        result = build_thread_context(messages)
+        assert "<@UBOT>:" in result
+        assert (
+            "<https://sentry.io/organizations/test-org/issues/456/|ValueError: invalid input>"
+            in result
+        )
+        assert "invalid literal for int()" in result
+
+    def test_includes_both_top_level_text_and_attachments(self):
+        messages = [
+            {
+                "user": "U123",
+                "text": "top level message",
+                "attachments": [{"text": "attachment body"}],
+                "ts": "1234567890.000001",
+            }
+        ]
+        result = build_thread_context(messages)
+        assert "<@U123>:" in result
+        assert "top level message" in result
+        assert "attachment body" in result
+
+    def test_extracts_attachments_when_text_empty(self):
+        messages = [
+            {
+                "user": "UBOT",
+                "text": "",
+                "attachments": [{"text": "attachment body"}],
+                "ts": "1234567890.000001",
+            }
+        ]
+        result = build_thread_context(messages)
+        assert result == "<@UBOT>: attachment body"
+
+
+class ExtractAttachmentTextTest(TestCase):
+    def test_legacy_attachment_with_title_and_text(self):
+        attachment = {
+            "title": "ValueError: invalid input",
+            "title_link": "https://sentry.io/organizations/test-org/issues/456/",
+            "text": "invalid literal for int()",
+        }
+        result = _extract_attachment_text(attachment)
+        assert (
+            "<https://sentry.io/organizations/test-org/issues/456/|ValueError: invalid input>"
+            in result
+        )
+        assert "invalid literal for int()" in result
+
+    def test_legacy_attachment_title_without_link(self):
+        attachment = {"title": "Just a title", "text": "body"}
+        result = _extract_attachment_text(attachment)
+        assert result == "Just a title\nbody"
+
+    def test_legacy_attachment_with_pretext(self):
+        attachment = {"pretext": "Heads up:", "text": "something happened"}
+        result = _extract_attachment_text(attachment)
+        assert result == "Heads up:\nsomething happened"
+
+    def test_legacy_attachment_with_fields(self):
+        attachment = {
+            "title": "Alert fired",
+            "fields": [
+                {"title": "Project", "value": "backend", "short": True},
+                {"title": "Environment", "value": "prod", "short": True},
+            ],
+        }
+        result = _extract_attachment_text(attachment)
+        assert "Alert fired" in result
+        assert "Project: backend" in result
+        assert "Environment: prod" in result
+
+    def test_legacy_attachment_field_value_only(self):
+        attachment = {"fields": [{"value": "no title here"}]}
+        assert _extract_attachment_text(attachment) == "no title here"
+
+    def test_attachment_with_blocks_prefers_blocks(self):
+        attachment = {
+            "fallback": "should not be used",
+            "text": "should not be used",
+            "blocks": [SectionBlock(text="block content").to_dict()],
+        }
+        assert _extract_attachment_text(attachment) == "block content"
+
+    def test_attachment_falls_back_to_fallback_field(self):
+        attachment = {"fallback": "Sentry alert: ValueError in backend"}
+        assert _extract_attachment_text(attachment) == "Sentry alert: ValueError in backend"
+
+    def test_attachment_skips_fallback_when_other_fields_present(self):
+        attachment = {"text": "main body", "fallback": "ignored"}
+        assert _extract_attachment_text(attachment) == "main body"
+
+    def test_empty_attachment(self):
+        assert _extract_attachment_text({}) == ""
+
+
+class ExtractTextFromAttachmentsTest(TestCase):
+    def test_multiple_attachments_joined(self):
+        attachments: list[Mapping[str, Any]] = [
+            {"text": "first"},
+            {"text": "second"},
+        ]
+        assert _extract_text_from_attachments(attachments) == "first\nsecond"
+
+    def test_skips_empty_attachments(self):
+        attachments: list[Mapping[str, Any]] = [
+            {"text": "first"},
+            {},
+            {"text": "second"},
+        ]
+        assert _extract_text_from_attachments(attachments) == "first\nsecond"
+
+    def test_skips_non_dict_entries(self):
+        attachments: list[Any] = [{"text": "first"}, "not-a-dict", {"text": "second"}]
+        assert _extract_text_from_attachments(attachments) == "first\nsecond"


### PR DESCRIPTION
we only parsed the message portion of the thread messages. some bots send messages with [legacy attachments](https://docs.slack.dev/legacy/legacy-messaging/legacy-secondary-message-attachments/).

there could be important context in there as it can contain rich text. this pr lets us parse the legacy attachments and pass it into seer agent.

an example of a legacy attachment:

<img width="1680" height="650" alt="image" src="https://github.com/user-attachments/assets/fc1f7816-b6a9-4d05-a4e5-7483a883b71c" />
