### PR TITLE
ref(seer): Remove enableSeerEnhancedAlerts org preference

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -41,7 +41,6 @@ from sentry.constants import (
     DEFAULT_CODE_REVIEW_TRIGGERS,
     DEFAULT_SEER_SCANNER_AUTOMATION_DEFAULT,
     ENABLE_SEER_CODING_DEFAULT,
-    ENABLE_SEER_ENHANCED_ALERTS_DEFAULT,
     ENABLED_CONSOLE_PLATFORMS_DEFAULT,
     EVENTS_MEMBER_ADMIN_DEFAULT,
     GITHUB_COMMENT_BOT_DEFAULT,
@@ -611,7 +610,6 @@ class OrganizationSerializerResponse(_OrganizationSerializerResponseOptional):
     streamlineOnly: bool
     defaultAutofixAutomationTuning: str
     defaultSeerScannerAutomation: bool
-    enableSeerEnhancedAlerts: bool
     enableSeerCoding: bool
     defaultCodingAgent: str
     defaultCodingAgentIntegrationId: str | None
@@ -845,12 +843,6 @@ class OrganizationSerializer(OrganizationSummarySerializer):
             "defaultSeerScannerAutomation": obj.get_option(
                 "sentry:default_seer_scanner_automation",
                 DEFAULT_SEER_SCANNER_AUTOMATION_DEFAULT,
-            ),
-            "enableSeerEnhancedAlerts": bool(
-                obj.get_option(
-                    "sentry:enable_seer_enhanced_alerts",
-                    ENABLE_SEER_ENHANCED_ALERTS_DEFAULT,
-                )
             ),
             "enableSeerCoding": bool(
                 obj.get_option(

--- a/src/sentry/apidocs/examples/organization_examples.py
+++ b/src/sentry/apidocs/examples/organization_examples.py
@@ -302,7 +302,6 @@ class OrganizationExamples:
                 ],
                 "defaultSeerScannerAutomation": True,
                 "enableSeerCoding": True,
-                "enableSeerEnhancedAlerts": True,
                 "autoOpenPrs": False,
                 "defaultCodingAgent": "seer",
                 "defaultCodingAgentIntegrationId": None,

--- a/src/sentry/constants.py
+++ b/src/sentry/constants.py
@@ -718,7 +718,6 @@ SAMPLING_MODE_DEFAULT = "organization"
 ROLLBACK_ENABLED_DEFAULT = True
 AUTOFIX_AUTOMATION_TUNING_DEFAULT = AutofixAutomationTuningSettings.OFF
 DEFAULT_SEER_SCANNER_AUTOMATION_DEFAULT = True
-ENABLE_SEER_ENHANCED_ALERTS_DEFAULT = True
 ENABLE_SEER_CODING_DEFAULT = True
 # Seer Org level default for automated_run_stopping_point in project preferences
 AUTO_OPEN_PRS_DEFAULT = False

--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -53,7 +53,6 @@ from sentry.constants import (
     DEFAULT_CODE_REVIEW_TRIGGERS,
     DEFAULT_SEER_SCANNER_AUTOMATION_DEFAULT,
     ENABLE_SEER_CODING_DEFAULT,
-    ENABLE_SEER_ENHANCED_ALERTS_DEFAULT,
     ENABLED_CONSOLE_PLATFORMS_DEFAULT,
     EVENTS_MEMBER_ADMIN_DEFAULT,
     GITHUB_COMMENT_BOT_DEFAULT,
@@ -278,12 +277,6 @@ ORG_OPTIONS = (
         DEFAULT_SEER_SCANNER_AUTOMATION_DEFAULT,
     ),
     (
-        "enableSeerEnhancedAlerts",
-        "sentry:enable_seer_enhanced_alerts",
-        bool,
-        ENABLE_SEER_ENHANCED_ALERTS_DEFAULT,
-    ),
-    (
         "enableSeerCoding",
         "sentry:enable_seer_coding",
         bool,
@@ -422,7 +415,6 @@ class OrganizationSerializer(BaseOrganizationSerializer):
     )
     consoleSdkInviteQuota = serializers.IntegerField(required=False, min_value=0)
     dashboardsAsyncQueueParallelLimit = serializers.IntegerField(required=False, min_value=1)
-    enableSeerEnhancedAlerts = serializers.BooleanField(required=False)
     enableSeerCoding = serializers.BooleanField(required=False)
     defaultCodingAgent = serializers.ChoiceField(
         choices=["seer", "cursor", "claude_code", "cursor_background_agent", "claude_code_agent"],

--- a/src/sentry/integrations/utils/issue_summary_for_alerts.py
+++ b/src/sentry/integrations/utils/issue_summary_for_alerts.py
@@ -29,8 +29,6 @@ def fetch_issue_summary(group: Group) -> dict[str, Any] | None:
         return None
     if group.organization.get_option("sentry:hide_ai_features"):
         return None
-    if not group.organization.get_option("sentry:enable_seer_enhanced_alerts", default=True):
-        return None
 
     from sentry import quotas
     from sentry.constants import DataCategory

--- a/src/sentry/seer/entrypoints/slack/entrypoint.py
+++ b/src/sentry/seer/entrypoints/slack/entrypoint.py
@@ -4,7 +4,7 @@ import logging
 from typing import TYPE_CHECKING, Any, TypedDict
 
 from sentry import features
-from sentry.constants import ENABLE_SEER_ENHANCED_ALERTS_DEFAULT, ObjectStatus
+from sentry.constants import ObjectStatus
 from sentry.integrations.services.integration.service import integration_service
 from sentry.locks import locks
 from sentry.models.organization import Organization
@@ -168,14 +168,7 @@ class SlackAutofixEntrypoint(
 
     @staticmethod
     def has_access(organization: Organization) -> bool:
-        has_feature_flag = features.has("organizations:seer-slack-workflows", organization)
-        has_enhanced_alerts = bool(
-            organization.get_option(
-                "sentry:enable_seer_enhanced_alerts",
-                default=ENABLE_SEER_ENHANCED_ALERTS_DEFAULT,
-            )
-        )
-        return has_feature_flag and has_enhanced_alerts
+        return features.has("organizations:seer-slack-workflows", organization)
 
     @staticmethod
     def get_group_link(group: Group) -> str:

--- a/tests/sentry/core/endpoints/test_organization_details.py
+++ b/tests/sentry/core/endpoints/test_organization_details.py
@@ -1640,25 +1640,6 @@ class OrganizationUpdateTest(OrganizationDetailsTestBase):
 
         mock_cleanup_task.assert_called_once_with(self.organization.id, [])
 
-    def test_enable_seer_enhanced_alerts_default_true(self) -> None:
-        response = self.get_success_response(self.organization.slug)
-        assert response.data["enableSeerEnhancedAlerts"] is True
-
-    def test_enable_seer_enhanced_alerts_can_be_disabled(self) -> None:
-        data = {"enableSeerEnhancedAlerts": False}
-        self.get_success_response(self.organization.slug, **data)
-
-        assert self.organization.get_option("sentry:enable_seer_enhanced_alerts") is False
-
-    def test_enable_seer_enhanced_alerts_can_be_enabled(self) -> None:
-        # First disable it
-        self.organization.update_option("sentry:enable_seer_enhanced_alerts", False)
-
-        data = {"enableSeerEnhancedAlerts": True}
-        self.get_success_response(self.organization.slug, **data)
-
-        assert self.organization.get_option("sentry:enable_seer_enhanced_alerts") is True
-
     def test_enable_seer_coding_default_true(self) -> None:
         response = self.get_success_response(self.organization.slug)
         assert response.data["enableSeerCoding"] is True

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -904,7 +904,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         self.project.flags.has_releases = True
         self.project.save(update_fields=["flags"])
         self.project.update_option("sentry:seer_scanner_automation", True)
-        self.organization.update_option("sentry:enable_seer_enhanced_alerts", True)
 
         mock_summary = {
             "headline": "Custom AI Title",
@@ -1009,7 +1008,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         self.project.flags.has_releases = True
         self.project.save(update_fields=["flags"])
         self.project.update_option("sentry:seer_scanner_automation", True)
-        self.organization.update_option("sentry:enable_seer_enhanced_alerts", True)
 
         mock_summary = {
             "headline": "Custom AI Title",
@@ -1104,7 +1102,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         }
     )
     def test_autofix_button_shown_when_all_conditions_met(self, mock_quota: MagicMock) -> None:
-        self.organization.update_option("sentry:enable_seer_enhanced_alerts", True)
         group = self.create_group(project=self.project)
         blocks = SlackIssuesMessageBuilder(group).build()
         assert self._has_autofix_button(blocks)
@@ -1119,22 +1116,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
     def test_autofix_button_hidden_without_slack_workflows_flag(
         self, mock_quota: MagicMock
     ) -> None:
-        self.organization.update_option("sentry:enable_seer_enhanced_alerts", True)
-        group = self.create_group(project=self.project)
-        blocks = SlackIssuesMessageBuilder(group).build()
-        assert not self._has_autofix_button(blocks)
-
-    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
-    @with_feature(
-        {
-            "organizations:gen-ai-features": True,
-            "organizations:seer-slack-workflows": True,
-        }
-    )
-    def test_autofix_button_hidden_without_enhanced_alerts_option(
-        self, mock_quota: MagicMock
-    ) -> None:
-        self.organization.update_option("sentry:enable_seer_enhanced_alerts", False)
         group = self.create_group(project=self.project)
         blocks = SlackIssuesMessageBuilder(group).build()
         assert not self._has_autofix_button(blocks)
@@ -1147,7 +1128,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         }
     )
     def test_autofix_button_hidden_on_unfurl(self, mock_quota: MagicMock) -> None:
-        self.organization.update_option("sentry:enable_seer_enhanced_alerts", True)
         group = self.create_group(project=self.project)
         blocks = SlackIssuesMessageBuilder(group, is_unfurl=True).build()
         assert not self._has_autofix_button(blocks)
@@ -1160,7 +1140,6 @@ class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTes
         }
     )
     def test_autofix_button_hidden_when_no_other_actions(self, mock_quota: MagicMock) -> None:
-        self.organization.update_option("sentry:enable_seer_enhanced_alerts", True)
         group = self.create_group(project=self.project)
         blocks = SlackIssuesMessageBuilder(group, issue_details=True).build()
         assert not self._has_autofix_button(blocks)

--- a/tests/sentry/integrations/utils/test_issue_summary_for_alerts.py
+++ b/tests/sentry/integrations/utils/test_issue_summary_for_alerts.py
@@ -57,7 +57,6 @@ class FetchIssueSummaryTest(TestCase):
         # Set up all the required conditions to pass
         self.project.update_option("sentry:seer_scanner_automation", True)
         self.organization.update_option("sentry:hide_ai_features", False)
-        self.organization.update_option("sentry:enable_seer_enhanced_alerts", True)
         mock_rate_limited.return_value = False
         mock_has_budget.return_value = True
 
@@ -84,23 +83,6 @@ class FetchIssueSummaryTest(TestCase):
         result = fetch_issue_summary(self.group)
 
         assert result is None
-
-    @with_feature("organizations:gen-ai-features")
-    @patch("sentry.quotas.backend.check_seer_quota")
-    def test_fetch_issue_summary_without_enable_seer_enhanced_alerts(
-        self, mock_has_budget: MagicMock
-    ) -> None:
-        """Test that fetch_issue_summary returns None when enable_seer_enhanced_alerts is disabled"""
-        # Set up all the required conditions to pass except enable_seer_enhanced_alerts
-        self.project.update_option("sentry:seer_scanner_automation", True)
-        self.organization.update_option("sentry:hide_ai_features", False)
-        self.organization.update_option("sentry:enable_seer_enhanced_alerts", False)
-
-        result = fetch_issue_summary(self.group)
-
-        assert result is None
-        # Verify that budget check wasn't called since we returned early
-        mock_has_budget.assert_not_called()
 
     def test_fetch_issue_summary_without_gen_ai_features(self) -> None:
         """Test that fetch_issue_summary returns None without gen-ai-features flag"""

--- a/tests/sentry/seer/entrypoints/slack/test_slack.py
+++ b/tests/sentry/seer/entrypoints/slack/test_slack.py
@@ -80,10 +80,6 @@ class SlackAutofixEntrypointTest(TestCase):
             assert not SlackAutofixEntrypoint.has_access(self.organization)
         with self.feature("organizations:seer-slack-workflows"):
             assert SlackAutofixEntrypoint.has_access(self.organization)
-            self.organization.update_option("sentry:enable_seer_enhanced_alerts", False)
-            assert not SlackAutofixEntrypoint.has_access(self.organization)
-            self.organization.update_option("sentry:enable_seer_enhanced_alerts", True)
-            assert SlackAutofixEntrypoint.has_access(self.organization)
 
     @patch("sentry.integrations.slack.integration.SlackIntegration.send_threaded_ephemeral_message")
     def test_on_trigger_autofix_error(self, mock_send_threaded_ephemeral_message):


### PR DESCRIPTION
Removes the backend setting for Seer Enhanced Alerts from the API and checks.

Requires: https://github.com/getsentry/sentry/pull/114211
Follow up will remove the initial guess from notifications