### PR TITLE
feat(preprod): Add fail_on_changed and fail_on_renamed snapshot status check options

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -1208,6 +1208,12 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
             "sentry:preprod_snapshot_status_checks_fail_on_removed": options.get(
                 "sentry:preprod_snapshot_status_checks_fail_on_removed", True
             ),
+            "sentry:preprod_snapshot_status_checks_fail_on_changed": options.get(
+                "sentry:preprod_snapshot_status_checks_fail_on_changed", True
+            ),
+            "sentry:preprod_snapshot_status_checks_fail_on_renamed": options.get(
+                "sentry:preprod_snapshot_status_checks_fail_on_renamed", False
+            ),
             "quotas:spike-protection-disabled": options.get("quotas:spike-protection-disabled"),
             "sentry:preprod_size_enabled_query": options.get("sentry:preprod_size_enabled_query"),
             "sentry:preprod_distribution_enabled_query": options.get(

--- a/src/sentry/core/endpoints/project_details.py
+++ b/src/sentry/core/endpoints/project_details.py
@@ -115,6 +115,8 @@ class ProjectMemberSerializer(serializers.Serializer):
     preprodSnapshotStatusChecksEnabled = serializers.BooleanField(required=False)
     preprodSnapshotStatusChecksFailOnAdded = serializers.BooleanField(required=False)
     preprodSnapshotStatusChecksFailOnRemoved = serializers.BooleanField(required=False)
+    preprodSnapshotStatusChecksFailOnChanged = serializers.BooleanField(required=False)
+    preprodSnapshotStatusChecksFailOnRenamed = serializers.BooleanField(required=False)
     preprodSizeEnabledByCustomer = serializers.BooleanField(required=False, allow_null=True)
     preprodDistributionEnabledByCustomer = serializers.BooleanField(required=False, allow_null=True)
     preprodDistributionPrCommentsEnabledByCustomer = serializers.BooleanField(
@@ -170,6 +172,8 @@ class ProjectMemberSerializer(serializers.Serializer):
         "preprodSnapshotStatusChecksEnabled",
         "preprodSnapshotStatusChecksFailOnAdded",
         "preprodSnapshotStatusChecksFailOnRemoved",
+        "preprodSnapshotStatusChecksFailOnChanged",
+        "preprodSnapshotStatusChecksFailOnRenamed",
         "preprodDistributionPrCommentsEnabledByCustomer",
         "preprodSnapshotPrCommentsEnabled",
         "preprodSnapshotPrCommentsOnlyIfDiff",
@@ -894,6 +898,22 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
             ):
                 changed_proj_settings["sentry:preprod_snapshot_status_checks_fail_on_removed"] = (
                     result["preprodSnapshotStatusChecksFailOnRemoved"]
+                )
+        if result.get("preprodSnapshotStatusChecksFailOnChanged") is not None:
+            if project.update_option(
+                "sentry:preprod_snapshot_status_checks_fail_on_changed",
+                result["preprodSnapshotStatusChecksFailOnChanged"],
+            ):
+                changed_proj_settings["sentry:preprod_snapshot_status_checks_fail_on_changed"] = (
+                    result["preprodSnapshotStatusChecksFailOnChanged"]
+                )
+        if result.get("preprodSnapshotStatusChecksFailOnRenamed") is not None:
+            if project.update_option(
+                "sentry:preprod_snapshot_status_checks_fail_on_renamed",
+                result["preprodSnapshotStatusChecksFailOnRenamed"],
+            ):
+                changed_proj_settings["sentry:preprod_snapshot_status_checks_fail_on_renamed"] = (
+                    result["preprodSnapshotStatusChecksFailOnRenamed"]
                 )
         if "preprodDistributionPrCommentsEnabledByCustomer" in result:
             if project.update_option(

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -78,6 +78,8 @@ OPTION_KEYS = frozenset(
         "sentry:preprod_snapshot_status_checks_enabled",
         "sentry:preprod_snapshot_status_checks_fail_on_added",
         "sentry:preprod_snapshot_status_checks_fail_on_removed",
+        "sentry:preprod_snapshot_status_checks_fail_on_changed",
+        "sentry:preprod_snapshot_status_checks_fail_on_renamed",
         "sentry:preprod_distribution_pr_comments_enabled_by_customer",
         "sentry:preprod_snapshot_pr_comments_enabled",
         "sentry:preprod_snapshot_pr_comments_only_if_diff",

--- a/src/sentry/preprod/snapshots/utils.py
+++ b/src/sentry/preprod/snapshots/utils.py
@@ -69,10 +69,12 @@ def _comparison_has_changes(
     comparison: PreprodSnapshotComparison,
     fail_on_added: bool = False,
     fail_on_removed: bool = True,
+    fail_on_changed: bool = True,
+    fail_on_renamed: bool = False,
 ) -> bool:
     return (
-        comparison.images_changed > 0
-        or comparison.images_renamed > 0
+        (fail_on_changed and comparison.images_changed > 0)
+        or (fail_on_renamed and comparison.images_renamed > 0)
         or (fail_on_added and comparison.images_added > 0)
         or (fail_on_removed and comparison.images_removed > 0)
     )
@@ -84,6 +86,8 @@ def build_changes_map(
     comparisons_map: dict[int, PreprodSnapshotComparison],
     fail_on_added: bool = False,
     fail_on_removed: bool = True,
+    fail_on_changed: bool = True,
+    fail_on_renamed: bool = False,
 ) -> dict[int, bool]:
     changes_map: dict[int, bool] = {}
     for artifact in artifacts:
@@ -94,6 +98,10 @@ def build_changes_map(
         if not comparison or comparison.state != PreprodSnapshotComparison.State.SUCCESS:
             continue
         changes_map[artifact.id] = _comparison_has_changes(
-            comparison, fail_on_added, fail_on_removed
+            comparison,
+            fail_on_added=fail_on_added,
+            fail_on_removed=fail_on_removed,
+            fail_on_changed=fail_on_changed,
+            fail_on_renamed=fail_on_renamed,
         )
     return changes_map

--- a/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
@@ -39,6 +39,8 @@ APPROVE_SNAPSHOT_ACTION_IDENTIFIER = "approve_snapshots"
 ENABLED_OPTION_KEY = "sentry:preprod_snapshot_status_checks_enabled"
 FAIL_ON_ADDED_OPTION_KEY = "sentry:preprod_snapshot_status_checks_fail_on_added"
 FAIL_ON_REMOVED_OPTION_KEY = "sentry:preprod_snapshot_status_checks_fail_on_removed"
+FAIL_ON_CHANGED_OPTION_KEY = "sentry:preprod_snapshot_status_checks_fail_on_changed"
+FAIL_ON_RENAMED_OPTION_KEY = "sentry:preprod_snapshot_status_checks_fail_on_renamed"
 
 
 @instrumented_task(
@@ -107,6 +109,8 @@ def create_preprod_snapshot_status_check_task(
 
     fail_on_added = preprod_artifact.project.get_option(FAIL_ON_ADDED_OPTION_KEY, default=False)
     fail_on_removed = preprod_artifact.project.get_option(FAIL_ON_REMOVED_OPTION_KEY, default=True)
+    fail_on_changed = preprod_artifact.project.get_option(FAIL_ON_CHANGED_OPTION_KEY, default=True)
+    fail_on_renamed = preprod_artifact.project.get_option(FAIL_ON_RENAMED_OPTION_KEY, default=False)
 
     all_artifacts = list(preprod_artifact.get_sibling_artifacts_for_commit())
 
@@ -154,6 +158,8 @@ def create_preprod_snapshot_status_check_task(
             comparisons_map,
             fail_on_added=fail_on_added,
             fail_on_removed=fail_on_removed,
+            fail_on_changed=fail_on_changed,
+            fail_on_renamed=fail_on_renamed,
         )
         for artifact in all_artifacts:
             if changes_map.get(artifact.id, False) and artifact.id not in approvals_map:

--- a/tests/sentry/preprod/vcs/status_checks/snapshots/test_tasks.py
+++ b/tests/sentry/preprod/vcs/status_checks/snapshots/test_tasks.py
@@ -88,13 +88,27 @@ class ComputeSnapshotStatusTest(SnapshotTasksTestBase):
         artifact, metrics, _ = self._make_artifact_with_comparison(images_removed=3)
         assert self._status_with_changes_map(artifact, metrics) == StatusCheckStatus.FAILURE
 
-    def test_images_changed_always_fails(self):
+    def test_images_changed_fails_by_default(self):
         artifact, metrics, _ = self._make_artifact_with_comparison(images_changed=2)
         assert self._status_with_changes_map(artifact, metrics) == StatusCheckStatus.FAILURE
 
-    def test_images_renamed_always_fails(self):
+    def test_images_changed_ignored_when_flag_off(self):
+        artifact, metrics, _ = self._make_artifact_with_comparison(images_changed=2)
+        assert (
+            self._status_with_changes_map(artifact, metrics, fail_on_changed=False)
+            == StatusCheckStatus.SUCCESS
+        )
+
+    def test_images_renamed_ignored_by_default(self):
         artifact, metrics, _ = self._make_artifact_with_comparison(images_renamed=1)
-        assert self._status_with_changes_map(artifact, metrics) == StatusCheckStatus.FAILURE
+        assert self._status_with_changes_map(artifact, metrics) == StatusCheckStatus.SUCCESS
+
+    def test_images_renamed_fails_when_flag_on(self):
+        artifact, metrics, _ = self._make_artifact_with_comparison(images_renamed=1)
+        assert (
+            self._status_with_changes_map(artifact, metrics, fail_on_renamed=True)
+            == StatusCheckStatus.FAILURE
+        )
 
     def test_no_changes_succeeds(self):
         artifact, metrics, _ = self._make_artifact_with_comparison()
@@ -137,10 +151,37 @@ class BuildChangesMapTest(SnapshotTasksTestBase):
         )
         assert changes_map[artifact.id] is True
 
-    def test_changed_always_detected(self):
+    def test_changed_detected_by_default(self):
         artifact, metrics, _ = self._make_artifact_with_comparison(images_changed=2)
         changes_map = build_changes_map(
             [artifact], {artifact.id: metrics}, {metrics.id: _get_comparison(metrics)}
+        )
+        assert changes_map[artifact.id] is True
+
+    def test_changed_ignored_when_flag_off(self):
+        artifact, metrics, _ = self._make_artifact_with_comparison(images_changed=2)
+        changes_map = build_changes_map(
+            [artifact],
+            {artifact.id: metrics},
+            {metrics.id: _get_comparison(metrics)},
+            fail_on_changed=False,
+        )
+        assert not any(changes_map.values())
+
+    def test_renamed_ignored_by_default(self):
+        artifact, metrics, _ = self._make_artifact_with_comparison(images_renamed=1)
+        changes_map = build_changes_map(
+            [artifact], {artifact.id: metrics}, {metrics.id: _get_comparison(metrics)}
+        )
+        assert not any(changes_map.values())
+
+    def test_renamed_detected_when_flag_on(self):
+        artifact, metrics, _ = self._make_artifact_with_comparison(images_renamed=1)
+        changes_map = build_changes_map(
+            [artifact],
+            {artifact.id: metrics},
+            {metrics.id: _get_comparison(metrics)},
+            fail_on_renamed=True,
         )
         assert changes_map[artifact.id] is True
 


### PR DESCRIPTION
Adds two new project options that gate snapshot status check failures on the `changed` and `renamed` image categories, mirroring the existing `fail_on_added` / `fail_on_removed` plumbing end-to-end. `_comparison_has_changes` previously treated `images_changed > 0` and `images_renamed > 0` as unconditional failures; both are now driven by per-project options.

**New options**

- `sentry:preprod_snapshot_status_checks_fail_on_changed` — default `True` (preserves current behavior)
- `sentry:preprod_snapshot_status_checks_fail_on_renamed` — default `False` (behavior change: rename detection is noisy)

Projects relying on the prior always-fail-on-rename behavior will need to set `fail_on_renamed=true` explicitly to preserve it.

**Plumbing**

The two options are wired through the project_option allowlist, the project serializer (with the documented defaults), and the `project_details` PUT endpoint, so they can be read and written via the existing API path the same way `fail_on_added` / `fail_on_removed` already are.

**Out of scope**

- The PR-comments task (`src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py`) intentionally still calls `build_changes_map` without the new kwargs; it picks up the signature defaults, which match the option defaults.
- Frontend toggles in `useSnapshotStatusChecks` and the settings UI will follow in a separate PR.

Refs EME-1082