### PR TITLE
fix(ci): cap snuba bulk-query thread pool to 4 under per-worker Snuba

### DIFF
--- a/src/sentry/testutils/pytest/sentry.py
+++ b/src/sentry/testutils/pytest/sentry.py
@@ -143,6 +143,28 @@ def pytest_configure(config: pytest.Config) -> None:
 
     integrationdocs.DOC_FOLDER = os.path.join(TEST_ROOT, os.pardir, "fixtures", "integration-docs")
 
+    # Per-worker Snuba in CI runs against a single worker container with
+    # CrossOrgQueryAllocationPolicy capped at 4 concurrent queries on the errors
+    # storage. bulk_snuba_queries' default fan-out of 10 trips that policy and
+    # surfaces flakes (see e.g. tests calling bulk_snuba_queries with wide
+    # parallel batches). Cap the executor to 4 workers — but only the instance
+    # used by sentry.utils.snuba, leaving any other use of the executor
+    # unaffected. Production code is unmodified.
+    if os.environ.get("XDIST_PER_WORKER_SNUBA") == "1":
+        from sentry.utils import snuba as _snuba
+
+        _Original = _snuba.ContextPropagatingThreadPoolExecutor
+
+        from typing import Any
+
+        class _CappedExecutor(_Original):  # type: ignore[misc, valid-type]
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                requested = kwargs.get("max_workers") or 10
+                kwargs["max_workers"] = min(requested, 4)
+                super().__init__(*args, **kwargs)
+
+        _snuba.ContextPropagatingThreadPoolExecutor = _CappedExecutor
+
     configure_split_db()
 
     if os.environ.get("PYTEST_XDIST_WORKER"):

--- a/src/sentry/testutils/pytest/sentry.py
+++ b/src/sentry/testutils/pytest/sentry.py
@@ -10,7 +10,7 @@ import time
 from datetime import datetime
 from hashlib import sha256
 from pathlib import Path
-from typing import TypeVar
+from typing import Any, TypeVar
 from unittest import mock
 
 import pytest
@@ -143,24 +143,14 @@ def pytest_configure(config: pytest.Config) -> None:
 
     integrationdocs.DOC_FOLDER = os.path.join(TEST_ROOT, os.pardir, "fixtures", "integration-docs")
 
-    # Per-worker Snuba in CI runs against a single worker container with
-    # CrossOrgQueryAllocationPolicy capped at 4 concurrent queries on the errors
-    # storage. bulk_snuba_queries' default fan-out of 10 trips that policy and
-    # surfaces flakes (see e.g. tests calling bulk_snuba_queries with wide
-    # parallel batches). Cap the executor to 4 workers — but only the instance
-    # used by sentry.utils.snuba, leaving any other use of the executor
-    # unaffected. Production code is unmodified.
+    # Cap the snuba.py executor to 4 workers under per-worker Snuba — CrossOrgQueryAllocationPolicy
+    # rejects more than 4 concurrent queries per worker, which flakes wide bulk_snuba_queries calls.
     if os.environ.get("XDIST_PER_WORKER_SNUBA") == "1":
         from sentry.utils import snuba as _snuba
 
-        _Original = _snuba.ContextPropagatingThreadPoolExecutor
-
-        from typing import Any
-
-        class _CappedExecutor(_Original):  # type: ignore[misc, valid-type]
+        class _CappedExecutor(_snuba.ContextPropagatingThreadPoolExecutor):  # type: ignore[misc, valid-type]
             def __init__(self, *args: Any, **kwargs: Any) -> None:
-                requested = kwargs.get("max_workers") or 10
-                kwargs["max_workers"] = min(requested, 4)
+                kwargs["max_workers"] = min(kwargs.get("max_workers") or 10, 4)
                 super().__init__(*args, **kwargs)
 
         _snuba.ContextPropagatingThreadPoolExecutor = _CappedExecutor


### PR DESCRIPTION
We're seeing RateLimitExceeded flakes from CrossOrgQueryAllocationPolicy on the errors storage in CI when bulk_snuba_queries fans out wide (e.g. backfill_supergroups_lightweight). Per-worker Snuba enforces a rejection_threshold of 4 concurrent queries, but the executor in sentry.utils.snuba defaults to max_workers=10. Replacing the previous closed PR (#114105) which added a constant inside snuba.py — this version monkey-patches the executor as imported by sentry.utils.snuba from the pytest plugin only, so production code is untouched and the cap is scoped to that module's executor uses.