### PR TITLE
ref(experiments): Default useExperiment reportExposure to false

### DIFF
--- a/static/app/utils/useExperiment.spec.tsx
+++ b/static/app/utils/useExperiment.spec.tsx
@@ -5,7 +5,10 @@ import {render, screen} from 'sentry-test/reactTestingLibrary';
 import {useExperiment} from 'sentry/utils/useExperiment';
 
 function TestComponent({feature}: {feature: string}) {
-  const {inExperiment, experimentAssignment} = useExperiment({feature});
+  const {inExperiment, experimentAssignment} = useExperiment({
+    feature,
+    reportExposure: false,
+  });
   return (
     <div>
       <span data-test-id="in-experiment">{String(inExperiment)}</span>

--- a/static/app/utils/useExperiment.tsx
+++ b/static/app/utils/useExperiment.tsx
@@ -23,14 +23,15 @@ export interface UseExperimentOptions {
   feature: string;
   /**
    * Whether to report that the user has been exposed to this experiment.
-   * Defaults to false: the FE is the source of truth for exposure, so each
-   * call site must opt in at the point where the user is actually rendered
-   * one of the experiment variants.
+   * Required so every call site is intentional: pass true only where the
+   * user is actually rendered one of the experiment variants, and false
+   * elsewhere (e.g. shared components whose surrounding flow may render
+   * something other than a variant).
    *
    * This option is reactive: changing it from false to true will report
    * exposure at that point.
    */
-  reportExposure?: boolean;
+  reportExposure: boolean;
 }
 
 /**
@@ -54,16 +55,19 @@ function useNoopExperiment(options: UseExperimentOptions): UseExperimentResult {
  *
  * @param options.feature - The experiment key, matching the flagpole flag name
  *   without the "organizations:" prefix (e.g. "my-experiment").
- * @param options.reportExposure - Whether to log an exposure event. Defaults
- *   to false. Set to true at the call site where the user is actually
- *   rendered one of the experiment variants. Leave off when the consuming
- *   component may render something other than the control or active variant,
- *   since the user has not seen the experiment in that case.
+ * @param options.reportExposure - Whether to log an exposure event.
+ *   Required: pass true at the call site where the user is actually
+ *   rendered one of the experiment variants, and false when the consuming
+ *   component may render something other than the control or active variant
+ *   (the user has not seen the experiment in that case).
  *
  * @example
  * ```tsx
  * function MyComponent() {
- *   const {inExperiment} = useExperiment({feature: 'my-experiment'});
+ *   const {inExperiment} = useExperiment({
+ *     feature: 'my-experiment',
+ *     reportExposure: true,
+ *   });
  *   if (!inExperiment) return null;
  *   return <NewFeature />;
  * }

--- a/static/app/utils/useExperiment.tsx
+++ b/static/app/utils/useExperiment.tsx
@@ -23,12 +23,10 @@ export interface UseExperimentOptions {
   feature: string;
   /**
    * Whether to report that the user has been exposed to this experiment.
-   * Defaults to false. Set to true at the single call site that represents
-   * the user actually seeing the experiment so exposure is counted exactly
-   * once. The backend org serializer already auto-logs exposure for every
-   * experiment-mode flagpole flag, so this option exists mainly for the
-   * synchronous browser-side Amplitude group property write that needs to
-   * win the race against events fired on the same mount.
+   * Defaults to false: the FE is the source of truth for exposure, so each
+   * call site must opt in at the point that represents the user actually
+   * seeing the experiment. Reading the assignment for conditional logic or
+   * analytics tagging should leave this off so exposure isn't double-counted.
    *
    * This option is reactive: changing it from false to true will report
    * exposure at that point.
@@ -58,8 +56,9 @@ function useNoopExperiment(options: UseExperimentOptions): UseExperimentResult {
  * @param options.feature - The experiment key, matching the flagpole flag name
  *   without the "organizations:" prefix (e.g. "my-experiment").
  * @param options.reportExposure - Whether to log an exposure event. Defaults
- *   to false. Set to true at the single call site that represents the user
- *   actually seeing the experiment.
+ *   to false. Set to true at the call site that represents the user actually
+ *   seeing the experiment; leave off when reading the assignment for
+ *   conditional logic so exposure isn't double-counted.
  *
  * @example
  * ```tsx

--- a/static/app/utils/useExperiment.tsx
+++ b/static/app/utils/useExperiment.tsx
@@ -25,10 +25,7 @@ export interface UseExperimentOptions {
    * Whether to report that the user has been exposed to this experiment.
    * Defaults to false: the FE is the source of truth for exposure, so each
    * call site must opt in at the point where the user is actually rendered
-   * one of the experiment variants. The hook is often consumed by shared
-   * components whose surrounding flow may render something other than the
-   * control or active variant; in those cases the user has not seen the
-   * experiment and exposure should not be reported.
+   * one of the experiment variants.
    *
    * This option is reactive: changing it from false to true will report
    * exposure at that point.

--- a/static/app/utils/useExperiment.tsx
+++ b/static/app/utils/useExperiment.tsx
@@ -24,9 +24,11 @@ export interface UseExperimentOptions {
   /**
    * Whether to report that the user has been exposed to this experiment.
    * Defaults to false: the FE is the source of truth for exposure, so each
-   * call site must opt in at the point that represents the user actually
-   * seeing the experiment. Reading the assignment for conditional logic or
-   * analytics tagging should leave this off so exposure isn't double-counted.
+   * call site must opt in at the point where the user is actually rendered
+   * one of the experiment variants. The hook is often consumed by shared
+   * components whose surrounding flow may render something other than the
+   * control or active variant; in those cases the user has not seen the
+   * experiment and exposure should not be reported.
    *
    * This option is reactive: changing it from false to true will report
    * exposure at that point.
@@ -56,9 +58,10 @@ function useNoopExperiment(options: UseExperimentOptions): UseExperimentResult {
  * @param options.feature - The experiment key, matching the flagpole flag name
  *   without the "organizations:" prefix (e.g. "my-experiment").
  * @param options.reportExposure - Whether to log an exposure event. Defaults
- *   to false. Set to true at the call site that represents the user actually
- *   seeing the experiment; leave off when reading the assignment for
- *   conditional logic so exposure isn't double-counted.
+ *   to false. Set to true at the call site where the user is actually
+ *   rendered one of the experiment variants. Leave off when the consuming
+ *   component may render something other than the control or active variant,
+ *   since the user has not seen the experiment in that case.
  *
  * @example
  * ```tsx

--- a/static/app/utils/useExperiment.tsx
+++ b/static/app/utils/useExperiment.tsx
@@ -23,10 +23,12 @@ export interface UseExperimentOptions {
   feature: string;
   /**
    * Whether to report that the user has been exposed to this experiment.
-   * When true (the default), the hook will fire an exposure event on mount,
-   * recording that the user has "seen" the experiment. Set to false when you
-   * need to check the assignment without triggering exposure — for example,
-   * to conditionally render a feature only if other criteria are also met.
+   * Defaults to false. Set to true at the single call site that represents
+   * the user actually seeing the experiment so exposure is counted exactly
+   * once. The backend org serializer already auto-logs exposure for every
+   * experiment-mode flagpole flag, so this option exists mainly for the
+   * synchronous browser-side Amplitude group property write that needs to
+   * win the race against events fired on the same mount.
    *
    * This option is reactive: changing it from false to true will report
    * exposure at that point.
@@ -56,7 +58,8 @@ function useNoopExperiment(options: UseExperimentOptions): UseExperimentResult {
  * @param options.feature - The experiment key, matching the flagpole flag name
  *   without the "organizations:" prefix (e.g. "my-experiment").
  * @param options.reportExposure - Whether to log an exposure event. Defaults
- *   to true. Set to false to check the assignment without exposing the user.
+ *   to false. Set to true at the single call site that represents the user
+ *   actually seeing the experiment.
  *
  * @example
  * ```tsx

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -183,6 +183,7 @@ export function OnboardingWithoutContext() {
   const hasNewWelcomeUI = useHasNewWelcomeUI();
   const {inExperiment: hasScmOnboarding} = useExperiment({
     feature: 'onboarding-scm-experiment',
+    reportExposure: true,
   });
 
   // Only report exposure for users who are actually in SCM onboarding —

--- a/static/app/views/onboarding/useWelcomeAnalyticsEffect.ts
+++ b/static/app/views/onboarding/useWelcomeAnalyticsEffect.ts
@@ -11,6 +11,7 @@ export function useWelcomeAnalyticsEffect() {
   const onboardingContext = useOnboardingContext();
   const {inExperiment: hasScmOnboarding} = useExperiment({
     feature: 'onboarding-scm-experiment',
+    reportExposure: false,
   });
 
   useEffect(() => {

--- a/static/app/views/onboarding/useWelcomeHandleComplete.ts
+++ b/static/app/views/onboarding/useWelcomeHandleComplete.ts
@@ -11,6 +11,7 @@ export function useWelcomeHandleComplete(onComplete: StepProps['onComplete']) {
   const organization = useOrganization();
   const {inExperiment: hasScmOnboarding} = useExperiment({
     feature: 'onboarding-scm-experiment',
+    reportExposure: false,
   });
 
   return useCallback(() => {

--- a/static/gsApp/hooks/useExperiment.spec.tsx
+++ b/static/gsApp/hooks/useExperiment.spec.tsx
@@ -12,7 +12,7 @@ function TestComponent({
   reportExposure,
 }: {
   feature: string;
-  reportExposure?: boolean;
+  reportExposure: boolean;
 }) {
   const {inExperiment, experimentAssignment} = useExperiment({
     feature,

--- a/static/gsApp/hooks/useExperiment.spec.tsx
+++ b/static/gsApp/hooks/useExperiment.spec.tsx
@@ -9,7 +9,7 @@ import {_resetExposureTracking, useExperiment} from 'getsentry/hooks/useExperime
 
 function TestComponent({
   feature,
-  reportExposure,
+  reportExposure = true,
 }: {
   feature: string;
   reportExposure?: boolean;

--- a/static/gsApp/hooks/useExperiment.spec.tsx
+++ b/static/gsApp/hooks/useExperiment.spec.tsx
@@ -9,7 +9,7 @@ import {_resetExposureTracking, useExperiment} from 'getsentry/hooks/useExperime
 
 function TestComponent({
   feature,
-  reportExposure = true,
+  reportExposure,
 }: {
   feature: string;
   reportExposure?: boolean;
@@ -86,7 +86,9 @@ describe('useExperiment (gsApp)', () => {
       statusCode: 204,
     });
 
-    render(<TestComponent feature="test-experiment" />, {organization: org});
+    render(<TestComponent feature="test-experiment" reportExposure />, {
+      organization: org,
+    });
 
     await waitFor(() => {
       expect(mockExposure).toHaveBeenCalledWith(
@@ -110,7 +112,9 @@ describe('useExperiment (gsApp)', () => {
       statusCode: 204,
     });
 
-    render(<TestComponent feature="onboarding-scm-experiment" />, {organization: org});
+    render(<TestComponent feature="onboarding-scm-experiment" reportExposure />, {
+      organization: org,
+    });
 
     await waitFor(() => expect(Amplitude.groupIdentify).toHaveBeenCalled());
 
@@ -160,7 +164,9 @@ describe('useExperiment (gsApp)', () => {
       statusCode: 204,
     });
 
-    render(<TestComponent feature="test-experiment" />, {organization: org});
+    render(<TestComponent feature="test-experiment" reportExposure />, {
+      organization: org,
+    });
 
     expect(Amplitude.groupIdentify).not.toHaveBeenCalled();
   });
@@ -180,7 +186,9 @@ describe('useExperiment (gsApp)', () => {
       statusCode: 204,
     });
 
-    render(<TestComponent feature="not-an-experiment" />, {organization: org});
+    render(<TestComponent feature="not-an-experiment" reportExposure />, {
+      organization: org,
+    });
 
     expect(Amplitude.groupIdentify).not.toHaveBeenCalled();
     expect(mockExposure).not.toHaveBeenCalled();
@@ -241,7 +249,7 @@ describe('useExperiment (gsApp)', () => {
       statusCode: 204,
     });
 
-    const {unmount} = render(<TestComponent feature="test-experiment" />, {
+    const {unmount} = render(<TestComponent feature="test-experiment" reportExposure />, {
       organization: org,
     });
 
@@ -251,7 +259,9 @@ describe('useExperiment (gsApp)', () => {
 
     unmount();
 
-    render(<TestComponent feature="test-experiment" />, {organization: org});
+    render(<TestComponent feature="test-experiment" reportExposure />, {
+      organization: org,
+    });
 
     expect(mockExposure).toHaveBeenCalledTimes(1);
   });
@@ -266,7 +276,7 @@ describe('useExperiment (gsApp)', () => {
       statusCode: 204,
     });
 
-    const {unmount} = render(<TestComponent feature="test-experiment" />, {
+    const {unmount} = render(<TestComponent feature="test-experiment" reportExposure />, {
       organization: org,
     });
 
@@ -279,7 +289,7 @@ describe('useExperiment (gsApp)', () => {
       experiments: {'test-experiment': 'active'},
     });
 
-    render(<TestComponent feature="test-experiment" />, {
+    render(<TestComponent feature="test-experiment" reportExposure />, {
       organization: updatedOrg,
     });
 

--- a/static/gsApp/hooks/useExperiment.tsx
+++ b/static/gsApp/hooks/useExperiment.tsx
@@ -48,7 +48,7 @@ export function _resetExposureTracking() {
 }
 
 export function useExperiment(options: UseExperimentOptions): UseExperimentResult {
-  const {feature, reportExposure = false} = options;
+  const {feature, reportExposure} = options;
   const organization = useOrganization();
 
   // Gate on organization.features so that SENTRY_FEATURES, self.feature(),

--- a/static/gsApp/hooks/useExperiment.tsx
+++ b/static/gsApp/hooks/useExperiment.tsx
@@ -48,7 +48,7 @@ export function _resetExposureTracking() {
 }
 
 export function useExperiment(options: UseExperimentOptions): UseExperimentResult {
-  const {feature, reportExposure = true} = options;
+  const {feature, reportExposure = false} = options;
   const organization = useOrganization();
 
   // Gate on organization.features so that SENTRY_FEATURES, self.feature(),


### PR DESCRIPTION
## TL;DR
Flip `useExperiment`'s `reportExposure` default from `true` to `false`. Pairs with an upcoming BE change that stops the org serializer from auto-logging exposure on every page load. With BE auto-logging gone, the FE becomes the source of truth, so call sites have to be intentional about whether the user is actually being rendered one of the experiment variants.

## Why a true default is wrong now
`useExperiment` can be consumed inside shared components whose surrounding flow can render something other than the control or active variant. When that happens the user has not seen the experiment, but a default-true call site logs them as exposed anyway. Flipping to `false` makes the opt-in visible at the call site, so exposure is only recorded where a variant is actually rendered.

## Effect on `onboarding-scm-experiment`
- `onboarding.tsx:184` opts in with `reportExposure: true`. Single point that fires the FE exposure POST and the synchronous browser `Amplitude.groupIdentify` for the parent SCM experiment.
- `useWelcomeAnalyticsEffect` and `useWelcomeHandleComplete` previously relied on the default and now fall through to `false`. Both run in flows where the user may not have rendered either variant.
- `onboarding.tsx:190` (`onboarding-scm-project-details-experiment`) keeps its `reportExposure: hasScmOnboarding` gate and is unchanged.