### PR TITLE
fix(autofix): Poll autofix state slower

### DIFF
--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -144,8 +144,7 @@ interface ExplorerAutofixResponse {
   autofix: ExplorerAutofixState | null;
 }
 
-const POLL_INTERVAL = 500;
-const IDLE_POLL_INTERVAL = 2500; // Slower polling when not actively processing
+const POLL_INTERVAL = 1000;
 
 function explorerAutofixApiOptions(orgSlug: string, groupId: string) {
   return apiOptions.as<ExplorerAutofixResponse>()(
@@ -197,10 +196,17 @@ const isActivelyProcessing = (
     state => state.pr_creation_status === 'creating'
   );
 
+  const anyCodingAgentsRunning = Object.values(autofixState.coding_agents ?? {}).some(
+    codingAgent =>
+      codingAgent.status === CodingAgentStatus.PENDING ||
+      codingAgent.status === CodingAgentStatus.RUNNING
+  );
+
   return (
     autofixState.status === 'processing' ||
     autofixState.blocks.some(block => block.loading) ||
-    anyPRCreating
+    anyPRCreating ||
+    anyCodingAgentsRunning
   );
 };
 
@@ -212,19 +218,9 @@ const getPollInterval = (
   autofixState: ExplorerAutofixState | null,
   runStarted: boolean
 ): number | false => {
-  // No run and nothing started - don't poll
-  if (!autofixState && !runStarted) {
-    return false;
-  }
-
   // Actively processing - poll fast
   if (isActivelyProcessing(autofixState, runStarted)) {
     return POLL_INTERVAL;
-  }
-
-  // Has a run but not actively processing - poll slow to catch external updates
-  if (autofixState) {
-    return IDLE_POLL_INTERVAL;
   }
 
   return false;


### PR DESCRIPTION
Autofix state is polled at 500ms intervals when actively processing and 2500ms intervals when not actively processing. This is excessive. This change reduces the poll interval to 1000ms intervals when actively processing and not poll when not actively processing. This does come at the cost of not getting external updates like from slack and such but saves on a lot of unnecessary api calls when users are just viewing issues.