### PR TITLE
feat(seer): Trigger explorer index if missing

### DIFF
--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -6,6 +6,7 @@ import time
 from datetime import datetime
 from typing import Any, Literal, overload
 
+import sentry_sdk
 from django.contrib.auth.models import AnonymousUser
 from django.utils import timezone as django_timezone
 from pydantic import BaseModel
@@ -37,6 +38,7 @@ from sentry.seer.explorer.on_completion_hook import (
 from sentry.seer.models import SeerApiError, SeerPermissionError, SeerRepoDefinition
 from sentry.seer.seer_setup import has_seer_access_with_detail
 from sentry.seer.signed_seer_api import SeerViewerContext
+from sentry.tasks.seer.context_engine_index import build_service_map, index_org_project_knowledge
 from sentry.tasks.seer.explorer_index import dispatch_explorer_index_projects
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
@@ -345,10 +347,13 @@ class SeerExplorerClient:
             raise SeerApiError("Seer request failed", response.status)
         result = response.json()
 
-        self._maybe_trigger_explorer_index_for_new_run(
-            result.get("has_explorer_index"),
-            result.get("has_org_project_context"),
-        )
+        try:
+            self._maybe_trigger_explorer_index_for_new_run(
+                result.get("has_explorer_index"),
+                result.get("has_org_project_context"),
+            )
+        except Exception as e:
+            sentry_sdk.capture_exception(e)
 
         return result["run_id"]
 
@@ -368,23 +373,27 @@ class SeerExplorerClient:
             logger.info("seer.explorer_index.killswitch.enable flag enabled, skipping")
             return
 
-        projects = list(
-            Project.objects.filter(
-                organization_id=self.organization.id,
-                status=ObjectStatus.ACTIVE,
+        if not has_explorer_index:
+            projects = list(
+                Project.objects.filter(
+                    organization_id=self.organization.id,
+                    status=ObjectStatus.ACTIVE,
+                )
             )
-        )
 
-        projects_batch = [
-            (p.id, self.organization.id) for p in projects if p.flags.has_transactions
-        ]
+            projects_batch = [
+                (p.id, self.organization.id) for p in projects if p.flags.has_transactions
+            ]
 
-        if not projects_batch:
-            return
+            if projects_batch:
+                for _ in dispatch_explorer_index_projects(
+                    iter(projects_batch), django_timezone.now()
+                ):
+                    pass
 
-        # Consume the generator to dispatch all batches
-        for _ in dispatch_explorer_index_projects(iter(projects_batch), django_timezone.now()):
-            pass
+        if not has_org_project_context and options.get("explorer.context_engine_indexing.enable"):
+            index_org_project_knowledge.apply_async(args=[self.organization.id])
+            build_service_map.apply_async(args=[self.organization.id])
 
     def continue_run(
         self,

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -363,9 +363,6 @@ class SeerExplorerClient:
         has_org_project_context: bool | None,
     ) -> None:
         """Trigger explorer indexing for the org if Seer reports missing indexes."""
-        if has_explorer_index is not False and has_org_project_context is not False:
-            return
-
         if not options.get("seer.explorer_index.enable"):
             return
 
@@ -373,7 +370,7 @@ class SeerExplorerClient:
             logger.info("seer.explorer_index.killswitch.enable flag enabled, skipping")
             return
 
-        if not has_explorer_index:
+        if has_explorer_index is not None and not has_explorer_index:
             projects = list(
                 Project.objects.filter(
                     organization_id=self.organization.id,
@@ -391,7 +388,11 @@ class SeerExplorerClient:
                 ):
                     pass
 
-        if not has_org_project_context and options.get("explorer.context_engine_indexing.enable"):
+        if (
+            has_org_project_context is not None
+            and not has_org_project_context
+            and options.get("explorer.context_engine_indexing.enable")
+        ):
             index_org_project_knowledge.apply_async(args=[self.organization.id])
             build_service_map.apply_async(args=[self.organization.id])
 

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -7,11 +7,12 @@ from datetime import datetime
 from typing import Any, Literal, overload
 
 from django.contrib.auth.models import AnonymousUser
+from django.utils import timezone as django_timezone
 from pydantic import BaseModel
 from rest_framework.request import Request
 
 from sentry import features, options
-from sentry.constants import ENABLE_SEER_CODING_DEFAULT
+from sentry.constants import ENABLE_SEER_CODING_DEFAULT, ObjectStatus
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.seer.explorer.client_models import ExplorerRun, ExplorerRunWithPrs, SeerRunState
@@ -36,6 +37,7 @@ from sentry.seer.explorer.on_completion_hook import (
 from sentry.seer.models import SeerApiError, SeerPermissionError, SeerRepoDefinition
 from sentry.seer.seer_setup import has_seer_access_with_detail
 from sentry.seer.signed_seer_api import SeerViewerContext
+from sentry.tasks.seer.explorer_index import dispatch_explorer_index_projects
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
 
@@ -342,7 +344,47 @@ class SeerExplorerClient:
         if response.status >= 400:
             raise SeerApiError("Seer request failed", response.status)
         result = response.json()
+
+        self._maybe_trigger_explorer_index_for_new_run(
+            result.get("has_explorer_index"),
+            result.get("has_org_project_context"),
+        )
+
         return result["run_id"]
+
+    def _maybe_trigger_explorer_index_for_new_run(
+        self,
+        has_explorer_index: bool | None,
+        has_org_project_context: bool | None,
+    ) -> None:
+        """Trigger explorer indexing for the org if Seer reports missing indexes."""
+        if has_explorer_index is not False and has_org_project_context is not False:
+            return
+
+        if not options.get("seer.explorer_index.enable"):
+            return
+
+        if options.get("seer.explorer_index.killswitch.enable"):
+            logger.info("seer.explorer_index.killswitch.enable flag enabled, skipping")
+            return
+
+        projects = list(
+            Project.objects.filter(
+                organization_id=self.organization.id,
+                status=ObjectStatus.ACTIVE,
+            )
+        )
+
+        projects_batch = [
+            (p.id, self.organization.id) for p in projects if p.flags.has_transactions
+        ]
+
+        if not projects_batch:
+            return
+
+        # Consume the generator to dispatch all batches
+        for _ in dispatch_explorer_index_projects(iter(projects_batch), django_timezone.now()):
+            pass
 
     def continue_run(
         self,

--- a/tests/sentry/seer/explorer/test_explorer_client.py
+++ b/tests/sentry/seer/explorer/test_explorer_client.py
@@ -949,3 +949,156 @@ class TestSeerRunStateCodeChanges(TestCase):
         assert len(result["owner/repo1"]) == 1
         assert result["owner/repo1"][0].patch.type == "A"
         assert result["owner/repo1"][0].patch.added == 100
+
+
+class TestStartRunExplorerIndexTrigger(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.user = self.create_user()
+        self.organization = self.create_organization(owner=self.user)
+        access_patcher = patch(
+            "sentry.seer.explorer.client.has_seer_access_with_detail",
+            return_value=(True, None),
+        )
+        access_patcher.start()
+        self.addCleanup(access_patcher.stop)
+        context_patcher = patch(
+            "sentry.seer.explorer.client.collect_user_org_context",
+            return_value={},
+        )
+        context_patcher.start()
+        self.addCleanup(context_patcher.stop)
+
+    def _mock_chat_response(self, run_id: int = 123, **flags: bool | None) -> MagicMock:
+        mock_response = MagicMock()
+        mock_response.status = 200
+        mock_response.json.return_value = {"run_id": run_id, **flags}
+        return mock_response
+
+    @patch("sentry.seer.explorer.client.dispatch_explorer_index_projects")
+    @patch("sentry.seer.explorer.client.make_explorer_chat_request")
+    def test_triggers_indexing_when_explorer_index_missing(self, mock_chat, mock_dispatch):
+        mock_chat.return_value = self._mock_chat_response(has_explorer_index=False)
+        mock_dispatch.return_value = iter([])
+        project = self.create_project(organization=self.organization)
+        project.flags.has_transactions = True
+        project.save()
+
+        client = SeerExplorerClient(self.organization, self.user)
+        with self.options(
+            {"seer.explorer_index.enable": True, "seer.explorer_index.killswitch.enable": False}
+        ):
+            run_id = client.start_run("Why are my errors spiking?")
+
+        assert run_id == 123
+        mock_dispatch.assert_called_once()
+        projects_batch = list(mock_dispatch.call_args[0][0])
+        assert (project.id, self.organization.id) in projects_batch
+
+    @patch("sentry.seer.explorer.client.dispatch_explorer_index_projects")
+    @patch("sentry.seer.explorer.client.make_explorer_chat_request")
+    def test_triggers_indexing_when_org_project_context_missing(self, mock_chat, mock_dispatch):
+        mock_chat.return_value = self._mock_chat_response(has_org_project_context=False)
+        mock_dispatch.return_value = iter([])
+        project = self.create_project(organization=self.organization)
+        project.flags.has_transactions = True
+        project.save()
+
+        client = SeerExplorerClient(self.organization, self.user)
+        with self.options(
+            {"seer.explorer_index.enable": True, "seer.explorer_index.killswitch.enable": False}
+        ):
+            run_id = client.start_run("Why are my errors spiking?")
+
+        assert run_id == 123
+        mock_dispatch.assert_called_once()
+
+    @patch("sentry.seer.explorer.client.dispatch_explorer_index_projects")
+    @patch("sentry.seer.explorer.client.make_explorer_chat_request")
+    def test_excludes_projects_without_transactions_from_batch(self, mock_chat, mock_dispatch):
+        mock_chat.return_value = self._mock_chat_response(has_explorer_index=False)
+        mock_dispatch.return_value = iter([])
+        project_with_txns = self.create_project(organization=self.organization)
+        project_with_txns.flags.has_transactions = True
+        project_with_txns.save()
+        project_without_txns = self.create_project(organization=self.organization)
+
+        client = SeerExplorerClient(self.organization, self.user)
+        with self.options(
+            {"seer.explorer_index.enable": True, "seer.explorer_index.killswitch.enable": False}
+        ):
+            client.start_run("Why are my errors spiking?")
+
+        projects_batch = list(mock_dispatch.call_args[0][0])
+        assert (project_with_txns.id, self.organization.id) in projects_batch
+        assert (project_without_txns.id, self.organization.id) not in projects_batch
+
+    @patch("sentry.seer.explorer.client.dispatch_explorer_index_projects")
+    @patch("sentry.seer.explorer.client.make_explorer_chat_request")
+    def test_skips_indexing_when_index_present(self, mock_chat, mock_dispatch):
+        mock_chat.return_value = self._mock_chat_response(
+            has_explorer_index=True, has_org_project_context=True
+        )
+
+        client = SeerExplorerClient(self.organization, self.user)
+        with self.options({"seer.explorer_index.enable": True}):
+            run_id = client.start_run("Why are my errors spiking?")
+
+        assert run_id == 123
+        mock_dispatch.assert_not_called()
+
+    @patch("sentry.seer.explorer.client.dispatch_explorer_index_projects")
+    @patch("sentry.seer.explorer.client.make_explorer_chat_request")
+    def test_skips_indexing_when_flags_absent_from_response(self, mock_chat, mock_dispatch):
+        mock_chat.return_value = self._mock_chat_response()
+
+        client = SeerExplorerClient(self.organization, self.user)
+        with self.options({"seer.explorer_index.enable": True}):
+            run_id = client.start_run("Why are my errors spiking?")
+
+        assert run_id == 123
+        mock_dispatch.assert_not_called()
+
+    @patch("sentry.seer.explorer.client.dispatch_explorer_index_projects")
+    @patch("sentry.seer.explorer.client.make_explorer_chat_request")
+    def test_skips_indexing_when_enable_option_off(self, mock_chat, mock_dispatch):
+        mock_chat.return_value = self._mock_chat_response(has_explorer_index=False)
+        project = self.create_project(organization=self.organization)
+        project.flags.has_transactions = True
+        project.save()
+
+        client = SeerExplorerClient(self.organization, self.user)
+        with self.options({"seer.explorer_index.enable": False}):
+            client.start_run("Why are my errors spiking?")
+
+        mock_dispatch.assert_not_called()
+
+    @patch("sentry.seer.explorer.client.dispatch_explorer_index_projects")
+    @patch("sentry.seer.explorer.client.make_explorer_chat_request")
+    def test_skips_indexing_when_killswitch_on(self, mock_chat, mock_dispatch):
+        mock_chat.return_value = self._mock_chat_response(has_explorer_index=False)
+        project = self.create_project(organization=self.organization)
+        project.flags.has_transactions = True
+        project.save()
+
+        client = SeerExplorerClient(self.organization, self.user)
+        with self.options(
+            {"seer.explorer_index.enable": True, "seer.explorer_index.killswitch.enable": True}
+        ):
+            client.start_run("Why are my errors spiking?")
+
+        mock_dispatch.assert_not_called()
+
+    @patch("sentry.seer.explorer.client.dispatch_explorer_index_projects")
+    @patch("sentry.seer.explorer.client.make_explorer_chat_request")
+    def test_skips_indexing_when_no_projects_with_transactions(self, mock_chat, mock_dispatch):
+        mock_chat.return_value = self._mock_chat_response(has_explorer_index=False)
+        self.create_project(organization=self.organization)
+
+        client = SeerExplorerClient(self.organization, self.user)
+        with self.options(
+            {"seer.explorer_index.enable": True, "seer.explorer_index.killswitch.enable": False}
+        ):
+            client.start_run("Why are my errors spiking?")
+
+        mock_dispatch.assert_not_called()

--- a/tests/sentry/seer/explorer/test_explorer_client.py
+++ b/tests/sentry/seer/explorer/test_explorer_client.py
@@ -995,9 +995,13 @@ class TestStartRunExplorerIndexTrigger(TestCase):
         projects_batch = list(mock_dispatch.call_args[0][0])
         assert (project.id, self.organization.id) in projects_batch
 
+    @patch("sentry.seer.explorer.client.index_org_project_knowledge")
+    @patch("sentry.seer.explorer.client.build_service_map")
     @patch("sentry.seer.explorer.client.dispatch_explorer_index_projects")
     @patch("sentry.seer.explorer.client.make_explorer_chat_request")
-    def test_triggers_indexing_when_org_project_context_missing(self, mock_chat, mock_dispatch):
+    def test_triggers_indexing_when_org_project_context_missing(
+        self, mock_chat, mock_dispatch, mock_build_service_map, mock_index_knowledge
+    ):
         mock_chat.return_value = self._mock_chat_response(has_org_project_context=False)
         mock_dispatch.return_value = iter([])
         project = self.create_project(organization=self.organization)
@@ -1006,12 +1010,18 @@ class TestStartRunExplorerIndexTrigger(TestCase):
 
         client = SeerExplorerClient(self.organization, self.user)
         with self.options(
-            {"seer.explorer_index.enable": True, "seer.explorer_index.killswitch.enable": False}
+            {
+                "seer.explorer_index.enable": True,
+                "seer.explorer_index.killswitch.enable": False,
+                "explorer.context_engine_indexing.enable": True,
+            }
         ):
             run_id = client.start_run("Why are my errors spiking?")
 
         assert run_id == 123
         mock_dispatch.assert_called_once()
+        mock_index_knowledge.apply_async.assert_called_once_with(args=[self.organization.id])
+        mock_build_service_map.apply_async.assert_called_once_with(args=[self.organization.id])
 
     @patch("sentry.seer.explorer.client.dispatch_explorer_index_projects")
     @patch("sentry.seer.explorer.client.make_explorer_chat_request")
@@ -1059,35 +1069,57 @@ class TestStartRunExplorerIndexTrigger(TestCase):
         assert run_id == 123
         mock_dispatch.assert_not_called()
 
+    @patch("sentry.seer.explorer.client.index_org_project_knowledge")
+    @patch("sentry.seer.explorer.client.build_service_map")
     @patch("sentry.seer.explorer.client.dispatch_explorer_index_projects")
     @patch("sentry.seer.explorer.client.make_explorer_chat_request")
-    def test_skips_indexing_when_enable_option_off(self, mock_chat, mock_dispatch):
-        mock_chat.return_value = self._mock_chat_response(has_explorer_index=False)
-        project = self.create_project(organization=self.organization)
-        project.flags.has_transactions = True
-        project.save()
-
-        client = SeerExplorerClient(self.organization, self.user)
-        with self.options({"seer.explorer_index.enable": False}):
-            client.start_run("Why are my errors spiking?")
-
-        mock_dispatch.assert_not_called()
-
-    @patch("sentry.seer.explorer.client.dispatch_explorer_index_projects")
-    @patch("sentry.seer.explorer.client.make_explorer_chat_request")
-    def test_skips_indexing_when_killswitch_on(self, mock_chat, mock_dispatch):
-        mock_chat.return_value = self._mock_chat_response(has_explorer_index=False)
+    def test_skips_indexing_when_enable_option_off(
+        self, mock_chat, mock_dispatch, mock_build_service_map, mock_index_knowledge
+    ):
+        mock_chat.return_value = self._mock_chat_response(
+            has_explorer_index=False, has_org_project_context=False
+        )
         project = self.create_project(organization=self.organization)
         project.flags.has_transactions = True
         project.save()
 
         client = SeerExplorerClient(self.organization, self.user)
         with self.options(
-            {"seer.explorer_index.enable": True, "seer.explorer_index.killswitch.enable": True}
+            {"seer.explorer_index.enable": False, "explorer.context_engine_indexing.enable": True}
         ):
             client.start_run("Why are my errors spiking?")
 
         mock_dispatch.assert_not_called()
+        mock_index_knowledge.apply_async.assert_not_called()
+        mock_build_service_map.apply_async.assert_not_called()
+
+    @patch("sentry.seer.explorer.client.index_org_project_knowledge")
+    @patch("sentry.seer.explorer.client.build_service_map")
+    @patch("sentry.seer.explorer.client.dispatch_explorer_index_projects")
+    @patch("sentry.seer.explorer.client.make_explorer_chat_request")
+    def test_skips_indexing_when_killswitch_on(
+        self, mock_chat, mock_dispatch, mock_build_service_map, mock_index_knowledge
+    ):
+        mock_chat.return_value = self._mock_chat_response(
+            has_explorer_index=False, has_org_project_context=False
+        )
+        project = self.create_project(organization=self.organization)
+        project.flags.has_transactions = True
+        project.save()
+
+        client = SeerExplorerClient(self.organization, self.user)
+        with self.options(
+            {
+                "seer.explorer_index.enable": True,
+                "seer.explorer_index.killswitch.enable": True,
+                "explorer.context_engine_indexing.enable": True,
+            }
+        ):
+            client.start_run("Why are my errors spiking?")
+
+        mock_dispatch.assert_not_called()
+        mock_index_knowledge.apply_async.assert_not_called()
+        mock_build_service_map.apply_async.assert_not_called()
 
     @patch("sentry.seer.explorer.client.dispatch_explorer_index_projects")
     @patch("sentry.seer.explorer.client.make_explorer_chat_request")

--- a/tests/sentry/seer/explorer/test_explorer_client.py
+++ b/tests/sentry/seer/explorer/test_explorer_client.py
@@ -1019,7 +1019,7 @@ class TestStartRunExplorerIndexTrigger(TestCase):
             run_id = client.start_run("Why are my errors spiking?")
 
         assert run_id == 123
-        mock_dispatch.assert_called_once()
+        mock_dispatch.assert_not_called()
         mock_index_knowledge.apply_async.assert_called_once_with(args=[self.organization.id])
         mock_build_service_map.apply_async.assert_called_once_with(args=[self.organization.id])
 


### PR DESCRIPTION
When starting a new Explorer chat run, check the has_explorer_index and has_org_project_context flags returned by Seer. If either is false, dispatch explorer index tasks for the org's active projects with transactions so the index is populated without waiting for the next hourly scheduler run.

Respects seer.explorer_index.enable and seer.explorer_index.killswitch.enable options, and uses dispatch_explorer_index_projects for consistent batching and load-spreading behaviour.

Avg e2e latency on tasks are under a min with the cron job, so I'll release as is and monitor if we need to scale up the pods