### PR TITLE
feat(preprod): Surface snapshot status check toggles in project settings

### DIFF
--- a/static/app/types/project.tsx
+++ b/static/app/types/project.tsx
@@ -95,7 +95,9 @@ export type Project = {
   preprodSnapshotPrCommentsEnabled?: boolean;
   preprodSnapshotStatusChecksEnabled?: boolean;
   preprodSnapshotStatusChecksFailOnAdded?: boolean;
+  preprodSnapshotStatusChecksFailOnChanged?: boolean;
   preprodSnapshotStatusChecksFailOnRemoved?: boolean;
+  preprodSnapshotStatusChecksFailOnRenamed?: boolean;
   scmSourceContextEnabled?: boolean;
   securityToken?: string;
   securityTokenHeader?: string;

--- a/static/app/views/settings/project/preprod/snapshotStatusChecks.spec.tsx
+++ b/static/app/views/settings/project/preprod/snapshotStatusChecks.spec.tsx
@@ -132,6 +132,42 @@ describe('SnapshotStatusChecks', () => {
     );
   });
 
+  it('immediately hides failure condition toggles when status checks are disabled', async () => {
+    const project = ProjectFixture({options: {}});
+    const projectEndpoint = `/projects/${organization.slug}/${project.slug}/`;
+    const mock = MockApiClient.addMockResponse({
+      url: projectEndpoint,
+      method: 'PUT',
+      body: {},
+    });
+
+    render(<SnapshotStatusChecks />, {
+      organization,
+      outletContext: {project},
+      initialRouterConfig,
+    });
+
+    await userEvent.click(
+      await screen.findByRole('checkbox', {name: 'Enable Snapshot Status Checks'})
+    );
+
+    expect(
+      screen.getByText('Enable status checks to configure failure conditions')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('checkbox', {name: 'Fail on Changed Snapshots'})
+    ).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(mock).toHaveBeenCalledWith(
+        projectEndpoint,
+        expect.objectContaining({
+          method: 'PUT',
+          data: {preprodSnapshotStatusChecksEnabled: false},
+        })
+      )
+    );
+  });
+
   it('hides per-category toggles and shows a hint when status checks are disabled', async () => {
     const project = ProjectFixture({
       options: {},

--- a/static/app/views/settings/project/preprod/snapshotStatusChecks.spec.tsx
+++ b/static/app/views/settings/project/preprod/snapshotStatusChecks.spec.tsx
@@ -1,0 +1,177 @@
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {initializeOrg} from 'sentry-test/initializeOrg';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {SnapshotStatusChecks} from 'sentry/views/settings/project/preprod/snapshotStatusChecks';
+
+describe('SnapshotStatusChecks', () => {
+  const {organization} = initializeOrg();
+  const initialRouterConfig = {
+    location: {
+      pathname: `/settings/projects/test-project/snapshots/`,
+    },
+    route: '/settings/projects/:projectId/snapshots/',
+  };
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('renders default values when the project has no preprod options', async () => {
+    const project = ProjectFixture({options: {}});
+    render(<SnapshotStatusChecks />, {
+      organization,
+      outletContext: {project},
+      initialRouterConfig,
+    });
+
+    expect(
+      await screen.findByRole('checkbox', {name: 'Enable Snapshot Status Checks'})
+    ).toBeChecked();
+    expect(
+      screen.getByRole('checkbox', {name: 'Fail on Added Snapshots'})
+    ).not.toBeChecked();
+    expect(
+      screen.getByRole('checkbox', {name: 'Fail on Removed Snapshots'})
+    ).toBeChecked();
+    expect(
+      screen.getByRole('checkbox', {name: 'Fail on Changed Snapshots'})
+    ).toBeChecked();
+    expect(
+      screen.getByRole('checkbox', {name: 'Fail on Renamed Snapshots'})
+    ).not.toBeChecked();
+  });
+
+  it('reflects project values from explicit fields', async () => {
+    const project = ProjectFixture({
+      options: {},
+      preprodSnapshotStatusChecksEnabled: true,
+      preprodSnapshotStatusChecksFailOnAdded: true,
+      preprodSnapshotStatusChecksFailOnRemoved: false,
+      preprodSnapshotStatusChecksFailOnChanged: false,
+      preprodSnapshotStatusChecksFailOnRenamed: true,
+    });
+    render(<SnapshotStatusChecks />, {
+      organization,
+      outletContext: {project},
+      initialRouterConfig,
+    });
+
+    expect(
+      await screen.findByRole('checkbox', {name: 'Fail on Added Snapshots'})
+    ).toBeChecked();
+    expect(
+      screen.getByRole('checkbox', {name: 'Fail on Removed Snapshots'})
+    ).not.toBeChecked();
+    expect(
+      screen.getByRole('checkbox', {name: 'Fail on Changed Snapshots'})
+    ).not.toBeChecked();
+    expect(
+      screen.getByRole('checkbox', {name: 'Fail on Renamed Snapshots'})
+    ).toBeChecked();
+  });
+
+  it('saves fail_on_changed when toggled off', async () => {
+    const project = ProjectFixture({options: {}});
+    const projectEndpoint = `/projects/${organization.slug}/${project.slug}/`;
+    const mock = MockApiClient.addMockResponse({
+      url: projectEndpoint,
+      method: 'PUT',
+      body: {},
+    });
+
+    render(<SnapshotStatusChecks />, {
+      organization,
+      outletContext: {project},
+      initialRouterConfig,
+    });
+
+    await userEvent.click(
+      await screen.findByRole('checkbox', {name: 'Fail on Changed Snapshots'})
+    );
+
+    await waitFor(() =>
+      expect(mock).toHaveBeenCalledWith(
+        projectEndpoint,
+        expect.objectContaining({
+          method: 'PUT',
+          data: {preprodSnapshotStatusChecksFailOnChanged: false},
+        })
+      )
+    );
+  });
+
+  it('saves fail_on_renamed when toggled on', async () => {
+    const project = ProjectFixture({options: {}});
+    const projectEndpoint = `/projects/${organization.slug}/${project.slug}/`;
+    const mock = MockApiClient.addMockResponse({
+      url: projectEndpoint,
+      method: 'PUT',
+      body: {},
+    });
+
+    render(<SnapshotStatusChecks />, {
+      organization,
+      outletContext: {project},
+      initialRouterConfig,
+    });
+
+    await userEvent.click(
+      await screen.findByRole('checkbox', {name: 'Fail on Renamed Snapshots'})
+    );
+
+    await waitFor(() =>
+      expect(mock).toHaveBeenCalledWith(
+        projectEndpoint,
+        expect.objectContaining({
+          method: 'PUT',
+          data: {preprodSnapshotStatusChecksFailOnRenamed: true},
+        })
+      )
+    );
+  });
+
+  it('disables and visually clears per-category toggles when status checks are disabled', async () => {
+    const project = ProjectFixture({
+      options: {},
+      preprodSnapshotStatusChecksEnabled: false,
+      preprodSnapshotStatusChecksFailOnChanged: true,
+      preprodSnapshotStatusChecksFailOnRemoved: true,
+    });
+    render(<SnapshotStatusChecks />, {
+      organization,
+      outletContext: {project},
+      initialRouterConfig,
+    });
+
+    const failOnAdded = await screen.findByRole('checkbox', {
+      name: 'Fail on Added Snapshots',
+    });
+    const failOnRemoved = screen.getByRole('checkbox', {
+      name: 'Fail on Removed Snapshots',
+    });
+    const failOnChanged = screen.getByRole('checkbox', {
+      name: 'Fail on Changed Snapshots',
+    });
+    const failOnRenamed = screen.getByRole('checkbox', {
+      name: 'Fail on Renamed Snapshots',
+    });
+
+    expect(failOnAdded).toBeDisabled();
+    expect(failOnRemoved).toBeDisabled();
+    expect(failOnChanged).toBeDisabled();
+    expect(failOnRenamed).toBeDisabled();
+
+    // Stored values may be on, but the disabled state should read as off so
+    // users don't see a confusing mix of "off but on" toggles.
+    expect(failOnAdded).not.toBeChecked();
+    expect(failOnRemoved).not.toBeChecked();
+    expect(failOnChanged).not.toBeChecked();
+    expect(failOnRenamed).not.toBeChecked();
+
+    expect(
+      screen.getByRole('checkbox', {name: 'Enable Snapshot Status Checks'})
+    ).toBeEnabled();
+  });
+});

--- a/static/app/views/settings/project/preprod/snapshotStatusChecks.spec.tsx
+++ b/static/app/views/settings/project/preprod/snapshotStatusChecks.spec.tsx
@@ -132,12 +132,10 @@ describe('SnapshotStatusChecks', () => {
     );
   });
 
-  it('disables and visually clears per-category toggles when status checks are disabled', async () => {
+  it('hides per-category toggles and shows a hint when status checks are disabled', async () => {
     const project = ProjectFixture({
       options: {},
       preprodSnapshotStatusChecksEnabled: false,
-      preprodSnapshotStatusChecksFailOnChanged: true,
-      preprodSnapshotStatusChecksFailOnRemoved: true,
     });
     render(<SnapshotStatusChecks />, {
       organization,
@@ -145,31 +143,21 @@ describe('SnapshotStatusChecks', () => {
       initialRouterConfig,
     });
 
-    const failOnAdded = await screen.findByRole('checkbox', {
-      name: 'Fail on Added Snapshots',
-    });
-    const failOnRemoved = screen.getByRole('checkbox', {
-      name: 'Fail on Removed Snapshots',
-    });
-    const failOnChanged = screen.getByRole('checkbox', {
-      name: 'Fail on Changed Snapshots',
-    });
-    const failOnRenamed = screen.getByRole('checkbox', {
-      name: 'Fail on Renamed Snapshots',
-    });
-
-    expect(failOnAdded).toBeDisabled();
-    expect(failOnRemoved).toBeDisabled();
-    expect(failOnChanged).toBeDisabled();
-    expect(failOnRenamed).toBeDisabled();
-
-    // Stored values may be on, but the disabled state should read as off so
-    // users don't see a confusing mix of "off but on" toggles.
-    expect(failOnAdded).not.toBeChecked();
-    expect(failOnRemoved).not.toBeChecked();
-    expect(failOnChanged).not.toBeChecked();
-    expect(failOnRenamed).not.toBeChecked();
-
+    expect(
+      await screen.findByText('Enable status checks to configure failure conditions')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('checkbox', {name: 'Fail on Added Snapshots'})
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('checkbox', {name: 'Fail on Removed Snapshots'})
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('checkbox', {name: 'Fail on Changed Snapshots'})
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('checkbox', {name: 'Fail on Renamed Snapshots'})
+    ).not.toBeInTheDocument();
     expect(
       screen.getByRole('checkbox', {name: 'Enable Snapshot Status Checks'})
     ).toBeEnabled();

--- a/static/app/views/settings/project/preprod/snapshotStatusChecks.tsx
+++ b/static/app/views/settings/project/preprod/snapshotStatusChecks.tsx
@@ -1,90 +1,149 @@
-import {Fragment} from 'react';
+import {z} from 'zod';
 
-import {Container, Flex, Stack} from '@sentry/scraps/layout';
-import {Switch} from '@sentry/scraps/switch';
-import {Text} from '@sentry/scraps/text';
+import {AutoSaveForm, FieldGroup} from '@sentry/scraps/form';
 
-import {Panel} from 'sentry/components/panels/panel';
-import {PanelBody} from 'sentry/components/panels/panelBody';
-import {PanelHeader} from 'sentry/components/panels/panelHeader';
 import {t} from 'sentry/locale';
+import {ProjectsStore} from 'sentry/stores/projectsStore';
+import type {Project} from 'sentry/types/project';
+import {fetchMutation} from 'sentry/utils/queryClient';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjectSettingsOutlet} from 'sentry/views/settings/project/projectSettingsLayout';
 
 import {useSnapshotStatusChecks} from './useSnapshotStatusChecks';
 
+const schema = z.object({
+  preprodSnapshotStatusChecksEnabled: z.boolean(),
+  preprodSnapshotStatusChecksFailOnAdded: z.boolean(),
+  preprodSnapshotStatusChecksFailOnRemoved: z.boolean(),
+  preprodSnapshotStatusChecksFailOnChanged: z.boolean(),
+  preprodSnapshotStatusChecksFailOnRenamed: z.boolean(),
+});
+
+type Schema = z.infer<typeof schema>;
+
 export function SnapshotStatusChecks() {
+  const organization = useOrganization();
   const {project} = useProjectSettingsOutlet();
-  const {
-    enabled,
-    failOnAdded,
-    failOnRemoved,
-    setEnabled,
-    setFailOnAdded,
-    setFailOnRemoved,
-  } = useSnapshotStatusChecks(project);
+  const {enabled, failOnAdded, failOnRemoved, failOnChanged, failOnRenamed} =
+    useSnapshotStatusChecks(project);
+
+  const projectEndpoint = `/projects/${organization.slug}/${project.slug}/`;
+
+  const mutationOptions = {
+    mutationFn: (data: Partial<Schema>) =>
+      fetchMutation<Project>({
+        url: projectEndpoint,
+        method: 'PUT',
+        data,
+      }),
+    onSuccess: (response: Project) => ProjectsStore.onUpdateSuccess(response),
+  };
+
+  const disabledHint = enabled
+    ? false
+    : t('Enable Snapshot Status Checks above to configure.');
 
   return (
-    <Panel>
-      <PanelHeader>{t('Snapshots - Status Checks')}</PanelHeader>
-      <PanelBody>
-        <Fragment>
-          <Flex align="center" justify="between" padding="xl" borderBottom="primary">
-            <Stack gap="xs">
-              <Text size="lg" bold>
-                {t('Snapshot Status Checks Enabled')}
-              </Text>
-              <Text size="sm" variant="muted">
-                {t(
-                  'Sentry will post status checks based on snapshot changes in your builds.'
-                )}
-              </Text>
-            </Stack>
-            <Switch
-              size="lg"
-              checked={enabled}
-              onChange={() => setEnabled(!enabled)}
-              aria-label={t('Toggle snapshot status checks')}
-            />
-          </Flex>
+    <FieldGroup title={t('Snapshots - Status Checks')}>
+      <AutoSaveForm
+        name="preprodSnapshotStatusChecksEnabled"
+        schema={schema}
+        initialValue={enabled}
+        mutationOptions={mutationOptions}
+      >
+        {field => (
+          <field.Layout.Row
+            label={t('Enable Snapshot Status Checks')}
+            hintText={t(
+              'Sentry will post status checks based on snapshot changes in your builds.'
+            )}
+          >
+            <field.Switch checked={field.state.value} onChange={field.handleChange} />
+          </field.Layout.Row>
+        )}
+      </AutoSaveForm>
 
-          {enabled ? (
-            <Stack padding="xl" gap="lg">
-              <Flex align="center" justify="between">
-                <Stack gap="xs">
-                  <Text bold>{t('Fail on Added Snapshots')}</Text>
-                  <Text size="sm" variant="muted">
-                    {t('Status check will fail if new snapshots are added in a build.')}
-                  </Text>
-                </Stack>
-                <Switch
-                  checked={failOnAdded}
-                  onChange={() => setFailOnAdded(!failOnAdded)}
-                  aria-label={t('Toggle fail on added snapshots')}
-                />
-              </Flex>
-              <Flex align="center" justify="between">
-                <Stack gap="xs">
-                  <Text bold>{t('Fail on Removed Snapshots')}</Text>
-                  <Text size="sm" variant="muted">
-                    {t('Status check will fail if snapshots are removed from a build.')}
-                  </Text>
-                </Stack>
-                <Switch
-                  checked={failOnRemoved}
-                  onChange={() => setFailOnRemoved(!failOnRemoved)}
-                  aria-label={t('Toggle fail on removed snapshots')}
-                />
-              </Flex>
-            </Stack>
-          ) : (
-            <Container padding="md">
-              <Text align="center" variant="muted" italic>
-                {t('Enable snapshot status checks above to configure.')}
-              </Text>
-            </Container>
-          )}
-        </Fragment>
-      </PanelBody>
-    </Panel>
+      <AutoSaveForm
+        name="preprodSnapshotStatusChecksFailOnChanged"
+        schema={schema}
+        initialValue={failOnChanged}
+        mutationOptions={mutationOptions}
+      >
+        {field => (
+          <field.Layout.Row
+            label={t('Fail on Changed Snapshots')}
+            hintText={t(
+              'Status check will fail if snapshot pixel content changes in a build.'
+            )}
+          >
+            <field.Switch
+              checked={enabled ? field.state.value : false}
+              onChange={field.handleChange}
+              disabled={disabledHint}
+            />
+          </field.Layout.Row>
+        )}
+      </AutoSaveForm>
+
+      <AutoSaveForm
+        name="preprodSnapshotStatusChecksFailOnRemoved"
+        schema={schema}
+        initialValue={failOnRemoved}
+        mutationOptions={mutationOptions}
+      >
+        {field => (
+          <field.Layout.Row
+            label={t('Fail on Removed Snapshots')}
+            hintText={t('Status check will fail if snapshots are removed from a build.')}
+          >
+            <field.Switch
+              checked={enabled ? field.state.value : false}
+              onChange={field.handleChange}
+              disabled={disabledHint}
+            />
+          </field.Layout.Row>
+        )}
+      </AutoSaveForm>
+
+      <AutoSaveForm
+        name="preprodSnapshotStatusChecksFailOnAdded"
+        schema={schema}
+        initialValue={failOnAdded}
+        mutationOptions={mutationOptions}
+      >
+        {field => (
+          <field.Layout.Row
+            label={t('Fail on Added Snapshots')}
+            hintText={t('Status check will fail if new snapshots are added in a build.')}
+          >
+            <field.Switch
+              checked={enabled ? field.state.value : false}
+              onChange={field.handleChange}
+              disabled={disabledHint}
+            />
+          </field.Layout.Row>
+        )}
+      </AutoSaveForm>
+
+      <AutoSaveForm
+        name="preprodSnapshotStatusChecksFailOnRenamed"
+        schema={schema}
+        initialValue={failOnRenamed}
+        mutationOptions={mutationOptions}
+      >
+        {field => (
+          <field.Layout.Row
+            label={t('Fail on Renamed Snapshots')}
+            hintText={t('Status check will fail if snapshots are renamed in a build.')}
+          >
+            <field.Switch
+              checked={enabled ? field.state.value : false}
+              onChange={field.handleChange}
+              disabled={disabledHint}
+            />
+          </field.Layout.Row>
+        )}
+      </AutoSaveForm>
+    </FieldGroup>
   );
 }

--- a/static/app/views/settings/project/preprod/snapshotStatusChecks.tsx
+++ b/static/app/views/settings/project/preprod/snapshotStatusChecks.tsx
@@ -1,4 +1,4 @@
-import {Fragment} from 'react';
+import {Fragment, useEffect, useState} from 'react';
 import {z} from 'zod';
 
 import {AutoSaveForm, FieldGroup} from '@sentry/scraps/form';
@@ -35,8 +35,13 @@ export function SnapshotStatusChecks() {
   const {project} = useProjectSettingsOutlet();
   const {enabled, failOnAdded, failOnRemoved, failOnChanged, failOnRenamed} =
     useSnapshotStatusChecks(project);
+  const [statusChecksEnabled, setStatusChecksEnabled] = useState(enabled);
 
   const projectEndpoint = `/projects/${organization.slug}/${project.slug}/`;
+
+  useEffect(() => {
+    setStatusChecksEnabled(enabled);
+  }, [enabled]);
 
   const mutationOptions = {
     mutationFn: (data: Partial<Schema>) =>
@@ -46,6 +51,11 @@ export function SnapshotStatusChecks() {
         data,
       }),
     onSuccess: (response: Project) => ProjectsStore.onUpdateSuccess(response),
+  };
+
+  const enabledMutationOptions = {
+    ...mutationOptions,
+    onError: () => setStatusChecksEnabled(enabled),
   };
 
   const failureConditionFields = [
@@ -81,7 +91,7 @@ export function SnapshotStatusChecks() {
         name="preprodSnapshotStatusChecksEnabled"
         schema={schema}
         initialValue={enabled}
-        mutationOptions={mutationOptions}
+        mutationOptions={enabledMutationOptions}
       >
         {field => (
           <field.Layout.Row
@@ -90,12 +100,18 @@ export function SnapshotStatusChecks() {
               'Sentry will post status checks based on snapshot changes in your builds.'
             )}
           >
-            <field.Switch checked={field.state.value} onChange={field.handleChange} />
+            <field.Switch
+              checked={field.state.value}
+              onChange={value => {
+                setStatusChecksEnabled(value);
+                field.handleChange(value);
+              }}
+            />
           </field.Layout.Row>
         )}
       </AutoSaveForm>
 
-      {enabled ? (
+      {statusChecksEnabled ? (
         <Fragment>
           {failureConditionFields.map(({name, initialValue, label, hintText}) => (
             <AutoSaveForm

--- a/static/app/views/settings/project/preprod/snapshotStatusChecks.tsx
+++ b/static/app/views/settings/project/preprod/snapshotStatusChecks.tsx
@@ -23,6 +23,12 @@ const schema = z.object({
 });
 
 type Schema = z.infer<typeof schema>;
+type SnapshotStatusCheckField = {
+  hintText: string;
+  initialValue: boolean;
+  label: string;
+  name: keyof Schema;
+};
 
 export function SnapshotStatusChecks() {
   const organization = useOrganization();
@@ -41,6 +47,33 @@ export function SnapshotStatusChecks() {
       }),
     onSuccess: (response: Project) => ProjectsStore.onUpdateSuccess(response),
   };
+
+  const failureConditionFields = [
+    {
+      name: 'preprodSnapshotStatusChecksFailOnChanged',
+      initialValue: failOnChanged,
+      label: t('Fail on Changed Snapshots'),
+      hintText: t('Status check will fail if snapshot pixel content changes in a build.'),
+    },
+    {
+      name: 'preprodSnapshotStatusChecksFailOnRemoved',
+      initialValue: failOnRemoved,
+      label: t('Fail on Removed Snapshots'),
+      hintText: t('Status check will fail if snapshots are removed from a build.'),
+    },
+    {
+      name: 'preprodSnapshotStatusChecksFailOnAdded',
+      initialValue: failOnAdded,
+      label: t('Fail on Added Snapshots'),
+      hintText: t('Status check will fail if new snapshots are added in a build.'),
+    },
+    {
+      name: 'preprodSnapshotStatusChecksFailOnRenamed',
+      initialValue: failOnRenamed,
+      label: t('Fail on Renamed Snapshots'),
+      hintText: t('Status check will fail if snapshots are renamed in a build.'),
+    },
+  ] satisfies SnapshotStatusCheckField[];
 
   return (
     <FieldGroup title={t('Snapshots - Status Checks')}>
@@ -64,77 +97,24 @@ export function SnapshotStatusChecks() {
 
       {enabled ? (
         <Fragment>
-          <AutoSaveForm
-            name="preprodSnapshotStatusChecksFailOnChanged"
-            schema={schema}
-            initialValue={failOnChanged}
-            mutationOptions={mutationOptions}
-          >
-            {field => (
-              <field.Layout.Row
-                label={t('Fail on Changed Snapshots')}
-                hintText={t(
-                  'Status check will fail if snapshot pixel content changes in a build.'
-                )}
-              >
-                <field.Switch checked={field.state.value} onChange={field.handleChange} />
-              </field.Layout.Row>
-            )}
-          </AutoSaveForm>
-
-          <AutoSaveForm
-            name="preprodSnapshotStatusChecksFailOnRemoved"
-            schema={schema}
-            initialValue={failOnRemoved}
-            mutationOptions={mutationOptions}
-          >
-            {field => (
-              <field.Layout.Row
-                label={t('Fail on Removed Snapshots')}
-                hintText={t(
-                  'Status check will fail if snapshots are removed from a build.'
-                )}
-              >
-                <field.Switch checked={field.state.value} onChange={field.handleChange} />
-              </field.Layout.Row>
-            )}
-          </AutoSaveForm>
-
-          <AutoSaveForm
-            name="preprodSnapshotStatusChecksFailOnAdded"
-            schema={schema}
-            initialValue={failOnAdded}
-            mutationOptions={mutationOptions}
-          >
-            {field => (
-              <field.Layout.Row
-                label={t('Fail on Added Snapshots')}
-                hintText={t(
-                  'Status check will fail if new snapshots are added in a build.'
-                )}
-              >
-                <field.Switch checked={field.state.value} onChange={field.handleChange} />
-              </field.Layout.Row>
-            )}
-          </AutoSaveForm>
-
-          <AutoSaveForm
-            name="preprodSnapshotStatusChecksFailOnRenamed"
-            schema={schema}
-            initialValue={failOnRenamed}
-            mutationOptions={mutationOptions}
-          >
-            {field => (
-              <field.Layout.Row
-                label={t('Fail on Renamed Snapshots')}
-                hintText={t(
-                  'Status check will fail if snapshots are renamed in a build.'
-                )}
-              >
-                <field.Switch checked={field.state.value} onChange={field.handleChange} />
-              </field.Layout.Row>
-            )}
-          </AutoSaveForm>
+          {failureConditionFields.map(({name, initialValue, label, hintText}) => (
+            <AutoSaveForm
+              key={name}
+              name={name}
+              schema={schema}
+              initialValue={initialValue}
+              mutationOptions={mutationOptions}
+            >
+              {field => (
+                <field.Layout.Row label={label} hintText={hintText}>
+                  <field.Switch
+                    checked={field.state.value}
+                    onChange={field.handleChange}
+                  />
+                </field.Layout.Row>
+              )}
+            </AutoSaveForm>
+          ))}
         </Fragment>
       ) : (
         <Container padding="md">

--- a/static/app/views/settings/project/preprod/snapshotStatusChecks.tsx
+++ b/static/app/views/settings/project/preprod/snapshotStatusChecks.tsx
@@ -1,6 +1,9 @@
+import {Fragment} from 'react';
 import {z} from 'zod';
 
 import {AutoSaveForm, FieldGroup} from '@sentry/scraps/form';
+import {Container} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
 
 import {t} from 'sentry/locale';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
@@ -39,10 +42,6 @@ export function SnapshotStatusChecks() {
     onSuccess: (response: Project) => ProjectsStore.onUpdateSuccess(response),
   };
 
-  const disabledHint = enabled
-    ? false
-    : t('Enable Snapshot Status Checks above to configure.');
-
   return (
     <FieldGroup title={t('Snapshots - Status Checks')}>
       <AutoSaveForm
@@ -63,87 +62,87 @@ export function SnapshotStatusChecks() {
         )}
       </AutoSaveForm>
 
-      <AutoSaveForm
-        name="preprodSnapshotStatusChecksFailOnChanged"
-        schema={schema}
-        initialValue={failOnChanged}
-        mutationOptions={mutationOptions}
-      >
-        {field => (
-          <field.Layout.Row
-            label={t('Fail on Changed Snapshots')}
-            hintText={t(
-              'Status check will fail if snapshot pixel content changes in a build.'
+      {enabled ? (
+        <Fragment>
+          <AutoSaveForm
+            name="preprodSnapshotStatusChecksFailOnChanged"
+            schema={schema}
+            initialValue={failOnChanged}
+            mutationOptions={mutationOptions}
+          >
+            {field => (
+              <field.Layout.Row
+                label={t('Fail on Changed Snapshots')}
+                hintText={t(
+                  'Status check will fail if snapshot pixel content changes in a build.'
+                )}
+              >
+                <field.Switch checked={field.state.value} onChange={field.handleChange} />
+              </field.Layout.Row>
             )}
-          >
-            <field.Switch
-              checked={enabled ? field.state.value : false}
-              onChange={field.handleChange}
-              disabled={disabledHint}
-            />
-          </field.Layout.Row>
-        )}
-      </AutoSaveForm>
+          </AutoSaveForm>
 
-      <AutoSaveForm
-        name="preprodSnapshotStatusChecksFailOnRemoved"
-        schema={schema}
-        initialValue={failOnRemoved}
-        mutationOptions={mutationOptions}
-      >
-        {field => (
-          <field.Layout.Row
-            label={t('Fail on Removed Snapshots')}
-            hintText={t('Status check will fail if snapshots are removed from a build.')}
+          <AutoSaveForm
+            name="preprodSnapshotStatusChecksFailOnRemoved"
+            schema={schema}
+            initialValue={failOnRemoved}
+            mutationOptions={mutationOptions}
           >
-            <field.Switch
-              checked={enabled ? field.state.value : false}
-              onChange={field.handleChange}
-              disabled={disabledHint}
-            />
-          </field.Layout.Row>
-        )}
-      </AutoSaveForm>
+            {field => (
+              <field.Layout.Row
+                label={t('Fail on Removed Snapshots')}
+                hintText={t(
+                  'Status check will fail if snapshots are removed from a build.'
+                )}
+              >
+                <field.Switch checked={field.state.value} onChange={field.handleChange} />
+              </field.Layout.Row>
+            )}
+          </AutoSaveForm>
 
-      <AutoSaveForm
-        name="preprodSnapshotStatusChecksFailOnAdded"
-        schema={schema}
-        initialValue={failOnAdded}
-        mutationOptions={mutationOptions}
-      >
-        {field => (
-          <field.Layout.Row
-            label={t('Fail on Added Snapshots')}
-            hintText={t('Status check will fail if new snapshots are added in a build.')}
+          <AutoSaveForm
+            name="preprodSnapshotStatusChecksFailOnAdded"
+            schema={schema}
+            initialValue={failOnAdded}
+            mutationOptions={mutationOptions}
           >
-            <field.Switch
-              checked={enabled ? field.state.value : false}
-              onChange={field.handleChange}
-              disabled={disabledHint}
-            />
-          </field.Layout.Row>
-        )}
-      </AutoSaveForm>
+            {field => (
+              <field.Layout.Row
+                label={t('Fail on Added Snapshots')}
+                hintText={t(
+                  'Status check will fail if new snapshots are added in a build.'
+                )}
+              >
+                <field.Switch checked={field.state.value} onChange={field.handleChange} />
+              </field.Layout.Row>
+            )}
+          </AutoSaveForm>
 
-      <AutoSaveForm
-        name="preprodSnapshotStatusChecksFailOnRenamed"
-        schema={schema}
-        initialValue={failOnRenamed}
-        mutationOptions={mutationOptions}
-      >
-        {field => (
-          <field.Layout.Row
-            label={t('Fail on Renamed Snapshots')}
-            hintText={t('Status check will fail if snapshots are renamed in a build.')}
+          <AutoSaveForm
+            name="preprodSnapshotStatusChecksFailOnRenamed"
+            schema={schema}
+            initialValue={failOnRenamed}
+            mutationOptions={mutationOptions}
           >
-            <field.Switch
-              checked={enabled ? field.state.value : false}
-              onChange={field.handleChange}
-              disabled={disabledHint}
-            />
-          </field.Layout.Row>
-        )}
-      </AutoSaveForm>
+            {field => (
+              <field.Layout.Row
+                label={t('Fail on Renamed Snapshots')}
+                hintText={t(
+                  'Status check will fail if snapshots are renamed in a build.'
+                )}
+              >
+                <field.Switch checked={field.state.value} onChange={field.handleChange} />
+              </field.Layout.Row>
+            )}
+          </AutoSaveForm>
+        </Fragment>
+      ) : (
+        <Container padding="md">
+          <Text align="center" variant="muted" italic>
+            {t('Enable status checks to configure failure conditions')}
+          </Text>
+        </Container>
+      )}
     </FieldGroup>
   );
 }

--- a/static/app/views/settings/project/preprod/useSnapshotStatusChecks.ts
+++ b/static/app/views/settings/project/preprod/useSnapshotStatusChecks.ts
@@ -1,21 +1,12 @@
-import {useCallback} from 'react';
-
-import {
-  addErrorMessage,
-  addLoadingMessage,
-  addSuccessMessage,
-} from 'sentry/actionCreators/indicator';
-import {t} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
-import {useUpdateProject} from 'sentry/utils/project/useUpdateProject';
 
 const ENABLED_KEY = 'sentry:preprod_snapshot_status_checks_enabled';
 const FAIL_ON_ADDED_KEY = 'sentry:preprod_snapshot_status_checks_fail_on_added';
 const FAIL_ON_REMOVED_KEY = 'sentry:preprod_snapshot_status_checks_fail_on_removed';
+const FAIL_ON_CHANGED_KEY = 'sentry:preprod_snapshot_status_checks_fail_on_changed';
+const FAIL_ON_RENAMED_KEY = 'sentry:preprod_snapshot_status_checks_fail_on_renamed';
 
 export function useSnapshotStatusChecks(project: Project) {
-  const updateProject = useUpdateProject(project);
-
   const enabled =
     project.preprodSnapshotStatusChecksEnabled ??
     project.options?.[ENABLED_KEY] !== false;
@@ -28,70 +19,19 @@ export function useSnapshotStatusChecks(project: Project) {
     project.preprodSnapshotStatusChecksFailOnRemoved ??
     project.options?.[FAIL_ON_REMOVED_KEY] !== false;
 
-  const setEnabled = useCallback(
-    (value: boolean) => {
-      addLoadingMessage(t('Saving...'));
-      updateProject.mutate(
-        {preprodSnapshotStatusChecksEnabled: value},
-        {
-          onSuccess: () => {
-            addSuccessMessage(
-              value
-                ? t('Snapshot status checks enabled.')
-                : t('Snapshot status checks disabled.')
-            );
-          },
-          onError: () => {
-            addErrorMessage(t('Failed to save changes. Please try again.'));
-          },
-        }
-      );
-    },
-    [updateProject]
-  );
+  const failOnChanged =
+    project.preprodSnapshotStatusChecksFailOnChanged ??
+    project.options?.[FAIL_ON_CHANGED_KEY] !== false;
 
-  const setFailOnAdded = useCallback(
-    (value: boolean) => {
-      addLoadingMessage(t('Saving...'));
-      updateProject.mutate(
-        {preprodSnapshotStatusChecksFailOnAdded: value},
-        {
-          onSuccess: () => {
-            addSuccessMessage(t('Snapshot status check settings updated.'));
-          },
-          onError: () => {
-            addErrorMessage(t('Failed to save changes. Please try again.'));
-          },
-        }
-      );
-    },
-    [updateProject]
-  );
-
-  const setFailOnRemoved = useCallback(
-    (value: boolean) => {
-      addLoadingMessage(t('Saving...'));
-      updateProject.mutate(
-        {preprodSnapshotStatusChecksFailOnRemoved: value},
-        {
-          onSuccess: () => {
-            addSuccessMessage(t('Snapshot status check settings updated.'));
-          },
-          onError: () => {
-            addErrorMessage(t('Failed to save changes. Please try again.'));
-          },
-        }
-      );
-    },
-    [updateProject]
-  );
+  const failOnRenamed =
+    project.preprodSnapshotStatusChecksFailOnRenamed ??
+    project.options?.[FAIL_ON_RENAMED_KEY] === true;
 
   return {
     enabled,
     failOnAdded,
     failOnRemoved,
-    setEnabled,
-    setFailOnAdded,
-    setFailOnRemoved,
+    failOnChanged,
+    failOnRenamed,
   };
 }


### PR DESCRIPTION
Add UI toggles for the new `fail_on_changed` and `fail_on_renamed` snapshot status check options shipped in [#114214](https://github.com/getsentry/sentry/pull/114214), and bring the snapshot status checks settings page in line with the `FieldGroup` + `AutoSaveForm` pattern used elsewhere.

**Show/hide failure conditions**

The page now renders the master "Enable Snapshot Status Checks" toggle plus four failure-condition rows (Changed, Removed, Added, Renamed) in one `FieldGroup`. When the master is toggled, the failure-condition rows show or hide immediately while the setting saves, then roll back if the save fails.

**Failure condition fields**

The repeated failure-condition rows are rendered from a typed field configuration, keeping the master toggle explicit while making the individual condition toggles easier to scan and extend.

**Defaults**

`fail_on_changed` defaults on (preserves current behavior); `fail_on_renamed` defaults off (rename detection is noisy). The hook encodes the per-option default direction so the UI reflects whatever the backend would do for an unset project.

Refs EME-1083