### PR TITLE
fix(dashboards): Return avatarType and correct avatarUrl in revision createdBy

### DIFF
--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -27,6 +27,7 @@ from sentry.snuba.metrics.extraction import OnDemandMetricSpecVersioning
 from sentry.users.api.serializers.user import UserSerializerResponse
 from sentry.users.services.user.service import user_service
 from sentry.utils import json
+from sentry.utils.avatar import get_gravatar_url
 from sentry.utils.dates import outside_retention_with_modified_start, parse_timestamp
 
 DATASET_SOURCES = dict(DatasetSourcesTypes.as_choices())
@@ -719,6 +720,7 @@ class DashboardRevisionSerializer(Serializer):
     def serialize(self, obj, attrs, user, **kwargs) -> DashboardRevisionResponse:
         created_by = attrs.get("created_by") or {}
         avatar = created_by.get("avatar") or {}
+        avatar_type = avatar.get("avatarType")
         return {
             "id": str(obj.id),
             "title": obj.title,
@@ -727,8 +729,10 @@ class DashboardRevisionSerializer(Serializer):
                 "id": created_by["id"],
                 "name": created_by["name"],
                 "email": created_by["email"],
-                "avatarType": avatar.get("avatarType"),
-                "avatarUrl": avatar.get("avatarUrl"),
+                "avatarType": avatar_type,
+                "avatarUrl": get_gravatar_url(created_by["email"], size=32)
+                if avatar_type == "gravatar"
+                else avatar.get("avatarUrl"),
             }
             if created_by
             else None,

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -717,22 +717,20 @@ class DashboardRevisionSerializer(Serializer):
         }
 
     def serialize(self, obj, attrs, user, **kwargs) -> DashboardRevisionResponse:
-        created_by = attrs.get("created_by")
-        if created_by:
-            avatar = created_by.get("avatar") or {}
-            created_by_data: dict[str, Any] | None = {
+        created_by = attrs.get("created_by") or {}
+        avatar = created_by.get("avatar") or {}
+        return {
+            "id": str(obj.id),
+            "title": obj.title,
+            "dateCreated": obj.date_added,
+            "createdBy": {
                 "id": created_by["id"],
                 "name": created_by["name"],
                 "email": created_by["email"],
                 "avatarType": avatar.get("avatarType"),
                 "avatarUrl": avatar.get("avatarUrl"),
             }
-        else:
-            created_by_data = None
-        return {
-            "id": str(obj.id),
-            "title": obj.title,
-            "dateCreated": obj.date_added,
-            "createdBy": created_by_data,
+            if created_by
+            else None,
             "source": obj.source,
         }

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -718,17 +718,22 @@ class DashboardRevisionSerializer(Serializer):
 
     def serialize(self, obj, attrs, user, **kwargs) -> DashboardRevisionResponse:
         created_by = attrs.get("created_by")
+        if created_by:
+            avatar = created_by.get("avatar") or {}
+            avatar_type = avatar.get("avatarType")
+            created_by_data: dict[str, Any] | None = {
+                "id": created_by["id"],
+                "name": created_by["name"],
+                "email": created_by["email"],
+                "avatarType": avatar_type,
+                "avatarUrl": avatar.get("avatarUrl") if avatar_type == "upload" else None,
+            }
+        else:
+            created_by_data = None
         return {
             "id": str(obj.id),
             "title": obj.title,
             "dateCreated": obj.date_added,
-            "createdBy": {
-                "id": created_by["id"],
-                "name": created_by["name"],
-                "email": created_by["email"],
-                "avatarUrl": created_by["avatarUrl"],
-            }
-            if created_by
-            else None,
+            "createdBy": created_by_data,
             "source": obj.source,
         }

--- a/src/sentry/api/serializers/models/dashboard.py
+++ b/src/sentry/api/serializers/models/dashboard.py
@@ -720,13 +720,12 @@ class DashboardRevisionSerializer(Serializer):
         created_by = attrs.get("created_by")
         if created_by:
             avatar = created_by.get("avatar") or {}
-            avatar_type = avatar.get("avatarType")
             created_by_data: dict[str, Any] | None = {
                 "id": created_by["id"],
                 "name": created_by["name"],
                 "email": created_by["email"],
-                "avatarType": avatar_type,
-                "avatarUrl": avatar.get("avatarUrl") if avatar_type == "upload" else None,
+                "avatarType": avatar.get("avatarType"),
+                "avatarUrl": avatar.get("avatarUrl"),
             }
         else:
             created_by_data = None

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_revisions.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_revisions.py
@@ -5,6 +5,7 @@ from django.urls import reverse
 from sentry.models.dashboard import Dashboard, DashboardRevision
 from sentry.testutils.cases import APITestCase
 from sentry.users.models.user_avatar import UserAvatarType
+from sentry.utils.avatar import get_gravatar_url
 
 
 class OrganizationDashboardRevisionsTestCase(APITestCase):
@@ -75,7 +76,9 @@ class GetOrganizationDashboardRevisionsTest(OrganizationDashboardRevisionsTestCa
             response = self.client.get(self.url)
 
         assert response.status_code == 200
-        assert response.data[0]["createdBy"]["avatarType"] == "gravatar"
+        created_by = response.data[0]["createdBy"]
+        assert created_by["avatarType"] == "gravatar"
+        assert created_by["avatarUrl"] == get_gravatar_url(self.user.email, size=32)
 
     def test_returns_upload_avatar_type(self) -> None:
         self.create_user_avatar(user=self.user, avatar_type=UserAvatarType.UPLOAD)

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_revisions.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_revisions.py
@@ -4,7 +4,7 @@ from django.urls import reverse
 
 from sentry.models.dashboard import Dashboard, DashboardRevision
 from sentry.testutils.cases import APITestCase
-from sentry.utils.avatar import get_gravatar_url
+from sentry.users.models.user_avatar import UserAvatarType
 
 
 class OrganizationDashboardRevisionsTestCase(APITestCase):
@@ -63,9 +63,32 @@ class GetOrganizationDashboardRevisionsTest(OrganizationDashboardRevisionsTestCa
             "id": str(self.user.id),
             "name": self.user.get_display_name(),
             "email": self.user.email,
-            "avatarUrl": get_gravatar_url(self.user.email, size=32),
+            "avatarType": "letter_avatar",
+            "avatarUrl": None,
         }
         assert "dateCreated" in data
+
+    def test_returns_null_avatar_url_for_gravatar_type(self) -> None:
+        self.create_user_avatar(user=self.user, avatar_type=UserAvatarType.GRAVATAR)
+        self._create_revision()
+        with self.feature("organizations:dashboards-revisions"):
+            response = self.client.get(self.url)
+
+        assert response.status_code == 200
+        created_by = response.data[0]["createdBy"]
+        assert created_by["avatarType"] == "gravatar"
+        assert created_by["avatarUrl"] is None
+
+    def test_returns_upload_avatar_url_for_upload_type(self) -> None:
+        avatar = self.create_user_avatar(user=self.user, avatar_type=UserAvatarType.UPLOAD)
+        self._create_revision()
+        with self.feature("organizations:dashboards-revisions"):
+            response = self.client.get(self.url)
+
+        assert response.status_code == 200
+        created_by = response.data[0]["createdBy"]
+        assert created_by["avatarType"] == "upload"
+        assert created_by["avatarUrl"] == avatar.absolute_url()
 
     def test_returns_revisions_newest_first(self) -> None:
         first = self._create_revision(title="First")

--- a/tests/sentry/dashboards/endpoints/test_organization_dashboard_revisions.py
+++ b/tests/sentry/dashboards/endpoints/test_organization_dashboard_revisions.py
@@ -68,27 +68,23 @@ class GetOrganizationDashboardRevisionsTest(OrganizationDashboardRevisionsTestCa
         }
         assert "dateCreated" in data
 
-    def test_returns_null_avatar_url_for_gravatar_type(self) -> None:
+    def test_returns_gravatar_avatar_type(self) -> None:
         self.create_user_avatar(user=self.user, avatar_type=UserAvatarType.GRAVATAR)
         self._create_revision()
         with self.feature("organizations:dashboards-revisions"):
             response = self.client.get(self.url)
 
         assert response.status_code == 200
-        created_by = response.data[0]["createdBy"]
-        assert created_by["avatarType"] == "gravatar"
-        assert created_by["avatarUrl"] is None
+        assert response.data[0]["createdBy"]["avatarType"] == "gravatar"
 
-    def test_returns_upload_avatar_url_for_upload_type(self) -> None:
-        avatar = self.create_user_avatar(user=self.user, avatar_type=UserAvatarType.UPLOAD)
+    def test_returns_upload_avatar_type(self) -> None:
+        self.create_user_avatar(user=self.user, avatar_type=UserAvatarType.UPLOAD)
         self._create_revision()
         with self.feature("organizations:dashboards-revisions"):
             response = self.client.get(self.url)
 
         assert response.status_code == 200
-        created_by = response.data[0]["createdBy"]
-        assert created_by["avatarType"] == "upload"
-        assert created_by["avatarUrl"] == avatar.absolute_url()
+        assert response.data[0]["createdBy"]["avatarType"] == "upload"
 
     def test_returns_revisions_newest_first(self) -> None:
         first = self._create_revision(title="First")


### PR DESCRIPTION
For the dashboard revisions serializer, add `avatarType`, so front end knows whether or not to use the avatarUrl, which is always set.