### PR TITLE
fix(jira): Bind JWT iss to body clientKey on install webhook

### DIFF
--- a/src/sentry/integrations/jira/webhooks/installed.py
+++ b/src/sentry/integrations/jira/webhooks/installed.py
@@ -91,18 +91,15 @@ class JiraSentryInstalledWebhook(JiraWebhookBase):
                     {"detail": "Could not decode JWT token"}, status=status.HTTP_400_BAD_REQUEST
                 )
 
-            # Bind the JWT issuer to whichever value will actually be persisted
-            # as Integration.external_id. Per Atlassian Connect, the `iss`
-            # claim on a lifecycle JWT is the tenant's clientKey
-            # (https://developer.atlassian.com/cloud/jira/platform/understanding-jwt-for-connect-apps/),
-            # so requiring iss == external_id ensures the tenant that signed
-            # the request is the same tenant whose Integration row we are
-            # about to write. JiraIntegrationProvider.build_integration
-            # prefers `state["jira"]["external_id"]` when present; otherwise
-            # it falls back to `state["clientKey"]`.
-            expected_external_id = state.get(IntegrationProviderSlug.JIRA.value, {}).get(
-                "external_id"
-            ) or state.get("clientKey")
+            # Bind iss to whichever value build_integration will persist as
+            # Integration.external_id. Branch on state["jira"] (the parent
+            # dict) to match build_integration exactly — branching on the
+            # inner external_id's truthiness diverges when it's empty.
+            jira_state = state.get(IntegrationProviderSlug.JIRA.value)
+            if jira_state:
+                expected_external_id = jira_state.get("external_id")
+            else:
+                expected_external_id = state.get("clientKey")
             if decoded_claims.get("iss") != expected_external_id:
                 lifecycle.record_halt(halt_reason="JWT iss does not match clientKey")
                 return self.respond(

--- a/src/sentry/integrations/jira/webhooks/installed.py
+++ b/src/sentry/integrations/jira/webhooks/installed.py
@@ -14,6 +14,7 @@ from sentry.integrations.jira.tasks import sync_metadata
 from sentry.integrations.jira.webhooks.base import JiraWebhookBase
 from sentry.integrations.pipeline import ensure_integration
 from sentry.integrations.project_management.metrics import ProjectManagementFailuresReason
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.integrations.utils.atlassian_connect import authenticate_asymmetric_jwt, verify_claims
 from sentry.integrations.utils.metrics import (
     IntegrationPipelineViewEvent,
@@ -90,7 +91,19 @@ class JiraSentryInstalledWebhook(JiraWebhookBase):
                     {"detail": "Could not decode JWT token"}, status=status.HTTP_400_BAD_REQUEST
                 )
 
-            if decoded_claims.get("iss") != state.get("clientKey"):
+            # Bind the JWT issuer to whichever value will actually be persisted
+            # as Integration.external_id. Per Atlassian Connect, the `iss`
+            # claim on a lifecycle JWT is the tenant's clientKey
+            # (https://developer.atlassian.com/cloud/jira/platform/understanding-jwt-for-connect-apps/),
+            # so requiring iss == external_id ensures the tenant that signed
+            # the request is the same tenant whose Integration row we are
+            # about to write. JiraIntegrationProvider.build_integration
+            # prefers `state["jira"]["external_id"]` when present; otherwise
+            # it falls back to `state["clientKey"]`.
+            expected_external_id = state.get(IntegrationProviderSlug.JIRA.value, {}).get(
+                "external_id"
+            ) or state.get("clientKey")
+            if decoded_claims.get("iss") != expected_external_id:
                 lifecycle.record_halt(halt_reason="JWT iss does not match clientKey")
                 return self.respond(
                     {"detail": "Token issuer does not match clientKey"},

--- a/src/sentry/integrations/jira/webhooks/installed.py
+++ b/src/sentry/integrations/jira/webhooks/installed.py
@@ -90,6 +90,13 @@ class JiraSentryInstalledWebhook(JiraWebhookBase):
                     {"detail": "Could not decode JWT token"}, status=status.HTTP_400_BAD_REQUEST
                 )
 
+            if decoded_claims.get("iss") != state.get("clientKey"):
+                lifecycle.record_halt(halt_reason="JWT iss does not match clientKey")
+                return self.respond(
+                    {"detail": "Token issuer does not match clientKey"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
             data = JiraIntegrationProvider().build_integration(state)
             integration = ensure_integration(self.provider, data)
 

--- a/tests/sentry/integrations/jira/test_installed.py
+++ b/tests/sentry/integrations/jira/test_installed.py
@@ -212,17 +212,45 @@ class JiraInstalledTest(APITestCase):
         self.add_response()
 
         # JWT is signed by tenant `it2may+cody` (self.external_id) but the body
-        # claims a different tenant via clientKey. Without the iss/clientKey
-        # binding check the install would rebind clientKey's existing
-        # integration row to this attacker's shared secret.
+        # carries a different tenant in clientKey. With no `jira` sub-dict
+        # build_integration falls back to clientKey for external_id, so
+        # rejecting on iss != clientKey prevents persisting a row keyed by
+        # an unsigned tenant.
+        body = dict(self.body(client_key="some-other-tenant"))
+        body.pop("jira", None)
         self.get_error_response(
-            **self.body(client_key="someone-elses-tenant"),
+            **body,
             extra_headers=dict(HTTP_AUTHORIZATION="JWT " + self.jwt_token_cdn()),
             status_code=status.HTTP_400_BAD_REQUEST,
         )
 
         assert not Integration.objects.filter(
-            provider="jira", external_id="someone-elses-tenant"
+            provider="jira", external_id="some-other-tenant"
+        ).exists()
+        assert_halt_metric(mock_record_event, "JWT iss does not match clientKey")
+
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @responses.activate
+    def test_rejects_when_jira_external_id_does_not_match_jwt_iss(
+        self, mock_record_event: MagicMock
+    ) -> None:
+        self.add_response()
+
+        # JWT is signed by tenant `it2may+cody` (self.external_id) and clientKey
+        # matches it, but `jira.external_id` is different. Since
+        # build_integration prefers `state["jira"]["external_id"]` over
+        # clientKey, the persisted Integration.external_id must also match the
+        # signing tenant.
+        body = dict(self.body())
+        body["jira"] = {"metadata": {}, "external_id": "some-other-tenant"}
+        self.get_error_response(
+            **body,
+            extra_headers=dict(HTTP_AUTHORIZATION="JWT " + self.jwt_token_cdn()),
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+        assert not Integration.objects.filter(
+            provider="jira", external_id="some-other-tenant"
         ).exists()
         assert_halt_metric(mock_record_event, "JWT iss does not match clientKey")
 

--- a/tests/sentry/integrations/jira/test_installed.py
+++ b/tests/sentry/integrations/jira/test_installed.py
@@ -57,13 +57,13 @@ class JiraInstalledTest(APITestCase):
     def jwt_token_cdn(self):
         return self._jwt_token("RS256", RS256_KEY, headers={"kid": self.kid})
 
-    def body(self) -> Mapping[str, Any]:
+    def body(self, client_key: str | None = None) -> Mapping[str, Any]:
         return {
             "jira": {
                 "metadata": {},
                 "external_id": self.external_id,
             },
-            "clientKey": "limepie",
+            "clientKey": client_key if client_key is not None else self.external_id,
             "oauthClientId": "EFG",
             "publicKey": "yourCar",
             "sharedSecret": self.shared_secret,
@@ -203,6 +203,28 @@ class JiraInstalledTest(APITestCase):
 
         mock_set_tag.assert_any_call("integration_id", integration.id)
         assert integration.status == ObjectStatus.ACTIVE
+
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @responses.activate
+    def test_rejects_when_jwt_iss_does_not_match_client_key(
+        self, mock_record_event: MagicMock
+    ) -> None:
+        self.add_response()
+
+        # JWT is signed by tenant `it2may+cody` (self.external_id) but the body
+        # claims a different tenant via clientKey. Without the iss/clientKey
+        # binding check the install would rebind clientKey's existing
+        # integration row to this attacker's shared secret.
+        self.get_error_response(
+            **self.body(client_key="someone-elses-tenant"),
+            extra_headers=dict(HTTP_AUTHORIZATION="JWT " + self.jwt_token_cdn()),
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+        assert not Integration.objects.filter(
+            provider="jira", external_id="someone-elses-tenant"
+        ).exists()
+        assert_halt_metric(mock_record_event, "JWT iss does not match clientKey")
 
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     def test_without_key_id(self, mock_record_event: MagicMock) -> None:

--- a/tests/sentry/integrations/jira/test_installed.py
+++ b/tests/sentry/integrations/jira/test_installed.py
@@ -255,6 +255,26 @@ class JiraInstalledTest(APITestCase):
         assert_halt_metric(mock_record_event, "JWT iss does not match clientKey")
 
     @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @responses.activate
+    def test_rejects_when_jira_external_id_is_empty(self, mock_record_event: MagicMock) -> None:
+        self.add_response()
+
+        # state["jira"] is truthy but its external_id is empty. build_integration
+        # branches on state["jira"]'s truthiness, so it would persist
+        # external_id="" — the binding must reject this rather than silently
+        # fall back to clientKey for the comparison.
+        body = dict(self.body())
+        body["jira"] = {"metadata": {}, "external_id": ""}
+        self.get_error_response(
+            **body,
+            extra_headers=dict(HTTP_AUTHORIZATION="JWT " + self.jwt_token_cdn()),
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+        assert not Integration.objects.filter(provider="jira", external_id="").exists()
+        assert_halt_metric(mock_record_event, "JWT iss does not match clientKey")
+
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
     def test_without_key_id(self, mock_record_event: MagicMock) -> None:
         self.get_error_response(
             **self.body(),


### PR DESCRIPTION
The Jira install webhook verifies an asymmetrically-signed JWT (per Atlassian Connect, the `iss` claim is the calling tenant's `clientKey`), but `JiraIntegrationProvider.build_integration` reads the persisted `Integration.external_id` from `state["jira"]["external_id"]` when present and only falls back to `state["clientKey"]` otherwise. Comparing `iss` solely against `clientKey` left a path where the body could carry one tenant in `clientKey` (matching the JWT) and a different tenant in `state["jira"]["external_id"]`, persisting an Integration row keyed by an unsigned tenant.

This PR binds `iss` against whichever value will actually become `external_id`, so the binding holds in both branches of `build_integration`. Two regression tests cover the clientKey-fallback path and the \`jira\` sub-dict path; both fail without the fix.

  Reference: https://developer.atlassian.com/cloud/jira/platform/understanding-jwt-for-connect-apps/
