### PR TITLE
ref(✂️): drop pipeline entry point from knip config

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -21,8 +21,6 @@ const productionEntryPoints = [
   // todo find out how chartcuterie works
   'static/app/chartcuterie/**/*.{js,ts,tsx}',
   // TODO: Remove when used
-  'static/app/components/pipeline/**/*.{js,ts,tsx}',
-  // TODO: Remove when used
   'static/app/views/seerExplorer/contexts/**/*.{js,ts,tsx}',
 ];
 

--- a/static/app/components/pipeline/shared/useRedirectPopupStep.tsx
+++ b/static/app/components/pipeline/shared/useRedirectPopupStep.tsx
@@ -10,7 +10,7 @@ export interface PopupOptions {
   width?: number;
 }
 
-export type PopupStatus = 'not-open' | 'popup-open' | 'failed-to-open';
+type PopupStatus = 'not-open' | 'popup-open' | 'failed-to-open';
 
 interface UseRedirectPopupStepOptions {
   /**

--- a/static/app/components/pipeline/types.tsx
+++ b/static/app/components/pipeline/types.tsx
@@ -14,7 +14,7 @@ export function getBackendPipelineType(type: PipelineType): string {
 /**
  * A single step in a pipeline definition.
  */
-export interface PipelineStepDefinition<StepId extends string = string> {
+interface PipelineStepDefinition<StepId extends string = string> {
   /**
    * The React component rendered for this step. Receives step data,
    * an advance callback, and error state via {@link PipelineStepProps}.


### PR DESCRIPTION
The pipeline framework is now reachable from real production entry points via `useAddIntegration` -> `openPipelineModal` -> `registry.tsx`, so the explicit knip entry can go away.

Verified by running `pnpm run knip:prod` -- the pipeline files are no longer flagged as unused.