### PR TITLE
ref(seer): Skip stale and security-report groups in supergroups backfill

### DIFF
--- a/src/sentry/tasks/seer/backfill_supergroups_lightweight.py
+++ b/src/sentry/tasks/seer/backfill_supergroups_lightweight.py
@@ -6,6 +6,7 @@ from snuba_sdk import Column, Condition, Direction, Entity, Limit, Op, OrderBy, 
 
 from sentry import features, options
 from sentry.api.serializers import EventSerializer, serialize
+from sentry.event_manager import SECURITY_REPORT_INTERFACES
 from sentry.eventstore import backend as eventstore
 from sentry.models.group import DEFAULT_TYPE_ID, Group, GroupStatus
 from sentry.models.organization import Organization
@@ -28,6 +29,7 @@ from sentry.utils.snuba import SnubaError, bulk_snuba_queries
 logger = logging.getLogger(__name__)
 
 SNUBA_QUERY_MAX_ATTEMPTS = 3
+MAX_GROUP_AGE_DAYS = 90
 
 
 @instrumented_task(
@@ -120,6 +122,7 @@ def _backfill_org(
             id__gt=last_group_id,
             status=GroupStatus.UNRESOLVED,
             substatus__in=UNRESOLVED_SUBSTATUS_CHOICES,
+            last_seen__gte=datetime.now(UTC) - timedelta(days=MAX_GROUP_AGE_DAYS),
         )
         .select_related("project", "project__organization")
         .order_by("id")[:batch_size]
@@ -313,13 +316,26 @@ def _batch_fetch_events(groups: Sequence[Group], organization_id: int) -> list[t
     # Batch fetch all event data from nodestore in one multi-get
     eventstore.bind_nodes(events)
 
-    # Filter out events with empty data
+    # Drop events with empty data and security-report event types (CSP/HPKP/
+    # Expect-CT/Expect-Staple/NEL) — they all roll up under ErrorGroupType but
+    # don't carry the application-code signal that RCA clustering needs.
     valid_groups: list[Group] = []
     valid_events: list[Event] = []
+    skipped_security_reports = 0
     for group, event in zip(matched_groups, events):
-        if event.data:
-            valid_groups.append(group)
-            valid_events.append(event)
+        if not event.data:
+            continue
+        if event.get_event_type() in SECURITY_REPORT_INTERFACES:
+            skipped_security_reports += 1
+            continue
+        valid_groups.append(group)
+        valid_events.append(event)
+
+    if skipped_security_reports:
+        metrics.incr(
+            "seer.supergroups_backfill_lightweight.security_reports_skipped",
+            amount=skipped_security_reports,
+        )
 
     if not valid_events:
         return []

--- a/tests/sentry/tasks/seer/test_backfill_supergroups_lightweight.py
+++ b/tests/sentry/tasks/seer/test_backfill_supergroups_lightweight.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from sentry.eventstore import backend as eventstore
 from sentry.models.group import DEFAULT_TYPE_ID
 from sentry.tasks.seer.backfill_supergroups_lightweight import (
     backfill_supergroups_lightweight_for_org,
@@ -177,13 +178,69 @@ class BackfillSupergroupsLightweightForOrgTest(TestCase):
     )
     @patch("sentry.tasks.seer.backfill_supergroups_lightweight.bulk_snuba_queries")
     def test_skips_old_groups_with_no_events(self, mock_snuba, mock_request):
-        """Old groups are still fetched from DB but skipped when Snuba returns no events."""
-        self.group.last_seen = datetime.now(UTC) - timedelta(days=91)
+        """Groups inside the age window but with no Snuba events are skipped."""
+        # Inside the 90-day DB cutoff so the group reaches Snuba; this exercises
+        # the secondary skip path (e.g. events aged out of Snuba retention).
+        self.group.last_seen = datetime.now(UTC) - timedelta(days=30)
         self.group.save(update_fields=["last_seen"])
 
         mock_snuba.return_value = [{"data": []}]
 
         backfill_supergroups_lightweight_for_org(self.organization.id)
+
+        mock_request.assert_not_called()
+
+    @with_feature("organizations:supergroups-lightweight-rca-clustering-write")
+    @patch(
+        "sentry.tasks.seer.backfill_supergroups_lightweight.make_lightweight_rca_cluster_request"
+    )
+    @patch("sentry.tasks.seer.backfill_supergroups_lightweight.bulk_snuba_queries")
+    def test_skips_groups_older_than_max_age(self, mock_snuba, mock_request):
+        self.group.last_seen = datetime.now(UTC) - timedelta(days=91)
+        self.group.save(update_fields=["last_seen"])
+
+        backfill_supergroups_lightweight_for_org(self.organization.id)
+
+        # DB-level filter — Snuba is never queried for stale groups.
+        mock_snuba.assert_not_called()
+        mock_request.assert_not_called()
+
+    @with_feature("organizations:supergroups-lightweight-rca-clustering-write")
+    @patch(
+        "sentry.tasks.seer.backfill_supergroups_lightweight.make_lightweight_rca_cluster_request"
+    )
+    def test_processes_groups_within_max_age(self, mock_request):
+        mock_request.return_value = MagicMock(status=200)
+        self.group.last_seen = datetime.now(UTC) - timedelta(days=89)
+        self.group.save(update_fields=["last_seen"])
+
+        backfill_supergroups_lightweight_for_org(self.organization.id)
+
+        mock_request.assert_called_once()
+
+    @with_feature("organizations:supergroups-lightweight-rca-clustering-write")
+    @patch(
+        "sentry.tasks.seer.backfill_supergroups_lightweight.make_lightweight_rca_cluster_request"
+    )
+    def test_skips_security_report_event_types(self, mock_request):
+        mock_request.return_value = MagicMock(status=200)
+
+        # Bind real node data, then stamp the event as a security report so the
+        # task's get_event_type() check trips. Avoids fighting Relay
+        # normalization to mint a real CSP fixture in the test.
+        original_bind = eventstore.bind_nodes
+
+        def bind_and_mark_csp(events):
+            original_bind(events)
+            for event in events:
+                if event.data:
+                    event.data["type"] = "csp"
+
+        with patch(
+            "sentry.tasks.seer.backfill_supergroups_lightweight.eventstore.bind_nodes",
+            side_effect=bind_and_mark_csp,
+        ):
+            backfill_supergroups_lightweight_for_org(self.organization.id)
 
         mock_request.assert_not_called()
 


### PR DESCRIPTION
Cuts cost on the Seer lightweight RCA clustering backfill by filtering two slices that don't carry clustering signal:

- Groups with `last_seen` > 90 days, filtered at the DB query (previously skipped only after a wasted Snuba round-trip).
- Security-report event types (CSP / HPKP / Expect-CT / Expect-Staple / NEL) — they collapse into `ErrorGroupType` but reflect browser/network conditions, not application code. Dropped after nodestore bind via `SECURITY_REPORT_INTERFACES`. New `seer.supergroups_backfill_lightweight.security_reports_skipped` metric tracks volume.