### PR TITLE
feat(issues): Allow prioritizing a thread in the Apple crash report

### DIFF
--- a/src/sentry/api/endpoints/event_apple_crash_report.py
+++ b/src/sentry/api/endpoints/event_apple_crash_report.py
@@ -37,6 +37,7 @@ class EventAppleCrashReportEndpoint(ProjectEndpoint):
             )
 
         symbolicated = request.GET.get("minified") not in ("1", "true")
+        prioritized_thread_id = request.GET.get("thread_id") or None
 
         apple_crash_report_string = str(
             AppleCrashReport(
@@ -45,6 +46,7 @@ class EventAppleCrashReportEndpoint(ProjectEndpoint):
                 debug_images=get_path(event.data, "debug_meta", "images", filter=True),
                 exceptions=get_path(event.data, "exception", "values", filter=True),
                 symbolicated=symbolicated,
+                prioritized_thread_id=prioritized_thread_id,
             )
         )
 

--- a/src/sentry/lang/native/applecrashreport.py
+++ b/src/sentry/lang/native/applecrashreport.py
@@ -20,7 +20,13 @@ REPORT_VERSION = "104"
 
 class AppleCrashReport:
     def __init__(
-        self, threads=None, context=None, debug_images=None, symbolicated=False, exceptions=None
+        self,
+        threads=None,
+        context=None,
+        debug_images=None,
+        symbolicated=False,
+        exceptions=None,
+        prioritized_thread_id=None,
     ):
         """
         Create an Apple crash report from the provided data.
@@ -31,6 +37,9 @@ class AppleCrashReport:
         self.context = context
         self.symbolicated = symbolicated
         self.exceptions = exceptions if exceptions else []
+        self.prioritized_thread_id = (
+            str(prioritized_thread_id) if prioritized_thread_id is not None else None
+        )
         self.image_addrs_to_vmaddrs = {}
 
         # Remove frames that don't have an `instruction_addr` and convert
@@ -212,6 +221,12 @@ class AppleCrashReport:
         rv = []
         exceptions = self.exceptions or []
         threads = self.threads or []
+
+        if self.prioritized_thread_id is not None:
+            threads = sorted(
+                threads,
+                key=lambda t: str(t.get("id")) != self.prioritized_thread_id,
+            )
 
         # Process threads first, tracking which ones produced output.
         # When an exception's thread_id matches a thread that produced

--- a/tests/sentry/lang/native/test_applecrashreport.py
+++ b/tests/sentry/lang/native/test_applecrashreport.py
@@ -190,6 +190,47 @@ Thread 2 name: background\n\
     )
 
 
+def _thread(thread_id):
+    return {
+        "id": thread_id,
+        "stacktrace": {
+            "frames": [
+                {
+                    "image_addr": "0x2c8000",
+                    "instruction_addr": "0x31c3e8",
+                    "symbol_addr": "0x31b9f8",
+                    "package": "/path/to/Lib.framework/Lib",
+                }
+            ]
+        },
+    }
+
+
+def _thread_order(output):
+    return [int(line.split()[1]) for line in output.splitlines() if line.startswith("Thread ")]
+
+
+def test_get_threads_apple_string_prioritized_thread_id() -> None:
+    threads = [_thread(965139), _thread(1874743)]
+
+    # Default: payload order.
+    default = AppleCrashReport(threads=threads).get_threads_apple_string()
+    assert _thread_order(default) == [965139, 1874743]
+
+    # Prioritized id moves to the top; accepts int or string.
+    for thread_id in (1874743, "1874743"):
+        output = AppleCrashReport(
+            threads=threads, prioritized_thread_id=thread_id
+        ).get_threads_apple_string()
+        assert _thread_order(output) == [1874743, 965139]
+
+    # Unknown id is a no-op.
+    unknown = AppleCrashReport(
+        threads=threads, prioritized_thread_id=999
+    ).get_threads_apple_string()
+    assert _thread_order(unknown) == [965139, 1874743]
+
+
 def test_get_threads_apple_string_symbolicated() -> None:
     acr = AppleCrashReport(
         symbolicated=True,


### PR DESCRIPTION
The Apple crash report renders threads in payload order. The header line says `Crashed Thread: <id>` but the thread with that id can land anywhere in the list, sometimes the middle, which is confusing when scanning the raw report.

Adds an optional `?thread_id=<id>` query param on the apple-crash-report endpoint. When set, that thread is sorted to the top and the rest keep payload order. Default behavior is unchanged when omitted, so the download link and other consumers aren't affected.

Frontend wiring (passing the active thread id from the UI) lands in a follow-up PR. This needs to deploy first.