### PR TITLE
fix(ACI): Restrict condition types based on whether it's a trigger or an action filter

### DIFF
--- a/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
@@ -35,6 +35,7 @@ from sentry.workflow_engine.models import (
     Workflow,
     WorkflowDataConditionGroup,
 )
+from sentry.workflow_engine.models.data_condition import TRIGGER_CONDITIONS, Condition
 
 InputData = dict[str, Any]
 ListInputData = list[InputData]
@@ -106,10 +107,26 @@ class WorkflowValidator(CamelSnakeSerializer[Any]):
         schema = Workflow.config_schema
         return validate_json_schema(value, schema)
 
+    def validate_triggers(self, value: InputData) -> InputData:
+        for condition in value.get("conditions", []):
+            if Condition(condition["type"]) not in TRIGGER_CONDITIONS:
+                raise serializers.ValidationError(
+                    f"Condition type '{condition['type']}' is not a valid trigger condition. "
+                    f"Only trigger condition types are permitted in triggers."
+                )
+        return value
+
     def validate_action_filters(self, value: ListInputData) -> ListInputData:
         for action_filter in value:
             actions, condition_group = self._split_action_and_condition_group(action_filter)
             BaseDataConditionGroupValidator(data=condition_group).is_valid(raise_exception=True)
+
+            for condition in condition_group.get("conditions", []):
+                if Condition(condition["type"]) in TRIGGER_CONDITIONS:
+                    raise serializers.ValidationError(
+                        f"Condition type '{condition['type']}' is not allowed in action filters. "
+                        f"Trigger condition types cannot be used in action filters."
+                    )
 
             validated_actions = []
             for action in actions:

--- a/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
+++ b/src/sentry/workflow_engine/endpoints/validators/base/workflow.py
@@ -111,8 +111,7 @@ class WorkflowValidator(CamelSnakeSerializer[Any]):
         for condition in value.get("conditions", []):
             if Condition(condition["type"]) not in TRIGGER_CONDITIONS:
                 raise serializers.ValidationError(
-                    f"Condition type '{condition['type']}' is not a valid trigger condition. "
-                    f"Only trigger condition types are permitted in triggers."
+                    f"Condition type '{condition['type']}' is not a valid trigger condition."
                 )
         return value
 
@@ -124,8 +123,7 @@ class WorkflowValidator(CamelSnakeSerializer[Any]):
             for condition in condition_group.get("conditions", []):
                 if Condition(condition["type"]) in TRIGGER_CONDITIONS:
                     raise serializers.ValidationError(
-                        f"Condition type '{condition['type']}' is not allowed in action filters. "
-                        f"Trigger condition types cannot be used in action filters."
+                        f"Condition type '{condition['type']}' is not a valid action filter condition."
                     )
 
             validated_actions = []

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
@@ -755,12 +755,12 @@ class OrganizationUpdateWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWo
             **self.valid_workflow,
             "actionFilters": [
                 {
-                    "logicType": "any-short",
+                    "logicType": "any",
                     "conditions": [
                         {
                             "conditionGroupId": other_dcg.id,
-                            "type": "first_seen_event",
-                            "comparison": True,
+                            "type": Condition.EQUAL.value,
+                            "comparison": 1,
                             "conditionResult": True,
                         }
                     ],

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
@@ -683,11 +683,9 @@ class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase, BaseWorkfl
         assert response.data == serialize(new_workflow)
 
     def test_create_workflow__with_triggers(self) -> None:
-        # TODO: the basic condition is not actually a trigger, it's an actionFilter
-        # we should restrict the Condition types to be passed through a trigger
         self.valid_workflow["triggers"] = {
-            "logicType": "any",
-            "conditions": self.basic_condition,
+            "logicType": "any-short",
+            "conditions": self.basic_trigger,
         }
 
         response = self.get_success_response(
@@ -1159,12 +1157,12 @@ class OrganizationWorkflowCreateTest(OrganizationWorkflowAPITestCase, BaseWorkfl
             **self.valid_workflow,
             "actionFilters": [
                 {
-                    "logicType": "any-short",
+                    "logicType": "any",
                     "conditions": [
                         {
                             "conditionGroupId": other_dcg.id,
-                            "type": "first_seen_event",
-                            "comparison": True,
+                            "type": Condition.EQUAL.value,
+                            "comparison": 1,
                             "conditionResult": True,
                         }
                     ],

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
@@ -131,7 +131,7 @@ class TestWorkflowValidator(TestCase):
         validator = WorkflowValidator(data=self.valid_data, context=self.context)
         assert validator.is_valid() is False
         assert validator.errors["triggers"][0] == ErrorDetail(
-            string="Condition type 'new_high_priority_issue' is not a valid trigger condition. Only trigger condition types are permitted in triggers.",
+            string="Condition type 'new_high_priority_issue' is not a valid trigger condition.",
             code="invalid",
         )
 
@@ -152,7 +152,7 @@ class TestWorkflowValidator(TestCase):
         validator = WorkflowValidator(data=self.valid_data, context=self.context)
         assert validator.is_valid() is False
         assert validator.errors["actionFilters"][0] == ErrorDetail(
-            string="Condition type 'first_seen_event' is not allowed in action filters. Trigger condition types cannot be used in action filters.",
+            string="Condition type 'first_seen_event' is not a valid action filter condition.",
             code="invalid",
         )
 

--- a/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/test_base_workflow.py
@@ -117,6 +117,45 @@ class TestWorkflowValidator(TestCase):
         validator = WorkflowValidator(data=self.valid_data, context=self.context)
         assert validator.is_valid() is False
 
+    def test_invalid_data__trigger_with_non_trigger_condition(self) -> None:
+        self.valid_data["triggers"] = {
+            "logicType": "any",
+            "conditions": [
+                {
+                    "type": Condition.NEW_HIGH_PRIORITY_ISSUE,
+                    "comparison": True,
+                    "conditionResult": True,
+                }
+            ],
+        }
+        validator = WorkflowValidator(data=self.valid_data, context=self.context)
+        assert validator.is_valid() is False
+        assert validator.errors["triggers"][0] == ErrorDetail(
+            string="Condition type 'new_high_priority_issue' is not a valid trigger condition. Only trigger condition types are permitted in triggers.",
+            code="invalid",
+        )
+
+    def test_invalid_data__action_filter_with_trigger_condition(self) -> None:
+        self.valid_data["actionFilters"] = [
+            {
+                "logicType": "any",
+                "conditions": [
+                    {
+                        "type": Condition.FIRST_SEEN_EVENT,
+                        "comparison": True,
+                        "conditionResult": True,
+                    }
+                ],
+                "actions": [],
+            }
+        ]
+        validator = WorkflowValidator(data=self.valid_data, context=self.context)
+        assert validator.is_valid() is False
+        assert validator.errors["actionFilters"][0] == ErrorDetail(
+            string="Condition type 'first_seen_event' is not allowed in action filters. Trigger condition types cannot be used in action filters.",
+            code="invalid",
+        )
+
 
 class TestWorkflowValidatorCreate(TestCase):
     def setUp(self) -> None:
@@ -279,11 +318,11 @@ class TestWorkflowValidatorCreate(TestCase):
 
     def test_create__validate_triggers_with_conditions(self) -> None:
         self.valid_data["triggers"] = {
-            "logicType": "any",
+            "logicType": "any-short",
             "conditions": [
                 {
-                    "type": Condition.EQUAL,
-                    "comparison": 1,
+                    "type": Condition.FIRST_SEEN_EVENT,
+                    "comparison": True,
                     "conditionResult": True,
                 }
             ],
@@ -299,7 +338,7 @@ class TestWorkflowValidatorCreate(TestCase):
 
         trigger_condition = trigger.conditions.first()
         assert trigger_condition is not None
-        assert trigger_condition.type == Condition.EQUAL
+        assert trigger_condition.type == Condition.FIRST_SEEN_EVENT
 
     @mock.patch(
         "sentry.workflow_engine.registry.action_handler_registry.get",
@@ -519,11 +558,11 @@ class TestWorkflowValidatorUpdate(TestCase):
                 "frequency": 30,
             },
             "triggers": {
-                "logicType": "any",
+                "logicType": "any-short",
                 "conditions": [
                     {
-                        "type": Condition.EQUAL,
-                        "comparison": 1,
+                        "type": Condition.FIRST_SEEN_EVENT,
+                        "comparison": True,
                         "condition_result": True,
                     },
                 ],
@@ -698,11 +737,11 @@ class TestWorkflowValidatorUpdate(TestCase):
 
     def test_update__data_condition(self, mock_action_validator: mock.MagicMock) -> None:
         first_condition = self._get_first_trigger_condition(self.workflow)
-        assert first_condition.comparison == 1
+        assert first_condition.comparison is True
 
         assert self.valid_saved_data["triggers"] is not None
         updated_condition = self.valid_saved_data["triggers"]["conditions"][0]
-        updated_condition["comparison"] = 2
+        updated_condition["comparison"] = False
         self.valid_saved_data["triggers"]["conditions"][0] = updated_condition
 
         validator = WorkflowValidator(data=self.valid_saved_data, context=self.context)
@@ -718,9 +757,9 @@ class TestWorkflowValidatorUpdate(TestCase):
         assert self.workflow.when_condition_group
         assert self.workflow.when_condition_group.conditions.count() == 1
         dc = self.workflow.when_condition_group.conditions.create(
-            type=Condition.EQUAL,
-            comparison=2,
-            condition_result=False,
+            type=Condition.REAPPEARED_EVENT,
+            comparison=True,
+            condition_result=True,
         )
         assert self.workflow.when_condition_group.conditions.count() == 2
         serializer = WorkflowSerializer()


### PR DESCRIPTION
We have two types of data conditions - triggers and action filters. Within these there are specific condition types that should only be used depending on which type of data condition it is. While the front end only provides the correct options it's currently possible to create an invalid Workflow via the API if passing the wrong type of condition. This PR enforces validation per type, mainly by checking if it's a trigger and the condition types is in a list of acceptable conditions. This is done on the workflow validation level because we don't know if it's a trigger or action filter in the data condition group validator. 