### PR TITLE
feat(cmdk): improve no-result query recall

### DIFF
--- a/static/app/components/commandPalette/ui/commandPalette.spec.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.spec.tsx
@@ -491,6 +491,25 @@ describe('CommandPalette', () => {
       expect(await screen.findByRole('option', {name: 'Dark'})).toBeInTheDocument();
       expect(screen.queryByRole('option', {name: 'Light'})).not.toBeInTheDocument();
     });
+
+    it('shows a group preview when the group label matches but its children do not', async () => {
+      render(
+        <GlobalActionsComponent>
+          <CMDKAction display={{label: 'Help'}}>
+            <CMDKAction to="/docs/" display={{label: 'Open Documentation'}} />
+            <CMDKAction to="/discord/" display={{label: 'Join Discord'}} />
+          </CMDKAction>
+        </GlobalActionsComponent>
+      );
+
+      const input = await screen.findByRole('textbox', {name: 'Search commands'});
+      await userEvent.type(input, 'help');
+
+      expect(
+        await screen.findByRole('option', {name: 'Open Documentation'})
+      ).toBeInTheDocument();
+      expect(screen.getByRole('option', {name: 'Join Discord'})).toBeInTheDocument();
+    });
   });
 
   describe('action with onAction and children', () => {

--- a/static/app/components/commandPalette/ui/commandPalette.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.tsx
@@ -904,10 +904,18 @@ function flattenActions(
       const matched = item.children.filter(
         c => scores.get(c.key)?.matched && !isEmptyResourceNode(c) && !seen.has(c.key)
       );
-      if (!matched.length) return [];
-      const sortedMatches = matched.sort((a, b) =>
-        compareCommandPaletteScores(scores.get(a.key), scores.get(b.key))
+      const fallbackChildren = item.children.filter(
+        c => !isEmptyResourceNode(c) && !seen.has(c.key)
       );
+      const shouldUseFallbackChildren =
+        matched.length === 0 && scores.get(item.key)?.matched;
+      const candidateChildren = shouldUseFallbackChildren ? fallbackChildren : matched;
+      if (!candidateChildren.length) return [];
+      const sortedMatches = shouldUseFallbackChildren
+        ? candidateChildren
+        : candidateChildren.sort((a, b) =>
+            compareCommandPaletteScores(scores.get(a.key), scores.get(b.key))
+          );
       const limitedMatches = getLimitedChildren(sortedMatches, item.limit);
       // Mark every child and their entire subtrees as seen — including those
       // beyond the limit — so neither over-limit children nor any of their
@@ -925,7 +933,7 @@ function flattenActions(
         root = parent;
       }
       const isNested = root.key !== item.key;
-      const seeMore = shouldShowSeeMore(matched.length, item.limit);
+      const seeMore = shouldShowSeeMore(candidateChildren.length, item.limit);
 
       if (isNested) {
         for (const child of limitedMatches) {

--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.spec.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.spec.tsx
@@ -354,6 +354,24 @@ describe('GlobalCommandPaletteActions - search recall', () => {
       query: '954df831ab094388ac98eee198584479',
       lookupUrl: `/organizations/${organization.slug}/eventids/954df831ab094388ac98eee198584479/`,
     },
+    {
+      body: {
+        event: {id: '954df831-ab09-4388-ac98-eee198584479'},
+        eventId: '954df831-ab09-4388-ac98-eee198584479',
+        groupId: '42',
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
+      },
+      expectedOption: /Event 954df831-ab09-4388-ac98-eee198584479/,
+      groupBody: {
+        id: '42',
+        metadata: {},
+        project: {id: project.id, slug: project.slug},
+        status: 'unresolved',
+      },
+      query: '954df831-ab09-4388-ac98-eee198584479',
+      lookupUrl: `/organizations/${organization.slug}/eventids/954df831-ab09-4388-ac98-eee198584479/`,
+    },
   ])(
     'resolves pasted identifiers for %s',
     async ({query, lookupUrl, body, groupBody, expectedOption}) => {

--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.spec.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.spec.tsx
@@ -321,18 +321,18 @@ describe('GlobalCommandPaletteActions - search recall', () => {
   it.each([
     {
       body: {
+        group: {
+          id: '42',
+          metadata: {},
+          project: {id: project.id, slug: project.slug},
+          status: 'unresolved',
+        },
         groupId: '42',
         organizationSlug: organization.slug,
         projectSlug: project.slug,
         shortId: 'WEB-HZX',
       },
       expectedOption: /Issue WEB-HZX/,
-      groupBody: {
-        id: '42',
-        metadata: {},
-        project: {id: project.id, slug: project.slug},
-        status: 'unresolved',
-      },
       query: 'WEB-HZX',
       lookupUrl: `/organizations/${organization.slug}/shortids/WEB-HZX/`,
     },
@@ -345,12 +345,6 @@ describe('GlobalCommandPaletteActions - search recall', () => {
         projectSlug: project.slug,
       },
       expectedOption: /Event 954df831ab094388ac98eee198584479/,
-      groupBody: {
-        id: '42',
-        metadata: {},
-        project: {id: project.id, slug: project.slug},
-        status: 'unresolved',
-      },
       query: '954df831ab094388ac98eee198584479',
       lookupUrl: `/organizations/${organization.slug}/eventids/954df831ab094388ac98eee198584479/`,
     },
@@ -363,25 +357,15 @@ describe('GlobalCommandPaletteActions - search recall', () => {
         projectSlug: project.slug,
       },
       expectedOption: /Event 954df831-ab09-4388-ac98-eee198584479/,
-      groupBody: {
-        id: '42',
-        metadata: {},
-        project: {id: project.id, slug: project.slug},
-        status: 'unresolved',
-      },
       query: '954df831-ab09-4388-ac98-eee198584479',
       lookupUrl: `/organizations/${organization.slug}/eventids/954df831-ab09-4388-ac98-eee198584479/`,
     },
   ])(
     'resolves pasted identifiers for %s',
-    async ({query, lookupUrl, body, groupBody, expectedOption}) => {
+    async ({query, lookupUrl, body, expectedOption}) => {
       MockApiClient.addMockResponse({
         url: lookupUrl,
         body,
-      });
-      MockApiClient.addMockResponse({
-        url: `/organizations/${organization.slug}/issues/42/`,
-        body: groupBody,
       });
 
       renderPalette();

--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.spec.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.spec.tsx
@@ -247,3 +247,133 @@ describe('GlobalCommandPaletteActions - project settings ordering', () => {
     expect(screen.getByRole('option', {name: 'project-c'})).toBeInTheDocument();
   });
 });
+
+describe('GlobalCommandPaletteActions - search recall', () => {
+  const organization = OrganizationFixture({
+    features: [
+      'session-replay-ui',
+      'performance-view',
+      'dashboards-prebuilt-insights-dashboards',
+    ],
+  });
+  const project = ProjectFixture({id: '1', slug: 'project-a', organization});
+
+  beforeEach(() => {
+    ProjectsStore.loadInitialData([project]);
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/group-search-views/starred/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/dashboards/starred/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/dashboards/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/explore/saved/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/users/`,
+      body: [],
+    });
+  });
+
+  function renderPalette() {
+    render(
+      <CommandPaletteProvider>
+        <GlobalCommandPaletteActions />
+        <SlotOutlets />
+        <CommandPalette {...makeRenderProps(jest.fn())} />
+      </CommandPaletteProvider>,
+      {
+        organization,
+        initialRouterConfig: {
+          location: {pathname: `/organizations/${organization.slug}/issues/`},
+        },
+      }
+    );
+  }
+
+  it.each([
+    ['auth tok', /Organization Tokens/, /Personal Tokens/],
+    ['source map', /Project Settings.*Source Maps/],
+    ['codeowners', /Project Settings.*Ownership Rules/],
+    ['inbound', /Project Settings.*Inbound Filters/],
+    ['size', /Project Settings.*Mobile Builds/],
+  ])('finds expected actions for %s', async (query, ...expectedOptions) => {
+    renderPalette();
+
+    const input = await screen.findByRole('textbox', {name: 'Search commands'});
+    await userEvent.type(input, query);
+
+    for (const expectedOption of expectedOptions) {
+      expect(
+        await screen.findByRole('option', {name: expectedOption})
+      ).toBeInTheDocument();
+    }
+  });
+
+  it.each([
+    {
+      body: {
+        groupId: '42',
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
+        shortId: 'WEB-HZX',
+      },
+      expectedOption: /Issue WEB-HZX/,
+      groupBody: {
+        id: '42',
+        metadata: {},
+        project: {id: project.id, slug: project.slug},
+        status: 'unresolved',
+      },
+      query: 'WEB-HZX',
+      lookupUrl: `/organizations/${organization.slug}/shortids/WEB-HZX/`,
+    },
+    {
+      body: {
+        event: {id: '954df831ab094388ac98eee198584479'},
+        eventId: '954df831ab094388ac98eee198584479',
+        groupId: '42',
+        organizationSlug: organization.slug,
+        projectSlug: project.slug,
+      },
+      expectedOption: /Event 954df831ab094388ac98eee198584479/,
+      groupBody: {
+        id: '42',
+        metadata: {},
+        project: {id: project.id, slug: project.slug},
+        status: 'unresolved',
+      },
+      query: '954df831ab094388ac98eee198584479',
+      lookupUrl: `/organizations/${organization.slug}/eventids/954df831ab094388ac98eee198584479/`,
+    },
+  ])(
+    'resolves pasted identifiers for %s',
+    async ({query, lookupUrl, body, groupBody, expectedOption}) => {
+      MockApiClient.addMockResponse({
+        url: lookupUrl,
+        body,
+      });
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/issues/42/`,
+        body: groupBody,
+      });
+
+      renderPalette();
+
+      const input = await screen.findByRole('textbox', {name: 'Search commands'});
+      await userEvent.type(input, query);
+
+      expect(
+        await screen.findByRole('option', {name: expectedOption})
+      ).toBeInTheDocument();
+    }
+  );
+});

--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -193,8 +193,7 @@ function ResolvedIdentifierCommandPaletteAction() {
             }
           );
           const project =
-            projects.find(p => p.slug === shortIdLookup.projectSlug) ??
-            (group.project as Project);
+            projects.find(p => p.slug === shortIdLookup.projectSlug) ?? group.project;
           return {
             event: null,
             group,
@@ -226,8 +225,7 @@ function ResolvedIdentifierCommandPaletteAction() {
           }
         );
         const project =
-          projects.find(p => p.slug === eventIdLookup.projectSlug) ??
-          (group.project as Project);
+          projects.find(p => p.slug === eventIdLookup.projectSlug) ?? group.project;
         return {
           event: eventIdLookup.event,
           eventUrl: `/organizations/${organization.slug}/issues/${group.id}/events/${eventIdLookup.eventId}/`,

--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -1,6 +1,6 @@
 import {useMemo} from 'react';
 import {SentryGlobalSearch} from '@sentry-internal/global-search';
-import {useMutation} from '@tanstack/react-query';
+import {useMutation, useQuery} from '@tanstack/react-query';
 import DOMPurify from 'dompurify';
 
 import {OrganizationAvatar, ProjectAvatar} from '@sentry/scraps/avatar';
@@ -51,6 +51,10 @@ import {t} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {OrganizationsStore} from 'sentry/stores/organizationsStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+import type {EventIdResponse} from 'sentry/types/event';
+import type {ShortIdResponse} from 'sentry/types/group';
+import type {Group} from 'sentry/types/group';
+import type {Project} from 'sentry/types/project';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {isDemoModeActive} from 'sentry/utils/demoMode';
@@ -79,6 +83,7 @@ import {BACKEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/backend/sett
 import {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/settings';
 import {MCP_LANDING_SUB_PATH} from 'sentry/views/insights/pages/mcp/settings';
 import {MOBILE_LANDING_SUB_PATH} from 'sentry/views/insights/pages/mobile/settings';
+import {useEnvironmentsFromUrl} from 'sentry/views/issueDetails/utils';
 import {ISSUE_TAXONOMY_CONFIG} from 'sentry/views/issueList/taxonomies';
 import {useStarredIssueViews} from 'sentry/views/navigation/secondary/sections/issues/issueViews/useStarredIssueViews';
 import {makeProjectsPathname} from 'sentry/views/projects/pathname';
@@ -91,6 +96,7 @@ import type {NavigationGroupProps} from 'sentry/views/settings/types';
 import {CMDKAction} from './cmdk';
 import type {CMDKResourceContext} from './cmdk';
 import {CommandPaletteSlot} from './commandPaletteSlot';
+import {useCommandPaletteState} from './commandPaletteStateContext';
 
 const DSN_ICONS: React.ReactElement[] = [
   <IconIssues key="issues" />,
@@ -113,6 +119,8 @@ const ORG_SETTINGS_ICONS: Record<string, React.ReactElement> = {
 };
 
 const helpSearch = new SentryGlobalSearch(['docs', 'develop']);
+const EVENT_ID_PATTERN = /^[A-Fa-f0-9-]{32,36}$/;
+const SHORT_ID_PATTERN = /^\w[\w-]*-\w{3,}$/;
 
 function renderAsyncResult(item: CommandPaletteAction, index: number) {
   if ('to' in item) {
@@ -122,6 +130,140 @@ function renderAsyncResult(item: CommandPaletteAction, index: number) {
     return <CMDKAction key={index} {...item} />;
   }
   return null;
+}
+
+type ResolvedIdentifier =
+  | {
+      event: EventIdResponse['event'];
+      eventUrl: string;
+      group: Group;
+      groupUrl: string;
+      kind: 'event';
+      label: string;
+      project: Project;
+    }
+  | {
+      event: null;
+      group: Group;
+      groupUrl: string;
+      kind: 'issue';
+      label: string;
+      project: Project;
+    };
+
+function ResolvedIdentifierCommandPaletteAction() {
+  const organization = useOrganization();
+  const {projects} = useProjects();
+  const {query} = useCommandPaletteState();
+  const environments = useEnvironmentsFromUrl();
+  const isShortId = SHORT_ID_PATTERN.test(query);
+  const isEventId = EVENT_ID_PATTERN.test(query);
+
+  const {data} = useQuery({
+    ...cmdkQueryOptions({
+      queryKey: [
+        'command-palette-identifier-lookup',
+        organization.slug,
+        query,
+        isShortId,
+        environments,
+        projects,
+      ],
+      queryFn: async (): Promise<ResolvedIdentifier | null> => {
+        try {
+          if (isShortId) {
+            const shortIdLookup = await QUERY_API_CLIENT.requestPromise<ShortIdResponse>(
+              getApiUrl('/organizations/$organizationIdOrSlug/shortids/$issueId/', {
+                path: {organizationIdOrSlug: organization.slug, issueId: query},
+              })
+            );
+            const group = await QUERY_API_CLIENT.requestPromise<Group>(
+              getApiUrl('/organizations/$organizationIdOrSlug/issues/$issueId/', {
+                path: {
+                  organizationIdOrSlug: organization.slug,
+                  issueId: shortIdLookup.groupId,
+                },
+              }),
+              {
+                query: {
+                  ...(environments.length > 0 ? {environment: environments} : {}),
+                  expand: ['inbox', 'owners'],
+                  collapse: ['release', 'tags', 'stats'],
+                },
+              }
+            );
+            const project =
+              projects.find(p => p.slug === shortIdLookup.projectSlug) ??
+              (group.project as Project);
+            return {
+              event: null,
+              group,
+              groupUrl: `/organizations/${organization.slug}/issues/${group.id}/`,
+              kind: 'issue',
+              label: t('Issue %s', shortIdLookup.shortId),
+              project,
+            };
+          }
+
+          const eventIdLookup = await QUERY_API_CLIENT.requestPromise<EventIdResponse>(
+            getApiUrl('/organizations/$organizationIdOrSlug/eventids/$eventId/', {
+              path: {organizationIdOrSlug: organization.slug, eventId: query},
+            })
+          );
+          const group = await QUERY_API_CLIENT.requestPromise<Group>(
+            getApiUrl('/organizations/$organizationIdOrSlug/issues/$issueId/', {
+              path: {
+                organizationIdOrSlug: organization.slug,
+                issueId: eventIdLookup.groupId,
+              },
+            }),
+            {
+              query: {
+                ...(environments.length > 0 ? {environment: environments} : {}),
+                expand: ['inbox', 'owners'],
+                collapse: ['release', 'tags', 'stats'],
+              },
+            }
+          );
+          const project =
+            projects.find(p => p.slug === eventIdLookup.projectSlug) ??
+            (group.project as Project);
+          return {
+            event: eventIdLookup.event,
+            eventUrl: `/organizations/${organization.slug}/issues/${group.id}/events/${eventIdLookup.eventId}/`,
+            group,
+            groupUrl: `/organizations/${organization.slug}/issues/${group.id}/`,
+            kind: 'event',
+            label: t('Event %s', eventIdLookup.eventId),
+            project,
+          };
+        } catch {
+          return null;
+        }
+      },
+      enabled: isShortId || isEventId,
+      staleTime: 30_000,
+    }),
+  });
+
+  if (!data) {
+    return null;
+  }
+
+  return (
+    <CMDKAction
+      display={{
+        label: data.label,
+        details: data.group.metadata?.value,
+        icon: <ProjectAvatar project={data.project} size={16} />,
+      }}
+    >
+      {data.kind === 'event' && (
+        <CMDKAction display={{label: t('Go to event')}} to={data.eventUrl} />
+      )}
+      <CMDKAction display={{label: t('Go to issue')}} to={data.groupUrl} />
+    </CMDKAction>
+  );
 }
 
 /**
@@ -414,6 +556,7 @@ export function GlobalCommandPaletteActions() {
               <CMDKAction
                 key={item.path}
                 display={{label: item.title, icon: ORG_SETTINGS_ICONS[item.path]}}
+                keywords={item.keywords}
                 to={item.path}
               />
             ))}
@@ -682,6 +825,8 @@ export function GlobalCommandPaletteActions() {
           </CMDKAction>
         )}
       </CMDKAction>
+
+      <ResolvedIdentifierCommandPaletteAction />
 
       <CMDKAction
         id="cmdk:supplementary:help"

--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -53,8 +53,7 @@ import {OrganizationsStore} from 'sentry/stores/organizationsStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import type {EventIdResponse} from 'sentry/types/event';
 import type {ShortIdResponse} from 'sentry/types/group';
-import type {Group} from 'sentry/types/group';
-import type {Project} from 'sentry/types/project';
+import type {AvatarProject, Project} from 'sentry/types/project';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {isDemoModeActive} from 'sentry/utils/demoMode';
@@ -83,7 +82,6 @@ import {BACKEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/backend/sett
 import {FRONTEND_LANDING_SUB_PATH} from 'sentry/views/insights/pages/frontend/settings';
 import {MCP_LANDING_SUB_PATH} from 'sentry/views/insights/pages/mcp/settings';
 import {MOBILE_LANDING_SUB_PATH} from 'sentry/views/insights/pages/mobile/settings';
-import {useEnvironmentsFromUrl} from 'sentry/views/issueDetails/utils';
 import {ISSUE_TAXONOMY_CONFIG} from 'sentry/views/issueList/taxonomies';
 import {useStarredIssueViews} from 'sentry/views/navigation/secondary/sections/issues/issueViews/useStarredIssueViews';
 import {makeProjectsPathname} from 'sentry/views/projects/pathname';
@@ -133,40 +131,31 @@ function renderAsyncResult(item: CommandPaletteAction, index: number) {
   return null;
 }
 
+type ResolvedIdentifier =
+  | (ShortIdResponse & {
+      kind: 'issue';
+      project: AvatarProject;
+      details?: string;
+    })
+  | (EventIdResponse & {
+      kind: 'event';
+      project: AvatarProject;
+      details?: string;
+    });
+
 function ResolvedIdentifierCommandPaletteAction() {
   const organization = useOrganization();
   const {projects} = useProjects();
   const {query} = useCommandPaletteState();
-  const environments = useEnvironmentsFromUrl();
   const isEventId = EVENT_ID_PATTERN.test(query);
   const isShortId = SHORT_ID_PATTERN.test(query) && !isEventId;
 
-  const {data} = useQuery<
-    | {
-        event: EventIdResponse['event'];
-        eventUrl: string;
-        group: Group;
-        groupUrl: string;
-        kind: 'event';
-        label: string;
-        project: Project;
-      }
-    | {
-        event: null;
-        group: Group;
-        groupUrl: string;
-        kind: 'issue';
-        label: string;
-        project: Project;
-      }
-    | null
-  >({
+  const {data} = useQuery<ResolvedIdentifier | null>({
     queryKey: [
       'command-palette-identifier-lookup',
       organization.slug,
       query,
       isShortId,
-      environments,
       projects,
     ],
     queryFn: async () => {
@@ -177,30 +166,14 @@ function ResolvedIdentifierCommandPaletteAction() {
               path: {organizationIdOrSlug: organization.slug, issueId: query},
             })
           );
-          const group: Group = await QUERY_API_CLIENT.requestPromise(
-            getApiUrl('/organizations/$organizationIdOrSlug/issues/$issueId/', {
-              path: {
-                organizationIdOrSlug: organization.slug,
-                issueId: shortIdLookup.groupId,
-              },
-            }),
-            {
-              query: {
-                ...(environments.length > 0 ? {environment: environments} : {}),
-                expand: ['inbox', 'owners'],
-                collapse: ['release', 'tags', 'stats'],
-              },
-            }
-          );
           const project =
-            projects.find(p => p.slug === shortIdLookup.projectSlug) ?? group.project;
+            projects.find(p => p.slug === shortIdLookup.projectSlug) ??
+            shortIdLookup.group.project;
           return {
-            event: null,
-            group,
-            groupUrl: `/organizations/${organization.slug}/issues/${group.id}/`,
+            details: shortIdLookup.group.metadata?.value,
             kind: 'issue' as const,
-            label: t('Issue %s', shortIdLookup.shortId),
             project,
+            ...shortIdLookup,
           };
         }
 
@@ -209,31 +182,14 @@ function ResolvedIdentifierCommandPaletteAction() {
             path: {organizationIdOrSlug: organization.slug, eventId: query},
           })
         );
-        const group: Group = await QUERY_API_CLIENT.requestPromise(
-          getApiUrl('/organizations/$organizationIdOrSlug/issues/$issueId/', {
-            path: {
-              organizationIdOrSlug: organization.slug,
-              issueId: eventIdLookup.groupId,
-            },
-          }),
-          {
-            query: {
-              ...(environments.length > 0 ? {environment: environments} : {}),
-              expand: ['inbox', 'owners'],
-              collapse: ['release', 'tags', 'stats'],
-            },
-          }
-        );
         const project =
-          projects.find(p => p.slug === eventIdLookup.projectSlug) ?? group.project;
+          projects.find(p => p.slug === eventIdLookup.projectSlug) ??
+          ({slug: eventIdLookup.projectSlug} as Project);
         return {
-          event: eventIdLookup.event,
-          eventUrl: `/organizations/${organization.slug}/issues/${group.id}/events/${eventIdLookup.eventId}/`,
-          group,
-          groupUrl: `/organizations/${organization.slug}/issues/${group.id}/`,
+          details: eventIdLookup.event.metadata?.value,
           kind: 'event' as const,
-          label: t('Event %s', eventIdLookup.eventId),
           project,
+          ...eventIdLookup,
         };
       } catch {
         return null;
@@ -251,15 +207,24 @@ function ResolvedIdentifierCommandPaletteAction() {
   return (
     <CMDKAction
       display={{
-        label: data.label,
-        details: data.group.metadata?.value,
+        label:
+          data.kind === 'event'
+            ? t('Event %s', data.eventId)
+            : t('Issue %s', data.shortId),
+        details: data.details,
         icon: <ProjectAvatar project={data.project} size={16} />,
       }}
     >
       {data.kind === 'event' && (
-        <CMDKAction display={{label: t('Go to event')}} to={data.eventUrl} />
+        <CMDKAction
+          display={{label: t('Go to event')}}
+          to={`/organizations/${organization.slug}/issues/${data.groupId}/events/${data.eventId}/`}
+        />
       )}
-      <CMDKAction display={{label: t('Go to issue')}} to={data.groupUrl} />
+      <CMDKAction
+        display={{label: t('Go to issue')}}
+        to={`/organizations/${organization.slug}/issues/${data.groupId}/`}
+      />
     </CMDKAction>
   );
 }

--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -119,8 +119,9 @@ const ORG_SETTINGS_ICONS: Record<string, React.ReactElement> = {
 };
 
 const helpSearch = new SentryGlobalSearch(['docs', 'develop']);
-const EVENT_ID_PATTERN = /^[A-Fa-f0-9-]{32,36}$/;
-const SHORT_ID_PATTERN = /^\w[\w-]*-\w{3,}$/;
+const EVENT_ID_PATTERN =
+  /^(?:[A-Fa-f0-9]{32}|[A-Fa-f0-9]{8}(?:-[A-Fa-f0-9]{4}){3}-[A-Fa-f0-9]{12})$/;
+const SHORT_ID_PATTERN = /^[A-Za-z][\w-]*-\w{3,}$/;
 
 function renderAsyncResult(item: CommandPaletteAction, index: number) {
   if ('to' in item) {
@@ -132,89 +133,55 @@ function renderAsyncResult(item: CommandPaletteAction, index: number) {
   return null;
 }
 
-type ResolvedIdentifier =
-  | {
-      event: EventIdResponse['event'];
-      eventUrl: string;
-      group: Group;
-      groupUrl: string;
-      kind: 'event';
-      label: string;
-      project: Project;
-    }
-  | {
-      event: null;
-      group: Group;
-      groupUrl: string;
-      kind: 'issue';
-      label: string;
-      project: Project;
-    };
-
 function ResolvedIdentifierCommandPaletteAction() {
   const organization = useOrganization();
   const {projects} = useProjects();
   const {query} = useCommandPaletteState();
   const environments = useEnvironmentsFromUrl();
-  const isShortId = SHORT_ID_PATTERN.test(query);
   const isEventId = EVENT_ID_PATTERN.test(query);
+  const isShortId = SHORT_ID_PATTERN.test(query) && !isEventId;
 
-  const {data} = useQuery({
-    ...cmdkQueryOptions({
-      queryKey: [
-        'command-palette-identifier-lookup',
-        organization.slug,
-        query,
-        isShortId,
-        environments,
-        projects,
-      ],
-      queryFn: async (): Promise<ResolvedIdentifier | null> => {
-        try {
-          if (isShortId) {
-            const shortIdLookup = await QUERY_API_CLIENT.requestPromise<ShortIdResponse>(
-              getApiUrl('/organizations/$organizationIdOrSlug/shortids/$issueId/', {
-                path: {organizationIdOrSlug: organization.slug, issueId: query},
-              })
-            );
-            const group = await QUERY_API_CLIENT.requestPromise<Group>(
-              getApiUrl('/organizations/$organizationIdOrSlug/issues/$issueId/', {
-                path: {
-                  organizationIdOrSlug: organization.slug,
-                  issueId: shortIdLookup.groupId,
-                },
-              }),
-              {
-                query: {
-                  ...(environments.length > 0 ? {environment: environments} : {}),
-                  expand: ['inbox', 'owners'],
-                  collapse: ['release', 'tags', 'stats'],
-                },
-              }
-            );
-            const project =
-              projects.find(p => p.slug === shortIdLookup.projectSlug) ??
-              (group.project as Project);
-            return {
-              event: null,
-              group,
-              groupUrl: `/organizations/${organization.slug}/issues/${group.id}/`,
-              kind: 'issue',
-              label: t('Issue %s', shortIdLookup.shortId),
-              project,
-            };
-          }
-
-          const eventIdLookup = await QUERY_API_CLIENT.requestPromise<EventIdResponse>(
-            getApiUrl('/organizations/$organizationIdOrSlug/eventids/$eventId/', {
-              path: {organizationIdOrSlug: organization.slug, eventId: query},
+  const {data} = useQuery<
+    | {
+        event: EventIdResponse['event'];
+        eventUrl: string;
+        group: Group;
+        groupUrl: string;
+        kind: 'event';
+        label: string;
+        project: Project;
+      }
+    | {
+        event: null;
+        group: Group;
+        groupUrl: string;
+        kind: 'issue';
+        label: string;
+        project: Project;
+      }
+    | null
+  >({
+    queryKey: [
+      'command-palette-identifier-lookup',
+      organization.slug,
+      query,
+      isShortId,
+      environments,
+      projects,
+    ],
+    queryFn: async () => {
+      try {
+        if (isShortId) {
+          const shortIdLookup: ShortIdResponse = await QUERY_API_CLIENT.requestPromise(
+            getApiUrl('/organizations/$organizationIdOrSlug/shortids/$issueId/', {
+              path: {organizationIdOrSlug: organization.slug, issueId: query},
             })
           );
-          const group = await QUERY_API_CLIENT.requestPromise<Group>(
+          const group: Group = await QUERY_API_CLIENT.requestPromise(
             getApiUrl('/organizations/$organizationIdOrSlug/issues/$issueId/', {
               path: {
                 organizationIdOrSlug: organization.slug,
-                issueId: eventIdLookup.groupId,
+                issueId: shortIdLookup.groupId,
               },
             }),
             {
@@ -226,24 +193,57 @@ function ResolvedIdentifierCommandPaletteAction() {
             }
           );
           const project =
-            projects.find(p => p.slug === eventIdLookup.projectSlug) ??
+            projects.find(p => p.slug === shortIdLookup.projectSlug) ??
             (group.project as Project);
           return {
-            event: eventIdLookup.event,
-            eventUrl: `/organizations/${organization.slug}/issues/${group.id}/events/${eventIdLookup.eventId}/`,
+            event: null,
             group,
             groupUrl: `/organizations/${organization.slug}/issues/${group.id}/`,
-            kind: 'event',
-            label: t('Event %s', eventIdLookup.eventId),
+            kind: 'issue' as const,
+            label: t('Issue %s', shortIdLookup.shortId),
             project,
           };
-        } catch {
-          return null;
         }
-      },
-      enabled: isShortId || isEventId,
-      staleTime: 30_000,
-    }),
+
+        const eventIdLookup: EventIdResponse = await QUERY_API_CLIENT.requestPromise(
+          getApiUrl('/organizations/$organizationIdOrSlug/eventids/$eventId/', {
+            path: {organizationIdOrSlug: organization.slug, eventId: query},
+          })
+        );
+        const group: Group = await QUERY_API_CLIENT.requestPromise(
+          getApiUrl('/organizations/$organizationIdOrSlug/issues/$issueId/', {
+            path: {
+              organizationIdOrSlug: organization.slug,
+              issueId: eventIdLookup.groupId,
+            },
+          }),
+          {
+            query: {
+              ...(environments.length > 0 ? {environment: environments} : {}),
+              expand: ['inbox', 'owners'],
+              collapse: ['release', 'tags', 'stats'],
+            },
+          }
+        );
+        const project =
+          projects.find(p => p.slug === eventIdLookup.projectSlug) ??
+          (group.project as Project);
+        return {
+          event: eventIdLookup.event,
+          eventUrl: `/organizations/${organization.slug}/issues/${group.id}/events/${eventIdLookup.eventId}/`,
+          group,
+          groupUrl: `/organizations/${organization.slug}/issues/${group.id}/`,
+          kind: 'event' as const,
+          label: t('Event %s', eventIdLookup.eventId),
+          project,
+        };
+      } catch {
+        return null;
+      }
+    },
+    enabled: isShortId || isEventId,
+    staleTime: 30_000,
+    meta: {cmdk: true},
   });
 
   if (!data) {

--- a/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
+++ b/static/app/views/settings/organization/userOrgNavigationConfiguration.tsx
@@ -103,6 +103,7 @@ export function getUserOrgNavigationConfiguration(): NavigationSection[] {
         {
           path: `${organizationSettingsPathPrefix}/security-and-privacy/`,
           title: t('Security & Privacy'),
+          keywords: ['data scrubbing', 'privacy', 'pii', 'attachments'],
           description: t(
             'Configuration related to dealing with sensitive data and other security settings. (Data Scrubbing, Data Privacy, Data Scrubbing)'
           ),
@@ -111,6 +112,7 @@ export function getUserOrgNavigationConfiguration(): NavigationSection[] {
         {
           path: `${organizationSettingsPathPrefix}/auth/`,
           title: t('Auth'),
+          keywords: ['sso', 'single sign-on', 'authentication', 'login'],
           description: t('Configure single sign-on'),
           id: 'sso',
         },
@@ -193,6 +195,7 @@ export function getUserOrgNavigationConfiguration(): NavigationSection[] {
         {
           path: `${organizationSettingsPathPrefix}/integrations/`,
           title: t('Integrations'),
+          keywords: ['slack', 'github', 'bitbucket', 'jira', 'azure devops', 'vercel'],
           description: t(
             'Manage organization-level integrations, including: Slack, GitHub, Bitbucket, Jira, and Azure DevOps'
           ),
@@ -209,6 +212,7 @@ export function getUserOrgNavigationConfiguration(): NavigationSection[] {
         {
           path: `${organizationSettingsPathPrefix}/developer-settings/`,
           title: t('Custom Integrations'),
+          keywords: ['integration', 'developer', 'vercel'],
           description: t('Manage custom integrations'),
           id: 'developer-settings',
         },
@@ -221,12 +225,28 @@ export function getUserOrgNavigationConfiguration(): NavigationSection[] {
         {
           path: `${organizationSettingsPathPrefix}/auth-tokens/`,
           title: t('Organization Tokens'),
+          keywords: [
+            'auth',
+            'auth token',
+            'auth tokens',
+            'api token',
+            'token',
+            'credentials',
+          ],
           description: t('Manage organization tokens'),
           id: 'auth-tokens',
         },
         {
           path: `${userSettingsPathPrefix}/api/auth-tokens/`,
           title: t('Personal Tokens'),
+          keywords: [
+            'auth',
+            'auth token',
+            'auth tokens',
+            'api token',
+            'token',
+            'credentials',
+          ],
           description: t(
             "Personal tokens allow you to perform actions against the Sentry API on behalf of your account. They're the easiest way to get started using the API."
           ),

--- a/static/app/views/settings/project/navigationConfiguration.tsx
+++ b/static/app/views/settings/project/navigationConfiguration.tsx
@@ -40,6 +40,7 @@ export function getNavigationConfiguration({
         {
           path: `${pathPrefix}/alerts/`,
           title: t('Alert Settings'),
+          keywords: ['alert', 'alerts'],
           description: t('Project alert settings'),
         },
         {
@@ -50,11 +51,13 @@ export function getNavigationConfiguration({
         {
           path: `${pathPrefix}/environments/`,
           title: t('Environments'),
+          keywords: ['environment', 'env'],
           description: t('Manage environments in a project'),
         },
         {
           path: `${pathPrefix}/ownership/`,
           title: t('Ownership Rules'),
+          keywords: ['ownership', 'codeowners', 'owners', 'owner rules'],
           description: t('Manage ownership rules for a project'),
         },
         {
@@ -80,6 +83,7 @@ export function getNavigationConfiguration({
         {
           path: `${pathPrefix}/filters/`,
           title: t('Inbound Filters'),
+          keywords: ['inbound', 'filter', 'filters', 'discard', 'ignore', 'attachments'],
           description: t(
             "Configure a project's inbound filters (e.g. browsers, messages)"
           ),
@@ -98,6 +102,7 @@ export function getNavigationConfiguration({
         {
           path: `${pathPrefix}/debug-symbols/`,
           title: t('Debug Files'),
+          keywords: ['debug file', 'debug files', 'symbols', 'dsyms'],
           badge: debugFilesNeedsReview ? () => 'warning' : undefined,
         },
         {
@@ -107,6 +112,7 @@ export function getNavigationConfiguration({
         {
           path: `${pathPrefix}/source-maps/`,
           title: t('Source Maps'),
+          keywords: ['source map', 'source maps', 'sourcemap', 'artifact bundles'],
         },
         {
           path: `${pathPrefix}/performance/`,
@@ -119,6 +125,7 @@ export function getNavigationConfiguration({
         {
           path: `${pathPrefix}/replays/`,
           title: t('Replays'),
+          keywords: ['session', 'session replay', 'replay'],
           show: () =>
             !!organization?.features?.includes('session-replay-ui') &&
             !isSelfHostedErrorsOnly,
@@ -132,6 +139,7 @@ export function getNavigationConfiguration({
           path: `${pathPrefix}/mobile-builds/`,
           title: t('Mobile Builds'),
           badge: () => 'new',
+          keywords: ['size', 'size analysis', 'build size', 'app size'],
           description: t('Size analysis and build distribution configuration.'),
         },
         {
@@ -151,7 +159,7 @@ export function getNavigationConfiguration({
           path: `${pathPrefix}/keys/`,
           title: t('Client Keys (DSN)'),
           description: t("View and manage the project's client keys (DSN)"),
-          keywords: [t('dsn')],
+          keywords: [t('dsn'), 'auth', 'token', 'client key'],
         },
         {
           path: `${pathPrefix}/loader-script/`,

--- a/static/app/views/settings/project/projectSettingsCommandPaletteActions.tsx
+++ b/static/app/views/settings/project/projectSettingsCommandPaletteActions.tsx
@@ -141,7 +141,12 @@ export function getProjectSettingsCommandPaletteSections({
                 label: item.title,
                 icon: PROJECT_SETTINGS_ICONS[suffix],
               },
-              keywords: [section.name, 'project settings', 'settings'],
+              keywords: [
+                section.name,
+                'project settings',
+                'settings',
+                ...(item.keywords ?? []),
+              ],
               to: replaceRouterParams(item.path, {
                 orgId: organization.slug,
                 projectId: project.slug,


### PR DESCRIPTION
Improve Cmd+K recall for common no-result queries by adding targeted synonyms for org and project settings, preserving project setting keywords in the palette, and surfacing matching group children when a group label matches.

This also adds pasted identifier lookup for issue short IDs and event IDs, rendering them as grouped Cmd+K results with direct navigation actions.

Tests:
- CI=true pnpm test static/app/components/commandPalette/ui/commandPalette.spec.tsx static/app/components/commandPalette/ui/commandPaletteGlobalActions.spec.tsx