### PR TITLE
fix(seer): Open metrics links with encoded query state

### DIFF
--- a/static/app/components/events/autofix/v3/autofixEvidence.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.spec.tsx
@@ -112,7 +112,11 @@ describe('AutofixEvidence', () => {
     it('renders "Query: Metrics" for metrics dataset', () => {
       const props = resolveProps(
         makeToolCall('telemetry_live_search'),
-        makeToolLink('telemetry_live_search', {dataset: 'metrics', query: 'test'})
+        makeToolLink('telemetry_live_search', {
+          dataset: 'metrics',
+          query: 'test',
+          trace_metric: {name: 'tool.duration', type: 'distribution', unit: 'second'},
+        })
       );
       render(<AutofixEvidence evidenceButtonProps={props!} />, {organization});
       expect(screen.getByText('Query: Metrics')).toBeInTheDocument();
@@ -121,7 +125,11 @@ describe('AutofixEvidence', () => {
     it('renders "Query: Metrics" for tracemetrics dataset', () => {
       const props = resolveProps(
         makeToolCall('telemetry_live_search'),
-        makeToolLink('telemetry_live_search', {dataset: 'tracemetrics', query: 'test'})
+        makeToolLink('telemetry_live_search', {
+          dataset: 'tracemetrics',
+          query: 'test',
+          trace_metric: {name: 'tool.duration', type: 'distribution', unit: 'second'},
+        })
       );
       render(<AutofixEvidence evidenceButtonProps={props!} />, {organization});
       expect(screen.getByText('Query: Metrics')).toBeInTheDocument();

--- a/static/app/views/seerExplorer/utils.spec.tsx
+++ b/static/app/views/seerExplorer/utils.spec.tsx
@@ -1,4 +1,7 @@
-import {postProcessLLMMarkdown} from 'sentry/views/seerExplorer/utils';
+import {decodeMetricsQueryParams} from 'sentry/views/explore/metrics/metricQuery';
+import {Mode} from 'sentry/views/explore/queryParams/mode';
+import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
+import {buildToolLinkUrl, postProcessLLMMarkdown} from 'sentry/views/seerExplorer/utils';
 
 describe('postProcessLLMMarkdown', () => {
   describe('issue short ID linkification', () => {
@@ -54,5 +57,73 @@ describe('postProcessLLMMarkdown', () => {
       expect(postProcessLLMMarkdown(undefined)).toBe('');
       expect(postProcessLLMMarkdown('')).toBe('');
     });
+  });
+});
+
+describe('buildToolLinkUrl', () => {
+  it('builds metrics links with encoded metric query state from Seer metadata', () => {
+    const result = buildToolLinkUrl(
+      {
+        kind: 'telemetry_live_search',
+        params: {
+          dataset: 'tracemetrics',
+          query: 'metric.name:"tool.duration" metric.type:distribution',
+          trace_metric: {name: 'tool.duration', type: 'distribution', unit: 'second'},
+          y_axes: ['p75(value)'],
+          group_by: ['environment'],
+          sort: '-p75(value)',
+          mode: 'aggregates',
+          stats_period: '7d',
+        },
+      },
+      'org-slug'
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        pathname: '/organizations/org-slug/explore/metrics/',
+        query: expect.objectContaining({
+          statsPeriod: '7d',
+        }),
+      })
+    );
+
+    const encodedMetric = (result as any)?.query?.metric?.[0];
+    const decoded = decodeMetricsQueryParams(encodedMetric);
+
+    expect(decoded?.metric).toEqual({
+      name: 'tool.duration',
+      type: 'distribution',
+      unit: 'second',
+    });
+    expect(decoded?.queryParams.mode).toBe(Mode.AGGREGATE);
+    expect(decoded?.queryParams.query).toBe(
+      'metric.name:"tool.duration" metric.type:distribution'
+    );
+    expect(decoded?.queryParams.aggregateFields).toEqual([
+      new VisualizeFunction('p75(value,tool.duration,distribution,second)'),
+      {groupBy: 'environment'},
+    ]);
+    expect(decoded?.queryParams.aggregateSortBys).toEqual([
+      {field: 'p75(value,tool.duration,distribution,second)', kind: 'desc'},
+    ]);
+  });
+
+  it('does not build a metrics link without Seer metric metadata', () => {
+    const result = buildToolLinkUrl(
+      {
+        kind: 'telemetry_live_search',
+        params: {
+          dataset: 'tracemetrics',
+          query:
+            'metric.name:"tool.duration" metric.type:distribution metric.unit:second',
+          y_axes: ['p75(value)'],
+          mode: 'aggregates',
+        },
+      },
+      'org-slug'
+    );
+
+    expect(result).toBeNull();
   });
 });

--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -8,6 +8,7 @@ import type {UseFeedbackOptions} from 'sentry/components/feedbackButton/useFeedb
 import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import type {Sort} from 'sentry/utils/discover/fields';
 import {getRouteStringFromRoutes} from 'sentry/utils/getRouteStringFromRoutes';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -18,6 +19,17 @@ import {
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {LOGS_SORT_BYS_KEY} from 'sentry/views/explore/contexts/logs/sortBys';
 import {getConversationsUrl} from 'sentry/views/explore/conversations/utils/urlParams';
+import {DEFAULT_YAXIS_BY_TYPE} from 'sentry/views/explore/metrics/constants';
+import {
+  defaultAggregateSortBys,
+  defaultMetricQuery,
+  encodeMetricQueryParams,
+  type TraceMetric,
+} from 'sentry/views/explore/metrics/metricQuery';
+import {makeMetricsAggregate} from 'sentry/views/explore/metrics/utils';
+import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateField';
+import {Mode} from 'sentry/views/explore/queryParams/mode';
+import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 import type {
   Block,
   ToolCall,
@@ -508,6 +520,117 @@ function validateIso(val: unknown): string | undefined {
   return isNaN(d.getTime()) ? undefined : d.toISOString().replace(/Z$/, '');
 }
 
+function getStringArray(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === 'string');
+  }
+  return typeof value === 'string' ? [value] : [];
+}
+
+function getTraceMetricFromParams(params: Record<string, any>): TraceMetric | null {
+  const rawTraceMetric = params.trace_metric;
+  if (
+    !rawTraceMetric ||
+    typeof rawTraceMetric !== 'object' ||
+    typeof rawTraceMetric.name !== 'string' ||
+    typeof rawTraceMetric.type !== 'string'
+  ) {
+    return null;
+  }
+
+  const traceMetric: TraceMetric = {
+    name: rawTraceMetric.name,
+    type: rawTraceMetric.type,
+  };
+  if (typeof rawTraceMetric.unit === 'string') {
+    traceMetric.unit = rawTraceMetric.unit;
+  }
+  return traceMetric;
+}
+
+function getMetricYAxis(yAxis: string, traceMetric: TraceMetric): string {
+  const visualize = new VisualizeFunction(yAxis);
+  const aggregate = visualize.parsedFunction?.name;
+  if (!aggregate) {
+    return yAxis;
+  }
+
+  return makeMetricsAggregate({aggregate, traceMetric});
+}
+
+function getDefaultMetricYAxis(traceMetric: TraceMetric): string {
+  return makeMetricsAggregate({
+    aggregate: DEFAULT_YAXIS_BY_TYPE[traceMetric.type] ?? 'sum',
+    traceMetric,
+  });
+}
+
+function parseMetricsSort(
+  sort: unknown,
+  normalizedYAxesByOriginal: Map<string, string>
+): Sort | undefined {
+  if (typeof sort !== 'string' || !sort) {
+    return undefined;
+  }
+
+  const kind = sort.startsWith('-') ? 'desc' : 'asc';
+  const sortField = sort.replace(/^-/, '');
+  const normalizedYAxis = normalizedYAxesByOriginal.get(sortField);
+  if (normalizedYAxis) {
+    return {field: normalizedYAxis, kind};
+  }
+
+  const sortFunction = new VisualizeFunction(sortField).parsedFunction;
+  if (sortFunction) {
+    for (const mappedYAxis of normalizedYAxesByOriginal.values()) {
+      const yAxisFunction = new VisualizeFunction(mappedYAxis).parsedFunction;
+      if (yAxisFunction?.name === sortFunction.name) {
+        return {field: mappedYAxis, kind};
+      }
+    }
+  }
+
+  return {field: sortField, kind};
+}
+
+function buildMetricsQueryParam(params: Record<string, any>): string[] | undefined {
+  const traceMetric = getTraceMetricFromParams(params);
+  if (!traceMetric) {
+    return undefined;
+  }
+
+  const mode = params.mode === 'aggregates' ? Mode.AGGREGATE : Mode.SAMPLES;
+  const base = defaultMetricQuery();
+  const normalizedYAxesByOriginal = new Map<string, string>();
+  const yAxes = getStringArray(params.y_axes);
+  const visualizes = (yAxes.length ? yAxes : [getDefaultMetricYAxis(traceMetric)]).map(
+    yAxis => {
+      const normalizedYAxis = getMetricYAxis(yAxis, traceMetric);
+      normalizedYAxesByOriginal.set(yAxis, normalizedYAxis);
+      return new VisualizeFunction(normalizedYAxis);
+    }
+  );
+
+  const aggregateFields: AggregateField[] = [
+    ...getStringArray(params.group_by).map(groupBy => ({groupBy})),
+    ...visualizes,
+  ];
+  const seerSort = parseMetricsSort(params.sort, normalizedYAxesByOriginal);
+
+  const queryParams = base.queryParams.replace({
+    query: typeof params.query === 'string' ? params.query : '',
+    mode,
+    aggregateFields,
+    aggregateSortBys:
+      mode === Mode.AGGREGATE && seerSort
+        ? [seerSort]
+        : defaultAggregateSortBys(aggregateFields),
+    sortBys: mode === Mode.SAMPLES && seerSort ? [seerSort] : base.queryParams.sortBys,
+  });
+
+  return [encodeMetricQueryParams({metric: traceMetric, queryParams})];
+}
+
 /**
  * Build a URL/LocationDescriptor for a tool link based on its kind and params
  */
@@ -617,13 +740,12 @@ export function buildToolLinkUrl(
       }
 
       if (dataset === 'metrics' || dataset === 'tracemetrics') {
-        // TODO: The metrics explore page reads metric-specific state (metric name,
-        // type, aggregations, group bys) from a JSON-encoded `metric` URL param.
-        // Currently we only pass page filter params (project, statsPeriod, etc.)
-        // which means the search query context is lost on navigation. To fully
-        // preserve context, the Seer backend should include structured metric
-        // metadata (name, type, unit) in tool_link params so we can build the
-        // `metric` param here via encodeMetricsQueryParams().
+        const metric = buildMetricsQueryParam(toolLink.params);
+        if (!metric) {
+          return null;
+        }
+        queryParams.metric = metric;
+
         return {
           pathname: `/organizations/${orgSlug}/explore/metrics/`,
           query: queryParams,

--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -601,14 +601,18 @@ function buildMetricsQueryParam(params: Record<string, any>): string[] | undefin
 
   const mode = params.mode === 'aggregates' ? Mode.AGGREGATE : Mode.SAMPLES;
   const base = defaultMetricQuery();
-  const normalizedYAxesByOriginal = new Map<string, string>();
+
+  // Seer y-axes use short names like "avg(duration)"; normalize them to fully
+  // qualified metric aggregates like "avg(metrics.foo.duration)".
   const yAxes = getStringArray(params.y_axes);
-  const visualizes = (yAxes.length ? yAxes : [getDefaultMetricYAxis(traceMetric)]).map(
-    yAxis => {
-      const normalizedYAxis = getMetricYAxis(yAxis, traceMetric);
-      normalizedYAxesByOriginal.set(yAxis, normalizedYAxis);
-      return new VisualizeFunction(normalizedYAxis);
-    }
+  const resolvedYAxes = yAxes.length ? yAxes : [getDefaultMetricYAxis(traceMetric)];
+  const normalizedYAxesByOriginal = resolvedYAxes.reduce((map, yAxis) => {
+    map.set(yAxis, getMetricYAxis(yAxis, traceMetric));
+    return map;
+  }, new Map<string, string>());
+  // VisualizeFunction instances that the Explore page uses to render charts.
+  const visualizes = resolvedYAxes.map(
+    yAxis => new VisualizeFunction(normalizedYAxesByOriginal.get(yAxis)!)
   );
 
   const aggregateFields: AggregateField[] = [
@@ -622,10 +626,10 @@ function buildMetricsQueryParam(params: Record<string, any>): string[] | undefin
     mode,
     aggregateFields,
     aggregateSortBys:
-      mode === Mode.AGGREGATE && seerSort
-        ? [seerSort]
+      mode === Mode.AGGREGATE && sortBys
+        ? [sortBys]
         : defaultAggregateSortBys(aggregateFields),
-    sortBys: mode === Mode.SAMPLES && seerSort ? [seerSort] : base.queryParams.sortBys,
+    sortBys: mode === Mode.SAMPLES && sortBys ? [sortBys] : base.queryParams.sortBys,
   });
 
   return [encodeMetricQueryParams({metric: traceMetric, queryParams})];

--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -615,7 +615,7 @@ function buildMetricsQueryParam(params: Record<string, any>): string[] | undefin
     ...getStringArray(params.group_by).map(groupBy => ({groupBy})),
     ...visualizes,
   ];
-  const seerSort = parseMetricsSort(params.sort, normalizedYAxesByOriginal);
+  const sortBys = parseMetricsSort(params.sort, normalizedYAxesByOriginal);
 
   const queryParams = base.queryParams.replace({
     query: typeof params.query === 'string' ? params.query : '',


### PR DESCRIPTION
Build the encoded Metrics tab `metric` URL state for Seer Explorer metrics tool links so clicking a result opens the single generated metric query instead of falling back to stale or default metrics state.

**Metric Query State**

Seer metric link params are converted into one encoded Metrics query, including aggregate, grouping, sort, mode, and query. Sentry requires the Seer-provided `trace_metric` metadata for metric identity, then normalizes Seer's aggregate and sort fields into the Metrics tab URL shape.

Companion Seer PR: https://github.com/getsentry/seer/pull/6047