### PR TITLE
ref(seer): Remove Seer API dual writes in project preference endpoints

### DIFF
--- a/src/sentry/seer/endpoints/organization_autofix_automation_settings.py
+++ b/src/sentry/seer/endpoints/organization_autofix_automation_settings.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from itertools import chain
 from typing import Any
 
@@ -10,7 +9,7 @@ from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import audit_log, features
+from sentry import audit_log
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -27,17 +26,13 @@ from sentry.models.project import Project
 from sentry.seer.autofix.utils import (
     SeerAutofixSettingsSerializer,
     bulk_read_preferences_from_sentry_db,
-    bulk_set_project_preferences,
     bulk_write_preferences_to_sentry_db,
     deduplicate_repositories,
     default_seer_project_preference,
-    resolve_repository_ids,
 )
 from sentry.seer.constants import SEER_SUPPORTED_SCM_PROVIDERS
 from sentry.seer.models import SeerProjectPreference, SeerRepoDefinition
 from sentry.seer.utils import filter_repo_by_provider
-
-logger = logging.getLogger(__name__)
 
 
 def merge_repositories(
@@ -353,8 +348,6 @@ class OrganizationAutofixAutomationSettingsEndpoint(OrganizationEndpoint):
 
                 preferences_to_set.append(pref_update)
 
-        # Wrap DB writes and Seer API call in a transaction.
-        # If Seer API fails, DB changes are rolled back.
         with transaction.atomic(router.db_for_write(ProjectOption)):
             if autofix_automation_tuning:
                 for project in projects:
@@ -363,30 +356,10 @@ class OrganizationAutofixAutomationSettingsEndpoint(OrganizationEndpoint):
                     )
 
             if preferences_to_set:
-                bulk_set_project_preferences(organization.id, preferences_to_set)
-
-        if preferences_to_set and features.has(
-            "organizations:seer-project-settings-dual-write", organization
-        ):
-            try:
                 validated_preferences = [
                     SeerProjectPreference.validate(pref) for pref in preferences_to_set
                 ]
-                # Seer API responses don't include repository_id.
-                # Resolve before dual-writing so repos aren't skipped.
-                # This will not be necessary once we start keying by repo ID.
-                resolved_preferences = resolve_repository_ids(
-                    organization.id, validated_preferences
-                )
-                bulk_write_preferences_to_sentry_db(projects, resolved_preferences)
-            except Exception:
-                logger.exception(
-                    "seer.write_preferences.failed",
-                    extra={
-                        "organization_id": organization.id,
-                        "project_ids": list(projects_by_id.keys()),
-                    },
-                )
+                bulk_write_preferences_to_sentry_db(projects, validated_preferences)
 
         self.create_audit_entry(
             request=request,

--- a/src/sentry/seer/endpoints/project_seer_preferences.py
+++ b/src/sentry/seer/endpoints/project_seer_preferences.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-import logging
-
 from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -15,22 +12,17 @@ from sentry.api.serializers.rest_framework import CamelSnakeSerializer
 from sentry.models.project import Project
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.seer.autofix.utils import (
-    SetProjectPreferenceRequest,
     deduplicate_repositories,
     get_autofix_repos_from_project_code_mappings,
-    make_set_project_preference_request,
     read_preference_from_sentry_db,
     write_preference_to_sentry_db,
 )
 from sentry.seer.endpoints.organization_autofix_automation_settings import (
     RepositorySerializer as BaseRepositorySerializer,
 )
-from sentry.seer.models import PreferenceResponse, SeerApiError, SeerProjectPreference
-from sentry.seer.signed_seer_api import SeerViewerContext, seer_autofix_default_connection_pool
+from sentry.seer.models import PreferenceResponse, SeerProjectPreference
 from sentry.seer.utils import filter_repo_by_provider
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
-
-logger = logging.getLogger(__name__)
 
 
 class RepositorySerializer(BaseRepositorySerializer):
@@ -127,26 +119,7 @@ class ProjectSeerPreferencesEndpoint(ProjectEndpoint):
                 "project_id": project.id,
             }
         )
-        viewer_context = SeerViewerContext(
-            organization_id=project.organization.id, user_id=request.user.id
-        )
-        response = make_set_project_preference_request(
-            SetProjectPreferenceRequest(preference=preference.dict()),
-            connection_pool=seer_autofix_default_connection_pool,
-            viewer_context=viewer_context,
-        )
-
-        if response.status >= 400:
-            raise SeerApiError("Seer request failed", response.status)
-
-        if features.has("organizations:seer-project-settings-dual-write", project.organization):
-            try:
-                write_preference_to_sentry_db(project, preference)
-            except Exception:
-                logger.exception(
-                    "seer.write_preferences.failed",
-                    extra={"project_id": project.id, "organization_id": project.organization.id},
-                )
+        write_preference_to_sentry_db(project, preference)
 
         return Response(status=204)
 

--- a/tests/sentry/seer/endpoints/test_organization_autofix_automation_settings.py
+++ b/tests/sentry/seer/endpoints/test_organization_autofix_automation_settings.py
@@ -1,15 +1,13 @@
-from unittest.mock import patch
-
 from django.urls import reverse
 
 from sentry.models.auditlogentry import AuditLogEntry
+from sentry.models.options.project_option import ProjectOption
 from sentry.models.repository import Repository
 from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
 from sentry.seer.autofix.utils import AutofixStoppingPoint
 from sentry.seer.models.project_repository import SeerProjectRepository
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode
 
@@ -131,10 +129,7 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
             },
         ]
 
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_set_project_preferences"
-    )
-    def test_post_creates_project_preferences(self, mock_bulk_set_preferences):
+    def test_post_creates_project_preferences(self):
         project = self.create_project(organization=self.organization)
 
         response = self.client.post(
@@ -152,25 +147,13 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
             project.get_option("sentry:autofix_automation_tuning")
             == AutofixAutomationTuningSettings.MEDIUM.value
         )
+        assert (
+            project.get_option("sentry:seer_automated_run_stopping_point")
+            == AutofixStoppingPoint.OPEN_PR.value
+        )
+        assert SeerProjectRepository.objects.filter(project=project).count() == 0
 
-        mock_bulk_set_preferences.assert_called_once()
-        call_args = mock_bulk_set_preferences.call_args
-        preferences = call_args[0][1]
-        assert preferences == [
-            {
-                "organization_id": self.organization.id,
-                "project_id": project.id,
-                "repositories": [],
-                "automated_run_stopping_point": AutofixStoppingPoint.OPEN_PR.value,
-                "automation_handoff": None,
-                "autofix_automation_tuning": AutofixAutomationTuningSettings.OFF,
-            }
-        ]
-
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_set_project_preferences"
-    )
-    def test_post_updates_each_preference_field_independently(self, mock_bulk_set_preferences):
+    def test_post_updates_each_preference_field_independently(self):
         project = self.create_project(organization=self.organization)
         assert (
             project.get_option("sentry:autofix_automation_tuning")
@@ -192,7 +175,10 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
             project.get_option("sentry:autofix_automation_tuning")
             == AutofixAutomationTuningSettings.MEDIUM.value
         )
-        mock_bulk_set_preferences.assert_not_called()
+        # Unset stopping point is preserved.
+        assert not ProjectOption.objects.filter(
+            project=project, key="sentry:seer_automated_run_stopping_point"
+        ).exists()
 
         response = self.client.post(
             self.url,
@@ -204,23 +190,14 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
 
         project.refresh_from_db()
         assert (
+            project.get_option("sentry:seer_automated_run_stopping_point")
+            == AutofixStoppingPoint.OPEN_PR.value
+        )
+        # Tuning set in the previous request is preserved.
+        assert (
             project.get_option("sentry:autofix_automation_tuning")
             == AutofixAutomationTuningSettings.MEDIUM.value
         )
-
-        mock_bulk_set_preferences.assert_called_once()
-        call_args = mock_bulk_set_preferences.call_args
-        preferences = call_args[0][1]
-        assert preferences == [
-            {
-                "organization_id": self.organization.id,
-                "project_id": project.id,
-                "repositories": [],
-                "automated_run_stopping_point": AutofixStoppingPoint.OPEN_PR.value,
-                "automation_handoff": None,
-                "autofix_automation_tuning": AutofixAutomationTuningSettings.MEDIUM,
-            }
-        ]
 
     def test_post_requires_one_or_more_project_ids(self) -> None:
         response = self.client.post(
@@ -268,14 +245,8 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
         )
         assert response.status_code == 400
 
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_set_project_preferences"
-    )
-    def test_post_accepts_root_cause_stopping_point_with_flag(
-        self, mock_bulk_set_preferences
-    ) -> None:
+    def test_post_accepts_root_cause_stopping_point_with_flag(self) -> None:
         project = self.create_project(organization=self.organization)
-        mock_bulk_set_preferences.return_value = None
 
         with self.feature("organizations:root-cause-stopping-point"):
             response = self.client.post(
@@ -286,6 +257,7 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
                 },
             )
         assert response.status_code == 204
+        assert project.get_option("sentry:seer_automated_run_stopping_point") == "root_cause"
 
     def test_post_rejects_projects_not_in_organization(self) -> None:
         project = self.create_project(organization=self.organization)
@@ -302,10 +274,7 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
         )
         assert response.status_code == 403
 
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_set_project_preferences"
-    )
-    def test_post_ignores_repo_mappings_not_in_project_ids(self, mock_bulk_set_preferences):
+    def test_post_ignores_repo_mappings_not_in_project_ids(self):
         project1 = self.create_project(organization=self.organization)
         project2 = self.create_project(organization=self.organization)
         Repository.objects.create(
@@ -335,19 +304,12 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
         )
         assert response.status_code == 204
 
-        mock_bulk_set_preferences.assert_called_once()
-        call_args = mock_bulk_set_preferences.call_args
-        preferences = call_args[0][1]
+        assert SeerProjectRepository.objects.filter(project=project1).count() == 1
+        assert SeerProjectRepository.objects.filter(project=project2).count() == 0
 
-        assert len(preferences) == 1
-        assert preferences[0]["project_id"] == project1.id
-
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_set_project_preferences"
-    )
-    def test_post_updates_project_repo_mappings(self, mock_bulk_set_preferences):
+    def test_post_updates_project_repo_mappings(self):
         project = self.create_project(organization=self.organization)
-        Repository.objects.create(
+        repo = Repository.objects.create(
             organization_id=self.organization.id,
             name="test-org/test-repo",
             provider="github",
@@ -380,22 +342,16 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
             project.get_option("sentry:autofix_automation_tuning")
             == AutofixAutomationTuningSettings.MEDIUM.value
         )
+        assert (
+            project.get_option("sentry:seer_automated_run_stopping_point")
+            == AutofixStoppingPoint.OPEN_PR.value
+        )
 
-        mock_bulk_set_preferences.assert_called_once()
-        call_args = mock_bulk_set_preferences.call_args
-        preferences = call_args[0][1]
-        assert len(preferences) == 1
-        assert preferences[0]["project_id"] == project.id
-        assert preferences[0]["automated_run_stopping_point"] == AutofixStoppingPoint.OPEN_PR.value
-        assert len(preferences[0]["repositories"]) == 1
-        assert preferences[0]["repositories"][0]["name"] == "test-repo"
-        assert preferences[0]["repositories"][0]["owner"] == "test-org"
-        assert preferences[0]["repositories"][0]["external_id"] == "12345"
+        seer_repos = list(SeerProjectRepository.objects.filter(project=project))
+        assert len(seer_repos) == 1
+        assert seer_repos[0].repository_id == repo.id
 
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_set_project_preferences"
-    )
-    def test_post_clears_repos_with_empty_list(self, mock_bulk_set_preferences):
+    def test_post_clears_repos_with_empty_list(self):
         project = self.create_project(organization=self.organization)
         existing_repo = self.create_repo(
             project=project,
@@ -416,16 +372,9 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
         )
         assert response.status_code == 204
 
-        mock_bulk_set_preferences.assert_called_once()
-        call_args = mock_bulk_set_preferences.call_args
-        preferences = call_args[0][1]
-        assert len(preferences) == 1
-        assert preferences[0]["repositories"] == []
+        assert SeerProjectRepository.objects.filter(project=project).count() == 0
 
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_set_project_preferences"
-    )
-    def test_post_overwrites_existing_repos(self, mock_bulk_set_preferences):
+    def test_post_overwrites_existing_repos(self):
         project = self.create_project(organization=self.organization)
         existing_repo = self.create_repo(
             project=project,
@@ -435,7 +384,7 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
         )
         SeerProjectRepository.objects.create(project=project, repository=existing_repo)
 
-        Repository.objects.create(
+        new_repo = Repository.objects.create(
             organization_id=self.organization.id,
             name="new-owner/new-repo",
             provider="github",
@@ -461,21 +410,21 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
         )
         assert response.status_code == 204
 
-        mock_bulk_set_preferences.assert_called_once()
-        call_args = mock_bulk_set_preferences.call_args
-        preferences = call_args[0][1]
-        assert len(preferences) == 1
-        assert len(preferences[0]["repositories"]) == 1
-        assert preferences[0]["repositories"][0]["name"] == "new-repo"
-        assert preferences[0]["repositories"][0]["owner"] == "new-owner"
-        assert preferences[0]["repositories"][0]["external_id"] == "222"
+        seer_repos = list(SeerProjectRepository.objects.filter(project=project))
+        assert len(seer_repos) == 1
+        assert seer_repos[0].repository_id == new_repo.id
 
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_set_project_preferences"
-    )
-    def test_post_only_updates_projects_with_changes(self, mock_bulk_set_preferences):
+    def test_post_only_updates_projects_with_changes(self):
         project1 = self.create_project(organization=self.organization)
         project2 = self.create_project(organization=self.organization)
+        existing_repo = self.create_repo(
+            project=project2,
+            name="test-org/existing-repo",
+            provider="github",
+            external_id="existing-id",
+        )
+        SeerProjectRepository.objects.create(project=project2, repository=existing_repo)
+
         Repository.objects.create(
             organization_id=self.organization.id,
             name="test-org/test-repo",
@@ -502,16 +451,13 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
         )
         assert response.status_code == 204
 
-        mock_bulk_set_preferences.assert_called_once()
-        call_args = mock_bulk_set_preferences.call_args
-        preferences = call_args[0][1]
-        assert len(preferences) == 1
-        assert preferences[0]["project_id"] == project1.id
+        # project1 got the new mapping; project2's existing repo is untouched.
+        assert SeerProjectRepository.objects.filter(project=project1).count() == 1
+        project2_repos = list(SeerProjectRepository.objects.filter(project=project2))
+        assert len(project2_repos) == 1
+        assert project2_repos[0].repository_id == existing_repo.id
 
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_set_project_preferences"
-    )
-    def test_post_appends_repos_when_append_flag_true(self, mock_bulk_set_preferences):
+    def test_post_appends_repos_when_append_flag_true(self):
         project = self.create_project(organization=self.organization)
         existing_repo = self.create_repo(
             project=project,
@@ -520,7 +466,7 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
             external_id="111",
         )
         SeerProjectRepository.objects.create(project=project, repository=existing_repo)
-        Repository.objects.create(
+        new_repo = Repository.objects.create(
             organization_id=self.organization.id,
             name="new-owner/new-repo",
             provider="github",
@@ -547,18 +493,10 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
         )
         assert response.status_code == 204
 
-        mock_bulk_set_preferences.assert_called_once()
-        call_args = mock_bulk_set_preferences.call_args
-        preferences = call_args[0][1]
-        assert len(preferences) == 1
-        assert len(preferences[0]["repositories"]) == 2
-        assert preferences[0]["repositories"][0]["external_id"] == "111"
-        assert preferences[0]["repositories"][1]["external_id"] == "222"
+        seer_repos = SeerProjectRepository.objects.filter(project=project).order_by("repository_id")
+        assert [r.repository_id for r in seer_repos] == sorted([existing_repo.id, new_repo.id])
 
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_set_project_preferences"
-    )
-    def test_post_append_skips_duplicates(self, mock_bulk_set_preferences):
+    def test_post_append_skips_duplicates(self):
         project = self.create_project(organization=self.organization)
         existing_repo = self.create_repo(
             project=project,
@@ -567,7 +505,7 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
             external_id="111",
         )
         SeerProjectRepository.objects.create(project=project, repository=existing_repo)
-        Repository.objects.create(
+        new_repo = Repository.objects.create(
             organization_id=self.organization.id,
             name="new-owner/new-repo",
             provider="github",
@@ -575,14 +513,14 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
         )
 
         # Include a duplicate (same organization_id, provider, external_id) and a new repo
-        duplicate_repo = {
+        duplicate_repo_data = {
             "provider": "github",
             "owner": "existing-owner",
             "name": "existing-repo",
             "externalId": "111",
             "organizationId": self.organization.id,
         }
-        new_repo = {
+        new_repo_data = {
             "provider": "github",
             "owner": "new-owner",
             "name": "new-repo",
@@ -595,27 +533,18 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
             {
                 "projectIds": [project.id],
                 "projectRepoMappings": {
-                    str(project.id): [duplicate_repo, new_repo],
+                    str(project.id): [duplicate_repo_data, new_repo_data],
                 },
                 "appendRepositories": True,
             },
         )
         assert response.status_code == 204
 
-        mock_bulk_set_preferences.assert_called_once()
-        call_args = mock_bulk_set_preferences.call_args
-        preferences = call_args[0][1]
-        assert len(preferences) == 1
         # Should only have 2 repos: the existing one and the new one (duplicate skipped)
-        assert len(preferences[0]["repositories"]) == 2
-        assert preferences[0]["repositories"][0]["external_id"] == "111"
-        assert preferences[0]["repositories"][0]["owner"] == "existing-owner"
-        assert preferences[0]["repositories"][1]["external_id"] == "222"
+        seer_repos = SeerProjectRepository.objects.filter(project=project).order_by("repository_id")
+        assert [r.repository_id for r in seer_repos] == sorted([existing_repo.id, new_repo.id])
 
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_set_project_preferences"
-    )
-    def test_post_creates_audit_log(self, mock_bulk_set_preferences):
+    def test_post_creates_audit_log(self):
         project1 = self.create_project(organization=self.organization)
         project2 = self.create_project(organization=self.organization)
 
@@ -646,13 +575,10 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
                 audit_log.data["automated_run_stopping_point"] == AutofixStoppingPoint.OPEN_PR.value
             )
 
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_set_project_preferences"
-    )
-    def test_post_validates_repository_exists_in_organization(self, mock_bulk_set_preferences):
+    def test_post_validates_repository_exists_in_organization(self):
         """Test that POST validates repositories exist in the organization"""
         project = self.create_project(organization=self.organization)
-        Repository.objects.create(
+        repo = Repository.objects.create(
             organization_id=self.organization.id,
             name="test-org/test-repo",
             provider="github",
@@ -677,12 +603,11 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
             },
         )
         assert response.status_code == 204
-        mock_bulk_set_preferences.assert_called_once()
+        seer_repos = list(SeerProjectRepository.objects.filter(project=project))
+        assert len(seer_repos) == 1
+        assert seer_repos[0].repository_id == repo.id
 
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_set_project_preferences"
-    )
-    def test_post_rejects_repository_not_in_organization(self, mock_bulk_set_preferences):
+    def test_post_rejects_repository_not_in_organization(self):
         """Test that POST fails when repository doesn't exist in the organization"""
         project = self.create_project(organization=self.organization)
 
@@ -704,12 +629,9 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
         )
         assert response.status_code == 400
         assert response.data["detail"] == "Invalid repository"
-        mock_bulk_set_preferences.assert_not_called()
+        assert SeerProjectRepository.objects.filter(project=project).count() == 0
 
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_set_project_preferences"
-    )
-    def test_post_rejects_repository_from_different_organization(self, mock_bulk_set_preferences):
+    def test_post_rejects_repository_from_different_organization(self):
         """Test that POST fails when repository exists but belongs to a different organization"""
         project = self.create_project(organization=self.organization)
         other_org = self.create_organization(owner=self.user)
@@ -738,14 +660,9 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
         )
         assert response.status_code == 400
         assert response.data["detail"] == "Invalid repository"
-        mock_bulk_set_preferences.assert_not_called()
+        assert SeerProjectRepository.objects.filter(project=project).count() == 0
 
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_set_project_preferences"
-    )
-    def test_post_rejects_mismatched_organization_id_in_repository_data(
-        self, mock_bulk_set_preferences
-    ):
+    def test_post_rejects_mismatched_organization_id_in_repository_data(self):
         """Test that POST fails when repository organization_id doesn't match the organization."""
         project = self.create_project(organization=self.organization)
         other_org = self.create_organization(owner=self.user)
@@ -775,12 +692,9 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
         )
         assert response.status_code == 400
         assert response.data["detail"] == "Invalid repository"
-        mock_bulk_set_preferences.assert_not_called()
+        assert SeerProjectRepository.objects.filter(project=project).count() == 0
 
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_set_project_preferences"
-    )
-    def test_post_rejects_mismatched_repo_name_or_owner(self, mock_bulk_set_preferences):
+    def test_post_rejects_mismatched_repo_name_or_owner(self):
         """Test that POST fails when repository name/owner don't match the database record."""
         project = self.create_project(organization=self.organization)
         Repository.objects.create(
@@ -809,104 +723,9 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
         )
         assert response.status_code == 400
         assert response.data["detail"] == "Invalid repository"
-        mock_bulk_set_preferences.assert_not_called()
+        assert SeerProjectRepository.objects.filter(project=project).count() == 0
 
-    @with_feature("organizations:seer-project-settings-dual-write")
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_write_preferences_to_sentry_db"
-    )
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_set_project_preferences"
-    )
-    def test_post_writes_to_sentry_db(self, mock_bulk_set_preferences, mock_bulk_write_db):
-        """When feature flag enabled, writes to Sentry DB instead of Seer API."""
-        project = self.create_project(organization=self.organization)
-        Repository.objects.create(
-            organization_id=self.organization.id,
-            name="test-org/test-repo",
-            provider="github",
-            external_id="12345",
-        )
-
-        repo_data = {
-            "provider": "github",
-            "owner": "test-org",
-            "name": "test-repo",
-            "externalId": "12345",
-            "organizationId": self.organization.id,
-        }
-
-        response = self.client.post(
-            self.url,
-            {
-                "projectIds": [project.id],
-                "automatedRunStoppingPoint": AutofixStoppingPoint.OPEN_PR.value,
-                "projectRepoMappings": {
-                    str(project.id): [repo_data],
-                },
-            },
-        )
-
-        assert response.status_code == 204
-
-        mock_bulk_write_db.assert_called_once()
-        preferences = mock_bulk_write_db.call_args[0][1]
-        assert len(preferences) == 1
-        assert preferences[0].project_id == project.id
-        assert preferences[0].repositories[0].owner == "test-org"
-        assert preferences[0].repositories[0].name == "test-repo"
-
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_set_project_preferences"
-    )
-    def test_post_append_resolves_repo_id_for_existing_repos(self, mock_bulk_set_preferences):
-        """Test that appending repos resolves repository_id for existing SeerProjectRepository rows during write."""
-        project = self.create_project(organization=self.organization)
-        existing_repo = self.create_repo(
-            project=project,
-            name="test-org/existing-repo",
-            provider="github",
-            external_id="11111",
-        )
-        SeerProjectRepository.objects.create(project=project, repository=existing_repo)
-        new_repo = Repository.objects.create(
-            organization_id=self.organization.id,
-            name="test-org/new-repo",
-            provider="github",
-            external_id="22222",
-        )
-
-        with self.feature("organizations:seer-project-settings-dual-write"):
-            response = self.client.post(
-                self.url,
-                {
-                    "projectIds": [project.id],
-                    "appendRepositories": True,
-                    "projectRepoMappings": {
-                        str(project.id): [
-                            {
-                                "provider": "github",
-                                "owner": "test-org",
-                                "name": "new-repo",
-                                "externalId": "22222",
-                                "organizationId": self.organization.id,
-                            }
-                        ],
-                    },
-                },
-            )
-
-        assert response.status_code == 204
-
-        seer_repos = SeerProjectRepository.objects.filter(project=project).order_by("repository_id")
-        assert len(seer_repos) == 2
-        assert seer_repos[0].repository_id == existing_repo.id
-        assert seer_repos[1].repository_id == new_repo.id
-
-    @patch(
-        "sentry.seer.endpoints.organization_autofix_automation_settings.bulk_set_project_preferences"
-    )
-    def test_post_rejects_unsupported_repo_provider(self, mock_bulk_set_preferences):
+    def test_post_rejects_unsupported_repo_provider(self):
         project = self.create_project(organization=self.organization)
 
         repo_data = {
@@ -926,4 +745,4 @@ class OrganizationAutofixAutomationSettingsEndpointTest(APITestCase):
             },
         )
         assert response.status_code == 400
-        mock_bulk_set_preferences.assert_not_called()
+        assert SeerProjectRepository.objects.filter(project=project).count() == 0

--- a/tests/sentry/seer/endpoints/test_project_seer_preferences.py
+++ b/tests/sentry/seer/endpoints/test_project_seer_preferences.py
@@ -147,8 +147,8 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
         assert response.status_code == 204
         seer_repos = list(SeerProjectRepository.objects.filter(project=self.project))
         assert len(seer_repos) == 1
-        assert seer_repos[0].branch_name in ("", None)
-        assert seer_repos[0].instructions in ("", None)
+        assert seer_repos[0].branch_name == ""
+        assert seer_repos[0].instructions == ""
 
     def test_post_with_automation_handoff(self) -> None:
         """Test that POST request correctly handles automation_handoff field"""
@@ -187,6 +187,7 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
             "sentry:seer_automation_handoff_target", "cursor_background_agent"
         )
         self.project.update_option("sentry:seer_automation_handoff_integration_id", 123)
+        self.project.update_option("sentry:seer_automation_handoff_auto_create_pr", True)
 
         request_data = {
             "repositories": [
@@ -209,6 +210,7 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
         assert self.project.get_option("sentry:seer_automation_handoff_point") is None
         assert self.project.get_option("sentry:seer_automation_handoff_target") is None
         assert self.project.get_option("sentry:seer_automation_handoff_integration_id") is None
+        assert self.project.get_option("sentry:seer_automation_handoff_auto_create_pr") is False
 
     def test_post_with_invalid_automation_handoff_target(self) -> None:
         """Test that POST request fails with invalid target value"""
@@ -258,6 +260,7 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
 
     def test_post_with_auto_create_pr_in_handoff_config(self) -> None:
         """Test that POST request correctly handles auto_create_pr in automation_handoff"""
+        # Request data with automation_handoff including auto_create_pr
         request_data = {
             "repositories": [
                 {
@@ -325,7 +328,6 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
         response = self.client.post(self.url, data=request_data)
 
         assert response.status_code == 204
-        # auto_create_pr defaults to False, which the helper persists by deleting the option.
         assert self.project.get_option("sentry:seer_automation_handoff_auto_create_pr") is False
 
     def test_post_validates_repository_exists_in_organization(self) -> None:

--- a/tests/sentry/seer/endpoints/test_project_seer_preferences.py
+++ b/tests/sentry/seer/endpoints/test_project_seer_preferences.py
@@ -1,11 +1,10 @@
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, patch
 
 from django.urls import reverse
 
 from sentry.models.repository import Repository
 from sentry.seer.models.project_repository import SeerProjectRepository
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.features import with_feature
 
 
 class ProjectSeerPreferencesEndpointTest(APITestCase):
@@ -62,14 +61,8 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
         assert response.data["code_mapping_repos"][0]["external_id"] == "123456"
         assert response.data["code_mapping_repos"][0]["name"] == "sentry"
 
-    @patch("sentry.seer.endpoints.project_seer_preferences.make_set_project_preference_request")
-    def test_post(self, mock_request: MagicMock) -> None:
-        """Test that the POST method correctly calls the SEER API and returns the response"""
-        mock_response = Mock()
-        mock_response.status = 200
-        mock_request.return_value = mock_response
-
-        # Request data
+    def test_post(self) -> None:
+        """Test that POST writes the preference to Sentry DB."""
         request_data = {
             "repositories": [
                 {
@@ -85,31 +78,19 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
             ]
         }
 
-        # Make the request
         response = self.client.post(self.url, data=request_data)
 
-        # Assert the response
         assert response.status_code == 204
 
-        # Assert that the mock was called with the correct arguments
-        mock_request.assert_called_once()
-        body_dict = mock_request.call_args[0][0]
+        seer_repos = list(
+            SeerProjectRepository.objects.filter(project=self.project).select_related("repository")
+        )
+        assert len(seer_repos) == 1
+        assert seer_repos[0].repository_id == self.repository.id
+        assert seer_repos[0].branch_name == "main"
+        assert seer_repos[0].instructions == "test instructions"
 
-        # Verify the request body contains the expected data
-        assert "preference" in body_dict
-        preference = body_dict["preference"]
-        assert preference["organization_id"] == self.org.id
-        assert preference["project_id"] == self.project.id
-        assert len(preference["repositories"]) == 1
-        assert preference["repositories"][0]["integration_id"] == "111"
-        assert preference["repositories"][0]["provider"] == "github"
-        assert preference["repositories"][0]["owner"] == "getsentry"
-        assert preference["repositories"][0]["name"] == "sentry"
-        assert preference["repositories"][0]["instructions"] == "test instructions"
-        assert preference["repositories"][0]["branch_name"] == "main"
-
-    @patch("sentry.seer.endpoints.project_seer_preferences.make_set_project_preference_request")
-    def test_invalid_request_data(self, mock_request: MagicMock) -> None:
+    def test_invalid_request_data(self) -> None:
         """Test handling of invalid request data"""
         # Request with invalid data (missing required fields)
         request_data = {
@@ -122,14 +103,11 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
             ]
         }
 
-        # Make the request
         response = self.client.post(self.url, data=request_data)
 
         # Should fail with a 400 error for invalid request data
         assert response.status_code == 400
-
-        # The request to Seer should not be called since validation fails
-        mock_request.assert_not_called()
+        assert SeerProjectRepository.objects.filter(project=self.project).count() == 0
 
     @patch(
         "sentry.seer.endpoints.project_seer_preferences.get_autofix_repos_from_project_code_mappings",
@@ -146,14 +124,8 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
         assert preference["automation_handoff"] is None
         assert response.data["code_mapping_repos"] == []
 
-    @patch("sentry.seer.endpoints.project_seer_preferences.make_set_project_preference_request")
-    def test_post_with_blank_string_fields(self, mock_request: MagicMock) -> None:
+    def test_post_with_blank_string_fields(self) -> None:
         """Test that optional fields accept blank strings (empty strings) not just null values"""
-        # Setup the mock
-        mock_response = Mock()
-        mock_response.status = 200
-        mock_request.return_value = mock_response
-
         # Request data with blank strings for optional fields
         request_data = {
             "repositories": [
@@ -170,24 +142,16 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
             ]
         }
 
-        # Make the request
         response = self.client.post(self.url, data=request_data)
 
-        # Assert the response is successful
         assert response.status_code == 204
+        seer_repos = list(SeerProjectRepository.objects.filter(project=self.project))
+        assert len(seer_repos) == 1
+        assert seer_repos[0].branch_name in ("", None)
+        assert seer_repos[0].instructions in ("", None)
 
-        # Assert that the mock was called
-        mock_request.assert_called_once()
-
-    @patch("sentry.seer.endpoints.project_seer_preferences.make_set_project_preference_request")
-    def test_post_with_automation_handoff(self, mock_request: MagicMock) -> None:
+    def test_post_with_automation_handoff(self) -> None:
         """Test that POST request correctly handles automation_handoff field"""
-        # Setup the mock
-        mock_response = Mock()
-        mock_response.status = 200
-        mock_request.return_value = mock_response
-
-        # Request data with automation_handoff
         request_data = {
             "repositories": [
                 {
@@ -206,32 +170,24 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
             },
         }
 
-        # Make the request
         response = self.client.post(self.url, data=request_data)
 
-        # Assert the response is successful
         assert response.status_code == 204
+        assert self.project.get_option("sentry:seer_automation_handoff_point") == "root_cause"
+        assert (
+            self.project.get_option("sentry:seer_automation_handoff_target")
+            == "cursor_background_agent"
+        )
+        assert self.project.get_option("sentry:seer_automation_handoff_integration_id") == 123
 
-        # Assert that the mock was called
-        mock_request.assert_called_once()
-        body_dict = mock_request.call_args[0][0]
-
-        # Verify the request body contains automation_handoff
-        assert "preference" in body_dict
-        preference = body_dict["preference"]
-        assert "automation_handoff" in preference
-        assert preference["automation_handoff"]["handoff_point"] == "root_cause"
-        assert preference["automation_handoff"]["target"] == "cursor_background_agent"
-
-    @patch("sentry.seer.endpoints.project_seer_preferences.make_set_project_preference_request")
-    def test_post_with_null_automation_handoff(self, mock_request: MagicMock) -> None:
+    def test_post_with_null_automation_handoff(self) -> None:
         """Test that POST request correctly handles null automation_handoff"""
-        # Setup the mock
-        mock_response = Mock()
-        mock_response.status = 200
-        mock_request.return_value = mock_response
+        self.project.update_option("sentry:seer_automation_handoff_point", "root_cause")
+        self.project.update_option(
+            "sentry:seer_automation_handoff_target", "cursor_background_agent"
+        )
+        self.project.update_option("sentry:seer_automation_handoff_integration_id", 123)
 
-        # Request data with null automation_handoff
         request_data = {
             "repositories": [
                 {
@@ -246,23 +202,16 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
             "automation_handoff": None,
         }
 
-        # Make the request
         response = self.client.post(self.url, data=request_data)
 
-        # Assert the response is successful
         assert response.status_code == 204
+        # Automation handoff should be cleared.
+        assert self.project.get_option("sentry:seer_automation_handoff_point") is None
+        assert self.project.get_option("sentry:seer_automation_handoff_target") is None
+        assert self.project.get_option("sentry:seer_automation_handoff_integration_id") is None
 
-        # Assert that the mock was called
-        mock_request.assert_called_once()
-        body_dict = mock_request.call_args[0][0]
-
-        # Verify the request body has null automation_handoff
-        assert body_dict["preference"]["automation_handoff"] is None
-
-    @patch("sentry.seer.endpoints.project_seer_preferences.make_set_project_preference_request")
-    def test_post_with_invalid_automation_handoff_target(self, mock_request: MagicMock) -> None:
+    def test_post_with_invalid_automation_handoff_target(self) -> None:
         """Test that POST request fails with invalid target value"""
-        # Request data with invalid target
         request_data = {
             "repositories": [
                 {
@@ -281,14 +230,11 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
             },
         }
 
-        # Make the request
         response = self.client.post(self.url, data=request_data)
 
         # Should fail with a 400 error for invalid request data
         assert response.status_code == 400
-
-        # The post to Seer should not be called since validation fails
-        mock_request.assert_not_called()
+        assert SeerProjectRepository.objects.filter(project=self.project).count() == 0
 
     @patch(
         "sentry.seer.endpoints.project_seer_preferences.get_autofix_repos_from_project_code_mappings",
@@ -310,15 +256,8 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
         assert handoff["target"] == "cursor_background_agent"
         assert handoff["integration_id"] == 123
 
-    @patch("sentry.seer.endpoints.project_seer_preferences.make_set_project_preference_request")
-    def test_post_with_auto_create_pr_in_handoff_config(self, mock_request: MagicMock) -> None:
+    def test_post_with_auto_create_pr_in_handoff_config(self) -> None:
         """Test that POST request correctly handles auto_create_pr in automation_handoff"""
-        # Setup the mock
-        mock_response = Mock()
-        mock_response.status = 200
-        mock_request.return_value = mock_response
-
-        # Request data with automation_handoff including auto_create_pr
         request_data = {
             "repositories": [
                 {
@@ -338,21 +277,10 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
             },
         }
 
-        # Make the request
         response = self.client.post(self.url, data=request_data)
 
-        # Assert the response is successful
         assert response.status_code == 204
-
-        # Assert that the mock was called
-        mock_request.assert_called_once()
-        body_dict = mock_request.call_args[0][0]
-
-        # Verify the request body contains auto_create_pr in automation_handoff
-        assert "preference" in body_dict
-        preference = body_dict["preference"]
-        assert "automation_handoff" in preference
-        assert preference["automation_handoff"]["auto_create_pr"] is True
+        assert self.project.get_option("sentry:seer_automation_handoff_auto_create_pr") is True
 
     @patch(
         "sentry.seer.endpoints.project_seer_preferences.get_autofix_repos_from_project_code_mappings",
@@ -374,17 +302,8 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
         assert response.status_code == 200
         assert response.data["preference"]["automation_handoff"]["auto_create_pr"] is True
 
-    @patch("sentry.seer.endpoints.project_seer_preferences.make_set_project_preference_request")
-    def test_post_handoff_without_auto_create_pr_defaults_to_false(
-        self, mock_request: MagicMock
-    ) -> None:
+    def test_post_handoff_without_auto_create_pr_defaults_to_false(self) -> None:
         """Test that when auto_create_pr is not specified in handoff, it defaults to False"""
-        # Setup the mock
-        mock_response = Mock()
-        mock_response.status = 200
-        mock_request.return_value = mock_response
-
-        # Request data with automation_handoff but without auto_create_pr
         request_data = {
             "repositories": [
                 {
@@ -403,37 +322,20 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
             },
         }
 
-        # Make the request
         response = self.client.post(self.url, data=request_data)
 
-        # Assert the response is successful
         assert response.status_code == 204
+        # auto_create_pr defaults to False, which the helper persists by deleting the option.
+        assert self.project.get_option("sentry:seer_automation_handoff_auto_create_pr") is False
 
-        # Assert that the mock was called
-        mock_request.assert_called_once()
-        body_dict = mock_request.call_args[0][0]
-
-        # Verify the request body contains auto_create_pr defaulted to False
-        assert "preference" in body_dict
-        preference = body_dict["preference"]
-        assert "automation_handoff" in preference
-        assert preference["automation_handoff"]["auto_create_pr"] is False
-
-    @patch("sentry.seer.endpoints.project_seer_preferences.make_set_project_preference_request")
-    def test_post_validates_repository_exists_in_organization(
-        self, mock_request: MagicMock
-    ) -> None:
+    def test_post_validates_repository_exists_in_organization(self) -> None:
         """Test that POST validates repository exists in the organization"""
-        Repository.objects.create(
+        repo = Repository.objects.create(
             organization_id=self.org.id,
             name="getsentry/sentry",
             provider="integrations:github",
             external_id="valid-external-id",
         )
-
-        mock_response = Mock()
-        mock_response.status = 200
-        mock_request.return_value = mock_response
 
         request_data = {
             "repositories": [
@@ -451,10 +353,11 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
         response = self.client.post(self.url, data=request_data)
 
         assert response.status_code == 204
-        mock_request.assert_called_once()
+        seer_repos = list(SeerProjectRepository.objects.filter(project=self.project))
+        assert len(seer_repos) == 1
+        assert seer_repos[0].repository_id == repo.id
 
-    @patch("sentry.seer.endpoints.project_seer_preferences.make_set_project_preference_request")
-    def test_post_rejects_repository_not_in_organization(self, mock_request: MagicMock) -> None:
+    def test_post_rejects_repository_not_in_organization(self) -> None:
         """Test that POST fails when repository doesn't exist in the organization"""
         request_data = {
             "repositories": [
@@ -473,12 +376,9 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
 
         assert response.status_code == 400
         assert response.data["detail"] == "Invalid repository"
-        mock_request.assert_not_called()
+        assert SeerProjectRepository.objects.filter(project=self.project).count() == 0
 
-    @patch("sentry.seer.endpoints.project_seer_preferences.make_set_project_preference_request")
-    def test_post_rejects_repository_from_different_organization(
-        self, mock_request: MagicMock
-    ) -> None:
+    def test_post_rejects_repository_from_different_organization(self) -> None:
         """Test that POST fails when repository exists but belongs to a different organization"""
         other_org = self.create_organization(owner=self.user)
         Repository.objects.create(
@@ -505,12 +405,9 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
 
         assert response.status_code == 400
         assert response.data["detail"] == "Invalid repository"
-        mock_request.assert_not_called()
+        assert SeerProjectRepository.objects.filter(project=self.project).count() == 0
 
-    @patch("sentry.seer.endpoints.project_seer_preferences.make_set_project_preference_request")
-    def test_post_rejects_mismatched_organization_id_in_repository_data(
-        self, mock_request: MagicMock
-    ) -> None:
+    def test_post_rejects_mismatched_organization_id_in_repository_data(self) -> None:
         """Test that POST fails when repository organization_id doesn't match project's org."""
         other_org = self.create_organization(owner=self.user)
 
@@ -531,10 +428,9 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
 
         assert response.status_code == 400
         assert response.data["detail"] == "Invalid repository"
-        mock_request.assert_not_called()
+        assert SeerProjectRepository.objects.filter(project=self.project).count() == 0
 
-    @patch("sentry.seer.endpoints.project_seer_preferences.make_set_project_preference_request")
-    def test_post_rejects_mismatched_repo_name_or_owner(self, mock_request: MagicMock) -> None:
+    def test_post_rejects_mismatched_repo_name_or_owner(self) -> None:
         """Test that POST fails when repository name/owner don't match the database record."""
         request_data = {
             "repositories": [
@@ -553,10 +449,9 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
 
         assert response.status_code == 400
         assert response.data["detail"] == "Invalid repository"
-        mock_request.assert_not_called()
+        assert SeerProjectRepository.objects.filter(project=self.project).count() == 0
 
-    @patch("sentry.seer.endpoints.project_seer_preferences.make_set_project_preference_request")
-    def test_post_rejects_unsupported_repo_provider(self, mock_request: MagicMock) -> None:
+    def test_post_rejects_unsupported_repo_provider(self) -> None:
         request_data = {
             "repositories": [
                 {
@@ -573,37 +468,4 @@ class ProjectSeerPreferencesEndpointTest(APITestCase):
         response = self.client.post(self.url, data=request_data)
 
         assert response.status_code == 400
-        mock_request.assert_not_called()
-
-    @with_feature("organizations:seer-project-settings-dual-write")
-    @patch("sentry.seer.endpoints.project_seer_preferences.write_preference_to_sentry_db")
-    @patch("sentry.seer.endpoints.project_seer_preferences.make_set_project_preference_request")
-    def test_post_writes_to_sentry_db(
-        self, mock_request: MagicMock, mock_write_db: MagicMock
-    ) -> None:
-        """When feature flag enabled, writes to Sentry DB instead of Seer API."""
-        mock_response = Mock()
-        mock_response.status = 200
-        mock_request.return_value = mock_response
-
-        request_data = {
-            "repositories": [
-                {
-                    "organization_id": self.org.id,
-                    "integration_id": "111",
-                    "provider": "github",
-                    "owner": "getsentry",
-                    "name": "sentry",
-                    "external_id": "123456",
-                    "branch_name": "main",
-                    "instructions": "test instructions",
-                }
-            ],
-            "automated_run_stopping_point": "open_pr",
-        }
-
-        response = self.client.post(self.url, data=request_data)
-
-        assert response.status_code == 204
-
-        mock_write_db.assert_called_once()
+        assert SeerProjectRepository.objects.filter(project=self.project).count() == 0


### PR DESCRIPTION
relates to AIML-2614

The Seer settings migration to Sentry DB is complete. The Seer API write path is no longer the source of truth, so this drops the Seer API call from both the bulk org-level endpoint and the single-project endpoint and makes the Sentry DB write the primary path. 

Tests are rewritten to assert on the resulting DB state.