### PR TITLE
ref(seer): Remove Seer API project preference dual writes in internal flows and helpers

### DIFF
--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -9,6 +9,7 @@ from sentry import analytics, features
 from sentry.analytics.events.autofix_events import AiAutofixPrCreatedCompletedEvent
 from sentry.models.group import Group
 from sentry.models.organization import Organization
+from sentry.models.project import Project
 from sentry.seer.autofix.autofix_agent import (
     STEP_CONFIGS,
     AutofixStep,
@@ -484,6 +485,19 @@ class AutofixOnCompletionHook(ExplorerOnCompletionHook):
         return read_preference_from_sentry_db(group.project).automation_handoff
 
     @classmethod
+    def _clear_handoff_preference(
+        cls, project: Project, run_id: int, organization: Organization
+    ) -> None:
+        """Clear automation_handoff from project preferences after integration is not found."""
+        try:
+            clear_preference_automation_handoff(project)
+        except Exception:
+            logger.exception(
+                "autofix.on_completion_hook.clear_handoff_preference_failed",
+                extra={"run_id": run_id, "organization_id": organization.id},
+            )
+
+    @classmethod
     def _trigger_coding_agent_handoff(
         cls,
         organization: Organization,
@@ -528,7 +542,7 @@ class AutofixOnCompletionHook(ExplorerOnCompletionHook):
                     "integration_id": handoff_config.integration_id,
                 },
             )
-            clear_preference_automation_handoff(group.project)
+            cls._clear_handoff_preference(group.project, run_id, organization)
         except Exception:
             logger.exception(
                 "autofix.on_completion_hook.coding_agent_handoff_failed",

--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -9,7 +9,6 @@ from sentry import analytics, features
 from sentry.analytics.events.autofix_events import AiAutofixPrCreatedCompletedEvent
 from sentry.models.group import Group
 from sentry.models.organization import Organization
-from sentry.models.project import Project
 from sentry.seer.autofix.autofix_agent import (
     STEP_CONFIGS,
     AutofixStep,
@@ -23,15 +22,12 @@ from sentry.seer.autofix.utils import (
     AutofixStoppingPoint,
     clear_preference_automation_handoff,
     read_preference_from_sentry_db,
-    set_project_seer_preference,
 )
 from sentry.seer.entrypoints.operator import SeerAutofixOperator, process_autofix_updates
 from sentry.seer.explorer.client_models import Artifact
 from sentry.seer.explorer.client_utils import fetch_run_status
 from sentry.seer.explorer.on_completion_hook import ExplorerOnCompletionHook
 from sentry.seer.models import (
-    SeerApiError,
-    SeerApiResponseValidationError,
     SeerAutomationHandoffConfiguration,
 )
 from sentry.seer.supergroups.embeddings import trigger_supergroups_embedding
@@ -488,35 +484,6 @@ class AutofixOnCompletionHook(ExplorerOnCompletionHook):
         return read_preference_from_sentry_db(group.project).automation_handoff
 
     @classmethod
-    def _clear_handoff_preference(
-        cls, project: Project, run_id: int, organization: Organization
-    ) -> None:
-        """Clear automation_handoff from project preferences after integration is not found."""
-        preference = read_preference_from_sentry_db(project)
-        if preference.automation_handoff is None:
-            return
-
-        updated_preference = preference.copy(update={"automation_handoff": None})
-
-        try:
-            set_project_seer_preference(updated_preference)
-        except (SeerApiError, SeerApiResponseValidationError):
-            logger.exception(
-                "autofix.on_completion_hook.clear_handoff_preference_failed",
-                extra={"run_id": run_id, "organization_id": organization.id},
-            )
-            return
-
-        if features.has("organizations:seer-project-settings-dual-write", organization):
-            try:
-                clear_preference_automation_handoff(project)
-            except Exception:
-                logger.exception(
-                    "seer.write_preferences.failed",
-                    extra={"project_id": project.id, "organization_id": organization.id},
-                )
-
-    @classmethod
     def _trigger_coding_agent_handoff(
         cls,
         organization: Organization,
@@ -561,7 +528,7 @@ class AutofixOnCompletionHook(ExplorerOnCompletionHook):
                     "integration_id": handoff_config.integration_id,
                 },
             )
-            cls._clear_handoff_preference(group.project, run_id, organization)
+            clear_preference_automation_handoff(group.project)
         except Exception:
             logger.exception(
                 "autofix.on_completion_hook.coding_agent_handoff_failed",

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -36,7 +36,6 @@ from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import AttributeKey, AttributeValue, StrArray
 from sentry_protos.snuba.v1.trace_item_filter_pb2 import ComparisonFilter, TraceItemFilter
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.authentication import AuthenticationSiloLimit, StandardAuthentication
@@ -618,13 +617,10 @@ def trigger_coding_agent_launch(
             },
         )
         try:
-            organization = Organization.objects.get_from_cache(id=organization_id)
-            if features.has("organizations:seer-project-settings-dual-write", organization):
-                project = Project.objects.get_from_cache(id=project_id)
-                if project.organization_id != organization_id:
-                    raise Project.DoesNotExist
-                clear_preference_automation_handoff(project)
-                # Returning the error code will prompt Seer to clear the preference handoff in its own DB too.
+            project = Project.objects.get_from_cache(id=project_id)
+            if project.organization_id != organization_id:
+                raise Project.DoesNotExist
+            clear_preference_automation_handoff(project)
         except Exception:
             logger.exception(
                 "coding_agent.clear_handoff_preference_failed",

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -583,7 +583,10 @@ def set_default_project_seer_preferences(organization: Organization, project: Pr
         automation_handoff=automation_handoff,
     )
 
-    write_preference_to_sentry_db(project, preference)
+    try:
+        write_preference_to_sentry_db(project, preference)
+    except Exception as e:
+        sentry_sdk.capture_exception(e)
 
 
 def report_token_count_metric(

--- a/src/sentry/seer/similarity/utils.py
+++ b/src/sentry/seer/similarity/utils.py
@@ -8,7 +8,7 @@ from typing import Any, TypedDict, TypeVar
 import sentry_sdk
 from tokenizers import Tokenizer
 
-from sentry import features, options
+from sentry import options
 from sentry.constants import (
     DATA_ROOT,
 )
@@ -22,7 +22,6 @@ from sentry.seer.autofix.constants import AutofixAutomationTuningSettings
 from sentry.seer.autofix.utils import (
     get_org_default_seer_automation_handoff,
     is_seer_seat_based_tier_enabled,
-    set_project_seer_preference,
     write_preference_to_sentry_db,
 )
 from sentry.seer.models import (
@@ -576,7 +575,6 @@ def set_default_project_seer_preferences(organization: Organization, project: Pr
 
     stopping_point, automation_handoff = get_org_default_seer_automation_handoff(organization)
 
-    # We need to make an API call to Seer to set this preference
     preference = SeerProjectPreference(
         organization_id=organization.id,
         project_id=project.id,
@@ -585,20 +583,7 @@ def set_default_project_seer_preferences(organization: Organization, project: Pr
         automation_handoff=automation_handoff,
     )
 
-    try:
-        set_project_seer_preference(preference)
-    except Exception as e:
-        sentry_sdk.capture_exception(e)
-        return
-
-    if features.has("organizations:seer-project-settings-dual-write", organization):
-        try:
-            write_preference_to_sentry_db(project, preference)
-        except Exception:
-            logger.exception(
-                "seer.write_preferences.failed",
-                extra={"project_id": project.id, "organization_id": organization.id},
-            )
+    write_preference_to_sentry_db(project, preference)
 
 
 def report_token_count_metric(

--- a/src/sentry/tasks/seer/autofix.py
+++ b/src/sentry/tasks/seer/autofix.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 from taskbroker_client.retry import Retry
 from taskbroker_client.state import current_task
 
-from sentry import analytics, features
+from sentry import analytics
 from sentry.analytics.events.autofix_automation_events import AiAutofixAutomationEvent
 from sentry.constants import (
     ObjectStatus,
@@ -21,7 +21,6 @@ from sentry.seer.autofix.constants import (
 )
 from sentry.seer.autofix.utils import (
     bulk_read_preferences_from_sentry_db,
-    bulk_set_project_preferences,
     bulk_write_preferences_to_sentry_db,
     get_autofix_state,
     get_org_default_seer_automation_handoff,
@@ -206,7 +205,9 @@ def configure_seer_for_existing_org(organization_id: int) -> None:
 
     Sets:
     - Project-level (all projects): seer_scanner_automation=True, autofix_automation_tuning="medium" or "off"
-    - Seer API (all projects): automated_run_stopping_point="code_changes" or "open_pr"
+    - Seer project preferences (all projects): automated_run_stopping_point="code_changes" or "open_pr",
+      and automation_handoff backfilled from the org defaults (when set) for projects that don't already
+      have one configured.
 
     Ignores:
     - Org-level: enable_seer_coding
@@ -281,17 +282,7 @@ def configure_seer_for_existing_org(organization_id: int) -> None:
         )
 
     if len(preferences_to_set) > 0:
-        bulk_set_project_preferences(
-            organization_id, [preference.dict() for preference in preferences_to_set]
-        )
-
-        if features.has("organizations:seer-project-settings-dual-write", organization):
-            try:
-                bulk_write_preferences_to_sentry_db(projects, preferences_to_set)
-            except Exception:
-                logger.exception(
-                    "seer.write_preferences.failed", extra={"organization_id": organization_id}
-                )
+        bulk_write_preferences_to_sentry_db(projects, preferences_to_set)
 
     # Invalidate existing cache entry and set cache to True to prevent race conditions where another
     # request re-caches False before the billing flag has fully propagated
@@ -303,6 +294,6 @@ def configure_seer_for_existing_org(organization_id: int) -> None:
             "org_id": organization.id,
             "org_slug": organization.slug,
             "projects_configured": len(project_ids),
-            "preferences_set_via_api": len(preferences_to_set),
+            "preferences_set": len(preferences_to_set),
         },
     )

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -509,13 +509,13 @@ class TestAutofixOnCompletionHookHandoff(TestCase):
             "sentry:seer_automation_handoff_target", "cursor_background_agent"
         )
         self.project.update_option("sentry:seer_automation_handoff_integration_id", integration_id)
-        self.project.update_option("sentry:seer_automation_handoff_auto_create_pr", False)
+        self.project.update_option("sentry:seer_automation_handoff_auto_create_pr", True)
 
         return SeerAutomationHandoffConfiguration(
             handoff_point=handoff_point,
             target="cursor_background_agent",
             integration_id=integration_id,
-            auto_create_pr=False,
+            auto_create_pr=True,
         )
 
     @patch("sentry.seer.autofix.on_completion_hook.read_preference_from_sentry_db")
@@ -602,6 +602,7 @@ class TestAutofixOnCompletionHookHandoff(TestCase):
         assert self.project.get_option("sentry:seer_automation_handoff_point") is None
         assert self.project.get_option("sentry:seer_automation_handoff_target") is None
         assert self.project.get_option("sentry:seer_automation_handoff_integration_id") is None
+        assert self.project.get_option("sentry:seer_automation_handoff_auto_create_pr") is False
 
     @patch("sentry.seer.autofix.on_completion_hook.trigger_coding_agent_handoff")
     def test_trigger_coding_agent_handoff_calls_function(self, mock_trigger):

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -584,11 +584,8 @@ class TestAutofixOnCompletionHookHandoff(TestCase):
 
         mock_trigger_handoff.assert_called_once()
 
-    @patch("sentry.seer.autofix.on_completion_hook.set_project_seer_preference")
     @patch("sentry.seer.autofix.on_completion_hook.trigger_coding_agent_handoff")
-    def test_trigger_coding_agent_handoff_clears_preference_on_not_found(
-        self, mock_trigger, mock_set_pref
-    ):
+    def test_trigger_coding_agent_handoff_clears_preference_on_not_found(self, mock_trigger):
         """When IntegrationNotFound is raised, automation_handoff is cleared from preferences."""
         from sentry.seer.autofix.coding_agent import IntegrationNotFound
 
@@ -602,32 +599,9 @@ class TestAutofixOnCompletionHookHandoff(TestCase):
             handoff_config=handoff_config,
         )
 
-        mock_set_pref.assert_called_once()
-        updated = mock_set_pref.call_args.args[0]
-        assert updated.automation_handoff is None
-
-    @patch("sentry.seer.autofix.on_completion_hook.set_project_seer_preference")
-    @patch("sentry.seer.autofix.on_completion_hook.trigger_coding_agent_handoff")
-    def test_trigger_coding_agent_handoff_not_found_seer_api_error_does_not_raise(
-        self, mock_trigger, mock_set_pref
-    ):
-        """A SeerApiError during preference SET after IntegrationNotFound should not propagate."""
-        from sentry.seer.autofix.coding_agent import IntegrationNotFound
-        from sentry.seer.models import SeerApiError
-
-        mock_trigger.side_effect = IntegrationNotFound()
-        mock_set_pref.side_effect = SeerApiError("seer unavailable", 503)
-        handoff_config = self._make_handoff_config()
-
-        # Should not raise
-        AutofixOnCompletionHook._trigger_coding_agent_handoff(
-            organization=self.organization,
-            run_id=123,
-            group=self.group,
-            handoff_config=handoff_config,
-        )
-
-        mock_set_pref.assert_called_once()
+        assert self.project.get_option("sentry:seer_automation_handoff_point") is None
+        assert self.project.get_option("sentry:seer_automation_handoff_target") is None
+        assert self.project.get_option("sentry:seer_automation_handoff_integration_id") is None
 
     @patch("sentry.seer.autofix.on_completion_hook.trigger_coding_agent_handoff")
     def test_trigger_coding_agent_handoff_calls_function(self, mock_trigger):

--- a/tests/sentry/seer/autofix/test_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_on_completion_hook.py
@@ -7,10 +7,8 @@ from sentry.seer.autofix.on_completion_hook import AutofixOnCompletionHook
 from sentry.seer.autofix.utils import CodingAgentProviderType
 from sentry.seer.models.seer_api_models import SeerAutomationHandoffConfiguration
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.features import with_feature
 
 
-@with_feature("organizations:seer-project-settings-dual-write")
 class TestTriggerCodingAgentHandoff(TestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -18,9 +16,8 @@ class TestTriggerCodingAgentHandoff(TestCase):
         self.project = self.create_project(organization=self.organization)
         self.group = self.create_group(project=self.project)
 
-    @patch("sentry.seer.autofix.on_completion_hook.set_project_seer_preference")
     @patch("sentry.seer.autofix.on_completion_hook.trigger_coding_agent_handoff")
-    def test_not_found_clears_automation_handoff(self, mock_trigger, mock_set_pref) -> None:
+    def test_not_found_clears_automation_handoff(self, mock_trigger) -> None:
         mock_trigger.side_effect = IntegrationNotFound("Integration not found")
 
         self.project.update_option("sentry:seer_automation_handoff_point", "root_cause")
@@ -41,33 +38,7 @@ class TestTriggerCodingAgentHandoff(TestCase):
             ),
         )
 
-        mock_set_pref.assert_called_once()
-        updated_pref = mock_set_pref.call_args[0][0]
-        assert updated_pref.automation_handoff is None
-
         assert self.project.get_option("sentry:seer_automation_handoff_point") is None
         assert self.project.get_option("sentry:seer_automation_handoff_target") is None
         assert self.project.get_option("sentry:seer_automation_handoff_integration_id") is None
         assert self.project.get_option("sentry:seer_automation_handoff_auto_create_pr") is False
-
-    @patch("sentry.seer.autofix.on_completion_hook.set_project_seer_preference")
-    @patch("sentry.seer.autofix.on_completion_hook.trigger_coding_agent_handoff")
-    def test_not_found_no_handoff_does_not_call_set(self, mock_trigger, mock_set_pref) -> None:
-        """With no handoff options set on the project, set_project_seer_preference is skipped."""
-        mock_trigger.side_effect = IntegrationNotFound("Integration not found")
-
-        # Handoff is passed to the function but not actually set in ProjectOptions.
-        handoff_config = SeerAutomationHandoffConfiguration(
-            handoff_point="root_cause",
-            target=CodingAgentProviderType.CURSOR_BACKGROUND_AGENT,
-            integration_id=789,
-        )
-
-        AutofixOnCompletionHook._trigger_coding_agent_handoff(
-            organization=self.organization,
-            run_id=1,
-            group=self.group,
-            handoff_config=handoff_config,
-        )
-
-        mock_set_pref.assert_not_called()

--- a/tests/sentry/seer/endpoints/test_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_seer_rpc.py
@@ -33,7 +33,6 @@ from sentry.seer.explorer.tools import get_trace_item_attributes
 from sentry.seer.models.project_repository import SeerProjectRepository
 from sentry.sentry_apps.metrics import SentryAppEventType
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import assume_test_silo_mode_of
 from sentry.utils.snuba_rpc import SnubaRPCRateLimitExceeded
 
@@ -1663,7 +1662,6 @@ class TestTriggerCodingAgentLaunch:
 
 
 class TestTriggerCodingAgentLaunchClearsHandoff(APITestCase):
-    @with_feature("organizations:seer-project-settings-dual-write")
     @patch("sentry.seer.endpoints.seer_rpc.launch_coding_agents_for_run")
     def test_integration_not_found_clears_handoff_project_options(self, mock_launch):
         mock_launch.side_effect = IntegrationNotFound()
@@ -1688,23 +1686,6 @@ class TestTriggerCodingAgentLaunchClearsHandoff(APITestCase):
         assert self.project.get_option("sentry:seer_automation_handoff_integration_id") is None
         assert self.project.get_option("sentry:seer_automation_handoff_auto_create_pr") is False
 
-    @patch("sentry.seer.endpoints.seer_rpc.launch_coding_agents_for_run")
-    def test_integration_not_found_skips_clear_without_feature_flag(self, mock_launch):
-        mock_launch.side_effect = IntegrationNotFound()
-
-        self.project.update_option("sentry:seer_automation_handoff_point", "root_cause")
-
-        result = trigger_coding_agent_launch(
-            organization_id=self.organization.id,
-            project_id=self.project.id,
-            integration_id=42,
-            run_id=99,
-        )
-
-        assert result == {"success": False, "error_code": "integration_not_found"}
-        assert self.project.get_option("sentry:seer_automation_handoff_point") == "root_cause"
-
-    @with_feature("organizations:seer-project-settings-dual-write")
     @patch("sentry.seer.endpoints.seer_rpc.launch_coding_agents_for_run")
     def test_integration_not_found_skips_clear_when_project_outside_org(self, mock_launch):
         """Project IDs outside the caller org must not have their preferences mutated."""

--- a/tests/sentry/tasks/seer/test_autofix.py
+++ b/tests/sentry/tasks/seer/test_autofix.py
@@ -216,8 +216,10 @@ class TestConfigureSeerForExistingOrg(SentryTestCase):
 
         # Existing stopping point and handoff preserved instead of being backfilled from org defaults.
         assert project.get_option("sentry:seer_automated_run_stopping_point") == "code_changes"
+        assert project.get_option("sentry:seer_automation_handoff_point") == "root_cause"
         assert project.get_option("sentry:seer_automation_handoff_target") == "claude_code_agent"
         assert project.get_option("sentry:seer_automation_handoff_integration_id") == 99
+        assert project.get_option("sentry:seer_automation_handoff_auto_create_pr") is False
 
     def test_project_with_valid_stopping_point_gets_handoff_from_org_defaults(self) -> None:
         """Project with valid stopping point but no handoff gets org default handoff applied.

--- a/tests/sentry/tasks/seer/test_autofix.py
+++ b/tests/sentry/tasks/seer/test_autofix.py
@@ -4,11 +4,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 from django.test import TestCase
 
-from sentry.constants import SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT
 from sentry.seer.autofix.constants import AutofixStatus, SeerAutomationSource
 from sentry.seer.autofix.utils import AutofixState, get_seer_seat_based_tier_cache_key
 from sentry.seer.models import (
-    SeerApiError,
     SummarizeIssueResponse,
     SummarizeIssueScores,
 )
@@ -19,7 +17,6 @@ from sentry.tasks.seer.autofix import (
     generate_issue_summary_only,
 )
 from sentry.testutils.cases import TestCase as SentryTestCase
-from sentry.testutils.helpers.features import with_feature
 from sentry.utils.cache import cache
 
 
@@ -153,8 +150,7 @@ class TestGenerateIssueSummaryOnly(SentryTestCase):
 
 
 class TestConfigureSeerForExistingOrg(SentryTestCase):
-    @patch("sentry.tasks.seer.autofix.bulk_set_project_preferences")
-    def test_configures_org_and_project_settings(self, mock_bulk_set: MagicMock) -> None:
+    def test_configures_org_and_project_settings(self) -> None:
         """Test that org and project settings are configured correctly."""
         project1 = self.create_project(organization=self.organization)
         project2 = self.create_project(organization=self.organization)
@@ -172,13 +168,14 @@ class TestConfigureSeerForExistingOrg(SentryTestCase):
         assert project1.get_option("sentry:autofix_automation_tuning") == "medium"
         assert project2.get_option("sentry:seer_scanner_automation") is True
         assert project2.get_option("sentry:autofix_automation_tuning") == "medium"
-
-        # Projects with valid default stopping point and no org default handoff are skipped.
-        mock_bulk_set.assert_not_called()
+        # Check Seer project preferences (valid stopping point + no org-default handoff means no change)
+        assert project1.get_option("sentry:seer_automation_handoff_point") is None
+        assert project1.get_option("sentry:seer_automation_handoff_target") is None
+        assert project2.get_option("sentry:seer_automation_handoff_point") is None
+        assert project2.get_option("sentry:seer_automation_handoff_target") is None
 
     @pytest.mark.skip("DO NOT override autofix automation tuning off")
-    @patch("sentry.tasks.seer.autofix.bulk_set_project_preferences")
-    def test_overrides_autofix_off_to_medium(self, mock_bulk_set: MagicMock) -> None:
+    def test_overrides_autofix_off_to_medium(self) -> None:
         """Test that projects with autofix set to off are migrated to medium."""
         project = self.create_project(organization=self.organization)
         project.update_option("sentry:autofix_automation_tuning", "off")
@@ -190,22 +187,18 @@ class TestConfigureSeerForExistingOrg(SentryTestCase):
         # Scanner should be enabled
         assert project.get_option("sentry:seer_scanner_automation") is True
 
-    @patch("sentry.tasks.seer.autofix.bulk_set_project_preferences")
-    def test_skips_project_with_valid_stopping_point_and_no_default_handoff(
-        self, mock_bulk_set: MagicMock
-    ) -> None:
+    def test_skips_project_with_valid_stopping_point_and_no_default_handoff(self) -> None:
         """Project is skipped when it has a valid stopping point and the org has no default handoff (seer agent)."""
         project = self.create_project(organization=self.organization)
         project.update_option("sentry:seer_automated_run_stopping_point", "open_pr")
 
         configure_seer_for_existing_org(organization_id=self.organization.id)
 
-        mock_bulk_set.assert_not_called()
+        # Existing stopping point is unchanged and no handoff is written.
+        assert project.get_option("sentry:seer_automated_run_stopping_point") == "open_pr"
+        assert project.get_option("sentry:seer_automation_handoff_point") is None
 
-    @patch("sentry.tasks.seer.autofix.bulk_set_project_preferences")
-    def test_skips_project_with_valid_stopping_point_and_existing_handoff(
-        self, mock_bulk_set: MagicMock
-    ) -> None:
+    def test_skips_project_with_valid_stopping_point_and_existing_handoff(self) -> None:
         """Project is skipped when it has a valid stopping point and an existing handoff configured."""
         project = self.create_project(organization=self.organization)
         self.organization.update_option(
@@ -221,12 +214,12 @@ class TestConfigureSeerForExistingOrg(SentryTestCase):
 
         configure_seer_for_existing_org(organization_id=self.organization.id)
 
-        mock_bulk_set.assert_not_called()
+        # Existing stopping point and handoff preserved instead of being backfilled from org defaults.
+        assert project.get_option("sentry:seer_automated_run_stopping_point") == "code_changes"
+        assert project.get_option("sentry:seer_automation_handoff_target") == "claude_code_agent"
+        assert project.get_option("sentry:seer_automation_handoff_integration_id") == 99
 
-    @patch("sentry.tasks.seer.autofix.bulk_set_project_preferences")
-    def test_project_with_valid_stopping_point_gets_handoff_from_org_defaults(
-        self, mock_bulk_set: MagicMock
-    ) -> None:
+    def test_project_with_valid_stopping_point_gets_handoff_from_org_defaults(self) -> None:
         """Project with valid stopping point but no handoff gets org default handoff applied.
         Existing stopping point is preserved, and auto_open_prs does not override it for external agents."""
         project = self.create_project(organization=self.organization)
@@ -240,21 +233,17 @@ class TestConfigureSeerForExistingOrg(SentryTestCase):
 
         configure_seer_for_existing_org(organization_id=self.organization.id)
 
-        mock_bulk_set.assert_called_once()
-        prefs = mock_bulk_set.call_args[0][1]
-        prefs_by_project = {p["project_id"]: p for p in prefs}
-        assert prefs_by_project[project.id]["automated_run_stopping_point"] == "open_pr"
-        assert prefs_by_project[project.id]["automation_handoff"] == {
-            "handoff_point": "root_cause",
-            "target": "cursor_background_agent",
-            "integration_id": 42,
-            "auto_create_pr": True,
-        }
+        # Stopping point preserved.
+        assert project.get_option("sentry:seer_automated_run_stopping_point") == "open_pr"
+        # New handoff from org defaults.
+        assert project.get_option("sentry:seer_automation_handoff_point") == "root_cause"
+        assert (
+            project.get_option("sentry:seer_automation_handoff_target") == "cursor_background_agent"
+        )
+        assert project.get_option("sentry:seer_automation_handoff_integration_id") == 42
+        assert project.get_option("sentry:seer_automation_handoff_auto_create_pr") is True
 
-    @patch("sentry.tasks.seer.autofix.bulk_set_project_preferences")
-    def test_project_with_invalid_stopping_point_gets_org_default_stopping_point(
-        self, mock_bulk_set: MagicMock
-    ) -> None:
+    def test_project_with_invalid_stopping_point_gets_org_default_stopping_point(self) -> None:
         """Project with unrecognized stopping point gets org default stopping point applied.
         Existing handoff (if any) is preserved."""
         project = self.create_project(organization=self.organization)
@@ -262,6 +251,7 @@ class TestConfigureSeerForExistingOrg(SentryTestCase):
             "sentry:seer_default_coding_agent", "cursor_background_agent"
         )
         self.organization.update_option("sentry:seer_default_coding_agent_integration_id", 42)
+        self.organization.update_option("sentry:default_automated_run_stopping_point", "open_pr")
 
         # "root_cause" is not in the valid set without the root-cause-stopping-point flag.
         project.update_option("sentry:seer_automated_run_stopping_point", "root_cause")
@@ -272,22 +262,13 @@ class TestConfigureSeerForExistingOrg(SentryTestCase):
 
         configure_seer_for_existing_org(organization_id=self.organization.id)
 
-        mock_bulk_set.assert_called_once()
-        prefs = mock_bulk_set.call_args[0][1]
-        prefs_by_project = {p["project_id"]: p for p in prefs}
-        assert (
-            prefs_by_project[project.id]["automated_run_stopping_point"]
-            == SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT
-        )
-        assert prefs_by_project[project.id]["automation_handoff"] == {
-            "handoff_point": "root_cause",
-            "target": "claude_code_agent",
-            "integration_id": 99,
-            "auto_create_pr": False,
-        }
+        # Stopping point changed to org default.
+        assert project.get_option("sentry:seer_automated_run_stopping_point") == "open_pr"
+        # Existing handoff preserved.
+        assert project.get_option("sentry:seer_automation_handoff_target") == "claude_code_agent"
+        assert project.get_option("sentry:seer_automation_handoff_integration_id") == 99
 
-    @patch("sentry.tasks.seer.autofix.bulk_set_project_preferences")
-    def test_root_cause_stopping_point_preserved_when_valid(self, mock_bulk_set: MagicMock) -> None:
+    def test_root_cause_stopping_point_preserved_when_valid(self) -> None:
         """Project with root_cause stopping point is preserved when root-cause-stopping-point flag is enabled."""
         project = self.create_project(organization=self.organization)
         project.update_option("sentry:seer_automated_run_stopping_point", "root_cause")
@@ -295,28 +276,9 @@ class TestConfigureSeerForExistingOrg(SentryTestCase):
         with self.feature("organizations:root-cause-stopping-point"):
             configure_seer_for_existing_org(organization_id=self.organization.id)
 
-        mock_bulk_set.assert_not_called()
+        assert project.get_option("sentry:seer_automated_run_stopping_point") == "root_cause"
 
-    @patch("sentry.tasks.seer.autofix.bulk_set_project_preferences")
-    def test_raises_on_bulk_set_api_failure(self, mock_bulk_set: MagicMock) -> None:
-        """Test that task raises on bulk SET API failure to trigger retry."""
-        project1 = self.create_project(organization=self.organization)
-        project2 = self.create_project(organization=self.organization)
-        # Force projects to take the update path so bulk_set is invoked.
-        project1.update_option("sentry:seer_automated_run_stopping_point", "root_cause")
-        project2.update_option("sentry:seer_automated_run_stopping_point", "root_cause")
-
-        mock_bulk_set.side_effect = SeerApiError("API error", 500)
-
-        with pytest.raises(SeerApiError):
-            configure_seer_for_existing_org(organization_id=self.organization.id)
-
-        # Sentry DB options should still be set before the API call
-        assert project1.get_option("sentry:seer_scanner_automation") is True
-        assert project2.get_option("sentry:seer_scanner_automation") is True
-
-    @patch("sentry.tasks.seer.autofix.bulk_set_project_preferences")
-    def test_sets_seat_based_tier_cache_to_true(self, mock_bulk_set: MagicMock) -> None:
+    def test_sets_seat_based_tier_cache_to_true(self) -> None:
         """Test that the seat-based tier cache is set to True after configuring org."""
         self.create_project(organization=self.organization)
 
@@ -330,8 +292,7 @@ class TestConfigureSeerForExistingOrg(SentryTestCase):
         # Cache should be set to True to prevent race conditions
         assert cache.get(cache_key) is True
 
-    @patch("sentry.tasks.seer.autofix.bulk_set_project_preferences")
-    def test_preserves_existing_repositories(self, mock_bulk_set: MagicMock) -> None:
+    def test_preserves_existing_repositories(self) -> None:
         """Test that existing repositories are preserved when preferences are set."""
         project = self.create_project(organization=self.organization)
         repo = self.create_repo(
@@ -346,40 +307,6 @@ class TestConfigureSeerForExistingOrg(SentryTestCase):
 
         configure_seer_for_existing_org(organization_id=self.organization.id)
 
-        preferences = mock_bulk_set.call_args[0][1]
-        assert len(preferences) == 1
-        repos = preferences[0]["repositories"]
-        assert len(repos) == 1
-        assert repos[0]["owner"] == "existing-org"
-        assert repos[0]["name"] == "existing-repo"
-        assert repos[0]["external_id"] == "ext123"
-
-    @with_feature("organizations:seer-project-settings-dual-write")
-    @patch("sentry.tasks.seer.autofix.bulk_write_preferences_to_sentry_db")
-    @patch("sentry.tasks.seer.autofix.bulk_set_project_preferences")
-    def test_writes_to_sentry_db(
-        self, mock_bulk_set: MagicMock, mock_bulk_write_db: MagicMock
-    ) -> None:
-        """When dual-write flag is enabled, preferences are also written to Sentry DB."""
-        project = self.create_project(organization=self.organization)
-        repo = self.create_repo(
-            project=project,
-            provider="integrations:github",
-            external_id="ext123",
-            name="test-org/test-repo",
-        )
-        SeerProjectRepository.objects.create(project=project, repository=repo)
-        # Force the update path so dual-write happens.
-        project.update_option("sentry:seer_automated_run_stopping_point", "root_cause")
-
-        configure_seer_for_existing_org(organization_id=self.organization.id)
-
-        mock_bulk_write_db.assert_called_once()
-        preferences = mock_bulk_write_db.call_args[0][1]
-        assert len(preferences) == 1
-        assert preferences[0].project_id == project.id
-        assert (
-            preferences[0].automated_run_stopping_point == SEER_AUTOMATED_RUN_STOPPING_POINT_DEFAULT
-        )
-        assert preferences[0].repositories[0].owner == "test-org"
-        assert preferences[0].repositories[0].name == "test-repo"
+        seer_repos = list(SeerProjectRepository.objects.filter(project=project))
+        assert len(seer_repos) == 1
+        assert seer_repos[0].repository_id == repo.id


### PR DESCRIPTION
relates to AIML-2614

The Seer settings migration to Sentry DB is complete. Remove the Seer API write call and dead dual-write feature flag from the remaining internal call sites:
- configure_seer_for_existing_org task (initial onboarding sweep)
- set_default_project_seer_preferences (called on project creation)
- AutofixOnCompletionHook handoff-clear path on IntegrationNotFound
- trigger_coding_agent_launch RPC handoff-clear path

The handoff-clear in on_completion_hook now always runs (not gated on the read returning a non-None handoff) so partial-state handoff options also get cleaned up instead of leaking (there are currently [no partial handoffs in prod](https://redash.getsentry.net/queries/11080/source )). 

Tests are rewritten to assert on resulting DB state.