### PR TITLE
feat(llm-detection): fingerprint by group_for_fingerprint behind option

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -52,6 +52,9 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:alerts-timeseries-comparison", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable AI-based issue detection for an organization
     manager.add("organizations:ai-issue-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Fingerprint LLM-detected issues by group_for_fingerprint (a stable signature derived from
+    # offender spans) instead of transaction_slug, to fix under-grouping across endpoints.
+    manager.add("organizations:llm-detection-use-group-fingerprint", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable anomaly detection feature for EAP spans
     manager.add("organizations:anomaly-detection-eap", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables the cron job to auto-enable codecov integrations.

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -4005,15 +4005,6 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
-# When True, fingerprint LLM-detected issues by detected_issue.group_for_fingerprint
-# (a stable signature derived from offender spans) instead of transaction_slug.
-register(
-    "issue-detection.llm-detection.use-group-fingerprint",
-    type=Bool,
-    default=False,
-    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
-)
-
 # Controls whether deletion from EAP is enabled.
 register(
     "eventstream.eap.deletion-enabled",

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -4005,6 +4005,15 @@ register(
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# When True, fingerprint LLM-detected issues by detected_issue.group_for_fingerprint
+# (a stable signature derived from offender spans) instead of transaction_slug.
+register(
+    "issue-detection.llm-detection.use-group-fingerprint",
+    type=Bool,
+    default=False,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Controls whether deletion from EAP is enabled.
 register(
     "eventstream.eap.deletion-enabled",

--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -207,9 +207,14 @@ def create_issue_occurrence_from_detection(
     detection_time = datetime.now(UTC)
     trace_id = detected_issue.trace_id
     transaction_name = normalize_description(detected_issue.transaction_name)
-    transaction_slug = transaction_name.strip().lower().replace(" ", "-")
 
-    fingerprint = [f"1-{group_type.type_id}-{transaction_slug}"]
+    if options.get("issue-detection.llm-detection.use-group-fingerprint") and (
+        group_for_fingerprint := detected_issue.group_for_fingerprint.strip()
+    ):
+        fingerprint_key = group_for_fingerprint.lower().replace(" ", "-")
+    else:
+        fingerprint_key = transaction_name.strip().lower().replace(" ", "-")
+    fingerprint = [f"1-{group_type.type_id}-{fingerprint_key}"]
 
     evidence_data = {
         "trace_id": trace_id,

--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -208,7 +208,10 @@ def create_issue_occurrence_from_detection(
     trace_id = detected_issue.trace_id
     transaction_name = normalize_description(detected_issue.transaction_name)
 
-    if options.get("issue-detection.llm-detection.use-group-fingerprint") and (
+    use_group_fingerprint = features.has(
+        "organizations:llm-detection-use-group-fingerprint", project.organization
+    )
+    if use_group_fingerprint and (
         group_for_fingerprint := detected_issue.group_for_fingerprint.strip()
     ):
         fingerprint_key = group_for_fingerprint.lower().replace(" ", "-")

--- a/tests/sentry/tasks/test_llm_issue_detection.py
+++ b/tests/sentry/tasks/test_llm_issue_detection.py
@@ -24,6 +24,7 @@ from sentry.tasks.llm_issue_detection.trace_data import (
 from sentry.testutils.cases import APITransactionTestCase, SnubaTestCase, SpanTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.options import override_options
 
 
 class LLMIssueDetectionTest(TestCase):
@@ -189,6 +190,87 @@ class LLMIssueDetectionTest(TestCase):
         occurrence = mock_produce_occurrence.call_args.kwargs["occurrence"]
         assert occurrence.fingerprint == [f"1-{AIDetectedDBGroupType.type_id}-get-/api"]
         assert occurrence.type == AIDetectedDBGroupType
+
+    @patch("sentry.tasks.llm_issue_detection.detection.produce_occurrence_to_kafka")
+    def test_create_issue_occurrence_fingerprint_uses_group_for_fingerprint_when_option_on(
+        self, mock_produce_occurrence
+    ):
+        detected_issue = DetectedIssue(
+            title="Inefficient Database Queries",
+            explanation="Multiple queries in loop",
+            impact="Medium",
+            evidence="5 queries",
+            offender_span_ids=["span_1"],
+            trace_id="trace456",
+            transaction_name="GET /api",
+            verification_reason="Verified",
+            group_for_fingerprint="Inefficient Database Queries:abc123def4567890",
+        )
+        with override_options({"issue-detection.llm-detection.use-group-fingerprint": True}):
+            create_issue_occurrence_from_detection(
+                detected_issue=detected_issue,
+                project=self.project,
+            )
+        occurrence = mock_produce_occurrence.call_args.kwargs["occurrence"]
+        assert occurrence.fingerprint == [
+            f"1-{AIDetectedDBGroupType.type_id}-inefficient-database-queries:abc123def4567890"
+        ]
+
+    @patch("sentry.tasks.llm_issue_detection.detection.produce_occurrence_to_kafka")
+    def test_same_group_for_fingerprint_groups_across_transactions_when_option_on(
+        self, mock_produce_occurrence
+    ):
+        # Two issues with the same root cause but different transactions must produce the same
+        # fingerprint when the option is on — this is the under-grouping fix.
+        shared = "Inefficient Database Queries:abc123def4567890"
+        for txn in ("GET /api/foo", "GET /api/bar", "POST /api/baz"):
+            detected_issue = DetectedIssue(
+                title="Inefficient Database Queries",
+                explanation="x",
+                impact="y",
+                evidence="z",
+                offender_span_ids=["span_1"],
+                trace_id=f"trace-{txn}",
+                transaction_name=txn,
+                verification_reason="Verified",
+                group_for_fingerprint=shared,
+            )
+            with override_options({"issue-detection.llm-detection.use-group-fingerprint": True}):
+                create_issue_occurrence_from_detection(
+                    detected_issue=detected_issue,
+                    project=self.project,
+                )
+
+        fingerprints = {
+            call.kwargs["occurrence"].fingerprint[0]
+            for call in mock_produce_occurrence.call_args_list
+        }
+        assert len(fingerprints) == 1
+
+    @patch("sentry.tasks.llm_issue_detection.detection.produce_occurrence_to_kafka")
+    def test_falls_back_to_transaction_when_option_on_but_group_for_fingerprint_blank(
+        self, mock_produce_occurrence
+    ):
+        # If group_for_fingerprint is empty (rolling deploy: old seer talking to new sentry),
+        # fall back to transaction-based fingerprint instead of producing "1-{type_id}-".
+        detected_issue = DetectedIssue(
+            title="Inefficient Database Queries",
+            explanation="x",
+            impact="y",
+            evidence="z",
+            offender_span_ids=[],
+            trace_id="trace1",
+            transaction_name="GET /api",
+            verification_reason="Verified",
+            group_for_fingerprint="   ",
+        )
+        with override_options({"issue-detection.llm-detection.use-group-fingerprint": True}):
+            create_issue_occurrence_from_detection(
+                detected_issue=detected_issue,
+                project=self.project,
+            )
+        occurrence = mock_produce_occurrence.call_args.kwargs["occurrence"]
+        assert occurrence.fingerprint == [f"1-{AIDetectedDBGroupType.type_id}-get-/api"]
 
     @patch("sentry.tasks.llm_issue_detection.detection.produce_occurrence_to_kafka")
     def test_other_title_uses_fallback_display_title(self, mock_produce_occurrence):

--- a/tests/sentry/tasks/test_llm_issue_detection.py
+++ b/tests/sentry/tasks/test_llm_issue_detection.py
@@ -24,7 +24,6 @@ from sentry.tasks.llm_issue_detection.trace_data import (
 from sentry.testutils.cases import APITransactionTestCase, SnubaTestCase, SpanTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.helpers.features import with_feature
-from sentry.testutils.helpers.options import override_options
 
 
 class LLMIssueDetectionTest(TestCase):
@@ -191,8 +190,9 @@ class LLMIssueDetectionTest(TestCase):
         assert occurrence.fingerprint == [f"1-{AIDetectedDBGroupType.type_id}-get-/api"]
         assert occurrence.type == AIDetectedDBGroupType
 
+    @with_feature("organizations:llm-detection-use-group-fingerprint")
     @patch("sentry.tasks.llm_issue_detection.detection.produce_occurrence_to_kafka")
-    def test_create_issue_occurrence_fingerprint_uses_group_for_fingerprint_when_option_on(
+    def test_create_issue_occurrence_fingerprint_uses_group_for_fingerprint_when_flag_on(
         self, mock_produce_occurrence
     ):
         detected_issue = DetectedIssue(
@@ -206,22 +206,22 @@ class LLMIssueDetectionTest(TestCase):
             verification_reason="Verified",
             group_for_fingerprint="Inefficient Database Queries:abc123def4567890",
         )
-        with override_options({"issue-detection.llm-detection.use-group-fingerprint": True}):
-            create_issue_occurrence_from_detection(
-                detected_issue=detected_issue,
-                project=self.project,
-            )
+        create_issue_occurrence_from_detection(
+            detected_issue=detected_issue,
+            project=self.project,
+        )
         occurrence = mock_produce_occurrence.call_args.kwargs["occurrence"]
         assert occurrence.fingerprint == [
             f"1-{AIDetectedDBGroupType.type_id}-inefficient-database-queries:abc123def4567890"
         ]
 
+    @with_feature("organizations:llm-detection-use-group-fingerprint")
     @patch("sentry.tasks.llm_issue_detection.detection.produce_occurrence_to_kafka")
-    def test_same_group_for_fingerprint_groups_across_transactions_when_option_on(
+    def test_same_group_for_fingerprint_groups_across_transactions_when_flag_on(
         self, mock_produce_occurrence
     ):
         # Two issues with the same root cause but different transactions must produce the same
-        # fingerprint when the option is on — this is the under-grouping fix.
+        # fingerprint when the flag is on — this is the under-grouping fix.
         shared = "Inefficient Database Queries:abc123def4567890"
         for txn in ("GET /api/foo", "GET /api/bar", "POST /api/baz"):
             detected_issue = DetectedIssue(
@@ -235,11 +235,10 @@ class LLMIssueDetectionTest(TestCase):
                 verification_reason="Verified",
                 group_for_fingerprint=shared,
             )
-            with override_options({"issue-detection.llm-detection.use-group-fingerprint": True}):
-                create_issue_occurrence_from_detection(
-                    detected_issue=detected_issue,
-                    project=self.project,
-                )
+            create_issue_occurrence_from_detection(
+                detected_issue=detected_issue,
+                project=self.project,
+            )
 
         fingerprints = {
             call.kwargs["occurrence"].fingerprint[0]
@@ -247,8 +246,9 @@ class LLMIssueDetectionTest(TestCase):
         }
         assert len(fingerprints) == 1
 
+    @with_feature("organizations:llm-detection-use-group-fingerprint")
     @patch("sentry.tasks.llm_issue_detection.detection.produce_occurrence_to_kafka")
-    def test_falls_back_to_transaction_when_option_on_but_group_for_fingerprint_blank(
+    def test_falls_back_to_transaction_when_flag_on_but_group_for_fingerprint_blank(
         self, mock_produce_occurrence
     ):
         # If group_for_fingerprint is empty (rolling deploy: old seer talking to new sentry),
@@ -264,11 +264,10 @@ class LLMIssueDetectionTest(TestCase):
             verification_reason="Verified",
             group_for_fingerprint="   ",
         )
-        with override_options({"issue-detection.llm-detection.use-group-fingerprint": True}):
-            create_issue_occurrence_from_detection(
-                detected_issue=detected_issue,
-                project=self.project,
-            )
+        create_issue_occurrence_from_detection(
+            detected_issue=detected_issue,
+            project=self.project,
+        )
         occurrence = mock_produce_occurrence.call_args.kwargs["occurrence"]
         assert occurrence.fingerprint == [f"1-{AIDetectedDBGroupType.type_id}-get-/api"]
 


### PR DESCRIPTION
## Why

Today the LLM-detected-issue fingerprint keys on the transaction slug, so the same root cause produces a different group on every endpoint that exercises it. Screenshot context: three separate \`Blocking Operation\` issues that are all the same \`ratelimit.__call__\` → slow \`http.client\` problem firing on different routes.

## What

Read \`detected_issue.group_for_fingerprint\` when building the \`IssueOccurrence\` fingerprint, instead of \`transaction_slug\`. Seer now populates that field with a stable signature derived from the offender spans (seer PRs getsentry/seer#6037 and getsentry/seer#6048).

Behind a new sentry-option \`issue-detection.llm-detection.use-group-fingerprint\` (default off) so we can flip on per-org via options-automator and observe before global rollout.

Falls back to the existing transaction-slug fingerprint if \`group_for_fingerprint\` is empty/whitespace — important during the rolling deploy window where seer hasn't yet populated the field.

## Tests

- \`test_create_issue_occurrence_fingerprint_uses_group_for_fingerprint_when_option_on\` — option-on path produces the new format.
- \`test_same_group_for_fingerprint_groups_across_transactions_when_option_on\` — three issues with different transactions but the same \`group_for_fingerprint\` produce a single fingerprint. This is the bug this PR fixes.
- \`test_falls_back_to_transaction_when_option_on_but_group_for_fingerprint_blank\` — guards the rolling-deploy fallback.
- Existing \`test_create_issue_occurrence_fingerprint_uses_transaction_name\` still passes — option-off path is unchanged.

## Rollout

1. Merge this PR. No production behavior change (option default off).
2. Confirm seer PRs #6037 + #6048 are deployed.
3. Flip option for a test org via options-automator. Observe for ~24h.
4. Roll out broadly.

## Status

**Draft.** Pairs with the seer PRs above. Not user-visible until the option is flipped.