### PR TITLE
chore(experiments): Add flag to feature flag checking functions to allow us to skip exposing the experiment, and stop exposing experiments when we return all feature flags from the ui

### DIFF
--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -400,8 +400,12 @@ class OrganizationSummarySerializer(Serializer):
         feature_set = set()
 
         with sentry_sdk.start_span(op="features.check", name="check batch features"):
-            # Check features in batch using the entity handler
-            batch_features = features.batch_has(org_features, actor=user, organization=obj)
+            # Evaluate flags purely to populate the response — the user has not
+            # actually encountered any experiments yet, so suppress the auto
+            # exposure events the entity handler would otherwise log.
+            batch_features = features.batch_has(
+                org_features, actor=user, organization=obj, skip_experiment_exposure=True
+            )
 
             # batch_has has found some features
             if batch_features:

--- a/src/sentry/features/handler.py
+++ b/src/sentry/features/handler.py
@@ -44,6 +44,7 @@ class FeatureHandler:
         feature: Feature,
         actor: User | RpcUser | AnonymousUser | None,
         skip_entity: bool | None = False,
+        skip_experiment_exposure: bool = False,
     ) -> bool | None:
         raise NotImplementedError
 
@@ -62,6 +63,7 @@ class FeatureHandler:
         projects: Sequence[Project] | None = None,
         organization: Organization | RpcOrganization | None = None,
         batch: bool = True,
+        skip_experiment_exposure: bool = False,
     ) -> dict[str, dict[str, bool | None]] | None:
         raise NotImplementedError
 
@@ -108,6 +110,7 @@ class BatchFeatureHandler(FeatureHandler):
         feature: Feature,
         actor: User | RpcUser | AnonymousUser | None,
         skip_entity: bool | None = False,
+        skip_experiment_exposure: bool = False,
     ) -> bool | None:
         return self._check_for_batch(feature.name, feature.get_subject(), actor)
 

--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -234,7 +234,14 @@ class FeatureManager(RegisteredFeatureManager):
         """
         self._entity_handler = handler
 
-    def has(self, name: str, *args: Any, skip_entity: bool | None = False, **kwargs: Any) -> bool:
+    def has(
+        self,
+        name: str,
+        *args: Any,
+        skip_entity: bool | None = False,
+        skip_experiment_exposure: bool = False,
+        **kwargs: Any,
+    ) -> bool:
         """
         Determine if a feature is enabled. If a handler returns None, then the next
         mechanism is used for feature checking.
@@ -262,6 +269,9 @@ class FeatureManager(RegisteredFeatureManager):
         Depending on the Feature class, additional arguments may need to be
         provided to assign organization or project context to the feature.
 
+        Pass ``skip_experiment_exposure=True`` to suppress automatic experiment
+        exposure logging when evaluating the flag.
+
         >>> FeatureManager.has('organizations:feature', organization, actor=request.user)
 
         """
@@ -283,7 +293,9 @@ class FeatureManager(RegisteredFeatureManager):
                     return rv
 
                 if self._entity_handler and not skip_entity:
-                    rv = self._entity_handler.has(feature, actor)
+                    rv = self._entity_handler.has(
+                        feature, actor, skip_experiment_exposure=skip_experiment_exposure
+                    )
                     if rv is not None:
                         metrics.incr(
                             "feature.has.result",
@@ -323,6 +335,7 @@ class FeatureManager(RegisteredFeatureManager):
         actor: User | RpcUser | AnonymousUser | None = None,
         projects: Sequence[Project] | None = None,
         organization: RpcOrganization | Organization | None = None,
+        skip_experiment_exposure: bool = False,
     ) -> dict[str, dict[str, bool | None]] | None:
         """
         Determine if multiple features are enabled. Unhandled flags will not be in
@@ -330,12 +343,20 @@ class FeatureManager(RegisteredFeatureManager):
 
         Will only accept one type of feature, either all ProjectFeatures or all
         OrganizationFeatures.
+
+        Pass ``skip_experiment_exposure=True`` to suppress automatic experiment
+        exposure logging when evaluating the flags (e.g. when populating an API
+        response — the user has not actually encountered the experiment yet).
         """
         try:
             if self._entity_handler:
                 with metrics.timer("features.entity_batch_has", sample_rate=0.01):
                     return self._entity_handler.batch_has(
-                        feature_names, actor, projects=projects, organization=organization
+                        feature_names,
+                        actor,
+                        projects=projects,
+                        organization=organization,
+                        skip_experiment_exposure=skip_experiment_exposure,
                     )
             else:
                 # Fall back to default handler if no entity handler available.

--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -367,7 +367,10 @@ class FeatureManager(RegisteredFeatureManager):
                         proj_results = results[f"project:{project.id}"] = {}
                         for feature_name in project_features:
                             proj_results[feature_name] = self.has(
-                                feature_name, project, actor=actor
+                                feature_name,
+                                project,
+                                actor=actor,
+                                skip_experiment_exposure=skip_experiment_exposure,
                             )
                     return results
 
@@ -376,7 +379,10 @@ class FeatureManager(RegisteredFeatureManager):
                     org_results: dict[str, bool | None] = {}
                     for feature_name in org_features:
                         org_results[feature_name] = self.has(
-                            feature_name, organization, actor=actor
+                            feature_name,
+                            organization,
+                            actor=actor,
+                            skip_experiment_exposure=skip_experiment_exposure,
                         )
                     return {f"organization:{organization.id}": org_results}
 
@@ -388,7 +394,11 @@ class FeatureManager(RegisteredFeatureManager):
                 if unscoped_features:
                     unscoped_results: dict[str, bool | None] = {}
                     for feature_name in unscoped_features:
-                        unscoped_results[feature_name] = self.has(feature_name, actor=actor)
+                        unscoped_results[feature_name] = self.has(
+                            feature_name,
+                            actor=actor,
+                            skip_experiment_exposure=skip_experiment_exposure,
+                        )
                     return {"unscoped": unscoped_results}
                 return None
         except Exception as e:

--- a/tests/sentry/api/serializers/test_project.py
+++ b/tests/sentry/api/serializers/test_project.py
@@ -232,7 +232,13 @@ class ProjectSerializerTest(TestCase):
             class ProjectColorFeatureHandler(features.FeatureHandler):
                 features = {color_flag}
 
-                def has(self, feature, actor, skip_entity: bool | None = False):
+                def has(
+                    self,
+                    feature,
+                    actor,
+                    skip_entity: bool | None = False,
+                    skip_experiment_exposure: bool = False,
+                ):
                     return feature.project in included_projects
 
                 def batch_has(self, *a, **k):

--- a/tests/sentry/features/test_manager.py
+++ b/tests/sentry/features/test_manager.py
@@ -27,6 +27,7 @@ class MockBatchHandler(features.BatchFeatureHandler):
         feature: Feature,
         actor: User | RpcUser | AnonymousUser | None,
         skip_entity: bool | None = False,
+        skip_experiment_exposure: bool = False,
     ) -> bool:
         return True
 
@@ -124,7 +125,13 @@ class FeatureManagerTest(TestCase):
                 self.true_set = frozenset(true_set)
                 self.false_set = frozenset(false_set)
 
-            def has(self, feature, actor, skip_entity: bool | None = False):
+            def has(
+                self,
+                feature,
+                actor,
+                skip_entity: bool | None = False,
+                skip_experiment_exposure: bool = False,
+            ):
                 assert actor == test_user
 
                 if feature.project in self.true_set:
@@ -376,7 +383,13 @@ class FeatureManagerTest(TestCase):
         class NoBatchOrgHandler(features.BatchFeatureHandler):
             features = {"organizations:feature"}
 
-            def has(self, feature, actor, skip_entity: bool | None = False):
+            def has(
+                self,
+                feature,
+                actor,
+                skip_entity: bool | None = False,
+                skip_experiment_exposure: bool = False,
+            ):
                 return feature.name in self.features
 
             def batch_has(
@@ -483,3 +496,59 @@ class FeatureManagerTest(TestCase):
             result = manager.get_experiment_assignments(test_org)
 
         assert result == {}
+
+    def test_has_passes_skip_experiment_exposure_to_entity_handler(self) -> None:
+        test_org = self.create_organization()
+
+        handler = mock.Mock(spec=features.FeatureHandler)
+        handler.has.return_value = True
+
+        manager = features.FeatureManager()
+        manager.add("organizations:feature", OrganizationFeature)
+        manager.add_entity_handler(handler)
+
+        manager.has("organizations:feature", test_org, skip_experiment_exposure=True)
+        handler.has.assert_called_once()
+        assert handler.has.call_args.kwargs == {"skip_experiment_exposure": True}
+
+    def test_has_default_does_not_skip_experiment_exposure(self) -> None:
+        test_org = self.create_organization()
+
+        handler = mock.Mock(spec=features.FeatureHandler)
+        handler.has.return_value = True
+
+        manager = features.FeatureManager()
+        manager.add("organizations:feature", OrganizationFeature)
+        manager.add_entity_handler(handler)
+
+        manager.has("organizations:feature", test_org)
+        handler.has.assert_called_once()
+        assert handler.has.call_args.kwargs == {"skip_experiment_exposure": False}
+
+    def test_batch_has_passes_skip_experiment_exposure_to_entity_handler(self) -> None:
+        test_org = self.create_organization()
+
+        handler = mock.Mock(spec=features.FeatureHandler)
+        handler.batch_has.return_value = {}
+
+        manager = features.FeatureManager()
+        manager.add_entity_handler(handler)
+
+        manager.batch_has(
+            ["organizations:feature"], organization=test_org, skip_experiment_exposure=True
+        )
+        handler.batch_has.assert_called_once()
+        assert handler.batch_has.call_args.kwargs["skip_experiment_exposure"] is True
+
+    def test_batch_has_default_does_not_skip_experiment_exposure(self) -> None:
+        test_org = self.create_organization()
+
+        handler = mock.Mock(spec=features.FeatureHandler)
+        handler.batch_has.return_value = {}
+
+        manager = features.FeatureManager()
+        manager.add_entity_handler(handler)
+
+        manager.batch_has(["organizations:feature"], organization=test_org)
+        handler.batch_has.assert_called_once()
+        assert handler.batch_has.call_args.kwargs["skip_experiment_exposure"] is False


### PR DESCRIPTION
This allows us to pass a value to our feature flag checkers to skip experiment exposure. We need to do this so that we no longer expose experiments when we just return them from the api, since at that point we don't know whether the user has actually seen the experiment or not.

Follow up to https://github.com/getsentry/getsentry/pull/20136, has to merge after it merges.

<!-- Describe your PR here. -->