### PR TITLE
fix(notifications): Don't use None when a dict is expected

### DIFF
--- a/src/sentry/notifications/notifications/digest.py
+++ b/src/sentry/notifications/notifications/digest.py
@@ -169,7 +169,7 @@ class DigestNotification(ProjectNotification):
             context["snooze_alert_urls"] = snooze_alert_urls
         else:
             context["snooze_alert"] = False
-            context["snooze_alert_urls"] = None
+            context["snooze_alert_urls"] = {}
 
         return context
 

--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -177,6 +177,11 @@ class DigestNotificationTest(TestCase, OccurrenceTestMixin, PerformanceIssueTest
         assert isinstance(message.alternatives[0][0], str)
         assert "notification_uuid" in message.alternatives[0][0]
 
+    def test_sends_digest_with_workflow_engine_ui(self) -> None:
+        with self.feature("organizations:workflow-engine-ui"):
+            self.run_test(event_count=2)
+        assert "new alerts since" in mail.outbox[0].subject
+
     def test_digest_email_uses_user_timezone(self) -> None:
         self.organization.member_set.exclude(user_id=self.user.id).delete()
 


### PR DESCRIPTION
The variable we bind the dict mapping to is unused with workflow-ui enabled, but we still do the lookup, so it should be a real dict.

Fixes ISWF-2560.