### PR TITLE
fix(dashboards): Remove checks needed for old pre-built dashboard handling

### DIFF
--- a/static/app/views/dashboards/controls.tsx
+++ b/static/app/views/dashboards/controls.tsx
@@ -35,13 +35,12 @@ import {checkUserHasEditAccess} from './utils/checkUserHasEditAccess';
 import {DashboardRevisionsButton} from './dashboardRevisions';
 import {UNSAVED_FILTERS_MESSAGE} from './detail';
 import {exportDashboard} from './exportDashboard';
-import type {DashboardDetails, DashboardListItem, DashboardPermissions} from './types';
+import type {DashboardDetails, DashboardPermissions} from './types';
 import {DashboardState, MAX_WIDGETS, PREBUILT_DASHBOARD_LABEL} from './types';
 
 type Props = {
   dashboard: DashboardDetails;
   dashboardState: DashboardState;
-  dashboards: DashboardListItem[];
   onAddWidget: (dataset: DataSet, openWidgetTemplates: boolean) => void;
   onCancel: () => void;
   onCommit: () => void;
@@ -58,7 +57,6 @@ type Props = {
 export function Controls({
   dashboardState,
   dashboard,
-  dashboards,
   hasUnsavedFilters,
   hideAddWidget = false,
   widgetLimitReached,
@@ -114,7 +112,6 @@ export function Controls({
           priority="danger"
           message={t('Are you sure you want to delete this dashboard?')}
           onConfirm={onDelete}
-          disabled={dashboards.length <= 1}
         >
           <Button size="sm" data-test-id="dashboard-delete" priority="danger">
             {t('Delete')}

--- a/static/app/views/dashboards/controls.tsx
+++ b/static/app/views/dashboards/controls.tsx
@@ -270,42 +270,40 @@ export function Controls({
       <DashboardEditFeature>
         {hasFeature => (
           <Fragment>
-            {dashboard.id !== 'default-overview' && (
-              <Tooltip title={isFavorited ? t('Starred Dashboard') : t('Star Dashboard')}>
-                <Button
-                  size="sm"
-                  aria-label={t('star-dashboard')}
-                  icon={
-                    <IconStar
-                      variant={isFavorited ? 'warning' : 'muted'}
-                      isSolid={isFavorited}
-                      aria-label={isFavorited ? t('Unstar') : t('Star')}
-                      data-test-id={isFavorited ? 'yellow-star' : 'empty-star'}
-                    />
+            <Tooltip title={isFavorited ? t('Starred Dashboard') : t('Star Dashboard')}>
+              <Button
+                size="sm"
+                aria-label={t('star-dashboard')}
+                icon={
+                  <IconStar
+                    variant={isFavorited ? 'warning' : 'muted'}
+                    isSolid={isFavorited}
+                    aria-label={isFavorited ? t('Unstar') : t('Star')}
+                    data-test-id={isFavorited ? 'yellow-star' : 'empty-star'}
+                  />
+                }
+                onClick={async () => {
+                  try {
+                    setIsFavorited(!isFavorited);
+                    await updateDashboardFavorite(
+                      api,
+                      queryClient,
+                      organization,
+                      dashboard.id,
+                      !isFavorited
+                    );
+                    trackAnalytics('dashboards_manage.toggle_favorite', {
+                      organization,
+                      dashboard_id: dashboard.id,
+                      favorited: !isFavorited,
+                    });
+                  } catch (error) {
+                    // If the api call fails, revert the state
+                    setIsFavorited(isFavorited);
                   }
-                  onClick={async () => {
-                    try {
-                      setIsFavorited(!isFavorited);
-                      await updateDashboardFavorite(
-                        api,
-                        queryClient,
-                        organization,
-                        dashboard.id,
-                        !isFavorited
-                      );
-                      trackAnalytics('dashboards_manage.toggle_favorite', {
-                        organization,
-                        dashboard_id: dashboard.id,
-                        favorited: !isFavorited,
-                      });
-                    } catch (error) {
-                      // If the api call fails, revert the state
-                      setIsFavorited(isFavorited);
-                    }
-                  }}
-                />
-              </Tooltip>
-            )}
+                }}
+              />
+            </Tooltip>
             <Feature features="dashboards-import">
               <Tooltip title={t('Export Dashboard')}>
                 <Button
@@ -363,7 +361,7 @@ export function Controls({
                   size="sm"
                 />
               ))}
-            {dashboard.id !== 'default-overview' && !isPrebuiltDashboard && (
+            {!isPrebuiltDashboard && (
               <EditAccessSelector
                 dashboard={dashboard}
                 onChangeEditAccess={onChangeEditAccess}

--- a/static/app/views/dashboards/create.tsx
+++ b/static/app/views/dashboards/create.tsx
@@ -46,11 +46,7 @@ export default function CreateDashboard() {
       renderDisabled={renderDisabled}
     >
       <ErrorBoundary>
-        <DashboardDetail
-          initialState={DashboardState.CREATE}
-          dashboard={dashboard}
-          dashboards={[]}
-        />
+        <DashboardDetail initialState={DashboardState.CREATE} dashboard={dashboard} />
       </ErrorBoundary>
     </Feature>
   );

--- a/static/app/views/dashboards/createFromSeer.tsx
+++ b/static/app/views/dashboards/createFromSeer.tsx
@@ -21,8 +21,6 @@ import type {DashboardDetails, Widget} from './types';
 import {DashboardState} from './types';
 import {useSeerDashboardSession} from './useSeerDashboardSession';
 
-const EMPTY_DASHBOARDS: never[] = [];
-
 export default function CreateFromSeer() {
   const organization = useOrganization();
   const location = useLocation();
@@ -174,7 +172,6 @@ export default function CreateFromSeer() {
         <MemoizedDashboardDetail
           initialState={DashboardState.PREVIEW}
           dashboard={dashboard}
-          dashboards={EMPTY_DASHBOARDS} // This prop is unused for the create from seer flow
         />
         <DashboardChatPanel
           blocks={session?.blocks ?? []}

--- a/static/app/views/dashboards/dashboardRevisions.spec.tsx
+++ b/static/app/views/dashboards/dashboardRevisions.spec.tsx
@@ -90,13 +90,6 @@ describe('DashboardRevisionsButton', () => {
     expect(screen.getByRole('button', {name: 'Dashboard Revisions'})).toBeInTheDocument();
   });
 
-  it('renders nothing for the default-overview dashboard', () => {
-    renderButton({id: 'default-overview'});
-    expect(
-      screen.queryByRole('button', {name: 'Dashboard Revisions'})
-    ).not.toBeInTheDocument();
-  });
-
   it('renders nothing for a prebuilt dashboard', () => {
     renderButton({prebuiltId: 'default-overview'});
     expect(

--- a/static/app/views/dashboards/dashboardRevisions.tsx
+++ b/static/app/views/dashboards/dashboardRevisions.tsx
@@ -33,11 +33,7 @@ interface DashboardRevisionsButtonProps {
 }
 
 export function DashboardRevisionsButton({dashboard}: DashboardRevisionsButtonProps) {
-  if (
-    !dashboard.id ||
-    dashboard.id === 'default-overview' ||
-    defined(dashboard.prebuiltId)
-  ) {
+  if (!dashboard.id || defined(dashboard.prebuiltId)) {
     return null;
   }
 

--- a/static/app/views/dashboards/detail.spec.tsx
+++ b/static/app/views/dashboards/detail.spec.tsx
@@ -597,7 +597,6 @@ describe('Dashboards > Detail', () => {
           <DashboardDetail
             initialState={DashboardState.VIEW}
             dashboard={DashboardFixture([], {id: '1', title: 'Custom Errors'})}
-            dashboards={[]}
             onDashboardUpdate={jest.fn()}
           />
         </TopBar.Slot.Provider>,
@@ -1861,7 +1860,6 @@ describe('Dashboards > Detail', () => {
           dashboard={DashboardFixture([], {
             prebuiltId: PrebuiltDashboardId.FRONTEND_SESSION_HEALTH,
           })}
-          dashboards={[]}
           onDashboardUpdate={jest.fn()}
         />
       );
@@ -1907,7 +1905,6 @@ describe('Dashboards > Detail', () => {
           <DashboardDetail
             initialState={DashboardState.VIEW}
             dashboard={DashboardFixture([])}
-            dashboards={[]}
             onDashboardUpdate={jest.fn()}
           />,
           {
@@ -1926,7 +1923,6 @@ describe('Dashboards > Detail', () => {
           <DashboardDetail
             initialState={DashboardState.VIEW}
             dashboard={DashboardFixture([])}
-            dashboards={[]}
             onDashboardUpdate={jest.fn()}
           />,
           {
@@ -1945,7 +1941,6 @@ describe('Dashboards > Detail', () => {
           <DashboardDetail
             initialState={DashboardState.EDIT}
             dashboard={DashboardFixture([])}
-            dashboards={[]}
             onDashboardUpdate={jest.fn()}
           />,
           {
@@ -1964,7 +1959,6 @@ describe('Dashboards > Detail', () => {
           <DashboardDetail
             initialState={DashboardState.EDIT}
             dashboard={DashboardFixture([])}
-            dashboards={[]}
             onDashboardUpdate={jest.fn()}
           />,
           {
@@ -1994,7 +1988,6 @@ describe('Dashboards > Detail', () => {
           <DashboardDetail
             initialState={DashboardState.EDIT}
             dashboard={mockDashboard}
-            dashboards={[]}
             onDashboardUpdate={jest.fn()}
           />,
           {
@@ -2042,7 +2035,6 @@ describe('Dashboards > Detail', () => {
           <DashboardDetail
             initialState={DashboardState.EDIT}
             dashboard={mockDashboard}
-            dashboards={[]}
             onDashboardUpdate={jest.fn()}
           />,
           {
@@ -2096,7 +2088,6 @@ describe('Dashboards > Detail', () => {
           <DashboardDetail
             initialState={DashboardState.VIEW}
             dashboard={mockDashboard}
-            dashboards={[]}
             onDashboardUpdate={jest.fn()}
           />,
           {
@@ -2154,7 +2145,6 @@ describe('Dashboards > Detail', () => {
           <DashboardDetail
             initialState={DashboardState.VIEW}
             dashboard={mockDashboard}
-            dashboards={[]}
             onDashboardUpdate={jest.fn()}
           />,
           {

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -101,7 +101,6 @@ import {DashboardTitle} from './title';
 import type {
   DashboardDetails,
   DashboardFilters,
-  DashboardListItem,
   DashboardPermissions,
   Widget,
 } from './types';
@@ -136,7 +135,6 @@ type RouteParams = {
 type Props = {
   api: Client;
   dashboard: DashboardDetails;
-  dashboards: DashboardListItem[];
   initialState: DashboardState;
   location: Location;
   navigate: ReactRouter3Navigate;

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -1175,7 +1175,6 @@ class DashboardDetail extends Component<Props, State> {
     } = this.state;
 
     const hasUnsavedFilters =
-      dashboard.id !== 'default-overview' &&
       dashboardState !== DashboardState.CREATE &&
       hasUnsavedFilterChanges(dashboard, location);
 

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -1047,7 +1047,7 @@ class DashboardDetail extends Component<Props, State> {
   };
 
   renderDefaultDashboardDetail() {
-    const {pageAlerts, organization, dashboard, dashboards, location} = this.props;
+    const {pageAlerts, organization, dashboard, location} = this.props;
     const {modifiedDashboard, dashboardState, widgetLimitReached} = this.state;
     return (
       <PageFiltersContainer
@@ -1075,7 +1075,6 @@ class DashboardDetail extends Component<Props, State> {
                   </Layout.Title>
                   <Controls
                     organization={organization}
-                    dashboards={dashboards}
                     dashboard={dashboard}
                     onEdit={this.onEdit}
                     onCancel={this.onCancel}
@@ -1161,7 +1160,6 @@ class DashboardDetail extends Component<Props, State> {
       api,
       organization,
       dashboard,
-      dashboards,
       location,
       onDashboardUpdate,
       pageAlerts,
@@ -1236,7 +1234,6 @@ class DashboardDetail extends Component<Props, State> {
                     <TopBar.Slot name="actions">
                       <Controls
                         organization={organization}
-                        dashboards={dashboards}
                         dashboard={dashboard}
                         hideAddWidget
                         hasUnsavedFilters={hasUnsavedFilters}
@@ -1255,7 +1252,6 @@ class DashboardDetail extends Component<Props, State> {
                     <Layout.HeaderActions>
                       <Controls
                         organization={organization}
-                        dashboards={dashboards}
                         dashboard={dashboard}
                         hasUnsavedFilters={hasUnsavedFilters}
                         onEdit={this.onEdit}

--- a/static/app/views/dashboards/manage/dashboardGrid.spec.tsx
+++ b/static/app/views/dashboards/manage/dashboardGrid.spec.tsx
@@ -203,33 +203,6 @@ describe('Dashboards - DashboardGrid', () => {
     expect(dashboardUpdateMock).toHaveBeenCalled();
   });
 
-  it('cannot delete last dashboard', async () => {
-    const singleDashboard = [
-      DashboardListItemFixture({
-        id: '1',
-        title: 'Dashboard 1',
-        dateCreated: '2021-04-19T13:13:23.962105Z',
-        createdBy: UserFixture({id: '1'}),
-        widgetPreview: [],
-      }),
-    ];
-    render(
-      <DashboardGrid
-        organization={organization}
-        dashboards={singleDashboard}
-        onDashboardsChange={dashboardUpdateMock}
-        columnCount={3}
-        rowCount={3}
-      />
-    );
-
-    await userEvent.click(screen.getByRole('button', {name: /dashboard actions/i}));
-    expect(screen.getByTestId('dashboard-delete')).toHaveAttribute(
-      'aria-disabled',
-      'true'
-    );
-  });
-
   it('can duplicate dashboards', async () => {
     render(
       <DashboardGrid

--- a/static/app/views/dashboards/manage/dashboardGrid.tsx
+++ b/static/app/views/dashboards/manage/dashboardGrid.tsx
@@ -130,8 +130,9 @@ function DashboardGrid({
     ];
 
     const disabledKeys = [];
-    if ((dashboards && dashboards.length <= 1) || disableDelete)
+    if (disableDelete) {
       disabledKeys.push('dashboard-delete');
+    }
     if (disableDuplicate) {
       disabledKeys.push('dashboard-duplicate');
     }

--- a/static/app/views/dashboards/manage/dashboardTable.spec.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.spec.tsx
@@ -199,31 +199,6 @@ describe('Dashboards - DashboardTable', () => {
     expect(dashboardUpdateMock).toHaveBeenCalled();
   });
 
-  it('cannot delete last dashboard', async () => {
-    const singleDashboard = [
-      DashboardListItemFixture({
-        id: '1',
-        title: 'Dashboard 1',
-        dateCreated: '2021-04-19T13:13:23.962105Z',
-        createdBy: UserFixture({id: '1'}),
-        widgetPreview: [],
-      }),
-    ];
-    render(
-      <DashboardTable
-        organization={organization}
-        dashboards={singleDashboard}
-        location={LocationFixture()}
-        onDashboardsChange={dashboardUpdateMock}
-      />
-    );
-
-    expect((await screen.findAllByTestId('dashboard-delete'))[0]).toHaveAttribute(
-      'aria-disabled',
-      'true'
-    );
-  });
-
   it('can duplicate dashboards', async () => {
     render(
       <DashboardTable

--- a/static/app/views/dashboards/manage/dashboardTable.tsx
+++ b/static/app/views/dashboards/manage/dashboardTable.tsx
@@ -309,9 +309,7 @@ function DashboardTable({
               data-test-id="dashboard-delete"
               icon={<IconDelete />}
               size="sm"
-              disabled={
-                (dashboards && dashboards.length <= 1) || defined(dataRow.prebuiltId)
-              }
+              disabled={defined(dataRow.prebuiltId)}
               tooltipProps={{
                 title: defined(dataRow.prebuiltId)
                   ? tct('[label] dashboards cannot be deleted', {

--- a/static/app/views/dashboards/prebuiltDashboardRenderer.tsx
+++ b/static/app/views/dashboards/prebuiltDashboardRenderer.tsx
@@ -155,7 +155,6 @@ export function PrebuiltDashboardRenderer({
     <LoadingContainer isLoading={isLoading} showChildrenWhileLoading={false}>
       <DashboardDetail
         dashboard={dashboard}
-        dashboards={[]}
         initialState={DashboardState.EMBEDDED}
         pageAlerts={pageAlerts}
         storageNamespace={storageNamespace}

--- a/static/app/views/dashboards/view.tsx
+++ b/static/app/views/dashboards/view.tsx
@@ -40,7 +40,7 @@ export default function ViewEditDashboard() {
   return (
     <DashboardBasicFeature organization={organization}>
       <OrgDashboards initialDashboard={optimisticDashboard}>
-        {({dashboard, dashboards, error, onDashboardUpdate}) => {
+        {({dashboard, error, onDashboardUpdate}) => {
           return error ? (
             <NotFound />
           ) : dashboard ? (
@@ -49,7 +49,6 @@ export default function ViewEditDashboard() {
                 key={dashboard.id}
                 initialState={DashboardState.VIEW}
                 dashboard={dashboard}
-                dashboards={dashboards}
                 onDashboardUpdate={onDashboardUpdate}
               />
             </ErrorBoundary>

--- a/static/app/views/dashboards/view.tsx
+++ b/static/app/views/dashboards/view.tsx
@@ -28,7 +28,7 @@ export default function ViewEditDashboard() {
   const orgSlug = organization.slug;
 
   useEffect(() => {
-    if (dashboardId && dashboardId !== 'default-overview') {
+    if (dashboardId) {
       updateDashboardVisit(api, orgSlug, dashboardId);
     }
   }, [api, orgSlug, dashboardId]);


### PR DESCRIPTION
In https://github.com/getsentry/sentry/pull/113608 I removed the "General" dashboard (AKA `"default-overview"`) that the backend returned. That is all fine and well, but there's still some FE handling for it. Some is explicit (e.g., checking if something is the "General" dashboard before allowing to star it) and some is implicit (forbidding the removal of the final dashboard because it's the "General" dashboard).

This PR removes those, which removes all FE knowledge of this old pre-built dashboard.