### PR TITLE
fix(explorer): fix slide in animation

### DIFF
--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
@@ -388,7 +388,7 @@ export function ExplorerDrawerContent({
           <Fragment>
             {blocks.map((block: Block, index: number) => (
               <BlockComponent
-                key={block.id}
+                key={index} // For slide-in animation - run/mount once per new index
                 ref={el => {
                   blockRefs.current[index] = el;
                 }}


### PR DESCRIPTION
Can simplify this to the index in the block list. Block.id is changing when hydrated from the server, triggering a remount -> dup animation