### PR TITLE
chore(groups): Replace category with category_v2

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -1185,7 +1185,7 @@ class SimpleGroupSerializer(Serializer):
         user: User | RpcUser | AnonymousUser,
         **kwargs: Any,
     ) -> SimpleGroupSerializerResponse:
-        issue_category = obj.issue_category_v2.name.lower()
+        issue_category = obj.issue_category.name.lower()
 
         return SimpleGroupSerializerResponse(
             id=str(obj.id),

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -363,7 +363,7 @@ class GroupSerializerBase(Serializer, ABC):
         is_subscribed, subscription_details = get_subscription_from_attributes(attrs)
         share_id = attrs["share_id"]
         priority_label = PriorityLevel(obj.priority).to_str() if obj.priority else None
-        issue_category = obj.issue_category_v2.name.lower()
+        issue_category = obj.issue_category.name.lower()
 
         group_dict: BaseGroupSerializerResponse = {
             "id": str(obj.id),

--- a/src/sentry/grouping/grouptype.py
+++ b/src/sentry/grouping/grouptype.py
@@ -28,7 +28,6 @@ class ErrorGroupType(GroupType):
     slug = "error"
     description = "Error"
     category = GroupCategory.ERROR.value
-    category_v2 = GroupCategory.ERROR.value
     default_priority = PriorityLevel.MEDIUM
     released = True
     detector_settings = DetectorSettings(

--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -351,7 +351,7 @@ class MetricIssue(GroupType):
     type_id = 8001
     slug = "metric_issue"
     description = "Metric issue triggered"
-    category = GroupCategory.METRIC_ALERT.value
+    category = GroupCategory.METRIC.value
     creation_quota = Quota(3600, 60, 100)
     default_priority = PriorityLevel.HIGH
     released = True

--- a/src/sentry/incidents/grouptype.py
+++ b/src/sentry/incidents/grouptype.py
@@ -352,7 +352,6 @@ class MetricIssue(GroupType):
     slug = "metric_issue"
     description = "Metric issue triggered"
     category = GroupCategory.METRIC_ALERT.value
-    category_v2 = GroupCategory.METRIC.value
     creation_quota = Quota(3600, 60, 100)
     default_priority = PriorityLevel.HIGH
     released = True

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -43,6 +43,7 @@ from sentry.seer.entrypoints.slack.entrypoint import prepare_slack_thread_for_au
 from sentry.seer.entrypoints.types import SeerEntrypointKey
 from sentry.services.eventstore.models import GroupEvent
 from sentry.types.rules import RuleFuture
+from sentry.uptime.grouptype import UptimeDomainCheckFailure
 from sentry.utils import metrics
 from sentry.workflow_engine.models.action import Action
 
@@ -328,7 +329,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
         )
 
         open_period_start: datetime | None = None
-        if event.group.issue_category == GroupCategory.OUTAGE:
+        if event.group.issue_type.type_id == UptimeDomainCheckFailure.type_id:
             open_period_start = open_period_start_for_group(event.group)
             new_notification_message_object.open_period_start = open_period_start
 
@@ -414,8 +415,8 @@ class SlackNotifyServiceAction(IntegrationEventAction):
 
         open_period_start: datetime | None = None
         if (
-            event.group.issue_category == GroupCategory.OUTAGE
-            or event.group.issue_category == GroupCategory.METRIC_ALERT
+            event.group.issue_type.type_id == UptimeDomainCheckFailure.type_id
+            or event.group.issue_category == GroupCategory.METRIC
         ):
             open_period_start = open_period_start_for_group(event.group)
             new_notification_message_object.open_period_start = open_period_start

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -11,6 +11,7 @@ from slack_sdk.errors import SlackApiError
 
 from sentry.api.serializers.rest_framework.rule import ACTION_UUID_KEY
 from sentry.constants import ISSUE_ALERTS_THREAD_DEFAULT
+from sentry.incidents.grouptype import MetricIssue
 from sentry.integrations.messaging.metrics import (
     MessagingInteractionEvent,
     MessagingInteractionType,
@@ -30,7 +31,6 @@ from sentry.integrations.slack.spec import SlackMessagingSpec
 from sentry.integrations.slack.utils.threads import NotificationActionThreadUtils
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.integrations.utils.metrics import EventLifecycle
-from sentry.issues.grouptype import GroupCategory
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organization import Organization
 from sentry.models.rule import Rule
@@ -416,7 +416,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
         open_period_start: datetime | None = None
         if (
             event.group.issue_type.type_id == UptimeDomainCheckFailure.type_id
-            or event.group.issue_category == GroupCategory.METRIC
+            or event.group.issue_type.type_id == MetricIssue.type_id
         ):
             open_period_start = open_period_start_for_group(event.group)
             new_notification_message_object.open_period_start = open_period_start

--- a/src/sentry/integrations/slack/actions/notification.py
+++ b/src/sentry/integrations/slack/actions/notification.py
@@ -328,7 +328,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
         )
 
         open_period_start: datetime | None = None
-        if event.group.issue_category == GroupCategory.UPTIME:
+        if event.group.issue_category == GroupCategory.OUTAGE:
             open_period_start = open_period_start_for_group(event.group)
             new_notification_message_object.open_period_start = open_period_start
 
@@ -414,7 +414,7 @@ class SlackNotifyServiceAction(IntegrationEventAction):
 
         open_period_start: datetime | None = None
         if (
-            event.group.issue_category == GroupCategory.UPTIME
+            event.group.issue_category == GroupCategory.OUTAGE
             or event.group.issue_category == GroupCategory.METRIC_ALERT
         ):
             open_period_start = open_period_start_for_group(event.group)

--- a/src/sentry/integrations/slack/message_builder/types.py
+++ b/src/sentry/integrations/slack/message_builder/types.py
@@ -1,7 +1,7 @@
 from enum import StrEnum
 from typing import Any, Union
 
-from sentry.issues.grouptype import GroupCategory
+from sentry.issues.grouptype import PERFORMANCE_ISSUE_CATEGORIES, GroupCategory
 
 # TODO(mgaeta): Continue fleshing out these types.
 SlackAttachment = dict[str, Any]
@@ -52,13 +52,19 @@ LEVEL_TO_EMOJI = {
 ACTION_EMOJI = [":white_circle:"]
 
 CATEGORY_TO_EMOJI = {
-    GroupCategory.PERFORMANCE: [":large_blue_circle:", ":chart_with_upwards_trend:"],
+    **{
+        category: [":large_blue_circle:", ":chart_with_upwards_trend:"]
+        for category in PERFORMANCE_ISSUE_CATEGORIES
+    },
     GroupCategory.FEEDBACK: [":large_blue_circle:", ":busts_in_silhouette:"],
     GroupCategory.CRON: [":large_yellow_circle:", ":spiral_calendar_pad:"],
 }
 
 ACTIONED_CATEGORY_TO_EMOJI: dict[GroupCategory, list[str]] = {
-    GroupCategory.PERFORMANCE: [ACTION_EMOJI[0], ":chart_with_upwards_trend:"],
+    **{
+        category: [ACTION_EMOJI[0], ":chart_with_upwards_trend:"]
+        for category in PERFORMANCE_ISSUE_CATEGORIES
+    },
     GroupCategory.FEEDBACK: [ACTION_EMOJI[0], ":busts_in_silhouette:"],
     GroupCategory.CRON: [ACTION_EMOJI[0], ":spiral_calendar_pad:"],
 }

--- a/src/sentry/integrations/slack/message_builder/types.py
+++ b/src/sentry/integrations/slack/message_builder/types.py
@@ -57,7 +57,7 @@ CATEGORY_TO_EMOJI = {
         for category in PERFORMANCE_ISSUE_CATEGORIES
     },
     GroupCategory.FEEDBACK: [":large_blue_circle:", ":busts_in_silhouette:"],
-    GroupCategory.CRON: [":large_yellow_circle:", ":spiral_calendar_pad:"],
+    GroupCategory.OUTAGE: [":large_yellow_circle:", ":spiral_calendar_pad:"],
 }
 
 ACTIONED_CATEGORY_TO_EMOJI: dict[GroupCategory, list[str]] = {
@@ -66,5 +66,5 @@ ACTIONED_CATEGORY_TO_EMOJI: dict[GroupCategory, list[str]] = {
         for category in PERFORMANCE_ISSUE_CATEGORIES
     },
     GroupCategory.FEEDBACK: [ACTION_EMOJI[0], ":busts_in_silhouette:"],
-    GroupCategory.CRON: [ACTION_EMOJI[0], ":spiral_calendar_pad:"],
+    GroupCategory.OUTAGE: [ACTION_EMOJI[0], ":spiral_calendar_pad:"],
 }

--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -258,7 +258,7 @@ class SlackService:
             will_fire_workflow_actions = should_fire_workflow_actions(
                 group.organization, group.type
             )
-            if group.issue_category == GroupCategory.OUTAGE:
+            if group.issue_category == GroupCategory.UPTIME:
                 use_open_period_start = True
                 open_period_start = open_period_start_for_group(group)
                 if will_fire_workflow_actions:

--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -258,7 +258,7 @@ class SlackService:
             will_fire_workflow_actions = should_fire_workflow_actions(
                 group.organization, group.type
             )
-            if group.issue_category == GroupCategory.UPTIME:
+            if group.issue_category == GroupCategory.OUTAGE:
                 use_open_period_start = True
                 open_period_start = open_period_start_for_group(group)
                 if will_fire_workflow_actions:

--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -38,7 +38,6 @@ from sentry.integrations.slack.threads.activity_notifications import (
 )
 from sentry.integrations.types import ExternalProviderEnum, ExternalProviders
 from sentry.integrations.utils.common import get_active_integration_for_organization
-from sentry.issues.grouptype import GroupCategory
 from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.models.options.organization_option import OrganizationOption
@@ -258,7 +257,7 @@ class SlackService:
             will_fire_workflow_actions = should_fire_workflow_actions(
                 group.organization, group.type
             )
-            if group.issue_category == GroupCategory.OUTAGE:
+            if group.issue_type.type_id == UptimeDomainCheckFailure.type_id:
                 use_open_period_start = True
                 open_period_start = open_period_start_for_group(group)
                 if will_fire_workflow_actions:

--- a/src/sentry/issue_detection/performance_detection.py
+++ b/src/sentry/issue_detection/performance_detection.py
@@ -79,7 +79,7 @@ class PerformanceDetectorConfigMapping:
 # Membership in this mapping means the detector is:
 #   - Sentry-managed: created automatically on project creation
 #   - Backed by the (soon to be removed) per-project performance detector config UI (ProjectOption-based)
-#   - GroupCategory.PERFORMANCE (for category, not category_v2)
+#   - GroupCategory.PERFORMANCE
 #
 # All but web_vitals, performance_p95_endpoint_regression and profile_function_regression
 # have corresponding DetectorTypes and are span-based.

--- a/src/sentry/issue_detection/performance_detection.py
+++ b/src/sentry/issue_detection/performance_detection.py
@@ -79,7 +79,7 @@ class PerformanceDetectorConfigMapping:
 # Membership in this mapping means the detector is:
 #   - Sentry-managed: created automatically on project creation
 #   - Backed by the (soon to be removed) per-project performance detector config UI (ProjectOption-based)
-#   - GroupCategory.PERFORMANCE
+#   - PERFORMANCE_ISSUE_CATEGORIES
 #
 # All but web_vitals, performance_p95_endpoint_regression and profile_function_regression
 # have corresponding DetectorTypes and are span-based.

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -59,7 +59,7 @@ class GroupCategory(IntEnum):
     METRIC_ALERT = 8
     TEST_NOTIFICATION = 9
 
-    # New issue categories (under the organizations:issue-taxonomy flag)
+    # New issue categories
     OUTAGE = 10
     METRIC = 11
     DB_QUERY = 12
@@ -120,7 +120,6 @@ class GroupTypeRegistry:
         self._registry[group_type.type_id] = group_type
         self._slug_lookup[group_type.slug] = group_type
         self._category_lookup[group_type.category].add(group_type.type_id)
-        self._category_lookup[group_type.category_v2].add(group_type.type_id)
 
     def all(self) -> list[type[GroupType]]:
         return list(self._registry.values())
@@ -237,9 +236,6 @@ class GroupType:
     slug: ClassVar[str]
     description: ClassVar[str]
     category: ClassVar[int]
-    # New issue category mapping (under the organizations:issue-taxonomy flag)
-    # When GA'd, the original `category` will be removed and this will be renamed to `category`.
-    category_v2: ClassVar[int]
     # Allows delayed creation of issues for this group type until the issue is seen `noise_config.ignore_limit` times.
     # Then a new issue is created, ignoring past events.
     noise_config: ClassVar[NoiseConfig | None] = None
@@ -358,8 +354,7 @@ class PerformanceSlowDBQueryGroupType(GroupType):
     type_id = 1001
     slug = "performance_slow_db_query"
     description = "Slow DB Query"
-    category = GroupCategory.PERFORMANCE.value
-    category_v2 = GroupCategory.DB_QUERY.value
+    category = GroupCategory.DB_QUERY.value
     noise_config = NoiseConfig(ignore_limit=100)
     default_priority = PriorityLevel.LOW
     released = True
@@ -370,8 +365,7 @@ class PerformanceRenderBlockingAssetSpanGroupType(GroupType):
     type_id = 1004
     slug = "performance_render_blocking_asset_span"
     description = "Large Render Blocking Asset"
-    category = GroupCategory.PERFORMANCE.value
-    category_v2 = GroupCategory.FRONTEND.value
+    category = GroupCategory.FRONTEND.value
     noise_config = NoiseConfig()
     default_priority = PriorityLevel.LOW
     released = True
@@ -383,8 +377,7 @@ class PerformanceNPlusOneGroupType(GroupType):
     type_id = 1006
     slug = "performance_n_plus_one_db_queries"
     description = "N+1 Query"
-    category = GroupCategory.PERFORMANCE.value
-    category_v2 = GroupCategory.DB_QUERY.value
+    category = GroupCategory.DB_QUERY.value
     noise_config = NoiseConfig()
     default_priority = PriorityLevel.LOW
     released = True
@@ -395,8 +388,7 @@ class PerformanceNPlusOneExperimentalGroupType(GroupType):
     type_id = 1906
     slug = "performance_n_plus_one_db_queries_experimental"
     description = "N+1 Query (Experimental)"
-    category = GroupCategory.PERFORMANCE.value
-    category_v2 = GroupCategory.DB_QUERY.value
+    category = GroupCategory.DB_QUERY.value
     noise_config = NoiseConfig()
     default_priority = PriorityLevel.LOW
     released = False
@@ -407,8 +399,7 @@ class PerformanceConsecutiveDBQueriesGroupType(GroupType):
     type_id = 1007
     slug = "performance_consecutive_db_queries"
     description = "Consecutive DB Queries"
-    category = GroupCategory.PERFORMANCE.value
-    category_v2 = GroupCategory.DB_QUERY.value
+    category = GroupCategory.DB_QUERY.value
     noise_config = NoiseConfig(ignore_limit=15)
     default_priority = PriorityLevel.LOW
     released = True
@@ -419,8 +410,7 @@ class PerformanceFileIOMainThreadGroupType(GroupType):
     type_id = 1008
     slug = "performance_file_io_main_thread"
     description = "File IO on Main Thread"
-    category = GroupCategory.PERFORMANCE.value
-    category_v2 = GroupCategory.MOBILE.value
+    category = GroupCategory.MOBILE.value
     noise_config = NoiseConfig()
     default_priority = PriorityLevel.LOW
     released = True
@@ -431,8 +421,7 @@ class PerformanceConsecutiveHTTPQueriesGroupType(GroupType):
     type_id = 1009
     slug = "performance_consecutive_http"
     description = "Consecutive HTTP"
-    category = GroupCategory.PERFORMANCE.value
-    category_v2 = GroupCategory.HTTP_CLIENT.value
+    category = GroupCategory.HTTP_CLIENT.value
     noise_config = NoiseConfig(ignore_limit=5)
     default_priority = PriorityLevel.LOW
     released = True
@@ -443,8 +432,7 @@ class PerformanceNPlusOneAPICallsGroupType(GroupType):
     type_id = 1010
     slug = "performance_n_plus_one_api_calls"
     description = "N+1 API Call"
-    category = GroupCategory.PERFORMANCE.value
-    category_v2 = GroupCategory.HTTP_CLIENT.value
+    category = GroupCategory.HTTP_CLIENT.value
     noise_config = NoiseConfig()
     default_priority = PriorityLevel.LOW
     released = True
@@ -455,8 +443,7 @@ class PerformanceNPlusOneAPICallsExperimentalGroupType(GroupType):
     type_id = 1910
     slug = "performance_n_plus_one_api_calls_experimental"
     description = "N+1 API Call (Experimental)"
-    category = GroupCategory.PERFORMANCE.value
-    category_v2 = GroupCategory.HTTP_CLIENT.value
+    category = GroupCategory.HTTP_CLIENT.value
     noise_config = NoiseConfig()
     default_priority = PriorityLevel.LOW
     released = False
@@ -473,8 +460,7 @@ class PerformanceMNPlusOneDBQueriesGroupType(GroupType):
     type_id = 1011
     slug = "performance_m_n_plus_one_db_queries"
     description = "MN+1 Query"
-    category = GroupCategory.PERFORMANCE.value
-    category_v2 = GroupCategory.DB_QUERY.value
+    category = GroupCategory.DB_QUERY.value
     noise_config = NoiseConfig()
     default_priority = PriorityLevel.LOW
     released = True
@@ -485,8 +471,7 @@ class PerformanceMNPlusOneDBQueriesExperimentalGroupType(GroupType):
     type_id = 1911
     slug = "performance_m_n_plus_one_db_queries_experimental"
     description = "MN+1 Query (Experimental)"
-    category = GroupCategory.PERFORMANCE.value
-    category_v2 = GroupCategory.DB_QUERY.value
+    category = GroupCategory.DB_QUERY.value
     noise_config = NoiseConfig()
     default_priority = PriorityLevel.LOW
     released = False
@@ -497,8 +482,7 @@ class PerformanceUncompressedAssetsGroupType(GroupType):
     type_id = 1012
     slug = "performance_uncompressed_assets"
     description = "Uncompressed Asset"
-    category = GroupCategory.PERFORMANCE.value
-    category_v2 = GroupCategory.FRONTEND.value
+    category = GroupCategory.FRONTEND.value
     noise_config = NoiseConfig(ignore_limit=100)
     default_priority = PriorityLevel.LOW
     released = True
@@ -509,8 +493,7 @@ class PerformanceDBMainThreadGroupType(GroupType):
     type_id = 1013
     slug = "performance_db_main_thread"
     description = "DB on Main Thread"
-    category = GroupCategory.PERFORMANCE.value
-    category_v2 = GroupCategory.MOBILE.value
+    category = GroupCategory.MOBILE.value
     noise_config = NoiseConfig()
     default_priority = PriorityLevel.LOW
     released = True
@@ -521,8 +504,7 @@ class PerformanceLargeHTTPPayloadGroupType(GroupType):
     type_id = 1015
     slug = "performance_large_http_payload"
     description = "Large HTTP payload"
-    category = GroupCategory.PERFORMANCE.value
-    category_v2 = GroupCategory.HTTP_CLIENT.value
+    category = GroupCategory.HTTP_CLIENT.value
     noise_config = NoiseConfig()
     default_priority = PriorityLevel.LOW
     released = True
@@ -534,8 +516,7 @@ class PerformanceHTTPOverheadGroupType(GroupType):
     slug = "performance_http_overhead"
     description = "HTTP/1.1 Overhead"
     noise_config = NoiseConfig(ignore_limit=20)
-    category = GroupCategory.PERFORMANCE.value
-    category_v2 = GroupCategory.HTTP_CLIENT.value
+    category = GroupCategory.HTTP_CLIENT.value
     default_priority = PriorityLevel.LOW
     released = True
 
@@ -545,8 +526,7 @@ class PerformanceP95EndpointRegressionGroupType(GroupType):
     type_id = 1018
     slug = "performance_p95_endpoint_regression"
     description = "Endpoint Regression"
-    category = GroupCategory.PERFORMANCE.value
-    category_v2 = GroupCategory.METRIC.value
+    category = GroupCategory.METRIC.value
     enable_auto_resolve = False
     enable_escalation_detection = False
     default_priority = PriorityLevel.MEDIUM
@@ -560,8 +540,7 @@ class PerformanceStreamedSpansGroupTypeExperimental(GroupType):
     type_id = 1019
     slug = "performance_streamed_spans_exp"
     description = "Streamed Spans (Experimental)"
-    category = GroupCategory.PERFORMANCE.value
-    category_v2 = GroupCategory.METRIC.value
+    category = GroupCategory.METRIC.value
     enable_auto_resolve = False
     enable_escalation_detection = False
     default_priority = PriorityLevel.LOW
@@ -573,8 +552,7 @@ class DBQueryInjectionVulnerabilityGroupType(GroupType):
     type_id = 1020
     slug = "db_query_injection_vulnerability"
     description = "Potential Database Query Injection Vulnerability"
-    category = GroupCategory.PERFORMANCE.value
-    category_v2 = GroupCategory.DB_QUERY.value
+    category = GroupCategory.DB_QUERY.value
     enable_auto_resolve = False
     enable_escalation_detection = False
     noise_config = NoiseConfig(ignore_limit=5)
@@ -586,8 +564,7 @@ class QueryInjectionVulnerabilityGroupType(GroupType):
     type_id = 1021
     slug = "query_injection_vulnerability"
     description = "Potential Query Injection Vulnerability"
-    category = GroupCategory.PERFORMANCE.value
-    category_v2 = GroupCategory.DB_QUERY.value
+    category = GroupCategory.DB_QUERY.value
     enable_auto_resolve = False
     enable_escalation_detection = False
     noise_config = NoiseConfig(ignore_limit=10)
@@ -600,8 +577,7 @@ class ProfileFileIOGroupType(GroupType):
     type_id = 2001
     slug = "profile_file_io_main_thread"
     description = "File I/O on Main Thread"
-    category = GroupCategory.PERFORMANCE.value
-    category_v2 = GroupCategory.MOBILE.value
+    category = GroupCategory.MOBILE.value
     default_priority = PriorityLevel.LOW
     released = True
 
@@ -611,8 +587,7 @@ class ProfileImageDecodeGroupType(GroupType):
     type_id = 2002
     slug = "profile_image_decode_main_thread"
     description = "Image Decoding on Main Thread"
-    category = GroupCategory.PERFORMANCE.value
-    category_v2 = GroupCategory.MOBILE.value
+    category = GroupCategory.MOBILE.value
     default_priority = PriorityLevel.LOW
     released = True
 
@@ -622,8 +597,7 @@ class ProfileJSONDecodeType(GroupType):
     type_id = 2003
     slug = "profile_json_decode_main_thread"
     description = "JSON Decoding on Main Thread"
-    category = GroupCategory.PERFORMANCE.value
-    category_v2 = GroupCategory.MOBILE.value
+    category = GroupCategory.MOBILE.value
     default_priority = PriorityLevel.LOW
     released = True
 
@@ -633,8 +607,7 @@ class ProfileRegexType(GroupType):
     type_id = 2007
     slug = "profile_regex_main_thread"
     description = "Regex on Main Thread"
-    category = GroupCategory.PERFORMANCE.value
-    category_v2 = GroupCategory.MOBILE.value
+    category = GroupCategory.MOBILE.value
     released = True
     default_priority = PriorityLevel.LOW
 
@@ -644,8 +617,7 @@ class ProfileFrameDropType(GroupType):
     type_id = 2009
     slug = "profile_frame_drop"
     description = "Frame Drop"
-    category = GroupCategory.PERFORMANCE.value
-    category_v2 = GroupCategory.MOBILE.value
+    category = GroupCategory.MOBILE.value
     noise_config = NoiseConfig(ignore_limit=2000)
     released = True
     default_priority = PriorityLevel.LOW
@@ -656,8 +628,7 @@ class ProfileFunctionRegressionType(GroupType):
     type_id = 2011
     slug = "profile_function_regression"
     description = "Function Regression"
-    category = GroupCategory.PERFORMANCE.value
-    category_v2 = GroupCategory.METRIC.value
+    category = GroupCategory.METRIC.value
     enable_auto_resolve = False
     released = True
     default_priority = PriorityLevel.MEDIUM
@@ -670,7 +641,6 @@ class LLMDetectedExperimentalGroupType(GroupType):
     slug = "llm_detected_experimental"
     description = "LLM Detected Issue"
     category = GroupCategory.AI_DETECTED.value
-    category_v2 = GroupCategory.AI_DETECTED.value
     default_priority = PriorityLevel.MEDIUM
     released = False
     enable_auto_resolve = False
@@ -683,7 +653,6 @@ class LLMDetectedExperimentalGroupTypeV2(GroupType):
     slug = "llm_detected_experimental_v2"
     description = "LLM Detected Issue"
     category = GroupCategory.AI_DETECTED.value
-    category_v2 = GroupCategory.AI_DETECTED.value
     default_priority = PriorityLevel.MEDIUM
     released = False
     enable_auto_resolve = False
@@ -695,8 +664,7 @@ class AIDetectedHTTPGroupType(GroupType):
     type_id = 3503
     slug = "ai_detected_http"
     description = "AI Detected HTTP Issue"
-    category = GroupCategory.AI_DETECTED.value
-    category_v2 = GroupCategory.HTTP_CLIENT.value
+    category = GroupCategory.HTTP_CLIENT.value
     default_priority = PriorityLevel.MEDIUM
     released = False
     enable_auto_resolve = False
@@ -708,8 +676,7 @@ class AIDetectedDBGroupType(GroupType):
     type_id = 3504
     slug = "ai_detected_db"
     description = "AI Detected Database Issue"
-    category = GroupCategory.AI_DETECTED.value
-    category_v2 = GroupCategory.DB_QUERY.value
+    category = GroupCategory.DB_QUERY.value
     default_priority = PriorityLevel.MEDIUM
     released = False
     enable_auto_resolve = False
@@ -722,7 +689,6 @@ class AIDetectedRuntimePerformanceGroupType(GroupType):
     slug = "ai_detected_runtime_performance"
     description = "AI Detected Runtime Performance Issue"
     category = GroupCategory.AI_DETECTED.value
-    category_v2 = GroupCategory.AI_DETECTED.value
     default_priority = PriorityLevel.MEDIUM
     released = False
     enable_auto_resolve = False
@@ -735,7 +701,6 @@ class AIDetectedSecurityGroupType(GroupType):
     slug = "ai_detected_security"
     description = "AI Detected Security Issue"
     category = GroupCategory.AI_DETECTED.value
-    category_v2 = GroupCategory.AI_DETECTED.value
     default_priority = PriorityLevel.MEDIUM
     released = False
     enable_auto_resolve = False
@@ -747,8 +712,7 @@ class AIDetectedCodeHealthGroupType(GroupType):
     type_id = 3507
     slug = "ai_detected_code_health"
     description = "AI Detected Code Health Issue"
-    category = GroupCategory.AI_DETECTED.value
-    category_v2 = GroupCategory.CONFIGURATION.value
+    category = GroupCategory.CONFIGURATION.value
     default_priority = PriorityLevel.MEDIUM
     released = False
     enable_auto_resolve = False
@@ -761,7 +725,6 @@ class AIDetectedGeneralGroupType(GroupType):
     slug = "ai_detected_general"
     description = "AI Detected Issue"
     category = GroupCategory.AI_DETECTED.value
-    category_v2 = GroupCategory.AI_DETECTED.value
     default_priority = PriorityLevel.MEDIUM
     released = False
     enable_auto_resolve = False
@@ -773,8 +736,7 @@ class ReplayRageClickType(ReplayGroupTypeDefaults, GroupType):
     type_id = 5002
     slug = "replay_click_rage"
     description = "Rage Click Detected"
-    category = GroupCategory.REPLAY.value
-    category_v2 = GroupCategory.FRONTEND.value
+    category = GroupCategory.FRONTEND.value
     default_priority = PriorityLevel.MEDIUM
     notification_config = NotificationConfig()
     released = True
@@ -785,8 +747,7 @@ class ReplayHydrationErrorType(ReplayGroupTypeDefaults, GroupType):
     type_id = 5003
     slug = "replay_hydration_error"
     description = "Hydration Error Detected"
-    category = GroupCategory.REPLAY.value
-    category_v2 = GroupCategory.FRONTEND.value
+    category = GroupCategory.FRONTEND.value
     default_priority = PriorityLevel.MEDIUM
     notification_config = NotificationConfig()
     released = True
@@ -798,7 +759,6 @@ class FeedbackGroup(GroupType):
     slug = "feedback"
     description = "Feedback"
     category = GroupCategory.FEEDBACK.value
-    category_v2 = GroupCategory.FEEDBACK.value
     creation_quota = Quota(3600, 60, 1000)  # 1000 per hour, sliding window of 60 seconds
     default_priority = PriorityLevel.MEDIUM
     notification_config = NotificationConfig(context=[])
@@ -813,8 +773,7 @@ class WebVitalsGroup(GroupType):  # TODO: Rename to WebVitalsGroupType
     type_id = 10001
     slug = "web_vitals"
     description = "Web Vitals"
-    category = GroupCategory.PERFORMANCE.value
-    category_v2 = GroupCategory.FRONTEND.value
+    category = GroupCategory.FRONTEND.value
     enable_auto_resolve = False
     enable_escalation_detection = False
     enable_status_change_workflow_notifications = False

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -96,6 +96,7 @@ PERFORMANCE_ISSUE_CATEGORIES = frozenset(
         GroupCategory.FRONTEND,
         GroupCategory.MOBILE,
         GroupCategory.HTTP_CLIENT,
+        GroupCategory.METRIC,
     }
 )
 

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -96,7 +96,6 @@ PERFORMANCE_ISSUE_CATEGORIES = frozenset(
         GroupCategory.FRONTEND,
         GroupCategory.MOBILE,
         GroupCategory.HTTP_CLIENT,
-        GroupCategory.METRIC,
     }
 )
 

--- a/src/sentry/issues/grouptype.py
+++ b/src/sentry/issues/grouptype.py
@@ -89,10 +89,20 @@ class GroupCategory(IntEnum):
     CONFIGURATION = 19
 
 
+# Categories that replaced GroupCategory.PERFORMANCE for span-evidence performance issue types
+PERFORMANCE_ISSUE_CATEGORIES = frozenset(
+    {
+        GroupCategory.DB_QUERY,
+        GroupCategory.FRONTEND,
+        GroupCategory.MOBILE,
+        GroupCategory.HTTP_CLIENT,
+    }
+)
+
 GROUP_CATEGORIES_CUSTOM_EMAIL = (
     GroupCategory.ERROR,
-    GroupCategory.PERFORMANCE,
     GroupCategory.FEEDBACK,
+    *PERFORMANCE_ISSUE_CATEGORIES,
 )
 # GroupCategories which have customized email templates. If not included here, will fall back to a generic template.
 

--- a/src/sentry/issues/issue_search.py
+++ b/src/sentry/issues/issue_search.py
@@ -19,7 +19,10 @@ from sentry.api.event_search import (
 )
 from sentry.api.event_search import parse_search_query as base_parse_query
 from sentry.exceptions import InvalidSearchQuery
-from sentry.issues.grouptype import GroupCategory, get_group_type_by_slug
+from sentry.issues.grouptype import (
+    GroupCategory,
+    get_group_type_by_slug,
+)
 from sentry.issues.grouptype import registry as GROUP_TYPE_REGISTRY
 from sentry.models.environment import Environment
 from sentry.models.group import GROUP_SUBSTATUS_TO_STATUS_MAP, STATUS_QUERY_CHOICES

--- a/src/sentry/issues/search.py
+++ b/src/sentry/issues/search.py
@@ -8,7 +8,12 @@ from typing import Any, Optional, Protocol, TypedDict, TypeGuard
 
 from sentry.api.event_search import SearchFilter, SearchKey, SearchValue
 from sentry.issues import grouptype
-from sentry.issues.grouptype import GroupCategory, get_all_group_type_ids, get_group_type_by_type_id
+from sentry.issues.grouptype import (
+    PERFORMANCE_ISSUE_CATEGORIES,
+    GroupCategory,
+    get_all_group_type_ids,
+    get_group_type_by_type_id,
+)
 from sentry.issues.grouptype import registry as GT_REGISTRY
 from sentry.models.organization import Organization
 from sentry.search.events.filter import convert_search_filter_to_snuba_query
@@ -253,7 +258,10 @@ def _update_profiling_search_filters(
 
 
 SEARCH_FILTER_UPDATERS: Mapping[int, GroupSearchFilterUpdater] = {
-    GroupCategory.PERFORMANCE.value: _update_profiling_search_filters,
+    **{
+        category.value: _update_profiling_search_filters
+        for category in PERFORMANCE_ISSUE_CATEGORIES
+    },
     GroupCategory.PROFILE.value: _update_profiling_search_filters,
 }
 

--- a/src/sentry/models/group.py
+++ b/src/sentry/models/group.py
@@ -1137,10 +1137,6 @@ class Group(Model):
     def issue_category(self):
         return GroupCategory(self.issue_type.category)
 
-    @property
-    def issue_category_v2(self):
-        return GroupCategory(self.issue_type.category_v2)
-
 
 @receiver(pre_save, sender=Group, dispatch_uid="pre_save_group_default_substatus", weak=False)
 def pre_save_group_default_substatus(instance, sender, *args, **kwargs):

--- a/src/sentry/monitors/grouptype.py
+++ b/src/sentry/monitors/grouptype.py
@@ -15,8 +15,7 @@ class MonitorIncidentType(GroupType):
     type_id = 4001
     slug = "monitor_check_in_failure"
     description = "Crons Monitor Failed"
-    category = GroupCategory.CRON.value
-    category_v2 = GroupCategory.OUTAGE.value
+    category = GroupCategory.OUTAGE.value
     released = True
     creation_quota = Quota(3600, 60, 60_000)  # 60,000 per hour, sliding window of 60 seconds
     default_priority = PriorityLevel.HIGH

--- a/src/sentry/notifications/notification_action/grouptype.py
+++ b/src/sentry/notifications/notification_action/grouptype.py
@@ -22,7 +22,6 @@ class SendTestNotification(GroupType):
     slug = "send-test-notification"
     description = "Send test notification"
     category = GroupCategory.TEST_NOTIFICATION.value
-    category_v2 = GroupCategory.TEST_NOTIFICATION.value
     released = False
     in_default_search = False
     enable_auto_resolve = True

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -19,7 +19,7 @@ from sentry.integrations.types import (
 )
 from sentry.issues.grouptype import (
     GROUP_CATEGORIES_CUSTOM_EMAIL,
-    GroupCategory,
+    PERFORMANCE_ISSUE_CATEGORIES,
     PerformanceP95EndpointRegressionGroupType,
     ProfileFunctionRegressionType,
 )
@@ -108,6 +108,8 @@ class AlertRuleNotification(ProjectNotification):
                 and event.occurrence.evidence_data.get("template_name") == "profile"
             ):
                 email_template_name = GENERIC_TEMPLATE_NAME
+            elif event.group.issue_category in PERFORMANCE_ISSUE_CATEGORIES:
+                email_template_name = "performance"
             else:
                 email_template_name = event.group.issue_category.name.lower()
         else:
@@ -239,7 +241,7 @@ class AlertRuleNotification(ProjectNotification):
             else None
         )
 
-        if self.group.issue_category == GroupCategory.PERFORMANCE and template_name != "profile":
+        if self.group.issue_category in PERFORMANCE_ISSUE_CATEGORIES and template_name != "profile":
             # This can't use data from the occurrence at the moment, so we'll keep fetching the event
             # and gathering span evidence.
 

--- a/src/sentry/notifications/notifications/rules.py
+++ b/src/sentry/notifications/notifications/rules.py
@@ -100,7 +100,14 @@ class AlertRuleNotification(ProjectNotification):
         self.fallthrough_choice = fallthrough_choice
         self.rules = notification.rules
 
-        if event.group.issue_category in GROUP_CATEGORIES_CUSTOM_EMAIL:
+        if (
+            event.group.issue_category in GROUP_CATEGORIES_CUSTOM_EMAIL
+            or event.group.issue_type.type_id
+            in (
+                PerformanceP95EndpointRegressionGroupType.type_id,
+                ProfileFunctionRegressionType.type_id,
+            )
+        ):
             # profile issues use the generic template for now
             if (
                 isinstance(event, GroupEvent)

--- a/src/sentry/preprod/size_analysis/grouptype.py
+++ b/src/sentry/preprod/size_analysis/grouptype.py
@@ -404,7 +404,6 @@ class PreprodSizeAnalysisGroupType(GroupType):
     slug = "preprod_size_analysis"
     description = "Size Analysis"
     category = GroupCategory.PREPROD.value
-    category_v2 = GroupCategory.PREPROD.value
     default_priority = PriorityLevel.LOW
     released = False
     enable_auto_resolve = True

--- a/src/sentry/processing_errors/grouptype.py
+++ b/src/sentry/processing_errors/grouptype.py
@@ -253,7 +253,6 @@ class SourcemapConfigurationType(GroupType):
     slug = "sourcemap_configuration"
     description = "Source Map Configuration Issue"
     category = GroupCategory.CONFIGURATION.value
-    category_v2 = GroupCategory.CONFIGURATION.value
     released = False
     default_priority = PriorityLevel.LOW
     enable_auto_resolve = False

--- a/src/sentry/rules/conditions/event_frequency.py
+++ b/src/sentry/rules/conditions/event_frequency.py
@@ -496,8 +496,7 @@ class EventFrequencyCondition(BaseEventFrequencyCondition):
         if generic_issue_ids and organization_id:
             generic_sums = self.get_chunked_result(
                 tsdb_function=self.tsdb.get_sums,
-                # this isn't necessarily performance, just any non-error category
-                model=get_issue_tsdb_group_model(GroupCategory.PERFORMANCE),
+                model=get_issue_tsdb_group_model(GroupCategory.DB_QUERY),
                 group_ids=generic_issue_ids,
                 organization_id=organization_id,
                 start=start,
@@ -571,8 +570,7 @@ class EventUniqueUserFrequencyCondition(BaseEventFrequencyCondition):
         if generic_issue_ids and organization_id:
             generic_totals = self.get_chunked_result(
                 tsdb_function=self.tsdb.get_distinct_counts_totals,
-                # this isn't necessarily performance, just any non-error category
-                model=get_issue_tsdb_user_group_model(GroupCategory.PERFORMANCE),
+                model=get_issue_tsdb_user_group_model(GroupCategory.DB_QUERY),
                 group_ids=generic_issue_ids,
                 organization_id=organization_id,
                 start=start,
@@ -694,7 +692,7 @@ class EventUniqueUserFrequencyConditionWithConditions(EventUniqueUserFrequencyCo
         if generic_issue_ids and organization_id:
             error_totals = self.get_chunked_result(
                 tsdb_function=self.tsdb.get_distinct_counts_totals,
-                model=get_issue_tsdb_user_group_model(GroupCategory.PERFORMANCE),
+                model=get_issue_tsdb_user_group_model(GroupCategory.DB_QUERY),
                 group_ids=generic_issue_ids,
                 organization_id=organization_id,
                 start=start,

--- a/src/sentry/rules/filters/issue_category.py
+++ b/src/sentry/rules/filters/issue_category.py
@@ -44,7 +44,7 @@ class IssueCategoryFilter(EventFilter):
         include_category = self.get_option("include", "true") != "false"
 
         if group:
-            category_matches = value == group.issue_category or value == group.issue_category_v2
+            category_matches = value == group.issue_category or value == group.issue_category
             return category_matches if include_category else not category_matches
 
         return False

--- a/src/sentry/rules/filters/issue_category.py
+++ b/src/sentry/rules/filters/issue_category.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from django import forms
 
-from sentry.issues.grouptype import GroupCategory
+from sentry.issues.grouptype import PERFORMANCE_ISSUE_CATEGORIES, GroupCategory
 from sentry.models.group import Group
 from sentry.rules import EventState
 from sentry.rules.filters import EventFilter
@@ -44,7 +44,15 @@ class IssueCategoryFilter(EventFilter):
         include_category = self.get_option("include", "true") != "false"
 
         if group:
-            category_matches = value == group.issue_category
+            # TODO(CEO): we're only temporarily handling GroupCategory.PERFORMANCE_ISSUE_CATEGORIES until we can migrate away from that data
+            # Until condition data is migrated, treat a stored PERFORMANCE value as matching any of the replacement categories too
+            if value == GroupCategory.PERFORMANCE:
+                category_matches = (
+                    group.issue_category in PERFORMANCE_ISSUE_CATEGORIES
+                    or group.issue_category == GroupCategory.PERFORMANCE
+                )
+            else:
+                category_matches = value == group.issue_category
             return category_matches if include_category else not category_matches
 
         return False

--- a/src/sentry/rules/filters/issue_category.py
+++ b/src/sentry/rules/filters/issue_category.py
@@ -44,7 +44,7 @@ class IssueCategoryFilter(EventFilter):
         include_category = self.get_option("include", "true") != "false"
 
         if group:
-            category_matches = value == group.issue_category or value == group.issue_category
+            category_matches = value == group.issue_category
             return category_matches if include_category else not category_matches
 
         return False

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -23,7 +23,7 @@ from sentry.api.paginator import DateTimePaginator, Paginator, SequencePaginator
 from sentry.api.serializers.models.group import SKIP_SNUBA_FIELDS
 from sentry.constants import ALLOWED_FUTURE_DELTA
 from sentry.db.models.manager.base_query_set import BaseQuerySet
-from sentry.issues.grouptype import PERFORMANCE_ISSUE_CATEGORIES, GroupCategory
+from sentry.issues.grouptype import GroupCategory
 from sentry.issues.search import (
     SEARCH_FILTER_UPDATERS,
     IntermediateSearchQueryPartial,

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -23,7 +23,7 @@ from sentry.api.paginator import DateTimePaginator, Paginator, SequencePaginator
 from sentry.api.serializers.models.group import SKIP_SNUBA_FIELDS
 from sentry.constants import ALLOWED_FUTURE_DELTA
 from sentry.db.models.manager.base_query_set import BaseQuerySet
-from sentry.issues.grouptype import GroupCategory
+from sentry.issues.grouptype import PERFORMANCE_ISSUE_CATEGORIES, GroupCategory
 from sentry.issues.search import (
     SEARCH_FILTER_UPDATERS,
     IntermediateSearchQueryPartial,

--- a/src/sentry/seer/autofix/utils.py
+++ b/src/sentry/seer/autofix/utils.py
@@ -888,7 +888,6 @@ def is_issue_category_eligible(group: Group) -> bool:
 
     return group.issue_category in {
         GroupCategory.ERROR,
-        GroupCategory.PERFORMANCE,
         GroupCategory.MOBILE,
         GroupCategory.FRONTEND,
         GroupCategory.DB_QUERY,

--- a/src/sentry/services/eventstore/models.py
+++ b/src/sentry/services/eventstore/models.py
@@ -21,7 +21,7 @@ from sentry.db.models import NodeData
 from sentry.grouping.api import get_grouping_config_dict_for_project
 from sentry.grouping.variants import BaseVariant
 from sentry.interfaces.base import Interface, get_interfaces
-from sentry.issues.grouptype import GroupCategory
+from sentry.issues.grouptype import PERFORMANCE_ISSUE_CATEGORIES
 from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.models.event import EventDict
 from sentry.snuba.events import Columns
@@ -482,7 +482,7 @@ class BaseEvent(metaclass=abc.ABCMeta):
         subject_template = self.project.get_option("mail:subject_template")
         if subject_template:
             template = EventSubjectTemplate(subject_template)
-        elif self.group.issue_category == GroupCategory.PERFORMANCE:
+        elif self.group.issue_category in PERFORMANCE_ISSUE_CATEGORIES:
             template = EventSubjectTemplate("$shortID - $issueType")
         else:
             template = DEFAULT_SUBJECT_TEMPLATE

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -1638,7 +1638,7 @@ GROUP_CATEGORY_POST_PROCESS_PIPELINE: dict[
         feedback_filter_decorator(process_workflow_engine_issue_alerts),
         feedback_filter_decorator(process_resource_change_bounds),
     ],
-    GroupCategory.METRIC_ALERT: [
+    GroupCategory.METRIC: [
         process_workflow_engine_metric_issues,
     ],
     GroupCategory.INSTRUMENTATION: [

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -649,11 +649,13 @@ def run_post_process_job(job: PostProcessJob) -> None:
         )
         return
 
-    if issue_category in GROUP_CATEGORY_POST_PROCESS_PIPELINE:
-        # specific pipelines for issue types
+    issue_type_id = group_event.group.issue_type.type_id if group_event.group else None
+    if (
+        issue_category in GROUP_CATEGORY_POST_PROCESS_PIPELINE
+        and issue_type_id not in _REGRESSION_TYPE_IDS_USE_GENERIC_PIPELINE
+    ):
         pipeline = GROUP_CATEGORY_POST_PROCESS_PIPELINE[issue_category]
     else:
-        # pipeline for generic issues
         pipeline = GENERIC_POST_PROCESS_PIPELINE
 
     for pipeline_step in pipeline:
@@ -1656,3 +1658,14 @@ GENERIC_POST_PROCESS_PIPELINE: list[Callable[[PostProcessJob], None]] = [
     process_resource_change_bounds,
     process_data_forwarding,
 ]
+
+# These regression group types were migrated from GroupCategory.PERFORMANCE to
+# GroupCategory.METRIC but should still use the generic pipeline rather than the
+# metric-alert-specific one.
+_REGRESSION_TYPE_IDS_USE_GENERIC_PIPELINE: frozenset[int] = frozenset(
+    {
+        1018,  # PerformanceP95EndpointRegressionGroupType
+        1019,  # PerformanceStreamedSpansGroupTypeExperimental
+        2011,  # ProfileFunctionRegressionType
+    }
+)

--- a/src/sentry/uptime/grouptype.py
+++ b/src/sentry/uptime/grouptype.py
@@ -266,8 +266,7 @@ class UptimeDomainCheckFailure(GroupType):
     slug = GROUP_TYPE_UPTIME_DOMAIN_CHECK_FAILURE
     description = "Uptime Domain Monitor Failure"
     released = True
-    category = GroupCategory.UPTIME.value
-    category_v2 = GroupCategory.OUTAGE.value
+    category = GroupCategory.OUTAGE.value
     creation_quota = Quota(3600, 60, 1000)  # 1000 per hour, sliding window of 60 seconds
     default_priority = PriorityLevel.HIGH
     enable_auto_resolve = False

--- a/src/sentry/workflow_engine/handlers/condition/issue_category_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_category_handler.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 from typing import Any
 
-from sentry.issues.grouptype import GroupCategory
+from sentry.issues.grouptype import PERFORMANCE_ISSUE_CATEGORIES, GroupCategory
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.registry import condition_handler_registry
 from sentry.workflow_engine.types import DataConditionHandler, WorkflowEventData
@@ -42,10 +42,17 @@ class IssueCategoryConditionHandler(DataConditionHandler[WorkflowEventData]):
         except ValueError:
             return False
 
-        if include:
-            return bool(value == issue_category)
+        # TODO(CEO): we're only temporarily handling GroupCategory.PERFORMANCE_ISSUE_CATEGORIES until we can migrate away from that data
+        # Until condition data is migrated, treat a stored PERFORMANCE value as matching any of the replacement categories too
+        if value == GroupCategory.PERFORMANCE:
+            category_matches = (
+                issue_category in PERFORMANCE_ISSUE_CATEGORIES
+                or issue_category == GroupCategory.PERFORMANCE
+            )
+        else:
+            category_matches = value == issue_category
 
-        return bool(value != issue_category)
+        return bool(category_matches if include else not category_matches)
 
     @classmethod
     def render_label(cls, condition_data: dict[str, Any]) -> str:

--- a/src/sentry/workflow_engine/handlers/condition/issue_category_handler.py
+++ b/src/sentry/workflow_engine/handlers/condition/issue_category_handler.py
@@ -39,14 +39,13 @@ class IssueCategoryConditionHandler(DataConditionHandler[WorkflowEventData]):
 
         try:
             issue_category = group.issue_category
-            issue_category_v2 = group.issue_category_v2
         except ValueError:
             return False
 
         if include:
-            return bool(value == issue_category or value == issue_category_v2)
+            return bool(value == issue_category)
 
-        return bool(value != issue_category and value != issue_category_v2)
+        return bool(value != issue_category)
 
     @classmethod
     def render_label(cls, condition_data: dict[str, Any]) -> str:

--- a/src/sentry/workflow_engine/typings/grouptype.py
+++ b/src/sentry/workflow_engine/typings/grouptype.py
@@ -10,7 +10,6 @@ class IssueStreamGroupType(GroupType):
     slug = "issue_stream"
     description = "Issue Stream"
     category = GroupCategory.ERROR.value
-    category_v2 = GroupCategory.ERROR.value
     released = False
     in_default_search = False
     enable_auto_resolve = False

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -2913,7 +2913,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
             )
             assert group.location() == "/books/"
             assert group.level == 40
-            assert group.issue_category == GroupCategory.PERFORMANCE
+            assert group.issue_category == GroupCategory.DB_QUERY
             assert group.issue_type == PerformanceNPlusOneGroupType
             assert isinstance(event, GroupEvent)
             assert event.occurrence

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -2957,7 +2957,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
             )
             group = event.group
             assert group is not None
-            assert group.issue_category == GroupCategory.PERFORMANCE
+            assert group.issue_category == GroupCategory.DB_QUERY
             assert group.issue_type == PerformanceNPlusOneGroupType
             group.data["metadata"] = {
                 "location": "hi",

--- a/tests/sentry/integrations/slack/service/test_slack_service.py
+++ b/tests/sentry/integrations/slack/service/test_slack_service.py
@@ -269,7 +269,7 @@ class TestNotifyAllThreadsForActivity(TestCase):
             type(group),
             "issue_category",
             new_callable=mock.PropertyMock,
-            return_value=GroupCategory.UPTIME,
+            return_value=GroupCategory.OUTAGE,
         ):
             self.service.notify_all_threads_for_activity(activity=activity)
 
@@ -326,7 +326,7 @@ class TestNotifyAllThreadsForActivity(TestCase):
             type(group),
             "issue_category",
             new_callable=mock.PropertyMock,
-            return_value=GroupCategory.UPTIME,
+            return_value=GroupCategory.OUTAGE,
         ):
             self.service.notify_all_threads_for_activity(activity=activity)
 
@@ -380,7 +380,7 @@ class TestNotifyAllThreadsForActivity(TestCase):
             type(group),
             "issue_category",
             new_callable=mock.PropertyMock,
-            return_value=GroupCategory.UPTIME,
+            return_value=GroupCategory.OUTAGE,
         ):
             self.service.notify_all_threads_for_activity(activity=activity)
 
@@ -508,7 +508,7 @@ class TestNotifyAllThreadsForActivity(TestCase):
             type(group),
             "issue_category",
             new_callable=mock.PropertyMock,
-            return_value=GroupCategory.UPTIME,
+            return_value=GroupCategory.OUTAGE,
         ):
             self.service.notify_all_threads_for_activity(activity=activity)
 

--- a/tests/sentry/integrations/slack/service/test_slack_service.py
+++ b/tests/sentry/integrations/slack/service/test_slack_service.py
@@ -13,6 +13,7 @@ from sentry.integrations.repository.notification_action import NotificationActio
 from sentry.integrations.slack.sdk_client import SlackSdkClient
 from sentry.integrations.slack.service import ActionDataError, RuleDataError, SlackService
 from sentry.integrations.types import EventLifecycleOutcome
+from sentry.issues.grouptype import GroupCategory
 from sentry.models.activity import Activity
 from sentry.models.groupopenperiod import get_latest_open_period
 from sentry.models.options.organization_option import OrganizationOption
@@ -264,7 +265,13 @@ class TestNotifyAllThreadsForActivity(TestCase):
             group=group,
         )
 
-        self.service.notify_all_threads_for_activity(activity=activity)
+        with mock.patch.object(
+            type(group),
+            "issue_category",
+            new_callable=mock.PropertyMock,
+            return_value=GroupCategory.UPTIME,
+        ):
+            self.service.notify_all_threads_for_activity(activity=activity)
 
         # Verify only one notification was handled
         assert mock_send_notification.call_count == 1
@@ -315,7 +322,13 @@ class TestNotifyAllThreadsForActivity(TestCase):
             group=group,
         )
 
-        self.service.notify_all_threads_for_activity(activity=activity)
+        with mock.patch.object(
+            type(group),
+            "issue_category",
+            new_callable=mock.PropertyMock,
+            return_value=GroupCategory.UPTIME,
+        ):
+            self.service.notify_all_threads_for_activity(activity=activity)
 
         # Verify only one notification was handled
         assert mock_send_notification.call_count == 1
@@ -363,7 +376,13 @@ class TestNotifyAllThreadsForActivity(TestCase):
             group=group,
         )
 
-        self.service.notify_all_threads_for_activity(activity=activity)
+        with mock.patch.object(
+            type(group),
+            "issue_category",
+            new_callable=mock.PropertyMock,
+            return_value=GroupCategory.UPTIME,
+        ):
+            self.service.notify_all_threads_for_activity(activity=activity)
 
         # Verify only one notification was handled
         assert mock_send_notification.call_count == 1
@@ -485,7 +504,13 @@ class TestNotifyAllThreadsForActivity(TestCase):
             notification_2
         )
 
-        self.service.notify_all_threads_for_activity(activity=activity)
+        with mock.patch.object(
+            type(group),
+            "issue_category",
+            new_callable=mock.PropertyMock,
+            return_value=GroupCategory.UPTIME,
+        ):
+            self.service.notify_all_threads_for_activity(activity=activity)
 
         # Verify only one notification was handled
         assert mock_send_notification.call_count == 1

--- a/tests/sentry/issues/endpoints/test_organization_group_index.py
+++ b/tests/sentry/issues/endpoints/test_organization_group_index.py
@@ -524,7 +524,9 @@ class GroupListTest(APITestCase, SnubaTestCase, SearchIssueTestMixin):
         assert group_info is not None
         perf_group = group_info.group
         self.login_as(user=self.user)
-        response = self.get_success_response(query="issue.category:performance")
+        response = self.get_success_response(
+            query=f"issue.type:{PerformanceNPlusOneGroupType.slug}"
+        )
         assert len(response.data) == 1
         assert response.data[0]["id"] == str(perf_group.id)
 

--- a/tests/sentry/issues/escalating/test_escalating.py
+++ b/tests/sentry/issues/escalating/test_escalating.py
@@ -119,8 +119,8 @@ class HistoricGroupCounts(
         assert len(Group.objects.all()) == 4
         assert profile_error_event.group.issue_category == GroupCategory.ERROR
         assert error_event.group.issue_category == GroupCategory.ERROR
-        assert profile_issue_occurrence.group.issue_category == GroupCategory.PERFORMANCE
-        assert perf_event.group.issue_category == GroupCategory.PERFORMANCE
+        assert profile_issue_occurrence.group.issue_category == GroupCategory.MOBILE
+        assert perf_event.group.issue_category == GroupCategory.DB_QUERY
 
         profile_issue_occurrence_bucket = {
             "count()": 1,

--- a/tests/sentry/issues/test_grouptype.py
+++ b/tests/sentry/issues/test_grouptype.py
@@ -29,14 +29,12 @@ class BaseGroupTypeTest(TestCase):
             slug = "error"
             description = "Error"
             category = GroupCategory.TEST_NOTIFICATION.value
-            category_v2 = GroupCategory.TEST_NOTIFICATION.value
 
         class IssueStreamGroupType(GroupType):
             type_id = 0
             slug = "issue_stream"
             description = "Issue Stream"
             category = GroupCategory.TEST_NOTIFICATION.value
-            category_v2 = GroupCategory.TEST_NOTIFICATION.value
 
     def tearDown(self) -> None:
         super().tearDown()
@@ -51,7 +49,6 @@ class GroupTypeTest(BaseGroupTypeTest):
             slug = "test"
             description = "Test"
             category = GroupCategory.ERROR.value
-            category_v2 = GroupCategory.ERROR.value
             ignore_limit = 0
 
         @dataclass(frozen=True)
@@ -59,16 +56,14 @@ class GroupTypeTest(BaseGroupTypeTest):
             type_id = 2
             slug = "hellboy"
             description = "Hellboy"
-            category = GroupCategory.PERFORMANCE.value
-            category_v2 = GroupCategory.DB_QUERY.value
+            category = GroupCategory.DB_QUERY.value
 
         @dataclass(frozen=True)
         class TestGroupType3(GroupType):
             type_id = 3
             slug = "angelgirl"
             description = "AngelGirl"
-            category = GroupCategory.PERFORMANCE.value
-            category_v2 = GroupCategory.DB_QUERY.value
+            category = GroupCategory.DB_QUERY.value
 
         assert get_group_types_by_category(GroupCategory.PERFORMANCE.value) == {2, 3}
         assert get_group_types_by_category(GroupCategory.ERROR.value) == {1}
@@ -80,7 +75,6 @@ class GroupTypeTest(BaseGroupTypeTest):
             slug = "test"
             description = "Test"
             category = GroupCategory.ERROR.value
-            category_v2 = GroupCategory.ERROR.value
             ignore_limit = 0
 
         assert get_group_type_by_slug(TestGroupType.slug) == TestGroupType
@@ -97,7 +91,6 @@ class GroupTypeTest(BaseGroupTypeTest):
                 slug = "error"
                 description = "Error"
                 category = 22
-                category_v2 = 22
 
     def test_default_noise_config(self) -> None:
         @dataclass(frozen=True)
@@ -106,15 +99,13 @@ class GroupTypeTest(BaseGroupTypeTest):
             slug = "test"
             description = "Test"
             category = GroupCategory.ERROR.value
-            category_v2 = GroupCategory.ERROR.value
 
         @dataclass(frozen=True)
         class TestGroupType2(GroupType):
             type_id = 2
             slug = "hellboy"
             description = "Hellboy"
-            category = GroupCategory.PERFORMANCE.value
-            category_v2 = GroupCategory.DB_QUERY.value
+            category = GroupCategory.DB_QUERY.value
             noise_config = NoiseConfig()
 
         assert TestGroupType.noise_config is None
@@ -128,8 +119,7 @@ class GroupTypeTest(BaseGroupTypeTest):
             type_id = 2
             slug = "hellboy"
             description = "Hellboy"
-            category = GroupCategory.PERFORMANCE.value
-            category_v2 = GroupCategory.DB_QUERY.value
+            category = GroupCategory.DB_QUERY.value
             noise_config = NoiseConfig(ignore_limit=100, expiry_time=timedelta(hours=12))
 
         assert TestGroupType.noise_config.ignore_limit == 100
@@ -143,8 +133,7 @@ class GroupTypeReleasedTest(BaseGroupTypeTest):
             type_id = 1
             slug = "test"
             description = "Test"
-            category = GroupCategory.PERFORMANCE.value
-            category_v2 = GroupCategory.DB_QUERY.value
+            category = GroupCategory.DB_QUERY.value
             noise_config = NoiseConfig()
             released = True
 
@@ -157,8 +146,7 @@ class GroupTypeReleasedTest(BaseGroupTypeTest):
             type_id = 1
             slug = "test"
             description = "Test"
-            category = GroupCategory.PERFORMANCE.value
-            category_v2 = GroupCategory.DB_QUERY.value
+            category = GroupCategory.DB_QUERY.value
             noise_config = NoiseConfig()
             released = False
 
@@ -171,8 +159,7 @@ class GroupTypeReleasedTest(BaseGroupTypeTest):
             type_id = 1
             slug = "test"
             description = "Test"
-            category = GroupCategory.PERFORMANCE.value
-            category_v2 = GroupCategory.DB_QUERY.value
+            category = GroupCategory.DB_QUERY.value
             noise_config = NoiseConfig()
             released = False
 
@@ -190,7 +177,6 @@ class GroupRegistryTest(BaseGroupTypeTest):
             description = "Mock unreleased issue group"
             released = False
             category = GroupCategory.ERROR.value
-            category_v2 = GroupCategory.ERROR.value
 
         registry = GroupTypeRegistry()
         registry.add(UnreleasedGroupType)

--- a/tests/sentry/issues/test_grouptype.py
+++ b/tests/sentry/issues/test_grouptype.py
@@ -65,7 +65,7 @@ class GroupTypeTest(BaseGroupTypeTest):
             description = "AngelGirl"
             category = GroupCategory.DB_QUERY.value
 
-        assert get_group_types_by_category(GroupCategory.PERFORMANCE.value) == {2, 3}
+        assert get_group_types_by_category(GroupCategory.DB_QUERY.value) == {2, 3}
         assert get_group_types_by_category(GroupCategory.ERROR.value) == {1}
 
     def test_get_group_type_by_slug(self) -> None:
@@ -196,14 +196,7 @@ class GroupRegistryTest(BaseGroupTypeTest):
         registry.add(PerformanceSlowDBQueryGroupType)
         registry.add(PerformanceNPlusOneGroupType)
 
-        # Works for old category mapping
         assert registry.get_by_category(GroupCategory.ERROR.value) == {ErrorGroupType.type_id}
-        assert registry.get_by_category(GroupCategory.PERFORMANCE.value) == {
-            PerformanceSlowDBQueryGroupType.type_id,
-            PerformanceNPlusOneGroupType.type_id,
-        }
-
-        # Works for new category mapping
         assert registry.get_by_category(GroupCategory.DB_QUERY.value) == {
             PerformanceSlowDBQueryGroupType.type_id,
             PerformanceNPlusOneGroupType.type_id,

--- a/tests/sentry/issues/test_ingest.py
+++ b/tests/sentry/issues/test_ingest.py
@@ -574,8 +574,7 @@ class SaveIssueFromOccurrenceTest(OccurrenceTestMixin, TestCase):
                 type_id = 1
                 slug = "test"
                 description = "Test"
-                category = GroupCategory.PROFILE.value
-                category_v2 = GroupCategory.MOBILE.value
+                category = GroupCategory.MOBILE.value
                 noise_config = NoiseConfig(ignore_limit=2)
 
             event = self.store_event(data={}, project_id=project_id)

--- a/tests/sentry/issues/test_issue_search.py
+++ b/tests/sentry/issues/test_issue_search.py
@@ -10,7 +10,7 @@ from sentry.api.event_search import (
     SearchValue,
 )
 from sentry.exceptions import InvalidSearchQuery
-from sentry.issues.grouptype import PERFORMANCE_ISSUE_CATEGORIES, GroupCategory
+from sentry.issues.grouptype import GroupCategory
 from sentry.issues.grouptype import registry as GROUP_TYPE_REGISTRY
 from sentry.issues.issue_search import (
     convert_actor_or_none_value,
@@ -433,31 +433,24 @@ class ConvertFirstReleaseValueTest(TestCase):
 class ConvertCategoryValueTest(TestCase):
     def test(self) -> None:
         error_group_types = GROUP_TYPE_REGISTRY.get_by_category(GroupCategory.ERROR.value)
-        perf_group_types = {
-            gt
-            for cat in PERFORMANCE_ISSUE_CATEGORIES
-            for gt in GROUP_TYPE_REGISTRY.get_by_category(cat.value)
-        }
+        db_query_group_types = GROUP_TYPE_REGISTRY.get_by_category(GroupCategory.DB_QUERY.value)
         assert (
             set(convert_category_value(["error"], [self.project], self.user, None))
             == error_group_types
         )
         assert (
-            set(convert_category_value(["performance"], [self.project], self.user, None))
-            == perf_group_types
-        )
-        assert (
-            set(convert_category_value(["error", "performance"], [self.project], self.user, None))
-            == error_group_types | perf_group_types
+            set(convert_category_value(["error", "DB_QUERY"], [self.project], self.user, None))
+            == error_group_types | db_query_group_types
         )
 
         # Also works with new categories
         assert set(
             convert_category_value(["outage"], [self.project], self.user, None)
         ) == GROUP_TYPE_REGISTRY.get_by_category(GroupCategory.OUTAGE.value)
-        assert set(
-            convert_category_value(["DB_QUERY"], [self.project], self.user, None)
-        ) == GROUP_TYPE_REGISTRY.get_by_category(GroupCategory.DB_QUERY.value)
+        assert (
+            set(convert_category_value(["DB_QUERY"], [self.project], self.user, None))
+            == db_query_group_types
+        )
 
         # Should raise an error for invalid values
         with pytest.raises(InvalidSearchQuery):

--- a/tests/sentry/issues/test_issue_search.py
+++ b/tests/sentry/issues/test_issue_search.py
@@ -10,7 +10,7 @@ from sentry.api.event_search import (
     SearchValue,
 )
 from sentry.exceptions import InvalidSearchQuery
-from sentry.issues.grouptype import GroupCategory
+from sentry.issues.grouptype import PERFORMANCE_ISSUE_CATEGORIES, GroupCategory
 from sentry.issues.grouptype import registry as GROUP_TYPE_REGISTRY
 from sentry.issues.issue_search import (
     convert_actor_or_none_value,
@@ -433,7 +433,11 @@ class ConvertFirstReleaseValueTest(TestCase):
 class ConvertCategoryValueTest(TestCase):
     def test(self) -> None:
         error_group_types = GROUP_TYPE_REGISTRY.get_by_category(GroupCategory.ERROR.value)
-        perf_group_types = GROUP_TYPE_REGISTRY.get_by_category(GroupCategory.PERFORMANCE.value)
+        perf_group_types = {
+            gt
+            for cat in PERFORMANCE_ISSUE_CATEGORIES
+            for gt in GROUP_TYPE_REGISTRY.get_by_category(cat.value)
+        }
         assert (
             set(convert_category_value(["error"], [self.project], self.user, None))
             == error_group_types

--- a/tests/sentry/rules/filters/test_issue_category.py
+++ b/tests/sentry/rules/filters/test_issue_category.py
@@ -101,6 +101,13 @@ class IssueCategoryFilterPerformanceTest(
     rule_cls = IssueCategoryFilter
 
     def test_transaction_category(self) -> None:
+        # Rule data stored before PERFORMANCE was split still uses GroupCategory.PERFORMANCE (2).
+        # Ensure those rules continue to match until the data is migrated.
+        tx_event = self.create_performance_issue()
+        assert tx_event.group
+        self.assertPasses(self.get_rule(data={"value": GroupCategory.PERFORMANCE.value}), tx_event)
+
+    def test_transaction_category_v2(self) -> None:
         tx_event = self.create_performance_issue()
         assert tx_event.group
         self.assertPasses(self.get_rule(data={"value": GroupCategory.DB_QUERY.value}), tx_event)

--- a/tests/sentry/rules/filters/test_issue_category.py
+++ b/tests/sentry/rules/filters/test_issue_category.py
@@ -103,9 +103,4 @@ class IssueCategoryFilterPerformanceTest(
     def test_transaction_category(self) -> None:
         tx_event = self.create_performance_issue()
         assert tx_event.group
-        self.assertPasses(self.get_rule(data={"value": GroupCategory.PERFORMANCE.value}), tx_event)
-
-    def test_transaction_category_v2(self) -> None:
-        tx_event = self.create_performance_issue()
-        assert tx_event.group
         self.assertPasses(self.get_rule(data={"value": GroupCategory.DB_QUERY.value}), tx_event)

--- a/tests/sentry/rules/filters/test_issue_category.py
+++ b/tests/sentry/rules/filters/test_issue_category.py
@@ -60,11 +60,11 @@ class IssueCategoryFilterErrorTest(RuleTestCase):
         )
 
         self.assertPasses(
-            self.get_rule(data={"value": GroupCategory.PERFORMANCE.value, "include": "false"}),
+            self.get_rule(data={"value": GroupCategory.DB_QUERY.value, "include": "false"}),
             event,
         )
         self.assertPasses(
-            self.get_rule(data={"value": GroupCategory.PERFORMANCE.value, "include": "false"}),
+            self.get_rule(data={"value": GroupCategory.DB_QUERY.value, "include": "false"}),
             group_event,
         )
 
@@ -76,7 +76,7 @@ class IssueCategoryFilterErrorTest(RuleTestCase):
             event,
         )
         self.assertDoesNotPass(
-            self.get_rule(data={"value": GroupCategory.PERFORMANCE.value}),
+            self.get_rule(data={"value": GroupCategory.DB_QUERY.value}),
             event,
         )
 
@@ -88,7 +88,7 @@ class IssueCategoryFilterErrorTest(RuleTestCase):
             event,
         )
         self.assertDoesNotPass(
-            self.get_rule(data={"value": GroupCategory.PERFORMANCE.value, "include": "true"}),
+            self.get_rule(data={"value": GroupCategory.DB_QUERY.value, "include": "true"}),
             event,
         )
 

--- a/tests/sentry/rules/history/test_preview.py
+++ b/tests/sentry/rules/history/test_preview.py
@@ -246,7 +246,7 @@ class ProjectRulePreviewTest(TestCase, SnubaTestCase, PerformanceIssueTestCase):
         filters = [
             {
                 "id": "sentry.rules.filters.issue_category.IssueCategoryFilter",
-                "value": GroupCategory.PERFORMANCE.value,
+                "value": GroupCategory.MOBILE.value,
             }
         ]
         result = preview(self.project, conditions, filters, *MATCH_ARGS)

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_types.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_types.py
@@ -85,8 +85,7 @@ class OrganizationDetectorTypesAPITestCase(APITestCase):
             type_id = 1
             slug = MetricIssue.slug
             description = "Metric alert"
-            category = GroupCategory.METRIC_ALERT.value
-            category_v2 = GroupCategory.METRIC.value
+            category = GroupCategory.METRIC.value
             detector_settings = DetectorSettings(handler=MockDetectorHandler)
             released = True
 
@@ -95,8 +94,7 @@ class OrganizationDetectorTypesAPITestCase(APITestCase):
             type_id = 2
             slug = MonitorIncidentType.slug
             description = "Crons"
-            category = GroupCategory.CRON.value
-            category_v2 = GroupCategory.OUTAGE.value
+            category = GroupCategory.OUTAGE.value
             detector_settings = DetectorSettings(handler=MockDetectorHandler)
             released = True
 
@@ -105,8 +103,7 @@ class OrganizationDetectorTypesAPITestCase(APITestCase):
             type_id = 3
             slug = UptimeDomainCheckFailure.slug
             description = "Uptime"
-            category = GroupCategory.UPTIME.value
-            category_v2 = GroupCategory.OUTAGE.value
+            category = GroupCategory.OUTAGE.value
             detector_settings = DetectorSettings(handler=MockDetectorHandler)
             released = True
 
@@ -116,8 +113,7 @@ class OrganizationDetectorTypesAPITestCase(APITestCase):
             type_id = 4
             slug = PerformanceSlowDBQueryGroupType.slug
             description = "Performance"
-            category = GroupCategory.PERFORMANCE.value
-            category_v2 = GroupCategory.DB_QUERY.value
+            category = GroupCategory.DB_QUERY.value
             released = True
 
     def tearDown(self) -> None:

--- a/tests/sentry/workflow_engine/endpoints/test_validators.py
+++ b/tests/sentry/workflow_engine/endpoints/test_validators.py
@@ -127,8 +127,7 @@ class TestBaseGroupTypeDetectorValidator(BaseValidatorTest):
             type_id = 1
             slug = "test_type"
             description = "no handler"
-            category = GroupCategory.METRIC_ALERT.value
-            category_v2 = GroupCategory.METRIC.value
+            category = GroupCategory.METRIC.value
             detector_settings = DetectorSettings(validator=MetricIssueDetectorValidator)
 
         with mock.patch.object(grouptype.registry, "get_by_slug") as mock_get_by_slug:
@@ -151,8 +150,7 @@ class TestBaseGroupTypeDetectorValidator(BaseValidatorTest):
             type_id = 1
             slug = "test_type"
             description = "no handler"
-            category = GroupCategory.METRIC_ALERT.value
-            category_v2 = GroupCategory.METRIC.value
+            category = GroupCategory.METRIC.value
 
         with mock.patch.object(grouptype.registry, "get_by_slug") as mock_get_by_slug:
             mock_get_by_slug.return_value = TestGroupType

--- a/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_query_handlers.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_event_frequency_query_handlers.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from sentry.issues.grouptype import GroupCategory
+from sentry.issues.grouptype import GroupCategory, PerformanceNPlusOneGroupType
 from sentry.models.group import Group
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.skips import requires_snuba
@@ -337,7 +337,10 @@ class EventFrequencyQueryTest(EventFrequencyQueryTestBase):
         error_group_ids = category_group_ids[GroupCategory.ERROR]
         assert self.event.group_id in error_group_ids
         assert self.event2.group_id in error_group_ids
-        assert self.perf_event.group_id in category_group_ids[GroupCategory.PERFORMANCE]
+        assert (
+            self.perf_event.group_id
+            in category_group_ids[GroupCategory(PerformanceNPlusOneGroupType.category)]
+        )
 
 
 class EventUniqueUserFrequencyQueryTest(EventFrequencyQueryTestBase):

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_category_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_category_handler.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from jsonschema import ValidationError
 
-from sentry.issues.grouptype import GroupCategory
+from sentry.issues.grouptype import GroupCategory, PerformanceNPlusOneGroupType
 from sentry.rules.filters.issue_category import IssueCategoryFilter
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.types import WorkflowEventData
@@ -106,6 +106,18 @@ class TestIssueCategoryCondition(ConditionTestCase):
         self.assert_does_not_pass(
             self.dc, WorkflowEventData(event=self.event, group=self.event.group)
         )
+
+    def test_category_v2(self) -> None:
+        perf_group, perf_event, perf_group_event = self.create_group_event(
+            group_type_id=PerformanceNPlusOneGroupType.type_id
+        )
+
+        # N+1 DB query issue should pass for 'PERFORMANCE' (deprecated) as well as 'DB_QUERY' (category_v2)
+        self.dc.update(comparison={"value": GroupCategory.PERFORMANCE.value})
+        self.assert_passes(self.dc, WorkflowEventData(event=perf_group_event, group=perf_group))
+
+        self.dc.update(comparison={"value": GroupCategory.DB_QUERY.value})
+        self.assert_passes(self.dc, WorkflowEventData(event=perf_group_event, group=perf_group))
 
     def test_exclude(self) -> None:
         assert self.event.group is not None

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_category_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_category_handler.py
@@ -115,6 +115,6 @@ class TestIssueCategoryCondition(ConditionTestCase):
         self.assert_does_not_pass(self.dc, WorkflowEventData(event=self.event, group=self.group))
         self.assert_does_not_pass(self.dc, WorkflowEventData(event=group_event, group=self.group))
 
-        self.dc.update(comparison={"value": GroupCategory.PERFORMANCE.value, "include": False})
+        self.dc.update(comparison={"value": GroupCategory.DB_QUERY.value, "include": False})
         self.assert_passes(self.dc, WorkflowEventData(event=self.event, group=self.group))
         self.assert_passes(self.dc, WorkflowEventData(event=group_event, group=self.group))

--- a/tests/sentry/workflow_engine/handlers/condition/test_issue_category_handler.py
+++ b/tests/sentry/workflow_engine/handlers/condition/test_issue_category_handler.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from jsonschema import ValidationError
 
-from sentry.issues.grouptype import GroupCategory, PerformanceNPlusOneGroupType
+from sentry.issues.grouptype import GroupCategory
 from sentry.rules.filters.issue_category import IssueCategoryFilter
 from sentry.workflow_engine.models.data_condition import Condition
 from sentry.workflow_engine.types import WorkflowEventData
@@ -106,18 +106,6 @@ class TestIssueCategoryCondition(ConditionTestCase):
         self.assert_does_not_pass(
             self.dc, WorkflowEventData(event=self.event, group=self.event.group)
         )
-
-    def test_category_v2(self) -> None:
-        perf_group, perf_event, perf_group_event = self.create_group_event(
-            group_type_id=PerformanceNPlusOneGroupType.type_id
-        )
-
-        # N+1 DB query issue should pass for 'PERFORMANCE' (deprecated) as well as 'DB_QUERY' (category_v2)
-        self.dc.update(comparison={"value": GroupCategory.PERFORMANCE.value})
-        self.assert_passes(self.dc, WorkflowEventData(event=perf_group_event, group=perf_group))
-
-        self.dc.update(comparison={"value": GroupCategory.DB_QUERY.value})
-        self.assert_passes(self.dc, WorkflowEventData(event=perf_group_event, group=perf_group))
 
     def test_exclude(self) -> None:
         assert self.event.group is not None

--- a/tests/sentry/workflow_engine/handlers/detector/test_base.py
+++ b/tests/sentry/workflow_engine/handlers/detector/test_base.py
@@ -98,7 +98,6 @@ class BaseDetectorHandlerTest(BaseGroupTypeTest):
             slug = "no_handler"
             description = "no handler"
             category = GroupCategory.METRIC_ALERT.value
-            category_v2 = GroupCategory.METRIC_ALERT.value
 
         class MockDetectorHandler(BaseDetectorHandler[dict[str, Any], int]):
             def evaluate_impl(
@@ -163,24 +162,21 @@ class BaseDetectorHandlerTest(BaseGroupTypeTest):
             type_id = 2
             slug = "handler"
             description = "handler"
-            category = GroupCategory.METRIC_ALERT.value
-            category_v2 = GroupCategory.METRIC.value
+            category = GroupCategory.METRIC.value
             detector_settings = DetectorSettings(handler=MockDetectorHandler)
 
         class HandlerStateGroupType(GroupType):
             type_id = 3
             slug = "handler_with_state"
             description = "handler with state"
-            category = GroupCategory.METRIC_ALERT.value
-            category_v2 = GroupCategory.METRIC.value
+            category = GroupCategory.METRIC.value
             detector_settings = DetectorSettings(handler=MockDetectorStateHandler)
 
         class HandlerUpdateGroupType(GroupType):
             type_id = 4
             slug = "handler_update"
             description = "handler update"
-            category = GroupCategory.METRIC_ALERT.value
-            category_v2 = GroupCategory.METRIC.value
+            category = GroupCategory.METRIC.value
             detector_settings = DetectorSettings(handler=MockDetectorWithUpdateHandler)
 
         self.no_handler_type = NoHandlerGroupType

--- a/tests/sentry/workflow_engine/models/test_json_config_base.py
+++ b/tests/sentry/workflow_engine/models/test_json_config_base.py
@@ -44,7 +44,6 @@ class JSONConfigBaseTest(BaseGroupTypeTest):
             slug = "test"
             description = "Test"
             category = GroupCategory.ERROR.value
-            category_v2 = GroupCategory.ERROR.value
             detector_settings = DetectorSettings(config_schema=self.example_schema)
 
         @dataclass(frozen=True)
@@ -52,8 +51,7 @@ class JSONConfigBaseTest(BaseGroupTypeTest):
             type_id = 2
             slug = "example"
             description = "Example"
-            category = GroupCategory.PERFORMANCE.value
-            category_v2 = GroupCategory.DB_QUERY.value
+            category = GroupCategory.DB_QUERY.value
             detector_settings = DetectorSettings(
                 config_schema={"type": "object", "additionalProperties": False},
             )
@@ -104,8 +102,7 @@ class TestMetricIssueDetectorConfig(JSONConfigBaseTest, APITestCase):
             type_id = 3
             slug = "test_metric_issue"
             description = "Metric alert fired"
-            category = GroupCategory.METRIC_ALERT.value
-            category_v2 = GroupCategory.METRIC.value
+            category = GroupCategory.METRIC.value
             detector_settings = DetectorSettings(
                 config_schema=MetricIssue.detector_settings.config_schema,
             )

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -3527,7 +3527,9 @@ class EventsGenericSnubaSearchTest(TestCase, SharedSnubaMixin, OccurrenceTestMix
                 assert group_info is not None
 
             with self.feature(group_type.build_visible_feature_name()):
-                results = self.make_query(search_filter_query="issue.type:{PerformanceNPlusOneGroupType.slug} my_tag:3")
+                results = self.make_query(
+                    search_filter_query=f"issue.type:{PerformanceNPlusOneGroupType.slug} my_tag:3"
+                )
 
         assert list(results) == [group_info.group]
 

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -3169,7 +3169,7 @@ class EventsTransactionsSnubaSearchTest(TestCase, SharedSnubaMixin):
 
     def test_performance_query(self) -> None:
         with self.feature(self.perf_group_1.issue_type.build_visible_feature_name()):
-            results = self.make_query(search_filter_query="issue.category:performance my_tag:1")
+            results = self.make_query(search_filter_query="issue.category:frontend my_tag:1")
             assert list(results) == [self.perf_group_1, self.perf_group_2]
 
             results = self.make_query(
@@ -3195,7 +3195,7 @@ class EventsTransactionsSnubaSearchTest(TestCase, SharedSnubaMixin):
                 self.error_group_1,
             ]
             results = self.make_query(
-                search_filter_query="issue.category:[performance, error] my_tag:1"
+                search_filter_query="issue.category:[frontend, error] my_tag:1"
             )
             assert list(results) == [
                 self.perf_group_1,
@@ -3218,7 +3218,7 @@ class EventsTransactionsSnubaSearchTest(TestCase, SharedSnubaMixin):
         with self.feature(self.perf_group_1.issue_type.build_visible_feature_name()):
             results = self.make_query(
                 projects=[self.project],
-                search_filter_query="issue.category:performance my_tag:1",
+                search_filter_query="issue.category:frontend my_tag:1",
                 sort_by="date",
                 limit=1,
                 count_hits=True,
@@ -3229,7 +3229,7 @@ class EventsTransactionsSnubaSearchTest(TestCase, SharedSnubaMixin):
 
             results = self.make_query(
                 projects=[self.project],
-                search_filter_query="issue.category:performance my_tag:1",
+                search_filter_query="issue.category:frontend my_tag:1",
                 sort_by="date",
                 limit=1,
                 cursor=results.next,
@@ -3240,7 +3240,7 @@ class EventsTransactionsSnubaSearchTest(TestCase, SharedSnubaMixin):
 
             results = self.make_query(
                 projects=[self.project],
-                search_filter_query="issue.category:performance my_tag:1",
+                search_filter_query="issue.category:frontend my_tag:1",
                 sort_by="date",
                 limit=1,
                 cursor=results.next,
@@ -3299,7 +3299,7 @@ class EventsTransactionsSnubaSearchTest(TestCase, SharedSnubaMixin):
             assert result["data"][0]["transaction_name"] == transaction_name
             assert result["data"][0]["group_id"] == created_group.id
 
-            results = self.make_query(search_filter_query="issue.category:performance tea")
+            results = self.make_query(search_filter_query="issue.category:frontend tea")
             assert set(results) == {created_group}
 
             results2 = self.make_query(search_filter_query="tea")

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -460,10 +460,10 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         )
         group_3 = event_3.group
         group_3.update(type=PerformanceNPlusOneGroupType.type_id)
-        results = self.make_query(search_filter_query="issue.category:performance")
+        results = self.make_query(search_filter_query="issue.category:db_query")
         assert set(results) == {group_3}
 
-        results = self.make_query(search_filter_query="issue.category:[error, performance]")
+        results = self.make_query(search_filter_query="issue.category:[error, db_query]")
         assert set(results) == {self.group1, self.group2, group_3}
 
         with pytest.raises(InvalidSearchQuery):
@@ -473,7 +473,7 @@ class EventsSnubaSearchTestCases(EventsDatasetTestSetup):
         results = self.make_query(search_filter_query="issue.category:error foo")
         assert set(results) == {self.group1}
 
-        not_results = self.make_query(search_filter_query="!issue.category:performance foo")
+        not_results = self.make_query(search_filter_query="!issue.category:db_query foo")
         assert set(not_results) == {self.group1}
 
     def test_type(self) -> None:
@@ -3490,10 +3490,12 @@ class EventsGenericSnubaSearchTest(TestCase, SharedSnubaMixin, OccurrenceTestMix
         self.error_group_2 = error_event_2.group
 
     def test_generic_query(self) -> None:
-        results = self.make_query(search_filter_query="issue.category:performance my_tag:1")
+        results = self.make_query(
+            search_filter_query=f"issue.type:{ProfileFileIOGroupType.slug} my_tag:1"
+        )
         assert list(results) == [self.profile_group_1, self.profile_group_2]
         results = self.make_query(
-            search_filter_query="issue.type:profile_file_io_main_thread my_tag:1"
+            search_filter_query=f"issue.type:{ProfileFileIOGroupType.slug} my_tag:1"
         )
         assert list(results) == [self.profile_group_1, self.profile_group_2]
 
@@ -3525,7 +3527,8 @@ class EventsGenericSnubaSearchTest(TestCase, SharedSnubaMixin, OccurrenceTestMix
                 assert group_info is not None
 
             with self.feature(group_type.build_visible_feature_name()):
-                results = self.make_query(search_filter_query="issue.category:performance my_tag:3")
+                results = self.make_query(search_filter_query="issue.type:{PerformanceNPlusOneGroupType.slug} my_tag:3")
+
         assert list(results) == [group_info.group]
 
     def test_error_generic_query(self) -> None:
@@ -3537,7 +3540,7 @@ class EventsGenericSnubaSearchTest(TestCase, SharedSnubaMixin, OccurrenceTestMix
             self.error_group_1,
         ]
         results = self.make_query(
-            search_filter_query="issue.category:[performance, error] my_tag:1"
+            search_filter_query=f"issue.type:[{ProfileFileIOGroupType.slug}, error] my_tag:1"
         )
         assert list(results) == [
             self.profile_group_1,
@@ -3547,7 +3550,7 @@ class EventsGenericSnubaSearchTest(TestCase, SharedSnubaMixin, OccurrenceTestMix
         ]
 
         results = self.make_query(
-            search_filter_query="issue.type:[profile_file_io_main_thread, error] my_tag:1"
+            search_filter_query=f"issue.type:[{ProfileFileIOGroupType.slug}, error] my_tag:1"
         )
         assert list(results) == [
             self.profile_group_1,
@@ -3559,7 +3562,7 @@ class EventsGenericSnubaSearchTest(TestCase, SharedSnubaMixin, OccurrenceTestMix
     def test_cursor_profile_issues(self) -> None:
         results = self.make_query(
             projects=[self.project],
-            search_filter_query="issue.category:performance my_tag:1",
+            search_filter_query=f"issue.type:{ProfileFileIOGroupType.slug} my_tag:1",
             sort_by="date",
             limit=1,
             count_hits=True,
@@ -3570,7 +3573,7 @@ class EventsGenericSnubaSearchTest(TestCase, SharedSnubaMixin, OccurrenceTestMix
 
         results = self.make_query(
             projects=[self.project],
-            search_filter_query="issue.category:performance my_tag:1",
+            search_filter_query=f"issue.type:{ProfileFileIOGroupType.slug} my_tag:1",
             sort_by="date",
             limit=1,
             cursor=results.next,
@@ -3581,7 +3584,7 @@ class EventsGenericSnubaSearchTest(TestCase, SharedSnubaMixin, OccurrenceTestMix
 
         results = self.make_query(
             projects=[self.project],
-            search_filter_query="issue.category:performance my_tag:1",
+            search_filter_query=f"issue.type:{ProfileFileIOGroupType.slug} my_tag:1",
             sort_by="date",
             limit=1,
             cursor=results.next,
@@ -3811,7 +3814,7 @@ class EventsGenericSnubaSearchTest(TestCase, SharedSnubaMixin, OccurrenceTestMix
 
             with self.feature(group_type.build_visible_feature_name()):
                 results = self.make_query(
-                    search_filter_query="issue.category:performance perfkeyword456"
+                    search_filter_query=f"issue.type:{PerformanceNPlusOneGroupType.slug} perfkeyword456"
                 )
                 assert list(results) == [group_info.group]
 


### PR DESCRIPTION
The issue taxonomy flag was removed a while ago but the multiple group categories still needed to be cleaned up. We only use v2 going forward, so this replaces all the group type `category` with `category_v2` but keeps the name category for simplicity.

As a temporary fallback in a couple files we still reference the old category type - this can be removed after a migration has been run to remove the old categories from data conditions.