### PR TITLE
fix(cmdk): Remove extra virtualizer padding from command palette

### DIFF
--- a/static/app/components/commandPalette/ui/commandPalette.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.tsx
@@ -650,6 +650,7 @@ export function CommandPalette({
             keyDownHandler={() => true}
             overlayIsOpen
             virtualized
+            virtualizedListPadding={0}
             size="md"
             aria-label={t('Search results')}
             selectionMode="none"

--- a/static/app/components/core/compactSelect/listBox/index.tsx
+++ b/static/app/components/core/compactSelect/listBox/index.tsx
@@ -112,6 +112,10 @@ interface ListBoxProps<T extends ObjectLike>
    * If true, virtualization will be enabled for the list
    */
   virtualized?: boolean;
+  /**
+   * Vertical padding (in px) added to the virtualizer height. Defaults to 4 (theme.space.xs).
+   */
+  virtualizedListPadding?: number;
 }
 
 const EMPTY_SET = new Set<never>();
@@ -144,6 +148,7 @@ export function ListBox<T extends ObjectLike>({
   showDetails = true,
   onAction,
   virtualized,
+  virtualizedListPadding = listPaddingVertical,
   scrollContainerRef,
   className,
   ...props
@@ -191,7 +196,12 @@ export function ListBox<T extends ObjectLike>({
     listState.selectionManager.setFocusedKey(null);
   };
 
-  const virtualizer = useVirtualizedItems({listItems, virtualized, size});
+  const virtualizer = useVirtualizedItems({
+    listItems,
+    virtualized,
+    size,
+    listPadding: virtualizedListPadding,
+  });
 
   useEffect(() => {
     if (!virtualized || listState.selectionManager.focusedKey === null) {
@@ -299,8 +309,10 @@ function useVirtualizedItems<T extends ObjectLike>({
   listItems,
   virtualized = false,
   size,
+  listPadding,
 }: {
   listItems: Array<Node<T>>;
+  listPadding: number;
   size: FormSize;
   virtualized: boolean | undefined;
 }) {
@@ -335,7 +347,7 @@ function useVirtualizedItems<T extends ObjectLike>({
       wrapperProps: {
         'data-is-virtualized': true,
         style: {
-          height: virtualizer.getTotalSize() + listPaddingVertical * 2,
+          height: virtualizer.getTotalSize() + listPadding * 2,
           width: '100%',
           position: 'relative',
         },


### PR DESCRIPTION
The ListBox virtualizer adds `listPaddingVertical` (4px × 2 = 8px) to
the wrapper height to account for the `ListWrap` `<ul>` padding. The
command palette manages its own layout and doesn't need this extra
height, which was causing a size mismatch.

Adds a `virtualizedListPadding` prop to `ListBox` (defaults to 4 to
preserve existing behavior) so callers can override the padding added
to the virtualizer height. The command palette passes 0.