### PR TITLE
feat(seer): Accept tri-state code mode (off/on/only) in explorer chat

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
@@ -28,6 +28,41 @@ from sentry.utils import json
 logger = logging.getLogger(__name__)
 
 
+_CODE_MODE_VALUES = frozenset({"off", "on", "only"})
+
+
+class CodeModeField(serializers.Field):
+    """Accepts 'off'|'on'|'only' strings, or booleans for backwards compat.
+
+    DRF's CharField rejects raw booleans before the field-level validator
+    runs, so we handle coercion in to_internal_value instead.
+    """
+
+    def to_internal_value(self, data: object) -> str | None:
+        if data is None:
+            return None
+        if data is True:
+            return "on"
+        if data is False:
+            return "off"
+        if isinstance(data, str):
+            lowered = data.lower()
+            if lowered in ("true",):
+                return "on"
+            if lowered in ("false",):
+                return "off"
+            if lowered in _CODE_MODE_VALUES:
+                return lowered
+        raise serializers.ValidationError(
+            f"Invalid value '{data}'. Must be 'off', 'on', 'only', or a boolean."
+        )
+
+    def to_representation(self, value: object) -> str | None:
+        if value is None:
+            return None
+        return str(value)
+
+
 class SeerExplorerChatSerializer(serializers.Serializer):
     query = serializers.CharField(
         required=True,
@@ -56,26 +91,12 @@ class SeerExplorerChatSerializer(serializers.Serializer):
         default=True,
         help_text="Override context engine rollout flag (applies to reasoning platform only).",
     )
-    override_code_mode_enable = serializers.CharField(
+    override_code_mode_enable = CodeModeField(
         required=False,
         default=None,
         allow_null=True,
-        allow_blank=False,
         help_text="Override code mode tools: 'off', 'on', 'only', or boolean for backwards compat.",
     )
-
-    def validate_override_code_mode_enable(self, value: str | bool | None) -> str | None:
-        if value is None:
-            return None
-        if value is True or value == "true":
-            return "on"
-        if value is False or value == "false":
-            return "off"
-        if isinstance(value, str) and value in ("off", "on", "only"):
-            return value
-        raise serializers.ValidationError(
-            f"Invalid value '{value}'. Must be 'off', 'on', 'only', or a boolean."
-        )
 
 
 class OrganizationSeerExplorerChatPermission(OrganizationPermission):

--- a/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_explorer_chat.py
@@ -56,12 +56,26 @@ class SeerExplorerChatSerializer(serializers.Serializer):
         default=True,
         help_text="Override context engine rollout flag (applies to reasoning platform only).",
     )
-    override_code_mode_enable = serializers.BooleanField(
+    override_code_mode_enable = serializers.CharField(
         required=False,
         default=None,
         allow_null=True,
-        help_text="Override code mode tools flag from the frontend toggle.",
+        allow_blank=False,
+        help_text="Override code mode tools: 'off', 'on', 'only', or boolean for backwards compat.",
     )
+
+    def validate_override_code_mode_enable(self, value: str | bool | None) -> str | None:
+        if value is None:
+            return None
+        if value is True or value == "true":
+            return "on"
+        if value is False or value == "false":
+            return "off"
+        if isinstance(value, str) and value in ("off", "on", "only"):
+            return value
+        raise serializers.ValidationError(
+            f"Invalid value '{value}'. Must be 'off', 'on', 'only', or a boolean."
+        )
 
 
 class OrganizationSeerExplorerChatPermission(OrganizationPermission):
@@ -188,11 +202,15 @@ class OrganizationSeerExplorerChatEndpoint(OrganizationEndpoint):
             ) and features.has(
                 "organizations:seer-explorer-chat-coding", organization, actor=request.user
             )
-            enable_code_mode_tools = features.has(
+            has_code_mode_feature = features.has(
                 "organizations:seer-explorer-code-mode-tools", organization, actor=request.user
             )
-            if override_code_mode_enable is not None and enable_code_mode_tools:
+            if not has_code_mode_feature:
+                enable_code_mode_tools = "off"
+            elif override_code_mode_enable is not None:
                 enable_code_mode_tools = override_code_mode_enable
+            else:
+                enable_code_mode_tools = "on"
             client = SeerExplorerClient(
                 organization,
                 request.user,

--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -198,7 +198,7 @@ class SeerExplorerClient:
         reasoning_effort: Literal["low", "medium", "high"] | None = None,
         is_interactive: bool = False,
         enable_coding: bool = False,
-        enable_code_mode_tools: bool = False,
+        enable_code_mode_tools: str = "off",
         max_iterations: int | None = None,
     ):
         self.organization = organization
@@ -285,7 +285,7 @@ class SeerExplorerClient:
             is_interactive=self.is_interactive,
             enable_coding=self.enable_coding,
             enable_code_mode_tools=self.enable_code_mode_tools,
-            proxy_headers=get_proxy_headers() if self.enable_code_mode_tools else None,
+            proxy_headers=get_proxy_headers() if self.enable_code_mode_tools != "off" else None,
         )
 
         if self.reasoning_effort is not None:
@@ -387,7 +387,7 @@ class SeerExplorerClient:
             is_interactive=self.is_interactive,
             enable_coding=self.enable_coding,
             enable_code_mode_tools=self.enable_code_mode_tools,
-            proxy_headers=get_proxy_headers() if self.enable_code_mode_tools else None,
+            proxy_headers=get_proxy_headers() if self.enable_code_mode_tools != "off" else None,
         )
 
         if prompt_metadata:

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -60,7 +60,7 @@ class ExplorerChatRequest(TypedDict):
     reasoning_effort: NotRequired[str]
     is_interactive: NotRequired[bool]
     enable_coding: NotRequired[bool]
-    enable_code_mode_tools: NotRequired[bool]
+    enable_code_mode_tools: NotRequired[str]
     project_id: NotRequired[int]
     query_metadata: NotRequired[dict[str, str]]
     artifact_key: NotRequired[str]

--- a/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py
@@ -1,6 +1,9 @@
 from typing import Any
 from unittest.mock import ANY, MagicMock, patch
 
+import pytest
+
+from sentry.seer.endpoints.organization_seer_explorer_chat import SeerExplorerChatSerializer
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.utils import json
@@ -113,7 +116,7 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
             ANY,
             is_interactive=True,
             enable_coding=False,
-            enable_code_mode_tools=False,
+            enable_code_mode_tools="off",
             reasoning_effort="medium",
         )
         mock_client.start_run.assert_called_once_with(
@@ -150,7 +153,7 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
                 ANY,
                 is_interactive=True,
                 enable_coding=feature_enabled and option_enabled,
-                enable_code_mode_tools=False,
+                enable_code_mode_tools="off",
                 reasoning_effort="medium",
             )
 
@@ -173,7 +176,7 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
             ANY,
             is_interactive=True,
             enable_coding=False,
-            enable_code_mode_tools=False,
+            enable_code_mode_tools="off",
             reasoning_effort="medium",
         )
         mock_client.continue_run.assert_called_once_with(
@@ -206,7 +209,7 @@ class OrganizationSeerExplorerChatEndpointTest(APITestCase):
                 ANY,
                 is_interactive=True,
                 enable_coding=feature_enabled and option_enabled,
-                enable_code_mode_tools=False,
+                enable_code_mode_tools="off",
                 reasoning_effort="medium",
             )
 
@@ -398,3 +401,38 @@ class OrganizationSeerExplorerChatContextEngineTest(APITestCase):
         assert response.status_code == 200
         body = mock_chat_request.call_args[0][0]
         assert body.get("is_context_engine_enabled") is not False
+
+
+class TestCodeModeSerializerField:
+    """Test the override_code_mode_enable serializer field accepts all valid inputs."""
+
+    @pytest.mark.parametrize(
+        "input_val,expected",
+        [
+            ("off", "off"),
+            ("on", "on"),
+            ("only", "only"),
+            (True, "on"),
+            (False, "off"),
+            ("true", "on"),
+            ("false", "off"),
+            (None, None),
+        ],
+    )
+    def test_valid_values(self, input_val, expected):
+        data = {"query": "test", "override_code_mode_enable": input_val}
+        serializer = SeerExplorerChatSerializer(data=data)
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["override_code_mode_enable"] == expected
+
+    def test_omitted_defaults_to_none(self):
+        data = {"query": "test"}
+        serializer = SeerExplorerChatSerializer(data=data)
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data["override_code_mode_enable"] is None
+
+    def test_invalid_string_rejected(self):
+        data = {"query": "test", "override_code_mode_enable": "invalid"}
+        serializer = SeerExplorerChatSerializer(data=data)
+        assert not serializer.is_valid()
+        assert "override_code_mode_enable" in serializer.errors


### PR DESCRIPTION
## Summary

Backend-only change to accept 3-way code mode values in the Explorer chat serializer.

- Add custom `CodeModeField` that accepts `"off"`, `"on"`, `"only"` strings plus boolean backwards compat (`true`→`"on"`, `false`→`"off"`)
- Update `SeerExplorerClient` to pass the string value through to seer
- All existing boolean callers continue to work unchanged

Ships before the frontend PR which adds slash commands for toggling.

## Test plan

- [x] `pytest tests/sentry/seer/endpoints/test_organization_seer_explorer_chat.py -k TestCodeMode` — 10/10 passing
- [x] Backwards compat: `True`→`"on"`, `False`→`"off"`, `None`→`None` all validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)