### PR TITLE
chore(scraps): Export more Tanstack form helpers to enable composition

### DIFF
--- a/static/app/components/core/form/index.ts
+++ b/static/app/components/core/form/index.ts
@@ -2,7 +2,6 @@
 export {
   formOptions,
   useScrapsForm,
-  useTypedAppFormContext,
   defaultFormOptions,
   setFieldErrors,
   withFieldGroup,

--- a/static/app/components/core/form/index.ts
+++ b/static/app/components/core/form/index.ts
@@ -1,9 +1,12 @@
 /** @public */
 export {
+  formOptions,
   useScrapsForm,
+  useTypedAppFormContext,
   defaultFormOptions,
   setFieldErrors,
   withFieldGroup,
+  withForm,
 } from './scrapsForm';
 export {AutoSaveForm} from './autoSaveForm';
 export {FieldGroup} from './layout/fieldGroup';

--- a/static/app/components/core/form/scrapsForm.tsx
+++ b/static/app/components/core/form/scrapsForm.tsx
@@ -57,7 +57,7 @@ const fieldComponents = {
 
 export type BoundFieldComponents = typeof fieldComponents;
 
-const {useAppForm, withFieldGroup} = createFormHook({
+const {useAppForm, useTypedAppFormContext, withFieldGroup, withForm} = createFormHook({
   fieldComponents,
   formComponents: {
     FieldGroup,
@@ -113,7 +113,8 @@ function FormWrapper({children}: {children: React.ReactNode}) {
 }
 
 export const useScrapsForm = useAppForm;
-export {withFieldGroup};
+/** @public */
+export {formOptions, useTypedAppFormContext, withFieldGroup, withForm};
 
 /**
  * Type for field errors that can be set after form submission (e.g., from backend validation).

--- a/static/app/components/core/form/scrapsForm.tsx
+++ b/static/app/components/core/form/scrapsForm.tsx
@@ -57,7 +57,7 @@ const fieldComponents = {
 
 export type BoundFieldComponents = typeof fieldComponents;
 
-const {useAppForm, useTypedAppFormContext, withFieldGroup, withForm} = createFormHook({
+const {useAppForm, withFieldGroup, withForm} = createFormHook({
   fieldComponents,
   formComponents: {
     FieldGroup,
@@ -114,7 +114,7 @@ function FormWrapper({children}: {children: React.ReactNode}) {
 
 export const useScrapsForm = useAppForm;
 /** @public */
-export {formOptions, useTypedAppFormContext, withFieldGroup, withForm};
+export {formOptions, withFieldGroup, withForm};
 
 /**
  * Type for field errors that can be set after form submission (e.g., from backend validation).


### PR DESCRIPTION
These are necessary for breaking up large forms

https://tanstack.com/form/v1/docs/framework/react/guides/form-composition#breaking-big-forms-into-smaller-pieces