### PR TITLE
feat(claude-code): Persist vault per GitHub installation to prevent vault leak

### DIFF
--- a/src/sentry/integrations/claude_code/integration.py
+++ b/src/sentry/integrations/claude_code/integration.py
@@ -33,7 +33,9 @@ from sentry.integrations.coding_agent.models import CodingAgentLaunchRequest
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.pipeline import IntegrationPipeline
+from sentry.integrations.services.integration import integration_service
 from sentry.integrations.services.integration.model import RpcIntegration
+from sentry.locks import locks
 from sentry.pipeline.types import PipelineStepResult
 from sentry.pipeline.views.base import ApiPipelineSteps
 from sentry.seer.autofix.utils import CodingAgentState
@@ -46,6 +48,7 @@ PROVIDER_KEY = "claude_code"
 PROVIDER_NAME = "Claude Agent"
 DESCRIPTION = "Connect your Sentry organization with Claude Agent."
 DEFAULT_ENVIRONMENT_NAME = "sentry-autofix-agents"
+VAULT_METADATA_LOCK_DURATION_S = 10
 
 
 def _get_client_class() -> type[Any]:
@@ -82,6 +85,8 @@ class ClaudeCodeIntegrationMetadata(BaseModel):
     agent_id: str | None = None
     agent_version: int | None = None
     model: str | None = None
+    # One vault per github installation so concurrent launches don't clobber each other's credentials.
+    installation_vault_ids: dict[str, str] = {}
 
     @validator("agent_version", pre=True)
     def coerce_agent_version(cls, v: object) -> int | None:
@@ -302,6 +307,40 @@ class ClaudeCodeAgentIntegration(CodingAgentIntegration):
         """Parse and return the integration metadata."""
         return ClaudeCodeIntegrationMetadata.parse_obj(self.model.metadata or {})
 
+    def _vault_metadata_lock(self):
+        return locks.get(
+            f"claude_code:vault:{self.model.id}",
+            duration=VAULT_METADATA_LOCK_DURATION_S,
+            name="claude_code_vault_metadata",
+        )
+
+    def _read_fresh_metadata(self) -> ClaudeCodeIntegrationMetadata | None:
+        fresh = integration_service.get_integration(integration_id=self.model.id)
+        if fresh is None:
+            return None
+        return ClaudeCodeIntegrationMetadata.parse_obj(fresh.metadata or {})
+
+    def get_vault_id_for_installation(self, installation_id: int) -> str | None:
+        return self._get_metadata().installation_vault_ids.get(str(installation_id))
+
+    def set_vault_id_for_installation(self, installation_id: int, vault_id: str) -> None:
+        with self._vault_metadata_lock().acquire():
+            metadata = self._read_fresh_metadata()
+            if metadata is None:
+                return
+            metadata.installation_vault_ids[str(installation_id)] = vault_id
+            self._persist_metadata(metadata)
+
+    def pop_vault_id_for_installation(self, installation_id: int) -> str | None:
+        with self._vault_metadata_lock().acquire():
+            metadata = self._read_fresh_metadata()
+            if metadata is None:
+                return None
+            vault_id = metadata.installation_vault_ids.pop(str(installation_id), None)
+            if vault_id is not None:
+                self._persist_metadata(metadata)
+            return vault_id
+
     def update_organization_config(self, data: MutableMapping[str, Any]) -> None:
         metadata = self._get_metadata()
 
@@ -331,7 +370,31 @@ class ClaudeCodeAgentIntegration(CodingAgentIntegration):
             agent_id=metadata.agent_id,
             agent_version=metadata.agent_version,
             model=metadata.model,
+            installation_vault_lookup=self.get_vault_id_for_installation,
+            installation_vault_writer=self.set_vault_id_for_installation,
         )
+
+    def uninstall(self) -> None:
+        metadata = self._get_metadata()
+        if not metadata.installation_vault_ids:
+            return
+
+        client = self.get_client()
+        for vault_id in list(metadata.installation_vault_ids.values()):
+            try:
+                client.archive_vault(vault_id)
+            except Exception:
+                logger.exception(
+                    "claude_code.uninstall.archive_vault_failed",
+                    extra={"vault_id": vault_id, "integration_id": self.model.id},
+                )
+
+        with self._vault_metadata_lock().acquire():
+            fresh = self._read_fresh_metadata()
+            if fresh is None:
+                return
+            fresh.installation_vault_ids = {}
+            self._persist_metadata(fresh)
 
     def launch(self, request: CodingAgentLaunchRequest) -> CodingAgentState:
         """Launch coding agent and persist resolved environment/agent IDs."""

--- a/tests/sentry/integrations/claude_code/test_integration.py
+++ b/tests/sentry/integrations/claude_code/test_integration.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import hashlib
 from collections.abc import Mapping
 from typing import Any, cast
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 from django.urls import reverse
@@ -234,7 +234,12 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
             agent_id=None,
             agent_version=None,
             model=None,
+            installation_vault_lookup=ANY,
+            installation_vault_writer=ANY,
         )
+        passed = mock_cls.call_args.kwargs
+        assert passed["installation_vault_lookup"] == installation.get_vault_id_for_installation
+        assert passed["installation_vault_writer"] == installation.set_vault_id_for_installation
 
     def test_get_client_with_environment_and_workspace(self) -> None:
         mock_cls, mock_client = _mock_client_class()
@@ -262,6 +267,8 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
             agent_id="agent-123",
             agent_version=1,
             model=None,
+            installation_vault_lookup=ANY,
+            installation_vault_writer=ANY,
         )
 
     def test_get_client_passes_model_from_metadata(self) -> None:
@@ -284,6 +291,8 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
             agent_id=None,
             agent_version=None,
             model="claude-sonnet-4-6",
+            installation_vault_lookup=ANY,
+            installation_vault_writer=ANY,
         )
 
     def test_get_client_passes_none_model_when_metadata_has_none(self) -> None:
@@ -306,6 +315,8 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
             agent_id=None,
             agent_version=None,
             model=None,
+            installation_vault_lookup=ANY,
+            installation_vault_writer=ANY,
         )
 
     def test_get_client_class_not_configured(self) -> None:
@@ -412,6 +423,112 @@ class ClaudeCodeIntegrationTest(IntegrationTestCase):
         assert "workspace_is_default" in fields
         assert fields["workspace_is_default"]["type"] == "boolean"
         assert "workspace_name" not in fields
+
+    # ── installation_vault_ids helpers ───────────────────────────────
+
+    def test_installation_vault_ids_default_empty(self) -> None:
+        installation = self._create_installation()
+        assert installation.get_vault_id_for_installation(42) is None
+
+    def test_installation_vault_ids_round_trip(self) -> None:
+        installation = self._create_installation(
+            installation_vault_ids={"42": "vault_pre"},
+        )
+        assert installation.get_vault_id_for_installation(42) == "vault_pre"
+
+    def test_set_vault_id_for_installation_writes_metadata(self) -> None:
+        installation = self._create_installation()
+
+        installation.set_vault_id_for_installation(42, "vault_abc")
+
+        assert installation.get_vault_id_for_installation(42) == "vault_abc"
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            integration = Integration.objects.get(id=installation.model.id)
+        assert integration.metadata["installation_vault_ids"] == {"42": "vault_abc"}
+
+    def test_set_vault_id_for_installation_merges_concurrent_writer(self) -> None:
+        installation = self._create_installation()
+
+        original_read = installation._read_fresh_metadata
+
+        def read_with_concurrent_writer():
+            with assume_test_silo_mode(SiloMode.CONTROL):
+                Integration.objects.filter(id=installation.model.id).update(
+                    metadata={
+                        **installation.model.metadata,
+                        "installation_vault_ids": {"99": "vault_other"},
+                    }
+                )
+            return original_read()
+
+        with patch.object(
+            installation, "_read_fresh_metadata", side_effect=read_with_concurrent_writer
+        ):
+            installation.set_vault_id_for_installation(42, "vault_mine")
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            integration = Integration.objects.get(id=installation.model.id)
+        assert integration.metadata["installation_vault_ids"] == {
+            "99": "vault_other",
+            "42": "vault_mine",
+        }
+
+    def test_pop_vault_id_for_installation_removes_and_returns(self) -> None:
+        installation = self._create_installation(
+            installation_vault_ids={"42": "vault_abc", "7": "vault_xyz"},
+        )
+
+        popped = installation.pop_vault_id_for_installation(42)
+
+        assert popped == "vault_abc"
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            integration = Integration.objects.get(id=installation.model.id)
+        assert integration.metadata["installation_vault_ids"] == {"7": "vault_xyz"}
+
+    def test_pop_vault_id_for_installation_missing_returns_none(self) -> None:
+        installation = self._create_installation()
+
+        assert installation.pop_vault_id_for_installation(42) is None
+
+    # ── uninstall ────────────────────────────────────────────────────
+
+    def test_uninstall_archives_each_vault_and_clears_metadata(self) -> None:
+        installation = self._create_installation(
+            installation_vault_ids={"42": "vault_a", "7": "vault_b"},
+        )
+        mock_cls, mock_client = _mock_client_class()
+
+        with patch(MOCK_GET_CLIENT_CLASS, return_value=mock_cls):
+            installation.uninstall()
+
+        archive_calls = [c.args[0] for c in mock_client.archive_vault.call_args_list]
+        assert sorted(archive_calls) == ["vault_a", "vault_b"]
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            integration = Integration.objects.get(id=installation.model.id)
+        assert integration.metadata["installation_vault_ids"] == {}
+
+    def test_uninstall_no_vaults_is_a_noop(self) -> None:
+        installation = self._create_installation()
+        mock_cls, mock_client = _mock_client_class()
+
+        with patch(MOCK_GET_CLIENT_CLASS, return_value=mock_cls):
+            installation.uninstall()
+
+        mock_client.archive_vault.assert_not_called()
+
+    def test_uninstall_clears_metadata_even_when_archive_fails(self) -> None:
+        installation = self._create_installation(
+            installation_vault_ids={"42": "vault_a"},
+        )
+        mock_cls, mock_client = _mock_client_class()
+        mock_client.archive_vault.side_effect = RuntimeError("anthropic api blew up")
+
+        with patch(MOCK_GET_CLIENT_CLASS, return_value=mock_cls):
+            installation.uninstall()
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            integration = Integration.objects.get(id=installation.model.id)
+        assert integration.metadata["installation_vault_ids"] == {}
 
     # ── launch ───────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Each Claude Code session launch previously created a new Anthropic vault that was never reused or archived, causing vault leak
- Stores one vault ID per GitHub installation in integration metadata (`installation_vault_ids` dict keyed by installation ID)
- Uses a distributed lock (`locks.get`) for concurrent-safe metadata writes
- Exposes `get_vault_id_for_installation` / `set_vault_id_for_installation` lookup/write callbacks to the client layer so getsentry can reuse existing vaults and rotate credentials in place
- Archives all vaults on `uninstall()` and clears metadata

**Companion PR in getsentry**: client-side vault reuse + credential rotation (incoming)

AIML-2775

## Test plan
- [x] 9 new tests + 4 updated tests in `tests/sentry/integrations/claude_code/test_integration.py`
- [x] Verified existing `test_autofix_agent.py` tests still pass (39/39)
- [x] Full claude_code integration test suite passes (47/47)

🤖 Generated with [Claude Code](https://claude.com/claude-code)