### PR TITLE
feat(seer): Log successful Slack agent triggers with referrer

### DIFF
--- a/src/sentry/seer/entrypoints/slack/tasks.py
+++ b/src/sentry/seer/entrypoints/slack/tasks.py
@@ -201,15 +201,12 @@ def process_mention_for_slack(
             extra={
                 "referrer": SeerEntrypointKey.SLACK,
                 "organization_id": organization.id,
-                "user_id": user.id,
+                "user_email": user.email,
                 "integration_id": integration_id,
                 "run_id": run_id,
                 "thread_ts": thread_ts or ts,
                 "channel_id": channel_id,
                 "slack_user_id": slack_user_id,
-                "prompt_length": len(prompt),
-                "messages_in_thread": max(len(messages), 1),
-                "conversation_type": conversation_type.value,
             },
         )
 

--- a/src/sentry/seer/entrypoints/slack/tasks.py
+++ b/src/sentry/seer/entrypoints/slack/tasks.py
@@ -207,6 +207,7 @@ def process_mention_for_slack(
                 "thread_ts": thread_ts or ts,
                 "channel_id": channel_id,
                 "slack_user_id": slack_user_id,
+                "conversation_type": conversation_type,
             },
         )
 

--- a/src/sentry/seer/entrypoints/slack/tasks.py
+++ b/src/sentry/seer/entrypoints/slack/tasks.py
@@ -26,7 +26,7 @@ from sentry.seer.entrypoints.slack.metrics import (
     ProcessMentionFailureReason,
     ProcessMentionHaltReason,
 )
-from sentry.seer.entrypoints.types import AgentReferrer
+from sentry.seer.entrypoints.types import SeerEntrypointKey
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import integrations_tasks
 from sentry.users.services.user import RpcUser
@@ -199,7 +199,7 @@ def process_mention_for_slack(
         _logger.info(
             "seer.slack.process_mention.success",
             extra={
-                "referrer": AgentReferrer.SLACK.value,
+                "referrer": SeerEntrypointKey.SLACK,
                 "organization_id": organization.id,
                 "user_id": user.id,
                 "integration_id": integration_id,

--- a/src/sentry/seer/entrypoints/slack/tasks.py
+++ b/src/sentry/seer/entrypoints/slack/tasks.py
@@ -201,7 +201,7 @@ def process_mention_for_slack(
             extra={
                 "referrer": SeerEntrypointKey.SLACK,
                 "organization_id": organization.id,
-                "user_email": user.email,
+                "user_id": user.id,
                 "integration_id": integration_id,
                 "run_id": run_id,
                 "thread_ts": thread_ts or ts,

--- a/src/sentry/seer/entrypoints/slack/tasks.py
+++ b/src/sentry/seer/entrypoints/slack/tasks.py
@@ -26,6 +26,7 @@ from sentry.seer.entrypoints.slack.metrics import (
     ProcessMentionFailureReason,
     ProcessMentionHaltReason,
 )
+from sentry.seer.entrypoints.types import AgentReferrer
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import integrations_tasks
 from sentry.users.services.user import RpcUser
@@ -194,6 +195,23 @@ def process_mention_for_slack(
             analytics.record(analytics_event)
         except Exception as e:
             _logger.warning("seer.slack.process_mention.analytics_failed", exc_info=e)
+
+        _logger.info(
+            "seer.slack.process_mention.success",
+            extra={
+                "referrer": AgentReferrer.SLACK.value,
+                "organization_id": organization.id,
+                "user_id": user.id,
+                "integration_id": integration_id,
+                "run_id": run_id,
+                "thread_ts": thread_ts or ts,
+                "channel_id": channel_id,
+                "slack_user_id": slack_user_id,
+                "prompt_length": len(prompt),
+                "messages_in_thread": max(len(messages), 1),
+                "conversation_type": conversation_type.value,
+            },
+        )
 
 
 def _resolve_user(

--- a/src/sentry/seer/entrypoints/types.py
+++ b/src/sentry/seer/entrypoints/types.py
@@ -9,6 +9,18 @@ class SeerEntrypointKey(StrEnum):
     SLACK = "slack"
 
 
+class AgentReferrer(StrEnum):
+    """
+    Identifies the surface that triggered a Seer Agent run.
+
+    Parallels ``AutofixReferrer`` (sentry.seer.autofix.constants) but for the
+    agent trigger path rather than the autofix step path.
+    """
+
+    SLACK = "slack"
+    UNKNOWN = "unknown"
+
+
 class SeerAutofixEntrypoint[CachePayloadT](Protocol):
     """
     Protocol for entrypoints that support autofix workflows.

--- a/src/sentry/seer/entrypoints/types.py
+++ b/src/sentry/seer/entrypoints/types.py
@@ -9,18 +9,6 @@ class SeerEntrypointKey(StrEnum):
     SLACK = "slack"
 
 
-class AgentReferrer(StrEnum):
-    """
-    Identifies the surface that triggered a Seer Agent run.
-
-    Parallels ``AutofixReferrer`` (sentry.seer.autofix.constants) but for the
-    agent trigger path rather than the autofix step path.
-    """
-
-    SLACK = "slack"
-    UNKNOWN = "unknown"
-
-
 class SeerAutofixEntrypoint[CachePayloadT](Protocol):
     """
     Protocol for entrypoints that support autofix workflows.


### PR DESCRIPTION
Adds a structured info log (`seer.slack.process_mention.success`) at the end of `process_mention_for_slack` so successful Slack-triggered Seer agent runs can be grepped by `run_id`, `org_id`, etc. — previously success was only signaled by metrics and analytics events.

Completes ISWF-2562 and ISWF-2563.