### PR TITLE
ref(dashboards): Add MOVE_TO_PENDING migration for DashboardTombstone

### DIFF
--- a/migrations_lockfile.txt
+++ b/migrations_lockfile.txt
@@ -31,7 +31,7 @@ replays: 0007_organizationmember_replay_access
 
 seer: 0008_add_seer_run_models
 
-sentry: 1073_add_org_ci_scope
+sentry: 1074_remove_dashboardtombstone
 
 social_auth: 0003_social_auth_json_field
 

--- a/src/sentry/migrations/1074_remove_dashboardtombstone.py
+++ b/src/sentry/migrations/1074_remove_dashboardtombstone.py
@@ -1,0 +1,31 @@
+import django.db.models.deletion
+import sentry.db.models.fields.foreignkey
+from django.db import migrations
+
+from sentry.new_migrations.migrations import CheckedMigration
+from sentry.new_migrations.monkey.models import SafeDeleteModel
+from sentry.new_migrations.monkey.state import DeletionAction
+
+
+class Migration(CheckedMigration):
+    is_post_deployment = False
+
+    dependencies = [
+        ("sentry", "1073_add_org_ci_scope"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="dashboardtombstone",
+            name="organization",
+            field=sentry.db.models.fields.foreignkey.FlexibleForeignKey(
+                db_constraint=False,
+                on_delete=django.db.models.deletion.CASCADE,
+                to="sentry.organization",
+            ),
+        ),
+        SafeDeleteModel(
+            name="DashboardTombstone",
+            deletion_action=DeletionAction.MOVE_TO_PENDING,
+        ),
+    ]


### PR DESCRIPTION
Add a migration that drops the FK constraint on `DashboardTombstone.organization`
and moves the model to pending deletion state via `SafeDeleteModel(MOVE_TO_PENDING)`.

This removes the model from Django's migration state but leaves the
`sentry_dashboardtombstone` table in place for rolling deploy safety.

## PR Stack
1. #114265 — Remove model class and code references
2. **#114266 ← this PR** — `MOVE_TO_PENDING` migration (deploy after #114265)
3. #114267 — `DELETE` migration (deploy after this PR)

Refs DAIN-1567