### PR TITLE
feat(explorer): Add back /resume slash command

### DIFF
--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
@@ -183,6 +183,8 @@ export function ExplorerDrawerContent({
     }
   }, [openFeedbackForm, runId]);
 
+  const handleResume = useCallback(() => setIsHistoryDropdownOpen(true), []);
+
   // - Pop-up menu component --------------------------------------------------
 
   // Extract repo_pr_states from session
@@ -207,7 +209,7 @@ export function ExplorerDrawerContent({
     panelSize: 'max',
     slashCommandHandlers: {
       onNew: startNewSession,
-      onResume: () => setIsHistoryDropdownOpen(true),
+      onResume: handleResume,
       onFeedback: openFeedbackForm ? handleFeedback : undefined,
       onLangfuse: langfuseUrl ? handleOpenLangfuse : undefined,
       onConversations: conversationsUrl ? handleOpenConversations : undefined,

--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
@@ -331,7 +331,7 @@ export function ExplorerDrawerContent({
         onCopySessionClick={copySessionEnabled ? copySessionToClipboard : undefined}
         onCopyLinkClick={runId === null ? undefined : handleCopyLink}
         isHistoryDropdownOpen={isHistoryDropdownOpen}
-        onHistoryDropdownOpenChange={setIsHistoryDropdownOpen}
+        setIsHistoryDropdownOpen={setIsHistoryDropdownOpen}
         overrideCtxEngEnable={overrideCtxEngEnable}
         onOverrideCtxEngEnableToggle={() => setOverrideCtxEngEnable(v => !v)}
         showContextEngineToggle={

--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
@@ -44,6 +44,7 @@ export function ExplorerDrawerContent({
 
   const [inputValue, setInputValue] = useState('');
   const [showThinking, setShowThinking] = useState(false);
+  const [isHistoryDropdownOpen, setIsHistoryDropdownOpen] = useState(false);
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -206,6 +207,7 @@ export function ExplorerDrawerContent({
     panelSize: 'max',
     slashCommandHandlers: {
       onNew: startNewSession,
+      onResume: () => setIsHistoryDropdownOpen(true),
       onFeedback: openFeedbackForm ? handleFeedback : undefined,
       onLangfuse: langfuseUrl ? handleOpenLangfuse : undefined,
       onConversations: conversationsUrl ? handleOpenConversations : undefined,
@@ -328,6 +330,8 @@ export function ExplorerDrawerContent({
         isEmptyState={isEmptyState}
         onCopySessionClick={copySessionEnabled ? copySessionToClipboard : undefined}
         onCopyLinkClick={runId === null ? undefined : handleCopyLink}
+        isHistoryDropdownOpen={isHistoryDropdownOpen}
+        onHistoryDropdownOpenChange={setIsHistoryDropdownOpen}
         overrideCtxEngEnable={overrideCtxEngEnable}
         onOverrideCtxEngEnableToggle={() => setOverrideCtxEngEnable(v => !v)}
         showContextEngineToggle={

--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerHeader.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerHeader.tsx
@@ -19,21 +19,21 @@ import {isSeerExplorerEnabled} from 'sentry/views/seerExplorer/utils';
 
 interface ExplorerDrawerHeaderProps {
   isEmptyState: boolean;
+  isHistoryDropdownOpen: boolean;
   onChangeSession: (runId: number) => void;
   onCopyLinkClick: (() => void) | undefined;
   onCopySessionClick: (() => void) | undefined;
-  onHistoryDropdownOpenChange: (isOpen: boolean) => void;
   onNewChatClick: () => void;
   onOverrideCodeModeEnableToggle: () => void;
   onOverrideCtxEngEnableToggle: () => void;
   onShowThinkingToggle: () => void;
   overrideCodeModeEnable: boolean;
   overrideCtxEngEnable: boolean;
+  setIsHistoryDropdownOpen: (isOpen: boolean) => void;
   showCodeModeToggle: boolean;
   showContextEngineToggle: boolean;
   showThinking: boolean;
   showThinkingToggle: boolean;
-  isHistoryDropdownOpen?: boolean;
 }
 
 export function ExplorerDrawerHeader({
@@ -52,7 +52,7 @@ export function ExplorerDrawerHeader({
   showThinkingToggle,
   onShowThinkingToggle,
   isHistoryDropdownOpen,
-  onHistoryDropdownOpenChange,
+  setIsHistoryDropdownOpen,
 }: ExplorerDrawerHeaderProps) {
   // Session history query
   const {
@@ -66,12 +66,12 @@ export function ExplorerDrawerHeader({
 
   const onHistoryOpenChange = useCallback(
     (isOpen: boolean) => {
-      onHistoryDropdownOpenChange(isOpen);
+      setIsHistoryDropdownOpen(isOpen);
       if (isOpen) {
         refetchSessionHistory();
       }
     },
-    [onHistoryDropdownOpenChange, refetchSessionHistory]
+    [setIsHistoryDropdownOpen, refetchSessionHistory]
   );
 
   // Session history menu items

--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerHeader.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerHeader.tsx
@@ -22,6 +22,7 @@ interface ExplorerDrawerHeaderProps {
   onChangeSession: (runId: number) => void;
   onCopyLinkClick: (() => void) | undefined;
   onCopySessionClick: (() => void) | undefined;
+  onHistoryDropdownOpenChange: (isOpen: boolean) => void;
   onNewChatClick: () => void;
   onOverrideCodeModeEnableToggle: () => void;
   onOverrideCtxEngEnableToggle: () => void;
@@ -32,6 +33,7 @@ interface ExplorerDrawerHeaderProps {
   showContextEngineToggle: boolean;
   showThinking: boolean;
   showThinkingToggle: boolean;
+  isHistoryDropdownOpen?: boolean;
 }
 
 export function ExplorerDrawerHeader({
@@ -49,6 +51,8 @@ export function ExplorerDrawerHeader({
   showThinking,
   showThinkingToggle,
   onShowThinkingToggle,
+  isHistoryDropdownOpen,
+  onHistoryDropdownOpenChange,
 }: ExplorerDrawerHeaderProps) {
   // Session history query
   const {
@@ -62,11 +66,12 @@ export function ExplorerDrawerHeader({
 
   const onHistoryOpenChange = useCallback(
     (isOpen: boolean) => {
+      onHistoryDropdownOpenChange(isOpen);
       if (isOpen) {
         refetchSessionHistory();
       }
     },
-    [refetchSessionHistory]
+    [onHistoryDropdownOpenChange, refetchSessionHistory]
   );
 
   // Session history menu items
@@ -199,6 +204,7 @@ export function ExplorerDrawerHeader({
           items={sessionMenuItems}
           size="xs"
           position="bottom-end"
+          isOpen={isHistoryDropdownOpen}
           onOpenChange={onHistoryOpenChange}
           triggerProps={{
             'aria-label': t('Chat history'),

--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerHeader.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerHeader.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useMemo} from 'react';
+import {useCallback, useEffect, useMemo} from 'react';
 import moment from 'moment-timezone';
 
 import {FeatureBadge} from '@sentry/scraps/badge';
@@ -64,14 +64,17 @@ export function ExplorerDrawerHeader({
     onChangeSession,
   });
 
+  useEffect(() => {
+    if (isHistoryDropdownOpen) {
+      refetchSessionHistory();
+    }
+  }, [isHistoryDropdownOpen, refetchSessionHistory]);
+
   const onHistoryOpenChange = useCallback(
     (isOpen: boolean) => {
       setIsHistoryDropdownOpen(isOpen);
-      if (isOpen) {
-        refetchSessionHistory();
-      }
     },
-    [setIsHistoryDropdownOpen, refetchSessionHistory]
+    [setIsHistoryDropdownOpen]
   );
 
   // Session history menu items

--- a/static/app/views/seerExplorer/components/explorerMenu.tsx
+++ b/static/app/views/seerExplorer/components/explorerMenu.tsx
@@ -12,6 +12,7 @@ interface SlashCommandHandlers {
   onLangfuse?: () => void;
   onMaxSize?: () => void;
   onMedSize?: () => void;
+  onResume?: () => void;
 }
 
 interface ExplorerMenuProps {
@@ -287,6 +288,7 @@ function useSlashCommands({
   onFeedback,
   onLangfuse,
   onConversations,
+  onResume,
 }: SlashCommandHandlers): MenuItemProps[] {
   const isSentryEmployee = useIsSentryEmployee();
 
@@ -298,6 +300,16 @@ function useSlashCommands({
         description: 'Start a new session',
         handler: onNew,
       },
+      ...(onResume
+        ? [
+            {
+              title: '/resume',
+              key: '/resume',
+              description: 'Resume a previous session',
+              handler: onResume,
+            },
+          ]
+        : []),
       ...(onMaxSize
         ? [
             {
@@ -351,6 +363,7 @@ function useSlashCommands({
     ],
     [
       onNew,
+      onResume,
       onMaxSize,
       onMedSize,
       onFeedback,

--- a/static/app/views/seerExplorer/components/explorerMenu.tsx
+++ b/static/app/views/seerExplorer/components/explorerMenu.tsx
@@ -10,8 +10,6 @@ interface SlashCommandHandlers {
   onNew: () => void;
   onConversations?: () => void;
   onLangfuse?: () => void;
-  onMaxSize?: () => void;
-  onMedSize?: () => void;
   onResume?: () => void;
 }
 
@@ -282,8 +280,6 @@ export function useExplorerMenu({
 }
 
 function useSlashCommands({
-  onMaxSize,
-  onMedSize,
   onNew,
   onFeedback,
   onLangfuse,
@@ -307,26 +303,6 @@ function useSlashCommands({
               key: '/resume',
               description: 'Resume a previous session',
               handler: onResume,
-            },
-          ]
-        : []),
-      ...(onMaxSize
-        ? [
-            {
-              title: '/max-size',
-              key: '/max-size',
-              description: 'Expand panel to full viewport height',
-              handler: onMaxSize,
-            },
-          ]
-        : []),
-      ...(onMedSize
-        ? [
-            {
-              title: '/med-size',
-              key: '/med-size',
-              description: 'Set panel to medium size (default)',
-              handler: onMedSize,
             },
           ]
         : []),
@@ -361,16 +337,7 @@ function useSlashCommands({
           ]
         : []),
     ],
-    [
-      onNew,
-      onResume,
-      onMaxSize,
-      onMedSize,
-      onFeedback,
-      onLangfuse,
-      onConversations,
-      isSentryEmployee,
-    ]
+    [onNew, onResume, onFeedback, onLangfuse, onConversations, isSentryEmployee]
   );
 }
 


### PR DESCRIPTION
## Summary

- Adds a `/resume` slash command to the Seer Explorer input that opens the chat history dropdown, allowing keyboard-driven session resumption
- Lifts `isHistoryDropdownOpen` state into `ExplorerDrawerContent` and passes it to `ExplorerDrawerHeader` as controlled `isOpen`/`onOpenChange` props on the `DropdownMenu`
- Hooks the `/resume` command handler to `setIsHistoryDropdownOpen(true)` via a new `onResume` callback in `SlashCommandHandlers`


**TODO**
I can't figure out a way to focus the first item when opening through /resume. Always focuses the last item which is annoying for keyboard nav, to start from the oldest session. The whole point of the command is for keyboard nav convenience - If no one has quick fixes for this I'm ok to not support this