### PR TITLE
perf(snapshots): Buffer image swap to eliminate flash during single-view navigation

### DIFF
--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -10,6 +10,7 @@ import {ContentSliderDiff} from 'sentry/components/contentSliderDiff';
 import {t} from 'sentry/locale';
 import type {SnapshotDiffPair} from 'sentry/views/preprod/types/snapshotTypes';
 
+import {useBufferedImageUrl} from './useBufferedImageUrl';
 import {useSyncedD3Zoom} from './useD3Zoom';
 import {
   ZoomableArea,
@@ -88,6 +89,8 @@ function SplitView({
 }: SplitViewProps) {
   const [zoom1, zoom2] = useSyncedD3Zoom();
   const showOverlay = diffMaskUrl && overlayColor !== TRANSPARENT_COLOR;
+  const displayBaseUrl = useBufferedImageUrl(baseImageUrl);
+  const displayHeadUrl = useBufferedImageUrl(headImageUrl);
   return (
     <Grid columns="repeat(2, 1fr)" gap="xl" flex="1" minHeight="0">
       <Flex direction="column" gap="sm" minHeight="0">
@@ -101,7 +104,12 @@ function SplitView({
               height="100%"
               style={zoomTransformStyle(zoom1.transform)}
             >
-              <ZoomableImage src={baseImageUrl} alt={t('Base')} />
+              <ZoomableImage
+                src={displayBaseUrl}
+                alt={t('Base')}
+                loading="eager"
+                decoding="async"
+              />
             </Flex>
           </ZoomContainer>
         </ZoomableArea>
@@ -119,7 +127,12 @@ function SplitView({
               style={zoomTransformStyle(zoom2.transform)}
             >
               <ImageWrapper>
-                <ZoomableImage src={headImageUrl} alt={t('Current Branch')} />
+                <ZoomableImage
+                  src={displayHeadUrl}
+                  alt={t('Current Branch')}
+                  loading="eager"
+                  decoding="async"
+                />
                 {showOverlay && (
                   <DiffOverlay $overlayColor={overlayColor} $maskUrl={diffMaskUrl} />
                 )}
@@ -144,17 +157,29 @@ function WipeView({
   baseImageUrl: string;
   headImageUrl: string;
 }) {
+  const displayBaseUrl = useBufferedImageUrl(baseImageUrl);
+  const displayHeadUrl = useBufferedImageUrl(headImageUrl);
   return (
     <Flex flex="1" minHeight="0">
       <ContentSliderDiff.Body
         before={
           <Flex justify="center" align="center" height="100%">
-            <ConstrainedImage src={baseImageUrl} alt={t('Base')} />
+            <ConstrainedImage
+              src={displayBaseUrl}
+              alt={t('Base')}
+              loading="eager"
+              decoding="async"
+            />
           </Flex>
         }
         after={
           <Flex justify="center" align="center" height="100%">
-            <ConstrainedImage src={headImageUrl} alt={t('Current Branch')} />
+            <ConstrainedImage
+              src={displayHeadUrl}
+              alt={t('Current Branch')}
+              loading="eager"
+              decoding="async"
+            />
           </Flex>
         }
         minHeight="200px"
@@ -174,6 +199,8 @@ function OnionView({
   onOpacityChange: (value: number) => void;
   opacity: number;
 }) {
+  const displayBaseUrl = useBufferedImageUrl(baseImageUrl);
+  const displayHeadUrl = useBufferedImageUrl(headImageUrl);
   return (
     <Flex
       direction="column"
@@ -191,9 +218,19 @@ function OnionView({
         background="secondary"
       >
         <OnionContainer>
-          <ConstrainedImage src={baseImageUrl} alt={t('Base')} />
+          <ConstrainedImage
+            src={displayBaseUrl}
+            alt={t('Base')}
+            loading="eager"
+            decoding="async"
+          />
           <OnionOverlayLayer style={{opacity: opacity / 100}}>
-            <ConstrainedImage src={headImageUrl} alt={t('Current Branch')} />
+            <ConstrainedImage
+              src={displayHeadUrl}
+              alt={t('Current Branch')}
+              loading="eager"
+              decoding="async"
+            />
           </OnionOverlayLayer>
         </OnionContainer>
       </Flex>

--- a/static/app/views/preprod/snapshots/main/imageDisplay/singleImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/singleImageDisplay.tsx
@@ -1,5 +1,6 @@
 import {Flex} from '@sentry/scraps/layout';
 
+import {useBufferedImageUrl} from './useBufferedImageUrl';
 import {useD3Zoom} from './useD3Zoom';
 import {
   ZoomableArea,
@@ -16,6 +17,7 @@ interface SingleImageDisplayProps {
 
 export function SingleImageDisplay({imageUrl, alt}: SingleImageDisplayProps) {
   const {containerRef, transform, zoomIn, zoomOut, resetZoom} = useD3Zoom();
+  const displayUrl = useBufferedImageUrl(imageUrl);
 
   return (
     <Flex align="center" justify="center" flex="1" minHeight="0" padding="3xl">
@@ -28,7 +30,7 @@ export function SingleImageDisplay({imageUrl, alt}: SingleImageDisplayProps) {
             height="100%"
             style={zoomTransformStyle(transform)}
           >
-            <ZoomableImage src={imageUrl} alt={alt} />
+            <ZoomableImage src={displayUrl} alt={alt} loading="eager" decoding="async" />
           </Flex>
         </ZoomContainer>
         <ZoomControls onZoomIn={zoomIn} onZoomOut={zoomOut} onReset={resetZoom} />

--- a/static/app/views/preprod/snapshots/main/imageDisplay/useBufferedImageUrl.ts
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/useBufferedImageUrl.ts
@@ -12,12 +12,15 @@ export function useBufferedImageUrl(targetUrl: string): string {
     let cancelled = false;
     const img = new Image();
     img.src = targetUrl;
-    img.decode().finally(() => {
-      if (!cancelled) {
-        activeUrlRef.current = targetUrl;
-        setDisplayUrl(targetUrl);
-      }
-    });
+    img
+      .decode()
+      .catch(() => undefined)
+      .then(() => {
+        if (!cancelled) {
+          activeUrlRef.current = targetUrl;
+          setDisplayUrl(targetUrl);
+        }
+      });
 
     return () => {
       cancelled = true;

--- a/static/app/views/preprod/snapshots/main/imageDisplay/useBufferedImageUrl.ts
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/useBufferedImageUrl.ts
@@ -1,0 +1,29 @@
+import {useEffect, useRef, useState} from 'react';
+
+export function useBufferedImageUrl(targetUrl: string): string {
+  const [displayUrl, setDisplayUrl] = useState(targetUrl);
+  const activeUrlRef = useRef(targetUrl);
+
+  useEffect(() => {
+    if (targetUrl === activeUrlRef.current) {
+      return undefined;
+    }
+
+    let cancelled = false;
+    const img = new Image();
+    img.src = targetUrl;
+    img.decode().finally(() => {
+      if (!cancelled) {
+        activeUrlRef.current = targetUrl;
+        setDisplayUrl(targetUrl);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      img.src = '';
+    };
+  }, [targetUrl]);
+
+  return displayUrl;
+}


### PR DESCRIPTION
Switching between images in single-view mode had a noticeable delay — the old image would disappear immediately, leaving a blank flash while the browser fetched and decoded the new one.

Two fixes:

**`loading="eager"` + `decoding="async"`** — The core `Image` component defaults to `loading="lazy"`, which is counterproductive for single-view images since they're always in the viewport. Switching to eager removes the lazy-load heuristic delay. `decoding="async"` keeps the decode non-blocking.

**`useBufferedImageUrl` hook** — Instead of swapping the `<img> src` immediately (which clears the old image), this hook pre-decodes the new image via `new Image().decode()` in the background and only swaps the URL once it's paint-ready. The old image stays on screen the entire time, so there's no blank gap.

List-view images are unaffected — they correctly use `loading="lazy"` via `snapshotDiffBodies.tsx`.