### PR TITLE
feat(night-shift): Hand triage findings to autofix as user_context

### DIFF
--- a/src/sentry/tasks/seer/night_shift/agentic_triage.py
+++ b/src/sentry/tasks/seer/night_shift/agentic_triage.py
@@ -158,7 +158,7 @@ def _triage_candidates(
     )
 
     return [
-        TriageResult(group=groups_by_id[v.group_id], action=v.action)
+        TriageResult(group=groups_by_id[v.group_id], action=v.action, reason=v.reason)
         for v in triage_response.verdicts
         if v.group_id in groups_by_id and v.action != TriageAction.SKIP
     ], agent_run_id
@@ -296,7 +296,12 @@ def _build_triage_prompt(
         the issue is to be fixable (0.0 = not fixable, 1.0 = very fixable). Use it as
         a signal but verify with your own investigation.
 
-        Provide a brief reason for each decision.
+        For each verdict, fill the `reason` field. For `autofix` and `root_cause_only`
+        verdicts, the `reason` is handed off as context to the downstream autofix agent
+        — write it like a debugging note to the next agent. Include the suspected file
+        and function, the bug mechanism in one or two sentences, and a sketch of the
+        fix direction so the next agent can resume your investigation instead of
+        starting over. For `skip` verdicts, a brief justification is sufficient.
 
         Candidates:
         {candidates_block}{extras_block}

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -444,12 +444,19 @@ def _run_autofix_for_candidates(
             else AutofixStoppingPoint.OPEN_PR
         )
 
+        user_context = (
+            f"Night-shift triage already investigated this issue and concluded:\n{c.reason}"
+            if c.reason
+            else None
+        )
+
         try:
             seer_run_id = trigger_autofix_explorer(
                 group=c.group,
                 step=AutofixStep.ROOT_CAUSE,
                 referrer=referrer,
                 stopping_point=stopping_point,
+                user_context=user_context,
             )
         except Exception:
             logger.exception(

--- a/src/sentry/tasks/seer/night_shift/models.py
+++ b/src/sentry/tasks/seer/night_shift/models.py
@@ -16,3 +16,4 @@ class TriageAction(enum.StrEnum):
 class TriageResult:
     group: Group
     action: TriageAction = TriageAction.AUTOFIX
+    reason: str = ""


### PR DESCRIPTION
The triage agent does real repo investigation (suspect file, function, bug mechanism)
before voting, but only the action verdict survived past triage — the reasoning was
dropped, so the downstream autofix run re-explored the same code from zero.

Carry the triage verdict's `reason` through `TriageResult` into
`trigger_autofix_explorer` as `user_context`, and update the triage prompt to tell
the agent its `reason` is consumed by the next agent and should read like a
debugging handoff.