### PR TITLE
feat(cmdk): Add bulk issue actions to command palette

### DIFF
--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -8,12 +8,7 @@ import {Alert} from '@sentry/scraps/alert';
 import {Checkbox} from '@sentry/scraps/checkbox';
 import {Flex} from '@sentry/scraps/layout';
 
-import {bulkDelete, bulkUpdate, mergeGroups} from 'sentry/actionCreators/group';
-import {
-  addErrorMessage,
-  addLoadingMessage,
-  clearIndicators,
-} from 'sentry/actionCreators/indicator';
+import {bulkDelete, mergeGroups} from 'sentry/actionCreators/group';
 import {useAnalyticsArea} from 'sentry/components/analyticsArea';
 import {IssueStreamHeaderLabel} from 'sentry/components/IssueStreamHeaderLabel';
 import {Sticky} from 'sentry/components/sticky';
@@ -22,9 +17,7 @@ import {GroupStore} from 'sentry/stores/groupStore';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {PageFilters} from 'sentry/types/core';
 import type {Group} from 'sentry/types/group';
-import {defined} from 'sentry/utils';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {safeParseQueryKey} from 'sentry/utils/api/apiQueryKey';
 import {uniq} from 'sentry/utils/array/uniq';
 import {useApi} from 'sentry/utils/useApi';
 import {useMedia} from 'sentry/utils/useMedia';
@@ -39,7 +32,13 @@ import {SAVED_SEARCHES_SIDEBAR_OPEN_LOCALSTORAGE_KEY} from 'sentry/views/issueLi
 
 import {ActionSet} from './actionSet';
 import {Headers} from './headers';
-import {BULK_LIMIT, BULK_LIMIT_STR, ConfirmAction} from './utils';
+import {
+  BULK_LIMIT,
+  BULK_LIMIT_STR,
+  ConfirmAction,
+  invalidateIssueQueries,
+  performBulkUpdate,
+} from './utils';
 
 type IssueListActionsProps = {
   allResultsVisible: boolean;
@@ -256,86 +255,24 @@ export function IssueListActions({
     });
   }
 
-  // If all selected groups are from the same project, return the project ID.
-  // Otherwise, return the global selection projects. This is important because
-  // resolution in release requires that a project is specified, but the global
-  // selection may not have that information if My Projects is selected.
-  function getSelectedProjectIds(selectedGroupIds: string[] | undefined) {
-    if (!selectedGroupIds) {
-      return selection.projects;
-    }
-
-    const groups = selectedGroupIds.map(id => GroupStore.get(id));
-
-    const projectIds = new Set(groups.map(group => group?.project?.id).filter(defined));
-
-    if (projectIds.size === 1) {
-      return [...projectIds];
-    }
-
-    return selection.projects;
-  }
-
   function handleUpdate(data: IssueUpdateData) {
     actionSelectedGroups(itemIds => {
-      // If `itemIds` is undefined then it means we expect to bulk update all items
-      // that match the query.
-      //
-      // We need to always respect the projects selected in the global selection header:
-      // * users with no global views requires a project to be specified
-      // * users with global views need to be explicit about what projects the query will run against
-      const projectConstraints = {project: getSelectedProjectIds(itemIds)};
-
-      if (itemIds?.length) {
-        addLoadingMessage(t('Saving changes\u2026'));
-      }
-
-      bulkUpdate(
+      performBulkUpdate({
         api,
-        {
-          orgId: organization.slug,
-          itemIds,
-          data,
-          query,
-          environment: selection.environments,
-          failSilently: true,
-          ...projectConstraints,
-          ...selection.datetime,
+        data,
+        itemIds,
+        organizationSlug: organization.slug,
+        query,
+        selection,
+        onSuccess: updatedItemIds => {
+          onActionTaken?.(updatedItemIds ?? [], data);
+          invalidateIssueQueries({
+            itemIds: updatedItemIds,
+            organizationSlug: organization.slug,
+            queryClient,
+          });
         },
-        {
-          success: () => {
-            clearIndicators();
-            onActionTaken?.(itemIds ?? [], data);
-
-            // Prevents stale data on issue details
-            if (itemIds?.length) {
-              for (const itemId of itemIds) {
-                queryClient.invalidateQueries({
-                  queryKey: [`/organizations/${organization.slug}/issues/${itemId}/`],
-                  exact: false,
-                });
-              }
-            } else {
-              // If we're doing a full query update we invalidate all issue queries to be safe
-              queryClient.invalidateQueries({
-                predicate: apiQuery => {
-                  const queryKey = safeParseQueryKey(apiQuery.queryKey);
-                  if (!queryKey) {
-                    return false;
-                  }
-                  return queryKey.url.startsWith(
-                    `/organizations/${organization.slug}/issues/`
-                  );
-                },
-              });
-            }
-          },
-          error: () => {
-            clearIndicators();
-            addErrorMessage(t('Unable to update issues'));
-          },
-        }
-      );
+      });
     });
   }
 

--- a/static/app/views/issueList/actions/utils.tsx
+++ b/static/app/views/issueList/actions/utils.tsx
@@ -256,9 +256,7 @@ export function performBulkUpdate({
     project: getSelectedProjectIds({selectedGroupIds: itemIds, selection}),
   };
 
-  if (itemIds?.length) {
-    addLoadingMessage(t('Saving changes…'));
-  }
+  addLoadingMessage(t('Saving changes…'));
 
   bulkUpdate(
     api,

--- a/static/app/views/issueList/actions/utils.tsx
+++ b/static/app/views/issueList/actions/utils.tsx
@@ -182,7 +182,7 @@ export const COLUMN_BREAKPOINTS = {
   ASSIGNEE: '500px',
 };
 
-export function getSelectedProjectIds({
+function getSelectedProjectIds({
   selectedGroupIds,
   selection,
 }: {

--- a/static/app/views/issueList/actions/utils.tsx
+++ b/static/app/views/issueList/actions/utils.tsx
@@ -1,10 +1,23 @@
 import {Fragment} from 'react';
+import type {QueryClient} from '@tanstack/react-query';
 
 import {Alert} from '@sentry/scraps/alert';
 import {ExternalLink} from '@sentry/scraps/link';
 
+import {bulkUpdate} from 'sentry/actionCreators/group';
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  clearIndicators,
+} from 'sentry/actionCreators/indicator';
+import type {Client} from 'sentry/api';
 import {t, tct, tn} from 'sentry/locale';
+import {GroupStore} from 'sentry/stores/groupStore';
+import type {PageFilters} from 'sentry/types/core';
+import {defined} from 'sentry/utils';
+import {safeParseQueryKey} from 'sentry/utils/api/apiQueryKey';
 import {capitalize} from 'sentry/utils/string/capitalize';
+import type {IssueUpdateData} from 'sentry/views/issueList/types';
 
 import {ExtraDescription} from './extraDescription';
 
@@ -168,3 +181,107 @@ export const COLUMN_BREAKPOINTS = {
   PRIORITY: '1100px',
   ASSIGNEE: '500px',
 };
+
+export function getSelectedProjectIds({
+  selectedGroupIds,
+  selection,
+}: {
+  selectedGroupIds: string[] | undefined;
+  selection: PageFilters;
+}) {
+  if (!selectedGroupIds) {
+    return selection.projects;
+  }
+
+  const groups = selectedGroupIds.map(id => GroupStore.get(id));
+  const projectIds = new Set(groups.map(group => group?.project?.id).filter(defined));
+
+  if (projectIds.size === 1) {
+    return [...projectIds];
+  }
+
+  return selection.projects;
+}
+
+export function invalidateIssueQueries({
+  itemIds,
+  organizationSlug,
+  queryClient,
+}: {
+  itemIds: string[] | undefined;
+  organizationSlug: string;
+  queryClient: QueryClient;
+}) {
+  if (itemIds?.length) {
+    for (const itemId of itemIds) {
+      queryClient.invalidateQueries({
+        queryKey: [`/organizations/${organizationSlug}/issues/${itemId}/`],
+        exact: false,
+      });
+    }
+    return;
+  }
+
+  queryClient.invalidateQueries({
+    predicate: apiQuery => {
+      const queryKey = safeParseQueryKey(apiQuery.queryKey);
+      if (!queryKey) {
+        return false;
+      }
+      return queryKey.url.startsWith(`/organizations/${organizationSlug}/issues/`);
+    },
+  });
+}
+
+export function performBulkUpdate({
+  api,
+  data,
+  itemIds,
+  organizationSlug,
+  query,
+  selection,
+  onError,
+  onSuccess,
+}: {
+  api: Client;
+  data: IssueUpdateData | Record<string, unknown>;
+  itemIds: string[] | undefined;
+  organizationSlug: string;
+  query: string;
+  selection: PageFilters;
+  onError?: () => void;
+  onSuccess?: (itemIds: string[] | undefined) => void;
+}) {
+  const projectConstraints = {
+    project: getSelectedProjectIds({selectedGroupIds: itemIds, selection}),
+  };
+
+  if (itemIds?.length) {
+    addLoadingMessage(t('Saving changes…'));
+  }
+
+  bulkUpdate(
+    api,
+    {
+      orgId: organizationSlug,
+      itemIds,
+      data,
+      query,
+      environment: selection.environments,
+      failSilently: true,
+      ...projectConstraints,
+      ...selection.datetime,
+    },
+    {
+      success: () => {
+        clearIndicators();
+        onSuccess?.(itemIds);
+      },
+      error: () => {
+        clearIndicators();
+        addErrorMessage(t('Unable to update issues'));
+        onError?.();
+      },
+    }
+  );
+}

--- a/static/app/views/issueList/issueListBulkCommandPaletteActions.spec.tsx
+++ b/static/app/views/issueList/issueListBulkCommandPaletteActions.spec.tsx
@@ -1,0 +1,126 @@
+import {useLayoutEffect} from 'react';
+import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {UserFixture} from 'sentry-fixture/user';
+
+import {render, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {
+  CMDKCollection,
+  CommandPaletteProvider,
+  type CMDKActionData,
+} from 'sentry/components/commandPalette/ui/cmdk';
+import type {CollectionTreeNode} from 'sentry/components/commandPalette/ui/collection';
+import {CommandPaletteSlot} from 'sentry/components/commandPalette/ui/commandPaletteSlot';
+import {ConfigStore} from 'sentry/stores/configStore';
+import {GroupStore} from 'sentry/stores/groupStore';
+import {GroupStatus} from 'sentry/types/group';
+import {IssueListBulkCommandPaletteActions} from 'sentry/views/issueList/issueListBulkCommandPaletteActions';
+import {
+  IssueSelectionProvider,
+  useIssueSelectionActions,
+} from 'sentry/views/issueList/issueSelectionContext';
+
+const organization = OrganizationFixture();
+
+function CommandPaletteTree({
+  onTree,
+}: {
+  onTree: (tree: Array<CollectionTreeNode<CMDKActionData>>) => void;
+}) {
+  const store = CMDKCollection.useStore();
+  onTree(store.tree());
+  return null;
+}
+
+function SlotOutlets() {
+  return (
+    <div style={{display: 'none'}}>
+      <CommandPaletteSlot.Outlet name="task">
+        {p => <div {...p} />}
+      </CommandPaletteSlot.Outlet>
+      <CommandPaletteSlot.Outlet name="page">
+        {p => <div {...p} />}
+      </CommandPaletteSlot.Outlet>
+      <CommandPaletteSlot.Outlet name="global">
+        {p => <div {...p} />}
+      </CommandPaletteSlot.Outlet>
+    </div>
+  );
+}
+
+function SelectionInitializer() {
+  const {setAllInQuerySelected, toggleSelectAllVisible} = useIssueSelectionActions();
+
+  useLayoutEffect(() => {
+    toggleSelectAllVisible();
+    setAllInQuerySelected(true);
+  }, [setAllInQuerySelected, toggleSelectAllVisible]);
+
+  return null;
+}
+
+describe('IssueListBulkCommandPaletteActions', () => {
+  beforeEach(() => {
+    GroupStore.reset();
+    ConfigStore.loadInitialData({
+      user: UserFixture({id: '1', name: 'Test User'}),
+    } as any);
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/users/`,
+      body: [],
+    });
+  });
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('shows resolve and archive actions when all matching issues are selected', async () => {
+    GroupStore.add([
+      GroupFixture({id: '1', status: GroupStatus.RESOLVED}),
+      GroupFixture({id: '2', status: GroupStatus.IGNORED}),
+    ]);
+
+    const treeRef: {current: Array<CollectionTreeNode<CMDKActionData>>} = {current: []};
+
+    render(
+      <CommandPaletteProvider>
+        <IssueSelectionProvider visibleGroupIds={['1', '2']}>
+          <SelectionInitializer />
+          <IssueListBulkCommandPaletteActions
+            groupIds={['1', '2']}
+            onActionTaken={jest.fn()}
+            query=""
+            queryCount={10}
+            selection={{
+              projects: [1],
+              environments: [],
+              datetime: {start: null, end: null, period: null, utc: true},
+            }}
+          />
+        </IssueSelectionProvider>
+        <SlotOutlets />
+        <CommandPaletteTree
+          onTree={tree => {
+            treeRef.current = tree;
+          }}
+        />
+      </CommandPaletteProvider>,
+      {organization}
+    );
+
+    await waitFor(() => {
+      expect(treeRef.current.length).toBeGreaterThan(0);
+    });
+
+    const labels = treeRef.current.flatMap(node => [
+      node.display.label,
+      ...node.children.map(child => child.display.label),
+    ]);
+
+    expect(labels).toContain('Resolve');
+    expect(labels).toContain('Archive');
+  });
+});

--- a/static/app/views/issueList/issueListBulkCommandPaletteActions.spec.tsx
+++ b/static/app/views/issueList/issueListBulkCommandPaletteActions.spec.tsx
@@ -3,8 +3,16 @@ import {GroupFixture} from 'sentry-fixture/group';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {UserFixture} from 'sentry-fixture/user';
 
-import {render, waitFor} from 'sentry-test/reactTestingLibrary';
+import {
+  act,
+  render,
+  renderGlobalModal,
+  screen,
+  userEvent,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
 
+import {addLoadingMessage} from 'sentry/actionCreators/indicator';
 import {
   CMDKCollection,
   CommandPaletteProvider,
@@ -16,10 +24,14 @@ import {ConfigStore} from 'sentry/stores/configStore';
 import {GroupStore} from 'sentry/stores/groupStore';
 import {GroupStatus} from 'sentry/types/group';
 import {IssueListBulkCommandPaletteActions} from 'sentry/views/issueList/issueListBulkCommandPaletteActions';
+import {IssueListCommandPaletteActions} from 'sentry/views/issueList/issueListCommandPaletteActions';
 import {
   IssueSelectionProvider,
   useIssueSelectionActions,
 } from 'sentry/views/issueList/issueSelectionContext';
+import {IssueSortOptions} from 'sentry/views/issueList/utils';
+
+jest.mock('sentry/actionCreators/indicator');
 
 const organization = OrganizationFixture();
 
@@ -63,6 +75,7 @@ function SelectionInitializer() {
 describe('IssueListBulkCommandPaletteActions', () => {
   beforeEach(() => {
     GroupStore.reset();
+    (addLoadingMessage as jest.Mock).mockClear();
     ConfigStore.loadInitialData({
       user: UserFixture({id: '1', name: 'Test User'}),
     } as any);
@@ -71,10 +84,71 @@ describe('IssueListBulkCommandPaletteActions', () => {
       url: `/organizations/${organization.slug}/users/`,
       body: [],
     });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/tags/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [],
+    });
   });
 
   afterEach(() => {
     MockApiClient.clearMockResponses();
+  });
+
+  it('shows mark all actions when no issues are selected', async () => {
+    const treeRef: {current: Array<CollectionTreeNode<CMDKActionData>>} = {current: []};
+
+    render(
+      <CommandPaletteProvider>
+        <IssueSelectionProvider visibleGroupIds={['1', '2']}>
+          <IssueListCommandPaletteActions
+            groupIds={['1', '2']}
+            onActionTaken={jest.fn()}
+            onQueryChange={jest.fn()}
+            onSortChange={jest.fn()}
+            query=""
+            queryCount={10}
+            selection={{
+              projects: [1],
+              environments: [],
+              datetime: {start: null, end: null, period: null, utc: true},
+            }}
+            sort={IssueSortOptions.DATE}
+          />
+        </IssueSelectionProvider>
+        <SlotOutlets />
+        <CommandPaletteTree
+          onTree={tree => {
+            treeRef.current = tree;
+          }}
+        />
+      </CommandPaletteProvider>,
+      {organization}
+    );
+
+    await waitFor(() => {
+      expect(treeRef.current.length).toBeGreaterThan(0);
+    });
+
+    const issueFeedNode = treeRef.current.find(
+      node => node.display.label === 'Issues Feed'
+    );
+    expect(issueFeedNode).toBeDefined();
+
+    const issueFeedLabels = issueFeedNode!.children.map(child => child.display.label);
+    expect(issueFeedLabels).toContain('Filter by');
+    expect(issueFeedLabels).toContain('Mark all issues as');
+
+    const markAllNode = issueFeedNode!.children.find(
+      child => child.display.label === 'Mark all issues as'
+    );
+    expect(markAllNode).toBeDefined();
+    expect(markAllNode!.children.map(child => child.display.label)).toEqual(
+      expect.arrayContaining(['Assigned to', 'Resolved', 'Archived'])
+    );
   });
 
   it('shows resolve and archive actions when all matching issues are selected', async () => {
@@ -122,5 +196,77 @@ describe('IssueListBulkCommandPaletteActions', () => {
 
     expect(labels).toContain('Resolve');
     expect(labels).toContain('Archive');
+  });
+
+  it('shows a loader when marking all issues as resolved', async () => {
+    const treeRef: {current: Array<CollectionTreeNode<CMDKActionData>>} = {current: []};
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/`,
+      method: 'PUT',
+      body: [],
+    });
+
+    render(
+      <CommandPaletteProvider>
+        <IssueSelectionProvider visibleGroupIds={['1', '2']}>
+          <IssueListCommandPaletteActions
+            groupIds={['1', '2']}
+            onActionTaken={jest.fn()}
+            onQueryChange={jest.fn()}
+            onSortChange={jest.fn()}
+            query=""
+            queryCount={10}
+            selection={{
+              projects: [1],
+              environments: [],
+              datetime: {start: null, end: null, period: null, utc: true},
+            }}
+            sort={IssueSortOptions.DATE}
+          />
+        </IssueSelectionProvider>
+        <SlotOutlets />
+        <CommandPaletteTree
+          onTree={tree => {
+            treeRef.current = tree;
+          }}
+        />
+      </CommandPaletteProvider>,
+      {organization}
+    );
+    renderGlobalModal();
+
+    await waitFor(() => {
+      expect(treeRef.current.length).toBeGreaterThan(0);
+    });
+
+    const issueFeedNode = treeRef.current.find(
+      node => node.display.label === 'Issues Feed'
+    );
+    const markAllNode = issueFeedNode?.children.find(
+      child => child.display.label === 'Mark all issues as'
+    );
+    const resolvedAction = markAllNode?.children.find(
+      child => child.display.label === 'Resolved' && 'onAction' in child
+    );
+
+    expect(resolvedAction).toBeDefined();
+
+    act(() => {
+      if (resolvedAction && 'onAction' in resolvedAction) {
+        resolvedAction.onAction();
+      }
+    });
+
+    expect(addLoadingMessage).not.toHaveBeenCalled();
+    expect(
+      await screen.findByText(
+        'You are about to resolve all 10 issues matching this search. Are you sure?'
+      )
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Confirm'}));
+
+    expect(addLoadingMessage).toHaveBeenCalledWith('Saving changes…');
   });
 });

--- a/static/app/views/issueList/issueListBulkCommandPaletteActions.spec.tsx
+++ b/static/app/views/issueList/issueListBulkCommandPaletteActions.spec.tsx
@@ -269,4 +269,78 @@ describe('IssueListBulkCommandPaletteActions', () => {
 
     expect(addLoadingMessage).toHaveBeenCalledWith('Saving changes…');
   });
+
+  it('sends query-based API request when marking all issues as resolved', async () => {
+    const treeRef: {current: Array<CollectionTreeNode<CMDKActionData>>} = {current: []};
+
+    const bulkUpdateMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/`,
+      method: 'PUT',
+      body: [],
+    });
+
+    render(
+      <CommandPaletteProvider>
+        <IssueSelectionProvider visibleGroupIds={['1', '2']}>
+          <IssueListCommandPaletteActions
+            groupIds={['1', '2']}
+            onActionTaken={jest.fn()}
+            onQueryChange={jest.fn()}
+            onSortChange={jest.fn()}
+            query="is:unresolved"
+            queryCount={10}
+            selection={{
+              projects: [1],
+              environments: [],
+              datetime: {start: null, end: null, period: null, utc: true},
+            }}
+            sort={IssueSortOptions.DATE}
+          />
+        </IssueSelectionProvider>
+        <SlotOutlets />
+        <CommandPaletteTree
+          onTree={tree => {
+            treeRef.current = tree;
+          }}
+        />
+      </CommandPaletteProvider>,
+      {organization}
+    );
+    renderGlobalModal();
+
+    await waitFor(() => {
+      expect(treeRef.current.length).toBeGreaterThan(0);
+    });
+
+    const issueFeedNode = treeRef.current.find(
+      node => node.display.label === 'Issues Feed'
+    );
+    const markAllNode = issueFeedNode?.children.find(
+      child => child.display.label === 'Mark all issues as'
+    );
+    const resolvedAction = markAllNode?.children.find(
+      child => child.display.label === 'Resolved' && 'onAction' in child
+    );
+
+    act(() => {
+      if (resolvedAction && 'onAction' in resolvedAction) {
+        resolvedAction.onAction();
+      }
+    });
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Confirm'}));
+
+    expect(bulkUpdateMock).toHaveBeenCalledWith(
+      `/organizations/${organization.slug}/issues/`,
+      expect.objectContaining({
+        query: expect.objectContaining({query: 'is:unresolved'}),
+      })
+    );
+    expect(bulkUpdateMock).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: expect.objectContaining({id: expect.anything()}),
+      })
+    );
+  });
 });

--- a/static/app/views/issueList/issueListBulkCommandPaletteActions.tsx
+++ b/static/app/views/issueList/issueListBulkCommandPaletteActions.tsx
@@ -1,0 +1,338 @@
+import {useMemo} from 'react';
+import {useQuery, useQueryClient} from '@tanstack/react-query';
+
+import {ActorAvatar, TeamAvatar, UserAvatar} from '@sentry/scraps/avatar';
+
+import {bulkUpdate} from 'sentry/actionCreators/group';
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  clearIndicators,
+} from 'sentry/actionCreators/indicator';
+import {IconCellSignal} from 'sentry/components/badge/iconCellSignal';
+import {CMDKAction} from 'sentry/components/commandPalette/ui/cmdk';
+import {CommandPaletteSlot} from 'sentry/components/commandPalette/ui/commandPaletteSlot';
+import {IconCheckmark, IconClock, IconIssues, IconUser} from 'sentry/icons';
+import {t, tn} from 'sentry/locale';
+import {GroupStore} from 'sentry/stores/groupStore';
+import type {PageFilters} from 'sentry/types/core';
+import type {BaseGroup} from 'sentry/types/group';
+import {GroupStatus, GroupSubstatus, PriorityLevel} from 'sentry/types/group';
+import type {Member} from 'sentry/types/organization';
+import {defined} from 'sentry/utils';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {safeParseQueryKey} from 'sentry/utils/api/apiQueryKey';
+import {useApi} from 'sentry/utils/useApi';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {useTeams} from 'sentry/utils/useTeams';
+import {useUser} from 'sentry/utils/useUser';
+import {
+  useIssueSelectionActions,
+  useIssueSelectionSummary,
+} from 'sentry/views/issueList/issueSelectionContext';
+import type {IssueUpdateData} from 'sentry/views/issueList/types';
+
+interface IssueListBulkCommandPaletteActionsProps {
+  groupIds: string[];
+  query: string;
+  selection: PageFilters;
+  onActionTaken?: (itemIds: string[], data: IssueUpdateData) => void;
+}
+
+function useOrgMembers() {
+  const organization = useOrganization();
+  return useQuery({
+    ...apiOptions.as<Member[]>()('/organizations/$organizationIdOrSlug/users/', {
+      path: {organizationIdOrSlug: organization.slug},
+      staleTime: 30_000,
+    }),
+    select: data =>
+      data.json.filter(
+        (m): m is Member & {user: NonNullable<Member['user']>} => m.user !== null
+      ),
+  });
+}
+
+function AssignActions({
+  onBulkUpdate,
+}: {
+  onBulkUpdate: (data: Record<string, unknown>) => void;
+}) {
+  const user = useUser();
+  const {teams} = useTeams({provideUserTeams: true});
+  const {data: members = []} = useOrgMembers();
+
+  const sortedTeams = useMemo(
+    () => [...teams].sort((a, b) => a.slug.localeCompare(b.slug)),
+    [teams]
+  );
+
+  const assignableMembers = useMemo(
+    () => members.filter(m => m.user.id !== user?.id),
+    [members, user?.id]
+  );
+
+  return (
+    <CMDKAction
+      display={{label: t('Assign to'), icon: <IconUser />}}
+      keywords={['assign', 'owner', 'assignee']}
+      prompt={t('Search assignees...')}
+    >
+      {user && (
+        <CMDKAction
+          display={{
+            label: t('Assign to me'),
+            icon: <UserAvatar user={user} size={16} hasTooltip={false} />,
+          }}
+          keywords={['mine', 'my issues', 'me']}
+          onAction={() => onBulkUpdate({assignedTo: `user:${user.id}`})}
+        />
+      )}
+      <CMDKAction
+        display={{label: t('Unassign'), icon: <IconUser />}}
+        keywords={['unassign', 'clear', 'remove assignee', 'nobody']}
+        onAction={() => onBulkUpdate({assignedTo: ''})}
+      />
+      {sortedTeams.map(team => (
+        <CMDKAction
+          key={`team-${team.id}`}
+          display={{
+            label: `#${team.slug}`,
+            icon: <TeamAvatar team={team} size={16} hasTooltip={false} />,
+          }}
+          onAction={() => onBulkUpdate({assignedTo: `team:${team.id}`})}
+        />
+      ))}
+      {assignableMembers.map(m => (
+        <CMDKAction
+          key={`member-${m.user.id}`}
+          display={{
+            label: m.user.name || m.user.email,
+            icon: (
+              <ActorAvatar
+                actor={{
+                  id: m.user.id,
+                  name: m.user.name || m.user.email,
+                  type: 'user',
+                }}
+                size={16}
+                hasTooltip={false}
+              />
+            ),
+          }}
+          onAction={() => onBulkUpdate({assignedTo: `user:${m.user.id}`})}
+        />
+      ))}
+    </CMDKAction>
+  );
+}
+
+function PriorityActions({onUpdate}: {onUpdate: (data: IssueUpdateData) => void}) {
+  return (
+    <CMDKAction
+      display={{label: t('Set Priority'), icon: <IconCellSignal bars={2} />}}
+      keywords={['priority', 'urgency', 'critical', 'high', 'medium', 'low']}
+    >
+      <CMDKAction
+        display={{label: t('High'), icon: <IconCellSignal bars={3} />}}
+        onAction={() => onUpdate({priority: PriorityLevel.HIGH})}
+      />
+      <CMDKAction
+        display={{label: t('Medium'), icon: <IconCellSignal bars={2} />}}
+        onAction={() => onUpdate({priority: PriorityLevel.MEDIUM})}
+      />
+      <CMDKAction
+        display={{label: t('Low'), icon: <IconCellSignal bars={1} />}}
+        onAction={() => onUpdate({priority: PriorityLevel.LOW})}
+      />
+    </CMDKAction>
+  );
+}
+
+export function IssueListBulkCommandPaletteActions({
+  query,
+  selection,
+  groupIds,
+  onActionTaken,
+}: IssueListBulkCommandPaletteActionsProps) {
+  const api = useApi();
+  const queryClient = useQueryClient();
+  const organization = useOrganization();
+  const {anySelected, selectedIdsSet, allInQuerySelected} = useIssueSelectionSummary();
+  const {deselectAll} = useIssueSelectionActions();
+
+  const numIssues = selectedIdsSet.size;
+
+  const selectedIssues = useMemo(
+    () =>
+      [...selectedIdsSet]
+        .map(issueId => GroupStore.get(issueId))
+        .filter((issue): issue is BaseGroup => !!issue),
+    [selectedIdsSet]
+  );
+
+  const canResolve = selectedIssues.some(issue => issue.status !== GroupStatus.RESOLVED);
+  const canArchive = selectedIssues.some(issue => issue.status !== GroupStatus.IGNORED);
+
+  function getSelectedIds(): string[] | undefined {
+    return allInQuerySelected
+      ? undefined
+      : groupIds.filter(itemId => selectedIdsSet.has(itemId));
+  }
+
+  function getSelectedProjectIds(selectedGroupIds: string[] | undefined) {
+    if (!selectedGroupIds) {
+      return selection.projects;
+    }
+    const groups = selectedGroupIds.map(id => GroupStore.get(id));
+    const projectIds = new Set(groups.map(group => group?.project?.id).filter(defined));
+    if (projectIds.size === 1) {
+      return [...projectIds];
+    }
+    return selection.projects;
+  }
+
+  function handleUpdate(data: IssueUpdateData) {
+    const itemIds = getSelectedIds();
+    const projectConstraints = {project: getSelectedProjectIds(itemIds)};
+
+    if (itemIds?.length) {
+      addLoadingMessage(t('Saving changes…'));
+    }
+
+    bulkUpdate(
+      api,
+      {
+        orgId: organization.slug,
+        itemIds,
+        data,
+        query,
+        environment: selection.environments,
+        failSilently: true,
+        ...projectConstraints,
+        ...selection.datetime,
+      },
+      {
+        success: () => {
+          clearIndicators();
+          onActionTaken?.(itemIds ?? [], data);
+          invalidateIssueQueries(itemIds);
+        },
+        error: () => {
+          clearIndicators();
+          addErrorMessage(t('Unable to update issues'));
+        },
+      }
+    );
+
+    deselectAll();
+  }
+
+  function handleBulkUpdate(data: Record<string, unknown>) {
+    const itemIds = getSelectedIds();
+    const projectConstraints = {project: getSelectedProjectIds(itemIds)};
+
+    if (itemIds?.length) {
+      addLoadingMessage(t('Saving changes…'));
+    }
+
+    bulkUpdate(
+      api,
+      {
+        orgId: organization.slug,
+        itemIds,
+        data,
+        query,
+        environment: selection.environments,
+        failSilently: true,
+        ...projectConstraints,
+        ...selection.datetime,
+      },
+      {
+        success: () => {
+          clearIndicators();
+          invalidateIssueQueries(itemIds);
+        },
+        error: () => {
+          clearIndicators();
+          addErrorMessage(t('Unable to update issues'));
+        },
+      }
+    );
+
+    deselectAll();
+  }
+
+  function invalidateIssueQueries(itemIds: string[] | undefined) {
+    if (itemIds?.length) {
+      for (const itemId of itemIds) {
+        queryClient.invalidateQueries({
+          queryKey: [`/organizations/${organization.slug}/issues/${itemId}/`],
+          exact: false,
+        });
+      }
+    } else {
+      queryClient.invalidateQueries({
+        predicate: apiQuery => {
+          const queryKey = safeParseQueryKey(apiQuery.queryKey);
+          if (!queryKey) {
+            return false;
+          }
+          return queryKey.url.startsWith(`/organizations/${organization.slug}/issues/`);
+        },
+      });
+    }
+  }
+
+  const selectedIssueIds = useMemo(() => {
+    const ids = selectedIssues.map(issue => `#${issue.shortId}`);
+    if (ids.length <= 3) {
+      return ids.join(', ');
+    }
+    return `${ids.slice(0, 3).join(', ')}, …`;
+  }, [selectedIssues]);
+
+  if (!anySelected) {
+    return null;
+  }
+
+  return (
+    <CommandPaletteSlot name="task">
+      <CMDKAction
+        display={{
+          label: `${tn('%s Selected Issue', '%s Selected Issues', numIssues)} (${selectedIssueIds})`,
+          icon: <IconIssues />,
+        }}
+      >
+        {canResolve && (
+          <CMDKAction
+            display={{label: t('Resolve'), icon: <IconCheckmark />}}
+            keywords={['resolve', 'fix', 'done', 'close']}
+            onAction={() =>
+              handleUpdate({
+                status: GroupStatus.RESOLVED,
+                statusDetails: {},
+                substatus: null,
+              })
+            }
+          />
+        )}
+        {canArchive && (
+          <CMDKAction
+            display={{label: t('Archive'), icon: <IconClock />}}
+            keywords={['archive', 'ignore', 'snooze', 'mute']}
+            onAction={() =>
+              handleUpdate({
+                status: GroupStatus.IGNORED,
+                statusDetails: {},
+                substatus: GroupSubstatus.ARCHIVED_UNTIL_ESCALATING,
+              })
+            }
+          />
+        )}
+        <PriorityActions onUpdate={handleUpdate} />
+        <AssignActions onBulkUpdate={handleBulkUpdate} />
+      </CMDKAction>
+    </CommandPaletteSlot>
+  );
+}

--- a/static/app/views/issueList/issueListBulkCommandPaletteActions.tsx
+++ b/static/app/views/issueList/issueListBulkCommandPaletteActions.tsx
@@ -236,9 +236,10 @@ function useIssueListBulkCommandPaletteActions({
 
   function performBulkUpdate(
     data: IssueUpdateData | Record<string, unknown>,
-    onSuccess?: (itemIds: string[] | undefined) => void
+    onSuccess?: (itemIds: string[] | undefined) => void,
+    allInQuery?: boolean
   ) {
-    const itemIds = getSelectedIds();
+    const itemIds = allInQuery ? undefined : getSelectedIds();
     performSharedBulkUpdate({
       api,
       data,
@@ -259,14 +260,18 @@ function useIssueListBulkCommandPaletteActions({
     deselectAll();
   }
 
-  function handleUpdate(data: IssueUpdateData) {
-    performBulkUpdate(data, itemIds => {
-      onActionTaken?.(itemIds ?? [], data);
-    });
+  function handleUpdate(data: IssueUpdateData, allInQuery?: boolean) {
+    performBulkUpdate(
+      data,
+      itemIds => {
+        onActionTaken?.(itemIds ?? [], data);
+      },
+      allInQuery
+    );
   }
 
-  function handleBulkUpdate(data: Record<string, unknown>) {
-    performBulkUpdate(data);
+  function handleBulkUpdate(data: Record<string, unknown>, allInQuery?: boolean) {
+    performBulkUpdate(data, undefined, allInQuery);
   }
   const selectedIssueIds = useMemo(() => {
     const ids = selectedIssues.map(issue => `#${issue.shortId}`);
@@ -339,6 +344,10 @@ export function IssueListMarkAllCommandPaletteAction(
     return null;
   }
 
+  const handleUpdateAll = (data: IssueUpdateData) => handleUpdate(data, true);
+  const handleBulkUpdateAll = (data: Record<string, unknown>) =>
+    handleBulkUpdate(data, true);
+
   return (
     <CMDKAction
       display={{
@@ -349,7 +358,7 @@ export function IssueListMarkAllCommandPaletteAction(
     >
       <AssignActions
         label={t('Assigned to')}
-        onBulkUpdate={handleBulkUpdate}
+        onBulkUpdate={handleBulkUpdateAll}
         onConfirmBulkUpdate={(actionLabel, onConfirm) =>
           confirmBulkAction(actionLabel, onConfirm, 'allInQuery')
         }
@@ -361,7 +370,7 @@ export function IssueListMarkAllCommandPaletteAction(
           confirmBulkAction(
             t('resolve'),
             () =>
-              handleUpdate({
+              handleUpdateAll({
                 status: GroupStatus.RESOLVED,
                 statusDetails: {},
                 substatus: null,
@@ -377,7 +386,7 @@ export function IssueListMarkAllCommandPaletteAction(
           confirmBulkAction(
             t('archive'),
             () =>
-              handleUpdate({
+              handleUpdateAll({
                 status: GroupStatus.IGNORED,
                 statusDetails: {},
                 substatus: GroupSubstatus.ARCHIVED_UNTIL_ESCALATING,

--- a/static/app/views/issueList/issueListBulkCommandPaletteActions.tsx
+++ b/static/app/views/issueList/issueListBulkCommandPaletteActions.tsx
@@ -192,7 +192,10 @@ export function IssueListBulkCommandPaletteActions({
     return selection.projects;
   }
 
-  function handleUpdate(data: IssueUpdateData) {
+  function performBulkUpdate(
+    data: IssueUpdateData | Record<string, unknown>,
+    onSuccess?: (itemIds: string[] | undefined) => void
+  ) {
     const itemIds = getSelectedIds();
     const projectConstraints = {project: getSelectedProjectIds(itemIds)};
 
@@ -215,7 +218,7 @@ export function IssueListBulkCommandPaletteActions({
       {
         success: () => {
           clearIndicators();
-          onActionTaken?.(itemIds ?? [], data);
+          onSuccess?.(itemIds);
           invalidateIssueQueries(itemIds);
         },
         error: () => {
@@ -228,39 +231,14 @@ export function IssueListBulkCommandPaletteActions({
     deselectAll();
   }
 
+  function handleUpdate(data: IssueUpdateData) {
+    performBulkUpdate(data, itemIds => {
+      onActionTaken?.(itemIds ?? [], data);
+    });
+  }
+
   function handleBulkUpdate(data: Record<string, unknown>) {
-    const itemIds = getSelectedIds();
-    const projectConstraints = {project: getSelectedProjectIds(itemIds)};
-
-    if (itemIds?.length) {
-      addLoadingMessage(t('Saving changes…'));
-    }
-
-    bulkUpdate(
-      api,
-      {
-        orgId: organization.slug,
-        itemIds,
-        data,
-        query,
-        environment: selection.environments,
-        failSilently: true,
-        ...projectConstraints,
-        ...selection.datetime,
-      },
-      {
-        success: () => {
-          clearIndicators();
-          invalidateIssueQueries(itemIds);
-        },
-        error: () => {
-          clearIndicators();
-          addErrorMessage(t('Unable to update issues'));
-        },
-      }
-    );
-
-    deselectAll();
+    performBulkUpdate(data);
   }
 
   function invalidateIssueQueries(itemIds: string[] | undefined) {

--- a/static/app/views/issueList/issueListBulkCommandPaletteActions.tsx
+++ b/static/app/views/issueList/issueListBulkCommandPaletteActions.tsx
@@ -3,12 +3,6 @@ import {useQuery, useQueryClient} from '@tanstack/react-query';
 
 import {ActorAvatar, TeamAvatar, UserAvatar} from '@sentry/scraps/avatar';
 
-import {bulkUpdate} from 'sentry/actionCreators/group';
-import {
-  addErrorMessage,
-  addLoadingMessage,
-  clearIndicators,
-} from 'sentry/actionCreators/indicator';
 import {IconCellSignal} from 'sentry/components/badge/iconCellSignal';
 import {CMDKAction} from 'sentry/components/commandPalette/ui/cmdk';
 import {CommandPaletteSlot} from 'sentry/components/commandPalette/ui/commandPaletteSlot';
@@ -19,13 +13,17 @@ import type {PageFilters} from 'sentry/types/core';
 import type {BaseGroup} from 'sentry/types/group';
 import {GroupStatus, GroupSubstatus, PriorityLevel} from 'sentry/types/group';
 import type {Member} from 'sentry/types/organization';
-import {defined} from 'sentry/utils';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
-import {safeParseQueryKey} from 'sentry/utils/api/apiQueryKey';
 import {useApi} from 'sentry/utils/useApi';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useTeams} from 'sentry/utils/useTeams';
 import {useUser} from 'sentry/utils/useUser';
+import {
+  BULK_LIMIT,
+  BULK_LIMIT_STR,
+  invalidateIssueQueries,
+  performBulkUpdate as performSharedBulkUpdate,
+} from 'sentry/views/issueList/actions/utils';
 import {
   useIssueSelectionActions,
   useIssueSelectionSummary,
@@ -35,6 +33,7 @@ import type {IssueUpdateData} from 'sentry/views/issueList/types';
 interface IssueListBulkCommandPaletteActionsProps {
   groupIds: string[];
   query: string;
+  queryCount: number;
   selection: PageFilters;
   onActionTaken?: (itemIds: string[], data: IssueUpdateData) => void;
 }
@@ -151,6 +150,7 @@ function PriorityActions({onUpdate}: {onUpdate: (data: IssueUpdateData) => void}
 
 export function IssueListBulkCommandPaletteActions({
   query,
+  queryCount,
   selection,
   groupIds,
   onActionTaken,
@@ -180,53 +180,27 @@ export function IssueListBulkCommandPaletteActions({
       : groupIds.filter(itemId => selectedIdsSet.has(itemId));
   }
 
-  function getSelectedProjectIds(selectedGroupIds: string[] | undefined) {
-    if (!selectedGroupIds) {
-      return selection.projects;
-    }
-    const groups = selectedGroupIds.map(id => GroupStore.get(id));
-    const projectIds = new Set(groups.map(group => group?.project?.id).filter(defined));
-    if (projectIds.size === 1) {
-      return [...projectIds];
-    }
-    return selection.projects;
-  }
-
   function performBulkUpdate(
     data: IssueUpdateData | Record<string, unknown>,
     onSuccess?: (itemIds: string[] | undefined) => void
   ) {
     const itemIds = getSelectedIds();
-    const projectConstraints = {project: getSelectedProjectIds(itemIds)};
-
-    if (itemIds?.length) {
-      addLoadingMessage(t('Saving changes…'));
-    }
-
-    bulkUpdate(
+    performSharedBulkUpdate({
       api,
-      {
-        orgId: organization.slug,
-        itemIds,
-        data,
-        query,
-        environment: selection.environments,
-        failSilently: true,
-        ...projectConstraints,
-        ...selection.datetime,
+      data,
+      itemIds,
+      organizationSlug: organization.slug,
+      query,
+      selection,
+      onSuccess: updatedItemIds => {
+        onSuccess?.(updatedItemIds);
+        invalidateIssueQueries({
+          itemIds: updatedItemIds,
+          organizationSlug: organization.slug,
+          queryClient,
+        });
       },
-      {
-        success: () => {
-          clearIndicators();
-          onSuccess?.(itemIds);
-          invalidateIssueQueries(itemIds);
-        },
-        error: () => {
-          clearIndicators();
-          addErrorMessage(t('Unable to update issues'));
-        },
-      }
-    );
+    });
 
     deselectAll();
   }
@@ -240,28 +214,6 @@ export function IssueListBulkCommandPaletteActions({
   function handleBulkUpdate(data: Record<string, unknown>) {
     performBulkUpdate(data);
   }
-
-  function invalidateIssueQueries(itemIds: string[] | undefined) {
-    if (itemIds?.length) {
-      for (const itemId of itemIds) {
-        queryClient.invalidateQueries({
-          queryKey: [`/organizations/${organization.slug}/issues/${itemId}/`],
-          exact: false,
-        });
-      }
-    } else {
-      queryClient.invalidateQueries({
-        predicate: apiQuery => {
-          const queryKey = safeParseQueryKey(apiQuery.queryKey);
-          if (!queryKey) {
-            return false;
-          }
-          return queryKey.url.startsWith(`/organizations/${organization.slug}/issues/`);
-        },
-      });
-    }
-  }
-
   const selectedIssueIds = useMemo(() => {
     const ids = selectedIssues.map(issue => `#${issue.shortId}`);
     if (ids.length <= 3) {
@@ -269,6 +221,16 @@ export function IssueListBulkCommandPaletteActions({
     }
     return `${ids.slice(0, 3).join(', ')}, …`;
   }, [selectedIssues]);
+
+  const label = useMemo(() => {
+    if (allInQuerySelected) {
+      if (queryCount >= BULK_LIMIT) {
+        return t('First %s Issues Matching Search', BULK_LIMIT_STR);
+      }
+      return t('All %s Issues Matching Search', queryCount);
+    }
+    return `${tn('%s Selected Issue', '%s Selected Issues', numIssues)} (${selectedIssueIds})`;
+  }, [allInQuerySelected, queryCount, numIssues, selectedIssueIds]);
 
   if (!anySelected) {
     return null;
@@ -278,7 +240,7 @@ export function IssueListBulkCommandPaletteActions({
     <CommandPaletteSlot name="task">
       <CMDKAction
         display={{
-          label: `${tn('%s Selected Issue', '%s Selected Issues', numIssues)} (${selectedIssueIds})`,
+          label,
           icon: <IconIssues />,
         }}
       >

--- a/static/app/views/issueList/issueListBulkCommandPaletteActions.tsx
+++ b/static/app/views/issueList/issueListBulkCommandPaletteActions.tsx
@@ -171,8 +171,12 @@ export function IssueListBulkCommandPaletteActions({
     [selectedIdsSet]
   );
 
-  const canResolve = selectedIssues.some(issue => issue.status !== GroupStatus.RESOLVED);
-  const canArchive = selectedIssues.some(issue => issue.status !== GroupStatus.IGNORED);
+  const canResolve =
+    allInQuerySelected ||
+    selectedIssues.some(issue => issue.status !== GroupStatus.RESOLVED);
+  const canArchive =
+    allInQuerySelected ||
+    selectedIssues.some(issue => issue.status !== GroupStatus.IGNORED);
 
   function getSelectedIds(): string[] | undefined {
     return allInQuerySelected

--- a/static/app/views/issueList/issueListBulkCommandPaletteActions.tsx
+++ b/static/app/views/issueList/issueListBulkCommandPaletteActions.tsx
@@ -6,6 +6,7 @@ import {ActorAvatar, TeamAvatar, UserAvatar} from '@sentry/scraps/avatar';
 import {IconCellSignal} from 'sentry/components/badge/iconCellSignal';
 import {CMDKAction} from 'sentry/components/commandPalette/ui/cmdk';
 import {CommandPaletteSlot} from 'sentry/components/commandPalette/ui/commandPaletteSlot';
+import {openConfirmModal} from 'sentry/components/confirm';
 import {IconCheckmark, IconClock, IconIssues, IconUser} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import {GroupStore} from 'sentry/stores/groupStore';
@@ -38,6 +39,10 @@ interface IssueListBulkCommandPaletteActionsProps {
   onActionTaken?: (itemIds: string[], data: IssueUpdateData) => void;
 }
 
+interface IssueListMarkAllCommandPaletteActionProps extends IssueListBulkCommandPaletteActionsProps {}
+
+type BulkActionConfirmScope = 'allInQuery' | 'selection';
+
 function useOrgMembers() {
   const organization = useOrganization();
   return useQuery({
@@ -53,9 +58,13 @@ function useOrgMembers() {
 }
 
 function AssignActions({
+  onConfirmBulkUpdate,
   onBulkUpdate,
+  label = t('Assign to'),
 }: {
   onBulkUpdate: (data: Record<string, unknown>) => void;
+  label?: string;
+  onConfirmBulkUpdate?: (actionLabel: string, onConfirm: () => void) => void;
 }) {
   const user = useUser();
   const {teams} = useTeams({provideUserTeams: true});
@@ -73,7 +82,7 @@ function AssignActions({
 
   return (
     <CMDKAction
-      display={{label: t('Assign to'), icon: <IconUser />}}
+      display={{label, icon: <IconUser />}}
       keywords={['assign', 'owner', 'assignee']}
       prompt={t('Search assignees...')}
     >
@@ -84,13 +93,25 @@ function AssignActions({
             icon: <UserAvatar user={user} size={16} hasTooltip={false} />,
           }}
           keywords={['mine', 'my issues', 'me']}
-          onAction={() => onBulkUpdate({assignedTo: `user:${user.id}`})}
+          onAction={() =>
+            onConfirmBulkUpdate
+              ? onConfirmBulkUpdate(t('assign issues to me'), () =>
+                  onBulkUpdate({assignedTo: `user:${user.id}`})
+                )
+              : onBulkUpdate({assignedTo: `user:${user.id}`})
+          }
         />
       )}
       <CMDKAction
         display={{label: t('Unassign'), icon: <IconUser />}}
         keywords={['unassign', 'clear', 'remove assignee', 'nobody']}
-        onAction={() => onBulkUpdate({assignedTo: ''})}
+        onAction={() =>
+          onConfirmBulkUpdate
+            ? onConfirmBulkUpdate(t('unassign issues'), () =>
+                onBulkUpdate({assignedTo: ''})
+              )
+            : onBulkUpdate({assignedTo: ''})
+        }
       />
       {sortedTeams.map(team => (
         <CMDKAction
@@ -99,7 +120,13 @@ function AssignActions({
             label: `#${team.slug}`,
             icon: <TeamAvatar team={team} size={16} hasTooltip={false} />,
           }}
-          onAction={() => onBulkUpdate({assignedTo: `team:${team.id}`})}
+          onAction={() =>
+            onConfirmBulkUpdate
+              ? onConfirmBulkUpdate(t('assign issues to team #%s', team.slug), () =>
+                  onBulkUpdate({assignedTo: `team:${team.id}`})
+                )
+              : onBulkUpdate({assignedTo: `team:${team.id}`})
+          }
         />
       ))}
       {assignableMembers.map(m => (
@@ -119,14 +146,25 @@ function AssignActions({
               />
             ),
           }}
-          onAction={() => onBulkUpdate({assignedTo: `user:${m.user.id}`})}
+          onAction={() =>
+            onConfirmBulkUpdate
+              ? onConfirmBulkUpdate(
+                  t('assign issues to %s', m.user.name || m.user.email),
+                  () => onBulkUpdate({assignedTo: `user:${m.user.id}`})
+                )
+              : onBulkUpdate({assignedTo: `user:${m.user.id}`})
+          }
         />
       ))}
     </CMDKAction>
   );
 }
 
-function PriorityActions({onUpdate}: {onUpdate: (data: IssueUpdateData) => void}) {
+function PriorityActions({
+  onConfirmUpdate,
+}: {
+  onConfirmUpdate: (actionLabel: string, data: IssueUpdateData) => void;
+}) {
   return (
     <CMDKAction
       display={{label: t('Set Priority'), icon: <IconCellSignal bars={2} />}}
@@ -134,21 +172,33 @@ function PriorityActions({onUpdate}: {onUpdate: (data: IssueUpdateData) => void}
     >
       <CMDKAction
         display={{label: t('High'), icon: <IconCellSignal bars={3} />}}
-        onAction={() => onUpdate({priority: PriorityLevel.HIGH})}
+        onAction={() =>
+          onConfirmUpdate(t('set issue priority to high'), {
+            priority: PriorityLevel.HIGH,
+          })
+        }
       />
       <CMDKAction
         display={{label: t('Medium'), icon: <IconCellSignal bars={2} />}}
-        onAction={() => onUpdate({priority: PriorityLevel.MEDIUM})}
+        onAction={() =>
+          onConfirmUpdate(t('set issue priority to medium'), {
+            priority: PriorityLevel.MEDIUM,
+          })
+        }
       />
       <CMDKAction
         display={{label: t('Low'), icon: <IconCellSignal bars={1} />}}
-        onAction={() => onUpdate({priority: PriorityLevel.LOW})}
+        onAction={() =>
+          onConfirmUpdate(t('set issue priority to low'), {
+            priority: PriorityLevel.LOW,
+          })
+        }
       />
     </CMDKAction>
   );
 }
 
-export function IssueListBulkCommandPaletteActions({
+function useIssueListBulkCommandPaletteActions({
   query,
   queryCount,
   selection,
@@ -236,6 +286,123 @@ export function IssueListBulkCommandPaletteActions({
     return `${tn('%s Selected Issue', '%s Selected Issues', numIssues)} (${selectedIssueIds})`;
   }, [allInQuerySelected, queryCount, numIssues, selectedIssueIds]);
 
+  function confirmBulkAction(
+    actionLabel: string,
+    onConfirm: () => void,
+    scope: BulkActionConfirmScope = 'selection'
+  ) {
+    const isAllInQuery = scope === 'allInQuery' || allInQuerySelected;
+    const message = isAllInQuery
+      ? queryCount >= BULK_LIMIT
+        ? t(
+            'You are about to %s the first %s issues matching this search. Are you sure?',
+            actionLabel,
+            BULK_LIMIT_STR
+          )
+        : t(
+            'You are about to %s all %s issues matching this search. Are you sure?',
+            actionLabel,
+            queryCount
+          )
+      : t(
+          'You are about to %s %s selected issue%s. Are you sure?',
+          actionLabel,
+          numIssues,
+          numIssues === 1 ? '' : 's'
+        );
+
+    openConfirmModal({
+      message,
+      confirmText: t('Confirm'),
+      onConfirm,
+    });
+  }
+
+  return {
+    anySelected,
+    canArchive,
+    canResolve,
+    confirmBulkAction,
+    handleBulkUpdate,
+    handleUpdate,
+    label,
+  };
+}
+
+export function IssueListMarkAllCommandPaletteAction(
+  props: IssueListMarkAllCommandPaletteActionProps
+) {
+  const {anySelected, confirmBulkAction, handleBulkUpdate, handleUpdate} =
+    useIssueListBulkCommandPaletteActions(props);
+
+  if (anySelected) {
+    return null;
+  }
+
+  return (
+    <CMDKAction
+      display={{
+        label: t('Mark all issues as'),
+        icon: <IconIssues />,
+      }}
+      keywords={['issues', 'all issues', 'bulk', 'resolve', 'archive', 'assign']}
+    >
+      <AssignActions
+        label={t('Assigned to')}
+        onBulkUpdate={handleBulkUpdate}
+        onConfirmBulkUpdate={(actionLabel, onConfirm) =>
+          confirmBulkAction(actionLabel, onConfirm, 'allInQuery')
+        }
+      />
+      <CMDKAction
+        display={{label: t('Resolved'), icon: <IconCheckmark />}}
+        keywords={['resolve', 'fix', 'done', 'close']}
+        onAction={() =>
+          confirmBulkAction(
+            t('resolve'),
+            () =>
+              handleUpdate({
+                status: GroupStatus.RESOLVED,
+                statusDetails: {},
+                substatus: null,
+              }),
+            'allInQuery'
+          )
+        }
+      />
+      <CMDKAction
+        display={{label: t('Archived'), icon: <IconClock />}}
+        keywords={['archive', 'ignore', 'snooze', 'mute']}
+        onAction={() =>
+          confirmBulkAction(
+            t('archive'),
+            () =>
+              handleUpdate({
+                status: GroupStatus.IGNORED,
+                statusDetails: {},
+                substatus: GroupSubstatus.ARCHIVED_UNTIL_ESCALATING,
+              }),
+            'allInQuery'
+          )
+        }
+      />
+    </CMDKAction>
+  );
+}
+
+export function IssueListBulkCommandPaletteActions(
+  props: IssueListBulkCommandPaletteActionsProps
+) {
+  const {
+    anySelected,
+    canArchive,
+    canResolve,
+    confirmBulkAction,
+    handleBulkUpdate,
+    handleUpdate,
+    label,
+  } = useIssueListBulkCommandPaletteActions(props);
+
   if (!anySelected) {
     return null;
   }
@@ -253,11 +420,13 @@ export function IssueListBulkCommandPaletteActions({
             display={{label: t('Resolve'), icon: <IconCheckmark />}}
             keywords={['resolve', 'fix', 'done', 'close']}
             onAction={() =>
-              handleUpdate({
-                status: GroupStatus.RESOLVED,
-                statusDetails: {},
-                substatus: null,
-              })
+              confirmBulkAction(t('resolve'), () =>
+                handleUpdate({
+                  status: GroupStatus.RESOLVED,
+                  statusDetails: {},
+                  substatus: null,
+                })
+              )
             }
           />
         )}
@@ -266,16 +435,25 @@ export function IssueListBulkCommandPaletteActions({
             display={{label: t('Archive'), icon: <IconClock />}}
             keywords={['archive', 'ignore', 'snooze', 'mute']}
             onAction={() =>
-              handleUpdate({
-                status: GroupStatus.IGNORED,
-                statusDetails: {},
-                substatus: GroupSubstatus.ARCHIVED_UNTIL_ESCALATING,
-              })
+              confirmBulkAction(t('archive'), () =>
+                handleUpdate({
+                  status: GroupStatus.IGNORED,
+                  statusDetails: {},
+                  substatus: GroupSubstatus.ARCHIVED_UNTIL_ESCALATING,
+                })
+              )
             }
           />
         )}
-        <PriorityActions onUpdate={handleUpdate} />
-        <AssignActions onBulkUpdate={handleBulkUpdate} />
+        <PriorityActions
+          onConfirmUpdate={(actionLabel, data) =>
+            confirmBulkAction(actionLabel, () => handleUpdate(data))
+          }
+        />
+        <AssignActions
+          onBulkUpdate={handleBulkUpdate}
+          onConfirmBulkUpdate={confirmBulkAction}
+        />
       </CMDKAction>
     </CommandPaletteSlot>
   );

--- a/static/app/views/issueList/issueListCommandPaletteActions.tsx
+++ b/static/app/views/issueList/issueListCommandPaletteActions.tsx
@@ -19,6 +19,7 @@ import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import type {SearchGroup} from 'sentry/components/searchBar/types';
 import {IconBookmark, IconFilter, IconGroup, IconIssues, IconSort} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import type {PageFilters} from 'sentry/types/core';
 import type {Tag} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getUtcDateString} from 'sentry/utils/dates';
@@ -35,12 +36,14 @@ import {useParams} from 'sentry/utils/useParams';
 import {useUser} from 'sentry/utils/useUser';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 import {mergeAndSortTagValues} from 'sentry/views/issueDetails/utils';
+import {IssueListMarkAllCommandPaletteAction} from 'sentry/views/issueList/issueListBulkCommandPaletteActions';
 import {createIssueViewFromUrl} from 'sentry/views/issueList/issueViews/createIssueViewFromUrl';
 import {CreateIssueViewModal} from 'sentry/views/issueList/issueViews/createIssueViewModal';
 import {useIssueViewUnsavedChanges} from 'sentry/views/issueList/issueViews/useIssueViewUnsavedChanges';
 import {useSelectedGroupSearchView} from 'sentry/views/issueList/issueViews/useSelectedGroupSeachView';
 import {canEditIssueView} from 'sentry/views/issueList/issueViews/utils';
 import {useUpdateGroupSearchView} from 'sentry/views/issueList/mutations/useUpdateGroupSearchView';
+import type {IssueUpdateData} from 'sentry/views/issueList/types';
 import {
   FOR_REVIEW_QUERIES,
   getSortLabel,
@@ -49,10 +52,14 @@ import {
 import {useIssueListFilterKeys} from 'sentry/views/issueList/utils/useIssueListFilterKeys';
 
 interface IssueListCommandPaletteActionsProps {
+  groupIds: string[];
   onQueryChange: (query: string) => void;
   onSortChange: (sort: string) => void;
   query: string;
+  queryCount: number;
+  selection: PageFilters;
   sort: IssueSortOptions;
+  onActionTaken?: (itemIds: string[], data: IssueUpdateData) => void;
 }
 
 /**
@@ -372,6 +379,10 @@ function SaveViewActions({
 }
 
 export function IssueListCommandPaletteActions({
+  groupIds,
+  queryCount,
+  selection,
+  onActionTaken,
   query,
   sort,
   onSortChange,
@@ -381,6 +392,13 @@ export function IssueListCommandPaletteActions({
     <CommandPaletteSlot name="page">
       <CMDKAction display={{label: t('Issues Feed'), icon: <IconIssues />}}>
         <FilterActions query={query} onQueryChange={onQueryChange} />
+        <IssueListMarkAllCommandPaletteAction
+          groupIds={groupIds}
+          query={query}
+          queryCount={queryCount}
+          selection={selection}
+          onActionTaken={onActionTaken}
+        />
         <SortActions sort={sort} query={query} onSortChange={onSortChange} />
         <SaveViewActions query={query} sort={sort} />
       </CMDKAction>

--- a/static/app/views/issueList/issueListTable.tsx
+++ b/static/app/views/issueList/issueListTable.tsx
@@ -14,7 +14,6 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {IssueListActions} from 'sentry/views/issueList/actions';
 import {GroupListBody} from 'sentry/views/issueList/groupListBody';
 import {IssueListBulkCommandPaletteActions} from 'sentry/views/issueList/issueListBulkCommandPaletteActions';
-import {IssueSelectionProvider} from 'sentry/views/issueList/issueSelectionContext';
 import {NewViewEmptyState} from 'sentry/views/issueList/newViewEmptyState';
 import type {SupergroupLookup} from 'sentry/views/issueList/supergroups/useSuperGroups';
 import type {IssueUpdateData} from 'sentry/views/issueList/types';
@@ -94,52 +93,50 @@ export function IssueListTable({
         {tourProps => (
           <div {...tourProps}>
             <ContainerPanel>
-              <IssueSelectionProvider visibleGroupIds={groupIds}>
-                <IssueListBulkCommandPaletteActions
+              <IssueListBulkCommandPaletteActions
+                query={query}
+                queryCount={queryCount}
+                selection={selection}
+                groupIds={groupIds}
+                onActionTaken={onActionTaken}
+              />
+              {(groupIds.length > 0 || issuesLoading) && (
+                <IssueListActions
+                  selection={selection}
                   query={query}
                   queryCount={queryCount}
-                  selection={selection}
-                  groupIds={groupIds}
+                  onSelectStatsPeriod={onSelectStatsPeriod}
                   onActionTaken={onActionTaken}
+                  onDelete={onDelete}
+                  statsPeriod={statsPeriod}
+                  groupIds={groupIds}
+                  allResultsVisible={allResultsVisible}
+                  displayReprocessingActions={displayReprocessingActions}
                 />
-                {(groupIds.length > 0 || issuesLoading) && (
-                  <IssueListActions
-                    selection={selection}
-                    query={query}
-                    queryCount={queryCount}
-                    onSelectStatsPeriod={onSelectStatsPeriod}
-                    onActionTaken={onActionTaken}
-                    onDelete={onDelete}
-                    statsPeriod={statsPeriod}
+              )}
+              <PanelBody>
+                <VisuallyCompleteWithData
+                  hasData={groupIds.length > 0}
+                  id="IssueList-Body"
+                  isLoading={issuesLoading}
+                >
+                  <GroupListBody
+                    memberList={memberList}
+                    groupStatsPeriod={statsPeriod}
                     groupIds={groupIds}
-                    allResultsVisible={allResultsVisible}
-                    displayReprocessingActions={displayReprocessingActions}
+                    displayReprocessingLayout={displayReprocessingActions}
+                    query={query}
+                    selectedProjectIds={selection.projects}
+                    // we need the stats loading and group id check because group ids do not update immediately
+                    loading={issuesLoading || (statsLoading && !groupIds.length)}
+                    error={error}
+                    pageSize={pageSize}
+                    refetchGroups={refetchGroups}
+                    onActionTaken={onActionTaken}
+                    supergroupLookup={supergroupLookup}
                   />
-                )}
-                <PanelBody>
-                  <VisuallyCompleteWithData
-                    hasData={groupIds.length > 0}
-                    id="IssueList-Body"
-                    isLoading={issuesLoading}
-                  >
-                    <GroupListBody
-                      memberList={memberList}
-                      groupStatsPeriod={statsPeriod}
-                      groupIds={groupIds}
-                      displayReprocessingLayout={displayReprocessingActions}
-                      query={query}
-                      selectedProjectIds={selection.projects}
-                      // we need the stats loading and group id check because group ids do not update immediately
-                      loading={issuesLoading || (statsLoading && !groupIds.length)}
-                      error={error}
-                      pageSize={pageSize}
-                      refetchGroups={refetchGroups}
-                      onActionTaken={onActionTaken}
-                      supergroupLookup={supergroupLookup}
-                    />
-                  </VisuallyCompleteWithData>
-                </PanelBody>
-              </IssueSelectionProvider>
+                </VisuallyCompleteWithData>
+              </PanelBody>
             </ContainerPanel>
           </div>
         )}

--- a/static/app/views/issueList/issueListTable.tsx
+++ b/static/app/views/issueList/issueListTable.tsx
@@ -97,6 +97,7 @@ export function IssueListTable({
               <IssueSelectionProvider visibleGroupIds={groupIds}>
                 <IssueListBulkCommandPaletteActions
                   query={query}
+                  queryCount={queryCount}
                   selection={selection}
                   groupIds={groupIds}
                   onActionTaken={onActionTaken}

--- a/static/app/views/issueList/issueListTable.tsx
+++ b/static/app/views/issueList/issueListTable.tsx
@@ -13,6 +13,7 @@ import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
 import {useLocation} from 'sentry/utils/useLocation';
 import {IssueListActions} from 'sentry/views/issueList/actions';
 import {GroupListBody} from 'sentry/views/issueList/groupListBody';
+import {IssueListBulkCommandPaletteActions} from 'sentry/views/issueList/issueListBulkCommandPaletteActions';
 import {IssueSelectionProvider} from 'sentry/views/issueList/issueSelectionContext';
 import {NewViewEmptyState} from 'sentry/views/issueList/newViewEmptyState';
 import type {SupergroupLookup} from 'sentry/views/issueList/supergroups/useSuperGroups';
@@ -94,6 +95,12 @@ export function IssueListTable({
           <div {...tourProps}>
             <ContainerPanel>
               <IssueSelectionProvider visibleGroupIds={groupIds}>
+                <IssueListBulkCommandPaletteActions
+                  query={query}
+                  selection={selection}
+                  groupIds={groupIds}
+                  onActionTaken={onActionTaken}
+                />
                 {(groupIds.length > 0 || issuesLoading) && (
                   <IssueListActions
                     selection={selection}

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -47,6 +47,7 @@ import {useParams} from 'sentry/utils/useParams';
 import {usePrevious} from 'sentry/utils/usePrevious';
 import {IssueListTable} from 'sentry/views/issueList/issueListTable';
 import {IssuesDataConsentBanner} from 'sentry/views/issueList/issuesDataConsentBanner';
+import {IssueSelectionProvider} from 'sentry/views/issueList/issueSelectionContext';
 import {IssueViewsHeader} from 'sentry/views/issueList/issueViewsHeader';
 import {useSupergroupDrawer} from 'sentry/views/issueList/supergroups/useSupergroupDrawer';
 import {useSuperGroups} from 'sentry/views/issueList/supergroups/useSuperGroups';
@@ -880,76 +881,84 @@ function IssueListOverview({
   const hasPageFrame = useHasPageFrameFeature();
 
   return (
-    <Stack flex={1}>
-      <IssueListCommandPaletteActions
-        query={query}
-        sort={sort}
-        onSortChange={onSortChange}
-        onQueryChange={onSearch}
-      />
-      <IssueViewsHeader
-        selectedProjectIds={selection.projects}
-        title={title}
-        description={titleDescription}
-        realtimeActive={realtimeActive}
-        onRealtimeChange={onRealtimeChange}
-        headerActions={headerActions}
-      />
-      <StyledBody>
-        <Grid
-          area="content"
-          padding={hasPageFrame ? {sm: 'md lg', md: 'md xl'} : {sm: 'xl', md: '2xl 3xl'}}
-        >
-          <IssuesDataConsentBanner source="issues" />
-          <IssueListFilters
-            query={query}
-            sort={sort}
-            onSortChange={onSortChange}
-            onSearch={onSearch}
-          />
-          <IssueListTable
-            selection={selection}
-            query={query}
-            queryCount={modifiedQueryCount}
-            onSelectStatsPeriod={onSelectStatsPeriod}
-            onActionTaken={onActionTaken}
-            onDelete={onDelete}
-            statsPeriod={getGroupStatsPeriod()}
-            groupIds={groupIds}
-            allResultsVisible={allResultsVisible()}
-            displayReprocessingActions={displayReprocessingActions}
-            memberList={memberList}
-            selectedProjectIds={selection.projects}
-            issuesLoading={issuesLoading || supergroupsLoading}
-            statsLoading={statsLoading}
-            supergroupLookup={supergroupLookup}
-            error={error}
-            refetchGroups={fetchData}
-            paginationCaption={
-              !issuesLoading && modifiedQueryCount > 0
-                ? tct('[start]-[end] of [total]', {
-                    start: numPreviousIssues + 1,
-                    end: numPreviousIssues + numIssuesOnPage,
-                    total: (
-                      <QueryCount
-                        hideParens
-                        hideIfEmpty={false}
-                        count={modifiedQueryCount}
-                        max={queryMaxCount || 100}
-                      />
-                    ),
-                  })
-                : null
+    <IssueSelectionProvider visibleGroupIds={groupIds}>
+      <Stack flex={1}>
+        <IssueListCommandPaletteActions
+          groupIds={groupIds}
+          query={query}
+          queryCount={modifiedQueryCount}
+          selection={selection}
+          sort={sort}
+          onSortChange={onSortChange}
+          onQueryChange={onSearch}
+          onActionTaken={onActionTaken}
+        />
+        <IssueViewsHeader
+          selectedProjectIds={selection.projects}
+          title={title}
+          description={titleDescription}
+          realtimeActive={realtimeActive}
+          onRealtimeChange={onRealtimeChange}
+          headerActions={headerActions}
+        />
+        <StyledBody>
+          <Grid
+            area="content"
+            padding={
+              hasPageFrame ? {sm: 'md lg', md: 'md xl'} : {sm: 'xl', md: '2xl 3xl'}
             }
-            pageLinks={pageLinks}
-            onCursor={onCursorChange}
-            paginationAnalyticsEvent={paginationAnalyticsEvent}
-            issuesSuccessfullyLoaded={issuesSuccessfullyLoaded}
-            pageSize={MAX_ITEMS}
-          />
-        </Grid>
-      </StyledBody>
-    </Stack>
+          >
+            <IssuesDataConsentBanner source="issues" />
+            <IssueListFilters
+              query={query}
+              sort={sort}
+              onSortChange={onSortChange}
+              onSearch={onSearch}
+            />
+            <IssueListTable
+              selection={selection}
+              query={query}
+              queryCount={modifiedQueryCount}
+              onSelectStatsPeriod={onSelectStatsPeriod}
+              onActionTaken={onActionTaken}
+              onDelete={onDelete}
+              statsPeriod={getGroupStatsPeriod()}
+              groupIds={groupIds}
+              allResultsVisible={allResultsVisible()}
+              displayReprocessingActions={displayReprocessingActions}
+              memberList={memberList}
+              selectedProjectIds={selection.projects}
+              issuesLoading={issuesLoading || supergroupsLoading}
+              statsLoading={statsLoading}
+              supergroupLookup={supergroupLookup}
+              error={error}
+              refetchGroups={fetchData}
+              paginationCaption={
+                !issuesLoading && modifiedQueryCount > 0
+                  ? tct('[start]-[end] of [total]', {
+                      start: numPreviousIssues + 1,
+                      end: numPreviousIssues + numIssuesOnPage,
+                      total: (
+                        <QueryCount
+                          hideParens
+                          hideIfEmpty={false}
+                          count={modifiedQueryCount}
+                          max={queryMaxCount || 100}
+                        />
+                      ),
+                    })
+                  : null
+              }
+              pageLinks={pageLinks}
+              onCursor={onCursorChange}
+              paginationAnalyticsEvent={paginationAnalyticsEvent}
+              issuesSuccessfullyLoaded={issuesSuccessfullyLoaded}
+              pageSize={MAX_ITEMS}
+            />
+          </Grid>
+        </StyledBody>
+      </Stack>
+    </IssueSelectionProvider>
   );
 }
 


### PR DESCRIPTION
## Summary
- When issues are selected on the Issues feed, a new **"N Selected Issues"** group appears in the command palette (Cmd+K) with bulk actions: **Resolve**, **Archive**, **Set Priority** (High/Medium/Low), and **Assign to** (me, teams, searchable org members)
- The group uses the `task` slot so it renders above the existing "Issues Feed" actions
- The label includes short IDs of selected issues (e.g. "2 Selected Issues (#PROJ-1, #PROJ-2)")
- The assign action eagerly loads org members as static children, so all assignees surface as sub-results during search without requiring drill-in

Closes #65088
Closes #61935