### PR TITLE
fix(seer): Propagate viewer_context on explorer run polling

### DIFF
--- a/src/sentry/seer/explorer/client.py
+++ b/src/sentry/seer/explorer/client.py
@@ -438,9 +438,15 @@ class SeerExplorerClient:
             TimeoutError: If polling exceeds poll_timeout when blocking=True
         """
         if blocking:
-            state = poll_until_done(run_id, self.organization, poll_interval, poll_timeout)
+            state = poll_until_done(
+                run_id,
+                self.organization,
+                poll_interval,
+                poll_timeout,
+                viewer_context=self.viewer_context,
+            )
         else:
-            state = fetch_run_status(run_id, self.organization)
+            state = fetch_run_status(run_id, self.organization, viewer_context=self.viewer_context)
 
         return state
 
@@ -599,7 +605,7 @@ class SeerExplorerClient:
         start_time = time.time()
 
         while True:
-            state = fetch_run_status(run_id, self.organization)
+            state = fetch_run_status(run_id, self.organization, viewer_context=self.viewer_context)
 
             # Check if any PRs are still being created
             any_creating = any(

--- a/src/sentry/seer/explorer/client_utils.py
+++ b/src/sentry/seer/explorer/client_utils.py
@@ -341,10 +341,14 @@ def get_proxy_headers() -> dict[str, str] | None:
         return None
 
 
-def fetch_run_status(run_id: int, organization: Organization) -> SeerRunState:
+def fetch_run_status(
+    run_id: int,
+    organization: Organization,
+    viewer_context: SeerViewerContext | None = None,
+) -> SeerRunState:
     """Fetch current run status from Seer."""
     body = ExplorerStateRequest(run_id=run_id, organization_id=organization.id)
-    response = make_explorer_state_request(body)
+    response = make_explorer_state_request(body, viewer_context=viewer_context)
 
     if response.status >= 400:
         raise SeerApiError("Seer request failed", response.status)
@@ -362,12 +366,13 @@ def poll_until_done(
     organization: Organization,
     poll_interval: float,
     poll_timeout: float,
+    viewer_context: SeerViewerContext | None = None,
 ) -> SeerRunState:
     """Poll the run status until completion, error, awaiting_user_input, or timeout."""
     start_time = time.time()
 
     while True:
-        result = fetch_run_status(run_id, organization)
+        result = fetch_run_status(run_id, organization, viewer_context=viewer_context)
 
         # Check if run is complete
         if result.status in ("completed", "error", "awaiting_user_input"):

--- a/tests/sentry/seer/explorer/test_explorer_client.py
+++ b/tests/sentry/seer/explorer/test_explorer_client.py
@@ -321,7 +321,9 @@ class TestSeerExplorerClient(TestCase):
 
         assert result.run_id == 123
         assert result.status == "processing"
-        mock_fetch.assert_called_once_with(123, self.organization)
+        mock_fetch.assert_called_once_with(
+            123, self.organization, viewer_context=client.viewer_context
+        )
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
     @patch("sentry.seer.explorer.client.poll_until_done")
@@ -341,7 +343,9 @@ class TestSeerExplorerClient(TestCase):
 
         assert result.run_id == 123
         assert result.status == "completed"
-        mock_poll.assert_called_once_with(123, self.organization, 1.0, 30.0)
+        mock_poll.assert_called_once_with(
+            123, self.organization, 1.0, 30.0, viewer_context=client.viewer_context
+        )
 
     @patch("sentry.seer.explorer.client.has_seer_access_with_detail")
     @patch("sentry.seer.explorer.client.fetch_run_status")


### PR DESCRIPTION
`SeerExplorerClient` builds a `SeerViewerContext` at construction and
threads it through `start_run`, `continue_run`, `get_runs`, and
`push_changes`. The polling path (`get_run`, and the `push_changes`
PR-creation poll) was the odd one out — it called `fetch_run_status` /
`poll_until_done` without passing `viewer_context`, so the explicit
context was silently dropped on every poll. This caused
`viewer_context.missing (point='seer_rpc_out')` warnings whenever the
caller (e.g. a Celery task) had no ambient viewer context set, like
night-shift triage.

Add an optional `viewer_context` kwarg to `fetch_run_status` and
`poll_until_done` and pass `self.viewer_context` from the three client
callsites, matching the existing pattern in the rest of the client.