### PR TITLE
chore(preprod): Drop redundant git_* defaults from frontend (EME-1047)

### DIFF
--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -103,17 +103,7 @@ export const SENTRY_PREPROD_STRING_TAGS: string[] = [
   'platform_name',
 ];
 
-const PREPROD_IMAGE_FIELDS = [
-  'image_count',
-  'images_added',
-  'images_changed',
-  'images_removed',
-  'images_renamed',
-  'images_skipped',
-  'images_unchanged',
-] as const;
-
-export const SENTRY_PREPROD_NUMBER_TAGS: string[] = [...PREPROD_IMAGE_FIELDS];
+export const SENTRY_PREPROD_NUMBER_TAGS: string[] = [];
 
 export const SENTRY_PREPROD_BOOLEAN_TAGS: string[] = ['is_approved'];
 
@@ -138,7 +128,13 @@ export const HIDDEN_PREPROD_ATTRIBUTES = [
   'metrics_artifact_type',
   'tags[metrics_artifact_type,number]',
   'tags[artifact_type,number]',
-  ...PREPROD_IMAGE_FIELDS,
+  'image_count',
+  'images_added',
+  'images_changed',
+  'images_removed',
+  'images_renamed',
+  'images_skipped',
+  'images_unchanged',
   'is_approved',
 ];
 

--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -103,10 +103,6 @@ export const SENTRY_PREPROD_STRING_TAGS: string[] = [
   'platform_name',
 ];
 
-export const SENTRY_PREPROD_NUMBER_TAGS: string[] = [];
-
-export const SENTRY_PREPROD_BOOLEAN_TAGS: string[] = ['is_approved'];
-
 const PREPROD_IMAGE_FIELDS = [
   'image_count',
   'images_added',
@@ -116,6 +112,14 @@ const PREPROD_IMAGE_FIELDS = [
   'images_skipped',
   'images_unchanged',
 ] as const;
+
+// Image fields are stored in Postgres (PreprodSnapshotMetrics), not EAP, so the
+// attribute keys API never returns them. Seeding them here makes them available
+// to the mobile builds search bar, which uses an allowlist (no hiddenKeys) and
+// therefore relies on the default seed to populate autocomplete.
+export const SENTRY_PREPROD_NUMBER_TAGS: string[] = [...PREPROD_IMAGE_FIELDS];
+
+export const SENTRY_PREPROD_BOOLEAN_TAGS: string[] = ['is_approved'];
 
 export const HIDDEN_PREPROD_ATTRIBUTES = [
   'min_install_size',

--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -100,8 +100,6 @@ export const SENTRY_PREPROD_STRING_TAGS: string[] = [
   'build_configuration_name',
   'build_number',
   'build_version',
-  'git_base_ref',
-  'git_head_ref',
   'platform_name',
 ];
 
@@ -115,10 +113,7 @@ const PREPROD_IMAGE_FIELDS = [
   'images_unchanged',
 ] as const;
 
-export const SENTRY_PREPROD_NUMBER_TAGS: string[] = [
-  'git_pr_number',
-  ...PREPROD_IMAGE_FIELDS,
-];
+export const SENTRY_PREPROD_NUMBER_TAGS: string[] = [...PREPROD_IMAGE_FIELDS];
 
 export const SENTRY_PREPROD_BOOLEAN_TAGS: string[] = ['is_approved'];
 

--- a/static/app/views/explore/constants.tsx
+++ b/static/app/views/explore/constants.tsx
@@ -107,6 +107,16 @@ export const SENTRY_PREPROD_NUMBER_TAGS: string[] = [];
 
 export const SENTRY_PREPROD_BOOLEAN_TAGS: string[] = ['is_approved'];
 
+const PREPROD_IMAGE_FIELDS = [
+  'image_count',
+  'images_added',
+  'images_changed',
+  'images_removed',
+  'images_renamed',
+  'images_skipped',
+  'images_unchanged',
+] as const;
+
 export const HIDDEN_PREPROD_ATTRIBUTES = [
   'min_install_size',
   'tags[min_install_size,number]',
@@ -128,13 +138,7 @@ export const HIDDEN_PREPROD_ATTRIBUTES = [
   'metrics_artifact_type',
   'tags[metrics_artifact_type,number]',
   'tags[artifact_type,number]',
-  'image_count',
-  'images_added',
-  'images_changed',
-  'images_removed',
-  'images_renamed',
-  'images_skipped',
-  'images_unchanged',
+  ...PREPROD_IMAGE_FIELDS,
   'is_approved',
 ];
 


### PR DESCRIPTION
## Summary

#114153 registered `git_base_ref`, `git_head_ref`, and `git_pr_number` in `PREPROD_SIZE_ATTRIBUTE_DEFINITIONS`, so the `trace-items/attributes` endpoint now returns them under their canonical Sentry-source aliases. The matching entries in `SENTRY_PREPROD_STRING_TAGS` and `SENTRY_PREPROD_NUMBER_TAGS` are redundant once that data is flowing through — the attribute keys API is the source of truth.

These static defaults weren't actively harming autocomplete (the spread merge in `traceItemAttributeContext.tsx` dedupes by key), but they had drifted from `src/sentry/preprod/eap/write.py` (the comment claims to mirror it) and only covered 3 of the 8 git fields written. Easier to delete than to keep partially in sync.

Issue: https://linear.app/getsentry/issue/EME-1047/parse-down-filters-on-dashboards