### PR TITLE
feat(dynamic-sampling): add per-org activity check

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/tasks/queries.py
+++ b/src/sentry/dynamic_sampling/per_org/tasks/queries.py
@@ -50,11 +50,11 @@ def get_eap_organization_volume(
         sampling_mode=SAMPLING_MODE_HIGHEST_ACCURACY,
     )
 
-    data = result.get("data", [])
+    data = result.get("data")
     if not data:
         return None
 
-    total = int(data[0].get("count()", 0) or 0)
+    total = int(data[0].get("count()", 0))
     if total <= 0:
         return None
 

--- a/src/sentry/dynamic_sampling/per_org/tasks/queries.py
+++ b/src/sentry/dynamic_sampling/per_org/tasks/queries.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 from sentry_protos.snuba.v1.trace_item_attribute_pb2 import ExtrapolationMode
 
@@ -16,6 +18,10 @@ from sentry.search.eap.types import SearchResolverConfig
 from sentry.search.events.types import SnubaParams
 from sentry.snuba.referrer import Referrer
 from sentry.snuba.spans_rpc import Spans
+
+
+def _get_aggregate_int(row: Mapping[str, Any], column: str) -> int:
+    return int(row.get(column, 0))
 
 
 def get_eap_organization_volume(
@@ -54,9 +60,10 @@ def get_eap_organization_volume(
     if not data:
         return None
 
-    total = int(data[0].get("count()"))
+    row = data[0]
+    total = _get_aggregate_int(row, "count()")
     if total <= 0:
         return None
-    indexed = int(data[0].get("count_sample()"))
+    indexed = _get_aggregate_int(row, "count_sample()")
 
     return OrganizationDataVolume(org_id=organization.id, total=total, indexed=indexed)

--- a/src/sentry/dynamic_sampling/per_org/tasks/queries.py
+++ b/src/sentry/dynamic_sampling/per_org/tasks/queries.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import ExtrapolationMode
+
+from sentry.constants import ObjectStatus
+from sentry.dynamic_sampling.tasks.common import (
+    ACTIVE_ORGS_VOLUMES_DEFAULT_TIME_INTERVAL,
+    OrganizationDataVolume,
+)
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.search.eap.constants import SAMPLING_MODE_HIGHEST_ACCURACY
+from sentry.search.eap.types import SearchResolverConfig
+from sentry.search.events.types import SnubaParams
+from sentry.snuba.referrer import Referrer
+from sentry.snuba.spans_rpc import Spans
+
+
+def get_eap_organization_volume(
+    organization: Organization,
+    time_interval: timedelta = ACTIVE_ORGS_VOLUMES_DEFAULT_TIME_INTERVAL,
+) -> OrganizationDataVolume | None:
+    projects = list(
+        Project.objects.filter(organization_id=organization.id, status=ObjectStatus.ACTIVE)
+    )
+    if not projects:
+        return None
+
+    end_time = datetime.now(UTC)
+    start_time = end_time - time_interval
+    result = Spans.run_table_query(
+        params=SnubaParams(
+            start=start_time,
+            end=end_time,
+            projects=projects,
+            organization=organization,
+        ),
+        query_string="is_transaction:true",
+        selected_columns=["count()"],
+        orderby=None,
+        offset=0,
+        limit=1,
+        referrer=Referrer.DYNAMIC_SAMPLING_PER_ORG_GET_EAP_ORG_VOLUME.value,
+        config=SearchResolverConfig(
+            auto_fields=True,
+            extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_SERVER_ONLY,
+        ),
+        sampling_mode=SAMPLING_MODE_HIGHEST_ACCURACY,
+    )
+
+    data = result.get("data", [])
+    if not data:
+        return None
+
+    total = int(data[0].get("count()", 0) or 0)
+    if total <= 0:
+        return None
+
+    return OrganizationDataVolume(org_id=organization.id, total=total, indexed=total)

--- a/src/sentry/dynamic_sampling/per_org/tasks/queries.py
+++ b/src/sentry/dynamic_sampling/per_org/tasks/queries.py
@@ -38,7 +38,7 @@ def get_eap_organization_volume(
             organization=organization,
         ),
         query_string="is_transaction:true",
-        selected_columns=["count()"],
+        selected_columns=["count()", "count_sample()"],
         orderby=None,
         offset=0,
         limit=1,
@@ -54,8 +54,9 @@ def get_eap_organization_volume(
     if not data:
         return None
 
-    total = int(data[0].get("count()", 0))
+    total = int(data[0].get("count()"))
     if total <= 0:
         return None
+    indexed = int(data[0].get("count_sample()"))
 
-    return OrganizationDataVolume(org_id=organization.id, total=total, indexed=total)
+    return OrganizationDataVolume(org_id=organization.id, total=total, indexed=indexed)

--- a/src/sentry/dynamic_sampling/per_org/tasks/scheduler.py
+++ b/src/sentry/dynamic_sampling/per_org/tasks/scheduler.py
@@ -109,4 +109,4 @@ def run_calculations_per_org_task(org_id: OrganizationId) -> TelemetryStatus | N
     if org_volume is None:
         return TelemetryStatus.NO_VOLUME
 
-    return
+    return None

--- a/src/sentry/dynamic_sampling/per_org/tasks/scheduler.py
+++ b/src/sentry/dynamic_sampling/per_org/tasks/scheduler.py
@@ -9,6 +9,7 @@ from django.db.models.functions import Mod
 from taskbroker_client.retry import Retry
 
 from sentry.dynamic_sampling.per_org.tasks.gate import is_org_in_rollout
+from sentry.dynamic_sampling.per_org.tasks.queries import get_eap_organization_volume
 from sentry.dynamic_sampling.per_org.tasks.telemetry import (
     SCHEDULER_BUCKET_ORG_STATUS_METRIC,
     TelemetryStatus,
@@ -16,6 +17,7 @@ from sentry.dynamic_sampling.per_org.tasks.telemetry import (
     track_dynamic_sampling,
 )
 from sentry.dynamic_sampling.rules.utils import OrganizationId, get_redis_client_for_ds
+from sentry.dynamic_sampling.utils import has_dynamic_sampling
 from sentry.models.organization import Organization, OrganizationStatus
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
@@ -94,5 +96,17 @@ def schedule_per_org_calculations() -> None:
     silo_mode=SiloMode.CELL,
 )
 @track_dynamic_sampling
-def run_calculations_per_org_task(org_id: OrganizationId) -> None:
+def run_calculations_per_org_task(org_id: OrganizationId) -> TelemetryStatus | None:
+    try:
+        organization = Organization.objects.get_from_cache(id=org_id)
+    except Organization.DoesNotExist:
+        return TelemetryStatus.ORG_NOT_FOUND
+
+    if not has_dynamic_sampling(organization):
+        return TelemetryStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
+
+    org_volume = get_eap_organization_volume(organization)
+    if org_volume is None:
+        return TelemetryStatus.NO_VOLUME
+
     return

--- a/src/sentry/dynamic_sampling/tasks/common.py
+++ b/src/sentry/dynamic_sampling/tasks/common.py
@@ -33,7 +33,7 @@ from sentry.utils.snuba import raw_snql_query
 ACTIVE_ORGS_DEFAULT_TIME_INTERVAL = timedelta(hours=1)
 ACTIVE_ORGS_DEFAULT_GRANULARITY = Granularity(3600)
 
-ACTIVE_ORGS_VOLUMES_DEFAULT_TIME_INTERVAL = timedelta(hours=1)
+ACTIVE_ORGS_VOLUMES_DEFAULT_TIME_INTERVAL = timedelta(minutes=5)
 ACTIVE_ORGS_VOLUMES_DEFAULT_GRANULARITY = Granularity(60)
 
 

--- a/src/sentry/dynamic_sampling/tasks/common.py
+++ b/src/sentry/dynamic_sampling/tasks/common.py
@@ -33,7 +33,7 @@ from sentry.utils.snuba import raw_snql_query
 ACTIVE_ORGS_DEFAULT_TIME_INTERVAL = timedelta(hours=1)
 ACTIVE_ORGS_DEFAULT_GRANULARITY = Granularity(3600)
 
-ACTIVE_ORGS_VOLUMES_DEFAULT_TIME_INTERVAL = timedelta(minutes=5)
+ACTIVE_ORGS_VOLUMES_DEFAULT_TIME_INTERVAL = timedelta(hours=1)
 ACTIVE_ORGS_VOLUMES_DEFAULT_GRANULARITY = Granularity(60)
 
 

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -634,6 +634,7 @@ class Referrer(StrEnum):
     DYNAMIC_SAMPLING_DISTRIBUTION_FETCH_PROJECTS_WITH_COUNT_PER_ROOT = (
         "dynamic_sampling.distribution.fetch_projects_with_count_per_root_total_volumes"
     )
+    DYNAMIC_SAMPLING_PER_ORG_GET_EAP_ORG_VOLUME = "dynamic_sampling.per_org.get_eap_org_volume"
     DYNAMIC_SAMPLING_COUNTERS_FETCH_PROJECTS_WITH_COUNT_PER_TRANSACTION = (
         "dynamic_sampling.counters.fetch_projects_with_count_per_transaction_volumes"
     )

--- a/tests/sentry/dynamic_sampling/per_org/tasks/test_queries.py
+++ b/tests/sentry/dynamic_sampling/per_org/tasks/test_queries.py
@@ -49,6 +49,29 @@ class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
 
         assert org_volume == OrganizationDataVolume(org_id=organization.id, total=2, indexed=2)
 
+    def test_get_eap_organization_volume_returns_raw_and_extrapolated_counts(self) -> None:
+        organization = self.create_organization()
+        project = self.create_project(organization=organization)
+        timestamp = before_now(minutes=15)
+
+        self.store_spans(
+            [
+                self.create_span(
+                    {
+                        "is_segment": True,
+                        "measurements": {"server_sample_rate": {"value": 0.1}},
+                    },
+                    organization=organization,
+                    project=project,
+                    start_ts=timestamp,
+                ),
+            ]
+        )
+
+        org_volume = get_eap_organization_volume(organization, time_interval=timedelta(hours=1))
+
+        assert org_volume == OrganizationDataVolume(org_id=organization.id, total=10, indexed=1)
+
     def test_get_eap_organization_volume_without_traffic(self) -> None:
         organization = self.create_organization()
         self.create_project(organization=organization)

--- a/tests/sentry/dynamic_sampling/per_org/tasks/test_queries.py
+++ b/tests/sentry/dynamic_sampling/per_org/tasks/test_queries.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+from sentry.dynamic_sampling.per_org.tasks.queries import get_eap_organization_volume
+from sentry.dynamic_sampling.tasks.common import OrganizationDataVolume
+from sentry.testutils.cases import SnubaTestCase, SpanTestCase, TestCase
+from sentry.testutils.helpers.datetime import before_now
+
+
+class EAPOrganizationVolumeTest(TestCase, SnubaTestCase, SpanTestCase):
+    def test_get_eap_organization_volume_existing_org(self) -> None:
+        organization = self.create_organization()
+        project = self.create_project(organization=organization)
+        other_organization = self.create_organization()
+        other_project = self.create_project(organization=other_organization)
+        timestamp = before_now(minutes=15)
+
+        self.store_spans(
+            [
+                self.create_span(
+                    {"is_segment": True},
+                    organization=organization,
+                    project=project,
+                    start_ts=timestamp,
+                ),
+                self.create_span(
+                    {"is_segment": True},
+                    organization=organization,
+                    project=project,
+                    start_ts=timestamp + timedelta(seconds=1),
+                ),
+                self.create_span(
+                    {"is_segment": False},
+                    organization=organization,
+                    project=project,
+                    start_ts=timestamp + timedelta(seconds=2),
+                ),
+                self.create_span(
+                    {"is_segment": True},
+                    organization=other_organization,
+                    project=other_project,
+                    start_ts=timestamp,
+                ),
+            ]
+        )
+
+        org_volume = get_eap_organization_volume(organization, time_interval=timedelta(hours=1))
+
+        assert org_volume == OrganizationDataVolume(org_id=organization.id, total=2, indexed=2)
+
+    def test_get_eap_organization_volume_without_traffic(self) -> None:
+        organization = self.create_organization()
+        self.create_project(organization=organization)
+
+        org_volume = get_eap_organization_volume(organization, time_interval=timedelta(hours=1))
+
+        assert org_volume is None
+
+    def test_get_eap_organization_volume_without_projects(self) -> None:
+        organization = self.create_organization()
+
+        org_volume = get_eap_organization_volume(organization, time_interval=timedelta(hours=1))
+
+        assert org_volume is None

--- a/tests/sentry/dynamic_sampling/per_org/tasks/test_scheduler.py
+++ b/tests/sentry/dynamic_sampling/per_org/tasks/test_scheduler.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+from unittest.mock import patch
+
 from sentry.dynamic_sampling.per_org.tasks.scheduler import (
     BUCKET_COUNT,
     BUCKET_CURSOR_KEY,
     _next_bucket_index,
+    run_calculations_per_org_task,
     schedule_per_org_calculations,
 )
+from sentry.dynamic_sampling.per_org.tasks.telemetry import TelemetryStatus
 from sentry.dynamic_sampling.rules.utils import get_redis_client_for_ds
+from sentry.dynamic_sampling.tasks.common import OrganizationDataVolume
 from sentry.models.organization import OrganizationStatus
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
@@ -107,6 +112,61 @@ class SchedulePerOrgCalculationsTest(TestCase):
 
         assert active.id in dispatched
         assert pending_deletion.id not in dispatched
+
+    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
+    def test_run_calculations_per_org_returns_no_volume_without_traffic(self) -> None:
+        org = self.create_organization()
+
+        with (
+            self.feature("organizations:dynamic-sampling"),
+            patch(
+                "sentry.dynamic_sampling.per_org.tasks.scheduler.get_eap_organization_volume",
+                return_value=None,
+            ) as get_volume,
+        ):
+            result = run_calculations_per_org_task(org.id)
+
+        assert result == TelemetryStatus.NO_VOLUME
+        get_volume.assert_called_once_with(org)
+
+    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
+    def test_run_calculations_per_org_continues_with_traffic(self) -> None:
+        org = self.create_organization()
+        org_volume = OrganizationDataVolume(org_id=org.id, total=100, indexed=25)
+
+        with (
+            self.feature("organizations:dynamic-sampling"),
+            patch(
+                "sentry.dynamic_sampling.per_org.tasks.scheduler.get_eap_organization_volume",
+                return_value=org_volume,
+            ) as get_volume,
+        ):
+            result = run_calculations_per_org_task(org.id)
+
+        assert result is None
+        get_volume.assert_called_once_with(org)
+
+    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
+    def test_run_calculations_per_org_skips_org_without_dynamic_sampling(self) -> None:
+        org = self.create_organization()
+
+        with patch(
+            "sentry.dynamic_sampling.per_org.tasks.scheduler.get_eap_organization_volume"
+        ) as get_volume:
+            result = run_calculations_per_org_task(org.id)
+
+        assert result == TelemetryStatus.ORG_HAS_NO_DYNAMIC_SAMPLING
+        get_volume.assert_not_called()
+
+    @override_options({"dynamic-sampling.per_org.rollout-rate": 1.0})
+    def test_run_calculations_per_org_skips_missing_org(self) -> None:
+        with patch(
+            "sentry.dynamic_sampling.per_org.tasks.scheduler.get_eap_organization_volume"
+        ) as get_volume:
+            result = run_calculations_per_org_task(99999999)
+
+        assert result == TelemetryStatus.ORG_NOT_FOUND
+        get_volume.assert_not_called()
 
 
 class NextBucketIndexTest(TestCase):


### PR DESCRIPTION
- Add a feature gate to check whether the org has dynamic sampling to the scheduler
- Add a new query to EAP to retrieve the volume for a specific org

Closes TET-2275