### PR TITLE
fix(hooks): Convert Hook component to FC to prevent child remounting

### DIFF
--- a/static/app/components/hook.spec.tsx
+++ b/static/app/components/hook.spec.tsx
@@ -72,7 +72,7 @@ describe('Hook', () => {
       </HookWrapper>
     ));
 
-    HookStore.add('sidebar:bottom-items', () => (
+    HookStore.add('sidebar:organization-dropdown-menu', () => (
       <HookWrapper key="bottom">Bottom Hook</HookWrapper>
     ));
 
@@ -83,7 +83,12 @@ describe('Hook', () => {
     expect(screen.getByText(/Help Hook/)).toBeInTheDocument();
     expect(screen.queryByText(/Bottom Hook/)).not.toBeInTheDocument();
 
-    rerender(<Hook name="sidebar:bottom-items" organization={OrganizationFixture()} />);
+    rerender(
+      <Hook
+        name="sidebar:organization-dropdown-menu"
+        organization={OrganizationFixture()}
+      />
+    );
 
     expect(screen.queryByText(/Help Hook/)).not.toBeInTheDocument();
     expect(screen.getByText(/Bottom Hook/)).toBeInTheDocument();

--- a/static/app/components/hook.spec.tsx
+++ b/static/app/components/hook.spec.tsx
@@ -65,6 +65,30 @@ describe('Hook', () => {
     expect(screen.getByText(/Old Hook/)).toBeInTheDocument();
   });
 
+  it('re-fetches hooks when name prop changes', () => {
+    HookStore.add('sidebar:help-menu', ({organization}) => (
+      <HookWrapper key="help" organization={organization}>
+        Help Hook
+      </HookWrapper>
+    ));
+
+    HookStore.add('sidebar:bottom-items', () => (
+      <HookWrapper key="bottom">Bottom Hook</HookWrapper>
+    ));
+
+    const {rerender} = render(
+      <Hook name="sidebar:help-menu" organization={OrganizationFixture()} />
+    );
+
+    expect(screen.getByText(/Help Hook/)).toBeInTheDocument();
+    expect(screen.queryByText(/Bottom Hook/)).not.toBeInTheDocument();
+
+    rerender(<Hook name="sidebar:bottom-items" organization={OrganizationFixture()} />);
+
+    expect(screen.queryByText(/Help Hook/)).not.toBeInTheDocument();
+    expect(screen.getByText(/Bottom Hook/)).toBeInTheDocument();
+  });
+
   it('can use children as a render prop', () => {
     let idx = 0;
     render(

--- a/static/app/components/hook.tsx
+++ b/static/app/components/hook.tsx
@@ -40,6 +40,8 @@ function Hook<H extends ComponentHookName>({name, children, ...props}: Props<H>)
   );
 
   useEffect(() => {
+    setHookCallbacks([...HookStore.get(name)]);
+
     const unsubscribe = HookStore.listen((hookName: HookName, hooks: Array<Hooks[H]>) => {
       if (hookName === name) {
         setHookCallbacks([...hooks]);

--- a/static/app/components/hook.tsx
+++ b/static/app/components/hook.tsx
@@ -1,4 +1,4 @@
-import {Component, memo, type ComponentType} from 'react';
+import {memo, useEffect, useState, type ComponentType} from 'react';
 
 import {HookStore} from 'sentry/stores/hookStore';
 import type {HookName, Hooks} from 'sentry/types/hooks';
@@ -20,10 +20,6 @@ type Props<H extends ComponentHookName> = {
   children?: (opts: {hooks: Array<Hooks[H]>}) => React.ReactNode;
 } & Omit<Parameters<Hooks[H]>[0], 'name'>;
 
-type HookState<H extends HookName> = {
-  hooks: Array<Hooks[H]>;
-};
-
 /**
  * Instead of accessing the HookStore directly, use this.
  *
@@ -38,52 +34,33 @@ type HookState<H extends HookName> = {
  *     ))}
  *   </Hook>
  */
-function Hook<H extends ComponentHookName>({name, ...props}: Props<H>) {
-  class HookComponent extends Component<Record<string, unknown>, HookState<H>> {
-    static displayName = `Hook(${name})`;
+function Hook<H extends ComponentHookName>({name, children, ...props}: Props<H>) {
+  const [hookCallbacks, setHookCallbacks] = useState<Array<Hooks[H]>>(() =>
+    HookStore.get(name)
+  );
 
-    state = {
-      hooks: HookStore.get(name).map((HookComp, index) => (
-        <HookComp key={index} {...props} />
-      )),
-    };
-
-    componentWillUnmount() {
-      this.unsubscribe();
-    }
-
-    handleHooks(hookName: HookName, hooks: Array<Hooks[H]>) {
-      // Make sure that the incoming hook update matches this component's hook name
-      if (hookName !== name) {
-        return;
+  useEffect(() => {
+    const unsubscribe = HookStore.listen((hookName: HookName, hooks: Array<Hooks[H]>) => {
+      if (hookName === name) {
+        setHookCallbacks([...hooks]);
       }
+    }, undefined);
+    return () => unsubscribe();
+  }, [name]);
 
-      this.setState({
-        hooks: hooks.map((HookComp, index) => <HookComp key={index} {...props} />),
-      });
-    }
-
-    unsubscribe = HookStore.listen(
-      (hookName: HookName, hooks: Array<Hooks[H]>) => this.handleHooks(hookName, hooks),
-      undefined
-    );
-
-    render() {
-      const {children} = props;
-
-      if (!this.state.hooks?.length) {
-        return null;
-      }
-
-      if (typeof children === 'function') {
-        return children({hooks: this.state.hooks});
-      }
-
-      return this.state.hooks;
-    }
+  if (!hookCallbacks?.length) {
+    return null;
   }
 
-  return <HookComponent />;
+  const rendered = hookCallbacks.map((HookComp, index) => (
+    <HookComp key={index} {...props} />
+  ));
+
+  if (typeof children === 'function') {
+    return children({hooks: rendered});
+  }
+
+  return rendered;
 }
 
 export default memo(Hook) as <H extends ComponentHookName>(


### PR DESCRIPTION
The `Hook` component defined a class component *inside* its render function body. Every time `Hook` re-rendered (e.g. when receiving new props), a brand new class was created. React saw a different component type on each render and unmounted the old instance before mounting the new one — destroying all internal state of every child in the subtree.

This meant any stateful component rendered through `<Hook>` (forms with mutation state, components with local state, refs, etc.) would lose their state whenever the parent re-rendered. For example, an `AutoSaveForm` toggle rendered via `<Hook>` would have its mutation status reset on every prop change, preventing success indicators from displaying.

The fix converts `Hook` from a class-inside-function to a proper functional component using `useState` + `useEffect` for the `HookStore` subscription. The component identity is now stable across re-renders.

Note: `HookStore.add` mutates the hooks array in place, so the listener spreads the array (`[...hooks]`) to create a new reference — otherwise `useState`'s shallow equality check skips the update.