### PR TITLE
fix(search-query-builder): Fix semver issues and enable limiting keys to single selects

### DIFF
--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.spec.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.spec.tsx
@@ -254,6 +254,11 @@ describe('multiSelectTokenValue', () => {
       name: 'browser.name',
       kind: FieldKind.FIELD,
     },
+    release: {
+      key: 'release',
+      name: 'release',
+      kind: FieldKind.FIELD,
+    },
   };
 
   function runToggle(query: string, value: string) {
@@ -292,5 +297,37 @@ describe('multiSelectTokenValue', () => {
   it('removes an already-escaped list value when toggled off with the same escaped form', () => {
     const result = runToggle('browser.name:[test\\*,foo]', 'test\\*');
     expect(result.query).toBe('browser.name:foo');
+  });
+
+  it('removes an existing release value from a list when toggled off', () => {
+    const result = runToggle('release:[1.0.0,2.0.0]', '1.0.0');
+    expect(result.query).toBe('release:2.0.0');
+  });
+
+  it('removes a quoted release value when toggled off with its escaped form', () => {
+    const result = runToggle('release:["1.0.0+build 1",2.0.0]', '"1.0.0+build 1"');
+    expect(result.query).toBe('release:2.0.0');
+  });
+
+  it.each([
+    ['release:["org/repo@1.0.0",2.0.0]', 'org/repo@1.0.0'],
+    ['release:["1.0.0+build 1",2.0.0]', '"1.0.0+build 1"'],
+    ['release:["1.0.0 (build 1)",2.0.0]', '"1.0.0 (build 1)"'],
+    ['release:["1.0.0,build1",2.0.0]', '"1.0.0,build1"'],
+    ['release:[1.0.0\\*,2.0.0]', '1.0.0\\*'],
+  ])('removes special-character value %s', (query, value) => {
+    const result = runToggle(query, value);
+    expect(result.query).toBe('release:2.0.0');
+  });
+
+  it('keeps repeated checkbox clicks from duplicating equivalent quoted values', () => {
+    const firstToggle = runToggle('release:2.0.0', '"1.0.0+build 1"');
+    expect(firstToggle.query).toBe('release:[2.0.0,"1.0.0+build 1"]');
+
+    const secondToggle = runToggle(firstToggle.query, '"1.0.0+build 1"');
+    expect(secondToggle.query).toBe('release:2.0.0');
+
+    const thirdToggle = runToggle(secondToggle.query, '"1.0.0+build 1"');
+    expect(thirdToggle.query).toBe('release:[2.0.0,"1.0.0+build 1"]');
   });
 });

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -706,14 +706,17 @@ export function multiSelectTokenValue(
   action: MultiSelectFilterValueAction
 ) {
   const tokenValue = action.token.value;
-  // action.value is pre-escaped (possibly quoted); canonicalize for comparison
+
+  // Suggestions already pass escaped search syntax, while parsed tokens expose
+  // semantic values. Canonicalize before comparing so toggling treats both
+  // representations as the same value.
   const normalizedActionValue = canonicalizeSearchValue(action.value);
 
   switch (tokenValue.type) {
     case Token.VALUE_TEXT_LIST:
     case Token.VALUE_NUMBER_LIST: {
-      // .value is the unquoted semantic value (for canonical comparison),
-      // .text is the raw text including quotes (preserved for reconstruction)
+      // Compare against canonical values, but keep each token's raw text for
+      // reconstruction so quotes and escaping already in the query are preserved.
       const values = tokenValue.items.map(item => ({
         canonicalValue: canonicalizeSearchValue(item.value?.value ?? ''),
         text: item.value?.text ?? '',
@@ -730,6 +733,10 @@ export function multiSelectTokenValue(
         ]);
       }
 
+      // The selected value was already present, so this is a deselect. Filter it
+      // by canonical value instead of raw text because the same value may appear
+      // quoted/escaped differently depending on whether it came from the parser
+      // or the suggestion list.
       const newValues: string[] = [];
       for (const value of values) {
         if (value.canonicalValue !== normalizedActionValue) {
@@ -740,6 +747,8 @@ export function multiSelectTokenValue(
       return updateFilterMultipleValues(state, action.token, newValues);
     }
     default: {
+      // Single values use the same toggle semantics as lists: if the canonical
+      // value is already selected, clear it; otherwise expand it into a list.
       if (canonicalizeSearchValue(tokenValue.value ?? '') === normalizedActionValue) {
         return updateFilterMultipleValues(state, action.token, ['']);
       }

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -657,10 +657,12 @@ function updateFilterMultipleValues(
     if (value.length === 0) {
       return false;
     }
+
     const canonical = canonicalizeSearchValue(value);
     if (seen.has(canonical)) {
       return false;
     }
+
     seen.add(canonical);
     return true;
   });
@@ -716,14 +718,24 @@ export function multiSelectTokenValue(
         canonicalValue: canonicalizeSearchValue(item.value?.value ?? ''),
         text: item.value?.text ?? '',
       }));
+
       const containsValue = values.some(
         ({canonicalValue}) => canonicalValue === normalizedActionValue
       );
-      const newValues = containsValue
-        ? values
-            .filter(({canonicalValue}) => canonicalValue !== normalizedActionValue)
-            .map(({text}) => text)
-        : [...values.map(({text}) => text), action.value];
+
+      if (!containsValue) {
+        return updateFilterMultipleValues(state, action.token, [
+          ...values.map(({text}) => text),
+          action.value,
+        ]);
+      }
+
+      const newValues: string[] = [];
+      for (const value of values) {
+        if (value.canonicalValue !== normalizedActionValue) {
+          newValues.push(value.text);
+        }
+      }
 
       return updateFilterMultipleValues(state, action.token, newValues);
     }

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -650,6 +650,8 @@ function updateFilterMultipleValues(
   token: TokenResult<Token.FILTER>,
   values: string[]
 ) {
+  // Deduplicate by canonical form while preserving the original text of the
+  // first occurrence (so the query string keeps the user's original formatting)
   const uniqNonEmptyValues = Array.from(
     values
       .filter(value => value.length > 0)
@@ -676,6 +678,19 @@ function updateFilterMultipleValues(
   return {...state, query: replaceQueryToken(state.query, token.value, newValue)};
 }
 
+// Normalizes a filter value so that different surface representations of the
+// same logical value compare as equal. This is needed because values arrive
+// from two different sources that use different formats:
+//
+//   1. `action.value` (from the suggestion checkbox) is pre-escaped by
+//      `escapeTagValueForSearch`, which may wrap the value in quotes
+//      (e.g. `"release@1.0"`) and escape wildcards (e.g. `test\*`).
+//
+//   2. `item.value?.value` (from the parsed token) is the unquoted semantic
+//      value produced by the parser (e.g. `release@1.0`).
+//
+// To compare them we strip quotes, unescape wildcards, then re-escape through
+// `escapeTagValueForSearch` so both sides end up in the same canonical form.
 function canonicalizeSearchValue(value: string) {
   const unquotedValue =
     value.startsWith('"') && value.endsWith('"')
@@ -690,11 +705,14 @@ export function multiSelectTokenValue(
   action: MultiSelectFilterValueAction
 ) {
   const tokenValue = action.token.value;
+  // action.value is pre-escaped (possibly quoted); canonicalize for comparison
   const normalizedActionValue = canonicalizeSearchValue(action.value);
 
   switch (tokenValue.type) {
     case Token.VALUE_TEXT_LIST:
     case Token.VALUE_NUMBER_LIST: {
+      // .value is the unquoted semantic value (for canonical comparison),
+      // .text is the raw text including quotes (preserved for reconstruction)
       const values = tokenValue.items.map(item => ({
         canonicalValue: canonicalizeSearchValue(item.value?.value ?? ''),
         text: item.value?.text ?? '',

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -683,11 +683,12 @@ function updateFilterMultipleValues(
 // from two different sources that use different formats:
 //
 //   1. `action.value` (from the suggestion checkbox) is pre-escaped by
-//      `escapeTagValueForSearch`, which may wrap the value in quotes
-//      (e.g. `"release@1.0"`) and escape wildcards (e.g. `test\*`).
+//      `escapeTagValueForSearch`, which quotes values containing spaces,
+//      parens, or commas (e.g. `1.0.0+build 1` → `"1.0.0+build 1"`)
+//      and escapes wildcards (e.g. `test*` → `test\*`).
 //
 //   2. `item.value?.value` (from the parsed token) is the unquoted semantic
-//      value produced by the parser (e.g. `release@1.0`).
+//      value produced by the parser (e.g. `"1.0.0+build 1"` → `1.0.0+build 1`).
 //
 // To compare them we strip quotes, unescape wildcards, then re-escape through
 // `escapeTagValueForSearch` so both sides end up in the same canonical form.

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -651,7 +651,18 @@ function updateFilterMultipleValues(
   values: string[]
 ) {
   const uniqNonEmptyValues = Array.from(
-    new Set(values.filter(value => value.length > 0))
+    values
+      .filter(value => value.length > 0)
+      .reduce((canonicalValues, value) => {
+        const canonicalValue = canonicalizeSearchValue(value);
+
+        if (!canonicalValues.has(canonicalValue)) {
+          canonicalValues.set(canonicalValue, value);
+        }
+
+        return canonicalValues;
+      }, new Map<string, string>())
+      .values()
   );
   if (uniqNonEmptyValues.length === 0) {
     return {...state, query: replaceQueryToken(state.query, token.value, '""')};
@@ -665,30 +676,42 @@ function updateFilterMultipleValues(
   return {...state, query: replaceQueryToken(state.query, token.value, newValue)};
 }
 
+function canonicalizeSearchValue(value: string) {
+  const unquotedValue =
+    value.startsWith('"') && value.endsWith('"')
+      ? value.slice(1, -1).replace(/\\"/g, '"')
+      : value;
+
+  return escapeTagValueForSearch(unescapeAsteriskSearchValue(unquotedValue));
+}
+
 export function multiSelectTokenValue(
   state: QueryBuilderState,
   action: MultiSelectFilterValueAction
 ) {
   const tokenValue = action.token.value;
-  // Normalize to the escaped form so that a manually-typed raw value like
-  // `foo*` matches the escaped form `foo\*` dispatched from suggestion checkboxes.
-  const normalize = (value: string) =>
-    escapeTagValueForSearch(unescapeAsteriskSearchValue(value));
-  const normalizedActionValue = normalize(action.value);
+  const normalizedActionValue = canonicalizeSearchValue(action.value);
 
   switch (tokenValue.type) {
     case Token.VALUE_TEXT_LIST:
     case Token.VALUE_NUMBER_LIST: {
-      const values = tokenValue.items.map(item => item.value?.text ?? '');
-      const containsValue = values.some(v => normalize(v) === normalizedActionValue);
+      const values = tokenValue.items.map(item => ({
+        canonicalValue: canonicalizeSearchValue(item.value?.value ?? ''),
+        text: item.value?.text ?? '',
+      }));
+      const containsValue = values.some(
+        ({canonicalValue}) => canonicalValue === normalizedActionValue
+      );
       const newValues = containsValue
-        ? values.filter(v => normalize(v) !== normalizedActionValue)
-        : [...values, action.value];
+        ? values
+            .filter(({canonicalValue}) => canonicalValue !== normalizedActionValue)
+            .map(({text}) => text)
+        : [...values.map(({text}) => text), action.value];
 
       return updateFilterMultipleValues(state, action.token, newValues);
     }
     default: {
-      if (normalize(tokenValue.text) === normalizedActionValue) {
+      if (canonicalizeSearchValue(tokenValue.value ?? '') === normalizedActionValue) {
         return updateFilterMultipleValues(state, action.token, ['']);
       }
       const newValue = tokenValue.value

--- a/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
+++ b/static/app/components/searchQueryBuilder/hooks/useQueryBuilderState.tsx
@@ -652,20 +652,18 @@ function updateFilterMultipleValues(
 ) {
   // Deduplicate by canonical form while preserving the original text of the
   // first occurrence (so the query string keeps the user's original formatting)
-  const uniqNonEmptyValues = Array.from(
-    values
-      .filter(value => value.length > 0)
-      .reduce((canonicalValues, value) => {
-        const canonicalValue = canonicalizeSearchValue(value);
-
-        if (!canonicalValues.has(canonicalValue)) {
-          canonicalValues.set(canonicalValue, value);
-        }
-
-        return canonicalValues;
-      }, new Map<string, string>())
-      .values()
-  );
+  const seen = new Set<string>();
+  const uniqNonEmptyValues = values.filter(value => {
+    if (value.length === 0) {
+      return false;
+    }
+    const canonical = canonicalizeSearchValue(value);
+    if (seen.has(canonical)) {
+      return false;
+    }
+    seen.add(canonical);
+    return true;
+  });
   if (uniqNonEmptyValues.length === 0) {
     return {...state, query: replaceQueryToken(state.query, token.value, '""')};
   }

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -108,6 +108,13 @@ const FILTER_KEYS: TagCollection = {
     name: 'bar',
     kind: FieldKind.MEASUREMENT,
   },
+  [FieldKey.RELEASE_VERSION]: {
+    key: FieldKey.RELEASE_VERSION,
+    name: 'Release Version',
+    kind: FieldKind.FIELD,
+    predefined: true,
+    values: ['1.0.0', '2.0.0'],
+  },
 };
 
 const FILTER_KEY_SECTIONS: FilterKeySection[] = [
@@ -3295,6 +3302,49 @@ describe('SearchQueryBuilder', () => {
           name: 'does not end with',
         });
         expect(doesNotEndWithOption).toBeInTheDocument();
+      });
+
+      it('replaces the value for fields that do not allow multiple values', async () => {
+        render(
+          <SearchQueryBuilder {...defaultProps} initialQuery="release.version:1.0.0" />
+        );
+
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: release.version'})
+        );
+
+        expect(screen.getByRole('combobox', {name: 'Edit filter value'})).toHaveValue('');
+        expect(
+          screen.queryByRole('checkbox', {name: 'Toggle 1.0.0'})
+        ).not.toBeInTheDocument();
+
+        await userEvent.click(await screen.findByRole('option', {name: '2.0.0'}));
+
+        expect(
+          await screen.findByRole('row', {name: 'release.version:2.0.0'})
+        ).toBeInTheDocument();
+        expect(
+          screen.queryByRole('row', {name: 'release.version:[1.0.0,2.0.0]'})
+        ).not.toBeInTheDocument();
+      });
+
+      it('keeps comma-separated input as one value for fields that do not allow multiple values', async () => {
+        render(
+          <SearchQueryBuilder {...defaultProps} initialQuery="release.version:1.0.0" />
+        );
+
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: release.version'})
+        );
+
+        await userEvent.keyboard('1.0.0,2.0.0{enter}');
+
+        expect(
+          await screen.findByRole('row', {name: 'release.version:"1.0.0,2.0.0"'})
+        ).toBeInTheDocument();
+        expect(
+          screen.queryByRole('row', {name: 'release.version:[1.0.0,2.0.0]'})
+        ).not.toBeInTheDocument();
       });
     });
 

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.spec.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.spec.tsx
@@ -1,6 +1,12 @@
-import {FieldValueType} from 'sentry/utils/fields';
+import {parseQueryBuilderValue} from 'sentry/components/searchQueryBuilder/utils';
+import {Token} from 'sentry/components/searchSyntax/parser';
+import {FieldKind, FieldValueType, type FieldDefinition} from 'sentry/utils/fields';
 
-import {getSelectedValuesFromText, prepareInputValueForSaving} from './valueCombobox';
+import {
+  getSelectedValuesFromText,
+  prepareInputValueForSaving,
+  tokenSupportsMultipleValues,
+} from './valueCombobox';
 
 describe('prepareInputValueForSaving', () => {
   it('preserves manual asterisks in unquoted string values', () => {
@@ -50,5 +56,114 @@ describe('getSelectedValuesFromText', () => {
       {value: 'foo*', text: 'foo*', selected: true},
       {value: 'bar*', text: 'bar\\*', selected: true},
     ]);
+  });
+});
+
+describe('tokenSupportsMultipleValues', () => {
+  const filterKeys = {
+    'release.version': {
+      key: 'release.version',
+      name: 'release.version',
+      kind: FieldKind.FIELD,
+    },
+  };
+
+  function getReleaseVersionFieldDefinition(
+    overrides: Partial<FieldDefinition> = {}
+  ): FieldDefinition {
+    return {
+      kind: FieldKind.FIELD,
+      valueType: FieldValueType.STRING,
+      allowComparisonOperators: true,
+      ...overrides,
+    };
+  }
+
+  function getFilterToken(
+    query: string,
+    fieldDefinition = getReleaseVersionFieldDefinition()
+  ) {
+    const parsed = parseQueryBuilderValue(
+      query,
+      key => (key === 'release.version' ? fieldDefinition : null),
+      {filterKeys}
+    );
+    const token = parsed?.find(t => t.type === Token.FILTER);
+
+    if (!token) {
+      throw new Error(`No filter token found in query: ${query}`);
+    }
+
+    return token;
+  }
+
+  it('allows multiple values for string filters by default', () => {
+    const fieldDefinition = getReleaseVersionFieldDefinition();
+
+    expect(
+      tokenSupportsMultipleValues(
+        getFilterToken('release.version:1.0.0', fieldDefinition),
+        filterKeys,
+        fieldDefinition
+      )
+    ).toBe(true);
+  });
+
+  it('does not allow multiple values when the field definition opts out', () => {
+    const fieldDefinition = getReleaseVersionFieldDefinition({
+      allowMultipleValues: false,
+    });
+
+    expect(
+      tokenSupportsMultipleValues(
+        getFilterToken('release.version:1.0.0', fieldDefinition),
+        filterKeys,
+        fieldDefinition
+      )
+    ).toBe(false);
+  });
+
+  it('does not allow multiple values for wildcard operators when the field definition opts out', () => {
+    const fieldDefinition = getReleaseVersionFieldDefinition({
+      allowMultipleValues: false,
+    });
+
+    expect(
+      tokenSupportsMultipleValues(
+        getFilterToken('release.version:*1.0.0*', fieldDefinition),
+        filterKeys,
+        fieldDefinition
+      )
+    ).toBe(false);
+  });
+
+  it('does not allow multiple values for comparison operators when the field definition opts out', () => {
+    const fieldDefinition = getReleaseVersionFieldDefinition({
+      allowMultipleValues: false,
+    });
+
+    expect(
+      tokenSupportsMultipleValues(
+        getFilterToken('release.version:>1.0.0', fieldDefinition),
+        filterKeys,
+        fieldDefinition
+      )
+    ).toBe(false);
+  });
+
+  it('allows multiple values for comparison operators when the field definition allows them', () => {
+    const fieldDefinition: FieldDefinition = {
+      kind: FieldKind.FIELD,
+      valueType: FieldValueType.STRING,
+      allowComparisonOperators: true,
+    };
+
+    expect(
+      tokenSupportsMultipleValues(
+        getFilterToken('release.version:>1.0.0', fieldDefinition),
+        filterKeys,
+        fieldDefinition
+      )
+    ).toBe(true);
   });
 });

--- a/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/valueCombobox.tsx
@@ -263,6 +263,10 @@ export function tokenSupportsMultipleValues(
   keys: TagCollection,
   fieldDefinition: FieldDefinition | null
 ): boolean {
+  if (fieldDefinition?.allowMultipleValues === false) {
+    return false;
+  }
+
   switch (token.filter) {
     case FilterType.TEXT: {
       // The search parser defaults to the text type, so we need to do further

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -479,6 +479,11 @@ export interface FieldDefinition {
    */
   allowComparisonOperators?: boolean;
   /**
+   * Allow multiple values to be selected for this field.
+   * This is only valid for string and default numeric filters and defaults to true.
+   */
+  allowMultipleValues?: boolean;
+  /**
    * Allow wildcard (*) matching for this field.
    * This is only valid for string fields and will default to true.
    * Note that the `disallowWildcardOperators` setting will override this.
@@ -2344,6 +2349,7 @@ const RELEASE_FIELD_DEFINITION: Record<ReleaseFieldKey, FieldDefinition> = {
     kind: FieldKind.FIELD,
     valueType: FieldValueType.STRING,
     allowComparisonOperators: true,
+    allowMultipleValues: false,
     disallowWildcardOperators: true,
   },
 };


### PR DESCRIPTION
This PR tackles two issues: odd behaviour when selecting semantic versions, and allowing field definitions to limit the amount of values that can be selected.

Closes EXP-901

Regarding the selecting semantic version issue, basically what would happen is we would add in the value fine the first time, however upon multiple selections we'd mess up the parsing and handling of the values and the brackets that surround them see:

<img width="768" height="270" alt="Screenshot 2026-04-29 at 08 03 19" src="https://github.com/user-attachments/assets/0b00394e-d6b4-4917-bd42-019bff163a91" />

---

The second issue however, is that we don't support multiple selection with semantic versions in event search. So I've gone ahead and added a new property to the field definitions to limit this on known fields so that we can limit users running into this with `release.version` for instance.