### PR TITLE
fix(forms): Reserve space for auto-save indicator to prevent layout shift

### DIFF
--- a/static/app/components/core/form/field/radioField.tsx
+++ b/static/app/components/core/form/field/radioField.tsx
@@ -67,7 +67,7 @@ function RadioGroup({children, value, onChange, disabled}: RadioGroupProps) {
       <RadioContext value={contextValue}>
         <Flex role="radiogroup" aria-labelledby={labelId} gap="sm" align="center">
           {children}
-          {indicator ?? <Flex width="14px" flexShrink={0} />}
+          {indicator ?? (autoSaveContext ? <Flex width="14px" flexShrink={0} /> : null)}
           <FieldMeta.Status disabled={disabled} />
         </Flex>
       </RadioContext>

--- a/static/app/components/core/form/field/rangeField.tsx
+++ b/static/app/components/core/form/field/rangeField.tsx
@@ -36,7 +36,7 @@ export function RangeField({
               }
             }}
           />
-          {indicator ?? <Flex width="14px" flexShrink={0} />}
+          {indicator ?? (autoSaveContext ? <Flex width="14px" flexShrink={0} /> : null)}
         </Fragment>
       )}
     </BaseField>

--- a/static/app/components/core/form/field/switchField.tsx
+++ b/static/app/components/core/form/field/switchField.tsx
@@ -35,7 +35,7 @@ export function SwitchField({
               }
             }}
           />
-          {indicator}
+          {indicator ?? (autoSaveContext ? <Flex width="14px" flexShrink={0} /> : null)}
         </Flex>
       )}
     </BaseField>


### PR DESCRIPTION
When AutoSaveForm fields show the save indicator (spinner/checkmark), the indicator appearing and disappearing causes adjacent content to shift. This is especially noticeable for standalone switches (e.g. the spike protection toggle on the settings page) where the indicator pushes neighboring elements sideways.

The fix reserves a 14px placeholder `Flex` when the indicator is not visible, matching the indicator's width. The placeholder is only rendered inside an `AutoSaveForm` context (`autoSaveContext` is non-null), so fields used outside of auto-save forms are unaffected.

Applied consistently to `SwitchField`, `RadioField`, and `RangeField`. `SwitchField` previously had no placeholder at all; `RadioField` and `RangeField` unconditionally rendered the placeholder even outside auto-save forms.