### PR TITLE
fix(conversations): Only show preview tooltips on overflow

### DIFF
--- a/static/app/views/explore/conversations/components/conversationsTable.spec.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTable.spec.tsx
@@ -1,0 +1,49 @@
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {InputOutputTooltipCell} from 'sentry/views/explore/conversations/components/conversationsTable';
+
+function mockOverflow(width: number, containerWidth: number) {
+  Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {
+    configurable: true,
+    value: width,
+  });
+  Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+    configurable: true,
+    value: containerWidth,
+  });
+}
+
+describe('InputOutputTooltipCell', () => {
+  afterEach(() => {
+    // @ts-expect-error cleanup previously mocked properties
+    delete HTMLElement.prototype.scrollWidth;
+    // @ts-expect-error cleanup previously mocked properties
+    delete HTMLElement.prototype.clientWidth;
+  });
+
+  it('does not show the tooltip when the cell content fits', async () => {
+    mockOverflow(80, 120);
+
+    render(
+      <InputOutputTooltipCell text={'Conversation preview\n\n```js\ntooltip only\n```'} />
+    );
+
+    await userEvent.hover(screen.getByText('Conversation preview'));
+
+    expect(screen.queryByText('tooltip only')).not.toBeInTheDocument();
+  });
+
+  it('shows the tooltip when the cell content overflows', async () => {
+    mockOverflow(180, 100);
+
+    render(
+      <InputOutputTooltipCell text={'Conversation preview\n\n```js\ntooltip only\n```'} />
+    );
+
+    await userEvent.hover(screen.getByText('Conversation preview'));
+
+    await waitFor(() => {
+      expect(screen.getByText('tooltip only')).toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/views/explore/conversations/components/conversationsTable.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTable.tsx
@@ -155,12 +155,27 @@ type CellContentProps = ComponentPropsWithRef<'div'> & {
   text: string;
 };
 
-function CellContent({text, ...props}: CellContentProps) {
+function CellContent({text, ref, ...props}: CellContentProps) {
   const cleanedText = cleanMarkdownForCell(text);
   return (
-    <SingleLineMarkdown {...props}>
+    <SingleLineMarkdown ref={ref} {...props}>
       <MarkedText text={ellipsize(cleanedText, CELL_MAX_CHARS)} />
     </SingleLineMarkdown>
+  );
+}
+
+export function InputOutputTooltipCell({text}: {text: string}) {
+  return (
+    <Tooltip
+      title={<TooltipContent text={text} />}
+      showOnlyOnOverflow
+      maxWidth={800}
+      isHoverable
+      skipWrapper
+      position="right"
+    >
+      <CellContent text={text} />
+    </Tooltip>
   );
 }
 
@@ -226,16 +241,7 @@ const BodyCell = memo(function BodyCell({
             <InputOutputLabel variant="muted">{t('Input')}</InputOutputLabel>
             <Flex flex="1" minWidth="0">
               {dataRow.firstInput ? (
-                <Tooltip
-                  title={<TooltipContent text={dataRow.firstInput} />}
-                  showOnlyOnOverflow
-                  maxWidth={800}
-                  isHoverable
-                  skipWrapper
-                  position="right"
-                >
-                  <CellContent text={dataRow.firstInput} />
-                </Tooltip>
+                <InputOutputTooltipCell text={dataRow.firstInput} />
               ) : (
                 <Text variant="muted">&mdash;</Text>
               )}
@@ -245,16 +251,7 @@ const BodyCell = memo(function BodyCell({
             <InputOutputLabel variant="muted">{t('Output')}</InputOutputLabel>
             <Flex flex="1" minWidth="0">
               {dataRow.lastOutput ? (
-                <Tooltip
-                  title={<TooltipContent text={dataRow.lastOutput} />}
-                  showOnlyOnOverflow
-                  maxWidth={800}
-                  isHoverable
-                  skipWrapper
-                  position="right"
-                >
-                  <CellContent text={dataRow.lastOutput} />
-                </Tooltip>
+                <InputOutputTooltipCell text={dataRow.lastOutput} />
               ) : (
                 <Text variant="muted">&mdash;</Text>
               )}


### PR DESCRIPTION
Measure conversation preview overflow through the existing Tooltip showOnlyOnOverflow behavior. This keeps short input and output previews from showing unnecessary hover content while preserving full tooltip content for truncated cells.

The cell now passes the Tooltip ref through to the rendered markdown element, and the local test covers both overflowing and non-overflowing preview text.

Fixes TET-2268