### PR TITLE
feat(agents): Add missing cost callout for AI spans

### DIFF
--- a/static/app/utils/analytics/agentMonitoringAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/agentMonitoringAnalyticsEvents.tsx
@@ -8,6 +8,9 @@ export type AgentMonitoringEventParameters = {
   'agent-monitoring.drawer.open': Record<string, unknown>;
   'agent-monitoring.drawer.span-select': Record<string, unknown>;
   'agent-monitoring.drawer.view-full-trace-click': Record<string, unknown>;
+  'agent-monitoring.model-cost-callout-copy-click': Record<string, unknown>;
+  'agent-monitoring.model-cost-callout-docs-click': Record<string, unknown>;
+  'agent-monitoring.model-cost-callout-tooltip-hover': Record<string, unknown>;
   'agent-monitoring.page-filter-change': {
     filter: 'project' | 'environment' | 'date' | 'agent' | 'search';
   };
@@ -38,6 +41,12 @@ export const agentMonitoringEventMap: Record<
   'agent-monitoring.drawer.span-select': 'Agent Monitoring: Span Select',
   'agent-monitoring.drawer.view-full-trace-click':
     'Agent Monitoring: View Full Trace Click',
+  'agent-monitoring.model-cost-callout-copy-click':
+    'Agent Monitoring: Model Cost Callout Copy Click',
+  'agent-monitoring.model-cost-callout-docs-click':
+    'Agent Monitoring: Model Cost Callout Docs Click',
+  'agent-monitoring.model-cost-callout-tooltip-hover':
+    'Agent Monitoring: Model Cost Callout Tooltip Hover',
   'agent-monitoring.trace.rendered': 'Agent Monitoring: Trace Rendered',
   'agent-monitoring.trace.span-select': 'Agent Monitoring: Trace Span Select',
   'agent-monitoring.trace.view-full-trace-click':

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.spec.tsx
@@ -175,7 +175,7 @@ describe('getHighlightedSpanAttributes', () => {
     expect(result.find(attr => attr.name === 'Context Utilization')).toBeUndefined();
   });
 
-  it('shows model cost setup callout when ai_client span is missing model', async () => {
+  it('shows model cost setup callout when ai_client span has tokens and is missing model', async () => {
     const organization = OrganizationFixture();
     const attributes = {
       'gen_ai.operation.type': 'ai_client',
@@ -192,7 +192,7 @@ describe('getHighlightedSpanAttributes', () => {
 
     render(<div>{modelAttribute?.value}</div>, {organization});
 
-    expect(screen.getByRole('button', {name: 'Cost unavailable'})).toBeInTheDocument();
+    expect(screen.getByText('No model data')).toBeInTheDocument();
     await waitFor(() => {
       expect(Sentry.captureMessage).toHaveBeenCalledWith(
         'AI span cost setup callout',
@@ -208,10 +208,26 @@ describe('getHighlightedSpanAttributes', () => {
     });
   });
 
+  it('does not show model cost setup callout when ai_client span is missing tokens', () => {
+    const attributes = {
+      'gen_ai.operation.type': 'ai_client',
+    };
+
+    const result = getHighlightedSpanAttributes({
+      spanId: 'missing-model-span',
+      attributes,
+    });
+
+    expect(result.find(attr => attr.name === 'Model')).toBeUndefined();
+  });
+
   it('emits a Sentry message when cost setup docs are opened', async () => {
     const organization = OrganizationFixture();
     const attributes = {
       'gen_ai.operation.type': 'ai_client',
+      'gen_ai.usage.input_tokens': '10',
+      'gen_ai.usage.output_tokens': '20',
+      'gen_ai.usage.total_tokens': '30',
     };
 
     const result = getHighlightedSpanAttributes({
@@ -222,8 +238,8 @@ describe('getHighlightedSpanAttributes', () => {
 
     render(<div>{modelAttribute?.value}</div>, {organization});
 
-    await userEvent.hover(screen.getByRole('button', {name: 'Cost unavailable'}));
-    await userEvent.click(await screen.findByRole('link', {name: 'Read the guide'}));
+    await userEvent.hover(screen.getByText('No model data'));
+    await userEvent.click(await screen.findByRole('link', {name: 'Docs'}));
 
     expect(Sentry.captureMessage).toHaveBeenCalledWith(
       'AI span cost setup callout',
@@ -231,7 +247,7 @@ describe('getHighlightedSpanAttributes', () => {
         level: 'info',
         tags: expect.objectContaining({
           action: 'docs_click',
-          has_token_counts: 'false',
+          has_token_counts: 'true',
           span_id: 'missing-model-span',
         }),
       })
@@ -239,7 +255,7 @@ describe('getHighlightedSpanAttributes', () => {
     expect(trackAnalytics).toHaveBeenCalledWith(
       'agent-monitoring.model-cost-callout-docs-click',
       expect.objectContaining({
-        hasTokenCounts: false,
+        hasTokenCounts: true,
       })
     );
   });
@@ -248,6 +264,9 @@ describe('getHighlightedSpanAttributes', () => {
     const organization = OrganizationFixture();
     const attributes = {
       'gen_ai.operation.type': 'ai_client',
+      'gen_ai.usage.input_tokens': '10',
+      'gen_ai.usage.output_tokens': '20',
+      'gen_ai.usage.total_tokens': '30',
     };
 
     const result = getHighlightedSpanAttributes({
@@ -258,7 +277,7 @@ describe('getHighlightedSpanAttributes', () => {
 
     render(<div>{modelAttribute?.value}</div>, {organization});
 
-    await userEvent.hover(screen.getByRole('button', {name: 'Cost unavailable'}));
+    await userEvent.hover(screen.getByText('No model data'));
     await userEvent.click(
       await screen.findByRole('button', {name: 'Copy LLM instructions'})
     );
@@ -272,7 +291,7 @@ describe('getHighlightedSpanAttributes', () => {
         level: 'info',
         tags: expect.objectContaining({
           action: 'copy_instructions',
-          has_token_counts: 'false',
+          has_token_counts: 'true',
           span_id: 'missing-model-span',
         }),
       })
@@ -280,7 +299,7 @@ describe('getHighlightedSpanAttributes', () => {
     expect(trackAnalytics).toHaveBeenCalledWith(
       'agent-monitoring.model-cost-callout-copy-click',
       expect.objectContaining({
-        hasTokenCounts: false,
+        hasTokenCounts: true,
       })
     );
   });
@@ -289,6 +308,9 @@ describe('getHighlightedSpanAttributes', () => {
     const organization = OrganizationFixture();
     const attributes = {
       'gen_ai.operation.type': 'ai_client',
+      'gen_ai.usage.input_tokens': '10',
+      'gen_ai.usage.output_tokens': '20',
+      'gen_ai.usage.total_tokens': '30',
     };
 
     const result = getHighlightedSpanAttributes({
@@ -299,12 +321,12 @@ describe('getHighlightedSpanAttributes', () => {
 
     render(<div>{modelAttribute?.value}</div>, {organization});
 
-    await userEvent.hover(screen.getByRole('button', {name: 'Cost unavailable'}));
+    await userEvent.hover(screen.getByText('No model data'));
 
     expect(trackAnalytics).toHaveBeenCalledWith(
       'agent-monitoring.model-cost-callout-tooltip-hover',
       expect.objectContaining({
-        hasTokenCounts: false,
+        hasTokenCounts: true,
       })
     );
   });

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.spec.tsx
@@ -1,4 +1,9 @@
 import * as Sentry from '@sentry/react';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {trackAnalytics} from 'sentry/utils/analytics';
 
 import {getHighlightedSpanAttributes} from './highlightedAttributes';
 
@@ -7,9 +12,16 @@ jest.mock('@sentry/react', () => ({
   captureMessage: jest.fn(),
 }));
 
+jest.mock('sentry/utils/analytics', () => ({
+  trackAnalytics: jest.fn(),
+}));
+
 describe('getHighlightedSpanAttributes', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    Object.assign(navigator, {
+      clipboard: {writeText: jest.fn().mockResolvedValue('')},
+    });
   });
 
   it('should emit Sentry error when gen_ai span with auto.ai origin is missing required attributes', () => {
@@ -161,5 +173,139 @@ describe('getHighlightedSpanAttributes', () => {
     });
 
     expect(result.find(attr => attr.name === 'Context Utilization')).toBeUndefined();
+  });
+
+  it('shows model cost setup callout when ai_client span is missing model', async () => {
+    const organization = OrganizationFixture();
+    const attributes = {
+      'gen_ai.operation.type': 'ai_client',
+      'gen_ai.usage.input_tokens': '10',
+      'gen_ai.usage.output_tokens': '20',
+      'gen_ai.usage.total_tokens': '30',
+    };
+
+    const result = getHighlightedSpanAttributes({
+      spanId: 'missing-model-span',
+      attributes,
+    });
+    const modelAttribute = result.find(attr => attr.name === 'Model');
+
+    render(<div>{modelAttribute?.value}</div>, {organization});
+
+    expect(screen.getByRole('button', {name: 'Cost unavailable'})).toBeInTheDocument();
+    await waitFor(() => {
+      expect(Sentry.captureMessage).toHaveBeenCalledWith(
+        'AI span cost setup callout',
+        expect.objectContaining({
+          level: 'info',
+          tags: expect.objectContaining({
+            action: 'shown',
+            has_token_counts: 'true',
+            span_id: 'missing-model-span',
+          }),
+        })
+      );
+    });
+  });
+
+  it('emits a Sentry message when cost setup docs are opened', async () => {
+    const organization = OrganizationFixture();
+    const attributes = {
+      'gen_ai.operation.type': 'ai_client',
+    };
+
+    const result = getHighlightedSpanAttributes({
+      spanId: 'missing-model-span',
+      attributes,
+    });
+    const modelAttribute = result.find(attr => attr.name === 'Model');
+
+    render(<div>{modelAttribute?.value}</div>, {organization});
+
+    await userEvent.hover(screen.getByRole('button', {name: 'Cost unavailable'}));
+    await userEvent.click(await screen.findByRole('link', {name: 'Read the guide'}));
+
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      'AI span cost setup callout',
+      expect.objectContaining({
+        level: 'info',
+        tags: expect.objectContaining({
+          action: 'docs_click',
+          has_token_counts: 'false',
+          span_id: 'missing-model-span',
+        }),
+      })
+    );
+    expect(trackAnalytics).toHaveBeenCalledWith(
+      'agent-monitoring.model-cost-callout-docs-click',
+      expect.objectContaining({
+        hasTokenCounts: false,
+      })
+    );
+  });
+
+  it('emits a Sentry message when LLM cost setup instructions are copied', async () => {
+    const organization = OrganizationFixture();
+    const attributes = {
+      'gen_ai.operation.type': 'ai_client',
+    };
+
+    const result = getHighlightedSpanAttributes({
+      spanId: 'missing-model-span',
+      attributes,
+    });
+    const modelAttribute = result.find(attr => attr.name === 'Model');
+
+    render(<div>{modelAttribute?.value}</div>, {organization});
+
+    await userEvent.hover(screen.getByRole('button', {name: 'Cost unavailable'}));
+    await userEvent.click(
+      await screen.findByRole('button', {name: 'Copy LLM instructions'})
+    );
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringContaining('gen_ai.response.model')
+    );
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(
+      'AI span cost setup callout',
+      expect.objectContaining({
+        level: 'info',
+        tags: expect.objectContaining({
+          action: 'copy_instructions',
+          has_token_counts: 'false',
+          span_id: 'missing-model-span',
+        }),
+      })
+    );
+    expect(trackAnalytics).toHaveBeenCalledWith(
+      'agent-monitoring.model-cost-callout-copy-click',
+      expect.objectContaining({
+        hasTokenCounts: false,
+      })
+    );
+  });
+
+  it('tracks when the model cost setup tooltip is hovered', async () => {
+    const organization = OrganizationFixture();
+    const attributes = {
+      'gen_ai.operation.type': 'ai_client',
+    };
+
+    const result = getHighlightedSpanAttributes({
+      spanId: 'missing-model-span',
+      attributes,
+    });
+    const modelAttribute = result.find(attr => attr.name === 'Model');
+
+    render(<div>{modelAttribute?.value}</div>, {organization});
+
+    await userEvent.hover(screen.getByRole('button', {name: 'Cost unavailable'}));
+
+    expect(trackAnalytics).toHaveBeenCalledWith(
+      'agent-monitoring.model-cost-callout-tooltip-hover',
+      expect.objectContaining({
+        hasTokenCounts: false,
+      })
+    );
   });
 });

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -249,7 +249,9 @@ function getAISpanAttributes({
   return highlightedAttributes;
 }
 
-function isPresentModel(value: string | number | boolean | undefined) {
+function isPresentModel(
+  value: string | number | boolean | undefined
+): value is string | number | boolean {
   return Boolean(value) && value?.toString() !== 'null';
 }
 

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -1,14 +1,21 @@
-import {Fragment} from 'react';
+import {Fragment, useEffect, useRef} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 
 import {Tag} from '@sentry/scraps/badge';
-import {Container, Flex} from '@sentry/scraps/layout';
+import {Button} from '@sentry/scraps/button';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {ExternalLink} from '@sentry/scraps/link';
+import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {Count} from 'sentry/components/count';
 import {StructuredData} from 'sentry/components/structuredEventData';
+import {IconCopy, IconWarning} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {copyToClipboard} from 'sentry/utils/useCopyToClipboard';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAttributes/utils';
 import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
 import {useSpans} from 'sentry/views/insights/common/queries/useDiscover';
@@ -28,6 +35,24 @@ type HighlightedAttribute = {
   name: string;
   value: React.ReactNode;
 };
+
+const AI_COST_DOCS_URL =
+  'https://docs.sentry.io/ai/monitoring/agents/costs/#troubleshooting';
+
+const LLM_COST_INSTRUCTIONS_MARKDOWN = `
+# Fix Sentry AI cost reporting
+
+Sentry can calculate LLM cost when each AI client span records token counts and a model ID.
+
+1. Set \`gen_ai.response.model\` or \`gen_ai.request.model\` to the model ID used for the call.
+2. Record token counts on the span:
+   - \`gen_ai.usage.input_tokens\`
+   - \`gen_ai.usage.output_tokens\`
+   - \`gen_ai.usage.total_tokens\`
+3. If those values are present and cost is still empty, Sentry may not have pricing data for that model.
+
+Follow Sentry's AI cost troubleshooting guide: ${AI_COST_DOCS_URL}
+`;
 
 /**
  * Gets AI tool definitions, checking attributes in priority order.
@@ -116,10 +141,21 @@ function getAISpanAttributes({
   }
 
   const model = attributes['gen_ai.response.model'] || attributes['gen_ai.request.model'];
-  if (model) {
+  if (isPresentModel(model)) {
     highlightedAttributes.push({
       name: t('Model'),
       value: <ModelName modelId={model.toString()} gap="xs" />,
+    });
+  } else if (genAiOpType === 'ai_client') {
+    highlightedAttributes.push({
+      name: t('Model'),
+      value: (
+        <MissingAIModelCostCallout
+          spanId={spanId}
+          hasTokenCounts={hasTokenCounts(attributes)}
+          hasCost={hasPositiveNumber(attributes['gen_ai.cost.total_tokens'])}
+        />
+      ),
     });
   }
 
@@ -221,6 +257,158 @@ function getAISpanAttributes({
   }
 
   return highlightedAttributes;
+}
+
+function isPresentModel(value: string | number | boolean | undefined) {
+  return Boolean(value) && value?.toString() !== 'null';
+}
+
+function hasPositiveNumber(value: string | number | boolean | undefined) {
+  return Boolean(value) && Number(value) > 0;
+}
+
+function hasTokenCounts(attributes: Record<string, string | number | boolean>) {
+  return (
+    hasPositiveNumber(attributes['gen_ai.usage.input_tokens']) ||
+    hasPositiveNumber(attributes['gen_ai.usage.output_tokens']) ||
+    hasPositiveNumber(attributes['gen_ai.usage.total_tokens'])
+  );
+}
+
+function captureMissingModelCostCalloutMessage({
+  action,
+  hasCost,
+  hasTokenCounts: tokenCountsRecorded,
+  spanId,
+}: {
+  action: 'copy_instructions' | 'docs_click' | 'shown';
+  hasCost: boolean;
+  hasTokenCounts: boolean;
+  spanId: string;
+}) {
+  Sentry.captureMessage('AI span cost setup callout', {
+    level: 'info',
+    tags: {
+      action,
+      feature: 'agent-monitoring',
+      has_cost: hasCost ? 'true' : 'false',
+      has_token_counts: tokenCountsRecorded ? 'true' : 'false',
+      missing_attributes: tokenCountsRecorded
+        ? 'gen_ai.response.model'
+        : 'gen_ai.response.model,gen_ai.usage.tokens',
+      span_id: spanId,
+      span_type: 'gen_ai',
+    },
+  });
+}
+
+function MissingAIModelCostCallout({
+  hasCost,
+  hasTokenCounts: tokenCountsRecorded,
+  spanId,
+}: {
+  hasCost: boolean;
+  hasTokenCounts: boolean;
+  spanId: string;
+}) {
+  const organization = useOrganization();
+  const didCaptureShown = useRef(false);
+  const didTrackHover = useRef(false);
+
+  useEffect(() => {
+    if (didCaptureShown.current) {
+      return;
+    }
+    didCaptureShown.current = true;
+    captureMissingModelCostCalloutMessage({
+      action: 'shown',
+      hasCost,
+      hasTokenCounts: tokenCountsRecorded,
+      spanId,
+    });
+  }, [hasCost, spanId, tokenCountsRecorded]);
+
+  const analyticsParams = {
+    organization,
+    hasCost,
+    hasTokenCounts: tokenCountsRecorded,
+  };
+
+  return (
+    <Tooltip
+      isHoverable
+      title={
+        <Stack gap="md" maxWidth="320px">
+          <Text as="p" size="sm">
+            {t(
+              'Sentry needs token counts and a model ID to calculate cost for AI spans.'
+            )}
+          </Text>
+          <Text as="p" size="sm" variant="muted">
+            {t(
+              'Record gen_ai usage token attributes and gen_ai.response.model or gen_ai.request.model. If those values are present and cost is still empty, Sentry may not have pricing data for this model.'
+            )}
+          </Text>
+          <Flex gap="sm" align="center" wrap="wrap">
+            <ExternalLink
+              href={AI_COST_DOCS_URL}
+              onClick={() => {
+                captureMissingModelCostCalloutMessage({
+                  action: 'docs_click',
+                  hasCost,
+                  hasTokenCounts: tokenCountsRecorded,
+                  spanId,
+                });
+                trackAnalytics('agent-monitoring.model-cost-callout-docs-click', {
+                  ...analyticsParams,
+                });
+              }}
+            >
+              {t('Read the guide')}
+            </ExternalLink>
+            <Button
+              size="xs"
+              priority="transparent"
+              icon={<IconCopy />}
+              onClick={() => {
+                copyToClipboard(LLM_COST_INSTRUCTIONS_MARKDOWN, {
+                  successMessage: t('Copied LLM instructions to clipboard'),
+                });
+                captureMissingModelCostCalloutMessage({
+                  action: 'copy_instructions',
+                  hasCost,
+                  hasTokenCounts: tokenCountsRecorded,
+                  spanId,
+                });
+                trackAnalytics('agent-monitoring.model-cost-callout-copy-click', {
+                  ...analyticsParams,
+                });
+              }}
+            >
+              {t('Copy LLM instructions')}
+            </Button>
+          </Flex>
+        </Stack>
+      }
+    >
+      <Button
+        size="xs"
+        priority="transparent"
+        icon={<IconWarning variant="warning" />}
+        onMouseEnter={() => {
+          if (didTrackHover.current) {
+            return;
+          }
+          didTrackHover.current = true;
+          trackAnalytics('agent-monitoring.model-cost-callout-tooltip-hover', {
+            ...analyticsParams,
+          });
+        }}
+      >
+        {t('Cost unavailable')}
+      </Button>
+    </Tooltip>
+  );
 }
 
 function getMCPAttributes(attributes: Record<string, string | number | boolean>) {

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/highlightedAttributes.tsx
@@ -4,14 +4,13 @@ import * as Sentry from '@sentry/react';
 
 import {Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
-import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Container, Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
-import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {Count} from 'sentry/components/count';
 import {StructuredData} from 'sentry/components/structuredEventData';
-import {IconCopy, IconWarning} from 'sentry/icons';
+import {IconCopy, IconDocs, IconWarning} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {copyToClipboard} from 'sentry/utils/useCopyToClipboard';
@@ -42,14 +41,11 @@ const AI_COST_DOCS_URL =
 const LLM_COST_INSTRUCTIONS_MARKDOWN = `
 # Fix Sentry AI cost reporting
 
-Sentry can calculate LLM cost when each AI client span records token counts and a model ID.
+This AI span already has token counts. Add the model ID so Sentry can calculate cost.
 
 1. Set \`gen_ai.response.model\` or \`gen_ai.request.model\` to the model ID used for the call.
-2. Record token counts on the span:
-   - \`gen_ai.usage.input_tokens\`
-   - \`gen_ai.usage.output_tokens\`
-   - \`gen_ai.usage.total_tokens\`
-3. If those values are present and cost is still empty, Sentry may not have pricing data for that model.
+2. Use the exact model name sent to the provider, for example \`gpt-4o-mini\` or \`claude-3-5-sonnet-latest\`.
+3. If model and token data are present and cost is still empty, Sentry may not have pricing data for that model.
 
 Follow Sentry's AI cost troubleshooting guide: ${AI_COST_DOCS_URL}
 `;
@@ -146,16 +142,10 @@ function getAISpanAttributes({
       name: t('Model'),
       value: <ModelName modelId={model.toString()} gap="xs" />,
     });
-  } else if (genAiOpType === 'ai_client') {
+  } else if (genAiOpType === 'ai_client' && hasTokenCounts(attributes)) {
     highlightedAttributes.push({
       name: t('Model'),
-      value: (
-        <MissingAIModelCostCallout
-          spanId={spanId}
-          hasTokenCounts={hasTokenCounts(attributes)}
-          hasCost={hasPositiveNumber(attributes['gen_ai.cost.total_tokens'])}
-        />
-      ),
+      value: <MissingAIModelCostCallout spanId={spanId} />,
     });
   }
 
@@ -277,13 +267,9 @@ function hasTokenCounts(attributes: Record<string, string | number | boolean>) {
 
 function captureMissingModelCostCalloutMessage({
   action,
-  hasCost,
-  hasTokenCounts: tokenCountsRecorded,
   spanId,
 }: {
   action: 'copy_instructions' | 'docs_click' | 'shown';
-  hasCost: boolean;
-  hasTokenCounts: boolean;
   spanId: string;
 }) {
   Sentry.captureMessage('AI span cost setup callout', {
@@ -291,26 +277,15 @@ function captureMissingModelCostCalloutMessage({
     tags: {
       action,
       feature: 'agent-monitoring',
-      has_cost: hasCost ? 'true' : 'false',
-      has_token_counts: tokenCountsRecorded ? 'true' : 'false',
-      missing_attributes: tokenCountsRecorded
-        ? 'gen_ai.response.model'
-        : 'gen_ai.response.model,gen_ai.usage.tokens',
+      has_token_counts: 'true',
+      missing_attributes: 'gen_ai.response.model',
       span_id: spanId,
       span_type: 'gen_ai',
     },
   });
 }
 
-function MissingAIModelCostCallout({
-  hasCost,
-  hasTokenCounts: tokenCountsRecorded,
-  spanId,
-}: {
-  hasCost: boolean;
-  hasTokenCounts: boolean;
-  spanId: string;
-}) {
+function MissingAIModelCostCallout({spanId}: {spanId: string}) {
   const organization = useOrganization();
   const didCaptureShown = useRef(false);
   const didTrackHover = useRef(false);
@@ -322,92 +297,74 @@ function MissingAIModelCostCallout({
     didCaptureShown.current = true;
     captureMissingModelCostCalloutMessage({
       action: 'shown',
-      hasCost,
-      hasTokenCounts: tokenCountsRecorded,
       spanId,
     });
-  }, [hasCost, spanId, tokenCountsRecorded]);
+  }, [spanId]);
 
   const analyticsParams = {
     organization,
-    hasCost,
-    hasTokenCounts: tokenCountsRecorded,
+    hasTokenCounts: true,
   };
 
   return (
-    <Tooltip
-      isHoverable
-      title={
-        <Stack gap="md" maxWidth="320px">
-          <Text as="p" size="sm">
-            {t(
-              'Sentry needs token counts and a model ID to calculate cost for AI spans.'
-            )}
-          </Text>
-          <Text as="p" size="sm" variant="muted">
-            {t(
-              'Record gen_ai usage token attributes and gen_ai.response.model or gen_ai.request.model. If those values are present and cost is still empty, Sentry may not have pricing data for this model.'
-            )}
-          </Text>
-          <Flex gap="sm" align="center" wrap="wrap">
-            <ExternalLink
-              href={AI_COST_DOCS_URL}
-              onClick={() => {
-                captureMissingModelCostCalloutMessage({
-                  action: 'docs_click',
-                  hasCost,
-                  hasTokenCounts: tokenCountsRecorded,
-                  spanId,
-                });
-                trackAnalytics('agent-monitoring.model-cost-callout-docs-click', {
-                  ...analyticsParams,
-                });
-              }}
-            >
-              {t('Read the guide')}
-            </ExternalLink>
-            <Button
-              size="xs"
-              priority="transparent"
-              icon={<IconCopy />}
-              onClick={() => {
-                copyToClipboard(LLM_COST_INSTRUCTIONS_MARKDOWN, {
-                  successMessage: t('Copied LLM instructions to clipboard'),
-                });
-                captureMissingModelCostCalloutMessage({
-                  action: 'copy_instructions',
-                  hasCost,
-                  hasTokenCounts: tokenCountsRecorded,
-                  spanId,
-                });
-                trackAnalytics('agent-monitoring.model-cost-callout-copy-click', {
-                  ...analyticsParams,
-                });
-              }}
-            >
-              {t('Copy LLM instructions')}
-            </Button>
-          </Flex>
-        </Stack>
-      }
-    >
-      <Button
-        size="xs"
-        priority="transparent"
-        icon={<IconWarning variant="warning" />}
-        onMouseEnter={() => {
-          if (didTrackHover.current) {
-            return;
-          }
-          didTrackHover.current = true;
-          trackAnalytics('agent-monitoring.model-cost-callout-tooltip-hover', {
+    <Flex align="center" gap="xs" wrap="wrap">
+      <Tooltip
+        title={t(
+          'There is no model data. Add gen_ai.response.model or gen_ai.request.model to calculate cost.'
+        )}
+      >
+        <Tag
+          variant="warning"
+          icon={<IconWarning />}
+          onMouseEnter={() => {
+            if (didTrackHover.current) {
+              return;
+            }
+            didTrackHover.current = true;
+            trackAnalytics('agent-monitoring.model-cost-callout-tooltip-hover', {
+              ...analyticsParams,
+            });
+          }}
+        >
+          {t('No model data')}
+        </Tag>
+      </Tooltip>
+      <ExternalLink
+        href={AI_COST_DOCS_URL}
+        onClick={() => {
+          captureMissingModelCostCalloutMessage({
+            action: 'docs_click',
+            spanId,
+          });
+          trackAnalytics('agent-monitoring.model-cost-callout-docs-click', {
             ...analyticsParams,
           });
         }}
       >
-        {t('Cost unavailable')}
-      </Button>
-    </Tooltip>
+        <Flex as="span" align="center" gap="xs">
+          <IconDocs size="xs" />
+          {t('Docs')}
+        </Flex>
+      </ExternalLink>
+      <Button
+        aria-label={t('Copy LLM instructions')}
+        size="zero"
+        priority="transparent"
+        icon={<IconCopy size="xs" />}
+        onClick={() => {
+          copyToClipboard(LLM_COST_INSTRUCTIONS_MARKDOWN, {
+            successMessage: t('Copied LLM instructions to clipboard'),
+          });
+          captureMissingModelCostCalloutMessage({
+            action: 'copy_instructions',
+            spanId,
+          });
+          trackAnalytics('agent-monitoring.model-cost-callout-copy-click', {
+            ...analyticsParams,
+          });
+        }}
+      />
+    </Flex>
   );
 }
 


### PR DESCRIPTION
Adds an inline callout in the trace drawer when an `ai_client` span is missing its model, explaining that cost requires model and token data and linking to docs or copyable LLM instructions for fixing instrumentation. The callout also emits Sentry messages and analytics for display, docs clicks, copy clicks, and tooltip hover so we can measure how often users try to fix missing cost data.

Refs TET-2244