### PR TITLE
feat(releases): Add referenced-in-commit activity

### DIFF
--- a/src/sentry/api/serializers/models/activity.py
+++ b/src/sentry/api/serializers/models/activity.py
@@ -11,6 +11,11 @@ from sentry.types.activity import ActivityType
 from sentry.users.services.user.serial import serialize_generic_user
 from sentry.users.services.user.service import user_service
 
+COMMIT_ACTIVITY_TYPES = {
+    ActivityType.SET_RESOLVED_IN_COMMIT.value,
+    ActivityType.REFERENCED_IN_COMMIT.value,
+}
+
 
 @register(Activity)
 class ActivitySerializer(Serializer):
@@ -45,11 +50,7 @@ class ActivitySerializer(Serializer):
             if app.proxy_user_id
         }
 
-        commit_ids = {
-            i.data["commit"]
-            for i in item_list
-            if i.type == ActivityType.SET_RESOLVED_IN_COMMIT.value
-        }
+        commit_ids = {i.data["commit"] for i in item_list if i.type in COMMIT_ACTIVITY_TYPES}
         if commit_ids:
             commit_list = list(Commit.objects.filter(id__in=commit_ids))
             commits_by_id = {
@@ -62,7 +63,7 @@ class ActivitySerializer(Serializer):
             commits = {
                 i: commits_by_id.get(i.data["commit"])
                 for i in item_list
-                if i.type == ActivityType.SET_RESOLVED_IN_COMMIT.value
+                if i.type in COMMIT_ACTIVITY_TYPES
             }
         else:
             commits = {}
@@ -122,7 +123,7 @@ class ActivitySerializer(Serializer):
         }
 
     def serialize(self, obj: Activity, attrs, user, **kwargs):
-        if obj.type == ActivityType.SET_RESOLVED_IN_COMMIT.value:
+        if obj.type in COMMIT_ACTIVITY_TYPES:
             data = {"commit": attrs["commit"]}
         elif obj.type == ActivityType.SET_RESOLVED_IN_PULL_REQUEST.value:
             data = {"pullRequest": attrs["pull_request"]}

--- a/src/sentry/integrations/msteams/notifications.py
+++ b/src/sentry/integrations/msteams/notifications.py
@@ -14,6 +14,9 @@ from sentry.notifications.notifications.activity.assigned import AssignedActivit
 from sentry.notifications.notifications.activity.base import GroupActivityNotification
 from sentry.notifications.notifications.activity.escalating import EscalatingActivityNotification
 from sentry.notifications.notifications.activity.note import NoteActivityNotification
+from sentry.notifications.notifications.activity.referenced_in_commit import (
+    ReferencedInCommitActivityNotification,
+)
 from sentry.notifications.notifications.activity.regression import RegressionActivityNotification
 from sentry.notifications.notifications.activity.release import ReleaseActivityNotification
 from sentry.notifications.notifications.activity.resolved import ResolvedActivityNotification
@@ -45,6 +48,7 @@ SUPPORTED_NOTIFICATION_TYPES = [
     AlertRuleNotification,
     ResolvedActivityNotification,
     ResolvedInCommitActivityNotification,
+    ReferencedInCommitActivityNotification,
     ResolvedInReleaseActivityNotification,
     ReleaseActivityNotification,
     RegressionActivityNotification,

--- a/src/sentry/integrations/slack/service.py
+++ b/src/sentry/integrations/slack/service.py
@@ -49,6 +49,9 @@ from sentry.notifications.notifications.activity.archive import ArchiveActivityN
 from sentry.notifications.notifications.activity.assigned import AssignedActivityNotification
 from sentry.notifications.notifications.activity.base import GroupActivityNotification
 from sentry.notifications.notifications.activity.escalating import EscalatingActivityNotification
+from sentry.notifications.notifications.activity.referenced_in_commit import (
+    ReferencedInCommitActivityNotification,
+)
 from sentry.notifications.notifications.activity.regression import RegressionActivityNotification
 from sentry.notifications.notifications.activity.resolved import ResolvedActivityNotification
 from sentry.notifications.notifications.activity.resolved_in_commit import (
@@ -80,6 +83,7 @@ DEFAULT_SUPPORTED_ACTIVITY_THREAD_NOTIFICATION_HANDLERS: dict[
     ActivityType.SET_RESOLVED: ResolvedActivityNotification,
     ActivityType.SET_RESOLVED_BY_AGE: ResolvedActivityNotification,
     ActivityType.SET_RESOLVED_IN_COMMIT: ResolvedInCommitActivityNotification,
+    ActivityType.REFERENCED_IN_COMMIT: ReferencedInCommitActivityNotification,
     ActivityType.SET_RESOLVED_IN_PULL_REQUEST: ResolvedInPullRequestActivityNotification,
     ActivityType.SET_RESOLVED_IN_RELEASE: ResolvedInReleaseActivityNotification,
     ActivityType.UNASSIGNED: UnassignedActivityNotification,

--- a/src/sentry/notifications/notifications/activity/referenced_in_commit.py
+++ b/src/sentry/notifications/notifications/activity/referenced_in_commit.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .base import GroupActivityNotification
+
+
+class ReferencedInCommitActivityNotification(GroupActivityNotification):
+    metrics_key = "referenced_in_commit_activity"
+    title = "Issue Referenced in Commit"
+
+    def get_description(self) -> tuple[str, str | None, Mapping[str, Any]]:
+        return "{author} referenced {an issue} in a commit", None, {}

--- a/src/sentry/notifications/notifications/activity/resolved_in_commit.py
+++ b/src/sentry/notifications/notifications/activity/resolved_in_commit.py
@@ -3,17 +3,12 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
-from sentry.models.group import GroupStatus
-
 from .base import GroupActivityNotification
 
 
 class ResolvedInCommitActivityNotification(GroupActivityNotification):
     metrics_key = "resolved_in_commit_activity"
-    title = "Issue Linked to Commit"
+    title = "Resolved Issue in Commit"
 
     def get_description(self) -> tuple[str, str | None, Mapping[str, Any]]:
-        # Check if the issue is already resolved (API path) or pending resolution (commit push path)
-        if self.group.status == GroupStatus.RESOLVED:
-            return "{author} marked {an issue} as resolved in a commit", None, {}
-        return "{author} made a commit that will resolve {an issue}", None, {}
+        return "{author} marked {an issue} as resolved in a commit", None, {}

--- a/src/sentry/receivers/releases.py
+++ b/src/sentry/receivers/releases.py
@@ -78,11 +78,11 @@ def resolved_in_commit(instance: Commit, created, **kwargs):
     Creates GroupLinks and Activity entries for commits that reference issues.
 
     With the "organizations:defer-commit-resolution" feature flag:
-    - Flag ON (new behavior): Creates GroupLinks and Activity but does NOT immediately
-      resolve issues. Resolution happens when a release is created that includes these
-      commits, via update_group_resolutions() in src/sentry/models/releases/set_commits.py.
-      This prevents issues from being resolved prematurely when commits are pushed to
-      feature branches.
+    - Flag ON (new behavior): Creates GroupLinks and REFERENCED_IN_COMMIT Activity but
+      does NOT immediately resolve issues. Resolution happens when a release is created
+      that includes these commits, via update_group_resolutions() in
+      src/sentry/models/releases/set_commits.py. This prevents issues from being resolved
+      prematurely when commits are pushed to feature branches.
     - Flag OFF (legacy behavior): Immediately resolves issues when commits are pushed.
     """
     groups = instance.find_referenced_groups()
@@ -174,10 +174,15 @@ def resolved_in_commit(instance: Commit, created, **kwargs):
                     group.substatus = None
                     remove_group_from_inbox(group, action=GroupInboxRemoveAction.RESOLVED)
 
+                activity_type = (
+                    ActivityType.REFERENCED_IN_COMMIT
+                    if defer_resolution
+                    else ActivityType.SET_RESOLVED_IN_COMMIT
+                )
                 activity_kwargs = {
                     "project_id": group.project_id,
                     "group": group,
-                    "type": ActivityType.SET_RESOLVED_IN_COMMIT.value,
+                    "type": activity_type.value,
                     "ident": instance.id,
                     "data": {"commit": instance.id},
                 }
@@ -186,11 +191,12 @@ def resolved_in_commit(instance: Commit, created, **kwargs):
 
                 Activity.objects.create(**activity_kwargs)
 
-                record_group_history_from_activity_type(
-                    group,
-                    ActivityType.SET_RESOLVED_IN_COMMIT.value,
-                    actor=acting_user if acting_user else None,
-                )
+                if not defer_resolution:
+                    record_group_history_from_activity_type(
+                        group,
+                        ActivityType.SET_RESOLVED_IN_COMMIT.value,
+                        actor=acting_user if acting_user else None,
+                    )
 
         except IntegrityError:
             pass

--- a/src/sentry/types/activity.py
+++ b/src/sentry/types/activity.py
@@ -32,6 +32,7 @@ class ActivityType(Enum):
 
     SET_PRIORITY = 26
     DELETED_ATTACHMENT = 27
+    REFERENCED_IN_COMMIT = 28
 
 
 # Warning: This must remain in this EXACT order.
@@ -65,6 +66,7 @@ CHOICES = tuple(
         ActivityType.SET_ESCALATING,  # 25
         ActivityType.SET_PRIORITY,  # 26
         ActivityType.DELETED_ATTACHMENT,  # 27
+        ActivityType.REFERENCED_IN_COMMIT,  # 28
     ]
 )
 

--- a/tests/sentry/api/serializers/test_activity.py
+++ b/tests/sentry/api/serializers/test_activity.py
@@ -62,6 +62,31 @@ class GroupActivityTestCase(TestCase):
         assert commit_data["repository"]["name"] == "organization-bar"
         assert commit_data["message"] == "gemuse"
 
+    def test_referenced_in_commit_activity(self) -> None:
+        self.org = self.create_organization(name="Rowdy Tiger")
+        user = self.create_user()
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
+        repo = self.create_repo(self.project, name="organization-bar")
+
+        commit = Commit.objects.create(
+            organization_id=self.org.id, repository_id=repo.id, key="11111111", message="gemuse"
+        )
+
+        activity = Activity.objects.create(
+            project_id=group.project_id,
+            group=group,
+            type=ActivityType.REFERENCED_IN_COMMIT.value,
+            ident=commit.id,
+            user_id=user.id,
+            data={"commit": commit.id},
+        )
+
+        result = serialize([activity], user)[0]
+        assert result["type"] == "referenced_in_commit"
+        commit_data = result["data"]["commit"]
+        assert commit_data["repository"]["name"] == "organization-bar"
+        assert commit_data["message"] == "gemuse"
+
     def test_serialize_set_resolve_in_commit_activity_with_release(self) -> None:
         project = self.create_project(name="test_throwaway")
         group = self.create_group(project)

--- a/tests/sentry/models/test_pullrequest.py
+++ b/tests/sentry/models/test_pullrequest.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 
 from django.utils import timezone
 
+from sentry.models.activity import Activity
 from sentry.models.commit import Commit
 from sentry.models.group import GroupStatus
 from sentry.models.grouphistory import GroupHistory, GroupHistoryStatus
@@ -15,6 +16,7 @@ from sentry.models.releaseheadcommit import ReleaseHeadCommit
 from sentry.models.repository import Repository
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
+from sentry.types.activity import ActivityType
 
 
 class FindReferencedGroupsTest(TestCase):
@@ -43,6 +45,14 @@ class FindReferencedGroupsTest(TestCase):
             linked_type=GroupLink.LinkedType.commit,
             linked_id=commit.id,
         ).exists()
+        assert Activity.objects.filter(
+            group=group,
+            type=ActivityType.SET_RESOLVED_IN_COMMIT.value,
+        ).exists()
+        assert not Activity.objects.filter(
+            group=group,
+            type=ActivityType.REFERENCED_IN_COMMIT.value,
+        ).exists()
         assert GroupHistory.objects.filter(
             group=group,
             status=GroupHistoryStatus.SET_RESOLVED_IN_COMMIT,
@@ -53,9 +63,9 @@ class FindReferencedGroupsTest(TestCase):
     @with_feature("organizations:defer-commit-resolution")
     def test_resolve_in_commit_deferred(self) -> None:
         """
-        With defer-commit-resolution ON: commits create GroupLinks but do NOT
-        immediately resolve issues. Resolution happens when a release is created
-        that includes these commits, via update_group_resolutions().
+        With defer-commit-resolution ON: commits create GroupLinks and referenced
+        activity but do NOT immediately resolve issues. Resolution happens when a
+        release is created that includes these commits, via update_group_resolutions().
         """
         group = self.create_group()
 
@@ -76,7 +86,16 @@ class FindReferencedGroupsTest(TestCase):
             linked_type=GroupLink.LinkedType.commit,
             linked_id=commit.id,
         ).exists()
-        assert GroupHistory.objects.filter(
+        activity = Activity.objects.get(
+            group=group,
+            type=ActivityType.REFERENCED_IN_COMMIT.value,
+        )
+        assert activity.data == {"commit": commit.id}
+        assert not Activity.objects.filter(
+            group=group,
+            type=ActivityType.SET_RESOLVED_IN_COMMIT.value,
+        ).exists()
+        assert not GroupHistory.objects.filter(
             group=group,
             status=GroupHistoryStatus.SET_RESOLVED_IN_COMMIT,
         ).exists()

--- a/tests/sentry/receivers/test_releases.py
+++ b/tests/sentry/receivers/test_releases.py
@@ -43,23 +43,28 @@ class ResolvedInCommitTest(TestCase):
     Tests for resolved_in_commit signal handler.
 
     With "organizations:defer-commit-resolution" flag ON (new behavior):
-    Commits with "Fixes ISSUE-123" create GroupLinks and Activity entries,
-    but do NOT immediately resolve issues. Resolution happens when a release is
-    created that includes these commits, via update_group_resolutions().
+    Commits with "Fixes ISSUE-123" create GroupLinks and REFERENCED_IN_COMMIT
+    Activity entries, but do NOT immediately resolve issues. Resolution happens
+    when a release is created that includes these commits, via update_group_resolutions().
 
     With flag OFF (legacy behavior): Issues are immediately resolved when commits
     are pushed.
     """
 
     def assertLinkedFromCommitDeferred(self, group, commit):
-        """Assert that a GroupLink, Activity, and GroupHistory were created, but issue is NOT resolved."""
+        """Assert that a GroupLink and Activity were created, but issue is NOT resolved."""
         assert GroupLink.objects.filter(
             group_id=group.id, linked_type=GroupLink.LinkedType.commit, linked_id=commit.id
         ).exists()
-        assert Activity.objects.filter(
+        activity = Activity.objects.get(
+            group=group,
+            type=ActivityType.REFERENCED_IN_COMMIT.value,
+        )
+        assert activity.data == {"commit": commit.id}
+        assert not Activity.objects.filter(
             group=group, type=ActivityType.SET_RESOLVED_IN_COMMIT.value
         ).exists()
-        assert GroupHistory.objects.filter(
+        assert not GroupHistory.objects.filter(
             group=group, status=GroupHistoryStatus.SET_RESOLVED_IN_COMMIT
         ).exists()
         # Issue should NOT be resolved immediately - resolution happens via releases
@@ -74,6 +79,9 @@ class ResolvedInCommitTest(TestCase):
         ).exists()
         assert Activity.objects.filter(
             group=group, type=ActivityType.SET_RESOLVED_IN_COMMIT.value
+        ).exists()
+        assert not Activity.objects.filter(
+            group=group, type=ActivityType.REFERENCED_IN_COMMIT.value
         ).exists()
         assert GroupHistory.objects.filter(
             group=group, status=GroupHistoryStatus.SET_RESOLVED_IN_COMMIT


### PR DESCRIPTION
Add a distinct issue activity for commit pushes that reference an issue while deferred commit resolution is enabled. This keeps unresolved issues from showing a misleading resolved-in-commit activity before the commit ships in a release.

**Activity Contract**

The deferred commit receiver now emits `referenced_in_commit`, while immediate and manual resolution paths continue to emit `set_resolved_in_commit`. The activity serializer hydrates the commit payload for both types so consumers can render the same commit link data.

**Notifications**

Slack and Microsoft Teams can render the new reference activity separately from resolution activity. `set_resolved_in_commit` notifications now stay resolution-only, so the temporary "will resolve" status check from the previous PR is no longer needed.

**Possible Follow-ups**

We may want to align pull request activity with this model by changing "Resolved in Pull Request" to "Referenced in Pull Request". We may also want to create a separate activity when the issue is actually resolved by the later release for both commit and pull request resolution paths.

Related to #107138.