### PR TITLE
feat(issues): Render referenced-in-commit activity

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -596,6 +596,7 @@ export enum GroupActivityType {
   SET_RESOLVED_BY_AGE = 'set_resolved_by_age',
   SET_RESOLVED_IN_RELEASE = 'set_resolved_in_release',
   SET_RESOLVED_IN_COMMIT = 'set_resolved_in_commit',
+  REFERENCED_IN_COMMIT = 'referenced_in_commit',
   SET_RESOLVED_IN_PULL_REQUEST = 'set_resolved_in_pull_request',
   SET_UNRESOLVED = 'set_unresolved',
   SET_IGNORED = 'set_ignored',
@@ -763,6 +764,13 @@ interface GroupActivitySetByResolvedInCommit extends GroupActivityBase {
   type: GroupActivityType.SET_RESOLVED_IN_COMMIT;
 }
 
+interface GroupActivityReferencedInCommit extends GroupActivityBase {
+  data: {
+    commit?: Commit;
+  };
+  type: GroupActivityType.REFERENCED_IN_COMMIT;
+}
+
 interface GroupActivitySetByResolvedInPullRequest extends GroupActivityBase {
   data: {
     pullRequest?: PullRequest;
@@ -899,6 +907,7 @@ export type GroupActivity =
   | GroupActivitySetByResolvedInRelease
   | GroupActivitySetByResolvedInNextSemverRelease
   | GroupActivitySetByResolvedInCommit
+  | GroupActivityReferencedInCommit
   | GroupActivitySetByResolvedInPullRequest
   | GroupActivityFirstSeen
   | GroupActivityMerge

--- a/static/app/views/issueDetails/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/groupActivityItem.tsx
@@ -373,6 +373,21 @@ export function GroupActivityItem({
         }
         return tct('[author] marked this issue as resolved in a commit', {author});
       }
+      case GroupActivityType.REFERENCED_IN_COMMIT: {
+        if (activity.data.commit) {
+          return tct('[author] referenced this issue in [commit]', {
+            author,
+            commit: (
+              <CommitLink
+                inline
+                commitId={activity.data.commit.id}
+                repository={activity.data.commit.repository}
+              />
+            ),
+          });
+        }
+        return tct('[author] referenced this issue in a commit', {author});
+      }
       case GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST: {
         const {data} = activity;
         const {pullRequest} = data;

--- a/static/app/views/issueDetails/streamline/sidebar/activitySection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/activitySection.spec.tsx
@@ -1,3 +1,4 @@
+import {CommitFixture} from 'sentry-fixture/commit';
 import {GroupFixture} from 'sentry-fixture/group';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {SentryAppFixture} from 'sentry-fixture/sentryApp';
@@ -375,5 +376,29 @@ describe('StreamlinedActivitySection', () => {
     render(<StreamlinedActivitySection group={resolvedGroup} />);
     expect(await screen.findByText('Resolved')).toBeInTheDocument();
     expect(screen.getByRole('link', {name: '1.0.0'})).toBeInTheDocument();
+  });
+
+  it('renders referenced in commit activity', async () => {
+    const referencedGroup = GroupFixture({
+      id: '1341',
+      activity: [
+        {
+          type: GroupActivityType.REFERENCED_IN_COMMIT,
+          id: 'referenced-in-commit-1',
+          dateCreated: '2020-01-01T00:00:00',
+          data: {
+            commit: CommitFixture({
+              id: 'f7f395d14b2fe29a4e253bf1d3094d61e6ad4434',
+            }),
+          },
+          user,
+        },
+      ],
+      project,
+    });
+
+    render(<StreamlinedActivitySection group={referencedGroup} />);
+    expect(await screen.findByText('Referenced in Commit')).toBeInTheDocument();
+    expect(screen.getByText('f7f395d')).toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/streamline/sidebar/groupActivityIcons.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/groupActivityIcons.tsx
@@ -72,6 +72,10 @@ export const groupActivityTypeIconMapping: Record<
     Component: IconCheckmark,
     defaultProps: {},
   },
+  [GroupActivityType.REFERENCED_IN_COMMIT]: {
+    Component: IconCommit,
+    defaultProps: {},
+  },
   [GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST]: {
     Component: IconCommit,
     defaultProps: {},

--- a/static/app/views/issueDetails/streamline/sidebar/groupActivityItem.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/groupActivityItem.tsx
@@ -427,6 +427,27 @@ export function getGroupActivityItem(
           message: tct('by [author] in a commit', {author}),
         };
       }
+      case GroupActivityType.REFERENCED_IN_COMMIT: {
+        if (activity.data.commit) {
+          return {
+            title: t('Referenced in Commit'),
+            message: tct('by [author] in [commit]', {
+              author,
+              commit: (
+                <CommitLink
+                  inline
+                  commitId={activity.data.commit.id}
+                  repository={activity.data.commit.repository}
+                />
+              ),
+            }),
+          };
+        }
+        return {
+          title: t('Referenced in Commit'),
+          message: tct('by [author] in a commit', {author}),
+        };
+      }
       case GroupActivityType.SET_RESOLVED_IN_PULL_REQUEST: {
         const {data} = activity;
         const {pullRequest} = data;


### PR DESCRIPTION
Add frontend support for the `referenced_in_commit` issue activity emitted by deferred commit resolution. Both the legacy activity feed and streamlined activity sidebar now render the activity as a commit reference, while resolved-in-commit copy remains reserved for actual resolution activity.

**Dependency**

Depends on backend activity support in #114298. This PR should land after that API activity type is available.

**Activity UI**

The new activity uses commit-link hydration from the API and displays as "Referenced in Commit" in the streamlined sidebar, with matching copy in the legacy feed.

Related to #107138.