### PR TITLE
ref(nightshift): Rename agent_run_id to run_id in response

### DIFF
--- a/src/sentry/seer/endpoints/project_seer_night_shift.py
+++ b/src/sentry/seer/endpoints/project_seer_night_shift.py
@@ -60,11 +60,11 @@ class ProjectSeerNightShiftEndpoint(ProjectEndpoint):
             "reasoning_effort": tweaks.reasoning_effort,
             "extra_triage_instructions": tweaks.extra_triage_instructions,
         }
-        agent_run_id = run_night_shift_for_org(
+        run_id = run_night_shift_for_org(
             project.organization_id,
             options=options,
             project_ids=[project.id],
             triggering_user_id=triggering_user_id,
             execute_in_task=True,
         )
-        return Response({"agent_run_id": agent_run_id}, status=200)
+        return Response({"run_id": run_id}, status=200)

--- a/tests/sentry/seer/endpoints/test_project_seer_night_shift.py
+++ b/tests/sentry/seer/endpoints/test_project_seer_night_shift.py
@@ -25,7 +25,7 @@ class ProjectSeerNightShiftTest(APITestCase):
                 status_code=200,
             )
 
-        assert response.data == {"agent_run_id": 42}
+        assert response.data == {"run_id": 42}
         mock_task.assert_called_once_with(
             self.organization.id,
             options={
@@ -54,7 +54,7 @@ class ProjectSeerNightShiftTest(APITestCase):
                 status_code=200,
             )
 
-        assert response.data == {"agent_run_id": None}
+        assert response.data == {"run_id": None}
         mock_task.assert_called_once_with(
             self.organization.id,
             options={
@@ -92,7 +92,7 @@ class ProjectSeerNightShiftTest(APITestCase):
                 status_code=200,
             )
 
-        assert response.data == {"agent_run_id": 99}
+        assert response.data == {"run_id": 99}
         mock_task.assert_called_once_with(
             self.organization.id,
             options={


### PR DESCRIPTION
Rename the variable and JSON response key returned from the manual
night-shift trigger endpoint (`POST /projects/{...}/seer/night-shift/`)
from `agent_run_id` to `run_id`.

Agent transcript: https://claudescope.sentry.dev/share/aK1GN53AB5Xa7ma6-LW2B2987iMzBU8nrH-YyRWH3jc