### PR TITLE
feat(preprod): Add per-category controls for snapshot PR comments (EME-1046)

### DIFF
--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -1234,6 +1234,12 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
             "sentry:preprod_snapshot_pr_comments_only_if_diff": self.get_value_with_default(
                 attrs, "sentry:preprod_snapshot_pr_comments_only_if_diff"
             ),
+            "sentry:preprod_snapshot_pr_comments_post_on_added": self.get_value_with_default(
+                attrs, "sentry:preprod_snapshot_pr_comments_post_on_added"
+            ),
+            "sentry:preprod_snapshot_pr_comments_post_on_removed": self.get_value_with_default(
+                attrs, "sentry:preprod_snapshot_pr_comments_post_on_removed"
+            ),
         }
 
     def get_value_with_default(self, attrs, key):

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -1231,9 +1231,6 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
             "sentry:preprod_snapshot_pr_comments_enabled": self.get_value_with_default(
                 attrs, "sentry:preprod_snapshot_pr_comments_enabled"
             ),
-            "sentry:preprod_snapshot_pr_comments_only_if_diff": self.get_value_with_default(
-                attrs, "sentry:preprod_snapshot_pr_comments_only_if_diff"
-            ),
             "sentry:preprod_snapshot_pr_comments_post_on_added": self.get_value_with_default(
                 attrs, "sentry:preprod_snapshot_pr_comments_post_on_added"
             ),

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -1237,6 +1237,12 @@ class DetailedProjectSerializer(ProjectWithTeamSerializer):
             "sentry:preprod_snapshot_pr_comments_post_on_removed": self.get_value_with_default(
                 attrs, "sentry:preprod_snapshot_pr_comments_post_on_removed"
             ),
+            "sentry:preprod_snapshot_pr_comments_post_on_changed": self.get_value_with_default(
+                attrs, "sentry:preprod_snapshot_pr_comments_post_on_changed"
+            ),
+            "sentry:preprod_snapshot_pr_comments_post_on_renamed": self.get_value_with_default(
+                attrs, "sentry:preprod_snapshot_pr_comments_post_on_renamed"
+            ),
         }
 
     def get_value_with_default(self, attrs, key):

--- a/src/sentry/core/endpoints/project_details.py
+++ b/src/sentry/core/endpoints/project_details.py
@@ -124,6 +124,10 @@ class ProjectMemberSerializer(serializers.Serializer):
     )
     preprodSnapshotPrCommentsEnabled = serializers.BooleanField(required=False, allow_null=True)
     preprodSnapshotPrCommentsOnlyIfDiff = serializers.BooleanField(required=False, allow_null=True)
+    preprodSnapshotPrCommentsPostOnAdded = serializers.BooleanField(required=False, allow_null=True)
+    preprodSnapshotPrCommentsPostOnRemoved = serializers.BooleanField(
+        required=False, allow_null=True
+    )
     preprodSizeEnabledQuery = serializers.CharField(required=False, allow_null=True)
     preprodDistributionEnabledQuery = serializers.CharField(required=False, allow_null=True)
 
@@ -177,6 +181,8 @@ class ProjectMemberSerializer(serializers.Serializer):
         "preprodDistributionPrCommentsEnabledByCustomer",
         "preprodSnapshotPrCommentsEnabled",
         "preprodSnapshotPrCommentsOnlyIfDiff",
+        "preprodSnapshotPrCommentsPostOnAdded",
+        "preprodSnapshotPrCommentsPostOnRemoved",
     ]
 )
 class ProjectAdminSerializer(ProjectMemberSerializer):
@@ -930,6 +936,22 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
                 changed_proj_settings["sentry:preprod_snapshot_pr_comments_only_if_diff"] = result[
                     "preprodSnapshotPrCommentsOnlyIfDiff"
                 ]
+        if "preprodSnapshotPrCommentsPostOnAdded" in result:
+            if project.update_option(
+                "sentry:preprod_snapshot_pr_comments_post_on_added",
+                result["preprodSnapshotPrCommentsPostOnAdded"],
+            ):
+                changed_proj_settings["sentry:preprod_snapshot_pr_comments_post_on_added"] = result[
+                    "preprodSnapshotPrCommentsPostOnAdded"
+                ]
+        if "preprodSnapshotPrCommentsPostOnRemoved" in result:
+            if project.update_option(
+                "sentry:preprod_snapshot_pr_comments_post_on_removed",
+                result["preprodSnapshotPrCommentsPostOnRemoved"],
+            ):
+                changed_proj_settings["sentry:preprod_snapshot_pr_comments_post_on_removed"] = (
+                    result["preprodSnapshotPrCommentsPostOnRemoved"]
+                )
         if "debugFilesRole" in result:
             if result["debugFilesRole"] is None:
                 project.delete_option("sentry:debug_files_role")

--- a/src/sentry/core/endpoints/project_details.py
+++ b/src/sentry/core/endpoints/project_details.py
@@ -123,7 +123,6 @@ class ProjectMemberSerializer(serializers.Serializer):
         required=False, allow_null=True
     )
     preprodSnapshotPrCommentsEnabled = serializers.BooleanField(required=False, allow_null=True)
-    preprodSnapshotPrCommentsOnlyIfDiff = serializers.BooleanField(required=False, allow_null=True)
     preprodSnapshotPrCommentsPostOnAdded = serializers.BooleanField(required=False, allow_null=True)
     preprodSnapshotPrCommentsPostOnRemoved = serializers.BooleanField(
         required=False, allow_null=True
@@ -180,7 +179,6 @@ class ProjectMemberSerializer(serializers.Serializer):
         "preprodSnapshotStatusChecksFailOnRenamed",
         "preprodDistributionPrCommentsEnabledByCustomer",
         "preprodSnapshotPrCommentsEnabled",
-        "preprodSnapshotPrCommentsOnlyIfDiff",
         "preprodSnapshotPrCommentsPostOnAdded",
         "preprodSnapshotPrCommentsPostOnRemoved",
     ]
@@ -927,14 +925,6 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
             ):
                 changed_proj_settings["sentry:preprod_snapshot_pr_comments_enabled"] = result[
                     "preprodSnapshotPrCommentsEnabled"
-                ]
-        if "preprodSnapshotPrCommentsOnlyIfDiff" in result:
-            if project.update_option(
-                "sentry:preprod_snapshot_pr_comments_only_if_diff",
-                result["preprodSnapshotPrCommentsOnlyIfDiff"],
-            ):
-                changed_proj_settings["sentry:preprod_snapshot_pr_comments_only_if_diff"] = result[
-                    "preprodSnapshotPrCommentsOnlyIfDiff"
                 ]
         if "preprodSnapshotPrCommentsPostOnAdded" in result:
             if project.update_option(

--- a/src/sentry/core/endpoints/project_details.py
+++ b/src/sentry/core/endpoints/project_details.py
@@ -127,6 +127,12 @@ class ProjectMemberSerializer(serializers.Serializer):
     preprodSnapshotPrCommentsPostOnRemoved = serializers.BooleanField(
         required=False, allow_null=True
     )
+    preprodSnapshotPrCommentsPostOnChanged = serializers.BooleanField(
+        required=False, allow_null=True
+    )
+    preprodSnapshotPrCommentsPostOnRenamed = serializers.BooleanField(
+        required=False, allow_null=True
+    )
     preprodSizeEnabledQuery = serializers.CharField(required=False, allow_null=True)
     preprodDistributionEnabledQuery = serializers.CharField(required=False, allow_null=True)
 
@@ -181,6 +187,8 @@ class ProjectMemberSerializer(serializers.Serializer):
         "preprodSnapshotPrCommentsEnabled",
         "preprodSnapshotPrCommentsPostOnAdded",
         "preprodSnapshotPrCommentsPostOnRemoved",
+        "preprodSnapshotPrCommentsPostOnChanged",
+        "preprodSnapshotPrCommentsPostOnRenamed",
     ]
 )
 class ProjectAdminSerializer(ProjectMemberSerializer):
@@ -941,6 +949,22 @@ class ProjectDetailsEndpoint(ProjectEndpoint):
             ):
                 changed_proj_settings["sentry:preprod_snapshot_pr_comments_post_on_removed"] = (
                     result["preprodSnapshotPrCommentsPostOnRemoved"]
+                )
+        if "preprodSnapshotPrCommentsPostOnChanged" in result:
+            if project.update_option(
+                "sentry:preprod_snapshot_pr_comments_post_on_changed",
+                result["preprodSnapshotPrCommentsPostOnChanged"],
+            ):
+                changed_proj_settings["sentry:preprod_snapshot_pr_comments_post_on_changed"] = (
+                    result["preprodSnapshotPrCommentsPostOnChanged"]
+                )
+        if "preprodSnapshotPrCommentsPostOnRenamed" in result:
+            if project.update_option(
+                "sentry:preprod_snapshot_pr_comments_post_on_renamed",
+                result["preprodSnapshotPrCommentsPostOnRenamed"],
+            ):
+                changed_proj_settings["sentry:preprod_snapshot_pr_comments_post_on_renamed"] = (
+                    result["preprodSnapshotPrCommentsPostOnRenamed"]
                 )
         if "debugFilesRole" in result:
             if result["debugFilesRole"] is None:

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -82,7 +82,6 @@ OPTION_KEYS = frozenset(
         "sentry:preprod_snapshot_status_checks_fail_on_renamed",
         "sentry:preprod_distribution_pr_comments_enabled_by_customer",
         "sentry:preprod_snapshot_pr_comments_enabled",
-        "sentry:preprod_snapshot_pr_comments_only_if_diff",
         "sentry:preprod_snapshot_pr_comments_post_on_added",
         "sentry:preprod_snapshot_pr_comments_post_on_removed",
         "sentry:scm_source_context_enabled",

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -84,6 +84,8 @@ OPTION_KEYS = frozenset(
         "sentry:preprod_snapshot_pr_comments_enabled",
         "sentry:preprod_snapshot_pr_comments_post_on_added",
         "sentry:preprod_snapshot_pr_comments_post_on_removed",
+        "sentry:preprod_snapshot_pr_comments_post_on_changed",
+        "sentry:preprod_snapshot_pr_comments_post_on_renamed",
         "sentry:scm_source_context_enabled",
         "quotas:spike-protection-disabled",
         "feedback:branding",

--- a/src/sentry/models/options/project_option.py
+++ b/src/sentry/models/options/project_option.py
@@ -83,6 +83,8 @@ OPTION_KEYS = frozenset(
         "sentry:preprod_distribution_pr_comments_enabled_by_customer",
         "sentry:preprod_snapshot_pr_comments_enabled",
         "sentry:preprod_snapshot_pr_comments_only_if_diff",
+        "sentry:preprod_snapshot_pr_comments_post_on_added",
+        "sentry:preprod_snapshot_pr_comments_post_on_removed",
         "sentry:scm_source_context_enabled",
         "quotas:spike-protection-disabled",
         "feedback:branding",

--- a/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
@@ -24,6 +24,8 @@ logger = logging.getLogger(__name__)
 ENABLED_OPTION_KEY = "sentry:preprod_snapshot_pr_comments_enabled"
 POST_ON_ADDED_OPTION_KEY = "sentry:preprod_snapshot_pr_comments_post_on_added"
 POST_ON_REMOVED_OPTION_KEY = "sentry:preprod_snapshot_pr_comments_post_on_removed"
+POST_ON_CHANGED_OPTION_KEY = "sentry:preprod_snapshot_pr_comments_post_on_changed"
+POST_ON_RENAMED_OPTION_KEY = "sentry:preprod_snapshot_pr_comments_post_on_renamed"
 FEATURE_FLAG = "organizations:preprod-snapshot-pr-comments"
 
 
@@ -155,12 +157,16 @@ def create_preprod_snapshot_pr_comment_task(
 
         post_on_added = artifact.project.get_option(POST_ON_ADDED_OPTION_KEY, default=False)
         post_on_removed = artifact.project.get_option(POST_ON_REMOVED_OPTION_KEY, default=True)
+        post_on_changed = artifact.project.get_option(POST_ON_CHANGED_OPTION_KEY, default=True)
+        post_on_renamed = artifact.project.get_option(POST_ON_RENAMED_OPTION_KEY, default=False)
         changes_map = build_changes_map(
             all_artifacts,
             snapshot_metrics_map,
             comparisons_map,
             fail_on_added=post_on_added,
             fail_on_removed=post_on_removed,
+            fail_on_changed=post_on_changed,
+            fail_on_renamed=post_on_renamed,
         )
 
         has_changes = any(changes_map.values())

--- a/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
@@ -22,7 +22,6 @@ from sentry.taskworker.namespaces import preprod_tasks
 logger = logging.getLogger(__name__)
 
 ENABLED_OPTION_KEY = "sentry:preprod_snapshot_pr_comments_enabled"
-ONLY_IF_DIFF_OPTION_KEY = "sentry:preprod_snapshot_pr_comments_only_if_diff"
 POST_ON_ADDED_OPTION_KEY = "sentry:preprod_snapshot_pr_comments_post_on_added"
 POST_ON_REMOVED_OPTION_KEY = "sentry:preprod_snapshot_pr_comments_post_on_removed"
 FEATURE_FLAG = "organizations:preprod-snapshot-pr-comments"
@@ -164,20 +163,19 @@ def create_preprod_snapshot_pr_comment_task(
             fail_on_removed=post_on_removed,
         )
 
-        if artifact.project.get_option(ONLY_IF_DIFF_OPTION_KEY):
-            has_changes = any(changes_map.values())
-            # Failed comparisons are absent from changes_map (which only tracks
-            # SUCCESS state), so check comparisons_map directly to avoid
-            # suppressing failure reports.
-            has_failures = any(
-                c.state == PreprodSnapshotComparison.State.FAILED for c in comparisons_map.values()
+        has_changes = any(changes_map.values())
+        # Failed comparisons are absent from changes_map (which only tracks
+        # SUCCESS state), so check comparisons_map directly to avoid
+        # suppressing failure reports.
+        has_failures = any(
+            c.state == PreprodSnapshotComparison.State.FAILED for c in comparisons_map.values()
+        )
+        if not has_changes and not has_failures:
+            logger.info(
+                "preprod.snapshot_pr_comments.create.skipped_no_diff",
+                extra={"artifact_id": artifact.id},
             )
-            if not has_changes and not has_failures:
-                logger.info(
-                    "preprod.snapshot_pr_comments.create.skipped_no_diff",
-                    extra={"artifact_id": artifact.id},
-                )
-                return
+            return
 
         comment_body = format_snapshot_pr_comment(
             all_artifacts,

--- a/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
@@ -14,10 +14,6 @@ from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSn
 from sentry.preprod.snapshots.utils import build_changes_map
 from sentry.preprod.vcs.pr_comments.snapshot_templates import format_snapshot_pr_comment
 from sentry.preprod.vcs.pr_comments.tasks import find_existing_comment_id, save_pr_comment_result
-from sentry.preprod.vcs.status_checks.snapshots.tasks import (
-    FAIL_ON_ADDED_OPTION_KEY,
-    FAIL_ON_REMOVED_OPTION_KEY,
-)
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
@@ -27,6 +23,8 @@ logger = logging.getLogger(__name__)
 
 ENABLED_OPTION_KEY = "sentry:preprod_snapshot_pr_comments_enabled"
 ONLY_IF_DIFF_OPTION_KEY = "sentry:preprod_snapshot_pr_comments_only_if_diff"
+POST_ON_ADDED_OPTION_KEY = "sentry:preprod_snapshot_pr_comments_post_on_added"
+POST_ON_REMOVED_OPTION_KEY = "sentry:preprod_snapshot_pr_comments_post_on_removed"
 FEATURE_FLAG = "organizations:preprod-snapshot-pr-comments"
 
 
@@ -156,14 +154,14 @@ def create_preprod_snapshot_pr_comment_task(
 
         base_artifact_map = PreprodArtifact.get_base_artifacts_for_commit(all_artifacts)
 
-        fail_on_added = artifact.project.get_option(FAIL_ON_ADDED_OPTION_KEY, default=False)
-        fail_on_removed = artifact.project.get_option(FAIL_ON_REMOVED_OPTION_KEY, default=True)
+        post_on_added = artifact.project.get_option(POST_ON_ADDED_OPTION_KEY, default=False)
+        post_on_removed = artifact.project.get_option(POST_ON_REMOVED_OPTION_KEY, default=True)
         changes_map = build_changes_map(
             all_artifacts,
             snapshot_metrics_map,
             comparisons_map,
-            fail_on_added=fail_on_added,
-            fail_on_removed=fail_on_removed,
+            fail_on_added=post_on_added,
+            fail_on_removed=post_on_removed,
         )
 
         if artifact.project.get_option(ONLY_IF_DIFF_OPTION_KEY):

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -235,5 +235,11 @@ register(key="sentry:preprod_snapshot_pr_comments_post_on_added", default=False)
 # When True, treat snapshot removals as a diff worth posting a PR comment.
 register(key="sentry:preprod_snapshot_pr_comments_post_on_removed", default=True)
 
+# When True, treat pixel-level snapshot changes as a diff worth posting a PR comment.
+register(key="sentry:preprod_snapshot_pr_comments_post_on_changed", default=True)
+
+# When True, treat snapshot renames as a diff worth posting a PR comment.
+register(key="sentry:preprod_snapshot_pr_comments_post_on_renamed", default=False)
+
 # Whether to enable on-demand source context fetching from SCM integrations
 register(key="sentry:scm_source_context_enabled", default=False)

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -231,5 +231,11 @@ register(key="sentry:preprod_snapshot_pr_comments_enabled", default=False)
 # When True, only post snapshot PR comments if the comparison reports any diffs.
 register(key="sentry:preprod_snapshot_pr_comments_only_if_diff", default=False)
 
+# When True, treat snapshot additions as a diff for the only-if-diff PR comment gate.
+register(key="sentry:preprod_snapshot_pr_comments_post_on_added", default=False)
+
+# When True, treat snapshot removals as a diff for the only-if-diff PR comment gate.
+register(key="sentry:preprod_snapshot_pr_comments_post_on_removed", default=True)
+
 # Whether to enable on-demand source context fetching from SCM integrations
 register(key="sentry:scm_source_context_enabled", default=False)

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -225,16 +225,14 @@ register(key="sentry:preprod_distribution_enabled_query", default="")
 # Boolean to enable/disable build distribution PR comments for this project.
 register(key="sentry:preprod_distribution_pr_comments_enabled_by_customer", default=True)
 
-# Boolean to enable/disable snapshot PR comments for this project.
+# Boolean to enable/disable snapshot PR comments for this project. When True, the
+# task posts a comment only if the comparison reports a diff.
 register(key="sentry:preprod_snapshot_pr_comments_enabled", default=False)
 
-# When True, only post snapshot PR comments if the comparison reports any diffs.
-register(key="sentry:preprod_snapshot_pr_comments_only_if_diff", default=False)
-
-# When True, treat snapshot additions as a diff for the only-if-diff PR comment gate.
+# When True, treat snapshot additions as a diff worth posting a PR comment.
 register(key="sentry:preprod_snapshot_pr_comments_post_on_added", default=False)
 
-# When True, treat snapshot removals as a diff for the only-if-diff PR comment gate.
+# When True, treat snapshot removals as a diff worth posting a PR comment.
 register(key="sentry:preprod_snapshot_pr_comments_post_on_removed", default=True)
 
 # Whether to enable on-demand source context fetching from SCM integrations

--- a/tests/sentry/core/endpoints/test_project_details.py
+++ b/tests/sentry/core/endpoints/test_project_details.py
@@ -827,6 +827,20 @@ class ProjectUpdateTest(APITestCase):
         project = Project.objects.get(id=self.project.id)
         assert project.get_option("sentry:preprod_snapshot_pr_comments_post_on_removed") is False
 
+    def test_preprod_snapshot_pr_comments_post_on_changed_option(self) -> None:
+        self.get_success_response(
+            self.org_slug, self.proj_slug, preprodSnapshotPrCommentsPostOnChanged=False
+        )
+        project = Project.objects.get(id=self.project.id)
+        assert project.get_option("sentry:preprod_snapshot_pr_comments_post_on_changed") is False
+
+    def test_preprod_snapshot_pr_comments_post_on_renamed_option(self) -> None:
+        self.get_success_response(
+            self.org_slug, self.proj_slug, preprodSnapshotPrCommentsPostOnRenamed=True
+        )
+        project = Project.objects.get(id=self.project.id)
+        assert project.get_option("sentry:preprod_snapshot_pr_comments_post_on_renamed") is True
+
     def test_bookmarks(self) -> None:
         self.get_success_response(self.org_slug, self.proj_slug, isBookmarked="false")
         assert not ProjectBookmark.objects.filter(

--- a/tests/sentry/core/endpoints/test_project_details.py
+++ b/tests/sentry/core/endpoints/test_project_details.py
@@ -813,13 +813,6 @@ class ProjectUpdateTest(APITestCase):
         project = Project.objects.get(id=self.project.id)
         assert project.get_option("sentry:preprod_snapshot_pr_comments_enabled") is False
 
-    def test_preprod_snapshot_pr_comments_only_if_diff_option(self) -> None:
-        self.get_success_response(
-            self.org_slug, self.proj_slug, preprodSnapshotPrCommentsOnlyIfDiff=True
-        )
-        project = Project.objects.get(id=self.project.id)
-        assert project.get_option("sentry:preprod_snapshot_pr_comments_only_if_diff") is True
-
     def test_preprod_snapshot_pr_comments_post_on_added_option(self) -> None:
         self.get_success_response(
             self.org_slug, self.proj_slug, preprodSnapshotPrCommentsPostOnAdded=True

--- a/tests/sentry/core/endpoints/test_project_details.py
+++ b/tests/sentry/core/endpoints/test_project_details.py
@@ -820,6 +820,20 @@ class ProjectUpdateTest(APITestCase):
         project = Project.objects.get(id=self.project.id)
         assert project.get_option("sentry:preprod_snapshot_pr_comments_only_if_diff") is True
 
+    def test_preprod_snapshot_pr_comments_post_on_added_option(self) -> None:
+        self.get_success_response(
+            self.org_slug, self.proj_slug, preprodSnapshotPrCommentsPostOnAdded=True
+        )
+        project = Project.objects.get(id=self.project.id)
+        assert project.get_option("sentry:preprod_snapshot_pr_comments_post_on_added") is True
+
+    def test_preprod_snapshot_pr_comments_post_on_removed_option(self) -> None:
+        self.get_success_response(
+            self.org_slug, self.proj_slug, preprodSnapshotPrCommentsPostOnRemoved=False
+        )
+        project = Project.objects.get(id=self.project.id)
+        assert project.get_option("sentry:preprod_snapshot_pr_comments_post_on_removed") is False
+
     def test_bookmarks(self) -> None:
         self.get_success_response(self.org_slug, self.proj_slug, isBookmarked="false")
         assert not ProjectBookmark.objects.filter(

--- a/tests/sentry/preprod/vcs/pr_comments/test_snapshot_tasks.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_snapshot_tasks.py
@@ -86,15 +86,17 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
             integration_id=123,
         )
 
+    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.build_changes_map")
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.get_commit_context_client")
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.format_snapshot_pr_comment")
-    def test_creates_comment(self, mock_format, mock_get_client):
+    def test_creates_comment(self, mock_format, mock_get_client, mock_build_changes_map):
         mock_client = Mock()
         mock_client.create_comment.return_value = {"id": 99999}
         mock_get_client.return_value = mock_client
         mock_format.return_value = "## Sentry Snapshot Testing\n..."
 
         artifact, metrics = self._create_artifact_with_metrics()
+        mock_build_changes_map.return_value = {artifact.id: True}
 
         with self.feature(self._feature):
             create_preprod_snapshot_pr_comment_task(artifact.id)
@@ -111,9 +113,10 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
         assert snapshots["success"] is True
         assert snapshots["comment_id"] == "99999"
 
+    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.build_changes_map")
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.get_commit_context_client")
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.format_snapshot_pr_comment")
-    def test_updates_existing_comment(self, mock_format, mock_get_client):
+    def test_updates_existing_comment(self, mock_format, mock_get_client, mock_build_changes_map):
         mock_client = Mock()
         mock_get_client.return_value = mock_client
         mock_format.return_value = "updated body"
@@ -134,6 +137,7 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
         artifact, metrics = self._create_artifact_with_metrics(
             commit_comparison=commit_comparison,
         )
+        mock_build_changes_map.return_value = {artifact.id: True}
 
         with self.feature(self._feature):
             create_preprod_snapshot_pr_comment_task(artifact.id)
@@ -217,10 +221,9 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
 
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.format_snapshot_pr_comment")
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.get_commit_context_client")
-    def test_skips_when_only_if_diff_enabled_and_no_changes(self, mock_get_client, mock_format):
+    def test_skips_when_no_changes(self, mock_get_client, mock_format):
         mock_client = Mock()
         mock_get_client.return_value = mock_client
-        self.project.update_option("sentry:preprod_snapshot_pr_comments_only_if_diff", True)
 
         artifact, metrics = self._create_artifact_with_metrics()
 
@@ -233,14 +236,11 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
 
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.format_snapshot_pr_comment")
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.get_commit_context_client")
-    def test_posts_when_only_if_diff_enabled_and_comparison_failed(
-        self, mock_get_client, mock_format
-    ):
+    def test_posts_when_comparison_failed(self, mock_get_client, mock_format):
         mock_client = Mock()
         mock_client.create_comment.return_value = {"id": 67890}
         mock_get_client.return_value = mock_client
         mock_format.return_value = "body"
-        self.project.update_option("sentry:preprod_snapshot_pr_comments_only_if_diff", True)
 
         artifact, metrics = self._create_artifact_with_metrics()
         base_artifact, base_metrics = self._create_artifact_with_metrics(
@@ -251,26 +251,6 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
             base_snapshot_metrics=base_metrics,
             state=PreprodSnapshotComparison.State.FAILED,
         )
-
-        with self.feature(self._feature):
-            create_preprod_snapshot_pr_comment_task(artifact.id)
-
-        mock_client.create_comment.assert_called_once()
-
-    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.build_changes_map")
-    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.format_snapshot_pr_comment")
-    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.get_commit_context_client")
-    def test_posts_when_only_if_diff_enabled_and_has_changes(
-        self, mock_get_client, mock_format, mock_build_changes_map
-    ):
-        mock_client = Mock()
-        mock_client.create_comment.return_value = {"id": 12345}
-        mock_get_client.return_value = mock_client
-        mock_format.return_value = "body"
-        self.project.update_option("sentry:preprod_snapshot_pr_comments_only_if_diff", True)
-
-        artifact, metrics = self._create_artifact_with_metrics()
-        mock_build_changes_map.return_value = {artifact.id: True}
 
         with self.feature(self._feature):
             create_preprod_snapshot_pr_comment_task(artifact.id)
@@ -291,15 +271,17 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
 
         mock_get_client.assert_not_called()
 
+    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.build_changes_map")
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.get_commit_context_client")
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.format_snapshot_pr_comment")
-    def test_handles_api_error(self, mock_format, mock_get_client):
+    def test_handles_api_error(self, mock_format, mock_get_client, mock_build_changes_map):
         mock_client = Mock()
         mock_client.create_comment.side_effect = ApiError("rate limited", code=429)
         mock_get_client.return_value = mock_client
         mock_format.return_value = "body"
 
         artifact, metrics = self._create_artifact_with_metrics()
+        mock_build_changes_map.return_value = {artifact.id: True}
 
         with self.feature(self._feature):
             with pytest.raises(ApiError):
@@ -311,9 +293,12 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
         assert snapshots["success"] is False
         assert snapshots["error_type"] == "api_error"
 
+    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.build_changes_map")
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.get_commit_context_client")
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.format_snapshot_pr_comment")
-    def test_retry_after_update_failure_uses_update(self, mock_format, mock_get_client):
+    def test_retry_after_update_failure_uses_update(
+        self, mock_format, mock_get_client, mock_build_changes_map
+    ):
         mock_client = Mock()
         mock_get_client.return_value = mock_client
         mock_format.return_value = "body"
@@ -334,6 +319,7 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
         artifact, metrics = self._create_artifact_with_metrics(
             commit_comparison=commit_comparison,
         )
+        mock_build_changes_map.return_value = {artifact.id: True}
 
         # First call: update fails
         mock_client.update_comment.side_effect = ApiError("server error", code=500)
@@ -362,14 +348,18 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
         )
         mock_client.create_comment.assert_not_called()
 
+    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.build_changes_map")
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.get_commit_context_client")
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.format_snapshot_pr_comment")
-    def test_retry_after_create_failure_creates_again(self, mock_format, mock_get_client):
+    def test_retry_after_create_failure_creates_again(
+        self, mock_format, mock_get_client, mock_build_changes_map
+    ):
         mock_client = Mock()
         mock_get_client.return_value = mock_client
         mock_format.return_value = "body"
 
         artifact, metrics = self._create_artifact_with_metrics()
+        mock_build_changes_map.return_value = {artifact.id: True}
 
         # First call: create fails
         mock_client.create_comment.side_effect = ApiError("server error", code=500)
@@ -404,9 +394,12 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
         assert snapshots["success"] is True
         assert snapshots["comment_id"] == "77777"
 
+    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.build_changes_map")
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.get_commit_context_client")
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.format_snapshot_pr_comment")
-    def test_reads_fresh_extras_via_select_for_update(self, mock_format, mock_get_client):
+    def test_reads_fresh_extras_via_select_for_update(
+        self, mock_format, mock_get_client, mock_build_changes_map
+    ):
         mock_client = Mock()
         mock_get_client.return_value = mock_client
         mock_format.return_value = "updated body"
@@ -426,6 +419,7 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
         artifact, metrics = self._create_artifact_with_metrics(
             commit_comparison=commit_comparison,
         )
+        mock_build_changes_map.return_value = {artifact.id: True}
 
         # Simulate a concurrent task writing a comment_id after artifact load
         CommitComparison.objects.filter(id=commit_comparison.id).update(
@@ -443,9 +437,12 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
         )
         mock_client.create_comment.assert_not_called()
 
+    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.build_changes_map")
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.get_commit_context_client")
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.format_snapshot_pr_comment")
-    def test_updates_comment_from_previous_commit(self, mock_format, mock_get_client):
+    def test_updates_comment_from_previous_commit(
+        self, mock_format, mock_get_client, mock_build_changes_map
+    ):
         mock_client = Mock()
         mock_get_client.return_value = mock_client
         mock_format.return_value = "updated body"
@@ -480,6 +477,7 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
         )
 
         artifact, metrics = self._create_artifact_with_metrics(commit_comparison=cc_b)
+        mock_build_changes_map.return_value = {artifact.id: True}
 
         with self.feature(self._feature):
             create_preprod_snapshot_pr_comment_task(artifact.id)
@@ -501,9 +499,12 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
         cc_a.refresh_from_db()
         assert cc_a.extras["pr_comments"]["snapshots"]["comment_id"] == "prev_commit_123"
 
+    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.build_changes_map")
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.get_commit_context_client")
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.format_snapshot_pr_comment")
-    def test_creates_when_no_sibling_has_comment_id(self, mock_format, mock_get_client):
+    def test_creates_when_no_sibling_has_comment_id(
+        self, mock_format, mock_get_client, mock_build_changes_map
+    ):
         mock_client = Mock()
         mock_client.create_comment.return_value = {"id": 55555}
         mock_get_client.return_value = mock_client
@@ -534,6 +535,7 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
         )
 
         artifact, metrics = self._create_artifact_with_metrics(commit_comparison=cc_b)
+        mock_build_changes_map.return_value = {artifact.id: True}
 
         with self.feature(self._feature):
             create_preprod_snapshot_pr_comment_task(artifact.id)

--- a/tests/sentry/preprod/vcs/pr_comments/test_snapshot_tasks.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_snapshot_tasks.py
@@ -502,6 +502,35 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.build_changes_map")
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.get_commit_context_client")
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.format_snapshot_pr_comment")
+    def test_passes_post_on_options_to_build_changes_map(
+        self, mock_format, mock_get_client, mock_build_changes_map
+    ):
+        mock_client = Mock()
+        mock_client.create_comment.return_value = {"id": 11111}
+        mock_get_client.return_value = mock_client
+        mock_format.return_value = "body"
+
+        self.project.update_option("sentry:preprod_snapshot_pr_comments_post_on_added", True)
+        self.project.update_option("sentry:preprod_snapshot_pr_comments_post_on_removed", False)
+        self.project.update_option("sentry:preprod_snapshot_pr_comments_post_on_changed", False)
+        self.project.update_option("sentry:preprod_snapshot_pr_comments_post_on_renamed", True)
+
+        artifact, metrics = self._create_artifact_with_metrics()
+        mock_build_changes_map.return_value = {artifact.id: True}
+
+        with self.feature(self._feature):
+            create_preprod_snapshot_pr_comment_task(artifact.id)
+
+        mock_build_changes_map.assert_called_once()
+        kwargs = mock_build_changes_map.call_args
+        assert kwargs[1]["fail_on_added"] is True
+        assert kwargs[1]["fail_on_removed"] is False
+        assert kwargs[1]["fail_on_changed"] is False
+        assert kwargs[1]["fail_on_renamed"] is True
+
+    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.build_changes_map")
+    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.get_commit_context_client")
+    @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.format_snapshot_pr_comment")
     def test_creates_when_no_sibling_has_comment_id(
         self, mock_format, mock_get_client, mock_build_changes_map
     ):


### PR DESCRIPTION
Gives snapshot PR comments the same granular controls as snapshot status checks. Previously PR comments shared the status-check options for deciding what counts as a diff; now they have their own independent set.

Here's a link to where these settings will eventually go: 
https://sentry.sentry.io/settings/projects/hackernews-android/snapshots/
This is just the backend for now though

**Drop only-if-diff toggle**

The `sentry:preprod_snapshot_pr_comments_only_if_diff` option is removed. Enabling PR comments now always implies "post only when there are changes" — commenting on every build regardless of diffs is no longer possible.

**Dedicated post-on options**

Four independent project options control which snapshot change types trigger a PR comment:

| Option | Default |
|--------|---------|
| `post_on_added` | `False` |
| `post_on_removed` | `True` |
| `post_on_changed` | `True` |
| `post_on_renamed` | `False` |

Defaults match the status-check equivalents so no project sees a behavior change from this decoupling. The task no longer imports from the status-check module.

The frontend changes (surfacing these toggles in the settings UI) are in #114130.