### PR TITLE
feat(search-query-build): Force cmd + del to reset query builder

### DIFF
--- a/static/app/components/searchQueryBuilder/context.tsx
+++ b/static/app/components/searchQueryBuilder/context.tsx
@@ -41,7 +41,9 @@ interface SearchQueryBuilderContextData {
   askSeerNLQueryRef: React.RefObject<string | null>;
   askSeerSuggestedQueryRef: React.RefObject<string | null>;
   autoSubmitSeer: boolean;
+  clearSearchQuery: (options?: {reopenDropdown?: boolean}) => void;
   committedQuery: string;
+  consumeReopenDropdownOnQueryClear: () => void;
   currentInputValueRef: React.RefObject<string>;
   disabled: boolean;
   disallowFreeText: boolean;
@@ -65,6 +67,7 @@ interface SearchQueryBuilderContextData {
   parseQuery: (query: string) => ParseResult | null;
   parsedQuery: ParseResult | null;
   query: string;
+  reopenDropdownOnQueryClear: boolean;
   searchSource: string;
   setAutoSubmitSeer: (enabled: boolean) => void;
   setDisplayAskSeer: (enabled: boolean) => void;
@@ -136,6 +139,7 @@ export function SearchQueryBuilderProvider({
 
   const [autoSubmitSeer, setAutoSubmitSeer] = useState(false);
   const [displayAskSeerFeedback, setDisplayAskSeerFeedback] = useState(false);
+  const [reopenDropdownOnQueryClear, setReopenDropdownOnQueryClear] = useState(false);
   const currentInputValueRef = useRef<string>('');
   const askSeerNLQueryRef = useRef<string | null>(null);
   const askSeerSuggestedQueryRef = useRef<string | null>(null);
@@ -241,6 +245,24 @@ export function SearchQueryBuilderProvider({
     searchSource,
     onSearch,
   });
+
+  const clearSearchQuery = useCallback(
+    ({reopenDropdown = false}: {reopenDropdown?: boolean} = {}) => {
+      currentInputValueRef.current = '';
+      askSeerNLQueryRef.current = null;
+      askSeerSuggestedQueryRef.current = null;
+      setDisplayAskSeerFeedback(false);
+      setReopenDropdownOnQueryClear(reopenDropdown);
+      dispatch({type: 'CLEAR'});
+      handleSearch('');
+    },
+    [dispatch, handleSearch]
+  );
+
+  const consumeReopenDropdownOnQueryClear = useCallback(() => {
+    setReopenDropdownOnQueryClear(false);
+  }, []);
+
   const {width: searchBarWidth} = useDimensions({elementRef: wrapperRef});
   const size =
     searchBarWidth && searchBarWidth < 600 ? ('small' as const) : ('normal' as const);
@@ -265,6 +287,8 @@ export function SearchQueryBuilderProvider({
       getTagKeys,
       getFieldDefinition: stableFieldDefinitionGetter,
       dispatch,
+      clearSearchQuery,
+      consumeReopenDropdownOnQueryClear,
       wrapperRef,
       actionBarRef,
       handleSearch,
@@ -283,6 +307,7 @@ export function SearchQueryBuilderProvider({
       filterKeyAliases,
       gaveSeerConsent: true,
       currentInputValueRef,
+      reopenDropdownOnQueryClear,
       displayAskSeerFeedback,
       setDisplayAskSeerFeedback,
       askSeerNLQueryRef,
@@ -294,6 +319,8 @@ export function SearchQueryBuilderProvider({
     aiSearchBadgeType,
     autoSubmitSeer,
     caseInsensitive,
+    clearSearchQuery,
+    consumeReopenDropdownOnQueryClear,
     disabled,
     disallowFreeText,
     disallowLogicalOperators,
@@ -316,6 +343,7 @@ export function SearchQueryBuilderProvider({
     placeholder,
     portalTarget,
     recentSearches,
+    reopenDropdownOnQueryClear,
     namespace,
     replaceRawSearchKeys,
     searchSource,

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -327,8 +327,8 @@ describe('SearchQueryBuilder', () => {
     });
 
     it.each([
-      ['Backspace', '{Meta>}{Backspace}{/Meta}'],
-      ['Delete', '{Meta>}{Delete}{/Meta}'],
+      ['Backspace', '{Control>}{Backspace}{/Control}'],
+      ['Delete', '{Control>}{Delete}{/Control}'],
     ])(
       'clears the query and reopens suggestions with Cmd+%s from an open token dropdown',
       async (_key, keyboardInput) => {
@@ -352,7 +352,7 @@ describe('SearchQueryBuilder', () => {
 
         await waitFor(() => {
           expect(
-            screen.queryByRole('button', {name: 'Edit value for filter: browser.name'})
+            screen.queryByRole('row', {name: 'browser.name:Firefox'})
           ).not.toBeInTheDocument();
         });
 

--- a/static/app/components/searchQueryBuilder/index.spec.tsx
+++ b/static/app/components/searchQueryBuilder/index.spec.tsx
@@ -326,6 +326,47 @@ describe('SearchQueryBuilder', () => {
       expect(screen.getByRole('combobox')).toHaveFocus();
     });
 
+    it.each([
+      ['Backspace', '{Meta>}{Backspace}{/Meta}'],
+      ['Delete', '{Meta>}{Delete}{/Meta}'],
+    ])(
+      'clears the query and reopens suggestions with Cmd+%s from an open token dropdown',
+      async (_key, keyboardInput) => {
+        const mockOnChange = jest.fn();
+        const mockOnSearch = jest.fn();
+        render(
+          <SearchQueryBuilder
+            {...defaultProps}
+            initialQuery="browser.name:Firefox"
+            onChange={mockOnChange}
+            onSearch={mockOnSearch}
+          />
+        );
+
+        await userEvent.click(
+          screen.getByRole('button', {name: 'Edit value for filter: browser.name'})
+        );
+        expect(await screen.findByRole('option', {name: 'Firefox'})).toBeInTheDocument();
+
+        await userEvent.keyboard(keyboardInput);
+
+        await waitFor(() => {
+          expect(
+            screen.queryByRole('button', {name: 'Edit value for filter: browser.name'})
+          ).not.toBeInTheDocument();
+        });
+
+        const input = screen.getByRole('combobox', {name: 'Add a search term'});
+        expect(input).toHaveFocus();
+        expect(await screen.findByRole('option', {name: 'age'})).toBeInTheDocument();
+
+        await waitFor(() => {
+          expect(mockOnChange).toHaveBeenCalledWith('', expect.anything());
+        });
+        expect(mockOnSearch).toHaveBeenCalledWith('', expect.anything());
+      }
+    );
+
     it('is hidden at small sizes', async () => {
       Object.defineProperty(Element.prototype, 'clientWidth', {value: 100});
       const mockOnChange = jest.fn();

--- a/static/app/components/searchQueryBuilder/index.tsx
+++ b/static/app/components/searchQueryBuilder/index.tsx
@@ -217,15 +217,8 @@ function ActionButtons({
   ref?: React.Ref<HTMLDivElement>;
   trailingItems?: React.ReactNode;
 }) {
-  const {
-    dispatch,
-    handleSearch,
-    disabled,
-    query,
-    setDisplayAskSeerFeedback,
-    caseInsensitive,
-    onCaseInsensitiveClick,
-  } = useSearchQueryBuilder();
+  const {clearSearchQuery, disabled, query, caseInsensitive, onCaseInsensitiveClick} =
+    useSearchQueryBuilder();
 
   if (disabled) {
     return null;
@@ -258,11 +251,7 @@ function ActionButtons({
           size="zero"
           icon={<IconClose />}
           priority="transparent"
-          onClick={() => {
-            setDisplayAskSeerFeedback(false);
-            dispatch({type: 'CLEAR'});
-            handleSearch('');
-          }}
+          onClick={() => clearSearchQuery()}
         />
       )}
     </ButtonsWrapper>

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -379,7 +379,8 @@ export function SearchQueryBuilderCombobox<
   ['data-test-id']: dataTestId,
   ref,
 }: SearchQueryBuilderComboboxProps<T>) {
-  const {disabled, portalTarget, enableAISearch, wrapperRef} = useSearchQueryBuilder();
+  const {clearSearchQuery, disabled, portalTarget, enableAISearch, wrapperRef} =
+    useSearchQueryBuilder();
   const listBoxRef = useRef<HTMLUListElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
@@ -617,7 +618,17 @@ export function SearchQueryBuilderCombobox<
         tabIndex={tabIndex}
         onPaste={onPaste}
         disabled={disabled}
-        onKeyDownCapture={e => onKeyDownCapture?.(e, {state})}
+        onKeyDownCapture={e => {
+          if (e.metaKey && (e.key === 'Backspace' || e.key === 'Delete')) {
+            e.preventDefault();
+            e.stopPropagation();
+            state.close();
+            clearSearchQuery({reopenDropdown: true});
+            return;
+          }
+
+          onKeyDownCapture?.(e, {state});
+        }}
         data-test-id={dataTestId}
       />
       {description ? (

--- a/static/app/components/searchQueryBuilder/tokens/combobox.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/combobox.tsx
@@ -619,7 +619,7 @@ export function SearchQueryBuilderCombobox<
         onPaste={onPaste}
         disabled={disabled}
         onKeyDownCapture={e => {
-          if (e.metaKey && (e.key === 'Backspace' || e.key === 'Delete')) {
+          if (isCtrlKeyPressed(e) && (e.key === 'Backspace' || e.key === 'Delete')) {
             e.preventDefault();
             e.stopPropagation();
             state.close();

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -293,6 +293,13 @@ function SearchQueryBuilderInputInternal({
   const shouldReopenDropdownOnFocus =
     reopenDropdownOnQueryClear && query === '' && trimmedTokenValue === '';
 
+  useEffect(() => {
+    if (shouldReopenDropdownOnFocus && inputRef.current === document.activeElement) {
+      consumeReopenDropdownOnQueryClear();
+      setIsOpen(true);
+    }
+  }, [shouldReopenDropdownOnFocus, consumeReopenDropdownOnQueryClear]);
+
   // When token value changes, reset the input value
   const [prevValue, setPrevValue] = useState(inputValue);
   if (trimmedTokenValue !== prevValue) {

--- a/static/app/components/searchQueryBuilder/tokens/freeText.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/freeText.tsx
@@ -269,6 +269,8 @@ function SearchQueryBuilderInputInternal({
     searchSource,
     recentSearches,
     currentInputValueRef,
+    consumeReopenDropdownOnQueryClear,
+    reopenDropdownOnQueryClear,
   } = useSearchQueryBuilder();
 
   const resetInputValue = useCallback(() => {
@@ -288,6 +290,8 @@ function SearchQueryBuilderInputInternal({
     });
 
   const items = customMenu ? sectionItems : sortedFilteredItems;
+  const shouldReopenDropdownOnFocus =
+    reopenDropdownOnQueryClear && query === '' && trimmedTokenValue === '';
 
   // When token value changes, reset the input value
   const [prevValue, setPrevValue] = useState(inputValue);
@@ -660,6 +664,12 @@ function SearchQueryBuilderInputInternal({
         onKeyDown={onKeyDown}
         onKeyDownCapture={onKeyDownCapture}
         onOpenChange={setIsOpen}
+        openOnFocus={shouldReopenDropdownOnFocus}
+        onFocus={() => {
+          if (shouldReopenDropdownOnFocus) {
+            consumeReopenDropdownOnQueryClear();
+          }
+        }}
         tabIndex={item.key === state.selectionManager.focusedKey ? 0 : -1}
         maxOptions={maxOptions}
         onPaste={onPaste}


### PR DESCRIPTION
Currently with the search query builder you're required to hit <kbd>Cmd</kbd> + <kbd>Del</kbd> twice if the dropdown is open, this is a little annoying so we're moving to override that behaviour and just close the dropdown **and** clear all tokens. 

Closes EXP-900