### PR TITLE
fix(conversations): Keep detail panels independently scrollable

### DIFF
--- a/static/app/views/explore/conversations/components/conversationView.tsx
+++ b/static/app/views/explore/conversations/components/conversationView.tsx
@@ -1,8 +1,7 @@
 import {memo, useState} from 'react';
-import styled from '@emotion/styled';
 
 import {Container, Flex} from '@sentry/scraps/layout';
-import {TabList, TabPanels, Tabs} from '@sentry/scraps/tabs';
+import {TabList, Tabs} from '@sentry/scraps/tabs';
 
 import {EmptyMessage} from 'sentry/components/emptyMessage';
 import {t} from 'sentry/locale';
@@ -113,38 +112,41 @@ function ConversationView({
     <ConversationSplitLayout
       left={
         <ConversationLeftPanel>
-          <StyledTabs
-            value={activeTab}
-            onChange={key => handleTabChange(key as ConversationTab)}
-          >
-            <Container borderBottom="primary">
-              <TabList>
-                <TabList.Item key="messages">{t('Chat')}</TabList.Item>
-                <TabList.Item key="trace">{t('Spans')}</TabList.Item>
-              </TabList>
+          <Flex direction="column" flex="1" minHeight="0" width="100%" overflow="hidden">
+            <Container flexShrink={0} borderBottom="primary" background="primary">
+              <Tabs value={activeTab} onChange={handleTabChange}>
+                <TabList>
+                  <TabList.Item key="messages">{t('Chat')}</TabList.Item>
+                  <TabList.Item key="trace">{t('Spans')}</TabList.Item>
+                </TabList>
+              </Tabs>
             </Container>
-            <Flex flex="1" minHeight="0" width="100%" overflowX="hidden" overflowY="auto">
-              <FullWidthTabPanels>
-                <TabPanels.Item key="messages">
-                  <MessagesPanel
+            <Flex
+              flex="1"
+              minHeight="0"
+              width="100%"
+              overflowX="hidden"
+              overflowY="auto"
+              background="secondary"
+            >
+              {activeTab === 'messages' ? (
+                <MessagesPanel
+                  nodes={nodes}
+                  selectedNodeId={selectedNode?.id ?? null}
+                  onSelectNode={onSelectNode}
+                />
+              ) : (
+                <Container padding="md lg md lg" width="100%">
+                  <AISpanList
                     nodes={nodes}
-                    selectedNodeId={selectedNode?.id ?? null}
+                    selectedNodeKey={selectedNode?.id ?? nodes[0]?.id ?? ''}
                     onSelectNode={onSelectNode}
+                    compressGaps
                   />
-                </TabPanels.Item>
-                <TabPanels.Item key="trace">
-                  <Container padding="md lg md lg">
-                    <AISpanList
-                      nodes={nodes}
-                      selectedNodeKey={selectedNode?.id ?? nodes[0]?.id ?? ''}
-                      onSelectNode={onSelectNode}
-                      compressGaps
-                    />
-                  </Container>
-                </TabPanels.Item>
-              </FullWidthTabPanels>
+                </Container>
+              )}
             </Flex>
-          </StyledTabs>
+          </Flex>
         </ConversationLeftPanel>
       }
       right={
@@ -156,19 +158,3 @@ function ConversationView({
     />
   );
 }
-
-const StyledTabs = styled(Tabs)`
-  min-height: 0;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-`;
-
-const FullWidthTabPanels = styled(TabPanels)`
-  width: 100%;
-  padding: 0;
-
-  > [role='tabpanel'] {
-    width: 100%;
-  }
-`;

--- a/static/app/views/explore/conversations/components/messagesPanel.tsx
+++ b/static/app/views/explore/conversations/components/messagesPanel.tsx
@@ -63,7 +63,7 @@ export function MessagesPanel({nodes, selectedNodeId, onSelectNode}: MessagesPan
     return (
       <Flex
         direction="column"
-        padding="lg lg md md"
+        padding="lg md md md"
         background="secondary"
         minHeight="100%"
         width="100%"
@@ -76,7 +76,7 @@ export function MessagesPanel({nodes, selectedNodeId, onSelectNode}: MessagesPan
   return (
     <Flex
       direction="column"
-      padding="lg lg md md"
+      padding="lg md md md"
       background="secondary"
       minHeight="100%"
       width="100%"

--- a/static/app/views/explore/conversations/conversationDetail.tsx
+++ b/static/app/views/explore/conversations/conversationDetail.tsx
@@ -4,7 +4,7 @@ import {parseAsInteger, parseAsString, useQueryStates} from 'nuqs';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 
 import {useParams} from 'sentry/utils/useParams';
-import {ExploreBodyContent} from 'sentry/views/explore/components/styles';
+import {ViewportConstrainedPage} from 'sentry/views/explore/components/viewportConstrainedPage';
 import {ConversationSummary} from 'sentry/views/explore/conversations/components/conversationSummary';
 import {ConversationViewContent} from 'sentry/views/explore/conversations/components/conversationView';
 import {useConversation} from 'sentry/views/explore/conversations/hooks/useConversation';
@@ -44,9 +44,9 @@ function ConversationDetailPage() {
   );
 
   return (
-    <ExploreBodyContent>
-      <Stack flex={1} padding="md 2xl" gap="md">
-        <Flex direction="column" gap="md" padding="0 0 xl 0">
+    <ViewportConstrainedPage background="secondary">
+      <Stack flex={1} minHeight="0" overflow="hidden" padding="md 2xl" gap="md">
+        <Flex direction="column" gap="md" flexShrink={0}>
           <ConversationSummary
             nodes={nodes}
             nodeTraceMap={nodeTraceMap}
@@ -63,7 +63,7 @@ function ConversationDetailPage() {
           />
         </ConversationViewContainer>
       </Stack>
-    </ExploreBodyContent>
+    </ViewportConstrainedPage>
   );
 }
 
@@ -75,6 +75,7 @@ function ConversationViewContainer({children}: {children: React.ReactNode}) {
       overflow="hidden"
       border="primary"
       radius="md"
+      background="primary"
       display="flex"
     >
       <Flex flex={1} minHeight="0" height="100%">


### PR DESCRIPTION
Constrain the conversation detail page to the viewport so long chat/span lists no longer push the span detail panel out of view. The split view now follows the trace waterfall pattern: the outer page owns the fixed height, while each pane handles overflow internally.

The tab content layout now uses scraps primitives directly instead of Emotion-styled tab panel wrappers, keeping the tab header fixed above the left pane's scrollable content.

Fixes TET-2264