### PR TITLE
fix(spans): Normalize device class attributes

### DIFF
--- a/src/sentry/spans/consumers/process_segments/convert.py
+++ b/src/sentry/spans/consumers/process_segments/convert.py
@@ -38,6 +38,10 @@ RENAME_ATTRIBUTES = {
     ATTRIBUTE_NAMES.SENTRY_SEGMENT_ID: "sentry.segment_id",
 }
 
+SENTRY_CONTEXT_ATTRIBUTE_ALIASES = {
+    ATTRIBUTE_NAMES.DEVICE_CLASS: "sentry.device.class",
+}
+
 
 def convert_span_to_item(span: CompatibleSpan) -> TraceItem:
     attributes: dict[str, AnyValue] = {}
@@ -82,6 +86,10 @@ def convert_span_to_item(span: CompatibleSpan) -> TraceItem:
         if convention_name in attributes:
             attributes[eap_name] = attributes.pop(convention_name)
 
+    for public_name, internal_name in SENTRY_CONTEXT_ATTRIBUTE_ALIASES.items():
+        if public_name in attributes:
+            attributes.setdefault(internal_name, attributes.pop(public_name))
+
     try:
         attributes["sentry.duration_ms"] = AnyValue(
             double_value=round(1000.0 * (span["end_timestamp"] - span["start_timestamp"]), 6)
@@ -94,6 +102,8 @@ def convert_span_to_item(span: CompatibleSpan) -> TraceItem:
             try:
                 if attr in RENAME_ATTRIBUTES:
                     attr = RENAME_ATTRIBUTES[attr]
+                if attr in SENTRY_CONTEXT_ATTRIBUTE_ALIASES:
+                    attr = SENTRY_CONTEXT_ATTRIBUTE_ALIASES[attr]
                 # Meta is expected to be a stringified json object.
                 value = orjson.dumps({"meta": meta}).decode()
                 attributes[f"sentry._meta.fields.attributes.{attr}"] = _anyvalue(value)

--- a/tests/sentry/spans/consumers/process_segments/test_convert.py
+++ b/tests/sentry/spans/consumers/process_segments/test_convert.py
@@ -207,6 +207,16 @@ def test_convert_span_to_item() -> None:
     }
 
 
+def test_convert_span_to_item_normalizes_device_class() -> None:
+    message = copy.deepcopy(SPAN_KAFKA_MESSAGE)
+    message["attributes"]["device.class"] = {"value": "3", "type": "string"}
+
+    item = convert_span_to_item(cast(CompatibleSpan, message))
+
+    assert item.attributes["sentry.device.class"] == AnyValue(string_value="3")
+    assert "device.class" not in item.attributes
+
+
 def test_convert_falsy_fields() -> None:
     message: SpanEvent = copy.deepcopy(SPAN_KAFKA_MESSAGE)
     message["is_segment"] = False


### PR DESCRIPTION
Normalize conventional span `device.class` attributes into the internal Sentry context field used by EAP.

Span v2 emits `device.class` as the public sentry-conventions attribute, while EAP's public `device.class` query field is currently backed by `sentry.device.class` so it can apply the existing device class value mapping. Without this normalization, v2 spans with a raw `device.class` value group as `Unknown` in dashboards and Explore.

This keeps the public query contract unchanged: product code continues to query `device.class`, while conversion stores the value in the canonical backing field expected by EAP. The conversion test covers the raw v2 attribute being promoted to `sentry.device.class`.

Made with [Cursor](https://cursor.com)