### PR TITLE
fix(integrations): Route Perforce install through API pipeline modal

### DIFF
--- a/static/app/utils/integrations/useAddIntegration.tsx
+++ b/static/app/utils/integrations/useAddIntegration.tsx
@@ -53,6 +53,7 @@ const UNCONDITIONAL_API_PIPELINE_PROVIDERS = [
   'gitlab',
   'opsgenie',
   'pagerduty',
+  'perforce',
   'slack',
   'slack_staging',
   'vsts',


### PR DESCRIPTION
The Perforce install flow was migrated to the API-driven pipeline in PRs #113468 (backend), #113471 (frontend pipeline definition), and #113701 (legacy Django views removed), but Perforce was never added to UNCONDITIONAL_API_PIPELINE_PROVIDERS. As a result, clicking 'Add Installation' fell through to the legacy popup at
/organizations/<org>/integrations/perforce/setup/ — and since PerforceIntegrationProvider.get_pipeline_views() now returns [], the pipeline immediately calls finish_pipeline -> build_integration({}), which raises 'Organization ID is required for Perforce integration'.

Add 'perforce' to the unconditional list so the install button opens the API-driven modal (PerforceInstallationConfigStep), which validates credentials and binds organization_id before completing the pipeline.
