### PR TITLE
feat(llm-issue-detection): Forward plan_tier to seer budget check

### DIFF
--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -160,6 +160,8 @@ def make_signed_seer_api_request(
     if retries is not None:
         options["retries"] = retries
 
+    request_target = f"{parsed.path}?{parsed.query}" if parsed.query else parsed.path
+
     with metrics.timer(
         "seer.request_to_seer",
         sample_rate=1.0,
@@ -167,7 +169,7 @@ def make_signed_seer_api_request(
     ):
         return connection_pool.urlopen(
             method,
-            parsed.path,
+            request_target,
             body=body,
             headers=headers,
             **options,

--- a/src/sentry/tasks/llm_issue_detection/detection.py
+++ b/src/sentry/tasks/llm_issue_detection/detection.py
@@ -107,6 +107,7 @@ class IssueDetectionRequest(BaseModel):
     organization_id: int
     project_id: int
     org_slug: str
+    plan_tier: str = "business"
 
 
 def make_issue_detection_request(
@@ -281,7 +282,7 @@ def _is_org_eligible(org_id: int) -> bool:
     namespace=issues_tasks,
     processing_deadline_duration=180,  # 3 minutes
 )
-def detect_llm_issues_for_org(org_id: int) -> None:
+def detect_llm_issues_for_org(org_id: int, plan_tier: str = "business") -> None:
     """
     Process a single organization for LLM issue detection.
 
@@ -321,7 +322,7 @@ def detect_llm_issues_for_org(org_id: int) -> None:
 
     budget_response = make_signed_seer_api_request(
         seer_issue_detection_connection_pool,
-        f"{SEER_CHECK_BUDGET_ENDPOINT_PATH}/{org_id}",
+        f"{SEER_CHECK_BUDGET_ENDPOINT_PATH}/{org_id}?plan_tier={plan_tier}",
         body=b"",
         method="GET",
         timeout=SEER_TIMEOUT_S,
@@ -371,6 +372,7 @@ def detect_llm_issues_for_org(org_id: int) -> None:
         organization_id=org_id,
         project_id=project_id,
         org_slug=organization.slug,
+        plan_tier=plan_tier,
     )
 
     viewer_context = SeerViewerContext(organization_id=org_id)

--- a/tests/sentry/seer/test_signed_seer_api.py
+++ b/tests/sentry/seer/test_signed_seer_api.py
@@ -55,6 +55,12 @@ def test_simple() -> None:
 
 
 @pytest.mark.django_db
+def test_preserves_query_string() -> None:
+    mock_url_open = run_test_case(path=f"{PATH}?foo=bar&baz=qux", method="GET")
+    assert mock_url_open.call_args.args[1] == f"{PATH}?foo=bar&baz=qux"
+
+
+@pytest.mark.django_db
 def test_uses_given_timeout() -> None:
     mock_url_open = run_test_case(timeout=5)
     mock_url_open.assert_called_once_with(

--- a/tests/sentry/tasks/test_llm_issue_detection.py
+++ b/tests/sentry/tasks/test_llm_issue_detection.py
@@ -347,6 +347,40 @@ class LLMIssueDetectionTest(TestCase):
         mock_get_transactions.assert_not_called()
         mock_seer_request.assert_not_called()
 
+    @with_feature("organizations:gen-ai-features")
+    @patch("sentry.tasks.llm_issue_detection.detection.make_issue_detection_request")
+    @patch(
+        "sentry.tasks.llm_issue_detection.trace_data.get_project_top_transaction_traces_for_llm_detection"
+    )
+    @patch("sentry.tasks.llm_issue_detection.detection.make_signed_seer_api_request")
+    def test_plan_tier_forwarded_to_seer(
+        self, mock_budget_request, mock_get_transactions, mock_seer_request
+    ):
+        mock_budget_request.return_value = self._budget_ok_response()
+        mock_get_transactions.return_value = []
+
+        detect_llm_issues_for_org(self.organization.id, plan_tier="team")
+
+        budget_url = mock_budget_request.call_args[0][1]
+        assert "plan_tier=team" in budget_url
+
+    @with_feature("organizations:gen-ai-features")
+    @patch("sentry.tasks.llm_issue_detection.detection.make_issue_detection_request")
+    @patch(
+        "sentry.tasks.llm_issue_detection.trace_data.get_project_top_transaction_traces_for_llm_detection"
+    )
+    @patch("sentry.tasks.llm_issue_detection.detection.make_signed_seer_api_request")
+    def test_plan_tier_defaults_to_business(
+        self, mock_budget_request, mock_get_transactions, mock_seer_request
+    ):
+        mock_budget_request.return_value = self._budget_ok_response()
+        mock_get_transactions.return_value = []
+
+        detect_llm_issues_for_org(self.organization.id)
+
+        budget_url = mock_budget_request.call_args[0][1]
+        assert "plan_tier=business" in budget_url
+
 
 class TestTraceProcessingFunctions:
     @pytest.mark.parametrize(


### PR DESCRIPTION
Adds a `plan_tier` kwarg to `detect_llm_issues_for_org` and forwards it to
Seer in both the check-budget GET query string and the analyze request body,
so Seer can apply the matching weekly-budget tier

https://github.com/getsentry/seer/pull/6063
