### PR TITLE
chore(autofix): Rollout autofix runs view with new autofix

### DIFF
--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -327,7 +327,7 @@ export function GlobalCommandPaletteActions() {
               to={`${prefix}/issues/views/${starredView.id}/`}
             />
           ))}
-          {organization.features.includes('seer-issue-view') && (
+          {organization.features.includes('autofix-on-explorer') && (
             <CMDKAction display={{label: t('Autofix')}}>
               <CMDKAction
                 display={{label: t('Recently Run')}}

--- a/static/app/views/issueList/pages/autofix/recentlyRun.tsx
+++ b/static/app/views/issueList/pages/autofix/recentlyRun.tsx
@@ -13,7 +13,7 @@ export default function AutofixRecentlyRunPage() {
   const organization = useOrganization();
 
   return (
-    <Feature features="seer-issue-view" renderDisabled>
+    <Feature features="autofix-on-explorer" renderDisabled>
       <IssueListContainer title={label}>
         <PageFiltersContainer>
           <NoProjectMessage organization={organization}>

--- a/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.tsx
@@ -74,7 +74,7 @@ export function IssuesSecondaryNavigation() {
             )}
           </SecondaryNavigation.List>
         </SecondaryNavigation.Section>
-        {organization.features.includes('seer-issue-view') && (
+        {organization.features.includes('autofix-on-explorer') && (
           <Fragment>
             <SecondaryNavigation.Separator />
             <SecondaryNavigation.Section id="issues-autofix" title={t('Autofix')}>


### PR DESCRIPTION
This switches the feature flag for the autofix runs view so it is rolled out together with the new autofix.

<img width="380" height="990" alt="image" src="https://github.com/user-attachments/assets/df022586-120f-4523-8cf7-de5caede9cff" />
