### PR TITLE
feat(preprod): Pare down snapshot search bar filters (EME-1071)

### DIFF
--- a/static/app/components/preprod/constants.ts
+++ b/static/app/components/preprod/constants.ts
@@ -43,4 +43,5 @@ export const SNAPSHOT_ALLOWED_KEYS = [
   'images_renamed',
   'images_skipped',
   'images_unchanged',
+  'is_approved',
 ];

--- a/static/app/components/preprod/constants.ts
+++ b/static/app/components/preprod/constants.ts
@@ -28,3 +28,19 @@ export const MOBILE_BUILDS_ALLOWED_KEYS = [
   'is_approved',
   'platform_name',
 ];
+
+export const SNAPSHOT_ALLOWED_KEYS = [
+  'app_id',
+  'git_base_ref',
+  'git_base_sha',
+  'git_head_ref',
+  'git_head_sha',
+  'git_pr_number',
+  'image_count',
+  'images_added',
+  'images_changed',
+  'images_removed',
+  'images_renamed',
+  'images_skipped',
+  'images_unchanged',
+];

--- a/static/app/components/preprod/preprodSearchBar.tsx
+++ b/static/app/components/preprod/preprodSearchBar.tsx
@@ -145,6 +145,7 @@ export function PreprodSearchBar({
       disallowHas={disallowHas}
       disallowLogicalOperators={disallowLogicalOperators}
       hiddenAttributeKeys={hiddenKeys}
+      allowedAttributeKeys={allowedKeys}
     />
   );
 }

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -29,6 +29,7 @@ export type TraceItemSearchQueryBuilderProps = {
   numberSecondaryAliases: TagCollection;
   stringAttributes: TagCollection;
   stringSecondaryAliases: TagCollection;
+  allowedAttributeKeys?: string[];
   attributeQuery?: string;
   caseInsensitive?: CaseInsensitive;
   disableRecentSearches?: boolean;
@@ -109,6 +110,7 @@ export function useTraceItemSearchQueryBuilderProps({
   disableRecentSearches,
   attributeQuery,
   hiddenAttributeKeys,
+  allowedAttributeKeys,
 }: TraceItemSearchQueryBuilderProps) {
   const placeholderText = itemTypeToDefaultPlaceholder(itemType);
 
@@ -147,13 +149,17 @@ export function useTraceItemSearchQueryBuilderProps({
     booleanAttributes,
   });
 
-  const getTagKeys = useGetTraceItemAttributeTagKeys({
+  const dynamicTagKeys = useGetTraceItemAttributeTagKeys({
     itemType,
     projects,
     extraTags: functionTags,
     query: attributeQuery,
     hiddenKeys: hiddenAttributeKeys,
   });
+  // When an allowlist is in effect, the static filterKeys are already curated to
+  // it. Skip the dynamic EAP fetch so typed-key autocomplete only matches against
+  // the allowlist (and unrecognized keys are auto-rejected).
+  const getTagKeys = allowedAttributeKeys ? undefined : dynamicTagKeys;
 
   return useMemo(
     () => ({
@@ -252,6 +258,7 @@ export function TraceItemSearchQueryBuilder({
   disableRecentSearches,
   attributeQuery,
   hiddenAttributeKeys,
+  allowedAttributeKeys,
 }: TraceItemSearchQueryBuilderProps) {
   const searchQueryBuilderProps = useTraceItemSearchQueryBuilderProps({
     itemType,
@@ -281,6 +288,7 @@ export function TraceItemSearchQueryBuilder({
     disableRecentSearches,
     attributeQuery,
     hiddenAttributeKeys,
+    allowedAttributeKeys,
   });
 
   return (

--- a/static/app/views/explore/releases/list/mobileBuilds.tsx
+++ b/static/app/views/explore/releases/list/mobileBuilds.tsx
@@ -9,6 +9,10 @@ import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {ALL_ACCESS_PROJECTS} from 'sentry/components/pageFilters/constants';
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {
+  MOBILE_BUILDS_ALLOWED_KEYS,
+  SNAPSHOT_ALLOWED_KEYS,
+} from 'sentry/components/preprod/constants';
+import {
   getPreprodBuildsDisplay,
   PreprodBuildsDisplay,
 } from 'sentry/components/preprod/preprodBuildsDisplay';
@@ -204,6 +208,11 @@ export function MobileBuilds({
         initialQuery={searchQuery ?? ''}
         display={activeDisplay}
         projects={selectedProjectIds.map(Number)}
+        allowedKeys={
+          activeDisplay === PreprodBuildsDisplay.SNAPSHOT
+            ? SNAPSHOT_ALLOWED_KEYS
+            : MOBILE_BUILDS_ALLOWED_KEYS
+        }
         hideDisplayToggle={hideDisplayToggle}
         onSearch={handleSearch}
         onDisplayChange={handleDisplayChange}


### PR DESCRIPTION
## Summary

- Add `SNAPSHOT_ALLOWED_KEYS` with fields relevant to snapshot comparisons (`app_id`, git context, and image counts) and pass it when `activeDisplay === SNAPSHOT`. Also pass `MOBILE_BUILDS_ALLOWED_KEYS` explicitly for the mobile builds display so both tabs have a curated allowlist.
- Add `allowedAttributeKeys` prop to `TraceItemSearchQueryBuilder` — when set, skips the dynamic EAP tag-key fetch so typed-key autocomplete only matches the curated `filterKeys` instead of surfacing keys outside the allowlist (e.g. `app_name`).

Refs EME-1071