### PR TITLE
fix(seer): Add top-level URL pattern for /seer/

### DIFF
--- a/src/sentry/web/urls.py
+++ b/src/sentry/web/urls.py
@@ -998,6 +998,12 @@ urlpatterns += [
         react_page_view,
         name="prevent",
     ),
+    # Seer
+    re_path(
+        r"^seer/",
+        react_page_view,
+        name="seer",
+    ),
     # Monitors
     re_path(
         r"^monitors/",

--- a/tests/sentry/organizations/test_absolute_url.py
+++ b/tests/sentry/organizations/test_absolute_url.py
@@ -68,6 +68,9 @@ from sentry.organizations.absolute_url import customer_domain_path
         ("/prevent/", "/prevent/"),
         ("/prevent/tokens/", "/prevent/tokens/"),
         ("/prevent/tests/", "/prevent/tests/"),
+        # Top-level seer routes should remain as-is (not the /settings/seer/ ones)
+        ("/seer/", "/seer/"),
+        ("/seer/workflows/", "/seer/workflows/"),
         # Seer org settings: strip org slug but keep /settings/seer/... paths
         ("/settings/acme/seer/", "/settings/seer/"),
         ("/settings/acme/seer/repos/", "/settings/seer/repos/"),


### PR DESCRIPTION
- Hard-refreshing on `/seer/workflows/` (or any other top-level `seer/*` page) failed because there was no top-level `^seer/` entry in `src/sentry/web/urls.py`. The earlier two-segment pattern at line 1382 (`^(?P<organization_slug>[^/]+)/(?P<project_id>[^/]+)/$`, name `sentry-stream`) matched first, treating `seer` as an org slug and `workflows` as a project, which mangled the path. Client-side navigation worked because React Router resolves the route directly.
- Add an explicit top-level `^seer/` entry mapped to `react_page_view`, mirroring the fix used for `/prevent/` in #98936.

Agent transcript: https://claudescope.sentry.dev/share/BXPoxsQX2IGrv6veudPodWxVohQUnHBR_FUmB5AYbLQ