### PR TITLE
feat(preprod): Produce snapshot comparisons to EAP (EME-1071)

### DIFF
--- a/src/sentry/preprod/eap/write.py
+++ b/src/sentry/preprod/eap/write.py
@@ -23,6 +23,7 @@ from sentry.preprod.models import (
     PreprodArtifact,
     PreprodArtifactSizeMetrics,
 )
+from sentry.preprod.snapshots.models import PreprodSnapshotComparison
 from sentry.search.eap.rpc_utils import anyvalue
 from sentry.utils.arroyo_producer import SingletonProducer, get_arroyo_producer
 from sentry.utils.eap import hex_to_item_id
@@ -244,6 +245,93 @@ def produce_preprod_build_distribution_to_eap(
         received=received,
         retention_days=quotas.backend.get_event_retention(
             organization=organization, category=DataCategory.INSTALLABLE_BUILD
+        )
+        or 90,
+        attributes={k: anyvalue(v) for k, v in attributes.items() if v is not None},
+        client_sample_rate=1.0,
+        server_sample_rate=1.0,
+    )
+
+    topic = get_topic_definition(Topic.SNUBA_ITEMS)["real_topic_name"]
+    payload = KafkaPayload(None, EAP_ITEMS_CODEC.encode(trace_item), [])
+    _eap_producer.produce(ArroyoTopic(topic), payload)
+
+
+def produce_preprod_snapshot_comparison_to_eap(
+    comparison: PreprodSnapshotComparison,
+    organization: Organization,
+    organization_id: int,
+    project_id: int,
+) -> None:
+    """
+    Write a PreprodSnapshotComparison to EAP as a TRACE_ITEM_TYPE_PREPROD trace item.
+
+    One row per comparison. Should only be called after the comparison has reached
+    SUCCESS state and the image counts are committed.
+    """
+    proto_timestamp = Timestamp()
+    proto_timestamp.FromDatetime(comparison.date_updated)
+
+    received = Timestamp()
+    received.FromDatetime(comparison.date_updated)
+
+    head_metrics = comparison.head_snapshot_metrics
+    head_artifact = head_metrics.preprod_artifact
+
+    # Group with the head artifact's other preprod rows so search joins by trace_id.
+    trace_id = get_preprod_trace_id(head_artifact.id)
+
+    item_id_str = f"snapshot_comparison_{comparison.id}"
+    item_id = hex_to_item_id(uuid.uuid5(PREPROD_NAMESPACE, item_id_str).hex)
+
+    mobile_app_info = head_artifact.get_mobile_app_info()
+    attributes: dict[str, Any] = {
+        "preprod_artifact_id": head_artifact.id,
+        "snapshot_comparison_id": comparison.id,
+        "head_snapshot_metrics_id": comparison.head_snapshot_metrics_id,
+        "base_snapshot_metrics_id": comparison.base_snapshot_metrics_id,
+        "sub_item_type": "snapshot_comparison",
+        "image_count": head_metrics.image_count,
+        "images_added": comparison.images_added,
+        "images_changed": comparison.images_changed,
+        "images_removed": comparison.images_removed,
+        "images_renamed": comparison.images_renamed,
+        "images_skipped": comparison.images_skipped,
+        "images_unchanged": comparison.images_unchanged,
+        "platform_name": (
+            "apple" if head_artifact.is_ios() else "android" if head_artifact.is_android() else None
+        ),
+        "app_id": head_artifact.app_id,
+        "app_name": mobile_app_info.app_name if mobile_app_info else None,
+        "build_version": mobile_app_info.build_version if mobile_app_info else None,
+        "build_number": mobile_app_info.build_number if mobile_app_info else None,
+    }
+
+    if head_artifact.commit_comparison is not None:
+        commit_comparison = head_artifact.commit_comparison
+        attributes.update(
+            {
+                "git_head_sha": commit_comparison.head_sha,
+                "git_base_sha": commit_comparison.base_sha,
+                "git_provider": commit_comparison.provider,
+                "git_head_repo_name": commit_comparison.head_repo_name,
+                "git_base_repo_name": commit_comparison.base_repo_name,
+                "git_head_ref": commit_comparison.head_ref,
+                "git_base_ref": commit_comparison.base_ref,
+                "git_pr_number": commit_comparison.pr_number,
+            }
+        )
+
+    trace_item = EAPTraceItem(
+        organization_id=organization_id,
+        project_id=project_id,
+        item_id=item_id,
+        item_type=TraceItemType.TRACE_ITEM_TYPE_PREPROD,
+        timestamp=proto_timestamp,
+        trace_id=trace_id,
+        received=received,
+        retention_days=quotas.backend.get_event_retention(
+            organization=organization, category=DataCategory.SIZE_ANALYSIS
         )
         or 90,
         attributes={k: anyvalue(v) for k, v in attributes.items() if v is not None},

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -13,6 +13,7 @@ from pydantic import ValidationError
 from taskbroker_client.retry import Retry
 
 from sentry.objectstore import get_preprod_session
+from sentry.preprod.eap.write import produce_preprod_snapshot_comparison_to_eap
 from sentry.preprod.models import PreprodArtifact, PreprodComparisonApproval
 from sentry.preprod.snapshots.image_diff.compare import DIFF_ALGORITHM_VERSION, compare_images_batch
 from sentry.preprod.snapshots.image_diff.odiff import OdiffServer
@@ -738,6 +739,24 @@ def compare_snapshots(
                 "date_updated",
             ]
         )
+
+        try:
+            organization = head_artifact.project.organization
+            produce_preprod_snapshot_comparison_to_eap(
+                comparison=comparison,
+                organization=organization,
+                organization_id=organization.id,
+                project_id=head_artifact.project_id,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to write preprod snapshot comparison to EAP",
+                extra={
+                    "snapshot_comparison_id": comparison.id,
+                    "head_artifact_id": head_artifact_id,
+                    "base_artifact_id": base_artifact_id,
+                },
+            )
 
         time_now = timezone.now()
 

--- a/src/sentry/search/eap/preprod_size/attributes.py
+++ b/src/sentry/search/eap/preprod_size/attributes.py
@@ -84,6 +84,41 @@ PREPROD_SIZE_ATTRIBUTE_DEFINITIONS = {
             search_type="boolean",
         ),
         ResolvedAttribute(
+            public_alias="image_count",
+            internal_name="image_count",
+            search_type="integer",
+        ),
+        ResolvedAttribute(
+            public_alias="images_added",
+            internal_name="images_added",
+            search_type="integer",
+        ),
+        ResolvedAttribute(
+            public_alias="images_changed",
+            internal_name="images_changed",
+            search_type="integer",
+        ),
+        ResolvedAttribute(
+            public_alias="images_removed",
+            internal_name="images_removed",
+            search_type="integer",
+        ),
+        ResolvedAttribute(
+            public_alias="images_renamed",
+            internal_name="images_renamed",
+            search_type="integer",
+        ),
+        ResolvedAttribute(
+            public_alias="images_skipped",
+            internal_name="images_skipped",
+            search_type="integer",
+        ),
+        ResolvedAttribute(
+            public_alias="images_unchanged",
+            internal_name="images_unchanged",
+            search_type="integer",
+        ),
+        ResolvedAttribute(
             public_alias="timestamp",
             internal_name="sentry.timestamp",
             internal_type=constants.DOUBLE,

--- a/tests/sentry/preprod/eap/test_write.py
+++ b/tests/sentry/preprod/eap/test_write.py
@@ -9,6 +9,7 @@ from sentry.models.commitcomparison import CommitComparison
 from sentry.preprod.eap.write import (
     produce_preprod_build_distribution_to_eap,
     produce_preprod_size_metric_to_eap,
+    produce_preprod_snapshot_comparison_to_eap,
 )
 from sentry.preprod.models import (
     InstallablePreprodArtifact,
@@ -16,6 +17,7 @@ from sentry.preprod.models import (
     PreprodArtifactSizeMetrics,
     PreprodBuildConfiguration,
 )
+from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
 from sentry.testutils.cases import TestCase
 
 
@@ -310,4 +312,149 @@ class WritePreprodBuildDistributionToEAPTest(TestCase):
         assert "codesigning_type" not in attrs
         assert "profile_name" not in attrs
         assert "build_configuration_name" not in attrs
+        assert "git_head_sha" not in attrs
+
+
+class WritePreprodSnapshotComparisonToEAPTest(TestCase):
+    @patch("sentry.preprod.eap.write._eap_producer.produce")
+    def test_write_preprod_snapshot_comparison_encodes_all_fields_correctly(self, mock_produce):
+        commit_comparison = CommitComparison.objects.create(
+            organization_id=self.organization.id,
+            head_sha="abc123",
+            base_sha="def456",
+            provider="github",
+            head_repo_name="owner/repo",
+            base_repo_name="owner/repo",
+            head_ref="feature/test",
+            base_ref="main",
+            pr_number=42,
+        )
+
+        head_artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            app_id="com.example.app",
+            commit_comparison=commit_comparison,
+        )
+        self.create_preprod_artifact_mobile_app_info(
+            preprod_artifact=head_artifact,
+            build_version="1.2.3",
+            build_number=100,
+            app_name="Example App",
+        )
+        base_artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            app_id="com.example.app",
+        )
+
+        head_metrics = PreprodSnapshotMetrics.objects.create(
+            preprod_artifact=head_artifact,
+            image_count=12,
+        )
+        base_metrics = PreprodSnapshotMetrics.objects.create(
+            preprod_artifact=base_artifact,
+            image_count=10,
+        )
+        comparison = PreprodSnapshotComparison.objects.create(
+            head_snapshot_metrics=head_metrics,
+            base_snapshot_metrics=base_metrics,
+            state=PreprodSnapshotComparison.State.SUCCESS,
+            images_added=3,
+            images_removed=1,
+            images_changed=2,
+            images_unchanged=6,
+            images_renamed=1,
+            images_skipped=0,
+        )
+
+        produce_preprod_snapshot_comparison_to_eap(
+            comparison=comparison,
+            organization=self.organization,
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+        )
+
+        mock_produce.assert_called_once()
+        topic, payload = mock_produce.call_args[0]
+
+        assert topic.name == "snuba-items"
+
+        codec = get_topic_codec(Topic.SNUBA_ITEMS)
+        trace_item = codec.decode(payload.value)
+
+        assert trace_item.organization_id == self.organization.id
+        assert trace_item.project_id == self.project.id
+        assert trace_item.item_type == TraceItemType.TRACE_ITEM_TYPE_PREPROD
+        assert trace_item.retention_days == 90
+
+        attrs = trace_item.attributes
+
+        assert attrs["preprod_artifact_id"].int_value == head_artifact.id
+        assert attrs["snapshot_comparison_id"].int_value == comparison.id
+        assert attrs["head_snapshot_metrics_id"].int_value == head_metrics.id
+        assert attrs["base_snapshot_metrics_id"].int_value == base_metrics.id
+        assert attrs["sub_item_type"].string_value == "snapshot_comparison"
+
+        assert attrs["image_count"].int_value == 12
+        assert attrs["images_added"].int_value == 3
+        assert attrs["images_removed"].int_value == 1
+        assert attrs["images_changed"].int_value == 2
+        assert attrs["images_unchanged"].int_value == 6
+        assert attrs["images_renamed"].int_value == 1
+        assert attrs["images_skipped"].int_value == 0
+
+        assert attrs["app_id"].string_value == "com.example.app"
+        assert attrs["app_name"].string_value == "Example App"
+        assert attrs["build_version"].string_value == "1.2.3"
+        assert attrs["build_number"].int_value == 100
+
+        assert attrs["git_head_sha"].string_value == "abc123"
+        assert attrs["git_base_sha"].string_value == "def456"
+        assert attrs["git_head_ref"].string_value == "feature/test"
+        assert attrs["git_base_ref"].string_value == "main"
+        assert attrs["git_pr_number"].int_value == 42
+
+    @patch("sentry.preprod.eap.write._eap_producer.produce")
+    def test_write_preprod_snapshot_comparison_handles_optional_fields(self, mock_produce):
+        head_artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+        base_artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+        )
+
+        head_metrics = PreprodSnapshotMetrics.objects.create(preprod_artifact=head_artifact)
+        base_metrics = PreprodSnapshotMetrics.objects.create(preprod_artifact=base_artifact)
+        comparison = PreprodSnapshotComparison.objects.create(
+            head_snapshot_metrics=head_metrics,
+            base_snapshot_metrics=base_metrics,
+            state=PreprodSnapshotComparison.State.SUCCESS,
+        )
+
+        produce_preprod_snapshot_comparison_to_eap(
+            comparison=comparison,
+            organization=self.organization,
+            organization_id=self.organization.id,
+            project_id=self.project.id,
+        )
+
+        mock_produce.assert_called_once()
+        topic, payload = mock_produce.call_args[0]
+
+        codec = get_topic_codec(Topic.SNUBA_ITEMS)
+        trace_item = codec.decode(payload.value)
+
+        attrs = trace_item.attributes
+
+        assert attrs["sub_item_type"].string_value == "snapshot_comparison"
+        assert attrs["images_added"].int_value == 0
+        assert attrs["image_count"].int_value == 0
+
+        assert "app_name" not in attrs
+        assert "build_number" not in attrs
         assert "git_head_sha" not in attrs


### PR DESCRIPTION
Snapshot comparison data (`image_count`, `images_added/changed/removed/renamed/skipped/unchanged`) lives only in Postgres today, so a search over `TraceItemDataset.PREPROD` can't surface those keys for autocomplete or filtering on the snapshots tab. This adds a snapshot-specific EAP writer.

**EAP writer**

`produce_preprod_snapshot_comparison_to_eap` emits one `TRACE_ITEM_TYPE_PREPROD` row per successful comparison with `sub_item_type = "snapshot_comparison"`. The row carries the image counts plus head-artifact context (`app_*`, `build_*`, `platform_name`, `git_*`) and reuses the head artifact's preprod `trace_id` so the row groups with the existing `size_metric` / `build_distribution` rows.

**Attribute registration**

Adds `image_count` and `images_*` to `PREPROD_SIZE_ATTRIBUTE_DEFINITIONS` as integer attributes so EAP types/aliases them like the existing fields.

**Wiring**

Calls the writer immediately after `comparison.save()` in the SUCCESS path of `sentry.preprod.snapshots.tasks.compare_artifacts`. The Kafka call is wrapped in `try/except` so a producer failure cannot break the saved comparison.

Once this lands, the frontend allowlist in #114316 can be extended with the `image_*` keys for the snapshots search bar.

Refs EME-1071