### PR TITLE
feat(eslint): enable unicorn/no-useless-switch-case

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -834,7 +834,6 @@ export default typescript.config([
       'unicorn/no-unreadable-array-destructuring': 'off',
       'unicorn/no-useless-promise-resolve-reject': 'off',
       'unicorn/no-useless-spread': 'off',
-      'unicorn/no-useless-switch-case': 'off',
       'unicorn/numeric-separators-style': 'off',
       'unicorn/prefer-add-event-listener': 'off',
       'unicorn/prefer-at': 'off',

--- a/static/app/components/core/menuListItem/menuListItem.tsx
+++ b/static/app/components/core/menuListItem/menuListItem.tsx
@@ -36,7 +36,6 @@ function getTextColor({
       return theme.tokens.content.accent;
     case 'danger':
       return theme.tokens.content.danger;
-    case 'default':
     default:
       return theme.tokens.content.primary;
   }
@@ -52,7 +51,6 @@ const getVerticalPadding = (size: FormSize | undefined, theme: Theme) => {
       return theme.space.xs;
     case 'sm':
       return theme.space.sm;
-    case 'md':
     default:
       return theme.space.md;
   }

--- a/static/app/components/events/autofix/codingAgentCard.tsx
+++ b/static/app/components/events/autofix/codingAgentCard.tsx
@@ -42,8 +42,6 @@ export function CodingAgentCard({codingAgentState, groupId, repo}: CodingAgentCa
         return 'success';
       case CodingAgentStatus.FAILED:
         return 'danger';
-      case CodingAgentStatus.PENDING:
-      case CodingAgentStatus.RUNNING:
       default:
         return 'info';
     }

--- a/static/app/components/events/autofix/v3/autofixEvidence.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.tsx
@@ -122,7 +122,6 @@ function getTelemetryEvidenceLabel(dataset?: string) {
     case 'metrics':
     case 'tracemetrics':
       return t('Query: Metrics');
-    case 'spans':
     default:
       return t('Query: Spans');
   }

--- a/static/app/components/events/breadcrumbs/utils.tsx
+++ b/static/app/components/events/breadcrumbs/utils.tsx
@@ -309,7 +309,6 @@ function getBreadcrumbColorConfig(
         icon: theme.tokens.content.accent,
         iconBorder: theme.tokens.border.transparent.accent.moderate,
       };
-    case BreadcrumbType.DEBUG:
     default:
       return {
         title: theme.tokens.content.primary,

--- a/static/app/components/events/featureFlags/utils.tsx
+++ b/static/app/components/events/featureFlags/utils.tsx
@@ -16,7 +16,6 @@ const getOrderByLabel = (sort: string) => {
       return t('Z-A');
     case OrderBy.OLDEST:
       return t('Oldest First');
-    case OrderBy.NEWEST:
     default:
       return t('Newest First');
   }

--- a/static/app/components/events/interfaces/debugMeta/debugImageDetails/reprocessAlert.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImageDetails/reprocessAlert.tsx
@@ -81,7 +81,6 @@ export function ReprocessAlert({
         return t(
           'This event cannot be reprocessed because a required attachment is missing'
         );
-      case ReprocessableEventReason.UNPROCESSED_EVENT_NOT_FOUND:
       default:
         return t('This event cannot be reprocessed');
     }

--- a/static/app/components/events/interfaces/nativeFrame.tsx
+++ b/static/app/components/events/interfaces/nativeFrame.tsx
@@ -220,7 +220,6 @@ function NativeFrame({
           return 'error';
         case SymbolicatorStatus.UNKNOWN_IMAGE:
           return frame.instructionAddr === '0x0' ? 'success' : 'error';
-        case SymbolicatorStatus.MISSING_SYMBOL:
         default:
           return undefined;
       }

--- a/static/app/components/events/interfaces/utils.tsx
+++ b/static/app/components/events/interfaces/utils.tsx
@@ -310,7 +310,6 @@ export function isStacktraceNewestFirst() {
       return true;
     case StacktraceOrder.MOST_RECENT_LAST:
       return false;
-    case StacktraceOrder.DEFAULT:
     default:
       return true;
   }

--- a/static/app/components/modals/dataWidgetViewerModal.tsx
+++ b/static/app/components/modals/dataWidgetViewerModal.tsx
@@ -594,7 +594,6 @@ function DataWidgetViewerModal(props: Props) {
             {renderTable}
           </ReleaseWidgetQueries>
         );
-      case WidgetType.DISCOVER:
       default:
         return (
           <WidgetQueries
@@ -941,7 +940,6 @@ function OpenButton({
     case WidgetType.PREPROD_APP_SIZE:
       // Mobile app size widgets are not integrated with Explore or Discover
       return null;
-    case WidgetType.DISCOVER:
     default:
       openLabel = t('Open in Discover');
       path = getWidgetDiscoverUrl(

--- a/static/app/components/pluginConfig.tsx
+++ b/static/app/components/pluginConfig.tsx
@@ -129,8 +129,6 @@ function mapPluginField(field: BackendPluginField): JsonFormAdapterFieldConfig {
       return {...base, type: 'email', default: defaultValue};
     case 'url':
       return {...base, type: 'url', default: defaultValue};
-    case 'string':
-    case 'text':
     default:
       return {...base, type: 'text', default: defaultValue};
   }

--- a/static/app/components/preprod/preprodBuildsDisplay.ts
+++ b/static/app/components/preprod/preprodBuildsDisplay.ts
@@ -16,7 +16,6 @@ export function getPreprodBuildsDisplay(
       return PreprodBuildsDisplay.DISTRIBUTION;
     case PreprodBuildsDisplay.SNAPSHOT:
       return PreprodBuildsDisplay.SNAPSHOT;
-    case PreprodBuildsDisplay.SIZE:
     default:
       return PreprodBuildsDisplay.SIZE;
   }

--- a/static/app/components/replays/player/replayCurrentTime.tsx
+++ b/static/app/components/replays/player/replayCurrentTime.tsx
@@ -29,7 +29,6 @@ function ReplayCurrentTimeNew() {
       const startTimestamp = replay?.getStartTimestampMs() ?? 0;
       return <DateTime date={currentTime.timeMs + startTimestamp} seconds timeOnly />;
     }
-    case 'relative':
     default:
       return <Duration duration={[currentTime.timeMs, 'ms']} precision="sec" />;
   }

--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
@@ -263,8 +263,6 @@ export function convertTokenTypeToValueType(tokenType: Token): FieldValueType {
       return FieldValueType.NUMBER;
     case Token.VALUE_PERCENTAGE:
       return FieldValueType.PERCENTAGE;
-    case Token.VALUE_TEXT:
-    case Token.VALUE_TEXT_LIST:
     default:
       return FieldValueType.STRING;
   }

--- a/static/app/components/searchQueryBuilder/tokens/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/utils.tsx
@@ -64,7 +64,6 @@ export function getDefaultValueForValueType(valueType: FieldValueType | null): s
       return '10bytes';
     case FieldValueType.PERCENTAGE:
       return '0.5';
-    case FieldValueType.STRING:
     default:
       return '""';
   }

--- a/static/app/gettingStartedDocs/javascript-vue/utils.tsx
+++ b/static/app/gettingStartedDocs/javascript-vue/utils.tsx
@@ -101,7 +101,6 @@ function getSiblingImportsSetupConfiguration(siblingOption: string): string {
           import {createRouter} from "vue-router";
           import router from "./router";
           `;
-    case VueVersion.VUE2:
     default:
       return `import Vue from "vue";
           import Router from "vue-router";`;
@@ -113,7 +112,6 @@ function getSiblingSuffix(siblingOption: string): string {
     case VueVersion.VUE3:
       return `app.use(router);
       app.mount("#app");`;
-    case VueVersion.VUE2:
     default:
       return `new Vue({
         router,

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -3623,8 +3623,6 @@ function _getFieldFromMappings(
       }
 
       return null;
-
-    case 'event':
     default:
       if (Object.hasOwn(EVENT_FIELD_DEFINITIONS, key)) {
         // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message

--- a/static/app/utils/integrationUtil.tsx
+++ b/static/app/utils/integrationUtil.tsx
@@ -284,8 +284,6 @@ export const getIntegrationSourceUrl = (
       }
       return url.toString();
     }
-    case 'github':
-    case 'github_enterprise':
     default:
       if (lineNo === null) {
         return sourceUrl;

--- a/static/app/utils/number/formatMetricUsingUnit.tsx
+++ b/static/app/utils/number/formatMetricUsingUnit.tsx
@@ -192,7 +192,6 @@ export function formatMetricUsingUnit(value: number | null, unit: string) {
     case 'exabyte':
     case 'exabytes':
       return formatBytesBase10(value, 6);
-    case 'none':
     default:
       return formatAbbreviatedNumberWithDynamicPrecision(value);
   }

--- a/static/app/utils/profiling/canvasView.tsx
+++ b/static/app/utils/profiling/canvasView.tsx
@@ -106,8 +106,6 @@ export class CanvasView<T extends {configSpace: Rect}> {
         );
         return;
       }
-      case 'anchorBottom':
-      case 'anchorTop':
       default: {
         this.configSpace = new Rect(
           0,

--- a/static/app/utils/seer/preferredAgentFilter.tsx
+++ b/static/app/utils/seer/preferredAgentFilter.tsx
@@ -26,7 +26,6 @@ function convertAgentNameToCodingAgentProvider(name: string): PreferredAgentProv
     case CodingAgentProvider.GITHUB_COPILOT_AGENT:
     case 'github_copilot':
       return CodingAgentProvider.GITHUB_COPILOT_AGENT;
-    case 'seer':
     default:
       return 'seer';
   }

--- a/static/app/utils/timeSeries/transformLegacySeriesToTimeSeries.tsx
+++ b/static/app/utils/timeSeries/transformLegacySeriesToTimeSeries.tsx
@@ -133,8 +133,6 @@ function mapAggregationTypeToValueTypeAndUnit(
       return {valueType: 'score', valueUnit: null};
     case 'percentage':
       return {valueType: 'percentage', valueUnit: null};
-    case 'integer':
-    case 'number':
     default:
       return {valueType: 'number', valueUnit: null};
   }

--- a/static/app/views/dashboards/datasetConfig/base.tsx
+++ b/static/app/views/dashboards/datasetConfig/base.tsx
@@ -369,7 +369,6 @@ export function getDatasetConfig(widgetType?: WidgetType):
       return TraceMetricsConfig;
     case WidgetType.PREPROD_APP_SIZE:
       return MobileAppSizeConfig;
-    case WidgetType.DISCOVER:
     default:
       return ErrorsAndTransactionsConfig;
   }

--- a/static/app/views/dashboards/detail.tsx
+++ b/static/app/views/dashboards/detail.tsx
@@ -981,7 +981,6 @@ class DashboardDetail extends Component<Props, State> {
         });
         break;
       }
-      case DashboardState.VIEW:
       default: {
         this.setState({
           dashboardState: DashboardState.VIEW,

--- a/static/app/views/dashboards/filtersBar.tsx
+++ b/static/app/views/dashboards/filtersBar.tsx
@@ -81,11 +81,6 @@ function getDataCategoriesFromWidgets(
       case WidgetType.LOGS:
         categories.add(DataCategory.LOG_ITEM);
         break;
-      case WidgetType.ERRORS:
-      case WidgetType.DISCOVER:
-      case WidgetType.ISSUE:
-      case WidgetType.RELEASE:
-      case WidgetType.METRICS:
       default:
         // For error-like widgets, use TRANSACTIONS as a safe default
         // since it has the most permissive date range

--- a/static/app/views/dashboards/globalFilter/genericFilterSelector.tsx
+++ b/static/app/views/dashboards/globalFilter/genericFilterSelector.tsx
@@ -24,7 +24,6 @@ function getFilterSelector(
     case FieldValueType.NUMBER:
     case FieldValueType.DURATION:
       return NumericFilterSelector;
-    case FieldValueType.STRING:
     default:
       return FilterSelector;
   }

--- a/static/app/views/dashboards/manage/gridPreview/index.tsx
+++ b/static/app/views/dashboards/manage/gridPreview/index.tsx
@@ -30,7 +30,6 @@ function MiniWidget({displayType, color}: {color: string; displayType: DisplayTy
       return <NumberPreview color={color} />;
     case DisplayType.TABLE:
       return <TablePreview />;
-    case DisplayType.LINE:
     default:
       return <LinePreview color={color} />;
   }

--- a/static/app/views/dashboards/utils/getWidgetMetricsUrl.tsx
+++ b/static/app/views/dashboards/utils/getWidgetMetricsUrl.tsx
@@ -92,8 +92,6 @@ function getChartTypeFromDisplayType(displayType: DisplayType): ChartType {
       return ChartType.AREA;
     case DisplayType.BAR:
       return ChartType.BAR;
-    case DisplayType.TABLE:
-    case DisplayType.BIG_NUMBER:
     default:
       return ChartType.LINE;
   }

--- a/static/app/views/dashboards/widgetCard/chart.tsx
+++ b/static/app/views/dashboards/widgetCard/chart.tsx
@@ -881,7 +881,6 @@ function getChartComponent(chartProps: any, widget: Widget): React.ReactNode {
     case 'area':
     case 'top_n':
       return <AreaChart stacked {...chartProps} />;
-    case 'line':
     default:
       return <LineChart {...chartProps} />;
   }

--- a/static/app/views/dashboards/widgetCard/confidenceFooter.tsx
+++ b/static/app/views/dashboards/widgetCard/confidenceFooter.tsx
@@ -185,7 +185,6 @@ function getExploreChartType(displayType: DisplayType) {
     case DisplayType.AREA:
     case DisplayType.TOP_N:
       return ChartType.AREA;
-    case DisplayType.LINE:
     default:
       return ChartType.LINE;
   }

--- a/static/app/views/dashboards/widgetLibrary/widgetCard.tsx
+++ b/static/app/views/dashboards/widgetLibrary/widgetCard.tsx
@@ -18,7 +18,6 @@ export function getWidgetIcon(displayType: DisplayType): React.ReactNode {
       return <StyledIconArrow />;
     case DisplayType.AREA:
       return <StyledIconGraphArea />;
-    case DisplayType.LINE:
     default:
       return <StyledIconGraph />;
   }

--- a/static/app/views/detectors/components/forms/metric/metricFormData.tsx
+++ b/static/app/views/detectors/components/forms/metric/metricFormData.tsx
@@ -375,7 +375,6 @@ export function metricDetectorFormDataToEndpointPayload(
         detectionType: 'dynamic',
       };
       break;
-    case 'static':
     default:
       config = {
         detectionType: 'static',

--- a/static/app/views/explore/profiling/landing/landingWidgetSelector.tsx
+++ b/static/app/views/explore/profiling/landing/landingWidgetSelector.tsx
@@ -172,7 +172,6 @@ export function LandingWidgetSelector({
           onDataState={onDataState}
         />
       );
-    case 'slowest functions':
     default:
       return (
         <SlowestFunctionsWidget

--- a/static/app/views/explore/releases/detail/overview/releaseComparisonChart/releaseSessionsChart.tsx
+++ b/static/app/views/explore/releases/detail/overview/releaseComparisonChart/releaseSessionsChart.tsx
@@ -80,8 +80,6 @@ class ReleaseSessionsChart extends Component<Props> {
       case ReleaseComparisonChartType.UNHANDLED_USERS:
       case ReleaseComparisonChartType.CRASHED_USERS:
         return defined(value) ? `${value}%` : '\u2015';
-      case ReleaseComparisonChartType.SESSION_COUNT:
-      case ReleaseComparisonChartType.USER_COUNT:
       default:
         return typeof value === 'number' ? value.toLocaleString() : value;
     }
@@ -117,8 +115,6 @@ class ReleaseSessionsChart extends Component<Props> {
             color: theme.tokens.content.secondary,
           },
         };
-      case ReleaseComparisonChartType.SESSION_COUNT:
-      case ReleaseComparisonChartType.USER_COUNT:
       default:
         return undefined;
     }
@@ -175,8 +171,6 @@ class ReleaseSessionsChart extends Component<Props> {
         return [colors[13]];
       case ReleaseComparisonChartType.CRASHED_USERS:
         return [theme.colors.red400];
-      case ReleaseComparisonChartType.SESSION_COUNT:
-      case ReleaseComparisonChartType.USER_COUNT:
       default:
         return undefined;
     }

--- a/static/app/views/explore/releases/detail/overview/releaseIssues.tsx
+++ b/static/app/views/explore/releases/detail/overview/releaseIssues.tsx
@@ -134,8 +134,6 @@ class ReleaseIssues extends Component<Props, State> {
       case IssuesType.REGRESSED:
         query.setFilterValues('regressed_in_release', [version]);
         break;
-      case IssuesType.RESOLVED:
-      case IssuesType.ALL:
       default:
         query.setFilterValues('release', [version]);
     }
@@ -216,7 +214,6 @@ class ReleaseIssues extends Component<Props, State> {
             ]).formatString(),
           },
         };
-      case IssuesType.NEW:
       default:
         return {
           endpoint: {

--- a/static/app/views/explore/releases/list/releasesRequest.tsx
+++ b/static/app/views/explore/releases/list/releasesRequest.tsx
@@ -65,7 +65,6 @@ export function sessionDisplayToField(display: ReleasesDisplayOption) {
   switch (display) {
     case ReleasesDisplayOption.USERS:
       return SessionFieldWithOperation.USERS;
-    case ReleasesDisplayOption.SESSIONS:
     default:
       return SessionFieldWithOperation.SESSIONS;
   }

--- a/static/app/views/explore/replays/detail/ai/useReplaySummary.tsx
+++ b/static/app/views/explore/replays/detail/ai/useReplaySummary.tsx
@@ -63,8 +63,6 @@ const shouldPoll = (
       return true;
 
     // Final states
-    case ReplaySummaryStatus.COMPLETED:
-    case ReplaySummaryStatus.ERROR:
     default:
       return false;
   }

--- a/static/app/views/explore/replays/detail/layout/focusArea.tsx
+++ b/static/app/views/explore/replays/detail/layout/focusArea.tsx
@@ -69,7 +69,6 @@ export function FocusArea({isVideoReplay}: {isVideoReplay?: boolean}) {
           <Playlist />
         </AnalyticsArea>
       );
-    case TabKey.BREADCRUMBS:
     default: {
       return (
         <AnalyticsArea name="breadcrumbs_tab">

--- a/static/app/views/explore/replays/detail/network/details/content.tsx
+++ b/static/app/views/explore/replays/detail/network/details/content.tsx
@@ -89,7 +89,6 @@ export function NetworkDetailsContent(props: Props) {
           )}
         </OverflowFluidHeight>
       );
-    case 'details':
     default:
       return (
         <OverflowFluidHeight>

--- a/static/app/views/insights/browser/webVitals/queries/useSpanSamplesWebVitalsQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/useSpanSamplesWebVitalsQuery.tsx
@@ -86,7 +86,6 @@ export function useSpanSamplesWebVitalsQuery({
       field = SpanFields.TTFB;
       ratioField = SpanFields.TTFB_SCORE_RATIO;
       break;
-    case 'inp':
     default:
       field = SpanFields.INP;
       ratioField = SpanFields.INP_SCORE_RATIO;

--- a/static/app/views/insights/crons/components/monitorForm.tsx
+++ b/static/app/views/insights/crons/components/monitorForm.tsx
@@ -201,7 +201,6 @@ export function MonitorForm({
         rv['config.schedule.frequency'] = config.schedule[0];
         rv['config.schedule.interval'] = config.schedule[1];
         break;
-      case 'crontab':
       default:
         rv['config.schedule'] = config.schedule;
         rv['config.timezone'] = config.timezone;

--- a/static/app/views/issueList/actions/index.tsx
+++ b/static/app/views/issueList/actions/index.tsx
@@ -420,8 +420,6 @@ function shouldConfirm(
     }
     case ConfirmAction.BOOKMARK:
       return selectedIdsSet.size > 1;
-    case ConfirmAction.MERGE:
-    case ConfirmAction.DELETE:
     default:
       return true; // By default, should confirm ...
   }

--- a/static/app/views/issueList/actions/sortOptions.tsx
+++ b/static/app/views/issueList/actions/sortOptions.tsx
@@ -31,7 +31,6 @@ function getSortTooltip(key: IssueSortOptions) {
       return t('Number of events.');
     case IssueSortOptions.USER:
       return t('Number of users affected.');
-    case IssueSortOptions.DATE:
     default:
       return t('Last time the issue occurred.');
   }

--- a/static/app/views/issueList/supergroups/supergroupDrawer.tsx
+++ b/static/app/views/issueList/supergroups/supergroupDrawer.tsx
@@ -453,8 +453,6 @@ function DrawerActionsBar({groupIds}: {groupIds: string[]}) {
           return pageSelected && selectedIdsSet.size > 1;
         case ConfirmAction.BOOKMARK:
           return selectedIdsSet.size > 1;
-        case ConfirmAction.MERGE:
-        case ConfirmAction.DELETE:
         default:
           return true;
       }

--- a/static/app/views/issueList/utils.tsx
+++ b/static/app/views/issueList/utils.tsx
@@ -46,7 +46,6 @@ export function getSortLabel(key: string) {
       return t('Users');
     case IssueSortOptions.INBOX:
       return t('Date Added');
-    case IssueSortOptions.DATE:
     default:
       return t('Last Seen');
   }

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/aiContentRenderer.tsx
@@ -112,8 +112,6 @@ export function AIContentRenderer({
       return (
         <TraceDrawerComponents.MultilineText>{text}</TraceDrawerComponents.MultilineText>
       );
-
-    case 'plain-text':
     default:
       if (inline) {
         return <Fragment>{text}</Fragment>;

--- a/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.tsx
+++ b/static/app/views/performance/newTraceDetails/traceSearch/traceSearchEvaluator.tsx
@@ -468,8 +468,6 @@ function resolveValueFromKey(node: BaseNode, token: ProcessedTokenResult): any |
         key = token.key.value;
         break;
       }
-      case Token.KEY_AGGREGATE:
-      case Token.KEY_EXPLICIT_TAG:
       default: {
         Sentry.captureMessage(`Unsupported key type for filter, got ${token.key.type}`);
         info(fmt`Unsupported key type for filter, got ${token.key.type}`);

--- a/static/app/views/performance/transactionSummary/header.tsx
+++ b/static/app/views/performance/transactionSummary/header.tsx
@@ -103,7 +103,6 @@ export function TransactionHeader({
         case Tab.PROFILING: {
           return profilesRouteWithQuery(routeQuery);
         }
-        case Tab.TRANSACTION_SUMMARY:
         default:
           return transactionSummaryRouteWithQuery(routeQuery);
       }

--- a/static/app/views/performance/transactionSummary/pageLayout.tsx
+++ b/static/app/views/performance/transactionSummary/pageLayout.tsx
@@ -154,7 +154,6 @@ export function PageLayout(props: Props) {
         case Tab.PROFILING: {
           return profilesRouteWithQuery(routeQuery);
         }
-        case Tab.TRANSACTION_SUMMARY:
         default:
           return transactionSummaryRouteWithQuery(routeQuery);
       }

--- a/static/app/views/performance/trends/utils/index.tsx
+++ b/static/app/views/performance/trends/utils/index.tsx
@@ -178,9 +178,6 @@ export function performanceTypeToTrendParameterLabel(
         label: TrendParameterLabel.LCP,
         column: TrendParameterColumn.LCP,
       };
-    case ProjectPerformanceType.ANY:
-    case ProjectPerformanceType.BACKEND:
-    case ProjectPerformanceType.FRONTEND_OTHER:
     default:
       return {
         label: TrendParameterLabel.DURATION,

--- a/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarStatusCheck.tsx
+++ b/static/app/views/preprod/buildDetails/sidebar/buildDetailsSidebarStatusCheck.tsx
@@ -107,7 +107,6 @@ function getErrorMessage(
       );
     case StatusCheckErrorType.API_ERROR:
       return t('A temporary API error occurred while posting the status check.');
-    case StatusCheckErrorType.UNKNOWN:
     default:
       return t('An error occurred while posting the status check to %s.', providerName);
   }

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -229,7 +229,6 @@ const Dot = styled('span')<{active: boolean; pillColor: PillColor}>`
         return p.theme.tokens.graphics.danger.vibrant;
       case 'warning':
         return p.theme.tokens.graphics.warning.vibrant;
-      case 'muted':
       default:
         return p.theme.tokens.content.secondary;
     }

--- a/static/app/views/projectDetail/projectCharts.tsx
+++ b/static/app/views/projectDetail/projectCharts.tsx
@@ -258,10 +258,6 @@ class ProjectCharts extends Component<Props, State> {
       case DisplayModes.ANR_RATE:
       case DisplayModes.FOREGROUND_ANR_RATE:
         return t('Total Users');
-      case DisplayModes.APDEX:
-      case DisplayModes.FAILURE_RATE:
-      case DisplayModes.TPM:
-      case DisplayModes.TRANSACTIONS:
       default:
         return t('Total Transactions');
     }

--- a/static/app/views/settings/organizationDeveloperSettings/index.tsx
+++ b/static/app/views/settings/organizationDeveloperSettings/index.tsx
@@ -145,7 +145,6 @@ function OrganizationDeveloperSettings() {
     switch (tab) {
       case 'internal':
         return renderInternalIntegrations();
-      case 'public':
       default:
         return renderPublicIntegrations();
     }

--- a/static/app/views/settings/project/tempest/index.tsx
+++ b/static/app/views/settings/project/tempest/index.tsx
@@ -100,7 +100,6 @@ export default function TempestSettings() {
     switch (tab) {
       case 'devkit-crashes':
         return t('DevKit Crashes');
-      case 'retail':
       default:
         return t('Retail');
     }

--- a/static/gsAdmin/views/sentryAppDetails.tsx
+++ b/static/gsAdmin/views/sentryAppDetails.tsx
@@ -85,7 +85,6 @@ export function SentryAppDetails() {
         onAction: () => onUpdateMutation.mutate({status: 'unpublished'}),
       };
       break;
-    case 'internal':
     default:
       publishingAction = undefined;
   }

--- a/static/gsApp/components/addEventsCTA.tsx
+++ b/static/gsApp/components/addEventsCTA.tsx
@@ -181,7 +181,6 @@ function AddEventsCTA(props: Props) {
           {t('Request Upgrade')}
         </Button>
       );
-    case 'send_to_checkout':
     default:
       return (
         <LinkButton

--- a/static/gsApp/views/subscriptionPage/usageAlert.tsx
+++ b/static/gsApp/views/subscriptionPage/usageAlert.tsx
@@ -53,7 +53,6 @@ export function UsageAlert({subscription, usage}: Props) {
         );
       case UsageAction.REQUEST_UPGRADE:
         return t('Bug your organization owner to upgrade your plan to avoid data loss.');
-      case UsageAction.SEND_TO_CHECKOUT:
       default:
         return t('Upgrade your plan to avoid data loss.');
     }


### PR DESCRIPTION
Removes the disable of [`unicorn/no-useless-switch-case `](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-useless-switch-case.md) and runs `pnpm lint:js --fix`.

...except, the rule only has _suggestions_ (manual opt-in) and not _fixes_ (automatic with `--fix`). I don't know why - maybe they haven't had time to add detection for unsafe removals (`case this.hasSideEffect():`)? Anyway, similar to #114222, I patched the rule locally to provide a fix.

<details>
<summary><code>patches/eslint-plugin-unicorn.patch</code></summary>

```diff
diff --git a/rules/no-useless-switch-case.js b/rules/no-useless-switch-case.js
index 292196e9852a1e488579fbd85f8105785cfbf52b..2c54f6a958b22a175671812d9100f4351bbb66cf 100644
--- a/rules/no-useless-switch-case.js
+++ b/rules/no-useless-switch-case.js
@@ -30,13 +30,8 @@ const create = context => {
 				node,
 				loc: getSwitchCaseHeadLocation(node, context),
 				messageId: MESSAGE_ID_ERROR,
-				suggest: [
-					{
-						messageId: MESSAGE_ID_SUGGESTION,
-						/** @param {import('eslint').Rule.RuleFixer} fixer */
-						fix: fixer => fixer.remove(node),
-					},
-				],
+				/** @param {import('eslint').Rule.RuleFixer} fixer */
+				fix: fixer => fixer.remove(node),
 			};
 		}
 	});
@@ -51,7 +46,7 @@ const config = {
 			description: 'Disallow useless case in switch statements.',
 			recommended: 'unopinionated',
 		},
-		hasSuggestions: true,
+		fixable: 'code',
 		messages,
 	},
 };
```

</details>

Fixes ENG-7564.