### PR TITLE
chore(explore): Migrate useGetTraceItemAttributeValues to apiOptions

### DIFF
--- a/static/app/views/explore/hooks/useGetTraceItemAttributeValues.spec.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeValues.spec.tsx
@@ -1,4 +1,4 @@
-import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+import {act, renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {FieldKind} from 'sentry/utils/fields';
@@ -45,12 +45,9 @@ describe('useGetTraceItemAttributeValues', () => {
       ],
     });
 
-    const {result} = renderHookWithProviders(() =>
-      useGetTraceItemAttributeValues({
-        traceItemType: TraceItemDataset.LOGS,
-        type: 'string',
-      })
-    );
+    const {result} = renderHookWithProviders(useGetTraceItemAttributeValues, {
+      initialProps: {traceItemType: TraceItemDataset.LOGS, type: 'string'},
+    });
 
     const tag = {
       key: attributeKey,
@@ -60,7 +57,10 @@ describe('useGetTraceItemAttributeValues', () => {
 
     expect(searchQueryMock).not.toHaveBeenCalled();
 
-    const searchResults = await result.current({tag, searchQuery: 'search-query'});
+    let searchResults: string[] = [];
+    await act(async () => {
+      searchResults = await result.current({tag, searchQuery: 'search-query'});
+    });
 
     expect(searchQueryMock).toHaveBeenCalled();
     expect(searchResults).toEqual(['search-result']);
@@ -88,12 +88,9 @@ describe('useGetTraceItemAttributeValues', () => {
       ],
     });
 
-    const {result} = renderHookWithProviders(() =>
-      useGetTraceItemAttributeValues({
-        traceItemType: TraceItemDataset.LOGS,
-        type: 'number',
-      })
-    );
+    const {result} = renderHookWithProviders(useGetTraceItemAttributeValues, {
+      initialProps: {traceItemType: TraceItemDataset.LOGS, type: 'number'},
+    });
 
     const tag = {
       key: attributeKey,
@@ -103,7 +100,10 @@ describe('useGetTraceItemAttributeValues', () => {
 
     expect(searchQueryMock).not.toHaveBeenCalled();
 
-    const searchResults = await result.current({tag, searchQuery: 'search-query'});
+    let searchResults: string[] = [];
+    await act(async () => {
+      searchResults = await result.current({tag, searchQuery: 'search-query'});
+    });
 
     expect(searchQueryMock).not.toHaveBeenCalled();
     expect(searchResults).toEqual([]); // This will always return an empty array because we don't suggest values for numbers
@@ -130,12 +130,9 @@ describe('useGetTraceItemAttributeValues', () => {
       ],
     });
 
-    const {result} = renderHookWithProviders(() =>
-      useGetTraceItemAttributeValues({
-        traceItemType: TraceItemDataset.LOGS,
-        type: 'boolean',
-      })
-    );
+    const {result} = renderHookWithProviders(useGetTraceItemAttributeValues, {
+      initialProps: {traceItemType: TraceItemDataset.LOGS, type: 'boolean'},
+    });
 
     const tag = {
       key: attributeKey,
@@ -145,7 +142,10 @@ describe('useGetTraceItemAttributeValues', () => {
 
     expect(searchQueryMock).not.toHaveBeenCalled();
 
-    const searchResults = await result.current({tag, searchQuery: 'search-query'});
+    let searchResults: string[] = [];
+    await act(async () => {
+      searchResults = await result.current({tag, searchQuery: 'search-query'});
+    });
 
     expect(searchQueryMock).not.toHaveBeenCalled();
     expect(searchResults).toEqual([]); // This will always return an empty array because we don't suggest values for booleans

--- a/static/app/views/explore/hooks/useGetTraceItemAttributeValues.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeValues.tsx
@@ -5,17 +5,11 @@ import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import type {GetTagValuesParams} from 'sentry/components/searchQueryBuilder';
 import type {PageFilters} from 'sentry/types/core';
 import {defined} from 'sentry/utils';
-import {parseQueryKey} from 'sentry/utils/api/apiQueryKey';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {FieldKind} from 'sentry/utils/fields';
-import {type ApiQueryKey} from 'sentry/utils/queryClient';
-import {useApi} from 'sentry/utils/useApi';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {EXPLORE_FIVE_MIN_STALE_TIME} from 'sentry/views/explore/constants';
-import type {
-  TraceItemDataset,
-  UseTraceItemAttributeBaseProps,
-} from 'sentry/views/explore/types';
+import type {UseTraceItemAttributeBaseProps} from 'sentry/views/explore/types';
 
 interface TraceItemAttributeValue {
   first_seen: null;
@@ -31,61 +25,6 @@ interface UseGetTraceItemAttributeValuesProps extends UseTraceItemAttributeBaseP
   query?: string;
 }
 
-function traceItemAttributeValuesQueryKey({
-  orgSlug,
-  attributeKey,
-  search,
-  projectIds,
-  datetime,
-  traceItemType,
-  type = 'string',
-  query: filterQuery,
-}: {
-  attributeKey: string;
-  orgSlug: string;
-  traceItemType: TraceItemDataset;
-  datetime?: PageFilters['datetime'];
-  projectIds?: number[];
-  query?: string;
-  search?: string;
-  type?: 'string' | 'number' | 'boolean';
-}): ApiQueryKey {
-  const query: Record<string, string | string[] | number[]> = {
-    itemType: traceItemType,
-    attributeType: type,
-  };
-
-  if (filterQuery) {
-    query.query = filterQuery;
-  }
-
-  if (search) {
-    query.substringMatch = search;
-  }
-
-  if (projectIds?.length) {
-    query.project = projectIds.map(String);
-  }
-
-  if (datetime) {
-    Object.entries(normalizeDateTimeParams(datetime)).forEach(([key, value]) => {
-      if (value !== undefined) {
-        query[key] = value!;
-      }
-    });
-  }
-
-  return [
-    getApiUrl(
-      '/organizations/$organizationIdOrSlug/trace-items/attributes/$key/values/',
-      {
-        path: {organizationIdOrSlug: orgSlug, key: attributeKey},
-      }
-    ),
-    {query},
-  ];
-}
-
 /**
  * Hook to fetch trace item attribute values for the Explore interface.
  * This is designed to be used with the organization_trace_item_attributes endpoint.
@@ -97,7 +36,6 @@ export function useGetTraceItemAttributeValues({
   type,
   query: filterQuery,
 }: UseGetTraceItemAttributeValuesProps) {
-  const api = useApi();
   const organization = useOrganization();
   const {selection} = usePageFilters();
   const queryClient = useQueryClient();
@@ -109,29 +47,33 @@ export function useGetTraceItemAttributeValues({
         return Promise.resolve([]);
       }
 
-      const queryKey = traceItemAttributeValuesQueryKey({
-        orgSlug: organization.slug,
-        attributeKey: tag.key,
-        search: searchQuery,
-        projectIds: projectIds ?? selection.projects,
-        datetime: datetime ?? selection.datetime,
-        traceItemType,
-        type,
-        query: filterQuery,
-      });
+      const project =
+        projectIds && projectIds.length > 0
+          ? projectIds.map(String)
+          : selection.projects.map(String);
+      const datetimeParams = datetime
+        ? normalizeDateTimeParams(datetime)
+        : normalizeDateTimeParams(selection.datetime);
+
+      const options = apiOptions.as<TraceItemAttributeValue[]>()(
+        '/organizations/$organizationIdOrSlug/trace-items/attributes/$key/values/',
+        {
+          path: {organizationIdOrSlug: organization.slug, key: tag.key},
+          staleTime: EXPLORE_FIVE_MIN_STALE_TIME,
+          query: {
+            itemType: traceItemType,
+            attributeType: type,
+            query: filterQuery && filterQuery !== '' ? filterQuery : undefined,
+            substringMatch: searchQuery && searchQuery !== '' ? searchQuery : undefined,
+            project,
+            ...datetimeParams,
+          },
+        }
+      );
 
       try {
-        const {url, options} = parseQueryKey(queryKey);
-        const result = await queryClient.fetchQuery({
-          queryKey,
-          queryFn: () =>
-            api.requestPromise(url, {
-              method: 'GET',
-              query: {...options?.query},
-            }),
-          staleTime: EXPLORE_FIVE_MIN_STALE_TIME,
-        });
-        return result
+        const {json} = await queryClient.fetchQuery(options);
+        return json
           .filter((item: TraceItemAttributeValue) => defined(item.value))
           .map((item: TraceItemAttributeValue) => item.value);
       } catch (e) {


### PR DESCRIPTION
Small PR to migrate the `useGetTraceItemAttributeValues` over to `apiOptions`