### PR TITLE
feat(api): capture every HTTP 429 response to Sentry

### DIFF
--- a/src/sentry/api/handlers.py
+++ b/src/sentry/api/handlers.py
@@ -30,6 +30,11 @@ def custom_exception_handler(exc, context):
                 exc,
                 level="warning",
             )
+        # The ratelimit middleware also captures every 429 to Sentry; suppress
+        # that here so we don't double-fire for the Snuba path that has richer
+        # exception data.
+        if request is not None:
+            request._rate_limit_captured_to_sentry = True
         # let the client know that they've been rate limited with details
         exc = Throttled(detail=RATE_LIMIT_ERROR_MESSAGE)
 

--- a/src/sentry/middleware/ratelimit.py
+++ b/src/sentry/middleware/ratelimit.py
@@ -34,6 +34,46 @@ DEFAULT_CONCURRENT_ERROR_MESSAGE = (
 logger = logging.getLogger("sentry.api.rate-limit")
 
 
+class APIRateLimited(Exception):
+    """Synthetic exception used to capture HTTP 429 responses to Sentry."""
+
+
+def _capture_429_to_sentry(request: HttpRequest) -> None:
+    """Capture a Sentry event for any response that resulted in HTTP 429.
+
+    Called from process_response so it covers all sources of 429s:
+    - this middleware's own rate limiting
+    - DRF Throttled exceptions handled by custom_exception_handler
+    - endpoints that return Response(status=429) directly
+    """
+    if getattr(request, "_rate_limit_captured_to_sentry", False):
+        return
+    request._rate_limit_captured_to_sentry = True
+
+    try:
+        with sentry_sdk.new_scope() as scope:
+            scope.fingerprint = ["api-rate-limited-429"]
+            scope.set_tag("rate_limit.path", request.path)
+            if request.method:
+                scope.set_tag("rate_limit.method", request.method)
+
+            rate_limit_metadata: RateLimitMeta | None = getattr(
+                request, "rate_limit_metadata", None
+            )
+            if rate_limit_metadata is not None:
+                scope.set_extra("rate_limit_key", getattr(request, "rate_limit_key", None))
+                scope.set_extra("rate_limit_type", rate_limit_metadata.rate_limit_type.value)
+                scope.set_extra("limit", rate_limit_metadata.limit)
+                scope.set_extra("window", rate_limit_metadata.window)
+
+            try:
+                raise APIRateLimited(f"{request.method} {request.path} returned 429")
+            except APIRateLimited:
+                sentry_sdk.capture_exception(level="warning")
+    except Exception:
+        logger.exception("Failed to capture 429 to Sentry")
+
+
 def _normalize_and_min_limit(a_limit: int, a_window: int, b_limit: int, b_window: int) -> int:
     """Normalize two (limit, window) pairs and return the minimum of the two normalized values."""
     norm_a = a_limit / a_window if a_window and a_window >= 1 else a_limit
@@ -223,4 +263,8 @@ class RatelimitMiddleware:
                     finish_request(request.rate_limit_key, request.rate_limit_uid)
             except Exception:
                 logging.exception("COULD NOT POPULATE RATE LIMIT HEADERS")
+
+            if getattr(response, "status_code", None) == 429:
+                _capture_429_to_sentry(request)
+
             return response

--- a/tests/sentry/middleware/test_ratelimit_middleware.py
+++ b/tests/sentry/middleware/test_ratelimit_middleware.py
@@ -1,4 +1,3 @@
-from concurrent.futures import ThreadPoolExecutor
 from functools import cached_property
 from time import sleep, time
 from unittest.mock import MagicMock, patch, sentinel
@@ -20,6 +19,7 @@ from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.silo import all_silo_test, assume_test_silo_mode_of
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.users.models.user import User
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 
 
 @all_silo_test
@@ -89,6 +89,36 @@ class RatelimitMiddlewareTest(TestCase, BaseTestCase):
 
         bad_request = BadRequest()
         assert self.middleware.process_response(bad_request, bad_response) is bad_response
+
+    @patch("sentry.middleware.ratelimit.sentry_sdk.capture_exception")
+    def test_process_response_captures_429_to_sentry(
+        self, mock_capture_exception: MagicMock
+    ) -> None:
+        request = self.factory.get("/api/0/some-endpoint/")
+        response = HttpResponse(status=429)
+        assert self.middleware.process_response(request, response) is response
+        assert mock_capture_exception.call_count == 1
+        assert mock_capture_exception.call_args.kwargs == {"level": "warning"}
+
+    @patch("sentry.middleware.ratelimit.sentry_sdk.capture_exception")
+    def test_process_response_does_not_capture_non_429(
+        self, mock_capture_exception: MagicMock
+    ) -> None:
+        request = self.factory.get("/api/0/some-endpoint/")
+        for status in (200, 400, 403, 500):
+            response = HttpResponse(status=status)
+            self.middleware.process_response(request, response)
+        assert mock_capture_exception.call_count == 0
+
+    @patch("sentry.middleware.ratelimit.sentry_sdk.capture_exception")
+    def test_process_response_skips_capture_when_already_captured(
+        self, mock_capture_exception: MagicMock
+    ) -> None:
+        request = self.factory.get("/api/0/some-endpoint/")
+        request._rate_limit_captured_to_sentry = True
+        response = HttpResponse(status=429)
+        self.middleware.process_response(request, response)
+        assert mock_capture_exception.call_count == 0
 
     @patch("sentry.middleware.ratelimit.get_rate_limit_value")
     def test_positive_rate_limit_check(self, default_rate_limit_mock: MagicMock) -> None:
@@ -608,7 +638,7 @@ class TestConcurrentRateLimiter(APITestCase):
 
     def test_concurrent_request_rate_limiting(self) -> None:
         """test the concurrent rate limiter end to-end"""
-        with ThreadPoolExecutor(max_workers=4) as executor:
+        with ContextPropagatingThreadPoolExecutor(max_workers=4) as executor:
             futures = []
             # dispatch more simultaneous requests to the endpoint than the concurrent limit
             for _ in range(CONCURRENT_RATE_LIMIT + 1):


### PR DESCRIPTION
## Summary

Adds a centralized capture point in `RatelimitMiddleware.process_response` so every 429 returned by the API surfaces as a Sentry event with a stable fingerprint (`api-rate-limited-429`) and tags for path/method, plus ratelimit metadata when available.

This catches all 429 sources at one chokepoint:
- the rate limit middleware itself
- DRF `Throttled` exceptions handled by `custom_exception_handler`
- endpoints that return `Response(status=429)` directly

The existing Snuba `RateLimitExceeded` capture in `custom_exception_handler` (`src/sentry/api/handlers.py`) already produces a richer event, so it sets `request._rate_limit_captured_to_sentry = True` to suppress the middleware capture for that path.

## Why a synthetic exception?

We use a small `APIRateLimited` exception so we can call `sentry_sdk.capture_exception` (with `level="warning"`) and get a real stack trace pointing at the middleware. Captures live behind a try/except so a Sentry SDK failure can never break a request.

## Things to consider before merging
- **Volume**: this fires on _every_ 429 across the API. We may want to sample, gate behind an option, or only fire on specific categories before landing this for real.
- **Noise**: a hot endpoint hitting its limit could generate a lot of warning events. The fingerprint groups them all into one Sentry issue, but event count still matters.

## Test plan
- [x] `pytest tests/sentry/middleware/test_ratelimit_middleware.py` — adds 3 new tests covering capture-on-429, no-capture-on-other-status, and the dedup flag
- [x] `pytest tests/sentry/middleware/test_access_log_middleware.py` — verified Snuba 429 path still works
- [ ] Validate Sentry event volume on a canary before flipping on for everyone


Agent transcript: https://claudescope.sentry.dev/share/uLWPpAtNQVNiyIZ6tW6pWAWvAM7dkNrKqigo6ZlIErE