### PR TITLE
chore(cross-events): Remove disabled save button

### DIFF
--- a/static/app/views/explore/hooks/useSaveQuery.spec.tsx
+++ b/static/app/views/explore/hooks/useSaveQuery.spec.tsx
@@ -1,0 +1,140 @@
+import type {ReactNode} from 'react';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
+
+import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
+
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {useSpansSaveQuery} from 'sentry/views/explore/hooks/useSaveQuery';
+import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryParamsProvider';
+
+jest.mock('sentry/components/pageFilters/usePageFilters');
+
+const mockUsePageFilters = jest.mocked(usePageFilters);
+
+function Wrapper({children}: {children: ReactNode}) {
+  return <SpansQueryParamsProvider>{children}</SpansQueryParamsProvider>;
+}
+
+describe('useSpansSaveQuery', () => {
+  const organization = OrganizationFixture();
+
+  beforeEach(() => {
+    mockUsePageFilters.mockReturnValue({
+      isReady: true,
+      pinnedFilters: new Set(),
+      shouldPersist: true,
+      selection: PageFiltersFixture({
+        projects: [1],
+        environments: ['production'],
+        datetime: {
+          start: '2024-01-01T00:00:00.000Z',
+          end: '2024-01-01T01:00:00.000Z',
+          period: '1h',
+          utc: false,
+        },
+      }),
+    });
+  });
+
+  afterEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('saves cross event queries', async () => {
+    const saveQueryMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/explore/saved/`,
+      method: 'POST',
+      body: {id: 'new-query-id', name: 'New Query'},
+    });
+
+    const {result} = renderHookWithProviders(useSpansSaveQuery, {
+      organization,
+      additionalWrapper: Wrapper,
+      initialRouterConfig: {
+        location: {
+          pathname: '/traces/',
+          query: {
+            query: 'span.op:db',
+            mode: 'samples',
+            field: ['span.op', 'span.duration'],
+            sort: ['-span.duration'],
+            crossEvents: JSON.stringify([
+              {query: 'span.op:cache', type: 'spans'},
+              {query: 'severity:error', type: 'logs'},
+            ]),
+          },
+        },
+      },
+    });
+
+    await result.current.saveQuery('New Query', true);
+
+    expect(saveQueryMock).toHaveBeenCalledWith(
+      `/organizations/${organization.slug}/explore/saved/`,
+      expect.objectContaining({
+        method: 'POST',
+        data: expect.objectContaining({
+          name: 'New Query',
+          dataset: 'spans',
+          projects: [1],
+          environment: ['production'],
+          start: '2024-01-01T00:00:00.000Z',
+          end: '2024-01-01T01:00:00.000Z',
+          range: '1h',
+          query: [
+            expect.objectContaining({
+              fields: ['span.op', 'span.duration'],
+              orderby: '-span.duration',
+              query: 'span.op:db',
+            }),
+          ],
+          crossEvents: [
+            {query: 'span.op:cache', type: 'spans'},
+            {query: 'severity:error', type: 'logs'},
+          ],
+          starred: true,
+        }),
+      })
+    );
+  });
+
+  it('updates cross event queries', async () => {
+    const updateQueryMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/explore/saved/123/`,
+      method: 'PUT',
+      body: {id: '123', name: 'Existing Query'},
+    });
+
+    const {result} = renderHookWithProviders(useSpansSaveQuery, {
+      organization,
+      additionalWrapper: Wrapper,
+      initialRouterConfig: {
+        location: {
+          pathname: '/traces/',
+          query: {
+            id: '123',
+            title: 'Existing Query',
+            query: 'span.status:ok',
+            mode: 'samples',
+            crossEvents: JSON.stringify([{query: 'severity:info', type: 'logs'}]),
+          },
+        },
+      },
+    });
+
+    await result.current.updateQuery();
+
+    expect(updateQueryMock).toHaveBeenCalledWith(
+      `/organizations/${organization.slug}/explore/saved/123/`,
+      expect.objectContaining({
+        method: 'PUT',
+        data: expect.objectContaining({
+          name: 'Existing Query',
+          dataset: 'spans',
+          crossEvents: [{query: 'severity:info', type: 'logs'}],
+        }),
+      })
+    );
+  });
+});

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -886,7 +886,7 @@ describe('ExploreToolbar', () => {
     });
   });
 
-  it('disables save as and compare when cross events are present', async () => {
+  it('allows save as and compare when cross events are present', async () => {
     render(<ExploreToolbar />, {
       organization,
       additionalWrapper: Wrapper,
@@ -895,6 +895,10 @@ describe('ExploreToolbar', () => {
           pathname: '/traces/',
           query: {
             crossEvents: JSON.stringify([{query: '', type: 'spans'}]),
+            visualize: [
+              '{"chartType":1,"yAxes":["p95(span.duration)"]}',
+              '{"chartType":1,"yAxes":["count(span.duration)"]}',
+            ],
           },
         },
       },
@@ -902,10 +906,9 @@ describe('ExploreToolbar', () => {
 
     const section = await screen.findByTestId('section-save-as');
 
-    expect(within(section).getByRole('button', {name: 'Save as'})).toBeDisabled();
+    expect(within(section).getByRole('button', {name: 'Save as'})).toBeEnabled();
 
-    // Compare Queries button should be disabled (LinkButton renders with role="button")
-    expect(within(section).getByRole('button', {name: 'Compare'})).toHaveAttribute(
+    expect(within(section).getByRole('button', {name: 'Compare'})).not.toHaveAttribute(
       'aria-disabled',
       'true'
     );

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -886,7 +886,26 @@ describe('ExploreToolbar', () => {
     });
   });
 
-  it('allows save as and compare when cross events are present', async () => {
+  it('allows save as when cross events are present', async () => {
+    render(<ExploreToolbar />, {
+      organization,
+      additionalWrapper: Wrapper,
+      initialRouterConfig: {
+        location: {
+          pathname: '/traces/',
+          query: {
+            crossEvents: JSON.stringify([{query: '', type: 'spans'}]),
+          },
+        },
+      },
+    });
+
+    const section = await screen.findByTestId('section-save-as');
+
+    expect(within(section).getByRole('button', {name: 'Save as'})).toBeEnabled();
+  });
+
+  it('disables compare when cross events are present', async () => {
     render(<ExploreToolbar />, {
       organization,
       additionalWrapper: Wrapper,
@@ -906,9 +925,7 @@ describe('ExploreToolbar', () => {
 
     const section = await screen.findByTestId('section-save-as');
 
-    expect(within(section).getByRole('button', {name: 'Save as'})).toBeEnabled();
-
-    expect(within(section).getByRole('button', {name: 'Compare'})).not.toHaveAttribute(
+    expect(within(section).getByRole('button', {name: 'Compare'})).toHaveAttribute(
       'aria-disabled',
       'true'
     );

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -4,7 +4,6 @@ import * as Sentry from '@sentry/react';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
 import {Grid} from '@sentry/scraps/layout';
-import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {
   addErrorMessage,
@@ -88,10 +87,6 @@ export function ToolbarSaveAs() {
       : projects.find(p => p.id === `${pageFilters.selection.projects[0]}`);
 
   const {data: savedQuery, isLoading: isLoadingSavedQuery} = useGetSavedQuery(id);
-  const hasCrossEvents = defined(crossEvents) && crossEvents.length > 0;
-  const crossEventUnsupportedTooltip = t(
-    'Cross event queries currently only support saved queries.'
-  );
 
   const alertsUrls = visualizeYAxes.map((yAxis, index) => {
     const func = parseFunction(yAxis);
@@ -169,12 +164,11 @@ export function ToolbarSaveAs() {
 
   items.push({
     key: 'create-alert',
-    label: hasCrossEvents ? <DisabledText>{newAlertLabel}</DisabledText> : newAlertLabel,
+    label: newAlertLabel,
     textValue: newAlertLabel,
     children: alertsUrls ?? [],
-    disabled: hasCrossEvents || !alertsUrls || alertsUrls.length === 0,
+    disabled: !alertsUrls || alertsUrls.length === 0,
     isSubmenu: true,
-    tooltip: hasCrossEvents ? crossEventUnsupportedTooltip : undefined,
   });
 
   const disableAddToDashboard = !organization.features.includes('dashboards-edit');
@@ -210,9 +204,7 @@ export function ToolbarSaveAs() {
     key: 'add-to-dashboard',
     textValue: t('Dashboard widget'),
     isSubmenu: chartOptions.length > 1 ? true : false,
-    label: hasCrossEvents ? (
-      <DisabledText>{t('Dashboard widget')}</DisabledText>
-    ) : (
+    label: (
       <Feature
         hookName="feature-disabled:dashboards-edit"
         features="organizations:dashboards-edit"
@@ -221,11 +213,10 @@ export function ToolbarSaveAs() {
         {t('Dashboard widget')}
       </Feature>
     ),
-    disabled: hasCrossEvents || disableAddToDashboard,
+    disabled: disableAddToDashboard,
     children: chartOptions.length > 1 ? chartOptions : undefined,
-    tooltip: hasCrossEvents ? crossEventUnsupportedTooltip : undefined,
     onAction: () => {
-      if (hasCrossEvents || disableAddToDashboard || chartOptions.length > 1) {
+      if (disableAddToDashboard || chartOptions.length > 1) {
         return undefined;
       }
 
@@ -299,33 +290,28 @@ export function ToolbarSaveAs() {
   return (
     <SaveStyledToolbarSection data-test-id="section-save-as">
       <Grid flow="column" align="center" gap="md">
-        <Tooltip
-          disabled={!hasCrossEvents}
-          title={t('Saving cross event queries is not supported during early access.')}
-        >
-          <DropdownMenu
-            isDisabled={hasCrossEvents}
-            items={items}
-            trigger={triggerProps => (
-              <SaveAsButton
-                {...triggerProps}
-                priority={shouldHighlightSaveButton ? 'primary' : 'default'}
-                aria-label={t('Save as')}
-                onClick={e => {
-                  e.stopPropagation();
-                  e.preventDefault();
+        <DropdownMenu
+          items={items}
+          trigger={triggerProps => (
+            <SaveAsButton
+              {...triggerProps}
+              priority={shouldHighlightSaveButton ? 'primary' : 'default'}
+              aria-label={t('Save as')}
+              onClick={e => {
+                e.stopPropagation();
+                e.preventDefault();
 
-                  triggerProps.onClick?.(e);
-                }}
-              >
-                {shouldHighlightSaveButton ? t('Save') : t('Save as')}
-              </SaveAsButton>
-            )}
-          />
-        </Tooltip>
+                triggerProps.onClick?.(e);
+              }}
+            >
+              {shouldHighlightSaveButton ? t('Save') : t('Save as')}
+            </SaveAsButton>
+          )}
+        />
+
         <WideLinkButton
           aria-label={t('Compare')}
-          disabled={hasCrossEvents || !canCompareQueries}
+          disabled={!canCompareQueries}
           onClick={() =>
             trackAnalytics('trace_explorer.compare', {
               organization,
@@ -345,11 +331,9 @@ export function ToolbarSaveAs() {
             })),
           })}
           tooltipProps={
-            hasCrossEvents
-              ? {title: t('Comparing queries is not supported during early access.')}
-              : canCompareQueries
-                ? undefined
-                : {title: t('Add two or more charts to compare chart queries.')}
+            canCompareQueries
+              ? undefined
+              : {title: t('Add two or more charts to compare chart queries.')}
           }
         >
           {t('Compare Queries')}

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -87,6 +87,7 @@ export function ToolbarSaveAs() {
       : projects.find(p => p.id === `${pageFilters.selection.projects[0]}`);
 
   const {data: savedQuery, isLoading: isLoadingSavedQuery} = useGetSavedQuery(id);
+  const hasCrossEvents = defined(crossEvents) && crossEvents.length > 0;
 
   const alertsUrls = visualizeYAxes.map((yAxis, index) => {
     const func = parseFunction(yAxis);
@@ -311,7 +312,7 @@ export function ToolbarSaveAs() {
 
         <WideLinkButton
           aria-label={t('Compare')}
-          disabled={!canCompareQueries}
+          disabled={hasCrossEvents || !canCompareQueries}
           onClick={() =>
             trackAnalytics('trace_explorer.compare', {
               organization,
@@ -331,9 +332,11 @@ export function ToolbarSaveAs() {
             })),
           })}
           tooltipProps={
-            canCompareQueries
-              ? undefined
-              : {title: t('Add two or more charts to compare chart queries.')}
+            hasCrossEvents
+              ? {title: t('Cross-event queries cannot be compared.')}
+              : canCompareQueries
+                ? undefined
+                : {title: t('Add two or more charts to compare chart queries.')}
           }
         >
           {t('Compare Queries')}


### PR DESCRIPTION
Now that we're going full steam ahead with cross-event queries we're good to remove the disabled button, though the feature still lives behind the FF.

This PR also adds in missing tests from `useSaveQuery` around cross-event queries ensuring they're getting passed correctly to the API.

Closes EXP-666