### PR TITLE
fix(detectors): Clear out owners fields when transfering Detectors to a new org

### DIFF
--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -724,6 +724,11 @@ class Project(Model):
                 organization_id=organization.id
             )
 
+            # Null out detector owners — the owning team/user won't belong to the new org
+            Detector.objects.filter(id__in=detector_ids).exclude(
+                owner_team_id__isnull=True, owner_user_id__isnull=True
+            ).update(owner_team_id=None, owner_user_id=None)
+
         # Manually move over external issues to the new org
         linked_groups = GroupLink.objects.filter(project_id=self.id).values_list(
             "linked_id", flat=True

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -628,6 +628,24 @@ class ProjectTest(APITestCase, TestCase):
         assert workflow.organization_id == to_org.id
         assert when_condition_group.organization_id == to_org.id
 
+    def test_transfer_to_organization_nulls_detector_owner(self) -> None:
+        from_user = self.create_user()
+        from_org = self.create_organization(owner=from_user)
+        team = self.create_team(organization=from_org)
+        project = self.create_project(teams=[team])
+
+        to_user = self.create_user()
+        to_org = self.create_organization(owner=to_user)
+
+        detector = self.create_detector(project=project, owner_team_id=team.id, owner_user_id=None)
+
+        project.transfer_to(organization=to_org)
+
+        detector.refresh_from_db()
+
+        assert detector.owner_team_id is None
+        assert detector.owner_user_id is None
+
 
 class CopyProjectSettingsTest(TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
The owners aren't expected to belong to the new org.
Part of ISWF-2571.