### PR TITLE
fix(slack): Drop stale aggregateSort in explore unfurl when field is unknown

### DIFF
--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -227,6 +227,16 @@ def _resolve_display_type(chart_type: int | None, y_axes: list[str]) -> str:
     return "line"
 
 
+def _aggregate_sorts_are_valid(
+    sort_values: list[str], y_axes: list[str], group_bys: list[str]
+) -> bool:
+    # Mirrors the frontend's validateAggregateSort: drop sort if any entry
+    # references a field that isn't a current yAxis or groupBy, so the unfurl
+    # falls back to the default `-yAxes[0]` sort like the Explore UI does.
+    valid_targets = set(y_axes) | set(group_bys)
+    return all(sv.lstrip("-") in valid_targets for sv in sort_values)
+
+
 def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[str, Any]:
     """
     Extracts explore arguments from the explore link's query string.
@@ -309,7 +319,7 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
         query.setlist("query", query_values)
 
     sort_values = raw_query.getlist(dataset_config["sort_key"])
-    if sort_values:
+    if sort_values and _aggregate_sorts_are_valid(sort_values, y_axes, group_bys):
         query.setlist("sort", sort_values)
 
     # Metrics stores query and sort inside the metric JSON param

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -319,8 +319,13 @@ def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[
         query.setlist("query", query_values)
 
     sort_values = raw_query.getlist(dataset_config["sort_key"])
-    if sort_values and _aggregate_sorts_are_valid(sort_values, y_axes, group_bys):
-        query.setlist("sort", sort_values)
+    if sort_values:
+        # Only aggregate sorts (spans, metrics) need to reference an active
+        # yAxis or groupBy. Log sorts target table columns like `timestamp`
+        # and shouldn't be validated against aggregate fields.
+        is_aggregate_sort = dataset_config["sort_key"] == "aggregateSort"
+        if not is_aggregate_sort or _aggregate_sorts_are_valid(sort_values, y_axes, group_bys):
+            query.setlist("sort", sort_values)
 
     # Metrics stores query and sort inside the metric JSON param
     if metric_query:

--- a/src/sentry/integrations/slack/unfurl/explore.py
+++ b/src/sentry/integrations/slack/unfurl/explore.py
@@ -234,7 +234,7 @@ def _aggregate_sorts_are_valid(
     # references a field that isn't a current yAxis or groupBy, so the unfurl
     # falls back to the default `-yAxes[0]` sort like the Explore UI does.
     valid_targets = set(y_axes) | set(group_bys)
-    return all(sv.lstrip("-") in valid_targets for sv in sort_values)
+    return all(sort_value.lstrip("-") in valid_targets for sort_value in sort_values)
 
 
 def map_explore_query_args(url: str, args: Mapping[str, str | None]) -> Mapping[str, Any]:

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -1906,6 +1906,57 @@ class UnfurlTest(TestCase):
         assert args["query"].getlist("groupBy") == ["gen_ai.tool.name"]
         assert args["chart_type"] == 0
 
+    def test_unfurl_explore_drops_aggregate_sort_referencing_unknown_field(self) -> None:
+        # When aggregateSort references a function that isn't in the active
+        # yAxes (e.g. a stale sort left over from a different visualize), the
+        # frontend's validateAggregateSort discards it and falls back to
+        # `-yAxes[0]`. The unfurl must mirror that, otherwise events-timeseries
+        # gets sorted by an aggregate it never selected and returns no data.
+        url = (
+            "https://sentry.io/organizations/org1/explore/traces/"
+            "?aggregateField=%7B%22groupBy%22%3A%22gen_ai.tool.name%22%7D"
+            "&aggregateField=%7B%22yAxes%22%3A%5B%22count(span.duration)%22%5D%2C%22chartType%22%3A0%7D"
+            "&aggregateSort=-count_unique(user.id)"
+            "&project=1&query=user.id%3A12345&statsPeriod=30d"
+        )
+        link_type, args = match_link(url)
+
+        assert link_type == LinkType.EXPLORE
+        assert args is not None
+        assert args["query"].getlist("yAxis") == ["count(span.duration)"]
+        assert args["query"].getlist("groupBy") == ["gen_ai.tool.name"]
+        # The stale aggregateSort is dropped; unfurl_explore will then default
+        # to `-count(span.duration)` for the topEvents sort.
+        assert args["query"].getlist("sort") == []
+
+    def test_unfurl_explore_keeps_aggregate_sort_when_field_matches_yaxis(self) -> None:
+        url = (
+            "https://sentry.io/organizations/org1/explore/traces/"
+            "?aggregateField=%7B%22groupBy%22%3A%22gen_ai.tool.name%22%7D"
+            "&aggregateField=%7B%22yAxes%22%3A%5B%22count(span.duration)%22%5D%7D"
+            "&aggregateSort=-count(span.duration)"
+            "&project=1&statsPeriod=30d"
+        )
+        link_type, args = match_link(url)
+
+        assert link_type == LinkType.EXPLORE
+        assert args is not None
+        assert args["query"].getlist("sort") == ["-count(span.duration)"]
+
+    def test_unfurl_explore_keeps_aggregate_sort_when_field_matches_groupby(self) -> None:
+        url = (
+            "https://sentry.io/organizations/org1/explore/traces/"
+            "?aggregateField=%7B%22groupBy%22%3A%22gen_ai.tool.name%22%7D"
+            "&aggregateField=%7B%22yAxes%22%3A%5B%22count(span.duration)%22%5D%7D"
+            "&aggregateSort=gen_ai.tool.name"
+            "&project=1&statsPeriod=30d"
+        )
+        link_type, args = match_link(url)
+
+        assert link_type == LinkType.EXPLORE
+        assert args is not None
+        assert args["query"].getlist("sort") == ["gen_ai.tool.name"]
+
     def test_unfurl_explore_multi_aggregate_uses_first_chart(self) -> None:
         # Two charts: count with chartType=2 (area, first) and avg (second).
         # The unfurl must render only the first chart and not merge avg's


### PR DESCRIPTION
Fix Slack unfurls of Explore traces URLs that carry an `aggregateSort` referencing a function that isn't in the active `aggregateField` yAxes/groupBys (a stale sort left over from an earlier `visualize` selection).

Mirror the frontend's validateAggregateSort

Refs #114188