### PR TITLE
ref(snapshots): Add per-image diffThreshold support

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_snapshot.py
@@ -295,15 +295,23 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
         )
 
         first_class = SnapshotImageResponse.__fields__
+        global_threshold = manifest.diff_threshold
         image_list = [
             SnapshotImageResponse(
-                **{k: v for k, v in metadata.dict().items() if k not in first_class},
+                **{
+                    k: v
+                    for k, v in metadata.dict().items()
+                    if k not in first_class and k != "diff_threshold"
+                },
                 key=metadata.content_hash,
                 display_name=metadata.display_name,
                 image_file_name=key,
                 group=metadata.group,
                 width=metadata.width,
                 height=metadata.height,
+                diff_threshold=metadata.diff_threshold
+                if metadata.diff_threshold is not None
+                else global_threshold,
             )
             for key, metadata in sorted(manifest.images.items())
         ]

--- a/src/sentry/preprod/snapshots/manifest.py
+++ b/src/sentry/preprod/snapshots/manifest.py
@@ -11,6 +11,7 @@ class ImageMetadata(BaseModel):
     group: str | None = None
     width: int = Field(ge=0)
     height: int = Field(ge=0)
+    diff_threshold: float | None = Field(default=None, ge=0.0, lt=1.0)
 
     class Config:
         extra = "allow"

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -619,7 +619,14 @@ def compare_snapshots(
                         if diff_result.total_pixels > 0
                         else 0
                     )
-                    effective_threshold = diff_threshold if diff_threshold is not None else 0.0
+                    specific_image_diff_threshold = head_images[name].diff_threshold
+                    effective_threshold = (
+                        specific_image_diff_threshold
+                        if specific_image_diff_threshold is not None
+                        else diff_threshold
+                        if diff_threshold is not None
+                        else 0.0
+                    )
                     is_changed = diff_pct > effective_threshold
                     if is_changed:
                         changed_count += 1
@@ -627,9 +634,11 @@ def compare_snapshots(
                         unchanged_count += 1
 
                     logger.debug(
-                        "compare_snapshots: %s diff_pct=%.6f threshold=%s is_changed=%s pixels=%d/%d",
+                        "compare_snapshots: %s diff_pct=%.6f threshold=%s (per_image=%s global=%s) is_changed=%s pixels=%d/%d",
                         name,
                         diff_pct,
+                        effective_threshold,
+                        specific_image_diff_threshold,
                         diff_threshold,
                         is_changed,
                         diff_result.changed_pixels,


### PR DESCRIPTION
## Summary

Adds support for per-image `diff_threshold` values in snapshot comparisons. Previously, only a single global `diff_threshold` applied to all images. Now, individual images in the manifest can specify their own threshold, with per-image taking precedence over global.

**Changes:**
- Added optional `diff_threshold` field to `ImageMetadata` (validated to `[0.0, 1.0)`)
- Updated `compare_snapshots` task to resolve threshold with per-image > global > 0.0 fallback
- Resolved effective `diff_threshold` onto each `SnapshotImageResponse` in the API (per-image or global fallback), so it's visible in the frontend metadata tooltip
- Enhanced debug logging to show per-image and global threshold values