### PR TITLE
fix(dashboards): Use avatarType from API to render correct avatar in revision list

### DIFF
--- a/static/app/views/dashboards/dashboardRevisions.tsx
+++ b/static/app/views/dashboards/dashboardRevisions.tsx
@@ -138,17 +138,7 @@ function DashboardRevisionsModal({
                 isSelected={isNewestVersionSelected}
                 onSelect={() => setSelectedRevisionId(NEWEST_VERSION_ID)}
                 revisionSource={revisions?.[0]?.source ?? 'edit'}
-                createdBy={
-                  dashboardCreatedBy
-                    ? {
-                        id: dashboardCreatedBy.id,
-                        name: dashboardCreatedBy.name,
-                        email: dashboardCreatedBy.email,
-                        avatarType: dashboardCreatedBy.avatar?.avatarType,
-                        avatarUrl: dashboardCreatedBy.avatar?.avatarUrl ?? undefined,
-                      }
-                    : null
-                }
+                createdBy={dashboardCreatedBy ?? null}
                 dateCreated={null}
                 dashboardId={dashboardId}
                 baseRevisionId={displayedRevisions[0]?.id ?? null}

--- a/static/app/views/dashboards/dashboardRevisions.tsx
+++ b/static/app/views/dashboards/dashboardRevisions.tsx
@@ -138,7 +138,17 @@ function DashboardRevisionsModal({
                 isSelected={isNewestVersionSelected}
                 onSelect={() => setSelectedRevisionId(NEWEST_VERSION_ID)}
                 revisionSource={revisions?.[0]?.source ?? 'edit'}
-                createdBy={dashboardCreatedBy ?? null}
+                createdBy={
+                  dashboardCreatedBy
+                    ? {
+                        id: dashboardCreatedBy.id,
+                        name: dashboardCreatedBy.name,
+                        email: dashboardCreatedBy.email,
+                        avatarType: dashboardCreatedBy.avatar?.avatarType,
+                        avatarUrl: dashboardCreatedBy.avatar?.avatarUrl,
+                      }
+                    : null
+                }
                 dateCreated={null}
                 dashboardId={dashboardId}
                 baseRevisionId={displayedRevisions[0]?.id ?? null}

--- a/static/app/views/dashboards/dashboardRevisions.tsx
+++ b/static/app/views/dashboards/dashboardRevisions.tsx
@@ -145,7 +145,7 @@ function DashboardRevisionsModal({
                         name: dashboardCreatedBy.name,
                         email: dashboardCreatedBy.email,
                         avatarType: dashboardCreatedBy.avatar?.avatarType,
-                        avatarUrl: dashboardCreatedBy.avatar?.avatarUrl,
+                        avatarUrl: dashboardCreatedBy.avatar?.avatarUrl ?? undefined,
                       }
                     : null
                 }

--- a/static/app/views/dashboards/hooks/useDashboardRevisions.tsx
+++ b/static/app/views/dashboards/hooks/useDashboardRevisions.tsx
@@ -6,26 +6,60 @@ import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import type {DashboardDetails} from 'sentry/views/dashboards/types';
 
+// Sparse user shape that both the API response (after normalization) and a full
+// User object satisfy, so callers can pass either without mapping.
 export type RevisionCreatedBy = Pick<
   AvatarUser,
-  'email' | 'id' | 'name' | 'avatarUrl'
-> & {
+  'id' | 'name' | 'email' | 'avatar' | 'avatarUrl'
+>;
+
+// Raw shape returned by the revisions API — avatarType/avatarUrl are flat fields.
+type RawRevisionCreatedBy = {
+  email: string;
+  id: string;
+  name: string;
   avatarType?: Avatar['avatarType'] | null;
+  avatarUrl?: string | null;
 };
 
-export type DashboardRevision = {
-  createdBy: RevisionCreatedBy | null;
+type RawDashboardRevision = {
+  createdBy: RawRevisionCreatedBy | null;
   dateCreated: string;
   id: string;
   source: 'edit' | 'edit-with-agent' | 'pre-restore';
   title: string;
 };
 
+export type DashboardRevision = Omit<RawDashboardRevision, 'createdBy'> & {
+  createdBy: RevisionCreatedBy | null;
+};
+
+function normalizeRevision(raw: RawDashboardRevision): DashboardRevision {
+  return {
+    ...raw,
+    createdBy: raw.createdBy
+      ? {
+          id: raw.createdBy.id,
+          name: raw.createdBy.name,
+          email: raw.createdBy.email,
+          avatarUrl: raw.createdBy.avatarUrl ?? undefined,
+          avatar: raw.createdBy.avatarType
+            ? {
+                avatarType: raw.createdBy.avatarType,
+                avatarUrl: raw.createdBy.avatarUrl ?? null,
+                avatarUuid: null,
+              }
+            : undefined,
+        }
+      : null,
+  };
+}
+
 const REVISIONS_PATH =
   '/organizations/$organizationIdOrSlug/dashboards/$dashboardId/revisions/' as const;
 
 export function getDashboardRevisionsQueryKey(orgSlug: string, dashboardId: string) {
-  return apiOptions.as<DashboardRevision[]>()(REVISIONS_PATH, {
+  return apiOptions.as<RawDashboardRevision[]>()(REVISIONS_PATH, {
     path: {organizationIdOrSlug: orgSlug, dashboardId},
     staleTime: 30_000,
   }).queryKey;
@@ -37,12 +71,13 @@ interface UseDashboardRevisionsOptions {
 
 export function useDashboardRevisions({dashboardId}: UseDashboardRevisionsOptions) {
   const organization = useOrganization();
-  return useQuery(
-    apiOptions.as<DashboardRevision[]>()(REVISIONS_PATH, {
+  const {data, isPending, isError} = useQuery(
+    apiOptions.as<RawDashboardRevision[]>()(REVISIONS_PATH, {
       path: {organizationIdOrSlug: organization.slug, dashboardId},
       staleTime: 30_000,
     })
   );
+  return {data: data?.map(normalizeRevision), isPending, isError};
 }
 
 const REVISION_DETAILS_PATH =

--- a/static/app/views/dashboards/hooks/useDashboardRevisions.tsx
+++ b/static/app/views/dashboards/hooks/useDashboardRevisions.tsx
@@ -1,3 +1,4 @@
+import {useMemo} from 'react';
 import {skipToken, useQuery} from '@tanstack/react-query';
 
 import type {Avatar} from 'sentry/types/core';
@@ -84,7 +85,8 @@ export function useDashboardRevisions({dashboardId}: UseDashboardRevisionsOption
       staleTime: 30_000,
     })
   );
-  return {data: data?.map(normalizeRevision), isPending, isError};
+  const normalizedData = useMemo(() => data?.map(normalizeRevision), [data]);
+  return {data: normalizedData, isPending, isError};
 }
 
 const REVISION_DETAILS_PATH =

--- a/static/app/views/dashboards/hooks/useDashboardRevisions.tsx
+++ b/static/app/views/dashboards/hooks/useDashboardRevisions.tsx
@@ -6,9 +6,11 @@ import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import type {DashboardDetails} from 'sentry/views/dashboards/types';
 
-export type RevisionCreatedBy = Pick<AvatarUser, 'email' | 'id' | 'name'> & {
+export type RevisionCreatedBy = Pick<
+  AvatarUser,
+  'email' | 'id' | 'name' | 'avatarUrl'
+> & {
   avatarType?: Avatar['avatarType'] | null;
-  avatarUrl?: string | null;
 };
 
 export type DashboardRevision = {

--- a/static/app/views/dashboards/hooks/useDashboardRevisions.tsx
+++ b/static/app/views/dashboards/hooks/useDashboardRevisions.tsx
@@ -1,17 +1,18 @@
 import {skipToken, useQuery} from '@tanstack/react-query';
 
+import type {Avatar} from 'sentry/types/core';
+import type {AvatarUser} from 'sentry/types/user';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import type {DashboardDetails} from 'sentry/views/dashboards/types';
 
+export type RevisionCreatedBy = Pick<AvatarUser, 'email' | 'id' | 'name'> & {
+  avatarType?: Avatar['avatarType'] | null;
+  avatarUrl?: string | null;
+};
+
 export type DashboardRevision = {
-  createdBy: {
-    email: string;
-    id: string;
-    name: string;
-    avatarType?: string | null;
-    avatarUrl?: string | null;
-  } | null;
+  createdBy: RevisionCreatedBy | null;
   dateCreated: string;
   id: string;
   source: 'edit' | 'edit-with-agent' | 'pre-restore';

--- a/static/app/views/dashboards/hooks/useDashboardRevisions.tsx
+++ b/static/app/views/dashboards/hooks/useDashboardRevisions.tsx
@@ -40,7 +40,10 @@ export type DashboardRevision = {
 
 function normalizeRevision(raw: RawDashboardRevision): DashboardRevision {
   return {
-    ...raw,
+    id: raw.id,
+    dateCreated: raw.dateCreated,
+    source: raw.source,
+    title: raw.title,
     createdBy: raw.createdBy
       ? {
           id: raw.createdBy.id,

--- a/static/app/views/dashboards/hooks/useDashboardRevisions.tsx
+++ b/static/app/views/dashboards/hooks/useDashboardRevisions.tsx
@@ -5,7 +5,13 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import type {DashboardDetails} from 'sentry/views/dashboards/types';
 
 export type DashboardRevision = {
-  createdBy: {email: string; id: string; name: string; avatarUrl?: string | null} | null;
+  createdBy: {
+    email: string;
+    id: string;
+    name: string;
+    avatarType?: string | null;
+    avatarUrl?: string | null;
+  } | null;
   dateCreated: string;
   id: string;
   source: 'edit' | 'edit-with-agent' | 'pre-restore';

--- a/static/app/views/dashboards/hooks/useDashboardRevisions.tsx
+++ b/static/app/views/dashboards/hooks/useDashboardRevisions.tsx
@@ -8,7 +8,7 @@ import type {DashboardDetails} from 'sentry/views/dashboards/types';
 
 // Sparse user shape that both the API response (after normalization) and a full
 // User object satisfy, so callers can pass either without mapping.
-export type RevisionCreatedBy = Pick<
+type RevisionCreatedBy = Pick<
   AvatarUser,
   'id' | 'name' | 'email' | 'avatar' | 'avatarUrl'
 >;

--- a/static/app/views/dashboards/hooks/useDashboardRevisions.tsx
+++ b/static/app/views/dashboards/hooks/useDashboardRevisions.tsx
@@ -30,8 +30,12 @@ type RawDashboardRevision = {
   title: string;
 };
 
-export type DashboardRevision = Omit<RawDashboardRevision, 'createdBy'> & {
+export type DashboardRevision = {
   createdBy: RevisionCreatedBy | null;
+  dateCreated: string;
+  id: string;
+  source: 'edit' | 'edit-with-agent' | 'pre-restore';
+  title: string;
 };
 
 function normalizeRevision(raw: RawDashboardRevision): DashboardRevision {

--- a/static/app/views/dashboards/revisionListItem.spec.tsx
+++ b/static/app/views/dashboards/revisionListItem.spec.tsx
@@ -147,6 +147,23 @@ describe('RevisionListItem', () => {
     );
   });
 
+  it('renders a gravatar avatar container when avatarType is gravatar', () => {
+    MockApiClient.addMockResponse({url: SNAPSHOT_URL, body: makeSnapshot()});
+    MockApiClient.addMockResponse({url: BASE_SNAPSHOT_URL, body: makeSnapshot()});
+
+    renderItem({
+      createdBy: {
+        id: '42',
+        name: 'Alice',
+        email: 'alice@example.com',
+        avatarType: 'gravatar',
+        avatarUrl: null,
+      },
+    });
+
+    expect(screen.getByTestId('gravatar-avatar')).toBeInTheDocument();
+  });
+
   it('shows "Unknown" when createdBy is null', async () => {
     MockApiClient.addMockResponse({url: SNAPSHOT_URL, body: makeSnapshot()});
     MockApiClient.addMockResponse({url: BASE_SNAPSHOT_URL, body: makeSnapshot()});

--- a/static/app/views/dashboards/revisionListItem.spec.tsx
+++ b/static/app/views/dashboards/revisionListItem.spec.tsx
@@ -157,7 +157,6 @@ describe('RevisionListItem', () => {
         name: 'Alice',
         email: 'alice@example.com',
         avatarType: 'gravatar',
-        avatarUrl: null,
       },
     });
 

--- a/static/app/views/dashboards/revisionListItem.spec.tsx
+++ b/static/app/views/dashboards/revisionListItem.spec.tsx
@@ -132,7 +132,13 @@ describe('RevisionListItem', () => {
 
     const avatarUrl = 'https://example.com/avatar.jpg';
     renderItem({
-      createdBy: {id: '42', name: 'Alice', email: 'alice@example.com', avatarUrl},
+      createdBy: {
+        id: '42',
+        name: 'Alice',
+        email: 'alice@example.com',
+        avatarType: 'upload',
+        avatarUrl,
+      },
     });
 
     expect(await screen.findByRole('img', {name: 'Alice'})).toHaveAttribute(

--- a/static/app/views/dashboards/revisionListItem.spec.tsx
+++ b/static/app/views/dashboards/revisionListItem.spec.tsx
@@ -136,8 +136,7 @@ describe('RevisionListItem', () => {
         id: '42',
         name: 'Alice',
         email: 'alice@example.com',
-        avatarType: 'upload',
-        avatarUrl,
+        avatar: {avatarType: 'upload', avatarUrl, avatarUuid: null},
       },
     });
 
@@ -156,7 +155,7 @@ describe('RevisionListItem', () => {
         id: '42',
         name: 'Alice',
         email: 'alice@example.com',
-        avatarType: 'gravatar',
+        avatar: {avatarType: 'gravatar', avatarUrl: null, avatarUuid: null},
       },
     });
 

--- a/static/app/views/dashboards/revisionListItem.stories.tsx
+++ b/static/app/views/dashboards/revisionListItem.stories.tsx
@@ -13,7 +13,7 @@ const CAROL = {
   id: '3',
   name: 'Carol',
   email: 'carol@example.com',
-  avatarType: 'upload',
+  avatarType: 'upload' as const,
   avatarUrl: 'https://gravatar.com/avatar/00000000000000000000000000000000?d=mp&s=120',
 };
 const DATE = '2024-06-01T10:00:00Z';

--- a/static/app/views/dashboards/revisionListItem.stories.tsx
+++ b/static/app/views/dashboards/revisionListItem.stories.tsx
@@ -13,8 +13,11 @@ const CAROL = {
   id: '3',
   name: 'Carol',
   email: 'carol@example.com',
-  avatarType: 'upload' as const,
-  avatarUrl: 'https://gravatar.com/avatar/00000000000000000000000000000000?d=mp&s=120',
+  avatar: {
+    avatarType: 'upload' as const,
+    avatarUrl: 'https://gravatar.com/avatar/00000000000000000000000000000000?d=mp&s=120',
+    avatarUuid: null,
+  },
 };
 const DATE = '2024-06-01T10:00:00Z';
 const DATE_OLDER = '2024-05-28T09:00:00Z';

--- a/static/app/views/dashboards/revisionListItem.stories.tsx
+++ b/static/app/views/dashboards/revisionListItem.stories.tsx
@@ -13,6 +13,7 @@ const CAROL = {
   id: '3',
   name: 'Carol',
   email: 'carol@example.com',
+  avatarType: 'upload',
   avatarUrl: 'https://gravatar.com/avatar/00000000000000000000000000000000?d=mp&s=120',
 };
 const DATE = '2024-06-01T10:00:00Z';

--- a/static/app/views/dashboards/revisionListItem.tsx
+++ b/static/app/views/dashboards/revisionListItem.tsx
@@ -23,7 +23,13 @@ import type {DashboardDetails} from './types';
 
 interface RevisionListItemProps {
   baseRevisionId: string | null;
-  createdBy: {email: string; id: string; name: string; avatarUrl?: string | null} | null;
+  createdBy: {
+    email: string;
+    id: string;
+    name: string;
+    avatarType?: string | null;
+    avatarUrl?: string | null;
+  } | null;
   dashboardId: string;
   dateCreated: string | null;
   isSelected: boolean;
@@ -97,8 +103,12 @@ export function RevisionListItem({
         email: createdBy.email,
         ip_address: '',
         username: createdBy.email,
-        avatar: createdBy.avatarUrl
-          ? {avatarType: 'upload', avatarUrl: createdBy.avatarUrl, avatarUuid: null}
+        avatar: createdBy.avatarType
+          ? {
+              avatarType: createdBy.avatarType,
+              avatarUrl: createdBy.avatarUrl ?? null,
+              avatarUuid: null,
+            }
           : undefined,
       } as User)
     : null;

--- a/static/app/views/dashboards/revisionListItem.tsx
+++ b/static/app/views/dashboards/revisionListItem.tsx
@@ -21,9 +21,13 @@ import type {WidgetChange} from './dashboardRevisionsDiff';
 import {diffFilters, diffWidgets, formatProjectIds} from './dashboardRevisionsDiff';
 import type {DashboardDetails} from './types';
 
+function isUser(createdBy: User | RevisionCreatedBy): createdBy is User {
+  return 'ip_address' in createdBy;
+}
+
 interface RevisionListItemProps {
   baseRevisionId: string | null;
-  createdBy: RevisionCreatedBy | null;
+  createdBy: User | RevisionCreatedBy | null;
   dashboardId: string;
   dateCreated: string | null;
   isSelected: boolean;
@@ -91,20 +95,22 @@ export function RevisionListItem({
   const isError = (!snapshotOverride && isSnapshotError) || isBaseError;
 
   const userForAvatar = createdBy
-    ? ({
-        id: createdBy.id,
-        name: createdBy.name,
-        email: createdBy.email,
-        ip_address: '',
-        username: createdBy.email,
-        avatar: createdBy.avatarType
-          ? {
-              avatarType: createdBy.avatarType,
-              avatarUrl: createdBy.avatarUrl ?? null,
-              avatarUuid: null,
-            }
-          : undefined,
-      } as User)
+    ? isUser(createdBy)
+      ? createdBy
+      : ({
+          id: createdBy.id,
+          name: createdBy.name,
+          email: createdBy.email,
+          ip_address: '',
+          username: createdBy.email,
+          avatar: createdBy.avatarType
+            ? {
+                avatarType: createdBy.avatarType,
+                avatarUrl: createdBy.avatarUrl ?? null,
+                avatarUuid: null,
+              }
+            : undefined,
+        } as User)
     : null;
 
   return (

--- a/static/app/views/dashboards/revisionListItem.tsx
+++ b/static/app/views/dashboards/revisionListItem.tsx
@@ -14,20 +14,16 @@ import type {User} from 'sentry/types/user';
 import type {TagVariant} from 'sentry/utils/theme';
 import {useProjects} from 'sentry/utils/useProjects';
 
-import type {DashboardRevision, RevisionCreatedBy} from './hooks/useDashboardRevisions';
+import type {DashboardRevision} from './hooks/useDashboardRevisions';
 import {useDashboardRevisionDetails} from './hooks/useDashboardRevisions';
 import {DISPLAY_TYPE_ICONS} from './widgetBuilder/components/typeSelector';
 import type {WidgetChange} from './dashboardRevisionsDiff';
 import {diffFilters, diffWidgets, formatProjectIds} from './dashboardRevisionsDiff';
 import type {DashboardDetails} from './types';
 
-function isUser(createdBy: User | RevisionCreatedBy): createdBy is User {
-  return 'ip_address' in createdBy;
-}
-
 interface RevisionListItemProps {
   baseRevisionId: string | null;
-  createdBy: User | RevisionCreatedBy | null;
+  createdBy: DashboardRevision['createdBy'];
   dashboardId: string;
   dateCreated: string | null;
   isSelected: boolean;
@@ -95,22 +91,7 @@ export function RevisionListItem({
   const isError = (!snapshotOverride && isSnapshotError) || isBaseError;
 
   const userForAvatar = createdBy
-    ? isUser(createdBy)
-      ? createdBy
-      : ({
-          id: createdBy.id,
-          name: createdBy.name,
-          email: createdBy.email,
-          ip_address: '',
-          username: createdBy.email,
-          avatar: createdBy.avatarType
-            ? {
-                avatarType: createdBy.avatarType,
-                avatarUrl: createdBy.avatarUrl ?? null,
-                avatarUuid: null,
-              }
-            : undefined,
-        } as User)
+    ? ({...createdBy, ip_address: '', username: createdBy.email} as User)
     : null;
 
   return (

--- a/static/app/views/dashboards/revisionListItem.tsx
+++ b/static/app/views/dashboards/revisionListItem.tsx
@@ -14,7 +14,7 @@ import type {User} from 'sentry/types/user';
 import type {TagVariant} from 'sentry/utils/theme';
 import {useProjects} from 'sentry/utils/useProjects';
 
-import type {DashboardRevision} from './hooks/useDashboardRevisions';
+import type {DashboardRevision, RevisionCreatedBy} from './hooks/useDashboardRevisions';
 import {useDashboardRevisionDetails} from './hooks/useDashboardRevisions';
 import {DISPLAY_TYPE_ICONS} from './widgetBuilder/components/typeSelector';
 import type {WidgetChange} from './dashboardRevisionsDiff';
@@ -23,13 +23,7 @@ import type {DashboardDetails} from './types';
 
 interface RevisionListItemProps {
   baseRevisionId: string | null;
-  createdBy: {
-    email: string;
-    id: string;
-    name: string;
-    avatarType?: string | null;
-    avatarUrl?: string | null;
-  } | null;
+  createdBy: RevisionCreatedBy | null;
   dashboardId: string;
   dateCreated: string | null;
   isSelected: boolean;


### PR DESCRIPTION
After #114186, we have the avatar type being returned in the revision list endpoint.

We should pass that into the avatar component so that it properly shows initials vs upload vs gravatar.

The current-version row in the modal passes a full `User` object whose avatar info is nested under `avatar.avatarType`. That field is now explicitly mapped to the flat `createdBy` prop shape so it follows the same rendering path as historical revision rows.

