### PR TITLE
feat(explore): Short circuit attribute value requests

### DIFF
--- a/static/app/views/explore/hooks/useGetTraceItemAttributeValues.spec.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeValues.spec.tsx
@@ -1,12 +1,81 @@
+import type {ReactNode} from 'react';
+import {QueryClientProvider, type QueryClient} from '@tanstack/react-query';
+
+import {makeTestQueryClient} from 'sentry-test/queryClient';
 import {act, renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {FieldKind} from 'sentry/utils/fields';
 import {useGetTraceItemAttributeValues} from 'sentry/views/explore/hooks/useGetTraceItemAttributeValues';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
 describe('useGetTraceItemAttributeValues', () => {
   const attributeKey = 'test.attribute';
+  const tag = {
+    key: attributeKey,
+    name: attributeKey,
+    kind: FieldKind.TAG,
+  };
+
+  function makeWrapper(queryClient: QueryClient) {
+    return function Wrapper({children}: {children?: ReactNode}) {
+      return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+    };
+  }
+
+  function makeAttributeValue(value: string, key = attributeKey) {
+    return {
+      key,
+      value,
+      first_seen: null,
+      last_seen: null,
+      times_seen: null,
+    };
+  }
+
+  function addAttributeValuesMock({
+    body,
+    key = attributeKey,
+    query = {},
+    substringMatch,
+  }: {
+    body: Array<ReturnType<typeof makeAttributeValue>>;
+    substringMatch: string;
+    key?: string;
+    query?: Record<string, unknown>;
+  }) {
+    return MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/trace-items/attributes/${key}/values/`,
+      body,
+      match: [
+        MockApiClient.matchQuery({
+          attributeType: 'string',
+          itemType: TraceItemDataset.LOGS,
+          project: ['1'],
+          statsPeriod: '14d',
+          substringMatch,
+          ...query,
+        }),
+      ],
+    });
+  }
+
+  function renderValuesHook({
+    queryClient = makeTestQueryClient(),
+    ...initialProps
+  }: Partial<Parameters<typeof useGetTraceItemAttributeValues>[0]> & {
+    queryClient?: QueryClient;
+  } = {}) {
+    return renderHookWithProviders(useGetTraceItemAttributeValues, {
+      additionalWrapper: makeWrapper(queryClient),
+      initialProps: {
+        traceItemType: TraceItemDataset.LOGS,
+        type: 'string',
+        ...initialProps,
+      },
+    });
+  }
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
@@ -25,18 +94,9 @@ describe('useGetTraceItemAttributeValues', () => {
   });
 
   it('getTraceItemAttributeValues works correctly for string type', async () => {
-    const mockSearchResponse = [
-      {
-        key: attributeKey,
-        value: 'search-result',
-        first_seen: null,
-        last_seen: null,
-        times_seen: null,
-      },
-    ];
     const searchQueryMock = MockApiClient.addMockResponse({
       url: `/organizations/org-slug/trace-items/attributes/${attributeKey}/values/`,
-      body: mockSearchResponse,
+      body: [makeAttributeValue('search-result')],
       match: [
         (_url, options) => {
           const query = options?.query || {};
@@ -45,15 +105,7 @@ describe('useGetTraceItemAttributeValues', () => {
       ],
     });
 
-    const {result} = renderHookWithProviders(useGetTraceItemAttributeValues, {
-      initialProps: {traceItemType: TraceItemDataset.LOGS, type: 'string'},
-    });
-
-    const tag = {
-      key: attributeKey,
-      name: attributeKey,
-      kind: FieldKind.TAG,
-    };
+    const {result} = renderValuesHook();
 
     expect(searchQueryMock).not.toHaveBeenCalled();
 
@@ -67,19 +119,9 @@ describe('useGetTraceItemAttributeValues', () => {
   });
 
   it('getTraceItemAttributeValues returns empty array for number type', async () => {
-    const mockSearchResponse = [
-      {
-        key: attributeKey,
-        value: 'search-result',
-        first_seen: null,
-        last_seen: null,
-        times_seen: null,
-      },
-    ];
-
     const searchQueryMock = MockApiClient.addMockResponse({
       url: `/organizations/org-slug/trace-items/attributes/${attributeKey}/values/`,
-      body: mockSearchResponse,
+      body: [makeAttributeValue('search-result')],
       match: [
         (_url, options) => {
           const query = options?.query || {};
@@ -91,12 +133,6 @@ describe('useGetTraceItemAttributeValues', () => {
     const {result} = renderHookWithProviders(useGetTraceItemAttributeValues, {
       initialProps: {traceItemType: TraceItemDataset.LOGS, type: 'number'},
     });
-
-    const tag = {
-      key: attributeKey,
-      name: attributeKey,
-      kind: FieldKind.TAG,
-    };
 
     expect(searchQueryMock).not.toHaveBeenCalled();
 
@@ -110,18 +146,9 @@ describe('useGetTraceItemAttributeValues', () => {
   });
 
   it('getTraceItemAttributeValues returns empty array for boolean type', async () => {
-    const mockSearchResponse = [
-      {
-        key: attributeKey,
-        value: 'true',
-        first_seen: null,
-        last_seen: null,
-        times_seen: null,
-      },
-    ];
     const searchQueryMock = MockApiClient.addMockResponse({
       url: `/organizations/org-slug/trace-items/attributes/${attributeKey}/values/`,
-      body: mockSearchResponse,
+      body: [makeAttributeValue('true')],
       match: [
         (_url, options) => {
           const query = options?.query || {};
@@ -134,12 +161,6 @@ describe('useGetTraceItemAttributeValues', () => {
       initialProps: {traceItemType: TraceItemDataset.LOGS, type: 'boolean'},
     });
 
-    const tag = {
-      key: attributeKey,
-      name: attributeKey,
-      kind: FieldKind.TAG,
-    };
-
     expect(searchQueryMock).not.toHaveBeenCalled();
 
     let searchResults: string[] = [];
@@ -149,5 +170,183 @@ describe('useGetTraceItemAttributeValues', () => {
 
     expect(searchQueryMock).not.toHaveBeenCalled();
     expect(searchResults).toEqual([]); // This will always return an empty array because we don't suggest values for booleans
+  });
+
+  it('reuses a fresh cached empty response from a shorter prefix', async () => {
+    const prefixRequest = addAttributeValuesMock({substringMatch: 'fo', body: []});
+    const longerRequest = addAttributeValuesMock({
+      substringMatch: 'foo',
+      body: [makeAttributeValue('foo-value')],
+    });
+
+    const {result} = renderValuesHook();
+
+    let prefixResults: string[] = [];
+    let longerResults: string[] = [];
+    await act(async () => {
+      prefixResults = await result.current({tag, searchQuery: 'fo'});
+      longerResults = await result.current({tag, searchQuery: 'foo'});
+    });
+
+    expect(prefixResults).toEqual([]);
+    expect(longerResults).toEqual([]);
+    expect(prefixRequest).toHaveBeenCalledTimes(1);
+    expect(longerRequest).not.toHaveBeenCalled();
+  });
+
+  it('does not reuse non-empty cached prefix results', async () => {
+    const prefixRequest = addAttributeValuesMock({
+      substringMatch: 'fo',
+      body: [makeAttributeValue('foo')],
+    });
+    const longerRequest = addAttributeValuesMock({
+      substringMatch: 'foo',
+      body: [makeAttributeValue('foo-value')],
+    });
+
+    const {result} = renderValuesHook();
+
+    let prefixResults: string[] = [];
+    let longerResults: string[] = [];
+    await act(async () => {
+      prefixResults = await result.current({tag, searchQuery: 'fo'});
+      longerResults = await result.current({tag, searchQuery: 'foo'});
+    });
+
+    expect(prefixResults).toEqual(['foo']);
+    expect(longerResults).toEqual(['foo-value']);
+    expect(prefixRequest).toHaveBeenCalledTimes(1);
+    expect(longerRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('scopes cache reuse to otherwise-identical value query options', async () => {
+    addAttributeValuesMock({substringMatch: 'fo', body: []});
+
+    const queryClient = makeTestQueryClient();
+    const {result, rerender} = renderValuesHook({queryClient});
+
+    await act(async () => {
+      await result.current({tag, searchQuery: 'fo'});
+    });
+
+    const scopedCases: Array<{
+      expectedQuery: Record<string, unknown>;
+      name: string;
+      hookProps?: Partial<Parameters<typeof useGetTraceItemAttributeValues>[0]>;
+      tagKey?: string;
+    }> = [
+      {
+        name: 'attribute key',
+        tagKey: 'other.attribute',
+        expectedQuery: {},
+      },
+      {
+        name: 'item type',
+        hookProps: {traceItemType: TraceItemDataset.SPANS},
+        expectedQuery: {itemType: TraceItemDataset.SPANS},
+      },
+      {
+        name: 'project',
+        hookProps: {projectIds: [2]},
+        expectedQuery: {project: ['2']},
+      },
+      {
+        name: 'datetime',
+        hookProps: {
+          datetime: {
+            end: null,
+            period: '7d',
+            start: null,
+            utc: false,
+          },
+        },
+        expectedQuery: {statsPeriod: '7d'},
+      },
+      {
+        name: 'filter query',
+        hookProps: {query: 'severity:error'},
+        expectedQuery: {query: 'severity:error'},
+      },
+    ];
+
+    for (const scopedCase of scopedCases) {
+      const key = scopedCase.tagKey ?? attributeKey;
+      const longerRequest = addAttributeValuesMock({
+        key,
+        substringMatch: 'foo',
+        body: [makeAttributeValue(`${scopedCase.name}-value`, key)],
+        query: scopedCase.expectedQuery,
+      });
+
+      rerender({
+        traceItemType: TraceItemDataset.LOGS,
+        type: 'string',
+        ...scopedCase.hookProps,
+      });
+
+      let results: string[] = [];
+      await act(async () => {
+        results = await result.current({
+          tag: {
+            key,
+            name: key,
+            kind: FieldKind.TAG,
+          },
+          searchQuery: 'foo',
+        });
+      });
+
+      expect(results).toEqual([`${scopedCase.name}-value`]);
+      expect(longerRequest).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it('scopes cache reuse to attribute type', async () => {
+    const queryClient = makeTestQueryClient();
+    const cachedBooleanPrefixRequest = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/trace-items/attributes/${attributeKey}/values/`,
+      body: [],
+      match: [
+        MockApiClient.matchQuery({
+          attributeType: 'boolean',
+          itemType: TraceItemDataset.LOGS,
+          project: ['1'],
+          statsPeriod: '14d',
+          substringMatch: 'fo',
+        }),
+      ],
+    });
+
+    await queryClient.fetchQuery(
+      apiOptions.as<Array<ReturnType<typeof makeAttributeValue>>>()(
+        '/organizations/$organizationIdOrSlug/trace-items/attributes/$key/values/',
+        {
+          path: {organizationIdOrSlug: 'org-slug', key: attributeKey},
+          staleTime: 10_000,
+          query: {
+            attributeType: 'boolean',
+            itemType: TraceItemDataset.LOGS,
+            project: ['1'],
+            statsPeriod: '14d',
+            substringMatch: 'fo',
+          },
+        }
+      )
+    );
+
+    const longerRequest = addAttributeValuesMock({
+      substringMatch: 'foo',
+      body: [makeAttributeValue('foo-value')],
+    });
+    const {result} = renderValuesHook({queryClient});
+
+    let results: string[] = [];
+    await act(async () => {
+      results = await result.current({tag, searchQuery: 'foo'});
+    });
+
+    expect(results).toEqual(['foo-value']);
+    expect(cachedBooleanPrefixRequest).toHaveBeenCalledTimes(1);
+    expect(longerRequest).toHaveBeenCalledTimes(1);
   });
 });

--- a/static/app/views/explore/hooks/useGetTraceItemAttributeValues.tsx
+++ b/static/app/views/explore/hooks/useGetTraceItemAttributeValues.tsx
@@ -1,4 +1,9 @@
-import {useMutation, useQueryClient} from '@tanstack/react-query';
+import {
+  queryOptions,
+  useMutation,
+  useQueryClient,
+  type QueryFunctionContext,
+} from '@tanstack/react-query';
 
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
@@ -6,10 +11,12 @@ import type {GetTagValuesParams} from 'sentry/components/searchQueryBuilder';
 import type {PageFilters} from 'sentry/types/core';
 import {defined} from 'sentry/utils';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
+import type {ApiQueryKey} from 'sentry/utils/api/apiQueryKey';
 import {FieldKind} from 'sentry/utils/fields';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {EXPLORE_FIVE_MIN_STALE_TIME} from 'sentry/views/explore/constants';
 import type {UseTraceItemAttributeBaseProps} from 'sentry/views/explore/types';
+import {findFreshEmptyPrefixSearchCacheMatch} from 'sentry/views/explore/utils/findFreshEmptyPrefixSearchCacheMatch';
 
 interface TraceItemAttributeValue {
   first_seen: null;
@@ -63,16 +70,31 @@ export function useGetTraceItemAttributeValues({
           query: {
             itemType: traceItemType,
             attributeType: type,
-            query: filterQuery && filterQuery !== '' ? filterQuery : undefined,
-            substringMatch: searchQuery && searchQuery !== '' ? searchQuery : undefined,
+            query: filterQuery || undefined,
+            substringMatch: searchQuery || undefined,
             project,
             ...datetimeParams,
           },
         }
       );
+      const originalQueryFn = options.queryFn;
+      const optionsWithPrefixCacheShortcut =
+        typeof originalQueryFn === 'function'
+          ? queryOptions({
+              ...options,
+              queryFn: (ctx: QueryFunctionContext<ApiQueryKey>) => {
+                return (
+                  findFreshEmptyPrefixSearchCacheMatch({
+                    client: ctx.client,
+                    currentKey: ctx.queryKey,
+                  }) ?? originalQueryFn(ctx)
+                );
+              },
+            })
+          : options;
 
       try {
-        const {json} = await queryClient.fetchQuery(options);
+        const {json} = await queryClient.fetchQuery(optionsWithPrefixCacheShortcut);
         return json
           .filter((item: TraceItemAttributeValue) => defined(item.value))
           .map((item: TraceItemAttributeValue) => item.value);

--- a/static/app/views/explore/utils/findFreshEmptyPrefixSearchCacheMatch.ts
+++ b/static/app/views/explore/utils/findFreshEmptyPrefixSearchCacheMatch.ts
@@ -1,0 +1,86 @@
+import type {QueryClient} from '@tanstack/react-query';
+
+import type {ApiResponse} from 'sentry/utils/api/apiFetch';
+import {safeParseQueryKey, type ApiQueryKey} from 'sentry/utils/api/apiQueryKey';
+
+type PrefixSearchCacheKey = {
+  optionsFingerprint: string;
+  queryFingerprint: string;
+  substringMatch: string;
+  url: string;
+};
+
+// If an earlier request with a shorter `substringMatch` (and otherwise-identical params)
+// returned an empty list, any longer search that has that value as a prefix is guaranteed
+// to also be empty. Reuse the cached empty response instead of re-fetching.
+export function findFreshEmptyPrefixSearchCacheMatch({
+  client,
+  currentKey,
+}: {
+  client: QueryClient;
+  currentKey: ApiQueryKey;
+}): ApiResponse<never[]> | undefined {
+  const currentSearch = getPrefixSearchCacheKey(currentKey);
+  if (!currentSearch) {
+    return undefined;
+  }
+
+  for (const query of client.getQueryCache().getAll()) {
+    if (query.isStale()) {
+      continue;
+    }
+    const cachedSearch = getPrefixSearchCacheKey(query.queryKey);
+    if (
+      !cachedSearch ||
+      !(
+        cachedSearch.url === currentSearch.url &&
+        cachedSearch.queryFingerprint === currentSearch.queryFingerprint &&
+        cachedSearch.optionsFingerprint === currentSearch.optionsFingerprint &&
+        currentSearch.substringMatch.startsWith(cachedSearch.substringMatch) &&
+        cachedSearch.substringMatch.length < currentSearch.substringMatch.length
+      )
+    ) {
+      continue;
+    }
+
+    const data = query.state.data as ApiResponse<unknown[]> | undefined;
+    if (data !== undefined && Array.isArray(data.json) && data.json.length === 0) {
+      return data as ApiResponse<never[]>;
+    }
+  }
+
+  return undefined;
+}
+
+function getPrefixSearchCacheKey(queryKey: unknown): PrefixSearchCacheKey | undefined {
+  if (!Array.isArray(queryKey) || queryKey.length < 2 || queryKey.length > 3) {
+    return undefined;
+  }
+
+  const parsed = safeParseQueryKey(queryKey);
+  if (parsed?.version !== 'v2' || parsed.isInfinite || !parsed.options) {
+    return undefined;
+  }
+
+  const query = getRecord(parsed.options.query);
+  const substringMatch = query?.substringMatch;
+  if (!query || typeof substringMatch !== 'string' || substringMatch.length === 0) {
+    return undefined;
+  }
+
+  const {substringMatch: _ignoredSubstring, ...queryWithoutSubstring} = query;
+  const {query: _ignoredQuery, ...optionsWithoutQuery} = parsed.options;
+
+  return {
+    url: parsed.url,
+    substringMatch,
+    queryFingerprint: JSON.stringify(queryWithoutSubstring),
+    optionsFingerprint: JSON.stringify(optionsWithoutQuery),
+  };
+}
+
+function getRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}

--- a/static/app/views/explore/utils/traceItemAttributeKeysOptions.tsx
+++ b/static/app/views/explore/utils/traceItemAttributeKeysOptions.tsx
@@ -1,8 +1,4 @@
-import {
-  queryOptions,
-  type QueryClient,
-  type QueryFunctionContext,
-} from '@tanstack/react-query';
+import {queryOptions, type QueryFunctionContext} from '@tanstack/react-query';
 
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import type {PageFilters} from 'sentry/types/core';
@@ -12,9 +8,10 @@ import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils';
 import type {ApiResponse} from 'sentry/utils/api/apiFetch';
 import {apiOptions, selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
-import {safeParseQueryKey, type ApiQueryKey} from 'sentry/utils/api/apiQueryKey';
+import type {ApiQueryKey} from 'sentry/utils/api/apiQueryKey';
 import {FieldKind} from 'sentry/utils/fields';
 import type {TraceItemDataset} from 'sentry/views/explore/types';
+import {findFreshEmptyPrefixSearchCacheMatch} from 'sentry/views/explore/utils/findFreshEmptyPrefixSearchCacheMatch';
 
 type AttributeType = {
   attributeSource: {
@@ -92,90 +89,15 @@ export function traceItemAttributeKeysOptions({
 
   return queryOptions({
     ...baseOptions,
-    queryFn: async (ctx: QueryFunctionContext<ApiQueryKey>) => {
-      return findEmptyPrefixMatch(ctx.client, ctx.queryKey) ?? originalQueryFn(ctx);
+    queryFn: (ctx: QueryFunctionContext<ApiQueryKey>) => {
+      return (
+        findFreshEmptyPrefixSearchCacheMatch({
+          client: ctx.client,
+          currentKey: ctx.queryKey,
+        }) ?? originalQueryFn(ctx)
+      );
     },
   });
-}
-
-// If an earlier request with a shorter `substringMatch` (and otherwise-identical params)
-// returned an empty list, any longer search that has that value as a prefix is guaranteed
-// to also be empty — the backend does a substring filter. Reuse the cached empty response
-// instead of re-fetching.
-function findEmptyPrefixMatch(
-  client: QueryClient,
-  currentKey: ApiQueryKey
-): ApiResponse<AttributeType[]> | undefined {
-  const currentSearch = getPrefixSearchCacheKey(currentKey);
-  if (!currentSearch) {
-    return undefined;
-  }
-
-  for (const query of client.getQueryCache().getAll()) {
-    if (query.isStale()) {
-      continue;
-    }
-    const cachedSearch = getPrefixSearchCacheKey(query.queryKey);
-    if (
-      !cachedSearch ||
-      !(
-        cachedSearch.url === currentSearch.url &&
-        cachedSearch.queryFingerprint === currentSearch.queryFingerprint &&
-        cachedSearch.optionsFingerprint === currentSearch.optionsFingerprint &&
-        currentSearch.substringMatch.startsWith(cachedSearch.substringMatch) &&
-        cachedSearch.substringMatch.length < currentSearch.substringMatch.length
-      )
-    ) {
-      continue;
-    }
-
-    const data = query.state.data as ApiResponse<AttributeType[]> | undefined;
-    if (!!data && Array.isArray(data.json) && data.json.length === 0) {
-      return data;
-    }
-  }
-
-  return undefined;
-}
-
-type PrefixSearchCacheKey = {
-  optionsFingerprint: string;
-  queryFingerprint: string;
-  substringMatch: string;
-  url: string;
-};
-
-function getPrefixSearchCacheKey(queryKey: unknown): PrefixSearchCacheKey | undefined {
-  if (!Array.isArray(queryKey) || queryKey.length < 2 || queryKey.length > 3) {
-    return undefined;
-  }
-
-  const parsed = safeParseQueryKey(queryKey);
-  if (parsed?.version !== 'v2' || parsed.isInfinite || !parsed.options) {
-    return undefined;
-  }
-
-  const query = getRecord(parsed.options.query);
-  const substringMatch = query?.substringMatch;
-  if (!query || typeof substringMatch !== 'string' || substringMatch.length === 0) {
-    return undefined;
-  }
-
-  const {substringMatch: _ignoredSubstring, ...queryWithoutSubstring} = query;
-  const {query: _ignoredQuery, ...optionsWithoutQuery} = parsed.options;
-
-  return {
-    url: parsed.url,
-    substringMatch,
-    queryFingerprint: JSON.stringify(queryWithoutSubstring),
-    optionsFingerprint: JSON.stringify(optionsWithoutQuery),
-  };
-}
-
-function getRecord(value: unknown): Record<string, unknown> | undefined {
-  return value !== null && typeof value === 'object' && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined;
 }
 
 type TraceItemTagCollections = {


### PR DESCRIPTION
This PR is similar to that of #113295, where we're introducing short-circuiting requests this time to the `/attributes/values` endpoint.

The idea is that if a user searches `test` and has no results, searching for `testing` will also revel no results so we can just skip that request and instead returned the cached value.

This PR also moves the logic for the short-circuiting into it's own file so that it's easily re-usable for fetching.

Closes EXP-920