### PR TITLE
fix(issue-detection): Add referrer for log attributes query

### DIFF
--- a/src/sentry/seer/explorer/tools.py
+++ b/src/sentry/seer/explorer/tools.py
@@ -1575,6 +1575,7 @@ def _make_get_trace_request(
     resolver: SearchResolver,
     limit: int | None,
     sampling_mode: SAMPLING_MODES,
+    referrer: Referrer = Referrer.SEER_EXPLORER_TOOLS,
 ) -> list[dict[str, Any]]:
     """
     Make a request to the EAP GetTrace endpoint to get all attributes for a given trace and item type.
@@ -1610,7 +1611,7 @@ def _make_get_trace_request(
         full_trace_id = trace_id
 
     # Build the GetTraceRequest.
-    meta = resolver.resolve_meta(referrer=Referrer.SEER_EXPLORER_TOOLS, sampling_mode=sampling_mode)
+    meta = resolver.resolve_meta(referrer=referrer, sampling_mode=sampling_mode)
     request = GetTraceRequest(
         meta=meta,
         trace_id=full_trace_id,
@@ -1703,6 +1704,7 @@ def get_log_attributes_for_trace(
     project_slugs: list[str] | None = None,
     sampling_mode: SAMPLING_MODES = "NORMAL",
     limit: int | None = 50,
+    referrer: str | None = None,
 ) -> dict[str, Any] | None:
     """
     Get all attributes for all logs in a trace. You can optionally filter by message substring and/or project slugs.
@@ -1742,12 +1744,18 @@ def get_log_attributes_for_trace(
     )
     resolver = OurLogs.get_resolver(params=snuba_params, config=SearchResolverConfig())
 
+    try:
+        referrer_enum = Referrer(referrer) if referrer else Referrer.SEER_EXPLORER_TOOLS
+    except ValueError:
+        referrer_enum = Referrer.SEER_EXPLORER_TOOLS
+
     items = _make_get_trace_request(
         trace_id=trace_id,
         trace_item_type=TraceItemType.TRACE_ITEM_TYPE_LOG,
         resolver=resolver,
         limit=(limit if not message_substring else None),  # Return all results if we're filtering.
         sampling_mode=sampling_mode,
+        referrer=referrer_enum,
     )
 
     if not message_substring:

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -674,6 +674,7 @@ class Referrer(StrEnum):
     ISSUES_LLM_ISSUE_DETECTION_TRANSACTION = "issues.llm_issue_detection.transaction"
     ISSUES_LLM_ISSUE_DETECTION_TRACE = "issues.llm_issue_detection.trace"
     ISSUES_LLM_ISSUE_DETECTION_SPAN_COUNT = "issues.llm_issue_detection.span_count"
+    ISSUES_LLM_ISSUE_DETECTION_LOGS = "issues.llm_issue_detection.logs"
 
     INSIGHTS_MOBILE_HAS_TTFDCONFIGURED = "insights.mobile.hasTTFDConfigured"
     INSIGHTS_TIME_SPENT_TOTAL_TIME = "insights.time_spent.total_time"


### PR DESCRIPTION
## Summary
- Add `referrer` parameter to `get_log_attributes_for_trace` and `_make_get_trace_request` so the detection pipeline can use its own Snuba allocation bucket for log queries
- Register new `issues.llm_issue_detection.logs` referrer
- Companion to getsentry/seer#TBD which passes the referrer from the detection pipeline

## Test plan
- [ ] Verify existing explorer log queries still default to `seer.explorer_tools` referrer
- [ ] Verify detection pipeline log queries use `issues.llm_issue_detection.logs` after seer-side change lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)