### PR TITLE
feat(seer): Show more workflow detail and add Autofix shortcut

### DIFF
--- a/static/app/views/seerWorkflows/index.tsx
+++ b/static/app/views/seerWorkflows/index.tsx
@@ -25,10 +25,26 @@ type SeerNightShiftRunIssue = {
   seerRunId: string | null;
 };
 
+type SeerNightShiftRunExtras = {
+  agent_run_id?: number | string;
+  options?: SeerNightShiftRunOptions;
+  target_project_ids?: number[];
+  triggering_user_id?: number;
+};
+
+type SeerNightShiftRunOptions = {
+  dry_run?: boolean;
+  extra_triage_instructions?: string;
+  intelligence_level?: 'low' | 'medium' | 'high';
+  max_candidates?: number;
+  reasoning_effort?: 'low' | 'medium' | 'high';
+  source?: string;
+};
+
 type SeerNightShiftRun = {
   dateAdded: string;
   errorMessage: string | null;
-  extras: Record<string, unknown>;
+  extras: SeerNightShiftRunExtras;
   id: string;
   issues: SeerNightShiftRunIssue[];
   triageStrategy: string;
@@ -80,6 +96,8 @@ function SeerWorkflows() {
                 <SimpleTable.HeaderCell>{t('Date')}</SimpleTable.HeaderCell>
                 <SimpleTable.HeaderCell>{t('Workflow')}</SimpleTable.HeaderCell>
                 <SimpleTable.HeaderCell>{t('Strategy')}</SimpleTable.HeaderCell>
+                <SimpleTable.HeaderCell>{t('Max candidates')}</SimpleTable.HeaderCell>
+                <SimpleTable.HeaderCell>{t('Source')}</SimpleTable.HeaderCell>
                 <SimpleTable.HeaderCell>{t('Status')}</SimpleTable.HeaderCell>
                 <SimpleTable.HeaderCell>{t('Issues')}</SimpleTable.HeaderCell>
                 <SimpleTable.HeaderCell />
@@ -112,11 +130,23 @@ function SeerWorkflows() {
                         <SimpleTable.RowCell>{t('Night Shift')}</SimpleTable.RowCell>
                         <SimpleTable.RowCell>{run.triageStrategy}</SimpleTable.RowCell>
                         <SimpleTable.RowCell>
+                          {run.extras.options?.max_candidates ?? '-'}
+                        </SimpleTable.RowCell>
+                        <SimpleTable.RowCell>
+                          {run.extras.options?.source ?? '-'}
+                        </SimpleTable.RowCell>
+                        <SimpleTable.RowCell>
                           <Text variant={run.errorMessage ? 'danger' : undefined}>
                             {status}
                           </Text>
                         </SimpleTable.RowCell>
-                        <SimpleTable.RowCell>{run.issues.length}</SimpleTable.RowCell>
+                        <SimpleTable.RowCell>
+                          {run.extras.options?.dry_run ? (
+                            <Text variant="muted">{t('dry run')}</Text>
+                          ) : (
+                            run.issues.length
+                          )}
+                        </SimpleTable.RowCell>
                         <SimpleTable.RowCell>
                           {explorerRunId === null ? null : (
                             <LinkButton
@@ -163,6 +193,13 @@ function RunDetail({
   organizationSlug: string;
   run: SeerNightShiftRun;
 }) {
+  const {reasoning_effort, intelligence_level, extra_triage_instructions} =
+    run.extras.options ?? {};
+  const hasSettings =
+    reasoning_effort !== undefined ||
+    intelligence_level !== undefined ||
+    extra_triage_instructions !== undefined;
+
   return (
     <Flex direction="column" gap="lg">
       {run.errorMessage ? (
@@ -170,6 +207,35 @@ function RunDetail({
           {t('Error: ')}
           {run.errorMessage}
         </Text>
+      ) : null}
+
+      {hasSettings ? (
+        <Grid columns="max-content 1fr" gap="sm xl" align="start">
+          {reasoning_effort === undefined ? null : (
+            <Fragment>
+              <Text bold size="xs" variant="muted">
+                {t('Reasoning effort')}
+              </Text>
+              <Text size="sm">{reasoning_effort}</Text>
+            </Fragment>
+          )}
+          {intelligence_level === undefined ? null : (
+            <Fragment>
+              <Text bold size="xs" variant="muted">
+                {t('Intelligence level')}
+              </Text>
+              <Text size="sm">{intelligence_level}</Text>
+            </Fragment>
+          )}
+          {extra_triage_instructions === undefined ? null : (
+            <Fragment>
+              <Text bold size="xs" variant="muted">
+                {t('Extra triage instructions')}
+              </Text>
+              <Text size="sm">{extra_triage_instructions}</Text>
+            </Fragment>
+          )}
+        </Grid>
       ) : null}
 
       <Flex direction="column" gap="sm">
@@ -183,7 +249,7 @@ function RunDetail({
           </Text>
         ) : (
           <Grid
-            columns="max-content max-content max-content max-content"
+            columns="max-content max-content max-content max-content max-content"
             gap="sm xl"
             align="center"
           >
@@ -196,6 +262,7 @@ function RunDetail({
             <Text bold size="xs" variant="muted">
               {t('Seer Run ID')}
             </Text>
+            <span />
             <span />
             {run.issues.flatMap(issue => [
               <Link
@@ -225,6 +292,17 @@ function RunDetail({
                   {t('Explorer')}
                 </LinkButton>
               ),
+              <LinkButton
+                key={`${issue.id}-autofix`}
+                size="xs"
+                icon={<IconOpen />}
+                to={{
+                  pathname: `/organizations/${organizationSlug}/issues/${issue.groupId}/`,
+                  query: {seerDrawer: true},
+                }}
+              >
+                {t('Autofix')}
+              </LinkButton>,
             ])}
           </Grid>
         )}
@@ -234,7 +312,7 @@ function RunDetail({
 }
 
 const RunsTable = styled(SimpleTable)`
-  grid-template-columns: min-content 1fr 1fr 1fr 1fr min-content min-content;
+  grid-template-columns: min-content 1fr 1fr 1fr 1fr 1fr 1fr min-content min-content;
 `;
 
 function getExplorerRunId(run: SeerNightShiftRun): number | string | null {


### PR DESCRIPTION
- Surface additional Night Shift run metadata on the Seer Workflows page and add a one-click path from a per-issue row into the issue with the Seer drawer pre-opened.
- Adds `Max candidates` and `Source` columns and replaces the issue count with `dry run` when `extras.options.dry_run` is true.
- When `reasoning_effort`, `intelligence_level`, or `extra_triage_instructions` are present in `extras.options`, they render as a key/value grid above the issues list.

---

After:

<img width="1502" height="1028" alt="CleanShot 2026-04-29 at 19 35 07@2x" src="https://github.com/user-attachments/assets/515f93ab-fa01-407c-89b0-a8e4496b98c3" />

---

Agent transcript: https://claudescope.sentry.dev/share/hmnd7V91Oo0puT1vf16jMbd_DxFYEeAXcRAH-JgMZB4