### PR TITLE
feat(seer): Default Night Shift to enabled

### DIFF
--- a/src/sentry/tasks/seer/night_shift/tweaks.py
+++ b/src/sentry/tasks/seer/night_shift/tweaks.py
@@ -26,7 +26,7 @@ def default_max_candidates() -> int:
 
 class NightShiftTweaks(pydantic.BaseModel):
     # Global settings — apply to scheduled (cron) runs as well as manual ones.
-    enabled: bool = False
+    enabled: bool = True
     # Manual-run-only settings — read by the manual trigger endpoint and
     # forwarded into SeerNightShiftRunOptions; cron runs use the shared
     # defaults instead.

--- a/tests/sentry/tasks/seer/night_shift/test_tweaks.py
+++ b/tests/sentry/tasks/seer/night_shift/test_tweaks.py
@@ -9,7 +9,7 @@ class GetNightShiftTweaksTest(TestCase):
     def test_unset_returns_defaults(self) -> None:
         tweaks = get_night_shift_tweaks(self.project)
 
-        assert tweaks.enabled is False
+        assert tweaks.enabled is True
         assert tweaks.max_candidates == options.get("seer.night_shift.issues_per_org")
 
     def test_empty_object_returns_defaults(self) -> None:
@@ -17,7 +17,7 @@ class GetNightShiftTweaksTest(TestCase):
 
         tweaks = get_night_shift_tweaks(self.project)
 
-        assert tweaks.enabled is False
+        assert tweaks.enabled is True
         assert tweaks.max_candidates == options.get("seer.night_shift.issues_per_org")
 
     def test_full_override(self) -> None:
@@ -50,7 +50,7 @@ class GetNightShiftTweaksTest(TestCase):
 
         tweaks = get_night_shift_tweaks(self.project)
 
-        assert tweaks.enabled is False
+        assert tweaks.enabled is True
         assert tweaks.max_candidates == 7
 
     def test_non_dict_value_reports_and_returns_defaults(self) -> None:
@@ -65,7 +65,7 @@ class GetNightShiftTweaksTest(TestCase):
             tweaks = get_night_shift_tweaks(self.project)
 
         mock_capture.assert_called_once()
-        assert tweaks.enabled is False
+        assert tweaks.enabled is True
         assert tweaks.max_candidates == options.get("seer.night_shift.issues_per_org")
 
     def test_invalid_payload_reports_and_returns_defaults(self) -> None:
@@ -80,5 +80,5 @@ class GetNightShiftTweaksTest(TestCase):
             tweaks = get_night_shift_tweaks(self.project)
 
         mock_capture.assert_called_once()
-        assert tweaks.enabled is False
+        assert tweaks.enabled is True
         assert tweaks.max_candidates == options.get("seer.night_shift.issues_per_org")


### PR DESCRIPTION
Switches `NightShiftTweaks.enabled` from `False` to `True` so projects without an explicit `sentry:seer_nightshift_tweaks` setting (or with only manual-run fields like `max_candidates` configured) participate in the nightly run by default. Existing projects that already set `enabled: false` are unaffected.

Agent transcript: https://claudescope.sentry.dev/share/Flb7DsfeYaH8mMNtlL-WpvxrUXUV8qqv3tVPjcXc7Hk