### PR TITLE
feat(seer): Update Night Shift "default" label to on-by-default

### DIFF
--- a/static/gsApp/views/seerAutomation/components/projectDetails/autofixAgent.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectDetails/autofixAgent.tsx
@@ -33,7 +33,7 @@ type NightShiftValue = 'on' | 'off' | 'default';
 const NIGHT_SHIFT_OPTIONS = [
   {value: 'on' as const, label: t('On')},
   {value: 'off' as const, label: t('Off')},
-  {value: 'default' as const, label: t('Default (Off)')},
+  {value: 'default' as const, label: t('Default (On)')},
 ];
 
 function getNightShiftValue(project: Project): NightShiftValue {


### PR DESCRIPTION
Updates the Night Shift dropdown's `default` option label from "Default (Off)" to "Default (On)" so it matches the new backend default.

Agent transcript: https://claudescope.sentry.dev/share/jKeUbaVNGY-fYf4PVeU9qWv8r6-6OU_lXtXOGhdZpEM