### PR TITLE
fix(trace): Add referrer to the trace view

### DIFF
--- a/src/sentry/api/endpoints/organization_trace.py
+++ b/src/sentry/api/endpoints/organization_trace.py
@@ -52,6 +52,7 @@ class OrganizationTraceEndpoint(OrganizationEventsEndpointBase):
         self,
         snuba_params: SnubaParams,
         trace_id: str,
+        referrer: str | None,
         error_id: str | None = None,
         additional_attributes: list[str] | None = None,
         include_uptime: bool = False,
@@ -61,6 +62,7 @@ class OrganizationTraceEndpoint(OrganizationEventsEndpointBase):
         return query_trace_data(
             snuba_params,
             trace_id,
+            referrer,
             error_id,
             additional_attributes,
             include_uptime,
@@ -75,6 +77,8 @@ class OrganizationTraceEndpoint(OrganizationEventsEndpointBase):
             snuba_params = self.get_snuba_params(request, organization)
         except NoProjects:
             return Response(status=404)
+
+        referrer = request.GET.get("referrer")
 
         additional_attributes = request.GET.getlist("additional_attributes", [])
         include_uptime = request.GET.get("include_uptime", "0") == "1"
@@ -91,6 +95,7 @@ class OrganizationTraceEndpoint(OrganizationEventsEndpointBase):
                 spans = self.query_trace_data(
                     snuba_params,
                     trace_id,
+                    referrer,
                     error_id,
                     additional_attributes,
                     include_uptime,

--- a/src/sentry/seer/autofix/autofix.py
+++ b/src/sentry/seer/autofix/autofix.py
@@ -309,7 +309,10 @@ def _get_trace_tree_for_event(
 
         trace_endpoint = OrganizationTraceEndpoint()
         trace = trace_endpoint.query_trace_data(
-            snuba_params, trace_id, organization=project.organization
+            snuba_params,
+            trace_id,
+            Referrer.SEER_AUTOFIX_GET_TRACE_EVENTS.value,
+            organization=project.organization,
         )
 
         if not trace:

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -789,6 +789,7 @@ class Referrer(StrEnum):
     SEER_EXPLORER_INDEX = "seer.explorer_index"
     SEER_EXPLORER_SERVICE_MAP = "seer.explorer_service_map"
     SEER_EXPLORER_TOOLS = "seer.explorer_tools"
+    SEER_AUTOFIX_GET_TRACE_EVENTS = "seer.autofix.trace.get-events"
     SUPERGROUPS_BACKFILL_LIGHTWEIGHT_GET_LATEST_EVENTS = (
         "supergroups_backfill_lightweight.get_latest_events"
     )

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -594,6 +594,8 @@ class Referrer(StrEnum):
     API_TRACE_VIEW_ERRORS_VIEW = "api.trace-view.errors-view"
     API_TRACE_VIEW_GET_TIMESTAMP_PROJECTS = "api.trace-view.get-timestamp-projects"
     API_TRACE_VIEW_GET_EVENTS = "api.trace-view.get-events"
+    API_TRACE_ISSUES_GET_EVENTS = "api.trace-view.issues.get-events"
+    API_TRACE_INSIGHTS_GET_EVENTS = "api.trace-view.insights.get-events"
     API_TRACE_VIEW_GET_META = "api.trace-view.get-meta"
     API_TRACE_VIEW_SPAN_META = "api.trace-view.spans-meta"
     API_TRACE_VIEW_SPAN_OP_META = "api.trace-view.spans-op-count"

--- a/src/sentry/snuba/trace.py
+++ b/src/sentry/snuba/trace.py
@@ -40,7 +40,7 @@ from sentry.search.events.builder.discover import DiscoverQueryBuilder
 from sentry.search.events.types import QueryBuilderConfig, SnubaParams
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.occurrences_rpc import OccurrenceCategory, Occurrences
-from sentry.snuba.referrer import Referrer
+from sentry.snuba.referrer import Referrer, is_valid_referrer
 from sentry.snuba.spans_rpc import Spans
 from sentry.uptime.eap_utils import get_columns_for_uptime_result
 from sentry.utils.numbers import base32_encode
@@ -621,10 +621,10 @@ def _serialize_columnar_uptime_item(
 def query_trace_data(
     snuba_params: SnubaParams,
     trace_id: str,
+    referrer: str | None,
     error_id: str | None = None,
     additional_attributes: list[str] | None = None,
     include_uptime: bool = False,
-    referrer: Referrer = Referrer.API_TRACE_VIEW_GET_EVENTS,
     organization: Organization | None = None,
 ) -> list[SerializedEvent]:
     """Queries span/error data for a given trace"""
@@ -641,6 +641,9 @@ def query_trace_data(
     # Attributes added only for metric tagging that should not appear in the response
     metric_only_attributes = metric_attributes - set(additional_attributes or [])
 
+    if referrer is None or not is_valid_referrer(referrer):
+        referrer = Referrer.API_TRACE_VIEW_GET_EVENTS.value
+
     errors_query = _errors_query(snuba_params, trace_id, error_id)
     occurrence_query = _perf_issues_query(snuba_params, trace_id, organization)
     uptime_query = _uptime_results_query(snuba_params, trace_id) if include_uptime else None
@@ -655,7 +658,7 @@ def query_trace_data(
             Spans.run_trace_query,
             trace_id=trace_id,
             params=snuba_params,
-            referrer=referrer.value,
+            referrer=referrer,
             config=SearchResolverConfig(),
             additional_attributes=all_additional_attributes,
         )
@@ -681,7 +684,7 @@ def query_trace_data(
         eap_errors_data = _run_errors_query_eap(
             snuba_params=snuba_params,
             trace_id=trace_id,
-            referrer=referrer.value,
+            referrer=referrer,
             error_id=error_id,
         )
         errors_data = EAPOccurrencesComparator.check_and_choose(

--- a/src/sentry/snuba/trace.py
+++ b/src/sentry/snuba/trace.py
@@ -641,7 +641,7 @@ def query_trace_data(
     # Attributes added only for metric tagging that should not appear in the response
     metric_only_attributes = metric_attributes - set(additional_attributes or [])
 
-    if referrer is None or not is_valid_referrer(referrer):
+    if referrer is None or referrer == "" or not is_valid_referrer(referrer):
         referrer = Referrer.API_TRACE_VIEW_GET_EVENTS.value
 
     errors_query = _errors_query(snuba_params, trace_id, error_id)


### PR DESCRIPTION
- This makes referrer a required parameter to the query_trace_data function
- This splits the referrers between the API and seer.
- TODO, will need to update the frontend to pass different referrers based on where they're calling from