### PR TITLE
feat(seer): Add structured LLM context for traces explorer page

### DIFF
--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -49,8 +49,10 @@ import {Tab, useTab} from 'sentry/views/explore/hooks/useTab';
 import {useVisitQuery} from 'sentry/views/explore/hooks/useVisitQuery';
 import {
   useQueryParamsExtrapolate,
+  useQueryParamsGroupBys,
   useQueryParamsId,
   useQueryParamsQuery,
+  useQueryParamsSortBys,
   useQueryParamsVisualizes,
   useSetQueryParamsVisualizes,
 } from 'sentry/views/explore/queryParams/context';
@@ -66,6 +68,8 @@ import {ExploreToolbar} from 'sentry/views/explore/toolbar';
 import {useRawCounts} from 'sentry/views/explore/useRawCounts';
 import {combineConfidenceForSeries} from 'sentry/views/explore/utils';
 import {Onboarding} from 'sentry/views/performance/onboarding';
+import {useLLMContext} from 'sentry/views/seerExplorer/contexts/llmContext';
+import {registerLLMContext} from 'sentry/views/seerExplorer/contexts/registerLLMContext';
 
 // eslint-disable-next-line boundaries/dependencies
 import QuotaExceededAlert from 'getsentry/components/performance/quotaExceededAlert';
@@ -168,12 +172,12 @@ function SpanTabControlSection({controlSectionExpanded}: SpanTabControlSectionPr
   );
 }
 
-interface SpanTabContentSectionProps {
+type SpanTabContentSectionProps = {
   controlSectionExpanded: boolean;
   setControlSectionExpanded: (expanded: boolean) => void;
-}
+};
 
-function SpanTabContentSection({
+function SpanTabContentSectionInner({
   controlSectionExpanded,
   setControlSectionExpanded,
 }: SpanTabContentSectionProps) {
@@ -186,6 +190,23 @@ function SpanTabContentSection({
   const [tab, setTab] = useTab();
   const [caseInsensitive] = useCaseInsensitivity();
   const crossEventQueries = useCrossEventQueries();
+  const sortBys = useQueryParamsSortBys();
+  const groupBys = useQueryParamsGroupBys();
+
+  // Push page state into the LLM context tree for Seer Explorer.
+  useLLMContext({
+    contextHint:
+      'Sentry traces explorer page. Users search spans/traces by attributes and view samples, aggregates, or breakdowns. ' +
+      'Tools: telemetry_live_search(dataset, question, project_slugs) to query spans/traces/errors/logs/metrics; ' +
+      'get_trace_waterfall(trace_id, span_id?) for full trace waterfall or specific span; ' +
+      'telemetry_index_list_nodes(keyword) to discover span/function types; ' +
+      'telemetry_index_dependencies(title) for upstream/downstream call graph.',
+    searchQuery: query,
+    activeTab: tab,
+    visualizes: visualizes.map(v => v.yAxis),
+    groupBys: groupBys.filter(g => g !== ''),
+    sortBys: sortBys.map(s => (s.kind === 'desc' ? `-${s.field}` : s.field)),
+  });
 
   const organization = useOrganization();
   const hasCrossEventQueries = organization.features.includes(
@@ -361,6 +382,11 @@ function SpanTabContentSection({
     </ExploreContentSection>
   );
 }
+
+const SpanTabContentSection = registerLLMContext(
+  'traces-explorer',
+  SpanTabContentSectionInner
+);
 
 const OnboardingContentSection = styled('section')`
   grid-column: 1/3;

--- a/static/app/views/seerExplorer/contexts/llmContext.spec.tsx
+++ b/static/app/views/seerExplorer/contexts/llmContext.spec.tsx
@@ -311,6 +311,47 @@ describe('registerLLMContext — trace node type', () => {
   });
 });
 
+describe('registerLLMContext — traces-explorer node type', () => {
+  it('registers a traces-explorer node with search and tab metadata', async () => {
+    const {ContextCapture, getSnapshot} = makeContextCapture();
+
+    function DummyTracesExplorer() {
+      useLLMContext({
+        contextHint: 'Sentry traces explorer page.',
+        searchQuery: 'span.description is /api/users',
+        activeTab: 'span',
+        visualizes: ['count(spans)'],
+        groupBys: ['span.op'],
+        sortBys: ['-timestamp'],
+      });
+      return <div>traces explorer</div>;
+    }
+    const ContextTracesExplorer = registerLLMContext(
+      'traces-explorer',
+      DummyTracesExplorer
+    );
+
+    render(
+      <LLMContextProvider>
+        <ContextTracesExplorer />
+        <ContextCapture />
+      </LLMContextProvider>
+    );
+
+    await waitFor(() => {
+      const snapshot = getSnapshot();
+      expect(snapshot.nodes).toHaveLength(1);
+      expect(snapshot.nodes[0]?.nodeType).toBe('traces-explorer');
+      const data = snapshot.nodes[0]?.data as Record<string, unknown>;
+      expect(data.searchQuery).toBe('span.description is /api/users');
+      expect(data.activeTab).toBe('span');
+      expect(data.visualizes).toEqual(['count(spans)']);
+      expect(data.groupBys).toEqual(['span.op']);
+      expect(data.sortBys).toEqual(['-timestamp']);
+    });
+  });
+});
+
 describe('getLLMContext — full tree vs componentOnly', () => {
   it('getLLMContext() returns full tree including sibling branches', async () => {
     const {ContextCapture, getSnapshot} = makeContextCapture();

--- a/static/app/views/seerExplorer/contexts/llmContextTypes.ts
+++ b/static/app/views/seerExplorer/contexts/llmContextTypes.ts
@@ -21,6 +21,7 @@ export type LLMContextNodeType =
   | 'chart'
   | 'dashboard'
   | 'trace'
+  | 'traces-explorer'
   | 'widget'
   | 'widget-builder';
 

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -54,6 +54,7 @@ const STRUCTURED_CONTEXT_ROUTES = new Set([
 ]);
 /** New experimental routes where the LLMContext tree provides structured page context. */
 const NEW_STRUCTURED_CONTEXT_ROUTES = new Set<string>([
+  '/explore/traces/',
   '/explore/traces/trace/:traceSlug/',
 ]);
 


### PR DESCRIPTION
+ Give the Seer Explorer agent structured page context on the /explore/traces/ route instead of falling back to the ASCII DOM snapshot. The context captures the user's current search query, active tab, visualize metrics, group-by fields, and sort order, plus tool-call hints so the agent knows how to drill deeper.

