### PR TITLE
fix(explore): Self-heal stale aggregateSort and visualize URL state on spans

### DIFF
--- a/static/app/views/explore/spans/spansQueryParamsProvider.spec.tsx
+++ b/static/app/views/explore/spans/spansQueryParamsProvider.spec.tsx
@@ -1,0 +1,98 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {SpansQueryParamsProvider} from 'sentry/views/explore/spans/spansQueryParamsProvider';
+
+const organization = OrganizationFixture();
+
+function renderWithQuery(query: Record<string, string | string[]>) {
+  return render(<SpansQueryParamsProvider>{null}</SpansQueryParamsProvider>, {
+    organization,
+    initialRouterConfig: {
+      route: '/organizations/:orgId/explore/traces/',
+      location: {
+        pathname: `/organizations/${organization.slug}/explore/traces/`,
+        query,
+      },
+    },
+  });
+}
+
+describe('SpansQueryParamsProvider', () => {
+  it('drops aggregateSort that does not reference any active yAxis or groupBy', async () => {
+    const {router} = renderWithQuery({
+      aggregateField: [
+        JSON.stringify({groupBy: 'gen_ai.tool.name'}),
+        JSON.stringify({yAxes: ['count(span.duration)'], chartType: 0}),
+      ],
+      aggregateSort: '-count_unique(user.id)',
+    });
+
+    await waitFor(() => {
+      expect(router.location.query.aggregateSort).toBeUndefined();
+    });
+    expect(router.location.query.aggregateField).toEqual([
+      JSON.stringify({groupBy: 'gen_ai.tool.name'}),
+      JSON.stringify({yAxes: ['count(span.duration)'], chartType: 0}),
+    ]);
+  });
+
+  it('keeps aggregateSort when every entry references an active yAxis', async () => {
+    const {router} = renderWithQuery({
+      aggregateField: [
+        JSON.stringify({groupBy: 'gen_ai.tool.name'}),
+        JSON.stringify({yAxes: ['count(span.duration)']}),
+      ],
+      aggregateSort: '-count(span.duration)',
+    });
+
+    // Give the effect a tick to fire — if it triggers a navigate, the test
+    // will see the change. Otherwise the URL should be untouched.
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(router.location.query.aggregateSort).toBe('-count(span.duration)');
+  });
+
+  it('keeps aggregateSort when every entry references an active groupBy', async () => {
+    const {router} = renderWithQuery({
+      aggregateField: [
+        JSON.stringify({groupBy: 'gen_ai.tool.name'}),
+        JSON.stringify({yAxes: ['count(span.duration)']}),
+      ],
+      aggregateSort: 'gen_ai.tool.name',
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(router.location.query.aggregateSort).toBe('gen_ai.tool.name');
+  });
+
+  it('drops legacy visualize and groupBy keys when aggregateField is present', async () => {
+    const {router} = renderWithQuery({
+      aggregateField: JSON.stringify({yAxes: ['count(span.duration)']}),
+      visualize: JSON.stringify({yAxes: ['count_unique(user.id)']}),
+      groupBy: 'gen_ai.tool.name',
+    });
+
+    await waitFor(() => {
+      expect(router.location.query.visualize).toBeUndefined();
+      expect(router.location.query.groupBy).toBeUndefined();
+    });
+    expect(router.location.query.aggregateField).toBe(
+      JSON.stringify({yAxes: ['count(span.duration)']})
+    );
+  });
+
+  it('does not navigate when URL is already canonical', async () => {
+    const {router} = renderWithQuery({
+      aggregateField: JSON.stringify({yAxes: ['count(span.duration)']}),
+      project: '1',
+    });
+
+    const initialPathname = router.location.pathname;
+    const initialQuery = {...router.location.query};
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(router.location.pathname).toBe(initialPathname);
+    expect(router.location.query).toEqual(initialQuery);
+  });
+});

--- a/static/app/views/explore/spans/spansQueryParamsProvider.tsx
+++ b/static/app/views/explore/spans/spansQueryParamsProvider.tsx
@@ -1,9 +1,11 @@
 import type {ReactNode} from 'react';
-import {useCallback, useMemo, useRef} from 'react';
+import {useCallback, useEffect, useMemo, useRef} from 'react';
 import type {Location} from 'history';
 
+import {decodeSorts} from 'sentry/utils/queryString';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import {validateAggregateSort} from 'sentry/views/explore/queryParams/aggregateSortBy';
 import {QueryParamsContextProvider} from 'sentry/views/explore/queryParams/context';
 import type {WritableQueryParams} from 'sentry/views/explore/queryParams/writableQueryParams';
 import {
@@ -37,6 +39,49 @@ export function SpansQueryParamsProvider({children}: SpansQueryParamsProviderPro
     () => getReadableQueryParamsFromLocation(location),
     [location]
   );
+
+  // Self-heal stale URL state in place so that links copied from the address
+  // bar (or unfurled in Slack) reflect what the UI is actually showing. The
+  // parser already discards stale values, but the URL keeps them around until
+  // a user-driven change overwrites them.
+  useEffect(() => {
+    const cleanedQuery = {...location.query};
+    let changed = false;
+
+    // When `aggregateField` is the active source of yAxes/groupBys, the legacy
+    // `visualize` and `groupBy` keys are ignored by the parser. Drop them so
+    // they can't drift back into shared URLs.
+    if (cleanedQuery.aggregateField !== undefined) {
+      if (cleanedQuery.visualize !== undefined) {
+        delete cleanedQuery.visualize;
+        changed = true;
+      }
+      if (cleanedQuery.groupBy !== undefined) {
+        delete cleanedQuery.groupBy;
+        changed = true;
+      }
+    }
+
+    // `aggregateSort` must reference an active yAxis or groupBy. If any entry
+    // is stale (e.g. left over from a previous `visualize`), the parser falls
+    // back to the default sort but the URL still carries the broken value.
+    // Reuse the exact validator the parser uses so the two stay in sync.
+    const urlAggregateSort = decodeSorts(cleanedQuery.aggregateSort);
+    if (urlAggregateSort.length > 0) {
+      const aggregateFields = [...readableQueryParams.aggregateFields];
+      const allValid = urlAggregateSort.every(sort =>
+        validateAggregateSort(sort, aggregateFields)
+      );
+      if (!allValid) {
+        delete cleanedQuery.aggregateSort;
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      navigate({...location, query: cleanedQuery}, {replace: true});
+    }
+  }, [location, readableQueryParams, navigate]);
 
   const setWritableQueryParams = useCallback(
     (writableQueryParams: WritableQueryParams) => {


### PR DESCRIPTION
Spans Explore URLs sometimes ship with `aggregateSort` referencing a yAxis that isn't in the active `aggregateField` (e.g. left over from a previous `visualize`). The parser already discards such values at read time — so the UI renders correctly — but the URL keeps the stale state, and anything that consumes the URL afterwards (links copied from the address bar, Slack unfurls, saved widgets that link to Explore) sees the broken form.

Add a `useEffect` to `SpansQueryParamsProvider` that detects this drift and replace-navigates to a normalized URL, so what's in the address bar matches what the parser actually used.

**What gets stripped**

- `visualize` and `groupBy` query keys when `aggregateField` is present (the parser ignores them in that case, so they're dead weight).
- `aggregateSort` when any entry fails `validateAggregateSort` against the parsed `aggregateFields`.

**Reuses the parser's validator**

The validation calls `validateAggregateSort` from `static/app/views/explore/queryParams/aggregateSortBy.ts` — the exact function `getAggregateSortBysFromLocation` uses. The self-heal can't disagree with the parser about what's valid.

**Idempotency**

A canonical URL produces no diff and no navigation, so the effect is a natural fixed point — no flag or one-shot guard needed. Replace-navigation (`{replace: true}`) avoids polluting browser history; the back button still goes to wherever the user came from.

**Scope**

Spans only. Logs and metrics each have their own provider and would need the same treatment if we want consistency.

Refs DAIN-1595