### PR TITLE
fix(search): Add ordering to pre-filter candidate query to leverage index

### DIFF
--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -1002,7 +1002,9 @@ class PostgresSnubaQueryExecutor(AbstractQueryExecutor):
 
         with sentry_sdk.start_span(op="snuba_group_query") as span:
             group_ids = list(
-                group_queryset.using_replica().values_list("id", flat=True)[: max_candidates + 1]
+                group_queryset.using_replica()
+                .order_by("-last_seen")
+                .values_list("id", flat=True)[: max_candidates + 1]
             )
             span.set_data("Max Candidates", max_candidates)
             span.set_data("Result Size", len(group_ids))


### PR DESCRIPTION
Fixes SENTRY-3WM8

The Postgres pre-filter query in PostgresSnubaQueryExecutor.query() fetches candidate group IDs from sentry_groupedmessage before querying Snuba. For large organizations with millions of unresolved issues, this query caused 1+ second DB latency because it had no ORDER BY clause.

Without ordering, PostgreSQL cannot efficiently use the existing composite index (project, status, last_seen, id) with the LIMIT. It falls back to a sequential or bitmap scan of potentially millions of rows.

Adding order_by('-last_seen') allows PostgreSQL to use an Index Scan Backward on the composite index, starting from the most recent entries and stopping as soon as max_candidates+1 rows are found. This turns a full-table scan into a bounded index scan.

