### PR TITLE
feat(users): Add suspension UI to gsAdmin user details

### DIFF
--- a/static/app/types/user.tsx
+++ b/static/app/types/user.tsx
@@ -44,6 +44,7 @@ export interface User extends Omit<AvatarUser, 'options'> {
   isManaged: boolean;
   isStaff: boolean;
   isSuperuser: boolean;
+  isSuspended: boolean;
   lastActive: string;
   lastLogin: string;
   options: {

--- a/static/gsAdmin/components/users/userOverview.tsx
+++ b/static/gsAdmin/components/users/userOverview.tsx
@@ -70,7 +70,7 @@ export function UserOverview({
       <div>
         <DetailList>
           <DetailLabel title="Status">
-            {user.isActive ? 'Active' : 'Disabled'}
+            {user.isSuspended ? 'Suspended' : user.isActive ? 'Active' : 'Disabled'}
           </DetailLabel>
           <DetailLabel title="Email">
             <ExternalLink href={`mailto:${user.email}`}>{user.email}</ExternalLink>

--- a/static/gsAdmin/views/userDetails.spec.tsx
+++ b/static/gsAdmin/views/userDetails.spec.tsx
@@ -97,4 +97,100 @@ describe('User Details', () => {
       expect(screen.getByText('Revoke')).toBeInTheDocument();
     });
   });
+
+  describe('suspension', () => {
+    it('shows Suspend Account action for active users', async () => {
+      render(<UserDetails />, {
+        initialRouterConfig: {
+          location: {
+            pathname: `/admin/users/${mockUser.id}/`,
+          },
+          route: '/admin/users/:userId/',
+        },
+      });
+
+      await userEvent.click(
+        (await screen.findAllByRole('button', {name: 'Users Actions'}))[0]!
+      );
+      expect(screen.getByText('Suspend Account')).toBeInTheDocument();
+      expect(screen.queryByText('Unsuspend Account')).not.toBeInTheDocument();
+    });
+
+    it('shows Unsuspend Account action and Suspended badge for suspended users', async () => {
+      const suspendedUser = UserFixture({
+        ...mockUser,
+        isSuspended: true,
+      });
+      MockApiClient.addMockResponse({
+        url: `/users/${suspendedUser.id}/`,
+        body: suspendedUser,
+      });
+
+      render(<UserDetails />, {
+        initialRouterConfig: {
+          location: {
+            pathname: `/admin/users/${suspendedUser.id}/`,
+          },
+          route: '/admin/users/:userId/',
+        },
+      });
+
+      const suspendedElements = await screen.findAllByText('Suspended');
+      expect(suspendedElements.length).toBeGreaterThanOrEqual(1);
+
+      await userEvent.click(screen.getAllByRole('button', {name: 'Users Actions'})[0]!);
+      expect(screen.getByText('Unsuspend Account')).toBeInTheDocument();
+      expect(screen.queryByText('Suspend Account')).not.toBeInTheDocument();
+    });
+
+    it('hides Reactivate Account when user is suspended', async () => {
+      const suspendedInactiveUser = UserFixture({
+        ...mockUser,
+        isActive: false,
+        isSuspended: true,
+      });
+      MockApiClient.addMockResponse({
+        url: `/users/${suspendedInactiveUser.id}/`,
+        body: suspendedInactiveUser,
+      });
+
+      render(<UserDetails />, {
+        initialRouterConfig: {
+          location: {
+            pathname: `/admin/users/${suspendedInactiveUser.id}/`,
+          },
+          route: '/admin/users/:userId/',
+        },
+      });
+
+      await userEvent.click(
+        (await screen.findAllByRole('button', {name: 'Users Actions'}))[0]!
+      );
+      expect(screen.getByText('Unsuspend Account')).toBeInTheDocument();
+      expect(screen.queryByText('Reactivate Account')).not.toBeInTheDocument();
+    });
+
+    it('shows Suspended status in user overview', async () => {
+      const suspendedUser = UserFixture({
+        ...mockUser,
+        isSuspended: true,
+      });
+      MockApiClient.addMockResponse({
+        url: `/users/${suspendedUser.id}/`,
+        body: suspendedUser,
+      });
+
+      render(<UserDetails />, {
+        initialRouterConfig: {
+          location: {
+            pathname: `/admin/users/${suspendedUser.id}/`,
+          },
+          route: '/admin/users/:userId/',
+        },
+      });
+
+      const suspendedElements = await screen.findAllByText('Suspended');
+      expect(suspendedElements.length).toBeGreaterThanOrEqual(2);
+    });
+  });
 });

--- a/static/gsAdmin/views/userDetails.spec.tsx
+++ b/static/gsAdmin/views/userDetails.spec.tsx
@@ -136,7 +136,7 @@ describe('User Details', () => {
       });
 
       const suspendedElements = await screen.findAllByText('Suspended');
-      expect(suspendedElements.length).toBeGreaterThanOrEqual(1);
+      expect(suspendedElements).toHaveLength(2);
 
       await userEvent.click(screen.getAllByRole('button', {name: 'Users Actions'})[0]!);
       expect(screen.getByText('Unsuspend Account')).toBeInTheDocument();
@@ -190,7 +190,7 @@ describe('User Details', () => {
       });
 
       const suspendedElements = await screen.findAllByText('Suspended');
-      expect(suspendedElements.length).toBeGreaterThanOrEqual(2);
+      expect(suspendedElements).toHaveLength(2);
     });
   });
 });

--- a/static/gsAdmin/views/userDetails.tsx
+++ b/static/gsAdmin/views/userDetails.tsx
@@ -16,7 +16,8 @@ import {UserIdentityCategory, UserIdentityStatus} from 'sentry/types/auth';
 import type {InternalAppApiToken, User} from 'sentry/types/user';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
-import {setApiQueryData, useApiQuery} from 'sentry/utils/queryClient';
+import {fetchMutation, setApiQueryData, useApiQuery} from 'sentry/utils/queryClient';
+import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {useApi} from 'sentry/utils/useApi';
 import {useParams} from 'sentry/utils/useParams';
 
@@ -115,6 +116,28 @@ export function UserDetails() {
     },
     onError: () => {
       addErrorMessage('Unable to revoke token.');
+    },
+  });
+
+  const suspendMutation = useMutation({
+    mutationFn: (params: Record<string, any>) =>
+      fetchMutation({
+        url: `/_admin/users/${userId}/suspend/`,
+        method: 'POST',
+        data: params,
+      }),
+    onMutate: () => {
+      addLoadingMessage('Saving changes...');
+    },
+    onSuccess: (_data, params) => {
+      clearIndicators();
+      const action = params.action === 'suspend' ? 'suspended' : 'unsuspended';
+      addSuccessMessage(`User account has been ${action}.`);
+      queryClient.invalidateQueries({queryKey: makeFetchUserQueryKey()});
+    },
+    onError: (error: RequestError) => {
+      clearIndicators();
+      addErrorMessage(error.message ?? 'Failed to update user suspension status.');
     },
   });
 
@@ -273,14 +296,18 @@ export function UserDetails() {
           name: 'Suspend Account',
           help: 'Prevent this user from logging in. Account and data are preserved.',
           visible: user.isActive && !user.isSuspended,
-          onAction: () => onUpdateMutation.mutate({isSuspended: true}),
+          confirmModalOpts: {
+            priority: 'danger',
+            confirmText: 'Suspend Account',
+          },
+          onAction: params => suspendMutation.mutate({...params, action: 'suspend'}),
         },
         {
           key: 'unsuspend',
           name: 'Unsuspend Account',
           help: 'Allow this user to log in again.',
           visible: user.isSuspended,
-          onAction: () => onUpdateMutation.mutate({isSuspended: false}),
+          onAction: params => suspendMutation.mutate({...params, action: 'unsuspend'}),
         },
       ]}
       sections={[

--- a/static/gsAdmin/views/userDetails.tsx
+++ b/static/gsAdmin/views/userDetails.tsx
@@ -17,7 +17,6 @@ import type {InternalAppApiToken, User} from 'sentry/types/user';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import type {ApiQueryKey} from 'sentry/utils/queryClient';
 import {fetchMutation, setApiQueryData, useApiQuery} from 'sentry/utils/queryClient';
-import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {useApi} from 'sentry/utils/useApi';
 import {useParams} from 'sentry/utils/useParams';
 
@@ -135,9 +134,9 @@ export function UserDetails() {
       addSuccessMessage(`User account has been ${action}.`);
       queryClient.invalidateQueries({queryKey: makeFetchUserQueryKey()});
     },
-    onError: (error: RequestError) => {
+    onError: () => {
       clearIndicators();
-      addErrorMessage(error.message ?? 'Failed to update user suspension status.');
+      addErrorMessage('Failed to update user suspension status.');
     },
   });
 

--- a/static/gsAdmin/views/userDetails.tsx
+++ b/static/gsAdmin/views/userDetails.tsx
@@ -227,7 +227,10 @@ export function UserDetails() {
     <DetailsPage
       rootName="Users"
       name={user.name === user.email ? user.email : `${user.name} (${user.email})`}
-      badges={[{name: 'Inactive', level: 'warning', visible: !user.isActive}]}
+      badges={[
+        {name: 'Inactive', level: 'warning', visible: !user.isActive},
+        {name: 'Suspended', level: 'danger', visible: user.isSuspended},
+      ]}
       actions={[
         {
           key: 'edit-permissions',
@@ -262,8 +265,22 @@ export function UserDetails() {
           key: 'reactivate',
           name: 'Reactivate Account',
           help: 'Restores this account allowing the user to login.',
-          visible: !user.isActive,
+          visible: !user.isActive && !user.isSuspended,
           onAction: () => onUpdateMutation.mutate({isActive: 1}),
+        },
+        {
+          key: 'suspend',
+          name: 'Suspend Account',
+          help: 'Prevent this user from logging in. Account and data are preserved.',
+          visible: user.isActive && !user.isSuspended,
+          onAction: () => onUpdateMutation.mutate({isSuspended: true}),
+        },
+        {
+          key: 'unsuspend',
+          name: 'Unsuspend Account',
+          help: 'Allow this user to log in again.',
+          visible: user.isSuspended,
+          onAction: () => onUpdateMutation.mutate({isSuspended: false}),
         },
       ]}
       sections={[

--- a/tests/js/fixtures/commitAuthor.ts
+++ b/tests/js/fixtures/commitAuthor.ts
@@ -28,6 +28,7 @@ export function CommitAuthorFixture(params: Partial<User> = {}): User {
       avatarType: 'letter_avatar',
     },
     hasPasswordAuth: true,
+    isSuspended: false,
     email: 'example@sentry.io',
     authenticators: [],
     options: {

--- a/tests/js/fixtures/user.ts
+++ b/tests/js/fixtures/user.ts
@@ -29,6 +29,7 @@ export function UserFixture(params: Partial<User> = {}): User {
     isManaged: false,
     isStaff: false,
     isSuperuser: false,
+    isSuspended: false,
     lastActive: '2020-01-01T00:00:00.000Z',
     lastLogin: '2020-01-01T00:00:00.000Z',
     permissions: new Set(),

--- a/tests/js/fixtures/userDetails.ts
+++ b/tests/js/fixtures/userDetails.ts
@@ -40,6 +40,7 @@ export function UserDetailsFixture(params: Partial<User> = {}): User {
     canReset2fa: false,
     flags: {newsletter_consent_prompt: false},
     hasPasswordAuth: false,
+    isSuspended: false,
     ...params,
   };
 }


### PR DESCRIPTION
Add Suspend/Unsuspend actions and Suspended badge to the gsAdmin user detail page so admins can manage user suspension from `/_admin/users/:userId/`.

<img width="252" height="365" alt="Screenshot 2026-04-29 at 8 31 29 PM" src="https://github.com/user-attachments/assets/cebdb2d1-0395-41eb-9c94-ca4305686352" />

<img width="651" height="460" alt="Screenshot 2026-04-29 at 8 32 10 PM" src="https://github.com/user-attachments/assets/c742a567-c8a3-4b7b-9bb6-95ec8da5bbab" />

<img width="431" height="247" alt="Screenshot 2026-04-29 at 8 33 29 PM" src="https://github.com/user-attachments/assets/87710e18-903d-4446-b15d-c62bb257c7ca" />



**Actions**

- "Suspend Account" — visible for active, non-suspended users. Calls `PUT /api/0/users/{id}/` with `{isSuspended: true}`.
- "Unsuspend Account" — visible for suspended users. Calls `PUT /api/0/users/{id}/` with `{isSuspended: false}`.
- "Reactivate Account" is hidden when a user is suspended, since only unsuspending should be offered first.

**Status Display**

The user overview shows "Suspended", "Active", or "Disabled". A red "Suspended" badge appears next to the user name (can coexist with the "Inactive" badge).

Depends on on #114349 and https://github.com/getsentry/getsentry/pull/20159 (backend logic), and #114328 (migration).