### PR TITLE
style(snapshots): Refine snapshot sidebar

### DIFF
--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.snapshots.tsx
@@ -1,0 +1,109 @@
+import {ThemeProvider} from '@emotion/react';
+
+// eslint-disable-next-line no-restricted-imports -- SSR snapshot rendering needs direct theme access
+import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
+import {DiffStatus} from 'sentry/views/preprod/types/snapshotTypes';
+
+import {SnapshotSidebarContent, type SidebarGroup} from './snapshotSidebarContent';
+
+jest.mock('@sentry/scraps/layout', () => {
+  const actual = jest.requireActual('@sentry/scraps/layout');
+  return {
+    ...actual,
+    Stack: (props: any) => <actual.Flex direction="column" {...props} />,
+  };
+});
+
+const themes = {light: lightTheme, dark: darkTheme};
+
+const noop = () => {};
+
+const groups: SidebarGroup[] = [
+  {key: 'Button/light', name: 'Button/light', count: 1},
+  {key: 'Alert/dark', name: 'Alert/dark', count: 3},
+  {key: 'Badge/light', name: 'Badge/light', count: 4},
+  {key: 'Checkbox/theme-dark', name: 'Checkbox/theme-dark', count: 2},
+];
+
+const statusCounts: Record<DiffStatus, number> = {
+  [DiffStatus.CHANGED]: 2,
+  [DiffStatus.ADDED]: 0,
+  [DiffStatus.REMOVED]: 0,
+  [DiffStatus.RENAMED]: 0,
+  [DiffStatus.UNCHANGED]: 2,
+};
+
+describe('SnapshotSidebarContent', () => {
+  describe.each(['light', 'dark'] as const)('%s', themeName => {
+    function Wrapper({children}: {children: React.ReactNode}) {
+      return (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{height: 520, width: 350}}>{children}</div>
+        </ThemeProvider>
+      );
+    }
+
+    it.snapshot(
+      'all-selected',
+      () => (
+        <Wrapper>
+          <SnapshotSidebarContent
+            groups={groups}
+            currentItemKey="Button/light"
+            isAllSelected
+            searchQuery=""
+            onSearchChange={noop}
+            onSelectItem={noop}
+            onSelectAll={noop}
+            statusCounts={statusCounts}
+            activeStatuses={new Set()}
+            onToggleStatus={noop}
+          />
+        </Wrapper>
+      ),
+      {theme: themeName, state: 'all-selected'}
+    );
+
+    it.snapshot(
+      'child-selected',
+      () => (
+        <Wrapper>
+          <SnapshotSidebarContent
+            groups={groups}
+            currentItemKey="Badge/light"
+            isAllSelected={false}
+            searchQuery=""
+            onSearchChange={noop}
+            onSelectItem={noop}
+            onSelectAll={noop}
+            statusCounts={statusCounts}
+            activeStatuses={new Set([DiffStatus.UNCHANGED])}
+            onToggleStatus={noop}
+          />
+        </Wrapper>
+      ),
+      {theme: themeName, state: 'child-selected'}
+    );
+
+    it.snapshot(
+      'no-results',
+      () => (
+        <Wrapper>
+          <SnapshotSidebarContent
+            groups={[]}
+            currentItemKey={null}
+            isAllSelected
+            searchQuery="missing"
+            onSearchChange={noop}
+            onSelectItem={noop}
+            onSelectAll={noop}
+            statusCounts={statusCounts}
+            activeStatuses={new Set([DiffStatus.CHANGED, DiffStatus.UNCHANGED])}
+            onToggleStatus={noop}
+          />
+        </Wrapper>
+      ),
+      {theme: themeName, state: 'no-results'}
+    );
+  });
+});

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -278,15 +278,10 @@ const SidebarItemRow = styled('div')<{isSelected: boolean}>`
   cursor: pointer;
   border-right: 3px solid
     ${p => (p.isSelected ? p.theme.tokens.border.accent.vibrant : 'transparent')};
-  border-bottom: 1px solid ${p => p.theme.tokens.border.secondary};
   background: ${p =>
     p.isSelected ? p.theme.tokens.background.transparent.accent.muted : 'transparent'};
 
   &:hover {
     background: ${p => p.theme.tokens.background.secondary};
-  }
-
-  &:last-child {
-    border-bottom: none;
   }
 `;

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -548,6 +548,7 @@ export default function SnapshotsPage() {
       <Flex
         flexShrink={0}
         overflow="auto"
+        borderRight="primary"
         style={{
           width: sidebarWidth,
           height: hasPageFrameFeature


### PR DESCRIPTION
Refine the preprod snapshot sidebar so it has a persistent primary divider and no row separators between menu items. This also adds light and dark visual snapshot coverage for the sidebar menu states we are iterating on.

**Sidebar Styling**

The sidebar wrapper now owns the right border, while individual rows no longer draw bottom borders. This keeps the menu as a continuous surface while preserving the selected row accent.

**Snapshot Coverage**

Adds visual snapshots for all-selected, child-selected, and no-results sidebar states across light and dark themes.

Stacked on #114271