### PR TITLE
feat(seer): Plumb reasoning_effort through trigger_autofix_explorer

### DIFF
--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -239,6 +239,7 @@ def trigger_autofix_explorer(
     run_id: int | None = None,
     stopping_point: AutofixStoppingPoint | None = None,
     intelligence_level: Literal["low", "medium", "high"] = "medium",
+    reasoning_effort: Literal["low", "medium", "high"] | None = None,
     user_context: str | None = None,
     insert_index: int | None = None,
 ) -> int:
@@ -277,7 +278,9 @@ def trigger_autofix_explorer(
     client = get_autofix_explorer_client(
         group,
         intelligence_level=intelligence_level,
-        reasoning_effort=config.reasoning_effort,
+        reasoning_effort=reasoning_effort
+        if reasoning_effort is not None
+        else config.reasoning_effort,
         enable_coding=config.enable_coding,
     )
 

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from enum import StrEnum
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel
 from rest_framework.exceptions import PermissionDenied
@@ -60,6 +60,8 @@ if TYPE_CHECKING:
     from sentry.models.organization import Organization
 
 logger = logging.getLogger(__name__)
+
+_UNSET: Any = object()
 
 
 class NoSeerQuotaException(Exception):
@@ -239,7 +241,7 @@ def trigger_autofix_explorer(
     run_id: int | None = None,
     stopping_point: AutofixStoppingPoint | None = None,
     intelligence_level: Literal["low", "medium", "high"] = "medium",
-    reasoning_effort: Literal["low", "medium", "high"] | None = None,
+    reasoning_effort: Literal["low", "medium", "high"] | None = _UNSET,
     user_context: str | None = None,
     insert_index: int | None = None,
 ) -> int:
@@ -278,9 +280,9 @@ def trigger_autofix_explorer(
     client = get_autofix_explorer_client(
         group,
         intelligence_level=intelligence_level,
-        reasoning_effort=reasoning_effort
-        if reasoning_effort is not None
-        else config.reasoning_effort,
+        reasoning_effort=(
+            config.reasoning_effort if reasoning_effort is _UNSET else reasoning_effort
+        ),
         enable_coding=config.enable_coding,
     )
 

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -286,6 +286,7 @@ def run_night_shift_execution(
         issues = _run_autofix_for_candidates(
             run=run,
             candidates=candidates,
+            options=resolved_options,
             log_extra=log_extra,
         )
         seer_run_id_by_group = {i.group_id: i.seer_run_id for i in issues}
@@ -416,6 +417,7 @@ def _get_eligible_projects(
 def _run_autofix_for_candidates(
     run: SeerNightShiftRun,
     candidates: Sequence[TriageResult],
+    options: SeerNightShiftRunOptions,
     log_extra: dict[str, object],
 ) -> list[SeerNightShiftRunIssue]:
     """
@@ -456,6 +458,8 @@ def _run_autofix_for_candidates(
                 step=AutofixStep.ROOT_CAUSE,
                 referrer=referrer,
                 stopping_point=stopping_point,
+                intelligence_level=options["intelligence_level"],
+                reasoning_effort=options["reasoning_effort"],
                 user_context=user_context,
             )
         except Exception:

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -502,6 +502,31 @@ class TestTriggerAutofixExplorer(TestCase):
 
         assert mock_client_class.call_args.kwargs["reasoning_effort"] == "low"
 
+    @patch("sentry.quotas.backend.record_seer_run")
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
+    @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
+    @patch("sentry.seer.autofix.autofix_agent.SeerExplorerClient")
+    def test_explicit_none_reasoning_effort_bypasses_step_default(
+        self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
+    ):
+        # Guard against the step default drifting to None and making this test
+        # pass coincidentally.
+        assert STEP_CONFIGS[AutofixStep.ROOT_CAUSE].reasoning_effort is not None
+
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.start_run.return_value = 123
+
+        trigger_autofix_explorer(
+            group=self.group,
+            step=AutofixStep.ROOT_CAUSE,
+            referrer=AutofixReferrer.UNKNOWN,
+            run_id=None,
+            reasoning_effort=None,
+        )
+
+        assert mock_client_class.call_args.kwargs["reasoning_effort"] is None
+
 
 class TestTriggerCodingAgentHandoff(TestCase):
     """Tests for trigger_coding_agent_handoff function."""

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -481,31 +481,6 @@ class TestTriggerAutofixExplorer(TestCase):
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
     @patch("sentry.seer.autofix.autofix_agent.SeerExplorerClient")
-    def test_reasoning_effort_override_wins_over_step_config(
-        self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
-    ):
-        # Guard against the step default drifting to "low" and making this test
-        # pass coincidentally even if the override plumbing breaks.
-        assert STEP_CONFIGS[AutofixStep.ROOT_CAUSE].reasoning_effort != "low"
-
-        mock_client = MagicMock()
-        mock_client_class.return_value = mock_client
-        mock_client.start_run.return_value = 123
-
-        trigger_autofix_explorer(
-            group=self.group,
-            step=AutofixStep.ROOT_CAUSE,
-            referrer=AutofixReferrer.UNKNOWN,
-            run_id=None,
-            reasoning_effort="low",
-        )
-
-        assert mock_client_class.call_args.kwargs["reasoning_effort"] == "low"
-
-    @patch("sentry.quotas.backend.record_seer_run")
-    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
-    @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.autofix_agent.SeerExplorerClient")
     def test_explicit_none_reasoning_effort_bypasses_step_default(
         self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
     ):

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -6,6 +6,7 @@ from rest_framework.exceptions import PermissionDenied
 
 from sentry.constants import DataCategory
 from sentry.seer.autofix.autofix_agent import (
+    STEP_CONFIGS,
     AutofixStep,
     NoSeerQuotaException,
     build_step_prompt,
@@ -452,6 +453,50 @@ class TestTriggerAutofixExplorer(TestCase):
         mock_client.continue_run.assert_called_once()
         mock_check_quota.assert_not_called()
         mock_record_run.assert_not_called()
+
+    @patch("sentry.quotas.backend.record_seer_run")
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
+    @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
+    @patch("sentry.seer.autofix.autofix_agent.SeerExplorerClient")
+    def test_reasoning_effort_falls_back_to_step_config_default(
+        self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
+    ):
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.start_run.return_value = 123
+
+        trigger_autofix_explorer(
+            group=self.group,
+            step=AutofixStep.ROOT_CAUSE,
+            referrer=AutofixReferrer.UNKNOWN,
+            run_id=None,
+        )
+
+        assert (
+            mock_client_class.call_args.kwargs["reasoning_effort"]
+            == STEP_CONFIGS[AutofixStep.ROOT_CAUSE].reasoning_effort
+        )
+
+    @patch("sentry.quotas.backend.record_seer_run")
+    @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
+    @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
+    @patch("sentry.seer.autofix.autofix_agent.SeerExplorerClient")
+    def test_reasoning_effort_override_wins_over_step_config(
+        self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
+    ):
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.start_run.return_value = 123
+
+        trigger_autofix_explorer(
+            group=self.group,
+            step=AutofixStep.ROOT_CAUSE,
+            referrer=AutofixReferrer.UNKNOWN,
+            run_id=None,
+            reasoning_effort="low",
+        )
+
+        assert mock_client_class.call_args.kwargs["reasoning_effort"] == "low"
 
 
 class TestTriggerCodingAgentHandoff(TestCase):

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -484,6 +484,10 @@ class TestTriggerAutofixExplorer(TestCase):
     def test_reasoning_effort_override_wins_over_step_config(
         self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
     ):
+        # Guard against the step default drifting to "low" and making this test
+        # pass coincidentally even if the override plumbing breaks.
+        assert STEP_CONFIGS[AutofixStep.ROOT_CAUSE].reasoning_effort != "low"
+
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
         mock_client.start_run.return_value = 123

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -376,6 +376,21 @@ class TestRunNightShiftForOrg(TestCase, SnubaTestCase):
         )
         assert issue_run_ids == {autofix_group.id: "42", root_cause_group.id: "99"}
 
+    def test_forwards_reasoning_effort_to_trigger(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        self._make_eligible(project)
+
+        group = self._store_event_and_update_group(
+            project, "fixable", seer_fixability_score=0.9, times_seen=5
+        )
+
+        with self._patched_night_shift([(group.id, "autofix")]) as (mock_trigger, _):
+            run_night_shift_for_org(org.id, options={"reasoning_effort": "low"})
+
+        mock_trigger.assert_called_once()
+        assert mock_trigger.call_args.kwargs["reasoning_effort"] == "low"
+
     def test_dry_run_skips_autofix(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)


### PR DESCRIPTION
`trigger_autofix_explorer` previously hardcoded `reasoning_effort` to `STEP_CONFIGS[step].reasoning_effort`, so callers couldn't override it.

Adds an optional `reasoning_effort` parameter that wins over the step default when provided, and threads the night-shift run's `options["reasoning_effort"]` through to it so per-run tweaks actually take effect.

Note: this PR also forwards `options["intelligence_level"]` through to `trigger_autofix_explorer`. That intentionally changes the effective default for cron-triggered night-shift runs from `"medium"` (the `trigger_autofix_explorer` parameter default) to `"high"` (`DEFAULT_INTELLIGENCE_LEVEL`). The night-shift options are now the single source of truth for both knobs.