### PR TITLE
fix(ACI): Don't show deactivated user id for detector created by

### DIFF
--- a/static/app/utils/useUserFromId.tsx
+++ b/static/app/utils/useUserFromId.tsx
@@ -20,9 +20,5 @@ export function useUserFromId({id}: {id: number | undefined}) {
     }
   );
 
-  if (isError) {
-    return {isPending: false, data: {name: id}};
-  }
-
-  return {isPending, data};
+  return {isPending, isError, data};
 }

--- a/static/app/utils/useUserFromId.tsx
+++ b/static/app/utils/useUserFromId.tsx
@@ -7,7 +7,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 export function useUserFromId({id}: {id: number | undefined}) {
   const organization = useOrganization();
 
-  const {isPending, isError, data} = useApiQuery<User>(
+  return useApiQuery<User>(
     [
       getApiUrl('/organizations/$organizationIdOrSlug/users/$userId/', {
         path: {organizationIdOrSlug: organization.slug, userId: id!},
@@ -19,6 +19,4 @@ export function useUserFromId({id}: {id: number | undefined}) {
       enabled: typeof id === 'number',
     }
   );
-
-  return {isPending, isError, data};
 }

--- a/static/app/views/detectors/components/details/common/extraDetails.spec.tsx
+++ b/static/app/views/detectors/components/details/common/extraDetails.spec.tsx
@@ -1,0 +1,51 @@
+import {MetricDetectorFixture} from 'sentry-fixture/detectors';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {UserFixture} from 'sentry-fixture/user';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {DetectorExtraDetails} from './extraDetails';
+
+describe('DetectorExtraDetails.CreatedBy', () => {
+  const organization = OrganizationFixture();
+  const user = UserFixture();
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('renders "Sentry" when createdBy is null', () => {
+    const detector = MetricDetectorFixture({createdBy: null});
+
+    render(<DetectorExtraDetails.CreatedBy detector={detector} />, {organization});
+
+    expect(screen.getByText('Sentry')).toBeInTheDocument();
+  });
+
+  it('renders the user name when user is found', async () => {
+    const detector = MetricDetectorFixture({createdBy: user.id});
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/users/${user.id}/`,
+      body: user,
+    });
+
+    render(<DetectorExtraDetails.CreatedBy detector={detector} />, {organization});
+
+    expect(await screen.findByText(user.name)).toBeInTheDocument();
+  });
+
+  it('renders "Deactivated user" when user cannot be found', async () => {
+    const detector = MetricDetectorFixture({createdBy: user.id});
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/users/${user.id}/`,
+      statusCode: 404,
+      body: {detail: 'Not found'},
+    });
+
+    render(<DetectorExtraDetails.CreatedBy detector={detector} />, {organization});
+
+    expect(await screen.findByText('Deactivated user')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/detectors/components/details/common/extraDetails.tsx
+++ b/static/app/views/detectors/components/details/common/extraDetails.tsx
@@ -50,7 +50,11 @@ DetectorExtraDetails.CreatedBy = function DetectorExtraDetailsCreatedBy({
 }) {
   const createdBy = detector.createdBy ?? null;
 
-  const {isPending, data: user} = useUserFromId({
+  const {
+    isPending,
+    isError,
+    data: user,
+  } = useUserFromId({
     id: createdBy ? parseInt(createdBy, 10) : undefined,
   });
 
@@ -67,6 +71,10 @@ DetectorExtraDetails.CreatedBy = function DetectorExtraDetailsCreatedBy({
         value={<Placeholder width="80px" height="16px" />}
       />
     );
+  }
+
+  if (isError) {
+    return <KeyValueTableRow keyName={keyName} value={t('Deactivated user')} />;
   }
 
   const title = user?.name ?? user?.email ?? t('Unknown');

--- a/static/app/views/settings/featureFlags/changeTracking/organizationFeatureFlagsProviderRow.tsx
+++ b/static/app/views/settings/featureFlags/changeTracking/organizationFeatureFlagsProviderRow.tsx
@@ -37,7 +37,9 @@ export function OrganizationFeatureFlagsProviderRow({
         <TimeSince date={secret.createdAt} />
       </Flex>
 
-      <Flex align="center">{isUserPending ? <LoadingIndicator mini /> : user?.name}</Flex>
+      <Flex align="center">
+        {isUserPending ? <LoadingIndicator mini /> : (user?.name ?? t('Unknown'))}
+      </Flex>
 
       <Flex justify="end">
         <Tooltip

--- a/static/app/views/settings/featureFlags/changeTracking/organizationFeatureFlagsProviderRow.tsx
+++ b/static/app/views/settings/featureFlags/changeTracking/organizationFeatureFlagsProviderRow.tsx
@@ -38,7 +38,11 @@ export function OrganizationFeatureFlagsProviderRow({
       </Flex>
 
       <Flex align="center">
-        {isUserPending ? <LoadingIndicator mini /> : (user?.name ?? t('Unknown'))}
+        {isUserPending ? (
+          <LoadingIndicator mini />
+        ) : (
+          (user?.name ?? t('Deactivated user'))
+        )}
       </Flex>
 
       <Flex justify="end">


### PR DESCRIPTION
If a deactivated user created an alert we currently show the ID we have stored on the `Detector.created_by_id` field because we're not able to look up the username. Instead of showing that, we can just show "Deactivated user". I'm open to other ideas for what to show.

<img width="345" height="262" alt="Screenshot 2026-04-29 at 1 24 38 PM" src="https://github.com/user-attachments/assets/1c3c83b8-cef5-4bbc-9d88-bb1ba24a28d0" />
