### PR TITLE
ref(grouping): Restrict values in IPv4 regex

### DIFF
--- a/src/sentry/grouping/parameterization.py
+++ b/src/sentry/grouping/parameterization.py
@@ -236,8 +236,18 @@ DEFAULT_PARAMETERIZATION_REGEXES = [
             (::[fF]{4}:)? # Optional prefix mapping the IPv4 address which follows to IPv6 format
             (
                 \b
-                (\d{1,3}\.){3} # Three sets of 1-3 digits, each followed by a literal dot
-                \d{1,3} # Final set of 1-3 digits
+                # Three numbers from 0-255, each followed by a literal dot, no leading zeros allowed
+                (
+                    (
+                        \d | # 0-9
+                        [1-9]\d | # 10-99
+                        1\d{2} | # 100-199
+                        2[0-4]\d | # 200-249
+                        25[0-5] # 250-255
+                    )\.
+                ){3}
+                # Final number from 0-255 (same pattern alternatives as above)
+                (\d | [1-9]\d | 1\d{2} | 2[0-4]\d | 25[0-5])
                 (/\d{1,2})? # Optional CIDR suffix
                 \b
             )

--- a/tests/sentry/grouping/test_parameterization.py
+++ b/tests/sentry/grouping/test_parameterization.py
@@ -802,8 +802,8 @@ ip_false_positive_cases = [
     ("ip - single leading colon", "Script error. :0:0", False),
     ("ip - single trailing colon", "12::31:", False),
     ("ip - too few segments", "12:31:99", True),
-    ("ip - v4 leading zeros", "11.21.12.001", True),
-    ("ip - v4 segment > 255", "12.31.12.908", True),
+    ("ip - v4 leading zeros", "11.21.12.001", False),
+    ("ip - v4 segment > 255", "12.31.12.908", False),
     ("ip - v4 too many segments", "11.21.12.31.12", True),
     ("date - colon btwn date and time", "21/Nov/2012:12:31:12", True),
 ]


### PR DESCRIPTION
This tightens our IPv4 regex to only allow valid values in each spot (nothing higher than 255, no leading zeros). No behavior changes, but should reduce the number of times we're hitting the false-positive fallback (which is slower than the happy path).