### PR TITLE
fix(pipeline): Guard against missing installation_id in GitHub install redirect

### DIFF
--- a/src/sentry/web/frontend/pipeline_advancer.py
+++ b/src/sentry/web/frontend/pipeline_advancer.py
@@ -124,12 +124,13 @@ class PipelineAdvancerView(BaseView):
         # GitHub apps may be installed directly from GitHub, in which case
         # they will redirect here *without* being in the pipeline. If that happens
         # redirect to the integration install org picker.
+        installation_id = request.GET.get("installation_id")
         if (
             provider_id == IntegrationProviderSlug.GITHUB.value
             and request.GET.get("setup_action") == "install"
             and pipeline is None
+            and installation_id
         ):
-            installation_id = request.GET.get("installation_id")
             return self.redirect(
                 reverse("integration-installation", args=[provider_id, installation_id])
             )


### PR DESCRIPTION
When `setup_action=install` is present but `installation_id` is missing, `reverse()` raises `NoReverseMatch` since the URL pattern requires a `\w+` match. Adds `installation_id` to the condition check, matching the same guard already present in the trampoline fallback logic.