### PR TITLE
feat(github-enterprise): Add API-driven pipeline backend for GHE integration setup

### DIFF
--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -9,8 +9,11 @@ from django.http.request import HttpRequest
 from django.http.response import HttpResponseBase, HttpResponseRedirect
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
+from rest_framework.fields import BooleanField, CharField, URLField
 
 from sentry import features, http
+from sentry.api.serializers.rest_framework.base import CamelSnakeSerializer
+from sentry.identity.oauth2 import OAuth2ApiStep
 from sentry.identity.pipeline import IdentityPipeline
 from sentry.integrations.base import (
     FeatureDescription,
@@ -46,7 +49,8 @@ from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.repository import Repository
 from sentry.organizations.services.organization import organization_service
 from sentry.organizations.services.organization.model import RpcOrganization
-from sentry.pipeline.views.base import PipelineView
+from sentry.pipeline.types import PipelineStepResult
+from sentry.pipeline.views.base import ApiPipelineSteps, PipelineView
 from sentry.pipeline.views.nested import NestedPipelineView
 from sentry.shared_integrations.constants import ERR_INTERNAL, ERR_UNAUTHORIZED
 from sentry.shared_integrations.exceptions import (
@@ -554,6 +558,111 @@ class GitHubEnterpriseIntegration(
             self.org_integration = org_integration
 
 
+class GHEInstallationConfigSerializer(CamelSnakeSerializer):
+    url = URLField(required=True)
+    id = CharField(required=True)
+    name = CharField(required=True)
+    public_link = URLField(required=False, allow_blank=True, default="")
+    verify_ssl = BooleanField(required=False, default=True)
+    webhook_secret = CharField(required=True)
+    private_key = CharField(required=True)
+    client_id = CharField(required=True)
+    client_secret = CharField(required=True)
+
+
+class GHEInstallationConfigApiStep:
+    step_name = "installation_config"
+
+    def get_step_data(self, pipeline: IntegrationPipeline, request: HttpRequest) -> dict[str, Any]:
+        return {
+            "defaults": {
+                "verifySsl": True,
+            },
+        }
+
+    def get_serializer_cls(self) -> type:
+        return GHEInstallationConfigSerializer
+
+    def handle_post(
+        self,
+        validated_data: dict[str, Any],
+        pipeline: IntegrationPipeline,
+        request: HttpRequest,
+    ) -> PipelineStepResult:
+        validated_data["url"] = urlparse(validated_data["url"]).netloc.lower()
+
+        if validated_data["url"] == "github.com" and not features.has(
+            "organizations:github-enterprise-github-com-source",
+            pipeline.organization,
+        ):
+            return PipelineStepResult.error(
+                "Installing on github.com is not enabled for your organization. "
+                "Contact Sentry support to request access."
+            )
+
+        if not validated_data["public_link"]:
+            validated_data["public_link"] = None
+
+        pipeline.bind_state("installation_data", validated_data)
+        pipeline.bind_state(
+            "oauth_config_information",
+            {
+                "access_token_url": f"https://{validated_data['url']}/login/oauth/access_token",
+                "authorize_url": f"https://{validated_data['url']}/login/oauth/authorize",
+                "client_id": validated_data["client_id"],
+                "client_secret": validated_data["client_secret"],
+                "verify_ssl": validated_data["verify_ssl"],
+            },
+        )
+        return PipelineStepResult.advance()
+
+
+class GHEAppInstallSerializer(CamelSnakeSerializer):
+    installation_id = CharField(required=False, allow_blank=True, default="")
+
+
+def _get_app_install_url(installation_data: Mapping[str, Any]) -> str:
+    if installation_data.get("public_link"):
+        return installation_data["public_link"]
+
+    url = installation_data.get("url")
+    name = installation_data.get("name")
+    # github.com uses /apps/{name}; GHES uses /github-apps/{name}.
+    if url == "github.com":
+        return f"https://{url}/apps/{name}"
+    return f"https://{url}/github-apps/{name}"
+
+
+class GHEAppInstallRedirectApiStep:
+    step_name = "app_install_redirect"
+
+    def get_step_data(self, pipeline: IntegrationPipeline, request: HttpRequest) -> dict[str, Any]:
+        installation_data = pipeline.fetch_state("installation_data")
+        if installation_data is None:
+            raise AssertionError("pipeline called out of order")
+        return {"appInstallUrl": _get_app_install_url(installation_data)}
+
+    def get_serializer_cls(self) -> type:
+        return GHEAppInstallSerializer
+
+    def handle_post(
+        self,
+        validated_data: dict[str, Any],
+        pipeline: IntegrationPipeline,
+        request: HttpRequest,
+    ) -> PipelineStepResult:
+        installation_id = validated_data.get("installation_id")
+        if not installation_id:
+            installation_data = pipeline.fetch_state("installation_data")
+            if installation_data is None:
+                raise AssertionError("pipeline called out of order")
+            return PipelineStepResult.stay(
+                data={"appInstallUrl": _get_app_install_url(installation_data)}
+            )
+        pipeline.bind_state("installation_id", installation_id)
+        return PipelineStepResult.advance()
+
+
 class InstallationForm(forms.Form):
     url = forms.CharField(
         label="Installation Url",
@@ -738,11 +847,30 @@ class GitHubEnterpriseIntegrationProvider(GitHubIntegrationProvider):
         return (
             InstallationConfigView(),
             GitHubEnterpriseInstallationRedirect(),
-            # The identity provider pipeline should be constructed at execution
-            # time, this allows for the oauth configuration parameters to be made
-            # available from the installation config view.
             lambda: self._make_identity_pipeline_view(),
         )
+
+    def _make_oauth_api_step(self) -> OAuth2ApiStep:
+        oauth_info = self.pipeline.fetch_state("oauth_config_information")
+        if oauth_info is None:
+            raise AssertionError("pipeline called out of order")
+        return OAuth2ApiStep(
+            authorize_url=oauth_info["authorize_url"],
+            client_id=oauth_info["client_id"],
+            client_secret=oauth_info["client_secret"],
+            access_token_url=oauth_info["access_token_url"],
+            scope="",
+            redirect_url=absolute_uri("/extensions/github-enterprise/setup/"),
+            verify_ssl=oauth_info.get("verify_ssl", True),
+            bind_key="oauth_data",
+        )
+
+    def get_pipeline_api_steps(self) -> ApiPipelineSteps[IntegrationPipeline]:
+        return [
+            GHEInstallationConfigApiStep(),
+            GHEAppInstallRedirectApiStep(),
+            lambda: self._make_oauth_api_step(),
+        ]
 
     def post_install(
         self,
@@ -792,7 +920,13 @@ class GitHubEnterpriseIntegrationProvider(GitHubIntegrationProvider):
         return None
 
     def build_integration(self, state: Mapping[str, Any]) -> IntegrationData:
-        identity = state["identity"]["data"]
+        # TODO: legacy views write token data to state["identity"]["data"] via
+        # NestedPipelineView. API steps write directly to state["oauth_data"].
+        # Remove the legacy path once the old views are retired.
+        if "oauth_data" in state:
+            identity = state["oauth_data"]
+        else:
+            identity = state["identity"]["data"]
         installation_data = state["installation_data"]
         user = get_user_info(installation_data["url"], identity["access_token"])
         installation = self._get_ghe_installation_info(
@@ -838,22 +972,13 @@ class GitHubEnterpriseIntegrationProvider(GitHubIntegrationProvider):
 
 
 class GitHubEnterpriseInstallationRedirect:
-    def get_app_url(self, installation_data):
-        if installation_data.get("public_link"):
-            return installation_data["public_link"]
-
-        url = installation_data.get("url")
-        name = installation_data.get("name")
-        # github.com uses /apps/{name}; GHES uses /github-apps/{name}.
-        if url == "github.com":
-            return f"https://{url}/apps/{name}"
-        return f"https://{url}/github-apps/{name}"
-
     def dispatch(self, request: HttpRequest, pipeline: IntegrationPipeline) -> HttpResponseBase:
         installation_data = pipeline.fetch_state(key="installation_data")
+        if installation_data is None:
+            raise AssertionError("pipeline called out of order")
 
         if "installation_id" in request.GET:
             pipeline.bind_state("installation_id", request.GET["installation_id"])
             return pipeline.next_step()
 
-        return HttpResponseRedirect(self.get_app_url(installation_data))
+        return HttpResponseRedirect(_get_app_install_url(installation_data))

--- a/tests/sentry/integrations/github_enterprise/test_integration.py
+++ b/tests/sentry/integrations/github_enterprise/test_integration.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 from dataclasses import asdict
 from datetime import datetime, timezone
+from typing import Any
 from unittest import mock
 from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qs, urlencode, urlparse
@@ -9,18 +12,20 @@ import pytest
 import responses
 from django.http import HttpResponse
 from django.test import RequestFactory
+from django.urls import reverse
 
 from sentry.integrations.github_enterprise.client import GitHubEnterpriseApiClient
 from sentry.integrations.github_enterprise.integration import (
-    GitHubEnterpriseInstallationRedirect,
     GitHubEnterpriseIntegration,
     GitHubEnterpriseIntegrationProvider,
     InstallationConfigView,
     _api_base_url,
+    _get_app_install_url,
     get_user_info,
 )
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.source_code_management.commit_context import (
     CommitInfo,
     FileBlameInfo,
@@ -28,7 +33,7 @@ from sentry.integrations.source_code_management.commit_context import (
 )
 from sentry.models.repository import Repository
 from sentry.silo.base import SiloMode
-from sentry.testutils.cases import IntegrationTestCase, TestCase
+from sentry.testutils.cases import APITestCase, IntegrationTestCase, TestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.integrations import get_installation_of_type
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
@@ -1308,20 +1313,19 @@ class InstallationConfigViewGitHubComFlagGateTest(TestCase):
     def test_app_install_redirect_uses_apps_path_for_github_com(self) -> None:
         # github.com hosts the App install page at /apps/{name}, not /github-apps/{name}
         # (which is the GHES convention). Wrong URL → 404 → broken install flow.
-        redirect = GitHubEnterpriseInstallationRedirect()
         assert (
-            redirect.get_app_url({"url": "github.com", "name": "my-app", "public_link": None})
+            _get_app_install_url({"url": "github.com", "name": "my-app", "public_link": None})
             == "https://github.com/apps/my-app"
         )
         assert (
-            redirect.get_app_url(
+            _get_app_install_url(
                 {"url": "github.example.org", "name": "my-app", "public_link": None}
             )
             == "https://github.example.org/github-apps/my-app"
         )
         # public_link, when set, takes precedence regardless of host
         assert (
-            redirect.get_app_url(
+            _get_app_install_url(
                 {"url": "github.com", "name": "my-app", "public_link": "https://example.com/app"}
             )
             == "https://example.com/app"
@@ -1395,3 +1399,222 @@ class BuildIntegrationGitHubComTest(TestCase):
         assert result["idp_external_id"] == "github.com:99"
         assert result["metadata"]["domain_name"] == "github.com/acme"
         assert result["metadata"]["installation_id"] == 12345
+
+
+@control_silo_test
+class GitHubEnterpriseApiPipelineTest(APITestCase):
+    endpoint = "sentry-api-0-organization-pipeline"
+    method = "post"
+
+    ghe_host = "github.example.com"
+    ghe_url = f"https://{ghe_host}"
+    installation_id = "12345"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(self.user)
+
+    def tearDown(self) -> None:
+        responses.reset()
+        super().tearDown()
+
+    def _get_pipeline_url(self) -> str:
+        return reverse(
+            self.endpoint,
+            args=[self.organization.slug, IntegrationPipeline.pipeline_name],
+        )
+
+    def _initialize_pipeline(self) -> Any:
+        return self.client.post(
+            self._get_pipeline_url(),
+            data={"action": "initialize", "provider": "github_enterprise"},
+            format="json",
+        )
+
+    def _advance_step(self, data: dict[str, Any]) -> Any:
+        return self.client.post(self._get_pipeline_url(), data=data, format="json")
+
+    def _submit_config(self, **overrides: Any) -> Any:
+        data = {
+            "url": self.ghe_url,
+            "id": "1",
+            "name": "sentry-app",
+            "verifySsl": True,
+            "webhookSecret": "webhook-secret-123",
+            "privateKey": "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----",
+            "clientId": "client-id-abc",
+            "clientSecret": "client-secret-xyz",
+        }
+        data.update(overrides)
+        return self._advance_step(data)
+
+    def _get_pipeline_signature(self, resp: Any) -> str:
+        return resp.data["data"]["oauthUrl"].split("state=")[1].split("&")[0]
+
+    def _stub_ghe_oauth(self) -> None:
+        responses.add(
+            responses.POST,
+            f"{self.ghe_url}/login/oauth/access_token",
+            json={
+                "access_token": "test-access-token",
+                "token_type": "bearer",
+            },
+        )
+
+    def _stub_ghe_user(self) -> None:
+        responses.add(
+            responses.GET,
+            f"{self.ghe_url}/api/v3/user",
+            json={"id": 42, "login": "testuser"},
+        )
+
+    def _stub_ghe_installation(self) -> None:
+        responses.add(
+            responses.GET,
+            f"{self.ghe_url}/api/v3/app/installations/{self.installation_id}",
+            json={
+                "id": int(self.installation_id),
+                "app_id": 1,
+                "account": {
+                    "login": "Test-Org",
+                    "avatar_url": f"{self.ghe_url}/avatar.png",
+                    "html_url": f"{self.ghe_url}/Test-Org",
+                    "type": "Organization",
+                },
+            },
+        )
+        responses.add(
+            responses.GET,
+            f"{self.ghe_url}/api/v3/user/installations",
+            json={
+                "installations": [
+                    {
+                        "id": int(self.installation_id),
+                        "app_id": 1,
+                        "account": {
+                            "login": "Test-Org",
+                            "avatar_url": f"{self.ghe_url}/avatar.png",
+                            "html_url": f"{self.ghe_url}/Test-Org",
+                            "type": "Organization",
+                        },
+                    }
+                ]
+            },
+        )
+
+    @responses.activate
+    def test_initialize_pipeline(self) -> None:
+        resp = self._initialize_pipeline()
+        assert resp.status_code == 200
+        assert resp.data["step"] == "installation_config"
+        assert resp.data["stepIndex"] == 0
+        assert resp.data["totalSteps"] == 3
+        assert resp.data["provider"] == "github_enterprise"
+
+    @responses.activate
+    def test_config_step_advance(self) -> None:
+        self._initialize_pipeline()
+        resp = self._submit_config()
+        assert resp.status_code == 200
+        assert resp.data["status"] == "advance"
+        assert resp.data["step"] == "app_install_redirect"
+        assert resp.data["stepIndex"] == 1
+        assert "appInstallUrl" in resp.data["data"]
+        assert "sentry-app" in resp.data["data"]["appInstallUrl"]
+
+    @responses.activate
+    def test_config_step_validation_missing_required_fields(self) -> None:
+        self._initialize_pipeline()
+        resp = self._advance_step({"url": self.ghe_url})
+        assert resp.status_code == 400
+        for field in ("id", "name", "webhookSecret", "privateKey", "clientId", "clientSecret"):
+            assert resp.data[field] == ["This field is required."]
+
+    @responses.activate
+    def test_app_install_step_no_installation_id(self) -> None:
+        self._initialize_pipeline()
+        self._submit_config()
+        resp = self._advance_step({})
+        assert resp.status_code == 200
+        assert resp.data["status"] == "stay"
+        assert "appInstallUrl" in resp.data["data"]
+
+    @responses.activate
+    def test_app_install_step_with_installation_id(self) -> None:
+        self._initialize_pipeline()
+        self._submit_config()
+        resp = self._advance_step({"installationId": self.installation_id})
+        assert resp.status_code == 200
+        assert resp.data["status"] == "advance"
+        assert resp.data["step"] == "oauth_login"
+        assert "oauthUrl" in resp.data["data"]
+        oauth_url = resp.data["data"]["oauthUrl"]
+        assert self.ghe_host in oauth_url
+
+    @responses.activate
+    @mock.patch(
+        "sentry.integrations.github_enterprise.integration.get_jwt", return_value="jwt_token"
+    )
+    def test_full_pipeline_flow(self, mock_jwt: MagicMock) -> None:
+        self._stub_ghe_oauth()
+        self._stub_ghe_user()
+        self._stub_ghe_installation()
+
+        resp = self._initialize_pipeline()
+        assert resp.data["step"] == "installation_config"
+
+        resp = self._submit_config()
+        assert resp.data["step"] == "app_install_redirect"
+
+        resp = self._advance_step({"installationId": self.installation_id})
+        assert resp.data["step"] == "oauth_login"
+        pipeline_signature = self._get_pipeline_signature(resp)
+
+        resp = self._advance_step({"code": "auth-code", "state": pipeline_signature})
+        assert resp.status_code == 200
+        assert resp.data["status"] == "complete"
+        assert "data" in resp.data
+
+        integration = Integration.objects.get(provider="github_enterprise")
+        assert integration.metadata["installation_id"] == int(self.installation_id)
+        assert OrganizationIntegration.objects.filter(
+            organization_id=self.organization.id,
+            integration=integration,
+        ).exists()
+
+    @responses.activate
+    def test_config_step_rejects_github_com_without_flag(self) -> None:
+        self._initialize_pipeline()
+        resp = self._submit_config(url="https://github.com")
+        assert resp.status_code == 400
+        assert resp.data["status"] == "error"
+        assert "github.com" in resp.data["data"]["detail"]
+
+    @responses.activate
+    def test_config_step_allows_github_com_with_flag(self) -> None:
+        self._initialize_pipeline()
+        with self.feature("organizations:github-enterprise-github-com-source"):
+            resp = self._submit_config(url="https://github.com")
+        assert resp.status_code == 200
+        assert resp.data["status"] == "advance"
+        assert resp.data["step"] == "app_install_redirect"
+
+    def test_config_step_rejects_mixed_case_github_com(self) -> None:
+        # The github.com flag gate must be case-insensitive. URL hostnames are
+        # case-insensitive in DNS, so `GitHub.COM` resolves identically and
+        # would bypass the gate if the comparison weren't normalized.
+        self._initialize_pipeline()
+        resp = self._submit_config(url="https://GitHub.COM")
+        assert resp.status_code == 400
+        assert resp.data["status"] == "error"
+        assert "github.com" in resp.data["data"]["detail"]
+
+    def test_app_install_step_uses_apps_path_for_github_com(self) -> None:
+        # github.com hosts the App install page at /apps/{name}, GHES at
+        # /github-apps/{name}. Wrong URL → 404 → broken install flow.
+        self._initialize_pipeline()
+        with self.feature("organizations:github-enterprise-github-com-source"):
+            self._submit_config(url="https://github.com")
+        resp = self._advance_step({})
+        assert resp.status_code == 200
+        assert resp.data["data"]["appInstallUrl"] == "https://github.com/apps/sentry-app"


### PR DESCRIPTION
Implement `get_pipeline_api_steps()` on `GitHubEnterpriseIntegrationProvider` with three steps: installation config (URL, app credentials, keys), app install redirect (popup-based GitHub app installation with polling), and a late-bound OAuth step constructed from the config step's data. Includes serializers for each step and updates `build_integration()` to handle both legacy and API state paths.

Ref [VDY-40](https://linear.app/getsentry/issue/VDY-40/github-enterprise-api-driven-integration-setup)