### PR TITLE
feat(github-enterprise): Add frontend pipeline steps for GHE integration setup

### DIFF
--- a/static/app/components/pipeline/pipelineIntegrationGitHubEnterprise.spec.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationGitHubEnterprise.spec.tsx
@@ -1,0 +1,278 @@
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {githubEnterpriseIntegrationPipeline} from './pipelineIntegrationGitHubEnterprise';
+import {createMakeStepProps, dispatchPipelineMessage, setupMockPopup} from './testUtils';
+
+const InstallationConfigStep = githubEnterpriseIntegrationPipeline.steps[0].component;
+const AppInstallRedirectStep = githubEnterpriseIntegrationPipeline.steps[1].component;
+const GHEOAuthLoginStep = githubEnterpriseIntegrationPipeline.steps[2].component;
+
+const makeStepProps = createMakeStepProps({totalSteps: 3});
+
+let mockPopup: Window;
+
+beforeEach(() => {
+  mockPopup = setupMockPopup();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+async function fillRequiredConfigFields() {
+  await userEvent.type(
+    screen.getByRole('textbox', {name: 'Installation URL'}),
+    'https://github.example.com'
+  );
+  await userEvent.type(screen.getByRole('textbox', {name: 'GitHub App ID'}), '1');
+  await userEvent.type(
+    screen.getByRole('textbox', {name: 'GitHub App Name'}),
+    'sentry-app'
+  );
+  await userEvent.type(screen.getByLabelText('Webhook Secret'), 'webhook-secret');
+  await userEvent.type(
+    screen.getByRole('textbox', {name: 'Private Key'}),
+    '-----BEGIN RSA PRIVATE KEY-----\nkey\n-----END RSA PRIVATE KEY-----'
+  );
+  await userEvent.type(
+    screen.getByRole('textbox', {name: 'OAuth Client ID'}),
+    'client-id'
+  );
+  await userEvent.type(screen.getByLabelText('OAuth Client Secret'), 'client-secret');
+}
+
+describe('GHE InstallationConfigStep', () => {
+  it('renders the config form fields', () => {
+    render(<InstallationConfigStep {...makeStepProps({stepData: {}})} />);
+
+    expect(screen.getByRole('textbox', {name: 'Installation URL'})).toBeInTheDocument();
+    expect(screen.getByRole('textbox', {name: 'GitHub App ID'})).toBeInTheDocument();
+    expect(screen.getByRole('textbox', {name: 'GitHub App Name'})).toBeInTheDocument();
+    expect(screen.getByLabelText('Webhook Secret')).toBeInTheDocument();
+    expect(screen.getByRole('textbox', {name: 'Private Key'})).toBeInTheDocument();
+    expect(screen.getByRole('textbox', {name: 'OAuth Client ID'})).toBeInTheDocument();
+    expect(screen.getByLabelText('OAuth Client Secret')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Continue'})).toBeInTheDocument();
+  });
+
+  it('calls advance with form data on submit', async () => {
+    const advance = jest.fn();
+    render(<InstallationConfigStep {...makeStepProps({stepData: {}, advance})} />);
+
+    await fillRequiredConfigFields();
+    await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+    await waitFor(() => {
+      expect(advance).toHaveBeenCalledWith({
+        url: 'https://github.example.com',
+        id: '1',
+        name: 'sentry-app',
+        publicLink: '',
+        verifySsl: true,
+        webhookSecret: 'webhook-secret',
+        privateKey: '-----BEGIN RSA PRIVATE KEY-----\nkey\n-----END RSA PRIVATE KEY-----',
+        clientId: 'client-id',
+        clientSecret: 'client-secret',
+      });
+    });
+  });
+
+  it('strips trailing slashes from the installation URL', async () => {
+    const advance = jest.fn();
+    render(<InstallationConfigStep {...makeStepProps({stepData: {}, advance})} />);
+
+    await fillRequiredConfigFields();
+    await userEvent.clear(screen.getByRole('textbox', {name: 'Installation URL'}));
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'Installation URL'}),
+      'https://github.example.com///'
+    );
+    await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+    await waitFor(() => {
+      expect(advance).toHaveBeenCalledWith(
+        expect.objectContaining({url: 'https://github.example.com'})
+      );
+    });
+  });
+
+  it('shows busy state when isAdvancing', () => {
+    render(
+      <InstallationConfigStep {...makeStepProps({stepData: {}, isAdvancing: true})} />
+    );
+
+    expect(screen.getByRole('button', {name: 'Continue'})).toHaveAttribute(
+      'aria-busy',
+      'true'
+    );
+  });
+});
+
+describe('GHE AppInstallRedirectStep', () => {
+  it('opens the install popup and advances on installation_id callback', async () => {
+    const advance = jest.fn();
+    render(
+      <AppInstallRedirectStep
+        {...makeStepProps({
+          stepData: {
+            appInstallUrl: 'https://github.example.com/github-apps/sentry-app',
+          },
+          advance,
+        })}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Install GitHub App'}));
+
+    expect(window.open).toHaveBeenCalledWith(
+      'https://github.example.com/github-apps/sentry-app',
+      'pipeline_popup',
+      expect.any(String)
+    );
+
+    dispatchPipelineMessage({
+      source: mockPopup,
+      data: {
+        _pipeline_source: 'sentry-pipeline',
+        installation_id: 'inst-42',
+      },
+    });
+
+    expect(advance).toHaveBeenCalledWith({installationId: 'inst-42'});
+  });
+
+  it('shows reopen button after popup opens', async () => {
+    render(
+      <AppInstallRedirectStep
+        {...makeStepProps({
+          stepData: {
+            appInstallUrl: 'https://github.example.com/github-apps/sentry-app',
+          },
+        })}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Install GitHub App'}));
+
+    expect(
+      screen.getByText(
+        'Complete the installation in the popup window. This page will update automatically.'
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'Reopen installation window'})
+    ).toBeInTheDocument();
+  });
+
+  it('disables the install button when appInstallUrl is not provided', () => {
+    render(<AppInstallRedirectStep {...makeStepProps({stepData: {}})} />);
+
+    expect(screen.getByRole('button', {name: 'Install GitHub App'})).toBeDisabled();
+  });
+
+  it('shows popup-blocked notice when window.open returns null', async () => {
+    jest.spyOn(window, 'open').mockReturnValue(null);
+
+    render(
+      <AppInstallRedirectStep
+        {...makeStepProps({
+          stepData: {
+            appInstallUrl: 'https://github.example.com/github-apps/sentry-app',
+          },
+        })}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Install GitHub App'}));
+
+    expect(
+      screen.getByText(
+        'The installation popup was blocked by your browser. Please ensure popups are allowed and try again.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('shows busy state when isAdvancing', () => {
+    render(
+      <AppInstallRedirectStep
+        {...makeStepProps({
+          stepData: {
+            appInstallUrl: 'https://github.example.com/github-apps/sentry-app',
+          },
+          isAdvancing: true,
+        })}
+      />
+    );
+
+    expect(screen.getByRole('button', {name: 'Install GitHub App'})).toHaveAttribute(
+      'aria-busy',
+      'true'
+    );
+  });
+});
+
+describe('GHE OAuthLoginStep', () => {
+  it('renders the OAuth login step', () => {
+    render(
+      <GHEOAuthLoginStep
+        {...makeStepProps({
+          stepData: {oauthUrl: 'https://github.example.com/login/oauth/authorize'},
+        })}
+      />
+    );
+
+    expect(
+      screen.getByRole('button', {name: 'Authorize GitHub Enterprise'})
+    ).toBeInTheDocument();
+  });
+
+  it('calls advance with code and state on OAuth callback', async () => {
+    const advance = jest.fn();
+    render(
+      <GHEOAuthLoginStep
+        {...makeStepProps({
+          stepData: {oauthUrl: 'https://github.example.com/login/oauth/authorize'},
+          advance,
+        })}
+      />
+    );
+
+    await userEvent.click(
+      screen.getByRole('button', {name: 'Authorize GitHub Enterprise'})
+    );
+
+    dispatchPipelineMessage({
+      source: mockPopup,
+      data: {
+        _pipeline_source: 'sentry-pipeline',
+        code: 'auth-code',
+        state: 'state-xyz',
+      },
+    });
+
+    expect(advance).toHaveBeenCalledWith({code: 'auth-code', state: 'state-xyz'});
+  });
+
+  it('shows busy state when isAdvancing', () => {
+    render(
+      <GHEOAuthLoginStep
+        {...makeStepProps({
+          stepData: {oauthUrl: 'https://github.example.com/login/oauth/authorize'},
+          isAdvancing: true,
+        })}
+      />
+    );
+
+    expect(
+      screen.getByRole('button', {name: 'Authorize GitHub Enterprise'})
+    ).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('disables authorize button when oauthUrl is missing', () => {
+    render(<GHEOAuthLoginStep {...makeStepProps({stepData: {}})} />);
+
+    expect(
+      screen.getByRole('button', {name: 'Authorize GitHub Enterprise'})
+    ).toBeDisabled();
+  });
+});

--- a/static/app/components/pipeline/pipelineIntegrationGitHubEnterprise.tsx
+++ b/static/app/components/pipeline/pipelineIntegrationGitHubEnterprise.tsx
@@ -1,0 +1,359 @@
+import {useCallback, useEffect} from 'react';
+import {z} from 'zod';
+
+import {Button} from '@sentry/scraps/button';
+import {defaultFormOptions, setFieldErrors, useScrapsForm} from '@sentry/scraps/form';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {ExternalLink} from '@sentry/scraps/link';
+import {Text} from '@sentry/scraps/text';
+
+import {t, tct} from 'sentry/locale';
+import type {IntegrationWithConfig} from 'sentry/types/integrations';
+
+import type {OAuthCallbackData} from './shared/oauthLoginStep';
+import {OAuthLoginStep} from './shared/oauthLoginStep';
+import {useRedirectPopupStep} from './shared/useRedirectPopupStep';
+import type {PipelineDefinition, PipelineStepProps} from './types';
+import {pipelineComplete} from './types';
+
+const installationConfigSchema = z.object({
+  url: z
+    .string()
+    .min(1, t('Installation URL is required'))
+    .transform(v => v.replace(/\/+$/, '')),
+  id: z.string().min(1, t('GitHub App ID is required')),
+  name: z.string().min(1, t('GitHub App Name is required')),
+  publicLink: z.string(),
+  verifySsl: z.boolean(),
+  webhookSecret: z.string().min(1, t('Webhook Secret is required')),
+  privateKey: z.string().min(1, t('Private Key is required')),
+  clientId: z.string().min(1, t('OAuth Client ID is required')),
+  clientSecret: z.string().min(1, t('OAuth Client Secret is required')),
+});
+
+interface InstallationConfigStepData {
+  defaults?: {
+    verifySsl?: boolean;
+  };
+}
+
+interface InstallationConfigAdvanceData {
+  clientId: string;
+  clientSecret: string;
+  id: string;
+  name: string;
+  privateKey: string;
+  publicLink: string;
+  url: string;
+  verifySsl: boolean;
+  webhookSecret: string;
+}
+
+function InstallationConfigStep({
+  stepData,
+  advance,
+  advanceError,
+  isAdvancing,
+  isInitializing,
+}: PipelineStepProps<InstallationConfigStepData, InstallationConfigAdvanceData>) {
+  const defaults = stepData?.defaults ?? {};
+
+  const form = useScrapsForm({
+    ...defaultFormOptions,
+    defaultValues: {
+      url: '',
+      id: '',
+      name: '',
+      publicLink: '',
+      verifySsl: defaults.verifySsl ?? true,
+      webhookSecret: '',
+      privateKey: '',
+      clientId: '',
+      clientSecret: '',
+    },
+    validators: {onDynamic: installationConfigSchema},
+    onSubmit: ({value}) => {
+      advance(installationConfigSchema.parse(value));
+    },
+  });
+
+  useEffect(() => {
+    if (advanceError) {
+      setFieldErrors(form, advanceError);
+    }
+  }, [advanceError, form]);
+
+  return (
+    <form.AppForm form={form}>
+      <Stack gap="lg">
+        <Text>
+          {tct(
+            'Create a GitHub App on your GitHub Enterprise instance and enter the details below. Refer to the [link:documentation] for setup instructions.',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/organization/integrations/source-code-mgmt/github-enterprise/" />
+              ),
+            }
+          )}
+        </Text>
+
+        <form.AppField name="url">
+          {field => (
+            <field.Layout.Stack
+              label={t('Installation URL')}
+              hintText={t(
+                'The base URL for your GitHub Enterprise instance, including the protocol.'
+              )}
+              required
+            >
+              <field.Input
+                value={field.state.value}
+                onChange={field.handleChange}
+                placeholder="https://github.example.com"
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+
+        <form.AppField name="id">
+          {field => (
+            <field.Layout.Stack
+              label={t('GitHub App ID')}
+              hintText={t("Found on your app's settings page.")}
+              required
+            >
+              <field.Input
+                value={field.state.value}
+                onChange={field.handleChange}
+                placeholder="1"
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+
+        <form.AppField name="name">
+          {field => (
+            <field.Layout.Stack
+              label={t('GitHub App Name')}
+              hintText={t(
+                "The slug of your GitHub App, found on the app's settings page."
+              )}
+              required
+            >
+              <field.Input
+                value={field.state.value}
+                onChange={field.handleChange}
+                placeholder="our-sentry-app"
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+
+        <form.AppField name="webhookSecret">
+          {field => (
+            <field.Layout.Stack
+              label={t('Webhook Secret')}
+              hintText={t(
+                'The webhook secret configured for your GitHub App. Must match the value in your app settings.'
+              )}
+              required
+            >
+              <field.Input
+                value={field.state.value}
+                onChange={field.handleChange}
+                type="password"
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+
+        <form.AppField name="privateKey">
+          {field => (
+            <field.Layout.Stack
+              label={t('Private Key')}
+              hintText={t('The private key generated for your GitHub App.')}
+              required
+            >
+              <field.TextArea
+                value={field.state.value}
+                onChange={field.handleChange}
+                rows={3}
+                placeholder={
+                  '-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----'
+                }
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+
+        <form.AppField name="clientId">
+          {field => (
+            <field.Layout.Stack label={t('OAuth Client ID')} required>
+              <field.Input value={field.state.value} onChange={field.handleChange} />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+
+        <form.AppField name="clientSecret">
+          {field => (
+            <field.Layout.Stack label={t('OAuth Client Secret')} required>
+              <field.Input
+                value={field.state.value}
+                onChange={field.handleChange}
+                type="password"
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+
+        <form.AppField name="publicLink">
+          {field => (
+            <field.Layout.Stack
+              label={t('Public Link')}
+              hintText={t(
+                'The publicly available link for your GitHub App, if different from the default.'
+              )}
+            >
+              <field.Input
+                value={field.state.value}
+                onChange={field.handleChange}
+                placeholder="https://github.example.com/github-apps/our-sentry-app"
+              />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+
+        <form.AppField name="verifySsl">
+          {field => (
+            <field.Layout.Stack
+              label={t('Verify SSL')}
+              hintText={t(
+                'Verify SSL certificates when communicating with your GitHub Enterprise instance.'
+              )}
+            >
+              <field.Switch checked={field.state.value} onChange={field.handleChange} />
+            </field.Layout.Stack>
+          )}
+        </form.AppField>
+
+        <Flex>
+          <form.SubmitButton busy={isAdvancing} disabled={isInitializing}>
+            {t('Continue')}
+          </form.SubmitButton>
+        </Flex>
+      </Stack>
+    </form.AppForm>
+  );
+}
+
+interface AppInstallStepData {
+  appInstallUrl?: string;
+}
+
+function AppInstallRedirectStep({
+  stepData,
+  advance,
+  isAdvancing,
+}: PipelineStepProps<AppInstallStepData, {installationId: string}>) {
+  const handleCallback = useCallback(
+    (data: Record<string, string>) => {
+      if (data.installation_id) {
+        advance({installationId: data.installation_id});
+      }
+    },
+    [advance]
+  );
+
+  const {openPopup, isWaitingForCallback, popupStatus} = useRedirectPopupStep({
+    redirectUrl: stepData?.appInstallUrl,
+    onCallback: handleCallback,
+  });
+
+  return (
+    <Stack gap="lg" align="start">
+      <Stack gap="sm">
+        <Text>
+          {t(
+            'Install the GitHub App on your GitHub Enterprise instance to grant Sentry access.'
+          )}
+        </Text>
+        {isWaitingForCallback && (
+          <Text variant="muted" size="sm">
+            {t(
+              'Complete the installation in the popup window. This page will update automatically.'
+            )}
+          </Text>
+        )}
+        {popupStatus === 'failed-to-open' && (
+          <Text variant="danger" size="sm">
+            {t(
+              'The installation popup was blocked by your browser. Please ensure popups are allowed and try again.'
+            )}
+          </Text>
+        )}
+      </Stack>
+      {isWaitingForCallback && !isAdvancing ? (
+        <Button size="sm" onClick={openPopup}>
+          {t('Reopen installation window')}
+        </Button>
+      ) : (
+        <Button
+          size="sm"
+          variant="primary"
+          onClick={openPopup}
+          busy={isAdvancing}
+          disabled={!stepData?.appInstallUrl}
+        >
+          {t('Install GitHub App')}
+        </Button>
+      )}
+    </Stack>
+  );
+}
+
+function GHEOAuthLoginStep({
+  stepData,
+  advance,
+  isAdvancing,
+}: PipelineStepProps<{oauthUrl?: string}, {code: string; state: string}>) {
+  const handleOAuthCallback = useCallback(
+    (data: OAuthCallbackData) => {
+      advance({code: data.code, state: data.state});
+    },
+    [advance]
+  );
+
+  return (
+    <OAuthLoginStep
+      oauthUrl={stepData?.oauthUrl}
+      isLoading={isAdvancing}
+      serviceName="GitHub Enterprise"
+      onOAuthCallback={handleOAuthCallback}
+    />
+  );
+}
+
+export const githubEnterpriseIntegrationPipeline = {
+  type: 'integration',
+  provider: 'github_enterprise',
+  actionTitle: t('Installing GitHub Enterprise Integration'),
+  getCompletionData: pipelineComplete<IntegrationWithConfig>,
+  completionView: null,
+  steps: [
+    {
+      stepId: 'installation_config',
+      shortDescription: t('Configuring GitHub Enterprise connection'),
+      component: InstallationConfigStep,
+    },
+    {
+      stepId: 'app_install_redirect',
+      shortDescription: t('Installing GitHub App'),
+      component: AppInstallRedirectStep,
+    },
+    {
+      stepId: 'oauth_login',
+      shortDescription: t('Authorizing via OAuth'),
+      component: GHEOAuthLoginStep,
+    },
+  ],
+} as const satisfies PipelineDefinition;

--- a/static/app/components/pipeline/registry.tsx
+++ b/static/app/components/pipeline/registry.tsx
@@ -5,6 +5,7 @@ import {claudeCodeIntegrationPipeline} from './pipelineIntegrationClaudeCode';
 import {cursorIntegrationPipeline} from './pipelineIntegrationCursor';
 import {discordIntegrationPipeline} from './pipelineIntegrationDiscord';
 import {githubIntegrationPipeline} from './pipelineIntegrationGitHub';
+import {githubEnterpriseIntegrationPipeline} from './pipelineIntegrationGitHubEnterprise';
 import {gitlabIntegrationPipeline} from './pipelineIntegrationGitLab';
 import {opsgenieIntegrationPipeline} from './pipelineIntegrationOpsgenie';
 import {pagerDutyIntegrationPipeline} from './pipelineIntegrationPagerDuty';
@@ -27,6 +28,7 @@ export const PIPELINE_REGISTRY = [
   discordIntegrationPipeline,
   dummyIntegrationPipeline,
   githubIntegrationPipeline,
+  githubEnterpriseIntegrationPipeline,
   gitlabIntegrationPipeline,
   opsgenieIntegrationPipeline,
   pagerDutyIntegrationPipeline,


### PR DESCRIPTION
Register GitHub Enterprise in the pipeline registry with three steps: an installation config form (URL, app ID, OAuth credentials, private key, webhook secret), a popup-based app install redirect step using `useRedirectPopupStep`, and the shared `OAuthLoginStep` for final authorization.

Ref [VDY-40](https://linear.app/getsentry/issue/VDY-40/github-enterprise-api-driven-integration-setup)