### PR TITLE
fix(cmdk): Restore Zendesk index to help search

### DIFF
--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -116,12 +116,7 @@ const ORG_SETTINGS_ICONS: Record<string, React.ReactElement> = {
   '/settings/account/notifications/': <IconSubscribed />,
 };
 
-const helpSearch = new SentryGlobalSearch([
-  'docs',
-  'zendesk_sentry_articles',
-  'develop',
-  'blog',
-]);
+const helpSearch = new SentryGlobalSearch(['docs', 'zendesk_sentry_articles', 'develop']);
 const EVENT_ID_PATTERN =
   /^(?:[A-Fa-f0-9]{32}|[A-Fa-f0-9]{8}(?:-[A-Fa-f0-9]{4}){3}-[A-Fa-f0-9]{12})$/;
 const SHORT_ID_PATTERN = /^[A-Za-z][\w-]*-\w{3,}$/;

--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -116,7 +116,12 @@ const ORG_SETTINGS_ICONS: Record<string, React.ReactElement> = {
   '/settings/account/notifications/': <IconSubscribed />,
 };
 
-const helpSearch = new SentryGlobalSearch(['docs', 'develop']);
+const helpSearch = new SentryGlobalSearch([
+  'docs',
+  'zendesk_sentry_articles',
+  'develop',
+  'blog',
+]);
 const EVENT_ID_PATTERN =
   /^(?:[A-Fa-f0-9]{32}|[A-Fa-f0-9]{8}(?:-[A-Fa-f0-9]{4}){3}-[A-Fa-f0-9]{12})$/;
 const SHORT_ID_PATTERN = /^[A-Za-z][\w-]*-\w{3,}$/;
@@ -806,6 +811,7 @@ export function GlobalCommandPaletteActions() {
       <CMDKAction
         id="cmdk:supplementary:help"
         display={{label: t('Help')}}
+        limit={4}
         resource={(query: string): CMDKQueryOptions => {
           return cmdkQueryOptions({
             queryKey: ['command-palette-help-search', query, helpSearch],
@@ -818,7 +824,7 @@ export function GlobalCommandPaletteActions() {
             select: data => {
               const results = [];
               for (const index of data) {
-                for (const hit of index.hits.slice(0, 3)) {
+                for (const hit of index.hits) {
                   results.push({
                     display: {
                       label: DOMPurify.sanitize(hit.title ?? '', {ALLOWED_TAGS: []}),


### PR DESCRIPTION
## Summary
- Restores `zendesk_sentry_articles` search index to the CMDK help search, which was dropped during the JSX refactor
- Adds `limit={4}` prop to the help action, consistent with other CMDK actions
- Removes hardcoded `.slice(0, 3)` per-index cap in favor of the `limit` prop

## Test plan
- [ ] Open Command+K, type a help query, and verify Zendesk article results appear
- [ ] Verify docs and develop results still appear
- [ ] Verify result count is capped at 4