### PR TITLE
fix(notifications): Don't assume context.replay is not None

### DIFF
--- a/src/sentry/notifications/utils/__init__.py
+++ b/src/sentry/notifications/utils/__init__.py
@@ -369,15 +369,15 @@ def send_activity_notification(notification: ActivityNotification | UserReportNo
 
 
 def get_replay_id(event: Event | GroupEvent) -> str | None:
-    replay_id = event.data.get("contexts", {}).get("replay", {}).get("replay_id", {})
+    contexts = event.data.get("contexts") or {}
+    replay_id = (contexts.get("replay") or {}).get("replay_id")
     if (
         isinstance(event, GroupEvent)
         and event.occurrence is not None
         and event.occurrence.evidence_data
     ):
-        evidence_replay_id = (
-            event.occurrence.evidence_data.get("contexts", {}).get("replay", {}).get("replay_id")
-        )
+        evidence_contexts = event.occurrence.evidence_data.get("contexts") or {}
+        evidence_replay_id = (evidence_contexts.get("replay") or {}).get("replay_id")
 
         if evidence_replay_id:
             return evidence_replay_id

--- a/tests/sentry/notifications/test_utils.py
+++ b/tests/sentry/notifications/test_utils.py
@@ -11,6 +11,7 @@ from sentry.notifications.utils import (
     NPlusOneAPICallProblemContext,
     PerformanceProblemContext,
     RenderBlockingAssetProblemContext,
+    get_replay_id,
 )
 
 
@@ -179,3 +180,30 @@ class PerformanceProblemContextTestCase(TestCase):
             "transaction_duration": 3000,
             "fcp": 1500,
         }
+
+
+class GetReplayIdTestCase(TestCase):
+    def test_returns_replay_id(self):
+        event = mock_event(
+            transaction="tx",
+            data={"contexts": {"replay": {"replay_id": "abc123"}}},
+        )
+        assert get_replay_id(event) == "abc123"
+
+    def test_returns_none_when_replay_context_is_none(self):
+        event = mock_event(
+            transaction="tx",
+            data={"contexts": {"replay": None}},
+        )
+        assert get_replay_id(event) is None
+
+    def test_returns_none_when_contexts_is_none(self):
+        event = mock_event(
+            transaction="tx",
+            data={"contexts": None},
+        )
+        assert get_replay_id(event) is None
+
+    def test_returns_none_when_no_contexts(self):
+        event = mock_event(transaction="tx", data={})
+        assert get_replay_id(event) is None


### PR DESCRIPTION
In addition to the empirical presence of Nones, there are explicit comments noting that Nones can happen and that we need to handle them.

Fixes SENTRY-5HE4.