### PR TITLE
ref(detectors): Migrate error detector form to TanStack Form

### DIFF
--- a/static/app/components/workflowEngine/form/fullHeightForm.tsx
+++ b/static/app/components/workflowEngine/form/fullHeightForm.tsx
@@ -3,9 +3,27 @@ import styled from '@emotion/styled';
 import {Form} from 'sentry/components/forms/form';
 
 /**
- * Extends the Form component to be full height and have a sticky footer.
+ * Wraps the form content in a full height container with sticky footer.
  */
-export const FullHeightForm = styled(Form)`
+export const FullHeightForm = styled('div')`
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 0%;
+  background-color: ${p => p.theme.tokens.background.primary};
+
+  & > div:first-child {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+  }
+`;
+
+/**
+ * Extends the Form component to be full height and have a sticky footer.
+ *
+ * Remove once all detector forms have migrated to the new form system.
+ */
+export const FullHeightFormDeprecated = styled(Form)`
   display: flex;
   flex-direction: column;
   flex: 1 1 0%;

--- a/static/app/components/workflowEngine/layout/edit.tsx
+++ b/static/app/components/workflowEngine/layout/edit.tsx
@@ -6,32 +6,50 @@ import {Text} from '@sentry/scraps/text';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {HeaderActions} from 'sentry/components/layouts/thirds';
-import {FullHeightForm} from 'sentry/components/workflowEngine/form/fullHeightForm';
+import {
+  FullHeightForm,
+  FullHeightFormDeprecated,
+} from 'sentry/components/workflowEngine/form/fullHeightForm';
 import {StickyFooter} from 'sentry/components/workflowEngine/ui/footer';
 import type {AvatarProject} from 'sentry/types/project';
 import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
-interface WorkflowEngineEditLayoutProps {
+interface EditLayoutProps {
   /**
    * The main content for this page
    * Expected to include `<EditLayout.Body>`, `<EditLayout.Header>`, and `<EditLayout.Footer>` components.
    */
   children: React.ReactNode;
-  formProps?: React.ComponentProps<typeof FullHeightForm>;
 }
 
-/**
- * Precomposed layout for Monitors / Alerts edit pages with form handling.
- */
-function EditLayoutComponent({children, formProps}: WorkflowEngineEditLayoutProps) {
+function EditLayoutComponent({children}: EditLayoutProps) {
   // TODO(JonasBadalic): Remove this once the page-frame feature is GA'd
   const hasPageFrame = useHasPageFrameFeature();
   return (
-    <FullHeightForm hideFooter {...formProps}>
+    <FullHeightForm>
       <Stack flex="unset" background={hasPageFrame ? undefined : 'primary'}>
         {children}
       </Stack>
     </FullHeightForm>
+  );
+}
+
+interface EditLayoutDeprecatedProps {
+  children: React.ReactNode;
+  formProps: React.ComponentProps<typeof FullHeightFormDeprecated>;
+}
+
+// Wraps the children in the legacy form component.
+// Remove once all detector forms have migrated to the new form system.
+function EditLayoutDeprecatedComponent({children, formProps}: EditLayoutDeprecatedProps) {
+  // TODO(JonasBadalic): Remove this once the page-frame feature is GA'd
+  const hasPageFrame = useHasPageFrameFeature();
+  return (
+    <FullHeightFormDeprecated hideFooter {...formProps}>
+      <Stack flex="unset" background={hasPageFrame ? undefined : 'primary'}>
+        {children}
+      </Stack>
+    </FullHeightFormDeprecated>
   );
 }
 
@@ -143,6 +161,20 @@ function Footer({children, label, maxWidth}: FooterProps) {
 }
 
 export const EditLayout = Object.assign(EditLayoutComponent, {
+  Header,
+  HeaderContent,
+  Actions,
+  HeaderFields,
+  Body,
+  Footer,
+  Title,
+});
+
+/**
+ * This component is for forms still using the legacy `FormModel` system.
+ * Remove once all detector forms have migrated to the new form system.
+ */
+export const EditLayoutDeprecated = Object.assign(EditLayoutDeprecatedComponent, {
   Header,
   HeaderContent,
   Actions,

--- a/static/app/views/automations/edit.tsx
+++ b/static/app/views/automations/edit.tsx
@@ -16,7 +16,7 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
-import {FullHeightForm} from 'sentry/components/workflowEngine/form/fullHeightForm';
+import {FullHeightFormDeprecated} from 'sentry/components/workflowEngine/form/fullHeightForm';
 import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
 import {StickyFooter} from 'sentry/components/workflowEngine/ui/footer';
 import {t} from 'sentry/locale';
@@ -232,7 +232,7 @@ function AutomationEditForm({automation}: {automation: Automation}) {
   );
 
   return (
-    <FullHeightForm
+    <FullHeightFormDeprecated
       hideFooter
       model={model}
       initialData={initialData}
@@ -319,7 +319,7 @@ function AutomationEditForm({automation}: {automation: Automation}) {
           </Flex>
         </StickyFooter>
       </AutomationFormProvider>
-    </FullHeightForm>
+    </FullHeightFormDeprecated>
   );
 }
 

--- a/static/app/views/automations/new.tsx
+++ b/static/app/views/automations/new.tsx
@@ -18,7 +18,7 @@ import type {OnSubmitCallback} from 'sentry/components/forms/types';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
-import {FullHeightForm} from 'sentry/components/workflowEngine/form/fullHeightForm';
+import {FullHeightFormDeprecated} from 'sentry/components/workflowEngine/form/fullHeightForm';
 import {useFormField} from 'sentry/components/workflowEngine/form/useFormField';
 import {StickyFooter} from 'sentry/components/workflowEngine/ui/footer';
 import {t} from 'sentry/locale';
@@ -228,7 +228,7 @@ export default function AutomationNewSettings() {
   );
 
   return (
-    <FullHeightForm
+    <FullHeightFormDeprecated
       hideFooter
       initialData={initialData}
       onSubmit={handleSubmit}
@@ -314,7 +314,7 @@ export default function AutomationNewSettings() {
           </Flex>
         </StickyFooter>
       </AutomationFormProvider>
-    </FullHeightForm>
+    </FullHeightFormDeprecated>
   );
 }
 

--- a/static/app/views/detectors/components/forms/automateSection.spec.tsx
+++ b/static/app/views/detectors/components/forms/automateSection.spec.tsx
@@ -16,6 +16,8 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 import {selectEvent} from 'sentry-test/selectEvent';
 
+import {defaultFormOptions, useScrapsForm} from '@sentry/scraps/form';
+
 import {Form} from 'sentry/components/forms/form';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {ActionGroup, ActionType} from 'sentry/types/workflowEngine/actions';
@@ -26,137 +28,145 @@ import {
 } from 'sentry/types/workflowEngine/dataConditions';
 import {DetectorFormProvider} from 'sentry/views/detectors/components/forms/context';
 
-import {AutomateSection} from './automateSection';
+import {AutomateSection, AutomateSectionDeprecated} from './automateSection';
+
+const automation1 = AutomationFixture();
+const project = ProjectFixture({id: '1', slug: 'test-project'});
+const mockMember = MemberFixture({
+  user: UserFixture({id: '1', name: 'Test User', email: 'test@sentry.io'}),
+});
+
+function setupSharedMocks() {
+  jest.resetAllMocks();
+  MockApiClient.clearMockResponses();
+  ProjectsStore.loadInitialData([project]);
+
+  MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/workflows/',
+    method: 'GET',
+    match: [MockApiClient.matchQuery({ids: [automation1.id]})],
+    body: [automation1],
+  });
+
+  MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/workflows/',
+    method: 'GET',
+    body: [automation1],
+  });
+
+  // Mocks for AutomationBuilderDrawerForm
+  MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/available-actions/',
+    method: 'GET',
+    body: [
+      ActionHandlerFixture({
+        type: ActionType.SLACK,
+        handlerGroup: ActionGroup.NOTIFICATION,
+        integrations: [{id: '1', name: 'My Slack Workspace'}],
+      }),
+      ActionHandlerFixture({
+        type: ActionType.EMAIL,
+        handlerGroup: ActionGroup.NOTIFICATION,
+        integrations: [],
+      }),
+    ],
+  });
+
+  MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/tags/',
+    method: 'GET',
+    body: [],
+  });
+
+  MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/data-conditions/',
+    method: 'GET',
+    match: [
+      MockApiClient.matchQuery({group: DataConditionHandlerGroupType.ACTION_FILTER}),
+    ],
+    body: [
+      DataConditionHandlerFixture({
+        handlerGroup: DataConditionHandlerGroupType.ACTION_FILTER,
+        handlerSubgroup: DataConditionHandlerSubgroupType.ISSUE_ATTRIBUTES,
+        type: DataConditionType.TAGGED_EVENT,
+      }),
+    ],
+  });
+
+  MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/data-conditions/',
+    method: 'GET',
+    match: [
+      MockApiClient.matchQuery({group: DataConditionHandlerGroupType.WORKFLOW_TRIGGER}),
+    ],
+    body: [
+      DataConditionHandlerFixture({
+        handlerGroup: DataConditionHandlerGroupType.WORKFLOW_TRIGGER,
+      }),
+    ],
+  });
+
+  MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/users/',
+    method: 'GET',
+    body: [mockMember],
+  });
+
+  MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/members/',
+    method: 'GET',
+    body: [mockMember],
+  });
+
+  MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/detectors/',
+    method: 'GET',
+    body: [],
+  });
+
+  MockApiClient.addMockResponse({
+    url: '/organizations/org-slug/projects/',
+    method: 'GET',
+    body: [project],
+  });
+}
 
 describe('AutomateSection', () => {
-  const automation1 = AutomationFixture();
-  const project = ProjectFixture({id: '1', slug: 'test-project'});
-  const mockMember = MemberFixture({
-    user: UserFixture({id: '1', name: 'Test User', email: 'test@sentry.io'}),
-  });
+  beforeEach(setupSharedMocks);
 
-  beforeEach(() => {
-    jest.resetAllMocks();
-    MockApiClient.clearMockResponses();
-    ProjectsStore.loadInitialData([project]);
-
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/workflows/',
-      method: 'GET',
-      match: [MockApiClient.matchQuery({ids: [automation1.id]})],
-      body: [automation1],
+  function FormHarness({initial}: {initial: string[]}) {
+    const form = useScrapsForm({
+      ...defaultFormOptions,
+      defaultValues: {workflowIds: initial},
+      onSubmit: () => {},
     });
-
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/workflows/',
-      method: 'GET',
-      body: [automation1],
-    });
-
-    // Mocks for AutomationBuilderDrawerForm
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/available-actions/',
-      method: 'GET',
-      body: [
-        ActionHandlerFixture({
-          type: ActionType.SLACK,
-          handlerGroup: ActionGroup.NOTIFICATION,
-          integrations: [{id: '1', name: 'My Slack Workspace'}],
-        }),
-        ActionHandlerFixture({
-          type: ActionType.EMAIL,
-          handlerGroup: ActionGroup.NOTIFICATION,
-          integrations: [],
-        }),
-      ],
-    });
-
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/tags/',
-      method: 'GET',
-      body: [],
-    });
-
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/data-conditions/',
-      method: 'GET',
-      match: [
-        MockApiClient.matchQuery({group: DataConditionHandlerGroupType.ACTION_FILTER}),
-      ],
-      body: [
-        DataConditionHandlerFixture({
-          handlerGroup: DataConditionHandlerGroupType.ACTION_FILTER,
-          handlerSubgroup: DataConditionHandlerSubgroupType.ISSUE_ATTRIBUTES,
-          type: DataConditionType.TAGGED_EVENT,
-        }),
-      ],
-    });
-
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/data-conditions/',
-      method: 'GET',
-      match: [
-        MockApiClient.matchQuery({group: DataConditionHandlerGroupType.WORKFLOW_TRIGGER}),
-      ],
-      body: [
-        DataConditionHandlerFixture({
-          handlerGroup: DataConditionHandlerGroupType.WORKFLOW_TRIGGER,
-        }),
-      ],
-    });
-
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/users/',
-      method: 'GET',
-      body: [mockMember],
-    });
-
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/members/',
-      method: 'GET',
-      body: [mockMember],
-    });
-
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/detectors/',
-      method: 'GET',
-      body: [],
-    });
-
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/projects/',
-      method: 'GET',
-      body: [project],
-    });
-  });
+    return (
+      <form.AppForm form={form}>
+        <AutomateSection
+          form={form}
+          fields={{workflowIds: 'workflowIds'}}
+          project={project}
+        />
+      </form.AppForm>
+    );
+  }
 
   it('can connect an existing automation', async () => {
-    render(
-      <DetectorFormProvider detectorType="metric_issue">
-        <Form initialData={{projectId: project.id}}>
-          <AutomateSection />
-        </Form>
-      </DetectorFormProvider>
-    );
+    render(<FormHarness initial={[]} />);
 
     expect(await screen.findByText('Alert')).toBeInTheDocument();
 
     await userEvent.click(screen.getByText('Connect Existing Alerts'));
 
-    const drawer = await screen.findByRole('complementary', {
-      name: 'Connect Alerts',
-    });
-
+    const drawer = await screen.findByRole('complementary', {name: 'Connect Alerts'});
     await within(drawer).findByText(automation1.name);
 
     const connectedAutomationsList = await screen.findByTestId(
       'drawer-connected-automations-list'
     );
     const allAutomationsList = await screen.findByTestId('drawer-all-automations-list');
-
     expect(within(allAutomationsList).getByText(automation1.name)).toBeInTheDocument();
 
-    // Clicking connect should add the automation to the connected list
     await userEvent.click(within(drawer).getByRole('button', {name: 'Connect'}));
     await waitFor(() => {
       expect(
@@ -166,22 +176,13 @@ describe('AutomateSection', () => {
   });
 
   it('can disconnect an existing automation', async () => {
-    render(
-      <DetectorFormProvider detectorType="metric_issue">
-        <Form initialData={{projectId: project.id, workflowIds: [automation1.id]}}>
-          <AutomateSection />
-        </Form>
-      </DetectorFormProvider>
-    );
+    render(<FormHarness initial={[automation1.id]} />);
 
-    // Should display automation as connected
     expect(screen.getByText('Connected Alerts')).toBeInTheDocument();
     expect(await screen.findByText(automation1.name)).toBeInTheDocument();
 
     await userEvent.click(screen.getByText('Edit Alerts'));
-    const drawer = await screen.findByRole('complementary', {
-      name: 'Connect Alerts',
-    });
+    const drawer = await screen.findByRole('complementary', {name: 'Connect Alerts'});
 
     const connectedAutomationsList = await screen.findByTestId(
       'drawer-connected-automations-list'
@@ -190,7 +191,6 @@ describe('AutomateSection', () => {
       within(connectedAutomationsList).getByText(automation1.name)
     ).toBeInTheDocument();
 
-    // Clicking disconnect should remove the automation from the connected list
     await userEvent.click(
       within(drawer).getAllByRole('button', {name: 'Disconnect'})[0]!
     );
@@ -210,7 +210,6 @@ describe('AutomateSection', () => {
       body: newAutomation,
     });
 
-    // Mock for fetching the newly created automation
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/workflows/',
       method: 'GET',
@@ -218,23 +217,12 @@ describe('AutomateSection', () => {
       body: [newAutomation],
     });
 
-    render(
-      <DetectorFormProvider detectorType="metric_issue">
-        <Form initialData={{projectId: project.id}}>
-          <AutomateSection />
-        </Form>
-      </DetectorFormProvider>
-    );
+    render(<FormHarness initial={[]} />);
 
-    // Click "Create New Alert" button
     await userEvent.click(await screen.findByRole('button', {name: 'Create New Alert'}));
 
-    // Wait for the drawer to open
-    const drawer = await screen.findByRole('complementary', {
-      name: 'Create New Alert',
-    });
+    const drawer = await screen.findByRole('complementary', {name: 'Create New Alert'});
 
-    // Add an action to make the form valid
     await selectEvent.select(
       within(drawer).getByRole('textbox', {name: 'Add action'}),
       'Slack'
@@ -244,23 +232,85 @@ describe('AutomateSection', () => {
       '#alerts'
     );
 
-    // Fill in the automation name
     const nameInput = within(drawer).getByRole('textbox', {name: 'Alert Name'});
     await userEvent.clear(nameInput);
     await userEvent.type(nameInput, 'My New Alert');
 
-    // Submit the form
     await userEvent.click(within(drawer).getByRole('button', {name: 'Create Alert'}));
 
-    // Wait for the drawer to close and the new automation to appear in the connected list
     await waitFor(() => {
       expect(
         screen.queryByRole('complementary', {name: 'Create New Alert'})
       ).not.toBeInTheDocument();
     });
 
-    // The new automation should appear in the connected alerts section
     expect(await screen.findByText('Connected Alerts')).toBeInTheDocument();
     expect(await screen.findByText('My New Alert')).toBeInTheDocument();
+  });
+});
+
+describe('AutomateSectionDeprecated', () => {
+  beforeEach(setupSharedMocks);
+
+  it('can connect an existing automation', async () => {
+    render(
+      <DetectorFormProvider detectorType="metric_issue">
+        <Form initialData={{projectId: project.id}}>
+          <AutomateSectionDeprecated />
+        </Form>
+      </DetectorFormProvider>
+    );
+
+    expect(await screen.findByText('Alert')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Connect Existing Alerts'));
+
+    const drawer = await screen.findByRole('complementary', {name: 'Connect Alerts'});
+    await within(drawer).findByText(automation1.name);
+
+    const connectedAutomationsList = await screen.findByTestId(
+      'drawer-connected-automations-list'
+    );
+    const allAutomationsList = await screen.findByTestId('drawer-all-automations-list');
+    expect(within(allAutomationsList).getByText(automation1.name)).toBeInTheDocument();
+
+    await userEvent.click(within(drawer).getByRole('button', {name: 'Connect'}));
+    await waitFor(() => {
+      expect(
+        within(connectedAutomationsList).getByText(automation1.name)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('can disconnect an existing automation', async () => {
+    render(
+      <DetectorFormProvider detectorType="metric_issue">
+        <Form initialData={{projectId: project.id, workflowIds: [automation1.id]}}>
+          <AutomateSectionDeprecated />
+        </Form>
+      </DetectorFormProvider>
+    );
+
+    expect(screen.getByText('Connected Alerts')).toBeInTheDocument();
+    expect(await screen.findByText(automation1.name)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Edit Alerts'));
+    const drawer = await screen.findByRole('complementary', {name: 'Connect Alerts'});
+
+    const connectedAutomationsList = await screen.findByTestId(
+      'drawer-connected-automations-list'
+    );
+    expect(
+      within(connectedAutomationsList).getByText(automation1.name)
+    ).toBeInTheDocument();
+
+    await userEvent.click(
+      within(drawer).getAllByRole('button', {name: 'Disconnect'})[0]!
+    );
+    await waitFor(() => {
+      expect(
+        within(connectedAutomationsList).queryByText(automation1.name)
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/static/app/views/detectors/components/forms/automateSection.tsx
+++ b/static/app/views/detectors/components/forms/automateSection.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 import {useDrawer} from '@sentry/scraps/drawer';
+import {withFieldGroup} from '@sentry/scraps/form';
 import {Flex} from '@sentry/scraps/layout';
 
 import {FormContext} from 'sentry/components/forms/formContext';
@@ -11,24 +12,75 @@ import {Container} from 'sentry/components/workflowEngine/ui/container';
 import {FormSection} from 'sentry/components/workflowEngine/ui/formSection';
 import {IconAdd, IconEdit} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import type {Project} from 'sentry/types/project';
 import {AutomationBuilderDrawerForm} from 'sentry/views/automations/components/automationBuilderDrawerForm';
 import {ConnectAutomationsDrawer} from 'sentry/views/detectors/components/connectAutomationsDrawer';
 import {ConnectedAutomationsList} from 'sentry/views/detectors/components/connectedAutomationList';
 import {ConnectedAlertsEmptyState} from 'sentry/views/detectors/components/connectedAutomationsEmptyState';
 import {useDetectorFormProject} from 'sentry/views/detectors/components/forms/common/useDetectorFormProject';
 
-export function AutomateSection({step}: {step?: number}) {
-  const ref = useRef<HTMLButtonElement>(null);
-  const formContext = useContext(FormContext);
-  const {openDrawer, closeDrawer, isDrawerOpen} = useDrawer();
+/**
+ * Section that lets the user connect, disconnect, and create automations
+ * for the detector being edited.
+ */
+export const AutomateSection = withFieldGroup({
+  defaultValues: {workflowIds: [] as string[]},
+  props: {} as {project: Project; step?: number},
+  render: ({group, step, project}) => (
+    <group.AppField name="workflowIds">
+      {field => (
+        <AutomateSectionInner
+          step={step}
+          project={project}
+          workflowIds={field.state.value}
+          setWorkflowIds={field.handleChange}
+        />
+      )}
+    </group.AppField>
+  ),
+});
 
+/**
+ * Legacy variant of {@link AutomateSection} for detector forms still using
+ * the legacy `FormModel` / `FormContext`. Reads and writes `workflowIds`
+ * via the surrounding form context.
+ *
+ * Remove once all detector forms have migrated to the new form system.
+ */
+export function AutomateSectionDeprecated({step}: {step?: number}) {
+  const formContext = useContext(FormContext);
   const project = useDetectorFormProject();
-  const workflowIds = useFormField('workflowIds')!;
+  const workflowIds = useFormField<string[]>('workflowIds') ?? [];
   const setWorkflowIds = useCallback(
-    (newWorkflowIds: string[]) =>
-      formContext.form?.setValue('workflowIds', newWorkflowIds),
+    (next: string[]) => formContext.form?.setValue('workflowIds', next),
     [formContext.form]
   );
+
+  return (
+    <AutomateSectionInner
+      step={step}
+      workflowIds={workflowIds}
+      setWorkflowIds={setWorkflowIds}
+      project={project}
+    />
+  );
+}
+
+interface AutomateSectionInnerProps {
+  project: Project;
+  setWorkflowIds: (workflowIds: string[]) => void;
+  workflowIds: string[];
+  step?: number;
+}
+
+function AutomateSectionInner({
+  step,
+  workflowIds,
+  setWorkflowIds,
+  project,
+}: AutomateSectionInnerProps) {
+  const ref = useRef<HTMLButtonElement>(null);
+  const {openDrawer, closeDrawer, isDrawerOpen} = useDrawer();
 
   const toggleDrawer = () => {
     if (isDrawerOpen) {

--- a/static/app/views/detectors/components/forms/cron/index.tsx
+++ b/static/app/views/detectors/components/forms/cron/index.tsx
@@ -5,7 +5,7 @@ import {Stack} from '@sentry/scraps/layout';
 
 import {t} from 'sentry/locale';
 import type {CronDetector} from 'sentry/types/workflowEngine/detectors';
-import {AutomateSection} from 'sentry/views/detectors/components/forms/automateSection';
+import {AutomateSectionDeprecated} from 'sentry/views/detectors/components/forms/automateSection';
 import {IssueOwnershipSection} from 'sentry/views/detectors/components/forms/common/issueOwnershipSection';
 import {ProjectSection} from 'sentry/views/detectors/components/forms/common/projectSection';
 import {CronDetectorFormDetectSection} from 'sentry/views/detectors/components/forms/cron/detect';
@@ -34,7 +34,7 @@ const FORM_SECTIONS = [
   CronDetectorFormResolveSection,
   IssueOwnershipSection,
   CronIssuePreview,
-  AutomateSection,
+  AutomateSectionDeprecated,
 ];
 /**
  * Maps API errors in the `dataSources` property to the correct form fields.

--- a/static/app/views/detectors/components/forms/editDetectorLayout.tsx
+++ b/static/app/views/detectors/components/forms/editDetectorLayout.tsx
@@ -8,7 +8,7 @@ import {FormContext} from 'sentry/components/forms/formContext';
 import {FormModel} from 'sentry/components/forms/model';
 import type {Data} from 'sentry/components/forms/types';
 import {useFormEagerValidation} from 'sentry/components/forms/useFormEagerValidation';
-import {EditLayout} from 'sentry/components/workflowEngine/layout/edit';
+import {EditLayoutDeprecated} from 'sentry/components/workflowEngine/layout/edit';
 import {t} from 'sentry/locale';
 import type {
   BaseDetectorUpdatePayload,
@@ -73,9 +73,9 @@ export function EditDetectorLayout<
   };
 
   return (
-    <EditLayout formProps={formProps}>
-      <EditLayout.Header maxWidth={maxWidth}>
-        <EditLayout.HeaderContent>
+    <EditLayoutDeprecated formProps={formProps}>
+      <EditLayoutDeprecated.Header maxWidth={maxWidth}>
+        <EditLayoutDeprecated.HeaderContent>
           {hasPageFrame ? (
             <TopBar.Slot name="title">
               <EditDetectorBreadcrumbs detector={detector} />
@@ -83,25 +83,25 @@ export function EditDetectorLayout<
           ) : (
             <EditDetectorBreadcrumbs detector={detector} />
           )}
-        </EditLayout.HeaderContent>
+        </EditLayoutDeprecated.HeaderContent>
 
         <div>
-          <EditLayout.Actions>
+          <EditLayoutDeprecated.Actions>
             <MonitorFeedbackButton />
-          </EditLayout.Actions>
+          </EditLayoutDeprecated.Actions>
         </div>
 
-        <EditLayout.HeaderFields>
+        <EditLayoutDeprecated.HeaderFields>
           <DetectorNameField />
           {previewChart ?? <div />}
-        </EditLayout.HeaderFields>
-      </EditLayout.Header>
+        </EditLayoutDeprecated.HeaderFields>
+      </EditLayoutDeprecated.Header>
 
-      <EditLayout.Body maxWidth={maxWidth}>{children}</EditLayout.Body>
+      <EditLayoutDeprecated.Body maxWidth={maxWidth}>{children}</EditLayoutDeprecated.Body>
 
       <FormContext.Consumer>
         {({form}) => (
-          <EditLayout.Footer maxWidth={maxWidth}>
+          <EditLayoutDeprecated.Footer maxWidth={maxWidth}>
             <DisableDetectorAction detector={detector} />
             <DeleteDetectorAction detector={detector} />
             {extraFooterButton}
@@ -119,9 +119,9 @@ export function EditDetectorLayout<
                 </Button>
               )}
             </Observer>
-          </EditLayout.Footer>
+          </EditLayoutDeprecated.Footer>
         )}
       </FormContext.Consumer>
-    </EditLayout>
+    </EditLayoutDeprecated>
   );
 }

--- a/static/app/views/detectors/components/forms/editDetectorLayout.tsx
+++ b/static/app/views/detectors/components/forms/editDetectorLayout.tsx
@@ -97,7 +97,9 @@ export function EditDetectorLayout<
         </EditLayoutDeprecated.HeaderFields>
       </EditLayoutDeprecated.Header>
 
-      <EditLayoutDeprecated.Body maxWidth={maxWidth}>{children}</EditLayoutDeprecated.Body>
+      <EditLayoutDeprecated.Body maxWidth={maxWidth}>
+        {children}
+      </EditLayoutDeprecated.Body>
 
       <FormContext.Consumer>
         {({form}) => (

--- a/static/app/views/detectors/components/forms/error/index.tsx
+++ b/static/app/views/detectors/components/forms/error/index.tsx
@@ -1,15 +1,14 @@
 import {Fragment} from 'react';
 import {Link} from 'react-router-dom';
 import {useTheme} from '@emotion/react';
-import {Observer} from 'mobx-react-lite';
+import {z} from 'zod';
 
-import {Button} from '@sentry/scraps/button';
+import {defaultFormOptions, useScrapsForm} from '@sentry/scraps/form';
 import {Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
-import {FormContext} from 'sentry/components/forms/formContext';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingError} from 'sentry/components/loadingError';
@@ -23,7 +22,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {AutomationFeedbackButton} from 'sentry/views/automations/components/automationFeedbackButton';
 import {AutomateSection} from 'sentry/views/detectors/components/forms/automateSection';
 import {EditDetectorBreadcrumbs} from 'sentry/views/detectors/components/forms/common/breadcrumbs';
-import {useEditDetectorFormSubmit} from 'sentry/views/detectors/hooks/useEditDetectorFormSubmit';
+import {useSubmitEditDetector} from 'sentry/views/detectors/hooks/useSubmitEditDetector';
 import {
   makeMonitorBasePathname,
   makeMonitorDetailsPathname,
@@ -35,16 +34,10 @@ import {useCanEditDetectorWorkflowConnections} from 'sentry/views/detectors/util
 import {TopBar} from 'sentry/views/navigation/topBar';
 import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 
-type ErrorDetectorFormData = {
-  workflowIds: string[];
-};
-
-function ErrorDetectorForm({project}: {project: Project}) {
+function StaticSections({project}: {project: Project}) {
   const organization = useOrganization();
-  const theme = useTheme();
-
   return (
-    <Stack gap="2xl" maxWidth={theme.breakpoints.xl}>
+    <Fragment>
       <Container>
         <FormSection step={1} title={t('Detect')}>
           <Text as="p">
@@ -107,8 +100,7 @@ function ErrorDetectorForm({project}: {project: Project}) {
           </Text>
         </FormSection>
       </Container>
-      <AutomateSection step={5} />
-    </Stack>
+    </Fragment>
   );
 }
 
@@ -135,100 +127,98 @@ export function EditExistingErrorDetectorForm({
   const theme = useTheme();
   const maxWidth = theme.breakpoints.xl;
   const hasPageFrameFeature = useHasPageFrameFeature();
+  const submitEditDetector = useSubmitEditDetector();
 
-  // Error monitors only allow editing workflow connections right now, so that's the only permission we need to check
   const canEditWorkflowConnections = useCanEditDetectorWorkflowConnections({
     projectId: detector.projectId,
   });
 
-  const handleFormSubmit = useEditDetectorFormSubmit({
-    detector,
-    formDataToEndpointPayload: (data: ErrorDetectorFormData) => ({
-      type: 'error',
-      name: detector.name,
-      owner: detector.owner ? `${detector.owner?.type}:${detector.owner?.id}` : '',
-      projectId: detector.projectId,
-      workflowIds: data.workflowIds,
-      dataSources: [],
-      conditionGroup: {},
-    }),
+  const form = useScrapsForm({
+    ...defaultFormOptions,
+    defaultValues: {workflowIds: detector.workflowIds},
+    validators: {
+      onDynamic: z.object({
+        workflowIds: z.array(z.string()),
+      }),
+    },
+    onSubmit: async ({value}) => {
+      await submitEditDetector({
+        detectorId: detector.id,
+        type: 'error' as const,
+        name: detector.name,
+        owner: detector.owner ? `${detector.owner.type}:${detector.owner.id}` : '',
+        projectId: detector.projectId,
+        workflowIds: value.workflowIds,
+      });
+    },
   });
 
   return (
-    <EditLayout
-      formProps={{
-        initialData: {
-          projectId: detector.projectId,
-          workflowIds: detector.workflowIds,
-        },
-        onSubmit: handleFormSubmit,
-      }}
-    >
-      {hasPageFrameFeature ? (
-        <Fragment>
-          <TopBar.Slot name="title">
-            <Breadcrumbs
-              crumbs={[
-                {
-                  label: t('Monitors'),
-                  to: makeMonitorBasePathname(organization.slug),
-                },
-                {
-                  label: getDetectorTypeLabel(detector.type),
-                  to: makeMonitorTypePathname(organization.slug, detector.type),
-                },
-                {
-                  label: <ProjectBadge disableLink project={project} avatarSize={16} />,
-                  to: makeMonitorDetailsPathname(organization.slug, detector.id),
-                },
-                {label: t('Configure')},
-              ]}
-            />
-          </TopBar.Slot>
-          <AutomationFeedbackButton />
-        </Fragment>
-      ) : (
-        <EditLayout.Header>
-          <EditLayout.HeaderContent>
-            <Fragment>
-              <EditDetectorBreadcrumbs detector={detector} />
-              <EditLayout.Title title={detector.name} project={project} />
-            </Fragment>
-          </EditLayout.HeaderContent>
-          <EditLayout.Actions>
+    <EditLayout>
+      <form.AppForm form={form}>
+        {hasPageFrameFeature ? (
+          <Fragment>
+            <TopBar.Slot name="title">
+              <Breadcrumbs
+                crumbs={[
+                  {
+                    label: t('Monitors'),
+                    to: makeMonitorBasePathname(organization.slug),
+                  },
+                  {
+                    label: getDetectorTypeLabel(detector.type),
+                    to: makeMonitorTypePathname(organization.slug, detector.type),
+                  },
+                  {
+                    label: <ProjectBadge disableLink project={project} avatarSize={16} />,
+                    to: makeMonitorDetailsPathname(organization.slug, detector.id),
+                  },
+                  {label: t('Configure')},
+                ]}
+              />
+            </TopBar.Slot>
             <AutomationFeedbackButton />
-          </EditLayout.Actions>
-        </EditLayout.Header>
-      )}
-
-      <EditLayout.Body>
-        <ErrorDetectorForm project={project} />
-      </EditLayout.Body>
-
-      <FormContext.Consumer>
-        {({form}) => (
-          <EditLayout.Footer maxWidth={maxWidth}>
-            <Observer>
-              {() => (
-                <Button
-                  type="submit"
-                  priority="primary"
-                  size="sm"
-                  busy={form?.isSaving}
-                  disabled={!canEditWorkflowConnections}
-                  tooltipProps={{
-                    title: canEditWorkflowConnections
-                      ? undefined
-                      : getNoPermissionToEditMonitorTooltip(),
-                  }}
-                >
-                  {t('Save')}
-                </Button>
-              )}
-            </Observer>
-          </EditLayout.Footer>
+          </Fragment>
+        ) : (
+          <EditLayout.Header>
+            <EditLayout.HeaderContent>
+              <Fragment>
+                <EditDetectorBreadcrumbs detector={detector} />
+                <EditLayout.Title title={detector.name} project={project} />
+              </Fragment>
+            </EditLayout.HeaderContent>
+            <EditLayout.Actions>
+              <AutomationFeedbackButton />
+            </EditLayout.Actions>
+          </EditLayout.Header>
         )}
-      </FormContext.Consumer>
+
+        <EditLayout.Body>
+          <Stack gap="2xl" maxWidth={maxWidth}>
+            <StaticSections project={project} />
+            <AutomateSection
+              form={form}
+              fields={{workflowIds: 'workflowIds'}}
+              step={5}
+              project={project}
+            />
+          </Stack>
+        </EditLayout.Body>
+
+        <EditLayout.Footer maxWidth={maxWidth}>
+          <form.SubmitButton
+            size="sm"
+            disabled={!canEditWorkflowConnections}
+            tooltipProps={{
+              title: canEditWorkflowConnections
+                ? undefined
+                : getNoPermissionToEditMonitorTooltip(),
+            }}
+          >
+            {t('Save')}
+          </form.SubmitButton>
+        </EditLayout.Footer>
+      </form.AppForm>
     </EditLayout>
   );
 }

--- a/static/app/views/detectors/components/forms/metric/metric.tsx
+++ b/static/app/views/detectors/components/forms/metric/metric.tsx
@@ -34,7 +34,7 @@ import {
   TransactionsDatasetWarning,
 } from 'sentry/views/detectors/components/details/metric/transactionsDatasetWarning';
 import {useIsMigratedExtrapolation} from 'sentry/views/detectors/components/details/metric/utils/useIsMigratedExtrapolation';
-import {AutomateSection} from 'sentry/views/detectors/components/forms/automateSection';
+import {AutomateSectionDeprecated} from 'sentry/views/detectors/components/forms/automateSection';
 import {IssueOwnershipSection} from 'sentry/views/detectors/components/forms/common/issueOwnershipSection';
 import {ProjectEnvironmentSection} from 'sentry/views/detectors/components/forms/common/projectEnvironmentSection';
 import {EditDetectorLayout} from 'sentry/views/detectors/components/forms/editDetectorLayout';
@@ -81,7 +81,7 @@ function MetricDetectorForm() {
       <DetectSection step={4} />
       <IssueOwnershipSection step={5} />
       <MetricIssuePreview step={6} />
-      <AutomateSection step={7} />
+      <AutomateSectionDeprecated step={7} />
     </Stack>
   );
 }

--- a/static/app/views/detectors/components/forms/mobileBuild/index.tsx
+++ b/static/app/views/detectors/components/forms/mobileBuild/index.tsx
@@ -9,7 +9,7 @@ import {Container} from 'sentry/components/workflowEngine/ui/container';
 import {FormSection} from 'sentry/components/workflowEngine/ui/formSection';
 import {t} from 'sentry/locale';
 import type {PreprodDetector} from 'sentry/types/workflowEngine/detectors';
-import {AutomateSection} from 'sentry/views/detectors/components/forms/automateSection';
+import {AutomateSectionDeprecated} from 'sentry/views/detectors/components/forms/automateSection';
 import {IssueOwnershipSection} from 'sentry/views/detectors/components/forms/common/issueOwnershipSection';
 import {ProjectSection} from 'sentry/views/detectors/components/forms/common/projectSection';
 import {EditDetectorLayout} from 'sentry/views/detectors/components/forms/editDetectorLayout';
@@ -64,7 +64,7 @@ function MobileBuildDetectorForm() {
       </Container>
       <IssueOwnershipSection step={5} />
       <MobileBuildPreviewSection step={6} />
-      <AutomateSection step={7} />
+      <AutomateSectionDeprecated step={7} />
     </Stack>
   );
 }

--- a/static/app/views/detectors/components/forms/newDetectorLayout.tsx
+++ b/static/app/views/detectors/components/forms/newDetectorLayout.tsx
@@ -6,7 +6,7 @@ import type {FormProps} from 'sentry/components/forms/form';
 import {FormModel} from 'sentry/components/forms/model';
 import type {Data} from 'sentry/components/forms/types';
 import {useFormEagerValidation} from 'sentry/components/forms/useFormEagerValidation';
-import {EditLayout} from 'sentry/components/workflowEngine/layout/edit';
+import {EditLayoutDeprecated} from 'sentry/components/workflowEngine/layout/edit';
 import type {
   BaseDetectorUpdatePayload,
   DetectorType,
@@ -97,9 +97,9 @@ export function NewDetectorLayout<
   };
 
   return (
-    <EditLayout formProps={formProps}>
-      <EditLayout.Header maxWidth={maxWidth}>
-        <EditLayout.HeaderContent>
+    <EditLayoutDeprecated formProps={formProps}>
+      <EditLayoutDeprecated.Header maxWidth={maxWidth}>
+        <EditLayoutDeprecated.HeaderContent>
           {hasPageFrame ? (
             <TopBar.Slot name="title">
               <NewDetectorBreadcrumbs detectorType={detectorType} />
@@ -107,25 +107,25 @@ export function NewDetectorLayout<
           ) : (
             <NewDetectorBreadcrumbs detectorType={detectorType} />
           )}
-        </EditLayout.HeaderContent>
+        </EditLayoutDeprecated.HeaderContent>
 
         <div>
           <MonitorFeedbackButton />
         </div>
 
-        <EditLayout.HeaderFields>
+        <EditLayoutDeprecated.HeaderFields>
           <DetectorNameField />
           {previewChart ?? <div />}
-        </EditLayout.HeaderFields>
-      </EditLayout.Header>
+        </EditLayoutDeprecated.HeaderFields>
+      </EditLayoutDeprecated.Header>
 
-      <EditLayout.Body maxWidth={maxWidth}>{children}</EditLayout.Body>
+      <EditLayoutDeprecated.Body maxWidth={maxWidth}>{children}</EditLayoutDeprecated.Body>
 
       <NewDetectorFooter
         maxWidth={maxWidth}
         disabledCreate={disabledCreate}
         extras={extraFooterButton}
       />
-    </EditLayout>
+    </EditLayoutDeprecated>
   );
 }

--- a/static/app/views/detectors/components/forms/newDetectorLayout.tsx
+++ b/static/app/views/detectors/components/forms/newDetectorLayout.tsx
@@ -119,7 +119,9 @@ export function NewDetectorLayout<
         </EditLayoutDeprecated.HeaderFields>
       </EditLayoutDeprecated.Header>
 
-      <EditLayoutDeprecated.Body maxWidth={maxWidth}>{children}</EditLayoutDeprecated.Body>
+      <EditLayoutDeprecated.Body maxWidth={maxWidth}>
+        {children}
+      </EditLayoutDeprecated.Body>
 
       <NewDetectorFooter
         maxWidth={maxWidth}

--- a/static/app/views/detectors/components/forms/uptime/index.tsx
+++ b/static/app/views/detectors/components/forms/uptime/index.tsx
@@ -10,7 +10,7 @@ import {
   usePreviewCheckResult,
 } from 'sentry/views/alerts/rules/uptime/previewCheckContext';
 import {useUptimeAssertionFeatures} from 'sentry/views/alerts/rules/uptime/useUptimeAssertionFeatures';
-import {AutomateSection} from 'sentry/views/detectors/components/forms/automateSection';
+import {AutomateSectionDeprecated} from 'sentry/views/detectors/components/forms/automateSection';
 import {IssueOwnershipSection} from 'sentry/views/detectors/components/forms/common/issueOwnershipSection';
 import {
   ProjectEnvironmentSection,
@@ -68,7 +68,7 @@ function UptimeDetectorForm() {
       <UptimeDetectorResolveSection step={nextStep()} />
       <IssueOwnershipSection step={nextStep()} />
       <UptimeIssuePreview step={nextStep()} />
-      <AutomateSection step={nextStep()} />
+      <AutomateSectionDeprecated step={nextStep()} />
     </Stack>
   );
 }

--- a/static/app/views/detectors/hooks/useSubmitEditDetector.tsx
+++ b/static/app/views/detectors/hooks/useSubmitEditDetector.tsx
@@ -1,0 +1,63 @@
+import {useCallback} from 'react';
+
+import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {t} from 'sentry/locale';
+import type {
+  BaseDetectorUpdatePayload,
+  Detector,
+} from 'sentry/types/workflowEngine/detectors';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {useNavigate} from 'sentry/utils/useNavigate';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {getDetectorAnalyticsPayload} from 'sentry/views/detectors/components/forms/common/getDetectorAnalyticsPayload';
+import {useUpdateDetector} from 'sentry/views/detectors/hooks';
+import {makeMonitorDetailsPathname} from 'sentry/views/detectors/pathnames';
+
+type UpdatePayload = {detectorId: string} & Partial<BaseDetectorUpdatePayload>;
+
+interface UseSubmitEditDetectorOptions<TDetector extends Detector> {
+  onError?: (error: unknown) => void;
+  onSuccess?: (detector: TDetector) => void;
+}
+
+/**
+ * Handles the common submission logic for edit detector forms:
+ * submitting the payload, tracking analytics, showing indicators,
+ * and navigating to the detector details page.
+ */
+export function useSubmitEditDetector<TDetector extends Detector>({
+  onSuccess,
+  onError,
+}: UseSubmitEditDetectorOptions<TDetector> = {}) {
+  const organization = useOrganization();
+  const navigate = useNavigate();
+  const {mutateAsync: updateDetector} = useUpdateDetector();
+
+  return useCallback(
+    async (payload: UpdatePayload) => {
+      try {
+        const resultDetector = await updateDetector(payload);
+
+        trackAnalytics('monitor.updated', {
+          organization,
+          ...getDetectorAnalyticsPayload(resultDetector),
+        });
+
+        addSuccessMessage(t('Monitor updated'));
+
+        if (onSuccess) {
+          onSuccess(resultDetector as TDetector);
+        } else {
+          navigate(makeMonitorDetailsPathname(organization.slug, resultDetector.id));
+        }
+
+        return resultDetector;
+      } catch (error) {
+        addErrorMessage(t('Unable to update monitor'));
+        onError?.(error);
+        return undefined;
+      }
+    },
+    [updateDetector, organization, navigate, onSuccess, onError]
+  );
+}

--- a/static/app/views/detectors/new.tsx
+++ b/static/app/views/detectors/new.tsx
@@ -75,7 +75,9 @@ export default function DetectorNew() {
           ) : (
             <NewDetectorBreadcrumbs />
           )}
-          {!hasPageFrame && <EditLayoutDeprecated.Title title={t('Select monitor type')} />}
+          {!hasPageFrame && (
+            <EditLayoutDeprecated.Title title={t('Select monitor type')} />
+          )}
           <Text as="p" size="md" variant="muted">
             {tct(
               'Monitors detect problems in your application and send alerts when they occur. [docsLink:Read the Docs].',

--- a/static/app/views/detectors/new.tsx
+++ b/static/app/views/detectors/new.tsx
@@ -7,7 +7,7 @@ import {Text} from '@sentry/scraps/text';
 
 import {Breadcrumbs} from 'sentry/components/breadcrumbs';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
-import {EditLayout} from 'sentry/components/workflowEngine/layout/edit';
+import {EditLayoutDeprecated} from 'sentry/components/workflowEngine/layout/edit';
 import {useWorkflowEngineFeatureGate} from 'sentry/components/workflowEngine/useWorkflowEngineFeatureGate';
 import {t, tct} from 'sentry/locale';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -64,10 +64,10 @@ export default function DetectorNew() {
   };
 
   return (
-    <EditLayout formProps={formProps}>
+    <EditLayoutDeprecated formProps={formProps}>
       <SentryDocumentTitle title={t('New Monitor')} />
-      <EditLayout.Header maxWidth={maxWidth}>
-        <EditLayout.HeaderContent>
+      <EditLayoutDeprecated.Header maxWidth={maxWidth}>
+        <EditLayoutDeprecated.HeaderContent>
           {hasPageFrame ? (
             <TopBar.Slot name="title">
               <NewDetectorBreadcrumbs />
@@ -75,7 +75,7 @@ export default function DetectorNew() {
           ) : (
             <NewDetectorBreadcrumbs />
           )}
-          {!hasPageFrame && <EditLayout.Title title={t('Select monitor type')} />}
+          {!hasPageFrame && <EditLayoutDeprecated.Title title={t('Select monitor type')} />}
           <Text as="p" size="md" variant="muted">
             {tct(
               'Monitors detect problems in your application and send alerts when they occur. [docsLink:Read the Docs].',
@@ -86,24 +86,24 @@ export default function DetectorNew() {
               }
             )}
           </Text>
-        </EditLayout.HeaderContent>
+        </EditLayoutDeprecated.HeaderContent>
         <div>
           <MonitorFeedbackButton />
         </div>
-      </EditLayout.Header>
+      </EditLayoutDeprecated.Header>
 
-      <EditLayout.Body maxWidth={maxWidth}>
+      <EditLayoutDeprecated.Body maxWidth={maxWidth}>
         <DetectorTypeForm />
-      </EditLayout.Body>
+      </EditLayoutDeprecated.Body>
 
-      <EditLayout.Footer label={t('Step 1 of 2')} maxWidth={maxWidth}>
+      <EditLayoutDeprecated.Footer label={t('Step 1 of 2')} maxWidth={maxWidth}>
         <LinkButton priority="default" to={makeMonitorBasePathname(organization.slug)}>
           {t('Cancel')}
         </LinkButton>
         <Button priority="primary" type="submit">
           {t('Next')}
         </Button>
-      </EditLayout.Footer>
-    </EditLayout>
+      </EditLayoutDeprecated.Footer>
+    </EditLayoutDeprecated>
   );
 }


### PR DESCRIPTION
Ref ISWF-2286

This migrates the error detector edit form off the legacy `FormModel`/`FormContext` system onto TanStack Form (`useScrapsForm`). The error detector is a good first candidate since its form is simple - it only sends `workflowIds` with `AutomateSection`, and it only implements the edit form.

The main structural change is splitting a few components into "new" and "deprecated" variants so the migrated error form can use the new system while other detector forms (metric, cron, uptime, mobile build) continue using the legacy one:

- `AutomateSection` now uses `withFieldGroup` and receives form/fields props from the parent TanStack form. The old version becomes `AutomateSectionDeprecated` which still reads from `FormContext`.
- `EditLayout` is split into a version that renders children directly (for forms managing their own `<form>` element via TanStack) and `EditLayoutDeprecated` which wraps children in a `<FullHeightForm>` for the legacy system.