### PR TITLE
ref(grouping): Clear old and invalid secondary grouping config options

### DIFF
--- a/src/sentry/grouping/ingest/config.py
+++ b/src/sentry/grouping/ingest/config.py
@@ -146,7 +146,9 @@ def update_or_set_grouping_config_if_needed(project: Project, source: str) -> st
 def is_in_transition(project: Project) -> bool:
     """
     Determine if a project is currently in a grouping transition, i.e., that it has a valid
-    secondary grouping config defined and that it's secondary grouping expiry date hasn't passed.
+    secondary grouping config defined and that its secondary grouping expiry date hasn't passed.
+
+    If out-dated secondary config options are found, clean them up.
     """
     primary_grouping_config = project.get_option("sentry:grouping_config")
     secondary_grouping_config = project.get_option("sentry:secondary_grouping_config")

--- a/src/sentry/grouping/ingest/config.py
+++ b/src/sentry/grouping/ingest/config.py
@@ -156,3 +156,35 @@ def is_in_transition(project: Project) -> bool:
         and secondary_grouping_config in GROUPING_CONFIG_CLASSES.keys()
         and (secondary_grouping_expiry or 0) >= time.time()
     )
+
+
+def _clean_up_expired_config_options(project_id: int) -> None:
+    """
+    Clean up out-dated secondary config and secondary config expiry project options. Uses caching
+    and a lock to prevent race conditions.
+
+    Note: This assumes we've already checked that the data exists and is out of date.
+    """
+    cache_key = f"grouping-config-cleanup:{project_id}"
+    lock_key = f"grouping-config-cleanup-lock:{project_id}"
+
+    if cache.get(cache_key) is not None:
+        return
+
+    try:
+        with locks.get(lock_key, duration=60, name="grouping-config-cleanup-lock").acquire():
+            # We wait to set the cache key until we've successfully acquired the lock so that if for
+            # some reason we can't, we don't have to wait 5 minutes before trying again
+            cache.set(cache_key, "1", 60 * 5)
+
+            ProjectOption.objects.filter(
+                key__in=["sentry:secondary_grouping_config", "sentry:secondary_grouping_expiry"],
+                project_id=project_id,
+            ).delete()
+
+            metrics.incr(
+                "grouping.old_config_options_cleared",
+                sample_rate=options.get("grouping.config_transition.metrics_sample_rate"),
+            )
+    except UnableToAcquireLock:
+        return

--- a/src/sentry/grouping/ingest/config.py
+++ b/src/sentry/grouping/ingest/config.py
@@ -148,14 +148,24 @@ def is_in_transition(project: Project) -> bool:
     Determine if a project is currently in a grouping transition, i.e., that it has a valid
     secondary grouping config defined and that it's secondary grouping expiry date hasn't passed.
     """
+    primary_grouping_config = project.get_option("sentry:grouping_config")
     secondary_grouping_config = project.get_option("sentry:secondary_grouping_config")
     secondary_grouping_expiry = project.get_option("sentry:secondary_grouping_expiry")
 
-    return (
-        bool(secondary_grouping_config)
-        and secondary_grouping_config in GROUPING_CONFIG_CLASSES.keys()
-        and (secondary_grouping_expiry or 0) >= time.time()
+    if not secondary_grouping_config and not secondary_grouping_expiry:
+        return False
+
+    secondary_is_invalid_or_expired = (
+        secondary_grouping_config not in GROUPING_CONFIG_CLASSES.keys()
+        or secondary_grouping_config == primary_grouping_config
+        or (secondary_grouping_expiry or 0) < time.time()
     )
+
+    if secondary_is_invalid_or_expired:
+        _clean_up_expired_config_options(project.id)
+        return False
+
+    return True
 
 
 def _clean_up_expired_config_options(project_id: int) -> None:

--- a/tests/sentry/grouping/test_config.py
+++ b/tests/sentry/grouping/test_config.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import time
 from unittest.mock import MagicMock, patch
 
 from sentry import audit_log
 from sentry.conf.server import DEFAULT_GROUPING_CONFIG, SENTRY_GROUPING_CONFIG_TRANSITION_DURATION
 from sentry.grouping.api import get_grouping_config_dict_for_project
-from sentry.grouping.ingest.config import update_or_set_grouping_config_if_needed
+from sentry.grouping.ingest.config import is_in_transition, update_or_set_grouping_config_if_needed
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.options.project_option import ProjectOption
 from sentry.testutils.cases import TestCase
@@ -16,6 +17,12 @@ from tests.sentry.grouping import NO_MSG_PARAM_CONFIG
 
 
 class GroupingConfigTest(TestCase):
+    def _count_secondary_config_options(self) -> int:
+        return ProjectOption.objects.filter(
+            key__in=["sentry:secondary_grouping_config", "sentry:secondary_grouping_expiry"],
+            project_id=self.project.id,
+        ).count()
+
     def test_loads_default_config_if_stored_config_option_is_invalid(self) -> None:
         self.project.update_option("sentry:grouping_config", "dogs.are.great")
         config_dict = get_grouping_config_dict_for_project(self.project)
@@ -194,3 +201,51 @@ class GroupingConfigTest(TestCase):
             ).exists()
             assert self.project.get_option("sentry:secondary_grouping_config") is None
             assert self.project.get_option("sentry:secondary_grouping_expiry") == 0
+
+    def test_transition_check_simple(self) -> None:
+        self.project.update_option("sentry:secondary_grouping_config", NO_MSG_PARAM_CONFIG)
+        self.project.update_option("sentry:secondary_grouping_expiry", time.time() + 60)
+
+        assert is_in_transition(self.project) is True
+
+    def test_transition_check_no_secondary_options_set(self) -> None:
+        assert self._count_secondary_config_options() == 0
+        assert is_in_transition(self.project) is False
+
+    def test_transition_check_invalid_secondary_config(self) -> None:
+        self.project.update_option("sentry:secondary_grouping_config", "dogs.are.great")
+        self.project.update_option("sentry:secondary_grouping_expiry", time.time() + 60)
+        assert self._count_secondary_config_options() == 2
+
+        assert is_in_transition(self.project) is False
+        assert self._count_secondary_config_options() == 0
+
+    def test_transition_check_expired_secondary_config(self) -> None:
+        self.project.update_option("sentry:secondary_grouping_config", NO_MSG_PARAM_CONFIG)
+        self.project.update_option("sentry:secondary_grouping_expiry", time.time() - 60)
+        assert self._count_secondary_config_options() == 2
+
+        assert is_in_transition(self.project) is False
+        assert self._count_secondary_config_options() == 0
+
+    def test_transition_check_missing_secondary_config(self) -> None:
+        self.project.update_option("sentry:secondary_grouping_expiry", time.time() + 60)
+        assert self._count_secondary_config_options() == 1
+
+        assert is_in_transition(self.project) is False
+        assert self._count_secondary_config_options() == 0
+
+    def test_transition_check_missing_secondary_expiry(self) -> None:
+        self.project.update_option("sentry:secondary_grouping_config", NO_MSG_PARAM_CONFIG)
+        assert self._count_secondary_config_options() == 1
+
+        assert is_in_transition(self.project) is False
+        assert self._count_secondary_config_options() == 0
+
+    def test_transition_check_matching_secondary_and_primary_configs(self) -> None:
+        self.project.update_option("sentry:secondary_grouping_config", DEFAULT_GROUPING_CONFIG)
+        self.project.update_option("sentry:secondary_grouping_expiry", time.time() + 60)
+        assert self._count_secondary_config_options() == 2
+
+        assert is_in_transition(self.project) is False
+        assert self._count_secondary_config_options() == 0


### PR DESCRIPTION
Right now, we store an expiry date for each project's grouping config transition period, but we never go back and clean out old/expired transition settings once that period has ended. We also don't make any effort to fix invalid data if/when we find it.

Other than wasting space in the database, this normally isn't an issue, unless the corrupt data leads our assumptions to be broken and our code to therefore fail, as happened recently when a project somehow got the same value set for its default and secondary grouping configs. (In that case, the fact that we discard new secondary hashes led us to also discard new primary hashes, [breaking grouping](https://sentry.sentry.io/issues/7368625348).)

To prevent future problems, and to clean up after ourselves, this PR therefore adds a new helper, `_clean_up_expired_config_options` (which, as the name suggests, deletes a project's secondary config and secondary config expiry `ProjectOption` records), and calls it when necessary in the spot where we're already checking the relevant values, namely in the existing `is_in_transition` function. Like grouping config upgrades, these database calls are guarded by both a cache key and a lock in order to prevent race conditions. It also turns out there were no tests specifically covering the transition check, so this adds them, and includes a check of the clean-up work as part of what they test.