### PR TITLE
fix(seer): Default Explorer query time ranges

### DIFF
--- a/src/sentry/seer/explorer/tools.py
+++ b/src/sentry/seer/explorer/tools.py
@@ -64,6 +64,8 @@ from sentry.utils.snuba_rpc import get_trace_rpc
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_STATS_PERIOD = "7d"
+
 
 def _get_full_trace_id(
     short_trace_id: str, organization: Organization, projects: list[Project]
@@ -148,6 +150,9 @@ def execute_table_query(
     if not project_ids and not project_slugs:
         project_ids = [ALL_ACCESS_PROJECT_ID]
     # Note if both project_ids and project_slugs are provided, the API request will 400.
+
+    if not stats_period and not start and not end:
+        stats_period = DEFAULT_STATS_PERIOD
 
     if sort:
         # Auto-select sort field to avoid snuba errors.
@@ -241,6 +246,9 @@ def execute_timeseries_query(
     if not project_ids and not project_slugs:
         project_ids = [ALL_ACCESS_PROJECT_ID]
     # Note if both project_ids and project_slugs are provided, the API request will 400.
+
+    if not stats_period and not start and not end:
+        stats_period = DEFAULT_STATS_PERIOD
 
     params: dict[str, Any] = {
         "dataset": dataset,

--- a/tests/sentry/seer/explorer/test_tools.py
+++ b/tests/sentry/seer/explorer/test_tools.py
@@ -63,6 +63,81 @@ def _get_utc_iso_without_timezone(dt: datetime) -> str:
     return dt.astimezone(UTC).isoformat().replace("+00:00", "")
 
 
+class TestSeerExplorerQueryDefaults(TestCase):
+    @patch("sentry.seer.explorer.tools.client.get")
+    def test_table_query_defaults_missing_time_range_to_seven_days(
+        self, mock_client_get: Mock
+    ) -> None:
+        mock_client_get.return_value = Mock(data={"data": [], "meta": {}})
+
+        execute_table_query(
+            org_id=self.organization.id,
+            dataset="tracemetrics",
+            fields=["timestamp"],
+            per_page=1,
+        )
+
+        params = mock_client_get.call_args.kwargs["params"]
+        assert params["statsPeriod"] == "7d"
+        assert "start" not in params
+        assert "end" not in params
+
+    @patch("sentry.seer.explorer.tools.client.get")
+    def test_timeseries_query_defaults_missing_time_range_to_seven_days(
+        self, mock_client_get: Mock
+    ) -> None:
+        mock_client_get.return_value = Mock(data={"data": []})
+
+        execute_timeseries_query(
+            org_id=self.organization.id,
+            dataset="tracemetrics",
+            y_axes=["count()"],
+            query="",
+        )
+
+        params = mock_client_get.call_args.kwargs["params"]
+        assert params["statsPeriod"] == "7d"
+        assert "start" not in params
+        assert "end" not in params
+
+    @patch("sentry.seer.explorer.tools.client.get")
+    def test_table_query_preserves_explicit_absolute_range(self, mock_client_get: Mock) -> None:
+        mock_client_get.return_value = Mock(data={"data": [], "meta": {}})
+        start = "2026-01-01T00:00:00"
+        end = "2026-01-02T00:00:00"
+
+        execute_table_query(
+            org_id=self.organization.id,
+            dataset="tracemetrics",
+            fields=["timestamp"],
+            per_page=1,
+            start=start,
+            end=end,
+        )
+
+        params = mock_client_get.call_args.kwargs["params"]
+        assert "statsPeriod" not in params
+        assert params["start"] == start
+        assert params["end"] == end
+
+    @patch("sentry.seer.explorer.tools.client.get")
+    def test_timeseries_query_preserves_explicit_stats_period(self, mock_client_get: Mock) -> None:
+        mock_client_get.return_value = Mock(data={"data": []})
+
+        execute_timeseries_query(
+            org_id=self.organization.id,
+            dataset="tracemetrics",
+            y_axes=["count()"],
+            query="",
+            stats_period="24h",
+        )
+
+        params = mock_client_get.call_args.kwargs["params"]
+        assert params["statsPeriod"] == "24h"
+        assert "start" not in params
+        assert "end" not in params
+
+
 class TestSpansQuery(APITransactionTestCase, SnubaTestCase, SpanTestCase):
     default_span_fields = [
         "id",


### PR DESCRIPTION
Seer Explorer table and timeseries RPC helpers now default missing time params to seven days. This gives Explorer a defensive backend fallback when callers omit `statsPeriod`, `start`, and `end`.

**Companion Change**

The Seer PR makes metrics assisted-query responses deterministic at the source and adds metadata for defaulted ranges: https://github.com/getsentry/seer/pull/6081