### PR TITLE
fix(seer): Show default metrics time range

### DIFF
--- a/static/app/views/seerExplorer/utils.spec.tsx
+++ b/static/app/views/seerExplorer/utils.spec.tsx
@@ -1,7 +1,11 @@
 import {decodeMetricsQueryParams} from 'sentry/views/explore/metrics/metricQuery';
 import {Mode} from 'sentry/views/explore/queryParams/mode';
 import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
-import {buildToolLinkUrl, postProcessLLMMarkdown} from 'sentry/views/seerExplorer/utils';
+import {
+  buildToolLinkUrl,
+  getToolsStringFromBlock,
+  postProcessLLMMarkdown,
+} from 'sentry/views/seerExplorer/utils';
 
 describe('postProcessLLMMarkdown', () => {
   describe('issue short ID linkification', () => {
@@ -125,5 +129,95 @@ describe('buildToolLinkUrl', () => {
     );
 
     expect(result).toBeNull();
+  });
+});
+
+describe('getToolsStringFromBlock', () => {
+  it('shows defaulted metrics time range in tool text', () => {
+    const tools = getToolsStringFromBlock({
+      id: 'block',
+      loading: false,
+      timestamp: '',
+      message: {
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          {
+            id: 'tc-1',
+            function: 'telemetry_live_search',
+            args: JSON.stringify({
+              dataset: 'tracemetrics',
+              question: 'p95 of char count metric grouped by environment',
+              project_slugs: [],
+            }),
+          },
+        ],
+      },
+      tool_results: [
+        {
+          tool_call_id: 'tc-1',
+          tool_call_function: 'telemetry_live_search',
+          content: '',
+        },
+      ],
+      tool_links: [
+        {
+          kind: 'telemetry_live_search',
+          params: {
+            dataset: 'tracemetrics',
+            stats_period: '7d',
+            time_range_defaulted: true,
+          },
+        },
+      ],
+    });
+
+    expect(tools).toEqual([
+      "Queried metrics in seer: 'p95 of char count metric grouped by environment in the last 7 days'",
+    ]);
+  });
+
+  it('does not show defaulted metrics time range for explicit ranges', () => {
+    const tools = getToolsStringFromBlock({
+      id: 'block',
+      loading: false,
+      timestamp: '',
+      message: {
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          {
+            id: 'tc-1',
+            function: 'telemetry_live_search',
+            args: JSON.stringify({
+              dataset: 'tracemetrics',
+              question: 'p95 of char count metric grouped by environment',
+              project_slugs: [],
+            }),
+          },
+        ],
+      },
+      tool_results: [
+        {
+          tool_call_id: 'tc-1',
+          tool_call_function: 'telemetry_live_search',
+          content: '',
+        },
+      ],
+      tool_links: [
+        {
+          kind: 'telemetry_live_search',
+          params: {
+            dataset: 'tracemetrics',
+            stats_period: '7d',
+            time_range_defaulted: false,
+          },
+        },
+      ],
+    });
+
+    expect(tools).toEqual([
+      "Queried metrics in seer: 'p95 of char count metric grouped by environment'",
+    ]);
   });
 });

--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -48,6 +48,15 @@ type ToolFormatter = (
   toolLinkParams?: Record<string, any> | null
 ) => string;
 
+function getDefaultedTimeRangeSuffix(
+  toolLinkParams?: Record<string, any> | null
+): string {
+  if (toolLinkParams?.time_range_defaulted && toolLinkParams?.stats_period === '7d') {
+    return ' in the last 7 days';
+  }
+  return '';
+}
+
 export const makeSeerExplorerQueryKey = (
   orgSlug: string,
   runId: number | null
@@ -110,9 +119,11 @@ const TOOL_FORMATTERS: Record<string, ToolFormatter> = {
     }
 
     if (dataset === 'metrics' || dataset === 'tracemetrics') {
+      const metricsInfo = projectInfo || ' in seer';
+      const displayQuestion = `${question}${getDefaultedTimeRangeSuffix(resultMetadata)}`;
       return isLoading
-        ? `Querying metrics${projectInfo}: '${question}'...`
-        : `Queried metrics${projectInfo}: '${question}'`;
+        ? `Querying metrics${metricsInfo}: '${displayQuestion}'...`
+        : `Queried metrics${metricsInfo}: '${displayQuestion}'`;
     }
 
     // Default to spans dataset


### PR DESCRIPTION
Metrics tool-call text now uses Seer metadata to show when a query used the default seven-day range. The formatter appends “in the last 7 days” only when Seer says the range was defaulted, so explicit user ranges keep their original wording.

**Companion Changes**

This depends on Seer sending `time_range_defaulted` metadata in https://github.com/getsentry/seer/pull/6081. The backend fallback is split into https://github.com/getsentry/sentry/pull/114379 because Sentry frontend and backend changes deploy independently.