### PR TITLE
fix(skills): Remove billing from control silo references in agent skill docs

### DIFF
--- a/.agents/skills/django-models/SKILL.md
+++ b/.agents/skills/django-models/SKILL.md
@@ -17,7 +17,7 @@ Before writing any fields, decide all four. They are coupled — getting one wro
 
 ### 1. Which silo does this data live in?
 
-Cell silo (`@cell_silo_model`) is the default. Use control silo (`@control_silo_model`) only when the data is shared across organizations or has to be strongly consistent with other control-silo resources (auth, billing, integration installs, API tokens, slug reservations).
+Cell silo (`@cell_silo_model`) is the default. Use control silo (`@control_silo_model`) only when the data is shared across organizations or has to be strongly consistent with other control-silo resources (auth, integration installs, API tokens, slug reservations).
 
 The wrong way to think about it: "this is a user-facing thing, so control." The right way: "what is the smallest silo where this can correctly live, and is that silo the same as everything that mutates it together?" If a cell never reads it, it does not belong in the cell.
 

--- a/.agents/skills/hybrid-cloud-rpc/SKILL.md
+++ b/.agents/skills/hybrid-cloud-rpc/SKILL.md
@@ -5,7 +5,7 @@ description: Guide for creating, updating, and deprecating hybrid cloud RPC serv
 
 # Hybrid Cloud RPC Services
 
-This skill guides you through creating, modifying, and deprecating RPC services in Sentry's hybrid cloud architecture. RPC services enable cross-silo communication between the Control silo (user auth, billing, org management) and Cell silos (project data, events, issues).
+This skill guides you through creating, modifying, and deprecating RPC services in Sentry's hybrid cloud architecture. RPC services enable cross-silo communication between the Control silo (user auth, org management) and Cell silos (project data, events, issues).
 
 ## Critical Constraints
 
@@ -39,10 +39,10 @@ Classify what the developer needs:
 
 The service's `local_mode` determines where the database-backed implementation runs:
 
-| Data lives in...                                  | `local_mode`       | Decorator on methods            | Example                            |
-| ------------------------------------------------- | ------------------ | ------------------------------- | ---------------------------------- |
-| Cell silo (projects, events, issues, org data)    | `SiloMode.CELL`    | `@cell_rpc_method(resolve=...)` | `OrganizationService`              |
-| Control silo (users, auth, billing, org mappings) | `SiloMode.CONTROL` | `@rpc_method`                   | `OrganizationMemberMappingService` |
+| Data lives in...                               | `local_mode`       | Decorator on methods            | Example                            |
+| ---------------------------------------------- | ------------------ | ------------------------------- | ---------------------------------- |
+| Cell silo (projects, events, issues, org data) | `SiloMode.CELL`    | `@cell_rpc_method(resolve=...)` | `OrganizationService`              |
+| Control silo (users, auth, org mappings)       | `SiloMode.CONTROL` | `@rpc_method`                   | `OrganizationMemberMappingService` |
 
 **Decision rule**: If the Django models you need to query live in the cell database, use `SiloMode.CELL`. If they live in the control database, use `SiloMode.CONTROL`.
 

--- a/.agents/skills/hybrid-cloud-rpc/SKILL.md
+++ b/.agents/skills/hybrid-cloud-rpc/SKILL.md
@@ -5,7 +5,7 @@ description: Guide for creating, updating, and deprecating hybrid cloud RPC serv
 
 # Hybrid Cloud RPC Services
 
-This skill guides you through creating, modifying, and deprecating RPC services in Sentry's hybrid cloud architecture. RPC services enable cross-silo communication between the Control silo (user auth, org management) and Cell silos (project data, events, issues).
+This skill guides you through creating, modifying, and deprecating RPC services in Sentry's hybrid cloud architecture. RPC services enable cross-silo communication between the Control silo (user auth, org management) and Cell silos (project data, events, issues, billing).
 
 ## Critical Constraints
 
@@ -39,10 +39,10 @@ Classify what the developer needs:
 
 The service's `local_mode` determines where the database-backed implementation runs:
 
-| Data lives in...                               | `local_mode`       | Decorator on methods            | Example                            |
-| ---------------------------------------------- | ------------------ | ------------------------------- | ---------------------------------- |
-| Cell silo (projects, events, issues, org data) | `SiloMode.CELL`    | `@cell_rpc_method(resolve=...)` | `OrganizationService`              |
-| Control silo (users, auth, org mappings)       | `SiloMode.CONTROL` | `@rpc_method`                   | `OrganizationMemberMappingService` |
+| Data lives in...                                        | `local_mode`       | Decorator on methods            | Example                            |
+| ------------------------------------------------------- | ------------------ | ------------------------------- | ---------------------------------- |
+| Cell silo (projects, events, issues, org data, billing) | `SiloMode.CELL`    | `@cell_rpc_method(resolve=...)` | `OrganizationService`              |
+| Control silo (users, auth, org mappings)                | `SiloMode.CONTROL` | `@rpc_method`                   | `OrganizationMemberMappingService` |
 
 **Decision rule**: If the Django models you need to query live in the cell database, use `SiloMode.CELL`. If they live in the control database, use `SiloMode.CONTROL`.
 


### PR DESCRIPTION
## Summary
- Billing transactional data (subscriptions, invoices, charges, payments, promotions) resides in the **cell silo**, not the control silo
- Several agent skill docs incorrectly listed billing as a control silo service, which could mislead developers creating new RPC services or silo-annotating models
- This PR removes the incorrect control-silo references and adds billing to the cell-silo descriptions

## Evidence
getsentry billing endpoints are overwhelmingly `@cell_silo_endpoint`:
`payment_create`, `customer_billing_details`, `customer_subscription`, `invoice_index`, `payment_setup`, `promotion`, `promotion_trigger_check`, `customer_subscription_preview`

Billing RPC services (`SubscriptionService`, `PartnerAccountService`, `HerokuService`) are `local_mode=CELL`.

Only admin/catalog components are control-silo: `Plan` model (plan definitions), `billing_config`, `admin_billingadmins`, Stripe webhook ingress (fans out to cells), notification services.

## Changes

### Commit 1: Remove incorrect control-silo references
- **hybrid-cloud-rpc/SKILL.md**: Removed "billing" from intro paragraph and silo mode decision table control-silo descriptions
- **django-models/SKILL.md**: Removed "billing" from control silo model selection guidance

### Commit 2: Add billing to cell-silo descriptions
- **hybrid-cloud-rpc/SKILL.md**: Added "billing" to cell silo intro paragraph and silo mode decision table

## Test plan
- [x] Verified billing endpoint silo decorators in getsentry (`grep -rn cell_silo_endpoint getsentry/api/`)
- [x] Verified billing RPC service `local_mode` declarations in getsentry
- [x] Verified billing model silo decorators in getsentry
- [x] Confirmed no other skill docs have incorrect billing/silo references
- [x] Confirmed getsentry skill docs are clean (no silo references at all)