### PR TITLE
fix(digests): Retry deliver_digest on lock conflict

### DIFF
--- a/src/sentry/tasks/digests.py
+++ b/src/sentry/tasks/digests.py
@@ -1,6 +1,8 @@
 import logging
 import time
 
+from taskbroker_client.retry import Retry
+
 from sentry.digests import get_option_key
 from sentry.digests.backends.base import InvalidState
 from sentry.digests.notifications import build_digest, split_key
@@ -11,6 +13,7 @@ from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import digests_tasks
 from sentry.utils import snuba
+from sentry.utils.locking import UnableToAcquireLock
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +47,7 @@ def schedule_digests() -> None:
     name="sentry.tasks.digests.deliver_digest",
     namespace=digests_tasks,
     processing_deadline_duration=20 * 60,
+    retry=Retry(on=(UnableToAcquireLock,), times=3, delay=5),
     silo_mode=SiloMode.CELL,
 )
 def deliver_digest(

--- a/tests/sentry/tasks/test_digests.py
+++ b/tests/sentry/tasks/test_digests.py
@@ -1,6 +1,8 @@
 import uuid
+from contextlib import contextmanager
 from unittest import mock
 
+import pytest
 from django.core import mail
 from django.core.mail.message import EmailMultiAlternatives
 
@@ -12,6 +14,7 @@ from sentry.tasks.digests import deliver_digest
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.skips import requires_snuba
+from sentry.utils.locking import UnableToAcquireLock
 
 pytestmark = [requires_snuba]
 
@@ -76,3 +79,15 @@ class DeliverDigestTest(TestCase):
     def test_no_records(self) -> None:
         # This shouldn't error if no records are present
         deliver_digest(f"mail:p:{self.project.id}:IssueOwners:")
+
+    def test_unable_to_acquire_lock_propagates(self) -> None:
+        @contextmanager
+        def raise_lock_error(*args, **kwargs):
+            raise UnableToAcquireLock("test lock contention")
+            yield
+
+        with mock.patch.object(sentry, "digests") as digests:
+            digests.backend.digest = raise_lock_error
+            key = f"mail:p:{self.project.id}:IssueOwners::AllMembers"
+            with pytest.raises(UnableToAcquireLock):
+                deliver_digest(key)

--- a/tests/sentry/tasks/test_digests.py
+++ b/tests/sentry/tasks/test_digests.py
@@ -84,7 +84,7 @@ class DeliverDigestTest(TestCase):
         @contextmanager
         def raise_lock_error(*args, **kwargs):
             raise UnableToAcquireLock("test lock contention")
-            yield
+            yield  # type: ignore[unreachable]
 
         with mock.patch.object(sentry, "digests") as digests:
             digests.backend.digest = raise_lock_error


### PR DESCRIPTION
The lock is held to ensure atomic interaction with the digest list, and it seems like occasional conflicts are unavoidable, so we should retry.

Fixes SENTRY-5HC4.
