### PR TITLE
fix(auth): Cleanly handle malformed token IDs in ApiTokenDetailsEndpoint

### DIFF
--- a/src/sentry/api/endpoints/api_token_details.py
+++ b/src/sentry/api/endpoints/api_token_details.py
@@ -15,6 +15,7 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.permissions import DisallowImpersonatedTokenCreation, SentryIsAuthenticated
 from sentry.api.serializers import serialize
 from sentry.models.apitoken import ApiToken
+from sentry.workflow_engine.endpoints.utils.ids import to_valid_int_id
 
 ALLOWED_FIELDS = ["name", "tokenId"]
 
@@ -33,11 +34,12 @@ class ApiTokenDetailsEndpoint(Endpoint):
     owner = ApiOwner.SECURITY
     permission_classes = (SentryIsAuthenticated, DisallowImpersonatedTokenCreation)
 
-    def convert_args(self, request: Request, token_id: int, *args, **kwargs):
+    def convert_args(self, request: Request, token_id: str, *args, **kwargs):
+        validated_token_id = to_valid_int_id("token_id", token_id, raise_404=True)
         user_id = get_appropriate_user_id(request=request)
         try:
             kwargs["instance"] = ApiToken.objects.get(
-                id=token_id, application__isnull=True, user_id=user_id
+                id=validated_token_id, application__isnull=True, user_id=user_id
             )
         except ApiToken.DoesNotExist:
             raise ResourceDoesNotExist(detail="Invalid token ID")

--- a/tests/sentry/api/endpoints/test_api_token_details.py
+++ b/tests/sentry/api/endpoints/test_api_token_details.py
@@ -38,6 +38,10 @@ class ApiTokenGetTest(APITestCase):
         self.login_as(self.user)
         self.get_error_response(-1, status_code=status.HTTP_404_NOT_FOUND)
 
+    def test_non_integer_token_id(self) -> None:
+        self.login_as(self.user)
+        self.get_error_response("abc", status_code=status.HTTP_404_NOT_FOUND)
+
     def test_no_auth(self) -> None:
         token = ApiToken.objects.create(user=self.user, name="token 1")
         self.get_error_response(token.id, status_code=status.HTTP_401_UNAUTHORIZED)
@@ -123,6 +127,12 @@ class ApiTokenPutTest(APITestCase):
         self.login_as(self.user)
         self.get_error_response(-1, status_code=status.HTTP_404_NOT_FOUND, **payload)
 
+    def test_non_integer_token_id(self) -> None:
+        payload = {"name": "new token"}
+
+        self.login_as(self.user)
+        self.get_error_response("abc", status_code=status.HTTP_404_NOT_FOUND, **payload)
+
     def test_no_auth(self) -> None:
         token = ApiToken.objects.create(user=self.user, name="token 1")
         payload = {"name": "new token"}
@@ -163,6 +173,10 @@ class ApiTokenDeleteTest(APITestCase):
     def test_invalid_token_id(self) -> None:
         self.login_as(self.user)
         self.get_error_response(-1, status_code=status.HTTP_404_NOT_FOUND)
+
+    def test_non_integer_token_id(self) -> None:
+        self.login_as(self.user)
+        self.get_error_response("abc", status_code=status.HTTP_404_NOT_FOUND)
 
     def test_no_auth(self) -> None:
         token = ApiToken.objects.create(user=self.user, name="token 1")


### PR DESCRIPTION
There's a steady flow of malformed or otherwise incorrect token IDs being passed, and we fail cleanly rather than 500ing.

Fixes SENTRY-400N.
