### PR TITLE
fix(tests): Fix flaky cart preview test

### DIFF
--- a/static/gsApp/views/amCheckout/components/cart.spec.tsx
+++ b/static/gsApp/views/amCheckout/components/cart.spec.tsx
@@ -338,10 +338,10 @@ describe('Cart', () => {
     );
 
     const dueToday = await screen.findByTestId('summary-item-due-today');
-    expect(mockResponse).toHaveBeenCalled();
 
     // wait for preview to be loaded
     await waitFor(() => expect(dueToday).toHaveTextContent('$91')); // original price
+    expect(mockResponse).toHaveBeenCalled();
     expect(dueToday).toHaveTextContent('$80'); // price after credits + additional fees
     expect(screen.getByTestId('summary-item-plan-total')).toHaveTextContent('$89');
     expect(screen.getByTestId('summary-item-sales_tax')).toHaveTextContent('$2');


### PR DESCRIPTION
## Summary
- Identified by claude as the root cause of frontend CI job failures in PR https://github.com/getsentry/sentry/pull/114354
- Fixes a flaky test in `static/gsApp/views/amCheckout/components/cart.spec.tsx` ("Cart > renders preview data")
- The `expect(mockResponse).toHaveBeenCalled()` assertion was firing before the Cart component's async preview fetch completed
- Moved the assertion after the `waitFor` content check, which guarantees the mock was called

## Root Cause
The Cart component has an async dependency chain before fetching preview data:
1. `useBillingDetails()` loads async → `hasCompleteBillingInfo` → `shouldDisableCheckout` → `fetchPreview`
2. On initial render, billing details are `undefined`, so `shouldDisableCheckout=true` and preview fetch is skipped
3. Only after billing details load does the preview fetch trigger
4. `findByTestId('summary-item-due-today')` can resolve before the preview mock is called, causing the bare `toHaveBeenCalled()` to fail intermittently

## Test plan
- [x] Ran cart.spec.tsx locally — all 14 tests pass
- [ ] CI passes