### PR TITLE
perf(ci): Increase Jest shards from 4 to 8 for faster CI

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -123,7 +123,7 @@ jobs:
       matrix:
         # XXX: When updating this, make sure you also update CI_NODE_TOTAL.
 
-        instance: [0, 1, 2, 3]
+        instance: [0, 1, 2, 3, 4, 5, 6, 7]
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -162,7 +162,7 @@ jobs:
           # XXX: CI_NODE_TOTAL must be hardcoded to the length of strategy.matrix.instance.
           #      Otherwise, if there are other things in the matrix, using strategy.job-total
           #      wouldn't be correct.
-          CI_NODE_TOTAL: 4
+          CI_NODE_TOTAL: 8
           CI_NODE_INDEX: ${{ matrix.instance }}
           # Disable testing-library from printing out any of of the DOM to
           # stdout. No one actually looks through this in CI, they're just

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -196,7 +196,7 @@ function getTestsForGroup(
     if (!nextTest) {
       throw new TypeError('Received falsy test' + JSON.stringify(nextTest));
     }
-    groups[i % 4]!.push(nextTest[0]);
+    groups[i % nodeTotal]!.push(nextTest[0]);
     i++;
   }
 


### PR DESCRIPTION
Increase Jest CI shards from 4 to 8 to reduce wall-clock time for frontend tests.

Current state: 4 shards run ~6-8 minutes each, with the slowest shard (typically shard 3) bottlenecking at ~7-8 min wall clock. Total test execution across all shards sums to ~25 minutes.

With 8 shards, each shard runs ~3 min of tests + ~22s setup overhead, cutting wall clock from ~8min to ~4min. Compute cost stays roughly the same (8×4min ≈ 4×8min), with minor additional overhead from 4 extra checkout/setup steps.

Also fixes a bug in `jest.config.ts` where the round-robin leftover distribution was hardcoded to `i % 4` instead of `i % nodeTotal`, which would have caused imbalanced shard assignment with any non-4 shard count.