### PR TITLE
ref(snapshots): Add shared context for snapshots react code

### DIFF
--- a/static/app/views/preprod/snapshots/main/snapshotListView.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.tsx
@@ -12,21 +12,11 @@ import type {
   SnapshotImage,
 } from 'sentry/views/preprod/types/snapshotTypes';
 
+import {useSnapshotViewer} from '../snapshotViewerContext';
+
 import type {DiffMode} from './imageDisplay/diffImageDisplay';
 import {ImageCard, PairCard} from './snapshotCards';
 import {MAX_IMAGE_HEIGHT} from './snapshotDiffBodies';
-
-interface SnapshotListViewProps {
-  imageBaseUrl: string;
-  items: SidebarItem[];
-  diffImageBaseUrl?: string;
-  diffMode?: DiffMode;
-  headBranch?: string | null;
-  onOpenSnapshot?: (key: string) => void;
-  onSelectSnapshot?: (key: string | null) => void;
-  overlayColor?: string;
-  selectedSnapshotKey?: string | null;
-}
 
 function snapshotKeyFor(card: GroupCard): string {
   return card.type === 'pair-card'
@@ -141,17 +131,18 @@ function buildGroups(items: SidebarItem[]): GroupRow[] {
   return groups;
 }
 
-export function SnapshotListView({
-  items,
-  imageBaseUrl,
-  headBranch,
-  selectedSnapshotKey,
-  onSelectSnapshot,
-  onOpenSnapshot,
-  diffMode = 'split',
-  overlayColor,
-  diffImageBaseUrl,
-}: SnapshotListViewProps) {
+export function SnapshotListView() {
+  const {
+    listItems: items,
+    imageBaseUrl,
+    headBranch,
+    selectedSnapshotKey,
+    onSelectSnapshot,
+    onOpenSnapshot,
+    diffMode,
+    overlayColor,
+    diffImageBaseUrl,
+  } = useSnapshotViewer();
   const groups = useMemo(() => buildGroups(items), [items]);
   const scrollRef = useRef<HTMLDivElement>(null);
 

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -6,7 +6,7 @@ import styled from '@emotion/styled';
 import {Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Flex} from '@sentry/scraps/layout';
 import {SegmentedControl} from '@sentry/scraps/segmentedControl';
 import {Separator} from '@sentry/scraps/separator';
 import {Text} from '@sentry/scraps/text';
@@ -22,7 +22,9 @@ import {
 } from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {DiffStatus, getImageName} from 'sentry/views/preprod/types/snapshotTypes';
-import type {SidebarItem} from 'sentry/views/preprod/types/snapshotTypes';
+
+import {useSnapshotViewer} from '../snapshotViewerContext';
+import type {SortBy, ViewMode} from '../snapshotViewerContext';
 
 import {
   DiffImageDisplay,
@@ -38,69 +40,31 @@ import {
   SnapshotListView,
 } from './snapshotListView';
 
-export type ViewMode = 'single' | 'list';
-type SortBy = 'diff' | 'alpha';
-
-interface SnapshotMainContentProps {
-  canNavigateNext: boolean;
-  canNavigatePrev: boolean;
-  comparisonType: 'diff' | 'solo' | undefined;
-  diffImageBaseUrl: string;
-  diffMode: DiffMode;
-  imageBaseUrl: string;
-  isSoloView: boolean;
-  listItems: SidebarItem[];
-  onDiffModeChange: (mode: DiffMode) => void;
-  onNavigateSingleView: (direction: 'prev' | 'next') => void;
-  onOverlayColorChange: (color: string) => void;
-  onToggleSoloView: () => void;
-  onViewModeChange: (mode: ViewMode) => void;
-  overlayColor: string;
-  selectedItem: SidebarItem | null;
-  variantIndex: number;
-  viewMode: ViewMode;
-  headBranch?: string | null;
-  onSelectSnapshot?: (key: string | null) => void;
-  onSortByChange?: (sort: SortBy) => void;
-  selectedSnapshotKey?: string | null;
-  sortBy?: SortBy;
-}
-
-export function SnapshotMainContent({
-  selectedItem,
-  variantIndex,
-  imageBaseUrl,
-  diffImageBaseUrl,
-  overlayColor,
-  onOverlayColorChange,
-  diffMode,
-  onDiffModeChange,
-  viewMode,
-  onViewModeChange,
-  listItems,
-  isSoloView,
-  onToggleSoloView,
-  comparisonType,
-  headBranch,
-  selectedSnapshotKey,
-  onSelectSnapshot,
-  sortBy = 'diff',
-  onSortByChange,
-  onNavigateSingleView,
-  canNavigatePrev,
-  canNavigateNext,
-}: SnapshotMainContentProps) {
+export function SnapshotMainContent() {
+  const {
+    selectedItem,
+    variantIndex,
+    imageBaseUrl,
+    diffImageBaseUrl,
+    overlayColor,
+    onOverlayColorChange,
+    diffMode,
+    onDiffModeChange,
+    viewMode,
+    onViewModeChange,
+    listItems,
+    isSoloView,
+    onToggleSoloView,
+    comparisonType,
+    sortBy,
+    onSortByChange,
+    onNavigateSingleView,
+    canNavigatePrev,
+    canNavigateNext,
+  } = useSnapshotViewer();
   const [isDark, setIsDark] = useState(false);
   const [pressedDir, setPressedDir] = useState<'up' | 'down' | null>(null);
   const toggleDark = () => setIsDark(v => !v);
-
-  const handleOpenSnapshot = useCallback(
-    (key: string) => {
-      onSelectSnapshot?.(key);
-      onViewModeChange('single');
-    },
-    [onSelectSnapshot, onViewModeChange]
-  );
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
@@ -140,7 +104,7 @@ export function SnapshotMainContent({
   );
   const hasChangedInList = listItems.some(i => i.type === 'changed');
   const sortDropdown =
-    onSortByChange && comparisonType !== 'solo' && hasChangedInList ? (
+    comparisonType !== 'solo' && hasChangedInList ? (
       <SortDropdown value={sortBy} onChange={onSortByChange} />
     ) : null;
   const listDiffControls =
@@ -182,17 +146,7 @@ export function SnapshotMainContent({
           </Flex>
         </Flex>
         <Separator orientation="horizontal" />
-        <SnapshotListView
-          items={listItems}
-          imageBaseUrl={imageBaseUrl}
-          headBranch={headBranch}
-          selectedSnapshotKey={selectedSnapshotKey}
-          onSelectSnapshot={onSelectSnapshot}
-          onOpenSnapshot={handleOpenSnapshot}
-          diffMode={diffMode}
-          overlayColor={overlayColor}
-          diffImageBaseUrl={diffImageBaseUrl}
-        />
+        <SnapshotListView />
       </Flex>
     );
   }

--- a/static/app/views/preprod/snapshots/snapshotViewerContext.tsx
+++ b/static/app/views/preprod/snapshots/snapshotViewerContext.tsx
@@ -1,0 +1,46 @@
+import {createContext, useContext} from 'react';
+
+import type {SidebarItem} from 'sentry/views/preprod/types/snapshotTypes';
+
+import type {DiffMode} from './main/imageDisplay/diffImageDisplay';
+
+export type ViewMode = 'single' | 'list';
+export type SortBy = 'diff' | 'alpha';
+
+interface SnapshotViewerContextValue {
+  canNavigateNext: boolean;
+  canNavigatePrev: boolean;
+  diffImageBaseUrl: string;
+  diffMode: DiffMode;
+  imageBaseUrl: string;
+  isSoloView: boolean;
+  listItems: SidebarItem[];
+  onDiffModeChange: (mode: DiffMode) => void;
+  onNavigateSingleView: (direction: 'prev' | 'next') => void;
+  onOpenSnapshot: (key: string) => void;
+  onOverlayColorChange: (color: string) => void;
+  onSelectSnapshot: (key: string | null) => void;
+  onSortByChange: (sort: SortBy) => void;
+  onToggleSoloView: () => void;
+  onViewModeChange: (mode: ViewMode) => void;
+  overlayColor: string;
+  selectedItem: SidebarItem | null;
+  selectedSnapshotKey: string | null;
+  sortBy: SortBy;
+  variantIndex: number;
+  viewMode: ViewMode;
+  comparisonType?: 'diff' | 'solo';
+  headBranch?: string | null;
+}
+
+const SnapshotViewerContext = createContext<SnapshotViewerContextValue | null>(null);
+
+export const SnapshotViewerProvider = SnapshotViewerContext.Provider;
+
+export function useSnapshotViewer(): SnapshotViewerContextValue {
+  const ctx = useContext(SnapshotViewerContext);
+  if (!ctx) {
+    throw new Error('useSnapshotViewer must be used within a SnapshotViewerProvider');
+  }
+  return ctx;
+}

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -38,6 +38,7 @@ import {
   type SidebarGroup,
   SnapshotSidebarContent,
 } from './sidebar/snapshotSidebarContent';
+import {SnapshotViewerProvider} from './snapshotViewerContext';
 
 function imageGroupKey(img: SnapshotImage): string {
   return img.group ?? img.image_file_name;
@@ -525,7 +526,10 @@ export default function SnapshotsPage() {
       comparisonRunInfo.state
     );
 
-  const imageBaseUrl = `/api/0/projects/${organization.slug}/${data?.project_id ?? ''}/files/images/`;
+  const imageBaseUrl = useMemo(
+    () => `/api/0/projects/${organization.slug}/${data?.project_id ?? ''}/files/images/`,
+    [organization.slug, data?.project_id]
+  );
   const diffImageBaseUrl = imageBaseUrl;
 
   const processingContent = (
@@ -537,71 +541,111 @@ export default function SnapshotsPage() {
     </Flex>
   );
 
+  const handleOpenSnapshot = useCallback(
+    (key: string) => {
+      setSelectedSnapshotKey(key);
+      setViewMode('single');
+    },
+    [setSelectedSnapshotKey, setViewMode]
+  );
+
   const handleDeselectSnapshot = () => {
     if (selectedSnapshotKey) {
       setSelectedSnapshotKey(null);
     }
   };
 
+  const viewerContextValue = useMemo(
+    () => ({
+      selectedItem: singleViewItem,
+      variantIndex: singleViewVariantIndex,
+      imageBaseUrl,
+      diffImageBaseUrl,
+      overlayColor,
+      onOverlayColorChange: setOverlayColor,
+      diffMode,
+      onDiffModeChange: setDiffMode,
+      viewMode,
+      onViewModeChange: setViewMode,
+      listItems,
+      isSoloView,
+      onToggleSoloView: handleToggleView,
+      comparisonType: data?.comparison_type,
+      headBranch: data?.vcs_info?.head_ref,
+      selectedSnapshotKey,
+      onSelectSnapshot: setSelectedSnapshotKey,
+      sortBy,
+      onSortByChange: setSortBy,
+      onNavigateSingleView: navigateSingleView,
+      canNavigatePrev: singleViewNav.canPrev,
+      canNavigateNext: singleViewNav.canNext,
+      onOpenSnapshot: handleOpenSnapshot,
+    }),
+    [
+      singleViewItem,
+      singleViewVariantIndex,
+      imageBaseUrl,
+      diffImageBaseUrl,
+      overlayColor,
+      setOverlayColor,
+      diffMode,
+      setDiffMode,
+      viewMode,
+      setViewMode,
+      listItems,
+      isSoloView,
+      handleToggleView,
+      data?.comparison_type,
+      data?.vcs_info?.head_ref,
+      selectedSnapshotKey,
+      setSelectedSnapshotKey,
+      sortBy,
+      setSortBy,
+      navigateSingleView,
+      singleViewNav.canPrev,
+      singleViewNav.canNext,
+      handleOpenSnapshot,
+    ]
+  );
+
   const snapshotContent = (
-    <Flex direction="row" flex="1" minHeight="0" width="100%" overflow="hidden">
-      <Flex
-        flexShrink={0}
-        overflow="auto"
-        style={{
-          width: sidebarWidth,
-          height: hasPageFrameFeature
-            ? 'calc(100dvh - var(--top-bar-height, 53px))'
-            : 'calc(100vh - 205px)',
-        }}
-      >
-        <SnapshotSidebarContent
-          groups={sidebarGroups}
-          currentItemKey={selectedGroup}
-          isAllSelected={isAllSelected}
-          searchQuery={searchQuery}
-          onSearchChange={setSearchQuery}
-          onSelectItem={handleSelectItem}
-          onSelectAll={handleSelectAll}
-          statusCounts={statusCounts}
-          activeStatuses={activeStatuses}
-          onToggleStatus={handleToggleStatus}
-        />
+    <SnapshotViewerProvider value={viewerContextValue}>
+      <Flex direction="row" flex="1" minHeight="0" width="100%" overflow="hidden">
+        <Flex
+          flexShrink={0}
+          overflow="auto"
+          style={{
+            width: sidebarWidth,
+            height: hasPageFrameFeature
+              ? 'calc(100dvh - var(--top-bar-height, 53px))'
+              : 'calc(100vh - 205px)',
+          }}
+        >
+          <SnapshotSidebarContent
+            groups={sidebarGroups}
+            currentItemKey={selectedGroup}
+            isAllSelected={isAllSelected}
+            searchQuery={searchQuery}
+            onSearchChange={setSearchQuery}
+            onSelectItem={handleSelectItem}
+            onSelectAll={handleSelectAll}
+            statusCounts={statusCounts}
+            activeStatuses={activeStatuses}
+            onToggleStatus={handleToggleStatus}
+          />
+        </Flex>
+        <DragHandle
+          data-is-held={isHeld}
+          onMouseDown={onMouseDown}
+          onDoubleClick={onDoubleClick}
+        >
+          <IconGrabbable size="sm" />
+        </DragHandle>
+        <Flex flex="1" minWidth={0} overflow="hidden">
+          <SnapshotMainContent />
+        </Flex>
       </Flex>
-      <DragHandle
-        data-is-held={isHeld}
-        onMouseDown={onMouseDown}
-        onDoubleClick={onDoubleClick}
-      >
-        <IconGrabbable size="sm" />
-      </DragHandle>
-      <Flex flex="1" minWidth={0} overflow="hidden">
-        <SnapshotMainContent
-          selectedItem={singleViewItem}
-          variantIndex={singleViewVariantIndex}
-          imageBaseUrl={imageBaseUrl}
-          diffImageBaseUrl={diffImageBaseUrl}
-          overlayColor={overlayColor}
-          onOverlayColorChange={setOverlayColor}
-          diffMode={diffMode}
-          onDiffModeChange={setDiffMode}
-          viewMode={viewMode}
-          onViewModeChange={setViewMode}
-          listItems={listItems}
-          isSoloView={isSoloView}
-          onToggleSoloView={handleToggleView}
-          comparisonType={comparisonType}
-          headBranch={data?.vcs_info?.head_ref}
-          selectedSnapshotKey={selectedSnapshotKey}
-          onSelectSnapshot={setSelectedSnapshotKey}
-          sortBy={sortBy}
-          onSortByChange={setSortBy}
-          onNavigateSingleView={navigateSingleView}
-          canNavigatePrev={singleViewNav.canPrev}
-          canNavigateNext={singleViewNav.canNext}
-        />
-      </Flex>
-    </Flex>
+    </SnapshotViewerProvider>
   );
 
   if (isPending) {


### PR DESCRIPTION
Refactors the snapshot viewer React code to reduce prop drilling via a shared context, and improves several UX patterns:

**Shared context (`SnapshotViewerContext`)**
- Extracts viewer state (view mode, diff mode, overlay color, selection, navigation, etc.) into a React context, replacing 20+ props threaded through `SnapshotMainContent` → child components. Sidebar and main content now consume state via `useSnapshotViewer()`.

**URL-driven state**
- Moves `viewMode`, `sortBy`, and filter state from localStorage/component state to URL query params with `history: 'push'`, so browser back/forward navigates between views and selections.

**Image buffering for smooth navigation**
- Adds `useBufferedImageUrl` hook that pre-decodes the next image before swapping `src`, eliminating the white flash when navigating between snapshots in single view.

**Sidebar group-based rendering**
- Sidebar now renders collapsed groups (by snapshot name) instead of flat items, with aggregated counts per group. Status filter counts are scoped to the active group when one is selected.

**Per-image diff threshold (backend)**
- `ImageMetadata` now supports an optional `diff_threshold` field. The comparison task uses per-image threshold when set, falling back to the global snapshot-level threshold.

**Header / card polish**
- Compact unified header with project badge and app ID.
- "Go to Base Build" action in overflow menu.
- Double-click card to open in single view; tooltips on icon buttons; hoverable metadata tooltip; dark-mode-aware theme toggle fix.
- Keyboard: `Space`/`Enter` both toggle selection; arrow left/right direction corrected for list↔single.

**Other**
- PR comment links use `selectedTypes` query param to match the new URL scheme.
- Diff views use `display: none` toggling instead of conditional rendering to preserve zoom/slider state across mode switches.