### PR TITLE
fix(notifications): Filter organization-integrations to only allowed providers

### DIFF
--- a/static/app/views/settings/account/notifications/notificationSettingsByType.spec.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.spec.tsx
@@ -46,6 +46,7 @@ function renderMockRequests({
     url: '/users/me/organization-integrations/',
     method: 'GET',
     body: organizationIntegrations,
+    match: [MockApiClient.matchQuery({provider: ['slack', 'slack_staging']})],
   });
 
   MockApiClient.addMockResponse({

--- a/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
+++ b/static/app/views/settings/account/notifications/notificationSettingsByType.tsx
@@ -99,7 +99,10 @@ export function NotificationSettingsByType({notificationType}: Props) {
 
   const {data: allOrgIntegrations = [], status: organizationIntegrationStatus} =
     useApiQuery<Array<OrganizationIntegration | null>>(
-      [getApiUrl('/users/$userId/organization-integrations/', {path: {userId: 'me'}})],
+      [
+        getApiUrl('/users/$userId/organization-integrations/', {path: {userId: 'me'}}),
+        {query: {provider: [...ALLOWED_PROVIDERS]}},
+      ],
       {staleTime: 30_000}
     );
   const organizationIntegrations = allOrgIntegrations.filter(


### PR DESCRIPTION
updates frontend to only fetch slack and slack-staging providers to improve load times on organization-integration endpoint

should go in after backend [PR](https://github.com/getsentry/sentry/pull/114393) 