### PR TITLE
feat(aci): Add inline alert creation to monitor details page

### DIFF
--- a/static/app/views/detectors/components/details/common/automations.spec.tsx
+++ b/static/app/views/detectors/components/details/common/automations.spec.tsx
@@ -3,8 +3,14 @@ import {
   IssueStreamDetectorFixture,
   UptimeDetectorFixture,
 } from 'sentry-fixture/detectors';
+import {MemberFixture} from 'sentry-fixture/member';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
+import {UserFixture} from 'sentry-fixture/user';
+import {
+  ActionHandlerFixture,
+  DataConditionHandlerFixture,
+} from 'sentry-fixture/workflowEngine';
 
 import {
   act,
@@ -14,8 +20,15 @@ import {
   waitFor,
   within,
 } from 'sentry-test/reactTestingLibrary';
+import {selectEvent} from 'sentry-test/selectEvent';
 
 import {ProjectsStore} from 'sentry/stores/projectsStore';
+import {ActionGroup, ActionType} from 'sentry/types/workflowEngine/actions';
+import {
+  DataConditionHandlerGroupType,
+  DataConditionHandlerSubgroupType,
+  DataConditionType,
+} from 'sentry/types/workflowEngine/dataConditions';
 
 import {DetectorDetailsAutomations} from './automations';
 
@@ -25,6 +38,9 @@ describe('DetectorDetailsAutomations', () => {
   const issueStreamDetector = IssueStreamDetectorFixture({id: '4'});
 
   const project = ProjectFixture({id: '1'});
+  const mockMember = MemberFixture({
+    user: UserFixture({id: '1', name: 'Test User', email: 'test@sentry.io'}),
+  });
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -41,6 +57,64 @@ describe('DetectorDetailsAutomations', () => {
           project: [1],
         }),
       ],
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/available-actions/',
+      body: [
+        ActionHandlerFixture({
+          type: ActionType.SLACK,
+          handlerGroup: ActionGroup.NOTIFICATION,
+          integrations: [{id: '1', name: 'My Slack Workspace'}],
+        }),
+      ],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/tags/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/data-conditions/',
+      match: [
+        MockApiClient.matchQuery({group: DataConditionHandlerGroupType.ACTION_FILTER}),
+      ],
+      body: [
+        DataConditionHandlerFixture({
+          handlerGroup: DataConditionHandlerGroupType.ACTION_FILTER,
+          handlerSubgroup: DataConditionHandlerSubgroupType.ISSUE_ATTRIBUTES,
+          type: DataConditionType.TAGGED_EVENT,
+        }),
+      ],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/data-conditions/',
+      match: [
+        MockApiClient.matchQuery({
+          group: DataConditionHandlerGroupType.WORKFLOW_TRIGGER,
+        }),
+      ],
+      body: [
+        DataConditionHandlerFixture({
+          handlerGroup: DataConditionHandlerGroupType.WORKFLOW_TRIGGER,
+        }),
+      ],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/users/',
+      body: [mockMember],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/members/',
+      body: [mockMember],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/detectors/',
+      body: [],
+      match: [(_url, options) => options.query?.query !== 'type:issue_stream'],
     });
   });
 
@@ -136,12 +210,7 @@ describe('DetectorDetailsAutomations', () => {
       await screen.findByRole('button', {name: 'Connect Existing Alerts'})
     ).toBeInTheDocument();
 
-    // Shows create new alert link to new alert page and a prefilled connectedIds
-    const createButton = screen.getByRole('button', {name: 'Create a New Alert'});
-    expect(createButton).toHaveAttribute(
-      'href',
-      `/organizations/org-slug/monitors/alerts/new/?connectedIds=${detector.id}`
-    );
+    expect(screen.getByRole('button', {name: 'Create a New Alert'})).toBeInTheDocument();
   });
 
   it('can search connected alerts', async () => {
@@ -239,6 +308,60 @@ describe('DetectorDetailsAutomations', () => {
     });
   });
 
+  it('can create a new alert from drawer', async () => {
+    const detector = UptimeDetectorFixture({
+      id: 'detector-123',
+      workflowIds: [automation1.id],
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/workflows/',
+      method: 'GET',
+      body: [automation1],
+    });
+
+    const createdAutomation = AutomationFixture({id: 'new-alert-1'});
+    const createRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/workflows/',
+      method: 'POST',
+      body: createdAutomation,
+    });
+
+    render(<DetectorDetailsAutomations detector={detector} />, {organization});
+
+    // Click the "New Alert" button in the header
+    await userEvent.click(await screen.findByRole('button', {name: 'New Alert'}));
+
+    // Fill in the drawer form — add an action
+    await selectEvent.select(
+      await screen.findByRole('textbox', {name: 'Add action'}),
+      'Slack'
+    );
+    await userEvent.type(screen.getByRole('textbox', {name: 'Target'}), '#alerts');
+
+    // Set the alert name
+    const nameInput = screen.getByRole('textbox', {name: 'Alert Name'});
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, 'My New Alert');
+
+    // Submit
+    await userEvent.click(screen.getByRole('button', {name: 'Create Alert'}));
+
+    // Verify the automation was created with the detector ID
+    await waitFor(() => {
+      expect(createRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          method: 'POST',
+          data: expect.objectContaining({
+            name: 'My New Alert',
+            detectorIds: [detector.id],
+          }),
+        })
+      );
+    });
+  }, 10_000);
+
   it('can disconnect an automation from drawer', async () => {
     const detector = UptimeDetectorFixture({
       id: 'detector-123',
@@ -259,9 +382,7 @@ describe('DetectorDetailsAutomations', () => {
 
     render(<DetectorDetailsAutomations detector={detector} />, {organization});
 
-    await userEvent.click(
-      await screen.findByRole('button', {name: 'Edit Connected Alerts'})
-    );
+    await userEvent.click(await screen.findByRole('button', {name: 'Edit Alerts'}));
 
     const connectedAutomationsList = await screen.findByTestId(
       'drawer-connected-automations-list'
@@ -313,7 +434,7 @@ describe('DetectorDetailsAutomations', () => {
       });
 
       const editButton = await screen.findByRole('button', {
-        name: 'Edit Connected Alerts',
+        name: 'Edit Alerts',
       });
       expect(editButton).toBeDisabled();
     });
@@ -349,7 +470,7 @@ describe('DetectorDetailsAutomations', () => {
       const createButton = screen.getByRole('button', {name: 'Create a New Alert'});
 
       expect(connectButton).toBeDisabled();
-      expect(createButton).toHaveAttribute('aria-disabled', 'true');
+      expect(createButton).toBeDisabled();
     });
   });
 });

--- a/static/app/views/detectors/components/details/common/automations.tsx
+++ b/static/app/views/detectors/components/details/common/automations.tsx
@@ -3,9 +3,9 @@ import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
 import {useQueryClient} from '@tanstack/react-query';
 
-import {Button, LinkButton} from '@sentry/scraps/button';
+import {Button} from '@sentry/scraps/button';
 import {useDrawer} from '@sentry/scraps/drawer';
-import {Stack} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {getPaginationCaption, Pagination} from '@sentry/scraps/pagination';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -18,17 +18,17 @@ import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {ActionCell} from 'sentry/components/workflowEngine/gridCell/actionCell';
 import {AutomationTitleCell} from 'sentry/components/workflowEngine/gridCell/automationTitleCell';
 import {DetailSection} from 'sentry/components/workflowEngine/ui/detailSection';
-import {IconAdd} from 'sentry/icons';
+import {IconAdd, IconEdit} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {Detector} from 'sentry/types/workflowEngine/detectors';
 import {defined} from 'sentry/utils';
 import {selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjectFromId} from 'sentry/utils/useProjectFromId';
+import {AutomationBuilderDrawerForm} from 'sentry/views/automations/components/automationBuilderDrawerForm';
 import {AutomationSearch} from 'sentry/views/automations/components/automationListTable/search';
 import {automationsApiOptions} from 'sentry/views/automations/hooks';
 import {getAutomationActions} from 'sentry/views/automations/hooks/utils';
-import {makeAutomationCreatePathname} from 'sentry/views/automations/pathnames';
 import {ConnectAutomationsDrawer} from 'sentry/views/detectors/components/connectAutomationsDrawer';
 import {ConnectedAlertsEmptyState} from 'sentry/views/detectors/components/connectedAutomationsEmptyState';
 import {useUpdateDetector} from 'sentry/views/detectors/hooks';
@@ -256,6 +256,25 @@ export function DetectorDetailsAutomations({detector}: Props) {
     );
   };
 
+  const openCreateDrawer = () => {
+    if (isDrawerOpen) {
+      closeDrawer();
+    }
+
+    openDrawer(
+      () => (
+        <AutomationBuilderDrawerForm
+          closeDrawer={closeDrawer}
+          initialData={{detectorIds: [detector.id]}}
+          onSuccess={() => {
+            closeDrawer();
+          }}
+        />
+      ),
+      {ariaLabel: t('Create New Alert')}
+    );
+  };
+
   const permissionTooltipText = canEditWorkflowConnections
     ? undefined
     : t(
@@ -276,14 +295,26 @@ export function DetectorDetailsAutomations({detector}: Props) {
     <DetailSection
       title={t('Connected Alerts')}
       trailingItems={
-        <Button
-          size="xs"
-          onClick={toggleDrawer}
-          disabled={!canEditWorkflowConnections}
-          tooltipProps={{title: permissionTooltipText}}
-        >
-          {t('Edit Connected Alerts')}
-        </Button>
+        <Flex gap="sm">
+          <Button
+            size="xs"
+            icon={<IconAdd />}
+            onClick={openCreateDrawer}
+            disabled={!canEditWorkflowConnections}
+            tooltipProps={{title: permissionTooltipText}}
+          >
+            {t('New Alert')}
+          </Button>
+          <Button
+            size="xs"
+            onClick={toggleDrawer}
+            disabled={!canEditWorkflowConnections}
+            tooltipProps={{title: permissionTooltipText}}
+            icon={<IconEdit />}
+          >
+            {t('Edit Alerts')}
+          </Button>
+        </Flex>
       }
     >
       <ErrorBoundary mini>
@@ -301,18 +332,15 @@ export function DetectorDetailsAutomations({detector}: Props) {
                 >
                   {t('Connect Existing Alerts')}
                 </Button>
-                <LinkButton
-                  href={makeAutomationCreatePathname(organization.slug, {
-                    connectedIds: [detector.id],
-                  })}
-                  external
+                <Button
                   size="sm"
                   icon={<IconAdd />}
+                  onClick={openCreateDrawer}
                   disabled={!canEditWorkflowConnections}
                   tooltipProps={{title: permissionTooltipText}}
                 >
                   {t('Create a New Alert')}
-                </LinkButton>
+                </Button>
               </ConnectedAlertsEmptyState>
             ) : (
               t('No alerts connected')


### PR DESCRIPTION
Ref ISWF-2572

This is using the same logic as the inline alert form on the detector edit form. Allows the user to quickly add a new alert and connect it to the monitor they are viewing.

https://github.com/user-attachments/assets/ce5f9afe-df07-42b1-9690-2834a3ec4226

