### PR TITLE
ref(onboarding): Drive SCM feature card volumes from billing-config

### DIFF
--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -2,7 +2,6 @@ import type {ButtonProps} from '@sentry/scraps/button';
 
 import type {ChildrenRenderFn} from 'sentry/components/acl/feature';
 import type {Guide} from 'sentry/components/assistant/types';
-import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import type {ProductSelectionProps} from 'sentry/components/onboarding/productSelection';
 import type {InstallationInfo} from 'sentry/components/pipeline/pipelineIntegrationGitHub';
 import type {DateRange} from 'sentry/components/timeRangeSelector/dateRange';
@@ -19,7 +18,7 @@ import type {
 } from 'sentry/utils/useMaxPickableDays';
 import type {WidgetType} from 'sentry/views/dashboards/types';
 import type {AutofixContentProps} from 'sentry/views/issueDetails/streamline/sidebar/autofixSection';
-import type {FeatureMeta} from 'sentry/views/onboarding/components/useScmFeatureMeta';
+import type {UseScmFeatureMetaResult} from 'sentry/views/onboarding/components/useScmFeatureMeta';
 import type {OrganizationStatsProps} from 'sentry/views/organizationStats';
 import type {RouteAnalyticsContext} from 'sentry/views/routeAnalyticsContextProvider';
 import type {NavigationSection} from 'sentry/views/settings/types';
@@ -365,7 +364,7 @@ type ReactHooks = {
     isLoading: boolean;
   };
   'react-hook:use-product-billing-access': (product: DataCategory) => boolean;
-  'react-hook:use-scm-feature-meta': () => Record<ProductSolution, FeatureMeta>;
+  'react-hook:use-scm-feature-meta': () => UseScmFeatureMetaResult;
 };
 
 /**

--- a/static/app/types/hooks.tsx
+++ b/static/app/types/hooks.tsx
@@ -2,6 +2,7 @@ import type {ButtonProps} from '@sentry/scraps/button';
 
 import type {ChildrenRenderFn} from 'sentry/components/acl/feature';
 import type {Guide} from 'sentry/components/assistant/types';
+import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import type {ProductSelectionProps} from 'sentry/components/onboarding/productSelection';
 import type {InstallationInfo} from 'sentry/components/pipeline/pipelineIntegrationGitHub';
 import type {DateRange} from 'sentry/components/timeRangeSelector/dateRange';
@@ -18,6 +19,7 @@ import type {
 } from 'sentry/utils/useMaxPickableDays';
 import type {WidgetType} from 'sentry/views/dashboards/types';
 import type {AutofixContentProps} from 'sentry/views/issueDetails/streamline/sidebar/autofixSection';
+import type {FeatureMeta} from 'sentry/views/onboarding/components/useScmFeatureMeta';
 import type {OrganizationStatsProps} from 'sentry/views/organizationStats';
 import type {RouteAnalyticsContext} from 'sentry/views/routeAnalyticsContextProvider';
 import type {NavigationSection} from 'sentry/views/settings/types';
@@ -363,6 +365,7 @@ type ReactHooks = {
     isLoading: boolean;
   };
   'react-hook:use-product-billing-access': (product: DataCategory) => boolean;
+  'react-hook:use-scm-feature-meta': () => Record<ProductSolution, FeatureMeta>;
 };
 
 /**

--- a/static/app/views/onboarding/components/scmFeatureCard.tsx
+++ b/static/app/views/onboarding/components/scmFeatureCard.tsx
@@ -6,6 +6,7 @@ import {Switch} from '@sentry/scraps/switch';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
+import {Placeholder} from 'sentry/components/placeholder';
 import {IconInfo} from 'sentry/icons/iconInfo';
 import type {SVGIconProps} from 'sentry/icons/svgIcon';
 
@@ -22,6 +23,7 @@ interface ScmFeatureCardProps {
   volumeTooltip: string;
   disabled?: boolean;
   disabledReason?: ReactNode;
+  isVolumeLoading?: boolean;
 }
 
 export function ScmFeatureCard({
@@ -34,6 +36,7 @@ export function ScmFeatureCard({
   onClick,
   volume,
   volumeTooltip,
+  isVolumeLoading,
 }: ScmFeatureCardProps) {
   return (
     <ScmCardButton
@@ -81,11 +84,15 @@ export function ScmFeatureCard({
             </Container>
           </Grid>
           <Flex align="start" gap="sm">
-            <Tooltip title={volumeTooltip} delay={100}>
-              <Tag variant="muted" icon={<IconInfo size="sm" />}>
-                {volume}
-              </Tag>
-            </Tooltip>
+            {isVolumeLoading ? (
+              <Placeholder height="22px" width="100px" />
+            ) : (
+              <Tooltip title={volumeTooltip} delay={100}>
+                <Tag variant="muted" icon={<IconInfo size="sm" />}>
+                  {volume}
+                </Tag>
+              </Tooltip>
+            )}
             <Tooltip title={disabledReason} disabled={!disabledReason} delay={500}>
               <Switch
                 checked={isSelected}

--- a/static/app/views/onboarding/components/scmFeatureSelectionCards.spec.tsx
+++ b/static/app/views/onboarding/components/scmFeatureSelectionCards.spec.tsx
@@ -4,6 +4,7 @@ import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/ty
 import type {DisabledProducts} from 'sentry/components/onboarding/productSelection';
 
 import {ScmFeatureSelectionCards} from './scmFeatureSelectionCards';
+import {FALLBACK_FEATURE_META} from './useScmFeatureMeta';
 
 const NO_DISABLED: DisabledProducts = {};
 
@@ -24,6 +25,7 @@ describe('ScmFeatureSelectionCards', () => {
         selectedFeatures={[ProductSolution.ERROR_MONITORING]}
         disabledProducts={NO_DISABLED}
         onToggleFeature={jest.fn()}
+        featureMeta={FALLBACK_FEATURE_META}
       />
     );
 
@@ -45,6 +47,7 @@ describe('ScmFeatureSelectionCards', () => {
         selectedFeatures={[ProductSolution.ERROR_MONITORING]}
         disabledProducts={NO_DISABLED}
         onToggleFeature={jest.fn()}
+        featureMeta={FALLBACK_FEATURE_META}
       />
     );
 
@@ -60,6 +63,7 @@ describe('ScmFeatureSelectionCards', () => {
         selectedFeatures={[ProductSolution.ERROR_MONITORING]}
         disabledProducts={NO_DISABLED}
         onToggleFeature={onToggleFeature}
+        featureMeta={FALLBACK_FEATURE_META}
       />
     );
 
@@ -84,6 +88,7 @@ describe('ScmFeatureSelectionCards', () => {
         selectedFeatures={[ProductSolution.ERROR_MONITORING]}
         disabledProducts={NO_DISABLED}
         onToggleFeature={onToggleFeature}
+        featureMeta={FALLBACK_FEATURE_META}
       />
     );
 
@@ -105,6 +110,7 @@ describe('ScmFeatureSelectionCards', () => {
           },
         }}
         onToggleFeature={jest.fn()}
+        featureMeta={FALLBACK_FEATURE_META}
       />
     );
 
@@ -120,6 +126,7 @@ describe('ScmFeatureSelectionCards', () => {
         selectedFeatures={[]}
         disabledProducts={NO_DISABLED}
         onToggleFeature={jest.fn()}
+        featureMeta={FALLBACK_FEATURE_META}
       />
     );
 
@@ -129,18 +136,37 @@ describe('ScmFeatureSelectionCards', () => {
     expect(errorMonitoringCard).toBeChecked();
   });
 
-  it('renders fallback volumes when no billing-config hook is registered', () => {
+  it('renders volume strings from featureMeta', () => {
     render(
       <ScmFeatureSelectionCards
         availableFeatures={ALL_FEATURES}
         selectedFeatures={[ProductSolution.ERROR_MONITORING]}
         disabledProducts={NO_DISABLED}
         onToggleFeature={jest.fn()}
+        featureMeta={FALLBACK_FEATURE_META}
       />
     );
 
     expect(screen.getByText('5,000 errors / mo')).toBeInTheDocument();
     expect(screen.getByText('5M spans / mo')).toBeInTheDocument();
     expect(screen.getByText('Usage-based')).toBeInTheDocument();
+  });
+
+  it('renders skeletons in place of volume tags while loading', () => {
+    render(
+      <ScmFeatureSelectionCards
+        availableFeatures={ALL_FEATURES}
+        selectedFeatures={[ProductSolution.ERROR_MONITORING]}
+        disabledProducts={NO_DISABLED}
+        onToggleFeature={jest.fn()}
+        featureMeta={FALLBACK_FEATURE_META}
+        isVolumeLoading
+      />
+    );
+
+    expect(screen.queryByText('5,000 errors / mo')).not.toBeInTheDocument();
+    expect(screen.getAllByTestId('loading-placeholder')).toHaveLength(
+      ALL_FEATURES.length
+    );
   });
 });

--- a/static/app/views/onboarding/components/scmFeatureSelectionCards.spec.tsx
+++ b/static/app/views/onboarding/components/scmFeatureSelectionCards.spec.tsx
@@ -1,7 +1,18 @@
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+/* eslint-disable boundaries/dependencies */
+import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
+import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+/* eslint-enable boundaries/dependencies */
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import type {DisabledProducts} from 'sentry/components/onboarding/productSelection';
+
+/* eslint-disable boundaries/dependencies */
+import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
+import {PlanTier} from 'getsentry/types';
+/* eslint-enable boundaries/dependencies */
 
 import {ScmFeatureSelectionCards} from './scmFeatureSelectionCards';
 
@@ -17,6 +28,11 @@ const ALL_FEATURES = [
 ];
 
 describe('ScmFeatureSelectionCards', () => {
+  beforeEach(() => {
+    SubscriptionStore.init();
+    MockApiClient.clearMockResponses();
+  });
+
   it('renders all available features', () => {
     render(
       <ScmFeatureSelectionCards
@@ -127,5 +143,77 @@ describe('ScmFeatureSelectionCards', () => {
       name: /Error monitoring/,
     });
     expect(errorMonitoringCard).toBeChecked();
+  });
+
+  it('renders fallback volumes when subscription is unavailable', () => {
+    render(
+      <ScmFeatureSelectionCards
+        availableFeatures={ALL_FEATURES}
+        selectedFeatures={[ProductSolution.ERROR_MONITORING]}
+        disabledProducts={NO_DISABLED}
+        onToggleFeature={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('5,000 errors / mo')).toBeInTheDocument();
+    expect(screen.getByText('5M spans / mo')).toBeInTheDocument();
+    expect(screen.getByText('Usage-based')).toBeInTheDocument();
+  });
+
+  it('renders dynamic volumes from billing-config response', async () => {
+    const organization = OrganizationFixture();
+    const subscription = SubscriptionFixture({organization, planTier: PlanTier.AM3});
+    SubscriptionStore.set(organization.slug, subscription);
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/billing-config/`,
+      query: {tier: 'am3'},
+      body: BillingConfigFixture(PlanTier.AM3),
+    });
+
+    render(
+      <ScmFeatureSelectionCards
+        availableFeatures={ALL_FEATURES}
+        selectedFeatures={[ProductSolution.ERROR_MONITORING]}
+        disabledProducts={NO_DISABLED}
+        onToggleFeature={jest.fn()}
+      />,
+      {organization}
+    );
+
+    expect(await screen.findByText('50,000 errors / mo')).toBeInTheDocument();
+    expect(screen.getByText('10M spans / mo')).toBeInTheDocument();
+    expect(screen.getByText('50 replays / mo')).toBeInTheDocument();
+    expect(screen.getByText('5 GB logs / mo')).toBeInTheDocument();
+    // Profile duration in the free plan is 0 → fallback "Usage-based" still wins.
+    expect(screen.getByText('Usage-based')).toBeInTheDocument();
+  });
+
+  it('falls back to static volumes when billing-config errors', async () => {
+    const organization = OrganizationFixture();
+    const subscription = SubscriptionFixture({organization, planTier: PlanTier.AM3});
+    SubscriptionStore.set(organization.slug, subscription);
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/billing-config/`,
+      query: {tier: 'am3'},
+      statusCode: 404,
+      body: {detail: 'Not Found'},
+    });
+
+    render(
+      <ScmFeatureSelectionCards
+        availableFeatures={ALL_FEATURES}
+        selectedFeatures={[ProductSolution.ERROR_MONITORING]}
+        disabledProducts={NO_DISABLED}
+        onToggleFeature={jest.fn()}
+      />,
+      {organization}
+    );
+
+    // The fallback (5,000 errors) should remain on screen even after the request
+    // resolves with 404, since the hook degrades gracefully.
+    await waitFor(() => {
+      expect(screen.getByText('5,000 errors / mo')).toBeInTheDocument();
+    });
+    expect(screen.getByText('5M spans / mo')).toBeInTheDocument();
   });
 });

--- a/static/app/views/onboarding/components/scmFeatureSelectionCards.spec.tsx
+++ b/static/app/views/onboarding/components/scmFeatureSelectionCards.spec.tsx
@@ -1,18 +1,7 @@
-import {OrganizationFixture} from 'sentry-fixture/organization';
-
-/* eslint-disable boundaries/dependencies */
-import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
-import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
-/* eslint-enable boundaries/dependencies */
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import type {DisabledProducts} from 'sentry/components/onboarding/productSelection';
-
-/* eslint-disable boundaries/dependencies */
-import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
-import {PlanTier} from 'getsentry/types';
-/* eslint-enable boundaries/dependencies */
 
 import {ScmFeatureSelectionCards} from './scmFeatureSelectionCards';
 
@@ -28,11 +17,6 @@ const ALL_FEATURES = [
 ];
 
 describe('ScmFeatureSelectionCards', () => {
-  beforeEach(() => {
-    SubscriptionStore.init();
-    MockApiClient.clearMockResponses();
-  });
-
   it('renders all available features', () => {
     render(
       <ScmFeatureSelectionCards
@@ -145,7 +129,7 @@ describe('ScmFeatureSelectionCards', () => {
     expect(errorMonitoringCard).toBeChecked();
   });
 
-  it('renders fallback volumes when subscription is unavailable', () => {
+  it('renders fallback volumes when no billing-config hook is registered', () => {
     render(
       <ScmFeatureSelectionCards
         availableFeatures={ALL_FEATURES}
@@ -158,62 +142,5 @@ describe('ScmFeatureSelectionCards', () => {
     expect(screen.getByText('5,000 errors / mo')).toBeInTheDocument();
     expect(screen.getByText('5M spans / mo')).toBeInTheDocument();
     expect(screen.getByText('Usage-based')).toBeInTheDocument();
-  });
-
-  it('renders dynamic volumes from billing-config response', async () => {
-    const organization = OrganizationFixture();
-    const subscription = SubscriptionFixture({organization, planTier: PlanTier.AM3});
-    SubscriptionStore.set(organization.slug, subscription);
-    MockApiClient.addMockResponse({
-      url: `/customers/${organization.slug}/billing-config/`,
-      query: {tier: 'am3'},
-      body: BillingConfigFixture(PlanTier.AM3),
-    });
-
-    render(
-      <ScmFeatureSelectionCards
-        availableFeatures={ALL_FEATURES}
-        selectedFeatures={[ProductSolution.ERROR_MONITORING]}
-        disabledProducts={NO_DISABLED}
-        onToggleFeature={jest.fn()}
-      />,
-      {organization}
-    );
-
-    expect(await screen.findByText('50,000 errors / mo')).toBeInTheDocument();
-    expect(screen.getByText('10M spans / mo')).toBeInTheDocument();
-    expect(screen.getByText('50 replays / mo')).toBeInTheDocument();
-    expect(screen.getByText('5 GB logs / mo')).toBeInTheDocument();
-    // Profile duration in the free plan is 0 → fallback "Usage-based" still wins.
-    expect(screen.getByText('Usage-based')).toBeInTheDocument();
-  });
-
-  it('falls back to static volumes when billing-config errors', async () => {
-    const organization = OrganizationFixture();
-    const subscription = SubscriptionFixture({organization, planTier: PlanTier.AM3});
-    SubscriptionStore.set(organization.slug, subscription);
-    MockApiClient.addMockResponse({
-      url: `/customers/${organization.slug}/billing-config/`,
-      query: {tier: 'am3'},
-      statusCode: 404,
-      body: {detail: 'Not Found'},
-    });
-
-    render(
-      <ScmFeatureSelectionCards
-        availableFeatures={ALL_FEATURES}
-        selectedFeatures={[ProductSolution.ERROR_MONITORING]}
-        disabledProducts={NO_DISABLED}
-        onToggleFeature={jest.fn()}
-      />,
-      {organization}
-    );
-
-    // The fallback (5,000 errors) should remain on screen even after the request
-    // resolves with 404, since the hook degrades gracefully.
-    await waitFor(() => {
-      expect(screen.getByText('5,000 errors / mo')).toBeInTheDocument();
-    });
-    expect(screen.getByText('5M spans / mo')).toBeInTheDocument();
   });
 });

--- a/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
+++ b/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
@@ -1,91 +1,12 @@
-import type {ComponentType} from 'react';
-
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
-import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import type {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import type {DisabledProducts} from 'sentry/components/onboarding/productSelection';
-import {
-  IconGraph,
-  IconProfiling,
-  IconSpan,
-  IconTerminal,
-  IconTimer,
-  IconWarning,
-} from 'sentry/icons';
-import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
 
 import {ScmFeatureCard} from './scmFeatureCard';
-
-type FeatureMeta = {
-  description: string;
-  icon: ComponentType<SVGIconProps>;
-  label: string;
-  volume: string;
-  volumeTooltip: string;
-  alwaysEnabled?: boolean;
-};
-
-const FEATURE_META: Record<ProductSolution, FeatureMeta> = {
-  [ProductSolution.ERROR_MONITORING]: {
-    label: t('Error monitoring'),
-    icon: IconWarning,
-    description: t('Automatically capture exceptions and stack traces'),
-    alwaysEnabled: true,
-    volume: t('5,000 errors / mo'),
-    volumeTooltip: t(
-      'Free plan includes 5,000 errors / month. Upgrade to Team or Business to send more.'
-    ),
-  },
-  [ProductSolution.PERFORMANCE_MONITORING]: {
-    label: t('Tracing'),
-    icon: IconSpan,
-    description: t(
-      'Find bottlenecks, broken requests, and understand application flow end-to-end'
-    ),
-    volume: t('5M spans / mo'),
-    volumeTooltip: t(
-      'Free plan includes 5M spans / month. Upgrade to Team or Business to send more.'
-    ),
-  },
-  [ProductSolution.SESSION_REPLAY]: {
-    label: t('Session replay'),
-    icon: IconTimer,
-    description: t('Watch real user sessions to see what went wrong'),
-    volume: t('50 replays / mo'),
-    volumeTooltip: t(
-      'Free plan includes 50 replays / month. Upgrade to Team or Business to send more.'
-    ),
-  },
-  [ProductSolution.LOGS]: {
-    label: t('Logging'),
-    icon: IconTerminal,
-    description: t('See logs in context with errors and performance issues'),
-    volume: t('5 GB logs / mo'),
-    volumeTooltip: t(
-      'Free plan includes 5 GB logs / month. Upgrade to Team or Business to send more.'
-    ),
-  },
-  [ProductSolution.PROFILING]: {
-    label: t('Profiling'),
-    icon: IconProfiling,
-    description: t(
-      'Pinpoint the functions and lines of code responsible for performance issues'
-    ),
-    volume: t('Usage-based'),
-    volumeTooltip: t('Upgrade to Team or Business to send more.'),
-  },
-  [ProductSolution.METRICS]: {
-    label: t('Application Metrics'),
-    icon: IconGraph,
-    description: t(
-      'Track application performance and usage over time with custom metrics'
-    ),
-    volume: t('5 GB / mo'),
-    volumeTooltip: t('Free plan includes 5 GB metrics / month'),
-  },
-};
+import {useScmFeatureMeta} from './useScmFeatureMeta';
 
 interface ScmFeatureSelectionCardsProps {
   availableFeatures: ProductSolution[];
@@ -100,6 +21,7 @@ export function ScmFeatureSelectionCards({
   disabledProducts,
   onToggleFeature,
 }: ScmFeatureSelectionCardsProps) {
+  const featureMeta = useScmFeatureMeta();
   return (
     <Stack gap="xl" width="100%" justify="center">
       <Flex justify="between" align="center">
@@ -112,7 +34,7 @@ export function ScmFeatureSelectionCards({
       </Flex>
       <Stack gap="md">
         {availableFeatures.map(feature => {
-          const meta = FEATURE_META[feature];
+          const meta = featureMeta[feature];
           const disabledProduct = disabledProducts[feature];
           const disabledReason = meta.alwaysEnabled
             ? t('Error monitoring is always enabled')

--- a/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
+++ b/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
@@ -6,13 +6,15 @@ import type {DisabledProducts} from 'sentry/components/onboarding/productSelecti
 import {t} from 'sentry/locale';
 
 import {ScmFeatureCard} from './scmFeatureCard';
-import {useScmFeatureMeta} from './useScmFeatureMeta';
+import type {FeatureMeta} from './useScmFeatureMeta';
 
 interface ScmFeatureSelectionCardsProps {
   availableFeatures: ProductSolution[];
   disabledProducts: DisabledProducts;
+  featureMeta: Record<ProductSolution, FeatureMeta>;
   onToggleFeature: (feature: ProductSolution) => void;
   selectedFeatures: ProductSolution[];
+  isVolumeLoading?: boolean;
 }
 
 export function ScmFeatureSelectionCards({
@@ -20,8 +22,9 @@ export function ScmFeatureSelectionCards({
   selectedFeatures,
   disabledProducts,
   onToggleFeature,
+  featureMeta,
+  isVolumeLoading,
 }: ScmFeatureSelectionCardsProps) {
-  const {meta: featureMeta, isLoading: isVolumeLoading} = useScmFeatureMeta();
   return (
     <Stack gap="xl" width="100%" justify="center">
       <Flex justify="between" align="center">

--- a/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
+++ b/static/app/views/onboarding/components/scmFeatureSelectionCards.tsx
@@ -21,7 +21,7 @@ export function ScmFeatureSelectionCards({
   disabledProducts,
   onToggleFeature,
 }: ScmFeatureSelectionCardsProps) {
-  const featureMeta = useScmFeatureMeta();
+  const {meta: featureMeta, isLoading: isVolumeLoading} = useScmFeatureMeta();
   return (
     <Stack gap="xl" width="100%" justify="center">
       <Flex justify="between" align="center">
@@ -51,6 +51,7 @@ export function ScmFeatureSelectionCards({
               onClick={() => onToggleFeature(feature)}
               volume={meta.volume}
               volumeTooltip={meta.volumeTooltip}
+              isVolumeLoading={isVolumeLoading}
             />
           );
         })}

--- a/static/app/views/onboarding/components/useScmFeatureMeta.tsx
+++ b/static/app/views/onboarding/components/useScmFeatureMeta.tsx
@@ -22,6 +22,11 @@ export type FeatureMeta = {
   alwaysEnabled?: boolean;
 };
 
+export type UseScmFeatureMetaResult = {
+  isLoading: boolean;
+  meta: Record<ProductSolution, FeatureMeta>;
+};
+
 export const FALLBACK_FEATURE_META: Record<ProductSolution, FeatureMeta> = {
   [ProductSolution.ERROR_MONITORING]: {
     label: t('Error monitoring'),
@@ -82,19 +87,19 @@ export const FALLBACK_FEATURE_META: Record<ProductSolution, FeatureMeta> = {
   },
 };
 
-function useFallbackScmFeatureMeta(): Record<ProductSolution, FeatureMeta> {
-  return FALLBACK_FEATURE_META;
+function useFallbackScmFeatureMeta(): UseScmFeatureMetaResult {
+  return {meta: FALLBACK_FEATURE_META, isLoading: false};
 }
 
 /**
  * Returns the per-product metadata used to render SCM onboarding feature cards.
  *
- * The implementation lives in gsApp (it reads the active org's billing-config
- * to keep the volume strings aligned with the actual free-plan limits). When
- * no implementation is registered — self-hosted, or before gsApp's lazy init
- * has finished — the static FALLBACK_FEATURE_META is returned.
+ * The implementation lives in gsApp; it reads the active org's billing-config
+ * to keep the volume strings aligned with the actual free-plan limits. On
+ * self-hosted, where gsApp isn't bundled, the static FALLBACK_FEATURE_META is
+ * returned with isLoading=false.
  */
-export function useScmFeatureMeta(): Record<ProductSolution, FeatureMeta> {
+export function useScmFeatureMeta(): UseScmFeatureMetaResult {
   const hook =
     HookStore.get('react-hook:use-scm-feature-meta')[0] ?? useFallbackScmFeatureMeta;
   return hook();

--- a/static/app/views/onboarding/components/useScmFeatureMeta.tsx
+++ b/static/app/views/onboarding/components/useScmFeatureMeta.tsx
@@ -11,17 +11,7 @@ import {
 } from 'sentry/icons';
 import type {SVGIconProps} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
-import {DataCategory} from 'sentry/types/core';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import {useApiQuery} from 'sentry/utils/queryClient';
-import {useOrganization} from 'sentry/utils/useOrganization';
-
-/* eslint-disable boundaries/dependencies */
-import {UPSELL_TIER} from 'getsentry/constants';
-import {useSubscription} from 'getsentry/hooks/useSubscription';
-import {type BillingConfig, type Plan, PlanTier} from 'getsentry/types';
-import {formatReservedWithUnits} from 'getsentry/utils/billing';
-/* eslint-enable boundaries/dependencies */
+import {HookStore} from 'sentry/stores/hookStore';
 
 export type FeatureMeta = {
   description: string;
@@ -92,133 +82,20 @@ export const FALLBACK_FEATURE_META: Record<ProductSolution, FeatureMeta> = {
   },
 };
 
-type DynamicCategoryFormat = {
-  category: DataCategory;
-  formatTooltip: (formattedVolume: string) => string;
-  formatVolume: (events: number) => string;
-};
-
-// Categories whose free-plan volume is sourced from billing-config. Profiling is
-// intentionally excluded — its free volume is 0 and the fallback "Usage-based" copy
-// is what we want to keep showing.
-const DYNAMIC_FORMATS: Partial<Record<ProductSolution, DynamicCategoryFormat>> = {
-  [ProductSolution.ERROR_MONITORING]: {
-    category: DataCategory.ERRORS,
-    formatVolume: events =>
-      t('%s errors / mo', formatReservedWithUnits(events, DataCategory.ERRORS)),
-    formatTooltip: volume =>
-      t(
-        'Free plan includes %s. Upgrade to Team or Business to send more.',
-        volume.replace(/ \/ mo$/, ' / month')
-      ),
-  },
-  [ProductSolution.PERFORMANCE_MONITORING]: {
-    category: DataCategory.SPANS,
-    formatVolume: events =>
-      t(
-        '%s spans / mo',
-        formatReservedWithUnits(events, DataCategory.SPANS, {isAbbreviated: true})
-      ),
-    formatTooltip: volume =>
-      t(
-        'Free plan includes %s. Upgrade to Team or Business to send more.',
-        volume.replace(/ \/ mo$/, ' / month')
-      ),
-  },
-  [ProductSolution.SESSION_REPLAY]: {
-    category: DataCategory.REPLAYS,
-    formatVolume: events =>
-      t('%s replays / mo', formatReservedWithUnits(events, DataCategory.REPLAYS)),
-    formatTooltip: volume =>
-      t(
-        'Free plan includes %s. Upgrade to Team or Business to send more.',
-        volume.replace(/ \/ mo$/, ' / month')
-      ),
-  },
-  [ProductSolution.LOGS]: {
-    category: DataCategory.LOG_BYTE,
-    formatVolume: gigabytes =>
-      t('%s logs / mo', formatReservedWithUnits(gigabytes, DataCategory.LOG_BYTE)),
-    formatTooltip: volume =>
-      t(
-        'Free plan includes %s. Upgrade to Team or Business to send more.',
-        volume.replace(/ \/ mo$/, ' / month')
-      ),
-  },
-  [ProductSolution.METRICS]: {
-    category: DataCategory.TRACE_METRIC_BYTE,
-    formatVolume: gigabytes =>
-      t('%s / mo', formatReservedWithUnits(gigabytes, DataCategory.TRACE_METRIC_BYTE)),
-    formatTooltip: volume =>
-      t('Free plan includes %s metrics / month.', volume.replace(/ \/ mo$/, '')),
-  },
-};
-
-function findFreePlan(planList: Plan[], freePlanId: string): Plan | undefined {
-  return planList.find(plan => plan.id === freePlanId);
-}
-
-function getFreeVolume(plan: Plan, category: DataCategory): number | undefined {
-  const buckets = plan.planCategories[category];
-  return buckets?.[0]?.events;
-}
-
-function getUpsellTier(planTier?: string, trialTier?: string | null) {
-  return planTier === PlanTier.AM3 || trialTier === PlanTier.AM3
-    ? PlanTier.AM3
-    : UPSELL_TIER;
+function useFallbackScmFeatureMeta(): Record<ProductSolution, FeatureMeta> {
+  return FALLBACK_FEATURE_META;
 }
 
 /**
  * Returns the per-product metadata used to render SCM onboarding feature cards.
  *
- * Volume strings (e.g. "5,000 errors / mo") and matching tooltips are derived
- * from the active org's billing-config response so they stay aligned with the
- * actual free-plan limits. When the response isn't available — self-hosted,
- * unhydrated subscription store, query in flight, or query errored — the
- * static FALLBACK_FEATURE_META is returned so the UI still renders sensible
- * copy.
+ * The implementation lives in gsApp (it reads the active org's billing-config
+ * to keep the volume strings aligned with the actual free-plan limits). When
+ * no implementation is registered — self-hosted, or before gsApp's lazy init
+ * has finished — the static FALLBACK_FEATURE_META is returned.
  */
 export function useScmFeatureMeta(): Record<ProductSolution, FeatureMeta> {
-  const organization = useOrganization();
-  const subscription = useSubscription();
-  const upsellTier = getUpsellTier(subscription?.planTier, subscription?.trialTier);
-  const {data: billingConfig} = useApiQuery<BillingConfig>(
-    [
-      getApiUrl('/customers/$organizationIdOrSlug/billing-config/', {
-        path: {organizationIdOrSlug: organization.slug},
-      }),
-      {query: {tier: upsellTier}},
-    ],
-    {staleTime: Infinity, enabled: !!subscription, retry: false}
-  );
-
-  if (!subscription || !billingConfig) {
-    return FALLBACK_FEATURE_META;
-  }
-
-  const freePlan = findFreePlan(billingConfig.planList, billingConfig.freePlan);
-  if (!freePlan) {
-    return FALLBACK_FEATURE_META;
-  }
-
-  const meta: Record<ProductSolution, FeatureMeta> = {...FALLBACK_FEATURE_META};
-  for (const [productKey, format] of Object.entries(DYNAMIC_FORMATS)) {
-    if (!format) {
-      continue;
-    }
-    const product = productKey as ProductSolution;
-    const events = getFreeVolume(freePlan, format.category);
-    if (events === undefined || events <= 0) {
-      continue;
-    }
-    const volume = format.formatVolume(events);
-    meta[product] = {
-      ...FALLBACK_FEATURE_META[product],
-      volume,
-      volumeTooltip: format.formatTooltip(volume),
-    };
-  }
-
-  return meta;
+  const hook =
+    HookStore.get('react-hook:use-scm-feature-meta')[0] ?? useFallbackScmFeatureMeta;
+  return hook();
 }

--- a/static/app/views/onboarding/components/useScmFeatureMeta.tsx
+++ b/static/app/views/onboarding/components/useScmFeatureMeta.tsx
@@ -1,0 +1,224 @@
+import type {ComponentType} from 'react';
+
+import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {
+  IconGraph,
+  IconProfiling,
+  IconSpan,
+  IconTerminal,
+  IconTimer,
+  IconWarning,
+} from 'sentry/icons';
+import type {SVGIconProps} from 'sentry/icons/svgIcon';
+import {t} from 'sentry/locale';
+import {DataCategory} from 'sentry/types/core';
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+/* eslint-disable boundaries/dependencies */
+import {UPSELL_TIER} from 'getsentry/constants';
+import {useSubscription} from 'getsentry/hooks/useSubscription';
+import {type BillingConfig, type Plan, PlanTier} from 'getsentry/types';
+import {formatReservedWithUnits} from 'getsentry/utils/billing';
+/* eslint-enable boundaries/dependencies */
+
+export type FeatureMeta = {
+  description: string;
+  icon: ComponentType<SVGIconProps>;
+  label: string;
+  volume: string;
+  volumeTooltip: string;
+  alwaysEnabled?: boolean;
+};
+
+export const FALLBACK_FEATURE_META: Record<ProductSolution, FeatureMeta> = {
+  [ProductSolution.ERROR_MONITORING]: {
+    label: t('Error monitoring'),
+    icon: IconWarning,
+    description: t('Automatically capture exceptions and stack traces'),
+    alwaysEnabled: true,
+    volume: t('5,000 errors / mo'),
+    volumeTooltip: t(
+      'Free plan includes 5,000 errors / month. Upgrade to Team or Business to send more.'
+    ),
+  },
+  [ProductSolution.PERFORMANCE_MONITORING]: {
+    label: t('Tracing'),
+    icon: IconSpan,
+    description: t(
+      'Find bottlenecks, broken requests, and understand application flow end-to-end'
+    ),
+    volume: t('5M spans / mo'),
+    volumeTooltip: t(
+      'Free plan includes 5M spans / month. Upgrade to Team or Business to send more.'
+    ),
+  },
+  [ProductSolution.SESSION_REPLAY]: {
+    label: t('Session replay'),
+    icon: IconTimer,
+    description: t('Watch real user sessions to see what went wrong'),
+    volume: t('50 replays / mo'),
+    volumeTooltip: t(
+      'Free plan includes 50 replays / month. Upgrade to Team or Business to send more.'
+    ),
+  },
+  [ProductSolution.LOGS]: {
+    label: t('Logging'),
+    icon: IconTerminal,
+    description: t('See logs in context with errors and performance issues'),
+    volume: t('5 GB logs / mo'),
+    volumeTooltip: t(
+      'Free plan includes 5 GB logs / month. Upgrade to Team or Business to send more.'
+    ),
+  },
+  [ProductSolution.PROFILING]: {
+    label: t('Profiling'),
+    icon: IconProfiling,
+    description: t(
+      'Pinpoint the functions and lines of code responsible for performance issues'
+    ),
+    volume: t('Usage-based'),
+    volumeTooltip: t('Upgrade to Team or Business to send more.'),
+  },
+  [ProductSolution.METRICS]: {
+    label: t('Application Metrics'),
+    icon: IconGraph,
+    description: t(
+      'Track application performance and usage over time with custom metrics'
+    ),
+    volume: t('5 GB / mo'),
+    volumeTooltip: t('Free plan includes 5 GB metrics / month'),
+  },
+};
+
+type DynamicCategoryFormat = {
+  category: DataCategory;
+  formatTooltip: (formattedVolume: string) => string;
+  formatVolume: (events: number) => string;
+};
+
+// Categories whose free-plan volume is sourced from billing-config. Profiling is
+// intentionally excluded — its free volume is 0 and the fallback "Usage-based" copy
+// is what we want to keep showing.
+const DYNAMIC_FORMATS: Partial<Record<ProductSolution, DynamicCategoryFormat>> = {
+  [ProductSolution.ERROR_MONITORING]: {
+    category: DataCategory.ERRORS,
+    formatVolume: events =>
+      t('%s errors / mo', formatReservedWithUnits(events, DataCategory.ERRORS)),
+    formatTooltip: volume =>
+      t(
+        'Free plan includes %s. Upgrade to Team or Business to send more.',
+        volume.replace(/ \/ mo$/, ' / month')
+      ),
+  },
+  [ProductSolution.PERFORMANCE_MONITORING]: {
+    category: DataCategory.SPANS,
+    formatVolume: events =>
+      t(
+        '%s spans / mo',
+        formatReservedWithUnits(events, DataCategory.SPANS, {isAbbreviated: true})
+      ),
+    formatTooltip: volume =>
+      t(
+        'Free plan includes %s. Upgrade to Team or Business to send more.',
+        volume.replace(/ \/ mo$/, ' / month')
+      ),
+  },
+  [ProductSolution.SESSION_REPLAY]: {
+    category: DataCategory.REPLAYS,
+    formatVolume: events =>
+      t('%s replays / mo', formatReservedWithUnits(events, DataCategory.REPLAYS)),
+    formatTooltip: volume =>
+      t(
+        'Free plan includes %s. Upgrade to Team or Business to send more.',
+        volume.replace(/ \/ mo$/, ' / month')
+      ),
+  },
+  [ProductSolution.LOGS]: {
+    category: DataCategory.LOG_BYTE,
+    formatVolume: gigabytes =>
+      t('%s logs / mo', formatReservedWithUnits(gigabytes, DataCategory.LOG_BYTE)),
+    formatTooltip: volume =>
+      t(
+        'Free plan includes %s. Upgrade to Team or Business to send more.',
+        volume.replace(/ \/ mo$/, ' / month')
+      ),
+  },
+  [ProductSolution.METRICS]: {
+    category: DataCategory.TRACE_METRIC_BYTE,
+    formatVolume: gigabytes =>
+      t('%s / mo', formatReservedWithUnits(gigabytes, DataCategory.TRACE_METRIC_BYTE)),
+    formatTooltip: volume =>
+      t('Free plan includes %s metrics / month.', volume.replace(/ \/ mo$/, '')),
+  },
+};
+
+function findFreePlan(planList: Plan[], freePlanId: string): Plan | undefined {
+  return planList.find(plan => plan.id === freePlanId);
+}
+
+function getFreeVolume(plan: Plan, category: DataCategory): number | undefined {
+  const buckets = plan.planCategories[category];
+  return buckets?.[0]?.events;
+}
+
+function getUpsellTier(planTier?: string, trialTier?: string | null) {
+  return planTier === PlanTier.AM3 || trialTier === PlanTier.AM3
+    ? PlanTier.AM3
+    : UPSELL_TIER;
+}
+
+/**
+ * Returns the per-product metadata used to render SCM onboarding feature cards.
+ *
+ * Volume strings (e.g. "5,000 errors / mo") and matching tooltips are derived
+ * from the active org's billing-config response so they stay aligned with the
+ * actual free-plan limits. When the response isn't available — self-hosted,
+ * unhydrated subscription store, query in flight, or query errored — the
+ * static FALLBACK_FEATURE_META is returned so the UI still renders sensible
+ * copy.
+ */
+export function useScmFeatureMeta(): Record<ProductSolution, FeatureMeta> {
+  const organization = useOrganization();
+  const subscription = useSubscription();
+  const upsellTier = getUpsellTier(subscription?.planTier, subscription?.trialTier);
+  const {data: billingConfig} = useApiQuery<BillingConfig>(
+    [
+      getApiUrl('/customers/$organizationIdOrSlug/billing-config/', {
+        path: {organizationIdOrSlug: organization.slug},
+      }),
+      {query: {tier: upsellTier}},
+    ],
+    {staleTime: Infinity, enabled: !!subscription, retry: false}
+  );
+
+  if (!subscription || !billingConfig) {
+    return FALLBACK_FEATURE_META;
+  }
+
+  const freePlan = findFreePlan(billingConfig.planList, billingConfig.freePlan);
+  if (!freePlan) {
+    return FALLBACK_FEATURE_META;
+  }
+
+  const meta: Record<ProductSolution, FeatureMeta> = {...FALLBACK_FEATURE_META};
+  for (const [productKey, format] of Object.entries(DYNAMIC_FORMATS)) {
+    if (!format) {
+      continue;
+    }
+    const product = productKey as ProductSolution;
+    const events = getFreeVolume(freePlan, format.category);
+    if (events === undefined || events <= 0) {
+      continue;
+    }
+    const volume = format.formatVolume(events);
+    meta[product] = {
+      ...FALLBACK_FEATURE_META[product],
+      volume,
+      volumeTooltip: format.formatTooltip(volume),
+    };
+  }
+
+  return meta;
+}

--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -33,6 +33,7 @@ import {useProjects} from 'sentry/utils/useProjects';
 import {useTeams} from 'sentry/utils/useTeams';
 import {ScmFeatureSelectionCards} from 'sentry/views/onboarding/components/scmFeatureSelectionCards';
 import {ScmPlatformCard} from 'sentry/views/onboarding/components/scmPlatformCard';
+import {useScmFeatureMeta} from 'sentry/views/onboarding/components/useScmFeatureMeta';
 import {SCM_STEP_CONTENT_WIDTH} from 'sentry/views/onboarding/consts';
 
 import {ScmSearchControl} from './components/scmSearchControl';
@@ -95,6 +96,9 @@ export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
   const {teams, fetching: isLoadingTeams} = useTeams();
   const {projects, initiallyLoaded: projectsLoaded} = useProjects();
   const createProject = useCreateProject();
+  // Fetch feature meta at step entry so billing-config is in flight (or cached)
+  // before the user reaches the feature cards below.
+  const {meta: featureMeta, isLoading: isFeatureMetaLoading} = useScmFeatureMeta();
   // Exposure is reported upstream in onboarding.tsx when the user enters SCM
   // onboarding; skip it here to avoid double-counting on step mount.
   const {inExperiment: hasProjectDetailsStep} = useExperiment({
@@ -585,6 +589,8 @@ export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
                   selectedFeatures={currentFeatures}
                   disabledProducts={disabledProducts}
                   onToggleFeature={handleToggleFeature}
+                  featureMeta={featureMeta}
+                  isVolumeLoading={isFeatureMetaLoading}
                 />
               </Stack>
             )}

--- a/static/gsApp/hooks/useScmFeatureMeta.spec.tsx
+++ b/static/gsApp/hooks/useScmFeatureMeta.spec.tsx
@@ -41,12 +41,13 @@ describe('useScmFeatureMeta', () => {
     expect(result.current.meta[ProductSolution.PROFILING].volume).toBe('Usage-based');
   });
 
-  it('falls back to static volumes when freePlan is missing from planList', async () => {
+  it('falls back to static volumes when billing-config errors', async () => {
     const organization = OrganizationFixture();
     MockApiClient.addMockResponse({
       url: `/customers/${organization.slug}/billing-config/`,
       query: {tier: 'am3'},
-      body: {...BillingConfigFixture(PlanTier.AM3), freePlan: 'missing_plan_id'},
+      statusCode: 404,
+      body: {detail: 'Not Found'},
     });
 
     const {result} = renderHookWithProviders(useScmFeatureMeta, {organization});

--- a/static/gsApp/hooks/useScmFeatureMeta.spec.tsx
+++ b/static/gsApp/hooks/useScmFeatureMeta.spec.tsx
@@ -1,25 +1,20 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
-import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
 import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 
 import {useScmFeatureMeta} from 'getsentry/hooks/useScmFeatureMeta';
-import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
 import {PlanTier} from 'getsentry/types';
 
 describe('useScmFeatureMeta (gsApp)', () => {
   beforeEach(() => {
-    SubscriptionStore.init();
     MockApiClient.clearMockResponses();
   });
 
   it('returns dynamic volumes from billing-config response', async () => {
     const organization = OrganizationFixture();
-    const subscription = SubscriptionFixture({organization, planTier: PlanTier.AM3});
-    SubscriptionStore.set(organization.slug, subscription);
     MockApiClient.addMockResponse({
       url: `/customers/${organization.slug}/billing-config/`,
       query: {tier: 'am3'},
@@ -44,8 +39,6 @@ describe('useScmFeatureMeta (gsApp)', () => {
 
   it('falls back to static volumes when billing-config errors', async () => {
     const organization = OrganizationFixture();
-    const subscription = SubscriptionFixture({organization, planTier: PlanTier.AM3});
-    SubscriptionStore.set(organization.slug, subscription);
     MockApiClient.addMockResponse({
       url: `/customers/${organization.slug}/billing-config/`,
       query: {tier: 'am3'},
@@ -60,18 +53,6 @@ describe('useScmFeatureMeta (gsApp)', () => {
         '5,000 errors / mo'
       );
     });
-    expect(result.current[ProductSolution.PERFORMANCE_MONITORING].volume).toBe(
-      '5M spans / mo'
-    );
-  });
-
-  it('returns fallback volumes when subscription store is empty', () => {
-    const organization = OrganizationFixture();
-    const {result} = renderHookWithProviders(useScmFeatureMeta, {organization});
-
-    expect(result.current[ProductSolution.ERROR_MONITORING].volume).toBe(
-      '5,000 errors / mo'
-    );
     expect(result.current[ProductSolution.PERFORMANCE_MONITORING].volume).toBe(
       '5M spans / mo'
     );

--- a/static/gsApp/hooks/useScmFeatureMeta.spec.tsx
+++ b/static/gsApp/hooks/useScmFeatureMeta.spec.tsx
@@ -23,18 +23,24 @@ describe('useScmFeatureMeta (gsApp)', () => {
 
     const {result} = renderHookWithProviders(useScmFeatureMeta, {organization});
 
+    expect(result.current.isLoading).toBe(true);
+
     await waitFor(() => {
-      expect(result.current[ProductSolution.ERROR_MONITORING].volume).toBe(
+      expect(result.current.meta[ProductSolution.ERROR_MONITORING].volume).toBe(
         '50,000 errors / mo'
       );
     });
-    expect(result.current[ProductSolution.PERFORMANCE_MONITORING].volume).toBe(
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.meta[ProductSolution.PERFORMANCE_MONITORING].volume).toBe(
       '10M spans / mo'
     );
-    expect(result.current[ProductSolution.SESSION_REPLAY].volume).toBe('50 replays / mo');
-    expect(result.current[ProductSolution.LOGS].volume).toBe('5 GB logs / mo');
-    // Profile duration in the free plan is 0 → fallback "Usage-based" still wins.
-    expect(result.current[ProductSolution.PROFILING].volume).toBe('Usage-based');
+    expect(result.current.meta[ProductSolution.SESSION_REPLAY].volume).toBe(
+      '50 replays / mo'
+    );
+    expect(result.current.meta[ProductSolution.LOGS].volume).toBe('5 GB logs / mo');
+    // PROFILING is intentionally absent from DYNAMIC_FORMATS, so the static
+    // "Usage-based" fallback is preserved.
+    expect(result.current.meta[ProductSolution.PROFILING].volume).toBe('Usage-based');
   });
 
   it('falls back to static volumes when billing-config errors', async () => {
@@ -49,11 +55,12 @@ describe('useScmFeatureMeta (gsApp)', () => {
     const {result} = renderHookWithProviders(useScmFeatureMeta, {organization});
 
     await waitFor(() => {
-      expect(result.current[ProductSolution.ERROR_MONITORING].volume).toBe(
-        '5,000 errors / mo'
-      );
+      expect(result.current.isLoading).toBe(false);
     });
-    expect(result.current[ProductSolution.PERFORMANCE_MONITORING].volume).toBe(
+    expect(result.current.meta[ProductSolution.ERROR_MONITORING].volume).toBe(
+      '5,000 errors / mo'
+    );
+    expect(result.current.meta[ProductSolution.PERFORMANCE_MONITORING].volume).toBe(
       '5M spans / mo'
     );
   });

--- a/static/gsApp/hooks/useScmFeatureMeta.spec.tsx
+++ b/static/gsApp/hooks/useScmFeatureMeta.spec.tsx
@@ -1,0 +1,79 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {BillingConfigFixture} from 'getsentry-test/fixtures/billingConfig';
+import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
+import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
+
+import {useScmFeatureMeta} from 'getsentry/hooks/useScmFeatureMeta';
+import {SubscriptionStore} from 'getsentry/stores/subscriptionStore';
+import {PlanTier} from 'getsentry/types';
+
+describe('useScmFeatureMeta (gsApp)', () => {
+  beforeEach(() => {
+    SubscriptionStore.init();
+    MockApiClient.clearMockResponses();
+  });
+
+  it('returns dynamic volumes from billing-config response', async () => {
+    const organization = OrganizationFixture();
+    const subscription = SubscriptionFixture({organization, planTier: PlanTier.AM3});
+    SubscriptionStore.set(organization.slug, subscription);
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/billing-config/`,
+      query: {tier: 'am3'},
+      body: BillingConfigFixture(PlanTier.AM3),
+    });
+
+    const {result} = renderHookWithProviders(useScmFeatureMeta, {organization});
+
+    await waitFor(() => {
+      expect(result.current[ProductSolution.ERROR_MONITORING].volume).toBe(
+        '50,000 errors / mo'
+      );
+    });
+    expect(result.current[ProductSolution.PERFORMANCE_MONITORING].volume).toBe(
+      '10M spans / mo'
+    );
+    expect(result.current[ProductSolution.SESSION_REPLAY].volume).toBe('50 replays / mo');
+    expect(result.current[ProductSolution.LOGS].volume).toBe('5 GB logs / mo');
+    // Profile duration in the free plan is 0 → fallback "Usage-based" still wins.
+    expect(result.current[ProductSolution.PROFILING].volume).toBe('Usage-based');
+  });
+
+  it('falls back to static volumes when billing-config errors', async () => {
+    const organization = OrganizationFixture();
+    const subscription = SubscriptionFixture({organization, planTier: PlanTier.AM3});
+    SubscriptionStore.set(organization.slug, subscription);
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/billing-config/`,
+      query: {tier: 'am3'},
+      statusCode: 404,
+      body: {detail: 'Not Found'},
+    });
+
+    const {result} = renderHookWithProviders(useScmFeatureMeta, {organization});
+
+    await waitFor(() => {
+      expect(result.current[ProductSolution.ERROR_MONITORING].volume).toBe(
+        '5,000 errors / mo'
+      );
+    });
+    expect(result.current[ProductSolution.PERFORMANCE_MONITORING].volume).toBe(
+      '5M spans / mo'
+    );
+  });
+
+  it('returns fallback volumes when subscription store is empty', () => {
+    const organization = OrganizationFixture();
+    const {result} = renderHookWithProviders(useScmFeatureMeta, {organization});
+
+    expect(result.current[ProductSolution.ERROR_MONITORING].volume).toBe(
+      '5,000 errors / mo'
+    );
+    expect(result.current[ProductSolution.PERFORMANCE_MONITORING].volume).toBe(
+      '5M spans / mo'
+    );
+  });
+});

--- a/static/gsApp/hooks/useScmFeatureMeta.spec.tsx
+++ b/static/gsApp/hooks/useScmFeatureMeta.spec.tsx
@@ -8,7 +8,7 @@ import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/ty
 import {useScmFeatureMeta} from 'getsentry/hooks/useScmFeatureMeta';
 import {PlanTier} from 'getsentry/types';
 
-describe('useScmFeatureMeta (gsApp)', () => {
+describe('useScmFeatureMeta', () => {
   beforeEach(() => {
     MockApiClient.clearMockResponses();
   });
@@ -24,13 +24,11 @@ describe('useScmFeatureMeta (gsApp)', () => {
     const {result} = renderHookWithProviders(useScmFeatureMeta, {organization});
 
     expect(result.current.isLoading).toBe(true);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    await waitFor(() => {
-      expect(result.current.meta[ProductSolution.ERROR_MONITORING].volume).toBe(
-        '50,000 errors / mo'
-      );
-    });
-    expect(result.current.isLoading).toBe(false);
+    expect(result.current.meta[ProductSolution.ERROR_MONITORING].volume).toBe(
+      '50,000 errors / mo'
+    );
     expect(result.current.meta[ProductSolution.PERFORMANCE_MONITORING].volume).toBe(
       '10M spans / mo'
     );
@@ -43,13 +41,12 @@ describe('useScmFeatureMeta (gsApp)', () => {
     expect(result.current.meta[ProductSolution.PROFILING].volume).toBe('Usage-based');
   });
 
-  it('falls back to static volumes when billing-config errors', async () => {
+  it('falls back to static volumes when freePlan is missing from planList', async () => {
     const organization = OrganizationFixture();
     MockApiClient.addMockResponse({
       url: `/customers/${organization.slug}/billing-config/`,
       query: {tier: 'am3'},
-      statusCode: 404,
-      body: {detail: 'Not Found'},
+      body: {...BillingConfigFixture(PlanTier.AM3), freePlan: 'missing_plan_id'},
     });
 
     const {result} = renderHookWithProviders(useScmFeatureMeta, {organization});

--- a/static/gsApp/hooks/useScmFeatureMeta.tsx
+++ b/static/gsApp/hooks/useScmFeatureMeta.tsx
@@ -1,8 +1,9 @@
+import {useQuery} from '@tanstack/react-query';
+
 import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {t} from 'sentry/locale';
 import {DataCategory} from 'sentry/types/core';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import {useApiQuery} from 'sentry/utils/queryClient';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   FALLBACK_FEATURE_META,
@@ -93,15 +94,17 @@ function getFreeVolume(plan: Plan, category: DataCategory): number | undefined {
  */
 export function useScmFeatureMeta(): UseScmFeatureMetaResult {
   const organization = useOrganization();
-  const {data: billingConfig, isLoading} = useApiQuery<BillingConfig>(
-    [
-      getApiUrl('/customers/$organizationIdOrSlug/billing-config/', {
+  const {data: billingConfig, isLoading} = useQuery({
+    ...apiOptions.as<BillingConfig>()(
+      '/customers/$organizationIdOrSlug/billing-config/',
+      {
         path: {organizationIdOrSlug: organization.slug},
-      }),
-      {query: {tier: DEFAULT_TIER}},
-    ],
-    {staleTime: Infinity, retry: false}
-  );
+        query: {tier: DEFAULT_TIER},
+        staleTime: Infinity,
+      }
+    ),
+    retry: false,
+  });
 
   if (!billingConfig) {
     return {meta: FALLBACK_FEATURE_META, isLoading};

--- a/static/gsApp/hooks/useScmFeatureMeta.tsx
+++ b/static/gsApp/hooks/useScmFeatureMeta.tsx
@@ -7,6 +7,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   FALLBACK_FEATURE_META,
   type FeatureMeta,
+  type UseScmFeatureMetaResult,
 } from 'sentry/views/onboarding/components/useScmFeatureMeta';
 
 import {DEFAULT_TIER} from 'getsentry/constants';
@@ -15,63 +16,63 @@ import {formatReservedWithUnits} from 'getsentry/utils/billing';
 
 type DynamicCategoryFormat = {
   category: DataCategory;
-  formatTooltip: (formattedVolume: string) => string;
-  formatVolume: (events: number) => string;
+  formatQuantity: (events: number) => string;
+  formatTooltip: (quantity: string) => string;
+  formatVolume: (quantity: string) => string;
 };
 
-// Categories whose free-plan volume is sourced from billing-config. Profiling is
-// intentionally excluded — its free volume is 0 and the fallback "Usage-based" copy
-// is what we want to keep showing.
+// Categories whose free-plan volume is sourced from billing-config. PROFILING is
+// intentionally absent — its free-plan duration is 0 and the fallback "Usage-based"
+// copy is what we want to keep showing.
 const DYNAMIC_FORMATS: Partial<Record<ProductSolution, DynamicCategoryFormat>> = {
   [ProductSolution.ERROR_MONITORING]: {
     category: DataCategory.ERRORS,
-    formatVolume: events =>
-      t('%s errors / mo', formatReservedWithUnits(events, DataCategory.ERRORS)),
-    formatTooltip: volume =>
+    formatQuantity: events => formatReservedWithUnits(events, DataCategory.ERRORS),
+    formatVolume: quantity => t('%s errors / mo', quantity),
+    formatTooltip: quantity =>
       t(
-        'Free plan includes %s. Upgrade to Team or Business to send more.',
-        volume.replace(/ \/ mo$/, ' / month')
+        'Free plan includes %s errors / month. Upgrade to Team or Business to send more.',
+        quantity
       ),
   },
   [ProductSolution.PERFORMANCE_MONITORING]: {
     category: DataCategory.SPANS,
-    formatVolume: events =>
+    formatQuantity: events =>
+      formatReservedWithUnits(events, DataCategory.SPANS, {isAbbreviated: true}),
+    formatVolume: quantity => t('%s spans / mo', quantity),
+    formatTooltip: quantity =>
       t(
-        '%s spans / mo',
-        formatReservedWithUnits(events, DataCategory.SPANS, {isAbbreviated: true})
-      ),
-    formatTooltip: volume =>
-      t(
-        'Free plan includes %s. Upgrade to Team or Business to send more.',
-        volume.replace(/ \/ mo$/, ' / month')
+        'Free plan includes %s spans / month. Upgrade to Team or Business to send more.',
+        quantity
       ),
   },
   [ProductSolution.SESSION_REPLAY]: {
     category: DataCategory.REPLAYS,
-    formatVolume: events =>
-      t('%s replays / mo', formatReservedWithUnits(events, DataCategory.REPLAYS)),
-    formatTooltip: volume =>
+    formatQuantity: events => formatReservedWithUnits(events, DataCategory.REPLAYS),
+    formatVolume: quantity => t('%s replays / mo', quantity),
+    formatTooltip: quantity =>
       t(
-        'Free plan includes %s. Upgrade to Team or Business to send more.',
-        volume.replace(/ \/ mo$/, ' / month')
+        'Free plan includes %s replays / month. Upgrade to Team or Business to send more.',
+        quantity
       ),
   },
   [ProductSolution.LOGS]: {
     category: DataCategory.LOG_BYTE,
-    formatVolume: gigabytes =>
-      t('%s logs / mo', formatReservedWithUnits(gigabytes, DataCategory.LOG_BYTE)),
-    formatTooltip: volume =>
+    formatQuantity: gigabytes =>
+      formatReservedWithUnits(gigabytes, DataCategory.LOG_BYTE),
+    formatVolume: quantity => t('%s logs / mo', quantity),
+    formatTooltip: quantity =>
       t(
-        'Free plan includes %s. Upgrade to Team or Business to send more.',
-        volume.replace(/ \/ mo$/, ' / month')
+        'Free plan includes %s logs / month. Upgrade to Team or Business to send more.',
+        quantity
       ),
   },
   [ProductSolution.METRICS]: {
     category: DataCategory.TRACE_METRIC_BYTE,
-    formatVolume: gigabytes =>
-      t('%s / mo', formatReservedWithUnits(gigabytes, DataCategory.TRACE_METRIC_BYTE)),
-    formatTooltip: volume =>
-      t('Free plan includes %s metrics / month.', volume.replace(/ \/ mo$/, '')),
+    formatQuantity: gigabytes =>
+      formatReservedWithUnits(gigabytes, DataCategory.TRACE_METRIC_BYTE),
+    formatVolume: quantity => t('%s / mo', quantity),
+    formatTooltip: quantity => t('Free plan includes %s metrics / month.', quantity),
   },
 };
 
@@ -87,12 +88,12 @@ function getFreeVolume(plan: Plan, category: DataCategory): number | undefined {
 /**
  * gsApp implementation of `useScmFeatureMeta`. Sources free-plan volume strings
  * from the default-tier billing-config response so the SCM onboarding cards stay
- * aligned with the actual free-plan limits. Falls back to the OSS static copy
- * while the request is in flight or if it fails.
+ * aligned with the actual free-plan limits. Reports isLoading while the request
+ * is in flight, and falls back to the OSS static copy on error.
  */
-export function useScmFeatureMeta(): Record<ProductSolution, FeatureMeta> {
+export function useScmFeatureMeta(): UseScmFeatureMetaResult {
   const organization = useOrganization();
-  const {data: billingConfig} = useApiQuery<BillingConfig>(
+  const {data: billingConfig, isLoading} = useApiQuery<BillingConfig>(
     [
       getApiUrl('/customers/$organizationIdOrSlug/billing-config/', {
         path: {organizationIdOrSlug: organization.slug},
@@ -103,12 +104,12 @@ export function useScmFeatureMeta(): Record<ProductSolution, FeatureMeta> {
   );
 
   if (!billingConfig) {
-    return FALLBACK_FEATURE_META;
+    return {meta: FALLBACK_FEATURE_META, isLoading};
   }
 
   const freePlan = findFreePlan(billingConfig.planList, billingConfig.freePlan);
   if (!freePlan) {
-    return FALLBACK_FEATURE_META;
+    return {meta: FALLBACK_FEATURE_META, isLoading: false};
   }
 
   const meta: Record<ProductSolution, FeatureMeta> = {...FALLBACK_FEATURE_META};
@@ -121,13 +122,13 @@ export function useScmFeatureMeta(): Record<ProductSolution, FeatureMeta> {
     if (events === undefined || events <= 0) {
       continue;
     }
-    const volume = format.formatVolume(events);
+    const quantity = format.formatQuantity(events);
     meta[product] = {
       ...FALLBACK_FEATURE_META[product],
-      volume,
-      volumeTooltip: format.formatTooltip(volume),
+      volume: format.formatVolume(quantity),
+      volumeTooltip: format.formatTooltip(quantity),
     };
   }
 
-  return meta;
+  return {meta, isLoading: false};
 }

--- a/static/gsApp/hooks/useScmFeatureMeta.tsx
+++ b/static/gsApp/hooks/useScmFeatureMeta.tsx
@@ -1,0 +1,142 @@
+import {ProductSolution} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {t} from 'sentry/locale';
+import {DataCategory} from 'sentry/types/core';
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {useApiQuery} from 'sentry/utils/queryClient';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {
+  FALLBACK_FEATURE_META,
+  type FeatureMeta,
+} from 'sentry/views/onboarding/components/useScmFeatureMeta';
+
+import {UPSELL_TIER} from 'getsentry/constants';
+import {useSubscription} from 'getsentry/hooks/useSubscription';
+import {type BillingConfig, type Plan, PlanTier} from 'getsentry/types';
+import {formatReservedWithUnits} from 'getsentry/utils/billing';
+
+type DynamicCategoryFormat = {
+  category: DataCategory;
+  formatTooltip: (formattedVolume: string) => string;
+  formatVolume: (events: number) => string;
+};
+
+// Categories whose free-plan volume is sourced from billing-config. Profiling is
+// intentionally excluded — its free volume is 0 and the fallback "Usage-based" copy
+// is what we want to keep showing.
+const DYNAMIC_FORMATS: Partial<Record<ProductSolution, DynamicCategoryFormat>> = {
+  [ProductSolution.ERROR_MONITORING]: {
+    category: DataCategory.ERRORS,
+    formatVolume: events =>
+      t('%s errors / mo', formatReservedWithUnits(events, DataCategory.ERRORS)),
+    formatTooltip: volume =>
+      t(
+        'Free plan includes %s. Upgrade to Team or Business to send more.',
+        volume.replace(/ \/ mo$/, ' / month')
+      ),
+  },
+  [ProductSolution.PERFORMANCE_MONITORING]: {
+    category: DataCategory.SPANS,
+    formatVolume: events =>
+      t(
+        '%s spans / mo',
+        formatReservedWithUnits(events, DataCategory.SPANS, {isAbbreviated: true})
+      ),
+    formatTooltip: volume =>
+      t(
+        'Free plan includes %s. Upgrade to Team or Business to send more.',
+        volume.replace(/ \/ mo$/, ' / month')
+      ),
+  },
+  [ProductSolution.SESSION_REPLAY]: {
+    category: DataCategory.REPLAYS,
+    formatVolume: events =>
+      t('%s replays / mo', formatReservedWithUnits(events, DataCategory.REPLAYS)),
+    formatTooltip: volume =>
+      t(
+        'Free plan includes %s. Upgrade to Team or Business to send more.',
+        volume.replace(/ \/ mo$/, ' / month')
+      ),
+  },
+  [ProductSolution.LOGS]: {
+    category: DataCategory.LOG_BYTE,
+    formatVolume: gigabytes =>
+      t('%s logs / mo', formatReservedWithUnits(gigabytes, DataCategory.LOG_BYTE)),
+    formatTooltip: volume =>
+      t(
+        'Free plan includes %s. Upgrade to Team or Business to send more.',
+        volume.replace(/ \/ mo$/, ' / month')
+      ),
+  },
+  [ProductSolution.METRICS]: {
+    category: DataCategory.TRACE_METRIC_BYTE,
+    formatVolume: gigabytes =>
+      t('%s / mo', formatReservedWithUnits(gigabytes, DataCategory.TRACE_METRIC_BYTE)),
+    formatTooltip: volume =>
+      t('Free plan includes %s metrics / month.', volume.replace(/ \/ mo$/, '')),
+  },
+};
+
+function findFreePlan(planList: Plan[], freePlanId: string): Plan | undefined {
+  return planList.find(plan => plan.id === freePlanId);
+}
+
+function getFreeVolume(plan: Plan, category: DataCategory): number | undefined {
+  const buckets = plan.planCategories[category];
+  return buckets?.[0]?.events;
+}
+
+function getUpsellTier(planTier?: string, trialTier?: string | null) {
+  return planTier === PlanTier.AM3 || trialTier === PlanTier.AM3
+    ? PlanTier.AM3
+    : UPSELL_TIER;
+}
+
+/**
+ * gsApp implementation of `useScmFeatureMeta`. Sources free-plan volume strings
+ * from the active org's billing-config response so the SCM onboarding cards stay
+ * aligned with the actual free-plan limits. Falls back to the OSS static copy
+ * when the subscription store hasn't been hydrated or the request hasn't resolved.
+ */
+export function useScmFeatureMeta(): Record<ProductSolution, FeatureMeta> {
+  const organization = useOrganization();
+  const subscription = useSubscription();
+  const upsellTier = getUpsellTier(subscription?.planTier, subscription?.trialTier);
+  const {data: billingConfig} = useApiQuery<BillingConfig>(
+    [
+      getApiUrl('/customers/$organizationIdOrSlug/billing-config/', {
+        path: {organizationIdOrSlug: organization.slug},
+      }),
+      {query: {tier: upsellTier}},
+    ],
+    {staleTime: Infinity, enabled: !!subscription, retry: false}
+  );
+
+  if (!subscription || !billingConfig) {
+    return FALLBACK_FEATURE_META;
+  }
+
+  const freePlan = findFreePlan(billingConfig.planList, billingConfig.freePlan);
+  if (!freePlan) {
+    return FALLBACK_FEATURE_META;
+  }
+
+  const meta: Record<ProductSolution, FeatureMeta> = {...FALLBACK_FEATURE_META};
+  for (const [productKey, format] of Object.entries(DYNAMIC_FORMATS)) {
+    if (!format) {
+      continue;
+    }
+    const product = productKey as ProductSolution;
+    const events = getFreeVolume(freePlan, format.category);
+    if (events === undefined || events <= 0) {
+      continue;
+    }
+    const volume = format.formatVolume(events);
+    meta[product] = {
+      ...FALLBACK_FEATURE_META[product],
+      volume,
+      volumeTooltip: format.formatTooltip(volume),
+    };
+  }
+
+  return meta;
+}

--- a/static/gsApp/hooks/useScmFeatureMeta.tsx
+++ b/static/gsApp/hooks/useScmFeatureMeta.tsx
@@ -9,9 +9,8 @@ import {
   type FeatureMeta,
 } from 'sentry/views/onboarding/components/useScmFeatureMeta';
 
-import {UPSELL_TIER} from 'getsentry/constants';
-import {useSubscription} from 'getsentry/hooks/useSubscription';
-import {type BillingConfig, type Plan, PlanTier} from 'getsentry/types';
+import {DEFAULT_TIER} from 'getsentry/constants';
+import type {BillingConfig, Plan} from 'getsentry/types';
 import {formatReservedWithUnits} from 'getsentry/utils/billing';
 
 type DynamicCategoryFormat = {
@@ -85,33 +84,25 @@ function getFreeVolume(plan: Plan, category: DataCategory): number | undefined {
   return buckets?.[0]?.events;
 }
 
-function getUpsellTier(planTier?: string, trialTier?: string | null) {
-  return planTier === PlanTier.AM3 || trialTier === PlanTier.AM3
-    ? PlanTier.AM3
-    : UPSELL_TIER;
-}
-
 /**
  * gsApp implementation of `useScmFeatureMeta`. Sources free-plan volume strings
- * from the active org's billing-config response so the SCM onboarding cards stay
+ * from the default-tier billing-config response so the SCM onboarding cards stay
  * aligned with the actual free-plan limits. Falls back to the OSS static copy
- * when the subscription store hasn't been hydrated or the request hasn't resolved.
+ * while the request is in flight or if it fails.
  */
 export function useScmFeatureMeta(): Record<ProductSolution, FeatureMeta> {
   const organization = useOrganization();
-  const subscription = useSubscription();
-  const upsellTier = getUpsellTier(subscription?.planTier, subscription?.trialTier);
   const {data: billingConfig} = useApiQuery<BillingConfig>(
     [
       getApiUrl('/customers/$organizationIdOrSlug/billing-config/', {
         path: {organizationIdOrSlug: organization.slug},
       }),
-      {query: {tier: upsellTier}},
+      {query: {tier: DEFAULT_TIER}},
     ],
-    {staleTime: Infinity, enabled: !!subscription, retry: false}
+    {staleTime: Infinity, retry: false}
   );
 
-  if (!subscription || !billingConfig) {
+  if (!billingConfig) {
     return FALLBACK_FEATURE_META;
   }
 

--- a/static/gsApp/registerHooks.tsx
+++ b/static/gsApp/registerHooks.tsx
@@ -73,6 +73,7 @@ import {useDashboardDatasetRetentionLimit} from 'getsentry/hooks/useDashboardDat
 import {useExperiment} from 'getsentry/hooks/useExperiment';
 import {useMetricDetectorLimit} from 'getsentry/hooks/useMetricDetectorLimit';
 import {useProductBillingAccess} from 'getsentry/hooks/useProductBillingAccess';
+import {useScmFeatureMeta} from 'getsentry/hooks/useScmFeatureMeta';
 import {rawTrackAnalyticsEvent} from 'getsentry/utils/rawTrackAnalyticsEvent';
 import {trackMetric} from 'getsentry/utils/trackMetric';
 
@@ -259,6 +260,7 @@ const GETSENTRY_HOOKS: Partial<Hooks> = {
   'react-hook:use-dashboard-dataset-retention-limit': useDashboardDatasetRetentionLimit,
   'react-hook:use-experiment': useExperiment,
   'react-hook:use-product-billing-access': useProductBillingAccess,
+  'react-hook:use-scm-feature-meta': useScmFeatureMeta,
   'component:partnership-agreement': p => (
     <LazyLoad LazyComponent={PartnershipAgreement} {...p} />
   ),


### PR DESCRIPTION
## TL;DR

SCM onboarding cards now read free-plan volumes from billing-config instead of hardcoded copy. The lookup lives in a gsApp hook so OSS doesn't import getsentry; self-hosted falls back to the static volumes.

## What changes for users

No visible volume change today — the previously hardcoded volumes happened to match the production AM3 free plan. The SCM cards now read those volumes from billing-config, so any future free-plan adjustment (e.g. raising the free errors quota) propagates automatically without a frontend code change.

Self-hosted keeps the static fallback unchanged.

## Implementation

`useScmFeatureMeta` in OSS holds the type, `FALLBACK_FEATURE_META`, and a thin HookStore delegator. gsApp registers `react-hook:use-scm-feature-meta`, which queries `/customers/<slug>/billing-config/?tier=am3` and overrides volumes for errors, spans, replays, logs, and metrics. Profiling stays static (free-plan volume is 0, "Usage-based" copy is what we want).

## Stacked on

Builds on #114261 (`onboarding-tweaks`). Merge that first.

## Test plan

```
CI=true pnpm test static/app/views/onboarding/components/scmFeatureSelectionCards.spec.tsx static/gsApp/hooks/useScmFeatureMeta.spec.tsx
```