### PR TITLE
chore(processing_errors): Sample processing error analytic events at 100% for orgs younger than 30 days.

### DIFF
--- a/src/sentry/analytics/events/event_processing_error_recorded.py
+++ b/src/sentry/analytics/events/event_processing_error_recorded.py
@@ -9,6 +9,7 @@ class EventProcessingErrorRecorded(analytics.Event):
     group_id: int | None
     error_type: str
     platform: str | None
+    sample_rate: float
     name: str | None = None
     value: str | None = None
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -1116,39 +1116,42 @@ def _eventstream_insert_many(jobs: Sequence[Job]) -> None:
                 tags={"event_type": job["event"].data.get("type") or "null"},
             )
 
-        # Record processing errors to analytics at 1% sample rate
+        # Record processing errors to analytics. Sample at 100% for orgs <30 days old
+        # so new-customer cohorts are fully observable; 1% otherwise.
         processing_errors = job["data"].get("errors", [])
         event = job["event"]
-        if (
-            processing_errors
-            and features.has("organizations:processing-error-analytics", event.project.organization)
-            and random.random() < 0.01
+        if processing_errors and features.has(
+            "organizations:processing-error-analytics", event.project.organization
         ):
-            group_id = job["groups"][0].group.id if job["groups"] else None
-            for error in processing_errors:
-                try:
-                    error_type = error.get("type", "unknown")
-                    error_name = error.get("name")
-                    error_value = error.get("value")
-                    # Convert non-string values to JSON and truncate
-                    if error_value is not None:
-                        if not isinstance(error_value, str):
-                            error_value = orjson.dumps(error_value).decode()
-                        error_value = error_value[:256]
-                    analytics.record(
-                        EventProcessingErrorRecorded(
-                            organization_id=event.project.organization_id,
-                            project_id=event.project_id,
-                            event_id=event.event_id,
-                            group_id=group_id,
-                            error_type=error_type,
-                            platform=job["data"].get("platform"),
-                            name=error_name,
-                            value=error_value,
+            org_age = datetime.now(timezone.utc) - event.project.organization.date_added
+            sample_rate = 1.0 if org_age < timedelta(days=30) else 0.01
+            if random.random() < sample_rate:
+                group_id = job["groups"][0].group.id if job["groups"] else None
+                for error in processing_errors:
+                    try:
+                        error_type = error.get("type", "unknown")
+                        error_name = error.get("name")
+                        error_value = error.get("value")
+                        # Convert non-string values to JSON and truncate
+                        if error_value is not None:
+                            if not isinstance(error_value, str):
+                                error_value = orjson.dumps(error_value).decode()
+                            error_value = error_value[:256]
+                        analytics.record(
+                            EventProcessingErrorRecorded(
+                                organization_id=event.project.organization_id,
+                                project_id=event.project_id,
+                                event_id=event.event_id,
+                                group_id=group_id,
+                                error_type=error_type,
+                                platform=job["data"].get("platform"),
+                                sample_rate=sample_rate,
+                                name=error_name,
+                                value=error_value,
+                            )
                         )
-                    )
-                except Exception:
-                    logger.warning("Failed to save EventProcessingErrorRecorded", exc_info=True)
+                    except Exception:
+                        logger.warning("Failed to save EventProcessingErrorRecorded", exc_info=True)
 
         # XXX: Temporary hack so that we keep this group info working for error issues. We'll need
         # to change the format of eventstream to be able to handle data for multiple groups

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -4489,6 +4489,7 @@ class EventProcessingErrorAnalyticsTest(TestCase, SnubaTestCase):
                     group_id=event.group_id,
                     error_type="future_timestamp",
                     platform="python",
+                    sample_rate=1.0,
                     name="timestamp",
                     value=None,
                 ),
@@ -4496,10 +4497,53 @@ class EventProcessingErrorAnalyticsTest(TestCase, SnubaTestCase):
             assert recorded_events == expected_events
 
     @mock.patch("sentry.event_manager.random.random")
+    def test_processing_errors_recorded_at_one_percent_for_older_orgs(
+        self, mock_random: mock.MagicMock
+    ) -> None:
+        """Orgs older than 30 days record at 1% sample rate, surfaced on the analytics event."""
+        self.organization.date_added = timezone.now() - timedelta(days=60)
+        self.organization.save()
+        mock_random.return_value = 0.001
+        with (
+            self.feature("organizations:processing-error-analytics"),
+            mock.patch.object(analytics, "record", wraps=analytics.record) as spy_analytics_record,
+        ):
+            future = timezone.now() + timedelta(minutes=10)
+            event = self.store_event(
+                data=make_event(
+                    platform="python",
+                    timestamp=future.isoformat(),
+                ),
+                project_id=self.project.id,
+                assert_no_errors=False,
+            )
+            recorded_events = [
+                call[0][0]
+                for call in spy_analytics_record.call_args_list
+                if isinstance(call[0][0], EventProcessingErrorRecorded)
+            ]
+            assert recorded_events == [
+                EventProcessingErrorRecorded(
+                    organization_id=self.project.organization_id,
+                    project_id=self.project.id,
+                    event_id=event.event_id,
+                    group_id=event.group_id,
+                    error_type="future_timestamp",
+                    platform="python",
+                    sample_rate=0.01,
+                    name="timestamp",
+                    value=None,
+                ),
+            ]
+
+    @mock.patch("sentry.event_manager.random.random")
     def test_processing_errors_not_recorded_when_not_sampled(
         self, mock_random: mock.MagicMock
     ) -> None:
-        """Test that processing errors are not recorded when outside the 1% sample."""
+        """Test that processing errors are not recorded when the random draw is above the sample rate."""
+        # Age the org past the 30-day full-sample window so the rate is 1%, then 0.5 fails the check.
+        self.organization.date_added = timezone.now() - timedelta(days=60)
+        self.organization.save()
         mock_random.return_value = 0.5
         with (
             self.feature("organizations:processing-error-analytics"),


### PR DESCRIPTION
This sends processing error analytics events at a 100% sample rate for young orgs. This lets us analyze how often these are happening to new orgs more easily.
