### PR TITLE
fix: handle duplicate list values in resolve_top_event_conditions

### DIFF
--- a/src/sentry/search/events/builder/discover.py
+++ b/src/sentry/search/events/builder/discover.py
@@ -412,8 +412,9 @@ class TopEventsQueryBuilder(TimeseriesQueryBuilder):
 
                 # Note that because orderby shouldn't be an array field its not included in the values
                 event_value = event.get(alias)
-                if isinstance(event_value, list) and event_value not in array_values:
-                    array_values.append(event_value)
+                if isinstance(event_value, list):
+                    if event_value not in array_values:
+                        array_values.append(event_value)
                 else:
                     values.add(event_value)
             values_list = list(values) + array_values

--- a/tests/sentry/search/events/builder/test_discover.py
+++ b/tests/sentry/search/events/builder/test_discover.py
@@ -13,7 +13,7 @@ from snuba_sdk.orderby import Direction, LimitBy, OrderBy
 
 from sentry.exceptions import InvalidSearchQuery
 from sentry.search.events import constants
-from sentry.search.events.builder.discover import DiscoverQueryBuilder
+from sentry.search.events.builder.discover import DiscoverQueryBuilder, TopEventsQueryBuilder
 from sentry.search.events.types import ParamsType, QueryBuilderConfig
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
@@ -1054,3 +1054,35 @@ class DiscoverQueryBuilderTest(TestCase):
             ],
         )
         query.get_snql_query().validate()
+
+
+class TopEventsQueryBuilderTest(TestCase):
+    def setUp(self) -> None:
+        self.start = datetime.datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        self.end = self.start + datetime.timedelta(days=1)
+        self.projects = [self.project.id]
+        self.params: ParamsType = {
+            "project_id": self.projects,
+            "start": self.start,
+            "end": self.end,
+        }
+
+    @pytest.mark.querybuilder
+    def test_resolve_top_event_conditions_duplicate_list_values(self) -> None:
+        """Regression test: duplicate list values in top events must not raise TypeError."""
+        # When the same list value appears in multiple top-event rows, the old
+        # code fell into the `else` branch and called set.add() on a list,
+        # raising TypeError: unhashable type: 'list'.
+        top_events = [
+            {"tags[foo]": ["a", "b"]},
+            {"tags[foo]": ["a", "b"]},
+        ]
+        # Should not raise TypeError
+        builder = TopEventsQueryBuilder(
+            Dataset.Discover,
+            self.params,
+            interval=3600,
+            top_events=top_events,
+            selected_columns=["tags[foo]"],
+        )
+        assert builder is not None


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes `TypeError: unhashable type: 'list'` raised in `resolve_top_event_conditions` (SENTRY-49E6), hitting 259 events from 9 users via the events-stats CLI endpoint.

## Root Cause

In `TopEventsQueryBuilder.resolve_top_event_conditions` (`src/sentry/search/events/builder/discover.py`), the loop over top events classifies each field value as either an array value or a hashable scalar:

```python
# Before (buggy)
if isinstance(event_value, list) and event_value not in array_values:
    array_values.append(event_value)
else:
    values.add(event_value)   # reached when event_value is a DUPLICATE list
```

When the same list value appears in two or more top-event rows, the combined condition `isinstance(event_value, list) and event_value not in array_values` evaluates to `True and False = False`, causing the `else` branch to execute `set.add(list)` — which raises `TypeError: unhashable type: 'list'`.

## Fix

Nest the duplicate-check inside the `isinstance` branch so the `else` branch is only reachable for non-list (hashable) values:

```python
# After (fixed)
if isinstance(event_value, list):
    if event_value not in array_values:
        array_values.append(event_value)
else:
    values.add(event_value)
```

## Testing

- Added a regression test `TopEventsQueryBuilderTest.test_resolve_top_event_conditions_duplicate_list_values` that directly reproduces the crash with two top-event rows sharing the same list value.
- Verified locally with a standalone script that: the old code raises `TypeError`, the new code returns `[['a', 'b']]` correctly.
- All pre-commit hooks (ruff, flake8, mypy) pass cleanly.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sentry.slack.com/archives/CUHS29QJ0/p1777485083136849?thread_ts=1777485083.136849&cid=CUHS29QJ0)

<div><a href="https://cursor.com/agents/bc-783c89e7-9792-587c-a869-080153018985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-783c89e7-9792-587c-a869-080153018985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



Fixes SENTRY-49E6