### PR TITLE
feat(seer): Tag night_shift.triage_action with fixability threshold

### DIFF
--- a/src/sentry/tasks/seer/night_shift/agentic_triage.py
+++ b/src/sentry/tasks/seer/night_shift/agentic_triage.py
@@ -157,6 +157,34 @@ def _triage_candidates(
         },
     )
 
+    unknown_group_ids = [
+        v.group_id for v in triage_response.verdicts if v.group_id not in groups_by_id
+    ]
+    if unknown_group_ids:
+        logger.warning(
+            "night_shift.triage_unknown_group_ids",
+            extra={
+                "organization_id": organization.id,
+                "agent_run_id": agent_run_id,
+                "unknown_group_ids": unknown_group_ids,
+            },
+        )
+
+    fixability_by_group_id = {c.group.id: c.fixability for c in candidates}
+    for v in triage_response.verdicts:
+        if v.group_id not in fixability_by_group_id:
+            continue
+        sentry_sdk.metrics.count(
+            "night_shift.triage_action",
+            1,
+            attributes={
+                "action": v.action,
+                "threshold_action": TriageAction.from_fixability_score(
+                    fixability_by_group_id[v.group_id]
+                ),
+            },
+        )
+
     return [
         TriageResult(group=groups_by_id[v.group_id], action=v.action, reason=v.reason)
         for v in triage_response.verdicts

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import dataclasses
 import logging
 import time
-from collections import Counter
 from collections.abc import Mapping, Sequence
 from datetime import timedelta
 from typing import Any, Literal, TypedDict
@@ -265,9 +264,6 @@ def run_night_shift_execution(
         return None
 
     sentry_sdk.metrics.distribution("night_shift.candidates_selected", len(candidates))
-    action_counts = Counter(c.action for c in candidates)
-    for action, count in action_counts.items():
-        sentry_sdk.metrics.count("night_shift.triage_action", count, attributes={"action": action})
     sentry_sdk.metrics.distribution("night_shift.org_run_duration", time.monotonic() - start_time)
 
     seer_run_id_by_group: dict[int, str | None] = {}

--- a/src/sentry/tasks/seer/night_shift/models.py
+++ b/src/sentry/tasks/seer/night_shift/models.py
@@ -4,12 +4,24 @@ import enum
 from dataclasses import dataclass
 
 from sentry.models.group import Group
+from sentry.seer.autofix.constants import FixabilityScoreThresholds
 
 
 class TriageAction(enum.StrEnum):
     AUTOFIX = "autofix"
     ROOT_CAUSE_ONLY = "root_cause_only"
     SKIP = "skip"
+
+    @classmethod
+    def from_fixability_score(cls, score: float) -> TriageAction:
+        """3-way collapse of the fixability stopping-point thresholds (see
+        `_get_stopping_point_from_fixability`), so a fixability score can be
+        compared against an agent verdict on equal footing."""
+        if score < FixabilityScoreThresholds.MEDIUM.value:
+            return cls.SKIP
+        if score < FixabilityScoreThresholds.HIGH.value:
+            return cls.ROOT_CAUSE_ONLY
+        return cls.AUTOFIX
 
 
 @dataclass

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -15,6 +15,7 @@ from sentry.tasks.seer.night_shift.cron import (
     run_night_shift_for_org,
     schedule_night_shift,
 )
+from sentry.tasks.seer.night_shift.models import TriageAction
 from sentry.tasks.seer.night_shift.simple_triage import fixability_score_strategy
 from sentry.testutils.cases import SnubaTestCase, TestCase
 from sentry.testutils.helpers.datetime import before_now
@@ -691,3 +692,17 @@ class TestFixabilityScoreStrategy(TestCase, SnubaTestCase):
         assert result[0].times_seen == 5
         assert result[0].severity == 1.0
         assert result[1].group.id == low.id
+
+
+class TestTriageActionFromFixabilityScore:
+    def test_bucket_boundaries(self) -> None:
+        cases = [
+            (0.0, TriageAction.SKIP),
+            (0.39, TriageAction.SKIP),
+            (0.40, TriageAction.ROOT_CAUSE_ONLY),
+            (0.65, TriageAction.ROOT_CAUSE_ONLY),
+            (0.66, TriageAction.AUTOFIX),
+            (0.95, TriageAction.AUTOFIX),
+        ]
+        for score, expected in cases:
+            assert TriageAction.from_fixability_score(score) == expected


### PR DESCRIPTION
Adds a `threshold_action` tag alongside the existing `action` tag on `night_shift.triage_action`, so we can chart how often the agent's verdict agrees with what the standard fixability-score threshold (`_get_stopping_point_from_fixability`, 3-way collapsed via the new `TriageAction.from_fixability_score`) would have picked.

Emission moves from `cron.py` to `agentic_triage.py` so we have per-candidate fixability in scope, and SKIP verdicts (previously dropped by the post-filter `candidates` list) are now captured too.

Also logs `night_shift.triage_unknown_group_ids` when the agent returns a verdict for a group we didn't send it — previously silently dropped.