### PR TITLE
fix(cmdk): Keep command palette open on shift+click navigation

### DIFF
--- a/static/app/components/commandPalette/ui/commandPalette.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.tsx
@@ -471,13 +471,17 @@ export function CommandPalette({
       }
 
       analytics.recordAction(action, resultIndex, '');
-      dispatch({type: 'trigger action'});
 
-      // Close the palette before running the action. ModalStore is a single-slot
-      // system: calling openModal() inside onAction would replace the palette's
-      // renderer, and a closeModal() call afterwards would immediately close the
-      // newly opened modal instead of the palette.
-      closeModal?.();
+      const openInNewTab = options?.modifierKeys?.shiftKey && 'to' in action;
+
+      if (!openInNewTab) {
+        dispatch({type: 'trigger action'});
+        // Close the palette before running the action. ModalStore is a single-slot
+        // system: calling openModal() inside onAction would replace the palette's
+        // renderer, and a closeModal() call afterwards would immediately close the
+        // newly opened modal instead of the palette.
+        closeModal?.();
+      }
 
       if ('to' in action) {
         const normalizedTo = normalizeUrl(action.to);


### PR DESCRIPTION
When a user shift+clicks or shift+enters a link in the command palette, the link opens in a new tab but the palette now stays open. This lets users open multiple results without re-opening and re-searching the palette.

Previously, `closeModal()` and `dispatch({type: 'trigger action'})` ran unconditionally for all leaf action selections. Now these are skipped when the user holds shift on a link action, since the intent is to keep browsing results.