### PR TITLE
feat(ai): Add output messages field renderer

### DIFF
--- a/static/app/utils/discover/fieldRenderers.spec.tsx
+++ b/static/app/utils/discover/fieldRenderers.spec.tsx
@@ -11,6 +11,7 @@ import {EventView} from 'sentry/utils/discover/eventView';
 import {getFieldRenderer} from 'sentry/utils/discover/fieldRenderers';
 import {SPAN_OP_RELATIVE_BREAKDOWN_FIELD} from 'sentry/utils/discover/fields';
 import {WidgetType, type DashboardFilters} from 'sentry/views/dashboards/types';
+import {SpanFields} from 'sentry/views/insights/types';
 
 const theme = ThemeFixture();
 
@@ -99,6 +100,38 @@ describe('getFieldRenderer', () => {
     );
 
     expect(screen.getByText('(empty string)')).toBeInTheDocument();
+  });
+
+  it('renders gen_ai.output.messages assistant content', () => {
+    const renderer = getFieldRenderer(
+      SpanFields.GEN_AI_OUTPUT_MESSAGES,
+      {[SpanFields.GEN_AI_OUTPUT_MESSAGES]: 'string'},
+      false
+    );
+    data[SpanFields.GEN_AI_OUTPUT_MESSAGES] = JSON.stringify([
+      {role: 'assistant', content: 'Output response'},
+    ]);
+
+    render(
+      renderer(data, {location, organization, theme}) as React.ReactElement<any, any>
+    );
+
+    expect(screen.getByText('Output response')).toBeInTheDocument();
+  });
+
+  it('renders empty gen_ai.output.messages values as no value', () => {
+    const renderer = getFieldRenderer(
+      SpanFields.GEN_AI_OUTPUT_MESSAGES,
+      {[SpanFields.GEN_AI_OUTPUT_MESSAGES]: 'string'},
+      false
+    );
+    data[SpanFields.GEN_AI_OUTPUT_MESSAGES] = '';
+
+    render(
+      renderer(data, {location, organization, theme}) as React.ReactElement<any, any>
+    );
+
+    expect(screen.getByText('(no value)')).toBeInTheDocument();
   });
 
   it('can render boolean fields', () => {

--- a/static/app/utils/discover/fieldRenderers.tsx
+++ b/static/app/utils/discover/fieldRenderers.tsx
@@ -78,6 +78,7 @@ import {SpanDescriptionCell} from 'sentry/views/insights/common/components/table
 import {StarredSegmentCell} from 'sentry/views/insights/common/components/tableCells/starredSegmentCell';
 import {TimeSpentCell} from 'sentry/views/insights/common/components/tableCells/timeSpentCell';
 import {ModelName} from 'sentry/views/insights/pages/agents/components/modelName';
+import {extractAssistantOutput} from 'sentry/views/insights/pages/agents/utils/aiMessageNormalizer';
 import {ModuleName, SpanFields} from 'sentry/views/insights/types';
 import {
   filterToLocationQuery,
@@ -426,6 +427,27 @@ const RightAlignedContainer = styled('span')`
   display: block;
   text-align: right;
 `;
+
+function renderAIOutputMessages(rawOutputMessages: unknown) {
+  if (!rawOutputMessages) {
+    return <Container>{emptyValue}</Container>;
+  }
+
+  const raw =
+    typeof rawOutputMessages === 'string'
+      ? rawOutputMessages
+      : JSON.stringify(rawOutputMessages);
+  if (!raw) {
+    return <Container>{emptyValue}</Container>;
+  }
+
+  const {responseText, responseObject, toolCalls} = extractAssistantOutput(raw, {
+    defaultRole: 'assistant',
+  });
+  const output = responseText ?? responseObject ?? toolCalls ?? raw;
+
+  return <Container>{output}</Container>;
+}
 
 /**
  * "Special fields" either do not map 1:1 to an single column in the event database,
@@ -1047,6 +1069,10 @@ const SPECIAL_FIELDS: Record<string, SpecialField> = {
 
       return <ModelName modelId={data[SpanFields.GEN_AI_RESPONSE_MODEL]} />;
     },
+  },
+  [SpanFields.GEN_AI_OUTPUT_MESSAGES]: {
+    sortField: SpanFields.GEN_AI_OUTPUT_MESSAGES,
+    renderFunc: data => renderAIOutputMessages(data[SpanFields.GEN_AI_OUTPUT_MESSAGES]),
   },
 };
 


### PR DESCRIPTION
Add a custom field renderer for `gen_ai.output.messages` so Explore and dashboard cells show extracted assistant output instead of the raw message envelope. The renderer keeps the output in the standard Discover field container without custom tooltip or styling.

Before:
<img width="880" height="495" alt="CleanShot 2026-04-30 at 12 02 30" src="https://github.com/user-attachments/assets/a23b5433-1e04-4d7c-8939-79ce5c02fc43" />

After:
<img width="881" height="496" alt="CleanShot 2026-04-30 at 12 02 59" src="https://github.com/user-attachments/assets/64e0ddd1-af39-4c9e-a1e9-478c416156ba" />


Closes TET-2267