### PR TITLE
feat(preprod): Add size status check rules API

### DIFF
--- a/src/sentry/apidocs/examples/preprod_examples.py
+++ b/src/sentry/apidocs/examples/preprod_examples.py
@@ -228,6 +228,34 @@ class PreprodExamples:
         "currentArtifact": EXAMPLE_BUILD_SUMMARY,
     }
 
+    EXAMPLE_SIZE_STATUS_CHECK_RULES = {
+        "enabled": True,
+        "rules": [
+            {
+                "id": "rule-1",
+                "metric": "install_size",
+                "measurement": "absolute_diff",
+                "value": "5000000",
+                "filterQuery": "app_id:com.example.app platform_name:apple build_configuration_name:Release",
+                "filters": [
+                    {
+                        "key": "app_id",
+                        "conditions": [{"operator": "equals", "values": ["com.example.app"]}],
+                    },
+                    {
+                        "key": "platform_name",
+                        "conditions": [{"operator": "equals", "values": ["apple"]}],
+                    },
+                    {
+                        "key": "build_configuration_name",
+                        "conditions": [{"operator": "equals", "values": ["Release"]}],
+                    },
+                ],
+                "artifactType": "main_artifact",
+            }
+        ],
+    }
+
     GET_LATEST_BUILD = [
         OpenApiExample(
             "Latest Build Only",
@@ -271,6 +299,15 @@ class PreprodExamples:
         OpenApiExample(
             "Completed Analysis with Comparison",
             value=EXAMPLE_SIZE_ANALYSIS_COMPLETED_WITH_COMPARISON,
+            status_codes=["200"],
+            response_only=True,
+        ),
+    ]
+
+    GET_SIZE_STATUS_CHECK_RULES = [
+        OpenApiExample(
+            "Configured Size Analysis Status Check Rules",
+            value=EXAMPLE_SIZE_STATUS_CHECK_RULES,
             status_codes=["200"],
             response_only=True,
         ),

--- a/src/sentry/preprod/api/endpoints/public/project_preprod_size_analysis_status_check_rules.py
+++ b/src/sentry/preprod/api/endpoints/public/project_preprod_size_analysis_status_check_rules.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from drf_spectacular.utils import extend_schema
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import cell_silo_endpoint
+from sentry.api.bases.project import ProjectEndpoint, ProjectPermission
+from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
+from sentry.apidocs.examples.preprod_examples import PreprodExamples
+from sentry.apidocs.parameters import GlobalParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.models.project import Project
+from sentry.preprod.api.models.public.size_status_check_rules import (
+    ProjectSizeStatusCheckRulesResponseDict,
+    create_project_status_check_rules_response,
+)
+from sentry.ratelimits.config import RateLimitConfig
+from sentry.types.ratelimit import RateLimit, RateLimitCategory
+
+
+@extend_schema(tags=["Mobile Builds"])
+@cell_silo_endpoint
+class ProjectPreprodSizeAnalysisStatusCheckRulesEndpoint(ProjectEndpoint):
+    owner = ApiOwner.EMERGE_TOOLS
+    publish_status = {
+        "GET": ApiPublishStatus.PUBLIC,
+    }
+    permission_classes = (ProjectPermission,)
+    rate_limits = RateLimitConfig(
+        limit_overrides={
+            "GET": {
+                RateLimitCategory.ORGANIZATION: RateLimit(limit=100, window=60),
+            }
+        }
+    )
+
+    @extend_schema(
+        operation_id="Retrieve Size Analysis status check rules for a project",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            GlobalParams.PROJECT_ID_OR_SLUG,
+        ],
+        request=None,
+        responses={
+            200: inline_sentry_response_serializer(
+                "ProjectSizeStatusCheckRulesResponse",
+                ProjectSizeStatusCheckRulesResponseDict,
+            ),
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+        examples=PreprodExamples.GET_SIZE_STATUS_CHECK_RULES,
+    )
+    def get(self, request: Request, project: Project) -> Response:
+        """
+        Retrieve the current Size Analysis status check rules configured for a project.
+
+        The response includes whether Sentry status check enforcement is enabled and the
+        normalized rule list Sentry uses when evaluating Size Analysis thresholds.
+        """
+        return Response(create_project_status_check_rules_response(project))

--- a/src/sentry/preprod/api/endpoints/public/project_preprod_size_analysis_status_check_rules.py
+++ b/src/sentry/preprod/api/endpoints/public/project_preprod_size_analysis_status_check_rules.py
@@ -55,10 +55,64 @@ class ProjectPreprodSizeAnalysisStatusCheckRulesEndpoint(ProjectEndpoint):
         examples=PreprodExamples.GET_SIZE_STATUS_CHECK_RULES,
     )
     def get(self, request: Request, project: Project) -> Response:
-        """
+        r"""
         Retrieve the current Size Analysis status check rules configured for a project.
 
-        The response includes whether Sentry status check enforcement is enabled and the
+        Use this endpoint after receiving a `size_analysis.completed` webhook when you
+        want external CI to evaluate the same Size Analysis status check thresholds that
+        Sentry uses. The endpoint returns the current project configuration, not a
+        historical snapshot from when the webhook was emitted.
+
+        The response includes whether status check enforcement is enabled and the
         normalized rule list Sentry uses when evaluating Size Analysis thresholds.
+
+        This endpoint requires a bearer token with `project:read` access. Project
+        distribution tokens are not supported.
+
+        Response notes:
+
+        - `enabled: false` means status-check enforcement is disabled for the project.
+        - `rules: []` means there are no configured thresholds to evaluate.
+        - `value` is returned as a string. For `absolute` and `absolute_diff`
+          measurements it is a byte value; for `relative_diff` it is a percentage.
+        - `filterQuery` is the original configured filter string.
+        - `filters` is the machine-readable version of `filterQuery`.
+        - `filters: []` means the rule has no filters and applies to all builds.
+        - `filters: null` means the saved filter query could not be parsed; Sentry's
+          status check trigger treats that rule as non-matching.
+
+        Rule evaluation semantics:
+
+        - Threshold comparisons are strict: a rule triggers only when the computed value
+          is greater than the configured threshold, not greater than or equal to it.
+        - `absolute_diff` and `relative_diff` require a matching base metric/build.
+        - `relative_diff` does not trigger when the base size is zero.
+        - `artifactType` identifies the artifact scope the rule evaluates.
+          `main_artifact`, `watch_artifact`, `android_dynamic_feature_artifact`,
+          and `app_clip_artifact` target their matching artifact metric.
+          `all_artifacts` evaluates all available artifact metrics.
+        - Rule filters support the keys `app_id`, `git_head_ref`,
+          `build_configuration_name`, and `platform_name`.
+        - Filter objects are combined with AND. Multiple `conditions` inside one
+          filter object are combined with OR.
+        - Each condition uses `values`; single-value operators still return a
+          one-item array.
+        - Values in `filters` are decoded literal values for exact/simple operators,
+          not query syntax. For example, `app_id:\*com` in `filterQuery` becomes
+          `values: ["*com"]` with `operator: "equals"`.
+        - The same key can appear in more than one filter object when positive and
+          negative conditions both exist; those filter objects are still combined with
+          AND.
+        - Supported filter operators are `equals`, `notEquals`, `in`, `notIn`,
+          `contains`, `notContains`, `startsWith`, `notStartsWith`, `endsWith`,
+          `notEndsWith`, `matches`, and `notMatches`.
+        - `matches` and `notMatches` values use Sentry wildcard pattern syntax, not
+          regular expressions. `*` matches zero or more characters, escaped `\*`
+          matches a literal asterisk, and a pattern without `*` is an exact match.
+        - `in` and `notIn` are evaluated as one condition against all values, matching
+          Sentry's status check trigger behavior.
+        - A rule applies only when the build metadata matches all filters. If a
+          referenced metadata key is missing, the filter does not match, even for
+          negated operators.
         """
         return Response(create_project_status_check_rules_response(project))

--- a/src/sentry/preprod/api/endpoints/urls.py
+++ b/src/sentry/preprod/api/endpoints/urls.py
@@ -56,6 +56,9 @@ from .public.organization_preprod_size_analysis import OrganizationPreprodPublic
 from .public.project_preprod_build_distribution_latest import (
     ProjectPreprodBuildDistributionLatestEndpoint,
 )
+from .public.project_preprod_size_analysis_status_check_rules import (
+    ProjectPreprodSizeAnalysisStatusCheckRulesEndpoint,
+)
 from .pull_request.organization_pullrequest_comments import OrganizationPrCommentsEndpoint
 from .pull_request.organization_pullrequest_details import OrganizationPullRequestDetailsEndpoint
 from .pull_request.organization_pullrequest_size_analysis_download import (
@@ -109,6 +112,11 @@ preprod_project_urlpatterns = [
         r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/preprodartifacts/build-distribution/latest/$",
         ProjectPreprodBuildDistributionLatestEndpoint.as_view(),
         name="sentry-api-0-project-preprod-public-builds",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/(?P<project_id_or_slug>[^/]+)/preprod/size-analysis/status-check-rules/$",
+        ProjectPreprodSizeAnalysisStatusCheckRulesEndpoint.as_view(),
+        name="sentry-api-0-project-preprod-size-analysis-status-check-rules",
     ),
 ]
 

--- a/src/sentry/preprod/api/models/public/size_status_check_rules.py
+++ b/src/sentry/preprod/api/models/public/size_status_check_rules.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+from typing import Literal, TypedDict, cast, get_args
+
+from sentry.api.event_search import SearchFilter, SearchValue, parse_search_query
+from sentry.exceptions import InvalidSearchQuery
+from sentry.models.project import Project
+from sentry.preprod.vcs.status_checks.size.rules import (
+    PREPROD_ARTIFACT_SEARCH_CONFIG,
+    STATUS_CHECK_FILTER_OPERATOR_NEGATIONS,
+    get_status_check_rules,
+    get_status_checks_enabled,
+)
+from sentry.preprod.vcs.status_checks.size.types import RuleArtifactType, StatusCheckRule
+
+SizeStatusCheckRuleMetric = Literal["install_size", "download_size"]
+SizeStatusCheckRuleMeasurement = Literal["absolute", "absolute_diff", "relative_diff"]
+SizeStatusCheckRuleArtifactType = Literal[
+    "main_artifact",
+    "watch_artifact",
+    "android_dynamic_feature_artifact",
+    "app_clip_artifact",
+    "all_artifacts",
+]
+SizeStatusCheckRuleFilterKey = Literal[
+    "app_id",
+    "build_configuration_name",
+    "git_head_ref",
+    "platform_name",
+]
+SizeStatusCheckRuleFilterOperator = Literal[
+    "contains",
+    "endsWith",
+    "equals",
+    "in",
+    "matches",
+    "notContains",
+    "notEndsWith",
+    "notEquals",
+    "notIn",
+    "notMatches",
+    "notStartsWith",
+    "startsWith",
+]
+
+
+class SizeStatusCheckRuleFilterConditionResponseDict(TypedDict):
+    operator: SizeStatusCheckRuleFilterOperator
+    values: list[str]
+
+
+class SizeStatusCheckRuleFilterResponseDict(TypedDict):
+    key: SizeStatusCheckRuleFilterKey
+    conditions: list[SizeStatusCheckRuleFilterConditionResponseDict]
+
+
+class SizeStatusCheckRuleResponseDict(TypedDict):
+    id: str
+    metric: SizeStatusCheckRuleMetric
+    measurement: SizeStatusCheckRuleMeasurement
+    value: str
+    filterQuery: str
+    filters: list[SizeStatusCheckRuleFilterResponseDict] | None
+    artifactType: SizeStatusCheckRuleArtifactType
+
+
+class ProjectSizeStatusCheckRulesResponseDict(TypedDict):
+    enabled: bool
+    rules: list[SizeStatusCheckRuleResponseDict]
+
+
+def _format_rule_value(value: float) -> str:
+    if value.is_integer():
+        return str(int(value))
+    return str(value)
+
+
+def _is_public_status_check_rule(rule: StatusCheckRule) -> bool:
+    return rule.metric in get_args(SizeStatusCheckRuleMetric) and rule.measurement in get_args(
+        SizeStatusCheckRuleMeasurement
+    )
+
+
+def _negate_operator(
+    operator: SizeStatusCheckRuleFilterOperator,
+) -> SizeStatusCheckRuleFilterOperator:
+    return cast(
+        SizeStatusCheckRuleFilterOperator,
+        STATUS_CHECK_FILTER_OPERATOR_NEGATIONS.get(operator, operator),
+    )
+
+
+def _format_filter_value(raw_value: object) -> str:
+    return str(SearchValue(str(raw_value)).value)
+
+
+def _operator_and_values(
+    search_value: SearchValue, is_negation: bool
+) -> tuple[SizeStatusCheckRuleFilterOperator, list[str]]:
+    if not search_value.is_wildcard():
+        operator: SizeStatusCheckRuleFilterOperator = "equals"
+        values = [str(search_value.value)]
+    else:
+        value = str(search_value.raw_value)
+        if value.startswith("*") and value.endswith("*") and len(value) >= 2:
+            operator = "contains"
+            values = [_format_filter_value(value[1:-1])]
+        elif value.startswith("*"):
+            operator = "endsWith"
+            values = [_format_filter_value(value[1:])]
+        elif value.endswith("*"):
+            operator = "startsWith"
+            values = [_format_filter_value(value[:-1])]
+        else:
+            operator = "matches"
+            values = [str(search_value.value)]
+
+    if is_negation:
+        operator = _negate_operator(operator)
+
+    return operator, values
+
+
+def _raw_filter_values(search_filter: SearchFilter) -> list[object]:
+    if isinstance(search_filter.value.raw_value, (list, tuple)):
+        return list(search_filter.value.raw_value)
+    return [search_filter.value.raw_value]
+
+
+def _condition_from_search_filter(
+    search_filter: SearchFilter,
+) -> SizeStatusCheckRuleFilterConditionResponseDict:
+    if search_filter.is_in_filter:
+        if search_filter.value.is_wildcard():
+            operator: SizeStatusCheckRuleFilterOperator = "matches"
+            if search_filter.is_negation:
+                operator = _negate_operator(operator)
+            return {"operator": operator, "values": [str(search_filter.value.value)]}
+
+        operator = "notIn" if search_filter.is_negation else "in"
+        values = [
+            _format_filter_value(raw_value) for raw_value in _raw_filter_values(search_filter)
+        ]
+        return {"operator": operator, "values": values}
+
+    operator, values = _operator_and_values(search_filter.value, search_filter.is_negation)
+    return {"operator": operator, "values": values}
+
+
+def create_filters(filter_query: str) -> list[SizeStatusCheckRuleFilterResponseDict] | None:
+    if not filter_query or not filter_query.strip():
+        return []
+
+    try:
+        search_filters = [
+            search_filter
+            for search_filter in parse_search_query(
+                filter_query, config=PREPROD_ARTIFACT_SEARCH_CONFIG
+            )
+            if isinstance(search_filter, SearchFilter)
+        ]
+    except InvalidSearchQuery:
+        return None
+
+    filters: dict[str, SizeStatusCheckRuleFilterResponseDict] = {}
+    for search_filter in search_filters:
+        filter_key = search_filter.key.name
+        group_key = f"{filter_key}:{'negated' if search_filter.is_negation else 'normal'}"
+        if group_key not in filters:
+            filters[group_key] = {
+                "key": cast(SizeStatusCheckRuleFilterKey, filter_key),
+                "conditions": [],
+            }
+
+        filters[group_key]["conditions"].append(_condition_from_search_filter(search_filter))
+
+    return list(filters.values())
+
+
+def create_status_check_rule_dict(rule: StatusCheckRule) -> SizeStatusCheckRuleResponseDict:
+    artifact_type = rule.artifact_type or RuleArtifactType.MAIN_ARTIFACT
+    return {
+        "id": rule.id,
+        "metric": cast(SizeStatusCheckRuleMetric, rule.metric),
+        "measurement": cast(SizeStatusCheckRuleMeasurement, rule.measurement),
+        "value": _format_rule_value(rule.value),
+        "filterQuery": rule.filter_query,
+        "filters": create_filters(rule.filter_query),
+        "artifactType": cast(SizeStatusCheckRuleArtifactType, artifact_type.value),
+    }
+
+
+def create_project_status_check_rules_response(
+    project: Project,
+) -> ProjectSizeStatusCheckRulesResponseDict:
+    return {
+        "enabled": get_status_checks_enabled(project),
+        "rules": [
+            create_status_check_rule_dict(rule)
+            for rule in get_status_check_rules(project)
+            if _is_public_status_check_rule(rule)
+        ],
+    }

--- a/src/sentry/preprod/api/models/public/size_status_check_rules.py
+++ b/src/sentry/preprod/api/models/public/size_status_check_rules.py
@@ -186,7 +186,7 @@ def create_status_check_rule_dict(rule: StatusCheckRule) -> SizeStatusCheckRuleR
         "value": _format_rule_value(rule.value),
         "filterQuery": rule.filter_query,
         "filters": create_filters(rule.filter_query),
-        "artifactType": cast(SizeStatusCheckRuleArtifactType, artifact_type.value),
+        "artifactType": artifact_type.value,
     }
 
 

--- a/src/sentry/preprod/api/models/public/size_status_check_rules.py
+++ b/src/sentry/preprod/api/models/public/size_status_check_rules.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 from typing import Literal, TypedDict, cast, get_args
 
-from sentry.api.event_search import SearchFilter, SearchValue, parse_search_query
+from sentry.api.event_search import (
+    WILDCARD_CHARS,
+    SearchFilter,
+    SearchValue,
+    parse_search_query,
+    translate_escape_sequences,
+)
 from sentry.exceptions import InvalidSearchQuery
 from sentry.models.project import Project
 from sentry.preprod.vcs.status_checks.size.rules import (
@@ -91,7 +97,11 @@ def _negate_operator(
 
 
 def _format_filter_value(raw_value: object) -> str:
-    return str(SearchValue(str(raw_value)).value)
+    return translate_escape_sequences(str(raw_value))
+
+
+def _wildcard_positions(value: str) -> list[int]:
+    return [match.end() - 1 for match in WILDCARD_CHARS.finditer(value)]
 
 
 def _operator_and_values(
@@ -99,21 +109,22 @@ def _operator_and_values(
 ) -> tuple[SizeStatusCheckRuleFilterOperator, list[str]]:
     if not search_value.is_wildcard():
         operator: SizeStatusCheckRuleFilterOperator = "equals"
-        values = [str(search_value.value)]
+        values = [_format_filter_value(search_value.raw_value)]
     else:
         value = str(search_value.raw_value)
-        if value.startswith("*") and value.endswith("*") and len(value) >= 2:
+        wildcard_positions = _wildcard_positions(value)
+        if wildcard_positions == [0, len(value) - 1] and len(value) > 2:
             operator = "contains"
             values = [_format_filter_value(value[1:-1])]
-        elif value.startswith("*"):
+        elif wildcard_positions == [0] and len(value) > 1:
             operator = "endsWith"
             values = [_format_filter_value(value[1:])]
-        elif value.endswith("*"):
+        elif wildcard_positions == [len(value) - 1] and len(value) > 1:
             operator = "startsWith"
             values = [_format_filter_value(value[:-1])]
         else:
             operator = "matches"
-            values = [str(search_value.value)]
+            values = [value]
 
     if is_negation:
         operator = _negate_operator(operator)
@@ -135,7 +146,10 @@ def _condition_from_search_filter(
             operator: SizeStatusCheckRuleFilterOperator = "matches"
             if search_filter.is_negation:
                 operator = _negate_operator(operator)
-            return {"operator": operator, "values": [str(search_filter.value.value)]}
+            return {
+                "operator": operator,
+                "values": [str(raw_value) for raw_value in _raw_filter_values(search_filter)],
+            }
 
         operator = "notIn" if search_filter.is_negation else "in"
         values = [

--- a/src/sentry/preprod/vcs/status_checks/size/rules.py
+++ b/src/sentry/preprod/vcs/status_checks/size/rules.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Literal
+
+from sentry.api.event_search import SearchConfig
+from sentry.models.project import Project
+from sentry.preprod.vcs.status_checks.size.types import RuleArtifactType, StatusCheckRule
+from sentry.utils import json
+
+logger = logging.getLogger(__name__)
+
+ENABLED_OPTION_KEY = "sentry:preprod_size_status_checks_enabled"
+RULES_OPTION_KEY = "sentry:preprod_size_status_checks_rules"
+
+VALID_STATUS_CHECK_METRICS = frozenset({"install_size", "download_size"})
+VALID_STATUS_CHECK_MEASUREMENTS = frozenset({"absolute", "absolute_diff", "relative_diff"})
+VALID_STATUS_CHECK_FILTER_KEYS = frozenset(
+    {"app_id", "build_configuration_name", "git_head_ref", "platform_name"}
+)
+STATUS_CHECK_FILTER_OPERATOR_NEGATIONS = {
+    "contains": "notContains",
+    "endsWith": "notEndsWith",
+    "equals": "notEquals",
+    "in": "notIn",
+    "matches": "notMatches",
+    "startsWith": "notStartsWith",
+}
+VALID_STATUS_CHECK_FILTER_OPERATORS = frozenset(
+    {
+        *STATUS_CHECK_FILTER_OPERATOR_NEGATIONS.keys(),
+        *STATUS_CHECK_FILTER_OPERATOR_NEGATIONS.values(),
+    }
+)
+
+PREPROD_ARTIFACT_SEARCH_CONFIG = SearchConfig.create_from(
+    SearchConfig[Literal[True]](),
+    text_operator_keys=VALID_STATUS_CHECK_FILTER_KEYS,
+    key_mappings={
+        "platform_name": ["platform_name"],
+        "git_head_ref": ["git_head_ref"],
+        "app_id": ["app_id"],
+        "build_configuration_name": ["build_configuration_name"],
+    },
+    allowed_keys=VALID_STATUS_CHECK_FILTER_KEYS,
+)
+
+
+def get_status_checks_enabled(project: Project) -> bool:
+    return bool(project.get_option(ENABLED_OPTION_KEY, default=True))
+
+
+def get_status_check_rules(project: Project) -> list[StatusCheckRule]:
+    """
+    Fetch and parse status check rules from project options.
+
+    Returns an empty list if feature is disabled or no rules configured.
+    """
+
+    raw = project.get_option(RULES_OPTION_KEY, default=None)
+    if not raw:
+        return []
+
+    try:
+        # Handle bytes from project options (json.loads requires str, not bytes)
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        rules_data = json.loads(raw) if isinstance(raw, str) else raw
+
+        if not isinstance(rules_data, list):
+            logger.warning(
+                "preprod.status_checks.rules.invalid_format",
+                extra={"project_id": project.id, "rules_type": type(rules_data).__name__},
+            )
+            return []
+
+        rules: list[StatusCheckRule] = []
+        for rule_dict in rules_data:
+            rule = _parse_rule(rule_dict, project_id=project.id)
+            if rule is not None:
+                rules.append(rule)
+        return rules
+    except (json.JSONDecodeError, TypeError, ValueError, AttributeError) as e:
+        logger.warning(
+            "preprod.status_checks.rules.parse_error",
+            extra={"project_id": project.id, "error": str(e)},
+        )
+        return []
+
+
+def _parse_rule(rule_dict: Any, *, project_id: int) -> StatusCheckRule | None:
+    rule_id = rule_dict.get("id")
+    metric = rule_dict.get("metric")
+    measurement = rule_dict.get("measurement")
+    value = rule_dict.get("value")
+
+    if (
+        not isinstance(rule_id, str)
+        or not isinstance(metric, str)
+        or not isinstance(measurement, str)
+        or not isinstance(value, (int, float))
+    ):
+        logger.warning(
+            "preprod.status_checks.rules.invalid_rule",
+            extra={"project_id": project_id, "rule_id": rule_id},
+        )
+        return None
+
+    filter_query_raw = rule_dict.get("filterQuery", "")
+    filter_query = str(filter_query_raw) if filter_query_raw is not None else ""
+    artifact_type = (
+        RuleArtifactType.from_raw(rule_dict.get("artifactType")) or RuleArtifactType.MAIN_ARTIFACT
+    )
+
+    return StatusCheckRule(
+        id=rule_id,
+        metric=metric,
+        measurement=measurement,
+        value=float(value),
+        filter_query=str(filter_query),
+        artifact_type=artifact_type,
+    )

--- a/src/sentry/preprod/vcs/status_checks/size/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/size/tasks.py
@@ -2,17 +2,16 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import Any, Literal
+from typing import Any
 
 from sentry import analytics as sentry_analytics
-from sentry.api.event_search import SearchConfig, SearchFilter, parse_search_query
+from sentry.api.event_search import SearchFilter, parse_search_query
 from sentry.exceptions import InvalidSearchQuery
 from sentry.integrations.github.status_check import GitHubCheckStatus
 from sentry.integrations.source_code_management.status_check import (
     StatusCheckStatus,
 )
 from sentry.models.commitcomparison import CommitComparison
-from sentry.models.project import Project
 from sentry.preprod.analytics import PreprodStatusCheckTriggeredRulePostedEvent
 from sentry.preprod.models import (
     PreprodArtifact,
@@ -20,6 +19,11 @@ from sentry.preprod.models import (
     PreprodComparisonApproval,
 )
 from sentry.preprod.url_utils import get_preprod_artifact_url
+from sentry.preprod.vcs.status_checks.size.rules import (
+    PREPROD_ARTIFACT_SEARCH_CONFIG,
+    get_status_check_rules,
+    get_status_checks_enabled,
+)
 from sentry.preprod.vcs.status_checks.size.templates import (
     format_all_skipped_messages,
     format_no_quota_messages,
@@ -42,38 +46,12 @@ from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import preprod_tasks
-from sentry.utils import json
 
 logger = logging.getLogger(__name__)
-
-ENABLED_OPTION_KEY = "sentry:preprod_size_status_checks_enabled"
-RULES_OPTION_KEY = "sentry:preprod_size_status_checks_rules"
 
 # Action identifier for the "Approve" button on GitHub check runs.
 # This is sent back in the webhook payload when the button is clicked.
 APPROVE_SIZE_ACTION_IDENTIFIER = "approve_size"
-
-preprod_artifact_search_config = SearchConfig.create_from(
-    SearchConfig[Literal[True]](),
-    text_operator_keys={
-        "platform_name",
-        "git_head_ref",
-        "app_id",
-        "build_configuration_name",
-    },
-    key_mappings={
-        "platform_name": ["platform_name"],
-        "git_head_ref": ["git_head_ref"],
-        "app_id": ["app_id"],
-        "build_configuration_name": ["build_configuration_name"],
-    },
-    allowed_keys={
-        "platform_name",
-        "git_head_ref",
-        "app_id",
-        "build_configuration_name",
-    },
-)
 
 RULE_ARTIFACT_TYPE_TO_METRICS_ARTIFACT_TYPE = {
     RuleArtifactType.MAIN_ARTIFACT: PreprodArtifactSizeMetrics.MetricsArtifactType.MAIN_ARTIFACT,
@@ -182,7 +160,7 @@ def create_preprod_status_check_task(
         )
         return
 
-    status_checks_enabled = preprod_artifact.project.get_option(ENABLED_OPTION_KEY, default=True)
+    status_checks_enabled = get_status_checks_enabled(preprod_artifact.project)
     if not status_checks_enabled:
         logger.info(
             "preprod.status_checks.create.disabled",
@@ -271,7 +249,7 @@ def create_preprod_status_check_task(
             completed_at = preprod_artifact.date_updated
             triggered_rules = []
         else:
-            rules = _get_status_check_rules(preprod_artifact.project)
+            rules = get_status_check_rules(preprod_artifact.project)
             base_artifact_map, base_size_metrics_map = _fetch_base_size_metrics(all_artifacts)
 
             status, triggered_rules = _compute_overall_status(
@@ -368,69 +346,6 @@ def create_preprod_status_check_task(
             "organization_slug": preprod_artifact.project.organization.slug,
         },
     )
-
-
-def _get_status_check_rules(project: Project) -> list[StatusCheckRule]:
-    """
-    Fetch and parse status check rules from project options.
-
-    Returns an empty list if feature is disabled or no rules configured.
-    """
-
-    rules_json = project.get_option(RULES_OPTION_KEY, default=None)
-    if not rules_json:
-        return []
-
-    try:
-        # Handle bytes from project options (json.loads requires str, not bytes)
-        if isinstance(rules_json, bytes):
-            rules_json = rules_json.decode("utf-8")
-        rules_data = json.loads(rules_json) if isinstance(rules_json, str) else rules_json
-        if not isinstance(rules_data, list):
-            logger.warning(
-                "preprod.status_checks.rules.invalid_format",
-                extra={"project_id": project.id, "rules_type": type(rules_data).__name__},
-            )
-            return []
-
-        rules: list[StatusCheckRule] = []
-        for rule_dict in rules_data:
-            if (
-                not isinstance(rule_dict.get("id"), str)
-                or not isinstance(rule_dict.get("metric"), str)
-                or not isinstance(rule_dict.get("measurement"), str)
-                or not isinstance(rule_dict.get("value"), (int, float))
-            ):
-                logger.warning(
-                    "preprod.status_checks.rules.invalid_rule",
-                    extra={"project_id": project.id, "rule_id": rule_dict.get("id")},
-                )
-                continue
-
-            filter_query_raw = rule_dict.get("filterQuery", "")
-            filter_query = str(filter_query_raw) if filter_query_raw is not None else ""
-            artifact_type = (
-                RuleArtifactType.from_raw(rule_dict.get("artifactType"))
-                or RuleArtifactType.MAIN_ARTIFACT
-            )
-
-            rules.append(
-                StatusCheckRule(
-                    id=rule_dict["id"],
-                    metric=rule_dict["metric"],
-                    measurement=rule_dict["measurement"],
-                    value=float(rule_dict["value"]),
-                    filter_query=filter_query,
-                    artifact_type=artifact_type,
-                )
-            )
-        return rules
-    except (json.JSONDecodeError, TypeError, ValueError, AttributeError) as e:
-        logger.warning(
-            "preprod.status_checks.rules.parse_error",
-            extra={"project_id": project.id, "error": str(e)},
-        )
-        return []
 
 
 def _fetch_base_size_metrics(
@@ -536,7 +451,7 @@ def _rule_matches_artifact(rule: StatusCheckRule, context: dict[str, str]) -> bo
     try:
         search_filters = [
             f
-            for f in parse_search_query(rule.filter_query, config=preprod_artifact_search_config)
+            for f in parse_search_query(rule.filter_query, config=PREPROD_ARTIFACT_SEARCH_CONFIG)
             if isinstance(f, SearchFilter)
         ]
     except InvalidSearchQuery:

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -681,6 +681,7 @@ export type KnownSentryApiUrls =
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/performance/configure/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/plugins/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/plugins/$pluginId/'
+  | '/projects/$organizationIdOrSlug/$projectIdOrSlug/preprod/size-analysis/status-check-rules/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/preprodartifacts/build-distribution/latest/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/preprodartifacts/check-for-updates/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/preprodartifacts/size-analysis/compare/$headSizeMetricId/$baseSizeMetricId/download/'

--- a/tests/sentry/preprod/api/endpoints/public/test_project_preprod_size_analysis_status_check_rules.py
+++ b/tests/sentry/preprod/api/endpoints/public/test_project_preprod_size_analysis_status_check_rules.py
@@ -333,6 +333,62 @@ class ProjectPreprodSizeAnalysisStatusCheckRulesEndpointTest(APITestCase):
             {"key": "platform_name", "conditions": [{"operator": "equals", "values": ["apple"]}]},
         ]
 
+    def test_complex_wildcards_serialize_as_matches_patterns(self) -> None:
+        self.project.update_option(
+            RULES_OPTION_KEY,
+            [
+                {
+                    "id": "rule1",
+                    "metric": "install_size",
+                    "measurement": "absolute",
+                    "value": 100,
+                    "filterQuery": "app_id:* app_id:*foo*bar* app_id:foo*bar !app_id:[foo*,*bar]",
+                },
+            ],
+        )
+
+        response = self._get_with_user_token()
+
+        assert response.status_code == 200
+        assert response.json()["rules"][0]["filters"] == [
+            {
+                "key": "app_id",
+                "conditions": [
+                    {"operator": "matches", "values": ["*"]},
+                    {"operator": "matches", "values": ["*foo*bar*"]},
+                    {"operator": "matches", "values": ["foo*bar"]},
+                ],
+            },
+            {
+                "key": "app_id",
+                "conditions": [{"operator": "notMatches", "values": ["foo*", "*bar"]}],
+            },
+        ]
+
+    def test_wildcard_operator_escapes_value_wildcards_before_serializing(self) -> None:
+        self.project.update_option(
+            RULES_OPTION_KEY,
+            [
+                {
+                    "id": "rule1",
+                    "metric": "install_size",
+                    "measurement": "absolute",
+                    "value": 100,
+                    "filterQuery": "app_id:\uf00dStartsWith\uf00dblaaa*",
+                },
+            ],
+        )
+
+        response = self._get_with_user_token()
+
+        assert response.status_code == 200
+        assert response.json()["rules"][0]["filters"] == [
+            {
+                "key": "app_id",
+                "conditions": [{"operator": "startsWith", "values": ["blaaa*"]}],
+            },
+        ]
+
     def test_negated_in_filter_serialization_preserves_runtime_logic(self) -> None:
         filter_query = "!app_id:[com.foo,com.bar]"
         self.project.update_option(

--- a/tests/sentry/preprod/api/endpoints/public/test_project_preprod_size_analysis_status_check_rules.py
+++ b/tests/sentry/preprod/api/endpoints/public/test_project_preprod_size_analysis_status_check_rules.py
@@ -1,0 +1,441 @@
+from typing import get_args
+
+from django.urls import reverse
+
+from sentry.models.orgauthtoken import OrgAuthToken
+from sentry.preprod.api.models.public.size_status_check_rules import (
+    SizeStatusCheckRuleArtifactType,
+    SizeStatusCheckRuleFilterKey,
+    SizeStatusCheckRuleFilterOperator,
+    SizeStatusCheckRuleMeasurement,
+    SizeStatusCheckRuleMetric,
+)
+from sentry.preprod.vcs.status_checks.size.rules import (
+    ENABLED_OPTION_KEY,
+    RULES_OPTION_KEY,
+    VALID_STATUS_CHECK_FILTER_KEYS,
+    VALID_STATUS_CHECK_FILTER_OPERATORS,
+    VALID_STATUS_CHECK_MEASUREMENTS,
+    VALID_STATUS_CHECK_METRICS,
+)
+from sentry.preprod.vcs.status_checks.size.tasks import _rule_matches_artifact
+from sentry.preprod.vcs.status_checks.size.types import RuleArtifactType, StatusCheckRule
+from sentry.silo.base import SiloMode
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.silo import assume_test_silo_mode
+from sentry.utils import json
+from sentry.utils.security.orgauthtoken_token import generate_token, hash_token
+
+
+class ProjectPreprodSizeAnalysisStatusCheckRulesEndpointTest(APITestCase):
+    endpoint = "sentry-api-0-project-preprod-size-analysis-status-check-rules"
+
+    def setUp(self) -> None:
+        self.user = self.create_user()
+        self.organization = self.create_organization(owner=self.user)
+        self.project = self.create_project(organization=self.organization)
+
+    def _get_url(self, organization_slug=None, project_slug=None):
+        return reverse(
+            self.endpoint,
+            args=[organization_slug or self.organization.slug, project_slug or self.project.slug],
+        )
+
+    def _get_with_user_token(self, scope_list=None, user=None, url=None):
+        token = self.create_user_auth_token(
+            user or self.user,
+            scope_list=scope_list or ["project:read"],
+        )
+        return self.client.get(url or self._get_url(), HTTP_AUTHORIZATION=f"Bearer {token.token}")
+
+    def _get_with_org_token(self, scope_list=None):
+        token_str = generate_token(self.organization.slug, "")
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            OrgAuthToken.objects.create(
+                organization_id=self.organization.id,
+                name="Test Token",
+                token_hashed=hash_token(token_str),
+                scope_list=scope_list or ["project:distribution"],
+            )
+        return self.client.get(self._get_url(), HTTP_AUTHORIZATION=f"Bearer {token_str}")
+
+    def test_default_config_returns_enabled_with_empty_rules(self) -> None:
+        response = self._get_with_user_token()
+
+        assert response.status_code == 200
+        assert response.json() == {"enabled": True, "rules": []}
+
+    def test_returns_configured_rules_public_contract(self) -> None:
+        self.project.update_option(
+            RULES_OPTION_KEY,
+            json.dumps(
+                [
+                    {
+                        "id": "rule1",
+                        "metric": "install_size",
+                        "measurement": "absolute_diff",
+                        "value": 5000000,
+                        "filterQuery": "app_id:com.cameroncooke.test platform_name:apple",
+                        "artifactType": "main_artifact",
+                    },
+                    {
+                        "id": "rule2",
+                        "metric": "download_size",
+                        "measurement": "relative_diff",
+                        "value": 10.5,
+                        "filterQuery": "",
+                        "artifactType": "all_artifacts",
+                    },
+                ]
+            ),
+        )
+
+        response = self._get_with_user_token()
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data == {
+            "enabled": True,
+            "rules": [
+                {
+                    "id": "rule1",
+                    "metric": "install_size",
+                    "measurement": "absolute_diff",
+                    "value": "5000000",
+                    "filterQuery": "app_id:com.cameroncooke.test platform_name:apple",
+                    "filters": [
+                        {
+                            "key": "app_id",
+                            "conditions": [
+                                {"operator": "equals", "values": ["com.cameroncooke.test"]}
+                            ],
+                        },
+                        {
+                            "key": "platform_name",
+                            "conditions": [{"operator": "equals", "values": ["apple"]}],
+                        },
+                    ],
+                    "artifactType": "main_artifact",
+                },
+                {
+                    "id": "rule2",
+                    "metric": "download_size",
+                    "measurement": "relative_diff",
+                    "value": "10.5",
+                    "filterQuery": "",
+                    "filters": [],
+                    "artifactType": "all_artifacts",
+                },
+            ],
+        }
+        assert set(data["rules"][0]) == {
+            "id",
+            "metric",
+            "measurement",
+            "value",
+            "filterQuery",
+            "filters",
+            "artifactType",
+        }
+        assert isinstance(data["rules"][0]["value"], str)
+
+    def test_disabled_project_still_returns_saved_rules(self) -> None:
+        self.project.update_option(ENABLED_OPTION_KEY, False)
+        self.project.update_option(
+            RULES_OPTION_KEY,
+            json.dumps(
+                [
+                    {
+                        "id": "rule1",
+                        "metric": "install_size",
+                        "measurement": "absolute",
+                        "value": 100,
+                    }
+                ]
+            ),
+        )
+
+        response = self._get_with_user_token()
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "enabled": False,
+            "rules": [
+                {
+                    "id": "rule1",
+                    "metric": "install_size",
+                    "measurement": "absolute",
+                    "value": "100",
+                    "filterQuery": "",
+                    "filters": [],
+                    "artifactType": "main_artifact",
+                }
+            ],
+        }
+
+    def test_legacy_rule_without_artifact_type_defaults_to_main_artifact(self) -> None:
+        self.project.update_option(
+            RULES_OPTION_KEY,
+            json.dumps(
+                [
+                    {
+                        "id": "rule1",
+                        "metric": "install_size",
+                        "measurement": "absolute",
+                        "value": 100,
+                    }
+                ]
+            ),
+        )
+
+        response = self._get_with_user_token()
+
+        assert response.status_code == 200
+        assert response.json()["rules"][0]["artifactType"] == "main_artifact"
+
+    def test_malformed_config_returns_empty_rules(self) -> None:
+        self.project.update_option(RULES_OPTION_KEY, "not-json")
+
+        response = self._get_with_user_token()
+
+        assert response.status_code == 200
+        assert response.json() == {"enabled": True, "rules": []}
+
+    def test_non_list_config_returns_empty_rules(self) -> None:
+        self.project.update_option(RULES_OPTION_KEY, json.dumps({"id": "rule1"}))
+
+        response = self._get_with_user_token()
+
+        assert response.status_code == 200
+        assert response.json() == {"enabled": True, "rules": []}
+
+    def test_invalid_dict_rule_entries_are_skipped(self) -> None:
+        self.project.update_option(
+            RULES_OPTION_KEY,
+            [
+                {"id": "bad", "metric": "install_size", "measurement": "absolute", "value": "100"},
+                {"id": "rule1", "metric": "install_size", "measurement": "absolute", "value": 100},
+            ],
+        )
+
+        response = self._get_with_user_token()
+
+        assert response.status_code == 200
+        assert [rule["id"] for rule in response.json()["rules"]] == ["rule1"]
+
+    def test_non_dict_rule_entry_returns_empty_rules(self) -> None:
+        self.project.update_option(
+            RULES_OPTION_KEY,
+            [
+                "not-a-rule",
+                {"id": "rule1", "metric": "install_size", "measurement": "absolute", "value": 100},
+            ],
+        )
+
+        response = self._get_with_user_token()
+
+        assert response.status_code == 200
+        assert response.json() == {"enabled": True, "rules": []}
+
+    def test_public_response_filters_unknown_metric_and_measurement(self) -> None:
+        self.project.update_option(
+            RULES_OPTION_KEY,
+            [
+                {
+                    "id": "unknown-metric",
+                    "metric": "unknown",
+                    "measurement": "absolute",
+                    "value": 1,
+                },
+                {
+                    "id": "unknown-measurement",
+                    "metric": "install_size",
+                    "measurement": "unknown",
+                    "value": 2,
+                },
+                {"id": "rule1", "metric": "install_size", "measurement": "absolute", "value": 100},
+            ],
+        )
+
+        response = self._get_with_user_token()
+
+        assert response.status_code == 200
+        assert [rule["id"] for rule in response.json()["rules"]] == ["rule1"]
+
+    def test_filter_query_serializes_to_machine_readable_filters(self) -> None:
+        self.project.update_option(
+            RULES_OPTION_KEY,
+            [
+                {
+                    "id": "rule1",
+                    "metric": "install_size",
+                    "measurement": "absolute",
+                    "value": 100,
+                    "filterQuery": "app_id:com.foo app_id:com.bar app_id:[com.qux,com.quux] !app_id:com.baz !app_id:bad* !app_id:[com.bad,com.worse] platform_name:apple build_configuration_name:Release* git_head_ref:*main",
+                },
+            ],
+        )
+
+        response = self._get_with_user_token()
+
+        assert response.status_code == 200
+        assert response.json()["rules"][0]["filters"] == [
+            {
+                "key": "app_id",
+                "conditions": [
+                    {"operator": "equals", "values": ["com.foo"]},
+                    {"operator": "equals", "values": ["com.bar"]},
+                    {"operator": "in", "values": ["com.qux", "com.quux"]},
+                ],
+            },
+            {
+                "key": "app_id",
+                "conditions": [
+                    {"operator": "notEquals", "values": ["com.baz"]},
+                    {"operator": "notStartsWith", "values": ["bad"]},
+                    {"operator": "notIn", "values": ["com.bad", "com.worse"]},
+                ],
+            },
+            {"key": "platform_name", "conditions": [{"operator": "equals", "values": ["apple"]}]},
+            {
+                "key": "build_configuration_name",
+                "conditions": [{"operator": "startsWith", "values": ["Release"]}],
+            },
+            {"key": "git_head_ref", "conditions": [{"operator": "endsWith", "values": ["main"]}]},
+        ]
+
+    def test_escaped_wildcards_serialize_as_literal_values(self) -> None:
+        self.project.update_option(
+            RULES_OPTION_KEY,
+            [
+                {
+                    "id": "rule1",
+                    "metric": "install_size",
+                    "measurement": "absolute",
+                    "value": 100,
+                    "filterQuery": r"app_id:\*com !app_id:com.example.\* platform_name:apple",
+                },
+            ],
+        )
+
+        response = self._get_with_user_token()
+
+        assert response.status_code == 200
+        assert response.json()["rules"][0]["filters"] == [
+            {
+                "key": "app_id",
+                "conditions": [{"operator": "equals", "values": ["*com"]}],
+            },
+            {
+                "key": "app_id",
+                "conditions": [{"operator": "notEquals", "values": ["com.example.*"]}],
+            },
+            {"key": "platform_name", "conditions": [{"operator": "equals", "values": ["apple"]}]},
+        ]
+
+    def test_negated_in_filter_serialization_preserves_runtime_logic(self) -> None:
+        filter_query = "!app_id:[com.foo,com.bar]"
+        self.project.update_option(
+            RULES_OPTION_KEY,
+            [
+                {
+                    "id": "rule1",
+                    "metric": "install_size",
+                    "measurement": "absolute",
+                    "value": 100,
+                    "filterQuery": filter_query,
+                },
+            ],
+        )
+
+        response = self._get_with_user_token()
+
+        assert response.status_code == 200
+        assert response.json()["rules"][0]["filters"] == [
+            {
+                "key": "app_id",
+                "conditions": [{"operator": "notIn", "values": ["com.foo", "com.bar"]}],
+            }
+        ]
+        runtime_rule = StatusCheckRule(
+            id="rule1",
+            metric="install_size",
+            measurement="absolute",
+            value=100,
+            filter_query=filter_query,
+        )
+        assert _rule_matches_artifact(runtime_rule, {"app_id": "com.foo"}) is False
+        assert _rule_matches_artifact(runtime_rule, {"app_id": "com.baz"}) is True
+
+    def test_invalid_filter_query_returns_null_filters(self) -> None:
+        self.project.update_option(
+            RULES_OPTION_KEY,
+            [
+                {
+                    "id": "rule1",
+                    "metric": "install_size",
+                    "measurement": "absolute",
+                    "value": 100,
+                    "filterQuery": "unknown_key:value",
+                },
+            ],
+        )
+
+        response = self._get_with_user_token()
+
+        assert response.status_code == 200
+        assert response.json()["rules"][0]["filters"] is None
+        runtime_rule = StatusCheckRule(
+            id="rule1",
+            metric="install_size",
+            measurement="absolute",
+            value=100,
+            filter_query="unknown_key:value",
+        )
+        assert _rule_matches_artifact(runtime_rule, {"app_id": "com.foo"}) is False
+
+    def test_denies_unauthenticated_request(self) -> None:
+        response = self.client.get(self._get_url())
+
+        assert response.status_code == 401
+
+    def test_denies_token_without_expected_scope(self) -> None:
+        response = self._get_with_user_token(scope_list=["event:read"])
+
+        assert response.status_code == 403
+
+    def test_allows_project_read_bearer_token(self) -> None:
+        response = self._get_with_user_token(scope_list=["project:read"])
+
+        assert response.status_code == 200
+
+    def test_allows_project_read_org_token(self) -> None:
+        response = self._get_with_org_token(scope_list=["project:read"])
+
+        assert response.status_code == 200
+
+    def test_denies_project_distribution_org_token(self) -> None:
+        response = self._get_with_org_token(scope_list=["project:distribution"])
+
+        assert response.status_code == 403
+
+    def test_public_schema_literals_match_public_normalization_values(self) -> None:
+        assert set(get_args(SizeStatusCheckRuleMetric)) == VALID_STATUS_CHECK_METRICS
+        assert set(get_args(SizeStatusCheckRuleMeasurement)) == VALID_STATUS_CHECK_MEASUREMENTS
+        assert set(get_args(SizeStatusCheckRuleFilterKey)) == VALID_STATUS_CHECK_FILTER_KEYS
+        assert (
+            set(get_args(SizeStatusCheckRuleFilterOperator)) == VALID_STATUS_CHECK_FILTER_OPERATORS
+        )
+        assert set(get_args(SizeStatusCheckRuleArtifactType)) == {
+            artifact_type.value for artifact_type in RuleArtifactType
+        }
+
+    def test_denies_other_organization_access(self) -> None:
+        other_user = self.create_user()
+        other_organization = self.create_organization(owner=other_user)
+        other_project = self.create_project(organization=other_organization)
+        url = self._get_url(other_organization.slug, other_project.slug)
+
+        response = self._get_with_user_token(user=self.user, url=url)
+
+        assert response.status_code == 403

--- a/tests/sentry/preprod/vcs/status_checks/size/test_status_check_filters.py
+++ b/tests/sentry/preprod/vcs/status_checks/size/test_status_check_filters.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from unittest import mock
+
 from sentry.integrations.source_code_management.status_check import StatusCheckStatus
 from sentry.models.commitcomparison import CommitComparison
 from sentry.preprod.models import (
@@ -7,12 +9,12 @@ from sentry.preprod.models import (
     PreprodArtifactSizeMetrics,
     PreprodBuildConfiguration,
 )
+from sentry.preprod.vcs.status_checks.size.rules import get_status_check_rules
 from sentry.preprod.vcs.status_checks.size.tasks import (
     _compute_overall_status,
     _evaluate_rule_threshold,
     _fetch_base_size_metrics,
     _get_artifact_filter_context,
-    _get_status_check_rules,
     _rule_matches_artifact,
 )
 from sentry.preprod.vcs.status_checks.size.types import RuleArtifactType, StatusCheckRule
@@ -208,6 +210,43 @@ class StatusCheckFiltersTest(TestCase):
         assert _rule_matches_artifact(rule_android_release, context) is False
         assert _rule_matches_artifact(rule_ios_debug, context) is False
 
+    def test_rule_matches_same_key_positive_and_negated_filters(self) -> None:
+        artifact = PreprodArtifact.objects.create(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.PROCESSED,
+            artifact_type=PreprodArtifact.ArtifactType.XCARCHIVE,
+            app_id="com.example.app",
+            commit_comparison=self.commit_comparison,
+        )
+
+        context = _get_artifact_filter_context(artifact)
+
+        satisfiable_rule = StatusCheckRule(
+            id="rule1",
+            metric="install_size",
+            measurement="absolute",
+            value=100 * 1024 * 1024,
+            filter_query="app_id:com.example.app !app_id:bad* platform_name:apple",
+        )
+        contradictory_rule = StatusCheckRule(
+            id="rule2",
+            metric="install_size",
+            measurement="absolute",
+            value=100 * 1024 * 1024,
+            filter_query="app_id:com.example.app !app_id:com.example.app platform_name:apple",
+        )
+        platform_mismatch_rule = StatusCheckRule(
+            id="rule3",
+            metric="install_size",
+            measurement="absolute",
+            value=100 * 1024 * 1024,
+            filter_query="app_id:com.example.app !app_id:bad* platform_name:android",
+        )
+
+        assert _rule_matches_artifact(satisfiable_rule, context) is True
+        assert _rule_matches_artifact(contradictory_rule, context) is False
+        assert _rule_matches_artifact(platform_mismatch_rule, context) is False
+
     def test_status_check_fails_when_rule_matches_and_exceeds_threshold(self) -> None:
         artifact = PreprodArtifact.objects.create(
             project=self.project,
@@ -335,7 +374,7 @@ class StatusCheckFiltersTest(TestCase):
             '"artifactType": "watch_artifact"}]',
         )
 
-        rules = _get_status_check_rules(self.project)
+        rules = get_status_check_rules(self.project)
 
         assert len(rules) == 1
         assert rules[0].id == "rule1"
@@ -351,7 +390,7 @@ class StatusCheckFiltersTest(TestCase):
             '[{"id": "rule1", "metric": "install_size", "measurement": "absolute", "value": 100}]',
         )
 
-        rules = _get_status_check_rules(self.project)
+        rules = get_status_check_rules(self.project)
 
         assert len(rules) == 1
         assert rules[0].artifact_type == "main_artifact"
@@ -363,10 +402,86 @@ class StatusCheckFiltersTest(TestCase):
             '"value": 100, "artifactType": "app_clip_artifact"}]',
         )
 
-        rules = _get_status_check_rules(self.project)
+        rules = get_status_check_rules(self.project)
 
         assert len(rules) == 1
         assert rules[0].artifact_type == RuleArtifactType.APP_CLIP_ARTIFACT
+
+    def test_parse_rules_from_bytes_project_option(self) -> None:
+        with mock.patch.object(
+            self.project,
+            "get_option",
+            return_value=(
+                b'[{"id": "rule1", "metric": "download_size", "measurement": "relative_diff", '
+                b'"value": 10.5}]'
+            ),
+        ):
+            rules = get_status_check_rules(self.project)
+
+        assert len(rules) == 1
+        assert rules[0].id == "rule1"
+        assert rules[0].metric == "download_size"
+        assert rules[0].measurement == "relative_diff"
+        assert rules[0].value == 10.5
+
+    def test_parse_rules_from_list_project_option_skips_invalid_dict_entries(self) -> None:
+        self.project.update_option(
+            "sentry:preprod_size_status_checks_rules",
+            [
+                {
+                    "id": "bad-value",
+                    "metric": "install_size",
+                    "measurement": "absolute",
+                    "value": "1",
+                },
+                {"id": "rule1", "metric": "install_size", "measurement": "absolute", "value": 100},
+            ],
+        )
+
+        rules = get_status_check_rules(self.project)
+
+        assert len(rules) == 1
+        assert rules[0].id == "rule1"
+
+    def test_parse_rules_preserves_unknown_metric_and_measurement_for_task_compatibility(
+        self,
+    ) -> None:
+        self.project.update_option(
+            "sentry:preprod_size_status_checks_rules",
+            [
+                {
+                    "id": "unknown-metric",
+                    "metric": "unknown",
+                    "measurement": "absolute",
+                    "value": 1,
+                },
+                {
+                    "id": "unknown-measurement",
+                    "metric": "install_size",
+                    "measurement": "unknown",
+                    "value": 2,
+                },
+            ],
+        )
+
+        rules = get_status_check_rules(self.project)
+
+        assert [rule.id for rule in rules] == ["unknown-metric", "unknown-measurement"]
+        assert rules[0].metric == "unknown"
+        assert rules[1].measurement == "unknown"
+
+    def test_parse_rules_non_dict_entry_returns_empty_rules_for_task_compatibility(self) -> None:
+        self.project.update_option(
+            "sentry:preprod_size_status_checks_rules",
+            [
+                "not-a-rule",
+                {"id": "rule1", "metric": "install_size", "measurement": "absolute", "value": 100},
+            ],
+        )
+
+        rules = get_status_check_rules(self.project)
+
+        assert rules == []
 
     def test_evaluate_absolute_diff_threshold_exceeds(self) -> None:
         head_artifact = self.create_preprod_artifact(


### PR DESCRIPTION
Add a public preprod project endpoint for reading the current Size Analysis status check rule configuration. External CI consumers can use this as the same source of truth Sentry uses when evaluating size thresholds, without duplicating rule config outside Sentry.

**Endpoint**

```
GET /api/0/projects/{organization_slug}/{project_slug}/preprod/size-analysis/status-check-rules/
```

**Example**

```json
{
  "enabled": true,
  "rules": [
    {
      "id": "12733d00-c8b5-1834-9d42-7f140d5ae079",
      "metric": "install_size",
      "measurement": "relative_diff",
      "value": "10",
      "filterQuery": "app_id:com.example.app platform_name:apple",
      "filters": [
        {
          "key": "app_id",
          "conditions": [
            {
              "operator": "equals",
              "values": [
                "com.example.app"
              ]
            }
          ]
        },
        {
          "key": "platform_name",
          "conditions": [
            {
              "operator": "equals",
              "values": [
                "apple"
              ]
            }
          ]
        }
      ],
      "artifactType": "main_artifact"
    },
    {
      "id": "19333983-0893-6abc-cc2a-f75d3df54af5",
      "metric": "download_size",
      "measurement": "absolute",
      "value": "20000000",
      "filterQuery": "app_id:com.example.app platform_name:apple",
      "filters": [
        {
          "key": "app_id",
          "conditions": [
            {
              "operator": "equals",
              "values": [
                "com.example.app"
              ]
            }
          ]
        },
        {
          "key": "platform_name",
          "conditions": [
            {
              "operator": "equals",
              "values": [
                "apple"
              ]
            }
          ]
        }
      ],
      "artifactType": "main_artifact"
    }
  ]
}
```

**Filter Semantics**

The response includes both the original `filterQuery` and a machine-readable `filters` form. Serialized filters preserve runtime grouping behavior: separate filter objects are ANDed, conditions inside one filter object are ORed, and same-key positive and negated groups remain separate.

For example, this response shape:

```json
[
  {
    "key": "app_id",
    "conditions": [
      {"operator": "equals", "values": ["com.example.app"]},
      {"operator": "startsWith", "values": ["com.example.beta"]}
    ]
  },
  {
    "key": "platform_name",
    "conditions": [{"operator": "equals", "values": ["apple"]}]
  },
  {
    "key": "app_id",
    "conditions": [{"operator": "notStartsWith", "values": ["internal"]}]
  }
]
```

means:

```text
(app_id = com.example.app OR app_id STARTS WITH com.example.beta)
AND platform_name = apple
AND app_id NOT STARTS WITH internal
```

**Wildcard Serialization**

The status-check runtime evaluates wildcard filters by translating them to an internal Python regex, but the public API intentionally does not expose that regex. `matches` and `notMatches` values use the same Sentry wildcard syntax users configured in the rule: `*` matches zero or more characters, and escaped `\*` is a literal asterisk.

Simple wildcard patterns are simplified to the most specific operator:

```text
app_id:foo*  -> {"operator": "startsWith", "values": ["foo"]}
app_id:*foo  -> {"operator": "endsWith", "values": ["foo"]}
app_id:*foo* -> {"operator": "contains", "values": ["foo"]}
```

Complex or match-all wildcard patterns stay as wildcard patterns:

```text
app_id:*          -> {"operator": "matches", "values": ["*"]}
app_id:foo*bar    -> {"operator": "matches", "values": ["foo*bar"]}
app_id:*foo*bar*  -> {"operator": "matches", "values": ["*foo*bar*"]}
!app_id:*internal -> {"operator": "notMatches", "values": ["*internal"]}
```

This is deliberately different from returning the runtime regex form, for example:

```text
app_id:*foo*bar* -> not returned as {"operator": "matches", "values": ["^.*foo.*bar.*$"]}
```

Keeping wildcard syntax in the API avoids exposing Python regex internals and gives external CI consumers a portable contract to implement in their own language. A `matches` value without `*` is equivalent to an exact match.

**Runtime Parity Edge Cases**

Invalid filter queries serialize as `filters: null`, while valid empty filters serialize as `filters: []`. `in` and `notIn` stay atomic so negated list filters keep the same boolean meaning as runtime evaluation. Escaped wildcard values are decoded as literals in `values`, so `app_id:\*com` becomes `operator: "equals"` with `values: ["*com"]`.

**Auth Model**

The endpoint requires project read permission and does not allow project distribution tokens because it exposes status-check rule configuration rather than build distribution data. Review note: confirm this is the intended auth model for external CI consumers.

Refs EME-1061