### PR TITLE
fix(preprod): Keep snapshot diff toggle visible

### DIFF
--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
@@ -1,0 +1,59 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {SnapshotMainContent} from './snapshotMainContent';
+
+const mockZoom = {
+  containerRef: {current: null},
+  resetZoom: jest.fn(),
+  transform: {x: 0, y: 0, k: 1},
+  zoomIn: jest.fn(),
+  zoomOut: jest.fn(),
+};
+
+jest.mock('./imageDisplay/useD3Zoom', () => ({
+  useD3Zoom: () => mockZoom,
+  useSyncedD3Zoom: () => [mockZoom, mockZoom],
+}));
+
+function renderSnapshotMainContent(
+  props: Partial<React.ComponentProps<typeof SnapshotMainContent>> = {}
+) {
+  const defaultProps: React.ComponentProps<typeof SnapshotMainContent> = {
+    canNavigateNext: false,
+    canNavigatePrev: false,
+    comparisonType: 'solo',
+    diffImageBaseUrl: '/api/0/projects/org-slug/project-slug/files/images/',
+    diffMode: 'split',
+    hasDiffComparison: true,
+    imageBaseUrl: '/api/0/projects/org-slug/project-slug/files/images/',
+    isSoloView: true,
+    listItems: [],
+    onDiffModeChange: jest.fn(),
+    onNavigateSingleView: jest.fn(),
+    onOverlayColorChange: jest.fn(),
+    onToggleSoloView: jest.fn(),
+    onViewModeChange: jest.fn(),
+    overlayColor: 'transparent',
+    selectedItem: null,
+    variantIndex: 0,
+    viewMode: 'list',
+  };
+
+  return render(<SnapshotMainContent {...defaultProps} {...props} />);
+}
+
+describe('SnapshotMainContent', () => {
+  it('keeps the diff/head toggle visible when viewing the head-only comparison', async () => {
+    const onToggleSoloView = jest.fn();
+
+    renderSnapshotMainContent({onToggleSoloView});
+
+    expect(screen.getByText('Diff')).toBeInTheDocument();
+    expect(screen.getByText('Head')).toBeInTheDocument();
+    expect(screen.queryByText('Base')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Diff'));
+
+    expect(onToggleSoloView).toHaveBeenCalledTimes(1);
+  });
+});

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -47,6 +47,7 @@ interface SnapshotMainContentProps {
   comparisonType: 'diff' | 'solo' | undefined;
   diffImageBaseUrl: string;
   diffMode: DiffMode;
+  hasDiffComparison: boolean;
   imageBaseUrl: string;
   isSoloView: boolean;
   listItems: SidebarItem[];
@@ -78,6 +79,7 @@ export function SnapshotMainContent({
   viewMode,
   onViewModeChange,
   listItems,
+  hasDiffComparison,
   isSoloView,
   onToggleSoloView,
   comparisonType,
@@ -119,7 +121,7 @@ export function SnapshotMainContent({
       </Flex>
     ) : null;
   let soloDiffToggle: React.ReactNode = null;
-  if (comparisonType === 'diff') {
+  if (hasDiffComparison) {
     soloDiffToggle = (
       <SoloDiffToggle isSoloView={isSoloView} onToggleSoloView={onToggleSoloView} />
     );
@@ -400,6 +402,7 @@ function SoloDiffToggle({
     <SegmentedControl
       size="xs"
       value={isSoloView ? 'head' : 'diff'}
+      aria-label={t('Comparison view')}
       onChange={value => {
         if ((value === 'head') !== isSoloView) {
           onToggleSoloView();

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -205,6 +205,7 @@ export default function SnapshotsPage() {
   const location = useLocation();
   const navigate = useNavigate();
   const viewOverride = location.query.view;
+  const hasDiffComparison = data?.comparison_type === 'diff';
   const comparisonType =
     viewOverride === 'solo' ? 'solo' : (data?.comparison_type ?? 'solo');
   const comparisonRunInfo = data?.comparison_run_info;
@@ -588,6 +589,7 @@ export default function SnapshotsPage() {
           viewMode={viewMode}
           onViewModeChange={setViewMode}
           listItems={listItems}
+          hasDiffComparison={hasDiffComparison}
           isSoloView={isSoloView}
           onToggleSoloView={handleToggleView}
           comparisonType={comparisonType}


### PR DESCRIPTION
On the snapshot comparison page, right now, after toggling the snapshot diff to "head", it switches to say "base" and you cannot switch back to the comparison.

Before fix:
<img width="329" height="184" alt="image" src="https://github.com/user-attachments/assets/6482405e-2edb-4e20-b962-14c4d19b5b7e" />

After fix switch stays visible:
<img width="250" height="203" alt="Screenshot 2026-04-30 at 13 03 47" src="https://github.com/user-attachments/assets/b7407254-9417-4105-be1c-d4301fcc4579" />
