### PR TITLE
ref(snuba): Add LOW_VALUE_SPANS_JOB referrer

### DIFF
--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -678,7 +678,7 @@ class Referrer(StrEnum):
     INSIGHTS_TIME_SPENT_TOTAL_TIME = "insights.time_spent.total_time"
 
     # TODO(telex-team): temporary referrer, remove once low value spans job is no longer needed
-    LOW_VALUE_SPANS_JOB = "low_value_spans_job"
+    LOW_VALUE_SPANS_JOB = "autopilot.low_value_spans_job"
 
     METRIC_EXTRACTION_CARDINALITY_CHECK = "metric_extraction.cardinality_check"
     BILLING_USAGE_SERVICE_CLICKHOUSE = "billing.usage_service.clickhouse"

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -677,7 +677,7 @@ class Referrer(StrEnum):
     INSIGHTS_MOBILE_HAS_TTFDCONFIGURED = "insights.mobile.hasTTFDConfigured"
     INSIGHTS_TIME_SPENT_TOTAL_TIME = "insights.time_spent.total_time"
 
-    # TODO(telex-team): temporary referrer, remove once low value spans job is stabilized
+    # TODO(telex-team): temporary referrer, remove once low value spans job is no longer needed
     LOW_VALUE_SPANS_JOB = "low_value_spans_job"
 
     METRIC_EXTRACTION_CARDINALITY_CHECK = "metric_extraction.cardinality_check"

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -677,6 +677,9 @@ class Referrer(StrEnum):
     INSIGHTS_MOBILE_HAS_TTFDCONFIGURED = "insights.mobile.hasTTFDConfigured"
     INSIGHTS_TIME_SPENT_TOTAL_TIME = "insights.time_spent.total_time"
 
+    # TODO(telex-team): temporary referrer, remove once low value spans job is stabilized
+    LOW_VALUE_SPANS_JOB = "low_value_spans_job"
+
     METRIC_EXTRACTION_CARDINALITY_CHECK = "metric_extraction.cardinality_check"
     BILLING_USAGE_SERVICE_CLICKHOUSE = "billing.usage_service.clickhouse"
     OUTCOMES_TIMESERIES = "outcomes.timeseries"


### PR DESCRIPTION
Adds a temporary `LOW_VALUE_SPANS_JOB` referrer to the Snuba `Referrer` enum for use by the low value spans job.

The referrer is marked with a `TODO(telex-team)` comment to signal it should be removed once the job is stabilized.