### PR TITLE
fix(integrations): URL-safe quote project_id

### DIFF
--- a/src/sentry/integrations/gitlab/blame.py
+++ b/src/sentry/integrations/gitlab/blame.py
@@ -9,11 +9,11 @@ from urllib.parse import quote
 
 import orjson
 
-from sentry.integrations.gitlab.client import safe_quote
 from sentry.integrations.gitlab.utils import (
     GitLabApiClientPath,
     GitLabRateLimitInfo,
     get_rate_limit_info_from_response,
+    safe_quote,
 )
 from sentry.integrations.source_code_management.commit_context import (
     CommitInfo,

--- a/src/sentry/integrations/gitlab/blame.py
+++ b/src/sentry/integrations/gitlab/blame.py
@@ -9,6 +9,7 @@ from urllib.parse import quote
 
 import orjson
 
+from sentry.integrations.gitlab.client import safe_quote
 from sentry.integrations.gitlab.utils import (
     GitLabApiClientPath,
     GitLabRateLimitInfo,
@@ -90,7 +91,9 @@ def _fetch_file_blame(
 
     # GitLab returns an invalid file path error if there are leading or trailing slashes
     encoded_path = quote(file.path.strip("/"), safe="")
-    request_path = GitLabApiClientPath.blame.format(project=project_id, path=encoded_path)
+    request_path = GitLabApiClientPath.blame.format(
+        project=safe_quote(project_id), path=encoded_path
+    )
     params = {"ref": file.ref, "range[start]": file.lineno, "range[end]": file.lineno}
 
     cache_key = client.get_cache_key(request_path, orjson.dumps(params).decode())

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any
-from urllib.parse import quote
+from urllib.parse import quote, unquote
 
 from django.urls import reverse
 from requests import PreparedRequest
@@ -30,6 +30,10 @@ if TYPE_CHECKING:
     from sentry.integrations.gitlab.integration import GitlabIntegration
 
 logger = logging.getLogger("sentry.integrations.gitlab")
+
+
+def safe_quote(s: Any) -> str:
+    return quote(unquote(s), safe="")
 
 
 class GitLabSetupApiClient(IntegrationProxyClient):
@@ -221,7 +225,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
 
         See https://docs.gitlab.com/ee/api/projects.html#get-single-project
         """
-        return self.get(GitLabApiClientPath.project.format(project=quote(str(project_id), safe="")))
+        return self.get(GitLabApiClientPath.project.format(project=safe_quote(project_id)))
 
     def get_issue(self, project_id, issue_id):
         """Get an issue
@@ -230,9 +234,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
         """
         try:
             return self.get(
-                GitLabApiClientPath.issue.format(
-                    project=quote(str(project_id), safe=""), issue=issue_id
-                )
+                GitLabApiClientPath.issue.format(project=safe_quote(project_id), issue=issue_id)
             )
         except IndexError:
             raise ApiError("Issue not found with ID", 404)
@@ -247,14 +249,14 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
     def get_issue_awards(self, project_id: str, issue_id: str):
         return self.get(
             GitLabApiClientPath.issue_awards.format(
-                project_id=quote(str(project_id), safe=""), issue_id=issue_id
+                project_id=safe_quote(project_id), issue_id=issue_id
             )
         )
 
     def create_issue_award(self, project_id: str, issue_id: str, emoji: str):
         return self.post(
             GitLabApiClientPath.issue_awards.format(
-                project_id=quote(str(project_id), safe=""), issue_id=issue_id
+                project_id=safe_quote(project_id), issue_id=issue_id
             ),
             params={"name": emoji},
         )
@@ -262,7 +264,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
     def delete_issue_award(self, project_id: str, issue_id: str, award_id: str):
         return self.delete(
             GitLabApiClientPath.issue_award.format(
-                project_id=quote(str(project_id), safe=""), issue_id=issue_id, award_id=award_id
+                project_id=safe_quote(project_id), issue_id=issue_id, award_id=award_id
             )
         )
 
@@ -270,7 +272,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
         """https://docs.gitlab.com/api/notes/#list-all-issue-notes"""
         return self.get(
             GitLabApiClientPath.issue_notes.format(
-                project_id=quote(str(project_id), safe=""), issue_id=issue_id
+                project_id=safe_quote(project_id), issue_id=issue_id
             )
         )
 
@@ -329,7 +331,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
     def get_merge_request(self, project_id: str, pr_key: str) -> Any:
         return self.get(
             GitLabApiClientPath.merge_request.format(
-                project_id=quote(str(project_id), safe=""), pr_key=pr_key
+                project_id=safe_quote(project_id), pr_key=pr_key
             )
         )
 
@@ -339,20 +341,20 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
         else:
             params = {"state": state}
         return self.get(
-            GitLabApiClientPath.merge_requests.format(project_id=quote(str(project_id), safe="")),
+            GitLabApiClientPath.merge_requests.format(project_id=safe_quote(project_id)),
             params=params,
         )
 
     def create_merge_request(self, project_id: str, data: dict[str, Any]) -> Any:
         return self.post(
-            GitLabApiClientPath.merge_requests.format(project_id=quote(str(project_id), safe="")),
+            GitLabApiClientPath.merge_requests.format(project_id=safe_quote(project_id)),
             data=data,
         )
 
     def update_merge_request(self, project_id: str, pr_key: str, data: dict[str, Any]) -> Any:
         return self.put(
             GitLabApiClientPath.merge_request.format(
-                project_id=quote(str(project_id), safe=""), pr_key=pr_key
+                project_id=safe_quote(project_id), pr_key=pr_key
             ),
             data=data,
         )
@@ -360,14 +362,14 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
     def get_merge_request_notes(self, project_id: str, pr_key: str) -> Any:
         return self.get(
             GitLabApiClientPath.merge_request_notes.format(
-                project_id=quote(str(project_id), safe=""), pr_key=pr_key
+                project_id=safe_quote(project_id), pr_key=pr_key
             )
         )
 
     def get_merge_request_versions(self, project_id: str, pr_key: str) -> Any:
         return self.get(
             GitLabApiClientPath.merge_request_versions.format(
-                project_id=quote(str(project_id), safe=""), pr_key=pr_key
+                project_id=safe_quote(project_id), pr_key=pr_key
             )
         )
 
@@ -376,7 +378,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
     ) -> Any:
         return self.post(
             GitLabApiClientPath.merge_request_discussions.format(
-                project_id=quote(str(project_id), safe=""), pr_key=pr_key
+                project_id=safe_quote(project_id), pr_key=pr_key
             ),
             data=data,
         )
@@ -386,7 +388,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
     ) -> Any:
         return self.post(
             GitLabApiClientPath.merge_request_discussion_notes.format(
-                project_id=quote(str(project_id), safe=""),
+                project_id=safe_quote(project_id),
                 pr_key=pr_key,
                 discussion_id=discussion_id,
             ),
@@ -398,7 +400,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
     ) -> Any:
         return self.put(
             GitLabApiClientPath.merge_request_discussion.format(
-                project_id=quote(str(project_id), safe=""),
+                project_id=safe_quote(project_id),
                 pr_key=pr_key,
                 discussion_id=discussion_id,
             ),
@@ -413,7 +415,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
     def create_merge_request_note(self, project_id: str, pr_key: str, data: dict[str, Any]) -> Any:
         return self.post(
             GitLabApiClientPath.merge_request_notes.format(
-                project_id=quote(str(project_id), safe=""), pr_key=pr_key
+                project_id=safe_quote(project_id), pr_key=pr_key
             ),
             data=data,
         )
@@ -427,7 +429,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
     ) -> Any:
         project_id = repo.config["project_id"]
         url = GitLabApiClientPath.merge_request_note.format(
-            project_id=quote(str(project_id), safe=""),
+            project_id=safe_quote(project_id),
             pr_key=pr.key,
             note_id=pr_comment.external_id,
         )
@@ -441,21 +443,21 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
     ) -> Any:
         return self.delete(
             GitLabApiClientPath.merge_request_note.format(
-                project_id=quote(str(project_id), safe=""), pr_key=pr_key, note_id=note_id
+                project_id=safe_quote(project_id), pr_key=pr_key, note_id=note_id
             )
         )
 
     def get_merge_request_awards(self, project_id: str, pr_key: str):
         return self.get(
             GitLabApiClientPath.merge_request_awards.format(
-                project_id=quote(str(project_id), safe=""), pr_key=pr_key
+                project_id=safe_quote(project_id), pr_key=pr_key
             )
         )
 
     def create_merge_request_award(self, project_id: str, pr_key: str, emoji: str):
         return self.post(
             GitLabApiClientPath.merge_request_awards.format(
-                project_id=quote(str(project_id), safe=""), pr_key=pr_key
+                project_id=safe_quote(project_id), pr_key=pr_key
             ),
             params={"name": emoji},
         )
@@ -463,14 +465,14 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
     def delete_merge_request_award(self, project_id: str, pr_key: str, award_id: str):
         return self.delete(
             GitLabApiClientPath.merge_request_award.format(
-                project_id=quote(str(project_id), safe=""), pr_key=pr_key, award_id=award_id
+                project_id=safe_quote(project_id), pr_key=pr_key, award_id=award_id
             )
         )
 
     def get_merge_request_note_awards(self, project_id: str, pr_key: str, note_id: str):
         return self.get(
             GitLabApiClientPath.merge_request_note_awards.format(
-                project_id=quote(str(project_id), safe=""), pr_key=pr_key, note_id=note_id
+                project_id=safe_quote(project_id), pr_key=pr_key, note_id=note_id
             )
         )
 
@@ -479,7 +481,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
     ):
         return self.post(
             GitLabApiClientPath.merge_request_note_awards.format(
-                project_id=quote(str(project_id), safe=""), pr_key=pr_key, note_id=note_id
+                project_id=safe_quote(project_id), pr_key=pr_key, note_id=note_id
             ),
             params={"name": emoji},
         )
@@ -489,7 +491,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
     ):
         return self.delete(
             GitLabApiClientPath.merge_request_note_award.format(
-                project_id=quote(str(project_id), safe=""),
+                project_id=safe_quote(project_id),
                 pr_key=pr_key,
                 note_id=note_id,
                 award_id=award_id,
@@ -501,7 +503,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
 
         See https://docs.gitlab.com/ee/api/issues.html#list-project-issues
         """
-        path = GitLabApiClientPath.project_issues.format(project=quote(str(project_id), safe=""))
+        path = GitLabApiClientPath.project_issues.format(project=safe_quote(project_id))
 
         return self.get(path, params={"scope": "all", "search": query, "iids": iids})
 
@@ -511,9 +513,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
         See https://docs.gitlab.com/ee/api/issues.html#edit-an-issue
         """
         data = {"assignee_ids": assignee_ids}
-        path = GitLabApiClientPath.issue.format(
-            project=quote(str(project_id), safe=""), issue=issue_iid
-        )
+        path = GitLabApiClientPath.issue.format(project=safe_quote(project_id), issue=issue_iid)
         return self.put(path, data=data)
 
     def update_issue_status(self, project_id: str, issue_iid: str, state: str):
@@ -521,9 +521,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
 
         See https://docs.gitlab.com/ee/api/issues.html#edit-an-issue
         """
-        path = GitLabApiClientPath.issue.format(
-            project=quote(str(project_id), safe=""), issue=issue_iid
-        )
+        path = GitLabApiClientPath.issue.format(project=safe_quote(project_id), issue=issue_iid)
         return self.put(path, data={"state_event": state})
 
     def create_project_webhook(self, project_id):
@@ -531,7 +529,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
 
         See https://docs.gitlab.com/ee/api/projects.html#add-project-hook
         """
-        path = GitLabApiClientPath.project_hooks.format(project=quote(str(project_id), safe=""))
+        path = GitLabApiClientPath.project_hooks.format(project=safe_quote(project_id))
         hook_uri = reverse("sentry-extensions-gitlab-webhook")
         model = self.installation.model
         data = {
@@ -551,7 +549,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
 
         See https://docs.gitlab.com/ee/api/projects.html#list-project-hooks
         """
-        path = GitLabApiClientPath.project_hooks.format(project=quote(str(project_id), safe=""))
+        path = GitLabApiClientPath.project_hooks.format(project=safe_quote(project_id))
         return self.get(path)
 
     def update_project_webhook(self, project_id, hook_id):
@@ -560,7 +558,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
         See https://docs.gitlab.com/ee/api/projects.html#edit-project-hook
         """
         path = GitLabApiClientPath.project_hook.format(
-            project=quote(str(project_id), safe=""), hook_id=hook_id
+            project=safe_quote(project_id), hook_id=hook_id
         )
         hook_uri = reverse("sentry-extensions-gitlab-webhook")
         model = self.installation.model
@@ -580,14 +578,14 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
         See https://docs.gitlab.com/ee/api/projects.html#delete-project-hook
         """
         path = GitLabApiClientPath.project_hook.format(
-            project=quote(str(project_id), safe=""), hook_id=hook_id
+            project=safe_quote(project_id), hook_id=hook_id
         )
         return self.delete(path)
 
     def create_branch(self, project_id: str, branch: str, ref: str):
         """https://docs.gitlab.com/api/branches/#create-repository-branch"""
         return self.post(
-            GitLabApiClientPath.branches.format(project_id=quote(str(project_id), safe="")),
+            GitLabApiClientPath.branches.format(project_id=safe_quote(project_id)),
             params={"branch": branch, "ref": ref},
         )
 
@@ -595,7 +593,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
         """https://docs.gitlab.com/api/branches/#retrieve-a-repository-branch"""
         return self.get(
             GitLabApiClientPath.branch.format(
-                project_id=quote(str(project_id), safe=""), branch=quote(branch, safe="")
+                project_id=safe_quote(project_id), branch=quote(branch, safe="")
             )
         )
 
@@ -609,15 +607,13 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
         See https://docs.gitlab.com/ee/api/commits.html#get-a-single-commit and
         https://docs.gitlab.com/ee/api/commits.html#list-repository-commits
         """
-        path = GitLabApiClientPath.commit.format(
-            project=quote(str(project_id), safe=""), sha=end_sha
-        )
+        path = GitLabApiClientPath.commit.format(project=safe_quote(project_id), sha=end_sha)
         commit = self.get(path)
         if not commit:
             return []
         end_date = commit["created_at"]
 
-        path = GitLabApiClientPath.commits.format(project=quote(str(project_id), safe=""))
+        path = GitLabApiClientPath.commits.format(project=safe_quote(project_id))
         return self.get(path, params={"until": end_date})
 
     def get_commit(self, project_id, sha):
@@ -626,7 +622,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
         See https://docs.gitlab.com/ee/api/commits.html#get-a-single-commit
         """
         return self.get_cached(
-            GitLabApiClientPath.commit.format(project=quote(str(project_id), safe=""), sha=sha)
+            GitLabApiClientPath.commit.format(project=safe_quote(project_id), sha=sha)
         )
 
     def get_commits(self, project_id, ref: str | None, path: str | None):
@@ -640,7 +636,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
         if path:
             params["path"] = path
         return self.get(
-            GitLabApiClientPath.commits.format(project=quote(str(project_id), safe="")),
+            GitLabApiClientPath.commits.format(project=safe_quote(project_id)),
             params=params,
         )
 
@@ -651,7 +647,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
         """
         project_id = repo.config["project_id"]
         path = GitLabApiClientPath.commit_merge_requests.format(
-            project=quote(str(project_id), safe=""), sha=sha
+            project=safe_quote(project_id), sha=sha
         )
         response = self.get(path)
 
@@ -673,7 +669,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
 
         See https://docs.gitlab.com/ee/api/repositories.html#compare-branches-tags-or-commits
         """
-        path = GitLabApiClientPath.compare.format(project=quote(str(project_id), safe=""))
+        path = GitLabApiClientPath.compare.format(project=safe_quote(project_id))
         return self.get(path, params={"from": start_sha, "to": end_sha})
 
     def get_diff(self, project_id, sha):
@@ -681,7 +677,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
 
         See https://docs.gitlab.com/ee/api/commits.html#get-the-diff-of-a-commit
         """
-        path = GitLabApiClientPath.diff.format(project=quote(str(project_id), safe=""), sha=sha)
+        path = GitLabApiClientPath.diff.format(project=safe_quote(project_id), sha=sha)
         return self.get(path)
 
     def check_file(self, repo: Repository, path: str, version: str | None) -> object | None:
@@ -695,7 +691,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
         encoded_path = quote(path, safe="")
 
         request_path = GitLabApiClientPath.file.format(
-            project=quote(str(project_id), safe=""), path=encoded_path
+            project=safe_quote(project_id), path=encoded_path
         )
 
         # Gitlab can return 404 or 400 if the file doesn't exist
@@ -704,7 +700,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
     def get_file_content(self, project_id: str, path: str, ref: str | None):
         return self.get(
             GitLabApiClientPath.file.format(
-                project=quote(str(project_id), safe=""), path=quote(path, safe="")
+                project=safe_quote(project_id), path=quote(path, safe="")
             ),
             params={"ref": ref},
         )
@@ -722,7 +718,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
         project_id = repo.config["project_id"]
         encoded_path = quote(path, safe="")
         request_path = GitLabApiClientPath.file_raw.format(
-            project=quote(str(project_id), safe=""), path=encoded_path
+            project=safe_quote(project_id), path=encoded_path
         )
 
         contents = self.get(request_path, params={"ref": ref}, raw_response=True)
@@ -747,7 +743,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
     def get_pr_diffs(self, repo: Repository, pr: PullRequest) -> list[dict[str, Any]]:
         project_id = repo.config["project_id"]
         path = GitLabApiClientPath.build_pr_diffs(
-            project=quote(str(project_id), safe=""), pr_key=pr.key, unidiff=True
+            project=safe_quote(project_id), pr_key=pr.key, unidiff=True
         )
         return self.get(path)
 
@@ -762,19 +758,17 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
         if recursive:
             params["recursive"] = "true"
         return self.get(
-            GitLabApiClientPath.tree.format(project=quote(str(project_id), safe="")), params=params
+            GitLabApiClientPath.tree.format(project=safe_quote(project_id)), params=params
         )
 
     def get_merge_request_diffs(self, project_id: str, pr_key: str) -> list[dict[str, Any]]:
         return self.get(
-            GitLabApiClientPath.pr_diffs.format(
-                project=quote(str(project_id), safe=""), pr_key=pr_key
-            )
+            GitLabApiClientPath.pr_diffs.format(project=safe_quote(project_id), pr_key=pr_key)
         )
 
     def get_merge_request_commits(self, project_id: str, pr_key: str) -> list[dict[str, Any]]:
         return self.get(
             GitLabApiClientPath.merge_request_commits.format(
-                project_id=quote(str(project_id), safe=""), pr_key=pr_key
+                project_id=safe_quote(project_id), pr_key=pr_key
             )
         )

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -282,7 +282,8 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
         See https://docs.gitlab.com/ee/api/notes.html#create-new-issue-note
         """
         return self.post(
-            GitLabApiClientPath.issue_notes.format(project_id=repo, issue_id=issue_id), data=data
+            GitLabApiClientPath.issue_notes.format(project_id=safe_quote(repo), issue_id=issue_id),
+            data=data,
         )
 
     def update_comment(self, repo: str, issue_id: str, comment_id: str, data: dict[str, Any]):
@@ -292,7 +293,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
         """
         return self.put(
             GitLabApiClientPath.issue_note.format(
-                project_id=repo, issue_id=issue_id, note_id=comment_id
+                project_id=safe_quote(repo), issue_id=issue_id, note_id=comment_id
             ),
             data=data,
         )
@@ -302,21 +303,21 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
 
         return self.delete(
             GitLabApiClientPath.issue_note.format(
-                project_id=repo, issue_id=issue_id, note_id=comment_id
+                project_id=safe_quote(repo), issue_id=issue_id, note_id=comment_id
             )
         )
 
     def get_issue_note_awards(self, repo: str, issue_id: str, note_id: str):
         return self.get(
             GitLabApiClientPath.issue_note_awards.format(
-                project_id=repo, issue_id=issue_id, note_id=note_id
+                project_id=safe_quote(repo), issue_id=issue_id, note_id=note_id
             )
         )
 
     def create_issue_note_award(self, repo: str, issue_id: str, note_id: str, emoji: str):
         return self.post(
             GitLabApiClientPath.issue_note_awards.format(
-                project_id=repo, issue_id=issue_id, note_id=note_id
+                project_id=safe_quote(repo), issue_id=issue_id, note_id=note_id
             ),
             params={"name": emoji},
         )
@@ -324,7 +325,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
     def delete_issue_note_award(self, repo: str, issue_id: str, note_id: str, award_id: str):
         return self.delete(
             GitLabApiClientPath.issue_note_award.format(
-                project_id=repo, issue_id=issue_id, note_id=note_id, award_id=award_id
+                project_id=safe_quote(repo), issue_id=issue_id, note_id=note_id, award_id=award_id
             )
         )
 
@@ -409,7 +410,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
 
     def create_pr_comment(self, repo: Repository, pr: PullRequest, data: dict[str, Any]) -> Any:
         return self.create_merge_request_note(
-            project_id=repo.config["project_id"], pr_key=pr.key, data=data
+            project_id=safe_quote(repo.config["project_id"]), pr_key=pr.key, data=data
         )
 
     def create_merge_request_note(self, project_id: str, pr_key: str, data: dict[str, Any]) -> Any:

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -33,7 +33,7 @@ logger = logging.getLogger("sentry.integrations.gitlab")
 
 
 def safe_quote(s: Any) -> str:
-    return quote(unquote(s), safe="")
+    return quote(unquote(str(s)), safe="")
 
 
 class GitLabSetupApiClient(IntegrationProxyClient):

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 import logging
 from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any
-from urllib.parse import quote, unquote
+from urllib.parse import quote
 
 from django.urls import reverse
 from requests import PreparedRequest
 
 from sentry.identity.services.identity.model import RpcIdentity
 from sentry.integrations.gitlab.blame import fetch_file_blames
-from sentry.integrations.gitlab.utils import GitLabApiClientPath
+from sentry.integrations.gitlab.utils import GitLabApiClientPath, safe_quote
 from sentry.integrations.source_code_management.commit_context import (
     CommitContextClient,
     FileBlameInfo,
@@ -30,10 +30,6 @@ if TYPE_CHECKING:
     from sentry.integrations.gitlab.integration import GitlabIntegration
 
 logger = logging.getLogger("sentry.integrations.gitlab")
-
-
-def safe_quote(s: Any) -> str:
-    return quote(unquote(str(s)), safe="")
 
 
 class GitLabSetupApiClient(IntegrationProxyClient):

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -410,7 +410,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
 
     def create_pr_comment(self, repo: Repository, pr: PullRequest, data: dict[str, Any]) -> Any:
         return self.create_merge_request_note(
-            project_id=safe_quote(repo.config["project_id"]), pr_key=pr.key, data=data
+            project_id=repo.config["project_id"], pr_key=pr.key, data=data
         )
 
     def create_merge_request_note(self, project_id: str, pr_key: str, data: dict[str, Any]) -> Any:

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -244,7 +244,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
 
         See https://docs.gitlab.com/ee/api/issues.html#new-issue
         """
-        return self.post(GitLabApiClientPath.issues.format(project=project), data=data)
+        return self.post(GitLabApiClientPath.issues.format(project=safe_quote(project)), data=data)
 
     def get_issue_awards(self, project_id: str, issue_id: str):
         return self.get(

--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -221,7 +221,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
 
         See https://docs.gitlab.com/ee/api/projects.html#get-single-project
         """
-        return self.get(GitLabApiClientPath.project.format(project=project_id))
+        return self.get(GitLabApiClientPath.project.format(project=quote(str(project_id), safe="")))
 
     def get_issue(self, project_id, issue_id):
         """Get an issue
@@ -229,7 +229,11 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
         See https://docs.gitlab.com/ee/api/issues.html#single-issue
         """
         try:
-            return self.get(GitLabApiClientPath.issue.format(project=project_id, issue=issue_id))
+            return self.get(
+                GitLabApiClientPath.issue.format(
+                    project=quote(str(project_id), safe=""), issue=issue_id
+                )
+            )
         except IndexError:
             raise ApiError("Issue not found with ID", 404)
 
@@ -242,26 +246,32 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
 
     def get_issue_awards(self, project_id: str, issue_id: str):
         return self.get(
-            GitLabApiClientPath.issue_awards.format(project_id=project_id, issue_id=issue_id)
+            GitLabApiClientPath.issue_awards.format(
+                project_id=quote(str(project_id), safe=""), issue_id=issue_id
+            )
         )
 
     def create_issue_award(self, project_id: str, issue_id: str, emoji: str):
         return self.post(
-            GitLabApiClientPath.issue_awards.format(project_id=project_id, issue_id=issue_id),
+            GitLabApiClientPath.issue_awards.format(
+                project_id=quote(str(project_id), safe=""), issue_id=issue_id
+            ),
             params={"name": emoji},
         )
 
     def delete_issue_award(self, project_id: str, issue_id: str, award_id: str):
         return self.delete(
             GitLabApiClientPath.issue_award.format(
-                project_id=project_id, issue_id=issue_id, award_id=award_id
+                project_id=quote(str(project_id), safe=""), issue_id=issue_id, award_id=award_id
             )
         )
 
     def get_issue_notes(self, project_id: str, issue_id: str):
         """https://docs.gitlab.com/api/notes/#list-all-issue-notes"""
         return self.get(
-            GitLabApiClientPath.issue_notes.format(project_id=project_id, issue_id=issue_id)
+            GitLabApiClientPath.issue_notes.format(
+                project_id=quote(str(project_id), safe=""), issue_id=issue_id
+            )
         )
 
     def create_comment(self, repo: str, issue_id: str, data: dict[str, Any]):
@@ -318,7 +328,9 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
 
     def get_merge_request(self, project_id: str, pr_key: str) -> Any:
         return self.get(
-            GitLabApiClientPath.merge_request.format(project_id=project_id, pr_key=pr_key)
+            GitLabApiClientPath.merge_request.format(
+                project_id=quote(str(project_id), safe=""), pr_key=pr_key
+            )
         )
 
     def get_merge_requests(self, project_id: str, state: str | None = None) -> Any:
@@ -327,29 +339,36 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
         else:
             params = {"state": state}
         return self.get(
-            GitLabApiClientPath.merge_requests.format(project_id=project_id),
+            GitLabApiClientPath.merge_requests.format(project_id=quote(str(project_id), safe="")),
             params=params,
         )
 
     def create_merge_request(self, project_id: str, data: dict[str, Any]) -> Any:
         return self.post(
-            GitLabApiClientPath.merge_requests.format(project_id=project_id), data=data
+            GitLabApiClientPath.merge_requests.format(project_id=quote(str(project_id), safe="")),
+            data=data,
         )
 
     def update_merge_request(self, project_id: str, pr_key: str, data: dict[str, Any]) -> Any:
         return self.put(
-            GitLabApiClientPath.merge_request.format(project_id=project_id, pr_key=pr_key),
+            GitLabApiClientPath.merge_request.format(
+                project_id=quote(str(project_id), safe=""), pr_key=pr_key
+            ),
             data=data,
         )
 
     def get_merge_request_notes(self, project_id: str, pr_key: str) -> Any:
         return self.get(
-            GitLabApiClientPath.merge_request_notes.format(project_id=project_id, pr_key=pr_key)
+            GitLabApiClientPath.merge_request_notes.format(
+                project_id=quote(str(project_id), safe=""), pr_key=pr_key
+            )
         )
 
     def get_merge_request_versions(self, project_id: str, pr_key: str) -> Any:
         return self.get(
-            GitLabApiClientPath.merge_request_versions.format(project_id=project_id, pr_key=pr_key)
+            GitLabApiClientPath.merge_request_versions.format(
+                project_id=quote(str(project_id), safe=""), pr_key=pr_key
+            )
         )
 
     def create_merge_request_discussion(
@@ -357,7 +376,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
     ) -> Any:
         return self.post(
             GitLabApiClientPath.merge_request_discussions.format(
-                project_id=project_id, pr_key=pr_key
+                project_id=quote(str(project_id), safe=""), pr_key=pr_key
             ),
             data=data,
         )
@@ -367,7 +386,9 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
     ) -> Any:
         return self.post(
             GitLabApiClientPath.merge_request_discussion_notes.format(
-                project_id=project_id, pr_key=pr_key, discussion_id=discussion_id
+                project_id=quote(str(project_id), safe=""),
+                pr_key=pr_key,
+                discussion_id=discussion_id,
             ),
             data=data,
         )
@@ -377,7 +398,9 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
     ) -> Any:
         return self.put(
             GitLabApiClientPath.merge_request_discussion.format(
-                project_id=project_id, pr_key=pr_key, discussion_id=discussion_id
+                project_id=quote(str(project_id), safe=""),
+                pr_key=pr_key,
+                discussion_id=discussion_id,
             ),
             params={"resolved": resolved},
         )
@@ -389,7 +412,9 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
 
     def create_merge_request_note(self, project_id: str, pr_key: str, data: dict[str, Any]) -> Any:
         return self.post(
-            GitLabApiClientPath.merge_request_notes.format(project_id=project_id, pr_key=pr_key),
+            GitLabApiClientPath.merge_request_notes.format(
+                project_id=quote(str(project_id), safe=""), pr_key=pr_key
+            ),
             data=data,
         )
 
@@ -402,7 +427,9 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
     ) -> Any:
         project_id = repo.config["project_id"]
         url = GitLabApiClientPath.merge_request_note.format(
-            project_id=project_id, pr_key=pr.key, note_id=pr_comment.external_id
+            project_id=quote(str(project_id), safe=""),
+            pr_key=pr.key,
+            note_id=pr_comment.external_id,
         )
         return self.put(url, data=data)
 
@@ -414,32 +441,36 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
     ) -> Any:
         return self.delete(
             GitLabApiClientPath.merge_request_note.format(
-                project_id=project_id, pr_key=pr_key, note_id=note_id
+                project_id=quote(str(project_id), safe=""), pr_key=pr_key, note_id=note_id
             )
         )
 
     def get_merge_request_awards(self, project_id: str, pr_key: str):
         return self.get(
-            GitLabApiClientPath.merge_request_awards.format(project_id=project_id, pr_key=pr_key)
+            GitLabApiClientPath.merge_request_awards.format(
+                project_id=quote(str(project_id), safe=""), pr_key=pr_key
+            )
         )
 
     def create_merge_request_award(self, project_id: str, pr_key: str, emoji: str):
         return self.post(
-            GitLabApiClientPath.merge_request_awards.format(project_id=project_id, pr_key=pr_key),
+            GitLabApiClientPath.merge_request_awards.format(
+                project_id=quote(str(project_id), safe=""), pr_key=pr_key
+            ),
             params={"name": emoji},
         )
 
     def delete_merge_request_award(self, project_id: str, pr_key: str, award_id: str):
         return self.delete(
             GitLabApiClientPath.merge_request_award.format(
-                project_id=project_id, pr_key=pr_key, award_id=award_id
+                project_id=quote(str(project_id), safe=""), pr_key=pr_key, award_id=award_id
             )
         )
 
     def get_merge_request_note_awards(self, project_id: str, pr_key: str, note_id: str):
         return self.get(
             GitLabApiClientPath.merge_request_note_awards.format(
-                project_id=project_id, pr_key=pr_key, note_id=note_id
+                project_id=quote(str(project_id), safe=""), pr_key=pr_key, note_id=note_id
             )
         )
 
@@ -448,7 +479,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
     ):
         return self.post(
             GitLabApiClientPath.merge_request_note_awards.format(
-                project_id=project_id, pr_key=pr_key, note_id=note_id
+                project_id=quote(str(project_id), safe=""), pr_key=pr_key, note_id=note_id
             ),
             params={"name": emoji},
         )
@@ -458,7 +489,10 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
     ):
         return self.delete(
             GitLabApiClientPath.merge_request_note_award.format(
-                project_id=project_id, pr_key=pr_key, note_id=note_id, award_id=award_id
+                project_id=quote(str(project_id), safe=""),
+                pr_key=pr_key,
+                note_id=note_id,
+                award_id=award_id,
             )
         )
 
@@ -477,7 +511,9 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
         See https://docs.gitlab.com/ee/api/issues.html#edit-an-issue
         """
         data = {"assignee_ids": assignee_ids}
-        path = GitLabApiClientPath.issue.format(project=project_id, issue=issue_iid)
+        path = GitLabApiClientPath.issue.format(
+            project=quote(str(project_id), safe=""), issue=issue_iid
+        )
         return self.put(path, data=data)
 
     def update_issue_status(self, project_id: str, issue_iid: str, state: str):
@@ -485,7 +521,9 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
 
         See https://docs.gitlab.com/ee/api/issues.html#edit-an-issue
         """
-        path = GitLabApiClientPath.issue.format(project=project_id, issue=issue_iid)
+        path = GitLabApiClientPath.issue.format(
+            project=quote(str(project_id), safe=""), issue=issue_iid
+        )
         return self.put(path, data={"state_event": state})
 
     def create_project_webhook(self, project_id):
@@ -493,7 +531,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
 
         See https://docs.gitlab.com/ee/api/projects.html#add-project-hook
         """
-        path = GitLabApiClientPath.project_hooks.format(project=project_id)
+        path = GitLabApiClientPath.project_hooks.format(project=quote(str(project_id), safe=""))
         hook_uri = reverse("sentry-extensions-gitlab-webhook")
         model = self.installation.model
         data = {
@@ -513,7 +551,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
 
         See https://docs.gitlab.com/ee/api/projects.html#list-project-hooks
         """
-        path = GitLabApiClientPath.project_hooks.format(project=project_id)
+        path = GitLabApiClientPath.project_hooks.format(project=quote(str(project_id), safe=""))
         return self.get(path)
 
     def update_project_webhook(self, project_id, hook_id):
@@ -521,7 +559,9 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
 
         See https://docs.gitlab.com/ee/api/projects.html#edit-project-hook
         """
-        path = GitLabApiClientPath.project_hook.format(project=project_id, hook_id=hook_id)
+        path = GitLabApiClientPath.project_hook.format(
+            project=quote(str(project_id), safe=""), hook_id=hook_id
+        )
         hook_uri = reverse("sentry-extensions-gitlab-webhook")
         model = self.installation.model
         data = {
@@ -539,20 +579,24 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
 
         See https://docs.gitlab.com/ee/api/projects.html#delete-project-hook
         """
-        path = GitLabApiClientPath.project_hook.format(project=project_id, hook_id=hook_id)
+        path = GitLabApiClientPath.project_hook.format(
+            project=quote(str(project_id), safe=""), hook_id=hook_id
+        )
         return self.delete(path)
 
     def create_branch(self, project_id: str, branch: str, ref: str):
         """https://docs.gitlab.com/api/branches/#create-repository-branch"""
         return self.post(
-            GitLabApiClientPath.branches.format(project_id=project_id),
+            GitLabApiClientPath.branches.format(project_id=quote(str(project_id), safe="")),
             params={"branch": branch, "ref": ref},
         )
 
     def get_branch(self, project_id: str, branch: str):
         """https://docs.gitlab.com/api/branches/#retrieve-a-repository-branch"""
         return self.get(
-            GitLabApiClientPath.branch.format(project_id=project_id, branch=quote(branch, safe=""))
+            GitLabApiClientPath.branch.format(
+                project_id=quote(str(project_id), safe=""), branch=quote(branch, safe="")
+            )
         )
 
     def get_last_commits(self, project_id, end_sha):
@@ -565,13 +609,15 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
         See https://docs.gitlab.com/ee/api/commits.html#get-a-single-commit and
         https://docs.gitlab.com/ee/api/commits.html#list-repository-commits
         """
-        path = GitLabApiClientPath.commit.format(project=project_id, sha=end_sha)
+        path = GitLabApiClientPath.commit.format(
+            project=quote(str(project_id), safe=""), sha=end_sha
+        )
         commit = self.get(path)
         if not commit:
             return []
         end_date = commit["created_at"]
 
-        path = GitLabApiClientPath.commits.format(project=project_id)
+        path = GitLabApiClientPath.commits.format(project=quote(str(project_id), safe=""))
         return self.get(path, params={"until": end_date})
 
     def get_commit(self, project_id, sha):
@@ -579,7 +625,9 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
         Get the details of a commit
         See https://docs.gitlab.com/ee/api/commits.html#get-a-single-commit
         """
-        return self.get_cached(GitLabApiClientPath.commit.format(project=project_id, sha=sha))
+        return self.get_cached(
+            GitLabApiClientPath.commit.format(project=quote(str(project_id), safe=""), sha=sha)
+        )
 
     def get_commits(self, project_id, ref: str | None, path: str | None):
         """
@@ -591,7 +639,10 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
             params["ref_name"] = ref
         if path:
             params["path"] = path
-        return self.get(GitLabApiClientPath.commits.format(project=project_id), params=params)
+        return self.get(
+            GitLabApiClientPath.commits.format(project=quote(str(project_id), safe="")),
+            params=params,
+        )
 
     def get_merge_commit_sha_from_commit(self, repo: Repository, sha: str) -> str | None:
         """
@@ -599,7 +650,9 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
         See https://docs.gitlab.com/api/commits/#list-merge-requests-associated-with-a-commit
         """
         project_id = repo.config["project_id"]
-        path = GitLabApiClientPath.commit_merge_requests.format(project=project_id, sha=sha)
+        path = GitLabApiClientPath.commit_merge_requests.format(
+            project=quote(str(project_id), safe=""), sha=sha
+        )
         response = self.get(path)
 
         # Filter out non-merged merge requests
@@ -620,7 +673,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
 
         See https://docs.gitlab.com/ee/api/repositories.html#compare-branches-tags-or-commits
         """
-        path = GitLabApiClientPath.compare.format(project=project_id)
+        path = GitLabApiClientPath.compare.format(project=quote(str(project_id), safe=""))
         return self.get(path, params={"from": start_sha, "to": end_sha})
 
     def get_diff(self, project_id, sha):
@@ -628,7 +681,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
 
         See https://docs.gitlab.com/ee/api/commits.html#get-the-diff-of-a-commit
         """
-        path = GitLabApiClientPath.diff.format(project=project_id, sha=sha)
+        path = GitLabApiClientPath.diff.format(project=quote(str(project_id), safe=""), sha=sha)
         return self.get(path)
 
     def check_file(self, repo: Repository, path: str, version: str | None) -> object | None:
@@ -641,14 +694,18 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
         project_id = repo.config["project_id"]
         encoded_path = quote(path, safe="")
 
-        request_path = GitLabApiClientPath.file.format(project=project_id, path=encoded_path)
+        request_path = GitLabApiClientPath.file.format(
+            project=quote(str(project_id), safe=""), path=encoded_path
+        )
 
         # Gitlab can return 404 or 400 if the file doesn't exist
         return self.head_cached(request_path, params={"ref": version})
 
     def get_file_content(self, project_id: str, path: str, ref: str | None):
         return self.get(
-            GitLabApiClientPath.file.format(project=project_id, path=quote(path, safe="")),
+            GitLabApiClientPath.file.format(
+                project=quote(str(project_id), safe=""), path=quote(path, safe="")
+            ),
             params={"ref": ref},
         )
 
@@ -664,7 +721,9 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
 
         project_id = repo.config["project_id"]
         encoded_path = quote(path, safe="")
-        request_path = GitLabApiClientPath.file_raw.format(project=project_id, path=encoded_path)
+        request_path = GitLabApiClientPath.file_raw.format(
+            project=quote(str(project_id), safe=""), path=encoded_path
+        )
 
         contents = self.get(request_path, params={"ref": ref}, raw_response=True)
         result = contents.content.decode("utf-8")
@@ -687,7 +746,9 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
 
     def get_pr_diffs(self, repo: Repository, pr: PullRequest) -> list[dict[str, Any]]:
         project_id = repo.config["project_id"]
-        path = GitLabApiClientPath.build_pr_diffs(project=project_id, pr_key=pr.key, unidiff=True)
+        path = GitLabApiClientPath.build_pr_diffs(
+            project=quote(str(project_id), safe=""), pr_key=pr.key, unidiff=True
+        )
         return self.get(path)
 
     def get_repository_tree(
@@ -700,12 +761,20 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
         params: dict[str, str] = {"ref": ref, "per_page": "100"}
         if recursive:
             params["recursive"] = "true"
-        return self.get(GitLabApiClientPath.tree.format(project=project_id), params=params)
+        return self.get(
+            GitLabApiClientPath.tree.format(project=quote(str(project_id), safe="")), params=params
+        )
 
     def get_merge_request_diffs(self, project_id: str, pr_key: str) -> list[dict[str, Any]]:
-        return self.get(GitLabApiClientPath.pr_diffs.format(project=project_id, pr_key=pr_key))
+        return self.get(
+            GitLabApiClientPath.pr_diffs.format(
+                project=quote(str(project_id), safe=""), pr_key=pr_key
+            )
+        )
 
     def get_merge_request_commits(self, project_id: str, pr_key: str) -> list[dict[str, Any]]:
         return self.get(
-            GitLabApiClientPath.merge_request_commits.format(project_id=project_id, pr_key=pr_key)
+            GitLabApiClientPath.merge_request_commits.format(
+                project_id=quote(str(project_id), safe=""), pr_key=pr_key
+            )
         )

--- a/src/sentry/integrations/gitlab/utils.py
+++ b/src/sentry/integrations/gitlab/utils.py
@@ -1,6 +1,7 @@
 from collections.abc import Mapping
 from datetime import datetime
-from urllib.parse import urlencode, urlparse
+from typing import Any
+from urllib.parse import quote, unquote, urlencode, urlparse
 
 from sentry.shared_integrations.response.base import BaseApiResponse
 
@@ -138,3 +139,7 @@ def parse_gitlab_blob_url(repo_url: str, source_url: str) -> tuple[str, str]:
 
     branch, _, remainder = after_blob.partition("/")
     return branch, remainder.lstrip("/")
+
+
+def safe_quote(s: Any) -> str:
+    return quote(unquote(str(s)), safe="")


### PR DESCRIPTION
GitLab accepts integer project-ids and project-ids formatted as `org-name/repo-name`[0]. If given as the latter we need to escape the slash otherwise it resolves to an unknown path in GitLab.

This fixes a regression introduced in: https://github.com/getsentry/sentry/pull/107216
The Sentry error can be found here: https://sentry.sentry.io/issues/7437099703/?project=1&referrer=issue-list&statsPeriod=7d

This does not fix any other bugs that may have been introduced by this interface change.

0. https://docs.gitlab.com/api/rest/#namespaced-paths