### PR TITLE
ref(tsc): Remove any from QueryKeyEndpointOptions

### DIFF
--- a/static/app/components/events/interfaces/frame/useStacktraceLink.tsx
+++ b/static/app/components/events/interfaces/frame/useStacktraceLink.tsx
@@ -13,7 +13,7 @@ interface UseStacktraceLinkProps {
   projectSlug: string | undefined;
 }
 
-interface StacktraceLinkQuery {
+type StacktraceLinkQuery = {
   file: string;
   lineNo: number;
   platform: string;
@@ -23,7 +23,7 @@ interface StacktraceLinkQuery {
   module?: string;
   package?: string;
   sdkName?: string;
-}
+};
 
 export function buildStacktraceLinkQuery(
   event: UseStacktraceLinkProps['event'],

--- a/static/app/components/replays/table/deleteReplays.tsx
+++ b/static/app/components/replays/table/deleteReplays.tsx
@@ -36,9 +36,7 @@ import {useProjects} from 'sentry/utils/useProjects';
 import type {ReplayListRecord} from 'sentry/views/explore/replays/types';
 
 interface Props {
-  queryOptions:
-    | QueryKeyEndpointOptions<unknown, Record<string, string>, unknown>
-    | undefined;
+  queryOptions: QueryKeyEndpointOptions | undefined;
   replays: ReplayListRecord[];
   selectedIds: 'all' | string[];
 }

--- a/static/app/components/replays/table/replayTableHeader.tsx
+++ b/static/app/components/replays/table/replayTableHeader.tsx
@@ -43,7 +43,7 @@ export function ReplayTableHeader({
   const queryOptions = queryKeyRef.current
     ? parseQueryKey(queryKeyRef.current).options
     : undefined;
-  const queryString = queryOptions?.query?.query;
+  const queryString = queryOptions?.query?.query as string | undefined;
 
   const headerStyle: React.CSSProperties = stickyHeader
     ? {position: 'sticky', top: 0}

--- a/static/app/utils/api/apiQueryKey.ts
+++ b/static/app/utils/api/apiQueryKey.ts
@@ -6,16 +6,12 @@ export type RequestMethod = 'DELETE' | 'GET' | 'POST' | 'PUT';
 
 type ApiUrl = ReturnType<typeof getApiUrl>;
 
-export type QueryKeyEndpointOptions<
-  Headers = Record<string, string>,
-  Query = Record<string, any>,
-  Data = Record<string, any>,
-> = {
-  data?: Data;
-  headers?: Headers;
+export type QueryKeyEndpointOptions = {
+  data?: Record<string, unknown>;
+  headers?: Record<string, string>;
   host?: string;
   method?: RequestMethod;
-  query?: Query;
+  query?: Record<string, unknown>;
 };
 
 const apiUrlSchema = z.custom<ApiUrl>(val => typeof val === 'string');

--- a/static/app/utils/queryClient.tsx
+++ b/static/app/utils/queryClient.tsx
@@ -191,15 +191,11 @@ export function setApiQueryData<TResponseData>(
   return updateResult?.[0];
 }
 
-type ApiMutationVariables<
-  Headers extends Record<string, unknown> = Record<string, string>,
-  Query extends Record<string, unknown> = Record<string, any>,
-  Data extends Record<string, unknown> = Record<string, unknown>,
-> = {
+type ApiMutationVariables = {
   method: 'PUT' | 'POST' | 'DELETE';
   url: string;
-  data?: Data;
-  options?: Pick<QueryKeyEndpointOptions<Headers, Query>, 'query' | 'headers' | 'host'>;
+  data?: Record<string, unknown>;
+  options?: Pick<QueryKeyEndpointOptions, 'query' | 'headers' | 'host'>;
 };
 
 /**

--- a/static/app/utils/replays/hooks/useDeleteReplays.tsx
+++ b/static/app/utils/replays/hooks/useDeleteReplays.tsx
@@ -53,9 +53,9 @@ export function useDeleteReplays({projectSlug}: Props) {
   const queryOptionsToPayload = useCallback(
     (
       selectedIds: 'all' | string[],
-      queryOptions: QueryKeyEndpointOptions<unknown, Record<string, string>, unknown>
+      queryOptions: QueryKeyEndpointOptions
     ): ReplayBulkDeletePayload => {
-      const environments = queryOptions?.query?.environment ?? [];
+      const environments = (queryOptions?.query?.environment as string | undefined) ?? [];
 
       const query = queryOptions?.query ?? {};
       const normalizedQuery = normalizeDateTimeParams(query);
@@ -70,7 +70,7 @@ export function useDeleteReplays({projectSlug}: Props) {
         environments: environments.length === 0 ? project?.environments : environments,
         query:
           selectedIds === 'all'
-            ? (queryOptions?.query?.query ?? '')
+            ? ((queryOptions?.query?.query as string | undefined) ?? '')
             : `id:[${selectedIds.join(',')}]`,
         rangeStart: getDateWithTimezoneInUtc(
           getDateFromTimestamp(start) ?? new Date(),

--- a/static/app/views/detectors/hooks/useMetricDetectorAnomalies.tsx
+++ b/static/app/views/detectors/hooks/useMetricDetectorAnomalies.tsx
@@ -14,7 +14,7 @@ const ANOMALY_DETECTION_THRESHOLD_TYPE_MAP = {
   [AlertRuleThresholdType.ABOVE_AND_BELOW]: 'both',
 } as const;
 
-interface EventAnomalyPayload {
+type EventAnomalyPayload = {
   config: {
     direction: 'up' | 'down' | 'both';
     /**
@@ -31,7 +31,7 @@ interface EventAnomalyPayload {
   historical_data: Array<[timestamp: number, {count: number}]>;
   organization_id: string;
   project_id: string;
-}
+};
 
 interface UseMetricDetectorAnomaliesProps {
   enabled: boolean;

--- a/static/app/views/explore/replays/list/replayIndexTable.tsx
+++ b/static/app/views/explore/replays/list/replayIndexTable.tsx
@@ -58,7 +58,7 @@ export function ReplayIndexTable({
 
   const {options} = parseQueryKey(queryKey);
   const needsSDKUpdateForClickSearch = useNeedsSDKUpdateForClickSearch({
-    search: options?.query?.query,
+    search: options?.query?.query as string | undefined,
   });
 
   const needsJetpackComposePiiWarning = useNeedsJetpackComposePiiNotice({

--- a/static/app/views/issueDetails/groupEventAttachments/useGroupEventAttachments.tsx
+++ b/static/app/views/issueDetails/groupEventAttachments/useGroupEventAttachments.tsx
@@ -28,7 +28,7 @@ type GroupEventAttachmentsTypeFilter =
   | 'event.applecrashreport'
   | 'event.screenshot';
 
-interface GroupEventAttachmentsQuery {
+type GroupEventAttachmentsQuery = {
   cursor?: string;
   end?: DateString;
   environment?: string[] | string;
@@ -38,7 +38,7 @@ interface GroupEventAttachmentsQuery {
   start?: DateString;
   statsPeriod?: string;
   types?: GroupEventAttachmentsTypeFilter | GroupEventAttachmentsTypeFilter[];
-}
+};
 
 export interface FetchGroupEventAttachmentsApiOptionsParams {
   activeAttachmentsTab: 'all' | 'onlyCrash' | 'screenshot';

--- a/static/app/views/issueDetails/issueFirstLastReleaseQueryOptions.tsx
+++ b/static/app/views/issueDetails/issueFirstLastReleaseQueryOptions.tsx
@@ -6,15 +6,15 @@ interface GroupRelease {
   lastRelease: Release;
 }
 
-interface FirstLastReleaseQueryOptions {
+type FirstLastReleaseQueryOptions = {
   environment?: string[];
-}
+};
 
-interface GetIssueFirstLastReleaseQueryOptions {
+type GetIssueFirstLastReleaseQueryOptions = {
   groupId: string;
   organizationSlug: string;
   query?: FirstLastReleaseQueryOptions;
-}
+};
 
 export function issueFirstLastReleaseQueryOptions({
   groupId,

--- a/static/app/views/issueDetails/metricIssues/useMetricEventStats.tsx
+++ b/static/app/views/issueDetails/metricIssues/useMetricEventStats.tsx
@@ -33,7 +33,7 @@ interface MetricEventStatsParams {
   timePeriod: TimePeriodType;
 }
 
-interface EventRequestQueryParams {
+type EventRequestQueryParams = {
   comparisonDelta?: number;
   dataset?: DiscoverDatasets;
   end?: string;
@@ -55,7 +55,7 @@ interface EventRequestQueryParams {
   useOnDemandMetrics?: 'true';
   withoutZerofill?: '1';
   yAxis?: string | string[];
-}
+};
 
 export function useMetricEventStats(
   {

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableHeader.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTableHeader.tsx
@@ -118,7 +118,7 @@ export function ProjectTableHeader({
   const queryOptions = queryKeyRef.current
     ? parseQueryKey(queryKeyRef.current).options
     : undefined;
-  const queryString = queryOptions?.query?.query;
+  const queryString = queryOptions?.query?.query as string | undefined;
 
   const projectIds = useMemo(
     () => (selectedIds === 'all' ? projects.map(project => project.id) : selectedIds),

--- a/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTableHeader.tsx
+++ b/static/gsApp/views/seerAutomation/components/repoTable/seerRepoTableHeader.tsx
@@ -80,7 +80,7 @@ export function SeerRepoTableHeader({
   const queryOptions = queryKeyRef.current
     ? parseQueryKey(queryKeyRef.current).options
     : undefined;
-  const queryString = queryOptions?.query?.query;
+  const queryString = queryOptions?.query?.query as string | undefined;
 
   const selectedRepos = useMemo(() => {
     if (selectedIds === 'all') {


### PR DESCRIPTION
Remove the generic type parameters (`Headers`, `Query`, `Data`) from `QueryKeyEndpointOptions` and `ApiMutationVariables`, replacing the `Record<string, any>` defaults with `Record<string, unknown>`.

This surfaces a handful of places that relied on the implicit `any` — fixed by converting `interface` declarations to `type` aliases (so they satisfy index signatures) and adding explicit casts where query key options are accessed with specific property names like `query.query`.