### PR TITLE
chore(explore-events): Delay requests until in view

### DIFF
--- a/static/app/components/events/interfaces/performance/eventTraceView.spec.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.spec.tsx
@@ -13,6 +13,10 @@ import {
 
 import {EventTraceView} from './eventTraceView';
 
+jest.mock('sentry/components/lazyRender', () => ({
+  LazyRender: ({children}: {children: React.ReactNode}) => children,
+}));
+
 describe('EventTraceView', () => {
   const traceId = 'this-is-a-good-trace-id';
   const {organization} = initializeData({

--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -75,6 +75,7 @@ function EventTraceViewInner({event, organization, traceId}: EventTraceViewInner
     traceSlug: traceId,
     limit: 10000,
     targetEventId: event.id,
+    referrer: 'api.trace-view.issues.get-events',
   });
   const params = useTraceQueryParams({
     timestamp,

--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -195,22 +195,20 @@ export function EventTraceView({group, event, organization}: EventTraceViewProps
         </Grid>
       }
     >
+      <OneOtherIssueEvent event={event} />
       <LazyRender>
-        <Fragment>
-          <OneOtherIssueEvent event={event} />
-          {hasTracePreviewFeature && (
-            <TraceStateProvider
-              initialPreferences={preferences}
-              preferencesStorageKey={TRACE_WATERFALL_PREFERENCES_KEY}
-            >
-              <EventTraceViewInner
-                event={event}
-                organization={organization}
-                traceId={traceId}
-              />
-            </TraceStateProvider>
-          )}
-        </Fragment>
+        {hasTracePreviewFeature && (
+          <TraceStateProvider
+            initialPreferences={preferences}
+            preferencesStorageKey={TRACE_WATERFALL_PREFERENCES_KEY}
+          >
+            <EventTraceViewInner
+              event={event}
+              organization={organization}
+              traceId={traceId}
+            />
+          </TraceStateProvider>
+        )}
       </LazyRender>
     </InterimSection>
   );

--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -58,6 +58,8 @@ const DEFAULT_ISSUE_DETAILS_TRACE_VIEW_PREFERENCES: TracePreferencesState = {
   },
 };
 
+const LAZY_RENDER_OBSERVER_OPTIONS = {rootMargin: '200px 0px'};
+
 interface EventTraceViewInnerProps {
   event: Event;
   organization: Organization;
@@ -196,7 +198,7 @@ export function EventTraceView({group, event, organization}: EventTraceViewProps
       }
     >
       <OneOtherIssueEvent event={event} />
-      <LazyRender>
+      <LazyRender observerOptions={LAZY_RENDER_OBSERVER_OPTIONS}>
         {hasTracePreviewFeature && (
           <TraceStateProvider
             initialPreferences={preferences}

--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -10,7 +10,6 @@ import {
 } from 'sentry/components/events/interfaces/performance/utils';
 import {getEventTimestampInSeconds} from 'sentry/components/events/interfaces/utils';
 import {LazyRender} from 'sentry/components/lazyRender';
-import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {generateTraceTarget} from 'sentry/components/quickTrace/utils';
 import {t} from 'sentry/locale';
 import {type Event} from 'sentry/types/event';
@@ -196,7 +195,7 @@ export function EventTraceView({group, event, organization}: EventTraceViewProps
         </Grid>
       }
     >
-      <LazyRender fallback={<LoadingIndicator />}>
+      <LazyRender>
         <Fragment>
           <OneOtherIssueEvent event={event} />
           {hasTracePreviewFeature && (

--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -9,6 +9,8 @@ import {
   TRACE_WATERFALL_PREFERENCES_KEY,
 } from 'sentry/components/events/interfaces/performance/utils';
 import {getEventTimestampInSeconds} from 'sentry/components/events/interfaces/utils';
+import {LazyRender} from 'sentry/components/lazyRender';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {generateTraceTarget} from 'sentry/components/quickTrace/utils';
 import {t} from 'sentry/locale';
 import {type Event} from 'sentry/types/event';
@@ -193,19 +195,23 @@ export function EventTraceView({group, event, organization}: EventTraceViewProps
         </Grid>
       }
     >
-      <OneOtherIssueEvent event={event} />
-      {hasTracePreviewFeature && (
-        <TraceStateProvider
-          initialPreferences={preferences}
-          preferencesStorageKey={TRACE_WATERFALL_PREFERENCES_KEY}
-        >
-          <EventTraceViewInner
-            event={event}
-            organization={organization}
-            traceId={traceId}
-          />
-        </TraceStateProvider>
-      )}
+      <LazyRender fallback={<LoadingIndicator />}>
+        <Fragment>
+          <OneOtherIssueEvent event={event} />
+          {hasTracePreviewFeature && (
+            <TraceStateProvider
+              initialPreferences={preferences}
+              preferencesStorageKey={TRACE_WATERFALL_PREFERENCES_KEY}
+            >
+              <EventTraceViewInner
+                event={event}
+                organization={organization}
+                traceId={traceId}
+              />
+            </TraceStateProvider>
+          )}
+        </Fragment>
+      </LazyRender>
     </InterimSection>
   );
 }

--- a/static/app/components/events/interfaces/performance/eventTraceView.tsx
+++ b/static/app/components/events/interfaces/performance/eventTraceView.tsx
@@ -9,6 +9,7 @@ import {
   TRACE_WATERFALL_PREFERENCES_KEY,
 } from 'sentry/components/events/interfaces/performance/utils';
 import {getEventTimestampInSeconds} from 'sentry/components/events/interfaces/utils';
+import {ISSUE_DETAILS_LAZY_RENDER_OBSERVER_OPTIONS} from 'sentry/components/events/issueDetailsLazyRender';
 import {LazyRender} from 'sentry/components/lazyRender';
 import {generateTraceTarget} from 'sentry/components/quickTrace/utils';
 import {t} from 'sentry/locale';
@@ -57,8 +58,6 @@ const DEFAULT_ISSUE_DETAILS_TRACE_VIEW_PREFERENCES: TracePreferencesState = {
     width: 0.5,
   },
 };
-
-const LAZY_RENDER_OBSERVER_OPTIONS = {rootMargin: '200px 0px'};
 
 interface EventTraceViewInnerProps {
   event: Event;
@@ -198,7 +197,7 @@ export function EventTraceView({group, event, organization}: EventTraceViewProps
       }
     >
       <OneOtherIssueEvent event={event} />
-      <LazyRender observerOptions={LAZY_RENDER_OBSERVER_OPTIONS}>
+      <LazyRender observerOptions={ISSUE_DETAILS_LAZY_RENDER_OBSERVER_OPTIONS}>
         {hasTracePreviewFeature && (
           <TraceStateProvider
             initialPreferences={preferences}

--- a/static/app/components/events/issueDetailsLazyRender.ts
+++ b/static/app/components/events/issueDetailsLazyRender.ts
@@ -1,0 +1,4 @@
+export const ISSUE_DETAILS_LAZY_RENDER_OBSERVER_OPTIONS: Partial<IntersectionObserverInit> =
+  {
+    rootMargin: '200px 0px',
+  };

--- a/static/app/components/events/metrics/metricsSection.spec.tsx
+++ b/static/app/components/events/metrics/metricsSection.spec.tsx
@@ -171,10 +171,11 @@ describe('MetricsSection', () => {
       organization,
     });
 
-    // Section header is always visible
-    expect(screen.getByText(/Metrics/)).toBeInTheDocument();
     await waitFor(() => {
       expect(mockRequestEmpty).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(screen.queryByText(/Metrics/)).not.toBeInTheDocument();
     });
   });
 

--- a/static/app/components/events/metrics/metricsSection.spec.tsx
+++ b/static/app/components/events/metrics/metricsSection.spec.tsx
@@ -12,6 +12,10 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import {MetricsSection} from 'sentry/components/events/metrics/metricsSection';
+
+jest.mock('sentry/components/lazyRender', () => ({
+  LazyRender: ({children}: {children: React.ReactNode}) => children,
+}));
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {TraceMetricKnownFieldKey} from 'sentry/views/explore/metrics/types';
@@ -154,7 +158,7 @@ describe('MetricsSection', () => {
     expect(screen.queryByText(/Metrics/)).not.toBeInTheDocument();
   });
 
-  it('renders empty when no metrics data', () => {
+  it('renders empty when no metrics data', async () => {
     const mockRequestEmpty = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
       body: {
@@ -167,8 +171,11 @@ describe('MetricsSection', () => {
       organization,
     });
 
-    expect(mockRequestEmpty).toHaveBeenCalledTimes(1);
-    expect(screen.queryByText(/Metrics/)).not.toBeInTheDocument();
+    // Section header is always visible
+    expect(screen.getByText(/Metrics/)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockRequestEmpty).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('renders metrics section with data', async () => {
@@ -184,7 +191,9 @@ describe('MetricsSection', () => {
       },
     });
 
-    expect(mockRequest).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(mockRequest).toHaveBeenCalledTimes(1);
+    });
 
     await waitFor(() => {
       expect(screen.getByText(/Metrics/)).toBeInTheDocument();
@@ -222,7 +231,9 @@ describe('MetricsSection', () => {
       organization,
     });
 
-    expect(mockRequestWithManyMetrics).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(mockRequestWithManyMetrics).toHaveBeenCalledTimes(1);
+    });
 
     await waitFor(() => {
       expect(screen.getByText(/Metrics/)).toBeInTheDocument();
@@ -268,7 +279,9 @@ describe('MetricsSection', () => {
       },
     });
 
-    expect(mockRequestWithManyMetrics).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(mockRequestWithManyMetrics).toHaveBeenCalledTimes(1);
+    });
 
     await waitFor(() => {
       expect(screen.getByText(/Metrics/)).toBeInTheDocument();
@@ -319,7 +332,9 @@ describe('MetricsSection', () => {
       organization,
     });
 
-    expect(mockRequestWithFewMetrics).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(mockRequestWithFewMetrics).toHaveBeenCalledTimes(1);
+    });
 
     await waitFor(() => {
       expect(screen.getByText(/Metrics/)).toBeInTheDocument();

--- a/static/app/components/events/metrics/metricsSection.tsx
+++ b/static/app/components/events/metrics/metricsSection.tsx
@@ -6,6 +6,8 @@ import {Flex} from '@sentry/scraps/layout';
 
 import {MetricsDrawer} from 'sentry/components/events/metrics/metricsDrawer';
 import {useMetricsIssueSection} from 'sentry/components/events/metrics/useMetricsIssueSection';
+import {LazyRender} from 'sentry/components/lazyRender';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
@@ -37,7 +39,6 @@ export function MetricsSection({
   const traceId = event.contexts?.trace?.trace_id;
 
   if (!traceId) {
-    // If there isn't a traceId, we shouldn't show metrics since they are trace specific
     return null;
   }
 
@@ -46,14 +47,23 @@ export function MetricsSection({
   }
 
   return (
-    <TraceViewMetricsProviderWrapper traceSlug={traceId}>
-      <MetricsSectionContent
-        event={event}
-        group={group}
-        project={project}
-        traceId={traceId}
-      />
-    </TraceViewMetricsProviderWrapper>
+    <InterimSection
+      key="metrics"
+      type={SectionKey.METRICS}
+      title={t('Application Metrics')}
+      data-test-id="metrics-data-section"
+    >
+      <LazyRender fallback={<LoadingIndicator />}>
+        <TraceViewMetricsProviderWrapper traceSlug={traceId}>
+          <MetricsSectionContent
+            event={event}
+            group={group}
+            project={project}
+            traceId={traceId}
+          />
+        </TraceViewMetricsProviderWrapper>
+      </LazyRender>
+    </InterimSection>
   );
 }
 
@@ -73,7 +83,7 @@ function MetricsSectionContent({
   const location = useLocation();
   const {openDrawer} = useDrawer();
   const viewAllButtonRef = useRef<HTMLButtonElement>(null);
-  const {result, error} = useMetricsIssueSection({traceId});
+  const {result, error, isPending} = useMetricsIssueSection({traceId});
   const abbreviatedTableData = result.data
     ? result.data.slice(0, NUMBER_ABBREVIATED_METRICS)
     : undefined;
@@ -129,33 +139,29 @@ function MetricsSectionContent({
     }
   }, [location.query, traceId, group, event, project, openDrawer, navigate, location]);
 
+  if (isPending) {
+    return <LoadingIndicator />;
+  }
   if (!result.data || result.data.length === 0 || error) {
     return null;
   }
 
   return (
-    <InterimSection
-      key="metrics"
-      type={SectionKey.METRICS}
-      title={t('Application Metrics')}
-      data-test-id="metrics-data-section"
-    >
-      <Flex direction="column" gap="xl">
-        <MetricsSamplesTable embedded overrideTableData={abbreviatedTableData} />
-        {result.data && result.data.length > NUMBER_ABBREVIATED_METRICS ? (
-          <div>
-            <Button
-              icon={<IconChevron direction="right" />}
-              aria-label={t('View more')}
-              size="sm"
-              onClick={onOpenMetricsDrawer}
-              ref={viewAllButtonRef}
-            >
-              {t('View more')}
-            </Button>
-          </div>
-        ) : null}
-      </Flex>
-    </InterimSection>
+    <Flex direction="column" gap="xl">
+      <MetricsSamplesTable embedded overrideTableData={abbreviatedTableData} />
+      {result.data && result.data.length > NUMBER_ABBREVIATED_METRICS ? (
+        <div>
+          <Button
+            icon={<IconChevron direction="right" />}
+            aria-label={t('View more')}
+            size="sm"
+            onClick={onOpenMetricsDrawer}
+            ref={viewAllButtonRef}
+          >
+            {t('View more')}
+          </Button>
+        </div>
+      ) : null}
+    </Flex>
   );
 }

--- a/static/app/components/events/metrics/metricsSection.tsx
+++ b/static/app/components/events/metrics/metricsSection.tsx
@@ -4,6 +4,7 @@ import {Button} from '@sentry/scraps/button';
 import {useDrawer} from '@sentry/scraps/drawer';
 import {Flex} from '@sentry/scraps/layout';
 
+import {ISSUE_DETAILS_LAZY_RENDER_OBSERVER_OPTIONS} from 'sentry/components/events/issueDetailsLazyRender';
 import {MetricsDrawer} from 'sentry/components/events/metrics/metricsDrawer';
 import {useMetricsIssueSection} from 'sentry/components/events/metrics/useMetricsIssueSection';
 import {LazyRender} from 'sentry/components/lazyRender';
@@ -24,8 +25,6 @@ import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSectio
 import {TraceViewMetricsProviderWrapper} from 'sentry/views/performance/newTraceDetails/traceMetrics';
 
 import {NUMBER_ABBREVIATED_METRICS} from './useMetricsIssueSection';
-
-const LAZY_RENDER_OBSERVER_OPTIONS = {rootMargin: '200px 0px'};
 
 export function MetricsSection({
   event,
@@ -51,7 +50,7 @@ export function MetricsSection({
   return (
     <LazyRender
       disabled={location.query[METRICS_DRAWER_QUERY_PARAM] === 'true'}
-      observerOptions={LAZY_RENDER_OBSERVER_OPTIONS}
+      observerOptions={ISSUE_DETAILS_LAZY_RENDER_OBSERVER_OPTIONS}
       withoutContainer
     >
       <TraceViewMetricsProviderWrapper traceSlug={traceId}>

--- a/static/app/components/events/metrics/metricsSection.tsx
+++ b/static/app/components/events/metrics/metricsSection.tsx
@@ -49,7 +49,10 @@ export function MetricsSection({
 
   return (
     <LazyRender
-      disabled={location.query[METRICS_DRAWER_QUERY_PARAM] === 'true'}
+      disabled={
+        location.query[METRICS_DRAWER_QUERY_PARAM] === 'true' ||
+        location.hash === `#${SectionKey.METRICS}`
+      }
       observerOptions={ISSUE_DETAILS_LAZY_RENDER_OBSERVER_OPTIONS}
       withoutContainer
     >

--- a/static/app/components/events/metrics/metricsSection.tsx
+++ b/static/app/components/events/metrics/metricsSection.tsx
@@ -25,6 +25,8 @@ import {TraceViewMetricsProviderWrapper} from 'sentry/views/performance/newTrace
 
 import {NUMBER_ABBREVIATED_METRICS} from './useMetricsIssueSection';
 
+const LAZY_RENDER_OBSERVER_OPTIONS = {rootMargin: '200px 0px'};
+
 export function MetricsSection({
   event,
   project,
@@ -47,7 +49,11 @@ export function MetricsSection({
   }
 
   return (
-    <LazyRender disabled={location.query[METRICS_DRAWER_QUERY_PARAM] === 'true'}>
+    <LazyRender
+      disabled={location.query[METRICS_DRAWER_QUERY_PARAM] === 'true'}
+      observerOptions={LAZY_RENDER_OBSERVER_OPTIONS}
+      withoutContainer
+    >
       <TraceViewMetricsProviderWrapper traceSlug={traceId}>
         <MetricsSectionContent
           event={event}

--- a/static/app/components/events/metrics/metricsSection.tsx
+++ b/static/app/components/events/metrics/metricsSection.tsx
@@ -7,7 +7,6 @@ import {Flex} from '@sentry/scraps/layout';
 import {MetricsDrawer} from 'sentry/components/events/metrics/metricsDrawer';
 import {useMetricsIssueSection} from 'sentry/components/events/metrics/useMetricsIssueSection';
 import {LazyRender} from 'sentry/components/lazyRender';
-import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
@@ -36,6 +35,7 @@ export function MetricsSection({
   project: Project;
 }) {
   const organization = useOrganization();
+  const location = useLocation();
   const traceId = event.contexts?.trace?.trace_id;
 
   if (!traceId) {
@@ -47,7 +47,7 @@ export function MetricsSection({
   }
 
   return (
-    <LazyRender>
+    <LazyRender disabled={location.query[METRICS_DRAWER_QUERY_PARAM] === 'true'}>
       <TraceViewMetricsProviderWrapper traceSlug={traceId}>
         <MetricsSectionContent
           event={event}
@@ -76,7 +76,7 @@ function MetricsSectionContent({
   const location = useLocation();
   const {openDrawer} = useDrawer();
   const viewAllButtonRef = useRef<HTMLButtonElement>(null);
-  const {result, error, isPending} = useMetricsIssueSection({traceId});
+  const {result, error} = useMetricsIssueSection({traceId});
   const abbreviatedTableData = result.data
     ? result.data.slice(0, NUMBER_ABBREVIATED_METRICS)
     : undefined;
@@ -132,7 +132,7 @@ function MetricsSectionContent({
     }
   }, [location.query, traceId, group, event, project, openDrawer, navigate, location]);
 
-  if (!isPending && (!result.data || result.data.length === 0 || error)) {
+  if (!result.data || result.data.length === 0 || error) {
     return null;
   }
 
@@ -143,26 +143,22 @@ function MetricsSectionContent({
       title={t('Application Metrics')}
       data-test-id="metrics-data-section"
     >
-      {isPending ? (
-        <LoadingIndicator />
-      ) : (
-        <Flex direction="column" gap="xl">
-          <MetricsSamplesTable embedded overrideTableData={abbreviatedTableData} />
-          {result.data && result.data.length > NUMBER_ABBREVIATED_METRICS ? (
-            <div>
-              <Button
-                icon={<IconChevron direction="right" />}
-                aria-label={t('View more')}
-                size="sm"
-                onClick={onOpenMetricsDrawer}
-                ref={viewAllButtonRef}
-              >
-                {t('View more')}
-              </Button>
-            </div>
-          ) : null}
-        </Flex>
-      )}
+      <Flex direction="column" gap="xl">
+        <MetricsSamplesTable embedded overrideTableData={abbreviatedTableData} />
+        {result.data && result.data.length > NUMBER_ABBREVIATED_METRICS ? (
+          <div>
+            <Button
+              icon={<IconChevron direction="right" />}
+              aria-label={t('View more')}
+              size="sm"
+              onClick={onOpenMetricsDrawer}
+              ref={viewAllButtonRef}
+            >
+              {t('View more')}
+            </Button>
+          </div>
+        ) : null}
+      </Flex>
     </InterimSection>
   );
 }

--- a/static/app/components/events/metrics/metricsSection.tsx
+++ b/static/app/components/events/metrics/metricsSection.tsx
@@ -47,23 +47,16 @@ export function MetricsSection({
   }
 
   return (
-    <InterimSection
-      key="metrics"
-      type={SectionKey.METRICS}
-      title={t('Application Metrics')}
-      data-test-id="metrics-data-section"
-    >
-      <LazyRender fallback={<LoadingIndicator />}>
-        <TraceViewMetricsProviderWrapper traceSlug={traceId}>
-          <MetricsSectionContent
-            event={event}
-            group={group}
-            project={project}
-            traceId={traceId}
-          />
-        </TraceViewMetricsProviderWrapper>
-      </LazyRender>
-    </InterimSection>
+    <LazyRender>
+      <TraceViewMetricsProviderWrapper traceSlug={traceId}>
+        <MetricsSectionContent
+          event={event}
+          group={group}
+          project={project}
+          traceId={traceId}
+        />
+      </TraceViewMetricsProviderWrapper>
+    </LazyRender>
   );
 }
 
@@ -139,29 +132,37 @@ function MetricsSectionContent({
     }
   }, [location.query, traceId, group, event, project, openDrawer, navigate, location]);
 
-  if (isPending) {
-    return <LoadingIndicator />;
-  }
-  if (!result.data || result.data.length === 0 || error) {
+  if (!isPending && (!result.data || result.data.length === 0 || error)) {
     return null;
   }
 
   return (
-    <Flex direction="column" gap="xl">
-      <MetricsSamplesTable embedded overrideTableData={abbreviatedTableData} />
-      {result.data && result.data.length > NUMBER_ABBREVIATED_METRICS ? (
-        <div>
-          <Button
-            icon={<IconChevron direction="right" />}
-            aria-label={t('View more')}
-            size="sm"
-            onClick={onOpenMetricsDrawer}
-            ref={viewAllButtonRef}
-          >
-            {t('View more')}
-          </Button>
-        </div>
-      ) : null}
-    </Flex>
+    <InterimSection
+      key="metrics"
+      type={SectionKey.METRICS}
+      title={t('Application Metrics')}
+      data-test-id="metrics-data-section"
+    >
+      {isPending ? (
+        <LoadingIndicator />
+      ) : (
+        <Flex direction="column" gap="xl">
+          <MetricsSamplesTable embedded overrideTableData={abbreviatedTableData} />
+          {result.data && result.data.length > NUMBER_ABBREVIATED_METRICS ? (
+            <div>
+              <Button
+                icon={<IconChevron direction="right" />}
+                aria-label={t('View more')}
+                size="sm"
+                onClick={onOpenMetricsDrawer}
+                ref={viewAllButtonRef}
+              >
+                {t('View more')}
+              </Button>
+            </div>
+          ) : null}
+        </Flex>
+      )}
+    </InterimSection>
   );
 }

--- a/static/app/components/events/metrics/useMetricsIssueSection.tsx
+++ b/static/app/components/events/metrics/useMetricsIssueSection.tsx
@@ -1,3 +1,4 @@
+import {EXPLORE_FIVE_MIN_STALE_TIME} from 'sentry/views/explore/constants';
 import {
   getTraceSamplesTableFields,
   TraceSamplesTableEmbeddedColumns,
@@ -13,5 +14,6 @@ export function useMetricsIssueSection({traceId}: {traceId: string}) {
     limit: NUMBER_ABBREVIATED_METRICS + 1, // Just needs to be >5 to show the view more button
     traceMetric: undefined,
     fields,
+    staleTime: EXPLORE_FIVE_MIN_STALE_TIME,
   });
 }

--- a/static/app/components/events/ourlogs/ourlogsSection.spec.tsx
+++ b/static/app/components/events/ourlogs/ourlogsSection.spec.tsx
@@ -13,6 +13,10 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import {OurlogsSection} from 'sentry/components/events/ourlogs/ourlogsSection';
+
+jest.mock('sentry/components/lazyRender', () => ({
+  LazyRender: ({children}: {children: React.ReactNode}) => children,
+}));
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
@@ -183,7 +187,7 @@ describe('OurlogsSection', () => {
     });
   });
 
-  it('renders empty', () => {
+  it('renders empty', async () => {
     const mockRequestEmpty = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/trace-logs/`,
       body: {
@@ -194,8 +198,11 @@ describe('OurlogsSection', () => {
     render(<OurlogsSection event={event} project={project} group={group} />, {
       organization,
     });
-    expect(mockRequestEmpty).toHaveBeenCalledTimes(1);
-    expect(screen.queryByText(/Logs/)).not.toBeInTheDocument();
+    // Section header is always visible
+    expect(screen.getByText(/Logs/)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockRequestEmpty).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('renders logs', async () => {

--- a/static/app/components/events/ourlogs/ourlogsSection.spec.tsx
+++ b/static/app/components/events/ourlogs/ourlogsSection.spec.tsx
@@ -198,10 +198,11 @@ describe('OurlogsSection', () => {
     render(<OurlogsSection event={event} project={project} group={group} />, {
       organization,
     });
-    // Section header is always visible
-    expect(screen.getByText(/Logs/)).toBeInTheDocument();
     await waitFor(() => {
       expect(mockRequestEmpty).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(screen.queryByText(/Logs/)).not.toBeInTheDocument();
     });
   });
 

--- a/static/app/components/events/ourlogs/ourlogsSection.tsx
+++ b/static/app/components/events/ourlogs/ourlogsSection.tsx
@@ -30,6 +30,8 @@ import {useQueryParamsSearch} from 'sentry/views/explore/queryParams/context';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
 
+const LAZY_RENDER_OBSERVER_OPTIONS = {rootMargin: '200px 0px'};
+
 export function OurlogsSection({
   event,
   project,
@@ -47,6 +49,7 @@ export function OurlogsSection({
   return (
     <LazyRender
       disabled={location.query[LOGS_DRAWER_QUERY_PARAM] === 'true'}
+      observerOptions={LAZY_RENDER_OBSERVER_OPTIONS}
       withoutContainer
     >
       <LogsQueryParamsProvider

--- a/static/app/components/events/ourlogs/ourlogsSection.tsx
+++ b/static/app/components/events/ourlogs/ourlogsSection.tsx
@@ -6,6 +6,8 @@ import {useDrawer} from '@sentry/scraps/drawer';
 import {Stack} from '@sentry/scraps/layout';
 
 import {OurlogsDrawer} from 'sentry/components/events/ourlogs/ourlogsDrawer';
+import {LazyRender} from 'sentry/components/lazyRender';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
@@ -39,16 +41,28 @@ export function OurlogsSection({
   project: Project;
 }) {
   const traceId = event.contexts?.trace?.trace_id;
+  if (!traceId) {
+    return null;
+  }
   return (
-    <LogsQueryParamsProvider
-      analyticsPageSource={LogsAnalyticsPageSource.ISSUE_DETAILS}
-      source="state"
-      freeze={traceId ? {traceId} : undefined}
+    <InterimSection
+      key="logs"
+      type={SectionKey.LOGS}
+      title={t('Logs')}
+      data-test-id="logs-data-section"
     >
-      <LogsPageDataProvider disabled={!traceId} staleTime={EXPLORE_FIVE_MIN_STALE_TIME}>
-        <OurlogsSectionContent event={event} group={group} project={project} />
-      </LogsPageDataProvider>
-    </LogsQueryParamsProvider>
+      <LazyRender fallback={<LoadingIndicator />}>
+        <LogsQueryParamsProvider
+          analyticsPageSource={LogsAnalyticsPageSource.ISSUE_DETAILS}
+          source="state"
+          freeze={{traceId}}
+        >
+          <LogsPageDataProvider disabled={false} staleTime={EXPLORE_FIVE_MIN_STALE_TIME}>
+            <OurlogsSectionContent event={event} group={group} project={project} />
+          </LogsPageDataProvider>
+        </LogsQueryParamsProvider>
+      </LazyRender>
+    </InterimSection>
   );
 }
 
@@ -161,53 +175,46 @@ function OurlogsSectionContent({
     return null;
   }
   if (!traceId) {
-    // If there isn't a traceId (eg. profiling issue), we shouldn't show logs since they are trace specific.
-    // We may change this in the future if we have a trace-group or we generate trace sids for these issue types.
     return null;
   }
+  if (tableData.isPending) {
+    return <LoadingIndicator />;
+  }
   if (!tableData?.data || (tableData.data.length === 0 && logsSearch.isEmpty())) {
-    // Like breadcrumbs, we don't show the logs section if there are no logs.
     return null;
   }
   return (
-    <InterimSection
-      key="logs"
-      type={SectionKey.LOGS}
-      title={t('Logs')}
-      data-test-id="logs-data-section"
-    >
-      <Stack>
-        <SmallTable>
-          <TableBody>
-            {abbreviatedTableData?.map((row, index) => (
-              <LogRowContent
-                dataRow={row}
-                meta={tableData.meta}
-                highlightTerms={[]}
-                embedded
-                sharedHoverTimeoutRef={sharedHoverTimeoutRef}
-                key={index}
-                blockRowExpanding
-                onEmbeddedRowClick={onEmbeddedRowClick}
-              />
-            ))}
-          </TableBody>
-        </SmallTable>
-        {tableData.data && tableData.data.length > 5 ? (
-          <div>
-            <Button
-              icon={<IconChevron direction="right" />}
-              aria-label={t('View more')}
-              size="sm"
-              onClick={onOpenLogsDrawer}
-              ref={viewAllButtonRef}
-            >
-              {t('View more')}
-            </Button>
-          </div>
-        ) : null}
-      </Stack>
-    </InterimSection>
+    <Stack>
+      <SmallTable>
+        <TableBody>
+          {abbreviatedTableData?.map((row, index) => (
+            <LogRowContent
+              dataRow={row}
+              meta={tableData.meta}
+              highlightTerms={[]}
+              embedded
+              sharedHoverTimeoutRef={sharedHoverTimeoutRef}
+              key={index}
+              blockRowExpanding
+              onEmbeddedRowClick={onEmbeddedRowClick}
+            />
+          ))}
+        </TableBody>
+      </SmallTable>
+      {tableData.data && tableData.data.length > 5 ? (
+        <div>
+          <Button
+            icon={<IconChevron direction="right" />}
+            aria-label={t('View more')}
+            size="sm"
+            onClick={onOpenLogsDrawer}
+            ref={viewAllButtonRef}
+          >
+            {t('View more')}
+          </Button>
+        </div>
+      ) : null}
+    </Stack>
   );
 }
 

--- a/static/app/components/events/ourlogs/ourlogsSection.tsx
+++ b/static/app/components/events/ourlogs/ourlogsSection.tsx
@@ -47,7 +47,10 @@ export function OurlogsSection({
   }
   return (
     <LazyRender
-      disabled={location.query[LOGS_DRAWER_QUERY_PARAM] === 'true'}
+      disabled={
+        location.query[LOGS_DRAWER_QUERY_PARAM] === 'true' ||
+        location.hash === `#${SectionKey.LOGS}`
+      }
       observerOptions={ISSUE_DETAILS_LAZY_RENDER_OBSERVER_OPTIONS}
       withoutContainer
     >

--- a/static/app/components/events/ourlogs/ourlogsSection.tsx
+++ b/static/app/components/events/ourlogs/ourlogsSection.tsx
@@ -5,6 +5,7 @@ import {Button} from '@sentry/scraps/button';
 import {useDrawer} from '@sentry/scraps/drawer';
 import {Stack} from '@sentry/scraps/layout';
 
+import {ISSUE_DETAILS_LAZY_RENDER_OBSERVER_OPTIONS} from 'sentry/components/events/issueDetailsLazyRender';
 import {OurlogsDrawer} from 'sentry/components/events/ourlogs/ourlogsDrawer';
 import {LazyRender} from 'sentry/components/lazyRender';
 import {IconChevron} from 'sentry/icons';
@@ -30,8 +31,6 @@ import {useQueryParamsSearch} from 'sentry/views/explore/queryParams/context';
 import {SectionKey} from 'sentry/views/issueDetails/streamline/context';
 import {InterimSection} from 'sentry/views/issueDetails/streamline/interimSection';
 
-const LAZY_RENDER_OBSERVER_OPTIONS = {rootMargin: '200px 0px'};
-
 export function OurlogsSection({
   event,
   project,
@@ -49,7 +48,7 @@ export function OurlogsSection({
   return (
     <LazyRender
       disabled={location.query[LOGS_DRAWER_QUERY_PARAM] === 'true'}
-      observerOptions={LAZY_RENDER_OBSERVER_OPTIONS}
+      observerOptions={ISSUE_DETAILS_LAZY_RENDER_OBSERVER_OPTIONS}
       withoutContainer
     >
       <LogsQueryParamsProvider

--- a/static/app/components/events/ourlogs/ourlogsSection.tsx
+++ b/static/app/components/events/ourlogs/ourlogsSection.tsx
@@ -7,7 +7,6 @@ import {Stack} from '@sentry/scraps/layout';
 
 import {OurlogsDrawer} from 'sentry/components/events/ourlogs/ourlogsDrawer';
 import {LazyRender} from 'sentry/components/lazyRender';
-import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
@@ -40,12 +39,13 @@ export function OurlogsSection({
   group: Group;
   project: Project;
 }) {
+  const location = useLocation();
   const traceId = event.contexts?.trace?.trace_id;
   if (!traceId) {
     return null;
   }
   return (
-    <LazyRender>
+    <LazyRender disabled={location.query[LOGS_DRAWER_QUERY_PARAM] === 'true'}>
       <LogsQueryParamsProvider
         analyticsPageSource={LogsAnalyticsPageSource.ISSUE_DETAILS}
         source="state"
@@ -170,10 +170,7 @@ function OurlogsSectionContent({
   if (!traceId) {
     return null;
   }
-  if (
-    !tableData.isPending &&
-    (!tableData?.data || (tableData.data.length === 0 && logsSearch.isEmpty()))
-  ) {
+  if (!tableData?.data || (tableData.data.length === 0 && logsSearch.isEmpty())) {
     return null;
   }
   return (
@@ -183,41 +180,37 @@ function OurlogsSectionContent({
       title={t('Logs')}
       data-test-id="logs-data-section"
     >
-      {tableData.isPending ? (
-        <LoadingIndicator />
-      ) : (
-        <Stack>
-          <SmallTable>
-            <TableBody>
-              {abbreviatedTableData?.map((row, index) => (
-                <LogRowContent
-                  dataRow={row}
-                  meta={tableData.meta}
-                  highlightTerms={[]}
-                  embedded
-                  sharedHoverTimeoutRef={sharedHoverTimeoutRef}
-                  key={index}
-                  blockRowExpanding
-                  onEmbeddedRowClick={onEmbeddedRowClick}
-                />
-              ))}
-            </TableBody>
-          </SmallTable>
-          {tableData.data && tableData.data.length > 5 ? (
-            <div>
-              <Button
-                icon={<IconChevron direction="right" />}
-                aria-label={t('View more')}
-                size="sm"
-                onClick={onOpenLogsDrawer}
-                ref={viewAllButtonRef}
-              >
-                {t('View more')}
-              </Button>
-            </div>
-          ) : null}
-        </Stack>
-      )}
+      <Stack>
+        <SmallTable>
+          <TableBody>
+            {abbreviatedTableData?.map((row, index) => (
+              <LogRowContent
+                dataRow={row}
+                meta={tableData.meta}
+                highlightTerms={[]}
+                embedded
+                sharedHoverTimeoutRef={sharedHoverTimeoutRef}
+                key={index}
+                blockRowExpanding
+                onEmbeddedRowClick={onEmbeddedRowClick}
+              />
+            ))}
+          </TableBody>
+        </SmallTable>
+        {tableData.data && tableData.data.length > 5 ? (
+          <div>
+            <Button
+              icon={<IconChevron direction="right" />}
+              aria-label={t('View more')}
+              size="sm"
+              onClick={onOpenLogsDrawer}
+              ref={viewAllButtonRef}
+            >
+              {t('View more')}
+            </Button>
+          </div>
+        ) : null}
+      </Stack>
     </InterimSection>
   );
 }

--- a/static/app/components/events/ourlogs/ourlogsSection.tsx
+++ b/static/app/components/events/ourlogs/ourlogsSection.tsx
@@ -17,6 +17,7 @@ import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {TableBody} from 'sentry/views/explore/components/table';
+import {EXPLORE_FIVE_MIN_STALE_TIME} from 'sentry/views/explore/constants';
 import {
   LogsPageDataProvider,
   useLogsPageDataQueryResult,
@@ -44,7 +45,7 @@ export function OurlogsSection({
       source="state"
       freeze={traceId ? {traceId} : undefined}
     >
-      <LogsPageDataProvider disabled={!traceId}>
+      <LogsPageDataProvider disabled={!traceId} staleTime={EXPLORE_FIVE_MIN_STALE_TIME}>
         <OurlogsSectionContent event={event} group={group} project={project} />
       </LogsPageDataProvider>
     </LogsQueryParamsProvider>
@@ -113,7 +114,10 @@ function OurlogsSectionContent({
             source="state"
             freeze={traceId ? {traceId} : undefined}
           >
-            <LogsPageDataProvider disabled={!traceId}>
+            <LogsPageDataProvider
+              disabled={!traceId}
+              staleTime={EXPLORE_FIVE_MIN_STALE_TIME}
+            >
               <OurlogsDrawer
                 group={group}
                 event={event}

--- a/static/app/components/events/ourlogs/ourlogsSection.tsx
+++ b/static/app/components/events/ourlogs/ourlogsSection.tsx
@@ -176,9 +176,12 @@ function OurlogsSectionContent({
     return null;
   }
   if (!traceId) {
+    // If there isn't a traceId (eg. profiling issue), we shouldn't show logs since they are trace specific.
+    // We may change this in the future if we have a trace-group or we generate trace sids for these issue types.
     return null;
   }
   if (!tableData?.data || (tableData.data.length === 0 && logsSearch.isEmpty())) {
+    // Like breadcrumbs, we don't show the logs section if there are no logs.
     return null;
   }
   return (

--- a/static/app/components/events/ourlogs/ourlogsSection.tsx
+++ b/static/app/components/events/ourlogs/ourlogsSection.tsx
@@ -45,7 +45,10 @@ export function OurlogsSection({
     return null;
   }
   return (
-    <LazyRender disabled={location.query[LOGS_DRAWER_QUERY_PARAM] === 'true'}>
+    <LazyRender
+      disabled={location.query[LOGS_DRAWER_QUERY_PARAM] === 'true'}
+      withoutContainer
+    >
       <LogsQueryParamsProvider
         analyticsPageSource={LogsAnalyticsPageSource.ISSUE_DETAILS}
         source="state"

--- a/static/app/components/events/ourlogs/ourlogsSection.tsx
+++ b/static/app/components/events/ourlogs/ourlogsSection.tsx
@@ -45,24 +45,17 @@ export function OurlogsSection({
     return null;
   }
   return (
-    <InterimSection
-      key="logs"
-      type={SectionKey.LOGS}
-      title={t('Logs')}
-      data-test-id="logs-data-section"
-    >
-      <LazyRender fallback={<LoadingIndicator />}>
-        <LogsQueryParamsProvider
-          analyticsPageSource={LogsAnalyticsPageSource.ISSUE_DETAILS}
-          source="state"
-          freeze={{traceId}}
-        >
-          <LogsPageDataProvider disabled={false} staleTime={EXPLORE_FIVE_MIN_STALE_TIME}>
-            <OurlogsSectionContent event={event} group={group} project={project} />
-          </LogsPageDataProvider>
-        </LogsQueryParamsProvider>
-      </LazyRender>
-    </InterimSection>
+    <LazyRender>
+      <LogsQueryParamsProvider
+        analyticsPageSource={LogsAnalyticsPageSource.ISSUE_DETAILS}
+        source="state"
+        freeze={{traceId}}
+      >
+        <LogsPageDataProvider disabled={false} staleTime={EXPLORE_FIVE_MIN_STALE_TIME}>
+          <OurlogsSectionContent event={event} group={group} project={project} />
+        </LogsPageDataProvider>
+      </LogsQueryParamsProvider>
+    </LazyRender>
   );
 }
 
@@ -177,44 +170,55 @@ function OurlogsSectionContent({
   if (!traceId) {
     return null;
   }
-  if (tableData.isPending) {
-    return <LoadingIndicator />;
-  }
-  if (!tableData?.data || (tableData.data.length === 0 && logsSearch.isEmpty())) {
+  if (
+    !tableData.isPending &&
+    (!tableData?.data || (tableData.data.length === 0 && logsSearch.isEmpty()))
+  ) {
     return null;
   }
   return (
-    <Stack>
-      <SmallTable>
-        <TableBody>
-          {abbreviatedTableData?.map((row, index) => (
-            <LogRowContent
-              dataRow={row}
-              meta={tableData.meta}
-              highlightTerms={[]}
-              embedded
-              sharedHoverTimeoutRef={sharedHoverTimeoutRef}
-              key={index}
-              blockRowExpanding
-              onEmbeddedRowClick={onEmbeddedRowClick}
-            />
-          ))}
-        </TableBody>
-      </SmallTable>
-      {tableData.data && tableData.data.length > 5 ? (
-        <div>
-          <Button
-            icon={<IconChevron direction="right" />}
-            aria-label={t('View more')}
-            size="sm"
-            onClick={onOpenLogsDrawer}
-            ref={viewAllButtonRef}
-          >
-            {t('View more')}
-          </Button>
-        </div>
-      ) : null}
-    </Stack>
+    <InterimSection
+      key="logs"
+      type={SectionKey.LOGS}
+      title={t('Logs')}
+      data-test-id="logs-data-section"
+    >
+      {tableData.isPending ? (
+        <LoadingIndicator />
+      ) : (
+        <Stack>
+          <SmallTable>
+            <TableBody>
+              {abbreviatedTableData?.map((row, index) => (
+                <LogRowContent
+                  dataRow={row}
+                  meta={tableData.meta}
+                  highlightTerms={[]}
+                  embedded
+                  sharedHoverTimeoutRef={sharedHoverTimeoutRef}
+                  key={index}
+                  blockRowExpanding
+                  onEmbeddedRowClick={onEmbeddedRowClick}
+                />
+              ))}
+            </TableBody>
+          </SmallTable>
+          {tableData.data && tableData.data.length > 5 ? (
+            <div>
+              <Button
+                icon={<IconChevron direction="right" />}
+                aria-label={t('View more')}
+                size="sm"
+                onClick={onOpenLogsDrawer}
+                ref={viewAllButtonRef}
+              >
+                {t('View more')}
+              </Button>
+            </div>
+          ) : null}
+        </Stack>
+      )}
+    </InterimSection>
   );
 }
 

--- a/static/app/components/lazyRender.tsx
+++ b/static/app/components/lazyRender.tsx
@@ -28,10 +28,6 @@ export interface LazyRenderProps {
    * When true, skips lazy loading and renders children immediately.
    */
   disabled?: boolean;
-  /**
-   * Content to render before the component becomes visible in the viewport.
-   */
-  fallback?: React.ReactNode;
   observerOptions?: Partial<IntersectionObserverInit>;
   /**
    * Removes the wrapping div once visible
@@ -97,5 +93,5 @@ export function LazyRender(props: LazyRenderProps) {
     return props.children;
   }
 
-  return <div ref={onRefNode}>{visible ? props.children : (props.fallback ?? null)}</div>;
+  return <div ref={onRefNode}>{visible ? props.children : null}</div>;
 }

--- a/static/app/components/lazyRender.tsx
+++ b/static/app/components/lazyRender.tsx
@@ -28,6 +28,10 @@ export interface LazyRenderProps {
    * When true, skips lazy loading and renders children immediately.
    */
   disabled?: boolean;
+  /**
+   * Content to render before the component becomes visible in the viewport.
+   */
+  fallback?: React.ReactNode;
   observerOptions?: Partial<IntersectionObserverInit>;
   /**
    * Removes the wrapping div once visible
@@ -93,5 +97,5 @@ export function LazyRender(props: LazyRenderProps) {
     return props.children;
   }
 
-  return <div ref={onRefNode}>{visible ? props.children : null}</div>;
+  return <div ref={onRefNode}>{visible ? props.children : (props.fallback ?? null)}</div>;
 }

--- a/static/app/views/explore/contexts/logs/logsPageData.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageData.tsx
@@ -23,10 +23,12 @@ export function LogsPageDataProvider({
   children,
   allowHighFidelity,
   disabled,
+  staleTime,
 }: {
   children: React.ReactNode;
   allowHighFidelity?: boolean;
   disabled?: boolean;
+  staleTime?: number;
 }) {
   const organization = useOrganization();
   const feature = isLogsEnabled(organization);
@@ -34,6 +36,7 @@ export function LogsPageDataProvider({
   const infiniteLogsQueryResult = useInfiniteLogsQuery({
     disabled: disabled || !feature,
     highFidelity: allowHighFidelity && highFidelity,
+    staleTime,
   });
   const value = useMemo(() => {
     return {

--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -409,10 +409,12 @@ export function useInfiniteLogsQuery({
   disabled,
   highFidelity,
   referrer,
+  staleTime: staleTimeOverride,
 }: {
   disabled?: boolean;
   highFidelity?: boolean;
   referrer?: string;
+  staleTime?: number;
 } = {}) {
   const _referrer = referrer ?? 'api.explore.logs-table';
   const autoRefresh = useLogsAutoRefreshEnabled();
@@ -519,7 +521,9 @@ export function useInfiniteLogsQuery({
     getNextPageParam,
     initialPageParam,
     enabled: !disabled,
-    staleTime: autoRefresh ? Infinity : getStaleTimeForEventView(other.eventView),
+    staleTime:
+      staleTimeOverride ??
+      (autoRefresh ? Infinity : getStaleTimeForEventView(other.eventView)),
     maxPages: maxPagesForLogsInfiniteQuery(queryClient, queryKeyWithInfinite),
     refetchIntervalInBackground: true, // Don't refetch when tab is not visible
   });

--- a/static/app/views/performance/newTraceDetails/traceApi/useTrace.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTrace.tsx
@@ -225,6 +225,7 @@ function useDemoTrace(
 type UseTraceOptions = {
   additionalAttributes?: string[];
   limit?: number;
+  referrer?: string;
   /**
    * When passed we make sure that the corresponding event is a part of the trace (if it exists)
    * irrespective of the trace query count limit.
@@ -291,7 +292,7 @@ export function useTrace(options: UseTraceOptions): TraceQueryResult {
       getApiUrl('/organizations/$organizationIdOrSlug/events-trace/$traceId/', {
         path: {organizationIdOrSlug: organization.slug, traceId: options.traceSlug ?? ''},
       }),
-      {query: queryParams},
+      {query: {...queryParams, referrer: options.referrer}},
     ],
     {
       staleTime: Infinity,
@@ -309,6 +310,7 @@ export function useTrace(options: UseTraceOptions): TraceQueryResult {
           ...queryParams,
           project: -1,
           additional_attributes: options.additionalAttributes,
+          referrer: options.referrer,
         },
       },
     ],

--- a/static/app/views/performance/newTraceDetails/traceApi/useTrace.tsx
+++ b/static/app/views/performance/newTraceDetails/traceApi/useTrace.tsx
@@ -283,8 +283,12 @@ export function useTrace(options: UseTraceOptions): TraceQueryResult {
     maxPickableDays > defaultStatsDays;
 
   const fallbackQueryParams = useMemo(
-    () => ({...queryParams, statsPeriod: `${maxPickableDays}d`}),
-    [queryParams, maxPickableDays]
+    () => ({
+      ...queryParams,
+      statsPeriod: `${maxPickableDays}d`,
+      referrer: options.referrer,
+    }),
+    [queryParams, maxPickableDays, options.referrer]
   );
 
   const traceQuery = useApiQuery<TraceSplitResults<TraceTree.Transaction>>(


### PR DESCRIPTION
The goal of this PR is to delay and retain the requests for logs, metrics, and the trace waterfall until the user scrolls down and brings them into the viewport, in an effort to reduce the amount of calls we're making to the events endpoint.

Also added in some new referrers to be more explicit as to where the requests are coming from.

Closes EXP-923