### PR TITLE
ref(cells) Make owner required for organization provision

### DIFF
--- a/src/sentry/core/endpoints/organization_index.py
+++ b/src/sentry/core/endpoints/organization_index.py
@@ -416,7 +416,6 @@ class OrganizationIndexEndpoint(Endpoint):
                 provision_options=OrganizationOptions(
                     name=result["name"],
                     slug=result.get("slug") or result["name"],
-                    owning_user_id=request.user.id,
                     owner=rpc_user,
                     create_default_team=create_default_team,
                     ip_address=request.META["REMOTE_ADDR"],

--- a/src/sentry/hybridcloud/services/cell_organization_provisioning/impl.py
+++ b/src/sentry/hybridcloud/services/cell_organization_provisioning/impl.py
@@ -47,18 +47,11 @@ class DatabaseBackedCellOrganizationProvisioningRpcService(CellOrganizationProvi
         self,
         organization_name: str,
         slug: str,
+        owner: RpcUser,
         create_default_team: bool,
         organization_id: int,
         is_test: bool = False,
-        owner: RpcUser | None = None,
-        # TODO(cells) Deprecated use owner instead
-        user_id: int | None = None,
-        # TODO(cells) Deprecated use owner instead
-        email: str | None = None,
     ) -> Organization:
-        assert (user_id is None and email) or (user_id and email is None), (
-            "Must set either user_id or email"
-        )
         truncated_name = organization_name[:ORGANIZATION_NAME_MAX_LENGTH]
         org = Organization.objects.create(
             id=organization_id, name=truncated_name, slug=slug, is_test=is_test
@@ -70,14 +63,8 @@ class DatabaseBackedCellOrganizationProvisioningRpcService(CellOrganizationProvi
         # or a bug in the slugify implementation, so we reject the organization creation
         assert org.slug == slug, "Organization slug should not have been modified on save"
 
-        om = (
-            OrganizationMember.objects.create(
-                user_id=user_id, organization=org, role=roles.get_top_dog().id
-            )
-            if user_id
-            else OrganizationMember.objects.create(
-                email=email, organization=org, role=roles.get_top_dog().id
-            )
+        om = OrganizationMember.objects.create(
+            user_id=owner.id, organization=org, role=roles.get_top_dog().id
         )
 
         if create_default_team:
@@ -107,7 +94,7 @@ class DatabaseBackedCellOrganizationProvisioningRpcService(CellOrganizationProvi
             try:
                 provisioning_user_is_org_owner = (
                     matching_org.get_default_owner().id
-                    == provision_payload.provision_options.owning_user_id
+                    == provision_payload.provision_options.owner.id
                 )
             except IndexError:
                 # get_default_owner raises this when the org has no default owner

--- a/src/sentry/hybridcloud/services/cell_organization_provisioning/impl.py
+++ b/src/sentry/hybridcloud/services/cell_organization_provisioning/impl.py
@@ -148,8 +148,6 @@ class DatabaseBackedCellOrganizationProvisioningRpcService(CellOrganizationProvi
         with outbox_context(transaction.atomic(router.db_for_write(Organization))):
             organization = self._create_organization_and_team(
                 owner=provision_options.owner,
-                user_id=provision_options.owning_user_id,
-                email=provision_options.owning_email,
                 slug=provision_options.slug,
                 organization_name=provision_options.name,
                 create_default_team=provision_options.create_default_team,

--- a/src/sentry/hybridcloud/services/control_organization_provisioning/impl.py
+++ b/src/sentry/hybridcloud/services/control_organization_provisioning/impl.py
@@ -156,7 +156,7 @@ class DatabaseBackedControlOrganizationProvisioningService(
             org_slug_res = OrganizationSlugReservation(
                 slug=slug,
                 organization_id=org_id,
-                user_id=org_provision_args.provision_options.owning_user_id,
+                user_id=org_provision_args.provision_options.owner.id,
                 cell_name=cell_name,
             )
 

--- a/src/sentry/runner/commands/createorg.py
+++ b/src/sentry/runner/commands/createorg.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import click
 
 from sentry.runner.decorators import configuration
+from sentry.users.models.user import User
 
 
 @click.command()
@@ -38,11 +39,13 @@ def createorg(
         organization_provisioning_service,
     )
 
+    owner = User.objects.get(email=owner_email)
+
     provision_args = OrganizationProvisioningOptions(
         provision_options=OrganizationOptions(
             name=name,
             slug=slug or name,
-            owning_email=owner_email,
+            owner=owner,
             create_default_team=not no_default_team,
         ),
         post_provision_options=PostProvisionOptions(),

--- a/src/sentry/runner/commands/createorg.py
+++ b/src/sentry/runner/commands/createorg.py
@@ -4,6 +4,7 @@ import click
 
 from sentry.runner.decorators import configuration
 from sentry.users.models.user import User
+from sentry.users.services.user.serial import serialize_generic_user
 
 
 @click.command()
@@ -40,12 +41,14 @@ def createorg(
     )
 
     owner = User.objects.get(email=owner_email)
+    rpc_owner = serialize_generic_user(owner)
+    assert rpc_owner  # remove None
 
     provision_args = OrganizationProvisioningOptions(
         provision_options=OrganizationOptions(
             name=name,
             slug=slug or name,
-            owner=owner,
+            owner=rpc_owner,
             create_default_team=not no_default_team,
         ),
         post_provision_options=PostProvisionOptions(),

--- a/src/sentry/runner/commands/createorg.py
+++ b/src/sentry/runner/commands/createorg.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import click
 
 from sentry.runner.decorators import configuration
-from sentry.users.models.user import User
-from sentry.users.services.user.serial import serialize_generic_user
 
 
 @click.command()
@@ -39,6 +37,8 @@ def createorg(
         OrganizationProvisioningException,
         organization_provisioning_service,
     )
+    from sentry.users.models.user import User
+    from sentry.users.services.user.serial import serialize_generic_user
 
     owner = User.objects.get(email=owner_email)
     rpc_owner = serialize_generic_user(owner)

--- a/src/sentry/services/organization/model.py
+++ b/src/sentry/services/organization/model.py
@@ -8,11 +8,7 @@ from sentry.users.services.user.model import RpcUser
 class OrganizationOptions(pydantic.BaseModel):
     name: str
     slug: str
-    # Deprecated use owner instead.
-    owning_user_id: int | None = None
-    # Deprecated use owner instead.
-    owning_email: str | None = None
-    owner: RpcUser | None = None
+    owner: RpcUser
     create_default_team: bool = True
     is_test: bool = False
     ip_address: str | None = None

--- a/tests/sentry/hybridcloud/services/test_cell_organization_provisioning.py
+++ b/tests/sentry/hybridcloud/services/test_cell_organization_provisioning.py
@@ -25,18 +25,22 @@ from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test, create_test_cells
 from sentry.users.models.user import User
+from sentry.users.services.user.serial import serialize_generic_user
 
 
 @control_silo_test(cells=create_test_cells("us"))
-class TestRegionOrganizationProvisioningCreateInRegion(TestCase):
+class TestCellOrganizationProvisioningCreateInRegion(TestCase):
     def get_provisioning_args(
         self, user: User, is_test: bool = False, create_default_team: bool = True
     ) -> OrganizationProvisioningOptions:
+        owner = serialize_generic_user(user)
+        assert owner, "User/owner is required"
+
         return OrganizationProvisioningOptions(
             provision_options=OrganizationOptions(
                 name="Santry",
                 slug="santry",
-                owning_user_id=user.id,
+                owner=owner,
                 is_test=is_test,
                 create_default_team=create_default_team,
             ),
@@ -50,9 +54,7 @@ class TestRegionOrganizationProvisioningCreateInRegion(TestCase):
             org: Organization = Organization.objects.get(id=organization_id)
             assert org.slug == provisioning_options.provision_options.slug
             assert org.name == provisioning_options.provision_options.name
-            assert (
-                org.get_default_owner().id == provisioning_options.provision_options.owning_user_id
-            )
+            assert org.get_default_owner().id == provisioning_options.provision_options.owner.id
         assert org.is_test == provisioning_options.provision_options.is_test
 
     def assert_has_default_team_and_membership(self, organization_id: int, user_id: int) -> None:
@@ -108,7 +110,7 @@ class TestRegionOrganizationProvisioningCreateInRegion(TestCase):
             organization_id=organization_id, provision_payload=provision_options, cell_name="us"
         )
 
-        assert result
+        assert result, "provisioning should succeed"
         self.organization_matches_provisioning_args(
             organization_id=organization_id, provisioning_options=provision_options
         )

--- a/tests/sentry/hybridcloud/services/test_control_organization_provisioning.py
+++ b/tests/sentry/hybridcloud/services/test_control_organization_provisioning.py
@@ -25,6 +25,8 @@ from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import all_silo_test, assume_test_silo_mode, create_test_cells
 from sentry.types.cell import get_local_cell
+from sentry.users.models.user import User
+from sentry.users.services.user.serial import serialize_generic_user
 from sentry.utils.security.orgauthtoken_token import hash_token
 
 
@@ -32,7 +34,7 @@ class TestControlOrganizationProvisioningBase(TestCase):
     def setUp(self) -> None:
         self.provision_user = self.create_user()
         self.provisioning_args = self.generate_provisioning_args(
-            name="sentry", slug="sentry", user_id=self.provision_user.id, default_team=True
+            name="sentry", slug="sentry", owner=self.provision_user, default_team=True
         )
 
         self.cell_name = (
@@ -44,16 +46,17 @@ class TestControlOrganizationProvisioningBase(TestCase):
         *,
         name: str,
         slug: str,
+        owner: User,
         default_team: bool,
-        user_id: int | None = None,
-        email: str | None = None,
     ) -> OrganizationProvisioningOptions:
+        rpc_owner = serialize_generic_user(owner)
+        assert rpc_owner, "owner/user is required"
+
         return OrganizationProvisioningOptions(
             provision_options=OrganizationOptions(
                 name=name,
                 slug=slug,
-                owning_user_id=user_id,
-                owning_email=email,
+                owner=rpc_owner,
                 create_default_team=default_team,
                 is_test=False,
             ),
@@ -103,17 +106,6 @@ class TestControlOrganizationProvisioning(TestControlOrganizationProvisioningBas
         rpc_org_slug = self.provision_organization()
         self.assert_slug_reservation_and_org_exist(
             rpc_org_slug=rpc_org_slug, user_id=self.provision_user.id
-        )
-
-    def test_organization_provisioning_before_user_provisioning(self) -> None:
-        provisioning_options = self.generate_provisioning_args(
-            name="sentry", slug="sentry", email="test-owner@sentry.io", default_team=True
-        )
-        slug = control_organization_provisioning_rpc_service.provision_organization(
-            cell_name="us", org_provision_args=provisioning_options
-        )
-        self.assert_slug_reservation_and_org_exist(
-            rpc_org_slug=slug,
         )
 
     def test_organization_already_provisioned_for_different_user(self) -> None:
@@ -207,9 +199,11 @@ class TestControlOrganizationProvisioningSlugUpdates(TestControlOrganizationProv
     def test_updates_inexact_slug_with_collision(self) -> None:
         test_org_slug_reservation = self.provision_organization()
 
-        new_user = self.create_user()
         conflicting_slug = "foobar"
-        self.provisioning_args.provision_options.owning_user_id = new_user.id
+        new_user = self.create_user()
+        new_user_rpc = serialize_generic_user(new_user)
+        assert new_user_rpc
+        self.provisioning_args.provision_options.owner = new_user_rpc
         self.provisioning_args.provision_options.slug = conflicting_slug
         org_slug_res_with_conflict = self.provision_organization()
 
@@ -243,8 +237,11 @@ class TestControlOrganizationProvisioningSlugUpdates(TestControlOrganizationProv
         original_slug = test_org_slug_reservation.slug
 
         new_user = self.create_user()
+        new_user_rpc = serialize_generic_user(new_user)
+        assert new_user_rpc
         conflicting_slug = "foobar"
-        self.provisioning_args.provision_options.owning_user_id = new_user.id
+
+        self.provisioning_args.provision_options.owner = new_user_rpc
         self.provisioning_args.provision_options.slug = conflicting_slug
         org_with_conflicting_slug = self.provision_organization()
 
@@ -270,8 +267,10 @@ class TestControlOrganizationProvisioningSlugUpdates(TestControlOrganizationProv
         original_slug = org_reservation.slug
 
         conflicting_owner = self.create_user()
+        conflicting_owner_rpc = serialize_generic_user(conflicting_owner)
+        assert conflicting_owner_rpc
         conflicting_slug = "conflicty"
-        self.provisioning_args.provision_options.owning_user_id = conflicting_owner.id
+        self.provisioning_args.provision_options.owner = conflicting_owner_rpc
         self.provisioning_args.provision_options.slug = conflicting_slug
         conflicting_slug_reservation = self.provision_organization(cell_name="de")
 

--- a/tests/sentry/runner/commands/test_createorg.py
+++ b/tests/sentry/runner/commands/test_createorg.py
@@ -3,30 +3,33 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.models.team import Team
 from sentry.runner.commands.createorg import createorg
 from sentry.testutils.cases import CliTestCase
+from sentry.testutils.silo import no_silo_test
 
 
+@no_silo_test
 class CreateOrgTest(CliTestCase):
     command = createorg
 
     def test_basic_create(self) -> None:
+        user = self.create_user("owner@example.com")
         rv = self.invoke("--name=Test Org", "--slug=test-org", "--owner-email=owner@example.com")
         assert rv.exit_code == 0, rv.output
         assert "test-org" in rv.output
 
         org = Organization.objects.get(slug="test-org")
         assert org.name == "Test Org"
-        assert OrganizationMember.objects.filter(
-            organization=org, email="owner@example.com"
-        ).exists()
+        assert OrganizationMember.objects.filter(organization=org, user_id=user.id).exists()
         assert Team.objects.filter(organization=org).exists()
 
     def test_slug_defaults_to_name(self) -> None:
+        self.create_user("owner@example.com")
         rv = self.invoke("--name=My Organization", "--owner-email=owner@example.com")
         assert rv.exit_code == 0, rv.output
 
         assert Organization.objects.filter(slug="my-organization").exists()
 
     def test_no_default_team(self) -> None:
+        self.create_user("owner@example.com")
         rv = self.invoke(
             "--name=No Team Org",
             "--slug=no-team-org",
@@ -39,6 +42,7 @@ class CreateOrgTest(CliTestCase):
         assert not Team.objects.filter(organization=org).exists()
 
     def test_missing_name(self) -> None:
+        self.create_user("owner@example.com")
         rv = self.invoke("--slug=test-org", "--owner-email=owner@example.com")
         assert rv.exit_code != 0
 


### PR DESCRIPTION
Reduce redundancy in provisioning parameters, and require a User. This requires minor changes in CLI tools, but reduces complexity.

Refs INFRENG-186
