### PR TITLE
fix(preprod): Constrain allowed search filters

### DIFF
--- a/static/app/components/preprod/constants.ts
+++ b/static/app/components/preprod/constants.ts
@@ -43,4 +43,5 @@ export const SNAPSHOT_ALLOWED_KEYS = [
   'images_renamed',
   'images_skipped',
   'images_unchanged',
+  'is_approved',
 ];

--- a/static/app/components/preprod/constants.ts
+++ b/static/app/components/preprod/constants.ts
@@ -28,3 +28,19 @@ export const MOBILE_BUILDS_ALLOWED_KEYS = [
   'is_approved',
   'platform_name',
 ];
+
+export const SNAPSHOT_ALLOWED_KEYS = [
+  'app_id',
+  'git_base_ref',
+  'git_base_sha',
+  'git_head_ref',
+  'git_head_sha',
+  'git_pr_number',
+  'image_count',
+  'images_added',
+  'images_changed',
+  'images_removed',
+  'images_renamed',
+  'images_skipped',
+  'images_unchanged',
+];

--- a/static/app/components/preprod/preprodSearchBar.tsx
+++ b/static/app/components/preprod/preprodSearchBar.tsx
@@ -145,6 +145,7 @@ export function PreprodSearchBar({
       disallowHas={disallowHas}
       disallowLogicalOperators={disallowLogicalOperators}
       hiddenAttributeKeys={hiddenKeys}
+      allowedAttributeKeys={allowedKeys}
     />
   );
 }

--- a/static/app/components/preprod/preprodSearchBar.tsx
+++ b/static/app/components/preprod/preprodSearchBar.tsx
@@ -1,6 +1,7 @@
 import {useMemo} from 'react';
 
 import type {TagCollection} from 'sentry/types/group';
+import {FieldKind} from 'sentry/utils/fields';
 import {TraceItemSearchQueryBuilder} from 'sentry/views/explore/components/traceItemSearchQueryBuilder';
 import {HIDDEN_PREPROD_ATTRIBUTES} from 'sentry/views/explore/constants';
 import {usePreprodItemAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
@@ -34,6 +35,35 @@ interface PreprodSearchBarProps {
   searchSource?: string;
 }
 
+const PREPROD_FILTER_KEY_KINDS: Record<string, FieldKind> = {
+  app_id: FieldKind.TAG,
+  app_name: FieldKind.TAG,
+  build_configuration_name: FieldKind.TAG,
+  build_number: FieldKind.TAG,
+  build_version: FieldKind.TAG,
+  distribution_error_code: FieldKind.TAG,
+  download_count: FieldKind.MEASUREMENT,
+  download_size: FieldKind.MEASUREMENT,
+  git_base_ref: FieldKind.TAG,
+  git_base_sha: FieldKind.TAG,
+  git_head_ref: FieldKind.TAG,
+  git_head_repo_name: FieldKind.TAG,
+  git_head_sha: FieldKind.TAG,
+  git_pr_number: FieldKind.MEASUREMENT,
+  image_count: FieldKind.MEASUREMENT,
+  images_added: FieldKind.MEASUREMENT,
+  images_changed: FieldKind.MEASUREMENT,
+  images_removed: FieldKind.MEASUREMENT,
+  images_renamed: FieldKind.MEASUREMENT,
+  images_skipped: FieldKind.MEASUREMENT,
+  images_unchanged: FieldKind.MEASUREMENT,
+  install_size: FieldKind.MEASUREMENT,
+  installable: FieldKind.BOOLEAN,
+  is_approved: FieldKind.BOOLEAN,
+  platform_name: FieldKind.TAG,
+  size_state: FieldKind.TAG,
+};
+
 function filterToAllowedKeys(
   attributes: TagCollection,
   allowedKeys: string[]
@@ -46,6 +76,22 @@ function filterToAllowedKeys(
     }
   }
   return result;
+}
+
+function getAllowedFilterKeys(allowedKeys: string[]): TagCollection {
+  return Object.fromEntries(
+    allowedKeys.map(key => {
+      const kind = PREPROD_FILTER_KEY_KINDS[key];
+      return [
+        key,
+        {
+          key,
+          name: key,
+          ...(kind ? {kind} : {}),
+        },
+      ];
+    })
+  );
 }
 
 /**
@@ -70,6 +116,10 @@ export function PreprodSearchBar({
   // When using allowedKeys, we fetch all attributes then filter to the allowlist.
   // Otherwise, we use HIDDEN_PREPROD_ATTRIBUTES to hide internal fields.
   const hiddenKeys = allowedKeys ? undefined : HIDDEN_PREPROD_ATTRIBUTES;
+  const allowedFilterKeys = useMemo(
+    () => (allowedKeys ? getAllowedFilterKeys(allowedKeys) : undefined),
+    [allowedKeys]
+  );
 
   const {attributes: rawStringAttributes, secondaryAliases: rawStringSecondaryAliases} =
     usePreprodItemAttributes({}, 'string', hiddenKeys);
@@ -145,7 +195,7 @@ export function PreprodSearchBar({
       disallowHas={disallowHas}
       disallowLogicalOperators={disallowLogicalOperators}
       hiddenAttributeKeys={hiddenKeys}
-      allowedAttributeKeys={allowedKeys}
+      allowedFilterKeys={allowedFilterKeys}
     />
   );
 }

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.spec.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.spec.tsx
@@ -168,6 +168,60 @@ describe('useTraceItemSearchQueryBuilderProps', () => {
     expect(result.current.disallowUnsupportedFilters).toBe(false);
   });
 
+  it('uses allowedFilterKeys as supported fallback keys', () => {
+    const {result} = renderHookWithProviders(useTraceItemSearchQueryBuilderProps, {
+      initialProps: {
+        ...defaultInitialProps,
+        itemType: TraceItemDataset.PREPROD,
+        allowedFilterKeys: {
+          git_head_sha: {
+            key: 'git_head_sha',
+            name: 'git_head_sha',
+          },
+          is_approved: {
+            key: 'is_approved',
+            name: 'is_approved',
+            kind: FieldKind.BOOLEAN,
+          },
+        },
+      },
+      organization,
+    });
+
+    expect(result.current.filterKeys.git_head_sha).toBeDefined();
+    expect(result.current.filterKeys.is_approved).toBeDefined();
+    expect(result.current.disallowUnsupportedFilters).toBe(true);
+    expect(result.current.getTagKeys).toEqual(expect.any(Function));
+  });
+
+  it('filters async getTagKeys results through allowedFilterKeys', async () => {
+    const traceItemAttributesMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/trace-items/attributes/',
+      body: [
+        {attributeType: 'string', key: 'git_head_sha', name: 'git_head_sha'},
+        {attributeType: 'string', key: 'app_name', name: 'app_name'},
+      ],
+    });
+
+    const {result} = renderHookWithProviders(useTraceItemSearchQueryBuilderProps, {
+      initialProps: {
+        ...defaultInitialProps,
+        itemType: TraceItemDataset.PREPROD,
+        allowedFilterKeys: {
+          git_head_sha: {
+            key: 'git_head_sha',
+            name: 'git_head_sha',
+          },
+        },
+      },
+      organization,
+    });
+    const tags = await result.current.getTagKeys?.('git');
+
+    expect(traceItemAttributesMock).toHaveBeenCalled();
+    expect(tags?.map(tag => tag.key)).toEqual(['git_head_sha']);
+  });
+
   it.each([TraceItemDataset.SPANS, TraceItemDataset.LOGS, TraceItemDataset.TRACEMETRICS])(
     'disables recent searches when disableRecentSearches is true for item type %s',
     itemType => {

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -29,6 +29,7 @@ export type TraceItemSearchQueryBuilderProps = {
   numberSecondaryAliases: TagCollection;
   stringAttributes: TagCollection;
   stringSecondaryAliases: TagCollection;
+  allowedAttributeKeys?: string[];
   attributeQuery?: string;
   caseInsensitive?: CaseInsensitive;
   disableRecentSearches?: boolean;
@@ -109,6 +110,7 @@ export function useTraceItemSearchQueryBuilderProps({
   disableRecentSearches,
   attributeQuery,
   hiddenAttributeKeys,
+  allowedAttributeKeys,
 }: TraceItemSearchQueryBuilderProps) {
   const placeholderText = itemTypeToDefaultPlaceholder(itemType);
 
@@ -147,13 +149,17 @@ export function useTraceItemSearchQueryBuilderProps({
     booleanAttributes,
   });
 
-  const getTagKeys = useGetTraceItemAttributeTagKeys({
+  const dynamicTagKeys = useGetTraceItemAttributeTagKeys({
     itemType,
     projects,
     extraTags: functionTags,
     query: attributeQuery,
     hiddenKeys: hiddenAttributeKeys,
   });
+  // When an allowlist is in effect, the static filterKeys are already curated to
+  // it. Skip the dynamic EAP fetch so typed-key autocomplete only matches against
+  // the allowlist (and unrecognized keys are auto-rejected).
+  const getTagKeys = allowedAttributeKeys ? undefined : dynamicTagKeys;
 
   return useMemo(
     () => ({
@@ -252,6 +258,7 @@ export function TraceItemSearchQueryBuilder({
   disableRecentSearches,
   attributeQuery,
   hiddenAttributeKeys,
+  allowedAttributeKeys,
 }: TraceItemSearchQueryBuilderProps) {
   const searchQueryBuilderProps = useTraceItemSearchQueryBuilderProps({
     itemType,
@@ -281,6 +288,7 @@ export function TraceItemSearchQueryBuilder({
     disableRecentSearches,
     attributeQuery,
     hiddenAttributeKeys,
+    allowedAttributeKeys,
   });
 
   return (

--- a/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
+++ b/static/app/views/explore/components/traceItemSearchQueryBuilder.tsx
@@ -1,4 +1,4 @@
-import {useMemo} from 'react';
+import {useCallback, useMemo} from 'react';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import type {SpanSearchQueryBuilderProps} from 'sentry/components/performance/spanSearchQueryBuilder';
@@ -29,7 +29,7 @@ export type TraceItemSearchQueryBuilderProps = {
   numberSecondaryAliases: TagCollection;
   stringAttributes: TagCollection;
   stringSecondaryAliases: TagCollection;
-  allowedAttributeKeys?: string[];
+  allowedFilterKeys?: TagCollection;
   attributeQuery?: string;
   caseInsensitive?: CaseInsensitive;
   disableRecentSearches?: boolean;
@@ -110,7 +110,7 @@ export function useTraceItemSearchQueryBuilderProps({
   disableRecentSearches,
   attributeQuery,
   hiddenAttributeKeys,
-  allowedAttributeKeys,
+  allowedFilterKeys,
 }: TraceItemSearchQueryBuilderProps) {
   const placeholderText = itemTypeToDefaultPlaceholder(itemType);
 
@@ -135,6 +135,34 @@ export function useTraceItemSearchQueryBuilderProps({
     booleanAttributes,
     disallowHas: disallowHas ?? false,
   });
+  const allowedFilterKeySet = useMemo(
+    () => (allowedFilterKeys ? new Set(Object.keys(allowedFilterKeys)) : undefined),
+    [allowedFilterKeys]
+  );
+  const effectiveFilterTags = useMemo(() => {
+    if (!allowedFilterKeys || !allowedFilterKeySet) {
+      return filterTags;
+    }
+
+    const tags = {...allowedFilterKeys};
+    for (const [key, tag] of Object.entries(filterTags)) {
+      if (allowedFilterKeySet.has(key)) {
+        tags[key] = tag;
+      }
+    }
+    return tags;
+  }, [allowedFilterKeySet, allowedFilterKeys, filterTags]);
+  const effectiveFilterKeySections = useMemo(() => {
+    if (!allowedFilterKeySet) {
+      return filterKeySections;
+    }
+    return filterKeySections
+      .map(section => ({
+        ...section,
+        children: section.children.filter(key => allowedFilterKeySet.has(key)),
+      }))
+      .filter(section => section.children.length);
+  }, [allowedFilterKeySet, filterKeySections]);
 
   const getTraceItemAttributeValues = useGetTraceItemAttributeValues({
     traceItemType: itemType,
@@ -148,35 +176,73 @@ export function useTraceItemSearchQueryBuilderProps({
     stringAttributes,
     booleanAttributes,
   });
+  const getAllowedSuggestedAttribute = useCallback(
+    (key: string) => {
+      const suggestedKey = getSuggestedAttribute(key);
+      if (!suggestedKey || !allowedFilterKeySet) {
+        return suggestedKey;
+      }
+      return allowedFilterKeySet.has(suggestedKey) ? suggestedKey : null;
+    },
+    [allowedFilterKeySet, getSuggestedAttribute]
+  );
 
-  const dynamicTagKeys = useGetTraceItemAttributeTagKeys({
+  const getTagKeys = useGetTraceItemAttributeTagKeys({
     itemType,
     projects,
     extraTags: functionTags,
     query: attributeQuery,
     hiddenKeys: hiddenAttributeKeys,
   });
-  // When an allowlist is in effect, the static filterKeys are already curated to
-  // it. Skip the dynamic EAP fetch so typed-key autocomplete only matches against
-  // the allowlist (and unrecognized keys are auto-rejected).
-  const getTagKeys = allowedAttributeKeys ? undefined : dynamicTagKeys;
+  const getAllowedTagKeys = useCallback(
+    async (searchQuery: string) => {
+      const tags = await getTagKeys(searchQuery);
+      if (!allowedFilterKeySet) {
+        return tags;
+      }
+      return tags.filter(tag => allowedFilterKeySet.has(tag.key));
+    },
+    [allowedFilterKeySet, getTagKeys]
+  );
+
+  const filterKeyAliases = useMemo(() => {
+    const aliases = {
+      ...numberSecondaryAliases,
+      ...stringSecondaryAliases,
+      ...booleanSecondaryAliases,
+    };
+    if (!allowedFilterKeySet) {
+      return aliases;
+    }
+    return Object.fromEntries(
+      Object.entries(aliases).filter(([key]) => allowedFilterKeySet.has(key))
+    );
+  }, [
+    allowedFilterKeySet,
+    booleanSecondaryAliases,
+    numberSecondaryAliases,
+    stringSecondaryAliases,
+  ]);
 
   return useMemo(
     () => ({
       placeholder: placeholderText,
-      filterKeys: filterTags,
+      filterKeys: effectiveFilterTags,
       initialQuery,
-      fieldDefinitionGetter: getTraceItemFieldDefinitionFunction(itemType, filterTags),
+      fieldDefinitionGetter: getTraceItemFieldDefinitionFunction(
+        itemType,
+        effectiveFilterTags
+      ),
       onSearch,
       onChange,
       onBlur,
       getFilterTokenWarning,
       searchSource,
-      filterKeySections,
-      getSuggestedFilterKey: getSuggestedAttribute,
+      filterKeySections: effectiveFilterKeySections,
+      getSuggestedFilterKey: getAllowedSuggestedAttribute,
       getTagValues: getTraceItemAttributeValues,
-      getTagKeys,
-      disallowUnsupportedFilters: !getTagKeys,
+      getTagKeys: getAllowedTagKeys,
+      disallowUnsupportedFilters: !!allowedFilterKeys,
       disallowFreeText,
       disallowLogicalOperators,
       recentSearches: disableRecentSearches
@@ -187,33 +253,28 @@ export function useTraceItemSearchQueryBuilderProps({
       portalTarget,
       replaceRawSearchKeys,
       matchKeySuggestions,
-      filterKeyAliases: {
-        ...numberSecondaryAliases,
-        ...stringSecondaryAliases,
-        ...booleanSecondaryAliases,
-      },
+      filterKeyAliases,
       caseInsensitive,
       onCaseInsensitiveClick,
       invalidFilterKeys,
     }),
     [
-      booleanSecondaryAliases,
+      allowedFilterKeys,
       caseInsensitive,
       disallowFreeText,
       disallowLogicalOperators,
       disableRecentSearches,
-      filterKeySections,
-      filterTags,
+      effectiveFilterKeySections,
+      effectiveFilterTags,
       getFilterTokenWarning,
-      getSuggestedAttribute,
-      getTagKeys,
+      getAllowedSuggestedAttribute,
+      getAllowedTagKeys,
       getTraceItemAttributeValues,
       initialQuery,
       invalidFilterKeys,
       itemType,
       matchKeySuggestions,
       namespace,
-      numberSecondaryAliases,
       onBlur,
       onCaseInsensitiveClick,
       onChange,
@@ -222,7 +283,7 @@ export function useTraceItemSearchQueryBuilderProps({
       portalTarget,
       replaceRawSearchKeys,
       searchSource,
-      stringSecondaryAliases,
+      filterKeyAliases,
     ]
   );
 }
@@ -258,7 +319,7 @@ export function TraceItemSearchQueryBuilder({
   disableRecentSearches,
   attributeQuery,
   hiddenAttributeKeys,
-  allowedAttributeKeys,
+  allowedFilterKeys,
 }: TraceItemSearchQueryBuilderProps) {
   const searchQueryBuilderProps = useTraceItemSearchQueryBuilderProps({
     itemType,
@@ -288,7 +349,7 @@ export function TraceItemSearchQueryBuilder({
     disableRecentSearches,
     attributeQuery,
     hiddenAttributeKeys,
-    allowedAttributeKeys,
+    allowedFilterKeys,
   });
 
   return (

--- a/static/app/views/explore/releases/list/mobileBuilds.tsx
+++ b/static/app/views/explore/releases/list/mobileBuilds.tsx
@@ -9,6 +9,10 @@ import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {ALL_ACCESS_PROJECTS} from 'sentry/components/pageFilters/constants';
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {
+  MOBILE_BUILDS_ALLOWED_KEYS,
+  SNAPSHOT_ALLOWED_KEYS,
+} from 'sentry/components/preprod/constants';
+import {
   getPreprodBuildsDisplay,
   PreprodBuildsDisplay,
 } from 'sentry/components/preprod/preprodBuildsDisplay';
@@ -204,6 +208,11 @@ export function MobileBuilds({
         initialQuery={searchQuery ?? ''}
         display={activeDisplay}
         projects={selectedProjectIds.map(Number)}
+        allowedKeys={
+          activeDisplay === PreprodBuildsDisplay.SNAPSHOT
+            ? SNAPSHOT_ALLOWED_KEYS
+            : MOBILE_BUILDS_ALLOWED_KEYS
+        }
         hideDisplayToggle={hideDisplayToggle}
         onSearch={handleSearch}
         onDisplayChange={handleDisplayChange}


### PR DESCRIPTION
Stacked on #114316 to make preprod search allowlists an actual key constraint instead of only filtering EAP-fetched attributes. This keeps curated snapshot keys like git_head_sha and is_approved valid even if EAP does not return them yet, while still filtering typed autocomplete results through the allowlist.

**Allowlist Semantics**

TraceItemSearchQueryBuilder now accepts allowedFilterKeys as the supported key set. Static and fetched tags, aliases, suggested keys, sections, and async tag keys are constrained to that set when present.

**Preprod Fallback Keys**

PreprodSearchBar builds typed fallback tags for allowed keys, including snapshot approval filtering, so known backend-supported fields remain parseable before attribute data loads.

Refs EME-1071