### PR TITLE
fix(autofix): Handle errors in code generation better

### DIFF
--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -436,6 +436,9 @@ export type AutofixArtifact =
 export function getAutofixArtifactFromSection(
   section: AutofixSection
 ): AutofixArtifact | null {
+  if (section.status !== 'completed') {
+    return null;
+  }
   if (isRootCauseSection(section)) {
     return section.artifacts.findLast(isRootCauseArtifact) ?? null;
   }

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -436,17 +436,17 @@ export type AutofixArtifact =
 export function getAutofixArtifactFromSection(
   section: AutofixSection
 ): AutofixArtifact | null {
-  if (section.status !== 'completed') {
-    return null;
-  }
-  if (isRootCauseSection(section)) {
-    return section.artifacts.findLast(isRootCauseArtifact) ?? null;
-  }
-  if (isSolutionSection(section)) {
-    return section.artifacts.findLast(isSolutionArtifact) ?? null;
-  }
-  if (isCodeChangesSection(section)) {
-    return section.artifacts.findLast(isCodeChangesArtifact) ?? null;
+  if (section.status === 'completed') {
+    // these artifacts are only usable once the section has completed running
+    if (isRootCauseSection(section)) {
+      return section.artifacts.findLast(isRootCauseArtifact) ?? null;
+    }
+    if (isSolutionSection(section)) {
+      return section.artifacts.findLast(isSolutionArtifact) ?? null;
+    }
+    if (isCodeChangesSection(section)) {
+      return section.artifacts.findLast(isCodeChangesArtifact) ?? null;
+    }
   }
   if (isPullRequestsSection(section)) {
     return section.artifacts.findLast(isPullRequestsArtifact) ?? null;

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -436,7 +436,7 @@ describe('ArtifactCard', () => {
     });
 
     it('renders error state when all patches have no changes', () => {
-      const emptyPatch: ExplorerFilePatch = {
+      const emptyPatch = {
         repo_name: 'org/repo',
         diff: '',
         patch: {

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -434,6 +434,90 @@ describe('ArtifactCard', () => {
 
       expect(screen.queryByRole('button', {name: 'Copy as Markdown'})).toBeDisabled();
     });
+
+    it('renders error state when all patches have no changes', () => {
+      const emptyPatch: ExplorerFilePatch = {
+        repo_name: 'org/repo',
+        diff: '',
+        patch: {
+          path: 'src/app.py',
+          added: 0,
+          removed: 0,
+          hunks: [],
+          source_file: 'src/app.py',
+          target_file: 'src/app.py',
+          type: 'M',
+        },
+      } as ExplorerFilePatch;
+
+      render(
+        <CodeChangesCard
+          autofix={mockAutofix}
+          section={makeSection('code_changes', 'completed', [[emptyPatch]])}
+        />
+      );
+
+      expect(
+        screen.getByText(
+          'Seer failed to generate a code change. This one is on us. Try running it again.'
+        )
+      ).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: 'Re-run'})).toBeInTheDocument();
+    });
+
+    it('calls startStep when re-run button is clicked in error state', async () => {
+      const startStepMock = jest.fn();
+      const autofixWithRunState = {
+        ...mockAutofix,
+        startStep: startStepMock,
+        runState: {
+          run_id: 123,
+          blocks: [],
+          status: 'completed' as const,
+          updated_at: '2026-01-01T00:00:00Z',
+        },
+      };
+
+      render(
+        <CodeChangesCard
+          autofix={autofixWithRunState}
+          section={makeSection('code_changes', 'completed', [])}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button', {name: 'Re-run'}));
+      expect(startStepMock).toHaveBeenCalledWith(
+        'code_changes',
+        expect.objectContaining({runId: 123})
+      );
+    });
+
+    it('renders loading state when processing, not error', () => {
+      render(
+        <CodeChangesCard
+          autofix={mockAutofix}
+          section={makeSection('code_changes', 'processing', [])}
+        />
+      );
+
+      expect(screen.getByText('Implementing changes…')).toBeInTheDocument();
+      expect(
+        screen.queryByText(
+          'Seer failed to generate a code change. This one is on us. Try running it again.'
+        )
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not render file diff viewers in error state', () => {
+      render(
+        <CodeChangesCard
+          autofix={mockAutofix}
+          section={makeSection('code_changes', 'completed', [])}
+        />
+      );
+
+      expect(screen.queryByTestId('file-diff-viewer')).not.toBeInTheDocument();
+    });
   });
 
   describe('PullRequestsCard', () => {

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -88,7 +88,7 @@ export function CodeChangesCard({autofix, section}: CodeChangesCardProps) {
           blocks={section.blocks}
           loadingMessage={t('Implementing changes\u2026')}
         />
-      ) : (
+      ) : artifact && patchesByRepo.size ? (
         <Fragment>
           {shouldShowReset && (
             <AutofixResetPrompt
@@ -98,48 +98,44 @@ export function CodeChangesCard({autofix, section}: CodeChangesCardProps) {
               prompt={t('How can this code change be improved?')}
             />
           )}
-          {patchesByRepo.size ? (
-            <Fragment>
-              <ArtifactDetails>
-                <Text>{summary}</Text>
-              </ArtifactDetails>
-              {[...patchesByRepo.entries()].map(([repo, patches]) => (
-                <ArtifactDetails key={repo}>
-                  <Flex gap="lg">
-                    <Text bold>{t('Repository:')}</Text>
-                    <Text>{repo}</Text>
-                  </Flex>
-                  {patches.map((patch, index) => (
-                    <FileDiffViewer
-                      key={index}
-                      patch={patch.patch}
-                      showBorder
-                      collapsible
-                      defaultExpanded={artifact !== null && artifact.length <= 1}
-                    />
-                  ))}
-                </ArtifactDetails>
+          <ArtifactDetails>
+            <Text>{summary}</Text>
+          </ArtifactDetails>
+          {[...patchesByRepo.entries()].map(([repo, patches]) => (
+            <ArtifactDetails key={repo}>
+              <Flex gap="lg">
+                <Text bold>{t('Repository:')}</Text>
+                <Text>{repo}</Text>
+              </Flex>
+              {patches.map((patch, index) => (
+                <FileDiffViewer
+                  key={index}
+                  patch={patch.patch}
+                  showBorder
+                  collapsible
+                  defaultExpanded={artifact !== null && artifact.length <= 1}
+                />
               ))}
-            </Fragment>
-          ) : (
-            <ArtifactDetails>
-              <Text>
-                {t(
-                  'Seer failed to generate a code change. This one is on us. Try running it again.'
-                )}
-              </Text>
-              <div>
-                <Button
-                  priority="primary"
-                  icon={<IconRefresh />}
-                  onClick={() => handleReset()}
-                >
-                  {t('Re-run')}
-                </Button>
-              </div>
             </ArtifactDetails>
-          )}
+          ))}
         </Fragment>
+      ) : (
+        <ArtifactDetails>
+          <Text>
+            {t(
+              'Seer failed to generate a code change. This one is on us. Try running it again.'
+            )}
+          </Text>
+          <div>
+            <Button
+              priority="primary"
+              icon={<IconRefresh />}
+              onClick={() => handleReset()}
+            >
+              {t('Re-run')}
+            </Button>
+          </div>
+        </ArtifactDetails>
       )}
     </ArtifactCard>
   );


### PR DESCRIPTION
This ensures that the section status is completed before rendering the file diffs to avoid partial diffs being shown and handle error states better allowing for retries.