### PR TITLE
feat(preprod): Add approval_status search key for builds

### DIFF
--- a/src/sentry/preprod/artifact_search.py
+++ b/src/sentry/preprod/artifact_search.py
@@ -27,6 +27,7 @@ search_config = SearchConfig.create_from(
     # Text keys we allow operators to be used on
     text_operator_keys={
         "app_name",
+        "approval_status",
         "build_configuration_name",
         "git_base_ref",
         "git_base_sha",
@@ -62,6 +63,7 @@ search_config = SearchConfig.create_from(
     allowed_keys={
         "app_id",
         "app_name",
+        "approval_status",
         "build_configuration_name",
         "build_number",
         "build_version",
@@ -136,9 +138,23 @@ SIZE_STATE_VALUES: dict[str, int] = {
     member.name.lower(): member.value for member in PreprodArtifactSizeMetrics.SizeAnalysisState
 }
 
+APPROVAL_STATUS_VALUES: dict[str, int] = {
+    member.name.lower(): member.value for member in PreprodComparisonApproval.ApprovalStatus
+}
+
 DISTRIBUTION_ERROR_CODE_VALUES: dict[str, int] = {
     member.name.lower(): member.value for member in PreprodArtifact.InstallableAppErrorCode
 }
+
+
+def _translate_approval_status(value: object) -> int:
+    raw = str(value).lower()
+    if raw not in APPROVAL_STATUS_VALUES:
+        raise InvalidSearchQuery(
+            f"Invalid approval_status value: {value}. "
+            f"Valid values: {', '.join(sorted(APPROVAL_STATUS_VALUES))}"
+        )
+    return APPROVAL_STATUS_VALUES[raw]
 
 
 def _translate_distribution_error_code(value: object) -> int:
@@ -306,6 +322,20 @@ def apply_filters(
                 queryset = queryset.exclude(q)
             else:
                 queryset = queryset.filter(q)
+            continue
+
+        if name == "approval_status":
+            values = token.value.value if token.is_in_filter else [token.value.value]
+            translated = [_translate_approval_status(v) for v in values]
+            approval_exists = PreprodComparisonApproval.objects.filter(
+                preprod_artifact=OuterRef("pk"),
+                preprod_feature_type=PreprodComparisonApproval.FeatureType.SNAPSHOTS,
+                approval_status__in=translated,
+            )
+            if token.is_negation:
+                queryset = queryset.filter(~Exists(approval_exists))
+            else:
+                queryset = queryset.filter(Exists(approval_exists))
             continue
 
         if name == "is_approved":

--- a/static/app/components/preprod/constants.ts
+++ b/static/app/components/preprod/constants.ts
@@ -5,6 +5,7 @@
 export const MOBILE_BUILDS_ALLOWED_KEYS = [
   'app_id',
   'app_name',
+  'approval_status',
   'build_configuration_name',
   'build_number',
   'build_version',

--- a/tests/sentry/preprod/test_artifact_search.py
+++ b/tests/sentry/preprod/test_artifact_search.py
@@ -276,6 +276,82 @@ class ArtifactMatchesQuerySnapshotFiltersTest(TestCase):
         assert artifact_matches_query(no_comparison, "images_changed:!=3", self.organization)
 
 
+class ArtifactMatchesQueryApprovalStatusFilterTest(TestCase):
+    def _create_artifact_with_approval(
+        self,
+        feature_type: int = PreprodComparisonApproval.FeatureType.SNAPSHOTS,
+        status: int = PreprodComparisonApproval.ApprovalStatus.APPROVED,
+        with_approval_row: bool = True,
+    ) -> PreprodArtifact:
+        artifact = self.create_preprod_artifact(project=self.project)
+        if with_approval_row:
+            self.create_preprod_comparison_approval(
+                preprod_artifact=artifact,
+                preprod_feature_type=feature_type,
+                approval_status=status,
+            )
+        return artifact
+
+    def test_approval_status_approved(self) -> None:
+        approved = self._create_artifact_with_approval()
+        pending = self._create_artifact_with_approval(
+            status=PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL
+        )
+        no_row = self._create_artifact_with_approval(with_approval_row=False)
+
+        assert artifact_matches_query(approved, "approval_status:approved", self.organization)
+        assert not artifact_matches_query(pending, "approval_status:approved", self.organization)
+        assert not artifact_matches_query(no_row, "approval_status:approved", self.organization)
+
+    def test_approval_status_needs_approval(self) -> None:
+        approved = self._create_artifact_with_approval()
+        pending = self._create_artifact_with_approval(
+            status=PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL
+        )
+        no_row = self._create_artifact_with_approval(with_approval_row=False)
+
+        assert not artifact_matches_query(
+            approved, "approval_status:needs_approval", self.organization
+        )
+        assert artifact_matches_query(pending, "approval_status:needs_approval", self.organization)
+        assert not artifact_matches_query(
+            no_row, "approval_status:needs_approval", self.organization
+        )
+
+    def test_approval_status_rejected(self) -> None:
+        rejected = self._create_artifact_with_approval(
+            status=PreprodComparisonApproval.ApprovalStatus.REJECTED
+        )
+        approved = self._create_artifact_with_approval()
+
+        assert artifact_matches_query(rejected, "approval_status:rejected", self.organization)
+        assert not artifact_matches_query(approved, "approval_status:rejected", self.organization)
+
+    def test_approval_status_negation(self) -> None:
+        approved = self._create_artifact_with_approval()
+        pending = self._create_artifact_with_approval(
+            status=PreprodComparisonApproval.ApprovalStatus.NEEDS_APPROVAL
+        )
+
+        assert not artifact_matches_query(approved, "!approval_status:approved", self.organization)
+        assert artifact_matches_query(pending, "!approval_status:approved", self.organization)
+
+    def test_approval_status_scoped_to_snapshots(self) -> None:
+        artifact = self._create_artifact_with_approval(
+            feature_type=PreprodComparisonApproval.FeatureType.SIZE,
+        )
+        assert not artifact_matches_query(artifact, "approval_status:approved", self.organization)
+
+    def test_approval_status_no_row_never_matches(self) -> None:
+        no_row = self._create_artifact_with_approval(with_approval_row=False)
+
+        assert not artifact_matches_query(no_row, "approval_status:approved", self.organization)
+        assert not artifact_matches_query(
+            no_row, "approval_status:needs_approval", self.organization
+        )
+        assert not artifact_matches_query(no_row, "approval_status:rejected", self.organization)
+
+
 class ArtifactMatchesQueryIsApprovedFilterTest(TestCase):
     def _create_artifact_with_approval(
         self,


### PR DESCRIPTION
Add an `approval_status` search filter that accepts the enum values
(`approved`, `needs_approval`, `rejected`) instead of the boolean
`is_approved`. This gives users finer-grained filtering over snapshot
approval state in the search bar.

The implementation follows the same pattern as `size_state` and
`distribution_error_code`: string values are translated to the
`ApprovalStatus` IntEnum and matched via an `Exists` subquery scoped
to the `SNAPSHOTS` feature type.