### PR TITLE
ref(seer): Rename 'Open Seer' button to 'Open Autofix'

### DIFF
--- a/static/app/views/issueDetails/streamline/sidebar/autofixSection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/autofixSection.spec.tsx
@@ -160,8 +160,8 @@ describe('AutofixSection', () => {
 
     expect(await screen.findByText('Root Cause')).toBeInTheDocument();
     expect(screen.getByText('Null pointer in user handler')).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'Open Seer'})).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'Open Seer'})).toHaveAttribute(
+    expect(screen.getByRole('button', {name: 'Open Autofix'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Open Autofix'})).toHaveAttribute(
       'href',
       expect.stringContaining('seerDrawer=true')
     );
@@ -206,7 +206,7 @@ describe('AutofixSection', () => {
 
     expect(await screen.findByText('Plan')).toBeInTheDocument();
     expect(screen.getByText('Add null check before accessing user')).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'Open Seer'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Open Autofix'})).toBeInTheDocument();
   });
 
   it('renders code changes preview from merged file patches', async () => {
@@ -266,7 +266,7 @@ describe('AutofixSection', () => {
 
     expect(await screen.findByText('Code Changes')).toBeInTheDocument();
     expect(screen.getByText('2 files changed in 1 repo')).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'Open Seer'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Open Autofix'})).toBeInTheDocument();
   });
 
   it('renders pull request previews from repo_pr_states', async () => {
@@ -326,7 +326,7 @@ describe('AutofixSection', () => {
     expect(await screen.findByText('Pull Requests')).toBeInTheDocument();
     const link = screen.getByRole('link', {name: 'org/repo#42'});
     expect(link).toHaveAttribute('href', 'https://github.com/org/repo/pull/42');
-    expect(screen.getByRole('button', {name: 'Open Seer'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Open Autofix'})).toBeInTheDocument();
   });
 
   it('shows loading placeholder while event is pending', async () => {
@@ -488,7 +488,7 @@ describe('AutofixSection', () => {
     expect(await screen.findByText('Root Cause')).toBeInTheDocument();
     expect(screen.getByText('Plan')).toBeInTheDocument();
     expect(screen.getByText('Code Changes')).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'Open Seer'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Open Autofix'})).toBeInTheDocument();
   });
 
   it('shows org setup UI when SCM integration is missing', async () => {

--- a/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/autofixSection.tsx
@@ -387,7 +387,7 @@ function AutofixPreviews({
       <LinkButton
         size="md"
         icon={<IconSeer />}
-        aria-label={t('Open Seer')}
+        aria-label={t('Open Autofix')}
         priority="primary"
         to={seerDrawerLink}
         onClick={openSeerDrawer}
@@ -407,7 +407,7 @@ function AutofixPreviews({
           referrer,
         }}
       >
-        {t('Open Seer')}
+        {t('Open Autofix')}
       </LinkButton>
     </Flex>
   );

--- a/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/seerSectionCtaButton.tsx
@@ -197,7 +197,7 @@ export function SeerSectionCtaButton({
       if (lastStep.type === AutofixStepType.SOLUTION) {
         return t('Fix with Seer');
       }
-      return t('Open Seer');
+      return t('Open Autofix');
     }
 
     return t('Fix with Seer');


### PR DESCRIPTION
Rename the issue details sidebar CTA from "Open Seer" to "Open Autofix" so the label matches what the button actually opens. Updates the button text, its `aria-label`, the matching CTA in `seerSectionCtaButton`, and the corresponding test queries.


Agent transcript: https://claudescope.sentry.dev/share/aOMGoV2gT1ccinKiTQjDbc18dU0rK9IYI-soU40HSHs