### PR TITLE
feat(scm): Wire GitHubProvider into fetch_service_provider for GitHub Enterprise

### DIFF
--- a/src/sentry/integrations/github_enterprise/client.py
+++ b/src/sentry/integrations/github_enterprise/client.py
@@ -7,13 +7,19 @@ class GitHubEnterpriseApiClient(GitHubBaseClient):
     integration_name = IntegrationProviderSlug.GITHUB_ENTERPRISE.value
 
     def __init__(self, base_url, integration, app_id, private_key, verify_ssl, org_integration_id):
-        self.base_url = f"https://{base_url}"
+        self._is_ghe_cloud: bool = base_url.endswith(".ghe.com")
+        if self._is_ghe_cloud:
+            self.base_url = f"https://api.{base_url}"
+        else:
+            self.base_url = f"https://{base_url}"
         self.integration = integration
         self.app_id = app_id
         self.private_key = private_key
         super().__init__(verify_ssl=verify_ssl, org_integration_id=org_integration_id)
 
     def build_url(self, path: str) -> str:
+        if self._is_ghe_cloud:
+            return super().build_url(path)
         if path.startswith("/"):
             if path == "/graphql":
                 path = "/api/graphql"

--- a/src/sentry/integrations/github_enterprise/integration.py
+++ b/src/sentry/integrations/github_enterprise/integration.py
@@ -57,10 +57,16 @@ from .client import GitHubEnterpriseApiClient
 from .repository import GitHubEnterpriseRepositoryProvider
 
 
+def _api_base_url(url: str) -> str:
+    if url.endswith(".ghe.com"):
+        return f"https://api.{url}"
+    return f"https://{url}/api/v3"
+
+
 def get_user_info(url, access_token):
     with http.build_session() as session:
         resp = session.get(
-            f"https://{url}/api/v3/user",
+            f"{_api_base_url(url)}/user",
             headers={"Accept": GITHUB_API_ACCEPT_HEADER, "Authorization": f"token {access_token}"},
             verify=False,
         )
@@ -696,9 +702,10 @@ class GitHubEnterpriseIntegrationProvider(GitHubIntegrationProvider):
                 )
             )
         )
+        base = _api_base_url(installation_data["url"])
         with http.build_session() as session:
             resp = session.get(
-                f"https://{installation_data['url']}/api/v3/app/installations/{installation_id}",
+                f"{base}/app/installations/{installation_id}",
                 headers=headers,
                 verify=installation_data["verify_ssl"],
             )
@@ -706,7 +713,7 @@ class GitHubEnterpriseIntegrationProvider(GitHubIntegrationProvider):
             installation_resp = resp.json()
 
             resp = session.get(
-                f"https://{installation_data['url']}/api/v3/user/installations",
+                f"{base}/user/installations",
                 headers={
                     "Accept": GITHUB_API_ACCEPT_HEADER,
                     "Authorization": f"token {access_token}",

--- a/src/sentry/integrations/github_enterprise/webhook.py
+++ b/src/sentry/integrations/github_enterprise/webhook.py
@@ -75,7 +75,13 @@ class UnsupportedSignatureAlgorithmError(Exception):
 def get_host(request: HttpRequest) -> str | None:
     # XXX: There's lots of customers that are giving us an IP rather than a host name
     # Use HTTP_X_REAL_IP in a follow up PR (#42405)
-    return request.headers.get("x-github-enterprise-host")
+    host = request.headers.get("x-github-enterprise-host")
+    if host:
+        return host
+    tenant = request.headers.get("x-github-tenant")
+    if tenant:
+        return f"{tenant}.ghe.com"
+    return None
 
 
 def get_installation_metadata(event, host):

--- a/src/sentry/integrations/github_enterprise/webhook.py
+++ b/src/sentry/integrations/github_enterprise/webhook.py
@@ -47,7 +47,7 @@ INVALID_SIGNATURE_ERROR = "Provided signature does not match the computed body s
 MALFORMED_SIGNATURE_ERROR = "Signature value does not match the expected format"
 UNSUPPORTED_SIGNATURE_ALGORITHM_ERROR = "Signature algorithm is unsupported"
 MISSING_WEBHOOK_PAYLOAD_ERROR = "Webhook payload not found"
-MISSING_GITHUB_ENTERPRISE_HOST_ERROR = "Missing X-GitHub-Enterprise-Host header"
+MISSING_GITHUB_ENTERPRISE_HOST_ERROR = "Missing X-GitHub-Enterprise-Host header (GitHub Enterprise Server) or X-Github-Tenant header (GitHub Enterprise Cloud)"
 MISSING_GITHUB_EVENT_HEADER_ERROR = "Missing X-GitHub-Event header"
 MISSING_SIGNATURE_HEADERS_ERROR = "Missing headers X-Hub-Signature-256 or X-Hub-Signature"
 

--- a/src/sentry/scm/private/helpers.py
+++ b/src/sentry/scm/private/helpers.py
@@ -39,6 +39,20 @@ def fetch_service_provider(
             repository,
             rate_limit_provider=rate_limit_provider or RedisRateLimitProvider(),
         )
+    elif integration.provider == "github_enterprise":
+        domain_name = integration.metadata.get("domain_name")
+        if not domain_name:
+            return None
+        domain = domain_name.split("/")[0]
+        return GitHubProvider(
+            client,
+            organization_id,
+            repository,
+            rate_limit_provider=rate_limit_provider or RedisRateLimitProvider(),
+            web_base_url=f"https://{domain}",
+            provider_name="github_enterprise",
+            referrer_allocation={},
+        )
     elif integration.provider == "gitlab":
         return GitLabProvider(client, organization_id, repository)
     else:

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -47,7 +47,10 @@ from sentry.constants import ObjectStatus
 from sentry.exceptions import InvalidSearchQuery
 from sentry.hybridcloud.rpc.service import RpcAuthenticationSetupException, RpcResolutionException
 from sentry.hybridcloud.rpc.sig import SerializableFunctionValueException
-from sentry.integrations.github_enterprise.integration import GitHubEnterpriseIntegration
+from sentry.integrations.github_enterprise.integration import (
+    GitHubEnterpriseIntegration,
+    _api_base_url,
+)
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organization import Organization, OrganizationStatus
@@ -520,7 +523,7 @@ def get_github_enterprise_integration_config(
 
     return {
         "success": True,
-        "base_url": f"https://{installation.model.metadata['domain_name'].split('/')[0]}/api/v3",
+        "base_url": _api_base_url(installation.model.metadata["domain_name"].split("/")[0]),
         "verify_ssl": installation.model.metadata["installation"]["verify_ssl"],
         "encrypted_access_token": encrypted_access_token,
         "permissions": permissions,

--- a/tests/sentry/integrations/github_enterprise/test_client.py
+++ b/tests/sentry/integrations/github_enterprise/test_client.py
@@ -5,6 +5,7 @@ import pytest
 import responses
 from django.utils import timezone
 
+from sentry.integrations.github_enterprise.client import GitHubEnterpriseApiClient
 from sentry.integrations.github_enterprise.integration import GitHubEnterpriseIntegration
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError
@@ -15,6 +16,49 @@ GITHUB_CODEOWNERS = {
     "html_url": "https://github.example.org/Test-Organization/foo/blob/master/CODEOWNERS",
     "raw": "docs/*    @jianyuan   @getsentry/ecosystem\n* @jianyuan\n",
 }
+
+
+class GitHubEnterpriseCloudApiClientTest(TestCase):
+    """Tests for GHE.com (GitHub Enterprise Cloud with data residency) URL construction."""
+
+    def _make_client(self, base_url: str) -> GitHubEnterpriseApiClient:
+        integration = mock.MagicMock()
+        integration.metadata = {"installation_id": "123"}
+        return GitHubEnterpriseApiClient(
+            base_url=base_url,
+            integration=integration,
+            app_id="1",
+            private_key="key",
+            verify_ssl=True,
+            org_integration_id=1,
+        )
+
+    def test_ghe_cloud_base_url(self) -> None:
+        client = self._make_client("acme-corp.ghe.com")
+        assert client.base_url == "https://api.acme-corp.ghe.com"
+
+    def test_ghes_base_url_unchanged(self) -> None:
+        client = self._make_client("github.example.org")
+        assert client.base_url == "https://github.example.org"
+
+    def test_ghe_cloud_build_url_no_api_v3_prefix(self) -> None:
+        client = self._make_client("acme-corp.ghe.com")
+        assert client.build_url("/repos/org/repo") == "https://api.acme-corp.ghe.com/repos/org/repo"
+
+    def test_ghe_cloud_build_url_graphql(self) -> None:
+        client = self._make_client("acme-corp.ghe.com")
+        assert client.build_url("/graphql") == "https://api.acme-corp.ghe.com/graphql"
+
+    def test_ghes_build_url_adds_api_v3_prefix(self) -> None:
+        client = self._make_client("github.example.org")
+        assert (
+            client.build_url("/repos/org/repo")
+            == "https://github.example.org/api/v3/repos/org/repo"
+        )
+
+    def test_ghes_build_url_graphql(self) -> None:
+        client = self._make_client("github.example.org")
+        assert client.build_url("/graphql") == "https://github.example.org/api/graphql"
 
 
 class GitHubEnterpriseApiClientTest(TestCase):

--- a/tests/sentry/integrations/github_enterprise/test_integration.py
+++ b/tests/sentry/integrations/github_enterprise/test_integration.py
@@ -12,6 +12,8 @@ from sentry.integrations.github_enterprise.client import GitHubEnterpriseApiClie
 from sentry.integrations.github_enterprise.integration import (
     GitHubEnterpriseIntegration,
     GitHubEnterpriseIntegrationProvider,
+    _api_base_url,
+    get_user_info,
 )
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
@@ -22,11 +24,45 @@ from sentry.integrations.source_code_management.commit_context import (
 )
 from sentry.models.repository import Repository
 from sentry.silo.base import SiloMode
-from sentry.testutils.cases import IntegrationTestCase
+from sentry.testutils.cases import IntegrationTestCase, TestCase
 from sentry.testutils.helpers import with_feature
 from sentry.testutils.helpers.integrations import get_installation_of_type
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.users.models.identity import Identity, IdentityProvider, IdentityStatus
+
+
+class ApiBaseUrlTest(TestCase):
+    def test_ghes_url(self) -> None:
+        assert _api_base_url("github.example.org") == "https://github.example.org/api/v3"
+
+    def test_ghe_cloud_url(self) -> None:
+        assert _api_base_url("acme-corp.ghe.com") == "https://api.acme-corp.ghe.com"
+
+    @responses.activate
+    def test_get_user_info_ghe_cloud_calls_api_subdomain(self) -> None:
+        responses.add(
+            method=responses.GET,
+            url="https://api.acme-corp.ghe.com/user",
+            json={"login": "testuser", "id": 1},
+            status=200,
+        )
+        result = get_user_info("acme-corp.ghe.com", "mytoken")
+        assert result == {"login": "testuser", "id": 1}
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.url == "https://api.acme-corp.ghe.com/user"
+
+    @responses.activate
+    def test_get_user_info_ghes_calls_api_v3(self) -> None:
+        responses.add(
+            method=responses.GET,
+            url="https://github.example.org/api/v3/user",
+            json={"login": "testuser", "id": 1},
+            status=200,
+        )
+        result = get_user_info("github.example.org", "mytoken")
+        assert result == {"login": "testuser", "id": 1}
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.url == "https://github.example.org/api/v3/user"
 
 
 @control_silo_test

--- a/tests/sentry/integrations/github_enterprise/test_webhooks.py
+++ b/tests/sentry/integrations/github_enterprise/test_webhooks.py
@@ -3,6 +3,8 @@ from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import responses
+from django.http import HttpRequest
+from django.test import RequestFactory
 
 from fixtures.github_enterprise import (
     ISSUES_ASSIGNED_EVENT_EXAMPLE,
@@ -16,6 +18,7 @@ from fixtures.github_enterprise import (
 )
 from sentry.integrations.github_enterprise.webhook import (
     GitHubEnterpriseInstallationRepositoriesEventWebhook,
+    get_host,
 )
 from sentry.integrations.services.integration import integration_service
 from sentry.models.commit import Commit
@@ -23,7 +26,7 @@ from sentry.models.commitauthor import CommitAuthor
 from sentry.models.pullrequest import PullRequest
 from sentry.models.repository import Repository
 from sentry.testutils.asserts import assert_failure_metric, assert_success_metric
-from sentry.testutils.cases import APITestCase
+from sentry.testutils.cases import APITestCase, TestCase
 from sentry.testutils.helpers import override_options
 
 
@@ -951,3 +954,30 @@ class IssuesEventWebhookTest(APITestCase):
             mock_sync.assert_called_once()
 
         assert_success_metric(mock_record)
+
+
+class GetHostTest(TestCase):
+    def _make_request(self, headers: dict[str, str]) -> HttpRequest:
+        factory = RequestFactory()
+        request = factory.post("/", content_type="application/json")
+        for key, value in headers.items():
+            request.META[f"HTTP_{key.upper().replace('-', '_')}"] = value
+        return request
+
+    def test_returns_enterprise_host_header(self) -> None:
+        request = self._make_request({"x-github-enterprise-host": "github.example.org"})
+        assert get_host(request) == "github.example.org"
+
+    def test_returns_ghe_cloud_host_from_tenant_header(self) -> None:
+        request = self._make_request({"x-github-tenant": "acme-corp"})
+        assert get_host(request) == "acme-corp.ghe.com"
+
+    def test_enterprise_host_takes_precedence_over_tenant(self) -> None:
+        request = self._make_request(
+            {"x-github-enterprise-host": "github.example.org", "x-github-tenant": "acme-corp"}
+        )
+        assert get_host(request) == "github.example.org"
+
+    def test_returns_none_when_no_host_headers(self) -> None:
+        request = self._make_request({})
+        assert get_host(request) is None

--- a/tests/sentry/scm/integration/test_helpers_integration.py
+++ b/tests/sentry/scm/integration/test_helpers_integration.py
@@ -84,6 +84,37 @@ class TestFetchServiceProvider(TestCase):
 
         assert isinstance(provider, GitHubProvider)
 
+    def test_returns_github_provider_for_github_enterprise(self) -> None:
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="github_enterprise",
+            name="GHE Test Org",
+            external_id="ghe.example.com:1",
+            metadata={
+                "domain_name": "ghe.example.com/test-org",
+                "installation_id": 1,
+                "installation": {
+                    "id": 1,
+                    "private_key": "key",
+                    "webhook_secret": "secret",
+                    "verify_ssl": True,
+                },
+            },
+        )
+
+        repository: Repository = {
+            "id": 1,
+            "integration_id": integration.id,
+            "name": "test-org/test-repo",
+            "organization_id": self.organization.id,
+            "is_active": True,
+            "external_id": None,
+            "provider_name": "github_enterprise",
+        }
+        provider = fetch_service_provider(self.organization.id, repository)
+
+        assert isinstance(provider, GitHubProvider)
+
     def test_returns_none_for_nonexistent_integration(self) -> None:
         repository: Repository = {
             "id": 1,


### PR DESCRIPTION
Adds GitHub Enterprise support to the SCM platform's `fetch_service_provider`.

Previously, `fetch_service_provider` handled `"github"` and `"gitlab"` integrations but had no branch for `"github_enterprise"` — GHE-backed repositories fell through to `return None`, making `SourceCodeManager` entirely non-functional for GHE.

The new branch reads `domain_name` from the integration metadata (the same field the GHE client already uses) and passes it as `web_base_url` to `GitHubProvider`. It also sets `provider_name="github_enterprise"` so rate-limit quota is tracked independently from GitHub Cloud, and `referrer_allocation={}` since GitHub Cloud-specific referrer policies (e.g. `emerge`) don't apply to GHE instances.

The SCM platform's event pipeline already handles GHE: `ipc.py` routes `"github_enterprise"` events through the same GitHub deserializer (the webhook payload format is identical), and the GHE webhook handler already produces events to the stream. This change fills the remaining gap on the actions side.

Depends on https://github.com/getsentry/scm-platform/pull/30, which adds `web_base_url`, `provider_name`, and `referrer_allocation` parameters to `GitHubProvider`.