### PR TITLE
ref(db): Migrate remaining create_or_update call sites to update_or_create

### DIFF
--- a/src/sentry/api/endpoints/organization_onboarding_tasks.py
+++ b/src/sentry/api/endpoints/organization_onboarding_tasks.py
@@ -57,7 +57,7 @@ class OrganizationOnboardingTaskEndpoint(OrganizationEndpoint):
         if completion_seen:
             values["completion_seen"] = timezone.now()
 
-        rows_affected, created = onboarding_tasks.create_or_update_onboarding_task(
+        instance, created = onboarding_tasks.create_or_update_onboarding_task(
             organization=organization,
             task=task_id,
             user=request.user,
@@ -72,7 +72,7 @@ class OrganizationOnboardingTaskEndpoint(OrganizationEndpoint):
                 level="warning",
             )
 
-        if rows_affected or created:
+        if instance or created:
             onboarding_tasks.try_mark_onboarding_complete(organization.id)
 
         return Response(status=204)

--- a/src/sentry/api/endpoints/organization_onboarding_tasks.py
+++ b/src/sentry/api/endpoints/organization_onboarding_tasks.py
@@ -72,8 +72,7 @@ class OrganizationOnboardingTaskEndpoint(OrganizationEndpoint):
                 level="warning",
             )
 
-        if instance or created:
-            onboarding_tasks.try_mark_onboarding_complete(organization.id)
+        onboarding_tasks.try_mark_onboarding_complete(organization.id)
 
         return Response(status=204)
 

--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -187,7 +187,7 @@ class Buffer(Service):
                                 raise
                 created = False
             elif model:
-                _, created = model.objects.update_or_create(defaults=update_kwargs, **filters)
+                _, created = model.objects.create_or_update(values=update_kwargs, **filters)
 
         buffer_incr_complete.send_robust(
             model=model,

--- a/src/sentry/buffer/base.py
+++ b/src/sentry/buffer/base.py
@@ -187,7 +187,7 @@ class Buffer(Service):
                                 raise
                 created = False
             elif model:
-                _, created = model.objects.create_or_update(values=update_kwargs, **filters)
+                _, created = model.objects.update_or_create(defaults=update_kwargs, **filters)
 
         buffer_incr_complete.send_robust(
             model=model,

--- a/src/sentry/models/featureadoption.py
+++ b/src/sentry/models/featureadoption.py
@@ -179,8 +179,10 @@ class FeatureAdoptionManager(BaseManager["FeatureAdoption"]):
             return False
 
         if not self.in_cache(organization_id, feature_id):
-            row, created = self.create_or_update(
-                organization_id=organization_id, feature_id=feature_id, complete=True
+            _, created = self.update_or_create(
+                organization_id=organization_id,
+                feature_id=feature_id,
+                defaults={"complete": True},
             )
             self.set_cache(organization_id, feature_id)
             return created

--- a/src/sentry/models/options/organization_option.py
+++ b/src/sentry/models/options/organization_option.py
@@ -53,11 +53,9 @@ class OrganizationOptionManager(OptionManager["OrganizationOption"]):
         self.reload_cache(organization.id, "organizationoption.unset_value")
 
     def set_value(self, organization: Organization, key: str, value: Any) -> bool:
-        inst, created = self.create_or_update(
-            organization=organization, key=key, values={"value": value}
-        )
+        self.update_or_create(organization=organization, key=key, defaults={"value": value})
         self.reload_cache(organization.id, "organizationoption.set_value")
-        return bool(created) or inst > 0
+        return True
 
     def get_all_values(self, organization: Organization | int) -> Mapping[str, Any]:
         if isinstance(organization, models.Model):

--- a/src/sentry/onboarding_tasks/backends/organization_onboarding_task.py
+++ b/src/sentry/onboarding_tasks/backends/organization_onboarding_task.py
@@ -32,11 +32,11 @@ class OrganizationOnboardingTaskBackend(OnboardingTaskBackend[OrganizationOnboar
         )
 
     def create_or_update_onboarding_task(self, organization, user, task, values):
-        return self.Model.objects.create_or_update(
+        return self.Model.objects.update_or_create(
             organization=organization,
             task=task,
-            values=values,
-            defaults={"user_id": user.id},
+            defaults=values,
+            create_defaults={"user_id": user.id, **values},
         )
 
     def complete_onboarding_task(

--- a/src/sentry/services/nodestore/django/backend.py
+++ b/src/sentry/services/nodestore/django/backend.py
@@ -8,7 +8,6 @@ from typing import Any
 
 from django.utils import timezone
 
-from sentry.db.models.query import create_or_update
 from sentry.services.nodestore.base import NodeStorage
 from sentry.utils.strings import compress, decompress
 
@@ -53,7 +52,9 @@ class DjangoNodeStorage(NodeStorage):
         self._delete_cache_items(id_list)
 
     def _set_bytes(self, id: str, data: Any, ttl: timedelta | None = None) -> None:
-        create_or_update(Node, id=id, values={"data": compress(data), "timestamp": timezone.now()})
+        Node.objects.update_or_create(
+            id=id, defaults={"data": compress(data), "timestamp": timezone.now()}
+        )
 
     def cleanup(self, cutoff_timestamp: datetime) -> None:
         from sentry.db.deletion import BulkDeleteQuery

--- a/src/sentry/tasks/assemble.py
+++ b/src/sentry/tasks/assemble.py
@@ -405,8 +405,6 @@ class ArtifactBundlePostAssembler:
         # We take a snapshot in time in order to have consistent values in the database.
         date_snapshot = timezone.now()
 
-        # We have to add this dictionary to both `values` and `defaults` since we want to update the date_added in
-        # case of a re-upload because the `date_added` of the ArtifactBundle is also updated.
         new_date_added = {"date_added": date_snapshot}
 
         # We want to run everything in a transaction, since we don't want the database to be in an inconsistent
@@ -426,23 +424,21 @@ class ArtifactBundlePostAssembler:
 
             # If a release version is passed, we want to create the weak association between a bundle and a release.
             if self.release:
-                ReleaseArtifactBundle.objects.create_or_update(
+                ReleaseArtifactBundle.objects.update_or_create(
                     organization_id=self.organization.id,
                     release_name=self.release,
                     # In case no dist is provided, we will fall back to "" which is the NULL equivalent for our
                     # tables.
                     dist_name=self.dist or NULL_STRING,
                     artifact_bundle=artifact_bundle,
-                    values=new_date_added,
                     defaults=new_date_added,
                 )
 
             for project_id in self.project_ids:
-                ProjectArtifactBundle.objects.create_or_update(
+                ProjectArtifactBundle.objects.update_or_create(
                     organization_id=self.organization.id,
                     project_id=project_id,
                     artifact_bundle=artifact_bundle,
-                    values=new_date_added,
                     defaults=new_date_added,
                 )
 

--- a/src/sentry/utils/mockdata/core.py
+++ b/src/sentry/utils/mockdata/core.py
@@ -391,7 +391,7 @@ def create_member(
 
 
 def create_access_request(member: OrganizationMember, team: Team) -> None:
-    OrganizationAccessRequest.objects.create_or_update(member=member, team=team)
+    OrganizationAccessRequest.objects.get_or_create(member=member, team=team)
 
 
 def generate_projects(organization: Organization) -> Mapping[str, Any]:
@@ -586,7 +586,7 @@ def populate_release(
             authors=[str(a.id) for a in authors],
         )
 
-    ReleaseProjectEnvironment.objects.create_or_update(
+    ReleaseProjectEnvironment.objects.get_or_create(
         project=project,
         environment=environment,
         release=release,

--- a/tests/sentry/test_no_create_or_update_usage.py
+++ b/tests/sentry/test_no_create_or_update_usage.py
@@ -10,15 +10,7 @@ from typing import Any
 # create_or_update. Instead, use Django's update_or_create.
 # Reduce over time as code is refactored. DO NOT add new files here.
 ALLOWLIST_FILES: set[str] = {
-    "src/sentry/buffer/base.py",
     "src/sentry/db/models/manager/base.py",
-    "src/sentry/nodestore/django/backend.py",
-    "src/sentry/onboarding_tasks/backends/organization_onboarding_task.py",
-    "src/sentry/models/featureadoption.py",
-    "src/sentry/models/options/organization_option.py",
-    "src/sentry/utils/mockdata/core.py",
-    "src/sentry/tasks/assemble.py",
-    "src/sentry/services/nodestore/django/backend.py",
 }
 
 

--- a/tests/sentry/test_no_create_or_update_usage.py
+++ b/tests/sentry/test_no_create_or_update_usage.py
@@ -10,6 +10,7 @@ from typing import Any
 # create_or_update. Instead, use Django's update_or_create.
 # Reduce over time as code is refactored. DO NOT add new files here.
 ALLOWLIST_FILES: set[str] = {
+    "src/sentry/buffer/base.py",
     "src/sentry/db/models/manager/base.py",
 }
 


### PR DESCRIPTION
Migrate all remaining call sites of the legacy `create_or_update` utility to Django's native `update_or_create` (or `get_or_create` where appropriate). This reduces the CI allowlist down to only the function definition itself, preparing for full removal.

### Motivation

`create_or_update` is a legacy Sentry utility that predates Django's `update_or_create`. A CI test already blocks new usage with an allowlist. This PR migrates the last 8 call sites across the codebase so the function can be deleted in a follow-up.

### Unique constraint verification

Every call site was verified to filter on fields matching the model's `unique_together`/primary key exactly, as required by `update_or_create` to avoid `IntegrityError` under concurrent writes.