### PR TITLE
style(snapshots): Add keyboard nav hints and visual feedback

### DIFF
--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -10,7 +10,7 @@ import {ContentSliderDiff} from 'sentry/components/contentSliderDiff';
 import {t} from 'sentry/locale';
 import type {SnapshotDiffPair} from 'sentry/views/preprod/types/snapshotTypes';
 
-import {useBufferedImageUrl} from './useBufferedImageUrl';
+import {useBufferedImageGroup} from './useBufferedImageUrl';
 import {useSyncedD3Zoom} from './useD3Zoom';
 import {
   ZoomableArea,
@@ -21,6 +21,20 @@ import {
 } from './zoomControls';
 
 export type DiffMode = 'split' | 'wipe' | 'onion';
+
+function computeMaskSize(
+  baseImage: SnapshotDiffPair['base_image'],
+  headImage: SnapshotDiffPair['head_image']
+): string {
+  const headW = headImage.width;
+  const headH = headImage.height;
+  if (!headW || !headH) {
+    return '100% 100%';
+  }
+  const maskW = Math.max(baseImage.width || headW, headW);
+  const maskH = Math.max(baseImage.height || headH, headH);
+  return `${(maskW / headW) * 100}% ${(maskH / headH) * 100}%`;
+}
 
 export const TRANSPARENT_COLOR = 'transparent';
 
@@ -47,6 +61,8 @@ export function DiffImageDisplay({
     ? `${diffImageBaseUrl}${pair.diff_image_key}/`
     : null;
 
+  const maskSize = computeMaskSize(pair.base_image, pair.head_image);
+
   return (
     <Flex direction="column" gap="lg" padding="xl" flex="1" minHeight="0">
       <HiddenWhenInactive active={diffMode === 'split'}>
@@ -55,6 +71,7 @@ export function DiffImageDisplay({
           headImageUrl={headImageUrl}
           overlayColor={overlayColor}
           diffMaskUrl={diffMaskUrl}
+          maskSize={maskSize}
         />
       </HiddenWhenInactive>
 
@@ -78,6 +95,7 @@ interface SplitViewProps {
   baseImageUrl: string;
   diffMaskUrl: string | null;
   headImageUrl: string;
+  maskSize: string;
   overlayColor: string;
 }
 
@@ -86,11 +104,15 @@ function SplitView({
   headImageUrl,
   overlayColor,
   diffMaskUrl,
+  maskSize,
 }: SplitViewProps) {
   const [zoom1, zoom2] = useSyncedD3Zoom();
-  const showOverlay = diffMaskUrl && overlayColor !== TRANSPARENT_COLOR;
-  const displayBaseUrl = useBufferedImageUrl(baseImageUrl);
-  const displayHeadUrl = useBufferedImageUrl(headImageUrl);
+  const [displayBaseUrl, displayHeadUrl, displayMaskUrl] = useBufferedImageGroup([
+    baseImageUrl,
+    headImageUrl,
+    diffMaskUrl,
+  ]);
+  const showOverlay = displayMaskUrl && overlayColor !== TRANSPARENT_COLOR;
   return (
     <Grid columns="repeat(2, 1fr)" gap="xl" flex="1" minHeight="0">
       <Flex direction="column" gap="sm" minHeight="0">
@@ -104,12 +126,14 @@ function SplitView({
               height="100%"
               style={zoomTransformStyle(zoom1.transform)}
             >
-              <ZoomableImage
-                src={displayBaseUrl}
-                alt={t('Base')}
-                loading="eager"
-                decoding="async"
-              />
+              {displayBaseUrl && (
+                <ZoomableImage
+                  src={displayBaseUrl}
+                  alt={t('Base')}
+                  loading="eager"
+                  decoding="async"
+                />
+              )}
             </Flex>
           </ZoomContainer>
         </ZoomableArea>
@@ -126,17 +150,23 @@ function SplitView({
               height="100%"
               style={zoomTransformStyle(zoom2.transform)}
             >
-              <ImageWrapper>
-                <ZoomableImage
-                  src={displayHeadUrl}
-                  alt={t('Current Branch')}
-                  loading="eager"
-                  decoding="async"
-                />
-                {showOverlay && (
-                  <DiffOverlay $overlayColor={overlayColor} $maskUrl={diffMaskUrl} />
-                )}
-              </ImageWrapper>
+              {displayHeadUrl && (
+                <ImageWrapper>
+                  <ZoomableImage
+                    src={displayHeadUrl}
+                    alt={t('Current Branch')}
+                    loading="eager"
+                    decoding="async"
+                  />
+                  {showOverlay && displayMaskUrl && (
+                    <DiffOverlay
+                      $overlayColor={overlayColor}
+                      $maskUrl={displayMaskUrl}
+                      $maskSize={maskSize}
+                    />
+                  )}
+                </ImageWrapper>
+              )}
             </Flex>
           </ZoomContainer>
           <ZoomControls
@@ -157,33 +187,37 @@ function WipeView({
   baseImageUrl: string;
   headImageUrl: string;
 }) {
-  const displayBaseUrl = useBufferedImageUrl(baseImageUrl);
-  const displayHeadUrl = useBufferedImageUrl(headImageUrl);
+  const [displayBaseUrl, displayHeadUrl] = useBufferedImageGroup([
+    baseImageUrl,
+    headImageUrl,
+  ]);
   return (
     <Flex flex="1" minHeight="0">
-      <ContentSliderDiff.Body
-        before={
-          <Flex justify="center" align="center" height="100%">
-            <ConstrainedImage
-              src={displayBaseUrl}
-              alt={t('Base')}
-              loading="eager"
-              decoding="async"
-            />
-          </Flex>
-        }
-        after={
-          <Flex justify="center" align="center" height="100%">
-            <ConstrainedImage
-              src={displayHeadUrl}
-              alt={t('Current Branch')}
-              loading="eager"
-              decoding="async"
-            />
-          </Flex>
-        }
-        minHeight="200px"
-      />
+      {displayBaseUrl && displayHeadUrl && (
+        <ContentSliderDiff.Body
+          before={
+            <Flex justify="center" align="center" height="100%">
+              <ConstrainedImage
+                src={displayBaseUrl}
+                alt={t('Base')}
+                loading="eager"
+                decoding="async"
+              />
+            </Flex>
+          }
+          after={
+            <Flex justify="center" align="center" height="100%">
+              <ConstrainedImage
+                src={displayHeadUrl}
+                alt={t('Current Branch')}
+                loading="eager"
+                decoding="async"
+              />
+            </Flex>
+          }
+          minHeight="200px"
+        />
+      )}
     </Flex>
   );
 }
@@ -199,8 +233,10 @@ function OnionView({
   onOpacityChange: (value: number) => void;
   opacity: number;
 }) {
-  const displayBaseUrl = useBufferedImageUrl(baseImageUrl);
-  const displayHeadUrl = useBufferedImageUrl(headImageUrl);
+  const [displayBaseUrl, displayHeadUrl] = useBufferedImageGroup([
+    baseImageUrl,
+    headImageUrl,
+  ]);
   return (
     <Flex
       direction="column"
@@ -210,30 +246,32 @@ function OnionView({
       align="center"
       justify="center"
     >
-      <Flex
-        justify="center"
-        border="primary"
-        radius="md"
-        overflow="hidden"
-        background="secondary"
-      >
-        <OnionContainer>
-          <ConstrainedImage
-            src={displayBaseUrl}
-            alt={t('Base')}
-            loading="eager"
-            decoding="async"
-          />
-          <OnionOverlayLayer style={{opacity: opacity / 100}}>
+      {displayBaseUrl && displayHeadUrl && (
+        <Flex
+          justify="center"
+          border="primary"
+          radius="md"
+          overflow="hidden"
+          background="secondary"
+        >
+          <OnionContainer>
             <ConstrainedImage
-              src={displayHeadUrl}
-              alt={t('Current Branch')}
+              src={displayBaseUrl}
+              alt={t('Base')}
               loading="eager"
               decoding="async"
             />
-          </OnionOverlayLayer>
-        </OnionContainer>
-      </Flex>
+            <OnionOverlayLayer style={{opacity: opacity / 100}}>
+              <ConstrainedImage
+                src={displayHeadUrl}
+                alt={t('Current Branch')}
+                loading="eager"
+                decoding="async"
+              />
+            </OnionOverlayLayer>
+          </OnionContainer>
+        </Flex>
+      )}
       <Flex align="center" gap="lg">
         <Text size="sm" variant="muted">
           {t('Base')}
@@ -266,7 +304,11 @@ const ImageWrapper = styled('div')`
   max-width: 100%;
 `;
 
-const DiffOverlay = styled('span')<{$maskUrl: string; $overlayColor: string}>`
+const DiffOverlay = styled('span')<{
+  $maskSize: string;
+  $maskUrl: string;
+  $overlayColor: string;
+}>`
   position: absolute;
   top: 0;
   left: 0;
@@ -275,10 +317,12 @@ const DiffOverlay = styled('span')<{$maskUrl: string; $overlayColor: string}>`
   pointer-events: none;
   background-color: ${p => p.$overlayColor};
   mask-image: url(${p => p.$maskUrl});
-  mask-size: 100% 100%;
+  mask-size: ${p => p.$maskSize};
+  mask-position: top left;
   mask-mode: luminance;
   -webkit-mask-image: url(${p => p.$maskUrl});
-  -webkit-mask-size: 100% 100%;
+  -webkit-mask-size: ${p => p.$maskSize};
+  -webkit-mask-position: top left;
 `;
 
 const OnionContainer = styled('div')`

--- a/static/app/views/preprod/snapshots/main/imageDisplay/singleImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/singleImageDisplay.tsx
@@ -30,7 +30,14 @@ export function SingleImageDisplay({imageUrl, alt}: SingleImageDisplayProps) {
             height="100%"
             style={zoomTransformStyle(transform)}
           >
-            <ZoomableImage src={displayUrl} alt={alt} loading="eager" decoding="async" />
+            {displayUrl && (
+              <ZoomableImage
+                src={displayUrl}
+                alt={alt}
+                loading="eager"
+                decoding="async"
+              />
+            )}
           </Flex>
         </ZoomContainer>
         <ZoomControls onZoomIn={zoomIn} onZoomOut={zoomOut} onReset={resetZoom} />

--- a/static/app/views/preprod/snapshots/main/imageDisplay/useBufferedImageUrl.ts
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/useBufferedImageUrl.ts
@@ -1,8 +1,8 @@
 import {useEffect, useRef, useState} from 'react';
 
-export function useBufferedImageUrl(targetUrl: string): string {
-  const [displayUrl, setDisplayUrl] = useState(targetUrl);
-  const activeUrlRef = useRef(targetUrl);
+export function useBufferedImageUrl(targetUrl: string): string | null {
+  const [displayUrl, setDisplayUrl] = useState<string | null>(null);
+  const activeUrlRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (targetUrl === activeUrlRef.current) {
@@ -24,9 +24,52 @@ export function useBufferedImageUrl(targetUrl: string): string {
 
     return () => {
       cancelled = true;
-      img.src = '';
     };
   }, [targetUrl]);
 
   return displayUrl;
+}
+
+export function useBufferedImageGroup(
+  targetUrls: ReadonlyArray<string | null>
+): Array<string | null> {
+  const serialized = targetUrls.join('\0');
+  const targetUrlsRef = useRef(targetUrls);
+  targetUrlsRef.current = targetUrls;
+
+  const [displayUrls, setDisplayUrls] = useState<Array<string | null>>(() =>
+    targetUrls.map(() => null)
+  );
+  const activeKeyRef = useRef('');
+
+  useEffect(() => {
+    if (serialized === activeKeyRef.current) {
+      return undefined;
+    }
+
+    const urls = targetUrlsRef.current;
+    let cancelled = false;
+
+    const promises = urls.map(url => {
+      if (!url) {
+        return Promise.resolve();
+      }
+      const img = new Image();
+      img.src = url;
+      return img.decode().catch(() => undefined);
+    });
+
+    Promise.all(promises).then(() => {
+      if (!cancelled) {
+        activeKeyRef.current = serialized;
+        setDisplayUrls([...urls]);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [serialized]);
+
+  return displayUrls;
 }

--- a/static/app/views/preprod/snapshots/main/snapshotDiffBodies.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotDiffBodies.tsx
@@ -1,4 +1,4 @@
-import {memo, useCallback, useState} from 'react';
+import {memo, type ReactNode, useCallback, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
@@ -15,6 +15,17 @@ import {useSyncedD3Zoom} from './imageDisplay/useD3Zoom';
 import {ZoomControls, zoomTransformStyle} from './imageDisplay/zoomControls';
 
 export const MAX_IMAGE_HEIGHT = 480;
+
+function computeMaskSize(baseImage: SnapshotImage, headImage: SnapshotImage): string {
+  const headW = headImage.width;
+  const headH = headImage.height;
+  if (!headW || !headH) {
+    return '100% 100%';
+  }
+  const maskW = Math.max(baseImage.width || headW, headW);
+  const maskH = Math.max(baseImage.height || headH, headH);
+  return `${(maskW / headW) * 100}% ${(maskH / headH) * 100}%`;
+}
 
 export const SplitPairBody = memo(function SplitPairBody({
   baseUrl,
@@ -71,17 +82,20 @@ export const SplitPairBody = memo(function SplitPairBody({
           </Container>
           <ZoomViewport ref={zoom2.containerRef}>
             <ZoomTransformLayer style={zoomTransformStyle(zoom2.transform)}>
-              <Container position="relative" display="inline-block" maxWidth="100%">
-                <LazyImage
-                  src={headUrl}
-                  alt={`${altPrefix} (head)`}
-                  width={headImage.width || undefined}
-                  height={headImage.height || undefined}
-                />
+              <LazyImage
+                src={headUrl}
+                alt={`${altPrefix} (head)`}
+                width={headImage.width || undefined}
+                height={headImage.height || undefined}
+              >
                 {diffMaskUrl && (
-                  <DiffOverlay $overlayColor={overlayColor!} $maskUrl={diffMaskUrl} />
+                  <DiffOverlay
+                    $overlayColor={overlayColor!}
+                    $maskUrl={diffMaskUrl}
+                    $maskSize={computeMaskSize(baseImage, headImage)}
+                  />
                 )}
-              </Container>
+              </LazyImage>
             </ZoomTransformLayer>
           </ZoomViewport>
         </Stack>
@@ -127,17 +141,20 @@ export const ImageColumn = memo(function ImageColumn({
         </Container>
       )}
       <Flex justify="center" padding="xl">
-        <Container position="relative" display="inline-block" maxWidth="100%">
-          <LazyImage
-            src={src}
-            alt={alt}
-            width={image.width || undefined}
-            height={image.height || undefined}
-          />
+        <LazyImage
+          src={src}
+          alt={alt}
+          width={image.width || undefined}
+          height={image.height || undefined}
+        >
           {diffMaskUrl && (
-            <DiffOverlay $overlayColor={overlayColor!} $maskUrl={diffMaskUrl} />
+            <DiffOverlay
+              $overlayColor={overlayColor!}
+              $maskUrl={diffMaskUrl}
+              $maskSize="100% 100%"
+            />
           )}
-        </Container>
+        </LazyImage>
       </Flex>
     </Stack>
   );
@@ -269,14 +286,22 @@ function LazyImage({
   alt,
   width,
   height,
+  children,
 }: {
   alt: string;
   src: string;
+  children?: ReactNode;
   height?: number;
   width?: number;
 }) {
   const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    setLoaded(false);
+  }, [src]);
+
   const onLoad = useCallback(() => setLoaded(true), []);
+  const onError = useCallback(() => setLoaded(true), []);
   const refCallback = useCallback((el: HTMLImageElement | null) => {
     if (el?.complete && el.naturalWidth > 0) {
       setLoaded(true);
@@ -300,8 +325,10 @@ function LazyImage({
         width={width || undefined}
         height={height || undefined}
         onLoad={onLoad}
+        onError={onError}
         style={loaded ? undefined : {position: 'absolute', top: 0, left: 0, opacity: 0}}
       />
+      {children}
     </Container>
   );
 }
@@ -314,7 +341,11 @@ const HiddenUntilLoaded = styled('img')`
   max-height: ${MAX_IMAGE_HEIGHT}px;
 `;
 
-const DiffOverlay = styled('span')<{$maskUrl: string; $overlayColor: string}>`
+const DiffOverlay = styled('span')<{
+  $maskSize: string;
+  $maskUrl: string;
+  $overlayColor: string;
+}>`
   position: absolute;
   top: 0;
   left: 0;
@@ -323,10 +354,12 @@ const DiffOverlay = styled('span')<{$maskUrl: string; $overlayColor: string}>`
   pointer-events: none;
   background-color: ${p => p.$overlayColor};
   mask-image: url(${p => p.$maskUrl});
-  mask-size: 100% 100%;
+  mask-size: ${p => p.$maskSize};
+  mask-position: top left;
   mask-mode: luminance;
   -webkit-mask-image: url(${p => p.$maskUrl});
-  -webkit-mask-size: 100% 100%;
+  -webkit-mask-size: ${p => p.$maskSize};
+  -webkit-mask-position: top left;
 `;
 
 const ZoomViewport = styled('div')`

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
@@ -28,6 +28,7 @@ function renderSnapshotMainContent(
     imageBaseUrl: '/api/0/projects/org-slug/project-slug/files/images/',
     isSoloView: true,
     listItems: [],
+    navButtonRefs: {next: {current: null}, prev: {current: null}},
     onDiffModeChange: jest.fn(),
     onNavigateSingleView: jest.fn(),
     onOverlayColorChange: jest.fn(),

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -41,6 +41,11 @@ import {
 type ViewMode = 'single' | 'list';
 type SortBy = 'diff' | 'alpha';
 
+export interface NavButtonRefs {
+  next: React.RefObject<HTMLButtonElement | null>;
+  prev: React.RefObject<HTMLButtonElement | null>;
+}
+
 interface SnapshotMainContentProps {
   canNavigateNext: boolean;
   canNavigatePrev: boolean;
@@ -51,6 +56,7 @@ interface SnapshotMainContentProps {
   imageBaseUrl: string;
   isSoloView: boolean;
   listItems: SidebarItem[];
+  navButtonRefs: NavButtonRefs;
   onDiffModeChange: (mode: DiffMode) => void;
   onNavigateSingleView: (direction: 'prev' | 'next') => void;
   onOverlayColorChange: (color: string) => void;
@@ -91,6 +97,7 @@ export function SnapshotMainContent({
   onNavigateSingleView,
   canNavigatePrev,
   canNavigateNext,
+  navButtonRefs,
 }: SnapshotMainContentProps) {
   const [isDark, setIsDark] = useState(false);
   const toggleDark = () => setIsDark(v => !v);
@@ -201,6 +208,7 @@ export function SnapshotMainContent({
         canNavigatePrev={canNavigatePrev}
         canNavigateNext={canNavigateNext}
         onNavigateSingleView={onNavigateSingleView}
+        navButtonRefs={navButtonRefs}
         headerProps={{
           displayName: image.display_name,
           fileName: image.image_file_name,
@@ -247,6 +255,7 @@ export function SnapshotMainContent({
         canNavigatePrev={canNavigatePrev}
         canNavigateNext={canNavigateNext}
         onNavigateSingleView={onNavigateSingleView}
+        navButtonRefs={navButtonRefs}
         headerProps={{
           displayName: image.display_name,
           fileName: image.image_file_name,
@@ -285,6 +294,7 @@ export function SnapshotMainContent({
       canNavigatePrev={canNavigatePrev}
       canNavigateNext={canNavigateNext}
       onNavigateSingleView={onNavigateSingleView}
+      navButtonRefs={navButtonRefs}
       headerProps={{
         displayName: currentImage.display_name,
         fileName: currentImage.image_file_name,
@@ -306,6 +316,7 @@ function SingleViewLayout({
   canNavigatePrev,
   canNavigateNext,
   onNavigateSingleView,
+  navButtonRefs,
   headerProps,
   body,
   rightControls,
@@ -316,6 +327,7 @@ function SingleViewLayout({
   groupName: string | null;
   headerProps: Omit<React.ComponentProps<typeof CardHeader>, 'isDark' | 'onToggleDark'>;
   isDark: boolean;
+  navButtonRefs: NavButtonRefs;
   onNavigateSingleView: (direction: 'prev' | 'next') => void;
   onToggleDark: () => void;
   soloDiffToggle: React.ReactNode;
@@ -366,8 +378,9 @@ function SingleViewLayout({
             </DarkAware>
           </Flex>
           <NavGutter onClick={e => e.stopPropagation()}>
-            <Tooltip title={t('Previous')} skipWrapper>
+            <Tooltip title={t('Previous (↑)')} skipWrapper>
               <Button
+                ref={navButtonRefs.prev}
                 size="sm"
                 icon={<IconArrow direction="up" />}
                 aria-label={t('Previous snapshot')}
@@ -375,8 +388,9 @@ function SingleViewLayout({
                 onClick={() => onNavigateSingleView('prev')}
               />
             </Tooltip>
-            <Tooltip title={t('Next')} skipWrapper>
+            <Tooltip title={t('Next (↓)')} skipWrapper>
               <Button
+                ref={navButtonRefs.next}
                 size="sm"
                 icon={<IconArrow direction="down" />}
                 aria-label={t('Next snapshot')}
@@ -437,13 +451,13 @@ function ViewModeToggle({
         key="list"
         icon={<IconList />}
         aria-label={t('List view')}
-        tooltip={t('List view')}
+        tooltip={t('List view (←)')}
       />
       <SegmentedControl.Item
         key="single"
         icon={<IconExpand />}
         aria-label={t('Single image view')}
-        tooltip={t('Single image view')}
+        tooltip={t('Single image view (→)')}
       />
     </SegmentedControl>
   );
@@ -588,6 +602,15 @@ const NavGutter = styled('div')`
   flex-direction: column;
   gap: ${p => p.theme.space.sm};
   flex-shrink: 0;
+
+  button[aria-pressed='true'] {
+    &::after {
+      transform: translateY(0px);
+    }
+    > span:last-child {
+      transform: translateY(0px);
+    }
+  }
 `;
 
 const SingleViewCard = styled(Card)`

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -278,15 +278,10 @@ const SidebarItemRow = styled('div')<{isSelected: boolean}>`
   cursor: pointer;
   border-right: 3px solid
     ${p => (p.isSelected ? p.theme.tokens.border.accent.vibrant : 'transparent')};
-  border-bottom: 1px solid ${p => p.theme.tokens.border.secondary};
   background: ${p =>
     p.isSelected ? p.theme.tokens.background.transparent.accent.muted : 'transparent'};
 
   &:hover {
     background: ${p => p.theme.tokens.background.secondary};
-  }
-
-  &:last-child {
-    border-bottom: none;
   }
 `;

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -278,10 +278,15 @@ const SidebarItemRow = styled('div')<{isSelected: boolean}>`
   cursor: pointer;
   border-right: 3px solid
     ${p => (p.isSelected ? p.theme.tokens.border.accent.vibrant : 'transparent')};
+  border-bottom: 1px solid ${p => p.theme.tokens.border.secondary};
   background: ${p =>
     p.isSelected ? p.theme.tokens.background.transparent.accent.muted : 'transparent'};
 
   &:hover {
     background: ${p => p.theme.tokens.background.secondary};
+  }
+
+  &:last-child {
+    border-bottom: none;
   }
 `;

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -471,6 +471,7 @@ export default function SnapshotsPage() {
     next: useRef<HTMLButtonElement>(null),
   };
 
+  const pressTimeoutRef = useRef<number>();
   // Ref so the keydown handler reads latest state without re-registering.
   const navRef = useRef({navigateSingleView, setViewMode, viewMode, navButtonRefs});
   navRef.current = {navigateSingleView, setViewMode, viewMode, navButtonRefs};
@@ -512,7 +513,11 @@ export default function SnapshotsPage() {
       if (btn && !btn.disabled) {
         btn.setAttribute('aria-pressed', 'true');
         btn.click();
-        setTimeout(() => btn.removeAttribute('aria-pressed'), 150);
+        clearTimeout(pressTimeoutRef.current);
+        pressTimeoutRef.current = window.setTimeout(
+          () => btn.removeAttribute('aria-pressed'),
+          150
+        );
       }
     }
 

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -471,7 +471,7 @@ export default function SnapshotsPage() {
     next: useRef<HTMLButtonElement>(null),
   };
 
-  const pressTimeoutRef = useRef<number>();
+  const pressTimeoutRef = useRef<number>(undefined);
   // Ref so the keydown handler reads latest state without re-registering.
   const navRef = useRef({navigateSingleView, setViewMode, viewMode, navButtonRefs});
   navRef.current = {navigateSingleView, setViewMode, viewMode, navButtonRefs};

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -32,7 +32,7 @@ import type {
 import {SnapshotHeaderActions} from './header/snapshotHeaderActions';
 import {SnapshotHeaderContent} from './header/snapshotHeaderContent';
 import type {DiffMode} from './main/imageDisplay/diffImageDisplay';
-import {SnapshotMainContent} from './main/snapshotMainContent';
+import {type NavButtonRefs, SnapshotMainContent} from './main/snapshotMainContent';
 import {
   DIFF_TYPE_ORDER,
   type SidebarGroup,
@@ -466,9 +466,14 @@ export default function SnapshotsPage() {
     };
   }, [listItems, singleViewPosition]);
 
+  const navButtonRefs: NavButtonRefs = {
+    prev: useRef<HTMLButtonElement>(null),
+    next: useRef<HTMLButtonElement>(null),
+  };
+
   // Ref so the keydown handler reads latest state without re-registering.
-  const navRef = useRef({navigateSingleView, setViewMode, viewMode});
-  navRef.current = {navigateSingleView, setViewMode, viewMode};
+  const navRef = useRef({navigateSingleView, setViewMode, viewMode, navButtonRefs});
+  navRef.current = {navigateSingleView, setViewMode, viewMode, navButtonRefs};
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
@@ -500,7 +505,15 @@ export default function SnapshotsPage() {
         return;
       }
       e.preventDefault();
-      navRef.current.navigateSingleView(e.key === 'ArrowDown' ? 'next' : 'prev');
+      const btn =
+        e.key === 'ArrowDown'
+          ? navRef.current.navButtonRefs.next.current
+          : navRef.current.navButtonRefs.prev.current;
+      if (btn && !btn.disabled) {
+        btn.setAttribute('aria-pressed', 'true');
+        btn.click();
+        setTimeout(() => btn.removeAttribute('aria-pressed'), 150);
+      }
     }
 
     document.addEventListener('keydown', handleKeyDown);
@@ -602,6 +615,7 @@ export default function SnapshotsPage() {
           onNavigateSingleView={navigateSingleView}
           canNavigatePrev={singleViewNav.canPrev}
           canNavigateNext={singleViewNav.canNext}
+          navButtonRefs={navButtonRefs}
         />
       </Flex>
     </Flex>


### PR DESCRIPTION
Improve the snapshot viewer's keyboard navigation UX:

- **Keyboard shortcut hints in tooltips** — navigation buttons and view mode toggles now show their keyboard shortcuts (↑/↓ for prev/next, ←/→ for list/single view)
- **Visual press feedback** — arrow key presses now trigger the actual nav buttons with a brief press animation (aria-pressed) so users get visual confirmation of keyboard navigation