### PR TITLE
feat(slack): Apply dashboard global filters when unfurling widgets

### DIFF
--- a/src/sentry/integrations/slack/unfurl/dashboards.py
+++ b/src/sentry/integrations/slack/unfurl/dashboards.py
@@ -38,6 +38,7 @@ from sentry.search.eap.types import SupportedTraceItemType
 from sentry.snuba.referrer import Referrer
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
+from sentry.utils import json
 
 
 class DashboardsUnfurlArgs(TypedDict):
@@ -246,9 +247,10 @@ def build_widget_timeseries_params(
         raise ValueError(f"Unsupported widget type: {widget.widget_type}")
 
     dashboard_filters = widget.dashboard.get_filters()
+    global_filters = _dashboard_filter_conditions(url_params, dashboard_filters, widget.widget_type)
 
     return [
-        _params_for_widget_query(wq, url_params, config, dashboard_filters)
+        _params_for_widget_query(wq, url_params, config, dashboard_filters, global_filters)
         for wq in widget.dashboardwidgetquery_set.all()
     ]
 
@@ -258,6 +260,7 @@ def _params_for_widget_query(
     url_params: QueryDict,
     config: _WidgetUnfurlConfig,
     dashboard_filters: Mapping[str, Any],
+    global_filters: str,
 ) -> dict[str, str | list[str]]:
     params: dict[str, str | list[str]] = {}
 
@@ -270,8 +273,13 @@ def _params_for_widget_query(
         params["groupBy"] = columns
         params["topEvents"] = str(TOP_N)
 
-    if widget_query.conditions:
-        params["query"] = widget_query.conditions
+    base_query = widget_query.conditions or ""
+    if base_query and global_filters:
+        params["query"] = f"({base_query}) {global_filters}"
+    elif global_filters:
+        params["query"] = global_filters
+    elif base_query:
+        params["query"] = base_query
 
     if widget_query.orderby:
         params["sort"] = widget_query.orderby
@@ -347,6 +355,62 @@ def _apply_page_filters(
     interval_value = url_params.get("interval")
     if interval_value:
         params["interval"] = interval_value
+
+
+def _dashboard_filter_conditions(
+    url_params: QueryDict,
+    dashboard_filters: Mapping[str, Any],
+    widget_type: int,
+) -> str:
+    """Build the extra query string contributed by dashboard global filters.
+
+    Mirrors ``dashboardFiltersToString`` in
+    ``static/app/views/dashboards/utils.tsx``. URL overrides win per-key
+    (matching ``getMergedDashboardFilters``). Only ``globalFilter`` entries
+    whose ``dataset`` matches the widget's type are applied.
+
+    Storage uses snake_case (``global_filter``); URL params use camelCase
+    (``globalFilter``), each value JSON-encoded.
+    """
+    url_release = url_params.getlist("release")
+    release = url_release if url_release else list(dashboard_filters.get("release") or [])
+
+    url_global = url_params.getlist("globalFilter")
+    if url_global:
+        global_filters: list[dict[str, Any]] = []
+        for raw in url_global:
+            try:
+                parsed = json.loads(raw)
+            except (TypeError, ValueError):
+                continue
+            if isinstance(parsed, dict):
+                global_filters.append(parsed)
+    else:
+        global_filters = [
+            global_filter
+            for global_filter in (dashboard_filters.get("global_filter") or [])
+            if isinstance(global_filter, dict)
+        ]
+
+    parts: list[str] = []
+
+    if release:
+        if len(release) == 1:
+            parts.append(f'release:"{release[0]}"')
+        else:
+            quoted = ",".join(f'"{r}"' for r in release)
+            parts.append(f"release:[{quoted}]")
+
+    widget_type_name = dict(DashboardWidgetTypes.TYPES).get(widget_type)
+    if widget_type_name:
+        for global_filter in global_filters:
+            if global_filter.get("dataset") != widget_type_name:
+                continue
+            value = global_filter.get("value")
+            if value:
+                parts.append(str(value))
+
+    return " ".join(parts)
 
 
 def map_dashboards_query_args(url: str, args: Mapping[str, str | None]) -> DashboardsUnfurlArgs:

--- a/tests/sentry/integrations/slack/test_unfurl.py
+++ b/tests/sentry/integrations/slack/test_unfurl.py
@@ -2742,3 +2742,153 @@ class BuildWidgetTimeseriesParamsTest(TestCase):
         assert params["statsPeriod"] == "7d"
         assert "start" not in params
         assert "end" not in params
+
+    def test_dashboard_release_filter_appended_to_query(self) -> None:
+        widget = self._make_widget()
+        widget.dashboard.filters = {"release": ["v1.0.0"]}
+        widget.dashboard.save()
+
+        params = build_widget_timeseries_params(widget, QueryDict())[0]
+
+        assert params["query"] == 'release:"v1.0.0"'
+
+    def test_dashboard_release_multiple_values_use_list_syntax(self) -> None:
+        widget = self._make_widget()
+        widget.dashboard.filters = {"release": ["v1.0.0", "v2.0.0"]}
+        widget.dashboard.save()
+
+        params = build_widget_timeseries_params(widget, QueryDict())[0]
+
+        assert params["query"] == 'release:["v1.0.0","v2.0.0"]'
+
+    def test_dashboard_release_combined_with_widget_conditions(self) -> None:
+        widget = self._make_widget(
+            queries=[{"aggregates": ["avg(span.duration)"], "conditions": "span.op:http"}],
+        )
+        widget.dashboard.filters = {"release": ["v1.0.0"]}
+        widget.dashboard.save()
+
+        params = build_widget_timeseries_params(widget, QueryDict())[0]
+
+        # Widget conditions are wrapped in parens, then global filters appended.
+        assert params["query"] == '(span.op:http) release:"v1.0.0"'
+
+    def test_url_release_overrides_dashboard_release(self) -> None:
+        widget = self._make_widget()
+        widget.dashboard.filters = {"release": ["v1.0.0"]}
+        widget.dashboard.save()
+
+        params = build_widget_timeseries_params(widget, QueryDict("release=v2.0.0"))[0]
+
+        assert params["query"] == 'release:"v2.0.0"'
+
+    def test_url_release_multiple_values(self) -> None:
+        widget = self._make_widget()
+
+        params = build_widget_timeseries_params(widget, QueryDict("release=v1.0.0&release=v2.0.0"))[
+            0
+        ]
+
+        assert params["query"] == 'release:["v1.0.0","v2.0.0"]'
+
+    def test_dashboard_global_filter_applied_when_dataset_matches(self) -> None:
+        widget = self._make_widget(widget_type=DashboardWidgetTypes.SPANS)
+        widget.dashboard.filters = {
+            "global_filter": [
+                {"dataset": "spans", "tag": {"key": "span.op"}, "value": "span.op:http"},
+            ],
+        }
+        widget.dashboard.save()
+
+        params = build_widget_timeseries_params(widget, QueryDict())[0]
+
+        assert params["query"] == "span.op:http"
+
+    def test_dashboard_global_filter_skipped_when_dataset_mismatches(self) -> None:
+        widget = self._make_widget(widget_type=DashboardWidgetTypes.LOGS)
+        widget.dashboard.filters = {
+            "global_filter": [
+                {"dataset": "spans", "tag": {"key": "span.op"}, "value": "span.op:http"},
+            ],
+        }
+        widget.dashboard.save()
+
+        params = build_widget_timeseries_params(widget, QueryDict())[0]
+
+        assert "query" not in params
+
+    def test_dashboard_global_filter_multiple_entries_joined_with_space(self) -> None:
+        widget = self._make_widget(widget_type=DashboardWidgetTypes.SPANS)
+        widget.dashboard.filters = {
+            "global_filter": [
+                {"dataset": "spans", "tag": {"key": "span.op"}, "value": "span.op:http"},
+                {"dataset": "spans", "tag": {"key": "env"}, "value": "env:prod"},
+                {"dataset": "logs", "tag": {"key": "level"}, "value": "level:error"},
+            ],
+        }
+        widget.dashboard.save()
+
+        params = build_widget_timeseries_params(widget, QueryDict())[0]
+
+        assert params["query"] == "span.op:http env:prod"
+
+    def test_release_and_global_filter_combined(self) -> None:
+        widget = self._make_widget(widget_type=DashboardWidgetTypes.SPANS)
+        widget.dashboard.filters = {
+            "release": ["v1.0.0"],
+            "global_filter": [
+                {"dataset": "spans", "tag": {"key": "span.op"}, "value": "span.op:http"},
+            ],
+        }
+        widget.dashboard.save()
+
+        params = build_widget_timeseries_params(widget, QueryDict())[0]
+
+        assert params["query"] == 'release:"v1.0.0" span.op:http'
+
+    def test_url_global_filter_overrides_dashboard_global_filter(self) -> None:
+        widget = self._make_widget(widget_type=DashboardWidgetTypes.SPANS)
+        widget.dashboard.filters = {
+            "global_filter": [
+                {"dataset": "spans", "tag": {"key": "span.op"}, "value": "span.op:http"},
+            ],
+        }
+        widget.dashboard.save()
+
+        url_filter = '{"dataset": "spans", "tag": {"key": "env"}, "value": "env:prod"}'
+        params = build_widget_timeseries_params(widget, QueryDict(f"globalFilter={url_filter}"))[0]
+
+        assert params["query"] == "env:prod"
+
+    def test_url_global_filter_invalid_json_is_skipped(self) -> None:
+        widget = self._make_widget(widget_type=DashboardWidgetTypes.SPANS)
+
+        url_filter = '{"dataset": "spans", "tag": {"key": "env"}, "value": "env:prod"}'
+        params = build_widget_timeseries_params(
+            widget, QueryDict(f"globalFilter=not-json&globalFilter={url_filter}")
+        )[0]
+
+        assert params["query"] == "env:prod"
+
+    def test_global_filter_for_error_events_widget(self) -> None:
+        widget = self._make_widget(
+            widget_type=DashboardWidgetTypes.ERROR_EVENTS,
+            queries=[{"aggregates": ["count()"]}],
+        )
+        widget.dashboard.filters = {
+            "global_filter": [
+                {"dataset": "error-events", "tag": {"key": "level"}, "value": "level:error"},
+            ],
+        }
+        widget.dashboard.save()
+
+        params = build_widget_timeseries_params(widget, QueryDict())[0]
+
+        assert params["query"] == "level:error"
+
+    def test_no_dashboard_filters_no_widget_conditions_omits_query(self) -> None:
+        widget = self._make_widget()
+
+        params = build_widget_timeseries_params(widget, QueryDict())[0]
+
+        assert "query" not in params


### PR DESCRIPTION
Code Generated by claude

The widget unfurl previously ignored the dashboard's `release` and `globalFilter` "global" filters, so unfurled charts could show different data than the dashboard. Mirror the FE's `dashboardFiltersToString` + `getMergedDashboardFilters` so URL overrides win per-key, and `globalFilter` entries only contribute when their `dataset` matches the widget's type.

**Query composition**

The release + matching globalFilter values are appended as a query-string fragment, with the widget's saved conditions wrapped in parens.

Before, with `conditions = "span.op:http"` and a dashboard release filter, the unfurl request used:

```
query=span.op:http
```

After:

```
query=(span.op:http) release:"v1.0.0"
```

Refs DAIN-1605