### PR TITLE
chore(cells) Mainline analytics in RPC call for provisioning

### DIFF
--- a/src/sentry/core/endpoints/organization_index.py
+++ b/src/sentry/core/endpoints/organization_index.py
@@ -10,12 +10,8 @@ from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import analytics, audit_log, features, options
+from sentry import features, options
 from sentry import ratelimits as ratelimiter
-from sentry.analytics.events.data_consent_org_creation import (
-    AggregatedDataConsentOrganizationCreatedEvent,
-)
-from sentry.analytics.events.organization_created import OrganizationCreatedEvent
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, all_silo_endpoint
 from sentry.api.bases.organization import OrganizationPermission
@@ -46,7 +42,6 @@ from sentry.services.organization import (
     PostProvisionOptions,
 )
 from sentry.services.organization.provisioning import organization_provisioning_service
-from sentry.signals import org_setup_complete, terms_accepted
 from sentry.silo.base import SiloMode
 from sentry.users.services.user.serial import serialize_generic_user
 from sentry.users.services.user.service import user_service
@@ -391,21 +386,18 @@ class OrganizationIndexEndpoint(Endpoint):
 
         result = serializer.validated_data
 
-        analytics_in_rpc = options.get("provision_organization_in_cell.record_analytics")
-
         getsentry_options = None
-        if analytics_in_rpc:
-            getsentry_options = {
-                # Define a self-serve free account for saas. Historically
-                # these were not trial accounts.
-                # See getsentry/utils/provisioning.py
-                "subscription": {
-                    "channel": 0,
-                    "type": 0,
-                },
-                "ip_address": request.META["REMOTE_ADDR"],
-                "provisioning_user_id": request.user.id,
-            }
+        getsentry_options = {
+            # Define a self-serve free account for saas. Historically
+            # these were not trial accounts.
+            # See getsentry/utils/provisioning.py
+            "subscription": {
+                "channel": 0,
+                "type": 0,
+            },
+            "ip_address": request.META["REMOTE_ADDR"],
+            "provisioning_user_id": request.user.id,
+        }
 
         try:
             create_default_team = bool(result.get("defaultTeam"))
@@ -435,61 +427,11 @@ class OrganizationIndexEndpoint(Endpoint):
             )
             org = Organization.objects.get(id=rpc_org.id)
 
-            if not analytics_in_rpc:
-                org_setup_complete.send_robust(
-                    instance=org, user=request.user, sender=self.__class__, referrer="in-app"
-                )
-
-                self.create_audit_entry(
-                    request=request,
-                    organization=org,
-                    target_object=org.id,
-                    event=audit_log.get_event_id("ORG_ADD"),
-                    data=org.get_audit_log_data(),
-                )
-
-                try:
-                    analytics.record(
-                        OrganizationCreatedEvent(
-                            id=org.id,
-                            name=org.name,
-                            slug=org.slug,
-                            actor_id=request.user.id if request.user.is_authenticated else None,
-                        )
-                    )
-                except Exception as e:
-                    sentry_sdk.capture_exception(e)
-
         # TODO(hybrid-cloud): We'll need to catch a more generic error
         # when the internal RPC is implemented.
         except IntegrityError:
             return Response(
                 {"detail": "An organization with this slug already exists."}, status=409
             )
-
-        if not analytics_in_rpc:
-            # failure on sending this signal is acceptable
-            if result.get("agreeTerms"):
-                terms_accepted.send_robust(
-                    user=request.user,
-                    organization_id=org.id,
-                    ip_address=request.META["REMOTE_ADDR"],
-                    sender=type(self),
-                )
-
-            if result.get("aggregatedDataConsent"):
-                org.update_option("sentry:aggregated_data_consent", True)
-
-                try:
-                    analytics.record(
-                        AggregatedDataConsentOrganizationCreatedEvent(
-                            organization_id=org.id,
-                        )
-                    )
-                except Exception as e:
-                    sentry_sdk.capture_exception(e)
-
-            # New organizations should not see the legacy UI
-            org.update_option("sentry:streamline_ui_only", True)
 
         return Response(serialize(org, request.user), status=201)

--- a/src/sentry/hybridcloud/services/cell_organization_provisioning/impl.py
+++ b/src/sentry/hybridcloud/services/cell_organization_provisioning/impl.py
@@ -45,20 +45,23 @@ class PreProvisionCheckException(Exception):
 class DatabaseBackedCellOrganizationProvisioningRpcService(CellOrganizationProvisioningRpcService):
     def _create_organization_and_team(
         self,
+        *,
+        owner: RpcUser,
         organization_name: str,
         slug: str,
         create_default_team: bool,
         organization_id: int,
         is_test: bool = False,
-        owner: RpcUser | None = None,
         # TODO(cells) Deprecated use owner instead
         user_id: int | None = None,
         # TODO(cells) Deprecated use owner instead
         email: str | None = None,
     ) -> Organization:
-        assert (user_id is None and email) or (user_id and email is None), (
-            "Must set either user_id or email"
+        assert owner or (user_id is None and email) or (user_id and email is None), (
+            "Must set either owner or one of user_id or email"
         )
+        if not user_id and owner:
+            user_id = owner.id
         truncated_name = organization_name[:ORGANIZATION_NAME_MAX_LENGTH]
         org = Organization.objects.create(
             id=organization_id, name=truncated_name, slug=slug, is_test=is_test

--- a/src/sentry/hybridcloud/services/cell_organization_provisioning/impl.py
+++ b/src/sentry/hybridcloud/services/cell_organization_provisioning/impl.py
@@ -2,7 +2,7 @@ from django.db import IntegrityError, router, transaction
 from django.db.models import Q
 from sentry_sdk import capture_exception
 
-from sentry import analytics, audit_log, options, roles
+from sentry import analytics, audit_log, roles
 from sentry.analytics.events.data_consent_org_creation import (
     AggregatedDataConsentOrganizationCreatedEvent,
 )
@@ -181,12 +181,6 @@ class DatabaseBackedCellOrganizationProvisioningRpcService(CellOrganizationProvi
     def _record_organization_create_analytics(
         self, organization: Organization, provision_options: OrganizationOptions
     ) -> None:
-        if not (
-            provision_options.owner
-            and options.get("provision_organization_in_cell.record_analytics")
-        ):
-            return
-
         # These operations involve RPC calls to control so do them outside of the transaction
         audit_data = organization.get_audit_log_data()
         actor_label = None

--- a/src/sentry/runner/commands/createorg.py
+++ b/src/sentry/runner/commands/createorg.py
@@ -37,12 +37,18 @@ def createorg(
         OrganizationProvisioningException,
         organization_provisioning_service,
     )
+    from sentry.users.models.user import User
+    from sentry.users.services.user.serial import serialize_generic_user
+
+    owner = User.objects.get(email=owner_email)
+    rpc_owner = serialize_generic_user(owner)
+    assert rpc_owner  # remove None
 
     provision_args = OrganizationProvisioningOptions(
         provision_options=OrganizationOptions(
             name=name,
             slug=slug or name,
-            owning_email=owner_email,
+            owner=rpc_owner,
             create_default_team=not no_default_team,
         ),
         post_provision_options=PostProvisionOptions(),

--- a/src/sentry/services/organization/model.py
+++ b/src/sentry/services/organization/model.py
@@ -8,11 +8,11 @@ from sentry.users.services.user.model import RpcUser
 class OrganizationOptions(pydantic.BaseModel):
     name: str
     slug: str
+    owner: RpcUser
     # Deprecated use owner instead.
     owning_user_id: int | None = None
     # Deprecated use owner instead.
     owning_email: str | None = None
-    owner: RpcUser | None = None
     create_default_team: bool = True
     is_test: bool = False
     ip_address: str | None = None

--- a/tests/sentry/hybridcloud/services/test_cell_organization_provisioning.py
+++ b/tests/sentry/hybridcloud/services/test_cell_organization_provisioning.py
@@ -25,6 +25,7 @@ from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test, create_test_cells
 from sentry.users.models.user import User
+from sentry.users.services.user.serial import serialize_generic_user
 
 
 @control_silo_test(cells=create_test_cells("us"))
@@ -32,11 +33,14 @@ class TestRegionOrganizationProvisioningCreateInRegion(TestCase):
     def get_provisioning_args(
         self, user: User, is_test: bool = False, create_default_team: bool = True
     ) -> OrganizationProvisioningOptions:
+        rpc_user = serialize_generic_user(user)
+        assert rpc_user
         return OrganizationProvisioningOptions(
             provision_options=OrganizationOptions(
                 name="Santry",
                 slug="santry",
-                owning_user_id=user.id,
+                owner=rpc_user,
+                owning_user_id=rpc_user.id,
                 is_test=is_test,
                 create_default_team=create_default_team,
             ),

--- a/tests/sentry/hybridcloud/services/test_control_organization_provisioning.py
+++ b/tests/sentry/hybridcloud/services/test_control_organization_provisioning.py
@@ -25,6 +25,8 @@ from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import all_silo_test, assume_test_silo_mode, create_test_cells
 from sentry.types.cell import get_local_cell
+from sentry.users.models.user import User
+from sentry.users.services.user.serial import serialize_generic_user
 from sentry.utils.security.orgauthtoken_token import hash_token
 
 
@@ -32,7 +34,7 @@ class TestControlOrganizationProvisioningBase(TestCase):
     def setUp(self) -> None:
         self.provision_user = self.create_user()
         self.provisioning_args = self.generate_provisioning_args(
-            name="sentry", slug="sentry", user_id=self.provision_user.id, default_team=True
+            name="sentry", slug="sentry", user=self.provision_user, default_team=True
         )
 
         self.cell_name = (
@@ -45,15 +47,17 @@ class TestControlOrganizationProvisioningBase(TestCase):
         name: str,
         slug: str,
         default_team: bool,
-        user_id: int | None = None,
-        email: str | None = None,
+        user: User,
     ) -> OrganizationProvisioningOptions:
+        rpc_user = serialize_generic_user(user)
+        assert rpc_user
         return OrganizationProvisioningOptions(
             provision_options=OrganizationOptions(
                 name=name,
                 slug=slug,
-                owning_user_id=user_id,
-                owning_email=email,
+                owner=rpc_user,
+                owning_user_id=rpc_user.id,
+                owning_email=rpc_user.email,
                 create_default_team=default_team,
                 is_test=False,
             ),
@@ -103,17 +107,6 @@ class TestControlOrganizationProvisioning(TestControlOrganizationProvisioningBas
         rpc_org_slug = self.provision_organization()
         self.assert_slug_reservation_and_org_exist(
             rpc_org_slug=rpc_org_slug, user_id=self.provision_user.id
-        )
-
-    def test_organization_provisioning_before_user_provisioning(self) -> None:
-        provisioning_options = self.generate_provisioning_args(
-            name="sentry", slug="sentry", email="test-owner@sentry.io", default_team=True
-        )
-        slug = control_organization_provisioning_rpc_service.provision_organization(
-            cell_name="us", org_provision_args=provisioning_options
-        )
-        self.assert_slug_reservation_and_org_exist(
-            rpc_org_slug=slug,
         )
 
     def test_organization_already_provisioned_for_different_user(self) -> None:

--- a/tests/sentry/runner/commands/test_createorg.py
+++ b/tests/sentry/runner/commands/test_createorg.py
@@ -3,30 +3,33 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.models.team import Team
 from sentry.runner.commands.createorg import createorg
 from sentry.testutils.cases import CliTestCase
+from sentry.testutils.silo import no_silo_test
 
 
+@no_silo_test
 class CreateOrgTest(CliTestCase):
     command = createorg
 
     def test_basic_create(self) -> None:
+        user = self.create_user("owner@example.com")
         rv = self.invoke("--name=Test Org", "--slug=test-org", "--owner-email=owner@example.com")
         assert rv.exit_code == 0, rv.output
         assert "test-org" in rv.output
 
         org = Organization.objects.get(slug="test-org")
         assert org.name == "Test Org"
-        assert OrganizationMember.objects.filter(
-            organization=org, email="owner@example.com"
-        ).exists()
+        assert OrganizationMember.objects.filter(organization=org, user_id=user.id).exists()
         assert Team.objects.filter(organization=org).exists()
 
     def test_slug_defaults_to_name(self) -> None:
+        self.create_user("owner@example.com")
         rv = self.invoke("--name=My Organization", "--owner-email=owner@example.com")
         assert rv.exit_code == 0, rv.output
 
         assert Organization.objects.filter(slug="my-organization").exists()
 
     def test_no_default_team(self) -> None:
+        self.create_user("owner@example.com")
         rv = self.invoke(
             "--name=No Team Org",
             "--slug=no-team-org",


### PR DESCRIPTION
With the option enabled, the old code paths can be removed.

Refs INFRENG-186
