### PR TITLE
fix(statistical-detectors): use transactions instead of generic metrics

### DIFF
--- a/src/sentry/tasks/statistical_detectors.py
+++ b/src/sentry/tasks/statistical_detectors.py
@@ -13,11 +13,9 @@ from snuba_sdk import (
     BooleanOp,
     Column,
     Condition,
-    CurriedFunction,
     Direction,
     Entity,
     Function,
-    Granularity,
     Limit,
     LimitBy,
     Op,
@@ -39,12 +37,9 @@ from sentry.search.events.fields import resolve_datetime64
 from sentry.search.events.types import SnubaParams
 from sentry.seer.breakpoints import BreakpointData
 from sentry.seer.signed_seer_api import SeerViewerContext
-from sentry.sentry_metrics import indexer
-from sentry.sentry_metrics.use_case_id_registry import UseCaseID
 from sentry.snuba import functions
 from sentry.snuba.dataset import Dataset, EntityKey, StorageKey
 from sentry.snuba.discover import zerofill
-from sentry.snuba.metrics.naming_layer.mri import TransactionMRI
 from sentry.snuba.referrer import Referrer
 from sentry.statistical_detectors.algorithm import (
     DetectorAlgorithm,
@@ -740,103 +735,43 @@ def query_transactions(
     start = start.replace(minute=0, second=0, microsecond=0)
     end = start + timedelta(hours=1)
 
-    org_ids = list({p.organization_id for p in projects})
     project_ids = list({p.id for p in projects})
 
-    use_case_id = UseCaseID.TRANSACTIONS
-
-    # both the metric and tag that we are using are hardcoded values in sentry_metrics.indexer.strings
-    # so the org_id that we are using does not actually matter here, we only need to pass in an org_id
-    #
-    # Because we filter on more than just `transaction`, we have to use DURATION here instead of
-    # DURATION_LIGHT.
-    duration_metric_id = indexer.resolve(
-        use_case_id, org_ids[0], str(TransactionMRI.DURATION.value)
-    )
-    transaction_name_metric_id = indexer.resolve(
-        use_case_id,
-        org_ids[0],
-        "transaction",
-    )
-    transaction_op_metric_id = indexer.resolve(
-        use_case_id,
-        org_ids[0],
-        "transaction.op",
-    )
-
-    # if our time range is more than an hour, use the hourly granularity
-    granularity = 3600 if int(end.timestamp()) - int(start.timestamp()) >= 3600 else 60
-
-    # This query returns the top `transactions_per_project` transaction names by count in the specified
-    # [start, end) time period along with the p95 of each transaction in that time period
-    # this is written in raw SnQL because the metrics layer does not support the limitby clause which is necessary for this operation to work
-
+    # This query returns the top `transactions_per_project` transaction names by count in the
+    # specified [start, end) time period along with the p95 of each transaction in that period.
+    # Written in raw SnQL because the discover layer does not support the LIMITBY clause needed here.
     query = Query(
-        match=Entity(EntityKey.GenericMetricsDistributions.value),
+        match=Entity(EntityKey.Transactions.value),
         select=[
             Column("project_id"),
-            Function(
-                "arrayElement",
-                (
-                    CurriedFunction(
-                        "quantilesIf",
-                        [0.95],
-                        (
-                            Column("value"),
-                            Function("equals", (Column("metric_id"), duration_metric_id)),
-                        ),
-                    ),
-                    1,
-                ),
-                "p95",
-            ),
-            Function(
-                "countIf",
-                (Column("value"), Function("equals", (Column("metric_id"), duration_metric_id))),
-                "count",
-            ),
-            Function(
-                "transform",
-                (
-                    Column(f"tags_raw[{transaction_name_metric_id}]"),
-                    Function("array", ("",)),
-                    Function("array", ("<< unparameterized >>",)),
-                ),
-                "transaction_name",
-            ),
+            Function("quantile(0.95)", [Column("duration")], "p95"),
+            Function("count", [], "count"),
+            Column("transaction_name"),
         ],
         groupby=[
             Column("project_id"),
             Column("transaction_name"),
         ],
         where=[
-            Condition(Column("org_id"), Op.IN, list(org_ids)),
             Condition(Column("project_id"), Op.IN, project_ids),
-            Condition(Column("timestamp"), Op.GTE, start),
-            Condition(Column("timestamp"), Op.LT, end),
-            Condition(Column("metric_id"), Op.EQ, duration_metric_id),
-            Condition(
-                Column(f"tags_raw[{transaction_op_metric_id}]"),
-                Op.IN,
-                list(BACKEND_TRANSACTION_OPS),
-            ),
+            Condition(Column("finish_ts"), Op.GTE, start),
+            Condition(Column("finish_ts"), Op.LT, end),
+            Condition(Column("transaction_op"), Op.IN, list(BACKEND_TRANSACTION_OPS)),
         ],
         limitby=LimitBy([Column("project_id")], transactions_per_project),
         orderby=[
             OrderBy(Column("project_id"), Direction.DESC),
             OrderBy(Column("count"), Direction.DESC),
         ],
-        granularity=Granularity(granularity),
         limit=Limit(len(project_ids) * transactions_per_project),
     )
     request = Request(
-        dataset=Dataset.PerformanceMetrics.value,
+        dataset=Dataset.Transactions.value,
         app_id="statistical_detectors",
         query=query,
         tenant_ids={
             "referrer": Referrer.STATISTICAL_DETECTORS_FETCH_TOP_TRANSACTION_NAMES.value,
             "cross_org_query": 1,
-            "use_case_id": use_case_id.value,
         },
     )
     data = raw_snql_query(
@@ -863,23 +798,10 @@ def query_transactions_timeseries(
     end = start.replace(minute=0, second=0, microsecond=0) + timedelta(hours=1)
     days_to_query = options.get("statistical_detectors.query.transactions.timeseries_days")
     start = end - timedelta(days=days_to_query)
-    use_case_id = UseCaseID.TRANSACTIONS
     interval = 3600  # 1 hour
 
     project_objects = {p for p, _ in transactions}
     project_ids = [project.id for project in project_objects]
-    org_ids = list({project.organization_id for project in project_objects})
-    # The only tag available on DURATION_LIGHT is `transaction`: as long as
-    # we don't filter on any other tags, DURATION_LIGHT's lower cardinality
-    # will be faster to query.
-    duration_metric_id = indexer.resolve(
-        use_case_id, org_ids[0], str(TransactionMRI.DURATION_LIGHT.value)
-    )
-    transaction_name_metric_id = indexer.resolve(
-        use_case_id,
-        org_ids[0],
-        "transaction",
-    )
 
     transactions_condition = None
     if len(transactions) == 1:
@@ -888,7 +810,7 @@ def query_transactions_timeseries(
             BooleanOp.AND,
             [
                 Condition(Column("project_id"), Op.EQ, project.id),
-                Condition(Column("transaction"), Op.EQ, transaction_name),
+                Condition(Column("transaction_name"), Op.EQ, transaction_name),
             ],
         )
     else:
@@ -899,7 +821,7 @@ def query_transactions_timeseries(
                     BooleanOp.AND,
                     [
                         Condition(Column("project_id"), Op.EQ, project.id),
-                        Condition(Column("transaction"), Op.EQ, transaction_name),
+                        Condition(Column("transaction_name"), Op.EQ, transaction_name),
                     ],
                 )
                 for project, transaction_name in transactions
@@ -907,74 +829,48 @@ def query_transactions_timeseries(
         )
 
     query = Query(
-        match=Entity(EntityKey.GenericMetricsDistributions.value),
+        match=Entity(EntityKey.Transactions.value),
         select=[
             Column("project_id"),
-            Function(
-                "arrayElement",
-                (
-                    CurriedFunction(
-                        "quantilesIf",
-                        [0.95],
-                        (
-                            Column("value"),
-                            Function("equals", (Column("metric_id"), duration_metric_id)),
-                        ),
-                    ),
-                    1,
-                ),
-                "p95_transaction_duration",
-            ),
-            Function(
-                "transform",
-                (
-                    Column(f"tags_raw[{transaction_name_metric_id}]"),
-                    Function("array", ("",)),
-                    Function("array", ("<< unparameterized >>",)),
-                ),
-                "transaction",
-            ),
+            Function("quantile(0.95)", [Column("duration")], "p95_transaction_duration"),
+            Column("transaction_name"),
         ],
         groupby=[
-            Column("transaction"),
+            Column("transaction_name"),
             Column("project_id"),
             Function(
                 "toStartOfInterval",
-                (Column("timestamp"), Function("toIntervalSecond", (3600,)), "Universal"),
+                (Column("finish_ts"), Function("toIntervalSecond", (3600,)), "Universal"),
                 "time",
             ),
         ],
         where=[
-            Condition(Column("org_id"), Op.IN, list(org_ids)),
             Condition(Column("project_id"), Op.IN, list(project_ids)),
-            Condition(Column("timestamp"), Op.GTE, start),
-            Condition(Column("timestamp"), Op.LT, end),
-            Condition(Column("metric_id"), Op.EQ, duration_metric_id),
+            Condition(Column("finish_ts"), Op.GTE, start),
+            Condition(Column("finish_ts"), Op.LT, end),
             transactions_condition,
         ],
         orderby=[
             OrderBy(Column("project_id"), Direction.ASC),
-            OrderBy(Column("transaction"), Direction.ASC),
+            OrderBy(Column("transaction_name"), Direction.ASC),
             OrderBy(
                 Function(
                     "toStartOfInterval",
-                    (Column("timestamp"), Function("toIntervalSecond", (3600,)), "Universal"),
+                    (Column("finish_ts"), Function("toIntervalSecond", (3600,)), "Universal"),
                     "time",
                 ),
                 Direction.ASC,
             ),
         ],
-        granularity=Granularity(interval),
         limit=Limit(10000),
     )
     request = Request(
-        dataset=Dataset.PerformanceMetrics.value,
+        dataset=Dataset.Transactions.value,
         app_id="statistical_detectors",
         query=query,
         tenant_ids={
             "referrer": Referrer.STATISTICAL_DETECTORS_FETCH_TRANSACTION_TIMESERIES.value,
             "cross_org_query": 1,
-            "use_case_id": use_case_id.value,
         },
     )
     data = raw_snql_query(
@@ -983,7 +879,7 @@ def query_transactions_timeseries(
 
     results = {}
     for index, datapoint in enumerate(data or []):
-        key = (datapoint["project_id"], datapoint["transaction"])
+        key = (datapoint["project_id"], datapoint["transaction_name"])
         if key not in results:
             results[key] = {
                 "data": [datapoint],

--- a/tests/sentry/tasks/test_statistical_detectors.py
+++ b/tests/sentry/tasks/test_statistical_detectors.py
@@ -24,7 +24,6 @@ from sentry.models.statistical_detectors import (
 )
 from sentry.seer.breakpoints import BreakpointData
 from sentry.snuba.discover import zerofill
-from sentry.snuba.metrics.naming_layer.mri import TransactionMRI
 from sentry.statistical_detectors.algorithm import MovingAverageDetectorState
 from sentry.statistical_detectors.base import DetectorPayload, TrendType
 from sentry.statistical_detectors.detector import TrendBundle, generate_fingerprint
@@ -41,7 +40,11 @@ from sentry.tasks.statistical_detectors import (
     query_transactions_timeseries,
     run_detection,
 )
-from sentry.testutils.cases import MetricsAPIBaseTestCase, ProfilesSnubaTestCase
+from sentry.testutils.cases import (
+    ProfilesSnubaTestCase,
+    SnubaTestCase,
+    TestCase,
+)
 from sentry.testutils.factories import Factories
 from sentry.testutils.helpers import override_options
 from sentry.testutils.helpers.datetime import before_now, freeze_time
@@ -1652,61 +1655,90 @@ class FunctionsTasksTest(ProfilesSnubaTestCase):
         )
 
 
-@pytest.mark.sentry_metrics
-class TestTransactionsQuery(MetricsAPIBaseTestCase):
+class TestTransactionsQuery(TestCase, SnubaTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.num_projects = 2
         self.num_transactions = 4
-
+        self.now = (datetime.now(UTC) - timedelta(days=1)).replace(
+            hour=10, minute=0, second=0, microsecond=0
+        )
         self.hour_ago = (self.now - timedelta(hours=1)).replace(minute=0, second=0, microsecond=0)
-        self.hour_ago_seconds = int(self.hour_ago.timestamp())
         self.projects = [
             self.create_project(organization=self.organization) for _ in range(self.num_projects)
         ]
 
         for project in self.projects:
             for i in range(self.num_transactions):
-                # Store metrics for a backend transaction
-                self.store_metric(
-                    self.organization.id,
-                    project.id,
-                    TransactionMRI.DURATION.value,
-                    {"transaction": f"transaction_{i}", "transaction.op": "http.server"},
-                    self.hour_ago_seconds,
-                    1.0,
+                # Store two backend transactions per name so count == 2 and p95 is meaningful
+                self.store_event(
+                    data={
+                        "type": "transaction",
+                        "transaction": f"transaction_{i}",
+                        "contexts": {
+                            "trace": {
+                                "op": "http.server",
+                                "trace_id": "a" * 32,
+                                "span_id": "b" * 16,
+                            }
+                        },
+                        "timestamp": self.hour_ago.isoformat(),
+                        "start_timestamp": (self.hour_ago - timedelta(milliseconds=1)).isoformat(),
+                        "received": self.hour_ago.isoformat(),
+                    },
+                    project_id=project.id,
                 )
-                self.store_metric(
-                    self.organization.id,
-                    project.id,
-                    TransactionMRI.DURATION.value,
-                    {"transaction": f"transaction_{i}", "transaction.op": "http.server"},
-                    self.hour_ago_seconds,
-                    9.5,
+                self.store_event(
+                    data={
+                        "type": "transaction",
+                        "transaction": f"transaction_{i}",
+                        "contexts": {
+                            "trace": {
+                                "op": "http.server",
+                                "trace_id": "c" * 32,
+                                "span_id": "d" * 16,
+                            }
+                        },
+                        "timestamp": self.hour_ago.isoformat(),
+                        "start_timestamp": (self.hour_ago - timedelta(milliseconds=10)).isoformat(),
+                        "received": self.hour_ago.isoformat(),
+                    },
+                    project_id=project.id,
                 )
 
-                # Store metrics for a frontend transaction, which should be
-                # ignored by the query
-                self.store_metric(
-                    self.organization.id,
-                    project.id,
-                    TransactionMRI.DURATION.value,
-                    {"transaction": f"fe_transaction_{i}", "transaction.op": "navigation"},
-                    self.hour_ago_seconds,
-                    1.0,
+                # Frontend transactions — should be excluded by the transaction_op filter
+                self.store_event(
+                    data={
+                        "type": "transaction",
+                        "transaction": f"fe_transaction_{i}",
+                        "contexts": {
+                            "trace": {"op": "navigation", "trace_id": "e" * 32, "span_id": "f" * 16}
+                        },
+                        "timestamp": self.hour_ago.isoformat(),
+                        "start_timestamp": (self.hour_ago - timedelta(milliseconds=1)).isoformat(),
+                        "received": self.hour_ago.isoformat(),
+                    },
+                    project_id=project.id,
                 )
-                self.store_metric(
-                    self.organization.id,
-                    project.id,
-                    TransactionMRI.DURATION.value,
-                    {"transaction": f"fe_transaction_{i}", "transaction.op": "navigation"},
-                    self.hour_ago_seconds,
-                    9.5,
+                self.store_event(
+                    data={
+                        "type": "transaction",
+                        "transaction": f"fe_transaction_{i}",
+                        "contexts": {
+                            "trace": {
+                                "op": "navigation",
+                                "trace_id": "a1" * 16,
+                                "span_id": "b1" * 8,
+                            }
+                        },
+                        "timestamp": self.hour_ago.isoformat(),
+                        "start_timestamp": (
+                            self.hour_ago - timedelta(milliseconds=9.5)
+                        ).isoformat(),
+                        "received": self.hour_ago.isoformat(),
+                    },
+                    project_id=project.id,
                 )
-
-    @property
-    def now(self):
-        return MetricsAPIBaseTestCase.MOCK_DATETIME
 
     def test_transactions_query(self) -> None:
         res = query_transactions(
@@ -1718,47 +1750,52 @@ class TestTransactionsQuery(MetricsAPIBaseTestCase):
         assert len(res) == len(self.projects) * self.num_transactions
         for trend_payload in res:
             assert trend_payload.count == 2
-            # p95 is  calculated by a probabilistic data structure, as such the value won't actually be 9.5 since we only have
-            # one sample at 9.5, but it should be close
+            # duration column stores integer ms; p95 of [1ms, 10ms] ≈ 9.55 > 9
             assert trend_payload.value > 9
             assert trend_payload.timestamp == self.hour_ago
 
 
-@pytest.mark.sentry_metrics
-class TestTransactionChangePointDetection(MetricsAPIBaseTestCase):
+class TestTransactionChangePointDetection(TestCase, SnubaTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.num_projects = 2
         self.num_transactions = 4
-
+        self.now = (datetime.now(UTC) - timedelta(days=1)).replace(
+            hour=10, minute=0, second=0, microsecond=0
+        )
         self.hour_ago = (self.now - timedelta(hours=1)).replace(minute=0, second=0, microsecond=0)
-        self.hour_ago_seconds = int(self.hour_ago.timestamp())
         self.projects = [
             self.create_project(organization=self.organization) for _ in range(self.num_projects)
         ]
 
-        def store_metric(project_id, transaction, minutes_ago, value):
-            self.store_metric(
-                self.organization.id,
-                project_id,
-                TransactionMRI.DURATION_LIGHT.value,
-                {"transaction": transaction},
-                int((self.now - timedelta(minutes=minutes_ago)).timestamp()),
-                value,
+        def store_transaction(project_id, transaction, minutes_ago, duration_ms):
+            ts = self.now - timedelta(minutes=minutes_ago)
+            self.store_event(
+                data={
+                    "type": "transaction",
+                    "transaction": transaction,
+                    "contexts": {
+                        "trace": {
+                            "op": "http.server",
+                            "trace_id": uuid.uuid4().hex,
+                            "span_id": uuid.uuid4().hex[:16],
+                        }
+                    },
+                    "timestamp": ts.isoformat(),
+                    "start_timestamp": (ts - timedelta(milliseconds=duration_ms)).isoformat(),
+                    "received": ts.isoformat(),
+                },
+                project_id=project_id,
             )
 
         for project in self.projects:
             for i in range(self.num_transactions):
-                store_metric(project.id, f"transaction_{i}", 20, 9.5)
-                store_metric(project.id, f"transaction_{i}", 40, 9.5)
-                store_metric(project.id, f"transaction_{i}", 60, 9.5)
-                store_metric(project.id, f"transaction_{i}", 80, 1.0)
-                store_metric(project.id, f"transaction_{i}", 100, 1.0)
-                store_metric(project.id, f"transaction_{i}", 120, 1.0)
-
-    @property
-    def now(self):
-        return MetricsAPIBaseTestCase.MOCK_DATETIME
+                store_transaction(project.id, f"transaction_{i}", 20, 9)
+                store_transaction(project.id, f"transaction_{i}", 40, 9)
+                store_transaction(project.id, f"transaction_{i}", 60, 9)
+                store_transaction(project.id, f"transaction_{i}", 80, 1)
+                store_transaction(project.id, f"transaction_{i}", 100, 1)
+                store_transaction(project.id, f"transaction_{i}", 120, 1)
 
     def test_query_transactions_timeseries(self) -> None:
         results = [
@@ -1787,16 +1824,16 @@ class TestTransactionChangePointDetection(MetricsAPIBaseTestCase):
                         "data": zerofill(
                             [
                                 {
-                                    "transaction": "transaction_1",
+                                    "transaction_name": "transaction_1",
                                     "time": first_timeseries_time.isoformat(),
                                     "project_id": self.projects[0].id,
-                                    "p95_transaction_duration": 1.0,
+                                    "p95_transaction_duration": 1,
                                 },
                                 {
-                                    "transaction": "transaction_1",
+                                    "transaction_name": "transaction_1",
                                     "time": second_timeseries_time.isoformat(),
                                     "project_id": self.projects[0].id,
-                                    "p95_transaction_duration": 9.5,
+                                    "p95_transaction_duration": 9,
                                 },
                             ],
                             start,
@@ -1819,16 +1856,16 @@ class TestTransactionChangePointDetection(MetricsAPIBaseTestCase):
                         "data": zerofill(
                             [
                                 {
-                                    "transaction": "transaction_2",
+                                    "transaction_name": "transaction_2",
                                     "time": first_timeseries_time.isoformat(),
                                     "project_id": self.projects[0].id,
-                                    "p95_transaction_duration": 1.0,
+                                    "p95_transaction_duration": 1,
                                 },
                                 {
-                                    "transaction": "transaction_2",
+                                    "transaction_name": "transaction_2",
                                     "time": second_timeseries_time.isoformat(),
                                     "project_id": self.projects[0].id,
-                                    "p95_transaction_duration": 9.5,
+                                    "p95_transaction_duration": 9,
                                 },
                             ],
                             start,
@@ -1851,16 +1888,16 @@ class TestTransactionChangePointDetection(MetricsAPIBaseTestCase):
                         "data": zerofill(
                             [
                                 {
-                                    "transaction": "transaction_1",
+                                    "transaction_name": "transaction_1",
                                     "time": first_timeseries_time.isoformat(),
                                     "project_id": self.projects[1].id,
-                                    "p95_transaction_duration": 1.0,
+                                    "p95_transaction_duration": 1,
                                 },
                                 {
-                                    "transaction": "transaction_1",
+                                    "transaction_name": "transaction_1",
                                     "time": second_timeseries_time.isoformat(),
                                     "project_id": self.projects[1].id,
-                                    "p95_transaction_duration": 9.5,
+                                    "p95_transaction_duration": 9,
                                 },
                             ],
                             start,


### PR DESCRIPTION
Since generic metrics is basically dead we want to use transactions instead. Heads up i'm not too familiar with this code and got claude to do most of the updates here. Let me know any of this doesn't make sense. 

From my understanding transactions dataset has some different names for fields (like finish_ts for timestamp) and don't need some of the metrics specific checks (like metric id). Also transactions only have integer number ms durations vs metrics allowed float values. These are the main reasons for all the changes but let me know if any of this is incorrect.