### PR TITLE
ref(cmdk): Remove cmd-k feature flags from backend

### DIFF
--- a/src/sentry/api/endpoints/dsn_lookup.py
+++ b/src/sentry/api/endpoints/dsn_lookup.py
@@ -3,7 +3,6 @@ from urllib.parse import urlparse
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -20,8 +19,7 @@ class DsnLookupEndpoint(OrganizationEndpoint):
     """Resolve a DSN to its project and key metadata within an organization.
 
     Used by the command palette to let users paste a DSN and quickly navigate
-    to the corresponding project. Gated behind the organizations:cmd-k-dsn-lookup
-    feature flag.
+    to the corresponding project.
     """
 
     owner = ApiOwner.TELEMETRY_EXPERIENCE
@@ -38,9 +36,6 @@ class DsnLookupEndpoint(OrganizationEndpoint):
     )
 
     def get(self, request: Request, organization: Organization) -> Response:
-        if not features.has("organizations:cmd-k-dsn-lookup", organization):
-            return Response(status=404)
-
         dsn = request.GET.get("dsn")
         if not dsn:
             return Response({"detail": "Missing required parameter: dsn"}, status=400)

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -513,10 +513,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:traces-overlay-charts-ui", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable feature flag to cache detectors by data source
     manager.add("organizations:cache-detectors-by-data-source", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enables CMD+K supercharged (omni search)
-    manager.add("organizations:cmd-k-supercharged", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
-    # Enables DSN lookup in CMD+K palette
-    manager.add("organizations:cmd-k-dsn-lookup", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Conversation focused views in AI Insights
     manager.add("organizations:gen-ai-conversations", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     manager.add("organizations:on-demand-gen-metrics-deprecation-prefill", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)

--- a/tests/sentry/api/endpoints/test_dsn_lookup.py
+++ b/tests/sentry/api/endpoints/test_dsn_lookup.py
@@ -54,6 +54,5 @@ class DsnLookupEndpointTest(APITestCase):
         self.create_member(user=user_without_access, organization=org, role="member", teams=[])
         self.login_as(user_without_access)
 
-        with self.feature("organizations:cmd-k-dsn-lookup"):
-            response = self.get_response(org.slug, qs_params={"dsn": key.dsn_public})
+        response = self.get_response(org.slug, qs_params={"dsn": key.dsn_public})
         assert response.status_code == 404

--- a/tests/sentry/api/endpoints/test_dsn_lookup.py
+++ b/tests/sentry/api/endpoints/test_dsn_lookup.py
@@ -16,21 +16,18 @@ class DsnLookupEndpointTest(APITestCase):
         self.login_as(self.user)
 
     def test_valid_dsn_returns_project_info(self) -> None:
-        with self.feature("organizations:cmd-k-dsn-lookup"):
-            response = self.get_success_response(self.org.slug, qs_params={"dsn": self.dsn})
+        response = self.get_success_response(self.org.slug, qs_params={"dsn": self.dsn})
         assert response.data["organizationSlug"] == self.org.slug
         assert response.data["projectSlug"] == self.project.slug
         assert response.data["projectId"] == str(self.project.id)
         assert response.data["projectName"] == self.project.name
 
     def test_missing_dsn_param_returns_400(self) -> None:
-        with self.feature("organizations:cmd-k-dsn-lookup"):
-            response = self.get_response(self.org.slug, qs_params={})
+        response = self.get_response(self.org.slug, qs_params={})
         assert response.status_code == 400
 
     def test_invalid_dsn_format_returns_404(self) -> None:
-        with self.feature("organizations:cmd-k-dsn-lookup"):
-            response = self.get_response(self.org.slug, qs_params={"dsn": "not-a-dsn"})
+        response = self.get_response(self.org.slug, qs_params={"dsn": "not-a-dsn"})
         assert response.status_code == 404
 
     def test_dsn_from_other_org_returns_404(self) -> None:
@@ -40,12 +37,7 @@ class DsnLookupEndpointTest(APITestCase):
         other_key = other_project.key_set.first()
         assert other_key is not None
 
-        with self.feature("organizations:cmd-k-dsn-lookup"):
-            response = self.get_response(self.org.slug, qs_params={"dsn": other_key.dsn_public})
-        assert response.status_code == 404
-
-    def test_feature_flag_disabled_returns_404(self) -> None:
-        response = self.get_response(self.org.slug, qs_params={"dsn": self.dsn})
+        response = self.get_response(self.org.slug, qs_params={"dsn": other_key.dsn_public})
         assert response.status_code == 404
 
     def test_user_without_project_access_returns_404(self) -> None:


### PR DESCRIPTION
## Summary
- Remove `cmd-k-supercharged` and `cmd-k-dsn-lookup` feature flag registrations from `temporary.py`
- Remove the `cmd-k-dsn-lookup` feature gate in the DSN lookup endpoint
- Remove feature flag context managers from DSN lookup tests and drop the `test_feature_flag_disabled_returns_404` test

The command palette is now GA — these flags are no longer needed.

## Test plan
- [x] Existing DSN lookup tests pass without feature flag wrappers