### PR TITLE
ref(seer): Move trace routes to stable structured context set

### DIFF
--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -51,12 +51,11 @@ const STRUCTURED_CONTEXT_ROUTES = new Set([
   '/dashboard/:dashboardId/',
   '/dashboard/:dashboardId/widget-builder/widget/new/',
   '/dashboard/:dashboardId/widget-builder/widget/:widgetIndex/edit/',
-]);
-/** New experimental routes where the LLMContext tree provides structured page context. */
-const NEW_STRUCTURED_CONTEXT_ROUTES = new Set<string>([
   '/explore/traces/',
   '/explore/traces/trace/:traceSlug/',
 ]);
+/** New experimental routes where the LLMContext tree provides structured page context. */
+const NEW_STRUCTURED_CONTEXT_ROUTES = new Set<string>();
 
 function supportsStructuredContext(
   referrer: string,


### PR DESCRIPTION
+ The traces explorer and trace detail routes are no longer experimental. Move them from NEW_STRUCTURED_CONTEXT_ROUTES into STRUCTURED_CONTEXT_ROUTES so they use the same seer-explorer-context-engine flag as dashboards. Opens it up to closed beta orgs ~ 450 orgs

