### PR TITLE
ref(cmdk): Remove cmd-k feature flag checks from frontend

### DIFF
--- a/.agents/skills/cmdk-actions/SKILL.md
+++ b/.agents/skills/cmdk-actions/SKILL.md
@@ -5,7 +5,7 @@ description: Guide for adding new actions to Sentry's Command+K palette. Use whe
 
 # Adding Actions to the Command Palette (cmdk)
 
-Sentry's Command+K palette (enabled behind `organizations:cmd-k-supercharged`) is built on a tree-collection system where `CMDKAction` components register themselves via React context. Actions render wherever in the component tree they live — no central registry to update.
+Sentry's Command+K palette is built on a tree-collection system where `CMDKAction` components register themselves via React context. Actions render wherever in the component tree they live — no central registry to update.
 
 ## Core files
 
@@ -509,8 +509,6 @@ function MyFeaturePage() {
 ---
 
 ## Feature Flag and Permission Gates
-
-The new palette only activates when the org has the `cmd-k-supercharged` flag. Actions registered via `CMDKAction` are always safe to render — they simply won't be visible to users without the flag.
 
 Gate on additional flags or permissions inline:
 

--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -283,7 +283,6 @@ export function GlobalCommandPaletteActions() {
       .sort((a, b) => a.title.localeCompare(b.title));
   }, [organization]);
 
-  const hasDsnLookup = organization.features.includes('cmd-k-dsn-lookup');
   const prefix = `/organizations/${organization.slug}`;
   const hasInsightsRollout = organization.features.includes(
     'insights-to-dashboards-ui-rollout'
@@ -762,43 +761,41 @@ export function GlobalCommandPaletteActions() {
       </CMDKAction>
 
       <CMDKAction display={{label: t('DSN')}} keywords={[t('client keys')]}>
-        {hasDsnLookup && (
-          <CMDKAction
-            display={{
-              label: t('Reverse DSN lookup'),
-              details: t(
-                'Paste a DSN into the search bar to find the project it belongs to.'
+        <CMDKAction
+          display={{
+            label: t('Reverse DSN lookup'),
+            details: t(
+              'Paste a DSN into the search bar to find the project it belongs to.'
+            ),
+            icon: <IconSearch />,
+          }}
+          prompt={t('Paste a DSN...')}
+          resource={(query: string): CMDKQueryOptions => {
+            return cmdkQueryOptions({
+              ...apiOptions.as<DsnLookupResponse>()(
+                '/organizations/$organizationIdOrSlug/dsn-lookup/',
+                {
+                  path: {organizationIdOrSlug: organization.slug},
+                  query: {dsn: query},
+                  staleTime: 30_000,
+                }
               ),
-              icon: <IconSearch />,
-            }}
-            prompt={t('Paste a DSN...')}
-            resource={(query: string): CMDKQueryOptions => {
-              return cmdkQueryOptions({
-                ...apiOptions.as<DsnLookupResponse>()(
-                  '/organizations/$organizationIdOrSlug/dsn-lookup/',
-                  {
-                    path: {organizationIdOrSlug: organization.slug},
-                    query: {dsn: query},
-                    staleTime: 30_000,
-                  }
-                ),
-                enabled: DSN_PATTERN.test(query),
-                select: data =>
-                  getDsnNavTargets(data.json).map((target, i) => ({
-                    to: target.to,
-                    display: {
-                      label: target.label,
-                      details: target.description,
-                      icon: DSN_ICONS[i],
-                    },
-                    keywords: [query],
-                  })),
-              });
-            }}
-          >
-            {data => data.map((item, i) => renderAsyncResult(item, i))}
-          </CMDKAction>
-        )}
+              enabled: DSN_PATTERN.test(query),
+              select: data =>
+                getDsnNavTargets(data.json).map((target, i) => ({
+                  to: target.to,
+                  display: {
+                    label: target.label,
+                    details: target.description,
+                    icon: DSN_ICONS[i],
+                  },
+                  keywords: [query],
+                })),
+            });
+          }}
+        >
+          {data => data.map((item, i) => renderAsyncResult(item, i))}
+        </CMDKAction>
       </CMDKAction>
 
       <ResolvedIdentifierCommandPaletteAction />

--- a/static/app/components/search/sources/dsnLookupSource.tsx
+++ b/static/app/components/search/sources/dsnLookupSource.tsx
@@ -16,7 +16,6 @@ type Props = {
 
 export function DsnLookupSource({query, children}: Props) {
   const organization = useOrganization({allowNull: true});
-  const hasDsnLookup = organization?.features?.includes('cmd-k-dsn-lookup') ?? false;
   const isDsn = DSN_PATTERN.test(query);
 
   const {data, isLoading} = useApiQuery<DsnLookupResponse>(
@@ -28,7 +27,7 @@ export function DsnLookupSource({query, children}: Props) {
     ],
     {
       staleTime: 30_000,
-      enabled: isDsn && !!organization && hasDsnLookup,
+      enabled: isDsn && !!organization,
     }
   );
 


### PR DESCRIPTION
## Summary
- Remove `cmd-k-dsn-lookup` feature flag check from `commandPaletteGlobalActions.tsx` (DSN lookup is always rendered)
- Remove `cmd-k-dsn-lookup` feature flag check from `dsnLookupSource.tsx`
- Update `SKILL.md` to remove outdated `cmd-k-supercharged` flag references

The command palette is now GA — these flags are no longer needed.

## Test plan
- [x] DSN lookup in the command palette works without feature flag gates