### PR TITLE
feat(releases): Add activities for auto release resolutions

### DIFF
--- a/src/sentry/models/releases/set_commits.py
+++ b/src/sentry/models/releases/set_commits.py
@@ -7,6 +7,7 @@ from typing import TypedDict
 
 from django.db import IntegrityError, router
 
+from sentry import features
 from sentry.constants import ObjectStatus
 from sentry.db.postgres.transactions import in_test_hide_transaction_boundary
 from sentry.locks import locks
@@ -19,6 +20,7 @@ from sentry.models.groupinbox import GroupInbox, GroupInboxRemoveAction, remove_
 from sentry.models.release import Release
 from sentry.models.releases.exceptions import ReleaseCommitError
 from sentry.signals import issue_resolved
+from sentry.types.activity import ActivityType
 from sentry.users.services.user import RpcUser
 from sentry.utils import metrics
 from sentry.utils.db import atomic_transaction
@@ -228,6 +230,9 @@ def update_group_resolutions(release, commit_author_by_commit):
     user_by_author: dict[CommitAuthor | None, RpcUser | None] = {None: None}
 
     commits_and_prs = list(itertools.chain(commit_group_authors, pull_request_group_authors))
+    create_resolution_activities = features.has(
+        "organizations:defer-commit-resolution", release.organization
+    )
 
     group_project_lookup = dict(
         Group.objects.filter(id__in=[group_id for group_id, _ in commits_and_prs]).values_list(
@@ -252,7 +257,7 @@ def update_group_resolutions(release, commit_author_by_commit):
                 router.db_for_write(Activity),
             )
         ):
-            GroupResolution.objects.update_or_create(
+            resolution, _ = GroupResolution.objects.update_or_create(
                 group_id=group_id,
                 defaults={
                     "release": release,
@@ -262,8 +267,20 @@ def update_group_resolutions(release, commit_author_by_commit):
                 },
             )
             group = Group.objects.get(id=group_id)
+            should_create_resolution_activity = (
+                create_resolution_activities and group.status != GroupStatus.RESOLVED
+            )
             group.update(status=GroupStatus.RESOLVED, substatus=None)
             remove_group_from_inbox(group, action=GroupInboxRemoveAction.RESOLVED, user=actor)
+            if should_create_resolution_activity:
+                Activity.objects.create(
+                    project_id=group.project_id,
+                    group=group,
+                    type=ActivityType.SET_RESOLVED_IN_RELEASE.value,
+                    user_id=actor.id if actor is not None else None,
+                    ident=resolution.id,
+                    data={"version": release.version},
+                )
             record_group_history(group, GroupHistoryStatus.RESOLVED, actor=actor)
 
             metrics.incr("group.resolved", instance="in_commit", skip_internal=True)

--- a/tests/sentry/models/test_pullrequest.py
+++ b/tests/sentry/models/test_pullrequest.py
@@ -140,6 +140,12 @@ class FindReferencedGroupsTest(TestCase):
         assert resolution.release == release
         assert resolution.type == GroupResolution.Type.in_release
         assert resolution.status == GroupResolution.Status.resolved
+        activity = Activity.objects.get(
+            group=group,
+            type=ActivityType.SET_RESOLVED_IN_RELEASE.value,
+        )
+        assert activity.data == {"version": release.version}
+        assert activity.ident == str(resolution.id)
 
     def test_resolve_in_pull_request(self) -> None:
         group = self.create_group()
@@ -170,6 +176,75 @@ class FindReferencedGroupsTest(TestCase):
         # XXX: Oddly,resolved_in_pull_request doesn't update the group status
         group.refresh_from_db()
         assert group.status == GroupStatus.UNRESOLVED
+
+    @with_feature("organizations:defer-commit-resolution")
+    def test_resolve_in_pull_request_resolved_via_release(self) -> None:
+        group = self.create_group()
+        repo = Repository.objects.create(name="example", organization_id=group.organization.id)
+        merge_commit_sha = sha1(uuid4().hex.encode("utf-8")).hexdigest()
+
+        pr = PullRequest.objects.create(
+            key="1",
+            repository_id=repo.id,
+            organization_id=group.organization.id,
+            title="very cool PR to fix the thing",
+            message=f"Foo Biz\n\nFixes {group.qualified_short_id}",
+            merge_commit_sha=merge_commit_sha,
+        )
+
+        assert GroupLink.objects.filter(
+            group=group,
+            linked_type=GroupLink.LinkedType.pull_request,
+            linked_id=pr.id,
+        ).exists()
+        group.refresh_from_db()
+        assert group.status == GroupStatus.UNRESOLVED
+
+        release = self.create_release(project=group.project, version="1.0.0")
+        release.set_commits([{"id": merge_commit_sha, "repository": repo.name}])
+
+        group.refresh_from_db()
+        assert group.status == GroupStatus.RESOLVED
+        resolution = GroupResolution.objects.get(group=group)
+        assert resolution.release == release
+        assert resolution.type == GroupResolution.Type.in_release
+        assert resolution.status == GroupResolution.Status.resolved
+        activity = Activity.objects.get(
+            group=group,
+            type=ActivityType.SET_RESOLVED_IN_RELEASE.value,
+        )
+        assert activity.data == {"version": release.version}
+        assert activity.ident == str(resolution.id)
+
+    def test_resolve_in_pull_request_resolved_via_release_with_defer_flag_off(self) -> None:
+        group = self.create_group()
+        repo = Repository.objects.create(name="example", organization_id=group.organization.id)
+        merge_commit_sha = sha1(uuid4().hex.encode("utf-8")).hexdigest()
+
+        PullRequest.objects.create(
+            key="1",
+            repository_id=repo.id,
+            organization_id=group.organization.id,
+            title="very cool PR to fix the thing",
+            message=f"Foo Biz\n\nFixes {group.qualified_short_id}",
+            merge_commit_sha=merge_commit_sha,
+        )
+
+        release = self.create_release(project=group.project, version="1.0.0")
+        release.set_commits([{"id": merge_commit_sha, "repository": repo.name}])
+
+        group.refresh_from_db()
+        assert group.status == GroupStatus.RESOLVED
+        assert GroupResolution.objects.filter(
+            group=group,
+            release=release,
+            type=GroupResolution.Type.in_release,
+            status=GroupResolution.Status.resolved,
+        ).exists()
+        assert not Activity.objects.filter(
+            group=group,
+            type=ActivityType.SET_RESOLVED_IN_RELEASE.value,
+        ).exists()
 
 
 class PullRequestRetentionTest(TestCase):


### PR DESCRIPTION
Create a visible resolved-in-release activity when release commit processing actually transitions an issue to resolved through deferred commit or pull request links. This is gated behind `organizations:defer-commit-resolution`, so the old release resolver behavior is unchanged while the commit-resolution rollout flag is off.

**Release Resolution Activity**

When the flag is enabled, `update_group_resolutions()` records `SET_RESOLVED_IN_RELEASE` with the resolving release version only if the group was not already resolved. The existing group status update behavior is otherwise unchanged.

**Covered Paths**

Tests cover deferred commit references, pull requests resolved by merge commit with the flag enabled, and the flag-off pull request path where the issue still resolves without creating the new activity.