### PR TITLE
fix(aci): Surface API error detail in edit form save toast

### DIFF
--- a/static/app/views/detectors/edit.spec.tsx
+++ b/static/app/views/detectors/edit.spec.tsx
@@ -17,6 +17,7 @@ import {
   within,
 } from 'sentry-test/reactTestingLibrary';
 
+import * as indicators from 'sentry/actionCreators/indicator';
 import {OrganizationStore} from 'sentry/stores/organizationStore';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {
@@ -254,6 +255,33 @@ describe('DetectorEdit', () => {
       await waitFor(() => {
         expect(router.location.pathname).toBe(
           `/organizations/${organization.slug}/monitors/1/`
+        );
+      });
+    });
+
+    it('displays error response detail in a toast when save fails', async () => {
+      const mockAddErrorMessage = jest.spyOn(indicators, 'addErrorMessage');
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/detectors/${mockDetector.id}/`,
+        body: mockDetector,
+      });
+
+      MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/detectors/${mockDetector.id}/`,
+        method: 'PUT',
+        statusCode: 403,
+        body: {detail: 'You do not have permission to perform this action.'},
+      });
+
+      render(<DetectorEdit />, {organization, initialRouterConfig});
+
+      expect(await screen.findByRole('link', {name})).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', {name: 'Save'}));
+
+      await waitFor(() => {
+        expect(mockAddErrorMessage).toHaveBeenCalledWith(
+          'You do not have permission to perform this action.'
         );
       });
     });

--- a/static/app/views/detectors/hooks/useEditDetectorFormSubmit.tsx
+++ b/static/app/views/detectors/hooks/useEditDetectorFormSubmit.tsx
@@ -2,12 +2,14 @@ import {useCallback} from 'react';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import type {OnSubmitCallback} from 'sentry/components/forms/types';
+import {getWorkflowEngineResponseErrorMessage} from 'sentry/components/workflowEngine/getWorkflowEngineResponseErrorMessage';
 import {t} from 'sentry/locale';
 import type {
   BaseDetectorUpdatePayload,
   Detector,
 } from 'sentry/types/workflowEngine/detectors';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {RequestError} from 'sentry/utils/requestError/requestError';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {getDetectorAnalyticsPayload} from 'sentry/views/detectors/components/forms/common/getDetectorAnalyticsPayload';
@@ -75,7 +77,11 @@ export function useEditDetectorFormSubmit<
 
         onSubmitSuccess?.(resultDetector);
       } catch (error) {
-        addErrorMessage(t('Unable to update monitor'));
+        addErrorMessage(
+          (error instanceof RequestError
+            ? getWorkflowEngineResponseErrorMessage(error.responseJSON)
+            : null) ?? t('Unable to update monitor')
+        );
 
         if (onError) {
           onError(error);

--- a/static/app/views/detectors/hooks/useSubmitEditDetector.tsx
+++ b/static/app/views/detectors/hooks/useSubmitEditDetector.tsx
@@ -1,12 +1,14 @@
 import {useCallback} from 'react';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
+import {getWorkflowEngineResponseErrorMessage} from 'sentry/components/workflowEngine/getWorkflowEngineResponseErrorMessage';
 import {t} from 'sentry/locale';
 import type {
   BaseDetectorUpdatePayload,
   Detector,
 } from 'sentry/types/workflowEngine/detectors';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {RequestError} from 'sentry/utils/requestError/requestError';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {getDetectorAnalyticsPayload} from 'sentry/views/detectors/components/forms/common/getDetectorAnalyticsPayload';
@@ -53,7 +55,11 @@ export function useSubmitEditDetector<TDetector extends Detector>({
 
         return resultDetector;
       } catch (error) {
-        addErrorMessage(t('Unable to update monitor'));
+        addErrorMessage(
+          (error instanceof RequestError
+            ? getWorkflowEngineResponseErrorMessage(error.responseJSON)
+            : null) ?? t('Unable to update monitor')
+        );
         onError?.(error);
         return undefined;
       }


### PR DESCRIPTION
The edit detector form was always showing a generic "Unable to update monitor" toast when saving failed. We have a util that extracts a useful error message, we just weren't using it. 

Made the change for both the new and old form logic, but the old one will be gone soon