### PR TITLE
ref(preprod): Update snapshot list framing

### DIFF
--- a/static/app/views/preprod/snapshots/main/snapshotCards.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.snapshots.tsx
@@ -359,7 +359,6 @@ describe('SnapshotCards', () => {
             image={headImage}
             cardType="added"
             imageBaseUrl={imageBaseUrl}
-            headBranch="Current Branch"
             isSelected
             copyUrl={copyUrl}
             snapshotKey="button-light-added"
@@ -379,7 +378,6 @@ describe('SnapshotCards', () => {
             image={baseImage}
             cardType="removed"
             imageBaseUrl={imageBaseUrl}
-            headBranch="Current Branch"
             isSelected={false}
             copyUrl={copyUrl}
             snapshotKey="button-light-removed"

--- a/static/app/views/preprod/snapshots/main/snapshotCards.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.tsx
@@ -207,11 +207,7 @@ export const ImageCard = memo(function ImageCard({
           showBottomBorder={false}
         />
         <Container padding="0 xl xl">
-          <ImageColumn
-            src={imageUrl}
-            alt={getImageName(image)}
-            image={image}
-          />
+          <ImageColumn src={imageUrl} alt={getImageName(image)} image={image} />
         </Container>
       </SnapshotVariantFrame>
     </DarkAware>

--- a/static/app/views/preprod/snapshots/main/snapshotCards.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.tsx
@@ -28,6 +28,7 @@ import {
   SplitPairBody,
   WipeCardBody,
 } from './snapshotDiffBodies';
+import {SnapshotCanvasWrapper, SnapshotVariantFrame} from './snapshotFrames';
 
 export function DarkAware({
   isDark,
@@ -87,17 +88,19 @@ export const PairCard = memo(function PairCard({
   let body: React.ReactNode;
   if (effectiveMode === 'split') {
     body = (
-      <SplitPairBody
-        baseUrl={baseUrl}
-        headUrl={headUrl}
-        baseImage={pair.base_image}
-        headImage={image}
-        headLabel={headBranch ?? t('Head')}
-        altPrefix={getImageName(image)}
-        overlayColor={cardType === 'changed' ? overlayColor : undefined}
-        diffImageKey={cardType === 'changed' ? pair.diff_image_key : null}
-        diffImageBaseUrl={diffImageBaseUrl}
-      />
+      <SnapshotCanvasWrapper>
+        <SplitPairBody
+          baseUrl={baseUrl}
+          headUrl={headUrl}
+          baseImage={pair.base_image}
+          headImage={image}
+          headLabel={headBranch ?? t('Head')}
+          altPrefix={getImageName(image)}
+          overlayColor={cardType === 'changed' ? overlayColor : undefined}
+          diffImageKey={cardType === 'changed' ? pair.diff_image_key : null}
+          diffImageBaseUrl={diffImageBaseUrl}
+        />
+      </SnapshotCanvasWrapper>
     );
   } else if (effectiveMode === 'wipe') {
     body = (
@@ -121,8 +124,7 @@ export const PairCard = memo(function PairCard({
 
   return (
     <DarkAware isDark={isDark}>
-      <Card
-        isDark={isDark}
+      <SnapshotVariantFrame
         isSelected={isSelected}
         data-snapshot-key={snapshotKey}
         onClick={e => e.stopPropagation()}
@@ -139,9 +141,10 @@ export const PairCard = memo(function PairCard({
           onSelect={handleSelect}
           onDoubleClick={handleOpen}
           isSelected={isSelected}
+          showBottomBorder={false}
         />
-        {body}
-      </Card>
+        <Container padding="0 xl xl">{body}</Container>
+      </SnapshotVariantFrame>
     </DarkAware>
   );
 });
@@ -150,7 +153,6 @@ export const ImageCard = memo(function ImageCard({
   image,
   cardType,
   imageBaseUrl,
-  headBranch,
   isSelected,
   copyUrl,
   snapshotKey,
@@ -163,7 +165,6 @@ export const ImageCard = memo(function ImageCard({
   imageBaseUrl: string;
   isSelected: boolean;
   snapshotKey: string;
-  headBranch?: string | null;
   onOpenSnapshot?: (key: string) => void;
   onSelectSnapshot?: (key: string | null) => void;
 }) {
@@ -180,7 +181,6 @@ export const ImageCard = memo(function ImageCard({
     status = DiffStatus.UNCHANGED;
   }
 
-  const label = headBranch ? (cardType === 'removed' ? t('Base') : headBranch) : null;
   const handleSelect = onSelectSnapshot
     ? () => onSelectSnapshot(isSelected ? null : snapshotKey)
     : undefined;
@@ -188,8 +188,7 @@ export const ImageCard = memo(function ImageCard({
 
   return (
     <DarkAware isDark={isDark}>
-      <Card
-        isDark={isDark}
+      <SnapshotVariantFrame
         isSelected={isSelected}
         data-snapshot-key={snapshotKey}
         onClick={e => e.stopPropagation()}
@@ -205,14 +204,16 @@ export const ImageCard = memo(function ImageCard({
           onSelect={handleSelect}
           onDoubleClick={handleOpen}
           isSelected={isSelected}
+          showBottomBorder={false}
         />
-        <ImageColumn
-          label={label}
-          src={imageUrl}
-          alt={getImageName(image)}
-          image={image}
-        />
-      </Card>
+        <Container padding="0 xl xl">
+          <ImageColumn
+            src={imageUrl}
+            alt={getImageName(image)}
+            image={image}
+          />
+        </Container>
+      </SnapshotVariantFrame>
     </DarkAware>
   );
 });
@@ -229,6 +230,7 @@ export const CardHeader = memo(function CardHeader({
   onSelect,
   onDoubleClick,
   isSelected,
+  showBottomBorder = true,
 }: {
   copyData: unknown;
   copyUrl: string;
@@ -240,6 +242,7 @@ export const CardHeader = memo(function CardHeader({
   isSelected?: boolean;
   onDoubleClick?: () => void;
   onSelect?: () => void;
+  showBottomBorder?: boolean;
   status?: DiffStatus | null;
 }) {
   const {copy} = useCopyToClipboard();
@@ -262,6 +265,7 @@ export const CardHeader = memo(function CardHeader({
       tabIndex={onSelect ? 0 : undefined}
       aria-pressed={onSelect ? isSelected : undefined}
       isInteractive={!!onSelect}
+      $showBottomBorder={showBottomBorder}
     >
       <Stack gap="xs" minWidth="0" flex="1">
         {displayName ? (
@@ -406,13 +410,17 @@ export const Card = styled(Container)<{isDark: boolean; isSelected: boolean}>`
   ${p => p.isDark && `color-scheme: dark;`}
 `;
 
-const CardHeaderRow = styled('div')<{isInteractive?: boolean}>`
+const CardHeaderRow = styled('div')<{
+  $showBottomBorder?: boolean;
+  isInteractive?: boolean;
+}>`
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: ${p => p.theme.space.md};
   padding: ${p => p.theme.space.lg} ${p => p.theme.space.xl};
-  border-bottom: 1px solid ${p => p.theme.tokens.border.secondary};
+  border-bottom: ${p =>
+    p.$showBottomBorder ? `1px solid ${p.theme.tokens.border.secondary}` : 0};
   ${p =>
     p.isInteractive &&
     `

--- a/static/app/views/preprod/snapshots/main/snapshotDiffBodies.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotDiffBodies.tsx
@@ -48,7 +48,7 @@ export const SplitPairBody = memo(function SplitPairBody({
     <Container position="relative">
       <Grid columns="1fr 1fr" gap="0">
         <Stack minWidth="0">
-          <Container padding="sm xl" borderBottom="secondary">
+          <Container padding="sm xl">
             <Text size="xs" variant="muted" ellipsis monospace>
               {t('Base')}
             </Text>
@@ -65,7 +65,7 @@ export const SplitPairBody = memo(function SplitPairBody({
           </ZoomViewport>
         </Stack>
         <Stack minWidth="0" borderLeft="secondary">
-          <Container padding="sm xl" borderBottom="secondary">
+          <Container padding="sm xl">
             <Text size="xs" variant="muted" ellipsis monospace>
               {headLabel}
             </Text>
@@ -100,7 +100,6 @@ export const SplitPairBody = memo(function SplitPairBody({
 });
 
 export const ImageColumn = memo(function ImageColumn({
-  label,
   src,
   alt,
   image,
@@ -113,7 +112,6 @@ export const ImageColumn = memo(function ImageColumn({
   src: string;
   diffImageBaseUrl?: string;
   diffImageKey?: string | null;
-  label?: string | null;
   overlayColor?: string;
 }) {
   const hasVisibleOverlay = !!overlayColor && overlayColor !== 'transparent';
@@ -123,14 +121,7 @@ export const ImageColumn = memo(function ImageColumn({
       : null;
   return (
     <Stack minWidth="0">
-      {label && (
-        <Container padding="sm xl" borderBottom="secondary">
-          <Text size="xs" variant="muted" ellipsis monospace>
-            {label}
-          </Text>
-        </Container>
-      )}
-      <Flex justify="center" padding="xl">
+      <Flex justify="center">
         <LazyImage
           src={src}
           alt={alt}
@@ -168,7 +159,7 @@ export const WipeCardBody = memo(function WipeCardBody({
     ? `${Math.min(Math.max(naturalHeight, WIPE_MIN_HEIGHT), MAX_IMAGE_HEIGHT)}px`
     : `${WIPE_MIN_HEIGHT}px`;
   return (
-    <Flex padding="xl">
+    <Flex>
       <ContentSliderDiff.Body
         before={
           <Flex justify="center" align="center" width="100%" height="100%">
@@ -226,7 +217,7 @@ export const OnionCardBody = memo(function OnionCardBody({
     height: maxH ? `${((headImage.height || 0) / maxH) * 100}%` : '100%',
   };
   return (
-    <Flex direction="column" gap="md" padding="lg" align="center">
+    <Flex direction="column" gap="md" align="center">
       <Container
         position="relative"
         width="100%"

--- a/static/app/views/preprod/snapshots/main/snapshotFrames.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotFrames.tsx
@@ -1,0 +1,77 @@
+import {useTheme} from '@emotion/react';
+import styled from '@emotion/styled';
+
+import {Container, Stack} from '@sentry/scraps/layout';
+import {Heading} from '@sentry/scraps/text';
+
+export function SnapshotCardFrame({
+  children,
+  groupName,
+}: {
+  children: React.ReactNode;
+  groupName?: string | null;
+}) {
+  return (
+    <Stack
+      gap="0"
+      width="100%"
+      background="primary"
+      border="primary"
+      radius="md"
+      overflow="hidden"
+    >
+      {groupName ? <SnapshotGroupHeader name={groupName} /> : null}
+      {children}
+    </Stack>
+  );
+}
+
+export function SnapshotGroupHeader({name}: {name: string}) {
+  return (
+    <Container padding="lg xl" borderBottom="secondary">
+      <Heading as="h3" size="md">
+        {name}
+      </Heading>
+    </Container>
+  );
+}
+
+export function SnapshotVariantFrame({
+  children,
+  isSelected,
+  ...props
+}: {
+  children: React.ReactNode;
+  isSelected?: boolean;
+} & React.HTMLAttributes<HTMLDivElement>) {
+  const theme = useTheme();
+  return (
+    <SnapshotVariantContainer position="relative" background="primary" {...props}>
+      {children}
+      {isSelected ? (
+        <Container
+          position="absolute"
+          inset={0}
+          pointerEvents="none"
+          style={{
+            border: `1px solid ${theme.tokens.border.accent.vibrant}`,
+          }}
+        />
+      ) : null}
+    </SnapshotVariantContainer>
+  );
+}
+
+export function SnapshotCanvasWrapper({children}: {children: React.ReactNode}) {
+  return (
+    <Container background="secondary" border="primary" radius="sm" overflow="hidden">
+      {children}
+    </Container>
+  );
+}
+
+const SnapshotVariantContainer = styled(Container)`
+  &:not(:last-child) {
+    border-bottom: 1px solid ${p => p.theme.tokens.border.secondary};
+  }
+`;

--- a/static/app/views/preprod/snapshots/main/snapshotFrames.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotFrames.tsx
@@ -26,7 +26,7 @@ export function SnapshotCardFrame({
   );
 }
 
-export function SnapshotGroupHeader({name}: {name: string}) {
+function SnapshotGroupHeader({name}: {name: string}) {
   return (
     <Container padding="lg xl" borderBottom="secondary">
       <Heading as="h3" size="md">

--- a/static/app/views/preprod/snapshots/main/snapshotListView.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.tsx
@@ -2,7 +2,7 @@ import {memo, useEffect, useMemo, useRef} from 'react';
 import styled from '@emotion/styled';
 import {useVirtualizer} from '@tanstack/react-virtual';
 
-import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Container, Flex} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {t} from 'sentry/locale';
@@ -15,6 +15,7 @@ import type {
 import type {DiffMode} from './imageDisplay/diffImageDisplay';
 import {ImageCard, PairCard} from './snapshotCards';
 import {MAX_IMAGE_HEIGHT} from './snapshotDiffBodies';
+import {SnapshotCardFrame} from './snapshotFrames';
 
 interface SnapshotListViewProps {
   imageBaseUrl: string;
@@ -66,8 +67,8 @@ interface GroupRow {
 
 const HEADER_HEIGHT = 44;
 const CARD_CHROME_HEIGHT = 120;
-const CARD_GAP = 16;
-const GROUP_PADDING = 32;
+const CARD_GAP = 0;
+const GROUP_PADDING = 0;
 const ROW_PADDING_BOTTOM = 16;
 const LIST_CONTENT_WIDTH_ASSUMPTION = 900;
 
@@ -407,15 +408,10 @@ const GroupContainer = memo(function GroupContainer({
     );
   });
 
-  if (group.isUngrouped) {
-    return <Stack gap="md">{cards}</Stack>;
-  }
-
   return (
-    <Stack background="primary" border="primary" radius="md" padding="lg" gap="md">
-      <GroupHeader name={group.name} />
-      <Stack gap="md">{cards}</Stack>
-    </Stack>
+    <SnapshotCardFrame groupName={group.isUngrouped ? null : group.name}>
+      {cards}
+    </SnapshotCardFrame>
   );
 });
 


### PR DESCRIPTION
Refactor the preprod snapshots list so grouped and ungrouped variants share the same parent frame and align more closely with the target Figma layout. This keeps focused view behavior unchanged while setting up the shared framing needed for the follow-up focus-view refactor.

**List Frame Layout**

Snapshot groups now render through shared group and variant frame primitives. Group headers are contained rows with bottom borders, ungrouped snapshots still get the same parent container, and sibling variants are separated by full-width borders instead of old card gaps.

**Split View Canvas**

Split diff mode now wraps the base/head columns in a canvas with secondary background and primary border. Branch labels sit at the top of the canvas without their previous bottom border.