### PR TITLE
fix(snapshots): Hide diff overlay while image loads and deduplicate computeMaskSize

### DIFF
--- a/static/app/views/preprod/snapshots/main/computeMaskSize.tsx
+++ b/static/app/views/preprod/snapshots/main/computeMaskSize.tsx
@@ -1,0 +1,15 @@
+import type {SnapshotImage} from 'sentry/views/preprod/types/snapshotTypes';
+
+export function computeMaskSize(
+  baseImage: SnapshotImage,
+  headImage: SnapshotImage
+): string {
+  const headW = headImage.width;
+  const headH = headImage.height;
+  if (!headW || !headH) {
+    return '100% 100%';
+  }
+  const maskW = Math.max(baseImage.width || headW, headW);
+  const maskH = Math.max(baseImage.height || headH, headH);
+  return `${(maskW / headW) * 100}% ${(maskH / headH) * 100}%`;
+}

--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -8,6 +8,7 @@ import {Heading, Text} from '@sentry/scraps/text';
 
 import {ContentSliderDiff} from 'sentry/components/contentSliderDiff';
 import {t} from 'sentry/locale';
+import {computeMaskSize} from 'sentry/views/preprod/snapshots/main/computeMaskSize';
 import type {SnapshotDiffPair} from 'sentry/views/preprod/types/snapshotTypes';
 
 import {useBufferedImageGroup} from './useBufferedImageUrl';
@@ -21,20 +22,6 @@ import {
 } from './zoomControls';
 
 export type DiffMode = 'split' | 'wipe' | 'onion';
-
-function computeMaskSize(
-  baseImage: SnapshotDiffPair['base_image'],
-  headImage: SnapshotDiffPair['head_image']
-): string {
-  const headW = headImage.width;
-  const headH = headImage.height;
-  if (!headW || !headH) {
-    return '100% 100%';
-  }
-  const maskW = Math.max(baseImage.width || headW, headW);
-  const maskH = Math.max(baseImage.height || headH, headH);
-  return `${(maskW / headW) * 100}% ${(maskH / headH) * 100}%`;
-}
 
 export const TRANSPARENT_COLOR = 'transparent';
 

--- a/static/app/views/preprod/snapshots/main/snapshotDiffBodies.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotDiffBodies.tsx
@@ -13,19 +13,9 @@ import {getImageName} from 'sentry/views/preprod/types/snapshotTypes';
 
 import {useSyncedD3Zoom} from './imageDisplay/useD3Zoom';
 import {ZoomControls, zoomTransformStyle} from './imageDisplay/zoomControls';
+import {computeMaskSize} from './computeMaskSize';
 
 export const MAX_IMAGE_HEIGHT = 480;
-
-function computeMaskSize(baseImage: SnapshotImage, headImage: SnapshotImage): string {
-  const headW = headImage.width;
-  const headH = headImage.height;
-  if (!headW || !headH) {
-    return '100% 100%';
-  }
-  const maskW = Math.max(baseImage.width || headW, headW);
-  const maskH = Math.max(baseImage.height || headH, headH);
-  return `${(maskW / headW) * 100}% ${(maskH / headH) * 100}%`;
-}
 
 export const SplitPairBody = memo(function SplitPairBody({
   baseUrl,
@@ -328,7 +318,7 @@ function LazyImage({
         onError={onError}
         style={loaded ? undefined : {position: 'absolute', top: 0, left: 0, opacity: 0}}
       />
-      {children}
+      {loaded && children}
     </Container>
   );
 }


### PR DESCRIPTION
Addresses two bot review comments from #114432 that landed after merge:

**DiffOverlay visible during image loading** — `LazyImage` rendered its `children` unconditionally, so the `DiffOverlay` would appear on top of the placeholder skeleton before the actual image loaded. Now children only render once the image has fully loaded (`{loaded && children}`).

**Duplicated `computeMaskSize`** — The same function existed in both `diffImageDisplay.tsx` and `snapshotDiffBodies.tsx`. Extracted it into a shared `computeMaskSize.tsx` module that both files import from.

Follows up on:
- https://github.com/getsentry/sentry/pull/114432#discussion_r3169646950
- https://github.com/getsentry/sentry/pull/114432#discussion_r3169669433