### PR TITLE
fix(seer): Pre-filter night-shift schedule by SeerProjectRepository

### DIFF
--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -81,7 +81,7 @@ class SeerNightShiftRunOptionsPartial(TypedDict, total=False):
 @instrumented_task(
     name="sentry.tasks.seer.night_shift.schedule_night_shift",
     namespace=seer_tasks,
-    processing_deadline_duration=15 * 60,
+    processing_deadline_duration=30 * 60,
 )
 def schedule_night_shift(**kwargs: Any) -> None:
     """

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -21,6 +21,7 @@ from sentry.seer.autofix.constants import (
 from sentry.seer.autofix.issue_summary import referrer_map
 from sentry.seer.autofix.utils import AutofixStoppingPoint, bulk_read_preferences_from_sentry_db
 from sentry.seer.models.night_shift import SeerNightShiftRun, SeerNightShiftRunIssue
+from sentry.seer.models.project_repository import SeerProjectRepository
 from sentry.tasks.base import instrumented_task
 from sentry.tasks.seer.night_shift.agentic_triage import agentic_triage_strategy
 from sentry.tasks.seer.night_shift.models import TriageAction, TriageResult
@@ -84,29 +85,36 @@ class SeerNightShiftRunOptionsPartial(TypedDict, total=False):
 )
 def schedule_night_shift(**kwargs: Any) -> None:
     """
-    Nightly scheduler: iterates active orgs in batches, checks feature flags
-    in bulk, and dispatches per-org worker tasks with jitter.
+    Nightly scheduler: collects org ids that have a Seer-connected repo, then
+    dispatches per-org worker tasks in batches with jitter. Feature flags
+    still gate the dispatch — SeerProjectRepository rows can outlive a paid
+    Seer subscription.
     """
     if not options.get("seer.night_shift.enable"):
         return
 
+    seer_org_ids: set[int] = set()
+    for spr in RangeQuerySetWrapper[SeerProjectRepository](
+        SeerProjectRepository.objects.filter(project__status=ObjectStatus.ACTIVE).select_related(
+            "project"
+        ),
+        step=1000,
+    ):
+        seer_org_ids.add(spr.project.organization_id)
+
     spread_seconds = int(NIGHT_SHIFT_SPREAD_DURATION.total_seconds())
     batch_index = 0
 
-    for org_batch in chunked(
-        RangeQuerySetWrapper[Organization](
-            Organization.objects.filter(status=OrganizationStatus.ACTIVE),
-            step=1000,
-        ),
-        100,
-    ):
+    for org_id_chunk in chunked(seer_org_ids, 100):
+        org_batch = list(
+            Organization.objects.filter(
+                id__in=list(org_id_chunk),
+                status=OrganizationStatus.ACTIVE,
+            )
+        )
         for org in _get_eligible_orgs_from_batch(org_batch):
             delay = (batch_index * NIGHT_SHIFT_DISPATCH_STEP_SECONDS) % spread_seconds
-
-            run_night_shift_for_org.apply_async(
-                args=[org.id],
-                countdown=delay,
-            )
+            run_night_shift_for_org.apply_async(args=[org.id], countdown=delay)
             batch_index += 1
 
     sentry_sdk.metrics.count("night_shift.orgs_dispatched", batch_index)

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -81,7 +81,7 @@ class SeerNightShiftRunOptionsPartial(TypedDict, total=False):
 @instrumented_task(
     name="sentry.tasks.seer.night_shift.schedule_night_shift",
     namespace=seer_tasks,
-    processing_deadline_duration=30 * 60,
+    processing_deadline_duration=15 * 60,
 )
 def schedule_night_shift(**kwargs: Any) -> None:
     """

--- a/tests/sentry/tasks/seer/test_night_shift.py
+++ b/tests/sentry/tasks/seer/test_night_shift.py
@@ -53,6 +53,14 @@ class FakeExplorerClient:
 
 @django_db_all
 class TestScheduleNightShift(TestCase):
+    def create_org_with_seer(self):
+        """Create an org with a SeerProjectRepository so it survives the pre-filter."""
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        repo = self.create_repo(project=project, provider="github", name=f"owner/{project.slug}")
+        SeerProjectRepository.objects.create(project=project, repository=repo)
+        return org
+
     def test_disabled_by_option(self) -> None:
         with (
             self.options({"seer.night_shift.enable": False}),
@@ -62,7 +70,7 @@ class TestScheduleNightShift(TestCase):
             mock_worker.apply_async.assert_not_called()
 
     def test_dispatches_eligible_orgs(self) -> None:
-        org = self.create_organization()
+        org = self.create_org_with_seer()
 
         with (
             self.options({"seer.night_shift.enable": True}),
@@ -80,7 +88,7 @@ class TestScheduleNightShift(TestCase):
             assert mock_worker.apply_async.call_args.kwargs["args"] == [org.id]
 
     def test_skips_orgs_without_seat_based_seer(self) -> None:
-        org = self.create_organization()
+        org = self.create_org_with_seer()
 
         with (
             self.options({"seer.night_shift.enable": True}),
@@ -97,7 +105,7 @@ class TestScheduleNightShift(TestCase):
             mock_worker.apply_async.assert_not_called()
 
     def test_skips_orgs_with_hidden_ai(self) -> None:
-        org = self.create_organization()
+        org = self.create_org_with_seer()
         org.update_option("sentry:hide_ai_features", True)
 
         with (
@@ -113,6 +121,29 @@ class TestScheduleNightShift(TestCase):
         ):
             schedule_night_shift()
             mock_worker.apply_async.assert_not_called()
+
+    def test_skips_orgs_without_seer_project_repository(self) -> None:
+        # Orgs that have never connected a Seer repo are pre-filtered before
+        # the feature flag fanout — even if they happen to have all the flags.
+        org = self.create_organization()
+
+        with (
+            self.options({"seer.night_shift.enable": True}),
+            self.feature(
+                {
+                    "organizations:seer-night-shift": [org.slug],
+                    "organizations:gen-ai-features": [org.slug],
+                    "organizations:seat-based-seer-enabled": [org.slug],
+                }
+            ),
+            patch("sentry.tasks.seer.night_shift.cron.run_night_shift_for_org") as mock_worker,
+            patch(
+                "sentry.tasks.seer.night_shift.cron.features.batch_has_for_organizations"
+            ) as mock_batch_has,
+        ):
+            schedule_night_shift()
+            mock_worker.apply_async.assert_not_called()
+            mock_batch_has.assert_not_called()
 
 
 @django_db_all


### PR DESCRIPTION
The daily `schedule_night_shift` cron was iterating every active org and running a 3-feature `batch_has_for_organizations` check against each one, which fans out a per-org subscription RPC inside the flagpole evaluator. The fanout exceeded the 15-minute task deadline, so the cron never reached `schedule_complete` and never dispatched any per-org workers.

Restrict the candidate set up front to orgs that have at least one project with a `SeerProjectRepository` — the prerequisite for any night-shift work — then run the existing feature flag gate over that much smaller set. Repo rows can outlive a paid Seer subscription, so the feature flag check stays.

Fixes SENTRY-5NQ2