### PR TITLE
fix(automations): Hide value input for is set/not set match types

### DIFF
--- a/static/app/views/automations/components/actionFilters/eventAttribute.tsx
+++ b/static/app/views/automations/components/actionFilters/eventAttribute.tsx
@@ -6,23 +6,45 @@ import type {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
 import {
   Attribute,
   MATCH_CHOICES,
-  type MatchType,
+  MatchType,
 } from 'sentry/views/automations/components/actionFilters/constants';
 import {useAutomationBuilderErrorContext} from 'sentry/views/automations/components/automationBuilderErrorContext';
 import type {ValidateDataConditionProps} from 'sentry/views/automations/components/automationFormData';
 import {useDataConditionNodeContext} from 'sentry/views/automations/components/dataConditionNodes';
 
+function matchRequiresValue(match: MatchType): boolean {
+  return match !== MatchType.IS_SET && match !== MatchType.NOT_SET;
+}
+
 export function EventAttributeDetails({condition}: {condition: DataCondition}) {
+  const matchLabel =
+    MATCH_CHOICES.find(choice => choice.value === condition.comparison.match)?.label ||
+    condition.comparison.match;
+
+  if (!matchRequiresValue(condition.comparison.match)) {
+    return tct("The event's [attribute] attribute [match]", {
+      attribute: condition.comparison.attribute,
+      match: matchLabel,
+    });
+  }
+
   return tct("The event's [attribute] attribute [match] [value]", {
     attribute: condition.comparison.attribute,
-    match:
-      MATCH_CHOICES.find(choice => choice.value === condition.comparison.match)?.label ||
-      condition.comparison.match,
+    match: matchLabel,
     value: condition.comparison.value,
   });
 }
 
 export function EventAttributeNode() {
+  const {condition} = useDataConditionNodeContext();
+
+  if (!matchRequiresValue(condition.comparison.match)) {
+    return tct("The event's [attribute] attribute [match]", {
+      attribute: <AttributeField />,
+      match: <MatchField />,
+    });
+  }
+
   return tct("The event's [attribute] attribute [match] [value]", {
     attribute: <AttributeField />,
     match: <MatchField />,
@@ -58,7 +80,12 @@ function MatchField() {
       value={condition.comparison.match}
       options={MATCH_CHOICES}
       onChange={(option: SelectValue<MatchType>) => {
-        onUpdate({comparison: {...condition.comparison, match: option.value}});
+        const {value: _value, ...rest} = condition.comparison;
+        if (matchRequiresValue(option.value)) {
+          onUpdate({comparison: {...condition.comparison, match: option.value}});
+        } else {
+          onUpdate({comparison: {...rest, match: option.value}});
+        }
       }}
     />
   );
@@ -85,11 +112,10 @@ function ValueField() {
 export function validateEventAttributeCondition({
   condition,
 }: ValidateDataConditionProps): string | undefined {
-  if (
-    !condition.comparison.attribute ||
-    !condition.comparison.match ||
-    !condition.comparison.value
-  ) {
+  if (!condition.comparison.attribute || !condition.comparison.match) {
+    return t('Ensure all fields are filled in.');
+  }
+  if (matchRequiresValue(condition.comparison.match) && !condition.comparison.value) {
     return t('Ensure all fields are filled in.');
   }
   return undefined;

--- a/static/app/views/automations/components/actionFilters/taggedEvent.tsx
+++ b/static/app/views/automations/components/actionFilters/taggedEvent.tsx
@@ -11,23 +11,45 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {Dataset} from 'sentry/views/alerts/rules/metric/types';
 import {
   MATCH_CHOICES,
-  type MatchType,
+  MatchType,
 } from 'sentry/views/automations/components/actionFilters/constants';
 import {useAutomationBuilderErrorContext} from 'sentry/views/automations/components/automationBuilderErrorContext';
 import type {ValidateDataConditionProps} from 'sentry/views/automations/components/automationFormData';
 import {useDataConditionNodeContext} from 'sentry/views/automations/components/dataConditionNodes';
 
+function matchRequiresValue(match: MatchType): boolean {
+  return match !== MatchType.IS_SET && match !== MatchType.NOT_SET;
+}
+
 export function TaggedEventDetails({condition}: {condition: DataCondition}) {
+  const matchLabel =
+    MATCH_CHOICES.find(choice => choice.value === condition.comparison.match)?.label ||
+    condition.comparison.match;
+
+  if (!matchRequiresValue(condition.comparison.match)) {
+    return tct("The event's [key] tag [match]", {
+      key: condition.comparison.key,
+      match: matchLabel,
+    });
+  }
+
   return tct("The event's [key] tag [match] [value]", {
     key: condition.comparison.key,
-    match:
-      MATCH_CHOICES.find(choice => choice.value === condition.comparison.match)?.label ||
-      condition.comparison.match,
+    match: matchLabel,
     value: condition.comparison.value,
   });
 }
 
 export function TaggedEventNode() {
+  const {condition} = useDataConditionNodeContext();
+
+  if (!matchRequiresValue(condition.comparison.match)) {
+    return tct("The event's [key] tag [match]", {
+      key: <KeyField />,
+      match: <MatchField />,
+    });
+  }
+
   return tct("The event's [key] tag [match] [value]", {
     key: <KeyField />,
     match: <MatchField />,
@@ -99,8 +121,13 @@ function MatchField() {
       aria-label={t('Match type')}
       value={condition.comparison.match ?? ''}
       options={MATCH_CHOICES}
-      onChange={(value: SelectValue<MatchType>) => {
-        onUpdate({comparison: {...condition.comparison, match: value.value}});
+      onChange={(option: SelectValue<MatchType>) => {
+        const {value: _value, ...rest} = condition.comparison;
+        if (matchRequiresValue(option.value)) {
+          onUpdate({comparison: {...condition.comparison, match: option.value}});
+        } else {
+          onUpdate({comparison: {...rest, match: option.value}});
+        }
       }}
     />
   );
@@ -127,11 +154,10 @@ function ValueField() {
 export function validateTaggedEventCondition({
   condition,
 }: ValidateDataConditionProps): string | undefined {
-  if (
-    !condition.comparison.key ||
-    !condition.comparison.match ||
-    !condition.comparison.value
-  ) {
+  if (!condition.comparison.key || !condition.comparison.match) {
+    return t('Ensure all fields are filled in.');
+  }
+  if (matchRequiresValue(condition.comparison.match) && !condition.comparison.value) {
     return t('Ensure all fields are filled in.');
   }
   return undefined;

--- a/static/app/views/automations/components/dataConditionNodeList.spec.tsx
+++ b/static/app/views/automations/components/dataConditionNodeList.spec.tsx
@@ -184,6 +184,76 @@ describe('DataConditionNodeList', () => {
     });
   });
 
+  it('clears value when switching tagged event to is set match type', async () => {
+    render(
+      <AutomationBuilderContext.Provider value={defaultContextProps}>
+        <AutomationBuilderErrorContext.Provider value={defaultErrorContextProps}>
+          <AutomationBuilderConflictContext.Provider value={defaultConflictContextProps}>
+            <DataConditionNodeList
+              {...defaultProps}
+              conditions={[
+                DataConditionFixture({
+                  type: DataConditionType.TAGGED_EVENT,
+                  comparison: {key: 'name', match: MatchType.CONTAINS, value: 'foo'},
+                }),
+              ]}
+            />
+          </AutomationBuilderConflictContext.Provider>
+        </AutomationBuilderErrorContext.Provider>
+      </AutomationBuilderContext.Provider>,
+      {organization}
+    );
+
+    expect(screen.getByRole('textbox', {name: 'Value'})).toBeInTheDocument();
+
+    const matchInput = await screen.findByRole('textbox', {name: 'Match type'});
+    await userEvent.click(matchInput);
+    await userEvent.click(screen.getByRole('menuitemradio', {name: 'is set'}));
+
+    await waitFor(() => {
+      expect(mockUpdateCondition).toHaveBeenCalledWith('1', {
+        comparison: {key: 'name', match: MatchType.IS_SET},
+      });
+    });
+  });
+
+  it('clears value when switching event attribute to is set match type', async () => {
+    render(
+      <AutomationBuilderContext.Provider value={defaultContextProps}>
+        <AutomationBuilderErrorContext.Provider value={defaultErrorContextProps}>
+          <AutomationBuilderConflictContext.Provider value={defaultConflictContextProps}>
+            <DataConditionNodeList
+              {...defaultProps}
+              conditions={[
+                DataConditionFixture({
+                  type: DataConditionType.EVENT_ATTRIBUTE,
+                  comparison: {
+                    attribute: 'message',
+                    match: MatchType.CONTAINS,
+                    value: 'foo',
+                  },
+                }),
+              ]}
+            />
+          </AutomationBuilderConflictContext.Provider>
+        </AutomationBuilderErrorContext.Provider>
+      </AutomationBuilderContext.Provider>,
+      {organization}
+    );
+
+    expect(screen.getByRole('textbox', {name: 'Value'})).toBeInTheDocument();
+
+    const matchInput = await screen.findByRole('textbox', {name: 'Match type'});
+    await userEvent.click(matchInput);
+    await userEvent.click(screen.getByRole('menuitemradio', {name: 'is set'}));
+
+    await waitFor(() => {
+      expect(mockUpdateCondition).toHaveBeenCalledWith('1', {
+        comparison: {attribute: 'message', match: MatchType.IS_SET},
+      });
+    });
+  });
+
   it('deletes existing condition', async () => {
     render(
       <AutomationBuilderContext.Provider value={defaultContextProps}>


### PR DESCRIPTION
Closes ISWF-2577

The "is set" and "not set" match types don't take a value, but the event attribute and tagged event condition nodes were still showing the value input and keeping a stale value in the comparison object. This caused a backend validation error because the schema explicitly forbids `IS_SET`/`NOT_SET` on comparison conditions that include a value.

This hides the value input when switching to "is set" or "not set", strips the `value` key from the comparison object so it doesn't get sent to the backend, and updates the validation logic to not require a value for these match types. The same fix is applied to both `EventAttributeNode` and `TaggedEventNode`, along with their read-only detail views.

There is some duplicated logic here, but I don't think it necessitates sharing code between the two filters. There are only two instances and the amount of logic we _can_ share isn't complicated and is quite minimal.