### PR TITLE
feat(ourlogs): add byte total estimates for large searches

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -410,6 +410,7 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
                 discoverSplitDecision = meta.pop("discoverSplitDecision", None)
                 full_scan = meta.pop("full_scan", None)
                 bytes_scanned = meta.pop("bytes_scanned", None)
+                estimated_total_bytes = meta.pop("estimated_total_bytes", None)
                 debug_info = meta.pop("debug_info", None)
                 fields, units = self.handle_unit_meta(fields_meta)
                 meta = {
@@ -434,6 +435,8 @@ class OrganizationEventsEndpointBase(OrganizationEndpoint):
 
                 if bytes_scanned is not None:
                     meta["bytesScanned"] = bytes_scanned
+                if estimated_total_bytes is not None:
+                    meta["estimatedTotalBytes"] = estimated_total_bytes
 
                 # Only appears in meta when debug is passed to the endpoint
                 if debug_info:

--- a/src/sentry/search/eap/sampling.py
+++ b/src/sentry/search/eap/sampling.py
@@ -28,14 +28,36 @@ def events_meta_from_rpc_request_meta(meta: ResponseMeta) -> EventsMeta:
     bytes_scanned = (
         sum(info.stats.progress_bytes for info in meta.query_info) if meta.query_info else None
     )
+    storage_meta = meta.downsampled_storage_meta
+    enr = storage_meta.estimated_num_rows
+    estimated_num_rows: int | None = int(enr) if enr > 0 else None
+
+    query_rows_read: int | None = None
+    if meta.query_info:
+        query_rows_read = sum(int(info.stats.rows_read) for info in meta.query_info)
+
+    # Heuristic: extrapolate total haystack bytes from row estimate × bytes per scanned row.
+    # rows_read and estimated_num_rows may not align 1:1 in semantics; treat as UI hint only.
+    estimated_total_bytes: int | None = None
+    if (
+        estimated_num_rows is not None
+        and query_rows_read is not None
+        and query_rows_read > 0
+        and bytes_scanned is not None
+        and bytes_scanned > 0
+    ):
+        estimated_total_bytes = int(estimated_num_rows * (bytes_scanned / float(query_rows_read)))
 
     span = sentry_sdk.get_current_span()
     if span:
         span.set_data("data_scanned", "full" if full_scan else "partial")
         span.set_data("bytes_scanned", bytes_scanned)
 
-    return EventsMeta(
+    result: EventsMeta = EventsMeta(
         fields={},
         full_scan=full_scan,
         bytes_scanned=bytes_scanned,
     )
+    if estimated_total_bytes is not None:
+        result["estimated_total_bytes"] = estimated_total_bytes
+    return result

--- a/src/sentry/search/events/types.py
+++ b/src/sentry/search/events/types.py
@@ -75,6 +75,8 @@ class EventsMeta(TypedDict):
     debug_info: NotRequired[dict[str, Any]]
     full_scan: NotRequired[bool]
     bytes_scanned: NotRequired[int | None]
+    # Heuristic haystack size from estimated_num_rows × (bytes_scanned / query_rows_read)
+    estimated_total_bytes: NotRequired[int]
 
 
 class EventsResponse(TypedDict):

--- a/static/app/utils/discover/eventView.tsx
+++ b/static/app/utils/discover/eventView.tsx
@@ -72,6 +72,7 @@ export type EventsMetaType = {fields: Record<string, ColumnType>} & {
   bytesScanned?: number | null;
   dataScanned?: 'full' | 'partial';
   discoverSplitDecision?: WidgetType;
+  estimatedTotalBytes?: number;
   isMetricsData?: boolean;
   isMetricsExtractedData?: boolean;
 };

--- a/static/app/views/explore/logs/constants.tsx
+++ b/static/app/views/explore/logs/constants.tsx
@@ -36,6 +36,11 @@ export const LOGS_HIGH_FIDELITY_INITIAL_AUTO_FETCH_WINDOW_MS = 10_000;
 export const LOGS_HIGH_FIDELITY_RESUMED_AUTO_FETCH_WINDOW_MS = 20_000;
 
 /**
+ * One TiB: accuracy cutoff to add an "of" estimate for needle-in-haystack searches.
+ */
+export const LOGS_HAYSTACK_DENOMINATOR_MIN_BYTES = 1024 ** 4;
+
+/**
  * These are required fields are always added to the query when fetching the log table.
  */
 export const AlwaysPresentLogFields: OurLogFieldKey[] = [

--- a/static/app/views/explore/logs/tables/logsEmptyResults.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsEmptyResults.spec.tsx
@@ -37,6 +37,25 @@ describe('LogsEmptyResults', () => {
     );
   });
 
+  it('renders X of Y when haystack denominator is shown', () => {
+    const twoTib = 2 * 1024 ** 4;
+    render(
+      <LogsEmptyResults
+        analyticsPageSource={LogsAnalyticsPageSource.EXPLORE_LOGS}
+        bytesScanned={500_000_000}
+        canResumeAutoFetch
+        estimatedTotalBytes={twoTib}
+        resumeAutoFetch={jest.fn()}
+      />,
+      {organization, additionalWrapper: TableBodyWrapper}
+    );
+
+    const emptyState = screen.getByTestId('empty-state');
+    expect(emptyState).toHaveTextContent(
+      /We scanned .+ of .+ so far but have not found anything matching your filters/
+    );
+  });
+
   it('renders the continue-scanning state when bytes were scanned and auto-fetch can resume', () => {
     const mockResumeAutoFetch = jest.fn();
 

--- a/static/app/views/explore/logs/tables/logsEmptyResults.tsx
+++ b/static/app/views/explore/logs/tables/logsEmptyResults.tsx
@@ -16,6 +16,7 @@ interface LogsEmptyResultsProps {
   analyticsPageSource: LogsAnalyticsPageSource;
   bytesScanned?: number;
   canResumeAutoFetch?: boolean;
+  estimatedTotalBytes?: number;
   resumeAutoFetch?: () => void;
 }
 
@@ -23,21 +24,36 @@ export function LogsEmptyResults({
   bytesScanned,
   canResumeAutoFetch,
   analyticsPageSource,
+  estimatedTotalBytes,
   resumeAutoFetch,
 }: LogsEmptyResultsProps) {
   const organization = useOrganization();
 
   if (bytesScanned && canResumeAutoFetch && resumeAutoFetch) {
+    const scannedSoFar = estimatedTotalBytes ? (
+      <EmptyStateText size="md">
+        {tct(
+          'We scanned [bytesScanned] of [estimatedTotal] so far but have not found anything matching your filters.',
+          {
+            bytesScanned: <FileSize bytes={bytesScanned} base={2} />,
+            estimatedTotal: <FileSize bytes={estimatedTotalBytes} base={2} />,
+          }
+        )}
+      </EmptyStateText>
+    ) : (
+      <EmptyStateText size="md">
+        {tct(
+          'We scanned [bytesScanned] so far but have not found anything matching your filters.',
+          {bytesScanned: <FileSize bytes={bytesScanned} base={2} />}
+        )}
+      </EmptyStateText>
+    );
+
     return (
       <TableStatus>
         <EmptyStateWarning withIcon variant="accent">
           <EmptyStateText size="xl">{t('No logs found yet')}</EmptyStateText>
-          <EmptyStateText size="md">
-            {tct(
-              'We scanned [bytesScanned] so far but have not found anything matching your filters',
-              {bytesScanned: <FileSize bytes={bytesScanned} base={2} />}
-            )}
-          </EmptyStateText>
+          {scannedSoFar}
           <EmptyStateText size="md">
             {t('We can keep digging or you can narrow down your search.')}
           </EmptyStateText>

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -6,25 +6,21 @@ import {
   useMemo,
   useRef,
   useState,
-  type CSSProperties,
   type RefObject,
 } from 'react';
-import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import type {Virtualizer} from '@tanstack/react-virtual';
 import {useVirtualizer, useWindowVirtualizer} from '@tanstack/react-virtual';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Flex} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {FileSize} from 'sentry/components/fileSize';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {JumpButtons} from 'sentry/components/replays/jumpButtons';
 import {useJumpButtons} from 'sentry/components/replays/useJumpButtons';
 import {GridResizer} from 'sentry/components/tables/gridEditable/styles';
 import {IconArrow, IconWarning} from 'sentry/icons';
-import {t, tct} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
 import type {TagCollection} from 'sentry/types/group';
 import {defined} from 'sentry/utils';
@@ -56,6 +52,7 @@ import {
   LogTableRow,
 } from 'sentry/views/explore/logs/styles';
 import {LogsEmptyResults} from 'sentry/views/explore/logs/tables/logsEmptyResults';
+import {LogsLoading} from 'sentry/views/explore/logs/tables/logsLoading';
 import {LogRowContent} from 'sentry/views/explore/logs/tables/logsTableRow';
 import {
   OurLogKnownFieldKey,
@@ -79,7 +76,6 @@ import {
   useQueryParamsSortBys,
   useSetQueryParamsSortBys,
 } from 'sentry/views/explore/queryParams/context';
-import {EmptyStateText} from 'sentry/views/explore/tables/tracesTable/styles';
 
 type LogsTableProps = {
   analyticsPageSource: LogsAnalyticsPageSource;
@@ -144,6 +140,7 @@ export function LogsInfiniteTable({
     bytesScanned,
     canResumeAutoFetch,
     resumeAutoFetch,
+    estimatedTotalBytes,
   } = useLogsPageDataQueryResult();
 
   const baseData = localOnlyItemFilters?.filteredItems ?? originalData;
@@ -454,7 +451,7 @@ export function LogsInfiniteTable({
     return (
       <Fragment>
         <Flex justify="center" align="center" height="100%" minHeight="200px">
-          {isPending && <LoadingRenderer />}
+          {isPending && <LogsLoading />}
           {isError && <ErrorRenderer />}
           {isEmpty &&
             (emptyRenderer ? (
@@ -509,7 +506,12 @@ export function LogsInfiniteTable({
             </TableRow>
           )}
           {/* Only render these in table for non-replay contexts */}
-          {!hasReplay && isPending && <LoadingRenderer bytesScanned={bytesScanned} />}
+          {!hasReplay && isPending && (
+            <LogsLoading
+              bytesScanned={bytesScanned}
+              estimatedTotalBytes={estimatedTotalBytes}
+            />
+          )}
           {!hasReplay && isError && <ErrorRenderer />}
           {!hasReplay &&
             isEmpty &&
@@ -521,6 +523,7 @@ export function LogsInfiniteTable({
                 bytesScanned={bytesScanned}
                 canResumeAutoFetch={canResumeAutoFetch}
                 resumeAutoFetch={resumeAutoFetch}
+                estimatedTotalBytes={estimatedTotalBytes}
               />
             ))}
           {!autoRefresh && !isPending && isFetchingPreviousPage && (
@@ -684,35 +687,6 @@ function ErrorRenderer() {
     </TableStatus>
   );
 }
-
-export function LoadingRenderer({bytesScanned}: {bytesScanned?: number}) {
-  return (
-    <TableStatus>
-      <Stack align="center">
-        <EmptyStateText size="md" textAlign="center">
-          <StyledLoadingIndicator margin="1em auto" />
-          {defined(bytesScanned) && bytesScanned > 0 && (
-            <Fragment>
-              {t('Searching for a needle in a haystack. This could take a while.')}
-              <br />
-              <span>
-                {tct('[bytesScanned] scanned', {
-                  bytesScanned: <FileSize bytes={bytesScanned} base={2} />,
-                })}
-              </span>
-            </Fragment>
-          )}
-        </EmptyStateText>
-      </Stack>
-    </TableStatus>
-  );
-}
-
-const StyledLoadingIndicator = styled(LoadingIndicator)<{
-  margin: CSSProperties['margin'];
-}>`
-  ${p => p.margin && `margin: ${p.margin}`};
-`;
 
 function HoveringRowLoadingRenderer({
   position,

--- a/static/app/views/explore/logs/tables/logsLoading.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsLoading.spec.tsx
@@ -1,0 +1,38 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {LogsLoading} from 'sentry/views/explore/logs/tables/logsLoading';
+
+function TableBodyWrapper({children}: {children?: React.ReactNode}) {
+  return (
+    <table>
+      <tbody>{children}</tbody>
+    </table>
+  );
+}
+
+describe('LogsLoading', () => {
+  it('shows a single scanned size when haystack denominator is hidden', () => {
+    render(<LogsLoading bytesScanned={8_000_000} estimatedTotalBytes={undefined} />, {
+      additionalWrapper: TableBodyWrapper,
+    });
+
+    expect(screen.getByText(/needle in a haystack/i)).toBeInTheDocument();
+    expect(screen.getByText(/MiB/)).toBeInTheDocument();
+    expect(screen.getByText(/scanned/)).toBeInTheDocument();
+    expect(screen.queryByText(' of ')).not.toBeInTheDocument();
+  });
+
+  it('shows X of Y scanned when haystack denominator is enabled', () => {
+    const twoTib = 2 * 1024 ** 4;
+    render(<LogsLoading bytesScanned={500_000_000} estimatedTotalBytes={twoTib} />, {
+      additionalWrapper: TableBodyWrapper,
+    });
+
+    expect(screen.getByText(/needle in a haystack/i)).toBeInTheDocument();
+    const row = screen.getByRole('row');
+    expect(row).toHaveTextContent('476.8 MiB');
+    expect(row).toHaveTextContent('2.0 TiB');
+    expect(row).toHaveTextContent(' of ');
+    expect(row).toHaveTextContent('scanned');
+  });
+});

--- a/static/app/views/explore/logs/tables/logsLoading.tsx
+++ b/static/app/views/explore/logs/tables/logsLoading.tsx
@@ -1,0 +1,65 @@
+import {Fragment, type CSSProperties} from 'react';
+import styled from '@emotion/styled';
+
+import {Stack} from '@sentry/scraps/layout';
+
+import {FileSize} from 'sentry/components/fileSize';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {t, tct} from 'sentry/locale';
+import {TableStatus} from 'sentry/views/explore/components/table';
+import {EmptyStateText} from 'sentry/views/explore/tables/tracesTable/styles';
+
+type Props = Partial<ProgressIndicatorProps>;
+
+export function LogsLoading({bytesScanned, estimatedTotalBytes}: Props) {
+  return (
+    <TableStatus>
+      <Stack align="center">
+        <EmptyStateText size="md" textAlign="center">
+          <StyledLoadingIndicator margin="1em auto" />
+          {bytesScanned ? (
+            <Fragment>
+              {t('Searching for a needle in a haystack. This could take a while.')}
+              <br />
+              <ProgressIndicator
+                bytesScanned={bytesScanned}
+                estimatedTotalBytes={estimatedTotalBytes}
+              />
+            </Fragment>
+          ) : null}
+        </EmptyStateText>
+      </Stack>
+    </TableStatus>
+  );
+}
+
+interface ProgressIndicatorProps {
+  bytesScanned: number;
+  estimatedTotalBytes?: number;
+}
+
+function ProgressIndicator({
+  bytesScanned,
+  estimatedTotalBytes: estimatedTotalBytes,
+}: ProgressIndicatorProps) {
+  return estimatedTotalBytes ? (
+    <span>
+      {tct('[bytesScanned] of [estimatedTotal] scanned', {
+        bytesScanned: <FileSize bytes={bytesScanned} base={2} />,
+        estimatedTotal: <FileSize bytes={estimatedTotalBytes} base={2} />,
+      })}
+    </span>
+  ) : (
+    <span>
+      {tct('[bytesScanned] scanned', {
+        bytesScanned: <FileSize bytes={bytesScanned} base={2} />,
+      })}
+    </span>
+  );
+}
+
+const StyledLoadingIndicator = styled(LoadingIndicator)<{
+  margin: CSSProperties['margin'];
+}>`
+  ${p => p.margin && `margin: ${p.margin}`};
+`;

--- a/static/app/views/explore/logs/useLogsQuery.spec.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.spec.tsx
@@ -20,6 +20,7 @@ import {
 } from 'sentry/views/explore/contexts/logs/logsAutoRefreshContext';
 import {LOGS_SORT_BYS_KEY} from 'sentry/views/explore/contexts/logs/sortBys';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
+import {LOGS_HAYSTACK_DENOMINATOR_MIN_BYTES} from 'sentry/views/explore/logs/constants';
 import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
 import type {
   EventsLogsResult,
@@ -339,6 +340,98 @@ describe('useInfiniteLogsQuery', () => {
       eventsEndpoint,
       expect.objectContaining({data: {highFidelity: true}})
     );
+  });
+
+  it('exposes haystack denominator when estimatedTotalBytes exceeds 1 TiB', async () => {
+    const base = createMockLogsData([
+      {id: '1', timestamp_precise: '100', timestamp: '100'},
+    ]);
+    const estimatedTotalBytes = LOGS_HAYSTACK_DENOMINATOR_MIN_BYTES + 1;
+    const body = {
+      ...base,
+      meta: {
+        ...base.meta,
+        bytesScanned: 1_000_000,
+        dataScanned: 'full',
+        estimatedTotalBytes,
+      },
+    };
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body,
+      headers: linkHeaders,
+    });
+
+    const {result} = renderHookWithProviders(() => useInfiniteLogsQuery({}), {
+      additionalWrapper: createWrapper(),
+      organization,
+    });
+
+    await waitFor(() => expect(result.current.bytesScanned).toBe(1_000_000));
+    await waitFor(() =>
+      expect(result.current.estimatedTotalBytes).toBe(
+        Math.max(estimatedTotalBytes, 1_000_000)
+      )
+    );
+  });
+
+  it('does not expose haystack denominator when hint is at or below 1 TiB', async () => {
+    const base = createMockLogsData([
+      {id: '1', timestamp_precise: '100', timestamp: '100'},
+    ]);
+    const body = {
+      ...base,
+      meta: {
+        ...base.meta,
+        bytesScanned: 500,
+        dataScanned: 'full',
+        estimatedTotalBytes: LOGS_HAYSTACK_DENOMINATOR_MIN_BYTES,
+      },
+    };
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body,
+      headers: linkHeaders,
+    });
+
+    const {result} = renderHookWithProviders(() => useInfiniteLogsQuery({}), {
+      additionalWrapper: createWrapper(),
+      organization,
+    });
+
+    await waitFor(() => expect(result.current.bytesScanned).toBe(500));
+    expect(result.current.estimatedTotalBytes).toBeUndefined();
+  });
+
+  it('does not expose haystack denominator without estimatedTotalBytes', async () => {
+    const base = createMockLogsData([
+      {id: '1', timestamp_precise: '100', timestamp: '100'},
+    ]);
+    const body = {
+      ...base,
+      meta: {
+        ...base.meta,
+        bytesScanned: 100,
+        dataScanned: 'full',
+        estimatedNumRows: 5_000_000_000,
+      },
+    };
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body,
+      headers: linkHeaders,
+    });
+
+    const {result} = renderHookWithProviders(() => useInfiniteLogsQuery({}), {
+      additionalWrapper: createWrapper(),
+      organization,
+    });
+
+    await waitFor(() => expect(result.current.bytesScanned).toBe(100));
+    expect(result.current.estimatedTotalBytes).toBeUndefined();
   });
 
   describe('high fidelity', () => {

--- a/static/app/views/explore/logs/useLogsQuery.tsx
+++ b/static/app/views/explore/logs/useLogsQuery.tsx
@@ -25,6 +25,7 @@ import {useTraceItemDetails} from 'sentry/views/explore/hooks/useTraceItemDetail
 import {
   AlwaysPresentLogFields,
   LOCAL_LOG_ROWS_FOR_EXPANDED_INFINITE_PAGES,
+  LOGS_HAYSTACK_DENOMINATOR_MIN_BYTES,
   LOGS_HIGH_FIDELITY_INITIAL_AUTO_FETCH_WINDOW_MS,
   LOGS_HIGH_FIDELITY_RESUMED_AUTO_FETCH_WINDOW_MS,
   MAX_LOG_INGEST_DELAY,
@@ -724,6 +725,7 @@ export function useInfiniteLogsQuery({
     resumeAutoFetch,
     dataScanned,
     bytesScanned: totalBytesScanned,
+    estimatedTotalBytes: normalizeestimatedTotalBytes(lastPage, totalBytesScanned),
   };
 }
 
@@ -819,4 +821,22 @@ export function useLogsQueryHighFidelity() {
     sortBys[0]?.field === 'timestamp' &&
     sortBys[0]?.kind === 'desc'
   );
+}
+
+/** When available, show "X of Y scanned" haystack copy; falsy means single "X scanned" line. */
+function normalizeestimatedTotalBytes(
+  lastPage: ApiResponse<EventsLogsResult> | undefined,
+  totalBytesScanned: number
+) {
+  const lastestimatedTotalBytes = lastPage?.json.meta?.estimatedTotalBytes;
+  if (!lastestimatedTotalBytes) {
+    return undefined;
+  }
+
+  const denominatorBytes = Math.max(lastestimatedTotalBytes, totalBytesScanned);
+  if (denominatorBytes <= LOGS_HAYSTACK_DENOMINATOR_MIN_BYTES) {
+    return undefined;
+  }
+
+  return denominatorBytes;
 }

--- a/static/app/views/explore/logs/useLogsTimeseries.spec.tsx
+++ b/static/app/views/explore/logs/useLogsTimeseries.spec.tsx
@@ -98,6 +98,7 @@ describe('useLogsTimeseries', () => {
             hasPreviousPage: false,
             isFetchingNextPage: false,
             isFetchingPreviousPage: false,
+            estimatedTotalBytes: undefined,
             lastPageLength: 0,
             bytesScanned: 0,
             dataScanned: undefined,

--- a/static/app/views/explore/replays/detail/ourlogs/index.tsx
+++ b/static/app/views/explore/replays/detail/ourlogs/index.tsx
@@ -18,10 +18,8 @@ import {logsTimestampAscendingSortBy} from 'sentry/views/explore/contexts/logs/s
 import {useLogItemAttributes} from 'sentry/views/explore/contexts/traceItemAttributeContext';
 import {LogsQueryParamsProvider} from 'sentry/views/explore/logs/logsQueryParamsProvider';
 import {LogsItemContainer} from 'sentry/views/explore/logs/styles';
-import {
-  LoadingRenderer,
-  LogsInfiniteTable,
-} from 'sentry/views/explore/logs/tables/logsInfiniteTable';
+import {LogsInfiniteTable} from 'sentry/views/explore/logs/tables/logsInfiniteTable';
+import {LogsLoading} from 'sentry/views/explore/logs/tables/logsLoading';
 import {rearrangedLogsReplayFields} from 'sentry/views/explore/logs/tables/logsTableUtils';
 import {FluidHeight} from 'sentry/views/explore/replays/detail/layout/fluidHeight';
 import {NoRowRenderer} from 'sentry/views/explore/replays/detail/noRowRenderer';
@@ -42,7 +40,7 @@ export function OurLogs() {
     return (
       <BorderedSection isStatus>
         <GridBody>
-          <LoadingRenderer />
+          <LogsLoading />
         </GridBody>
       </BorderedSection>
     );

--- a/tests/sentry/search/eap/test_sampling.py
+++ b/tests/sentry/search/eap/test_sampling.py
@@ -1,0 +1,102 @@
+from sentry_protos.snuba.v1.request_common_pb2 import ResponseMeta
+
+from sentry.search.eap.sampling import events_meta_from_rpc_request_meta
+
+
+def test_events_meta_bytes_scanned_and_full_scan() -> None:
+    rpc_meta = ResponseMeta()
+    rpc_meta.downsampled_storage_meta.estimated_num_rows = 5_000_000
+    rpc_meta.downsampled_storage_meta.can_go_to_higher_accuracy_tier = False
+    qi = rpc_meta.query_info.add()
+    qi.stats.progress_bytes = 100
+    qi.stats.rows_read = 1
+
+    result = events_meta_from_rpc_request_meta(rpc_meta)
+
+    assert result["bytes_scanned"] == 100
+    assert result["full_scan"] is True
+    assert result["fields"] == {}
+    # Row estimate is not exposed; only derived hint when rows_read and bytes are positive.
+    assert result["estimated_total_bytes"] == 5_000_000 * 100
+
+
+def test_events_meta_partial_scan_when_higher_accuracy_available() -> None:
+    rpc_meta = ResponseMeta()
+    rpc_meta.downsampled_storage_meta.can_go_to_higher_accuracy_tier = True
+    qi = rpc_meta.query_info.add()
+    qi.stats.progress_bytes = 1
+
+    result = events_meta_from_rpc_request_meta(rpc_meta)
+
+    assert result["full_scan"] is False
+    assert result["bytes_scanned"] == 1
+
+
+def test_events_meta_estimated_total_bytes_sums_query_info() -> None:
+    rpc_meta = ResponseMeta()
+    rpc_meta.downsampled_storage_meta.estimated_num_rows = 10_000
+    rpc_meta.downsampled_storage_meta.can_go_to_higher_accuracy_tier = False
+    qi1 = rpc_meta.query_info.add()
+    qi1.stats.progress_bytes = 200
+    qi1.stats.rows_read = 100
+    qi2 = rpc_meta.query_info.add()
+    qi2.stats.progress_bytes = 300
+    qi2.stats.rows_read = 50
+
+    result = events_meta_from_rpc_request_meta(rpc_meta)
+
+    assert result["bytes_scanned"] == 500
+    # 10_000 * (500 / 150)
+    assert result["estimated_total_bytes"] == 33_333
+
+
+def test_events_meta_omits_estimated_total_bytes_when_estimated_num_rows_zero() -> None:
+    rpc_meta = ResponseMeta()
+    rpc_meta.downsampled_storage_meta.estimated_num_rows = 0
+    rpc_meta.downsampled_storage_meta.can_go_to_higher_accuracy_tier = True
+    qi = rpc_meta.query_info.add()
+    qi.stats.progress_bytes = 50
+    qi.stats.rows_read = 10
+
+    result = events_meta_from_rpc_request_meta(rpc_meta)
+
+    assert "estimated_total_bytes" not in result
+    assert result["bytes_scanned"] == 50
+
+
+def test_events_meta_omits_estimated_total_bytes_when_rows_read_zero() -> None:
+    rpc_meta = ResponseMeta()
+    rpc_meta.downsampled_storage_meta.estimated_num_rows = 1_000
+    rpc_meta.downsampled_storage_meta.can_go_to_higher_accuracy_tier = False
+    qi = rpc_meta.query_info.add()
+    qi.stats.progress_bytes = 100
+    qi.stats.rows_read = 0
+
+    result = events_meta_from_rpc_request_meta(rpc_meta)
+
+    assert "estimated_total_bytes" not in result
+
+
+def test_events_meta_omits_estimated_total_bytes_when_bytes_scanned_zero() -> None:
+    rpc_meta = ResponseMeta()
+    rpc_meta.downsampled_storage_meta.estimated_num_rows = 1_000
+    rpc_meta.downsampled_storage_meta.can_go_to_higher_accuracy_tier = False
+    qi = rpc_meta.query_info.add()
+    qi.stats.progress_bytes = 0
+    qi.stats.rows_read = 10
+
+    result = events_meta_from_rpc_request_meta(rpc_meta)
+
+    assert result["bytes_scanned"] == 0
+    assert "estimated_total_bytes" not in result
+
+
+def test_events_meta_omits_estimated_total_bytes_without_query_info() -> None:
+    rpc_meta = ResponseMeta()
+    rpc_meta.downsampled_storage_meta.estimated_num_rows = 1_000_000
+    rpc_meta.downsampled_storage_meta.can_go_to_higher_accuracy_tier = False
+
+    result = events_meta_from_rpc_request_meta(rpc_meta)
+
+    assert result.get("bytes_scanned") is None
+    assert "estimated_total_bytes" not in result


### PR DESCRIPTION
Adds an `estimated_total_bytes` -> `estimatedTotalBytes` to the `EventsMetaType` response. Then when it exists, adds it to the logs searching notices on the frontend.

The notice is only added when the total estimated bytes are about a TiB or higher. That should limit this to times when the user would actually see the "continue scanning" notice more than a second. At data that size, the chance of the row sizes being wildly skewed should be much lower, too.

<table>
<thead>
<tr>
<th>Loading</th>
<th>No Results</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="658" height="333" alt="Searching for a needle in a haystack. This could take a while. / 3.3 TiB of 112.3 TiB scanned" src="https://github.com/user-attachments/assets/89e46629-c3ff-4174-a67c-65c498ecf50b" />
</td>
<td>
<img width="658" height="333" alt="No logs found yet / We scanned 2.2 TiB of 112.3 TiB so far but have not found anything matching your filters. / We can keep digging or you can narrow down your search. / Continue Scanning" src="https://github.com/user-attachments/assets/44af73e9-7e25-483b-be29-c97367c82271" />
</td>
</tr>
</tbody>
</table>

Interestingly, I don't think this needs a staged rollout. The field is optional in the server response. If it doesn't exist, the frontend doesn't change behavior from today.

Fixes LOGS-748.