### PR TITLE
feat(seer): Hide unconfigured Autofix projects

### DIFF
--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
@@ -55,7 +55,11 @@ import {SeerProjectTableRow} from 'getsentry/views/seerAutomation/components/pro
 export function SeerProjectTable() {
   const queryClient = useQueryClient();
   const organization = useOrganization();
-  const {projects, fetching, fetchError} = useProjects();
+  const {
+    projects: allProjects,
+    fetching: fetchingProjects,
+    fetchError: projectFetchError,
+  } = useProjects();
 
   const [isLoadingModal, setIsLoadingModal] = useState(false);
 
@@ -79,7 +83,18 @@ export function SeerProjectTable() {
       ),
   });
   useFetchAllPages({result});
-  const {data: autofixSettingsByProjectId} = result;
+  const {
+    data: autofixSettingsByProjectId,
+    isPending: isPendingSettings,
+    isError: isErrorSettings,
+  } = result;
+
+  const projects = useMemo(() => {
+    return allProjects.filter(project => {
+      const setting = autofixSettingsByProjectId?.[project.id];
+      return setting?.reposCount;
+    });
+  }, [allProjects, autofixSettingsByProjectId]);
 
   const {data: integrations, isPending: isPendingIntegrations} = useQuery({
     ...organizationIntegrationsCodingAgents(organization),
@@ -292,11 +307,11 @@ export function SeerProjectTable() {
             updateBulkAutofixAutomationSettings={updateBulkAutofixAutomationSettings}
           />
 
-          {fetching ? (
+          {fetchingProjects || isPendingSettings ? (
             <SimpleTable.Empty>
               <LoadingIndicator />
             </SimpleTable.Empty>
-          ) : fetchError ? (
+          ) : projectFetchError || isErrorSettings ? (
             <SimpleTable.Empty>
               <LoadingError />
             </SimpleTable.Empty>

--- a/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
+++ b/static/gsApp/views/seerAutomation/components/projectTable/seerProjectTable.tsx
@@ -86,6 +86,7 @@ export function SeerProjectTable() {
   const {
     data: autofixSettingsByProjectId,
     isPending: isPendingSettings,
+    isFetchingNextPage,
     isError: isErrorSettings,
   } = result;
 
@@ -307,7 +308,7 @@ export function SeerProjectTable() {
             updateBulkAutofixAutomationSettings={updateBulkAutofixAutomationSettings}
           />
 
-          {fetchingProjects || isPendingSettings ? (
+          {fetchingProjects || isPendingSettings || isFetchingNextPage ? (
             <SimpleTable.Empty>
               <LoadingIndicator />
             </SimpleTable.Empty>


### PR DESCRIPTION
Since we have the [Add Project modal for Autofix](https://github.com/getsentry/sentry/pull/113751) we can hide projects that are not yet configured (that have zero repos) and have a smaller autofix list to render.

As a followup I would like to re-orient the tables to render based on the list of `AutofixAutomationSettings` objects, not on the list of `Project` objects. but I need a corresponding backend change to inject the project name & slug (or just slug? name seems annoying not useful) into the response, so that'll be a followup. See https://github.com/getsentry/sentry/pull/114457 & https://github.com/getsentry/sentry/pull/114459