### PR TITLE
feat(snapshots): Show tooltip on truncated sidebar item names

### DIFF
--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -101,6 +101,7 @@ export function SnapshotSidebarContent({
             variant={isSelected ? 'accent' : 'muted'}
             bold={isSelected}
             ellipsis
+            onPointerEnter={setTitleOnOverflow}
           >
             {group.name}
           </Text>
@@ -218,6 +219,11 @@ function StatusPill({
       </Text>
     </PillButton>
   );
+}
+
+function setTitleOnOverflow(e: React.PointerEvent<HTMLElement>) {
+  const el = e.currentTarget;
+  el.title = el.scrollWidth > el.clientWidth ? (el.textContent ?? '') : '';
 }
 
 const PillButton = styled('button')<{active: boolean}>`


### PR DESCRIPTION
Adds a native tooltip to snapshot sidebar items when the name is truncated
by CSS ellipsis. On pointer enter, the handler checks if the element's
`scrollWidth` exceeds its `clientWidth` and sets the `title` attribute
imperatively — no React state, no re-renders, no extra DOM nodes.

The tooltip only appears when the name is actually being clipped, so
short names that fit the sidebar width show nothing on hover.