### PR TITLE
feat(source-map-config-issues): Switching to sentry metrics to measure cross-project impact

### DIFF
--- a/src/sentry/processing_errors/detection.py
+++ b/src/sentry/processing_errors/detection.py
@@ -138,7 +138,7 @@ def _detect_for_config(
         return
 
     matching_error_types = sorted(
-        e.get("type") for e in errors if e.get("type") in config.handler_cls.error_types
+        config.handler_cls.error_types.intersection(filter(None, (e.get("type") for e in errors)))
     )
     sentry_sdk.metrics.count(
         f"processing_errors.{config.slug}.event_with_errors",

--- a/src/sentry/processing_errors/detection.py
+++ b/src/sentry/processing_errors/detection.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
+import sentry_sdk
 from django.core.cache import cache
 from django.utils import timezone
 
@@ -136,7 +137,20 @@ def _detect_for_config(
     if not any(e.get("type") in config.handler_cls.error_types for e in errors):
         return
 
-    metrics.incr(f"processing_errors.{config.slug}.event_with_errors")
+    matching_error_types = sorted(
+        e.get("type") for e in errors if e.get("type") in config.handler_cls.error_types
+    )
+    sentry_sdk.metrics.count(
+        f"processing_errors.{config.slug}.event_with_errors",
+        1,
+        attributes={
+            "org_slug": event.project.organization.slug,
+            "project_id": str(event.project.id),
+            "project_slug": event.project.slug,
+            "platform": event.project.platform or "unknown",
+            "error_type": ",".join(matching_error_types),
+        },
+    )
 
     project_id = event.project.id
 

--- a/src/sentry/processing_errors/detection.py
+++ b/src/sentry/processing_errors/detection.py
@@ -24,6 +24,20 @@ from sentry.workflow_engine.processors.detector import process_detectors
 
 logger = logging.getLogger(__name__)
 
+
+def _project_age_bucket(project: Any) -> str:
+    age_days = (timezone.now() - project.date_added).days
+    if age_days <= 7:
+        return "0-7d"
+    elif age_days <= 30:
+        return "8-30d"
+    elif age_days <= 90:
+        return "31-90d"
+    elif age_days <= 365:
+        return "91-365d"
+    return "365d+"
+
+
 # How often (seconds) to refresh date_updated when the detector is already triggered.
 # Must be much less than the staleness threshold used for resolution.
 REFRESH_INTERVAL_SECONDS = 5 * 60  # 5 minutes
@@ -149,6 +163,7 @@ def _detect_for_config(
             "project_slug": event.project.slug,
             "platform": event.project.platform or "unknown",
             "error_type": ",".join(matching_error_types),
+            "project_age_bucket": _project_age_bucket(event.project),
         },
     )
 


### PR DESCRIPTION
We want to know: 
- The count of unique project/orgs impacted
- The platforms ranked by impact

High cardinality attrs are discouraged in the "previous platform we use to track metrics", so switch to sentry metrics