### PR TITLE
feat(integrations): Add `enabled` field to missing-members endpoint response

### DIFF
--- a/src/sentry/api/endpoints/organization_missing_org_members.py
+++ b/src/sentry/api/endpoints/organization_missing_org_members.py
@@ -189,7 +189,7 @@ class OrganizationMissingMembersEndpoint(OrganizationEndpoint):
                 continue
 
             if use_oi_config_reads:
-                nudge_enabled_ids = [
+                nudge_enabled_ids = {
                     oi.integration_id
                     for oi in integration_service.get_organization_integrations(
                         organization_id=organization.id,
@@ -197,21 +197,27 @@ class OrganizationMissingMembersEndpoint(OrganizationEndpoint):
                         status=ObjectStatus.ACTIVE,
                     )
                     if oi.config.get("nudge_invite", False)
-                ]
-                integration_ids = [iid for iid in integration_ids if iid in nudge_enabled_ids]
-                if not integration_ids:
-                    continue
+                }
+                enabled_ids = [iid for iid in integration_ids if iid in nudge_enabled_ids]
+                enabled = bool(enabled_ids)
+            else:
+                enabled_ids = list(integration_ids)
+                enabled = True
 
-            queryset = _get_missing_organization_members(
-                organization, integration_provider, integration_ids, shared_domain
+            users = []
+            if enabled:
+                queryset = _get_missing_organization_members(
+                    organization, integration_provider, enabled_ids, shared_domain
+                )
+                users = serialize(queryset, request.user, serializer=MissingOrgMemberSerializer())
+
+            missing_org_members.append(
+                {
+                    "integration": integration_provider,
+                    "enabled": enabled,
+                    "users": users,
+                }
             )
-
-            missing_members_for_integration = {
-                "integration": integration_provider,
-                "users": serialize(queryset, request.user, serializer=MissingOrgMemberSerializer()),
-            }
-
-            missing_org_members.append(missing_members_for_integration)
 
         return Response(
             missing_org_members,

--- a/tests/sentry/api/endpoints/test_organization_missing_org_members.py
+++ b/tests/sentry/api/endpoints/test_organization_missing_org_members.py
@@ -99,6 +99,7 @@ class OrganizationMissingMembersTestCase(APITestCase):
 
         response = self.get_success_response(self.organization.slug)
         assert response.data[0]["integration"] == "github"
+        assert response.data[0]["enabled"] is True
         assert response.data[0]["users"] == [
             {"email": "c@example.com", "externalId": "c", "commitCount": 2},
             {"email": "d@example.com", "externalId": "d", "commitCount": 1},
@@ -120,6 +121,7 @@ class OrganizationMissingMembersTestCase(APITestCase):
 
         response = self.get_success_response(self.organization.slug)
         assert response.data[0]["integration"] == "github"
+        assert response.data[0]["enabled"] is True
         assert response.data[0]["users"] == [
             {"email": "c@example.com", "externalId": "c", "commitCount": 2},
             {"email": "d@example.com", "externalId": "d", "commitCount": 1},
@@ -134,6 +136,7 @@ class OrganizationMissingMembersTestCase(APITestCase):
 
         response = self.get_success_response(self.organization.slug)
         assert response.data[0]["integration"] == "github"
+        assert response.data[0]["enabled"] is True
         assert response.data[0]["users"] == [
             {"email": "c@example.com", "externalId": "c", "commitCount": 2},
             {"email": "d@example.com", "externalId": "d", "commitCount": 1},
@@ -150,6 +153,7 @@ class OrganizationMissingMembersTestCase(APITestCase):
 
         response = self.get_success_response(self.organization.slug)
         assert response.data[0]["integration"] == "github"
+        assert response.data[0]["enabled"] is True
         assert response.data[0]["users"] == [
             {"email": "c@example.com", "externalId": "c", "commitCount": 2},
             {"email": "d@example.com", "externalId": "d", "commitCount": 1},
@@ -164,6 +168,7 @@ class OrganizationMissingMembersTestCase(APITestCase):
 
         response = self.get_success_response(org.slug)
         assert response.data[0]["integration"] == "github"
+        assert response.data[0]["enabled"] is True
         assert response.data[0]["users"] == []
 
     def test_owners_filters_with_different_domains(self) -> None:
@@ -211,6 +216,7 @@ class OrganizationMissingMembersTestCase(APITestCase):
 
         response = self.get_success_response(self.organization.slug)
         assert response.data[0]["integration"] == "github"
+        assert response.data[0]["enabled"] is True
         assert response.data[0]["users"] == [
             {"email": "c@example.com", "externalId": "c", "commitCount": 2},
             {"email": "d@example.com", "externalId": "d", "commitCount": 1},
@@ -241,6 +247,7 @@ class OrganizationMissingMembersTestCase(APITestCase):
         response = self.get_success_response(self.organization.slug)
 
         assert response.data[0]["integration"] == "github"
+        assert response.data[0]["enabled"] is True
         assert response.data[0]["users"] == [
             {"email": "c@example.com", "externalId": "c", "commitCount": 2},
             {"email": "d@example.com", "externalId": "d", "commitCount": 1},
@@ -265,7 +272,7 @@ class OrganizationMissingMembersTestCase(APITestCase):
         assert len(response.data) == 0
 
     def test_oi_config_reads_flag_skips_non_nudge_integrations(self) -> None:
-        """With the flag on and no OI having nudge_invite, the endpoint returns []."""
+        """With the flag on and no OI having nudge_invite, the endpoint returns enabled=False."""
         from sentry.integrations.models.organization_integration import (
             OrganizationIntegration,
         )
@@ -274,7 +281,9 @@ class OrganizationMissingMembersTestCase(APITestCase):
         with Feature({"organizations:scm-config-oi-reads": True}):
             response = self.get_success_response(self.organization.slug)
 
-        assert len(response.data) == 0
+        assert response.data[0]["integration"] == "github"
+        assert response.data[0]["enabled"] is False
+        assert response.data[0]["users"] == []
 
         # Now turn the nudge_invite flag on for one of the two github OIs. The
         # endpoint must still return missing members for the org.
@@ -288,6 +297,7 @@ class OrganizationMissingMembersTestCase(APITestCase):
         with Feature({"organizations:scm-config-oi-reads": True}):
             response = self.get_success_response(self.organization.slug)
         assert response.data[0]["integration"] == "github"
+        assert response.data[0]["enabled"] is True
         assert len(response.data[0]["users"]) > 0
 
     def test_nongithub_integration(self) -> None:
@@ -330,6 +340,7 @@ class OrganizationMissingMembersTestCase(APITestCase):
 
         response = self.get_success_response(self.organization.slug)
         assert response.data[0]["integration"] == "github"
+        assert response.data[0]["enabled"] is True
         assert response.data[0]["users"] == [
             {"email": "c@example.com", "externalId": "c", "commitCount": 2},
             {"email": "d@example.com", "externalId": "d", "commitCount": 1},
@@ -348,6 +359,7 @@ class OrganizationMissingMembersTestCase(APITestCase):
             response = self.get_success_response(self.organization.slug)
 
         assert response.data[0]["integration"] == "github"
+        assert response.data[0]["enabled"] is True
         assert response.data[0]["users"] == []
 
     def test_limit_50_missing_members(self) -> None:
@@ -363,4 +375,5 @@ class OrganizationMissingMembersTestCase(APITestCase):
             self.create_commit(repo=repo, author=nonmember_commit_author)
 
         response = self.get_success_response(self.organization.slug)
+        assert response.data[0]["enabled"] is True
         assert len(response.data[0]["users"]) == 50


### PR DESCRIPTION
The `/organizations/{slug}/missing-members/` endpoint previously returned `[]` when no `OrganizationIntegration` had `nudge_invite` enabled (under the new `scm-config-oi-reads` flag path), making it impossible to distinguish "feature disabled" from "no missing members currently."

Adds an `enabled` boolean to each integration entry. The expensive member query still only runs when `enabled=true`, so disabled orgs pay only the cost of the OI config check.

This unblocks removing `githubNudgeInvite` / `githubPRBot` / `gitlabPRBot` from the org serializer in a follow-up PR.