### PR TITLE
chore(repositories): Abstract broken integration handling into base class

### DIFF
--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -36,7 +36,6 @@ from sentry.users.models.identity import Identity
 HaltReason = Literal[
     "configuration_error",
     "connection_reset",
-    "forbidden",
     "host_timeout",
     "host_unreachable",
     "identity_not_found",
@@ -214,8 +213,6 @@ class RepositoryIntegration(
                 return "rate_limited"
             if isinstance(exc, ApiUnauthorized):
                 return "unauthorized"
-            if isinstance(exc, ApiForbiddenError):
-                return "forbidden"
             if isinstance(exc, ApiHostError):
                 return "host_unreachable"
             if isinstance(exc, ApiTimeoutError):

--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -19,12 +19,17 @@ from sentry.integrations.source_code_management.metrics import (
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import (
+    ApiConnectionResetError,
     ApiError,
     ApiForbiddenError,
+    ApiHostError,
+    ApiRateLimitedError,
     ApiRetryError,
+    ApiTimeoutError,
     ApiUnauthorized,
     IntegrationConfigurationError,
     IntegrationError,
+    UnsupportedResponseType,
 )
 from sentry.users.models.identity import Identity
 
@@ -171,6 +176,55 @@ class RepositoryIntegration(
         repositories = self.get_repositories(query=repo.name)
         repo_info = self.find_repo_info(repositories, repo.name)
         return repo_info.get("default_branch") if repo_info else None
+
+    def is_broken_integration_error(self, exc: Exception) -> str | None:
+        """Return a halt reason if this is a terminal integration error, else None.
+
+        Terminal errors indicate a broken or misconfigured integration that
+        will not self-heal through retries (e.g. revoked credentials, suspended
+        installs, unreachable hosts). Provider subclasses can override to add
+        provider-specific terminal states or refine the default behaviour.
+        """
+        from requests.exceptions import TooManyRedirects
+
+        from sentry.auth.exceptions import IdentityNotValid
+
+        if isinstance(exc, IdentityNotValid):
+            return "identity_not_valid"
+        if isinstance(exc, Identity.DoesNotExist):
+            return "identity_not_found"
+
+        if isinstance(exc, ApiError):
+            if self.is_rate_limited_error(exc):
+                return "rate_limited"
+            if isinstance(exc, ApiUnauthorized):
+                return "unauthorized"
+            if isinstance(exc, ApiForbiddenError):
+                return "forbidden"
+            if isinstance(exc, ApiHostError):
+                return "host_unreachable"
+            if isinstance(exc, ApiTimeoutError):
+                return "host_timeout"
+            if isinstance(exc, ApiConnectionResetError):
+                return "connection_reset"
+            if isinstance(exc, UnsupportedResponseType):
+                return "unsupported_response"
+            if isinstance(exc, ApiRateLimitedError):
+                return "rate_limited"
+            return None
+
+        if isinstance(exc, IntegrationConfigurationError):
+            return "configuration_error"
+        if isinstance(exc, IntegrationError):
+            cause = exc.__context__
+            if cause is not None:
+                return self.is_broken_integration_error(cause)
+            return None
+
+        if isinstance(exc, TooManyRedirects):
+            return "too_many_redirects"
+
+        return None
 
     def get_unmigratable_repositories(self) -> list[RpcRepository]:
         """

--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
-from typing import Any, Generic, NotRequired, TypedDict, TypeVar
+from typing import Any, Generic, Literal, NotRequired, TypedDict, TypeVar
 from urllib.parse import quote as urlquote
 from urllib.parse import unquote, urlparse, urlunparse
 
@@ -32,6 +32,21 @@ from sentry.shared_integrations.exceptions import (
     UnsupportedResponseType,
 )
 from sentry.users.models.identity import Identity
+
+HaltReason = Literal[
+    "configuration_error",
+    "connection_reset",
+    "forbidden",
+    "host_timeout",
+    "host_unreachable",
+    "identity_not_found",
+    "identity_not_valid",
+    "installation_suspended",
+    "rate_limited",
+    "too_many_redirects",
+    "unauthorized",
+    "unsupported_response",
+]
 
 
 class RepositoryInfo(TypedDict):
@@ -177,7 +192,7 @@ class RepositoryIntegration(
         repo_info = self.find_repo_info(repositories, repo.name)
         return repo_info.get("default_branch") if repo_info else None
 
-    def is_broken_integration_error(self, exc: Exception) -> str | None:
+    def is_broken_integration_error(self, exc: Exception) -> HaltReason | None:
         """Return a halt reason if this is a terminal integration error, else None.
 
         Terminal errors indicate a broken or misconfigured integration that

--- a/src/sentry/integrations/source_code_management/repository.py
+++ b/src/sentry/integrations/source_code_management/repository.py
@@ -232,7 +232,7 @@ class RepositoryIntegration(
             return "configuration_error"
         if isinstance(exc, IntegrationError):
             cause = exc.__context__
-            if cause is not None:
+            if isinstance(cause, Exception):
                 return self.is_broken_integration_error(cause)
             return None
 

--- a/src/sentry/integrations/source_code_management/sync_repos.py
+++ b/src/sentry/integrations/source_code_management/sync_repos.py
@@ -245,6 +245,15 @@ def _sync_repos_for_org(organization_integration_id: int) -> None:
                     "installation_suspended",
                 )
                 return
+            # Delegate remaining ApiErrors to the installation's generic check.
+            # TODO: Move the provider-specific checks above into per-provider
+            # is_broken_integration_error overrides.
+            halt_reason = installation.is_broken_integration_error(e)
+            if halt_reason:
+                _halt_broken_integration(
+                    lifecycle, e, integration.id, rpc_org.id, provider_key, halt_reason
+                )
+                return
             raise
         except IntegrationError as e:
             # VSTS's get_repositories re-wraps ApiError/IdentityNotValid into an
@@ -258,6 +267,22 @@ def _sync_repos_for_org(organization_integration_id: int) -> None:
             if provider_key == "vsts" and isinstance(cause, (IdentityNotValid, ApiUnauthorized)):
                 _halt_broken_integration(
                     lifecycle, e, integration.id, rpc_org.id, provider_key, "unauthorized"
+                )
+                return
+            # Delegate remaining IntegrationErrors to the generic check.
+            # TODO: Move the VSTS check above into a VSTS-specific override.
+            halt_reason = installation.is_broken_integration_error(e)
+            if halt_reason:
+                _halt_broken_integration(
+                    lifecycle, e, integration.id, rpc_org.id, provider_key, halt_reason
+                )
+                return
+            raise
+        except Exception as e:
+            halt_reason = installation.is_broken_integration_error(e)
+            if halt_reason:
+                _halt_broken_integration(
+                    lifecycle, e, integration.id, rpc_org.id, provider_key, halt_reason
                 )
                 return
             raise

--- a/src/sentry/integrations/source_code_management/sync_repos.py
+++ b/src/sentry/integrations/source_code_management/sync_repos.py
@@ -29,7 +29,10 @@ from sentry.integrations.source_code_management.metrics import (
     SCMIntegrationInteractionType,
 )
 from sentry.integrations.source_code_management.repo_audit import log_repo_change
-from sentry.integrations.source_code_management.repository import RepositoryIntegration
+from sentry.integrations.source_code_management.repository import (
+    HaltReason,
+    RepositoryIntegration,
+)
 from sentry.integrations.utils.metrics import IntegrationEventLifecycle
 from sentry.locks import locks
 from sentry.organizations.services.organization import organization_service
@@ -106,7 +109,7 @@ def _halt_broken_integration(
     integration_id: int,
     organization_id: int,
     provider_key: str,
-    reason: str,
+    reason: HaltReason,
 ) -> None:
     """Record a known broken-integration failure without retrying or paging.
 

--- a/src/sentry/integrations/source_code_management/sync_repos.py
+++ b/src/sentry/integrations/source_code_management/sync_repos.py
@@ -212,28 +212,10 @@ def _sync_repos_for_org(organization_integration_id: int) -> None:
                 tags={"provider": provider_key},
                 sample_rate=1.0,
             )
-        except IdentityNotValid as e:
-            _halt_broken_integration(
-                lifecycle, e, integration.id, rpc_org.id, provider_key, "identity_not_valid"
-            )
-            return
         except ApiError as e:
-            # Rate-limit check first — GitHub surfaces rate limiting as a 403,
-            # so it must be detected before the suspended-install branch.
-            if installation.is_rate_limited_error(e):
-                _halt_broken_integration(
-                    lifecycle, e, integration.id, rpc_org.id, provider_key, "rate_limited"
-                )
-                return
-            if isinstance(e, ApiUnauthorized):
-                _halt_broken_integration(
-                    lifecycle, e, integration.id, rpc_org.id, provider_key, "unauthorized"
-                )
-                return
             # GitHub returns 403 "This installation has been suspended" when the
-            # user has suspended the app install. Treat as a dead integration.
-            # Gated to GitHub providers to avoid swallowing unrelated "suspended"
-            # 403s from other providers.
+            # user has suspended the app install.
+            # TODO: Move into GitHub-specific is_broken_integration_error override.
             if (
                 provider_key in ("github", "github_enterprise")
                 and isinstance(e, ApiForbiddenError)
@@ -248,9 +230,6 @@ def _sync_repos_for_org(organization_integration_id: int) -> None:
                     "installation_suspended",
                 )
                 return
-            # Delegate remaining ApiErrors to the installation's generic check.
-            # TODO: Move the provider-specific checks above into per-provider
-            # is_broken_integration_error overrides.
             halt_reason = installation.is_broken_integration_error(e)
             if halt_reason:
                 _halt_broken_integration(
@@ -259,21 +238,15 @@ def _sync_repos_for_org(organization_integration_id: int) -> None:
                 return
             raise
         except IntegrationError as e:
-            # VSTS's get_repositories re-wraps ApiError/IdentityNotValid into an
-            # IntegrationError via message_from_error. Message text isn't a
-            # reliable signal: ApiUnauthorized maps to ERR_UNAUTHORIZED but
-            # IdentityNotValid maps to ERR_INTERNAL ("An internal error..."),
-            # which wouldn't match a "Unauthorized" string match. Python sets
-            # __context__ to the original exception when you raise inside an
-            # except block, so inspect that directly.
+            # VSTS's get_repositories re-wraps ApiError/IdentityNotValid into
+            # an IntegrationError via message_from_error.
+            # TODO: Move into a VSTS-specific is_broken_integration_error override.
             cause = e.__context__
             if provider_key == "vsts" and isinstance(cause, (IdentityNotValid, ApiUnauthorized)):
                 _halt_broken_integration(
                     lifecycle, e, integration.id, rpc_org.id, provider_key, "unauthorized"
                 )
                 return
-            # Delegate remaining IntegrationErrors to the generic check.
-            # TODO: Move the VSTS check above into a VSTS-specific override.
             halt_reason = installation.is_broken_integration_error(e)
             if halt_reason:
                 _halt_broken_integration(

--- a/tests/sentry/integrations/source_code_management/test_sync_repos.py
+++ b/tests/sentry/integrations/source_code_management/test_sync_repos.py
@@ -892,13 +892,10 @@ class IsBrokenIntegrationErrorTestCase(TestCase):
             == "unauthorized"
         )
 
-    def test_api_forbidden(self) -> None:
+    def test_api_forbidden_not_terminal(self) -> None:
         from sentry.shared_integrations.exceptions import ApiForbiddenError
 
-        assert (
-            self.installation.is_broken_integration_error(ApiForbiddenError("forbidden"))
-            == "forbidden"
-        )
+        assert self.installation.is_broken_integration_error(ApiForbiddenError("forbidden")) is None
 
     def test_api_host_error(self) -> None:
         from sentry.shared_integrations.exceptions import ApiHostError

--- a/tests/sentry/integrations/source_code_management/test_sync_repos.py
+++ b/tests/sentry/integrations/source_code_management/test_sync_repos.py
@@ -909,7 +909,7 @@ class IsBrokenIntegrationErrorTestCase(TestCase):
     def test_api_timeout_error(self) -> None:
         from sentry.shared_integrations.exceptions import ApiTimeoutError
 
-        exc = ApiTimeoutError.from_exception(Exception("timed out"))
+        exc = ApiTimeoutError("timed out")
         assert self.installation.is_broken_integration_error(exc) == "host_timeout"
 
     def test_api_connection_reset(self) -> None:
@@ -1028,7 +1028,7 @@ class SyncReposForOrgNewErrorHandlingTestCase(IntegrationTestCase):
     def test_api_timeout_halts(self, mock_get_repositories: MagicMock, _: MagicMock) -> None:
         from sentry.shared_integrations.exceptions import ApiTimeoutError
 
-        mock_get_repositories.side_effect = ApiTimeoutError.from_exception(Exception("timed out"))
+        mock_get_repositories.side_effect = ApiTimeoutError("timed out")
 
         with self.feature("organizations:github-repo-auto-sync"), self.tasks():
             sync_repos_for_org(self.oi.id)

--- a/tests/sentry/integrations/source_code_management/test_sync_repos.py
+++ b/tests/sentry/integrations/source_code_management/test_sync_repos.py
@@ -848,3 +848,245 @@ class SyncReposLockTestCase(IntegrationTestCase):
         # A second call should succeed (lock was released).
         with self.feature("organizations:github-repo-auto-sync"), self.tasks():
             sync_repos_for_org(self.oi.id)
+
+
+@control_silo_test
+class IsBrokenIntegrationErrorTestCase(TestCase):
+    """Tests for the RepositoryIntegration.is_broken_integration_error base implementation."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.integration = self.create_provider_integration(
+            provider="github",
+            external_id="12345",
+            name="test-gh",
+            metadata={
+                "access_token": "xxx",
+                "expires_at": "",
+            },
+        )
+        self.integration.add_organization(self.organization, self.user)
+        self.installation = self.integration.get_installation(organization_id=self.organization.id)
+
+    def test_identity_not_valid(self) -> None:
+        from sentry.auth.exceptions import IdentityNotValid
+
+        assert (
+            self.installation.is_broken_integration_error(IdentityNotValid())
+            == "identity_not_valid"
+        )
+
+    def test_identity_does_not_exist(self) -> None:
+        from sentry.users.models.identity import Identity
+
+        assert (
+            self.installation.is_broken_integration_error(Identity.DoesNotExist())
+            == "identity_not_found"
+        )
+
+    def test_api_unauthorized(self) -> None:
+        from sentry.shared_integrations.exceptions import ApiUnauthorized
+
+        assert (
+            self.installation.is_broken_integration_error(ApiUnauthorized("bad token"))
+            == "unauthorized"
+        )
+
+    def test_api_forbidden(self) -> None:
+        from sentry.shared_integrations.exceptions import ApiForbiddenError
+
+        assert (
+            self.installation.is_broken_integration_error(ApiForbiddenError("forbidden"))
+            == "forbidden"
+        )
+
+    def test_api_host_error(self) -> None:
+        from sentry.shared_integrations.exceptions import ApiHostError
+
+        exc = ApiHostError.from_exception(Exception("host down"))
+        assert self.installation.is_broken_integration_error(exc) == "host_unreachable"
+
+    def test_api_timeout_error(self) -> None:
+        from sentry.shared_integrations.exceptions import ApiTimeoutError
+
+        exc = ApiTimeoutError.from_exception(Exception("timed out"))
+        assert self.installation.is_broken_integration_error(exc) == "host_timeout"
+
+    def test_api_connection_reset(self) -> None:
+        from sentry.shared_integrations.exceptions import ApiConnectionResetError
+
+        assert (
+            self.installation.is_broken_integration_error(
+                ApiConnectionResetError("Connection reset")
+            )
+            == "connection_reset"
+        )
+
+    def test_unsupported_response_type(self) -> None:
+        from sentry.shared_integrations.exceptions import UnsupportedResponseType
+
+        assert (
+            self.installation.is_broken_integration_error(UnsupportedResponseType("text/html"))
+            == "unsupported_response"
+        )
+
+    def test_api_rate_limited(self) -> None:
+        from sentry.shared_integrations.exceptions import ApiRateLimitedError
+
+        assert (
+            self.installation.is_broken_integration_error(ApiRateLimitedError("slow down"))
+            == "rate_limited"
+        )
+
+    def test_integration_configuration_error(self) -> None:
+        from sentry.shared_integrations.exceptions import IntegrationConfigurationError
+
+        assert (
+            self.installation.is_broken_integration_error(
+                IntegrationConfigurationError("bad config")
+            )
+            == "configuration_error"
+        )
+
+    def test_integration_error_wrapping_terminal_cause(self) -> None:
+        from sentry.auth.exceptions import IdentityNotValid
+        from sentry.shared_integrations.exceptions import IntegrationError
+
+        exc = IntegrationError("wrapped")
+        exc.__context__ = IdentityNotValid()
+        assert self.installation.is_broken_integration_error(exc) == "identity_not_valid"
+
+    def test_integration_error_wrapping_non_terminal_cause(self) -> None:
+        from sentry.shared_integrations.exceptions import IntegrationError
+
+        exc = IntegrationError("wrapped")
+        exc.__context__ = ValueError("not terminal")
+        assert self.installation.is_broken_integration_error(exc) is None
+
+    def test_integration_error_without_context(self) -> None:
+        from sentry.shared_integrations.exceptions import IntegrationError
+
+        assert self.installation.is_broken_integration_error(IntegrationError("plain")) is None
+
+    def test_too_many_redirects(self) -> None:
+        from requests.exceptions import TooManyRedirects
+
+        assert (
+            self.installation.is_broken_integration_error(TooManyRedirects())
+            == "too_many_redirects"
+        )
+
+    def test_generic_api_error_not_terminal(self) -> None:
+        from sentry.shared_integrations.exceptions import ApiError
+
+        assert (
+            self.installation.is_broken_integration_error(ApiError("server error", code=500))
+            is None
+        )
+
+    def test_unrelated_exception_not_terminal(self) -> None:
+        assert self.installation.is_broken_integration_error(RuntimeError("boom")) is None
+
+    def test_rate_limited_via_is_rate_limited_error(self) -> None:
+        from sentry.shared_integrations.exceptions import ApiForbiddenError
+
+        exc = ApiForbiddenError('{"message":"API rate limit exceeded"}')
+        with patch.object(type(self.installation), "is_rate_limited_error", return_value=True):
+            assert self.installation.is_broken_integration_error(exc) == "rate_limited"
+
+
+@control_silo_test
+@patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+class SyncReposForOrgNewErrorHandlingTestCase(IntegrationTestCase):
+    """Tests that sync_repos_for_org halts correctly for newly-handled error types."""
+
+    provider = GitHubIntegrationProvider
+    base_url = "https://api.github.com"
+    key = "github"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.oi = OrganizationIntegration.objects.get(
+            organization_id=self.organization.id, integration=self.integration
+        )
+
+    @patch("sentry.integrations.github.integration.GitHubIntegration.get_repositories")
+    def test_api_host_error_halts(self, mock_get_repositories: MagicMock, _: MagicMock) -> None:
+        from sentry.shared_integrations.exceptions import ApiHostError
+
+        mock_get_repositories.side_effect = ApiHostError.from_exception(
+            Exception("Unable to reach host")
+        )
+
+        with self.feature("organizations:github-repo-auto-sync"), self.tasks():
+            sync_repos_for_org(self.oi.id)
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            assert Repository.objects.count() == 0
+
+    @patch("sentry.integrations.github.integration.GitHubIntegration.get_repositories")
+    def test_api_timeout_halts(self, mock_get_repositories: MagicMock, _: MagicMock) -> None:
+        from sentry.shared_integrations.exceptions import ApiTimeoutError
+
+        mock_get_repositories.side_effect = ApiTimeoutError.from_exception(Exception("timed out"))
+
+        with self.feature("organizations:github-repo-auto-sync"), self.tasks():
+            sync_repos_for_org(self.oi.id)
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            assert Repository.objects.count() == 0
+
+    @patch("sentry.integrations.github.integration.GitHubIntegration.get_repositories")
+    def test_too_many_redirects_halts(self, mock_get_repositories: MagicMock, _: MagicMock) -> None:
+        from requests.exceptions import TooManyRedirects
+
+        mock_get_repositories.side_effect = TooManyRedirects("Exceeded 30 redirects")
+
+        with self.feature("organizations:github-repo-auto-sync"), self.tasks():
+            sync_repos_for_org(self.oi.id)
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            assert Repository.objects.count() == 0
+
+    @patch("sentry.integrations.github.integration.GitHubIntegration.get_repositories")
+    def test_integration_configuration_error_halts(
+        self, mock_get_repositories: MagicMock, _: MagicMock
+    ) -> None:
+        from sentry.shared_integrations.exceptions import IntegrationConfigurationError
+
+        mock_get_repositories.side_effect = IntegrationConfigurationError("Identity not found.")
+
+        with self.feature("organizations:github-repo-auto-sync"), self.tasks():
+            sync_repos_for_org(self.oi.id)
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            assert Repository.objects.count() == 0
+
+    @patch("sentry.integrations.github.integration.GitHubIntegration.get_repositories")
+    def test_identity_does_not_exist_halts(
+        self, mock_get_repositories: MagicMock, _: MagicMock
+    ) -> None:
+        from sentry.users.models.identity import Identity
+
+        mock_get_repositories.side_effect = Identity.DoesNotExist()
+
+        with self.feature("organizations:github-repo-auto-sync"), self.tasks():
+            sync_repos_for_org(self.oi.id)
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            assert Repository.objects.count() == 0
+
+    @patch("sentry.integrations.github.integration.GitHubIntegration.get_repositories")
+    def test_generic_api_error_still_raises(
+        self, mock_get_repositories: MagicMock, _: MagicMock
+    ) -> None:
+        import pytest
+        from taskbroker_client.retry import RetryTaskError
+
+        from sentry.shared_integrations.exceptions import ApiError
+
+        mock_get_repositories.side_effect = ApiError("Internal Server Error", code=500)
+
+        with self.feature("organizations:github-repo-auto-sync"), self.tasks():
+            with pytest.raises((ApiError, RetryTaskError)):
+                sync_repos_for_org(self.oi.id)


### PR DESCRIPTION
It's getting increasingly messy handling all of these errors. Consolidating these into the `RepositoryIntegration` so that we can override it per provider

<!-- Describe your PR here. -->