### PR TITLE
fix(spans-migration): don't migrate homepage discover queries

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -345,6 +345,7 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
                     "widget_type": "Attribute value `discover` is deprecated. Please use `error-events` or `transaction-like`"
                 }
             )
+
         return widget_type
 
     validate_id = validate_id
@@ -447,7 +448,6 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
                 self.context["organization"],
                 actor=self.context["request"].user,
             )
-            and not data.get("id")
             and data.get("widget_type") == DashboardWidgetTypes.TRANSACTION_LIKE
         ):
             raise serializers.ValidationError(

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -448,6 +448,7 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
                 self.context["organization"],
                 actor=self.context["request"].user,
             )
+            and not data.get("id")
             and data.get("widget_type") == DashboardWidgetTypes.TRANSACTION_LIKE
         ):
             raise serializers.ValidationError(

--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -345,7 +345,6 @@ class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
                     "widget_type": "Attribute value `discover` is deprecated. Please use `error-events` or `transaction-like`"
                 }
             )
-
         return widget_type
 
     validate_id = validate_id

--- a/src/sentry/explore/translation/discover_translation.py
+++ b/src/sentry/explore/translation/discover_translation.py
@@ -262,6 +262,11 @@ def _translate_discover_query_field_to_explore_query_schema(
 def translate_discover_query_to_explore_query(
     discover_query: DiscoverSavedQuery,
 ) -> ExploreSavedQuery:
+    if discover_query.is_homepage:
+        raise Exception(
+            "this query is a homepage query and will not be translated to an explore query"
+        )
+
     translated_query_field, dropped_fields_from_translation = (
         _translate_discover_query_field_to_explore_query_schema(discover_query.query)
     )

--- a/tests/sentry/explore/translation/test_discover_translation.py
+++ b/tests/sentry/explore/translation/test_discover_translation.py
@@ -23,7 +23,7 @@ class DiscoverToExploreTranslationTest(TestCase):
             last_visited=before_now(minutes=5),
             dataset=DiscoverSavedQueryTypes.TRANSACTION_LIKE,
             explore_query=explore_query,
-            is_homepage=is_homepage if is_homepage is not None else None,
+            is_homepage=is_homepage,
         )
         discover_saved_query.set_projects([self.project1.id, self.project2.id])
 

--- a/tests/sentry/explore/translation/test_discover_translation.py
+++ b/tests/sentry/explore/translation/test_discover_translation.py
@@ -1,3 +1,5 @@
+import pytest
+
 from sentry.discover.models import DiscoverSavedQuery, DiscoverSavedQueryTypes
 from sentry.explore.models import ExploreSavedQuery, ExploreSavedQueryDataset
 from sentry.explore.translation.discover_translation import (
@@ -8,7 +10,7 @@ from sentry.testutils.helpers.datetime import before_now
 
 
 class DiscoverToExploreTranslationTest(TestCase):
-    def create_discover_query(self, name: str, query: dict, explore_query=None):
+    def create_discover_query(self, name: str, query: dict, explore_query=None, is_homepage=False):
         discover_saved_query = DiscoverSavedQuery.objects.create(
             organization=self.org,
             created_by_id=self.user.id,
@@ -21,6 +23,7 @@ class DiscoverToExploreTranslationTest(TestCase):
             last_visited=before_now(minutes=5),
             dataset=DiscoverSavedQueryTypes.TRANSACTION_LIKE,
             explore_query=explore_query,
+            is_homepage=is_homepage if is_homepage is not None else None,
         )
         discover_saved_query.set_projects([self.project1.id, self.project2.id])
 
@@ -374,3 +377,20 @@ class DiscoverToExploreTranslationTest(TestCase):
         assert query["mode"] == "samples"
         assert query["aggregateOrderby"] is None
         assert query["orderby"] is None
+
+    def test_translate_homepage_discover_query_to_explore_query(self) -> None:
+        self.homepage_query = {
+            "query": "",
+            "range": "14d",
+            "yAxis": ["count()"],
+            "fields": ["id", "timestamp"],
+            "orderby": "-timestamp",
+            "display": "default",
+            "environment": [],
+        }
+        self.homepage_saved_query = self.create_discover_query(
+            "Homepage query", self.homepage_query, is_homepage=True
+        )
+
+        with pytest.raises(Exception):
+            translate_discover_query_to_explore_query(self.homepage_saved_query)


### PR DESCRIPTION
just realized we were migrating homepage queries which we shouldn't be. I was revisiting these scripts just because we need to migrate the queries of freshly am1->3 migrated orgs (billing team is doing them in small batches and i wanna make sure those are migrated before span first goes out)
