### PR TITLE
fix(preprod): Keep snapshot group headers visible

### DIFF
--- a/static/app/views/preprod/snapshots/main/snapshotFrames.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotFrames.tsx
@@ -26,9 +26,9 @@ export function SnapshotCardFrame({
   );
 }
 
-function SnapshotGroupHeader({name}: {name: string}) {
+export function SnapshotGroupHeader({name}: {name: string}) {
   return (
-    <Container padding="lg xl" borderBottom="secondary">
+    <Container padding="lg xl" borderBottom="secondary" background="primary">
       <Heading as="h3" size="md">
         {name}
       </Heading>

--- a/static/app/views/preprod/snapshots/main/snapshotListView.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.tsx
@@ -356,9 +356,10 @@ export function SnapshotListView({
       ? 0
       : Math.min(
           Math.max(0, (activeGroupTop ?? 0) - stickyHeaderTop),
-          activeGroupBottom - (stickyHeaderTop + HEADER_HEIGHT)
+          activeGroupBottom - (stickyHeaderTop + HEADER_HEIGHT) + 2
         );
   const stickyHeaderHasDetachedFrame = scrollTop < scrollContainerPaddingTop;
+  const stickyHeaderHasBottomFrame = stickyHeaderTranslateY < 0;
   const stickyHeaderStyle = {
     '--sticky-header-translate-y': `${stickyHeaderTranslateY}px`,
   } as React.CSSProperties;
@@ -406,6 +407,7 @@ export function SnapshotListView({
       scrollTop,
       activeGroupBottom,
       activeGroupTop,
+      stickyHeaderHasBottomFrame,
       stickyHeaderHasDetachedFrame,
       stickyHeaderTop,
       stickyHeaderTranslateY,
@@ -429,6 +431,7 @@ export function SnapshotListView({
     scrollTop,
     activeGroupBottom,
     activeGroupTop,
+    stickyHeaderHasBottomFrame,
     stickyHeaderHasDetachedFrame,
     stickyHeaderTop,
     stickyHeaderTranslateY,
@@ -447,6 +450,7 @@ export function SnapshotListView({
       {activeGroupName ? (
         <StickyGroupHeader
           ref={stickyHeaderRef}
+          data-bottom-frame={stickyHeaderHasBottomFrame ? '' : undefined}
           data-detached-frame={stickyHeaderHasDetachedFrame ? '' : undefined}
           style={stickyHeaderStyle}
         >
@@ -587,6 +591,12 @@ const StickyGroupHeader = styled('div')`
     border-top: 1px solid ${p => p.theme.tokens.border.primary};
     border-top-left-radius: ${p => p.theme.radius.md};
     border-top-right-radius: ${p => p.theme.radius.md};
+  }
+
+  &[data-bottom-frame] > * {
+    border-bottom-left-radius: ${p => p.theme.radius.md};
+    border-bottom-right-radius: ${p => p.theme.radius.md};
+    border-bottom: 0;
   }
 `;
 

--- a/static/app/views/preprod/snapshots/main/snapshotListView.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.tsx
@@ -1,4 +1,5 @@
-import {memo, useEffect, useMemo, useRef} from 'react';
+import {memo, useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {useVirtualizer} from '@tanstack/react-virtual';
 
@@ -71,6 +72,7 @@ const CARD_GAP = 0;
 const GROUP_PADDING = 0;
 const ROW_PADDING_BOTTOM = 16;
 const LIST_CONTENT_WIDTH_ASSUMPTION = 900;
+const STICKY_HEADER_DEBUG_PARAM = 'debugStickyHeader';
 
 function estimateCardHeight(image: SnapshotImage, splitColumns: boolean) {
   const columnWidth = splitColumns
@@ -153,8 +155,14 @@ export function SnapshotListView({
   overlayColor,
   diffImageBaseUrl,
 }: SnapshotListViewProps) {
+  const theme = useTheme();
   const groups = useMemo(() => buildGroups(items), [items]);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const stickyHeaderRef = useRef<HTMLDivElement>(null);
+  const [scrollTop, setScrollTop] = useState(0);
+  const handleScroll = useCallback((event: React.UIEvent<HTMLDivElement>) => {
+    setScrollTop(event.currentTarget.scrollTop);
+  }, []);
 
   const virtualizer = useVirtualizer({
     count: groups.length,
@@ -319,6 +327,113 @@ export function SnapshotListView({
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, []);
 
+  const virtualItems = virtualizer.getVirtualItems();
+  const totalSize = virtualizer.getTotalSize();
+  const scrollOffset = virtualizer.scrollOffset ?? 0;
+  const scrollContainerPaddingTop = Number.parseFloat(theme.space.xl);
+  const activeGroupThreshold = scrollTop - scrollContainerPaddingTop;
+  const activeVirtualItem = virtualItems.find(virtualItem => {
+    return scrollTop > 0 && activeGroupThreshold < virtualItem.end - ROW_PADDING_BOTTOM;
+  });
+  const activeGroup =
+    activeVirtualItem === undefined ? null : groups[activeVirtualItem.index]!;
+  const activeGroupName =
+    activeGroup && !activeGroup.isUngrouped ? activeGroup.name : null;
+  const stickyHeaderTop = Math.max(scrollContainerPaddingTop - scrollTop, 0);
+  const activeGroupTop =
+    activeVirtualItem === undefined
+      ? null
+      : scrollContainerPaddingTop + activeVirtualItem.start - scrollTop;
+  const activeGroupBottom =
+    activeVirtualItem === undefined
+      ? null
+      : scrollContainerPaddingTop +
+        activeVirtualItem.end -
+        ROW_PADDING_BOTTOM -
+        scrollTop;
+  const stickyHeaderTranslateY =
+    activeGroupBottom === null
+      ? 0
+      : Math.min(
+          Math.max(0, (activeGroupTop ?? 0) - stickyHeaderTop),
+          activeGroupBottom - (stickyHeaderTop + HEADER_HEIGHT)
+        );
+  const stickyHeaderHasDetachedFrame = scrollTop < scrollContainerPaddingTop;
+  const stickyHeaderStyle = {
+    '--sticky-header-translate-y': `${stickyHeaderTranslateY}px`,
+  } as React.CSSProperties;
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    if (!params.has(STICKY_HEADER_DEBUG_PARAM)) {
+      return;
+    }
+
+    const scrollElement = scrollRef.current;
+    const stickyElement = stickyHeaderRef.current;
+    const stickyHeaderElement = stickyElement?.firstElementChild;
+    const scrollRect = scrollElement?.getBoundingClientRect();
+    const stickyRect = stickyElement?.getBoundingClientRect();
+    const headerRect = stickyHeaderElement?.getBoundingClientRect();
+    const scrollStyles = scrollElement ? window.getComputedStyle(scrollElement) : null;
+    const stickyStyles = stickyElement ? window.getComputedStyle(stickyElement) : null;
+    const headerStyles = stickyHeaderElement
+      ? window.getComputedStyle(stickyHeaderElement)
+      : null;
+    const stickyTop = stickyStyles ? Number.parseFloat(stickyStyles.top) : null;
+    const stickyTopInScrollContainer =
+      stickyRect && scrollRect ? stickyRect.top - scrollRect.top : null;
+
+    // eslint-disable-next-line no-console
+    console.debug('[snapshot sticky header]', {
+      activeGroupName,
+      activeVirtualItem: activeVirtualItem
+        ? {
+            index: activeVirtualItem.index,
+            start: activeVirtualItem.start,
+            end: activeVirtualItem.end,
+            size: activeVirtualItem.size,
+          }
+        : null,
+      distanceIntoActiveRow: activeVirtualItem
+        ? scrollOffset - activeVirtualItem.start
+        : null,
+      distanceToActiveRowEnd: activeVirtualItem
+        ? activeVirtualItem.end - ROW_PADDING_BOTTOM - scrollOffset
+        : null,
+      activeGroupThreshold,
+      scrollOffset,
+      scrollTop,
+      activeGroupBottom,
+      activeGroupTop,
+      stickyHeaderHasDetachedFrame,
+      stickyHeaderTop,
+      stickyHeaderTranslateY,
+      scrollPaddingTop: scrollStyles ? Number.parseFloat(scrollStyles.paddingTop) : null,
+      stickyTop,
+      stickyTopInScrollContainer,
+      stickyDistanceToClamp:
+        stickyTop !== null && stickyTopInScrollContainer !== null
+          ? stickyTopInScrollContainer - stickyTop
+          : null,
+      stickyHeaderBorderRadius: headerStyles?.borderTopLeftRadius ?? null,
+      stickyHeaderBorderTopWidth: headerStyles?.borderTopWidth ?? null,
+      stickyHeaderTopInScrollContainer:
+        headerRect && scrollRect ? headerRect.top - scrollRect.top : null,
+    });
+  }, [
+    activeGroupName,
+    activeVirtualItem,
+    activeGroupThreshold,
+    scrollOffset,
+    scrollTop,
+    activeGroupBottom,
+    activeGroupTop,
+    stickyHeaderHasDetachedFrame,
+    stickyHeaderTop,
+    stickyHeaderTranslateY,
+  ]);
+
   if (items.length === 0) {
     return (
       <Flex align="center" justify="center" padding="3xl" width="100%">
@@ -327,24 +442,14 @@ export function SnapshotListView({
     );
   }
 
-  const virtualItems = virtualizer.getVirtualItems();
-  const totalSize = virtualizer.getTotalSize();
-  const scrollOffset = virtualizer.scrollOffset ?? 0;
-  const activeVirtualItem = virtualItems.find(virtualItem => {
-    return (
-      scrollOffset > virtualItem.start &&
-      scrollOffset < virtualItem.end - ROW_PADDING_BOTTOM
-    );
-  });
-  const activeGroup =
-    activeVirtualItem === undefined ? null : groups[activeVirtualItem.index]!;
-  const activeGroupName =
-    activeGroup && !activeGroup.isUngrouped ? activeGroup.name : null;
-
   return (
-    <ScrollContainer ref={scrollRef}>
+    <ScrollContainer ref={scrollRef} onScroll={handleScroll}>
       {activeGroupName ? (
-        <StickyGroupHeader>
+        <StickyGroupHeader
+          ref={stickyHeaderRef}
+          data-detached-frame={stickyHeaderHasDetachedFrame ? '' : undefined}
+          style={stickyHeaderStyle}
+        >
           <SnapshotGroupHeader name={activeGroupName} />
         </StickyGroupHeader>
       ) : null}
@@ -475,6 +580,13 @@ const StickyGroupHeader = styled('div')`
   > * {
     border-left: 1px solid ${p => p.theme.tokens.border.primary};
     border-right: 1px solid ${p => p.theme.tokens.border.primary};
+    transform: translateY(var(--sticky-header-translate-y, 0px));
+  }
+
+  &[data-detached-frame] > * {
+    border-top: 1px solid ${p => p.theme.tokens.border.primary};
+    border-top-left-radius: ${p => p.theme.radius.md};
+    border-top-right-radius: ${p => p.theme.radius.md};
   }
 `;
 

--- a/static/app/views/preprod/snapshots/main/snapshotListView.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.tsx
@@ -15,7 +15,7 @@ import type {
 import type {DiffMode} from './imageDisplay/diffImageDisplay';
 import {ImageCard, PairCard} from './snapshotCards';
 import {MAX_IMAGE_HEIGHT} from './snapshotDiffBodies';
-import {SnapshotCardFrame} from './snapshotFrames';
+import {SnapshotCardFrame, SnapshotGroupHeader} from './snapshotFrames';
 
 interface SnapshotListViewProps {
   imageBaseUrl: string;
@@ -329,9 +329,25 @@ export function SnapshotListView({
 
   const virtualItems = virtualizer.getVirtualItems();
   const totalSize = virtualizer.getTotalSize();
+  const scrollOffset = virtualizer.scrollOffset ?? 0;
+  const activeVirtualItem = virtualItems.find(virtualItem => {
+    return (
+      scrollOffset > virtualItem.start &&
+      scrollOffset < virtualItem.end - ROW_PADDING_BOTTOM
+    );
+  });
+  const activeGroup =
+    activeVirtualItem === undefined ? null : groups[activeVirtualItem.index]!;
+  const activeGroupName =
+    activeGroup && !activeGroup.isUngrouped ? activeGroup.name : null;
 
   return (
     <ScrollContainer ref={scrollRef}>
+      {activeGroupName ? (
+        <StickyGroupHeader>
+          <SnapshotGroupHeader name={activeGroupName} />
+        </StickyGroupHeader>
+      ) : null}
       <Container position="relative" width="100%" style={{height: totalSize}}>
         {virtualItems.map(vi => {
           const group = groups[vi.index]!;
@@ -435,6 +451,7 @@ export const GroupHeader = memo(function GroupHeader({name}: {name: string}) {
 });
 
 const ScrollContainer = styled('div')`
+  position: relative;
   flex: 1 1 0;
   min-height: 0;
   width: 100%;
@@ -446,6 +463,19 @@ const ScrollContainer = styled('div')`
   overscroll-behavior: contain;
   scroll-padding-top: ${p => p.theme.space.md};
   scroll-padding-bottom: ${p => p.theme.space.md};
+`;
+
+const StickyGroupHeader = styled('div')`
+  position: sticky;
+  top: -${p => p.theme.space.xl};
+  z-index: 1;
+  height: 0;
+  pointer-events: none;
+
+  > * {
+    border-left: 1px solid ${p => p.theme.tokens.border.primary};
+    border-right: 1px solid ${p => p.theme.tokens.border.primary};
+  }
 `;
 
 const RowPositioner = styled('div')`

--- a/static/app/views/preprod/snapshots/main/snapshotListView.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.tsx
@@ -72,7 +72,6 @@ const CARD_GAP = 0;
 const GROUP_PADDING = 0;
 const ROW_PADDING_BOTTOM = 16;
 const LIST_CONTENT_WIDTH_ASSUMPTION = 900;
-const STICKY_HEADER_DEBUG_PARAM = 'debugStickyHeader';
 const SNAPSHOT_FRAME_BORDER_WIDTH = 1;
 const STICKY_HEADER_BOTTOM_OVERLAP = SNAPSHOT_FRAME_BORDER_WIDTH * 2;
 
@@ -160,7 +159,6 @@ export function SnapshotListView({
   const theme = useTheme();
   const groups = useMemo(() => buildGroups(items), [items]);
   const scrollRef = useRef<HTMLDivElement>(null);
-  const stickyHeaderRef = useRef<HTMLDivElement>(null);
   const [scrollTop, setScrollTop] = useState(0);
   const handleScroll = useCallback((event: React.UIEvent<HTMLDivElement>) => {
     setScrollTop(event.currentTarget.scrollTop);
@@ -331,7 +329,6 @@ export function SnapshotListView({
 
   const virtualItems = virtualizer.getVirtualItems();
   const totalSize = virtualizer.getTotalSize();
-  const scrollOffset = virtualizer.scrollOffset ?? 0;
   const scrollContainerPaddingTop = Number.parseFloat(theme.space.xl);
   const activeGroupThreshold = scrollTop - scrollContainerPaddingTop;
   const activeVirtualItem = virtualItems.find(virtualItem => {
@@ -369,79 +366,6 @@ export function SnapshotListView({
     '--sticky-header-translate-y': `${stickyHeaderTranslateY}px`,
   } as React.CSSProperties;
 
-  useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    if (!params.has(STICKY_HEADER_DEBUG_PARAM)) {
-      return;
-    }
-
-    const scrollElement = scrollRef.current;
-    const stickyElement = stickyHeaderRef.current;
-    const stickyHeaderElement = stickyElement?.firstElementChild;
-    const scrollRect = scrollElement?.getBoundingClientRect();
-    const stickyRect = stickyElement?.getBoundingClientRect();
-    const headerRect = stickyHeaderElement?.getBoundingClientRect();
-    const scrollStyles = scrollElement ? window.getComputedStyle(scrollElement) : null;
-    const stickyStyles = stickyElement ? window.getComputedStyle(stickyElement) : null;
-    const headerStyles = stickyHeaderElement
-      ? window.getComputedStyle(stickyHeaderElement)
-      : null;
-    const stickyTop = stickyStyles ? Number.parseFloat(stickyStyles.top) : null;
-    const stickyTopInScrollContainer =
-      stickyRect && scrollRect ? stickyRect.top - scrollRect.top : null;
-
-    // eslint-disable-next-line no-console
-    console.debug('[snapshot sticky header]', {
-      activeGroupName,
-      activeVirtualItem: activeVirtualItem
-        ? {
-            index: activeVirtualItem.index,
-            start: activeVirtualItem.start,
-            end: activeVirtualItem.end,
-            size: activeVirtualItem.size,
-          }
-        : null,
-      distanceIntoActiveRow: activeVirtualItem
-        ? scrollOffset - activeVirtualItem.start
-        : null,
-      distanceToActiveRowEnd: activeVirtualItem
-        ? activeVirtualItem.end - ROW_PADDING_BOTTOM - scrollOffset
-        : null,
-      activeGroupThreshold,
-      scrollOffset,
-      scrollTop,
-      activeGroupBottom,
-      activeGroupTop,
-      stickyHeaderHasBottomFrame,
-      stickyHeaderHasDetachedFrame,
-      stickyHeaderTop,
-      stickyHeaderTranslateY,
-      scrollPaddingTop: scrollStyles ? Number.parseFloat(scrollStyles.paddingTop) : null,
-      stickyTop,
-      stickyTopInScrollContainer,
-      stickyDistanceToClamp:
-        stickyTop !== null && stickyTopInScrollContainer !== null
-          ? stickyTopInScrollContainer - stickyTop
-          : null,
-      stickyHeaderBorderRadius: headerStyles?.borderTopLeftRadius ?? null,
-      stickyHeaderBorderTopWidth: headerStyles?.borderTopWidth ?? null,
-      stickyHeaderTopInScrollContainer:
-        headerRect && scrollRect ? headerRect.top - scrollRect.top : null,
-    });
-  }, [
-    activeGroupName,
-    activeVirtualItem,
-    activeGroupThreshold,
-    scrollOffset,
-    scrollTop,
-    activeGroupBottom,
-    activeGroupTop,
-    stickyHeaderHasBottomFrame,
-    stickyHeaderHasDetachedFrame,
-    stickyHeaderTop,
-    stickyHeaderTranslateY,
-  ]);
-
   if (items.length === 0) {
     return (
       <Flex align="center" justify="center" padding="3xl" width="100%">
@@ -454,7 +378,6 @@ export function SnapshotListView({
     <ScrollContainer ref={scrollRef} onScroll={handleScroll}>
       {activeGroupName ? (
         <StickyGroupHeader
-          ref={stickyHeaderRef}
           data-bottom-frame={stickyHeaderHasBottomFrame ? '' : undefined}
           data-detached-frame={stickyHeaderHasDetachedFrame ? '' : undefined}
           style={stickyHeaderStyle}

--- a/static/app/views/preprod/snapshots/main/snapshotListView.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.tsx
@@ -334,28 +334,29 @@ export function SnapshotListView({
   const activeVirtualItem = virtualItems.find(virtualItem => {
     return scrollTop > 0 && activeGroupThreshold < virtualItem.end - ROW_PADDING_BOTTOM;
   });
-  const activeGroup =
-    activeVirtualItem === undefined ? null : groups[activeVirtualItem.index]!;
+  const activeGroupBounds =
+    activeVirtualItem === undefined
+      ? null
+      : {
+          bottom:
+            scrollContainerPaddingTop +
+            activeVirtualItem.end -
+            ROW_PADDING_BOTTOM -
+            scrollTop,
+          group: groups[activeVirtualItem.index]!,
+          top: scrollContainerPaddingTop + activeVirtualItem.start - scrollTop,
+        };
   const activeGroupName =
-    activeGroup && !activeGroup.isUngrouped ? activeGroup.name : null;
+    activeGroupBounds && !activeGroupBounds.group.isUngrouped
+      ? activeGroupBounds.group.name
+      : null;
   const stickyHeaderTop = Math.max(scrollContainerPaddingTop - scrollTop, 0);
-  const activeGroupTop =
-    activeVirtualItem === undefined
-      ? null
-      : scrollContainerPaddingTop + activeVirtualItem.start - scrollTop;
-  const activeGroupBottom =
-    activeVirtualItem === undefined
-      ? null
-      : scrollContainerPaddingTop +
-        activeVirtualItem.end -
-        ROW_PADDING_BOTTOM -
-        scrollTop;
   const stickyHeaderTranslateY =
-    activeGroupBottom === null
+    activeGroupBounds === null
       ? 0
       : Math.min(
-          Math.max(0, (activeGroupTop ?? 0) - stickyHeaderTop),
-          activeGroupBottom -
+          Math.max(0, activeGroupBounds.top - stickyHeaderTop),
+          activeGroupBounds.bottom -
             (stickyHeaderTop + HEADER_HEIGHT) +
             STICKY_HEADER_BOTTOM_OVERLAP
         );

--- a/static/app/views/preprod/snapshots/main/snapshotListView.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.tsx
@@ -360,8 +360,10 @@ export function SnapshotListView({
             (stickyHeaderTop + HEADER_HEIGHT) +
             STICKY_HEADER_BOTTOM_OVERLAP
         );
+  // detached frame is to detect when the top of the active group has not yet hit the control container and needs top border styling
   const stickyHeaderHasDetachedFrame =
     scrollTop < scrollContainerPaddingTop || stickyHeaderTranslateY > 0;
+  // bottom frame is to detect when the sticky header is near the bottom of the group container
   const stickyHeaderHasBottomFrame = stickyHeaderTranslateY < 0;
   const stickyHeaderStyle = {
     '--sticky-header-translate-y': `${stickyHeaderTranslateY}px`,

--- a/static/app/views/preprod/snapshots/main/snapshotListView.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.tsx
@@ -66,7 +66,8 @@ interface GroupRow {
   name: string;
 }
 
-const HEADER_HEIGHT = 44;
+// Keep in sync with SnapshotGroupHeader: lg vertical padding + md heading height.
+const SNAPSHOT_GROUP_HEADER_HEIGHT = 44;
 const CARD_CHROME_HEIGHT = 120;
 const CARD_GAP = 0;
 const GROUP_PADDING = 0;
@@ -138,7 +139,9 @@ function buildGroups(items: SidebarItem[]): GroupRow[] {
       cards,
       isUngrouped: ungrouped,
       estimatedHeight:
-        (ungrouped ? cardsHeight : HEADER_HEIGHT + cardsHeight + GROUP_PADDING) +
+        (ungrouped
+          ? cardsHeight
+          : SNAPSHOT_GROUP_HEADER_HEIGHT + cardsHeight + GROUP_PADDING) +
         ROW_PADDING_BOTTOM,
     });
   }
@@ -357,7 +360,7 @@ export function SnapshotListView({
       : Math.min(
           Math.max(0, activeGroupBounds.top - stickyHeaderTop),
           activeGroupBounds.bottom -
-            (stickyHeaderTop + HEADER_HEIGHT) +
+            (stickyHeaderTop + SNAPSHOT_GROUP_HEADER_HEIGHT) +
             STICKY_HEADER_BOTTOM_OVERLAP
         );
   // detached frame is to detect when the top of the active group has not yet hit the control container and needs top border styling

--- a/static/app/views/preprod/snapshots/main/snapshotListView.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.tsx
@@ -73,6 +73,8 @@ const GROUP_PADDING = 0;
 const ROW_PADDING_BOTTOM = 16;
 const LIST_CONTENT_WIDTH_ASSUMPTION = 900;
 const STICKY_HEADER_DEBUG_PARAM = 'debugStickyHeader';
+const SNAPSHOT_FRAME_BORDER_WIDTH = 1;
+const STICKY_HEADER_BOTTOM_OVERLAP = SNAPSHOT_FRAME_BORDER_WIDTH * 2;
 
 function estimateCardHeight(image: SnapshotImage, splitColumns: boolean) {
   const columnWidth = splitColumns
@@ -356,9 +358,12 @@ export function SnapshotListView({
       ? 0
       : Math.min(
           Math.max(0, (activeGroupTop ?? 0) - stickyHeaderTop),
-          activeGroupBottom - (stickyHeaderTop + HEADER_HEIGHT) + 2
+          activeGroupBottom -
+            (stickyHeaderTop + HEADER_HEIGHT) +
+            STICKY_HEADER_BOTTOM_OVERLAP
         );
-  const stickyHeaderHasDetachedFrame = scrollTop < scrollContainerPaddingTop;
+  const stickyHeaderHasDetachedFrame =
+    scrollTop < scrollContainerPaddingTop || stickyHeaderTranslateY > 0;
   const stickyHeaderHasBottomFrame = stickyHeaderTranslateY < 0;
   const stickyHeaderStyle = {
     '--sticky-header-translate-y': `${stickyHeaderTranslateY}px`,


### PR DESCRIPTION
Keep snapshot group context visible while scrolling long preprod snapshot lists. This stacks on #114448 and adds a pinned group label inside the virtualized list so reviewers can tell which grouped variants are currently in view after the original group header scrolls away.

**Virtualized List Header**

The pinned label is driven by the active virtual row instead of native sticky positioning inside transformed rows, which avoids moving every mounted group header at once.

Refs #114448