### PR TITLE
feat(sentry-apps): Enforce is_disabled at the endpoint layer

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -386,7 +386,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-added", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Organizations on the new seat-based Seer plan
     manager.add("organizations:seat-based-seer-enabled", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
-    manager.add("organizations:sentry-app-disabled-enforcement", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable new SentryApp webhook request endpoint
     manager.add("organizations:sentry-app-webhook-requests", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable mobile starfish ui module view

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -386,6 +386,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-added", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Organizations on the new seat-based Seer plan
     manager.add("organizations:seat-based-seer-enabled", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
+    manager.add("organizations:sentry-app-disabled-enforcement", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable new SentryApp webhook request endpoint
     manager.add("organizations:sentry-app-webhook-requests", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable mobile starfish ui module view

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -4047,6 +4047,14 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Enforce is_disabled field on sentry app endpoints and webhooks.
+register(
+    "sentry-apps.disabled-enforcement",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Disable paranoia for sentry apps
 register(
     "sentry-apps.hard-delete",

--- a/src/sentry/sentry_apps/api/bases/sentryapps.py
+++ b/src/sentry/sentry_apps/api/bases/sentryapps.py
@@ -9,6 +9,7 @@ from rest_framework.permissions import BasePermission
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.api.authentication import ClientIdSecretAuthentication, JWTClientSecretAuthentication
 from sentry.api.base import Endpoint
 from sentry.api.permissions import SentryPermission, StaffPermissionMixin
@@ -93,7 +94,33 @@ class SentryAppsAndStaffPermission(StaffPermissionMixin, SentryAppsPermission):
     staff_allowed_methods = {"GET"}
 
 
+def _check_sentry_app_disabled(
+    endpoint: IntegrationPlatformEndpoint,
+    request: Request,
+    sentry_app: SentryApp | RpcSentryApp,
+) -> None:
+    if not sentry_app.is_disabled:
+        return
+
+    if request.method in endpoint.allow_disabled_sentry_app_for_methods:
+        return
+
+    owner_context = organization_service.get_organization_by_id(
+        id=sentry_app.owner_id, user_id=None, include_projects=False, include_teams=False
+    )
+    if owner_context and features.has(
+        "organizations:sentry-app-disabled-enforcement",
+        owner_context.organization,
+    ):
+        raise SentryAppError(
+            message="This Sentry App has been disabled",
+            status_code=403,
+        )
+
+
 class IntegrationPlatformEndpoint(Endpoint):
+    allow_disabled_sentry_app_for_methods: set[str] = set()
+
     def respond_rpc_sentry_app_error(self, rpc_error: RpcSentryAppError) -> Response:
         """
         Surfaces errors from the cell-side Sentry App RPC to the client.
@@ -279,6 +306,7 @@ class SentryAppBaseEndpoint(IntegrationPlatformEndpoint):
             raise SentryAppError(message="Could not find the requested sentry app", status_code=404)
 
         self.check_object_permissions(request, sentry_app)
+        _check_sentry_app_disabled(self, request, sentry_app)
 
         sentry_sdk.get_isolation_scope().set_tag("sentry_app", sentry_app.slug)
 
@@ -298,6 +326,7 @@ class CellSentryAppBaseEndpoint(IntegrationPlatformEndpoint):
             raise SentryAppError(message="Could not find the requested sentry app", status_code=404)
 
         self.check_object_permissions(request, sentry_app)
+        _check_sentry_app_disabled(self, request, sentry_app)
 
         sentry_sdk.get_isolation_scope().set_tag("sentry_app", sentry_app.slug)
 
@@ -424,6 +453,7 @@ class SentryAppInstallationBaseEndpoint(IntegrationPlatformEndpoint):
             )
 
         self.check_object_permissions(request, installation)
+        _check_sentry_app_disabled(self, request, installation.sentry_app)
 
         sentry_sdk.get_isolation_scope().set_tag("sentry_app_installation", installation.uuid)
 

--- a/src/sentry/sentry_apps/api/bases/sentryapps.py
+++ b/src/sentry/sentry_apps/api/bases/sentryapps.py
@@ -9,7 +9,7 @@ from rest_framework.permissions import BasePermission
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
+from sentry import options
 from sentry.api.authentication import ClientIdSecretAuthentication, JWTClientSecretAuthentication
 from sentry.api.base import Endpoint
 from sentry.api.permissions import SentryPermission, StaffPermissionMixin
@@ -105,13 +105,7 @@ def _check_sentry_app_disabled(
     if request.method in endpoint.allow_disabled_sentry_app_for_methods:
         return
 
-    owner_context = organization_service.get_organization_by_id(
-        id=sentry_app.owner_id, user_id=None, include_projects=False, include_teams=False
-    )
-    if owner_context and features.has(
-        "organizations:sentry-app-disabled-enforcement",
-        owner_context.organization,
-    ):
+    if options.get("sentry-apps.disabled-enforcement"):
         raise SentryAppError(
             message="This Sentry App has been disabled",
             status_code=403,

--- a/src/sentry/sentry_apps/api/endpoints/installation_details.py
+++ b/src/sentry/sentry_apps/api/endpoints/installation_details.py
@@ -34,6 +34,7 @@ class SentryAppInstallationDetailsEndpoint(SentryAppInstallationBaseEndpoint):
         "GET": ApiPublishStatus.UNKNOWN,
         "PUT": ApiPublishStatus.UNKNOWN,
     }
+    allow_disabled_sentry_app_for_methods = {"DELETE"}
 
     def get(self, request: Request, installation) -> Response:
         return Response(

--- a/src/sentry/sentry_apps/api/endpoints/sentry_app_details.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_app_details.py
@@ -62,6 +62,7 @@ class SentryAppDetailsEndpoint(SentryAppBaseEndpoint):
         "PUT": ApiPublishStatus.PUBLIC,
     }
     permission_classes = (SentryAppDetailsEndpointPermission,)
+    allow_disabled_sentry_app_for_methods = {"DELETE", "PUT"}
 
     @extend_schema(
         operation_id="Retrieve a custom integration by ID or slug.",

--- a/src/sentry/sentry_apps/api/endpoints/sentry_internal_app_token_details.py
+++ b/src/sentry/sentry_apps/api/endpoints/sentry_internal_app_token_details.py
@@ -29,6 +29,7 @@ class SentryInternalAppTokenDetailsEndpoint(SentryAppBaseEndpoint):
         "DELETE": ApiPublishStatus.PRIVATE,
     }
     permission_classes = (SentryInternalAppTokenPermission, DisallowImpersonatedTokenCreation)
+    allow_disabled_sentry_app_for_methods = {"DELETE"}
 
     def convert_args(self, request: Request, sentry_app_id_or_slug, api_token_id, *args, **kwargs):
         # get the sentry_app from the SentryAppBaseEndpoint class

--- a/src/sentry/sentry_apps/services/app/model.py
+++ b/src/sentry/sentry_apps/services/app/model.py
@@ -86,6 +86,7 @@ class RpcSentryApp(RpcModel):
     events: list[str] = Field(default_factory=list)
     webhook_url: str | None = None
     is_alertable: bool = False
+    is_disabled: bool = False
     is_published: bool = False
     is_unpublished: bool = False
     is_internal: bool = True

--- a/src/sentry/sentry_apps/services/app/serial.py
+++ b/src/sentry/sentry_apps/services/app/serial.py
@@ -42,6 +42,7 @@ def serialize_sentry_app(
         events=app.events,
         webhook_url=app.webhook_url,
         is_alertable=app.is_alertable,
+        is_disabled=app.is_disabled,
         is_published=app.status == SentryAppStatus.PUBLISHED,
         is_unpublished=app.status == SentryAppStatus.UNPUBLISHED,
         is_internal=app.status == SentryAppStatus.INTERNAL,

--- a/tests/sentry/sentry_apps/api/bases/test_disabled_sentry_app.py
+++ b/tests/sentry/sentry_apps/api/bases/test_disabled_sentry_app.py
@@ -1,10 +1,10 @@
 from sentry.sentry_apps.models.sentry_app import SentryApp
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
-FEATURE_FLAG = "organizations:sentry-app-disabled-enforcement"
+OPTION = {"sentry-apps.disabled-enforcement": True}
 
 
 def disable_app(app: SentryApp) -> None:
@@ -21,26 +21,26 @@ class DisabledSentryAppDetailsTest(APITestCase):
         self.app = self.create_sentry_app(name="Test", organization=self.organization)
         self.login_as(self.user)
 
-    @with_feature(FEATURE_FLAG)
+    @override_options(OPTION)
     def test_get_disabled_app_returns_403(self) -> None:
         disable_app(self.app)
         self.get_error_response(self.app.slug, status_code=403)
 
-    @with_feature(FEATURE_FLAG)
+    @override_options(OPTION)
     def test_get_non_disabled_app_returns_200(self) -> None:
         self.get_success_response(self.app.slug, status_code=200)
 
-    @with_feature(FEATURE_FLAG)
+    @override_options(OPTION)
     def test_delete_disabled_app_allowed(self) -> None:
         disable_app(self.app)
         self.get_success_response(self.app.slug, method="delete", status_code=204)
 
-    @with_feature(FEATURE_FLAG)
+    @override_options(OPTION)
     def test_put_disabled_app_allowed(self) -> None:
         disable_app(self.app)
         self.get_success_response(self.app.slug, method="put", status_code=200, name="Test")
 
-    def test_disabled_app_without_flag_returns_200(self) -> None:
+    def test_disabled_app_without_option_returns_200(self) -> None:
         disable_app(self.app)
         self.get_success_response(self.app.slug, status_code=200)
 
@@ -56,16 +56,16 @@ class DisabledSentryAppInstallationTest(APITestCase):
         )
         self.login_as(self.user)
 
-    @with_feature(FEATURE_FLAG)
+    @override_options(OPTION)
     def test_get_installation_of_disabled_app_returns_403(self) -> None:
         disable_app(self.app)
         self.get_error_response(self.install.uuid, status_code=403)
 
-    @with_feature(FEATURE_FLAG)
+    @override_options(OPTION)
     def test_delete_installation_of_disabled_app_allowed(self) -> None:
         disable_app(self.app)
         self.get_success_response(self.install.uuid, method="delete", status_code=204)
 
-    @with_feature(FEATURE_FLAG)
+    @override_options(OPTION)
     def test_get_installation_of_non_disabled_app_returns_200(self) -> None:
         self.get_success_response(self.install.uuid, status_code=200)

--- a/tests/sentry/sentry_apps/api/bases/test_disabled_sentry_app.py
+++ b/tests/sentry/sentry_apps/api/bases/test_disabled_sentry_app.py
@@ -1,3 +1,4 @@
+from sentry.sentry_apps.models.sentry_app import SentryApp
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
@@ -6,7 +7,7 @@ from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 FEATURE_FLAG = "organizations:sentry-app-disabled-enforcement"
 
 
-def disable_app(app) -> None:
+def disable_app(app: SentryApp) -> None:
     with assume_test_silo_mode(SiloMode.CONTROL):
         app.update(is_disabled=True)
 
@@ -68,27 +69,3 @@ class DisabledSentryAppInstallationTest(APITestCase):
     @with_feature(FEATURE_FLAG)
     def test_get_installation_of_non_disabled_app_returns_200(self) -> None:
         self.get_success_response(self.install.uuid, status_code=200)
-
-
-@control_silo_test
-class DisabledCellSentryAppTest(APITestCase):
-    endpoint = "sentry-api-0-sentry-app-interaction"
-
-    def setUp(self) -> None:
-        self.superuser = self.create_user(is_superuser=True)
-        self.app = self.create_sentry_app(
-            name="Test",
-            organization=self.organization,
-            published=True,
-            schema={"elements": [self.create_issue_link_schema()]},
-        )
-        self.login_as(self.superuser, superuser=True)
-
-    @with_feature(FEATURE_FLAG)
-    def test_get_disabled_app_returns_403(self) -> None:
-        disable_app(self.app)
-        self.get_error_response(self.app.slug, tsdbField="sentry_app_viewed", status_code=403)
-
-    @with_feature(FEATURE_FLAG)
-    def test_get_non_disabled_app_returns_200(self) -> None:
-        self.get_success_response(self.app.slug, tsdbField="sentry_app_viewed", status_code=200)

--- a/tests/sentry/sentry_apps/api/bases/test_disabled_sentry_app.py
+++ b/tests/sentry/sentry_apps/api/bases/test_disabled_sentry_app.py
@@ -1,0 +1,94 @@
+from sentry.silo.base import SiloMode
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
+
+FEATURE_FLAG = "organizations:sentry-app-disabled-enforcement"
+
+
+def disable_app(app) -> None:
+    with assume_test_silo_mode(SiloMode.CONTROL):
+        app.update(is_disabled=True)
+
+
+@control_silo_test
+class DisabledSentryAppDetailsTest(APITestCase):
+    endpoint = "sentry-api-0-sentry-app-details"
+
+    def setUp(self) -> None:
+        self.superuser = self.create_user(is_superuser=True)
+        self.app = self.create_sentry_app(name="Test", organization=self.organization)
+        self.login_as(self.user)
+
+    @with_feature(FEATURE_FLAG)
+    def test_get_disabled_app_returns_403(self) -> None:
+        disable_app(self.app)
+        self.get_error_response(self.app.slug, status_code=403)
+
+    @with_feature(FEATURE_FLAG)
+    def test_get_non_disabled_app_returns_200(self) -> None:
+        self.get_success_response(self.app.slug, status_code=200)
+
+    @with_feature(FEATURE_FLAG)
+    def test_delete_disabled_app_allowed(self) -> None:
+        disable_app(self.app)
+        self.get_success_response(self.app.slug, method="delete", status_code=204)
+
+    @with_feature(FEATURE_FLAG)
+    def test_put_disabled_app_allowed(self) -> None:
+        disable_app(self.app)
+        self.get_success_response(self.app.slug, method="put", status_code=200, name="Test")
+
+    def test_disabled_app_without_flag_returns_200(self) -> None:
+        disable_app(self.app)
+        self.get_success_response(self.app.slug, status_code=200)
+
+
+@control_silo_test
+class DisabledSentryAppInstallationTest(APITestCase):
+    endpoint = "sentry-api-0-sentry-app-installation-details"
+
+    def setUp(self) -> None:
+        self.app = self.create_sentry_app(name="Test", organization=self.organization)
+        self.install = self.create_sentry_app_installation(
+            slug=self.app.slug, organization=self.organization, user=self.user
+        )
+        self.login_as(self.user)
+
+    @with_feature(FEATURE_FLAG)
+    def test_get_installation_of_disabled_app_returns_403(self) -> None:
+        disable_app(self.app)
+        self.get_error_response(self.install.uuid, status_code=403)
+
+    @with_feature(FEATURE_FLAG)
+    def test_delete_installation_of_disabled_app_allowed(self) -> None:
+        disable_app(self.app)
+        self.get_success_response(self.install.uuid, method="delete", status_code=204)
+
+    @with_feature(FEATURE_FLAG)
+    def test_get_installation_of_non_disabled_app_returns_200(self) -> None:
+        self.get_success_response(self.install.uuid, status_code=200)
+
+
+@control_silo_test
+class DisabledCellSentryAppTest(APITestCase):
+    endpoint = "sentry-api-0-sentry-app-interaction"
+
+    def setUp(self) -> None:
+        self.superuser = self.create_user(is_superuser=True)
+        self.app = self.create_sentry_app(
+            name="Test",
+            organization=self.organization,
+            published=True,
+            schema={"elements": [self.create_issue_link_schema()]},
+        )
+        self.login_as(self.superuser, superuser=True)
+
+    @with_feature(FEATURE_FLAG)
+    def test_get_disabled_app_returns_403(self) -> None:
+        disable_app(self.app)
+        self.get_error_response(self.app.slug, tsdbField="sentry_app_viewed", status_code=403)
+
+    @with_feature(FEATURE_FLAG)
+    def test_get_non_disabled_app_returns_200(self) -> None:
+        self.get_success_response(self.app.slug, tsdbField="sentry_app_viewed", status_code=200)


### PR DESCRIPTION
Enforce the `is_disabled` field for sentry app endpoints. When a Sentry App has `is_disabled=True` and the `organizations:sentry-app-disabled-enforcement` flag is enabled for the owner org, all endpoints return 403.

We also add an 'excape hatch' via `allow_disabled_sentry_app_for_methods` for DELETE and PUT on the details endpoint so owners can still delete/uninstall and staff can re-enable.

Depends on #114263.

Refs ISWF-1235
Refs ISWF-1234