### PR TITLE
feat(snapshots): Add Build Metadata modal to snapshot actions menu

### DIFF
--- a/static/app/views/preprod/snapshots/header/buildDebugInfoModal.tsx
+++ b/static/app/views/preprod/snapshots/header/buildDebugInfoModal.tsx
@@ -2,6 +2,8 @@ import {Fragment, useMemo} from 'react';
 import {css} from '@emotion/react';
 import pick from 'lodash/pick';
 
+import {Heading} from '@sentry/scraps/text';
+
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {openModal} from 'sentry/actionCreators/modal';
 import {StructuredEventData} from 'sentry/components/structuredEventData';
@@ -29,7 +31,7 @@ function BuildDebugInfoModal({Header, Body, data}: Props) {
   return (
     <Fragment>
       <Header closeButton>
-        <h3>{t('Build Metadata')}</h3>
+        <Heading as="h3">{t('Build Metadata')}</Heading>
       </Header>
       <Body>
         <StructuredEventData

--- a/static/app/views/preprod/snapshots/header/buildDebugInfoModal.tsx
+++ b/static/app/views/preprod/snapshots/header/buildDebugInfoModal.tsx
@@ -1,0 +1,54 @@
+import {Fragment, useMemo} from 'react';
+import {css} from '@emotion/react';
+import pick from 'lodash/pick';
+
+import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import {openModal} from 'sentry/actionCreators/modal';
+import {StructuredEventData} from 'sentry/components/structuredEventData';
+import {t} from 'sentry/locale';
+import type {SnapshotDetailsApiResponse} from 'sentry/views/preprod/types/snapshotTypes';
+
+const VISIBLE_FIELDS: Array<keyof SnapshotDetailsApiResponse> = [
+  'app_id',
+  'base_artifact_id',
+  'comparison_run_info',
+  'comparison_type',
+  'diff_threshold',
+  'head_artifact_id',
+  'project_id',
+  'vcs_info',
+];
+
+type Props = ModalRenderProps & {
+  data: SnapshotDetailsApiResponse;
+};
+
+function BuildDebugInfoModal({Header, Body, data}: Props) {
+  const filteredData = useMemo(() => pick(data, VISIBLE_FIELDS), [data]);
+
+  return (
+    <Fragment>
+      <Header closeButton>
+        <h3>{t('Build Metadata')}</h3>
+      </Header>
+      <Body>
+        <StructuredEventData
+          data={filteredData}
+          maxDefaultDepth={Infinity}
+          autoCollapseLimit={Infinity}
+          forceDefaultExpand
+          showCopyButton
+        />
+      </Body>
+    </Fragment>
+  );
+}
+
+export function openBuildDebugInfoModal(data: SnapshotDetailsApiResponse) {
+  openModal(deps => <BuildDebugInfoModal {...deps} data={data} />, {
+    modalCss: css`
+      max-width: 800px;
+      width: 90vw;
+    `,
+  });
+}

--- a/static/app/views/preprod/snapshots/header/snapshotHeaderActions.tsx
+++ b/static/app/views/preprod/snapshots/header/snapshotHeaderActions.tsx
@@ -19,6 +19,7 @@ import {
   IconEllipsis,
   IconInfo,
   IconOpen,
+  IconReceipt,
   IconRefresh,
   IconThumb,
   IconTimer,
@@ -27,6 +28,7 @@ import {t} from 'sentry/locale';
 import type {AvatarUser} from 'sentry/types/user';
 import {useIsSentryEmployee} from 'sentry/utils/useIsSentryEmployee';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import {openBuildDebugInfoModal} from 'sentry/views/preprod/snapshots/header/buildDebugInfoModal';
 import type {SnapshotDetailsApiResponse} from 'sentry/views/preprod/types/snapshotTypes';
 import {getSnapshotPath} from 'sentry/views/preprod/utils/buildLinkUtils';
 import {handleStaffPermissionError} from 'sentry/views/preprod/utils/staffPermissionError';
@@ -229,6 +231,17 @@ export function SnapshotHeaderActions({
               ),
               onAction: handleRerunStatusChecks,
               textValue: t('Rerun Status Checks'),
+            },
+            {
+              key: 'build-debug-info',
+              label: (
+                <Flex align="center" gap="sm">
+                  <IconReceipt size="sm" />
+                  {t('Build Metadata')}
+                </Flex>
+              ),
+              onAction: () => openBuildDebugInfoModal(data),
+              textValue: t('Build Metadata'),
             },
             {
               key: 'delete',


### PR DESCRIPTION
Closes EME-1016

Adds a "Build Metadata" option to the snapshot header ellipsis menu that opens a full-screen modal displaying key build metadata fields in a collapsible JSON tree (using `StructuredEventData`).

This gives customers visibility into snapshot comparison details like VCS info, diff threshold, comparison run info, and artifact IDs — without needing to hit the API directly.

The displayed fields are allowlisted to avoid exposing internal/image data:
`app_id`, `base_artifact_id`, `comparison_run_info`, `comparison_type`, `diff_threshold`, `head_artifact_id`, `project_id`, `vcs_info`

Screenshots:
<img width="714" height="580" alt="image" src="https://github.com/user-attachments/assets/44ba69fe-2405-4cde-9a4d-e3e700f29f8e" />
<img width="3458" height="2058" alt="image" src="https://github.com/user-attachments/assets/f51e5bd4-7b2d-4a25-89f1-7a2b836b652f" />
