### PR TITLE
fix(dashboards): Show last editor instead of creator on current version

### DIFF
--- a/static/app/views/dashboards/dashboardRevisions.spec.tsx
+++ b/static/app/views/dashboards/dashboardRevisions.spec.tsx
@@ -8,6 +8,7 @@ import {
   screen,
   userEvent,
   waitFor,
+  within,
 } from 'sentry-test/reactTestingLibrary';
 
 import {DashboardRevisionsButton} from './dashboardRevisions';
@@ -248,6 +249,20 @@ describe('DashboardRevisionsButton', () => {
     expect(
       await screen.findByText('Failed to restore this revision.')
     ).toBeInTheDocument();
+  });
+
+  it('shows the author of the most recent revision in the current version entry', async () => {
+    MockApiClient.addMockResponse({url: REVISIONS_URL, body: [makeRevision()]});
+    MockApiClient.addMockResponse({url: REVISION_DETAILS_URL, body: makeSnapshot()});
+
+    renderButton();
+    renderGlobalModal();
+    await openModal();
+
+    await screen.findAllByRole('radio');
+
+    const currentVersionItem = screen.getByText('Current Version').closest('div');
+    expect(within(currentVersionItem!).getByText('Alice')).toBeInTheDocument();
   });
 
   it('limits displayed revisions to 10', async () => {

--- a/static/app/views/dashboards/dashboardRevisions.spec.tsx
+++ b/static/app/views/dashboards/dashboardRevisions.spec.tsx
@@ -265,6 +265,38 @@ describe('DashboardRevisionsButton', () => {
     expect(within(currentVersionItem!).getByText('Alice')).toBeInTheDocument();
   });
 
+  it('shows the author from the following revision for each historical entry', async () => {
+    MockApiClient.addMockResponse({
+      url: REVISIONS_URL,
+      body: [
+        makeRevision({
+          id: '1',
+          source: 'edit-with-agent' as const,
+          createdBy: {id: '99', name: 'Recent Editor', email: 'recent@example.com'},
+        }),
+        makeRevision({
+          id: '2',
+          source: 'pre-restore' as const,
+          createdBy: {id: '42', name: 'Alice', email: 'alice@example.com'},
+        }),
+      ],
+    });
+    MockApiClient.addMockResponse({url: REVISION_DETAILS_URL, body: makeSnapshot()});
+    MockApiClient.addMockResponse({url: BASE_REVISION_DETAILS_URL, body: makeSnapshot()});
+
+    renderButton();
+    renderGlobalModal();
+    await openModal();
+
+    await screen.findAllByRole('radio');
+
+    // The first historical entry's label and author both come from revisions[1]:
+    // label = revisions[1].source = 'pre-restore' → "Revert Dashboard"
+    // author = revisions[1].createdBy = Alice
+    const revertEntry = screen.getByText('Revert Dashboard').closest('div');
+    expect(within(revertEntry!).getByText('Alice')).toBeInTheDocument();
+  });
+
   it('limits displayed revisions to 10', async () => {
     const revisions = Array.from({length: 12}, (_, i) =>
       makeRevision({id: String(i + 1)})

--- a/static/app/views/dashboards/dashboardRevisions.tsx
+++ b/static/app/views/dashboards/dashboardRevisions.tsx
@@ -134,9 +134,9 @@ function DashboardRevisionsModal({
                   isSelected={revision.id === selectedRevisionId}
                   onSelect={() => setSelectedRevisionId(revision.id)}
                   // Each revision is saved before the operation that produces it,
-                  // so the label for this entry comes from the following revision's source.
+                  // so the label and author for this entry come from the following revision.
                   revisionSource={revisions?.[index + 1]?.source ?? 'edit'}
-                  createdBy={revision.createdBy}
+                  createdBy={revisions?.[index + 1]?.createdBy ?? null}
                   dateCreated={revision.dateCreated}
                   dashboardId={dashboardId}
                   revisionId={revision.id}

--- a/static/app/views/dashboards/dashboardRevisions.tsx
+++ b/static/app/views/dashboards/dashboardRevisions.tsx
@@ -13,7 +13,6 @@ import {openModal} from 'sentry/actionCreators/modal';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {IconClock} from 'sentry/icons/iconClock';
 import {t} from 'sentry/locale';
-import type {User} from 'sentry/types/user';
 import {defined} from 'sentry/utils';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 import {useApi} from 'sentry/utils/useApi';
@@ -38,21 +37,12 @@ export function DashboardRevisionsButton({dashboard}: DashboardRevisionsButtonPr
   }
 
   const handleClick = () => {
-    openModal(
-      props => (
-        <DashboardRevisionsModal
-          {...props}
-          dashboard={dashboard}
-          dashboardCreatedBy={dashboard.createdBy}
-        />
-      ),
-      {
-        modalCss: css`
-          max-width: 720px;
-          width: 90vw;
-        `,
-      }
-    );
+    openModal(props => <DashboardRevisionsModal {...props} dashboard={dashboard} />, {
+      modalCss: css`
+        max-width: 720px;
+        width: 90vw;
+      `,
+    });
   };
 
   return (
@@ -73,10 +63,8 @@ function DashboardRevisionsModal({
   Footer,
   closeModal,
   dashboard,
-  dashboardCreatedBy,
 }: ModalRenderProps & {
   dashboard: DashboardDetails;
-  dashboardCreatedBy: User | undefined;
 }) {
   const dashboardId = dashboard.id;
   const [selectedRevisionId, setSelectedRevisionId] = useState<string>(NEWEST_VERSION_ID);
@@ -134,7 +122,7 @@ function DashboardRevisionsModal({
                 isSelected={isNewestVersionSelected}
                 onSelect={() => setSelectedRevisionId(NEWEST_VERSION_ID)}
                 revisionSource={revisions?.[0]?.source ?? 'edit'}
-                createdBy={dashboardCreatedBy ?? null}
+                createdBy={revisions?.[0]?.createdBy ?? null}
                 dateCreated={null}
                 dashboardId={dashboardId}
                 baseRevisionId={displayedRevisions[0]?.id ?? null}


### PR DESCRIPTION
The Dashboard Revision list was showing the wrong user for the current version and each revision item.

For the current version, we were using the dashboard creator, when we should use the user we stored for the first revision (since that's the newest edit).

For each historical version in the list, we need to look at the user/edit-source of the next revision, since that's from whom/why a particular revision was made.

Fixes DAIN-1618