### PR TITLE
fix(search): map bare `duration` to `transaction.duration` in search parser

### DIFF
--- a/src/sentry/search/events/constants.py
+++ b/src/sentry/search/events/constants.py
@@ -215,7 +215,11 @@ PERCENT_UNITS = {"ratio", "percent"}
 NO_CONVERSION_FIELDS = {"start", "end"}
 # Skip total_count_alias since it queries the total count and therefore doesn't make sense in a filter
 # In these cases we should instead treat it as a tag instead
-SKIP_FILTER_RESOLUTION = {TOTAL_COUNT_ALIAS, TOTAL_TRANSACTION_DURATION_ALIAS}
+# "duration" is an internal Snuba column name for transaction.duration (UInt32).
+# Bare `duration:>3s` (without the `transaction.` prefix) causes a 500 because
+# the parser produces a string value while resolve_column maps to the raw numeric
+# column.  Forcing tag resolution makes the filter harmless instead of crashing.
+SKIP_FILTER_RESOLUTION = {TOTAL_COUNT_ALIAS, TOTAL_TRANSACTION_DURATION_ALIAS, "duration"}
 EQUALITY_OPERATORS = frozenset(["=", "IN"])
 INEQUALITY_OPERATORS = frozenset(["!=", "NOT IN"])
 ARRAY_FIELDS = {

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -319,6 +319,19 @@ class ParseSearchQueryBackendTest(SimpleTestCase):
             ),
         ]
 
+    def test_bare_duration_treated_as_tag(self) -> None:
+        """Bare `duration:>3s` is not a duration key — it should parse as a text
+        filter so that column resolution sends it to `tags[duration]` instead of
+        the internal ClickHouse `duration` column (which would cause a
+        type-mismatch 500)."""
+        assert parse_search_query("duration:>3s") == [
+            SearchFilter(
+                key=SearchKey(name="duration"),
+                operator="=",
+                value=SearchValue(">3s"),
+            ),
+        ]
+
     def test_paren_expression(self) -> None:
         assert parse_search_query("(x:1 OR y:1) AND z:1") == [
             ParenExpression(


### PR DESCRIPTION
## Summary

- Adds `"duration"` to `SKIP_FILTER_RESOLUTION` in `constants.py` so bare `duration` in search filters resolves to `tags[duration]` instead of the internal ClickHouse column
- Fixes a 500 Internal Server Error when users write `duration:>3s` instead of `transaction.duration:>3s`

## Root Cause

Bare `duration` is an internal Snuba column name (UInt32, milliseconds) for `transaction.duration`. It is NOT in `duration_keys` or `numeric_keys`, so the search parser correctly treats it as a text filter — but `resolve_column` then resolves it to the raw ClickHouse column via `DATASET_FIELDS`, creating a string-vs-numeric mismatch that crashes Snuba with a 500.

When a user writes `duration:>3s`:
1. The PEG grammar matches it as a `duration_filter` node
2. `is_duration_key("duration")` returns `False` → falls through to text filter handling
3. The value becomes the string `">3s"` (operator + value concatenated)
4. `resolve_column("duration")` finds it in `DATASET_FIELDS[Transactions]` as the raw UInt32 column
5. This produces `WHERE duration = '>3s'` — string vs UInt32 mismatch → Snuba 500

## Fix

Add `"duration"` to `SKIP_FILTER_RESOLUTION` (alongside the existing `total_count` and `total_transaction_duration` entries). This forces `default_filter_converter` to resolve it as `tags[duration]` instead of the internal column — harmless (no results from a nonexistent tag) instead of a 500.