### PR TITLE
feat(snapshots): Add Cmd/Ctrl+Arrow shortcuts to jump to first/last image

### DIFF
--- a/static/app/views/preprod/snapshots/main/snapshotListView.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.tsx
@@ -287,6 +287,15 @@ export function SnapshotListView({
         return;
       }
 
+      if ((e.metaKey || e.ctrlKey) && (e.key === 'ArrowUp' || e.key === 'ArrowDown')) {
+        e.preventDefault();
+        const isUp = e.key === 'ArrowUp';
+        const targetKey = isUp ? idx.order[0]! : idx.order[idx.order.length - 1]!;
+        onSelect(targetKey);
+        revealCard(targetKey, isUp ? 'start' : 'end');
+        return;
+      }
+
       const lastPos = idx.order.length - 1;
       const currentPos = currentKey ? (idx.positionByKey.get(currentKey) ?? -1) : -1;
       const isDown = e.key === 'ArrowDown';

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -473,8 +473,22 @@ export default function SnapshotsPage() {
 
   const pressTimeoutRef = useRef<number>(undefined);
   // Ref so the keydown handler reads latest state without re-registering.
-  const navRef = useRef({navigateSingleView, setViewMode, viewMode, navButtonRefs});
-  navRef.current = {navigateSingleView, setViewMode, viewMode, navButtonRefs};
+  const navRef = useRef({
+    navigateSingleView,
+    setViewMode,
+    viewMode,
+    navButtonRefs,
+    listItems,
+    setSelectedSnapshotKey,
+  });
+  navRef.current = {
+    navigateSingleView,
+    setViewMode,
+    viewMode,
+    navButtonRefs,
+    listItems,
+    setSelectedSnapshotKey,
+  };
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
@@ -505,6 +519,23 @@ export default function SnapshotsPage() {
       if (navRef.current.viewMode !== 'single') {
         return;
       }
+
+      if ((e.metaKey || e.ctrlKey) && (e.key === 'ArrowUp' || e.key === 'ArrowDown')) {
+        e.preventDefault();
+        const items = navRef.current.listItems;
+        if (items.length > 0) {
+          const lastItem = items[items.length - 1]!;
+          const key =
+            e.key === 'ArrowUp'
+              ? snapshotKeyAt(items[0]!, 0)
+              : snapshotKeyAt(lastItem, itemVariantCount(lastItem) - 1);
+          if (key) {
+            navRef.current.setSelectedSnapshotKey(key);
+          }
+        }
+        return;
+      }
+
       e.preventDefault();
       const btn =
         e.key === 'ArrowDown'


### PR DESCRIPTION
Add keyboard shortcuts for Cmd/Ctrl+Up and Cmd/Ctrl+Down to jump to
the first or last snapshot image in the viewer.

In single view, Cmd+Up selects the very first image variant and Cmd+Down
selects the last. In list view, the same shortcuts select and scroll to
the first or last card respectively.

The handlers are placed after the existing `viewMode !== 'single'` guard
in `snapshots.tsx` so that in list view, only the `snapshotListView.tsx`
handler processes the shortcut — avoiding double-firing from the two
document-level keydown listeners.