### PR TITLE
ref(repos): Use flag-aware Seer provider check in SCM views

### DIFF
--- a/static/app/components/events/autofix/utils.tsx
+++ b/static/app/components/events/autofix/utils.tsx
@@ -190,6 +190,7 @@ export function hasPullRequest(autofixData: AutofixData | null | undefined): boo
 const BASE_SUPPORTED_PROVIDERS = [
   'github',
   'integrations:github',
+  'github_enterprise',
   'integrations:github_enterprise',
 ];
 

--- a/static/app/views/settings/organizationRepositories/connectProviderDropdown.tsx
+++ b/static/app/views/settings/organizationRepositories/connectProviderDropdown.tsx
@@ -5,13 +5,13 @@ import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
+import {useIsSeerSupportedProvider} from 'sentry/components/events/autofix/utils';
 import {IconSeer} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {IntegrationProvider, IntegrationWithConfig} from 'sentry/types/integrations';
 import {useAddIntegration} from 'sentry/utils/integrations/useAddIntegration';
 import {getIntegrationIcon} from 'sentry/utils/integrationUtil';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {isSeerCompatibleProvider} from 'sentry/views/settings/organizationRepositories/seerCompatibleProviders';
 
 interface Props {
   onAddIntegration: (data: IntegrationWithConfig) => void;
@@ -21,11 +21,14 @@ interface Props {
 export function ConnectProviderDropdown({providers, onAddIntegration}: Props) {
   const organization = useOrganization();
   const {startFlow} = useAddIntegration();
+  const isSeerSupported = useIsSeerSupportedProvider();
 
-  const hasSeerCompatible = providers.some(p => isSeerCompatibleProvider(p.key));
+  const hasSeerCompatible = providers.some(p =>
+    isSeerSupported({id: p.key, name: p.name})
+  );
 
   const items: MenuItemProps[] = providers.map(provider => {
-    const isSeerCompatible = isSeerCompatibleProvider(provider.key);
+    const isSeerCompatible = isSeerSupported({id: provider.key, name: provider.name});
     return {
       key: provider.key,
       label: isSeerCompatible ? (

--- a/static/app/views/settings/organizationRepositories/noIntegrationsEmptyState.tsx
+++ b/static/app/views/settings/organizationRepositories/noIntegrationsEmptyState.tsx
@@ -3,6 +3,7 @@ import {Flex} from '@sentry/scraps/layout';
 import {Heading} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
+import {useIsSeerSupportedProvider} from 'sentry/components/events/autofix/utils';
 import {Panel} from 'sentry/components/panels/panel';
 import {PanelItem} from 'sentry/components/panels/panelItem';
 import {IconAdd, IconSeer} from 'sentry/icons';
@@ -11,7 +12,6 @@ import type {IntegrationProvider, IntegrationWithConfig} from 'sentry/types/inte
 import {getIntegrationIcon} from 'sentry/utils/integrationUtil';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {AddIntegrationButton} from 'sentry/views/settings/organizationIntegrations/addIntegrationButton';
-import {isSeerCompatibleProvider} from 'sentry/views/settings/organizationRepositories/seerCompatibleProviders';
 
 interface Props {
   onAddIntegration: (data: IntegrationWithConfig) => void;
@@ -20,6 +20,7 @@ interface Props {
 
 export function NoIntegrationsEmptyState({providers, onAddIntegration}: Props) {
   const organization = useOrganization();
+  const isSeerSupported = useIsSeerSupportedProvider();
 
   return (
     <Panel>
@@ -28,7 +29,7 @@ export function NoIntegrationsEmptyState({providers, onAddIntegration}: Props) {
           <Flex align="center" gap="md" flex="1">
             {getIntegrationIcon(provider.key, 'md')}
             <Heading as="h4">{provider.name}</Heading>
-            {isSeerCompatibleProvider(provider.key) && (
+            {isSeerSupported({id: provider.key, name: provider.name}) && (
               <Tooltip title={t('Compatible with Seer.')}>
                 <Tag variant="promotion" icon={<IconSeer />}>
                   {t('Seer')}

--- a/static/app/views/settings/organizationRepositories/seerCompatibleProviders.tsx
+++ b/static/app/views/settings/organizationRepositories/seerCompatibleProviders.tsx
@@ -1,5 +1,0 @@
-const SEER_COMPATIBLE_PROVIDERS = new Set(['github', 'gitlab']);
-
-export function isSeerCompatibleProvider(key: string): boolean {
-  return SEER_COMPATIBLE_PROVIDERS.has(key);
-}


### PR DESCRIPTION
Address review feedback from #114364: drop the local `seerCompatibleProviders` helper that hardcoded `['github', 'gitlab']` and switch the SCM settings views to the shared `useIsSeerSupportedProvider` hook from `autofix/utils`.

The hook is the source of truth for Seer-compatible providers — it includes GitHub Enterprise in the base list and gates GitLab on the `seer-gitlab-support` feature flag, neither of which the hardcoded list captured.