### PR TITLE
fix(dashboards): Detect text widget content changes in revision diff

### DIFF
--- a/static/app/views/dashboards/dashboardRevisionsDiff.spec.ts
+++ b/static/app/views/dashboards/dashboardRevisionsDiff.spec.ts
@@ -142,6 +142,17 @@ describe('diffWidgets', () => {
     });
   });
 
+  it('does not flag a change when one widget has null description and the other has empty string', () => {
+    const base = makeWidget({
+      id: '1',
+      displayType: DisplayType.TEXT,
+      description: null as any,
+    });
+    const snap = makeWidget({id: '1', displayType: DisplayType.TEXT, description: ''});
+    const result = diffWidgets(makeDashboard([base]), makeDashboard([snap]));
+    expect(result).toEqual([]);
+  });
+
   it('detects a text widget content change', () => {
     const base = makeWidget({
       id: '1',

--- a/static/app/views/dashboards/dashboardRevisionsDiff.spec.ts
+++ b/static/app/views/dashboards/dashboardRevisionsDiff.spec.ts
@@ -171,6 +171,22 @@ describe('diffWidgets', () => {
     });
   });
 
+  it('truncates text widget content longer than 150 characters', () => {
+    const long = 'x'.repeat(200);
+    const base = makeWidget({id: '1', displayType: DisplayType.TEXT, description: long});
+    const snap = makeWidget({
+      id: '1',
+      displayType: DisplayType.TEXT,
+      description: long + 'y',
+    });
+    const result = diffWidgets(makeDashboard([base]), makeDashboard([snap]));
+    expect(result[0]).toMatchObject({status: 'modified'});
+    const field = (result[0] as any).fields[0];
+    expect(field.before).toHaveLength(151); // 150 chars + ellipsis char
+    expect(field.before.endsWith('…')).toBe(true);
+    expect(field.after.endsWith('…')).toBe(true);
+  });
+
   it('handles a query being added to a widget', () => {
     const q = {conditions: '', aggregates: [], columns: [], orderby: '', name: ''} as any;
     const base = makeWidget({id: '1', queries: [q]});

--- a/static/app/views/dashboards/dashboardRevisionsDiff.spec.ts
+++ b/static/app/views/dashboards/dashboardRevisionsDiff.spec.ts
@@ -142,6 +142,24 @@ describe('diffWidgets', () => {
     });
   });
 
+  it('detects a text widget content change', () => {
+    const base = makeWidget({
+      id: '1',
+      displayType: DisplayType.TEXT,
+      description: '# Hello',
+    });
+    const snap = makeWidget({
+      id: '1',
+      displayType: DisplayType.TEXT,
+      description: '# Hello World',
+    });
+    const result = diffWidgets(makeDashboard([base]), makeDashboard([snap]));
+    expect(result[0]).toMatchObject({
+      status: 'modified',
+      fields: [{field: 'content', before: '# Hello', after: '# Hello World'}],
+    });
+  });
+
   it('handles a query being added to a widget', () => {
     const q = {conditions: '', aggregates: [], columns: [], orderby: '', name: ''} as any;
     const base = makeWidget({id: '1', queries: [q]});

--- a/static/app/views/dashboards/dashboardRevisionsDiff.ts
+++ b/static/app/views/dashboards/dashboardRevisionsDiff.ts
@@ -6,6 +6,8 @@ import {getFormattedDate} from 'sentry/utils/dates';
 import type {DashboardDetails, Widget, WidgetQuery} from './types';
 import {DashboardFilterKeys, DisplayType} from './types';
 
+const DESCRIPTION_PREVIEW_MAX_LENGTH = 150;
+
 type FieldChange = {after: string; before: string; field: string};
 
 type FilterChange = {after: string; before: string; label: string};
@@ -85,6 +87,12 @@ export function diffFilters(
   }
 
   return changes;
+}
+
+function truncateDescription(value: string): string {
+  if (!value) return t('(empty)');
+  if (value.length <= DESCRIPTION_PREVIEW_MAX_LENGTH) return value;
+  return value.slice(0, DESCRIPTION_PREVIEW_MAX_LENGTH) + '…';
 }
 
 export type WidgetChange =
@@ -210,8 +218,8 @@ export function diffWidgets(
         snapshotWidget.displayType === DisplayType.TEXT;
       fields.push({
         field: isTextWidget ? t('content') : t('description'),
-        before: baseDescription || t('(empty)'),
-        after: snapshotDescription || t('(empty)'),
+        before: truncateDescription(baseDescription),
+        after: truncateDescription(snapshotDescription),
       });
     }
 

--- a/static/app/views/dashboards/dashboardRevisionsDiff.ts
+++ b/static/app/views/dashboards/dashboardRevisionsDiff.ts
@@ -4,7 +4,7 @@ import {t} from 'sentry/locale';
 import {getFormattedDate} from 'sentry/utils/dates';
 
 import type {DashboardDetails, Widget, WidgetQuery} from './types';
-import {DashboardFilterKeys} from './types';
+import {DashboardFilterKeys, DisplayType} from './types';
 
 type FieldChange = {after: string; before: string; field: string};
 
@@ -199,6 +199,17 @@ export function diffWidgets(
         field: 'interval',
         before: match.interval,
         after: snapshotWidget.interval,
+      });
+    }
+
+    if (match.description !== snapshotWidget.description) {
+      const isTextWidget =
+        match.displayType === DisplayType.TEXT ||
+        snapshotWidget.displayType === DisplayType.TEXT;
+      fields.push({
+        field: isTextWidget ? t('content') : t('description'),
+        before: match.description || t('(empty)'),
+        after: snapshotWidget.description || t('(empty)'),
       });
     }
 

--- a/static/app/views/dashboards/dashboardRevisionsDiff.ts
+++ b/static/app/views/dashboards/dashboardRevisionsDiff.ts
@@ -202,14 +202,16 @@ export function diffWidgets(
       });
     }
 
-    if (match.description !== snapshotWidget.description) {
+    const baseDescription = match.description || '';
+    const snapshotDescription = snapshotWidget.description || '';
+    if (baseDescription !== snapshotDescription) {
       const isTextWidget =
         match.displayType === DisplayType.TEXT ||
         snapshotWidget.displayType === DisplayType.TEXT;
       fields.push({
         field: isTextWidget ? t('content') : t('description'),
-        before: match.description || t('(empty)'),
-        after: snapshotWidget.description || t('(empty)'),
+        before: baseDescription || t('(empty)'),
+        after: snapshotDescription || t('(empty)'),
       });
     }
 


### PR DESCRIPTION
`diffWidgets` compared title, display type, interval, queries, and layout — but never the `description` field. For text widgets, `description` stores the markdown content, so edits to the text body were silently ignored and the revision diff showed "No widget changes in this revision."

**Description comparison**

Add a `description` comparison after the interval check. Uses the label `content` when either widget is a text widget, and `description` otherwise.

Before

<img width="679" height="105" alt="image" src="https://github.com/user-attachments/assets/c1857e89-1654-49d0-9473-cd5fa38a0407" />


After

<img width="640" height="161" alt="image" src="https://github.com/user-attachments/assets/02fb7328-5e2a-4734-bd51-5f3dee403f2c" />

Fixes DAIN-1599