### PR TITLE
styles(autofix): Clean up autofix drawer header

### DIFF
--- a/static/app/components/events/autofix/v3/header.tsx
+++ b/static/app/components/events/autofix/v3/header.tsx
@@ -6,7 +6,6 @@ import {InfoTip} from '@sentry/scraps/info';
 import {Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
-import {AutofixFeedback} from 'sentry/components/events/autofix/autofixFeedback';
 import {getReferrerConfig} from 'sentry/components/events/autofix/autofixReferrer';
 import {IconCopy} from 'sentry/icons/iconCopy';
 import {IconRefresh} from 'sentry/icons/iconRefresh';
@@ -29,20 +28,13 @@ export function SeerDrawerHeader({
   }, [referrer]);
 
   return (
-    <DrawerHeader>
+    <DrawerHeader hideBar hideCloseButtonText>
       <Flex justify="between" width="100%">
         <Flex align="center" gap="xs">
           <Text>{t('Seer Autofix')}</Text>
           {tooltip && <InfoTip title={tooltip} size="xs" />}
-          <Button
-            size="xs"
-            icon={<IconCopy />}
-            onClick={onCopyMarkdown}
-            disabled={!onCopyMarkdown}
-            tooltipProps={{title: t('Copy analysis as Markdown')}}
-            aria-label={t('Copy analysis as Markdown')}
-            priority="transparent"
-          />
+        </Flex>
+        <Flex align="center" gap="xs">
           <Button
             size="xs"
             icon={<IconRefresh />}
@@ -52,8 +44,16 @@ export function SeerDrawerHeader({
             aria-label={t('Start a new analysis from scratch')}
             priority="transparent"
           />
+          <Button
+            size="xs"
+            icon={<IconCopy />}
+            onClick={onCopyMarkdown}
+            disabled={!onCopyMarkdown}
+            tooltipProps={{title: t('Copy analysis as Markdown')}}
+            aria-label={t('Copy analysis as Markdown')}
+            priority="transparent"
+          />
         </Flex>
-        <AutofixFeedback iconOnly priority="transparent" />
       </Flex>
     </DrawerHeader>
   );


### PR DESCRIPTION
Clean up the header a little to align more with the seer agent header.

<img width="1422" height="106" alt="image" src="https://github.com/user-attachments/assets/1d5b7179-c5d7-48b6-9792-583112d5e2dc" />