### PR TITLE
feat(onboarding): Enforce display order for SCM feature cards

### DIFF
--- a/static/app/views/onboarding/scmPlatformFeatures.tsx
+++ b/static/app/views/onboarding/scmPlatformFeatures.tsx
@@ -49,6 +49,15 @@ interface ResolvedPlatform extends DetectedPlatform {
   info: PlatformIntegration;
 }
 
+const FEATURE_DISPLAY_ORDER: ProductSolution[] = [
+  ProductSolution.ERROR_MONITORING,
+  ProductSolution.LOGS,
+  ProductSolution.SESSION_REPLAY,
+  ProductSolution.PERFORMANCE_MONITORING,
+  ProductSolution.PROFILING,
+  ProductSolution.METRICS,
+];
+
 const platformsByKey = new Map(platforms.map(p => [p.id, p]));
 
 const getPlatformInfo = (key: PlatformKey) => platformsByKey.get(key);
@@ -170,18 +179,16 @@ export function ScmPlatformFeatures({onComplete, genBackButton}: StepProps) {
     });
   }, [detectedPlatformKey, selectedPlatform?.key, organization]);
 
-  const availableFeatures = useMemo(
-    () =>
-      currentPlatformKey
-        ? [
-            ...new Set([
-              ProductSolution.ERROR_MONITORING,
-              ...(platformProductAvailability[currentPlatformKey] ?? []),
-            ]),
-          ]
-        : [],
-    [currentPlatformKey]
-  );
+  const availableFeatures = useMemo(() => {
+    if (!currentPlatformKey) {
+      return [];
+    }
+    const features = new Set([
+      ProductSolution.ERROR_MONITORING,
+      ...(platformProductAvailability[currentPlatformKey] ?? []),
+    ]);
+    return FEATURE_DISPLAY_ORDER.filter(f => features.has(f));
+  }, [currentPlatformKey]);
 
   const disabledProducts = useMemo(
     () => getDisabledProducts(organization),


### PR DESCRIPTION
Order the SCM onboarding feature cards consistently as errors, logs, replays, tracing, profiling, metrics regardless of the order each platform happens to use in `platformProductAvailability`.

Previously `availableFeatures` was a `Set` spread directly into an array, so card order followed whatever the platform's product list returned — varying per platform (e.g. `bun` ordered tracing before logs, `dotnet` ordered tracing, profiling, logs, metrics).

The new `FEATURE_DISPLAY_ORDER` constant covers every value currently used in `platformProductAvailability` plus `ERROR_MONITORING`, and the filter against the platform's available set preserves the prior gating — features not available for the platform are still excluded.