### PR TITLE
fix(aci): Make ACTION_TARGET_TYPE_TO_STRING complete

### DIFF
--- a/src/sentry/incidents/serializers/__init__.py
+++ b/src/sentry/incidents/serializers/__init__.py
@@ -13,6 +13,7 @@ ACTION_TARGET_TYPE_TO_STRING = {
     AlertRuleTriggerAction.TargetType.TEAM: "team",
     AlertRuleTriggerAction.TargetType.SPECIFIC: "specific",
     AlertRuleTriggerAction.TargetType.SENTRY_APP: "sentry_app",
+    AlertRuleTriggerAction.TargetType.ISSUE_OWNERS: "issue_owners",
 }
 STRING_TO_ACTION_TARGET_TYPE = {v: k for (k, v) in ACTION_TARGET_TYPE_TO_STRING.items()}
 


### PR DESCRIPTION
We were missing ISSUE_OWNERS.

From what I can see, this shouldn't create problems for downstream consumers, but if it does we'll fix those.

Fixes SENTRY-5P1K.
