### PR TITLE
feat(snapshots): Add scroll progress indicator to snapshot list toolbar

### DIFF
--- a/static/app/views/preprod/snapshots/main/snapshotDiffBodies.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotDiffBodies.tsx
@@ -310,15 +310,16 @@ function LazyImage({
   return (
     <Container position="relative" display="inline-block" maxWidth="100%">
       {!loaded && (
-        <Placeholder
-          width={width ? `${width}px` : '100%'}
-          height={width && height ? 'auto' : `${MAX_IMAGE_HEIGHT}px`}
+        <PlaceholderSizer
           style={{
+            width: width ? `${width}px` : '100%',
             maxWidth: '100%',
             maxHeight: `${MAX_IMAGE_HEIGHT}px`,
-            aspectRatio: aspectRatio(width, height),
+            aspectRatio: width && height ? `${width} / ${height}` : undefined,
           }}
-        />
+        >
+          <Placeholder width="100%" height="100%" />
+        </PlaceholderSizer>
       )}
       <HiddenUntilLoaded
         ref={refCallback}
@@ -334,6 +335,10 @@ function LazyImage({
     </Container>
   );
 }
+
+const PlaceholderSizer = styled('div')`
+  overflow: hidden;
+`;
 
 const HiddenUntilLoaded = styled('img')`
   display: block;

--- a/static/app/views/preprod/snapshots/main/snapshotFrames.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotFrames.tsx
@@ -59,7 +59,7 @@ export function SnapshotVariantFrame({
     >
       {children}
       {isSelected ? (
-        <Container
+        <SelectedOverlay
           position="absolute"
           inset={0}
           pointerEvents="none"
@@ -80,6 +80,8 @@ export function SnapshotCanvasWrapper({children}: {children: React.ReactNode}) {
   );
 }
 
+const SelectedOverlay = styled(Container)``;
+
 const SnapshotVariantContainer = styled(Container, {
   shouldForwardProp: prop => prop !== '$fillHeight',
 })<{$fillHeight: boolean}>`
@@ -94,5 +96,15 @@ const SnapshotVariantContainer = styled(Container, {
 
   &:not(:last-child) {
     border-bottom: 1px solid ${p => p.theme.tokens.border.secondary};
+  }
+
+  &:first-child > ${SelectedOverlay} {
+    border-top-left-radius: ${p => p.theme.radius.md};
+    border-top-right-radius: ${p => p.theme.radius.md};
+  }
+
+  &:last-child > ${SelectedOverlay} {
+    border-bottom-left-radius: ${p => p.theme.radius.md};
+    border-bottom-right-radius: ${p => p.theme.radius.md};
   }
 `;

--- a/static/app/views/preprod/snapshots/main/snapshotListView.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.tsx
@@ -1,4 +1,12 @@
-import {memo, useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {useVirtualizer} from '@tanstack/react-virtual';
@@ -25,8 +33,11 @@ interface SnapshotListViewProps {
   diffMode?: DiffMode;
   headBranch?: string | null;
   onOpenSnapshot?: (key: string) => void;
+  onScrollProgress?: (progress: number, firstVisibleIndex: number) => void;
   onSelectSnapshot?: (key: string | null) => void;
+  onVisibleGroupChange?: (name: string | null) => void;
   overlayColor?: string;
+  ref?: React.Ref<SnapshotListViewHandle>;
   selectedSnapshotKey?: string | null;
 }
 
@@ -158,34 +169,38 @@ function buildGroups(items: SidebarItem[]): GroupRow[] {
   return groups;
 }
 
-export function SnapshotListView({
+export interface SnapshotListViewHandle {
+  scrollToGroup: (name: string) => void;
+}
+
+export const SnapshotListView = memo(function SnapshotListView({
   items,
   imageBaseUrl,
   headBranch,
   selectedSnapshotKey,
   onSelectSnapshot,
   onOpenSnapshot,
+  onScrollProgress,
   diffMode = 'split',
   overlayColor,
   diffImageBaseUrl,
+  ref,
+  onVisibleGroupChange,
 }: SnapshotListViewProps) {
   const theme = useTheme();
   const groups = useMemo(() => buildGroups(items), [items]);
   const scrollRef = useRef<HTMLDivElement>(null);
   const [scrollTop, setScrollTop] = useState(0);
-  const handleScroll = useCallback((event: React.UIEvent<HTMLDivElement>) => {
-    setScrollTop(event.currentTarget.scrollTop);
-  }, []);
 
   const virtualizer = useVirtualizer({
     count: groups.length,
     getScrollElement: () => scrollRef.current,
     estimateSize: i => groups[i]!.estimatedHeight,
     getItemKey: i => groups[i]!.id,
-    overscan: 2,
-    // Breathing margin between the target card and the chrome when scrollToIndex aligns to either edge
+    overscan: 5,
     scrollPaddingEnd: 8,
   });
+  virtualizer.shouldAdjustScrollPositionOnItemSizeChange = () => false;
 
   // Flat (snapshotKey -> groupIdx / position) index for keyboard nav and scroll; O(1) lookups
   const flatIndex = useMemo(() => {
@@ -193,7 +208,8 @@ export function SnapshotListView({
     const groupIdxByKey = new Map<string, number>();
     const positionByKey = new Map<string, number>();
     for (let gi = 0; gi < groups.length; gi++) {
-      for (const card of groups[gi]!.cards) {
+      const group = groups[gi]!;
+      for (const card of group.cards) {
         const key = snapshotKeyFor(card);
         positionByKey.set(key, order.length);
         order.push(key);
@@ -202,6 +218,97 @@ export function SnapshotListView({
     }
     return {order, groupIdxByKey, positionByKey};
   }, [groups]);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      scrollToGroup(name: string) {
+        const groupIdx = groups.findIndex(g => g.name === name);
+        if (groupIdx === -1) {
+          return;
+        }
+        virtualizer.scrollToIndex(groupIdx, {align: 'start'});
+      },
+    }),
+    [groups, virtualizer]
+  );
+
+  const rafId = useRef(0);
+  const onVisibleGroupChangeRef = useRef(onVisibleGroupChange);
+  onVisibleGroupChangeRef.current = onVisibleGroupChange;
+  const onScrollProgressRef = useRef(onScrollProgress);
+  onScrollProgressRef.current = onScrollProgress;
+  const groupsRef = useRef(groups);
+  groupsRef.current = groups;
+  const flatIndexRef = useRef(flatIndex);
+  flatIndexRef.current = flatIndex;
+  const handleScroll = useCallback(() => {
+    cancelAnimationFrame(rafId.current);
+    rafId.current = requestAnimationFrame(() => {
+      const el = scrollRef.current;
+      if (!el) {
+        return;
+      }
+      setScrollTop(el.scrollTop);
+      const containerTop = el.getBoundingClientRect().top;
+
+      const rows = el.querySelectorAll<HTMLElement>('[data-index]');
+      const ROW_THRESHOLD = 100;
+      let visibleGroupName = groupsRef.current[0]?.name ?? null;
+      for (const row of rows) {
+        const idx = parseInt(row.dataset.index ?? '', 10);
+        if (isNaN(idx)) {
+          continue;
+        }
+        const rowTop = row.getBoundingClientRect().top - containerTop;
+        if (rowTop <= ROW_THRESHOLD) {
+          visibleGroupName = groupsRef.current[idx]?.name ?? null;
+        }
+      }
+      onVisibleGroupChangeRef.current?.(visibleGroupName);
+
+      if (onScrollProgressRef.current) {
+        const maxScroll = el.scrollHeight - el.clientHeight;
+        const progress = maxScroll > 0 ? (el.scrollTop / maxScroll) * 100 : 0;
+        const cards = el.querySelectorAll<HTMLElement>('[data-snapshot-key]');
+        const SNAP_THRESHOLD = 9;
+        let topCard = 0;
+        for (const card of cards) {
+          const key = card.dataset.snapshotKey;
+          if (!key) {
+            continue;
+          }
+          const pos = flatIndexRef.current.positionByKey.get(key);
+          if (pos === undefined) {
+            continue;
+          }
+          const cardTop = card.getBoundingClientRect().top - containerTop;
+          if (cardTop <= SNAP_THRESHOLD) {
+            topCard = pos;
+          }
+        }
+        onScrollProgressRef.current(progress, topCard);
+      }
+    });
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) {
+      return;
+    }
+    el.addEventListener('scroll', handleScroll, {passive: true});
+    return () => {
+      el.removeEventListener('scroll', handleScroll);
+      cancelAnimationFrame(rafId.current);
+    };
+  }, [handleScroll]);
+
+  useEffect(() => {
+    if (groups.length > 0) {
+      handleScroll();
+    }
+  }, [groups, handleScroll]);
 
   const initialSnapshotKey = useRef(selectedSnapshotKey ?? null).current;
   const didInitialScroll = useRef(false);
@@ -221,6 +328,14 @@ export function SnapshotListView({
       );
       if (el) {
         el.scrollIntoView({block: 'start'});
+        const groupIdx = flatIndex.groupIdxByKey.get(initialSnapshotKey);
+        if (
+          groupIdx !== undefined &&
+          !groups[groupIdx]?.isUngrouped &&
+          scrollRef.current
+        ) {
+          scrollRef.current.scrollTop -= SNAPSHOT_GROUP_HEADER_HEIGHT;
+        }
       }
     });
   }, [groups, initialSnapshotKey, flatIndex, virtualizer]);
@@ -248,6 +363,16 @@ export function SnapshotListView({
         return false;
       }
       cardEl.scrollIntoView({block});
+      if (block === 'start') {
+        const groupIdx = keyNavRef.current.flatIndex.groupIdxByKey.get(key);
+        if (
+          groupIdx !== undefined &&
+          !groupsRef.current[groupIdx]?.isUngrouped &&
+          scrollRef.current
+        ) {
+          scrollRef.current.scrollTop -= SNAPSHOT_GROUP_HEADER_HEIGHT;
+        }
+      }
       return true;
     }
 
@@ -391,7 +516,7 @@ export function SnapshotListView({
   }
 
   return (
-    <ScrollContainer ref={scrollRef} onScroll={handleScroll}>
+    <ScrollContainer ref={scrollRef}>
       {activeGroupName ? (
         <StickyGroupHeader
           data-bottom-frame={stickyHeaderHasBottomFrame ? '' : undefined}
@@ -428,7 +553,7 @@ export function SnapshotListView({
       </Container>
     </ScrollContainer>
   );
-}
+});
 
 const GroupContainer = memo(function GroupContainer({
   group,

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -1,5 +1,5 @@
 import type React from 'react';
-import {Fragment, useCallback, useEffect, useRef, useState} from 'react';
+import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -12,6 +12,7 @@ import {Separator} from '@sentry/scraps/separator';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
+import {ProgressBar} from 'sentry/components/progressBar';
 import {
   IconArrow,
   IconExpand,
@@ -32,7 +33,12 @@ import {
 import {SingleImageDisplay} from './imageDisplay/singleImageDisplay';
 import {CardHeader, DarkAware} from './snapshotCards';
 import {SnapshotCardFrame, SnapshotVariantFrame} from './snapshotFrames';
-import {buildSnapshotLink, isItemUngrouped, SnapshotListView} from './snapshotListView';
+import {
+  buildSnapshotLink,
+  isItemUngrouped,
+  SnapshotListView,
+  type SnapshotListViewHandle,
+} from './snapshotListView';
 
 type ViewMode = 'single' | 'list';
 type SortBy = 'diff' | 'alpha';
@@ -63,8 +69,10 @@ interface SnapshotMainContentProps {
   variantIndex: number;
   viewMode: ViewMode;
   headBranch?: string | null;
+  listViewRef?: React.RefObject<SnapshotListViewHandle | null>;
   onSelectSnapshot?: (key: string | null) => void;
   onSortByChange?: (sort: SortBy) => void;
+  onVisibleGroupChange?: (name: string | null) => void;
   selectedSnapshotKey?: string | null;
   sortBy?: SortBy;
 }
@@ -86,17 +94,60 @@ export function SnapshotMainContent({
   onToggleSoloView,
   comparisonType,
   headBranch,
+  listViewRef,
   selectedSnapshotKey,
   onSelectSnapshot,
   sortBy = 'diff',
   onSortByChange,
+  onVisibleGroupChange,
   onNavigateSingleView,
   canNavigatePrev,
   canNavigateNext,
   navButtonRefs,
 }: SnapshotMainContentProps) {
   const [isDark, setIsDark] = useState(false);
-  const toggleDark = () => setIsDark(v => !v);
+  const toggleDark = useCallback(() => setIsDark(v => !v), []);
+  const [scrollProgress, setScrollProgress] = useState(0);
+  const [currentCardIndex, setCurrentCardIndex] = useState(0);
+
+  const {cardOffsets, totalCards} = useMemo(() => {
+    const offsets: number[] = [];
+    let total = 0;
+    for (const item of listItems) {
+      offsets.push(total);
+      const count =
+        item.type === 'changed' || item.type === 'renamed'
+          ? item.pairs.length
+          : item.images.length;
+      total += count;
+    }
+    return {cardOffsets: offsets, totalCards: total};
+  }, [listItems]);
+
+  const handleListScrollProgress = useCallback(
+    (progress: number, firstVisibleCardIndex: number) => {
+      setScrollProgress(progress);
+      setCurrentCardIndex(firstVisibleCardIndex);
+    },
+    []
+  );
+
+  const singleViewIndex = useMemo(() => {
+    if (!selectedItem) {
+      return 0;
+    }
+    const idx = listItems.indexOf(selectedItem);
+    return idx === -1 ? 0 : idx;
+  }, [selectedItem, listItems]);
+
+  useEffect(() => {
+    if (viewMode !== 'single') {
+      return;
+    }
+    const cardIndex = (cardOffsets[singleViewIndex] ?? 0) + variantIndex;
+    setCurrentCardIndex(cardIndex);
+    setScrollProgress(totalCards <= 1 ? 100 : (cardIndex / (totalCards - 1)) * 100);
+  }, [viewMode, singleViewIndex, variantIndex, totalCards, cardOffsets]);
 
   const handleOpenSnapshot = useCallback(
     (key: string) => {
@@ -108,6 +159,14 @@ export function SnapshotMainContent({
 
   const toggle = (
     <ViewModeToggle viewMode={viewMode} onViewModeChange={onViewModeChange} />
+  );
+  const progressIndicator = totalCards > 0 && (
+    <ProgressPill>
+      <ToolbarProgressBar value={scrollProgress} />
+      <ProgressCounter size="xs" variant="muted">
+        {currentCardIndex + 1}/{totalCards}
+      </ProgressCounter>
+    </ProgressPill>
   );
   const hasChangedInList = listItems.some(i => i.type === 'changed');
   const sortDropdown =
@@ -146,6 +205,7 @@ export function SnapshotMainContent({
           <Flex align="center" gap="md" onClick={e => e.stopPropagation()}>
             {toggle}
             {sortDropdown}
+            {progressIndicator}
           </Flex>
           <Flex align="center" gap="md" onClick={e => e.stopPropagation()}>
             {listDiffControls}
@@ -154,15 +214,18 @@ export function SnapshotMainContent({
         </Flex>
         <Separator orientation="horizontal" />
         <SnapshotListView
+          ref={listViewRef}
           items={listItems}
           imageBaseUrl={imageBaseUrl}
           headBranch={headBranch}
           selectedSnapshotKey={selectedSnapshotKey}
           onSelectSnapshot={onSelectSnapshot}
           onOpenSnapshot={handleOpenSnapshot}
+          onScrollProgress={handleListScrollProgress}
           diffMode={diffMode}
           overlayColor={overlayColor}
           diffImageBaseUrl={diffImageBaseUrl}
+          onVisibleGroupChange={onVisibleGroupChange}
         />
       </Flex>
     );
@@ -175,6 +238,7 @@ export function SnapshotMainContent({
           <Flex align="center" gap="md">
             {toggle}
             {sortDropdown}
+            {progressIndicator}
           </Flex>
           {soloDiffToggle}
         </Flex>
@@ -201,6 +265,8 @@ export function SnapshotMainContent({
         groupName={groupName}
         toggle={toggle}
         soloDiffToggle={soloDiffToggle}
+        sortDropdown={sortDropdown}
+        progressIndicator={progressIndicator}
         canNavigatePrev={canNavigatePrev}
         canNavigateNext={canNavigateNext}
         onNavigateSingleView={onNavigateSingleView}
@@ -249,6 +315,8 @@ export function SnapshotMainContent({
         groupName={groupName}
         toggle={toggle}
         soloDiffToggle={soloDiffToggle}
+        sortDropdown={sortDropdown}
+        progressIndicator={progressIndicator}
         canNavigatePrev={canNavigatePrev}
         canNavigateNext={canNavigateNext}
         onNavigateSingleView={onNavigateSingleView}
@@ -288,6 +356,8 @@ export function SnapshotMainContent({
       groupName={groupName}
       toggle={toggle}
       soloDiffToggle={soloDiffToggle}
+      sortDropdown={sortDropdown}
+      progressIndicator={progressIndicator}
       canNavigatePrev={canNavigatePrev}
       canNavigateNext={canNavigateNext}
       onNavigateSingleView={onNavigateSingleView}
@@ -310,6 +380,8 @@ function SingleViewLayout({
   groupName,
   toggle,
   soloDiffToggle,
+  sortDropdown,
+  progressIndicator,
   canNavigatePrev,
   canNavigateNext,
   onNavigateSingleView,
@@ -327,7 +399,9 @@ function SingleViewLayout({
   navButtonRefs: NavButtonRefs;
   onNavigateSingleView: (direction: 'prev' | 'next') => void;
   onToggleDark: () => void;
+  progressIndicator: React.ReactNode;
   soloDiffToggle: React.ReactNode;
+  sortDropdown: React.ReactNode;
   toggle: React.ReactNode;
   rightControls?: React.ReactNode;
 }) {
@@ -360,7 +434,11 @@ function SingleViewLayout({
         padding="md xl md 0"
         onClick={e => e.stopPropagation()}
       >
-        {toggle}
+        <Flex align="center" gap="md">
+          {toggle}
+          {sortDropdown}
+          {progressIndicator}
+        </Flex>
         <Flex align="center" gap="md">
           {rightControls}
           {soloDiffToggle}
@@ -633,6 +711,21 @@ const ColorTrigger = styled('button')<{color: string}>`
   &:hover {
     border-color: ${p => p.theme.tokens.border.accent};
   }
+`;
+
+const ProgressPill = styled('div')`
+  display: flex;
+  align-items: center;
+  gap: ${p => p.theme.space.sm};
+`;
+
+const ProgressCounter = styled(Text)`
+  white-space: nowrap;
+  font-family: ${p => p.theme.font.family.mono};
+`;
+
+const ToolbarProgressBar = styled(ProgressBar)`
+  width: 50px;
 `;
 
 const ColorSwatch = styled('button')<{color: string; selected: boolean}>`

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.snapshots.tsx
@@ -44,45 +44,58 @@ describe('SnapshotSidebarContent', () => {
     }
 
     it.snapshot(
-      'all-selected',
+      'default',
       () => (
         <Wrapper>
           <SnapshotSidebarContent
             groups={groups}
-            currentItemKey="Button/light"
-            isAllSelected
             searchQuery=""
             onSearchChange={noop}
             onSelectItem={noop}
-            onSelectAll={noop}
             statusCounts={statusCounts}
             activeStatuses={new Set()}
             onToggleStatus={noop}
           />
         </Wrapper>
       ),
-      {theme: themeName, state: 'all-selected'}
+      {theme: themeName, state: 'default'}
     );
 
     it.snapshot(
-      'child-selected',
+      'active-group',
       () => (
         <Wrapper>
           <SnapshotSidebarContent
             groups={groups}
-            currentItemKey="Badge/light"
-            isAllSelected={false}
+            activeGroupName="Badge/light"
             searchQuery=""
             onSearchChange={noop}
             onSelectItem={noop}
-            onSelectAll={noop}
+            statusCounts={statusCounts}
+            activeStatuses={new Set()}
+            onToggleStatus={noop}
+          />
+        </Wrapper>
+      ),
+      {theme: themeName, state: 'active-group'}
+    );
+
+    it.snapshot(
+      'filtered',
+      () => (
+        <Wrapper>
+          <SnapshotSidebarContent
+            groups={groups}
+            searchQuery=""
+            onSearchChange={noop}
+            onSelectItem={noop}
             statusCounts={statusCounts}
             activeStatuses={new Set([DiffStatus.UNCHANGED])}
             onToggleStatus={noop}
           />
         </Wrapper>
       ),
-      {theme: themeName, state: 'child-selected'}
+      {theme: themeName, state: 'filtered'}
     );
 
     it.snapshot(
@@ -91,12 +104,9 @@ describe('SnapshotSidebarContent', () => {
         <Wrapper>
           <SnapshotSidebarContent
             groups={[]}
-            currentItemKey={null}
-            isAllSelected
             searchQuery="missing"
             onSearchChange={noop}
             onSelectItem={noop}
-            onSelectAll={noop}
             statusCounts={statusCounts}
             activeStatuses={new Set([DiffStatus.CHANGED, DiffStatus.UNCHANGED])}
             onToggleStatus={noop}

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.tsx
@@ -41,25 +41,21 @@ const STATUS_PILLS: ReadonlyArray<{
 
 interface SnapshotSidebarContentProps {
   activeStatuses: Set<DiffStatus>;
-  currentItemKey: string | null;
   groups: SidebarGroup[];
-  isAllSelected: boolean;
   onSearchChange: (query: string) => void;
-  onSelectAll: () => void;
   onSelectItem: (key: string) => void;
   onToggleStatus: (status: DiffStatus) => void;
   searchQuery: string;
+  activeGroupName?: string | null;
   statusCounts?: StatusCounts | null;
 }
 
 export function SnapshotSidebarContent({
   groups,
-  currentItemKey,
-  isAllSelected,
+  activeGroupName,
   searchQuery,
   onSearchChange,
   onSelectItem,
-  onSelectAll,
   statusCounts,
   activeStatuses,
   onToggleStatus,
@@ -70,36 +66,42 @@ export function SnapshotSidebarContent({
   const listRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!listRef.current || !currentItemKey || isAllSelected) {
+    const container = listRef.current;
+    if (!container || !activeGroupName) {
       return;
     }
-    const el = listRef.current.querySelector(
-      `[data-item-name="${CSS.escape(currentItemKey)}"]`
+    const el = container.querySelector<HTMLElement>(
+      `[data-item-name="${CSS.escape(activeGroupName)}"]`
     );
-    el?.scrollIntoView({block: 'nearest'});
-  }, [currentItemKey, groups, isAllSelected]);
+    if (!el) {
+      return;
+    }
+    const cRect = container.getBoundingClientRect();
+    const eRect = el.getBoundingClientRect();
+    if (eRect.top < cRect.top) {
+      container.scrollTop -= cRect.top - eRect.top;
+    } else if (eRect.bottom > cRect.bottom) {
+      container.scrollTop += eRect.bottom - cRect.bottom;
+    }
+  }, [activeGroupName]);
 
   const renderGroup = (group: SidebarGroup) => {
-    const isSelected = !isAllSelected && group.key === currentItemKey;
+    const isActive = group.key === activeGroupName;
     return (
       <SidebarItemRow
         key={group.key}
         data-item-name={group.key}
-        isSelected={isSelected}
+        isSelected={isActive}
         onClick={e => {
           e.stopPropagation();
-          if (isSelected) {
-            onSelectAll();
-          } else {
-            onSelectItem(group.key);
-          }
+          onSelectItem(group.key);
         }}
       >
         <Flex align="center" gap="sm" flex="1" minWidth="0">
           <Text
             size="md"
-            variant={isSelected ? 'accent' : 'muted'}
-            bold={isSelected}
+            variant={isActive ? 'accent' : 'muted'}
+            bold={isActive}
             ellipsis
             onPointerEnter={setTitleOnOverflow}
           >
@@ -129,18 +131,7 @@ export function SnapshotSidebarContent({
           </InputGroup.LeadingItems>
           <InputGroup.Input
             size="sm"
-            placeholder={
-              currentItemKey
-                ? t(
-                    'Search %s %s components...',
-                    groups.find(g => g.key === currentItemKey)?.count ?? '',
-                    currentItemKey
-                  )
-                : t(
-                    'Search %s components...',
-                    groups.reduce((sum, g) => sum + g.count, 0)
-                  )
-            }
+            placeholder={t('Search components...')}
             value={searchQuery}
             onChange={e => onSearchChange(e.target.value)}
           />
@@ -167,24 +158,6 @@ export function SnapshotSidebarContent({
         )}
       </Stack>
       <Stack ref={listRef} overflow="auto" flex="1" paddingRight="0">
-        <SidebarItemRow
-          isSelected={isAllSelected}
-          onClick={e => {
-            e.stopPropagation();
-            onSelectAll();
-          }}
-        >
-          <Flex align="center" gap="sm" flex="1" minWidth="0">
-            <Text
-              size="md"
-              variant={isAllSelected ? 'accent' : 'primary'}
-              bold={isAllSelected}
-              ellipsis
-            >
-              {t('All')}
-            </Text>
-          </Flex>
-        </SidebarItemRow>
         {groups.map(renderGroup)}
         {groups.length === 0 && (
           <Flex align="center" justify="center" padding="lg">

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -32,6 +32,7 @@ import type {
 import {SnapshotHeaderActions} from './header/snapshotHeaderActions';
 import {SnapshotHeaderContent} from './header/snapshotHeaderContent';
 import type {DiffMode} from './main/imageDisplay/diffImageDisplay';
+import type {SnapshotListViewHandle} from './main/snapshotListView';
 import {type NavButtonRefs, SnapshotMainContent} from './main/snapshotMainContent';
 import {
   DIFF_TYPE_ORDER,
@@ -136,11 +137,6 @@ export default function SnapshotsPage() {
 
   const [searchQuery, setSearchQuery] = useState('');
   const pushHistory = {history: 'push' as const};
-  const [selectedGroup, setSelectedGroup] = useQueryState(
-    'selectedGroup',
-    parseAsString.withOptions(pushHistory)
-  );
-  const [variantIndex, setVariantIndex] = useState(0);
   const palette = theme.chart.getColorPalette(10);
   const [overlayColor, setOverlayColor] = useLocalStorageState<string>(
     'snapshot-overlay-color',
@@ -212,7 +208,7 @@ export default function SnapshotsPage() {
 
   const isSoloView = comparisonType === 'solo';
   const handleToggleView = useCallback(() => {
-    const {view: _view, selectedGroup: _sg, ...restQuery} = location.query;
+    const {view: _view, ...restQuery} = location.query;
     if (isSoloView) {
       navigate({...location, query: restQuery}, {replace: true});
     } else {
@@ -339,24 +335,8 @@ export default function SnapshotsPage() {
     return [...merged.values()];
   }, [filteredItems]);
 
-  const isAllSelected = selectedGroup === null;
-  const hasMatchingItems =
-    selectedGroup !== null && filteredItems.some(i => i.name === selectedGroup);
-  const currentItem = hasMatchingItems
-    ? (filteredItems.find(i => i.name === selectedGroup) ?? null)
-    : isAllSelected
-      ? (filteredItems[0] ?? null)
-      : null;
-
-  const listItems = useMemo(() => {
-    if (isAllSelected) {
-      return filteredItems;
-    }
-    if (!selectedGroup) {
-      return [];
-    }
-    return filteredItems.filter(i => i.name === selectedGroup);
-  }, [isAllSelected, filteredItems, selectedGroup]);
+  const currentItem = filteredItems[0] ?? null;
+  const listItems = filteredItems;
 
   const statusCounts = useMemo<Record<DiffStatus, number> | null>(() => {
     if (comparisonType !== 'diff') {
@@ -369,36 +349,35 @@ export default function SnapshotsPage() {
       [DiffStatus.RENAMED]: 0,
       [DiffStatus.UNCHANGED]: 0,
     };
-    const source = selectedGroup
-      ? searchFilteredItems.filter(i => i.name === selectedGroup)
-      : searchFilteredItems;
-    for (const item of source) {
+    for (const item of searchFilteredItems) {
       if (item.type in counts) {
         counts[item.type as DiffStatus] += itemVariantCount(item);
       }
     }
     return counts;
-  }, [searchFilteredItems, selectedGroup, comparisonType]);
+  }, [searchFilteredItems, comparisonType]);
 
-  // Clamp variantIndex when the selected item changes implicitly (e.g. search
-  // filtering selects a new item with fewer variants).
-  const variantCount = currentItem ? itemVariantCount(currentItem) : 0;
-  const safeVariantIndex =
-    variantCount > 0 ? Math.min(variantIndex, variantCount - 1) : 0;
+  const listViewRef = useRef<SnapshotListViewHandle>(null);
+  const [visibleGroupName, setVisibleGroupName] = useState<string | null>(null);
 
-  const handleSelectItem = (name: string) => {
-    setSelectedGroup(name);
-    setVariantIndex(0);
-  };
-
-  const handleSelectAll = () => {
-    setSelectedGroup(null);
-    setVariantIndex(0);
-  };
+  const handleSelectItem = useCallback(
+    (name: string) => {
+      const item = filteredItems.find(i => i.name === name);
+      if (!item) {
+        return;
+      }
+      const key = snapshotKeyAt(item, 0);
+      if (key) {
+        setSelectedSnapshotKey(key);
+      }
+      listViewRef.current?.scrollToGroup(name);
+    },
+    [filteredItems, setSelectedSnapshotKey]
+  );
 
   // Scoped to listItems (not sidebarItems) so up/down nav only walks the
-  // snapshots currently visible to the user. Falls back to currentItem +
-  // variantIndex when selectedSnapshotKey can't be resolved.
+  // snapshots currently visible to the user. Falls back to currentItem
+  // when selectedSnapshotKey can't be resolved.
   const singleViewPosition = useMemo(() => {
     if (selectedSnapshotKey) {
       const pos = findSnapshotPosition(listItems, selectedSnapshotKey);
@@ -413,8 +392,8 @@ export default function SnapshotsPage() {
     if (itemIdx === -1) {
       return null;
     }
-    return {itemIdx, variantIdx: safeVariantIndex};
-  }, [selectedSnapshotKey, listItems, currentItem, safeVariantIndex]);
+    return {itemIdx, variantIdx: 0};
+  }, [selectedSnapshotKey, listItems, currentItem]);
 
   const navigateSingleView = useCallback(
     (direction: 'prev' | 'next') => {
@@ -564,10 +543,10 @@ export default function SnapshotsPage() {
     viewMode === 'single' && singleViewPosition
       ? (listItems[singleViewPosition.itemIdx] ?? deferredItem)
       : deferredItem;
-  const singleViewVariantIndex =
-    viewMode === 'single' && singleViewPosition
-      ? singleViewPosition.variantIdx
-      : safeVariantIndex;
+  const singleViewVariantIndex = singleViewPosition?.variantIdx ?? 0;
+
+  const activeGroupName =
+    viewMode === 'list' ? visibleGroupName : (singleViewItem?.name ?? null);
 
   const isComparisonProcessing =
     !!comparisonRunInfo?.state &&
@@ -608,12 +587,10 @@ export default function SnapshotsPage() {
       >
         <SnapshotSidebarContent
           groups={sidebarGroups}
-          currentItemKey={selectedGroup}
-          isAllSelected={isAllSelected}
+          activeGroupName={activeGroupName}
           searchQuery={searchQuery}
           onSearchChange={setSearchQuery}
           onSelectItem={handleSelectItem}
-          onSelectAll={handleSelectAll}
           statusCounts={statusCounts}
           activeStatuses={activeStatuses}
           onToggleStatus={handleToggleStatus}
@@ -631,6 +608,7 @@ export default function SnapshotsPage() {
           selectedItem={singleViewItem}
           variantIndex={singleViewVariantIndex}
           imageBaseUrl={imageBaseUrl}
+          listViewRef={listViewRef}
           diffImageBaseUrl={diffImageBaseUrl}
           overlayColor={overlayColor}
           onOverlayColorChange={setOverlayColor}
@@ -646,6 +624,7 @@ export default function SnapshotsPage() {
           headBranch={data?.vcs_info?.head_ref}
           selectedSnapshotKey={selectedSnapshotKey}
           onSelectSnapshot={setSelectedSnapshotKey}
+          onVisibleGroupChange={setVisibleGroupName}
           sortBy={sortBy}
           onSortByChange={setSortBy}
           onNavigateSingleView={navigateSingleView}


### PR DESCRIPTION
Adds a pill-shaped progress bar with a card counter (e.g. "3/11") to the snapshot viewer toolbar, positioned between the view mode toggle and the diff controls.

**List view**: Tracks scroll position using a RAF-throttled scroll handler that queries visible card DOM elements (bounded by virtualization) to determine the current card index accurately within groups.

**Single image view**: Computes position from the selected item index and variant index within the item's card list.

The progress indicator is visible in both view modes and includes:
- A small `ProgressBar` showing scroll/position percentage
- A text counter showing current card / total cards
- A pill container with border styling matching the toolbar controls