### PR TITLE
fix: flaky `test_handler` by isolating trace context in log handler tests

### DIFF
--- a/src/sentry/testutils/helpers/sdk.py
+++ b/src/sentry/testutils/helpers/sdk.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from contextlib import contextmanager
+
+import sentry_sdk
+
+
+@contextmanager
+def reset_trace_context() -> Generator[None]:
+    """
+    Context manager that isolates the SDK scope AND clears any inherited span.
+
+    ``sentry_sdk.isolation_scope()`` forks (shallow-copies) the current scope,
+    which means any active span is carried over.  This wrapper also sets
+    ``scope.span = None`` so that ``get_trace_id()`` returns ``None`` inside
+    the block — which is the expected state when no span is active.
+
+    Usage::
+
+        with reset_trace_context():
+            handler.emit(record, logger=logger)
+    """
+    with sentry_sdk.isolation_scope():
+        sentry_sdk.get_current_scope().span = None
+        yield

--- a/tests/sentry/logging/test_handler.py
+++ b/tests/sentry/logging/test_handler.py
@@ -13,6 +13,7 @@ from sentry.logging.handlers import (
     SamplingFilter,
     StructLogHandler,
 )
+from sentry.testutils.helpers.sdk import reset_trace_context
 from sentry.utils.sdk import get_trace_id
 
 
@@ -99,7 +100,8 @@ def make_logrecord(
 )
 def test_emit(record, out, handler, logger) -> None:
     record = make_logrecord(**record)
-    handler.emit(record, logger=logger)
+    with reset_trace_context():
+        handler.emit(record, logger=logger)
     expected = {
         "level": logging.INFO,
         "event": "msg",
@@ -190,7 +192,10 @@ def test_logging_raiseExcpetions_disabled_generic_logging(caplog, snafu) -> None
 
 def test_gke_emit() -> None:
     logger = mock.Mock()
-    GKEStructLogHandler().emit(make_logrecord(), logger=logger)
+    # Isolate from any ambient trace left by a previous test; get_trace_id()
+    # must return None when no span is active.
+    with reset_trace_context():
+        GKEStructLogHandler().emit(make_logrecord(), logger=logger)
     logger.log.assert_called_once_with(
         name="name",
         level=logging.INFO,


### PR DESCRIPTION
fixes flakes like https://github.com/getsentry/sentry/actions/runs/25186909243/job/73846655451?pr=114485

this has been verified on my `shuffle-tests-v5` branch as well

`get_trace_id()` reads `sentry_sdk.get_current_scope().span`. When a preceding test leaves an active span on the shared thread-local scope, `test_emit` and `test_gke_emit` receive a real trace ID instead of `None` and fail their assertions.

alternative solution doesn't work:

`sentry_sdk.isolation_scope()` alone doesn't help — it shallow-copies the current scope and carries the active span over. The new `reset_trace_context()` helper wraps `isolation_scope()` and explicitly zeroes `scope.span`, giving the enclosed call a clean slate. Applied surgically at the two call sites that assert `trace_id=None`.