### PR TITLE
feat(seer): Add structured LLM context for issue list page

### DIFF
--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -54,6 +54,8 @@ import {useSuperGroups} from 'sentry/views/issueList/supergroups/useSuperGroups'
 import type {IssueUpdateData} from 'sentry/views/issueList/types';
 import {parseIssuePrioritySearch} from 'sentry/views/issueList/utils/parseIssuePrioritySearch';
 import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
+import {useLLMContext} from 'sentry/views/seerExplorer/contexts/llmContext';
+import {registerLLMContext} from 'sentry/views/seerExplorer/contexts/registerLLMContext';
 
 import {IssueListFilters} from './filters';
 import {IssueListCommandPaletteActions} from './issueListCommandPaletteActions';
@@ -124,7 +126,7 @@ const parsePageQueryParam = (location: Location, defaultPage = 0) => {
   return pageInt;
 };
 
-function IssueListOverview({
+function IssueListOverviewInner({
   initialQuery = DEFAULT_QUERY,
   shouldFetchOnMount = true,
   title = t('Issues'),
@@ -880,6 +882,32 @@ function IssueListOverview({
 
   const hasPageFrame = useHasPageFrameFeature();
 
+  useLLMContext({
+    contextHint:
+      'Sentry issue list page. Shows a filterable, sortable list of grouped issues. ' +
+      'query is the current search filter (Sentry search syntax). ' +
+      'displayedIssues is a pipe-delimited CSV with header row (shortId|title|issueType|level|priority|events|users|firstSeen) of the visible issues on the current page. ' +
+      'issueCount is the total matching issues — there may be more than what is displayed. ' +
+      'Tools: get_issue_details(issue_id) for issue aggregate stats; ' +
+      'get_event_details(event_id?, issue_id?) for a specific error event; ' +
+      'telemetry_live_search(dataset, question, project_slugs) for querying spans/errors/logs/metrics.',
+    query,
+    sort,
+    issueCount: queryCount,
+    projects: selection.projects,
+    environments: selection.environments,
+    dateRange: selection.datetime,
+    displayedIssues: [
+      'shortId|title|issueType|level|priority|events|users|firstSeen',
+      ...groups
+        .slice(0, MAX_ITEMS)
+        .map(
+          g =>
+            `${g.shortId}|${g.title.replace(/[|\n]/g, ' ')}|${g.issueType}|${g.level}|${g.priority}|${'count' in g ? g.count : ''}|${'userCount' in g ? g.userCount : ''}|${g.firstSeen}`
+        ),
+    ].join('\n'),
+  });
+
   return (
     <IssueSelectionProvider visibleGroupIds={groupIds}>
       <Stack flex={1}>
@@ -961,6 +989,8 @@ function IssueListOverview({
     </IssueSelectionProvider>
   );
 }
+
+const IssueListOverview = registerLLMContext('issue-list', IssueListOverviewInner);
 
 export default Sentry.withProfiler(IssueListOverview);
 

--- a/static/app/views/seerExplorer/contexts/llmContextTypes.ts
+++ b/static/app/views/seerExplorer/contexts/llmContextTypes.ts
@@ -20,6 +20,7 @@
 export type LLMContextNodeType =
   | 'chart'
   | 'dashboard'
+  | 'issue-list'
   | 'trace'
   | 'traces-explorer'
   | 'widget'

--- a/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
+++ b/static/app/views/seerExplorer/hooks/useSeerExplorer.tsx
@@ -55,7 +55,7 @@ const STRUCTURED_CONTEXT_ROUTES = new Set([
   '/explore/traces/trace/:traceSlug/',
 ]);
 /** New experimental routes where the LLMContext tree provides structured page context. */
-const NEW_STRUCTURED_CONTEXT_ROUTES = new Set<string>();
+const NEW_STRUCTURED_CONTEXT_ROUTES = new Set<string>(['/issues/']);
 
 function supportsStructuredContext(
   referrer: string,


### PR DESCRIPTION
+ Replace the ASCII DOM snapshot with structured semantic context on the /issues/ page for the Seer Explorer agent. Registers an 'issue-list' node type that pushes query filters, sort order, issue count, page filters, and a compact pipe-delimited CSV of the 25 visible issues (shortId, title, type, level, priority, events, users, firstSeen) into the LLM context tree.
+ Current p50 for this page is [5700 tokens](https://redash.getsentry.net/queries/10910). I am estimating this will bring it down to ~1200.
+ Gated behind the context-engine-structured-page-context flag via NEW_STRUCTURED_CONTEXT_ROUTES. ONly open to 4 internal users. 
+ Similar work on other pages: 
    + Trace details page -https://github.com/getsentry/sentry/pull/114093
    + Traces explore page - https://github.com/getsentry/sentry/pull/114347
    + Dashboard page - https://github.com/getsentry/sentry/pull/111973
+ Shipped post: https://vanguard.getsentry.net/p/cmodhfvfr00033pvr5owrfnke
