### PR TITLE
ref(seer-agent): Use Link component to enable cmd clicking tool links

### DIFF
--- a/static/app/views/seerExplorer/components/blockComponents.tsx
+++ b/static/app/views/seerExplorer/components/blockComponents.tsx
@@ -49,7 +49,6 @@ interface BlockProps {
   onClick?: () => void;
   onMouseEnter?: () => void;
   onMouseLeave?: () => void;
-  onNavigate?: () => void;
   readOnly?: boolean;
   ref?: React.Ref<HTMLDivElement>;
   runId?: number;
@@ -145,7 +144,6 @@ export function BlockComponent({
   onClick,
   onMouseEnter,
   onMouseLeave,
-  onNavigate,
   ref,
   showThinking = false,
 }: BlockProps) {
@@ -321,7 +319,6 @@ export function BlockComponent({
 
                       if (href.startsWith('/')) {
                         navigate(href);
-                        onNavigate?.();
                       } else {
                         window.open(href, '_blank', 'noopener,noreferrer');
                       }
@@ -364,14 +361,30 @@ export function BlockComponent({
                       </Tooltip>
                     );
 
-                    const toolUrl =
-                      hasLink && correspondingLinkIndex !== undefined
-                        ? buildToolLinkUrl(
-                            sortedToolLinks[correspondingLinkIndex]!,
-                            organization.slug,
-                            projects
-                          )
-                        : undefined;
+                    const toolUrl = hasLink
+                      ? buildToolLinkUrl(
+                          sortedToolLinks[correspondingLinkIndex],
+                          organization.slug,
+                          projects
+                        )
+                      : null;
+
+                    const handleToolLinkClick = (e: React.MouseEvent) => {
+                      if (hasLink) {
+                        e.stopPropagation();
+                        const selectedLink = sortedToolLinks[correspondingLinkIndex];
+                        if (selectedLink) {
+                          trackAnalytics(
+                            'seer.explorer.global_panel.tool_link_navigation',
+                            {
+                              referrer: getPageReferrer?.() ?? '',
+                              organization,
+                              tool_kind: selectedLink.kind,
+                            }
+                          );
+                        }
+                      }
+                    };
 
                     return (
                       <Stack gap="xs" key={`${toolCall.function}-${idx}`}>
@@ -382,21 +395,7 @@ export function BlockComponent({
                           {hasLink ? (
                             <ToolCallLink
                               to={toolUrl ?? ''}
-                              onClick={e => {
-                                e.stopPropagation();
-                                const selectedLink =
-                                  sortedToolLinks[correspondingLinkIndex];
-                                if (selectedLink) {
-                                  trackAnalytics(
-                                    'seer.explorer.global_panel.tool_link_navigation',
-                                    {
-                                      referrer: getPageReferrer?.() ?? '',
-                                      organization,
-                                      tool_kind: selectedLink.kind,
-                                    }
-                                  );
-                                }
-                              }}
+                              onClick={handleToolLinkClick}
                             >
                               {toolCallText}
                               <ToolCallLinkIconWrapper>

--- a/static/app/views/seerExplorer/components/blockComponents.tsx
+++ b/static/app/views/seerExplorer/components/blockComponents.tsx
@@ -1,13 +1,13 @@
-import {useCallback, useMemo} from 'react';
+import {useMemo} from 'react';
 import {keyframes} from '@emotion/react';
 import styled from '@emotion/styled';
 import {motion} from 'framer-motion';
-import type {LocationDescriptor} from 'history';
 
 import {Button} from '@sentry/scraps/button';
 import {inlineCodeStyles} from '@sentry/scraps/code';
 import {Disclosure} from '@sentry/scraps/disclosure';
 import {Flex, Stack} from '@sentry/scraps/layout';
+import {Link} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -199,20 +199,6 @@ export function BlockComponent({
     return map;
   }, [block.tool_links, block.tool_results]);
 
-  // Tool link navigation, with analytics and onNavigate hook.
-  const navigateToToolLink = useCallback(
-    (url: LocationDescriptor, toolKind: string) => {
-      trackAnalytics('seer.explorer.global_panel.tool_link_navigation', {
-        referrer: getPageReferrer?.() ?? '',
-        organization,
-        tool_kind: toolKind,
-      });
-      navigate(url);
-      onNavigate?.();
-    },
-    [organization, navigate, onNavigate, getPageReferrer]
-  );
-
   // Allow 1 feedback per session. This only writes to session storage on change, not init.
   const [feedbackSubmitted, setFeedbackSubmitted] = useSessionStorage(
     `seer-explorer-feedback:run-${runId ?? 'null'}:block-${block.id}`,
@@ -267,22 +253,6 @@ export function BlockComponent({
   const handleCopyClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     copy(block.message.content);
-  };
-
-  const handleNavigateClick = (e: React.MouseEvent, linkIndex: number) => {
-    e.stopPropagation();
-    if (sortedToolLinks.length === 0) {
-      return;
-    }
-
-    // Navigate to the clicked link
-    const selectedLink = sortedToolLinks[linkIndex];
-    if (selectedLink) {
-      const url = buildToolLinkUrl(selectedLink, organization.slug, projects);
-      if (url) {
-        navigateToToolLink(url, selectedLink.kind);
-      }
-    }
   };
 
   const showActions =
@@ -394,6 +364,15 @@ export function BlockComponent({
                       </Tooltip>
                     );
 
+                    const toolUrl =
+                      hasLink && correspondingLinkIndex !== undefined
+                        ? buildToolLinkUrl(
+                            sortedToolLinks[correspondingLinkIndex]!,
+                            organization.slug,
+                            projects
+                          )
+                        : undefined;
+
                     return (
                       <Stack gap="xs" key={`${toolCall.function}-${idx}`}>
                         <ToolCallTextContainer>
@@ -402,9 +381,22 @@ export function BlockComponent({
                           </ToolStatusSlot>
                           {hasLink ? (
                             <ToolCallLink
-                              onClick={e =>
-                                handleNavigateClick(e, correspondingLinkIndex)
-                              }
+                              to={toolUrl ?? ''}
+                              onClick={e => {
+                                e.stopPropagation();
+                                const selectedLink =
+                                  sortedToolLinks[correspondingLinkIndex];
+                                if (selectedLink) {
+                                  trackAnalytics(
+                                    'seer.explorer.global_panel.tool_link_navigation',
+                                    {
+                                      referrer: getPageReferrer?.() ?? '',
+                                      organization,
+                                      tool_kind: selectedLink.kind,
+                                    }
+                                  );
+                                }
+                              }}
                             >
                               {toolCallText}
                               <ToolCallLinkIconWrapper>
@@ -634,16 +626,14 @@ const ToolCallText = styled(Text)`
   text-decoration-color: transparent;
 `;
 
-const ToolCallLink = styled('button')`
+const ToolCallLink = styled(Link)`
   display: inline-flex;
   align-items: center;
   gap: ${p => p.theme.space.md};
   max-width: 100%;
-  background: none;
-  border: none;
   padding: 0;
   cursor: pointer;
-  text-align: left;
+  text-decoration: none;
   font-weight: ${p => p.theme.font.weight.sans.medium};
 
   &:hover {

--- a/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
+++ b/static/app/views/seerExplorer/components/drawer/explorerDrawerContent.tsx
@@ -373,7 +373,6 @@ export function ExplorerDrawerContent({
                 isLatestTodoBlock={index === latestTodoBlockIndex}
                 readOnly={readOnly}
                 showThinking={showThinking}
-                onNavigate={undefined} // TODO: close drawer on link navigate? useDrawerContentContext
               />
             ))}
             {!readOnly &&

--- a/static/app/views/seerExplorer/utils.tsx
+++ b/static/app/views/seerExplorer/utils.tsx
@@ -639,10 +639,14 @@ function buildMetricsQueryParam(params: Record<string, any>): string[] | undefin
  * Build a URL/LocationDescriptor for a tool link based on its kind and params
  */
 export function buildToolLinkUrl(
-  toolLink: ToolLink,
+  toolLink: ToolLink | undefined,
   orgSlug: string,
   projects?: Array<{id: string; slug: string}>
 ): LocationDescriptor | null {
+  if (!toolLink) {
+    return null;
+  }
+
   switch (toolLink.kind) {
     case 'telemetry_live_search': {
       const {dataset, project_slugs, query, sort, stats_period, start, end} =


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/de723eb3-3130-4484-aaed-75a1998fdb5d



- Replaces the styled `button` + manual `navigate()` pattern on tool call links with `Link` from `@sentry/scraps/link`
- cmd/ctrl+click now works natively (opens in a new tab) since `Link` renders a proper `<a>` with `href`
- Click handler is simplified to only stop propagation and fire the analytics event — all navigation is deferred to the `Link` component

## Test plan

- [x] Click a tool call link — should navigate client-side as before
- [x] cmd+click / ctrl+click a tool call link — should open in a new tab