### PR TITLE
fix(preprod): Detect renames when multiple files share the same content hash

### DIFF
--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import threading
+from difflib import SequenceMatcher
 from typing import NamedTuple
 
 import orjson
@@ -55,6 +56,32 @@ class _ImageDiffResult(NamedTuple):
     skipped: set[str]
 
 
+# When multiple added/removed files share the same content hash (e.g. dark/light
+# theme variants), greedily pair them by filename similarity for rename detection.
+def _match_by_name_similarity(
+    added_names: list[str], removed_names: list[str]
+) -> list[tuple[str, str]]:
+    scored: list[tuple[float, int, int]] = []
+    for ai, a in enumerate(added_names):
+        for ri, r in enumerate(removed_names):
+            scored.append((SequenceMatcher(None, a, r).ratio(), ai, ri))
+
+    scored.sort(reverse=True)
+
+    pairs: list[tuple[str, str]] = []
+    used_added: set[int] = set()
+    used_removed: set[int] = set()
+
+    for _, ai, ri in scored:
+        if ai in used_added or ri in used_removed:
+            continue
+        pairs.append((added_names[ai], removed_names[ri]))
+        used_added.add(ai)
+        used_removed.add(ri)
+
+    return pairs
+
+
 def categorize_image_diff(
     head_manifest: SnapshotManifest, base_manifest: SnapshotManifest
 ) -> _ImageDiffResult:
@@ -93,11 +120,19 @@ def categorize_image_diff(
         r_names = removed_hash_to_names[h]
         if len(a_names) == 1 and len(r_names) == 1:
             renamed_pairs.append((a_names[0], r_names[0]))
+        else:
+            renamed_pairs.extend(_match_by_name_similarity(a_names, r_names))
 
     for new_name, old_name in renamed_pairs:
         added.discard(new_name)
         removed.discard(old_name)
-        added_hash_to_names.pop(head_by_name[new_name], None)
+        h = head_by_name[new_name]
+        if h in added_hash_to_names:
+            names = added_hash_to_names[h]
+            if new_name in names:
+                names.remove(new_name)
+            if not names:
+                del added_hash_to_names[h]
 
     if skipped:
         skipped_hash_to_names: dict[str, list[str]] = {}
@@ -109,9 +144,13 @@ def categorize_image_diff(
             a_names = added_hash_to_names[h]
             s_names = skipped_hash_to_names[h]
             if len(a_names) == 1 and len(s_names) == 1:
-                renamed_pairs.append((a_names[0], s_names[0]))
-                added.discard(a_names[0])
-                skipped.discard(s_names[0])
+                matched_pairs = [(a_names[0], s_names[0])]
+            else:
+                matched_pairs = _match_by_name_similarity(a_names, s_names)
+            for a_name, s_name in matched_pairs:
+                renamed_pairs.append((a_name, s_name))
+                added.discard(a_name)
+                skipped.discard(s_name)
 
     return _ImageDiffResult(
         renamed_pairs, added, removed, matched, head_by_name, base_by_name, skipped

--- a/tests/sentry/preprod/snapshots/test_tasks.py
+++ b/tests/sentry/preprod/snapshots/test_tasks.py
@@ -71,6 +71,50 @@ class TestCategorizeImageDiff:
         assert rename_dict["new_a.png"] == "old_a.png"
         assert rename_dict["new_b.png"] == "old_b.png"
 
+    def test_duplicate_hash_renames_matched_by_name_similarity(self) -> None:
+        head = SnapshotManifest(
+            images={
+                "badge-dark-beta.png": _meta("hash_same"),
+                "badge-light-beta.png": _meta("hash_same"),
+            }
+        )
+        base = SnapshotManifest(
+            images={
+                "old/badge-dark-beta.png": _meta("hash_same"),
+                "old/badge-light-beta.png": _meta("hash_same"),
+            }
+        )
+
+        result = categorize_image_diff(head, base)
+
+        assert len(result.renamed_pairs) == 2
+        rename_dict = dict(result.renamed_pairs)
+        assert rename_dict["badge-dark-beta.png"] == "old/badge-dark-beta.png"
+        assert rename_dict["badge-light-beta.png"] == "old/badge-light-beta.png"
+        assert result.added == set()
+        assert result.removed == set()
+
+    def test_asymmetric_duplicate_hash_partial_rename(self) -> None:
+        head = SnapshotManifest(
+            images={
+                "new-a.png": _meta("hash_dup"),
+                "new-b.png": _meta("hash_dup"),
+                "new-c.png": _meta("hash_dup"),
+            }
+        )
+        base = SnapshotManifest(
+            images={
+                "old-a.png": _meta("hash_dup"),
+                "old-b.png": _meta("hash_dup"),
+            }
+        )
+
+        result = categorize_image_diff(head, base)
+
+        assert len(result.renamed_pairs) == 2
+        assert result.removed == set()
+        assert len(result.added) == 1
+
 
 class TestCategorizeImageDiffSelective:
     def test_selective_all_categories(self) -> None:
@@ -149,6 +193,31 @@ class TestCategorizeImageDiffSelective:
         assert result.skipped == {"in_list.png"}
         assert result.added == set()
         assert result.removed == set()
+
+    def test_selective_duplicate_hash_skipped_rename(self) -> None:
+        head = SnapshotManifest(
+            images={
+                "new-dark.png": _meta("hash_dup"),
+                "new-light.png": _meta("hash_dup"),
+                "new-extra.png": _meta("hash_dup"),
+            },
+            selective=True,
+            all_image_file_names=["new-dark.png", "new-light.png", "new-extra.png", "skip.png"],
+        )
+        base = SnapshotManifest(
+            images={
+                "old-dark.png": _meta("hash_dup"),
+                "old-light.png": _meta("hash_dup"),
+                "skip.png": _meta("hash_dup"),
+            }
+        )
+
+        result = categorize_image_diff(head, base)
+
+        assert len(result.renamed_pairs) == 3
+        assert result.added == set()
+        assert result.removed == set()
+        assert result.skipped == set()
 
     def test_selective_empty_subset(self) -> None:
         head = SnapshotManifest(images={}, selective=True, all_image_file_names=["a.png", "b.png"])


### PR DESCRIPTION
Snapshot rename detection required exactly 1 added and 1 removed file per
content hash to classify a rename. When multiple files had identical pixel
content (e.g. dark/light theme variants of the same badge), the 1:1 check
failed and all files were shown as added + removed instead of renamed.

This was happening sporadically but frequently — any snapshot where
theme variants rendered identically would miss those renames. For example,
`sentry-frontend` snapshots consistently showed "18 added, 18 removed"
when all 18 were actually renames of duplicate-hash images.

**Changes:**
- Added `_match_by_name_similarity()` which uses `SequenceMatcher` to
  greedily pair files with the same content hash by filename similarity
- Fixed `added_hash_to_names.pop()` which removed the entire hash entry
  after the first match, preventing leftover unmatched files from being
  paired in the subsequent skipped-matching phase
- Applied the same multi-match logic to the skipped-files rename path