### PR TITLE
ref(snapshots): Share focused snapshot card frames

### DIFF
--- a/static/app/views/preprod/snapshots/main/diffOverlay.tsx
+++ b/static/app/views/preprod/snapshots/main/diffOverlay.tsx
@@ -1,0 +1,22 @@
+import styled from '@emotion/styled';
+
+export const DiffOverlay = styled('span')<{
+  $maskSize: string;
+  $maskUrl: string;
+  $overlayColor: string;
+}>`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  background-color: ${p => p.$overlayColor};
+  mask-image: url(${p => p.$maskUrl});
+  mask-size: ${p => p.$maskSize};
+  mask-position: top left;
+  mask-mode: luminance;
+  -webkit-mask-image: url(${p => p.$maskUrl});
+  -webkit-mask-size: ${p => p.$maskSize};
+  -webkit-mask-position: top left;
+`;

--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -2,9 +2,9 @@ import {useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Image} from '@sentry/scraps/image';
-import {Flex, Grid} from '@sentry/scraps/layout';
+import {Container, Flex, Grid} from '@sentry/scraps/layout';
 import {Slider} from '@sentry/scraps/slider';
-import {Heading, Text} from '@sentry/scraps/text';
+import {Text} from '@sentry/scraps/text';
 
 import {ContentSliderDiff} from 'sentry/components/contentSliderDiff';
 import {t} from 'sentry/locale';
@@ -53,7 +53,7 @@ export function DiffImageDisplay({
   const maskSize = computeMaskSize(pair.base_image, pair.head_image);
 
   return (
-    <Flex direction="column" gap="lg" padding="xl" flex="1" minHeight="0">
+    <Flex direction="column" gap="lg" padding="0 xl xl" flex="1" minHeight="0">
       <HiddenWhenInactive active={diffMode === 'split'}>
         <SplitView
           baseImageUrl={baseImageUrl}
@@ -111,11 +111,15 @@ function SplitView({
   ]);
   const showOverlay = displayMaskUrl && overlayColor !== TRANSPARENT_COLOR;
   return (
-    <Grid columns="repeat(2, 1fr)" gap="xl" flex="1" minHeight="0">
-      <Flex direction="column" gap="sm" minHeight="0">
-        <Heading as="h4">{t('Base')}</Heading>
-        <ZoomableArea>
-          <ZoomContainer ref={zoom1.containerRef}>
+    <ZoomableArea>
+      <Grid columns="repeat(2, minmax(0, 1fr))" gap="0" height="100%" minHeight="0">
+        <Flex direction="column" minWidth="0" minHeight="0">
+          <Container padding="sm xl">
+            <Text size="xs" variant="muted" ellipsis monospace>
+              {t('Base')}
+            </Text>
+          </Container>
+          <ZoomContainer ref={zoom1.containerRef} style={splitZoomContainerStyle}>
             <Flex
               justify="center"
               align="center"
@@ -133,13 +137,15 @@ function SplitView({
               )}
             </Flex>
           </ZoomContainer>
-        </ZoomableArea>
-      </Flex>
+        </Flex>
 
-      <Flex direction="column" gap="sm" minHeight="0">
-        <Heading as="h4">{headLabel}</Heading>
-        <ZoomableArea>
-          <ZoomContainer ref={zoom2.containerRef}>
+        <Flex direction="column" minWidth="0" minHeight="0" borderLeft="secondary">
+          <Container padding="sm xl">
+            <Text size="xs" variant="muted" ellipsis monospace>
+              {headLabel}
+            </Text>
+          </Container>
+          <ZoomContainer ref={zoom2.containerRef} style={splitZoomContainerStyle}>
             <Flex
               justify="center"
               align="center"
@@ -166,16 +172,22 @@ function SplitView({
               )}
             </Flex>
           </ZoomContainer>
-          <ZoomControls
-            onZoomIn={zoom2.zoomIn}
-            onZoomOut={zoom2.zoomOut}
-            onReset={zoom2.resetZoom}
-          />
-        </ZoomableArea>
-      </Flex>
-    </Grid>
+        </Flex>
+      </Grid>
+      <ZoomControls
+        onZoomIn={zoom2.zoomIn}
+        onZoomOut={zoom2.zoomOut}
+        onReset={zoom2.resetZoom}
+      />
+    </ZoomableArea>
   );
 }
+
+const splitZoomContainerStyle: React.CSSProperties = {
+  flex: '1 1 0',
+  minHeight: 0,
+  overflow: 'hidden',
+};
 
 function WipeView({
   baseImageUrl,

--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -31,6 +31,7 @@ interface DiffImageDisplayProps {
   imageBaseUrl: string;
   overlayColor: string;
   pair: SnapshotDiffPair;
+  headLabel?: string;
 }
 
 export function DiffImageDisplay({
@@ -39,6 +40,7 @@ export function DiffImageDisplay({
   diffImageBaseUrl,
   overlayColor,
   diffMode,
+  headLabel = t('Head'),
 }: DiffImageDisplayProps) {
   const [onionOpacity, setOnionOpacity] = useState(50);
 
@@ -59,11 +61,16 @@ export function DiffImageDisplay({
           overlayColor={overlayColor}
           diffMaskUrl={diffMaskUrl}
           maskSize={maskSize}
+          headLabel={headLabel}
         />
       </HiddenWhenInactive>
 
       <HiddenWhenInactive active={diffMode === 'wipe'}>
-        <WipeView baseImageUrl={baseImageUrl} headImageUrl={headImageUrl} />
+        <WipeView
+          baseImageUrl={baseImageUrl}
+          headImageUrl={headImageUrl}
+          headLabel={headLabel}
+        />
       </HiddenWhenInactive>
 
       <HiddenWhenInactive active={diffMode === 'onion'}>
@@ -72,6 +79,7 @@ export function DiffImageDisplay({
           headImageUrl={headImageUrl}
           opacity={onionOpacity}
           onOpacityChange={setOnionOpacity}
+          headLabel={headLabel}
         />
       </HiddenWhenInactive>
     </Flex>
@@ -82,6 +90,7 @@ interface SplitViewProps {
   baseImageUrl: string;
   diffMaskUrl: string | null;
   headImageUrl: string;
+  headLabel: string;
   maskSize: string;
   overlayColor: string;
 }
@@ -89,6 +98,7 @@ interface SplitViewProps {
 function SplitView({
   baseImageUrl,
   headImageUrl,
+  headLabel,
   overlayColor,
   diffMaskUrl,
   maskSize,
@@ -127,7 +137,7 @@ function SplitView({
       </Flex>
 
       <Flex direction="column" gap="sm" minHeight="0">
-        <Heading as="h4">{t('Current Branch')}</Heading>
+        <Heading as="h4">{headLabel}</Heading>
         <ZoomableArea>
           <ZoomContainer ref={zoom2.containerRef}>
             <Flex
@@ -141,7 +151,7 @@ function SplitView({
                 <ImageWrapper>
                   <ZoomableImage
                     src={displayHeadUrl}
-                    alt={t('Current Branch')}
+                    alt={headLabel}
                     loading="eager"
                     decoding="async"
                   />
@@ -170,9 +180,11 @@ function SplitView({
 function WipeView({
   baseImageUrl,
   headImageUrl,
+  headLabel,
 }: {
   baseImageUrl: string;
   headImageUrl: string;
+  headLabel: string;
 }) {
   const [displayBaseUrl, displayHeadUrl] = useBufferedImageGroup([
     baseImageUrl,
@@ -196,7 +208,7 @@ function WipeView({
             <Flex justify="center" align="center" height="100%">
               <ConstrainedImage
                 src={displayHeadUrl}
-                alt={t('Current Branch')}
+                alt={headLabel}
                 loading="eager"
                 decoding="async"
               />
@@ -212,11 +224,13 @@ function WipeView({
 function OnionView({
   baseImageUrl,
   headImageUrl,
+  headLabel,
   opacity,
   onOpacityChange,
 }: {
   baseImageUrl: string;
   headImageUrl: string;
+  headLabel: string;
   onOpacityChange: (value: number) => void;
   opacity: number;
 }) {
@@ -251,7 +265,7 @@ function OnionView({
             <OnionOverlayLayer style={{opacity: opacity / 100}}>
               <ConstrainedImage
                 src={displayHeadUrl}
-                alt={t('Current Branch')}
+                alt={headLabel}
                 loading="eager"
                 decoding="async"
               />

--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.tsx
@@ -9,6 +9,7 @@ import {Text} from '@sentry/scraps/text';
 import {ContentSliderDiff} from 'sentry/components/contentSliderDiff';
 import {t} from 'sentry/locale';
 import {computeMaskSize} from 'sentry/views/preprod/snapshots/main/computeMaskSize';
+import {DiffOverlay} from 'sentry/views/preprod/snapshots/main/diffOverlay';
 import type {SnapshotDiffPair} from 'sentry/views/preprod/types/snapshotTypes';
 
 import {useBufferedImageGroup} from './useBufferedImageUrl';
@@ -161,7 +162,7 @@ function SplitView({
                     loading="eager"
                     decoding="async"
                   />
-                  {showOverlay && displayMaskUrl && (
+                  {showOverlay && (
                     <DiffOverlay
                       $overlayColor={overlayColor}
                       $maskUrl={displayMaskUrl}
@@ -315,27 +316,6 @@ const ImageWrapper = styled('div')`
   position: relative;
   display: inline-block;
   max-width: 100%;
-`;
-
-const DiffOverlay = styled('span')<{
-  $maskSize: string;
-  $maskUrl: string;
-  $overlayColor: string;
-}>`
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  pointer-events: none;
-  background-color: ${p => p.$overlayColor};
-  mask-image: url(${p => p.$maskUrl});
-  mask-size: ${p => p.$maskSize};
-  mask-position: top left;
-  mask-mode: luminance;
-  -webkit-mask-image: url(${p => p.$maskUrl});
-  -webkit-mask-size: ${p => p.$maskSize};
-  -webkit-mask-position: top left;
 `;
 
 const OnionContainer = styled('div')`

--- a/static/app/views/preprod/snapshots/main/imageDisplay/singleImageDisplay.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/singleImageDisplay.tsx
@@ -20,7 +20,7 @@ export function SingleImageDisplay({imageUrl, alt}: SingleImageDisplayProps) {
   const displayUrl = useBufferedImageUrl(imageUrl);
 
   return (
-    <Flex align="center" justify="center" flex="1" minHeight="0" padding="3xl">
+    <Flex align="center" justify="center" flex="1" minHeight="0" padding="0 xl xl">
       <ZoomableArea>
         <ZoomContainer ref={containerRef}>
           <Flex

--- a/static/app/views/preprod/snapshots/main/snapshotCards.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.snapshots.tsx
@@ -281,11 +281,9 @@ describe('SnapshotCards', () => {
     function snapshotPairCard({
       state,
       pair,
-      cardType,
       diffMode,
       isSelected,
     }: {
-      cardType: 'changed' | 'renamed';
       diffMode: 'split' | 'wipe' | 'onion';
       isSelected: boolean;
       pair: SnapshotDiffPair;
@@ -297,7 +295,6 @@ describe('SnapshotCards', () => {
           <Wrapper>
             <PairCard
               pair={pair}
-              cardType={cardType}
               imageBaseUrl={imageBaseUrl}
               headBranch="Current Branch"
               isSelected={isSelected}
@@ -318,35 +315,24 @@ describe('SnapshotCards', () => {
     snapshotPairCard({
       state: 'changed-split',
       pair: changedPair,
-      cardType: 'changed',
       diffMode: 'split',
       isSelected: false,
     });
     snapshotPairCard({
       state: 'changed-wipe',
       pair: changedPair,
-      cardType: 'changed',
       diffMode: 'wipe',
       isSelected: false,
     });
     snapshotPairCard({
       state: 'changed-onion',
       pair: changedPair,
-      cardType: 'changed',
       diffMode: 'onion',
-      isSelected: false,
-    });
-    snapshotPairCard({
-      state: 'renamed',
-      pair: renamedPair,
-      cardType: 'renamed',
-      diffMode: 'split',
       isSelected: false,
     });
     snapshotPairCard({
       state: 'selected-changed-split',
       pair: changedPair,
-      cardType: 'changed',
       diffMode: 'split',
       isSelected: true,
     });
@@ -387,6 +373,26 @@ describe('SnapshotCards', () => {
         </Wrapper>
       ),
       {theme: themeName, state: 'image-card-removed-unselected'}
+    );
+
+    it.snapshot(
+      'image-card-renamed-with-pair-metadata',
+      () => (
+        <Wrapper>
+          <ImageCard
+            image={renamedPair.head_image}
+            cardType="renamed"
+            copyData={renamedPair}
+            imageBaseUrl={imageBaseUrl}
+            isSelected={false}
+            copyUrl={copyUrl}
+            snapshotKey="button-light-renamed"
+            onSelectSnapshot={noop}
+            onOpenSnapshot={noop}
+          />
+        </Wrapper>
+      ),
+      {theme: themeName, state: 'image-card-renamed-with-pair-metadata'}
     );
 
     it.snapshot(

--- a/static/app/views/preprod/snapshots/main/snapshotCards.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.tsx
@@ -48,7 +48,6 @@ export function DarkAware({
 
 export const PairCard = memo(function PairCard({
   pair,
-  cardType,
   imageBaseUrl,
   headBranch,
   isSelected,
@@ -60,7 +59,6 @@ export const PairCard = memo(function PairCard({
   onSelectSnapshot,
   onOpenSnapshot,
 }: {
-  cardType: 'changed' | 'renamed';
   copyUrl: string;
   diffMode: DiffMode;
   imageBaseUrl: string;
@@ -78,15 +76,13 @@ export const PairCard = memo(function PairCard({
   const baseUrl = `${imageBaseUrl}${pair.base_image.key}/`;
   const headUrl = `${imageBaseUrl}${image.key}/`;
 
-  // Renamed cards always show split — wipe/onion don't make sense for file renames
-  const effectiveMode = cardType === 'renamed' ? ('split' as const) : diffMode;
   const handleSelect = onSelectSnapshot
     ? () => onSelectSnapshot(isSelected ? null : snapshotKey)
     : undefined;
   const handleOpen = onOpenSnapshot ? () => onOpenSnapshot(snapshotKey) : undefined;
 
   let body: React.ReactNode;
-  if (effectiveMode === 'split') {
+  if (diffMode === 'split') {
     body = (
       <SnapshotCanvasWrapper>
         <SplitPairBody
@@ -96,13 +92,13 @@ export const PairCard = memo(function PairCard({
           headImage={image}
           headLabel={headBranch ?? t('Head')}
           altPrefix={getImageName(image)}
-          overlayColor={cardType === 'changed' ? overlayColor : undefined}
-          diffImageKey={cardType === 'changed' ? pair.diff_image_key : null}
+          overlayColor={overlayColor}
+          diffImageKey={pair.diff_image_key}
           diffImageBaseUrl={diffImageBaseUrl}
         />
       </SnapshotCanvasWrapper>
     );
-  } else if (effectiveMode === 'wipe') {
+  } else if (diffMode === 'wipe') {
     body = (
       <WipeCardBody
         baseUrl={baseUrl}
@@ -132,8 +128,8 @@ export const PairCard = memo(function PairCard({
         <CardHeader
           displayName={image.display_name}
           fileName={image.image_file_name}
-          status={cardType === 'changed' ? DiffStatus.CHANGED : DiffStatus.RENAMED}
-          diffPercent={cardType === 'changed' ? pair.diff : null}
+          status={DiffStatus.CHANGED}
+          diffPercent={pair.diff}
           isDark={isDark}
           onToggleDark={() => setIsDark(v => !v)}
           copyData={pair}
@@ -152,6 +148,7 @@ export const PairCard = memo(function PairCard({
 export const ImageCard = memo(function ImageCard({
   image,
   cardType,
+  copyData,
   imageBaseUrl,
   isSelected,
   copyUrl,
@@ -159,12 +156,13 @@ export const ImageCard = memo(function ImageCard({
   onSelectSnapshot,
   onOpenSnapshot,
 }: {
-  cardType: 'added' | 'removed' | 'unchanged' | 'solo';
+  cardType: 'added' | 'removed' | 'renamed' | 'solo' | 'unchanged';
   copyUrl: string;
   image: SnapshotImage;
   imageBaseUrl: string;
   isSelected: boolean;
   snapshotKey: string;
+  copyData?: unknown;
   onOpenSnapshot?: (key: string) => void;
   onSelectSnapshot?: (key: string | null) => void;
 }) {
@@ -177,6 +175,8 @@ export const ImageCard = memo(function ImageCard({
     status = DiffStatus.ADDED;
   } else if (cardType === 'removed') {
     status = DiffStatus.REMOVED;
+  } else if (cardType === 'renamed') {
+    status = DiffStatus.RENAMED;
   } else {
     status = DiffStatus.UNCHANGED;
   }
@@ -199,7 +199,7 @@ export const ImageCard = memo(function ImageCard({
           status={status}
           isDark={isDark}
           onToggleDark={() => setIsDark(v => !v)}
-          copyData={image}
+          copyData={copyData ?? image}
           copyUrl={copyUrl}
           onSelect={handleSelect}
           onDoubleClick={handleOpen}

--- a/static/app/views/preprod/snapshots/main/snapshotCards.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.tsx
@@ -393,19 +393,6 @@ function IconButton({
   );
 }
 
-export const Card = styled(Container)<{isDark: boolean; isSelected: boolean}>`
-  background: ${p => p.theme.tokens.background.primary};
-  color: ${p => p.theme.tokens.content.primary};
-  border: 1px solid
-    ${p =>
-      p.isSelected
-        ? p.theme.tokens.border.accent.vibrant
-        : p.theme.tokens.border.primary};
-  border-radius: ${p => p.theme.radius.md};
-  overflow: hidden;
-  ${p => p.isDark && `color-scheme: dark;`}
-`;
-
 const CardHeaderRow = styled('div')<{
   $showBottomBorder?: boolean;
   isInteractive?: boolean;

--- a/static/app/views/preprod/snapshots/main/snapshotDiffBodies.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotDiffBodies.tsx
@@ -14,6 +14,7 @@ import {getImageName} from 'sentry/views/preprod/types/snapshotTypes';
 import {useSyncedD3Zoom} from './imageDisplay/useD3Zoom';
 import {ZoomControls, zoomTransformStyle} from './imageDisplay/zoomControls';
 import {computeMaskSize} from './computeMaskSize';
+import {DiffOverlay} from './diffOverlay';
 
 export const MAX_IMAGE_HEIGHT = 480;
 
@@ -340,27 +341,6 @@ const HiddenUntilLoaded = styled('img')`
   height: auto;
   max-width: 100%;
   max-height: ${MAX_IMAGE_HEIGHT}px;
-`;
-
-const DiffOverlay = styled('span')<{
-  $maskSize: string;
-  $maskUrl: string;
-  $overlayColor: string;
-}>`
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  pointer-events: none;
-  background-color: ${p => p.$overlayColor};
-  mask-image: url(${p => p.$maskUrl});
-  mask-size: ${p => p.$maskSize};
-  mask-position: top left;
-  mask-mode: luminance;
-  -webkit-mask-image: url(${p => p.$maskUrl});
-  -webkit-mask-size: ${p => p.$maskSize};
-  -webkit-mask-position: top left;
 `;
 
 const ZoomViewport = styled('div')`

--- a/static/app/views/preprod/snapshots/main/snapshotFrames.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotFrames.tsx
@@ -14,18 +14,18 @@ export function SnapshotCardFrame({
   groupName?: string | null;
 }) {
   return (
-    <SnapshotCardContainer
+    <Stack
       gap="0"
       width="100%"
       background="primary"
       border="primary"
       radius="md"
       overflow="hidden"
-      $fillHeight={fillHeight}
+      {...(fillHeight ? {flex: '1', minHeight: '0'} : {})}
     >
       {groupName ? <SnapshotGroupHeader name={groupName} /> : null}
       {children}
-    </SnapshotCardContainer>
+    </Stack>
   );
 }
 
@@ -79,17 +79,6 @@ export function SnapshotCanvasWrapper({children}: {children: React.ReactNode}) {
     </Container>
   );
 }
-
-const SnapshotCardContainer = styled(Stack, {
-  shouldForwardProp: prop => prop !== '$fillHeight',
-})<{$fillHeight: boolean}>`
-  ${p =>
-    p.$fillHeight &&
-    `
-      flex: 1 1 0;
-      min-height: 0;
-    `}
-`;
 
 const SnapshotVariantContainer = styled(Container, {
   shouldForwardProp: prop => prop !== '$fillHeight',

--- a/static/app/views/preprod/snapshots/main/snapshotFrames.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotFrames.tsx
@@ -6,23 +6,26 @@ import {Heading} from '@sentry/scraps/text';
 
 export function SnapshotCardFrame({
   children,
+  fillHeight = false,
   groupName,
 }: {
   children: React.ReactNode;
+  fillHeight?: boolean;
   groupName?: string | null;
 }) {
   return (
-    <Stack
+    <SnapshotCardContainer
       gap="0"
       width="100%"
       background="primary"
       border="primary"
       radius="md"
       overflow="hidden"
+      $fillHeight={fillHeight}
     >
       {groupName ? <SnapshotGroupHeader name={groupName} /> : null}
       {children}
-    </Stack>
+    </SnapshotCardContainer>
   );
 }
 
@@ -38,15 +41,22 @@ export function SnapshotGroupHeader({name}: {name: string}) {
 
 export function SnapshotVariantFrame({
   children,
+  fillHeight = false,
   isSelected,
   ...props
 }: {
   children: React.ReactNode;
+  fillHeight?: boolean;
   isSelected?: boolean;
 } & React.HTMLAttributes<HTMLDivElement>) {
   const theme = useTheme();
   return (
-    <SnapshotVariantContainer position="relative" background="primary" {...props}>
+    <SnapshotVariantContainer
+      position="relative"
+      background="primary"
+      $fillHeight={fillHeight}
+      {...props}
+    >
       {children}
       {isSelected ? (
         <Container
@@ -70,7 +80,29 @@ export function SnapshotCanvasWrapper({children}: {children: React.ReactNode}) {
   );
 }
 
-const SnapshotVariantContainer = styled(Container)`
+const SnapshotCardContainer = styled(Stack, {
+  shouldForwardProp: prop => prop !== '$fillHeight',
+})<{$fillHeight: boolean}>`
+  ${p =>
+    p.$fillHeight &&
+    `
+      flex: 1 1 0;
+      min-height: 0;
+    `}
+`;
+
+const SnapshotVariantContainer = styled(Container, {
+  shouldForwardProp: prop => prop !== '$fillHeight',
+})<{$fillHeight: boolean}>`
+  ${p =>
+    p.$fillHeight &&
+    `
+      display: flex;
+      flex-direction: column;
+      flex: 1 1 0;
+      min-height: 0;
+    `}
+
   &:not(:last-child) {
     border-bottom: 1px solid ${p => p.theme.tokens.border.secondary};
   }

--- a/static/app/views/preprod/snapshots/main/snapshotListView.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.tsx
@@ -44,18 +44,19 @@ export function buildSnapshotLink(snapshotKey: string): string {
 
 type GroupCard =
   | {
-      cardType: 'changed' | 'renamed';
+      cardType: 'changed';
       estimatedHeight: number;
       id: string;
       pair: SnapshotDiffPair;
       type: 'pair-card';
     }
   | {
-      cardType: 'added' | 'removed' | 'unchanged' | 'solo';
+      cardType: 'added' | 'removed' | 'renamed' | 'solo' | 'unchanged';
       estimatedHeight: number;
       id: string;
       image: SnapshotImage;
       type: 'image-card';
+      copyData?: unknown;
     };
 
 interface GroupRow {
@@ -104,7 +105,7 @@ function buildGroups(items: SidebarItem[]): GroupRow[] {
   const groups: GroupRow[] = [];
   for (const item of items) {
     const cards: GroupCard[] = [];
-    if (item.type === 'changed' || item.type === 'renamed') {
+    if (item.type === 'changed') {
       for (const pair of item.pairs) {
         cards.push({
           type: 'pair-card',
@@ -115,6 +116,17 @@ function buildGroups(items: SidebarItem[]): GroupRow[] {
             estimateCardHeight(pair.head_image, true),
             estimateCardHeight(pair.base_image, true)
           ),
+        });
+      }
+    } else if (item.type === 'renamed') {
+      for (const pair of item.pairs) {
+        cards.push({
+          type: 'image-card',
+          id: `c:${item.key}:${pair.head_image.key}`,
+          image: pair.head_image,
+          copyData: pair,
+          cardType: item.type,
+          estimatedHeight: estimateCardHeight(pair.head_image, false),
         });
       }
     } else {
@@ -449,9 +461,8 @@ const GroupContainer = memo(function GroupContainer({
       <PairCard
         key={card.id}
         pair={card.pair}
-        cardType={card.cardType}
         imageBaseUrl={imageBaseUrl}
-        headBranch={card.cardType === 'changed' ? headBranch : undefined}
+        headBranch={headBranch}
         isSelected={isSelected}
         copyUrl={copyUrl}
         diffMode={diffMode}
@@ -466,6 +477,7 @@ const GroupContainer = memo(function GroupContainer({
         key={card.id}
         image={card.image}
         cardType={card.cardType}
+        copyData={card.copyData}
         imageBaseUrl={imageBaseUrl}
         isSelected={isSelected}
         copyUrl={copyUrl}

--- a/static/app/views/preprod/snapshots/main/snapshotListView.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.tsx
@@ -44,7 +44,6 @@ export function buildSnapshotLink(snapshotKey: string): string {
 
 type GroupCard =
   | {
-      cardType: 'changed';
       estimatedHeight: number;
       id: string;
       pair: SnapshotDiffPair;
@@ -111,7 +110,6 @@ function buildGroups(items: SidebarItem[]): GroupRow[] {
           type: 'pair-card',
           id: `c:${item.key}:${pair.head_image.key}`,
           pair,
-          cardType: item.type,
           estimatedHeight: Math.max(
             estimateCardHeight(pair.head_image, true),
             estimateCardHeight(pair.base_image, true)

--- a/static/app/views/preprod/snapshots/main/snapshotListView.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import {useVirtualizer} from '@tanstack/react-virtual';
 
 import {Container, Flex} from '@sentry/scraps/layout';
-import {Heading, Text} from '@sentry/scraps/text';
+import {Text} from '@sentry/scraps/text';
 
 import {t} from 'sentry/locale';
 import type {
@@ -492,16 +492,6 @@ const GroupContainer = memo(function GroupContainer({
     <SnapshotCardFrame groupName={group.isUngrouped ? null : group.name}>
       {cards}
     </SnapshotCardFrame>
-  );
-});
-
-export const GroupHeader = memo(function GroupHeader({name}: {name: string}) {
-  return (
-    <Container padding="0 xs">
-      <Heading as="h3" size="md">
-        {name}
-      </Heading>
-    </Container>
   );
 });
 

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
@@ -1,6 +1,13 @@
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
+import type {
+  SnapshotDiffPair,
+  SnapshotImage,
+} from 'sentry/views/preprod/types/snapshotTypes';
+
 import {SnapshotMainContent} from './snapshotMainContent';
+
+const mockCopy = jest.fn();
 
 const mockZoom = {
   containerRef: {current: null},
@@ -13,6 +20,15 @@ const mockZoom = {
 jest.mock('./imageDisplay/useD3Zoom', () => ({
   useD3Zoom: () => mockZoom,
   useSyncedD3Zoom: () => [mockZoom, mockZoom],
+}));
+
+jest.mock('./imageDisplay/useBufferedImageUrl', () => ({
+  useBufferedImageGroup: (targetUrls: Array<string | null>) => targetUrls,
+  useBufferedImageUrl: (targetUrl: string) => targetUrl,
+}));
+
+jest.mock('sentry/utils/useCopyToClipboard', () => ({
+  useCopyToClipboard: () => ({copy: mockCopy}),
 }));
 
 function renderSnapshotMainContent(
@@ -43,7 +59,60 @@ function renderSnapshotMainContent(
   return render(<SnapshotMainContent {...defaultProps} {...props} />);
 }
 
+function image(overrides: Partial<SnapshotImage> = {}): SnapshotImage {
+  return {
+    content_hash: 'synthetic-content-hash',
+    display_name: 'Button / light',
+    height: 180,
+    image_file_name: 'button.light.png',
+    key: 'head-button-light',
+    width: 320,
+    ...overrides,
+  };
+}
+
+const baseImage = image({
+  content_hash: 'base-content-hash',
+  display_name: 'Button / light base',
+  image_file_name: 'button.light.base.png',
+  key: 'base-button-light',
+});
+
+const headImage = image({
+  content_hash: 'head-content-hash',
+  group: 'components',
+  key: 'head-button-light',
+});
+
+const changedPair: SnapshotDiffPair = {
+  base_image: baseImage,
+  diff: 0.042,
+  diff_image_key: 'diff-button-light',
+  head_image: headImage,
+};
+
+const renamedPair: SnapshotDiffPair = {
+  base_image: image({
+    content_hash: 'base-renamed-content-hash',
+    display_name: 'Button / light old',
+    image_file_name: 'button.light.old.png',
+    key: 'base-button-light-old',
+  }),
+  diff: null,
+  diff_image_key: null,
+  head_image: image({
+    content_hash: 'head-renamed-content-hash',
+    group: 'components',
+    image_file_name: 'button.light.png',
+    key: 'head-button-light',
+  }),
+};
+
 describe('SnapshotMainContent', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('keeps the diff/head toggle visible when viewing the head-only comparison', async () => {
     const onToggleSoloView = jest.fn();
 
@@ -56,5 +125,69 @@ describe('SnapshotMainContent', () => {
     await userEvent.click(screen.getByText('Diff'));
 
     expect(onToggleSoloView).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders focused changed snapshots with diff controls and navigation state', async () => {
+    const onNavigateSingleView = jest.fn();
+
+    renderSnapshotMainContent({
+      canNavigateNext: true,
+      canNavigatePrev: false,
+      comparisonType: 'diff',
+      headBranch: 'feature/snapshot-updates',
+      isSoloView: false,
+      listItems: [
+        {key: 'changed-buttons', name: 'Buttons', pairs: [changedPair], type: 'changed'},
+      ],
+      onNavigateSingleView,
+      selectedItem: {
+        key: 'changed-buttons',
+        name: 'Buttons',
+        pairs: [changedPair],
+        type: 'changed',
+      },
+      viewMode: 'single',
+    });
+
+    expect(screen.getByText('Buttons')).toBeInTheDocument();
+    expect(screen.getByText('Button / light')).toBeInTheDocument();
+    expect(screen.getByText(/Modified/)).toBeInTheDocument();
+    expect(screen.getByText('feature/snapshot-updates')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Pick overlay color'})).toBeInTheDocument();
+    expect(screen.getByRole('radio', {name: 'Split'})).toBeChecked();
+    expect(screen.getByRole('radio', {name: 'Wipe'})).toBeInTheDocument();
+    expect(screen.getByRole('radio', {name: 'Onion'})).toBeInTheDocument();
+
+    expect(screen.getByRole('button', {name: 'Previous snapshot'})).toBeDisabled();
+    const nextButton = screen.getByRole('button', {name: 'Next snapshot'});
+    expect(nextButton).toBeEnabled();
+
+    await userEvent.click(nextButton);
+
+    expect(onNavigateSingleView).toHaveBeenCalledWith('next');
+  });
+
+  it('renders focused renamed snapshots as a single image with pair metadata', async () => {
+    renderSnapshotMainContent({
+      comparisonType: 'diff',
+      isSoloView: false,
+      selectedItem: {
+        key: 'renamed-buttons',
+        name: 'Buttons',
+        pairs: [renamedPair],
+        type: 'renamed',
+      },
+      viewMode: 'single',
+    });
+
+    expect(screen.getByText('Buttons')).toBeInTheDocument();
+    expect(screen.getByText('Renamed')).toBeInTheDocument();
+    expect(screen.getByRole('img', {name: 'Button / light'})).toBeInTheDocument();
+    expect(screen.queryByText('Base')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Copy metadata as JSON'}));
+
+    const copiedJson = mockCopy.mock.calls.at(-1)?.[0];
+    expect(JSON.parse(copiedJson)).toEqual(renamedPair);
   });
 });

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -339,7 +339,9 @@ function SingleViewLayout({
         onToggleDark={onToggleDark}
         showBottomBorder={false}
       />
-      <SingleViewBody>{body}</SingleViewBody>
+      <Flex direction="column" flex="1" minHeight="0">
+        {body}
+      </Flex>
     </SnapshotVariantFrame>
   );
   return (
@@ -589,22 +591,6 @@ const NavGutter = styled('div')`
   flex-direction: column;
   gap: ${p => p.theme.space.sm};
   flex-shrink: 0;
-
-  button[aria-pressed='true'] {
-    &::after {
-      transform: translateY(0px);
-    }
-    > span:last-child {
-      transform: translateY(0px);
-    }
-  }
-`;
-
-const SingleViewBody = styled('div')`
-  display: flex;
-  flex-direction: column;
-  flex: 1 1 0;
-  min-height: 0;
 `;
 
 const ColorPickerWrapper = styled('div')`

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -228,6 +228,7 @@ export function SnapshotMainContent({
             diffImageBaseUrl={diffImageBaseUrl}
             overlayColor={overlayColor}
             diffMode={diffMode}
+            headLabel={headBranch ?? t('Head')}
           />
         }
       />

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -6,7 +6,7 @@ import styled from '@emotion/styled';
 import {Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Flex} from '@sentry/scraps/layout';
 import {SegmentedControl} from '@sentry/scraps/segmentedControl';
 import {Separator} from '@sentry/scraps/separator';
 import {Text} from '@sentry/scraps/text';
@@ -30,13 +30,9 @@ import {
   TRANSPARENT_COLOR,
 } from './imageDisplay/diffImageDisplay';
 import {SingleImageDisplay} from './imageDisplay/singleImageDisplay';
-import {Card, CardHeader, DarkAware} from './snapshotCards';
-import {
-  buildSnapshotLink,
-  GroupHeader,
-  isItemUngrouped,
-  SnapshotListView,
-} from './snapshotListView';
+import {CardHeader, DarkAware} from './snapshotCards';
+import {SnapshotCardFrame, SnapshotVariantFrame} from './snapshotFrames';
+import {buildSnapshotLink, isItemUngrouped, SnapshotListView} from './snapshotListView';
 
 type ViewMode = 'single' | 'list';
 type SortBy = 'diff' | 'alpha';
@@ -335,10 +331,15 @@ function SingleViewLayout({
   rightControls?: React.ReactNode;
 }) {
   const card = (
-    <SingleViewCard isDark={isDark} isSelected={false}>
-      <CardHeader {...headerProps} isDark={isDark} onToggleDark={onToggleDark} />
+    <SnapshotVariantFrame fillHeight>
+      <CardHeader
+        {...headerProps}
+        isDark={isDark}
+        onToggleDark={onToggleDark}
+        showBottomBorder={false}
+      />
       <SingleViewBody>{body}</SingleViewBody>
-    </SingleViewCard>
+    </SnapshotVariantFrame>
   );
   return (
     <Flex
@@ -367,14 +368,9 @@ function SingleViewLayout({
         <Flex direction="row" gap="xl" flex="1" minHeight="0" align="stretch">
           <Flex direction="column" flex="1" minWidth="0">
             <DarkAware isDark={isDark}>
-              {groupName ? (
-                <SingleViewGroup>
-                  <GroupHeader name={groupName} />
-                  {card}
-                </SingleViewGroup>
-              ) : (
-                card
-              )}
+              <SnapshotCardFrame groupName={groupName} fillHeight>
+                {card}
+              </SnapshotCardFrame>
             </DarkAware>
           </Flex>
           <NavGutter onClick={e => e.stopPropagation()}>
@@ -570,16 +566,6 @@ function DiffModeToggle({
   );
 }
 
-const SingleViewGroup = styled(Stack)`
-  flex: 1 1 0;
-  min-height: 0;
-  padding: ${p => p.theme.space.lg};
-  gap: ${p => p.theme.space.md};
-  background: ${p => p.theme.tokens.background.primary};
-  border: 1px solid ${p => p.theme.tokens.border.primary};
-  border-radius: ${p => p.theme.radius.md};
-`;
-
 const SingleViewScroll = styled('div')`
   flex: 1 1 0;
   min-height: 0;
@@ -611,13 +597,6 @@ const NavGutter = styled('div')`
       transform: translateY(0px);
     }
   }
-`;
-
-const SingleViewCard = styled(Card)`
-  display: flex;
-  flex-direction: column;
-  flex: 1 1 0;
-  min-height: 0;
 `;
 
 const SingleViewBody = styled('div')`


### PR DESCRIPTION
Make the focus view look like list view. 

prod
<img width="2022" height="1400" alt="CleanShot 2026-05-01 at 00 23 55@2x" src="https://github.com/user-attachments/assets/2bfecff0-1f0a-4200-afad-2b8e9c3d1967" />


pr
<img width="2040" height="1398" alt="CleanShot 2026-05-01 at 00 24 06@2x" src="https://github.com/user-attachments/assets/3037d178-b040-4891-9fe8-ff0e5361672c" />

---

Share the snapshot card and variant frames between list and focused snapshot views so focused diffs inherit the same grouping and fill-height behavior. This also fixes the focused diff branch label and renders renamed snapshots as a single image with the existing card metadata.

**Focused Snapshot Frames**

The focused view now composes `SnapshotCardFrame` and `SnapshotVariantFrame` instead of maintaining a separate card/group wrapper, keeping the layout behavior aligned with the list view.

**Focused View Coverage**

Adds React tests for changed and renamed focused snapshot states, including diff controls, navigation state, and metadata copying.