### PR TITLE
fix(ACI): Re-land GitHub ticket action validation (#114095) with schema and selective test fix

### DIFF
--- a/src/sentry/integrations/github/handlers/github_handler.py
+++ b/src/sentry/integrations/github/handlers/github_handler.py
@@ -11,3 +11,41 @@ from sentry.workflow_engine.types import ActionHandler
 class GithubActionHandler(TicketingActionHandler):
     group = ActionHandler.Group.TICKET_CREATION
     provider_slug = IntegrationProviderSlug.GITHUB
+
+    data_schema = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "type": "object",
+        "description": "Schema for GitHub ticket creation action data blob",
+        "properties": {
+            "dynamic_form_fields": {
+                "type": "array",
+                "description": "Dynamic form fields from customer configuration",
+                "items": {"type": "object"},
+                "default": [],
+            },
+            "additional_fields": {
+                "type": "object",
+                "description": "Additional fields that aren't part of standard fields",
+                "additionalProperties": True,
+                "properties": {
+                    "repo": {"type": "string"},
+                    "labels": {
+                        "type": ["array", "null"],
+                        "items": {"type": "string"},
+                        "default": [],
+                    },
+                    "assignee": {
+                        "type": ["string", "null"],
+                    },
+                    "integration": {
+                        "type": [
+                            "string",
+                        ],
+                    },
+                },
+                "required": ["repo", "integration"],
+            },
+        },
+        "required": ["additional_fields"],
+        "additionalProperties": False,
+    }

--- a/src/sentry/integrations/github/handlers/github_handler.py
+++ b/src/sentry/integrations/github/handlers/github_handler.py
@@ -37,13 +37,8 @@ class GithubActionHandler(TicketingActionHandler):
                     "assignee": {
                         "type": ["string", "null"],
                     },
-                    "integration": {
-                        "type": [
-                            "string",
-                        ],
-                    },
                 },
-                "required": ["repo", "integration"],
+                "required": ["repo"],
             },
         },
         "required": ["additional_fields"],

--- a/src/sentry/integrations/github_enterprise/handlers/github_enterprise_handler.py
+++ b/src/sentry/integrations/github_enterprise/handlers/github_enterprise_handler.py
@@ -1,13 +1,11 @@
+from sentry.integrations.github.handlers.github_handler import GithubActionHandler
 from sentry.integrations.types import IntegrationProviderSlug
-from sentry.notifications.notification_action.action_handler_registry.base import (
-    TicketingActionHandler,
-)
 from sentry.workflow_engine.models import Action
 from sentry.workflow_engine.registry import action_handler_registry
 from sentry.workflow_engine.types import ActionHandler
 
 
 @action_handler_registry.register(Action.Type.GITHUB_ENTERPRISE)
-class GithubEnterpriseActionHandler(TicketingActionHandler):
+class GithubEnterpriseActionHandler(GithubActionHandler):
     group = ActionHandler.Group.TICKET_CREATION
     provider_slug = IntegrationProviderSlug.GITHUB_ENTERPRISE

--- a/tests/sentry/api/serializers/test_rule.py
+++ b/tests/sentry/api/serializers/test_rule.py
@@ -1,3 +1,10 @@
+# Explicit imports so selective testing can detect when these handlers change.
+# They register via @action_handler_registry.register at import time (startup
+# side-effect), so without these the static scanner has no edge from handler
+# files to this test file.
+import sentry.integrations.github.handlers  # noqa: F401
+import sentry.integrations.github_enterprise.handlers  # noqa: F401
+
 import responses
 from django.db import DEFAULT_DB_ALIAS, connections
 from django.test.utils import CaptureQueriesContext

--- a/tests/sentry/api/serializers/test_rule.py
+++ b/tests/sentry/api/serializers/test_rule.py
@@ -1,13 +1,13 @@
-# Explicit imports so selective testing can detect when these handlers change.
-# They register via @action_handler_registry.register at import time (startup
-# side-effect), so without these the static scanner has no edge from handler
-# files to this test file.
 import responses
 from django.db import DEFAULT_DB_ALIAS, connections
 from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 from rest_framework import serializers
 
+# Explicit imports so selective testing can detect when these handlers change.
+# They register via @action_handler_registry.register at import time (startup
+# side-effect), so without these the static scanner has no edge from handler
+# files to this test file.
 import sentry.integrations.github.handlers  # noqa: F401
 import sentry.integrations.github_enterprise.handlers  # noqa: F401
 from sentry.api.serializers import serialize

--- a/tests/sentry/api/serializers/test_rule.py
+++ b/tests/sentry/api/serializers/test_rule.py
@@ -2,15 +2,14 @@
 # They register via @action_handler_registry.register at import time (startup
 # side-effect), so without these the static scanner has no edge from handler
 # files to this test file.
-import sentry.integrations.github.handlers  # noqa: F401
-import sentry.integrations.github_enterprise.handlers  # noqa: F401
-
 import responses
 from django.db import DEFAULT_DB_ALIAS, connections
 from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 from rest_framework import serializers
 
+import sentry.integrations.github.handlers  # noqa: F401
+import sentry.integrations.github_enterprise.handlers  # noqa: F401
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.rule import RuleSerializer, WorkflowEngineRuleSerializer
 from sentry.integrations.models import OrganizationIntegration

--- a/tests/sentry/workflow_engine/endpoints/validators/actions/test_ticketing.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/actions/test_ticketing.py
@@ -32,6 +32,14 @@ class BaseTicketingActionValidatorTest(TestCase):
         assert result is True
 
 
+class TestGitHubActionValidator(BaseTicketingActionValidatorTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.valid_data["data"] = {
+            "additional_fields": {"repo": "owner/test-repo", "integration": "12345"}
+        }
+
+
 class TestJiraActionValidator(BaseTicketingActionValidatorTest):
     __test__ = True
     provider = Action.Type.JIRA
@@ -47,11 +55,27 @@ class TestAzureDevOpsActionValidator(BaseTicketingActionValidatorTest):
     provider = Action.Type.AZURE_DEVOPS
 
 
-class TestGithubActionValidator(BaseTicketingActionValidatorTest):
+class TestGithubActionValidator(TestGitHubActionValidator):
     __test__ = True
     provider = Action.Type.GITHUB
 
+    def test_validate_missing_repo(self) -> None:
+        data = {**self.valid_data, "data": {}}
+        validator = BaseActionValidator(
+            data=data,
+            context={"organization": self.organization},
+        )
+        assert validator.is_valid() is False
 
-class TestGithubEnterpriseActionValidator(BaseTicketingActionValidatorTest):
+
+class TestGithubEnterpriseActionValidator(TestGitHubActionValidator):
     __test__ = True
     provider = Action.Type.GITHUB_ENTERPRISE
+
+    def test_validate_missing_repo(self) -> None:
+        data = {**self.valid_data, "data": {}}
+        validator = BaseActionValidator(
+            data=data,
+            context={"organization": self.organization},
+        )
+        assert validator.is_valid() is False

--- a/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
+++ b/tests/sentry/workflow_engine/migration_helpers/test_migrate_rule_action.py
@@ -834,6 +834,7 @@ class TestNotificationActionMigrationUtils(TestCase):
                 {
                     "integration": "1",
                     "id": "sentry.integrations.github.notify_action.GitHubCreateTicketAction",
+                    "repo": "owner/repo",
                     "uuid": "test-uuid",
                 },
                 Action.Type.GITHUB,
@@ -843,6 +844,7 @@ class TestNotificationActionMigrationUtils(TestCase):
                 {
                     "integration": "1",
                     "id": "sentry.integrations.github_enterprise.notify_action.GitHubEnterpriseCreateTicketAction",
+                    "repo": "owner/repo",
                     "uuid": "test-uuid",
                 },
                 Action.Type.GITHUB_ENTERPRISE,


### PR DESCRIPTION
## Summary

Re-applies #114095 (reverted in a630f3f due to a CI failure that selective testing had missed) 

**Original change (re-landed):**
- Adds a `data_schema` to `GithubActionHandler` requiring `repo` in `additional_fields`, so the API rejects GitHub ticketing actions created without a repo.
- Makes `GithubEnterpriseActionHandler` inherit from `GithubActionHandler` to pick up the same validation.

**Schema fix:**
- Removes `integration` from `required` in `additional_fields`. The `IssueAlertMigrator` translator moves `integration` into `Action.integration_id` (a dedicated model field), so it never lands in `additional_fields`. Requiring it in the schema caused `action.save()` to raise a `ValidationError` when serializing existing GitHub/GithubEnterprise rules via `WorkflowEngineRuleSerializer`.

---

edit: this doesn't really work so i'm prioritizing getting this PR back in and overriding selective testing for now

**Selective testing fix:**
- Adds explicit `import sentry.integrations.github.handlers` and `import sentry.integrations.github_enterprise.handlers` at the top of `test_rule.py`. Both handlers self-register via `@action_handler_registry.register` at import time (a Django startup side-effect), which means the static import scanner had no edge from the handler files to `test_rule.py`. The explicit imports make the dependency traceable, so future handler changes will select this test.