### PR TITLE
ref(projects): Move action buttons inline with search bar

### DIFF
--- a/static/app/views/projectsDashboard/index.tsx
+++ b/static/app/views/projectsDashboard/index.tsx
@@ -6,7 +6,7 @@ import debounce from 'lodash/debounce';
 import uniqBy from 'lodash/uniqBy';
 
 import {LinkButton} from '@sentry/scraps/button';
-import {Grid, Stack} from '@sentry/scraps/layout';
+import {Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 
 import * as Layout from 'sentry/components/layouts/thirds';
@@ -42,8 +42,6 @@ import {useTeamsById} from 'sentry/utils/useTeamsById';
 import {useUser} from 'sentry/utils/useUser';
 import {useUserTeams} from 'sentry/utils/useUserTeams';
 import {TeamFilter} from 'sentry/views/alerts/list/rules/teamFilter';
-import {TopBar} from 'sentry/views/navigation/topBar';
-import {useHasPageFrameFeature} from 'sentry/views/navigation/useHasPageFrameFeature';
 import {makeProjectsPathname} from 'sentry/views/projects/pathname';
 
 import {ProjectCard} from './projectCard';
@@ -140,7 +138,6 @@ function Dashboard() {
   const navigate = useNavigate();
   const location = useLocation();
   const organization = useOrganization();
-  const hasPageFrameFeature = useHasPageFrameFeature();
 
   useEffect(() => {
     return function cleanup() {
@@ -242,77 +239,6 @@ function Dashboard() {
             />
           </Layout.Title>
         </Layout.HeaderContent>
-        {hasPageFrameFeature ? (
-          <TopBar.Slot name="actions">
-            <LinkButton
-              icon={<IconUser />}
-              tooltipProps={{
-                title: canJoinTeam
-                  ? undefined
-                  : t('You do not have permission to join a team.'),
-              }}
-              disabled={!canJoinTeam}
-              to={`/settings/${organization.slug}/teams/`}
-              data-test-id="join-team"
-            >
-              {t('Join a Team')}
-            </LinkButton>
-            <LinkButton
-              priority="primary"
-              disabled={!canUserCreateProject}
-              tooltipProps={{
-                title: canUserCreateProject
-                  ? undefined
-                  : t('You do not have permission to create projects'),
-              }}
-              to={makeProjectsPathname({
-                path: '/new/',
-                organization,
-              })}
-              icon={<IconAdd />}
-              data-test-id="create-project"
-            >
-              {t('Create Project')}
-            </LinkButton>
-          </TopBar.Slot>
-        ) : (
-          <Layout.HeaderActions>
-            <Grid flow="column" align="center" gap="md">
-              <LinkButton
-                size="sm"
-                icon={<IconUser />}
-                tooltipProps={{
-                  title: canJoinTeam
-                    ? undefined
-                    : t('You do not have permission to join a team.'),
-                }}
-                disabled={!canJoinTeam}
-                to={`/settings/${organization.slug}/teams/`}
-                data-test-id="join-team"
-              >
-                {t('Join a Team')}
-              </LinkButton>
-              <LinkButton
-                size="sm"
-                priority="primary"
-                disabled={!canUserCreateProject}
-                tooltipProps={{
-                  title: canUserCreateProject
-                    ? undefined
-                    : t('You do not have permission to create projects'),
-                }}
-                to={makeProjectsPathname({
-                  path: '/new/',
-                  organization,
-                })}
-                icon={<IconAdd />}
-                data-test-id="create-project"
-              >
-                {t('Create Project')}
-              </LinkButton>
-            </Grid>
-          </Layout.HeaderActions>
-        )}
       </Layout.Header>
       <Layout.Body>
         <Layout.Main width="full">
@@ -330,6 +256,38 @@ function Dashboard() {
               onChange={debouncedSearchQuery}
               query={projectQuery}
             />
+            <LinkButton
+              size="sm"
+              icon={<IconUser />}
+              tooltipProps={{
+                title: canJoinTeam
+                  ? undefined
+                  : t('You do not have permission to join a team.'),
+              }}
+              disabled={!canJoinTeam}
+              to={`/settings/${organization.slug}/teams/`}
+              data-test-id="join-team"
+            >
+              {t('Join a Team')}
+            </LinkButton>
+            <LinkButton
+              size="sm"
+              priority="primary"
+              disabled={!canUserCreateProject}
+              tooltipProps={{
+                title: canUserCreateProject
+                  ? undefined
+                  : t('You do not have permission to create projects'),
+              }}
+              to={makeProjectsPathname({
+                path: '/new/',
+                organization,
+              })}
+              icon={<IconAdd />}
+              data-test-id="create-project"
+            >
+              {t('Create Project')}
+            </LinkButton>
           </SearchAndSelectorWrapper>
 
           <Profiler id="ProjectCardList" onRender={onRenderCallback}>
@@ -359,7 +317,7 @@ const SearchAndSelectorWrapper = styled('div')`
   display: flex;
   gap: ${p => p.theme.space.xl};
   justify-content: flex-end;
-  align-items: flex-end;
+  align-items: center;
   margin-bottom: ${p => p.theme.space.xl};
 
   @media (max-width: ${p => p.theme.breakpoints.sm}) {

--- a/static/app/views/projectsDashboard/index.tsx
+++ b/static/app/views/projectsDashboard/index.tsx
@@ -256,7 +256,7 @@ function Dashboard() {
               onChange={debouncedSearchQuery}
               query={projectQuery}
             />
-            <LinkButton
+            <StyledLinkButton
               size="sm"
               icon={<IconUser />}
               tooltipProps={{
@@ -269,8 +269,8 @@ function Dashboard() {
               data-test-id="join-team"
             >
               {t('Join a Team')}
-            </LinkButton>
-            <LinkButton
+            </StyledLinkButton>
+            <StyledLinkButton
               size="sm"
               priority="primary"
               disabled={!canUserCreateProject}
@@ -287,7 +287,7 @@ function Dashboard() {
               data-test-id="create-project"
             >
               {t('Create Project')}
-            </LinkButton>
+            </StyledLinkButton>
           </SearchAndSelectorWrapper>
 
           <Profiler id="ProjectCardList" onRender={onRenderCallback}>
@@ -332,6 +332,12 @@ const SearchAndSelectorWrapper = styled('div')`
 const StyledSearchBar = styled(SearchBar)`
   flex-grow: 1;
 
+  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+    margin-top: ${p => p.theme.space.md};
+  }
+`;
+
+const StyledLinkButton = styled(LinkButton)`
   @media (max-width: ${p => p.theme.breakpoints.sm}) {
     margin-top: ${p => p.theme.space.md};
   }


### PR DESCRIPTION
Cleanup projects page header
<img width="1076" height="164" alt="CleanShot 2026-04-30 at 15 05 09" src="https://github.com/user-attachments/assets/b3ce7869-c8ad-4f01-a16b-aa46d3c6c00d" />
