### PR TITLE
ref(discover): Make Save As a primary button and reorder action buttons

### DIFF
--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -1348,15 +1348,6 @@ function DiscoverPageFilters({
       </PageFilterBar>
       {hasPageFrameFeature && (
         <Flex gap="md" align="center">
-          <SaveQueryButton
-            eventView={eventView}
-            organization={organization}
-            location={location}
-            savedQuery={savedQuery}
-            yAxis={yAxis}
-            setSavedQuery={setSavedQuery}
-            errorCode={errorCode}
-          />
           {!shouldHideCreateAlert && (
             <Feature organization={organization} features="incidents">
               {({hasFeature}) =>
@@ -1390,6 +1381,15 @@ function DiscoverPageFilters({
             yAxis={yAxis}
             isHomepage={isHomepage}
             setSavedQuery={setSavedQuery}
+          />
+          <SaveQueryButton
+            eventView={eventView}
+            organization={organization}
+            location={location}
+            savedQuery={savedQuery}
+            yAxis={yAxis}
+            setSavedQuery={setSavedQuery}
+            errorCode={errorCode}
           />
         </Flex>
       )}

--- a/static/app/views/discover/savedQuery/index.tsx
+++ b/static/app/views/discover/savedQuery/index.tsx
@@ -96,7 +96,7 @@ export function SaveAsDropdown({
       <Button
         {...triggerProps}
         size="sm"
-        icon={<IconStar />}
+        priority="primary"
         aria-label={t('Save as')}
         disabled={disabled}
       >


### PR DESCRIPTION
Cleanup discover page header
<img width="1074" height="233" alt="CleanShot 2026-04-30 at 15 06 00" src="https://github.com/user-attachments/assets/ba27b365-f40b-448b-a315-d204418f476d" />
