### PR TITLE
feat(ACI): Hide team metric alerts triggered component in workflow engine UI

### DIFF
--- a/static/app/views/organizationStats/teamInsights/health.tsx
+++ b/static/app/views/organizationStats/teamInsights/health.tsx
@@ -100,19 +100,23 @@ export default function TeamStatsHealth() {
               />
             </DescriptionCard>
 
-            <DescriptionCard
-              title={t('Metric Alerts Triggered')}
-              description={t('Alerts triggered from the Alert Rules your team created.')}
-            >
-              <TeamAlertsTriggered
-                organization={organization}
-                projects={projects}
-                teamSlug={currentTeam!.slug}
-                period={period}
-                start={start?.toString()}
-                end={end?.toString()}
-              />
-            </DescriptionCard>
+            {!organization.features.includes('workflow-engine-ui') && (
+              <DescriptionCard
+                title={t('Metric Alerts Triggered')}
+                description={t(
+                  'Alerts triggered from the Alert Rules your team created.'
+                )}
+              >
+                <TeamAlertsTriggered
+                  organization={organization}
+                  projects={projects}
+                  teamSlug={currentTeam!.slug}
+                  period={period}
+                  start={start?.toString()}
+                  end={end?.toString()}
+                />
+              </DescriptionCard>
+            )}
 
             <DescriptionCard
               title={t('Number of Releases')}


### PR DESCRIPTION
This component hasn't been able to load because it relies on incident data that we no longer write - however it's in a rather buried page and we haven't heard anything from customers about it not working. We're going to hide it behind the workflow engine ui flag (which is being GA'd next week) and see if anyone notices / cares. If they do, we can work on updating it with ACI data.

**without (local)**
<img width="1085" height="716" alt="Screenshot 2026-04-30 at 3 03 56 PM" src="https://github.com/user-attachments/assets/b38b7585-bb13-4f45-94f2-814db3fe0ede" />
**with (local, no alerts to be spoken of)**
<img width="705" height="720" alt="Screenshot 2026-04-30 at 3 06 29 PM" src="https://github.com/user-attachments/assets/ad0ca1f9-e531-43f2-b3cc-b1773da8bbf7" />
**with (prod, there are alerts but it spins until it times out)**
<img width="1379" height="273" alt="Screenshot 2026-04-30 at 3 09 59 PM" src="https://github.com/user-attachments/assets/e0eed8cd-7302-49e5-9d8e-c495041cefc2" />
