### PR TITLE
feat(notifications): Instrument killswitch mechanism for notifications

### DIFF
--- a/src/sentry/notifications/platform/service.py
+++ b/src/sentry/notifications/platform/service.py
@@ -5,6 +5,7 @@ from typing import Any, Final
 
 from pydantic import ValidationError
 
+from sentry import options as sentry_options
 from sentry.models.organization import Organization
 from sentry.notifications.models.notificationthread import NotificationThread
 from sentry.notifications.platform.metrics import (
@@ -45,12 +46,18 @@ from sentry.utils.registry import NoRegistrationExistsError
 
 logger = logging.getLogger(__name__)
 
+KILLSWITCH_OPTION_KEY = "notifications.platform.killswitch.sources"
+
 
 class NotificationServiceError(Exception):
     pass
 
 
 class NotificationRenderError(NotificationServiceError):
+    pass
+
+
+class NotificationKillswitchedError(NotificationServiceError):
     pass
 
 
@@ -80,6 +87,18 @@ class NotificationService[T: NotificationData]:
         if not self.data:
             raise NotificationServiceError(
                 "Notification service must be initialized with data before sending!"
+            )
+
+        if self.data.source in sentry_options.get(KILLSWITCH_OPTION_KEY):
+            logger.info(
+                "notifications.platform.killswitch.blocked",
+                extra={"source": self.data.source, "method": "notify_target"},
+            )
+            return SendFailure(
+                status=SendFailureStatus.HALT,
+                exception=NotificationKillswitchedError(
+                    f"Notification source '{self.data.source}' is killswitched"
+                ),
             )
 
         event_lifecycle = NotificationEventLifecycleMetric(
@@ -186,6 +205,14 @@ class NotificationService[T: NotificationData]:
         Send a notification directly to a target via task, if you care about using the result of the notification, use notify_sync instead.
         """
         self._validate_strategy_and_targets(strategy=strategy, targets=targets)
+
+        if self.data.source in sentry_options.get(KILLSWITCH_OPTION_KEY):
+            logger.info(
+                "notifications.platform.killswitch.blocked",
+                extra={"source": self.data.source, "method": "notify_async"},
+            )
+            return
+
         targets = self._get_targets(strategy=strategy, targets=targets)
 
         for target in targets:
@@ -308,6 +335,13 @@ def notify_target_async(
         logger.warning(
             "notifications.platform.notify_target_async.deserialize_error",
             extra={"error": e, "data": data, "nested_target": nested_target},
+        )
+        return
+
+    if notification_data.source in sentry_options.get(KILLSWITCH_OPTION_KEY):
+        logger.info(
+            "notifications.platform.killswitch.blocked",
+            extra={"source": notification_data.source, "method": "notify_target_async"},
         )
         return
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3385,6 +3385,16 @@ register(
     default={},
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+# Killswitch list of NotificationSource values that should be blocked from being
+# dispatched by the notification platform's NotificationService. Values must match
+# the string values of `sentry.notifications.platform.types.NotificationSource`.
+register(
+    "notifications.platform.killswitch.sources",
+    type=Sequence,
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
 # Notification Options - End
 
 # List of organizations with increased rate limits for organization_events API

--- a/tests/sentry/notifications/platform/test_service.py
+++ b/tests/sentry/notifications/platform/test_service.py
@@ -8,15 +8,19 @@ from sentry.integrations.types import EventLifecycleOutcome
 from sentry.notifications.platform.email.provider import EmailNotificationProvider
 from sentry.notifications.platform.provider import SendFailure, SendFailureStatus
 from sentry.notifications.platform.service import (
+    KILLSWITCH_OPTION_KEY,
+    NotificationKillswitchedError,
     NotificationRenderError,
     NotificationService,
     NotificationServiceError,
     deserialize_notification_data,
+    notify_target_async,
     serialize_notification_data,
 )
 from sentry.notifications.platform.target import (
     GenericNotificationTarget,
     IntegrationNotificationTarget,
+    serialize_target,
 )
 from sentry.notifications.platform.templates.data_export import DataExportFailure
 from sentry.notifications.platform.types import (
@@ -26,6 +30,7 @@ from sentry.notifications.platform.types import (
 from sentry.shared_integrations.exceptions import IntegrationConfigurationError, IntegrationError
 from sentry.testutils.asserts import assert_count_of_metric
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.notifications.platform import (
     MockNotification,
     MockNotificationTemplate,
@@ -208,6 +213,67 @@ class NotificationServiceTest(TestCase):
 
         assert "missing occurrence" in str(exc_info.value.__cause__)
         assert_count_of_metric(mock_record, EventLifecycleOutcome.FAILURE, 1)
+
+    @override_options({KILLSWITCH_OPTION_KEY: ["test"]})
+    @mock.patch("sentry.notifications.platform.email.provider.EmailNotificationProvider.send")
+    def test_notify_target_blocked_by_killswitch(self, mock_send: mock.MagicMock) -> None:
+        service = NotificationService(data=MockNotification(message="test"))
+        result = service.notify_target(target=self.target)
+
+        mock_send.assert_not_called()
+        assert isinstance(result, SendFailure)
+        assert result.status == SendFailureStatus.HALT
+        assert isinstance(result.exception, NotificationKillswitchedError)
+
+    @override_options({KILLSWITCH_OPTION_KEY: ["test"]})
+    @mock.patch("sentry.notifications.platform.email.provider.EmailNotificationProvider.send")
+    def test_notify_sync_blocked_by_killswitch(self, mock_send: mock.MagicMock) -> None:
+        service = NotificationService(data=MockNotification(message="test"))
+        errors = service.notify_sync(targets=[self.target])
+
+        mock_send.assert_not_called()
+        assert len(errors[NotificationProviderKey.EMAIL]) == 1
+        failure = errors[NotificationProviderKey.EMAIL][0]
+        assert failure.status == SendFailureStatus.HALT
+        assert isinstance(failure.exception, NotificationKillswitchedError)
+
+    @override_options({KILLSWITCH_OPTION_KEY: ["test"]})
+    @mock.patch("sentry.notifications.platform.service.notify_target_async.delay")
+    def test_notify_async_blocked_by_killswitch_does_not_enqueue(
+        self, mock_delay: mock.MagicMock
+    ) -> None:
+        service = NotificationService(data=MockNotification(message="test"))
+        service.notify_async(targets=[self.target])
+
+        mock_delay.assert_not_called()
+
+    @mock.patch("sentry.notifications.platform.email.provider.EmailNotificationProvider.send")
+    def test_notify_target_async_task_blocked_by_killswitch(
+        self, mock_send: mock.MagicMock
+    ) -> None:
+        """
+        Even when the killswitch is added after the task is enqueued, the task
+        itself must short-circuit before sending.
+        """
+        service = NotificationService(data=MockNotification(message="test"))
+        with override_options({KILLSWITCH_OPTION_KEY: ["test"]}):
+            with self.tasks():
+                # Enqueue the task directly to simulate a task that was
+                # scheduled before the killswitch was activated.
+                notify_target_async.delay(
+                    data=serialize_notification_data(service.data),
+                    nested_target=serialize_target(self.target),
+                )
+
+        mock_send.assert_not_called()
+
+    @override_options({KILLSWITCH_OPTION_KEY: ["data-export-success"]})
+    @mock.patch("sentry.notifications.platform.email.provider.EmailNotificationProvider.send")
+    def test_killswitch_only_blocks_listed_sources(self, mock_send: mock.MagicMock) -> None:
+        service = NotificationService(data=MockNotification(message="test"))
+        service.notify_sync(targets=[self.target])
+
+        mock_send.assert_called_once()
 
 
 class NotificationDataSerializationTest(TestCase):

--- a/tests/sentry/notifications/platform/test_service.py
+++ b/tests/sentry/notifications/platform/test_service.py
@@ -215,8 +215,11 @@ class NotificationServiceTest(TestCase):
         assert_count_of_metric(mock_record, EventLifecycleOutcome.FAILURE, 1)
 
     @override_options({KILLSWITCH_OPTION_KEY: ["test"]})
+    @mock.patch("sentry.notifications.platform.service.logger")
     @mock.patch("sentry.notifications.platform.email.provider.EmailNotificationProvider.send")
-    def test_notify_target_blocked_by_killswitch(self, mock_send: mock.MagicMock) -> None:
+    def test_notify_target_blocked_by_killswitch(
+        self, mock_send: mock.MagicMock, mock_logger: mock.MagicMock
+    ) -> None:
         service = NotificationService(data=MockNotification(message="test"))
         result = service.notify_target(target=self.target)
 
@@ -224,10 +227,17 @@ class NotificationServiceTest(TestCase):
         assert isinstance(result, SendFailure)
         assert result.status == SendFailureStatus.HALT
         assert isinstance(result.exception, NotificationKillswitchedError)
+        mock_logger.info.assert_called_with(
+            "notifications.platform.killswitch.blocked",
+            extra={"source": "test", "method": "notify_target"},
+        )
 
     @override_options({KILLSWITCH_OPTION_KEY: ["test"]})
+    @mock.patch("sentry.notifications.platform.service.logger")
     @mock.patch("sentry.notifications.platform.email.provider.EmailNotificationProvider.send")
-    def test_notify_sync_blocked_by_killswitch(self, mock_send: mock.MagicMock) -> None:
+    def test_notify_sync_blocked_by_killswitch(
+        self, mock_send: mock.MagicMock, mock_logger: mock.MagicMock
+    ) -> None:
         service = NotificationService(data=MockNotification(message="test"))
         errors = service.notify_sync(targets=[self.target])
 
@@ -236,20 +246,30 @@ class NotificationServiceTest(TestCase):
         failure = errors[NotificationProviderKey.EMAIL][0]
         assert failure.status == SendFailureStatus.HALT
         assert isinstance(failure.exception, NotificationKillswitchedError)
+        mock_logger.info.assert_called_with(
+            "notifications.platform.killswitch.blocked",
+            extra={"source": "test", "method": "notify_target"},
+        )
 
     @override_options({KILLSWITCH_OPTION_KEY: ["test"]})
+    @mock.patch("sentry.notifications.platform.service.logger")
     @mock.patch("sentry.notifications.platform.service.notify_target_async.delay")
     def test_notify_async_blocked_by_killswitch_does_not_enqueue(
-        self, mock_delay: mock.MagicMock
+        self, mock_delay: mock.MagicMock, mock_logger: mock.MagicMock
     ) -> None:
         service = NotificationService(data=MockNotification(message="test"))
         service.notify_async(targets=[self.target])
 
         mock_delay.assert_not_called()
+        mock_logger.info.assert_called_with(
+            "notifications.platform.killswitch.blocked",
+            extra={"source": "test", "method": "notify_async"},
+        )
 
+    @mock.patch("sentry.notifications.platform.service.logger")
     @mock.patch("sentry.notifications.platform.email.provider.EmailNotificationProvider.send")
     def test_notify_target_async_task_blocked_by_killswitch(
-        self, mock_send: mock.MagicMock
+        self, mock_send: mock.MagicMock, mock_logger: mock.MagicMock
     ) -> None:
         """
         Even when the killswitch is added after the task is enqueued, the task
@@ -266,6 +286,10 @@ class NotificationServiceTest(TestCase):
                 )
 
         mock_send.assert_not_called()
+        mock_logger.info.assert_called_with(
+            "notifications.platform.killswitch.blocked",
+            extra={"source": "test", "method": "notify_target_async"},
+        )
 
     @override_options({KILLSWITCH_OPTION_KEY: ["data-export-success"]})
     @mock.patch("sentry.notifications.platform.email.provider.EmailNotificationProvider.send")


### PR DESCRIPTION
resolves ISWF-2178

Adds `notifications.platform.killswitch.sources` option key which can be set in options automator with string values corresponding to notification sources we want to block sending. Blocks in `notify_target`, `notify_async`, and `notify_target_async`.