### PR TITLE
chore(issues): Remove performance issues search flag

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -219,8 +219,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:page-frame", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enables setting the fetch all custom measurements request time range to match the user selected time range instead of 90 days
     manager.add("organizations:performance-discover-get-custom-measurements-reduced-range", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Temporary flag to test search performance that's running slow in S4S
-    manager.add("organizations:performance-issues-search", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=True, api_expose=False)
     # Detect performance issues in the new standalone spans pipeline instead of on transactions
     manager.add("organizations:performance-issues-spans", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, default=False, api_expose=False)
     # Re-enable histograms for Metrics Enhanced Performance Views

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -41,8 +41,6 @@ from sentry.search.eap.occurrences.rollout_utils import EAPOccurrencesComparator
 from sentry.search.eap.occurrences.search_executor import EAP_SORT_STRATEGIES, run_eap_group_search
 from sentry.search.events.filter import convert_search_filter_to_snuba_query, format_search_filter
 from sentry.snuba.dataset import Dataset
-from sentry.users.models.user import User
-from sentry.users.services.user.model import RpcUser
 from sentry.utils import json, metrics
 from sentry.utils.cursors import Cursor, CursorResult
 from sentry.utils.snuba import (
@@ -159,9 +157,7 @@ def get_search_filter(
     return found_val
 
 
-def group_categories_from_search_filters(
-    search_filters: Sequence[SearchFilter], organization: Organization, actor: User | RpcUser
-) -> set[int]:
+def group_categories_from_search_filters(search_filters: Sequence[SearchFilter]) -> set[int]:
     group_categories = group_categories_from(search_filters)
 
     if not group_categories:
@@ -460,7 +456,7 @@ class AbstractQueryExecutor(metaclass=ABCMeta):
             ),
         )
 
-        group_categories = group_categories_from_search_filters(search_filters, organization, actor)
+        group_categories = group_categories_from_search_filters(search_filters)
 
         query_params_for_categories = {}
 

--- a/src/sentry/search/snuba/executors.py
+++ b/src/sentry/search/snuba/executors.py
@@ -171,9 +171,6 @@ def group_categories_from_search_filters(
         group_categories.discard(GroupCategory.INSTRUMENTATION.value)
         group_categories.discard(GroupCategory.CONFIGURATION.value)
 
-    if not features.has("organizations:performance-issues-search", organization):
-        group_categories.discard(GroupCategory.PERFORMANCE.value)
-
     return group_categories
 
 

--- a/tests/snuba/search/test_backend.py
+++ b/tests/snuba/search/test_backend.py
@@ -31,7 +31,6 @@ from sentry.seer.autofix.constants import FixabilityScoreThresholds
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.referrer import Referrer
 from sentry.testutils.cases import SnubaTestCase, TestCase
-from sentry.testutils.helpers import Feature
 from sentry.testutils.helpers.datetime import before_now
 from sentry.types.group import GroupSubStatus, PriorityLevel
 from sentry.utils import snuba
@@ -3186,14 +3185,6 @@ class EventsTransactionsSnubaSearchTest(TestCase, SharedSnubaMixin):
             results = self.make_query(search_filter_query="!issue.category:error my_tag:1")
             assert list(results) == [self.perf_group_1, self.perf_group_2]
 
-    def test_performance_issue_search_feature_off(self) -> None:
-        with Feature({"organizations:performance-issues-search": False}):
-            results = self.make_query(search_filter_query="issue.category:performance my_tag:1")
-            assert list(results) == []
-        with self.feature(self.perf_group_1.issue_type.build_visible_feature_name()):
-            results = self.make_query(search_filter_query="issue.category:performance my_tag:1")
-            assert list(results) == [self.perf_group_1, self.perf_group_2]
-
     def test_error_performance_query(self) -> None:
         with self.feature(self.perf_group_1.issue_type.build_visible_feature_name()):
             results = self.make_query(search_filter_query="my_tag:1")
@@ -3533,12 +3524,7 @@ class EventsGenericSnubaSearchTest(TestCase, SharedSnubaMixin, OccurrenceTestMix
                 )
                 assert group_info is not None
 
-            with self.feature(
-                [
-                    *group_type.build_visible_feature_name(),
-                    "organizations:performance-issues-search",
-                ]
-            ):
+            with self.feature(group_type.build_visible_feature_name()):
                 results = self.make_query(search_filter_query="issue.category:performance my_tag:3")
         assert list(results) == [group_info.group]
 
@@ -3823,12 +3809,7 @@ class EventsGenericSnubaSearchTest(TestCase, SharedSnubaMixin, OccurrenceTestMix
             group = Group.objects.get(id=group_info.group.id)
             assert "perfkeyword456" not in group.message
 
-            with self.feature(
-                [
-                    *group_type.build_visible_feature_name(),
-                    "organizations:performance-issues-search",
-                ]
-            ):
+            with self.feature(group_type.build_visible_feature_name()):
                 results = self.make_query(
                     search_filter_query="issue.category:performance perfkeyword456"
                 )


### PR DESCRIPTION
This has been defaulted to true for at least 2 years (see [blame](https://github.com/getsentry/sentry/blame/23766ddbaddffeff072ea3df3c4bdf68e04091fc/src/sentry/features/temporary.py#L223-L223)) so it seems safe to remove. 