### PR TITLE
fix(issues): Load member store on issue details page

### DIFF
--- a/static/app/views/issueDetails/groupDetails.tsx
+++ b/static/app/views/issueDetails/groupDetails.tsx
@@ -9,6 +9,7 @@ import * as qs from 'query-string';
 import {useDrawer} from '@sentry/scraps/drawer';
 import {Container} from '@sentry/scraps/layout';
 
+import {fetchOrgMembers} from 'sentry/actionCreators/members';
 import {FloatingFeedbackButton} from 'sentry/components/feedbackButton/floatingFeedbackButton';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
@@ -569,6 +570,7 @@ function GroupDetailsContent({
   project,
   event,
 }: GroupDetailsContentProps) {
+  const api = useApi();
   const organization = useOrganization();
   const includeFlagDistributions = featureFlagDrawerPlatforms.includes(
     project.platform ?? 'other'
@@ -591,6 +593,10 @@ function GroupDetailsContent({
   });
 
   const {hasAutofixQuota} = useAiConfig(group, project);
+
+  useEffect(() => {
+    fetchOrgMembers(api, organization.slug, [project.id]);
+  }, [api, organization.slug, project.id]);
 
   useEffect(() => {
     if (isAnyDrawerOpen) {

--- a/static/app/views/issueDetails/streamline/sidebar/activitySection.spec.tsx
+++ b/static/app/views/issueDetails/streamline/sidebar/activitySection.spec.tsx
@@ -14,6 +14,7 @@ import {
 import * as indicators from 'sentry/actionCreators/indicator';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {GroupStore} from 'sentry/stores/groupStore';
+import {MemberListStore} from 'sentry/stores/memberListStore';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {GroupActivity} from 'sentry/types/group';
 import {GroupActivityType} from 'sentry/types/group';
@@ -47,6 +48,7 @@ describe('StreamlinedActivitySection', () => {
   beforeEach(() => {
     jest.restoreAllMocks();
     MockApiClient.clearMockResponses();
+    MemberListStore.reset();
     localStorage.clear();
   });
 
@@ -106,6 +108,39 @@ describe('StreamlinedActivitySection', () => {
     await userEvent.type(commentInput, comment);
     await userEvent.keyboard('{Meta>}{Enter}{/Meta}');
     expect(postMock).toHaveBeenCalled();
+  });
+
+  it('uses loaded members for mentions in the drawer comment input', async () => {
+    const mentionedUser = UserFixture({id: '42', name: 'Jane Doe'});
+    MemberListStore.loadInitialData([mentionedUser]);
+    const postMock = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/1337/comments/',
+      method: 'POST',
+      body: {
+        id: 'note-4',
+        user: UserFixture({id: '2'}),
+        type: 'note',
+        data: {text: '@Jane Doe'},
+        dateCreated: '2024-10-31T00:00:00.000000Z',
+      },
+    });
+
+    render(<StreamlinedActivitySection group={group} isDrawer />);
+
+    await userEvent.type(screen.getByRole('textbox', {name: 'Add a comment'}), '@jane');
+    await userEvent.click(await screen.findByRole('option', {name: 'Jane Doe'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Submit comment'}));
+
+    expect(postMock).toHaveBeenCalledWith(
+      '/organizations/org-slug/issues/1337/comments/',
+      expect.objectContaining({
+        method: 'POST',
+        data: {
+          text: '**@Jane Doe** ',
+          mentions: ['user:42'],
+        },
+      })
+    );
   });
 
   it('renders note and allows for delete', async () => {


### PR DESCRIPTION
Issue comments were unable to tag team members `@scott` unless the member store had already been populated by another page.
