### PR TITLE
fix(seer-preferences): Don't delete SeerProjectRepository on repo hide

### DIFF
--- a/src/sentry/deletions/defaults/repository.py
+++ b/src/sentry/deletions/defaults/repository.py
@@ -10,13 +10,11 @@ def _get_repository_child_relations(instance: Repository) -> list[BaseRelation]:
     )
     from sentry.models.commit import Commit
     from sentry.models.pullrequest import PullRequest
-    from sentry.seer.models.project_repository import SeerProjectRepository
 
     return [
         ModelRelation(Commit, {"repository_id": instance.id}),
         ModelRelation(PullRequest, {"repository_id": instance.id}),
         ModelRelation(RepositoryProjectPathConfig, {"repository_id": instance.id}),
-        ModelRelation(SeerProjectRepository, {"repository_id": instance.id}),
     ]
 
 
@@ -28,7 +26,13 @@ class RepositoryDeletionTask(ModelDeletionTask[Repository]):
         return instance.status in {ObjectStatus.PENDING_DELETION, ObjectStatus.DELETION_IN_PROGRESS}
 
     def get_child_relations(self, instance: Repository) -> list[BaseRelation]:
-        return _get_repository_child_relations(instance)
+        from sentry.seer.models.project_repository import SeerProjectRepository
+
+        return _get_repository_child_relations(instance) + [
+            # We only delete SeerProjectRepository when the repo is actually deleted,
+            # but not when it's hidden/disabled (repository_cascade_delete_on_hide).
+            ModelRelation(SeerProjectRepository, {"repository_id": instance.id}),
+        ]
 
     def delete_instance(self, instance: Repository) -> None:
         # TODO: child_relations should also send pending_delete so we

--- a/tests/sentry/tasks/test_repository.py
+++ b/tests/sentry/tasks/test_repository.py
@@ -1,0 +1,77 @@
+from sentry.constants import ObjectStatus
+from sentry.integrations.models.repository_project_path_config import RepositoryProjectPathConfig
+from sentry.models.commit import Commit
+from sentry.models.commitauthor import CommitAuthor
+from sentry.models.pullrequest import PullRequest
+from sentry.models.repository import Repository
+from sentry.seer.models.project_repository import SeerProjectRepository
+from sentry.tasks.repository import repository_cascade_delete_on_hide
+from sentry.testutils.cases import TestCase
+
+
+class RepositoryCascadeDeleteOnHideTest(TestCase):
+    def test_deletes_child_relations(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        self.integration, org_integration = self.create_provider_integration_for(
+            org, self.user, provider="github", name="Example", external_id="abcd"
+        )
+        repo = Repository.objects.create(
+            organization_id=org.id,
+            provider="dummy",
+            name="example/example",
+            status=ObjectStatus.HIDDEN,
+        )
+        commit_author = CommitAuthor.objects.create(
+            organization_id=org.id,
+            name="Sally",
+            email="sally@example.org",
+        )
+        commit = Commit.objects.create(
+            repository_id=repo.id,
+            organization_id=org.id,
+            key="1234abcd",
+            author=commit_author,
+        )
+        pull = PullRequest.objects.create(
+            organization_id=org.id,
+            repository_id=repo.id,
+            key="42",
+            title="fix bugs",
+            message="various fixes",
+            author=commit_author,
+        )
+        path_config = RepositoryProjectPathConfig.objects.create(
+            project=project,
+            repository=repo,
+            stack_root="",
+            source_root="src/packages/store",
+            default_branch="main",
+            organization_integration_id=org_integration.id,
+            integration_id=org_integration.integration_id,
+            organization_id=org_integration.organization_id,
+        )
+
+        repository_cascade_delete_on_hide(repo_id=repo.id)
+
+        assert not Commit.objects.filter(id=commit.id).exists()
+        assert not PullRequest.objects.filter(id=pull.id).exists()
+        assert not RepositoryProjectPathConfig.objects.filter(id=path_config.id).exists()
+
+    def test_preserves_seer_project_repository(self) -> None:
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        repo = Repository.objects.create(
+            organization_id=org.id,
+            provider="dummy",
+            name="example/example",
+            status=ObjectStatus.HIDDEN,
+        )
+        seer_project_repo = SeerProjectRepository.objects.create(
+            project=project,
+            repository=repo,
+        )
+
+        repository_cascade_delete_on_hide(repo_id=repo.id)
+
+        assert SeerProjectRepository.objects.filter(id=seer_project_repo.id).exists()

--- a/tests/sentry/tasks/test_repository.py
+++ b/tests/sentry/tasks/test_repository.py
@@ -13,7 +13,7 @@ class RepositoryCascadeDeleteOnHideTest(TestCase):
     def test_deletes_child_relations(self) -> None:
         org = self.create_organization()
         project = self.create_project(organization=org)
-        self.integration, org_integration = self.create_provider_integration_for(
+        _, org_integration = self.create_provider_integration_for(
             org, self.user, provider="github", name="Example", external_id="abcd"
         )
         repo = Repository.objects.create(
@@ -33,7 +33,7 @@ class RepositoryCascadeDeleteOnHideTest(TestCase):
             key="1234abcd",
             author=commit_author,
         )
-        pull = PullRequest.objects.create(
+        pull_request = PullRequest.objects.create(
             organization_id=org.id,
             repository_id=repo.id,
             key="42",
@@ -41,7 +41,7 @@ class RepositoryCascadeDeleteOnHideTest(TestCase):
             message="various fixes",
             author=commit_author,
         )
-        path_config = RepositoryProjectPathConfig.objects.create(
+        code_mapping = RepositoryProjectPathConfig.objects.create(
             project=project,
             repository=repo,
             stack_root="",
@@ -55,8 +55,8 @@ class RepositoryCascadeDeleteOnHideTest(TestCase):
         repository_cascade_delete_on_hide(repo_id=repo.id)
 
         assert not Commit.objects.filter(id=commit.id).exists()
-        assert not PullRequest.objects.filter(id=pull.id).exists()
-        assert not RepositoryProjectPathConfig.objects.filter(id=path_config.id).exists()
+        assert not PullRequest.objects.filter(id=pull_request.id).exists()
+        assert not RepositoryProjectPathConfig.objects.filter(id=code_mapping.id).exists()
 
     def test_preserves_seer_project_repository(self) -> None:
         org = self.create_organization()


### PR DESCRIPTION
Followup fix for https://github.com/getsentry/sentry/pull/114326

Remove `SeerProjectRepository` from the `_get_repository_child_relations` helper (which is used by `repository_cascade_delete_on_hide`) and add it manually to `RepositoryDeletionTask`. This is because we don't want to delete `SeerProjectRepository` when the associated repo is disabled/hidden.

Add tests for `repository_cascade_delete_on_hide` (`DeleteRepositoryTest.test_simple` already tests that `SeerProjectRepository` is deleted on repo deletion).