### PR TITLE
ref(repos): Refactor ScmRepositoryTable to per-install actions and virtualized list

### DIFF
--- a/static/app/views/settings/organizationRepositories/scmRepositoryTable.spec.tsx
+++ b/static/app/views/settings/organizationRepositories/scmRepositoryTable.spec.tsx
@@ -1,0 +1,398 @@
+import {GitHubIntegrationProviderFixture} from 'sentry-fixture/githubIntegrationProvider';
+import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
+import {RepositoryFixture} from 'sentry-fixture/repository';
+
+import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
+
+import type {Repository} from 'sentry/types/integrations';
+
+import type {ScmInstallation} from './scmRepositoryTable';
+import {ScmRepositoryTable} from './scmRepositoryTable';
+
+// `useVirtualizer` only renders rows whose computed bounding rect overlaps
+// the scroll container. Without a stub it sees a 0×0 viewport and renders
+// nothing — fake a non-zero box on every element so the rows mount.
+function stubBoundingClientRect() {
+  jest
+    .spyOn(window.Element.prototype, 'getBoundingClientRect')
+    .mockImplementation(() => ({
+      x: 0,
+      y: 0,
+      width: 600,
+      height: 400,
+      left: 0,
+      top: 0,
+      right: 600,
+      bottom: 400,
+      toJSON: jest.fn(),
+    }));
+}
+
+function makeRepo(id: string, name: string): Repository {
+  return RepositoryFixture({
+    id,
+    name,
+    externalSlug: name,
+    externalId: id,
+    integrationId: '1',
+  });
+}
+
+function makeInstallation(overrides: Partial<ScmInstallation> = {}): ScmInstallation {
+  return {
+    integration: OrganizationIntegrationsFixture({id: '1'}),
+    repositories: [
+      makeRepo('1', 'org/aardvark'),
+      makeRepo('2', 'org/cobra'),
+      makeRepo('3', 'org/badger'),
+    ],
+    initiallyExpanded: true,
+    ...overrides,
+  };
+}
+
+const provider = GitHubIntegrationProviderFixture();
+
+describe('ScmRepositoryTable', () => {
+  beforeEach(() => {
+    stubBoundingClientRect();
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [
+        {id: '1', slug: 'frontend', platform: 'javascript'},
+        {id: '2', slug: 'backend', platform: 'python'},
+        {id: '3', slug: 'workers', platform: 'node'},
+        {id: '4', slug: 'mobile', platform: 'react-native'},
+      ],
+    });
+  });
+
+  it('renders repos for an installation', () => {
+    render(
+      <ScmRepositoryTable provider={provider} installations={[makeInstallation()]} />
+    );
+
+    const region = screen.getByRole('region', {name: 'GitHub'});
+    const repoList = within(region).getByRole('list', {name: 'Repositories'});
+    expect(within(repoList).getAllByRole('listitem')).toHaveLength(3);
+    expect(within(repoList).getByText('org/aardvark')).toBeInTheDocument();
+    expect(within(repoList).getByText('org/cobra')).toBeInTheDocument();
+    expect(within(repoList).getByText('org/badger')).toBeInTheDocument();
+  });
+
+  describe('installation actions', () => {
+    it('toggles expansion on click for multi-installation tables', async () => {
+      const second: ScmInstallation = {
+        ...makeInstallation({initiallyExpanded: false}),
+        integration: OrganizationIntegrationsFixture({id: '2', name: '@second-org'}),
+        repositories: [makeRepo('10', 'second/repo')],
+      };
+
+      render(
+        <ScmRepositoryTable
+          provider={provider}
+          installations={[makeInstallation(), second]}
+        />
+      );
+
+      const region = screen.getByRole('region', {name: 'GitHub'});
+      expect(screen.queryByText('second/repo')).not.toBeInTheDocument();
+
+      await userEvent.click(
+        within(region).getByRole('button', {name: '@second-org', expanded: false})
+      );
+
+      expect(within(region).getByText('second/repo')).toBeInTheDocument();
+    });
+
+    it('wires up settings and delete callbacks', async () => {
+      const onUninstall = jest.fn();
+      const onSettings = jest.fn();
+      render(
+        <ScmRepositoryTable
+          provider={provider}
+          installations={[makeInstallation()]}
+          onUninstall={onUninstall}
+          onSettings={onSettings}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button', {name: 'Integration settings'}));
+      expect(onSettings).toHaveBeenCalledWith(
+        expect.objectContaining({integration: expect.anything()})
+      );
+
+      await userEvent.click(screen.getByRole('button', {name: 'Uninstall'}));
+      expect(onUninstall).toHaveBeenCalledWith(
+        expect.objectContaining({integration: expect.anything()})
+      );
+    });
+
+    it('shows a manage repositories link when manageUrl is provided', () => {
+      render(
+        <ScmRepositoryTable
+          provider={provider}
+          installations={[
+            makeInstallation({manageUrl: 'https://github.com/apps/sentry-io'}),
+          ]}
+        />
+      );
+
+      expect(screen.getByText('Manage repositories').closest('a')).toHaveAttribute(
+        'href',
+        'https://github.com/apps/sentry-io'
+      );
+    });
+
+    it('auto-expands installations with search hits even when collapsed', () => {
+      const second: ScmInstallation = {
+        ...makeInstallation({initiallyExpanded: false}),
+        integration: OrganizationIntegrationsFixture({id: '2', name: '@second-org'}),
+        repositories: [makeRepo('10', 'second/repo')],
+      };
+
+      render(
+        <ScmRepositoryTable
+          provider={provider}
+          installations={[makeInstallation(), second]}
+          repoMatches={{
+            // Only a repo in the second installation matches.
+            '10': [{key: 'name', value: 'second/repo', indices: [[0, 5]]}],
+          }}
+        />
+      );
+
+      const region = screen.getByRole('region', {name: 'GitHub'});
+      const repoLists = within(region).getAllByRole('list', {name: 'Repositories'});
+      // The second installation's list should contain the matched repo.
+      expect(within(repoLists[1]!).getByText('second')).toBeInTheDocument();
+    });
+
+    it('does not toggle expansion when a button inside the row is clicked', async () => {
+      const second: ScmInstallation = {
+        ...makeInstallation({initiallyExpanded: false}),
+        integration: OrganizationIntegrationsFixture({id: '2', name: '@second-org'}),
+        repositories: [makeRepo('10', 'second/repo')],
+      };
+
+      render(
+        <ScmRepositoryTable
+          provider={provider}
+          installations={[makeInstallation(), second]}
+          onUninstall={jest.fn()}
+        />
+      );
+
+      expect(screen.queryByText('second/repo')).not.toBeInTheDocument();
+
+      // Clicking the Uninstall button inside the row should not expand it.
+      await userEvent.click(screen.getAllByRole('button', {name: 'Uninstall'})[1]!);
+
+      expect(screen.queryByText('second/repo')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('empty states', () => {
+    it('shows an empty-state message when there are no repos', () => {
+      render(
+        <ScmRepositoryTable
+          provider={provider}
+          installations={[
+            makeInstallation({repositories: [], manageUrl: 'https://github.com/'}),
+          ]}
+        />
+      );
+
+      expect(screen.getByText('No repositories available.')).toBeInTheDocument();
+    });
+
+    it('shows a loading message in the body and a loading indicator on the tag when reposLoading', () => {
+      render(
+        <ScmRepositoryTable
+          provider={provider}
+          installations={[makeInstallation({repositories: [], reposLoading: true})]}
+        />
+      );
+
+      // Tag always shows the count (0 while loading), with a StatusIndicator alongside it.
+      expect(screen.getByText('0 repos')).toBeInTheDocument();
+      // Body shows loading text when no repos have arrived yet.
+      const repoList = screen.getByRole('list', {name: 'Repositories'});
+      expect(within(repoList).getByText('Loading repositories')).toBeInTheDocument();
+    });
+
+    it('hides repos that do not match repoMatches', () => {
+      render(
+        <ScmRepositoryTable
+          provider={provider}
+          installations={[makeInstallation()]}
+          repoMatches={{
+            // Only 'cobra' matches.
+            '2': [{key: 'name', value: 'org/cobra', indices: [[4, 8]]}],
+          }}
+        />
+      );
+
+      const repoList = screen.getByRole('list', {name: 'Repositories'});
+      expect(within(repoList).getByText('cobra')).toBeInTheDocument();
+      expect(within(repoList).getAllByRole('listitem')).toHaveLength(1);
+    });
+
+    it('shows a no-matches message when search filters out all repos', () => {
+      render(
+        <ScmRepositoryTable
+          provider={provider}
+          installations={[makeInstallation()]}
+          repoMatches={{}}
+        />
+      );
+
+      const repoList = screen.getByRole('list', {name: 'Repositories'});
+      expect(
+        within(repoList).getByText('No repositories match your search')
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('footer', () => {
+    it('shows last-synced time when lastSyncedAt is provided', () => {
+      render(
+        <ScmRepositoryTable
+          provider={provider}
+          installations={[makeInstallation()]}
+          lastSyncedAt={new Date(Date.now() - 5 * 60 * 1000)}
+        />
+      );
+
+      expect(screen.getByText(/Last synced/)).toBeInTheDocument();
+    });
+
+    it('shows a sync button when onSync is provided', async () => {
+      const onSync = jest.fn();
+      render(
+        <ScmRepositoryTable
+          provider={provider}
+          installations={[makeInstallation()]}
+          onSync={onSync}
+        />
+      );
+
+      await userEvent.click(screen.getByRole('button', {name: 'Sync'}));
+      expect(onSync).toHaveBeenCalledTimes(1);
+    });
+
+    it('hides the footer when neither lastSyncedAt nor onSync is provided', () => {
+      render(
+        <ScmRepositoryTable provider={provider} installations={[makeInstallation()]} />
+      );
+
+      expect(screen.queryByText(/Last synced/)).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', {name: 'Sync'})).not.toBeInTheDocument();
+    });
+  });
+
+  describe('project mappings', () => {
+    it('sorts mapped repos before unmapped, alphabetically within each group', async () => {
+      render(
+        <ScmRepositoryTable
+          provider={provider}
+          installations={[
+            makeInstallation({
+              mappedProjectSlugsByRepoId: {
+                // `cobra` (id=2) is mapped — should appear first even though
+                // alphabetically it comes after aardvark/badger.
+                '2': ['frontend'],
+              },
+            }),
+          ]}
+        />
+      );
+
+      // Wait for async ProjectList resolution before reading order.
+      await screen.findByTestId('platform-icon-javascript');
+      const repoList = screen.getByRole('list', {name: 'Repositories'});
+      const rows = within(repoList)
+        .getAllByRole('listitem')
+        .map(el => el.textContent?.trim());
+      expect(rows[0]).toContain('org/cobra');
+      expect(rows[1]).toContain('org/aardvark');
+      expect(rows[2]).toContain('org/badger');
+    });
+
+    it('shows a placeholder for repos without slugs while mappings load', () => {
+      render(
+        <ScmRepositoryTable
+          provider={provider}
+          installations={[
+            makeInstallation({
+              mappedProjectSlugsByRepoId: {'1': ['frontend']},
+              mappingsLoading: true,
+            }),
+          ]}
+        />
+      );
+
+      // Two of three rows have no slugs yet → two placeholders.
+      expect(screen.getAllByTestId('loading-placeholder')).toHaveLength(2);
+    });
+
+    it('omits the placeholder once mappings finish loading', () => {
+      render(
+        <ScmRepositoryTable
+          provider={provider}
+          installations={[
+            makeInstallation({
+              mappedProjectSlugsByRepoId: {'1': ['frontend']},
+              mappingsLoading: false,
+            }),
+          ]}
+        />
+      );
+
+      expect(screen.queryByTestId('loading-placeholder')).not.toBeInTheDocument();
+    });
+
+    it('renders repoActions for every row when mapping data is provided', () => {
+      render(
+        <ScmRepositoryTable
+          provider={provider}
+          installations={[makeInstallation({mappedProjectSlugsByRepoId: {}})]}
+          repoActions={() => <button aria-label="Project mappings" />}
+        />
+      );
+
+      expect(screen.getAllByRole('button', {name: 'Project mappings'})).toHaveLength(3);
+    });
+
+    it('does not render repoActions when mapping data is not provided', () => {
+      render(
+        <ScmRepositoryTable
+          provider={provider}
+          installations={[makeInstallation()]}
+          repoActions={() => <button aria-label="Project mappings" />}
+        />
+      );
+
+      expect(
+        screen.queryByRole('button', {name: 'Project mappings'})
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders project platform icons for mapped repos', async () => {
+      render(
+        <ScmRepositoryTable
+          provider={provider}
+          installations={[
+            makeInstallation({
+              mappedProjectSlugsByRepoId: {'1': ['frontend', 'backend']},
+            }),
+          ]}
+        />
+      );
+
+      // `frontend` → javascript platform; `backend` → python platform.
+      expect(await screen.findByTestId('platform-icon-javascript')).toBeInTheDocument();
+      expect(await screen.findByTestId('platform-icon-python')).toBeInTheDocument();
+    });
+  });
+});

--- a/static/app/views/settings/organizationRepositories/scmRepositoryTable.stories.tsx
+++ b/static/app/views/settings/organizationRepositories/scmRepositoryTable.stories.tsx
@@ -5,11 +5,12 @@ import {Flex} from '@sentry/scraps/layout';
 
 import * as Storybook from 'sentry/stories';
 import type {
-  Integration,
   IntegrationProvider,
+  OrganizationIntegration,
   Repository,
 } from 'sentry/types/integrations';
 import {RepositoryStatus} from 'sentry/types/integrations';
+import {useProjects} from 'sentry/utils/useProjects';
 
 import type {ScmInstallation} from './scmRepositoryTable';
 import {ScmRepositoryTable} from './scmRepositoryTable';
@@ -34,7 +35,7 @@ const GITHUB_PROVIDER: IntegrationProvider = {
   },
 };
 
-function makeIntegration(id: string, name: string): Integration {
+function makeIntegration(id: string, name: string): OrganizationIntegration {
   return {
     id,
     name,
@@ -44,6 +45,10 @@ function makeIntegration(id: string, name: string): Integration {
     icon: null,
     organizationIntegrationStatus: 'active',
     status: 'active',
+    configData: null,
+    configOrganization: [],
+    externalId: id,
+    organizationId: '',
     provider: {
       key: 'github',
       slug: 'github',
@@ -79,19 +84,47 @@ const REPO_NAMES = [
   'org-name/repo-name-empanada',
 ];
 
-const INSTALLATIONS: ScmInstallation[] = [
-  {
-    integration: makeIntegration('1', '@org-name-123'),
-    repositories: REPO_NAMES.map((name, i) => makeRepo(`a-${i}`, name)),
-    manageUrl: 'https://github.com/',
-  },
-  {
-    integration: makeIntegration('2', '@org-name-456'),
-    repositories: REPO_NAMES.map((name, i) => makeRepo(`b-${i}`, name)),
-    manageUrl: 'https://github.com/',
-    initiallyExpanded: true,
-  },
-];
+/**
+ * Deterministically pick a subset of project slugs for a given repo index, so
+ * the story shows a realistic mix of "no mapping", "single project", and
+ * "many projects (with +N collapse)" rows without reshuffling on every render.
+ */
+function pickSlugsForRepo(allSlugs: string[], repoIndex: number): string[] {
+  if (allSlugs.length === 0) return [];
+  const counts = [0, 1, 1, 3, 0, 5];
+  const count = Math.min(counts[repoIndex % counts.length]!, allSlugs.length);
+  const start = (repoIndex * 3) % allSlugs.length;
+  return Array.from({length: count}, (_, i) => allSlugs[(start + i) % allSlugs.length]!);
+}
+
+function useStoryInstallations(): ScmInstallation[] {
+  const {projects} = useProjects();
+  return useMemo(() => {
+    const slugs = projects.map(p => p.slug);
+    const buildMap = (prefix: string) =>
+      Object.fromEntries(
+        REPO_NAMES.map((_, i) => [
+          `${prefix}-${i}`,
+          pickSlugsForRepo(slugs, i + 1),
+        ]).filter(([, list]) => (list as string[]).length > 0)
+      );
+    return [
+      {
+        integration: makeIntegration('1', '@org-name-123'),
+        repositories: REPO_NAMES.map((name, i) => makeRepo(`a-${i}`, name)),
+        mappedProjectSlugsByRepoId: buildMap('a'),
+        manageUrl: 'https://github.com/',
+      },
+      {
+        integration: makeIntegration('2', '@org-name-456'),
+        repositories: REPO_NAMES.map((name, i) => makeRepo(`b-${i}`, name)),
+        mappedProjectSlugsByRepoId: buildMap('b'),
+        manageUrl: 'https://github.com/',
+        initiallyExpanded: true,
+      },
+    ];
+  }, [projects]);
+}
 
 const EMPTY_INSTALLATION: ScmInstallation[] = [
   {
@@ -103,29 +136,24 @@ const EMPTY_INSTALLATION: ScmInstallation[] = [
 ];
 
 export default Storybook.story('ScmRepositoryTable', story => {
-  story('Default', () => (
-    <ScmRepositoryTable
-      provider={GITHUB_PROVIDER}
-      installations={INSTALLATIONS}
-      onDelete={() => {}}
-      settingsTo="#"
-      overflowMenuItems={[
-        {key: 'disable', label: 'Disable integration', onAction: () => {}},
-      ]}
-      lastSyncedAt={new Date(Date.now() - 5 * 60 * 1000)}
-      onSync={() => {}}
-    />
-  ));
+  story('Default', () => {
+    const installations = useStoryInstallations();
+    return (
+      <ScmRepositoryTable
+        provider={GITHUB_PROVIDER}
+        installations={installations}
+        lastSyncedAt={new Date(Date.now() - 5 * 60 * 1000)}
+        onSync={() => {}}
+        onUninstall={() => {}}
+        onSettings={() => {}}
+      />
+    );
+  });
 
   story('Empty installation', () => (
     <ScmRepositoryTable
       provider={GITHUB_PROVIDER}
       installations={EMPTY_INSTALLATION}
-      onDelete={() => {}}
-      settingsTo="#"
-      overflowMenuItems={[
-        {key: 'disable', label: 'Disable integration', onAction: () => {}},
-      ]}
       lastSyncedAt={new Date(Date.now() - 5 * 60 * 1000)}
       onSync={() => {}}
     />
@@ -133,7 +161,11 @@ export default Storybook.story('ScmRepositoryTable', story => {
 
   story('With search', () => {
     const [query, setQuery] = useState('');
-    const allRepos = useMemo(() => INSTALLATIONS.flatMap(i => i.repositories), []);
+    const installations = useStoryInstallations();
+    const allRepos = useMemo(
+      () => installations.flatMap(i => i.repositories),
+      [installations]
+    );
     const repoMatches = useRepoSearch(allRepos, query);
 
     return (
@@ -146,10 +178,8 @@ export default Storybook.story('ScmRepositoryTable', story => {
         />
         <ScmRepositoryTable
           provider={GITHUB_PROVIDER}
-          installations={INSTALLATIONS.map(i => ({...i, initiallyExpanded: true}))}
+          installations={installations.map(i => ({...i, initiallyExpanded: true}))}
           repoMatches={repoMatches}
-          onDelete={() => {}}
-          settingsTo="#"
         />
       </Flex>
     );
@@ -158,12 +188,14 @@ export default Storybook.story('ScmRepositoryTable', story => {
   story('Loading and disabled', () => (
     <ScmRepositoryTable
       provider={GITHUB_PROVIDER}
+      onUninstall={() => {}}
+      onSettings={() => {}}
       installations={[
         {
           integration: makeIntegration('1', '@org-name-123'),
           repositories: REPO_NAMES.map((name, i) => makeRepo(`a-${i}`, name)),
           manageUrl: 'https://github.com/',
-          isLoading: true,
+          reposLoading: true,
           initiallyExpanded: true,
         },
         {
@@ -176,8 +208,23 @@ export default Storybook.story('ScmRepositoryTable', story => {
           expandDisabled: true,
         },
       ]}
-      onDelete={() => {}}
-      settingsTo="#"
     />
   ));
+
+  story('Mappings loading', () => {
+    const installations = useStoryInstallations();
+    return (
+      <ScmRepositoryTable
+        provider={GITHUB_PROVIDER}
+        installations={installations.map(i => ({
+          ...i,
+          // Drop the seeded mappings so every row appears unmapped, then
+          // mark the mappings query as in-flight to render the placeholder
+          // skeletons in the right slot.
+          mappedProjectSlugsByRepoId: {},
+          mappingsLoading: true,
+        }))}
+      />
+    );
+  });
 });

--- a/static/app/views/settings/organizationRepositories/scmRepositoryTable.tsx
+++ b/static/app/views/settings/organizationRepositories/scmRepositoryTable.tsx
@@ -1,41 +1,40 @@
-import {Fragment, useEffect, useRef, useState} from 'react';
-import {useTheme} from '@emotion/react';
+import {Fragment, type ReactNode, useCallback, useMemo, useRef, useState} from 'react';
 import styled from '@emotion/styled';
+import {useVirtualizer} from '@tanstack/react-virtual';
 
 import {Tag} from '@sentry/scraps/badge';
 import {Button, LinkButton} from '@sentry/scraps/button';
-import {Flex, Grid} from '@sentry/scraps/layout';
+import {Container, Flex, Grid} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {StatusIndicator} from '@sentry/scraps/statusIndicator';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {CircleIndicator} from 'sentry/components/circleIndicator';
 import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
 import {Panel} from 'sentry/components/panels/panel';
-import {PanelHeader} from 'sentry/components/panels/panelHeader';
-import {getRepoStatusLabel} from 'sentry/components/repositories/getRepoStatusLabel';
+import {Placeholder} from 'sentry/components/placeholder';
+import {ProjectList} from 'sentry/components/projectList';
 import {TimeSince} from 'sentry/components/timeSince';
 import {
   IconChevron,
   IconDelete,
   IconEllipsis,
   IconOpen,
-  IconSettings,
+  IconSliders,
   IconSync,
 } from 'sentry/icons';
 import {t, tct, tn} from 'sentry/locale';
 import type {
-  Integration,
   IntegrationProvider,
+  OrganizationIntegration,
   Repository,
 } from 'sentry/types/integrations';
-import {RepositoryStatus} from 'sentry/types/integrations';
 import type {Fuse} from 'sentry/utils/fuzzySearch';
 import {highlightFuseMatches} from 'sentry/utils/highlightFuseMatches';
 import {getIntegrationIcon} from 'sentry/utils/integrationUtil';
-import {unreachable} from 'sentry/utils/unreachable';
-import {IntegrationIcon} from 'sentry/views/settings/organizationIntegrations/integrationIcon';
+
+const REPO_LIST_MAX_HEIGHT = 400;
+const ESTIMATED_REPO_ROW_HEIGHT = 36;
 
 /**
  * Fuse match results keyed by `repository.id`, used to highlight the matched
@@ -44,113 +43,209 @@ import {IntegrationIcon} from 'sentry/views/settings/organizationIntegrations/in
 export type ScmRepoMatches = Record<string, readonly Fuse.FuseResultMatch[]>;
 
 export interface ScmInstallation {
-  integration: Integration;
+  /**
+   * The installed integration this row represents.
+   */
+  integration: OrganizationIntegration;
+  /**
+   * Repositories under this installation. Empty arrays render an empty-state
+   * message in place of the row list.
+   */
   repositories: Repository[];
+  /**
+   * When true, the installation header is rendered as a non-toggleable row
+   * (can't be expanded). Use for disabled/inactive integrations whose
+   * repos shouldn't be exposed.
+   */
   expandDisabled?: boolean;
+  /**
+   * Whether the installation should start expanded. Single-installation
+   * tables auto-expand regardless of this flag.
+   */
   initiallyExpanded?: boolean;
-  isLoading?: boolean;
+  /**
+   * Optional URL to the upstream provider's installation-management page
+   * (e.g. GitHub's app settings). Surfaced as a "Manage repositories" link in
+   * the empty state and the no-search-results state.
+   */
   manageUrl?: string;
+  /**
+   * Project slugs keyed by `repository.id` for repos that have code mappings.
+   * Each repo with one or more slugs renders a stack of project avatars on the
+   * right of its row, with a hover tooltip identifying each project. When the
+   * key is undefined, the right-side button + project list slot is hidden
+   * entirely (use this when mapping data isn't available at all, vs. an empty
+   * record which means "loaded, this repo has no mappings").
+   */
+  mappedProjectSlugsByRepoId?: Record<string, string[]>;
+  /**
+   * Whether code mappings are still being fetched. When true, rows that don't
+   * yet have any mapped slugs render a `<Placeholder>` skeleton in place of
+   * the project list, so users see an inline loading hint without blocking
+   * the rest of the row.
+   */
+  mappingsLoading?: boolean;
+  /**
+   * Items rendered into the per-installation overflow (`...`) menu. When
+   * omitted or empty, the menu trigger is hidden.
+   */
+  overflowMenuItems?: MenuItemProps[];
+  /**
+   * Whether the parent is still fetching the repository list. Drives the
+   * "Loading repositories" empty state and hides the repo-count tag while
+   * `repositories` is still empty.
+   */
+  reposLoading?: boolean;
 }
 
 interface ScmRepositoryTableProps {
+  /**
+   * Installations to render, one expand/collapse section per entry.
+   */
   installations: ScmInstallation[];
+  /**
+   * The SCM provider these installations belong to. Drives the header icon and name.
+   */
   provider: IntegrationProvider;
+  /**
+   * When provided, renders a "Last synced N ago" label in the footer.
+   */
   lastSyncedAt?: Date;
-  onDelete?: (integration: Integration) => void;
+  /**
+   * Called when the user clicks the settings button for an installation.
+   * When omitted the button is hidden.
+   */
+  onSettings?: (installation: ScmInstallation) => void;
+  /**
+   * When provided, renders a Sync button in the footer.
+   */
   onSync?: () => void;
-  overflowMenuItems?: MenuItemProps[];
+  /**
+   * Called when the user clicks the uninstall button for an installation.
+   * When omitted the button is hidden.
+   */
+  onUninstall?: (installation: ScmInstallation) => void;
+  /**
+   * Renders an action element in the right slot of each repository row.
+   * Only called when `mappedProjectSlugsByRepoId` is set on the installation.
+   */
+  repoActions?: (repo: Repository, installation: ScmInstallation) => ReactNode;
+  /**
+   * Fuse match results used to filter and highlight repo names.
+   */
   repoMatches?: ScmRepoMatches;
-  settingsTo?: string;
+}
+
+/**
+ * Tracks which installations are expanded via an explicit user-toggle override
+ * map. The effective expansion state is `overrides.get(id) ?? initiallyExpanded`.
+ * Late-arriving installations get their default applied automatically.
+ */
+function useExpandedInstallations(installations: ScmInstallation[]) {
+  const [overrides, setOverrides] = useState<Map<string, boolean>>(() => new Map());
+
+  const defaultExpandedById = useMemo(
+    () =>
+      new Map(installations.map(i => [i.integration.id, i.initiallyExpanded ?? false])),
+    [installations]
+  );
+
+  const expandedIds = useMemo(() => {
+    const expanded = installations
+      .map(install => install.integration.id)
+      .filter(id => overrides.get(id) ?? defaultExpandedById.get(id) ?? false);
+    return new Set(expanded);
+  }, [installations, overrides, defaultExpandedById]);
+
+  const toggle = useCallback(
+    (id: string) =>
+      setOverrides(prev => {
+        const next = new Map(prev);
+        next.set(id, !(prev.get(id) ?? defaultExpandedById.get(id) ?? false));
+        return next;
+      }),
+    [defaultExpandedById]
+  );
+
+  return {expandedIds, toggle};
 }
 
 export function ScmRepositoryTable({
   provider,
   installations,
-  onDelete,
-  settingsTo,
-  overflowMenuItems,
   lastSyncedAt,
+  onSettings,
   onSync,
+  onUninstall,
+  repoActions,
   repoMatches,
 }: ScmRepositoryTableProps) {
   const showFooter = lastSyncedAt !== undefined || onSync !== undefined;
+  const soleInstallation = installations.length === 1 ? installations[0]! : null;
 
-  const [expandedIds, setExpandedIds] = useState<Set<string>>(() => new Set());
-
-  // `initiallyExpanded` should apply the first time we see a given integration,
-  // not on every render. Tracking which ids we've already considered lets late-
-  // arriving installations honor the flag without resetting user toggles on a
-  // refetch.
-  const seenIds = useRef<Set<string>>(new Set());
-  useEffect(() => {
-    setExpandedIds(prev => {
-      let changed = false;
-      const next = new Set(prev);
-      for (const i of installations) {
-        if (seenIds.current.has(i.integration.id)) {
-          continue;
-        }
-        seenIds.current.add(i.integration.id);
-        if (i.initiallyExpanded) {
-          next.add(i.integration.id);
-          changed = true;
-        }
-      }
-      return changed ? next : prev;
-    });
-  }, [installations]);
-
-  const toggle = (id: string) =>
-    setExpandedIds(prev => {
-      const next = new Set(prev);
-      if (next.has(id)) {
-        next.delete(id);
-      } else {
-        next.add(id);
-      }
-      return next;
-    });
+  const {expandedIds, toggle} = useExpandedInstallations(installations);
 
   return (
-    <Panel>
-      <PanelHeader hasButtons>
+    <Panel role="region" aria-label={provider.name}>
+      <Flex
+        justify="between"
+        background="secondary"
+        padding="xs lg"
+        radius="sm sm 0 0"
+        borderBottom="secondary"
+        minHeight="36px"
+      >
         <Flex align="center" gap="sm">
           {getIntegrationIcon(provider.key, 'sm')}
-          {provider.name}
+          <Text bold>{provider.name}</Text>
+          {soleInstallation && (
+            <Fragment>
+              <Text variant="muted">/</Text>
+              <IntegrationSummary installation={soleInstallation} />
+            </Fragment>
+          )}
         </Flex>
         <Flex align="center" gap="sm">
-          {settingsTo && (
-            <LinkButton to={settingsTo} size="xs" icon={<IconSettings />}>
-              {t('Settings')}
-            </LinkButton>
-          )}
-          {overflowMenuItems && overflowMenuItems.length > 0 && (
-            <DropdownMenu
-              items={overflowMenuItems}
-              position="bottom-end"
-              triggerProps={{
-                size: 'xs',
-                'aria-label': t('More actions'),
-                icon: <IconEllipsis />,
-              }}
+          {soleInstallation && (
+            <InstallationActions
+              installation={soleInstallation}
+              providerName={provider.name}
+              onUninstall={onUninstall}
+              onSettings={onSettings}
             />
           )}
         </Flex>
-      </PanelHeader>
-      <Grid columns="max-content 1fr" gap="0 md">
-        {installations.map(installation => (
-          <InstallationSubgrid key={installation.integration.id}>
-            <InstallationRow
-              provider={provider}
-              installation={installation}
-              expanded={expandedIds.has(installation.integration.id)}
-              onToggle={() => toggle(installation.integration.id)}
-              onDelete={onDelete ? () => onDelete(installation.integration) : undefined}
-              repoMatches={repoMatches}
-            />
-          </InstallationSubgrid>
-        ))}
-      </Grid>
+      </Flex>
+      {soleInstallation ? (
+        <VirtualizedRepoList
+          installation={soleInstallation}
+          repoMatches={repoMatches}
+          providerName={provider.name}
+          repoActions={repoActions}
+        />
+      ) : (
+        <Grid role="list" columns="max-content 1fr" gap="0 md">
+          {installations.map(installation => {
+            const hasSearchHits =
+              repoMatches !== undefined &&
+              installation.repositories.some(r => repoMatches[r.id]);
+            return (
+              <InstallationSubgrid key={installation.integration.id} role="listitem">
+                <InstallationRow
+                  provider={provider}
+                  installation={installation}
+                  expanded={hasSearchHits || expandedIds.has(installation.integration.id)}
+                  onToggle={() => toggle(installation.integration.id)}
+                  onUninstall={onUninstall}
+                  onSettings={onSettings}
+                  repoActions={repoActions}
+                  repoMatches={repoMatches}
+                />
+              </InstallationSubgrid>
+            );
+          })}
+        </Grid>
+      )}
       {showFooter && (
         <Flex
           align="center"
@@ -188,7 +283,9 @@ interface InstallationRowProps {
   installation: ScmInstallation;
   onToggle: () => void;
   provider: IntegrationProvider;
-  onDelete?: () => void;
+  onSettings?: (installation: ScmInstallation) => void;
+  onUninstall?: (installation: ScmInstallation) => void;
+  repoActions?: (repo: Repository, installation: ScmInstallation) => ReactNode;
   repoMatches?: ScmRepoMatches;
 }
 
@@ -197,17 +294,19 @@ function InstallationRow({
   installation,
   expanded,
   onToggle,
-  onDelete,
+  onUninstall,
+  onSettings,
+  repoActions,
   repoMatches,
 }: InstallationRowProps) {
-  const {integration, repositories, manageUrl, isLoading, expandDisabled} = installation;
-  const isDisabled = integration.status === 'disabled';
+  const {expandDisabled} = installation;
 
   const handleRowClick = (event: React.MouseEvent<HTMLDivElement>) => {
     if (expandDisabled) {
       return;
     }
-    if ((event.target as HTMLElement).closest('a, button')) {
+    const interactive = (event.target as HTMLElement).closest('a, button');
+    if (interactive && interactive !== event.currentTarget) {
       return;
     }
     onToggle();
@@ -228,6 +327,7 @@ function InstallationRow({
       <RowButton
         role="button"
         tabIndex={expandDisabled ? -1 : 0}
+        aria-label={installation.integration.name}
         aria-expanded={expandDisabled ? undefined : expanded}
         aria-disabled={expandDisabled || undefined}
         onClick={handleRowClick}
@@ -236,140 +336,313 @@ function InstallationRow({
         <IconChevron direction={expanded && !expandDisabled ? 'down' : 'right'} />
         <Flex column="2" align="center" justify="between" gap="md">
           <Flex align="center" gap="sm">
-            <IntegrationIcon integration={integration} size={16} />
-            <Text bold>{integration.name}</Text>
-            {isDisabled ? (
-              <Tag variant="warning">{t('Disabled')}</Tag>
-            ) : (
-              <Tag variant="muted">
-                {tn('%s repo connected', '%s repos connected', repositories.length)}
-              </Tag>
-            )}
+            <IntegrationSummary installation={installation} />
           </Flex>
           <Flex align="center" gap="md">
-            {isLoading && (
-              <Flex align="center" gap="sm">
-                <StatusIndicator variant="accent" />
-                <Text variant="muted" size="xs">
-                  {t('Loading Repositories')}
-                </Text>
-              </Flex>
-            )}
-            {manageUrl && (
-              <LinkButton
-                tooltipProps={{
-                  title: t('Add or remove repository access on %s', provider.name),
-                }}
-                href={manageUrl}
-                external
-                variant="link"
-                size="xs"
-                icon={<IconOpen />}
-              >
-                {t('Manage repositories')}
-              </LinkButton>
-            )}
-            {onDelete && (
-              <Button
-                aria-label={t('Uninstall')}
-                size="xs"
-                variant="transparent"
-                icon={<IconDelete />}
-                onClick={onDelete}
-              />
-            )}
+            <InstallationActions
+              installation={installation}
+              providerName={provider.name}
+              onUninstall={onUninstall}
+              onSettings={onSettings}
+            />
           </Flex>
         </Flex>
       </RowButton>
       {expanded && !expandDisabled && (
-        <RepoRows
-          repositories={repositories}
+        <VirtualizedRepoList
+          installation={installation}
           repoMatches={repoMatches}
-          manageUrl={manageUrl}
+          providerName={provider.name}
+          repoActions={repoActions}
+          nested
         />
       )}
     </Fragment>
   );
 }
 
-interface RepoRowsProps {
-  repositories: Repository[];
-  manageUrl?: string;
+function IntegrationSummary({installation}: {installation: ScmInstallation}) {
+  const {integration, repositories, reposLoading} = installation;
+  return (
+    <Fragment>
+      {getIntegrationIcon(integration.provider.key, 'sm')}
+      <Text bold>{integration.name}</Text>
+      {integration.status === 'disabled' ? (
+        <Tag variant="warning">{t('Disabled')}</Tag>
+      ) : (
+        <Fragment>
+          <Tag variant="muted">{tn('%s repo', '%s repos', repositories.length)}</Tag>
+          {reposLoading && (
+            <Tooltip title={t('Loading repositories')} skipWrapper>
+              <StatusIndicator variant="accent" />
+            </Tooltip>
+          )}
+        </Fragment>
+      )}
+    </Fragment>
+  );
+}
+
+interface InstallationActionsProps {
+  installation: ScmInstallation;
+  providerName: string;
+  onSettings?: (installation: ScmInstallation) => void;
+  onUninstall?: (installation: ScmInstallation) => void;
+}
+
+function InstallationActions({
+  installation,
+  providerName,
+  onUninstall,
+  onSettings,
+}: InstallationActionsProps) {
+  const {manageUrl, overflowMenuItems} = installation;
+  return (
+    <Fragment>
+      {manageUrl && (
+        <LinkButton
+          tooltipProps={{
+            title: t('Add or remove repository access on %s', providerName),
+          }}
+          href={manageUrl}
+          external
+          variant="link"
+          size="xs"
+          icon={<IconOpen />}
+        >
+          {t('Manage repositories')}
+        </LinkButton>
+      )}
+      {(onUninstall || onSettings || !!overflowMenuItems?.length) && (
+        <Flex align="center" gap="2xs">
+          {onUninstall && (
+            <Button
+              aria-label={t('Uninstall')}
+              size="xs"
+              variant="transparent"
+              icon={<IconDelete />}
+              onClick={() => onUninstall(installation)}
+            />
+          )}
+          {onSettings && (
+            <Button
+              aria-label={t('Integration settings')}
+              size="xs"
+              variant="transparent"
+              icon={<IconSliders />}
+              onClick={() => onSettings(installation)}
+            />
+          )}
+          {overflowMenuItems && overflowMenuItems.length > 0 && (
+            <DropdownMenu
+              items={overflowMenuItems}
+              position="bottom-end"
+              trigger={triggerProps => (
+                <Button
+                  {...triggerProps}
+                  size="xs"
+                  variant="transparent"
+                  aria-label={t('More Actions')}
+                  icon={<IconEllipsis />}
+                />
+              )}
+            />
+          )}
+        </Flex>
+      )}
+    </Fragment>
+  );
+}
+
+function RepoMappings({
+  slugs,
+  mappingsLoading,
+  action,
+}: {
+  mappingsLoading: boolean | undefined;
+  slugs: string[];
+  action?: ReactNode;
+}) {
+  return (
+    <Flex align="center" gap="2xs">
+      {slugs.length > 0 && <ProjectList projectSlugs={slugs} maxVisibleProjects={3} />}
+      {mappingsLoading && slugs.length === 0 && (
+        <Placeholder width="60px" height="16px" />
+      )}
+      {action}
+    </Flex>
+  );
+}
+
+interface VirtualizedRepoListProps {
+  installation: ScmInstallation;
+  providerName: string;
+  nested?: boolean;
+  repoActions?: (repo: Repository, installation: ScmInstallation) => ReactNode;
   repoMatches?: ScmRepoMatches;
 }
 
-function RepoRows({repositories, repoMatches, manageUrl}: RepoRowsProps) {
-  const theme = useTheme();
+function VirtualizedRepoList({
+  installation,
+  repoMatches,
+  providerName,
+  repoActions,
+  nested = false,
+}: VirtualizedRepoListProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const {
+    repositories,
+    manageUrl,
+    reposLoading: isLoading,
+    mappedProjectSlugsByRepoId,
+    mappingsLoading,
+  } = installation;
 
-  const statusColor = (status: RepositoryStatus) => {
-    switch (status) {
-      case RepositoryStatus.DISABLED:
-      case RepositoryStatus.HIDDEN:
-      case RepositoryStatus.DELETION_IN_PROGRESS:
-        return theme.tokens.graphics.danger.vibrant;
-      case RepositoryStatus.PENDING_DELETION:
-        return theme.tokens.graphics.warning.vibrant;
-      case RepositoryStatus.ACTIVE:
-        return theme.tokens.graphics.success.vibrant;
-      default:
-        return unreachable(status);
+  const visibleRepos = useMemo(() => {
+    const filtered =
+      repoMatches === undefined
+        ? repositories
+        : repositories.filter(r => repoMatches[r.id]);
+    const hasMapping = (id: string) =>
+      (mappedProjectSlugsByRepoId?.[id]?.length ?? 0) > 0;
+    return [...filtered].sort((a, b) => {
+      const aHas = hasMapping(a.id);
+      const bHas = hasMapping(b.id);
+      if (aHas !== bHas) return aHas ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    });
+  }, [repositories, repoMatches, mappedProjectSlugsByRepoId]);
+
+  const virtualizer = useVirtualizer({
+    count: visibleRepos.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => ESTIMATED_REPO_ROW_HEIGHT,
+    overscan: 6,
+    getItemKey: i => visibleRepos[i]!.id,
+  });
+
+  const renderEmptyMessage = () => {
+    if (isLoading) {
+      return (
+        <Flex align="center" gap="sm">
+          <StatusIndicator variant="accent" />
+          <Text variant="muted">{t('Loading repositories')}</Text>
+        </Flex>
+      );
     }
-  };
-
-  const visibleRepos =
-    repoMatches === undefined
-      ? repositories
-      : repositories.filter(r => repoMatches[r.id]);
-
-  if (visibleRepos.length === 0) {
-    const message =
-      repoMatches !== undefined && repositories.length > 0
-        ? t('No repositories match your search')
-        : manageUrl
+    if (repoMatches !== undefined && repositories.length > 0) {
+      return <Text variant="muted">{t('No repositories match your search')}</Text>;
+    }
+    return (
+      <Text variant="muted">
+        {manageUrl
           ? tct('No repositories available. [link:Manage repository access]', {
               link: <ExternalLink href={manageUrl} />,
             })
-          : t('No repositories available.');
-    return (
-      <RepoRow padding="md xl" justify="center">
-        <Text variant="muted">{message}</Text>
-      </RepoRow>
+          : t('No repositories available.')}
+      </Text>
     );
-  }
+  };
 
-  return (
-    <Fragment>
-      {visibleRepos.map(repo => {
-        const statusLabel = getRepoStatusLabel(repo) ?? t('Active');
-        const nameMatch = repoMatches?.[repo.id]?.find(m => m.key === 'name');
-        return (
-          <RepoRow
-            key={repo.id}
-            align="center"
-            justify="between"
-            gap="md"
-            padding="xs xl"
-          >
-            <Flex align="center" gap="md">
-              <Tooltip title={statusLabel} skipWrapper>
-                <CircleIndicator size={4} color={statusColor(repo.status)} />
-              </Tooltip>
-              <Text>
-                {nameMatch ? highlightFuseMatches(nameMatch, HighlightMark) : repo.name}
-              </Text>
-            </Flex>
-            <LinkButton
-              href={repo.url ?? ''}
-              external
-              size="xs"
-              variant="transparent"
-              icon={<IconOpen variant="muted" />}
-              aria-label={t('Open repository')}
-            />
-          </RepoRow>
-        );
-      })}
-    </Fragment>
+  const outerColumn = nested ? '1/-1' : undefined;
+  const outerColumns = nested ? 'subgrid' : '1fr';
+  const contentColumn = nested ? '2' : undefined;
+
+  const items =
+    visibleRepos.length === 0 ? (
+      <Flex column={contentColumn} padding="md xl" justify="center">
+        {renderEmptyMessage()}
+      </Flex>
+    ) : (
+      <Grid
+        column={outerColumn}
+        columns={outerColumns}
+        position="relative"
+        style={{height: virtualizer.getTotalSize()}}
+      >
+        {virtualizer.getVirtualItems().map(virtualItem => {
+          const repo = visibleRepos[virtualItem.index]!;
+          const nameMatch = repoMatches?.[repo.id]?.find(m => m.key === 'name');
+          const isLast = virtualItem.index === visibleRepos.length - 1;
+          return (
+            <Fragment key={virtualItem.key}>
+              <Container
+                column="1/-1"
+                position="absolute"
+                top="0"
+                left="0"
+                right="0"
+                borderBottom={isLast ? undefined : 'secondary'}
+                style={{
+                  transform: `translateY(${virtualItem.start}px)`,
+                  height: virtualItem.size,
+                }}
+              />
+              <RepoRow
+                role="listitem"
+                ref={virtualizer.measureElement}
+                data-index={virtualItem.index}
+                column={contentColumn}
+                position="absolute"
+                top="0"
+                left="0"
+                right="0"
+                align="center"
+                justify="between"
+                gap="sm"
+                padding={nested ? 'xs xl xs 0' : 'xs lg'}
+                style={{transform: `translateY(${virtualItem.start}px)`}}
+              >
+                <Flex align="center" gap="sm" minWidth="0">
+                  <Text>
+                    {nameMatch
+                      ? highlightFuseMatches(nameMatch, HighlightMark)
+                      : repo.name}
+                  </Text>
+                  <LinkButton
+                    className="hover-reveal"
+                    href={repo.url ?? ''}
+                    external
+                    size="zero"
+                    variant="transparent"
+                    icon={<IconOpen variant="muted" />}
+                    aria-label={t('View repository on %s', providerName)}
+                    tooltipProps={{
+                      title: t('View repository on %s', providerName),
+                    }}
+                  />
+                </Flex>
+                {mappedProjectSlugsByRepoId && (
+                  <RepoMappings
+                    slugs={mappedProjectSlugsByRepoId[repo.id] ?? []}
+                    mappingsLoading={mappingsLoading}
+                    action={repoActions?.(repo, installation)}
+                  />
+                )}
+              </RepoRow>
+            </Fragment>
+          );
+        })}
+      </Grid>
+    );
+
+  const commonProps = {
+    ref: scrollRef,
+    role: 'list',
+    'aria-label': t('Repositories'),
+    maxHeight: `${REPO_LIST_MAX_HEIGHT}px`,
+    overflowY: 'auto',
+    position: 'relative',
+  } as const;
+
+  return nested ? (
+    <Grid {...commonProps} column={outerColumn} columns={outerColumns}>
+      {items}
+    </Grid>
+  ) : (
+    <Flex {...commonProps} direction="column">
+      {items}
+    </Flex>
   );
 }
 
@@ -385,11 +658,12 @@ const InstallationSubgrid = styled('div')`
 
 const RowButton = styled('div')`
   cursor: pointer;
+
   display: grid;
   grid-template-columns: subgrid;
   grid-column: 1 / -1;
   align-items: center;
-  padding: ${p => p.theme.space.md} ${p => p.theme.space.xl};
+  padding: ${p => p.theme.space.md} ${p => p.theme.space.lg};
 
   &[aria-expanded='true'] {
     border-bottom: 1px solid ${p => p.theme.tokens.border.secondary};
@@ -407,32 +681,16 @@ const RowButton = styled('div')`
     outline: 2px solid ${p => p.theme.tokens.focus.default};
     outline-offset: -2px;
   }
-
-  *:last-child > &:last-child {
-    border-bottom-left-radius: ${p => p.theme.radius.md};
-    border-bottom-right-radius: ${p => p.theme.radius.md};
-  }
 `;
 
-function RepoRow({
-  children,
-  padding,
-  ...flexProps
-}: Omit<React.ComponentProps<typeof Flex>, 'children'> & {
-  children?: React.ReactNode;
-}) {
-  return (
-    <RepoRowWrapper column="1/-1" columns="subgrid" padding={padding}>
-      <Flex column="2" {...flexProps}>
-        {children}
-      </Flex>
-    </RepoRowWrapper>
-  );
-}
-
-const RepoRowWrapper = styled(Grid)`
-  &:not(:last-child) {
-    border-bottom: 1px solid ${p => p.theme.tokens.border.secondary};
+const RepoRow = styled(Flex)`
+  .hover-reveal {
+    opacity: 0;
+    transition: opacity 100ms;
+  }
+  &:hover .hover-reveal,
+  &:focus-within .hover-reveal {
+    opacity: 1;
   }
 `;
 


### PR DESCRIPTION
- Move `onDelete`/`settingsTo`/`overflowMenuItems` out of `ScmInstallation`; replace with table-level `onUninstall`, `onSettings`, and `repoActions` callbacks that receive the installation (or repo + installation) as parameters
- Add `mappedProjectSlugsByRepoId`/`mappingsLoading` to `ScmInstallation` for inline code mapping display per repo row
- Replace flat repo list with a virtualized `@tanstack/react-virtual` list capped at 400px
- Single-installation tables flatten the header (no expand/collapse toggle)
- Add unit tests and update stories to match the new API

Preview here https://sentry-hucnmwegd.sentry.dev/stories/product/views/settings/organizationrepositories/scmrepositorytable/