### PR TITLE
feat(seer): Expose DSN lookup through public RPC

### DIFF
--- a/src/sentry/seer/endpoints/organization_seer_rpc.py
+++ b/src/sentry/seer/endpoints/organization_seer_rpc.py
@@ -32,6 +32,7 @@ from sentry.seer.agent.tools import (
     execute_trace_table_query,
     get_baseline_tag_distribution,
     get_comparative_attribute_distributions,
+    get_dsn,
     get_event_details,
     get_issue_and_event_details_v2,
     get_issue_details,
@@ -122,6 +123,7 @@ public_org_seer_method_registry: dict[str, Callable] = {
     "get_issues_stats": map_org_id_param(get_issues_stats),
     "get_baseline_tag_distribution": get_baseline_tag_distribution,
     "get_comparative_attribute_distributions": get_comparative_attribute_distributions,
+    "get_dsn": get_dsn,
     #
     # Agent eval tooling
     "export_explorer_indexes": map_org_id_param(export_agent_indexes),

--- a/tests/sentry/seer/endpoints/test_organization_seer_rpc.py
+++ b/tests/sentry/seer/endpoints/test_organization_seer_rpc.py
@@ -64,6 +64,22 @@ class TestOrganizationSeerRpcEndpoint(APITestCase):
         assert self.project.id in project_ids
 
     @with_feature("organizations:seer-public-rpc")
+    def test_org_level_method_get_dsn(self) -> None:
+        project = self.create_project(organization=self.organization, slug="wordcraft")
+        path = self._get_path("get_dsn")
+
+        response = self.client.post(
+            path, data={"args": {"project_slug": "wordcraft"}}, format="json"
+        )
+
+        assert response.status_code == 200
+        assert response.data is not None
+        assert response.data["project_slug"] == "wordcraft"
+        assert response.data["platform"] == project.platform
+        assert response.data["dsn_public"].startswith("http")
+        assert response.data["dsn_public"].endswith(f"/{project.id}")
+
+    @with_feature("organizations:seer-public-rpc")
     def test_project_method_requires_project_id(self) -> None:
         """Test that project-level methods require project_id in args"""
         path = self._get_path("get_transactions_for_project")


### PR DESCRIPTION
Expose the existing Seer `get_dsn` RPC method through the organization-scoped public Seer RPC endpoint. This lets local Explorer evals exercise the real remote RPC path for DSN lookup instead of failing at the proxy allowlist.

**Public RPC Registry**

The org-scoped registry now includes `get_dsn`, which is already implemented and scoped by organization plus project slug.

**Endpoint Coverage**

Adds coverage that the public org RPC endpoint returns a project's public DSN for a valid project slug.