### PR TITLE
feat(sentry-apps): Skip webhook dispatch for disabled sentry apps

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -386,7 +386,6 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:seer-added", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
     # Organizations on the new seat-based Seer plan
     manager.add("organizations:seat-based-seer-enabled", OrganizationFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
-    manager.add("organizations:sentry-app-disabled-enforcement", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable new SentryApp webhook request endpoint
     manager.add("organizations:sentry-app-webhook-requests", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable mobile starfish ui module view

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -4042,6 +4042,14 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Enforce is_disabled field on sentry app endpoints and webhooks.
+register(
+    "sentry-apps.disabled-enforcement",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Disable paranoia for sentry apps
 register(
     "sentry-apps.hard-delete",

--- a/src/sentry/sentry_apps/api/bases/sentryapps.py
+++ b/src/sentry/sentry_apps/api/bases/sentryapps.py
@@ -9,7 +9,7 @@ from rest_framework.permissions import BasePermission
 from rest_framework.request import Request
 from rest_framework.response import Response
 
-from sentry import features
+from sentry import options
 from sentry.api.authentication import ClientIdSecretAuthentication, JWTClientSecretAuthentication
 from sentry.api.base import Endpoint
 from sentry.api.permissions import SentryPermission, StaffPermissionMixin
@@ -105,13 +105,7 @@ def _check_sentry_app_disabled(
     if request.method in endpoint.allow_disabled_sentry_app_for_methods:
         return
 
-    owner_context = organization_service.get_organization_by_id(
-        id=sentry_app.owner_id, user_id=None, include_projects=False, include_teams=False
-    )
-    if owner_context and features.has(
-        "organizations:sentry-app-disabled-enforcement",
-        owner_context.organization,
-    ):
+    if options.get("sentry-apps.disabled-enforcement"):
         raise SentryAppError(
             message="This Sentry App has been disabled",
             status_code=403,

--- a/src/sentry/sentry_apps/metrics.py
+++ b/src/sentry/sentry_apps/metrics.py
@@ -73,6 +73,7 @@ class SentryAppWebhookHaltReason(StrEnum):
     CONNECTION_RESET = "connection_reset"
     HARD_TIMEOUT = "hard_timeout"
     CIRCUIT_BROKEN = "circuit_broken"
+    APP_DISABLED = "app_disabled"
 
 
 class SentryAppExternalRequestFailureReason(StrEnum):

--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -13,7 +13,7 @@ from requests.exceptions import ChunkedEncodingError, ConnectionError, RequestEx
 from taskbroker_client.constants import CompressionType
 from taskbroker_client.retry import NoRetriesRemainingError, Retry, retry_task
 
-from sentry import analytics, nodestore
+from sentry import analytics, features, nodestore
 from sentry.analytics.events.alert_rule_ui_component_webhook_sent import (
     AlertRuleUiComponentWebhookSentEvent,
 )
@@ -45,6 +45,7 @@ from sentry.models.organization import Organization
 from sentry.models.organizationmapping import OrganizationMapping
 from sentry.models.project import Project
 from sentry.notifications.utils.rules import get_rule_or_workflow_id
+from sentry.organizations.services.organization import organization_service
 from sentry.sentry_apps.api.serializers.app_platform_event import AppPlatformEvent
 from sentry.sentry_apps.metrics import (
     SentryAppEventType,
@@ -56,7 +57,7 @@ from sentry.sentry_apps.metrics import (
 from sentry.sentry_apps.models.sentry_app import SentryApp
 from sentry.sentry_apps.models.sentry_app_installation import SentryAppInstallation
 from sentry.sentry_apps.models.servicehook import ServiceHook, ServiceHookProject
-from sentry.sentry_apps.services.app.model import RpcSentryAppInstallation
+from sentry.sentry_apps.services.app.model import RpcSentryApp, RpcSentryAppInstallation
 from sentry.sentry_apps.services.app.service import (
     app_service,
     get_by_application_id,
@@ -213,6 +214,10 @@ def send_alert_webhook_v2(
         sentry_app = app_service.get_sentry_app_by_id(id=sentry_app_id)
         if sentry_app is None:
             raise SentryAppSentryError(message=SentryAppWebhookFailureReason.MISSING_SENTRY_APP)
+
+        if _is_sentry_app_disabled_for_webhooks(sentry_app):
+            lifecycle.record_halt(halt_reason=SentryAppWebhookHaltReason.APP_DISABLED)
+            return
 
         installations = app_service.get_many(
             filter=dict(
@@ -740,11 +745,29 @@ def notify_sentry_app(event: GroupEvent, futures: Sequence[RuleFuture]):
         )
 
 
+def _is_sentry_app_disabled_for_webhooks(sentry_app: RpcSentryApp) -> bool:
+    if not sentry_app.is_disabled:
+        return False
+    owner_context = organization_service.get_organization_by_id(
+        id=sentry_app.owner_id, user_id=None, include_projects=False, include_teams=False
+    )
+    if owner_context and features.has(
+        "organizations:sentry-app-disabled-enforcement",
+        owner_context.organization,
+    ):
+        return True
+    return False
+
+
 def send_webhooks(installation: RpcSentryAppInstallation, event: str, **kwargs: Any) -> None:
     with SentryAppInteractionEvent(
         operation_type=SentryAppInteractionType.SEND_WEBHOOK,
         event_type=SentryAppEventType(event),
     ).capture() as lifecycle:
+        if _is_sentry_app_disabled_for_webhooks(installation.sentry_app):
+            lifecycle.record_halt(halt_reason=SentryAppWebhookHaltReason.APP_DISABLED)
+            return
+
         servicehook: ServiceHook | None = _load_service_hook(
             installation.organization_id, installation.id
         )
@@ -962,6 +985,10 @@ def send_metric_alert_webhook(
         sentry_app = app_service.get_sentry_app_by_id(id=sentry_app_id)
         if sentry_app is None:
             lifecycle.record_failure(SentryAppWebhookFailureReason.MISSING_SENTRY_APP)
+            return
+
+        if _is_sentry_app_disabled_for_webhooks(sentry_app):
+            lifecycle.record_halt(halt_reason=SentryAppWebhookHaltReason.APP_DISABLED)
             return
 
         installations = app_service.get_many(

--- a/tests/sentry/sentry_apps/api/bases/test_disabled_sentry_app.py
+++ b/tests/sentry/sentry_apps/api/bases/test_disabled_sentry_app.py
@@ -1,10 +1,10 @@
 from sentry.sentry_apps.models.sentry_app import SentryApp
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
-from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 
-FEATURE_FLAG = "organizations:sentry-app-disabled-enforcement"
+OPTION = {"sentry-apps.disabled-enforcement": True}
 
 
 def disable_app(app: SentryApp) -> None:
@@ -21,26 +21,26 @@ class DisabledSentryAppDetailsTest(APITestCase):
         self.app = self.create_sentry_app(name="Test", organization=self.organization)
         self.login_as(self.user)
 
-    @with_feature(FEATURE_FLAG)
+    @override_options(OPTION)
     def test_get_disabled_app_returns_403(self) -> None:
         disable_app(self.app)
         self.get_error_response(self.app.slug, status_code=403)
 
-    @with_feature(FEATURE_FLAG)
+    @override_options(OPTION)
     def test_get_non_disabled_app_returns_200(self) -> None:
         self.get_success_response(self.app.slug, status_code=200)
 
-    @with_feature(FEATURE_FLAG)
+    @override_options(OPTION)
     def test_delete_disabled_app_allowed(self) -> None:
         disable_app(self.app)
         self.get_success_response(self.app.slug, method="delete", status_code=204)
 
-    @with_feature(FEATURE_FLAG)
+    @override_options(OPTION)
     def test_put_disabled_app_allowed(self) -> None:
         disable_app(self.app)
         self.get_success_response(self.app.slug, method="put", status_code=200, name="Test")
 
-    def test_disabled_app_without_flag_returns_200(self) -> None:
+    def test_disabled_app_without_option_returns_200(self) -> None:
         disable_app(self.app)
         self.get_success_response(self.app.slug, status_code=200)
 
@@ -56,16 +56,16 @@ class DisabledSentryAppInstallationTest(APITestCase):
         )
         self.login_as(self.user)
 
-    @with_feature(FEATURE_FLAG)
+    @override_options(OPTION)
     def test_get_installation_of_disabled_app_returns_403(self) -> None:
         disable_app(self.app)
         self.get_error_response(self.install.uuid, status_code=403)
 
-    @with_feature(FEATURE_FLAG)
+    @override_options(OPTION)
     def test_delete_installation_of_disabled_app_allowed(self) -> None:
         disable_app(self.app)
         self.get_success_response(self.install.uuid, method="delete", status_code=204)
 
-    @with_feature(FEATURE_FLAG)
+    @override_options(OPTION)
     def test_get_installation_of_non_disabled_app_returns_200(self) -> None:
         self.get_success_response(self.install.uuid, status_code=200)

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -2109,3 +2109,94 @@ class TestSendMetricAlertWebhook(TestCase):
             if isinstance(call.args[0], AlertRuleUiComponentWebhookSentEvent)
         ]
         assert len(ui_component_calls) == 0
+
+
+FEATURE_FLAG = "organizations:sentry-app-disabled-enforcement"
+
+
+def disable_app(app: SentryApp) -> None:
+    with assume_test_silo_mode(SiloMode.CONTROL):
+        app.update(is_disabled=True)
+
+
+class TestDisabledSentryAppWebhooks(TestCase):
+    def setUp(self) -> None:
+        self.project = self.create_project()
+        self.user = self.create_user()
+        self.sentry_app = self.create_sentry_app(
+            organization=self.project.organization,
+            events=["issue.resolved", "issue.ignored", "issue.assigned"],
+        )
+        self.install = self.create_sentry_app_installation(
+            organization=self.project.organization, slug=self.sentry_app.slug
+        )
+        self.issue = self.create_group(project=self.project)
+
+    @with_feature(FEATURE_FLAG)
+    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen", return_value=MockResponseInstance)
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_workflow_notification_blocked_for_disabled_app(
+        self, mock_record: MagicMock, safe_urlopen: MagicMock
+    ) -> None:
+        disable_app(self.sentry_app)
+        workflow_notification(self.install.id, self.issue.id, "resolved", self.user.id)
+        assert not safe_urlopen.called
+        assert_halt_metric(
+            mock_record=mock_record, error_msg=SentryAppWebhookHaltReason.APP_DISABLED
+        )
+
+    @with_feature(FEATURE_FLAG)
+    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen", return_value=MockResponseInstance)
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_send_alert_webhook_v2_blocked_for_disabled_app(
+        self, mock_record: MagicMock, safe_urlopen: MagicMock
+    ) -> None:
+        event = self.store_event(data={}, project_id=self.project.id)
+        assert event.group is not None
+        disable_app(self.sentry_app)
+        send_alert_webhook_v2(
+            instance_id=event.event_id,
+            group_id=event.group.id,
+            occurrence_id=None,
+            rule_label="Test Rule",
+            sentry_app_id=self.sentry_app.id,
+        )
+        assert not safe_urlopen.called
+        assert_halt_metric(
+            mock_record=mock_record, error_msg=SentryAppWebhookHaltReason.APP_DISABLED
+        )
+
+    @with_feature(FEATURE_FLAG)
+    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen", return_value=MockResponseInstance)
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    def test_send_metric_alert_webhook_blocked_for_disabled_app(
+        self, mock_record: MagicMock, safe_urlopen: MagicMock
+    ) -> None:
+        disable_app(self.sentry_app)
+        send_metric_alert_webhook(
+            sentry_app_id=self.sentry_app.id,
+            new_status=IncidentStatus.CRITICAL.value,
+            incident_attachment_json=json.dumps(
+                {
+                    "metric_alert": {"alert_rule": {"triggers": []}},
+                    "description_text": "Something went wrong",
+                    "description_title": "Test Alert",
+                    "web_url": "http://example.com/alert/1",
+                }
+            ),
+            organization_id=self.project.organization.id,
+            project_id=self.project.id,
+            alert_id=42,
+        )
+        assert not safe_urlopen.called
+        assert_halt_metric(
+            mock_record=mock_record, error_msg=SentryAppWebhookHaltReason.APP_DISABLED
+        )
+
+    @patch("sentry.utils.sentry_apps.webhooks.safe_urlopen", return_value=MockResponseInstance)
+    def test_workflow_notification_still_sends_without_feature_flag(
+        self, safe_urlopen: MagicMock
+    ) -> None:
+        disable_app(self.sentry_app)
+        workflow_notification(self.install.id, self.issue.id, "resolved", self.user.id)
+        assert safe_urlopen.called


### PR DESCRIPTION
## Summary
- Adds early-return checks in `send_webhooks`, `send_alert_webhook_v2`, and `send_metric_alert_webhook` to skip webhook delivery when a sentry app's `is_disabled` flag is `True` and the `organizations:sentry-app-disabled-enforcement` feature flag is enabled
- Adds `APP_DISABLED` halt reason to `SentryAppWebhookHaltReason` for metrics tracking
- Installation lifecycle webhooks (install/uninstall) are intentionally **not** blocked so cleanup operations still work

Depends on #114469 (PR 2 — endpoint enforcement)

## Test plan
- [ ] `workflow_notification` blocked for disabled app (tests `send_webhooks` path)
- [ ] `send_alert_webhook_v2` blocked for disabled app
- [ ] `send_metric_alert_webhook` blocked for disabled app
- [ ] Webhooks still fire when app is disabled but feature flag is off (rollback safety)