### PR TITLE
ref(🥞): add Layer primitive with portal outlets and stacking context isolation

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -23,6 +23,8 @@ const productionEntryPoints = [
   'static/app/chartcuterie/**/*.{js,ts,tsx}',
   // TODO: Remove when used
   'static/app/views/seerExplorer/contexts/**/*.{js,ts,tsx}',
+  // TODO: Remove when Layer consumers land (nm/zindex/wire-portals)
+  'static/app/components/core/layer/*.{ts,tsx}',
 ];
 
 const testingEntryPoints = [

--- a/static/app/components/core/layer/index.tsx
+++ b/static/app/components/core/layer/index.tsx
@@ -1,0 +1,1 @@
+export {Layer, useLayerContext, usePortalContainer} from './layer';

--- a/static/app/components/core/layer/layer.mdx
+++ b/static/app/components/core/layer/layer.mdx
@@ -1,0 +1,143 @@
+---
+title: Layer
+description: Layer creates isolated stacking contexts with built-in portal outlets for managing visual layering without global z-index values.
+category: layout
+source: '@sentry/scraps/layer'
+resources:
+  js: https://github.com/getsentry/sentry/blob/master/static/app/components/core/layer/index.tsx
+---
+
+import {createPortal} from 'react-dom';
+import {Button} from '@sentry/scraps/button';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
+import {Layer, useLayerContext, usePortalContainer} from '@sentry/scraps/layer';
+
+import * as Storybook from 'sentry/stories';
+
+export const documentation = import('!!type-loader!@sentry/scraps/layer/layer');
+
+Layer wraps a region of the UI in an isolated stacking context (`isolation: isolate`) and provides a portal outlet for descendant overlays like tooltips, hovercards, and dropdowns.
+
+Stacking order between sibling Layers is determined by **DOM order**, not z-index. A Layer that appears later in the DOM paints above earlier siblings.
+
+<Storybook.Demo>
+  <Flex gap="lg" style={{position: 'relative', height: 120}}>
+    <Layer variant="content">
+      <Container
+        padding="lg"
+        border="primary"
+        style={{background: 'var(--background-secondary)'}}
+      >
+        <Text>Content layer (renders first)</Text>
+      </Container>
+    </Layer>
+    <Layer variant="overlay">
+      <Container
+        padding="lg"
+        border="primary"
+        style={{background: 'var(--background-overlay)'}}
+      >
+        <Text>Overlay layer (renders second, paints above)</Text>
+      </Container>
+    </Layer>
+  </Flex>
+</Storybook.Demo>
+
+```jsx
+<Layer variant="content">
+  <PageContent />
+</Layer>
+<Layer variant="overlay">
+  <Drawer />
+</Layer>
+```
+
+## Variants
+
+Layer accepts three semantic variants: `content`, `nav`, and `overlay`. Variants describe **what** the surface is, not where it stacks.
+
+| Variant   | Use for                                      |
+| --------- | -------------------------------------------- |
+| `content` | Page body, main content area                 |
+| `nav`     | App chrome, sidebar, top bar, sticky headers |
+| `overlay` | Drawers, modals, toasts                      |
+
+```jsx
+<Layer variant="content">...</Layer>
+<Layer variant="nav">...</Layer>
+<Layer variant="overlay">...</Layer>
+```
+
+## Recursive Nesting
+
+Layers can be nested. An inner Layer creates a nested stacking context within the parent.
+
+When nesting the same variant, `depth` increments automatically. When the variant changes, depth resets to 0.
+
+<Storybook.Demo>
+  {() => {
+    function DepthDisplay() {
+      const {variant, depth} = useLayerContext();
+      return (
+        <Text size="sm">
+          {variant} (depth {depth})
+        </Text>
+      );
+    }
+    return (
+      <Stack gap="md">
+        <Layer variant="overlay">
+          <Container padding="md" border="primary">
+            <DepthDisplay />
+            <Layer variant="overlay">
+              <Container padding="md" border="primary">
+                <DepthDisplay />
+              </Container>
+            </Layer>
+          </Container>
+        </Layer>
+      </Stack>
+    );
+  }}
+</Storybook.Demo>
+
+```jsx
+<Layer variant="overlay">
+  {/* depth 0 — e.g. drawer */}
+  <Layer variant="overlay">{/* depth 1 — e.g. modal inside drawer */}</Layer>
+</Layer>
+```
+
+## Portal Outlet
+
+Each Layer provides a portal outlet that portaled children (tooltips, hovercards, dropdowns) can render into via `usePortalContainer()`. Content rendered into the outlet stays within the Layer's stacking context.
+
+```jsx
+function MyOverlay() {
+  const portalOutlet = usePortalContainer();
+  if (!portalOutlet) return null;
+  return createPortal(<div>I render inside my Layer</div>, portalOutlet);
+}
+```
+
+This replaces the pattern of portaling to `document.body` with global z-index values. A tooltip inside a content Layer will paint behind an overlay Layer, because the portal outlet is contained within the content Layer's stacking context.
+
+## Hooks
+
+### useLayerContext
+
+Returns the current Layer context: `{ variant, depth, portalOutlet }`.
+
+```jsx
+const {variant, depth, portalOutlet} = useLayerContext();
+```
+
+### usePortalContainer
+
+Returns the nearest Layer's portal outlet element, or `null` if outside a Layer.
+
+```jsx
+const container = usePortalContainer();
+```

--- a/static/app/components/core/layer/layer.spec.tsx
+++ b/static/app/components/core/layer/layer.spec.tsx
@@ -1,0 +1,142 @@
+import {createPortal} from 'react-dom';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {Layer, useLayerContext, usePortalContainer} from '@sentry/scraps/layer';
+
+function LayerInfo({testId}: {testId: string}) {
+  const {variant, depth} = useLayerContext();
+  return (
+    <div data-test-id={testId}>
+      {variant ?? 'none'}:{depth}
+    </div>
+  );
+}
+
+function PortaledContent({children}: {children: React.ReactNode}) {
+  const portalOutlet = usePortalContainer();
+  if (!portalOutlet) {
+    return null;
+  }
+  return createPortal(
+    <div style={{pointerEvents: 'auto'}}>{children}</div>,
+    portalOutlet
+  );
+}
+
+describe('Layer', () => {
+  it('renders children', () => {
+    render(
+      <Layer variant="content">
+        <span>hello</span>
+      </Layer>
+    );
+    expect(screen.getByText('hello')).toBeInTheDocument();
+  });
+
+  it('provides variant and depth via context', () => {
+    render(
+      <Layer variant="nav">
+        <LayerInfo testId="info" />
+      </Layer>
+    );
+    expect(screen.getByTestId('info')).toHaveTextContent('nav:0');
+  });
+
+  it('increments depth when nesting same variant', () => {
+    render(
+      <Layer variant="overlay">
+        <LayerInfo testId="outer" />
+        <Layer variant="overlay">
+          <LayerInfo testId="inner" />
+          <Layer variant="overlay">
+            <LayerInfo testId="deepest" />
+          </Layer>
+        </Layer>
+      </Layer>
+    );
+    expect(screen.getByTestId('outer')).toHaveTextContent('overlay:0');
+    expect(screen.getByTestId('inner')).toHaveTextContent('overlay:1');
+    expect(screen.getByTestId('deepest')).toHaveTextContent('overlay:2');
+  });
+
+  it('resets depth when variant changes', () => {
+    render(
+      <Layer variant="content">
+        <LayerInfo testId="content" />
+        <Layer variant="overlay">
+          <LayerInfo testId="overlay" />
+        </Layer>
+      </Layer>
+    );
+    expect(screen.getByTestId('content')).toHaveTextContent('content:0');
+    expect(screen.getByTestId('overlay')).toHaveTextContent('overlay:0');
+  });
+
+  it('renders a wrapping div for the stacking context', () => {
+    render(
+      <Layer variant="content">
+        <span>styled</span>
+      </Layer>
+    );
+    const layerDiv = screen.getByText('styled').parentElement!;
+    expect(layerDiv.tagName).toBe('DIV');
+  });
+
+  it('creates a portal outlet element', () => {
+    render(
+      <Layer variant="content">
+        <PortaledContent>portaled text</PortaledContent>
+      </Layer>
+    );
+    expect(screen.getByText('portaled text')).toBeInTheDocument();
+  });
+
+  it('contains portaled content within the layer DOM', () => {
+    render(
+      <Layer variant="content">
+        <span data-test-id="sibling">sibling</span>
+        <PortaledContent>portaled text</PortaledContent>
+      </Layer>
+    );
+    const layerDiv = screen.getByTestId('sibling').parentElement!;
+    expect(layerDiv).toContainElement(screen.getByText('portaled text'));
+  });
+
+  it('provides separate portal outlets for nested layers', () => {
+    const outlets: Record<string, HTMLElement | null> = {};
+
+    function CaptureOutlet({name}: {name: string}) {
+      const outlet = usePortalContainer();
+      outlets[name] = outlet;
+      return null;
+    }
+
+    render(
+      <Layer variant="content">
+        <CaptureOutlet name="content" />
+        <Layer variant="overlay">
+          <CaptureOutlet name="overlay" />
+        </Layer>
+      </Layer>
+    );
+
+    expect(outlets.content).not.toBeNull();
+    expect(outlets.overlay).not.toBeNull();
+    expect(outlets.content).not.toBe(outlets.overlay);
+  });
+
+  it('returns null from usePortalContainer when outside a Layer', () => {
+    function Check() {
+      const container = usePortalContainer();
+      return <span>{container === null ? 'null' : 'exists'}</span>;
+    }
+    render(<Check />);
+    expect(screen.getByText('null')).toBeInTheDocument();
+  });
+
+  it('returns default context from useLayerContext when outside a Layer', () => {
+    render(<LayerInfo testId="outside" />);
+    expect(screen.getByTestId('outside')).toHaveTextContent('none:0');
+  });
+});

--- a/static/app/components/core/layer/layer.spec.tsx
+++ b/static/app/components/core/layer/layer.spec.tsx
@@ -139,4 +139,32 @@ describe('Layer', () => {
     render(<LayerInfo testId="outside" />);
     expect(screen.getByTestId('outside')).toHaveTextContent('none:0');
   });
+
+  it('supports render child pattern', () => {
+    render(
+      <Layer variant="overlay">
+        {({className}) => (
+          <section className={className} data-test-id="custom-element">
+            <LayerInfo testId="info" />
+          </section>
+        )}
+      </Layer>
+    );
+    const section = screen.getByTestId('custom-element');
+    expect(section.tagName).toBe('SECTION');
+    expect(screen.getByTestId('info')).toHaveTextContent('overlay:0');
+  });
+
+  it('provides portal outlet with render child pattern', () => {
+    render(
+      <Layer variant="content">
+        {({className}) => (
+          <div className={className}>
+            <PortaledContent>render-child portaled</PortaledContent>
+          </div>
+        )}
+      </Layer>
+    );
+    expect(screen.getByText('render-child portaled')).toBeInTheDocument();
+  });
 });

--- a/static/app/components/core/layer/layer.tsx
+++ b/static/app/components/core/layer/layer.tsx
@@ -1,0 +1,62 @@
+import {createContext, useContext, useMemo, useState} from 'react';
+import styled from '@emotion/styled';
+
+type LayerVariant = 'content' | 'nav' | 'overlay';
+
+interface LayerContextValue {
+  depth: number;
+  portalOutlet: HTMLElement | null;
+  variant: LayerVariant | null;
+}
+
+const LayerContext = createContext<LayerContextValue>({
+  variant: null,
+  depth: 0,
+  portalOutlet: null,
+});
+
+interface LayerProps {
+  children: React.ReactNode;
+  variant: LayerVariant;
+}
+
+export function Layer({variant, children}: LayerProps) {
+  const parentContext = useContext(LayerContext);
+  const [portalOutlet, setPortalOutlet] = useState<HTMLElement | null>(null);
+
+  const depth = parentContext.variant === variant ? parentContext.depth + 1 : 0;
+
+  const contextValue = useMemo<LayerContextValue>(
+    () => ({variant, depth, portalOutlet}),
+    [variant, depth, portalOutlet]
+  );
+
+  return (
+    <LayerContext value={contextValue}>
+      <StyledLayer>
+        {children}
+        <PortalOutlet ref={setPortalOutlet} />
+      </StyledLayer>
+    </LayerContext>
+  );
+}
+
+export function useLayerContext(): LayerContextValue {
+  return useContext(LayerContext);
+}
+
+export function usePortalContainer(): HTMLElement | null {
+  const {portalOutlet} = useContext(LayerContext);
+  return portalOutlet;
+}
+
+const StyledLayer = styled('div')`
+  isolation: isolate;
+  position: relative;
+`;
+
+const PortalOutlet = styled('div')`
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+`;

--- a/static/app/components/core/layer/layer.tsx
+++ b/static/app/components/core/layer/layer.tsx
@@ -56,7 +56,6 @@ export const Layer = styled(
   }
 )<LayerProps>`
   isolation: isolate;
-  position: relative;
 `;
 
 export function useLayerContext(): LayerContextValue {

--- a/static/app/components/core/layer/layer.tsx
+++ b/static/app/components/core/layer/layer.tsx
@@ -1,4 +1,4 @@
-import {createContext, useContext, useMemo, useState} from 'react';
+import {createContext, Fragment, useContext, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
 type LayerVariant = 'content' | 'nav' | 'overlay';
@@ -16,30 +16,48 @@ const LayerContext = createContext<LayerContextValue>({
 });
 
 interface LayerProps {
-  children: React.ReactNode;
+  children: React.ReactNode | ((props: {className: string}) => React.ReactNode);
   variant: LayerVariant;
 }
 
-export function Layer({variant, children}: LayerProps) {
-  const parentContext = useContext(LayerContext);
-  const [portalOutlet, setPortalOutlet] = useState<HTMLElement | null>(null);
+export const Layer = styled(
+  ({variant, children, ...props}: LayerProps & {className?: string}) => {
+    const parentContext = useContext(LayerContext);
+    const [portalOutlet, setPortalOutlet] = useState<HTMLElement | null>(null);
 
-  const depth = parentContext.variant === variant ? parentContext.depth + 1 : 0;
+    const depth = parentContext.variant === variant ? parentContext.depth + 1 : 0;
 
-  const contextValue = useMemo<LayerContextValue>(
-    () => ({variant, depth, portalOutlet}),
-    [variant, depth, portalOutlet]
-  );
+    const contextValue = useMemo<LayerContextValue>(
+      () => ({variant, depth, portalOutlet}),
+      [variant, depth, portalOutlet]
+    );
 
-  return (
-    <LayerContext value={contextValue}>
-      <StyledLayer>
-        {children}
-        <PortalOutlet ref={setPortalOutlet} />
-      </StyledLayer>
-    </LayerContext>
-  );
-}
+    const className = props.className ?? '';
+
+    if (typeof children === 'function') {
+      return (
+        <LayerContext value={contextValue}>
+          <Fragment>
+            {children({className})}
+            <PortalOutlet ref={setPortalOutlet} />
+          </Fragment>
+        </LayerContext>
+      );
+    }
+
+    return (
+      <LayerContext value={contextValue}>
+        <div className={className}>
+          {children}
+          <PortalOutlet ref={setPortalOutlet} />
+        </div>
+      </LayerContext>
+    );
+  }
+)<LayerProps>`
+  isolation: isolate;
+  position: relative;
+`;
 
 export function useLayerContext(): LayerContextValue {
   return useContext(LayerContext);
@@ -50,13 +68,9 @@ export function usePortalContainer(): HTMLElement | null {
   return portalOutlet;
 }
 
-const StyledLayer = styled('div')`
-  isolation: isolate;
-  position: relative;
-`;
-
 const PortalOutlet = styled('div')`
   position: fixed;
   inset: 0;
   pointer-events: none;
+  z-index: 2147483647;
 `;

--- a/static/app/components/core/layer/layer.tsx
+++ b/static/app/components/core/layer/layer.tsx
@@ -69,13 +69,13 @@ export function useLayerContext(): LayerContextValue {
 }
 
 export function usePortalContainer(): HTMLElement | null {
-  const {portalOutlet} = useContext(LayerContext);
-  return portalOutlet;
+  return useLayerContext().portalOutlet;
 }
 
 const PortalOutlet = styled('div')`
   position: fixed;
-  inset: 0;
   pointer-events: none;
-  z-index: 2147483647;
+  width: 0;
+  height: 0;
+  overflow: visible;
 `;

--- a/static/app/components/core/layer/layer.tsx
+++ b/static/app/components/core/layer/layer.tsx
@@ -1,6 +1,8 @@
 import {createContext, Fragment, useContext, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
+import {HoverOverlayGroupProvider} from 'sentry/utils/useHoverOverlay';
+
 type LayerVariant = 'content' | 'nav' | 'overlay';
 
 interface LayerContextValue {
@@ -37,20 +39,24 @@ export const Layer = styled(
     if (typeof children === 'function') {
       return (
         <LayerContext value={contextValue}>
-          <Fragment>
-            {children({className})}
-            <PortalOutlet ref={setPortalOutlet} />
-          </Fragment>
+          <HoverOverlayGroupProvider>
+            <Fragment>
+              {children({className})}
+              <PortalOutlet ref={setPortalOutlet} />
+            </Fragment>
+          </HoverOverlayGroupProvider>
         </LayerContext>
       );
     }
 
     return (
       <LayerContext value={contextValue}>
-        <div className={className}>
-          {children}
-          <PortalOutlet ref={setPortalOutlet} />
-        </div>
+        <HoverOverlayGroupProvider>
+          <div className={className}>
+            {children}
+            <PortalOutlet ref={setPortalOutlet} />
+          </div>
+        </HoverOverlayGroupProvider>
       </LayerContext>
     );
   }


### PR DESCRIPTION
## Summary

Add a `Layer` component that uses `isolation: isolate` to create scoped stacking contexts. Each Layer provides a portal outlet for portaled children (tooltips, hovercards, dropdowns) so they remain contained within the Layer's paint order. Stacking order between sibling Layers is determined by DOM position, not z-index.

**Layer Component**

Three semantic variants (`content`, `nav`, `overlay`) describe the surface type. Recursive nesting is supported with automatic depth tracking. Each Layer renders a `position: fixed; inset: 0; pointer-events: none` portal outlet at the end of its DOM, following the same pattern already used by `DrawerContainer`.

**Hooks**

`useLayerContext()` returns the current `{ variant, depth, portalOutlet }`. `usePortalContainer()` returns the nearest Layer's portal outlet element for use with `createPortal`.

This is purely additive with no consumers — safe to merge with zero behavioral change.

## 🥞 Layer Primitive Series
- [ ] #114516 `nm/zindex/layer-primitive` — Layer component + hooks ← this PR
- [ ] #114520 `nm/zindex/dom-order` — DOM restructuring for paint-order stacking
- [ ] #114549 `nm/zindex/wire-portals` — Wire portal consumers to Layer outlets
- [ ] #115959 `nm/zindex/remove-structural-zindex` — Remove structural z-index refs
- [ ] #115957 `nm/zindex/remove-portal-zindex` — Remove portal z-index refs
- [ ] #115956 `nm/zindex/remove-local-zindex` — Replace local z-index refs with bare z-index: 1
- [ ] #115961 `nm/zindex/deprecate-zindex` — Deprecate theme.zIndex scale
- [ ] #115963 `nm/zindex/lint-ban` — Lint rule banning z-index/zIndex
- [ ] #115964 `nm/zindex/final-cleanup` — Remove theme.zIndex entirely

## Test plan
- [ ] Layer renders with `isolation: isolate` stacking context
- [ ] Portal outlet renders as `position: fixed; inset: 0; pointer-events: none`
- [ ] `usePortalContainer()` returns the nearest Layer's portal outlet
- [ ] Nested Layers accumulate depth correctly
- [ ] `pnpm test-ci static/app/components/core/layer/`