### PR TITLE
fix(onboarding): add upgrade suffix to SCM metrics tooltip

### DIFF
--- a/static/app/views/onboarding/components/useScmFeatureMeta.tsx
+++ b/static/app/views/onboarding/components/useScmFeatureMeta.tsx
@@ -83,7 +83,9 @@ export const FALLBACK_FEATURE_META: Record<ProductSolution, FeatureMeta> = {
       'Track application performance and usage over time with custom metrics'
     ),
     volume: t('5 GB / mo'),
-    volumeTooltip: t('Free plan includes 5 GB metrics / month'),
+    volumeTooltip: t(
+      'Free plan includes 5 GB metrics / month. Upgrade to Team or Business to send more.'
+    ),
   },
 };
 

--- a/static/gsApp/hooks/useScmFeatureMeta.tsx
+++ b/static/gsApp/hooks/useScmFeatureMeta.tsx
@@ -73,7 +73,11 @@ const DYNAMIC_FORMATS: Partial<Record<ProductSolution, DynamicCategoryFormat>> =
     formatQuantity: gigabytes =>
       formatReservedWithUnits(gigabytes, DataCategory.TRACE_METRIC_BYTE),
     formatVolume: quantity => t('%s / mo', quantity),
-    formatTooltip: quantity => t('Free plan includes %s metrics / month.', quantity),
+    formatTooltip: quantity =>
+      t(
+        'Free plan includes %s metrics / month. Upgrade to Team or Business to send more.',
+        quantity
+      ),
   },
 };
 


### PR DESCRIPTION
Aligns the Metrics card tooltip with the other SCM onboarding cards by appending "Upgrade to Team or Business to send more." Updated in both the gsApp billing-config-driven hook and the OSS `FALLBACK_FEATURE_META`.

## Test plan
- [ ] Hover the Application Metrics card on SCM onboarding; tooltip ends with "Upgrade to Team or Business to send more."