### PR TITLE
ref(🥞): restructure DOM order for paint-order stacking

### DIFF
--- a/static/app/components/core/drawer/components.tsx
+++ b/static/app/components/core/drawer/components.tsx
@@ -4,6 +4,7 @@ import {mergeRefs} from '@react-aria/utils';
 
 import {Button} from '@sentry/scraps/button';
 import type {DrawerOptions} from '@sentry/scraps/drawer';
+import {Layer} from '@sentry/scraps/layer';
 import {SlideOverPanel} from '@sentry/scraps/slideOverPanel';
 import {TooltipContext} from '@sentry/scraps/tooltip';
 
@@ -98,11 +99,13 @@ function DrawerPanel({
             For example: <DrawerHeader />, will trigger the custom onClose callback set in openDrawer
             when it's button is pressed.
           */}
-          <TooltipContext value={{container: tooltipContainer}}>
-            <DrawerContentContext value={{onClose, ariaLabel}}>
-              {children}
-            </DrawerContentContext>
-          </TooltipContext>
+          <Layer variant="overlay">
+            <TooltipContext value={{container: tooltipContainer}}>
+              <DrawerContentContext value={{onClose, ariaLabel}}>
+                {children}
+              </DrawerContentContext>
+            </TooltipContext>
+          </Layer>
         </DrawerSlidePanel>
       </DrawerWidthContext.Provider>
     </DrawerContainer>

--- a/static/app/components/core/drawer/components.tsx
+++ b/static/app/components/core/drawer/components.tsx
@@ -74,39 +74,43 @@ function DrawerPanel({
   return (
     <DrawerContainer mode={mode}>
       <DrawerWidthContext.Provider value={actualDrawerWidth}>
-        <DrawerSlidePanel
-          mode={mode}
-          ariaLabel={ariaLabel}
-          position="right"
-          ref={mergeRefs(panelRef, ref, (node: HTMLDivElement | null) =>
-            setTooltipContainer(node)
+        <Layer variant="overlay">
+          {({className: layerClassName}) => (
+            <DrawerSlidePanel
+              mode={mode}
+              ariaLabel={ariaLabel}
+              position="right"
+              ref={mergeRefs(panelRef, ref, (node: HTMLDivElement | null) =>
+                setTooltipContainer(node)
+              )}
+              panelWidth="var(--drawer-width)" // Initial width only
+              className={`drawer-panel ${layerClassName}`}
+            >
+              {drawerKey && enabled && (
+                <ResizeHandle
+                  ref={resizeHandleRef}
+                  onMouseDown={handleResizeStart}
+                  data-at-min-width={(
+                    persistedWidthPercent <= MIN_WIDTH_PERCENT
+                  ).toString()}
+                  data-at-max-width={(
+                    Math.abs(persistedWidthPercent - MAX_WIDTH_PERCENT) < 1
+                  ).toString()}
+                />
+              )}
+              {/*
+                This provider allows data passed to openDrawer to be accessed by drawer components.
+                For example: <DrawerHeader />, will trigger the custom onClose callback set in openDrawer
+                when it's button is pressed.
+              */}
+              <TooltipContext value={{container: tooltipContainer}}>
+                <DrawerContentContext value={{onClose, ariaLabel}}>
+                  {children}
+                </DrawerContentContext>
+              </TooltipContext>
+            </DrawerSlidePanel>
           )}
-          panelWidth="var(--drawer-width)" // Initial width only
-          className="drawer-panel"
-        >
-          {drawerKey && enabled && (
-            <ResizeHandle
-              ref={resizeHandleRef}
-              onMouseDown={handleResizeStart}
-              data-at-min-width={(persistedWidthPercent <= MIN_WIDTH_PERCENT).toString()}
-              data-at-max-width={(
-                Math.abs(persistedWidthPercent - MAX_WIDTH_PERCENT) < 1
-              ).toString()}
-            />
-          )}
-          {/*
-            This provider allows data passed to openDrawer to be accessed by drawer components.
-            For example: <DrawerHeader />, will trigger the custom onClose callback set in openDrawer
-            when it's button is pressed.
-          */}
-          <Layer variant="overlay">
-            <TooltipContext value={{container: tooltipContainer}}>
-              <DrawerContentContext value={{onClose, ariaLabel}}>
-                {children}
-              </DrawerContentContext>
-            </TooltipContext>
-          </Layer>
-        </DrawerSlidePanel>
+        </Layer>
       </DrawerWidthContext.Provider>
     </DrawerContainer>
   );

--- a/static/app/components/core/drawer/index.tsx
+++ b/static/app/components/core/drawer/index.tsx
@@ -213,6 +213,7 @@ export function GlobalDrawer({children}: any) {
 
   return (
     <DrawerContext value={{closeDrawer, activeDrawerId, openDrawer, panelRef}}>
+      {children}
       <ErrorBoundary
         mini
         allowDismiss
@@ -238,7 +239,6 @@ export function GlobalDrawer({children}: any) {
           )}
         </AnimatePresence>
       </ErrorBoundary>
-      {children}
     </DrawerContext>
   );
 }

--- a/static/app/components/core/modal/index.tsx
+++ b/static/app/components/core/modal/index.tsx
@@ -260,11 +260,17 @@ export function GlobalModal({onClose}: Props) {
                   role="dialog"
                   aria-modal
                   css={options.modalCss}
-                  initial={hasPageFrame ? {opacity: 0, scale: 0.98} : {opacity: 0, y: -10}}
+                  initial={
+                    hasPageFrame ? {opacity: 0, scale: 0.98} : {opacity: 0, y: -10}
+                  }
                   animate={hasPageFrame ? {opacity: 1, scale: 1} : {opacity: 1, y: 0}}
                   exit={
                     hasPageFrame
-                      ? {opacity: 0, scale: 0.99, transition: theme.motion.framer.exit.fast}
+                      ? {
+                          opacity: 0,
+                          scale: 0.99,
+                          transition: theme.motion.framer.exit.fast,
+                        }
                       : {opacity: 0, y: 15}
                   }
                   transition={

--- a/static/app/components/core/modal/index.tsx
+++ b/static/app/components/core/modal/index.tsx
@@ -7,6 +7,7 @@ import {createFocusTrap} from 'focus-trap';
 import {AnimatePresence, motion} from 'framer-motion';
 
 import {Backdrop} from '@sentry/scraps/backdrop';
+import {Layer} from '@sentry/scraps/layer';
 import {Surface} from '@sentry/scraps/layout';
 import {TooltipContext} from '@sentry/scraps/tooltip';
 import {useScrollLock} from '@sentry/scraps/useScrollLock';
@@ -245,47 +246,49 @@ export function GlobalModal({onClose}: Props) {
         style={{pointerEvents: visible ? 'auto' : 'none'}}
         onClick={backdrop ? clickClose : undefined}
       >
-        <TooltipContext
-          value={{
-            // To ensure tooltips within the modal remain interactive (e.g., clickable or selectable),
-            // they need to be rendered inside the modal's DOM node.
-            container: portal,
-          }}
-        >
-          <AnimatePresence>
-            {visible && (
-              <ModalDialog
-                role="dialog"
-                aria-modal
-                css={options.modalCss}
-                initial={hasPageFrame ? {opacity: 0, scale: 0.98} : {opacity: 0, y: -10}}
-                animate={hasPageFrame ? {opacity: 1, scale: 1} : {opacity: 1, y: 0}}
-                exit={
-                  hasPageFrame
-                    ? {opacity: 0, scale: 0.99, transition: theme.motion.framer.exit.fast}
-                    : {opacity: 0, y: 15}
-                }
-                transition={
-                  hasPageFrame
-                    ? theme.motion.framer.enter.moderate
-                    : {
-                        type: 'spring',
-                        stiffness: 450,
-                        damping: 25,
-                      }
-                }
-              >
-                <Surface variant="overlay" elevation="high">
-                  {p => (
-                    <ModalContent role="document" {...p}>
-                      {renderedChild}
-                    </ModalContent>
-                  )}
-                </Surface>
-              </ModalDialog>
-            )}
-          </AnimatePresence>
-        </TooltipContext>
+        <Layer variant="overlay">
+          <TooltipContext
+            value={{
+              // To ensure tooltips within the modal remain interactive (e.g., clickable or selectable),
+              // they need to be rendered inside the modal's DOM node.
+              container: portal,
+            }}
+          >
+            <AnimatePresence>
+              {visible && (
+                <ModalDialog
+                  role="dialog"
+                  aria-modal
+                  css={options.modalCss}
+                  initial={hasPageFrame ? {opacity: 0, scale: 0.98} : {opacity: 0, y: -10}}
+                  animate={hasPageFrame ? {opacity: 1, scale: 1} : {opacity: 1, y: 0}}
+                  exit={
+                    hasPageFrame
+                      ? {opacity: 0, scale: 0.99, transition: theme.motion.framer.exit.fast}
+                      : {opacity: 0, y: 15}
+                  }
+                  transition={
+                    hasPageFrame
+                      ? theme.motion.framer.enter.moderate
+                      : {
+                          type: 'spring',
+                          stiffness: 450,
+                          damping: 25,
+                        }
+                  }
+                >
+                  <Surface variant="overlay" elevation="high">
+                    {p => (
+                      <ModalContent role="document" {...p}>
+                        {renderedChild}
+                      </ModalContent>
+                    )}
+                  </Surface>
+                </ModalDialog>
+              )}
+            </AnimatePresence>
+          </TooltipContext>
+        </Layer>
       </ModalContainer>
     </Fragment>,
     portal

--- a/static/app/views/app/index.tsx
+++ b/static/app/views/app/index.tsx
@@ -223,10 +223,10 @@ export function App() {
       <AppProviders preloadData={preloadData}>
         <MainContainer tabIndex={-1}>
           <AppAlerts />
-          <GlobalModal />
-          <Indicators className="indicators-container" />
           <Override name="component:replay-init" />
           <ErrorBoundary>{renderBody()}</ErrorBoundary>
+          <GlobalModal />
+          <Indicators className="indicators-container" />
         </MainContainer>
       </AppProviders>
     </Profiler>

--- a/static/app/views/navigation/topBar.tsx
+++ b/static/app/views/navigation/topBar.tsx
@@ -26,7 +26,7 @@ import {
 
 const Slot = slot(['title', 'search', 'actions', 'feedback'] as const);
 
-function TopBarContent() {
+function TopBarContent({className}: {className?: string}) {
   const theme = useTheme();
   const hasPageFrame = useHasPageFrameFeature();
   const {barTop, contentTop} = useTopOffset();
@@ -56,6 +56,7 @@ function TopBarContent() {
 
   return (
     <Flex
+      className={className}
       height={{
         sm: `${NAVIGATION_MOBILE_TOPBAR_HEIGHT_WITH_PAGE_FRAME}px`,
         md: `${PRIMARY_HEADER_HEIGHT}px`,

--- a/static/app/views/organizationLayout/index.tsx
+++ b/static/app/views/organizationLayout/index.tsx
@@ -106,7 +106,11 @@ function AppLayout({organization}: LayoutProps) {
           position="relative"
         >
           <Layer variant="nav">
-            <Navigation />
+            {({className}) => (
+              <NavLayerContainer className={className}>
+                <Navigation />
+              </NavLayerContainer>
+            )}
           </Layer>
           {/* The `#main` selector is used to make the app content `inert` when an overlay is active */}
           <ContentStack
@@ -125,10 +129,12 @@ function AppLayout({organization}: LayoutProps) {
                     {({className}) => <TopBar className={className} />}
                   </Layer>
                   <Layer variant="content">
-                    <Layout.Page>
-                      <Outlet />
-                      <Footer />
-                    </Layout.Page>
+                    {({className}) => (
+                      <Layout.Page className={className}>
+                        <Outlet />
+                        <Footer />
+                      </Layout.Page>
+                    )}
                   </Layer>
                 </TopBar.Slot.Provider>
               </OrganizationDetailsBody>
@@ -140,6 +146,10 @@ function AppLayout({organization}: LayoutProps) {
     </PrimaryNavigationContextProvider>
   );
 }
+
+const NavLayerContainer = styled('div')`
+  display: flex;
+`;
 
 const ContentStack = styled(Stack)`
   &:focus-visible {

--- a/static/app/views/organizationLayout/index.tsx
+++ b/static/app/views/organizationLayout/index.tsx
@@ -116,21 +116,23 @@ function AppLayout({organization}: LayoutProps) {
             minWidth="0"
             background={hasPageFrame ? 'secondary' : undefined}
           >
-            <Layer variant="content">
-              <DemoHeader />
-              <AppBodyContent>
-                {organization && <OrganizationHeader organization={organization} />}
-                <OrganizationDetailsBody>
-                  <TopBar.Slot.Provider>
-                    <TopBar />
+            <DemoHeader />
+            <AppBodyContent>
+              {organization && <OrganizationHeader organization={organization} />}
+              <OrganizationDetailsBody>
+                <TopBar.Slot.Provider>
+                  <Layer variant="nav">
+                    {({className}) => <TopBar className={className} />}
+                  </Layer>
+                  <Layer variant="content">
                     <Layout.Page>
                       <Outlet />
                       <Footer />
                     </Layout.Page>
-                  </TopBar.Slot.Provider>
-                </OrganizationDetailsBody>
-              </AppBodyContent>
-            </Layer>
+                  </Layer>
+                </TopBar.Slot.Provider>
+              </OrganizationDetailsBody>
+            </AppBodyContent>
           </ContentStack>
         </Flex>
       </Stack>

--- a/static/app/views/organizationLayout/index.tsx
+++ b/static/app/views/organizationLayout/index.tsx
@@ -2,6 +2,7 @@ import {Outlet, ScrollRestoration} from 'react-router-dom';
 import styled from '@emotion/styled';
 
 import {GlobalDrawer} from '@sentry/scraps/drawer';
+import {Layer} from '@sentry/scraps/layer';
 import {Flex, Stack} from '@sentry/scraps/layout';
 
 import {DemoHeader} from 'sentry/components/demo/demoHeader';
@@ -113,19 +114,21 @@ function AppLayout({organization}: LayoutProps) {
             minWidth="0"
             background={hasPageFrame ? 'secondary' : undefined}
           >
-            <DemoHeader />
-            <AppBodyContent>
-              {organization && <OrganizationHeader organization={organization} />}
-              <OrganizationDetailsBody>
-                <TopBar.Slot.Provider>
-                  <TopBar />
-                  <Layout.Page>
-                    <Outlet />
-                    <Footer />
-                  </Layout.Page>
-                </TopBar.Slot.Provider>
-              </OrganizationDetailsBody>
-            </AppBodyContent>
+            <Layer variant="content">
+              <DemoHeader />
+              <AppBodyContent>
+                {organization && <OrganizationHeader organization={organization} />}
+                <OrganizationDetailsBody>
+                  <TopBar.Slot.Provider>
+                    <TopBar />
+                    <Layout.Page>
+                      <Outlet />
+                      <Footer />
+                    </Layout.Page>
+                  </TopBar.Slot.Provider>
+                </OrganizationDetailsBody>
+              </AppBodyContent>
+            </Layer>
           </ContentStack>
         </Flex>
       </Stack>

--- a/static/app/views/organizationLayout/index.tsx
+++ b/static/app/views/organizationLayout/index.tsx
@@ -105,7 +105,9 @@ function AppLayout({organization}: LayoutProps) {
           direction={{sm: 'column', md: 'row'}}
           position="relative"
         >
-          <Navigation />
+          <Layer variant="nav">
+            <Navigation />
+          </Layer>
           {/* The `#main` selector is used to make the app content `inert` when an overlay is active */}
           <ContentStack
             id="main"


### PR DESCRIPTION
## Summary

Move overlay elements (drawer, modal, indicators) after content in DOM order so they paint above content without relying solely on global z-index values. Wrap content area, drawer panel, and modal in Layer components to create isolated stacking contexts.

**DOM Reorder**

`GlobalDrawer` now renders its backdrop and panel *after* `{children}` instead of before. `GlobalModal` and `Indicators` now render after the `ErrorBoundary` content outlet. This makes DOM order agree with intended paint order — later siblings paint above earlier ones.

**Layer Wrappers**

Page content is wrapped in `<Layer variant="content">`, drawer panel content in `<Layer variant="overlay">`, and modal content in `<Layer variant="overlay">`. Each creates an isolated stacking context via `isolation: isolate`.

Existing z-index values and `TooltipContext` are kept as safety nets — they will be removed in later PRs once portal consumers are wired to Layer outlets.

## 🥞 Layer Primitive Series
- [x] #114516 `nm/zindex/layer-primitive` — Layer component + hooks
- [ ] #114520 `nm/zindex/dom-order` — DOM restructuring for paint-order stacking ← this PR
- [ ] #114549 `nm/zindex/wire-portals` — Wire portal consumers to Layer outlets
- [ ] #115959 `nm/zindex/remove-structural-zindex` — Remove structural z-index refs
- [ ] #115957 `nm/zindex/remove-portal-zindex` — Remove portal z-index refs
- [ ] #115956 `nm/zindex/remove-local-zindex` — Replace local z-index refs with bare z-index: 1
- [ ] #115961 `nm/zindex/deprecate-zindex` — Deprecate theme.zIndex scale
- [ ] #115963 `nm/zindex/lint-ban` — Lint rule banning z-index/zIndex
- [ ] #115964 `nm/zindex/final-cleanup` — Remove theme.zIndex entirely

## Test plan
- [ ] Drawer paints above content (DOM order, not z-index)
- [ ] Modal paints above drawer
- [ ] Tooltips still functional in all contexts
- [ ] Manual QA: open drawer, open modal, verify tooltip behavior in each context
- [ ] `pnpm run typecheck`