### PR TITLE
codemod(button-variant): apply changes for explore

### DIFF
--- a/static/app/utils/discover/teamKeyTransactionField.tsx
+++ b/static/app/utils/discover/teamKeyTransactionField.tsx
@@ -99,7 +99,7 @@ export function TeamKeyTransactionFieldWrapper({
     return (
       <Button
         disabled
-        priority="transparent"
+        variant="transparent"
         size="zero"
         icon={<IconStar variant="muted" />}
         aria-label={t('Toggle star for team')}

--- a/static/app/views/discover/landing.tsx
+++ b/static/app/views/discover/landing.tsx
@@ -220,7 +220,7 @@ function DiscoverLanding() {
                   data-test-id="build-new-query"
                   to={to}
                   size="sm"
-                  priority="primary"
+                  variant="primary"
                   onClick={() => {
                     trackAnalytics('discover_v2.build_new_query', {
                       organization,
@@ -263,7 +263,7 @@ function DiscoverLanding() {
                   <LinkButton
                     data-test-id="build-new-query"
                     to={to}
-                    priority="primary"
+                    variant="primary"
                     onClick={() => {
                       trackAnalytics('discover_v2.build_new_query', {
                         organization,

--- a/static/app/views/discover/queryList.tsx
+++ b/static/app/views/discover/queryList.tsx
@@ -122,7 +122,7 @@ class QueryList extends Component<Props> {
             {...triggerProps}
             aria-label={t('Query actions')}
             size="xs"
-            priority="transparent"
+            variant="transparent"
             onClick={e => {
               e.stopPropagation();
               e.preventDefault();

--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -652,7 +652,7 @@ export class Results extends Component<Props, State> {
                   this.setState({showQueryIncompatibleWithDataset: false});
                 }}
                 size="zero"
-                priority="transparent"
+                variant="transparent"
               />
             }
           >
@@ -725,7 +725,7 @@ export class Results extends Component<Props, State> {
                   this.setState({showTransactionsDeprecationAlert: false});
                 }}
                 size="zero"
-                priority="transparent"
+                variant="transparent"
               />
             }
           >

--- a/static/app/views/discover/results/sampleDataAlert.tsx
+++ b/static/app/views/discover/results/sampleDataAlert.tsx
@@ -48,7 +48,7 @@ export function SampleDataAlert({query}: {query?: string}) {
             'Based on your search criteria and sample rate, the events available may be limited because Discover uses sampled data only.'
           )}
           <DismissButton
-            priority="link"
+            variant="link"
             icon={<IconClose />}
             onClick={dismiss}
             aria-label={t('Dismiss Alert')}

--- a/static/app/views/discover/results/tags.tsx
+++ b/static/app/views/discover/results/tags.tsx
@@ -196,7 +196,7 @@ class Tags extends Component<Props, State> {
               <Flex direction="column" align="center">
                 <Button
                   size="xs"
-                  priority="primary"
+                  variant="primary"
                   disabled={loading}
                   aria-label={t('Show More')}
                   onClick={() => {

--- a/static/app/views/discover/savedQuery/index.tsx
+++ b/static/app/views/discover/savedQuery/index.tsx
@@ -120,7 +120,7 @@ export function SaveAsDropdown({
                     <SaveAsButton
                       type="submit"
                       onClick={modifiedHandleCreateQuery}
-                      priority="primary"
+                      variant="primary"
                       disabled={disabled || !queryName}
                     >
                       {t('Save for Organization')}

--- a/static/app/views/discover/table/columnEditCollection.tsx
+++ b/static/app/views/discover/table/columnEditCollection.tsx
@@ -530,7 +530,7 @@ class ColumnEditCollection extends Component<Props, State> {
                 tooltipProps={{title: t('Remove column')}}
                 onClick={() => this.removeColumn(i)}
                 icon={<IconDelete />}
-                priority="transparent"
+                variant="transparent"
               />
             ) : (
               <RemoveButton
@@ -538,7 +538,7 @@ class ColumnEditCollection extends Component<Props, State> {
                 aria-label={t('Remove column')}
                 onClick={() => this.removeColumn(i)}
                 icon={<IconDelete />}
-                priority="transparent"
+                variant="transparent"
               />
             )
           ) : singleColumn && showAliasField ? null : (

--- a/static/app/views/discover/table/columnEditModal.tsx
+++ b/static/app/views/discover/table/columnEditModal.tsx
@@ -176,10 +176,10 @@ export function ColumnEditModal(props: Props) {
       </Body>
       <Footer>
         <Grid flow="column" align="center" gap="md">
-          <LinkButton priority="default" href={DISCOVER2_DOCS_URL} external>
+          <LinkButton variant="secondary" href={DISCOVER2_DOCS_URL} external>
             {t('Read the Docs')}
           </LinkButton>
-          <Button aria-label={t('Apply')} priority="primary" onClick={handleApply}>
+          <Button aria-label={t('Apply')} variant="primary" onClick={handleApply}>
             {t('Apply')}
           </Button>
         </Grid>

--- a/static/app/views/discover/table/quickContext/actionDropdown.tsx
+++ b/static/app/views/discover/table/quickContext/actionDropdown.tsx
@@ -153,7 +153,7 @@ export function ActionDropDown(props: Props) {
           {...triggerProps}
           aria-label={t('Quick Context Action Menu')}
           data-test-id="quick-context-action-trigger"
-          priority="transparent"
+          variant="transparent"
           size="zero"
           onClick={e => {
             e.stopPropagation();

--- a/static/app/views/explore/components/attributeBreakdowns/attributeDistributionChart.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/attributeDistributionChart.tsx
@@ -108,7 +108,7 @@ export function Chart({
           </AttributeBreakdownsComponent.PopulationIndicator>
           <Button
             size="zero"
-            priority="transparent"
+            variant="transparent"
             icon={<IconExpand size="xs" />}
             aria-label={t('Expand chart')}
             onClick={() =>

--- a/static/app/views/explore/components/attributeBreakdowns/cohortComparisonChart.tsx
+++ b/static/app/views/explore/components/attributeBreakdowns/cohortComparisonChart.tsx
@@ -145,7 +145,7 @@ export function Chart({
           </AttributeBreakdownsComponent.PopulationIndicator>
           <Button
             size="zero"
-            priority="transparent"
+            variant="transparent"
             icon={<IconExpand size="xs" />}
             aria-label={t('Expand chart')}
             onClick={() =>

--- a/static/app/views/explore/components/toolbar/styles.tsx
+++ b/static/app/views/explore/components/toolbar/styles.tsx
@@ -22,10 +22,10 @@ export const ToolbarLabel = styled('h6')<{disabled?: boolean}>`
 
 export const ToolbarFooterButton = styled(Button)<{
   disabled?: boolean;
-  priority?: ButtonProps['priority'];
+  variant?: ButtonProps['variant'];
 }>`
   ${p =>
-    p.priority === 'link'
+    p.variant === 'link'
       ? css`
           color: ${p.disabled
             ? p.theme.tokens.content.disabled

--- a/static/app/views/explore/components/toolbar/toolbarGroupBy/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarGroupBy/index.tsx
@@ -118,7 +118,7 @@ export function ToolbarGroupByDropdown({
       {canDelete ? (
         <Button
           aria-label={t('Remove Column')}
-          priority="transparent"
+          variant="transparent"
           size="zero"
           icon={<IconDelete size="sm" />}
           onClick={() => onColumnDelete()}
@@ -126,7 +126,7 @@ export function ToolbarGroupByDropdown({
       ) : column.column ? (
         <Button
           aria-label={t('Clear Group By')}
-          priority="transparent"
+          variant="transparent"
           size="zero"
           icon={<IconDelete size="sm" />}
           onClick={() => onColumnChange('')}

--- a/static/app/views/explore/components/toolbar/toolbarGroupBy/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarGroupBy/index.tsx
@@ -147,7 +147,7 @@ export function ToolbarGroupByAddGroupBy({add, disabled}: ToolbarVisualizeAddPro
       size="zero"
       icon={<IconAdd />}
       onClick={add}
-      priority="link"
+      variant="link"
       aria-label={t('Add Group')}
       disabled={disabled}
     >

--- a/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
@@ -116,7 +116,7 @@ export function ToolbarVisualizeDropdown({
       )}
       {onDelete ? (
         <Button
-          priority="transparent"
+          variant="transparent"
           icon={<IconDelete />}
           size="zero"
           onClick={onDelete}

--- a/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
@@ -147,7 +147,7 @@ export function ToolbarVisualizeAddChart({
       size={display === 'link' ? 'zero' : size}
       icon={<IconAdd />}
       onClick={add}
-      priority={display === 'link' ? 'link' : undefined}
+      variant={display === 'link' ? 'link' : undefined}
       aria-label={label ?? t('Add Chart')}
       disabled={disabled}
     >
@@ -162,7 +162,7 @@ export function ToolbarVisualizeAddEquation({add, disabled}: ToolbarVisualizeAdd
       size="zero"
       icon={<IconAdd />}
       onClick={add}
-      priority="link"
+      variant="link"
       aria-label={t('Add Equation')}
       disabled={disabled}
     >

--- a/static/app/views/explore/components/toolbar/toolbarVisualize/visualizeEquation.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/visualizeEquation.tsx
@@ -113,7 +113,7 @@ export function VisualizeEquation({
       </Flex>
       {onDelete && (
         <Button
-          priority="transparent"
+          variant="transparent"
           icon={<IconDelete />}
           size="zero"
           onClick={onDelete}

--- a/static/app/views/explore/logs/exports/logsExportModal.tsx
+++ b/static/app/views/explore/logs/exports/logsExportModal.tsx
@@ -149,7 +149,7 @@ export function LogsExportModal({
       <Footer>
         <Flex gap="xl" justify="end">
           <Button
-            priority="default"
+            variant="secondary"
             onClick={() => {
               trackAnalytics('logs.export_modal', {
                 organization,

--- a/static/app/views/explore/logs/exports/logsExportModalButton.tsx
+++ b/static/app/views/explore/logs/exports/logsExportModalButton.tsx
@@ -42,7 +42,7 @@ export function LogsExportModalButton({
     <Button
       disabled={!!disabledTooltip}
       size="xs"
-      priority="default"
+      variant="secondary"
       icon={<IconDownload />}
       onClick={() => {
         trackAnalytics('logs.export_modal', {

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -202,7 +202,7 @@ const LogsSearchSection = memo(function LogsSearchSection({
                 trigger={triggerProps => (
                   <Button
                     {...triggerProps}
-                    priority="primary"
+                    variant="primary"
                     aria-label={t('Save as')}
                     onClick={e => {
                       e.stopPropagation();

--- a/static/app/views/explore/logs/tables/logsEmptyResults.tsx
+++ b/static/app/views/explore/logs/tables/logsEmptyResults.tsx
@@ -43,7 +43,7 @@ export function LogsEmptyResults({
           </EmptyStateText>
           <Container paddingTop="md">
             <Button
-              priority="default"
+              variant="secondary"
               onClick={() => {
                 trackAnalytics('logs.explorer.continue_searching_clicked', {
                   bytes_scanned: bytesScanned,

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -614,7 +614,7 @@ function LogRowDetailsFilterActions({tableDataRow}: {tableDataRow: LogTableRowIt
   return (
     <LogDetailTableActionsButtonBar>
       <Button
-        priority="transparent"
+        variant="transparent"
         size="sm"
         icon={<IconAdd />}
         onClick={() => {
@@ -627,7 +627,7 @@ function LogRowDetailsFilterActions({tableDataRow}: {tableDataRow: LogTableRowIt
         {t('Add to filter')}
       </Button>
       <Button
-        priority="transparent"
+        variant="transparent"
         size="sm"
         icon={<IconSubtract />}
         onClick={() => {
@@ -685,7 +685,7 @@ function LogRowDetailsActions({
       )}
       <LogDetailTableActionsButtonBar>
         <Button
-          priority="transparent"
+          variant="transparent"
           size="sm"
           icon={<IconJson />}
           onClick={betterCopyToClipboard}

--- a/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTableRow.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricsSamplesTableRow.tsx
@@ -114,7 +114,7 @@ export function SampleTableRow({
         aria-label={t('Toggle trace details')}
         aria-expanded={isExpanded}
         size={embedded ? 'zero' : 'sm'}
-        priority="transparent"
+        variant="transparent"
         onClick={() => setIsExpanded(!isExpanded)}
       />
     );

--- a/static/app/views/explore/metrics/metricToolbar/deleteMetricButton.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/deleteMetricButton.tsx
@@ -9,7 +9,7 @@ export function DeleteMetricButton({disabledReason}: {disabledReason?: string}) 
 
   return (
     <Button
-      priority="transparent"
+      variant="transparent"
       icon={<IconDelete />}
       size="zero"
       onClick={removeMetric}

--- a/static/app/views/explore/metrics/metricToolbar/metricSaveAs.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/metricSaveAs.tsx
@@ -22,7 +22,7 @@ export function MetricSaveAs({size = 'sm'}: MetricSaveAsProps) {
     return (
       <Button
         size={size}
-        priority="primary"
+        variant="primary"
         onClick={item.onAction}
         aria-label={item.textValue}
       >
@@ -38,7 +38,7 @@ export function MetricSaveAs({size = 'sm'}: MetricSaveAsProps) {
         <Button
           {...triggerProps}
           size={size}
-          priority="primary"
+          variant="primary"
           aria-label={t('Save as')}
           onClick={e => {
             e.stopPropagation();

--- a/static/app/views/explore/multiQueryMode/content.tsx
+++ b/static/app/views/explore/multiQueryMode/content.tsx
@@ -168,7 +168,7 @@ function Content({datePageFilterProps}: ContentProps) {
             trigger={triggerProps => (
               <Button
                 {...triggerProps}
-                priority={shouldHighlightSaveButton ? 'primary' : 'default'}
+                variant={shouldHighlightSaveButton ? 'primary' : 'secondary'}
                 aria-label={t('Save')}
                 onClick={e => {
                   e.stopPropagation();

--- a/static/app/views/explore/releases/detail/commitsAndFiles/emptyState.tsx
+++ b/static/app/views/explore/releases/detail/commitsAndFiles/emptyState.tsx
@@ -50,7 +50,7 @@ export function NoRepositories({orgSlug}: {orgSlug: string}) {
             icon={<IconCommit />}
             title={t('Releases are better with commit data!')}
             action={
-              <LinkButton priority="primary" to={`/settings/${orgSlug}/repos/`}>
+              <LinkButton variant="primary" to={`/settings/${orgSlug}/repos/`}>
                 {t('Connect a repository')}
               </LinkButton>
             }

--- a/static/app/views/explore/releases/detail/overview/releaseArchivedNotice.tsx
+++ b/static/app/views/explore/releases/detail/overview/releaseArchivedNotice.tsx
@@ -22,7 +22,7 @@ export function ReleaseArchivedNotice({onRestore, multi}: Props) {
         {!multi && onRestore && (
           <Fragment>
             {' '}
-            <UnarchiveButton size="zero" priority="link" onClick={onRestore}>
+            <UnarchiveButton size="zero" variant="link" onClick={onRestore}>
               {t('Restore this release')}
             </UnarchiveButton>
           </Fragment>

--- a/static/app/views/explore/releases/detail/overview/releaseComparisonChart/index.tsx
+++ b/static/app/views/explore/releases/detail/overview/releaseComparisonChart/index.tsx
@@ -1124,7 +1124,7 @@ export function ReleaseComparisonChart({
             </ShowMoreTitle>
             <Flex justify="end" align="center" column="2 / -1">
               <Button
-                priority="transparent"
+                variant="transparent"
                 size="zero"
                 icon={<IconChevron direction={isOtherExpanded ? 'up' : 'down'} />}
                 aria-label={t('Toggle additional charts')}

--- a/static/app/views/explore/releases/detail/overview/releaseComparisonChart/releaseComparisonChartRow.tsx
+++ b/static/app/views/explore/releases/detail/overview/releaseComparisonChart/releaseComparisonChartRow.tsx
@@ -100,7 +100,7 @@ export function ReleaseComparisonChartRow({
           {role === 'parent' && (
             <ToggleButton
               onClick={() => onExpanderToggle(type)}
-              priority="transparent"
+              variant="transparent"
               size="zero"
               icon={<IconChevron direction={expanded ? 'up' : 'down'} />}
               aria-label={t('Toggle chart group')}

--- a/static/app/views/explore/releases/detail/overview/sidebar/commitAuthorBreakdown.tsx
+++ b/static/app/views/explore/releases/detail/overview/sidebar/commitAuthorBreakdown.tsx
@@ -92,7 +92,7 @@ export function CommitAuthorBreakdown({orgId, projectSlug, version}: Props) {
       <SidebarSection.Content>
         <Collapsible
           expandButton={({onExpand, numberOfHiddenItems}) => (
-            <Button priority="link" onClick={onExpand}>
+            <Button variant="link" onClick={onExpand}>
               {tn('Show %s other author', 'Show %s other authors', numberOfHiddenItems)}
             </Button>
           )}

--- a/static/app/views/explore/releases/detail/overview/sidebar/otherProjects.tsx
+++ b/static/app/views/explore/releases/detail/overview/sidebar/otherProjects.tsx
@@ -32,7 +32,7 @@ export function OtherProjects({projects, location, version, organization}: Props
       <SidebarSection.Content>
         <Collapsible
           expandButton={({onExpand, numberOfHiddenItems}) => (
-            <Button priority="link" onClick={onExpand}>
+            <Button variant="link" onClick={onExpand}>
               {tn(
                 'Show %s collapsed project',
                 'Show %s collapsed projects',

--- a/static/app/views/explore/releases/list/releaseCard/index.tsx
+++ b/static/app/views/explore/releases/list/releaseCard/index.tsx
@@ -234,14 +234,14 @@ export function ReleaseCard({
           <Collapsible
             expandButton={({onExpand, numberOfHiddenItems}) => (
               <ExpandButtonWrapper>
-                <Button priority="primary" size="xs" onClick={onExpand}>
+                <Button variant="primary" size="xs" onClick={onExpand}>
                   {tct('Show [numberOfHiddenItems] More', {numberOfHiddenItems})}
                 </Button>
               </ExpandButtonWrapper>
             )}
             collapseButton={({onCollapse}) => (
               <Flex justify="center" align="center" height="41px">
-                <Button priority="primary" size="xs" onClick={onCollapse}>
+                <Button variant="primary" size="xs" onClick={onCollapse}>
                   {t('Collapse')}
                 </Button>
               </Flex>

--- a/static/app/views/explore/savedQueries/savedQueriesLandingContent.tsx
+++ b/static/app/views/explore/savedQueries/savedQueriesLandingContent.tsx
@@ -87,7 +87,7 @@ export function SavedQueriesLandingContent() {
             trigger={triggerProps => (
               <Button
                 {...triggerProps}
-                priority="primary"
+                variant="primary"
                 icon={<IconAdd />}
                 size="md"
                 aria-label={t('Create Query')}
@@ -104,7 +104,7 @@ export function SavedQueriesLandingContent() {
           />
         ) : (
           <LinkButton
-            priority="primary"
+            variant="primary"
             icon={<IconAdd />}
             size="md"
             to={getExploreUrl({organization, visualize: []})}

--- a/static/app/views/explore/spans/extrapolationEnabledAlert.tsx
+++ b/static/app/views/explore/spans/extrapolationEnabledAlert.tsx
@@ -26,7 +26,7 @@ export function ExtrapolationEnabledAlert() {
             </ExternalLink>
           ),
           toggle: (
-            <Button priority="link" onClick={() => setExtrapolate(true)}>
+            <Button variant="link" onClick={() => setExtrapolate(true)}>
               {t('Re-enable')}
             </Button>
           ),

--- a/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
+++ b/static/app/views/explore/tables/aggregateColumnEditorModal.tsx
@@ -177,10 +177,10 @@ export function AggregateColumnEditorModal({
           </Body>
           <Footer data-test-id="editor-footer">
             <Grid flow="column" align="center" gap="md">
-              <LinkButton priority="default" href={SPAN_PROPS_DOCS_URL} external>
+              <LinkButton variant="secondary" href={SPAN_PROPS_DOCS_URL} external>
                 {t('Read the Docs')}
               </LinkButton>
-              <Button aria-label={t('Apply')} priority="primary" onClick={handleApply}>
+              <Button aria-label={t('Apply')} variant="primary" onClick={handleApply}>
                 {t('Apply')}
               </Button>
             </Grid>
@@ -252,7 +252,7 @@ function ColumnEditorRow({
       )}
       <StyledButton
         aria-label={t('Remove Column')}
-        priority="transparent"
+        variant="transparent"
         disabled={!canDelete}
         size="sm"
         icon={<IconDelete size="sm" />}

--- a/static/app/views/explore/tables/columnEditorModal.tsx
+++ b/static/app/views/explore/tables/columnEditorModal.tsx
@@ -195,7 +195,7 @@ export function ColumnEditorModal({
           <Footer data-test-id="editor-footer">
             <Grid flow="column" align="center" gap="md">
               {!isDocsButtonHidden && (
-                <LinkButton priority="default" href={SPAN_PROPS_DOCS_URL} external>
+                <LinkButton variant="secondary" href={SPAN_PROPS_DOCS_URL} external>
                   {t('Read the Docs')}
                 </LinkButton>
               )}
@@ -210,7 +210,7 @@ export function ColumnEditorModal({
                   {t('Reset')}
                 </Button>
               ) : null}
-              <Button aria-label={t('Apply')} priority="primary" onClick={handleApply}>
+              <Button aria-label={t('Apply')} variant="primary" onClick={handleApply}>
                 {t('Apply')}
               </Button>
             </Grid>
@@ -304,7 +304,7 @@ function ColumnEditorRow({
       />
       <StyledButton
         aria-label={t('Remove Column')}
-        priority="transparent"
+        variant="transparent"
         disabled={!canDelete || required}
         size="sm"
         icon={<IconDelete size="sm" />}

--- a/static/app/views/explore/tables/tracesTable/index.tsx
+++ b/static/app/views/explore/tables/tracesTable/index.tsx
@@ -207,7 +207,7 @@ function TraceRow({
           aria-label={t('Toggle trace details')}
           aria-expanded={expanded}
           size="zero"
-          priority="transparent"
+          variant="transparent"
           onClick={() =>
             trackAnalytics('trace_explorer.toggle_trace_details', {
               organization,

--- a/static/app/views/explore/toolbar/toolbarSaveAs.tsx
+++ b/static/app/views/explore/toolbar/toolbarSaveAs.tsx
@@ -296,7 +296,7 @@ export function ToolbarSaveAs() {
           trigger={triggerProps => (
             <SaveAsButton
               {...triggerProps}
-              priority={shouldHighlightSaveButton ? 'primary' : 'default'}
+              variant={shouldHighlightSaveButton ? 'primary' : 'secondary'}
               aria-label={t('Save as')}
               onClick={e => {
                 e.stopPropagation();


### PR DESCRIPTION
Applies the [`button-variant` codemod](https://github.com/getsentry/design-engineering/tree/main/codemods/button-variant) to files owned by `@getsentry/explore`.