### PR TITLE
codemod(button-variant): apply changes for enterprise

### DIFF
--- a/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.tsx
+++ b/static/app/views/organizationStats/teamInsights/teamAlertsTriggered.tsx
@@ -160,7 +160,7 @@ export function TeamAlertsTriggered({
         emptyAction={
           <ButtonsContainer>
             <LinkButton
-              priority="primary"
+              variant="primary"
               size="sm"
               to={makeAlertsPathname({
                 path: '/rules/',

--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -708,7 +708,7 @@ function SpansStored({organization, acceptedStored}: SpansStoredProps) {
       {organization.access.includes('org:read') &&
         hasDynamicSamplingCustomFeature(organization) && (
           <StyledSettingsButton
-            priority="transparent"
+            variant="transparent"
             size="zero"
             icon={<IconSettings variant="muted" />}
             tooltipProps={{title: t('Dynamic Sampling Settings')}}


### PR DESCRIPTION
Applies the [`button-variant` codemod](https://github.com/getsentry/design-engineering/tree/main/codemods/button-variant) to files owned by `@getsentry/enterprise`.