### PR TITLE
codemod(button-variant): apply changes for revenue

### DIFF
--- a/static/app/views/admin/adminRelays.tsx
+++ b/static/app/views/admin/adminRelays.tsx
@@ -51,7 +51,7 @@ export default function AdminRelays() {
             message={t('Are you sure you wish to delete this relay?')}
             onConfirm={() => onDelete(row.id)}
           >
-            <Button priority="danger" size="sm" icon={<IconDelete />}>
+            <Button variant="danger" size="sm" icon={<IconDelete />}>
               {t('Remove Relay')}
             </Button>
           </Confirm>

--- a/static/app/views/admin/adminUserEdit.tsx
+++ b/static/app/views/admin/adminUserEdit.tsx
@@ -106,7 +106,7 @@ function RemoveUserModal({user, onRemove, closeModal}: RemoveModalProps) {
         ]}
       />
       <ModalFooter>
-        <Button priority="danger" onClick={handleRemove}>
+        <Button variant="danger" onClick={handleRemove}>
           {REMOVE_BUTTON_LABEL[deleteType]}
         </Button>
         <Button onClick={closeModal}>{t('Cancel')}</Button>
@@ -199,7 +199,7 @@ function AdminUserEdit() {
           <Button
             onClick={openDeleteModal}
             style={{marginLeft: theme.space.md}}
-            priority="danger"
+            variant="danger"
           >
             {t('Remove User')}
           </Button>

--- a/static/gsApp/components/ai/AiSetupDataConsent.tsx
+++ b/static/gsApp/components/ai/AiSetupDataConsent.tsx
@@ -176,7 +176,7 @@ export function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
                     <Flex>
                       {userHasBillingAccess ? (
                         <AddBudgetButton
-                          priority="primary"
+                          variant="primary"
                           onClick={() => {
                             handleAddBudget();
                             autofixAcknowledgeMutation.mutate();
@@ -189,7 +189,7 @@ export function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
                         </AddBudgetButton>
                       ) : (
                         <Button
-                          priority="primary"
+                          variant="primary"
                           onClick={async () => {
                             await sendAddEventsRequest({
                               api,
@@ -212,14 +212,14 @@ export function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
                           addSuccessMessage(t('Refreshed Seer quota'));
                         }}
                         size="md"
-                        priority="default"
+                        variant="secondary"
                         aria-label={t('Refresh')}
                       />
                     </Flex>
                   </Flex>
                 ) : (
                   <Button
-                    priority="primary"
+                    variant="primary"
                     onClick={() => {
                       autofixAcknowledgeMutation.mutate();
                       handlePurchaseSeer();
@@ -253,7 +253,7 @@ export function AiSetupDataConsent({groupId}: AiSetupDataConsentProps) {
           <Fragment>
             <Flex align="center" gap="md">
               <Button
-                priority="primary"
+                variant="primary"
                 onClick={() => autofixAcknowledgeMutation.mutate()}
                 disabled={autofixAcknowledgeMutation.isPending}
                 analyticsEventKey="gen_ai_consent.in_drawer_clicked"

--- a/static/gsApp/components/ai/aiSetupConfiguration.tsx
+++ b/static/gsApp/components/ai/aiSetupConfiguration.tsx
@@ -65,7 +65,7 @@ function AutofixConfigureQuota() {
               {hasAccessToSubscriptionOverview(subscription, organization) ? (
                 <LinkButton
                   to={`/settings/${organization.slug}/billing/overview/?product=seer`}
-                  priority="primary"
+                  variant="primary"
                   icon={<IconUpgrade />}
                 >
                   {t('Try Out Seer Now')}

--- a/static/gsApp/components/billingDetails/panel.tsx
+++ b/static/gsApp/components/billingDetails/panel.tsx
@@ -118,7 +118,7 @@ export function BillingDetailsPanel({
             }}
             extraButton={
               <Button
-                priority="default"
+                variant="secondary"
                 size="sm"
                 onClick={() => {
                   setIsEditing(false);
@@ -171,7 +171,7 @@ export function BillingDetailsPanel({
       </Flex>
       {!isEditing && (
         <Button
-          priority="default"
+          variant="secondary"
           size="sm"
           onClick={() => setIsEditing(true)}
           aria-label={t('Edit business address')}

--- a/static/gsApp/components/creditCardEdit/panel.tsx
+++ b/static/gsApp/components/creditCardEdit/panel.tsx
@@ -127,7 +127,7 @@ export function CreditCardPanel({
       </Flex>
       {!isEditing && (
         <Button
-          priority="default"
+          variant="secondary"
           size="sm"
           onClick={() => setIsEditing(true)}
           aria-label={t('Edit payment method')}

--- a/static/gsApp/components/dataConsentBanner.tsx
+++ b/static/gsApp/components/dataConsentBanner.tsx
@@ -84,7 +84,7 @@ function DataConsentBanner({
         analyticsEventName="Data Consent Banner: Dismissed"
         analyticsParams={{source}}
         size="zero"
-        priority="transparent"
+        variant="transparent"
         icon={<IconClose size="xs" />}
         aria-label={t('Dismiss')}
         onClick={() => dismissPrompt()}

--- a/static/gsApp/components/dataConsentModal.tsx
+++ b/static/gsApp/components/dataConsentModal.tsx
@@ -45,7 +45,7 @@ export default function DataConsentModal({closeModal}: ModalRenderProps) {
         analyticsEventKey="data_consent_banner.dismissed"
         analyticsEventName="Data Consent Banner: Dismissed"
         size="zero"
-        priority="transparent"
+        variant="transparent"
         icon={<IconClose size="xs" />}
         aria-label={t('Dismiss')}
         onClick={() => closeModal()}
@@ -139,7 +139,7 @@ export default function DataConsentModal({closeModal}: ModalRenderProps) {
           onClick={() => {
             updateOrganizationOption();
           }}
-          priority="primary"
+          variant="primary"
           busy={isPending}
         >
           {t('I agree')}

--- a/static/gsApp/components/dataConsentPriorityLearnMore.tsx
+++ b/static/gsApp/components/dataConsentPriorityLearnMore.tsx
@@ -71,7 +71,7 @@ function DataConsentPriorityLearnMore({subscription}: {subscription?: Subscripti
         analyticsEventKey="data_consent_priority.dismiss"
         analyticsEventName="Data Consent Priority: Dismiss"
         size="zero"
-        priority="transparent"
+        variant="transparent"
         icon={<IconClose size="xs" />}
         aria-label={t('Dismiss')}
         onClick={() => dismissPrompt()}

--- a/static/gsApp/components/features/disabledAlertWizard.tsx
+++ b/static/gsApp/components/features/disabledAlertWizard.tsx
@@ -27,7 +27,7 @@ export function DisabledAlertWizard({organization}: Props) {
         >
           {t('Learn More')}
         </Button>
-        <Button priority="primary" disabled>
+        <Button variant="primary" disabled>
           {t('Set Conditions')}
         </Button>
       </Grid>

--- a/static/gsApp/components/features/disabledAuthProvider.tsx
+++ b/static/gsApp/components/features/disabledAuthProvider.tsx
@@ -46,7 +46,7 @@ export function DisabledAuthProvider({
               renderInstallButton: p => (
                 <Button
                   size="sm"
-                  priority="primary"
+                  variant="primary"
                   icon={<IconBusiness />}
                   onClick={() =>
                     openUpsellModal({

--- a/static/gsApp/components/features/disabledCustomInboundFilters.tsx
+++ b/static/gsApp/components/features/disabledCustomInboundFilters.tsx
@@ -42,7 +42,7 @@ function DisabledAlert({organization, features}: Props) {
             )}
             <Button
               size="sm"
-              priority="primary"
+              variant="primary"
               icon={<IconBusiness />}
               onClick={() =>
                 openUpsellModal({

--- a/static/gsApp/components/features/disabledDataForwarding.tsx
+++ b/static/gsApp/components/features/disabledDataForwarding.tsx
@@ -30,7 +30,7 @@ export function DisabledDataForwarding({organization, features}: Props) {
             action={
               <ButtonGroup>
                 <Button
-                  priority="primary"
+                  variant="primary"
                   icon={<IconBusiness />}
                   onClick={() =>
                     openUpsellModal({organization, source: 'feature.data_forwarding'})

--- a/static/gsApp/components/features/disabledDiscardGroup.tsx
+++ b/static/gsApp/components/features/disabledDiscardGroup.tsx
@@ -28,7 +28,7 @@ export function DisabledDiscardGroup({organization, features}: Props) {
             <ButtonGroup>
               <Button
                 size="sm"
-                priority="primary"
+                variant="primary"
                 icon={<IconBusiness />}
                 onClick={() =>
                   openUpsellModal({

--- a/static/gsApp/components/features/disabledRateLimits.tsx
+++ b/static/gsApp/components/features/disabledRateLimits.tsx
@@ -38,7 +38,7 @@ function DisabledAlert({organization, features}: Props) {
             </span>
             <Button
               size="sm"
-              priority="primary"
+              variant="primary"
               icon={<IconBusiness />}
               data-test-id="rate-limit-upsell"
               onClick={() =>

--- a/static/gsApp/components/features/pageUpsellOverlay.tsx
+++ b/static/gsApp/components/features/pageUpsellOverlay.tsx
@@ -77,7 +77,7 @@ function PageUpsellOverlay({
                   triggerMemberRequests
                 >
                   {({defaultButtonText, onClick}) => (
-                    <Button priority="primary" size="sm" onClick={onClick}>
+                    <Button variant="primary" size="sm" onClick={onClick}>
                       {defaultButtonText}
                     </Button>
                   )}

--- a/static/gsApp/components/features/performanceNewProjectPrompt.tsx
+++ b/static/gsApp/components/features/performanceNewProjectPrompt.tsx
@@ -24,7 +24,7 @@ export function PerformanceNewProjectPrompt({organization}: Props) {
           )}
           <StyledButton
             size="sm"
-            priority="primary"
+            variant="primary"
             icon={<IconBusiness />}
             onClick={() =>
               openUpsellModal({

--- a/static/gsApp/components/features/projectPerformanceScoreCard.tsx
+++ b/static/gsApp/components/features/projectPerformanceScoreCard.tsx
@@ -13,7 +13,7 @@ export function ProjectPerformanceScoreCard({organization}: Props) {
   return (
     <Button
       size="sm"
-      priority="primary"
+      variant="primary"
       onClick={() => openUpsellModal({organization, source: 'project-details'})}
     >
       {t('Learn More')}

--- a/static/gsApp/components/forcedTrialModal.tsx
+++ b/static/gsApp/components/forcedTrialModal.tsx
@@ -135,7 +135,7 @@ function ForcedTrialModal(props: ForcedTrialModalProps) {
           >
             {hasBillingScope ? t('Upgrade') : t('Request Upgrade')}
           </UpgradeOrTrialButton>
-          <Button data-test-id="maybe-later" priority="default" onClick={closeModal}>
+          <Button data-test-id="maybe-later" variant="secondary" onClick={closeModal}>
             {t('Continue with Trial')}
           </Button>
         </StyledButtonBar>

--- a/static/gsApp/components/gsBanner.tsx
+++ b/static/gsApp/components/gsBanner.tsx
@@ -272,7 +272,7 @@ function NoticeModal({
       <Footer>
         <Button onClick={() => closeModalDoNotContinue()}>{t('Remind Me Later')}</Button>
         <Button
-          priority="primary"
+          variant="primary"
           onClick={() => closeModalAndContinue(link)}
           style={{marginLeft: theme.space.xl}}
           data-test-id="modal-continue-button"
@@ -965,7 +965,7 @@ class GSBanner extends Component<Props, State> {
                       <LinkButton
                         to={billingUrl}
                         size="zero"
-                        priority="default"
+                        variant="secondary"
                         aria-label={t('Update payment information')}
                         onClick={addButtonAnalytics}
                       />
@@ -979,7 +979,7 @@ class GSBanner extends Component<Props, State> {
                       <LinkButton
                         to={membersPageUrl}
                         size="zero"
-                        priority="default"
+                        variant="secondary"
                         aria-label={t('Org Owner or Billing Member')}
                         onClick={addButtonAnalytics}
                       />
@@ -1022,14 +1022,14 @@ class GSBanner extends Component<Props, State> {
                     to={checkoutUrl}
                     onClick={this.handleUpgradeLinkClick}
                     size="xs"
-                    priority="primary"
+                    variant="primary"
                   >
                     {t('Upgrade')}
                   </LinkButton>
                   <Button
                     onClick={this.handleSnoozeMemberDeactivatedAlert}
                     size="xs"
-                    priority="default"
+                    variant="secondary"
                     tooltipProps={{
                       title: t(
                         'You can also resolve this warning by removing the deactivated members from your organization'

--- a/static/gsApp/components/memberInviteModalCustomization.tsx
+++ b/static/gsApp/components/memberInviteModalCustomization.tsx
@@ -78,7 +78,7 @@ function MemberInviteModalCustomization({
         source="member_invite_modal"
         subscription={subscription}
         organization={organization}
-        upgradePriority="default"
+        upgradePriority="secondary"
       />
     );
 

--- a/static/gsApp/components/metricAlertQuotaMessage.tsx
+++ b/static/gsApp/components/metricAlertQuotaMessage.tsx
@@ -15,7 +15,7 @@ function UpgradeLink({children}: {children?: React.ReactNode}) {
 
   return (
     <Button
-      priority="link"
+      variant="link"
       onClick={() => {
         openUpsellModal({
           organization,

--- a/static/gsApp/components/navBillingStatus.tsx
+++ b/static/gsApp/components/navBillingStatus.tsx
@@ -159,7 +159,7 @@ function QuotaExceededContent({
           </Description>
           <Flex justify="between" align="center">
             <LinkButton
-              priority="primary"
+              variant="primary"
               href="mailto:sales@sentry.io"
               external
               size="xs"
@@ -204,7 +204,7 @@ function QuotaExceededContent({
           </Description>
           <Flex justify="start" align="center">
             <LinkButton
-              priority="primary"
+              variant="primary"
               href="mailto:sales@sentry.io"
               external
               size="xs"

--- a/static/gsApp/components/partnerPlanEndingBanner.tsx
+++ b/static/gsApp/components/partnerPlanEndingBanner.tsx
@@ -76,7 +76,7 @@ export function PartnerPlanEndingBanner({
             )}
           </div>
           <LinkButton
-            priority="primary"
+            variant="primary"
             analyticsEventKey="partner_plan_ending_banner.manage_subscription"
             analyticsEventName="Partner Plan Ending Banner: Manage Subscription"
             size="md"

--- a/static/gsApp/components/partnerPlanEndingModal.tsx
+++ b/static/gsApp/components/partnerPlanEndingModal.tsx
@@ -151,7 +151,7 @@ function PartnerPlanEndingModal({organization, subscription, closeModal}: Props)
         </Flex>
         <div style={{display: 'block'}}>
           <StyledButtonBar>
-            <Button data-test-id="maybe-later" priority="default" onClick={closeModal}>
+            <Button data-test-id="maybe-later" variant="secondary" onClick={closeModal}>
               {t('Remind Me Later')}
             </Button>
             {hasBillingAccess ? (
@@ -159,7 +159,7 @@ function PartnerPlanEndingModal({organization, subscription, closeModal}: Props)
                 size="md"
                 to={`/checkout/${organization.slug}/?referrer=partner_plan_ending_modal`}
                 aria-label="Upgrade Now"
-                priority="primary"
+                variant="primary"
                 onClick={() =>
                   trackGetsentryAnalytics('partner_billing_migration.modal.clicked_cta', {
                     subscription,
@@ -175,7 +175,7 @@ function PartnerPlanEndingModal({organization, subscription, closeModal}: Props)
               <Button
                 size="md"
                 aria-label="Request to Upgrade"
-                priority="primary"
+                variant="primary"
                 onClick={handleRequest}
               >
                 {t('Request to Upgrade')}

--- a/static/gsApp/components/powerFeatureHovercard.tsx
+++ b/static/gsApp/components/powerFeatureHovercard.tsx
@@ -104,7 +104,7 @@ function PowerFeatureHovercard({
                   : t('Requires %s Plan', planName)}
               </div>
               <Button
-                priority="primary"
+                variant="primary"
                 onClick={handleClick}
                 data-test-id="power-learn-more"
                 size="xs"

--- a/static/gsApp/components/primaryNavSeerConfigReminder.tsx
+++ b/static/gsApp/components/primaryNavSeerConfigReminder.tsx
@@ -136,7 +136,7 @@ export function PrimaryNavSeerConfigReminder() {
               <LinkButton
                 size="sm"
                 to={`/settings/${organization.slug}/seer/`}
-                priority="primary"
+                variant="primary"
                 onClick={() => state.close()}
                 analyticsEventName="Seer Config Reminder: Configure Now Clicked"
                 analyticsParams={analyticsParams}

--- a/static/gsApp/components/productTrial/productTrialAlert.tsx
+++ b/static/gsApp/components/productTrial/productTrialAlert.tsx
@@ -132,7 +132,7 @@ export function ProductTrialAlert(props: ProductTrialAlertProps) {
             hasBillingRole ? UsageAction.ADD_EVENTS : UsageAction.REQUEST_ADD_EVENTS
           }
           buttonProps={{
-            priority: 'default',
+            variant: 'secondary',
             size: 'xs',
             style: {marginBlock: '-2px'},
           }}
@@ -165,7 +165,7 @@ export function ProductTrialAlert(props: ProductTrialAlertProps) {
           </Button>
         ) : (
           <Button
-            priority="primary"
+            variant="primary"
             onClick={() => {
               navigate(normalizeUrl(`/checkout/${organization.slug}/`));
             }}
@@ -208,7 +208,7 @@ export function ProductTrialAlert(props: ProductTrialAlertProps) {
         </Button>
       ) : (
         <Button
-          priority="primary"
+          variant="primary"
           onClick={() => {
             navigate(normalizeUrl(`/checkout/${organization.slug}/`));
           }}
@@ -234,7 +234,7 @@ export function ProductTrialAlert(props: ProductTrialAlertProps) {
           onDismiss?.();
         }}
         size="zero"
-        priority="transparent"
+        variant="transparent"
         tooltipProps={{title: t('Dismiss')}}
         aria-label={t('Dismiss trial notice')}
       />

--- a/static/gsApp/components/profiling/alerts.tsx
+++ b/static/gsApp/components/profiling/alerts.tsx
@@ -117,7 +117,7 @@ function GraceAlert({children, action, dismiss, type, disableAction}: GraceAlert
         {action.label}
       </Button>
       {dismiss ? (
-        <StyledButton priority="link" size="sm" onClick={dismiss}>
+        <StyledButton variant="link" size="sm" onClick={dismiss}>
           <IconClose variant="primary" size="sm" />
         </StyledButton>
       ) : null}
@@ -520,7 +520,7 @@ function OnDemandOrPaygBanner({
           organization={organization}
           subscription={subscription}
           buttonProps={{
-            priority: 'primary',
+            variant: 'primary',
             size: 'sm',
             style: {textDecoration: 'none'},
           }}

--- a/static/gsApp/components/profiling/profilingUpgradeModal.tsx
+++ b/static/gsApp/components/profiling/profilingUpgradeModal.tsx
@@ -242,7 +242,7 @@ function ActionButtons({
   return hasBillingAccess ? (
     <ButtonRow>
       <Button
-        priority="primary"
+        variant="primary"
         onClick={onUpdatePlan}
         disabled={isActionDisabled === true}
       >

--- a/static/gsApp/components/superuser/superuserWarning.tsx
+++ b/static/gsApp/components/superuser/superuserWarning.tsx
@@ -54,7 +54,7 @@ function ExitSuperuserButton() {
         bottom: theme.space.sm,
       }}
       size="sm"
-      priority="primary"
+      variant="primary"
       onClick={() => {
         handleExitSuperuser(api);
       }}

--- a/static/gsApp/components/trialEndingModal.tsx
+++ b/static/gsApp/components/trialEndingModal.tsx
@@ -99,7 +99,7 @@ function TrialEndingModal({organization, subscription, closeModal}: Props) {
             <Bullets>{leftColumnItems.map(WarningItem)}</Bullets>
 
             <Button
-              priority="default"
+              variant="secondary"
               onClick={() => {
                 trackGetsentryAnalytics('trial_ended_notice.dismissed_understood', {
                   organization,

--- a/static/gsApp/components/upgradeNowModal/actionButtons.tsx
+++ b/static/gsApp/components/upgradeNowModal/actionButtons.tsx
@@ -125,7 +125,7 @@ export function ActionButtons({
   return hasBillingAccess ? (
     <ButtonRow>
       <Button
-        priority="primary"
+        variant="primary"
         onClick={onUpdatePlan}
         disabled={isActionDisabled === true}
       >
@@ -141,7 +141,7 @@ export function ActionButtons({
   ) : (
     <ButtonRow>
       <Button
-        priority="primary"
+        variant="primary"
         tooltipProps={{
           title: t(
             'Notify an owner by email to update to the latest version of your plan'

--- a/static/gsApp/components/upgradeNowModal/modalSamePrice.tsx
+++ b/static/gsApp/components/upgradeNowModal/modalSamePrice.tsx
@@ -97,7 +97,7 @@ function UpgradeNowModal({
           <CTAPrimary>{t('500 replays')}</CTAPrimary>
           <CTASecondary>{t('at no additional cost')}</CTASecondary>
         </div>
-        <Button priority="primary" onClick={onUpdatePlan}>
+        <Button variant="primary" onClick={onUpdatePlan}>
           {t('Enable Now')}
         </Button>
       </CTAPanel>

--- a/static/gsApp/components/upgradeOrTrialButton.tsx
+++ b/static/gsApp/components/upgradeOrTrialButton.tsx
@@ -129,7 +129,7 @@ function UpgradeOrTrialButton({
           source={source}
           onTrialStarted={handleSuccess}
           requestData={requestData}
-          priority={buttonPriority}
+          variant={buttonPriority}
           {...(props as LinkButtonProps)}
         >
           {childComponent || t('Start %s-Day Trial', getTrialLength(organization))}

--- a/static/gsApp/components/upgradeOrTrialButton.tsx
+++ b/static/gsApp/components/upgradeOrTrialButton.tsx
@@ -33,11 +33,11 @@ interface BaseButtonProps {
   /**
    * Default button priority to use when the button triggers an upgrade
    */
-  trialPriority?: ButtonProps['priority'];
+  trialPriority?: ButtonProps['variant'];
   /**
    * Default button priority to use when the button will start a trial
    */
-  upgradePriority?: ButtonProps['priority'];
+  upgradePriority?: ButtonProps['variant'];
 }
 
 /**
@@ -74,7 +74,7 @@ function UpgradeOrTrialButton({
       : children;
 
   // The button color depends on the priority, and that is determined by the action
-  const buttonPriority: ButtonProps['priority'] =
+  const buttonPriority: ButtonProps['variant'] =
     action === 'trial' ? trialPriority : upgradePriority;
 
   const recordAnalytics = () => {
@@ -141,7 +141,7 @@ function UpgradeOrTrialButton({
       <Button
         onClick={handleRequest}
         busy={busy}
-        priority={buttonPriority}
+        variant={buttonPriority}
         {...(props as ButtonProps)}
       >
         {childComponent || t('Request Trial')}
@@ -159,7 +159,7 @@ function UpgradeOrTrialButton({
       <LinkButton
         onClick={handleSuccess}
         href={`${baseUrl}?referrer=upgrade-${source}`}
-        priority={buttonPriority}
+        variant={buttonPriority}
         {...(props as LinkButtonProps)}
       >
         {childComponent || t('Upgrade now')}
@@ -170,7 +170,7 @@ function UpgradeOrTrialButton({
     <Button
       onClick={handleRequest}
       busy={busy}
-      priority={buttonPriority}
+      variant={buttonPriority}
       {...(props as ButtonProps)}
     >
       {childComponent || t('Request Upgrade')}

--- a/static/gsApp/components/upsellModal/footer.tsx
+++ b/static/gsApp/components/upsellModal/footer.tsx
@@ -47,7 +47,7 @@ export function Footer({
           {...buttonProps}
         />
       ) : (
-        <Button data-test-id="maybe-later" priority="default" onClick={onCloseModal}>
+        <Button data-test-id="maybe-later" variant="secondary" onClick={onCloseModal}>
           {t('Maybe Later')}
         </Button>
       )}

--- a/static/gsApp/components/upsellProvider.tsx
+++ b/static/gsApp/components/upsellProvider.tsx
@@ -63,7 +63,7 @@ function LoadingButton(props: {
   return (
     <Button
       autoFocus
-      priority="primary"
+      variant="primary"
       busy={busy}
       onClick={async () => {
         setBusy(true);

--- a/static/gsApp/hooks/disabledCustomSymbolSources.tsx
+++ b/static/gsApp/hooks/disabledCustomSymbolSources.tsx
@@ -39,7 +39,7 @@ export function DisabledCustomSymbolSources({organization}: Props) {
       action={
         <Grid flow="column" align="center" gap="sm">
           <StyledButton
-            priority="primary"
+            variant="primary"
             icon={<IconBusiness />}
             onClick={() =>
               openUpsellModal({

--- a/static/gsApp/hooks/disabledMemberView.tsx
+++ b/static/gsApp/hooks/disabledMemberView.tsx
@@ -117,7 +117,7 @@ function DisabledMemberView(props: Props) {
     <Button
       onClick={() => handleUpgradeRequestMutation.mutate()}
       size="sm"
-      priority="primary"
+      variant="primary"
     >
       {t('Request Upgrade')}
     </Button>
@@ -164,7 +164,7 @@ function DisabledMemberView(props: Props) {
                       orgName,
                     })}
                   >
-                    <Button size="sm" priority="danger">
+                    <Button size="sm" variant="danger">
                       {t('Leave')}
                     </Button>
                   </Confirm>

--- a/static/gsApp/hooks/memberListHeader.tsx
+++ b/static/gsApp/hooks/memberListHeader.tsx
@@ -51,7 +51,7 @@ function MemberListHeader({members, organization, subscription}: Props) {
         <UpsellProvider source="member-settings-table-header">
           {({canTrial, onClick}) => (
             <Button
-              priority="default"
+              variant="secondary"
               size="xs"
               onClick={onClick}
               icon={<IconBusiness />}

--- a/static/gsApp/hooks/scmGithubMultiOrgInstall.tsx
+++ b/static/gsApp/hooks/scmGithubMultiOrgInstall.tsx
@@ -53,7 +53,7 @@ export function ScmGithubMultiOrgInstall({
           trailingItems={
             <LinkButton
               size="xs"
-              priority="primary"
+              variant="primary"
               icon={<IconLightning />}
               href={`/settings/${organization.slug}/billing/overview/?referrer=upgrade-github-multi-org`}
               external

--- a/static/gsApp/hooks/targetedOnboardingHeader.tsx
+++ b/static/gsApp/hooks/targetedOnboardingHeader.tsx
@@ -59,7 +59,7 @@ function TargetedOnboardingHeader({source, subscription}: Props) {
         external
         size="sm"
         icon={<IconBusiness />}
-        priority="default"
+        variant="secondary"
       >
         {t('Upgrade Now')}
       </LinkButton>

--- a/static/gsApp/views/amCheckout/components/cart.tsx
+++ b/static/gsApp/views/amCheckout/components/cart.tsx
@@ -736,7 +736,7 @@ function TotalSummary({
           {isMigratingPartner && (
             <StyledButton
               aria-label={t('Migrate Now')}
-              priority="danger"
+              variant="danger"
               onClick={() => onSubmit(true)}
               disabled={buttonDisabled || previewDataLoading}
               tooltipProps={{title: buttonDisabled ? buttonDisabledText : undefined}}
@@ -747,7 +747,7 @@ function TotalSummary({
           )}
           <StyledButton
             aria-label={buttonText}
-            priority="primary"
+            variant="primary"
             onClick={() => onSubmit()}
             disabled={buttonDisabled || previewDataLoading}
             tooltipProps={{title: buttonDisabled ? buttonDisabledText : undefined}}
@@ -944,7 +944,7 @@ export function Cart({
             <Button
               aria-label={summaryIsOpen ? t('Hide plan summary') : t('Show plan summary')}
               onClick={() => setSummaryIsOpen(!summaryIsOpen)}
-              priority="transparent"
+              variant="transparent"
               size="zero"
               icon={<IconChevron direction={summaryIsOpen ? 'up' : 'down'} />}
             />

--- a/static/gsApp/views/amCheckout/components/cartDiff.tsx
+++ b/static/gsApp/views/amCheckout/components/cartDiff.tsx
@@ -573,7 +573,7 @@ export function CartDiff({
         <Button
           aria-label={`${isOpen ? 'Hide' : 'Show'} changes`}
           onClick={() => onToggle(!isOpen)}
-          priority="transparent"
+          variant="transparent"
           size="zero"
           icon={<IconChevron direction={isOpen ? 'up' : 'down'} />}
         />

--- a/static/gsApp/views/amCheckout/components/checkoutSuccess.tsx
+++ b/static/gsApp/views/amCheckout/components/checkoutSuccess.tsx
@@ -604,7 +604,7 @@ export function CheckoutSuccess({
           </Description>
           <Flex gap="sm">
             <LinkButton
-              priority="primary"
+              variant="primary"
               aria-label={t('View your subscription')}
               to={`/settings/${organization.slug}/billing/overview/${viewSubscriptionQueryParams}`}
             >

--- a/static/gsApp/views/amCheckout/index.tsx
+++ b/static/gsApp/views/amCheckout/index.tsx
@@ -751,7 +751,7 @@ function AMCheckout(props: Props) {
                     <ExternalLink href="https://sentry.zendesk.com/hc/en-us/categories/17135853065755-Account-Billing" />
                   ),
                   contact: hasZendesk() ? (
-                    <Button size="zero" priority="link" onClick={activateZendesk}>
+                    <Button size="zero" variant="link" onClick={activateZendesk}>
                       <Text variant="accent">{t('ask Support')}</Text>
                     </Button>
                   ) : (
@@ -819,7 +819,7 @@ function AMCheckout(props: Props) {
             to={`/settings/${organization.slug}/billing/`}
             icon={<IconChevron direction="left" />}
             size="xs"
-            priority="transparent"
+            variant="transparent"
             onClick={() => {
               trackGetsentryAnalytics('checkout.exit', {
                 subscription,

--- a/static/gsApp/views/amCheckout/steps/reserveAdditionalVolume.tsx
+++ b/static/gsApp/views/amCheckout/steps/reserveAdditionalVolume.tsx
@@ -98,7 +98,7 @@ export function ReserveAdditionalVolume({
         <Stack gap="sm" align="start">
           <Button
             size="sm"
-            priority="link"
+            variant="link"
             icon={showSliders ? <IconSubtract /> : <IconAdd />}
             aria-label={
               showSliders

--- a/static/gsApp/views/cancelSubscription.tsx
+++ b/static/gsApp/views/cancelSubscription.tsx
@@ -173,7 +173,7 @@ function CancelSubscriptionForm() {
           </Alert>
         </Alert.Container>
         <Button
-          priority="danger"
+          variant="danger"
           onClick={() =>
             setState(currentState => ({...currentState, understandsMembers: true}))
           }
@@ -263,7 +263,7 @@ function CancelSubscriptionForm() {
             )}
 
             <ButtonList>
-              <Button type="submit" priority="danger" disabled={!state.canSubmit}>
+              <Button type="submit" variant="danger" disabled={!state.canSubmit}>
                 {t('Cancel Subscription')}
               </Button>
               <Button

--- a/static/gsApp/views/invoiceDetails/actions.tsx
+++ b/static/gsApp/views/invoiceDetails/actions.tsx
@@ -95,17 +95,13 @@ export function InvoiceDetailsActions({organization, invoice, reloadInvoice}: Pr
           {invoice.isPaid && (
             <Fragment>
               <Input type="email" name="email" placeholder="you@example.com" />
-              <StyledButton type="submit" priority="primary">
+              <StyledButton type="submit" variant="primary">
                 {t('Email Receipt')}
               </StyledButton>
             </Fragment>
           )}
           {showPayNowButton && (
-            <StyledButton
-              priority="primary"
-              onClick={handlePayNow}
-              data-test-id="pay-now"
-            >
+            <StyledButton variant="primary" onClick={handlePayNow} data-test-id="pay-now">
               {t('Pay Now')}
             </StyledButton>
           )}

--- a/static/gsApp/views/legalAndCompliance/policyRow.tsx
+++ b/static/gsApp/views/legalAndCompliance/policyRow.tsx
@@ -152,7 +152,7 @@ export function PolicyRow({
                   </Button>
                   <Button
                     size="sm"
-                    priority="primary"
+                    variant="primary"
                     onClick={() => {
                       onAccept(curPolicy);
                       closeModal();
@@ -212,7 +212,7 @@ export function PolicyRow({
             hasBillingAccess ? (
             <Button
               size="sm"
-              priority="primary"
+              variant="primary"
               onClick={showModal}
               disabled={activeSuperUser || !hasBillingAccess}
               tooltipProps={{

--- a/static/gsApp/views/legalAndCompliance/termsAndConditions.tsx
+++ b/static/gsApp/views/legalAndCompliance/termsAndConditions.tsx
@@ -141,7 +141,7 @@ export function TermsAndConditions({subscription}: TermsProps) {
               <div>
                 <Button
                   size="sm"
-                  priority="primary"
+                  variant="primary"
                   icon={<IconBusiness />}
                   onClick={() =>
                     openUpsellModal({organization, source: 'legal_and_compliance.baa'})

--- a/static/gsApp/views/spendAllocations/components/allocationForm.tsx
+++ b/static/gsApp/views/spendAllocations/components/allocationForm.tsx
@@ -493,7 +493,7 @@ function AllocationForm({
           <Button onClick={closeModal}>{t('Cancel')}</Button>
           <Button
             data-test-id="spend-allocation-submit"
-            priority="primary"
+            variant="primary"
             onClick={onSubmit}
             disabled={overBudgetedEvents || !rootAllocation}
           >

--- a/static/gsApp/views/spendAllocations/components/allocationRow.tsx
+++ b/static/gsApp/views/spendAllocations/components/allocationRow.tsx
@@ -126,7 +126,7 @@ export function AllocationRow({
             icon={<IconDelete />}
             size="xs"
             onClick={deleteAction}
-            priority="danger"
+            variant="danger"
             style={deleteHovered ? {color: theme.colors.red500} : {}}
             onMouseEnter={() => setDeleteHovered(true)}
             onMouseLeave={() => setDeleteHovered(false)}

--- a/static/gsApp/views/spendAllocations/enableSpendAllocations.tsx
+++ b/static/gsApp/views/spendAllocations/enableSpendAllocations.tsx
@@ -53,7 +53,7 @@ export function EnableSpendAllocations({
         {hasScope && (
           <Button
             aria-label={t('Get started')}
-            priority="primary"
+            variant="primary"
             size="sm"
             disabled={!hasScope}
             onClick={enableAction}

--- a/static/gsApp/views/spendAllocations/index.tsx
+++ b/static/gsApp/views/spendAllocations/index.tsx
@@ -380,7 +380,7 @@ export function SpendAllocationsRoot({organization, subscription}: Props) {
               )}
               <Button
                 aria-label={t('New Allocation')}
-                priority="primary"
+                variant="primary"
                 size="sm"
                 data-test-id="new-allocation"
                 icon={<IconAdd size="xs" />}
@@ -514,7 +514,7 @@ export function SpendAllocationsRoot({organization, subscription}: Props) {
           <Button
             aria-label={t('Disable Spend Allocations')}
             size="sm"
-            priority="danger"
+            variant="danger"
             data-test-id="disable"
             disabled={!orgEnabledFlag}
           >

--- a/static/gsApp/views/spendLimits/editModal.tsx
+++ b/static/gsApp/views/spendLimits/editModal.tsx
@@ -235,7 +235,7 @@ class SpendLimitsEditModal extends Component<Props, State> {
             >
               {t('Cancel')}
             </Button>
-            <Button priority="primary" onClick={this.handleSave}>
+            <Button variant="primary" onClick={this.handleSave}>
               {t('Save')}
             </Button>
           </Grid>

--- a/static/gsApp/views/spikeProtection/spikeProtectionProjects.tsx
+++ b/static/gsApp/views/spikeProtection/spikeProtectionProjects.tsx
@@ -207,7 +207,7 @@ function SpikeProtectionProjects({subscription}: Props) {
       >
         <Button
           disabled={!hasOrgWrite}
-          priority={isEnabling ? 'primary' : 'default'}
+          variant={isEnabling ? 'primary' : 'secondary'}
           data-test-id={`sp-${action.toLowerCase()}-all`}
           tooltipProps={{
             title: hasOrgWrite

--- a/static/gsApp/views/subscriptionPage/headerCards/billingInfoCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/billingInfoCard.tsx
@@ -42,7 +42,7 @@ export function BillingInfoCard({
           key="edit-billing-information"
           aria-label={t('Edit billing information')}
           to={`/settings/${organization.slug}/billing/details/`}
-          priority="link"
+          variant="link"
           size="sm"
         >
           <Text size="sm" variant="accent">

--- a/static/gsApp/views/subscriptionPage/headerCards/linksCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/linksCard.tsx
@@ -22,7 +22,7 @@ export function LinksCard({organization}: {organization: Organization}) {
           {hasBillingPerms ? (
             <Fragment>
               <LinkButton
-                priority="link"
+                variant="link"
                 icon={<IconList />}
                 to={`/settings/${organization.slug}/billing/receipts/`}
                 size="xs"
@@ -30,7 +30,7 @@ export function LinksCard({organization}: {organization: Organization}) {
                 {t('View all receipts')}
               </LinkButton>
               <LinkButton
-                priority="link"
+                variant="link"
                 icon={<IconTimer />}
                 to={`/settings/${organization.slug}/billing/activity-logs/`}
                 size="xs"
@@ -39,7 +39,7 @@ export function LinksCard({organization}: {organization: Organization}) {
               </LinkButton>
               {hasSpendNotifications && (
                 <LinkButton
-                  priority="link"
+                  variant="link"
                   icon={<IconSubscribed />}
                   to={`/settings/${organization.slug}/billing/notifications/`}
                   size="xs"
@@ -50,7 +50,7 @@ export function LinksCard({organization}: {organization: Organization}) {
             </Fragment>
           ) : (
             <LinkButton
-              priority="link"
+              variant="link"
               icon={<IconTimer />}
               to={`/settings/${organization.slug}/billing/activity-logs/`}
               size="xs"

--- a/static/gsApp/views/subscriptionPage/headerCards/paygCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/paygCard.tsx
@@ -168,7 +168,7 @@ export function PaygCard({
                 </Currency>
                 <Flex justify="between" align="center" gap="xl sm" wrap="wrap">
                   <Flex gap="sm" align="center">
-                    <Button priority="primary" onClick={() => handleSubmit()}>
+                    <Button variant="primary" onClick={() => handleSubmit()}>
                       {t('Save')}
                     </Button>
                     <Button
@@ -183,7 +183,7 @@ export function PaygCard({
                     </Button>
                   </Flex>
                   <Button
-                    priority="link"
+                    variant="link"
                     onClick={() =>
                       openSpendLimitsPricingModal({organization, subscription, theme})
                     }

--- a/static/gsApp/views/subscriptionPage/notifications.tsx
+++ b/static/gsApp/views/subscriptionPage/notifications.tsx
@@ -303,7 +303,7 @@ function NotificationButtons({
       </Button>
       <Button
         icon={<IconCheckmark />}
-        priority="primary"
+        variant="primary"
         disabled={
           !notificationThresholds ||
           !backendThresholds ||

--- a/static/gsApp/views/subscriptionPage/seerAutomationAlert.tsx
+++ b/static/gsApp/views/subscriptionPage/seerAutomationAlert.tsx
@@ -40,7 +40,7 @@ export function SeerAutomationAlert({organization}: SeerAutomationAlertProps) {
             icon={<IconClose />}
             onClick={dismiss}
             size="zero"
-            priority="transparent"
+            variant="transparent"
             aria-label={t('Dismiss banner')}
           />
         }

--- a/static/gsApp/views/subscriptionPage/subscriptionHeader.tsx
+++ b/static/gsApp/views/subscriptionPage/subscriptionHeader.tsx
@@ -74,7 +74,7 @@ export function SubscriptionHeader(props: Props) {
                 size="md"
                 to={`/checkout/${organization.slug}/?referrer=manage_subscription`}
                 aria-label="Manage plan"
-                priority="primary"
+                variant="primary"
               >
                 {t('Manage plan')}
               </LinkButton>

--- a/static/gsApp/views/subscriptionPage/subscriptionUpsellBanner.tsx
+++ b/static/gsApp/views/subscriptionPage/subscriptionUpsellBanner.tsx
@@ -145,7 +145,7 @@ export function SubscriptionUpsellBanner({
           {description}{' '}
           <Button
             size="zero"
-            priority="link"
+            variant="link"
             onClick={() =>
               openUpsellModal({organization, source: 'subscription_overview'})
             }
@@ -170,7 +170,7 @@ export function SubscriptionUpsellBanner({
       </div>
       <BannerImage src={subscription.canTrial ? businessTrial : businessUpgrade} />
       <CloseBannerButton
-        priority="link"
+        variant="link"
         aria-label={t('Dismiss')}
         icon={<IconClose variant="muted" />}
         size="xs"

--- a/static/gsApp/views/subscriptionPage/usageOverview/components/actions.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/components/actions.tsx
@@ -89,7 +89,7 @@ export function UsageOverviewActions({organization}: {organization: Organization
           <LinkButton
             key={buttonInfo.label}
             icon={buttonInfo.icon}
-            priority="default"
+            variant="secondary"
             to={buttonInfo.to}
           >
             {buttonInfo.label}
@@ -98,7 +98,7 @@ export function UsageOverviewActions({organization}: {organization: Organization
           <Button
             key={buttonInfo.label}
             icon={buttonInfo.icon}
-            priority="default"
+            variant="secondary"
             onClick={buttonInfo.onClick}
             disabled={buttonInfo.disabled}
           >

--- a/static/gsApp/views/subscriptionPage/usageOverview/components/cta.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/components/cta.tsx
@@ -104,7 +104,7 @@ function FindOutMoreButton({
   return (
     <LinkButton
       icon={<IconOpen />}
-      priority="link"
+      variant="link"
       size="sm"
       href={href}
       to={to ?? ''}
@@ -288,7 +288,7 @@ function UpgradeCta({
             subscription.canSelfServe ? (
               <LinkButton
                 icon={<IconUpload />}
-                priority="primary"
+                variant="primary"
                 href={`/checkout/${organization.slug}/?referrer=${USAGE_OVERVIEW_PANEL_REFERRER}`}
               >
                 {t('Add to plan')}
@@ -337,7 +337,7 @@ function UpgradeCta({
         subscription.canSelfServe && hasBillingPerms ? (
           <Fragment>
             <LinkButton
-              priority="primary"
+              variant="primary"
               href={`/checkout/${organization.slug}/?referrer=${USAGE_OVERVIEW_PANEL_REFERRER}`}
             >
               {t('Upgrade now')}
@@ -379,7 +379,7 @@ function SetupCta({
         <LinkButton
           icon={<IconSeer />}
           href={`/settings/${organization.slug}/seer/?referrer=${USAGE_OVERVIEW_PANEL_REFERRER}`}
-          priority="primary"
+          variant="primary"
           analyticsEventName="Subscription Settings: Set Up Button Clicked"
           analyticsEventKey="subscription_settings.set_up_button_clicked"
           analyticsParams={{


### PR DESCRIPTION
Applies the [`button-variant` codemod](https://github.com/getsentry/design-engineering/tree/main/codemods/button-variant) to files owned by `@getsentry/revenue`.