### PR TITLE
codemod(button-variant): apply changes for emerge-tools

### DIFF
--- a/static/app/views/preprod/buildComparison/main/insights/insightDiffRow.tsx
+++ b/static/app/views/preprod/buildComparison/main/insights/insightDiffRow.tsx
@@ -97,7 +97,7 @@ export function InsightDiffRow({
                   </Text>
                 </Flex>
                 <Button
-                  priority="transparent"
+                  variant="transparent"
                   size="sm"
                   onClick={() => setIsExpanded(!isExpanded)}
                   aria-label={isExpanded ? t('Collapse insight') : t('Expand insight')}

--- a/static/app/views/preprod/buildComparison/main/sizeCompareItemDiffTable.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareItemDiffTable.tsx
@@ -164,7 +164,7 @@ export function SizeCompareItemDiffTable({
                 {t('No results found')}
               </Text>
               {originalItemCount > 0 && (
-                <Button priority="primary" onClick={disableHideSmallChanges}>
+                <Button variant="primary" onClick={disableHideSmallChanges}>
                   {t('Show all changes')}
                 </Button>
               )}

--- a/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareMainContent.tsx
@@ -201,7 +201,7 @@ export function SizeCompareMainContent() {
         message={t("We don't have any comparison data available yet for these builds.")}
       >
         <Button
-          priority="primary"
+          variant="primary"
           onClick={() => {
             triggerComparison({
               baseArtifactId,
@@ -241,7 +241,7 @@ export function SizeCompareMainContent() {
         }
       >
         <Button
-          priority="default"
+          variant="secondary"
           onClick={() => {
             triggerComparison({
               baseArtifactId,
@@ -324,7 +324,7 @@ export function SizeCompareMainContent() {
             </Flex>
             <Flex align="center" gap="sm">
               <Button
-                priority="transparent"
+                variant="transparent"
                 size="sm"
                 onClick={() => setIsFilesExpanded(!isFilesExpanded)}
                 aria-label={isFilesExpanded ? t('Collapse items') : t('Expand items')}

--- a/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
+++ b/static/app/views/preprod/buildComparison/main/sizeCompareSelectedBuilds.tsx
@@ -121,7 +121,7 @@ function BuildButton({buildDetails, icon, label, onRemove, slot}: BuildButtonPro
                 onRemove();
               }}
               size="zero"
-              priority="transparent"
+              variant="transparent"
               aria-label={t('Clear base build')}
               icon={<IconClose size="xs" variant="accent" />}
             />
@@ -237,7 +237,7 @@ export function SizeCompareSelectedBuilds({
             }
           }}
           disabled={!baseBuildDetails || isComparing}
-          priority="primary"
+          variant="primary"
           icon={<IconTelescope size="sm" />}
         >
           {isComparing ? t('Comparing...') : t('Compare builds')}

--- a/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
+++ b/static/app/views/preprod/buildDetails/header/buildDetailsHeaderContent.tsx
@@ -185,7 +185,7 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
         <React.Fragment>
           <TopBar.Slot name="actions">
             <Button
-              priority="default"
+              variant="secondary"
               icon={<IconTelescope />}
               onClick={handleCompareClick}
               disabled={!areActionsEnabled}
@@ -310,7 +310,7 @@ export function BuildDetailsHeaderContent(props: BuildDetailsHeaderContentProps)
             <FeedbackButton feedbackOptions={buildDetailsFeedbackOptions} />
             <Button
               size="sm"
-              priority="default"
+              variant="secondary"
               icon={<IconTelescope />}
               onClick={handleCompareClick}
               disabled={!areActionsEnabled}

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMainContent.tsx
@@ -196,7 +196,7 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
           }
         >
           <Button
-            priority="primary"
+            variant="primary"
             onClick={onRerunAnalysis}
             disabled={isRerunning}
             icon={<IconRefresh />}
@@ -234,7 +234,7 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
           }
         >
           <Button
-            priority="primary"
+            variant="primary"
             onClick={onRerunAnalysis}
             disabled={isRerunning}
             icon={<IconRefresh />}
@@ -407,7 +407,7 @@ export function BuildDetailsMainContent(props: BuildDetailsMainContentProps) {
                   <Button
                     onClick={() => setSearchQuery(undefined)}
                     aria-label="Clear search"
-                    priority="transparent"
+                    variant="transparent"
                     size="zero"
                   >
                     <IconClose size="sm" />

--- a/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
+++ b/static/app/views/preprod/buildDetails/main/buildDetailsMetricCards.tsx
@@ -241,7 +241,7 @@ export function BuildDetailsMetricCards(props: BuildDetailsMetricCardsProps) {
                     <LinkButton
                       to={card.comparisonUrl}
                       size="zero"
-                      priority="link"
+                      variant="link"
                       aria-label={t('Compare builds')}
                     >
                       <Flex align="center" gap="xs">

--- a/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
+++ b/static/app/views/preprod/buildDetails/main/insights/appSizeInsightsSidebarRow.tsx
@@ -146,7 +146,7 @@ export function AppSizeInsightsSidebarRow({
           {insight.description}
         </Text>
         {shouldShowTooltip && (
-          <Button priority="link" onClick={handleOpenModal} size="xs" icon={<IconInfo />}>
+          <Button variant="link" onClick={handleOpenModal} size="xs" icon={<IconInfo />}>
             {t('How to fix this locally')}
           </Button>
         )}

--- a/static/app/views/preprod/components/installAppButton.tsx
+++ b/static/app/views/preprod/components/installAppButton.tsx
@@ -44,7 +44,7 @@ export function InstallAppButton({
         aria-label={t('Install')}
         icon={<IconDownload size="sm" />}
         onClick={handleClick}
-        priority="transparent"
+        variant="transparent"
         size="zero"
         tooltipProps={{title: t('Install')}}
       />
@@ -52,12 +52,7 @@ export function InstallAppButton({
   }
 
   return (
-    <Button
-      onClick={handleClick}
-      priority="link"
-      size="sm"
-      style={{fontWeight: 'normal'}}
-    >
+    <Button onClick={handleClick} variant="link" size="sm" style={{fontWeight: 'normal'}}>
       {t('Install')}
     </Button>
   );

--- a/static/app/views/preprod/components/installDetailsContent.tsx
+++ b/static/app/views/preprod/components/installDetailsContent.tsx
@@ -238,7 +238,7 @@ export function InstallDetailsContent({
               <Flex width={{xs: '100%', sm: 'auto'}}>
                 <Button
                   onClick={() => window.open(installDetails.install_url, '_blank')}
-                  priority="primary"
+                  variant="primary"
                   size="md"
                   style={{width: '100%'}}
                 >
@@ -258,7 +258,7 @@ export function InstallDetailsContent({
                         })
                       }
                       size="md"
-                      priority="default"
+                      variant="secondary"
                       style={{width: '100%'}}
                     >
                       {t('Copy Download Link')}

--- a/static/app/views/preprod/components/installModal.tsx
+++ b/static/app/views/preprod/components/installModal.tsx
@@ -26,7 +26,7 @@ function InstallModal({artifactId, closeModal, projectSlug}: InstallModalProps) 
         <Container justifySelf="end">
           <Button
             onClick={closeModal}
-            priority="transparent"
+            variant="transparent"
             icon={<IconClose />}
             size="sm"
             aria-label={t('Close')}

--- a/static/app/views/preprod/components/metricCard.tsx
+++ b/static/app/views/preprod/components/metricCard.tsx
@@ -53,7 +53,7 @@ export function MetricCard(props: MetricCardProps) {
         {action && (
           <Button
             size="xs"
-            priority="link"
+            variant="link"
             icon={action.icon}
             aria-label={action.ariaLabel}
             tooltipProps={{title: action.tooltip}}

--- a/static/app/views/preprod/components/missingDsymModal.tsx
+++ b/static/app/views/preprod/components/missingDsymModal.tsx
@@ -29,7 +29,7 @@ function MissingDsymModal({binaries, closeModal}: MissingDsymModalProps) {
         >
           <Button
             onClick={closeModal}
-            priority="transparent"
+            variant="transparent"
             icon={<IconClose />}
             size="sm"
             aria-label={t('Close')}

--- a/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
+++ b/static/app/views/preprod/components/visualizations/appSizeTreemap.tsx
@@ -102,7 +102,7 @@ function FullscreenModalContent({
             <Button
               onClick={() => handleSearchChange('')}
               aria-label="Clear search"
-              priority="transparent"
+              variant="transparent"
               size="zero"
             >
               <IconClose size="sm" />

--- a/static/app/views/preprod/components/visualizations/treemapControlButtons.tsx
+++ b/static/app/views/preprod/components/visualizations/treemapControlButtons.tsx
@@ -34,7 +34,7 @@ export function TreemapControlButtons({buttons}: TreemapControlButtonsProps) {
           size="xs"
           aria-label={button.ariaLabel}
           tooltipProps={{title: button.title}}
-          priority="transparent"
+          variant="transparent"
           icon={button.icon}
           onClick={button.onClick}
           disabled={button.disabled}

--- a/static/app/views/preprod/snapshots/header/snapshotHeaderActions.tsx
+++ b/static/app/views/preprod/snapshots/header/snapshotHeaderActions.tsx
@@ -182,7 +182,7 @@ export function SnapshotHeaderActions({
             </Tag>
             <Button
               size="sm"
-              priority="primary"
+              variant="primary"
               icon={<IconThumb />}
               onClick={handleApprove}
               disabled={isApproving}

--- a/static/app/views/preprod/snapshots/main/snapshotCards.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.tsx
@@ -377,7 +377,7 @@ function IconButton({
   const button = (
     <Button
       size="xs"
-      priority="transparent"
+      variant="transparent"
       icon={icon}
       aria-label={ariaLabel}
       onClick={onClick}


### PR DESCRIPTION
Applies the [`button-variant` codemod](https://github.com/getsentry/design-engineering/tree/main/codemods/button-variant) to files owned by `@getsentry/emerge-tools`.