### PR TITLE
codemod(button-variant): apply changes for coding-workflows-sentry-frontend

### DIFF
--- a/static/app/components/repositories/scmIntegrationTree/scmIntegrationTree.tsx
+++ b/static/app/components/repositories/scmIntegrationTree/scmIntegrationTree.tsx
@@ -288,7 +288,7 @@ export function ScmIntegrationTree({search, repoFilter, providerFilter}: Props) 
           {t('No source code management integrations found.')}
         </Text>
         <LinkButton
-          priority="primary"
+          variant="primary"
           to={`/settings/${organization.slug}/integrations/?category=source+code+management`}
         >
           {t('Connect an Integration')}

--- a/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeRow.tsx
+++ b/static/app/components/repositories/scmIntegrationTree/scmIntegrationTreeRow.tsx
@@ -419,7 +419,7 @@ function RemoveButton({
       <Flex align="center" gap="sm">
         <Button
           size="xs"
-          priority="danger"
+          variant="danger"
           disabled={isToggling}
           onClick={() => {
             onRemove();


### PR DESCRIPTION
Applies the [`button-variant` codemod](https://github.com/getsentry/design-engineering/tree/main/codemods/button-variant) to files owned by `@getsentry/coding-workflows-sentry-frontend`.