### PR TITLE
ref(seer-grouping): rm v2

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -549,9 +549,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("projects:similarity-embeddings", ProjectFeature, FeatureHandlerStrategy.INTERNAL, default=False, api_expose=True)
     manager.add("projects:similarity-indexing", ProjectFeature, FeatureHandlerStrategy.INTERNAL, api_expose=False)
     manager.add("projects:similarity-view", ProjectFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)
-    # Enable new similarity grouping model upgrade (version-agnostic rollout)
-    manager.add("projects:similarity-grouping-model-upgrade", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
-    # Enable next similarity grouping model rollout (for migrating EA projects from v2 to v2.1)
+    # Enable next similarity grouping model rollout
     manager.add("projects:similarity-grouping-model-next", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Starfish: extract metrics from the spans
     manager.add("projects:span-metrics-extraction", ProjectFeature, FeatureHandlerStrategy.INTERNAL, api_expose=True)

--- a/src/sentry/seer/similarity/config.py
+++ b/src/sentry/seer/similarity/config.py
@@ -16,13 +16,7 @@ SEER_GROUPING_STABLE_VERSION = GroupingVersion.V1
 # - Rolled-out projects: Use this for ALL requests (both grouping and embeddings)
 # - Non-rolled-out projects: Never use this (use stable version for everything)
 # Set to None to disable rollout entirely
-SEER_GROUPING_NEW_VERSION: GroupingVersion | None = GroupingVersion.V2
-
-# Model version to migrate EA projects from new to next
 SEER_GROUPING_NEXT_VERSION: GroupingVersion | None = GroupingVersion.V2_1
-
-# Feature flag names
-SEER_GROUPING_NEW_MODEL_ROLLOUT_FEATURE = "projects:similarity-grouping-model-upgrade"
 SEER_GROUPING_NEXT_MODEL_ROLLOUT_FEATURE = "projects:similarity-grouping-model-next"
 
 
@@ -31,19 +25,13 @@ def get_grouping_model_version(project: Project) -> GroupingVersion:
     Get the model version to use for grouping decisions for this project.
 
     Returns:
-        - Next version if rollout is enabled for this project (for migrating EA projects from new to next)
-        - New version if rollout is enabled for this project
+        - Next version if rollout is enabled for this project
         - Stable version otherwise
     """
     if SEER_GROUPING_NEXT_VERSION is not None and features.has(
         SEER_GROUPING_NEXT_MODEL_ROLLOUT_FEATURE, project
     ):
         return SEER_GROUPING_NEXT_VERSION
-
-    if SEER_GROUPING_NEW_VERSION is not None and features.has(
-        SEER_GROUPING_NEW_MODEL_ROLLOUT_FEATURE, project
-    ):
-        return SEER_GROUPING_NEW_VERSION
 
     return SEER_GROUPING_STABLE_VERSION
 
@@ -61,10 +49,6 @@ def should_send_to_seer_for_training(
     2. The grouphash hasn't already been sent to that version
     """
     model_version = get_grouping_model_version(project)
-    if model_version == SEER_GROUPING_STABLE_VERSION:
-        return False
-
-    if grouphash_seer_latest_training_model == model_version.value:
-        return False
-
-    return True
+    is_stable = model_version == SEER_GROUPING_STABLE_VERSION
+    was_grouphash_already_sent = grouphash_seer_latest_training_model == model_version.value
+    return not (is_stable or was_grouphash_already_sent)

--- a/src/sentry/seer/similarity/types.py
+++ b/src/sentry/seer/similarity/types.py
@@ -13,7 +13,6 @@ class GroupingVersion(StrEnum):
     """Model version for similarity grouping."""
 
     V1 = "v1"
-    V2 = "v2"
     V2_1 = "v2.1"
 
 

--- a/tests/sentry/event_manager/grouping/test_seer_grouping.py
+++ b/tests/sentry/event_manager/grouping/test_seer_grouping.py
@@ -276,7 +276,7 @@ class StoredSeerMetadataTest(TestCase):
             should_group=True,
         )
 
-        # Mock Seer responding with v1 even though we'd request v2
+        # Mock Seer responding with v1 even though we'd request v2.1
         with (
             patch(
                 "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
@@ -284,7 +284,7 @@ class StoredSeerMetadataTest(TestCase):
             ),
             patch(
                 "sentry.grouping.ingest.seer.get_grouping_model_version",
-                return_value=GroupingVersion.V2,
+                return_value=GroupingVersion.V2_1,
             ),
         ):
             new_event = save_new_event(get_event_data(dog="Maisey"), self.project)
@@ -296,7 +296,7 @@ class StoredSeerMetadataTest(TestCase):
             assert new_event_grouphash and new_event_grouphash.metadata
 
             # seer_model should be what Seer actually used (v1)
-            # seer_latest_training_model should be what we requested (v2)
+            # seer_latest_training_model should be what we requested (v2.1)
             self.assert_correct_seer_metadata(
                 new_event_grouphash,
                 new_event_grouphash.metadata.date_added,
@@ -304,7 +304,7 @@ class StoredSeerMetadataTest(TestCase):
                 GroupingVersion.V1.value,
                 existing_event_grouphash,
                 seer_result_data.stacktrace_distance,
-                expected_seer_latest_training_model=GroupingVersion.V2.value,
+                expected_seer_latest_training_model=GroupingVersion.V2_1.value,
             )
 
     def test_event_not_sent_to_seer(self) -> None:

--- a/tests/sentry/grouping/seer_similarity/test_training_mode.py
+++ b/tests/sentry/grouping/seer_similarity/test_training_mode.py
@@ -3,10 +3,7 @@ from unittest.mock import patch
 from sentry.grouping.ingest.seer import maybe_send_seer_for_new_model_training
 from sentry.models.grouphash import GroupHash
 from sentry.models.grouphashmetadata import GroupHashMetadata
-from sentry.seer.similarity.config import (
-    SEER_GROUPING_NEW_MODEL_ROLLOUT_FEATURE,
-    SEER_GROUPING_NEXT_MODEL_ROLLOUT_FEATURE,
-)
+from sentry.seer.similarity.config import SEER_GROUPING_NEXT_MODEL_ROLLOUT_FEATURE
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.eventprocessing import save_new_event
 
@@ -30,28 +27,27 @@ class MaybeSendSeerForNewModelTrainingTest(TestCase):
             mock_get_similarity_data.assert_not_called()
 
     def test_does_nothing_when_no_rollout(self) -> None:
-        """Should not send request when no new version is being rolled out"""
+        """Should not send request when no version is being rolled out"""
         with (
-            patch("sentry.seer.similarity.config.SEER_GROUPING_NEW_VERSION", None),
             patch("sentry.seer.similarity.config.SEER_GROUPING_NEXT_VERSION", None),
             patch(
                 "sentry.grouping.ingest.seer.get_similarity_data_from_seer"
             ) as mock_get_similarity_data,
-            self.feature(SEER_GROUPING_NEW_MODEL_ROLLOUT_FEATURE),
+            self.feature(SEER_GROUPING_NEXT_MODEL_ROLLOUT_FEATURE),
         ):
             maybe_send_seer_for_new_model_training(self.event, self.grouphash, self.variants)
             mock_get_similarity_data.assert_not_called()
 
     def test_does_nothing_when_training_model_already_sent(self) -> None:
-        """Should not send request when seer_latest_training_model already matches new version"""
+        """Should not send request when seer_latest_training_model already matches current version"""
         with (
             patch(
                 "sentry.grouping.ingest.seer.get_similarity_data_from_seer"
             ) as mock_get_similarity_data,
-            self.feature(SEER_GROUPING_NEW_MODEL_ROLLOUT_FEATURE),
+            self.feature(SEER_GROUPING_NEXT_MODEL_ROLLOUT_FEATURE),
         ):
             metadata, _ = GroupHashMetadata.objects.get_or_create(grouphash=self.grouphash)
-            metadata.seer_latest_training_model = "v2"
+            metadata.seer_latest_training_model = "v2.1"
             metadata.save()
 
             maybe_send_seer_for_new_model_training(self.event, self.grouphash, self.variants)
@@ -62,9 +58,10 @@ class MaybeSendSeerForNewModelTrainingTest(TestCase):
         with (
             patch("sentry.grouping.ingest.seer.should_call_seer_for_grouping", return_value=True),
             patch(
-                "sentry.grouping.ingest.seer.get_similarity_data_from_seer", return_value=([], "v2")
+                "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
+                return_value=([], "v2.1"),
             ) as mock_get_similarity_data,
-            self.feature(SEER_GROUPING_NEW_MODEL_ROLLOUT_FEATURE),
+            self.feature(SEER_GROUPING_NEXT_MODEL_ROLLOUT_FEATURE),
         ):
             metadata, _ = GroupHashMetadata.objects.get_or_create(grouphash=self.grouphash)
             assert metadata.seer_latest_training_model is None
@@ -79,36 +76,49 @@ class MaybeSendSeerForNewModelTrainingTest(TestCase):
 
             # Should update seer_latest_training_model without touching seer_model
             metadata = GroupHashMetadata.objects.get(id=metadata.id)
-            assert metadata.seer_latest_training_model == "v2"
+            assert metadata.seer_latest_training_model == "v2.1"
             assert metadata.seer_model is None
 
     def test_sends_request_when_training_model_is_old_version(self) -> None:
         """Should send training request when seer_latest_training_model has an old version"""
-        with (
-            patch("sentry.grouping.ingest.seer.should_call_seer_for_grouping", return_value=True),
-            patch(
-                "sentry.grouping.ingest.seer.get_similarity_data_from_seer", return_value=([], "v2")
-            ) as mock_get_similarity_data,
-            self.feature(SEER_GROUPING_NEW_MODEL_ROLLOUT_FEATURE),
-        ):
-            metadata, _ = GroupHashMetadata.objects.get_or_create(grouphash=self.grouphash)
-            metadata.seer_latest_training_model = "v1"
-            metadata.save()
+        for old_version in ["v1", "v2"]:
+            with self.subTest(old_version=old_version):
+                event = save_new_event({"message": f"event-{old_version}"}, self.project)
+                grouphash = GroupHash.objects.get(
+                    hash=event.get_primary_hash(), project_id=self.project.id
+                )
+                with (
+                    patch(
+                        "sentry.grouping.ingest.seer.should_call_seer_for_grouping",
+                        return_value=True,
+                    ),
+                    patch(
+                        "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
+                        return_value=([], "v2.1"),
+                    ) as mock_get_similarity_data,
+                    self.feature(SEER_GROUPING_NEXT_MODEL_ROLLOUT_FEATURE),
+                ):
+                    metadata, _ = GroupHashMetadata.objects.get_or_create(grouphash=grouphash)
+                    metadata.seer_latest_training_model = old_version
+                    metadata.save()
 
-            maybe_send_seer_for_new_model_training(self.event, self.grouphash, self.variants)
+                    maybe_send_seer_for_new_model_training(
+                        event, grouphash, event.get_grouping_variants()
+                    )
 
-            mock_get_similarity_data.assert_called_once()
-            metadata.refresh_from_db()
-            assert metadata.seer_latest_training_model == "v2"
+                    mock_get_similarity_data.assert_called_once()
+                    metadata.refresh_from_db()
+                    assert metadata.seer_latest_training_model == "v2.1"
 
     def test_sends_request_when_sent_to_old_seer_model(self) -> None:
         """Should send training request when seer_model is old and training model is unset"""
         with (
             patch("sentry.grouping.ingest.seer.should_call_seer_for_grouping", return_value=True),
             patch(
-                "sentry.grouping.ingest.seer.get_similarity_data_from_seer", return_value=([], "v2")
+                "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
+                return_value=([], "v2.1"),
             ) as mock_get_similarity_data,
-            self.feature(SEER_GROUPING_NEW_MODEL_ROLLOUT_FEATURE),
+            self.feature(SEER_GROUPING_NEXT_MODEL_ROLLOUT_FEATURE),
         ):
             metadata, _ = GroupHashMetadata.objects.get_or_create(grouphash=self.grouphash)
             metadata.seer_model = "v1"
@@ -124,7 +134,7 @@ class MaybeSendSeerForNewModelTrainingTest(TestCase):
 
             # Should update seer_latest_training_model without touching seer_model
             metadata = GroupHashMetadata.objects.get(id=metadata.id)
-            assert metadata.seer_latest_training_model == "v2"
+            assert metadata.seer_latest_training_model == "v2.1"
             assert metadata.seer_model == "v1"
 
     def test_does_not_send_duplicate_request(self) -> None:
@@ -132,9 +142,10 @@ class MaybeSendSeerForNewModelTrainingTest(TestCase):
         with (
             patch("sentry.grouping.ingest.seer.should_call_seer_for_grouping", return_value=True),
             patch(
-                "sentry.grouping.ingest.seer.get_similarity_data_from_seer", return_value=([], "v2")
+                "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
+                return_value=([], "v2.1"),
             ) as mock_get_similarity_data,
-            self.feature(SEER_GROUPING_NEW_MODEL_ROLLOUT_FEATURE),
+            self.feature(SEER_GROUPING_NEXT_MODEL_ROLLOUT_FEATURE),
         ):
             metadata, _ = GroupHashMetadata.objects.get_or_create(grouphash=self.grouphash)
             assert metadata.seer_latest_training_model is None
@@ -145,7 +156,7 @@ class MaybeSendSeerForNewModelTrainingTest(TestCase):
 
             mock_get_similarity_data.reset_mock()
 
-            # Second call should not send because seer_latest_training_model was updated to v2
+            # Second call should not send because seer_latest_training_model was updated
             maybe_send_seer_for_new_model_training(self.event, self.grouphash, self.variants)
             mock_get_similarity_data.assert_not_called()
 
@@ -160,7 +171,7 @@ class MaybeSendSeerForNewModelTrainingTest(TestCase):
                 side_effect=test_exception,
             ),
             patch("sentry.grouping.ingest.seer.sentry_sdk.capture_exception"),
-            self.feature(SEER_GROUPING_NEW_MODEL_ROLLOUT_FEATURE),
+            self.feature(SEER_GROUPING_NEXT_MODEL_ROLLOUT_FEATURE),
         ):
             metadata, _ = GroupHashMetadata.objects.get_or_create(grouphash=self.grouphash)
             assert metadata.seer_latest_training_model is None
@@ -178,7 +189,7 @@ class MaybeSendSeerForNewModelTrainingTest(TestCase):
             patch(
                 "sentry.grouping.ingest.seer.get_similarity_data_from_seer"
             ) as mock_get_similarity_data,
-            self.feature(SEER_GROUPING_NEW_MODEL_ROLLOUT_FEATURE),
+            self.feature(SEER_GROUPING_NEXT_MODEL_ROLLOUT_FEATURE),
         ):
             metadata, _ = GroupHashMetadata.objects.get_or_create(grouphash=self.grouphash)
             assert metadata.seer_latest_training_model is None
@@ -199,7 +210,7 @@ class MaybeSendSeerForNewModelTrainingTest(TestCase):
                 side_effect=test_exception,
             ),
             patch("sentry.grouping.ingest.seer.sentry_sdk.capture_exception") as mock_capture,
-            self.feature(SEER_GROUPING_NEW_MODEL_ROLLOUT_FEATURE),
+            self.feature(SEER_GROUPING_NEXT_MODEL_ROLLOUT_FEATURE),
         ):
             metadata, _ = GroupHashMetadata.objects.get_or_create(grouphash=self.grouphash)
             assert metadata.seer_latest_training_model is None
@@ -216,26 +227,3 @@ class MaybeSendSeerForNewModelTrainingTest(TestCase):
                     "grouphash": self.grouphash.hash,
                 },
             )
-
-    def test_retrains_for_next_model_when_already_trained_for_new(self) -> None:
-        """v2 -> v2.1 transition: grouphash trained for v2, project now on v2.1"""
-        with (
-            patch("sentry.grouping.ingest.seer.should_call_seer_for_grouping", return_value=True),
-            patch(
-                "sentry.grouping.ingest.seer.get_similarity_data_from_seer",
-                return_value=([], "v2.1"),
-            ) as mock_get_similarity_data,
-            self.feature(SEER_GROUPING_NEXT_MODEL_ROLLOUT_FEATURE),
-        ):
-            metadata, _ = GroupHashMetadata.objects.get_or_create(grouphash=self.grouphash)
-            metadata.seer_latest_training_model = "v2"
-            metadata.save()
-
-            maybe_send_seer_for_new_model_training(self.event, self.grouphash, self.variants)
-
-            mock_get_similarity_data.assert_called_once()
-            call_args = mock_get_similarity_data.call_args
-            assert call_args[0][0]["model"].value == "v2.1"
-
-            metadata.refresh_from_db()
-            assert metadata.seer_latest_training_model == "v2.1"

--- a/tests/sentry/seer/similarity/test_config.py
+++ b/tests/sentry/seer/similarity/test_config.py
@@ -1,8 +1,6 @@
 from unittest.mock import patch
 
 from sentry.seer.similarity.config import (
-    SEER_GROUPING_NEW_MODEL_ROLLOUT_FEATURE,
-    SEER_GROUPING_NEW_VERSION,
     SEER_GROUPING_NEXT_MODEL_ROLLOUT_FEATURE,
     SEER_GROUPING_NEXT_VERSION,
     SEER_GROUPING_STABLE_VERSION,
@@ -17,43 +15,24 @@ class GetGroupingModelVersionTest(TestCase):
         assert get_grouping_model_version(self.project) == SEER_GROUPING_STABLE_VERSION
 
     def test_returns_stable_when_rollout_disabled(self) -> None:
-        with (
-            patch("sentry.seer.similarity.config.SEER_GROUPING_NEW_VERSION", None),
-            patch("sentry.seer.similarity.config.SEER_GROUPING_NEXT_VERSION", None),
-        ):
+        with patch("sentry.seer.similarity.config.SEER_GROUPING_NEXT_VERSION", None):
             assert get_grouping_model_version(self.project) == SEER_GROUPING_STABLE_VERSION
 
-    def test_returns_flagged_version(self) -> None:
-        cases = [
-            (SEER_GROUPING_NEW_MODEL_ROLLOUT_FEATURE, SEER_GROUPING_NEW_VERSION),
-            (SEER_GROUPING_NEXT_MODEL_ROLLOUT_FEATURE, SEER_GROUPING_NEXT_VERSION),
-        ]
-        for feature_flag, expected_version in cases:
-            with self.subTest(feature_flag=feature_flag), self.feature(feature_flag):
-                assert get_grouping_model_version(self.project) == expected_version
-
-    def test_next_flag_takes_priority_over_new_flag(self) -> None:
-        with self.feature(
-            [SEER_GROUPING_NEW_MODEL_ROLLOUT_FEATURE, SEER_GROUPING_NEXT_MODEL_ROLLOUT_FEATURE]
-        ):
+    def test_returns_next_version_when_flag_enabled(self) -> None:
+        with self.feature(SEER_GROUPING_NEXT_MODEL_ROLLOUT_FEATURE):
             assert get_grouping_model_version(self.project) == SEER_GROUPING_NEXT_VERSION
 
-    def test_falls_back_to_new_when_next_version_is_none(self) -> None:
+    def test_flag_is_noop_when_version_is_none(self) -> None:
         with (
             patch("sentry.seer.similarity.config.SEER_GROUPING_NEXT_VERSION", None),
-            self.feature(
-                [SEER_GROUPING_NEW_MODEL_ROLLOUT_FEATURE, SEER_GROUPING_NEXT_MODEL_ROLLOUT_FEATURE]
-            ),
+            self.feature(SEER_GROUPING_NEXT_MODEL_ROLLOUT_FEATURE),
         ):
-            assert get_grouping_model_version(self.project) == SEER_GROUPING_NEW_VERSION
+            assert get_grouping_model_version(self.project) == SEER_GROUPING_STABLE_VERSION
 
 
 class ShouldSendToSeerForTrainingTest(TestCase):
     def test_returns_false_when_no_rollout(self) -> None:
-        with (
-            patch("sentry.seer.similarity.config.SEER_GROUPING_NEW_VERSION", None),
-            patch("sentry.seer.similarity.config.SEER_GROUPING_NEXT_VERSION", None),
-        ):
+        with patch("sentry.seer.similarity.config.SEER_GROUPING_NEXT_VERSION", None):
             result = should_send_to_seer_for_training(
                 self.project, grouphash_seer_latest_training_model=None
             )
@@ -66,32 +45,18 @@ class ShouldSendToSeerForTrainingTest(TestCase):
         assert result is False
 
     def test_returns_true_when_training_needed(self) -> None:
-        cases = [
-            # (feature_flag, seer_latest_training_model)
-            (SEER_GROUPING_NEW_MODEL_ROLLOUT_FEATURE, None),
-            (SEER_GROUPING_NEW_MODEL_ROLLOUT_FEATURE, "v1"),
-            (SEER_GROUPING_NEXT_MODEL_ROLLOUT_FEATURE, None),
-            (SEER_GROUPING_NEXT_MODEL_ROLLOUT_FEATURE, "v1"),
-            (SEER_GROUPING_NEXT_MODEL_ROLLOUT_FEATURE, "v2"),  # v2 → v2.1 transition
-        ]
-        for feature_flag, training_model in cases:
-            with self.subTest(feature_flag=feature_flag, training_model=training_model):
-                with self.feature(feature_flag):
+        # Old training models that should trigger retraining for the current rollout version
+        for training_model in [None, "v1", "v2"]:
+            with self.subTest(training_model=training_model):
+                with self.feature(SEER_GROUPING_NEXT_MODEL_ROLLOUT_FEATURE):
                     result = should_send_to_seer_for_training(
                         self.project, grouphash_seer_latest_training_model=training_model
                     )
                     assert result is True
 
     def test_returns_false_when_already_sent_to_current_version(self) -> None:
-        cases = [
-            # (feature_flag, seer_latest_training_model)
-            (SEER_GROUPING_NEW_MODEL_ROLLOUT_FEATURE, "v2"),
-            (SEER_GROUPING_NEXT_MODEL_ROLLOUT_FEATURE, "v2.1"),
-        ]
-        for feature_flag, training_model in cases:
-            with self.subTest(feature_flag=feature_flag, training_model=training_model):
-                with self.feature(feature_flag):
-                    result = should_send_to_seer_for_training(
-                        self.project, grouphash_seer_latest_training_model=training_model
-                    )
-                    assert result is False
+        with self.feature(SEER_GROUPING_NEXT_MODEL_ROLLOUT_FEATURE):
+            result = should_send_to_seer_for_training(
+                self.project, grouphash_seer_latest_training_model="v2.1"
+            )
+            assert result is False

--- a/tests/sentry/seer/similarity/test_utils.py
+++ b/tests/sentry/seer/similarity/test_utils.py
@@ -1042,9 +1042,6 @@ class StacktraceExceedsLimitsTest(TestCase):
                     is True
                 )
 
-    def test_bypassed_platforms_are_checked_for_v2(self) -> None:
-        self._assert_bypassed_platforms_are_checked(GroupingVersion.V2)
-
     def test_bypassed_platforms_are_checked_for_v2_1(self) -> None:
         self._assert_bypassed_platforms_are_checked(GroupingVersion.V2_1)
 


### PR DESCRIPTION
flag was rm'd in https://github.com/getsentry/sentry-options-automator/pull/7624

can be deployed independently of https://github.com/getsentry/seer/pull/6127