### PR TITLE
codemod(button-variant): apply changes for replay-frontend

### DIFF
--- a/static/app/components/events/featureFlags/cta/featureFlagCTAContent.tsx
+++ b/static/app/components/events/featureFlags/cta/featureFlagCTAContent.tsx
@@ -36,11 +36,11 @@ export function FeatureFlagCTAContent({
           )}
         </Container>
         <Flex gap="md">
-          <Button onClick={handleSetupButtonClick} priority="primary">
+          <Button onClick={handleSetupButtonClick} variant="primary">
             {t('Set Up Now')}
           </Button>
           <LinkButton
-            priority="default"
+            variant="secondary"
             href="https://docs.sentry.io/product/explore/feature-flags/"
             external
             onClick={() => {

--- a/static/app/components/events/featureFlags/onboarding/featureFlagOnboardingLayout.tsx
+++ b/static/app/components/events/featureFlags/onboarding/featureFlagOnboardingLayout.tsx
@@ -111,7 +111,7 @@ export function FeatureFlagOnboardingLayout({
                 }
               />
             ))}
-            <StyledLinkButton to="/issues/" priority="primary">
+            <StyledLinkButton to="/issues/" variant="primary">
               {t('Take me to Issues')}
             </StyledLinkButton>
           </Steps>

--- a/static/app/components/replays/breadcrumbs/breadcrumbDescription.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbDescription.tsx
@@ -54,7 +54,7 @@ export function BreadcrumbDescription({
         !showSnippet &&
         frame.data?.nodeId !== undefined &&
         !isSpanFrame(frame) && (
-          <NoWrapButton priority="link" onClick={handleViewHtml} size="xs">
+          <NoWrapButton variant="link" onClick={handleViewHtml} size="xs">
             {t('View HTML')}
           </NoWrapButton>
         )}

--- a/static/app/components/replays/breadcrumbs/breadcrumbWebVital.tsx
+++ b/static/app/components/replays/breadcrumbs/breadcrumbWebVital.tsx
@@ -93,7 +93,7 @@ export function BreadcrumbWebVital({
         >
           <ValueObjectKey>{t('element')}</ValueObjectKey>
           <span>{': '}</span>
-          <SelectorButton size="zero" priority="transparent">
+          <SelectorButton size="zero" variant="transparent">
             {key}
           </SelectorButton>
         </span>
@@ -117,7 +117,7 @@ export function BreadcrumbWebVital({
         />
       </NoMarginWrapper>
       <NoWrapButton
-        priority="link"
+        variant="link"
         size="xs"
         to={{
           pathname: `/organizations/${organization.slug}/insights/frontend/pageloads/`,

--- a/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
+++ b/static/app/components/replays/breadcrumbs/replayComparisonModal.tsx
@@ -83,7 +83,7 @@ export default function ReplayComparisonModal({
                   <Button
                     aria-label={t('Adjust diff')}
                     icon={<IconSliders size="md" />}
-                    priority="transparent"
+                    variant="transparent"
                   />
                 </AutoWideHovercard>
               ) : null}

--- a/static/app/components/replays/canvasSupportNotice.tsx
+++ b/static/app/components/replays/canvasSupportNotice.tsx
@@ -52,7 +52,7 @@ export function CanvasSupportNotice() {
           icon={<IconClose />}
           onClick={dismiss}
           size="zero"
-          priority="transparent"
+          variant="transparent"
         />
       }
     >

--- a/static/app/components/replays/diff/learnMoreButton.tsx
+++ b/static/app/components/replays/diff/learnMoreButton.tsx
@@ -23,7 +23,7 @@ function Resource({
   return (
     <StyledLinkButton
       icon={<IconOpen />}
-      priority="transparent"
+      variant="transparent"
       external
       href={link}
       analyticsEventKey="learn-more-resource.clicked"

--- a/static/app/components/replays/jetpackComposePiiNotice.tsx
+++ b/static/app/components/replays/jetpackComposePiiNotice.tsx
@@ -27,7 +27,7 @@ export function JetpackComposePiiNotice() {
             icon={<IconClose />}
             onClick={dismiss}
             size="zero"
-            priority="transparent"
+            variant="transparent"
           />
         }
       >

--- a/static/app/components/replays/jumpButtons.tsx
+++ b/static/app/components/replays/jumpButtons.tsx
@@ -18,7 +18,7 @@ export function JumpButtons({jump, onClick, tableHeaderHeight}: Props) {
       <JumpButton
         onClick={onClick}
         aria-label={t('Jump Up')}
-        priority="primary"
+        variant="primary"
         size="xs"
         style={{top: `${tableHeaderHeight + offsetFromEdge}px`}}
       >
@@ -31,7 +31,7 @@ export function JumpButtons({jump, onClick, tableHeaderHeight}: Props) {
       <JumpButton
         onClick={onClick}
         aria-label={t('Jump Down')}
-        priority="primary"
+        variant="primary"
         size="xs"
         style={{bottom: `${offsetFromEdge}px`}}
       >

--- a/static/app/components/replays/player/replayPlayPauseButton.tsx
+++ b/static/app/components/replays/player/replayPlayPauseButton.tsx
@@ -23,7 +23,7 @@ export function ReplayPlayPauseButton(props: Partial<ButtonProps>) {
         userAction({type: 'play'});
       }}
       aria-label={t('Restart Replay')}
-      priority="primary"
+      variant="primary"
       {...props}
     />
   ) : (
@@ -32,7 +32,7 @@ export function ReplayPlayPauseButton(props: Partial<ButtonProps>) {
       icon={isPlaying ? <IconPause /> : <IconPlay />}
       onClick={() => userAction(isPlaying ? {type: 'pause'} : {type: 'play'})}
       aria-label={isPlaying ? t('Pause') : t('Play')}
-      priority="primary"
+      variant="primary"
       {...props}
     />
   );

--- a/static/app/components/replays/replayPlayPauseButton.tsx
+++ b/static/app/components/replays/replayPlayPauseButton.tsx
@@ -30,7 +30,7 @@ function OriginalReplayPlayPauseButton(
       icon={<IconRefresh />}
       onClick={restart}
       aria-label={t('Restart Replay')}
-      priority="primary"
+      variant="primary"
       {...props}
     />
   ) : (
@@ -39,7 +39,7 @@ function OriginalReplayPlayPauseButton(
       icon={isPlaying ? <IconPause /> : <IconPlay />}
       onClick={() => togglePlayPause(!isPlaying)}
       aria-label={isPlaying ? t('Pause') : t('Play')}
-      priority="primary"
+      variant="primary"
       disabled={props.isLoading}
       {...props}
     />

--- a/static/app/components/replays/table/deleteReplays.tsx
+++ b/static/app/components/replays/table/deleteReplays.tsx
@@ -114,7 +114,7 @@ export function DeleteReplays({selectedIds, replays, queryOptions}: Props) {
                   </ErrorBoundary>
                 ),
               renderConfirmButton: ({defaultOnClick}) => (
-                <Button onClick={defaultOnClick} priority="danger">
+                <Button onClick={defaultOnClick} variant="danger">
                   {t('Delete')}
                 </Button>
               ),

--- a/static/app/components/replays/table/replayTableColumns.tsx
+++ b/static/app/components/replays/table/replayTableColumns.tsx
@@ -420,7 +420,7 @@ export const ReplayPlayPauseColumn: ReplayTableColumn = {
             pathname: location.pathname,
             query: {...location.query, selected_replay_index: rowIndex},
           }}
-          priority="default"
+          variant="secondary"
           size="sm"
           tooltipProps={{title: t('Play')}}
         />

--- a/static/app/components/replays/timeAndScrubberGrid.tsx
+++ b/static/app/components/replays/timeAndScrubberGrid.tsx
@@ -55,7 +55,7 @@ function TimelineSizeBar({isLoading}: {isLoading?: boolean}) {
         size="xs"
         tooltipProps={{title: t('Zoom out')}}
         icon={<IconSubtract />}
-        priority="transparent"
+        variant="transparent"
         onClick={handleZoomOut}
         aria-label={t('Zoom out')}
         disabled={timelineScale === 1 || isLoading}
@@ -68,7 +68,7 @@ function TimelineSizeBar({isLoading}: {isLoading?: boolean}) {
         size="xs"
         tooltipProps={{title: t('Zoom in')}}
         icon={<IconAdd />}
-        priority="transparent"
+        variant="transparent"
         onClick={handleZoomIn}
         aria-label={t('Zoom in')}
         disabled={timelineScale === maxScale || isLoading}

--- a/static/app/components/replays/unmaskAlert.tsx
+++ b/static/app/components/replays/unmaskAlert.tsx
@@ -29,7 +29,7 @@ export function UnmaskAlert() {
             icon={<IconClose />}
             onClick={dismiss}
             size="zero"
-            priority="transparent"
+            variant="transparent"
           />
         }
       >

--- a/static/app/components/replays/virtualizedGrid/detailsSplitDivider.tsx
+++ b/static/app/components/replays/virtualizedGrid/detailsSplitDivider.tsx
@@ -33,7 +33,7 @@ export function DetailsSplitDivider({
       <CloseButtonWrapper>
         <Button
           aria-label={t('Hide details')}
-          priority="transparent"
+          variant="transparent"
           icon={<IconClose size="sm" variant="muted" />}
           onClick={(e: MouseEvent) => {
             e.preventDefault();

--- a/static/app/views/explore/replays/detail/ai/ai.tsx
+++ b/static/app/views/explore/replays/detail/ai/ai.tsx
@@ -117,7 +117,7 @@ export function Ai() {
               {t('Replay Summary')}
             </Text>
             <Button
-              priority="default"
+              variant="secondary"
               type="button"
               size="xs"
               onClick={() => {

--- a/static/app/views/explore/replays/detail/header/replayDetailsPageBreadcrumbs.tsx
+++ b/static/app/views/explore/replays/detail/header/replayDetailsPageBreadcrumbs.tsx
@@ -95,7 +95,7 @@ export function ReplayDetailsPageBreadcrumbs({readerResult}: Props) {
             >
               <LinkButton
                 size="zero"
-                priority="transparent"
+                variant="transparent"
                 icon={<IconChevron direction="left" size="xs" />}
                 disabled={!previousReplay}
                 aria-label={t('Previous replay based on search query')}
@@ -122,7 +122,7 @@ export function ReplayDetailsPageBreadcrumbs({readerResult}: Props) {
             >
               <LinkButton
                 size="zero"
-                priority="transparent"
+                variant="transparent"
                 icon={<IconChevron direction="right" size="xs" />}
                 disabled={!nextReplay}
                 aria-label={t('Next replay based on search query')}
@@ -171,7 +171,7 @@ export function ReplayDetailsPageBreadcrumbs({readerResult}: Props) {
                   })
                 }
                 size="zero"
-                priority="transparent"
+                variant="transparent"
                 icon={<IconCopy size="xs" variant="muted" />}
               />
             )}
@@ -183,7 +183,7 @@ export function ReplayDetailsPageBreadcrumbs({readerResult}: Props) {
               }}
               data-test-id="refresh-button"
               size="zero"
-              priority="link"
+              variant="link"
               onClick={doRefresh}
               icon={<IconRefresh size="xs" variant="accent" />}
             >

--- a/static/app/views/explore/replays/list/replayOnboardingPanel.tsx
+++ b/static/app/views/explore/replays/list/replayOnboardingPanel.tsx
@@ -235,7 +235,7 @@ export function SetupReplaysCTA({disabled, primaryAction}: SetupReplaysCTAProps)
             data-test-id="setup-replays-btn"
             type="button"
             onClick={() => activateSidebar()}
-            priority="primary"
+            variant="primary"
             disabled={disabled}
           >
             {t('Set Up Replays')}
@@ -259,7 +259,7 @@ export function SetupReplaysCTA({disabled, primaryAction}: SetupReplaysCTAProps)
             path: '/new/',
             organization,
           })}
-          priority="primary"
+          variant="primary"
           disabled={disabled}
         >
           {t('Create Project')}

--- a/static/app/views/explore/replays/list/saveReplayQueryButton.tsx
+++ b/static/app/views/explore/replays/list/saveReplayQueryButton.tsx
@@ -19,7 +19,7 @@ export function SaveReplayQueryButton() {
   };
 
   return (
-    <Button priority="primary" onClick={handleClick}>
+    <Button variant="primary" onClick={handleClick}>
       {t('Save as')}
     </Button>
   );

--- a/static/gsApp/components/replayOnboardingCTA.tsx
+++ b/static/gsApp/components/replayOnboardingCTA.tsx
@@ -178,7 +178,7 @@ function ReplayOnboardingCTAUpsell({
           <LinkButton
             to={`/settings/${organization.slug}/billing/overview/?referrer=replay_onboard-managed-cta`}
             onClick={onClickManageSubscription}
-            priority="primary"
+            variant="primary"
           >
             {t('Manage Subscription')}
           </LinkButton>
@@ -206,12 +206,12 @@ function ReplayOnboardingCTAUpsell({
             <LinkButton
               to={`/settings/${organization.slug}/billing/overview/?referrer=replay_onboard_mmx-cta`}
               onClick={onClickManageSubscription}
-              priority="primary"
+              variant="primary"
             >
               {t('Manage Subscription')}
             </LinkButton>
           ) : (
-            <Button disabled={isDismissed} onClick={onEmailOwner} priority="primary">
+            <Button disabled={isDismissed} onClick={onEmailOwner} variant="primary">
               {t('Request to Update Plan')}
             </Button>
           )}
@@ -239,13 +239,13 @@ function ReplayOnboardingCTAUpsell({
         {hasBillingAccess ? (
           <Button
             onClick={handleOpenModal}
-            priority="primary"
+            variant="primary"
             disabled={didClickOpenModal && previewData.loading}
           >
             {t('Set Up Replays')}
           </Button>
         ) : (
-          <Button disabled={isDismissed} onClick={onEmailOwner} priority="primary">
+          <Button disabled={isDismissed} onClick={onEmailOwner} variant="primary">
             {t('Notify Owner')}
           </Button>
         )}


### PR DESCRIPTION
Applies the [`button-variant` codemod](https://github.com/getsentry/design-engineering/tree/main/codemods/button-variant) to files owned by `@getsentry/replay-frontend`.