### PR TITLE
fix(seer): Persist night shift agent_run_id as soon as the run starts

### DIFF
--- a/src/sentry/tasks/seer/night_shift/agentic_triage.py
+++ b/src/sentry/tasks/seer/night_shift/agentic_triage.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import textwrap
 import time
-from collections.abc import Callable, Sequence
+from collections.abc import Sequence
 
 import pydantic
 import sentry_sdk
@@ -12,6 +12,7 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.seer.agent.client import SeerAgentClient
 from sentry.seer.agent.client_models import SeerRunState
+from sentry.seer.models.night_shift import SeerNightShiftRun
 from sentry.tasks.seer.night_shift.models import TriageAction, TriageResult
 from sentry.tasks.seer.night_shift.simple_triage import (
     ScoredCandidate,
@@ -51,7 +52,7 @@ def agentic_triage_strategy(
     intelligence_level: IntelligenceLevel = DEFAULT_INTELLIGENCE_LEVEL,
     reasoning_effort: ReasoningEffort = DEFAULT_REASONING_EFFORT,
     extra_triage_instructions: str = DEFAULT_EXTRA_TRIAGE_INSTRUCTIONS,
-    on_agent_run_started: Callable[[int], None] | None = None,
+    run: SeerNightShiftRun | None = None,
 ) -> tuple[list[TriageResult], int | None]:
     """
     Select candidates via fixability scoring, then use the Seer Agent
@@ -59,10 +60,10 @@ def agentic_triage_strategy(
 
     Returns a tuple of (triage_results, agent_run_id).
 
-    on_agent_run_started, if provided, is called with the agent run id as
-    soon as the Seer Agent run is started — before the agent has finished
-    polling. This lets callers surface the run id to users (e.g. an
-    Explorer link) without waiting for the full triage to complete.
+    When `run` is provided, the agent run id is persisted onto
+    `run.extras` as soon as the Seer Agent run starts — before the agent
+    finishes polling — so the workflows UI can surface the Explorer link
+    without waiting for the full triage to complete.
     """
     # TODO: try a new way to get scored issues
     scored = fixability_score_strategy(projects, max_candidates)
@@ -75,7 +76,7 @@ def agentic_triage_strategy(
         intelligence_level=intelligence_level,
         reasoning_effort=reasoning_effort,
         extra_triage_instructions=extra_triage_instructions,
-        on_agent_run_started=on_agent_run_started,
+        run=run,
     )
 
 
@@ -86,7 +87,7 @@ def _triage_candidates(
     intelligence_level: IntelligenceLevel,
     reasoning_effort: ReasoningEffort,
     extra_triage_instructions: str,
-    on_agent_run_started: Callable[[int], None] | None = None,
+    run: SeerNightShiftRun | None = None,
 ) -> tuple[list[TriageResult], int | None]:
     """
     Start a Seer Agent run to investigate candidate issues and return
@@ -117,8 +118,8 @@ def _triage_candidates(
             artifact_schema=_TriageResponse,
         )
 
-        if on_agent_run_started is not None:
-            on_agent_run_started(agent_run_id)
+        if run is not None:
+            run.update(extras={**run.extras, "agent_run_id": agent_run_id})
 
         logger.info(
             "night_shift.explorer_run_started",

--- a/src/sentry/tasks/seer/night_shift/agentic_triage.py
+++ b/src/sentry/tasks/seer/night_shift/agentic_triage.py
@@ -58,11 +58,7 @@ def agentic_triage_strategy(
     Select candidates via fixability scoring, then use the Seer Agent
     to investigate each candidate and decide the appropriate action.
 
-    Returns a tuple of (triage_results, agent_run_id). The agent run id
-    is persisted onto `run.extras` as soon as the Seer Agent run starts
-    — before the agent finishes polling — so the workflows UI can
-    surface the Explorer link without waiting for the full triage to
-    complete.
+    Returns a tuple of (triage_results, agent_run_id).
     """
     # TODO: try a new way to get scored issues
     scored = fixability_score_strategy(projects, max_candidates)

--- a/src/sentry/tasks/seer/night_shift/agentic_triage.py
+++ b/src/sentry/tasks/seer/night_shift/agentic_triage.py
@@ -52,18 +52,17 @@ def agentic_triage_strategy(
     intelligence_level: IntelligenceLevel = DEFAULT_INTELLIGENCE_LEVEL,
     reasoning_effort: ReasoningEffort = DEFAULT_REASONING_EFFORT,
     extra_triage_instructions: str = DEFAULT_EXTRA_TRIAGE_INSTRUCTIONS,
-    run: SeerNightShiftRun | None = None,
+    run: SeerNightShiftRun,
 ) -> tuple[list[TriageResult], int | None]:
     """
     Select candidates via fixability scoring, then use the Seer Agent
     to investigate each candidate and decide the appropriate action.
 
-    Returns a tuple of (triage_results, agent_run_id).
-
-    When `run` is provided, the agent run id is persisted onto
-    `run.extras` as soon as the Seer Agent run starts — before the agent
-    finishes polling — so the workflows UI can surface the Explorer link
-    without waiting for the full triage to complete.
+    Returns a tuple of (triage_results, agent_run_id). The agent run id
+    is persisted onto `run.extras` as soon as the Seer Agent run starts
+    — before the agent finishes polling — so the workflows UI can
+    surface the Explorer link without waiting for the full triage to
+    complete.
     """
     # TODO: try a new way to get scored issues
     scored = fixability_score_strategy(projects, max_candidates)
@@ -87,7 +86,7 @@ def _triage_candidates(
     intelligence_level: IntelligenceLevel,
     reasoning_effort: ReasoningEffort,
     extra_triage_instructions: str,
-    run: SeerNightShiftRun | None = None,
+    run: SeerNightShiftRun,
 ) -> tuple[list[TriageResult], int | None]:
     """
     Start a Seer Agent run to investigate candidate issues and return
@@ -118,8 +117,7 @@ def _triage_candidates(
             artifact_schema=_TriageResponse,
         )
 
-        if run is not None:
-            run.update(extras={**run.extras, "agent_run_id": agent_run_id})
+        run.update(extras={**run.extras, "agent_run_id": agent_run_id})
 
         logger.info(
             "night_shift.explorer_run_started",

--- a/src/sentry/tasks/seer/night_shift/agentic_triage.py
+++ b/src/sentry/tasks/seer/night_shift/agentic_triage.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import textwrap
 import time
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 
 import pydantic
 import sentry_sdk
@@ -51,12 +51,18 @@ def agentic_triage_strategy(
     intelligence_level: IntelligenceLevel = DEFAULT_INTELLIGENCE_LEVEL,
     reasoning_effort: ReasoningEffort = DEFAULT_REASONING_EFFORT,
     extra_triage_instructions: str = DEFAULT_EXTRA_TRIAGE_INSTRUCTIONS,
+    on_agent_run_started: Callable[[int], None] | None = None,
 ) -> tuple[list[TriageResult], int | None]:
     """
     Select candidates via fixability scoring, then use the Seer Agent
     to investigate each candidate and decide the appropriate action.
 
     Returns a tuple of (triage_results, agent_run_id).
+
+    on_agent_run_started, if provided, is called with the agent run id as
+    soon as the Seer Agent run is started — before the agent has finished
+    polling. This lets callers surface the run id to users (e.g. an
+    Explorer link) without waiting for the full triage to complete.
     """
     # TODO: try a new way to get scored issues
     scored = fixability_score_strategy(projects, max_candidates)
@@ -69,6 +75,7 @@ def agentic_triage_strategy(
         intelligence_level=intelligence_level,
         reasoning_effort=reasoning_effort,
         extra_triage_instructions=extra_triage_instructions,
+        on_agent_run_started=on_agent_run_started,
     )
 
 
@@ -79,6 +86,7 @@ def _triage_candidates(
     intelligence_level: IntelligenceLevel,
     reasoning_effort: ReasoningEffort,
     extra_triage_instructions: str,
+    on_agent_run_started: Callable[[int], None] | None = None,
 ) -> tuple[list[TriageResult], int | None]:
     """
     Start a Seer Agent run to investigate candidate issues and return
@@ -108,6 +116,9 @@ def _triage_candidates(
             artifact_key="triage_verdicts",
             artifact_schema=_TriageResponse,
         )
+
+        if on_agent_run_started is not None:
+            on_agent_run_started(agent_run_id)
 
         logger.info(
             "night_shift.explorer_run_started",

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -258,18 +258,26 @@ def run_night_shift_execution(
 
     eligible_projects = [ep.project for ep in eligible]
     agent_run_id = None
+
+    def _persist_agent_run_id(started_id: int) -> None:
+        # Persist as soon as the agent starts so the workflows UI can show
+        # the Explorer link immediately, instead of waiting for the full
+        # triage (and downstream autofix) to complete.
+        nonlocal agent_run_id
+        agent_run_id = started_id
+        run.update(extras={**run.extras, "agent_run_id": started_id})
+        log_extra["agent_run_id"] = started_id
+
     try:
-        candidates, agent_run_id = agentic_triage_strategy(
+        candidates, _ = agentic_triage_strategy(
             eligible_projects,
             organization,
             resolved_options["max_candidates"],
             intelligence_level=resolved_options["intelligence_level"],
             reasoning_effort=resolved_options["reasoning_effort"],
             extra_triage_instructions=resolved_options["extra_triage_instructions"],
+            on_agent_run_started=_persist_agent_run_id,
         )
-        if agent_run_id is not None:
-            run.update(extras={**run.extras, "agent_run_id": agent_run_id})
-            log_extra["agent_run_id"] = agent_run_id
     except Exception:
         sentry_sdk.metrics.count("night_shift.run_error", 1)
         _fail_run(

--- a/src/sentry/tasks/seer/night_shift/cron.py
+++ b/src/sentry/tasks/seer/night_shift/cron.py
@@ -257,27 +257,19 @@ def run_night_shift_execution(
         return None
 
     eligible_projects = [ep.project for ep in eligible]
-    agent_run_id = None
-
-    def _persist_agent_run_id(started_id: int) -> None:
-        # Persist as soon as the agent starts so the workflows UI can show
-        # the Explorer link immediately, instead of waiting for the full
-        # triage (and downstream autofix) to complete.
-        nonlocal agent_run_id
-        agent_run_id = started_id
-        run.update(extras={**run.extras, "agent_run_id": started_id})
-        log_extra["agent_run_id"] = started_id
-
+    agent_run_id: int | None = None
     try:
-        candidates, _ = agentic_triage_strategy(
+        candidates, agent_run_id = agentic_triage_strategy(
             eligible_projects,
             organization,
             resolved_options["max_candidates"],
             intelligence_level=resolved_options["intelligence_level"],
             reasoning_effort=resolved_options["reasoning_effort"],
             extra_triage_instructions=resolved_options["extra_triage_instructions"],
-            on_agent_run_started=_persist_agent_run_id,
+            run=run,
         )
+        if agent_run_id is not None:
+            log_extra["agent_run_id"] = agent_run_id
     except Exception:
         sentry_sdk.metrics.count("night_shift.run_error", 1)
         _fail_run(


### PR DESCRIPTION
The `/seer/workflows/` UI gates the Explorer link on `extras.agent_run_id`, but `cron.py` only wrote it after `agentic_triage_strategy` returned — i.e. after the entire triage agent had finished polling. Users had to wait several minutes before they could open a run in Explorer, even though the agent run id is known the moment `client.start_run()` returns.

`agentic_triage_strategy` now takes the `SeerNightShiftRun` directly and writes `agent_run_id` onto `run.extras` as soon as `client.start_run()` returns, so the workflows table can show the Explorer button as soon as the run is actually running rather than after the full triage (and downstream autofix) completes.