### PR TITLE
fix(seer): Tidy up the workflows table

### DIFF
--- a/src/sentry/tasks/seer/night_shift/agentic_triage.py
+++ b/src/sentry/tasks/seer/night_shift/agentic_triage.py
@@ -52,13 +52,18 @@ def agentic_triage_strategy(
     intelligence_level: IntelligenceLevel = DEFAULT_INTELLIGENCE_LEVEL,
     reasoning_effort: ReasoningEffort = DEFAULT_REASONING_EFFORT,
     extra_triage_instructions: str = DEFAULT_EXTRA_TRIAGE_INSTRUCTIONS,
-    run: SeerNightShiftRun,
+    run: SeerNightShiftRun | None = None,
 ) -> tuple[list[TriageResult], int | None]:
     """
     Select candidates via fixability scoring, then use the Seer Agent
     to investigate each candidate and decide the appropriate action.
 
     Returns a tuple of (triage_results, agent_run_id).
+
+    When `run` is provided, the agent run id is persisted onto
+    `run.extras` as soon as the Seer Agent run starts — before the agent
+    finishes polling — so the workflows UI can surface the Explorer link
+    without waiting for the full triage to complete.
     """
     # TODO: try a new way to get scored issues
     scored = fixability_score_strategy(projects, max_candidates)
@@ -82,7 +87,7 @@ def _triage_candidates(
     intelligence_level: IntelligenceLevel,
     reasoning_effort: ReasoningEffort,
     extra_triage_instructions: str,
-    run: SeerNightShiftRun,
+    run: SeerNightShiftRun | None = None,
 ) -> tuple[list[TriageResult], int | None]:
     """
     Start a Seer Agent run to investigate candidate issues and return
@@ -113,7 +118,8 @@ def _triage_candidates(
             artifact_schema=_TriageResponse,
         )
 
-        run.update(extras={**run.extras, "agent_run_id": agent_run_id})
+        if run is not None:
+            run.update(extras={**run.extras, "agent_run_id": agent_run_id})
 
         logger.info(
             "night_shift.explorer_run_started",

--- a/src/sentry/tasks/seer/night_shift/agentic_triage.py
+++ b/src/sentry/tasks/seer/night_shift/agentic_triage.py
@@ -58,11 +58,7 @@ def agentic_triage_strategy(
     Select candidates via fixability scoring, then use the Seer Agent
     to investigate each candidate and decide the appropriate action.
 
-    Returns a tuple of (triage_results, agent_run_id). The agent run id
-    is persisted onto `run.extras` as soon as the Seer Agent run starts
-    — before the agent finishes polling — so the workflows UI can
-    surface the Explorer link without waiting for the full triage to
-    complete.
+    Returns a tuple of (triage_results, agent_run_id).
     """
     # TODO: try a new way to get scored issues
     scored = fixability_score_strategy(projects, max_candidates)

--- a/src/sentry/tasks/seer/night_shift/agentic_triage.py
+++ b/src/sentry/tasks/seer/night_shift/agentic_triage.py
@@ -52,18 +52,17 @@ def agentic_triage_strategy(
     intelligence_level: IntelligenceLevel = DEFAULT_INTELLIGENCE_LEVEL,
     reasoning_effort: ReasoningEffort = DEFAULT_REASONING_EFFORT,
     extra_triage_instructions: str = DEFAULT_EXTRA_TRIAGE_INSTRUCTIONS,
-    run: SeerNightShiftRun | None = None,
+    run: SeerNightShiftRun,
 ) -> tuple[list[TriageResult], int | None]:
     """
     Select candidates via fixability scoring, then use the Seer Agent
     to investigate each candidate and decide the appropriate action.
 
-    Returns a tuple of (triage_results, agent_run_id).
-
-    When `run` is provided, the agent run id is persisted onto
-    `run.extras` as soon as the Seer Agent run starts — before the agent
-    finishes polling — so the workflows UI can surface the Explorer link
-    without waiting for the full triage to complete.
+    Returns a tuple of (triage_results, agent_run_id). The agent run id
+    is persisted onto `run.extras` as soon as the Seer Agent run starts
+    — before the agent finishes polling — so the workflows UI can
+    surface the Explorer link without waiting for the full triage to
+    complete.
     """
     # TODO: try a new way to get scored issues
     scored = fixability_score_strategy(projects, max_candidates)
@@ -87,7 +86,7 @@ def _triage_candidates(
     intelligence_level: IntelligenceLevel,
     reasoning_effort: ReasoningEffort,
     extra_triage_instructions: str,
-    run: SeerNightShiftRun | None = None,
+    run: SeerNightShiftRun,
 ) -> tuple[list[TriageResult], int | None]:
     """
     Start a Seer Agent run to investigate candidate issues and return
@@ -118,8 +117,7 @@ def _triage_candidates(
             artifact_schema=_TriageResponse,
         )
 
-        if run is not None:
-            run.update(extras={**run.extras, "agent_run_id": agent_run_id})
+        run.update(extras={**run.extras, "agent_run_id": agent_run_id})
 
         logger.info(
             "night_shift.explorer_run_started",

--- a/static/app/views/seerWorkflows/index.spec.tsx
+++ b/static/app/views/seerWorkflows/index.spec.tsx
@@ -38,8 +38,27 @@ describe('SeerWorkflows', () => {
 
     expect(await screen.findByText('Night Shift')).toBeInTheDocument();
     expect(screen.getByText('agentic')).toBeInTheDocument();
-    expect(screen.getByText('Completed')).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Seer Workflows'})).toBeInTheDocument();
+  });
+
+  it('shows the error message inline when a run failed', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/workflows/`,
+      body: [
+        {
+          id: '1',
+          dateAdded: '2026-04-20T00:00:00Z',
+          triageStrategy: 'agentic',
+          errorMessage: 'No Seer quota available',
+          extras: {},
+          issues: [],
+        },
+      ],
+    });
+
+    render(<SeerWorkflows />, {organization});
+
+    expect(await screen.findByText('No Seer quota available')).toBeInTheDocument();
   });
 
   it('expands a row to show issue drill-down', async () => {

--- a/static/app/views/seerWorkflows/index.tsx
+++ b/static/app/views/seerWorkflows/index.tsx
@@ -89,9 +89,10 @@ function SeerWorkflows() {
         ) : isPending ? (
           <LoadingIndicator />
         ) : (
-          <Container width="100%">
+          <Container width={{md: '100%', lg: '60%'}}>
             <RunsTable>
               <SimpleTable.Header>
+                <SimpleTable.HeaderCell />
                 <SimpleTable.HeaderCell />
                 <SimpleTable.HeaderCell>{t('Date')}</SimpleTable.HeaderCell>
                 <SimpleTable.HeaderCell>{t('Workflow')}</SimpleTable.HeaderCell>
@@ -99,7 +100,6 @@ function SeerWorkflows() {
                 <SimpleTable.HeaderCell>{t('Max candidates')}</SimpleTable.HeaderCell>
                 <SimpleTable.HeaderCell>{t('Source')}</SimpleTable.HeaderCell>
                 <SimpleTable.HeaderCell>{t('Issues')}</SimpleTable.HeaderCell>
-                <SimpleTable.HeaderCell />
               </SimpleTable.Header>
 
               {data?.length === 0 ? (
@@ -123,6 +123,20 @@ function SeerWorkflows() {
                           />
                         </SimpleTable.RowCell>
                         <SimpleTable.RowCell>
+                          {explorerRunId === null ? null : (
+                            <LinkButton
+                              size="xs"
+                              icon={<IconOpen />}
+                              to={{
+                                pathname: `/organizations/${organization.slug}/seer/workflows/`,
+                                query: {explorerRunId},
+                              }}
+                            >
+                              {t('Explorer')}
+                            </LinkButton>
+                          )}
+                        </SimpleTable.RowCell>
+                        <SimpleTable.RowCell>
                           <DateTime date={run.dateAdded} />
                         </SimpleTable.RowCell>
                         <SimpleTable.RowCell>{t('Night Shift')}</SimpleTable.RowCell>
@@ -142,20 +156,6 @@ function SeerWorkflows() {
                             <Text variant="muted">{t('dry run')}</Text>
                           ) : (
                             run.issues.length
-                          )}
-                        </SimpleTable.RowCell>
-                        <SimpleTable.RowCell>
-                          {explorerRunId === null ? null : (
-                            <LinkButton
-                              size="xs"
-                              icon={<IconOpen />}
-                              to={{
-                                pathname: `/organizations/${organization.slug}/seer/workflows/`,
-                                query: {explorerRunId},
-                              }}
-                            >
-                              {t('Explorer')}
-                            </LinkButton>
                           )}
                         </SimpleTable.RowCell>
                       </SimpleTable.Row>
@@ -309,7 +309,7 @@ function RunDetail({
 }
 
 const RunsTable = styled(SimpleTable)`
-  grid-template-columns: min-content 1fr 1fr 1fr 1fr 1fr 1fr min-content;
+  grid-template-columns: min-content min-content 1fr 1fr 1fr 1fr 1fr 1fr;
 `;
 
 function getExplorerRunId(run: SeerNightShiftRun): number | string | null {

--- a/static/app/views/seerWorkflows/index.tsx
+++ b/static/app/views/seerWorkflows/index.tsx
@@ -89,7 +89,7 @@ function SeerWorkflows() {
         ) : isPending ? (
           <LoadingIndicator />
         ) : (
-          <Container width={{md: '100%', lg: '50%'}}>
+          <Container width="100%">
             <RunsTable>
               <SimpleTable.Header>
                 <SimpleTable.HeaderCell />

--- a/static/app/views/seerWorkflows/index.tsx
+++ b/static/app/views/seerWorkflows/index.tsx
@@ -98,7 +98,6 @@ function SeerWorkflows() {
                 <SimpleTable.HeaderCell>{t('Strategy')}</SimpleTable.HeaderCell>
                 <SimpleTable.HeaderCell>{t('Max candidates')}</SimpleTable.HeaderCell>
                 <SimpleTable.HeaderCell>{t('Source')}</SimpleTable.HeaderCell>
-                <SimpleTable.HeaderCell>{t('Status')}</SimpleTable.HeaderCell>
                 <SimpleTable.HeaderCell>{t('Issues')}</SimpleTable.HeaderCell>
                 <SimpleTable.HeaderCell />
               </SimpleTable.Header>
@@ -108,7 +107,6 @@ function SeerWorkflows() {
               ) : (
                 (data ?? []).map(run => {
                   const isExpanded = expanded.has(run.id);
-                  const status = run.errorMessage ? t('Error') : t('Completed');
                   const explorerRunId = getExplorerRunId(run);
                   return (
                     <Fragment key={run.id}>
@@ -136,12 +134,11 @@ function SeerWorkflows() {
                           {run.extras.options?.source ?? '-'}
                         </SimpleTable.RowCell>
                         <SimpleTable.RowCell>
-                          <Text variant={run.errorMessage ? 'danger' : undefined}>
-                            {status}
-                          </Text>
-                        </SimpleTable.RowCell>
-                        <SimpleTable.RowCell>
-                          {run.extras.options?.dry_run ? (
+                          {run.errorMessage ? (
+                            <Text variant="danger" size="sm">
+                              {run.errorMessage}
+                            </Text>
+                          ) : run.extras.options?.dry_run ? (
                             <Text variant="muted">{t('dry run')}</Text>
                           ) : (
                             run.issues.length
@@ -312,7 +309,7 @@ function RunDetail({
 }
 
 const RunsTable = styled(SimpleTable)`
-  grid-template-columns: min-content 1fr 1fr 1fr 1fr 1fr 1fr min-content min-content;
+  grid-template-columns: min-content 1fr 1fr 1fr 1fr 1fr 1fr min-content;
 `;
 
 function getExplorerRunId(run: SeerNightShiftRun): number | string | null {


### PR DESCRIPTION
A few small fixes to the `/seer/workflows/` table:

**Cap the table at 60% on wide screens**

The original 50% cap squeezed the table on its own but kept room for the Ask Seer drawer to sit beside it. 60% gives the table more breathing room while still leaving the drawer space.

**Drop the Status column, surface errors inline**

The Status column showed "Completed" the entire time a run was executing, which was a lie — the row is created at the start of the run and the only completion-adjacent backend signal we have is `error_message`. The Explorer link already covers "is something happening" for in-flight runs, so the column wasn't earning its keep. When a run errors, the message now renders inline in the Issues cell.

**Move Explorer to the first column after the chevron**

It's the most useful action on each row, so put it where you don't have to look for it.

Stacked on #114544.