### PR TITLE
ref(button-variant): shim downstream components for priority/variant compat

### DIFF
--- a/static/app/components/core/segmentedControl/segmentedControl.tsx
+++ b/static/app/components/core/segmentedControl/segmentedControl.tsx
@@ -17,7 +17,7 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 
 import type {FormSize, Theme} from 'sentry/utils/theme';
 
-type Priority = 'default' | 'primary';
+type Priority = 'default' | 'primary' | 'secondary';
 
 const getChildTransforms = (count: number) => {
   return Array.from(
@@ -41,7 +41,7 @@ function getTextColor({
   isDisabled?: boolean;
 }) {
   if (isSelected) {
-    return priority === 'default'
+    return priority === 'default' || priority === 'secondary'
       ? theme.tokens.interactive.chonky.embossed.neutral.content.accent
       : undefined;
   }

--- a/static/app/components/dropdownButton.tsx
+++ b/static/app/components/dropdownButton.tsx
@@ -4,6 +4,8 @@ import type {DistributedOmit} from 'type-fest';
 
 import type {ButtonProps} from '@sentry/scraps/button';
 import {Button} from '@sentry/scraps/button';
+// eslint-disable-next-line boundaries/dependencies
+import {DO_NOT_USE_resolveButtonVariant as resolveButtonVariant} from '@sentry/scraps/button/types';
 
 import {IconChevron} from 'sentry/icons';
 
@@ -51,9 +53,7 @@ export function DropdownButton({
       {showChevron && (
         <ChevronWrap>
           <IconChevron
-            variant={
-              !props.priority || props.priority === 'default' ? 'muted' : undefined
-            }
+            variant={resolveButtonVariant(props) === 'secondary' ? 'muted' : undefined}
             direction={isOpen ? 'up' : 'down'}
             size={size === 'zero' || size === 'xs' ? 'xs' : 'sm'}
           />


### PR DESCRIPTION
Prerequisite for [button `priority -> variant` migration](https://github.com/getsentry/sentry/pull/113838) via codemod.

Updates downstream components that check button `priority` to also handle the new `variant` prop, ensuring a smooth migration path:

- **DropdownButton**: chevron icon color check now uses `resolveButtonVariant()` so it works with both `priority` and `variant` callers
- **SegmentedControl**: `Priority` type now includes `'secondary'` and `getTextColor` handles both `'default'` and `'secondary'`