### PR TITLE
ref(🥞): wire portal consumers to Layer outlets

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -23,8 +23,6 @@ const productionEntryPoints = [
   'static/app/chartcuterie/**/*.{js,ts,tsx}',
   // TODO: Remove when used
   'static/app/views/seerExplorer/contexts/**/*.{js,ts,tsx}',
-  // TODO: Remove when Layer consumers land (nm/zindex/wire-portals)
-  'static/app/components/core/layer/*.{ts,tsx}',
 ];
 
 const testingEntryPoints = [

--- a/static/app/components/core/layer/index.tsx
+++ b/static/app/components/core/layer/index.tsx
@@ -1,1 +1,2 @@
-export {Layer, useLayerContext, usePortalContainer} from './layer';
+export {Layer, LayerContext, useLayerContext, usePortalContainer} from './layer';
+export type {LayerContextValue} from './layer';

--- a/static/app/components/core/layer/index.tsx
+++ b/static/app/components/core/layer/index.tsx
@@ -1,1 +1,1 @@
-export {Layer, LayerContext, useLayerContext, usePortalContainer} from './layer';
+export {Layer, LayerContext, usePortalContainer} from './layer';

--- a/static/app/components/core/layer/index.tsx
+++ b/static/app/components/core/layer/index.tsx
@@ -1,1 +1,1 @@
-export {Layer, LayerContext, usePortalContainer} from './layer';
+export {Layer, LayerContext, useLayerContext, usePortalContainer} from './layer';

--- a/static/app/components/core/layer/index.tsx
+++ b/static/app/components/core/layer/index.tsx
@@ -1,2 +1,1 @@
 export {Layer, LayerContext, useLayerContext, usePortalContainer} from './layer';
-export type {LayerContextValue} from './layer';

--- a/static/app/components/core/layer/layer.tsx
+++ b/static/app/components/core/layer/layer.tsx
@@ -64,10 +64,6 @@ export const Layer = styled(
   isolation: isolate;
 `;
 
-export function useLayerContext(): LayerContextValue {
-  return useContext(LayerContext);
-}
-
 export function usePortalContainer(): HTMLElement | null {
   return useLayerContext().portalOutlet;
 }

--- a/static/app/components/core/layer/layer.tsx
+++ b/static/app/components/core/layer/layer.tsx
@@ -5,7 +5,7 @@ import {HoverOverlayGroupProvider} from 'sentry/utils/useHoverOverlay';
 
 type LayerVariant = 'content' | 'nav' | 'overlay';
 
-export interface LayerContextValue {
+interface LayerContextValue {
   depth: number;
   portalOutlet: HTMLElement | null;
   variant: LayerVariant | null;

--- a/static/app/components/core/layer/layer.tsx
+++ b/static/app/components/core/layer/layer.tsx
@@ -64,6 +64,10 @@ export const Layer = styled(
   isolation: isolate;
 `;
 
+export function useLayerContext(): LayerContextValue {
+  return useContext(LayerContext);
+}
+
 export function usePortalContainer(): HTMLElement | null {
   return useLayerContext().portalOutlet;
 }

--- a/static/app/components/core/layer/layer.tsx
+++ b/static/app/components/core/layer/layer.tsx
@@ -5,13 +5,13 @@ import {HoverOverlayGroupProvider} from 'sentry/utils/useHoverOverlay';
 
 type LayerVariant = 'content' | 'nav' | 'overlay';
 
-interface LayerContextValue {
+export interface LayerContextValue {
   depth: number;
   portalOutlet: HTMLElement | null;
   variant: LayerVariant | null;
 }
 
-const LayerContext = createContext<LayerContextValue>({
+export const LayerContext = createContext<LayerContextValue>({
   variant: null,
   depth: 0,
   portalOutlet: null,

--- a/static/app/components/core/slot/knownContexts.ts
+++ b/static/app/components/core/slot/knownContexts.ts
@@ -1,4 +1,7 @@
 import {LayerContext} from '@sentry/scraps/layer';
 import {SizeContext} from '@sentry/scraps/sizeContext';
 
-export const KNOWN_BRIDGED_CONTEXTS = [LayerContext, SizeContext] as const;
+export const KNOWN_BRIDGED_CONTEXTS: Array<React.Context<any>> = [
+  LayerContext,
+  SizeContext,
+];

--- a/static/app/components/core/slot/knownContexts.ts
+++ b/static/app/components/core/slot/knownContexts.ts
@@ -1,3 +1,4 @@
+import {LayerContext} from '@sentry/scraps/layer';
 import {SizeContext} from '@sentry/scraps/sizeContext';
 
-export const KNOWN_BRIDGED_CONTEXTS = [SizeContext] as const;
+export const KNOWN_BRIDGED_CONTEXTS = [LayerContext, SizeContext] as const;

--- a/static/app/components/core/slot/slot.tsx
+++ b/static/app/components/core/slot/slot.tsx
@@ -201,7 +201,7 @@ type SlotModule<T extends Slot> = React.FunctionComponent<SlotConsumerProps<T>> 
 };
 
 function useContextBridges(): ContextBridge[] {
-  const values = KNOWN_BRIDGED_CONTEXTS.map(ctx => use(ctx));
+  const values: unknown[] = KNOWN_BRIDGED_CONTEXTS.map(ctx => use(ctx));
   const [prev, setPrev] = useState<ContextBridge[]>([]);
 
   const changed =

--- a/static/app/components/core/slot/slot.tsx
+++ b/static/app/components/core/slot/slot.tsx
@@ -201,6 +201,7 @@ type SlotModule<T extends Slot> = React.FunctionComponent<SlotConsumerProps<T>> 
 };
 
 function useContextBridges(): ContextBridge[] {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
   const values: unknown[] = KNOWN_BRIDGED_CONTEXTS.map(ctx => use(ctx));
   const [prev, setPrev] = useState<ContextBridge[]>([]);
 

--- a/static/app/components/core/tooltip/tooltip.tsx
+++ b/static/app/components/core/tooltip/tooltip.tsx
@@ -1,9 +1,10 @@
 import {createContext, Fragment, useContext, useLayoutEffect} from 'react';
 import {createPortal} from 'react-dom';
 import type {SerializedStyles} from '@emotion/react';
-import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {AnimatePresence} from 'framer-motion';
+
+import {usePortalContainer} from '@sentry/scraps/layer';
 
 import {Overlay, PositionWrapper} from 'sentry/components/overlay';
 import type {UseHoverOverlayProps} from 'sentry/utils/useHoverOverlay';
@@ -48,8 +49,8 @@ export function Tooltip({
   maxWidth,
   ...hoverOverlayProps
 }: TooltipProps) {
-  const theme = useTheme();
   const {container} = useContext(TooltipContext);
+  const layerPortal = usePortalContainer();
   const {
     wrapTrigger,
     isOpen,
@@ -95,7 +96,7 @@ export function Tooltip({
         snapClosed ? null : (
           <AnimatePresence>
             {isOpen ? (
-              <PositionWrapper zIndex={theme.zIndex.tooltip} {...overlayProps}>
+              <PositionWrapper {...overlayProps}>
                 <TooltipContent
                   animated
                   maxWidth={maxWidth}
@@ -111,7 +112,7 @@ export function Tooltip({
             ) : null}
           </AnimatePresence>
         ),
-        container ?? document.body
+        layerPortal ?? container ?? document.body
       )}
     </Fragment>
   );

--- a/static/app/components/dropdownMenu/index.tsx
+++ b/static/app/components/dropdownMenu/index.tsx
@@ -6,6 +6,8 @@ import {useMenuTrigger} from '@react-aria/menu';
 import {Item, Section} from '@react-stately/collections';
 import type {LocationDescriptor} from 'history';
 
+import {usePortalContainer} from '@sentry/scraps/layer';
+
 import type {DropdownButtonProps} from 'sentry/components/dropdownButton';
 import {DropdownButton} from 'sentry/components/dropdownButton';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
@@ -190,6 +192,7 @@ function DropdownMenu({
   ...props
 }: DropdownMenuProps) {
   const isDisabled = disabledProp ?? (!items || items.length === 0);
+  const layerPortal = usePortalContainer();
 
   const {rootOverlayState} = useContext(DropdownMenuContext);
   const {
@@ -296,7 +299,7 @@ function DropdownMenu({
     );
 
     return usePortal
-      ? createPortal(menu, portalContainerRef?.current ?? document.body)
+      ? createPortal(menu, portalContainerRef?.current ?? layerPortal ?? document.body)
       : menu;
   }
 

--- a/static/app/components/dropdownMenu/index.tsx
+++ b/static/app/components/dropdownMenu/index.tsx
@@ -146,12 +146,9 @@ export interface DropdownMenuProps
    */
   triggerProps?: Partial<DropdownButtonProps>;
   /**
-   * Whether to render the menu inside a React portal (false by default). This should
-   * only be enabled if necessary, e.g. when the dropdown menu is inside a small,
-   * scrollable container that messes with the menu's position. Some features, namely
-   * submenus, will not work correctly inside portals.
-   *
-   * Consider passing `strategy` as `'fixed'` before using `usePortal`
+   * Whether to render the menu inside a React portal. When unset, auto-portals
+   * into the nearest Layer's PortalOutlet (if inside a Layer). Set to `false` to
+   * force inline rendering (e.g. for submenus that need focus containment).
    */
   usePortal?: boolean;
 }
@@ -173,7 +170,7 @@ function DropdownMenu({
   className,
 
   // Overlay props
-  usePortal = false,
+  usePortal: usePortalProp,
   offset = 8,
   position = 'bottom-start',
   isDismissable = true,
@@ -193,6 +190,7 @@ function DropdownMenu({
 }: DropdownMenuProps) {
   const isDisabled = disabledProp ?? (!items || items.length === 0);
   const layerPortal = usePortalContainer();
+  const usePortal = usePortalProp ?? layerPortal !== null;
 
   const {rootOverlayState} = useContext(DropdownMenuContext);
   const {

--- a/static/app/components/hovercard.tsx
+++ b/static/app/components/hovercard.tsx
@@ -6,6 +6,8 @@ import type {State} from '@popperjs/core';
 import {useResizeObserver} from '@react-aria/utils';
 import {AnimatePresence} from 'framer-motion';
 
+import {usePortalContainer} from '@sentry/scraps/layer';
+
 import {Overlay, PositionWrapper} from 'sentry/components/overlay';
 import type {UseHoverOverlayProps} from 'sentry/utils/useHoverOverlay';
 import {HoverOverlayGroupProvider, useHoverOverlay} from 'sentry/utils/useHoverOverlay';
@@ -92,11 +94,10 @@ function HovercardContent({
   header,
   hoverOverlayState: {arrowData, arrowProps, overlayProps, placement, update},
 }: HovercardContentProps) {
-  const theme = useTheme();
   const ref = useUpdateOverlayPositionOnContentChange({update});
 
   return (
-    <PositionWrapper zIndex={theme.zIndex.hovercard} {...overlayProps}>
+    <PositionWrapper {...overlayProps}>
       <StyledHovercard
         animated={animated}
         arrowProps={{
@@ -125,10 +126,11 @@ function Hovercard({
   offset = 12,
   displayTimeout = 100,
   animated = true,
-  portalContainer = document.body,
+  portalContainer,
   ...hoverOverlayProps
 }: HovercardProps): React.ReactElement {
   const theme = useTheme();
+  const layerPortal = usePortalContainer();
   const {wrapTrigger, isOpen, snapClosed, ...hoverOverlayState} = useHoverOverlay({
     offset,
     displayTimeout,
@@ -183,7 +185,7 @@ function Hovercard({
       {wrapTrigger(children)}
       {createPortal(
         <HoverOverlayGroupProvider>{hovercard}</HoverOverlayGroupProvider>,
-        portalContainer
+        portalContainer ?? layerPortal ?? document.body
       )}
     </HovercardContext.Provider>
   );

--- a/static/app/components/overlay.tsx
+++ b/static/app/components/overlay.tsx
@@ -143,8 +143,6 @@ const OverlayInner = styled(motion.div)<{
   box-shadow: 0 2px 0 ${p => p.theme.tokens.border.primary};
   font-size: ${p => p.theme.font.size.md};
 
-  /* Override z-index from useOverlayPosition */
-  z-index: ${p => p.theme.zIndex.dropdown} !important;
   will-change: transform, opacity;
 
   /* Specificity hack to allow override styles to have higher specificity than
@@ -155,11 +153,12 @@ const OverlayInner = styled(motion.div)<{
 `;
 
 interface PositionWrapperProps extends React.HTMLAttributes<HTMLDivElement> {
-  /**
-   * Determines the zindex over the position wrapper
-   */
-  zIndex: number;
   ref?: React.Ref<HTMLDivElement>;
+  /**
+   * @deprecated Stacking is handled by Layer portal outlets. Only pass
+   * this when rendering outside a Layer.
+   */
+  zIndex?: number;
 }
 
 /**

--- a/static/app/views/dashboards/widgets/widget/widget.tsx
+++ b/static/app/views/dashboards/widgets/widget/widget.tsx
@@ -2,6 +2,7 @@ import {Fragment} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import {Layer} from '@sentry/scraps/layer';
 import {Container, Flex} from '@sentry/scraps/layout';
 
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
@@ -72,39 +73,41 @@ function WidgetLayout(props: Widget) {
       revealActions={revealActions}
       minHeight={defined(props.height) ? Math.min(props.height, MIN_HEIGHT) : MIN_HEIGHT}
     >
-      <Header noPadding={props.noHeaderPadding}>
-        {props.Title && <Fragment>{props.Title}</Fragment>}
-        {props.TitleBadges && (
-          <Flex align="center" gap="xs">
-            {props.TitleBadges}
-          </Flex>
+      <WidgetLayer variant="nav">
+        <Header noPadding={props.noHeaderPadding}>
+          {props.Title && <Fragment>{props.Title}</Fragment>}
+          {props.TitleBadges && (
+            <Flex align="center" gap="xs">
+              {props.TitleBadges}
+            </Flex>
+          )}
+          {props.Actions && <TitleHoverItems>{props.Actions}</TitleHoverItems>}
+        </Header>
+
+        {props.Visualization && (
+          <VisualizationWrapper noPadding={props.noVisualizationPadding}>
+            <ErrorBoundary
+              customComponent={({error}) => (
+                <Container position="absolute" inset={0}>
+                  <WidgetError error={error ?? undefined} />
+                </Container>
+              )}
+            >
+              {props.Visualization}
+            </ErrorBoundary>
+          </VisualizationWrapper>
         )}
-        {props.Actions && <TitleHoverItems>{props.Actions}</TitleHoverItems>}
-      </Header>
 
-      {props.Visualization && (
-        <VisualizationWrapper noPadding={props.noVisualizationPadding}>
-          <ErrorBoundary
-            customComponent={({error}) => (
-              <Container position="absolute" inset={0}>
-                <WidgetError error={error ?? undefined} />
-              </Container>
-            )}
-          >
-            {props.Visualization}
-          </ErrorBoundary>
-        </VisualizationWrapper>
-      )}
-
-      {props.Footer && (
-        <FooterWrapper noPadding={props.noFooterPadding}>
-          <ErrorBoundary
-            customComponent={({error}) => <WidgetError error={error ?? undefined} />}
-          >
-            {props.Footer}
-          </ErrorBoundary>
-        </FooterWrapper>
-      )}
+        {props.Footer && (
+          <FooterWrapper noPadding={props.noFooterPadding}>
+            <ErrorBoundary
+              customComponent={({error}) => <WidgetError error={error ?? undefined} />}
+            >
+              {props.Footer}
+            </ErrorBoundary>
+          </FooterWrapper>
+        )}
+      </WidgetLayer>
     </Frame>
   );
 }
@@ -173,6 +176,13 @@ export const Header = styled('div')<{noPadding?: boolean}>`
   gap: ${p => p.theme.space.sm};
   padding: ${p =>
     p.noPadding ? 0 : `${p.theme.space.lg} ${p.theme.space.xl} 0 ${p.theme.space.xl}`};
+`;
+
+const WidgetLayer = styled(Layer)`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
 `;
 
 const VisualizationWrapper = styled('div')<{noPadding?: boolean}>`

--- a/static/app/views/discover/savedQuery/index.tsx
+++ b/static/app/views/discover/savedQuery/index.tsx
@@ -1,5 +1,5 @@
 import {Fragment, PureComponent} from 'react';
-import {useTheme} from '@emotion/react';
+import {createPortal} from 'react-dom';
 import styled from '@emotion/styled';
 import {FocusScope} from '@react-aria/focus';
 import {AnimatePresence} from 'framer-motion';
@@ -8,6 +8,7 @@ import isEqual from 'lodash/isEqual';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
 import {Input} from '@sentry/scraps/input';
+import {usePortalContainer} from '@sentry/scraps/layer';
 import {Flex, Grid, type GridProps} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -90,7 +91,7 @@ export function SaveAsDropdown({
   const {isOpen, triggerProps, overlayProps, arrowProps} = useOverlay({
     position: 'bottom',
   });
-  const theme = useTheme();
+  const layerPortal = usePortalContainer();
 
   return (
     <div>
@@ -103,36 +104,39 @@ export function SaveAsDropdown({
       >
         {t('Save as')}
       </Button>
-      <AnimatePresence>
-        {isOpen && (
-          <PositionWrapper zIndex={theme.zIndex.dropdown} {...overlayProps}>
-            <StyledOverlay arrowProps={arrowProps} animated>
-              <FocusScope contain restoreFocus autoFocus>
-                <form onSubmit={modifiedHandleCreateQuery}>
-                  <Flex gap="md" direction="column">
-                    <Input
-                      type="text"
-                      name="query_name"
-                      placeholder={t('Display name')}
-                      value={queryName || ''}
-                      onChange={onChangeInput}
-                      disabled={disabled}
-                    />
-                    <SaveAsButton
-                      type="submit"
-                      onClick={modifiedHandleCreateQuery}
-                      variant="primary"
-                      disabled={disabled || !queryName}
-                    >
-                      {t('Save for Organization')}
-                    </SaveAsButton>
-                  </Flex>
-                </form>
-              </FocusScope>
-            </StyledOverlay>
-          </PositionWrapper>
-        )}
-      </AnimatePresence>
+      {createPortal(
+        <AnimatePresence>
+          {isOpen && (
+            <PositionWrapper {...overlayProps}>
+              <StyledOverlay arrowProps={arrowProps} animated>
+                <FocusScope contain restoreFocus autoFocus>
+                  <form onSubmit={modifiedHandleCreateQuery}>
+                    <Flex gap="md" direction="column">
+                      <Input
+                        type="text"
+                        name="query_name"
+                        placeholder={t('Display name')}
+                        value={queryName || ''}
+                        onChange={onChangeInput}
+                        disabled={disabled}
+                      />
+                      <SaveAsButton
+                        type="submit"
+                        onClick={modifiedHandleCreateQuery}
+                        variant="primary"
+                        disabled={disabled || !queryName}
+                      >
+                        {t('Save for Organization')}
+                      </SaveAsButton>
+                    </Flex>
+                  </form>
+                </FocusScope>
+              </StyledOverlay>
+            </PositionWrapper>
+          )}
+        </AnimatePresence>,
+        layerPortal ?? document.body
+      )}
     </div>
   );
 }

--- a/static/app/views/issueDetails/streamline/groupDetailsLayout.tsx
+++ b/static/app/views/issueDetails/streamline/groupDetailsLayout.tsx
@@ -1,6 +1,7 @@
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import {Layer} from '@sentry/scraps/layer';
 import {Container} from '@sentry/scraps/layout';
 
 import {t} from 'sentry/locale';
@@ -58,63 +59,65 @@ export function GroupDetailsLayout({
 
   return (
     <IssueDetailsContextProvider>
-      <Container
-        display="contents"
-        style={
-          hasPageFrameFeature
-            ? ({'--issue-details-inset': theme.space.xl} as React.CSSProperties)
-            : undefined
-        }
-      >
-        <StreamlinedGroupHeader group={group} event={event ?? null} project={project} />
-        <GroupLayoutBody>
-          <div>
-            <SharedTourElement<IssueDetailsTour>
-              id={IssueDetailsTour.AGGREGATES}
-              demoTourId={DemoTourStep.ISSUES_AGGREGATES}
-              tourContext={IssueDetailsTourContext}
-              title={t('See overall impact')}
-              description={t(
-                "Here you'll see aggregate metrics like frequency over time, total affected users, and where it occurs (environment, release, device, etc.)."
-              )}
-              position="bottom"
-            >
-              {tourProps => (
-                <div {...tourProps}>
-                  <EventDetailsHeader event={event} group={group} project={project} />
-                </div>
-              )}
-            </SharedTourElement>
-            <SharedTourElement<IssueDetailsTour>
-              id={IssueDetailsTour.EVENT_DETAILS}
-              demoTourId={DemoTourStep.ISSUES_EVENT_DETAILS}
-              tourContext={IssueDetailsTourContext}
-              title={t('Investigate the issue')}
-              description={t(
-                'See all the issue context including the stack trace, tags, screenshots and connected replays, logs, and traces.'
-              )}
-              position="top"
-            >
-              {tourProps => (
-                <div {...tourProps}>
-                  <GroupContent>
-                    {groupReprocessingStatus !== ReprocessingStatus.REPROCESSING &&
-                      issueTypeConfig.header.eventNavigation.enabled && (
-                        <NavigationSidebarWrapper hasToggleSidebar={!hasFilterBar}>
-                          <IssueEventNavigation event={event} group={group} />
-                          {/* Since the event details header is disabled, display the sidebar toggle here */}
-                          {!hasFilterBar && <ToggleSidebar size="sm" />}
-                        </NavigationSidebarWrapper>
-                      )}
-                    <ContentPadding>{children}</ContentPadding>
-                  </GroupContent>
-                </div>
-              )}
-            </SharedTourElement>
-          </div>
-          <StreamlinedSidebar group={group} event={event} project={project} />
-        </GroupLayoutBody>
-      </Container>
+      <IssueDetailsLayer variant="nav">
+        <Container
+          display="contents"
+          style={
+            hasPageFrameFeature
+              ? ({'--issue-details-inset': theme.space.xl} as React.CSSProperties)
+              : undefined
+          }
+        >
+          <StreamlinedGroupHeader group={group} event={event ?? null} project={project} />
+          <GroupLayoutBody>
+            <div>
+              <SharedTourElement<IssueDetailsTour>
+                id={IssueDetailsTour.AGGREGATES}
+                demoTourId={DemoTourStep.ISSUES_AGGREGATES}
+                tourContext={IssueDetailsTourContext}
+                title={t('See overall impact')}
+                description={t(
+                  "Here you'll see aggregate metrics like frequency over time, total affected users, and where it occurs (environment, release, device, etc.)."
+                )}
+                position="bottom"
+              >
+                {tourProps => (
+                  <div {...tourProps}>
+                    <EventDetailsHeader event={event} group={group} project={project} />
+                  </div>
+                )}
+              </SharedTourElement>
+              <SharedTourElement<IssueDetailsTour>
+                id={IssueDetailsTour.EVENT_DETAILS}
+                demoTourId={DemoTourStep.ISSUES_EVENT_DETAILS}
+                tourContext={IssueDetailsTourContext}
+                title={t('Investigate the issue')}
+                description={t(
+                  'See all the issue context including the stack trace, tags, screenshots and connected replays, logs, and traces.'
+                )}
+                position="top"
+              >
+                {tourProps => (
+                  <div {...tourProps}>
+                    <GroupContent>
+                      {groupReprocessingStatus !== ReprocessingStatus.REPROCESSING &&
+                        issueTypeConfig.header.eventNavigation.enabled && (
+                          <NavigationSidebarWrapper hasToggleSidebar={!hasFilterBar}>
+                            <IssueEventNavigation event={event} group={group} />
+                            {/* Since the event details header is disabled, display the sidebar toggle here */}
+                            {!hasFilterBar && <ToggleSidebar size="sm" />}
+                          </NavigationSidebarWrapper>
+                        )}
+                      <ContentPadding>{children}</ContentPadding>
+                    </GroupContent>
+                  </div>
+                )}
+              </SharedTourElement>
+            </div>
+            <StreamlinedSidebar group={group} event={event} project={project} />
+          </GroupLayoutBody>
+        </Container>
+      </IssueDetailsLayer>
     </IssueDetailsContextProvider>
   );
 }
@@ -161,4 +164,10 @@ const ContentPadding = styled('div')`
   min-height: 100vh;
   padding: 0 var(--issue-details-inset, ${p => p.theme.space['2xl']})
     ${p => p.theme.space['2xl']} var(--issue-details-inset, ${p => p.theme.space['2xl']});
+`;
+
+const IssueDetailsLayer = styled(Layer)`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
 `;

--- a/static/app/views/issueList/issueListTable.tsx
+++ b/static/app/views/issueList/issueListTable.tsx
@@ -102,8 +102,8 @@ export function IssueListTable({
                 groupIds={groupIds}
                 onActionTaken={onActionTaken}
               />
-              {(groupIds.length > 0 || issuesLoading) && (
-                <Layer variant="nav">
+              <Layer variant="nav">
+                {(groupIds.length > 0 || issuesLoading) && (
                   <IssueListActions
                     selection={selection}
                     query={query}
@@ -116,31 +116,31 @@ export function IssueListTable({
                     allResultsVisible={allResultsVisible}
                     displayReprocessingActions={displayReprocessingActions}
                   />
-                </Layer>
-              )}
-              <PanelBody>
-                <VisuallyCompleteWithData
-                  hasData={groupIds.length > 0}
-                  id="IssueList-Body"
-                  isLoading={issuesLoading}
-                >
-                  <GroupListBody
-                    memberList={memberList}
-                    groupStatsPeriod={statsPeriod}
-                    groupIds={groupIds}
-                    displayReprocessingLayout={displayReprocessingActions}
-                    query={query}
-                    selectedProjectIds={selection.projects}
-                    // we need the stats loading and group id check because group ids do not update immediately
-                    loading={issuesLoading || (statsLoading && !groupIds.length)}
-                    error={error}
-                    pageSize={pageSize}
-                    refetchGroups={refetchGroups}
-                    onActionTaken={onActionTaken}
-                    supergroupLookup={supergroupLookup}
-                  />
-                </VisuallyCompleteWithData>
-              </PanelBody>
+                )}
+                <PanelBody>
+                  <VisuallyCompleteWithData
+                    hasData={groupIds.length > 0}
+                    id="IssueList-Body"
+                    isLoading={issuesLoading}
+                  >
+                    <GroupListBody
+                      memberList={memberList}
+                      groupStatsPeriod={statsPeriod}
+                      groupIds={groupIds}
+                      displayReprocessingLayout={displayReprocessingActions}
+                      query={query}
+                      selectedProjectIds={selection.projects}
+                      // we need the stats loading and group id check because group ids do not update immediately
+                      loading={issuesLoading || (statsLoading && !groupIds.length)}
+                      error={error}
+                      pageSize={pageSize}
+                      refetchGroups={refetchGroups}
+                      onActionTaken={onActionTaken}
+                      supergroupLookup={supergroupLookup}
+                    />
+                  </VisuallyCompleteWithData>
+                </PanelBody>
+              </Layer>
             </ContainerPanel>
           </div>
         )}

--- a/static/app/views/issueList/issueListTable.tsx
+++ b/static/app/views/issueList/issueListTable.tsx
@@ -1,6 +1,7 @@
 import {Fragment} from 'react';
 import styled from '@emotion/styled';
 
+import {Layer} from '@sentry/scraps/layer';
 import type {CursorHandler} from '@sentry/scraps/pagination';
 import {Pagination} from '@sentry/scraps/pagination';
 
@@ -11,7 +12,6 @@ import type {PageFilters} from 'sentry/types/core';
 import {DemoTourElement, DemoTourStep} from 'sentry/utils/demoMode/demoTours';
 import type {IndexedMembersByProject} from 'sentry/utils/members/shared';
 import {VisuallyCompleteWithData} from 'sentry/utils/performanceForSentry';
-import {HoverOverlayGroupProvider} from 'sentry/utils/useHoverOverlay';
 import {useLocation} from 'sentry/utils/useLocation';
 import {IssueListActions} from 'sentry/views/issueList/actions';
 import {GroupListBody} from 'sentry/views/issueList/groupListBody';
@@ -103,7 +103,7 @@ export function IssueListTable({
                 onActionTaken={onActionTaken}
               />
               {(groupIds.length > 0 || issuesLoading) && (
-                <HoverOverlayGroupProvider>
+                <Layer variant="nav">
                   <IssueListActions
                     selection={selection}
                     query={query}
@@ -116,33 +116,31 @@ export function IssueListTable({
                     allResultsVisible={allResultsVisible}
                     displayReprocessingActions={displayReprocessingActions}
                   />
-                </HoverOverlayGroupProvider>
+                </Layer>
               )}
-              <HoverOverlayGroupProvider>
-                <PanelBody>
-                  <VisuallyCompleteWithData
-                    hasData={groupIds.length > 0}
-                    id="IssueList-Body"
-                    isLoading={issuesLoading}
-                  >
-                    <GroupListBody
-                      memberList={memberList}
-                      groupStatsPeriod={statsPeriod}
-                      groupIds={groupIds}
-                      displayReprocessingLayout={displayReprocessingActions}
-                      query={query}
-                      selectedProjectIds={selection.projects}
-                      // we need the stats loading and group id check because group ids do not update immediately
-                      loading={issuesLoading || (statsLoading && !groupIds.length)}
-                      error={error}
-                      pageSize={pageSize}
-                      refetchGroups={refetchGroups}
-                      onActionTaken={onActionTaken}
-                      supergroupLookup={supergroupLookup}
-                    />
-                  </VisuallyCompleteWithData>
-                </PanelBody>
-              </HoverOverlayGroupProvider>
+              <PanelBody>
+                <VisuallyCompleteWithData
+                  hasData={groupIds.length > 0}
+                  id="IssueList-Body"
+                  isLoading={issuesLoading}
+                >
+                  <GroupListBody
+                    memberList={memberList}
+                    groupStatsPeriod={statsPeriod}
+                    groupIds={groupIds}
+                    displayReprocessingLayout={displayReprocessingActions}
+                    query={query}
+                    selectedProjectIds={selection.projects}
+                    // we need the stats loading and group id check because group ids do not update immediately
+                    loading={issuesLoading || (statsLoading && !groupIds.length)}
+                    error={error}
+                    pageSize={pageSize}
+                    refetchGroups={refetchGroups}
+                    onActionTaken={onActionTaken}
+                    supergroupLookup={supergroupLookup}
+                  />
+                </VisuallyCompleteWithData>
+              </PanelBody>
             </ContainerPanel>
           </div>
         )}

--- a/static/app/views/navigation/index.tsx
+++ b/static/app/views/navigation/index.tsx
@@ -10,7 +10,6 @@ import {GlobalCommandPaletteActions} from 'sentry/components/commandPalette/ui/c
 import {CommandPaletteSlot} from 'sentry/components/commandPalette/ui/commandPaletteSlot';
 import {CommandPaletteHotkeys} from 'sentry/components/commandPalette/ui/commandPaletteStateContext';
 import {t} from 'sentry/locale';
-import {HoverOverlayGroupProvider} from 'sentry/utils/useHoverOverlay';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {
   MobileNavigation,
@@ -127,20 +126,14 @@ export function Navigation() {
 
   if (!organization) {
     // @TODO(JonasBadalic): When this page gets any content, we should add the skip link back in.
-    return (
-      <HoverOverlayGroupProvider>
-        <UserOnlyNavigation />
-      </HoverOverlayGroupProvider>
-    );
+    return <UserOnlyNavigation />;
   }
 
   return (
-    <HoverOverlayGroupProvider>
-      <NavigationTourProvider>
-        <SkipLink />
-        <UserAndOrganizationNavigation />
-      </NavigationTourProvider>
-    </HoverOverlayGroupProvider>
+    <NavigationTourProvider>
+      <SkipLink />
+      <UserAndOrganizationNavigation />
+    </NavigationTourProvider>
   );
 }
 

--- a/tests/acceptance/test_organization_events_v2.py
+++ b/tests/acceptance/test_organization_events_v2.py
@@ -465,8 +465,8 @@ class OrganizationEventsTest(AcceptanceTestCase, SnubaTestCase):
 
             # Open the context menu
             card.find_element(by=By.CSS_SELECTOR, value='[data-test-id="menu-trigger"]').click()
-            # Delete the query
-            card.find_element(by=By.CSS_SELECTOR, value='[data-test-id="delete"]').click()
+            # Delete the query (menu content is portaled outside the card)
+            self.browser.find_element(by=By.CSS_SELECTOR, value='[data-test-id="delete"]').click()
 
             # Wait for card to clear
             self.browser.wait_until_not(card_selector)
@@ -493,7 +493,10 @@ class OrganizationEventsTest(AcceptanceTestCase, SnubaTestCase):
 
             # Open the context menu, and duplicate
             card.find_element(by=By.CSS_SELECTOR, value='[data-test-id="menu-trigger"]').click()
-            card.find_element(by=By.CSS_SELECTOR, value='[data-test-id="duplicate"]').click()
+            # Menu content is portaled outside the card
+            self.browser.find_element(
+                by=By.CSS_SELECTOR, value='[data-test-id="duplicate"]'
+            ).click()
 
             duplicate_name = f"{query.name} copy"
 


### PR DESCRIPTION
## Summary

Wire tooltip, hovercard, and dropdown portal consumers to use `usePortalContainer()` from the Layer context instead of defaulting to `document.body`. This ensures portaled overlays render within their Layer's stacking context, so content tooltips appear behind the drawer and drawer tooltips stay within the drawer.

**Slot context bridging**

`createPortal` preserves React context from the Consumer's tree, not the Outlet's DOM position. This caused tooltips from slotted TopBar buttons (e.g. the "Enable real-time updates" button in IssueViewsHeader) to render in the wrong stacking context. Automatic bridging of known contexts (including `LayerContext`) from the Outlet to the Consumer fixes this.

**Overlay z-index removal**

`PositionWrapper.zIndex` is now optional and deprecated — stacking is handled by Layer portal outlets. The `z-index: dropdown !important` override on `OverlayInner` is removed.

## 🥞 Layer Primitive Series
- [x] #114516 `nm/zindex/layer-primitive` — Layer component + hooks
- [x] #114520 `nm/zindex/dom-order` — DOM restructuring for paint-order stacking
- [ ] #114549 `nm/zindex/wire-portals` — Wire portal consumers to Layer outlets ← this PR
- [ ] #115959 `nm/zindex/remove-structural-zindex` — Remove structural z-index refs
- [ ] #115957 `nm/zindex/remove-portal-zindex` — Remove portal z-index refs
- [ ] #115956 `nm/zindex/remove-local-zindex` — Replace local z-index refs with bare z-index: 1
- [ ] #115961 `nm/zindex/deprecate-zindex` — Deprecate theme.zIndex scale
- [ ] #115963 `nm/zindex/lint-ban` — Lint rule banning z-index/zIndex
- [ ] #115964 `nm/zindex/final-cleanup` — Remove theme.zIndex entirely

## Test plan
- [ ] Content tooltips appear behind drawer
- [ ] Drawer tooltips stay within drawer
- [ ] Tooltips from slotted TopBar buttons render in correct stacking context
- [ ] Dropdown menus position correctly inside Layer contexts
- [ ] Acceptance tests pass (discover, issue details)
- [ ] `pnpm run typecheck`