### PR TITLE
fix(eap): normalize dashed UUIDs in search filters and resolve internal column names

### DIFF
--- a/src/sentry/search/eap/columns.py
+++ b/src/sentry/search/eap/columns.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Literal, TypeAlias, TypedDict, cast
@@ -60,6 +60,9 @@ class ResolvedColumn:
     processor: Callable[[Any], Any] | None = None
     # Validator to check if the value in a query is correct
     validator: Callable[[Any], bool] | list[Callable[[Any], bool]] | None = None
+    # Normalizer transforms a search value before sending to Snuba (e.g. stripping dashes from UUIDs).
+    # Called after validation, before building the AttributeValue proto.
+    normalizer: Callable[[Any], Any] | None = None
     # Indicates this attribute is a secondary alias for the attribute.
     # It exists for compatibility or convenience reasons and should NOT be preferred.
     secondary_alias: bool = False
@@ -70,6 +73,20 @@ class ResolvedColumn:
         if self.processor:
             return self.processor(value)
         return value
+
+    def normalize(
+        self, value: str | float | datetime | Sequence[float] | Sequence[str]
+    ) -> str | float | datetime | Sequence[float] | Sequence[str]:
+        """Normalize a search value before building the AttributeValue proto.
+
+        If a normalizer is defined, applies it to each element of a list or to the scalar value.
+        Returns the value unchanged when no normalizer is set.
+        """
+        if self.normalizer is None:
+            return value
+        if isinstance(value, list):
+            return [self.normalizer(item) for item in value]
+        return self.normalizer(value)
 
     def validate(self, value: Any) -> None:
         if callable(self.validator):

--- a/src/sentry/search/eap/occurrences/attributes.py
+++ b/src/sentry/search/eap/occurrences/attributes.py
@@ -6,7 +6,7 @@ from sentry.search.eap.columns import (
     datetime_processor,
 )
 from sentry.search.eap.common_columns import COMMON_COLUMNS, project_virtual_contexts
-from sentry.utils.validators import is_event_id_or_list
+from sentry.utils.validators import is_event_id_or_list, normalize_event_id_strict
 
 OCCURRENCE_ATTRIBUTE_DEFINITIONS = {
     column.public_alias: column
@@ -19,12 +19,14 @@ OCCURRENCE_ATTRIBUTE_DEFINITIONS = {
                 internal_name="sentry.item_id",
                 search_type="string",
                 validator=is_event_id_or_list,
+                normalizer=normalize_event_id_strict,
             ),
             ResolvedAttribute(
                 public_alias=constants.TRACE_ALIAS,
                 internal_name="sentry.trace_id",
                 search_type="string",
                 validator=is_event_id_or_list,
+                normalizer=normalize_event_id_strict,
             ),
             ResolvedAttribute(
                 public_alias="span_id",

--- a/src/sentry/search/eap/ourlogs/attributes.py
+++ b/src/sentry/search/eap/ourlogs/attributes.py
@@ -6,7 +6,7 @@ from sentry.search.eap.columns import (
     simple_sentry_field,
 )
 from sentry.search.eap.common_columns import COMMON_COLUMNS, project_virtual_contexts
-from sentry.utils.validators import is_event_id_or_list
+from sentry.utils.validators import is_event_id_or_list, normalize_event_id_strict
 
 OURLOG_ATTRIBUTE_DEFINITIONS = {
     column.public_alias: column
@@ -17,6 +17,7 @@ OURLOG_ATTRIBUTE_DEFINITIONS = {
             internal_name="sentry.item_id",
             search_type="string",
             validator=is_event_id_or_list,
+            normalizer=normalize_event_id_strict,
         ),
         ResolvedAttribute(
             public_alias="severity_number",
@@ -38,6 +39,7 @@ OURLOG_ATTRIBUTE_DEFINITIONS = {
             internal_name="sentry.trace_id",
             search_type="string",
             validator=is_event_id_or_list,
+            normalizer=normalize_event_id_strict,
         ),
         ResolvedAttribute(
             public_alias=constants.TIMESTAMP_PRECISE_ALIAS,

--- a/src/sentry/search/eap/profile_functions/attributes.py
+++ b/src/sentry/search/eap/profile_functions/attributes.py
@@ -3,7 +3,7 @@ from typing import Literal
 from sentry.search.eap import constants
 from sentry.search.eap.columns import ResolvedAttribute
 from sentry.search.eap.common_columns import COMMON_COLUMNS, project_virtual_contexts
-from sentry.utils.validators import is_event_id_or_list
+from sentry.utils.validators import is_event_id_or_list, normalize_event_id_strict
 
 PROFILE_FUNCTIONS_ATTRIBUTE_DEFINITIONS = {
     column.public_alias: column
@@ -14,12 +14,14 @@ PROFILE_FUNCTIONS_ATTRIBUTE_DEFINITIONS = {
             internal_name="sentry.item_id",
             search_type="string",
             validator=is_event_id_or_list,
+            normalizer=normalize_event_id_strict,
         ),
         ResolvedAttribute(
             public_alias=constants.TRACE_ALIAS,
             internal_name="sentry.trace_id",
             search_type="string",
             validator=is_event_id_or_list,
+            normalizer=normalize_event_id_strict,
         ),
         ResolvedAttribute(
             public_alias="environment",

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -1047,6 +1047,7 @@ class SearchResolver:
                 internal_type=internal_match.internal_type,
                 validator=internal_match.validator,
                 normalizer=internal_match.normalizer,
+                processor=internal_match.processor,
             )
         else:
             if len(column) > qb_constants.MAX_TAG_KEY_LENGTH:

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -107,6 +107,17 @@ class SearchResolver:
     ] = field(default_factory=dict)
     qualified_short_id_to_group_id_cache: dict[int, dict[str, int]] = field(default_factory=dict)
 
+    def _find_column_by_internal_name(self, internal_name: str) -> ResolvedAttribute | None:
+        """Look up a column definition by its internal name (e.g. 'sentry.item_id' -> 'id' column).
+
+        This enables users to query using internal attribute names and still get
+        the correct column definition with validators and normalizers.
+        """
+        for column_def in self.definitions.columns.values():
+            if column_def.internal_name == internal_name:
+                return column_def
+        return None
+
     def get_function_definition(
         self, function_name: str
     ) -> FormulaDefinition | AggregateDefinition:
@@ -836,6 +847,7 @@ class SearchResolver:
         value: str | float | datetime | Sequence[float] | Sequence[str],
     ) -> AttributeValue:
         column.validate(value)
+        value = column.normalize(value)
         if isinstance(column.proto_definition, AttributeKey):
             column_type = column.proto_definition.type
             if column_type == constants.STRING:
@@ -1026,6 +1038,16 @@ class SearchResolver:
                     internal_name=column_definition.internal_name,
                     search_type=column_definition.search_type,
                 )
+        elif (internal_match := self._find_column_by_internal_name(column)) is not None:
+            column_context = None
+            column_definition = ResolvedAttribute(
+                public_alias=alias,
+                internal_name=internal_match.internal_name,
+                search_type=internal_match.search_type,
+                internal_type=internal_match.internal_type,
+                validator=internal_match.validator,
+                normalizer=internal_match.normalizer,
+            )
         else:
             if len(column) > qb_constants.MAX_TAG_KEY_LENGTH:
                 raise InvalidSearchQuery(

--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -106,17 +106,23 @@ class SearchResolver:
         ],
     ] = field(default_factory=dict)
     qualified_short_id_to_group_id_cache: dict[int, dict[str, int]] = field(default_factory=dict)
+    _internal_name_to_column: dict[str, ResolvedAttribute] = field(default_factory=dict, repr=False)
 
     def _find_column_by_internal_name(self, internal_name: str) -> ResolvedAttribute | None:
         """Look up a column definition by its internal name (e.g. 'sentry.item_id' -> 'id' column).
 
-        This enables users to query using internal attribute names and still get
-        the correct column definition with validators and normalizers.
+        Uses a lazily-built reverse mapping from internal_name -> column definition,
+        cached for the lifetime of this resolver instance.
         """
-        for column_def in self.definitions.columns.values():
-            if column_def.internal_name == internal_name:
-                return column_def
-        return None
+        if not self._internal_name_to_column:
+            self._internal_name_to_column.update(
+                {
+                    col.internal_name: col
+                    for col in self.definitions.columns.values()
+                    if not col.secondary_alias
+                }
+            )
+        return self._internal_name_to_column.get(internal_name)
 
     def get_function_definition(
         self, function_name: str

--- a/src/sentry/search/eap/spans/attributes.py
+++ b/src/sentry/search/eap/spans/attributes.py
@@ -28,6 +28,7 @@ from sentry.utils.validators import (
     is_event_id_or_list,
     is_span_id,
     is_span_id_or_list,
+    normalize_event_id_strict,
 )
 
 logger = logging.getLogger(__name__)
@@ -139,6 +140,7 @@ SPAN_ATTRIBUTE_DEFINITIONS = {
             internal_name="sentry.trace_id",
             search_type="string",
             validator=is_event_id_or_list,
+            normalizer=normalize_event_id_strict,
         ),
         ResolvedAttribute(
             public_alias="transaction",

--- a/src/sentry/search/eap/trace_metrics/attributes.py
+++ b/src/sentry/search/eap/trace_metrics/attributes.py
@@ -6,7 +6,7 @@ from sentry.search.eap.columns import (
     simple_sentry_field,
 )
 from sentry.search.eap.common_columns import COMMON_COLUMNS, project_virtual_contexts
-from sentry.utils.validators import is_event_id_or_list
+from sentry.utils.validators import is_event_id_or_list, normalize_event_id_strict
 
 TRACE_METRICS_ATTRIBUTE_DEFINITIONS = {
     column.public_alias: column
@@ -17,12 +17,14 @@ TRACE_METRICS_ATTRIBUTE_DEFINITIONS = {
             internal_name="sentry.item_id",
             search_type="string",
             validator=is_event_id_or_list,
+            normalizer=normalize_event_id_strict,
         ),
         ResolvedAttribute(
             public_alias=constants.TRACE_ALIAS,
             internal_name="sentry.trace_id",
             search_type="string",
             validator=is_event_id_or_list,
+            normalizer=normalize_event_id_strict,
         ),
         ResolvedAttribute(
             public_alias=constants.TIMESTAMP_PRECISE_ALIAS,

--- a/src/sentry/utils/validators.py
+++ b/src/sentry/utils/validators.py
@@ -33,6 +33,12 @@ def is_event_id_or_list(value):
         return is_event_id(value)
 
 
+def normalize_event_id_strict(value):
+    """Normalize a UUID by stripping dashes. Returns the original value if normalization fails."""
+    result = normalize_event_id(value)
+    return result if result is not None else value
+
+
 def is_span_id(value: object) -> TypeGuard[str]:
     return bool(HEXADECIMAL_16_DIGITS.search(force_str(value)))
 

--- a/tests/sentry/search/eap/test_ourlogs.py
+++ b/tests/sentry/search/eap/test_ourlogs.py
@@ -233,6 +233,92 @@ class SearchResolverQueryTest(TestCase):
         assert where is None
         assert having is None
 
+    def test_id_query_normalizes_dashes(self) -> None:
+        """Dashed UUIDs in id: filters are normalized to dashless hex before sending to Snuba."""
+        where, having, _ = self.resolver.resolve_query("id:f13343d4-6625-40d0-946f-f5b4d564c642")
+        assert where == TraceItemFilter(
+            comparison_filter=ComparisonFilter(
+                key=AttributeKey(name="sentry.item_id", type=AttributeKey.Type.TYPE_STRING),
+                op=ComparisonFilter.OP_EQUALS,
+                value=AttributeValue(val_str="f13343d4662540d0946ff5b4d564c642"),
+            )
+        )
+        assert having is None
+
+    def test_id_query_dashless_unchanged(self) -> None:
+        """Already-dashless hex IDs pass through normalization unchanged."""
+        where, having, _ = self.resolver.resolve_query("id:f13343d4662540d0946ff5b4d564c642")
+        assert where == TraceItemFilter(
+            comparison_filter=ComparisonFilter(
+                key=AttributeKey(name="sentry.item_id", type=AttributeKey.Type.TYPE_STRING),
+                op=ComparisonFilter.OP_EQUALS,
+                value=AttributeValue(val_str="f13343d4662540d0946ff5b4d564c642"),
+            )
+        )
+        assert having is None
+
+    def test_trace_query_normalizes_dashes(self) -> None:
+        """Dashed UUIDs in trace: filters are normalized to dashless hex."""
+        where, having, _ = self.resolver.resolve_query("trace:f13343d4-6625-40d0-946f-f5b4d564c642")
+        assert where == TraceItemFilter(
+            comparison_filter=ComparisonFilter(
+                key=AttributeKey(name="sentry.trace_id", type=AttributeKey.Type.TYPE_STRING),
+                op=ComparisonFilter.OP_EQUALS,
+                value=AttributeValue(val_str="f13343d4662540d0946ff5b4d564c642"),
+            )
+        )
+        assert having is None
+
+    def test_id_in_filter_normalizes_dashes(self) -> None:
+        """Dashed UUIDs in id:[...] IN filters are normalized."""
+        where, having, _ = self.resolver.resolve_query(
+            "id:[f13343d4-6625-40d0-946f-f5b4d564c642,b802415f-7531-431c-aa27-f5c0bf923302]"
+        )
+        assert where == TraceItemFilter(
+            comparison_filter=ComparisonFilter(
+                key=AttributeKey(name="sentry.item_id", type=AttributeKey.Type.TYPE_STRING),
+                op=ComparisonFilter.OP_IN,
+                value=AttributeValue(
+                    val_str_array=StrArray(
+                        values=[
+                            "f13343d4662540d0946ff5b4d564c642",
+                            "b802415f7531431caa27f5c0bf923302",
+                        ]
+                    )
+                ),
+            )
+        )
+        assert having is None
+
+    def test_internal_name_resolves_with_normalizer(self) -> None:
+        """Using the internal name 'sentry.item_id' resolves to the same definition as 'id'
+        with the correct validator and normalizer, so dashed UUIDs are normalized."""
+        where, having, _ = self.resolver.resolve_query(
+            "sentry.item_id:f13343d4-6625-40d0-946f-f5b4d564c642"
+        )
+        assert where == TraceItemFilter(
+            comparison_filter=ComparisonFilter(
+                key=AttributeKey(name="sentry.item_id", type=AttributeKey.Type.TYPE_STRING),
+                op=ComparisonFilter.OP_EQUALS,
+                value=AttributeValue(val_str="f13343d4662540d0946ff5b4d564c642"),
+            )
+        )
+        assert having is None
+
+    def test_internal_trace_id_resolves_with_normalizer(self) -> None:
+        """Using the internal name 'sentry.trace_id' resolves with normalizer."""
+        where, having, _ = self.resolver.resolve_query(
+            "sentry.trace_id:f13343d4-6625-40d0-946f-f5b4d564c642"
+        )
+        assert where == TraceItemFilter(
+            comparison_filter=ComparisonFilter(
+                key=AttributeKey(name="sentry.trace_id", type=AttributeKey.Type.TYPE_STRING),
+                op=ComparisonFilter.OP_EQUALS,
+                value=AttributeValue(val_str="f13343d4662540d0946ff5b4d564c642"),
+            )
+        )
+        assert having is None
+
 
 def test_count_default_argument() -> None:
     resolver = SearchResolver(

--- a/tests/sentry/utils/test_validators.py
+++ b/tests/sentry/utils/test_validators.py
@@ -61,3 +61,26 @@ def test_is_span_id() -> None:
     assert not is_span_id("202ab439bb9c4f31AAAAAAAAAA")
     assert not is_span_id(False)
     assert not is_span_id(None)
+
+
+def test_normalize_event_id_strict() -> None:
+    from sentry.utils.validators import normalize_event_id_strict
+
+    # Strips dashes from UUID
+    assert (
+        normalize_event_id_strict("b802415f-7531-431c-aa27-f5c0bf923302")
+        == "b802415f7531431caa27f5c0bf923302"
+    )
+    # Already-normalized hex passes through
+    assert (
+        normalize_event_id_strict("b802415f7531431caa27f5c0bf923302")
+        == "b802415f7531431caa27f5c0bf923302"
+    )
+    # Uppercase is lowered
+    assert (
+        normalize_event_id_strict("B802415F7531431CAA27F5C0BF923302")
+        == "b802415f7531431caa27f5c0bf923302"
+    )
+    # Invalid input is returned as-is (fallback)
+    assert normalize_event_id_strict("not-a-uuid") == "not-a-uuid"
+    assert normalize_event_id_strict(4711) == 4711


### PR DESCRIPTION
## Summary

Fixes a Snuba 500 error when users search EAP datasets (logs, spans, etc.) with dashed UUIDs in `id:` or `trace:` filters, or when using internal column names like `sentry.item_id` instead of the public alias `id`.

**Root cause**: The `is_event_id_or_list` validator accepted dashed UUIDs (`f13343d4-6625-40d0-946f-f5b4d564c642`) but the value was sent to Snuba as-is. Snuba's `HexIntColumnProcessor` calls `int(value, 16)` which raises `ValueError` on dashes, producing a 500 "Internal error. Please try again."

**Two bugs fixed**:
1. **Missing UUID normalization**: Added a `normalizer` field to `ResolvedColumn` and set `normalize_event_id_strict` on all `id`/`trace` columns across all EAP datasets (ourlogs, spans, occurrences, profile_functions, trace_metrics). The normalizer strips dashes via `uuid.UUID().hex` after validation, before building the protobuf `AttributeValue`.

2. **Missing reverse alias lookup**: When users typed internal names like `sentry.item_id` (instead of `id`), `resolve_attribute()` fell through to the generic tag handler, bypassing validators and normalizers. Added `_find_column_by_internal_name()` to resolve internal names to their proper column definitions.

Fixes [CLI-1J6](https://sentry.sentry.io/issues/7451076364/)

## Changes

- `src/sentry/search/eap/columns.py` — Added `normalizer` field + `normalize()` method to `ResolvedColumn`
- `src/sentry/search/eap/resolver.py` — Call `column.normalize(value)` in `_resolve_search_value()` + add internal name reverse lookup in `resolve_attribute()`
- `src/sentry/utils/validators.py` — Added `normalize_event_id_strict()` helper
- `src/sentry/search/eap/{ourlogs,occurrences,profile_functions,spans,trace_metrics}/attributes.py` — Set `normalizer=normalize_event_id_strict` on all UUID columns
- `tests/sentry/search/eap/test_ourlogs.py` — 6 new tests for normalization and reverse alias
- `tests/sentry/utils/test_validators.py` — 1 new test for `normalize_event_id_strict`