### PR TITLE
perf(queryClient): Cache safeParseQueryKey results in a WeakMap

### DIFF
--- a/static/app/utils/api/apiQueryKey.ts
+++ b/static/app/utils/api/apiQueryKey.ts
@@ -103,8 +103,16 @@ export function parseQueryKey(
   return queryKeySchema.parse(queryKey);
 }
 
+const safeParseCache = new WeakMap<readonly unknown[], ParsedQueryKey | undefined>();
+
 export function safeParseQueryKey(
   queryKey: readonly unknown[]
 ): ParsedQueryKey | undefined {
-  return queryKeySchema.safeParse(queryKey).data;
+  if (safeParseCache.has(queryKey)) {
+    return safeParseCache.get(queryKey);
+  }
+
+  const result = queryKeySchema.safeParse(queryKey).data;
+  safeParseCache.set(queryKey, result);
+  return result;
 }


### PR DESCRIPTION
`safeParseQueryKey` runs a Zod union parse (4 branches with transforms) on every query key in the cache — both inside `getQueriesData` predicates and on every cache subscription event in `useAggregatedQueryKeys`. On pages like issue details this fires hundreds of times, adding ~500ms of work.

Add a module-level `WeakMap` cache keyed by the query key array reference. React Query cache entries hold stable `queryKey` references, so each key gets parsed exactly once. The `WeakMap` entries are automatically garbage-collected when React Query evicts queries from its cache.